### PR TITLE
fix: use stable message IDs in typography refresh tests

### DIFF
--- a/clients/macos/vellum-assistantTests/MessageListTypographyRefreshTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListTypographyRefreshTests.swift
@@ -5,29 +5,32 @@ import XCTest
 @MainActor
 final class MessageListTypographyRefreshTests: XCTestCase {
     func testMessageListContentViewEqualityIncludesTypographyGeneration() {
+        let state = makeDerivedState()
         XCTAssertNotEqual(
-            makeMessageListContentView(typographyGeneration: 0),
-            makeMessageListContentView(typographyGeneration: 1)
+            makeMessageListContentView(state: state, typographyGeneration: 0),
+            makeMessageListContentView(state: state, typographyGeneration: 1)
         )
     }
 
     func testMessageCellViewEqualityIncludesTypographyGeneration() {
+        let message = ChatMessage(role: .assistant, text: "*italic*")
         XCTAssertNotEqual(
-            makeMessageCellView(typographyGeneration: 0),
-            makeMessageCellView(typographyGeneration: 1)
+            makeMessageCellView(message: message, typographyGeneration: 0),
+            makeMessageCellView(message: message, typographyGeneration: 1)
         )
     }
 
     func testChatBubbleEqualityIncludesTypographyGeneration() {
+        let message = ChatMessage(role: .assistant, text: "*italic*")
         XCTAssertNotEqual(
-            makeChatBubble(typographyGeneration: 0),
-            makeChatBubble(typographyGeneration: 1)
+            makeChatBubble(message: message, typographyGeneration: 0),
+            makeChatBubble(message: message, typographyGeneration: 1)
         )
     }
 
-    private func makeMessageListContentView(typographyGeneration: Int) -> MessageListContentView {
+    private func makeMessageListContentView(state: MessageListDerivedState, typographyGeneration: Int) -> MessageListContentView {
         MessageListContentView(
-            state: makeDerivedState(),
+            state: state,
             providerCatalog: [],
             providerCatalogHash: 0,
             typographyGeneration: typographyGeneration,
@@ -50,9 +53,8 @@ final class MessageListTypographyRefreshTests: XCTestCase {
         )
     }
 
-    private func makeMessageCellView(typographyGeneration: Int) -> MessageCellView {
-        let message = ChatMessage(role: .assistant, text: "*italic*")
-        return MessageCellView(
+    private func makeMessageCellView(message: ChatMessage, typographyGeneration: Int) -> MessageCellView {
+        MessageCellView(
             message: message,
             showTimestamp: false,
             nextDecidedConfirmation: nil,
@@ -80,9 +82,9 @@ final class MessageListTypographyRefreshTests: XCTestCase {
         )
     }
 
-    private func makeChatBubble(typographyGeneration: Int) -> ChatBubble {
+    private func makeChatBubble(message: ChatMessage, typographyGeneration: Int) -> ChatBubble {
         ChatBubble(
-            message: ChatMessage(role: .assistant, text: "*italic*"),
+            message: message,
             decidedConfirmation: nil,
             onSurfaceAction: { _, _, _ in },
             onDismissDocumentWidget: { _ in },


### PR DESCRIPTION
Addresses review feedback on PR #24250. Uses shared message instances with stable IDs so that test assertions actually validate typographyGeneration differences rather than passing due to UUID inequality.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24320" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
