### PR TITLE
feat(browser/cdp): add CdpClient interface and factory shell

### DIFF
--- a/assistant/src/tools/browser/cdp-client/__tests__/types.test.ts
+++ b/assistant/src/tools/browser/cdp-client/__tests__/types.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  type CdpClient,
+  type CdpClientKind,
+  CdpError,
+  type CdpErrorCode,
+  type ScopedCdpClient,
+} from "../index.js";
+
+describe("CdpError", () => {
+  test("subclasses Error", () => {
+    const err = new CdpError("cdp_error", "boom");
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(CdpError);
+  });
+
+  test("sets name to CdpError", () => {
+    const err = new CdpError("aborted", "test");
+    expect(err.name).toBe("CdpError");
+  });
+
+  test("captures code, message, and default details", () => {
+    const err = new CdpError("aborted", "caller aborted");
+    expect(err.code).toBe("aborted");
+    expect(err.message).toBe("caller aborted");
+    expect(err.cdpMethod).toBeUndefined();
+    expect(err.cdpParams).toBeUndefined();
+    expect(err.underlying).toBeUndefined();
+  });
+
+  test("captures cdpMethod, cdpParams, and underlying when provided", () => {
+    const cause = new Error("socket closed");
+    const err = new CdpError("transport_error", "send failed", {
+      cdpMethod: "Page.navigate",
+      cdpParams: { url: "https://example.com/" },
+      underlying: cause,
+    });
+    expect(err.code).toBe("transport_error");
+    expect(err.cdpMethod).toBe("Page.navigate");
+    expect(err.cdpParams).toEqual({ url: "https://example.com/" });
+    expect(err.underlying).toBe(cause);
+  });
+
+  test("supports all documented CdpErrorCode values", () => {
+    const codes: CdpErrorCode[] = [
+      "cdp_error",
+      "transport_error",
+      "aborted",
+      "disposed",
+    ];
+    for (const code of codes) {
+      const err = new CdpError(code, `code ${code}`);
+      expect(err.code).toBe(code);
+    }
+  });
+});
+
+describe("cdp-client re-exports", () => {
+  test("CdpError is reachable from index", () => {
+    expect(CdpError).toBeDefined();
+    expect(typeof CdpError).toBe("function");
+  });
+
+  test("CdpClient interface is structurally assignable", () => {
+    // Compile-time: ensure CdpClient is importable and can be implemented.
+    const stub: CdpClient = {
+      send: async <T = unknown>(
+        _method: string,
+        _params?: Record<string, unknown>,
+        _signal?: AbortSignal,
+      ): Promise<T> => {
+        throw new CdpError("disposed", "stub");
+      },
+      dispose: () => {},
+    };
+    expect(typeof stub.send).toBe("function");
+    expect(typeof stub.dispose).toBe("function");
+  });
+
+  test("ScopedCdpClient exposes kind and conversationId", () => {
+    const kinds: CdpClientKind[] = ["local", "extension"];
+    for (const kind of kinds) {
+      const scoped: ScopedCdpClient = {
+        kind,
+        conversationId: "conv-123",
+        send: async <T = unknown>(): Promise<T> => {
+          throw new CdpError("disposed", "stub");
+        },
+        dispose: () => {},
+      };
+      expect(scoped.kind).toBe(kind);
+      expect(scoped.conversationId).toBe("conv-123");
+    }
+  });
+});

--- a/assistant/src/tools/browser/cdp-client/errors.ts
+++ b/assistant/src/tools/browser/cdp-client/errors.ts
@@ -1,0 +1,34 @@
+export type CdpErrorCode =
+  | "cdp_error" // JSON-RPC error returned by CDP
+  | "transport_error" // underlying transport failed (socket closed, timeout)
+  | "aborted" // caller-provided AbortSignal fired
+  | "disposed"; // client.dispose() already called
+
+/**
+ * Single error type thrown by all CdpClient implementations. Carries
+ * the offending CDP method + params for logging and a stable code so
+ * callers can branch without string-sniffing.
+ */
+export class CdpError extends Error {
+  readonly code: CdpErrorCode;
+  readonly cdpMethod?: string;
+  readonly cdpParams?: Record<string, unknown>;
+  readonly underlying?: unknown;
+
+  constructor(
+    code: CdpErrorCode,
+    message: string,
+    details?: {
+      cdpMethod?: string;
+      cdpParams?: Record<string, unknown>;
+      underlying?: unknown;
+    },
+  ) {
+    super(message);
+    this.name = "CdpError";
+    this.code = code;
+    this.cdpMethod = details?.cdpMethod;
+    this.cdpParams = details?.cdpParams;
+    this.underlying = details?.underlying;
+  }
+}

--- a/assistant/src/tools/browser/cdp-client/index.ts
+++ b/assistant/src/tools/browser/cdp-client/index.ts
@@ -1,0 +1,2 @@
+export { CdpError, type CdpErrorCode } from "./errors.js";
+export type { CdpClient, CdpClientKind, ScopedCdpClient } from "./types.js";

--- a/assistant/src/tools/browser/cdp-client/types.ts
+++ b/assistant/src/tools/browser/cdp-client/types.ts
@@ -1,0 +1,51 @@
+/**
+ * Minimal typed surface over Chrome DevTools Protocol. Implemented by
+ * LocalCdpClient (Playwright-backed, same-process Chromium) and by
+ * ExtensionCdpClient (routes through HostBrowserProxy to the user's
+ * Chrome via chrome.debugger). Tools call `send(method, params)` with
+ * a CDP method name and return the raw CDP result object; errors are
+ * thrown as {@link CdpError}.
+ */
+export interface CdpClient {
+  /**
+   * Send a CDP command and await the result. `method` must be a
+   * well-known CDP method name (e.g. "Page.navigate",
+   * "Runtime.evaluate", "Accessibility.getFullAXTree"). `params` is
+   * forwarded verbatim.
+   *
+   * On success, returns the raw `result` object from the CDP response
+   * as `T`. On JSON-RPC error or transport failure, throws a
+   * {@link CdpError}. Abort propagates via `signal`; aborted calls
+   * throw an {@link CdpError} with `code === "aborted"`.
+   */
+  send<T = unknown>(
+    method: string,
+    params?: Record<string, unknown>,
+    signal?: AbortSignal,
+  ): Promise<T>;
+
+  /**
+   * Release any backend-side resources (CDP sessions, in-flight
+   * requests, listeners). Idempotent. Calling `send` after `dispose`
+   * is allowed but should surface as an error.
+   */
+  dispose(): void;
+}
+
+/**
+ * Backend kind exposed by a concrete CdpClient. Used by tools that
+ * want to branch on the transport (e.g. browser_navigate should skip
+ * the sacrificial-profile screencast setup when running against the
+ * user's own Chrome via the extension).
+ */
+export type CdpClientKind = "local" | "extension";
+
+/**
+ * Concrete CdpClient instance returned by the factory. Carries the
+ * backend `kind` for transport-aware branches in tool code.
+ */
+export interface ScopedCdpClient extends CdpClient {
+  readonly kind: CdpClientKind;
+  /** Stable conversation id this client is bound to. */
+  readonly conversationId: string;
+}


### PR DESCRIPTION
## Summary
- New `assistant/src/tools/browser/cdp-client/` directory with `types.ts`, `errors.ts`, `index.ts`
- Publishes the `CdpClient` / `ScopedCdpClient` interfaces and the `CdpError` class that every Phase 3 CDP implementation will use
- Pure types + minimal tests; no consumers yet

Part of plan: phase3-cdp-migration.md (PR 1 of 14)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24265" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
