### PR TITLE
feat(macos): show CPU/memory/disk usage in General settings on platform

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
@@ -196,29 +196,29 @@ struct SettingsGeneralTab: View {
         ) {
             if let healthz {
                 if let disk = healthz.disk {
-                    VStack(alignment: .leading, spacing: VSpacing.xs) {
-                        HStack(alignment: .center) {
-                            Text("Disk")
-                                .font(VFont.labelDefault)
-                                .foregroundStyle(VColor.contentTertiary)
-                                .frame(width: 100, alignment: .leading)
+                    HStack(alignment: .top) {
+                        Text("Disk Usage:")
+                            .font(VFont.labelDefault)
+                            .foregroundStyle(VColor.contentTertiary)
+                            .frame(width: 100, alignment: .leading)
+
+                        VStack(alignment: .leading, spacing: VSpacing.xs) {
+                            ProgressView(value: Double(disk.usedMb), total: Double(max(disk.totalMb, 1)))
+                                .progressViewStyle(.linear)
+                                .tint(Double(disk.usedMb) / Double(max(disk.totalMb, 1)) > 0.9 ? VColor.systemNegativeStrong : VColor.systemPositiveStrong)
                             Text("\(formatMb(disk.usedMb)) used of \(formatMb(disk.totalMb))")
                                 .font(VFont.bodyMediumLighter)
                                 .foregroundStyle(VColor.contentDefault)
-                            Spacer()
                         }
-                        ProgressView(value: Double(disk.usedMb), total: Double(max(disk.totalMb, 1)))
-                            .progressViewStyle(.linear)
-                            .tint(Double(disk.usedMb) / Double(max(disk.totalMb, 1)) > 0.9 ? VColor.systemNegativeStrong : VColor.primaryBase)
                     }
                 }
 
                 if let memory = healthz.memory {
-                    resourceRow(label: "Memory", value: "\(formatMb(memory.currentMb)) / \(formatMb(memory.maxMb))")
+                    resourceRow(label: "Memory:", value: "\(formatMb(memory.currentMb)) / \(formatMb(memory.maxMb))")
                 }
 
                 if let cpu = healthz.cpu {
-                    resourceRow(label: "CPU", value: String(format: "%.1f%%", cpu.currentPercent))
+                    resourceRow(label: "CPU:", value: String(format: "%.1f%%", cpu.currentPercent))
                 }
 
                 if healthz.disk == nil && healthz.memory == nil && healthz.cpu == nil {

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
@@ -195,7 +195,7 @@ struct SettingsGeneralTab: View {
     private var systemResourcesSection: some View {
         SettingsCard(
             title: "System Resources",
-            subtitle: "Current resource usage on your platform-managed assistant",
+            subtitle: "Current resource usage on your assistant",
             accessory: {
                 if isRefreshingHealthz {
                     ProgressView()

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
@@ -78,6 +78,9 @@ struct SettingsGeneralTab: View {
                     updateManager: updateManager
                 )
             }
+            if topology == .managed {
+                systemResourcesSection
+            }
             if MacOSClientFeatureFlagManager.shared.isEnabled("teleport"),
                let assistant = currentAssistant,
                !assistant.isManaged && (!assistant.isRemote || assistant.isDocker) {
@@ -179,6 +182,83 @@ struct SettingsGeneralTab: View {
             healthz = DaemonHealthz()
         }
         healthzLoaded = true
+    }
+
+    // MARK: - System Resources
+
+    /// Resource usage card shown for platform-managed assistants. Mirrors the
+    /// disk/memory/CPU rows from the Developer tab so users on the platform can
+    /// see their assistant's resource consumption without enabling dev mode.
+    private var systemResourcesSection: some View {
+        SettingsCard(
+            title: "System Resources",
+            subtitle: "Current resource usage on your platform-managed assistant"
+        ) {
+            if let healthz {
+                if let disk = healthz.disk {
+                    VStack(alignment: .leading, spacing: VSpacing.xs) {
+                        HStack(alignment: .center) {
+                            Text("Disk")
+                                .font(VFont.labelDefault)
+                                .foregroundStyle(VColor.contentTertiary)
+                                .frame(width: 100, alignment: .leading)
+                            Text("\(formatMb(disk.usedMb)) used of \(formatMb(disk.totalMb))")
+                                .font(VFont.bodyMediumLighter)
+                                .foregroundStyle(VColor.contentDefault)
+                            Spacer()
+                        }
+                        ProgressView(value: Double(disk.usedMb), total: Double(max(disk.totalMb, 1)))
+                            .progressViewStyle(.linear)
+                            .tint(Double(disk.usedMb) / Double(max(disk.totalMb, 1)) > 0.9 ? VColor.systemNegativeStrong : VColor.primaryBase)
+                    }
+                }
+
+                if let memory = healthz.memory {
+                    resourceRow(label: "Memory", value: "\(formatMb(memory.currentMb)) / \(formatMb(memory.maxMb))")
+                }
+
+                if let cpu = healthz.cpu {
+                    resourceRow(label: "CPU", value: String(format: "%.1f%%", cpu.currentPercent))
+                }
+
+                if healthz.disk == nil && healthz.memory == nil && healthz.cpu == nil {
+                    Text("Resource metrics are not available for this assistant.")
+                        .font(VFont.bodyMediumLighter)
+                        .foregroundStyle(VColor.contentTertiary)
+                }
+            } else {
+                HStack(spacing: VSpacing.sm) {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text("Loading resource metrics...")
+                        .font(VFont.labelDefault)
+                        .foregroundStyle(VColor.contentTertiary)
+                }
+            }
+        }
+    }
+
+    private func resourceRow(label: String, value: String) -> some View {
+        HStack(alignment: .top) {
+            Text(label)
+                .font(VFont.labelDefault)
+                .foregroundStyle(VColor.contentTertiary)
+                .frame(width: 100, alignment: .leading)
+
+            Text(value)
+                .font(VFont.bodyMediumLighter)
+                .foregroundStyle(VColor.contentDefault)
+                .textSelection(.enabled)
+
+            Spacer()
+        }
+    }
+
+    private func formatMb(_ mb: Double) -> String {
+        if mb >= 1024 {
+            return String(format: "%.1f GB", mb / 1024.0)
+        }
+        return String(format: "%.0f MB", mb)
     }
 
     // MARK: - Mobile Pairing

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
@@ -27,6 +27,7 @@ struct SettingsGeneralTab: View {
     @State private var dockerOperationTimedOut = false
     @State private var dockerOperationTimeoutTask: Task<Void, Never>?
     @State private var healthzLoaded = false
+    @State private var isRefreshingHealthz = false
 
     /// Publisher for reactive observation of connectionManager's isUpdateInProgress.
     /// Falls back to a single `false` emission when connectionManager is nil.
@@ -172,6 +173,8 @@ struct SettingsGeneralTab: View {
 
     private func fetchHealthz() async {
         guard !selectedAssistantId.isEmpty else { return }
+        isRefreshingHealthz = true
+        defer { isRefreshingHealthz = false }
         do {
             let (decoded, _): (DaemonHealthz?, _) = try await GatewayHTTPClient.get(
                 path: "assistants/{assistantId}/healthz",
@@ -192,7 +195,24 @@ struct SettingsGeneralTab: View {
     private var systemResourcesSection: some View {
         SettingsCard(
             title: "System Resources",
-            subtitle: "Current resource usage on your platform-managed assistant"
+            subtitle: "Current resource usage on your platform-managed assistant",
+            accessory: {
+                if isRefreshingHealthz {
+                    ProgressView()
+                        .controlSize(.small)
+                        .progressViewStyle(.circular)
+                } else {
+                    VButton(
+                        label: "Refresh resource metrics",
+                        iconOnly: VIcon.refreshCw.rawValue,
+                        style: .ghost,
+                        size: .compact,
+                        tooltip: "Refresh"
+                    ) {
+                        Task { await fetchHealthz() }
+                    }
+                }
+            }
         ) {
             if let healthz {
                 if let disk = healthz.disk {

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
@@ -203,9 +203,7 @@ struct SettingsGeneralTab: View {
                             .frame(width: 100, alignment: .leading)
 
                         VStack(alignment: .leading, spacing: VSpacing.xs) {
-                            ProgressView(value: Double(disk.usedMb), total: Double(max(disk.totalMb, 1)))
-                                .progressViewStyle(.linear)
-                                .tint(Double(disk.usedMb) / Double(max(disk.totalMb, 1)) > 0.9 ? VColor.systemNegativeStrong : VColor.systemPositiveStrong)
+                            diskUsageBar(usedMb: disk.usedMb, totalMb: disk.totalMb)
                             Text("\(formatMb(disk.usedMb)) used of \(formatMb(disk.totalMb))")
                                 .font(VFont.bodyMediumLighter)
                                 .foregroundStyle(VColor.contentDefault)
@@ -236,6 +234,28 @@ struct SettingsGeneralTab: View {
                 }
             }
         }
+    }
+
+    /// Custom disk usage bar built from Capsule shapes. Avoids `ProgressView(.linear)`
+    /// because on macOS its tint is overridden by the system accent color, which
+    /// renders as orange on default installs instead of the themed green.
+    private func diskUsageBar(usedMb: Double, totalMb: Double) -> some View {
+        let ratio = min(1.0, max(0.0, usedMb / max(totalMb, 1)))
+        let isCritical = ratio > 0.9
+        let fillColor = isCritical ? VColor.systemNegativeStrong : VColor.systemPositiveStrong
+        return GeometryReader { geo in
+            ZStack(alignment: .leading) {
+                Capsule()
+                    .fill(VColor.borderHover)
+                Capsule()
+                    .fill(fillColor)
+                    .frame(width: ratio * geo.size.width)
+            }
+        }
+        .frame(height: 8)
+        .accessibilityElement()
+        .accessibilityLabel("Disk usage")
+        .accessibilityValue("\(Int(ratio * 100)) percent")
     }
 
     private func resourceRow(label: String, value: String) -> some View {


### PR DESCRIPTION
## Summary
- Adds a **System Resources** card to the General settings tab showing disk (with progress bar), memory, and CPU usage from the existing `/v1/health` payload that the tab already fetches.
- Gated to `topology == .managed` so it only appears for platform-managed assistants — Docker, local, and remote topologies are unaffected.
- Mirrors the row layout, progress-bar tint thresholds, and `formatMb` helper from `SettingsDeveloperTab` so platform users can see resource usage without enabling dev mode.

## Original prompt
if in platform mode add cpu/memory and disk space usage to the general panel follow existing styling standards
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24193" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
