### PR TITLE
feat(browser/cdp): add AX-tree-to-snapshot transformer

### DIFF
--- a/assistant/src/tools/browser/cdp-client/__tests__/accessibility-snapshot.test.ts
+++ b/assistant/src/tools/browser/cdp-client/__tests__/accessibility-snapshot.test.ts
@@ -1,0 +1,318 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  type AxSnapshotElement,
+  type AxSnapshotResult,
+  formatAxSnapshot,
+  transformAxTree,
+} from "../accessibility-snapshot.js";
+import nestedFramesFixture from "./fixtures/ax-tree-nested-frames.json" with { type: "json" };
+import simpleFixture from "./fixtures/ax-tree-simple.json" with { type: "json" };
+
+// ── transformAxTree ──────────────────────────────────────────────────
+
+describe("transformAxTree", () => {
+  it("happy path: simple fixture returns exactly 3 elements with stable eids", () => {
+    const result = transformAxTree(simpleFixture);
+
+    expect(result.elements).toHaveLength(3);
+
+    const [e1, e2, e3] = result.elements as [
+      AxSnapshotElement,
+      AxSnapshotElement,
+      AxSnapshotElement,
+    ];
+
+    // e1: the button (trimmed + focusable prop not surfaced as attr).
+    expect(e1.eid).toBe("e1");
+    expect(e1.role).toBe("button");
+    expect(e1.name).toBe("Submit Form");
+    expect(e1.backendNodeId).toBe(101);
+    expect(e1.attrs).toEqual({ disabled: "false" });
+    expect(e1.value).toBeUndefined();
+
+    // e2: the link carries its url property in attrs.
+    expect(e2.eid).toBe("e2");
+    expect(e2.role).toBe("link");
+    expect(e2.name).toBe("About Us");
+    expect(e2.backendNodeId).toBe(102);
+    expect(e2.attrs).toEqual({ url: "https://example.com/about" });
+
+    // e3: the textbox carries placeholder + required + a `value` field.
+    expect(e3.eid).toBe("e3");
+    expect(e3.role).toBe("textbox");
+    expect(e3.name).toBe("Email address");
+    expect(e3.backendNodeId).toBe(103);
+    expect(e3.value).toBe("user@example.com");
+    expect(e3.attrs).toEqual({
+      placeholder: "you@example.com",
+      required: "true",
+    });
+  });
+
+  it("filters out ignored nodes", () => {
+    const result = transformAxTree(simpleFixture);
+    for (const el of result.elements) {
+      expect(el.name).not.toBe("Hidden Action");
+    }
+  });
+
+  it("filters out nodes without backendDOMNodeId", () => {
+    const result = transformAxTree(simpleFixture);
+    for (const el of result.elements) {
+      expect(el.name).not.toBe("Orphan Button");
+    }
+  });
+
+  it("truncates to opts.maxElements", () => {
+    const result = transformAxTree(simpleFixture, { maxElements: 2 });
+    expect(result.elements).toHaveLength(2);
+    expect(result.elements[0]?.eid).toBe("e1");
+    expect(result.elements[1]?.eid).toBe("e2");
+    // selectorMap only contains the kept elements.
+    expect(result.selectorMap.size).toBe(2);
+    expect(result.selectorMap.get("e1")).toBe(101);
+    expect(result.selectorMap.get("e2")).toBe(102);
+    expect(result.selectorMap.has("e3")).toBe(false);
+  });
+
+  it("selectorMap.get() returns the backendNodeId for each eid", () => {
+    const result = transformAxTree(simpleFixture);
+    expect(result.selectorMap.size).toBe(3);
+    expect(result.selectorMap.get("e1")).toBe(101);
+    expect(result.selectorMap.get("e2")).toBe(102);
+    expect(result.selectorMap.get("e3")).toBe(103);
+  });
+
+  it("filters out non-interactive roles (StaticText, generic, RootWebArea)", () => {
+    const fixture = {
+      nodes: [
+        {
+          nodeId: "1",
+          role: { value: "RootWebArea" },
+          name: { value: "Root" },
+          backendDOMNodeId: 1,
+          childIds: ["2", "3", "4"],
+          ignored: false,
+        },
+        {
+          nodeId: "2",
+          role: { value: "StaticText" },
+          name: { value: "Just some text" },
+          backendDOMNodeId: 2,
+          childIds: [],
+          ignored: false,
+        },
+        {
+          nodeId: "3",
+          role: { value: "generic" },
+          name: { value: "A div" },
+          backendDOMNodeId: 3,
+          childIds: [],
+          ignored: false,
+        },
+        {
+          nodeId: "4",
+          role: { value: "button" },
+          name: { value: "Real Button" },
+          backendDOMNodeId: 4,
+          childIds: [],
+          ignored: false,
+        },
+      ],
+    };
+
+    const result = transformAxTree(fixture);
+    expect(result.elements).toHaveLength(1);
+    expect(result.elements[0]?.name).toBe("Real Button");
+    expect(result.elements[0]?.role).toBe("button");
+  });
+
+  it("includes focusable nodes even when the role is not interactive", () => {
+    // Regression test for contenteditable divs and custom widgets: a
+    // generic-role node with `focusable: true` must still surface.
+    const fixture = {
+      nodes: [
+        {
+          nodeId: "1",
+          role: { value: "RootWebArea" },
+          name: { value: "Root" },
+          backendDOMNodeId: 1,
+          childIds: ["2"],
+          ignored: false,
+        },
+        {
+          nodeId: "2",
+          role: { value: "generic" },
+          name: { value: "Contenteditable field" },
+          properties: [
+            { name: "focusable", value: { type: "boolean", value: true } },
+          ],
+          backendDOMNodeId: 42,
+          childIds: [],
+          ignored: false,
+        },
+      ],
+    };
+
+    const result = transformAxTree(fixture);
+    expect(result.elements).toHaveLength(1);
+    const [el] = result.elements;
+    expect(el?.role).toBe("generic");
+    expect(el?.backendNodeId).toBe(42);
+    expect(el?.name).toBe("Contenteditable field");
+  });
+
+  it("traverses nested RootWebArea (iframe) children in document order", () => {
+    const result = transformAxTree(nestedFramesFixture);
+
+    // Expect 4 kept elements across parent + inner frame, in doc order.
+    expect(result.elements).toHaveLength(4);
+    expect(result.elements.map((el) => el.name)).toEqual([
+      "Parent Button",
+      "Inner Link",
+      "Inner Search",
+      "Subscribe",
+    ]);
+    expect(result.elements.map((el) => el.backendNodeId)).toEqual([
+      201, 203, 204, 205,
+    ]);
+    expect(result.elements.map((el) => el.eid)).toEqual([
+      "e1",
+      "e2",
+      "e3",
+      "e4",
+    ]);
+  });
+
+  it("truncates names longer than 80 chars", () => {
+    const longName = "x".repeat(200);
+    const fixture = {
+      nodes: [
+        {
+          nodeId: "1",
+          role: { value: "button" },
+          name: { value: longName },
+          backendDOMNodeId: 1,
+          childIds: [],
+          ignored: false,
+        },
+      ],
+    };
+    const result = transformAxTree(fixture);
+    expect(result.elements).toHaveLength(1);
+    expect(result.elements[0]?.name.length).toBe(80);
+  });
+
+  it("returns an empty result for malformed input", () => {
+    expect(transformAxTree(null)).toEqual({
+      elements: [],
+      selectorMap: new Map(),
+    });
+    expect(transformAxTree(undefined)).toEqual({
+      elements: [],
+      selectorMap: new Map(),
+    });
+    expect(transformAxTree({})).toEqual({
+      elements: [],
+      selectorMap: new Map(),
+    });
+    expect(transformAxTree({ nodes: [] })).toEqual({
+      elements: [],
+      selectorMap: new Map(),
+    });
+  });
+});
+
+// ── formatAxSnapshot ──────────────────────────────────────────────────
+
+describe("formatAxSnapshot", () => {
+  it("byte-matches the legacy executeBrowserSnapshot format for the simple fixture", () => {
+    const result = transformAxTree(simpleFixture);
+    const formatted = formatAxSnapshot(result, {
+      url: "https://example.com/",
+      title: "Example",
+    });
+
+    const expected = [
+      "URL: https://example.com/",
+      "Title: Example",
+      "",
+      `[e1] <button disabled="false"> Submit Form`,
+      `[e2] <link url="https://example.com/about"> About Us`,
+      `[e3] <textbox placeholder="you@example.com" required="true" value="user@example.com"> Email address`,
+      "",
+      "3 interactive elements found.",
+    ].join("\n");
+
+    expect(formatted).toBe(expected);
+  });
+
+  it("uses '(none)' when title is empty", () => {
+    const result: AxSnapshotResult = {
+      elements: [],
+      selectorMap: new Map(),
+    };
+    const formatted = formatAxSnapshot(result, {
+      url: "about:blank",
+      title: "",
+    });
+    expect(formatted).toBe(
+      [
+        "URL: about:blank",
+        "Title: (none)",
+        "",
+        "(no interactive elements found)",
+      ].join("\n"),
+    );
+  });
+
+  it("renders 'interactive element' (singular) for a single-element result", () => {
+    const result: AxSnapshotResult = {
+      elements: [
+        {
+          eid: "e1",
+          role: "button",
+          name: "Click",
+          attrs: {},
+          backendNodeId: 1,
+        },
+      ],
+      selectorMap: new Map([["e1", 1]]),
+    };
+    const formatted = formatAxSnapshot(result, {
+      url: "https://example.com/",
+      title: "T",
+    });
+    expect(formatted).toBe(
+      [
+        "URL: https://example.com/",
+        "Title: T",
+        "",
+        "[e1] <button> Click",
+        "",
+        "1 interactive element found.",
+      ].join("\n"),
+    );
+  });
+
+  it("omits the trailing ' name' segment when name is empty", () => {
+    const result: AxSnapshotResult = {
+      elements: [
+        {
+          eid: "e1",
+          role: "button",
+          name: "",
+          attrs: {},
+          backendNodeId: 1,
+        },
+      ],
+      selectorMap: new Map([["e1", 1]]),
+    };
+    const formatted = formatAxSnapshot(result, {
+      url: "https://example.com/",
+      title: "T",
+    });
+    expect(formatted.split("\n")[3]).toBe("[e1] <button>");
+  });
+});

