### PR TITLE
feat: add in-memory context injection to Conversation

### DIFF
--- a/assistant/src/__tests__/conversation-inject-context.test.ts
+++ b/assistant/src/__tests__/conversation-inject-context.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "bun:test";
+
+import type { Message } from "../providers/types.js";
+
+/**
+ * Unit tests for Conversation.injectInheritedContext() and
+ * Conversation.getCurrentSystemPrompt().
+ *
+ * These methods are thin enough to test via a minimal stub that mirrors the
+ * Conversation fields they touch, avoiding the heavyweight constructor
+ * dependencies.
+ */
+
+/**
+ * Minimal stub that replicates the subset of Conversation used by
+ * injectInheritedContext() and getCurrentSystemPrompt().
+ */
+function createStub(systemPrompt: string) {
+  return {
+    messages: [] as Message[],
+    systemPrompt,
+
+    injectInheritedContext(messages: Message[]): void {
+      if (this.messages.length !== 0) {
+        throw new Error(
+          "injectInheritedContext must be called before any messages have been added",
+        );
+      }
+      this.messages = [...messages];
+    },
+
+    getCurrentSystemPrompt(): string {
+      return this.systemPrompt;
+    },
+  };
+}
+
+const sampleMessages: Message[] = [
+  { role: "user", content: [{ type: "text", text: "Hello from parent" }] },
+  {
+    role: "assistant",
+    content: [{ type: "text", text: "Hi there, I am the assistant" }],
+  },
+  {
+    role: "user",
+    content: [{ type: "text", text: "Follow-up question" }],
+  },
+];
+
+describe("Conversation.injectInheritedContext", () => {
+  test("injected messages appear in this.messages after injection", () => {
+    const stub = createStub("You are a helpful assistant.");
+    stub.injectInheritedContext(sampleMessages);
+
+    expect(stub.messages).toHaveLength(3);
+    expect(stub.messages[0]).toEqual(sampleMessages[0]);
+    expect(stub.messages[1]).toEqual(sampleMessages[1]);
+    expect(stub.messages[2]).toEqual(sampleMessages[2]);
+  });
+
+  test("injected messages are a shallow copy, not the same array reference", () => {
+    const stub = createStub("prompt");
+    stub.injectInheritedContext(sampleMessages);
+
+    expect(stub.messages).not.toBe(sampleMessages);
+    // Individual message objects are shared (shallow copy)
+    expect(stub.messages[0]).toBe(sampleMessages[0]);
+  });
+
+  test("assertion fires if called after messages have been added", () => {
+    const stub = createStub("prompt");
+    // Simulate a message already being present (as if persistUserMessage was called)
+    stub.messages.push({
+      role: "user",
+      content: [{ type: "text", text: "existing message" }],
+    });
+
+    expect(() => stub.injectInheritedContext(sampleMessages)).toThrow(
+      "injectInheritedContext must be called before any messages have been added",
+    );
+  });
+
+  test("injecting an empty array leaves messages empty", () => {
+    const stub = createStub("prompt");
+    stub.injectInheritedContext([]);
+
+    expect(stub.messages).toHaveLength(0);
+  });
+});
+
+describe("Conversation.getCurrentSystemPrompt", () => {
+  test("returns the construction-time system prompt", () => {
+    const prompt = "You are a research assistant with deep knowledge.";
+    const stub = createStub(prompt);
+
+    expect(stub.getCurrentSystemPrompt()).toBe(prompt);
+  });
+
+  test("returns empty string when constructed with empty prompt", () => {
+    const stub = createStub("");
+    expect(stub.getCurrentSystemPrompt()).toBe("");
+  });
+});

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -553,6 +553,34 @@ export class Conversation {
     this.isSubagent = value;
   }
 
+  /**
+   * Prepend inherited parent messages into the in-memory message array so that
+   * the AgentLoop includes them in provider calls (enabling KV cache sharing).
+   *
+   * These messages are NOT persisted to the database — they exist only in
+   * memory. When the conversation is later read from DB via getMessages(),
+   * only the conversation's own persisted messages appear.
+   *
+   * Must be called before the first persistUserMessage() call — i.e. while
+   * `this.messages` is still empty.
+   */
+  injectInheritedContext(messages: Message[]): void {
+    if (this.messages.length !== 0) {
+      throw new Error(
+        "injectInheritedContext must be called before any messages have been added",
+      );
+    }
+    this.messages = [...messages];
+  }
+
+  /**
+   * Return the system prompt string set at construction time (or its override).
+   * Fork consumers use this to pass the parent's system prompt to the fork.
+   */
+  getCurrentSystemPrompt(): string {
+    return this.systemPrompt;
+  }
+
   isProcessing(): boolean {
     return this.processing;
   }


### PR DESCRIPTION
## Summary
- Add injectInheritedContext() for prepending parent messages in-memory without DB persistence
- Add getCurrentSystemPrompt() getter for fork consumers
- Tests for injection, assertion guard, and system prompt access

Part of plan: subagent-context-forking.md (PR 2 of 5)