### PR TITLE
fix: mark injected inherited context as non-persisted for accurate compaction counting

### DIFF
--- a/assistant/src/context/window-manager.ts
+++ b/assistant/src/context/window-manager.ts
@@ -103,6 +103,14 @@ export class ContextWindowManager {
   private readonly config: ContextWindowConfig;
   private readonly toolTokenBudget: number;
   /**
+   * Number of leading messages that are non-persisted (injected inherited
+   * context from a parent conversation).  `countPersistedMessages` subtracts
+   * this so `compactedPersistedMessages` only reflects DB-backed messages.
+   * Set by `Conversation.injectInheritedContext` and consumed (decremented)
+   * after a successful compaction pass.
+   */
+  nonPersistedPrefixCount = 0;
+  /**
    * Cached resolved system prompt. Lazily populated on first access via the
    * `systemPrompt` getter and cleared after each compaction pass so the next
    * pass picks up any prompt changes.
@@ -305,8 +313,12 @@ export class ContextWindowManager {
       };
     }
 
+    const injectedInCompactable = Math.min(
+      this.nonPersistedPrefixCount,
+      compactableMessages.length,
+    );
     const compactedPersistedMessages =
-      countPersistedMessages(compactableMessages);
+      countPersistedMessages(compactableMessages) - injectedInCompactable;
     const rawProjectedMessages = [
       createContextSummaryMessage(existingSummary ?? "Projected summary"),
       ...messages.slice(keepPlan.keepFromIndex),
@@ -452,6 +464,12 @@ export class ContextWindowManager {
         toolTokenBudget: this.toolTokenBudget,
       },
     );
+    // Consume the injected prefix messages that were compacted away.
+    this.nonPersistedPrefixCount = Math.max(
+      0,
+      this.nonPersistedPrefixCount - injectedInCompactable,
+    );
+
     log.info(
       {
         previousEstimatedInputTokens,

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -616,6 +616,7 @@ export class Conversation {
       );
     }
     this.messages = [...messages];
+    this.contextWindowManager.nonPersistedPrefixCount = messages.length;
   }
 
   /**


### PR DESCRIPTION
Addresses review feedback on PR #24217. Tracks the count of injected parent messages so compaction logic does not incorrectly count them as DB-backed persisted messages.

## Changes

- Added `nonPersistedPrefixCount` property to `ContextWindowManager` to track the number of leading messages that are non-persisted (injected inherited context from parent conversations)
- In `_maybeCompact`, the persisted message count now subtracts injected messages that fall within the compactable range, so `compactedPersistedMessages` only reflects actual DB-backed messages
- After successful compaction, the consumed injected prefix count is decremented
- `Conversation.injectInheritedContext` sets the count on the window manager when injecting parent messages
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24324" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
