### PR TITLE
cache + validate kata container kernel

### DIFF
--- a/.github/workflows/ci-main-macos.yaml
+++ b/.github/workflows/ci-main-macos.yaml
@@ -224,7 +224,7 @@ jobs:
           done
 
       - name: Cache Kata kernel
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: clients/macos/.container-cache/kata-3.17.0-arm64/vmlinux.container
           key: kata-kernel-3.17.0-arm64

--- a/.github/workflows/ci-main-macos.yaml
+++ b/.github/workflows/ci-main-macos.yaml
@@ -223,6 +223,12 @@ jobs:
             wait "$pid"
           done
 
+      - name: Cache Kata kernel
+        uses: actions/cache@v4
+        with:
+          path: clients/macos/.container-cache/kata-3.17.0-arm64/vmlinux.container
+          key: kata-kernel-3.17.0-arm64
+
       - name: Build binaries
         timeout-minutes: 5
         working-directory: clients/macos

--- a/.github/workflows/pr-macos.yaml
+++ b/.github/workflows/pr-macos.yaml
@@ -168,6 +168,12 @@ jobs:
             wait "$pid"
           done
 
+      - name: Cache Kata kernel
+        uses: actions/cache@v4
+        with:
+          path: clients/macos/.container-cache/kata-3.17.0-arm64/vmlinux.container
+          key: kata-kernel-3.17.0-arm64
+
       - name: Build binaries
         timeout-minutes: 5
         run: ./build.sh binaries

--- a/.github/workflows/pr-macos.yaml
+++ b/.github/workflows/pr-macos.yaml
@@ -169,7 +169,7 @@ jobs:
           done
 
       - name: Cache Kata kernel
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: clients/macos/.container-cache/kata-3.17.0-arm64/vmlinux.container
           key: kata-kernel-3.17.0-arm64

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -151,6 +151,7 @@ RESOURCES_DIR="$CONTENTS/Resources"
 FRAMEWORKS_DIR="$CONTENTS/Frameworks"
 KATA_KERNEL_VERSION="3.17.0"
 KATA_KERNEL_ARCHIVE_URL="${KATA_KERNEL_ARCHIVE_URL:-https://github.com/kata-containers/kata-containers/releases/download/$KATA_KERNEL_VERSION/kata-static-$KATA_KERNEL_VERSION-arm64.tar.xz}"
+KATA_KERNEL_ARCHIVE_SHA256="647c7612e6edf789d5e14698c48c99d8bac15ad139ffaa1c8bb7d229f748d181"
 KATA_KERNEL_CACHE_DIR="${KATA_KERNEL_CACHE_DIR:-$SCRIPT_DIR/.container-cache/kata-$KATA_KERNEL_VERSION-arm64}"
 KATA_KERNEL_ARCHIVE_PATH="$KATA_KERNEL_CACHE_DIR/kata.tar.xz"
 KATA_KERNEL_PATH="$KATA_KERNEL_CACHE_DIR/vmlinux.container"
