### PR TITLE
fix: allow usage updates after terminal status in SubagentDetailStore

### DIFF
--- a/clients/shared/Features/Chat/SubagentDetailStore.swift
+++ b/clients/shared/Features/Chat/SubagentDetailStore.swift
@@ -336,9 +336,6 @@ public final class SubagentDetailStore {
             stageEvents(events, for: subagentId)
 
         case .usageUpdate(let update):
-            // Skip late deltas after terminal status to avoid double-counting
-            // (recordStatusChanged already wrote cumulative stats).
-            guard !terminalSubagentIds.contains(subagentId) else { break }
             let current = stagedUsage[subagentId] ?? subagentStates[subagentId]?.usageStats ?? SubagentUsageStats()
             stagedUsage[subagentId] = SubagentUsageStats(
                 inputTokens: update.totalInputTokens,


### PR DESCRIPTION
Addresses review feedback on PR #24179. Allows .usageUpdate events to be processed even after a subagent reaches terminal status, ensuring late-arriving usage data (final token counts) is not silently dropped.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24319" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
