### PR TITLE
feat(browser): migrate type/press_key/select_option/scroll to CDP

### DIFF
--- a/assistant/src/__tests__/headless-browser-interactions.test.ts
+++ b/assistant/src/__tests__/headless-browser-interactions.test.ts
@@ -9,36 +9,94 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
+/**
+ * Fake CDP session used by the tools that have been migrated to
+ * CdpClient (type, press_key, select_option, scroll). Each
+ * `session.send(method, params)` call is recorded in `sendCalls` and
+ * routed to `sendHandler`, which tests configure per-case. The
+ * handler returns either a CDP response object or an `Error` to
+ * simulate transport failure.
+ *
+ * The fake session is exposed via `mockPage.context().newCDPSession(
+ * page)` so the real `LocalCdpClient` drives it. Routing through the
+ * production client (instead of mocking the factory / cdp-client
+ * submodules) avoids polluting the global module cache that the CDP
+ * unit tests rely on.
+ */
+interface SendCall {
+  method: string;
+  params: Record<string, unknown> | undefined;
+}
+
+let sendCalls: SendCall[];
+let sendHandler: (
+  method: string,
+  params: Record<string, unknown> | undefined,
+) => unknown;
+
+function resetCdpMock() {
+  sendCalls = [];
+  sendHandler = () => ({});
+}
+
+const fakeCdpSession = {
+  send: async (method: string, params?: Record<string, unknown>) => {
+    sendCalls.push({ method, params });
+    const value = sendHandler(method, params);
+    if (value instanceof Error) throw value;
+    return value;
+  },
+  detach: async () => {},
+};
+
+/**
+ * The Playwright mock page backs two code paths:
+ *   • executeBrowserClick / executeBrowserHover drive the Playwright
+ *     `page.click` / `page.hover` methods directly.
+ *   • The CDP-migrated tools (type, press_key, select_option,
+ *     scroll) only use `page.context().newCDPSession(page)` to grab a
+ *     CDP session, which is wired to `fakeCdpSession` above.
+ */
 let mockPage: {
   click: ReturnType<typeof mock>;
-  fill: ReturnType<typeof mock>;
-  press: ReturnType<typeof mock>;
-  evaluate: ReturnType<typeof mock>;
-  title: ReturnType<typeof mock>;
-  url: ReturnType<typeof mock>;
-  goto: ReturnType<typeof mock>;
-  selectOption: ReturnType<typeof mock>;
   hover: ReturnType<typeof mock>;
   close: () => Promise<void>;
   isClosed: () => boolean;
-  keyboard: { press: ReturnType<typeof mock> };
-  mouse: { wheel: ReturnType<typeof mock>; move: ReturnType<typeof mock> };
+  context: () => {
+    newCDPSession: (page: unknown) => Promise<typeof fakeCdpSession>;
+  };
 };
 
