### PR TITLE
fix(macOS): mark writeLockfileEntry as nonisolated to fix Swift concurrency error

### DIFF
--- a/clients/macos/vellum-assistant/App/AppleContainersLauncher.swift
+++ b/clients/macos/vellum-assistant/App/AppleContainersLauncher.swift
@@ -248,7 +248,7 @@ final class AppleContainersLauncher: AssistantManagementClient {
     /// Kept here (not in the shared `LockfileAssistant`) because apple-container
     /// logic is macOS-only and should not bleed into the shared/iOS/CLI target.
     @discardableResult
-    static func writeLockfileEntry(
+    nonisolated static func writeLockfileEntry(
         assistantId: String,
         hatchedAt: String,
         lockfilePath: String? = nil


### PR DESCRIPTION
## Summary
- Mark `AppleContainersLauncher.writeLockfileEntry()` as `nonisolated` — it only does file I/O and doesn't need `@MainActor` isolation
- Fixes compilation error in `LockfileAssistantAppleContainerTests` where tests call the method from a synchronous nonisolated context

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24150712414/job/70476643218
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24368" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
