### PR TITLE
fix: detach from following-bottom on manual content expansion

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -538,6 +538,35 @@ final class MessageListScrollState {
         }
     }
 
+    /// Treats manual content expansion/collapse as explicit browsing intent.
+    ///
+    /// When the user opens tool details while the transcript is following the
+    /// bottom, immediately re-pinning defeats the interaction: the viewport
+    /// jumps, recovery keeps chasing new content, and the user loses their
+    /// place mid-inspection. Instead we:
+    /// 1. cancel any delayed restore/recovery bottom pins
+    /// 2. detach into `freeBrowsing`
+    /// 3. start a short expansion stabilization window so layout settles
+    ///
+    /// After the stabilization timeout, the transcript stays in
+    /// `freeBrowsing` until the user explicitly returns to latest.
+    func handleManualExpansionInteraction() {
+        scrollRestoreTask?.cancel()
+        scrollRestoreTask = nil
+        recoveryDeadline = nil
+
+        switch mode {
+        case .freeBrowsing:
+            break
+        case .stabilizing(let previousMode, _) where previousMode == .freeBrowsing:
+            break
+        default:
+            transition(to: .freeBrowsing)
+        }
+
+        beginStabilization(.expansion)
+    }
+
     private func cancelStabilizationTasks() {
         expansionTimeoutTask?.cancel()
         expansionTimeoutTask = nil

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -128,14 +128,8 @@ struct MessageListView: View {
             .defaultScrollAnchor(.bottom, for: .initialOffset)
             .scrollPosition($scrollPosition)
             .environment(\.suppressAutoScroll, { [self] in
-                scrollState.endStabilization()
-                if scrollState.isFollowingBottom {
-                    os_signpost(.event, log: PerfSignposts.log, name: "scrollSuppressionChanged", "on reason=expansionPinning")
-                    scrollState.requestPinToBottom()
-                } else {
-                    os_signpost(.event, log: PerfSignposts.log, name: "scrollSuppressionChanged", "on reason=offBottomExpansion")
-                    scrollState.beginStabilization(.expansion)
-                }
+                os_signpost(.event, log: PerfSignposts.log, name: "scrollSuppressionChanged", "on reason=manualExpansionDetach")
+                scrollState.handleManualExpansionInteraction()
             })
             .onScrollPhaseChange { oldPhase, newPhase in
                 scrollState.scrollPhase = newPhase

--- a/clients/macos/vellum-assistantTests/MessageListScrollStateTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListScrollStateTests.swift
@@ -273,6 +273,35 @@ final class MessageListScrollStateTests: XCTestCase {
                        "Expansion stabilization should auto-clear after the reset timeout")
     }
 
+    func testManualExpansionDetachesFollowingBottom() async throws {
+        state.transition(to: .followingBottom)
+        state.recoveryDeadline = Date().addingTimeInterval(2.0)
+        state.scrollRestoreTask = Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 1_000_000_000)
+        }
+
+        state.handleManualExpansionInteraction()
+
+        XCTAssertTrue(state.isSuppressed,
+                      "Manual expansion should enter stabilization while layout settles")
+        XCTAssertFalse(state.isFollowingBottom,
+                       "Manual expansion should detach from following-bottom mode")
+        XCTAssertNil(state.recoveryDeadline,
+                     "Manual expansion should cancel bottom recovery")
+        XCTAssertNil(state.scrollRestoreTask,
+                     "Manual expansion should cancel delayed restore pins")
+
+        try await Task.sleep(nanoseconds: 250_000_000)
+
+        XCTAssertFalse(state.isSuppressed,
+                       "Expansion stabilization should still auto-clear")
+        if case .freeBrowsing = state.mode {
+            // correct
+        } else {
+            XCTFail("Manual expansion should settle into freeBrowsing")
+        }
+    }
+
     // MARK: - Reset
 
     func testResetRestoresDefaults() {


### PR DESCRIPTION
## Summary
- Add `handleManualExpansionInteraction()` to `MessageListScrollState` that cancels pending restore/recovery pins and transitions to `freeBrowsing` when the user manually expands or collapses content (e.g. tool details)
- Simplify the `suppressAutoScroll` closure in `MessageListView` to use the new method instead of inline branching logic
- Add test verifying the detach behavior: cancels recovery, enters stabilization, settles into freeBrowsing