### PR TITLE
feat(browser/cdp): add CDP DOM/Input/Page helper primitives

### DIFF
--- a/assistant/src/tools/browser/cdp-client/__tests__/cdp-dom-helpers.test.ts
+++ b/assistant/src/tools/browser/cdp-client/__tests__/cdp-dom-helpers.test.ts
@@ -1,0 +1,691 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  captureScreenshotJpeg,
+  dispatchClickAt,
+  dispatchHoverAt,
+  dispatchInsertText,
+  dispatchKeyPress,
+  dispatchWheelScroll,
+  evaluateExpression,
+  focusElement,
+  getCenterPoint,
+  getCurrentUrl,
+  getPageTitle,
+  navigateAndWait,
+  querySelectorBackendNodeId,
+  scrollIntoViewIfNeeded,
+  waitForSelector,
+  waitForText,
+} from "../cdp-dom-helpers.js";
+import { CdpError } from "../errors.js";
+import type { CdpClient } from "../types.js";
+
+// ── Test utilities ────────────────────────────────────────────────────
+
+type CdpCall = { method: string; params?: Record<string, unknown> };
+
+/**
+ * Minimal in-memory fake CdpClient. The programmable `handler` is
+ * called for every `send` and must return the raw CDP result object
+ * (or throw). Every call is recorded on `calls` so tests can assert
+ * method order and param shape.
+ */
+function fakeCdp(
+  handler: (method: string, params?: Record<string, unknown>) => unknown,
+): CdpClient & { calls: CdpCall[] } {
+  const calls: CdpCall[] = [];
+  return {
+    calls,
+    async send<T>(
+      method: string,
+      params?: Record<string, unknown>,
+    ): Promise<T> {
+      calls.push({ method, params });
+      const value = handler(method, params);
+      return (await value) as T;
+    },
+    dispose() {},
+  };
+}
+
+// ── querySelectorBackendNodeId ────────────────────────────────────────
+
+describe("querySelectorBackendNodeId", () => {
+  test("returns backendNodeId on happy path", async () => {
+    const cdp = fakeCdp((method) => {
+      switch (method) {
+        case "DOM.getDocument":
+          return { root: { nodeId: 1 } };
+        case "DOM.querySelector":
+          return { nodeId: 42 };
+        case "DOM.describeNode":
+          return { node: { backendNodeId: 777 } };
+        default:
+          throw new Error(`unexpected method: ${method}`);
+      }
+    });
+
+    const backendNodeId = await querySelectorBackendNodeId(cdp, "#submit");
+
+    expect(backendNodeId).toBe(777);
+    expect(cdp.calls.map((c) => c.method)).toEqual([
+      "DOM.getDocument",
+      "DOM.querySelector",
+      "DOM.describeNode",
+    ]);
+    expect(cdp.calls[1]!.params).toEqual({ nodeId: 1, selector: "#submit" });
+    expect(cdp.calls[2]!.params).toEqual({ nodeId: 42, depth: 0 });
+  });
+
+  test("throws CdpError with code 'cdp_error' when nodeId is 0", async () => {
+    const cdp = fakeCdp((method) => {
+      switch (method) {
+        case "DOM.getDocument":
+          return { root: { nodeId: 1 } };
+        case "DOM.querySelector":
+          return { nodeId: 0 };
+        default:
+          throw new Error(`unexpected method: ${method}`);
+      }
+    });
+
+    await expect(
+      querySelectorBackendNodeId(cdp, "#missing"),
+    ).rejects.toMatchObject({
+      name: "CdpError",
+      code: "cdp_error",
+      cdpMethod: "DOM.querySelector",
+      cdpParams: { selector: "#missing" },
+    });
+  });
+});
+
+// ── scrollIntoViewIfNeeded ────────────────────────────────────────────
+
+describe("scrollIntoViewIfNeeded", () => {
+  test("sends DOM.scrollIntoViewIfNeeded with backendNodeId", async () => {
+    const cdp = fakeCdp(() => ({}));
+    await scrollIntoViewIfNeeded(cdp, 99);
+    expect(cdp.calls).toEqual([
+      { method: "DOM.scrollIntoViewIfNeeded", params: { backendNodeId: 99 } },
+    ]);
+  });
+
+  test("propagates transport errors from the client", async () => {
+    const cdp = fakeCdp(() => {
+      throw new CdpError("transport_error", "socket closed");
+    });
+    await expect(scrollIntoViewIfNeeded(cdp, 99)).rejects.toMatchObject({
+      name: "CdpError",
+      code: "transport_error",
+    });
+  });
+});
+
+// ── getCenterPoint ────────────────────────────────────────────────────
+
+describe("getCenterPoint", () => {
+  test("returns midpoint of the content quad", async () => {
+    // Content quad: (10,20) (30,20) (30,40) (10,40)
+    // Midpoint: ((10+30)/2, (20+40)/2) = (20, 30)
+    const cdp = fakeCdp(() => ({
+      model: { content: [10, 20, 30, 20, 30, 40, 10, 40] },
+    }));
+
+    const point = await getCenterPoint(cdp, 55);
+
+    expect(point).toEqual({ x: 20, y: 30 });
+    expect(cdp.calls[0]).toEqual({
+      method: "DOM.getBoxModel",
+      params: { backendNodeId: 55 },
+    });
+  });
+
+  test("throws CdpError when DOM.getBoxModel rejects", async () => {
+    const cdp = fakeCdp(() => {
+      throw new CdpError("cdp_error", "Could not compute box model.");
+    });
+    await expect(getCenterPoint(cdp, 55)).rejects.toMatchObject({
+      name: "CdpError",
+      code: "cdp_error",
+    });
+  });
+});
+
+// ── focusElement ──────────────────────────────────────────────────────
+
+describe("focusElement", () => {
+  test("sends DOM.focus with backendNodeId", async () => {
+    const cdp = fakeCdp(() => ({}));
+    await focusElement(cdp, 123);
+    expect(cdp.calls).toEqual([
+      { method: "DOM.focus", params: { backendNodeId: 123 } },
+    ]);
+  });
+
+  test("propagates errors from the client", async () => {
+    const cdp = fakeCdp(() => {
+      throw new CdpError("cdp_error", "Element is not focusable");
+    });
+    await expect(focusElement(cdp, 123)).rejects.toMatchObject({
+      name: "CdpError",
+      code: "cdp_error",
+    });
+  });
+});
+
+// ── dispatchClickAt ───────────────────────────────────────────────────
+
+describe("dispatchClickAt", () => {
+  test("emits exactly three Input.dispatchMouseEvent calls in order", async () => {
+    const cdp = fakeCdp(() => ({}));
+
+    await dispatchClickAt(cdp, { x: 100, y: 200 });
+
+    expect(cdp.calls).toHaveLength(3);
+    expect(cdp.calls[0]).toEqual({
+      method: "Input.dispatchMouseEvent",
+      params: {
+        x: 100,
+        y: 200,
+        button: "left",
+        clickCount: 1,
+        type: "mouseMoved",
+      },
+    });
+    expect(cdp.calls[1]).toEqual({
+      method: "Input.dispatchMouseEvent",
+      params: {
+        x: 100,
+        y: 200,
+        button: "left",
+        clickCount: 1,
+        type: "mousePressed",
+      },
+    });
+    expect(cdp.calls[2]).toEqual({
+      method: "Input.dispatchMouseEvent",
+      params: {
+        x: 100,
+        y: 200,
+        button: "left",
+        clickCount: 1,
+        type: "mouseReleased",
+      },
+    });
+  });
+
+  test("propagates errors from the client", async () => {
+    const cdp = fakeCdp(() => {
+      throw new CdpError("transport_error", "send failed");
+    });
+    await expect(dispatchClickAt(cdp, { x: 1, y: 2 })).rejects.toMatchObject({
+      name: "CdpError",
+      code: "transport_error",
+    });
+  });
+});
+
+// ── dispatchHoverAt ───────────────────────────────────────────────────
+
+describe("dispatchHoverAt", () => {
+  test("emits a single mouseMoved event", async () => {
+    const cdp = fakeCdp(() => ({}));
+
+    await dispatchHoverAt(cdp, { x: 10, y: 20 });
+
+    expect(cdp.calls).toEqual([
+      {
+        method: "Input.dispatchMouseEvent",
+        params: { type: "mouseMoved", x: 10, y: 20, button: "none" },
+      },
+    ]);
+  });
+
+  test("propagates errors from the client", async () => {
+    const cdp = fakeCdp(() => {
+      throw new CdpError("cdp_error", "boom");
+    });
+    await expect(dispatchHoverAt(cdp, { x: 10, y: 20 })).rejects.toMatchObject({
+      name: "CdpError",
+    });
+  });
+});
+
+// ── dispatchInsertText ────────────────────────────────────────────────
+
+describe("dispatchInsertText", () => {
+  test("sends a single Input.insertText with the expected text", async () => {
+    const cdp = fakeCdp(() => ({}));
+
+    await dispatchInsertText(cdp, "hello world");
+
+    expect(cdp.calls).toEqual([
+      { method: "Input.insertText", params: { text: "hello world" } },
+    ]);
+  });
+
+  test("propagates errors from the client", async () => {
+    const cdp = fakeCdp(() => {
+      throw new CdpError("cdp_error", "boom");
+    });
+    await expect(dispatchInsertText(cdp, "x")).rejects.toMatchObject({
+      name: "CdpError",
+    });
+  });
+});
+
+// ── dispatchKeyPress ──────────────────────────────────────────────────
+
+describe("dispatchKeyPress", () => {
+  test("emits keyDown + keyUp with the requested key", async () => {
+    const cdp = fakeCdp(() => ({}));
+
+    await dispatchKeyPress(cdp, "Enter");
+
+    expect(cdp.calls).toEqual([
+      {
+        method: "Input.dispatchKeyEvent",
+        params: { type: "keyDown", key: "Enter" },
+      },
+      {
+        method: "Input.dispatchKeyEvent",
+        params: { type: "keyUp", key: "Enter" },
+      },
+    ]);
+  });
+
+  test("propagates errors from the client", async () => {
+    const cdp = fakeCdp(() => {
+      throw new CdpError("cdp_error", "boom");
+    });
+    await expect(dispatchKeyPress(cdp, "a")).rejects.toMatchObject({
+      name: "CdpError",
+    });
+  });
+});
+
+// ── dispatchWheelScroll ───────────────────────────────────────────────
+
+describe("dispatchWheelScroll", () => {
+  test("emits a mouseWheel event with the requested delta", async () => {
+    const cdp = fakeCdp(() => ({}));
+
+    await dispatchWheelScroll(
+      cdp,
+      { x: 100, y: 200 },
+      { deltaX: 0, deltaY: 500 },
+    );
+
+    expect(cdp.calls).toEqual([
+      {
+        method: "Input.dispatchMouseEvent",
+        params: {
+          type: "mouseWheel",
+          x: 100,
+          y: 200,
+          deltaX: 0,
+          deltaY: 500,
+        },
+      },
+    ]);
+  });
+
+  test("propagates errors from the client", async () => {
+    const cdp = fakeCdp(() => {
+      throw new CdpError("transport_error", "boom");
+    });
+    await expect(
+      dispatchWheelScroll(cdp, { x: 0, y: 0 }, { deltaX: 0, deltaY: 10 }),
+    ).rejects.toMatchObject({ name: "CdpError", code: "transport_error" });
+  });
+});
+
+// ── getCurrentUrl ─────────────────────────────────────────────────────
+
+describe("getCurrentUrl", () => {
+  test("returns the result.value from Runtime.evaluate", async () => {
+    const cdp = fakeCdp((method, params) => {
+      expect(method).toBe("Runtime.evaluate");
+      expect(params).toEqual({
+        expression: "document.location.href",
+        returnByValue: true,
+      });
+      return { result: { value: "https://example.com/" } };
+    });
+
+    const url = await getCurrentUrl(cdp);
+    expect(url).toBe("https://example.com/");
+  });
+
+  test("propagates errors from the client", async () => {
+    const cdp = fakeCdp(() => {
+      throw new CdpError("transport_error", "boom");
+    });
+    await expect(getCurrentUrl(cdp)).rejects.toMatchObject({
+      name: "CdpError",
+      code: "transport_error",
+    });
+  });
+});
+
+// ── getPageTitle ──────────────────────────────────────────────────────
+
+describe("getPageTitle", () => {
+  test("returns the result.value from Runtime.evaluate", async () => {
+    const cdp = fakeCdp((method, params) => {
+      expect(method).toBe("Runtime.evaluate");
+      expect(params).toEqual({
+        expression: "document.title",
+        returnByValue: true,
+      });
+      return { result: { value: "My Page" } };
+    });
+    expect(await getPageTitle(cdp)).toBe("My Page");
+  });
+
+  test("returns empty string when result value is missing", async () => {
+    const cdp = fakeCdp(() => ({ result: { value: undefined } }));
+    expect(await getPageTitle(cdp)).toBe("");
+  });
+
+  test("propagates errors from the client", async () => {
+    const cdp = fakeCdp(() => {
+      throw new CdpError("transport_error", "boom");
+    });
+    await expect(getPageTitle(cdp)).rejects.toMatchObject({
+      name: "CdpError",
+    });
+  });
+});
+
+// ── evaluateExpression ────────────────────────────────────────────────
+
+describe("evaluateExpression", () => {
+  test("returns result.value on happy path with default opts", async () => {
+    const cdp = fakeCdp((method, params) => {
+      expect(method).toBe("Runtime.evaluate");
+      expect(params).toEqual({
+        expression: "1 + 2",
+        returnByValue: true,
+        awaitPromise: true,
+        userGesture: true,
+      });
+      return { result: { value: 3 } };
+    });
+
+    const value = await evaluateExpression<number>(cdp, "1 + 2");
+    expect(value).toBe(3);
+  });
+
+  test("honors awaitPromise: false override", async () => {
+    const cdp = fakeCdp(() => ({ result: { value: "ok" } }));
+    await evaluateExpression<string>(cdp, "'ok'", { awaitPromise: false });
+    expect(cdp.calls[0]!.params).toMatchObject({
+      awaitPromise: false,
+    });
+  });
+
+  test("throws CdpError when exceptionDetails is present", async () => {
+    const cdp = fakeCdp(() => ({
+      result: { value: undefined },
+      exceptionDetails: {
+        text: "Uncaught",
+        exception: { description: "ReferenceError: foo is not defined" },
+      },
+    }));
+
+    await expect(evaluateExpression(cdp, "foo")).rejects.toMatchObject({
+      name: "CdpError",
+      code: "cdp_error",
+      message: "ReferenceError: foo is not defined",
+      cdpMethod: "Runtime.evaluate",
+      cdpParams: { expression: "foo" },
+    });
+  });
+
+  test("falls back to exceptionDetails.text if no description", async () => {
+    const cdp = fakeCdp(() => ({
+      result: { value: undefined },
+      exceptionDetails: { text: "Uncaught SyntaxError" },
+    }));
+    await expect(evaluateExpression(cdp, "???")).rejects.toMatchObject({
+      message: "Uncaught SyntaxError",
+    });
+  });
+});
+
+// ── captureScreenshotJpeg ─────────────────────────────────────────────
+
+describe("captureScreenshotJpeg", () => {
+  test("returns a Buffer with decoded bytes", async () => {
+    const rawBytes = Buffer.from([0xff, 0xd8, 0xff, 0xe0]); // JPEG SOI + APP0
+    const base64 = rawBytes.toString("base64");
+
+    const cdp = fakeCdp((method, params) => {
+      expect(method).toBe("Page.captureScreenshot");
+      expect(params).toEqual({
+        format: "jpeg",
+        quality: 80,
+        captureBeyondViewport: false,
+      });
+      return { data: base64 };
+    });
+
+    const buf = await captureScreenshotJpeg(cdp);
+    expect(Buffer.isBuffer(buf)).toBe(true);
+    expect(buf.equals(rawBytes)).toBe(true);
+  });
+
+  test("forwards quality + fullPage options", async () => {
+    const cdp = fakeCdp(() => ({ data: "" }));
+    await captureScreenshotJpeg(cdp, { quality: 50, fullPage: true });
+    expect(cdp.calls[0]!.params).toEqual({
+      format: "jpeg",
+      quality: 50,
+      captureBeyondViewport: true,
+    });
+  });
+
+  test("propagates errors from the client", async () => {
+    const cdp = fakeCdp(() => {
+      throw new CdpError("transport_error", "boom");
+    });
+    await expect(captureScreenshotJpeg(cdp)).rejects.toMatchObject({
+      name: "CdpError",
+    });
+  });
+});
+
+// ── navigateAndWait ───────────────────────────────────────────────────
+
+describe("navigateAndWait", () => {
+  test("calls Page.navigate and returns finalUrl once readyState is complete", async () => {
+    const cdp = fakeCdp((method, params) => {
+      if (method === "Page.navigate") return {};
+      if (method === "Runtime.evaluate") {
+        const expr = (params as { expression: string }).expression;
+        if (expr === "document.readyState")
+          return { result: { value: "complete" } };
+        if (expr === "document.location.href")
+          return { result: { value: "https://example.com/final" } };
+      }
+      throw new Error(`unexpected: ${method}`);
+    });
+
+    const result = await navigateAndWait(cdp, "https://example.com/start", {
+      timeoutMs: 5_000,
+    });
+
+    expect(result).toEqual({
+      finalUrl: "https://example.com/final",
+      timedOut: false,
+    });
+
+    const navigateCalls = cdp.calls.filter((c) => c.method === "Page.navigate");
+    expect(navigateCalls).toHaveLength(1);
+    expect(navigateCalls[0]!.params).toEqual({
+      url: "https://example.com/start",
+    });
+  });
+
+  test("resolves when readyState becomes interactive (not just complete)", async () => {
+    const cdp = fakeCdp((method, params) => {
+      if (method === "Page.navigate") return {};
+      if (method === "Runtime.evaluate") {
+        const expr = (params as { expression: string }).expression;
+        if (expr === "document.readyState")
+          return { result: { value: "interactive" } };
+        if (expr === "document.location.href")
+          return { result: { value: "https://x" } };
+      }
+      throw new Error(`unexpected: ${method}`);
+    });
+
+    const result = await navigateAndWait(cdp, "https://x", {
+      timeoutMs: 5_000,
+    });
+    expect(result.timedOut).toBe(false);
+  });
+
+  test("returns timedOut: true when readyState never becomes ready", async () => {
+    const cdp = fakeCdp((method, params) => {
+      if (method === "Page.navigate") return {};
+      if (method === "Runtime.evaluate") {
+        const expr = (params as { expression: string }).expression;
+        if (expr === "document.readyState")
+          return { result: { value: "loading" } };
+        if (expr === "document.location.href")
+          return { result: { value: "https://slow" } };
+      }
+      throw new Error(`unexpected: ${method}`);
+    });
+
+    // Use a tiny timeout so the test finishes quickly.
+    const result = await navigateAndWait(cdp, "https://slow", {
+      timeoutMs: 50,
+    });
+    expect(result).toEqual({
+      finalUrl: "https://slow",
+      timedOut: true,
+    });
+  });
+
+  test("throws CdpError with code 'aborted' when signal fires", async () => {
+    const controller = new AbortController();
+    const cdp = fakeCdp((method) => {
+      if (method === "Page.navigate") {
+        controller.abort();
+        return {};
+      }
+      if (method === "Runtime.evaluate")
+        return { result: { value: "loading" } };
+      throw new Error(`unexpected: ${method}`);
+    });
+
+    await expect(
+      navigateAndWait(
+        cdp,
+        "https://x",
+        { timeoutMs: 5_000 },
+        controller.signal,
+      ),
+    ).rejects.toMatchObject({
+      name: "CdpError",
+      code: "aborted",
+    });
+  });
+});
+
+// ── waitForSelector ───────────────────────────────────────────────────
+
+describe("waitForSelector", () => {
+  test("resolves when the selector appears on the 2nd poll", async () => {
+    let evalCount = 0;
+    const cdp = fakeCdp((method) => {
+      if (method === "Runtime.evaluate") {
+        evalCount++;
+        // First poll: not present. Second poll: present.
+        return { result: { value: evalCount >= 2 } };
+      }
+      if (method === "DOM.getDocument") return { root: { nodeId: 1 } };
+      if (method === "DOM.querySelector") return { nodeId: 9 };
+      if (method === "DOM.describeNode")
+        return { node: { backendNodeId: 321 } };
+      throw new Error(`unexpected: ${method}`);
+    });
+
+    const backendNodeId = await waitForSelector(cdp, "#ready", 5_000);
+    expect(backendNodeId).toBe(321);
+    expect(evalCount).toBeGreaterThanOrEqual(2);
+  });
+
+  test("throws CdpError on timeout", async () => {
+    const cdp = fakeCdp((method) => {
+      if (method === "Runtime.evaluate") return { result: { value: false } };
+      throw new Error(`unexpected: ${method}`);
+    });
+
+    await expect(waitForSelector(cdp, "#nope", 50)).rejects.toMatchObject({
+      name: "CdpError",
+      code: "cdp_error",
+      message: "Timed out waiting for #nope",
+    });
+  });
+
+  test("throws CdpError with code 'aborted' when signal fires", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const cdp = fakeCdp(() => ({ result: { value: false } }));
+    await expect(
+      waitForSelector(cdp, "#x", 5_000, controller.signal),
+    ).rejects.toMatchObject({
+      name: "CdpError",
+      code: "aborted",
+    });
+  });
+});
+
+// ── waitForText ───────────────────────────────────────────────────────
+
+describe("waitForText", () => {
+  test("resolves when the text is found", async () => {
+    let count = 0;
+    const cdp = fakeCdp((method) => {
+      if (method === "Runtime.evaluate") {
+        count++;
+        return { result: { value: count >= 2 } };
+      }
+      throw new Error(`unexpected: ${method}`);
+    });
+
+    await waitForText(cdp, "hello", 5_000);
+    expect(count).toBeGreaterThanOrEqual(2);
+  });
+
+  test("throws CdpError on timeout", async () => {
+    const cdp = fakeCdp((method) => {
+      if (method === "Runtime.evaluate") return { result: { value: false } };
+      throw new Error(`unexpected: ${method}`);
+    });
+
+    await expect(waitForText(cdp, "never-here", 50)).rejects.toMatchObject({
+      name: "CdpError",
+      code: "cdp_error",
+      message: "Timed out waiting for text: never-here",
+    });
+  });
+
+  test("throws CdpError with code 'aborted' when signal fires", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const cdp = fakeCdp(() => ({ result: { value: false } }));
+    await expect(
+      waitForText(cdp, "x", 5_000, controller.signal),
+    ).rejects.toMatchObject({
+      name: "CdpError",
+      code: "aborted",
+    });
+  });
+});

