### PR TITLE
feat(security): add bulkSetSecureKeysAsync to CES RPC credential backend

### DIFF
--- a/assistant/src/security/ces-credential-client.ts
+++ b/assistant/src/security/ces-credential-client.ts
@@ -190,6 +190,21 @@ export class CesCredentialBackend implements CredentialBackend {
     }
   }
 
+  async bulkSet(
+    credentials: Array<{ account: string; value: string }>,
+  ): Promise<Array<{ account: string; ok: boolean }>> {
+    const res = await cesRequest("POST", "/v1/credentials/bulk", {
+      credentials,
+    });
+    if (!res?.ok) {
+      return credentials.map((c) => ({ account: c.account, ok: false }));
+    }
+    const data = (await res.json()) as {
+      results: Array<{ account: string; ok: boolean }>;
+    };
+    return data.results;
+  }
+
   async list(): Promise<CredentialListResult> {
     try {
       const res = await cesRequest("GET", "/v1/credentials");

--- a/assistant/src/security/ces-rpc-credential-backend.ts
+++ b/assistant/src/security/ces-rpc-credential-backend.ts
@@ -86,4 +86,21 @@ export class CesRpcCredentialBackend implements CredentialBackend {
       return { accounts: [], unreachable: true };
     }
   }
+
+  async bulkSet(
+    credentials: Array<{ account: string; value: string }>,
+  ): Promise<Array<{ account: string; ok: boolean }>> {
+    if (!this.isAvailable()) {
+      return credentials.map((c) => ({ account: c.account, ok: false }));
+    }
+    try {
+      const result = await this.client.call(CesRpcMethod.BulkSetCredentials, {
+        credentials,
+      });
+      return result.results;
+    } catch (err) {
+      log.warn({ err }, "CES RPC bulk credential set failed");
+      return credentials.map((c) => ({ account: c.account, ok: false }));
+    }
+  }
 }

--- a/assistant/src/security/credential-backend.ts
+++ b/assistant/src/security/credential-backend.ts
@@ -47,6 +47,11 @@ export interface CredentialBackend {
 
   /** List all account names. */
   list(): Promise<CredentialListResult>;
+
+  /** Bulk-set multiple credentials. Optional — backends without native bulk support omit this. */
+  bulkSet?(
+    credentials: Array<{ account: string; value: string }>,
+  ): Promise<Array<{ account: string; ok: boolean }>>;
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/security/secure-keys.ts
+++ b/assistant/src/security/secure-keys.ts
@@ -450,6 +450,33 @@ export async function deleteSecureKeyAsync(
   }, "error");
 }
 
+/**
+ * Bulk-set multiple credentials in a single operation.
+ *
+ * Uses the backend's native `bulkSet` when available (CES RPC / HTTP),
+ * otherwise falls back to individual `set` calls.
+ */
+export async function bulkSetSecureKeysAsync(
+  credentials: Array<{ account: string; value: string }>,
+): Promise<Array<{ account: string; ok: boolean }>> {
+  return withCredentialTimeout(
+    async () => {
+      const backend = await resolveBackendAsync();
+      if (backend.bulkSet) {
+        return backend.bulkSet(credentials);
+      }
+      // Fallback: loop individual sets
+      const results = [];
+      for (const { account, value } of credentials) {
+        const ok = await backend.set(account, value);
+        results.push({ account, ok });
+      }
+      return results;
+    },
+    credentials.map((c) => ({ account: c.account, ok: false })),
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Provider API key lookup — secure store + env var fallback
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add optional bulkSet method to CredentialBackend interface
- Implement bulkSet on CesRpcCredentialBackend (RPC) and CesCredentialBackend (HTTP)
- Add bulkSetSecureKeysAsync public function to secure-keys.ts with fallback to individual sets

Part of plan: cred-teleport-vbundle.md (PR 5 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24290" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
