### PR TITLE
feat: add chat surface performance diagnostics

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatSurfaceMetrics.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatSurfaceMetrics.swift
@@ -1,0 +1,111 @@
+import Foundation
+import os
+
+// MARK: - Chat Surface Metrics Vocabulary
+
+/// Shared, content-safe vocabulary for chat-surface instrumentation.
+///
+/// Provides standardized identifiers for the sources and interactions
+/// that participate in chat-surface rendering so that downstream
+/// signpost emission and diagnostics recording use a single canonical
+/// set of names instead of ad-hoc strings.
+enum ChatSurfaceMetrics {
+
+    // MARK: - Source
+
+    /// Identifies the architectural component that originated a metric event.
+    enum Source: String, Codable, Sendable {
+        case chatView
+        case transcriptProjector
+        case messageList
+        case chatBubble
+        case progressCard
+        case composerController
+        case composerTextBridge
+        case scrollCoordinator
+    }
+
+    // MARK: - Interaction
+
+    /// Identifies the user or system interaction that triggered the event.
+    enum Interaction: String, Codable, Sendable {
+        case send
+        case stream
+        case manualScroll
+        case manualExpansion
+        case emojiPopup
+        case slashPopup
+        case anchorJump
+        case searchJump
+    }
+
+    // MARK: - Signpost Helpers
+
+    /// Emits an `os_signpost` event on the shared Points of Interest log
+    /// and records a diagnostic event in `ChatDiagnosticsStore`.
+    ///
+    /// - Parameters:
+    ///   - source: The architectural component originating the event.
+    ///   - interaction: The user/system interaction that triggered the event.
+    ///   - kind: The diagnostic event kind to record.
+    ///   - conversationId: The conversation associated with the event, if any.
+    ///   - reason: A short, content-safe reason string.
+    @MainActor
+    static func emit(
+        source: Source,
+        interaction: Interaction,
+        kind: ChatDiagnosticEventKind,
+        conversationId: String? = nil,
+        reason: String? = nil
+    ) {
+        let signpostName: StaticString = "chatSurface"
+        os_signpost(
+            .event,
+            log: PerfSignposts.log,
+            name: signpostName,
+            "%{public}s.%{public}s",
+            source.rawValue,
+            interaction.rawValue
+        )
+
+        let event = ChatDiagnosticEvent(
+            kind: kind,
+            conversationId: conversationId,
+            reason: reason,
+            source: source,
+            interaction: interaction
+        )
+        ChatDiagnosticsStore.shared.record(event)
+    }
+
+    /// Begins a signpost interval on the shared Points of Interest log.
+    ///
+    /// Returns an `OSSignpostID` that the caller passes to ``endInterval``
+    /// when the measured region completes.
+    static func beginInterval(
+        source: Source,
+        interaction: Interaction
+    ) -> OSSignpostID {
+        let id = OSSignpostID(log: PerfSignposts.log)
+        os_signpost(
+            .begin,
+            log: PerfSignposts.log,
+            name: "chatSurfaceInterval",
+            signpostID: id,
+            "%{public}s.%{public}s",
+            source.rawValue,
+            interaction.rawValue
+        )
+        return id
+    }
+
+    /// Ends a signpost interval previously started with ``beginInterval``.
+    static func endInterval(_ signpostID: OSSignpostID) {
+        os_signpost(
+            .end,
+            log: PerfSignposts.log,
+            name: "chatSurfaceInterval",
+            signpostID: signpostID
+        )
+    }
+}

--- a/clients/macos/vellum-assistant/Logging/ChatDiagnosticsStore.swift
+++ b/clients/macos/vellum-assistant/Logging/ChatDiagnosticsStore.swift
@@ -57,6 +57,24 @@ enum ChatDiagnosticEventKind: String, Codable, Sendable {
     case appLifecycle
 }
 
+/// Content-safe popup state for the composer.
+/// The raw value is written into JSONL logs and must remain stable.
+enum ComposerPopupState: String, Codable, Sendable {
+    case slash
+    case emoji
+    case none
+}
+
+/// Content-safe scroll intent source.
+/// The raw value is written into JSONL logs and must remain stable.
+enum ScrollIntentSource: String, Codable, Sendable {
+    case followBottom
+    case manual
+    case anchor
+    case search
+    case resizeRecovery
+}
+
 /// Content-safe diagnostic event.
 ///
 /// **Privacy invariant**: events record only identifiers, flags, counts, and