--- a/assistant/src/tools/browser/cdp-client/__tests__/fixtures/ax-tree-nested-frames.json
+++ b/assistant/src/tools/browser/cdp-client/__tests__/fixtures/ax-tree-nested-frames.json
@@ -1,0 +1,64 @@
+{
+  "nodes": [
+    {
+      "nodeId": "1",
+      "role": { "type": "internalRole", "value": "RootWebArea" },
+      "name": { "type": "computedString", "value": "Parent" },
+      "ignored": false,
+      "backendDOMNodeId": 200,
+      "childIds": ["2", "3", "6"]
+    },
+    {
+      "nodeId": "2",
+      "role": { "type": "role", "value": "button" },
+      "name": { "type": "computedString", "value": "Parent Button" },
+      "backendDOMNodeId": 201,
+      "ignored": false,
+      "childIds": []
+    },
+    {
+      "nodeId": "3",
+      "role": { "type": "internalRole", "value": "RootWebArea" },
+      "name": { "type": "computedString", "value": "Inner Frame" },
+      "backendDOMNodeId": 202,
+      "ignored": false,
+      "childIds": ["4", "5"]
+    },
+    {
+      "nodeId": "4",
+      "role": { "type": "role", "value": "link" },
+      "name": { "type": "computedString", "value": "Inner Link" },
+      "properties": [
+        {
+          "name": "url",
+          "value": {
+            "type": "string",
+            "value": "https://example.com/inner"
+          }
+        }
+      ],
+      "backendDOMNodeId": 203,
+      "ignored": false,
+      "childIds": []
+    },
+    {
+      "nodeId": "5",
+      "role": { "type": "role", "value": "textbox" },
+      "name": { "type": "computedString", "value": "Inner Search" },
+      "backendDOMNodeId": 204,
+      "ignored": false,
+      "childIds": []
+    },
+    {
+      "nodeId": "6",
+      "role": { "type": "role", "value": "checkbox" },
+      "name": { "type": "computedString", "value": "Subscribe" },
+      "properties": [
+        { "name": "checked", "value": { "type": "boolean", "value": true } }
+      ],
+      "backendDOMNodeId": 205,
+      "ignored": false,
+      "childIds": []
+    }
+  ]
+}

