### PR TITLE
fix: skip credential entries silently in commitImport and log unreachable credential store on export

### DIFF
--- a/assistant/src/runtime/migrations/vbundle-importer.ts
+++ b/assistant/src/runtime/migrations/vbundle-importer.ts
@@ -227,6 +227,12 @@ export function commitImport(options: ImportCommitOptions): ImportCommitResult {
   let backupsCreated = 0;
 
   for (const fileEntry of manifest.files) {
+    // Credential entries are handled separately by extractCredentialsFromBundle()
+    // in migration-routes.ts — skip them silently without warnings or skip counts.
+    if (fileEntry.path.startsWith("credentials/")) {
+      continue;
+    }
+
     const diskPath = pathResolver.resolve(fileEntry.path);
 
     if (!diskPath) {

--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -157,7 +157,11 @@ export async function handleMigrationExport(req: Request): Promise<Response> {
     // Read all stored credentials to include in the export bundle
     const credentialList = await listSecureKeysAsync();
     const credentials: Array<{ account: string; value: string }> = [];
-    if (!credentialList.unreachable) {
+    if (credentialList.unreachable) {
+      log.warn(
+        "Credential store is unreachable — export will not include credentials",
+      );
+    } else {
       for (const account of credentialList.accounts) {
         const value = await getSecureKeyAsync(account);
         if (value) {
@@ -217,6 +221,7 @@ export async function handleMigrationExport(req: Request): Promise<Response> {
         "Content-Length": String(size),
         "X-Vbundle-Schema-Version": manifest.schema_version,
         "X-Vbundle-Manifest-Sha256": manifest.manifest_sha256,
+        "X-Vbundle-Credentials-Included": String(credentials.length),
       },
     });
   } catch (err) {


### PR DESCRIPTION
## Summary
- Skip credentials/ entries silently in commitImport() to avoid spurious warnings and inflated skip counts
- Add log warning and X-Vbundle-Credentials-Included response header when credential store is unreachable during export
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24335" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
