### PR TITLE
fix: strip fork directive framing from objective in parseSubagentMessages

### DIFF
--- a/assistant/src/runtime/routes/subagents-routes.ts
+++ b/assistant/src/runtime/routes/subagents-routes.ts
@@ -35,6 +35,14 @@ export interface SubagentDetailResult {
   }>;
 }
 
+const FORK_DIRECTIVE_RE =
+  /^⎯⎯⎯ FORK TASK ⎯⎯⎯\n.*?Complete this task directly and return only your findings:\n\n([\s\S]*?)\n⎯⎯⎯+$/;
+
+function stripForkDirectiveFraming(text: string): string {
+  const match = FORK_DIRECTIVE_RE.exec(text);
+  return match ? match[1] : text;
+}
+
 /**
  * Parse raw message rows into subagent detail events. Extracted as a pure
  * function so it can be unit-tested without a database.
@@ -54,7 +62,7 @@ export function parseSubagentMessages(
           (b: Record<string, unknown>) => isRecord(b) && b.type === "text",
         );
         if (textBlock && typeof textBlock.text === "string") {
-          objective = textBlock.text;
+          objective = stripForkDirectiveFraming(textBlock.text);
         }
       }
     } catch {


### PR DESCRIPTION
Addresses review feedback on PR #24243. Strips the FORK TASK directive wrapper from the first user message text when extracting the objective in parseSubagentMessages, so detail APIs and UI show the raw objective instead of the framing.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24318" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
