### PR TITLE
fix: thread typographyGeneration through chat views for font-change re-render

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -35,6 +35,7 @@ struct ChatBubble: View, Equatable {
             && lhs.mediaEmbedSettings == rhs.mediaEmbedSettings
             && lhs.activeConfirmationRequestId == rhs.activeConfirmationRequestId
             && lhs.isLatestAssistantMessage == rhs.isLatestAssistantMessage
+            && lhs.typographyGeneration == rhs.typographyGeneration
             && lhs.isProcessingAfterTools == rhs.isProcessingAfterTools
             && lhs.processingStatusText == rhs.processingStatusText
             && lhs.isTTSEnabled == rhs.isTTSEnabled
@@ -67,6 +68,7 @@ struct ChatBubble: View, Equatable {
     var onRetryConversationError: (() -> Void)?
 
     var isLatestAssistantMessage: Bool = false
+    var typographyGeneration: Int = 0
     @State private var avatarBounceScale: CGFloat = 1.0
     /// When true, the assistant is still processing after tool calls completed.
     /// Renders an inline loading indicator in trailingStatus to avoid a separate
@@ -126,6 +128,7 @@ struct ChatBubble: View, Equatable {
         onRetryFailedMessage: ((UUID) -> Void)? = nil,
         onRetryConversationError: (() -> Void)? = nil,
         isLatestAssistantMessage: Bool = false,
+        typographyGeneration: Int = 0,
         isProcessingAfterTools: Bool = false,
         processingStatusText: String? = nil,
         activeSurfaceId: String? = nil,
@@ -151,6 +154,7 @@ struct ChatBubble: View, Equatable {
         self.onRetryFailedMessage = onRetryFailedMessage
         self.onRetryConversationError = onRetryConversationError
         self.isLatestAssistantMessage = isLatestAssistantMessage
+        self.typographyGeneration = typographyGeneration
         self.isProcessingAfterTools = isProcessingAfterTools
         self.processingStatusText = processingStatusText
         self.activeSurfaceId = activeSurfaceId
@@ -505,6 +509,7 @@ struct ChatBubble: View, Equatable {
                     MarkdownSegmentView(
                         segments: segments,
                         isStreaming: message.isStreaming,
+                        typographyGeneration: typographyGeneration,
                         maxContentWidth: isUser ? max(bubbleMaxWidth - 2 * VSpacing.lg, 0) : bubbleMaxWidth,
                         textColor: isUser ? VColor.contentDefault : VColor.contentDefault,
                         secondaryTextColor: isUser ? VColor.contentSecondary : VColor.contentSecondary,

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
@@ -463,7 +463,11 @@ extension ChatBubble {
                         .filter { !$0.isEmpty }
                         .joined(separator: "\n")
                     if !joined.isEmpty {
-                        ThinkingBlockView(content: joined, isStreaming: message.isStreaming)
+                        ThinkingBlockView(
+                            content: joined,
+                            isStreaming: message.isStreaming,
+                            typographyGeneration: typographyGeneration
+                        )
                     }
                 }
             }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
@@ -18,7 +18,12 @@ extension ChatBubble {
             // Switching between Text and MarkdownSegmentView caused
             // LazyVStack to use stale height measurements, resulting in
             // content truncation and footer overlap.
-            MarkdownSegmentView(segments: segments, isStreaming: streaming, maxContentWidth: bubbleMaxWidth)
+            MarkdownSegmentView(
+                segments: segments,
+                isStreaming: streaming,
+                typographyGeneration: typographyGeneration,
+                maxContentWidth: bubbleMaxWidth
+            )
                 .equatable()
         }
         .task(id: "\(segmentText)|\(streaming)") {

--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -25,6 +25,7 @@ private final class MeasuredTextCacheEntry: NSObject {
 struct MarkdownSegmentView: View, Equatable {
     let segments: [MarkdownSegment]
     var isStreaming: Bool = false
+    var typographyGeneration: Int? = nil
     var maxContentWidth: CGFloat? = VSpacing.chatBubbleMaxWidth
     var textColor: Color = VColor.contentDefault
     var secondaryTextColor: Color = VColor.contentSecondary
@@ -40,6 +41,7 @@ struct MarkdownSegmentView: View, Equatable {
     static func == (lhs: MarkdownSegmentView, rhs: MarkdownSegmentView) -> Bool {
         lhs.segments == rhs.segments
             && lhs.isStreaming == rhs.isStreaming
+            && lhs.typographyGeneration == rhs.typographyGeneration
             && lhs.maxContentWidth == rhs.maxContentWidth
             && lhs.textColor == rhs.textColor
             && lhs.secondaryTextColor == rhs.secondaryTextColor
@@ -55,7 +57,7 @@ struct MarkdownSegmentView: View, Equatable {
         let chatFont = VFont.chat
         let scaledCodeLabelSize: CGFloat = 11
         #if os(macOS)
-        let typographyGeneration = typographyObserver.generation
+        let typographyGeneration = self.typographyGeneration ?? typographyObserver.generation
         #endif
         VStack(alignment: .leading, spacing: VSpacing.lg) {
             ForEach(Array(groups.enumerated()), id: \.offset) { _, group in

--- a/clients/macos/vellum-assistant/Features/Chat/MessageCellView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageCellView.swift
@@ -16,6 +16,7 @@ struct MessageCellView: View, Equatable {
             && lhs.activePendingRequestId == rhs.activePendingRequestId
             && lhs.subagentsByParent[lhs.message.id] == rhs.subagentsByParent[rhs.message.id]
             && lhs.isLatestAssistantMessage == rhs.isLatestAssistantMessage
+            && lhs.typographyGeneration == rhs.typographyGeneration
             && lhs.isProcessingAfterTools == rhs.isProcessingAfterTools
             && lhs.processingStatusText == rhs.processingStatusText
             && lhs.hideInlineAvatar == rhs.hideInlineAvatar
@@ -41,6 +42,7 @@ struct MessageCellView: View, Equatable {
     let activePendingRequestId: String?
     let subagentsByParent: [UUID: [SubagentInfo]]
     let isLatestAssistantMessage: Bool
+    let typographyGeneration: Int
     let isProcessingAfterTools: Bool
     let processingStatusText: String?
     let hideInlineAvatar: Bool
@@ -124,6 +126,7 @@ struct MessageCellView: View, Equatable {
                 onRetryFailedMessage: onRetryFailedMessage,
                 onRetryConversationError: message.isError ? { onRetryConversationError?(message.id) } : nil,
                 isLatestAssistantMessage: isLatestAssistantMessage,
+                typographyGeneration: typographyGeneration,
                 isProcessingAfterTools: isProcessingAfterTools,
                 processingStatusText: processingStatusText,
                 activeSurfaceId: activeSurfaceId,
@@ -211,6 +214,7 @@ struct MessageCellView: View, Equatable {
                 onRetryFailedMessage: onRetryFailedMessage,
                 onRetryConversationError: message.isError ? { onRetryConversationError?(message.id) } : nil,
                 isLatestAssistantMessage: isLatestAssistantMessage,
+                typographyGeneration: typographyGeneration,
                 isProcessingAfterTools: isProcessingAfterTools,
                 processingStatusText: processingStatusText,
                 activeSurfaceId: activeSurfaceId,

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
@@ -45,6 +45,7 @@ struct MessageListContentView: View, Equatable {
             && lhs.state.isStreamingWithoutText == rhs.state.isStreamingWithoutText
             && lhs.state.hasMessages == rhs.state.hasMessages
             && lhs.providerCatalogHash == rhs.providerCatalogHash
+            && lhs.typographyGeneration == rhs.typographyGeneration
             && lhs.isLoadingMoreMessages == rhs.isLoadingMoreMessages
             && lhs.isCompacting == rhs.isCompacting
             && lhs.isInteractionEnabled == rhs.isInteractionEnabled
@@ -67,6 +68,7 @@ struct MessageListContentView: View, Equatable {
     let state: MessageListDerivedState
     let providerCatalog: [ProviderCatalogEntry]
     let providerCatalogHash: Int
+    let typographyGeneration: Int
     let isLoadingMoreMessages: Bool
     let isCompacting: Bool
     let isInteractionEnabled: Bool
@@ -200,6 +202,7 @@ struct MessageListContentView: View, Equatable {
                     activePendingRequestId: cellActivePendingRequestId,
                     subagentsByParent: state.subagentsByParent,
                     isLatestAssistantMessage: isLatestAssistant,
+                    typographyGeneration: typographyGeneration,
                     isProcessingAfterTools: state.canInlineProcessing && isLatestAssistant,
                     processingStatusText: state.canInlineProcessing && isLatestAssistant ? state.effectiveStatusText : nil,
                     hideInlineAvatar: isLatestAssistant && isUnanchoredThinking,

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+DerivedState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+DerivedState.swift
@@ -366,6 +366,7 @@ extension MessageListView {
             state: state,
             providerCatalog: providerCatalog,
             providerCatalogHash: catalogHash,
+            typographyGeneration: typographyObserver.generation,
             isLoadingMoreMessages: isLoadingMoreMessages,
             isCompacting: isCompacting,
             isInteractionEnabled: isInteractionEnabled,

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -81,6 +81,7 @@ struct MessageListView: View {
     /// the state; persisted back in `handleSendingChanged()` when flipped.
     @State var hasEverSentMessage: Bool = UserDefaults.standard.bool(forKey: "hasEverSentMessage")
     @State var appearance = AvatarAppearanceManager.shared
+    @ObservedObject var typographyObserver = VFont.typographyObserver
     /// Read at the list level and passed down to each ChatBubble so that
     /// individual bubbles don't each subscribe to the shared manager.
     /// With @Observable fine-grained tracking, reading only `activeSurfaceId`

--- a/clients/macos/vellum-assistant/Features/Chat/ThinkingBlockView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ThinkingBlockView.swift
@@ -7,6 +7,7 @@ import VellumAssistantShared
 struct ThinkingBlockView: View {
     let content: String
     let isStreaming: Bool
+    var typographyGeneration: Int = 0
 
     @State private var isExpanded: Bool
     /// Cached parsed markdown segments — parsed lazily only when the block is
@@ -14,9 +15,10 @@ struct ThinkingBlockView: View {
     @State private var cachedSegments: [MarkdownSegment]
     @State private var cachedContent: String
 
-    init(content: String, isStreaming: Bool, initiallyExpanded: Bool = false) {
+    init(content: String, isStreaming: Bool, typographyGeneration: Int = 0, initiallyExpanded: Bool = false) {
         self.content = content
         self.isStreaming = isStreaming
+        self.typographyGeneration = typographyGeneration
         _isExpanded = State(initialValue: initiallyExpanded)
         if initiallyExpanded {
             _cachedSegments = State(initialValue: parseMarkdownSegments(content))
@@ -38,6 +40,7 @@ struct ThinkingBlockView: View {
                 MarkdownSegmentView(
                     segments: cachedSegments,
                     isStreaming: isStreaming,
+                    typographyGeneration: typographyGeneration,
                     maxContentWidth: nil,
                     textColor: VColor.contentSecondary,
                     secondaryTextColor: VColor.contentTertiary,

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SubagentDetailPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SubagentDetailPanel.swift
@@ -8,6 +8,7 @@ struct SubagentDetailPanel: View {
     var onAbort: (() -> Void)?
     var onRequestDetail: (() -> Void)?
     var onClose: () -> Void
+    @ObservedObject private var typographyObserver = VFont.typographyObserver
 
     private var subagentInfo: SubagentInfo? { viewModel.activeSubagents.first(where: { $0.id == subagentId }) }
     private var state: SubagentState? { detailStore.subagentStates[subagentId] }
@@ -211,7 +212,11 @@ struct SubagentDetailPanel: View {
     private func eventContent(_ event: SubagentEventItem) -> some View {
         switch event.kind {
         case .text:
-            MarkdownSegmentView(segments: parseMarkdownSegments(event.content), maxContentWidth: nil)
+            MarkdownSegmentView(
+                segments: parseMarkdownSegments(event.content),
+                typographyGeneration: typographyObserver.generation,
+                maxContentWidth: nil
+            )
                 .equatable()
                 .textSelection(.enabled)
                 .padding(VSpacing.sm)

--- a/clients/macos/vellum-assistantTests/MessageListTypographyRefreshTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListTypographyRefreshTests.swift
@@ -1,0 +1,118 @@
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+@MainActor
+final class MessageListTypographyRefreshTests: XCTestCase {
+    func testMessageListContentViewEqualityIncludesTypographyGeneration() {
+        XCTAssertNotEqual(
+            makeMessageListContentView(typographyGeneration: 0),
+            makeMessageListContentView(typographyGeneration: 1)
+        )
+    }
+
+    func testMessageCellViewEqualityIncludesTypographyGeneration() {
+        XCTAssertNotEqual(
+            makeMessageCellView(typographyGeneration: 0),
+            makeMessageCellView(typographyGeneration: 1)
+        )
+    }
+
+    func testChatBubbleEqualityIncludesTypographyGeneration() {
+        XCTAssertNotEqual(
+            makeChatBubble(typographyGeneration: 0),
+            makeChatBubble(typographyGeneration: 1)
+        )
+    }
+
+    private func makeMessageListContentView(typographyGeneration: Int) -> MessageListContentView {
+        MessageListContentView(
+            state: makeDerivedState(),
+            providerCatalog: [],
+            providerCatalogHash: 0,
+            typographyGeneration: typographyGeneration,
+            isLoadingMoreMessages: false,
+            isCompacting: false,
+            isInteractionEnabled: true,
+            containerWidth: 800,
+            dismissedDocumentSurfaceIds: [],
+            activeSurfaceId: nil,
+            highlightedMessageId: nil,
+            mediaEmbedSettings: nil,
+            hasEverSentMessage: true,
+            showInspectButton: false,
+            isTTSEnabled: false,
+            selectedModel: "",
+            configuredProviders: [],
+            subagentDetailStore: SubagentDetailStore(),
+            assistantStatusText: nil,
+            scrollState: MessageListScrollState()
+        )
+    }
+
+    private func makeMessageCellView(typographyGeneration: Int) -> MessageCellView {
+        let message = ChatMessage(role: .assistant, text: "*italic*")
+        return MessageCellView(
+            message: message,
+            showTimestamp: false,
+            nextDecidedConfirmation: nil,
+            isConfirmationRenderedInline: false,
+            hasPrecedingAssistant: false,
+            activePendingRequestId: nil,
+            subagentsByParent: [:],
+            isLatestAssistantMessage: true,
+            typographyGeneration: typographyGeneration,
+            isProcessingAfterTools: false,
+            processingStatusText: nil,
+            hideInlineAvatar: false,
+            showAnchoredThinkingIndicator: false,
+            anchoredThinkingLabel: "",
+            dismissedDocumentSurfaceIds: [],
+            activeSurfaceId: nil,
+            isHighlighted: false,
+            mediaEmbedSettings: nil,
+            onDismissDocumentWidget: nil,
+            subagentDetailStore: SubagentDetailStore(),
+            selectedModel: "",
+            configuredProviders: [],
+            providerCatalog: [],
+            providerCatalogHash: 0
+        )
+    }
+
+    private func makeChatBubble(typographyGeneration: Int) -> ChatBubble {
+        ChatBubble(
+            message: ChatMessage(role: .assistant, text: "*italic*"),
+            decidedConfirmation: nil,
+            onSurfaceAction: { _, _, _ in },
+            onDismissDocumentWidget: { _ in },
+            dismissedDocumentSurfaceIds: [],
+            isLatestAssistantMessage: true,
+            typographyGeneration: typographyGeneration
+        )
+    }
+
+    private func makeDerivedState() -> MessageListDerivedState {
+        let message = ChatMessage(role: .assistant, text: "*italic*")
+        return MessageListDerivedState(
+            messageIndexById: [message.id: 0],
+            showTimestamp: [],
+            hasPrecedingAssistantByIndex: [],
+            hasUserMessage: false,
+            latestAssistantId: message.id,
+            subagentsByParent: [:],
+            orphanSubagents: [],
+            effectiveStatusText: nil,
+            displayMessages: [message],
+            activePendingRequestId: nil,
+            nextDecidedConfirmationByIndex: [:],
+            isConfirmationRenderedInlineByIndex: [],
+            anchoredThinkingIndex: nil,
+            hasActiveToolCall: false,
+            canInlineProcessing: false,
+            shouldShowThinkingIndicator: false,
+            isStreamingWithoutText: false,
+            hasMessages: true
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Thread `typographyGeneration` counter from `MessageListView` down through `MessageListContentView` → `MessageCellView` → `ChatBubble` → `MarkdownSegmentView` / `ThinkingBlockView` so equatable views properly invalidate when typography settings change
- Add `typographyObserver` to `SubagentDetailPanel` for the same fix in subagent detail text
- Add `MessageListTypographyRefreshTests` verifying equality checks include the generation counter
- Include Chrome native host binary
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24250" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
