### PR TITLE
fix: allowlist post-turn-tool-result-truncation in web_search guard

### DIFF
--- a/assistant/src/__tests__/conversation-history-web-search.test.ts
+++ b/assistant/src/__tests__/conversation-history-web-search.test.ts
@@ -747,6 +747,7 @@ describe("web_search_tool_result structural guard", () => {
     // web_search_tool_result has a structurally different content format
     // (array of web_search_result objects) and is not truncated this way.
     "context/tool-result-truncation.ts",
+    "context/post-turn-tool-result-truncation.ts",
 
     // Anthropic provider type guards define API-specific discriminants.
     // It has a separate isWebSearchToolResultBlock for the other type.


### PR DESCRIPTION
## Summary
- Add `context/post-turn-tool-result-truncation.ts` to the `ALLOWLISTED_FILES` set in the `web_search_tool_result` structural guard test
- Same rationale as the existing `context/tool-result-truncation.ts` entry: truncation logic operates on `tool_result` text content (string `.content`), and `web_search_tool_result` has a structurally different content format

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24112752672/job/70350605263
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24208" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
