### PR TITLE
feat: add derefToolResultReReads to deduplicate re-reads of saved tool results

### DIFF
--- a/assistant/src/__tests__/post-turn-tool-result-truncation.test.ts
+++ b/assistant/src/__tests__/post-turn-tool-result-truncation.test.ts
@@ -9,9 +9,11 @@ import {
   TARGET_CHARS,
   TOOL_RESULT_DIR,
   TRUNCATION_MARKER,
+  REREAD_STUB,
   buildTruncatedContent,
   getToolResultFilePath,
   postTurnTruncateToolResults,
+  derefToolResultReReads,
 } from "../context/post-turn-tool-result-truncation.js";
 
 function makeToolResult(
@@ -158,5 +160,137 @@ describe("postTurnTruncateToolResults", () => {
     // Different IDs produce different paths.
     const path3 = getToolResultFilePath("/some/dir", "tool_use_other");
     expect(path3).not.toBe(path1);
+  });
+});
+
+describe("derefToolResultReReads", () => {
+  function makeToolUse(
+    id: string,
+    name: string,
+    input: Record<string, unknown>,
+  ): ContentBlock {
+    return { type: "tool_use" as const, id, name, input };
+  }
+
+  test("file_read of .tool-results/ path: tool_result content replaced with REREAD_STUB", () => {
+    const toolUseId = "tu_reread_1";
+    const messages: Message[] = [
+      {
+        role: "assistant",
+        content: [
+          makeToolUse(toolUseId, "file_read", {
+            file_path: `/home/user/.vellum/workspace/conversations/abc/${TOOL_RESULT_DIR}/abc123.txt`,
+          }),
+        ],
+      },
+      {
+        role: "user",
+        content: [makeToolResult("full file contents here", toolUseId)],
+      },
+    ];
+
+    const { messages: result, dereferencedCount } =
+      derefToolResultReReads(messages);
+
+    expect(dereferencedCount).toBe(1);
+    const block = result[1].content[0] as { type: "tool_result"; content: string };
+    expect(block.content).toBe(REREAD_STUB);
+  });
+
+  test("file_read of normal path: tool_result unchanged", () => {
+    const toolUseId = "tu_normal_read";
+    const originalContent = "some file contents";
+    const messages: Message[] = [
+      {
+        role: "assistant",
+        content: [
+          makeToolUse(toolUseId, "file_read", {
+            file_path: "src/foo.ts",
+          }),
+        ],
+      },
+      {
+        role: "user",
+        content: [makeToolResult(originalContent, toolUseId)],
+      },
+    ];
+
+    const { messages: result, dereferencedCount } =
+      derefToolResultReReads(messages);
+
+    expect(dereferencedCount).toBe(0);
+    expect(result).toBe(messages); // same reference — no copy
+    const block = result[1].content[0] as { type: "tool_result"; content: string };
+    expect(block.content).toBe(originalContent);
+  });
+
+  test("non-file_read tool: tool_result unchanged even if output mentions .tool-results/", () => {
+    const toolUseId = "tu_bash";
+    const outputMentioningDir = `Found file at /home/user/${TOOL_RESULT_DIR}/abc.txt`;
+    const messages: Message[] = [
+      {
+        role: "assistant",
+        content: [
+          makeToolUse(toolUseId, "bash", {
+            command: "ls",
+          }),
+        ],
+      },
+      {
+        role: "user",
+        content: [makeToolResult(outputMentioningDir, toolUseId)],
+      },
+    ];
+
+    const { messages: result, dereferencedCount } =
+      derefToolResultReReads(messages);
+
+    expect(dereferencedCount).toBe(0);
+    expect(result).toBe(messages);
+    const block = result[1].content[0] as { type: "tool_result"; content: string };
+    expect(block.content).toBe(outputMentioningDir);
+  });
+
+  test("multiple re-reads in one turn: each deduplicated independently", () => {
+    const tu1 = "tu_multi_1";
+    const tu2 = "tu_multi_2";
+    const tuNormal = "tu_multi_normal";
+    const messages: Message[] = [
+      {
+        role: "assistant",
+        content: [
+          makeToolUse(tu1, "file_read", {
+            file_path: `/workspace/conv/${TOOL_RESULT_DIR}/aaa.txt`,
+          }),
+          makeToolUse(tu2, "file_read", {
+            file_path: `/workspace/conv/${TOOL_RESULT_DIR}/bbb.txt`,
+          }),
+          makeToolUse(tuNormal, "file_read", {
+            file_path: "src/bar.ts",
+          }),
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          makeToolResult("re-read content 1", tu1),
+          makeToolResult("re-read content 2", tu2),
+          makeToolResult("normal read content", tuNormal),
+        ],
+      },
+    ];
+
+    const { messages: result, dereferencedCount } =
+      derefToolResultReReads(messages);
+
+    expect(dereferencedCount).toBe(2);
+
+    const b0 = result[1].content[0] as { type: "tool_result"; content: string };
+    const b1 = result[1].content[1] as { type: "tool_result"; content: string };
+    const b2 = result[1].content[2] as { type: "tool_result"; content: string };
+
+    expect(b0.content).toBe(REREAD_STUB);
+    expect(b1.content).toBe(REREAD_STUB);
+    expect(b2.content).toBe("normal read content"); // unchanged
   });
 });

