### PR TITLE
feat: add postTurnTruncateToolResults for saving and truncating stale tool results

### DIFF
--- a/assistant/src/__tests__/post-turn-tool-result-truncation.test.ts
+++ b/assistant/src/__tests__/post-turn-tool-result-truncation.test.ts
@@ -1,0 +1,162 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import type { ContentBlock, Message } from "../providers/types.js";
+import {
+  THRESHOLD_CHARS,
+  TARGET_CHARS,
+  TOOL_RESULT_DIR,
+  TRUNCATION_MARKER,
+  buildTruncatedContent,
+  getToolResultFilePath,
+  postTurnTruncateToolResults,
+} from "../context/post-turn-tool-result-truncation.js";
+
+function makeToolResult(
+  content: string,
+  toolUseId = "tool_use_1",
+  is_error = false,
+): ContentBlock {
+  return {
+    type: "tool_result" as const,
+    tool_use_id: toolUseId,
+    content,
+    ...(is_error ? { is_error: true } : {}),
+  };
+}
+
+function makeMessages(blocks: ContentBlock[]): Message[] {
+  return [{ role: "user", content: blocks }];
+}
+
+describe("postTurnTruncateToolResults", () => {
+  let convDir: string;
+
+  beforeEach(() => {
+    convDir = mkdtempSync(join(tmpdir(), "tool-result-trunc-"));
+  });
+
+  afterEach(() => {
+    rmSync(convDir, { recursive: true, force: true });
+  });
+
+  test("result below threshold is returned unchanged, no file written", () => {
+    const shortContent = "a".repeat(THRESHOLD_CHARS);
+    const messages = makeMessages([makeToolResult(shortContent)]);
+
+    const { messages: result, truncatedCount } =
+      postTurnTruncateToolResults(messages, { conversationDir: convDir });
+
+    expect(truncatedCount).toBe(0);
+    expect(result).toBe(messages); // same reference — no copy
+    expect(existsSync(join(convDir, TOOL_RESULT_DIR))).toBe(false);
+  });
+
+  test("result above threshold is truncated, file written with original content", () => {
+    const longContent = "x".repeat(THRESHOLD_CHARS + 1);
+    const toolUseId = "tool_use_abc";
+    const messages = makeMessages([makeToolResult(longContent, toolUseId)]);
+
+    const { messages: result, truncatedCount } =
+      postTurnTruncateToolResults(messages, { conversationDir: convDir });
+
+    expect(truncatedCount).toBe(1);
+
+    const block = result[0].content[0] as { type: "tool_result"; content: string };
+    expect(block.content).toContain(TRUNCATION_MARKER);
+    expect(block.content.length).toBeLessThan(longContent.length);
+
+    // Verify file on disk contains original content.
+    const filePath = getToolResultFilePath(convDir, toolUseId);
+    expect(existsSync(filePath)).toBe(true);
+    expect(readFileSync(filePath, "utf-8")).toBe(longContent);
+  });
+
+  test("error result above threshold is unchanged", () => {
+    const longContent = "e".repeat(THRESHOLD_CHARS + 100);
+    const messages = makeMessages([
+      makeToolResult(longContent, "tool_err", true),
+    ]);
+
+    const { messages: result, truncatedCount } =
+      postTurnTruncateToolResults(messages, { conversationDir: convDir });
+
+    expect(truncatedCount).toBe(0);
+    expect(result).toBe(messages);
+  });
+
+  test("already-truncated result is unchanged (idempotency)", () => {
+    // Simulate a result that was already truncated in a prior pass.
+    const alreadyTruncated =
+      "prefix..." +
+      `\n\n...(500 tokens omitted ${TRUNCATION_MARKER} /some/path.txt)\n\n` +
+      "...suffix".padEnd(THRESHOLD_CHARS + 1, "z");
+    const messages = makeMessages([
+      makeToolResult(alreadyTruncated, "tool_idempotent"),
+    ]);
+
+    const { messages: result, truncatedCount } =
+      postTurnTruncateToolResults(messages, { conversationDir: convDir });
+
+    expect(truncatedCount).toBe(0);
+    expect(result).toBe(messages);
+  });
+
+  test("multiple results in one turn are each evaluated independently", () => {
+    const short = "s".repeat(100);
+    const long1 = "a".repeat(THRESHOLD_CHARS + 1);
+    const long2 = "b".repeat(THRESHOLD_CHARS + 2);
+    const messages = makeMessages([
+      makeToolResult(short, "tool_short"),
+      makeToolResult(long1, "tool_long1"),
+      makeToolResult(long2, "tool_long2"),
+    ]);
+
+    const { messages: result, truncatedCount } =
+      postTurnTruncateToolResults(messages, { conversationDir: convDir });
+
+    expect(truncatedCount).toBe(2);
+
+    // Short result unchanged.
+    const b0 = result[0].content[0] as { type: "tool_result"; content: string };
+    expect(b0.content).toBe(short);
+
+    // Both long results truncated.
+    const b1 = result[0].content[1] as { type: "tool_result"; content: string };
+    const b2 = result[0].content[2] as { type: "tool_result"; content: string };
+    expect(b1.content).toContain(TRUNCATION_MARKER);
+    expect(b2.content).toContain(TRUNCATION_MARKER);
+  });
+
+  test("prefix/suffix split preserves first and last halves of TARGET_CHARS", () => {
+    // Build content where each char is its position modulo 10 so we can verify slicing.
+    const longContent = Array.from({ length: THRESHOLD_CHARS + 500 }, (_, i) =>
+      String(i % 10),
+    ).join("");
+
+    const filePath = "/tmp/fake-path.txt";
+    const stub = buildTruncatedContent(longContent, filePath);
+
+    const half = Math.floor(TARGET_CHARS / 2);
+    const expectedPrefix = longContent.slice(0, half);
+    const expectedSuffix = longContent.slice(-half);
+
+    expect(stub.startsWith(expectedPrefix)).toBe(true);
+    expect(stub.endsWith(expectedSuffix)).toBe(true);
+    expect(stub).toContain(TRUNCATION_MARKER);
+    expect(stub).toContain(filePath);
+  });
+
+  test("file path is deterministic for the same toolUseId", () => {
+    const id = "tool_use_deterministic";
+    const path1 = getToolResultFilePath("/some/dir", id);
+    const path2 = getToolResultFilePath("/some/dir", id);
+    expect(path1).toBe(path2);
+
+    // Different IDs produce different paths.
+    const path3 = getToolResultFilePath("/some/dir", "tool_use_other");
+    expect(path3).not.toBe(path1);
+  });
+});

