### PR TITLE
fix(macOS): re-evaluate hover state when supportsOverflowHover changes

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -84,6 +84,10 @@ struct ChatBubble: View, Equatable {
     /// Owned but never read in this body — only ChatBubbleOverflowMenu reads it,
     /// so hover changes invalidate only the overflow menu, not this view.
     @State private var hoverState = ChatBubbleHoverState()
+    /// Raw pointer presence — always updated by onHover regardless of
+    /// `supportsOverflowHover`, so we can re-derive hover state when
+    /// the property transitions (e.g. streaming ends while cursor is over bubble).
+    @State private var pointerIsOverBubble = false
     @Environment(\.bubbleMaxWidth) var bubbleMaxWidth
     /// Stores async-parsed segments for large messages (>500 chars) that missed the
     /// synchronous cache. Keyed by text content so multiple segments can be in flight.
@@ -428,12 +432,16 @@ struct ChatBubble: View, Equatable {
         .onChange(of: message.contentOrder) { _, _ in recomputeInterleavedContentCache() }
         .onChange(of: message.textSegments) { _, _ in recomputeInterleavedContentCache() }
         .onHover { hovering in
-            guard supportsOverflowHover else {
-                if hoverState.isHovered { hoverState.isHovered = false }
-                return
+            pointerIsOverBubble = hovering
+            let shouldHover = hovering && supportsOverflowHover
+            if hoverState.isHovered != shouldHover {
+                hoverState.isHovered = shouldHover
             }
-            if hoverState.isHovered != hovering {
-                hoverState.isHovered = hovering
+        }
+        .onChange(of: supportsOverflowHover) { _, supports in
+            let shouldHover = pointerIsOverBubble && supports
+            if hoverState.isHovered != shouldHover {
+                hoverState.isHovered = shouldHover
             }
         }
         .task(id: mediaEmbedTaskID) {


### PR DESCRIPTION
## Summary
- Track `pointerIsOverBubble` separately from `hoverState.isHovered` so raw pointer presence is always known
- Derive `hoverState.isHovered` from `pointerIsOverBubble && supportsOverflowHover`
- Add `.onChange(of: supportsOverflowHover)` to re-evaluate hover when the property transitions (e.g. streaming ends while cursor is over bubble)

Addresses feedback from https://github.com/vellum-ai/vellum-assistant/pull/24328

## Test plan
- [ ] Start a streaming response, hover over the bubble during streaming
- [ ] When streaming ends, verify overflow actions appear immediately without moving the cursor
- [ ] Verify normal hover/unhover behavior still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24357" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