--- a/assistant/src/context/post-turn-tool-result-truncation.ts
+++ b/assistant/src/context/post-turn-tool-result-truncation.ts
@@ -6,6 +6,7 @@ import type {
   ContentBlock,
   Message,
   ToolResultContent,
+  ToolUseContent,
 } from "../providers/types.js";
 
 /** Minimum content length (chars) before a tool result is eligible for truncation. ~2000 tokens at 4 chars/token. */
@@ -106,4 +107,67 @@ export function postTurnTruncateToolResults(
   });
 
   return { messages: truncatedCount > 0 ? mapped : messages, truncatedCount };
+}
+
+/** Stub that replaces a re-read of a saved tool result to avoid context duplication. */
+export const REREAD_STUB =
+  "(Re-read of saved tool result — original context is preserved above)";
+
+/**
+ * Deduplicate re-reads of saved tool results.
+ *
+ * When `postTurnTruncateToolResults` truncates a large result, it saves the full
+ * content to a `.tool-results/` file. If the model later calls `file_read` on that
+ * saved file, the result is a second copy of content whose truncated prefix/suffix
+ * is already in context. This function detects those re-reads and replaces their
+ * tool_result content with a short stub to avoid duplication.
+ */
+export function derefToolResultReReads(messages: Message[]): {
+  messages: Message[];
+  dereferencedCount: number;
+} {
+  // Build a set of tool_use_ids that are file_read calls targeting .tool-results/ paths.
+  const reReadToolUseIds = new Set<string>();
+
+  for (const msg of messages) {
+    if (msg.role !== "assistant") continue;
+    for (const block of msg.content) {
+      if (block.type !== "tool_use") continue;
+      const tu = block as ToolUseContent;
+      if (tu.name !== "file_read") continue;
+      const filePath = tu.input.file_path;
+      if (typeof filePath !== "string") continue;
+      if (filePath.includes(`/${TOOL_RESULT_DIR}/`)) {
+        reReadToolUseIds.add(tu.id);
+      }
+    }
+  }
+
+  if (reReadToolUseIds.size === 0) {
+    return { messages, dereferencedCount: 0 };
+  }
+
+  let dereferencedCount = 0;
+
+  const mapped = messages.map((msg) => {
+    if (msg.role !== "user") return msg;
+
+    let changed = false;
+    const nextContent: ContentBlock[] = msg.content.map((block) => {
+      if (block.type !== "tool_result") return block;
+      const tr = block as ToolResultContent;
+      if (!reReadToolUseIds.has(tr.tool_use_id)) return block;
+
+      changed = true;
+      dereferencedCount++;
+      return { ...tr, content: REREAD_STUB } as ContentBlock;
+    });
+
+    return changed ? { ...msg, content: nextContent } : msg;
+  });
+
+  return {
+    messages: dereferencedCount > 0 ? mapped : messages,
+    dereferencedCount,
+  };
 }


### PR DESCRIPTION
## Summary
- Add derefToolResultReReads function that detects file_read calls targeting .tool-results/ paths
- Replace re-read tool result content with a short stub to avoid context duplication
- Add tests for re-read dedup covering normal paths, non-file_read tools, and multiple re-reads

Part of plan: post-turn-tool-result-truncation.md (PR 3 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24204" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