-let snapshotMaps: Map<string, Map<string, string>>;
+let snapshotStringMaps: Map<string, Map<string, string>>;
+let snapshotBackendNodeMaps: Map<string, Map<string, number>>;
 
 mock.module("../tools/browser/browser-manager.js", () => {
-  snapshotMaps = new Map();
+  snapshotStringMaps = new Map();
+  snapshotBackendNodeMaps = new Map();
   return {
     browserManager: {
       getOrCreateSessionPage: async () => mockPage,
       closeSessionPage: async () => {},
       closeAllPages: async () => {},
       storeSnapshotMap: (conversationId: string, map: Map<string, string>) => {
-        snapshotMaps.set(conversationId, map);
+        snapshotStringMaps.set(conversationId, map);
+      },
+      storeSnapshotBackendNodeMap: (
+        conversationId: string,
+        map: Map<string, number>,
+      ) => {
+        snapshotBackendNodeMaps.set(conversationId, map);
       },
       resolveSnapshotSelector: (conversationId: string, elementId: string) => {
-        const map = snapshotMaps.get(conversationId);
+        const map = snapshotStringMaps.get(conversationId);
+        if (!map) return null;
+        return map.get(elementId) ?? null;
+      },
+      resolveSnapshotBackendNodeId: (
+        conversationId: string,
+        elementId: string,
+      ) => {
+        const map = snapshotBackendNodeMaps.get(conversationId);
         if (!map) return null;
         return map.get(elementId) ?? null;
       },
@@ -81,22 +139,43 @@ const ctx: ToolContext = {
 function resetMockPage() {
   mockPage = {
     click: mock(async () => {}),
-    fill: mock(async () => {}),
-    press: mock(async () => {}),
-    evaluate: mock(async () => ""),
-    title: mock(async () => "Test Page"),
-    url: mock(() => "https://example.com/"),
-    goto: mock(async () => ({
-      status: () => 200,
-      url: () => "https://example.com/",
-    })),
-    selectOption: mock(async () => []),
     hover: mock(async () => {}),
     close: async () => {},
     isClosed: () => false,
-    keyboard: { press: mock(async () => {}) },
-    mouse: { wheel: mock(async () => {}), move: mock(async () => {}) },
+    // `LocalCdpClient.ensureSession()` calls `page.context().newCDPSession(
+    // page)` to obtain a CDP session. Return the in-file `fakeCdpSession`
+    // so tests can assert on the exact CDP method sequence.
+    context: () => ({
+      newCDPSession: async (_page: unknown) => fakeCdpSession,
+    }),
   };
+}
+
+/**
+ * Default CDP send handler that answers the common plumbing calls
+ * used by the migrated tools (querySelectorBackendNodeId, DOM.focus,
+ * DOM.resolveNode, Runtime.callFunctionOn, Input.*, and
+ * Runtime.evaluate for viewport dimensions). Individual tests can
+ * override `sendHandler` to simulate failures or shape responses.
+ */
+function defaultCdpHandler(
+  method: string,
+  _params: Record<string, unknown> | undefined,
+): unknown {
+  switch (method) {
+    case "DOM.getDocument":
+      return { root: { nodeId: 1 } };
+    case "DOM.querySelector":
+      return { nodeId: 42 };
+    case "DOM.describeNode":
+      return { node: { backendNodeId: 100 } };
+    case "DOM.resolveNode":
+      return { object: { objectId: "obj-1" } };
+    case "Runtime.evaluate":
+      return { result: { value: { w: 800, h: 600 } } };
+    default:
+      return {};
+  }
 }
 
 // ── browser_click ────────────────────────────────────────────────────
@@ -104,11 +183,13 @@ function resetMockPage() {
 describe("executeBrowserClick", () => {
   beforeEach(() => {
     resetMockPage();
-    snapshotMaps.clear();
+    resetCdpMock();
+    snapshotStringMaps.clear();
+    snapshotBackendNodeMaps.clear();
   });
 
   test("clicks by element_id via snapshot map", async () => {
-    snapshotMaps.set(
+    snapshotStringMaps.set(
       "test-conversation",
       new Map([["e1", '[data-vellum-eid="e1"]']]),
     );
@@ -129,7 +210,7 @@ describe("executeBrowserClick", () => {
   });
 
   test("prefers element_id over selector", async () => {
-    snapshotMaps.set(
+    snapshotStringMaps.set(
       "test-conversation",
       new Map([["e1", '[data-vellum-eid="e1"]']]),
     );
@@ -180,51 +261,69 @@ describe("executeBrowserClick", () => {
 describe("executeBrowserType", () => {
   beforeEach(() => {
     resetMockPage();
-    snapshotMaps.clear();
+    resetCdpMock();
+    snapshotStringMaps.clear();
+    snapshotBackendNodeMaps.clear();
+    sendHandler = defaultCdpHandler;
   });
 
   test("types with element_id and default clear_first=true", async () => {
-    snapshotMaps.set(
-      "test-conversation",
-      new Map([["e3", '[data-vellum-eid="e3"]']]),
-    );
+    snapshotBackendNodeMaps.set("test-conversation", new Map([["e3", 555]]));
     const result = await executeBrowserType(
       { element_id: "e3", text: "hello" },
       ctx,
     );
     expect(result.isError).toBe(false);
-    expect(result.content).toContain("Typed into element");
+    expect(result.content).toContain('Typed into element: element_id "e3"');
     expect(result.content).toContain("cleared existing content");
-    expect(mockPage.fill).toHaveBeenCalledWith(
-      '[data-vellum-eid="e3"]',
-      "hello",
-      { timeout: 10000 },
-    );
+
+    // Expected CDP sequence when resolving by backendNodeId + clearFirst:
+    //   DOM.focus → DOM.resolveNode → Runtime.callFunctionOn (clear) →
+    //   DOM.focus → Input.insertText
+    const methods = sendCalls.map((c) => c.method);
+    expect(methods).toEqual([
+      "DOM.focus",
+      "DOM.resolveNode",
+      "Runtime.callFunctionOn",
+      "DOM.focus",
+      "Input.insertText",
+    ]);
+    const focusCall = sendCalls[0]!;
+    expect(focusCall.params).toEqual({ backendNodeId: 555 });
+    const insertCall = sendCalls[sendCalls.length - 1]!;
+    expect(insertCall.params).toEqual({ text: "hello" });
   });
 
-  test("types with raw selector", async () => {
+  test("types with raw selector (resolves via DOM.querySelector)", async () => {
     const result = await executeBrowserType(
       { selector: 'input[name="email"]', text: "test" },
       ctx,
     );
     expect(result.isError).toBe(false);
-    expect(mockPage.fill).toHaveBeenCalledWith('input[name="email"]', "test", {
-      timeout: 10000,
-    });
+    expect(result.content).toContain('Typed into element: input[name="email"]');
+    // Raw-selector path must resolve the backendNodeId first.
+    const methods = sendCalls.map((c) => c.method);
+    expect(methods[0]).toBe("DOM.getDocument");
+    expect(methods[1]).toBe("DOM.querySelector");
+    expect(methods[2]).toBe("DOM.describeNode");
+    expect(methods).toContain("Input.insertText");
   });
 
   test("appends text when clear_first=false", async () => {
-    mockPage.evaluate = mock(async () => "existing");
     const result = await executeBrowserType(
       { selector: "#input", text: " more", clear_first: false },
       ctx,
     );
     expect(result.isError).toBe(false);
-    expect(mockPage.evaluate).toHaveBeenCalled();
-    expect(mockPage.fill).toHaveBeenCalledWith("#input", "existing more", {
-      timeout: 10000,
-    });
     expect(result.content).not.toContain("cleared");
+    // clear_first=false skips DOM.resolveNode + Runtime.callFunctionOn
+    // and the re-focus call, so we should see focus + insertText only.
+    const methods = sendCalls.map((c) => c.method);
+    expect(methods).not.toContain("DOM.resolveNode");
+    expect(methods).not.toContain("Runtime.callFunctionOn");
+    const focusCount = methods.filter((m) => m === "DOM.focus").length;
+    expect(focusCount).toBe(1);
+    expect(methods).toContain("Input.insertText");
   });
 
   test("presses Enter after typing when press_enter=true", async () => {
@@ -234,16 +333,28 @@ describe("executeBrowserType", () => {
     );
     expect(result.isError).toBe(false);
     expect(result.content).toContain("pressed Enter");
-    expect(mockPage.fill).toHaveBeenCalledWith("#search", "query", {
-      timeout: 10000,
-    });
-    expect(mockPage.press).toHaveBeenCalledWith("#search", "Enter");
+    const methods = sendCalls.map((c) => c.method);
+    // Input.insertText must come before the Enter keyDown/keyUp.
+    const insertIdx = methods.indexOf("Input.insertText");
+    const keyDownIdx = methods.findIndex(
+      (m, i) =>
+        m === "Input.dispatchKeyEvent" &&
+        (sendCalls[i]!.params as { type: string }).type === "keyDown",
+    );
+    expect(insertIdx).toBeGreaterThanOrEqual(0);
+    expect(keyDownIdx).toBeGreaterThan(insertIdx);
+    const keyEvents = sendCalls.filter(
+      (c) => c.method === "Input.dispatchKeyEvent",
+    );
+    expect(keyEvents).toHaveLength(2);
+    expect((keyEvents[0]!.params as { key: string }).key).toBe("Enter");
   });
 
   test("errors when text is missing", async () => {
     const result = await executeBrowserType({ selector: "#input" }, ctx);
     expect(result.isError).toBe(true);
     expect(result.content).toContain("text is required");
+    expect(sendCalls).toHaveLength(0);
   });
 
   test("errors when text is empty string", async () => {
@@ -253,6 +364,7 @@ describe("executeBrowserType", () => {
     );
     expect(result.isError).toBe(true);
     expect(result.content).toContain("text is required");
+    expect(sendCalls).toHaveLength(0);
   });
 
   test("errors when neither element_id nor selector provided", async () => {
@@ -261,6 +373,7 @@ describe("executeBrowserType", () => {
     expect(result.content).toContain(
       "Either element_id or selector is required",
     );
+    expect(sendCalls).toHaveLength(0);
   });
 
   test("errors when element_id not found", async () => {
@@ -270,40 +383,33 @@ describe("executeBrowserType", () => {
     );
     expect(result.isError).toBe(true);
     expect(result.content).toContain('element_id "e99" not found');
+    expect(sendCalls).toHaveLength(0);
   });
 
-  test("handles type error from page", async () => {
-    mockPage.fill = mock(async () => {
-      throw new Error("Element is not an input");
-    });
+  test("surfaces CDP failure as a type error", async () => {
+    sendHandler = () => new Error("focus failed");
     const result = await executeBrowserType(
       { selector: "#div", text: "hello" },
       ctx,
     );
     expect(result.isError).toBe(true);
     expect(result.content).toContain("Type failed");
-    expect(result.content).toContain("Element is not an input");
+    expect(result.content).toContain("focus failed");
   });
 });
 
 // NOTE: executeBrowserSnapshot tests live in
-// `headless-browser-snapshot.test.ts`. The snapshot tool now talks to
-// CDP via `getCdpClient` (no longer Playwright `page.evaluate`), so its
-// mocking surface is incompatible with the Playwright `mockPage`
-// scaffolding used here. The interactions file continues to drive the
-// still-Playwright-backed click/type/hover/etc. tools through the
-// `browserManager.snapshotMaps` bridge the snapshot tool writes.
+// `headless-browser-snapshot.test.ts`.
 
 // browser_screenshot tests live in headless-browser-read-tools.test.ts
-// (alongside browser_extract / browser_wait_for) because it drives
-// CDP via getCdpClient() rather than the Playwright page mock this
-// file uses for the interaction-oriented tools.
+// (alongside browser_extract / browser_wait_for).
 
 // ── browser_close ────────────────────────────────────────────────────
 
 describe("executeBrowserClose", () => {
   beforeEach(() => {
     resetMockPage();
+    resetCdpMock();
   });
 
   test("closes session page", async () => {
@@ -330,31 +436,47 @@ describe("executeBrowserClose", () => {
 describe("executeBrowserPressKey", () => {
   beforeEach(() => {
     resetMockPage();
-    snapshotMaps.clear();
+    resetCdpMock();
+    snapshotStringMaps.clear();
+    snapshotBackendNodeMaps.clear();
+    sendHandler = defaultCdpHandler;
   });
 
-  test("presses key on page (focused element) when no target", async () => {
+  test("presses key on focused element when no target", async () => {
     const result = await executeBrowserPressKey({ key: "Enter" }, ctx);
     expect(result.isError).toBe(false);
     expect(result.content).toContain('Pressed "Enter"');
-    expect(mockPage.keyboard.press).toHaveBeenCalledWith("Enter");
+    // No target => no DOM.focus, no selector resolution, just keyDown + keyUp.
+    const methods = sendCalls.map((c) => c.method);
+    expect(methods).toEqual([
+      "Input.dispatchKeyEvent",
+      "Input.dispatchKeyEvent",
+    ]);
+    const keyDown = sendCalls[0]!.params as { type: string; key: string };
+    const keyUp = sendCalls[1]!.params as { type: string; key: string };
+    expect(keyDown.type).toBe("keyDown");
+    expect(keyDown.key).toBe("Enter");
+    expect(keyUp.type).toBe("keyUp");
+    expect(keyUp.key).toBe("Enter");
   });
 
   test("presses key on targeted element via element_id", async () => {
-    snapshotMaps.set(
-      "test-conversation",
-      new Map([["e5", '[data-vellum-eid="e5"]']]),
-    );
+    snapshotBackendNodeMaps.set("test-conversation", new Map([["e5", 555]]));
     const result = await executeBrowserPressKey(
       { key: "Tab", element_id: "e5" },
       ctx,
     );
     expect(result.isError).toBe(false);
     expect(result.content).toContain('Pressed "Tab" on element');
-    expect(mockPage.press).toHaveBeenCalledWith(
-      '[data-vellum-eid="e5"]',
-      "Tab",
-    );
+    expect(result.content).toContain('element_id "e5"');
+    // Backend-resolved path: focus → dispatchKeyEvent × 2
+    const methods = sendCalls.map((c) => c.method);
+    expect(methods).toEqual([
+      "DOM.focus",
+      "Input.dispatchKeyEvent",
+      "Input.dispatchKeyEvent",
+    ]);
+    expect(sendCalls[0]!.params).toEqual({ backendNodeId: 555 });
   });
 
   test("presses key on targeted element via selector", async () => {
@@ -364,13 +486,24 @@ describe("executeBrowserPressKey", () => {
     );
     expect(result.isError).toBe(false);
     expect(result.content).toContain('Pressed "Escape" on element');
-    expect(mockPage.press).toHaveBeenCalledWith("#dialog", "Escape");
+    // Selector path: DOM.getDocument → DOM.querySelector → DOM.describeNode
+    // → DOM.focus → dispatchKeyEvent × 2
+    const methods = sendCalls.map((c) => c.method);
+    expect(methods).toEqual([
+      "DOM.getDocument",
+      "DOM.querySelector",
+      "DOM.describeNode",
+      "DOM.focus",
+      "Input.dispatchKeyEvent",
+      "Input.dispatchKeyEvent",
+    ]);
   });
 
   test("errors when key is missing", async () => {
     const result = await executeBrowserPressKey({}, ctx);
     expect(result.isError).toBe(true);
     expect(result.content).toContain("key is required");
+    expect(sendCalls).toHaveLength(0);
   });
 
   test("errors when element_id not found", async () => {
@@ -380,12 +513,11 @@ describe("executeBrowserPressKey", () => {
     );
     expect(result.isError).toBe(true);
     expect(result.content).toContain('element_id "e99" not found');
+    expect(sendCalls).toHaveLength(0);
   });
 
-  test("handles press key error from page", async () => {
-    mockPage.keyboard.press = mock(async () => {
-      throw new Error("Key not recognized");
-    });
+  test("surfaces CDP failure as a press-key error", async () => {
+    sendHandler = () => new Error("Key not recognized");
     const result = await executeBrowserPressKey({ key: "InvalidKey" }, ctx);
     expect(result.isError).toBe(true);
     expect(result.content).toContain("Press key failed");
@@ -398,14 +530,32 @@ describe("executeBrowserPressKey", () => {
 describe("executeBrowserScroll", () => {
   beforeEach(() => {
     resetMockPage();
-    snapshotMaps.clear();
+    resetCdpMock();
+    sendHandler = defaultCdpHandler;
   });
 
   test("scrolls down by default amount", async () => {
     const result = await executeBrowserScroll({ direction: "down" }, ctx);
     expect(result.isError).toBe(false);
     expect(result.content).toContain("Scrolled down by 500px");
-    expect(mockPage.mouse.wheel).toHaveBeenCalledWith(0, 500);
+    // Runtime.evaluate for viewport dimensions, then a single
+    // Input.dispatchMouseEvent mouseWheel at the viewport center.
+    const evaluateCall = sendCalls.find((c) => c.method === "Runtime.evaluate");
+    expect(evaluateCall).toBeDefined();
+    expect((evaluateCall!.params as { expression: string }).expression).toBe(
+      "({ w: window.innerWidth, h: window.innerHeight })",
+    );
+    const wheelCall = sendCalls.find(
+      (c) => c.method === "Input.dispatchMouseEvent",
+    );
+    expect(wheelCall).toBeDefined();
+    expect(wheelCall!.params).toEqual({
+      type: "mouseWheel",
+      x: 400,
+      y: 300,
+      deltaX: 0,
+      deltaY: 500,
+    });
   });
 
   test("scrolls up by custom amount", async () => {
@@ -415,7 +565,16 @@ describe("executeBrowserScroll", () => {
     );
     expect(result.isError).toBe(false);
     expect(result.content).toContain("Scrolled up by 300px");
-    expect(mockPage.mouse.wheel).toHaveBeenCalledWith(0, -300);
+    const wheelCall = sendCalls.find(
+      (c) => c.method === "Input.dispatchMouseEvent",
+    );
+    expect(wheelCall!.params).toEqual({
+      type: "mouseWheel",
+      x: 400,
+      y: 300,
+      deltaX: 0,
+      deltaY: -300,
+    });
   });
 
   test("scrolls left", async () => {
@@ -424,7 +583,16 @@ describe("executeBrowserScroll", () => {
       ctx,
     );
     expect(result.isError).toBe(false);
-    expect(mockPage.mouse.wheel).toHaveBeenCalledWith(-200, 0);
+    const wheelCall = sendCalls.find(
+      (c) => c.method === "Input.dispatchMouseEvent",
+    );
+    expect(wheelCall!.params).toEqual({
+      type: "mouseWheel",
+      x: 400,
+      y: 300,
+      deltaX: -200,
+      deltaY: 0,
+    });
   });
 
   test("scrolls right", async () => {
@@ -433,19 +601,38 @@ describe("executeBrowserScroll", () => {
       ctx,
     );
     expect(result.isError).toBe(false);
-    expect(mockPage.mouse.wheel).toHaveBeenCalledWith(200, 0);
+    const wheelCall = sendCalls.find(
+      (c) => c.method === "Input.dispatchMouseEvent",
+    );
+    expect(wheelCall!.params).toEqual({
+      type: "mouseWheel",
+      x: 400,
+      y: 300,
+      deltaX: 200,
+      deltaY: 0,
+    });
   });
 
   test("errors when direction is missing", async () => {
     const result = await executeBrowserScroll({}, ctx);
     expect(result.isError).toBe(true);
     expect(result.content).toContain("direction is required");
+    expect(sendCalls).toHaveLength(0);
   });
 
   test("errors when direction is invalid", async () => {
     const result = await executeBrowserScroll({ direction: "diagonal" }, ctx);
     expect(result.isError).toBe(true);
     expect(result.content).toContain("direction is required");
+    expect(sendCalls).toHaveLength(0);
+  });
+
+  test("surfaces CDP failure as a scroll error", async () => {
+    sendHandler = () => new Error("viewport unavailable");
+    const result = await executeBrowserScroll({ direction: "down" }, ctx);
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("Scroll failed");
+    expect(result.content).toContain("viewport unavailable");
   });
 });
 
@@ -454,14 +641,14 @@ describe("executeBrowserScroll", () => {
 describe("executeBrowserSelectOption", () => {
   beforeEach(() => {
     resetMockPage();
-    snapshotMaps.clear();
+    resetCdpMock();
+    snapshotStringMaps.clear();
+    snapshotBackendNodeMaps.clear();
+    sendHandler = defaultCdpHandler;
   });
 
   test("selects by value via element_id", async () => {
-    snapshotMaps.set(
-      "test-conversation",
-      new Map([["e4", '[data-vellum-eid="e4"]']]),
-    );
+    snapshotBackendNodeMaps.set("test-conversation", new Map([["e4", 777]]));
     const result = await executeBrowserSelectOption(
       { element_id: "e4", value: "ca" },
       ctx,
@@ -469,10 +656,22 @@ describe("executeBrowserSelectOption", () => {
     expect(result.isError).toBe(false);
     expect(result.content).toContain("Selected option");
     expect(result.content).toContain('value="ca"');
-    expect(mockPage.selectOption).toHaveBeenCalledWith(
-      '[data-vellum-eid="e4"]',
+    expect(result.content).toContain('element_id "e4"');
+
+    // Expected CDP sequence: DOM.resolveNode → Runtime.callFunctionOn
+    const methods = sendCalls.map((c) => c.method);
+    expect(methods).toEqual(["DOM.resolveNode", "Runtime.callFunctionOn"]);
+    expect(sendCalls[0]!.params).toEqual({ backendNodeId: 777 });
+    const callFn = sendCalls[1]!.params as {
+      objectId: string;
+      arguments: Array<{ value: unknown }>;
+    };
+    expect(callFn.objectId).toBe("obj-1");
+    expect(callFn.arguments).toEqual([
       { value: "ca" },
-    );
+      { value: null },
+      { value: null },
+    ]);
   });
 
   test("selects by label", async () => {
@@ -482,9 +681,23 @@ describe("executeBrowserSelectOption", () => {
     );
     expect(result.isError).toBe(false);
     expect(result.content).toContain('label="California"');
-    expect(mockPage.selectOption).toHaveBeenCalledWith("#state", {
-      label: "California",
-    });
+    // Selector path: querySelectorBackendNodeId sequence + DOM.resolveNode + Runtime.callFunctionOn
+    const methods = sendCalls.map((c) => c.method);
+    expect(methods).toEqual([
+      "DOM.getDocument",
+      "DOM.querySelector",
+      "DOM.describeNode",
+      "DOM.resolveNode",
+      "Runtime.callFunctionOn",
+    ]);
+    const callFn = sendCalls[4]!.params as {
+      arguments: Array<{ value: unknown }>;
+    };
+    expect(callFn.arguments).toEqual([
+      { value: null },
+      { value: "California" },
+      { value: null },
+    ]);
   });
 
   test("selects by index", async () => {
@@ -494,7 +707,13 @@ describe("executeBrowserSelectOption", () => {
     );
     expect(result.isError).toBe(false);
     expect(result.content).toContain("index=2");
-    expect(mockPage.selectOption).toHaveBeenCalledWith("#state", { index: 2 });
+    const callFn = sendCalls.find((c) => c.method === "Runtime.callFunctionOn")!
+      .params as { arguments: Array<{ value: unknown }> };
+    expect(callFn.arguments).toEqual([
+      { value: null },
+      { value: null },
+      { value: 2 },
+    ]);
   });
 
   test("errors when no option specifier provided", async () => {
@@ -506,6 +725,7 @@ describe("executeBrowserSelectOption", () => {
     expect(result.content).toContain(
       "One of value, label, or index is required",
     );
+    expect(sendCalls).toHaveLength(0);
   });
 
   test("errors when neither element_id nor selector provided", async () => {
@@ -514,12 +734,11 @@ describe("executeBrowserSelectOption", () => {
     expect(result.content).toContain(
       "Either element_id or selector is required",
     );
+    expect(sendCalls).toHaveLength(0);
   });
 
-  test("handles select option error from page", async () => {
-    mockPage.selectOption = mock(async () => {
-      throw new Error("Not a select element");
-    });
+  test("surfaces CDP failure as a select-option error", async () => {
+    sendHandler = () => new Error("Not a select element");
     const result = await executeBrowserSelectOption(
       { selector: "#div", value: "x" },
       ctx,
@@ -535,11 +754,13 @@ describe("executeBrowserSelectOption", () => {
 describe("executeBrowserHover", () => {
   beforeEach(() => {
     resetMockPage();
-    snapshotMaps.clear();
+    resetCdpMock();
+    snapshotStringMaps.clear();
+    snapshotBackendNodeMaps.clear();
   });
 
   test("hovers by element_id via snapshot map", async () => {
-    snapshotMaps.set(
+    snapshotStringMaps.set(
       "test-conversation",
       new Map([["e2", '[data-vellum-eid="e2"]']]),
     );
@@ -594,11 +815,14 @@ describe("executeBrowserHover", () => {
 describe("browser execution wrapper contract", () => {
   beforeEach(() => {
     resetMockPage();
-    snapshotMaps.clear();
+    resetCdpMock();
+    sendHandler = defaultCdpHandler;
+    snapshotStringMaps.clear();
+    snapshotBackendNodeMaps.clear();
   });
 
   test("executeBrowserClick matches wrapper contract (input, context) → result", async () => {
-    snapshotMaps.set(
+    snapshotStringMaps.set(
       "test-conversation",
       new Map([["e1", '[data-vellum-eid="e1"]']]),
     );
@@ -611,10 +835,7 @@ describe("browser execution wrapper contract", () => {
   });
 
   test("executeBrowserType matches wrapper contract", async () => {
-    snapshotMaps.set(
-      "test-conversation",
-      new Map([["e3", '[data-vellum-eid="e3"]']]),
-    );
+    snapshotBackendNodeMaps.set("test-conversation", new Map([["e3", 555]]));
     const result = await executeBrowserType(
       { element_id: "e3", text: "hello" },
       ctx,
@@ -625,13 +846,11 @@ describe("browser execution wrapper contract", () => {
   });
 
   // executeBrowserSnapshot wrapper-contract check lives in
-  // `headless-browser-snapshot.test.ts` since the tool now talks to CDP
-  // and can't reuse this file's Playwright mock surface.
+  // `headless-browser-snapshot.test.ts`.
 
   // wrapper contract for executeBrowserExtract and
   // executeBrowserScreenshot lives in
-  // headless-browser-read-tools.test.ts alongside their
-  // CDP-driven tests.
+  // headless-browser-read-tools.test.ts.
 
   test("executeBrowserPressKey matches wrapper contract", async () => {
     const result = await executeBrowserPressKey({ key: "Enter" }, ctx);
@@ -655,10 +874,7 @@ describe("browser execution wrapper contract", () => {
   });
 
   test("executeBrowserSelectOption matches wrapper contract", async () => {
-    snapshotMaps.set(
-      "test-conversation",
-      new Map([["e4", '[data-vellum-eid="e4"]']]),
-    );
+    snapshotBackendNodeMaps.set("test-conversation", new Map([["e4", 777]]));
     const result = await executeBrowserSelectOption(
       { element_id: "e4", value: "opt1" },
       ctx,
@@ -669,7 +885,7 @@ describe("browser execution wrapper contract", () => {
   });
 
   test("executeBrowserHover matches wrapper contract", async () => {
-    snapshotMaps.set(
+    snapshotStringMaps.set(
       "test-conversation",
       new Map([["e2", '[data-vellum-eid="e2"]']]),
     );

--- a/assistant/src/__tests__/headless-browser-read-tools.test.ts
+++ b/assistant/src/__tests__/headless-browser-read-tools.test.ts
@@ -54,14 +54,10 @@ const fakeCdpSession = {
 };
 
 // The mock page is served by `browserManager.getOrCreateSessionPage`
-// and is consumed by two different code paths in this file:
-//   • executeBrowserPressKey uses it as a Playwright Page (click,
-//     press, keyboard.press, etc.).
-//   • executeBrowserScreenshot / Extract / WaitFor use it only
-//     indirectly: LocalCdpClient calls `page.context().newCDPSession(
-//     page)` to obtain a CDP session and then dispatches raw CDP
-//     methods against it. The page's `context().newCDPSession` is
-//     wired to return `fakeCdpSession` above.
+// and is consumed indirectly: LocalCdpClient calls
+// `page.context().newCDPSession(page)` to obtain a CDP session and
+// then dispatches raw CDP methods against it. The page's
+// `context().newCDPSession` is wired to return `fakeCdpSession` above.
 let mockPage: {
   click: ReturnType<typeof mock>;
   fill: ReturnType<typeof mock>;
@@ -111,7 +107,6 @@ mock.module("../tools/network/url-safety.js", () => ({
 
 import {
   executeBrowserExtract,
-  executeBrowserPressKey,
   executeBrowserScreenshot,
   executeBrowserWaitFor,
   EXTRACT_LINKS_EXPRESSION,
@@ -152,71 +147,9 @@ function resetMockPage() {
   };
 }
 
-// ── browser_press_key ────────────────────────────────────────────────
-
-describe("executeBrowserPressKey", () => {
-  beforeEach(() => {
-    resetMockPage();
-    snapshotMaps.clear();
-  });
-
-  test("presses key on focused element (no target)", async () => {
-    const result = await executeBrowserPressKey({ key: "Enter" }, ctx);
-    expect(result.isError).toBe(false);
-    expect(result.content).toContain('Pressed "Enter"');
-    expect(mockPage.keyboard.press).toHaveBeenCalledWith("Enter");
-  });
-
-  test("presses key on targeted element via element_id", async () => {
-    snapshotMaps.set(
-      "test-conversation",
-      new Map([["e1", '[data-vellum-eid="e1"]']]),
-    );
-    const result = await executeBrowserPressKey(
-      { key: "Tab", element_id: "e1" },
-      ctx,
-    );
-    expect(result.isError).toBe(false);
-    expect(result.content).toContain('Pressed "Tab" on element');
-    expect(mockPage.press).toHaveBeenCalledWith(
-      '[data-vellum-eid="e1"]',
-      "Tab",
-    );
-  });
-
-  test("presses key on targeted element via selector", async () => {
-    const result = await executeBrowserPressKey(
-      { key: "Escape", selector: "#modal" },
-      ctx,
-    );
-    expect(result.isError).toBe(false);
-    expect(mockPage.press).toHaveBeenCalledWith("#modal", "Escape");
-  });
-
-  test("errors when key is missing", async () => {
-    const result = await executeBrowserPressKey({}, ctx);
-    expect(result.isError).toBe(true);
-    expect(result.content).toContain("key is required");
-  });
-
-  test("errors when element_id not found", async () => {
-    const result = await executeBrowserPressKey(
-      { key: "Enter", element_id: "e99" },
-      ctx,
-    );
-    expect(result.isError).toBe(true);
-    expect(result.content).toContain('element_id "e99" not found');
-  });
-
-  test("handles press error", async () => {
-    mockPage.keyboard.press = mock(async () => {
-      throw new Error("key not recognized");
-    });
-    const result = await executeBrowserPressKey({ key: "InvalidKey" }, ctx);
-    expect(result.isError).toBe(true);
-    expect(result.content).toContain("Press key failed");
-  });
-});
+// executeBrowserPressKey tests live in
+// `headless-browser-interactions.test.ts` alongside the other
+// CDP-migrated interaction tools.
 
 // ── browser_screenshot ───────────────────────────────────────────────
 

--- a/assistant/src/tools/browser/browser-execution.ts
+++ b/assistant/src/tools/browser/browser-execution.ts
@@ -29,10 +29,15 @@ import {
 } from "./cdp-client/accessibility-snapshot.js";
 import {
   captureScreenshotJpeg,
+  dispatchInsertText,
+  dispatchKeyPress,
+  dispatchWheelScroll,
   evaluateExpression,
+  focusElement,
   getCurrentUrl,
   getPageTitle,
   navigateAndWait,
+  querySelectorBackendNodeId,
   waitForSelector as cdpWaitForSelector,
   waitForText as cdpWaitForText,
 } from "./cdp-client/cdp-dom-helpers.js";
@@ -834,7 +839,7 @@ export async function executeBrowserType(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  const { selector, error } = resolveSelector(context.conversationId, input);
+  const { resolved, error } = resolveElement(context.conversationId, input);
   if (error) return { content: error, isError: true };
 
   const text = typeof input.text === "string" ? input.text : "";
@@ -845,40 +850,73 @@ export async function executeBrowserType(
   const clearFirst = input.clear_first !== false; // default true
   const pressEnter = input.press_enter === true;
 
-  try {
-    const page = await browserManager.getOrCreateSessionPage(
-      context.conversationId,
-    );
+  const targetDescription =
+    resolved!.kind === "backend"
+      ? `element_id "${resolved!.eid}"`
+      : resolved!.selector;
 
-    const fillTimeout =
-      typeof input.timeout === "number" ? input.timeout : ACTION_TIMEOUT_MS;
+  const cdp = getCdpClient(context);
+  try {
+    let backendNodeId: number;
+    if (resolved!.kind === "backend") {
+      backendNodeId = resolved!.backendNodeId;
+    } else {
+      backendNodeId = await querySelectorBackendNodeId(
+        cdp,
+        resolved!.selector,
+        context.signal,
+      );
+    }
+
+    await focusElement(cdp, backendNodeId, context.signal);
 
     if (clearFirst) {
-      await page.fill(selector!, text, { timeout: fillTimeout });
-    } else {
-      // Read existing content before appending. Use .value for form inputs,
-      // with fallback to .innerText for contenteditable elements (preserves
-      // visual line breaks from <br> and block elements, unlike textContent).
-      const currentValue = (await page.evaluate(
-        `(() => { const el = document.querySelector(${JSON.stringify(
-          selector!,
-        )}); if (!el) return ''; if (typeof el.value === 'string') return el.value; return el.innerText ?? ''; })()`,
-      )) as string;
-      await page.fill(selector!, currentValue + text, { timeout: fillTimeout });
+      // Resolve the node to a Runtime.RemoteObject so we can invoke a
+      // function on the element itself via Runtime.callFunctionOn. This
+      // is more reliable than a keyboard select-all + delete sequence
+      // across input, textarea, and contenteditable targets.
+      const { object } = await cdp.send<{ object: { objectId: string } }>(
+        "DOM.resolveNode",
+        { backendNodeId },
+        context.signal,
+      );
+      await cdp.send(
+        "Runtime.callFunctionOn",
+        {
+          objectId: object.objectId,
+          functionDeclaration: `function() {
+            if (typeof this.value === "string") {
+              this.value = "";
+            } else if (this.isContentEditable) {
+              this.textContent = "";
+            }
+            this.dispatchEvent(new Event("input", { bubbles: true }));
+          }`,
+          arguments: [],
+        },
+        context.signal,
+      );
+      // Re-focus after clearing — some sites move focus when the
+      // value property is reassigned programmatically.
+      await focusElement(cdp, backendNodeId, context.signal);
     }
+
+    await dispatchInsertText(cdp, text, context.signal);
 
     if (pressEnter) {
-      await page.press(selector!, "Enter");
+      await dispatchKeyPress(cdp, "Enter", context.signal);
     }
 
-    const lines = [`Typed into element: ${selector}`];
+    const lines = [`Typed into element: ${targetDescription}`];
     if (clearFirst) lines.push("(cleared existing content first)");
     if (pressEnter) lines.push("(pressed Enter after typing)");
     return { content: lines.join("\n"), isError: false };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    log.error({ err, selector }, "Type failed");
+    log.error({ err, target: targetDescription }, "Type failed");
     return { content: `Error: Type failed: ${msg}`, isError: true };
+  } finally {
+    cdp.dispose();
   }
 }
 
@@ -893,39 +931,56 @@ export async function executeBrowserPressKey(
     return { content: "Error: key is required.", isError: true };
   }
 
+  const elementId =
+    typeof input.element_id === "string" ? input.element_id : null;
+  const rawSelector =
+    typeof input.selector === "string" ? input.selector : null;
+  const hasTarget = elementId !== null || rawSelector !== null;
+
+  let targetDescription: string | null = null;
+  let resolved: ResolvedElement | null = null;
+  if (hasTarget) {
+    const res = resolveElement(context.conversationId, input);
+    if (res.error) {
+      return { content: res.error, isError: true };
+    }
+    resolved = res.resolved;
+    targetDescription =
+      resolved!.kind === "backend"
+        ? `element_id "${resolved!.eid}"`
+        : resolved!.selector;
+  }
+
+  const cdp = getCdpClient(context);
   try {
-    const page = await browserManager.getOrCreateSessionPage(
-      context.conversationId,
-    );
-
-    // If element_id or selector is provided, press key on that element
-    const elementId =
-      typeof input.element_id === "string" ? input.element_id : null;
-    const rawSelector =
-      typeof input.selector === "string" ? input.selector : null;
-
-    if (elementId || rawSelector) {
-      const { selector, error } = resolveSelector(
-        context.conversationId,
-        input,
-      );
-      if (error) {
-        return { content: error, isError: true };
+    if (resolved) {
+      let backendNodeId: number;
+      if (resolved.kind === "backend") {
+        backendNodeId = resolved.backendNodeId;
+      } else {
+        backendNodeId = await querySelectorBackendNodeId(
+          cdp,
+          resolved.selector,
+          context.signal,
+        );
       }
-      await page.press(selector!, key);
+      await focusElement(cdp, backendNodeId, context.signal);
+      await dispatchKeyPress(cdp, key, context.signal);
       return {
-        content: `Pressed "${key}" on element: ${selector}`,
+        content: `Pressed "${key}" on element: ${targetDescription}`,
         isError: false,
       };
     }
 
-    // No target -> press key on the page (focused element)
-    await page.keyboard.press(key);
+    // No target -> press key on the currently focused element
+    await dispatchKeyPress(cdp, key, context.signal);
     return { content: `Pressed "${key}"`, isError: false };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     log.error({ err, key }, "Press key failed");
     return { content: `Error: Press key failed: ${msg}`, isError: true };
+  } finally {
+    cdp.dispose();
   }
 }
 
@@ -947,35 +1002,49 @@ export async function executeBrowserScroll(
   const amount =
     typeof input.amount === "number" ? Math.abs(input.amount) : 500;
 
+  let deltaX = 0;
+  let deltaY = 0;
+  switch (direction) {
+    case "up":
+      deltaY = -amount;
+      break;
+    case "down":
+      deltaY = amount;
+      break;
+    case "left":
+      deltaX = -amount;
+      break;
+    case "right":
+      deltaX = amount;
+      break;
+  }
+
+  const cdp = getCdpClient(context);
   try {
-    const page = await browserManager.getOrCreateSessionPage(
-      context.conversationId,
+    // Fetch viewport dimensions so we can dispatch the wheel event at
+    // the viewport center — scrolling from (0, 0) misses sticky
+    // headers and overflow containers on many sites.
+    const { w, h } = await evaluateExpression<{ w: number; h: number }>(
+      cdp,
+      "({ w: window.innerWidth, h: window.innerHeight })",
+      {},
+      context.signal,
     );
 
-    let deltaX = 0;
-    let deltaY = 0;
-    switch (direction) {
-      case "up":
-        deltaY = -amount;
-        break;
-      case "down":
-        deltaY = amount;
-        break;
-      case "left":
-        deltaX = -amount;
-        break;
-      case "right":
-        deltaX = amount;
-        break;
-    }
-
-    await page.mouse.wheel(deltaX, deltaY);
+    await dispatchWheelScroll(
+      cdp,
+      { x: w / 2, y: h / 2 },
+      { deltaX, deltaY },
+      context.signal,
+    );
 
     return { content: `Scrolled ${direction} by ${amount}px`, isError: false };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     log.error({ err, direction }, "Scroll failed");
     return { content: `Error: Scroll failed: ${msg}`, isError: true };
+  } finally {
+    cdp.dispose();
   }
 }
 
@@ -985,7 +1054,7 @@ export async function executeBrowserSelectOption(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  const { selector, error } = resolveSelector(context.conversationId, input);
+  const { resolved, error } = resolveElement(context.conversationId, input);
   if (error) return { content: error, isError: true };
 
   const value = typeof input.value === "string" ? input.value : undefined;
@@ -999,17 +1068,60 @@ export async function executeBrowserSelectOption(
     };
   }
 
+  const targetDescription =
+    resolved!.kind === "backend"
+      ? `element_id "${resolved!.eid}"`
+      : resolved!.selector;
+
+  const cdp = getCdpClient(context);
   try {
-    const page = await browserManager.getOrCreateSessionPage(
-      context.conversationId,
+    let backendNodeId: number;
+    if (resolved!.kind === "backend") {
+      backendNodeId = resolved!.backendNodeId;
+    } else {
+      backendNodeId = await querySelectorBackendNodeId(
+        cdp,
+        resolved!.selector,
+        context.signal,
+      );
+    }
+
+    // CDP does not expose a native "set select value" command, so we
+    // resolve the node to a Runtime.RemoteObject and invoke a function
+    // on it that applies value/label/index and dispatches a bubbling
+    // `change` event.
+    const { object } = await cdp.send<{ object: { objectId: string } }>(
+      "DOM.resolveNode",
+      { backendNodeId },
+      context.signal,
     );
-
-    const option: Record<string, string | number> = {};
-    if (value !== undefined) option.value = value;
-    else if (label !== undefined) option.label = label;
-    else if (index !== undefined) option.index = index;
-
-    await page.selectOption(selector!, option);
+    await cdp.send(
+      "Runtime.callFunctionOn",
+      {
+        objectId: object.objectId,
+        functionDeclaration: `function(value, label, index) {
+          if (value !== null && value !== undefined) {
+            this.value = value;
+          } else if (label !== null && label !== undefined) {
+            for (const opt of this.options) {
+              if (opt.label === label) {
+                this.value = opt.value;
+                break;
+              }
+            }
+          } else if (index !== null && index !== undefined) {
+            this.selectedIndex = index;
+          }
+          this.dispatchEvent(new Event("change", { bubbles: true }));
+        }`,
+        arguments: [
+          { value: value ?? null },
+          { value: label ?? null },
+          { value: index ?? null },
+        ],
+      },
+      context.signal,
+    );
 
     const desc =
       value !== undefined
@@ -1018,13 +1130,15 @@ export async function executeBrowserSelectOption(
           ? `label="${label}"`
           : `index=${index}`;
     return {
-      content: `Selected option (${desc}) on element: ${selector}`,
+      content: `Selected option (${desc}) on element: ${targetDescription}`,
       isError: false,
     };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    log.error({ err, selector }, "Select option failed");
+    log.error({ err, target: targetDescription }, "Select option failed");
     return { content: `Error: Select option failed: ${msg}`, isError: true };
+  } finally {
+    cdp.dispose();
   }
 }
 


### PR DESCRIPTION
## Summary
- `executeBrowserType`, `executeBrowserPressKey`, `executeBrowserSelectOption`, `executeBrowserScroll` now drive CDP `Input` / `Runtime` commands through `CdpClient`
- Select-option uses `DOM.resolveNode` + `Runtime.callFunctionOn` to apply value/label/index and dispatch a bubbling `change` event
- Scroll fetches viewport size via `Runtime.evaluate` and dispatches a `mouseWheel` event at the viewport center
- Tests updated to mock via the browser-manager fake page pattern

Part of plan: phase3-cdp-migration.md (PR 10 of 14)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24303" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
