### PR TITLE
feat(browser/cdp): add ExtensionCdpClient routing through HostBrowserProxy

### DIFF
--- a/assistant/src/tools/browser/cdp-client/__tests__/extension-cdp-client.test.ts
+++ b/assistant/src/tools/browser/cdp-client/__tests__/extension-cdp-client.test.ts
@@ -1,0 +1,330 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import type { HostBrowserProxy } from "../../../../daemon/host-browser-proxy.js";
+import { CdpError } from "../errors.js";
+import {
+  createExtensionCdpClient,
+  ExtensionCdpClient,
+} from "../extension-cdp-client.js";
+
+type ProxyResult = { content: string; isError: boolean };
+
+/**
+ * Build a fake HostBrowserProxy whose `request` method delegates to the
+ * provided handler. The returned object is structurally compatible with
+ * the parts of HostBrowserProxy that ExtensionCdpClient touches.
+ */
+function fakeProxy(
+  handler: (
+    input: unknown,
+    conversationId: string,
+    signal?: AbortSignal,
+  ) => Promise<ProxyResult> | ProxyResult,
+): {
+  proxy: HostBrowserProxy;
+  request: ReturnType<typeof mock>;
+} {
+  const request = mock(
+    async (
+      input: unknown,
+      conversationId: string,
+      signal?: AbortSignal,
+    ): Promise<ProxyResult> => handler(input, conversationId, signal),
+  );
+  const proxy = { request } as unknown as HostBrowserProxy;
+  return { proxy, request };
+}
+
+describe("ExtensionCdpClient", () => {
+  test("kind is 'extension' and exposes conversationId", () => {
+    const { proxy } = fakeProxy(async () => ({
+      content: "{}",
+      isError: false,
+    }));
+    const client = createExtensionCdpClient(proxy, "conv-abc");
+    expect(client).toBeInstanceOf(ExtensionCdpClient);
+    expect(client.kind).toBe("extension");
+    expect(client.conversationId).toBe("conv-abc");
+  });
+
+  test("happy path: send returns parsed JSON and forwards method/params/conversationId", async () => {
+    const { proxy, request } = fakeProxy(async () => ({
+      content: JSON.stringify({
+        product: "Chrome/123.0",
+        userAgent: "Mozilla/5.0",
+      }),
+      isError: false,
+    }));
+
+    const client = createExtensionCdpClient(proxy, "conv-1");
+    const result = await client.send<{ product: string; userAgent: string }>(
+      "Browser.getVersion",
+    );
+
+    expect(result).toEqual({
+      product: "Chrome/123.0",
+      userAgent: "Mozilla/5.0",
+    });
+    expect(request).toHaveBeenCalledTimes(1);
+    const call = request.mock.calls[0];
+    expect(call?.[0]).toEqual({
+      cdpMethod: "Browser.getVersion",
+      cdpParams: undefined,
+      cdpSessionId: undefined,
+    });
+    expect(call?.[1]).toBe("conv-1");
+    expect(call?.[2]).toBeUndefined();
+  });
+
+  test("params are forwarded verbatim to proxy.request", async () => {
+    const { proxy, request } = fakeProxy(async () => ({
+      content: JSON.stringify({ frameId: "frame-1", loaderId: "loader-1" }),
+      isError: false,
+    }));
+
+    const client = createExtensionCdpClient(proxy, "conv-2");
+    await client.send("Page.navigate", { url: "https://example.com/" });
+
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(request.mock.calls[0]?.[0]).toEqual({
+      cdpMethod: "Page.navigate",
+      cdpParams: { url: "https://example.com/" },
+      cdpSessionId: undefined,
+    });
+  });
+
+  test("cdpSessionId from constructor is forwarded on every send", async () => {
+    const { proxy, request } = fakeProxy(async () => ({
+      content: "{}",
+      isError: false,
+    }));
+
+    const client = createExtensionCdpClient(proxy, "conv-3", "session-xyz");
+    await client.send("Runtime.evaluate", { expression: "1" });
+    await client.send("DOM.getDocument");
+
+    expect(request).toHaveBeenCalledTimes(2);
+    for (const call of request.mock.calls) {
+      expect((call?.[0] as { cdpSessionId?: string }).cdpSessionId).toBe(
+        "session-xyz",
+      );
+    }
+  });
+
+  test("result.isError === true throws CdpError('cdp_error') with .underlying === parsed", async () => {
+    const errorBody = {
+      code: -32000,
+      message: "Cannot find context with specified id",
+    };
+    const { proxy } = fakeProxy(async () => ({
+      content: JSON.stringify(errorBody),
+      isError: true,
+    }));
+
+    const client = createExtensionCdpClient(proxy, "conv-4");
+
+    let caught: unknown;
+    try {
+      await client.send("Runtime.evaluate", { expression: "boom" });
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(CdpError);
+    const err = caught as CdpError;
+    expect(err.code).toBe("cdp_error");
+    expect(err.message).toBe("Cannot find context with specified id");
+    expect(err.cdpMethod).toBe("Runtime.evaluate");
+    expect(err.cdpParams).toEqual({ expression: "boom" });
+    expect(err.underlying).toEqual(errorBody);
+  });
+
+  test("result.isError with non-string message falls back to default message", async () => {
+    const { proxy } = fakeProxy(async () => ({
+      content: JSON.stringify({ code: -32000 }),
+      isError: true,
+    }));
+
+    const client = createExtensionCdpClient(proxy, "conv-5");
+
+    let caught: unknown;
+    try {
+      await client.send("Target.attachToTarget");
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(CdpError);
+    const err = caught as CdpError;
+    expect(err.code).toBe("cdp_error");
+    expect(err.message).toBe("CDP error for Target.attachToTarget");
+    expect(err.underlying).toEqual({ code: -32000 });
+  });
+
+  test("non-JSON content throws CdpError('transport_error')", async () => {
+    const { proxy } = fakeProxy(async () => ({
+      content: "not json at all",
+      isError: false,
+    }));
+
+    const client = createExtensionCdpClient(proxy, "conv-6");
+
+    let caught: unknown;
+    try {
+      await client.send("Browser.getVersion");
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(CdpError);
+    const err = caught as CdpError;
+    expect(err.code).toBe("transport_error");
+    expect(err.cdpMethod).toBe("Browser.getVersion");
+    expect(err.underlying).toBeDefined();
+    // Underlying should be the JSON.parse error.
+    expect(err.underlying).toBeInstanceOf(Error);
+  });
+
+  test("result.content === 'Aborted' throws CdpError('aborted')", async () => {
+    const { proxy, request } = fakeProxy(async () => ({
+      content: "Aborted",
+      isError: true,
+    }));
+
+    const client = createExtensionCdpClient(proxy, "conv-7");
+
+    let caught: unknown;
+    try {
+      await client.send("Page.navigate", { url: "https://slow.example.com/" });
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(CdpError);
+    const err = caught as CdpError;
+    expect(err.code).toBe("aborted");
+    expect(err.cdpMethod).toBe("Page.navigate");
+    expect(err.cdpParams).toEqual({ url: "https://slow.example.com/" });
+    expect(request).toHaveBeenCalledTimes(1);
+  });
+
+  test("proxy.request throwing wraps as CdpError('transport_error') with .underlying", async () => {
+    const underlying = new Error("socket closed");
+    const { proxy } = fakeProxy(async () => {
+      throw underlying;
+    });
+
+    const client = createExtensionCdpClient(proxy, "conv-8");
+
+    let caught: unknown;
+    try {
+      await client.send("Runtime.evaluate", { expression: "1" });
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(CdpError);
+    const err = caught as CdpError;
+    expect(err.code).toBe("transport_error");
+    expect(err.message).toBe("socket closed");
+    expect(err.cdpMethod).toBe("Runtime.evaluate");
+    expect(err.cdpParams).toEqual({ expression: "1" });
+    expect(err.underlying).toBe(underlying);
+  });
+
+  test("proxy.request throwing non-Error wraps as CdpError('transport_error') with stringified message", async () => {
+    const { proxy } = fakeProxy(async () => {
+      throw "string error";
+    });
+
+    const client = createExtensionCdpClient(proxy, "conv-9");
+
+    let caught: unknown;
+    try {
+      await client.send("Browser.getVersion");
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(CdpError);
+    const err = caught as CdpError;
+    expect(err.code).toBe("transport_error");
+    expect(err.message).toBe("string error");
+    expect(err.underlying).toBe("string error");
+  });
+
+  test("send after dispose throws CdpError('disposed') without calling proxy", async () => {
+    const { proxy, request } = fakeProxy(async () => ({
+      content: "{}",
+      isError: false,
+    }));
+
+    const client = createExtensionCdpClient(proxy, "conv-10");
+    client.dispose();
+    // dispose is idempotent
+    client.dispose();
+
+    let caught: unknown;
+    try {
+      await client.send("Browser.getVersion");
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(CdpError);
+    const err = caught as CdpError;
+    expect(err.code).toBe("disposed");
+    expect(err.cdpMethod).toBe("Browser.getVersion");
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  test("send with already-aborted signal throws CdpError('aborted') without calling proxy", async () => {
+    const { proxy, request } = fakeProxy(async () => ({
+      content: "{}",
+      isError: false,
+    }));
+
+    const client = createExtensionCdpClient(proxy, "conv-11");
+    const controller = new AbortController();
+    controller.abort();
+
+    let caught: unknown;
+    try {
+      await client.send("Browser.getVersion", undefined, controller.signal);
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(CdpError);
+    const err = caught as CdpError;
+    expect(err.code).toBe("aborted");
+    expect(err.message).toBe("Aborted before send");
+    expect(err.cdpMethod).toBe("Browser.getVersion");
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  test("signal that aborts after proxy resolve throws CdpError('aborted')", async () => {
+    const controller = new AbortController();
+    const { proxy } = fakeProxy(async () => {
+      // Abort the signal before we return, simulating race between
+      // proxy resolution and the caller's abort.
+      controller.abort();
+      return { content: JSON.stringify({ ok: true }), isError: false };
+    });
+
+    const client = createExtensionCdpClient(proxy, "conv-12");
+
+    let caught: unknown;
+    try {
+      await client.send("Browser.getVersion", undefined, controller.signal);
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(CdpError);
+    const err = caught as CdpError;
+    expect(err.code).toBe("aborted");
+    expect(err.message).toBe("CDP call aborted");
+    expect(err.cdpMethod).toBe("Browser.getVersion");
+  });
+});

--- a/assistant/src/tools/browser/cdp-client/extension-cdp-client.ts
+++ b/assistant/src/tools/browser/cdp-client/extension-cdp-client.ts
@@ -1,0 +1,125 @@
+import type { HostBrowserProxy } from "../../../daemon/host-browser-proxy.js";
+import { getLogger } from "../../../util/logger.js";
+import { CdpError } from "./errors.js";
+import type { CdpClientKind, ScopedCdpClient } from "./types.js";
+
+const log = getLogger("extension-cdp-client");
+
+/**
+ * CdpClient backed by HostBrowserProxy. Each `send` becomes a
+ * host_browser_request / host_browser_result round-trip over the
+ * chrome-extension WebSocket.
+ *
+ * Unlike LocalCdpClient, this implementation cannot deliver
+ * CDP events (subscribing to "Page.lifecycleEvent" etc.) because
+ * HostBrowserProxy is request/reply only. Helpers that need
+ * event subscription (waitForLifecycleEvent) must fall back to
+ * polling via Runtime.evaluate — see cdp-dom-helpers.ts#navigateAndWait.
+ */
+export class ExtensionCdpClient implements ScopedCdpClient {
+  readonly kind: CdpClientKind = "extension";
+  private disposed = false;
+
+  constructor(
+    private readonly proxy: HostBrowserProxy,
+    public readonly conversationId: string,
+    private readonly cdpSessionId?: string,
+  ) {}
+
+  async send<T = unknown>(
+    method: string,
+    params?: Record<string, unknown>,
+    signal?: AbortSignal,
+  ): Promise<T> {
+    if (this.disposed) {
+      throw new CdpError("disposed", "ExtensionCdpClient already disposed", {
+        cdpMethod: method,
+        cdpParams: params,
+      });
+    }
+    if (signal?.aborted) {
+      throw new CdpError("aborted", "Aborted before send", {
+        cdpMethod: method,
+        cdpParams: params,
+      });
+    }
+
+    let result;
+    try {
+      result = await this.proxy.request(
+        {
+          cdpMethod: method,
+          cdpParams: params,
+          cdpSessionId: this.cdpSessionId,
+        },
+        this.conversationId,
+        signal,
+      );
+    } catch (err) {
+      throw new CdpError(
+        "transport_error",
+        err instanceof Error ? err.message : String(err),
+        {
+          cdpMethod: method,
+          cdpParams: params,
+          underlying: err,
+        },
+      );
+    }
+
+    if (signal?.aborted || result.content === "Aborted") {
+      throw new CdpError("aborted", "CDP call aborted", {
+        cdpMethod: method,
+        cdpParams: params,
+      });
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(result.content);
+    } catch (err) {
+      throw new CdpError(
+        "transport_error",
+        `Non-JSON content from host_browser_result: ${result.content.slice(0, 200)}`,
+        {
+          cdpMethod: method,
+          cdpParams: params,
+          underlying: err,
+        },
+      );
+    }
+
+    if (result.isError) {
+      const msg =
+        (typeof parsed === "object" &&
+          parsed !== null &&
+          "message" in parsed &&
+          typeof (parsed as { message: unknown }).message === "string" &&
+          (parsed as { message: string }).message) ||
+        `CDP error for ${method}`;
+      log.debug({ method, params, parsed }, "ExtensionCdpClient: CDP error");
+      throw new CdpError("cdp_error", msg, {
+        cdpMethod: method,
+        cdpParams: params,
+        underlying: parsed,
+      });
+    }
+
+    return parsed as T;
+  }
+
+  dispose(): void {
+    this.disposed = true;
+    // HostBrowserProxy is owned by the conversation — do NOT dispose
+    // it here. In-flight requests will be cancelled by the AbortSignal
+    // the tool passes in, or by conversation teardown.
+  }
+}
+
+export function createExtensionCdpClient(
+  proxy: HostBrowserProxy,
+  conversationId: string,
+  cdpSessionId?: string,
+): ExtensionCdpClient {
+  return new ExtensionCdpClient(proxy, conversationId, cdpSessionId);
+}


### PR DESCRIPTION
## Summary
- `ExtensionCdpClient` implements `ScopedCdpClient` by forwarding each CDP send to `HostBrowserProxy.request()` over the host_browser envelope transport
- Parses the JSON `result.content` envelope and maps isError / aborted / transport failures to `CdpError` codes
- Bun:test coverage against a fake HostBrowserProxy; no runtime consumers yet

Part of plan: phase3-cdp-migration.md (PR 5 of 14)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24272" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
