### PR TITLE
fix: update CES HTTP reachability after bulk credential writes

### DIFF
--- a/assistant/src/security/secure-keys.ts
+++ b/assistant/src/security/secure-keys.ts
@@ -463,14 +463,20 @@ export async function bulkSetSecureKeysAsync(
     async () => {
       const backend = await resolveBackendAsync();
       if (backend.bulkSet) {
-        return backend.bulkSet(credentials);
+        const results = await backend.bulkSet(credentials);
+        const anyFailed = results.some((r) => !r.ok);
+        updateCesHttpReachability(backend, anyFailed);
+        return results;
       }
       // Fallback: loop individual sets
       const results = [];
+      let anyFailed = false;
       for (const { account, value } of credentials) {
         const ok = await backend.set(account, value);
+        if (!ok) anyFailed = true;
         results.push({ account, ok });
       }
+      updateCesHttpReachability(backend, anyFailed);
       return results;
     },
     credentials.map((c) => ({ account: c.account, ok: false })),


### PR DESCRIPTION
## Summary
Call updateCesHttpReachability after bulkSetSecureKeysAsync to preserve reconnect signal on failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24340" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
