### PR TITLE
feat: add fork configuration to sub-agent types

### DIFF
--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -1521,6 +1521,7 @@ function makeSubagentState(
     },
     status: overrides.status ?? "running",
     conversationId: `conv-${overrides.id}`,
+    isFork: overrides.isFork ?? false,
     createdAt: overrides.createdAt ?? Date.now() - 60_000,
     startedAt: overrides.startedAt ?? Date.now() - 55_000,
     completedAt: overrides.completedAt,

--- a/assistant/src/__tests__/subagent-disposal.test.ts
+++ b/assistant/src/__tests__/subagent-disposal.test.ts
@@ -89,6 +89,7 @@ function makeState(
     },
     status: "running",
     conversationId: "conv-sub-1",
+    isFork: false,
     createdAt: Date.now(),
     usage: { inputTokens: 0, outputTokens: 0, estimatedCost: 0 },
     ...overrides,

--- a/assistant/src/__tests__/subagent-manager-notify.test.ts
+++ b/assistant/src/__tests__/subagent-manager-notify.test.ts
@@ -87,6 +87,7 @@ function makeState(
     },
     status: "running",
     conversationId: "conv-sub-1",
+    isFork: false,
     createdAt: Date.now(),
     usage: { inputTokens: 0, outputTokens: 0, estimatedCost: 0 },
     ...overrides,

--- a/assistant/src/__tests__/subagent-notify-parent.test.ts
+++ b/assistant/src/__tests__/subagent-notify-parent.test.ts
@@ -70,6 +70,7 @@ function injectSubagent(
     },
     status,
     conversationId: `conv-${subagentId}`,
+    isFork: false,
     createdAt: Date.now(),
     usage: { inputTokens: 0, outputTokens: 0, estimatedCost: 0 },
     ...overrides,

--- a/assistant/src/__tests__/subagent-tools.test.ts
+++ b/assistant/src/__tests__/subagent-tools.test.ts
@@ -86,6 +86,7 @@ function injectSubagent(
     },
     status,
     conversationId: `conv-${subagentId}`,
+    isFork: false,
     createdAt: Date.now(),
     usage: { inputTokens: 0, outputTokens: 0, estimatedCost: 0 },
     ...overrides,

--- a/assistant/src/__tests__/subagent-types.test.ts
+++ b/assistant/src/__tests__/subagent-types.test.ts
@@ -68,6 +68,7 @@ describe("SubagentState type shape", () => {
       },
       status: "pending" as SubagentStatus,
       conversationId: "conv-id",
+      isFork: false,
       createdAt: Date.now(),
       usage: { inputTokens: 0, outputTokens: 0, estimatedCost: 0 },
     };

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -212,6 +212,7 @@ export class SubagentManager {
       config: { ...config, id: subagentId },
       status: "pending",
       conversationId: conversationRecord.id,
+      isFork: config.fork ?? false,
       createdAt: now,
       usage: { inputTokens: 0, outputTokens: 0, estimatedCost: 0 },
     };

--- a/assistant/src/subagent/types.ts
+++ b/assistant/src/subagent/types.ts
@@ -7,6 +7,7 @@
  */
 
 import type { UsageStats } from "../daemon/message-protocol.js";
+import type { Message } from "../providers/types.js";
 
 // ── Status ──────────────────────────────────────────────────────────────
 
@@ -43,6 +44,22 @@ export interface SubagentConfig {
   sendResultToUser?: boolean;
   /** Optional role for the subagent. Defaults handled by consumers. */
   role?: SubagentRole;
+  /**
+   * When true, the sub-agent inherits the parent's full context instead of
+   * receiving only the objective + context fields.
+   */
+  fork?: boolean;
+  /**
+   * The parent conversation's in-memory message history at fork time.
+   * Only set when `fork: true`.
+   */
+  parentMessages?: Message[];
+  /**
+   * The parent's current resolved system prompt. Only set when `fork: true`.
+   * Distinct from `systemPromptOverride` which replaces the subagent-built prompt;
+   * for forks, this IS the system prompt (no subagent preamble is built).
+   */
+  parentSystemPrompt?: string;
 }
 
 // ── State (runtime) ─────────────────────────────────────────────────────
@@ -52,6 +69,8 @@ export interface SubagentState {
   status: SubagentStatus;
   /** The subagent's own conversationId (different from parentConversationId). */
   conversationId: string;
+  /** Whether this sub-agent is a fork (inherits parent context). Defaults to `false`. */
+  isFork: boolean;
   /** Error message if status is 'failed'. */
   error?: string;
   /** Timestamps (epoch ms). */


### PR DESCRIPTION
## Summary
- Add fork?, parentMessages?, and parentSystemPrompt? fields to SubagentConfig
- Add isFork field to SubagentState for runtime fork identification

Part of plan: subagent-context-forking.md (PR 1 of 5)