### PR TITLE
fix: escape child.error in buildSubagentStatusBlock XML block

### DIFF
--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -480,7 +480,7 @@ export function buildSubagentStatusBlock(
       parts.push(`elapsed: ${elapsed}`);
     }
     if (child.status === "failed" && child.error) {
-      parts.push(`error: ${child.error}`);
+      parts.push(`error: ${escapeXml(child.error)}`);
     }
     lines.push(parts.join(" | "));
   }


### PR DESCRIPTION
Applies escapeXml() to child.error in the active_subagents XML block, closing the remaining injection vector missed by #24315.

Addresses feedback from https://github.com/vellum-ai/vellum-assistant/pull/24315
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24345" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
