### PR TITLE
feat(migrations): skip re-enter-secrets step when credentials were auto-imported

### DIFF
--- a/assistant/src/runtime/migrations/__tests__/rebind-secrets-credentials.test.ts
+++ b/assistant/src/runtime/migrations/__tests__/rebind-secrets-credentials.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Tests for credential-aware rebind-secrets screen behavior.
+ *
+ * Covers:
+ * - All credentials imported successfully -> re-enter-secrets auto-completed
+ * - Partial import failure -> targeted list of failed credentials
+ * - Legacy bundles without credentials -> original rebind-secrets behavior
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import type { MigrationWizardState } from "../migration-wizard.js";
+import { createWizardState } from "../migration-wizard.js";
+import {
+  createTaskCompletionState,
+  deriveRebindSecretsScreenState,
+} from "../rebind-secrets-screen.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a wizard state that has progressed to the rebind-secrets step.
+ */
+function wizardAtRebindSecrets(
+  credentialsImported?: MigrationWizardState["credentialsImported"],
+): MigrationWizardState {
+  const base = createWizardState();
+  return {
+    ...base,
+    currentStep: "rebind-secrets",
+    direction: "managed-to-self-hosted",
+    steps: {
+      ...base.steps,
+      "select-direction": { status: "success" },
+      "upload-bundle": { status: "success" },
+      validate: { status: "success" },
+      "preflight-review": { status: "success" },
+      transfer: { status: "success" },
+      "rebind-secrets": { status: "idle" },
+      complete: { status: "idle" },
+    },
+    hasBundleData: true,
+    credentialsImported,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("rebind-secrets-screen credential awareness", () => {
+  test("all credentials imported successfully -> re-enter-secrets is auto-completed", () => {
+    const wizard = wizardAtRebindSecrets({
+      total: 3,
+      succeeded: 3,
+      failed: 0,
+      failedAccounts: [],
+    });
+    const completion = createTaskCompletionState();
+    const screen = deriveRebindSecretsScreenState(wizard, completion);
+
+    expect(screen.phase).toBe("active");
+    if (screen.phase !== "active") return;
+
+    const secretsTask = screen.tasks.find((t) => t.id === "re-enter-secrets");
+    expect(secretsTask).toBeDefined();
+    expect(secretsTask!.status).toBe("complete");
+    expect(secretsTask!.title).toBe("API keys and secrets transferred");
+    expect(secretsTask!.description).toContain("3 credential(s)");
+    expect(secretsTask!.description).toContain("automatically imported");
+  });
+
+  test("partial import failure -> shows only failed credentials", () => {
+    const wizard = wizardAtRebindSecrets({
+      total: 3,
+      succeeded: 2,
+      failed: 1,
+      failedAccounts: ["openai-key"],
+    });
+    const completion = createTaskCompletionState();
+    const screen = deriveRebindSecretsScreenState(wizard, completion);
+
+    expect(screen.phase).toBe("active");
+    if (screen.phase !== "active") return;
+
+    const secretsTask = screen.tasks.find((t) => t.id === "re-enter-secrets");
+    expect(secretsTask).toBeDefined();
+    expect(secretsTask!.status).toBe("pending");
+    expect(secretsTask!.title).toBe("Re-enter failed credentials");
+    expect(secretsTask!.description).toContain("2 of 3");
+    expect(secretsTask!.description).toContain('"openai-key"');
+    expect(secretsTask!.description).toContain("manual re-entry");
+  });
+
+  test("legacy bundle without credentials -> original rebind-secrets behavior", () => {
+    const wizard = wizardAtRebindSecrets(undefined);
+    const completion = createTaskCompletionState();
+    const screen = deriveRebindSecretsScreenState(wizard, completion);
+
+    expect(screen.phase).toBe("active");
+    if (screen.phase !== "active") return;
+
+    const secretsTask = screen.tasks.find((t) => t.id === "re-enter-secrets");
+    expect(secretsTask).toBeDefined();
+    expect(secretsTask!.status).toBe("pending");
+    expect(secretsTask!.title).toBe("Re-enter API keys and secrets");
+    expect(secretsTask!.description).toContain("redacted in export bundles");
+  });
+
+  test("all credentials imported -> allRequiredComplete reflects auto-completion", () => {
+    const wizard = wizardAtRebindSecrets({
+      total: 2,
+      succeeded: 2,
+      failed: 0,
+      failedAccounts: [],
+    });
+    // Mark all other required tasks as complete
+    let completion = createTaskCompletionState();
+    completion = {
+      ...completion,
+      "rebind-channels": true,
+      "reconfigure-auth": true,
+    };
+    const screen = deriveRebindSecretsScreenState(wizard, completion);
+
+    expect(screen.phase).toBe("active");
+    if (screen.phase !== "active") return;
+
+    // re-enter-secrets is auto-completed, rebind-channels and reconfigure-auth are manually done
+    expect(screen.allRequiredComplete).toBe(true);
+  });
+
+  test("partial failure -> allRequiredComplete is false when failed creds not manually acknowledged", () => {
+    const wizard = wizardAtRebindSecrets({
+      total: 3,
+      succeeded: 2,
+      failed: 1,
+      failedAccounts: ["anthropic-key"],
+    });
+    const completion = createTaskCompletionState();
+    const screen = deriveRebindSecretsScreenState(wizard, completion);
+
+    expect(screen.phase).toBe("active");
+    if (screen.phase !== "active") return;
+
+    // re-enter-secrets is still pending (partial failure), so not all required complete
+    expect(screen.allRequiredComplete).toBe(false);
+  });
+
+  test("multiple failed credentials are listed in description", () => {
+    const wizard = wizardAtRebindSecrets({
+      total: 4,
+      succeeded: 1,
+      failed: 3,
+      failedAccounts: ["openai-key", "anthropic-key", "github-token"],
+    });
+    const completion = createTaskCompletionState();
+    const screen = deriveRebindSecretsScreenState(wizard, completion);
+
+    expect(screen.phase).toBe("active");
+    if (screen.phase !== "active") return;
+
+    const secretsTask = screen.tasks.find((t) => t.id === "re-enter-secrets");
+    expect(secretsTask).toBeDefined();
+    expect(secretsTask!.description).toContain('"openai-key"');
+    expect(secretsTask!.description).toContain('"anthropic-key"');
+    expect(secretsTask!.description).toContain('"github-token"');
+    expect(secretsTask!.description).toContain("1 of 4");
+  });
+});

--- a/assistant/src/runtime/migrations/migration-wizard.ts
+++ b/assistant/src/runtime/migrations/migration-wizard.ts
@@ -92,6 +92,14 @@ export interface MigrationWizardState {
   /** Import commit result. */
   importResult?: ImportCommitResponse;
 
+  /** Credential import results from the transfer step (if credentials were in the bundle). */
+  credentialsImported?: {
+    total: number;
+    succeeded: number;
+    failed: number;
+    failedAccounts: string[];
+  };
+
   /** Timestamp of last state change (ISO 8601). */
   updatedAt: string;
 
@@ -317,7 +325,11 @@ export function goBackTo(
       ? { preflightResult: undefined }
       : {}),
     ...(targetIdx <= STEP_INDEX.get("transfer")!
-      ? { exportResult: undefined, importResult: undefined }
+      ? {
+          exportResult: undefined,
+          importResult: undefined,
+          credentialsImported: undefined,
+        }
       : {}),
   });
 }