@@ -94,6 +112,19 @@ struct ChatDiagnosticEvent: Codable, Sendable {
     /// Viewport height at event time.
     let viewportHeight: Double?
 
+    // MARK: Surface metadata
+
+    /// The chat-surface component that originated this event.
+    let source: ChatSurfaceMetrics.Source?
+    /// The user/system interaction that triggered this event.
+    let interaction: ChatSurfaceMetrics.Interaction?
+    /// Number of progress cards currently in the expanded state.
+    let expandedProgressCardCount: Int?
+    /// Current composer popup state (slash picker, emoji picker, or none).
+    let composerPopupState: ComposerPopupState?
+    /// The source of the current scroll intent.
+    let scrollIntentSource: ScrollIntentSource?
+
     // MARK: Sanitization metadata
 
     /// Names of geometry fields whose original values were non-finite
@@ -111,6 +142,11 @@ struct ChatDiagnosticEvent: Codable, Sendable {
         scrollOffsetY: Double? = nil,
         contentHeight: Double? = nil,
         viewportHeight: Double? = nil,
+        source: ChatSurfaceMetrics.Source? = nil,
+        interaction: ChatSurfaceMetrics.Interaction? = nil,
+        expandedProgressCardCount: Int? = nil,
+        composerPopupState: ComposerPopupState? = nil,
+        scrollIntentSource: ScrollIntentSource? = nil,
         nonFiniteFields: [String]? = nil
     ) {
         self.id = UUID().uuidString
@@ -125,6 +161,11 @@ struct ChatDiagnosticEvent: Codable, Sendable {
         self.scrollOffsetY = scrollOffsetY
         self.contentHeight = contentHeight
         self.viewportHeight = viewportHeight
+        self.source = source
+        self.interaction = interaction
+        self.expandedProgressCardCount = expandedProgressCardCount
+        self.composerPopupState = composerPopupState
+        self.scrollIntentSource = scrollIntentSource
         self.nonFiniteFields = nonFiniteFields
     }
 
@@ -142,6 +183,11 @@ struct ChatDiagnosticEvent: Codable, Sendable {
         scrollOffsetY: Double? = nil,
         contentHeight: Double? = nil,
         viewportHeight: Double? = nil,
+        source: ChatSurfaceMetrics.Source? = nil,
+        interaction: ChatSurfaceMetrics.Interaction? = nil,
+        expandedProgressCardCount: Int? = nil,
+        composerPopupState: ComposerPopupState? = nil,
+        scrollIntentSource: ScrollIntentSource? = nil,
         nonFiniteFields: [String]? = nil
     ) {
         self.id = id
@@ -156,6 +202,11 @@ struct ChatDiagnosticEvent: Codable, Sendable {
         self.scrollOffsetY = scrollOffsetY
         self.contentHeight = contentHeight
         self.viewportHeight = viewportHeight
+        self.source = source
+        self.interaction = interaction
+        self.expandedProgressCardCount = expandedProgressCardCount
+        self.composerPopupState = composerPopupState
+        self.scrollIntentSource = scrollIntentSource
         self.nonFiniteFields = nonFiniteFields
     }
 }
@@ -210,6 +261,17 @@ struct ChatTranscriptSnapshot: Codable, Sendable {
     /// serialized snapshots.
     let scrollLoopGuardCounts: [String: Int]?
 
+    // MARK: Surface metadata
+
+    /// The chat-surface component that last updated this snapshot.
+    let source: ChatSurfaceMetrics.Source?
+    /// Number of progress cards currently in the expanded state.
+    let expandedProgressCardCount: Int?
+    /// Current composer popup state (slash picker, emoji picker, or none).
+    let composerPopupState: ComposerPopupState?
+    /// The source of the current scroll intent.
+    let scrollIntentSource: ScrollIntentSource?
+
     // MARK: Sanitization metadata
 
     /// Names of geometry fields whose original values were non-finite
@@ -239,6 +301,10 @@ struct ChatTranscriptSnapshot: Codable, Sendable {
         lastScrollToReason: String? = nil,
         lastLoopWarningTimestamp: Date? = nil,
         scrollLoopGuardCounts: [String: Int]? = nil,
+        source: ChatSurfaceMetrics.Source? = nil,
+        expandedProgressCardCount: Int? = nil,
+        composerPopupState: ComposerPopupState? = nil,
+        scrollIntentSource: ScrollIntentSource? = nil,
         nonFiniteFields: [String]? = nil
     ) {
         self.conversationId = conversationId
@@ -263,6 +329,10 @@ struct ChatTranscriptSnapshot: Codable, Sendable {
         self.lastScrollToReason = lastScrollToReason
         self.lastLoopWarningTimestamp = lastLoopWarningTimestamp
         self.scrollLoopGuardCounts = scrollLoopGuardCounts
+        self.source = source
+        self.expandedProgressCardCount = expandedProgressCardCount
+        self.composerPopupState = composerPopupState
+        self.scrollIntentSource = scrollIntentSource
         self.nonFiniteFields = nonFiniteFields
     }
 }

--- a/clients/macos/vellum-assistant/Telemetry/PerfSignposts.swift
+++ b/clients/macos/vellum-assistant/Telemetry/PerfSignposts.swift
@@ -13,4 +13,66 @@ enum PerfSignposts {
         category: .pointsOfInterest
     )
 
+    // MARK: - Chat Surface Signpost Helpers
+
+    /// Marks the start of a SwiftUI body evaluation for a chat surface view.
+    ///
+    /// Use `endBodyEvaluation` with the returned `OSSignpostID` when the
+    /// evaluation completes.
+    static func beginBodyEvaluation(_ viewName: StaticString) -> OSSignpostID {
+        let id = OSSignpostID(log: log)
+        os_signpost(.begin, log: log, name: "bodyEvaluation", signpostID: id,
+                    "%{public}s", String(describing: viewName))
+        return id
+    }
+
+    /// Marks the end of a SwiftUI body evaluation interval.
+    static func endBodyEvaluation(_ signpostID: OSSignpostID) {
+        os_signpost(.end, log: log, name: "bodyEvaluation", signpostID: signpostID)
+    }
+
+    /// Marks the start of a transcript projection pass (deriving the
+    /// visible message list from the underlying model).
+    static func beginProjection() -> OSSignpostID {
+        let id = OSSignpostID(log: log)
+        os_signpost(.begin, log: log, name: "transcriptProjection", signpostID: id)
+        return id
+    }
+
+    /// Marks the end of a transcript projection pass.
+    static func endProjection(_ signpostID: OSSignpostID) {
+        os_signpost(.end, log: log, name: "transcriptProjection", signpostID: signpostID)
+    }
+
+    /// Marks the start of a popup refresh cycle (slash command or emoji picker).
+    static func beginPopupRefresh(_ popupKind: StaticString) -> OSSignpostID {
+        let id = OSSignpostID(log: log)
+        os_signpost(.begin, log: log, name: "popupRefresh", signpostID: id,
+                    "%{public}s", String(describing: popupKind))
+        return id
+    }
+
+    /// Marks the end of a popup refresh cycle.
+    static func endPopupRefresh(_ signpostID: OSSignpostID) {
+        os_signpost(.end, log: log, name: "popupRefresh", signpostID: signpostID)
+    }
+
+    /// Emits a single-point signpost for a scroll intent event.
+    static func markScrollIntent(_ intent: StaticString) {
+        os_signpost(.event, log: log, name: "scrollIntent",
+                    "%{public}s", String(describing: intent))
+    }
+
+    /// Marks the start of a first-responder sync cycle (AppKit text bridge
+    /// coordinating focus state with SwiftUI).
+    static func beginFirstResponderSync() -> OSSignpostID {
+        let id = OSSignpostID(log: log)
+        os_signpost(.begin, log: log, name: "firstResponderSync", signpostID: id)
+        return id
+    }
+
+    /// Marks the end of a first-responder sync cycle.
+    static func endFirstResponderSync(_ signpostID: OSSignpostID) {
+        os_signpost(.end, log: log, name: "firstResponderSync", signpostID: signpostID)
+    }
 }

--- a/clients/macos/vellum-assistantTests/ChatDiagnosticsStoreTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatDiagnosticsStoreTests.swift
@@ -462,6 +462,246 @@ struct ChatDiagnosticsStoreTests {
         #expect(ChatDiagnosticEventKind.stallDetected.rawValue == "stallDetected")
         #expect(ChatDiagnosticEventKind.appLifecycle.rawValue == "appLifecycle")
     }
+
+    // MARK: - Surface Metadata Fields
+
+    @Test @MainActor
+    func eventWithSurfaceMetadataRoundTrips() throws {
+        let event = ChatDiagnosticEvent(
+            kind: .scrollPositionChanged,
+            conversationId: "conv-surface",
+            reason: "stream-append",
+            source: .transcriptProjector,
+            interaction: .stream,
+            expandedProgressCardCount: 2,
+            composerPopupState: .slash,
+            scrollIntentSource: .followBottom
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(event)
+        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+
+        // New surface metadata fields must be present.
+        #expect(json["source"] as? String == "transcriptProjector")
+        #expect(json["interaction"] as? String == "stream")
+        #expect(json["expandedProgressCardCount"] as? Int == 2)
+        #expect(json["composerPopupState"] as? String == "slash")
+        #expect(json["scrollIntentSource"] as? String == "followBottom")
+
+        // Round-trip through decoder.
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(ChatDiagnosticEvent.self, from: data)
+        #expect(decoded.source == .transcriptProjector)
+        #expect(decoded.interaction == .stream)
+        #expect(decoded.expandedProgressCardCount == 2)
+        #expect(decoded.composerPopupState == .slash)
+        #expect(decoded.scrollIntentSource == .followBottom)
+    }
+
+    @Test @MainActor
+    func eventWithNilSurfaceMetadataOmitsFields() throws {
+        let event = ChatDiagnosticEvent(
+            kind: .appLifecycle,
+            reason: "launch"
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(event)
+        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+
+        let surfaceKeys = ["source", "interaction", "expandedProgressCardCount",
+                           "composerPopupState", "scrollIntentSource"]
+        for key in surfaceKeys {
+            let val = json[key]
+            let isAbsentOrNull = val == nil || val is NSNull
+            #expect(isAbsentOrNull,
+                    "Surface metadata field '\(key)' should be absent or null when not set")
+        }
+    }
+
+    @Test @MainActor
+    func eventSurfaceMetadataIsContentSafe() throws {
+        let event = ChatDiagnosticEvent(
+            kind: .progressCardTransition,
+            conversationId: "conv-safe",
+            source: .progressCard,
+            interaction: .manualExpansion,
+            expandedProgressCardCount: 3,
+            composerPopupState: .emoji,
+            scrollIntentSource: .manual
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(event)
+        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+
+        // Must NOT contain any user-content keys.
+        let forbiddenKeys = ["messageText", "text", "toolInput", "toolOutput",
+                             "html", "surfaceHtml", "attachmentContent", "body"]
+        for key in forbiddenKeys {
+            #expect(json[key] == nil,
+                    "JSON with surface metadata must not contain user-content key '\(key)'")
+        }
+    }
+
+    @Test @MainActor
+    func snapshotWithSurfaceMetadataRoundTrips() throws {
+        let snapshot = ChatTranscriptSnapshot(
+            conversationId: "conv-snap-surface",
+            capturedAt: Date(),
+            messageCount: 15,
+            toolCallCount: 4,
+            isPinnedToBottom: true,
+            isUserScrolling: false,
+            scrollOffsetY: 500.0,
+            contentHeight: 3000.0,
+            viewportHeight: 800.0,
+            source: .chatView,
+            expandedProgressCardCount: 1,
+            composerPopupState: ComposerPopupState.none,
+            scrollIntentSource: .anchor
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(snapshot)
+        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+
+        #expect(json["source"] as? String == "chatView")
+        #expect(json["expandedProgressCardCount"] as? Int == 1)
+        #expect(json["composerPopupState"] as? String == "none")
+        #expect(json["scrollIntentSource"] as? String == "anchor")
+
+        // Round-trip through decoder.
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(ChatTranscriptSnapshot.self, from: data)
+        #expect(decoded.source == .chatView)
+        #expect(decoded.expandedProgressCardCount == 1)
+        #expect(decoded.composerPopupState == ComposerPopupState.none)
+        #expect(decoded.scrollIntentSource == .anchor)
+    }
+
+    @Test @MainActor
+    func snapshotWithNilSurfaceMetadataOmitsFields() throws {
+        let snapshot = ChatTranscriptSnapshot(
+            conversationId: "conv-nil-surface",
+            capturedAt: Date(),
+            messageCount: 5,
+            toolCallCount: 0,
+            isPinnedToBottom: true,
+            isUserScrolling: false
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(snapshot)
+        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+
+        let surfaceKeys = ["source", "expandedProgressCardCount",
+                           "composerPopupState", "scrollIntentSource"]
+        for key in surfaceKeys {
+            let val = json[key]
+            let isAbsentOrNull = val == nil || val is NSNull
+            #expect(isAbsentOrNull,
+                    "Snapshot surface field '\(key)' should be absent or null when not set")
+        }
+    }
+
+    @Test @MainActor
+    func storeRecordsEventWithSurfaceMetadata() {
+        let store = ChatDiagnosticsStore()
+
+        store.record(ChatDiagnosticEvent(
+            kind: .scrollPositionChanged,
+            conversationId: "conv-record",
+            source: .scrollCoordinator,
+            interaction: .anchorJump,
+            expandedProgressCardCount: 0,
+            composerPopupState: ComposerPopupState.none,
+            scrollIntentSource: .anchor
+        ))
+
+        #expect(store.events.count == 1)
+        let recorded = store.events.first
+        #expect(recorded?.source == .scrollCoordinator)
+        #expect(recorded?.interaction == .anchorJump)
+        #expect(recorded?.expandedProgressCardCount == 0)
+        #expect(recorded?.composerPopupState == ComposerPopupState.none)
+        #expect(recorded?.scrollIntentSource == .anchor)
+    }
+
+    @Test @MainActor
+    func storeSnapshotRetainsSurfaceMetadata() {
+        let store = ChatDiagnosticsStore()
+
+        let snapshot = ChatTranscriptSnapshot(
+            conversationId: "conv-snap-retain",
+            capturedAt: Date(),
+            messageCount: 8,
+            toolCallCount: 2,
+            isPinnedToBottom: true,
+            isUserScrolling: false,
+            source: .composerController,
+            expandedProgressCardCount: 3,
+            composerPopupState: .emoji,
+            scrollIntentSource: .resizeRecovery
+        )
+
+        store.updateSnapshot(snapshot)
+        let retrieved = store.snapshot(for: "conv-snap-retain")
+        #expect(retrieved?.source == .composerController)
+        #expect(retrieved?.expandedProgressCardCount == 3)
+        #expect(retrieved?.composerPopupState == .emoji)
+        #expect(retrieved?.scrollIntentSource == .resizeRecovery)
+    }
+
+    // MARK: - Surface Metrics Enum Stability
+
+    @Test
+    func sourceRawValuesAreStable() {
+        #expect(ChatSurfaceMetrics.Source.chatView.rawValue == "chatView")
+        #expect(ChatSurfaceMetrics.Source.transcriptProjector.rawValue == "transcriptProjector")
+        #expect(ChatSurfaceMetrics.Source.messageList.rawValue == "messageList")
+        #expect(ChatSurfaceMetrics.Source.chatBubble.rawValue == "chatBubble")
+        #expect(ChatSurfaceMetrics.Source.progressCard.rawValue == "progressCard")
+        #expect(ChatSurfaceMetrics.Source.composerController.rawValue == "composerController")
+        #expect(ChatSurfaceMetrics.Source.composerTextBridge.rawValue == "composerTextBridge")
+        #expect(ChatSurfaceMetrics.Source.scrollCoordinator.rawValue == "scrollCoordinator")
+    }
+
+    @Test
+    func interactionRawValuesAreStable() {
+        #expect(ChatSurfaceMetrics.Interaction.send.rawValue == "send")
+        #expect(ChatSurfaceMetrics.Interaction.stream.rawValue == "stream")
+        #expect(ChatSurfaceMetrics.Interaction.manualScroll.rawValue == "manualScroll")
+        #expect(ChatSurfaceMetrics.Interaction.manualExpansion.rawValue == "manualExpansion")
+        #expect(ChatSurfaceMetrics.Interaction.emojiPopup.rawValue == "emojiPopup")
+        #expect(ChatSurfaceMetrics.Interaction.slashPopup.rawValue == "slashPopup")
+        #expect(ChatSurfaceMetrics.Interaction.anchorJump.rawValue == "anchorJump")
+        #expect(ChatSurfaceMetrics.Interaction.searchJump.rawValue == "searchJump")
+    }
+
+    @Test
+    func composerPopupStateRawValuesAreStable() {
+        #expect(ComposerPopupState.slash.rawValue == "slash")
+        #expect(ComposerPopupState.emoji.rawValue == "emoji")
+        #expect(ComposerPopupState.none.rawValue == "none")
+    }
+
+    @Test
+    func scrollIntentSourceRawValuesAreStable() {
+        #expect(ScrollIntentSource.followBottom.rawValue == "followBottom")
+        #expect(ScrollIntentSource.manual.rawValue == "manual")
+        #expect(ScrollIntentSource.anchor.rawValue == "anchor")
+        #expect(ScrollIntentSource.search.rawValue == "search")
+        #expect(ScrollIntentSource.resizeRecovery.rawValue == "resizeRecovery")
+    }
 }
 
 // MARK: - Test Helpers


### PR DESCRIPTION
## Summary
- Add ChatSurfaceMetrics.swift with source and interaction enums plus signpost/diagnostics helpers
- Expand PerfSignposts.swift with named signpost helpers for chat surface hot paths
- Extend ChatDiagnosticsStore with source, progress-card count, popup state, and scroll intent metadata

Part of plan: macos-chat-surface-stabilization.md (PR 1 of 11)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24379" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
