### PR TITLE
fix: mark defaultBundledKernelURL() as nonisolated to fix macOS build

### DIFF
--- a/clients/macos/vellum-assistant/App/AppleContainersLauncher.swift
+++ b/clients/macos/vellum-assistant/App/AppleContainersLauncher.swift
@@ -312,7 +312,7 @@ final class AppleContainersLauncher: AssistantManagementClient {
         }
     }
 
-    static func defaultBundledKernelURL() -> URL? {
+    nonisolated static func defaultBundledKernelURL() -> URL? {
         let relativePath = bundledKernelSubdirectory + "/vmlinux.container"
 
         if let resourceURL = Bundle.main.resourceURL?


### PR DESCRIPTION
## Summary
- `AppleContainersLauncher.defaultBundledKernelURL()` inherited `@MainActor` isolation from the class but is called from a `nonisolated(unsafe)` static closure, causing a Swift concurrency compile error
- The method only accesses `Bundle.main` and `FileManager` — no main actor dependency — so marking it `nonisolated` is the correct fix

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24150233396/job/70474947904
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24352" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