@@ -488,7 +500,17 @@ export async function executeTransferStep(
 
     if (importResult.success) {
       current = setStepStatus(current, "transfer", "success");
-      current = { ...current, currentStep: "rebind-secrets" };
+      // Extract credential import results from the response (if present)
+      const credentialsImported = (
+        importResult as unknown as Record<string, unknown>
+      ).credentialsImported as
+        | MigrationWizardState["credentialsImported"]
+        | undefined;
+      current = {
+        ...current,
+        currentStep: "rebind-secrets",
+        ...(credentialsImported ? { credentialsImported } : {}),
+      };
     } else {
       current = setStepStatus(current, "transfer", "error", {
         message:

--- a/assistant/src/runtime/migrations/rebind-secrets-screen.ts
+++ b/assistant/src/runtime/migrations/rebind-secrets-screen.ts
@@ -194,18 +194,63 @@ export function markTaskPending(
 
 /**
  * Build the task list from definitions and completion state.
+ *
+ * When credential import results are provided:
+ * - If all credentials were imported successfully, the re-enter-secrets task
+ *   is marked as auto-completed with an updated description.
+ * - If some credentials failed, the description is updated to list only the
+ *   failed credentials that need manual re-entry.
+ * - If no credentials were in the bundle (legacy), the original behavior is kept.
  */
-function buildTasks(completionState: RebindTaskCompletionState): RebindTask[] {
-  return TASK_DEFINITIONS.map((def) => ({
-    id: def.id,
-    title: def.title,
-    description: def.description,
-    status: completionState[def.id]
-      ? ("complete" as const)
-      : ("pending" as const),
-    required: def.required,
-    ...(def.helpText !== undefined ? { helpText: def.helpText } : {}),
-  }));
+function buildTasks(
+  completionState: RebindTaskCompletionState,
+  credentialsImported?: MigrationWizardState["credentialsImported"],
+): RebindTask[] {
+  return TASK_DEFINITIONS.map((def) => {
+    // Apply credential import awareness to the re-enter-secrets task
+    if (def.id === "re-enter-secrets" && credentialsImported) {
+      if (credentialsImported.failed === 0 && credentialsImported.total > 0) {
+        // All credentials imported successfully — auto-complete this task
+        return {
+          id: def.id,
+          title: "API keys and secrets transferred",
+          description: `All ${credentialsImported.total} credential(s) were automatically imported from the bundle. No manual re-entry needed.`,
+          status: "complete" as const,
+          required: def.required,
+          helpText:
+            "Credentials were securely transferred as part of the migration bundle. You can verify them in Settings > Models & Services.",
+        };
+      }
+
+      if (credentialsImported.failed > 0) {
+        // Partial failure — show only the failed credentials
+        const failedList = credentialsImported.failedAccounts
+          .map((a) => `"${a}"`)
+          .join(", ");
+        return {
+          id: def.id,
+          title: "Re-enter failed credentials",
+          description: `${credentialsImported.succeeded} of ${credentialsImported.total} credential(s) were imported automatically. The following failed and need manual re-entry: ${failedList}.`,
+          status: completionState[def.id]
+            ? ("complete" as const)
+            : ("pending" as const),
+          required: def.required,
+          helpText: `Navigate to Settings > Models & Services to re-enter the failed credential(s): ${failedList}.`,
+        };
+      }
+    }
+
+    return {
+      id: def.id,
+      title: def.title,
+      description: def.description,
+      status: completionState[def.id]
+        ? ("complete" as const)
+        : ("pending" as const),
+      required: def.required,
+      ...(def.helpText !== undefined ? { helpText: def.helpText } : {}),
+    };
+  });
 }
 
 /**
@@ -235,6 +280,7 @@ export function deriveRebindSecretsScreenState(
   completionState: RebindTaskCompletionState,
 ): RebindSecretsScreenState {
   const rebindStep = wizardState.steps["rebind-secrets"];
+  const credInfo = wizardState.credentialsImported;
 
   // Not yet accessible -- earlier steps incomplete
   if (
@@ -246,15 +292,22 @@ export function deriveRebindSecretsScreenState(
     }
   }
 
+  // Apply credential-aware completion state: if all credentials imported
+  // successfully, treat re-enter-secrets as auto-completed.
+  let effectiveCompletion = completionState;
+  if (credInfo && credInfo.total > 0 && credInfo.failed === 0) {
+    effectiveCompletion = markTaskComplete(completionState, "re-enter-secrets");
+  }
+
   // Already completed (viewing from a later step or after completion)
   if (rebindStep.status === "success") {
-    const tasks = buildTasks(completionState);
+    const tasks = buildTasks(effectiveCompletion, credInfo);
     return { phase: "complete", tasks };
   }
 
   // Active -- show the checklist
   if (wizardState.currentStep === "rebind-secrets") {
-    const tasks = buildTasks(completionState);
+    const tasks = buildTasks(effectiveCompletion, credInfo);
     const requiredTasks = tasks.filter((t) => t.required);
     const completedTasks = tasks.filter((t) => t.status === "complete");
     const requiredCompletedTasks = requiredTasks.filter(
@@ -264,7 +317,7 @@ export function deriveRebindSecretsScreenState(
     return {
       phase: "active",
       tasks,
-      allRequiredComplete: areAllRequiredTasksComplete(completionState),
+      allRequiredComplete: areAllRequiredTasksComplete(effectiveCompletion),
       completedCount: completedTasks.length,
       totalCount: tasks.length,
       requiredCount: requiredTasks.length,

--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -467,6 +467,15 @@ export async function handleMigrationImport(req: Request): Promise<Response> {
 
     // Import credentials from the bundle into CES (non-blocking — failures
     // are logged as warnings but do not fail the overall import).
+    let credentialsImported:
+      | {
+          total: number;
+          succeeded: number;
+          failed: number;
+          failedAccounts: string[];
+        }
+      | undefined;
+
     if (validation.entries) {
       const bundleCredentials = extractCredentialsFromBundle(
         validation.entries,
@@ -474,21 +483,27 @@ export async function handleMigrationImport(req: Request): Promise<Response> {
       if (bundleCredentials.length > 0) {
         try {
           const credResults = await bulkSetSecureKeysAsync(bundleCredentials);
-          const failed = credResults.filter((r) => !r.ok);
-          if (failed.length > 0) {
+          const failedResults = credResults.filter((r) => !r.ok);
+          if (failedResults.length > 0) {
             log.warn(
-              { failed: failed.map((f) => f.account) },
+              { failed: failedResults.map((f) => f.account) },
               "Some credentials failed to import",
             );
           }
           log.info(
-            { total: bundleCredentials.length, failed: failed.length },
+            { total: bundleCredentials.length, failed: failedResults.length },
             "Credential import complete",
           );
-          const succeeded = bundleCredentials.length - failed.length;
-          if (failed.length > 0) {
+          const succeeded = bundleCredentials.length - failedResults.length;
+          credentialsImported = {
+            total: bundleCredentials.length,
+            succeeded,
+            failed: failedResults.length,
+            failedAccounts: failedResults.map((f) => f.account),
+          };
+          if (failedResults.length > 0) {
             result.report.warnings.push(
-              `Imported ${succeeded} credential(s), ${failed.length} failed`,
+              `Imported ${succeeded} credential(s), ${failedResults.length} failed`,
             );
           }
         } catch (err) {
@@ -519,7 +534,10 @@ export async function handleMigrationImport(req: Request): Promise<Response> {
       // Don't fail the import if validation itself errors
     }
 
-    return Response.json(result.report);
+    return Response.json({
+      ...result.report,
+      ...(credentialsImported ? { credentialsImported } : {}),
+    });
   } catch (err) {
     log.error({ err }, "Unexpected error during import commit");
     return httpError(


### PR DESCRIPTION
## Summary
- Include credentialsImported stats in migration import response
- Pass credential import results through migration wizard to rebind-secrets screen
- Auto-complete re-enter-secrets task when all credentials imported successfully; show targeted list on partial failure

Part of plan: cred-teleport-vbundle.md (PR 7 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24294" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