--- a/assistant/src/tools/browser/cdp-client/cdp-dom-helpers.ts
+++ b/assistant/src/tools/browser/cdp-client/cdp-dom-helpers.ts
@@ -1,0 +1,385 @@
+/**
+ * Common CDP idioms that each browser tool would otherwise reimplement:
+ * selector resolution, mouse/keyboard dispatch, screenshot capture,
+ * navigation, polling waits, and small Runtime.evaluate wrappers.
+ *
+ * Every helper takes a {@link CdpClient} as its first argument, forwards
+ * an optional {@link AbortSignal} verbatim to `CdpClient.send`, and
+ * throws a {@link CdpError} on failure. The module is pure plumbing —
+ * no I/O beyond the injected CdpClient — which keeps it trivial to
+ * unit-test against a fake in-memory client.
+ */
+
+import { CdpError } from "./errors.js";
+import type { CdpClient } from "./types.js";
+
+// ── Selector / node resolution ────────────────────────────────────────
+
+/**
+ * Resolve a CSS selector to a CDP `backendNodeId`. Runs
+ * `DOM.getDocument` → `DOM.querySelector` → `DOM.describeNode` and
+ * throws {@link CdpError} with `code: "cdp_error"` if no element
+ * matches (CDP signals this by returning `nodeId: 0`).
+ */
+export async function querySelectorBackendNodeId(
+  cdp: CdpClient,
+  selector: string,
+  signal?: AbortSignal,
+): Promise<number> {
+  const { root } = await cdp.send<{ root: { nodeId: number } }>(
+    "DOM.getDocument",
+    {},
+    signal,
+  );
+  const { nodeId } = await cdp.send<{ nodeId: number }>(
+    "DOM.querySelector",
+    { nodeId: root.nodeId, selector },
+    signal,
+  );
+  if (!nodeId) {
+    throw new CdpError("cdp_error", `Element not found: ${selector}`, {
+      cdpMethod: "DOM.querySelector",
+      cdpParams: { selector },
+    });
+  }
+  const { node } = await cdp.send<{ node: { backendNodeId: number } }>(
+    "DOM.describeNode",
+    { nodeId, depth: 0 },
+    signal,
+  );
+  return node.backendNodeId;
+}
+
+/** Scroll the element identified by `backendNodeId` into view if needed. */
+export async function scrollIntoViewIfNeeded(
+  cdp: CdpClient,
+  backendNodeId: number,
+  signal?: AbortSignal,
+): Promise<void> {
+  await cdp.send("DOM.scrollIntoViewIfNeeded", { backendNodeId }, signal);
+}
+
+/**
+ * Read the element's content-quad via `DOM.getBoxModel` and return the
+ * midpoint in viewport coordinates. CDP returns `content` as a flat
+ * 8-number array `[x1,y1, x2,y2, x3,y3, x4,y4]`.
+ */
+export async function getCenterPoint(
+  cdp: CdpClient,
+  backendNodeId: number,
+  signal?: AbortSignal,
+): Promise<{ x: number; y: number }> {
+  const { model } = await cdp.send<{
+    model: { content: number[] };
+  }>("DOM.getBoxModel", { backendNodeId }, signal);
+  const xs = [
+    model.content[0]!,
+    model.content[2]!,
+    model.content[4]!,
+    model.content[6]!,
+  ];
+  const ys = [
+    model.content[1]!,
+    model.content[3]!,
+    model.content[5]!,
+    model.content[7]!,
+  ];
+  return {
+    x: (Math.min(...xs) + Math.max(...xs)) / 2,
+    y: (Math.min(...ys) + Math.max(...ys)) / 2,
+  };
+}
+
+/** Focus an element by `backendNodeId` via `DOM.focus`. */
+export async function focusElement(
+  cdp: CdpClient,
+  backendNodeId: number,
+  signal?: AbortSignal,
+): Promise<void> {
+  await cdp.send("DOM.focus", { backendNodeId }, signal);
+}
+
+// ── Mouse / keyboard / wheel dispatch ─────────────────────────────────
+
+/**
+ * Dispatch a full left-click (mouseMoved + mousePressed + mouseReleased)
+ * at the given viewport point.
+ */
+export async function dispatchClickAt(
+  cdp: CdpClient,
+  point: { x: number; y: number },
+  signal?: AbortSignal,
+): Promise<void> {
+  const base = { x: point.x, y: point.y, button: "left", clickCount: 1 };
+  await cdp.send(
+    "Input.dispatchMouseEvent",
+    { ...base, type: "mouseMoved" },
+    signal,
+  );
+  await cdp.send(
+    "Input.dispatchMouseEvent",
+    { ...base, type: "mousePressed" },
+    signal,
+  );
+  await cdp.send(
+    "Input.dispatchMouseEvent",
+    { ...base, type: "mouseReleased" },
+    signal,
+  );
+}
+
+/** Dispatch a single mouseMoved (hover) at the given viewport point. */
+export async function dispatchHoverAt(
+  cdp: CdpClient,
+  point: { x: number; y: number },
+  signal?: AbortSignal,
+): Promise<void> {
+  await cdp.send(
+    "Input.dispatchMouseEvent",
+    { type: "mouseMoved", x: point.x, y: point.y, button: "none" },
+    signal,
+  );
+}
+
+/**
+ * Insert text at the currently focused element via `Input.insertText`.
+ * Unlike synthesizing individual key events, this dispatches the right
+ * `input`/`change` events that form controls expect.
+ */
+export async function dispatchInsertText(
+  cdp: CdpClient,
+  text: string,
+  signal?: AbortSignal,
+): Promise<void> {
+  await cdp.send("Input.insertText", { text }, signal);
+}
+
+/**
+ * Press a single key (keyDown + keyUp). Key names follow CDP
+ * conventions ("Enter", "Tab", "ArrowDown", "a").
+ */
+export async function dispatchKeyPress(
+  cdp: CdpClient,
+  key: string,
+  signal?: AbortSignal,
+): Promise<void> {
+  await cdp.send("Input.dispatchKeyEvent", { type: "keyDown", key }, signal);
+  await cdp.send("Input.dispatchKeyEvent", { type: "keyUp", key }, signal);
+}
+
+/** Dispatch a wheel scroll delta at the given viewport point. */
+export async function dispatchWheelScroll(
+  cdp: CdpClient,
+  point: { x: number; y: number },
+  delta: { deltaX: number; deltaY: number },
+  signal?: AbortSignal,
+): Promise<void> {
+  await cdp.send(
+    "Input.dispatchMouseEvent",
+    {
+      type: "mouseWheel",
+      x: point.x,
+      y: point.y,
+      deltaX: delta.deltaX,
+      deltaY: delta.deltaY,
+    },
+    signal,
+  );
+}
+
+// ── Runtime.evaluate wrappers ─────────────────────────────────────────
+
+/** Get the current page URL via `Runtime.evaluate("document.location.href")`. */
+export async function getCurrentUrl(
+  cdp: CdpClient,
+  signal?: AbortSignal,
+): Promise<string> {
+  const { result } = await cdp.send<{ result: { value: string } }>(
+    "Runtime.evaluate",
+    { expression: "document.location.href", returnByValue: true },
+    signal,
+  );
+  return result.value;
+}
+
+/** Get the current page title via `Runtime.evaluate("document.title")`. */
+export async function getPageTitle(
+  cdp: CdpClient,
+  signal?: AbortSignal,
+): Promise<string> {
+  const { result } = await cdp.send<{ result: { value: string } }>(
+    "Runtime.evaluate",
+    { expression: "document.title", returnByValue: true },
+    signal,
+  );
+  return result.value ?? "";
+}
+
+/**
+ * Evaluate a JS expression via `Runtime.evaluate` and return the
+ * deserialized value. Throws {@link CdpError} with `code: "cdp_error"`
+ * if the expression threw (surfaced via CDP's `exceptionDetails`).
+ *
+ * Defaults: `returnByValue: true`, `awaitPromise: true`, `userGesture: true`.
+ */
+export async function evaluateExpression<T = unknown>(
+  cdp: CdpClient,
+  expression: string,
+  opts?: { awaitPromise?: boolean },
+  signal?: AbortSignal,
+): Promise<T> {
+  const res = await cdp.send<{
+    result: { value: T };
+    exceptionDetails?: {
+      text?: string;
+      exception?: { description?: string };
+    };
+  }>(
+    "Runtime.evaluate",
+    {
+      expression,
+      returnByValue: true,
+      awaitPromise: opts?.awaitPromise ?? true,
+      userGesture: true,
+    },
+    signal,
+  );
+  if (res.exceptionDetails) {
+    const msg =
+      res.exceptionDetails.exception?.description ??
+      res.exceptionDetails.text ??
+      "Runtime.evaluate exception";
+    throw new CdpError("cdp_error", msg, {
+      cdpMethod: "Runtime.evaluate",
+      cdpParams: { expression },
+    });
+  }
+  return res.result.value;
+}
+
+// ── Screenshot ────────────────────────────────────────────────────────
+
+/**
+ * Capture a JPEG screenshot via `Page.captureScreenshot` and return the
+ * decoded bytes as a Node `Buffer`. Defaults to quality 80. Pass
+ * `fullPage: true` to capture beyond the viewport.
+ */
+export async function captureScreenshotJpeg(
+  cdp: CdpClient,
+  opts: { quality?: number; fullPage?: boolean } = {},
+  signal?: AbortSignal,
+): Promise<Buffer> {
+  const { data } = await cdp.send<{ data: string }>(
+    "Page.captureScreenshot",
+    {
+      format: "jpeg",
+      quality: opts.quality ?? 80,
+      captureBeyondViewport: opts.fullPage === true,
+    },
+    signal,
+  );
+  return Buffer.from(data, "base64");
+}
+
+// ── Navigation / waiting ──────────────────────────────────────────────
+
+/**
+ * Navigate to `url` and wait until `document.readyState` reaches
+ * `interactive` or `complete`, or the timeout elapses.
+ *
+ * CDP's `Page.navigate` resolves as soon as the request is sent, not
+ * when the page has loaded. Subscribing to lifecycle events would
+ * require a long-lived event channel that the extension-backed
+ * CdpClient cannot currently provide, so this helper polls
+ * `document.readyState` via {@link evaluateExpression} — which works
+ * uniformly across both Playwright-backed and extension-backed
+ * clients.
+ *
+ * Returns `{ finalUrl, timedOut }`. `finalUrl` is read after the wait
+ * completes and may differ from `url` if the page redirected.
+ */
+export async function navigateAndWait(
+  cdp: CdpClient,
+  url: string,
+  opts: { timeoutMs?: number } = {},
+  signal?: AbortSignal,
+): Promise<{ finalUrl: string; timedOut: boolean }> {
+  const timeoutMs = opts.timeoutMs ?? 15_000;
+  await cdp.send("Page.navigate", { url }, signal);
+  const startedAt = Date.now();
+  let timedOut = false;
+  while (Date.now() - startedAt < timeoutMs) {
+    if (signal?.aborted) {
+      throw new CdpError("aborted", "Navigation aborted");
+    }
+    const state = await evaluateExpression<string>(
+      cdp,
+      "document.readyState",
+      {},
+      signal,
+    );
+    if (state === "interactive" || state === "complete") break;
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  if (Date.now() - startedAt >= timeoutMs) timedOut = true;
+  const finalUrl = await getCurrentUrl(cdp, signal);
+  return { finalUrl, timedOut };
+}
+
+/**
+ * Poll until a selector matches a non-null element, then return its
+ * `backendNodeId`. Throws {@link CdpError} on timeout or abort.
+ */
+export async function waitForSelector(
+  cdp: CdpClient,
+  selector: string,
+  timeoutMs: number,
+  signal?: AbortSignal,
+): Promise<number> {
+  const startedAt = Date.now();
+  const escapedSel = JSON.stringify(selector);
+  while (Date.now() - startedAt < timeoutMs) {
+    if (signal?.aborted) {
+      throw new CdpError("aborted", "waitForSelector aborted");
+    }
+    const exists = await evaluateExpression<boolean>(
+      cdp,
+      `document.querySelector(${escapedSel}) !== null`,
+      {},
+      signal,
+    );
+    if (exists) {
+      return await querySelectorBackendNodeId(cdp, selector, signal);
+    }
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  throw new CdpError("cdp_error", `Timed out waiting for ${selector}`);
+}
+
+/**
+ * Poll `document.body.innerText` for a substring. Throws
+ * {@link CdpError} on timeout or abort.
+ */
+export async function waitForText(
+  cdp: CdpClient,
+  text: string,
+  timeoutMs: number,
+  signal?: AbortSignal,
+): Promise<void> {
+  const escaped = JSON.stringify(text);
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    if (signal?.aborted) {
+      throw new CdpError("aborted", "waitForText aborted");
+    }
+    const found = await evaluateExpression<boolean>(
+      cdp,
+      `(document.body?.innerText ?? "").includes(${escaped})`,
+      {},
+      signal,
+    );
+    if (found) return;
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  throw new CdpError("cdp_error", `Timed out waiting for text: ${text}`);
+}


### PR DESCRIPTION
## Summary
- Common CDP idioms (querySelector→backendNodeId, click, type, key press, scroll, screenshot, navigate-and-wait, waitForSelector/Text) as pure helpers over `CdpClient`
- Each helper forwards an optional AbortSignal and throws `CdpError` on failure
- Unit-tested with a fake in-memory CdpClient; no runtime consumers yet

Part of plan: phase3-cdp-migration.md (PR 3 of 14)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24271" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
