### PR TITLE
fix: validate credential entries against manifest and preserve empty-string credentials

### DIFF
--- a/assistant/src/runtime/migrations/__tests__/vbundle-import-credentials.test.ts
+++ b/assistant/src/runtime/migrations/__tests__/vbundle-import-credentials.test.ts
@@ -11,7 +11,7 @@ import { describe, expect, test } from "bun:test";
 
 import { DefaultPathResolver } from "../vbundle-import-analyzer.js";
 import { extractCredentialsFromBundle } from "../vbundle-importer.js";
-import type { VBundleTarEntry } from "../vbundle-validator.js";
+import type { ManifestType, VBundleTarEntry } from "../vbundle-validator.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -20,6 +20,20 @@ import type { VBundleTarEntry } from "../vbundle-validator.js";
 function makeTarEntry(data: string): VBundleTarEntry {
   const encoded = new TextEncoder().encode(data);
   return { name: "", data: encoded, size: encoded.length };
+}
+
+function makeManifest(paths: string[]): ManifestType {
+  return {
+    schema_version: "1.0.0",
+    created_at: new Date().toISOString(),
+    source: "test",
+    manifest_sha256: "test",
+    files: paths.map((path) => ({
+      path,
+      size: 0,
+      sha256: "test",
+    })),
+  } as ManifestType;
 }
 
 // ---------------------------------------------------------------------------
@@ -34,7 +48,12 @@ describe("extractCredentialsFromBundle", () => {
     entries.set("workspace/config.json", makeTarEntry('{"test": true}'));
     entries.set("manifest.json", makeTarEntry("{}"));
 
-    const credentials = extractCredentialsFromBundle(entries);
+    const manifest = makeManifest([
+      "credentials/openai-key",
+      "credentials/anthropic-key",
+      "workspace/config.json",
+    ]);
+    const credentials = extractCredentialsFromBundle(entries, manifest);
 
     expect(credentials).toHaveLength(2);
     expect(credentials).toContainEqual({
@@ -52,7 +71,8 @@ describe("extractCredentialsFromBundle", () => {
     entries.set("workspace/config.json", makeTarEntry('{"test": true}'));
     entries.set("manifest.json", makeTarEntry("{}"));
 
-    const credentials = extractCredentialsFromBundle(entries);
+    const manifest = makeManifest(["workspace/config.json"]);
+    const credentials = extractCredentialsFromBundle(entries, manifest);
 
     expect(credentials).toHaveLength(0);
   });
@@ -60,7 +80,8 @@ describe("extractCredentialsFromBundle", () => {
   test("returns empty array for empty entries map", () => {
     const entries = new Map<string, VBundleTarEntry>();
 
-    const credentials = extractCredentialsFromBundle(entries);
+    const manifest = makeManifest([]);
+    const credentials = extractCredentialsFromBundle(entries, manifest);
 
     expect(credentials).toHaveLength(0);
   });
@@ -70,12 +91,31 @@ describe("extractCredentialsFromBundle", () => {
     entries.set("credentials/", makeTarEntry("some-value"));
     entries.set("credentials/valid-key", makeTarEntry("valid-secret"));
 
-    const credentials = extractCredentialsFromBundle(entries);
+    const manifest = makeManifest(["credentials/", "credentials/valid-key"]);
+    const credentials = extractCredentialsFromBundle(entries, manifest);
 
     expect(credentials).toHaveLength(1);
     expect(credentials[0]).toEqual({
       account: "valid-key",
       value: "valid-secret",
+    });
+  });
+
+  test("ignores credential entries not declared in manifest", () => {
+    const entries = new Map<string, VBundleTarEntry>();
+    entries.set("credentials/declared-key", makeTarEntry("declared-secret"));
+    entries.set(
+      "credentials/undeclared-key",
+      makeTarEntry("undeclared-secret"),
+    );
+
+    const manifest = makeManifest(["credentials/declared-key"]);
+    const credentials = extractCredentialsFromBundle(entries, manifest);
+
+    expect(credentials).toHaveLength(1);
+    expect(credentials[0]).toEqual({
+      account: "declared-key",
+      value: "declared-secret",
     });
   });
 
@@ -86,7 +126,8 @@ describe("extractCredentialsFromBundle", () => {
       makeTarEntry("value with spaces & special=chars!"),
     );
 
-    const credentials = extractCredentialsFromBundle(entries);
+    const manifest = makeManifest(["credentials/complex-key"]);
+    const credentials = extractCredentialsFromBundle(entries, manifest);
 
     expect(credentials).toHaveLength(1);
     expect(credentials[0]).toEqual({

--- a/assistant/src/runtime/migrations/vbundle-importer.ts
+++ b/assistant/src/runtime/migrations/vbundle-importer.ts
@@ -399,10 +399,12 @@ export function commitImport(options: ImportCommitOptions): ImportCommitResult {
  */
 export function extractCredentialsFromBundle(
   entries: Map<string, VBundleTarEntry>,
+  manifest: ManifestType,
 ): Array<{ account: string; value: string }> {
+  const manifestPaths = new Set(manifest.files.map((f) => f.path));
   const credentials: Array<{ account: string; value: string }> = [];
   for (const [path, entry] of entries) {
-    if (path.startsWith("credentials/")) {
+    if (path.startsWith("credentials/") && manifestPaths.has(path)) {
       const account = path.slice("credentials/".length);
       if (account) {
         const value = new TextDecoder().decode(entry.data);

--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -164,7 +164,7 @@ export async function handleMigrationExport(req: Request): Promise<Response> {
     } else {
       for (const account of credentialList.accounts) {
         const value = await getSecureKeyAsync(account);
-        if (value) {
+        if (value != null) {
           credentials.push({ account, value });
         }
       }
@@ -484,6 +484,7 @@ export async function handleMigrationImport(req: Request): Promise<Response> {
     if (validation.entries) {
       const bundleCredentials = extractCredentialsFromBundle(
         validation.entries,
+        validation.manifest!,
       );
       if (bundleCredentials.length > 0) {
         try {


### PR DESCRIPTION
## Summary
- Only import credentials that are declared in the manifest (prevents undeclared entries bypassing checksum verification)
- Preserve empty-string credential values in export bundles (change if(value) to if(value != null))
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24338" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
