### PR TITLE
fix(macos): mark AppleContainersLauncher.defaultBundledKernelURL as nonisolated

### DIFF
--- a/clients/macos/vellum-assistant/App/AppleContainersLauncher.swift
+++ b/clients/macos/vellum-assistant/App/AppleContainersLauncher.swift
@@ -312,7 +312,7 @@ final class AppleContainersLauncher: AssistantManagementClient {
         }
     }
 
-    static func defaultBundledKernelURL() -> URL? {
+    nonisolated static func defaultBundledKernelURL() -> URL? {
         let relativePath = bundledKernelSubdirectory + "/vmlinux.container"
 
         if let resourceURL = Bundle.main.resourceURL?


### PR DESCRIPTION
## Summary
Follow-up to #24267. The static var `locateBundledKernel` is declared `nonisolated(unsafe)` and its initializer closure runs at static-init time, but it calls `defaultBundledKernelURL()` which inherits the enclosing class's `@MainActor` isolation. Under Swift 6.2 strict concurrency this fails the build:

```
error: call to main actor-isolated static method 'defaultBundledKernelURL()' in a synchronous nonisolated(unsafe) context
 73 |     nonisolated(unsafe) static var locateBundledKernel: () -> URL? = {
 74 |         defaultBundledKernelURL()
    |         `- error: ...
```

`defaultBundledKernelURL()` only reads `Bundle.main` and `FileManager.default`, neither of which need main-actor isolation. Marking it `nonisolated` is the minimal fix and lets the existing `nonisolated(unsafe)` test hook on `locateBundledKernel` keep working as designed.

## Why CI didn't catch this in #24267
`.github/workflows/pr-macos.yaml` runs on `macos-15` (Sequoia), which ships with Swift 6.0.x / 6.1.x in the runner image. The actor-isolation rule for synchronous static-var initializers calling main-actor members was a **warning** in those toolchains and was promoted to a **hard error** in Swift 6.2.

Developers on macOS 26 (Tahoe) / Xcode 26 are on Swift 6.2.4, so anyone who pulled main after #24267 merged got an unbuildable tree. CI ≠ local for this class of diagnostic — and as more of the team upgrades to Tahoe, every actor-isolation papercut that lands will pass CI and break developer machines silently.

Worth a follow-up: bump the CI runner to `macos-26` once GitHub publishes that image, or add a soft-signal matrix job on the newer image so we catch this kind of regression at PR time instead of in someone's `git pull`.

## Test plan
- [x] `swift build` from `clients/` succeeds locally on Swift 6.2.4 / macOS 26
- [ ] CI passes (will pass on macos-15 regardless — this fix is no-op there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)