### PR TITLE
feat(migrations): include credentials in vbundle export

### DIFF
--- a/assistant/src/runtime/migrations/__tests__/vbundle-builder-credentials.test.ts
+++ b/assistant/src/runtime/migrations/__tests__/vbundle-builder-credentials.test.ts
@@ -1,0 +1,276 @@
+/**
+ * Tests for credential inclusion in vbundle export.
+ *
+ * Covers:
+ * - buildExportVBundle() with credentials includes credentials/* entries
+ * - Credentials appear in the manifest with correct SHA-256 checksums
+ * - Export with no credentials produces the same archive as before (backward compat)
+ * - Streaming path (streamExportVBundle) includes credential entries
+ */
+
+import { createHash } from "node:crypto";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { gunzipSync } from "node:zlib";
+import { describe, expect, test } from "bun:test";
+
+import { buildExportVBundle, streamExportVBundle } from "../vbundle-builder.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const BLOCK_SIZE = 512;
+
+function sha256Hex(data: Uint8Array | string): string {
+  return createHash("sha256").update(data).digest("hex");
+}
+
+/** Parse a tar archive into its entries (name -> data). */
+function parseTar(tar: Uint8Array): Map<string, Uint8Array> {
+  const entries = new Map<string, Uint8Array>();
+  let offset = 0;
+  let paxPath: string | undefined;
+
+  while (offset + BLOCK_SIZE <= tar.length) {
+    const header = tar.subarray(offset, offset + BLOCK_SIZE);
+
+    // Check for end-of-archive (all zeros)
+    if (header.every((b) => b === 0)) break;
+
+    // Read file name
+    let name = "";
+    for (let i = 0; i < 100 && header[i] !== 0; i++) {
+      name += String.fromCharCode(header[i]);
+    }
+
+    // Read size (octal at offset 124, 12 bytes)
+    let sizeStr = "";
+    for (let i = 124; i < 136 && header[i] !== 0; i++) {
+      sizeStr += String.fromCharCode(header[i]);
+    }
+    const size = parseInt(sizeStr.trim(), 8) || 0;
+
+    // Type flag
+    const typeFlag = String.fromCharCode(header[156]);
+
+    offset += BLOCK_SIZE;
+
+    const data = tar.subarray(offset, offset + size);
+    const paddedSize = Math.ceil(size / BLOCK_SIZE) * BLOCK_SIZE;
+    offset += paddedSize;
+
+    if (typeFlag === "x") {
+      // PAX extended header — extract path
+      const paxStr = new TextDecoder().decode(data);
+      const match = paxStr.match(/\d+ path=(.+)\n/);
+      if (match) {
+        paxPath = match[1];
+      }
+      continue;
+    }
+
+    const entryName = paxPath ?? name;
+    paxPath = undefined;
+    entries.set(entryName, new Uint8Array(data));
+  }
+
+  return entries;
+}
+
+/** Create a minimal workspace directory with a config file for testing. */
+function createTestWorkspace(): { dir: string; cleanup: () => void } {
+  const dir = join(
+    tmpdir(),
+    `vbundle-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "config.json"), JSON.stringify({ test: true }));
+  // Create a minimal data/db directory with a fake database file
+  const dbDir = join(dir, "data", "db");
+  mkdirSync(dbDir, { recursive: true });
+  writeFileSync(join(dbDir, "assistant.db"), "fake-db-content");
+  return {
+    dir,
+    cleanup: () => rmSync(dir, { recursive: true, force: true }),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("buildExportVBundle with credentials", () => {
+  test("includes credential entries under credentials/ prefix", () => {
+    const workspace = createTestWorkspace();
+    try {
+      const credentials = [
+        { account: "openai-key", value: "sk-test-123" },
+        { account: "anthropic-key", value: "sk-ant-456" },
+      ];
+
+      const result = buildExportVBundle({
+        workspaceDir: workspace.dir,
+        credentials,
+      });
+
+      const tar = gunzipSync(result.archive);
+      const entries = parseTar(tar);
+
+      expect(entries.has("credentials/openai-key")).toBe(true);
+      expect(entries.has("credentials/anthropic-key")).toBe(true);
+
+      const decoder = new TextDecoder();
+      expect(decoder.decode(entries.get("credentials/openai-key")!)).toBe(
+        "sk-test-123",
+      );
+      expect(decoder.decode(entries.get("credentials/anthropic-key")!)).toBe(
+        "sk-ant-456",
+      );
+    } finally {
+      workspace.cleanup();
+    }
+  });
+
+  test("credentials appear in manifest with correct SHA-256 checksums", () => {
+    const workspace = createTestWorkspace();
+    try {
+      const credentials = [
+        { account: "my-api-key", value: "secret-value-abc" },
+      ];
+
+      const result = buildExportVBundle({
+        workspaceDir: workspace.dir,
+        credentials,
+      });
+
+      const expectedHash = sha256Hex(
+        new TextEncoder().encode("secret-value-abc"),
+      );
+
+      const credEntry = result.manifest.files.find(
+        (f) => f.path === "credentials/my-api-key",
+      );
+      expect(credEntry).toBeDefined();
+      expect(credEntry!.sha256).toBe(expectedHash);
+      expect(credEntry!.size).toBe(
+        new TextEncoder().encode("secret-value-abc").length,
+      );
+    } finally {
+      workspace.cleanup();
+    }
+  });
+
+  test("export with no credentials produces archive without credentials/ entries", () => {
+    const workspace = createTestWorkspace();
+    try {
+      const result = buildExportVBundle({
+        workspaceDir: workspace.dir,
+      });
+
+      const tar = gunzipSync(result.archive);
+      const entries = parseTar(tar);
+
+      const credentialEntries = [...entries.keys()].filter((k) =>
+        k.startsWith("credentials/"),
+      );
+      expect(credentialEntries).toHaveLength(0);
+
+      // Manifest should have no credential entries
+      const credManifestEntries = result.manifest.files.filter((f) =>
+        f.path.startsWith("credentials/"),
+      );
+      expect(credManifestEntries).toHaveLength(0);
+    } finally {
+      workspace.cleanup();
+    }
+  });
+
+  test("export with empty credentials array produces archive without credentials/ entries", () => {
+    const workspace = createTestWorkspace();
+    try {
+      const result = buildExportVBundle({
+        workspaceDir: workspace.dir,
+        credentials: [],
+      });
+
+      const tar = gunzipSync(result.archive);
+      const entries = parseTar(tar);
+
+      const credentialEntries = [...entries.keys()].filter((k) =>
+        k.startsWith("credentials/"),
+      );
+      expect(credentialEntries).toHaveLength(0);
+    } finally {
+      workspace.cleanup();
+    }
+  });
+});
+
+describe("streamExportVBundle with credentials", () => {
+  test("includes credential entries in the streaming archive", async () => {
+    const workspace = createTestWorkspace();
+    let result: Awaited<ReturnType<typeof streamExportVBundle>> | undefined;
+    try {
+      const credentials = [
+        { account: "stream-key", value: "stream-secret-789" },
+      ];
+
+      result = await streamExportVBundle({
+        workspaceDir: workspace.dir,
+        credentials,
+      });
+
+      // Read the temp file and decompress
+      const archiveData = new Uint8Array(
+        await Bun.file(result.tempPath).arrayBuffer(),
+      );
+      const tar = gunzipSync(archiveData);
+      const entries = parseTar(tar);
+
+      expect(entries.has("credentials/stream-key")).toBe(true);
+
+      const decoder = new TextDecoder();
+      expect(decoder.decode(entries.get("credentials/stream-key")!)).toBe(
+        "stream-secret-789",
+      );
+
+      // Verify manifest entry
+      const credEntry = result.manifest.files.find(
+        (f) => f.path === "credentials/stream-key",
+      );
+      expect(credEntry).toBeDefined();
+      expect(credEntry!.sha256).toBe(
+        sha256Hex(new TextEncoder().encode("stream-secret-789")),
+      );
+    } finally {
+      await result?.cleanup();
+      workspace.cleanup();
+    }
+  });
+
+  test("streaming export without credentials has no credentials/ entries", async () => {
+    const workspace = createTestWorkspace();
+    let result: Awaited<ReturnType<typeof streamExportVBundle>> | undefined;
+    try {
+      result = await streamExportVBundle({
+        workspaceDir: workspace.dir,
+      });
+
+      const archiveData = new Uint8Array(
+        await Bun.file(result.tempPath).arrayBuffer(),
+      );
+      const tar = gunzipSync(archiveData);
+      const entries = parseTar(tar);
+
+      const credentialEntries = [...entries.keys()].filter((k) =>
+        k.startsWith("credentials/"),
+      );
+      expect(credentialEntries).toHaveLength(0);
+    } finally {
+      await result?.cleanup();
+      workspace.cleanup();
+    }
+  });
+});

--- a/assistant/src/runtime/migrations/vbundle-builder.ts
+++ b/assistant/src/runtime/migrations/vbundle-builder.ts
@@ -66,6 +66,20 @@ interface FileMetadata {
   size: number;
 }
 
+/** In-memory entry for data not backed by a file on disk (e.g. credentials). */
+interface InMemoryEntry {
+  archivePath: string;
+  data: Uint8Array;
+  size: number;
+}
+
+/** Union of disk-backed and in-memory tar stream entries. */
+type TarStreamEntry = FileMetadata | InMemoryEntry;
+
+function isInMemoryEntry(entry: TarStreamEntry): entry is InMemoryEntry {
+  return "data" in entry;
+}
+
 // ---------------------------------------------------------------------------
 // Hash helpers
 // ---------------------------------------------------------------------------
@@ -439,6 +453,8 @@ export interface BuildExportVBundleOptions {
    * Called before the workspace walk so the DB file is up to date.
    */
   checkpoint?: () => void;
+  /** Optional credential entries to include in the archive under credentials/ prefix. */
+  credentials?: Array<{ account: string; value: string }>;
 }
 
 /**
@@ -456,8 +472,15 @@ export interface BuildExportVBundleOptions {
 export function buildExportVBundle(
   options: BuildExportVBundleOptions,
 ): BuildVBundleResult {
-  const { source, description, checkpoint, trustPath, workspaceDir, hooksDir } =
-    options;
+  const {
+    source,
+    description,
+    checkpoint,
+    trustPath,
+    workspaceDir,
+    hooksDir,
+    credentials,
+  } = options;
 
   // Flush WAL to the main database file before reading so the export
   // captures all committed rows (SQLite WAL mode keeps recent writes
@@ -492,6 +515,14 @@ export function buildExportVBundle(
   if (trustPath && existsSync(trustPath)) {
     const trustData = new Uint8Array(readFileSync(trustPath));
     files.push({ path: "trust/trust.json", data: trustData });
+  }
+
+  // Include credential entries if provided
+  if (credentials?.length) {
+    for (const { account, value } of credentials) {
+      const data = new TextEncoder().encode(value);
+      files.push({ path: `credentials/${account}`, data });
+    }
   }
 
   return buildVBundle({
@@ -688,7 +719,7 @@ function tarPaddingBytes(dataSize: number): Uint8Array {
  */
 async function* generateTarStream(
   manifestJson: Uint8Array,
-  files: FileMetadata[],
+  files: TarStreamEntry[],
 ): AsyncGenerator<Uint8Array> {
   // Manifest entry
   yield createPaxAndHeaderBlocks("manifest.json", manifestJson.length);
@@ -697,43 +728,52 @@ async function* generateTarStream(
 
   // File entries
   for (const file of files) {
-    yield createPaxAndHeaderBlocks(file.archivePath, file.size);
+    const entrySize = isInMemoryEntry(file) ? file.size : file.size;
+    yield createPaxAndHeaderBlocks(file.archivePath, entrySize);
 
-    // Stream exactly file.size bytes from disk. Capping the read at the
-    // declared size keeps the tar structure valid even if the file grows
-    // between passes (common for log files on active assistants). If the
-    // file shrinks below the declared size, zero-pad to maintain block
-    // alignment. The WAL checkpoint before export is the primary
-    // consistency mechanism for the database.
-    let bytesWritten = 0;
-    if (file.size > 0) {
-      try {
-        const stream = createReadStream(file.diskPath, {
-          start: 0,
-          end: file.size - 1,
-        });
-        for await (const chunk of stream) {
-          const data =
-            chunk instanceof Uint8Array ? chunk : new Uint8Array(chunk);
-          bytesWritten += data.length;
-          yield data;
+    if (isInMemoryEntry(file)) {
+      // In-memory entry — yield data directly
+      if (file.size > 0) {
+        yield file.data;
+      }
+    } else {
+      // Disk-backed entry — stream from disk
+      // Stream exactly file.size bytes from disk. Capping the read at the
+      // declared size keeps the tar structure valid even if the file grows
+      // between passes (common for log files on active assistants). If the
+      // file shrinks below the declared size, zero-pad to maintain block
+      // alignment. The WAL checkpoint before export is the primary
+      // consistency mechanism for the database.
+      let bytesWritten = 0;
+      if (file.size > 0) {
+        try {
+          const stream = createReadStream(file.diskPath, {
+            start: 0,
+            end: file.size - 1,
+          });
+          for await (const chunk of stream) {
+            const data =
+              chunk instanceof Uint8Array ? chunk : new Uint8Array(chunk);
+            bytesWritten += data.length;
+            yield data;
+          }
+        } catch {
+          // File was deleted or rotated between passes — emit zeros for
+          // the full declared size so the tar structure stays valid
         }
-      } catch {
-        // File was deleted or rotated between passes — emit zeros for
-        // the full declared size so the tar structure stays valid
+      }
+
+      // If the file shrank, pad with zeros in bounded chunks to reach
+      // the declared size without a large single allocation
+      let remaining = file.size - bytesWritten;
+      while (remaining > 0) {
+        const chunkSize = Math.min(remaining, 65536);
+        yield new Uint8Array(chunkSize);
+        remaining -= chunkSize;
       }
     }
 
-    // If the file shrank, pad with zeros in bounded chunks to reach
-    // the declared size without a large single allocation
-    let remaining = file.size - bytesWritten;
-    while (remaining > 0) {
-      const chunkSize = Math.min(remaining, 65536);
-      yield new Uint8Array(chunkSize);
-      remaining -= chunkSize;
-    }
-
-    yield tarPaddingBytes(file.size);
+    yield tarPaddingBytes(entrySize);
   }
 
   // End-of-archive: two zero blocks
@@ -765,8 +805,15 @@ export interface StreamExportVBundleResult {
 export async function streamExportVBundle(
   options: BuildExportVBundleOptions,
 ): Promise<StreamExportVBundleResult> {
-  const { source, description, checkpoint, trustPath, workspaceDir, hooksDir } =
-    options;
+  const {
+    source,
+    description,
+    checkpoint,
+    trustPath,
+    workspaceDir,
+    hooksDir,
+    credentials,
+  } = options;
 
   // Flush WAL to the main database file before reading
   if (checkpoint) {
@@ -806,6 +853,19 @@ export async function streamExportVBundle(
     }
   }
 
+  // Build in-memory entries for credentials (not disk-backed)
+  const inMemoryEntries: InMemoryEntry[] = [];
+  if (credentials?.length) {
+    for (const { account, value } of credentials) {
+      const data = new TextEncoder().encode(value);
+      inMemoryEntries.push({
+        archivePath: `credentials/${account}`,
+        data,
+        size: data.length,
+      });
+    }
+  }
+
   // ------------------------------------------------------------------
   // Pass 1: Compute SHA-256 checksums to build the manifest
   // ------------------------------------------------------------------
@@ -817,6 +877,16 @@ export async function streamExportVBundle(
       path: file.archivePath,
       sha256,
       size: file.size,
+    });
+  }
+
+  // Add in-memory credential entries to the manifest
+  for (const entry of inMemoryEntries) {
+    const sha256 = sha256Hex(entry.data);
+    fileEntries.push({
+      path: entry.archivePath,
+      sha256,
+      size: entry.size,
     });
   }
 
@@ -842,7 +912,8 @@ export async function streamExportVBundle(
 
   const tempPath = join(tmpdir(), `vbundle-export-${randomUUID()}.tmp`);
 
-  const tarGenerator = generateTarStream(manifestData, allFileMetadata);
+  const allEntries: TarStreamEntry[] = [...allFileMetadata, ...inMemoryEntries];
+  const tarGenerator = generateTarStream(manifestData, allEntries);
   const tarReadable = Readable.from(tarGenerator);
   const gzipStream = createGzip();
   const writeStream = createWriteStream(tempPath, { mode: 0o600 });

--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -21,6 +21,10 @@ import { invalidateConfigCache } from "../../config/loader.js";
 import { getDb, resetDb } from "../../memory/db-connection.js";
 import { validateMigrationState } from "../../memory/migrations/validate-migration-state.js";
 import { clearCache as clearTrustCache } from "../../permissions/trust-store.js";
+import {
+  getSecureKeyAsync,
+  listSecureKeysAsync,
+} from "../../security/secure-keys.js";
 import { getLogger } from "../../util/logger.js";
 import {
   getDbPath,
@@ -146,6 +150,18 @@ export async function handleMigrationExport(req: Request): Promise<Response> {
   let cleanup: (() => Promise<void>) | undefined;
 
   try {
+    // Read all stored credentials to include in the export bundle
+    const credentialList = await listSecureKeysAsync();
+    const credentials: Array<{ account: string; value: string }> = [];
+    if (!credentialList.unreachable) {
+      for (const account of credentialList.accounts) {
+        const value = await getSecureKeyAsync(account);
+        if (value) {
+          credentials.push({ account, value });
+        }
+      }
+    }
+
     const result = await streamExportVBundle({
       // hooksDir is intentionally omitted — hooks now live under workspace/hooks/
       // and are included in the workspace walk. Passing hooksDir separately would
@@ -153,6 +169,7 @@ export async function handleMigrationExport(req: Request): Promise<Response> {
       workspaceDir: getWorkspaceDir(),
       source: "runtime-export",
       description,
+      credentials,
       checkpoint: () => {
         const dbPath = getDbPath();
         try {


### PR DESCRIPTION
## Summary
- Add credentials option to BuildExportVBundleOptions for including credential entries in vbundle archives
- Update both sync (buildExportVBundle) and streaming (streamExportVBundle) paths to include credentials under credentials/ prefix
- Read all stored credentials in the migration export HTTP handler and pass them to the builder

Part of plan: cred-teleport-vbundle.md (PR 4 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24285" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
