### PR TITLE
fix: increase gateway credential bootstrap test timeouts for CI

### DIFF
--- a/gateway/src/__tests__/credential-watcher-managed-bootstrap.test.ts
+++ b/gateway/src/__tests__/credential-watcher-managed-bootstrap.test.ts
@@ -76,7 +76,7 @@ async function startGateway(): Promise<void> {
     stdio: ["ignore", "pipe", "pipe"],
   });
 
-  const deadline = Date.now() + 10_000;
+  const deadline = Date.now() + 30_000;
   while (Date.now() < deadline) {
     try {
       const res = await fetch(`http://localhost:${gatewayPort}/healthz`);
@@ -86,7 +86,7 @@ async function startGateway(): Promise<void> {
     }
     await new Promise((resolve) => setTimeout(resolve, 100));
   }
-  throw new Error("Gateway failed to start within 10 seconds");
+  throw new Error("Gateway failed to start within 30 seconds");
 }
 
 function startFakeCes(opts: {
@@ -176,7 +176,7 @@ describe("gateway managed credential bootstrap retry", () => {
     }
 
     expect(status).toBe(401);
-  }, 20_000);
+  }, 45_000);
 
   test("keeps retrying until configured credential reads succeed after CES list is already available", async () => {
     mkdirSync(testDir, { recursive: true });
@@ -220,7 +220,7 @@ describe("gateway managed credential bootstrap retry", () => {
     }
 
     expect(status).toBe(401);
-  }, 20_000);
+  }, 45_000);
 
   test("detects new Slack credentials when metadata is written after startup with no initial channel services", async () => {
     // Start with NO channel service metadata — only non-channel credentials
@@ -274,5 +274,5 @@ describe("gateway managed credential bootstrap retry", () => {
     }
 
     expect(status).toBe(401);
-  }, 20_000);
+  }, 45_000);
 });


### PR DESCRIPTION
## Summary
- Increase gateway startup health-check timeout from 10s to 30s in `credential-watcher-managed-bootstrap.test.ts`
- Increase per-test timeouts from 20s to 45s to accommodate slower CI runners
- Fixes flaky "Gateway failed to start within 10 seconds" failures caused by cold TypeScript compilation on the first test run

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24112741084/job/70350573701