### PR TITLE
chore(chrome-extension): remove stale cdp-proxy declarations and outdated comment

### DIFF
--- a/clients/chrome-extension/background/cdp-proxy.ts
+++ b/clients/chrome-extension/background/cdp-proxy.ts
@@ -5,8 +5,7 @@
  * API. The module is decoupled from the service worker lifecycle and from any
  * relay transport so it can be consumed by a host-browser dispatcher and
  * exercised in isolation. The `ChromeDebuggerApi` interface is injectable so
- * tests can drive both success and error paths against a mock; tests will be
- * added once a test runner is configured for this package.
+ * tests can drive both success and error paths against a mock.
  *
  * Flat-session handling
  * ---------------------
@@ -59,10 +58,9 @@ export interface CdpEventFrame {
 }
 
 /**
- * Target identifier passed to chrome.debugger.attach. Mirrors the shape of
- * `chrome.debugger.Debuggee` from `@types/chrome` so that when those types
- * are added to the Chrome extension package in a later PR the cast between
- * the two is a no-op.
+ * Target identifier passed to chrome.debugger.attach. Source-compatible with
+ * `chrome.debugger.Debuggee` so the two values can be interchanged at the
+ * call site without a structural cast.
  */
 export interface CdpDebuggee {
   tabId?: number;
@@ -149,20 +147,6 @@ export interface ChromeDebuggerApi {
     lastError?: { message?: string };
   };
 }
-
-/**
- * Minimal ambient view of the parts of the `chrome` global that this module
- * touches. Declared locally so the module does not depend on `@types/chrome`
- * and can compile standalone under a tsconfig that only includes this file.
- * When `@types/chrome` lands in the extension package these declarations can
- * be removed — the shapes are source-compatible with the real types.
- */
-declare const chrome: {
-  debugger: Omit<ChromeDebuggerApi, "runtime">;
-  runtime: {
-    lastError?: { message?: string };
-  };
-};
 
 /**
  * Compose a default `ChromeDebuggerApi` from the real `chrome` global. We

--- a/clients/chrome-extension/types/chrome-globals.d.ts
+++ b/clients/chrome-extension/types/chrome-globals.d.ts
@@ -224,14 +224,71 @@ interface ChromeDebuggerDebuggee {
   targetId?: string;
 }
 
+/**
+ * Chrome 125+ flat-session target. Extends `Debuggee` with an optional
+ * `sessionId` that addresses a child flat session created via
+ * `Target.attachToTarget` with `flatten: true`. The `chrome.debugger`
+ * sendCommand API and the `onEvent` `source` argument both accept this
+ * shape so child sessions can be routed via the target argument rather
+ * than smuggled into command params.
+ */
+interface ChromeDebuggerSession extends ChromeDebuggerDebuggee {
+  sessionId?: string;
+}
+
+interface ChromeDebuggerOnEventEvent {
+  addListener(
+    callback: (
+      source: ChromeDebuggerSession,
+      method: string,
+      params?: unknown,
+    ) => void,
+  ): void;
+  removeListener(
+    callback: (
+      source: ChromeDebuggerSession,
+      method: string,
+      params?: unknown,
+    ) => void,
+  ): void;
+}
+
+interface ChromeDebuggerOnDetachEvent {
+  addListener(
+    callback: (source: ChromeDebuggerDebuggee, reason: string) => void,
+  ): void;
+  removeListener(
+    callback: (source: ChromeDebuggerDebuggee, reason: string) => void,
+  ): void;
+}
+
 interface ChromeDebuggerNamespace {
+  // Promise-style (modern MV3 usage — used by worker.ts).
   attach(target: ChromeDebuggerDebuggee, requiredVersion: string): Promise<void>;
   detach(target: ChromeDebuggerDebuggee): Promise<void>;
   sendCommand(
-    target: ChromeDebuggerDebuggee,
+    target: ChromeDebuggerSession,
     method: string,
     commandParams?: Record<string, unknown>,
   ): Promise<unknown>;
+  // Callback-style overloads (still supported in MV3). cdp-proxy.ts uses the
+  // callback form so it can thread errors through `chrome.runtime.lastError`
+  // on a per-call basis, which is what makes the injected `ChromeDebuggerApi`
+  // testable against a mock.
+  attach(
+    target: ChromeDebuggerDebuggee,
+    requiredVersion: string,
+    callback: () => void,
+  ): void;
+  detach(target: ChromeDebuggerDebuggee, callback: () => void): void;
+  sendCommand(
+    target: ChromeDebuggerSession,
+    method: string,
+    commandParams: Record<string, unknown> | undefined,
+    callback: (result?: unknown) => void,
+  ): void;
+  onEvent: ChromeDebuggerOnEventEvent;
+  onDetach: ChromeDebuggerOnDetachEvent;
 }
 
 interface ChromeGlobal {


### PR DESCRIPTION
## Summary
- Removes the module-scoped declare const chrome block in cdp-proxy.ts that shadowed the new global chrome-globals.d.ts declarations (obsolete after #24199)
- Removes the stale 'tests will be added once a test runner is configured' rationale comment now that cdp-proxy.test.ts exists
- Pure cleanup; no behavior changes

Addresses P2 #1 and related P3 comment cleanup from PR #24159 self-review round 2.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24228" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
