### PR TITLE
feat(browser): migrate close/fill_credential and remove legacy snapshot bridge

### DIFF
--- a/assistant/src/__tests__/browser-fill-credential.test.ts
+++ b/assistant/src/__tests__/browser-fill-credential.test.ts
@@ -9,34 +9,81 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
-let mockPage: {
-  click: ReturnType<typeof mock>;
-  fill: ReturnType<typeof mock>;
-  press: ReturnType<typeof mock>;
-  evaluate: ReturnType<typeof mock>;
-  title: ReturnType<typeof mock>;
-  url: ReturnType<typeof mock>;
-  goto: ReturnType<typeof mock>;
-  close: () => Promise<void>;
-  isClosed: () => boolean;
+/**
+ * Fake CDP session driven by the real `LocalCdpClient` via the mocked
+ * `browserManager.getOrCreateSessionPage` below. `sendCalls` records
+ * every `session.send(method, params)` so tests can assert the exact
+ * sequence of CDP commands issued by `executeBrowserFillCredential`.
+ * `sendHandler` is replaced per test to shape responses or throw.
+ */
+interface SendCall {
+  method: string;
+  params: Record<string, unknown> | undefined;
+}
+
+let sendCalls: SendCall[];
+let sendHandler: (
+  method: string,
+  params: Record<string, unknown> | undefined,
+) => unknown;
+let detachCalls: number;
+
+function resetCdpMock() {
+  sendCalls = [];
+  detachCalls = 0;
+  sendHandler = defaultCdpHandler;
+}
+
+const fakeCdpSession = {
+  send: async (method: string, params?: Record<string, unknown>) => {
+    sendCalls.push({ method, params });
+    const value = sendHandler(method, params);
+    if (value instanceof Error) throw value;
+    return value;
+  },
+  detach: async () => {
+    detachCalls += 1;
+  },
 };
 
-let snapshotMaps: Map<string, Map<string, string>>;
+/**
+ * Fake Playwright page that LocalCdpClient drives. Only the
+ * `context().newCDPSession()` surface is needed — all credential-fill
+ * work now flows through CDP.
+ */
+let mockPage: {
+  close: () => Promise<void>;
+  isClosed: () => boolean;
+  context: () => {
+    newCDPSession: (page: unknown) => Promise<typeof fakeCdpSession>;
+  };
+};
+
+let snapshotBackendNodeMaps: Map<string, Map<string, number>>;
 
 mock.module("../tools/browser/browser-manager.js", () => {
-  snapshotMaps = new Map();
+  snapshotBackendNodeMaps = new Map();
   return {
     browserManager: {
       getOrCreateSessionPage: async () => mockPage,
       closeSessionPage: async () => {},
       closeAllPages: async () => {},
-      storeSnapshotMap: (conversationId: string, map: Map<string, string>) => {
-        snapshotMaps.set(conversationId, map);
+      storeSnapshotBackendNodeMap: (
+        conversationId: string,
+        map: Map<string, number>,
+      ) => {
+        snapshotBackendNodeMaps.set(conversationId, map);
       },
-      resolveSnapshotSelector: (conversationId: string, elementId: string) => {
-        const map = snapshotMaps.get(conversationId);
+      resolveSnapshotBackendNodeId: (
+        conversationId: string,
+        elementId: string,
+      ) => {
+        const map = snapshotBackendNodeMaps.get(conversationId);
         if (!map) return null;
         return map.get(elementId) ?? null;
+      },
+      clearSnapshotBackendNodeMap: (conversationId: string) => {
+        snapshotBackendNodeMaps.delete(conversationId);
       },
     },
   };
@@ -82,19 +129,40 @@ const ctx: ToolContext = {
 
 function resetMockPage() {
   mockPage = {
-    click: mock(async () => {}),
-    fill: mock(async () => {}),
-    press: mock(async () => {}),
-    evaluate: mock(async () => ""),
-    title: mock(async () => "Test Page"),
-    url: mock(() => "https://example.com/"),
-    goto: mock(async () => ({
-      status: () => 200,
-      url: () => "https://example.com/",
-    })),
     close: async () => {},
     isClosed: () => false,
+    context: () => ({
+      newCDPSession: async (_page: unknown) => fakeCdpSession,
+    }),
   };
+}
+
+/**
+ * Default CDP handler used by every test unless overridden. Returns
+ * the minimum plumbing needed for:
+ *   - `getCurrentUrl` via Runtime.evaluate (for the broker domain check)
+ *   - `querySelectorBackendNodeId` via DOM.getDocument / querySelector / describeNode
+ *   - `focusElement` via DOM.focus
+ *   - `dispatchInsertText` via Input.insertText
+ *   - `dispatchKeyPress` via Input.dispatchKeyEvent
+ */
+function defaultCdpHandler(
+  method: string,
+  _params: Record<string, unknown> | undefined,
+): unknown {
+  switch (method) {
+    case "Runtime.evaluate":
+      // getCurrentUrl() reads document.location.href via Runtime.evaluate
+      return { result: { value: "https://example.com/" } };
+    case "DOM.getDocument":
+      return { root: { nodeId: 1 } };
+    case "DOM.querySelector":
+      return { nodeId: 42 };
+    case "DOM.describeNode":
+      return { node: { backendNodeId: 100 } };
+    default:
+      return {};
+  }
 }
 
 function defaultMetadata(service: string, field: string) {
@@ -114,7 +182,8 @@ function defaultMetadata(service: string, field: string) {
 describe("executeBrowserFillCredential", () => {
   beforeEach(() => {
     resetMockPage();
-    snapshotMaps.clear();
+    resetCdpMock();
+    snapshotBackendNodeMaps.clear();
     mockGetSecureKey = mock(() => "super-secret-password");
     mockGetCredentialMetadata = mock((service: string, field: string) =>
       defaultMetadata(service, field),
@@ -122,23 +191,33 @@ describe("executeBrowserFillCredential", () => {
   });
 
   test("fills credential into element by element_id", async () => {
-    snapshotMaps.set(
-      "test-conversation",
-      new Map([["e1", '[data-vellum-eid="e1"]']]),
-    );
+    snapshotBackendNodeMaps.set("test-conversation", new Map([["e1", 555]]));
     const result = await executeBrowserFillCredential(
       { service: "gmail", field: "password", element_id: "e1" },
       ctx,
     );
     expect(result.isError).toBe(false);
     expect(result.content).toContain("Filled password for gmail");
-    expect(mockPage.fill).toHaveBeenCalledWith(
-      '[data-vellum-eid="e1"]',
-      "super-secret-password",
-    );
+
+    // Backend path: Runtime.evaluate (getCurrentUrl) → DOM.focus → Input.insertText
+    const methods = sendCalls.map((c) => c.method);
+    expect(methods).toContain("DOM.focus");
+    expect(methods).toContain("Input.insertText");
+    expect(methods).not.toContain("DOM.querySelector");
+
+    const focusCall = sendCalls.find((c) => c.method === "DOM.focus")!;
+    expect(focusCall.params).toEqual({ backendNodeId: 555 });
+
+    const insertCall = sendCalls.find((c) => c.method === "Input.insertText")!;
+    expect(insertCall.params).toEqual({ text: "super-secret-password" });
+
     expect(mockGetSecureKey).toHaveBeenCalledWith(
       credentialKey("gmail", "password"),
     );
+
+    // CdpClient disposed in finally → session.detach called.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(detachCalls).toBe(1);
   });
 
   test("fills credential by CSS selector", async () => {
@@ -148,18 +227,27 @@ describe("executeBrowserFillCredential", () => {
     );
     expect(result.isError).toBe(false);
     expect(result.content).toContain("Filled token for github");
-    expect(mockPage.fill).toHaveBeenCalledWith(
-      'input[name="password"]',
-      "super-secret-password",
-    );
+
+    // Selector path must resolve the backendNodeId via DOM.querySelector
+    // before focusing + inserting text.
+    const methods = sendCalls.map((c) => c.method);
+    expect(methods).toContain("DOM.getDocument");
+    expect(methods).toContain("DOM.querySelector");
+    expect(methods).toContain("DOM.describeNode");
+    expect(methods).toContain("DOM.focus");
+    expect(methods).toContain("Input.insertText");
+
+    // DOM.focus uses the backendNodeId (100) returned by DOM.describeNode
+    const focusCall = sendCalls.find((c) => c.method === "DOM.focus")!;
+    expect(focusCall.params).toEqual({ backendNodeId: 100 });
+
+    const insertCall = sendCalls.find((c) => c.method === "Input.insertText")!;
+    expect(insertCall.params).toEqual({ text: "super-secret-password" });
   });
 
   test("returns error when credential not found", async () => {
     mockGetCredentialMetadata = mock(() => undefined);
-    snapshotMaps.set(
-      "test-conversation",
-      new Map([["e1", '[data-vellum-eid="e1"]']]),
-    );
+    snapshotBackendNodeMaps.set("test-conversation", new Map([["e1", 555]]));
     const result = await executeBrowserFillCredential(
       { service: "slack", field: "api_key", element_id: "e1" },
       ctx,
@@ -167,15 +255,15 @@ describe("executeBrowserFillCredential", () => {
     expect(result.isError).toBe(true);
     expect(result.content).toContain("No credential stored for slack/api_key");
     expect(result.content).toContain("credential_store");
-    expect(mockPage.fill).not.toHaveBeenCalled();
+    // The broker short-circuits before DOM.focus is dispatched.
+    const methods = sendCalls.map((c) => c.method);
+    expect(methods).not.toContain("DOM.focus");
+    expect(methods).not.toContain("Input.insertText");
   });
 
   test("returns error when metadata exists but no stored value", async () => {
     mockGetSecureKey = mock(() => undefined);
-    snapshotMaps.set(
-      "test-conversation",
-      new Map([["e1", '[data-vellum-eid="e1"]']]),
-    );
+    snapshotBackendNodeMaps.set("test-conversation", new Map([["e1", 555]]));
     const result = await executeBrowserFillCredential(
       { service: "slack", field: "api_key", element_id: "e1" },
       ctx,
@@ -183,7 +271,8 @@ describe("executeBrowserFillCredential", () => {
     expect(result.isError).toBe(true);
     expect(result.content).toContain("No credential stored for slack/api_key");
     expect(result.content).toContain("credential_store");
-    expect(mockPage.fill).not.toHaveBeenCalled();
+    const methods = sendCalls.map((c) => c.method);
+    expect(methods).not.toContain("Input.insertText");
   });
 
   test("returns error when element not found", async () => {
@@ -194,13 +283,13 @@ describe("executeBrowserFillCredential", () => {
     expect(result.isError).toBe(true);
     expect(result.content).toContain('element_id "e99" not found');
     expect(result.content).toContain("browser_snapshot");
+    // Element resolution fails before any CDP session is opened.
+    expect(sendCalls).toHaveLength(0);
+    expect(detachCalls).toBe(0);
   });
 
   test("presses Enter after fill when press_enter is true", async () => {
-    snapshotMaps.set(
-      "test-conversation",
-      new Map([["e2", '[data-vellum-eid="e2"]']]),
-    );
+    snapshotBackendNodeMaps.set("test-conversation", new Map([["e2", 222]]));
     const result = await executeBrowserFillCredential(
       {
         service: "gmail",
@@ -211,21 +300,34 @@ describe("executeBrowserFillCredential", () => {
       ctx,
     );
     expect(result.isError).toBe(false);
-    expect(mockPage.fill).toHaveBeenCalledWith(
-      '[data-vellum-eid="e2"]',
-      "super-secret-password",
+    const methods = sendCalls.map((c) => c.method);
+    expect(methods).toContain("Input.insertText");
+    // dispatchKeyPress dispatches keyDown + keyUp via Input.dispatchKeyEvent
+    const keyEvents = sendCalls.filter(
+      (c) => c.method === "Input.dispatchKeyEvent",
     );
-    expect(mockPage.press).toHaveBeenCalledWith(
-      '[data-vellum-eid="e2"]',
+    expect(keyEvents).toHaveLength(2);
+    expect((keyEvents[0]!.params as { type: string; key: string }).type).toBe(
+      "keyDown",
+    );
+    expect((keyEvents[0]!.params as { type: string; key: string }).key).toBe(
       "Enter",
     );
+    expect((keyEvents[1]!.params as { type: string; key: string }).type).toBe(
+      "keyUp",
+    );
+    // Enter must come AFTER Input.insertText.
+    const insertIdx = sendCalls.findIndex(
+      (c) => c.method === "Input.insertText",
+    );
+    const firstKeyIdx = sendCalls.findIndex(
+      (c) => c.method === "Input.dispatchKeyEvent",
+    );
+    expect(firstKeyIdx).toBeGreaterThan(insertIdx);
   });
 
   test("credential value NEVER appears in result content", async () => {
-    snapshotMaps.set(
-      "test-conversation",
-      new Map([["e1", '[data-vellum-eid="e1"]']]),
-    );
+    snapshotBackendNodeMaps.set("test-conversation", new Map([["e1", 555]]));
     const result = await executeBrowserFillCredential(
       { service: "gmail", field: "password", element_id: "e1" },
       ctx,
@@ -235,10 +337,7 @@ describe("executeBrowserFillCredential", () => {
   });
 
   test("returns error when service is missing", async () => {
-    snapshotMaps.set(
-      "test-conversation",
-      new Map([["e1", '[data-vellum-eid="e1"]']]),
-    );
+    snapshotBackendNodeMaps.set("test-conversation", new Map([["e1", 555]]));
     const result = await executeBrowserFillCredential(
       { field: "password", element_id: "e1" },
       ctx,
@@ -248,10 +347,7 @@ describe("executeBrowserFillCredential", () => {
   });
 
   test("returns error when field is missing", async () => {
-    snapshotMaps.set(
-      "test-conversation",
-      new Map([["e1", '[data-vellum-eid="e1"]']]),
-    );
+    snapshotBackendNodeMaps.set("test-conversation", new Map([["e1", 555]]));
     const result = await executeBrowserFillCredential(
       { service: "gmail", element_id: "e1" },
       ctx,
@@ -265,10 +361,7 @@ describe("executeBrowserFillCredential", () => {
   // -----------------------------------------------------------------------
   describe("broker integration", () => {
     test("fill succeeds with no domain or tool-policy checks", async () => {
-      snapshotMaps.set(
-        "test-conversation",
-        new Map([["e1", '[data-vellum-eid="e1"]']]),
-      );
+      snapshotBackendNodeMaps.set("test-conversation", new Map([["e1", 555]]));
       const result = await executeBrowserFillCredential(
         { service: "gmail", field: "password", element_id: "e1" },
         ctx,
@@ -279,10 +372,7 @@ describe("executeBrowserFillCredential", () => {
     });
 
     test("credential access goes through broker (metadata + value checked)", async () => {
-      snapshotMaps.set(
-        "test-conversation",
-        new Map([["e1", '[data-vellum-eid="e1"]']]),
-      );
+      snapshotBackendNodeMaps.set("test-conversation", new Map([["e1", 555]]));
       await executeBrowserFillCredential(
         { service: "gmail", field: "password", element_id: "e1" },
         ctx,
@@ -302,10 +392,7 @@ describe("executeBrowserFillCredential", () => {
         ...defaultMetadata(service, field),
         allowedTools: ["some_other_tool"],
       }));
-      snapshotMaps.set(
-        "test-conversation",
-        new Map([["e1", '[data-vellum-eid="e1"]']]),
-      );
+      snapshotBackendNodeMaps.set("test-conversation", new Map([["e1", 555]]));
       const result = await executeBrowserFillCredential(
         { service: "gmail", field: "password", element_id: "e1" },
         ctx,
@@ -314,7 +401,9 @@ describe("executeBrowserFillCredential", () => {
       expect(result.content).toContain("Policy denied");
       expect(result.content).toContain("not allowed to use credential");
       expect(result.content).toContain("credential_store");
-      expect(mockPage.fill).not.toHaveBeenCalled();
+      // The broker short-circuits before Input.insertText fires.
+      const methods = sendCalls.map((c) => c.method);
+      expect(methods).not.toContain("Input.insertText");
     });
 
     test("returns domain policy denial with actionable message", async () => {
@@ -322,10 +411,7 @@ describe("executeBrowserFillCredential", () => {
         ...defaultMetadata(service, field),
         allowedDomains: ["other-site.com"],
       }));
-      snapshotMaps.set(
-        "test-conversation",
-        new Map([["e1", '[data-vellum-eid="e1"]']]),
-      );
+      snapshotBackendNodeMaps.set("test-conversation", new Map([["e1", 555]]));
       const result = await executeBrowserFillCredential(
         { service: "gmail", field: "password", element_id: "e1" },
         ctx,
@@ -333,7 +419,8 @@ describe("executeBrowserFillCredential", () => {
       expect(result.isError).toBe(true);
       expect(result.content).toContain("Domain policy denied");
       expect(result.content).toContain("Navigate to an allowed domain");
-      expect(mockPage.fill).not.toHaveBeenCalled();
+      const methods = sendCalls.map((c) => c.method);
+      expect(methods).not.toContain("Input.insertText");
     });
 
     test("passes current page domain to broker", async () => {
@@ -341,15 +428,12 @@ describe("executeBrowserFillCredential", () => {
         ...defaultMetadata(service, field),
         allowedDomains: ["example.com"],
       }));
-      snapshotMaps.set(
-        "test-conversation",
-        new Map([["e1", '[data-vellum-eid="e1"]']]),
-      );
+      snapshotBackendNodeMaps.set("test-conversation", new Map([["e1", 555]]));
       const result = await executeBrowserFillCredential(
         { service: "gmail", field: "password", element_id: "e1" },
         ctx,
       );
-      // Page URL is https://example.com/ which matches allowedDomains
+      // Default handler returns https://example.com/ → matches allowedDomains
       expect(result.isError).toBe(false);
       expect(result.content).toContain("Filled password for gmail");
     });
@@ -359,10 +443,7 @@ describe("executeBrowserFillCredential", () => {
         ...defaultMetadata(service, field),
         allowedTools: ["other_tool"],
       }));
-      snapshotMaps.set(
-        "test-conversation",
-        new Map([["e1", '[data-vellum-eid="e1"]']]),
-      );
+      snapshotBackendNodeMaps.set("test-conversation", new Map([["e1", 555]]));
       const result = await executeBrowserFillCredential(
         { service: "gmail", field: "password", element_id: "e1" },
         ctx,

--- a/assistant/src/__tests__/browser-manager.test.ts
+++ b/assistant/src/__tests__/browser-manager.test.ts
@@ -165,13 +165,15 @@ describe("BrowserManager", () => {
       // Should not throw
     });
 
-    test("clears snapshot map for the session", async () => {
+    test("clears snapshot backendNodeId map for the session", async () => {
       await browserManager.getOrCreateSessionPage("s1");
-      browserManager.storeSnapshotMap("s1", new Map([["e1", "#btn"]]));
-      expect(browserManager.resolveSnapshotSelector("s1", "e1")).toBe("#btn");
+      browserManager.storeSnapshotBackendNodeMap("s1", new Map([["e1", 42]]));
+      expect(browserManager.resolveSnapshotBackendNodeId("s1", "e1")).toBe(42);
 
       await browserManager.closeSessionPage("s1");
-      expect(browserManager.resolveSnapshotSelector("s1", "e1")).toBeNull();
+      expect(
+        browserManager.resolveSnapshotBackendNodeId("s1", "e1"),
+      ).toBeNull();
     });
   });
 
@@ -195,52 +197,63 @@ describe("BrowserManager", () => {
       // Should not throw
     });
 
-    test("clears all snapshot maps", async () => {
+    test("clears all snapshot backendNodeId maps", async () => {
       await browserManager.getOrCreateSessionPage("s1");
       await browserManager.getOrCreateSessionPage("s2");
-      browserManager.storeSnapshotMap("s1", new Map([["e1", "#a"]]));
-      browserManager.storeSnapshotMap("s2", new Map([["e2", "#b"]]));
+      browserManager.storeSnapshotBackendNodeMap("s1", new Map([["e1", 11]]));
+      browserManager.storeSnapshotBackendNodeMap("s2", new Map([["e2", 22]]));
 
       await browserManager.closeAllPages();
 
-      expect(browserManager.resolveSnapshotSelector("s1", "e1")).toBeNull();
-      expect(browserManager.resolveSnapshotSelector("s2", "e2")).toBeNull();
+      expect(
+        browserManager.resolveSnapshotBackendNodeId("s1", "e1"),
+      ).toBeNull();
+      expect(
+        browserManager.resolveSnapshotBackendNodeId("s2", "e2"),
+      ).toBeNull();
     });
   });
 
-  // ── snapshot map ─────────────────────────────────────────────
+  // ── snapshot backendNodeId map ───────────────────────────────
 
-  describe("snapshot map", () => {
-    test("stores and resolves element selectors", () => {
+  describe("snapshot backendNodeId map", () => {
+    test("stores and resolves element backendNodeIds", () => {
       const map = new Map([
-        ["e1", "#submit-btn"],
-        ["e2", 'input[name="email"]'],
+        ["e1", 101],
+        ["e2", 202],
       ]);
-      browserManager.storeSnapshotMap("s1", map);
+      browserManager.storeSnapshotBackendNodeMap("s1", map);
 
-      expect(browserManager.resolveSnapshotSelector("s1", "e1")).toBe(
-        "#submit-btn",
-      );
-      expect(browserManager.resolveSnapshotSelector("s1", "e2")).toBe(
-        'input[name="email"]',
-      );
+      expect(browserManager.resolveSnapshotBackendNodeId("s1", "e1")).toBe(101);
+      expect(browserManager.resolveSnapshotBackendNodeId("s1", "e2")).toBe(202);
     });
 
     test("returns null for unknown element id", () => {
-      browserManager.storeSnapshotMap("s1", new Map([["e1", "#btn"]]));
-      expect(browserManager.resolveSnapshotSelector("s1", "e999")).toBeNull();
+      browserManager.storeSnapshotBackendNodeMap("s1", new Map([["e1", 42]]));
+      expect(
+        browserManager.resolveSnapshotBackendNodeId("s1", "e999"),
+      ).toBeNull();
     });
 
     test("returns null for unknown session", () => {
       expect(
-        browserManager.resolveSnapshotSelector("unknown", "e1"),
+        browserManager.resolveSnapshotBackendNodeId("unknown", "e1"),
       ).toBeNull();
     });
 
     test("overwrites previous snapshot map for same session", () => {
-      browserManager.storeSnapshotMap("s1", new Map([["e1", "#old"]]));
-      browserManager.storeSnapshotMap("s1", new Map([["e1", "#new"]]));
-      expect(browserManager.resolveSnapshotSelector("s1", "e1")).toBe("#new");
+      browserManager.storeSnapshotBackendNodeMap("s1", new Map([["e1", 1]]));
+      browserManager.storeSnapshotBackendNodeMap("s1", new Map([["e1", 999]]));
+      expect(browserManager.resolveSnapshotBackendNodeId("s1", "e1")).toBe(999);
+    });
+
+    test("clearSnapshotBackendNodeMap drops the map for a session", () => {
+      browserManager.storeSnapshotBackendNodeMap("s1", new Map([["e1", 42]]));
+      expect(browserManager.resolveSnapshotBackendNodeId("s1", "e1")).toBe(42);
+      browserManager.clearSnapshotBackendNodeMap("s1");
+      expect(
+        browserManager.resolveSnapshotBackendNodeId("s1", "e1"),
+      ).toBeNull();
     });
   });
 });

--- a/assistant/src/__tests__/headless-browser-interactions.test.ts
+++ b/assistant/src/__tests__/headless-browser-interactions.test.ts
@@ -69,30 +69,20 @@ let mockPage: {
   };
 };
 
-let snapshotStringMaps: Map<string, Map<string, string>>;
 let snapshotBackendNodeMaps: Map<string, Map<string, number>>;
 
 mock.module("../tools/browser/browser-manager.js", () => {
-  snapshotStringMaps = new Map();
   snapshotBackendNodeMaps = new Map();
   return {
     browserManager: {
       getOrCreateSessionPage: async () => mockPage,
       closeSessionPage: async () => {},
       closeAllPages: async () => {},
-      storeSnapshotMap: (conversationId: string, map: Map<string, string>) => {
-        snapshotStringMaps.set(conversationId, map);
-      },
       storeSnapshotBackendNodeMap: (
         conversationId: string,
         map: Map<string, number>,
       ) => {
         snapshotBackendNodeMaps.set(conversationId, map);
-      },
-      resolveSnapshotSelector: (conversationId: string, elementId: string) => {
-        const map = snapshotStringMaps.get(conversationId);
-        if (!map) return null;
-        return map.get(elementId) ?? null;
       },
       resolveSnapshotBackendNodeId: (
         conversationId: string,
@@ -101,6 +91,9 @@ mock.module("../tools/browser/browser-manager.js", () => {
         const map = snapshotBackendNodeMaps.get(conversationId);
         if (!map) return null;
         return map.get(elementId) ?? null;
+      },
+      clearSnapshotBackendNodeMap: (conversationId: string) => {
+        snapshotBackendNodeMaps.delete(conversationId);
       },
     },
   };
@@ -227,7 +220,6 @@ describe("executeBrowserClick (CDP)", () => {
   beforeEach(() => {
     resetMockPage();
     resetCdpMock();
-    snapshotStringMaps.clear();
     snapshotBackendNodeMaps.clear();
   });
 
@@ -394,7 +386,6 @@ describe("executeBrowserType", () => {
   beforeEach(() => {
     resetMockPage();
     resetCdpMock();
-    snapshotStringMaps.clear();
     snapshotBackendNodeMaps.clear();
     sendHandler = defaultCdpHandler;
   });
@@ -569,7 +560,6 @@ describe("executeBrowserPressKey", () => {
   beforeEach(() => {
     resetMockPage();
     resetCdpMock();
-    snapshotStringMaps.clear();
     snapshotBackendNodeMaps.clear();
     sendHandler = defaultCdpHandler;
   });
@@ -774,7 +764,6 @@ describe("executeBrowserSelectOption", () => {
   beforeEach(() => {
     resetMockPage();
     resetCdpMock();
-    snapshotStringMaps.clear();
     snapshotBackendNodeMaps.clear();
     sendHandler = defaultCdpHandler;
   });
@@ -887,7 +876,6 @@ describe("executeBrowserHover (CDP)", () => {
   beforeEach(() => {
     resetMockPage();
     resetCdpMock();
-    snapshotStringMaps.clear();
     snapshotBackendNodeMaps.clear();
   });
 
@@ -989,7 +977,6 @@ describe("browser execution wrapper contract", () => {
     resetMockPage();
     resetCdpMock();
     sendHandler = defaultCdpHandler;
-    snapshotStringMaps.clear();
     snapshotBackendNodeMaps.clear();
   });
 

--- a/assistant/src/__tests__/headless-browser-navigate.test.ts
+++ b/assistant/src/__tests__/headless-browser-navigate.test.ts
@@ -74,17 +74,17 @@ let mockPage: {
 };
 
 let getOrCreateSessionPageMock: ReturnType<typeof mock>;
-let clearSnapshotMapMock: ReturnType<typeof mock>;
+let clearSnapshotBackendNodeMapMock: ReturnType<typeof mock>;
 let positionWindowSidebarMock: ReturnType<typeof mock>;
 
 mock.module("../tools/browser/browser-manager.js", () => {
   getOrCreateSessionPageMock = mock(async () => mockPage);
-  clearSnapshotMapMock = mock(() => {});
+  clearSnapshotBackendNodeMapMock = mock(() => {});
   positionWindowSidebarMock = mock(async () => {});
   return {
     browserManager: {
       getOrCreateSessionPage: getOrCreateSessionPageMock,
-      clearSnapshotMap: clearSnapshotMapMock,
+      clearSnapshotBackendNodeMap: clearSnapshotBackendNodeMapMock,
       supportsRouteInterception: true,
       isInteractive: () => false,
       positionWindowSidebar: positionWindowSidebarMock,

--- a/assistant/src/__tests__/headless-browser-read-tools.test.ts
+++ b/assistant/src/__tests__/headless-browser-read-tools.test.ts
@@ -76,23 +76,12 @@ let mockPage: {
   };
 };
 
-let snapshotMaps: Map<string, Map<string, string>>;
-
 mock.module("../tools/browser/browser-manager.js", () => {
-  snapshotMaps = new Map();
   return {
     browserManager: {
       getOrCreateSessionPage: async () => mockPage,
       closeSessionPage: async () => {},
       closeAllPages: async () => {},
-      storeSnapshotMap: (conversationId: string, map: Map<string, string>) => {
-        snapshotMaps.set(conversationId, map);
-      },
-      resolveSnapshotSelector: (conversationId: string, elementId: string) => {
-        const map = snapshotMaps.get(conversationId);
-        if (!map) return null;
-        return map.get(elementId) ?? null;
-      },
     },
   };
 });

--- a/assistant/src/__tests__/headless-browser-snapshot.test.ts
+++ b/assistant/src/__tests__/headless-browser-snapshot.test.ts
@@ -32,21 +32,17 @@ let detachCalls: number;
 
 let closeSessionPageMock: ReturnType<typeof mock>;
 let closeAllPagesMock: ReturnType<typeof mock>;
-let storeSnapshotMapMock: ReturnType<typeof mock>;
+let clearSnapshotBackendNodeMapMock: ReturnType<typeof mock>;
 let storeSnapshotBackendNodeMapMock: ReturnType<typeof mock>;
-let storedStringMaps: Map<string, Map<string, string>>;
 let storedBackendNodeMaps: Map<string, Map<string, number>>;
 
 mock.module("../tools/browser/browser-manager.js", () => {
-  storedStringMaps = new Map();
   storedBackendNodeMaps = new Map();
   closeSessionPageMock = mock(async () => {});
   closeAllPagesMock = mock(async () => {});
-  storeSnapshotMapMock = mock(
-    (conversationId: string, map: Map<string, string>) => {
-      storedStringMaps.set(conversationId, map);
-    },
-  );
+  clearSnapshotBackendNodeMapMock = mock((conversationId: string) => {
+    storedBackendNodeMaps.delete(conversationId);
+  });
   storeSnapshotBackendNodeMapMock = mock(
     (conversationId: string, map: Map<string, number>) => {
       storedBackendNodeMaps.set(conversationId, map);
@@ -74,13 +70,8 @@ mock.module("../tools/browser/browser-manager.js", () => {
       getOrCreateSessionPage: async (_conversationId: string) => fakePage,
       closeSessionPage: closeSessionPageMock,
       closeAllPages: closeAllPagesMock,
-      storeSnapshotMap: storeSnapshotMapMock,
       storeSnapshotBackendNodeMap: storeSnapshotBackendNodeMapMock,
-      resolveSnapshotSelector: (conversationId: string, elementId: string) => {
-        const map = storedStringMaps.get(conversationId);
-        if (!map) return null;
-        return map.get(elementId) ?? null;
-      },
+      clearSnapshotBackendNodeMap: clearSnapshotBackendNodeMapMock,
       resolveSnapshotBackendNodeId: (
         conversationId: string,
         elementId: string,
@@ -179,14 +170,12 @@ function installCdpSend(
     url: string;
     title: string;
     axTree: unknown;
-    pushedNodeIds: number[];
     throwFrom: string;
   }> = {},
 ) {
   const url = overrides.url ?? "https://example.com/";
   const title = overrides.title ?? "Example Page";
   const axTree = overrides.axTree ?? { nodes: [] };
-  const pushedNodeIds = overrides.pushedNodeIds ?? [];
   const throwFrom = overrides.throwFrom;
 
   let runtimeEvaluateCall = 0;
@@ -210,16 +199,11 @@ function installCdpSend(
         return {};
       case "Accessibility.getFullAXTree":
         return axTree;
-      case "DOM.pushNodesByBackendIdsToFrontend":
-        return { nodeIds: pushedNodeIds };
-      case "DOM.setAttributeValue":
-        return {};
       default:
         return {};
     }
   };
-  // Return the params so tests can reference them in assertions.
-  return { url, title, pushedNodeIds };
+  return { url, title };
 }
 
 function resetCdpState() {
@@ -233,9 +217,7 @@ function resetCdpState() {
 describe("executeBrowserSnapshot (CDP Accessibility.getFullAXTree)", () => {
   beforeEach(() => {
     resetCdpState();
-    storedStringMaps.clear();
     storedBackendNodeMaps.clear();
-    storeSnapshotMapMock.mockClear();
     storeSnapshotBackendNodeMapMock.mockClear();
   });
 
@@ -244,7 +226,6 @@ describe("executeBrowserSnapshot (CDP Accessibility.getFullAXTree)", () => {
       url: "https://example.com/",
       title: "Example Page",
       axTree: buildAxTreeFixture(),
-      pushedNodeIds: [11, 12, 13],
     });
 
     const result = await executeBrowserSnapshot({}, ctx);
@@ -270,64 +251,33 @@ describe("executeBrowserSnapshot (CDP Accessibility.getFullAXTree)", () => {
     expect(methods).toContain("Accessibility.getFullAXTree");
   });
 
-  test("stores both backendNodeId and legacy string selector maps", async () => {
+  test("stores backendNodeId map keyed by eid", async () => {
     installCdpSend({
       axTree: buildAxTreeFixture(),
-      pushedNodeIds: [11, 12, 13],
     });
 
     await executeBrowserSnapshot({}, ctx);
 
-    // Backend-node map stored (new AX-based path).
     expect(storeSnapshotBackendNodeMapMock).toHaveBeenCalledTimes(1);
     const backendMap = storedBackendNodeMaps.get("test-conversation");
     expect(backendMap).toBeDefined();
     expect(backendMap!.get("e1")).toBe(42);
     expect(backendMap!.get("e2")).toBe(99);
     expect(backendMap!.get("e3")).toBe(101);
-
-    // Legacy string map also populated (bridge for unmigrated tools).
-    expect(storeSnapshotMapMock).toHaveBeenCalledTimes(1);
-    const stringMap = storedStringMaps.get("test-conversation");
-    expect(stringMap).toBeDefined();
-    expect(stringMap!.get("e1")).toBe('[data-vellum-eid="e1"]');
-    expect(stringMap!.get("e2")).toBe('[data-vellum-eid="e2"]');
-    expect(stringMap!.get("e3")).toBe('[data-vellum-eid="e3"]');
   });
 
-  test("tags elements via DOM.pushNodesByBackendIdsToFrontend + setAttributeValue", async () => {
+  test("does not invoke the legacy DOM tagging bridge", async () => {
     installCdpSend({
       axTree: buildAxTreeFixture(),
-      pushedNodeIds: [11, 12, 13],
     });
 
     await executeBrowserSnapshot({}, ctx);
 
-    const pushCalls = cdpCalls.filter(
-      (c) => c.method === "DOM.pushNodesByBackendIdsToFrontend",
-    );
-    expect(pushCalls.length).toBe(1);
-    expect(pushCalls[0]!.params.backendNodeIds).toEqual([42, 99, 101]);
-
-    const setAttrCalls = cdpCalls.filter(
-      (c) => c.method === "DOM.setAttributeValue",
-    );
-    expect(setAttrCalls.length).toBe(3);
-    expect(setAttrCalls[0]!.params).toMatchObject({
-      nodeId: 11,
-      name: "data-vellum-eid",
-      value: "e1",
-    });
-    expect(setAttrCalls[1]!.params).toMatchObject({
-      nodeId: 12,
-      name: "data-vellum-eid",
-      value: "e2",
-    });
-    expect(setAttrCalls[2]!.params).toMatchObject({
-      nodeId: 13,
-      name: "data-vellum-eid",
-      value: "e3",
-    });
+    // The legacy eid → data-vellum-eid bridge has been removed;
+    // interaction tools use the backendNodeId map directly.
+    const methods = cdpCalls.map((c) => c.method);
+    expect(methods).not.toContain("DOM.pushNodesByBackendIdsToFrontend");
+    expect(methods).not.toContain("DOM.setAttributeValue");
   });
 
   test("renders '(no interactive elements found)' on empty AX tree", async () => {
@@ -336,14 +286,11 @@ describe("executeBrowserSnapshot (CDP Accessibility.getFullAXTree)", () => {
     const result = await executeBrowserSnapshot({}, ctx);
     expect(result.isError).toBe(false);
     expect(result.content).toContain("(no interactive elements found)");
-    // Empty maps should still be stored so stale eids from a previous
+    // Empty map should still be stored so stale eids from a previous
     // snapshot cannot resolve after this call.
     expect(storeSnapshotBackendNodeMapMock).toHaveBeenCalledTimes(1);
-    expect(storeSnapshotMapMock).toHaveBeenCalledTimes(1);
     const backendMap = storedBackendNodeMaps.get("test-conversation");
-    const stringMap = storedStringMaps.get("test-conversation");
     expect(backendMap?.size ?? 0).toBe(0);
-    expect(stringMap?.size ?? 0).toBe(0);
   });
 
   test("returns error content when Accessibility.getFullAXTree throws", async () => {

--- a/assistant/src/tools/browser/browser-execution.ts
+++ b/assistant/src/tools/browser/browser-execution.ts
@@ -55,33 +55,6 @@ export const NAVIGATE_TIMEOUT_MS = 15_000;
 
 export const ACTION_TIMEOUT_MS = 10_000;
 
-export const MAX_SNAPSHOT_ELEMENTS = 150;
-
-export const INTERACTIVE_SELECTOR = [
-  "a[href]",
-  "button",
-  "input",
-  "select",
-  "textarea",
-  '[role="button"]',
-  '[role="link"]',
-  '[role="checkbox"]',
-  '[role="radio"]',
-  '[role="tab"]',
-  '[role="menuitem"]',
-  '[role="option"]',
-  '[role="combobox"]',
-  '[role="listbox"]',
-  '[contenteditable="true"]',
-].join(", ");
-
-export type SnapshotElement = {
-  eid: string;
-  tag: string;
-  attrs: Record<string, string>;
-  text: string;
-};
-
 export const MAX_WAIT_MS = 30_000;
 
 export const MAX_EXTRACT_LENGTH = 50_000;
@@ -127,52 +100,16 @@ export const EXTRACT_LINKS_EXPRESSION = `
 
 // ── Shared element resolution ────────────────────────────────────────
 
-export function resolveSelector(
-  conversationId: string,
-  input: Record<string, unknown>,
-): { selector: string | null; error: string | null } {
-  const elementId =
-    typeof input.element_id === "string" ? input.element_id : null;
-  const rawSelector =
-    typeof input.selector === "string" ? input.selector : null;
-
-  if (!elementId && !rawSelector) {
-    return {
-      selector: null,
-      error: "Error: Either element_id or selector is required.",
-    };
-  }
-
-  if (elementId) {
-    const resolved = browserManager.resolveSnapshotSelector(
-      conversationId,
-      elementId,
-    );
-    if (!resolved) {
-      return {
-        selector: null,
-        error: `Error: element_id "${elementId}" not found. Run browser_snapshot first to get current element IDs.`,
-      };
-    }
-    return { selector: resolved, error: null };
-  }
-
-  return { selector: rawSelector!, error: null };
-}
-
 /**
  * Discriminated union returned by {@link resolveElement}. The
  * `"backend"` variant is produced when an `element_id` from the most
  * recent AX-tree snapshot is resolved to a CDP `backendNodeId`; the
  * `"selector"` variant is produced when the caller passed a raw CSS
- * `selector` that should be resolved via `DOM.querySelector` (or
- * equivalent) at send-time by the individual tool.
+ * `selector` that should be resolved via `DOM.querySelector` at
+ * send-time by the individual tool.
  *
- * Consumed by CDP-migrated interaction tools (click, hover, type, …)
- * that talk to CDP directly rather than going through Playwright's
- * selector engine. Legacy tools that still drive a Playwright `Page`
- * continue to call {@link resolveSelector} and receive a plain string
- * selector — the two helpers coexist during the Phase 3 migration.
+ * Consumed by CDP-native interaction tools (click, hover, type, …)
+ * that talk to CDP directly.
  */
 export type ResolvedElement =
   | { kind: "backend"; backendNodeId: number; eid: string }
@@ -180,12 +117,11 @@ export type ResolvedElement =
 
 /**
  * Resolve an element reference (either `element_id` from a prior
- * snapshot or a raw `selector`) for CDP-native tools. Behaves like
- * {@link resolveSelector} in its input validation but returns a
- * {@link ResolvedElement} instead of a string so the caller can
- * branch on whether a backendNodeId was recovered from the snapshot
- * map. Returns `{ resolved: null, error: "Error: …" }` on invalid
- * input or when an `element_id` is provided but the snapshot map is
+ * snapshot or a raw `selector`) for CDP-native tools. Returns a
+ * {@link ResolvedElement} discriminated union so callers can branch
+ * on whether a backendNodeId was recovered from the snapshot map.
+ * Returns `{ resolved: null, error: "Error: …" }` on invalid input
+ * or when an `element_id` is provided but the snapshot map is
  * empty/stale.
  */
 export function resolveElement(
@@ -443,9 +379,9 @@ export async function executeBrowserNavigate(
     }
 
     // Navigation changed the page content, so clear stale snapshot
-    // mappings regardless of backend. The snapshot map is shared
+    // mappings regardless of backend. The backendNodeId map is shared
     // per-conversation state that needs to be invalidated on any nav.
-    browserManager.clearSnapshotMap(context.conversationId);
+    browserManager.clearSnapshotBackendNodeMap(context.conversationId);
 
     // Auto-dismiss common blocker modals (regulatory notices, cookie
     // banners) that aren't exposed in the accessibility tree. Runs
@@ -646,81 +582,22 @@ export async function executeBrowserSnapshot(
     const title = await getPageTitle(cdp, context.signal);
 
     // Pull the full accessibility tree via CDP and fold it into typed
-    // interactive elements + an `eid → backendNodeId` map. This replaces
-    // the legacy `document.querySelectorAll` + `data-vellum-eid` JS that
-    // used to drive the snapshot, and lets downstream CDP-migrated tools
-    // (click, hover, type, …) jump straight to DOM commands without
-    // another round-trip through Playwright's selector engine.
+    // interactive elements + an `eid → backendNodeId` map. Interaction
+    // tools (click, hover, type, …) resolve element_id against this map
+    // and jump straight to CDP DOM commands without another round-trip
+    // through any selector engine.
     await cdp.send("Accessibility.enable", {}, context.signal);
     const rawTree = await cdp.send(
       "Accessibility.getFullAXTree",
       {},
       context.signal,
     );
-    const { elements, selectorMap: backendNodeMap } = transformAxTree(rawTree, {
-      maxElements: MAX_SNAPSHOT_ELEMENTS,
-    });
+    const { elements, selectorMap: backendNodeMap } = transformAxTree(rawTree);
 
     browserManager.storeSnapshotBackendNodeMap(
       context.conversationId,
       backendNodeMap,
     );
-
-    // Bridge: tag every surfaced element with `data-vellum-eid` via
-    // `DOM.pushNodesByBackendIdsToFrontend` + `DOM.setAttributeValue`
-    // so the legacy string selector map keeps working for unmigrated
-    // interaction tools (click/type/hover/etc.) during the Phase 3
-    // migration window. This block is removed in PR 12 once every
-    // interaction tool resolves eids against the backendNodeId map
-    // directly. The cost is ~one CDP call per interactive element per
-    // snapshot — measurable but bounded to the migration window.
-    const stringSelectorMap = new Map<string, string>();
-    if (backendNodeMap.size > 0) {
-      const eidsInOrder = [...backendNodeMap.keys()];
-      const backendNodeIds = eidsInOrder.map((eid) => backendNodeMap.get(eid)!);
-      try {
-        const { nodeIds } = await cdp.send<{ nodeIds: number[] }>(
-          "DOM.pushNodesByBackendIdsToFrontend",
-          { backendNodeIds },
-          context.signal,
-        );
-        for (let i = 0; i < eidsInOrder.length; i += 1) {
-          const eid = eidsInOrder[i]!;
-          const nodeId = nodeIds?.[i];
-          if (!nodeId) continue;
-          try {
-            await cdp.send(
-              "DOM.setAttributeValue",
-              {
-                nodeId,
-                name: "data-vellum-eid",
-                value: eid,
-              },
-              context.signal,
-            );
-            stringSelectorMap.set(eid, `[data-vellum-eid="${eid}"]`);
-          } catch (tagErr) {
-            // Best-effort: a single element failing to be tagged should
-            // not invalidate the whole snapshot. Log and move on so the
-            // backendNodeId path for that element still works.
-            log.debug(
-              { err: tagErr, eid, nodeId },
-              "Failed to tag element with data-vellum-eid during legacy bridge",
-            );
-          }
-        }
-      } catch (bridgeErr) {
-        // If the bridge itself blows up (e.g. pushNodesByBackendIdsToFrontend
-        // rejected), fall through with an empty legacy map. Unmigrated
-        // interaction tools will surface their own "element_id not
-        // found" error which points the agent at `browser_snapshot`.
-        log.warn(
-          { err: bridgeErr },
-          "Legacy snapshot selector bridge failed; unmigrated interaction tools may regress",
-        );
-      }
-    }
-    browserManager.storeSnapshotMap(context.conversationId, stringSelectorMap);
 
     return {
       content: formatAxSnapshot(
@@ -786,29 +663,46 @@ export async function executeBrowserClose(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
+  const cdp = getCdpClient(context);
   try {
-    const sender = getSender(context.conversationId);
-    if (sender) {
-      await stopBrowserScreencast(context.conversationId);
-    }
+    if (cdp.kind === "local") {
+      // Local/sacrificial-profile path: tear down the Playwright page,
+      // screencast, and associated CDP state for this conversation.
+      const sender = getSender(context.conversationId);
+      if (sender) {
+        await stopBrowserScreencast(context.conversationId);
+      }
 
-    if (input.close_all_pages === true) {
-      await stopAllScreencasts();
-      await browserManager.closeAllPages();
+      if (input.close_all_pages === true) {
+        await stopAllScreencasts();
+        await browserManager.closeAllPages();
+        return {
+          content: "All browser pages and context closed.",
+          isError: false,
+        };
+      }
+      await browserManager.closeSessionPage(context.conversationId);
       return {
-        content: "All browser pages and context closed.",
+        content: "Browser page closed for this conversation.",
         isError: false,
       };
     }
-    await browserManager.closeSessionPage(context.conversationId);
+
+    // Extension path: the user owns their Chrome tab — we must not
+    // close it. Only drop the cached snapshot state so stale eids
+    // from prior snapshots cannot be resolved by later tool calls.
+    browserManager.clearSnapshotBackendNodeMap(context.conversationId);
     return {
-      content: "Browser page closed for this conversation.",
+      content:
+        "Browser session cleared. (Your Chrome tab was not closed — close it yourself if desired.)",
       isError: false,
     };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     log.error({ err }, "Close failed");
     return { content: `Error: Close failed: ${msg}`, isError: true };
+  } finally {
+    cdp.dispose();
   }
 }
 
@@ -1339,26 +1233,41 @@ export async function executeBrowserFillCredential(
     return { content: "Error: field is required.", isError: true };
   }
 
-  const { selector, error } = resolveSelector(context.conversationId, input);
+  const { resolved, error } = resolveElement(context.conversationId, input);
   if (error) return { content: error, isError: true };
 
   const pressEnter = input.press_enter === true;
+  const targetDescription =
+    resolved!.kind === "backend"
+      ? `element_id "${resolved!.eid}"`
+      : resolved!.selector;
 
+  const cdp = getCdpClient(context);
   try {
-    const page = await browserManager.getOrCreateSessionPage(
-      context.conversationId,
-    );
+    let backendNodeId: number;
+    if (resolved!.kind === "backend") {
+      backendNodeId = resolved!.backendNodeId;
+    } else {
+      backendNodeId = await querySelectorBackendNodeId(
+        cdp,
+        resolved!.selector,
+        context.signal,
+      );
+    }
 
-    // Extract domain from the current page for domain policy enforcement
+    // Extract the current page's hostname for broker domain policy
+    // enforcement. Failures here (pre-navigation, about:blank, malformed
+    // URL) fall through with pageDomain undefined; if the credential
+    // has a domain policy the broker will deny the fill.
     let pageDomain: string | undefined;
     try {
-      const pageUrl = page.url();
+      const pageUrl = await getCurrentUrl(cdp, context.signal);
       if (pageUrl && pageUrl !== "about:blank") {
         const parsed = new URL(pageUrl);
         pageDomain = parsed.hostname;
       }
     } catch {
-      // Invalid URL - pageDomain stays undefined, broker will deny if domain policy exists
+      // pageDomain stays undefined
     }
 
     const result = await credentialBroker.browserFill({
@@ -1367,7 +1276,11 @@ export async function executeBrowserFillCredential(
       toolName: "browser_fill_credential",
       domain: pageDomain,
       fill: async (value) => {
-        await page.fill(selector!, value);
+        // Focus the target immediately before inserting text so
+        // Input.insertText lands on the right element even if a
+        // prior tool call shifted focus.
+        await focusElement(cdp, backendNodeId, context.signal);
+        await dispatchInsertText(cdp, value, context.signal);
       },
     });
 
@@ -1397,7 +1310,10 @@ export async function executeBrowserFillCredential(
           isError: true,
         };
       }
-      log.error({ selector, reason }, "Fill credential failed");
+      log.error(
+        { target: targetDescription, reason },
+        "Fill credential failed",
+      );
       return {
         content: `Error: Fill credential failed: ${reason}`,
         isError: true,
@@ -1405,7 +1321,7 @@ export async function executeBrowserFillCredential(
     }
 
     if (pressEnter) {
-      await page.press(selector!, "Enter");
+      await dispatchKeyPress(cdp, "Enter", context.signal);
     }
 
     return {
@@ -1416,5 +1332,7 @@ export async function executeBrowserFillCredential(
     const msg = err instanceof Error ? err.message : String(err);
     log.error({ err }, "Fill credential failed");
     return { content: `Error: Fill credential failed: ${msg}`, isError: true };
+  } finally {
+    cdp.dispose();
   }
 }

--- a/assistant/src/tools/browser/browser-manager.ts
+++ b/assistant/src/tools/browser/browser-manager.ts
@@ -203,14 +203,11 @@ class BrowserManager {
   private pages = new Map<string, Page>();
   private rawPages = new Map<string, unknown>();
   private cdpSessions = new Map<string, CDPSession>();
-  private snapshotMaps = new Map<string, Map<string, string>>();
   /**
    * CDP backendNodeId lookup per conversation, populated by the
    * AX-tree-based `executeBrowserSnapshot`. Click/type/hover/etc. tools
    * resolve an element_id against this map and talk to CDP with the
-   * resulting backendNodeId. Lives alongside {@link snapshotMaps} during
-   * the Phase 3 migration window; the legacy string-selector map is
-   * removed in PR 12 once every interaction tool reads from this map.
+   * resulting backendNodeId.
    */
   private snapshotBackendNodeMaps = new Map<string, Map<string, number>>();
   private browserCdpSession: CDPSession | null = null;
@@ -367,7 +364,6 @@ class BrowserManager {
           this.rawPages.clear();
           this.cdpSessions.clear();
 
-          this.snapshotMaps.clear();
           this.snapshotBackendNodeMaps.clear();
           this.downloads.clear();
           for (const pending of this.pendingDownloads.values()) {
@@ -394,7 +390,6 @@ class BrowserManager {
     }
 
     // Clear stale snapshot mappings and CDP state when replacing a closed page
-    this.snapshotMaps.delete(conversationId);
     this.snapshotBackendNodeMaps.delete(conversationId);
     await this.stopScreencast(conversationId);
 
@@ -448,7 +443,6 @@ class BrowserManager {
     }
     this.pages.delete(conversationId);
     this.rawPages.delete(conversationId);
-    this.snapshotMaps.delete(conversationId);
     this.snapshotBackendNodeMaps.delete(conversationId);
     this.downloads.delete(conversationId);
     // Reject any pending download waiters
@@ -482,7 +476,6 @@ class BrowserManager {
     }
     this.pages.clear();
     this.rawPages.clear();
-    this.snapshotMaps.clear();
     this.snapshotBackendNodeMaps.clear();
     this.downloads.clear();
     for (const pending of this.pendingDownloads.values()) {
@@ -539,30 +532,6 @@ class BrowserManager {
     }
   }
 
-  storeSnapshotMap(conversationId: string, map: Map<string, string>): void {
-    this.snapshotMaps.set(conversationId, map);
-  }
-
-  /**
-   * Clear any cached snapshot lookups for the given conversation. Drops
-   * BOTH the legacy string-selector map and the newer backendNodeId map
-   * so that stale element IDs from a previous page can never resolve
-   * after a navigation or page close.
-   */
-  clearSnapshotMap(conversationId: string): void {
-    this.snapshotMaps.delete(conversationId);
-    this.snapshotBackendNodeMaps.delete(conversationId);
-  }
-
-  resolveSnapshotSelector(
-    conversationId: string,
-    elementId: string,
-  ): string | null {
-    const map = this.snapshotMaps.get(conversationId);
-    if (!map) return null;
-    return map.get(elementId) ?? null;
-  }
-
   /**
    * Store the backendNodeId lookup produced by the AX-tree-based
    * `executeBrowserSnapshot`. Callers overwrite any prior map for the
@@ -576,9 +545,9 @@ class BrowserManager {
   }
 
   /**
-   * Drop the backendNodeId lookup for a conversation without touching
-   * the legacy string-selector map. Prefer {@link clearSnapshotMap}
-   * when you want to invalidate everything at once.
+   * Drop the backendNodeId lookup for a conversation so stale element
+   * IDs from a previous snapshot cannot resolve after a navigation or
+   * page close.
    */
   clearSnapshotBackendNodeMap(conversationId: string): void {
     this.snapshotBackendNodeMaps.delete(conversationId);

--- a/assistant/src/tools/browser/cdp-client/accessibility-snapshot.ts
+++ b/assistant/src/tools/browser/cdp-client/accessibility-snapshot.ts
@@ -46,20 +46,16 @@ export interface AxSnapshotResult {
 
 // ── Constants ─────────────────────────────────────────────────────────
 
-/**
- * Default maximum number of interactive elements returned in a snapshot.
- * Mirrors the legacy `MAX_SNAPSHOT_ELEMENTS` constant in
- * `browser-execution.ts` so parity is preserved during the migration.
- */
+/** Default maximum number of interactive elements returned in a snapshot. */
 export const DEFAULT_MAX_ELEMENTS = 150;
 
 /**
- * AX roles we consider "interactive" and surface to the LLM. Derived
- * from the legacy `INTERACTIVE_SELECTOR` list in `browser-execution.ts`
- * plus standard ARIA interactive roles. A node whose role is in this set
- * is always kept (subject to ignored/backendNodeId filters). Nodes with
- * a `focusable: true` property are also kept regardless of role so that
- * contenteditable widgets and custom controls surface.
+ * AX roles we consider "interactive" and surface to the LLM. Includes
+ * common form controls, links, buttons, and standard ARIA interactive
+ * roles. A node whose role is in this set is always kept (subject to
+ * ignored/backendNodeId filters). Nodes with a `focusable: true`
+ * property are also kept regardless of role so that contenteditable
+ * widgets and custom controls surface.
  */
 const INTERACTIVE_ROLES: ReadonlySet<string> = new Set([
   "button",


### PR DESCRIPTION
## Summary
- \`executeBrowserClose\` and \`executeBrowserFillCredential\` now drive CDP via \`CdpClient\`; close branches on transport kind and skips local cleanup on the extension path
- \`executeBrowserSnapshot\` no longer populates the legacy string-selector map bridge — all interaction tools use the backendNodeId map directly
- Deletes \`browserManager.snapshotMaps\`, \`storeSnapshotMap\`, \`clearSnapshotMap\`, \`resolveSnapshotSelector\` and the legacy \`resolveSelector\` helper in browser-execution.ts
- Completes the Phase 3 tool migration: every \`executeBrowserXxx\` function now routes through \`getCdpClient(context)\`

Part of plan: phase3-cdp-migration.md (PR 12 of 14)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24306" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