@@ -367,6 +368,17 @@ bundle_kata_kernel() {
         curl --fail --location --retry 3 --retry-delay 2 --connect-timeout 30 \
             --output "$KATA_KERNEL_ARCHIVE_PATH.tmp" "$KATA_KERNEL_ARCHIVE_URL"
         mv "$KATA_KERNEL_ARCHIVE_PATH.tmp" "$KATA_KERNEL_ARCHIVE_PATH"
+    fi
+
+    echo "Verifying Kata kernel archive checksum..."
+    local actual_sha256
+    actual_sha256=$(shasum -a 256 "$KATA_KERNEL_ARCHIVE_PATH" | awk '{print $1}')
+    if [ "$actual_sha256" != "$KATA_KERNEL_ARCHIVE_SHA256" ]; then
+        echo "ERROR: SHA-256 mismatch for Kata kernel archive" >&2
+        echo "  Expected: $KATA_KERNEL_ARCHIVE_SHA256" >&2
+        echo "  Actual:   $actual_sha256" >&2
+        rm -f "$KATA_KERNEL_ARCHIVE_PATH"
+        exit 1
     fi
 
     if [ ! -f "$KATA_KERNEL_PATH" ]; then

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -151,7 +151,11 @@ RESOURCES_DIR="$CONTENTS/Resources"
 FRAMEWORKS_DIR="$CONTENTS/Frameworks"
 KATA_KERNEL_VERSION="3.17.0"
 KATA_KERNEL_ARCHIVE_URL="${KATA_KERNEL_ARCHIVE_URL:-https://github.com/kata-containers/kata-containers/releases/download/$KATA_KERNEL_VERSION/kata-static-$KATA_KERNEL_VERSION-arm64.tar.xz}"
+# When bumping KATA_KERNEL_VERSION, update both SHAs:
+#   Archive: curl -sL "$KATA_KERNEL_ARCHIVE_URL" | shasum -a 256 (more recent releases will have the SHA on github)
+#   Kernel:  tar -xJf archive.tar.xz && shasum -a 256 opt/kata/share/kata-containers/vmlinux.container
 KATA_KERNEL_ARCHIVE_SHA256="647c7612e6edf789d5e14698c48c99d8bac15ad139ffaa1c8bb7d229f748d181"
+KATA_KERNEL_SHA256="67bac9f416af4cdc9b151e4ba4962d6515e0ad7acc53816761cf964aa6af6ea0"
 KATA_KERNEL_CACHE_DIR="${KATA_KERNEL_CACHE_DIR:-$SCRIPT_DIR/.container-cache/kata-$KATA_KERNEL_VERSION-arm64}"
 KATA_KERNEL_ARCHIVE_PATH="$KATA_KERNEL_CACHE_DIR/kata.tar.xz"
 KATA_KERNEL_PATH="$KATA_KERNEL_CACHE_DIR/vmlinux.container"
@@ -362,32 +366,40 @@ build_binaries() {
 bundle_kata_kernel() {
     mkdir -p "$KATA_KERNEL_CACHE_DIR"
 
-    if [ ! -f "$KATA_KERNEL_ARCHIVE_PATH" ]; then
-        echo "Downloading Kata $KATA_KERNEL_VERSION ARM64 kernel..."
-        # TODO: Cache this for CI/CD builds.
-        curl --fail --location --retry 3 --retry-delay 2 --connect-timeout 30 \
-            --output "$KATA_KERNEL_ARCHIVE_PATH.tmp" "$KATA_KERNEL_ARCHIVE_URL"
-        mv "$KATA_KERNEL_ARCHIVE_PATH.tmp" "$KATA_KERNEL_ARCHIVE_PATH"
-    fi
-
-    echo "Verifying Kata kernel archive checksum..."
-    local actual_sha256
-    actual_sha256=$(shasum -a 256 "$KATA_KERNEL_ARCHIVE_PATH" | awk '{print $1}')
-    if [ "$actual_sha256" != "$KATA_KERNEL_ARCHIVE_SHA256" ]; then
-        echo "ERROR: SHA-256 mismatch for Kata kernel archive" >&2
-        echo "  Expected: $KATA_KERNEL_ARCHIVE_SHA256" >&2
-        echo "  Actual:   $actual_sha256" >&2
-        rm -f "$KATA_KERNEL_ARCHIVE_PATH"
-        exit 1
-    fi
-
     if [ ! -f "$KATA_KERNEL_PATH" ]; then
+        echo "Downloading Kata $KATA_KERNEL_VERSION ARM64 kernel..."
+        curl --fail --location --retry 3 --retry-delay 2 --connect-timeout 30 \
+            --output "$KATA_KERNEL_ARCHIVE_PATH" "$KATA_KERNEL_ARCHIVE_URL"
+
+        echo "Verifying Kata kernel archive checksum..."
+        local actual_sha256
+        actual_sha256=$(shasum -a 256 "$KATA_KERNEL_ARCHIVE_PATH" | awk '{print $1}')
+        if [ "$actual_sha256" != "$KATA_KERNEL_ARCHIVE_SHA256" ]; then
+            echo "ERROR: SHA-256 mismatch for Kata kernel archive" >&2
+            echo "  Expected: $KATA_KERNEL_ARCHIVE_SHA256" >&2
+            echo "  Actual:   $actual_sha256" >&2
+            rm -f "$KATA_KERNEL_ARCHIVE_PATH"
+            exit 1
+        fi
+
         echo "Extracting Kata kernel..."
         local temp_extract
         temp_extract=$(mktemp -d "$KATA_KERNEL_CACHE_DIR/extract.XXXXXX")
         tar -xJf "$KATA_KERNEL_ARCHIVE_PATH" -C "$temp_extract"
         cp -L "$temp_extract/opt/kata/share/kata-containers/vmlinux.container" "$KATA_KERNEL_PATH"
         rm -rf "$temp_extract"
+        rm -f "$KATA_KERNEL_ARCHIVE_PATH"
+    fi
+
+    echo "Verifying Kata kernel checksum..."
+    local actual_kernel_sha256
+    actual_kernel_sha256=$(shasum -a 256 "$KATA_KERNEL_PATH" | awk '{print $1}')
+    if [ "$actual_kernel_sha256" != "$KATA_KERNEL_SHA256" ]; then
+        echo "ERROR: SHA-256 mismatch for Kata kernel" >&2
+        echo "  Expected: $KATA_KERNEL_SHA256" >&2
+        echo "  Actual:   $actual_kernel_sha256" >&2
+        rm -f "$KATA_KERNEL_PATH"
+        exit 1
     fi
 
     echo "Bundling Kata kernel..."


### PR DESCRIPTION
The full archive is ~500MB, but the actual kernel is only ~20MB. Let's cache this for CI.

Also validates SHA of archive + kernel
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24258" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
