### PR TITLE
feat: add transcript projection models for chat rendering

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/TranscriptProjector.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/TranscriptProjector.swift
@@ -1,0 +1,243 @@
+import Foundation
+import VellumAssistantShared
+
+// MARK: - Transcript Projector
+
+/// Pure projector that transforms the raw chat inputs into a
+/// `TranscriptRenderModel`. Mirrors the logic currently spread across
+/// `MessageListView+DerivedState.swift` but expressed as a stateless,
+/// testable function with no SwiftUI dependencies.
+///
+/// The projector accepts the same inputs that `MessageListView` already
+/// threads through its properties and produces a fully resolved render
+/// model that downstream views can consume without re-deriving layout.
+enum TranscriptProjector {
+
+    // MARK: - Projection
+
+    /// Project the current chat state into a fully resolved render model.
+    ///
+    /// - Parameters:
+    ///   - messages: The full (unfiltered) message array from the model layer.
+    ///   - paginatedVisibleMessages: Pre-filtered paginated subset of messages.
+    ///   - activeSubagents: Currently active subagent info list.
+    ///   - isSending: Whether the user's last message is still being processed.
+    ///   - isThinking: Whether the assistant is in a thinking state.
+    ///   - isCompacting: Whether context compaction is in progress.
+    ///   - assistantStatusText: Current assistant activity status text.
+    ///   - assistantActivityPhase: Activity phase string (e.g. "thinking").
+    ///   - assistantActivityAnchor: Activity anchor string (e.g. "assistant_turn").
+    ///   - assistantActivityReason: Optional activity reason (e.g. "confirmation_resolved").
+    ///   - activePendingRequestId: Active pending confirmation request ID.
+    ///   - highlightedMessageId: Message ID currently highlighted in the UI.
+    static func project(
+        messages: [ChatMessage],
+        paginatedVisibleMessages: [ChatMessage],
+        activeSubagents: [SubagentInfo],
+        isSending: Bool,
+        isThinking: Bool,
+        isCompacting: Bool,
+        assistantStatusText: String?,
+        assistantActivityPhase: String,
+        assistantActivityAnchor: String,
+        assistantActivityReason: String?,
+        activePendingRequestId: String?,
+        highlightedMessageId: UUID?
+    ) -> TranscriptRenderModel {
+        // Deduplicate visible messages (streaming can produce duplicate IDs).
+        let visibleMessages: [ChatMessage] = {
+            var seen = Set<UUID>()
+            return paginatedVisibleMessages.filter { seen.insert($0.id).inserted }
+        }()
+
+        // --- Structural metadata ---
+
+        let timestampSet = timestampIds(for: visibleMessages)
+        let latestAssistantId = visibleMessages.last(where: { $0.role == .assistant })?.id
+
+        var hasPrecedingAssistantByIndex = Set<Int>()
+        for i in visibleMessages.indices where i > 0 {
+            if visibleMessages[i - 1].role == .assistant {
+                hasPrecedingAssistantByIndex.insert(i)
+            }
+        }
+
+        let hasUserMessage = visibleMessages.contains { $0.role == .user }
+
+        let subagentsByParent: [UUID: [SubagentInfo]] = Dictionary(
+            grouping: activeSubagents.filter { $0.parentMessageId != nil },
+            by: { $0.parentMessageId! }
+        )
+        let orphanSubagents = activeSubagents.filter { $0.parentMessageId == nil }
+
+        let effectiveStatusText = isCompacting ? "Compacting context\u{2026}" : assistantStatusText
+
+        // --- Content-derived state ---
+
+        let anchoredThinkingIndex = resolvedThinkingAnchorIndex(
+            for: visibleMessages,
+            phase: assistantActivityPhase,
+            anchor: assistantActivityAnchor,
+            reason: assistantActivityReason
+        )
+
+        var nextDecidedConfirmationByIndex: [Int: ToolConfirmationData] = [:]
+        for i in visibleMessages.indices {
+            if i + 1 < visibleMessages.count,
+               let conf = visibleMessages[i + 1].confirmation,
+               conf.state != .pending {
+                nextDecidedConfirmationByIndex[i] = conf
+            }
+        }
+
+        var isConfirmationRenderedInlineByIndex = Set<Int>()
+        for i in visibleMessages.indices {
+            guard let confirmation = visibleMessages[i].confirmation,
+                  confirmation.state == .pending,
+                  let confirmationToolUseId = confirmation.toolUseId,
+                  !confirmationToolUseId.isEmpty else { continue }
+            for j in (0..<i).reversed() {
+                let msg = visibleMessages[j]
+                guard msg.role == .assistant, msg.confirmation == nil else { continue }
+                if msg.toolCalls.contains(where: { $0.toolUseId == confirmationToolUseId && $0.pendingConfirmation != nil }) {
+                    isConfirmationRenderedInlineByIndex.insert(i)
+                }
+                break
+            }
+        }
+
+        // --- Processing / thinking state ---
+
+        let lastVisible = visibleMessages.last
+
+        let currentTurnMessages: ArraySlice<ChatMessage> = {
+            if isSending, let last = visibleMessages.last, last.role == .user {
+                let lastNonUser = visibleMessages.last(where: { $0.role != .user })
+                let isActivelyProcessing = lastNonUser?.isStreaming == true
+                    || lastNonUser?.confirmation?.state == .pending
+                if !isActivelyProcessing {
+                    return visibleMessages[visibleMessages.endIndex...]
+                }
+            }
+            let lastTurnStart = visibleMessages.indices.reversed().first(where: { idx in
+                visibleMessages[idx].role == .user
+                    && visibleMessages.index(after: idx) < visibleMessages.endIndex
+                    && visibleMessages[visibleMessages.index(after: idx)].role != .user
+            })
+            if let idx = lastTurnStart {
+                return visibleMessages[visibleMessages.index(after: idx)...]
+            }
+            return visibleMessages[visibleMessages.startIndex...]
+        }()
+
+        let hasActiveToolCall = currentTurnMessages.contains(where: {
+            $0.toolCalls.contains(where: { !$0.isComplete })
+        })
+
+        let wouldShowThinking = isSending
+            && (isThinking || !(lastVisible?.isStreaming == true))
+            && !hasActiveToolCall
+        let lastVisibleIsAssistant = lastVisible?.role == .assistant
+        let canInlineProcessing = wouldShowThinking && lastVisibleIsAssistant
+        let shouldShowThinkingIndicator = wouldShowThinking && !canInlineProcessing
+        let isStreamingWithoutText = isSending
+            && (lastVisible?.isStreaming == true)
+            && (lastVisible?.text.isEmpty ?? true)
+            && !hasActiveToolCall
+            && !canInlineProcessing
+
+        // --- Build row models ---
+
+        let rows: [TranscriptRowModel] = visibleMessages.enumerated().map { index, message in
+            TranscriptRowModel(
+                message: message,
+                showTimestamp: timestampSet.contains(message.id),
+                hasPrecedingAssistant: hasPrecedingAssistantByIndex.contains(index),
+                isLatestAssistant: message.id == latestAssistantId,
+                isHighlighted: message.id == highlightedMessageId,
+                index: index,
+                decidedConfirmation: nextDecidedConfirmationByIndex[index],
+                isConfirmationRenderedInline: isConfirmationRenderedInlineByIndex.contains(index),
+                isAnchoredThinkingRow: index == anchoredThinkingIndex
+            )
+        }
+
+        return TranscriptRenderModel(
+            rows: rows,
+            subagentsByParent: subagentsByParent,
+            orphanSubagents: orphanSubagents,
+            effectiveStatusText: effectiveStatusText,
+            canInlineProcessing: canInlineProcessing,
+            shouldShowThinkingIndicator: shouldShowThinkingIndicator,
+            isStreamingWithoutText: isStreamingWithoutText,
+            hasMessages: !visibleMessages.isEmpty,
+            hasUserMessage: hasUserMessage,
+            hasActiveToolCall: hasActiveToolCall,
+            activePendingRequestId: activePendingRequestId
+        )
+    }
+
+    // MARK: - Timestamp computation
+
+    /// Pre-compute which message IDs should show a timestamp divider.
+    /// A timestamp is shown for the first message and whenever there is a
+    /// day boundary or >5 minute gap between consecutive messages.
+    ///
+    /// Mirrors `MessageListView.timestampIds(for:)`.
+    static func timestampIds(for list: [ChatMessage]) -> Set<UUID> {
+        guard !list.isEmpty else { return [] }
+        var result: Set<UUID> = [list[0].id]
+        var calendar = Calendar.current
+        calendar.timeZone = ChatTimestampTimeZone.resolve()
+        for i in 1..<list.count {
+            let current = list[i].timestamp
+            let previous = list[i - 1].timestamp
+            if !calendar.isDate(current, inSameDayAs: previous) || current.timeIntervalSince(previous) > 300 {
+                result.insert(list[i].id)
+            }
+        }
+        return result
+    }
+
+    // MARK: - Thinking anchor
+
+    /// Determines whether the thinking indicator should be anchored to a
+    /// confirmation chip row.
+    ///
+    /// Mirrors `MessageListView.shouldAnchorThinkingToConfirmationChip`
+    /// and `resolvedThinkingAnchorIndex(for:)`.
+    static func resolvedThinkingAnchorIndex(
+        for list: [ChatMessage],
+        phase: String,
+        anchor: String,
+        reason: String?
+    ) -> Int? {
+        let shouldAnchor = phase == "thinking"
+            && anchor == "assistant_turn"
+            && reason == "confirmation_resolved"
+        guard shouldAnchor else { return nil }
+        guard !list.isEmpty else { return nil }
+
+        for index in list.indices.reversed() {
+            // Decided confirmation chips are usually rendered inline on the
+            // preceding assistant bubble.
+            if list[index].role == .assistant, list.index(after: index) < list.endIndex {
+                let next = list[list.index(after: index)]
+                if let nextConfirmation = next.confirmation, nextConfirmation.state != .pending {
+                    return index
+                }
+            }
+
+            // Fallback for standalone decided confirmation bubbles.
+            if let confirmation = list[index].confirmation, confirmation.state != .pending {
+                let hasPrecedingAssistant = index > list.startIndex
+                    && list[list.index(before: index)].role == .assistant
+                if !hasPrecedingAssistant {
+                    return index
+                }
+            }
+        }
+
+        return nil
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Chat/TranscriptRenderModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/TranscriptRenderModel.swift
@@ -1,0 +1,98 @@
+import Foundation
+import VellumAssistantShared
+
+// MARK: - Transcript Render Model
+
+/// Top-level immutable render model for the entire chat transcript.
+/// Mirrors what `MessageListDerivedState` currently provides but
+/// expresses the layout as pure data — no SwiftUI state, no caching
+/// bookkeeping, no closure callbacks.
+///
+/// - SeeAlso: `TranscriptProjector` which produces this from raw inputs.
+struct TranscriptRenderModel: Equatable {
+    /// Ordered rows ready for display. Each row wraps a unique message
+    /// together with all per-row adornments the view layer needs.
+    let rows: [TranscriptRowModel]
+
+    /// Subagents grouped by their parent message ID.
+    /// Keyed by the parent message's UUID; value is the ordered list of
+    /// subagents that were spawned from that message.
+    let subagentsByParent: [UUID: [SubagentInfo]]
+
+    /// Subagents that have no known parent message (e.g. spawned before
+    /// any message was streamed).
+    let orphanSubagents: [SubagentInfo]
+
+    /// The effective status text to show at the bottom of the transcript
+    /// (e.g. "Compacting context..." or the assistant's current activity).
+    let effectiveStatusText: String?
+
+    /// Whether the assistant is currently processing after tool calls
+    /// completed and the processing indicator can be shown inline on the
+    /// latest assistant bubble (instead of a separate thinking row).
+    let canInlineProcessing: Bool
+
+    /// Whether a standalone thinking indicator should be shown.
+    let shouldShowThinkingIndicator: Bool
+
+    /// Whether the assistant is streaming but has not yet produced any text.
+    let isStreamingWithoutText: Bool
+
+    /// Whether the transcript has any messages at all.
+    let hasMessages: Bool
+
+    /// Whether the transcript contains at least one user message.
+    let hasUserMessage: Bool
+
+    /// Whether the current turn has an active (incomplete) tool call.
+    let hasActiveToolCall: Bool
+
+    /// The active pending confirmation request ID, if any.
+    let activePendingRequestId: String?
+}
+
+// MARK: - Transcript Row Model
+
+/// Per-row render model. Wraps a single `ChatMessage` together with
+/// all layout adornments that the current view code derives on the fly
+/// inside `MessageListContentView` and `ChatBubble`.
+struct TranscriptRowModel: Equatable, Identifiable {
+    /// Stable identity — same as the underlying message ID.
+    var id: UUID { message.id }
+
+    /// The underlying chat message.
+    let message: ChatMessage
+
+    /// When true, a timestamp divider should be rendered above this row.
+    let showTimestamp: Bool
+
+    /// When true, the previous message in the transcript was from the
+    /// assistant. Used for grouping-related spacing adjustments.
+    let hasPrecedingAssistant: Bool
+
+    /// When true, this row is the latest assistant message in the
+    /// transcript. Drives avatar placement and inline processing display.
+    let isLatestAssistant: Bool
+
+    /// When true, this row should be visually highlighted (e.g. after
+    /// an anchor-scroll from a notification deep link).
+    let isHighlighted: Bool
+
+    /// Index of this row's message in the projected visible list.
+    /// Needed by consumers that reference positional state (e.g.
+    /// next-message confirmation lookups, anchored thinking).
+    let index: Int
+
+    /// Non-nil when the *next* message in the transcript carries a
+    /// decided (non-pending) confirmation that should render as a
+    /// compact chip at the bottom of this row's bubble.
+    let decidedConfirmation: ToolConfirmationData?
+
+    /// When true, this row's confirmation message is rendered inline
+    /// on its matching tool-call bubble (not as a standalone bubble).
+    let isConfirmationRenderedInline: Bool
+
+    /// When true, the anchored thinking indicator should attach to
+    /// this row (post-confirmation thinking state).
+    let isAnchoredThinkingRow: Bool
+}

--- a/clients/macos/vellum-assistantTests/TranscriptProjectorTests.swift
+++ b/clients/macos/vellum-assistantTests/TranscriptProjectorTests.swift
@@ -1,0 +1,497 @@
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+// MARK: - TranscriptProjectorTests
+//
+// Locks current transcript projection behavior before any consumer
+// switches over. Each test mirrors a specific derivation in
+// MessageListView+DerivedState.swift to ensure the projector
+// reproduces identical results.
+
+@MainActor
+final class TranscriptProjectorTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    /// Build a simple ChatMessage with the given role, text, and timestamp.
+    private func makeMessage(
+        id: UUID = UUID(),
+        role: ChatRole = .assistant,
+        text: String = "Hello",
+        timestamp: Date = Date(),
+        isStreaming: Bool = false,
+        confirmation: ToolConfirmationData? = nil,
+        toolCalls: [ToolCallData] = []
+    ) -> ChatMessage {
+        ChatMessage(
+            id: id,
+            role: role,
+            text: text,
+            timestamp: timestamp,
+            isStreaming: isStreaming,
+            confirmation: confirmation,
+            toolCalls: toolCalls
+        )
+    }
+
+    /// Build a default projection from the given messages with sensible defaults.
+    private func project(
+        messages: [ChatMessage],
+        paginatedVisibleMessages: [ChatMessage]? = nil,
+        activeSubagents: [SubagentInfo] = [],
+        isSending: Bool = false,
+        isThinking: Bool = false,
+        isCompacting: Bool = false,
+        assistantStatusText: String? = nil,
+        assistantActivityPhase: String = "",
+        assistantActivityAnchor: String = "",
+        assistantActivityReason: String? = nil,
+        activePendingRequestId: String? = nil,
+        highlightedMessageId: UUID? = nil
+    ) -> TranscriptRenderModel {
+        TranscriptProjector.project(
+            messages: messages,
+            paginatedVisibleMessages: paginatedVisibleMessages ?? messages,
+            activeSubagents: activeSubagents,
+            isSending: isSending,
+            isThinking: isThinking,
+            isCompacting: isCompacting,
+            assistantStatusText: assistantStatusText,
+            assistantActivityPhase: assistantActivityPhase,
+            assistantActivityAnchor: assistantActivityAnchor,
+            assistantActivityReason: assistantActivityReason,
+            activePendingRequestId: activePendingRequestId,
+            highlightedMessageId: highlightedMessageId
+        )
+    }
+
+    // MARK: - Empty State
+
+    func testEmptyMessagesProducesEmptyModel() {
+        let model = project(messages: [])
+        XCTAssertTrue(model.rows.isEmpty)
+        XCTAssertFalse(model.hasMessages)
+        XCTAssertFalse(model.hasUserMessage)
+    }
+
+    // MARK: - Timestamp Grouping
+
+    func testFirstMessageAlwaysShowsTimestamp() {
+        let msg = makeMessage(text: "Hi")
+        let model = project(messages: [msg])
+        XCTAssertTrue(model.rows[0].showTimestamp)
+    }
+
+    func testMessagesWithinFiveMinutesSameDay_NoExtraTimestamp() {
+        let base = Date()
+        let msg1 = makeMessage(role: .user, text: "Hello", timestamp: base)
+        let msg2 = makeMessage(role: .assistant, text: "Hi there", timestamp: base.addingTimeInterval(60))
+        let msg3 = makeMessage(role: .user, text: "How are you?", timestamp: base.addingTimeInterval(200))
+
+        let model = project(messages: [msg1, msg2, msg3])
+        XCTAssertEqual(model.rows.count, 3)
+        XCTAssertTrue(model.rows[0].showTimestamp, "First message always shows timestamp")
+        XCTAssertFalse(model.rows[1].showTimestamp, "Within 5 minutes, no timestamp")
+        XCTAssertFalse(model.rows[2].showTimestamp, "Within 5 minutes, no timestamp")
+    }
+
+    func testMessagesOverFiveMinutesApart_ShowTimestamp() {
+        let base = Date()
+        let msg1 = makeMessage(role: .user, text: "Hello", timestamp: base)
+        let msg2 = makeMessage(role: .assistant, text: "Hi", timestamp: base.addingTimeInterval(301))
+
+        let model = project(messages: [msg1, msg2])
+        XCTAssertTrue(model.rows[0].showTimestamp)
+        XCTAssertTrue(model.rows[1].showTimestamp, "Over 5 minute gap should show timestamp")
+    }
+
+    func testMessagesAcrossDayBoundary_ShowTimestamp() {
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: Date())
+        let yesterday = calendar.date(byAdding: .day, value: -1, to: today)!
+        let yesterdayLate = calendar.date(byAdding: .hour, value: 23, to: yesterday)!
+
+        let msg1 = makeMessage(role: .user, text: "Last night", timestamp: yesterdayLate)
+        let msg2 = makeMessage(role: .assistant, text: "Good morning", timestamp: today.addingTimeInterval(1))
+
+        let model = project(messages: [msg1, msg2])
+        XCTAssertTrue(model.rows[0].showTimestamp)
+        XCTAssertTrue(model.rows[1].showTimestamp, "Day boundary should show timestamp")
+    }
+
+    // MARK: - Latest Assistant Message
+
+    func testLatestAssistantMessageIsMarked() {
+        let msg1 = makeMessage(role: .user, text: "Hi")
+        let msg2 = makeMessage(role: .assistant, text: "Hello")
+        let msg3 = makeMessage(role: .user, text: "Thanks")
+        let msg4 = makeMessage(role: .assistant, text: "You're welcome")
+
+        let model = project(messages: [msg1, msg2, msg3, msg4])
+        XCTAssertFalse(model.rows[0].isLatestAssistant)
+        XCTAssertFalse(model.rows[1].isLatestAssistant, "Not the last assistant message")
+        XCTAssertFalse(model.rows[2].isLatestAssistant, "User message")
+        XCTAssertTrue(model.rows[3].isLatestAssistant, "Last assistant in list")
+    }
+
+    func testNoAssistantMessages_NoneMarkedLatest() {
+        let msg1 = makeMessage(role: .user, text: "Hi")
+        let msg2 = makeMessage(role: .user, text: "Hello?")
+
+        let model = project(messages: [msg1, msg2])
+        XCTAssertFalse(model.rows[0].isLatestAssistant)
+        XCTAssertFalse(model.rows[1].isLatestAssistant)
+    }
+
+    // MARK: - Preceding Assistant Grouping
+
+    func testHasPrecedingAssistant() {
+        let msg1 = makeMessage(role: .assistant, text: "Hi")
+        let msg2 = makeMessage(role: .user, text: "Thanks")
+        let msg3 = makeMessage(role: .assistant, text: "More info")
+        let msg4 = makeMessage(role: .assistant, text: "Continued")
+
+        let model = project(messages: [msg1, msg2, msg3, msg4])
+        XCTAssertFalse(model.rows[0].hasPrecedingAssistant, "First message has no predecessor")
+        XCTAssertTrue(model.rows[1].hasPrecedingAssistant, "Preceded by assistant")
+        XCTAssertFalse(model.rows[2].hasPrecedingAssistant, "Preceded by user")
+        XCTAssertTrue(model.rows[3].hasPrecedingAssistant, "Preceded by assistant")
+    }
+
+    // MARK: - Highlighted State
+
+    func testHighlightedMessageId() {
+        let targetId = UUID()
+        let msg1 = makeMessage(role: .user, text: "Hi")
+        let msg2 = makeMessage(id: targetId, role: .assistant, text: "Hello")
+
+        let model = project(messages: [msg1, msg2], highlightedMessageId: targetId)
+        XCTAssertFalse(model.rows[0].isHighlighted)
+        XCTAssertTrue(model.rows[1].isHighlighted)
+    }
+
+    // MARK: - Pending Confirmation Inline Detection
+
+    func testPendingConfirmationRenderedInline() {
+        let toolUseId = "tool-use-123"
+        let assistantMsg = makeMessage(
+            role: .assistant,
+            text: "Running command",
+            toolCalls: [
+                ToolCallData(
+                    toolName: "bash",
+                    inputSummary: "ls -la",
+                    toolUseId: toolUseId,
+                    pendingConfirmation: ToolConfirmationData(
+                        requestId: "req-1",
+                        toolName: "bash",
+                        riskLevel: "medium",
+                        toolUseId: toolUseId
+                    )
+                )
+            ]
+        )
+        let confirmationMsg = makeMessage(
+            role: .assistant,
+            text: "",
+            confirmation: ToolConfirmationData(
+                requestId: "req-1",
+                toolName: "bash",
+                riskLevel: "medium",
+                toolUseId: toolUseId,
+                state: .pending
+            )
+        )
+
+        let model = project(messages: [assistantMsg, confirmationMsg])
+        XCTAssertFalse(model.rows[0].isConfirmationRenderedInline)
+        XCTAssertTrue(model.rows[1].isConfirmationRenderedInline,
+                      "Pending confirmation with matching toolUseId on preceding assistant should be inline")
+    }
+
+    func testDecidedConfirmationAsChipOnPrecedingAssistant() {
+        let assistantMsg = makeMessage(role: .assistant, text: "I'll run this")
+        let confirmationMsg = makeMessage(
+            role: .assistant,
+            text: "",
+            confirmation: ToolConfirmationData(
+                requestId: "req-1",
+                toolName: "bash",
+                riskLevel: "medium",
+                state: .approved
+            )
+        )
+
+        let model = project(messages: [assistantMsg, confirmationMsg])
+        XCTAssertNotNil(model.rows[0].decidedConfirmation,
+                        "Preceding assistant row should carry decided confirmation chip")
+        XCTAssertEqual(model.rows[0].decidedConfirmation?.state, .approved)
+    }
+
+    // MARK: - Anchored Thinking Indicator
+
+    func testAnchoredThinkingRow_AfterDecidedConfirmation() {
+        let assistantMsg = makeMessage(role: .assistant, text: "Checking permissions")
+        let confirmationMsg = makeMessage(
+            role: .assistant,
+            text: "",
+            confirmation: ToolConfirmationData(
+                requestId: "req-1",
+                toolName: "bash",
+                riskLevel: "medium",
+                state: .approved
+            )
+        )
+
+        let model = project(
+            messages: [assistantMsg, confirmationMsg],
+            assistantActivityPhase: "thinking",
+            assistantActivityAnchor: "assistant_turn",
+            assistantActivityReason: "confirmation_resolved"
+        )
+
+        XCTAssertTrue(model.rows[0].isAnchoredThinkingRow,
+                       "Anchored thinking should attach to the assistant message preceding the decided confirmation")
+        XCTAssertFalse(model.rows[1].isAnchoredThinkingRow)
+    }
+
+    func testAnchoredThinkingRow_NotSetWhenNotConfirmationResolved() {
+        let msg = makeMessage(role: .assistant, text: "Hello")
+        let model = project(
+            messages: [msg],
+            assistantActivityPhase: "thinking",
+            assistantActivityAnchor: "assistant_turn",
+            assistantActivityReason: nil
+        )
+        XCTAssertFalse(model.rows[0].isAnchoredThinkingRow)
+    }
+
+    // MARK: - Streaming Without Text
+
+    func testStreamingWithoutText_SelectsCorrectState() {
+        let streamingMsg = makeMessage(
+            role: .assistant,
+            text: "",
+            isStreaming: true
+        )
+
+        let model = project(
+            messages: [streamingMsg],
+            isSending: true,
+            isThinking: false
+        )
+
+        // Streaming with empty text, no active tool calls, but last visible is assistant
+        // so canInlineProcessing should be true (wouldShowThinking && lastVisibleIsAssistant),
+        // and isStreamingWithoutText should be false because canInlineProcessing is true.
+        // This matches the current DerivedState logic.
+        XCTAssertTrue(model.isStreamingWithoutText == false || model.canInlineProcessing,
+                      "Streaming without text should either show inline or be flagged")
+    }
+
+    func testStreamingAssistantNoText_CanInlineProcessing() {
+        let streamingMsg = makeMessage(
+            role: .assistant,
+            text: "",
+            isStreaming: true
+        )
+
+        let model = project(
+            messages: [streamingMsg],
+            isSending: true,
+            isThinking: true
+        )
+
+        // isSending=true, isThinking=true, no active tool calls, last visible is assistant
+        // -> wouldShowThinking=true, lastVisibleIsAssistant=true -> canInlineProcessing=true
+        XCTAssertTrue(model.canInlineProcessing)
+        XCTAssertFalse(model.shouldShowThinkingIndicator,
+                       "Inline processing should suppress standalone thinking indicator")
+    }
+
+    // MARK: - Row Identity Stability
+
+    func testRowIdentityStableWhenLastAssistantStreamsNewText() {
+        let msgId = UUID()
+        let msg1 = makeMessage(role: .user, text: "Hi")
+        let msg2 = makeMessage(id: msgId, role: .assistant, text: "Hel", isStreaming: true)
+
+        let model1 = project(messages: [msg1, msg2], isSending: true)
+
+        // Simulate new text arriving on the same message
+        let msg2Updated = makeMessage(id: msgId, role: .assistant, text: "Hello, how can I help?", isStreaming: true)
+        let model2 = project(messages: [msg1, msg2Updated], isSending: true)
+
+        XCTAssertEqual(model1.rows.count, model2.rows.count, "Row count should be stable")
+        XCTAssertEqual(model1.rows[0].id, model2.rows[0].id, "First row identity stable")
+        XCTAssertEqual(model1.rows[1].id, model2.rows[1].id, "Streaming row identity stable")
+        XCTAssertEqual(model1.rows[1].id, msgId, "Row ID matches message ID")
+    }
+
+    // MARK: - Subagent Grouping
+
+    func testSubagentsGroupedByParentMessage() {
+        let parentId = UUID()
+        let msg = makeMessage(id: parentId, role: .assistant, text: "Spawning workers")
+
+        let subagents = [
+            SubagentInfo(id: "sub-1", label: "Worker 1", parentMessageId: parentId),
+            SubagentInfo(id: "sub-2", label: "Worker 2", parentMessageId: parentId),
+            SubagentInfo(id: "sub-3", label: "Orphan"),
+        ]
+
+        let model = project(messages: [msg], activeSubagents: subagents)
+        XCTAssertEqual(model.subagentsByParent[parentId]?.count, 2)
+        XCTAssertEqual(model.orphanSubagents.count, 1)
+        XCTAssertEqual(model.orphanSubagents[0].id, "sub-3")
+    }
+
+    // MARK: - Compacting Status
+
+    func testCompactingOverridesStatusText() {
+        let msg = makeMessage(role: .assistant, text: "Hi")
+        let model = project(
+            messages: [msg],
+            isCompacting: true,
+            assistantStatusText: "Running tool"
+        )
+        XCTAssertEqual(model.effectiveStatusText, "Compacting context\u{2026}")
+    }
+
+    func testNonCompactingPassesThroughStatusText() {
+        let msg = makeMessage(role: .assistant, text: "Hi")
+        let model = project(
+            messages: [msg],
+            assistantStatusText: "Running tool"
+        )
+        XCTAssertEqual(model.effectiveStatusText, "Running tool")
+    }
+
+    // MARK: - Has User Message
+
+    func testHasUserMessage() {
+        let msg1 = makeMessage(role: .assistant, text: "Welcome")
+        let msg2 = makeMessage(role: .user, text: "Hi")
+
+        let modelNoUser = project(messages: [msg1])
+        XCTAssertFalse(modelNoUser.hasUserMessage)
+
+        let modelWithUser = project(messages: [msg1, msg2])
+        XCTAssertTrue(modelWithUser.hasUserMessage)
+    }
+
+    // MARK: - Active Tool Call Detection
+
+    func testHasActiveToolCall_IncompleteToolInCurrentTurn() {
+        let userMsg = makeMessage(role: .user, text: "Do something")
+        let assistantMsg = makeMessage(
+            role: .assistant,
+            text: "Running...",
+            toolCalls: [
+                ToolCallData(toolName: "bash", inputSummary: "ls", isComplete: false)
+            ]
+        )
+
+        let model = project(messages: [userMsg, assistantMsg], isSending: true)
+        XCTAssertTrue(model.hasActiveToolCall)
+    }
+
+    func testNoActiveToolCall_AllComplete() {
+        let userMsg = makeMessage(role: .user, text: "Do something")
+        let assistantMsg = makeMessage(
+            role: .assistant,
+            text: "Done",
+            toolCalls: [
+                ToolCallData(toolName: "bash", inputSummary: "ls", isComplete: true)
+            ]
+        )
+
+        let model = project(messages: [userMsg, assistantMsg], isSending: true)
+        XCTAssertFalse(model.hasActiveToolCall)
+    }
+
+    // MARK: - Thinking Indicator
+
+    func testThinkingIndicator_WhenSendingAndThinking_LastIsUser() {
+        let userMsg = makeMessage(role: .user, text: "Question")
+
+        let model = project(
+            messages: [userMsg],
+            isSending: true,
+            isThinking: true
+        )
+
+        // Last visible is user, so canInlineProcessing=false, shouldShowThinkingIndicator=true
+        XCTAssertTrue(model.shouldShowThinkingIndicator)
+        XCTAssertFalse(model.canInlineProcessing)
+    }
+
+    func testThinkingIndicator_SuppressedByActiveToolCall() {
+        let userMsg = makeMessage(role: .user, text: "Run it")
+        let assistantMsg = makeMessage(
+            role: .assistant,
+            text: "",
+            toolCalls: [
+                ToolCallData(toolName: "bash", inputSummary: "ls", isComplete: false)
+            ]
+        )
+
+        let model = project(
+            messages: [userMsg, assistantMsg],
+            isSending: true,
+            isThinking: true
+        )
+
+        // Active tool call suppresses thinking indicator entirely
+        XCTAssertFalse(model.shouldShowThinkingIndicator)
+        XCTAssertFalse(model.canInlineProcessing)
+    }
+
+    // MARK: - Duplicate Message Deduplication
+
+    func testDuplicateMessageIdsAreDeduped() {
+        let sharedId = UUID()
+        let msg1 = makeMessage(id: sharedId, role: .assistant, text: "First")
+        let msg2 = makeMessage(id: sharedId, role: .assistant, text: "Duplicate")
+
+        let model = project(messages: [msg1, msg2])
+        XCTAssertEqual(model.rows.count, 1, "Duplicate IDs should be deduped")
+        XCTAssertEqual(model.rows[0].message.text, "First", "First occurrence wins")
+    }
+
+    // MARK: - Active Pending Request ID Pass-Through
+
+    func testActivePendingRequestIdPassedThrough() {
+        let msg = makeMessage(role: .assistant, text: "Hi")
+        let model = project(messages: [msg], activePendingRequestId: "req-42")
+        XCTAssertEqual(model.activePendingRequestId, "req-42")
+    }
+
+    // MARK: - Index Correctness
+
+    func testRowIndicesMatchPositionInVisibleList() {
+        let msgs = (0..<5).map { i in
+            makeMessage(role: i % 2 == 0 ? .user : .assistant, text: "Message \(i)")
+        }
+        let model = project(messages: msgs)
+        for (i, row) in model.rows.enumerated() {
+            XCTAssertEqual(row.index, i, "Row index should match position in rows array")
+        }
+    }
+}
+
+// MARK: - ToolCallData convenience init for tests
+
+private extension ToolCallData {
+    init(toolName: String, inputSummary: String, isComplete: Bool = false, toolUseId: String? = nil, pendingConfirmation: ToolConfirmationData? = nil) {
+        self.init(
+            toolName: toolName,
+            inputSummary: inputSummary,
+            isError: false,
+            isComplete: isComplete
+        )
+        self.toolUseId = toolUseId
+        self.pendingConfirmation = pendingConfirmation
+    }
+}


### PR DESCRIPTION
## Summary
- Add TranscriptRenderModel with immutable row models mirroring current derived state
- Add TranscriptProjector with pure projection API accepting current MessageListView inputs
- Add TranscriptProjectorTests locking current timestamp, confirmation, and thinking behavior

Part of plan: macos-chat-surface-stabilization.md (PR 2 of 11)