### PR TITLE
feat(macOS): add copy and inspect buttons to subagent detail panel

### DIFF
--- a/assistant/src/__tests__/subagent-detail.test.ts
+++ b/assistant/src/__tests__/subagent-detail.test.ts
@@ -5,10 +5,20 @@
 
 import { describe, expect, test } from "bun:test";
 
+import type { MessageRow } from "../memory/conversation-crud.js";
 import { parseSubagentMessages } from "../runtime/routes/subagents-routes.js";
 
-function msg(role: string, content: unknown[]) {
-  return { role, content: JSON.stringify(content) };
+let msgCounter = 0;
+function msg(role: string, content: unknown[]): MessageRow {
+  msgCounter += 1;
+  return {
+    id: `msg-${msgCounter}`,
+    conversationId: "conv-1",
+    role,
+    content: JSON.stringify(content),
+    createdAt: Date.now(),
+    metadata: null,
+  };
 }
 
 describe("parseSubagentMessages", () => {
@@ -80,5 +90,17 @@ describe("parseSubagentMessages", () => {
 
     const result = parseSubagentMessages("sub-1", messages);
     expect(result.objective).toBe("Research vampire lore");
+  });
+
+  test("includes messageId on text events from assistant messages", () => {
+    const messages = [
+      msg("user", [{ type: "text", text: "Do something" }]),
+      msg("assistant", [{ type: "text", text: "Done." }]),
+    ];
+
+    const result = parseSubagentMessages("sub-1", messages);
+    const textEvent = result.events.find((e) => e.type === "text");
+    expect(textEvent).toBeDefined();
+    expect(textEvent!.messageId).toBe(messages[1].id);
   });
 });

--- a/assistant/src/daemon/message-types/subagents.ts
+++ b/assistant/src/daemon/message-types/subagents.ts
@@ -30,6 +30,7 @@ export interface SubagentDetailResponse {
     content: string;
     toolName?: string;
     isError?: boolean;
+    messageId?: string;
   }>;
 }
 

--- a/assistant/src/runtime/routes/subagents-routes.ts
+++ b/assistant/src/runtime/routes/subagents-routes.ts
@@ -7,7 +7,7 @@
  */
 import { z } from "zod";
 
-import { getMessages } from "../../memory/conversation-crud.js";
+import { getMessages, type MessageRow } from "../../memory/conversation-crud.js";
 import { getSubagentManager } from "../../subagent/index.js";
 import { getLogger } from "../../util/logger.js";
 import { httpError } from "../http-errors.js";
@@ -31,6 +31,7 @@ export interface SubagentDetailResult {
     content: string;
     toolName?: string;
     isError?: boolean;
+    messageId?: string;
   }>;
 }
 
