### PR TITLE
feat(oauth): refresh_url parity with platform

### DIFF
--- a/assistant/src/__tests__/credential-vault.test.ts
+++ b/assistant/src/__tests__/credential-vault.test.ts
@@ -50,7 +50,15 @@ mock.module("../tools/registry.js", () => ({
 // ---------------------------------------------------------------------------
 
 let mockRefreshOAuth2Token: ReturnType<
-  typeof mock<() => Promise<{ accessToken: string; expiresIn: number }>>
+  typeof mock<
+    (
+      tokenExchangeUrl: string,
+      clientId: string,
+      refreshToken: string,
+      clientSecret?: string,
+      tokenEndpointAuthMethod?: string,
+    ) => Promise<{ accessToken: string; expiresIn: number }>
+  >
 >;
 
 mock.module("../security/oauth2.js", () => {
@@ -93,6 +101,7 @@ const mockProviders = new Map<
   {
     key: string;
     tokenExchangeUrl: string;
+    refreshUrl?: string | null;
     tokenEndpointAuthMethod?: string;
   }
 >();
@@ -1325,6 +1334,7 @@ describe("withValidToken refresh deduplication", () => {
     mockProviders.set(service, {
       key: service,
       tokenExchangeUrl: "https://oauth.example.com/token",
+      refreshUrl: null,
     });
     mockApps.set(appId, {
       id: appId,
@@ -1526,5 +1536,134 @@ describe("withValidToken refresh deduplication", () => {
 
     // Only one actual refresh attempt
     expect(mockRefreshOAuth2Token).toHaveBeenCalledTimes(1);
+  });
+
+  // -----------------------------------------------------------------------
+  // refreshUrl resolution — provider.refreshUrl with fallback to tokenExchangeUrl
+  // -----------------------------------------------------------------------
+  describe("refreshUrl resolution", () => {
+    test("uses provider.refreshUrl when set", async () => {
+      await setupService("google");
+      mockProviders.get("google")!.refreshUrl =
+        "https://refresh.example.com/token";
+
+      mockRefreshOAuth2Token.mockImplementation(() =>
+        Promise.resolve({
+          accessToken: "new-token-from-refresh-url",
+          expiresIn: 3600,
+        }),
+      );
+
+      const err401 = Object.assign(new Error("Unauthorized"), { status: 401 });
+
+      const callback = async (token: string) => {
+        if (token === "old-access-token") throw err401;
+        return `result-with-${token}`;
+      };
+
+      const result = await withValidToken("google", callback);
+
+      expect(result).toBe("result-with-new-token-from-refresh-url");
+      expect(mockRefreshOAuth2Token).toHaveBeenCalledTimes(1);
+      // Assert the refresh endpoint passed in is provider.refreshUrl, not
+      // the tokenExchangeUrl fallback.
+      expect(mockRefreshOAuth2Token.mock.calls[0]?.[0]).toBe(
+        "https://refresh.example.com/token",
+      );
+    });
+
+    test("falls back to provider.tokenExchangeUrl when refreshUrl is null", async () => {
+      // setupService sets refreshUrl: null by default — this exercises the
+      // fallback path explicitly.
+      await setupService("google");
+      expect(mockProviders.get("google")!.refreshUrl).toBeNull();
+
+      mockRefreshOAuth2Token.mockImplementation(() =>
+        Promise.resolve({
+          accessToken: "new-token-from-token-exchange-url",
+          expiresIn: 3600,
+        }),
+      );
+
+      const err401 = Object.assign(new Error("Unauthorized"), { status: 401 });
+
+      const callback = async (token: string) => {
+        if (token === "old-access-token") throw err401;
+        return `result-with-${token}`;
+      };
+
+      const result = await withValidToken("google", callback);
+
+      expect(result).toBe("result-with-new-token-from-token-exchange-url");
+      expect(mockRefreshOAuth2Token).toHaveBeenCalledTimes(1);
+      // Assert the refresh endpoint falls back to tokenExchangeUrl.
+      expect(mockRefreshOAuth2Token.mock.calls[0]?.[0]).toBe(
+        "https://oauth.example.com/token",
+      );
+    });
+
+    test("falls back to provider.tokenExchangeUrl when refreshUrl is undefined", async () => {
+      await setupService("google");
+      // Delete the refreshUrl field entirely so the property is `undefined`
+      // rather than `null`. Both representations of "not set" must produce
+      // the fallback behavior.
+      delete mockProviders.get("google")!.refreshUrl;
+      expect(mockProviders.get("google")!.refreshUrl).toBeUndefined();
+
+      mockRefreshOAuth2Token.mockImplementation(() =>
+        Promise.resolve({
+          accessToken: "new-token-from-token-exchange-url",
+          expiresIn: 3600,
+        }),
+      );
+
+      const err401 = Object.assign(new Error("Unauthorized"), { status: 401 });
+
+      const callback = async (token: string) => {
+        if (token === "old-access-token") throw err401;
+        return `result-with-${token}`;
+      };
+
+      const result = await withValidToken("google", callback);
+
+      expect(result).toBe("result-with-new-token-from-token-exchange-url");
+      expect(mockRefreshOAuth2Token).toHaveBeenCalledTimes(1);
+      // Assert the refresh endpoint falls back to tokenExchangeUrl.
+      expect(mockRefreshOAuth2Token.mock.calls[0]?.[0]).toBe(
+        "https://oauth.example.com/token",
+      );
+    });
+
+    test("falls back to provider.tokenExchangeUrl when refreshUrl is empty string", async () => {
+      // Platform's Python `oauth_app.refresh_url or oauth_app.token_exchange_url`
+      // treats an empty string as unset. We use `||` (not `??`) so empty
+      // strings follow the same fallback path and never resolve to an empty
+      // endpoint.
+      await setupService("google");
+      mockProviders.get("google")!.refreshUrl = "";
+
+      mockRefreshOAuth2Token.mockImplementation(() =>
+        Promise.resolve({
+          accessToken: "new-token-from-token-exchange-url",
+          expiresIn: 3600,
+        }),
+      );
+
+      const err401 = Object.assign(new Error("Unauthorized"), { status: 401 });
+
+      const callback = async (token: string) => {
+        if (token === "old-access-token") throw err401;
+        return `result-with-${token}`;
+      };
+
+      const result = await withValidToken("google", callback);
+
+      expect(result).toBe("result-with-new-token-from-token-exchange-url");
+      expect(mockRefreshOAuth2Token).toHaveBeenCalledTimes(1);
+      // Assert the refresh endpoint falls back to tokenExchangeUrl — NOT "".
+      expect(mockRefreshOAuth2Token.mock.calls[0]?.[0]).toBe(
+        "https://oauth.example.com/token",
+      );
+    });
   });
 });

--- a/assistant/src/__tests__/oauth-cli.test.ts
+++ b/assistant/src/__tests__/oauth-cli.test.ts
@@ -169,6 +169,7 @@ mock.module("../oauth/oauth-store.js", () => ({
       provider: params.provider,
       authorizeUrl: params.authorizeUrl,
       tokenExchangeUrl: params.tokenExchangeUrl,
+      refreshUrl: (params.refreshUrl as string | undefined) ?? null,
       tokenEndpointAuthMethod: params.tokenEndpointAuthMethod ?? null,
       userinfoUrl: params.userinfoUrl ?? null,
       baseUrl: params.baseUrl ?? null,
@@ -230,6 +231,9 @@ mock.module("../oauth/oauth-store.js", () => ({
     }
     if (params.tokenExchangeUrl !== undefined) {
       updated.tokenExchangeUrl = params.tokenExchangeUrl;
+    }
+    if (params.refreshUrl !== undefined) {
+      updated.refreshUrl = params.refreshUrl;
     }
     if (params.defaultScopes !== undefined) {
       updated.defaultScopes = JSON.stringify(params.defaultScopes);
@@ -1523,5 +1527,121 @@ describe("assistant oauth providers --scope-separator", () => {
     expect(exitCode).toBe(0);
     const parsed = JSON.parse(stdout);
     expect(parsed.scopeSeparator).toBe(",");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// providers register / update / get — --refresh-url wiring
+// ---------------------------------------------------------------------------
+
+describe("assistant oauth providers --refresh-url", () => {
+  beforeEach(() => {
+    mockWithValidToken = async (_service, cb) => cb("mock-access-token-xyz");
+    mockProviderStore.clear();
+    // Default getProvider falls through to mockProviderStore via the
+    // oauth-store mock module.
+    mockGetProvider = () => undefined;
+    mockGetConfig = () => ({ services: {} });
+  });
+
+  afterEach(() => {
+    mockProviderStore.clear();
+    mockGetProvider = () => undefined;
+  });
+
+  test("providers register --refresh-url stores the URL on the provider row", async () => {
+    const { exitCode } = await runCli([
+      "providers",
+      "register",
+      "--provider-key",
+      "custom-refresh-url",
+      "--auth-url",
+      "https://example.com/oauth/authorize",
+      "--token-url",
+      "https://example.com/oauth/token",
+      "--refresh-url",
+      "https://refresh.example.com/token",
+      "--json",
+    ]);
+    expect(exitCode).toBe(0);
+    const stored = mockProviderStore.get("custom-refresh-url");
+    expect(stored).toBeDefined();
+    expect(stored?.refreshUrl).toBe("https://refresh.example.com/token");
+  });
+
+  test("providers register without --refresh-url stores null", async () => {
+    const { exitCode } = await runCli([
+      "providers",
+      "register",
+      "--provider-key",
+      "custom-no-refresh-url",
+      "--auth-url",
+      "https://example.com/oauth/authorize",
+      "--token-url",
+      "https://example.com/oauth/token",
+      "--json",
+    ]);
+    expect(exitCode).toBe(0);
+    const stored = mockProviderStore.get("custom-no-refresh-url");
+    expect(stored).toBeDefined();
+    expect(stored?.refreshUrl).toBeNull();
+  });
+
+  test("providers update --refresh-url updates an existing custom provider", async () => {
+    // Seed the store with an existing custom provider that has no refresh URL.
+    await runCli([
+      "providers",
+      "register",
+      "--provider-key",
+      "custom-update-refresh",
+      "--auth-url",
+      "https://example.com/oauth/authorize",
+      "--token-url",
+      "https://example.com/oauth/token",
+      "--json",
+    ]);
+    expect(
+      mockProviderStore.get("custom-update-refresh")?.refreshUrl,
+    ).toBeNull();
+
+    const { exitCode } = await runCli([
+      "providers",
+      "update",
+      "custom-update-refresh",
+      "--refresh-url",
+      "https://new-refresh.example.com/token",
+      "--json",
+    ]);
+    expect(exitCode).toBe(0);
+    expect(mockProviderStore.get("custom-update-refresh")?.refreshUrl).toBe(
+      "https://new-refresh.example.com/token",
+    );
+  });
+
+  test("providers get <key> --json includes refreshUrl from the serialized output", async () => {
+    // Seed the store with a custom provider that has a refresh URL set.
+    await runCli([
+      "providers",
+      "register",
+      "--provider-key",
+      "custom-get-refresh",
+      "--auth-url",
+      "https://example.com/oauth/authorize",
+      "--token-url",
+      "https://example.com/oauth/token",
+      "--refresh-url",
+      "https://refresh.example.com/token",
+      "--json",
+    ]);
+
+    const { exitCode, stdout } = await runCli([
+      "providers",
+      "get",
+      "custom-get-refresh",
+      "--json",
+    ]);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.refreshUrl).toBe("https://refresh.example.com/token");
   });
 });

--- a/assistant/src/__tests__/oauth-provider-serializer.test.ts
+++ b/assistant/src/__tests__/oauth-provider-serializer.test.ts
@@ -181,6 +181,20 @@ describe("serializeProvider", () => {
     const result = serializeProvider(row)!;
     expect(result.scopeSeparator).toBe(" ");
   });
+
+  test("emits refreshUrl from the row when set to a URL", () => {
+    const row = makeRow({
+      refreshUrl: "https://refresh.example.com/token",
+    });
+    const result = serializeProvider(row)!;
+    expect(result.refreshUrl).toBe("https://refresh.example.com/token");
+  });
+
+  test("emits refreshUrl as null when the row value is null", () => {
+    const row = makeRow({ refreshUrl: null });
+    const result = serializeProvider(row)!;
+    expect(result.refreshUrl).toBeNull();
+  });
 });
 
 describe("serializeProviderSummary", () => {
@@ -250,5 +264,12 @@ describe("serializeProviderSummary", () => {
     const result = serializeProviderSummary(row)!;
     expect(result).not.toHaveProperty("scope_separator");
     expect(result).not.toHaveProperty("scopeSeparator");
+  });
+
+  test("does NOT include refresh_url (intentionally omitted from the HTTP summary)", () => {
+    const row = makeRow({ refreshUrl: "https://refresh.example.com/token" });
+    const result = serializeProviderSummary(row)!;
+    expect(result).not.toHaveProperty("refresh_url");
+    expect(result).not.toHaveProperty("refreshUrl");
   });
 });

--- a/assistant/src/__tests__/oauth-provider-serializer.test.ts
+++ b/assistant/src/__tests__/oauth-provider-serializer.test.ts
@@ -13,6 +13,7 @@ function makeRow(overrides: Partial<OAuthProviderRow> = {}): OAuthProviderRow {
     provider: "test-provider",
     authorizeUrl: "https://auth.example.com/authorize",
     tokenExchangeUrl: "https://auth.example.com/token",
+    refreshUrl: null,
     tokenEndpointAuthMethod: null,
     userinfoUrl: null,
     baseUrl: null,

--- a/assistant/src/__tests__/oauth-store.test.ts
+++ b/assistant/src/__tests__/oauth-store.test.ts
@@ -342,6 +342,72 @@ describe("provider operations", () => {
       const row = getProvider("linear");
       expect(row!.scopeSeparator).toBe(",");
     });
+
+    test("persists refreshUrl when provided", () => {
+      seedProviders([
+        {
+          provider: "test-provider",
+          authorizeUrl: "https://example.com/authorize",
+          tokenExchangeUrl: "https://example.com/token",
+          refreshUrl: "https://refresh.example.com/token",
+          defaultScopes: ["read"],
+          scopePolicy: {},
+        },
+      ]);
+
+      const row = getProvider("test-provider");
+      expect(row).toBeDefined();
+      expect(row!.refreshUrl).toBe("https://refresh.example.com/token");
+    });
+
+    test("refreshUrl defaults to null when omitted", () => {
+      seedProviders([
+        {
+          provider: "test-provider",
+          authorizeUrl: "https://example.com/authorize",
+          tokenExchangeUrl: "https://example.com/token",
+          defaultScopes: ["read"],
+          scopePolicy: {},
+        },
+      ]);
+
+      const row = getProvider("test-provider");
+      expect(row).toBeDefined();
+      expect(row!.refreshUrl).toBeNull();
+    });
+
+    test("re-seeding with a changed refreshUrl overwrites the stored value", () => {
+      seedProviders([
+        {
+          provider: "test-provider",
+          authorizeUrl: "https://example.com/authorize",
+          tokenExchangeUrl: "https://example.com/token",
+          refreshUrl: "https://refresh.example.com/token",
+          defaultScopes: ["read"],
+          scopePolicy: {},
+        },
+      ]);
+
+      const first = getProvider("test-provider");
+      expect(first!.refreshUrl).toBe("https://refresh.example.com/token");
+
+      // Re-seed with a different refreshUrl — it should be overwritten,
+      // proving refreshUrl is in the onConflictDoUpdate set clause (not
+      // preserved like defaultScopes).
+      seedProviders([
+        {
+          provider: "test-provider",
+          authorizeUrl: "https://example.com/authorize",
+          tokenExchangeUrl: "https://example.com/token",
+          refreshUrl: "https://refresh-v2.example.com/token",
+          defaultScopes: ["read"],
+          scopePolicy: {},
+        },
+      ]);
+
+      const row = getProvider("test-provider");
+      expect(row!.refreshUrl).toBe("https://refresh-v2.example.com/token");
+    });
   });
 
   describe("getProvider", () => {
@@ -432,6 +498,35 @@ describe("provider operations", () => {
       expect(fetched).toBeDefined();
       expect(fetched!.scopeSeparator).toBe(" ");
     });
+
+    test("persists refreshUrl and round-trips via getProvider", () => {
+      registerProvider({
+        provider: "linear",
+        authorizeUrl: "https://linear.app/oauth/authorize",
+        tokenExchangeUrl: "https://api.linear.app/oauth/token",
+        refreshUrl: "https://api.linear.app/oauth/refresh",
+        defaultScopes: ["read"],
+        scopePolicy: {},
+      });
+
+      const fetched = getProvider("linear");
+      expect(fetched).toBeDefined();
+      expect(fetched!.refreshUrl).toBe("https://api.linear.app/oauth/refresh");
+    });
+
+    test("refreshUrl defaults to null when omitted", () => {
+      registerProvider({
+        provider: "linear",
+        authorizeUrl: "https://linear.app/oauth/authorize",
+        tokenExchangeUrl: "https://api.linear.app/oauth/token",
+        defaultScopes: ["read"],
+        scopePolicy: {},
+      });
+
+      const fetched = getProvider("linear");
+      expect(fetched).toBeDefined();
+      expect(fetched!.refreshUrl).toBeNull();
+    });
   });
 
   describe("updateProvider", () => {
@@ -478,6 +573,61 @@ describe("provider operations", () => {
       expect(updated).toBeDefined();
       expect(updated!.scopeSeparator).toBe(" ");
       expect(getProvider("github")!.scopeSeparator).toBe(" ");
+    });
+
+    test("sets refreshUrl on an existing row where it was previously null", () => {
+      seedProviders([
+        {
+          provider: "github",
+          authorizeUrl: "https://github.com/authorize",
+          tokenExchangeUrl: "https://github.com/token",
+          defaultScopes: ["repo"],
+          scopePolicy: {},
+        },
+      ]);
+
+      const before = getProvider("github");
+      expect(before!.refreshUrl).toBeNull();
+
+      const updated = updateProvider("github", {
+        refreshUrl: "https://github.com/login/oauth/refresh",
+      });
+      expect(updated).toBeDefined();
+      expect(updated!.refreshUrl).toBe(
+        "https://github.com/login/oauth/refresh",
+      );
+
+      const fetched = getProvider("github");
+      expect(fetched!.refreshUrl).toBe(
+        "https://github.com/login/oauth/refresh",
+      );
+    });
+
+    test("leaves refreshUrl unchanged when not passed to updateProvider", () => {
+      seedProviders([
+        {
+          provider: "github",
+          authorizeUrl: "https://github.com/authorize",
+          tokenExchangeUrl: "https://github.com/token",
+          refreshUrl: "https://github.com/login/oauth/refresh",
+          defaultScopes: ["repo"],
+          scopePolicy: {},
+        },
+      ]);
+
+      expect(getProvider("github")!.refreshUrl).toBe(
+        "https://github.com/login/oauth/refresh",
+      );
+
+      // Update a different field — refreshUrl should be left alone.
+      const updated = updateProvider("github", {
+        displayLabel: "GitHub (updated)",
+      });
+      expect(updated).toBeDefined();
+      expect(updated!.refreshUrl).toBe(
+        "https://github.com/login/oauth/refresh",
+      );
+      expect(updated!.displayLabel).toBe("GitHub (updated)");
     });
   });
 

--- a/assistant/src/cli/commands/oauth/providers.ts
+++ b/assistant/src/cli/commands/oauth/providers.ts
@@ -220,6 +220,10 @@ Examples:
       "--token-url <url>",
       "OAuth token endpoint URL (e.g. https://oauth2.example.com/token)",
     )
+    .option(
+      "--refresh-url <url>",
+      "OAuth token refresh endpoint URL. Defaults to --token-url when omitted. Set this when the provider uses a different endpoint for the refresh_token grant than for the authorization_code grant.",
+    )
     .option("--base-url <url>", "API base URL for the service")
     .option("--userinfo-url <url>", "OpenID Connect userinfo endpoint URL")
     .option(
@@ -351,6 +355,11 @@ Examples:
       --scopes read,write \\
       --scope-separator ","
   $ assistant oauth providers register \\
+      --provider-key split-grants \\
+      --auth-url https://example.com/oauth/authorize \\
+      --token-url https://example.com/oauth/token \\
+      --refresh-url https://example.com/oauth/refresh
+  $ assistant oauth providers register \\
       --provider-key my-api \\
       --auth-url https://example.com/auth \\
       --token-url https://example.com/token \\
@@ -365,6 +374,7 @@ Examples:
           providerKey: string;
           authUrl: string;
           tokenUrl: string;
+          refreshUrl?: string;
           baseUrl?: string;
           userinfoUrl?: string;
           scopes?: string;
@@ -398,6 +408,7 @@ Examples:
             provider: opts.providerKey,
             authorizeUrl: opts.authUrl,
             tokenExchangeUrl: opts.tokenUrl,
+            refreshUrl: opts.refreshUrl,
             baseUrl: opts.baseUrl,
             userinfoUrl: opts.userinfoUrl,
             defaultScopes: opts.scopes ? opts.scopes.split(",") : [],
@@ -466,6 +477,10 @@ Examples:
     .option(
       "--token-url <url>",
       "OAuth token endpoint URL (e.g. https://oauth2.example.com/token)",
+    )
+    .option(
+      "--refresh-url <url>",
+      "OAuth token refresh endpoint URL. Defaults to --token-url when omitted. Set this when the provider uses a different endpoint for the refresh_token grant than for the authorization_code grant.",
     )
     .option("--base-url <url>", "API base URL for the service")
     .option("--userinfo-url <url>", "OpenID Connect userinfo endpoint URL")
@@ -579,6 +594,7 @@ Examples:
   $ assistant oauth providers update custom-api --scopes read,write --auth-url https://new.example.com/auth
   $ assistant oauth providers update custom-api --ping-url https://api.example.com/me --json
   $ assistant oauth providers update custom-api --scope-separator ","
+  $ assistant oauth providers update custom-api --refresh-url https://example.com/oauth/refresh
   $ assistant oauth providers update custom-api \\
       --identity-url https://api.example.com/me \\
       --identity-response-paths email,name
@@ -591,6 +607,7 @@ Examples:
         opts: {
           authUrl?: string;
           tokenUrl?: string;
+          refreshUrl?: string;
           baseUrl?: string;
           userinfoUrl?: string;
           scopes?: string;
@@ -656,6 +673,8 @@ Examples:
           if (opts.authUrl !== undefined) params.authorizeUrl = opts.authUrl;
           if (opts.tokenUrl !== undefined)
             params.tokenExchangeUrl = opts.tokenUrl;
+          if (opts.refreshUrl !== undefined)
+            params.refreshUrl = opts.refreshUrl;
           if (opts.baseUrl !== undefined) params.baseUrl = opts.baseUrl;
           if (opts.userinfoUrl !== undefined)
             params.userinfoUrl = opts.userinfoUrl;

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -113,6 +113,7 @@ import {
   migrateOAuthProvidersManagedServiceConfigKey,
   migrateOAuthProvidersPingConfig,
   migrateOAuthProvidersPingUrl,
+  migrateOAuthProvidersRefreshUrl,
   migrateOAuthProvidersScopeSeparator,
   migrateReminderRoutingIntent,
   migrateRemindersToSchedules,
@@ -354,6 +355,7 @@ export function initializeDb(): void {
     migrateMemoryRecallLogsQueryContext,
     migrateLlmRequestLogsCreatedAtIndex,
     migrateOAuthProvidersScopeSeparator,
+    migrateOAuthProvidersRefreshUrl,
   ];
 
   // Run each migration step, catching and logging individual failures so one

--- a/assistant/src/memory/migrations/214-oauth-providers-refresh-url.ts
+++ b/assistant/src/memory/migrations/214-oauth-providers-refresh-url.ts
@@ -1,0 +1,11 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+
+export function migrateOAuthProvidersRefreshUrl(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+  try {
+    raw.exec(`ALTER TABLE oauth_providers ADD COLUMN refresh_url TEXT`);
+  } catch {
+    // Column already exists — nothing to do.
+  }
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -155,6 +155,7 @@ export { migrateScheduleReuseConversation } from "./210-schedule-reuse-conversat
 export { migrateMemoryRecallLogsQueryContext } from "./211-memory-recall-logs-query-context.js";
 export { migrateLlmRequestLogsCreatedAtIndex } from "./212-llm-request-logs-created-at-index.js";
 export { migrateOAuthProvidersScopeSeparator } from "./213-oauth-providers-scope-separator.js";
+export { migrateOAuthProvidersRefreshUrl } from "./214-oauth-providers-refresh-url.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema/oauth.ts
+++ b/assistant/src/memory/schema/oauth.ts
@@ -10,6 +10,7 @@ export const oauthProviders = sqliteTable("oauth_providers", {
   provider: text("provider_key").primaryKey(),
   authorizeUrl: text("auth_url").notNull(),
   tokenExchangeUrl: text("token_url").notNull(),
+  refreshUrl: text("refresh_url"),
   tokenEndpointAuthMethod: text("token_endpoint_auth_method"),
   userinfoUrl: text("userinfo_url"),
   baseUrl: text("base_url"),

--- a/assistant/src/oauth/__tests__/identity-verifier.test.ts
+++ b/assistant/src/oauth/__tests__/identity-verifier.test.ts
@@ -32,6 +32,7 @@ function makeProviderRow(
     provider,
     authorizeUrl: "https://example.com/auth",
     tokenExchangeUrl: "https://example.com/token",
+    refreshUrl: null,
     tokenEndpointAuthMethod: null,
     userinfoUrl: null,
     baseUrl: null,

--- a/assistant/src/oauth/oauth-store.ts
+++ b/assistant/src/oauth/oauth-store.ts
@@ -49,7 +49,7 @@ export type OAuthConnectionRow = typeof oauthConnections.$inferSelect;
 /**
  * Seed well-known provider profiles into the database. Uses INSERT … ON
  * CONFLICT DO UPDATE so that implementation fields (authorizeUrl, tokenExchangeUrl,
- * tokenEndpointAuthMethod, userinfoUrl, authorizeParams,
+ * refreshUrl, tokenEndpointAuthMethod, userinfoUrl, authorizeParams,
  * pingUrl, pingMethod, pingHeaders, pingBody, managedServiceConfigKey,
  * loopbackPort, injectionTemplates, appType, setupNotes,
  * identityUrl, identityMethod, identityHeaders, identityBody,
@@ -68,6 +68,7 @@ export function seedProviders(
     provider: string;
     authorizeUrl: string;
     tokenExchangeUrl: string;
+    refreshUrl?: string;
     tokenEndpointAuthMethod?: string;
     userinfoUrl?: string;
     pingUrl?: string;
@@ -109,6 +110,7 @@ export function seedProviders(
   for (const p of profiles) {
     const authorizeUrl = p.authorizeUrl;
     const tokenExchangeUrl = p.tokenExchangeUrl;
+    const refreshUrl = p.refreshUrl ?? null;
     const tokenEndpointAuthMethod = p.tokenEndpointAuthMethod ?? null;
     const userinfoUrl = p.userinfoUrl ?? null;
     const pingUrl = p.pingUrl ?? null;
@@ -157,6 +159,7 @@ export function seedProviders(
         provider: p.provider,
         authorizeUrl,
         tokenExchangeUrl,
+        refreshUrl,
         tokenEndpointAuthMethod,
         userinfoUrl,
         baseUrl,
@@ -194,6 +197,7 @@ export function seedProviders(
         set: {
           authorizeUrl,
           tokenExchangeUrl,
+          refreshUrl,
           tokenEndpointAuthMethod,
           userinfoUrl,
           baseUrl: sql`COALESCE(${oauthProviders.baseUrl}, ${baseUrl})`,
@@ -252,6 +256,7 @@ export function registerProvider(params: {
   provider: string;
   authorizeUrl: string;
   tokenExchangeUrl: string;
+  refreshUrl?: string;
   tokenEndpointAuthMethod?: string;
   userinfoUrl?: string;
   pingUrl?: string;
@@ -299,6 +304,7 @@ export function registerProvider(params: {
     provider: params.provider,
     authorizeUrl: params.authorizeUrl,
     tokenExchangeUrl: params.tokenExchangeUrl,
+    refreshUrl: params.refreshUrl ?? null,
     tokenEndpointAuthMethod: params.tokenEndpointAuthMethod ?? null,
     userinfoUrl: params.userinfoUrl ?? null,
     baseUrl: params.baseUrl ?? null,
@@ -364,6 +370,7 @@ export function updateProvider(
   params: Partial<{
     authorizeUrl: string;
     tokenExchangeUrl: string;
+    refreshUrl: string;
     tokenEndpointAuthMethod: string;
     userinfoUrl: string;
     pingUrl: string;
@@ -408,6 +415,7 @@ export function updateProvider(
   if (params.authorizeUrl !== undefined) set.authorizeUrl = params.authorizeUrl;
   if (params.tokenExchangeUrl !== undefined)
     set.tokenExchangeUrl = params.tokenExchangeUrl;
+  if (params.refreshUrl !== undefined) set.refreshUrl = params.refreshUrl;
   if (params.tokenEndpointAuthMethod !== undefined)
     set.tokenEndpointAuthMethod = params.tokenEndpointAuthMethod;
   if (params.userinfoUrl !== undefined) set.userinfoUrl = params.userinfoUrl;

--- a/assistant/src/oauth/provider-serializer.ts
+++ b/assistant/src/oauth/provider-serializer.ts
@@ -77,6 +77,7 @@ function _serializeProvider(
     providerKey: provider,
     authUrl: authorizeUrl,
     tokenUrl: tokenExchangeUrl,
+    refreshUrl: row.refreshUrl ?? null,
     displayName: displayLabel ?? null,
     description: row.description ?? null,
     dashboardUrl: row.dashboardUrl ?? null,

--- a/assistant/src/oauth/seed-providers.ts
+++ b/assistant/src/oauth/seed-providers.ts
@@ -5,7 +5,7 @@ import { seedProviders } from "./oauth-store.js";
  *
  * These values are upserted into the `oauth_providers` SQLite table on
  * every startup. Only Vellum implementation fields (authorizeUrl, tokenExchangeUrl,
- * tokenEndpointAuthMethod, userinfoUrl, authorizeParams,
+ * refreshUrl, tokenEndpointAuthMethod, userinfoUrl, authorizeParams,
  * pingUrl, pingMethod, pingHeaders, pingBody, managedServiceConfigKey,
  * loopbackPort, injectionTemplates, appType, setupNotes,
  * identityUrl, identityMethod, identityHeaders, identityBody,
@@ -23,6 +23,7 @@ const PROVIDER_SEED_DATA: Record<
     provider: string;
     authorizeUrl: string;
     tokenExchangeUrl: string;
+    refreshUrl?: string;
     tokenEndpointAuthMethod?: string;
     userinfoUrl?: string;
     pingUrl?: string;

--- a/assistant/src/security/token-manager.ts
+++ b/assistant/src/security/token-manager.ts
@@ -1,7 +1,7 @@
 /**
  * Token manager for OAuth2 credentials.
  *
- * Reads refresh configuration (tokenExchangeUrl, clientId, authMethod) exclusively
+ * Reads refresh configuration (refreshUrl with fallback to tokenExchangeUrl, clientId, authMethod) exclusively
  * from the SQLite oauth-store (provider + app + connection rows). After a
  * successful refresh, writes tokens to new-format secure key paths and
  * updates the oauth_connection row.
@@ -90,6 +90,11 @@ const secureKeyBackend: SecureKeyBackend = {
 
 /** Shared shape for resolved refresh configuration. */
 interface RefreshConfig {
+  /**
+   * Token endpoint used for the refresh grant. Resolved from
+   * `provider.refreshUrl` when set to a non-empty string, otherwise
+   * `provider.tokenExchangeUrl` (matching platform's Python `or` semantics).
+   */
   tokenExchangeUrl: string;
   clientId: string;
   /** OAuth client secret (optional — PKCE flows may omit it). */
@@ -102,8 +107,9 @@ interface RefreshConfig {
 /**
  * Resolve refresh configuration from the SQLite oauth-store.
  *
- * Looks up connection -> app -> provider to read tokenExchangeUrl, clientId, and
- * authMethod. Throws `TokenExpiredError` if the connection is not found
+ * Looks up connection -> app -> provider to read the refresh endpoint (preferring
+ * `provider.refreshUrl`, falling back to `provider.tokenExchangeUrl`), clientId,
+ * and authMethod. Throws `TokenExpiredError` if the connection is not found
  * or incomplete.
  */
 async function resolveRefreshConfig(
@@ -134,7 +140,14 @@ async function resolveRefreshConfig(
     );
   }
 
-  const tokenExchangeUrl = provider.tokenExchangeUrl;
+  // Prefer provider.refreshUrl when set; fall back to tokenExchangeUrl.
+  // This mirrors platform's `oauth_app.refresh_url or oauth_app.token_exchange_url`
+  // in `token_service.py:112`, so both repos resolve the refresh endpoint
+  // identically for managed and BYO flows. We use `||` (not `??`) so empty
+  // strings fall back to tokenExchangeUrl — matching Python's `or` semantics
+  // and preventing a malformed provider row with `refreshUrl: ""` from
+  // resolving to an empty endpoint.
+  const tokenExchangeUrl = provider.refreshUrl || provider.tokenExchangeUrl;
   const resolvedClientId = app.clientId;
   if (!tokenExchangeUrl || !resolvedClientId) {
     throw new TokenExpiredError(


### PR DESCRIPTION
## Summary

Adds a `refreshUrl` field to the OAuth provider schema, seed type, store, token-refresh flow, serializer, and CLI so the assistant can use a provider-configured refresh endpoint when it differs from the token exchange endpoint — matching the shape and semantics of `vellum-assistant-platform`'s `VellumManagedOAuth2App.refresh_url`.

`token-manager.ts` now resolves the refresh endpoint via `provider.refreshUrl || provider.tokenExchangeUrl`, mirroring platform's `token_service.py:112` `oauth_app.refresh_url or oauth_app.token_exchange_url` fallback. Uses `||` (not `??`) so empty strings fall back to `tokenExchangeUrl` — matching Python `or` semantics.

No existing provider entries are populated with `refreshUrl` — platform's `provider_registry.json` sets redundant character-for-character duplicates of `token_exchange_url` on four providers; we rely on the runtime fallback instead.

## PRs merged into feature branch
- #24182: feat(oauth): add refresh_url column and plumb through store + seed
- #24185: feat(oauth): use provider refreshUrl with fallback in token-manager
- #24186: feat(oauth): expose refreshUrl in provider serializer and CLI

Part of plan: refresh-url-parity.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24198" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
