### PR TITLE
feat: register tool-result-truncation feature flag (default disabled)

### DIFF
--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -296,6 +296,14 @@
       "label": "Apple Container",
       "description": "Enable assistant sandboxing via Apple Containers on macOS 26+, providing a lightweight native sandbox without third-party dependencies",
       "defaultEnabled": false
+    },
+    {
+      "id": "tool-result-truncation",
+      "scope": "assistant",
+      "key": "tool-result-truncation",
+      "label": "Post-Turn Tool Result Truncation",
+      "description": "Truncate large tool results after each assistant turn, persisting full content to disk for on-demand re-reads",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add tool-result-truncation feature flag to the registry with scope assistant and defaultEnabled false
- This gates the post-turn tool result truncation feature while we test it

Part of plan: post-turn-tool-result-truncation.md (PR 1 of 4)