### PR TITLE
feat: add progress card presentation and ui state models

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ProgressCardPresentationModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ProgressCardPresentationModel.swift
@@ -1,0 +1,306 @@
+import Foundation
+import VellumAssistantShared
+
+// MARK: - Progress Card Phase
+
+/// Pure enum representing the current phase of assistant progress.
+/// Mirrors the private `ProgressPhase` in `AssistantProgressView` so that later
+/// refactors can swap the view's inline derivation for this standalone model
+/// without changing phase semantics.
+enum ProgressCardPhase: Equatable, Sendable {
+    case thinking
+    case toolRunning
+    case streamingCode
+    case toolsCompleteThinking
+    case processing
+    case complete
+    case denied
+}
+
+// MARK: - Progress Card Presentation Model
+
+/// Pure value model that captures all derived state needed to render a progress
+/// card. Produced by a single O(n) pass over tool calls — no SwiftUI state, no
+/// `@State`, no environment reads. The view layer can consume this as a plain
+/// value and remain a thin rendering shell.
+///
+/// This mirrors the current `DerivedProgressState` + phase computation in
+/// `AssistantProgressView` so that later PRs can adopt it without behavioral
+/// change.
+struct ProgressCardPresentationModel: Equatable {
+
+    // MARK: - Tool Aggregates
+
+    /// Whether every tool call in the group has completed.
+    let allComplete: Bool
+    /// Whether the group contains at least one tool call.
+    let hasTools: Bool
+    /// Number of tool calls that have finished (regardless of success/failure).
+    let completedToolCount: Int
+    /// Number of tool calls whose confirmation was denied or timed out.
+    let deniedCount: Int
+    /// Whether any tool call was denied or timed out (includes decidedConfirmations fallback).
+    let hasDeniedToolCalls: Bool
+    /// Whether any tool call currently has a pending confirmation request.
+    let hasPendingConfirmation: Bool
+    /// Total number of tool calls in the group.
+    let totalToolCount: Int
+
+    // MARK: - Identity & Ordering
+
+    /// Stable group identifier derived from the first tool call's UUID.
+    /// Falls back to `"no-tools"` when the group is empty.
+    let groupId: String
+    /// The first incomplete tool call in iteration order, used for the
+    /// "currently running" headline.
+    let currentCall: ToolCallData?
+    /// The very last tool call in the array (by position, not time).
+    let lastToolCall: ToolCallData?
+    /// The last incomplete tool call in iteration order.
+    let lastIncompleteCall: ToolCallData?
+
+    // MARK: - Display Metadata
+
+    /// Human-friendly label for skill_execute tool calls, derived from the
+    /// last completed `skill_load`'s input.
+    let skillExecuteLabel: String
+    /// Sorted array of unique tool names present in the group.
+    let uniqueToolNamesSorted: [String]
+
+    // MARK: - Timestamps
+
+    /// Earliest `startedAt` across all tool calls in the group.
+    let earliestStartedAt: Date?
+    /// Latest `completedAt` across all tool calls in the group.
+    let latestCompletedAt: Date?
+
+    // MARK: - Computed Phase
+
+    /// The resolved progress phase given the streaming/processing context.
+    let phase: ProgressCardPhase
+
+    /// Whether the card is in an active (animating) state.
+    var isActive: Bool {
+        switch phase {
+        case .thinking, .toolRunning, .streamingCode, .toolsCompleteThinking, .processing:
+            return true
+        case .complete, .denied:
+            return false
+        }
+    }
+
+    // MARK: - Auto-Expand
+
+    /// Whether the card should auto-expand on initial presentation, taking into
+    /// account the `expand-completed-steps` feature flag and pending confirmations.
+    let shouldAutoExpand: Bool
+
+    // MARK: - Builder
+
+    /// Streaming/processing context passed alongside tool calls to resolve the phase.
+    struct StreamingContext: Equatable, Sendable {
+        let isStreaming: Bool
+        let hasText: Bool
+        let isProcessing: Bool
+        let streamingCodePreview: String?
+
+        static let idle = StreamingContext(
+            isStreaming: false,
+            hasText: false,
+            isProcessing: false,
+            streamingCodePreview: nil
+        )
+    }
+
+    /// Builds a presentation model from the raw tool call array and streaming
+    /// context in a single O(n) pass. This is a pure function with no side
+    /// effects — safe to call from any thread.
+    ///
+    /// - Parameters:
+    ///   - toolCalls: The ordered array of tool calls in this progress group.
+    ///   - decidedConfirmations: Confirmation decisions that may not yet be
+    ///     reflected on individual tool calls.
+    ///   - context: Current streaming/processing state of the message.
+    ///   - expandCompletedStepsFlag: Value of the `expand-completed-steps`
+    ///     feature flag. Passed explicitly to keep the builder pure.
+    static func build(
+        toolCalls: [ToolCallData],
+        decidedConfirmations: [ToolConfirmationData],
+        context: StreamingContext,
+        expandCompletedStepsFlag: Bool = false
+    ) -> ProgressCardPresentationModel {
+        // --- Single O(n) pass over tool calls ---
+
+        var allComplete = true
+        let hasTools = !toolCalls.isEmpty
+        var completedToolCount = 0
+        var deniedCount = 0
+        var hasDeniedToolCalls = false
+        var hasPendingConfirmation = false
+        var currentCall: ToolCallData?
+        var lastIncompleteCall: ToolCallData?
+        var lastSkillLoad: ToolCallData?
+        var toolNameSet = Set<String>()
+        var earliestStart: Date?
+        var latestEnd: Date?
+        var foundFirstIncomplete = false
+
+        for toolCall in toolCalls {
+            // Track completion
+            if toolCall.isComplete {
+                completedToolCount += 1
+            } else {
+                allComplete = false
+                if !foundFirstIncomplete {
+                    currentCall = toolCall
+                    foundFirstIncomplete = true
+                }
+                lastIncompleteCall = toolCall
+            }
+
+            // Track denied/timed-out
+            if toolCall.confirmationDecision == .denied || toolCall.confirmationDecision == .timedOut {
+                deniedCount += 1
+                hasDeniedToolCalls = true
+            }
+
+            // Track pending confirmations
+            if toolCall.pendingConfirmation != nil {
+                hasPendingConfirmation = true
+            }
+
+            // Track unique tool names
+            toolNameSet.insert(toolCall.toolName)
+
+            // Track skill_load (last completed one)
+            if toolCall.toolName == "skill_load" && toolCall.isComplete {
+                lastSkillLoad = toolCall
+            }
+
+            // Track timestamps
+            if let started = toolCall.startedAt {
+                if earliestStart == nil || started < earliestStart! {
+                    earliestStart = started
+                }
+            }
+            if let completed = toolCall.completedAt {
+                if latestEnd == nil || completed > latestEnd! {
+                    latestEnd = completed
+                }
+            }
+        }
+
+        let resolvedAllComplete = !toolCalls.isEmpty && allComplete
+        let groupId = toolCalls.first?.id.uuidString ?? "no-tools"
+
+        // Derive skill execute label
+        var skillExecuteLabel = "Using a skill"
+        if let skillLoad = lastSkillLoad,
+           let skillId = skillLoad.inputRawDict?["skill"]?.value as? String,
+           !skillId.isEmpty {
+            let display = skillId
+                .replacingOccurrences(of: "-", with: " ")
+                .replacingOccurrences(of: "_", with: " ")
+            skillExecuteLabel = "Using my \(display) skill"
+        }
+
+        // Check decidedConfirmations for denied state (fallback)
+        if !hasDeniedToolCalls {
+            for confirmation in decidedConfirmations {
+                if confirmation.state == .denied || confirmation.state == .timedOut {
+                    hasDeniedToolCalls = true
+                    break
+                }
+            }
+        }
+
+        // --- Phase resolution ---
+        let phase = resolvePhase(
+            hasTools: hasTools,
+            allComplete: resolvedAllComplete,
+            hasDeniedToolCalls: hasDeniedToolCalls,
+            isStreaming: context.isStreaming,
+            hasText: context.hasText,
+            isProcessing: context.isProcessing,
+            streamingCodePreview: context.streamingCodePreview
+        )
+
+        // --- Auto-expand ---
+        let isCompleteOrDenied = phase == .complete || phase == .denied
+        let shouldAutoExpand = (isCompleteOrDenied && expandCompletedStepsFlag) || hasPendingConfirmation
+
+        return ProgressCardPresentationModel(
+            allComplete: resolvedAllComplete,
+            hasTools: hasTools,
+            completedToolCount: completedToolCount,
+            deniedCount: deniedCount,
+            hasDeniedToolCalls: hasDeniedToolCalls,
+            hasPendingConfirmation: hasPendingConfirmation,
+            totalToolCount: toolCalls.count,
+            groupId: groupId,
+            currentCall: currentCall,
+            lastToolCall: toolCalls.last,
+            lastIncompleteCall: lastIncompleteCall,
+            skillExecuteLabel: skillExecuteLabel,
+            uniqueToolNamesSorted: toolNameSet.sorted(),
+            earliestStartedAt: earliestStart,
+            latestCompletedAt: latestEnd,
+            phase: phase,
+            shouldAutoExpand: shouldAutoExpand
+        )
+    }
+
+    // MARK: - Phase Resolution (private)
+
+    /// Pure phase resolution matching the logic in AssistantProgressView.phase.
+    private static func resolvePhase(
+        hasTools: Bool,
+        allComplete: Bool,
+        hasDeniedToolCalls: Bool,
+        isStreaming: Bool,
+        hasText: Bool,
+        isProcessing: Bool,
+        streamingCodePreview: String?
+    ) -> ProgressCardPhase {
+        let hasIncompleteTools = hasTools && !allComplete
+
+        // If confirmation was denied/timed out and tools are incomplete, those tools
+        // will never finish — show the denied state instead of an indefinite spinner.
+        if hasDeniedToolCalls && hasIncompleteTools {
+            return .denied
+        }
+
+        // Streaming code preview active
+        if isStreaming, let preview = streamingCodePreview, !preview.isEmpty {
+            return .streamingCode
+        }
+
+        // At least one tool still running
+        if hasTools && !allComplete {
+            return .toolRunning
+        }
+
+        // All tools done, model composing response (daemon sent activity_state "thinking").
+        if allComplete && isProcessing {
+            return .processing
+        }
+
+        // All tools done but message still streaming with no text yet — more tools
+        // may come. Show active "Thinking" state rather than premature "Completed N steps".
+        if allComplete && isStreaming && !hasText {
+            return .toolsCompleteThinking
+        }
+
+        // All done — either message finished or text is already visible while streaming.
+        if allComplete && (!isStreaming || hasText) && !isProcessing {
+            return .complete
+        }
+
+        // No tools, model working
+        if !hasTools && (isStreaming || isProcessing) {
+            return .processing
+        }
+
+        return .thinking
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Chat/ProgressCardUIState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ProgressCardUIState.swift
@@ -1,0 +1,104 @@
+import Foundation
+
+// MARK: - Progress Card UI State
+
+/// User-owned interaction state for a progress card that must outlive lazy row
+/// churn. SwiftUI's `LazyVStack` recycles views aggressively, destroying any
+/// `@State` on offscreen rows. This type captures the interaction state that
+/// must be preserved externally (e.g. in a `@Binding` or view model) so the
+/// card can be reconstructed identically when scrolled back into view.
+///
+/// All stored identifiers are stable `UUID`s from `ToolCallData.id`, making
+/// the state reconstructable from message/tool IDs alone without any SwiftUI
+/// dependency.
+struct ProgressCardUIState: Equatable, Sendable {
+
+    // MARK: - Step-Level Expansion
+
+    /// Set of tool call IDs whose detail rows are currently expanded.
+    /// Keyed by `ToolCallData.id` (UUID).
+    var expandedStepIds: Set<UUID> = []
+
+    // MARK: - Card-Level Expansion Overrides
+
+    /// Per-card expansion overrides set by the user clicking the chevron.
+    /// Keyed by the first tool call UUID in the group (the card's stable identity).
+    /// When present, overrides auto-expand logic from feature flags and
+    /// pending-confirmation heuristics.
+    var cardExpansionOverrides: [UUID: Bool] = [:]
+
+    // MARK: - Rehydration Tracking
+
+    /// Set of group IDs (first tool call UUID) for which rehydration has already
+    /// been triggered during the current view lifecycle. Prevents redundant
+    /// network calls when the same card is scrolled in and out of view.
+    var rehydratedGroupIds: Set<UUID> = []
+
+    // MARK: - Queries
+
+    /// Returns whether the step with the given tool call ID is expanded.
+    func isStepExpanded(_ toolCallId: UUID) -> Bool {
+        expandedStepIds.contains(toolCallId)
+    }
+
+    /// Returns the user's explicit card expansion override for the group
+    /// identified by `cardKey`, or `nil` if no override has been set.
+    func cardExpansionOverride(for cardKey: UUID) -> Bool? {
+        cardExpansionOverrides[cardKey]
+    }
+
+    /// Resolves the effective expansion state for a card, combining the user
+    /// override (if any) with the model's `shouldAutoExpand` recommendation.
+    func resolveCardExpanded(
+        cardKey: UUID?,
+        model: ProgressCardPresentationModel
+    ) -> Bool {
+        if let key = cardKey, let override = cardExpansionOverrides[key] {
+            return override
+        }
+        return model.shouldAutoExpand
+    }
+
+    /// Whether rehydration has already been performed for the given group.
+    func hasRehydrated(groupId: UUID) -> Bool {
+        rehydratedGroupIds.contains(groupId)
+    }
+
+    // MARK: - Mutations
+
+    /// Toggles the expansion state of an individual step detail row.
+    mutating func toggleStepExpansion(_ toolCallId: UUID) {
+        if expandedStepIds.contains(toolCallId) {
+            expandedStepIds.remove(toolCallId)
+        } else {
+            expandedStepIds.insert(toolCallId)
+        }
+    }
+
+    /// Sets the step expansion state explicitly.
+    mutating func setStepExpanded(_ toolCallId: UUID, expanded: Bool) {
+        if expanded {
+            expandedStepIds.insert(toolCallId)
+        } else {
+            expandedStepIds.remove(toolCallId)
+        }
+    }
+
+    /// Records a user-initiated card expansion toggle, storing the override
+    /// so it persists across view recycling.
+    mutating func setCardExpansionOverride(cardKey: UUID, expanded: Bool) {
+        cardExpansionOverrides[cardKey] = expanded
+    }
+
+    /// Marks a group as having been rehydrated.
+    mutating func markRehydrated(groupId: UUID) {
+        rehydratedGroupIds.insert(groupId)
+    }
+
+    /// Resets all state. Useful when switching conversations.
+    mutating func reset() {
+        expandedStepIds.removeAll()
+        cardExpansionOverrides.removeAll()
+        rehydratedGroupIds.removeAll()
+    }
+}

--- a/clients/macos/vellum-assistantTests/ProgressCardPresentationModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ProgressCardPresentationModelTests.swift
@@ -1,0 +1,736 @@
+import Foundation
+import Testing
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+@Suite("ProgressCardPresentationModel")
+struct ProgressCardPresentationModelTests {
+
+    // MARK: - Helpers
+
+    /// Creates a ToolCallData with a deterministic UUID for stable assertions.
+    private static func makeToolCall(
+        index: Int = 0,
+        toolName: String = "edit_file",
+        isComplete: Bool = false,
+        isError: Bool = false,
+        startedAt: Date? = Date(timeIntervalSince1970: 1000),
+        completedAt: Date? = nil,
+        confirmationDecision: ToolConfirmationState? = nil,
+        pendingConfirmation: ToolConfirmationData? = nil,
+        inputRawDict: [String: AnyCodable]? = nil
+    ) -> ToolCallData {
+        let id = UUID(uuidString: "00000000-0000-0000-0000-\(String(format: "%012d", index))")!
+        var tc = ToolCallData(
+            id: id,
+            toolName: toolName,
+            inputSummary: "test input \(index)",
+            startedAt: startedAt,
+            completedAt: completedAt
+        )
+        tc.isComplete = isComplete
+        tc.isError = isError
+        tc.confirmationDecision = confirmationDecision
+        tc.pendingConfirmation = pendingConfirmation
+        tc.inputRawDict = inputRawDict
+        return tc
+    }
+
+    private static func makeConfirmation(
+        requestId: String = "req-1",
+        state: ToolConfirmationState = .pending
+    ) -> ToolConfirmationData {
+        var c = ToolConfirmationData(
+            requestId: requestId,
+            toolName: "run_command",
+            riskLevel: "medium"
+        )
+        c.state = state
+        return c
+    }
+
+    private static let idleContext = ProgressCardPresentationModel.StreamingContext.idle
+
+    private static func streamingContext(
+        isStreaming: Bool = false,
+        hasText: Bool = false,
+        isProcessing: Bool = false,
+        streamingCodePreview: String? = nil
+    ) -> ProgressCardPresentationModel.StreamingContext {
+        .init(
+            isStreaming: isStreaming,
+            hasText: hasText,
+            isProcessing: isProcessing,
+            streamingCodePreview: streamingCodePreview
+        )
+    }
+
+    // MARK: - Phase: Thinking
+
+    @Test
+    func emptyToolCallsIdleYieldsThinking() {
+        let model = ProgressCardPresentationModel.build(
+            toolCalls: [],
+            decidedConfirmations: [],
+            context: Self.idleContext
+        )
+        #expect(model.phase == ProgressCardPhase.thinking)
+        #expect(!model.hasTools)
+        #expect(model.totalToolCount == 0)
+        #expect(model.groupId == "no-tools")
+    }
+
+    // MARK: - Phase: Tool Running
+
+    @Test
+    func singleIncompleteToolYieldsToolRunning() {
+        let tc = Self.makeToolCall(index: 1)
+        let model = ProgressCardPresentationModel.build(
+            toolCalls: [tc],
+            decidedConfirmations: [],
+            context: Self.idleContext
+        )
+        #expect(model.phase == ProgressCardPhase.toolRunning)
+        #expect(model.hasTools)
+        #expect(!model.allComplete)
+        #expect(model.currentCall?.id == tc.id)
+        #expect(model.totalToolCount == 1)
+        #expect(model.completedToolCount == 0)
+    }
+
+    @Test
+    func mixedCompletionYieldsToolRunning() {
+        let tc1 = Self.makeToolCall(
+            index: 1, isComplete: true,
+            completedAt: Date(timeIntervalSince1970: 1001)
+        )
+        let tc2 = Self.makeToolCall(index: 2)
+        let model = ProgressCardPresentationModel.build(
+            toolCalls: [tc1, tc2],
+            decidedConfirmations: [],
+            context: Self.idleContext
+        )
+        #expect(model.phase == ProgressCardPhase.toolRunning)
+        #expect(model.completedToolCount == 1)
+        #expect(model.currentCall?.id == tc2.id)
+        #expect(model.lastIncompleteCall?.id == tc2.id)
+    }
+
+    // MARK: - Phase: Streaming Code
+
+    @Test
+    func streamingCodePreviewYieldsStreamingCode() {
+        let tc = Self.makeToolCall(index: 1)
+        let model = ProgressCardPresentationModel.build(
+            toolCalls: [tc],
+            decidedConfirmations: [],
+            context: Self.streamingContext(isStreaming: true, streamingCodePreview: "func hello() {}")
+        )
+        #expect(model.phase == ProgressCardPhase.streamingCode)
+    }
+
+    @Test
+    func emptyCodePreviewDoesNotYieldStreamingCode() {
+        let tc = Self.makeToolCall(index: 1)
+        let model = ProgressCardPresentationModel.build(
+            toolCalls: [tc],
+            decidedConfirmations: [],
+            context: Self.streamingContext(isStreaming: true, streamingCodePreview: "")
+        )
+        // Empty preview should fall through to toolRunning (tool is incomplete)
+        #expect(model.phase == ProgressCardPhase.toolRunning)
+    }
+
+    // MARK: - Phase: Tools Complete Thinking
+
+    @Test
+    func allCompleteStreamingNoTextYieldsToolsCompleteThinking() {
+        let tc = Self.makeToolCall(
+            index: 1, isComplete: true,
+            completedAt: Date(timeIntervalSince1970: 1001)
+        )
+        let model = ProgressCardPresentationModel.build(
+            toolCalls: [tc],
+            decidedConfirmations: [],
+            context: Self.streamingContext(isStreaming: true, hasText: false)
+        )
+        #expect(model.phase == ProgressCardPhase.toolsCompleteThinking)
+    }
+
+    // MARK: - Phase: Processing
+
+    @Test
+    func allCompleteProcessingYieldsProcessing() {
+        let tc = Self.makeToolCall(
+            index: 1, isComplete: true,
+            completedAt: Date(timeIntervalSince1970: 1001)
+        )
+        let model = ProgressCardPresentationModel.build(
+            toolCalls: [tc],
+            decidedConfirmations: [],
+            context: Self.streamingContext(isProcessing: true)
+        )
+        #expect(model.phase == ProgressCardPhase.processing)
+    }
+
+    @Test
+    func noToolsStreamingYieldsProcessing() {
+        let model = ProgressCardPresentationModel.build(
+            toolCalls: [],
+            decidedConfirmations: [],
+            context: Self.streamingContext(isStreaming: true)
+        )
+        #expect(model.phase == ProgressCardPhase.processing)
+    }
+
+    @Test
+    func noToolsProcessingYieldsProcessing() {
+        let model = ProgressCardPresentationModel.build(
+            toolCalls: [],
+            decidedConfirmations: [],
+            context: Self.streamingContext(isProcessing: true)
+        )
+        #expect(model.phase == ProgressCardPhase.processing)
+    }
+
+    // MARK: - Phase: Complete
+
+    @Test
+    func allCompleteNotStreamingYieldsComplete() {
+        let tc = Self.makeToolCall(
+            index: 1, isComplete: true,
+            completedAt: Date(timeIntervalSince1970: 1001)
+        )
+        let model = ProgressCardPresentationModel.build(
+            toolCalls: [tc],
+            decidedConfirmations: [],
+            context: Self.idleContext
+        )
+        #expect(model.phase == ProgressCardPhase.complete)
+        #expect(model.allComplete)
+        #expect(model.completedToolCount == 1)
+    }
+
+    @Test
+    func allCompleteStreamingWithTextYieldsComplete() {
+        let tc = Self.makeToolCall(
+            index: 1, isComplete: true,
+            completedAt: Date(timeIntervalSince1970: 1001)
+        )
+        let model = ProgressCardPresentationModel.build(
+            toolCalls: [tc],
+            decidedConfirmations: [],
+            context: Self.streamingContext(isStreaming: true, hasText: true)
+        )
+        #expect(model.phase == ProgressCardPhase.complete)
+    }
+
+    // MARK: - Phase: Denied
+
+    @Test
+    func deniedToolCallWithIncompleteYieldsDenied() {
+        let tc = Self.makeToolCall(index: 1, confirmationDecision: .denied)
+        let model = ProgressCardPresentationModel.build(
+            toolCalls: [tc],
+            decidedConfirmations: [],
+            context: Self.idleContext
+        )
+        #expect(model.phase == ProgressCardPhase.denied)
+        #expect(model.hasDeniedToolCalls)
+        #expect(model.deniedCount == 1)
+    }
+
+    @Test
+    func timedOutToolCallWithIncompleteYieldsDenied() {
+        let tc = Self.makeToolCall(index: 1, confirmationDecision: .timedOut)
+        let model = ProgressCardPresentationModel.build(
+            toolCalls: [tc],
+            decidedConfirmations: [],
+            context: Self.idleContext
+        )
+        #expect(model.phase == ProgressCardPhase.denied)
+        #expect(model.hasDeniedToolCalls)
+        #expect(model.deniedCount == 1)
+    }
+
+    @Test
+    func deniedFromDecidedConfirmationsFallback() {
+        let tc = Self.makeToolCall(index: 1) // No confirmationDecision on call itself
+        let denied = Self.makeConfirmation(state: .denied)
+        let model = ProgressCardPresentationModel.build(
+            toolCalls: [tc],
+            decidedConfirmations: [denied],
+            context: Self.idleContext
+        )
+        #expect(model.hasDeniedToolCalls)
+        // The denied fallback sets hasDeniedToolCalls, so with an incomplete tool
+        // the phase resolves to denied.
+        #expect(model.phase == ProgressCardPhase.denied)
+    }
+
+    @Test
+    func deniedToolCallAllCompleteYieldsCompleteNotDenied() {
+        // When all tools are complete (even if some were denied), the phase
+        // should be .complete (with hasDeniedToolCalls = true for the warning icon).
+        let tc = Self.makeToolCall(
+            index: 1, isComplete: true,
+            completedAt: Date(timeIntervalSince1970: 1001),
+            confirmationDecision: .denied
+        )
+        let model = ProgressCardPresentationModel.build(
+            toolCalls: [tc],
+            decidedConfirmations: [],
+            context: Self.idleContext
+        )
+        #expect(model.phase == ProgressCardPhase.complete)
+        #expect(model.hasDeniedToolCalls)
+        #expect(model.deniedCount == 1)
+    }
+
+    // MARK: - Denied takes precedence over streaming code
+
+    @Test
+    func deniedTakesPrecedenceOverStreamingCode() {
+        let tc = Self.makeToolCall(index: 1, confirmationDecision: .denied)
+        let model = ProgressCardPresentationModel.build(
+            toolCalls: [tc],
+            decidedConfirmations: [],
+            context: Self.streamingContext(isStreaming: true, streamingCodePreview: "code")
+        )
+        // Denied check comes before streamingCode check
+        #expect(model.phase == ProgressCardPhase.denied)
+    }
+
+    // MARK: - Processing takes precedence over toolsCompleteThinking
+
+    @Test
+    func processingTakesPrecedenceOverToolsCompleteThinking() {
+        let tc = Self.makeToolCall(
+            index: 1, isComplete: true,
+            completedAt: Date(timeIntervalSince1970: 1001)
+        )
+        let model = ProgressCardPresentationModel.build(
+            toolCalls: [tc],
+            decidedConfirmations: [],
+            context: Self.streamingContext(isStreaming: true, hasText: false, isProcessing: true)
+        )
+        // isProcessing should yield .processing even when streaming with no text
+        #expect(model.phase == ProgressCardPhase.processing)
+    }
+
+    // MARK: - Completion Grouping
+
+    @Test
+    func multipleToolsGroupedCorrectly() {
+        let tc1 = Self.makeToolCall(
+            index: 1, toolName: "edit_file", isComplete: true,
+            startedAt: Date(timeIntervalSince1970: 1000),
+            completedAt: Date(timeIntervalSince1970: 1002)
+        )
+        let tc2 = Self.makeToolCall(
+            index: 2, toolName: "run_command", isComplete: true,
+            startedAt: Date(timeIntervalSince1970: 1001),
+            completedAt: Date(timeIntervalSince1970: 1005)
+        )
+        let tc3 = Self.makeToolCall(
+            index: 3, toolName: "edit_file", isComplete: true,
+            startedAt: Date(timeIntervalSince1970: 1003),
+            completedAt: Date(timeIntervalSince1970: 1004)
+        )
+        let model = ProgressCardPresentationModel.build(
+            toolCalls: [tc1, tc2, tc3],
+            decidedConfirmations: [],
+            context: Self.idleContext
+        )
+        #expect(model.phase == ProgressCardPhase.complete)
+        #expect(model.totalToolCount == 3)
+        #expect(model.completedToolCount == 3)
+        #expect(model.allComplete)
+        #expect(model.groupId == tc1.id.uuidString)
+        #expect(model.lastToolCall?.id == tc3.id)
+        // Two unique tool names
+        #expect(model.uniqueToolNamesSorted == ["edit_file", "run_command"])
+    }
+
+    // MARK: - Timestamps
+
+    @Test
+    func timestampsReflectEarliestAndLatest() {
+        let early = Date(timeIntervalSince1970: 500)
+        let mid = Date(timeIntervalSince1970: 1000)
+        let late = Date(timeIntervalSince1970: 2000)
+
+        let tc1 = Self.makeToolCall(
+            index: 1, isComplete: true,
+            startedAt: mid, completedAt: late
+        )
+        let tc2 = Self.makeToolCall(
+            index: 2, isComplete: true,
+            startedAt: early, completedAt: mid
+        )
+        let model = ProgressCardPresentationModel.build(
+            toolCalls: [tc1, tc2],
+            decidedConfirmations: [],
+            context: Self.idleContext
+        )
+        #expect(model.earliestStartedAt == early)
+        #expect(model.latestCompletedAt == late)
+    }
+
+    @Test
+    func timestampsNilWhenNoToolCalls() {
+        let model = ProgressCardPresentationModel.build(
+            toolCalls: [],
+            decidedConfirmations: [],
+            context: Self.idleContext
+        )
+        #expect(model.earliestStartedAt == nil)
+        #expect(model.latestCompletedAt == nil)
+    }
+
+    // MARK: - Skill Execute Label
+
+    @Test
+    func skillExecuteLabelDerivedFromLastSkillLoad() {
+        let skillLoad = Self.makeToolCall(
+            index: 1, toolName: "skill_load", isComplete: true,
+            completedAt: Date(timeIntervalSince1970: 1001),
+            inputRawDict: ["skill": AnyCodable("frontend-design")]
+        )
+        let skillExec = Self.makeToolCall(index: 2, toolName: "skill_execute")
+        let model = ProgressCardPresentationModel.build(
+            toolCalls: [skillLoad, skillExec],
+            decidedConfirmations: [],
+            context: Self.idleContext
+        )
+        #expect(model.skillExecuteLabel == "Using my frontend design skill")
+    }
+
+    @Test
+    func skillExecuteLabelDefaultsWhenNoSkillLoad() {
+        let tc = Self.makeToolCall(index: 1, toolName: "skill_execute")
+        let model = ProgressCardPresentationModel.build(
+            toolCalls: [tc],
+            decidedConfirmations: [],
+            context: Self.idleContext
+        )
+        #expect(model.skillExecuteLabel == "Using a skill")
+    }
+
+    // MARK: - Pending Confirmation
+
+    @Test
+    func pendingConfirmationDetected() {
+        let confirmation = Self.makeConfirmation(state: .pending)
+        let tc = Self.makeToolCall(index: 1, pendingConfirmation: confirmation)
+        let model = ProgressCardPresentationModel.build(
+            toolCalls: [tc],
+            decidedConfirmations: [],
+            context: Self.idleContext
+        )
+        #expect(model.hasPendingConfirmation)
+    }
+
+    @Test
+    func noPendingConfirmationWhenAbsent() {
+        let tc = Self.makeToolCall(index: 1)
+        let model = ProgressCardPresentationModel.build(
+            toolCalls: [tc],
+            decidedConfirmations: [],
+            context: Self.idleContext
+        )
+        #expect(!model.hasPendingConfirmation)
+    }
+
+    // MARK: - isActive
+
+    @Test
+    func isActiveForActivePhases() {
+        let activePhases: [(String, ProgressCardPresentationModel)] = [
+            ("toolRunning", ProgressCardPresentationModel.build(
+                toolCalls: [Self.makeToolCall(index: 1)],
+                decidedConfirmations: [],
+                context: Self.idleContext
+            )),
+            ("processing", ProgressCardPresentationModel.build(
+                toolCalls: [],
+                decidedConfirmations: [],
+                context: Self.streamingContext(isProcessing: true)
+            )),
+            ("thinking", ProgressCardPresentationModel.build(
+                toolCalls: [],
+                decidedConfirmations: [],
+                context: Self.idleContext
+            )),
+        ]
+        for (label, model) in activePhases {
+            #expect(model.isActive, "Expected isActive for \(label)")
+        }
+    }
+
+    @Test
+    func isNotActiveForTerminalPhases() {
+        let complete = ProgressCardPresentationModel.build(
+            toolCalls: [Self.makeToolCall(index: 1, isComplete: true, completedAt: Date(timeIntervalSince1970: 1001))],
+            decidedConfirmations: [],
+            context: Self.idleContext
+        )
+        #expect(!complete.isActive)
+
+        let denied = ProgressCardPresentationModel.build(
+            toolCalls: [Self.makeToolCall(index: 1, confirmationDecision: .denied)],
+            decidedConfirmations: [],
+            context: Self.idleContext
+        )
+        #expect(!denied.isActive)
+    }
+
+    // MARK: - Auto-Expand
+
+    @Test
+    func autoExpandWhenCompleteAndFlagEnabled() {
+        let tc = Self.makeToolCall(
+            index: 1, isComplete: true,
+            completedAt: Date(timeIntervalSince1970: 1001)
+        )
+        let model = ProgressCardPresentationModel.build(
+            toolCalls: [tc],
+            decidedConfirmations: [],
+            context: Self.idleContext,
+            expandCompletedStepsFlag: true
+        )
+        #expect(model.shouldAutoExpand)
+    }
+
+    @Test
+    func noAutoExpandWhenCompleteAndFlagDisabled() {
+        let tc = Self.makeToolCall(
+            index: 1, isComplete: true,
+            completedAt: Date(timeIntervalSince1970: 1001)
+        )
+        let model = ProgressCardPresentationModel.build(
+            toolCalls: [tc],
+            decidedConfirmations: [],
+            context: Self.idleContext,
+            expandCompletedStepsFlag: false
+        )
+        #expect(!model.shouldAutoExpand)
+    }
+
+    @Test
+    func autoExpandWhenDeniedAndFlagEnabled() {
+        let tc = Self.makeToolCall(index: 1, confirmationDecision: .denied)
+        let model = ProgressCardPresentationModel.build(
+            toolCalls: [tc],
+            decidedConfirmations: [],
+            context: Self.idleContext,
+            expandCompletedStepsFlag: true
+        )
+        #expect(model.shouldAutoExpand)
+    }
+
+    @Test
+    func autoExpandWhenPendingConfirmation() {
+        let confirmation = Self.makeConfirmation(state: .pending)
+        let tc = Self.makeToolCall(index: 1, pendingConfirmation: confirmation)
+        let model = ProgressCardPresentationModel.build(
+            toolCalls: [tc],
+            decidedConfirmations: [],
+            context: Self.idleContext,
+            expandCompletedStepsFlag: false
+        )
+        // Pending confirmation always forces auto-expand regardless of flag
+        #expect(model.shouldAutoExpand)
+    }
+
+    @Test
+    func noAutoExpandWhenRunningAndFlagEnabled() {
+        let tc = Self.makeToolCall(index: 1)
+        let model = ProgressCardPresentationModel.build(
+            toolCalls: [tc],
+            decidedConfirmations: [],
+            context: Self.idleContext,
+            expandCompletedStepsFlag: true
+        )
+        // toolRunning phase is not complete/denied, so no auto-expand
+        #expect(!model.shouldAutoExpand)
+    }
+
+    // MARK: - Equatable
+
+    @Test
+    func identicalBuildsAreEqual() {
+        let tc = Self.makeToolCall(index: 1, isComplete: true, completedAt: Date(timeIntervalSince1970: 1001))
+        let a = ProgressCardPresentationModel.build(
+            toolCalls: [tc],
+            decidedConfirmations: [],
+            context: Self.idleContext
+        )
+        let b = ProgressCardPresentationModel.build(
+            toolCalls: [tc],
+            decidedConfirmations: [],
+            context: Self.idleContext
+        )
+        #expect(a == b)
+    }
+}
+
+// MARK: - ProgressCardUIState Tests
+
+@Suite("ProgressCardUIState")
+struct ProgressCardUIStateTests {
+
+    private static let id1 = UUID(uuidString: "00000000-0000-0000-0000-000000000001")!
+    private static let id2 = UUID(uuidString: "00000000-0000-0000-0000-000000000002")!
+    private static let id3 = UUID(uuidString: "00000000-0000-0000-0000-000000000003")!
+
+    // MARK: - Step Expansion
+
+    @Test
+    func stepExpansionToggle() {
+        var state = ProgressCardUIState()
+        #expect(!state.isStepExpanded(Self.id1))
+
+        state.toggleStepExpansion(Self.id1)
+        #expect(state.isStepExpanded(Self.id1))
+
+        state.toggleStepExpansion(Self.id1)
+        #expect(!state.isStepExpanded(Self.id1))
+    }
+
+    @Test
+    func setStepExpandedExplicitly() {
+        var state = ProgressCardUIState()
+        state.setStepExpanded(Self.id1, expanded: true)
+        #expect(state.isStepExpanded(Self.id1))
+
+        state.setStepExpanded(Self.id1, expanded: false)
+        #expect(!state.isStepExpanded(Self.id1))
+    }
+
+    @Test
+    func multipleStepsIndependent() {
+        var state = ProgressCardUIState()
+        state.setStepExpanded(Self.id1, expanded: true)
+        state.setStepExpanded(Self.id2, expanded: true)
+        #expect(state.isStepExpanded(Self.id1))
+        #expect(state.isStepExpanded(Self.id2))
+        #expect(!state.isStepExpanded(Self.id3))
+    }
+
+    // MARK: - Card Expansion Overrides
+
+    @Test
+    func cardExpansionOverrideReadWrite() {
+        var state = ProgressCardUIState()
+        #expect(state.cardExpansionOverride(for: Self.id1) == nil)
+
+        state.setCardExpansionOverride(cardKey: Self.id1, expanded: true)
+        #expect(state.cardExpansionOverride(for: Self.id1) == true)
+
+        state.setCardExpansionOverride(cardKey: Self.id1, expanded: false)
+        #expect(state.cardExpansionOverride(for: Self.id1) == false)
+    }
+
+    @Test
+    func resolveCardExpandedUsesOverrideWhenPresent() {
+        var state = ProgressCardUIState()
+        state.setCardExpansionOverride(cardKey: Self.id1, expanded: false)
+
+        // Build a model that would auto-expand
+        let tc = ToolCallData(
+            id: Self.id1,
+            toolName: "edit_file",
+            inputSummary: "test",
+            isComplete: true,
+            startedAt: Date(timeIntervalSince1970: 1000),
+            completedAt: Date(timeIntervalSince1970: 1001)
+        )
+        let model = ProgressCardPresentationModel.build(
+            toolCalls: [tc],
+            decidedConfirmations: [],
+            context: .idle,
+            expandCompletedStepsFlag: true
+        )
+        #expect(model.shouldAutoExpand) // Model recommends expansion
+        #expect(!state.resolveCardExpanded(cardKey: Self.id1, model: model)) // Override wins
+    }
+
+    @Test
+    func resolveCardExpandedFallsBackToModelWhenNoOverride() {
+        let state = ProgressCardUIState()
+
+        let tc = ToolCallData(
+            id: Self.id1,
+            toolName: "edit_file",
+            inputSummary: "test",
+            isComplete: true,
+            startedAt: Date(timeIntervalSince1970: 1000),
+            completedAt: Date(timeIntervalSince1970: 1001)
+        )
+        let model = ProgressCardPresentationModel.build(
+            toolCalls: [tc],
+            decidedConfirmations: [],
+            context: .idle,
+            expandCompletedStepsFlag: true
+        )
+        #expect(state.resolveCardExpanded(cardKey: Self.id1, model: model))
+    }
+
+    // MARK: - Rehydration Tracking
+
+    @Test
+    func rehydrationTracking() {
+        var state = ProgressCardUIState()
+        #expect(!state.hasRehydrated(groupId: Self.id1))
+
+        state.markRehydrated(groupId: Self.id1)
+        #expect(state.hasRehydrated(groupId: Self.id1))
+        #expect(!state.hasRehydrated(groupId: Self.id2))
+    }
+
+    // MARK: - Reset
+
+    @Test
+    func resetClearsAllState() {
+        var state = ProgressCardUIState()
+        state.setStepExpanded(Self.id1, expanded: true)
+        state.setCardExpansionOverride(cardKey: Self.id2, expanded: true)
+        state.markRehydrated(groupId: Self.id3)
+
+        state.reset()
+
+        #expect(!state.isStepExpanded(Self.id1))
+        #expect(state.cardExpansionOverride(for: Self.id2) == nil)
+        #expect(!state.hasRehydrated(groupId: Self.id3))
+        #expect(state.expandedStepIds.isEmpty)
+        #expect(state.cardExpansionOverrides.isEmpty)
+        #expect(state.rehydratedGroupIds.isEmpty)
+    }
+
+    // MARK: - Equatable
+
+    @Test
+    func equatable() {
+        var a = ProgressCardUIState()
+        var b = ProgressCardUIState()
+        #expect(a == b)
+
+        a.setStepExpanded(Self.id1, expanded: true)
+        #expect(a != b)
+
+        b.setStepExpanded(Self.id1, expanded: true)
+        #expect(a == b)
+    }
+
+    // MARK: - Sendable
+
+    @Test
+    func sendableConformance() {
+        // Verify the type can cross actor boundaries (compile-time check).
+        let state = ProgressCardUIState()
+        let _: any Sendable = state
+        // If this compiles, Sendable conformance is valid.
+        #expect(Bool(true))
+    }
+}


### PR DESCRIPTION
## Summary
- Add ProgressCardPresentationModel with pure model builder mirroring current DerivedProgressState.compute
- Add ProgressCardUIState for expansion overrides and interaction state that outlives row churn
- Add ProgressCardPresentationModelTests locking current phase computation and grouping behavior

Part of plan: macos-chat-surface-stabilization.md (PR 4 of 11)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24381" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
