### PR TITLE
fix: lazily start AppSourceWatcher so app live reload works after first app creation

### DIFF
--- a/assistant/src/__tests__/app-source-watcher.test.ts
+++ b/assistant/src/__tests__/app-source-watcher.test.ts
@@ -21,23 +21,25 @@ const testDirNameMap = new Map<string, string>([["my-app", "app-id-1"]]);
 
 let capturedWatchCallback: ((eventType: string, filename: string | null) => void) | null = null;
 const mockWatcher = { close: mock(() => {}) };
+const mockExistsSync = mock((p: string): boolean => p === TEST_APPS_DIR);
+const mockWatch = mock(
+  (
+    _path: string,
+    _opts: Record<string, unknown>,
+    callback: (eventType: string, filename: string | null) => void,
+  ) => {
+    capturedWatchCallback = callback;
+    return mockWatcher;
+  },
+);
 
 mock.module("node:fs", () => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const actualFs = require("node:fs");
   return {
     ...actualFs,
-    existsSync: mock((p: string) => p === TEST_APPS_DIR),
-    watch: mock(
-      (
-        _path: string,
-        _opts: Record<string, unknown>,
-        callback: (eventType: string, filename: string | null) => void,
-      ) => {
-        capturedWatchCallback = callback;
-        return mockWatcher;
-      },
-    ),
+    existsSync: mockExistsSync,
+    watch: mockWatch,
   };
 });
 
@@ -67,6 +69,8 @@ describe("AppSourceWatcher", () => {
     onChangeSpy = mock(() => {});
     capturedWatchCallback = null;
     mockWatcher.close.mockClear();
+    // Reset existsSync to default behavior for each test
+    mockExistsSync.mockImplementation((p: string) => p === TEST_APPS_DIR);
   });
 
   afterEach(() => {
@@ -155,5 +159,27 @@ describe("AppSourceWatcher", () => {
     watcher.stop();
 
     expect(mockWatcher.close).toHaveBeenCalledTimes(1);
+  });
+
+  test("ensureStarted() initializes watcher after apps directory is created", () => {
+    // Simulate apps dir not existing at start time
+    mockExistsSync.mockImplementation((_p: string) => false);
+
+    watcher.start(onChangeSpy);
+    expect(capturedWatchCallback).toBeNull(); // watcher didn't start
+
+    // Simulate apps dir now existing (e.g. after app_create)
+    mockExistsSync.mockImplementation((p: string) => p === TEST_APPS_DIR);
+
+    watcher.ensureStarted();
+    expect(capturedWatchCallback).not.toBeNull(); // watcher started
+  });
+
+  test("ensureStarted() is a no-op when watcher is already running", () => {
+    watcher.start(onChangeSpy);
+    const callCountAfterStart = mockWatch.mock.calls.length;
+
+    watcher.ensureStarted();
+    expect(mockWatch.mock.calls.length).toBe(callCountAfterStart); // no extra watch call
   });
 });

--- a/assistant/src/daemon/app-source-watcher.ts
+++ b/assistant/src/daemon/app-source-watcher.ts
@@ -25,6 +25,20 @@ const APP_REFRESH_DEBOUNCE_MS = 500;
 export type AppSourceChangeCallback = (appId: string) => void;
 
 /**
+ * Module-level callback so tool-side-effects can ensure the watcher starts
+ * after the apps directory is created (e.g. on first app_create).
+ */
+let ensureWatcherStarted: (() => void) | null = null;
+
+export function setEnsureAppSourceWatcher(fn: () => void): void {
+  ensureWatcherStarted = fn;
+}
+
+export function ensureAppSourceWatcher(): void {
+  ensureWatcherStarted?.();
+}
+
+/**
  * Resolve app ID from a relative path within the apps directory.
  * Returns null if the path is not an app source file (e.g. dist/, records/).
  */
