### PR TITLE
fix: app preview not updating after edits in workspace panel

### DIFF
--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -4,9 +4,9 @@ import {
   getApp,
   getAppDirPath,
   getAppPreview,
-  inlineDistAssets,
   isMultifileApp,
   resolveAppDir,
+  resolveEffectiveAppHtml,
   updateApp,
 } from "../memory/app-store.js";
 import {
@@ -1150,10 +1150,12 @@ export function refreshSurfacesForApp(
     // Push current HTML onto the undo stack before overwriting
     pushUndoState(ctx.surfaceUndoStacks, surfaceId, data.html);
 
-    // Update in-memory surface state so the next refinement gets fresh HTML
+    // Update in-memory surface state so the next refinement gets fresh HTML.
+    // For multifile apps, resolve the compiled dist/index.html with inlined
+    // assets rather than the empty root index.html (app.htmlDefinition).
     const updatedData: DynamicPageSurfaceData = {
       ...data,
-      html: app.htmlDefinition,
+      html: resolveEffectiveAppHtml(app),
       ...(opts?.fileChange
         ? { reloadGeneration: (data.reloadGeneration ?? 0) + 1 }
         : {}),
@@ -1543,11 +1545,10 @@ export async function surfaceProxyResolver(
     const storedPreview = getAppPreview(app.id);
     const { dirName } = resolveAppDir(app.id);
 
-    // For multifile TSX apps, resolve HTML from compiled dist/index.html
-    // rather than the root index.html (which is empty for formatVersion 2).
-    let html = app.htmlDefinition;
+    // For multifile TSX apps, auto-compile if dist is missing, then
+    // resolve HTML from compiled dist/index.html with inlined assets.
     if (isMultifileApp(app)) {
-      const { existsSync, readFileSync } = await import("node:fs");
+      const { existsSync } = await import("node:fs");
       const { join } = await import("node:path");
       const appDir = getAppDirPath(app.id);
       const distIndex = join(appDir, "dist", "index.html");
@@ -1561,12 +1562,8 @@ export async function surfaceProxyResolver(
           );
         }
       }
-      if (existsSync(distIndex)) {
-        html = inlineDistAssets(appDir, readFileSync(distIndex, "utf-8"));
-      } else {
-        html = `<p>App compilation failed. Edit a source file to trigger a rebuild.</p>`;
-      }
     }
+    const html = resolveEffectiveAppHtml(app);
 
     const surfaceData: DynamicPageSurfaceData = {
       html,

--- a/assistant/src/memory/app-store.ts
+++ b/assistant/src/memory/app-store.ts
@@ -65,6 +65,23 @@ export function isMultifileApp(app: AppDefinition): boolean {
 }
 
 /**
+ * Resolve the effective HTML for an app. For single-file apps this is
+ * `htmlDefinition` (the root index.html). For multifile apps it reads the
+ * compiled `dist/index.html` and inlines JS/CSS assets so the result is a
+ * self-contained HTML string suitable for `loadHTMLString`.
+ */
+export function resolveEffectiveAppHtml(app: AppDefinition): string {
+  if (!isMultifileApp(app)) return app.htmlDefinition;
+
+  const appDir = getAppDirPath(app.id);
+  const distIndex = join(appDir, "dist", "index.html");
+  if (existsSync(distIndex)) {
+    return inlineDistAssets(appDir, readFileSync(distIndex, "utf-8"));
+  }
+  return app.htmlDefinition;
+}
+
+/**
  * Inline dist assets (main.js, main.css) into the compiled HTML so it can be
  * delivered as a self-contained string via loadHTMLString/SSE without needing
  * the client to resolve external script/stylesheet URLs.

--- a/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
@@ -388,10 +388,13 @@ extension AppDelegate {
                     ))
                 case .appFilesChanged(let msg):
                     self.refreshAppsCache()
-                    for (surfaceId, appSurfaceId) in self.surfaceManager.surfaceAppIds {
-                        guard appSurfaceId == msg.appId else { continue }
-                        self.surfaceManager.surfaceCoordinators[surfaceId]?.webView?.reload()
-                    }
+                    // WebView reload is handled by the separate ui_surface_update
+                    // message which triggers updateNSView → reloadGeneration →
+                    // loadHTMLString with fresh compiled HTML. Calling
+                    // webView.reload() here would replay stale inline HTML for
+                    // surfaces loaded via loadHTMLString (isInlineFallback),
+                    // racing with the correct ui_surface_update path.
+                    _ = msg
                 case .uiLayoutConfig(let msg):
                     self.mainWindow?.windowState.applyLayoutConfig(msg)
 


### PR DESCRIPTION
## Summary
- Add `resolveEffectiveAppHtml()` helper to `app-store.ts` that returns compiled `dist/index.html` with inlined assets for multifile apps, falling back to `htmlDefinition` for single-file apps
- Fix `refreshSurfacesForApp()` to use the helper instead of raw `app.htmlDefinition`, which was empty for multifile (formatVersion 2) apps
- Remove redundant `webView.reload()` from the macOS `app_files_changed` handler — it replayed stale inline HTML, racing with the correct `ui_surface_update` → `reloadGeneration` path

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] `bun test conversation-tool-setup-app-refresh.test.ts` — 12/12 pass
- [x] `bun test app-source-watcher.test.ts app-compiler.test.ts` — 34/34 pass
- [ ] Manual: create a multifile app, ask to change background color → verify workspace panel updates
- [ ] Manual: create a single-file app, ask to change styles → verify workspace panel updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24262" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
