### PR TITLE
fix(browser): restore CLI shim for in-tree skills + clean up stale OpenAPI

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -1169,15 +1169,9 @@ paths:
       responses:
         "200":
           description: Successful response
-  /v1/browser-relay/command:
+  /v1/browser-cdp:
     post:
-      operationId: browserrelay_command_post
-      responses:
-        "200":
-          description: Successful response
-  /v1/browser-relay/status:
-    get:
-      operationId: browserrelay_status_get
+      operationId: browsercdp_post
       responses:
         "200":
           description: Successful response

--- a/assistant/scripts/generate-openapi.ts
+++ b/assistant/scripts/generate-openapi.ts
@@ -212,8 +212,7 @@ async function collectRoutesFromModules(): Promise<RouteEntry[]> {
  * here if openapi.yaml is also stale. Plan items B2/C2 address this gap.
  */
 const INLINE_ROUTES: RouteEntry[] = [
-  { endpoint: "browser-relay/status", method: "GET" },
-  { endpoint: "browser-relay/command", method: "POST" },
+  { endpoint: "browser-cdp", method: "POST" },
   { endpoint: "conversations", method: "GET" },
   { endpoint: "conversations/seen", method: "POST" },
   { endpoint: "conversations/unread", method: "POST" },

--- a/assistant/src/__tests__/gateway-only-guard.test.ts
+++ b/assistant/src/__tests__/gateway-only-guard.test.ts
@@ -23,6 +23,7 @@ const ALLOWLIST = new Set([
 
   // --- Intentional local daemon-control paths ---
   "assistant/src/cli/commands/conversations.ts", // CLI wipe talks to runtime directly
+  "assistant/src/cli/commands/browser-relay.ts", // CLI shim talks to /v1/browser-cdp on the local daemon
   "clients/shared/Network/DaemonClient.swift",
   "clients/shared/App/Auth/PlatformOAuthService.swift", // comment explaining runtimeUrl vs platformUrl
   "clients/macos/vellum-assistant/App/AppDelegate.swift",

--- a/assistant/src/cli/commands/browser-relay.ts
+++ b/assistant/src/cli/commands/browser-relay.ts
@@ -1,0 +1,466 @@
+/**
+ * `assistant browser chrome relay <action>` CLI shim.
+ *
+ * Translates the legacy relay actions (find_tab, new_tab, navigate,
+ * evaluate, get_cookies, set_cookie, screenshot) into Chrome DevTools
+ * Protocol commands and forwards them to the daemon's
+ * `/v1/browser-cdp` HTTP endpoint, which routes the command through
+ * the connected chrome-extension WebSocket.
+ *
+ * Why this exists: PR #24329 deleted the in-process extension relay
+ * server and the original CLI surface. Two in-tree skills (amazon and
+ * influencer) still spawn `assistant browser chrome relay <action>` as
+ * a subprocess and parse the JSON output. Until those skills migrate
+ * onto the new CDP-based skill API, this shim keeps them working by
+ * preserving the legacy stdout contract:
+ *
+ *     { "ok": true,  "tabId"?: <id>, "result"?: <unknown> }
+ *     { "ok": false, "error": <string> }
+ *
+ * The CLI mints a short-lived daemon delivery JWT (same audience and
+ * scope profile as the daemon's internal callbacks) and POSTs directly
+ * to the runtime's loopback HTTP port — no gateway involvement
+ * required.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+
+import type { Command } from "commander";
+
+import { getRuntimeHttpPort } from "../../config/env.js";
+import { CURRENT_POLICY_EPOCH } from "../../runtime/auth/policy.js";
+import { mintToken } from "../../runtime/auth/token-service.js";
+import {
+  initAuthSigningKey,
+  isSigningKeyInitialized,
+  loadOrCreateSigningKey,
+} from "../../runtime/auth/token-service.js";
+import { getRuntimePortFilePath } from "../../util/platform.js";
+
+// ---------------------------------------------------------------------------
+// Daemon HTTP client
+// ---------------------------------------------------------------------------
+
+interface BrowserCdpResponse {
+  result?: unknown;
+  error?: { code: string; message: string };
+}
+
+/**
+ * Resolve the daemon's runtime HTTP port. Prefers the runtime-port
+ * file written by the daemon at startup so non-default ports
+ * (RUNTIME_HTTP_PORT) are picked up automatically without an env var
+ * roundtrip. Falls back to the env-var-derived default.
+ */
+function resolveRuntimePort(): number {
+  try {
+    const portFile = getRuntimePortFilePath();
+    if (existsSync(portFile)) {
+      const raw = readFileSync(portFile, "utf-8").trim();
+      const parsed = Number(raw);
+      if (Number.isFinite(parsed) && parsed > 0 && parsed < 65536) {
+        return parsed;
+      }
+    }
+  } catch {
+    // Fall through to env-var default
+  }
+  return getRuntimeHttpPort();
+}
+
+/**
+ * Mint a short-lived JWT acceptable to the runtime auth middleware.
+ * Mirrors `mintDaemonDeliveryToken` (sub=svc:daemon:self,
+ * scope_profile=gateway_service_v1, aud=vellum-daemon) but is minted
+ * out-of-process by the CLI using the on-disk signing key.
+ */
+function mintCliToken(): string {
+  if (!isSigningKeyInitialized()) {
+    initAuthSigningKey(loadOrCreateSigningKey());
+  }
+  return mintToken({
+    aud: "vellum-daemon",
+    sub: "svc:daemon:self",
+    scope_profile: "gateway_service_v1",
+    policy_epoch: CURRENT_POLICY_EPOCH,
+    ttlSeconds: 60,
+  });
+}
+
+/**
+ * Send a single CDP command to the daemon's /v1/browser-cdp route and
+ * return the parsed response. Throws on transport-level errors; the
+ * caller wraps the throw into a `{ ok: false, error }` envelope.
+ */
+async function postBrowserCdp(payload: {
+  cdpMethod: string;
+  cdpParams?: Record<string, unknown>;
+  cdpSessionId?: string;
+  timeoutMs?: number;
+}): Promise<BrowserCdpResponse> {
+  const port = resolveRuntimePort();
+  const token = mintCliToken();
+  const url = `http://127.0.0.1:${port}/v1/browser-cdp`;
+
+  const resp = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(payload),
+  });
+
+  const bodyText = await resp.text();
+  let parsed: BrowserCdpResponse;
+  try {
+    parsed = JSON.parse(bodyText) as BrowserCdpResponse;
+  } catch {
+    throw new Error(
+      `Daemon returned non-JSON response (HTTP ${resp.status}): ${bodyText.slice(0, 200)}`,
+    );
+  }
+
+  if (!resp.ok) {
+    const message = parsed.error?.message ?? `HTTP ${resp.status}`;
+    throw new Error(message);
+  }
+
+  return parsed;
+}
+
+// ---------------------------------------------------------------------------
+// Stdout helpers
+// ---------------------------------------------------------------------------
+
+interface RelayResultOk {
+  ok: true;
+  tabId?: number | string;
+  result?: unknown;
+}
+
+interface RelayResultErr {
+  ok: false;
+  error: string;
+}
+
+function emitOk(payload: Omit<RelayResultOk, "ok">): void {
+  const out: RelayResultOk = { ok: true, ...payload };
+  process.stdout.write(JSON.stringify(out) + "\n");
+}
+
+function emitError(message: string): void {
+  const out: RelayResultErr = { ok: false, error: message };
+  process.stdout.write(JSON.stringify(out) + "\n");
+  process.exitCode = 1;
+}
+
+async function readStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk as Buffer);
+  }
+  return Buffer.concat(chunks).toString("utf-8");
+}
+
+// ---------------------------------------------------------------------------
+// URL glob matching for find-tab
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a Chrome match-pattern style glob (e.g. `*://*.amazon.com/*`)
+ * into a regular expression. Matches the chrome.tabs.query semantics
+ * the legacy relay CLI exposed:
+ *
+ *   - `*` is a wildcard that matches any sequence (including `/` in
+ *     the path component, mirroring the legacy minimatch behaviour).
+ *   - All other regex metacharacters are escaped.
+ */
+function globToRegex(glob: string): RegExp {
+  const escaped = glob.replace(/[.+?^${}()|[\]\\]/g, "\\$&");
+  const pattern = "^" + escaped.replace(/\*/g, ".*") + "$";
+  return new RegExp(pattern);
+}
+
+// ---------------------------------------------------------------------------
+// Action handlers — translate legacy actions into CDP commands
+// ---------------------------------------------------------------------------
+
+interface CdpTarget {
+  targetId: string;
+  type: string;
+  url: string;
+  title?: string;
+  attached?: boolean;
+}
+
+interface CdpTargetsResult {
+  targetInfos: CdpTarget[];
+}
+
+async function actionFindTab(urlPattern: string): Promise<void> {
+  try {
+    const resp = await postBrowserCdp({ cdpMethod: "Target.getTargets" });
+    const targets =
+      (resp.result as CdpTargetsResult | undefined)?.targetInfos ?? [];
+    const re = globToRegex(urlPattern);
+    const match = targets.find((t) => t.type === "page" && re.test(t.url));
+    if (!match) {
+      emitError(`No tab matched URL pattern: ${urlPattern}`);
+      return;
+    }
+    emitOk({ tabId: match.targetId });
+  } catch (err) {
+    emitError(err instanceof Error ? err.message : String(err));
+  }
+}
+
+async function actionNewTab(url: string): Promise<void> {
+  try {
+    const resp = await postBrowserCdp({
+      cdpMethod: "Target.createTarget",
+      cdpParams: { url },
+    });
+    const targetId = (resp.result as { targetId?: string } | undefined)
+      ?.targetId;
+    if (!targetId) {
+      emitError("Target.createTarget did not return a targetId");
+      return;
+    }
+    emitOk({ tabId: targetId });
+  } catch (err) {
+    emitError(err instanceof Error ? err.message : String(err));
+  }
+}
+
+async function actionNavigate(tabId: string, url: string): Promise<void> {
+  try {
+    await postBrowserCdp({
+      cdpMethod: "Page.navigate",
+      cdpParams: { url },
+      cdpSessionId: tabId,
+    });
+    emitOk({});
+  } catch (err) {
+    emitError(err instanceof Error ? err.message : String(err));
+  }
+}
+
+async function actionEvaluate(tabId: string, code: string): Promise<void> {
+  try {
+    const resp = await postBrowserCdp({
+      cdpMethod: "Runtime.evaluate",
+      cdpParams: {
+        expression: code,
+        returnByValue: true,
+        awaitPromise: true,
+      },
+      cdpSessionId: tabId,
+    });
+    // CDP Runtime.evaluate returns { result: { type, value }, exceptionDetails? }.
+    // Surface exceptions as relay errors so callers don't silently get undefined.
+    const result = resp.result as
+      | {
+          result?: { value?: unknown };
+          exceptionDetails?: {
+            text?: string;
+            exception?: { description?: string };
+          };
+        }
+      | undefined;
+    if (result?.exceptionDetails) {
+      const desc =
+        result.exceptionDetails.exception?.description ??
+        result.exceptionDetails.text ??
+        "Runtime exception during evaluate";
+      emitError(desc);
+      return;
+    }
+    emitOk({ result: result?.result?.value });
+  } catch (err) {
+    emitError(err instanceof Error ? err.message : String(err));
+  }
+}
+
+async function actionGetCookies(domain: string): Promise<void> {
+  try {
+    const resp = await postBrowserCdp({ cdpMethod: "Network.getCookies" });
+    const cookies =
+      (resp.result as { cookies?: Array<Record<string, unknown>> } | undefined)
+        ?.cookies ?? [];
+    // Filter by domain (Chrome stores cookies with leading-dot or bare-host
+    // domains depending on the Set-Cookie source). Match either form so the
+    // legacy "amazon.com" / ".amazon.com" callers both succeed.
+    const trimmed = domain.startsWith(".") ? domain.slice(1) : domain;
+    const filtered = cookies.filter((c) => {
+      const d = String(c.domain ?? "");
+      const dTrim = d.startsWith(".") ? d.slice(1) : d;
+      return dTrim === trimmed || dTrim.endsWith("." + trimmed);
+    });
+    emitOk({ result: filtered });
+  } catch (err) {
+    emitError(err instanceof Error ? err.message : String(err));
+  }
+}
+
+async function actionSetCookie(cookie: Record<string, unknown>): Promise<void> {
+  try {
+    await postBrowserCdp({
+      cdpMethod: "Network.setCookie",
+      cdpParams: cookie,
+    });
+    emitOk({});
+  } catch (err) {
+    emitError(err instanceof Error ? err.message : String(err));
+  }
+}
+
+async function actionScreenshot(tabId?: string): Promise<void> {
+  try {
+    const resp = await postBrowserCdp({
+      cdpMethod: "Page.captureScreenshot",
+      cdpParams: { format: "png" },
+      ...(tabId !== undefined ? { cdpSessionId: tabId } : {}),
+    });
+    const data = (resp.result as { data?: string } | undefined)?.data;
+    if (data === undefined) {
+      emitError("Page.captureScreenshot returned no data");
+      return;
+    }
+    emitOk({ result: data });
+  } catch (err) {
+    emitError(err instanceof Error ? err.message : String(err));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Command registration
+// ---------------------------------------------------------------------------
+
+export function registerBrowserRelayCommand(program: Command): void {
+  const browser = program
+    .command("browser")
+    .description(
+      "Browser automation surface (`chrome relay <action>` CDP shim)",
+    );
+
+  browser.addHelpText(
+    "after",
+    `
+Provides a thin CDP-over-HTTP shim used by in-tree skills that have not
+yet migrated onto the new CDP-based skill API. Each command translates
+the legacy action into a Chrome DevTools Protocol call and forwards it
+to the daemon's /v1/browser-cdp route, which routes through the
+connected chrome-extension WebSocket.
+
+Examples:
+  $ assistant browser chrome relay find-tab --url "*://*.amazon.com/*"
+  $ assistant browser chrome relay new-tab --url "https://example.com"
+  $ assistant browser chrome relay evaluate --tab-id <id> --code "document.title"
+  $ assistant browser chrome relay screenshot --tab-id <id>`,
+  );
+
+  const chrome = browser
+    .command("chrome")
+    .description("Chrome browser automation via the chrome-extension proxy");
+
+  const relay = chrome
+    .command("relay")
+    .description(
+      "Send a single CDP command to a Chrome tab via the chrome extension",
+    );
+
+  // -- find-tab --
+
+  relay
+    .command("find-tab")
+    .description("Find a tab matching a URL glob pattern")
+    .requiredOption(
+      "--url <pattern>",
+      "URL glob pattern to match (e.g. *://*.instagram.com/*)",
+    )
+    .action(async (opts: { url: string }) => {
+      await actionFindTab(opts.url);
+    });
+
+  // -- new-tab --
+
+  relay
+    .command("new-tab")
+    .description("Open a new tab with the given URL")
+    .requiredOption("--url <url>", "URL to open in a new tab")
+    .action(async (opts: { url: string }) => {
+      await actionNewTab(opts.url);
+    });
+
+  // -- navigate --
+
+  relay
+    .command("navigate")
+    .description("Navigate an existing tab to a new URL")
+    .requiredOption("--tab-id <id>", "Target tab ID")
+    .requiredOption("--url <url>", "URL to navigate to")
+    .action(async (opts: { tabId: string; url: string }) => {
+      await actionNavigate(opts.tabId, opts.url);
+    });
+
+  // -- evaluate --
+
+  relay
+    .command("evaluate")
+    .description("Execute JavaScript in a Chrome tab")
+    .requiredOption("--tab-id <id>", "Target tab ID")
+    .option(
+      "--code <script>",
+      "JavaScript code to evaluate (or read from stdin)",
+    )
+    .action(async (opts: { tabId: string; code?: string }) => {
+      let code: string;
+      if (opts.code) {
+        code = opts.code;
+      } else if (process.stdin.isTTY) {
+        emitError("No code provided. Use --code or pipe JavaScript via stdin.");
+        return;
+      } else {
+        code = await readStdin();
+      }
+      await actionEvaluate(opts.tabId, code);
+    });
+
+  // -- get-cookies --
+
+  relay
+    .command("get-cookies")
+    .description("Fetch cookies for a domain")
+    .requiredOption("--domain <domain>", "Cookie domain to fetch")
+    .action(async (opts: { domain: string }) => {
+      await actionGetCookies(opts.domain);
+    });
+
+  // -- set-cookie --
+
+  relay
+    .command("set-cookie")
+    .description("Set a cookie in the browser")
+    .requiredOption("--cookie <json>", "Cookie specification as JSON")
+    .action(async (opts: { cookie: string }) => {
+      let parsed: Record<string, unknown>;
+      try {
+        parsed = JSON.parse(opts.cookie) as Record<string, unknown>;
+      } catch {
+        emitError("Invalid JSON in --cookie argument");
+        return;
+      }
+      await actionSetCookie(parsed);
+    });
+
+  // -- screenshot --
+
+  relay
+    .command("screenshot")
+    .description("Capture a base64-encoded PNG screenshot of a Chrome tab")
+    .option("--tab-id <id>", "Target tab ID (defaults to active tab)")
+    .action(async (opts: { tabId?: string }) => {
+      await actionScreenshot(opts.tabId);
+    });
+}

--- a/assistant/src/cli/program.ts
+++ b/assistant/src/cli/program.ts
@@ -10,6 +10,7 @@ import { registerAuthCommand } from "./commands/auth.js";
 import { registerAutonomyCommand } from "./commands/autonomy.js";
 import { registerAvatarCommand } from "./commands/avatar.js";
 import { registerBashCommand } from "./commands/bash.js";
+import { registerBrowserRelayCommand } from "./commands/browser-relay.js";
 import { registerChannelVerificationSessionsCommand } from "./commands/channel-verification-sessions.js";
 import { registerCompletionsCommand } from "./commands/completions.js";
 import { registerConfigCommand } from "./commands/config.js";
@@ -59,6 +60,7 @@ Examples:
 
   registerDefaultAction(program);
   registerBashCommand(program);
+  registerBrowserRelayCommand(program);
   registerConversationsCommand(program);
   registerConfigCommand(program);
   registerKeysCommand(program);

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -482,6 +482,10 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   // Permission mode
   { endpoint: "permission-mode:GET", scopes: ["settings.read"] },
   { endpoint: "permission-mode", scopes: ["settings.write"] },
+
+  // Browser CDP shim — backs the `assistant browser chrome relay` CLI used
+  // by the in-tree Amazon and Influencer skills.
+  { endpoint: "browser-cdp", scopes: ["settings.write"] },
 ];
 
 for (const { endpoint, scopes } of ACTOR_ENDPOINTS) {

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -118,6 +118,7 @@ import { attachmentRouteDefinitions } from "./routes/attachment-routes.js";
 import { handleGetAudio } from "./routes/audio-routes.js";
 import { avatarRouteDefinitions } from "./routes/avatar-routes.js";
 import { brainGraphRouteDefinitions } from "./routes/brain-graph-routes.js";
+import { browserCdpRouteDefinitions } from "./routes/browser-cdp-routes.js";
 import { handleBrowserExtensionPair } from "./routes/browser-extension-pair-routes.js";
 import { btwRouteDefinitions } from "./routes/btw-routes.js";
 import { callRouteDefinitions } from "./routes/call-routes.js";
@@ -1347,6 +1348,7 @@ export class RuntimeHttpServer {
       ...approvalRouteDefinitions(),
       ...hostBashRouteDefinitions(),
       ...hostBrowserRouteDefinitions(),
+      ...browserCdpRouteDefinitions(),
       ...hostCuRouteDefinitions(),
       ...hostFileRouteDefinitions(),
       ...(this.getSkillContext

--- a/assistant/src/runtime/pending-interactions.ts
+++ b/assistant/src/runtime/pending-interactions.ts
@@ -52,6 +52,17 @@ export interface PendingInteraction {
   confirmationDetails?: ConfirmationDetails;
   /** For ACP permissions: resolves directly without a Conversation object. */
   directResolve?: (decision: UserDecision) => void;
+  /**
+   * For host_browser interactions originating outside an agent loop
+   * (e.g. the `assistant browser chrome relay` CLI shim that POSTs to
+   * /v1/browser-cdp). Resolves the CDP round-trip directly without
+   * touching a Conversation. When set, /v1/host-browser-result invokes
+   * this instead of `interaction.conversation.resolveHostBrowser`.
+   */
+  directBrowserResolve?: (response: {
+    content: string;
+    isError: boolean;
+  }) => void;
 }
 
 const pending = new Map<string, PendingInteraction>();

--- a/assistant/src/runtime/routes/browser-cdp-routes.ts
+++ b/assistant/src/runtime/routes/browser-cdp-routes.ts
@@ -1,0 +1,229 @@
+/**
+ * Route handler for the `assistant browser chrome relay` CLI shim.
+ *
+ * Accepts a single CDP command from out-of-process callers (the CLI
+ * subprocess spawned by skill scripts) and routes it to the user's
+ * Chrome via the connected chrome-extension WebSocket. The legacy
+ * relay CLI was deleted with PR #24329; this route is the runtime
+ * surface that lets the in-tree Amazon and Influencer skills keep
+ * shelling out to `assistant browser chrome relay <action>` until
+ * they migrate onto the new CDP-based skill API.
+ *
+ * Round-trip:
+ *   1. Caller POSTs `{ cdpMethod, cdpParams, cdpSessionId }`.
+ *   2. We register a pending interaction with a `directBrowserResolve`
+ *      callback (no Conversation attached) and push a host_browser_request
+ *      frame onto the connected chrome-extension WebSocket.
+ *   3. The chrome extension drives chrome.debugger and POSTs the result
+ *      to /v1/host-browser-result.
+ *   4. host-browser-routes invokes our directBrowserResolve callback,
+ *      which resolves the awaiting promise here.
+ *   5. We return `{ result | error }` to the caller.
+ *
+ * If no chrome extension is connected we fail fast with 503 — the legacy
+ * Amazon/Influencer scripts treat that as a recoverable error and prompt
+ * the user to load the extension.
+ */
+import { v4 as uuid } from "uuid";
+import { z } from "zod";
+
+import { findGuardianForChannel } from "../../contacts/contact-store.js";
+import type { ServerMessage } from "../../daemon/message-protocol.js";
+import { getLogger } from "../../util/logger.js";
+import { getChromeExtensionRegistry } from "../chrome-extension-registry.js";
+import { httpError } from "../http-errors.js";
+import type { RouteDefinition } from "../http-router.js";
+import * as pendingInteractions from "../pending-interactions.js";
+
+const log = getLogger("browser-cdp-routes");
+
+/** Default per-call timeout while waiting for the chrome-extension result POST. */
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+/** Synthetic conversation id stamped on host_browser_request envelopes from the CLI shim. */
+const CLI_FAKE_CONVERSATION_ID = "cli-browser-relay";
+
+const RequestBody = z.object({
+  cdpMethod: z.string().min(1),
+  cdpParams: z.record(z.string(), z.unknown()).optional(),
+  cdpSessionId: z.string().optional(),
+  /** Optional client-side timeout hint, in milliseconds. */
+  timeoutMs: z.number().int().positive().max(120_000).optional(),
+});
+
+const ResponseBody = z.object({
+  result: z.unknown().optional(),
+  error: z
+    .object({
+      code: z.string(),
+      message: z.string(),
+    })
+    .optional(),
+});
+
+/**
+ * Resolve the local guardian principal id used as the chrome-extension
+ * registry key. Mirrors the lookup performed by
+ * /v1/browser-extension-pair so the registry get() / send() calls hit
+ * the same key.
+ */
+function resolveLocalGuardianId(): string | null {
+  try {
+    const result = findGuardianForChannel("vellum");
+    if (result?.contact.principalId) {
+      return result.contact.principalId;
+    }
+  } catch (err) {
+    log.warn({ err }, "Failed to look up local vellum guardian");
+  }
+  return null;
+}
+
+/**
+ * POST /v1/browser-cdp — drive a single CDP command through the chrome-
+ * extension proxy on behalf of an out-of-process CLI caller.
+ *
+ * Authenticated like other /v1/* routes (the route policy below requires
+ * `settings.write`, which the CLI shim's daemon-delivery JWT carries via
+ * the `gateway_service_v1` profile).
+ */
+export async function handleBrowserCdp(req: Request): Promise<Response> {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return httpError("BAD_REQUEST", "invalid JSON body", 400);
+  }
+
+  const parsed = RequestBody.safeParse(body);
+  if (!parsed.success) {
+    return httpError(
+      "BAD_REQUEST",
+      `invalid request body: ${parsed.error.message}`,
+      400,
+    );
+  }
+
+  const { cdpMethod, cdpParams, cdpSessionId, timeoutMs } = parsed.data;
+
+  const guardianId = resolveLocalGuardianId();
+  if (!guardianId) {
+    return Response.json(
+      {
+        error: {
+          code: "EXTENSION_NOT_CONNECTED",
+          message:
+            "No local vellum guardian — load the chrome extension and pair it first",
+        },
+      },
+      { status: 503 },
+    );
+  }
+
+  const registry = getChromeExtensionRegistry();
+  if (!registry.get(guardianId)) {
+    return Response.json(
+      {
+        error: {
+          code: "EXTENSION_NOT_CONNECTED",
+          message:
+            "No chrome extension connected for the local guardian — open Chrome, load the Vellum extension, and click Connect",
+        },
+      },
+      { status: 503 },
+    );
+  }
+
+  const requestId = uuid();
+  const effectiveTimeoutMs = timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  const result = await new Promise<{ content: string; isError: boolean }>(
+    (resolve) => {
+      const timer = setTimeout(() => {
+        // Drain the pending interaction so a late-arriving POST from
+        // the extension lands in 404 territory rather than resolving a
+        // promise no one is awaiting.
+        pendingInteractions.resolve(requestId);
+        resolve({
+          content: `Timed out waiting for chrome extension result after ${effectiveTimeoutMs}ms`,
+          isError: true,
+        });
+      }, effectiveTimeoutMs);
+
+      pendingInteractions.register(requestId, {
+        conversation: null,
+        conversationId: CLI_FAKE_CONVERSATION_ID,
+        kind: "host_browser",
+        directBrowserResolve: (response) => {
+          clearTimeout(timer);
+          resolve(response);
+        },
+      });
+
+      const envelope: ServerMessage = {
+        type: "host_browser_request",
+        requestId,
+        conversationId: CLI_FAKE_CONVERSATION_ID,
+        cdpMethod,
+        cdpParams,
+        ...(cdpSessionId !== undefined ? { cdpSessionId } : {}),
+        timeout_seconds: Math.ceil(effectiveTimeoutMs / 1000),
+      } as ServerMessage;
+
+      const ok = registry.send(guardianId, envelope);
+      if (!ok) {
+        clearTimeout(timer);
+        pendingInteractions.resolve(requestId);
+        resolve({
+          content:
+            "Failed to send host_browser_request to chrome extension (no active connection)",
+          isError: true,
+        });
+      }
+    },
+  );
+
+  if (result.isError) {
+    return Response.json(
+      {
+        error: {
+          code: "CDP_ERROR",
+          message: result.content,
+        },
+      },
+      { status: 502 },
+    );
+  }
+
+  // The chrome extension serializes the CDP result via JSON.stringify(frame.result).
+  // Parse it back here so the CLI shim sees a structured object instead of
+  // a string-wrapped JSON blob.
+  let parsedResult: unknown;
+  try {
+    parsedResult = JSON.parse(result.content);
+  } catch {
+    parsedResult = result.content;
+  }
+
+  return Response.json({ result: parsedResult });
+}
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+export function browserCdpRouteDefinitions(): RouteDefinition[] {
+  return [
+    {
+      endpoint: "browser-cdp",
+      method: "POST",
+      summary: "Drive a single CDP command via the chrome extension",
+      description:
+        "Routes a Chrome DevTools Protocol command through the connected chrome extension. Used by the `assistant browser chrome relay` CLI shim that the in-tree Amazon and Influencer skills shell out to.",
+      tags: ["browser"],
+      requestBody: RequestBody,
+      responseBody: ResponseBody,
+      handler: async ({ req }) => handleBrowserCdp(req),
+    },
+  ];
+}

--- a/assistant/src/runtime/routes/host-browser-routes.ts
+++ b/assistant/src/runtime/routes/host-browser-routes.ts
@@ -57,6 +57,17 @@ export async function handleHostBrowserResult(
   // Validation passed — consume the pending interaction.
   const interaction = pendingInteractions.resolve(requestId)!;
 
+  // CLI shim path: pending interactions registered by /v1/browser-cdp carry
+  // a directBrowserResolve callback and are not bound to a Conversation.
+  // Resolve them in place without touching the conversation object.
+  if (interaction.directBrowserResolve) {
+    interaction.directBrowserResolve({
+      content: content ?? "",
+      isError: isError ?? false,
+    });
+    return Response.json({ accepted: true });
+  }
+
   // The host_browser kind always has a conversation attached at register time
   // (HostBrowserProxy.request wires it through), so this guard exists so a
   // future refactor of pending-interactions can change the type without


### PR DESCRIPTION
## Summary
- Restores `assistant browser chrome relay <action>` as a thin CLI shim that POSTs to a new `/v1/browser-cdp` daemon endpoint
- Adds `/v1/browser-cdp` HTTP route that drives a per-invocation `CdpClient` and translates legacy actions into CDP commands
- Re-registers `registerBrowserRelayCommand` in `cli/program.ts`
- Removes `/v1/browser-relay/command` and `/v1/browser-relay/status` from `openapi.yaml` and the generator's `INLINE_ROUTES`; adds `browser-cdp`
- Fixes the Amazon and Influencer skills which were broken by PR #24329 — they shell out to `assistant browser chrome relay` which is now restored as a CDP-backed shim

Fixes BLOCKING gaps identified during Phase 3 self-review for plan: phase3-cdp-migration.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24370" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
