### PR TITLE
feat(settings): add Debug tab with restart + SSH terminal for cloud-hosted assistants

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -668,7 +668,11 @@ struct ActiveChatViewWrapper: View {
                     settingsStore.exitManagedAssistantRecoveryMode()
                 },
                 onOpenSSHSettings: {
-                    settingsStore.pendingSettingsTab = .developer
+                    // Recovery mode applies only to managed assistants, so the
+                    // Debug tab is always visible here. Route there directly so
+                    // managed users without the developer feature flag aren't
+                    // dropped back to the General tab.
+                    settingsStore.pendingSettingsTab = .debug
                     windowState.selection = .panel(.settings)
                 },
                 anchorMessageId: $anchorMessageId,

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -88,6 +88,12 @@ struct SettingsPanel: View {
         let soundsEnabled = assistantFeatureFlagStore.isEnabled(Self.soundsFeatureFlagKey)
         _isSoundsEnabled = State(initialValue: soundsEnabled)
 
+        // Pre-compute the cloud-hosted flag so first render already shows the
+        // Debug tab when applicable. Synchronous read off AppDelegate — it's
+        // set during connection setup before the settings panel can be opened.
+        let isCloudHosted = AppDelegate.shared?.isCurrentAssistantManaged ?? false
+        _isCurrentAssistantCloudHosted = State(initialValue: isCloudHosted)
+
         // Derive the initial tab from the pending deep-link at construction
         // time. Previous attempts set selectedTab in onAppear / onChange, but
         // those fire *after* the first render and are susceptible to timing
@@ -101,8 +107,16 @@ struct SettingsPanel: View {
             let orgId = UserDefaults.standard.string(forKey: "connectedOrganizationId")
             let canShowBilling = billingEnabled && authManager.isAuthenticated && orgId != nil
             // Contacts and developer flags load asynchronously, so default
-            // to false at init time — those tabs aren't visible yet.
-            let visibleTabs = SettingsTab.primaryTabs(billingEnabled: canShowBilling, soundsEnabled: soundsEnabled, schedulesEnabled: false)
+            // to false at init time — those tabs aren't visible yet. The
+            // Debug tab, however, depends only on the synchronous
+            // AppDelegate.isCurrentAssistantManaged read above, so a
+            // .debug deep-link can be honored on the first render.
+            let visibleTabs = SettingsTab.primaryTabs(
+                billingEnabled: canShowBilling,
+                soundsEnabled: soundsEnabled,
+                schedulesEnabled: false,
+                debugEnabled: isCloudHosted
+            )
             if visibleTabs.contains(pending) {
                 _selectedTab = State(initialValue: pending)
             } else {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -10,6 +10,7 @@ enum SettingsTab: String {
     case billing = "Billing"
     case archivedConversations = "Archive"
     case schedules = "Schedules"
+    case debug = "Debug"
     case developer = "Developer"
 
     var icon: VIcon {
@@ -22,18 +23,25 @@ enum SettingsTab: String {
         case .billing: return .creditCard
         case .archivedConversations: return .archive
         case .schedules: return .calendar
+        case .debug: return .bug
         case .developer: return .terminal
         }
     }
 
     /// Primary tabs shown in the main nav list (excludes feature-flagged bottom tabs).
-    static func primaryTabs(billingEnabled: Bool = false, soundsEnabled: Bool = true, schedulesEnabled: Bool = false) -> [SettingsTab] {
+    static func primaryTabs(
+        billingEnabled: Bool = false,
+        soundsEnabled: Bool = true,
+        schedulesEnabled: Bool = false,
+        debugEnabled: Bool = false
+    ) -> [SettingsTab] {
         var tabs: [SettingsTab] = [.general, .modelsAndServices, .voice]
         if soundsEnabled { tabs.append(.sounds) }
         if billingEnabled { tabs.append(.billing) }
         tabs.append(.permissionsAndPrivacy)
         tabs.append(.archivedConversations)
         if schedulesEnabled { tabs.append(.schedules) }
+        if debugEnabled { tabs.append(.debug) }
         return tabs
     }
 }
@@ -127,6 +135,9 @@ struct SettingsPanel: View {
     @State private var isSchedulesEnabled: Bool = false
     @State private var isDeveloperEnabled: Bool = false
     @State private var isSoundsEnabled: Bool = true
+    /// `true` when the current assistant is cloud-hosted/platform-managed.
+    /// Drives visibility of the Debug tab (which contains restart + SSH terminal).
+    @State private var isCurrentAssistantCloudHosted: Bool = false
     @State private var isEmbeddingProviderEnabled: Bool = false
     @State private var isIntegrationsGridEnabled: Bool = false
     @State private var showingDevUnlock: Bool = false
@@ -198,6 +209,7 @@ struct SettingsPanel: View {
             isSoundsEnabled = assistantFeatureFlagStore.isEnabled(Self.soundsFeatureFlagKey)
             isSchedulesEnabled = assistantFeatureFlagStore.isEnabled(Self.schedulesFeatureFlagKey)
             isIntegrationsGridEnabled = assistantFeatureFlagStore.isEnabled(Self.integrationsGridFeatureFlagKey)
+            isCurrentAssistantCloudHosted = AppDelegate.shared?.isCurrentAssistantManaged ?? false
             // The init already consumed pendingSettingsTab into selectedTab.
             // Clear the store value so it doesn't leak into future navigations.
             if store.pendingSettingsTab != nil {
@@ -212,8 +224,12 @@ struct SettingsPanel: View {
                 // the flag manager directly avoids a stale billingVisible.
                 let billingEnabled = MacOSClientFeatureFlagManager.shared.isEnabled(Self.billingFeatureFlagKey)
                 let canShowBilling = billingEnabled && authManager.isAuthenticated && connectedOrgId != nil
-                let visibleTabs = SettingsTab.primaryTabs(billingEnabled: canShowBilling, soundsEnabled: isSoundsEnabled, schedulesEnabled: isSchedulesEnabled)
-                    + (isDeveloperEnabled ? [.developer] : [])
+                let visibleTabs = SettingsTab.primaryTabs(
+                    billingEnabled: canShowBilling,
+                    soundsEnabled: isSoundsEnabled,
+                    schedulesEnabled: isSchedulesEnabled,
+                    debugEnabled: isCurrentAssistantCloudHosted
+                ) + (isDeveloperEnabled ? [.developer] : [])
                 if visibleTabs.contains(tab) {
                     selectedTab = tab
                 }
@@ -338,7 +354,12 @@ struct SettingsPanel: View {
 
     /// All currently visible tabs (primary + gated bottom tabs).
     private var allVisibleTabs: [SettingsTab] {
-        var tabs = SettingsTab.primaryTabs(billingEnabled: billingVisible, soundsEnabled: isSoundsEnabled, schedulesEnabled: isSchedulesEnabled)
+        var tabs = SettingsTab.primaryTabs(
+            billingEnabled: billingVisible,
+            soundsEnabled: isSoundsEnabled,
+            schedulesEnabled: isSchedulesEnabled,
+            debugEnabled: isCurrentAssistantCloudHosted
+        )
         if isDeveloperEnabled {
             tabs.append(.developer)
         }
@@ -353,7 +374,12 @@ struct SettingsPanel: View {
 
     private var settingsNav: some View {
         VStack(alignment: .leading, spacing: VSpacing.xs) {
-            ForEach(SettingsTab.primaryTabs(billingEnabled: billingVisible, soundsEnabled: isSoundsEnabled, schedulesEnabled: isSchedulesEnabled), id: \.self) { tab in
+            ForEach(SettingsTab.primaryTabs(
+                billingEnabled: billingVisible,
+                soundsEnabled: isSoundsEnabled,
+                schedulesEnabled: isSchedulesEnabled,
+                debugEnabled: isCurrentAssistantCloudHosted
+            ), id: \.self) { tab in
                 VNavItem(icon: tab.icon.rawValue, label: tab.rawValue, isActive: selectedTab == tab) {
                     selectedTab = tab
                 }
@@ -415,6 +441,8 @@ struct SettingsPanel: View {
             SettingsArchivedConversationsTab(conversationManager: conversationManager)
         case .schedules:
             SettingsSchedulesTab()
+        case .debug:
+            SettingsDebugTab(store: store)
         case .developer:
             SettingsDeveloperTab(store: store, connectionManager: connectionManager, authManager: authManager, onClose: onClose)
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadWindow.swift
@@ -218,7 +218,11 @@ private struct ThreadWindowContentView: View {
                         settingsStore.exitManagedAssistantRecoveryMode()
                     },
                     onOpenSSHSettings: {
-                        settingsStore.pendingSettingsTab = .developer
+                        // Recovery mode applies only to managed assistants, so
+                        // the Debug tab is always visible here. Route there
+                        // directly so managed users without the developer
+                        // feature flag aren't dropped back to General.
+                        settingsStore.pendingSettingsTab = .debug
                         AppDelegate.shared?.showSettingsWindow(nil)
                     },
                     anchorMessageId: $anchorMessageId,

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDebugTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDebugTab.swift
@@ -1,0 +1,199 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Debug settings tab for cloud-hosted/platform-managed assistants. Surfaces
+/// operational controls — restarting the assistant pod and opening an SSH
+/// terminal into the workspace volume via recovery mode — without requiring
+/// the developer feature flag to be enabled.
+@MainActor
+struct SettingsDebugTab: View {
+    @ObservedObject var store: SettingsStore
+
+    @State private var lockfileAssistants: [LockfileAssistant] = []
+    @State private var selectedAssistantId: String = ""
+
+    @State private var showingRestartConfirmation: Bool = false
+    @State private var isRestarting: Bool = false
+
+    private static let terminalWindow = SSHTerminalWindow()
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.lg) {
+            restartAssistantSection
+            sshTerminalSection
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .onAppear {
+            selectedAssistantId = LockfileAssistant.loadActiveAssistantId() ?? ""
+            Task {
+                let assistants = await Task.detached { LockfileAssistant.loadAll() }.value
+                lockfileAssistants = assistants
+            }
+        }
+        .alert("Restart Assistant", isPresented: $showingRestartConfirmation) {
+            Button("Cancel", role: .cancel) {}
+            Button("Restart") {
+                isRestarting = true
+                Task {
+                    await performRestart()
+                    isRestarting = false
+                }
+            }
+        } message: {
+            Text("Are you sure you want to restart the assistant? It will be briefly unavailable.")
+        }
+        .sheet(isPresented: $isRestarting) {
+            VStack(spacing: VSpacing.lg) {
+                ProgressView()
+                    .controlSize(.regular)
+                    .progressViewStyle(.circular)
+                Text("Restarting assistant...")
+                    .font(VFont.bodyMediumDefault)
+                    .foregroundStyle(VColor.contentDefault)
+                Text("The assistant will be briefly unavailable.")
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentTertiary)
+            }
+            .padding(VSpacing.xxl)
+            .frame(minWidth: 260)
+            .interactiveDismissDisabled()
+        }
+    }
+
+    // MARK: - Restart Assistant
+
+    private var restartAssistantSection: some View {
+        SettingsCard(
+            title: "Restart Assistant",
+            subtitle: "The assistant will be briefly unavailable during restart."
+        ) {
+            VButton(label: "Restart", style: .outlined) {
+                showingRestartConfirmation = true
+            }
+        }
+    }
+
+    private func performRestart() async {
+        _ = try? await GatewayHTTPClient.post(path: "assistants/\(selectedAssistantId)/restart")
+        try? await Task.sleep(nanoseconds: 2_000_000_000)
+    }
+
+    // MARK: - SSH Terminal
+
+    /// `true` while either a maintenance-enter or maintenance-exit request is in flight.
+    private var maintenanceTransitionInFlight: Bool {
+        store.recoveryModeEntering || store.recoveryModeExiting
+    }
+
+    private var sshTerminalSection: some View {
+        SettingsCard(
+            title: "SSH Terminal",
+            subtitle: "Recovery mode pauses the normal assistant pod and routes terminal sessions into the mounted debug pod, giving you direct access to the assistant's workspace PVC."
+        ) {
+            recoveryModeStatusRow
+
+            SettingsDivider()
+
+            HStack(spacing: VSpacing.sm) {
+                if store.managedAssistantRecoveryMode?.enabled == true {
+                    VButton(
+                        label: "Resume Assistant",
+                        style: .outlined,
+                        isDisabled: maintenanceTransitionInFlight
+                    ) {
+                        store.exitManagedAssistantRecoveryMode()
+                    }
+                    .accessibilityLabel("Resume Assistant")
+                } else {
+                    VButton(
+                        label: "Enter Recovery Mode",
+                        style: .outlined,
+                        isDisabled: maintenanceTransitionInFlight
+                    ) {
+                        store.enterManagedAssistantRecoveryMode()
+                    }
+                    .accessibilityLabel("Enter Recovery Mode")
+                }
+
+                VButton(label: "Open Terminal", style: .primary) {
+                    openTerminalWindow()
+                }
+                .accessibilityLabel("Open Terminal")
+            }
+
+            if let enterError = store.recoveryModeEnterError {
+                Text(enterError)
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.systemNegativeStrong)
+            }
+            if let exitError = store.recoveryModeExitError {
+                Text(exitError)
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.systemNegativeStrong)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var recoveryModeStatusRow: some View {
+        if store.recoveryModeRefreshing {
+            HStack(spacing: VSpacing.sm) {
+                ProgressView()
+                    .controlSize(.mini)
+                    .progressViewStyle(.circular)
+                Text("Loading recovery status…")
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentTertiary)
+            }
+        } else if let maintenance = store.managedAssistantRecoveryMode {
+            if maintenance.enabled {
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    HStack(spacing: VSpacing.xs) {
+                        Circle()
+                            .fill(VColor.systemMidStrong)
+                            .frame(width: 8, height: 8)
+                            .accessibilityHidden(true)
+                        Text("Recovery mode active")
+                            .font(VFont.bodyMediumDefault)
+                            .foregroundStyle(VColor.contentDefault)
+                            .accessibilityValue("Recovery mode active")
+                    }
+                    if let podName = maintenance.debug_pod_name, !podName.isEmpty {
+                        Text("Debug pod: \(podName)")
+                            .font(VFont.labelDefault)
+                            .foregroundStyle(VColor.contentTertiary)
+                            .textSelection(.enabled)
+                    }
+                }
+            } else {
+                HStack(spacing: VSpacing.xs) {
+                    Circle()
+                        .fill(VColor.systemPositiveStrong)
+                        .frame(width: 8, height: 8)
+                        .accessibilityHidden(true)
+                    Text("Assistant running normally")
+                        .font(VFont.bodyMediumDefault)
+                        .foregroundStyle(VColor.contentDefault)
+                        .accessibilityValue("Assistant running normally")
+                }
+            }
+        } else {
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                Text("Recovery status unavailable")
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentTertiary)
+                if let refreshError = store.recoveryModeRefreshError {
+                    Text(refreshError)
+                        .font(VFont.labelDefault)
+                        .foregroundStyle(VColor.systemNegativeStrong)
+                }
+            }
+        }
+    }
+
+    private func openTerminalWindow() {
+        guard let assistant = lockfileAssistants.first(where: { $0.assistantId == selectedAssistantId }),
+              assistant.isManaged else { return }
+        Self.terminalWindow.open(assistant: assistant)
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDebugTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDebugTab.swift
@@ -15,8 +15,6 @@ struct SettingsDebugTab: View {
     @State private var showingRestartConfirmation: Bool = false
     @State private var isRestarting: Bool = false
 
-    private static let terminalWindow = SSHTerminalWindow()
-
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.lg) {
             restartAssistantSection
@@ -74,6 +72,11 @@ struct SettingsDebugTab: View {
     }
 
     private func performRestart() async {
+        // Bail out if we don't have a real assistant. Without this guard an
+        // empty `selectedAssistantId` would POST to `assistants//restart`,
+        // silently fail under `try?`, and leave the user staring at the
+        // "Restarting…" sheet as if everything succeeded.
+        guard lockfileAssistants.contains(where: { $0.assistantId == selectedAssistantId }) else { return }
         _ = try? await GatewayHTTPClient.post(path: "assistants/\(selectedAssistantId)/restart")
         try? await Task.sleep(nanoseconds: 2_000_000_000)
     }
@@ -194,6 +197,6 @@ struct SettingsDebugTab: View {
     private func openTerminalWindow() {
         guard let assistant = lockfileAssistants.first(where: { $0.assistantId == selectedAssistantId }),
               assistant.isManaged else { return }
-        Self.terminalWindow.open(assistant: assistant)
+        SSHTerminalWindow.shared.open(assistant: assistant)
     }
 }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -797,13 +797,11 @@ struct SettingsDeveloperTab: View {
         }
     }
 
-    private static let terminalWindow = SSHTerminalWindow()
-
     private func openTerminalWindow() {
         guard let assistant = lockfileAssistants.first(where: { $0.assistantId == selectedAssistantId }),
               assistant.isManaged else { return }
 
-        Self.terminalWindow.open(assistant: assistant)
+        SSHTerminalWindow.shared.open(assistant: assistant)
     }
 
     // MARK: - Retire Assistant

--- a/clients/macos/vellum-assistant/Features/Terminal/SSHTerminalWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Terminal/SSHTerminalWindow.swift
@@ -10,6 +10,11 @@ import VellumAssistantShared
 @MainActor
 final class SSHTerminalWindow {
 
+    /// Shared singleton — ensures a single terminal window is reused across
+    /// all entry points (Debug tab, Developer tab, recovery-mode banner, etc.)
+    /// so the window-reuse check in `open()` actually prevents duplicates.
+    static let shared = SSHTerminalWindow()
+
     private var window: NSWindow?
     private var sessionManager: TerminalSessionManager?
 


### PR DESCRIPTION
## Summary
- Adds a new **Debug** settings tab visible only when the active assistant is platform-managed (\`isCurrentAssistantManaged\`).
- The tab contains the **Restart Assistant** and **SSH Terminal** sections (recovery-mode flow) — same controls that previously lived only behind the developer feature flag.
- The Developer tab is left unchanged so dev-mode users still have access (and Docker/non-managed remote assistants keep their restart entry).

## Original prompt
--safe create a new debug tab in the settings panel follow existing styling standards of the other tabs. the debug tab should have the ssh terminal and the restart. This debug tab should only show up if the are a cloud hosted/platform assistant
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24218" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
