### PR TITLE
feat(oauth): use provider refreshUrl with fallback in token-manager

### DIFF
--- a/assistant/src/__tests__/credential-vault.test.ts
+++ b/assistant/src/__tests__/credential-vault.test.ts
@@ -1633,5 +1633,37 @@ describe("withValidToken refresh deduplication", () => {
         "https://oauth.example.com/token",
       );
     });
+
+    test("falls back to provider.tokenExchangeUrl when refreshUrl is empty string", async () => {
+      // Platform's Python `oauth_app.refresh_url or oauth_app.token_exchange_url`
+      // treats an empty string as unset. We use `||` (not `??`) so empty
+      // strings follow the same fallback path and never resolve to an empty
+      // endpoint.
+      await setupService("google");
+      mockProviders.get("google")!.refreshUrl = "";
+
+      mockRefreshOAuth2Token.mockImplementation(() =>
+        Promise.resolve({
+          accessToken: "new-token-from-token-exchange-url",
+          expiresIn: 3600,
+        }),
+      );
+
+      const err401 = Object.assign(new Error("Unauthorized"), { status: 401 });
+
+      const callback = async (token: string) => {
+        if (token === "old-access-token") throw err401;
+        return `result-with-${token}`;
+      };
+
+      const result = await withValidToken("google", callback);
+
+      expect(result).toBe("result-with-new-token-from-token-exchange-url");
+      expect(mockRefreshOAuth2Token).toHaveBeenCalledTimes(1);
+      // Assert the refresh endpoint falls back to tokenExchangeUrl — NOT "".
+      expect(mockRefreshOAuth2Token.mock.calls[0]?.[0]).toBe(
+        "https://oauth.example.com/token",
+      );
+    });
   });
 });

