### PR TITLE
fix: escape subagent labels in buildSubagentStatusBlock to prevent XML injection

### DIFF
--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -448,6 +448,16 @@ export function injectActiveSurfaceContext(
 // Subagent status injection
 // ---------------------------------------------------------------------------
 
+/** Escape XML special characters to prevent injection in XML blocks. */
+function escapeXml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
 /**
  * Build the `<active_subagents>` injection block from the current child states.
  * Returns null if there are no children (zero overhead for non-subagent parents).
@@ -464,7 +474,7 @@ export function buildSubagentStatusBlock(
       ? `${Math.round((now - child.startedAt) / 1000)}s`
       : "pending";
     const parts = [
-      `- [${child.status}] "${child.config.label}" (${child.config.id})`,
+      `- [${child.status}] "${escapeXml(child.config.label)}" (${escapeXml(child.config.id)})`,
     ];
     if (!TERMINAL_STATUSES.has(child.status)) {
       parts.push(`elapsed: ${elapsed}`);


### PR DESCRIPTION
Addresses review feedback on PR #24161. Applies XML entity encoding to child.config.label and child.config.id before injecting into the active_subagents XML block, preventing crafted labels from breaking the prompt structure.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24315" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
