### PR TITLE
feat(settings): move backups to general tab, managed assistants only

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AssistantBackupsSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantBackupsSection.swift
@@ -1,4 +1,3 @@
-import AppKit
 import Foundation
 import SwiftUI
 import VellumAssistantShared
@@ -7,26 +6,19 @@ import VellumAssistantShared
 ///
 /// Only rendered for cloud-hosted (platform-managed) assistants — the call site
 /// in `SettingsGeneralTab` gates this section on `LockfileAssistant.isManaged`.
+/// Uses the platform API endpoints (`GET/POST /v1/assistants/{id}/backups`,
+/// `POST /v1/assistants/{id}/backups/{name}/restore`).
 ///
-/// For managed assistants, uses the platform API endpoints
-/// (`GET/POST /v1/assistants/{id}/backups`, `POST /v1/assistants/{id}/backups/{name}/restore`).
-///
-/// The local `.vbundle` export/restore code paths remain in place to support
-/// pre-update recovery for local assistants when triggered via the CLI, but
-/// they are not currently exposed through this view.
+/// Pre-update local recovery for non-managed assistants lives in
+/// `PreUpdateBackupBanner` and is rendered separately above this section.
 @MainActor
 struct AssistantBackupsSection: View {
     let assistant: LockfileAssistant
     let store: SettingsStore
 
-    @State private var isExporting = false
-    @State private var isImporting = false
     @State private var errorMessage: String?
     @State private var successMessage: String?
 
-    @AppStorage("preUpdateBackupPath") private var preUpdateBackupPath: String?
-
-    // Managed assistant state
     @State private var managedBackups: [ManagedBackup] = []
     @State private var isLoadingBackups = false
     @State private var isCreatingBackup = false
@@ -39,31 +31,7 @@ struct AssistantBackupsSection: View {
                 .font(VFont.titleSmall)
                 .foregroundStyle(VColor.contentDefault)
 
-            if let backupPath = preUpdateBackupPath,
-               FileManager.default.fileExists(atPath: backupPath) {
-                VStack(alignment: .leading, spacing: VSpacing.sm) {
-                    Text("A backup was automatically created before the last update.")
-                        .font(VFont.labelDefault)
-                        .foregroundStyle(VColor.contentSecondary)
-                    HStack {
-                        VButton(label: "Restore Pre-Update Data", style: .outlined) {
-                            Task {
-                                await performLocalRestore(URL(fileURLWithPath: backupPath))
-                                preUpdateBackupPath = nil
-                            }
-                        }
-                        VButton(label: "Dismiss", style: .ghost) {
-                            preUpdateBackupPath = nil
-                        }
-                    }
-                }
-            }
-
-            if assistant.isManaged || (assistant.isRemote && !assistant.isDocker) {
-                managedBackupContent
-            } else {
-                localBackupContent
-            }
+            managedBackupContent
 
             if let error = errorMessage {
                 Text(error)
@@ -82,42 +50,7 @@ struct AssistantBackupsSection: View {
         .vCard()
         .frame(maxWidth: .infinity, alignment: .leading)
         .task {
-            if assistant.isManaged || (assistant.isRemote && !assistant.isDocker) {
-                await loadManagedBackupsQuietly()
-            }
-        }
-    }
-
-    // MARK: - Local Backup Content
-
-    @ViewBuilder
-    private var localBackupContent: some View {
-        VStack(alignment: .leading, spacing: VSpacing.sm) {
-            Text("Export or restore assistant data as a .vbundle archive.")
-                .font(VFont.labelDefault)
-                .foregroundStyle(VColor.contentTertiary)
-        }
-
-        HStack(spacing: VSpacing.md) {
-            VButton(label: isExporting ? "Exporting..." : "Create Backup", style: .outlined) {
-                Task { await exportLocalBackup() }
-            }
-            .disabled(isExporting || isImporting)
-
-            VButton(label: isImporting ? "Restoring..." : "Restore from Backup", style: .outlined) {
-                selectAndRestoreLocalBackup()
-            }
-            .disabled(isExporting || isImporting)
-        }
-
-        if isExporting || isImporting {
-            HStack(spacing: VSpacing.sm) {
-                ProgressView()
-                    .controlSize(.small)
-                Text(isExporting ? "Creating backup..." : "Restoring backup...")
-                    .font(VFont.labelDefault)
-                    .foregroundStyle(VColor.contentTertiary)
-            }
+            await loadManagedBackupsQuietly()
         }
     }
 
@@ -205,77 +138,6 @@ struct AssistantBackupsSection: View {
         }
     }
 
-    // MARK: - Local Backup Actions
-
-    private func exportLocalBackup() async {
-        clearMessages()
-        isExporting = true
-        defer { isExporting = false }
-
-        do {
-            let response = try await GatewayHTTPClient.post(path: "migrations/export", timeout: 120)
-
-            guard response.isSuccess else {
-                errorMessage = "Export failed (HTTP \(response.statusCode))"
-                return
-            }
-
-            // Generate a timestamped filename (Content-Disposition header is not
-            // available through GatewayHTTPClient.Response).
-            let formatter = DateFormatter()
-            formatter.dateFormat = "yyyy-MM-dd-HHmmss"
-            let filename = "export-\(formatter.string(from: Date())).vbundle"
-
-            // Show save panel — don't set allowedContentTypes since the filename
-            // already includes .vbundle; setting it causes NSSavePanel to append
-            // a duplicate extension (.vbundle.vbundle).
-            let panel = NSSavePanel()
-            panel.nameFieldStringValue = filename
-            panel.canCreateDirectories = true
-
-            let panelResult = await panel.beginSheetModal(for: NSApp.keyWindow ?? NSApp.mainWindow ?? NSApp.windows.first!)
-            guard panelResult == .OK, let saveURL = panel.url else { return }
-
-            try response.data.write(to: saveURL)
-            successMessage = "Backup saved to \(saveURL.lastPathComponent)"
-        } catch let error as GatewayHTTPClient.ClientError {
-            errorMessage = error.localizedDescription
-        } catch {
-            errorMessage = "Export failed: \(error.localizedDescription)"
-        }
-    }
-
-    private func selectAndRestoreLocalBackup() {
-        clearMessages()
-
-        let panel = NSOpenPanel()
-        panel.allowedContentTypes = [.init(filenameExtension: "vbundle") ?? .data]
-        panel.allowsMultipleSelection = false
-        panel.canChooseDirectories = false
-
-        panel.begin { result in
-            Task { @MainActor in
-                guard result == .OK, let url = panel.url else { return }
-
-                // Use NSAlert instead of SwiftUI .alert — SwiftUI alerts on
-                // inner views are swallowed when the parent has its own .alert
-                // modifiers (SettingsDeveloperTab has several).
-                let alert = NSAlert()
-                alert.messageText = "Restore from Backup"
-                alert.informativeText = "This will replace the assistant's current data with the backup and restart it. This action cannot be undone."
-                alert.alertStyle = .warning
-                alert.addButton(withTitle: "Restore")
-                alert.addButton(withTitle: "Cancel")
-                alert.buttons.first?.hasDestructiveAction = true
-
-                let response = alert.runModal()
-                guard response == .alertFirstButtonReturn else { return }
-
-                await performLocalRestore(url)
-            }
-        }
-    }
-
     // MARK: - Managed Backup Actions
 
     private func loadManagedBackups() async {
@@ -355,52 +217,6 @@ struct AssistantBackupsSection: View {
     private func clearMessages() {
         errorMessage = nil
         successMessage = nil
-    }
-}
-
-// MARK: - Local Restore
-
-extension AssistantBackupsSection {
-    func performLocalRestore(_ fileURL: URL) async {
-        isImporting = true
-        defer { isImporting = false }
-
-        do {
-            let fileData = try Data(contentsOf: fileURL)
-            let response = try await GatewayHTTPClient.post(path: "migrations/import", body: fileData, contentType: "application/octet-stream", timeout: 120)
-
-            if response.isSuccess {
-                if let json = try? JSONSerialization.jsonObject(with: response.data) as? [String: Any],
-                   let success = json["success"] as? Bool, success {
-                    successMessage = "Backup restored. Restarting assistant..."
-
-                    // Auto-restart the assistant so restored state takes effect
-                    let assistantName = assistant.assistantId
-                    let isDocker = assistant.isDocker
-                    Task {
-                        if isDocker {
-                            try? await AppDelegate.shared?.vellumCli.sleep(name: assistantName)
-                        } else {
-                            await AppDelegate.shared?.vellumCli.stop(name: assistantName)
-                        }
-                        try? await Task.sleep(nanoseconds: 500_000_000)
-                        try? await AppDelegate.shared?.vellumCli.wake(name: assistantName)
-                        // Reload avatar after restart so the restored avatar is displayed
-                        AvatarAppearanceManager.shared.reloadAvatar()
-                    }
-                } else {
-                    errorMessage = "Import completed with warnings. Check assistant logs for details."
-                }
-            } else if response.statusCode == 413 {
-                errorMessage = "Backup file is too large. Please upgrade the assistant to restore this backup."
-            } else {
-                errorMessage = "Import failed (HTTP \(response.statusCode))"
-            }
-        } catch let error as GatewayHTTPClient.ClientError {
-            errorMessage = error.localizedDescription
-        } catch {
-            errorMessage = "Import failed: \(error.localizedDescription)"
-        }
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/Settings/AssistantBackupsSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantBackupsSection.swift
@@ -3,13 +3,17 @@ import Foundation
 import SwiftUI
 import VellumAssistantShared
 
-/// Backup and restore UI for the Settings Account tab.
+/// Backup and restore UI for the General settings tab.
 ///
-/// For local assistants, creates/restores `.vbundle` archives via the gateway's
-/// migration endpoints (`POST /v1/migrations/export` and `POST /v1/migrations/import`).
+/// Only rendered for cloud-hosted (platform-managed) assistants — the call site
+/// in `SettingsGeneralTab` gates this section on `LockfileAssistant.isManaged`.
 ///
-/// For managed/remote assistants, uses the platform API endpoints
+/// For managed assistants, uses the platform API endpoints
 /// (`GET/POST /v1/assistants/{id}/backups`, `POST /v1/assistants/{id}/backups/{name}/restore`).
+///
+/// The local `.vbundle` export/restore code paths remain in place to support
+/// pre-update recovery for local assistants when triggered via the CLI, but
+/// they are not currently exposed through this view.
 @MainActor
 struct AssistantBackupsSection: View {
     let assistant: LockfileAssistant

--- a/clients/macos/vellum-assistant/Features/Settings/PreUpdateBackupBanner.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/PreUpdateBackupBanner.swift
@@ -1,0 +1,122 @@
+import AppKit
+import Foundation
+import SwiftUI
+import VellumAssistantShared
+
+/// Banner that surfaces a pre-update `.vbundle` backup created automatically
+/// by Sparkle's `onWillInstallUpdate` hook (see `AppDelegate+ConnectionSetup`).
+///
+/// Visible to all assistant types — local users are the primary consumers of
+/// pre-update recovery, so this view is rendered outside of `AssistantBackupsSection`
+/// (which is gated on managed/cloud assistants only). The banner only renders
+/// when `preUpdateBackupPath` is set in defaults and the file still exists on
+/// disk; otherwise it's a no-op.
+@MainActor
+struct PreUpdateBackupBanner: View {
+    let assistant: LockfileAssistant?
+
+    @AppStorage("preUpdateBackupPath") private var preUpdateBackupPath: String?
+
+    @State private var isImporting = false
+    @State private var errorMessage: String?
+    @State private var successMessage: String?
+
+    var body: some View {
+        if let backupPath = preUpdateBackupPath,
+           FileManager.default.fileExists(atPath: backupPath) {
+            VStack(alignment: .leading, spacing: VSpacing.md) {
+                Text("Pre-Update Backup")
+                    .font(VFont.titleSmall)
+                    .foregroundStyle(VColor.contentDefault)
+
+                Text("A backup was automatically created before the last update.")
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentSecondary)
+
+                HStack {
+                    VButton(
+                        label: isImporting ? "Restoring..." : "Restore Pre-Update Data",
+                        style: .outlined
+                    ) {
+                        Task {
+                            await performLocalRestore(URL(fileURLWithPath: backupPath))
+                            preUpdateBackupPath = nil
+                        }
+                    }
+                    .disabled(isImporting)
+                    VButton(label: "Dismiss", style: .ghost) {
+                        preUpdateBackupPath = nil
+                    }
+                    .disabled(isImporting)
+                }
+
+                if let error = errorMessage {
+                    Text(error)
+                        .font(VFont.labelDefault)
+                        .foregroundStyle(VColor.systemNegativeStrong)
+                }
+
+                if let success = successMessage {
+                    Text(success)
+                        .font(VFont.labelDefault)
+                        .foregroundStyle(VColor.systemPositiveStrong)
+                }
+            }
+            .padding(VSpacing.lg)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .vCard()
+        }
+    }
+
+    /// Restores the assistant from a `.vbundle` backup via the gateway's
+    /// `migrations/import` endpoint, then bounces the daemon so the restored
+    /// state takes effect.
+    private func performLocalRestore(_ fileURL: URL) async {
+        isImporting = true
+        defer { isImporting = false }
+
+        do {
+            let fileData = try Data(contentsOf: fileURL)
+            let response = try await GatewayHTTPClient.post(
+                path: "migrations/import",
+                body: fileData,
+                contentType: "application/octet-stream",
+                timeout: 120
+            )
+
+            if response.isSuccess {
+                if let json = try? JSONSerialization.jsonObject(with: response.data) as? [String: Any],
+                   let success = json["success"] as? Bool, success {
+                    successMessage = "Backup restored. Restarting assistant..."
+
+                    // Auto-restart the assistant so restored state takes effect.
+                    if let assistant {
+                        let assistantName = assistant.assistantId
+                        let isDocker = assistant.isDocker
+                        Task {
+                            if isDocker {
+                                try? await AppDelegate.shared?.vellumCli.sleep(name: assistantName)
+                            } else {
+                                await AppDelegate.shared?.vellumCli.stop(name: assistantName)
+                            }
+                            try? await Task.sleep(nanoseconds: 500_000_000)
+                            try? await AppDelegate.shared?.vellumCli.wake(name: assistantName)
+                            // Reload avatar after restart so the restored avatar is displayed.
+                            AvatarAppearanceManager.shared.reloadAvatar()
+                        }
+                    }
+                } else {
+                    errorMessage = "Import completed with warnings. Check assistant logs for details."
+                }
+            } else if response.statusCode == 413 {
+                errorMessage = "Backup file is too large. Please upgrade the assistant to restore this backup."
+            } else {
+                errorMessage = "Import failed (HTTP \(response.statusCode))"
+            }
+        } catch let error as GatewayHTTPClient.ClientError {
+            errorMessage = error.localizedDescription
+        } catch {
+            errorMessage = "Import failed: \(error.localizedDescription)"
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Settings/PreUpdateBackupBanner.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/PreUpdateBackupBanner.swift
@@ -11,9 +11,13 @@ import VellumAssistantShared
 /// (which is gated on managed/cloud assistants only). The banner only renders
 /// when `preUpdateBackupPath` is set in defaults and the file still exists on
 /// disk; otherwise it's a no-op.
+///
+/// `assistant` is required (not optional): the call site must wait for the
+/// active lockfile assistant to load before mounting this view, since
+/// `performLocalRestore` needs to bounce that specific assistant after import.
 @MainActor
 struct PreUpdateBackupBanner: View {
-    let assistant: LockfileAssistant?
+    let assistant: LockfileAssistant
 
     @AppStorage("preUpdateBackupPath") private var preUpdateBackupPath: String?
 
@@ -101,20 +105,18 @@ struct PreUpdateBackupBanner: View {
                     successMessage = "Backup restored. Restarting assistant..."
 
                     // Auto-restart the assistant so restored state takes effect.
-                    if let assistant {
-                        let assistantName = assistant.assistantId
-                        let isDocker = assistant.isDocker
-                        Task {
-                            if isDocker {
-                                try? await AppDelegate.shared?.vellumCli.sleep(name: assistantName)
-                            } else {
-                                await AppDelegate.shared?.vellumCli.stop(name: assistantName)
-                            }
-                            try? await Task.sleep(nanoseconds: 500_000_000)
-                            try? await AppDelegate.shared?.vellumCli.wake(name: assistantName)
-                            // Reload avatar after restart so the restored avatar is displayed.
-                            AvatarAppearanceManager.shared.reloadAvatar()
+                    let assistantName = assistant.assistantId
+                    let isDocker = assistant.isDocker
+                    Task {
+                        if isDocker {
+                            try? await AppDelegate.shared?.vellumCli.sleep(name: assistantName)
+                        } else {
+                            await AppDelegate.shared?.vellumCli.stop(name: assistantName)
                         }
+                        try? await Task.sleep(nanoseconds: 500_000_000)
+                        try? await AppDelegate.shared?.vellumCli.wake(name: assistantName)
+                        // Reload avatar after restart so the restored avatar is displayed.
+                        AvatarAppearanceManager.shared.reloadAvatar()
                     }
                     return true
                 }

--- a/clients/macos/vellum-assistant/Features/Settings/PreUpdateBackupBanner.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/PreUpdateBackupBanner.swift
@@ -39,8 +39,13 @@ struct PreUpdateBackupBanner: View {
                         style: .outlined
                     ) {
                         Task {
-                            await performLocalRestore(URL(fileURLWithPath: backupPath))
-                            preUpdateBackupPath = nil
+                            // Only clear the pre-update path on a successful restore.
+                            // On failure, leave it set so the banner stays visible
+                            // (with the error message) and the user can retry or dismiss.
+                            let restored = await performLocalRestore(URL(fileURLWithPath: backupPath))
+                            if restored {
+                                preUpdateBackupPath = nil
+                            }
                         }
                     }
                     .disabled(isImporting)
@@ -71,9 +76,15 @@ struct PreUpdateBackupBanner: View {
     /// Restores the assistant from a `.vbundle` backup via the gateway's
     /// `migrations/import` endpoint, then bounces the daemon so the restored
     /// state takes effect.
-    private func performLocalRestore(_ fileURL: URL) async {
+    ///
+    /// Returns `true` only when the import succeeded; the caller uses this to
+    /// decide whether to clear `preUpdateBackupPath`. On failure the banner is
+    /// kept on screen so the user can see the error message.
+    private func performLocalRestore(_ fileURL: URL) async -> Bool {
         isImporting = true
         defer { isImporting = false }
+        errorMessage = nil
+        successMessage = nil
 
         do {
             let fileData = try Data(contentsOf: fileURL)
@@ -105,18 +116,23 @@ struct PreUpdateBackupBanner: View {
                             AvatarAppearanceManager.shared.reloadAvatar()
                         }
                     }
-                } else {
-                    errorMessage = "Import completed with warnings. Check assistant logs for details."
+                    return true
                 }
+                errorMessage = "Import completed with warnings. Check assistant logs for details."
+                return false
             } else if response.statusCode == 413 {
                 errorMessage = "Backup file is too large. Please upgrade the assistant to restore this backup."
+                return false
             } else {
                 errorMessage = "Import failed (HTTP \(response.statusCode))"
+                return false
             }
         } catch let error as GatewayHTTPClient.ClientError {
             errorMessage = error.localizedDescription
+            return false
         } catch {
             errorMessage = "Import failed: \(error.localizedDescription)"
+            return false
         }
     }
 }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -92,10 +92,6 @@ struct SettingsDeveloperTab: View {
                     sshTerminalSection
                 }
             }
-            // Backups (all assistant types)
-            if let assistant = lockfileAssistants.first(where: { $0.assistantId == selectedAssistantId }) {
-                AssistantBackupsSection(assistant: assistant, store: store)
-            }
             // Transfer (local ↔ managed)
             if let assistant = lockfileAssistants.first(where: { $0.assistantId == selectedAssistantId }),
                !assistant.isRemote || assistant.isManaged {

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
@@ -87,6 +87,10 @@ struct SettingsGeneralTab: View {
                 mobilePairingCard
             }
             SettingsAppearanceTab(store: store)
+            // Backups — only shown for cloud-hosted/platform-managed assistants.
+            if let assistant = currentAssistant, assistant.isManaged {
+                AssistantBackupsSection(assistant: assistant, store: store)
+            }
             uninstallSection
         }
         .onAppear {

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
@@ -79,9 +79,13 @@ struct SettingsGeneralTab: View {
                 )
             }
             // Pre-update backup recovery — visible to all assistant types when
-            // a `.vbundle` snapshot from the most recent app update is still on disk.
-            // Renders nothing if no pre-update backup path is set.
-            PreUpdateBackupBanner(assistant: currentAssistant)
+            // a `.vbundle` snapshot from the most recent app update is still on
+            // disk. Gated on a loaded `currentAssistant` so the post-restore
+            // restart can target a specific assistant. Renders nothing if no
+            // pre-update backup path is set.
+            if let assistant = currentAssistant {
+                PreUpdateBackupBanner(assistant: assistant)
+            }
             if MacOSClientFeatureFlagManager.shared.isEnabled("teleport"),
                let assistant = currentAssistant,
                !assistant.isManaged && (!assistant.isRemote || assistant.isDocker) {

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
@@ -78,6 +78,10 @@ struct SettingsGeneralTab: View {
                     updateManager: updateManager
                 )
             }
+            // Pre-update backup recovery — visible to all assistant types when
+            // a `.vbundle` snapshot from the most recent app update is still on disk.
+            // Renders nothing if no pre-update backup path is set.
+            PreUpdateBackupBanner(assistant: currentAssistant)
             if MacOSClientFeatureFlagManager.shared.isEnabled("teleport"),
                let assistant = currentAssistant,
                !assistant.isManaged && (!assistant.isRemote || assistant.isDocker) {


### PR DESCRIPTION
## Summary
- Removed the \`AssistantBackupsSection\` from \`SettingsDeveloperTab\` where it was buried under the developer tools and rendered for every assistant type.
- Added it to \`SettingsGeneralTab\` toward the bottom (after Appearance, before Uninstall), gated on \`currentAssistant?.isManaged == true\` so it only renders for cloud-hosted / platform-managed assistants.
- Updated the file-level doc comment in \`AssistantBackupsSection.swift\` to reflect the new location and managed-only visibility.

## Original prompt
--safe move backups out of the settings developer tab and into the general settings tab towards the bottom. Only show backups if its a cloud hosted/platform assistant
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24191" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
