### PR TITLE
feat(oauth): expose refreshUrl in provider serializer and CLI

### DIFF
--- a/assistant/src/__tests__/oauth-cli.test.ts
+++ b/assistant/src/__tests__/oauth-cli.test.ts
@@ -169,6 +169,7 @@ mock.module("../oauth/oauth-store.js", () => ({
       provider: params.provider,
       authorizeUrl: params.authorizeUrl,
       tokenExchangeUrl: params.tokenExchangeUrl,
+      refreshUrl: (params.refreshUrl as string | undefined) ?? null,
       tokenEndpointAuthMethod: params.tokenEndpointAuthMethod ?? null,
       userinfoUrl: params.userinfoUrl ?? null,
       baseUrl: params.baseUrl ?? null,
@@ -230,6 +231,9 @@ mock.module("../oauth/oauth-store.js", () => ({
     }
     if (params.tokenExchangeUrl !== undefined) {
       updated.tokenExchangeUrl = params.tokenExchangeUrl;
+    }
+    if (params.refreshUrl !== undefined) {
+      updated.refreshUrl = params.refreshUrl;
     }
     if (params.defaultScopes !== undefined) {
       updated.defaultScopes = JSON.stringify(params.defaultScopes);
@@ -1523,5 +1527,121 @@ describe("assistant oauth providers --scope-separator", () => {
     expect(exitCode).toBe(0);
     const parsed = JSON.parse(stdout);
     expect(parsed.scopeSeparator).toBe(",");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// providers register / update / get — --refresh-url wiring
+// ---------------------------------------------------------------------------
+
+describe("assistant oauth providers --refresh-url", () => {
+  beforeEach(() => {
+    mockWithValidToken = async (_service, cb) => cb("mock-access-token-xyz");
+    mockProviderStore.clear();
+    // Default getProvider falls through to mockProviderStore via the
+    // oauth-store mock module.
+    mockGetProvider = () => undefined;
+    mockGetConfig = () => ({ services: {} });
+  });
+
+  afterEach(() => {
+    mockProviderStore.clear();
+    mockGetProvider = () => undefined;
+  });
+
+  test("providers register --refresh-url stores the URL on the provider row", async () => {
+    const { exitCode } = await runCli([
+      "providers",
+      "register",
+      "--provider-key",
+      "custom-refresh-url",
+      "--auth-url",
+      "https://example.com/oauth/authorize",
+      "--token-url",
+      "https://example.com/oauth/token",
+      "--refresh-url",
+      "https://refresh.example.com/token",
+      "--json",
+    ]);
+    expect(exitCode).toBe(0);
+    const stored = mockProviderStore.get("custom-refresh-url");
+    expect(stored).toBeDefined();
+    expect(stored?.refreshUrl).toBe("https://refresh.example.com/token");
+  });
+
+  test("providers register without --refresh-url stores null", async () => {
+    const { exitCode } = await runCli([
+      "providers",
+      "register",
+      "--provider-key",
+      "custom-no-refresh-url",
+      "--auth-url",
+      "https://example.com/oauth/authorize",
+      "--token-url",
+      "https://example.com/oauth/token",
+      "--json",
+    ]);
+    expect(exitCode).toBe(0);
+    const stored = mockProviderStore.get("custom-no-refresh-url");
+    expect(stored).toBeDefined();
+    expect(stored?.refreshUrl).toBeNull();
+  });
+
+  test("providers update --refresh-url updates an existing custom provider", async () => {
+    // Seed the store with an existing custom provider that has no refresh URL.
+    await runCli([
+      "providers",
+      "register",
+      "--provider-key",
+      "custom-update-refresh",
+      "--auth-url",
+      "https://example.com/oauth/authorize",
+      "--token-url",
+      "https://example.com/oauth/token",
+      "--json",
+    ]);
+    expect(
+      mockProviderStore.get("custom-update-refresh")?.refreshUrl,
+    ).toBeNull();
+
+    const { exitCode } = await runCli([
+      "providers",
+      "update",
+      "custom-update-refresh",
+      "--refresh-url",
+      "https://new-refresh.example.com/token",
+      "--json",
+    ]);
+    expect(exitCode).toBe(0);
+    expect(mockProviderStore.get("custom-update-refresh")?.refreshUrl).toBe(
+      "https://new-refresh.example.com/token",
+    );
+  });
+
+  test("providers get <key> --json includes refreshUrl from the serialized output", async () => {
+    // Seed the store with a custom provider that has a refresh URL set.
+    await runCli([
+      "providers",
+      "register",
+      "--provider-key",
+      "custom-get-refresh",
+      "--auth-url",
+      "https://example.com/oauth/authorize",
+      "--token-url",
+      "https://example.com/oauth/token",
+      "--refresh-url",
+      "https://refresh.example.com/token",
+      "--json",
+    ]);
+
+    const { exitCode, stdout } = await runCli([
+      "providers",
+      "get",
+      "custom-get-refresh",
+      "--json",
+    ]);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.refreshUrl).toBe("https://refresh.example.com/token");
   });
 });

--- a/assistant/src/__tests__/oauth-provider-serializer.test.ts
+++ b/assistant/src/__tests__/oauth-provider-serializer.test.ts
@@ -181,6 +181,20 @@ describe("serializeProvider", () => {
     const result = serializeProvider(row)!;
     expect(result.scopeSeparator).toBe(" ");
   });
+
+  test("emits refreshUrl from the row when set to a URL", () => {
+    const row = makeRow({
+      refreshUrl: "https://refresh.example.com/token",
+    });
+    const result = serializeProvider(row)!;
+    expect(result.refreshUrl).toBe("https://refresh.example.com/token");
+  });
+
+  test("emits refreshUrl as null when the row value is null", () => {
+    const row = makeRow({ refreshUrl: null });
+    const result = serializeProvider(row)!;
+    expect(result.refreshUrl).toBeNull();
+  });
 });
 
 describe("serializeProviderSummary", () => {
@@ -250,5 +264,12 @@ describe("serializeProviderSummary", () => {
     const result = serializeProviderSummary(row)!;
     expect(result).not.toHaveProperty("scope_separator");
     expect(result).not.toHaveProperty("scopeSeparator");
+  });
+
+  test("does NOT include refresh_url (intentionally omitted from the HTTP summary)", () => {
+    const row = makeRow({ refreshUrl: "https://refresh.example.com/token" });
+    const result = serializeProviderSummary(row)!;
+    expect(result).not.toHaveProperty("refresh_url");
+    expect(result).not.toHaveProperty("refreshUrl");
   });
 });

--- a/assistant/src/cli/commands/oauth/providers.ts
+++ b/assistant/src/cli/commands/oauth/providers.ts
@@ -220,6 +220,10 @@ Examples:
       "--token-url <url>",
       "OAuth token endpoint URL (e.g. https://oauth2.example.com/token)",
     )
+    .option(
+      "--refresh-url <url>",
+      "OAuth token refresh endpoint URL. Defaults to --token-url when omitted. Set this when the provider uses a different endpoint for the refresh_token grant than for the authorization_code grant.",
+    )
     .option("--base-url <url>", "API base URL for the service")
     .option("--userinfo-url <url>", "OpenID Connect userinfo endpoint URL")
     .option(
@@ -351,6 +355,11 @@ Examples:
       --scopes read,write \\
       --scope-separator ","
   $ assistant oauth providers register \\
+      --provider-key split-grants \\
+      --auth-url https://example.com/oauth/authorize \\
+      --token-url https://example.com/oauth/token \\
+      --refresh-url https://example.com/oauth/refresh
+  $ assistant oauth providers register \\
       --provider-key my-api \\
       --auth-url https://example.com/auth \\
       --token-url https://example.com/token \\
@@ -365,6 +374,7 @@ Examples:
           providerKey: string;
           authUrl: string;
           tokenUrl: string;
+          refreshUrl?: string;
           baseUrl?: string;
           userinfoUrl?: string;
           scopes?: string;
@@ -398,6 +408,7 @@ Examples:
             provider: opts.providerKey,
             authorizeUrl: opts.authUrl,
             tokenExchangeUrl: opts.tokenUrl,
+            refreshUrl: opts.refreshUrl,
             baseUrl: opts.baseUrl,
             userinfoUrl: opts.userinfoUrl,
             defaultScopes: opts.scopes ? opts.scopes.split(",") : [],
@@ -466,6 +477,10 @@ Examples:
     .option(
       "--token-url <url>",
       "OAuth token endpoint URL (e.g. https://oauth2.example.com/token)",
+    )
+    .option(
+      "--refresh-url <url>",
+      "OAuth token refresh endpoint URL. Defaults to --token-url when omitted. Set this when the provider uses a different endpoint for the refresh_token grant than for the authorization_code grant.",
     )
     .option("--base-url <url>", "API base URL for the service")
     .option("--userinfo-url <url>", "OpenID Connect userinfo endpoint URL")
@@ -579,6 +594,7 @@ Examples:
   $ assistant oauth providers update custom-api --scopes read,write --auth-url https://new.example.com/auth
   $ assistant oauth providers update custom-api --ping-url https://api.example.com/me --json
   $ assistant oauth providers update custom-api --scope-separator ","
+  $ assistant oauth providers update custom-api --refresh-url https://example.com/oauth/refresh
   $ assistant oauth providers update custom-api \\
       --identity-url https://api.example.com/me \\
       --identity-response-paths email,name
@@ -591,6 +607,7 @@ Examples:
         opts: {
           authUrl?: string;
           tokenUrl?: string;
+          refreshUrl?: string;
           baseUrl?: string;
           userinfoUrl?: string;
           scopes?: string;
@@ -656,6 +673,8 @@ Examples:
           if (opts.authUrl !== undefined) params.authorizeUrl = opts.authUrl;
           if (opts.tokenUrl !== undefined)
             params.tokenExchangeUrl = opts.tokenUrl;
+          if (opts.refreshUrl !== undefined)
+            params.refreshUrl = opts.refreshUrl;
           if (opts.baseUrl !== undefined) params.baseUrl = opts.baseUrl;
           if (opts.userinfoUrl !== undefined)
             params.userinfoUrl = opts.userinfoUrl;

--- a/assistant/src/oauth/provider-serializer.ts
+++ b/assistant/src/oauth/provider-serializer.ts
@@ -77,6 +77,7 @@ function _serializeProvider(
     providerKey: provider,
     authUrl: authorizeUrl,
     tokenUrl: tokenExchangeUrl,
+    refreshUrl: row.refreshUrl ?? null,
     displayName: displayLabel ?? null,
     description: row.description ?? null,
     dashboardUrl: row.dashboardUrl ?? null,


### PR DESCRIPTION
## Summary
- Adds `refreshUrl` to `_serializeProvider` output (normalized to `null` when unset)
- Adds `--refresh-url <url>` flag to `providers register` and `providers update` CLI commands
- `serializeProviderSummary` is intentionally left untouched — refreshUrl is an internal protocol detail, not part of the HTTP summary shape

Part of plan: refresh-url-parity.md (PR 3 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24186" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