--- a/assistant/src/tools/browser/cdp-client/__tests__/fixtures/ax-tree-simple.json
+++ b/assistant/src/tools/browser/cdp-client/__tests__/fixtures/ax-tree-simple.json
@@ -1,0 +1,69 @@
+{
+  "nodes": [
+    {
+      "nodeId": "1",
+      "role": { "type": "internalRole", "value": "RootWebArea" },
+      "name": { "type": "computedString", "value": "Example" },
+      "ignored": false,
+      "backendDOMNodeId": 100,
+      "childIds": ["2", "3", "4", "5", "6"]
+    },
+    {
+      "nodeId": "2",
+      "role": { "type": "role", "value": "button" },
+      "name": { "type": "computedString", "value": "  Submit Form  " },
+      "properties": [
+        { "name": "disabled", "value": { "type": "boolean", "value": false } },
+        { "name": "focusable", "value": { "type": "boolean", "value": true } }
+      ],
+      "backendDOMNodeId": 101,
+      "ignored": false,
+      "childIds": []
+    },
+    {
+      "nodeId": "3",
+      "role": { "type": "role", "value": "link" },
+      "name": { "type": "computedString", "value": "About Us" },
+      "properties": [
+        {
+          "name": "url",
+          "value": { "type": "string", "value": "https://example.com/about" }
+        }
+      ],
+      "backendDOMNodeId": 102,
+      "ignored": false,
+      "childIds": []
+    },
+    {
+      "nodeId": "4",
+      "role": { "type": "role", "value": "textbox" },
+      "name": { "type": "computedString", "value": "Email address" },
+      "value": { "type": "string", "value": "user@example.com" },
+      "properties": [
+        {
+          "name": "placeholder",
+          "value": { "type": "string", "value": "you@example.com" }
+        },
+        { "name": "required", "value": { "type": "boolean", "value": true } }
+      ],
+      "backendDOMNodeId": 103,
+      "ignored": false,
+      "childIds": []
+    },
+    {
+      "nodeId": "5",
+      "role": { "type": "role", "value": "button" },
+      "name": { "type": "computedString", "value": "Hidden Action" },
+      "backendDOMNodeId": 104,
+      "ignored": true,
+      "childIds": []
+    },
+    {
+      "nodeId": "6",
+      "role": { "type": "role", "value": "button" },
+      "name": { "type": "computedString", "value": "Orphan Button" },
+      "ignored": false,
+      "childIds": []
+    }
+  ]
+}

