### PR TITLE
feat(deeplink): route vellum://send to the requested assistant

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+BundleHandling.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+BundleHandling.swift
@@ -31,20 +31,61 @@ extension AppDelegate {
         }
     }
 
-    /// Handle `vellum://send?message=...` deep links by buffering the message
-    /// in `DeepLinkManager` for the active `ChatViewModel` to consume,
-    /// then bringing the main window to front.
+    /// Handle `vellum://send?message=...[&assistant=<id>]` deep links by
+    /// buffering the message in `DeepLinkManager` for the active
+    /// `ChatViewModel` to consume, optionally switching to the requested
+    /// assistant first, then bringing the main window to front.
+    ///
+    /// Routing behavior is decided by `DeepLinkRouter.decide(...)`; this
+    /// method is the side-effect layer that applies the chosen decision.
     private func handleDeepLink(_ url: URL) {
-        guard url.host == "send" else { return }
-        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
-              let messageItem = components.queryItems?.first(where: { $0.name == "message" }),
-              let message = messageItem.value, !message.isEmpty else { return }
+        let knownAssistantIds = Set(LockfileAssistant.loadAll().map(\.assistantId))
+        let multiAssistantEnabled = AssistantFeatureFlagResolver.isEnabled("multi-platform-assistant")
 
-        log.info("Received deep link send message (\(message.count) chars)")
-        DeepLinkManager.pendingMessage = message
+        let decision = DeepLinkRouter.decide(
+            url: url,
+            knownAssistantIds: knownAssistantIds,
+            multiAssistantEnabled: multiAssistantEnabled
+        )
 
-        // Bring the main window to front and consume the pending message
-        // in the active conversation's view model.
+        switch decision {
+        case .ignore:
+            return
+
+        case .routeToActive(let message):
+            log.info("Received deep link send message (\(message.count) chars)")
+            deliverDeepLinkToActiveAssistant(message: message)
+
+        case .routeToActiveAfterUnknownAssistant(let requestedAssistantId, let message):
+            log.warning("Deep link requested unknown assistant \(requestedAssistantId, privacy: .public); falling back to active assistant")
+            deliverDeepLinkToActiveAssistant(message: message)
+
+        case .switchLive(let assistantId, let message):
+            log.info("Deep link switching live to assistant \(assistantId, privacy: .public) (\(message.count) chars)")
+            DeepLinkManager.pendingMessage = message
+            guard let assistant = LockfileAssistant.loadByName(assistantId) else {
+                // Race: the assistant disappeared from the lockfile between
+                // the decision and now. Fall back to delivering to the active
+                // assistant rather than dropping the message.
+                log.warning("Assistant \(assistantId, privacy: .public) disappeared from lockfile before switch; delivering to active")
+                deliverDeepLinkToActiveAssistant(message: message, alreadyBuffered: true)
+                return
+            }
+            performSwitchAssistant(to: assistant)
+
+        case .switchActiveIdOnly(let assistantId, let message):
+            log.info("Deep link setting active assistant id to \(assistantId, privacy: .public) (flag off; live SSE switch waits for next launch)")
+            LockfileAssistant.setActiveAssistantId(assistantId)
+            deliverDeepLinkToActiveAssistant(message: message)
+        }
+    }
+
+    /// Buffer the message in `DeepLinkManager`, show the main window, and
+    /// ask the active conversation view model to consume it.
+    private func deliverDeepLinkToActiveAssistant(message: String, alreadyBuffered: Bool = false) {
+        if !alreadyBuffered {
+            DeepLinkManager.pendingMessage = message
+        }
         showMainWindow()
         mainWindow?.conversationManager.activeViewModel?.consumeDeepLinkIfNeeded()
     }

