### PR TITLE
fix: wrap fork objective in directive framing to override conversational momentum

### DIFF
--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -415,8 +415,24 @@ export class SubagentManager {
       }
 
       // Send the objective as the first user message and process it.
-      const messageId = await conversation.persistUserMessage(objective, []);
-      await conversation.runAgentLoop(objective, messageId, onEvent);
+      // For forks, wrap the objective in directive framing so it overrides
+      // conversational momentum from the inherited context. Without this,
+      // the fork tends to continue the parent conversation instead of
+      // pivoting to the task — the inherited context is louder than a bare
+      // objective buried after 100k+ tokens of chat history.
+      const message = managed.state.isFork
+        ? [
+            "⎯⎯⎯ FORK TASK ⎯⎯⎯",
+            "You have been forked from the parent conversation to execute a specific task.",
+            "The conversation above is context — do NOT continue it. Do NOT spawn sub-agents.",
+            "Complete this task directly and return only your findings:",
+            "",
+            objective,
+            "⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯",
+          ].join("\n")
+        : objective;
+      const messageId = await conversation.persistUserMessage(message, []);
+      await conversation.runAgentLoop(message, messageId, onEvent);
 
       // Agent loop completed successfully.
       // Copy usage stats from the conversation before sending status (which includes usage).


### PR DESCRIPTION
## Summary
- Wrap fork objective in directive framing (`⎯⎯⎯ FORK TASK ⎯⎯⎯`) to break conversational momentum
- Instructs the fork to not continue the parent conversation or spawn sub-agents
- Preserves system prompt identity (no cache bust) — framing is in the user message only

## Original prompt
Wrap fork objective in directive framing to prevent conversational momentum from drowning out the task