### PR TITLE
fix: add transient error resilience to macOS import polling loops

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
@@ -405,7 +405,16 @@ struct AssistantTransferSection: View {
 
             while Date().timeIntervalSince(start) < timeout {
                 try await Task.sleep(nanoseconds: pollInterval)
-                let status = try await PlatformMigrationClient.pollImportStatus(jobId: jobId)
+
+                let status: PlatformMigrationClient.ImportJobStatus
+                do {
+                    status = try await PlatformMigrationClient.pollImportStatus(jobId: jobId)
+                } catch is CancellationError {
+                    throw CancellationError()
+                } catch {
+                    // Transient polling error — retry on next cycle
+                    continue
+                }
 
                 if status.status == "complete" {
                     return

--- a/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
@@ -635,7 +635,16 @@ struct TeleportSection: View {
 
             while Date().timeIntervalSince(start) < timeout {
                 try await Task.sleep(nanoseconds: pollInterval)
-                let status = try await PlatformMigrationClient.pollImportStatus(jobId: jobId)
+
+                let status: PlatformMigrationClient.ImportJobStatus
+                do {
+                    status = try await PlatformMigrationClient.pollImportStatus(jobId: jobId)
+                } catch is CancellationError {
+                    throw CancellationError()
+                } catch {
+                    // Transient polling error — retry on next cycle
+                    continue
+                }
 
                 if status.status == "complete" {
                     return


### PR DESCRIPTION
## Summary
- Wrap pollImportStatus calls in do/catch in TeleportSection and AssistantTransferSection
- Transient network errors during polling are caught and retried, matching CLI behavior
- CancellationError is re-thrown to support task cancellation
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24393" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
