### PR TITLE
feat(clients): add async import polling to PlatformMigrationClient

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
@@ -392,6 +392,31 @@ struct AssistantTransferSection: View {
             throw TransferError.importFailed(message: "HTTP \(statusCode)")
         }
 
+        // Handle async import: 202 means the job was accepted and we need to poll
+        if statusCode == 202 {
+            guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let jobId = json["job_id"] as? String else {
+                throw TransferError.importFailed(message: "Import accepted but no job ID returned")
+            }
+
+            let pollInterval: UInt64 = 5_000_000_000 // 5 seconds
+            let timeout: TimeInterval = 600 // 10 minutes
+            let start = Date()
+
+            while Date().timeIntervalSince(start) < timeout {
+                try await Task.sleep(nanoseconds: pollInterval)
+                let status = try await PlatformMigrationClient.pollImportStatus(jobId: jobId)
+
+                if status.status == "complete" {
+                    return
+                }
+                if status.status == "failed" {
+                    throw TransferError.importFailed(message: status.error ?? "Import job failed")
+                }
+            }
+            throw TransferError.importFailed(message: "Import timed out after 10 minutes")
+        }
+
         if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
            let success = json["success"] as? Bool, !success {
             let errorMsg = (json["error"] as? String) ?? "Import reported failure"

--- a/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
@@ -622,6 +622,31 @@ struct TeleportSection: View {
             throw TeleportError.importFailed(message: "HTTP \(statusCode)")
         }
 
+        // Handle async import: 202 means the job was accepted and we need to poll
+        if statusCode == 202 {
+            guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let jobId = json["job_id"] as? String else {
+                throw TeleportError.importFailed(message: "Import accepted but no job ID returned")
+            }
+
+            let pollInterval: UInt64 = 5_000_000_000 // 5 seconds
+            let timeout: TimeInterval = 600 // 10 minutes
+            let start = Date()
+
+            while Date().timeIntervalSince(start) < timeout {
+                try await Task.sleep(nanoseconds: pollInterval)
+                let status = try await PlatformMigrationClient.pollImportStatus(jobId: jobId)
+
+                if status.status == "complete" {
+                    return
+                }
+                if status.status == "failed" {
+                    throw TeleportError.importFailed(message: status.error ?? "Import job failed")
+                }
+            }
+            throw TeleportError.importFailed(message: "Import timed out after 10 minutes")
+        }
+
         if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
            let success = json["success"] as? Bool, !success {
             let errorMsg = (json["error"] as? String) ?? "Import reported failure"

--- a/clients/shared/Network/PlatformMigrationClient.swift
+++ b/clients/shared/Network/PlatformMigrationClient.swift
@@ -26,6 +26,15 @@ public enum PlatformMigrationClient {
         }
     }
 
+    /// Status of an asynchronous import job returned by the polling endpoint.
+    public struct ImportJobStatus {
+        public let status: String
+        public let jobId: String?
+        public let error: String?
+        /// Raw result data — only present when status == "complete"
+        public let resultData: Data?
+    }
+
     // MARK: - Errors
 
     /// Errors specific to platform migration requests.
@@ -196,6 +205,47 @@ public enum PlatformMigrationClient {
         let (data, statusCode) = try await executeWithRetry(request: request, label: "import-from-gcs")
 
         return (statusCode: statusCode, data: data)
+    }
+
+    /// Polls the status of an asynchronous import job.
+    ///
+    /// - Parameter jobId: The job ID returned by `importFromGcs` when it responds with 202.
+    /// - Returns: An `ImportJobStatus` with the current status, optional error, and result data.
+    /// - Throws: `PlatformMigrationError` on auth or request failures.
+    public static func pollImportStatus(jobId: String) async throws -> ImportJobStatus {
+        let (baseURL, token, orgId) = try resolveAuthContext()
+
+        guard let url = URL(string: "\(baseURL)/v1/migrations/import/\(jobId)/status/") else {
+            throw PlatformMigrationError.requestFailed(statusCode: 0, detail: "Invalid URL")
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.timeoutInterval = 30
+        request.setValue(token, forHTTPHeaderField: "X-Session-Token")
+        if let orgId {
+            request.setValue(orgId, forHTTPHeaderField: "Vellum-Organization-Id")
+        }
+
+        let (data, statusCode) = try await executeWithRetry(request: request, label: "import-status")
+
+        guard statusCode == 200 else {
+            throw PlatformMigrationError.requestFailed(statusCode: statusCode, detail: "Import status check failed")
+        }
+
+        // Parse status and error from top level, keep raw data for result
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] ?? [:]
+        let status = json["status"] as? String ?? "unknown"
+        let jobIdValue = json["job_id"] as? String
+        let error = json["error"] as? String
+
+        // Re-serialize result sub-object if present
+        var resultData: Data? = nil
+        if let result = json["result"] {
+            resultData = try? JSONSerialization.data(withJSONObject: result)
+        }
+
+        return ImportJobStatus(status: status, jobId: jobIdValue, error: error, resultData: resultData)
     }
 
     /// Imports a migration bundle by sending the raw data directly to the platform.


### PR DESCRIPTION
## Summary
- Add ImportJobStatus struct and pollImportStatus method to PlatformMigrationClient
- Handle 202 responses in TeleportSection and AssistantTransferSection with polling loop
- Poll every 5 seconds with 10-minute timeout

Part of plan: async-import-polling.md (PR 3 of 3)

## Test plan
- [ ] Verify TeleportSection handles 202 responses with async polling
- [ ] Verify AssistantTransferSection handles 202 responses with async polling
- [ ] Verify synchronous error responses (400/404/409/413) still work
- [ ] Verify "failed" status throws with the error message
- [ ] Verify 10-minute timeout is enforced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24390" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
