### PR TITLE
feat(ui): add assistant switcher to menu bar with new/retire actions

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -122,6 +122,15 @@ extension AppDelegate {
 
         rebindConnectionStatusObserver()
 
+        // Read the multi-platform-assistant flag exactly once when the
+        // status item is constructed. Flag changes require relaunch.
+        multiAssistantSwitcherEnabled = featureFlagStore.isEnabled("multi-platform-assistant")
+        if multiAssistantSwitcherEnabled {
+            assistantSwitcherViewModel = makeAssistantSwitcherViewModel()
+        } else {
+            assistantSwitcherViewModel = nil
+        }
+
         // Update menu bar icon when the assistant's avatar changes.
         if avatarChangeObserver == nil {
             avatarChangeObserver = NotificationCenter.default.addObserver(
@@ -413,6 +422,23 @@ extension AppDelegate {
             menu.addItem(restartItem)
         }
 
+        if multiAssistantSwitcherEnabled, onboardingWindow == nil, let switcherVM = assistantSwitcherViewModel {
+            // Force a re-read of the lockfile before rebuilding so items
+            // reflect any changes the active assistant may have missed
+            // (e.g. just after a create).
+            switcherVM.refresh()
+            menu.addItem(NSMenuItem.separator())
+            for item in AssistantSwitcherMenu.buildItems(
+                viewModel: switcherVM,
+                target: self,
+                selectAction: #selector(assistantSwitcherDidSelect(_:)),
+                createAction: #selector(assistantSwitcherDidRequestCreate(_:)),
+                retireAction: #selector(assistantSwitcherDidRequestRetire(_:))
+            ) {
+                menu.addItem(item)
+            }
+        }
+
         menu.addItem(NSMenuItem.separator())
 
         let quitItem = NSMenuItem(title: "Quit", action: #selector(NSApplication.terminate(_:)), keyEquivalent: "q")
@@ -697,6 +723,142 @@ extension AppDelegate {
         }
     }
 
+    // MARK: - Assistant Switcher (multi-platform-assistant)
+
+    /// Build the view model used by the menu-bar switcher. Production
+    /// handlers wrap `ManagedAssistantConnectionCoordinator.switchToManagedAssistant`,
+    /// the hatch path, and the existing vellum CLI retire path.
+    func makeAssistantSwitcherViewModel() -> AssistantSwitcherViewModel {
+        AssistantSwitcherViewModel(
+            switchHandler: { [weak self] assistantId in
+                guard let self else { return }
+                let controller = AppDelegateManagedConnectionController(appDelegate: self)
+                let coordinator = ManagedAssistantConnectionCoordinator(
+                    connectionController: controller
+                )
+                _ = try await coordinator.switchToManagedAssistant(assistantId: assistantId)
+            },
+            createHandler: { [weak self] name in
+                guard let self else { return }
+                try await self.hatchAndPersistManagedAssistant(name: name)
+            },
+            retireHandler: { [weak self] assistantId in
+                guard let self else { return }
+                try await self.retireManagedAssistantFromSwitcher(assistantId: assistantId)
+            }
+        )
+    }
+
+    /// Hatch a new managed assistant against the platform and persist it to
+    /// the lockfile. The organization id is read from UserDefaults — matching
+    /// the path the onboarding flow and TeleportSection use.
+    private func hatchAndPersistManagedAssistant(name: String) async throws {
+        guard let organizationId = UserDefaults.standard.string(forKey: "connectedOrganizationId"),
+              !organizationId.isEmpty else {
+            throw NSError(
+                domain: "AssistantSwitcher",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "No organization connected."]
+            )
+        }
+        let result = try await AuthService.shared.hatchAssistant(
+            organizationId: organizationId,
+            name: name
+        )
+        let platformAssistant: PlatformAssistant
+        switch result {
+        case .reusedExisting(let assistant), .createdNew(let assistant):
+            platformAssistant = assistant
+        }
+        let success = LockfileAssistant.ensureManagedEntry(
+            assistantId: platformAssistant.id,
+            runtimeUrl: AuthService.shared.baseURL,
+            hatchedAt: platformAssistant.created_at ?? Date().iso8601String
+        )
+        guard success else {
+            throw NSError(
+                domain: "AssistantSwitcher",
+                code: 2,
+                userInfo: [NSLocalizedDescriptionKey: "Failed to persist new assistant to lockfile."]
+            )
+        }
+    }
+
+    /// Retire an assistant requested from the switcher. If the target is the
+    /// currently active assistant we delegate to the existing `performRetire`
+    /// path which handles fallback selection and tear-down. Retiring a
+    /// non-active managed assistant from the switcher is not yet wired — we
+    /// surface a log and throw so the user sees a clear failure rather than
+    /// a silent no-op. Tracked as a follow-up; see the TODO below.
+    private func retireManagedAssistantFromSwitcher(assistantId: String) async throws {
+        let activeId = LockfileAssistant.loadActiveAssistantId()
+        if assistantId == activeId {
+            _ = await performRetireAsync()
+            return
+        }
+        // TODO(multi-host-asst): retire a non-active managed assistant from
+        // the switcher. This requires a variant of `performRetireAsync()`
+        // that targets an arbitrary id without tearing down the current
+        // connection. Tracked separately from PR 4.
+        log.warning("Retire for non-active managed assistant not yet supported: \(assistantId, privacy: .public)")
+        throw NSError(
+            domain: "AssistantSwitcher",
+            code: 3,
+            userInfo: [NSLocalizedDescriptionKey: "Retiring a non-active assistant is not yet supported. Switch to this assistant first, then retire it."]
+        )
+    }
+
+    @objc func assistantSwitcherDidSelect(_ sender: NSMenuItem) {
+        guard let assistantId = sender.representedObject as? String else { return }
+        guard let vm = assistantSwitcherViewModel else { return }
+        Task { @MainActor in
+            do {
+                try await vm.select(assistantId: assistantId)
+            } catch {
+                log.error("Assistant switch failed: \(error.localizedDescription, privacy: .public)")
+                let alert = NSAlert()
+                alert.messageText = "Could not switch assistant"
+                alert.informativeText = error.localizedDescription
+                alert.alertStyle = .warning
+                alert.runModal()
+            }
+        }
+    }
+
+    @objc func assistantSwitcherDidRequestCreate(_ sender: NSMenuItem) {
+        guard let vm = assistantSwitcherViewModel else { return }
+        guard let name = AssistantSwitcherMenu.promptForNewAssistantName() else { return }
+        Task { @MainActor in
+            do {
+                try await vm.createNewAssistant(name: name)
+            } catch {
+                log.error("New managed assistant failed: \(error.localizedDescription, privacy: .public)")
+                let alert = NSAlert()
+                alert.messageText = "Could not create assistant"
+                alert.informativeText = error.localizedDescription
+                alert.alertStyle = .warning
+                alert.runModal()
+            }
+        }
+    }
+
+    @objc func assistantSwitcherDidRequestRetire(_ sender: NSMenuItem) {
+        guard let assistantId = sender.representedObject as? String else { return }
+        guard let vm = assistantSwitcherViewModel else { return }
+        Task { @MainActor in
+            do {
+                try await vm.retire(assistantId: assistantId)
+            } catch {
+                log.error("Retire from switcher failed: \(error.localizedDescription, privacy: .public)")
+                let alert = NSAlert()
+                alert.messageText = "Could not retire assistant"
+                alert.informativeText = error.localizedDescription
+                alert.alertStyle = .warning
+                alert.runModal()
+            }
+        }
+    }
+
     #if DEBUG
     @objc func showComponentGallery() {
         AvatarGallerySection.registerInGallery()
@@ -705,4 +867,26 @@ extension AppDelegate {
     }
 
     #endif
+}
+
+/// Bridges `ManagedAssistantConnectionController` onto the live
+/// `AppDelegate` connection stack. On teardown it disconnects the current
+/// gateway client; on bring-up it re-runs `setupGatewayConnectionManager()`
+/// which reads the (now-updated) active assistant from the lockfile and
+/// reconnects.
+@MainActor
+final class AppDelegateManagedConnectionController: ManagedAssistantConnectionController {
+    private weak var appDelegate: AppDelegate?
+
+    init(appDelegate: AppDelegate) {
+        self.appDelegate = appDelegate
+    }
+
+    func teardown() async {
+        appDelegate?.connectionManager.disconnect()
+    }
+
+    func bringUp(for assistant: LockfileAssistant) async {
+        appDelegate?.setupGatewayConnectionManager()
+    }
 }

--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -729,13 +729,19 @@ extension AppDelegate {
     /// handlers wrap `ManagedAssistantConnectionCoordinator.switchToManagedAssistant`,
     /// the hatch path, and the existing vellum CLI retire path.
     func makeAssistantSwitcherViewModel() -> AssistantSwitcherViewModel {
-        AssistantSwitcherViewModel(
-            switchHandler: { [weak self] assistantId in
-                guard let self else { return }
-                let controller = AppDelegateManagedConnectionController(appDelegate: self)
-                let coordinator = ManagedAssistantConnectionCoordinator(
-                    connectionController: controller
-                )
+        // Reuse one coordinator + controller for the lifetime of the
+        // switcher rather than allocating per-click. The coordinator is
+        // effectively stateless today, but caching keeps this call site
+        // consistent with how `activateManagedAssistant` is wired and
+        // guards against silent drift if state is added later.
+        let controller = AppDelegateManagedConnectionController(appDelegate: self)
+        let coordinator = ManagedAssistantConnectionCoordinator(
+            connectionController: controller
+        )
+        assistantSwitcherConnectionController = controller
+        assistantSwitcherCoordinator = coordinator
+        return AssistantSwitcherViewModel(
+            switchHandler: { assistantId in
                 _ = try await coordinator.switchToManagedAssistant(assistantId: assistantId)
             },
             createHandler: { [weak self] name in
@@ -750,16 +756,14 @@ extension AppDelegate {
     }
 
     /// Hatch a new managed assistant against the platform and persist it to
-    /// the lockfile. The organization id is read from UserDefaults — matching
-    /// the path the onboarding flow and TeleportSection use.
+    /// the lockfile. The organization id is read from UserDefaults —
+    /// matching the path the onboarding flow and TeleportSection use. There
+    /// is no centralized constant for this key yet; see TeleportSection for
+    /// the other call site that reads it directly.
     private func hatchAndPersistManagedAssistant(name: String) async throws {
         guard let organizationId = UserDefaults.standard.string(forKey: "connectedOrganizationId"),
               !organizationId.isEmpty else {
-            throw NSError(
-                domain: "AssistantSwitcher",
-                code: 1,
-                userInfo: [NSLocalizedDescriptionKey: "No organization connected."]
-            )
+            throw AssistantSwitcherError.noOrganizationConnected
         }
         let result = try await AuthService.shared.hatchAssistant(
             organizationId: organizationId,
@@ -776,36 +780,25 @@ extension AppDelegate {
             hatchedAt: platformAssistant.created_at ?? Date().iso8601String
         )
         guard success else {
-            throw NSError(
-                domain: "AssistantSwitcher",
-                code: 2,
-                userInfo: [NSLocalizedDescriptionKey: "Failed to persist new assistant to lockfile."]
-            )
+            throw AssistantSwitcherError.lockfilePersistenceFailed
         }
     }
 
-    /// Retire an assistant requested from the switcher. If the target is the
-    /// currently active assistant we delegate to the existing `performRetire`
-    /// path which handles fallback selection and tear-down. Retiring a
-    /// non-active managed assistant from the switcher is not yet wired — we
-    /// surface a log and throw so the user sees a clear failure rather than
-    /// a silent no-op. Tracked as a follow-up; see the TODO below.
+    /// Retire an assistant requested from the switcher. Today the switcher
+    /// only exposes a retire row for the currently active assistant (the
+    /// menu builder enforces this), so we always delegate to the existing
+    /// `performRetireAsync()` path which handles fallback selection and
+    /// tear-down. Retiring a non-active managed assistant requires a
+    /// variant that targets an arbitrary id without tearing down the
+    /// current connection — tracked as a follow-up.
     private func retireManagedAssistantFromSwitcher(assistantId: String) async throws {
         let activeId = LockfileAssistant.loadActiveAssistantId()
-        if assistantId == activeId {
-            _ = await performRetireAsync()
-            return
+        guard assistantId == activeId else {
+            // Defensive: the menu should never surface this row, but throw
+            // a typed error rather than silently no-op if it ever does.
+            throw AssistantSwitcherError.retireNonActiveNotSupported
         }
-        // TODO(multi-host-asst): retire a non-active managed assistant from
-        // the switcher. This requires a variant of `performRetireAsync()`
-        // that targets an arbitrary id without tearing down the current
-        // connection. Tracked separately from PR 4.
-        log.warning("Retire for non-active managed assistant not yet supported: \(assistantId, privacy: .public)")
-        throw NSError(
-            domain: "AssistantSwitcher",
-            code: 3,
-            userInfo: [NSLocalizedDescriptionKey: "Retiring a non-active assistant is not yet supported. Switch to this assistant first, then retire it."]
-        )
+        _ = await performRetireAsync()
     }
 
     @objc func assistantSwitcherDidSelect(_ sender: NSMenuItem) {
@@ -887,12 +880,32 @@ final class AppDelegateManagedConnectionController: ManagedAssistantConnectionCo
     }
 
     func bringUp(for assistant: LockfileAssistant) async {
-        guard let appDelegate else { return }
-        // `setupGatewayConnectionManager()` short-circuits when
-        // `hasSetupDaemon` is true, which it always is after the app has
-        // finished launching. Reset it here so the switched assistant gets a
-        // fresh gateway client + SSE connection instead of a silent no-op.
-        appDelegate.hasSetupDaemon = false
-        appDelegate.setupGatewayConnectionManager()
+        // Reuse the existing `reconnectManagedAssistant()` entry point so
+        // the "reset the idempotency flag + re-run setup" dance lives in
+        // one place, rather than having the switcher toggle
+        // `hasSetupDaemon` directly and silently couple to every one-shot
+        // initializer inside `setupGatewayConnectionManager()`.
+        appDelegate?.reconnectManagedAssistant()
+    }
+}
+
+/// Typed errors surfaced from the menu-bar assistant switcher. Defined here
+/// (rather than alongside `ManagedAssistantConnectionCoordinatorError`)
+/// because these are UI-layer failures — no organization connected, the
+/// lockfile write failed, etc. — that never originate from the coordinator.
+enum AssistantSwitcherError: LocalizedError {
+    case noOrganizationConnected
+    case lockfilePersistenceFailed
+    case retireNonActiveNotSupported
+
+    var errorDescription: String? {
+        switch self {
+        case .noOrganizationConnected:
+            return "No organization connected. Sign in first, then try again."
+        case .lockfilePersistenceFailed:
+            return "Failed to save the new assistant to your lockfile."
+        case .retireNonActiveNotSupported:
+            return "Retiring a non-active assistant from the switcher isn't supported yet. Switch to the assistant first, then retire it."
+        }
     }
 }

--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -887,6 +887,12 @@ final class AppDelegateManagedConnectionController: ManagedAssistantConnectionCo
     }
 
     func bringUp(for assistant: LockfileAssistant) async {
-        appDelegate?.setupGatewayConnectionManager()
+        guard let appDelegate else { return }
+        // `setupGatewayConnectionManager()` short-circuits when
+        // `hasSetupDaemon` is true, which it always is after the app has
+        // finished launching. Reset it here so the switched assistant gets a
+        // fresh gateway client + SSE connection instead of a silent no-op.
+        appDelegate.hasSetupDaemon = false
+        appDelegate.setupGatewayConnectionManager()
     }
 }

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -147,6 +147,11 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     /// View model for the menu-bar assistant switcher. Lazily constructed in
     /// `setupMenuBar()` when `multiAssistantSwitcherEnabled` is true.
     var assistantSwitcherViewModel: AssistantSwitcherViewModel?
+    /// Cached coordinator + controller for the switcher's handlers. Stored
+    /// so every menu click doesn't allocate fresh instances and so future
+    /// state on the coordinator isn't silently bypassed by the switcher.
+    var assistantSwitcherCoordinator: ManagedAssistantConnectionCoordinator?
+    var assistantSwitcherConnectionController: AppDelegateManagedConnectionController?
     var cachedSkills: [SkillInfo] = []
     var refreshSkillsTask: Task<Void, Never>?
     var cachedApps: [AppItem] = []

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -139,6 +139,14 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     var pulseTimer: Timer?
     var pulsePhase: CGFloat = 1.0
     var pulseDirection: CGFloat = -1.0
+    /// Cached value of the `multi-platform-assistant` flag, read once when
+    /// the status item is constructed in `setupMenuBar()`. Flag changes
+    /// require relaunch; the status item does not subscribe to live updates
+    /// so it stays cheap and predictable.
+    var multiAssistantSwitcherEnabled: Bool = false
+    /// View model for the menu-bar assistant switcher. Lazily constructed in
+    /// `setupMenuBar()` when `multiAssistantSwitcherEnabled` is true.
+    var assistantSwitcherViewModel: AssistantSwitcherViewModel?
     var cachedSkills: [SkillInfo] = []
     var refreshSkillsTask: Task<Void, Never>?
     var cachedApps: [AppItem] = []

--- a/clients/macos/vellum-assistant/Features/AssistantSwitcher/AssistantSwitcherMenu.swift
+++ b/clients/macos/vellum-assistant/Features/AssistantSwitcher/AssistantSwitcherMenu.swift
@@ -1,0 +1,126 @@
+import AppKit
+import VellumAssistantShared
+import os
+
+private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "AssistantSwitcherMenu")
+
+/// Builds the assistant-switcher section of the status-item menu. This type
+/// owns no state — it is a pure builder that takes a view model and a target
+/// (for `NSMenuItem.target`), and returns a list of `NSMenuItem`s ready to be
+/// inserted into the parent menu.
+///
+/// Gating the section behind `multi-platform-assistant` is the caller's
+/// responsibility: when the flag is off the caller must not invoke
+/// `buildItems` at all, so the menu is byte-for-byte identical to the
+/// pre-feature build.
+@MainActor
+enum AssistantSwitcherMenu {
+    /// Tag used on the "New Assistant…" item so tests / code inspection can
+    /// find it without string matching.
+    static let newAssistantTag = 9101
+    /// Tag used on the parent "Retire" submenu item.
+    static let retireParentTag = 9102
+    /// Tag used on individual assistant row items. `representedObject` holds
+    /// the assistant id string.
+    static let assistantRowTag = 9103
+
+    static func buildItems(
+        viewModel: AssistantSwitcherViewModel,
+        target: AnyObject,
+        selectAction: Selector,
+        createAction: Selector,
+        retireAction: Selector
+    ) -> [NSMenuItem] {
+        var items: [NSMenuItem] = []
+
+        let header = NSMenuItem(title: "Assistants", action: nil, keyEquivalent: "")
+        header.isEnabled = false
+        items.append(header)
+
+        let assistants = viewModel.assistants
+        let activeId = viewModel.selectedAssistantId
+
+        if assistants.isEmpty {
+            let empty = NSMenuItem(title: "No managed assistants", action: nil, keyEquivalent: "")
+            empty.isEnabled = false
+            items.append(empty)
+        } else {
+            for assistant in assistants {
+                let item = NSMenuItem(
+                    title: assistant.assistantId,
+                    action: selectAction,
+                    keyEquivalent: ""
+                )
+                item.target = target
+                item.tag = assistantRowTag
+                item.representedObject = assistant.assistantId
+                item.state = (assistant.assistantId == activeId) ? .on : .off
+                items.append(item)
+            }
+        }
+
+        items.append(NSMenuItem.separator())
+
+        let newItem = NSMenuItem(
+            title: "New Assistant…",
+            action: createAction,
+            keyEquivalent: ""
+        )
+        newItem.target = target
+        newItem.tag = newAssistantTag
+        items.append(newItem)
+
+        // Retire submenu: one entry per assistant (including the active one).
+        // A `performRetire`-style path that only retires the *active* assistant
+        // already exists, but retiring a non-active managed assistant from the
+        // switcher is not yet implemented — gate those rows behind a TODO so
+        // the UI shows the affordance without wiring an incomplete operation.
+        // See `AssistantSwitcherViewModel.retire(assistantId:)`.
+        let retireParent = NSMenuItem(title: "Retire", action: nil, keyEquivalent: "")
+        retireParent.tag = retireParentTag
+        let retireSubmenu = NSMenu(title: "Retire")
+        retireSubmenu.autoenablesItems = false
+        if assistants.isEmpty {
+            let empty = NSMenuItem(title: "Nothing to retire", action: nil, keyEquivalent: "")
+            empty.isEnabled = false
+            retireSubmenu.addItem(empty)
+        } else {
+            for assistant in assistants {
+                let item = NSMenuItem(
+                    title: "Retire \(assistant.assistantId)…",
+                    action: retireAction,
+                    keyEquivalent: ""
+                )
+                item.target = target
+                item.representedObject = assistant.assistantId
+                retireSubmenu.addItem(item)
+            }
+        }
+        retireParent.submenu = retireSubmenu
+        retireParent.isEnabled = !assistants.isEmpty
+        items.append(retireParent)
+
+        return items
+    }
+
+    /// Display a modal prompt for a new assistant name. Returns `nil` when
+    /// the user cancels or submits an empty string.
+    static func promptForNewAssistantName() -> String? {
+        let alert = NSAlert()
+        alert.messageText = "New Assistant"
+        alert.informativeText = "Give this assistant a name. You can change it later."
+        alert.alertStyle = .informational
+        alert.addButton(withTitle: "Create")
+        alert.addButton(withTitle: "Cancel")
+
+        let field = NSTextField(frame: NSRect(x: 0, y: 0, width: 260, height: 24))
+        field.placeholderString = "Assistant name"
+        alert.accessoryView = field
+        alert.window.initialFirstResponder = field
+
+        let response = alert.runModal()
+        guard response == .alertFirstButtonReturn else { return nil }
+        let trimmed = field.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}

--- a/clients/macos/vellum-assistant/Features/AssistantSwitcher/AssistantSwitcherMenu.swift
+++ b/clients/macos/vellum-assistant/Features/AssistantSwitcher/AssistantSwitcherMenu.swift
@@ -46,15 +46,17 @@ enum AssistantSwitcherMenu {
             items.append(empty)
         } else {
             for assistant in assistants {
+                let isActive = assistant.assistantId == activeId
+                let title = displayTitle(for: assistant, isActive: isActive)
                 let item = NSMenuItem(
-                    title: assistant.assistantId,
+                    title: title,
                     action: selectAction,
                     keyEquivalent: ""
                 )
                 item.target = target
                 item.tag = assistantRowTag
                 item.representedObject = assistant.assistantId
-                item.state = (assistant.assistantId == activeId) ? .on : .off
+                item.state = isActive ? .on : .off
                 items.append(item)
             }
         }
@@ -70,37 +72,41 @@ enum AssistantSwitcherMenu {
         newItem.tag = newAssistantTag
         items.append(newItem)
 
-        // Retire submenu: one entry per assistant (including the active one).
-        // A `performRetire`-style path that only retires the *active* assistant
-        // already exists, but retiring a non-active managed assistant from the
-        // switcher is not yet implemented — gate those rows behind a TODO so
-        // the UI shows the affordance without wiring an incomplete operation.
-        // See `AssistantSwitcherViewModel.retire(assistantId:)`.
-        let retireParent = NSMenuItem(title: "Retire", action: nil, keyEquivalent: "")
-        retireParent.tag = retireParentTag
-        let retireSubmenu = NSMenu(title: "Retire")
-        retireSubmenu.autoenablesItems = false
-        if assistants.isEmpty {
-            let empty = NSMenuItem(title: "Nothing to retire", action: nil, keyEquivalent: "")
-            empty.isEnabled = false
-            retireSubmenu.addItem(empty)
-        } else {
-            for assistant in assistants {
-                let item = NSMenuItem(
-                    title: "Retire \(assistant.assistantId)…",
-                    action: retireAction,
-                    keyEquivalent: ""
-                )
-                item.target = target
-                item.representedObject = assistant.assistantId
-                retireSubmenu.addItem(item)
-            }
+        // Retire row: only surfaced for the *active* assistant, since the
+        // existing retire path (`AppDelegate.performRetireAsync`) only
+        // handles that case. Retiring a non-active managed assistant
+        // requires a dedicated code path and is tracked as a follow-up —
+        // don't show a row we can't back. See
+        // `AppDelegate.retireManagedAssistantFromSwitcher`.
+        if let activeId,
+           let activeAssistant = assistants.first(where: { $0.assistantId == activeId }) {
+            let activeTitle = AssistantDisplayName.resolve(activeAssistant.assistantId)
+            let retireItem = NSMenuItem(
+                title: "Retire \(activeTitle)…",
+                action: retireAction,
+                keyEquivalent: ""
+            )
+            retireItem.target = target
+            retireItem.representedObject = activeAssistant.assistantId
+            retireItem.tag = retireParentTag
+            items.append(retireItem)
         }
-        retireParent.submenu = retireSubmenu
-        retireParent.isEnabled = !assistants.isEmpty
-        items.append(retireParent)
 
         return items
+    }
+
+    /// Resolve a user-facing title for a menu row. The active assistant
+    /// prefers `IdentityInfo.current?.name` (the same source the status
+    /// tooltip uses) so users see "Luna" rather than a raw UUID. Non-active
+    /// assistants fall back to their id — LockfileAssistant doesn't carry a
+    /// display name yet, so there's nothing better we can show without a
+    /// per-assistant IDENTITY.md read. Both paths go through
+    /// `AssistantDisplayName.resolve` so the bootstrap sentinel is masked.
+    private static func displayTitle(for assistant: LockfileAssistant, isActive: Bool) -> String {
+        if isActive {
+            return AssistantDisplayName.resolve(IdentityInfo.current?.name, assistant.assistantId)
+        }
+        return AssistantDisplayName.resolve(assistant.assistantId)
     }
 
     /// Display a modal prompt for a new assistant name. Returns `nil` when

--- a/clients/macos/vellum-assistant/Features/AssistantSwitcher/AssistantSwitcherMenu.swift
+++ b/clients/macos/vellum-assistant/Features/AssistantSwitcher/AssistantSwitcherMenu.swift
@@ -15,15 +15,6 @@ private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "Assis
 /// pre-feature build.
 @MainActor
 enum AssistantSwitcherMenu {
-    /// Tag used on the "New Assistant…" item so tests / code inspection can
-    /// find it without string matching.
-    static let newAssistantTag = 9101
-    /// Tag used on the parent "Retire" submenu item.
-    static let retireParentTag = 9102
-    /// Tag used on individual assistant row items. `representedObject` holds
-    /// the assistant id string.
-    static let assistantRowTag = 9103
-
     static func buildItems(
         viewModel: AssistantSwitcherViewModel,
         target: AnyObject,
@@ -41,6 +32,10 @@ enum AssistantSwitcherMenu {
         let activeId = viewModel.selectedAssistantId
 
         if assistants.isEmpty {
+            // Intentional first-launch-under-flag state: the user enabled
+            // the switcher but has no managed assistants yet (e.g. they're
+            // running a local-only lockfile). The "New Assistant…" row
+            // below is the path forward.
             let empty = NSMenuItem(title: "No managed assistants", action: nil, keyEquivalent: "")
             empty.isEnabled = false
             items.append(empty)
@@ -54,7 +49,6 @@ enum AssistantSwitcherMenu {
                     keyEquivalent: ""
                 )
                 item.target = target
-                item.tag = assistantRowTag
                 item.representedObject = assistant.assistantId
                 item.state = isActive ? .on : .off
                 items.append(item)
@@ -69,7 +63,6 @@ enum AssistantSwitcherMenu {
             keyEquivalent: ""
         )
         newItem.target = target
-        newItem.tag = newAssistantTag
         items.append(newItem)
 
         // Retire row: only surfaced for the *active* assistant, since the
@@ -88,7 +81,6 @@ enum AssistantSwitcherMenu {
             )
             retireItem.target = target
             retireItem.representedObject = activeAssistant.assistantId
-            retireItem.tag = retireParentTag
             items.append(retireItem)
         }
 

--- a/clients/macos/vellum-assistant/Features/AssistantSwitcher/AssistantSwitcherViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/AssistantSwitcher/AssistantSwitcherViewModel.swift
@@ -1,0 +1,109 @@
+import Foundation
+import VellumAssistantShared
+import os
+
+private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "AssistantSwitcherViewModel")
+
+/// View model backing the menu-bar assistant switcher. Owns the list of
+/// managed assistants eligible for the current environment, the currently
+/// active assistant id, and the handlers used to switch / create / retire
+/// entries.
+///
+/// Handlers are injected as closures so tests can substitute fakes without
+/// constructing a real `ManagedAssistantConnectionCoordinator`, SSE stack,
+/// or AuthService. In production the wiring site (AppDelegate) adapts those
+/// closures onto the coordinator's `switchToManagedAssistant`, the hatch
+/// path, and the vellum CLI retire path.
+///
+/// This type is `@MainActor` because it manipulates menu-bar UI state and
+/// subscribes to `LockfileAssistant.activeAssistantDidChange` on the main
+/// queue.
+@MainActor
+@Observable
+final class AssistantSwitcherViewModel {
+    /// Managed assistants present in the lockfile for the current runtime
+    /// environment. Updated on init and whenever the active assistant
+    /// changes.
+    private(set) var assistants: [LockfileAssistant] = []
+
+    /// Mirror of `LockfileAssistant.loadActiveAssistantId()` — the id the
+    /// menu uses to render the checkmark.
+    private(set) var selectedAssistantId: String?
+
+    @ObservationIgnored private let switchHandler: @MainActor (String) async throws -> Void
+    @ObservationIgnored private let createHandler: @MainActor (String) async throws -> Void
+    @ObservationIgnored private let retireHandler: @MainActor (String) async throws -> Void
+    @ObservationIgnored private let lockfileLoader: @MainActor () -> [LockfileAssistant]
+    @ObservationIgnored private let activeIdLoader: @MainActor () -> String?
+    @ObservationIgnored private let notificationCenter: NotificationCenter
+    @ObservationIgnored private var activeChangeObserver: NSObjectProtocol?
+
+    init(
+        switchHandler: @escaping @MainActor (String) async throws -> Void,
+        createHandler: @escaping @MainActor (String) async throws -> Void,
+        retireHandler: @escaping @MainActor (String) async throws -> Void,
+        lockfileLoader: @escaping @MainActor () -> [LockfileAssistant] = { LockfileAssistant.loadAll() },
+        activeIdLoader: @escaping @MainActor () -> String? = { LockfileAssistant.loadActiveAssistantId() },
+        notificationCenter: NotificationCenter = .default
+    ) {
+        self.switchHandler = switchHandler
+        self.createHandler = createHandler
+        self.retireHandler = retireHandler
+        self.lockfileLoader = lockfileLoader
+        self.activeIdLoader = activeIdLoader
+        self.notificationCenter = notificationCenter
+
+        refresh()
+
+        activeChangeObserver = notificationCenter.addObserver(
+            forName: LockfileAssistant.activeAssistantDidChange,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.refresh()
+            }
+        }
+    }
+
+    deinit {
+        if let activeChangeObserver {
+            notificationCenter.removeObserver(activeChangeObserver)
+        }
+    }
+
+    /// Re-read the lockfile. Exposed so the menu can force a refresh right
+    /// before it is rebuilt (the `activeAssistantDidChange` notification is
+    /// async, so a synchronous rebuild after a `select` would otherwise race
+    /// the notification delivery).
+    func refresh() {
+        assistants = lockfileLoader().filter { $0.isManaged && $0.isCurrentEnvironment }
+        selectedAssistantId = activeIdLoader()
+    }
+
+    /// Switch the active assistant. Calls the injected handler (which in
+    /// production wraps `ManagedAssistantConnectionCoordinator.switchToManagedAssistant`)
+    /// then refreshes local state synchronously so the UI updates within one
+    /// event loop tick rather than waiting for `activeAssistantDidChange`.
+    func select(assistantId: String) async throws {
+        try await switchHandler(assistantId)
+        refresh()
+    }
+
+    /// Hatch a new managed assistant and persist it to the lockfile. The
+    /// caller is responsible for presenting the name prompt UI before
+    /// invoking this method.
+    func createNewAssistant(name: String) async throws {
+        try await createHandler(name)
+        refresh()
+    }
+
+    /// Retire an assistant via the injected handler. When the retired
+    /// assistant is the active one the handler is responsible for falling
+    /// back to another assistant (or the no-assistant state) — the view
+    /// model only refreshes its local view of the lockfile afterwards.
+    func retire(assistantId: String) async throws {
+        try await retireHandler(assistantId)
+        refresh()
+    }
+}

--- a/clients/macos/vellum-assistant/Features/AssistantSwitcher/AssistantSwitcherViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/AssistantSwitcher/AssistantSwitcherViewModel.swift
@@ -60,6 +60,10 @@ final class AssistantSwitcherViewModel {
             object: nil,
             queue: .main
         ) { [weak self] _ in
+            // `queue: .main` hops the closure onto the main queue, which
+            // matches the @MainActor isolation of `refresh()`. Future
+            // Swift-concurrency tightening may flag `assumeIsolated`, at
+            // which point we can switch to a `Task { @MainActor in … }`.
             MainActor.assumeIsolated {
                 self?.refresh()
             }
@@ -67,6 +71,9 @@ final class AssistantSwitcherViewModel {
     }
 
     deinit {
+        // `NotificationCenter.removeObserver` is documented thread-safe,
+        // which is what lets us call it from the non-isolated `deinit`
+        // with the captured `notificationCenter` reference.
         if let activeChangeObserver {
             notificationCenter.removeObserver(activeChangeObserver)
         }
@@ -94,6 +101,10 @@ final class AssistantSwitcherViewModel {
             return
         }
         try await switchHandler(assistantId)
+        // Refresh synchronously so the UI updates within this event loop
+        // tick. `activeAssistantDidChange` will fire from
+        // `setActiveAssistantId` and trigger a second refresh — redundant
+        // but harmless, since `refresh()` is idempotent.
         refresh()
     }
 

--- a/clients/macos/vellum-assistant/Features/AssistantSwitcher/AssistantSwitcherViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/AssistantSwitcher/AssistantSwitcherViewModel.swift
@@ -86,6 +86,13 @@ final class AssistantSwitcherViewModel {
     /// then refreshes local state synchronously so the UI updates within one
     /// event loop tick rather than waiting for `activeAssistantDidChange`.
     func select(assistantId: String) async throws {
+        // No-op when the target is already the active assistant. Without
+        // this guard, clicking the already-checked row would drive the
+        // coordinator's teardown/bring-up path and disconnect SSE for no
+        // reason, interrupting any in-flight work.
+        if assistantId == selectedAssistantId {
+            return
+        }
         try await switchHandler(assistantId)
         refresh()
     }

--- a/clients/macos/vellum-assistantTests/AssistantSwitcherViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/AssistantSwitcherViewModelTests.swift
@@ -1,0 +1,216 @@
+import VellumAssistantShared
+import XCTest
+@testable import VellumAssistantLib
+
+@MainActor
+final class AssistantSwitcherViewModelTests: XCTestCase {
+    private var tempDir: URL!
+    private var lockfilePath: String!
+
+    override func setUp() {
+        super.setUp()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try! FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        lockfilePath = tempDir.appendingPathComponent(".vellum.lock.json").path
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: tempDir)
+        tempDir = nil
+        lockfilePath = nil
+        super.tearDown()
+    }
+
+    // MARK: - Filtering
+
+    func testListsOnlyManagedCurrentEnvironmentAssistants() {
+        // Seed three managed entries + verify we read them back. Non-managed /
+        // wrong-environment filtering relies on `LockfileAssistant` computed
+        // properties, which are covered by LockfileAssistantManagedTests —
+        // here we exercise the filter predicate on a mocked loader so the
+        // test stays pure.
+        let managedCurrent = makeAssistant(id: "managed-a", runtimeUrl: "https://platform.example.com")
+        let managedOther = makeAssistant(id: "managed-b", runtimeUrl: "https://platform.example.com")
+        let unmanaged = makeAssistant(id: "local-a", runtimeUrl: "", isLocal: true)
+
+        let spy = SwitcherSpy()
+        let vm = AssistantSwitcherViewModel(
+            switchHandler: spy.switchHandler,
+            createHandler: spy.createHandler,
+            retireHandler: spy.retireHandler,
+            lockfileLoader: { [managedCurrent, managedOther, unmanaged] },
+            activeIdLoader: { "managed-a" }
+        )
+
+        XCTAssertEqual(vm.assistants.map(\.assistantId), ["managed-a", "managed-b"])
+        XCTAssertEqual(vm.selectedAssistantId, "managed-a")
+    }
+
+    // MARK: - Select
+
+    func testSelectInvokesSwitchHandlerWithCorrectId() async throws {
+        let managedA = makeAssistant(id: "managed-a", runtimeUrl: "https://platform.example.com")
+        let managedB = makeAssistant(id: "managed-b", runtimeUrl: "https://platform.example.com")
+
+        let spy = SwitcherSpy()
+        var activeId = "managed-a"
+        let vm = AssistantSwitcherViewModel(
+            switchHandler: spy.switchHandler,
+            createHandler: spy.createHandler,
+            retireHandler: spy.retireHandler,
+            lockfileLoader: { [managedA, managedB] },
+            activeIdLoader: { activeId }
+        )
+
+        // Pretend the switchHandler flipped the active id (as the real
+        // coordinator would via LockfileAssistant.setActiveAssistantId).
+        spy.onSwitch = { _ in activeId = "managed-b" }
+
+        try await vm.select(assistantId: "managed-b")
+
+        XCTAssertEqual(spy.switchCalls, ["managed-b"])
+        XCTAssertEqual(vm.selectedAssistantId, "managed-b",
+                       "refresh() should run after select and pick up the new active id")
+    }
+
+    // MARK: - Active change notification
+
+    func testActiveAssistantDidChangeTriggersRefresh() {
+        let managedA = makeAssistant(id: "managed-a", runtimeUrl: "https://platform.example.com")
+        let managedB = makeAssistant(id: "managed-b", runtimeUrl: "https://platform.example.com")
+
+        let spy = SwitcherSpy()
+        var activeId: String? = "managed-a"
+        // Use a scoped NotificationCenter to avoid cross-test pollution.
+        let center = NotificationCenter()
+        let vm = AssistantSwitcherViewModel(
+            switchHandler: spy.switchHandler,
+            createHandler: spy.createHandler,
+            retireHandler: spy.retireHandler,
+            lockfileLoader: { [managedA, managedB] },
+            activeIdLoader: { activeId },
+            notificationCenter: center
+        )
+
+        XCTAssertEqual(vm.selectedAssistantId, "managed-a")
+
+        activeId = "managed-b"
+        let expectation = self.expectation(description: "refresh after active change")
+        center.post(name: LockfileAssistant.activeAssistantDidChange, object: nil)
+        // The observer posts to the main queue. Hop through it so we can
+        // observe the refresh.
+        DispatchQueue.main.async {
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
+
+        XCTAssertEqual(vm.selectedAssistantId, "managed-b")
+    }
+
+    // MARK: - Retire
+
+    func testRetireRemovesAssistantFromListAfterHandlerCompletes() async throws {
+        let managedA = makeAssistant(id: "managed-a", runtimeUrl: "https://platform.example.com")
+        let managedB = makeAssistant(id: "managed-b", runtimeUrl: "https://platform.example.com")
+
+        var current: [LockfileAssistant] = [managedA, managedB]
+        let spy = SwitcherSpy()
+        let vm = AssistantSwitcherViewModel(
+            switchHandler: spy.switchHandler,
+            createHandler: spy.createHandler,
+            retireHandler: spy.retireHandler,
+            lockfileLoader: { current },
+            activeIdLoader: { "managed-a" }
+        )
+
+        // Pretend the retire handler removed managed-b from the lockfile.
+        spy.onRetire = { id in
+            current.removeAll { $0.assistantId == id }
+        }
+
+        try await vm.retire(assistantId: "managed-b")
+
+        XCTAssertEqual(spy.retireCalls, ["managed-b"])
+        XCTAssertEqual(vm.assistants.map(\.assistantId), ["managed-a"])
+    }
+
+    // MARK: - Create
+
+    func testCreateNewAssistantInvokesCreateHandler() async throws {
+        let spy = SwitcherSpy()
+        let vm = AssistantSwitcherViewModel(
+            switchHandler: spy.switchHandler,
+            createHandler: spy.createHandler,
+            retireHandler: spy.retireHandler,
+            lockfileLoader: { [] },
+            activeIdLoader: { nil }
+        )
+
+        try await vm.createNewAssistant(name: "Zephyr")
+
+        XCTAssertEqual(spy.createCalls, ["Zephyr"])
+    }
+
+    // MARK: - Helpers
+
+    /// Construct a minimal `LockfileAssistant` for testing. We round-trip
+    /// through `ensureManagedEntry` on a temp file so the resulting value
+    /// has `isManaged == true` and `isCurrentEnvironment == true` against
+    /// the injected runtime URL.
+    private func makeAssistant(
+        id: String,
+        runtimeUrl: String,
+        isLocal: Bool = false
+    ) -> LockfileAssistant {
+        let dir = tempDir.appendingPathComponent(UUID().uuidString, isDirectory: true).path
+        try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        let path = (dir as NSString).appendingPathComponent(".vellum.lock.json")
+        if isLocal {
+            // Write a local (non-managed) entry directly.
+            let json: [String: Any] = [
+                "activeAssistant": id,
+                "assistants": [
+                    id: [
+                        "createdAt": "2024-01-01T00:00:00Z",
+                        "instanceDir": dir,
+                    ]
+                ]
+            ]
+            let data = try! JSONSerialization.data(withJSONObject: json)
+            try! data.write(to: URL(fileURLWithPath: path))
+        } else {
+            LockfileAssistant.ensureManagedEntry(
+                assistantId: id,
+                runtimeUrl: runtimeUrl,
+                hatchedAt: "2024-01-01T00:00:00Z",
+                lockfilePath: path
+            )
+        }
+        return LockfileAssistant.loadByName(id, lockfilePath: path)!
+    }
+}
+
+@MainActor
+private final class SwitcherSpy {
+    var switchCalls: [String] = []
+    var createCalls: [String] = []
+    var retireCalls: [String] = []
+
+    var onSwitch: ((String) -> Void)?
+    var onCreate: ((String) -> Void)?
+    var onRetire: ((String) -> Void)?
+
+    lazy var switchHandler: @MainActor (String) async throws -> Void = { [weak self] id in
+        self?.switchCalls.append(id)
+        self?.onSwitch?(id)
+    }
+    lazy var createHandler: @MainActor (String) async throws -> Void = { [weak self] name in
+        self?.createCalls.append(name)
+        self?.onCreate?(name)
+    }
+    lazy var retireHandler: @MainActor (String) async throws -> Void = { [weak self] id in
+        self?.retireCalls.append(id)
+        self?.onRetire?(id)
+    }
+}

--- a/clients/macos/vellum-assistantTests/AssistantSwitcherViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/AssistantSwitcherViewModelTests.swift
@@ -74,6 +74,23 @@ final class AssistantSwitcherViewModelTests: XCTestCase {
                        "refresh() should run after select and pick up the new active id")
     }
 
+    func testSelectIsNoOpWhenAlreadyActive() async throws {
+        let managedA = makeAssistant(id: "managed-a", runtimeUrl: "https://platform.example.com")
+        let spy = SwitcherSpy()
+        let vm = AssistantSwitcherViewModel(
+            switchHandler: spy.switchHandler,
+            createHandler: spy.createHandler,
+            retireHandler: spy.retireHandler,
+            lockfileLoader: { [managedA] },
+            activeIdLoader: { "managed-a" }
+        )
+
+        try await vm.select(assistantId: "managed-a")
+
+        XCTAssertTrue(spy.switchCalls.isEmpty,
+                      "Selecting the already-active assistant must not drive the switch handler")
+    }
+
     // MARK: - Active change notification
 
     func testActiveAssistantDidChangeTriggersRefresh() {

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -186,6 +186,14 @@
       "defaultEnabled": false
     },
     {
+      "id": "multi-platform-assistant",
+      "scope": "macos",
+      "key": "multi-platform-assistant",
+      "label": "Multi-Platform Assistant Switcher",
+      "description": "Enable the menu-bar assistant switcher for managing multiple platform-hosted assistants (new/switch/retire)",
+      "defaultEnabled": false
+    },
+    {
       "id": "quick-input",
       "scope": "macos",
       "key": "quick-input",


### PR DESCRIPTION
## Summary
- Adds an `AssistantSwitcherViewModel` (`@Observable`, `@MainActor`) that lists managed assistants for the current environment, tracks the active id, and exposes `select`/`createNewAssistant`/`retire` via injected closures so tests can mock the coordinator.
- Adds `AssistantSwitcherMenu` — a pure builder that produces the status-item submenu rows (checkmarked active assistant, "New Assistant…", "Retire" submenu) plus a name-prompt NSAlert.
- Wires the switcher into `AppDelegate+MenuBar.swift`: the `multi-platform-assistant` flag is read once in `setupMenuBar()`, and when enabled the switcher section is injected into `showStatusMenu()` above Quit. Production handlers wrap `ManagedAssistantConnectionCoordinator.switchToManagedAssistant` (via a new `AppDelegateManagedConnectionController` adapter), `AuthService.hatchAssistant` + `LockfileAssistant.ensureManagedEntry`, and the existing `performRetireAsync` path for the active assistant. Retiring a non-active assistant is gated behind a TODO and surfaces a clear error to the user — tracked as a follow-up.
- View-model unit tests cover filtering, `select` invoking the coordinator handler, refresh on `activeAssistantDidChange`, retire removing from the list, and create invoking the handler.

When the flag is off, `setupMenuBar` and `showStatusMenu` take the pre-existing code path with no additional items, so the menu bar remains byte-for-byte identical.

## Original prompt
PR 4 of multi-host-asst plan — assistant switcher UI (menu bar only; sidebar intentionally untouched per spec).

## Test plan
- [ ] Flag on: new status-item submenu lists managed assistants with active one checkmarked
- [ ] Selecting an assistant calls `switchToManagedAssistant` and UI updates within one event loop tick
- [ ] "New Assistant…" prompts for name, hatches, and the lockfile gains a new entry
- [ ] "Retire <active>…" falls back cleanly to another assistant or no-assistant state
- [ ] Flag off: menu bar unchanged
- [ ] View-model unit tests pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24196" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
