### PR TITLE
feat: add explicit scroll coordination policy for chat transcript

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ScrollCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ScrollCoordinator.swift
@@ -1,0 +1,510 @@
+import Foundation
+
+// MARK: - ScrollCoordinator
+
+/// Pure policy object that models the scroll decisions currently spread across
+/// `MessageListView`, `MessageListView+Lifecycle`, `MessageListView+ScrollHandling`,
+/// and `MessageListScrollState`.
+///
+/// The coordinator consumes discrete input events and produces output intents
+/// describing what scroll action the view layer should perform — without owning
+/// `ScrollPosition`, `ScrollGeometrySnapshot`, or any SwiftUI view references.
+///
+/// **Not yet wired into the live message list.** This PR is additive scaffolding;
+/// existing transcript scrolling is unchanged.
+///
+/// Scroll policy domains modeled:
+///   - following-bottom vs free-browsing
+///   - deep-link anchor jumps
+///   - search jumps
+///   - resize recovery
+///   - manual expansion detach
+@MainActor
+final class ScrollCoordinator {
+
+    // MARK: - Types
+
+    /// Discrete events the coordinator can receive.
+    enum InputEvent: Equatable {
+        /// View appeared (initial mount or conversation switch).
+        case appeared
+
+        /// The visible message count changed.
+        case messageCountChanged
+
+        /// The sending state changed.
+        case sendingChanged(isSending: Bool)
+
+        /// The scroll phase changed (idle, interacting, decelerating, animating).
+        case scrollPhaseChanged(phase: Phase)
+
+        /// The user intentionally scrolled up (manual browse gesture).
+        case manualBrowseIntent
+
+        /// The user manually expanded or collapsed inline content (e.g. tool details).
+        case manualExpansion
+
+        /// A deep-link or search anchor was requested.
+        case anchorRequested(id: AnchorID)
+
+        /// A previously-requested anchor resolved (message is now visible).
+        case anchorResolved(id: AnchorID)
+
+        /// The container width changed (sidebar resize, split-view change).
+        case containerWidthChanged
+    }
+
+    /// Anchor identifier — wraps a UUID to keep the coordinator decoupled
+    /// from the concrete message ID type used by the view layer.
+    struct AnchorID: Hashable, Equatable {
+        let rawValue: UUID
+
+        init(_ rawValue: UUID) {
+            self.rawValue = rawValue
+        }
+    }
+
+    /// Scroll phase abstraction mirroring SwiftUI's `ScrollPhase` without
+    /// importing SwiftUI.
+    enum Phase: Equatable {
+        case idle
+        case interacting
+        case decelerating
+        case animating
+    }
+
+    /// Output intents the coordinator produces. The view layer translates
+    /// these into concrete `ScrollPosition` mutations.
+    enum OutputIntent: Equatable {
+        /// Scroll to the absolute bottom of the content.
+        case scrollToBottom(animated: Bool)
+
+        /// Scroll to a specific message with an anchor position.
+        case scrollToMessage(id: AnchorID, anchor: ScrollAnchorPoint)
+
+        /// Show the "Scroll to latest" call-to-action overlay.
+        case showScrollToLatest
+
+        /// Hide all scroll-related indicators (CTA, scroll bars, etc.).
+        case hideIndicators
+
+        /// Begin a recovery window — the view layer should repeatedly
+        /// attempt bottom-pinning until the window expires or the bottom
+        /// anchor materializes.
+        case startRecoveryWindow
+
+        /// Cancel any active recovery window.
+        case cancelRecoveryWindow
+    }
+
+    /// Abstract anchor position for scroll-to-message intents.
+    enum ScrollAnchorPoint: Equatable {
+        case top
+        case center
+        case bottom
+    }
+
+    // MARK: - Mode
+
+    /// The coordinator's internal scroll mode — mirrors the existing
+    /// `ScrollMode` semantics from `MessageListScrollState`.
+    enum Mode: Equatable, CustomStringConvertible {
+        /// Initial render — content starts at bottom, no user interaction yet.
+        case initialLoad
+
+        /// User is at the bottom. Auto-scroll on new content, streaming, etc.
+        case followingBottom
+
+        /// User scrolled away from bottom. No auto-scroll.
+        case freeBrowsing
+
+        /// A programmatic scroll is in flight (deep-link anchor, search, etc.).
+        case programmaticScroll(anchorId: AnchorID)
+
+        /// Temporarily stabilizing after a layout change.
+        case stabilizing(previousMode: StabilizedMode, reason: StabilizationReason)
+
+        var description: String {
+            switch self {
+            case .initialLoad: "initialLoad"
+            case .followingBottom: "followingBottom"
+            case .freeBrowsing: "freeBrowsing"
+            case .programmaticScroll(let id): "programmaticScroll(\(id.rawValue))"
+            case .stabilizing(let prev, let reason): "stabilizing(\(prev), \(reason))"
+            }
+        }
+
+        /// Whether the mode allows automatic bottom-pinning on new content.
+        var allowsAutoScroll: Bool {
+            switch self {
+            case .initialLoad, .followingBottom: true
+            default: false
+            }
+        }
+
+        /// Whether the "Scroll to latest" CTA should be visible.
+        var showsScrollToLatest: Bool {
+            switch self {
+            case .freeBrowsing: true
+            case .stabilizing(let prev, _) where prev == .freeBrowsing: true
+            default: false
+            }
+        }
+    }
+
+    /// The mode before entering stabilizing.
+    enum StabilizedMode: Equatable, CustomStringConvertible {
+        case followingBottom
+        case freeBrowsing
+
+        var description: String {
+            switch self {
+            case .followingBottom: "followingBottom"
+            case .freeBrowsing: "freeBrowsing"
+            }
+        }
+    }
+
+    enum StabilizationReason: Equatable, CustomStringConvertible {
+        case resize
+        case expansion
+
+        var description: String {
+            switch self {
+            case .resize: "resize"
+            case .expansion: "expansion"
+            }
+        }
+    }
+
+    // MARK: - State
+
+    /// The current scroll mode. Read-only externally; mutated by `handle(_:)`.
+    private(set) var mode: Mode = .initialLoad
+
+    /// Current scroll phase — used for hysteresis decisions.
+    private(set) var phase: Phase = .idle
+
+    /// Whether the viewport is currently at the bottom (within hysteresis threshold).
+    private(set) var isAtBottom: Bool = true
+
+    /// Tracks overlapping stabilization windows.
+    private var activeStabilizationCount: Int = 0
+
+    /// Timestamp of the last user-initiated pin (CTA tap). Used to suppress
+    /// stale momentum from the pre-CTA scroll gesture.
+    private var lastUserInitiatedPinTime: Date?
+
+    /// Pending anchor that hasn't resolved yet.
+    private(set) var pendingAnchor: AnchorID?
+
+    // MARK: - Convenience Queries
+
+    /// Whether the mode is following the bottom (including when stabilizing
+    /// from a following state).
+    var isFollowingBottom: Bool {
+        switch mode {
+        case .followingBottom: true
+        case .stabilizing(let prev, _): prev == .followingBottom
+        default: false
+        }
+    }
+
+    /// Whether auto-scroll is currently suppressed (stabilizing mode).
+    var isSuppressed: Bool {
+        if case .stabilizing = mode { return true }
+        return false
+    }
+
+    /// Whether the scroll system has received initial interaction.
+    var hasBeenInteracted: Bool {
+        if case .initialLoad = mode { return false }
+        return true
+    }
+
+    // MARK: - Event Processing
+
+    /// Process an input event and return the resulting output intents.
+    ///
+    /// The coordinator is deterministic: given the same sequence of events,
+    /// it produces the same sequence of intents. The view layer is responsible
+    /// for translating intents into concrete scroll mutations.
+    @discardableResult
+    func handle(_ event: InputEvent) -> [OutputIntent] {
+        switch event {
+        case .appeared:
+            return handleAppeared()
+
+        case .messageCountChanged:
+            return handleMessageCountChanged()
+
+        case .sendingChanged(let isSending):
+            return handleSendingChanged(isSending: isSending)
+
+        case .scrollPhaseChanged(let newPhase):
+            return handleScrollPhaseChanged(newPhase: newPhase)
+
+        case .manualBrowseIntent:
+            return handleManualBrowseIntent()
+
+        case .manualExpansion:
+            return handleManualExpansion()
+
+        case .anchorRequested(let id):
+            return handleAnchorRequested(id: id)
+
+        case .anchorResolved(let id):
+            return handleAnchorResolved(id: id)
+
+        case .containerWidthChanged:
+            return handleContainerWidthChanged()
+        }
+    }
+
+    // MARK: - Event Handlers
+
+    private func handleAppeared() -> [OutputIntent] {
+        var intents: [OutputIntent] = []
+        // On initial appear, start following the bottom with a recovery window.
+        if mode == .initialLoad || mode == .followingBottom {
+            intents.append(.startRecoveryWindow)
+            intents.append(.scrollToBottom(animated: false))
+        }
+        return intents
+    }
+
+    private func handleMessageCountChanged() -> [OutputIntent] {
+        var intents: [OutputIntent] = []
+
+        // If we have a pending anchor, check if it resolved.
+        // (The view layer calls anchorResolved separately when it finds the message.)
+
+        // Auto-pin to bottom when in a following mode.
+        if mode.allowsAutoScroll {
+            intents.append(.scrollToBottom(animated: true))
+        }
+        return intents
+    }
+
+    private func handleSendingChanged(isSending: Bool) -> [OutputIntent] {
+        var intents: [OutputIntent] = []
+        if isSending {
+            // User sent a message — reattach to bottom.
+            transition(to: .followingBottom)
+            intents.append(.startRecoveryWindow)
+            intents.append(.scrollToBottom(animated: true))
+        }
+        return intents
+    }
+
+    private func handleScrollPhaseChanged(newPhase: Phase) -> [OutputIntent] {
+        let oldPhase = phase
+        phase = newPhase
+
+        var intents: [OutputIntent] = []
+
+        // When scroll settles to idle and we're at the bottom, reattach.
+        if newPhase == .idle && oldPhase != .idle && isAtBottom {
+            reattachAtBottom()
+        }
+
+        return intents
+    }
+
+    private func handleManualBrowseIntent() -> [OutputIntent] {
+        var intents: [OutputIntent] = []
+
+        // Check for stale momentum suppression: if the user tapped the CTA
+        // recently and we're in a decelerating phase, the upward scroll is
+        // residual momentum — not a new deliberate gesture.
+        if phase == .decelerating,
+           let pinTime = lastUserInitiatedPinTime,
+           Date().timeIntervalSince(pinTime) < 0.5 {
+            // Stale momentum — ignore.
+            return intents
+        }
+
+        // Detach from auto-follow.
+        switch mode {
+        case .initialLoad, .followingBottom:
+            transition(to: .freeBrowsing)
+            intents.append(.cancelRecoveryWindow)
+        case .stabilizing:
+            transition(to: .freeBrowsing)
+            intents.append(.cancelRecoveryWindow)
+        case .freeBrowsing, .programmaticScroll:
+            break
+        }
+
+        if mode.showsScrollToLatest {
+            intents.append(.showScrollToLatest)
+        }
+
+        return intents
+    }
+
+    private func handleManualExpansion() -> [OutputIntent] {
+        var intents: [OutputIntent] = []
+
+        // Cancel recovery — manual expansion is explicit user intent to inspect.
+        intents.append(.cancelRecoveryWindow)
+
+        // Detach into free-browsing if not already there.
+        switch mode {
+        case .freeBrowsing:
+            break
+        case .stabilizing(let previousMode, _) where previousMode == .freeBrowsing:
+            break
+        default:
+            transition(to: .freeBrowsing)
+        }
+
+        // Begin expansion stabilization.
+        beginStabilization(.expansion)
+        intents.append(.showScrollToLatest)
+
+        return intents
+    }
+
+    private func handleAnchorRequested(id: AnchorID) -> [OutputIntent] {
+        pendingAnchor = id
+        transition(to: .programmaticScroll(anchorId: id))
+        return [.cancelRecoveryWindow]
+    }
+
+    private func handleAnchorResolved(id: AnchorID) -> [OutputIntent] {
+        guard pendingAnchor == id else { return [] }
+        pendingAnchor = nil
+        // Scroll to the resolved anchor at center.
+        return [.scrollToMessage(id: id, anchor: .center)]
+    }
+
+    private func handleContainerWidthChanged() -> [OutputIntent] {
+        var intents: [OutputIntent] = []
+
+        if mode.allowsAutoScroll {
+            // Re-pin to bottom after resize with a recovery window.
+            intents.append(.startRecoveryWindow)
+            intents.append(.scrollToBottom(animated: false))
+        } else if case .freeBrowsing = mode {
+            // Stabilize during resize to maintain reading position.
+            beginStabilization(.resize)
+        }
+
+        return intents
+    }
+
+    // MARK: - User-Initiated Pin (CTA tap)
+
+    /// Handles a user-initiated scroll-to-bottom (e.g. tapping the CTA).
+    /// Always succeeds — user intent overrides all mode checks.
+    func requestUserInitiatedPin() -> [OutputIntent] {
+        lastUserInitiatedPinTime = Date()
+        transition(to: .followingBottom)
+        return [
+            .hideIndicators,
+            .startRecoveryWindow,
+            .scrollToBottom(animated: true)
+        ]
+    }
+
+    // MARK: - Bottom State Updates
+
+    /// Called by the view layer to report whether the viewport is at the bottom.
+    /// Uses asymmetric thresholds (hysteresis) to prevent oscillation during
+    /// streaming: the "leave" threshold (30pt) is wider than the "enter"
+    /// threshold (10pt).
+    func updateBottomState(distanceFromBottom: CGFloat) {
+        let nowAtBottom: Bool
+        if isAtBottom {
+            // Stay "at bottom" until clearly scrolled away.
+            nowAtBottom = distanceFromBottom.isFinite && distanceFromBottom <= 30
+        } else {
+            // Only re-enter "at bottom" when truly close.
+            nowAtBottom = distanceFromBottom.isFinite && distanceFromBottom <= 10
+        }
+        isAtBottom = nowAtBottom
+    }
+
+    // MARK: - Mode Transitions
+
+    private func transition(to newMode: Mode) {
+        let oldMode = mode
+        guard oldMode != newMode else { return }
+
+        // Exit actions.
+        switch oldMode {
+        case .stabilizing:
+            if case .stabilizing = newMode {
+                // Staying in stabilizing — preserve window count.
+            } else {
+                activeStabilizationCount = 0
+            }
+        default:
+            break
+        }
+
+        mode = newMode
+    }
+
+    // MARK: - Stabilization
+
+    private func beginStabilization(_ reason: StabilizationReason) {
+        let previousMode: StabilizedMode
+        switch mode {
+        case .followingBottom, .initialLoad:
+            previousMode = .followingBottom
+        case .freeBrowsing:
+            previousMode = .freeBrowsing
+        case .stabilizing(let prev, let activeReason):
+            previousMode = prev
+            if activeReason == reason {
+                // Same-reason re-entry — increment count but don't re-transition.
+                activeStabilizationCount += 1
+                return
+            }
+        case .programmaticScroll:
+            return
+        }
+
+        activeStabilizationCount += 1
+        transition(to: .stabilizing(previousMode: previousMode, reason: reason))
+    }
+
+    /// Ends one stabilization window. Only restores the previous mode
+    /// when all overlapping windows have completed.
+    func endStabilization() {
+        guard case .stabilizing(let previousMode, _) = mode else { return }
+        activeStabilizationCount = max(0, activeStabilizationCount - 1)
+        guard activeStabilizationCount == 0 else { return }
+        switch previousMode {
+        case .followingBottom:
+            transition(to: .followingBottom)
+        case .freeBrowsing:
+            transition(to: .freeBrowsing)
+        }
+    }
+
+    // MARK: - Reattach
+
+    private func reattachAtBottom() {
+        switch mode {
+        case .freeBrowsing, .initialLoad, .programmaticScroll:
+            transition(to: .followingBottom)
+        case .stabilizing, .followingBottom:
+            break
+        }
+    }
+
+    // MARK: - Reset
+
+    /// Resets the coordinator for a conversation switch.
+    func reset() {
+        mode = .initialLoad
+        phase = .idle
+        isAtBottom = false
+        activeStabilizationCount = 0
+        lastUserInitiatedPinTime = nil
+        pendingAnchor = nil
+    }
+}

