### PR TITLE
Add daemon memory diagnostics to health output

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -3381,8 +3381,93 @@ paths:
                     additionalProperties: {}
                   memory:
                     type: object
-                    properties: {}
-                    additionalProperties: {}
+                    properties:
+                      currentMb:
+                        type: number
+                      maxMb:
+                        type: number
+                      process:
+                        type: object
+                        properties:
+                          rssMb:
+                            type: number
+                          heapTotalMb:
+                            type: number
+                          heapUsedMb:
+                            type: number
+                          externalMb:
+                            type: number
+                          arrayBuffersMb:
+                            type: number
+                        required:
+                          - rssMb
+                          - heapTotalMb
+                          - heapUsedMb
+                          - externalMb
+                          - arrayBuffersMb
+                        additionalProperties: false
+                      jsc:
+                        anyOf:
+                          - type: object
+                            properties:
+                              heapSizeMb:
+                                type: number
+                              heapCapacityMb:
+                                type: number
+                              extraMemorySizeMb:
+                                type: number
+                              objectCount:
+                                type: number
+                              protectedObjectCount:
+                                type: number
+                              globalObjectCount:
+                                type: number
+                              protectedGlobalObjectCount:
+                                type: number
+                            required:
+                              - heapSizeMb
+                              - heapCapacityMb
+                              - extraMemorySizeMb
+                              - objectCount
+                              - protectedObjectCount
+                              - globalObjectCount
+                              - protectedGlobalObjectCount
+                            additionalProperties: false
+                          - type: "null"
+                      peaks:
+                        type: object
+                        properties:
+                          rssMb:
+                            type: number
+                          heapUsedMb:
+                            type: number
+                          externalMb:
+                            type: number
+                          arrayBuffersMb:
+                            type: number
+                          jscHeapSizeMb:
+                            anyOf:
+                              - type: number
+                              - type: "null"
+                          jscExtraMemorySizeMb:
+                            anyOf:
+                              - type: number
+                              - type: "null"
+                        required:
+                          - rssMb
+                          - heapUsedMb
+                          - externalMb
+                          - arrayBuffersMb
+                          - jscHeapSizeMb
+                          - jscExtraMemorySizeMb
+                        additionalProperties: false
+                    required:
+                      - currentMb
+                      - maxMb
+                      - process
+                      - jsc
+                      - peaks
+                    additionalProperties: false
                   cpu:
                     type: object
                     properties: {}
@@ -3502,8 +3587,93 @@ paths:
                     additionalProperties: {}
                   memory:
                     type: object
-                    properties: {}
-                    additionalProperties: {}
+                    properties:
+                      currentMb:
+                        type: number
+                      maxMb:
+                        type: number
+                      process:
+                        type: object
+                        properties:
+                          rssMb:
+                            type: number
+                          heapTotalMb:
+                            type: number
+                          heapUsedMb:
+                            type: number
+                          externalMb:
+                            type: number
+                          arrayBuffersMb:
+                            type: number
+                        required:
+                          - rssMb
+                          - heapTotalMb
+                          - heapUsedMb
+                          - externalMb
+                          - arrayBuffersMb
+                        additionalProperties: false
+                      jsc:
+                        anyOf:
+                          - type: object
+                            properties:
+                              heapSizeMb:
+                                type: number
+                              heapCapacityMb:
+                                type: number
+                              extraMemorySizeMb:
+                                type: number
+                              objectCount:
+                                type: number
+                              protectedObjectCount:
+                                type: number
+                              globalObjectCount:
+                                type: number
+                              protectedGlobalObjectCount:
+                                type: number
+                            required:
+                              - heapSizeMb
+                              - heapCapacityMb
+                              - extraMemorySizeMb
+                              - objectCount
+                              - protectedObjectCount
+                              - globalObjectCount
+                              - protectedGlobalObjectCount
+                            additionalProperties: false
+                          - type: "null"
+                      peaks:
+                        type: object
+                        properties:
+                          rssMb:
+                            type: number
+                          heapUsedMb:
+                            type: number
+                          externalMb:
+                            type: number
+                          arrayBuffersMb:
+                            type: number
+                          jscHeapSizeMb:
+                            anyOf:
+                              - type: number
+                              - type: "null"
+                          jscExtraMemorySizeMb:
+                            anyOf:
+                              - type: number
+                              - type: "null"
+                        required:
+                          - rssMb
+                          - heapUsedMb
+                          - externalMb
+                          - arrayBuffersMb
+                          - jscHeapSizeMb
+                          - jscExtraMemorySizeMb
+                        additionalProperties: false
+                    required:
+                      - currentMb
+                      - maxMb
+                      - process
+                      - jsc
+                      - peaks
+                    additionalProperties: false
                   cpu:
                     type: object
                     properties: {}

