### PR TITLE
fix(oauth): use replaceAll in revoke template substitution for Python str.replace parity

### DIFF
--- a/assistant/src/__tests__/oauth-store.test.ts
+++ b/assistant/src/__tests__/oauth-store.test.ts
@@ -1935,6 +1935,44 @@ describe("disconnectOAuthProvider", () => {
     expect(params.get("token")).toBe("tok$&abc");
   });
 
+  test("replaces all occurrences of {access_token} in body template values (matching Python str.replace)", async () => {
+    // Python's str.replace(old, new) replaces ALL occurrences by default,
+    // whereas JavaScript's String.prototype.replace with a string pattern
+    // only replaces the FIRST occurrence. The platform's try_revoke_token
+    // is implemented in Python, so any template value containing repeated
+    // placeholders must have ALL of them substituted to preserve parity.
+    // This test guards against a regression to .replace(), which would
+    // leave the second {access_token} as a literal placeholder.
+    seedProviderWithRevoke("google", "https://revoke.example.com/r", {
+      token: "token={access_token}&also={access_token}",
+    });
+    const app = await upsertApp("google", "client-1");
+    const conn = createConnection({
+      oauthAppId: app.id,
+      provider: "google",
+      grantedScopes: ["email"],
+      hasRefreshToken: false,
+    });
+    secureKeyValues.set(`oauth_connection/${conn.id}/access_token`, "fake-abc");
+
+    mockFetch(
+      "https://revoke.example.com/r",
+      { method: "POST" },
+      { status: 200, body: {} },
+    );
+
+    await disconnectOAuthProvider("google");
+
+    const calls = getMockFetchCalls();
+    expect(calls.length).toBe(1);
+    const body = String(calls[0]!.init.body ?? "");
+    const params = new URLSearchParams(body);
+    // Both {access_token} placeholders must be substituted. With the buggy
+    // .replace() (single-occurrence), this would be
+    // "token=fake-abc&also={access_token}" instead.
+    expect(params.get("token")).toBe("token=fake-abc&also=fake-abc");
+  });
+
   test("coerces non-string body template values to strings", async () => {
     // seedProviderWithRevoke restricts to Record<string, string>; bypass it
     // here by inserting a template with a numeric value via a direct seed.

--- a/assistant/src/oauth/revoke.ts
+++ b/assistant/src/oauth/revoke.ts
@@ -11,7 +11,10 @@
  * - `{client_id}` — replaced with the OAuth app's client ID
  *
  * Non-string template values are coerced via String(value), matching platform's str(value)
- * fallback. Returns void on every path — callers must NOT depend on the upstream result.
+ * fallback. Substitution replaces ALL occurrences of each placeholder within a value
+ * (matching Python's str.replace default) and preserves literal semantics for replacement
+ * text (no $-pattern expansion). Returns void on every path — callers must NOT depend on
+ * the upstream result.
  */
 
 import { getLogger } from "../util/logger.js";
@@ -36,14 +39,14 @@ export async function tryRevokeOAuthToken(params: {
   if (bodyTemplate) {
     for (const [key, value] of Object.entries(bodyTemplate)) {
       if (typeof value === "string") {
-        // Use function replacements to bypass String.replace's $-pattern
-        // expansion (e.g. $&, $', $`, $$). This preserves literal semantics
-        // and mirrors Python's str.replace() behavior. Without this, an
-        // access token containing "$&" would expand to the matched string
-        // ("{access_token}") instead of being substituted literally.
+        // Use .replaceAll with function callbacks to:
+        // 1. Replace ALL occurrences (matching Python's str.replace default).
+        // 2. Bypass String.replace's $-pattern expansion (e.g. $&, $', $`, $$),
+        //    so an access token containing "$&" substitutes literally.
+        // This mirrors platform's str.replace() semantics character-for-character.
         body[key] = value
-          .replace("{access_token}", () => accessToken)
-          .replace("{client_id}", () => clientId);
+          .replaceAll("{access_token}", () => accessToken)
+          .replaceAll("{client_id}", () => clientId);
       } else {
         body[key] = String(value);
       }


### PR DESCRIPTION
## Summary
- Switch tryRevokeOAuthToken to use String.prototype.replaceAll so ALL occurrences of {access_token}/{client_id} are substituted, matching Python str.replace default
- Function-callback form still bypasses $-pattern expansion (previous fix preserved)
- Add regression test for body template values with repeated placeholders

Fixes gap from round 2 plan review for revoke-token-parity.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24241" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
