### PR TITLE
fix(macos): wire github-oauth into SettingsStore and onboarding

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -378,6 +378,7 @@ struct HatchingStepView: View {
             configValues["services.google-oauth.mode"] = "managed"
             configValues["services.outlook-oauth.mode"] = "managed"
             configValues["services.linear-oauth.mode"] = "managed"
+            configValues["services.github-oauth.mode"] = "managed"
         }
         return configValues
     }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -2129,6 +2129,10 @@ public final class SettingsStore: ObservableObject {
            let mode = linearOAuth["mode"] as? String {
             self.managedOAuthMode["linear"] = mode
         }
+        if let githubOAuth = services["github-oauth"] as? [String: Any],
+           let mode = githubOAuth["mode"] as? String {
+            self.managedOAuthMode["github"] = mode
+        }
     }
 
     @discardableResult


### PR DESCRIPTION
## Summary
Fixes two gaps identified during plan review for github-managed-oauth.md.

- **SettingsStore.loadServiceModes()** now reads `services["github-oauth"].mode` so the managed-mode flag is re-hydrated on app launch / daemon reconnect (matching the existing google/outlook/linear blocks). Without this, `fetchManagedOAuthConnections(providerKey: "github")` would silently short-circuit after restart.
- **HatchingStepView.buildOnboardingConfigValues()** now sets `services.github-oauth.mode = "managed"` for signed-in users so GitHub participates in the same auto-route behavior as the other three managed OAuth services.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24304" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
