### PR TITLE
fix: search scrolling when allowsVerticalScrolling is false in VCodeView

### DIFF
--- a/clients/shared/DesignSystem/Components/Display/VCodeView.swift
+++ b/clients/shared/DesignSystem/Components/Display/VCodeView.swift
@@ -449,6 +449,30 @@ struct VCodeTextView: NSViewRepresentable {
             if !matchRanges.isEmpty, currentIndex < matchRanges.count {
                 let currentRange = NSRange(matchRanges[currentIndex], in: storage.string)
                 textView.scrollRangeToVisible(currentRange)
+
+                // scrollRangeToVisible only scrolls the immediate enclosing
+                // NSScrollView (VCodeHorizontalScrollView for horizontal).
+                // When vertical scrolling is handled by an ancestor scroll
+                // view (allowsVerticalScrolling = false), also scroll that
+                // ancestor to make the match visible.
+                if let layoutManager = textView.layoutManager,
+                   let textContainer = textView.textContainer,
+                   let innerScrollView = textView.enclosingScrollView,
+                   let outerScrollView = innerScrollView.enclosingScrollView,
+                   let outerDocView = outerScrollView.documentView {
+                    let glyphRange = layoutManager.glyphRange(
+                        forCharacterRange: currentRange,
+                        actualCharacterRange: nil
+                    )
+                    var matchRect = layoutManager.boundingRect(
+                        forGlyphRange: glyphRange,
+                        in: textContainer
+                    )
+                    let origin = textView.textContainerOrigin
+                    matchRect = matchRect.offsetBy(dx: origin.x, dy: origin.y)
+                    let converted = textView.convert(matchRect, to: outerDocView)
+                    outerDocView.scrollToVisible(converted)
+                }
             }
         }
     }


### PR DESCRIPTION
Addresses review feedback on PR #24181. When the inner ScrollView is removed (allowsVerticalScrolling: false), scrollRangeToVisible falls back to scrolling the parent/enclosing scroll view to make search matches visible.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24323" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
