### PR TITLE
fix: subtract summaryOffset from nonPersistedPrefixCount in compaction

### DIFF
--- a/assistant/src/context/window-manager.ts
+++ b/assistant/src/context/window-manager.ts
@@ -314,7 +314,7 @@ export class ContextWindowManager {
     }
 
     const injectedInCompactable = Math.min(
-      this.nonPersistedPrefixCount,
+      Math.max(0, this.nonPersistedPrefixCount - summaryOffset),
       compactableMessages.length,
     );
     const compactedPersistedMessages =


### PR DESCRIPTION
Fixes off-by-one in injectedInCompactable calculation for forked conversations with prior compaction.

Addresses feedback from https://github.com/vellum-ai/vellum-assistant/pull/24324
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24353" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
