### PR TITLE
[codex] Fix permission controls v2 toggles

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
@@ -492,7 +492,12 @@ extension AppDelegate {
     @discardableResult
     func ensureMainWindowExists(isFirstLaunch: Bool = false) -> MainWindow {
         if let existing = mainWindow { return existing }
-        let main = MainWindow(services: services, updateManager: updateManager, isFirstLaunch: isFirstLaunch)
+        let main = MainWindow(
+            services: services,
+            updateManager: updateManager,
+            assistantFeatureFlagStore: featureFlagStore,
+            isFirstLaunch: isFirstLaunch
+        )
         main.onMicrophoneToggle = { [weak self] in
             self?.voiceInput?.toggleRecording()
         }

--- a/clients/macos/vellum-assistant/Features/Chat/PermissionModeStatusModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/PermissionModeStatusModel.swift
@@ -1,0 +1,74 @@
+import Combine
+import Foundation
+import VellumAssistantShared
+
+/// Small view-model for the permission controls popover.
+///
+/// The toolbar popover should reflect a successful `PUT /v1/permission-mode`
+/// response immediately instead of waiting for a follow-up SSE message.
+@MainActor
+final class PermissionModeStatusModel: ObservableObject {
+    @Published private(set) var askBeforeActing: Bool
+    @Published private(set) var hostAccess: Bool
+    @Published private(set) var isUpdating: Bool = false
+    @Published private(set) var lastError: String?
+
+    private let connectionManager: GatewayConnectionManager
+    private let permissionModeClient: any PermissionModeClientProtocol
+    private var cancellables = Set<AnyCancellable>()
+
+    init(
+        connectionManager: GatewayConnectionManager,
+        permissionModeClient: any PermissionModeClientProtocol = PermissionModeClient()
+    ) {
+        self.connectionManager = connectionManager
+        self.permissionModeClient = permissionModeClient
+
+        let initialMode = connectionManager.permissionMode
+        self.askBeforeActing = initialMode?.askBeforeActing ?? PermissionModeDefaults.askBeforeActing
+        self.hostAccess = initialMode?.hostAccess ?? PermissionModeDefaults.hostAccess
+
+        connectionManager.$permissionMode
+            .receive(on: RunLoop.main)
+            .sink { [weak self] mode in
+                guard let self else { return }
+                self.askBeforeActing = mode?.askBeforeActing ?? PermissionModeDefaults.askBeforeActing
+                self.hostAccess = mode?.hostAccess ?? PermissionModeDefaults.hostAccess
+            }
+            .store(in: &cancellables)
+    }
+
+    func toggleAskBeforeActing() {
+        updateMode(askBeforeActing: !askBeforeActing)
+    }
+
+    func toggleHostAccess() {
+        updateMode(hostAccess: !hostAccess)
+    }
+
+    private func updateMode(askBeforeActing: Bool? = nil, hostAccess: Bool? = nil) {
+        guard !isUpdating else { return }
+
+        isUpdating = true
+        lastError = nil
+
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            let response = await self.permissionModeClient.updatePermissionMode(
+                askBeforeActing: askBeforeActing,
+                hostAccess: hostAccess
+            )
+
+            defer { self.isUpdating = false }
+
+            guard let response else {
+                self.lastError = "Couldn't update permission controls."
+                return
+            }
+
+            // Keep the local UI in sync even when the SSE confirmation is late
+            // or missing.
+            self.connectionManager.permissionMode = response
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Chat/PermissionModeStatusView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/PermissionModeStatusView.swift
@@ -6,18 +6,22 @@ import VellumAssistantShared
 /// - **Ask before acting** — when on the assistant checks in before high-stakes actions.
 /// - **Computer access** — when on the assistant can run commands on the host machine.
 ///
-/// Toggles send `PUT /v1/permission-mode` and update immediately on the SSE response.
+/// Toggles send `PUT /v1/permission-mode` and apply the successful response immediately.
+/// SSE still reconciles follow-up updates from other clients.
 /// The view is feature-flag gated on `permission-controls-v2`.
 struct PermissionModeStatusView: View {
-    @ObservedObject var connectionManager: GatewayConnectionManager
-    private let permissionModeClient: any PermissionModeClientProtocol = PermissionModeClient()
+    @StateObject private var model: PermissionModeStatusModel
 
-    private var askBeforeActing: Bool {
-        connectionManager.permissionMode?.askBeforeActing ?? PermissionModeDefaults.askBeforeActing
-    }
-
-    private var hostAccess: Bool {
-        connectionManager.permissionMode?.hostAccess ?? PermissionModeDefaults.hostAccess
+    init(
+        connectionManager: GatewayConnectionManager,
+        permissionModeClient: any PermissionModeClientProtocol = PermissionModeClient()
+    ) {
+        _model = StateObject(
+            wrappedValue: PermissionModeStatusModel(
+                connectionManager: connectionManager,
+                permissionModeClient: permissionModeClient
+            )
+        )
     }
 
     var body: some View {
@@ -26,26 +30,32 @@ struct PermissionModeStatusView: View {
                 .font(VFont.titleSmall)
                 .foregroundStyle(VColor.contentEmphasized)
 
+            if let lastError = model.lastError {
+                Text(lastError)
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.systemNegativeStrong)
+            }
+
             toggleRow(
                 label: "Ask before acting",
-                subtitle: askBeforeActing
+                subtitle: model.askBeforeActing
                     ? "Checks in before high-stakes actions"
                     : "Acts autonomously",
-                isOn: askBeforeActing,
-                icon: askBeforeActing ? .shieldCheck : .shieldOff
+                isOn: model.askBeforeActing,
+                icon: model.askBeforeActing ? .shieldCheck : .shieldOff
             ) {
-                updateMode(askBeforeActing: !askBeforeActing)
+                model.toggleAskBeforeActing()
             }
 
             toggleRow(
                 label: "Computer access",
-                subtitle: hostAccess
+                subtitle: model.hostAccess
                     ? "Can run commands on your computer"
                     : "Cannot access your computer",
-                isOn: hostAccess,
-                icon: hostAccess ? .terminal : .lock
+                isOn: model.hostAccess,
+                icon: model.hostAccess ? .terminal : .lock
             ) {
-                updateMode(hostAccess: !hostAccess)
+                model.toggleHostAccess()
             }
         }
         .padding(VSpacing.lg)
@@ -86,24 +96,12 @@ struct PermissionModeStatusView: View {
             .labelsHidden()
             .controlSize(.small)
             .tint(VColor.systemPositiveStrong)
+            .disabled(model.isUpdating)
         }
         .accessibilityElement(children: .combine)
         .accessibilityLabel(label)
         .accessibilityValue(isOn ? "On" : "Off")
         .accessibilityAddTraits(.isButton)
         .accessibilityAction { onToggle() }
-    }
-
-    // MARK: - Network
-
-    private func updateMode(askBeforeActing: Bool? = nil, hostAccess: Bool? = nil) {
-        Task {
-            _ = await permissionModeClient.updatePermissionMode(
-                askBeforeActing: askBeforeActing,
-                hostAccess: hostAccess
-            )
-            // State update arrives via SSE `permission_mode_update` event,
-            // which updates connectionManager.permissionMode automatically.
-        }
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -268,6 +268,7 @@ public final class MainWindow {
     let usageDashboardStore: UsageDashboardStore
     public let windowState = MainWindowState()
     let documentManager = DocumentManager()
+    private let assistantFeatureFlagStore: AssistantFeatureFlagStore
     var onMicrophoneToggle: (() -> Void)?
     let voiceModeManager = VoiceModeManager()
     let updateManager: UpdateManager
@@ -309,9 +310,15 @@ public final class MainWindow {
         conversationManager.activeViewModel
     }
 
-    init(services: AppServices, updateManager: UpdateManager, isFirstLaunch: Bool = false) {
+    init(
+        services: AppServices,
+        updateManager: UpdateManager,
+        assistantFeatureFlagStore: AssistantFeatureFlagStore,
+        isFirstLaunch: Bool = false
+    ) {
         self.services = services
         self.updateManager = updateManager
+        self.assistantFeatureFlagStore = assistantFeatureFlagStore
         self.conversationManager = ConversationManager(
             connectionManager: services.connectionManager,
             eventStreamClient: services.connectionManager.eventStreamClient,
@@ -434,7 +441,7 @@ public final class MainWindow {
             }
         } : nil
 
-        let rootView = MainWindowView(conversationManager: conversationManager, appListManager: appListManager, zoomManager: zoomManager, traceStore: traceStore, usageDashboardStore: usageDashboardStore, connectionManager: connectionManager, eventStreamClient: eventStreamClient, surfaceManager: surfaceManager, ambientAgent: ambientAgent, settingsStore: services.settingsStore, authManager: services.authManager, windowState: windowState, documentManager: documentManager, onMicrophoneToggle: onMicrophoneToggle ?? {}, voiceModeManager: voiceModeManager, updateManager: updateManager, onSendWakeUp: wakeUpCallback)
+        let rootView = MainWindowView(conversationManager: conversationManager, appListManager: appListManager, zoomManager: zoomManager, traceStore: traceStore, usageDashboardStore: usageDashboardStore, connectionManager: connectionManager, eventStreamClient: eventStreamClient, surfaceManager: surfaceManager, ambientAgent: ambientAgent, settingsStore: services.settingsStore, authManager: services.authManager, windowState: windowState, assistantFeatureFlagStore: assistantFeatureFlagStore, documentManager: documentManager, onMicrophoneToggle: onMicrophoneToggle ?? {}, voiceModeManager: voiceModeManager, updateManager: updateManager, onSendWakeUp: wakeUpCallback)
         let hostingController = NonDraggableHostingController(rootView: rootView)
 
         let screenFrame = NSScreen.main?.visibleFrame ?? NSScreen.screens.first?.visibleFrame ?? NSRect(x: 0, y: 0, width: 1440, height: 900)

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -19,7 +19,7 @@ struct MainWindowView: View {
     let traceStore: TraceStore
     let usageDashboardStore: UsageDashboardStore
     @ObservedObject var windowState: MainWindowState
-    @StateObject var assistantFeatureFlagStore: AssistantFeatureFlagStore
+    @ObservedObject var assistantFeatureFlagStore: AssistantFeatureFlagStore
     @State var selectedConversationId: UUID?
     @State var sharing = SharingState()
     @State var sidebar = SidebarInteractionState()
@@ -88,7 +88,7 @@ struct MainWindowView: View {
     /// Whether the permission mode popover is shown.
     @State private var showPermissionModePopover: Bool = false
 
-    init(conversationManager: ConversationManager, appListManager: AppListManager, zoomManager: ZoomManager, traceStore: TraceStore, usageDashboardStore: UsageDashboardStore, connectionManager: GatewayConnectionManager, eventStreamClient: EventStreamClient, surfaceManager: SurfaceManager, ambientAgent: AmbientAgent, settingsStore: SettingsStore, authManager: AuthManager, windowState: MainWindowState, documentManager: DocumentManager, onMicrophoneToggle: @escaping () -> Void = {}, voiceModeManager: VoiceModeManager, updateManager: UpdateManager, onSendWakeUp: (() -> Void)? = nil) {
+    init(conversationManager: ConversationManager, appListManager: AppListManager, zoomManager: ZoomManager, traceStore: TraceStore, usageDashboardStore: UsageDashboardStore, connectionManager: GatewayConnectionManager, eventStreamClient: EventStreamClient, surfaceManager: SurfaceManager, ambientAgent: AmbientAgent, settingsStore: SettingsStore, authManager: AuthManager, windowState: MainWindowState, assistantFeatureFlagStore: AssistantFeatureFlagStore, documentManager: DocumentManager, onMicrophoneToggle: @escaping () -> Void = {}, voiceModeManager: VoiceModeManager, updateManager: UpdateManager, onSendWakeUp: (() -> Void)? = nil) {
         self.conversationManager = conversationManager
         self.appListManager = appListManager
         self.zoomManager = zoomManager
@@ -101,9 +101,7 @@ struct MainWindowView: View {
         self.settingsStore = settingsStore
         self.authManager = authManager
         self.windowState = windowState
-        self._assistantFeatureFlagStore = StateObject(
-            wrappedValue: AssistantFeatureFlagStore()
-        )
+        self.assistantFeatureFlagStore = assistantFeatureFlagStore
         self.documentManager = documentManager
         self.onMicrophoneToggle = onMicrophoneToggle
         self.voiceModeManager = voiceModeManager

--- a/clients/macos/vellum-assistantTests/PermissionModeStatusModelTests.swift
+++ b/clients/macos/vellum-assistantTests/PermissionModeStatusModelTests.swift
@@ -1,0 +1,108 @@
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+@MainActor
+final class PermissionModeStatusModelTests: XCTestCase {
+    private var connectionManager: GatewayConnectionManager!
+    private var mockClient: MockPermissionModeClient!
+    private var model: PermissionModeStatusModel!
+
+    override func setUp() {
+        super.setUp()
+        connectionManager = GatewayConnectionManager()
+        mockClient = MockPermissionModeClient()
+        model = PermissionModeStatusModel(
+            connectionManager: connectionManager,
+            permissionModeClient: mockClient
+        )
+    }
+
+    override func tearDown() {
+        model = nil
+        mockClient = nil
+        connectionManager = nil
+        super.tearDown()
+    }
+
+    func testToggleAskBeforeActingAppliesSuccessfulResponseToConnectionManager() {
+        mockClient.updateResponse = PermissionModeUpdateMessage(
+            askBeforeActing: false,
+            hostAccess: false
+        )
+
+        model.toggleAskBeforeActing()
+
+        let predicate = NSPredicate { _, _ in
+            self.connectionManager.permissionMode?.askBeforeActing == false &&
+            self.model.isUpdating == false
+        }
+        wait(for: [XCTNSPredicateExpectation(predicate: predicate, object: nil)], timeout: 2.0)
+
+        XCTAssertEqual(mockClient.updateCalls.count, 1)
+        XCTAssertEqual(mockClient.updateCalls[0].askBeforeActing, false)
+        XCTAssertEqual(connectionManager.permissionMode?.askBeforeActing, false)
+        XCTAssertFalse(model.askBeforeActing)
+        XCTAssertNil(model.lastError)
+    }
+
+    func testToggleHostAccessAppliesSuccessfulResponseToConnectionManager() {
+        mockClient.updateResponse = PermissionModeUpdateMessage(
+            askBeforeActing: true,
+            hostAccess: true
+        )
+
+        model.toggleHostAccess()
+
+        let predicate = NSPredicate { _, _ in
+            self.connectionManager.permissionMode?.hostAccess == true &&
+            self.model.isUpdating == false
+        }
+        wait(for: [XCTNSPredicateExpectation(predicate: predicate, object: nil)], timeout: 2.0)
+
+        XCTAssertEqual(mockClient.updateCalls.count, 1)
+        XCTAssertEqual(mockClient.updateCalls[0].hostAccess, true)
+        XCTAssertEqual(connectionManager.permissionMode?.hostAccess, true)
+        XCTAssertTrue(model.hostAccess)
+        XCTAssertNil(model.lastError)
+    }
+
+    func testFailedUpdateSurfacesErrorWithoutChangingMode() {
+        mockClient.updateResponse = nil
+
+        model.toggleHostAccess()
+
+        let predicate = NSPredicate { _, _ in
+            self.model.isUpdating == false && self.model.lastError != nil
+        }
+        wait(for: [XCTNSPredicateExpectation(predicate: predicate, object: nil)], timeout: 2.0)
+
+        XCTAssertEqual(mockClient.updateCalls.count, 1)
+        XCTAssertEqual(mockClient.updateCalls[0].hostAccess, true)
+        XCTAssertNil(connectionManager.permissionMode)
+        XCTAssertFalse(model.hostAccess)
+        XCTAssertEqual(model.lastError, "Couldn't update permission controls.")
+    }
+}
+
+private final class MockPermissionModeClient: PermissionModeClientProtocol {
+    struct UpdateCall {
+        let askBeforeActing: Bool?
+        let hostAccess: Bool?
+    }
+
+    var updateResponse: PermissionModeUpdateMessage?
+    private(set) var updateCalls: [UpdateCall] = []
+
+    func fetchPermissionMode() async -> PermissionModeUpdateMessage? {
+        nil
+    }
+
+    func updatePermissionMode(
+        askBeforeActing: Bool?,
+        hostAccess: Bool?
+    ) async -> PermissionModeUpdateMessage? {
+        updateCalls.append(UpdateCall(askBeforeActing: askBeforeActing, hostAccess: hostAccess))
+        return updateResponse
+    }
+}


### PR DESCRIPTION
## Summary
- apply successful `PUT /v1/permission-mode` responses locally so the permission controls reflect clicks immediately instead of waiting on SSE
- keep the popover state synced with `GatewayConnectionManager` and show an explicit error when the update request fails
- pass the shared `AssistantFeatureFlagStore` into `MainWindowView` so the `permission-controls-v2` gate follows the connected assistant's refreshed flag state

## Root Cause
The permission-controls popover sent the update request but only changed visible state after a later `permission_mode_update` SSE event. If that event was delayed or missing, the toggles looked dead even when the click handler ran. Separately, `MainWindowView` built its own feature-flag store instead of observing the app-level store, so the toolbar gate could diverge from the connected assistant's actual flag state.

## Impact
This makes the v2 permissions UI a reliable test surface again: successful toggle changes become visible immediately, failed updates surface an error, and the toolbar button now tracks the authoritative assistant flag state.

## Validation
- `./build.sh test --filter 'PermissionModeStatusModelTests|AssistantFeatureFlagResolverTests'`
- `./build.sh lint`
- pre-push `clients/` Swift build
- pre-push design token guard

## Apple refs checked (2026-04-08)
- Apple Developer Documentation: SwiftUI `Model data`
- Apple Developer Documentation: `Managing user interface state`
- Apple Developer Documentation: `Migrating from the Observable Object protocol to the Observable macro`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24373" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
