### PR TITLE
feat: async platform import-from-gcs with polling

### DIFF
--- a/cli/src/commands/teleport.ts
+++ b/cli/src/commands/teleport.ts
@@ -510,7 +510,9 @@ async function exportFromAssistant(
         status = await platformPollExportStatus(jobId, token, entry.runtimeUrl);
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
-        if (msg.includes("not found")) {
+        // Re-throw permanent errors (not found, auth failures, etc.)
+        // Only retry on transient network/connection errors
+        if (msg.includes("not found") || msg.includes("status check failed")) {
           throw err;
         }
         console.warn(`Polling failed, retrying... (${msg})`);
@@ -743,7 +745,12 @@ async function importToAssistant(
           );
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
-          if (msg.includes("not found")) {
+          // Re-throw permanent errors (not found, auth failures, etc.)
+          // Only retry on transient network/connection errors
+          if (
+            msg.includes("not found") ||
+            msg.includes("status check failed")
+          ) {
             throw err;
           }
           console.warn(`Polling failed, retrying... (${msg})`);

--- a/cli/src/commands/teleport.ts
+++ b/cli/src/commands/teleport.ts
@@ -23,6 +23,7 @@ import {
   platformUploadToSignedUrl,
   platformImportPreflightFromGcs,
   platformImportBundleFromGcs,
+  platformPollImportStatus,
 } from "../lib/platform-client.js";
 import {
   hatchDocker,
@@ -706,13 +707,71 @@ async function importToAssistant(
         : await platformImportBundle(bundleData, token, entry.runtimeUrl);
     } catch (err) {
       if (err instanceof Error && err.name === "TimeoutError") {
-        console.error("Error: Import request timed out after 5 minutes.");
+        console.error("Error: Import request timed out.");
         process.exit(1);
       }
       throw err;
     }
 
     handleImportStatusErrors(importResult.statusCode, entry.assistantId);
+
+    if (importResult.statusCode === 202) {
+      const jobId = (importResult.body as { job_id?: string }).job_id;
+      if (!jobId) {
+        console.error("Error: Import accepted but no job ID returned.");
+        process.exit(1);
+      }
+
+      const POLL_INTERVAL_MS = 5_000;
+      const TIMEOUT_MS = 10 * 60 * 1_000; // 10 minutes (platform staleness is 930s)
+      const startTime = Date.now();
+      const deadline = startTime + TIMEOUT_MS;
+
+      while (Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+
+        let status: {
+          status: string;
+          result?: Record<string, unknown>;
+          error?: string;
+        };
+        try {
+          status = await platformPollImportStatus(
+            jobId,
+            token,
+            entry.runtimeUrl,
+          );
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          if (msg.includes("not found")) {
+            throw err;
+          }
+          console.warn(`Polling failed, retrying... (${msg})`);
+          continue;
+        }
+
+        if (status.status === "complete") {
+          importResult = { statusCode: 200, body: status.result ?? {} };
+          break;
+        }
+
+        if (status.status === "failed") {
+          console.error(`Import failed: ${status.error ?? "unknown error"}`);
+          process.exit(1);
+        }
+
+        const elapsed = Math.round((Date.now() - startTime) / 1000);
+        process.stdout.write(`\rImporting... ${elapsed}s elapsed`);
+      }
+
+      // Clear the progress line
+      process.stdout.write("\r" + " ".repeat(40) + "\r");
+
+      if (importResult.statusCode === 202) {
+        console.error("Import timed out after 10 minutes.");
+        process.exit(1);
+      }
+    }
 
     const result = importResult.body as unknown as ImportResponse;
     printImportSummary(result);

--- a/cli/src/commands/teleport.ts
+++ b/cli/src/commands/teleport.ts
@@ -510,11 +510,19 @@ async function exportFromAssistant(
         status = await platformPollExportStatus(jobId, token, entry.runtimeUrl);
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
-        // Re-throw permanent errors (not found, auth failures, etc.)
-        // Only retry on transient network/connection errors
-        if (msg.includes("not found") || msg.includes("status check failed")) {
+        if (msg.includes("not found")) {
           throw err;
         }
+        // Re-throw permanent 4xx errors (auth, forbidden, etc.)
+        // but retry transient 5xx errors
+        const statusMatch = msg.match(/status check failed: (\d+)/);
+        if (statusMatch) {
+          const statusCode = parseInt(statusMatch[1], 10);
+          if (statusCode >= 400 && statusCode < 500) {
+            throw err;
+          }
+        }
+        // Transient error — retry
         console.warn(`Polling failed, retrying... (${msg})`);
         await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
         continue;
@@ -745,14 +753,19 @@ async function importToAssistant(
           );
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
-          // Re-throw permanent errors (not found, auth failures, etc.)
-          // Only retry on transient network/connection errors
-          if (
-            msg.includes("not found") ||
-            msg.includes("status check failed")
-          ) {
+          if (msg.includes("not found")) {
             throw err;
           }
+          // Re-throw permanent 4xx errors (auth, forbidden, etc.)
+          // but retry transient 5xx errors
+          const statusMatch = msg.match(/status check failed: (\d+)/);
+          if (statusMatch) {
+            const statusCode = parseInt(statusMatch[1], 10);
+            if (statusCode >= 400 && statusCode < 500) {
+              throw err;
+            }
+          }
+          // Transient error — retry
           console.warn(`Polling failed, retrying... (${msg})`);
           continue;
         }

--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -529,7 +529,7 @@ export async function platformImportBundleFromGcs(
       method: "POST",
       headers: await authHeaders(token, platformUrl),
       body: JSON.stringify({ bundle_key: bundleKey }),
-      signal: AbortSignal.timeout(300_000),
+      signal: AbortSignal.timeout(60_000),
     },
   );
 
@@ -542,4 +542,44 @@ export async function platformImportBundleFromGcs(
     unknown
   >;
   return { statusCode: response.status, body };
+}
+
+export async function platformPollImportStatus(
+  jobId: string,
+  token: string,
+  platformUrl?: string,
+): Promise<{
+  status: string;
+  result?: Record<string, unknown>;
+  error?: string;
+}> {
+  const resolvedUrl = platformUrl || getPlatformUrl();
+  const response = await fetch(
+    `${resolvedUrl}/v1/migrations/import/${jobId}/status/`,
+    {
+      headers: await authHeaders(token, platformUrl),
+    },
+  );
+
+  if (response.status === 404) {
+    throw new Error("Import job not found");
+  }
+
+  if (!response.ok) {
+    throw new Error(
+      `Import status check failed: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const body = (await response.json()) as {
+    status: string;
+    job_id?: string;
+    result?: Record<string, unknown>;
+    error?: string;
+  };
+  return {
+    status: body.status,
+    result: body.result,
+    error: body.error,
+  };
 }

--- a/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
@@ -412,13 +412,13 @@ struct AssistantTransferSection: View {
                 } catch is CancellationError {
                     throw CancellationError()
                 } catch let error as PlatformMigrationClient.PlatformMigrationError {
-                    // Only fail fast on permanent 4xx errors
-                    // Retry transient 5xx errors
-                    if case .requestFailed(let statusCode, _) = error, (400..<500).contains(statusCode) {
-                        throw error
+                    // Only retry on transient 5xx server errors
+                    // All other PlatformMigrationError cases (notAuthenticated, 4xx, etc.) are permanent
+                    if case .requestFailed(let statusCode, _) = error, (500..<600).contains(statusCode) {
+                        continue
                     }
-                    // Transient server error — retry on next cycle
-                    continue
+                    // Permanent error — fail fast
+                    throw error
                 } catch {
                     // Transient network errors — retry on next cycle
                     continue

--- a/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
@@ -412,8 +412,13 @@ struct AssistantTransferSection: View {
                 } catch is CancellationError {
                     throw CancellationError()
                 } catch let error as PlatformMigrationClient.PlatformMigrationError {
-                    // Permanent HTTP errors (auth, not found, etc.) — fail fast
-                    throw error
+                    // Only fail fast on permanent 4xx errors
+                    // Retry transient 5xx errors
+                    if case .requestFailed(let statusCode, _) = error, (400..<500).contains(statusCode) {
+                        throw error
+                    }
+                    // Transient server error — retry on next cycle
+                    continue
                 } catch {
                     // Transient network errors — retry on next cycle
                     continue

--- a/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
@@ -405,7 +405,16 @@ struct AssistantTransferSection: View {
 
             while Date().timeIntervalSince(start) < timeout {
                 try await Task.sleep(nanoseconds: pollInterval)
-                let status = try await PlatformMigrationClient.pollImportStatus(jobId: jobId)
+
+                let status: PlatformMigrationClient.ImportJobStatus
+                do {
+                    status = try await PlatformMigrationClient.pollImportStatus(jobId: jobId)
+                } catch is CancellationError {
+                    throw CancellationError()
+                } catch {
+                    // Transient polling error — retry on next cycle
+                    continue
+                }
 
                 if status.status == "complete" {
                     return

--- a/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
@@ -411,8 +411,11 @@ struct AssistantTransferSection: View {
                     status = try await PlatformMigrationClient.pollImportStatus(jobId: jobId)
                 } catch is CancellationError {
                     throw CancellationError()
+                } catch let error as PlatformMigrationClient.PlatformMigrationError {
+                    // Permanent HTTP errors (auth, not found, etc.) — fail fast
+                    throw error
                 } catch {
-                    // Transient polling error — retry on next cycle
+                    // Transient network errors — retry on next cycle
                     continue
                 }
 

--- a/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
@@ -392,6 +392,31 @@ struct AssistantTransferSection: View {
             throw TransferError.importFailed(message: "HTTP \(statusCode)")
         }
 
+        // Handle async import: 202 means the job was accepted and we need to poll
+        if statusCode == 202 {
+            guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let jobId = json["job_id"] as? String else {
+                throw TransferError.importFailed(message: "Import accepted but no job ID returned")
+            }
+
+            let pollInterval: UInt64 = 5_000_000_000 // 5 seconds
+            let timeout: TimeInterval = 600 // 10 minutes
+            let start = Date()
+
+            while Date().timeIntervalSince(start) < timeout {
+                try await Task.sleep(nanoseconds: pollInterval)
+                let status = try await PlatformMigrationClient.pollImportStatus(jobId: jobId)
+
+                if status.status == "complete" {
+                    return
+                }
+                if status.status == "failed" {
+                    throw TransferError.importFailed(message: status.error ?? "Import job failed")
+                }
+            }
+            throw TransferError.importFailed(message: "Import timed out after 10 minutes")
+        }
+
         if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
            let success = json["success"] as? Bool, !success {
             let errorMsg = (json["error"] as? String) ?? "Import reported failure"

--- a/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
@@ -622,6 +622,31 @@ struct TeleportSection: View {
             throw TeleportError.importFailed(message: "HTTP \(statusCode)")
         }
 
+        // Handle async import: 202 means the job was accepted and we need to poll
+        if statusCode == 202 {
+            guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let jobId = json["job_id"] as? String else {
+                throw TeleportError.importFailed(message: "Import accepted but no job ID returned")
+            }
+
+            let pollInterval: UInt64 = 5_000_000_000 // 5 seconds
+            let timeout: TimeInterval = 600 // 10 minutes
+            let start = Date()
+
+            while Date().timeIntervalSince(start) < timeout {
+                try await Task.sleep(nanoseconds: pollInterval)
+                let status = try await PlatformMigrationClient.pollImportStatus(jobId: jobId)
+
+                if status.status == "complete" {
+                    return
+                }
+                if status.status == "failed" {
+                    throw TeleportError.importFailed(message: status.error ?? "Import job failed")
+                }
+            }
+            throw TeleportError.importFailed(message: "Import timed out after 10 minutes")
+        }
+
         if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
            let success = json["success"] as? Bool, !success {
             let errorMsg = (json["error"] as? String) ?? "Import reported failure"

--- a/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
@@ -641,8 +641,11 @@ struct TeleportSection: View {
                     status = try await PlatformMigrationClient.pollImportStatus(jobId: jobId)
                 } catch is CancellationError {
                     throw CancellationError()
+                } catch let error as PlatformMigrationClient.PlatformMigrationError {
+                    // Permanent HTTP errors (auth, not found, etc.) — fail fast
+                    throw error
                 } catch {
-                    // Transient polling error — retry on next cycle
+                    // Transient network errors — retry on next cycle
                     continue
                 }
 

--- a/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
@@ -635,7 +635,16 @@ struct TeleportSection: View {
 
             while Date().timeIntervalSince(start) < timeout {
                 try await Task.sleep(nanoseconds: pollInterval)
-                let status = try await PlatformMigrationClient.pollImportStatus(jobId: jobId)
+
+                let status: PlatformMigrationClient.ImportJobStatus
+                do {
+                    status = try await PlatformMigrationClient.pollImportStatus(jobId: jobId)
+                } catch is CancellationError {
+                    throw CancellationError()
+                } catch {
+                    // Transient polling error — retry on next cycle
+                    continue
+                }
 
                 if status.status == "complete" {
                     return

--- a/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
@@ -642,8 +642,13 @@ struct TeleportSection: View {
                 } catch is CancellationError {
                     throw CancellationError()
                 } catch let error as PlatformMigrationClient.PlatformMigrationError {
-                    // Permanent HTTP errors (auth, not found, etc.) — fail fast
-                    throw error
+                    // Only fail fast on permanent 4xx errors
+                    // Retry transient 5xx errors
+                    if case .requestFailed(let statusCode, _) = error, (400..<500).contains(statusCode) {
+                        throw error
+                    }
+                    // Transient server error — retry on next cycle
+                    continue
                 } catch {
                     // Transient network errors — retry on next cycle
                     continue

--- a/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
@@ -642,13 +642,13 @@ struct TeleportSection: View {
                 } catch is CancellationError {
                     throw CancellationError()
                 } catch let error as PlatformMigrationClient.PlatformMigrationError {
-                    // Only fail fast on permanent 4xx errors
-                    // Retry transient 5xx errors
-                    if case .requestFailed(let statusCode, _) = error, (400..<500).contains(statusCode) {
-                        throw error
+                    // Only retry on transient 5xx server errors
+                    // All other PlatformMigrationError cases (notAuthenticated, 4xx, etc.) are permanent
+                    if case .requestFailed(let statusCode, _) = error, (500..<600).contains(statusCode) {
+                        continue
                     }
-                    // Transient server error — retry on next cycle
-                    continue
+                    // Permanent error — fail fast
+                    throw error
                 } catch {
                     // Transient network errors — retry on next cycle
                     continue

--- a/clients/shared/Network/PlatformMigrationClient.swift
+++ b/clients/shared/Network/PlatformMigrationClient.swift
@@ -26,6 +26,15 @@ public enum PlatformMigrationClient {
         }
     }
 
+    /// Status of an asynchronous import job returned by the polling endpoint.
+    public struct ImportJobStatus {
+        public let status: String
+        public let jobId: String?
+        public let error: String?
+        /// Raw result data — only present when status == "complete"
+        public let resultData: Data?
+    }
+
     // MARK: - Errors
 
     /// Errors specific to platform migration requests.
@@ -196,6 +205,47 @@ public enum PlatformMigrationClient {
         let (data, statusCode) = try await executeWithRetry(request: request, label: "import-from-gcs")
 
         return (statusCode: statusCode, data: data)
+    }
+
+    /// Polls the status of an asynchronous import job.
+    ///
+    /// - Parameter jobId: The job ID returned by `importFromGcs` when it responds with 202.
+    /// - Returns: An `ImportJobStatus` with the current status, optional error, and result data.
+    /// - Throws: `PlatformMigrationError` on auth or request failures.
+    public static func pollImportStatus(jobId: String) async throws -> ImportJobStatus {
+        let (baseURL, token, orgId) = try resolveAuthContext()
+
+        guard let url = URL(string: "\(baseURL)/v1/migrations/import/\(jobId)/status/") else {
+            throw PlatformMigrationError.requestFailed(statusCode: 0, detail: "Invalid URL")
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.timeoutInterval = 30
+        request.setValue(token, forHTTPHeaderField: "X-Session-Token")
+        if let orgId {
+            request.setValue(orgId, forHTTPHeaderField: "Vellum-Organization-Id")
+        }
+
+        let (data, statusCode) = try await executeWithRetry(request: request, label: "import-status")
+
+        guard statusCode == 200 else {
+            throw PlatformMigrationError.requestFailed(statusCode: statusCode, detail: "Import status check failed")
+        }
+
+        // Parse status and error from top level, keep raw data for result
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] ?? [:]
+        let status = json["status"] as? String ?? "unknown"
+        let jobIdValue = json["job_id"] as? String
+        let error = json["error"] as? String
+
+        // Re-serialize result sub-object if present
+        var resultData: Data? = nil
+        if let result = json["result"] {
+            resultData = try? JSONSerialization.data(withJSONObject: result)
+        }
+
+        return ImportJobStatus(status: status, jobId: jobIdValue, error: error, resultData: resultData)
     }
 
     /// Imports a migration bundle by sending the raw data directly to the platform.


### PR DESCRIPTION
## Summary
Adapt the CLI and macOS client to the new asynchronous platform import-from-gcs endpoint. The POST now returns 202 with a job ID instead of blocking for up to 5 minutes. Clients poll a status endpoint every 5 seconds until the job completes, with a 10-minute timeout.

## Self-review result
GAPS FOUND — 1 gap fixed (macOS polling error resilience)

## PRs merged into feature branch
- #24387: feat(cli): add platformPollImportStatus and reduce import-from-gcs timeout
- #24390: feat(clients): add async import polling to PlatformMigrationClient
- #24392: feat(cli): poll async import-from-gcs endpoint with progress indicator

### Fix PRs
- #24393: fix: add transient error resilience to macOS import polling loops

Part of plan: async-import-polling.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24394" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
