### PR TITLE
Fix duplicate embed workers after backend cache resets

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -790,9 +790,7 @@ export async function runDaemon(): Promise<void> {
                       },
                     }
                   : {}),
-                ...(options.taskRunId
-                  ? { taskRunId: options.taskRunId }
-                  : {}),
+                ...(options.taskRunId ? { taskRunId: options.taskRunId } : {}),
               }
             : undefined,
         );
@@ -1240,10 +1238,11 @@ export async function runDaemon(): Promise<void> {
         if (!runtimeManager.isReady()) {
           log.info("Downloading embedding runtime in background...");
           await runtimeManager.ensureInstalled();
-          // Reset the localBackendBroken flag so auto mode retries local embeddings
-          const { clearEmbeddingBackendCache } =
+          // Reset the sticky local-backend failure flag so auto mode retries
+          // local embeddings without evicting a worker that may already be live.
+          const { resetLocalEmbeddingFailureState } =
             await import("../memory/embedding-backend.js");
-          clearEmbeddingBackendCache();
+          resetLocalEmbeddingFailureState();
           log.info("Embedding runtime download complete");
         }
       } catch (err) {

--- a/assistant/src/memory/embedding-backend.test.ts
+++ b/assistant/src/memory/embedding-backend.test.ts
@@ -50,4 +50,26 @@ describe("embedding backend cache invalidation", () => {
     const secondSelection = await selectEmbeddingBackend(LOCAL_CONFIG);
     expect(secondSelection.backend).toBe(firstSelection.backend);
   });
+
+  test("resetLocalEmbeddingFailureState clears poisoned local backend retry state", async () => {
+    const firstSelection = await selectEmbeddingBackend(LOCAL_CONFIG);
+    expect(firstSelection.backend).not.toBeNull();
+
+    const poisonedInitPromise = Promise.reject(new Error("poisoned"));
+    poisonedInitPromise.catch(() => {});
+
+    const backend = firstSelection.backend as {
+      delegate: unknown;
+      initPromise: Promise<unknown> | null;
+    };
+    backend.delegate = null;
+    backend.initPromise = poisonedInitPromise;
+
+    resetLocalEmbeddingFailureState();
+
+    expect(backend.initPromise).toBeNull();
+
+    const secondSelection = await selectEmbeddingBackend(LOCAL_CONFIG);
+    expect(secondSelection.backend).toBe(firstSelection.backend);
+  });
 });