--- a/assistant/src/__tests__/credential-vault.test.ts
+++ b/assistant/src/__tests__/credential-vault.test.ts
@@ -50,7 +50,15 @@ mock.module("../tools/registry.js", () => ({
 // ---------------------------------------------------------------------------
 
 let mockRefreshOAuth2Token: ReturnType<
-  typeof mock<() => Promise<{ accessToken: string; expiresIn: number }>>
+  typeof mock<
+    (
+      tokenExchangeUrl: string,
+      clientId: string,
+      refreshToken: string,
+      clientSecret?: string,
+      tokenEndpointAuthMethod?: string,
+    ) => Promise<{ accessToken: string; expiresIn: number }>
+  >
 >;
 
 mock.module("../security/oauth2.js", () => {
@@ -93,6 +101,7 @@ const mockProviders = new Map<
   {
     key: string;
     tokenExchangeUrl: string;
+    refreshUrl?: string | null;
     tokenEndpointAuthMethod?: string;
   }
 >();
@@ -1325,6 +1334,7 @@ describe("withValidToken refresh deduplication", () => {
     mockProviders.set(service, {
       key: service,
       tokenExchangeUrl: "https://oauth.example.com/token",
+      refreshUrl: null,
     });
     mockApps.set(appId, {
       id: appId,
@@ -1526,5 +1536,102 @@ describe("withValidToken refresh deduplication", () => {
 
     // Only one actual refresh attempt
     expect(mockRefreshOAuth2Token).toHaveBeenCalledTimes(1);
+  });
+
+  // -----------------------------------------------------------------------
+  // refreshUrl resolution — provider.refreshUrl with fallback to tokenExchangeUrl
+  // -----------------------------------------------------------------------
+  describe("refreshUrl resolution", () => {
+    test("uses provider.refreshUrl when set", async () => {
+      await setupService("google");
+      mockProviders.get("google")!.refreshUrl =
+        "https://refresh.example.com/token";
+
+      mockRefreshOAuth2Token.mockImplementation(() =>
+        Promise.resolve({
+          accessToken: "new-token-from-refresh-url",
+          expiresIn: 3600,
+        }),
+      );
+
+      const err401 = Object.assign(new Error("Unauthorized"), { status: 401 });
+
+      const callback = async (token: string) => {
+        if (token === "old-access-token") throw err401;
+        return `result-with-${token}`;
+      };
+
+      const result = await withValidToken("google", callback);
+
+      expect(result).toBe("result-with-new-token-from-refresh-url");
+      expect(mockRefreshOAuth2Token).toHaveBeenCalledTimes(1);
+      // Assert the refresh endpoint passed in is provider.refreshUrl, not
+      // the tokenExchangeUrl fallback.
+      expect(mockRefreshOAuth2Token.mock.calls[0]?.[0]).toBe(
+        "https://refresh.example.com/token",
+      );
+    });
+
+    test("falls back to provider.tokenExchangeUrl when refreshUrl is null", async () => {
+      // setupService sets refreshUrl: null by default — this exercises the
+      // fallback path explicitly.
+      await setupService("google");
+      expect(mockProviders.get("google")!.refreshUrl).toBeNull();
+
+      mockRefreshOAuth2Token.mockImplementation(() =>
+        Promise.resolve({
+          accessToken: "new-token-from-token-exchange-url",
+          expiresIn: 3600,
+        }),
+      );
+
+      const err401 = Object.assign(new Error("Unauthorized"), { status: 401 });
+
+      const callback = async (token: string) => {
+        if (token === "old-access-token") throw err401;
+        return `result-with-${token}`;
+      };
+
+      const result = await withValidToken("google", callback);
+
+      expect(result).toBe("result-with-new-token-from-token-exchange-url");
+      expect(mockRefreshOAuth2Token).toHaveBeenCalledTimes(1);
+      // Assert the refresh endpoint falls back to tokenExchangeUrl.
+      expect(mockRefreshOAuth2Token.mock.calls[0]?.[0]).toBe(
+        "https://oauth.example.com/token",
+      );
+    });
+
+    test("falls back to provider.tokenExchangeUrl when refreshUrl is undefined", async () => {
+      await setupService("google");
+      // Delete the refreshUrl field entirely so the property is `undefined`
+      // rather than `null`. Both representations of "not set" must produce
+      // the fallback behavior.
+      delete mockProviders.get("google")!.refreshUrl;
+      expect(mockProviders.get("google")!.refreshUrl).toBeUndefined();
+
+      mockRefreshOAuth2Token.mockImplementation(() =>
+        Promise.resolve({
+          accessToken: "new-token-from-token-exchange-url",
+          expiresIn: 3600,
+        }),
+      );
+
+      const err401 = Object.assign(new Error("Unauthorized"), { status: 401 });
+
+      const callback = async (token: string) => {
+        if (token === "old-access-token") throw err401;
+        return `result-with-${token}`;
+      };
+
+      const result = await withValidToken("google", callback);
+
+      expect(result).toBe("result-with-new-token-from-token-exchange-url");
+      expect(mockRefreshOAuth2Token).toHaveBeenCalledTimes(1);
+      // Assert the refresh endpoint falls back to tokenExchangeUrl.
+      expect(mockRefreshOAuth2Token.mock.calls[0]?.[0]).toBe(
+        "https://oauth.example.com/token",
+      );
+    });
   });
 });

--- a/assistant/src/security/token-manager.ts
+++ b/assistant/src/security/token-manager.ts
@@ -92,7 +92,8 @@ const secureKeyBackend: SecureKeyBackend = {
 interface RefreshConfig {
   /**
    * Token endpoint used for the refresh grant. Resolved from
-   * `provider.refreshUrl` when set, otherwise `provider.tokenExchangeUrl`.
+   * `provider.refreshUrl` when set to a non-empty string, otherwise
+   * `provider.tokenExchangeUrl` (matching platform's Python `or` semantics).
    */
   tokenExchangeUrl: string;
   clientId: string;
@@ -142,8 +143,11 @@ async function resolveRefreshConfig(
   // Prefer provider.refreshUrl when set; fall back to tokenExchangeUrl.
   // This mirrors platform's `oauth_app.refresh_url or oauth_app.token_exchange_url`
   // in `token_service.py:112`, so both repos resolve the refresh endpoint
-  // identically for managed and BYO flows.
-  const tokenExchangeUrl = provider.refreshUrl ?? provider.tokenExchangeUrl;
+  // identically for managed and BYO flows. We use `||` (not `??`) so empty
+  // strings fall back to tokenExchangeUrl — matching Python's `or` semantics
+  // and preventing a malformed provider row with `refreshUrl: ""` from
+  // resolving to an empty endpoint.
+  const tokenExchangeUrl = provider.refreshUrl || provider.tokenExchangeUrl;
   const resolvedClientId = app.clientId;
   if (!tokenExchangeUrl || !resolvedClientId) {
     throw new TokenExpiredError(

--- a/assistant/src/security/token-manager.ts
+++ b/assistant/src/security/token-manager.ts
@@ -1,7 +1,7 @@
 /**
  * Token manager for OAuth2 credentials.
  *
- * Reads refresh configuration (tokenExchangeUrl, clientId, authMethod) exclusively
+ * Reads refresh configuration (refreshUrl with fallback to tokenExchangeUrl, clientId, authMethod) exclusively
  * from the SQLite oauth-store (provider + app + connection rows). After a
  * successful refresh, writes tokens to new-format secure key paths and
  * updates the oauth_connection row.
@@ -90,6 +90,10 @@ const secureKeyBackend: SecureKeyBackend = {
 
 /** Shared shape for resolved refresh configuration. */
 interface RefreshConfig {
+  /**
+   * Token endpoint used for the refresh grant. Resolved from
+   * `provider.refreshUrl` when set, otherwise `provider.tokenExchangeUrl`.
+   */
   tokenExchangeUrl: string;
   clientId: string;
   /** OAuth client secret (optional — PKCE flows may omit it). */
@@ -102,8 +106,9 @@ interface RefreshConfig {
 /**
  * Resolve refresh configuration from the SQLite oauth-store.
  *
- * Looks up connection -> app -> provider to read tokenExchangeUrl, clientId, and
- * authMethod. Throws `TokenExpiredError` if the connection is not found
+ * Looks up connection -> app -> provider to read the refresh endpoint (preferring
+ * `provider.refreshUrl`, falling back to `provider.tokenExchangeUrl`), clientId,
+ * and authMethod. Throws `TokenExpiredError` if the connection is not found
  * or incomplete.
  */
 async function resolveRefreshConfig(
@@ -134,7 +139,11 @@ async function resolveRefreshConfig(
     );
   }
 
-  const tokenExchangeUrl = provider.tokenExchangeUrl;
+  // Prefer provider.refreshUrl when set; fall back to tokenExchangeUrl.
+  // This mirrors platform's `oauth_app.refresh_url or oauth_app.token_exchange_url`
+  // in `token_service.py:112`, so both repos resolve the refresh endpoint
+  // identically for managed and BYO flows.
+  const tokenExchangeUrl = provider.refreshUrl ?? provider.tokenExchangeUrl;
   const resolvedClientId = app.clientId;
   if (!tokenExchangeUrl || !resolvedClientId) {
     throw new TokenExpiredError(


### PR DESCRIPTION
## Summary
- `resolveRefreshConfig` now resolves the refresh endpoint via `provider.refreshUrl ?? provider.tokenExchangeUrl`, mirroring platform's `token_service.py:112` fallback
- Updates docstrings on `RefreshConfig`, `resolveRefreshConfig`, and the top-of-file comment to document the semantic shift
- Adds three new tests in `credential-vault.test.ts` covering the set/null/undefined paths

Part of plan: refresh-url-parity.md (PR 2 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24185" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
