### PR TITLE
fix: remove unused variable in subagent fork spawn test

### DIFF
--- a/assistant/src/__tests__/subagent-fork-spawn.test.ts
+++ b/assistant/src/__tests__/subagent-fork-spawn.test.ts
@@ -276,14 +276,11 @@ describe("SubagentManager fork spawn", () => {
     const manager = new SubagentManager();
     const subagentId = "sub-fork-role";
 
-    let toolFilterCalled = false;
     const fakeConversation = makeFakeConversation();
     fakeConversation.persistUserMessage = () => "msg-1";
     fakeConversation.runAgentLoop = async () => {};
     fakeConversation.injectInheritedContext = () => {};
-    fakeConversation.setSubagentAllowedTools = () => {
-      toolFilterCalled = true;
-    };
+    fakeConversation.setSubagentAllowedTools = () => {};
 
     // Create a fork state — in real spawn(), the role would be forced to
     // "general" regardless of what was requested, and tool filtering skipped.


### PR DESCRIPTION
## Summary
- Remove unused `toolFilterCalled` variable in `subagent-fork-spawn.test.ts` that caused a lint error (`@typescript-eslint/no-unused-vars`)

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24113529707/job/70352911899