### PR TITLE
fix: add credentialsImported to ImportCommitSuccessResponse type

### DIFF
--- a/assistant/src/runtime/migrations/migration-transport.ts
+++ b/assistant/src/runtime/migrations/migration-transport.ts
@@ -202,6 +202,12 @@ export interface ImportCommitSuccessResponse {
   files: ImportedFileReport[];
   manifest: Manifest;
   warnings: string[];
+  credentialsImported?: {
+    total: number;
+    succeeded: number;
+    failed: number;
+    failedAccounts: string[];
+  };
 }
 
 export interface ImportCommitFailureResponse {

--- a/assistant/src/runtime/migrations/migration-wizard.ts
+++ b/assistant/src/runtime/migrations/migration-wizard.ts
@@ -501,15 +501,12 @@ export async function executeTransferStep(
     if (importResult.success) {
       current = setStepStatus(current, "transfer", "success");
       // Extract credential import results from the response (if present)
-      const credentialsImported = (
-        importResult as unknown as Record<string, unknown>
-      ).credentialsImported as
-        | MigrationWizardState["credentialsImported"]
-        | undefined;
       current = {
         ...current,
         currentStep: "rebind-secrets",
-        ...(credentialsImported ? { credentialsImported } : {}),
+        ...(importResult.credentialsImported
+          ? { credentialsImported: importResult.credentialsImported }
+          : {}),
       };
     } else {
       current = setStepStatus(current, "transfer", "error", {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for cred-teleport-vbundle.md.

**Gap:** ImportCommitSuccessResponse type not updated
**What was expected:** Type-safe access to credentialsImported field
**What was found:** Unsafe cast required in migration-wizard.ts
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24296" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
