### PR TITLE
Bump Swift tools version to 6.2 for containerization support

### DIFF
--- a/clients/Package.swift
+++ b/clients/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.2
 import PackageDescription
 
 let appVersion = "0.6.2"

--- a/clients/Package.swift
+++ b/clients/Package.swift
@@ -124,5 +124,8 @@ let package = Package(
             dependencies: ["VellumAssistantShared"],
             path: "ios/Tests"
         )
-    ]
+    ],
+    // swift-tools-version 6.2 is required by the `containerization` dependency,
+    // but the codebase isn't yet migrated to Swift 6 strict concurrency.
+    swiftLanguageModes: [.v5]
 )

--- a/clients/macos/README.md
+++ b/clients/macos/README.md
@@ -70,13 +70,13 @@ All releases are available at [github.com/vellum-ai/velly/releases](https://gith
 
 ### Local Mode
 - macOS 15.0 (Sequoia) or later
-- Xcode 15+ (for building from source)
+- Xcode 26+ (for building from source)
 - Anthropic API key
 - Local daemon running (`vellum wake`)
 
 ### Managed Mode
 - macOS 15.0 (Sequoia) or later
-- Xcode 15+ (for building from source)
+- Xcode 26+ (for building from source)
 - Internet connection (assistant runs on the Vellum platform)
 - No API key or local daemon required
 


### PR DESCRIPTION
## Context
We're exploring Apple Containers as an option, and https://github.com/apple/containerization 0.2.0+ requires Swift 6.2+.

## Summary
- Bumps `swift-tools-version` from 5.9 to 6.2 in `Package.swift`, required by the upcoming `containerization` dependency
- Pins `swiftLanguageModes: [.v5]` so the codebase continues building under Swift 5 concurrency rules
- Updates README to reflect the new Xcode 26+ requirement

## Test plan
- [ ] Verify `swift build` succeeds with Xcode 26
- [ ] Verify existing macOS and iOS targets still compile
- [ ] Confirm no Swift 6 strict concurrency errors surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24252" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
