### PR TITLE
fix: add try/catch to CesCredentialBackend.bulkSet for consistency

### DIFF
--- a/assistant/src/security/ces-credential-client.ts
+++ b/assistant/src/security/ces-credential-client.ts
@@ -193,16 +193,21 @@ export class CesCredentialBackend implements CredentialBackend {
   async bulkSet(
     credentials: Array<{ account: string; value: string }>,
   ): Promise<Array<{ account: string; ok: boolean }>> {
-    const res = await cesRequest("POST", "/v1/credentials/bulk", {
-      credentials,
-    });
-    if (!res?.ok) {
+    try {
+      const res = await cesRequest("POST", "/v1/credentials/bulk", {
+        credentials,
+      });
+      if (!res?.ok) {
+        return credentials.map((c) => ({ account: c.account, ok: false }));
+      }
+      const data = (await res.json()) as {
+        results: Array<{ account: string; ok: boolean }>;
+      };
+      return data.results;
+    } catch (err) {
+      log.warn({ err }, "CES credential bulk set threw unexpectedly");
       return credentials.map((c) => ({ account: c.account, ok: false }));
     }
-    const data = (await res.json()) as {
-      results: Array<{ account: string; ok: boolean }>;
-    };
-    return data.results;
   }
 
   async list(): Promise<CredentialListResult> {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for cred-teleport-vbundle.md.

**Gap:** CesCredentialBackend.bulkSet lacks try/catch
**What was expected:** Consistent error handling with other methods in the class
**What was found:** Missing try/catch could leak exceptions on malformed responses
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24297" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
