### PR TITLE
feat(oauth): enable managed mode for GitHub provider

### DIFF
--- a/assistant/src/config/schemas/services.ts
+++ b/assistant/src/config/schemas/services.ts
@@ -61,6 +61,11 @@ export const LinearOAuthServiceSchema = BaseServiceSchema.extend({
 });
 export type LinearOAuthService = z.infer<typeof LinearOAuthServiceSchema>;
 
+export const GitHubOAuthServiceSchema = BaseServiceSchema.extend({
+  mode: ServiceModeSchema.default("your-own"),
+});
+export type GitHubOAuthService = z.infer<typeof GitHubOAuthServiceSchema>;
+
 export const ServicesSchema = z.object({
   inference: InferenceServiceSchema.default(InferenceServiceSchema.parse({})),
   "image-generation": ImageGenerationServiceSchema.default(
@@ -77,6 +82,9 @@ export const ServicesSchema = z.object({
   ),
   "linear-oauth": LinearOAuthServiceSchema.default(
     LinearOAuthServiceSchema.parse({}),
+  ),
+  "github-oauth": GitHubOAuthServiceSchema.default(
+    GitHubOAuthServiceSchema.parse({}),
   ),
 });
 export type Services = z.infer<typeof ServicesSchema>;

--- a/assistant/src/oauth/__tests__/seed-providers-managed.test.ts
+++ b/assistant/src/oauth/__tests__/seed-providers-managed.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+
+import { ServicesSchema } from "../../config/schemas/services.js";
+import { PROVIDER_SEED_DATA } from "../seed-providers.js";
+
+describe("PROVIDER_SEED_DATA managed mode wiring", () => {
+  test("github provider is wired up for managed mode", () => {
+    const github = PROVIDER_SEED_DATA.github;
+    expect(github).toBeDefined();
+    expect(github.managedServiceConfigKey).toBe("github-oauth");
+    expect("github-oauth" in ServicesSchema.shape).toBe(true);
+  });
+
+  test("every managedServiceConfigKey resolves to a ServicesSchema key", () => {
+    // Cross-repo invariant: a provider with managedServiceConfigKey but no
+    // matching ServicesSchema entry silently falls back to BYO mode in
+    // connection-resolver.ts. This test guards against that drift.
+    const offenders: Array<{ provider: string; key: string }> = [];
+    for (const [provider, seed] of Object.entries(PROVIDER_SEED_DATA)) {
+      const key = seed.managedServiceConfigKey;
+      if (key && !(key in ServicesSchema.shape)) {
+        offenders.push({ provider, key });
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  test("github managed service schema defaults to your-own", () => {
+    const parsed = ServicesSchema.shape["github-oauth"].parse({});
+    expect(parsed.mode).toBe("your-own");
+  });
+});

--- a/assistant/src/oauth/connection-resolver.test.ts
+++ b/assistant/src/oauth/connection-resolver.test.ts
@@ -148,6 +148,19 @@ describe("resolveOAuthConnection", () => {
     expect(result.accountInfo).toBe("user@example.com");
   });
 
+  test("returns PlatformOAuthConnection when GitHub is in managed mode", async () => {
+    mockProvider!.provider = "github";
+    mockProvider!.managedServiceConfigKey = "github-oauth";
+    (mockConfig.services as Record<string, unknown>)["github-oauth"] = {
+      mode: "managed",
+    };
+
+    const result = await resolveOAuthConnection("github");
+    expect(result).toBeInstanceOf(PlatformOAuthConnection);
+    expect(result.id).toBe("github");
+    expect(result.provider).toBe("github");
+  });
+
   test("returns BYOOAuthConnection when service config mode is your-own", async () => {
     mockProvider!.managedServiceConfigKey = "google-oauth";
     (mockConfig.services as Record<string, unknown>)["google-oauth"] = {

--- a/assistant/src/oauth/seed-providers.ts
+++ b/assistant/src/oauth/seed-providers.ts
@@ -18,7 +18,7 @@ import { seedProviders } from "./oauth-store.js";
  * fields (defaultScopes, scopePolicy) are only
  * written on initial insert and preserved across restarts.
  */
-const PROVIDER_SEED_DATA: Record<
+export const PROVIDER_SEED_DATA: Record<
   string,
   {
     provider: string;
@@ -273,6 +273,7 @@ const PROVIDER_SEED_DATA: Record<
       ],
       forbiddenScopes: ["delete_repo", "admin:org"],
     },
+    managedServiceConfigKey: "github-oauth",
     loopbackPort: 17332,
     injectionTemplates: [
       {


### PR DESCRIPTION
## Summary
- Wire `managedServiceConfigKey: "github-oauth"` on the GitHub seed entry and export `PROVIDER_SEED_DATA` for testability
- Add `GitHubOAuthServiceSchema` and `"github-oauth"` entry to `ServicesSchema` so managed-mode resolution actually engages
- Add cross-repo invariant test that guards every `managedServiceConfigKey` against silent BYO fallback, plus a GitHub-managed resolution smoke test

Part of plan: github-managed-oauth.md (PR 1 of 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24299" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
