### PR TITLE
feat(browser/cdp): add getCdpClient factory that routes by ToolContext

### DIFF
--- a/assistant/src/tools/browser/cdp-client/__tests__/factory.test.ts
+++ b/assistant/src/tools/browser/cdp-client/__tests__/factory.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { HostBrowserProxy } from "../../../../daemon/host-browser-proxy.js";
+import type { ToolContext } from "../../../types.js";
+
+const createExtensionCdpClientMock = mock(
+  (_proxy: HostBrowserProxy, conversationId: string) => ({
+    kind: "extension" as const,
+    conversationId,
+    send: async () => ({}),
+    dispose: () => {},
+  }),
+);
+
+const createLocalCdpClientMock = mock((conversationId: string) => ({
+  kind: "local" as const,
+  conversationId,
+  send: async () => ({}),
+  dispose: () => {},
+}));
+
+mock.module("../extension-cdp-client.js", () => ({
+  createExtensionCdpClient: createExtensionCdpClientMock,
+}));
+mock.module("../local-cdp-client.js", () => ({
+  createLocalCdpClient: createLocalCdpClientMock,
+}));
+
+// Import under test AFTER mock.module calls so that the factory's
+// top-level imports resolve to our fakes.
+const { getCdpClient } = await import("../factory.js");
+
+/**
+ * Minimal ToolContext suitable for factory tests. Only the fields the
+ * factory reads (`conversationId` and `hostBrowserProxy`) need to be
+ * populated; other required fields are cast away.
+ */
+function makeContext(
+  overrides: Partial<ToolContext> & { conversationId: string },
+): ToolContext {
+  return overrides as unknown as ToolContext;
+}
+
+describe("getCdpClient", () => {
+  beforeEach(() => {
+    createExtensionCdpClientMock.mockClear();
+    createLocalCdpClientMock.mockClear();
+  });
+
+  test("routes to ExtensionCdpClient when hostBrowserProxy is set", () => {
+    const fakeProxy = {
+      request: mock(async () => ({})),
+    } as unknown as HostBrowserProxy;
+    const ctx = makeContext({
+      conversationId: "test-convo",
+      hostBrowserProxy: fakeProxy,
+    });
+
+    const client = getCdpClient(ctx);
+
+    expect(client.kind).toBe("extension");
+    expect(client.conversationId).toBe("test-convo");
+    expect(createExtensionCdpClientMock).toHaveBeenCalledTimes(1);
+    expect(createExtensionCdpClientMock).toHaveBeenCalledWith(
+      fakeProxy,
+      "test-convo",
+    );
+    expect(createLocalCdpClientMock).not.toHaveBeenCalled();
+  });
+
+  test("routes to LocalCdpClient when hostBrowserProxy is undefined", () => {
+    const ctx = makeContext({
+      conversationId: "test-convo",
+      hostBrowserProxy: undefined,
+    });
+
+    const client = getCdpClient(ctx);
+
+    expect(client.kind).toBe("local");
+    expect(client.conversationId).toBe("test-convo");
+    expect(createLocalCdpClientMock).toHaveBeenCalledTimes(1);
+    expect(createLocalCdpClientMock).toHaveBeenCalledWith("test-convo");
+    expect(createExtensionCdpClientMock).not.toHaveBeenCalled();
+  });
+
+  test("routes to LocalCdpClient when hostBrowserProxy key is omitted", () => {
+    const ctx = makeContext({ conversationId: "another-convo" });
+
+    const client = getCdpClient(ctx);
+
+    expect(client.kind).toBe("local");
+    expect(client.conversationId).toBe("another-convo");
+    expect(createLocalCdpClientMock).toHaveBeenCalledTimes(1);
+    expect(createLocalCdpClientMock).toHaveBeenCalledWith("another-convo");
+    expect(createExtensionCdpClientMock).not.toHaveBeenCalled();
+  });
+});

--- a/assistant/src/tools/browser/cdp-client/factory.ts
+++ b/assistant/src/tools/browser/cdp-client/factory.ts
@@ -1,0 +1,37 @@
+import type { ToolContext } from "../../types.js";
+import { createExtensionCdpClient } from "./extension-cdp-client.js";
+import { createLocalCdpClient } from "./local-cdp-client.js";
+import type { ScopedCdpClient } from "./types.js";
+
+/**
+ * Select the appropriate CdpClient implementation for a tool
+ * invocation based on the ToolContext:
+ *
+ *  - When `context.hostBrowserProxy` is set (macOS desktop / cloud-
+ *    hosted with a chrome-extension bound to the conversation),
+ *    return an ExtensionCdpClient so CDP commands ride the
+ *    host_browser_request / host_browser_result round-trip.
+ *  - Otherwise (CLI, tests, headless Chromium launched in-process),
+ *    return a LocalCdpClient that drives Playwright's CDPSession
+ *    against the sacrificial-profile browser managed by
+ *    browserManager.
+ *
+ * The returned client is `kind`-tagged so tools can branch on
+ * transport — e.g. browser_navigate skips the Playwright-specific
+ * screencast and handoff hooks when `kind === "extension"`.
+ *
+ * IMPORTANT: the returned client is per-invocation. Tools MUST call
+ * `dispose()` in a finally block to release the CDP session (local
+ * path) or mark the wrapper disposed (extension path). Disposing
+ * an ExtensionCdpClient does NOT dispose the underlying
+ * HostBrowserProxy — that is owned by the conversation.
+ */
+export function getCdpClient(context: ToolContext): ScopedCdpClient {
+  if (context.hostBrowserProxy) {
+    return createExtensionCdpClient(
+      context.hostBrowserProxy,
+      context.conversationId,
+    );
+  }
+  return createLocalCdpClient(context.conversationId);
+}

--- a/assistant/src/tools/browser/cdp-client/index.ts
+++ b/assistant/src/tools/browser/cdp-client/index.ts
@@ -1,2 +1,8 @@
 export { CdpError, type CdpErrorCode } from "./errors.js";
+export {
+  createExtensionCdpClient,
+  ExtensionCdpClient,
+} from "./extension-cdp-client.js";
+export { getCdpClient } from "./factory.js";
+export { createLocalCdpClient, LocalCdpClient } from "./local-cdp-client.js";
 export type { CdpClient, CdpClientKind, ScopedCdpClient } from "./types.js";


### PR DESCRIPTION
## Summary
- `getCdpClient(context)` factory routes between `ExtensionCdpClient` (when `context.hostBrowserProxy` is set) and `LocalCdpClient` (otherwise)
- Public surface re-exported from `cdp-client/index.ts` so tools import everything from one path
- Bun:test coverage with mocked backends; no runtime consumers yet (Wave 4 tool migrations use it)

Part of plan: phase3-cdp-migration.md (PR 6 of 14)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24273" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
