### PR TITLE
fix: wrap post-turn tool result truncation in try/catch for non-fatal I/O errors

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -1750,18 +1750,22 @@ export async function runAgentLoopImpl(
     // Post-turn tool result truncation: save large results to disk and
     // replace in-context content with a prefix/suffix stub + file pointer.
     if (isAssistantFeatureFlagEnabled("tool-result-truncation", config)) {
-      const conv = getConversation(ctx.conversationId);
-      if (conv) {
-        const convDir = getResolvedConversationDirPath(ctx.conversationId, conv.createdAt);
-        const { messages: derefMessages, dereferencedCount } = derefToolResultReReads(restoredHistory);
-        const { messages: truncatedMessages, truncatedCount } = postTurnTruncateToolResults(derefMessages, { conversationDir: convDir });
-        if (truncatedCount > 0 || dereferencedCount > 0) {
-          rlog.info(
-            { truncatedCount, dereferencedCount },
-            "Post-turn tool result truncation applied",
-          );
+      try {
+        const conv = getConversation(ctx.conversationId);
+        if (conv) {
+          const convDir = getResolvedConversationDirPath(ctx.conversationId, conv.createdAt);
+          const { messages: derefMessages, dereferencedCount } = derefToolResultReReads(restoredHistory);
+          const { messages: truncatedMessages, truncatedCount } = postTurnTruncateToolResults(derefMessages, { conversationDir: convDir });
+          if (truncatedCount > 0 || dereferencedCount > 0) {
+            rlog.info(
+              { truncatedCount, dereferencedCount },
+              "Post-turn tool result truncation applied",
+            );
+          }
+          restoredHistory = truncatedMessages;
         }
-        restoredHistory = truncatedMessages;
+      } catch (err) {
+        rlog.warn({ err }, "Post-turn tool result truncation failed (non-fatal)");
       }
     }
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for post-turn-tool-result-truncation.md.

**Gap:** Missing error handling around disk I/O in post-turn truncation
**What was expected:** I/O failures during truncation should be non-fatal
**What was found:** mkdirSync/writeFileSync can throw and terminate the turn