### PR TITLE
fix: address CI failure and review feedback for credential teleportation

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -194,6 +194,7 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "oauth/token-persistence.ts", // OAuth token persistence (set/delete tokens)
       "oauth/connection-resolver.ts", // resolve OAuthConnection from oauth-store (access_token lookup)
       "runtime/routes/secret-routes.ts", // HTTP secret management routes (set/delete secrets)
+      "runtime/routes/migration-routes.ts", // migration import credential restore
       "daemon/conversation-messaging.ts", // credential storage during session messaging
       "runtime/routes/settings-routes.ts", // settings routes OAuth credential lookup (client_secret)
       "oauth/oauth-store.ts", // OAuth provider disconnect (delete stored tokens)

--- a/assistant/src/runtime/migrations/migration-wizard.ts
+++ b/assistant/src/runtime/migrations/migration-wizard.ts
@@ -658,6 +658,7 @@ export function prepareForResume(
       preflightResult: undefined,
       exportResult: undefined,
       importResult: undefined,
+      credentialsImported: undefined,
     };
   }
 

--- a/assistant/src/runtime/migrations/rebind-secrets-screen.ts
+++ b/assistant/src/runtime/migrations/rebind-secrets-screen.ts
@@ -342,7 +342,15 @@ export function completeMigration(
   wizardState: MigrationWizardState,
   completionState: RebindTaskCompletionState,
 ): MigrationWizardState {
-  if (!areAllRequiredTasksComplete(completionState)) {
+  // Apply credential-aware effective completion: if all credentials were
+  // imported successfully, treat re-enter-secrets as auto-completed
+  // (mirrors the logic in deriveRebindSecretsScreenState).
+  let effectiveCompletion = completionState;
+  const credInfo = wizardState?.credentialsImported;
+  if (credInfo && credInfo.total > 0 && credInfo.failed === 0) {
+    effectiveCompletion = { ...completionState, "re-enter-secrets": true };
+  }
+  if (!areAllRequiredTasksComplete(effectiveCompletion)) {
     throw new Error(
       "Cannot complete migration: not all required tasks are done",
     );

--- a/assistant/src/runtime/migrations/vbundle-import-analyzer.ts
+++ b/assistant/src/runtime/migrations/vbundle-import-analyzer.ts
@@ -195,6 +195,20 @@ export function analyzeImport(
   for (const fileEntry of manifest.files) {
     const diskPath = pathResolver.resolve(fileEntry.path);
 
+    // Credential entries are handled separately by the credential import
+    // step — skip them without flagging as unknown/conflict.
+    if (fileEntry.path.startsWith("credentials/")) {
+      files.push({
+        path: fileEntry.path,
+        action: "skip",
+        bundle_size: fileEntry.size,
+        bundle_sha256: fileEntry.sha256,
+        current_size: null,
+        current_sha256: null,
+      });
+      continue;
+    }
+
     if (!diskPath) {
       // Unknown archive path — would have nowhere to write
       conflicts.push({

--- a/credential-executor/src/http/credential-routes.ts
+++ b/credential-executor/src/http/credential-routes.ts
@@ -98,14 +98,9 @@ export async function handleCredentialRoute(
   const accountSegment = pathname.slice(CREDENTIAL_PATH_PREFIX.length);
 
   // POST /v1/credentials/bulk — bulk set credentials
-  if (accountSegment === "/bulk") {
-    if (req.method !== "POST") {
-      return new Response(
-        JSON.stringify({ error: "Method not allowed" }),
-        { status: 405, headers: { "Content-Type": "application/json" } },
-      );
-    }
-
+  // Only intercept POST; other methods (GET, DELETE) fall through to the
+  // :account handler so a credential literally named "bulk" stays accessible.
+  if (accountSegment === "/bulk" && req.method === "POST") {
     let body: { credentials?: unknown };
     try {
       body = await req.json();


### PR DESCRIPTION
## Summary
Fixes CI test failure and all review feedback for credential teleportation feature.

- Add migration-routes.ts to credential security invariant allowlist
- Handle credentials/ paths in import analyzer to avoid false preflight conflicts
- Apply credential-aware effective completion in completeMigration()
- Clear credentialsImported in prepareForResume
- Guard /v1/credentials/bulk route to only match POST method
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24327" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
