### PR TITLE
fix(chrome-extension): popup connect handler honors selected relay mode

### DIFF
--- a/clients/chrome-extension/popup/popup.ts
+++ b/clients/chrome-extension/popup/popup.ts
@@ -116,13 +116,32 @@ btnConnect.addEventListener('click', async () => {
 
   errorText.style.display = 'none';
 
+  // Read the current relay mode so we know whether to auto-fetch a local
+  // daemon token. In cloud mode the worker uses the stored cloud token
+  // (vellum.cloudAuthToken) directly, so the popup must NOT try to hit
+  // localhost — a cloud-only user may not have a local assistant running.
+  //
+  // We prefer the radio button's checked state as a tiebreaker: if the
+  // user just toggled the radio, the async chrome.storage.local.set from
+  // handleModeChange() may not have landed yet. The DOM is the source of
+  // truth for the user's current intent.
+  const modeStorage = await chrome.storage.local.get(RELAY_MODE_KEY);
+  const storedMode = modeStorage[RELAY_MODE_KEY];
+  const relayMode: RelayModeKind = modeCloud.checked
+    ? 'cloud'
+    : modeSelfHosted.checked
+      ? 'self-hosted'
+      : storedMode === 'cloud'
+        ? 'cloud'
+        : 'self-hosted';
+
   // Only honour the manual token input when the user has explicitly revealed
-  // it.  When manual mode is hidden, always auto-fetch a fresh token from the
-  // gateway so we never silently reuse an expired JWT that was pre-loaded from
-  // storage.
+  // it.  When manual mode is hidden and we're in self-hosted mode, auto-fetch
+  // a fresh token from the gateway so we never silently reuse an expired JWT
+  // that was pre-loaded from storage.
   let token = manualMode ? tokenInput.value.trim() : '';
 
-  if (!token) {
+  if (!token && relayMode === 'self-hosted') {
     try {
       btnConnect.disabled = true;
       statusText.textContent = 'Fetching token…';
@@ -134,6 +153,10 @@ btnConnect.addEventListener('click', async () => {
       return;
     }
   }
+
+  // In cloud mode with no manual token we proceed with no bearerToken —
+  // the worker reads vellum.cloudAuthToken from chrome.storage when it
+  // builds the relay mode config in buildRelayModeConfig().
 
   if (token) storageUpdate.bearerToken = token;
   if (portInput.value.trim()) {


### PR DESCRIPTION
## Summary
- Fixes P1: the popup's Connect button always tried to fetch a localhost token regardless of the selected relay mode, which made cloud-only users (no local assistant running) unable to connect because the localhost fetch errored out before the connect message was sent.
- Connect handler now reads vellum.relayMode and only calls fetchTokenFromGateway when relayMode === 'self-hosted'.
- In cloud mode the worker reads vellum.cloudAuthToken directly, so the popup proceeds without a bearerToken in storage.

Addresses P1 #3 from PR #24159 self-review round 2 (caught by Codex on cfe5004360).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24225" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
