### PR TITLE
feat(browser): migrate executeBrowserSnapshot to CDP Accessibility.getFullAXTree

### DIFF
--- a/assistant/src/__tests__/headless-browser-interactions.test.ts
+++ b/assistant/src/__tests__/headless-browser-interactions.test.ts
@@ -71,7 +71,6 @@ import {
   executeBrowserScreenshot,
   executeBrowserScroll,
   executeBrowserSelectOption,
-  executeBrowserSnapshot,
   executeBrowserType,
 } from "../tools/browser/browser-execution.js";
 import type { ToolContext } from "../tools/types.js";
@@ -291,72 +290,13 @@ describe("executeBrowserType", () => {
   });
 });
 
-// ── browser_snapshot ──────────────────────────────────────────────────
-
-describe("executeBrowserSnapshot", () => {
-  beforeEach(() => {
-    resetMockPage();
-    snapshotMaps.clear();
-  });
-
-  test("returns element list with eid format", async () => {
-    const sampleElements = [
-      { eid: "e1", tag: "a", attrs: { href: "/about" }, text: "About Us" },
-      { eid: "e2", tag: "button", attrs: { type: "submit" }, text: "Submit" },
-      {
-        eid: "e3",
-        tag: "input",
-        attrs: { type: "text", name: "email", placeholder: "Enter email" },
-        text: "",
-      },
-    ];
-    mockPage.evaluate = mock(async () => sampleElements);
-    const result = await executeBrowserSnapshot({}, ctx);
-    expect(result.isError).toBe(false);
-    expect(result.content).toContain("[e1]");
-    expect(result.content).toContain("[e2]");
-    expect(result.content).toContain("[e3]");
-    expect(result.content).toContain("<a");
-    expect(result.content).toContain("<button");
-    expect(result.content).toContain("<input");
-    expect(result.content).toContain("3 interactive elements found");
-  });
-
-  test("stores snapshot map for later element resolution", async () => {
-    const sampleElements = [
-      { eid: "e1", tag: "a", attrs: { href: "/" }, text: "Home" },
-    ];
-    mockPage.evaluate = mock(async () => sampleElements);
-    await executeBrowserSnapshot({}, ctx);
-    const map = snapshotMaps.get("test-conversation");
-    expect(map).toBeDefined();
-    expect(map!.get("e1")).toBe('[data-vellum-eid="e1"]');
-  });
-
-  test("reports no interactive elements when page is empty", async () => {
-    mockPage.evaluate = mock(async () => []);
-    const result = await executeBrowserSnapshot({}, ctx);
-    expect(result.isError).toBe(false);
-    expect(result.content).toContain("no interactive elements found");
-  });
-
-  test("includes page URL and title", async () => {
-    mockPage.evaluate = mock(async () => []);
-    const result = await executeBrowserSnapshot({}, ctx);
-    expect(result.content).toContain("URL: https://example.com/");
-    expect(result.content).toContain("Title: Test Page");
-  });
-
-  test("handles snapshot error from page", async () => {
-    mockPage.evaluate = mock(async () => {
-      throw new Error("Page crashed");
-    });
-    const result = await executeBrowserSnapshot({}, ctx);
-    expect(result.isError).toBe(true);
-    expect(result.content).toContain("Snapshot failed");
-    expect(result.content).toContain("Page crashed");
-  });
-});
+// NOTE: executeBrowserSnapshot tests live in
+// `headless-browser-snapshot.test.ts`. The snapshot tool now talks to
+// CDP via `getCdpClient` (no longer Playwright `page.evaluate`), so its
+// mocking surface is incompatible with the Playwright `mockPage`
+// scaffolding used here. The interactions file continues to drive the
+// still-Playwright-backed click/type/hover/etc. tools through the
+// `browserManager.snapshotMaps` bridge the snapshot tool writes.
 
 // ── browser_screenshot ───────────────────────────────────────────────
 
@@ -784,17 +724,9 @@ describe("browser execution wrapper contract", () => {
     expect(result.isError).toBe(false);
   });
 
