### PR TITLE
fix: fork-aware body text in notifications and context param docs

### DIFF
--- a/assistant/src/config/bundled-skills/subagent/TOOLS.json
+++ b/assistant/src/config/bundled-skills/subagent/TOOLS.json
@@ -19,7 +19,7 @@
           },
           "context": {
             "type": "string",
-            "description": "Optional additional context to pass to the subagent"
+            "description": "Optional additional context to pass to the subagent. Ignored when fork is true — forks inherit the parent's full context."
           },
           "fork": {
             "type": "boolean",

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -509,7 +509,7 @@ export class SubagentManager {
         const prefix = managed.state.isFork ? "Fork" : "Subagent";
         const message =
           `[${prefix} "${label}" was explicitly aborted]\n\n` +
-          `This subagent was cancelled on purpose. Do NOT re-spawn or retry it.`;
+          `This ${prefix.toLowerCase()} was cancelled on purpose. Do NOT re-spawn or retry it.`;
         try {
           // Use the managed subagent's stored parentSendToClient so the
           // notification routes to the parent conversation's socket, not the
@@ -861,7 +861,7 @@ export class SubagentManager {
     let notificationString = `[${prefix} "${info.label}" — ${urgency}] ${message}`;
     if (urgency === "blocked") {
       notificationString +=
-        "\nUse subagent_message to send guidance to this subagent.";
+        `\nUse subagent_message to send guidance to this ${prefix.toLowerCase()}.`;
     }
 
     try {


### PR DESCRIPTION
## Summary
- Abort and blocked notification body text now says 'fork' instead of 'subagent' for forks
- TOOLS.json context parameter notes it's ignored when fork is true

Part of plan: subagent-context-forking.md (review fix round 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24242" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
