### PR TITLE
fix: use correct SecureKeyDeleteResult value in bulk credential routes test

### DIFF
--- a/credential-executor/src/http/__tests__/credential-routes-bulk.test.ts
+++ b/credential-executor/src/http/__tests__/credential-routes-bulk.test.ts
@@ -32,7 +32,7 @@ function makeDeps(
     delete: async (account: string) => {
       if (!store.has(account)) return "not-found";
       store.delete(account);
-      return "ok";
+      return "deleted";
     },
     list: async () => [...store.keys()],
     ...overrides,


### PR DESCRIPTION
## Summary
- Fix type error in credential-routes-bulk.test.ts: mock delete returns "deleted" instead of "ok" to match SecureKeyDeleteResult type
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24377" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
