### PR TITLE
chore(chrome-extension): extend bun:test ambient shim with common symbols

### DIFF
--- a/clients/chrome-extension/types/bun-test-shim.d.ts
+++ b/clients/chrome-extension/types/bun-test-shim.d.ts
@@ -7,12 +7,27 @@
  */
 
 declare module 'bun:test' {
-  type TestFn = () => void | Promise<void>;
+  type TestCallback = () => void | Promise<void>;
+  type TestFn = (name: string, fn?: TestCallback) => void;
 
-  export function describe(name: string, fn: () => void): void;
-  export function test(name: string, fn: TestFn): void;
-  export function beforeEach(fn: TestFn): void;
-  export function afterEach(fn: TestFn): void;
+  interface TestApi extends TestFn {
+    todo: TestFn;
+    skip: TestFn;
+    only: TestFn;
+  }
+
+  interface DescribeApi {
+    (name: string, fn: () => void): void;
+    skip(name: string, fn: () => void): void;
+    only(name: string, fn: () => void): void;
+  }
+
+  export const test: TestApi;
+  export const describe: DescribeApi;
+  export function beforeEach(fn: TestCallback): void;
+  export function afterEach(fn: TestCallback): void;
+  export function beforeAll(fn: TestCallback): void;
+  export function afterAll(fn: TestCallback): void;
 
   interface Matchers<R> {
     toBe(expected: unknown): R;


### PR DESCRIPTION
## Summary
- Adds beforeAll, afterAll, test.todo, test.skip, test.only, and describe.skip/only to the ambient bun:test shim so future chrome-extension tests using these symbols are actually typechecked instead of silently falling back to any.

Addresses P3 #4 from PR #24159 self-review round 2.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24226" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
