### PR TITLE
feat(credential-executor): add POST /v1/credentials/bulk HTTP endpoint

### DIFF
--- a/credential-executor/src/http/__tests__/credential-routes-bulk.test.ts
+++ b/credential-executor/src/http/__tests__/credential-routes-bulk.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Tests for the POST /v1/credentials/bulk endpoint.
+ *
+ * Verifies:
+ * - Successful bulk set with multiple credentials
+ * - Validation failure (missing fields, non-array body)
+ * - Auth requirement (401 without token)
+ */
+
+import { describe, it, expect } from "bun:test";
+
+import { handleCredentialRoute } from "../credential-routes.js";
+import type { CredentialRouteDeps } from "../credential-routes.js";
+import type { SecureKeyBackend } from "@vellumai/credential-storage";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const SERVICE_TOKEN = "test-ces-service-token-12345";
+
+function makeDeps(
+  overrides: Partial<SecureKeyBackend> = {},
+): CredentialRouteDeps {
+  const store = new Map<string, string>();
+  const backend: SecureKeyBackend = {
+    get: async (account: string) => store.get(account),
+    set: async (account: string, value: string) => {
+      store.set(account, value);
+      return true;
+    },
+    delete: async (account: string) => {
+      if (!store.has(account)) return "not-found";
+      store.delete(account);
+      return "ok";
+    },
+    list: async () => [...store.keys()],
+    ...overrides,
+  };
+  return { backend, serviceToken: SERVICE_TOKEN };
+}
+
+function makeRequest(
+  opts: {
+    body?: unknown;
+    token?: string | null;
+    method?: string;
+  } = {},
+): Request {
+  const url = "http://localhost:8090/v1/credentials/bulk";
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (opts.token !== null) {
+    headers["Authorization"] = `Bearer ${opts.token ?? SERVICE_TOKEN}`;
+  }
+
+  return new Request(url, {
+    method: opts.method ?? "POST",
+    headers,
+    body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("POST /v1/credentials/bulk", () => {
+  it("sets multiple credentials and returns per-credential results", async () => {
+    const deps = makeDeps();
+    const res = await handleCredentialRoute(
+      makeRequest({
+        body: {
+          credentials: [
+            { account: "openai", value: "sk-abc" },
+            { account: "anthropic", value: "sk-xyz" },
+          ],
+        },
+      }),
+      deps,
+    );
+
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(200);
+
+    const body = await res!.json();
+    expect(body.results).toEqual([
+      { account: "openai", ok: true },
+      { account: "anthropic", ok: true },
+    ]);
+
+    // Verify credentials were actually stored
+    expect(await deps.backend.get("openai")).toBe("sk-abc");
+    expect(await deps.backend.get("anthropic")).toBe("sk-xyz");
+  });
+
+  it("reports per-credential failure when backend.set returns false", async () => {
+    let callCount = 0;
+    const deps = makeDeps({
+      set: async () => {
+        callCount++;
+        // Fail on the second call
+        return callCount !== 2;
+      },
+    });
+
+    const res = await handleCredentialRoute(
+      makeRequest({
+        body: {
+          credentials: [
+            { account: "a", value: "1" },
+            { account: "b", value: "2" },
+            { account: "c", value: "3" },
+          ],
+        },
+      }),
+      deps,
+    );
+
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(200);
+
+    const body = await res!.json();
+    expect(body.results).toEqual([
+      { account: "a", ok: true },
+      { account: "b", ok: false },
+      { account: "c", ok: true },
+    ]);
+  });
+
+  it("returns 400 when credentials field is not an array", async () => {
+    const deps = makeDeps();
+    const res = await handleCredentialRoute(
+      makeRequest({ body: { credentials: "not-an-array" } }),
+      deps,
+    );
+
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(400);
+
+    const body = await res!.json();
+    expect(body.error).toMatch(/credentials.*array/i);
+  });
+
+  it("returns 400 when credentials field is missing", async () => {
+    const deps = makeDeps();
+    const res = await handleCredentialRoute(
+      makeRequest({ body: {} }),
+      deps,
+    );
+
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(400);
+
+    const body = await res!.json();
+    expect(body.error).toMatch(/credentials.*array/i);
+  });
+
+  it("returns 400 when an entry is missing account field", async () => {
+    const deps = makeDeps();
+    const res = await handleCredentialRoute(
+      makeRequest({
+        body: {
+          credentials: [{ value: "sk-abc" }],
+        },
+      }),
+      deps,
+    );
+
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(400);
+
+    const body = await res!.json();
+    expect(body.error).toMatch(/account.*value/i);
+  });
+
+  it("returns 400 when an entry is missing value field", async () => {
+    const deps = makeDeps();
+    const res = await handleCredentialRoute(
+      makeRequest({
+        body: {
+          credentials: [{ account: "openai" }],
+        },
+      }),
+      deps,
+    );
+
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(400);
+
+    const body = await res!.json();
+    expect(body.error).toMatch(/account.*value/i);
+  });
+
+  it("returns 401 without Authorization header", async () => {
+    const deps = makeDeps();
+    const res = await handleCredentialRoute(
+      makeRequest({ token: null, body: { credentials: [] } }),
+      deps,
+    );
+
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(401);
+
+    const body = await res!.json();
+    expect(body.error).toMatch(/Missing Authorization/i);
+  });
+
+  it("returns 403 with wrong service token", async () => {
+    const deps = makeDeps();
+    const res = await handleCredentialRoute(
+      makeRequest({ token: "wrong-token", body: { credentials: [] } }),
+      deps,
+    );
+
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(403);
+
+    const body = await res!.json();
+    expect(body.error).toMatch(/Invalid service token/i);
+  });
+
+  it("returns 405 for non-POST methods", async () => {
+    const deps = makeDeps();
+    const res = await handleCredentialRoute(
+      makeRequest({ method: "GET", body: undefined }),
+      deps,
+    );
+
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(405);
+  });
+
+  it("handles empty credentials array", async () => {
+    const deps = makeDeps();
+    const res = await handleCredentialRoute(
+      makeRequest({ body: { credentials: [] } }),
+      deps,
+    );
+
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(200);
+
+    const body = await res!.json();
+    expect(body.results).toEqual([]);
+  });
+});

--- a/credential-executor/src/http/credential-routes.ts
+++ b/credential-executor/src/http/credential-routes.ts
@@ -7,6 +7,7 @@
  *
  * Endpoints:
  * - `GET  /v1/credentials`           — list credential account names
+ * - `POST /v1/credentials/bulk`      — bulk set credentials
  * - `GET  /v1/credentials/:account`  — get a credential value
  * - `POST /v1/credentials/:account`  — set a credential value
  * - `DELETE /v1/credentials/:account` — delete a credential
@@ -95,6 +96,60 @@ export async function handleCredentialRoute(
 
   // Extract account from path: /v1/credentials/:account
   const accountSegment = pathname.slice(CREDENTIAL_PATH_PREFIX.length);
+
+  // POST /v1/credentials/bulk — bulk set credentials
+  if (accountSegment === "/bulk") {
+    if (req.method !== "POST") {
+      return new Response(
+        JSON.stringify({ error: "Method not allowed" }),
+        { status: 405, headers: { "Content-Type": "application/json" } },
+      );
+    }
+
+    let body: { credentials?: unknown };
+    try {
+      body = await req.json();
+    } catch {
+      return new Response(
+        JSON.stringify({ error: "Invalid JSON body" }),
+        { status: 400, headers: { "Content-Type": "application/json" } },
+      );
+    }
+
+    if (!Array.isArray(body.credentials)) {
+      return new Response(
+        JSON.stringify({ error: "Body must contain a 'credentials' array field" }),
+        { status: 400, headers: { "Content-Type": "application/json" } },
+      );
+    }
+
+    for (const entry of body.credentials) {
+      if (
+        typeof entry !== "object" ||
+        entry === null ||
+        typeof entry.account !== "string" ||
+        typeof entry.value !== "string"
+      ) {
+        return new Response(
+          JSON.stringify({
+            error: "Each credential entry must have string 'account' and 'value' fields",
+          }),
+          { status: 400, headers: { "Content-Type": "application/json" } },
+        );
+      }
+    }
+
+    const results: Array<{ account: string; ok: boolean }> = [];
+    for (const entry of body.credentials as Array<{ account: string; value: string }>) {
+      const ok = await backend.set(entry.account, entry.value);
+      results.push({ account: entry.account, ok: !!ok });
+    }
+
+    return new Response(
+      JSON.stringify({ results }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+  }
 
   // GET /v1/credentials — list all credential account names
   if (accountSegment === "" || accountSegment === "/") {


### PR DESCRIPTION
## Summary
- Add POST /v1/credentials/bulk endpoint to CES HTTP credential routes
- Accepts array of {account, value} entries and stores them via the backend
- Returns per-credential success/failure results with bearer token auth

Part of plan: cred-teleport-vbundle.md (PR 3 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24289" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
