### PR TITLE
fix: use multiline-safe pattern in FORK_DIRECTIVE_RE

### DIFF
--- a/assistant/src/__tests__/subagent-detail.test.ts
+++ b/assistant/src/__tests__/subagent-detail.test.ts
@@ -92,6 +92,26 @@ describe("parseSubagentMessages", () => {
     expect(result.objective).toBe("Research vampire lore");
   });
 
+  test("strips fork directive framing from objective", () => {
+    const forkPrompt = [
+      "⎯⎯⎯ FORK TASK ⎯⎯⎯",
+      "You have been forked from the parent conversation to execute a specific task.",
+      "The conversation above is context — do NOT continue it. Do NOT spawn sub-agents.",
+      "Complete this task directly and return only your findings:",
+      "",
+      "Research vampire lore",
+      "⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯",
+    ].join("\n");
+
+    const messages = [
+      msg("user", [{ type: "text", text: forkPrompt }]),
+      msg("assistant", [{ type: "text", text: "On it." }]),
+    ];
+
+    const result = parseSubagentMessages("sub-1", messages);
+    expect(result.objective).toBe("Research vampire lore");
+  });
+
   test("includes messageId on text events from assistant messages", () => {
     const messages = [
       msg("user", [{ type: "text", text: "Do something" }]),

--- a/assistant/src/runtime/routes/subagents-routes.ts
+++ b/assistant/src/runtime/routes/subagents-routes.ts
@@ -36,7 +36,7 @@ export interface SubagentDetailResult {
 }
 
 const FORK_DIRECTIVE_RE =
-  /^⎯⎯⎯ FORK TASK ⎯⎯⎯\n.*?Complete this task directly and return only your findings:\n\n([\s\S]*?)\n⎯⎯⎯+$/;
+  /^⎯⎯⎯ FORK TASK ⎯⎯⎯\n[\s\S]*?Complete this task directly and return only your findings:\n\n([\s\S]*?)\n⎯⎯⎯+$/;
 
 function stripForkDirectiveFraming(text: string): string {
   const match = FORK_DIRECTIVE_RE.exec(text);


### PR DESCRIPTION
Fixes the fork directive stripping regex to match across newlines, making the feature actually functional.

Addresses feedback from https://github.com/vellum-ai/vellum-assistant/pull/24318
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24348" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
