### PR TITLE
fix: sort imports in subagent fork spawn test

### DIFF
--- a/assistant/src/__tests__/subagent-spawn-tool-fork.test.ts
+++ b/assistant/src/__tests__/subagent-spawn-tool-fork.test.ts
@@ -29,8 +29,8 @@ mock.module("../memory/conversation-crud.js", () => ({
   createConversation: () => ({ id: "mock-conv" }),
 }));
 
-import { getSubagentManager } from "../subagent/index.js";
 import type { Message } from "../providers/types.js";
+import { getSubagentManager } from "../subagent/index.js";
 import { executeSubagentSpawn } from "../tools/subagent/spawn.js";
 
 // ── Shared helpers ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Fix `simple-import-sort/imports` lint error in `subagent-spawn-tool-fork.test.ts` by alphabetizing imports by path

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24113628170/job/70353196982
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24223" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
