### PR TITLE
chore(host-browser): Phase 2 polish + hardening (P3 cleanups)

### DIFF
--- a/assistant/src/browser-session/index.ts
+++ b/assistant/src/browser-session/index.ts
@@ -1,3 +1,19 @@
+/**
+ * BrowserSessionManager — multi-backend session router for host_browser.
+ *
+ * Phase 2 hand-off: this module has no production consumers yet. The
+ * `extension` backend is wired structurally so the daemon's HostBrowserProxy
+ * can delegate to it in Phase 3. Phase 3 will:
+ *   1. Migrate `assistant/src/tools/browser/browser-execution.ts` to call
+ *      `BrowserSessionManager.send()` instead of the legacy `browserManager`
+ *      sacrificial-profile path.
+ *   2. Add a Playwright backend for cloud-runtime headless sessions (Phase 5).
+ *
+ * Until Phase 3 lands, the only consumers are the unit tests in
+ * `__tests__/manager.test.ts`.
+ *
+ * See `docs/browser-use-architecture-phase2.md` for the full hand-off context.
+ */
 export * from "./backends/extension.js";
 export * from "./manager.js";
 export * from "./types.js";

--- a/assistant/src/daemon/__tests__/conversation-tool-setup.test.ts
+++ b/assistant/src/daemon/__tests__/conversation-tool-setup.test.ts
@@ -20,6 +20,8 @@ import { describe, expect, test } from "bun:test";
 
 import type { SkillProjectionCache } from "../conversation-skill-tools.js";
 import {
+  HOST_TOOL_NAMES,
+  HOST_TOOL_TO_CAPABILITY,
   isToolActiveForContext,
   type SkillProjectionContext,
 } from "../conversation-tool-setup.js";
@@ -163,5 +165,22 @@ describe("isToolActiveForContext — host tool capability gating", () => {
         makeCtx({ hasNoClient: true, transportInterface: undefined }),
       ),
     ).toBe(false);
