### PR TITLE
chore(chrome-extension): tighten bun:test shim so only test.todo has optional callback

### DIFF
--- a/clients/chrome-extension/types/bun-test-shim.d.ts
+++ b/clients/chrome-extension/types/bun-test-shim.d.ts
@@ -8,12 +8,22 @@
 
 declare module 'bun:test' {
   type TestCallback = () => void | Promise<void>;
-  type TestFn = (name: string, fn?: TestCallback) => void;
 
-  interface TestApi extends TestFn {
-    todo: TestFn;
-    skip: TestFn;
-    only: TestFn;
+  /** Runnable test: body is required. Applies to test(), test.skip(), test.only(). */
+  type RunnableTestFn = (name: string, fn: TestCallback) => void;
+
+  /** Permissive variant for test.todo — a body is optional because
+   * a todo can declare intent to write a test in the future. */
+  type TodoTestFn = (name: string, fn?: TestCallback) => void;
+
+  interface TestApi extends RunnableTestFn {
+    /** Mark a test as a TODO — reports as 'todo' rather than 'passed'.
+     * Use for planned tests that haven't been written yet. */
+    todo: TodoTestFn;
+    /** Skip a test temporarily. Use sparingly; prefer removing or fixing. */
+    skip: RunnableTestFn;
+    /** Run only this test. Do not commit .only() calls. */
+    only: RunnableTestFn;
   }
 
   interface DescribeApi {


### PR DESCRIPTION
## Summary
- Splits TestFn into RunnableTestFn (body required) and TodoTestFn (body optional) so that test(), test.skip(), test.only() all require a callback while test.todo() stays permissive. Prevents missing test bodies from silently compiling.

Addresses round-3 P2 from PR #24159 self-review.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24234" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