@@ -40,7 +41,7 @@ export interface SubagentDetailResult {
  */
 export function parseSubagentMessages(
   subagentId: string,
-  messages: Array<{ role: string; content: string }>,
+  messages: MessageRow[],
 ): SubagentDetailResult {
   // Extract objective from the first user message
   let objective: string | undefined;
@@ -62,12 +63,7 @@ export function parseSubagentMessages(
   }
 
   // Extract events from both assistant and user messages.
-  const events: Array<{
-    type: string;
-    content: string;
-    toolName?: string;
-    isError?: boolean;
-  }> = [];
+  const events: SubagentDetailResult["events"] = [];
   const pendingTools = new Map<string, string>();
   for (const m of messages) {
     if (m.role !== "assistant" && m.role !== "user") continue;
@@ -86,7 +82,7 @@ export function parseSubagentMessages(
         block.type === "text" &&
         typeof block.text === "string"
       ) {
-        events.push({ type: "text", content: block.text });
+        events.push({ type: "text", content: block.text, messageId: m.id });
       } else if (block.type === "tool_use") {
         const name = typeof block.name === "string" ? block.name : "unknown";
         const input = isRecord(block.input)

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
@@ -62,6 +62,10 @@ public final class MainWindowState: ObservableObject {
 
     @Published var selectedSubagentId: String?
 
+    /// Daemon message ID for the LLM context inspector overlay. Shared so both
+    /// the main chat and the subagent detail panel can trigger the inspector.
+    @Published var inspectorMessageId: String?
+
     /// Transient memory ID to deep-link into when the Intelligence panel opens.
     /// Consumed once by IntelligencePanel/MemoriesPanel, then set back to nil.
     @Published var pendingMemoryId: String?

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -400,6 +400,7 @@ extension MainWindowView {
                         subagentId: subagentId,
                         viewModel: viewModel,
                         detailStore: viewModel.subagentDetailStore,
+                        showInspectButton: assistantFeatureFlagStore.isEnabled("settings-developer-nav"),
                         onAbort: { Task { await SubagentClient().abort(subagentId: subagentId, conversationId: viewModel.conversationId) } },
                         onRequestDetail: {
                             if let conversationId = viewModel.activeSubagents.first(where: { $0.id == subagentId })?.conversationId {
@@ -408,6 +409,11 @@ extension MainWindowView {
                                         viewModel.subagentDetailStore.populateFromDetailResponse(response)
                                     }
                                 }
+                            }
+                        },
+                        onInspectMessage: { messageId in
+                            withAnimation(VAnimation.standard) {
+                                windowState.inspectorMessageId = messageId
                             }
                         },
                         onClose: { windowState.selectedSubagentId = nil }
@@ -617,8 +623,9 @@ extension MainWindowView {
 // MARK: - Wrapper Views
 
 /// Renders the chat interface with an optional message inspector overlay.
-/// Owns the inspector state and bootstrap-state reading; ChatView reads
-/// viewModel properties directly via @Bindable.
+/// Owns bootstrap-state reading; ChatView reads viewModel properties directly
+/// via @Bindable. Inspector state is shared via `MainWindowState.inspectorMessageId`
+/// so both the chat and the subagent panel can trigger it.
 struct ActiveChatViewWrapper: View {
     @Bindable var viewModel: ChatViewModel
     var windowState: MainWindowState
@@ -639,8 +646,6 @@ struct ActiveChatViewWrapper: View {
     var conversationId: UUID?
     @Binding var anchorMessageId: UUID?
     @Binding var highlightedMessageId: UUID?
-
-    @State private var inspectorMessageId: String? = nil
 
     /// Reads the persisted bootstrap state so the chat view can suppress
     /// the empty state during first-launch bootstrap.
@@ -691,7 +696,7 @@ struct ActiveChatViewWrapper: View {
                 anchorMessageId: $anchorMessageId,
                 highlightedMessageId: $highlightedMessageId,
                 conversationId: conversationId,
-                isInteractionEnabled: inspectorMessageId == nil,
+                isInteractionEnabled: windowState.inspectorMessageId == nil,
                 isReadonly: isReadonly,
                 isBootstrapping: isBootstrapping,
                 isBootstrapTimedOut: isBootstrapTimedOut,
@@ -707,9 +712,9 @@ struct ActiveChatViewWrapper: View {
                 watchSession: ambientAgent.activeWatchSession
             )
             .environment(\.cmdEnterToSend, settingsStore.cmdEnterToSend)
-            .disabled(inspectorMessageId != nil)
+            .disabled(windowState.inspectorMessageId != nil)
 
-            if let messageId = inspectorMessageId {
+            if let messageId = windowState.inspectorMessageId {
                 MessageInspectorView(
                     messageId: messageId,
                     onBack: dismissInspector
@@ -717,22 +722,22 @@ struct ActiveChatViewWrapper: View {
                 .transition(.move(edge: .trailing).combined(with: .opacity))
             }
         }
-        .animation(VAnimation.standard, value: inspectorMessageId)
+        .animation(VAnimation.standard, value: windowState.inspectorMessageId)
         .onChange(of: conversationId) { _, _ in
-            inspectorMessageId = nil
+            windowState.inspectorMessageId = nil
         }
     }
 
     private func presentInspector(for messageId: String?) {
         guard let messageId else { return }
         withAnimation(VAnimation.standard) {
-            inspectorMessageId = messageId
+            windowState.inspectorMessageId = messageId
         }
     }
 
     private func dismissInspector() {
         withAnimation(VAnimation.standard) {
-            inspectorMessageId = nil
+            windowState.inspectorMessageId = nil
         }
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SubagentDetailPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SubagentDetailPanel.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 import VellumAssistantShared
 
@@ -5,8 +6,10 @@ struct SubagentDetailPanel: View {
     let subagentId: String
     var viewModel: ChatViewModel
     var detailStore: SubagentDetailStore
+    var showInspectButton: Bool = false
     var onAbort: (() -> Void)?
     var onRequestDetail: (() -> Void)?
+    var onInspectMessage: ((String) -> Void)?
     var onClose: () -> Void
     @ObservedObject private var typographyObserver = VFont.typographyObserver
 
@@ -97,7 +100,12 @@ struct SubagentDetailPanel: View {
             } else {
                 LazyVStack(alignment: .leading, spacing: VSpacing.lg) {
                     ForEach(events) { event in
-                        eventRow(event)
+                        SubagentEventRowView(
+                            event: event,
+                            showInspectButton: showInspectButton,
+                            onInspectMessage: onInspectMessage,
+                            typographyGeneration: typographyObserver.generation
+                        )
                     }
                 }
             }
@@ -171,18 +179,117 @@ struct SubagentDetailPanel: View {
         }
     }
 
-    // MARK: - Event Row
+    // MARK: - Formatting
 
-    @ViewBuilder
-    private func eventRow(_ event: SubagentEventItem) -> some View {
+    private func formatNumber(_ n: Int) -> String {
+        if n >= 1_000_000 { return String(format: "%.1fM", Double(n) / 1_000_000) }
+        if n >= 1_000 { return String(format: "%.1fK", Double(n) / 1_000) }
+        return "\(n)"
+    }
+
+    private func formatCost(_ cost: Double) -> String {
+        if cost == 0 { return UsageFormatting.formatCostShort(0) }
+        if cost < 0.01 { return "<\(UsageFormatting.formatCostShort(0.01))" }
+        return UsageFormatting.formatCostShort(cost)
+    }
+}
+
+// MARK: - Event Row View
+
+/// Each event row needs its own hover/copy-confirmation state, so it must be a
+/// separate view struct (SwiftUI scopes @State per view identity in ForEach).
+private struct SubagentEventRowView: View {
+    let event: SubagentEventItem
+    let showInspectButton: Bool
+    var onInspectMessage: ((String) -> Void)?
+    let typographyGeneration: Int
+
+    @State private var isHovered = false
+    @State private var showCopyConfirmation = false
+    @State private var copyConfirmationTimer: DispatchWorkItem?
+
+    private var hasCopyableContent: Bool {
+        !event.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private var canInspect: Bool {
+        showInspectButton && event.daemonMessageId != nil && {
+            if case .text = event.kind { return true }
+            return false
+        }()
+    }
+
+    private var showActions: Bool {
+        (hasCopyableContent || canInspect) && (isHovered || showCopyConfirmation)
+    }
+
+    var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.xs) {
-            // Label above the card
             eventLabel(for: event.kind)
 
-            // Content card
-            eventContent(event)
+            ZStack(alignment: .topTrailing) {
+                eventContent(event)
+
+                if showActions {
+                    actionButtons
+                        .transition(.opacity)
+                }
+            }
+            .onHover { isHovered = $0 }
+            .animation(VAnimation.fast, value: showActions)
         }
     }
+
+    // MARK: - Action Buttons
+
+    private var actionButtons: some View {
+        HStack(spacing: 2) {
+            if hasCopyableContent {
+                ChatEquatableButton(
+                    label: showCopyConfirmation ? "Copied" : "Copy",
+                    iconOnly: (showCopyConfirmation ? VIcon.check : VIcon.copy).rawValue,
+                    iconColorRole: showCopyConfirmation ? .systemPositiveStrong : .contentTertiary
+                ) {
+                    copyContent()
+                }
+                .equatable()
+                .vTooltip(showCopyConfirmation ? "Copied" : "Copy", edge: .bottom)
+                .animation(VAnimation.fast, value: showCopyConfirmation)
+            }
+            if canInspect, let daemonMessageId = event.daemonMessageId {
+                ChatEquatableButton(
+                    label: "Inspect LLM context",
+                    iconOnly: VIcon.fileCode.rawValue
+                ) {
+                    onInspectMessage?(daemonMessageId)
+                }
+                .equatable()
+                .vTooltip("Inspect", edge: .bottom)
+            }
+        }
+        .padding(VSpacing.xxs)
+        .background(
+            RoundedRectangle(cornerRadius: VRadius.sm)
+                .fill(VColor.surfaceOverlay.opacity(0.9))
+        )
+        .textSelection(.disabled)
+    }
+
+    // MARK: - Copy
+
+    private func copyContent() {
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(event.content, forType: .string)
+
+        copyConfirmationTimer?.cancel()
+        showCopyConfirmation = true
+        let timer = DispatchWorkItem { showCopyConfirmation = false }
+        copyConfirmationTimer = timer
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5, execute: timer)
+    }
+
+    // MARK: - Event Label
 
     @ViewBuilder
     private func eventLabel(for kind: SubagentEventItem.Kind) -> some View {
@@ -208,13 +315,15 @@ struct SubagentDetailPanel: View {
         .foregroundStyle(color)
     }
 
+    // MARK: - Event Content
+
     @ViewBuilder
     private func eventContent(_ event: SubagentEventItem) -> some View {
         switch event.kind {
         case .text:
             MarkdownSegmentView(
                 segments: parseMarkdownSegments(event.content),
-                typographyGeneration: typographyObserver.generation,
+                typographyGeneration: typographyGeneration,
                 maxContentWidth: nil
             )
                 .equatable()
@@ -279,19 +388,5 @@ struct SubagentDetailPanel: View {
                         )
                 )
         }
-    }
-
-    // MARK: - Formatting
-
-    private func formatNumber(_ n: Int) -> String {
-        if n >= 1_000_000 { return String(format: "%.1fM", Double(n) / 1_000_000) }
-        if n >= 1_000 { return String(format: "%.1fK", Double(n) / 1_000) }
-        return "\(n)"
-    }
-
-    private func formatCost(_ cost: Double) -> String {
-        if cost == 0 { return UsageFormatting.formatCostShort(0) }
-        if cost < 0.01 { return "<\(UsageFormatting.formatCostShort(0.01))" }
-        return UsageFormatting.formatCostShort(cost)
     }
 }

--- a/clients/shared/Features/Chat/SubagentDetailStore.swift
+++ b/clients/shared/Features/Chat/SubagentDetailStore.swift
@@ -26,13 +26,16 @@ public struct SubagentEventItem: Identifiable {
     public var resultContent: String?
     /// Whether the attached result is an error.
     public var resultIsError: Bool
+    /// Daemon message ID for assistant text events (used for LLM context inspection).
+    public var daemonMessageId: String?
 
-    public init(timestamp: Date, kind: Kind, content: String, resultContent: String? = nil, resultIsError: Bool = false) {
+    public init(timestamp: Date, kind: Kind, content: String, resultContent: String? = nil, resultIsError: Bool = false, daemonMessageId: String? = nil) {
         self.timestamp = timestamp
         self.kind = kind
         self.content = content
         self.resultContent = resultContent
         self.resultIsError = resultIsError
+        self.daemonMessageId = daemonMessageId
     }
 }
 
@@ -320,6 +323,18 @@ public final class SubagentDetailStore {
             trackMutation()
             #endif
 
+        case .messageComplete(let msg):
+            guard let messageId = msg.messageId else { break }
+            var events = currentEvents(for: subagentId)
+            // Walk backward to find the last text event and attach the daemon message ID.
+            for i in stride(from: events.count - 1, through: 0, by: -1) {
+                if case .text = events[i].kind, events[i].daemonMessageId == nil {
+                    events[i].daemonMessageId = messageId
+                    break
+                }
+            }
+            stageEvents(events, for: subagentId)
+
         case .usageUpdate(let update):
             // Skip late deltas after terminal status to avoid double-counting
             // (recordStatusChanged already wrote cumulative stats).
@@ -362,6 +377,14 @@ public final class SubagentDetailStore {
                     subagentId: subagentId,
                     event: .assistantTextDelta(AssistantTextDelta(type: "assistant_text_delta", text: event.content, conversationId: nil))
                 )
+                // Attach daemon message ID from the detail response if available.
+                if let messageId = event.messageId {
+                    var events = currentEvents(for: subagentId)
+                    if let lastIndex = events.indices.last, case .text = events[lastIndex].kind {
+                        events[lastIndex].daemonMessageId = messageId
+                        stageEvents(events, for: subagentId)
+                    }
+                }
             case "tool_use":
                 let input: [String: AnyCodable]
                 if let data = event.content.data(using: .utf8),

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -4316,12 +4316,14 @@ public struct SubagentDetailResponseEvent: Codable, Sendable {
     public let content: String
     public let toolName: String?
     public let isError: Bool?
+    public let messageId: String?
 
-    public init(type: String, content: String, toolName: String? = nil, isError: Bool? = nil) {
+    public init(type: String, content: String, toolName: String? = nil, isError: Bool? = nil, messageId: String? = nil) {
         self.type = type
         self.content = content
         self.toolName = toolName
         self.isError = isError
+        self.messageId = messageId
     }
 }
 


### PR DESCRIPTION
## Summary
- Add hover-activated copy and inspect buttons to subagent event rows in the right-side detail panel
- Thread daemon message IDs through the subagent event system (streaming via `messageComplete` handling, historical via detail response) so the LLM context inspector works for subagent responses
- Lift inspector state from `ActiveChatViewWrapper` to `MainWindowState` so both the main chat and subagent panel can trigger the inspector

## Original prompt
Add copy and inspect buttons to subagent messages (right panel)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24312" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
