### PR TITLE
fix: use correct input property name (path not file_path) in derefToolResultReReads

### DIFF
--- a/assistant/src/__tests__/post-turn-tool-result-truncation.test.ts
+++ b/assistant/src/__tests__/post-turn-tool-result-truncation.test.ts
@@ -179,7 +179,7 @@ describe("derefToolResultReReads", () => {
         role: "assistant",
         content: [
           makeToolUse(toolUseId, "file_read", {
-            file_path: `/home/user/.vellum/workspace/conversations/abc/${TOOL_RESULT_DIR}/abc123.txt`,
+            path: `/home/user/.vellum/workspace/conversations/abc/${TOOL_RESULT_DIR}/abc123.txt`,
           }),
         ],
       },
@@ -205,7 +205,7 @@ describe("derefToolResultReReads", () => {
         role: "assistant",
         content: [
           makeToolUse(toolUseId, "file_read", {
-            file_path: "src/foo.ts",
+            path: "src/foo.ts",
           }),
         ],
       },
@@ -260,13 +260,13 @@ describe("derefToolResultReReads", () => {
         role: "assistant",
         content: [
           makeToolUse(tu1, "file_read", {
-            file_path: `/workspace/conv/${TOOL_RESULT_DIR}/aaa.txt`,
+            path: `/workspace/conv/${TOOL_RESULT_DIR}/aaa.txt`,
           }),
           makeToolUse(tu2, "file_read", {
-            file_path: `/workspace/conv/${TOOL_RESULT_DIR}/bbb.txt`,
+            path: `/workspace/conv/${TOOL_RESULT_DIR}/bbb.txt`,
           }),
           makeToolUse(tuNormal, "file_read", {
-            file_path: "src/bar.ts",
+            path: "src/bar.ts",
           }),
         ],
       },

--- a/assistant/src/context/post-turn-tool-result-truncation.ts
+++ b/assistant/src/context/post-turn-tool-result-truncation.ts
@@ -135,7 +135,7 @@ export function derefToolResultReReads(messages: Message[]): {
       if (block.type !== "tool_use") continue;
       const tu = block as ToolUseContent;
       if (tu.name !== "file_read") continue;
-      const filePath = tu.input.file_path;
+      const filePath = tu.input.path;
       if (typeof filePath !== "string") continue;
       if (filePath.includes(`/${TOOL_RESULT_DIR}/`)) {
         reReadToolUseIds.add(tu.id);


### PR DESCRIPTION
## Summary
Fixes bug where derefToolResultReReads was dead code in production.

**Bug:** The dedup function read tu.input.file_path but the file_read tool schema uses path as the property name
**Fix:** Changed to tu.input.path in implementation and updated all test fixtures to match
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24215" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
