### PR TITLE
fix: sort imports in post-turn-tool-result-truncation files

### DIFF
--- a/assistant/src/__tests__/post-turn-tool-result-truncation.test.ts
+++ b/assistant/src/__tests__/post-turn-tool-result-truncation.test.ts
@@ -3,18 +3,18 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
-import type { ContentBlock, Message } from "../providers/types.js";
 import {
-  THRESHOLD_CHARS,
-  TARGET_CHARS,
-  TOOL_RESULT_DIR,
-  TRUNCATION_MARKER,
-  REREAD_STUB,
   buildTruncatedContent,
+  derefToolResultReReads,
   getToolResultFilePath,
   postTurnTruncateToolResults,
-  derefToolResultReReads,
+  REREAD_STUB,
+  TARGET_CHARS,
+  THRESHOLD_CHARS,
+  TOOL_RESULT_DIR,
+  TRUNCATION_MARKER,
 } from "../context/post-turn-tool-result-truncation.js";
+import type { ContentBlock, Message } from "../providers/types.js";
 
 function makeToolResult(
   content: string,

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -24,7 +24,7 @@ import type {
 } from "../channels/types.js";
 import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import { getConfig } from "../config/loader.js";
-import { postTurnTruncateToolResults, derefToolResultReReads } from "../context/post-turn-tool-result-truncation.js";
+import { derefToolResultReReads,postTurnTruncateToolResults } from "../context/post-turn-tool-result-truncation.js";
 import { estimatePromptTokens } from "../context/token-estimator.js";
 import type { ContextWindowManager } from "../context/window-manager.js";
 import type { ToolProfiler } from "../events/tool-profiling-listener.js";


### PR DESCRIPTION
## Summary
- Fix `simple-import-sort/imports` lint errors in `post-turn-tool-result-truncation.test.ts` and `conversation-agent-loop.ts`
- Ran `eslint --fix` to auto-sort the imports

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24112899010/job/70351041629
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24211" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