--- a/clients/macos/vellum-assistant/App/AppDelegate+BundleHandling.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+BundleHandling.swift
@@ -39,7 +39,16 @@ extension AppDelegate {
     /// Routing behavior is decided by `DeepLinkRouter.decide(...)`; this
     /// method is the side-effect layer that applies the chosen decision.
     private func handleDeepLink(_ url: URL) {
-        let knownAssistantIds = Set(LockfileAssistant.loadAll().map(\.assistantId))
+        // Only consider assistants that belong to the current runtime
+        // environment. A deep link targeting a managed assistant from a
+        // different environment would otherwise match here and then fail
+        // further down; falling back to the active assistant via the
+        // unknown-id path is cleaner.
+        let knownAssistantIds = Set(
+            LockfileAssistant.loadAll()
+                .filter(\.isCurrentEnvironment)
+                .map(\.assistantId)
+        )
         let multiAssistantEnabled = AssistantFeatureFlagResolver.isEnabled("multi-platform-assistant")
 
         let decision = DeepLinkRouter.decide(

--- a/clients/macos/vellum-assistant/App/AppDelegate+BundleHandling.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+BundleHandling.swift
@@ -62,30 +62,44 @@ extension AppDelegate {
 
         case .switchLive(let assistantId, let message):
             log.info("Deep link switching live to assistant \(assistantId, privacy: .public) (\(message.count) chars)")
-            DeepLinkManager.pendingMessage = message
             guard let assistant = LockfileAssistant.loadByName(assistantId) else {
                 // Race: the assistant disappeared from the lockfile between
                 // the decision and now. Fall back to delivering to the active
                 // assistant rather than dropping the message.
                 log.warning("Assistant \(assistantId, privacy: .public) disappeared from lockfile before switch; delivering to active")
-                deliverDeepLinkToActiveAssistant(message: message, alreadyBuffered: true)
+                deliverDeepLinkToActiveAssistant(message: message)
                 return
             }
+            // `performSwitchAssistant` early-returns for managed assistants
+            // when the user is logged out (it shows the auth window). That
+            // path doesn't close the old main window or consume pending
+            // messages, which would orphan the deep-link message until a
+            // future conversation change. Skip the switch entirely in that
+            // case and deliver the message to the currently active
+            // assistant instead.
+            if assistant.isManaged && !authManager.isAuthenticated {
+                log.warning("Deep link switch to managed assistant \(assistantId, privacy: .public) skipped — not authenticated; delivering to active assistant")
+                deliverDeepLinkToActiveAssistant(message: message)
+                return
+            }
+            DeepLinkManager.pendingMessage = message
             performSwitchAssistant(to: assistant)
 
-        case .switchActiveIdOnly(let assistantId, let message):
-            log.info("Deep link setting active assistant id to \(assistantId, privacy: .public) (flag off; live SSE switch waits for next launch)")
-            LockfileAssistant.setActiveAssistantId(assistantId)
+        case .routeToActiveFlagOff(let requestedAssistantId, let message):
+            // Flag is off — we intentionally do not mutate `activeAssistant`
+            // here. Writing a new active id without a corresponding SSE
+            // reconnect would desync HTTP routing from SSE (see
+            // `DeepLinkRoutingDecision.routeToActiveFlagOff`). Deliver to
+            // whatever is currently active instead.
+            log.warning("Deep link requested assistant \(requestedAssistantId, privacy: .public) but multi-platform-assistant flag is off; delivering to active assistant")
             deliverDeepLinkToActiveAssistant(message: message)
         }
     }
 
     /// Buffer the message in `DeepLinkManager`, show the main window, and
     /// ask the active conversation view model to consume it.
-    private func deliverDeepLinkToActiveAssistant(message: String, alreadyBuffered: Bool = false) {
-        if !alreadyBuffered {
-            DeepLinkManager.pendingMessage = message
-        }
+    private func deliverDeepLinkToActiveAssistant(message: String) {
+        DeepLinkManager.pendingMessage = message
         showMainWindow()
         mainWindow?.conversationManager.activeViewModel?.consumeDeepLinkIfNeeded()
     }

--- a/clients/macos/vellum-assistant/App/DeepLinkRouter.swift
+++ b/clients/macos/vellum-assistant/App/DeepLinkRouter.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+/// Pure routing decision produced from a `vellum://send` deep link URL.
+/// Kept separate from `AppDelegate+BundleHandling` so the parsing and
+/// dispatch logic can be unit-tested without pulling in AppKit, the
+/// gateway connection, or main-window plumbing.
+enum DeepLinkRoutingDecision: Equatable {
+    /// URL is malformed, has the wrong host, or carries an empty `message`.
+    case ignore
+    /// No `assistant` query param — route the message to whatever the
+    /// active assistant currently is (existing behavior).
+    case routeToActive(message: String)
+    /// An `assistant` param was present but did not match any entry in the
+    /// lockfile. The caller should log a warning and still deliver the
+    /// message to the active assistant (graceful degradation).
+    case routeToActiveAfterUnknownAssistant(requestedAssistantId: String, message: String)
+    /// `assistant` param matched a lockfile entry and the
+    /// `multi-platform-assistant` flag is enabled — perform a live SSE
+    /// switch to the requested assistant, then deliver the message.
+    case switchLive(assistantId: String, message: String)
+    /// `assistant` param matched a lockfile entry but the
+    /// `multi-platform-assistant` flag is disabled — update the active
+    /// assistant id only (live SSE switch waits for next launch) and
+    /// deliver the message.
+    case switchActiveIdOnly(assistantId: String, message: String)
+}
+
+enum DeepLinkRouter {
+    /// Parse a `vellum://send` URL and decide how to route it.
+    ///
+    /// - Parameters:
+    ///   - url: The incoming URL (typically from `application(_:open:)`).
+    ///   - knownAssistantIds: Ids currently present in the lockfile.
+    ///   - multiAssistantEnabled: Whether `multi-platform-assistant` is on.
+    static func decide(
+        url: URL,
+        knownAssistantIds: Set<String>,
+        multiAssistantEnabled: Bool
+    ) -> DeepLinkRoutingDecision {
+        guard url.host == "send" else { return .ignore }
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              let messageItem = components.queryItems?.first(where: { $0.name == "message" }),
+              let message = messageItem.value, !message.isEmpty else {
+            return .ignore
+        }
+
+        let requestedAssistantId = components.queryItems?
+            .first(where: { $0.name == "assistant" })?
+            .value
+
+        guard let requestedAssistantId, !requestedAssistantId.isEmpty else {
+            return .routeToActive(message: message)
+        }
+
+        guard knownAssistantIds.contains(requestedAssistantId) else {
+            return .routeToActiveAfterUnknownAssistant(
+                requestedAssistantId: requestedAssistantId,
+                message: message
+            )
+        }
+
+        if multiAssistantEnabled {
+            return .switchLive(assistantId: requestedAssistantId, message: message)
+        } else {
+            return .switchActiveIdOnly(assistantId: requestedAssistantId, message: message)
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/App/DeepLinkRouter.swift
+++ b/clients/macos/vellum-assistant/App/DeepLinkRouter.swift
@@ -19,10 +19,15 @@ enum DeepLinkRoutingDecision: Equatable {
     /// switch to the requested assistant, then deliver the message.
     case switchLive(assistantId: String, message: String)
     /// `assistant` param matched a lockfile entry but the
-    /// `multi-platform-assistant` flag is disabled — update the active
-    /// assistant id only (live SSE switch waits for next launch) and
-    /// deliver the message.
-    case switchActiveIdOnly(assistantId: String, message: String)
+    /// `multi-platform-assistant` flag is disabled. In this case we do
+    /// **not** mutate `activeAssistant` — doing so would desync the
+    /// per-request HTTP routing (which re-reads the lockfile) from the
+    /// live SSE connection (which stays pinned to the old assistant until
+    /// a full reconnect), causing sends to go to one assistant while
+    /// replies come back on another. Instead we log the requested id and
+    /// deliver the message to whatever is currently active. A true
+    /// cross-assistant switch waits until multi-platform-assistant ships.
+    case routeToActiveFlagOff(requestedAssistantId: String, message: String)
 }
 
 enum DeepLinkRouter {
@@ -62,7 +67,7 @@ enum DeepLinkRouter {
         if multiAssistantEnabled {
             return .switchLive(assistantId: requestedAssistantId, message: message)
         } else {
-            return .switchActiveIdOnly(assistantId: requestedAssistantId, message: message)
+            return .routeToActiveFlagOff(requestedAssistantId: requestedAssistantId, message: message)
         }
     }
 }

--- a/clients/macos/vellum-assistantTests/DeepLinkRoutingTests.swift
+++ b/clients/macos/vellum-assistantTests/DeepLinkRoutingTests.swift
@@ -43,13 +43,13 @@ final class DeepLinkRoutingTests: XCTestCase {
         XCTAssertEqual(decision, .switchLive(assistantId: "asst_known", message: "hi"))
     }
 
-    func testKnownAssistantWithFlagOffRequestsActiveIdOnlySwitch() {
+    func testKnownAssistantWithFlagOffDoesNotMutateStateAndRoutesToActive() {
         let decision = DeepLinkRouter.decide(
             url: url("vellum://send?message=hi&assistant=asst_known"),
             knownAssistantIds: known,
             multiAssistantEnabled: false
         )
-        XCTAssertEqual(decision, .switchActiveIdOnly(assistantId: "asst_known", message: "hi"))
+        XCTAssertEqual(decision, .routeToActiveFlagOff(requestedAssistantId: "asst_known", message: "hi"))
     }
 
     // MARK: - Unknown assistant id

--- a/clients/macos/vellum-assistantTests/DeepLinkRoutingTests.swift
+++ b/clients/macos/vellum-assistantTests/DeepLinkRoutingTests.swift
@@ -1,0 +1,128 @@
+import XCTest
+@testable import VellumAssistantLib
+
+final class DeepLinkRoutingTests: XCTestCase {
+
+    private let known: Set<String> = ["asst_known", "asst_other"]
+
+    private func url(_ string: String) -> URL {
+        guard let url = URL(string: string) else {
+            fatalError("Invalid URL in test: \(string)")
+        }
+        return url
+    }
+
+    // MARK: - No assistant param (regression guard)
+
+    func testNoAssistantParamRoutesToActive() {
+        let decision = DeepLinkRouter.decide(
+            url: url("vellum://send?message=hello"),
+            knownAssistantIds: known,
+            multiAssistantEnabled: true
+        )
+        XCTAssertEqual(decision, .routeToActive(message: "hello"))
+    }
+
+    func testNoAssistantParamRoutesToActiveWhenFlagOff() {
+        let decision = DeepLinkRouter.decide(
+            url: url("vellum://send?message=hello"),
+            knownAssistantIds: known,
+            multiAssistantEnabled: false
+        )
+        XCTAssertEqual(decision, .routeToActive(message: "hello"))
+    }
+
+    // MARK: - Known assistant id
+
+    func testKnownAssistantWithFlagOnRequestsLiveSwitch() {
+        let decision = DeepLinkRouter.decide(
+            url: url("vellum://send?message=hi&assistant=asst_known"),
+            knownAssistantIds: known,
+            multiAssistantEnabled: true
+        )
+        XCTAssertEqual(decision, .switchLive(assistantId: "asst_known", message: "hi"))
+    }
+
+    func testKnownAssistantWithFlagOffRequestsActiveIdOnlySwitch() {
+        let decision = DeepLinkRouter.decide(
+            url: url("vellum://send?message=hi&assistant=asst_known"),
+            knownAssistantIds: known,
+            multiAssistantEnabled: false
+        )
+        XCTAssertEqual(decision, .switchActiveIdOnly(assistantId: "asst_known", message: "hi"))
+    }
+
+    // MARK: - Unknown assistant id
+
+    func testUnknownAssistantFallsBackToActiveWithMessagePreserved() {
+        let decision = DeepLinkRouter.decide(
+            url: url("vellum://send?message=hi&assistant=asst_nope"),
+            knownAssistantIds: known,
+            multiAssistantEnabled: true
+        )
+        XCTAssertEqual(
+            decision,
+            .routeToActiveAfterUnknownAssistant(
+                requestedAssistantId: "asst_nope",
+                message: "hi"
+            )
+        )
+    }
+
+    func testUnknownAssistantFallsBackEvenWhenFlagOff() {
+        let decision = DeepLinkRouter.decide(
+            url: url("vellum://send?message=hi&assistant=asst_nope"),
+            knownAssistantIds: known,
+            multiAssistantEnabled: false
+        )
+        XCTAssertEqual(
+            decision,
+            .routeToActiveAfterUnknownAssistant(
+                requestedAssistantId: "asst_nope",
+                message: "hi"
+            )
+        )
+    }
+
+    // MARK: - Empty / missing message guard
+
+    func testEmptyMessageIsIgnored() {
+        let decision = DeepLinkRouter.decide(
+            url: url("vellum://send?message=&assistant=asst_known"),
+            knownAssistantIds: known,
+            multiAssistantEnabled: true
+        )
+        XCTAssertEqual(decision, .ignore)
+    }
+
+    func testMissingMessageIsIgnored() {
+        let decision = DeepLinkRouter.decide(
+            url: url("vellum://send?assistant=asst_known"),
+            knownAssistantIds: known,
+            multiAssistantEnabled: true
+        )
+        XCTAssertEqual(decision, .ignore)
+    }
+
+    // MARK: - Host guard
+
+    func testWrongHostIsIgnored() {
+        let decision = DeepLinkRouter.decide(
+            url: url("vellum://other?message=hi"),
+            knownAssistantIds: known,
+            multiAssistantEnabled: true
+        )
+        XCTAssertEqual(decision, .ignore)
+    }
+
+    // MARK: - Empty assistant param
+
+    func testEmptyAssistantParamIsTreatedAsNoParam() {
+        let decision = DeepLinkRouter.decide(
+            url: url("vellum://send?message=hi&assistant="),
+            knownAssistantIds: known,
+            multiAssistantEnabled: true
+        )
+        XCTAssertEqual(decision, .routeToActive(message: "hi"))
+    }
+}


### PR DESCRIPTION
## Summary
- Extend `vellum://send` deep-link handling to accept an optional `&assistant=<id>` query param so external tools can target a specific assistant.
- **Flag on** (`multi-platform-assistant`) + known id: perform a live switch via `AppDelegate.performSwitchAssistant(to:)` — the same entry point used by the menu bar, Settings → Developer, AssistantTransferSection, and TeleportSection — then deliver the message. A guard short-circuits the managed + logged-out case where `performSwitchAssistant` would early-return to the auth window, so the pending message is never orphaned; we deliver to the active assistant instead.
- **Flag off** + known id: we do **not** mutate `activeAssistant`. Writing a new active id without a corresponding SSE reconnect would desync HTTP routing (which re-reads the lockfile per request in `GatewayHTTPClient.resolveConnection()`) from the live SSE connection (pinned to the old assistant), so sends and replies would land on different assistants. Instead we log the requested id and deliver the message to whatever is currently active. Cross-assistant deep-link switching waits until `multi-platform-assistant` ships.
- **Unknown id**: logs a warning and falls back to the active assistant (message is never dropped).
- **Environment filter**: `knownAssistantIds` only includes entries where `isCurrentEnvironment` is true, so a deep link targeting a managed assistant from a different runtime environment hits the unknown-id fallback instead of matching and then failing further down.
- **No assistant param**: byte-for-byte unchanged from main.
- Routing decision extracted into a pure `DeepLinkRouter.decide(...)` so every branch is covered by unit tests without pulling in AppKit/SSE plumbing.

Depends on #24180 (`switchToManagedAssistant` API). Not flag-gated — the new param is additive and every path degrades gracefully.

### Follow-ups
- No first-party generators of `vellum://send` URLs exist in this repo (only `.md` docs reference the scheme); downstream daemon/platform generators should be updated in a follow-up to include the assistant id when known.
- Integration-layer tests for `handleDeepLink` dispatch (managed+unauth guard, `loadByName` race, `performSwitchAssistant` call) are not included here — the decision function carries the complexity and is well-tested, but a follow-up issue tracks adding coverage for the unauth-managed guard specifically.

## Test plan
- [x] Pure routing covered by `DeepLinkRoutingTests` (10 cases).
- [ ] Manual: `vellum://send?message=hi` unchanged (regression).
- [ ] Manual: `vellum://send?message=hi&assistant=asst_xyz` with flag on switches live and delivers.
- [ ] Manual: Same URL with flag off delivers to the current active assistant without mutating `activeAssistant`.
- [ ] Manual: `vellum://send?message=hi&assistant=asst_unknown` logs a warning and delivers to the active assistant.
- [ ] Manual: Flag on + managed target + logged out → message is delivered to the active assistant (guard), not orphaned.
- [ ] Manual: `vellum://send?message=&assistant=asst_xyz` is ignored.

## Original prompt
PR 5: Deep link `?assistant=<id>` routing (un-flagged, fast-follow). Extend `AppDelegate+BundleHandling.handleDeepLink` to parse an optional `assistant` query item; switch live via coordinator when flag is on, otherwise log and route to the current active assistant; unknown ids log a warning and fall back. Tests in `DeepLinkRoutingTests.swift`.