--- a/assistant/src/__tests__/identity-routes.test.ts
+++ b/assistant/src/__tests__/identity-routes.test.ts
@@ -14,12 +14,26 @@ import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
+const mockHeapStats = {
+  heapSize: 24 * 1024 * 1024,
+  heapCapacity: 48 * 1024 * 1024,
+  extraMemorySize: 12 * 1024 * 1024,
+  objectCount: 12_345,
+  protectedObjectCount: 123,
+  globalObjectCount: 1,
+  protectedGlobalObjectCount: 1,
+};
+
 // Silence logger before any imports that use it
 mock.module("../util/logger.js", () => ({
   getLogger: () =>
     new Proxy({} as Record<string, unknown>, {
       get: () => () => {},
     }),
+}));
+
+mock.module("bun:jsc", () => ({
+  heapStats: () => mockHeapStats,
 }));
 
 import { handleDetailedHealth } from "../runtime/routes/identity-routes.js";
@@ -147,6 +161,34 @@ describe("identity routes — health endpoint", () => {
       expect(body.cpu).toBeDefined();
       expect(body.migrations).toBeDefined();
 
+      const memory = body.memory as Record<string, unknown>;
+      expect(typeof memory.currentMb).toBe("number");
+      expect(typeof memory.maxMb).toBe("number");
+      expect(memory.process).toEqual({
+        rssMb: expect.any(Number),
+        heapTotalMb: expect.any(Number),
+        heapUsedMb: expect.any(Number),
+        externalMb: expect.any(Number),
+        arrayBuffersMb: expect.any(Number),
+      });
+      expect(memory.jsc).toEqual({
+        heapSizeMb: 24,
+        heapCapacityMb: 48,
+        extraMemorySizeMb: 12,
+        objectCount: 12_345,
+        protectedObjectCount: 123,
+        globalObjectCount: 1,
+        protectedGlobalObjectCount: 1,
+      });
+      expect(memory.peaks).toEqual({
+        rssMb: expect.any(Number),
+        heapUsedMb: expect.any(Number),
+        externalMb: expect.any(Number),
+        arrayBuffersMb: expect.any(Number),
+        jscHeapSizeMb: 24,
+        jscExtraMemorySizeMb: 12,
+      });
+
       // Profiler should either be absent or show enabled: false
       if ("profiler" in body) {
         const profiler = body.profiler as Record<string, unknown>;
@@ -165,6 +207,7 @@ describe("identity routes — health endpoint", () => {
       expect(body.status).toBe("healthy");
       expect(body.timestamp).toBeDefined();
       expect(body.migrations).toBeDefined();
+      expect((body.memory as Record<string, unknown>).jsc).toBeDefined();
     });
   });
 

--- a/assistant/src/runtime/routes/identity-routes.ts
+++ b/assistant/src/runtime/routes/identity-routes.ts
@@ -6,6 +6,7 @@ import { existsSync, readFileSync, statfsSync, statSync } from "node:fs";
 import { cpus, totalmem } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { heapStats } from "bun:jsc";
 
 import { z } from "zod";
 
@@ -52,6 +53,64 @@ function getDiskSpaceInfo(): DiskSpaceInfo | null {
 interface MemoryInfo {
   currentMb: number;
   maxMb: number;
+  process: ProcessMemoryInfo;
+  jsc: JscMemoryInfo | null;
+  peaks: MemoryPeakInfo;
+}
+
+interface ProcessMemoryInfo {
+  rssMb: number;
+  heapTotalMb: number;
+  heapUsedMb: number;
+  externalMb: number;
+  arrayBuffersMb: number;
+}
+
+interface JscMemoryInfo {
+  heapSizeMb: number;
+  heapCapacityMb: number;
+  extraMemorySizeMb: number;
+  objectCount: number;
+  protectedObjectCount: number;
+  globalObjectCount: number;
+  protectedGlobalObjectCount: number;
+}
+
+interface MemoryPeakInfo {
+  rssMb: number;
+  heapUsedMb: number;
+  externalMb: number;
+  arrayBuffersMb: number;
+  jscHeapSizeMb: number | null;
+  jscExtraMemorySizeMb: number | null;
+}
+
+interface MemorySnapshot {
+  process: {
+    rssBytes: number;
+    heapTotalBytes: number;
+    heapUsedBytes: number;
+    externalBytes: number;
+    arrayBuffersBytes: number;
+  };
+  jsc: {
+    heapSizeBytes: number;
+    heapCapacityBytes: number;
+    extraMemorySizeBytes: number;
+    objectCount: number;
+    protectedObjectCount: number;
+    globalObjectCount: number;
+    protectedGlobalObjectCount: number;
+  } | null;
+}
+
+interface MemoryPeakSnapshot {
+  rssBytes: number;
+  heapUsedBytes: number;
+  externalBytes: number;
+  arrayBuffersBytes: number;
+  jscHeapSizeBytes: number | null;
+  jscExtraMemorySizeBytes: number | null;
 }
 
 /**
@@ -133,11 +192,122 @@ function getContainerMemoryLimitBytes(): number | null {
   return null;
 }
 
-function getMemoryInfo(): MemoryInfo {
-  const bytesToMb = (b: number) => Math.round((b / (1024 * 1024)) * 100) / 100;
+function bytesToMb(bytes: number): number {
+  return Math.round((bytes / (1024 * 1024)) * 100) / 100;
+}
+
+function captureMemorySnapshot(): MemorySnapshot {
+  const usage = process.memoryUsage();
+
+  let jsc: MemorySnapshot["jsc"] = null;
+  try {
+    const stats = heapStats();
+    jsc = {
+      heapSizeBytes: stats.heapSize,
+      heapCapacityBytes: stats.heapCapacity,
+      extraMemorySizeBytes: stats.extraMemorySize,
+      objectCount: stats.objectCount,
+      protectedObjectCount: stats.protectedObjectCount,
+      globalObjectCount: stats.globalObjectCount,
+      protectedGlobalObjectCount: stats.protectedGlobalObjectCount,
+    };
+  } catch {
+    jsc = null;
+  }
+
   return {
-    currentMb: bytesToMb(process.memoryUsage().rss),
+    process: {
+      rssBytes: usage.rss,
+      heapTotalBytes: usage.heapTotal,
+      heapUsedBytes: usage.heapUsed,
+      externalBytes: usage.external,
+      arrayBuffersBytes: usage.arrayBuffers,
+    },
+    jsc,
+  };
+}
+
+let _memoryPeaks: MemoryPeakSnapshot = {
+  rssBytes: 0,
+  heapUsedBytes: 0,
+  externalBytes: 0,
+  arrayBuffersBytes: 0,
+  jscHeapSizeBytes: null,
+  jscExtraMemorySizeBytes: null,
+};
+
+function updateMemoryPeaks(snapshot: MemorySnapshot): void {
+  _memoryPeaks = {
+    rssBytes: Math.max(_memoryPeaks.rssBytes, snapshot.process.rssBytes),
+    heapUsedBytes: Math.max(
+      _memoryPeaks.heapUsedBytes,
+      snapshot.process.heapUsedBytes,
+    ),
+    externalBytes: Math.max(
+      _memoryPeaks.externalBytes,
+      snapshot.process.externalBytes,
+    ),
+    arrayBuffersBytes: Math.max(
+      _memoryPeaks.arrayBuffersBytes,
+      snapshot.process.arrayBuffersBytes,
+    ),
+    jscHeapSizeBytes:
+      snapshot.jsc === null
+        ? _memoryPeaks.jscHeapSizeBytes
+        : Math.max(
+            _memoryPeaks.jscHeapSizeBytes ?? 0,
+            snapshot.jsc.heapSizeBytes,
+          ),
+    jscExtraMemorySizeBytes:
+      snapshot.jsc === null
+        ? _memoryPeaks.jscExtraMemorySizeBytes
+        : Math.max(
+            _memoryPeaks.jscExtraMemorySizeBytes ?? 0,
+            snapshot.jsc.extraMemorySizeBytes,
+          ),
+  };
+}
+
+function getMemoryInfo(): MemoryInfo {
+  const snapshot = captureMemorySnapshot();
+  updateMemoryPeaks(snapshot);
+
+  return {
+    currentMb: bytesToMb(snapshot.process.rssBytes),
     maxMb: bytesToMb(getContainerMemoryLimitBytes() ?? totalmem()),
+    process: {
+      rssMb: bytesToMb(snapshot.process.rssBytes),
+      heapTotalMb: bytesToMb(snapshot.process.heapTotalBytes),
+      heapUsedMb: bytesToMb(snapshot.process.heapUsedBytes),
+      externalMb: bytesToMb(snapshot.process.externalBytes),
+      arrayBuffersMb: bytesToMb(snapshot.process.arrayBuffersBytes),
+    },
+    jsc:
+      snapshot.jsc === null
+        ? null
+        : {
+            heapSizeMb: bytesToMb(snapshot.jsc.heapSizeBytes),
+            heapCapacityMb: bytesToMb(snapshot.jsc.heapCapacityBytes),
+            extraMemorySizeMb: bytesToMb(snapshot.jsc.extraMemorySizeBytes),
+            objectCount: snapshot.jsc.objectCount,
+            protectedObjectCount: snapshot.jsc.protectedObjectCount,
+            globalObjectCount: snapshot.jsc.globalObjectCount,
+            protectedGlobalObjectCount: snapshot.jsc.protectedGlobalObjectCount,
+          },
+    peaks: {
+      rssMb: bytesToMb(_memoryPeaks.rssBytes),
+      heapUsedMb: bytesToMb(_memoryPeaks.heapUsedBytes),
+      externalMb: bytesToMb(_memoryPeaks.externalBytes),
+      arrayBuffersMb: bytesToMb(_memoryPeaks.arrayBuffersBytes),
+      jscHeapSizeMb:
+        _memoryPeaks.jscHeapSizeBytes === null
+          ? null
+          : bytesToMb(_memoryPeaks.jscHeapSizeBytes),
+      jscExtraMemorySizeMb:
+        _memoryPeaks.jscExtraMemorySizeBytes === null
+          ? null
+          : bytesToMb(_memoryPeaks.jscExtraMemorySizeBytes),
+    },
   };
 }
 
@@ -170,6 +340,7 @@ setInterval(() => {
   }
   _lastCpuUsage = newUsage;
   _lastCpuTime = now;
+  updateMemoryPeaks(captureMemorySnapshot());
 }, CPU_SAMPLE_INTERVAL_MS).unref();
 
 function getCpuInfo(): CpuInfo {
@@ -331,12 +502,47 @@ const profilerStatusSchema = z.object({
   lastCompletedRun: profilerLastCompletedRunSchema.nullable(),
 });
 
+const processMemorySchema = z.object({
+  rssMb: z.number(),
+  heapTotalMb: z.number(),
+  heapUsedMb: z.number(),
+  externalMb: z.number(),
+  arrayBuffersMb: z.number(),
+});
+
+const jscMemorySchema = z.object({
+  heapSizeMb: z.number(),
+  heapCapacityMb: z.number(),
+  extraMemorySizeMb: z.number(),
+  objectCount: z.number(),
+  protectedObjectCount: z.number(),
+  globalObjectCount: z.number(),
+  protectedGlobalObjectCount: z.number(),
+});
+
+const memoryPeakSchema = z.object({
+  rssMb: z.number(),
+  heapUsedMb: z.number(),
+  externalMb: z.number(),
+  arrayBuffersMb: z.number(),
+  jscHeapSizeMb: z.number().nullable(),
+  jscExtraMemorySizeMb: z.number().nullable(),
+});
+
+const memoryInfoSchema = z.object({
+  currentMb: z.number(),
+  maxMb: z.number(),
+  process: processMemorySchema,
+  jsc: jscMemorySchema.nullable(),
+  peaks: memoryPeakSchema,
+});
+
 const detailedHealthSchema = z.object({
   status: z.string(),
   timestamp: z.string(),
   version: z.string(),
   disk: z.object({}).passthrough(),
-  memory: z.object({}).passthrough(),
+  memory: memoryInfoSchema,
   cpu: z.object({}).passthrough(),
   migrations: z.object({}).passthrough(),
   profiler: profilerStatusSchema.optional(),

--- a/clients/macos/vellum-assistant/Features/Settings/DaemonHealthz.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/DaemonHealthz.swift
@@ -29,6 +29,36 @@ struct DaemonHealthz: Decodable {
     struct MemoryInfo: Decodable {
         let currentMb: Double
         let maxMb: Double
+        let process: ProcessInfo?
+        let jsc: JscInfo?
+        let peaks: PeakInfo?
+    }
+
+    struct ProcessInfo: Decodable {
+        let rssMb: Double
+        let heapTotalMb: Double
+        let heapUsedMb: Double
+        let externalMb: Double
+        let arrayBuffersMb: Double
+    }
+
+    struct JscInfo: Decodable {
+        let heapSizeMb: Double
+        let heapCapacityMb: Double
+        let extraMemorySizeMb: Double
+        let objectCount: Int
+        let protectedObjectCount: Int
+        let globalObjectCount: Int
+        let protectedGlobalObjectCount: Int
+    }
+
+    struct PeakInfo: Decodable {
+        let rssMb: Double
+        let heapUsedMb: Double
+        let externalMb: Double
+        let arrayBuffersMb: Double
+        let jscHeapSizeMb: Double?
+        let jscExtraMemorySizeMb: Double?
     }
 
     struct CpuInfo: Decodable {

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -397,7 +397,42 @@ struct SettingsDeveloperTab: View {
             }
 
             if let memory = healthz.memory {
-                infoRow(label: "Memory", value: "\(formatMb(memory.currentMb)) / \(formatMb(memory.maxMb))")
+                infoRow(label: "RSS", value: "\(formatMb(memory.currentMb)) / \(formatMb(memory.maxMb))")
+
+                if let process = memory.process {
+                    infoRow(
+                        label: "JS heap",
+                        value: "\(formatMb(process.heapUsedMb)) / \(formatMb(process.heapTotalMb))"
+                    )
+                    infoRow(
+                        label: "External",
+                        value: "\(formatMb(process.externalMb))"
+                    )
+                    infoRow(
+                        label: "Array buf",
+                        value: "\(formatMb(process.arrayBuffersMb))"
+                    )
+                }
+
+                if let jsc = memory.jsc {
+                    infoRow(
+                        label: "JSC heap",
+                        value: "\(formatMb(jsc.heapSizeMb)) / \(formatMb(jsc.heapCapacityMb))"
+                    )
+                    infoRow(
+                        label: "JSC extra",
+                        value: "\(formatMb(jsc.extraMemorySizeMb))"
+                    )
+                }
+
+                if let peaks = memory.peaks {
+                    infoRow(label: "Peak RSS", value: formatMb(peaks.rssMb))
+                    infoRow(label: "Peak heap", value: formatMb(peaks.heapUsedMb))
+                    infoRow(label: "Peak ext", value: formatMb(peaks.externalMb))
+                    if let peakJscHeap = peaks.jscHeapSizeMb {
+                        infoRow(label: "Peak JSC", value: formatMb(peakJscHeap))
+                    }
+                }
             }
 
             if let cpu = healthz.cpu {


### PR DESCRIPTION
## Summary
- enrich `/v1/health` and `/v1/healthz` with Bun `process.memoryUsage()` counters, `bun:jsc` heap stats, and startup peak tracking
- keep the existing memory summary fields while documenting and testing the richer health payload
- surface RSS, JS heap, external memory, JSC heap, and peaks in the macOS developer settings view

## Original prompt
Set up memory diagnostics so we can compare the assistant daemon's RSS growth against Bun heap and JSC heap usage.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24339" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
