### PR TITLE
fix: address integration review gaps in context forking

### DIFF
--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -249,7 +249,7 @@ export class Conversation {
   /** @internal */ workspaceTopLevelContext: string | null = null;
   /** @internal */ workspaceTopLevelDirty = true;
   public readonly traceEmitter: TraceEmitter;
-  public readonly hasSystemPromptOverride: boolean;
+  /** @internal */ hasSystemPromptOverride: boolean;
   public memoryPolicy: ConversationMemoryPolicy;
   /** @internal */ readonly graphMemory: ConversationGraphMemory;
   /** @internal */ activeContextNodeIds?: string[];
@@ -389,7 +389,7 @@ export class Conversation {
       _history: import("../providers/types.js").Message[],
     ): ResolvedSystemPrompt => {
       const resolved = {
-        systemPrompt: hasSystemPromptOverride
+        systemPrompt: this.hasSystemPromptOverride
           ? systemPrompt
           : (() => {
               const persona = resolvePersonaContext(

--- a/assistant/src/daemon/message-types/subagents.ts
+++ b/assistant/src/daemon/message-types/subagents.ts
@@ -10,6 +10,7 @@ export interface SubagentSpawned {
   parentConversationId: string;
   label: string;
   objective: string;
+  isFork?: boolean;
 }
 
 export interface SubagentStatusChanged {

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -309,6 +309,12 @@ export class SubagentManager {
     conversation.updateClient(wrappedSendToClient, true);
     conversation.setIsSubagent(true);
 
+    if (isFork) {
+      // Force the fork to use the parent's system prompt as-is without dynamic rebuild.
+      // This ensures KV cache alignment with the parent conversation.
+      conversation.hasSystemPromptOverride = true;
+    }
+
     // Apply role-based tool filter if the role defines one.
     // Skip for forks — general role has allowedTools: undefined, and forks
     // should have the same tool access as the parent.
@@ -401,6 +407,11 @@ export class SubagentManager {
       // awareness while the objective becomes the latest user turn.
       if (managed.state.isFork && managed.state.config.parentMessages) {
         conversation.injectInheritedContext(managed.state.config.parentMessages);
+        // Release the parent message arrays now that they've been injected — holding
+        // them in SubagentState.config would retain significant memory until the TTL
+        // sweep disposes this entry (up to 30 minutes for terminal subagents).
+        managed.state.config.parentMessages = undefined;
+        managed.state.config.parentSystemPrompt = undefined;
       }
 
       // Send the objective as the first user message and process it.


### PR DESCRIPTION
## Summary
Fixes 3 gaps found during self-review of the sub-agent context forking feature:

- **Wire type**: Add missing `isFork` field to `SubagentSpawned` interface
- **Memory**: Clear `parentMessages` and `parentSystemPrompt` after injection
- **KV cache**: Force `hasSystemPromptOverride = true` for forks so the system prompt is not rebuilt dynamically

Part of plan: subagent-context-forking.md (review fix)