--- a/assistant/src/memory/embedding-backend.test.ts
+++ b/assistant/src/memory/embedding-backend.test.ts
@@ -58,7 +58,7 @@ describe("embedding backend cache invalidation", () => {
     const poisonedInitPromise = Promise.reject(new Error("poisoned"));
     poisonedInitPromise.catch(() => {});
 
-    const backend = firstSelection.backend as {
+    const backend = firstSelection.backend as unknown as {
       delegate: unknown;
       initPromise: Promise<unknown> | null;
     };

--- a/assistant/src/memory/embedding-backend.test.ts
+++ b/assistant/src/memory/embedding-backend.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import type { AssistantConfig } from "../config/types.js";
+import {
+  clearEmbeddingBackendCache,
+  resetLocalEmbeddingFailureState,
+  selectEmbeddingBackend,
+} from "./embedding-backend.js";
+
+const LOCAL_CONFIG = {
+  memory: {
+    embeddings: {
+      provider: "local",
+      localModel: "BAAI/bge-small-en-v1.5",
+    },
+  },
+} as unknown as AssistantConfig;
+
+describe("embedding backend cache invalidation", () => {
+  afterEach(() => {
+    clearEmbeddingBackendCache();
+  });
+
+  test("clearEmbeddingBackendCache disposes cached backends before clearing", async () => {
+    const firstSelection = await selectEmbeddingBackend(LOCAL_CONFIG);
+    expect(firstSelection.backend).not.toBeNull();
+
+    const dispose = mock();
+    (firstSelection.backend as { dispose?: () => void }).dispose = dispose;
+
+    clearEmbeddingBackendCache();
+
+    expect(dispose).toHaveBeenCalledTimes(1);
+
+    const secondSelection = await selectEmbeddingBackend(LOCAL_CONFIG);
+    expect(secondSelection.backend).not.toBe(firstSelection.backend);
+  });
+
+  test("resetLocalEmbeddingFailureState preserves live cached backends", async () => {
+    const firstSelection = await selectEmbeddingBackend(LOCAL_CONFIG);
+    expect(firstSelection.backend).not.toBeNull();
+
+    const dispose = mock();
+    (firstSelection.backend as { dispose?: () => void }).dispose = dispose;
+
+    resetLocalEmbeddingFailureState();
+
+    expect(dispose).not.toHaveBeenCalled();
+
+    const secondSelection = await selectEmbeddingBackend(LOCAL_CONFIG);
+    expect(secondSelection.backend).toBe(firstSelection.backend);
+  });
+});

--- a/assistant/src/memory/embedding-backend.ts
+++ b/assistant/src/memory/embedding-backend.ts
@@ -67,6 +67,10 @@ class LazyLocalEmbeddingBackend implements EmbeddingBackend {
     }
   }
 
+  dispose(): void {
+    this.delegate?.dispose?.();
+  }
+
   private async getDelegate(): Promise<EmbeddingBackend> {
     if (this.delegate) return this.delegate;
     if (!this.initPromise) {
@@ -176,9 +180,24 @@ function putInVectorCache(
 
 /** Clear cached embedding backends and the in-memory vector cache. */
 export function clearEmbeddingBackendCache(): void {
+  for (const backend of new Set(backendCache.values())) {
+    try {
+      backend.dispose?.();
+    } catch (err) {
+      log.warn(
+        { err, provider: backend.provider, model: backend.model },
+        "Failed to dispose embedding backend during cache clear",
+      );
+    }
+  }
   backendCache.clear();
   vectorCache.clear();
   vectorCacheBytes = 0;
+  localBackendBroken = false;
+}
+
+/** Reset the sticky local-backend failure flag without evicting live backends. */
+export function resetLocalEmbeddingFailureState(): void {
   localBackendBroken = false;
 }
 
@@ -243,6 +262,7 @@ export interface EmbeddingBackend {
     inputs: EmbeddingInput[],
     options?: EmbeddingRequestOptions,
   ): Promise<number[][]>;
+  dispose?(): void;
 }
 
 export interface EmbeddingBackendSelection {

--- a/assistant/src/memory/embedding-backend.ts
+++ b/assistant/src/memory/embedding-backend.ts
@@ -71,6 +71,12 @@ class LazyLocalEmbeddingBackend implements EmbeddingBackend {
     this.delegate?.dispose?.();
   }
 
+  resetForRetry(): void {
+    if (!this.delegate) {
+      this.initPromise = null;
+    }
+  }
+
   private async getDelegate(): Promise<EmbeddingBackend> {
     if (this.delegate) return this.delegate;
     if (!this.initPromise) {
@@ -199,6 +205,11 @@ export function clearEmbeddingBackendCache(): void {
 /** Reset the sticky local-backend failure flag without evicting live backends. */
 export function resetLocalEmbeddingFailureState(): void {
   localBackendBroken = false;
+  for (const backend of new Set(backendCache.values())) {
+    if (backend instanceof LazyLocalEmbeddingBackend) {
+      backend.resetForRetry();
+    }
+  }
 }
 
 function cacheKey(provider: string, model: string, extras?: string[]): string {

--- a/assistant/src/memory/embedding-local.ts
+++ b/assistant/src/memory/embedding-local.ts
@@ -83,6 +83,8 @@ export class LocalEmbeddingBackend implements EmbeddingBackend {
     }
   >();
   private stdoutReaderActive = false;
+  private activeEmbeds = 0;
+  private disposeRequested = false;
 
   private readonly initGuard = new PromiseGuard<void>();
 
@@ -94,6 +96,9 @@ export class LocalEmbeddingBackend implements EmbeddingBackend {
     inputs: EmbeddingInput[],
     options?: EmbeddingRequestOptions,
   ): Promise<number[][]> {
+    if (this.disposeRequested) {
+      throw new Error("Local embedding backend is shutting down");
+    }
     if (inputs.length === 0) return [];
 
     const texts = inputs.map((i) => {
@@ -106,24 +111,30 @@ export class LocalEmbeddingBackend implements EmbeddingBackend {
     if (options?.signal?.aborted)
       throw new DOMException("Aborted", "AbortError");
 
-    await this.ensureInitialized();
+    this.activeEmbeds++;
+    try {
+      await this.ensureInitialized();
 
-    const results: number[][] = [];
-    const batchSize = 32;
-    for (let i = 0; i < texts.length; i += batchSize) {
-      if (options?.signal?.aborted)
-        throw new DOMException("Aborted", "AbortError");
-      const batch = texts.slice(i, i + batchSize);
-      const response = await this.sendRequest(batch);
-      if (response.error) {
-        throw new Error(`Embedding worker error: ${response.error}`);
+      const results: number[][] = [];
+      const batchSize = 32;
+      for (let i = 0; i < texts.length; i += batchSize) {
+        if (options?.signal?.aborted)
+          throw new DOMException("Aborted", "AbortError");
+        const batch = texts.slice(i, i + batchSize);
+        const response = await this.sendRequest(batch);
+        if (response.error) {
+          throw new Error(`Embedding worker error: ${response.error}`);
+        }
+        if (!response.vectors) {
+          throw new Error("Embedding worker returned no vectors");
+        }
+        results.push(...response.vectors);
       }
-      if (!response.vectors) {
-        throw new Error("Embedding worker returned no vectors");
-      }
-      results.push(...response.vectors);
+      return results;
+    } finally {
+      this.activeEmbeds--;
+      this.disposeIfIdle();
     }
-    return results;
   }
 
   private sendRequest(texts: string[]): Promise<WorkerResponse> {
@@ -146,6 +157,11 @@ export class LocalEmbeddingBackend implements EmbeddingBackend {
   private async ensureInitialized(): Promise<void> {
     if (this.workerProc) return;
     await this.initGuard.run(() => this.initialize());
+  }
+
+  dispose(): void {
+    this.disposeRequested = true;
+    this.disposeIfIdle();
   }
 
   private async initialize(): Promise<void> {
@@ -255,6 +271,8 @@ export class LocalEmbeddingBackend implements EmbeddingBackend {
       { pid: proc.pid, model: this.model },
       "Embedding worker process started",
     );
+
+    this.disposeIfIdle();
   }
 
   private drainStderr(stderr: ReadableStream<Uint8Array>): void {
@@ -355,6 +373,7 @@ export class LocalEmbeddingBackend implements EmbeddingBackend {
         if (pending) {
           this.pendingRequests.delete(msg.id);
           pending.resolve(msg);
+          this.disposeIfIdle();
         }
       }
     }
@@ -423,6 +442,29 @@ export class LocalEmbeddingBackend implements EmbeddingBackend {
       unlinkSync(this.getPidFilePath());
     } catch {
       // Best-effort
+    }
+  }
+
+  private disposeIfIdle(): void {
+    if (!this.disposeRequested) return;
+    if (this.activeEmbeds > 0) return;
+    if (this.initGuard.active) return;
+    if (this.pendingRequests.size > 0) return;
+    if (this.readyResolve || this.readyReject) return;
+
+    const proc = this.workerProc;
+    this.workerProc = null;
+    this.stdoutReaderActive = false;
+    this.stdoutBuffer = "";
+    this.initGuard.reset();
+    this.removePidFile();
+
+    if (!proc) return;
+
+    try {
+      proc.kill();
+    } catch {
+      // Worker may already be exiting
     }
   }
 }

--- a/assistant/src/memory/embedding-local.ts
+++ b/assistant/src/memory/embedding-local.ts
@@ -448,7 +448,6 @@ export class LocalEmbeddingBackend implements EmbeddingBackend {
   private disposeIfIdle(): void {
     if (!this.disposeRequested) return;
     if (this.activeEmbeds > 0) return;
-    if (this.initGuard.active) return;
     if (this.pendingRequests.size > 0) return;
     if (this.readyResolve || this.readyReject) return;
 


### PR DESCRIPTION
## Summary
- dispose cached embedding backends when invalidating the cache so local embed workers are not orphaned after config or credential refreshes
- keep the background embedding runtime warmup from evicting a live local backend just to reset the sticky failure flag
- add a regression test covering cache disposal and the non-evicting warmup reset path

## Original prompt
--safe It seems like multiple assistant embed workers can sometimes get spawned in platform can you track this down
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24391" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
