### PR TITLE
fix(chrome-extension): worker reads live relay mode from storage on connect

### DIFF
--- a/clients/chrome-extension/background/__tests__/worker-host-browser-result.test.ts
+++ b/clients/chrome-extension/background/__tests__/worker-host-browser-result.test.ts
@@ -17,6 +17,15 @@
  * The function lives in `relay-connection.ts` (rather than `worker.ts`)
  * so the test can import it directly without dragging in the chrome
  * service worker module surface.
+ *
+ * Related: worker.ts's `connect()` re-reads `vellum.relayMode` from
+ * chrome.storage.local at entry to close a race where the popup toggles
+ * the mode radio and immediately clicks Connect before the async
+ * `chrome.storage.onChanged` listener updates the module-level
+ * `relayMode` variable. That live-read cannot be unit-tested here
+ * without dragging in the entire service worker module surface
+ * (chrome.* globals, bootstrap(), native messaging, etc.), but the
+ * behaviour is verifiable by reading `connect()` in worker.ts.
  */
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';

--- a/clients/chrome-extension/background/worker.ts
+++ b/clients/chrome-extension/background/worker.ts
@@ -287,7 +287,18 @@ function missingTokenMessage(kind: RelayModeKind): string {
 
 async function connect(): Promise<void> {
   if (relayConnection && relayConnection.isOpen()) return;
-  const mode = await buildRelayModeConfig(relayMode);
+  // Re-read the live relay mode from storage at connect time. The
+  // module-level `relayMode` variable is only refreshed asynchronously
+  // via chrome.storage.onChanged, so trusting it races against a popup
+  // that toggles the radio and immediately clicks Connect. Reading from
+  // storage here makes the connect flow deterministic.
+  //
+  // The module-level `relayMode` is still updated to match so other code
+  // paths (status queries, disconnect, result routing) stay consistent
+  // with the mode we're about to connect with.
+  const liveMode = await loadRelayMode();
+  relayMode = liveMode;
+  const mode = await buildRelayModeConfig(liveMode);
   if (!mode.token) {
     const msg = missingTokenMessage(mode.kind);
     console.warn(`[vellum-relay] ${msg}`);


### PR DESCRIPTION
## Summary
- Fixes a race where the worker's connect() handler read the module-level relayMode variable that is only updated asynchronously via chrome.storage.onChanged. If the user toggled the radio and immediately clicked Connect, the worker would connect with the stale mode.
- connect() now re-reads the live mode from chrome.storage at entry, keeping the flow deterministic.

Addresses round-3 P3 #4 from PR #24159 self-review (symmetric to the popup-side fix in #24225).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24236" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
