### PR TITLE
fix(browser/cdp): correctness batch from Phase 3 self-review

### DIFF
--- a/assistant/src/__tests__/browser-fill-credential.test.ts
+++ b/assistant/src/__tests__/browser-fill-credential.test.ts
@@ -143,7 +143,7 @@ function resetMockPage() {
  *   - `getCurrentUrl` via Runtime.evaluate (for the broker domain check)
  *   - `querySelectorBackendNodeId` via DOM.getDocument / querySelector / describeNode
  *   - `focusElement` via DOM.focus
- *   - `dispatchInsertText` via Input.insertText
+ *   - `clearAndInsertText` via DOM.resolveNode + Runtime.callFunctionOn + Input.insertText
  *   - `dispatchKeyPress` via Input.dispatchKeyEvent
  */
 function defaultCdpHandler(
@@ -160,6 +160,14 @@ function defaultCdpHandler(
       return { nodeId: 42 };
     case "DOM.describeNode":
       return { node: { backendNodeId: 100 } };
+    case "DOM.resolveNode":
+      // Used by clearAndInsertText to obtain a remote object on the
+      // target element so it can run the value-clearing function.
+      return { object: { objectId: "obj-1" } };
+    case "Runtime.callFunctionOn":
+      // The clear-helper function returns undefined; tests don't
+      // depend on the return value.
+      return { result: { value: undefined } };
     default:
       return {};
   }
@@ -199,9 +207,17 @@ describe("executeBrowserFillCredential", () => {
     expect(result.isError).toBe(false);
     expect(result.content).toContain("Filled password for gmail");
 
-    // Backend path: Runtime.evaluate (getCurrentUrl) → DOM.focus → Input.insertText
+    // Backend path now goes through clearAndInsertText:
+    //   Runtime.evaluate (getCurrentUrl)
+    //   → DOM.focus
+    //   → DOM.resolveNode
+    //   → Runtime.callFunctionOn (clear)
+    //   → DOM.focus (re-focus)
+    //   → Input.insertText
     const methods = sendCalls.map((c) => c.method);
     expect(methods).toContain("DOM.focus");
+    expect(methods).toContain("DOM.resolveNode");
+    expect(methods).toContain("Runtime.callFunctionOn");
     expect(methods).toContain("Input.insertText");
     expect(methods).not.toContain("DOM.querySelector");
 
@@ -218,6 +234,44 @@ describe("executeBrowserFillCredential", () => {
     // CdpClient disposed in finally → session.detach called.
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(detachCalls).toBe(1);
+  });
+
+  test("clears pre-populated field BEFORE inserting credential text", async () => {
+    // Regression: previously, fillCredential called focus + insertText
+    // directly, which APPENDED the credential to any existing value
+    // (autofill, prior typing, etc.) — corrupting the password and
+    // leaking partial state. The fix routes through the shared
+    // clearAndInsertText helper.
+    snapshotBackendNodeMaps.set("test-conversation", new Map([["e1", 555]]));
+    await executeBrowserFillCredential(
+      { service: "gmail", field: "password", element_id: "e1" },
+      ctx,
+    );
+
+    // The clear must happen BEFORE the insertText. Specifically, the
+    // Runtime.callFunctionOn that runs the clearing function declaration
+    // must precede Input.insertText.
+    const methodSeq = sendCalls.map((c) => c.method);
+    const clearIdx = methodSeq.indexOf("Runtime.callFunctionOn");
+    const insertIdx = methodSeq.indexOf("Input.insertText");
+    expect(clearIdx).toBeGreaterThanOrEqual(0);
+    expect(insertIdx).toBeGreaterThan(clearIdx);
+
+    // The clearing function must reset both `value` and
+    // `textContent` so input/textarea AND contenteditable targets
+    // are handled.
+    const clearCall = sendCalls[clearIdx]!;
+    const fnDecl = (clearCall.params as { functionDeclaration: string })
+      .functionDeclaration;
+    expect(fnDecl).toContain('this.value = ""');
+    expect(fnDecl).toContain("this.textContent");
+    expect(fnDecl).toContain('new Event("input"');
+
+    // After the clear, the helper re-focuses the element (some sites
+    // blur on programmatic value reset) before inserting text — so we
+    // expect at least 2 DOM.focus calls in total.
+    const focusCount = methodSeq.filter((m) => m === "DOM.focus").length;
+    expect(focusCount).toBeGreaterThanOrEqual(2);
   });
 
   test("fills credential by CSS selector", async () => {
@@ -302,20 +356,20 @@ describe("executeBrowserFillCredential", () => {
     expect(result.isError).toBe(false);
     const methods = sendCalls.map((c) => c.method);
     expect(methods).toContain("Input.insertText");
-    // dispatchKeyPress dispatches keyDown + keyUp via Input.dispatchKeyEvent
+    // dispatchKeyPress for "Enter" dispatches keyDown + char + keyUp
+    // (Enter has text "\r" so it now produces a char event too).
     const keyEvents = sendCalls.filter(
       (c) => c.method === "Input.dispatchKeyEvent",
     );
-    expect(keyEvents).toHaveLength(2);
+    expect(keyEvents).toHaveLength(3);
     expect((keyEvents[0]!.params as { type: string; key: string }).type).toBe(
       "keyDown",
     );
     expect((keyEvents[0]!.params as { type: string; key: string }).key).toBe(
       "Enter",
     );
-    expect((keyEvents[1]!.params as { type: string; key: string }).type).toBe(
-      "keyUp",
-    );
+    expect((keyEvents[1]!.params as { type: string }).type).toBe("char");
+    expect((keyEvents[2]!.params as { type: string }).type).toBe("keyUp");
     // Enter must come AFTER Input.insertText.
     const insertIdx = sendCalls.findIndex(
       (c) => c.method === "Input.insertText",

--- a/assistant/src/__tests__/headless-browser-interactions.test.ts
+++ b/assistant/src/__tests__/headless-browser-interactions.test.ts
@@ -166,6 +166,13 @@ function defaultCdpHandler(
       return { object: { objectId: "obj-1" } };
     case "Runtime.evaluate":
       return { result: { value: { w: 800, h: 600 } } };
+    case "Runtime.callFunctionOn":
+      // executeBrowserSelectOption invokes a function that returns
+      // a `matched` boolean — default to true so wrapper-contract
+      // tests don't need to know the inner select-option matching
+      // shape. Tests that exercise the no-match path override the
+      // handler explicitly.
+      return { result: { value: true } };
     default:
       return {};
   }
@@ -457,7 +464,7 @@ describe("executeBrowserType", () => {
     expect(result.isError).toBe(false);
     expect(result.content).toContain("pressed Enter");
     const methods = sendCalls.map((c) => c.method);
-    // Input.insertText must come before the Enter keyDown/keyUp.
+    // Input.insertText must come before the Enter keyDown/char/keyUp.
     const insertIdx = methods.indexOf("Input.insertText");
     const keyDownIdx = methods.findIndex(
       (m, i) =>
@@ -466,11 +473,15 @@ describe("executeBrowserType", () => {
     );
     expect(insertIdx).toBeGreaterThanOrEqual(0);
     expect(keyDownIdx).toBeGreaterThan(insertIdx);
+    // Enter is text-producing → keyDown + char + keyUp.
     const keyEvents = sendCalls.filter(
       (c) => c.method === "Input.dispatchKeyEvent",
     );
-    expect(keyEvents).toHaveLength(2);
+    expect(keyEvents).toHaveLength(3);
     expect((keyEvents[0]!.params as { key: string }).key).toBe("Enter");
+    expect((keyEvents[0]!.params as { type: string }).type).toBe("keyDown");
+    expect((keyEvents[1]!.params as { type: string }).type).toBe("char");
+    expect((keyEvents[2]!.params as { type: string }).type).toBe("keyUp");
   });
 
   test("errors when text is missing", async () => {
@@ -568,16 +579,22 @@ describe("executeBrowserPressKey", () => {
     const result = await executeBrowserPressKey({ key: "Enter" }, ctx);
     expect(result.isError).toBe(false);
     expect(result.content).toContain('Pressed "Enter"');
-    // No target => no DOM.focus, no selector resolution, just keyDown + keyUp.
+    // No target => no DOM.focus, no selector resolution. Enter is a
+    // text-producing key (text "\r") so dispatchKeyPress emits
+    // keyDown + char + keyUp.
     const methods = sendCalls.map((c) => c.method);
     expect(methods).toEqual([
       "Input.dispatchKeyEvent",
       "Input.dispatchKeyEvent",
+      "Input.dispatchKeyEvent",
     ]);
-    const keyDown = sendCalls[0]!.params as { type: string; key: string };
-    const keyUp = sendCalls[1]!.params as { type: string; key: string };
+    const keyDown = sendCalls[0]!.params as Record<string, unknown>;
+    const charEvt = sendCalls[1]!.params as Record<string, unknown>;
+    const keyUp = sendCalls[2]!.params as Record<string, unknown>;
     expect(keyDown.type).toBe("keyDown");
     expect(keyDown.key).toBe("Enter");
+    expect(keyDown.windowsVirtualKeyCode).toBe(13);
+    expect(charEvt.type).toBe("char");
     expect(keyUp.type).toBe("keyUp");
     expect(keyUp.key).toBe("Enter");
   });
@@ -591,10 +608,12 @@ describe("executeBrowserPressKey", () => {
     expect(result.isError).toBe(false);
     expect(result.content).toContain('Pressed "Tab" on element');
     expect(result.content).toContain('element_id "e5"');
-    // Backend-resolved path: focus → dispatchKeyEvent × 2
+    // Backend-resolved path: focus → dispatchKeyEvent × 3 (Tab is
+    // text-producing so we also dispatch a char event).
     const methods = sendCalls.map((c) => c.method);
     expect(methods).toEqual([
       "DOM.focus",
+      "Input.dispatchKeyEvent",
       "Input.dispatchKeyEvent",
       "Input.dispatchKeyEvent",
     ]);
@@ -609,7 +628,7 @@ describe("executeBrowserPressKey", () => {
     expect(result.isError).toBe(false);
     expect(result.content).toContain('Pressed "Escape" on element');
     // Selector path: DOM.getDocument → DOM.querySelector → DOM.describeNode
-    // → DOM.focus → dispatchKeyEvent × 2
+    // → DOM.focus → dispatchKeyEvent × 2 (Escape has no text, so no char event).
     const methods = sendCalls.map((c) => c.method);
     expect(methods).toEqual([
       "DOM.getDocument",
@@ -760,12 +779,38 @@ describe("executeBrowserScroll", () => {
 
 // ── browser_select_option ────────────────────────────────────────────
 
+/**
+ * Default handler tuned for select-option tests. The Runtime.callFunctionOn
+ * call now returns whether an option matched; tests assert on this
+ * via `result.value`.
+ */
+function selectOptionHandler(
+  matched = true,
+): (method: string, params?: Record<string, unknown>) => unknown {
+  return (method, _params) => {
+    switch (method) {
+      case "DOM.getDocument":
+        return { root: { nodeId: 1 } };
+      case "DOM.querySelector":
+        return { nodeId: 42 };
+      case "DOM.describeNode":
+        return { node: { backendNodeId: 100 } };
+      case "DOM.resolveNode":
+        return { object: { objectId: "obj-1" } };
+      case "Runtime.callFunctionOn":
+        return { result: { value: matched } };
+      default:
+        return {};
+    }
+  };
+}
+
 describe("executeBrowserSelectOption", () => {
   beforeEach(() => {
     resetMockPage();
     resetCdpMock();
     snapshotBackendNodeMaps.clear();
-    sendHandler = defaultCdpHandler;
+    sendHandler = selectOptionHandler();
   });
 
   test("selects by value via element_id", async () => {
@@ -786,6 +831,7 @@ describe("executeBrowserSelectOption", () => {
     const callFn = sendCalls[1]!.params as {
       objectId: string;
       arguments: Array<{ value: unknown }>;
+      returnByValue?: boolean;
     };
     expect(callFn.objectId).toBe("obj-1");
     expect(callFn.arguments).toEqual([
@@ -793,6 +839,9 @@ describe("executeBrowserSelectOption", () => {
       { value: null },
       { value: null },
     ]);
+    // returnByValue must be true so the matched boolean comes back
+    // primitive instead of as a RemoteObject reference.
+    expect(callFn.returnByValue).toBe(true);
   });
 
   test("selects by label", async () => {
@@ -835,6 +884,32 @@ describe("executeBrowserSelectOption", () => {
       { value: null },
       { value: 2 },
     ]);
+  });
+
+  test("returns error when no option matches", async () => {
+    sendHandler = selectOptionHandler(false);
+    const result = await executeBrowserSelectOption(
+      { selector: "#state", value: "nope" },
+      ctx,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("Select option failed");
+    expect(result.content).toContain("no option matched");
+    expect(result.content).toContain('value="nope"');
+  });
+
+  test("dispatches input + change events via the function declaration", async () => {
+    await executeBrowserSelectOption({ selector: "#state", value: "ca" }, ctx);
+    const callFn = sendCalls.find((c) => c.method === "Runtime.callFunctionOn")!
+      .params as { functionDeclaration: string };
+    // The function body must dispatch BOTH input and change events
+    // (HTML spec order: input fires before change for <select>).
+    expect(callFn.functionDeclaration).toContain('new Event("input"');
+    expect(callFn.functionDeclaration).toContain('new Event("change"');
+    const inputIdx = callFn.functionDeclaration.indexOf('new Event("input"');
+    const changeIdx = callFn.functionDeclaration.indexOf('new Event("change"');
+    expect(inputIdx).toBeGreaterThanOrEqual(0);
+    expect(changeIdx).toBeGreaterThan(inputIdx);
   });
 
   test("errors when no option specifier provided", async () => {

--- a/assistant/src/__tests__/headless-browser-navigate.test.ts
+++ b/assistant/src/__tests__/headless-browser-navigate.test.ts
@@ -397,6 +397,47 @@ describe("executeBrowserNavigate", () => {
     expect(cdpDisposed).toBe(true);
   });
 
+  test("surfaces Page.navigate errorText as a navigation failure", async () => {
+    // CDP signals DNS / connection errors via the response's
+    // `errorText` field rather than throwing. Without this, the
+    // navigate helper would poll readyState on the OLD page (which is
+    // "complete") and report success with the stale URL — leaking
+    // potentially sensitive content the agent never asked for.
+    parseUrlResult = new URL("https://nope.invalid");
+    cdpSendHandler = (method, params) => {
+      if (method === "Page.navigate") {
+        return { frameId: "f1", errorText: "net::ERR_NAME_NOT_RESOLVED" };
+      }
+      if (method === "Runtime.evaluate") {
+        const expression = String(params?.["expression"] ?? "");
+        if (expression === "document.location.href") {
+          return { result: { value: "https://example.com/old" } };
+        }
+        return { result: { value: null } };
+      }
+      return {};
+    };
+
+    const result = await executeBrowserNavigate(
+      { url: "https://nope.invalid" },
+      ctx,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("Navigation failed");
+    expect(result.content).toContain("ERR_NAME_NOT_RESOLVED");
+    expect(cdpDisposed).toBe(true);
+
+    // Should NOT have polled readyState — navigate failed before the
+    // wait loop ran.
+    const readyStateCalls = cdpSendCalls.filter(
+      (c) =>
+        c.method === "Runtime.evaluate" &&
+        (c.params as { expression?: string } | undefined)?.expression ===
+          "document.readyState",
+    );
+    expect(readyStateCalls).toHaveLength(0);
+  });
+
   // ── SSRF route interception (local path only) ─────────────────
 
   test("returns security message when route handler blocks a redirect", async () => {

--- a/assistant/src/tools/browser/browser-execution.ts
+++ b/assistant/src/tools/browser/browser-execution.ts
@@ -46,6 +46,7 @@ import {
   waitForText as cdpWaitForText,
 } from "./cdp-client/cdp-dom-helpers.js";
 import { getCdpClient } from "./cdp-client/factory.js";
+import type { CdpClient } from "./cdp-client/types.js";
 
 const log = getLogger("headless-browser");
 
@@ -744,6 +745,60 @@ export async function executeBrowserClick(
   }
 }
 
+// ── Shared input helpers ─────────────────────────────────────────────
+
+/**
+ * Focus an element, clear its existing value (handling both
+ * `<input>`/`<textarea>` and `contentEditable` targets), re-focus
+ * (sites sometimes blur on a programmatic value reset), and insert
+ * the requested text via `Input.insertText`.
+ *
+ * Used by both `executeBrowserType` and `executeBrowserFillCredential`
+ * so credential fills cannot append to autofilled / pre-populated
+ * fields — appending would leak the existing value into the broker
+ * payload and corrupt the resulting password.
+ */
+async function clearAndInsertText(
+  cdp: CdpClient,
+  backendNodeId: number,
+  value: string,
+  signal?: AbortSignal,
+): Promise<void> {
+  await focusElement(cdp, backendNodeId, signal);
+
+  // Resolve the node to a Runtime.RemoteObject so we can invoke a
+  // function on the element itself via Runtime.callFunctionOn. This
+  // is more reliable than a keyboard select-all + delete sequence
+  // across input, textarea, and contenteditable targets.
+  const { object } = await cdp.send<{ object: { objectId: string } }>(
+    "DOM.resolveNode",
+    { backendNodeId },
+    signal,
+  );
+  await cdp.send(
+    "Runtime.callFunctionOn",
+    {
+      objectId: object.objectId,
+      functionDeclaration: `function() {
+        if (typeof this.value === "string") {
+          this.value = "";
+        } else if (this.isContentEditable) {
+          this.textContent = "";
+        }
+        this.dispatchEvent(new Event("input", { bubbles: true }));
+      }`,
+      arguments: [],
+    },
+    signal,
+  );
+
+  // Re-focus after clearing — some sites move focus when the value
+  // property is reassigned programmatically.
+  await focusElement(cdp, backendNodeId, signal);
+
+  await dispatchInsertText(cdp, value, signal);
+}
+
 // ── browser_type ─────────────────────────────────────────────────────
 
 export async function executeBrowserType(
@@ -779,40 +834,12 @@ export async function executeBrowserType(
       );
     }
 
-    await focusElement(cdp, backendNodeId, context.signal);
-
     if (clearFirst) {
-      // Resolve the node to a Runtime.RemoteObject so we can invoke a
-      // function on the element itself via Runtime.callFunctionOn. This
-      // is more reliable than a keyboard select-all + delete sequence
-      // across input, textarea, and contenteditable targets.
-      const { object } = await cdp.send<{ object: { objectId: string } }>(
-        "DOM.resolveNode",
-        { backendNodeId },
-        context.signal,
-      );
-      await cdp.send(
-        "Runtime.callFunctionOn",
-        {
-          objectId: object.objectId,
-          functionDeclaration: `function() {
-            if (typeof this.value === "string") {
-              this.value = "";
-            } else if (this.isContentEditable) {
-              this.textContent = "";
-            }
-            this.dispatchEvent(new Event("input", { bubbles: true }));
-          }`,
-          arguments: [],
-        },
-        context.signal,
-      );
-      // Re-focus after clearing — some sites move focus when the
-      // value property is reassigned programmatically.
+      await clearAndInsertText(cdp, backendNodeId, text, context.signal);
+    } else {
       await focusElement(cdp, backendNodeId, context.signal);
+      await dispatchInsertText(cdp, text, context.signal);
     }
-
-    await dispatchInsertText(cdp, text, context.signal);
 
     if (pressEnter) {
       await dispatchKeyPress(cdp, "Enter", context.signal);
@@ -999,47 +1026,76 @@ export async function executeBrowserSelectOption(
 
     // CDP does not expose a native "set select value" command, so we
     // resolve the node to a Runtime.RemoteObject and invoke a function
-    // on it that applies value/label/index and dispatches a bubbling
-    // `change` event.
+    // on it that applies value/label/index and dispatches `input`
+    // followed by `change` (HTML spec order — Angular's
+    // DefaultValueAccessor listens for `input`, so missing it breaks
+    // form bindings on Angular sites).
     const { object } = await cdp.send<{ object: { objectId: string } }>(
       "DOM.resolveNode",
       { backendNodeId },
       context.signal,
     );
-    await cdp.send(
+    const callResult = await cdp.send<{
+      result?: { value?: boolean };
+    }>(
       "Runtime.callFunctionOn",
       {
         objectId: object.objectId,
         functionDeclaration: `function(value, label, index) {
+          let matched = false;
           if (value !== null && value !== undefined) {
-            this.value = value;
+            for (const opt of this.options) {
+              if (opt.value === value) {
+                this.value = value;
+                matched = true;
+                break;
+              }
+            }
           } else if (label !== null && label !== undefined) {
             for (const opt of this.options) {
               if (opt.label === label) {
                 this.value = opt.value;
+                matched = true;
                 break;
               }
             }
           } else if (index !== null && index !== undefined) {
-            this.selectedIndex = index;
+            if (index >= 0 && index < this.options.length) {
+              this.selectedIndex = index;
+              matched = true;
+            }
           }
-          this.dispatchEvent(new Event("change", { bubbles: true }));
+          if (matched) {
+            this.dispatchEvent(new Event("input", { bubbles: true }));
+            this.dispatchEvent(new Event("change", { bubbles: true }));
+          }
+          return matched;
         }`,
         arguments: [
           { value: value ?? null },
           { value: label ?? null },
           { value: index ?? null },
         ],
+        returnByValue: true,
       },
       context.signal,
     );
 
+    const matched = callResult?.result?.value === true;
     const desc =
       value !== undefined
         ? `value="${value}"`
         : label !== undefined
           ? `label="${label}"`
           : `index=${index}`;
+
+    if (!matched) {
+      return {
+        content: `Error: Select option failed: no option matched ${desc} on ${targetDescription}.`,
+        isError: true,
+      };
+    }
+
     return {
       content: `Selected option (${desc}) on element: ${targetDescription}`,
       isError: false,
@@ -1276,11 +1332,13 @@ export async function executeBrowserFillCredential(
       toolName: "browser_fill_credential",
       domain: pageDomain,
       fill: async (value) => {
-        // Focus the target immediately before inserting text so
-        // Input.insertText lands on the right element even if a
-        // prior tool call shifted focus.
-        await focusElement(cdp, backendNodeId, context.signal);
-        await dispatchInsertText(cdp, value, context.signal);
+        // Clear-then-focus-then-insert via the shared helper. We
+        // MUST clear first: Input.insertText writes at the cursor,
+        // so on autofilled / pre-populated fields a bare insert
+        // would append the credential to the existing value,
+        // producing a corrupted password and leaking partial state
+        // back into the page.
+        await clearAndInsertText(cdp, backendNodeId, value, context.signal);
       },
     });
 

--- a/assistant/src/tools/browser/cdp-client/__tests__/cdp-dom-helpers.test.ts
+++ b/assistant/src/tools/browser/cdp-client/__tests__/cdp-dom-helpers.test.ts
@@ -279,21 +279,116 @@ describe("dispatchInsertText", () => {
 // ── dispatchKeyPress ──────────────────────────────────────────────────
 
 describe("dispatchKeyPress", () => {
-  test("emits keyDown + keyUp with the requested key", async () => {
+  test("Enter sends keyDown + char + keyUp with windowsVirtualKeyCode 13", async () => {
     const cdp = fakeCdp(() => ({}));
 
     await dispatchKeyPress(cdp, "Enter");
 
-    expect(cdp.calls).toEqual([
-      {
-        method: "Input.dispatchKeyEvent",
-        params: { type: "keyDown", key: "Enter" },
-      },
-      {
-        method: "Input.dispatchKeyEvent",
-        params: { type: "keyUp", key: "Enter" },
-      },
-    ]);
+    // Enter is text-producing (\r) so we get keyDown + char + keyUp.
+    expect(cdp.calls).toHaveLength(3);
+    for (const call of cdp.calls) {
+      expect(call.method).toBe("Input.dispatchKeyEvent");
+      const params = call.params as Record<string, unknown>;
+      expect(params.key).toBe("Enter");
+      expect(params.code).toBe("Enter");
+      expect(params.windowsVirtualKeyCode).toBe(13);
+      expect(params.text).toBe("\r");
+    }
+    expect((cdp.calls[0]!.params as Record<string, unknown>).type).toBe(
+      "keyDown",
+    );
+    expect((cdp.calls[1]!.params as Record<string, unknown>).type).toBe("char");
+    expect((cdp.calls[2]!.params as Record<string, unknown>).type).toBe(
+      "keyUp",
+    );
+  });
+
+  test("'a' sends keyCode 65, code KeyA, and a char event", async () => {
+    const cdp = fakeCdp(() => ({}));
+
+    await dispatchKeyPress(cdp, "a");
+
+    expect(cdp.calls).toHaveLength(3);
+    for (const call of cdp.calls) {
+      const params = call.params as Record<string, unknown>;
+      expect(params.key).toBe("a");
+      expect(params.code).toBe("KeyA");
+      expect(params.windowsVirtualKeyCode).toBe(65);
+      expect(params.text).toBe("a");
+    }
+    expect((cdp.calls[1]!.params as Record<string, unknown>).type).toBe("char");
+  });
+
+  test("ArrowDown sends keyCode 40 and NO char event", async () => {
+    const cdp = fakeCdp(() => ({}));
+
+    await dispatchKeyPress(cdp, "ArrowDown");
+
+    // ArrowDown is non-printing → no char event (just keyDown + keyUp).
+    expect(cdp.calls).toHaveLength(2);
+    for (const call of cdp.calls) {
+      const params = call.params as Record<string, unknown>;
+      expect(params.key).toBe("ArrowDown");
+      expect(params.code).toBe("ArrowDown");
+      expect(params.windowsVirtualKeyCode).toBe(40);
+      expect(params.text).toBeUndefined();
+    }
+    expect((cdp.calls[0]!.params as Record<string, unknown>).type).toBe(
+      "keyDown",
+    );
+    expect((cdp.calls[1]!.params as Record<string, unknown>).type).toBe(
+      "keyUp",
+    );
+  });
+
+  test("digit '7' sends keyCode 55 and code Digit7", async () => {
+    const cdp = fakeCdp(() => ({}));
+
+    await dispatchKeyPress(cdp, "7");
+
+    expect(cdp.calls).toHaveLength(3);
+    const params = cdp.calls[0]!.params as Record<string, unknown>;
+    expect(params.key).toBe("7");
+    expect(params.code).toBe("Digit7");
+    expect(params.windowsVirtualKeyCode).toBe(55);
+    expect(params.text).toBe("7");
+  });
+
+  test("Tab sends keyCode 9 and text '\\t'", async () => {
+    const cdp = fakeCdp(() => ({}));
+
+    await dispatchKeyPress(cdp, "Tab");
+
+    expect(cdp.calls).toHaveLength(3);
+    const params = cdp.calls[0]!.params as Record<string, unknown>;
+    expect(params.windowsVirtualKeyCode).toBe(9);
+    expect(params.text).toBe("\t");
+  });
+
+  test("Escape sends keyCode 27 and NO char event", async () => {
+    const cdp = fakeCdp(() => ({}));
+
+    await dispatchKeyPress(cdp, "Escape");
+
+    expect(cdp.calls).toHaveLength(2);
+    const params = cdp.calls[0]!.params as Record<string, unknown>;
+    expect(params.windowsVirtualKeyCode).toBe(27);
+    expect(params.text).toBeUndefined();
+  });
+
+  test("unknown multi-character key falls back to minimal payload", async () => {
+    const cdp = fakeCdp(() => ({}));
+    // Suppress the console.warn for the duration of the call.
+    const originalWarn = console.warn;
+    console.warn = () => {};
+    try {
+      await dispatchKeyPress(cdp, "F19");
+    } finally {
+      console.warn = originalWarn;
+    }
+    expect(cdp.calls).toHaveLength(2);
+    expect(cdp.calls[0]!.params).toEqual({ type: "keyDown", key: "F19" });
+    expect(cdp.calls[1]!.params).toEqual({ type: "keyUp", key: "F19" });
   });
 
   test("propagates errors from the client", async () => {
@@ -595,6 +690,33 @@ describe("navigateAndWait", () => {
       name: "CdpError",
       code: "aborted",
     });
+  });
+
+  test("throws CdpError when Page.navigate returns errorText", async () => {
+    // CDP signals DNS / connection errors via `errorText` rather than
+    // throwing — navigateAndWait must surface this instead of polling
+    // the OLD page's readyState (which is "complete") and reporting
+    // success with the stale URL.
+    const cdp = fakeCdp((method) => {
+      if (method === "Page.navigate")
+        return { frameId: "f1", errorText: "net::ERR_CONNECTION_REFUSED" };
+      throw new Error(`unexpected: ${method}`);
+    });
+
+    await expect(
+      navigateAndWait(cdp, "https://nope.invalid", { timeoutMs: 5_000 }),
+    ).rejects.toMatchObject({
+      name: "CdpError",
+      code: "cdp_error",
+      message: "net::ERR_CONNECTION_REFUSED",
+      cdpMethod: "Page.navigate",
+      cdpParams: { url: "https://nope.invalid" },
+    });
+
+    // Should NOT have polled readyState or read final URL after the
+    // navigate failed.
+    const evals = cdp.calls.filter((c) => c.method === "Runtime.evaluate");
+    expect(evals).toHaveLength(0);
   });
 });
 

--- a/assistant/src/tools/browser/cdp-client/cdp-dom-helpers.ts
+++ b/assistant/src/tools/browser/cdp-client/cdp-dom-helpers.ts
@@ -155,16 +155,161 @@ export async function dispatchInsertText(
 }
 
 /**
- * Press a single key (keyDown + keyUp). Key names follow CDP
- * conventions ("Enter", "Tab", "ArrowDown", "a").
+ * Per-key descriptor used by {@link dispatchKeyPress}. Mirrors the
+ * fields CDP's `Input.dispatchKeyEvent` accepts. `text` is set only
+ * for printable keys (so we know to also dispatch a `char` event).
+ */
+interface KeyDescriptor {
+  key: string;
+  code: string;
+  windowsVirtualKeyCode: number;
+  text?: string;
+}
+
+/**
+ * Subset of the US keyboard layout used to populate
+ * `Input.dispatchKeyEvent` params. Without these fields, sites that
+ * read `event.keyCode` (e.g. `event.keyCode === 13` for Enter) or
+ * `event.code` see zeros and the press is silently ignored.
+ *
+ * Single-character keys (a-z, A-Z, 0-9) are resolved dynamically by
+ * {@link resolveKeyDescriptor} to keep the static map small.
+ */
+const KEY_DESCRIPTORS: Record<string, KeyDescriptor> = {
+  Enter: {
+    key: "Enter",
+    code: "Enter",
+    windowsVirtualKeyCode: 13,
+    text: "\r",
+  },
+  Tab: { key: "Tab", code: "Tab", windowsVirtualKeyCode: 9, text: "\t" },
+  Escape: { key: "Escape", code: "Escape", windowsVirtualKeyCode: 27 },
+  Backspace: {
+    key: "Backspace",
+    code: "Backspace",
+    windowsVirtualKeyCode: 8,
+  },
+  Delete: { key: "Delete", code: "Delete", windowsVirtualKeyCode: 46 },
+  ArrowUp: { key: "ArrowUp", code: "ArrowUp", windowsVirtualKeyCode: 38 },
+  ArrowDown: {
+    key: "ArrowDown",
+    code: "ArrowDown",
+    windowsVirtualKeyCode: 40,
+  },
+  ArrowLeft: {
+    key: "ArrowLeft",
+    code: "ArrowLeft",
+    windowsVirtualKeyCode: 37,
+  },
+  ArrowRight: {
+    key: "ArrowRight",
+    code: "ArrowRight",
+    windowsVirtualKeyCode: 39,
+  },
+};
+
+/**
+ * Resolve a key name into a {@link KeyDescriptor}. Single-character
+ * keys (a-z, A-Z, 0-9) are computed on demand: `code` is `KeyA`/
+ * `Digit0`/etc., `windowsVirtualKeyCode` is the uppercase ASCII code,
+ * and `text` is the literal character. Returns `null` for unknown
+ * multi-character keys so callers can fall back to a minimal event.
+ */
+function resolveKeyDescriptor(key: string): KeyDescriptor | null {
+  const fromMap = KEY_DESCRIPTORS[key];
+  if (fromMap) return fromMap;
+  if (key.length !== 1) return null;
+  const charCode = key.charCodeAt(0);
+  // a-z / A-Z
+  if (
+    (charCode >= 65 && charCode <= 90) ||
+    (charCode >= 97 && charCode <= 122)
+  ) {
+    const upper = key.toUpperCase();
+    return {
+      key,
+      code: `Key${upper}`,
+      windowsVirtualKeyCode: upper.charCodeAt(0),
+      text: key,
+    };
+  }
+  // 0-9
+  if (charCode >= 48 && charCode <= 57) {
+    return {
+      key,
+      code: `Digit${key}`,
+      windowsVirtualKeyCode: charCode,
+      text: key,
+    };
+  }
+  // Other printable ASCII (space, punctuation): still emit text + the
+  // raw char code so sites that check `event.key` and `event.charCode`
+  // see something sensible.
+  if (charCode >= 32 && charCode <= 126) {
+    return {
+      key,
+      code: "",
+      windowsVirtualKeyCode: charCode,
+      text: key,
+    };
+  }
+  return null;
+}
+
+/**
+ * Press a single key (keyDown + optional `char` + keyUp). Resolves
+ * the key name to a {@link KeyDescriptor} so CDP receives the right
+ * `code` / `windowsVirtualKeyCode` / `text` fields — required by
+ * sites that check `event.keyCode` (e.g. Enter-to-submit) or
+ * `event.code`. For printable keys we also dispatch a `char` event
+ * between keyDown and keyUp so the character is actually inserted
+ * into focused inputs.
  */
 export async function dispatchKeyPress(
   cdp: CdpClient,
   key: string,
   signal?: AbortSignal,
 ): Promise<void> {
-  await cdp.send("Input.dispatchKeyEvent", { type: "keyDown", key }, signal);
-  await cdp.send("Input.dispatchKeyEvent", { type: "keyUp", key }, signal);
+  const desc = resolveKeyDescriptor(key);
+  if (!desc) {
+    // Unknown multi-character key (e.g. F-keys we have not mapped).
+    // Fall back to the minimal payload so callers still see a
+    // keyDown/keyUp pair, and warn so we can extend the map.
+
+    console.warn(
+      `dispatchKeyPress: no descriptor for key "${key}", sending minimal event`,
+    );
+    await cdp.send("Input.dispatchKeyEvent", { type: "keyDown", key }, signal);
+    await cdp.send("Input.dispatchKeyEvent", { type: "keyUp", key }, signal);
+    return;
+  }
+
+  const baseParams: Record<string, unknown> = {
+    key: desc.key,
+    code: desc.code,
+    windowsVirtualKeyCode: desc.windowsVirtualKeyCode,
+  };
+  if (desc.text !== undefined) {
+    baseParams.text = desc.text;
+  }
+
+  await cdp.send(
+    "Input.dispatchKeyEvent",
+    { ...baseParams, type: "keyDown" },
+    signal,
+  );
+  if (desc.text !== undefined) {
+    await cdp.send(
+      "Input.dispatchKeyEvent",
+      { ...baseParams, type: "char" },
+      signal,
+    );
+  }
+  await cdp.send(
+    "Input.dispatchKeyEvent",
+    { ...baseParams, type: "keyUp" },
+    signal,
+  );
 }
 
 /** Dispatch a wheel scroll delta at the given viewport point. */
@@ -305,9 +450,29 @@ export async function navigateAndWait(
   signal?: AbortSignal,
 ): Promise<{ finalUrl: string; timedOut: boolean }> {
   const timeoutMs = opts.timeoutMs ?? 15_000;
-  await cdp.send("Page.navigate", { url }, signal);
+  // CDP's `Page.navigate` does NOT throw on transport-layer errors
+  // (DNS failure, connection refused, etc.). Instead it resolves with
+  // `{ frameId, errorText? }` and we have to surface the failure
+  // ourselves. Otherwise we silently start polling readyState on the
+  // OLD page (which is "complete") and report success with the stale
+  // URL.
+  const navResp = await cdp.send<{ frameId?: string; errorText?: string }>(
+    "Page.navigate",
+    { url },
+    signal,
+  );
+  if (navResp?.errorText) {
+    throw new CdpError("cdp_error", navResp.errorText, {
+      cdpMethod: "Page.navigate",
+      cdpParams: { url },
+    });
+  }
   const startedAt = Date.now();
-  let timedOut = false;
+  // Track exit reason explicitly so the post-loop classification does
+  // not race against `Date.now()` after a successful break (the final
+  // readyState read could otherwise push us across the timeout
+  // boundary and falsely flip `timedOut` back to true).
+  let completed = false;
   while (Date.now() - startedAt < timeoutMs) {
     if (signal?.aborted) {
       throw new CdpError("aborted", "Navigation aborted");
@@ -318,10 +483,13 @@ export async function navigateAndWait(
       {},
       signal,
     );
-    if (state === "interactive" || state === "complete") break;
+    if (state === "interactive" || state === "complete") {
+      completed = true;
+      break;
+    }
     await new Promise((r) => setTimeout(r, 100));
   }
-  if (Date.now() - startedAt >= timeoutMs) timedOut = true;
+  const timedOut = !completed;
   const finalUrl = await getCurrentUrl(cdp, signal);
   return { finalUrl, timedOut };
 }


### PR DESCRIPTION
## Summary
- `executeBrowserFillCredential` now clears pre-populated fields before insertText via shared `clearAndInsertText` helper extracted from `executeBrowserType` (security: prevents credential leak when fields are autofilled)
- `dispatchKeyPress` resolves keys to `{key, code, windowsVirtualKeyCode, text}` via a US keyboard map; fixes `event.keyCode === 13` checks on Enter and similar
- `executeBrowserSelectOption` dispatches `input` before `change` (matches HTML spec / Angular DefaultValueAccessor) and reports an error when no option matched
- `navigateAndWait` captures `Page.navigate.errorText` and throws as `CdpError`; tracks completion via a `completed` flag instead of recomputing `Date.now()` after the loop

Fixes gaps identified during Phase 3 self-review for plan: phase3-cdp-migration.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24367" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
