### PR TITLE
fix(host-browser): Phase 2 follow-ups (P1 + P2 cleanups)

### DIFF
--- a/assistant/src/__tests__/extension-id-sync-guard.test.ts
+++ b/assistant/src/__tests__/extension-id-sync-guard.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Sync guard: the dev placeholder chrome extension id is referenced
+ * from three coupled files that MUST be updated in lockstep:
+ *
+ *   - assistant/src/runtime/routes/browser-extension-pair-routes.ts
+ *     (`ALLOWED_EXTENSION_ORIGINS`)
+ *   - clients/chrome-extension-native-host/src/index.ts
+ *     (`ALLOWED_EXTENSION_IDS`)
+ *   - clients/macos/vellum-assistant/App/AppDelegate+NativeMessaging.swift
+ *     (`ChromeExtensionAllowlist.devPlaceholderId`)
+ *
+ * If any single file is updated without the other two, the self-hosted
+ * pair flow breaks silently: the native host rejects the extension
+ * origin, the assistant's pair route rejects the request, or the macOS
+ * installer writes a stale `allowed_origins` entry to the native
+ * messaging manifest.
+ *
+ * Before releasing the extension publicly, all three references must
+ * flip from the dev placeholder (`aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`) to
+ * the real production id at the same time. This test fails the moment
+ * any single reference drifts out of sync, forcing the update to span
+ * all three files (and catches accidental divergence between them).
+ */
+
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { describe, test } from "bun:test";
+
+const repoRoot = resolve(__dirname, "..", "..", "..");
+
+const COUPLED_FILES: ReadonlyArray<string> = [
+  "assistant/src/runtime/routes/browser-extension-pair-routes.ts",
+  "clients/chrome-extension-native-host/src/index.ts",
+  "clients/macos/vellum-assistant/App/AppDelegate+NativeMessaging.swift",
+];
+
+/**
+ * The shared dev placeholder extension id. Must match the literal
+ * embedded in each of the coupled files above.
+ */
+const DEV_PLACEHOLDER_ID = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+describe("dev extension ID sync guard", () => {
+  test("all three coupled files reference the same dev placeholder id", () => {
+    const mismatches: Array<{ file: string; reason: string }> = [];
+
+    for (const relPath of COUPLED_FILES) {
+      const absPath = join(repoRoot, relPath);
+      let content: string;
+      try {
+        content = readFileSync(absPath, "utf8");
+      } catch (err) {
+        mismatches.push({
+          file: relPath,
+          reason: `could not read: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        });
+        continue;
+      }
+      if (!content.includes(DEV_PLACEHOLDER_ID)) {
+        mismatches.push({
+          file: relPath,
+          reason: `does not contain the dev placeholder id '${DEV_PLACEHOLDER_ID}'`,
+        });
+      }
+    }
+
+    if (mismatches.length > 0) {
+      const lines = mismatches
+        .map((m) => `  - ${m.file}: ${m.reason}`)
+        .join("\n");
+      throw new Error(
+        `Dev chrome extension id sync guard failed. All of ${JSON.stringify(
+          COUPLED_FILES,
+        )} must contain the shared id '${DEV_PLACEHOLDER_ID}':\n${lines}\n\n` +
+          `If you are rotating to the production extension id, update all three files ` +
+          `AND update DEV_PLACEHOLDER_ID in this test at the same time.`,
+      );
+    }
+  });
+
+  test("the shared id is referenced at least once in each file (not just in a comment)", () => {
+    // Stronger assertion: make sure the id appears as part of a string
+    // literal (not purely in a stale comment). We look for common
+    // string-literal quoting markers adjacent to the id.
+    const quotingRegexes: ReadonlyArray<RegExp> = [
+      new RegExp(`"${DEV_PLACEHOLDER_ID}"`),
+      new RegExp(`'${DEV_PLACEHOLDER_ID}'`),
+      new RegExp(`\`${DEV_PLACEHOLDER_ID}\``),
+      // Allow it to appear inside a chrome-extension URL literal too.
+      new RegExp(`"chrome-extension://${DEV_PLACEHOLDER_ID}/"`),
+      new RegExp(`'chrome-extension://${DEV_PLACEHOLDER_ID}/'`),
+    ];
+
+    const missing: string[] = [];
+    for (const relPath of COUPLED_FILES) {
+      const absPath = join(repoRoot, relPath);
+      const content = readFileSync(absPath, "utf8");
+      const hasStringLiteral = quotingRegexes.some((re) => re.test(content));
+      if (!hasStringLiteral) {
+        missing.push(relPath);
+      }
+    }
+
+    if (missing.length > 0) {
+      throw new Error(
+        `The following files reference the dev placeholder id only in ` +
+          `comments — it should appear as a live string literal ` +
+          `(the runtime allowlist entry), not just in documentation: ` +
+          `${JSON.stringify(missing)}`,
+      );
+    }
+  });
+});

--- a/assistant/src/runtime/AGENTS.md
+++ b/assistant/src/runtime/AGENTS.md
@@ -61,6 +61,18 @@ Host browser allows the assistant to proxy CDP (Chrome DevTools Protocol) JSON-R
   - `POST /v1/host-browser-result` — `{ requestId, content, isError }`
 - **Tracking**: Uses the same `pending-interactions` tracker as the other host proxy types, with `kind: "host_browser"`. Registration happens in `conversation-routes.ts` and the route handler is in `host-browser-routes.ts`.
 
+### `chrome-extension` interface (Phase 2)
+
+The `chrome-extension` interface in `INTERFACE_IDS` is a non-interactive transport that supports only the `host_browser` capability — it does NOT support `host_bash`, `host_file`, or `host_cu`. This is encoded in `supportsHostProxy(id, capability)`: passing a capability argument returns `true` for `chrome-extension` only when the capability is `host_browser`; the no-arg form returns `false` for `chrome-extension` (so legacy desktop-only call sites that assume full-desktop proxy availability continue to gate correctly).
+
+Unlike the SSE-based host proxies used by the macOS client, `host_browser_request` frames for the chrome-extension interface do NOT travel through `assistantEventHub`. Instead they are routed through the `ChromeExtensionRegistry` singleton (`runtime/chrome-extension-registry.ts`), which tracks active chrome-extension WebSocket connections keyed by `guardianId`. The registry is populated on WebSocket `open` and drained on `close` inside `http-server.ts`'s `/v1/browser-relay` handlers — see the `wsType === "browser-relay"` branches.
+
+`Conversation.hostBrowserSenderOverride` is the integration point between the turn layer and the registry. When a turn for a chrome-extension interface enters the routes layer, `conversation-routes.ts` resolves the active registry entry for the caller's guardian and sets the override to a sender that writes to that WebSocket. `Conversation.restoreBrowserProxyAvailability()` re-threads the override on queue drain — without this, the drain path would clobber the registry-routed sender with the default `sendToClient` (pointed at the SSE hub) and `host_browser_request` frames would stop reaching the extension mid-queue.
+
+Capability token bootstrap for self-hosted deployments is handled by `routes/browser-extension-pair-routes.ts` (loopback-only; mints a guardian-bound HMAC capability token via `capability-tokens.ts`). Cloud deployments issue guardian-bound JWTs via the gateway's WorkOS-backed flow — `browser-extension-pair-routes.ts` is not involved.
+
+See `docs/browser-use-architecture-phase2.md` for the full wire diagram and component inventory.
+
 ### Channel approvals (Telegram, Slack)
 
 Channel approval flows use `requestId` (not `runId`) as the primary identifier:

--- a/assistant/src/runtime/__tests__/capability-tokens.test.ts
+++ b/assistant/src/runtime/__tests__/capability-tokens.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Tests for the capability-token secret lifecycle and mint/verify
+ * helpers. These paths are covered transitively by
+ * `browser-extension-pair-routes.test.ts` for the happy-path mint flow,
+ * but the on-disk secret lifecycle (first-call creation with mode 0600,
+ * legacy workspace → protected migration, corrupt-secret regeneration)
+ * has no direct coverage elsewhere.
+ *
+ * All tests use temp directories and inject paths via the
+ * `CapabilityTokenSecretPaths` parameter so none of them touch the real
+ * `~/.vellum/` tree. Mint/verify tests inject a deterministic secret
+ * via `setCapabilityTokenSecretForTests` + `resetCapabilityTokenSecretForTests`.
+ */
+
+import { randomBytes } from "node:crypto";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  type CapabilityTokenSecretPaths,
+  loadOrCreateCapabilityTokenSecret,
+  mintHostBrowserCapability,
+  resetCapabilityTokenSecretForTests,
+  setCapabilityTokenSecretForTests,
+  verifyHostBrowserCapability,
+} from "../capability-tokens.js";
+
+// ---------------------------------------------------------------------------
+// Temp-directory helpers
+// ---------------------------------------------------------------------------
+
+interface TempPaths extends CapabilityTokenSecretPaths {
+  root: string;
+  protectedDir: string;
+  legacyDir: string;
+}
+
+function makeTempPaths(): TempPaths {
+  const root = mkdtempSync(join(tmpdir(), "vellum-cap-tok-"));
+  const protectedDir = join(root, "protected");
+  const legacyDir = join(root, "workspace", "data");
+  return {
+    root,
+    protectedDir,
+    legacyDir,
+    secretPath: join(protectedDir, "capability-token-secret"),
+    legacySecretPath: join(legacyDir, "capability-token-secret"),
+  };
+}
+
+function cleanupTempPaths(paths: TempPaths): void {
+  try {
+    rmSync(paths.root, { recursive: true, force: true });
+  } catch {
+    // best-effort
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Secret lifecycle
+// ---------------------------------------------------------------------------
+
+describe("loadOrCreateCapabilityTokenSecret", () => {
+  let paths: TempPaths;
+
+  beforeEach(() => {
+    paths = makeTempPaths();
+  });
+
+  afterEach(() => {
+    cleanupTempPaths(paths);
+  });
+
+  test("first call generates a fresh 32-byte secret and persists it with mode 0600", () => {
+    const secret = loadOrCreateCapabilityTokenSecret(paths);
+    expect(secret.length).toBe(32);
+    expect(existsSync(paths.secretPath)).toBe(true);
+
+    const mode = statSync(paths.secretPath).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
+  test("second call returns the same bytes persisted on the first call", () => {
+    const first = loadOrCreateCapabilityTokenSecret(paths);
+    const second = loadOrCreateCapabilityTokenSecret(paths);
+    expect(Buffer.compare(first, second)).toBe(0);
+  });
+
+  test("legacy workspace secret is migrated into the protected directory and removed from workspace", () => {
+    mkdirSync(paths.legacyDir, { recursive: true });
+    const legacySecret = randomBytes(32);
+    writeFileSync(paths.legacySecretPath, legacySecret, { mode: 0o600 });
+    expect(existsSync(paths.legacySecretPath)).toBe(true);
+    expect(existsSync(paths.secretPath)).toBe(false);
+
+    const loaded = loadOrCreateCapabilityTokenSecret(paths);
+
+    expect(Buffer.compare(loaded, legacySecret)).toBe(0);
+    // After migration, legacy copy is gone and the protected copy is
+    // the authoritative location.
+    expect(existsSync(paths.legacySecretPath)).toBe(false);
+    expect(existsSync(paths.secretPath)).toBe(true);
+    const persisted = readFileSync(paths.secretPath);
+    expect(Buffer.compare(persisted, legacySecret)).toBe(0);
+
+    // Migrated file should inherit 0o600 too.
+    const mode = statSync(paths.secretPath).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
+  test("a corrupt / truncated secret file is regenerated instead of throwing", () => {
+    mkdirSync(paths.protectedDir, { recursive: true });
+    writeFileSync(paths.secretPath, Buffer.from([0x00, 0x01, 0x02]), {
+      mode: 0o600,
+    });
+    expect(statSync(paths.secretPath).size).toBe(3);
+
+    const loaded = loadOrCreateCapabilityTokenSecret(paths);
+
+    expect(loaded.length).toBe(32);
+    const persisted = readFileSync(paths.secretPath);
+    expect(persisted.length).toBe(32);
+    expect(Buffer.compare(loaded, persisted)).toBe(0);
+  });
+
+  test("a legacy secret with unexpected length is ignored and a fresh secret is generated", () => {
+    mkdirSync(paths.legacyDir, { recursive: true });
+    writeFileSync(paths.legacySecretPath, Buffer.from([0xaa, 0xbb]), {
+      mode: 0o600,
+    });
+
+    const loaded = loadOrCreateCapabilityTokenSecret(paths);
+
+    expect(loaded.length).toBe(32);
+    // Short legacy file is left alone (it doesn't look like a valid
+    // legacy secret) and a fresh secret is written to the protected path.
+    expect(existsSync(paths.secretPath)).toBe(true);
+    const persisted = readFileSync(paths.secretPath);
+    expect(Buffer.compare(persisted, loaded)).toBe(0);
+  });
+
+  test("an unreadable (permission-denied) secret file is regenerated", () => {
+    mkdirSync(paths.protectedDir, { recursive: true });
+    writeFileSync(paths.secretPath, randomBytes(32), { mode: 0o600 });
+    // Strip read permissions so readFileSync throws. Skip the test if
+    // we're running as root (where chmod can't lock us out).
+    if (process.getuid && process.getuid() === 0) {
+      return;
+    }
+    chmodSync(paths.secretPath, 0o000);
+
+    const loaded = loadOrCreateCapabilityTokenSecret(paths);
+    expect(loaded.length).toBe(32);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mint / verify
+// ---------------------------------------------------------------------------
+
+describe("mint / verify round trip", () => {
+  beforeEach(() => {
+    // Inject a deterministic secret so mint/verify don't depend on the
+    // on-disk secret file at all.
+    setCapabilityTokenSecretForTests(randomBytes(32));
+  });
+
+  afterEach(() => {
+    resetCapabilityTokenSecretForTests();
+  });
+
+  test("a freshly minted token verifies and decodes to the same guardian id", () => {
+    const { token, expiresAt } = mintHostBrowserCapability("guardian-abc");
+    expect(typeof token).toBe("string");
+    expect(expiresAt).toBeGreaterThan(Date.now());
+
+    const claims = verifyHostBrowserCapability(token);
+    expect(claims).not.toBeNull();
+    expect(claims?.guardianId).toBe("guardian-abc");
+    expect(claims?.capability).toBe("host_browser_command");
+    expect(claims?.expiresAt).toBe(expiresAt);
+  });
+
+  test("a tampered payload fails verification", () => {
+    const { token } = mintHostBrowserCapability("guardian-abc");
+    // Flip the last character of the payload half to invalidate the
+    // HMAC signature (payload is `<b64>.<b64>`; we mutate before the dot).
+    const dot = token.indexOf(".");
+    const payload = token.slice(0, dot);
+    const sig = token.slice(dot + 1);
+    const lastChar = payload[payload.length - 1]!;
+    const replacement = lastChar === "A" ? "B" : "A";
+    const mutatedPayload = payload.slice(0, -1) + replacement;
+    const mutated = `${mutatedPayload}.${sig}`;
+
+    const claims = verifyHostBrowserCapability(mutated);
+    expect(claims).toBeNull();
+  });
+
+  test("a tampered signature fails verification", () => {
+    const { token } = mintHostBrowserCapability("guardian-abc");
+    const dot = token.indexOf(".");
+    const payload = token.slice(0, dot);
+    const sig = token.slice(dot + 1);
+    const lastChar = sig[sig.length - 1]!;
+    const replacement = lastChar === "A" ? "B" : "A";
+    const mutatedSig = sig.slice(0, -1) + replacement;
+    const mutated = `${payload}.${mutatedSig}`;
+
+    const claims = verifyHostBrowserCapability(mutated);
+    expect(claims).toBeNull();
+  });
+
+  test("a malformed token with no `.` separator fails verification", () => {
+    const claims = verifyHostBrowserCapability("not-a-token");
+    expect(claims).toBeNull();
+  });
+
+  test("an expired token fails verification", () => {
+    // Mint with a tiny negative TTL so the token is born expired.
+    // verifyHostBrowserCapability checks `expiresAt <= Date.now()` and
+    // rejects.
+    const { token } = mintHostBrowserCapability("guardian-abc", -1);
+    const claims = verifyHostBrowserCapability(token);
+    expect(claims).toBeNull();
+  });
+
+  test("a token issued under one secret fails verification under a different secret", () => {
+    // Mint with the current test secret.
+    const { token } = mintHostBrowserCapability("guardian-abc");
+    // Rotate the secret — the old token's HMAC no longer matches.
+    setCapabilityTokenSecretForTests(randomBytes(32));
+    const claims = verifyHostBrowserCapability(token);
+    expect(claims).toBeNull();
+  });
+
+  test("tokens for different guardians carry distinct claims", () => {
+    const { token: a } = mintHostBrowserCapability("guardian-a");
+    const { token: b } = mintHostBrowserCapability("guardian-b");
+    expect(a).not.toBe(b);
+
+    const claimsA = verifyHostBrowserCapability(a);
+    const claimsB = verifyHostBrowserCapability(b);
+    expect(claimsA?.guardianId).toBe("guardian-a");
+    expect(claimsB?.guardianId).toBe("guardian-b");
+  });
+});

--- a/assistant/src/runtime/capability-tokens.ts
+++ b/assistant/src/runtime/capability-tokens.ts
@@ -87,6 +87,19 @@ function getLegacySecretPath(): string {
 }
 
 /**
+ * Path overrides used by unit tests to drive the secret lifecycle
+ * without touching the real `~/.vellum/` tree. Production callers must
+ * omit this argument so the canonical paths (`getProtectedDir()` +
+ * `getDataDir()`) are used.
+ */
+export interface CapabilityTokenSecretPaths {
+  /** Protected-directory secret path (authoritative). */
+  secretPath: string;
+  /** Legacy workspace-directory secret path (migration source). */
+  legacySecretPath: string;
+}
+
+/**
  * Load the capability-token secret from disk or generate and persist a new
  * one. Atomically writes with mode 0o600 so the secret is not readable by
  * other users on the same host.
@@ -94,9 +107,16 @@ function getLegacySecretPath(): string {
  * Migration: if the secret exists only at the legacy workspace path, copy
  * it into the protected directory and delete the workspace copy so we do
  * not leave security-sensitive material inside `workspace/`.
+ *
+ * The optional `paths` argument is for unit tests only — production
+ * callers must omit it and use the canonical `~/.vellum/protected/` /
+ * `~/.vellum/workspace/data/` paths.
  */
-export function loadOrCreateCapabilityTokenSecret(): Buffer {
-  const keyPath = getSecretPath();
+export function loadOrCreateCapabilityTokenSecret(
+  paths?: CapabilityTokenSecretPaths,
+): Buffer {
+  const keyPath = paths?.secretPath ?? getSecretPath();
+  const legacyPath = paths?.legacySecretPath ?? getLegacySecretPath();
   if (existsSync(keyPath)) {
     try {
       const raw = readFileSync(keyPath);
@@ -119,7 +139,7 @@ export function loadOrCreateCapabilityTokenSecret(): Buffer {
   // generate a fresh one. If this succeeds we end up with the legacy
   // secret persisted at the protected path and the workspace copy
   // removed, preserving every outstanding token across the upgrade.
-  const migrated = migrateLegacyCapabilityTokenSecret();
+  const migrated = migrateLegacyCapabilityTokenSecret(keyPath, legacyPath);
   if (migrated) {
     return migrated;
   }
@@ -159,8 +179,10 @@ function writeSecretAtomic(keyPath: string, secret: Buffer): void {
  * successfully, or `undefined` if there was nothing to migrate or the
  * migration failed.
  */
-function migrateLegacyCapabilityTokenSecret(): Buffer | undefined {
-  const legacyPath = getLegacySecretPath();
+function migrateLegacyCapabilityTokenSecret(
+  secretPath: string,
+  legacyPath: string,
+): Buffer | undefined {
   if (!existsSync(legacyPath)) {
     return undefined;
   }
@@ -173,7 +195,7 @@ function migrateLegacyCapabilityTokenSecret(): Buffer | undefined {
       );
       return undefined;
     }
-    writeSecretAtomic(getSecretPath(), raw);
+    writeSecretAtomic(secretPath, raw);
     try {
       unlinkSync(legacyPath);
     } catch (err) {
@@ -183,7 +205,7 @@ function migrateLegacyCapabilityTokenSecret(): Buffer | undefined {
       );
     }
     log.info(
-      { from: legacyPath, to: getSecretPath() },
+      { from: legacyPath, to: secretPath },
       "Migrated capability token secret out of workspace into protected directory",
     );
     return raw;

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -10,6 +10,7 @@ import {
   mkdirSync,
   readFileSync,
   renameSync,
+  unlinkSync,
   writeFileSync,
 } from "node:fs";
 import { dirname, resolve } from "node:path";
@@ -508,6 +509,28 @@ export class RuntimeHttpServer {
     }
   }
 
+  /**
+   * Remove the runtime port file written by `writeRuntimePortFile`.
+   * Called from `stop()` on clean shutdown so a stale file does not
+   * point thin helpers (e.g. the chrome-extension native messaging
+   * helper) at a dead port until the next daemon start overwrites it.
+   * Best-effort — unlink failures never block shutdown.
+   *
+   * Note: this only runs on graceful shutdown. A crash leaves the
+   * file in place; the next successful startup overwrites it.
+   */
+  private removeRuntimePortFile(): void {
+    try {
+      const portFile = getRuntimePortFilePath();
+      if (existsSync(portFile)) {
+        unlinkSync(portFile);
+        log.info({ portFile }, "Removed runtime port file");
+      }
+    } catch (err) {
+      log.warn({ err }, "Failed to remove runtime port file");
+    }
+  }
+
   async stop(): Promise<void> {
     this.pairingStore.stop();
     stopGuardianExpirySweep();
@@ -522,6 +545,7 @@ export class RuntimeHttpServer {
       this.server = null;
       log.info("Runtime HTTP server stopped");
     }
+    this.removeRuntimePortFile();
   }
 
   private async handleRequest(

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -5,8 +5,14 @@
  * configured port (default: 7821).
  */
 
-import { existsSync, readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, resolve } from "node:path";
 
 import type { ServerWebSocket } from "bun";
 
@@ -63,6 +69,7 @@ import {
 } from "../security/oauth-callback-registry.js";
 import { UserError } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
+import { getRuntimePortFilePath } from "../util/platform.js";
 import { buildAssistantEvent } from "./assistant-event.js";
 import { assistantEventHub } from "./assistant-event-hub.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "./assistant-scope.js";
@@ -469,6 +476,36 @@ export class RuntimeHttpServer {
       },
       "Runtime HTTP server listening",
     );
+
+    // Advertise the actual port to thin helpers that need to reach the
+    // runtime without inheriting the daemon's environment (e.g. the
+    // chrome-extension native messaging helper, spawned by Chrome).
+    this.writeRuntimePortFile(this.actualPort);
+  }
+
+  /**
+   * Atomically publish the runtime HTTP port to ~/.vellum/runtime-port so
+   * external helpers can locate a non-default `RUNTIME_HTTP_PORT` without
+   * any manifest changes. Best-effort — write failures never block
+   * daemon startup (see assistant/CLAUDE.md "Daemon startup philosophy").
+   */
+  private writeRuntimePortFile(actualPort: number): void {
+    try {
+      const portFile = getRuntimePortFilePath();
+      const dir = dirname(portFile);
+      if (!existsSync(dir)) {
+        mkdirSync(dir, { recursive: true });
+      }
+      const tmpPath = `${portFile}.tmp.${process.pid}`;
+      writeFileSync(tmpPath, String(actualPort), { mode: 0o644 });
+      renameSync(tmpPath, portFile);
+      log.info({ portFile, actualPort }, "Wrote runtime port file");
+    } catch (err) {
+      log.warn(
+        { err },
+        "Failed to write runtime port file; non-default assistant ports may require --assistant-port on thin helpers",
+      );
+    }
   }
 
   async stop(): Promise<void> {

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -488,7 +488,7 @@ export class RuntimeHttpServer {
    * Atomically publish the runtime HTTP port to ~/.vellum/runtime-port so
    * external helpers can locate a non-default `RUNTIME_HTTP_PORT` without
    * any manifest changes. Best-effort — write failures never block
-   * daemon startup (see assistant/CLAUDE.md "Daemon startup philosophy").
+   * daemon startup (see assistant/AGENTS.md "Daemon startup philosophy").
    */
   private writeRuntimePortFile(actualPort: number): void {
     try {

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -516,16 +516,39 @@ export class RuntimeHttpServer {
    * helper) at a dead port until the next daemon start overwrites it.
    * Best-effort — unlink failures never block shutdown.
    *
+   * The unlink is conditional: we only remove the file if its current
+   * contents still match this server's port. The runtime-port file
+   * lives at the user-home level (`~/.vellum/runtime-port`) and is
+   * therefore shared across multiple daemon instances running on
+   * different `RUNTIME_HTTP_PORT`s. If a sibling instance has already
+   * rewritten the file with its own port, deleting it would strand
+   * thin helpers on the default port `7821` and break their ability
+   * to reach the still-running sibling.
+   *
    * Note: this only runs on graceful shutdown. A crash leaves the
    * file in place; the next successful startup overwrites it.
    */
   private removeRuntimePortFile(): void {
     try {
       const portFile = getRuntimePortFilePath();
-      if (existsSync(portFile)) {
-        unlinkSync(portFile);
-        log.info({ portFile }, "Removed runtime port file");
+      if (!existsSync(portFile)) return;
+      // Read-then-compare-then-unlink. Race-safe enough: the worst case
+      // is that another instance writes the file between our read and
+      // our unlink, in which case we erroneously delete its mapping.
+      // That window is short (a few microseconds) and a sibling startup
+      // will rewrite the file on its next port-publish call. The much
+      // more common multi-instance race — sibling already overwrote
+      // before our stop() runs — is correctly handled here as a no-op.
+      const current = readFileSync(portFile, "utf-8").trim();
+      if (current !== String(this.actualPort)) {
+        log.info(
+          { portFile, current, actualPort: this.actualPort },
+          "Leaving runtime port file alone — owned by another instance",
+        );
+        return;
       }
+      unlinkSync(portFile);
+      log.info({ portFile }, "Removed runtime port file");
     } catch (err) {
       log.warn({ err }, "Failed to remove runtime port file");
     }

--- a/assistant/src/runtime/routes/browser-extension-pair-routes.ts
+++ b/assistant/src/runtime/routes/browser-extension-pair-routes.ts
@@ -44,12 +44,19 @@ export type PairServerContext = {
  * Hard-coded allowlist of chrome extension origins permitted to request a
  * capability token. Mirrors the placeholder id used by the native messaging
  * helper at `clients/chrome-extension-native-host/src/index.ts`
- * (`ALLOWED_EXTENSION_IDS`). Both lists must agree for the dev pair flow
- * to work end-to-end — update them together before release.
+ * (`ALLOWED_EXTENSION_IDS`) and the macOS installer at
+ * `clients/macos/vellum-assistant/App/AppDelegate+NativeMessaging.swift`
+ * (`devPlaceholderId`). All three must agree for the dev pair flow to work
+ * end-to-end — the
+ * `assistant/src/__tests__/extension-id-sync-guard.test.ts` sync guard
+ * will fail if any of the three drifts out of sync, so update them
+ * together before release.
  */
 export const ALLOWED_EXTENSION_ORIGINS: ReadonlySet<string> = new Set<string>([
   // Dev placeholder — replaced when the unpacked extension is loaded locally.
-  // TODO: production chrome extension id before release
+  // SYNC: update alongside the native host and macOS installer constants
+  // (see extension-id-sync-guard.test.ts). TODO: production chrome extension
+  // id before release.
   "chrome-extension://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/",
 ]);
 

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -185,6 +185,18 @@ export function getPidPath(): string {
   return join(vellumRoot(), "vellum.pid");
 }
 
+/**
+ * Returns the path to the runtime HTTP port file (~/.vellum/runtime-port).
+ * The daemon writes its active HTTP port here on startup so thin helpers
+ * that need to reach the runtime (e.g. the chrome-extension native messaging
+ * helper) can locate a non-default `RUNTIME_HTTP_PORT` without a manifest
+ * change. Root-level path by design — the file is read by helpers that may
+ * not know the workspace override path.
+ */
+export function getRuntimePortFilePath(): string {
+  return join(vellumRoot(), "runtime-port");
+}
+
 export function getDbPath(): string {
   return join(getDataDir(), "db", "assistant.db");
 }

--- a/clients/chrome-extension-native-host/README.md
+++ b/clients/chrome-extension-native-host/README.md
@@ -117,22 +117,16 @@ precedence (highest first):
    named local instances spawned by `cli/src/lib/local.ts` which set
    `RUNTIME_HTTP_PORT` from `resources.daemonPort`).
 2. **`~/.vellum/runtime-port`** lockfile — a single integer written by
-   the assistant on startup. *Note: this lockfile is not yet written by
-   the assistant — see the TODO below.* Once it is, default installs
-   will not need any manifest-side configuration.
+   the assistant on startup via
+   `RuntimeHttpServer.writeRuntimePortFile()`. Default installs (and any
+   setup with a single running assistant) resolve their port through
+   this file without any manifest-side configuration.
 3. **`7821`** — the well-known default port.
 
 If a step fails (file missing, parse error, etc.), resolution falls
 through to the next step. The subsequent HTTP request will surface a
 clear connection error if the assistant isn't actually listening on the
 resolved port.
-
-> **TODO (follow-up):** Have the assistant write its active HTTP port
-> to `~/.vellum/runtime-port` on startup so the lockfile branch above
-> starts working without requiring `--assistant-port`. This was
-> intentionally left out of the scaffold PR (PR 7) to keep the change
-> surface small. Until then, multi-instance installs should rely on the
-> CLI flag via a wrapper script in the native messaging manifest.
 
 ## Building
 

--- a/clients/chrome-extension-native-host/src/index.ts
+++ b/clients/chrome-extension-native-host/src/index.ts
@@ -44,9 +44,18 @@ import { decodeFrames, encodeFrame, FrameDecodeError } from "./protocol.js";
  * Chrome passes the calling extension's origin as the first positional
  * argument, e.g. `chrome-extension://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/`.
  * Anything not on this list is rejected before any further processing.
+ *
+ * Must agree with `ALLOWED_EXTENSION_ORIGINS` in
+ * `assistant/src/runtime/routes/browser-extension-pair-routes.ts` and
+ * `devPlaceholderId` in
+ * `clients/macos/vellum-assistant/App/AppDelegate+NativeMessaging.swift`.
+ * The sync guard at `assistant/src/__tests__/extension-id-sync-guard.test.ts`
+ * fails CI if any of the three drifts out of sync.
  */
 const ALLOWED_EXTENSION_IDS: ReadonlySet<string> = new Set<string>([
   // Dev placeholder — replaced when the unpacked extension is loaded locally.
+  // SYNC: update alongside the assistant pair route and macOS installer
+  // constants (see extension-id-sync-guard.test.ts).
   // TODO: production id before release
   "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 ]);
@@ -98,10 +107,10 @@ function parseAssistantPortArg(argv: readonly string[]): number | null {
  *      so a wrapper script registered in Chrome's NativeMessagingHosts
  *      manifest can pin the helper to a known port without relying on a
  *      lockfile.
- *   2. `~/.vellum/runtime-port` lockfile (a single integer). This file is
- *      not yet written by the assistant — see the TODO in this package's
- *      README. Once it is, no manifest changes are needed for default
- *      installs.
+ *   2. `~/.vellum/runtime-port` lockfile (a single integer). The assistant
+ *      writes this file on HTTP server startup via
+ *      `RuntimeHttpServer.writeRuntimePortFile()`, so default installs do
+ *      not need any manifest-side configuration.
  *   3. The well-known default port `7821`.
  *
  * Any read or parse failure on the lockfile silently falls through to the

--- a/clients/chrome-extension/background/worker.ts
+++ b/clients/chrome-extension/background/worker.ts
@@ -388,10 +388,11 @@ async function handleServerMessage(raw: string): Promise<void> {
   }
 
   // Phase 2 PR 9: host_browser_* envelopes are dispatched via the CDP proxy
-  // only when the feature flag is on. With the flag off we return early and
-  // let the daemon's host-browser-proxy time out gracefully — the envelope
-  // is NOT forwarded to the legacy ExtensionCommand dispatch because its
-  // shape is incompatible.
+  // only when the feature flag is on. With the flag off we synthesize an
+  // immediate error result so the daemon side clears its pending interaction
+  // instantly instead of waiting for host-browser-proxy to time out. The
+  // envelope is NOT forwarded to the legacy ExtensionCommand dispatch because
+  // its shape is incompatible.
   if (
     parsed !== null &&
     typeof parsed === 'object' &&
@@ -400,7 +401,27 @@ async function handleServerMessage(raw: string): Promise<void> {
   ) {
     const envelopeType = (parsed as { type: string }).type;
     if (envelopeType === 'host_browser_request') {
-      if (!cdpProxyEnabled) return;
+      if (!cdpProxyEnabled) {
+        console.warn(
+          '[vellum-relay] host_browser_request received but cdpProxyEnabled=false; returning error',
+        );
+        const request = parsed as HostBrowserRequestEnvelope;
+        const errorResult: HostBrowserResultEnvelope = {
+          requestId: request.requestId,
+          content:
+            'Vellum CDP browser proxy is not enabled in this extension. Enable the "Host browser CDP proxy" toggle in the popup to use host_browser.',
+          isError: true,
+        };
+        try {
+          await dispatchHostBrowserResult(errorResult);
+        } catch (err) {
+          console.warn(
+            '[vellum-relay] Failed to dispatch cdpProxyEnabled=false error result',
+            err,
+          );
+        }
+        return;
+      }
       await hostBrowserDispatcher.handle(parsed as HostBrowserRequestEnvelope);
       return;
     }

--- a/clients/macos/vellum-assistant/App/AppDelegate+NativeMessaging.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+NativeMessaging.swift
@@ -94,17 +94,22 @@ extension AppDelegate {
 /// Hard-coded allowlist of Chrome extension IDs the installer pins
 /// into the manifest's `allowed_origins`. Must stay in lockstep with
 /// `ALLOWED_EXTENSION_IDS` in
-/// `clients/chrome-extension-native-host/src/index.ts` (PR 7) and the
-/// allowlist the assistant's `/v1/browser-extension-pair` endpoint
-/// checks (PR 11).
+/// `clients/chrome-extension-native-host/src/index.ts` and
+/// `ALLOWED_EXTENSION_ORIGINS` in
+/// `assistant/src/runtime/routes/browser-extension-pair-routes.ts`.
+/// The sync guard at
+/// `assistant/src/__tests__/extension-id-sync-guard.test.ts` fails CI
+/// if any of the three drifts out of sync.
 ///
 /// Kept in a standalone enum so unit tests can reference it without
 /// instantiating `AppDelegate`.
 enum ChromeExtensionAllowlist {
     /// Dev placeholder id. Matches the single entry currently present
-    /// in the helper binary's allowlist in PR 7. Replaced before
-    /// release with the production extension id — see the
-    /// `TODO: production id before release` comment in
+    /// in the helper binary's allowlist and the assistant's pair route
+    /// allowlist. Replaced before release with the production extension
+    /// id — see the `TODO: production id before release` comment in
     /// `clients/chrome-extension-native-host/src/index.ts`.
+    // SYNC: update alongside the assistant pair route and native host
+    // constants (see extension-id-sync-guard.test.ts).
     static let devPlaceholderId = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 }

--- a/docs/browser-use-architecture-phase2.md
+++ b/docs/browser-use-architecture-phase2.md
@@ -1,22 +1,248 @@
-# Browser Use Architecture — Phase 2 notes
+# Browser Use Architecture — Phase 2
 
-## chrome.debugger infobar
+This doc describes the architecture of **Phase 2 browser use**: the Chrome
+extension transport that lets the assistant drive a browser on the user's
+machine via CDP (Chrome DevTools Protocol) JSON-RPC, without bundling a
+headful Chromium.
 
-When the Chrome extension calls `chrome.debugger.attach(target, requiredVersion)`, Chrome displays a persistent yellow infobar at the top of the affected tab saying "Vellum started debugging this browser." This is an intentional security mitigation — it cannot be suppressed via the public MV3 API.
+Phase 2 replaces the legacy `ExtensionCommand` action dispatch
+(`evaluate`, `navigate`, `screenshot`, …) with a generic, future-proof
+`host_browser_request` / `host_browser_result` envelope pair that carries
+raw CDP method names and params. The action dispatch remains in place
+under a feature flag so existing installs continue to work unchanged.
 
-### Investigation (Phase 2)
+## Overview
 
-- `chrome.debugger.attach(target, requiredVersion, callback)` — three-argument form, no options parameter. Chrome 120+. (https://developer.chrome.com/docs/extensions/reference/api/debugger)
+Phase 2 ships:
+
+1. A Chrome extension that acts as a CDP JSON-RPC proxy, attaching
+   `chrome.debugger` to the active tab and forwarding CDP commands from
+   the assistant.
+2. Two transports between the extension and the assistant runtime:
+   - **Cloud**: WSS to the gateway's `/v1/browser-relay` endpoint, using
+     a guardian-bound JWT minted via WorkOS-backed
+     `chrome.identity.launchWebAuthFlow`.
+   - **Self-hosted**: WS to the local daemon's `/v1/browser-relay`
+     endpoint on `127.0.0.1`, using a scoped capability token bootstrapped
+     via Chrome Native Messaging.
+3. A new `chrome-extension` interface in `INTERFACE_IDS` that routes
+   `host_browser_request` frames through a `ChromeExtensionRegistry`
+   singleton instead of the SSE hub used by the macOS client.
+4. A per-capability `supportsHostProxy(id, capability)` so the
+   chrome-extension interface can advertise `host_browser` without
+   implying that bash / file / CU proxies are also available.
+
+Consumers of the new envelope (notably the `browser-execution.ts` tool
+code that drives live navigation) are scheduled for Phase 3 — Phase 2
+only ships the scaffold and the proxy plumbing, plus a feature-flagged
+CDP proxy in the extension so we can test it end-to-end against a
+real guardian.
+
+## Architecture
+
+The two transports share the same envelope vocabulary and the same
+registry/proxy code path on the runtime side. Only the transport layer
+and the handshake differ.
+
+```
+ ┌───────────────────────┐
+ │  Chrome extension     │
+ │  (service worker)     │
+ │                       │
+ │  host-browser-dispatcher
+ │   + cdp-proxy         │
+ │   + relay-connection  │
+ └──────────┬────────────┘
+            │ WS (self-hosted)     WSS (cloud)
+            │                      │
+            ▼                      ▼
+    127.0.0.1:<port>         api.vellum.ai
+    /v1/browser-relay        /v1/browser-relay
+            │                      │
+            └──────────┬───────────┘
+                       │
+                       ▼
+          ┌────────────────────────────┐
+          │  assistant runtime         │
+          │  http-server.ts open/close │
+          │        │                   │
+          │        ▼                   │
+          │  ChromeExtensionRegistry   │  (guardianId → ws)
+          │        │                   │
+          │        ▼                   │
+          │  HostBrowserProxy          │
+          │        │                   │
+          │        ▼                   │
+          │  pendingInteractions       │
+          │        ▲                   │
+          │        │ result            │
+          │  POST /v1/host-browser-    │
+          │   result                   │
+          └────────────────────────────┘
+```
+
+Result envelopes flow back via `POST /v1/host-browser-result`, which
+resolves the pending interaction keyed by `requestId` and feeds the
+result into the current agent turn exactly like the macOS host proxies
+do.
+
+## Cloud transport
+
+The cloud transport is used by users who do **not** run their own
+assistant. The extension talks to the production gateway directly and
+the runtime runs on infrastructure managed by Vellum.
+
+Handshake:
+
+1. The user clicks "Sign in with Vellum (cloud)" in the extension
+   popup.
+2. The service worker (not the popup) runs
+   `chrome.identity.launchWebAuthFlow` against the gateway's WorkOS
+   OIDC endpoint. Running it in the service worker keeps the awaited
+   promise alive if the popup closes mid-flow.
+3. On success, the gateway returns a guardian-bound JWT and the
+   extension persists it via `cloud-auth.ts::getStoredToken`.
+4. The extension opens `wss://api.vellum.ai/v1/browser-relay` with the
+   JWT as the `Authorization: Bearer …` header.
+5. The gateway verifies the JWT, extracts the guardian id, and forwards
+   the upgrade to the assistant runtime. The runtime registers the
+   connection under that guardian id in the `ChromeExtensionRegistry`.
+
+## Self-hosted transport
+
+The self-hosted transport is used by users who run the assistant
+locally on their own machine (the default desktop experience). The
+extension talks directly to the local daemon over loopback.
+
+Handshake:
+
+1. The user clicks "Pair with Vellum (self-hosted)" in the extension
+   popup.
+2. The service worker calls
+   `chrome.runtime.connectNative("com.vellum.daemon")`, which spawns
+   `clients/chrome-extension-native-host/` (a tiny CLI helper bundled
+   into the macOS `.app` at
+   `Contents/MacOS/vellum-chrome-native-host`).
+3. The helper:
+   a. Parses the calling extension's origin from `argv[1]` and rejects
+      anything not in `ALLOWED_EXTENSION_IDS`.
+   b. Resolves the assistant's HTTP port from (in order)
+      `--assistant-port`, `~/.vellum/runtime-port`, then `7821`.
+   c. POSTs to `http://127.0.0.1:<port>/v1/browser-extension-pair` to
+      mint a scoped capability token bound to the caller's guardian.
+   d. Writes a `token_response` frame to stdout and exits.
+4. The extension persists the token and opens
+   `ws://127.0.0.1:<port>/v1/browser-relay` with the token as a bearer
+   header.
+5. The daemon verifies the token via
+   `verifyHostBrowserCapability`, registers the connection in the
+   `ChromeExtensionRegistry`, and starts routing `host_browser_request`
+   frames to it.
+
+`/v1/browser-extension-pair` is loopback-only and refuses requests
+from any non-private peer. The capability token is HMAC-SHA256 signed
+with a long-lived random secret persisted under `~/.vellum/protected/`
+with 0600 permissions (see `capability-tokens.ts`).
+
+## Components
+
+The new modules that implement Phase 2:
+
+- **`assistant/src/runtime/chrome-extension-registry.ts`** — Singleton
+  tracking active `chrome-extension` WebSocket connections keyed by
+  guardian id. Reconnects from the same guardian supersede the prior
+  entry, closing the older socket cleanly.
+- **`assistant/src/runtime/routes/browser-extension-pair-routes.ts`** —
+  `POST /v1/browser-extension-pair` endpoint. Loopback-only. Mints a
+  capability token bound to the caller's guardian id and the
+  `host_browser_command` capability.
+- **`assistant/src/runtime/capability-tokens.ts`** — HMAC-SHA256
+  capability token mint/verify, plus the secret lifecycle
+  (`loadOrCreateCapabilityTokenSecret`, legacy workspace →
+  protected-directory migration, mode enforcement on write,
+  corruption-triggered regeneration, per-test injection).
+- **`assistant/src/browser-session/`** — Phase 3 `BrowserSessionManager`
+  scaffold (types, backends, manager). No consumers yet — the
+  in-turn browser-execution loop still uses the legacy path in Phase 2.
+- **`clients/chrome-extension/background/cdp-proxy.ts`** — CDP JSON-RPC
+  wrapper around `chrome.debugger`. Tracks attach state per target so
+  concurrent commands don't double-attach.
+- **`clients/chrome-extension/background/host-browser-dispatcher.ts`** —
+  Consumes `host_browser_request` envelopes, drives the `cdp-proxy`, and
+  hands results to the worker for POST-back.
+- **`clients/chrome-extension/background/relay-connection.ts`** —
+  WebSocket relay with heartbeat, reconnect-with-token-refresh, and
+  mode-aware bearer injection.
+- **`clients/chrome-extension-native-host/`** — Native messaging helper
+  binary that bootstraps the self-hosted capability token.
+
+Runtime wiring:
+
+- `http-server.ts` open/close handlers for `/v1/browser-relay` register
+  the connection in `ChromeExtensionRegistry` on open and unregister on
+  close.
+- `conversation-routes.ts` turn-start wires a registry-routed
+  `hostBrowserSenderOverride` onto the `Conversation` so
+  `host_browser_request` frames go to the extension WebSocket instead of
+  the SSE hub.
+- `Conversation.restoreBrowserProxyAvailability()` is called on queue
+  drain to re-thread the override — without this, the drain path would
+  clobber the registry-routed sender with the default `sendToClient`
+  (which points at the SSE hub and nothing else).
+- `supportsHostProxy(id, capability)` — chrome-extension returns `true`
+  only for `host_browser`; macOS returns `true` for all four (bash,
+  file, cu, browser).
+
+## Phase 2 → Phase 3 hand-off
+
+Work explicitly deferred to Phase 3:
+
+- Migration of `browser-execution.ts` to consume `host_browser_request`
+  envelopes directly instead of the legacy `ExtensionCommand` dispatch.
+- Cloud-side `host_browser_result` inbound routing on the gateway
+  WebSocket (today the extension POSTs results directly to the runtime;
+  in cloud mode this goes through the gateway).
+- Deriving `x-guardian-id` from the edge JWT inside the gateway rather
+  than trusting it from the runtime headers.
+- Production extension allowlist: today the native messaging helper,
+  the assistant's pair endpoint, and the macOS `NativeMessagingInstaller`
+  all contain a dev placeholder extension id. A sync-guard unit test
+  exists to prevent these from drifting before release.
+
+## Known UX considerations
+
+### `chrome.debugger` infobar
+
+When the Chrome extension calls
+`chrome.debugger.attach(target, requiredVersion)`, Chrome displays a
+persistent yellow infobar at the top of the affected tab saying "Vellum
+started debugging this browser." This is an intentional security
+mitigation — it cannot be suppressed via the public MV3 API.
+
+Investigation notes (Phase 2):
+
+- `chrome.debugger.attach(target, requiredVersion, callback)` — three-
+  argument form, no options parameter. Chrome 120+.
+  (https://developer.chrome.com/docs/extensions/reference/api/debugger)
 - There is no `{ silent: true }` option on attach.
-- The `--silent-debugger-extension-api` command-line flag exists for Chromium but (a) requires the user to launch Chrome with the flag, (b) is not enabled by default in stable channels, and (c) is not something we can enforce on end users.
-- Chrome 126+ added `chrome.debugger.attach` acceptance via `targetId` / `tabId` but did not add a silent-mode option.
-- Closing the infobar does not detach the debugger; it is purely informational.
+- The `--silent-debugger-extension-api` command-line flag exists for
+  Chromium but (a) requires the user to launch Chrome with the flag,
+  (b) is not enabled by default in stable channels, and (c) is not
+  something we can enforce on end users.
+- Chrome 126+ added `chrome.debugger.attach` acceptance via `targetId`
+  / `tabId` but did not add a silent-mode option.
+- Closing the infobar does not detach the debugger; it is purely
+  informational.
 
-### Decision
+Decision: accept the infobar. The TDD already concluded this; Phase 2
+confirms no public API exists to suppress it. End-user messaging in the
+Mac app popup should explain that the banner is expected and normal
+when Vellum is driving the browser.
 
-Accept the infobar. The TDD already concluded this; Phase 2 confirms no public API exists to suppress it. End-user messaging in the Mac app popup should explain that the banner is expected and normal when Vellum is driving the browser.
+Alternatives considered:
 
-### Alternatives considered
-
-- Playwright / `chrome --remote-debugging-port` in a sacrificial profile avoids the infobar but requires installing Chromium and is out-of-scope (Phase 5).
-- Chrome 146+ `chrome://inspect` attach backend may offer a less intrusive UX and is being tracked for Phase 4.
+- Playwright / `chrome --remote-debugging-port` in a sacrificial profile
+  avoids the infobar but requires installing Chromium and is out-of-
+  scope (Phase 5).
+- Chrome 146+ `chrome://inspect` attach backend may offer a less
+  intrusive UX and is being tracked for Phase 4.


### PR DESCRIPTION
## Summary
- P1: Chrome extension now returns an immediate error when host_browser_request arrives but cdpProxyEnabled is off, instead of silently dropping it and forcing the daemon to time out
- P2: Daemon writes its HTTP port to ~/.vellum/runtime-port on startup so the native messaging helper can find non-default RUNTIME_HTTP_PORT setups
- P2: Expanded docs/browser-use-architecture-phase2.md to actually describe the Phase 2 architecture, and added a paragraph to runtime/AGENTS.md covering the chrome-extension interface
- P2: New unit test file for runtime/capability-tokens.ts covering the secret lifecycle (mint/verify, tampering, expiry, secret persistence)
- P2: Promoted the dev placeholder chrome extension ID to a sync-guard test so the three coupled occurrences cannot drift before production release

Addresses items 1-5 from the round-4 self-review of PR #24159.

## Original prompt
one PR for items 1-5 and also /do in parallel another PR for items 6-13
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24246" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
