### PR TITLE
fix(macOS): clear inspectorMessageId on ActiveChatViewWrapper disappear

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -723,6 +723,9 @@ struct ActiveChatViewWrapper: View {
             }
         }
         .animation(VAnimation.standard, value: windowState.inspectorMessageId)
+        .onDisappear {
+            windowState.inspectorMessageId = nil
+        }
         .onChange(of: conversationId) { _, _ in
             windowState.inspectorMessageId = nil
         }


### PR DESCRIPTION
Fixes stale inspector state when navigating away from chat panel and returning to the same conversation.

Addresses feedback from https://github.com/vellum-ai/vellum-assistant/pull/24312
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24344" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
