### PR TITLE
fix(browser/cdp): LocalCdpClient cache poisoning + click/hover wait-for-visible regression

### DIFF
--- a/assistant/src/__tests__/headless-browser-interactions.test.ts
+++ b/assistant/src/__tests__/headless-browser-interactions.test.ts
@@ -208,6 +208,13 @@ function installClickHoverCdpSend(
         return { model: { content: [10, 20, 30, 20, 30, 40, 10, 40] } };
       case "Input.dispatchMouseEvent":
         return {};
+      case "Runtime.evaluate":
+        // cdpWaitForSelector (used by click/hover selector branches)
+        // polls Runtime.evaluate with the visible-state probe and
+        // expects { result: { value: boolean } }. Returning true on
+        // the first poll lets the test resolve immediately instead
+        // of timing out after ACTION_TIMEOUT_MS.
+        return { result: { value: true } };
       default:
         return {};
     }
@@ -230,9 +237,14 @@ describe("executeBrowserClick (CDP)", () => {
     expect(result.isError).toBe(false);
     expect(result.content).toContain("Clicked element: #submit-btn");
 
-    // Expected CDP call sequence for the selector path:
+    // Expected CDP call sequence for the selector path. The leading
+    // Runtime.evaluate is the visible-state probe issued by
+    // cdpWaitForSelector before resolving the backend node — this
+    // matches Playwright's `page.click(selector, { timeout })`
+    // semantics and lets click work on async-hydrated pages.
     const methods = sendCalls.map((c) => c.method);
     expect(methods).toEqual([
+      "Runtime.evaluate",
       "DOM.getDocument",
       "DOM.querySelector",
       "DOM.describeNode",
@@ -242,6 +254,14 @@ describe("executeBrowserClick (CDP)", () => {
       "Input.dispatchMouseEvent",
       "Input.dispatchMouseEvent",
     ]);
+
+    // The leading Runtime.evaluate is the visible-state probe.
+    const visibleProbe = sendCalls.find(
+      (c) => c.method === "Runtime.evaluate",
+    )!;
+    expect(
+      (visibleProbe.params as { expression: string }).expression,
+    ).toContain("getBoundingClientRect");
 
     // Arguments threaded through correctly.
     const qsCall = sendCalls.find((c) => c.method === "DOM.querySelector")!;
@@ -377,6 +397,54 @@ describe("executeBrowserClick (CDP)", () => {
     // finally { cdp.dispose() } must still fire → detach called.
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(detachCalls).toBe(1);
+  });
+
+  test("waits for selector that initially doesn't exist but becomes visible", async () => {
+    // Simulates a hydrating page: the visible-state probe returns
+    // false for the first 2 polls, then true on the 3rd. The click
+    // tool must wait through these polls (instead of failing
+    // immediately) and then complete the click as normal.
+    let visibleProbeCount = 0;
+    sendHandler = (method, _params) => {
+      switch (method) {
+        case "Runtime.evaluate":
+          visibleProbeCount++;
+          return { result: { value: visibleProbeCount >= 3 } };
+        case "DOM.getDocument":
+          return { root: { nodeId: 1 } };
+        case "DOM.querySelector":
+          return { nodeId: 2 };
+        case "DOM.describeNode":
+          return { node: { backendNodeId: 8888 } };
+        case "DOM.scrollIntoViewIfNeeded":
+          return {};
+        case "DOM.getBoxModel":
+          return { model: { content: [10, 20, 30, 20, 30, 40, 10, 40] } };
+        case "Input.dispatchMouseEvent":
+          return {};
+        default:
+          return {};
+      }
+    };
+
+    const result = await executeBrowserClick({ selector: "#hydrated" }, ctx);
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Clicked element: #hydrated");
+    // The visible-state probe was polled at least 3 times before
+    // succeeding, then the rest of the click pipeline ran exactly
+    // once.
+    expect(visibleProbeCount).toBeGreaterThanOrEqual(3);
+    const mouseCalls = sendCalls.filter(
+      (c) => c.method === "Input.dispatchMouseEvent",
+    );
+    expect(mouseCalls).toHaveLength(3);
+    // querySelectorBackendNodeId only ran once at the end (after the
+    // probe returned true) — not on every polling iteration.
+    const describeCalls = sendCalls.filter(
+      (c) => c.method === "DOM.describeNode",
+    );
+    expect(describeCalls).toHaveLength(1);
   });
 });
 
@@ -888,8 +956,11 @@ describe("executeBrowserHover (CDP)", () => {
     expect(result.isError).toBe(false);
     expect(result.content).toContain("Hovered element: .menu-trigger");
 
+    // Selector path waits for the element to become visible via
+    // cdpWaitForSelector before resolving the backend node.
     const methods = sendCalls.map((c) => c.method);
     expect(methods).toEqual([
+      "Runtime.evaluate",
       "DOM.getDocument",
       "DOM.querySelector",
       "DOM.describeNode",

--- a/assistant/src/tools/browser/browser-execution.ts
+++ b/assistant/src/tools/browser/browser-execution.ts
@@ -721,9 +721,16 @@ export async function executeBrowserClick(
     if (resolved!.kind === "backend") {
       backendNodeId = resolved!.backendNodeId;
     } else {
-      backendNodeId = await querySelectorBackendNodeId(
+      // Wait until the selector matches a visible element. Mirrors
+      // Playwright's `page.click(selector, { timeout })` semantics
+      // and lets click work on async-hydrated pages where the
+      // target may not yet exist when the tool is invoked.
+      // cdpWaitForSelector returns the backendNodeId so we don't
+      // need a separate querySelectorBackendNodeId round-trip.
+      backendNodeId = await cdpWaitForSelector(
         cdp,
         resolved!.selector,
+        ACTION_TIMEOUT_MS,
         context.signal,
       );
     }
@@ -1068,9 +1075,13 @@ export async function executeBrowserHover(
     if (resolved!.kind === "backend") {
       backendNodeId = resolved!.backendNodeId;
     } else {
-      backendNodeId = await querySelectorBackendNodeId(
+      // Wait until the selector matches a visible element. See the
+      // matching note in executeBrowserClick — async-hydrated pages
+      // need this to behave like Playwright's hover-with-timeout.
+      backendNodeId = await cdpWaitForSelector(
         cdp,
         resolved!.selector,
+        ACTION_TIMEOUT_MS,
         context.signal,
       );
     }
@@ -1139,7 +1150,14 @@ export async function executeBrowserWaitFor(
   const cdp = getCdpClient(context);
   try {
     if (selector) {
-      await cdpWaitForSelector(cdp, selector, timeout, context.signal);
+      // browser_wait_for selector mode is "did this node appear at
+      // all" — preserve the existing semantics by polling for DOM
+      // attachment, not full visibility. Tools that need
+      // visible-state polling (click/hover) get it via the default
+      // state in cdpWaitForSelector.
+      await cdpWaitForSelector(cdp, selector, timeout, context.signal, {
+        state: "attached",
+      });
       return {
         content: `Element matching "${selector}" appeared.`,
         isError: false,

--- a/assistant/src/tools/browser/cdp-client/__tests__/cdp-dom-helpers.test.ts
+++ b/assistant/src/tools/browser/cdp-client/__tests__/cdp-dom-helpers.test.ts
@@ -601,11 +601,13 @@ describe("navigateAndWait", () => {
 // ── waitForSelector ───────────────────────────────────────────────────
 
 describe("waitForSelector", () => {
-  test("resolves when the selector appears on the 2nd poll", async () => {
+  test("resolves when the selector appears on the 2nd poll (default visible state)", async () => {
     let evalCount = 0;
-    const cdp = fakeCdp((method) => {
+    let lastExpression = "";
+    const cdp = fakeCdp((method, params) => {
       if (method === "Runtime.evaluate") {
         evalCount++;
+        lastExpression = (params as { expression: string }).expression;
         // First poll: not present. Second poll: present.
         return { result: { value: evalCount >= 2 } };
       }
@@ -619,6 +621,67 @@ describe("waitForSelector", () => {
     const backendNodeId = await waitForSelector(cdp, "#ready", 5_000);
     expect(backendNodeId).toBe(321);
     expect(evalCount).toBeGreaterThanOrEqual(2);
+    // Default state is "visible" — the polling expression must check
+    // bounding box + display + visibility, not just `!== null`.
+    expect(lastExpression).toContain("getBoundingClientRect");
+    expect(lastExpression).toContain("display");
+    expect(lastExpression).toContain("visibility");
+  });
+
+  test("with state: 'attached' polls DOM existence only", async () => {
+    let evalCount = 0;
+    let lastExpression = "";
+    const cdp = fakeCdp((method, params) => {
+      if (method === "Runtime.evaluate") {
+        evalCount++;
+        lastExpression = (params as { expression: string }).expression;
+        return { result: { value: true } };
+      }
+      if (method === "DOM.getDocument") return { root: { nodeId: 1 } };
+      if (method === "DOM.querySelector") return { nodeId: 9 };
+      if (method === "DOM.describeNode")
+        return { node: { backendNodeId: 555 } };
+      throw new Error(`unexpected: ${method}`);
+    });
+
+    const backendNodeId = await waitForSelector(
+      cdp,
+      "#exists",
+      5_000,
+      undefined,
+      { state: "attached" },
+    );
+    expect(backendNodeId).toBe(555);
+    expect(evalCount).toBeGreaterThanOrEqual(1);
+    // Attached state must use the simple `!== null` check, not the
+    // bounding-box / computed-style probe.
+    expect(lastExpression).toBe(`document.querySelector("#exists") !== null`);
+    expect(lastExpression).not.toContain("getBoundingClientRect");
+  });
+
+  test("default state polls until the visible-state probe returns true", async () => {
+    let evalCount = 0;
+    const cdp = fakeCdp((method, params) => {
+      if (method === "Runtime.evaluate") {
+        evalCount++;
+        const expression = (params as { expression: string }).expression;
+        // Sanity-check: the polling expression must be the visible
+        // probe, not the simple existence check.
+        expect(expression).toContain("getBoundingClientRect");
+        // Element exists in DOM but isn't yet visible until the third
+        // poll.
+        return { result: { value: evalCount >= 3 } };
+      }
+      if (method === "DOM.getDocument") return { root: { nodeId: 1 } };
+      if (method === "DOM.querySelector") return { nodeId: 9 };
+      if (method === "DOM.describeNode")
+        return { node: { backendNodeId: 999 } };
+      throw new Error(`unexpected: ${method}`);
+    });
+
+    const backendNodeId = await waitForSelector(cdp, "#hydrating", 5_000);
+    expect(backendNodeId).toBe(999);
+    expect(evalCount).toBeGreaterThanOrEqual(3);
   });
 
   test("throws CdpError on timeout", async () => {

--- a/assistant/src/tools/browser/cdp-client/__tests__/local-cdp-client.test.ts
+++ b/assistant/src/tools/browser/cdp-client/__tests__/local-cdp-client.test.ts
@@ -16,6 +16,13 @@ let newCdpSessionCalls = 0;
 let getOrCreateSessionPageCalls = 0;
 let fakeSessionHandler: (method: string, params?: unknown) => unknown = () =>
   undefined;
+// When set, the next call to `browserManager.getOrCreateSessionPage`
+// throws this error then clears it (so subsequent calls succeed). Used
+// by tests that exercise the cache-clear-on-rejection retry path.
+let getOrCreateSessionPageError: Error | null = null;
+// When non-null, every call to `browserManager.getOrCreateSessionPage`
+// throws this error indefinitely.
+let getOrCreateSessionPagePersistentError: Error | null = null;
 
 function resetFakes() {
   fakeSessionSendCalls = [];
@@ -23,6 +30,8 @@ function resetFakes() {
   newCdpSessionCalls = 0;
   getOrCreateSessionPageCalls = 0;
   fakeSessionHandler = () => undefined;
+  getOrCreateSessionPageError = null;
+  getOrCreateSessionPagePersistentError = null;
 }
 
 mock.module("../../browser-manager.js", () => {
@@ -47,6 +56,14 @@ mock.module("../../browser-manager.js", () => {
     browserManager: {
       getOrCreateSessionPage: async (_conversationId: string) => {
         getOrCreateSessionPageCalls += 1;
+        if (getOrCreateSessionPagePersistentError) {
+          throw getOrCreateSessionPagePersistentError;
+        }
+        if (getOrCreateSessionPageError) {
+          const err = getOrCreateSessionPageError;
+          getOrCreateSessionPageError = null;
+          throw err;
+        }
         return fakePage;
       },
     },
@@ -231,5 +248,63 @@ describe("LocalCdpClient", () => {
     expect(cdpErr.code).toBe("aborted");
     expect(cdpErr.cdpMethod).toBe("Page.navigate");
     expect(cdpErr.underlying).toBeInstanceOf(Error);
+  });
+
+  test("send() wraps ensureSession failures as CdpError 'transport_error'", async () => {
+    getOrCreateSessionPagePersistentError = new Error(
+      "Failed to launch chromium",
+    );
+    const client = createLocalCdpClient("conv-launch-fail");
+    let caught: unknown;
+    try {
+      await client.send("Browser.getVersion");
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(CdpError);
+    const cdpErr = caught as InstanceType<typeof CdpError>;
+    expect(cdpErr.code).toBe("transport_error");
+    expect(cdpErr.message).toBe("Failed to launch chromium");
+    expect(cdpErr.cdpMethod).toBe("Browser.getVersion");
+    expect(cdpErr.underlying).toBeInstanceOf(Error);
+    // Underlying session was never created.
+    expect(newCdpSessionCalls).toBe(0);
+  });
+
+  test("send() retries ensureSession after a transient failure", async () => {
+    // First call: ensureSession rejects (transient browser launch error).
+    // Second call: ensureSession succeeds and the underlying CDP method
+    // resolves. The cached promise from the first failure must have
+    // been cleared so the second call actually retries.
+    getOrCreateSessionPageError = new Error("transient launch failure");
+    fakeSessionHandler = (method) => {
+      if (method === "Browser.getVersion") {
+        return { product: "HeadlessChrome/120.0.0.0" };
+      }
+      return undefined;
+    };
+    const client = createLocalCdpClient("conv-retry");
+
+    // First call → CdpError("transport_error") from ensureSession.
+    let firstErr: unknown;
+    try {
+      await client.send("Browser.getVersion");
+    } catch (err) {
+      firstErr = err;
+    }
+    expect(firstErr).toBeInstanceOf(CdpError);
+    expect((firstErr as InstanceType<typeof CdpError>).code).toBe(
+      "transport_error",
+    );
+    expect(getOrCreateSessionPageCalls).toBe(1);
+    expect(newCdpSessionCalls).toBe(0);
+
+    // Second call → cached promise was cleared, so ensureSession is
+    // re-invoked, getOrCreateSessionPage runs again, and the call
+    // succeeds against the freshly created session.
+    const result = await client.send<{ product: string }>("Browser.getVersion");
+    expect(result).toEqual({ product: "HeadlessChrome/120.0.0.0" });
+    expect(getOrCreateSessionPageCalls).toBe(2);
+    expect(newCdpSessionCalls).toBe(1);
   });
 });

--- a/assistant/src/tools/browser/cdp-client/cdp-dom-helpers.ts
+++ b/assistant/src/tools/browser/cdp-client/cdp-dom-helpers.ts
@@ -327,28 +327,51 @@ export async function navigateAndWait(
 }
 
 /**
- * Poll until a selector matches a non-null element, then return its
- * `backendNodeId`. Throws {@link CdpError} on timeout or abort.
+ * Poll until a selector matches an element in the requested state,
+ * then return its `backendNodeId`. Throws {@link CdpError} on timeout
+ * or abort.
+ *
+ * `state` controls the readiness check:
+ * - `"visible"` (default): the element must be in the DOM AND have a
+ *   non-zero bounding box AND not be `display:none` /
+ *   `visibility:hidden`. This matches Playwright's
+ *   `page.waitForSelector` default and is the right semantics for
+ *   click/hover targets that may be hydrated asynchronously.
+ * - `"attached"`: the element only needs to exist in the DOM. Useful
+ *   for `browser_wait_for` selector mode where the caller just wants
+ *   to know "did this node appear at all" regardless of layout.
  */
 export async function waitForSelector(
   cdp: CdpClient,
   selector: string,
   timeoutMs: number,
   signal?: AbortSignal,
+  opts: { state?: "attached" | "visible" } = {},
 ): Promise<number> {
+  const state = opts.state ?? "visible";
   const startedAt = Date.now();
   const escapedSel = JSON.stringify(selector);
+  const expression =
+    state === "visible"
+      ? `(() => {
+          const el = document.querySelector(${escapedSel});
+          if (!el) return false;
+          const r = el.getBoundingClientRect();
+          const cs = getComputedStyle(el);
+          return r.width > 0 && r.height > 0 && cs.display !== "none" && cs.visibility !== "hidden";
+        })()`
+      : `document.querySelector(${escapedSel}) !== null`;
   while (Date.now() - startedAt < timeoutMs) {
     if (signal?.aborted) {
       throw new CdpError("aborted", "waitForSelector aborted");
     }
-    const exists = await evaluateExpression<boolean>(
+    const ready = await evaluateExpression<boolean>(
       cdp,
-      `document.querySelector(${escapedSel}) !== null`,
+      expression,
       {},
       signal,
     );
-    if (exists) {
+    if (ready) {
       return await querySelectorBackendNodeId(cdp, selector, signal);
     }
     await new Promise((r) => setTimeout(r, 100));

--- a/assistant/src/tools/browser/cdp-client/local-cdp-client.ts
+++ b/assistant/src/tools/browser/cdp-client/local-cdp-client.ts
@@ -50,25 +50,42 @@ export class LocalCdpClient implements ScopedCdpClient {
    * conversation. Concurrent callers share the same in-flight promise
    * so `newCDPSession` is only called once per LocalCdpClient
    * instance.
+   *
+   * If the underlying browser launch / `newCDPSession` rejects (e.g.
+   * a transient Chromium spawn failure), the cached promise is
+   * cleared so the next `ensureSession()` call retries from scratch
+   * instead of replaying the same rejection forever.
    */
   private async ensureSession(): Promise<PlaywrightCdpSession> {
     if (this.disposed) {
       throw new CdpError("disposed", "LocalCdpClient already disposed");
     }
     if (this.sessionPromise) return this.sessionPromise;
-    this.sessionPromise = (async () => {
-      const page = await browserManager.getOrCreateSessionPage(
-        this.conversationId,
-      );
-      const rawPage = page as unknown as RawPlaywrightPage;
-      const session = await rawPage.context().newCDPSession(rawPage);
-      log.debug(
-        { conversationId: this.conversationId },
-        "Created Playwright CDP session for LocalCdpClient",
-      );
-      return session;
-    })();
-    return this.sessionPromise;
+    const created = this.createSession();
+    this.sessionPromise = created;
+    // Clear the cached promise on rejection so the next call retries
+    // from scratch instead of replaying the same failure forever.
+    // Only clear if `created` is still the cached promise — a
+    // concurrent dispose may have already nulled it.
+    created.catch(() => {
+      if (this.sessionPromise === created) {
+        this.sessionPromise = null;
+      }
+    });
+    return created;
+  }
+
+  private async createSession(): Promise<PlaywrightCdpSession> {
+    const page = await browserManager.getOrCreateSessionPage(
+      this.conversationId,
+    );
+    const rawPage = page as unknown as RawPlaywrightPage;
+    const session = await rawPage.context().newCDPSession(rawPage);
+    log.debug(
+      { conversationId: this.conversationId },
+      "Created Playwright CDP session for LocalCdpClient",
+    );
+    return session;
   }
 
   async send<T = unknown>(
@@ -88,7 +105,34 @@ export class LocalCdpClient implements ScopedCdpClient {
         cdpParams: params,
       });
     }
-    const session = await this.ensureSession();
+    let session: PlaywrightCdpSession;
+    try {
+      session = await this.ensureSession();
+    } catch (err) {
+      if (signal?.aborted) {
+        throw new CdpError("aborted", "Aborted during send", {
+          cdpMethod: method,
+          cdpParams: params,
+          underlying: err,
+        });
+      }
+      // Re-throw existing CdpError instances unchanged so we don't
+      // double-wrap (e.g. a "disposed" error raised by a concurrent
+      // dispose landing during ensureSession()).
+      if (err instanceof CdpError) {
+        throw err;
+      }
+      // ensureSession failures (browser launch errors, Chromium
+      // spawn failures, etc) are surfaced as transport_error so
+      // callers can distinguish them from CDP protocol errors raised
+      // by session.send below.
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new CdpError("transport_error", msg, {
+        cdpMethod: method,
+        cdpParams: params,
+        underlying: err,
+      });
+    }
     try {
       const result = (await session.send(method, params)) as T;
       return result;
@@ -99,6 +143,9 @@ export class LocalCdpClient implements ScopedCdpClient {
           cdpParams: params,
           underlying: err,
         });
+      }
+      if (err instanceof CdpError) {
+        throw err;
       }
       const msg = err instanceof Error ? err.message : String(err);
       throw new CdpError("cdp_error", msg, {


### PR DESCRIPTION
## Summary
- `LocalCdpClient.ensureSession` clears the cached promise on rejection so transient browser launch errors are recoverable; was previously bricking the client for the conversation
- `LocalCdpClient.send` wraps `ensureSession` errors as `CdpError("transport_error")` to honor the documented contract
- `cdpWaitForSelector` accepts `state: "visible" | "attached"` (default "visible"), checking bounding box + computed style to match Playwright's default
- `executeBrowserClick` and `executeBrowserHover` wait for a visible selector with the action timeout before resolving the backend node, fixing async-hydrated page regressions
- `executeBrowserWaitFor` selector mode passes `state: "attached"` to preserve its existing semantics

Fixes gaps identified during Phase 3 self-review for plan: phase3-cdp-migration.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24369" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