@@ -48,12 +62,29 @@ function resolveAppIdFromRelPath(relPath: string): string | null {
 
 export class AppSourceWatcher {
   private watcher: FSWatcher | null = null;
+  private onChange: AppSourceChangeCallback | null = null;
   private debouncer = new DebouncerMap({
     defaultDelayMs: APP_REFRESH_DEBOUNCE_MS,
     maxEntries: 50,
   });
 
   start(onChange: AppSourceChangeCallback): void {
+    this.onChange = onChange;
+    this.tryWatch();
+  }
+
+  /**
+   * Ensure the watcher is running. Call after app creation so the watcher
+   * starts if the apps directory was created after daemon startup.
+   */
+  ensureStarted(): void {
+    if (this.watcher || !this.onChange) return;
+    this.tryWatch();
+  }
+
+  private tryWatch(): void {
+    if (this.watcher) return;
+
     let appsDir: string;
     try {
       appsDir = getAppsDir();
@@ -67,6 +98,9 @@ export class AppSourceWatcher {
       return;
     }
 
+    const onChange = this.onChange;
+    if (!onChange) return;
+
     try {
       this.watcher = watch(appsDir, { recursive: true }, (_eventType, filename) => {
         if (!filename) return;
@@ -78,6 +112,7 @@ export class AppSourceWatcher {
           onChange(appId);
         });
       });
+      log.info("App source watcher started");
     } catch (err) {
       log.warn({ err }, "Failed to watch apps directory; source watching disabled");
     }

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -66,7 +66,7 @@ import {
   getWorkspacePromptPath,
 } from "../util/platform.js";
 import { registerDaemonCallbacks } from "../work-items/work-item-runner.js";
-import { AppSourceWatcher } from "./app-source-watcher.js";
+import { AppSourceWatcher, setEnsureAppSourceWatcher } from "./app-source-watcher.js";
 import { ConfigWatcher } from "./config-watcher.js";
 import {
   Conversation,
@@ -392,6 +392,7 @@ export class DaemonServer {
     getSubagentManager().broadcastToAllClients = (msg) => this.broadcast(msg);
     getSubagentManager().resolveParentConversation = (id) => this.conversations.get(id);
     setBroadcastToAllClients((msg) => this.broadcast(msg));
+    setEnsureAppSourceWatcher(() => this.appSourceWatcher.ensureStarted());
     this.evictor.onEvict = (conversationId: string) => {
       getSubagentManager().abortAllForParent(conversationId);
     };

--- a/assistant/src/daemon/tool-side-effects.ts
+++ b/assistant/src/daemon/tool-side-effects.ts
@@ -15,6 +15,7 @@ import { deliverVerificationSlack } from "../runtime/verification-outbound-actio
 import { updatePublishedAppDeployment } from "../services/published-app-updater.js";
 import type { ToolExecutionResult } from "../tools/types.js";
 import { getLogger } from "../util/logger.js";
+import { ensureAppSourceWatcher } from "./app-source-watcher.js";
 import { refreshSurfacesForApp } from "./conversation-surfaces.js";
 import type { ToolSetupContext } from "./conversation-tool-setup.js";
 import { isDoordashCommand, updateDoordashProgress } from "./doordash-steps.js";
@@ -109,6 +110,11 @@ registerHook(
         description?: string;
       };
       if (parsed.id) {
+        // The apps directory may have just been created — ensure the
+        // filesystem watcher is running so subsequent file edits
+        // trigger live reload.
+        ensureAppSourceWatcher();
+
         handleAppChange(ctx, parsed.id, broadcastToAllClients);
 
         // Fire-and-forget: generate an app icon in the background.


### PR DESCRIPTION
## Summary
- **Root cause**: `AppSourceWatcher.start()` silently gave up if the apps directory didn't exist at daemon startup. The old tool-level hooks were removed in `4f80c53bd`, so apps created after startup never got live reload.
- **Fix**: Added `ensureStarted()` to `AppSourceWatcher` and call it from the `app_create` tool hook so the watcher lazily initializes when the apps directory first appears.
- **Tests**: Added 2 new tests verifying lazy init and idempotent no-op behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24256" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
