### PR TITLE
fix: strengthen conversation title length guidance

### DIFF
--- a/assistant/src/memory/conversation-title-service.ts
+++ b/assistant/src/memory/conversation-title-service.ts
@@ -284,10 +284,13 @@ export function queueRegenerateConversationTitle(
  */
 function buildTitleSystemPrompt(): string {
   return [
-    "You generate short conversation titles. Output ONLY the title text — no explanation, no quotes, no markdown, no preamble.",
+    "You generate ultra-concise conversation titles. Output ONLY the title text — no explanation, no quotes, no markdown, no preamble.",
     "",
     "Rules:",
-    "- Summarize the TOPIC the user is asking about",
+    "- 2–6 words. Titles longer than 6 words are unacceptable — ruthlessly compress",
+    "- Summarize the TOPIC, not the request or instructions",
+    "- Noun phrases are ideal (e.g. 'Auth Middleware Rewrite', 'Docker Volume Mounts')",
+    "- Do NOT echo back what the user asked you to do",
     "- Do NOT respond to the conversation content",
     "- Do NOT assess feasibility or comment on capabilities",
   ].join("\n");


### PR DESCRIPTION
## Summary
- Strengthened title generation system prompt from vague "short" to explicit "2–6 words" with compression language
- Added guidance to use noun phrases and summarize the topic rather than echoing the user's request
- Added examples of ideal titles (e.g. 'Auth Middleware Rewrite', 'Docker Volume Mounts')

## Original prompt
This conversation title is absolutely unhinged lmao. Can we make the prompt guidance on target length stronger? Don't enforce hard limits or set max_tokens, but just make the prompt more strongly worded
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24205" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
