### PR TITLE
feat(migrations): import credentials from vbundle to CES on migration import

### DIFF
--- a/assistant/src/runtime/migrations/__tests__/vbundle-import-credentials.test.ts
+++ b/assistant/src/runtime/migrations/__tests__/vbundle-import-credentials.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Tests for credential import from vbundle archives.
+ *
+ * Covers:
+ * - extractCredentialsFromBundle() correctly extracts credential entries
+ * - DefaultPathResolver skips credentials/ paths (not written to disk)
+ * - Empty and missing credential entries are handled gracefully
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { DefaultPathResolver } from "../vbundle-import-analyzer.js";
+import { extractCredentialsFromBundle } from "../vbundle-importer.js";
+import type { VBundleTarEntry } from "../vbundle-validator.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTarEntry(data: string): VBundleTarEntry {
+  const encoded = new TextEncoder().encode(data);
+  return { name: "", data: encoded, size: encoded.length };
+}
+
+// ---------------------------------------------------------------------------
+// extractCredentialsFromBundle
+// ---------------------------------------------------------------------------
+
+describe("extractCredentialsFromBundle", () => {
+  test("extracts credential entries from tar entries map", () => {
+    const entries = new Map<string, VBundleTarEntry>();
+    entries.set("credentials/openai-key", makeTarEntry("sk-test-123"));
+    entries.set("credentials/anthropic-key", makeTarEntry("sk-ant-456"));
+    entries.set("workspace/config.json", makeTarEntry('{"test": true}'));
+    entries.set("manifest.json", makeTarEntry("{}"));
+
+    const credentials = extractCredentialsFromBundle(entries);
+
+    expect(credentials).toHaveLength(2);
+    expect(credentials).toContainEqual({
+      account: "openai-key",
+      value: "sk-test-123",
+    });
+    expect(credentials).toContainEqual({
+      account: "anthropic-key",
+      value: "sk-ant-456",
+    });
+  });
+
+  test("returns empty array when no credential entries exist", () => {
+    const entries = new Map<string, VBundleTarEntry>();
+    entries.set("workspace/config.json", makeTarEntry('{"test": true}'));
+    entries.set("manifest.json", makeTarEntry("{}"));
+
+    const credentials = extractCredentialsFromBundle(entries);
+
+    expect(credentials).toHaveLength(0);
+  });
+
+  test("returns empty array for empty entries map", () => {
+    const entries = new Map<string, VBundleTarEntry>();
+
+    const credentials = extractCredentialsFromBundle(entries);
+
+    expect(credentials).toHaveLength(0);
+  });
+
+  test("skips bare credentials/ path with no account name", () => {
+    const entries = new Map<string, VBundleTarEntry>();
+    entries.set("credentials/", makeTarEntry("some-value"));
+    entries.set("credentials/valid-key", makeTarEntry("valid-secret"));
+
+    const credentials = extractCredentialsFromBundle(entries);
+
+    expect(credentials).toHaveLength(1);
+    expect(credentials[0]).toEqual({
+      account: "valid-key",
+      value: "valid-secret",
+    });
+  });
+
+  test("handles credential values with special characters", () => {
+    const entries = new Map<string, VBundleTarEntry>();
+    entries.set(
+      "credentials/complex-key",
+      makeTarEntry("value with spaces & special=chars!"),
+    );
+
+    const credentials = extractCredentialsFromBundle(entries);
+
+    expect(credentials).toHaveLength(1);
+    expect(credentials[0]).toEqual({
+      account: "complex-key",
+      value: "value with spaces & special=chars!",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DefaultPathResolver — credential path skipping
+// ---------------------------------------------------------------------------
+
+describe("DefaultPathResolver skips credential paths", () => {
+  test("resolve() returns null for credentials/ paths", () => {
+    const resolver = new DefaultPathResolver("/tmp/workspace", "/tmp/hooks");
+
+    expect(resolver.resolve("credentials/openai-key")).toBeNull();
+    expect(resolver.resolve("credentials/anthropic-key")).toBeNull();
+    expect(resolver.resolve("credentials/")).toBeNull();
+  });
+
+  test("resolve() still resolves non-credential paths normally", () => {
+    const resolver = new DefaultPathResolver("/tmp/workspace", "/tmp/hooks");
+
+    // workspace/ paths should resolve
+    expect(resolver.resolve("workspace/config.json")).not.toBeNull();
+
+    // data/db should resolve
+    expect(resolver.resolve("data/db/assistant.db")).not.toBeNull();
+  });
+});

--- a/assistant/src/runtime/migrations/vbundle-import-analyzer.ts
+++ b/assistant/src/runtime/migrations/vbundle-import-analyzer.ts
@@ -93,6 +93,11 @@ export class DefaultPathResolver implements PathResolver {
   ) {}
 
   resolve(archivePath: string): string | null {
+    // Skip credential entries — handled separately by the credential import step
+    if (archivePath.startsWith("credentials/")) {
+      return null;
+    }
+
     // New format: workspace/ prefix — maps directly into the workspace dir
     if (archivePath.startsWith("workspace/") && this.workspaceDir) {
       const relPath = archivePath.slice("workspace/".length);

--- a/assistant/src/runtime/migrations/vbundle-importer.ts
+++ b/assistant/src/runtime/migrations/vbundle-importer.ts
@@ -381,6 +381,33 @@ export function commitImport(options: ImportCommitOptions): ImportCommitResult {
 }
 
 // ---------------------------------------------------------------------------
+// Credential extraction
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract credential entries from a validated vbundle tar entries map.
+ *
+ * Credentials are stored under the `credentials/` prefix in the archive,
+ * where the remainder of the path is the account name and the entry data
+ * is the credential value.
+ */
+export function extractCredentialsFromBundle(
+  entries: Map<string, VBundleTarEntry>,
+): Array<{ account: string; value: string }> {
+  const credentials: Array<{ account: string; value: string }> = [];
+  for (const [path, entry] of entries) {
+    if (path.startsWith("credentials/")) {
+      const account = path.slice("credentials/".length);
+      if (account) {
+        const value = new TextDecoder().decode(entry.data);
+        credentials.push({ account, value });
+      }
+    }
+  }
+  return credentials;
+}
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 

--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -22,6 +22,7 @@ import { getDb, resetDb } from "../../memory/db-connection.js";
 import { validateMigrationState } from "../../memory/migrations/validate-migration-state.js";
 import { clearCache as clearTrustCache } from "../../permissions/trust-store.js";
 import {
+  bulkSetSecureKeysAsync,
   getSecureKeyAsync,
   listSecureKeysAsync,
 } from "../../security/secure-keys.js";
@@ -38,7 +39,10 @@ import {
   analyzeImport,
   DefaultPathResolver,
 } from "../migrations/vbundle-import-analyzer.js";
-import { commitImport } from "../migrations/vbundle-importer.js";
+import {
+  commitImport,
+  extractCredentialsFromBundle,
+} from "../migrations/vbundle-importer.js";
 import { validateVBundle } from "../migrations/vbundle-validator.js";
 
 const log = getLogger("migration-routes");
@@ -459,6 +463,41 @@ export async function handleMigrationImport(req: Request): Promise<Response> {
         },
         { status: 500 },
       );
+    }
+
+    // Import credentials from the bundle into CES (non-blocking — failures
+    // are logged as warnings but do not fail the overall import).
+    if (validation.entries) {
+      const bundleCredentials = extractCredentialsFromBundle(
+        validation.entries,
+      );
+      if (bundleCredentials.length > 0) {
+        try {
+          const credResults = await bulkSetSecureKeysAsync(bundleCredentials);
+          const failed = credResults.filter((r) => !r.ok);
+          if (failed.length > 0) {
+            log.warn(
+              { failed: failed.map((f) => f.account) },
+              "Some credentials failed to import",
+            );
+          }
+          log.info(
+            { total: bundleCredentials.length, failed: failed.length },
+            "Credential import complete",
+          );
+          const succeeded = bundleCredentials.length - failed.length;
+          if (failed.length > 0) {
+            result.report.warnings.push(
+              `Imported ${succeeded} credential(s), ${failed.length} failed`,
+            );
+          }
+        } catch (err) {
+          log.warn({ err }, "Credential import failed entirely");
+          result.report.warnings.push(
+            `Credential import failed: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      }
     }
 
     // Invalidate in-process caches so imported settings.json and trust.json take effect


### PR DESCRIPTION
## Summary
- Add extractCredentialsFromBundle() to extract credential entries from vbundle tar entries
- Skip credentials/ paths in path resolver to prevent writing credential files to workspace
- After vbundle import, bulk-write extracted credentials to CES via bulkSetSecureKeysAsync

Part of plan: cred-teleport-vbundle.md (PR 6 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24291" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
