### PR TITLE
fix: derefToolResultReReads backwards compat and error handling

### DIFF
--- a/assistant/src/context/post-turn-tool-result-truncation.ts
+++ b/assistant/src/context/post-turn-tool-result-truncation.ts
@@ -135,7 +135,7 @@ export function derefToolResultReReads(messages: Message[]): {
       if (block.type !== "tool_use") continue;
       const tu = block as ToolUseContent;
       if (tu.name !== "file_read") continue;
-      const filePath = tu.input.path;
+      const filePath = tu.input.path ?? tu.input.file_path;
       if (typeof filePath !== "string") continue;
       if (filePath.includes(`/${TOOL_RESULT_DIR}/`)) {
         reReadToolUseIds.add(tu.id);
@@ -157,6 +157,9 @@ export function derefToolResultReReads(messages: Message[]): {
       if (block.type !== "tool_result") return block;
       const tr = block as ToolResultContent;
       if (!reReadToolUseIds.has(tr.tool_use_id)) return block;
+
+      // Skip error results — preserve diagnostics (e.g. file not found).
+      if (tr.is_error) return block;
 
       changed = true;
       dereferencedCount++;


### PR DESCRIPTION
Addresses review feedback on PR #24204 and #24215. Checks both tu.input.path and tu.input.file_path for backwards compatibility with old conversations. Skips replacement when tr.is_error is true to preserve error diagnostics.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24316" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
