### PR TITLE
fix: propagate guardian trust and taskRunId through schedule execution

### DIFF
--- a/assistant/src/__tests__/require-fresh-approval.test.ts
+++ b/assistant/src/__tests__/require-fresh-approval.test.ts
@@ -108,16 +108,20 @@ mock.module("../permissions/checker.js", () => ({
 
 mock.module("../memory/tool-usage-store.js", () => ({
   recordToolInvocation: () => {},
+  getRecentInvocations: () => [],
+  rotateToolInvocations: () => 0,
 }));
 
 mock.module("../tools/registry.js", () => ({
   getTool: (name: string) => {
     if (name === "unknown_tool") return undefined;
+    const isGmailTool = name.startsWith("gmail_");
     return {
       name,
       description: "test tool",
-      category: "credential-execution",
+      category: isGmailTool ? "gmail" : "credential-execution",
       defaultRiskLevel: "high",
+      executionTarget: isGmailTool ? ("host" as const) : undefined,
       getDefinition: () => ({}),
       execute: async () => fakeToolResult,
     };
@@ -255,6 +259,41 @@ describe("requireFreshApproval: non-interactive guardian denial", () => {
     );
 
     expect(result.isError).toBe(false);
+  });
+
+  test("medium-risk gmail archive is auto-approved in non-interactive guardian sessions", async () => {
+    riskOverride = RiskLevel.Medium;
+    checkResultOverride = {
+      decision: "prompt",
+      reason: "Needs approval",
+    };
+
+    const executor = new ToolExecutor(makePrompter());
+    const result = await executor.execute(
+      "gmail_archive",
+      { query: "in:inbox", confidence: 0.92 },
+      makeContext({ isInteractive: false, trustClass: "guardian" }),
+    );
+
+    expect(result.isError).toBe(false);
+  });
+
+  test("high-risk gmail send_draft is denied in non-interactive guardian sessions", async () => {
+    riskOverride = RiskLevel.High;
+    checkResultOverride = {
+      decision: "prompt",
+      reason: "Needs approval",
+    };
+
+    const executor = new ToolExecutor(makePrompter());
+    const result = await executor.execute(
+      "gmail_send_draft",
+      { draft_id: "draft-123", confidence: 0.99 },
+      makeContext({ isInteractive: false, trustClass: "guardian" }),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("requires user approval");
   });
 
   test("low-risk tools are still auto-approved in non-interactive guardian sessions", async () => {

--- a/assistant/src/__tests__/schedule-routes.test.ts
+++ b/assistant/src/__tests__/schedule-routes.test.ts
@@ -1,0 +1,162 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import { getDb, initializeDb } from "../memory/db.js";
+import { createSchedule } from "../schedule/schedule-store.js";
+import { scheduleRouteDefinitions } from "../runtime/routes/schedule-routes.js";
+import { createTask } from "../tasks/task-store.js";
+import { scheduleTask } from "../tasks/task-scheduler.js";
+
+initializeDb();
+
+function clearTables(): void {
+  const db = getDb();
+  db.run("DELETE FROM cron_runs");
+  db.run("DELETE FROM cron_jobs");
+  db.run("DELETE FROM task_runs");
+  db.run("DELETE FROM tasks");
+  db.run("DELETE FROM messages");
+  db.run("DELETE FROM conversations");
+}
+
+function getRunNowHandler(sendMessageDeps: {
+  getOrCreateConversation: (
+    conversationId: string,
+    options?: Record<string, unknown>,
+  ) => Promise<unknown>;
+}) {
+  const route = scheduleRouteDefinitions({
+    sendMessageDeps: sendMessageDeps as never,
+  }).find(
+    (candidate) =>
+      candidate.endpoint === "schedules/:id/run" && candidate.method === "POST",
+  );
+  if (!route) {
+    throw new Error("Run-now schedule route not found");
+  }
+  return route.handler;
+}
+
+describe("schedule run-now trust propagation", () => {
+  beforeEach(() => {
+    clearTables();
+  });
+
+  test("manual run-now executes plain schedules with guardian trust", async () => {
+    const schedule = createSchedule({
+      name: "Direct schedule",
+      cronExpression: "* * * * *",
+      message: "scan my inbox",
+      syntax: "cron",
+    });
+
+    const getOrCreateCalls: Array<{
+      conversationId: string;
+      options?: Record<string, unknown>;
+    }> = [];
+    const processCalls: Array<unknown[]> = [];
+    const fakeConversation: {
+      taskRunId?: string;
+      processMessage: (...args: unknown[]) => Promise<string>;
+    } = {
+      taskRunId: "stale-task-run",
+      async processMessage(...args: unknown[]) {
+        processCalls.push(args);
+        return "message-id";
+      },
+    };
+
+    const handler = getRunNowHandler({
+      getOrCreateConversation: async (conversationId, options) => {
+        getOrCreateCalls.push({ conversationId, options });
+        return fakeConversation;
+      },
+    });
+
+    const response = await handler({
+      req: new Request(`http://localhost/v1/schedules/${schedule.id}/run`, {
+        method: "POST",
+      }),
+      url: new URL(`http://localhost/v1/schedules/${schedule.id}/run`),
+      server: {} as never,
+      authContext: {} as never,
+      params: { id: schedule.id },
+    });
+
+    expect(response.status).toBe(200);
+    expect(getOrCreateCalls).toHaveLength(1);
+    expect(getOrCreateCalls[0].options?.trustContext).toEqual({
+      sourceChannel: "vellum",
+      trustClass: "guardian",
+    });
+    expect(processCalls).toHaveLength(1);
+    expect(processCalls[0][0]).toBe("scan my inbox");
+    expect(processCalls[0][6]).toEqual({ isInteractive: false });
+    expect(fakeConversation.taskRunId).toBeUndefined();
+  });
+
+  test("manual run-now executes scheduled tasks with guardian trust and taskRunId", async () => {
+    const task = createTask({
+      title: "Email triage",
+      template: "triage inbox in background",
+    });
+    const schedule = scheduleTask({
+      taskId: task.id,
+      name: "Scheduled task",
+      cronExpression: "* * * * *",
+    });
+
+    const getOrCreateCalls: Array<{
+      conversationId: string;
+      options?: Record<string, unknown>;
+    }> = [];
+    const observedTaskRunIds: Array<string | undefined> = [];
+    const processCalls: Array<unknown[]> = [];
+    const fakeConversation: {
+      taskRunId?: string;
+      processMessage: (...args: unknown[]) => Promise<string>;
+    } = {
+      taskRunId: undefined,
+      async processMessage(...args: unknown[]) {
+        observedTaskRunIds.push(fakeConversation.taskRunId);
+        processCalls.push(args);
+        return "message-id";
+      },
+    };
+
+    const handler = getRunNowHandler({
+      getOrCreateConversation: async (conversationId, options) => {
+        getOrCreateCalls.push({ conversationId, options });
+        return fakeConversation;
+      },
+    });
+
+    const response = await handler({
+      req: new Request(`http://localhost/v1/schedules/${schedule.id}/run`, {
+        method: "POST",
+      }),
+      url: new URL(`http://localhost/v1/schedules/${schedule.id}/run`),
+      server: {} as never,
+      authContext: {} as never,
+      params: { id: schedule.id },
+    });
+
+    expect(response.status).toBe(200);
+    expect(getOrCreateCalls).toHaveLength(1);
+    expect(getOrCreateCalls[0].options?.trustContext).toEqual({
+      sourceChannel: "vellum",
+      trustClass: "guardian",
+    });
+    expect(processCalls).toHaveLength(1);
+    expect(processCalls[0][0]).toBe("triage inbox in background");
+    expect(processCalls[0][6]).toEqual({ isInteractive: false });
+    expect(typeof observedTaskRunIds[0]).toBe("string");
+    expect(fakeConversation.taskRunId).toBeUndefined();
+  });
+});

--- a/assistant/src/__tests__/task-scheduler.test.ts
+++ b/assistant/src/__tests__/task-scheduler.test.ts
@@ -128,9 +128,17 @@ describe("scheduler run_task detection", () => {
     forceScheduleDue(schedule.id);
 
     // Track all processMessage calls
-    const directCalls: { conversationId: string; message: string }[] = [];
-    const processMessage = async (conversationId: string, message: string) => {
-      directCalls.push({ conversationId, message });
+    const directCalls: Array<{
+      conversationId: string;
+      message: string;
+      options?: { trustClass?: string; taskRunId?: string };
+    }> = [];
+    const processMessage = async (
+      conversationId: string,
+      message: string,
+      options?: { trustClass?: string; taskRunId?: string },
+    ) => {
+      directCalls.push({ conversationId, message, options });
     };
 
     const scheduler = startScheduler(
@@ -154,6 +162,8 @@ describe("scheduler run_task detection", () => {
     expect(runTaskCalls.length).toBe(1);
     // The scheduler should NOT pass the raw run_task: message to processMessage
     expect(rawCalls.length).toBe(0);
+    expect(runTaskCalls[0].options?.trustClass).toBe("guardian");
+    expect(typeof runTaskCalls[0].options?.taskRunId).toBe("string");
   });
 
   test("regular messages still go through processMessage normally", async () => {
@@ -167,9 +177,17 @@ describe("scheduler run_task detection", () => {
 
     forceScheduleDue(schedule.id);
 
-    const processedMessages: { conversationId: string; message: string }[] = [];
-    const processMessage = async (conversationId: string, message: string) => {
-      processedMessages.push({ conversationId, message });
+    const processedMessages: Array<{
+      conversationId: string;
+      message: string;
+      options?: { trustClass?: string; taskRunId?: string };
+    }> = [];
+    const processMessage = async (
+      conversationId: string,
+      message: string,
+      options?: { trustClass?: string; taskRunId?: string },
+    ) => {
+      processedMessages.push({ conversationId, message, options });
     };
 
     const scheduler = startScheduler(
@@ -184,6 +202,14 @@ describe("scheduler run_task detection", () => {
     // processMessage should have been called with the regular message
     expect(
       processedMessages.some((m) => m.message === "Do something normal"),
+    ).toBe(true);
+    expect(
+      processedMessages.some(
+        (m) =>
+          m.message === "Do something normal" &&
+          m.options?.trustClass === "guardian" &&
+          m.options?.taskRunId === undefined,
+      ),
     ).toBe(true);
   });
 

--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -110,6 +110,11 @@ export interface ConversationCreateOptions {
   transport?: ConversationTransportMetadata;
   assistantId?: string;
   trustContext?: TrustContext;
+  /**
+   * Active task-run scope for this turn. Cleared when omitted so background
+   * task permissions do not leak into later turns on a reused conversation.
+   */
+  taskRunId?: string;
   /** Normalized auth context for the conversation. */
   authContext?: AuthContext;
   /** Whether this turn can block on interactive approval prompts. */

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -780,12 +780,19 @@ export async function runDaemon(): Promise<void> {
           conversationId,
           message,
           undefined,
-          options?.trustClass
+          options
             ? {
-                trustContext: {
-                  sourceChannel: "vellum",
-                  trustClass: options.trustClass,
-                },
+                ...(options.trustClass
+                  ? {
+                      trustContext: {
+                        sourceChannel: "vellum",
+                        trustClass: options.trustClass,
+                      },
+                    }
+                  : {}),
+                ...(options.taskRunId
+                  ? { taskRunId: options.taskRunId }
+                  : {}),
               }
             : undefined,
         );

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -891,10 +891,11 @@ export class DaemonServer {
     let conversation = this.conversations.get(conversationId);
     const sendToClient = () => {};
 
-    if (options && Object.values(options).some((v) => v !== undefined)) {
+    const { taskRunId: _taskRunId, ...persistentOptions } = options ?? {};
+    if (Object.values(persistentOptions).some((v) => v !== undefined)) {
       this.conversationOptions.set(conversationId, {
         ...this.conversationOptions.get(conversationId),
-        ...options,
+        ...persistentOptions,
       });
     }
 
@@ -1066,6 +1067,7 @@ export class DaemonServer {
     conversation.setAssistantId(
       options?.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID,
     );
+    conversation.taskRunId = options?.taskRunId;
     // Only overwrite trust/auth context when explicitly provided. Callers that
     // don't supply a trust context (e.g. signal-injected messages) should
     // inherit whatever the conversation already has from a prior session.

--- a/assistant/src/runtime/routes/schedule-routes.ts
+++ b/assistant/src/runtime/routes/schedule-routes.ts
@@ -25,6 +25,10 @@ import type { RouteDefinition } from "../http-router.js";
 import type { SendMessageDeps } from "../http-types.js";
 
 const log = getLogger("schedule-routes");
+const SCHEDULE_GUARDIAN_TRUST_CONTEXT = {
+  sourceChannel: "vellum",
+  trustClass: "guardian",
+} as const;
 
 // ---------------------------------------------------------------------------
 // Handlers
@@ -202,17 +206,23 @@ async function handleRunScheduleNow(
             );
           }
           const conversation =
-            await sendMessageDeps.getOrCreateConversation(conversationId);
+            await sendMessageDeps.getOrCreateConversation(conversationId, {
+              trustContext: SCHEDULE_GUARDIAN_TRUST_CONTEXT,
+            });
           conversation.taskRunId = taskRunId;
-          await conversation.processMessage(
-            message,
-            [],
-            () => {}, // no event callback for HTTP mode
-            undefined,
-            undefined,
-            undefined,
-            { isInteractive: false },
-          );
+          try {
+            await conversation.processMessage(
+              message,
+              [],
+              () => {}, // no event callback for HTTP mode
+              undefined,
+              undefined,
+              undefined,
+              { isInteractive: false },
+            );
+          } finally {
+            conversation.taskRunId = undefined;
+          }
         },
       );
 
@@ -276,7 +286,10 @@ async function handleRunScheduleNow(
       throw new Error("sendMessageDeps not available for schedule execution");
     }
     const activeConversation =
-      await sendMessageDeps.getOrCreateConversation(conversationId);
+      await sendMessageDeps.getOrCreateConversation(conversationId, {
+        trustContext: SCHEDULE_GUARDIAN_TRUST_CONTEXT,
+      });
+    activeConversation.taskRunId = undefined;
     await activeConversation.processMessage(
       schedule.message,
       [],

--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -23,6 +23,7 @@ const log = getLogger("scheduler");
 
 export interface ScheduleMessageOptions {
   trustClass?: "guardian" | "trusted_contact" | "unknown";
+  taskRunId?: string;
 }
 
 export type ScheduleMessageProcessor = (
@@ -196,11 +197,12 @@ async function runScheduleOnce(
             source: "schedule",
             scheduleJobId: job.id,
           },
-          processMessage as (
-            conversationId: string,
-            message: string,
-            taskRunId: string,
-          ) => Promise<void>,
+          async (conversationId, message, taskRunId) => {
+            await processMessage(conversationId, message, {
+              trustClass: "guardian",
+              taskRunId,
+            });
+          },
         );
 
         onScheduleConversationCreated?.({


### PR DESCRIPTION
## Summary
- Pass `trustClass: guardian` and `taskRunId` through the scheduler → daemon → conversation pipeline so scheduled runs get proper trust context
- Clear `taskRunId` after each turn (via `finally` blocks and option destructuring) to prevent permission leaks across conversation reuse
- Add schedule-routes and task-scheduler tests validating trust propagation, plus gmail tool approval tests for non-interactive guardian sessions
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24343" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
