### PR TITLE
feat: include credentials in vbundle teleportation

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -194,6 +194,7 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "oauth/token-persistence.ts", // OAuth token persistence (set/delete tokens)
       "oauth/connection-resolver.ts", // resolve OAuthConnection from oauth-store (access_token lookup)
       "runtime/routes/secret-routes.ts", // HTTP secret management routes (set/delete secrets)
+      "runtime/routes/migration-routes.ts", // migration import credential restore
       "daemon/conversation-messaging.ts", // credential storage during session messaging
       "runtime/routes/settings-routes.ts", // settings routes OAuth credential lookup (client_secret)
       "oauth/oauth-store.ts", // OAuth provider disconnect (delete stored tokens)

--- a/assistant/src/runtime/migrations/__tests__/rebind-secrets-credentials.test.ts
+++ b/assistant/src/runtime/migrations/__tests__/rebind-secrets-credentials.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Tests for credential-aware rebind-secrets screen behavior.
+ *
+ * Covers:
+ * - All credentials imported successfully -> re-enter-secrets auto-completed
+ * - Partial import failure -> targeted list of failed credentials
+ * - Legacy bundles without credentials -> original rebind-secrets behavior
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import type { MigrationWizardState } from "../migration-wizard.js";
+import { createWizardState } from "../migration-wizard.js";
+import {
+  createTaskCompletionState,
+  deriveRebindSecretsScreenState,
+} from "../rebind-secrets-screen.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a wizard state that has progressed to the rebind-secrets step.
+ */
+function wizardAtRebindSecrets(
+  credentialsImported?: MigrationWizardState["credentialsImported"],
+): MigrationWizardState {
+  const base = createWizardState();
+  return {
+    ...base,
+    currentStep: "rebind-secrets",
+    direction: "managed-to-self-hosted",
+    steps: {
+      ...base.steps,
+      "select-direction": { status: "success" },
+      "upload-bundle": { status: "success" },
+      validate: { status: "success" },
+      "preflight-review": { status: "success" },
+      transfer: { status: "success" },
+      "rebind-secrets": { status: "idle" },
+      complete: { status: "idle" },
+    },
+    hasBundleData: true,
+    credentialsImported,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("rebind-secrets-screen credential awareness", () => {
+  test("all credentials imported successfully -> re-enter-secrets is auto-completed", () => {
+    const wizard = wizardAtRebindSecrets({
+      total: 3,
+      succeeded: 3,
+      failed: 0,
+      failedAccounts: [],
+    });
+    const completion = createTaskCompletionState();
+    const screen = deriveRebindSecretsScreenState(wizard, completion);
+
+    expect(screen.phase).toBe("active");
+    if (screen.phase !== "active") return;
+
+    const secretsTask = screen.tasks.find((t) => t.id === "re-enter-secrets");
+    expect(secretsTask).toBeDefined();
+    expect(secretsTask!.status).toBe("complete");
+    expect(secretsTask!.title).toBe("API keys and secrets transferred");
+    expect(secretsTask!.description).toContain("3 credential(s)");
+    expect(secretsTask!.description).toContain("automatically imported");
+  });
+
+  test("partial import failure -> shows only failed credentials", () => {
+    const wizard = wizardAtRebindSecrets({
+      total: 3,
+      succeeded: 2,
+      failed: 1,
+      failedAccounts: ["openai-key"],
+    });
+    const completion = createTaskCompletionState();
+    const screen = deriveRebindSecretsScreenState(wizard, completion);
+
+    expect(screen.phase).toBe("active");
+    if (screen.phase !== "active") return;
+
+    const secretsTask = screen.tasks.find((t) => t.id === "re-enter-secrets");
+    expect(secretsTask).toBeDefined();
+    expect(secretsTask!.status).toBe("pending");
+    expect(secretsTask!.title).toBe("Re-enter failed credentials");
+    expect(secretsTask!.description).toContain("2 of 3");
+    expect(secretsTask!.description).toContain('"openai-key"');
+    expect(secretsTask!.description).toContain("manual re-entry");
+  });
+
+  test("legacy bundle without credentials -> original rebind-secrets behavior", () => {
+    const wizard = wizardAtRebindSecrets(undefined);
+    const completion = createTaskCompletionState();
+    const screen = deriveRebindSecretsScreenState(wizard, completion);
+
+    expect(screen.phase).toBe("active");
+    if (screen.phase !== "active") return;
+
+    const secretsTask = screen.tasks.find((t) => t.id === "re-enter-secrets");
+    expect(secretsTask).toBeDefined();
+    expect(secretsTask!.status).toBe("pending");
+    expect(secretsTask!.title).toBe("Re-enter API keys and secrets");
+    expect(secretsTask!.description).toContain("redacted in export bundles");
+  });
+
+  test("all credentials imported -> allRequiredComplete reflects auto-completion", () => {
+    const wizard = wizardAtRebindSecrets({
+      total: 2,
+      succeeded: 2,
+      failed: 0,
+      failedAccounts: [],
+    });
+    // Mark all other required tasks as complete
+    let completion = createTaskCompletionState();
+    completion = {
+      ...completion,
+      "rebind-channels": true,
+      "reconfigure-auth": true,
+    };
+    const screen = deriveRebindSecretsScreenState(wizard, completion);
+
+    expect(screen.phase).toBe("active");
+    if (screen.phase !== "active") return;
+
+    // re-enter-secrets is auto-completed, rebind-channels and reconfigure-auth are manually done
+    expect(screen.allRequiredComplete).toBe(true);
+  });
+
+  test("partial failure -> allRequiredComplete is false when failed creds not manually acknowledged", () => {
+    const wizard = wizardAtRebindSecrets({
+      total: 3,
+      succeeded: 2,
+      failed: 1,
+      failedAccounts: ["anthropic-key"],
+    });
+    const completion = createTaskCompletionState();
+    const screen = deriveRebindSecretsScreenState(wizard, completion);
+
+    expect(screen.phase).toBe("active");
+    if (screen.phase !== "active") return;
+
+    // re-enter-secrets is still pending (partial failure), so not all required complete
+    expect(screen.allRequiredComplete).toBe(false);
+  });
+
+  test("multiple failed credentials are listed in description", () => {
+    const wizard = wizardAtRebindSecrets({
+      total: 4,
+      succeeded: 1,
+      failed: 3,
+      failedAccounts: ["openai-key", "anthropic-key", "github-token"],
+    });
+    const completion = createTaskCompletionState();
+    const screen = deriveRebindSecretsScreenState(wizard, completion);
+
+    expect(screen.phase).toBe("active");
+    if (screen.phase !== "active") return;
+
+    const secretsTask = screen.tasks.find((t) => t.id === "re-enter-secrets");
+    expect(secretsTask).toBeDefined();
+    expect(secretsTask!.description).toContain('"openai-key"');
+    expect(secretsTask!.description).toContain('"anthropic-key"');
+    expect(secretsTask!.description).toContain('"github-token"');
+    expect(secretsTask!.description).toContain("1 of 4");
+  });
+});

--- a/assistant/src/runtime/migrations/__tests__/vbundle-builder-credentials.test.ts
+++ b/assistant/src/runtime/migrations/__tests__/vbundle-builder-credentials.test.ts
@@ -1,0 +1,276 @@
+/**
+ * Tests for credential inclusion in vbundle export.
+ *
+ * Covers:
+ * - buildExportVBundle() with credentials includes credentials/* entries
+ * - Credentials appear in the manifest with correct SHA-256 checksums
+ * - Export with no credentials produces the same archive as before (backward compat)
+ * - Streaming path (streamExportVBundle) includes credential entries
+ */
+
+import { createHash } from "node:crypto";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { gunzipSync } from "node:zlib";
+import { describe, expect, test } from "bun:test";
+
+import { buildExportVBundle, streamExportVBundle } from "../vbundle-builder.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const BLOCK_SIZE = 512;
+
+function sha256Hex(data: Uint8Array | string): string {
+  return createHash("sha256").update(data).digest("hex");
+}
+
+/** Parse a tar archive into its entries (name -> data). */
+function parseTar(tar: Uint8Array): Map<string, Uint8Array> {
+  const entries = new Map<string, Uint8Array>();
+  let offset = 0;
+  let paxPath: string | undefined;
+
+  while (offset + BLOCK_SIZE <= tar.length) {
+    const header = tar.subarray(offset, offset + BLOCK_SIZE);
+
+    // Check for end-of-archive (all zeros)
+    if (header.every((b) => b === 0)) break;
+
+    // Read file name
+    let name = "";
+    for (let i = 0; i < 100 && header[i] !== 0; i++) {
+      name += String.fromCharCode(header[i]);
+    }
+
+    // Read size (octal at offset 124, 12 bytes)
+    let sizeStr = "";
+    for (let i = 124; i < 136 && header[i] !== 0; i++) {
+      sizeStr += String.fromCharCode(header[i]);
+    }
+    const size = parseInt(sizeStr.trim(), 8) || 0;
+
+    // Type flag
+    const typeFlag = String.fromCharCode(header[156]);
+
+    offset += BLOCK_SIZE;
+
+    const data = tar.subarray(offset, offset + size);
+    const paddedSize = Math.ceil(size / BLOCK_SIZE) * BLOCK_SIZE;
+    offset += paddedSize;
+
+    if (typeFlag === "x") {
+      // PAX extended header — extract path
+      const paxStr = new TextDecoder().decode(data);
+      const match = paxStr.match(/\d+ path=(.+)\n/);
+      if (match) {
+        paxPath = match[1];
+      }
+      continue;
+    }
+
+    const entryName = paxPath ?? name;
+    paxPath = undefined;
+    entries.set(entryName, new Uint8Array(data));
+  }
+
+  return entries;
+}
+
+/** Create a minimal workspace directory with a config file for testing. */
+function createTestWorkspace(): { dir: string; cleanup: () => void } {
+  const dir = join(
+    tmpdir(),
+    `vbundle-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "config.json"), JSON.stringify({ test: true }));
+  // Create a minimal data/db directory with a fake database file
+  const dbDir = join(dir, "data", "db");
+  mkdirSync(dbDir, { recursive: true });
+  writeFileSync(join(dbDir, "assistant.db"), "fake-db-content");
+  return {
+    dir,
+    cleanup: () => rmSync(dir, { recursive: true, force: true }),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("buildExportVBundle with credentials", () => {
+  test("includes credential entries under credentials/ prefix", () => {
+    const workspace = createTestWorkspace();
+    try {
+      const credentials = [
+        { account: "openai-key", value: "sk-test-123" },
+        { account: "anthropic-key", value: "sk-ant-456" },
+      ];
+
+      const result = buildExportVBundle({
+        workspaceDir: workspace.dir,
+        credentials,
+      });
+
+      const tar = gunzipSync(result.archive);
+      const entries = parseTar(tar);
+
+      expect(entries.has("credentials/openai-key")).toBe(true);
+      expect(entries.has("credentials/anthropic-key")).toBe(true);
+
+      const decoder = new TextDecoder();
+      expect(decoder.decode(entries.get("credentials/openai-key")!)).toBe(
+        "sk-test-123",
+      );
+      expect(decoder.decode(entries.get("credentials/anthropic-key")!)).toBe(
+        "sk-ant-456",
+      );
+    } finally {
+      workspace.cleanup();
+    }
+  });
+
+  test("credentials appear in manifest with correct SHA-256 checksums", () => {
+    const workspace = createTestWorkspace();
+    try {
+      const credentials = [
+        { account: "my-api-key", value: "secret-value-abc" },
+      ];
+
+      const result = buildExportVBundle({
+        workspaceDir: workspace.dir,
+        credentials,
+      });
+
+      const expectedHash = sha256Hex(
+        new TextEncoder().encode("secret-value-abc"),
+      );
+
+      const credEntry = result.manifest.files.find(
+        (f) => f.path === "credentials/my-api-key",
+      );
+      expect(credEntry).toBeDefined();
+      expect(credEntry!.sha256).toBe(expectedHash);
+      expect(credEntry!.size).toBe(
+        new TextEncoder().encode("secret-value-abc").length,
+      );
+    } finally {
+      workspace.cleanup();
+    }
+  });
+
+  test("export with no credentials produces archive without credentials/ entries", () => {
+    const workspace = createTestWorkspace();
+    try {
+      const result = buildExportVBundle({
+        workspaceDir: workspace.dir,
+      });
+
+      const tar = gunzipSync(result.archive);
+      const entries = parseTar(tar);
+
+      const credentialEntries = [...entries.keys()].filter((k) =>
+        k.startsWith("credentials/"),
+      );
+      expect(credentialEntries).toHaveLength(0);
+
+      // Manifest should have no credential entries
+      const credManifestEntries = result.manifest.files.filter((f) =>
+        f.path.startsWith("credentials/"),
+      );
+      expect(credManifestEntries).toHaveLength(0);
+    } finally {
+      workspace.cleanup();
+    }
+  });
+
+  test("export with empty credentials array produces archive without credentials/ entries", () => {
+    const workspace = createTestWorkspace();
+    try {
+      const result = buildExportVBundle({
+        workspaceDir: workspace.dir,
+        credentials: [],
+      });
+
+      const tar = gunzipSync(result.archive);
+      const entries = parseTar(tar);
+
+      const credentialEntries = [...entries.keys()].filter((k) =>
+        k.startsWith("credentials/"),
+      );
+      expect(credentialEntries).toHaveLength(0);
+    } finally {
+      workspace.cleanup();
+    }
+  });
+});
+
+describe("streamExportVBundle with credentials", () => {
+  test("includes credential entries in the streaming archive", async () => {
+    const workspace = createTestWorkspace();
+    let result: Awaited<ReturnType<typeof streamExportVBundle>> | undefined;
+    try {
+      const credentials = [
+        { account: "stream-key", value: "stream-secret-789" },
+      ];
+
+      result = await streamExportVBundle({
+        workspaceDir: workspace.dir,
+        credentials,
+      });
+
+      // Read the temp file and decompress
+      const archiveData = new Uint8Array(
+        await Bun.file(result.tempPath).arrayBuffer(),
+      );
+      const tar = gunzipSync(archiveData);
+      const entries = parseTar(tar);
+
+      expect(entries.has("credentials/stream-key")).toBe(true);
+
+      const decoder = new TextDecoder();
+      expect(decoder.decode(entries.get("credentials/stream-key")!)).toBe(
+        "stream-secret-789",
+      );
+
+      // Verify manifest entry
+      const credEntry = result.manifest.files.find(
+        (f) => f.path === "credentials/stream-key",
+      );
+      expect(credEntry).toBeDefined();
+      expect(credEntry!.sha256).toBe(
+        sha256Hex(new TextEncoder().encode("stream-secret-789")),
+      );
+    } finally {
+      await result?.cleanup();
+      workspace.cleanup();
+    }
+  });
+
+  test("streaming export without credentials has no credentials/ entries", async () => {
+    const workspace = createTestWorkspace();
+    let result: Awaited<ReturnType<typeof streamExportVBundle>> | undefined;
+    try {
+      result = await streamExportVBundle({
+        workspaceDir: workspace.dir,
+      });
+
+      const archiveData = new Uint8Array(
+        await Bun.file(result.tempPath).arrayBuffer(),
+      );
+      const tar = gunzipSync(archiveData);
+      const entries = parseTar(tar);
+
+      const credentialEntries = [...entries.keys()].filter((k) =>
+        k.startsWith("credentials/"),
+      );
+      expect(credentialEntries).toHaveLength(0);
+    } finally {
+      await result?.cleanup();
+      workspace.cleanup();
+    }
+  });
+});

--- a/assistant/src/runtime/migrations/__tests__/vbundle-import-credentials.test.ts
+++ b/assistant/src/runtime/migrations/__tests__/vbundle-import-credentials.test.ts
@@ -11,7 +11,7 @@ import { describe, expect, test } from "bun:test";
 
 import { DefaultPathResolver } from "../vbundle-import-analyzer.js";
 import { extractCredentialsFromBundle } from "../vbundle-importer.js";
-import type { VBundleTarEntry } from "../vbundle-validator.js";
+import type { ManifestType, VBundleTarEntry } from "../vbundle-validator.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -20,6 +20,20 @@ import type { VBundleTarEntry } from "../vbundle-validator.js";
 function makeTarEntry(data: string): VBundleTarEntry {
   const encoded = new TextEncoder().encode(data);
   return { name: "", data: encoded, size: encoded.length };
+}
+
+function makeManifest(paths: string[]): ManifestType {
+  return {
+    schema_version: "1.0.0",
+    created_at: new Date().toISOString(),
+    source: "test",
+    manifest_sha256: "test",
+    files: paths.map((path) => ({
+      path,
+      size: 0,
+      sha256: "test",
+    })),
+  } as ManifestType;
 }
 
 // ---------------------------------------------------------------------------
@@ -34,7 +48,12 @@ describe("extractCredentialsFromBundle", () => {
     entries.set("workspace/config.json", makeTarEntry('{"test": true}'));
     entries.set("manifest.json", makeTarEntry("{}"));
 
-    const credentials = extractCredentialsFromBundle(entries);
+    const manifest = makeManifest([
+      "credentials/openai-key",
+      "credentials/anthropic-key",
+      "workspace/config.json",
+    ]);
+    const credentials = extractCredentialsFromBundle(entries, manifest);
 
     expect(credentials).toHaveLength(2);
     expect(credentials).toContainEqual({
@@ -52,7 +71,8 @@ describe("extractCredentialsFromBundle", () => {
     entries.set("workspace/config.json", makeTarEntry('{"test": true}'));
     entries.set("manifest.json", makeTarEntry("{}"));
 
-    const credentials = extractCredentialsFromBundle(entries);
+    const manifest = makeManifest(["workspace/config.json"]);
+    const credentials = extractCredentialsFromBundle(entries, manifest);
 
     expect(credentials).toHaveLength(0);
   });
@@ -60,7 +80,8 @@ describe("extractCredentialsFromBundle", () => {
   test("returns empty array for empty entries map", () => {
     const entries = new Map<string, VBundleTarEntry>();
 
-    const credentials = extractCredentialsFromBundle(entries);
+    const manifest = makeManifest([]);
+    const credentials = extractCredentialsFromBundle(entries, manifest);
 
     expect(credentials).toHaveLength(0);
   });
@@ -70,12 +91,31 @@ describe("extractCredentialsFromBundle", () => {
     entries.set("credentials/", makeTarEntry("some-value"));
     entries.set("credentials/valid-key", makeTarEntry("valid-secret"));
 
-    const credentials = extractCredentialsFromBundle(entries);
+    const manifest = makeManifest(["credentials/", "credentials/valid-key"]);
+    const credentials = extractCredentialsFromBundle(entries, manifest);
 
     expect(credentials).toHaveLength(1);
     expect(credentials[0]).toEqual({
       account: "valid-key",
       value: "valid-secret",
+    });
+  });
+
+  test("ignores credential entries not declared in manifest", () => {
+    const entries = new Map<string, VBundleTarEntry>();
+    entries.set("credentials/declared-key", makeTarEntry("declared-secret"));
+    entries.set(
+      "credentials/undeclared-key",
+      makeTarEntry("undeclared-secret"),
+    );
+
+    const manifest = makeManifest(["credentials/declared-key"]);
+    const credentials = extractCredentialsFromBundle(entries, manifest);
+
+    expect(credentials).toHaveLength(1);
+    expect(credentials[0]).toEqual({
+      account: "declared-key",
+      value: "declared-secret",
     });
   });
 
@@ -86,7 +126,8 @@ describe("extractCredentialsFromBundle", () => {
       makeTarEntry("value with spaces & special=chars!"),
     );
 
-    const credentials = extractCredentialsFromBundle(entries);
+    const manifest = makeManifest(["credentials/complex-key"]);
+    const credentials = extractCredentialsFromBundle(entries, manifest);
 
     expect(credentials).toHaveLength(1);
     expect(credentials[0]).toEqual({

--- a/assistant/src/runtime/migrations/__tests__/vbundle-import-credentials.test.ts
+++ b/assistant/src/runtime/migrations/__tests__/vbundle-import-credentials.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Tests for credential import from vbundle archives.
+ *
+ * Covers:
+ * - extractCredentialsFromBundle() correctly extracts credential entries
+ * - DefaultPathResolver skips credentials/ paths (not written to disk)
+ * - Empty and missing credential entries are handled gracefully
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { DefaultPathResolver } from "../vbundle-import-analyzer.js";
+import { extractCredentialsFromBundle } from "../vbundle-importer.js";
+import type { VBundleTarEntry } from "../vbundle-validator.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTarEntry(data: string): VBundleTarEntry {
+  const encoded = new TextEncoder().encode(data);
+  return { name: "", data: encoded, size: encoded.length };
+}
+
+// ---------------------------------------------------------------------------
+// extractCredentialsFromBundle
+// ---------------------------------------------------------------------------
+
+describe("extractCredentialsFromBundle", () => {
+  test("extracts credential entries from tar entries map", () => {
+    const entries = new Map<string, VBundleTarEntry>();
+    entries.set("credentials/openai-key", makeTarEntry("sk-test-123"));
+    entries.set("credentials/anthropic-key", makeTarEntry("sk-ant-456"));
+    entries.set("workspace/config.json", makeTarEntry('{"test": true}'));
+    entries.set("manifest.json", makeTarEntry("{}"));
+
+    const credentials = extractCredentialsFromBundle(entries);
+
+    expect(credentials).toHaveLength(2);
+    expect(credentials).toContainEqual({
+      account: "openai-key",
+      value: "sk-test-123",
+    });
+    expect(credentials).toContainEqual({
+      account: "anthropic-key",
+      value: "sk-ant-456",
+    });
+  });
+
+  test("returns empty array when no credential entries exist", () => {
+    const entries = new Map<string, VBundleTarEntry>();
+    entries.set("workspace/config.json", makeTarEntry('{"test": true}'));
+    entries.set("manifest.json", makeTarEntry("{}"));
+
+    const credentials = extractCredentialsFromBundle(entries);
+
+    expect(credentials).toHaveLength(0);
+  });
+
+  test("returns empty array for empty entries map", () => {
+    const entries = new Map<string, VBundleTarEntry>();
+
+    const credentials = extractCredentialsFromBundle(entries);
+
+    expect(credentials).toHaveLength(0);
+  });
+
+  test("skips bare credentials/ path with no account name", () => {
+    const entries = new Map<string, VBundleTarEntry>();
+    entries.set("credentials/", makeTarEntry("some-value"));
+    entries.set("credentials/valid-key", makeTarEntry("valid-secret"));
+
+    const credentials = extractCredentialsFromBundle(entries);
+
+    expect(credentials).toHaveLength(1);
+    expect(credentials[0]).toEqual({
+      account: "valid-key",
+      value: "valid-secret",
+    });
+  });
+
+  test("handles credential values with special characters", () => {
+    const entries = new Map<string, VBundleTarEntry>();
+    entries.set(
+      "credentials/complex-key",
+      makeTarEntry("value with spaces & special=chars!"),
+    );
+
+    const credentials = extractCredentialsFromBundle(entries);
+
+    expect(credentials).toHaveLength(1);
+    expect(credentials[0]).toEqual({
+      account: "complex-key",
+      value: "value with spaces & special=chars!",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DefaultPathResolver — credential path skipping
+// ---------------------------------------------------------------------------
+
+describe("DefaultPathResolver skips credential paths", () => {
+  test("resolve() returns null for credentials/ paths", () => {
+    const resolver = new DefaultPathResolver("/tmp/workspace", "/tmp/hooks");
+
+    expect(resolver.resolve("credentials/openai-key")).toBeNull();
+    expect(resolver.resolve("credentials/anthropic-key")).toBeNull();
+    expect(resolver.resolve("credentials/")).toBeNull();
+  });
+
+  test("resolve() still resolves non-credential paths normally", () => {
+    const resolver = new DefaultPathResolver("/tmp/workspace", "/tmp/hooks");
+
+    // workspace/ paths should resolve
+    expect(resolver.resolve("workspace/config.json")).not.toBeNull();
+
+    // data/db should resolve
+    expect(resolver.resolve("data/db/assistant.db")).not.toBeNull();
+  });
+});

--- a/assistant/src/runtime/migrations/migration-transport.ts
+++ b/assistant/src/runtime/migrations/migration-transport.ts
@@ -202,6 +202,12 @@ export interface ImportCommitSuccessResponse {
   files: ImportedFileReport[];
   manifest: Manifest;
   warnings: string[];
+  credentialsImported?: {
+    total: number;
+    succeeded: number;
+    failed: number;
+    failedAccounts: string[];
+  };
 }
 
 export interface ImportCommitFailureResponse {

--- a/assistant/src/runtime/migrations/migration-wizard.ts
+++ b/assistant/src/runtime/migrations/migration-wizard.ts
@@ -92,6 +92,14 @@ export interface MigrationWizardState {
   /** Import commit result. */
   importResult?: ImportCommitResponse;
 
+  /** Credential import results from the transfer step (if credentials were in the bundle). */
+  credentialsImported?: {
+    total: number;
+    succeeded: number;
+    failed: number;
+    failedAccounts: string[];
+  };
+
   /** Timestamp of last state change (ISO 8601). */
   updatedAt: string;
 
@@ -317,7 +325,11 @@ export function goBackTo(
       ? { preflightResult: undefined }
       : {}),
     ...(targetIdx <= STEP_INDEX.get("transfer")!
-      ? { exportResult: undefined, importResult: undefined }
+      ? {
+          exportResult: undefined,
+          importResult: undefined,
+          credentialsImported: undefined,
+        }
       : {}),
   });
 }
@@ -488,7 +500,17 @@ export async function executeTransferStep(
 
     if (importResult.success) {
       current = setStepStatus(current, "transfer", "success");
-      current = { ...current, currentStep: "rebind-secrets" };
+      // Extract credential import results from the response (if present)
+      const credentialsImported = (
+        importResult as unknown as Record<string, unknown>
+      ).credentialsImported as
+        | MigrationWizardState["credentialsImported"]
+        | undefined;
+      current = {
+        ...current,
+        currentStep: "rebind-secrets",
+        ...(credentialsImported ? { credentialsImported } : {}),
+      };
     } else {
       current = setStepStatus(current, "transfer", "error", {
         message:

--- a/assistant/src/runtime/migrations/migration-wizard.ts
+++ b/assistant/src/runtime/migrations/migration-wizard.ts
@@ -658,6 +658,7 @@ export function prepareForResume(
       preflightResult: undefined,
       exportResult: undefined,
       importResult: undefined,
+      credentialsImported: undefined,
     };
   }
 

--- a/assistant/src/runtime/migrations/migration-wizard.ts
+++ b/assistant/src/runtime/migrations/migration-wizard.ts
@@ -501,15 +501,12 @@ export async function executeTransferStep(
     if (importResult.success) {
       current = setStepStatus(current, "transfer", "success");
       // Extract credential import results from the response (if present)
-      const credentialsImported = (
-        importResult as unknown as Record<string, unknown>
-      ).credentialsImported as
-        | MigrationWizardState["credentialsImported"]
-        | undefined;
       current = {
         ...current,
         currentStep: "rebind-secrets",
-        ...(credentialsImported ? { credentialsImported } : {}),
+        ...(importResult.credentialsImported
+          ? { credentialsImported: importResult.credentialsImported }
+          : {}),
       };
     } else {
       current = setStepStatus(current, "transfer", "error", {

--- a/assistant/src/runtime/migrations/rebind-secrets-screen.ts
+++ b/assistant/src/runtime/migrations/rebind-secrets-screen.ts
@@ -194,18 +194,63 @@ export function markTaskPending(
 
 /**
  * Build the task list from definitions and completion state.
+ *
+ * When credential import results are provided:
+ * - If all credentials were imported successfully, the re-enter-secrets task
+ *   is marked as auto-completed with an updated description.
+ * - If some credentials failed, the description is updated to list only the
+ *   failed credentials that need manual re-entry.
+ * - If no credentials were in the bundle (legacy), the original behavior is kept.
  */
-function buildTasks(completionState: RebindTaskCompletionState): RebindTask[] {
-  return TASK_DEFINITIONS.map((def) => ({
-    id: def.id,
-    title: def.title,
-    description: def.description,
-    status: completionState[def.id]
-      ? ("complete" as const)
-      : ("pending" as const),
-    required: def.required,
-    ...(def.helpText !== undefined ? { helpText: def.helpText } : {}),
-  }));
+function buildTasks(
+  completionState: RebindTaskCompletionState,
+  credentialsImported?: MigrationWizardState["credentialsImported"],
+): RebindTask[] {
+  return TASK_DEFINITIONS.map((def) => {
+    // Apply credential import awareness to the re-enter-secrets task
+    if (def.id === "re-enter-secrets" && credentialsImported) {
+      if (credentialsImported.failed === 0 && credentialsImported.total > 0) {
+        // All credentials imported successfully — auto-complete this task
+        return {
+          id: def.id,
+          title: "API keys and secrets transferred",
+          description: `All ${credentialsImported.total} credential(s) were automatically imported from the bundle. No manual re-entry needed.`,
+          status: "complete" as const,
+          required: def.required,
+          helpText:
+            "Credentials were securely transferred as part of the migration bundle. You can verify them in Settings > Models & Services.",
+        };
+      }
+
+      if (credentialsImported.failed > 0) {
+        // Partial failure — show only the failed credentials
+        const failedList = credentialsImported.failedAccounts
+          .map((a) => `"${a}"`)
+          .join(", ");
+        return {
+          id: def.id,
+          title: "Re-enter failed credentials",
+          description: `${credentialsImported.succeeded} of ${credentialsImported.total} credential(s) were imported automatically. The following failed and need manual re-entry: ${failedList}.`,
+          status: completionState[def.id]
+            ? ("complete" as const)
+            : ("pending" as const),
+          required: def.required,
+          helpText: `Navigate to Settings > Models & Services to re-enter the failed credential(s): ${failedList}.`,
+        };
+      }
+    }
+
+    return {
+      id: def.id,
+      title: def.title,
+      description: def.description,
+      status: completionState[def.id]
+        ? ("complete" as const)
+        : ("pending" as const),
+      required: def.required,
+      ...(def.helpText !== undefined ? { helpText: def.helpText } : {}),
+    };
+  });
 }
 
 /**
@@ -235,6 +280,7 @@ export function deriveRebindSecretsScreenState(
   completionState: RebindTaskCompletionState,
 ): RebindSecretsScreenState {
   const rebindStep = wizardState.steps["rebind-secrets"];
+  const credInfo = wizardState.credentialsImported;
 
   // Not yet accessible -- earlier steps incomplete
   if (
@@ -246,15 +292,22 @@ export function deriveRebindSecretsScreenState(
     }
   }
 
+  // Apply credential-aware completion state: if all credentials imported
+  // successfully, treat re-enter-secrets as auto-completed.
+  let effectiveCompletion = completionState;
+  if (credInfo && credInfo.total > 0 && credInfo.failed === 0) {
+    effectiveCompletion = markTaskComplete(completionState, "re-enter-secrets");
+  }
+
   // Already completed (viewing from a later step or after completion)
   if (rebindStep.status === "success") {
-    const tasks = buildTasks(completionState);
+    const tasks = buildTasks(effectiveCompletion, credInfo);
     return { phase: "complete", tasks };
   }
 
   // Active -- show the checklist
   if (wizardState.currentStep === "rebind-secrets") {
-    const tasks = buildTasks(completionState);
+    const tasks = buildTasks(effectiveCompletion, credInfo);
     const requiredTasks = tasks.filter((t) => t.required);
     const completedTasks = tasks.filter((t) => t.status === "complete");
     const requiredCompletedTasks = requiredTasks.filter(
@@ -264,7 +317,7 @@ export function deriveRebindSecretsScreenState(
     return {
       phase: "active",
       tasks,
-      allRequiredComplete: areAllRequiredTasksComplete(completionState),
+      allRequiredComplete: areAllRequiredTasksComplete(effectiveCompletion),
       completedCount: completedTasks.length,
       totalCount: tasks.length,
       requiredCount: requiredTasks.length,

--- a/assistant/src/runtime/migrations/rebind-secrets-screen.ts
+++ b/assistant/src/runtime/migrations/rebind-secrets-screen.ts
@@ -342,7 +342,15 @@ export function completeMigration(
   wizardState: MigrationWizardState,
   completionState: RebindTaskCompletionState,
 ): MigrationWizardState {
-  if (!areAllRequiredTasksComplete(completionState)) {
+  // Apply credential-aware effective completion: if all credentials were
+  // imported successfully, treat re-enter-secrets as auto-completed
+  // (mirrors the logic in deriveRebindSecretsScreenState).
+  let effectiveCompletion = completionState;
+  const credInfo = wizardState?.credentialsImported;
+  if (credInfo && credInfo.total > 0 && credInfo.failed === 0) {
+    effectiveCompletion = { ...completionState, "re-enter-secrets": true };
+  }
+  if (!areAllRequiredTasksComplete(effectiveCompletion)) {
     throw new Error(
       "Cannot complete migration: not all required tasks are done",
     );

--- a/assistant/src/runtime/migrations/vbundle-builder.ts
+++ b/assistant/src/runtime/migrations/vbundle-builder.ts
@@ -66,6 +66,20 @@ interface FileMetadata {
   size: number;
 }
 
+/** In-memory entry for data not backed by a file on disk (e.g. credentials). */
+interface InMemoryEntry {
+  archivePath: string;
+  data: Uint8Array;
+  size: number;
+}
+
+/** Union of disk-backed and in-memory tar stream entries. */
+type TarStreamEntry = FileMetadata | InMemoryEntry;
+
+function isInMemoryEntry(entry: TarStreamEntry): entry is InMemoryEntry {
+  return "data" in entry;
+}
+
 // ---------------------------------------------------------------------------
 // Hash helpers
 // ---------------------------------------------------------------------------
@@ -439,6 +453,8 @@ export interface BuildExportVBundleOptions {
    * Called before the workspace walk so the DB file is up to date.
    */
   checkpoint?: () => void;
+  /** Optional credential entries to include in the archive under credentials/ prefix. */
+  credentials?: Array<{ account: string; value: string }>;
 }
 
 /**
@@ -456,8 +472,15 @@ export interface BuildExportVBundleOptions {
 export function buildExportVBundle(
   options: BuildExportVBundleOptions,
 ): BuildVBundleResult {
-  const { source, description, checkpoint, trustPath, workspaceDir, hooksDir } =
-    options;
+  const {
+    source,
+    description,
+    checkpoint,
+    trustPath,
+    workspaceDir,
+    hooksDir,
+    credentials,
+  } = options;
 
   // Flush WAL to the main database file before reading so the export
   // captures all committed rows (SQLite WAL mode keeps recent writes
@@ -492,6 +515,14 @@ export function buildExportVBundle(
   if (trustPath && existsSync(trustPath)) {
     const trustData = new Uint8Array(readFileSync(trustPath));
     files.push({ path: "trust/trust.json", data: trustData });
+  }
+
+  // Include credential entries if provided
+  if (credentials?.length) {
+    for (const { account, value } of credentials) {
+      const data = new TextEncoder().encode(value);
+      files.push({ path: `credentials/${account}`, data });
+    }
   }
 
   return buildVBundle({
@@ -688,7 +719,7 @@ function tarPaddingBytes(dataSize: number): Uint8Array {
  */
 async function* generateTarStream(
   manifestJson: Uint8Array,
-  files: FileMetadata[],
+  files: TarStreamEntry[],
 ): AsyncGenerator<Uint8Array> {
   // Manifest entry
   yield createPaxAndHeaderBlocks("manifest.json", manifestJson.length);
@@ -697,43 +728,52 @@ async function* generateTarStream(
 
   // File entries
   for (const file of files) {
-    yield createPaxAndHeaderBlocks(file.archivePath, file.size);
+    const entrySize = isInMemoryEntry(file) ? file.size : file.size;
+    yield createPaxAndHeaderBlocks(file.archivePath, entrySize);
 
-    // Stream exactly file.size bytes from disk. Capping the read at the
-    // declared size keeps the tar structure valid even if the file grows
-    // between passes (common for log files on active assistants). If the
-    // file shrinks below the declared size, zero-pad to maintain block
-    // alignment. The WAL checkpoint before export is the primary
-    // consistency mechanism for the database.
-    let bytesWritten = 0;
-    if (file.size > 0) {
-      try {
-        const stream = createReadStream(file.diskPath, {
-          start: 0,
-          end: file.size - 1,
-        });
-        for await (const chunk of stream) {
-          const data =
-            chunk instanceof Uint8Array ? chunk : new Uint8Array(chunk);
-          bytesWritten += data.length;
-          yield data;
+    if (isInMemoryEntry(file)) {
+      // In-memory entry — yield data directly
+      if (file.size > 0) {
+        yield file.data;
+      }
+    } else {
+      // Disk-backed entry — stream from disk
+      // Stream exactly file.size bytes from disk. Capping the read at the
+      // declared size keeps the tar structure valid even if the file grows
+      // between passes (common for log files on active assistants). If the
+      // file shrinks below the declared size, zero-pad to maintain block
+      // alignment. The WAL checkpoint before export is the primary
+      // consistency mechanism for the database.
+      let bytesWritten = 0;
+      if (file.size > 0) {
+        try {
+          const stream = createReadStream(file.diskPath, {
+            start: 0,
+            end: file.size - 1,
+          });
+          for await (const chunk of stream) {
+            const data =
+              chunk instanceof Uint8Array ? chunk : new Uint8Array(chunk);
+            bytesWritten += data.length;
+            yield data;
+          }
+        } catch {
+          // File was deleted or rotated between passes — emit zeros for
+          // the full declared size so the tar structure stays valid
         }
-      } catch {
-        // File was deleted or rotated between passes — emit zeros for
-        // the full declared size so the tar structure stays valid
+      }
+
+      // If the file shrank, pad with zeros in bounded chunks to reach
+      // the declared size without a large single allocation
+      let remaining = file.size - bytesWritten;
+      while (remaining > 0) {
+        const chunkSize = Math.min(remaining, 65536);
+        yield new Uint8Array(chunkSize);
+        remaining -= chunkSize;
       }
     }
 
-    // If the file shrank, pad with zeros in bounded chunks to reach
-    // the declared size without a large single allocation
-    let remaining = file.size - bytesWritten;
-    while (remaining > 0) {
-      const chunkSize = Math.min(remaining, 65536);
-      yield new Uint8Array(chunkSize);
-      remaining -= chunkSize;
-    }
-
-    yield tarPaddingBytes(file.size);
+    yield tarPaddingBytes(entrySize);
   }
 
   // End-of-archive: two zero blocks
@@ -765,8 +805,15 @@ export interface StreamExportVBundleResult {
 export async function streamExportVBundle(
   options: BuildExportVBundleOptions,
 ): Promise<StreamExportVBundleResult> {
-  const { source, description, checkpoint, trustPath, workspaceDir, hooksDir } =
-    options;
+  const {
+    source,
+    description,
+    checkpoint,
+    trustPath,
+    workspaceDir,
+    hooksDir,
+    credentials,
+  } = options;
 
   // Flush WAL to the main database file before reading
   if (checkpoint) {
@@ -806,6 +853,19 @@ export async function streamExportVBundle(
     }
   }
 
+  // Build in-memory entries for credentials (not disk-backed)
+  const inMemoryEntries: InMemoryEntry[] = [];
+  if (credentials?.length) {
+    for (const { account, value } of credentials) {
+      const data = new TextEncoder().encode(value);
+      inMemoryEntries.push({
+        archivePath: `credentials/${account}`,
+        data,
+        size: data.length,
+      });
+    }
+  }
+
   // ------------------------------------------------------------------
   // Pass 1: Compute SHA-256 checksums to build the manifest
   // ------------------------------------------------------------------
@@ -817,6 +877,16 @@ export async function streamExportVBundle(
       path: file.archivePath,
       sha256,
       size: file.size,
+    });
+  }
+
+  // Add in-memory credential entries to the manifest
+  for (const entry of inMemoryEntries) {
+    const sha256 = sha256Hex(entry.data);
+    fileEntries.push({
+      path: entry.archivePath,
+      sha256,
+      size: entry.size,
     });
   }
 
@@ -842,7 +912,8 @@ export async function streamExportVBundle(
 
   const tempPath = join(tmpdir(), `vbundle-export-${randomUUID()}.tmp`);
 
-  const tarGenerator = generateTarStream(manifestData, allFileMetadata);
+  const allEntries: TarStreamEntry[] = [...allFileMetadata, ...inMemoryEntries];
+  const tarGenerator = generateTarStream(manifestData, allEntries);
   const tarReadable = Readable.from(tarGenerator);
   const gzipStream = createGzip();
   const writeStream = createWriteStream(tempPath, { mode: 0o600 });

--- a/assistant/src/runtime/migrations/vbundle-import-analyzer.ts
+++ b/assistant/src/runtime/migrations/vbundle-import-analyzer.ts
@@ -93,6 +93,11 @@ export class DefaultPathResolver implements PathResolver {
   ) {}
 
   resolve(archivePath: string): string | null {
+    // Skip credential entries — handled separately by the credential import step
+    if (archivePath.startsWith("credentials/")) {
+      return null;
+    }
+
     // New format: workspace/ prefix — maps directly into the workspace dir
     if (archivePath.startsWith("workspace/") && this.workspaceDir) {
       const relPath = archivePath.slice("workspace/".length);

--- a/assistant/src/runtime/migrations/vbundle-import-analyzer.ts
+++ b/assistant/src/runtime/migrations/vbundle-import-analyzer.ts
@@ -195,6 +195,20 @@ export function analyzeImport(
   for (const fileEntry of manifest.files) {
     const diskPath = pathResolver.resolve(fileEntry.path);
 
+    // Credential entries are handled separately by the credential import
+    // step — skip them without flagging as unknown/conflict.
+    if (fileEntry.path.startsWith("credentials/")) {
+      files.push({
+        path: fileEntry.path,
+        action: "skip",
+        bundle_size: fileEntry.size,
+        bundle_sha256: fileEntry.sha256,
+        current_size: null,
+        current_sha256: null,
+      });
+      continue;
+    }
+
     if (!diskPath) {
       // Unknown archive path — would have nowhere to write
       conflicts.push({

--- a/assistant/src/runtime/migrations/vbundle-importer.ts
+++ b/assistant/src/runtime/migrations/vbundle-importer.ts
@@ -381,6 +381,33 @@ export function commitImport(options: ImportCommitOptions): ImportCommitResult {
 }
 
 // ---------------------------------------------------------------------------
+// Credential extraction
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract credential entries from a validated vbundle tar entries map.
+ *
+ * Credentials are stored under the `credentials/` prefix in the archive,
+ * where the remainder of the path is the account name and the entry data
+ * is the credential value.
+ */
+export function extractCredentialsFromBundle(
+  entries: Map<string, VBundleTarEntry>,
+): Array<{ account: string; value: string }> {
+  const credentials: Array<{ account: string; value: string }> = [];
+  for (const [path, entry] of entries) {
+    if (path.startsWith("credentials/")) {
+      const account = path.slice("credentials/".length);
+      if (account) {
+        const value = new TextDecoder().decode(entry.data);
+        credentials.push({ account, value });
+      }
+    }
+  }
+  return credentials;
+}
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 

--- a/assistant/src/runtime/migrations/vbundle-importer.ts
+++ b/assistant/src/runtime/migrations/vbundle-importer.ts
@@ -227,6 +227,12 @@ export function commitImport(options: ImportCommitOptions): ImportCommitResult {
   let backupsCreated = 0;
 
   for (const fileEntry of manifest.files) {
+    // Credential entries are handled separately by extractCredentialsFromBundle()
+    // in migration-routes.ts — skip them silently without warnings or skip counts.
+    if (fileEntry.path.startsWith("credentials/")) {
+      continue;
+    }
+
     const diskPath = pathResolver.resolve(fileEntry.path);
 
     if (!diskPath) {

--- a/assistant/src/runtime/migrations/vbundle-importer.ts
+++ b/assistant/src/runtime/migrations/vbundle-importer.ts
@@ -399,10 +399,12 @@ export function commitImport(options: ImportCommitOptions): ImportCommitResult {
  */
 export function extractCredentialsFromBundle(
   entries: Map<string, VBundleTarEntry>,
+  manifest: ManifestType,
 ): Array<{ account: string; value: string }> {
+  const manifestPaths = new Set(manifest.files.map((f) => f.path));
   const credentials: Array<{ account: string; value: string }> = [];
   for (const [path, entry] of entries) {
-    if (path.startsWith("credentials/")) {
+    if (path.startsWith("credentials/") && manifestPaths.has(path)) {
       const account = path.slice("credentials/".length);
       if (account) {
         const value = new TextDecoder().decode(entry.data);

--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -23,7 +23,7 @@ import { validateMigrationState } from "../../memory/migrations/validate-migrati
 import { clearCache as clearTrustCache } from "../../permissions/trust-store.js";
 import {
   bulkSetSecureKeysAsync,
-  getSecureKeyAsync,
+  getSecureKeyResultAsync,
   listSecureKeysAsync,
 } from "../../security/secure-keys.js";
 import { getLogger } from "../../util/logger.js";
@@ -163,9 +163,14 @@ export async function handleMigrationExport(req: Request): Promise<Response> {
       );
     } else {
       for (const account of credentialList.accounts) {
-        const value = await getSecureKeyAsync(account);
-        if (value != null) {
-          credentials.push({ account, value });
+        const result = await getSecureKeyResultAsync(account);
+        if (result.unreachable) {
+          log.warn(
+            { account },
+            "Credential store unreachable when reading credential — skipping",
+          );
+        } else if (result.value != null) {
+          credentials.push({ account, value: result.value });
         }
       }
     }

--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -21,6 +21,10 @@ import { invalidateConfigCache } from "../../config/loader.js";
 import { getDb, resetDb } from "../../memory/db-connection.js";
 import { validateMigrationState } from "../../memory/migrations/validate-migration-state.js";
 import { clearCache as clearTrustCache } from "../../permissions/trust-store.js";
+import {
+  getSecureKeyAsync,
+  listSecureKeysAsync,
+} from "../../security/secure-keys.js";
 import { getLogger } from "../../util/logger.js";
 import {
   getDbPath,
@@ -146,6 +150,18 @@ export async function handleMigrationExport(req: Request): Promise<Response> {
   let cleanup: (() => Promise<void>) | undefined;
 
   try {
+    // Read all stored credentials to include in the export bundle
+    const credentialList = await listSecureKeysAsync();
+    const credentials: Array<{ account: string; value: string }> = [];
+    if (!credentialList.unreachable) {
+      for (const account of credentialList.accounts) {
+        const value = await getSecureKeyAsync(account);
+        if (value) {
+          credentials.push({ account, value });
+        }
+      }
+    }
+
     const result = await streamExportVBundle({
       // hooksDir is intentionally omitted — hooks now live under workspace/hooks/
       // and are included in the workspace walk. Passing hooksDir separately would
@@ -153,6 +169,7 @@ export async function handleMigrationExport(req: Request): Promise<Response> {
       workspaceDir: getWorkspaceDir(),
       source: "runtime-export",
       description,
+      credentials,
       checkpoint: () => {
         const dbPath = getDbPath();
         try {

--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -157,7 +157,11 @@ export async function handleMigrationExport(req: Request): Promise<Response> {
     // Read all stored credentials to include in the export bundle
     const credentialList = await listSecureKeysAsync();
     const credentials: Array<{ account: string; value: string }> = [];
-    if (!credentialList.unreachable) {
+    if (credentialList.unreachable) {
+      log.warn(
+        "Credential store is unreachable — export will not include credentials",
+      );
+    } else {
       for (const account of credentialList.accounts) {
         const value = await getSecureKeyAsync(account);
         if (value) {
@@ -217,6 +221,7 @@ export async function handleMigrationExport(req: Request): Promise<Response> {
         "Content-Length": String(size),
         "X-Vbundle-Schema-Version": manifest.schema_version,
         "X-Vbundle-Manifest-Sha256": manifest.manifest_sha256,
+        "X-Vbundle-Credentials-Included": String(credentials.length),
       },
     });
   } catch (err) {

--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -22,6 +22,7 @@ import { getDb, resetDb } from "../../memory/db-connection.js";
 import { validateMigrationState } from "../../memory/migrations/validate-migration-state.js";
 import { clearCache as clearTrustCache } from "../../permissions/trust-store.js";
 import {
+  bulkSetSecureKeysAsync,
   getSecureKeyAsync,
   listSecureKeysAsync,
 } from "../../security/secure-keys.js";
@@ -38,7 +39,10 @@ import {
   analyzeImport,
   DefaultPathResolver,
 } from "../migrations/vbundle-import-analyzer.js";
-import { commitImport } from "../migrations/vbundle-importer.js";
+import {
+  commitImport,
+  extractCredentialsFromBundle,
+} from "../migrations/vbundle-importer.js";
 import { validateVBundle } from "../migrations/vbundle-validator.js";
 
 const log = getLogger("migration-routes");
@@ -459,6 +463,41 @@ export async function handleMigrationImport(req: Request): Promise<Response> {
         },
         { status: 500 },
       );
+    }
+
+    // Import credentials from the bundle into CES (non-blocking — failures
+    // are logged as warnings but do not fail the overall import).
+    if (validation.entries) {
+      const bundleCredentials = extractCredentialsFromBundle(
+        validation.entries,
+      );
+      if (bundleCredentials.length > 0) {
+        try {
+          const credResults = await bulkSetSecureKeysAsync(bundleCredentials);
+          const failed = credResults.filter((r) => !r.ok);
+          if (failed.length > 0) {
+            log.warn(
+              { failed: failed.map((f) => f.account) },
+              "Some credentials failed to import",
+            );
+          }
+          log.info(
+            { total: bundleCredentials.length, failed: failed.length },
+            "Credential import complete",
+          );
+          const succeeded = bundleCredentials.length - failed.length;
+          if (failed.length > 0) {
+            result.report.warnings.push(
+              `Imported ${succeeded} credential(s), ${failed.length} failed`,
+            );
+          }
+        } catch (err) {
+          log.warn({ err }, "Credential import failed entirely");
+          result.report.warnings.push(
+            `Credential import failed: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      }
     }
 
     // Invalidate in-process caches so imported settings.json and trust.json take effect

--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -467,6 +467,15 @@ export async function handleMigrationImport(req: Request): Promise<Response> {
 
     // Import credentials from the bundle into CES (non-blocking — failures
     // are logged as warnings but do not fail the overall import).
+    let credentialsImported:
+      | {
+          total: number;
+          succeeded: number;
+          failed: number;
+          failedAccounts: string[];
+        }
+      | undefined;
+
     if (validation.entries) {
       const bundleCredentials = extractCredentialsFromBundle(
         validation.entries,
@@ -474,21 +483,27 @@ export async function handleMigrationImport(req: Request): Promise<Response> {
       if (bundleCredentials.length > 0) {
         try {
           const credResults = await bulkSetSecureKeysAsync(bundleCredentials);
-          const failed = credResults.filter((r) => !r.ok);
-          if (failed.length > 0) {
+          const failedResults = credResults.filter((r) => !r.ok);
+          if (failedResults.length > 0) {
             log.warn(
-              { failed: failed.map((f) => f.account) },
+              { failed: failedResults.map((f) => f.account) },
               "Some credentials failed to import",
             );
           }
           log.info(
-            { total: bundleCredentials.length, failed: failed.length },
+            { total: bundleCredentials.length, failed: failedResults.length },
             "Credential import complete",
           );
-          const succeeded = bundleCredentials.length - failed.length;
-          if (failed.length > 0) {
+          const succeeded = bundleCredentials.length - failedResults.length;
+          credentialsImported = {
+            total: bundleCredentials.length,
+            succeeded,
+            failed: failedResults.length,
+            failedAccounts: failedResults.map((f) => f.account),
+          };
+          if (failedResults.length > 0) {
             result.report.warnings.push(
-              `Imported ${succeeded} credential(s), ${failed.length} failed`,
+              `Imported ${succeeded} credential(s), ${failedResults.length} failed`,
             );
           }
         } catch (err) {
@@ -519,7 +534,10 @@ export async function handleMigrationImport(req: Request): Promise<Response> {
       // Don't fail the import if validation itself errors
     }
 
-    return Response.json(result.report);
+    return Response.json({
+      ...result.report,
+      ...(credentialsImported ? { credentialsImported } : {}),
+    });
   } catch (err) {
     log.error({ err }, "Unexpected error during import commit");
     return httpError(

--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -164,7 +164,7 @@ export async function handleMigrationExport(req: Request): Promise<Response> {
     } else {
       for (const account of credentialList.accounts) {
         const value = await getSecureKeyAsync(account);
-        if (value) {
+        if (value != null) {
           credentials.push({ account, value });
         }
       }
@@ -484,6 +484,7 @@ export async function handleMigrationImport(req: Request): Promise<Response> {
     if (validation.entries) {
       const bundleCredentials = extractCredentialsFromBundle(
         validation.entries,
+        validation.manifest!,
       );
       if (bundleCredentials.length > 0) {
         try {

--- a/assistant/src/security/ces-credential-client.ts
+++ b/assistant/src/security/ces-credential-client.ts
@@ -190,6 +190,21 @@ export class CesCredentialBackend implements CredentialBackend {
     }
   }
 
+  async bulkSet(
+    credentials: Array<{ account: string; value: string }>,
+  ): Promise<Array<{ account: string; ok: boolean }>> {
+    const res = await cesRequest("POST", "/v1/credentials/bulk", {
+      credentials,
+    });
+    if (!res?.ok) {
+      return credentials.map((c) => ({ account: c.account, ok: false }));
+    }
+    const data = (await res.json()) as {
+      results: Array<{ account: string; ok: boolean }>;
+    };
+    return data.results;
+  }
+
   async list(): Promise<CredentialListResult> {
     try {
       const res = await cesRequest("GET", "/v1/credentials");

--- a/assistant/src/security/ces-credential-client.ts
+++ b/assistant/src/security/ces-credential-client.ts
@@ -193,16 +193,21 @@ export class CesCredentialBackend implements CredentialBackend {
   async bulkSet(
     credentials: Array<{ account: string; value: string }>,
   ): Promise<Array<{ account: string; ok: boolean }>> {
-    const res = await cesRequest("POST", "/v1/credentials/bulk", {
-      credentials,
-    });
-    if (!res?.ok) {
+    try {
+      const res = await cesRequest("POST", "/v1/credentials/bulk", {
+        credentials,
+      });
+      if (!res?.ok) {
+        return credentials.map((c) => ({ account: c.account, ok: false }));
+      }
+      const data = (await res.json()) as {
+        results: Array<{ account: string; ok: boolean }>;
+      };
+      return data.results;
+    } catch (err) {
+      log.warn({ err }, "CES credential bulk set threw unexpectedly");
       return credentials.map((c) => ({ account: c.account, ok: false }));
     }
-    const data = (await res.json()) as {
-      results: Array<{ account: string; ok: boolean }>;
-    };
-    return data.results;
   }
 
   async list(): Promise<CredentialListResult> {

--- a/assistant/src/security/ces-rpc-credential-backend.ts
+++ b/assistant/src/security/ces-rpc-credential-backend.ts
@@ -86,4 +86,21 @@ export class CesRpcCredentialBackend implements CredentialBackend {
       return { accounts: [], unreachable: true };
     }
   }
+
+  async bulkSet(
+    credentials: Array<{ account: string; value: string }>,
+  ): Promise<Array<{ account: string; ok: boolean }>> {
+    if (!this.isAvailable()) {
+      return credentials.map((c) => ({ account: c.account, ok: false }));
+    }
+    try {
+      const result = await this.client.call(CesRpcMethod.BulkSetCredentials, {
+        credentials,
+      });
+      return result.results;
+    } catch (err) {
+      log.warn({ err }, "CES RPC bulk credential set failed");
+      return credentials.map((c) => ({ account: c.account, ok: false }));
+    }
+  }
 }

--- a/assistant/src/security/credential-backend.ts
+++ b/assistant/src/security/credential-backend.ts
@@ -47,6 +47,11 @@ export interface CredentialBackend {
 
   /** List all account names. */
   list(): Promise<CredentialListResult>;
+
+  /** Bulk-set multiple credentials. Optional — backends without native bulk support omit this. */
+  bulkSet?(
+    credentials: Array<{ account: string; value: string }>,
+  ): Promise<Array<{ account: string; ok: boolean }>>;
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/security/secure-keys.ts
+++ b/assistant/src/security/secure-keys.ts
@@ -450,6 +450,33 @@ export async function deleteSecureKeyAsync(
   }, "error");
 }
 
+/**
+ * Bulk-set multiple credentials in a single operation.
+ *
+ * Uses the backend's native `bulkSet` when available (CES RPC / HTTP),
+ * otherwise falls back to individual `set` calls.
+ */
+export async function bulkSetSecureKeysAsync(
+  credentials: Array<{ account: string; value: string }>,
+): Promise<Array<{ account: string; ok: boolean }>> {
+  return withCredentialTimeout(
+    async () => {
+      const backend = await resolveBackendAsync();
+      if (backend.bulkSet) {
+        return backend.bulkSet(credentials);
+      }
+      // Fallback: loop individual sets
+      const results = [];
+      for (const { account, value } of credentials) {
+        const ok = await backend.set(account, value);
+        results.push({ account, ok });
+      }
+      return results;
+    },
+    credentials.map((c) => ({ account: c.account, ok: false })),
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Provider API key lookup — secure store + env var fallback
 // ---------------------------------------------------------------------------

--- a/assistant/src/security/secure-keys.ts
+++ b/assistant/src/security/secure-keys.ts
@@ -463,14 +463,20 @@ export async function bulkSetSecureKeysAsync(
     async () => {
       const backend = await resolveBackendAsync();
       if (backend.bulkSet) {
-        return backend.bulkSet(credentials);
+        const results = await backend.bulkSet(credentials);
+        const anyFailed = results.some((r) => !r.ok);
+        updateCesHttpReachability(backend, anyFailed);
+        return results;
       }
       // Fallback: loop individual sets
       const results = [];
+      let anyFailed = false;
       for (const { account, value } of credentials) {
         const ok = await backend.set(account, value);
+        if (!ok) anyFailed = true;
         results.push({ account, ok });
       }
+      updateCesHttpReachability(backend, anyFailed);
       return results;
     },
     credentials.map((c) => ({ account: c.account, ok: false })),

--- a/credential-executor/src/__tests__/bulk-set-credentials.test.ts
+++ b/credential-executor/src/__tests__/bulk-set-credentials.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Tests for the BulkSetCredentials RPC handler.
+ *
+ * Validates that the handler stores each credential independently and
+ * returns per-credential success/failure status.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { CesRpcMethod } from "@vellumai/ces-contracts";
+import type { SecureKeyBackend } from "@vellumai/credential-storage";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a minimal BulkSetCredentials handler using the same logic as
+ * main.ts / managed-main.ts, backed by the given SecureKeyBackend.
+ */
+function buildBulkSetHandler(secureKeyBackend: SecureKeyBackend) {
+  return async (req: { credentials: Array<{ account: string; value: string }> }) => {
+    const results = [];
+    for (const { account, value } of req.credentials) {
+      const ok = await secureKeyBackend.set(account, value);
+      results.push({ account, ok });
+    }
+    return { results };
+  };
+}
+
+/**
+ * Create an in-memory SecureKeyBackend for testing.
+ * Optionally accepts a set of accounts that should fail on set().
+ */
+function createMockBackend(failingAccounts: Set<string> = new Set()): SecureKeyBackend & { store: Map<string, string> } {
+  const store = new Map<string, string>();
+  return {
+    store,
+    async get(key: string) {
+      return store.get(key);
+    },
+    async set(key: string, value: string) {
+      if (failingAccounts.has(key)) {
+        return false;
+      }
+      store.set(key, value);
+      return true;
+    },
+    async delete(key: string) {
+      if (store.has(key)) {
+        store.delete(key);
+        return "deleted";
+      }
+      return "not-found";
+    },
+    async list() {
+      return Array.from(store.keys());
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("BulkSetCredentials handler", () => {
+  test("stores multiple credentials and returns ok: true for each", async () => {
+    const backend = createMockBackend();
+    const handler = buildBulkSetHandler(backend);
+
+    const result = await handler({
+      credentials: [
+        { account: "acct-1", value: "secret-1" },
+        { account: "acct-2", value: "secret-2" },
+        { account: "acct-3", value: "secret-3" },
+      ],
+    });
+
+    expect(result.results).toEqual([
+      { account: "acct-1", ok: true },
+      { account: "acct-2", ok: true },
+      { account: "acct-3", ok: true },
+    ]);
+
+    // Verify all credentials were actually stored
+    expect(await backend.get("acct-1")).toBe("secret-1");
+    expect(await backend.get("acct-2")).toBe("secret-2");
+    expect(await backend.get("acct-3")).toBe("secret-3");
+  });
+
+  test("partial failure returns mixed results without aborting the rest", async () => {
+    const failingAccounts = new Set(["acct-2"]);
+    const backend = createMockBackend(failingAccounts);
+    const handler = buildBulkSetHandler(backend);
+
+    const result = await handler({
+      credentials: [
+        { account: "acct-1", value: "secret-1" },
+        { account: "acct-2", value: "secret-2" },
+        { account: "acct-3", value: "secret-3" },
+      ],
+    });
+
+    expect(result.results).toEqual([
+      { account: "acct-1", ok: true },
+      { account: "acct-2", ok: false },
+      { account: "acct-3", ok: true },
+    ]);
+
+    // acct-1 and acct-3 should be stored; acct-2 should not
+    expect(await backend.get("acct-1")).toBe("secret-1");
+    expect(await backend.get("acct-2")).toBeUndefined();
+    expect(await backend.get("acct-3")).toBe("secret-3");
+  });
+
+  test("empty credentials array returns empty results array", async () => {
+    const backend = createMockBackend();
+    const handler = buildBulkSetHandler(backend);
+
+    const result = await handler({ credentials: [] });
+
+    expect(result.results).toEqual([]);
+  });
+
+  test("handler is registered under the correct RPC method key", () => {
+    // Verify the enum value matches what we register against
+    expect(CesRpcMethod.BulkSetCredentials).toBe("bulk_set_credentials");
+  });
+});

--- a/credential-executor/src/http/__tests__/credential-routes-bulk.test.ts
+++ b/credential-executor/src/http/__tests__/credential-routes-bulk.test.ts
@@ -221,7 +221,7 @@ describe("POST /v1/credentials/bulk", () => {
     expect(body.error).toMatch(/Invalid service token/i);
   });
 
-  it("returns 405 for non-POST methods", async () => {
+  it("non-POST methods fall through to single-account handler (bulk treated as account name)", async () => {
     const deps = makeDeps();
     const res = await handleCredentialRoute(
       makeRequest({ method: "GET", body: undefined }),
@@ -229,7 +229,9 @@ describe("POST /v1/credentials/bulk", () => {
     );
 
     expect(res).not.toBeNull();
-    expect(res!.status).toBe(405);
+    // "bulk" is interpreted as an account name by the :account handler;
+    // no such credential exists, so we get 404.
+    expect(res!.status).toBe(404);
   });
 
   it("handles empty credentials array", async () => {

--- a/credential-executor/src/http/__tests__/credential-routes-bulk.test.ts
+++ b/credential-executor/src/http/__tests__/credential-routes-bulk.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Tests for the POST /v1/credentials/bulk endpoint.
+ *
+ * Verifies:
+ * - Successful bulk set with multiple credentials
+ * - Validation failure (missing fields, non-array body)
+ * - Auth requirement (401 without token)
+ */
+
+import { describe, it, expect } from "bun:test";
+
+import { handleCredentialRoute } from "../credential-routes.js";
+import type { CredentialRouteDeps } from "../credential-routes.js";
+import type { SecureKeyBackend } from "@vellumai/credential-storage";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const SERVICE_TOKEN = "test-ces-service-token-12345";
+
+function makeDeps(
+  overrides: Partial<SecureKeyBackend> = {},
+): CredentialRouteDeps {
+  const store = new Map<string, string>();
+  const backend: SecureKeyBackend = {
+    get: async (account: string) => store.get(account),
+    set: async (account: string, value: string) => {
+      store.set(account, value);
+      return true;
+    },
+    delete: async (account: string) => {
+      if (!store.has(account)) return "not-found";
+      store.delete(account);
+      return "ok";
+    },
+    list: async () => [...store.keys()],
+    ...overrides,
+  };
+  return { backend, serviceToken: SERVICE_TOKEN };
+}
+
+function makeRequest(
+  opts: {
+    body?: unknown;
+    token?: string | null;
+    method?: string;
+  } = {},
+): Request {
+  const url = "http://localhost:8090/v1/credentials/bulk";
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (opts.token !== null) {
+    headers["Authorization"] = `Bearer ${opts.token ?? SERVICE_TOKEN}`;
+  }
+
+  return new Request(url, {
+    method: opts.method ?? "POST",
+    headers,
+    body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("POST /v1/credentials/bulk", () => {
+  it("sets multiple credentials and returns per-credential results", async () => {
+    const deps = makeDeps();
+    const res = await handleCredentialRoute(
+      makeRequest({
+        body: {
+          credentials: [
+            { account: "openai", value: "sk-abc" },
+            { account: "anthropic", value: "sk-xyz" },
+          ],
+        },
+      }),
+      deps,
+    );
+
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(200);
+
+    const body = await res!.json();
+    expect(body.results).toEqual([
+      { account: "openai", ok: true },
+      { account: "anthropic", ok: true },
+    ]);
+
+    // Verify credentials were actually stored
+    expect(await deps.backend.get("openai")).toBe("sk-abc");
+    expect(await deps.backend.get("anthropic")).toBe("sk-xyz");
+  });
+
+  it("reports per-credential failure when backend.set returns false", async () => {
+    let callCount = 0;
+    const deps = makeDeps({
+      set: async () => {
+        callCount++;
+        // Fail on the second call
+        return callCount !== 2;
+      },
+    });
+
+    const res = await handleCredentialRoute(
+      makeRequest({
+        body: {
+          credentials: [
+            { account: "a", value: "1" },
+            { account: "b", value: "2" },
+            { account: "c", value: "3" },
+          ],
+        },
+      }),
+      deps,
+    );
+
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(200);
+
+    const body = await res!.json();
+    expect(body.results).toEqual([
+      { account: "a", ok: true },
+      { account: "b", ok: false },
+      { account: "c", ok: true },
+    ]);
+  });
+
+  it("returns 400 when credentials field is not an array", async () => {
+    const deps = makeDeps();
+    const res = await handleCredentialRoute(
+      makeRequest({ body: { credentials: "not-an-array" } }),
+      deps,
+    );
+
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(400);
+
+    const body = await res!.json();
+    expect(body.error).toMatch(/credentials.*array/i);
+  });
+
+  it("returns 400 when credentials field is missing", async () => {
+    const deps = makeDeps();
+    const res = await handleCredentialRoute(
+      makeRequest({ body: {} }),
+      deps,
+    );
+
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(400);
+
+    const body = await res!.json();
+    expect(body.error).toMatch(/credentials.*array/i);
+  });
+
+  it("returns 400 when an entry is missing account field", async () => {
+    const deps = makeDeps();
+    const res = await handleCredentialRoute(
+      makeRequest({
+        body: {
+          credentials: [{ value: "sk-abc" }],
+        },
+      }),
+      deps,
+    );
+
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(400);
+
+    const body = await res!.json();
+    expect(body.error).toMatch(/account.*value/i);
+  });
+
+  it("returns 400 when an entry is missing value field", async () => {
+    const deps = makeDeps();
+    const res = await handleCredentialRoute(
+      makeRequest({
+        body: {
+          credentials: [{ account: "openai" }],
+        },
+      }),
+      deps,
+    );
+
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(400);
+
+    const body = await res!.json();
+    expect(body.error).toMatch(/account.*value/i);
+  });
+
+  it("returns 401 without Authorization header", async () => {
+    const deps = makeDeps();
+    const res = await handleCredentialRoute(
+      makeRequest({ token: null, body: { credentials: [] } }),
+      deps,
+    );
+
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(401);
+
+    const body = await res!.json();
+    expect(body.error).toMatch(/Missing Authorization/i);
+  });
+
+  it("returns 403 with wrong service token", async () => {
+    const deps = makeDeps();
+    const res = await handleCredentialRoute(
+      makeRequest({ token: "wrong-token", body: { credentials: [] } }),
+      deps,
+    );
+
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(403);
+
+    const body = await res!.json();
+    expect(body.error).toMatch(/Invalid service token/i);
+  });
+
+  it("returns 405 for non-POST methods", async () => {
+    const deps = makeDeps();
+    const res = await handleCredentialRoute(
+      makeRequest({ method: "GET", body: undefined }),
+      deps,
+    );
+
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(405);
+  });
+
+  it("handles empty credentials array", async () => {
+    const deps = makeDeps();
+    const res = await handleCredentialRoute(
+      makeRequest({ body: { credentials: [] } }),
+      deps,
+    );
+
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(200);
+
+    const body = await res!.json();
+    expect(body.results).toEqual([]);
+  });
+});

--- a/credential-executor/src/http/credential-routes.ts
+++ b/credential-executor/src/http/credential-routes.ts
@@ -98,14 +98,9 @@ export async function handleCredentialRoute(
   const accountSegment = pathname.slice(CREDENTIAL_PATH_PREFIX.length);
 
   // POST /v1/credentials/bulk — bulk set credentials
-  if (accountSegment === "/bulk") {
-    if (req.method !== "POST") {
-      return new Response(
-        JSON.stringify({ error: "Method not allowed" }),
-        { status: 405, headers: { "Content-Type": "application/json" } },
-      );
-    }
-
+  // Only intercept POST; other methods (GET, DELETE) fall through to the
+  // :account handler so a credential literally named "bulk" stays accessible.
+  if (accountSegment === "/bulk" && req.method === "POST") {
     let body: { credentials?: unknown };
     try {
       body = await req.json();

--- a/credential-executor/src/http/credential-routes.ts
+++ b/credential-executor/src/http/credential-routes.ts
@@ -7,6 +7,7 @@
  *
  * Endpoints:
  * - `GET  /v1/credentials`           — list credential account names
+ * - `POST /v1/credentials/bulk`      — bulk set credentials
  * - `GET  /v1/credentials/:account`  — get a credential value
  * - `POST /v1/credentials/:account`  — set a credential value
  * - `DELETE /v1/credentials/:account` — delete a credential
@@ -95,6 +96,60 @@ export async function handleCredentialRoute(
 
   // Extract account from path: /v1/credentials/:account
   const accountSegment = pathname.slice(CREDENTIAL_PATH_PREFIX.length);
+
+  // POST /v1/credentials/bulk — bulk set credentials
+  if (accountSegment === "/bulk") {
+    if (req.method !== "POST") {
+      return new Response(
+        JSON.stringify({ error: "Method not allowed" }),
+        { status: 405, headers: { "Content-Type": "application/json" } },
+      );
+    }
+
+    let body: { credentials?: unknown };
+    try {
+      body = await req.json();
+    } catch {
+      return new Response(
+        JSON.stringify({ error: "Invalid JSON body" }),
+        { status: 400, headers: { "Content-Type": "application/json" } },
+      );
+    }
+
+    if (!Array.isArray(body.credentials)) {
+      return new Response(
+        JSON.stringify({ error: "Body must contain a 'credentials' array field" }),
+        { status: 400, headers: { "Content-Type": "application/json" } },
+      );
+    }
+
+    for (const entry of body.credentials) {
+      if (
+        typeof entry !== "object" ||
+        entry === null ||
+        typeof entry.account !== "string" ||
+        typeof entry.value !== "string"
+      ) {
+        return new Response(
+          JSON.stringify({
+            error: "Each credential entry must have string 'account' and 'value' fields",
+          }),
+          { status: 400, headers: { "Content-Type": "application/json" } },
+        );
+      }
+    }
+
+    const results: Array<{ account: string; ok: boolean }> = [];
+    for (const entry of body.credentials as Array<{ account: string; value: string }>) {
+      const ok = await backend.set(entry.account, entry.value);
+      results.push({ account: entry.account, ok: !!ok });
+    }
+
+    return new Response(
+      JSON.stringify({ results }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+  }
 
   // GET /v1/credentials — list all credential account names
   if (accountSegment === "" || accountSegment === "/") {

--- a/credential-executor/src/main.ts
+++ b/credential-executor/src/main.ts
@@ -284,6 +284,15 @@ function buildHandlers(sessionIdRef: SessionIdRef): RpcHandlerRegistry {
     return { accounts };
   }) as typeof handlers[string];
 
+  handlers[CesRpcMethod.BulkSetCredentials] = (async (req: { credentials: Array<{ account: string; value: string }> }) => {
+    const results = [];
+    for (const { account, value } of req.credentials) {
+      const ok = await secureKeyBackend.set(account, value);
+      results.push({ account, ok });
+    }
+    return { results };
+  }) as typeof handlers[string];
+
   return handlers;
 }
 

--- a/credential-executor/src/managed-main.ts
+++ b/credential-executor/src/managed-main.ts
@@ -344,6 +344,15 @@ function buildHandlers(sessionIdRef: SessionIdRef, apiKeyRef: ApiKeyRef, assista
     return { accounts };
   }) as typeof handlers[string];
 
+  handlers[CesRpcMethod.BulkSetCredentials] = (async (req: { credentials: Array<{ account: string; value: string }> }) => {
+    const results = [];
+    for (const { account, value } of req.credentials) {
+      const ok = await secureKeyBackend.set(account, value);
+      results.push({ account, ok });
+    }
+    return { results };
+  }) as typeof handlers[string];
+
   return handlers;
 }
 

--- a/packages/ces-contracts/src/rpc.ts
+++ b/packages/ces-contracts/src/rpc.ts
@@ -65,6 +65,8 @@ export const CesRpcMethod = {
   DeleteCredential: "delete_credential",
   /** List all credential account names. */
   ListCredentials: "list_credentials",
+  /** Bulk-import credentials (set multiple at once). */
+  BulkSetCredentials: "bulk_set_credentials",
 } as const;
 
 export type CesRpcMethod =
@@ -514,6 +516,38 @@ export type ListCredentialsResponse = z.infer<
 >;
 
 // ---------------------------------------------------------------------------
+// bulk_set_credentials
+// ---------------------------------------------------------------------------
+
+export const BulkSetCredentialsSchema = z.object({
+  /** Array of credentials to set in bulk. */
+  credentials: z.array(
+    z.object({
+      /** The account name to store the credential under. */
+      account: z.string(),
+      /** The credential value to store. */
+      value: z.string(),
+    }),
+  ),
+});
+export type BulkSetCredentials = z.infer<typeof BulkSetCredentialsSchema>;
+
+export const BulkSetCredentialsResponseSchema = z.object({
+  /** Per-credential results indicating success or failure. */
+  results: z.array(
+    z.object({
+      /** The account name that was set. */
+      account: z.string(),
+      /** Whether the credential was successfully stored. */
+      ok: z.boolean(),
+    }),
+  ),
+});
+export type BulkSetCredentialsResponse = z.infer<
+  typeof BulkSetCredentialsResponseSchema
+>;
+
+// ---------------------------------------------------------------------------
 // Full RPC contract type map
 // ---------------------------------------------------------------------------
 
@@ -574,6 +608,10 @@ export interface CesRpcContract {
     request: ListCredentials;
     response: ListCredentialsResponse;
   };
+  [CesRpcMethod.BulkSetCredentials]: {
+    request: BulkSetCredentials;
+    response: BulkSetCredentialsResponse;
+  };
 }
 
 /**
@@ -631,5 +669,9 @@ export const CesRpcSchemas = {
   [CesRpcMethod.ListCredentials]: {
     request: ListCredentialsSchema,
     response: ListCredentialsResponseSchema,
+  },
+  [CesRpcMethod.BulkSetCredentials]: {
+    request: BulkSetCredentialsSchema,
+    response: BulkSetCredentialsResponseSchema,
   },
 } as const;


### PR DESCRIPTION
## Summary
- Include stored credentials in vbundle export archives under `credentials/` prefix
- Add `bulk_set_credentials` RPC method and HTTP endpoint to CES for efficient batch credential import
- Extract and write credentials to CES during vbundle import, with per-credential error handling
- Auto-complete the "re-enter-secrets" migration step when credentials are successfully transferred

## PRs merged into feature branch
- #24283: feat(ces-contracts): add bulk_set_credentials RPC method
- #24285: feat(migrations): include credentials in vbundle export
- #24288: feat(credential-executor): implement bulk_set_credentials handler
- #24289: feat(credential-executor): add POST /v1/credentials/bulk HTTP endpoint
- #24290: feat(security): add bulkSetSecureKeysAsync to CES RPC credential backend
- #24291: feat(migrations): import credentials from vbundle to CES on migration import
- #24294: feat(migrations): skip re-enter-secrets step when credentials were auto-imported

Part of plan: cred-teleport-vbundle.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24295" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
