### PR TITLE
feat(oauth): add revoke_url and revoke_body_template columns and seed Google/Twitter/Linear

### DIFF
--- a/assistant/src/__tests__/oauth-provider-serializer.test.ts
+++ b/assistant/src/__tests__/oauth-provider-serializer.test.ts
@@ -25,6 +25,8 @@ function makeRow(overrides: Partial<OAuthProviderRow> = {}): OAuthProviderRow {
     pingMethod: null,
     pingHeaders: null,
     pingBody: null,
+    revokeUrl: null,
+    revokeBodyTemplate: null,
     managedServiceConfigKey: null,
     displayLabel: null,
     description: null,

--- a/assistant/src/__tests__/oauth-store.test.ts
+++ b/assistant/src/__tests__/oauth-store.test.ts
@@ -46,6 +46,7 @@ import {
   updateProvider,
   upsertApp,
 } from "../oauth/oauth-store.js";
+import { seedOAuthProviders } from "../oauth/seed-providers.js";
 
 initializeDb();
 
@@ -408,6 +409,117 @@ describe("provider operations", () => {
       const row = getProvider("test-provider");
       expect(row!.refreshUrl).toBe("https://refresh-v2.example.com/token");
     });
+
+    test("persists revokeUrl and revokeBodyTemplate when provided", () => {
+      seedProviders([
+        {
+          provider: "test-provider",
+          authorizeUrl: "https://example.com/authorize",
+          tokenExchangeUrl: "https://example.com/token",
+          revokeUrl: "https://revoke.example.com",
+          revokeBodyTemplate: { token: "{access_token}" },
+          defaultScopes: ["read"],
+          scopePolicy: {},
+        },
+      ]);
+
+      const row = getProvider("test-provider");
+      expect(row).toBeDefined();
+      expect(row!.revokeUrl).toBe("https://revoke.example.com");
+      expect(JSON.parse(row!.revokeBodyTemplate!)).toEqual({
+        token: "{access_token}",
+      });
+    });
+
+    test("revokeUrl and revokeBodyTemplate default to null when omitted", () => {
+      seedProviders([
+        {
+          provider: "test-provider",
+          authorizeUrl: "https://example.com/authorize",
+          tokenExchangeUrl: "https://example.com/token",
+          defaultScopes: ["read"],
+          scopePolicy: {},
+        },
+      ]);
+
+      const row = getProvider("test-provider");
+      expect(row).toBeDefined();
+      expect(row!.revokeUrl).toBeNull();
+      expect(row!.revokeBodyTemplate).toBeNull();
+    });
+
+    test("re-seeding with a changed revokeUrl overwrites the stored value", () => {
+      seedProviders([
+        {
+          provider: "test-provider",
+          authorizeUrl: "https://example.com/authorize",
+          tokenExchangeUrl: "https://example.com/token",
+          revokeUrl: "https://revoke.example.com",
+          defaultScopes: ["read"],
+          scopePolicy: {},
+        },
+      ]);
+
+      const first = getProvider("test-provider");
+      expect(first!.revokeUrl).toBe("https://revoke.example.com");
+
+      // Re-seed with a different revokeUrl — it should be overwritten,
+      // proving revokeUrl is in the onConflictDoUpdate set clause (not
+      // preserved like defaultScopes).
+      seedProviders([
+        {
+          provider: "test-provider",
+          authorizeUrl: "https://example.com/authorize",
+          tokenExchangeUrl: "https://example.com/token",
+          revokeUrl: "https://revoke-v2.example.com",
+          defaultScopes: ["read"],
+          scopePolicy: {},
+        },
+      ]);
+
+      const row = getProvider("test-provider");
+      expect(row!.revokeUrl).toBe("https://revoke-v2.example.com");
+    });
+
+    test("seedOAuthProviders seeds Google, Twitter, and Linear with revoke config and leaves other providers null", () => {
+      seedOAuthProviders();
+
+      const google = getProvider("google");
+      expect(google).toBeDefined();
+      expect(google!.revokeUrl).toBe("https://oauth2.googleapis.com/revoke");
+      expect(JSON.parse(google!.revokeBodyTemplate!)).toEqual({
+        token: "{access_token}",
+      });
+
+      const twitter = getProvider("twitter");
+      expect(twitter).toBeDefined();
+      expect(twitter!.revokeUrl).toBe("https://api.x.com/2/oauth2/revoke");
+      expect(JSON.parse(twitter!.revokeBodyTemplate!)).toEqual({
+        token: "{access_token}",
+        token_type_hint: "access_token",
+        client_id: "{client_id}",
+      });
+
+      const linear = getProvider("linear");
+      expect(linear).toBeDefined();
+      expect(linear!.revokeUrl).toBe("https://api.linear.app/oauth/revoke");
+      expect(JSON.parse(linear!.revokeBodyTemplate!)).toEqual({
+        token: "{access_token}",
+      });
+
+      const slack = getProvider("slack");
+      expect(slack).toBeDefined();
+      expect(slack!.revokeUrl).toBeNull();
+      expect(slack!.revokeBodyTemplate).toBeNull();
+
+      const github = getProvider("github");
+      expect(github).toBeDefined();
+      expect(github!.revokeUrl).toBeNull();
+
+      const outlook = getProvider("outlook");
+      expect(outlook).toBeDefined();
+      expect(outlook!.revokeUrl).toBeNull();
+    });
   });
 
   describe("getProvider", () => {
@@ -527,6 +639,25 @@ describe("provider operations", () => {
       expect(fetched).toBeDefined();
       expect(fetched!.refreshUrl).toBeNull();
     });
+
+    test("persists revokeUrl and revokeBodyTemplate and round-trips via getProvider", () => {
+      registerProvider({
+        provider: "linear",
+        authorizeUrl: "https://linear.app/oauth/authorize",
+        tokenExchangeUrl: "https://api.linear.app/oauth/token",
+        revokeUrl: "https://api.linear.app/oauth/revoke",
+        revokeBodyTemplate: { token: "{access_token}" },
+        defaultScopes: ["read"],
+        scopePolicy: {},
+      });
+
+      const fetched = getProvider("linear");
+      expect(fetched).toBeDefined();
+      expect(fetched!.revokeUrl).toBe("https://api.linear.app/oauth/revoke");
+      expect(JSON.parse(fetched!.revokeBodyTemplate!)).toEqual({
+        token: "{access_token}",
+      });
+    });
   });
 
   describe("updateProvider", () => {
@@ -627,6 +758,95 @@ describe("provider operations", () => {
       expect(updated!.refreshUrl).toBe(
         "https://github.com/login/oauth/refresh",
       );
+      expect(updated!.displayLabel).toBe("GitHub (updated)");
+    });
+
+    test("sets revokeUrl on an existing row where it was previously null", () => {
+      seedProviders([
+        {
+          provider: "github",
+          authorizeUrl: "https://github.com/authorize",
+          tokenExchangeUrl: "https://github.com/token",
+          defaultScopes: ["repo"],
+          scopePolicy: {},
+        },
+      ]);
+
+      const before = getProvider("github");
+      expect(before!.revokeUrl).toBeNull();
+
+      const updated = updateProvider("github", {
+        revokeUrl: "https://github.com/login/oauth/revoke",
+      });
+      expect(updated).toBeDefined();
+      expect(updated!.revokeUrl).toBe("https://github.com/login/oauth/revoke");
+
+      const fetched = getProvider("github");
+      expect(fetched!.revokeUrl).toBe("https://github.com/login/oauth/revoke");
+    });
+
+    test("sets revokeBodyTemplate on an existing row and JSON round-trips", () => {
+      seedProviders([
+        {
+          provider: "github",
+          authorizeUrl: "https://github.com/authorize",
+          tokenExchangeUrl: "https://github.com/token",
+          defaultScopes: ["repo"],
+          scopePolicy: {},
+        },
+      ]);
+
+      const before = getProvider("github");
+      expect(before!.revokeBodyTemplate).toBeNull();
+
+      const updated = updateProvider("github", {
+        revokeBodyTemplate: {
+          token: "{access_token}",
+          client_id: "{client_id}",
+        },
+      });
+      expect(updated).toBeDefined();
+      expect(JSON.parse(updated!.revokeBodyTemplate!)).toEqual({
+        token: "{access_token}",
+        client_id: "{client_id}",
+      });
+
+      const fetched = getProvider("github");
+      expect(JSON.parse(fetched!.revokeBodyTemplate!)).toEqual({
+        token: "{access_token}",
+        client_id: "{client_id}",
+      });
+    });
+
+    test("leaves revokeUrl and revokeBodyTemplate unchanged when not passed to updateProvider", () => {
+      seedProviders([
+        {
+          provider: "github",
+          authorizeUrl: "https://github.com/authorize",
+          tokenExchangeUrl: "https://github.com/token",
+          revokeUrl: "https://github.com/login/oauth/revoke",
+          revokeBodyTemplate: { token: "{access_token}" },
+          defaultScopes: ["repo"],
+          scopePolicy: {},
+        },
+      ]);
+
+      expect(getProvider("github")!.revokeUrl).toBe(
+        "https://github.com/login/oauth/revoke",
+      );
+      expect(JSON.parse(getProvider("github")!.revokeBodyTemplate!)).toEqual({
+        token: "{access_token}",
+      });
+
+      // Update a different field — revoke fields should be left alone.
+      const updated = updateProvider("github", {
+        displayLabel: "GitHub (updated)",
+      });
+      expect(updated).toBeDefined();
+      expect(updated!.revokeUrl).toBe("https://github.com/login/oauth/revoke");
+      expect(JSON.parse(updated!.revokeBodyTemplate!)).toEqual({
+        token: "{access_token}",
+      });
       expect(updated!.displayLabel).toBe("GitHub (updated)");
     });
   });

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -114,6 +114,7 @@ import {
   migrateOAuthProvidersPingConfig,
   migrateOAuthProvidersPingUrl,
   migrateOAuthProvidersRefreshUrl,
+  migrateOAuthProvidersRevoke,
   migrateOAuthProvidersScopeSeparator,
   migrateReminderRoutingIntent,
   migrateRemindersToSchedules,
@@ -356,6 +357,7 @@ export function initializeDb(): void {
     migrateLlmRequestLogsCreatedAtIndex,
     migrateOAuthProvidersScopeSeparator,
     migrateOAuthProvidersRefreshUrl,
+    migrateOAuthProvidersRevoke,
   ];
 
   // Run each migration step, catching and logging individual failures so one

--- a/assistant/src/memory/migrations/215-oauth-providers-revoke.ts
+++ b/assistant/src/memory/migrations/215-oauth-providers-revoke.ts
@@ -1,0 +1,14 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+
+export function migrateOAuthProvidersRevoke(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+  const columns = ["revoke_url TEXT", "revoke_body_template TEXT"];
+  for (const col of columns) {
+    try {
+      raw.exec(`ALTER TABLE oauth_providers ADD COLUMN ${col}`);
+    } catch {
+      // Column already exists — nothing to do.
+    }
+  }
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -156,6 +156,7 @@ export { migrateMemoryRecallLogsQueryContext } from "./211-memory-recall-logs-qu
 export { migrateLlmRequestLogsCreatedAtIndex } from "./212-llm-request-logs-created-at-index.js";
 export { migrateOAuthProvidersScopeSeparator } from "./213-oauth-providers-scope-separator.js";
 export { migrateOAuthProvidersRefreshUrl } from "./214-oauth-providers-refresh-url.js";
+export { migrateOAuthProvidersRevoke } from "./215-oauth-providers-revoke.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema/oauth.ts
+++ b/assistant/src/memory/schema/oauth.ts
@@ -22,6 +22,8 @@ export const oauthProviders = sqliteTable("oauth_providers", {
   pingMethod: text("ping_method"),
   pingHeaders: text("ping_headers"),
   pingBody: text("ping_body"),
+  revokeUrl: text("revoke_url"),
+  revokeBodyTemplate: text("revoke_body_template"),
   managedServiceConfigKey: text("managed_service_config_key"),
   displayLabel: text("display_name"),
   description: text("description"),

--- a/assistant/src/oauth/__tests__/identity-verifier.test.ts
+++ b/assistant/src/oauth/__tests__/identity-verifier.test.ts
@@ -44,6 +44,8 @@ function makeProviderRow(
     pingMethod: null,
     pingHeaders: null,
     pingBody: null,
+    revokeUrl: null,
+    revokeBodyTemplate: null,
     managedServiceConfigKey: null,
     displayLabel: null,
     description: null,

--- a/assistant/src/oauth/oauth-store.ts
+++ b/assistant/src/oauth/oauth-store.ts
@@ -50,7 +50,8 @@ export type OAuthConnectionRow = typeof oauthConnections.$inferSelect;
  * Seed well-known provider profiles into the database. Uses INSERT … ON
  * CONFLICT DO UPDATE so that implementation fields (authorizeUrl, tokenExchangeUrl,
  * refreshUrl, tokenEndpointAuthMethod, userinfoUrl, authorizeParams,
- * pingUrl, pingMethod, pingHeaders, pingBody, managedServiceConfigKey,
+ * pingUrl, pingMethod, pingHeaders, pingBody, revokeUrl, revokeBodyTemplate,
+ * managedServiceConfigKey,
  * loopbackPort, injectionTemplates, appType, setupNotes,
  * identityUrl, identityMethod, identityHeaders, identityBody,
  * identityResponsePaths, identityFormat, identityOkField, featureFlag,
@@ -75,6 +76,8 @@ export function seedProviders(
     pingMethod?: string;
     pingHeaders?: Record<string, string>;
     pingBody?: unknown;
+    revokeUrl?: string;
+    revokeBodyTemplate?: Record<string, string>;
     baseUrl?: string;
     defaultScopes: string[];
     scopePolicy: Record<string, unknown>;
@@ -118,6 +121,10 @@ export function seedProviders(
     const pingHeaders = p.pingHeaders ? JSON.stringify(p.pingHeaders) : null;
     const pingBody =
       p.pingBody !== undefined ? JSON.stringify(p.pingBody) : null;
+    const revokeUrl = p.revokeUrl ?? null;
+    const revokeBodyTemplate = p.revokeBodyTemplate
+      ? JSON.stringify(p.revokeBodyTemplate)
+      : null;
     const baseUrl = p.baseUrl ?? null;
     const defaultScopes = JSON.stringify(p.defaultScopes);
     const scopePolicy = JSON.stringify(p.scopePolicy);
@@ -171,6 +178,8 @@ export function seedProviders(
         pingMethod,
         pingHeaders,
         pingBody,
+        revokeUrl,
+        revokeBodyTemplate,
         managedServiceConfigKey,
         displayLabel,
         description,
@@ -207,6 +216,8 @@ export function seedProviders(
           pingMethod,
           pingHeaders,
           pingBody,
+          revokeUrl,
+          revokeBodyTemplate,
           managedServiceConfigKey,
           displayLabel,
           description,
@@ -263,6 +274,8 @@ export function registerProvider(params: {
   pingMethod?: string;
   pingHeaders?: Record<string, string>;
   pingBody?: unknown;
+  revokeUrl?: string;
+  revokeBodyTemplate?: Record<string, string>;
   baseUrl?: string;
   defaultScopes: string[];
   scopePolicy: Record<string, unknown>;
@@ -320,6 +333,10 @@ export function registerProvider(params: {
     pingHeaders: params.pingHeaders ? JSON.stringify(params.pingHeaders) : null,
     pingBody:
       params.pingBody !== undefined ? JSON.stringify(params.pingBody) : null,
+    revokeUrl: params.revokeUrl ?? null,
+    revokeBodyTemplate: params.revokeBodyTemplate
+      ? JSON.stringify(params.revokeBodyTemplate)
+      : null,
     managedServiceConfigKey: params.managedServiceConfigKey ?? null,
     displayLabel: params.displayLabel ?? null,
     description: params.description ?? null,
@@ -377,6 +394,8 @@ export function updateProvider(
     pingMethod: string;
     pingHeaders: Record<string, string>;
     pingBody: unknown;
+    revokeUrl: string;
+    revokeBodyTemplate: Record<string, string>;
     baseUrl: string;
     defaultScopes: string[];
     scopePolicy: Record<string, unknown>;
@@ -425,6 +444,9 @@ export function updateProvider(
     set.pingHeaders = JSON.stringify(params.pingHeaders);
   if (params.pingBody !== undefined)
     set.pingBody = JSON.stringify(params.pingBody);
+  if (params.revokeUrl !== undefined) set.revokeUrl = params.revokeUrl;
+  if (params.revokeBodyTemplate !== undefined)
+    set.revokeBodyTemplate = JSON.stringify(params.revokeBodyTemplate);
   if (params.baseUrl !== undefined) set.baseUrl = params.baseUrl;
   if (params.defaultScopes !== undefined)
     set.defaultScopes = JSON.stringify(params.defaultScopes);

--- a/assistant/src/oauth/seed-providers.ts
+++ b/assistant/src/oauth/seed-providers.ts
@@ -6,7 +6,8 @@ import { seedProviders } from "./oauth-store.js";
  * These values are upserted into the `oauth_providers` SQLite table on
  * every startup. Only Vellum implementation fields (authorizeUrl, tokenExchangeUrl,
  * refreshUrl, tokenEndpointAuthMethod, userinfoUrl, authorizeParams,
- * pingUrl, pingMethod, pingHeaders, pingBody, managedServiceConfigKey,
+ * pingUrl, pingMethod, pingHeaders, pingBody, revokeUrl, revokeBodyTemplate,
+ * managedServiceConfigKey,
  * loopbackPort, injectionTemplates, appType, setupNotes,
  * identityUrl, identityMethod, identityHeaders, identityBody,
  * identityResponsePaths, identityFormat, identityOkField, featureFlag,
@@ -30,6 +31,8 @@ const PROVIDER_SEED_DATA: Record<
     pingMethod?: string;
     pingHeaders?: Record<string, string>;
     pingBody?: unknown;
+    revokeUrl?: string;
+    revokeBodyTemplate?: Record<string, string>;
     baseUrl?: string;
     defaultScopes: string[];
     scopePolicy: {
@@ -115,6 +118,8 @@ const PROVIDER_SEED_DATA: Record<
         valuePrefix: "Bearer ",
       },
     ],
+    revokeUrl: "https://oauth2.googleapis.com/revoke",
+    revokeBodyTemplate: { token: "{access_token}" },
     appType: "Desktop app",
     identityUrl: "https://www.googleapis.com/oauth2/v2/userinfo",
     identityResponsePaths: ["email"],
@@ -235,6 +240,12 @@ const PROVIDER_SEED_DATA: Record<
         valuePrefix: "Bearer ",
       },
     ],
+    revokeUrl: "https://api.x.com/2/oauth2/revoke",
+    revokeBodyTemplate: {
+      token: "{access_token}",
+      token_type_hint: "access_token",
+      client_id: "{client_id}",
+    },
     appType: "App",
     identityUrl: "https://api.x.com/2/users/me",
     identityResponsePaths: ["data.username"],
@@ -308,6 +319,8 @@ const PROVIDER_SEED_DATA: Record<
         valuePrefix: "Bearer ",
       },
     ],
+    revokeUrl: "https://api.linear.app/oauth/revoke",
+    revokeBodyTemplate: { token: "{access_token}" },
     appType: "OAuth application",
     identityUrl: "https://api.linear.app/graphql",
     identityMethod: "POST",


### PR DESCRIPTION
## Summary
- Add nullable revoke_url and revoke_body_template columns via migration 215
- Seed Google, Twitter, and Linear with verbatim revoke config from platform's provider_registry.json
- Wire both fields through seedProviders, registerProvider, and updateProvider (protocol-level, overwritten on re-seed)

Part of plan: revoke-token-parity.md (PR 1 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24200" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
