### PR TITLE
fix(macOS): defer lifecycle bottom-pin writes to avoid SwiftUI update-cycle mutation

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -428,6 +428,12 @@ final class MessageListScrollState {
     /// Timeout task for expansion stabilization — auto-ends after 200ms.
     @ObservationIgnored private var expansionTimeoutTask: Task<Void, Never>?
 
+    /// Generation counter for lifecycle-driven bottom pins that are deferred
+    /// onto the next main-queue turn. This keeps `onChange` handlers from
+    /// mutating `ScrollPosition` during the same SwiftUI update pass that
+    /// triggered them.
+    @ObservationIgnored private var deferredBottomPinGeneration: UInt64 = 0
+
     /// Tracks overlapping stabilization windows. Stabilization only ends
     /// when all active windows have completed, so concurrent reasons
     /// (e.g. resize during pagination) don't prematurely restore the mode.
@@ -588,6 +594,40 @@ final class MessageListScrollState {
             }
             self.endStabilization()
         }
+    }
+
+    /// Schedules a bottom-pin for the next main-queue turn, coalescing
+    /// repeated requests from the same render cycle into a single execution.
+    ///
+    /// This is primarily used by lifecycle `onChange` handlers that can fire
+    /// during a SwiftUI update pass (for example `isSending` and
+    /// `messages.count`). Deferring the actual `ScrollPosition` write avoids
+    /// tripping SwiftUI's "Modifying state during view update" runtime guard.
+    func scheduleDeferredBottomPin(
+        animated: Bool = false,
+        userInitiated: Bool = false,
+        forceFollowingBottom: Bool = false,
+        refreshRecoveryWindow: Bool = false
+    ) {
+        deferredBottomPinGeneration &+= 1
+        let generation = deferredBottomPinGeneration
+        DispatchQueue.main.async { [weak self] in
+            Task { @MainActor [weak self] in
+                guard let self, self.deferredBottomPinGeneration == generation else { return }
+                if forceFollowingBottom {
+                    self.transition(to: .followingBottom)
+                }
+                if refreshRecoveryWindow {
+                    self.bottomAnchorAppeared = false
+                    self.recoveryDeadline = Date().addingTimeInterval(2.0)
+                }
+                _ = self.requestPinToBottom(animated: animated, userInitiated: userInitiated)
+            }
+        }
+    }
+
+    func cancelDeferredBottomPin() {
+        deferredBottomPinGeneration &+= 1
     }
 
     // MARK: - Scroll Execution
@@ -810,6 +850,7 @@ final class MessageListScrollState {
     func reset(for newConversationId: UUID?) {
         cancelStabilizationTasks()
         stabilizationGeneration &+= 1
+        cancelDeferredBottomPin()
         paginationTask?.cancel()
         paginationTask = nil
         ScrollGeometryUpdateDispatcher.shared.cancel(for: self)
@@ -857,6 +898,7 @@ final class MessageListScrollState {
     func cancelAll() {
         cancelStabilizationTasks()
         stabilizationGeneration &+= 1
+        cancelDeferredBottomPin()
         uiSyncTask?.cancel()
         uiSyncTask = nil
         scrollRestoreTask?.cancel()

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
@@ -124,15 +124,16 @@ extension MessageListView {
             if isDaemonConfirmationResume && !scrollState.isFollowingBottom {
                 // Daemon resumed from confirmation while user was scrolled up.
             } else {
-                scrollState.transition(to: .followingBottom)
-                // Start a fresh recovery window: the animated scroll can
-                // overshoot into blank LazyVStack estimated space. Without
-                // this, isAtBottom is falsely true at the estimated bottom
-                // and persistent recovery doesn't fire — the viewport
-                // stays blank until the user scrolls manually.
-                scrollState.bottomAnchorAppeared = false
-                scrollState.recoveryDeadline = Date().addingTimeInterval(2.0)
-                scrollState.requestPinToBottom(animated: true)
+                // Defer the actual bottom-pin to the next main-queue turn.
+                // Both `isSending` and `messages.count` can change in the
+                // same SwiftUI update cycle after the user sends a message;
+                // issuing immediate `ScrollPosition` writes here can trip
+                // SwiftUI's "Modifying state during view update" guard.
+                scrollState.scheduleDeferredBottomPin(
+                    animated: true,
+                    forceFollowingBottom: true,
+                    refreshRecoveryWindow: true
+                )
                 os_signpost(.event, log: PerfSignposts.log, name: "scrollToRequested",
                             "target=bottom reason=sendFollowingBottom")
             }
@@ -193,7 +194,7 @@ extension MessageListView {
             scrollState.lastMessageId = lastId
         }
         if anchorMessageId == nil {
-            scrollState.requestPinToBottom(animated: true)
+            scrollState.scheduleDeferredBottomPin(animated: true)
         }
         // --- Confirmation focus handoff ---
         #if os(macOS)

--- a/clients/macos/vellum-assistantTests/MessageListScrollStateTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListScrollStateTests.swift
@@ -302,6 +302,56 @@ final class MessageListScrollStateTests: XCTestCase {
         }
     }
 
+    // MARK: - Deferred Bottom Pins
+
+    func testDeferredBottomPinExecutesOnNextRunLoop() async throws {
+        state.transition(to: .followingBottom)
+        let lastId = UUID()
+        state.lastMessageId = lastId
+
+        state.scheduleDeferredBottomPin(animated: true)
+
+        XCTAssertTrue(scrollToCalls.isEmpty,
+                      "Deferred pin should not mutate scroll position synchronously")
+
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertEqual(scrollToCalls.count, 1)
+        XCTAssertEqual(scrollToCalls.first?.id, AnyHashable(lastId))
+        XCTAssertEqual(scrollToCalls.first?.anchor, .bottom)
+    }
+
+    func testDeferredBottomPinCoalescesRepeatedRequests() async throws {
+        state.transition(to: .followingBottom)
+        let lastId = UUID()
+        state.lastMessageId = lastId
+
+        state.scheduleDeferredBottomPin(animated: true)
+        state.scheduleDeferredBottomPin(animated: true)
+        state.scheduleDeferredBottomPin(animated: true, forceFollowingBottom: true, refreshRecoveryWindow: true)
+
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertEqual(scrollToCalls.count, 1,
+                       "Repeated deferred pins from one update cycle should coalesce")
+        XCTAssertTrue(state.isFollowingBottom)
+        XCTAssertFalse(state.bottomAnchorAppeared)
+        XCTAssertNotNil(state.recoveryDeadline)
+    }
+
+    func testDeferredBottomPinCancelledByReset() async throws {
+        state.transition(to: .followingBottom)
+        state.lastMessageId = UUID()
+
+        state.scheduleDeferredBottomPin(animated: true)
+        state.reset(for: UUID())
+
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertTrue(scrollToCalls.isEmpty,
+                      "Reset should cancel any deferred bottom pin from the old conversation")
+    }
+
     // MARK: - Reset
 
     func testResetRestoresDefaults() {


### PR DESCRIPTION
## Summary
- Introduce `scheduleDeferredBottomPin()` on `MessageListScrollState` that coalesces repeated requests via a generation counter and defers `ScrollPosition` writes to the next main-queue turn
- Replace direct `requestPinToBottom` calls in `MessageListView+Lifecycle` onChange handlers with the deferred variant to avoid tripping SwiftUI's "Modifying state during view update" runtime guard
- Add tests verifying deferred execution, coalescing, and cancellation on reset
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24332" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