+  });
+});
+
+describe("HOST_TOOL_NAMES derivation", () => {
+  test("HOST_TOOL_NAMES is derived from HOST_TOOL_TO_CAPABILITY", () => {
+    // Sanity check: every tool in the names set has a capability mapping.
+    // This is structurally enforced by the code (HOST_TOOL_NAMES is built
+    // from HOST_TOOL_TO_CAPABILITY.keys()), but we test it to make the
+    // invariant visible to readers and to catch any regression that
+    // splits the two collections back apart.
+    for (const name of HOST_TOOL_NAMES) {
+      expect(HOST_TOOL_TO_CAPABILITY.has(name)).toBe(true);
+    }
+    // Cardinality check: the two collections must have the same size so a
+    // future addition to HOST_TOOL_NAMES without a matching capability entry
+    // (or vice versa) would fail.
+    expect(HOST_TOOL_NAMES.size).toBe(HOST_TOOL_TO_CAPABILITY.size);
   });
 });

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -478,31 +478,35 @@ export interface SkillProjectionContext {
 // ── Conditional tool sets ────────────────────────────────────────────
 
 const UI_SURFACE_TOOL_NAMES = new Set(["ui_show", "ui_update", "ui_dismiss"]);
-const HOST_TOOL_NAMES = new Set([
-  "host_file_read",
-  "host_file_write",
-  "host_file_edit",
-  "host_bash",
-  "host_browser",
-]);
 /**
- * Maps each host tool name to the host proxy capability that the connected
- * client interface must support. `isToolActiveForContext` uses this to gate
- * each host tool individually so that partial-capability transports (e.g.
- * chrome-extension only supports `host_browser`) only see the host tools
- * their interface can actually service.
+ * Single source of truth for which tools are host tools and the capability
+ * each one requires from the connected client interface. Adding a tool here
+ * automatically adds it to `HOST_TOOL_NAMES` below, so the two collections
+ * cannot drift apart: if a new host tool is added without a capability
+ * mapping, `isToolActiveForContext` cannot accidentally return `true` for
+ * chrome-extension (or any other partial-capability transport) because
+ * `HOST_TOOL_NAMES` wouldn't contain it either.
+ *
+ * `isToolActiveForContext` uses this map to gate each host tool individually
+ * so that partial-capability transports (e.g. chrome-extension only supports
+ * `host_browser`) only see the host tools their interface can actually
+ * service.
  *
  * Note: there is no `host_cu` tool exposed via the tool gating layer today;
  * computer-use is preactivated as a skill and projected through the skill
- * tools path. Only the host tools listed in `HOST_TOOL_NAMES` need entries.
+ * tools path. Only host tools that flow through the per-capability gate
+ * need entries here.
  */
-const HOST_TOOL_TO_CAPABILITY = new Map<string, HostProxyCapability>([
+export const HOST_TOOL_TO_CAPABILITY = new Map<string, HostProxyCapability>([
   ["host_bash", "host_bash"],
   ["host_file_read", "host_file"],
   ["host_file_write", "host_file"],
   ["host_file_edit", "host_file"],
   ["host_browser", "host_browser"],
 ]);
+// Derived from HOST_TOOL_TO_CAPABILITY so the invariant "every host tool has
+// a capability mapping" is a structural fact — no runtime assertion needed.
+export const HOST_TOOL_NAMES = new Set(HOST_TOOL_TO_CAPABILITY.keys());
 const CLIENT_CAPABILITY_TOOL_NAMES = new Set(["app_open"]);
 const PLATFORM_TOOL_NAMES = new Set(["request_system_permission"]);
 

--- a/assistant/src/daemon/handlers/conversations.ts
+++ b/assistant/src/daemon/handlers/conversations.ts
@@ -1,11 +1,5 @@
 import { v4 as uuid } from "uuid";
 
-import {
-  type InterfaceId,
-  parseChannelId,
-  parseInterfaceId,
-  supportsHostProxy,
-} from "../../channels/types.js";
 import { getConfig } from "../../config/loader.js";
 import {
   createCanonicalGuardianRequest,
@@ -14,29 +8,18 @@ import {
 import {
   batchSetDisplayOrders,
   clearAll,
-  createConversation,
   getConversation,
   updateConversationTitle,
 } from "../../memory/conversation-crud.js";
 import { resolveConversationId } from "../../memory/conversation-key-store.js";
-import {
-  GENERATING_TITLE,
-  queueGenerateConversationTitle,
-  UNTITLED_FALLBACK,
-} from "../../memory/conversation-title-service.js";
 import * as pendingInteractions from "../../runtime/pending-interactions.js";
 import { redactSecrets } from "../../security/secret-scanner.js";
 import { getSubagentManager } from "../../subagent/index.js";
 import { summarizeToolInput } from "../../tools/tool-input-summary.js";
 import { truncate } from "../../util/truncate.js";
 import type { Conversation } from "../conversation.js";
-import { HostBashProxy } from "../host-bash-proxy.js";
-import { HostBrowserProxy } from "../host-browser-proxy.js";
-import { HostCuProxy } from "../host-cu-proxy.js";
-import { HostFileProxy } from "../host-file-proxy.js";
 import type {
   ConfirmationResponse,
-  ConversationCreateRequest,
   ConversationRenameRequest,
   ConversationSwitchRequest,
   DeleteQueuedMessage,
@@ -232,141 +215,6 @@ export function clearAllConversations(ctx: HandlerContext): number {
   // the "clear all conversations" intent.
   clearAll();
   return cleared;
-}
-
-export async function handleConversationCreate(
-  msg: ConversationCreateRequest,
-  ctx: HandlerContext,
-): Promise<void> {
-  const conversationType = normalizeConversationType(msg.conversationType);
-  const title =
-    msg.title ?? (msg.initialMessage ? GENERATING_TITLE : "New Conversation");
-  const conversation = createConversation({
-    title,
-    conversationType,
-  });
-  const conversationObj = await ctx.getOrCreateConversation(conversation.id, {
-    systemPromptOverride: msg.systemPromptOverride,
-    maxResponseTokens: msg.maxResponseTokens,
-    transport: msg.transport,
-  });
-
-  // Pre-activate skills before sending conversation_info so they're available
-  // for the initial message processing.
-  if (msg.preactivatedSkillIds?.length) {
-    conversationObj.setPreactivatedSkillIds(msg.preactivatedSkillIds);
-  }
-
-  ctx.send({
-    type: "conversation_info",
-    conversationId: conversation.id,
-    title: conversation.title ?? "New Conversation",
-    ...(msg.correlationId ? { correlationId: msg.correlationId } : {}),
-    conversationType: normalizeConversationType(conversation.conversationType),
-  });
-
-  // Auto-send the initial message if provided, kick-starting the skill.
-  if (msg.initialMessage) {
-    // Queue title generation eagerly — some processMessage paths (guardian
-    // replies, unknown slash commands) bypass the agent loop entirely, so
-    // we can't rely on the agent loop's early title generation alone.
-    // The agent loop also queues title generation, but isReplaceableTitle
-    // prevents double-writes since the first to complete sets a real title.
-    if (title === GENERATING_TITLE) {
-      queueGenerateConversationTitle({
-        conversationId: conversation.id,
-        context: { origin: "local" },
-        userMessage: msg.initialMessage,
-        onTitleUpdated: (newTitle) => {
-          ctx.send({
-            type: "conversation_title_updated",
-            conversationId: conversation.id,
-            title: newTitle,
-          });
-        },
-      });
-    }
-
-    const requestId = uuid();
-    const transportChannel =
-      parseChannelId(msg.transport?.channelId) ?? "vellum";
-    const sendEvent = makeEventSender({
-      ctx,
-      conversation: conversationObj,
-      conversationId: conversation.id,
-      sourceChannel: transportChannel,
-    });
-    conversationObj.setTurnChannelContext({
-      userMessageChannel: transportChannel,
-      assistantMessageChannel: transportChannel,
-    });
-    const transportInterface: InterfaceId =
-      parseInterfaceId(msg.transport?.interfaceId) ?? "vellum";
-    conversationObj.setTurnInterfaceContext({
-      userMessageInterface: transportInterface,
-      assistantMessageInterface: transportInterface,
-    });
-    // Only create each host proxy for interfaces that support the matching
-    // capability. macOS supports all four; the chrome-extension interface only
-    // supports host_browser. Set before updateClient so updateClient's call to
-    // hostBashProxy.updateSender targets the new proxy.
-    if (supportsHostProxy(transportInterface, "host_bash")) {
-      const proxy = new HostBashProxy(sendEvent, (requestId) => {
-        pendingInteractions.resolve(requestId);
-      });
-      conversationObj.setHostBashProxy(proxy);
-    }
-    if (supportsHostProxy(transportInterface, "host_browser")) {
-      const browserProxy = new HostBrowserProxy(sendEvent, (requestId) => {
-        pendingInteractions.resolve(requestId);
-      });
-      conversationObj.setHostBrowserProxy(browserProxy);
-    }
-    if (supportsHostProxy(transportInterface, "host_file")) {
-      const fileProxy = new HostFileProxy(sendEvent, (requestId) => {
-        pendingInteractions.resolve(requestId);
-      });
-      conversationObj.setHostFileProxy(fileProxy);
-    }
-    if (supportsHostProxy(transportInterface, "host_cu")) {
-      const cuProxy = new HostCuProxy(sendEvent, (requestId) => {
-        pendingInteractions.resolve(requestId);
-      });
-      conversationObj.setHostCuProxy(cuProxy);
-      conversationObj.addPreactivatedSkillId("computer-use");
-    }
-    conversationObj.updateClient(sendEvent, false);
-    conversationObj
-      .processMessage(msg.initialMessage, [], sendEvent, requestId)
-      .catch((err) => {
-        const message = err instanceof Error ? err.message : String(err);
-        log.error(
-          { err, conversationId: conversation.id },
-          "Error processing initial message",
-        );
-        ctx.send({
-          type: "error",
-          message: `Failed to process initial message: ${message}`,
-        });
-
-        // Replace stuck loading placeholder with a stable fallback title
-        // if title generation hasn't already completed or been renamed.
-        try {
-          const current = getConversation(conversation.id);
-          if (current && current.title === GENERATING_TITLE) {
-            const fallback = UNTITLED_FALLBACK;
-            updateConversationTitle(conversation.id, fallback);
-            ctx.send({
-              type: "conversation_title_updated",
-              conversationId: conversation.id,
-              title: fallback,
-            });
-          }
-        } catch {
-          // Best-effort fallback
-        }
-      });
-  }
 }
 
 /**

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -390,7 +390,8 @@ export class DaemonServer {
     this.evictor = new ConversationEvictor(this.conversations);
     getSubagentManager().sharedRequestTimestamps = this.sharedRequestTimestamps;
     getSubagentManager().broadcastToAllClients = (msg) => this.broadcast(msg);
-    getSubagentManager().resolveParentConversation = (id) => this.conversations.get(id);
+    getSubagentManager().resolveParentConversation = (id) =>
+      this.conversations.get(id);
     setBroadcastToAllClients((msg) => this.broadcast(msg));
     this.evictor.onEvict = (conversationId: string) => {
       getSubagentManager().abortAllForParent(conversationId);
@@ -1091,6 +1092,28 @@ export class DaemonServer {
         options?.transport?.chatType,
       ),
     );
+    // Chrome-extension host_browser wiring is intentionally not supported
+    // through this entry point. `prepareConversationForMessage` constructs
+    // host_browser proxies that capture `conversation.getCurrentSender()`
+    // directly, which would route browser frames through the daemon SSE
+    // channel instead of the `ChromeExtensionRegistry`. Chrome-extension
+    // flows reach host_browser exclusively through the
+    // `/v1/messages` flow in `conversation-routes.ts`, which wires a
+    // registry-aware sender and sets `hostBrowserSenderOverride`.
+    //
+    // Fail loudly rather than silently returning a mis-wired proxy so that
+    // any future caller that tries to route chrome-extension through this
+    // path discovers the gap immediately. When the time comes, factor the
+    // wiring in conversation-routes.ts (registry lookup + override) into a
+    // shared helper and call it from both sites.
+    if (resolvedInterface === "chrome-extension") {
+      throw new Error(
+        "prepareConversationForMessage does not yet support chrome-extension transport — " +
+          "use the conversation-routes.ts /v1/messages flow which routes host_browser through " +
+          "the ChromeExtensionRegistry. If you need chrome-extension here, factor out the " +
+          "wiring in conversation-routes.ts into a shared helper.",
+      );
+    }
     // Only create each host proxy for interfaces that support the matching
     // capability. macOS supports all four; the chrome-extension interface only
     // supports host_browser. Non-desktop conversations (CLI, channels, headless)

--- a/assistant/src/runtime/__tests__/browser-extension-pair-routes.test.ts
+++ b/assistant/src/runtime/__tests__/browser-extension-pair-routes.test.ts
@@ -397,3 +397,69 @@ describe("handleBrowserExtensionPair", () => {
     expect(verifyHostBrowserCapability(tampered)).toBeNull();
   });
 });
+
+// ---------------------------------------------------------------------------
+// parseHostHeader — table-driven unit tests for IPv6 / port / malformed edge
+// cases. The handler-level tests above cover end-to-end accept/reject of the
+// pair endpoint; these tests pin down the parser contract itself so that a
+// future refactor of `parseHostHeader` cannot silently change its semantics.
+//
+// Important: `parseHostHeader` does NOT lowercase the hostname — case
+// normalization happens later in `isLoopbackHostHeader`. The tests below
+// reflect that.
+// ---------------------------------------------------------------------------
+describe("parseHostHeader", () => {
+  // [input, expected-parseHostHeader-output]. `null` means "malformed".
+  const cases: Array<[string, string | null]> = [
+    // IPv4 with port
+    ["127.0.0.1:7821", "127.0.0.1"],
+    // Bare IPv4
+    ["127.0.0.1", "127.0.0.1"],
+    // IPv4 in 127.0.0.0/8 range
+    ["127.1.2.3:7821", "127.1.2.3"],
+    // IPv6 with brackets and port
+    ["[::1]:7821", "::1"],
+    // IPv6 with brackets, no port
+    ["[::1]", "::1"],
+    // Bare IPv6 (no brackets, no port) — two or more colons, no brackets,
+    // so treated as a whole IPv6 literal rather than split at the first colon.
+    ["::1", "::1"],
+    // Non-loopback IPv6 with brackets
+    ["[2001:db8::1]:443", "2001:db8::1"],
+    // Non-loopback IPv6, bare (multi-colon → treated as IPv6 literal)
+    ["2001:db8::1", "2001:db8::1"],
+    // Hostname with port
+    ["localhost:7821", "localhost"],
+    // Bare hostname
+    ["localhost", "localhost"],
+    // Mixed-case hostname — the parser preserves case; downstream
+    // `isLoopbackHostHeader` is responsible for case folding.
+    ["LocalHost:7821", "LocalHost"],
+    // Empty string
+    ["", null],
+    // Malformed: content after the closing bracket that isn't `:port`.
+    // Critical security case: `[::1]attacker.com` would slip a non-loopback
+    // hostname past a naive parser that truncates at `]`.
+    ["[::1]attacker.com", null],
+    ["[::1]extra", null],
+    // Malformed: unbalanced brackets (missing closing `]`)
+    ["[::1", null],
+    // Malformed: unbalanced brackets (missing opening `[`) — the leading
+    // character is not `[`, so the bare-host path runs; `"]":"port"` has
+    // two colons so it's treated as an IPv6 literal (garbage in, garbage
+    // out for this edge case — documented for visibility).
+    ["::1]:7821", "::1]:7821"],
+    // Empty brackets: after `[` we see `]` at index 1, after `]` is `:7821`
+    // which is a valid port, so the parser returns the substring between
+    // the brackets — the empty string. `isLoopbackHostHeader` then rejects
+    // it because `""` is not a loopback address.
+    ["[]:7821", ""],
+    // Empty brackets, no port
+    ["[]", ""],
+  ];
+  for (const [input, expected] of cases) {
+    test(`parseHostHeader(${JSON.stringify(input)}) returns ${JSON.stringify(expected)}`, () => {
+      expect(parseHostHeader(input)).toBe(expected);
+    });
+  }
+});

--- a/assistant/src/runtime/capability-tokens.ts
+++ b/assistant/src/runtime/capability-tokens.ts
@@ -285,12 +285,24 @@ export function mintHostBrowserCapability(
 }
 
 /**
- * Verify a capability token. Returns the decoded claims on success or null
- * if the signature is invalid, the payload is malformed, the token has
- * expired, or the bound capability is not `host_browser_command`.
+ * Verify a capability token minted by `mintHostBrowserCapability`.
+ *
+ * Returns the decoded claims on success or null if the signature is
+ * invalid, the payload is malformed, the token has expired, or the bound
+ * capability is not `host_browser_command`.
  *
  * Signature comparison uses `timingSafeEqual` to avoid leaking the secret
  * through timing side channels.
+ *
+ * Phase 2 hand-off: this function has no production caller yet. The
+ * `/v1/browser-relay` WebSocket upgrade handler currently authenticates
+ * with guardian-bound JWTs only. Phase 3 will extend the upgrade handler
+ * to accept capability tokens minted by `mintHostBrowserCapability` so
+ * the chrome extension can present the token from the
+ * `/v1/browser-extension-pair` flow on its WebSocket handshake — at
+ * which point this function becomes the authoritative verifier for
+ * chrome-extension host_browser connections. Until then the tests in
+ * `browser-extension-pair-routes.test.ts` are the only call site.
  */
 export function verifyHostBrowserCapability(
   token: string,

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1177,7 +1177,19 @@ export async function handleSendMessage(
   const browserProxySendToClient: (msg: ServerMessage) => void =
     sourceInterface === "chrome-extension"
       ? (msg) => {
-          const gid = authContext.actorPrincipalId;
+          // Resolve the guardian principal id at send time rather than
+          // capturing it from the POST-time authContext. This closure can be
+          // re-fired on queue drain — if a different actor's POST lands while
+          // the queue is still draining an earlier turn, a captured
+          // authContext.actorPrincipalId would mis-route the earlier turn's
+          // host_browser frames to the *new* actor. Preferring
+          // conversation.trustContext?.guardianPrincipalId makes the routing
+          // follow the conversation's bound guardian, which is stable across
+          // subsequent POSTs. Falls back to the per-POST authContext for
+          // turns that haven't been bound to a trust context yet.
+          const gid =
+            conversation.trustContext?.guardianPrincipalId ??
+            authContext.actorPrincipalId;
           if (!gid) {
             // No guardian identity on this turn — nothing to route to.
             // The proxy will observe this via its try/catch and surface a

--- a/assistant/src/runtime/routes/host-browser-routes.ts
+++ b/assistant/src/runtime/routes/host-browser-routes.ts
@@ -57,7 +57,20 @@ export async function handleHostBrowserResult(
   // Validation passed — consume the pending interaction.
   const interaction = pendingInteractions.resolve(requestId)!;
 
-  interaction.conversation!.resolveHostBrowser(requestId, {
+  // The host_browser kind always has a conversation attached at register time
+  // (HostBrowserProxy.request wires it through), so this guard exists so a
+  // future refactor of pending-interactions can change the type without
+  // silently breaking the host_browser path. Prefer an explicit 400 over an
+  // optional-chain no-op that would leave the proxy request unresolved.
+  if (!interaction.conversation) {
+    return httpError(
+      "BAD_REQUEST",
+      "host_browser pending interaction has no associated conversation",
+      400,
+    );
+  }
+
+  interaction.conversation.resolveHostBrowser(requestId, {
     content: content ?? "",
     isError: isError ?? false,
   });

--- a/clients/chrome-extension/build.sh
+++ b/clients/chrome-extension/build.sh
@@ -13,6 +13,12 @@ DIST_DIR="$SCRIPT_DIR/dist"
 
 echo "Building Vellum browser-relay extension…"
 
+# Type-check with tsc --noEmit before bundling so type errors fail fast
+# rather than surfacing as runtime errors in the loaded extension. `bun build`
+# does not run a TypeScript check — it strips types and bundles.
+echo "Type-checking with tsc --noEmit..."
+(cd "$SCRIPT_DIR" && bunx tsc --noEmit)
+
 # Clean previous build
 rm -rf "$DIST_DIR"
 mkdir -p "$DIST_DIR/background"
@@ -20,6 +26,7 @@ mkdir -p "$DIST_DIR/popup"
 mkdir -p "$DIST_DIR/icons"
 
 # Build service worker
+echo "Bundling service worker with bun build..."
 bun build \
   "$SCRIPT_DIR/background/worker.ts" \
   --outdir "$DIST_DIR/background" \
@@ -28,6 +35,7 @@ bun build \
   --minify
 
 # Build popup script
+echo "Bundling popup script with bun build..."
 bun build \
   "$SCRIPT_DIR/popup/popup.ts" \
   --outdir "$DIST_DIR/popup" \


### PR DESCRIPTION
## Summary
- Derive HOST_TOOL_NAMES from HOST_TOOL_TO_CAPABILITY so the invariant is structural
- Delete dead chrome-extension wiring in handleConversationCreate (zero callers in production code)
- Add explicit assert in prepareConversationForMessage to fail loudly if chrome-extension reaches it
- Add tsc --noEmit step to chrome-extension build.sh so type errors are caught at build time
- Tighten host-browser-routes.ts non-null assertion with an explicit guard + 400 response
- Resolve chrome-extension registry guardianId at send-time from conversation.trustContext instead of captured per-POST authContext
- Add parseHostHeader IPv6 edge-case unit tests (table-driven)
- Add Phase 3 hand-off comments to verifyHostBrowserCapability and browser-session/index.ts

Addresses items 6-13 from the round-4 self-review of PR #24159.

## Original prompt
one PR for items 1-5 and also /do in parallel another PR for items 6-13
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24245" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
