### PR TITLE
chore(chrome-extension): dedupe RelayConnection.mode accessor (keep getCurrentMode)

### DIFF
--- a/clients/chrome-extension/background/__tests__/relay-connection.test.ts
+++ b/clients/chrome-extension/background/__tests__/relay-connection.test.ts
@@ -467,17 +467,17 @@ describe('RelayConnection', () => {
       conn.close();
     });
 
-    test('updates the mode getter', () => {
+    test('updates the mode accessor', () => {
       const cbs = makeCallbacks();
       const conn = makeConn(
         { kind: 'self-hosted', baseUrl: 'http://127.0.0.1:7830', token: 't' },
         cbs,
       );
       conn.start();
-      expect(conn.mode.kind).toBe('self-hosted');
+      expect(conn.getCurrentMode().kind).toBe('self-hosted');
 
       conn.setMode({ kind: 'cloud', baseUrl: 'https://api.vellum.ai', token: 'c' });
-      expect(conn.mode.kind).toBe('cloud');
+      expect(conn.getCurrentMode().kind).toBe('cloud');
 
       conn.close();
     });
@@ -508,7 +508,7 @@ describe('RelayConnection', () => {
       expect(newSocket.url).toBe(
         'wss://api.vellum.ai/v1/browser-relay?token=cloud-jwt',
       );
-      expect(conn.mode.kind).toBe('cloud');
+      expect(conn.getCurrentMode().kind).toBe('cloud');
 
       // Now simulate the asynchronous close event that socket A fires
       // after setMode already re-pointed this.ws at socket B. The

--- a/clients/chrome-extension/background/relay-connection.ts
+++ b/clients/chrome-extension/background/relay-connection.ts
@@ -81,11 +81,6 @@ export class RelayConnection {
     this.deps = deps;
   }
 
-  /** Current connection mode (read-only; use `setMode` to switch). */
-  get mode(): RelayMode {
-    return this.deps.mode;
-  }
-
   /**
    * Return the live connection mode. Callers must invoke this right
    * before each use — after a reconnect-with-refresh cycle the
@@ -96,6 +91,10 @@ export class RelayConnection {
    * mode through this accessor per-POST so that result envelopes sent
    * after a WebSocket drop authenticate with the new bearer token
    * instead of silently 401/403ing.
+   *
+   * This is the ONLY public accessor for the mode — there is
+   * deliberately no `get mode()` getter, because a property-style
+   * access reads as a static field and invites callers to cache it.
    */
   getCurrentMode(): RelayMode {
     return this.deps.mode;


### PR DESCRIPTION
## Summary
- Removes the legacy 'get mode()' getter on RelayConnection. getCurrentMode() is now the sole public accessor and its docstring warns callers must re-read per-use because scheduleReconnectWithRefresh replaces deps.mode wholesale.
- Prevents a future maintainer from caching '.mode' and reintroducing the stale-token bug PR #24227 fixed.
- Updates call sites in tests.

Addresses round-3 P3 #1 from PR #24159 self-review.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24235" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