--- a/assistant/src/tools/browser/cdp-client/accessibility-snapshot.ts
+++ b/assistant/src/tools/browser/cdp-client/accessibility-snapshot.ts
@@ -1,0 +1,391 @@
+/**
+ * Pure transformer that converts a raw CDP `Accessibility.getFullAXTree`
+ * result into a typed list of interactive snapshot elements plus a
+ * `selectorMap` (eid → backendNodeId) for downstream DOM commands.
+ *
+ * This module is intentionally standalone — no I/O, no CDP calls, no
+ * dependency on `cdp-client/types.ts`. That decoupling lets the entire
+ * transformer be unit-tested against JSON fixtures without any transport
+ * plumbing.
+ *
+ * The output shape and the `formatAxSnapshot` output are designed to be
+ * byte-compatible with the legacy DOM-based snapshot produced by
+ * `executeBrowserSnapshot` in `browser-execution.ts`, so the migration in
+ * a later PR is a direct drop-in replacement.
+ */
+
+// ── Types ─────────────────────────────────────────────────────────────
+
+/**
+ * Stable element identifier handed back to the LLM. Matches the `eid`
+ * shape the existing DOM-based snapshot produced (`e1`, `e2`, ...) so
+ * that prompts referring to "element e5" continue to work after the
+ * migration.
+ */
+export type ElementId = string;
+
+export interface AxSnapshotElement {
+  eid: ElementId;
+  /** Accessibility role (e.g. "button", "link", "textbox"). */
+  role: string;
+  /** Accessible name, trimmed and truncated to 80 chars. */
+  name: string;
+  /** Role-specific value (e.g. input value, checkbox state). */
+  value?: string;
+  /** Additional attributes surfaced from the AX tree ("placeholder", "checked", "expanded", ...). */
+  attrs: Record<string, string>;
+  /** Opaque CDP backend node id — used by downstream tools to call DOM commands (click, focus, etc.). */
+  backendNodeId: number;
+}
+
+export interface AxSnapshotResult {
+  elements: AxSnapshotElement[];
+  /** Map from `eid` to backendNodeId for O(1) lookup during click/type/etc. */
+  selectorMap: Map<ElementId, number>;
+}
+
+// ── Constants ─────────────────────────────────────────────────────────
+
+/**
+ * Default maximum number of interactive elements returned in a snapshot.
+ * Mirrors the legacy `MAX_SNAPSHOT_ELEMENTS` constant in
+ * `browser-execution.ts` so parity is preserved during the migration.
+ */
+export const DEFAULT_MAX_ELEMENTS = 150;
+
+/**
+ * AX roles we consider "interactive" and surface to the LLM. Derived
+ * from the legacy `INTERACTIVE_SELECTOR` list in `browser-execution.ts`
+ * plus standard ARIA interactive roles. A node whose role is in this set
+ * is always kept (subject to ignored/backendNodeId filters). Nodes with
+ * a `focusable: true` property are also kept regardless of role so that
+ * contenteditable widgets and custom controls surface.
+ */
+const INTERACTIVE_ROLES: ReadonlySet<string> = new Set([
+  "button",
+  "link",
+  "textbox",
+  "checkbox",
+  "radio",
+  "tab",
+  "menuitem",
+  "option",
+  "combobox",
+  "listbox",
+  "switch",
+  "searchbox",
+  "slider",
+  "spinbutton",
+  "treeitem",
+]);
+
+/**
+ * AX node properties we surface into the element's `attrs` map. Keys not
+ * in this set are dropped.
+ */
+const PROPERTY_ALLOWLIST: ReadonlySet<string> = new Set([
+  "placeholder",
+  "checked",
+  "expanded",
+  "selected",
+  "pressed",
+  "disabled",
+  "required",
+  "level",
+  "url",
+]);
+
+// ── Raw AX-tree shapes ────────────────────────────────────────────────
+// We only define the subset of fields we actually read. Everything else
+// is discarded. These shapes are `unknown`-tolerant on purpose — the
+// transformer accepts any JSON-ish input and defensively validates each
+// field.
+
+interface RawAxValue {
+  type?: string;
+  value?: unknown;
+}
+
+interface RawAxProperty {
+  name?: string;
+  value?: RawAxValue;
+}
+
+interface RawAxNode {
+  nodeId?: string;
+  role?: RawAxValue;
+  name?: RawAxValue;
+  value?: RawAxValue;
+  properties?: RawAxProperty[];
+  backendDOMNodeId?: number;
+  childIds?: string[];
+  ignored?: boolean;
+}
+
+interface RawAxTree {
+  nodes?: RawAxNode[];
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+/** Coerce any AX property value to a string for the `attrs` map. */
+function stringifyAxValue(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  // Object/array values are rare here; fall back to JSON for completeness.
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+/**
+ * Build a tree traversal order over the AX nodes. CDP's
+ * `Accessibility.getFullAXTree` returns nodes in a flat array, but
+ * element ordering that feels natural to the LLM is document order,
+ * which is the result of a depth-first walk from the root(s).
+ *
+ * Strategy: build a nodeId → node index, then walk from any node that
+ * isn't referenced as a child (roots). Nested `RootWebArea` children
+ * (iframes) are traversed transparently since they appear as regular
+ * children in the flat list.
+ *
+ * Nodes not reachable from a root are appended at the end in their
+ * original order so we never silently lose them in the presence of
+ * malformed fixtures.
+ */
+function walkAxTreeInDocumentOrder(nodes: RawAxNode[]): RawAxNode[] {
+  const byId = new Map<string, RawAxNode>();
+  const childIds = new Set<string>();
+  for (const node of nodes) {
+    if (typeof node.nodeId === "string") {
+      byId.set(node.nodeId, node);
+    }
+    if (Array.isArray(node.childIds)) {
+      for (const childId of node.childIds) {
+        if (typeof childId === "string") childIds.add(childId);
+      }
+    }
+  }
+
+  const roots: RawAxNode[] = [];
+  for (const node of nodes) {
+    if (typeof node.nodeId === "string" && !childIds.has(node.nodeId)) {
+      roots.push(node);
+    }
+  }
+
+  const ordered: RawAxNode[] = [];
+  const visited = new Set<string>();
+  const stack: RawAxNode[] = [];
+
+  // Push roots in reverse so pop order matches input order.
+  for (let i = roots.length - 1; i >= 0; i -= 1) {
+    const root = roots[i];
+    if (root) stack.push(root);
+  }
+
+  while (stack.length > 0) {
+    const node = stack.pop();
+    if (!node) continue;
+    const id = node.nodeId;
+    if (typeof id === "string") {
+      if (visited.has(id)) continue;
+      visited.add(id);
+    }
+    ordered.push(node);
+    if (Array.isArray(node.childIds)) {
+      // Iterate in reverse so the first child is popped next.
+      for (let i = node.childIds.length - 1; i >= 0; i -= 1) {
+        const childId = node.childIds[i];
+        if (typeof childId !== "string") continue;
+        const child = byId.get(childId);
+        if (child) stack.push(child);
+      }
+    }
+  }
+
+  // Preserve any orphan nodes (not reachable from roots) for determinism.
+  for (const node of nodes) {
+    const id = node.nodeId;
+    if (typeof id === "string" && !visited.has(id)) {
+      visited.add(id);
+      ordered.push(node);
+    } else if (typeof id !== "string") {
+      ordered.push(node);
+    }
+  }
+
+  return ordered;
+}
+
+/**
+ * Determine whether a node should be included in the snapshot based on
+ * its role and `focusable` property. Does NOT check `ignored` or
+ * `backendDOMNodeId` — callers handle those earlier.
+ */
+function isKeeperNode(node: RawAxNode): boolean {
+  const role = node.role?.value;
+  if (typeof role === "string" && INTERACTIVE_ROLES.has(role)) {
+    return true;
+  }
+  if (Array.isArray(node.properties)) {
+    for (const prop of node.properties) {
+      if (prop?.name === "focusable" && prop.value?.value === true) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/**
+ * Extract the `attrs` map from an AX node's properties, filtered by the
+ * property allowlist.
+ */
+function extractAttrs(node: RawAxNode): Record<string, string> {
+  const attrs: Record<string, string> = {};
+  if (!Array.isArray(node.properties)) return attrs;
+  for (const prop of node.properties) {
+    const name = prop?.name;
+    if (typeof name !== "string") continue;
+    if (!PROPERTY_ALLOWLIST.has(name)) continue;
+    attrs[name] = stringifyAxValue(prop.value?.value);
+  }
+  return attrs;
+}
+
+// ── Public API ────────────────────────────────────────────────────────
+
+/**
+ * Transform a raw CDP `Accessibility.getFullAXTree` result into a typed
+ * list of interactive elements + a selector map for downstream DOM
+ * commands.
+ *
+ * The input is accepted as `unknown` and defensively validated — garbage
+ * input yields an empty result rather than throwing.
+ */
+export function transformAxTree(
+  rawTree: unknown,
+  opts?: { maxElements?: number },
+): AxSnapshotResult {
+  const maxElements = opts?.maxElements ?? DEFAULT_MAX_ELEMENTS;
+
+  const tree = rawTree as RawAxTree | null;
+  const rawNodes = tree?.nodes;
+  if (!Array.isArray(rawNodes) || rawNodes.length === 0) {
+    return { elements: [], selectorMap: new Map() };
+  }
+
+  const orderedNodes = walkAxTreeInDocumentOrder(rawNodes);
+
+  const elements: AxSnapshotElement[] = [];
+  const selectorMap = new Map<ElementId, number>();
+
+  for (const node of orderedNodes) {
+    if (elements.length >= maxElements) break;
+
+    // Drop ignored nodes (Chrome excluded from the AX tree on purpose).
+    if (node.ignored === true) continue;
+
+    // Role and backendNodeId are mandatory for an element to be usable.
+    const role = node.role?.value;
+    if (typeof role !== "string" || role.length === 0) continue;
+
+    const backendNodeId = node.backendDOMNodeId;
+    if (typeof backendNodeId !== "number") continue;
+
+    if (!isKeeperNode(node)) continue;
+
+    const rawName = typeof node.name?.value === "string" ? node.name.value : "";
+    const name = rawName.trim().slice(0, 80);
+
+    const rawValue = node.value?.value;
+    const value =
+      typeof rawValue === "string" && rawValue.length > 0
+        ? rawValue
+        : undefined;
+
+    const attrs = extractAttrs(node);
+
+    const eid: ElementId = `e${elements.length + 1}`;
+    const element: AxSnapshotElement = {
+      eid,
+      role,
+      name,
+      attrs,
+      backendNodeId,
+      ...(value !== undefined ? { value } : {}),
+    };
+    elements.push(element);
+    selectorMap.set(eid, backendNodeId);
+  }
+
+  return { elements, selectorMap };
+}
+
+/**
+ * Render a snapshot result to the same multi-line human-readable output
+ * the legacy DOM-based `executeBrowserSnapshot` produced. This format is
+ * deliberately byte-compatible with `browser-execution.ts:524-551` so
+ * existing prompts, tests, and users keep working after the migration.
+ *
+ * Output shape:
+ *
+ *   URL: <url>
+ *   Title: <title or "(none)">
+ *
+ *   [e1] <role attr="val" ...> name
+ *   [e2] ...
+ *
+ *   N interactive element(s) found.
+ *
+ * When the element list is empty:
+ *
+ *   URL: <url>
+ *   Title: <title or "(none)">
+ *
+ *   (no interactive elements found)
+ */
+export function formatAxSnapshot(
+  result: AxSnapshotResult,
+  page: { url: string; title: string },
+): string {
+  const lines: string[] = [
+    `URL: ${page.url}`,
+    `Title: ${page.title || "(none)"}`,
+    "",
+  ];
+
+  const { elements } = result;
+  if (elements.length === 0) {
+    lines.push("(no interactive elements found)");
+  } else {
+    for (const el of elements) {
+      let desc = `<${el.role}`;
+      for (const [key, val] of Object.entries(el.attrs)) {
+        desc += ` ${key}="${val}"`;
+      }
+      if (el.value !== undefined) {
+        desc += ` value="${el.value}"`;
+      }
+      desc += ">";
+      if (el.name) {
+        desc += ` ${el.name}`;
+      }
+      lines.push(`[${el.eid}] ${desc}`);
+    }
+    lines.push("");
+    lines.push(
+      `${elements.length} interactive element${
+        elements.length === 1 ? "" : "s"
+      } found.`,
+    );
+  }
+
+  return lines.join("\n");
+}


### PR DESCRIPTION
## Summary
- Pure transformer from CDP `Accessibility.getFullAXTree` JSON to typed `SnapshotElement[]` + `selectorMap`
- Produces output format byte-identical to the current `executeBrowserSnapshot` for drop-in replacement in PR 8
- Fixtures + bun:test coverage; no external consumers yet

Part of plan: phase3-cdp-migration.md (PR 2 of 14)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24268" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
