### PR TITLE
feat(browser/cdp): add LocalCdpClient backed by Playwright CDPSession

### DIFF
--- a/assistant/src/tools/browser/cdp-client/__tests__/local-cdp-client.test.ts
+++ b/assistant/src/tools/browser/cdp-client/__tests__/local-cdp-client.test.ts
@@ -1,0 +1,235 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Silence the logger from local-cdp-client.
+mock.module("../../../../util/logger.js", () => ({
+  getLogger: () => ({
+    info: () => {},
+    debug: () => {},
+    warn: () => {},
+    error: () => {},
+  }),
+}));
+
+let fakeSessionSendCalls: Array<{ method: string; params?: unknown }> = [];
+let fakeSessionDetachCalls = 0;
+let newCdpSessionCalls = 0;
+let getOrCreateSessionPageCalls = 0;
+let fakeSessionHandler: (method: string, params?: unknown) => unknown = () =>
+  undefined;
+
+function resetFakes() {
+  fakeSessionSendCalls = [];
+  fakeSessionDetachCalls = 0;
+  newCdpSessionCalls = 0;
+  getOrCreateSessionPageCalls = 0;
+  fakeSessionHandler = () => undefined;
+}
+
+mock.module("../../browser-manager.js", () => {
+  const fakeSession = {
+    send: async (method: string, params?: unknown) => {
+      fakeSessionSendCalls.push({ method, params });
+      return fakeSessionHandler(method, params);
+    },
+    detach: async () => {
+      fakeSessionDetachCalls += 1;
+    },
+  };
+  const fakePage = {
+    context: () => ({
+      newCDPSession: async () => {
+        newCdpSessionCalls += 1;
+        return fakeSession;
+      },
+    }),
+  };
+  return {
+    browserManager: {
+      getOrCreateSessionPage: async (_conversationId: string) => {
+        getOrCreateSessionPageCalls += 1;
+        return fakePage;
+      },
+    },
+  };
+});
+
+// Import under test AFTER mock.module calls so that the module's
+// top-level imports resolve to our fakes.
+const { createLocalCdpClient, LocalCdpClient } =
+  await import("../local-cdp-client.js");
+const { CdpError } = await import("../errors.js");
+
+describe("LocalCdpClient", () => {
+  beforeEach(() => {
+    resetFakes();
+  });
+
+  test("kind is 'local' and exposes conversationId", () => {
+    const client = createLocalCdpClient("conv-kind");
+    expect(client).toBeInstanceOf(LocalCdpClient);
+    expect(client.kind).toBe("local");
+    expect(client.conversationId).toBe("conv-kind");
+  });
+
+  test("send() returns the underlying session's response", async () => {
+    fakeSessionHandler = (method) => {
+      if (method === "Browser.getVersion") {
+        return { product: "HeadlessChrome/120.0.0.0" };
+      }
+      return undefined;
+    };
+    const client = createLocalCdpClient("conv-happy");
+    const result = await client.send<{ product: string }>("Browser.getVersion");
+    expect(result).toEqual({ product: "HeadlessChrome/120.0.0.0" });
+    expect(fakeSessionSendCalls).toEqual([
+      { method: "Browser.getVersion", params: undefined },
+    ]);
+    expect(getOrCreateSessionPageCalls).toBe(1);
+    expect(newCdpSessionCalls).toBe(1);
+  });
+
+  test("send() forwards params to the underlying session", async () => {
+    fakeSessionHandler = () => ({ ok: true });
+    const client = createLocalCdpClient("conv-params");
+    await client.send("Page.navigate", { url: "https://example.com/" });
+    expect(fakeSessionSendCalls).toEqual([
+      {
+        method: "Page.navigate",
+        params: { url: "https://example.com/" },
+      },
+    ]);
+  });
+
+  test("multiple send() calls share a single CDP session", async () => {
+    fakeSessionHandler = () => ({ ok: true });
+    const client = createLocalCdpClient("conv-reuse");
+    await client.send("Browser.getVersion");
+    await client.send("Runtime.enable");
+    await client.send("Page.enable");
+    expect(newCdpSessionCalls).toBe(1);
+    expect(getOrCreateSessionPageCalls).toBe(1);
+    expect(fakeSessionSendCalls.map((c) => c.method)).toEqual([
+      "Browser.getVersion",
+      "Runtime.enable",
+      "Page.enable",
+    ]);
+  });
+
+  test("concurrent send() calls share a single in-flight session", async () => {
+    fakeSessionHandler = () => ({ ok: true });
+    const client = createLocalCdpClient("conv-concurrent");
+    await Promise.all([
+      client.send("Browser.getVersion"),
+      client.send("Runtime.enable"),
+      client.send("Page.enable"),
+    ]);
+    expect(newCdpSessionCalls).toBe(1);
+    expect(getOrCreateSessionPageCalls).toBe(1);
+    expect(fakeSessionSendCalls.length).toBe(3);
+  });
+
+  test("dispose() detaches the CDP session exactly once", async () => {
+    fakeSessionHandler = () => ({ ok: true });
+    const client = createLocalCdpClient("conv-dispose");
+    await client.send("Browser.getVersion");
+    client.dispose();
+    // dispose schedules detach asynchronously; flush microtasks.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(fakeSessionDetachCalls).toBe(1);
+
+    // Idempotent: a second dispose is a no-op.
+    client.dispose();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(fakeSessionDetachCalls).toBe(1);
+  });
+
+  test("dispose() without any sends does not call detach", async () => {
+    const client = createLocalCdpClient("conv-dispose-empty");
+    client.dispose();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(fakeSessionDetachCalls).toBe(0);
+    expect(newCdpSessionCalls).toBe(0);
+  });
+
+  test("send() after dispose throws CdpError with code 'disposed'", async () => {
+    const client = createLocalCdpClient("conv-after-dispose");
+    client.dispose();
+    let caught: unknown;
+    try {
+      await client.send("Browser.getVersion");
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(CdpError);
+    const cdpErr = caught as InstanceType<typeof CdpError>;
+    expect(cdpErr.code).toBe("disposed");
+    expect(cdpErr.cdpMethod).toBe("Browser.getVersion");
+    // No session was ever created, so no calls to the fake page.
+    expect(newCdpSessionCalls).toBe(0);
+    expect(fakeSessionSendCalls.length).toBe(0);
+  });
+
+  test("send() with an already-aborted signal throws CdpError 'aborted' without touching the session", async () => {
+    const client = createLocalCdpClient("conv-pre-aborted");
+    const controller = new AbortController();
+    controller.abort();
+    let caught: unknown;
+    try {
+      await client.send("Browser.getVersion", undefined, controller.signal);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(CdpError);
+    const cdpErr = caught as InstanceType<typeof CdpError>;
+    expect(cdpErr.code).toBe("aborted");
+    expect(cdpErr.cdpMethod).toBe("Browser.getVersion");
+    expect(fakeSessionSendCalls.length).toBe(0);
+    expect(newCdpSessionCalls).toBe(0);
+    expect(getOrCreateSessionPageCalls).toBe(0);
+  });
+
+  test("send() wraps underlying session errors as CdpError 'cdp_error'", async () => {
+    const underlying = new Error("target closed");
+    fakeSessionHandler = () => {
+      throw underlying;
+    };
+    const client = createLocalCdpClient("conv-throw");
+    let caught: unknown;
+    try {
+      await client.send("Runtime.evaluate", { expression: "1+1" });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(CdpError);
+    const cdpErr = caught as InstanceType<typeof CdpError>;
+    expect(cdpErr.code).toBe("cdp_error");
+    expect(cdpErr.message).toBe("target closed");
+    expect(cdpErr.cdpMethod).toBe("Runtime.evaluate");
+    expect(cdpErr.cdpParams).toEqual({ expression: "1+1" });
+    expect(cdpErr.underlying).toBe(underlying);
+  });
+
+  test("send() classifies as 'aborted' when the signal fires during the underlying call", async () => {
+    const controller = new AbortController();
+    fakeSessionHandler = () => {
+      controller.abort();
+      throw new Error("target closed");
+    };
+    const client = createLocalCdpClient("conv-abort-mid");
+    let caught: unknown;
+    try {
+      await client.send(
+        "Page.navigate",
+        { url: "about:blank" },
+        controller.signal,
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(CdpError);
+    const cdpErr = caught as InstanceType<typeof CdpError>;
+    expect(cdpErr.code).toBe("aborted");
+    expect(cdpErr.cdpMethod).toBe("Page.navigate");
+    expect(cdpErr.underlying).toBeInstanceOf(Error);
+  });
+});

--- a/assistant/src/tools/browser/cdp-client/local-cdp-client.ts
+++ b/assistant/src/tools/browser/cdp-client/local-cdp-client.ts
@@ -1,0 +1,140 @@
+import { getLogger } from "../../../util/logger.js";
+import { browserManager } from "../browser-manager.js";
+import { CdpError } from "./errors.js";
+import type { CdpClientKind, ScopedCdpClient } from "./types.js";
+
+const log = getLogger("local-cdp-client");
+
+/**
+ * Minimal shape of the Playwright CDPSession we depend on. Avoids a
+ * direct Playwright type import so the CDP client stays buildable
+ * even when Playwright types are not present (dev builds, CI jobs
+ * that skip the playwright install).
+ */
+interface PlaywrightCdpSession {
+  send(method: string, params?: Record<string, unknown>): Promise<unknown>;
+  detach(): Promise<void>;
+}
+
+/**
+ * Minimal shape of the Playwright Page we use for CDP session
+ * creation. Intentionally narrow so we never have to import the
+ * Playwright types directly from this module.
+ */
+interface RawPlaywrightPage {
+  context(): {
+    newCDPSession(page: unknown): Promise<PlaywrightCdpSession>;
+  };
+}
+
+/**
+ * Playwright-backed implementation of {@link ScopedCdpClient}. Used
+ * for CLI conversations, headless cloud conversations, unit tests,
+ * and any desktop conversation that does not have a `hostBrowserProxy`
+ * configured.
+ *
+ * LocalCdpClient owns only the per-conversation CDP session; the
+ * underlying Chromium is still launched and torn down by
+ * `browserManager.ensureContext()` / `browserManager.shutdown()`.
+ */
+export class LocalCdpClient implements ScopedCdpClient {
+  readonly kind: CdpClientKind = "local";
+
+  private sessionPromise: Promise<PlaywrightCdpSession> | null = null;
+  private disposed = false;
+
+  constructor(public readonly conversationId: string) {}
+
+  /**
+   * Lazily create (and cache) a Playwright CDP session for this
+   * conversation. Concurrent callers share the same in-flight promise
+   * so `newCDPSession` is only called once per LocalCdpClient
+   * instance.
+   */
+  private async ensureSession(): Promise<PlaywrightCdpSession> {
+    if (this.disposed) {
+      throw new CdpError("disposed", "LocalCdpClient already disposed");
+    }
+    if (this.sessionPromise) return this.sessionPromise;
+    this.sessionPromise = (async () => {
+      const page = await browserManager.getOrCreateSessionPage(
+        this.conversationId,
+      );
+      const rawPage = page as unknown as RawPlaywrightPage;
+      const session = await rawPage.context().newCDPSession(rawPage);
+      log.debug(
+        { conversationId: this.conversationId },
+        "Created Playwright CDP session for LocalCdpClient",
+      );
+      return session;
+    })();
+    return this.sessionPromise;
+  }
+
+  async send<T = unknown>(
+    method: string,
+    params?: Record<string, unknown>,
+    signal?: AbortSignal,
+  ): Promise<T> {
+    if (this.disposed) {
+      throw new CdpError("disposed", "LocalCdpClient already disposed", {
+        cdpMethod: method,
+        cdpParams: params,
+      });
+    }
+    if (signal?.aborted) {
+      throw new CdpError("aborted", "Aborted before send", {
+        cdpMethod: method,
+        cdpParams: params,
+      });
+    }
+    const session = await this.ensureSession();
+    try {
+      const result = (await session.send(method, params)) as T;
+      return result;
+    } catch (err) {
+      if (signal?.aborted) {
+        throw new CdpError("aborted", "Aborted during send", {
+          cdpMethod: method,
+          cdpParams: params,
+          underlying: err,
+        });
+      }
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new CdpError("cdp_error", msg, {
+        cdpMethod: method,
+        cdpParams: params,
+        underlying: err,
+      });
+    }
+  }
+
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    const pending = this.sessionPromise;
+    this.sessionPromise = null;
+    if (!pending) return;
+    pending
+      .then(async (session) => {
+        try {
+          await session.detach();
+        } catch (err) {
+          log.debug({ err }, "LocalCdpClient: session.detach threw (ignored)");
+        }
+      })
+      .catch(() => {
+        // Session never resolved — nothing to detach.
+      });
+  }
+}
+
+/**
+ * Factory for a fresh {@link LocalCdpClient} bound to a conversation.
+ * Keeping the constructor + factory split lets the cdp-client factory
+ * (PR 6) branch between local and extension transports without
+ * exposing the class directly to callers.
+ */
+export function createLocalCdpClient(conversationId: string): LocalCdpClient {
+  return new LocalCdpClient(conversationId);
+}


### PR DESCRIPTION
## Summary
- `LocalCdpClient` implements `ScopedCdpClient` by wrapping a Playwright `CDPSession` obtained via `browserManager.getOrCreateSessionPage().context().newCDPSession()`
- Lazy session creation, shared across concurrent sends; `dispose()` detaches the session
- Bun:test coverage against a mocked `browserManager`; no runtime consumers yet

Part of plan: phase3-cdp-migration.md (PR 4 of 14)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24270" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