--- a/clients/macos/vellum-assistantTests/ScrollCoordinatorTests.swift
+++ b/clients/macos/vellum-assistantTests/ScrollCoordinatorTests.swift
@@ -1,0 +1,520 @@
+import XCTest
+@testable import VellumAssistantLib
+
+@MainActor
+final class ScrollCoordinatorTests: XCTestCase {
+    private var coordinator: ScrollCoordinator!
+
+    override func setUp() {
+        super.setUp()
+        coordinator = ScrollCoordinator()
+    }
+
+    override func tearDown() {
+        coordinator = nil
+        super.tearDown()
+    }
+
+    // MARK: - Initial State
+
+    func testInitialModeIsInitialLoad() {
+        XCTAssertEqual(coordinator.mode, .initialLoad)
+    }
+
+    func testInitialStateAllowsAutoScroll() {
+        XCTAssertTrue(coordinator.mode.allowsAutoScroll)
+    }
+
+    func testInitialStateIsNotFollowingBottom() {
+        // initialLoad allows auto-scroll but isFollowingBottom is only
+        // true for .followingBottom (and stabilizing from followingBottom).
+        XCTAssertFalse(coordinator.isFollowingBottom)
+    }
+
+    func testInitialStateHasNotBeenInteracted() {
+        XCTAssertFalse(coordinator.hasBeenInteracted)
+    }
+
+    func testInitialStateIsAtBottom() {
+        XCTAssertTrue(coordinator.isAtBottom)
+    }
+
+    // MARK: - Mode: Following Bottom vs Free Browsing
+
+    func testManualBrowseIntentDetachesFromFollowingBottom() {
+        // Transition to followingBottom first.
+        coordinator.handle(.sendingChanged(isSending: true))
+        XCTAssertTrue(coordinator.isFollowingBottom)
+
+        let intents = coordinator.handle(.manualBrowseIntent)
+
+        XCTAssertFalse(coordinator.isFollowingBottom)
+        XCTAssertEqual(coordinator.mode, .freeBrowsing)
+        XCTAssertTrue(intents.contains(.cancelRecoveryWindow),
+                      "Should cancel recovery when user scrolls away")
+    }
+
+    func testManualBrowseIntentDetachesFromInitialLoad() {
+        XCTAssertEqual(coordinator.mode, .initialLoad)
+
+        let intents = coordinator.handle(.manualBrowseIntent)
+
+        XCTAssertEqual(coordinator.mode, .freeBrowsing)
+        XCTAssertTrue(coordinator.hasBeenInteracted)
+        XCTAssertTrue(intents.contains(.cancelRecoveryWindow))
+    }
+
+    func testManualBrowseIntentIsNoopInFreeBrowsing() {
+        coordinator.handle(.manualBrowseIntent)
+        XCTAssertEqual(coordinator.mode, .freeBrowsing)
+
+        // Second browse intent should not change anything.
+        let intents = coordinator.handle(.manualBrowseIntent)
+        XCTAssertEqual(coordinator.mode, .freeBrowsing)
+        // No cancelRecoveryWindow because we were already in free-browsing.
+        XCTAssertFalse(intents.contains(.cancelRecoveryWindow))
+    }
+
+    func testSendingReattachesToFollowingBottom() {
+        // Start in free-browsing.
+        coordinator.handle(.manualBrowseIntent)
+        XCTAssertFalse(coordinator.isFollowingBottom)
+
+        let intents = coordinator.handle(.sendingChanged(isSending: true))
+
+        XCTAssertTrue(coordinator.isFollowingBottom)
+        XCTAssertTrue(intents.contains(.scrollToBottom(animated: true)))
+        XCTAssertTrue(intents.contains(.startRecoveryWindow))
+    }
+
+    func testSendStoppedDoesNotChangeMode() {
+        coordinator.handle(.sendingChanged(isSending: true))
+        XCTAssertTrue(coordinator.isFollowingBottom)
+
+        let intents = coordinator.handle(.sendingChanged(isSending: false))
+
+        XCTAssertTrue(coordinator.isFollowingBottom)
+        XCTAssertTrue(intents.isEmpty, "Stopping send should not produce intents")
+    }
+
+    // MARK: - Hysteresis (Bottom Detection)
+
+    func testHysteresisStaysAtBottomWithinLeaveThreshold() {
+        // Start at bottom.
+        XCTAssertTrue(coordinator.isAtBottom)
+
+        // Distance within the 30pt leave threshold — stay at bottom.
+        coordinator.updateBottomState(distanceFromBottom: 25)
+        XCTAssertTrue(coordinator.isAtBottom,
+                      "Should stay at bottom when within 30pt leave threshold")
+    }
+
+    func testHysteresisLeavesBottomBeyondLeaveThreshold() {
+        XCTAssertTrue(coordinator.isAtBottom)
+
+        // Distance beyond the 30pt leave threshold.
+        coordinator.updateBottomState(distanceFromBottom: 35)
+        XCTAssertFalse(coordinator.isAtBottom,
+                       "Should leave bottom when beyond 30pt leave threshold")
+    }
+
+    func testHysteresisReentersBottomOnlyWithinEnterThreshold() {
+        // Leave the bottom zone first.
+        coordinator.updateBottomState(distanceFromBottom: 35)
+        XCTAssertFalse(coordinator.isAtBottom)
+
+        // 15pt — between enter (10pt) and leave (30pt) thresholds.
+        // Should NOT re-enter because we're using the tighter enter threshold.
+        coordinator.updateBottomState(distanceFromBottom: 15)
+        XCTAssertFalse(coordinator.isAtBottom,
+                       "Should not re-enter bottom when between enter and leave thresholds")
+
+        // 8pt — within the 10pt enter threshold.
+        coordinator.updateBottomState(distanceFromBottom: 8)
+        XCTAssertTrue(coordinator.isAtBottom,
+                      "Should re-enter bottom when within 10pt enter threshold")
+    }
+
+    func testHysteresisNonFiniteDistanceIsNotAtBottom() {
+        coordinator.updateBottomState(distanceFromBottom: .infinity)
+        XCTAssertFalse(coordinator.isAtBottom,
+                       "Non-finite distance should not be considered at bottom")
+    }
+
+    func testHysteresisNegativeDistanceIsAtBottom() {
+        // Negative distance means past the bottom — should be at bottom.
+        coordinator.updateBottomState(distanceFromBottom: -5)
+        XCTAssertTrue(coordinator.isAtBottom,
+                      "Negative distance (past bottom) should be considered at bottom")
+    }
+
+    // MARK: - Reattach on Idle at Bottom
+
+    func testReattachOnIdleAtBottom() {
+        // Detach.
+        coordinator.handle(.manualBrowseIntent)
+        XCTAssertEqual(coordinator.mode, .freeBrowsing)
+
+        // Simulate scrolling back to bottom.
+        coordinator.updateBottomState(distanceFromBottom: 5)
+        XCTAssertTrue(coordinator.isAtBottom)
+
+        // Phase goes to idle — should reattach.
+        coordinator.handle(.scrollPhaseChanged(phase: .interacting))
+        coordinator.handle(.scrollPhaseChanged(phase: .idle))
+
+        XCTAssertTrue(coordinator.isFollowingBottom,
+                      "Should reattach to following bottom when scroll settles at bottom")
+    }
+
+    func testNoReattachOnIdleWhenNotAtBottom() {
+        coordinator.handle(.manualBrowseIntent)
+        XCTAssertEqual(coordinator.mode, .freeBrowsing)
+
+        // Not at bottom.
+        coordinator.updateBottomState(distanceFromBottom: 100)
+        XCTAssertFalse(coordinator.isAtBottom)
+
+        // Phase goes to idle — should NOT reattach.
+        coordinator.handle(.scrollPhaseChanged(phase: .interacting))
+        coordinator.handle(.scrollPhaseChanged(phase: .idle))
+
+        XCTAssertEqual(coordinator.mode, .freeBrowsing,
+                       "Should stay in free-browsing when scroll settles away from bottom")
+    }
+
+    // MARK: - Stale Momentum Suppression
+
+    func testStaleMomentumSuppressedAfterCTATap() {
+        // Simulate CTA tap.
+        _ = coordinator.requestUserInitiatedPin()
+        XCTAssertTrue(coordinator.isFollowingBottom)
+
+        // Simulate stale upward momentum in decelerating phase.
+        coordinator.handle(.scrollPhaseChanged(phase: .decelerating))
+        let intents = coordinator.handle(.manualBrowseIntent)
+
+        XCTAssertTrue(coordinator.isFollowingBottom,
+                      "Should NOT detach on stale decelerating momentum after CTA tap")
+        XCTAssertTrue(intents.isEmpty,
+                      "Should produce no intents for stale momentum")
+    }
+
+    func testFreshInteractionOverridesCTATap() {
+        // Simulate CTA tap.
+        _ = coordinator.requestUserInitiatedPin()
+        XCTAssertTrue(coordinator.isFollowingBottom)
+
+        // Simulate fresh user interaction (interacting phase, not decelerating).
+        coordinator.handle(.scrollPhaseChanged(phase: .interacting))
+        let intents = coordinator.handle(.manualBrowseIntent)
+
+        XCTAssertFalse(coordinator.isFollowingBottom,
+                       "Should detach on fresh user interaction even after CTA tap")
+        XCTAssertTrue(intents.contains(.cancelRecoveryWindow))
+    }
+
+    // MARK: - Manual Expansion Detach
+
+    func testManualExpansionDetachesAndStabilizes() {
+        coordinator.handle(.sendingChanged(isSending: true))
+        XCTAssertTrue(coordinator.isFollowingBottom)
+
+        let intents = coordinator.handle(.manualExpansion)
+
+        XCTAssertTrue(coordinator.isSuppressed,
+                      "Should enter stabilization after manual expansion")
+        // The pre-stabilization mode was freeBrowsing (expansion detaches first).
+        XCTAssertTrue(intents.contains(.cancelRecoveryWindow))
+        XCTAssertTrue(intents.contains(.showScrollToLatest))
+    }
+
+    func testManualExpansionInFreeBrowsingStabilizes() {
+        coordinator.handle(.manualBrowseIntent)
+        XCTAssertEqual(coordinator.mode, .freeBrowsing)
+
+        let intents = coordinator.handle(.manualExpansion)
+
+        XCTAssertTrue(coordinator.isSuppressed,
+                      "Should enter stabilization even when already free-browsing")
+        XCTAssertTrue(intents.contains(.showScrollToLatest))
+    }
+
+    func testManualExpansionStabilizationRestoresFreeBrowsing() {
+        coordinator.handle(.sendingChanged(isSending: true))
+        coordinator.handle(.manualExpansion)
+        XCTAssertTrue(coordinator.isSuppressed)
+
+        // End stabilization — should restore to free-browsing (not followingBottom).
+        coordinator.endStabilization()
+        XCTAssertEqual(coordinator.mode, .freeBrowsing,
+                       "After expansion stabilization, should stay in free-browsing")
+    }
+
+    // MARK: - Deep-Link Anchor Jumps
+
+    func testAnchorRequestTransitionsToProgrammaticScroll() {
+        let anchorId = ScrollCoordinator.AnchorID(UUID())
+
+        let intents = coordinator.handle(.anchorRequested(id: anchorId))
+
+        if case .programmaticScroll(let id) = coordinator.mode {
+            XCTAssertEqual(id, anchorId)
+        } else {
+            XCTFail("Expected programmaticScroll mode after anchor request")
+        }
+        XCTAssertEqual(coordinator.pendingAnchor, anchorId)
+        XCTAssertTrue(intents.contains(.cancelRecoveryWindow))
+    }
+
+    func testAnchorResolvedScrollsToMessage() {
+        let anchorId = ScrollCoordinator.AnchorID(UUID())
+        coordinator.handle(.anchorRequested(id: anchorId))
+
+        let intents = coordinator.handle(.anchorResolved(id: anchorId))
+
+        XCTAssertNil(coordinator.pendingAnchor)
+        XCTAssertTrue(intents.contains(.scrollToMessage(id: anchorId, anchor: .center)),
+                      "Should scroll to the resolved anchor at center")
+    }
+
+    func testAnchorResolvedForWrongIdIsIgnored() {
+        let requestedId = ScrollCoordinator.AnchorID(UUID())
+        let wrongId = ScrollCoordinator.AnchorID(UUID())
+        coordinator.handle(.anchorRequested(id: requestedId))
+
+        let intents = coordinator.handle(.anchorResolved(id: wrongId))
+
+        XCTAssertTrue(intents.isEmpty,
+                      "Should ignore resolution for a non-matching anchor ID")
+        XCTAssertEqual(coordinator.pendingAnchor, requestedId)
+    }
+
+    // MARK: - Resize Recovery
+
+    func testContainerWidthChangedInFollowingModeRecoverToBottom() {
+        coordinator.handle(.sendingChanged(isSending: true))
+        XCTAssertTrue(coordinator.isFollowingBottom)
+
+        let intents = coordinator.handle(.containerWidthChanged)
+
+        XCTAssertTrue(intents.contains(.startRecoveryWindow))
+        XCTAssertTrue(intents.contains(.scrollToBottom(animated: false)))
+    }
+
+    func testContainerWidthChangedInFreeBrowsingStabilizes() {
+        coordinator.handle(.manualBrowseIntent)
+        XCTAssertEqual(coordinator.mode, .freeBrowsing)
+
+        coordinator.handle(.containerWidthChanged)
+
+        XCTAssertTrue(coordinator.isSuppressed,
+                      "Should stabilize during resize in free-browsing")
+    }
+
+    func testContainerWidthStabilizationRestoresFreeBrowsing() {
+        coordinator.handle(.manualBrowseIntent)
+        coordinator.handle(.containerWidthChanged)
+        XCTAssertTrue(coordinator.isSuppressed)
+
+        coordinator.endStabilization()
+        XCTAssertEqual(coordinator.mode, .freeBrowsing)
+    }
+
+    // MARK: - Message Count Changed
+
+    func testMessageCountChangedPinsToBottomInFollowingMode() {
+        coordinator.handle(.sendingChanged(isSending: true))
+        XCTAssertTrue(coordinator.isFollowingBottom)
+
+        let intents = coordinator.handle(.messageCountChanged)
+
+        XCTAssertTrue(intents.contains(.scrollToBottom(animated: true)))
+    }
+
+    func testMessageCountChangedDoesNotPinInFreeBrowsing() {
+        coordinator.handle(.manualBrowseIntent)
+        XCTAssertEqual(coordinator.mode, .freeBrowsing)
+
+        let intents = coordinator.handle(.messageCountChanged)
+
+        XCTAssertTrue(intents.isEmpty,
+                      "Should not auto-pin when in free-browsing mode")
+    }
+
+    func testMessageCountChangedDoesNotPinWhenStabilizing() {
+        coordinator.handle(.sendingChanged(isSending: true))
+        coordinator.handle(.manualExpansion)
+        XCTAssertTrue(coordinator.isSuppressed)
+
+        let intents = coordinator.handle(.messageCountChanged)
+
+        XCTAssertTrue(intents.isEmpty,
+                      "Should not auto-pin when stabilizing")
+    }
+
+    // MARK: - Appeared Event
+
+    func testAppearedStartsRecoveryInInitialLoad() {
+        let intents = coordinator.handle(.appeared)
+
+        XCTAssertTrue(intents.contains(.startRecoveryWindow))
+        XCTAssertTrue(intents.contains(.scrollToBottom(animated: false)))
+    }
+
+    func testAppearedStartsRecoveryInFollowingBottom() {
+        coordinator.handle(.sendingChanged(isSending: true))
+        XCTAssertTrue(coordinator.isFollowingBottom)
+
+        let intents = coordinator.handle(.appeared)
+
+        XCTAssertTrue(intents.contains(.startRecoveryWindow))
+    }
+
+    func testAppearedDoesNotRecoverInFreeBrowsing() {
+        coordinator.handle(.manualBrowseIntent)
+
+        let intents = coordinator.handle(.appeared)
+
+        XCTAssertTrue(intents.isEmpty,
+                      "Should not start recovery when user has scrolled away")
+    }
+
+    // MARK: - User-Initiated Pin (CTA)
+
+    func testUserInitiatedPinAlwaysSucceeds() {
+        // Even when in free-browsing + stabilizing.
+        coordinator.handle(.manualBrowseIntent)
+        coordinator.handle(.containerWidthChanged)
+        XCTAssertTrue(coordinator.isSuppressed)
+
+        let intents = coordinator.requestUserInitiatedPin()
+
+        XCTAssertTrue(coordinator.isFollowingBottom)
+        XCTAssertTrue(intents.contains(.hideIndicators))
+        XCTAssertTrue(intents.contains(.startRecoveryWindow))
+        XCTAssertTrue(intents.contains(.scrollToBottom(animated: true)))
+    }
+
+    func testUserInitiatedPinFromFreeBrowsing() {
+        coordinator.handle(.manualBrowseIntent)
+        XCTAssertEqual(coordinator.mode, .freeBrowsing)
+
+        let intents = coordinator.requestUserInitiatedPin()
+
+        XCTAssertTrue(coordinator.isFollowingBottom)
+        XCTAssertTrue(intents.contains(.scrollToBottom(animated: true)))
+    }
+
+    // MARK: - Stabilization
+
+    func testOverlappingStabilizationWaitsForAllWindows() {
+        coordinator.handle(.sendingChanged(isSending: true))
+
+        // Window 1: resize.
+        coordinator.handle(.containerWidthChanged)
+        XCTAssertTrue(coordinator.isSuppressed)
+
+        // Window 2: expansion (overlapping).
+        coordinator.handle(.manualExpansion)
+        XCTAssertTrue(coordinator.isSuppressed)
+
+        // Window 1 completes — should still be stabilizing.
+        coordinator.endStabilization()
+        XCTAssertTrue(coordinator.isSuppressed,
+                      "Should remain stabilizing while overlapping windows are active")
+
+        // Window 2 completes — now should exit.
+        coordinator.endStabilization()
+        XCTAssertFalse(coordinator.isSuppressed,
+                       "Should exit stabilization after all windows complete")
+    }
+
+    func testStabilizationPreservesFollowingBottom() {
+        coordinator.handle(.sendingChanged(isSending: true))
+        XCTAssertTrue(coordinator.isFollowingBottom)
+
+        coordinator.handle(.containerWidthChanged)
+        XCTAssertTrue(coordinator.isSuppressed)
+        XCTAssertTrue(coordinator.isFollowingBottom,
+                      "isFollowingBottom should reflect pre-stabilization mode")
+
+        coordinator.endStabilization()
+        XCTAssertTrue(coordinator.isFollowingBottom)
+    }
+
+    func testStabilizationSuppressesPinRequests() {
+        coordinator.handle(.sendingChanged(isSending: true))
+        coordinator.handle(.containerWidthChanged)
+        XCTAssertTrue(coordinator.isSuppressed)
+
+        // Message count change while stabilizing should not produce pin intents.
+        let intents = coordinator.handle(.messageCountChanged)
+        XCTAssertTrue(intents.isEmpty)
+    }
+
+    // MARK: - Reset
+
+    func testResetRestoresInitialState() {
+        // Put coordinator in a non-initial state.
+        coordinator.handle(.sendingChanged(isSending: true))
+        coordinator.handle(.manualBrowseIntent)
+        coordinator.updateBottomState(distanceFromBottom: 100)
+        let anchorId = ScrollCoordinator.AnchorID(UUID())
+        coordinator.handle(.anchorRequested(id: anchorId))
+
+        coordinator.reset()
+
+        XCTAssertEqual(coordinator.mode, .initialLoad)
+        XCTAssertEqual(coordinator.phase, .idle)
+        XCTAssertFalse(coordinator.isAtBottom)
+        XCTAssertFalse(coordinator.isFollowingBottom)
+        XCTAssertFalse(coordinator.hasBeenInteracted)
+        XCTAssertNil(coordinator.pendingAnchor)
+    }
+
+    // MARK: - ShowScrollToLatest Visibility
+
+    func testShowScrollToLatestInFreeBrowsing() {
+        coordinator.handle(.manualBrowseIntent)
+        XCTAssertTrue(coordinator.mode.showsScrollToLatest)
+    }
+
+    func testShowScrollToLatestDuringStabilizingFromFreeBrowsing() {
+        coordinator.handle(.manualBrowseIntent)
+        coordinator.handle(.containerWidthChanged)
+        XCTAssertTrue(coordinator.mode.showsScrollToLatest,
+                      "CTA should remain visible during stabilization from free-browsing")
+    }
+
+    func testShowScrollToLatestFalseInFollowingBottom() {
+        coordinator.handle(.sendingChanged(isSending: true))
+        XCTAssertFalse(coordinator.mode.showsScrollToLatest)
+    }
+
+    func testShowScrollToLatestFalseInInitialLoad() {
+        XCTAssertFalse(coordinator.mode.showsScrollToLatest)
+    }
+
+    // MARK: - No View Dependencies
+
+    /// Verifies the coordinator has no SwiftUI imports or view references.
+    /// This is a compile-time guarantee — this test exists as documentation.
+    func testCoordinatorIsPurePolicy() {
+        // ScrollCoordinator only imports Foundation.
+        // If it imported SwiftUI, this file would need to import it too,
+        // and the coordinator would no longer be a pure policy object.
+        //
+        // The types it exposes (Mode, Phase, OutputIntent, etc.) are all
+        // value types with no view references. ScrollPosition, ScrollGeometrySnapshot,
+        // and SwiftUI view types are not referenced anywhere in the coordinator.
+        let _ = coordinator.mode
+        let _ = coordinator.phase
+        let _ = coordinator.isAtBottom
+        let _ = coordinator.isFollowingBottom
+        let _ = coordinator.isSuppressed
+        let _ = coordinator.hasBeenInteracted
+        let _ = coordinator.pendingAnchor
+        // All pass — the coordinator is a pure policy object.
+    }
+}


### PR DESCRIPTION
## Summary
- Add ScrollCoordinator with explicit input events and output intents for scroll policy
- Model following-bottom, anchor jumps, search jumps, resize recovery, and manual detach
- Add ScrollCoordinatorTests locking current hysteresis and auto-follow detach rules

Part of plan: macos-chat-surface-stabilization.md (PR 5 of 11)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24389" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
