### PR TITLE
fix(chrome-extension): evict attached-target cache on CDP send failure

### DIFF
--- a/clients/chrome-extension/background/__tests__/host-browser-dispatcher.test.ts
+++ b/clients/chrome-extension/background/__tests__/host-browser-dispatcher.test.ts
@@ -30,6 +30,14 @@ import type {
 interface MockCdpProxyOptions {
   /** Optional override for the next `send()` call's resolved frame. */
   sendResult?: CdpResultFrame;
+  /**
+   * Optional FIFO queue of canned `send()` results. Each call to `send()`
+   * shifts the head of this queue and returns it. Falls back to
+   * `sendResult` (or the default `{ id, result: { ok: true } }`) once the
+   * queue is empty. Useful for tests that need to sequence multiple
+   * different responses across repeat requests.
+   */
+  sendResults?: CdpResultFrame[];
   /** If set, the next `send()` call will throw this error. */
   sendThrows?: Error;
   /** If set, `attach()` will reject with this error. */
@@ -57,6 +65,10 @@ function createMockCdpProxy(options: MockCdpProxyOptions = {}): MockCdpProxy {
   const sendCalls: Array<{ target: CdpTarget; frame: CdpRequestFrame }> = [];
   const detachCalls: CdpTarget[] = [];
   let disposeCalls = 0;
+  // Mutable copy so each `send()` invocation can shift one off the front.
+  const queuedSendResults: CdpResultFrame[] = options.sendResults
+    ? [...options.sendResults]
+    : [];
 
   const proxy: MockCdpProxy = {
     attachCalls,
@@ -76,6 +88,12 @@ function createMockCdpProxy(options: MockCdpProxyOptions = {}): MockCdpProxy {
     async send(target, frame) {
       sendCalls.push({ target, frame });
       if (options.sendThrows) throw options.sendThrows;
+      const queued = queuedSendResults.shift();
+      if (queued) {
+        // Re-tag the queued frame's id with the actual request id so the
+        // dispatcher's monotonic counter doesn't drift in the test view.
+        return { ...queued, id: frame.id };
+      }
       return options.sendResult ?? { id: frame.id, result: { ok: true } };
     },
     onEvent(handler) {
@@ -371,6 +389,73 @@ describe('createHostBrowserDispatcher', () => {
       // Cache entry for tabId 42 is still there → no new attach.
       await harness.dispatcher.handle({ ...sampleRequest, requestId: 'req-2' });
       expect(harness.proxy.attachCalls.length).toBe(1);
+    });
+  });
+
+  describe('handle — send-error cache eviction', () => {
+    test('evicts the cache when send returns a detach-style error so the next request re-attaches', async () => {
+      // Two requests against the same target. The first send returns a
+      // "Target closed" error frame; the dispatcher must surface that
+      // error to the caller AND evict the cached attach so the second
+      // request re-runs proxy.attach instead of silently re-using a
+      // dead session.
+      harness = createHarness({
+        sendResults: [
+          { id: 0, error: { code: -32000, message: 'Target closed' } },
+          { id: 0, result: { ok: true } },
+        ],
+      });
+
+      await harness.dispatcher.handle(sampleRequest);
+      await harness.dispatcher.handle({ ...sampleRequest, requestId: 'req-2' });
+
+      // Two attaches: one before the first request, one before the second
+      // after the cache was evicted by the detach-style error response.
+      expect(harness.proxy.attachCalls.length).toBe(2);
+      expect(harness.proxy.attachCalls[0].target).toEqual({ tabId: 42 });
+      expect(harness.proxy.attachCalls[1].target).toEqual({ tabId: 42 });
+
+      // Both sends fired against the same resolved target.
+      expect(harness.proxy.sendCalls.length).toBe(2);
+
+      // The first request still surfaces the error frame to the caller —
+      // eviction is a recovery hint, not a retry. The second succeeds.
+      expect(harness.results.length).toBe(2);
+      expect(harness.results[0].isError).toBe(true);
+      expect(harness.results[0].content).toBe(
+        JSON.stringify({ code: -32000, message: 'Target closed' }),
+      );
+      expect(harness.results[1].isError).toBe(false);
+    });
+
+    test('does not evict the cache when send returns a non-detach error', async () => {
+      // A "Method not implemented" failure is unrelated to the attach
+      // lifecycle — re-attaching wouldn't help and would be wasteful.
+      // The dispatcher must keep the cache entry intact and the next
+      // request must reuse the cached attach.
+      harness = createHarness({
+        sendResults: [
+          {
+            id: 0,
+            error: { code: -32601, message: 'Method not implemented' },
+          },
+          { id: 0, result: { ok: true } },
+        ],
+      });
+
+      await harness.dispatcher.handle(sampleRequest);
+      await harness.dispatcher.handle({ ...sampleRequest, requestId: 'req-2' });
+
+      // Only one attach: the cache survived the non-detach error.
+      expect(harness.proxy.attachCalls.length).toBe(1);
+      expect(harness.proxy.sendCalls.length).toBe(2);
+
+      expect(harness.results.length).toBe(2);
+      expect(harness.results[0].isError).toBe(true);
+      expect(harness.results[0].content).toBe(
+        JSON.stringify({ code: -32601, message: 'Method not implemented' }),
+      );
+      expect(harness.results[1].isError).toBe(false);
     });
   });
 

--- a/clients/chrome-extension/background/host-browser-dispatcher.ts
+++ b/clients/chrome-extension/background/host-browser-dispatcher.ts
@@ -174,6 +174,29 @@ export function createHostBrowserDispatcher(
         params: envelope.cdpParams,
         sessionId: envelope.cdpSessionId,
       });
+      // Recovery hint: if the CDP send returned an error indicating the
+      // target is no longer attached (tab closed mid-flight, navigated
+      // across origins, another debugger took over, etc.), evict the
+      // cache entry so the *next* request triggers a fresh attach. The
+      // current request still fails — eviction does not retry, it only
+      // unblocks subsequent traffic that would otherwise hit the same
+      // stale-cache failure forever.
+      //
+      // Error matching is intentionally string-based: chrome.debugger
+      // surfaces these failures via `chrome.runtime.lastError.message`
+      // and the wording varies across Chrome versions. cdp-proxy maps
+      // those into `{ code: -32000, message }` JSON-RPC error frames.
+      if (frame.error) {
+        const errMsg = (frame.error.message ?? '').toLowerCase();
+        if (
+          errMsg.includes('not attached') ||
+          errMsg.includes('detached') ||
+          errMsg.includes('target closed') ||
+          errMsg.includes('no target with given id')
+        ) {
+          attachedTargets.delete(key);
+        }
+      }
       await deps.postResult({
         requestId: envelope.requestId,
         content: JSON.stringify(frame.error ?? frame.result ?? {}),


### PR DESCRIPTION
## Summary
- Evicts the host-browser-dispatcher attachedTargets cache when proxy.send returns an error indicating the target is no longer attached
- Adds tests for both detach-error eviction and non-detach-error cache reuse

Addresses gap 8 from PR #24159 self-review.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24188" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
