### PR TITLE
feat(oauth): expose revokeUrl and revokeBodyTemplate in provider serializer and CLI

### DIFF
--- a/assistant/src/__tests__/oauth-cli.test.ts
+++ b/assistant/src/__tests__/oauth-cli.test.ts
@@ -186,6 +186,10 @@ mock.module("../oauth/oauth-store.js", () => ({
         : null,
       pingBody:
         params.pingBody !== undefined ? JSON.stringify(params.pingBody) : null,
+      revokeUrl: (params.revokeUrl as string | undefined) ?? null,
+      revokeBodyTemplate: params.revokeBodyTemplate
+        ? JSON.stringify(params.revokeBodyTemplate)
+        : null,
       managedServiceConfigKey: params.managedServiceConfigKey ?? null,
       displayLabel: params.displayLabel ?? null,
       description: params.description ?? null,
@@ -234,6 +238,12 @@ mock.module("../oauth/oauth-store.js", () => ({
     }
     if (params.refreshUrl !== undefined) {
       updated.refreshUrl = params.refreshUrl;
+    }
+    if (params.revokeUrl !== undefined) {
+      updated.revokeUrl = params.revokeUrl;
+    }
+    if (params.revokeBodyTemplate !== undefined) {
+      updated.revokeBodyTemplate = JSON.stringify(params.revokeBodyTemplate);
     }
     if (params.defaultScopes !== undefined) {
       updated.defaultScopes = JSON.stringify(params.defaultScopes);
@@ -1643,5 +1653,217 @@ describe("assistant oauth providers --refresh-url", () => {
     expect(exitCode).toBe(0);
     const parsed = JSON.parse(stdout);
     expect(parsed.refreshUrl).toBe("https://refresh.example.com/token");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// providers register / update / get — --revoke-url and --revoke-body-template wiring
+// ---------------------------------------------------------------------------
+
+describe("assistant oauth providers --revoke-url and --revoke-body-template", () => {
+  beforeEach(() => {
+    mockWithValidToken = async (_service, cb) => cb("mock-access-token-xyz");
+    mockProviderStore.clear();
+    mockGetProvider = () => undefined;
+    mockGetConfig = () => ({ services: {} });
+  });
+
+  afterEach(() => {
+    mockProviderStore.clear();
+    mockGetProvider = () => undefined;
+  });
+
+  test("providers register --revoke-url and --revoke-body-template stores both fields", async () => {
+    const { exitCode } = await runCli([
+      "providers",
+      "register",
+      "--provider-key",
+      "custom-revoke-roundtrip",
+      "--auth-url",
+      "https://example.com/oauth/authorize",
+      "--token-url",
+      "https://example.com/oauth/token",
+      "--revoke-url",
+      "https://revoke.example.com",
+      "--revoke-body-template",
+      '{"token":"{access_token}"}',
+      "--json",
+    ]);
+    expect(exitCode).toBe(0);
+    const stored = mockProviderStore.get("custom-revoke-roundtrip");
+    expect(stored).toBeDefined();
+    expect(stored?.revokeUrl).toBe("https://revoke.example.com");
+    // revokeBodyTemplate is JSON-stringified at the storage layer.
+    expect(JSON.parse(stored?.revokeBodyTemplate as string)).toEqual({
+      token: "{access_token}",
+    });
+  });
+
+  test("providers register without --revoke-url or --revoke-body-template stores both as null", async () => {
+    const { exitCode } = await runCli([
+      "providers",
+      "register",
+      "--provider-key",
+      "custom-no-revoke",
+      "--auth-url",
+      "https://example.com/oauth/authorize",
+      "--token-url",
+      "https://example.com/oauth/token",
+      "--json",
+    ]);
+    expect(exitCode).toBe(0);
+    const stored = mockProviderStore.get("custom-no-revoke");
+    expect(stored).toBeDefined();
+    expect(stored?.revokeUrl).toBeNull();
+    expect(stored?.revokeBodyTemplate).toBeNull();
+  });
+
+  test("providers register with malformed --revoke-body-template fails with a JSON parse error", async () => {
+    const { exitCode, stdout } = await runCli([
+      "providers",
+      "register",
+      "--provider-key",
+      "custom-bad-revoke",
+      "--auth-url",
+      "https://example.com/oauth/authorize",
+      "--token-url",
+      "https://example.com/oauth/token",
+      "--revoke-body-template",
+      "not-json{",
+      "--json",
+    ]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    // The error message comes from JSON.parse — match permissively.
+    expect(parsed.error).toMatch(/JSON|Unexpected|parse/i);
+    // Provider should not have been written.
+    expect(mockProviderStore.get("custom-bad-revoke")).toBeUndefined();
+  });
+
+  test("providers update --revoke-url updates only the URL", async () => {
+    // Seed an existing custom provider.
+    await runCli([
+      "providers",
+      "register",
+      "--provider-key",
+      "custom-update-revoke-url",
+      "--auth-url",
+      "https://example.com/oauth/authorize",
+      "--token-url",
+      "https://example.com/oauth/token",
+      "--json",
+    ]);
+    expect(
+      mockProviderStore.get("custom-update-revoke-url")?.revokeUrl,
+    ).toBeNull();
+
+    const { exitCode } = await runCli([
+      "providers",
+      "update",
+      "custom-update-revoke-url",
+      "--revoke-url",
+      "https://new-revoke.example.com",
+      "--json",
+    ]);
+    expect(exitCode).toBe(0);
+    expect(mockProviderStore.get("custom-update-revoke-url")?.revokeUrl).toBe(
+      "https://new-revoke.example.com",
+    );
+    // revokeBodyTemplate should still be null (unchanged).
+    expect(
+      mockProviderStore.get("custom-update-revoke-url")?.revokeBodyTemplate,
+    ).toBeNull();
+  });
+
+  test("providers update --revoke-body-template updates only the template (JSON round-trip)", async () => {
+    await runCli([
+      "providers",
+      "register",
+      "--provider-key",
+      "custom-update-revoke-body",
+      "--auth-url",
+      "https://example.com/oauth/authorize",
+      "--token-url",
+      "https://example.com/oauth/token",
+      "--json",
+    ]);
+
+    const { exitCode } = await runCli([
+      "providers",
+      "update",
+      "custom-update-revoke-body",
+      "--revoke-body-template",
+      '{"token":"{access_token}","client_id":"{client_id}"}',
+      "--json",
+    ]);
+    expect(exitCode).toBe(0);
+    const stored = mockProviderStore.get("custom-update-revoke-body");
+    expect(stored).toBeDefined();
+    expect(JSON.parse(stored?.revokeBodyTemplate as string)).toEqual({
+      token: "{access_token}",
+      client_id: "{client_id}",
+    });
+    // revokeUrl should still be null (unchanged).
+    expect(stored?.revokeUrl).toBeNull();
+  });
+
+  test("providers get google --json includes both fields populated from PR 1's seed data", async () => {
+    // Simulate the seeded "google" provider row by overriding mockGetProvider
+    // to return a row matching what PR 1's seed inserts.
+    const now = Date.now();
+    mockGetProvider = (provider: string) => {
+      if (provider !== "google") return undefined;
+      return {
+        provider: "google",
+        authorizeUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+        tokenExchangeUrl: "https://oauth2.googleapis.com/token",
+        refreshUrl: null,
+        tokenEndpointAuthMethod: null,
+        userinfoUrl: null,
+        baseUrl: null,
+        defaultScopes: "[]",
+        scopePolicy: "{}",
+        scopeSeparator: " ",
+        authorizeParams: null,
+        pingUrl: null,
+        pingMethod: null,
+        pingHeaders: null,
+        pingBody: null,
+        revokeUrl: "https://oauth2.googleapis.com/revoke",
+        revokeBodyTemplate: JSON.stringify({ token: "{access_token}" }),
+        managedServiceConfigKey: null,
+        displayLabel: "Google",
+        description: null,
+        dashboardUrl: null,
+        clientIdPlaceholder: null,
+        requiresClientSecret: 1,
+        loopbackPort: null,
+        injectionTemplates: null,
+        appType: null,
+        setupNotes: null,
+        identityUrl: null,
+        identityMethod: null,
+        identityHeaders: null,
+        identityBody: null,
+        identityResponsePaths: null,
+        identityFormat: null,
+        identityOkField: null,
+        featureFlag: null,
+        createdAt: now,
+        updatedAt: now,
+      };
+    };
+
+    const { exitCode, stdout } = await runCli([
+      "providers",
+      "get",
+      "google",
+      "--json",
+    ]);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.revokeUrl).toBe("https://oauth2.googleapis.com/revoke");
+    expect(parsed.revokeBodyTemplate).toEqual({ token: "{access_token}" });
   });
 });

--- a/assistant/src/__tests__/oauth-cli.test.ts
+++ b/assistant/src/__tests__/oauth-cli.test.ts
@@ -1776,6 +1776,45 @@ describe("assistant oauth providers --revoke-url and --revoke-body-template", ()
     ).toBeNull();
   });
 
+  test("providers update --revoke-url with empty string clears the stored URL to null", async () => {
+    // Seed an existing custom provider that already has a non-null revokeUrl.
+    await runCli([
+      "providers",
+      "register",
+      "--provider-key",
+      "custom-clear-revoke-url",
+      "--auth-url",
+      "https://example.com/oauth/authorize",
+      "--token-url",
+      "https://example.com/oauth/token",
+      "--revoke-url",
+      "https://revoke.example.com",
+      "--json",
+    ]);
+    expect(mockProviderStore.get("custom-clear-revoke-url")?.revokeUrl).toBe(
+      "https://revoke.example.com",
+    );
+
+    // Pass an empty string to --revoke-url — the help text promises this
+    // clears the field, so the stored value should end up as null (not "").
+    const { exitCode, stdout } = await runCli([
+      "providers",
+      "update",
+      "custom-clear-revoke-url",
+      "--revoke-url",
+      "",
+      "--json",
+    ]);
+    expect(exitCode).toBe(0);
+    expect(
+      mockProviderStore.get("custom-clear-revoke-url")?.revokeUrl,
+    ).toBeNull();
+
+    // The serialized --json output should also reflect null, not "".
+    const parsed = JSON.parse(stdout);
+    expect(parsed.revokeUrl).toBeNull();
+  });
+
   test("providers update --revoke-body-template updates only the template (JSON round-trip)", async () => {
     await runCli([
       "providers",

--- a/assistant/src/__tests__/oauth-provider-serializer.test.ts
+++ b/assistant/src/__tests__/oauth-provider-serializer.test.ts
@@ -197,6 +197,46 @@ describe("serializeProvider", () => {
     const result = serializeProvider(row)!;
     expect(result.refreshUrl).toBeNull();
   });
+
+  test("emits revokeUrl from the row and parses revokeBodyTemplate JSON", () => {
+    const row = makeRow({
+      revokeUrl: "https://revoke.example.com",
+      revokeBodyTemplate: JSON.stringify({ token: "{access_token}" }),
+    });
+    const result = serializeProvider(row)!;
+    expect(result.revokeUrl).toBe("https://revoke.example.com");
+    expect(result.revokeBodyTemplate).toEqual({ token: "{access_token}" });
+    // Make sure it's a parsed object, not a string.
+    expect(typeof result.revokeBodyTemplate).toBe("object");
+    expect(result.revokeBodyTemplate).not.toBe(
+      JSON.stringify({ token: "{access_token}" }),
+    );
+  });
+
+  test("emits revokeUrl and revokeBodyTemplate as null when the row values are null", () => {
+    const row = makeRow({
+      revokeUrl: null,
+      revokeBodyTemplate: null,
+    });
+    const result = serializeProvider(row)!;
+    expect(result.revokeUrl).toBeNull();
+    expect(result.revokeBodyTemplate).toBeNull();
+  });
+
+  test("preserves all keys in a complex revokeBodyTemplate", () => {
+    const template = {
+      token: "{access_token}",
+      client_id: "{client_id}",
+      token_type_hint: "access_token",
+      extra_field: "static-value",
+    };
+    const row = makeRow({
+      revokeUrl: "https://revoke.example.com/oauth/revoke",
+      revokeBodyTemplate: JSON.stringify(template),
+    });
+    const result = serializeProvider(row)!;
+    expect(result.revokeBodyTemplate).toEqual(template);
+  });
 });
 
 describe("serializeProviderSummary", () => {
@@ -273,5 +313,17 @@ describe("serializeProviderSummary", () => {
     const result = serializeProviderSummary(row)!;
     expect(result).not.toHaveProperty("refresh_url");
     expect(result).not.toHaveProperty("refreshUrl");
+  });
+
+  test("does NOT include revoke_url or revoke_body_template (internal protocol details)", () => {
+    const row = makeRow({
+      revokeUrl: "https://revoke.example.com",
+      revokeBodyTemplate: JSON.stringify({ token: "{access_token}" }),
+    });
+    const result = serializeProviderSummary(row)!;
+    expect(result).not.toHaveProperty("revoke_url");
+    expect(result).not.toHaveProperty("revokeUrl");
+    expect(result).not.toHaveProperty("revoke_body_template");
+    expect(result).not.toHaveProperty("revokeBodyTemplate");
   });
 });

--- a/assistant/src/__tests__/oauth-provider-serializer.test.ts
+++ b/assistant/src/__tests__/oauth-provider-serializer.test.ts
@@ -223,6 +223,16 @@ describe("serializeProvider", () => {
     expect(result.revokeBodyTemplate).toBeNull();
   });
 
+  test("normalizes empty string revokeUrl to null on the serialized output", () => {
+    // Legacy rows or rows that reached the store via an empty-string update
+    // may persist `revokeUrl: ""`. The serializer should normalize this to
+    // null so wire consumers (CLI --json, HTTP API) see a consistent
+    // "disabled" signal.
+    const row = makeRow({ revokeUrl: "" });
+    const result = serializeProvider(row)!;
+    expect(result.revokeUrl).toBeNull();
+  });
+
   test("preserves all keys in a complex revokeBodyTemplate", () => {
     const template = {
       token: "{access_token}",

--- a/assistant/src/cli/commands/oauth/providers.ts
+++ b/assistant/src/cli/commands/oauth/providers.ts
@@ -255,6 +255,14 @@ Examples:
       'JSON body to send with the ping request (e.g. \'{"query":"{ viewer { id } }"}\')',
     )
     .option(
+      "--revoke-url <url>",
+      'OAuth token revocation endpoint URL. Called best-effort during disconnect to invalidate the access token upstream (e.g. "https://oauth2.googleapis.com/revoke"). When omitted, disconnect is local-only — the upstream token is left valid until it naturally expires.',
+    )
+    .option(
+      "--revoke-body-template <json>",
+      'JSON object body template for the revoke request, supporting {access_token} and {client_id} substitution (e.g. \'{"token":"{access_token}","client_id":"{client_id}"}\'). The body is form-encoded and POSTed to --revoke-url.',
+    )
+    .option(
       "--display-name <name>",
       "Human-readable display name for the provider",
     )
@@ -366,7 +374,13 @@ Examples:
       --loopback-port 17400 \\
       --injection-templates '[{"hostPattern":"api.example.com","injectionType":"header","headerName":"Authorization","valuePrefix":"Bearer "}]' \\
       --identity-url https://api.example.com/me \\
-      --identity-response-paths email,name`,
+      --identity-response-paths email,name
+  $ assistant oauth providers register \\
+      --provider-key custom-revokable \\
+      --auth-url https://example.com/oauth/authorize \\
+      --token-url https://example.com/oauth/token \\
+      --revoke-url https://example.com/oauth/revoke \\
+      --revoke-body-template '{"token":"{access_token}","client_id":"{client_id}"}'`,
     )
     .action(
       (
@@ -384,6 +398,8 @@ Examples:
           pingMethod?: string;
           pingHeaders?: string;
           pingBody?: string;
+          revokeUrl?: string;
+          revokeBodyTemplate?: string;
           displayName?: string;
           description?: string;
           dashboardUrl?: string;
@@ -421,6 +437,10 @@ Examples:
               ? JSON.parse(opts.pingHeaders)
               : undefined,
             pingBody: opts.pingBody ? JSON.parse(opts.pingBody) : undefined,
+            revokeUrl: opts.revokeUrl,
+            revokeBodyTemplate: opts.revokeBodyTemplate
+              ? JSON.parse(opts.revokeBodyTemplate)
+              : undefined,
             displayLabel: opts.displayName,
             description: opts.description,
             dashboardUrl: opts.dashboardUrl,
@@ -513,6 +533,14 @@ Examples:
       'JSON body to send with the ping request (e.g. \'{"query":"{ viewer { id } }"}\')',
     )
     .option(
+      "--revoke-url <url>",
+      "OAuth token revocation endpoint URL. Called best-effort during disconnect to invalidate the access token upstream. Pass an empty string to clear.",
+    )
+    .option(
+      "--revoke-body-template <json>",
+      "JSON object body template for the revoke request, supporting {access_token} and {client_id} substitution.",
+    )
+    .option(
       "--display-name <name>",
       "Human-readable display name for the provider",
     )
@@ -599,7 +627,10 @@ Examples:
       --identity-url https://api.example.com/me \\
       --identity-response-paths email,name
   $ assistant oauth providers update custom-api \\
-      --injection-templates '[{"hostPattern":"api.example.com","injectionType":"header","headerName":"Authorization","valuePrefix":"Bearer "}]'`,
+      --injection-templates '[{"hostPattern":"api.example.com","injectionType":"header","headerName":"Authorization","valuePrefix":"Bearer "}]'
+  $ assistant oauth providers update custom-api \\
+      --revoke-url https://api.example.com/oauth/revoke \\
+      --revoke-body-template '{"token":"{access_token}"}'`,
     )
     .action(
       (
@@ -617,6 +648,8 @@ Examples:
           pingMethod?: string;
           pingHeaders?: string;
           pingBody?: string;
+          revokeUrl?: string;
+          revokeBodyTemplate?: string;
           displayName?: string;
           description?: string;
           dashboardUrl?: string;
@@ -691,6 +724,9 @@ Examples:
             params.pingHeaders = JSON.parse(opts.pingHeaders);
           if (opts.pingBody !== undefined)
             params.pingBody = JSON.parse(opts.pingBody);
+          if (opts.revokeUrl !== undefined) params.revokeUrl = opts.revokeUrl;
+          if (opts.revokeBodyTemplate !== undefined)
+            params.revokeBodyTemplate = JSON.parse(opts.revokeBodyTemplate);
           if (opts.displayName !== undefined)
             params.displayLabel = opts.displayName;
           if (opts.description !== undefined)

--- a/assistant/src/cli/commands/oauth/providers.ts
+++ b/assistant/src/cli/commands/oauth/providers.ts
@@ -724,7 +724,13 @@ Examples:
             params.pingHeaders = JSON.parse(opts.pingHeaders);
           if (opts.pingBody !== undefined)
             params.pingBody = JSON.parse(opts.pingBody);
-          if (opts.revokeUrl !== undefined) params.revokeUrl = opts.revokeUrl;
+          if (opts.revokeUrl !== undefined) {
+            // Empty string means "clear" — normalize to null so the stored
+            // value matches the "disabled" semantics documented in the help
+            // text. `updateProvider`'s Partial type accepts `string | null`
+            // for this field so drizzle writes `null` to clear the column.
+            params.revokeUrl = opts.revokeUrl === "" ? null : opts.revokeUrl;
+          }
           if (opts.revokeBodyTemplate !== undefined)
             params.revokeBodyTemplate = JSON.parse(opts.revokeBodyTemplate);
           if (opts.displayName !== undefined)

--- a/assistant/src/oauth/oauth-store.ts
+++ b/assistant/src/oauth/oauth-store.ts
@@ -394,7 +394,7 @@ export function updateProvider(
     pingMethod: string;
     pingHeaders: Record<string, string>;
     pingBody: unknown;
-    revokeUrl: string;
+    revokeUrl: string | null;
     revokeBodyTemplate: Record<string, string>;
     baseUrl: string;
     defaultScopes: string[];

--- a/assistant/src/oauth/provider-serializer.ts
+++ b/assistant/src/oauth/provider-serializer.ts
@@ -90,7 +90,7 @@ function _serializeProvider(
     extraParams: authorizeParams ? JSON.parse(authorizeParams) : null,
     pingHeaders: row.pingHeaders ? JSON.parse(row.pingHeaders) : null,
     pingBody: row.pingBody ? JSON.parse(row.pingBody) : null,
-    revokeUrl: row.revokeUrl ?? null,
+    revokeUrl: row.revokeUrl || null,
     revokeBodyTemplate: row.revokeBodyTemplate
       ? JSON.parse(row.revokeBodyTemplate)
       : null,

--- a/assistant/src/oauth/provider-serializer.ts
+++ b/assistant/src/oauth/provider-serializer.ts
@@ -90,6 +90,10 @@ function _serializeProvider(
     extraParams: authorizeParams ? JSON.parse(authorizeParams) : null,
     pingHeaders: row.pingHeaders ? JSON.parse(row.pingHeaders) : null,
     pingBody: row.pingBody ? JSON.parse(row.pingBody) : null,
+    revokeUrl: row.revokeUrl ?? null,
+    revokeBodyTemplate: row.revokeBodyTemplate
+      ? JSON.parse(row.revokeBodyTemplate)
+      : null,
     loopbackPort: row.loopbackPort ?? null,
     injectionTemplates: row.injectionTemplates
       ? JSON.parse(row.injectionTemplates)


### PR DESCRIPTION
## Summary
- Emit revokeUrl + parsed revokeBodyTemplate from _serializeProvider
- Add --revoke-url and --revoke-body-template flags to providers register and providers update
- Summary serializer unchanged (revoke config is internal protocol detail)

Part of plan: revoke-token-parity.md (PR 3 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24213" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