--- a/assistant/src/context/post-turn-tool-result-truncation.ts
+++ b/assistant/src/context/post-turn-tool-result-truncation.ts
@@ -1,0 +1,109 @@
+import { createHash } from "node:crypto";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type {
+  ContentBlock,
+  Message,
+  ToolResultContent,
+} from "../providers/types.js";
+
+/** Minimum content length (chars) before a tool result is eligible for truncation. ~2000 tokens at 4 chars/token. */
+export const THRESHOLD_CHARS = 8_000;
+
+/** Target size (chars) for the truncated stub. ~300 tokens at 4 chars/token. */
+export const TARGET_CHARS = 1_200;
+
+/** Subdirectory name under the conversation directory for saved full results. */
+export const TOOL_RESULT_DIR = ".tool-results";
+
+/** Marker used to detect already-truncated results (idempotency guard). */
+export const TRUNCATION_MARKER = "\u2014 full result:";
+
+/**
+ * Deterministic file path for a tool result's full content on disk.
+ * Uses the first 12 hex chars of the SHA-256 of the tool_use_id.
+ */
+export function getToolResultFilePath(
+  conversationDir: string,
+  toolUseId: string,
+): string {
+  const hash = createHash("sha256").update(toolUseId).digest("hex").slice(0, 12);
+  return join(conversationDir, TOOL_RESULT_DIR, `${hash}.txt`);
+}
+
+/**
+ * Build the truncated stub that replaces a large tool result in context.
+ * Preserves the first and last halves of TARGET_CHARS, with a middle marker
+ * indicating how many tokens were omitted and where to find the full result.
+ */
+export function buildTruncatedContent(
+  original: string,
+  filePath: string,
+): string {
+  const half = Math.floor(TARGET_CHARS / 2);
+  const prefix = original.slice(0, half);
+  const suffix = original.slice(-half);
+  const omittedChars = original.length - TARGET_CHARS;
+  const estimatedTokens = Math.round(omittedChars / 4);
+  return `${prefix}\n\n...(${estimatedTokens} tokens omitted ${TRUNCATION_MARKER} ${filePath})\n\n${suffix}`;
+}
+
+/**
+ * Walk all messages and truncate tool results that exceed `THRESHOLD_CHARS`.
+ *
+ * For each eligible result:
+ * - The full content is persisted to a deterministic file path on disk.
+ * - The in-context content is replaced with a prefix/suffix stub.
+ *
+ * Results are skipped if they are below threshold, are error results,
+ * or have already been truncated (contain `TRUNCATION_MARKER`).
+ *
+ * Returns a shallow-copied messages array (only modified messages are cloned)
+ * and the count of results that were truncated.
+ */
+export function postTurnTruncateToolResults(
+  messages: Message[],
+  options: { conversationDir: string },
+): { messages: Message[]; truncatedCount: number } {
+  let truncatedCount = 0;
+
+  const mapped = messages.map((msg) => {
+    let changed = false;
+    const nextContent: ContentBlock[] = msg.content.map((block) => {
+      if (block.type !== "tool_result") return block;
+      const tr = block as ToolResultContent;
+
+      // Skip short results.
+      if (tr.content.length <= THRESHOLD_CHARS) return block;
+
+      // Skip error results.
+      if (tr.is_error) return block;
+
+      // Skip already-truncated results (idempotency).
+      if (tr.content.includes(TRUNCATION_MARKER)) return block;
+
+      const filePath = getToolResultFilePath(
+        options.conversationDir,
+        tr.tool_use_id,
+      );
+
+      // Persist full content to disk.
+      mkdirSync(join(options.conversationDir, TOOL_RESULT_DIR), {
+        recursive: true,
+      });
+      writeFileSync(filePath, tr.content, "utf-8");
+
+      changed = true;
+      truncatedCount++;
+      return {
+        ...tr,
+        content: buildTruncatedContent(tr.content, filePath),
+      } as ContentBlock;
+    });
+
+    return changed ? { ...msg, content: nextContent } : msg;
+  });
+
+  return { messages: truncatedCount > 0 ? mapped : messages, truncatedCount };
+}


### PR DESCRIPTION
## Summary
- Add post-turn tool result truncation module with threshold/target-based truncation
- Save full tool result content to disk before truncating in-context to prefix/suffix stub
- Include comprehensive unit tests covering all edge cases

Part of plan: post-turn-tool-result-truncation.md (PR 2 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24203" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
