### PR TITLE
fix: remove arbitrary 500-word threshold from document-writer skill

### DIFF
--- a/skills/document-writer/SKILL.md
+++ b/skills/document-writer/SKILL.md
@@ -6,6 +6,8 @@ metadata:
   emoji: "📝"
   vellum:
     display-name: "Document Writer"
+    includes:
+      - "document"
 ---
 
 You are helping your user write long-form content (blog posts, articles, essays, reports, documentation) using the built-in document editor. This skill should be used whenever the user asks to write, draft, or create any document-like content.
@@ -19,10 +21,9 @@ You are helping your user write long-form content (blog posts, articles, essays,
 - Reports
 - Guides or tutorials
 - Documentation
-- Any long-form written content (500+ words)
+- Any written content that benefits from the document editor
 
 **DO NOT use this skill for:**
-- Short responses or explanations (< 500 words)
 - Code snippets or technical implementations
 - Interactive apps or dashboards (use `app_create` instead)
 - Quick summaries


### PR DESCRIPTION
## Summary
- Remove the 500-word minimum guideline from the document-writer skill
- The skill is now available for any written content that benefits from the document editor, regardless of length

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24388" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
