### PR TITLE
fix: enable Open App button when tool result and surface are in different messages

### DIFF
--- a/clients/shared/Features/Chat/ChatActionHandler.swift
+++ b/clients/shared/Features/Chat/ChatActionHandler.swift
@@ -365,6 +365,20 @@ final class ChatActionHandler {
         }
         // Strip heavy binary data from old messages to cap memory growth.
         vm.trimOldMessagesIfNeeded()
+        // Fallback: mark any remaining dynamic page surfaces as complete.
+        // handleToolResult sets isToolCallComplete per-surface when an app tool
+        // finishes, but it can miss surfaces if the tool_result was dropped
+        // (e.g. during workspace refinement) or if the surface ended up in a
+        // different message than the tool call. By message_complete, all tool
+        // calls have definitely finished so it's safe to enable Open App.
+        for i in vm.messages.indices {
+            for surfIdx in vm.messages[i].inlineSurfaces.indices {
+                if !vm.messages[i].inlineSurfaces[surfIdx].isToolCallComplete,
+                   case .dynamicPage = vm.messages[i].inlineSurfaces[surfIdx].data {
+                    vm.messages[i].inlineSurfaces[surfIdx].isToolCallComplete = true
+                }
+            }
+        }
         let wasRefinement = vm.isWorkspaceRefinementInFlight || vm.cancelledDuringRefinement
         vm.isWorkspaceRefinementInFlight = false
         vm.cancelledDuringRefinement = false

--- a/clients/shared/Features/Chat/ChatViewModel+StreamingHelpers.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+StreamingHelpers.swift
@@ -451,13 +451,27 @@ extension ChatViewModel {
                messages[msgIndex].toolCalls[tcIndex].confirmationDecision == .approved {
                 messages[msgIndex].toolCalls[tcIndex].confirmationDecision = .denied
             }
-            // When an app tool call completes, mark dynamic page surfaces in the
-            // same message as ready so the inline card enables its "Open App" button.
+            // When an app tool call completes, mark dynamic page surfaces as
+            // ready so the inline card enables its "Open App" button. Search
+            // the matched message first, then fall back to the current assistant
+            // message in case the surface ended up in a different message due
+            // to rotation or toolUseId-based matching across messages.
             let toolName = messages[msgIndex].toolCalls[tcIndex].toolName
             if toolName == "app_create" || toolName == "app_refresh" || toolName == "app_update" {
+                var found = false
                 for surfIdx in messages[msgIndex].inlineSurfaces.indices {
                     if case .dynamicPage = messages[msgIndex].inlineSurfaces[surfIdx].data {
                         messages[msgIndex].inlineSurfaces[surfIdx].isToolCallComplete = true
+                        found = true
+                    }
+                }
+                if !found, let currentId = currentAssistantMessageId,
+                   let currentIdx = messages.firstIndex(where: { $0.id == currentId }),
+                   currentIdx != msgIndex {
+                    for surfIdx in messages[currentIdx].inlineSurfaces.indices {
+                        if case .dynamicPage = messages[currentIdx].inlineSurfaces[surfIdx].data {
+                            messages[currentIdx].inlineSurfaces[surfIdx].isToolCallComplete = true
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Fix `handleToolResult` to search the current assistant message as fallback when the surface ended up in a different message than the matched tool call (due to message rotation or toolUseId-based cross-message matching)
- Add safety net in `handleMessageComplete` that marks all remaining `isToolCallComplete = false` dynamic page surfaces as complete, covering edge cases like workspace refinement guard mismatch

## Test plan
- [ ] Create an app via chat ("build me a calculator app") — Open App button should be enabled after tool completes
- [ ] Create an app while in side-by-side mode (app workspace + docked chat) — Open App button should be enabled
- [ ] Verify existing app refresh/update flows still enable the button promptly

🤖 Generated with [Claude Code](https://claude.com/claude-code)