### PR TITLE
fix(macOS): clean up chat hover and table resize hover tracking

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -216,8 +216,20 @@ struct ChatBubble: View, Equatable {
     var activeSurfaceId: String?
 
     var isUser: Bool { message.role == .user }
+    var hasCopyableText: Bool {
+        !message.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
     var canForkFromMessage: Bool {
         onForkFromMessage != nil && message.daemonMessageId != nil && !message.isStreaming
+    }
+
+    var canInspectMessage: Bool {
+        showInspectButton && !isUser && message.daemonMessageId != nil
+    }
+
+    var supportsOverflowHover: Bool {
+        !message.isStreaming && (hasCopyableText || canInspectMessage || canForkFromMessage)
     }
 
     /// Composite identity for the `.task` modifier so it re-runs when either
@@ -416,7 +428,13 @@ struct ChatBubble: View, Equatable {
         .onChange(of: message.contentOrder) { _, _ in recomputeInterleavedContentCache() }
         .onChange(of: message.textSegments) { _, _ in recomputeInterleavedContentCache() }
         .onHover { hovering in
-            hoverState.isHovered = hovering
+            guard supportsOverflowHover else {
+                if hoverState.isHovered { hoverState.isHovered = false }
+                return
+            }
+            if hoverState.isHovered != hovering {
+                hoverState.isHovered = hovering
+            }
         }
         .task(id: mediaEmbedTaskID) {
             guard !message.isStreaming else { return }

--- a/clients/shared/Features/Chat/InlineWidgets/InlineTableWidget.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineTableWidget.swift
@@ -114,7 +114,6 @@ public struct InlineTableWidget: View {
     @State private var columnOverrides: [String: CGFloat] = [:]
     /// Baseline width captured at drag start for each column.
     @State private var resizeDragStartWidths: [String: CGFloat] = [:]
-    @State private var hoveredResizeHandleIndex: Int?
     @State private var activeResizeHandleIndex: Int?
 
     public init(data: TableSurfaceData, onAction: @escaping (String, [String: AnyCodable]?) -> Void) {
@@ -204,7 +203,6 @@ public struct InlineTableWidget: View {
         }
         .coordinateSpace(name: resizeGestureCoordinateSpaceName)
         .onDisappear {
-            hoveredResizeHandleIndex = nil
             activeResizeHandleIndex = nil
         }
     }
@@ -388,13 +386,6 @@ public struct InlineTableWidget: View {
             .overlay {
                 HorizontalResizeHandleTrackingView(
                     isDragging: activeResizeHandleIndex == columnIndex,
-                    onHoverChanged: { hovering in
-                        if hovering {
-                            hoveredResizeHandleIndex = columnIndex
-                        } else if hoveredResizeHandleIndex == columnIndex {
-                            hoveredResizeHandleIndex = nil
-                        }
-                    },
                     onDragBegan: {
                         beginResize(for: columnIndex)
                     },
@@ -424,7 +415,7 @@ public struct InlineTableWidget: View {
     }
 
     private func isResizeHandleHighlighted(_ columnIndex: Int) -> Bool {
-        hoveredResizeHandleIndex == columnIndex || activeResizeHandleIndex == columnIndex
+        activeResizeHandleIndex == columnIndex
     }
 
     private func resizeHandleIndicatorOpacity(isHighlighted: Bool) -> Double {
@@ -479,9 +470,7 @@ public struct InlineTableWidget: View {
         resizeDragStartWidths[column.id] = nil
         activeResizeHandleIndex = nil
         #if os(macOS)
-        if hoveredResizeHandleIndex == nil {
-            NSCursor.arrow.set()
-        }
+        NSCursor.arrow.set()
         #endif
     }
 
@@ -550,24 +539,20 @@ public struct InlineTableWidget: View {
 #if os(macOS)
 private struct HorizontalResizeHandleTrackingView: NSViewRepresentable {
     let isDragging: Bool
-    let onHoverChanged: (Bool) -> Void
     let onDragBegan: () -> Void
     let onDragChanged: (CGFloat) -> Void
     let onDragEnded: () -> Void
 
     final class Coordinator {
-        var onHoverChanged: (Bool) -> Void
         var onDragBegan: () -> Void
         var onDragChanged: (CGFloat) -> Void
         var onDragEnded: () -> Void
 
         init(
-            onHoverChanged: @escaping (Bool) -> Void,
             onDragBegan: @escaping () -> Void,
             onDragChanged: @escaping (CGFloat) -> Void,
             onDragEnded: @escaping () -> Void
         ) {
-            self.onHoverChanged = onHoverChanged
             self.onDragBegan = onDragBegan
             self.onDragChanged = onDragChanged
             self.onDragEnded = onDragEnded
@@ -576,7 +561,6 @@ private struct HorizontalResizeHandleTrackingView: NSViewRepresentable {
 
     func makeCoordinator() -> Coordinator {
         Coordinator(
-            onHoverChanged: onHoverChanged,
             onDragBegan: onDragBegan,
             onDragChanged: onDragChanged,
             onDragEnded: onDragEnded
@@ -585,9 +569,6 @@ private struct HorizontalResizeHandleTrackingView: NSViewRepresentable {
 
     func makeNSView(context: Context) -> HorizontalResizeHandleTrackingNSView {
         let view = HorizontalResizeHandleTrackingNSView()
-        view.onHoverChanged = { hovering in
-            context.coordinator.onHoverChanged(hovering)
-        }
         view.onDragBegan = {
             context.coordinator.onDragBegan()
         }
@@ -601,13 +582,9 @@ private struct HorizontalResizeHandleTrackingView: NSViewRepresentable {
     }
 
     func updateNSView(_ nsView: HorizontalResizeHandleTrackingNSView, context: Context) {
-        context.coordinator.onHoverChanged = onHoverChanged
         context.coordinator.onDragBegan = onDragBegan
         context.coordinator.onDragChanged = onDragChanged
         context.coordinator.onDragEnded = onDragEnded
-        nsView.onHoverChanged = { hovering in
-            context.coordinator.onHoverChanged(hovering)
-        }
         nsView.onDragBegan = {
             context.coordinator.onDragBegan()
         }
@@ -626,7 +603,6 @@ private struct HorizontalResizeHandleTrackingView: NSViewRepresentable {
 }
 
 private final class HorizontalResizeHandleTrackingNSView: NSView {
-    var onHoverChanged: ((Bool) -> Void)?
     var onDragBegan: (() -> Void)?
     var onDragChanged: ((CGFloat) -> Void)?
     var onDragEnded: (() -> Void)?
@@ -644,7 +620,6 @@ private final class HorizontalResizeHandleTrackingNSView: NSView {
             removeTrackingArea(trackingAreaRef)
         }
         let options: NSTrackingArea.Options = [
-            .mouseEnteredAndExited,
             .activeInKeyWindow,
             .enabledDuringMouseDrag,
             .inVisibleRect,
@@ -662,18 +637,6 @@ private final class HorizontalResizeHandleTrackingNSView: NSView {
 
     override func cursorUpdate(with event: NSEvent) {
         NSCursor.resizeLeftRight.set()
-    }
-
-    override func mouseEntered(with event: NSEvent) {
-        onHoverChanged?(true)
-        NSCursor.resizeLeftRight.set()
-    }
-
-    override func mouseExited(with event: NSEvent) {
-        onHoverChanged?(false)
-        if !isDragging {
-            NSCursor.arrow.set()
-        }
     }
 
     override func hitTest(_ point: NSPoint) -> NSView? {


### PR DESCRIPTION
## Summary
- ChatBubble: add `supportsOverflowHover` guard so streaming/empty/non-actionable messages don't trigger hover overlay
- InlineTableWidget: remove `hoveredResizeHandleIndex` state and all hover callbacks from the resize handle — highlight is now drag-only, reducing state and removing stale hover artifacts