-  test("executeBrowserSnapshot matches wrapper contract", async () => {
-    mockPage.evaluate = mock(async () => [
-      { eid: "e1", tag: "button", attrs: {}, text: "Click me" },
-    ]);
-    mockPage.title = mock(async () => "Test");
-    mockPage.url = mock(() => "https://example.com");
-    const result = await executeBrowserSnapshot({}, ctx);
-    expect(result).toHaveProperty("content");
-    expect(result).toHaveProperty("isError");
-    expect(result.isError).toBe(false);
-  });
+  // executeBrowserSnapshot wrapper-contract check lives in
+  // `headless-browser-snapshot.test.ts` since the tool now talks to CDP
+  // and can't reuse this file's Playwright mock surface.
 
   test("executeBrowserExtract matches wrapper contract", async () => {
     mockPage.evaluate = mock(async () => "Page text content");

--- a/assistant/src/__tests__/headless-browser-snapshot.test.ts
+++ b/assistant/src/__tests__/headless-browser-snapshot.test.ts
@@ -9,37 +9,83 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
-let mockPage: {
-  evaluate: ReturnType<typeof mock>;
-  title: ReturnType<typeof mock>;
-  url: ReturnType<typeof mock>;
-  goto: ReturnType<typeof mock>;
-  close: ReturnType<typeof mock>;
-  isClosed: () => boolean;
-};
+/**
+ * Shared fake CDP session state. Tests install a custom `cdpSend`
+ * implementation in their setup, then assert against `cdpCalls` and
+ * `detachCalls` after the tool runs.
+ *
+ * Rather than mocking `factory.js` or `local-cdp-client.js` directly
+ * (both of which would leak module-level mocks into other test files
+ * via bun's shared mock registry), we only mock `browser-manager.js`
+ * and return a fake Playwright page whose CDP session routes through
+ * a programmable handler. That lets the real `LocalCdpClient` +
+ * `getCdpClient` factory code run end-to-end, so this file does not
+ * interfere with `local-cdp-client.test.ts` or `factory.test.ts`.
+ */
+type CdpCall = { method: string; params: Record<string, unknown> };
+let cdpCalls: CdpCall[] = [];
+let cdpSend: (
+  method: string,
+  params?: Record<string, unknown>,
+) => Promise<unknown>;
+let detachCalls: number;
 
 let closeSessionPageMock: ReturnType<typeof mock>;
 let closeAllPagesMock: ReturnType<typeof mock>;
 let storeSnapshotMapMock: ReturnType<typeof mock>;
-let storedMaps: Map<string, Map<string, string>>;
+let storeSnapshotBackendNodeMapMock: ReturnType<typeof mock>;
+let storedStringMaps: Map<string, Map<string, string>>;
+let storedBackendNodeMaps: Map<string, Map<string, number>>;
 
 mock.module("../tools/browser/browser-manager.js", () => {
-  storedMaps = new Map();
+  storedStringMaps = new Map();
+  storedBackendNodeMaps = new Map();
   closeSessionPageMock = mock(async () => {});
   closeAllPagesMock = mock(async () => {});
   storeSnapshotMapMock = mock(
     (conversationId: string, map: Map<string, string>) => {
-      storedMaps.set(conversationId, map);
+      storedStringMaps.set(conversationId, map);
     },
   );
+  storeSnapshotBackendNodeMapMock = mock(
+    (conversationId: string, map: Map<string, number>) => {
+      storedBackendNodeMaps.set(conversationId, map);
+    },
+  );
+  // Fake Playwright page whose CDPSession routes to our per-test
+  // handler. LocalCdpClient lazily creates the session on first send,
+  // which is how the real tool path drives us.
+  const fakeSession = {
+    send: async (method: string, params?: Record<string, unknown>) => {
+      cdpCalls.push({ method, params: params ?? {} });
+      return cdpSend(method, params);
+    },
+    detach: async () => {
+      detachCalls += 1;
+    },
+  };
+  const fakePage = {
+    context: () => ({
+      newCDPSession: async () => fakeSession,
+    }),
+  };
   return {
     browserManager: {
-      getOrCreateSessionPage: async () => mockPage,
+      getOrCreateSessionPage: async (_conversationId: string) => fakePage,
       closeSessionPage: closeSessionPageMock,
       closeAllPages: closeAllPagesMock,
       storeSnapshotMap: storeSnapshotMapMock,
+      storeSnapshotBackendNodeMap: storeSnapshotBackendNodeMapMock,
       resolveSnapshotSelector: (conversationId: string, elementId: string) => {
-        const map = storedMaps.get(conversationId);
+        const map = storedStringMaps.get(conversationId);
+        if (!map) return null;
+        return map.get(elementId) ?? null;
+      },
+      resolveSnapshotBackendNodeId: (
+        conversationId: string,
+        elementId: string,
+      ) => {
+        const map = storedBackendNodeMaps.get(conversationId);
         if (!map) return null;
         return map.get(elementId) ?? null;
       },
@@ -67,95 +113,265 @@ const ctx: ToolContext = {
   trustClass: "guardian",
 };
 
-function resetMockPage() {
-  mockPage = {
-    evaluate: mock(async () => []),
-    title: mock(async () => "Test Page"),
-    url: mock(() => "https://example.com/"),
-    goto: mock(async () => ({
-      status: () => 200,
-      url: () => "https://example.com/",
-    })),
-    close: mock(async () => {}),
-    isClosed: () => false,
+// ── Fixtures ─────────────────────────────────────────────────────────
+
+/**
+ * Minimal three-element Accessibility.getFullAXTree fixture. Mirrors
+ * the shape CDP returns — a flat array of nodes with parent/child
+ * references via `childIds`. Roles are chosen from the snapshot
+ * transformer's interactive-role allowlist so the output contains
+ * exactly three elements. The root `WebArea` node owns all three as
+ * children so document-order traversal yields e1/e2/e3.
+ */
+function buildAxTreeFixture(): { nodes: Record<string, unknown>[] } {
+  return {
+    nodes: [
+      {
+        nodeId: "1",
+        role: { type: "role", value: "WebArea" },
+        name: { type: "computedString", value: "" },
+        childIds: ["2", "3", "4"],
+        backendDOMNodeId: 1,
+      },
+      {
+        nodeId: "2",
+        role: { type: "role", value: "link" },
+        name: { type: "computedString", value: "About Us" },
+        properties: [
+          { name: "url", value: { type: "string", value: "/about" } },
+        ],
+        childIds: [],
+        backendDOMNodeId: 42,
+      },
+      {
+        nodeId: "3",
+        role: { type: "role", value: "button" },
+        name: { type: "computedString", value: "Submit" },
+        properties: [],
+        childIds: [],
+        backendDOMNodeId: 99,
+      },
+      {
+        nodeId: "4",
+        role: { type: "role", value: "textbox" },
+        name: { type: "computedString", value: "Email" },
+        properties: [
+          {
+            name: "placeholder",
+            value: { type: "string", value: "you@example.com" },
+          },
+        ],
+        childIds: [],
+        backendDOMNodeId: 101,
+      },
+    ],
   };
+}
+
+/**
+ * Build a default CDP `send` handler that returns canned success
+ * responses for the methods `executeBrowserSnapshot` touches. Tests
+ * pass a map of overrides to customise individual responses or throw
+ * from a specific method.
+ */
+function installCdpSend(
+  overrides: Partial<{
+    url: string;
+    title: string;
+    axTree: unknown;
+    pushedNodeIds: number[];
+    throwFrom: string;
+  }> = {},
+) {
+  const url = overrides.url ?? "https://example.com/";
+  const title = overrides.title ?? "Example Page";
+  const axTree = overrides.axTree ?? { nodes: [] };
+  const pushedNodeIds = overrides.pushedNodeIds ?? [];
+  const throwFrom = overrides.throwFrom;
+
+  let runtimeEvaluateCall = 0;
+  cdpSend = async (method, _params) => {
+    if (throwFrom === method) {
+      throw new Error("tab detached");
+    }
+    switch (method) {
+      case "Runtime.evaluate": {
+        // First call → URL, second → title. Anything beyond returns "".
+        const value =
+          runtimeEvaluateCall === 0
+            ? url
+            : runtimeEvaluateCall === 1
+              ? title
+              : "";
+        runtimeEvaluateCall += 1;
+        return { result: { value } };
+      }
+      case "Accessibility.enable":
+        return {};
+      case "Accessibility.getFullAXTree":
+        return axTree;
+      case "DOM.pushNodesByBackendIdsToFrontend":
+        return { nodeIds: pushedNodeIds };
+      case "DOM.setAttributeValue":
+        return {};
+      default:
+        return {};
+    }
+  };
+  // Return the params so tests can reference them in assertions.
+  return { url, title, pushedNodeIds };
+}
+
+function resetCdpState() {
+  cdpCalls = [];
+  detachCalls = 0;
+  cdpSend = async () => ({});
 }
 
 // ── browser_snapshot ─────────────────────────────────────────────────
 
-describe("executeBrowserSnapshot", () => {
+describe("executeBrowserSnapshot (CDP Accessibility.getFullAXTree)", () => {
   beforeEach(() => {
-    resetMockPage();
-    storedMaps.clear();
+    resetCdpState();
+    storedStringMaps.clear();
+    storedBackendNodeMaps.clear();
     storeSnapshotMapMock.mockClear();
+    storeSnapshotBackendNodeMapMock.mockClear();
   });
 
-  test("returns page URL and title with no elements", async () => {
+  test("returns URL, title, and a list of interactive elements", async () => {
+    installCdpSend({
+      url: "https://example.com/",
+      title: "Example Page",
+      axTree: buildAxTreeFixture(),
+      pushedNodeIds: [11, 12, 13],
+    });
+
     const result = await executeBrowserSnapshot({}, ctx);
+
     expect(result.isError).toBe(false);
     expect(result.content).toContain("URL: https://example.com/");
-    expect(result.content).toContain("Title: Test Page");
-    expect(result.content).toContain("(no interactive elements found)");
-  });
-
-  test("lists interactive elements with element IDs", async () => {
-    mockPage.evaluate = mock(async () => [
-      { eid: "e1", tag: "a", attrs: { href: "/about" }, text: "About Us" },
-      { eid: "e2", tag: "button", attrs: {}, text: "Submit" },
-      {
-        eid: "e3",
-        tag: "input",
-        attrs: { type: "text", name: "email", placeholder: "Email" },
-        text: "",
-      },
-    ]);
-
-    const result = await executeBrowserSnapshot({}, ctx);
-    expect(result.isError).toBe(false);
-    expect(result.content).toContain('[e1] <a href="/about"> About Us');
+    expect(result.content).toContain("Title: Example Page");
+    expect(result.content).toContain("[e1] <link");
+    expect(result.content).toContain("About Us");
     expect(result.content).toContain("[e2] <button> Submit");
-    expect(result.content).toContain(
-      '[e3] <input type="text" name="email" placeholder="Email">',
-    );
+    expect(result.content).toContain("[e3] <textbox");
+    expect(result.content).toContain("Email");
     expect(result.content).toContain("3 interactive elements found.");
   });
 
-  test("stores selector map in browser manager", async () => {
-    mockPage.evaluate = mock(async () => [
-      { eid: "e1", tag: "a", attrs: { href: "/" }, text: "Home" },
-      { eid: "e2", tag: "button", attrs: {}, text: "OK" },
-    ]);
+  test("calls Accessibility.enable and getFullAXTree via CDP", async () => {
+    installCdpSend();
 
     await executeBrowserSnapshot({}, ctx);
-    expect(storeSnapshotMapMock).toHaveBeenCalledTimes(1);
 
-    const stored = storedMaps.get("test-conversation");
-    expect(stored).toBeDefined();
-    expect(stored!.get("e1")).toBe('[data-vellum-eid="e1"]');
-    expect(stored!.get("e2")).toBe('[data-vellum-eid="e2"]');
+    const methods = cdpCalls.map((c) => c.method);
+    expect(methods).toContain("Accessibility.enable");
+    expect(methods).toContain("Accessibility.getFullAXTree");
   });
 
-  test("handles single element with singular count", async () => {
-    mockPage.evaluate = mock(async () => [
-      { eid: "e1", tag: "button", attrs: {}, text: "Click" },
-    ]);
-
-    const result = await executeBrowserSnapshot({}, ctx);
-    expect(result.content).toContain("1 interactive element found.");
-  });
-
-  test("handles evaluate error", async () => {
-    mockPage.evaluate = mock(async () => {
-      throw new Error("page crashed");
+  test("stores both backendNodeId and legacy string selector maps", async () => {
+    installCdpSend({
+      axTree: buildAxTreeFixture(),
+      pushedNodeIds: [11, 12, 13],
     });
+
+    await executeBrowserSnapshot({}, ctx);
+
+    // Backend-node map stored (new AX-based path).
+    expect(storeSnapshotBackendNodeMapMock).toHaveBeenCalledTimes(1);
+    const backendMap = storedBackendNodeMaps.get("test-conversation");
+    expect(backendMap).toBeDefined();
+    expect(backendMap!.get("e1")).toBe(42);
+    expect(backendMap!.get("e2")).toBe(99);
+    expect(backendMap!.get("e3")).toBe(101);
+
+    // Legacy string map also populated (bridge for unmigrated tools).
+    expect(storeSnapshotMapMock).toHaveBeenCalledTimes(1);
+    const stringMap = storedStringMaps.get("test-conversation");
+    expect(stringMap).toBeDefined();
+    expect(stringMap!.get("e1")).toBe('[data-vellum-eid="e1"]');
+    expect(stringMap!.get("e2")).toBe('[data-vellum-eid="e2"]');
+    expect(stringMap!.get("e3")).toBe('[data-vellum-eid="e3"]');
+  });
+
+  test("tags elements via DOM.pushNodesByBackendIdsToFrontend + setAttributeValue", async () => {
+    installCdpSend({
+      axTree: buildAxTreeFixture(),
+      pushedNodeIds: [11, 12, 13],
+    });
+
+    await executeBrowserSnapshot({}, ctx);
+
+    const pushCalls = cdpCalls.filter(
+      (c) => c.method === "DOM.pushNodesByBackendIdsToFrontend",
+    );
+    expect(pushCalls.length).toBe(1);
+    expect(pushCalls[0]!.params.backendNodeIds).toEqual([42, 99, 101]);
+
+    const setAttrCalls = cdpCalls.filter(
+      (c) => c.method === "DOM.setAttributeValue",
+    );
+    expect(setAttrCalls.length).toBe(3);
+    expect(setAttrCalls[0]!.params).toMatchObject({
+      nodeId: 11,
+      name: "data-vellum-eid",
+      value: "e1",
+    });
+    expect(setAttrCalls[1]!.params).toMatchObject({
+      nodeId: 12,
+      name: "data-vellum-eid",
+      value: "e2",
+    });
+    expect(setAttrCalls[2]!.params).toMatchObject({
+      nodeId: 13,
+      name: "data-vellum-eid",
+      value: "e3",
+    });
+  });
+
+  test("renders '(no interactive elements found)' on empty AX tree", async () => {
+    installCdpSend({ axTree: { nodes: [] } });
+
     const result = await executeBrowserSnapshot({}, ctx);
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("(no interactive elements found)");
+    // Empty maps should still be stored so stale eids from a previous
+    // snapshot cannot resolve after this call.
+    expect(storeSnapshotBackendNodeMapMock).toHaveBeenCalledTimes(1);
+    expect(storeSnapshotMapMock).toHaveBeenCalledTimes(1);
+    const backendMap = storedBackendNodeMaps.get("test-conversation");
+    const stringMap = storedStringMaps.get("test-conversation");
+    expect(backendMap?.size ?? 0).toBe(0);
+    expect(stringMap?.size ?? 0).toBe(0);
+  });
+
+  test("returns error content when Accessibility.getFullAXTree throws", async () => {
+    installCdpSend({ throwFrom: "Accessibility.getFullAXTree" });
+
+    const result = await executeBrowserSnapshot({}, ctx);
+
     expect(result.isError).toBe(true);
     expect(result.content).toContain("Snapshot failed");
-    expect(result.content).toContain("page crashed");
+    expect(result.content).toContain("tab detached");
+    // dispose still runs in the finally block, which schedules an
+    // async session.detach() — flush microtasks before asserting.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(detachCalls).toBe(1);
+  });
+
+  test("disposes the CdpClient even on success", async () => {
+    installCdpSend();
+
+    await executeBrowserSnapshot({}, ctx);
+    // dispose schedules detach asynchronously; flush microtasks.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(detachCalls).toBe(1);
   });
 
   test("shows (none) for empty title", async () => {
-    mockPage.title = mock(async () => "");
+    installCdpSend({ title: "", axTree: { nodes: [] } });
     const result = await executeBrowserSnapshot({}, ctx);
     expect(result.content).toContain("Title: (none)");
   });
@@ -165,7 +381,7 @@ describe("executeBrowserSnapshot", () => {
 
 describe("executeBrowserClose", () => {
   beforeEach(() => {
-    resetMockPage();
+    resetCdpState();
     closeSessionPageMock.mockClear();
     closeAllPagesMock.mockClear();
   });

--- a/assistant/src/tools/browser/browser-execution.ts
+++ b/assistant/src/tools/browser/browser-execution.ts
@@ -23,6 +23,12 @@ import {
   stopAllScreencasts,
   stopBrowserScreencast,
 } from "./browser-screencast.js";
+import {
+  formatAxSnapshot,
+  transformAxTree,
+} from "./cdp-client/accessibility-snapshot.js";
+import { getCurrentUrl, getPageTitle } from "./cdp-client/cdp-dom-helpers.js";
+import { getCdpClient } from "./cdp-client/factory.js";
 
 const log = getLogger("headless-browser");
 
@@ -96,6 +102,73 @@ export function resolveSelector(
   }
 
   return { selector: rawSelector!, error: null };
+}
+
+/**
+ * Discriminated union returned by {@link resolveElement}. The
+ * `"backend"` variant is produced when an `element_id` from the most
+ * recent AX-tree snapshot is resolved to a CDP `backendNodeId`; the
+ * `"selector"` variant is produced when the caller passed a raw CSS
+ * `selector` that should be resolved via `DOM.querySelector` (or
+ * equivalent) at send-time by the individual tool.
+ *
+ * Consumed by CDP-migrated interaction tools (click, hover, type, …)
+ * that talk to CDP directly rather than going through Playwright's
+ * selector engine. Legacy tools that still drive a Playwright `Page`
+ * continue to call {@link resolveSelector} and receive a plain string
+ * selector — the two helpers coexist during the Phase 3 migration.
+ */
+export type ResolvedElement =
+  | { kind: "backend"; backendNodeId: number; eid: string }
+  | { kind: "selector"; selector: string };
+
+/**
+ * Resolve an element reference (either `element_id` from a prior
+ * snapshot or a raw `selector`) for CDP-native tools. Behaves like
+ * {@link resolveSelector} in its input validation but returns a
+ * {@link ResolvedElement} instead of a string so the caller can
+ * branch on whether a backendNodeId was recovered from the snapshot
+ * map. Returns `{ resolved: null, error: "Error: …" }` on invalid
+ * input or when an `element_id` is provided but the snapshot map is
+ * empty/stale.
+ */
+export function resolveElement(
+  conversationId: string,
+  input: Record<string, unknown>,
+): { resolved: ResolvedElement | null; error: string | null } {
+  const elementId =
+    typeof input.element_id === "string" ? input.element_id : null;
+  const rawSelector =
+    typeof input.selector === "string" ? input.selector : null;
+
+  if (!elementId && !rawSelector) {
+    return {
+      resolved: null,
+      error: "Error: Either element_id or selector is required.",
+    };
+  }
+
+  if (elementId) {
+    const backendNodeId = browserManager.resolveSnapshotBackendNodeId(
+      conversationId,
+      elementId,
+    );
+    if (backendNodeId !== null) {
+      return {
+        resolved: { kind: "backend", backendNodeId, eid: elementId },
+        error: null,
+      };
+    }
+    return {
+      resolved: null,
+      error: `Error: element_id "${elementId}" not found. Run browser_snapshot first to get current element IDs.`,
+    };
+  }
+
+  return {
+    resolved: { kind: "selector", selector: rawSelector! },
+    error: null,
+  };
 }
 
 // ── browser_navigate ─────────────────────────────────────────────────
@@ -482,79 +555,101 @@ export async function executeBrowserSnapshot(
   _input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
+  const cdp = getCdpClient(context);
   try {
-    const page = await browserManager.getOrCreateSessionPage(
-      context.conversationId,
+    const currentUrl = await getCurrentUrl(cdp, context.signal);
+    const title = await getPageTitle(cdp, context.signal);
+
+    // Pull the full accessibility tree via CDP and fold it into typed
+    // interactive elements + an `eid → backendNodeId` map. This replaces
+    // the legacy `document.querySelectorAll` + `data-vellum-eid` JS that
+    // used to drive the snapshot, and lets downstream CDP-migrated tools
+    // (click, hover, type, …) jump straight to DOM commands without
+    // another round-trip through Playwright's selector engine.
+    await cdp.send("Accessibility.enable", {}, context.signal);
+    const rawTree = await cdp.send(
+      "Accessibility.getFullAXTree",
+      {},
+      context.signal,
     );
-    const currentUrl = page.url();
-    const title = await page.title();
+    const { elements, selectorMap: backendNodeMap } = transformAxTree(rawTree, {
+      maxElements: MAX_SNAPSHOT_ELEMENTS,
+    });
 
-    const elements = (await page.evaluate(`
-      (() => {
-        const SELECTOR = ${JSON.stringify(INTERACTIVE_SELECTOR)};
-        const MAX = ${MAX_SNAPSHOT_ELEMENTS};
-        // Clear stale eid attributes from previous snapshots
-        document.querySelectorAll('[data-vellum-eid]').forEach(el => el.removeAttribute('data-vellum-eid'));
-        const els = Array.from(document.querySelectorAll(SELECTOR));
-        const visible = els.filter(el => {
-          const rect = el.getBoundingClientRect();
-          return rect.width > 0 && rect.height > 0;
-        });
-        return visible.slice(0, MAX).map((el, i) => {
-          const eid = 'e' + (i + 1);
-          el.setAttribute('data-vellum-eid', eid);
-          const tag = el.tagName.toLowerCase();
-          const attrs = {};
-          for (const attr of ['type', 'name', 'placeholder', 'href', 'value', 'role', 'aria-label', 'id']) {
-            if (el.hasAttribute(attr)) attrs[attr] = el.getAttribute(attr);
+    browserManager.storeSnapshotBackendNodeMap(
+      context.conversationId,
+      backendNodeMap,
+    );
+
+    // Bridge: tag every surfaced element with `data-vellum-eid` via
+    // `DOM.pushNodesByBackendIdsToFrontend` + `DOM.setAttributeValue`
+    // so the legacy string selector map keeps working for unmigrated
+    // interaction tools (click/type/hover/etc.) during the Phase 3
+    // migration window. This block is removed in PR 12 once every
+    // interaction tool resolves eids against the backendNodeId map
+    // directly. The cost is ~one CDP call per interactive element per
+    // snapshot — measurable but bounded to the migration window.
+    const stringSelectorMap = new Map<string, string>();
+    if (backendNodeMap.size > 0) {
+      const eidsInOrder = [...backendNodeMap.keys()];
+      const backendNodeIds = eidsInOrder.map((eid) => backendNodeMap.get(eid)!);
+      try {
+        const { nodeIds } = await cdp.send<{ nodeIds: number[] }>(
+          "DOM.pushNodesByBackendIdsToFrontend",
+          { backendNodeIds },
+          context.signal,
+        );
+        for (let i = 0; i < eidsInOrder.length; i += 1) {
+          const eid = eidsInOrder[i]!;
+          const nodeId = nodeIds?.[i];
+          if (!nodeId) continue;
+          try {
+            await cdp.send(
+              "DOM.setAttributeValue",
+              {
+                nodeId,
+                name: "data-vellum-eid",
+                value: eid,
+              },
+              context.signal,
+            );
+            stringSelectorMap.set(eid, `[data-vellum-eid="${eid}"]`);
+          } catch (tagErr) {
+            // Best-effort: a single element failing to be tagged should
+            // not invalidate the whole snapshot. Log and move on so the
+            // backendNodeId path for that element still works.
+            log.debug(
+              { err: tagErr, eid, nodeId },
+              "Failed to tag element with data-vellum-eid during legacy bridge",
+            );
           }
-          const text = (el.textContent || '').trim().slice(0, 80);
-          return { eid, tag, attrs, text };
-        });
-      })()
-    `)) as SnapshotElement[];
-
-    // Build and store selector map
-    const selectorMap = new Map<string, string>();
-    for (const el of elements) {
-      selectorMap.set(el.eid, `[data-vellum-eid="${el.eid}"]`);
-    }
-    browserManager.storeSnapshotMap(context.conversationId, selectorMap);
-
-    // Format output
-    const lines: string[] = [
-      `URL: ${currentUrl}`,
-      `Title: ${title || "(none)"}`,
-      "",
-    ];
-
-    if (elements.length === 0) {
-      lines.push("(no interactive elements found)");
-    } else {
-      for (const el of elements) {
-        let desc = `<${el.tag}`;
-        for (const [key, val] of Object.entries(el.attrs)) {
-          desc += ` ${key}="${val}"`;
         }
-        desc += ">";
-        if (el.text) {
-          desc += ` ${el.text}`;
-        }
-        lines.push(`[${el.eid}] ${desc}`);
+      } catch (bridgeErr) {
+        // If the bridge itself blows up (e.g. pushNodesByBackendIdsToFrontend
+        // rejected), fall through with an empty legacy map. Unmigrated
+        // interaction tools will surface their own "element_id not
+        // found" error which points the agent at `browser_snapshot`.
+        log.warn(
+          { err: bridgeErr },
+          "Legacy snapshot selector bridge failed; unmigrated interaction tools may regress",
+        );
       }
-      lines.push("");
-      lines.push(
-        `${elements.length} interactive element${
-          elements.length === 1 ? "" : "s"
-        } found.`,
-      );
     }
+    browserManager.storeSnapshotMap(context.conversationId, stringSelectorMap);
 
-    return { content: lines.join("\n"), isError: false };
+    return {
+      content: formatAxSnapshot(
+        { elements, selectorMap: backendNodeMap },
+        { url: currentUrl, title },
+      ),
+      isError: false,
+    };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     log.error({ err }, "Snapshot failed");
     return { content: `Error: Snapshot failed: ${msg}`, isError: true };
+  } finally {
+    cdp.dispose();
   }
 }
 

--- a/assistant/src/tools/browser/browser-manager.ts
+++ b/assistant/src/tools/browser/browser-manager.ts
@@ -204,6 +204,15 @@ class BrowserManager {
   private rawPages = new Map<string, unknown>();
   private cdpSessions = new Map<string, CDPSession>();
   private snapshotMaps = new Map<string, Map<string, string>>();
+  /**
+   * CDP backendNodeId lookup per conversation, populated by the
+   * AX-tree-based `executeBrowserSnapshot`. Click/type/hover/etc. tools
+   * resolve an element_id against this map and talk to CDP with the
+   * resulting backendNodeId. Lives alongside {@link snapshotMaps} during
+   * the Phase 3 migration window; the legacy string-selector map is
+   * removed in PR 12 once every interaction tool reads from this map.
+   */
+  private snapshotBackendNodeMaps = new Map<string, Map<string, number>>();
   private browserCdpSession: CDPSession | null = null;
   private browserWindowId: number | null = null;
   private interactiveModeSessions = new Set<string>();
@@ -359,6 +368,7 @@ class BrowserManager {
           this.cdpSessions.clear();
 
           this.snapshotMaps.clear();
+          this.snapshotBackendNodeMaps.clear();
           this.downloads.clear();
           for (const pending of this.pendingDownloads.values()) {
             for (const waiter of pending)
@@ -385,6 +395,7 @@ class BrowserManager {
 
     // Clear stale snapshot mappings and CDP state when replacing a closed page
     this.snapshotMaps.delete(conversationId);
+    this.snapshotBackendNodeMaps.delete(conversationId);
     await this.stopScreencast(conversationId);
 
     const page = await context.newPage();
@@ -438,6 +449,7 @@ class BrowserManager {
     this.pages.delete(conversationId);
     this.rawPages.delete(conversationId);
     this.snapshotMaps.delete(conversationId);
+    this.snapshotBackendNodeMaps.delete(conversationId);
     this.downloads.delete(conversationId);
     // Reject any pending download waiters
     const pending = this.pendingDownloads.get(conversationId);
@@ -471,6 +483,7 @@ class BrowserManager {
     this.pages.clear();
     this.rawPages.clear();
     this.snapshotMaps.clear();
+    this.snapshotBackendNodeMaps.clear();
     this.downloads.clear();
     for (const pending of this.pendingDownloads.values()) {
       for (const waiter of pending) waiter.reject(new Error("Browser closed"));
@@ -530,8 +543,15 @@ class BrowserManager {
     this.snapshotMaps.set(conversationId, map);
   }
 
+  /**
+   * Clear any cached snapshot lookups for the given conversation. Drops
+   * BOTH the legacy string-selector map and the newer backendNodeId map
+   * so that stale element IDs from a previous page can never resolve
+   * after a navigation or page close.
+   */
   clearSnapshotMap(conversationId: string): void {
     this.snapshotMaps.delete(conversationId);
+    this.snapshotBackendNodeMaps.delete(conversationId);
   }
 
   resolveSnapshotSelector(
@@ -539,6 +559,41 @@ class BrowserManager {
     elementId: string,
   ): string | null {
     const map = this.snapshotMaps.get(conversationId);
+    if (!map) return null;
+    return map.get(elementId) ?? null;
+  }
+
+  /**
+   * Store the backendNodeId lookup produced by the AX-tree-based
+   * `executeBrowserSnapshot`. Callers overwrite any prior map for the
+   * conversation so each snapshot fully supersedes the previous one.
+   */
+  storeSnapshotBackendNodeMap(
+    conversationId: string,
+    map: Map<string, number>,
+  ): void {
+    this.snapshotBackendNodeMaps.set(conversationId, map);
+  }
+
+  /**
+   * Drop the backendNodeId lookup for a conversation without touching
+   * the legacy string-selector map. Prefer {@link clearSnapshotMap}
+   * when you want to invalidate everything at once.
+   */
+  clearSnapshotBackendNodeMap(conversationId: string): void {
+    this.snapshotBackendNodeMaps.delete(conversationId);
+  }
+
+  /**
+   * Look up the CDP backendNodeId for an element id produced by the
+   * most recent AX-tree snapshot. Returns `null` if no snapshot has
+   * been taken or the id is unknown.
+   */
+  resolveSnapshotBackendNodeId(
+    conversationId: string,
+    elementId: string,
+  ): number | null {
+    const map = this.snapshotBackendNodeMaps.get(conversationId);
     if (!map) return null;
     return map.get(elementId) ?? null;
   }


### PR DESCRIPTION
## Summary
- `executeBrowserSnapshot` now calls `Accessibility.getFullAXTree` via `CdpClient` and uses `transformAxTree` + `formatAxSnapshot` (from PR 2) instead of the bespoke DOM-scraping JS
- Adds a backendNodeId store to `browserManager` alongside the legacy string selector map (legacy map bridged via `data-vellum-eid` attribute tagging for unmigrated interaction tools during the migration window; removed in PR 12)
- New `resolveElement` helper returning a `{ kind: "backend" | "selector" }` discriminated union consumed by later wave PRs

Part of plan: phase3-cdp-migration.md (PR 8 of 14)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24279" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
