### PR TITLE
feat(cli): add platformPollImportStatus and reduce import-from-gcs timeout

### DIFF
--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -529,7 +529,7 @@ export async function platformImportBundleFromGcs(
       method: "POST",
       headers: await authHeaders(token, platformUrl),
       body: JSON.stringify({ bundle_key: bundleKey }),
-      signal: AbortSignal.timeout(300_000),
+      signal: AbortSignal.timeout(60_000),
     },
   );
 
@@ -542,4 +542,44 @@ export async function platformImportBundleFromGcs(
     unknown
   >;
   return { statusCode: response.status, body };
+}
+
+export async function platformPollImportStatus(
+  jobId: string,
+  token: string,
+  platformUrl?: string,
+): Promise<{
+  status: string;
+  result?: Record<string, unknown>;
+  error?: string;
+}> {
+  const resolvedUrl = platformUrl || getPlatformUrl();
+  const response = await fetch(
+    `${resolvedUrl}/v1/migrations/import/${jobId}/status/`,
+    {
+      headers: await authHeaders(token, platformUrl),
+    },
+  );
+
+  if (response.status === 404) {
+    throw new Error("Import job not found");
+  }
+
+  if (!response.ok) {
+    throw new Error(
+      `Import status check failed: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const body = (await response.json()) as {
+    status: string;
+    job_id?: string;
+    result?: Record<string, unknown>;
+    error?: string;
+  };
+  return {
+    status: body.status,
+    result: body.result,
+    error: body.error,
+  };
 }


### PR DESCRIPTION
## Summary
- Add platformPollImportStatus() for polling GET /v1/migrations/import/{jobId}/status/
- Reduce platformImportBundleFromGcs timeout from 300s to 60s (POST now returns 202 quickly)

Part of plan: async-import-polling.md (PR 1 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24387" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
