### PR TITLE
M1: Update WakeUpStepView to match Figma welcome screen

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
@@ -46,7 +46,7 @@ struct WakeUpStepView: View {
             .padding(.bottom, VSpacing.md)
 
         // Subtitle
-        Text("Your personal AI assistant,\nrunning on your terms.")
+        Text("The safest way to create your personal assistant.")
             .font(VFont.titleSmall)
             .foregroundStyle(VColor.contentSecondary)
             .multilineTextAlignment(.center)
@@ -79,13 +79,17 @@ struct WakeUpStepView: View {
                 }
                 .frame(height: 36)
             } else if managedSignInEnabled {
-                VButton(label: "Log In", style: .primary, isFullWidth: true) {
-                    onContinueWithVellum()
-                }
+                HStack(spacing: VSpacing.sm) {
+                    VButton(label: "Sign In", style: .primary) {
+                        onContinueWithVellum()
+                    }
+                    .frame(maxWidth: .infinity)
 
-                VButton(label: "Continue without account", style: .ghost) {
-                    state?.skippedAuth = true
-                    onStartWithAPIKey()
+                    VButton(label: "Self-Host", style: .outlined) {
+                        state?.skippedAuth = true
+                        onStartWithAPIKey()
+                    }
+                    .frame(maxWidth: .infinity)
                 }
             } else {
                 VButton(label: "Get Started", style: .primary, isFullWidth: true) {
@@ -121,7 +125,7 @@ struct WakeUpStepView: View {
 
         Text("\u{00A9} 2026 Vellum Inc.")
             .font(VFont.bodySmallDefault)
-            .foregroundStyle(VColor.contentTertiary.opacity(0.5))
+            .foregroundStyle(VColor.borderElement)
             .padding(.bottom, VSpacing.sm)
 
         // Characters peeking up from the bottom — single composed image


### PR DESCRIPTION
## Summary
- Update subtitle text to "The safest way to create your personal assistant."
- Change managed sign-in buttons from vertical to horizontal layout with side-by-side "Sign In" (primary) and "Self-Host" (outlined) buttons
- Update copyright text color from `VColor.contentTertiary.opacity(0.5)` to `VColor.borderElement`

## Test plan
- [ ] Verify welcome screen renders with updated subtitle (single line)
- [ ] Verify Sign In and Self-Host buttons appear side-by-side when `managedSignInEnabled` is true
- [ ] Verify Get Started button is unchanged when `managedSignInEnabled` is false
- [ ] Verify copyright text color matches design

Part of #24382.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24386" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
