### PR TITLE
build(macos): auto-refresh /Applications bundle on ./build.sh run

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -1360,6 +1360,25 @@ if [ "$CMD" = "run" ]; then
     fi
     pkill -x "vellum-assistant" 2>/dev/null || true
     sleep 0.3
+
+    # Refresh /Applications/$BUNDLE_DISPLAY_NAME.app from the freshly-built
+    # dist/ bundle, if a copy already exists. Without this, `./build.sh run`
+    # only updates dist/ and a Finder/dock launch silently keeps using the
+    # last DMG-installed bundle — which can be many features stale and
+    # presents as missing menus, missing feature flags, and ghost data loss.
+    # We only refresh when /Applications already has a copy so this doesn't
+    # become an unsolicited installer for users who never installed via DMG.
+    INSTALLED_APP="/Applications/$BUNDLE_DISPLAY_NAME.app"
+    if [ -d "$INSTALLED_APP" ]; then
+        echo "Refreshing $INSTALLED_APP from dist/..."
+        rm -rf "$INSTALLED_APP"
+        if cp -R "$APP_DIR" "$INSTALLED_APP"; then
+            echo "Refreshed installed bundle."
+        else
+            echo "Warning: failed to refresh $INSTALLED_APP — Finder launches may use a stale bundle."
+        fi
+    fi
+
     # Launch via `open` so Launch Services registers the bundle —
     # this is required for macOS TCC to associate the app with its
     # bundle ID and show it in System Settings > Privacy & Security.

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -1368,13 +1368,38 @@ if [ "$CMD" = "run" ]; then
     # presents as missing menus, missing feature flags, and ghost data loss.
     # We only refresh when /Applications already has a copy so this doesn't
     # become an unsolicited installer for users who never installed via DMG.
+    #
+    # The refresh is *best-effort*: under `set -euo pipefail` we have to
+    # guard every failable step with `|| refresh_ok=false`, otherwise a
+    # permission error or disk-full would propagate up and abort the entire
+    # `run` flow before `open "$APP_DIR"` executes — turning a best-effort
+    # mirror into a hard launch failure for anyone whose /Applications
+    # bundle isn't writable. We also stage the new copy beside the
+    # destination *before* removing the old one, so a partial cp failure
+    # doesn't leave the user with no installed bundle at all.
     INSTALLED_APP="/Applications/$BUNDLE_DISPLAY_NAME.app"
     if [ -d "$INSTALLED_APP" ]; then
         echo "Refreshing $INSTALLED_APP from dist/..."
-        rm -rf "$INSTALLED_APP"
-        if cp -R "$APP_DIR" "$INSTALLED_APP"; then
+        STAGING_APP="$INSTALLED_APP.tmp.$$"
+        refresh_ok=true
+        cp -R "$APP_DIR" "$STAGING_APP" 2>/dev/null || refresh_ok=false
+        if $refresh_ok; then
+            rm -rf "$INSTALLED_APP" 2>/dev/null || refresh_ok=false
+        fi
+        if $refresh_ok; then
+            mv "$STAGING_APP" "$INSTALLED_APP" 2>/dev/null || refresh_ok=false
+        fi
+        if $refresh_ok; then
             echo "Refreshed installed bundle."
         else
+            # The realistic failure modes we're protecting against are
+            # `cp` failing (disk full / permission denied), which happens
+            # *before* we touch $INSTALLED_APP. The staging-then-swap
+            # ordering means an `rm` or `mv` failure after a successful
+            # `cp` is only possible under TOCTOU races with another
+            # process — vanishingly rare and out of scope for a
+            # best-effort dev mirror. Clean up the staging copy and warn.
+            rm -rf "$STAGING_APP" 2>/dev/null || true
             echo "Warning: failed to refresh $INSTALLED_APP — Finder launches may use a stale bundle."
         fi
     fi


### PR DESCRIPTION
## Summary
- \`./build.sh run\` rebuilds \`clients/macos/dist/\` but never touches the DMG-installed copy in \`/Applications/\`. After a few features have shipped, Finder/dock launches silently diverge from \`./build.sh run\` launches — the same \`.app\` icon opens a many-features-stale binary.
- Symptoms look like data loss: missing menu sections, missing feature flags, missing assistants. Today this cost an hour of debugging the menu-bar assistant switcher being completely absent on Finder launch — turned out the \`/Applications\` bundle was six days stale and predated the entire feature.
- Mirror the freshly-built bundle into \`/Applications\` at the end of \`run\`, gated on an existing install being present so this doesn't become an unsolicited installer for users who've never DMG-installed.

## Test plan
- [ ] With \`/Applications/Vellum Staging.app\` already installed: run \`VELLUM_PLATFORM_URL=https://dev-platform.vellum.ai BUNDLE_DISPLAY_NAME="Vellum Staging" ./build.sh run\`. Confirm log line \`Refreshing /Applications/Vellum Staging.app from dist/...\` appears, and that double-clicking the Finder icon afterward launches the same binary as the \`run\` invocation.
- [ ] Without an existing \`/Applications\` install: run the same command. Confirm no refresh log line, no new install in \`/Applications\`, \`run\` still launches \`dist/\` as before.
- [ ] cp failure path: \`chmod -w /Applications\` then run. Confirm the warning prints and \`run\` continues to launch \`dist/\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24351" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
