### PR TITLE
refactor: drive message list derived state from transcript projector

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
@@ -27,23 +27,7 @@ struct MessageListContentView: View, Equatable {
     // MARK: - Equatable
 
     static func == (lhs: MessageListContentView, rhs: MessageListContentView) -> Bool {
-        lhs.state.displayMessages == rhs.state.displayMessages
-            && lhs.state.showTimestamp == rhs.state.showTimestamp
-            && lhs.state.hasPrecedingAssistantByIndex == rhs.state.hasPrecedingAssistantByIndex
-            && lhs.state.hasUserMessage == rhs.state.hasUserMessage
-            && lhs.state.latestAssistantId == rhs.state.latestAssistantId
-            && lhs.state.subagentsByParent == rhs.state.subagentsByParent
-            && lhs.state.orphanSubagents == rhs.state.orphanSubagents
-            && lhs.state.effectiveStatusText == rhs.state.effectiveStatusText
-            && lhs.state.activePendingRequestId == rhs.state.activePendingRequestId
-            && lhs.state.nextDecidedConfirmationByIndex == rhs.state.nextDecidedConfirmationByIndex
-            && lhs.state.isConfirmationRenderedInlineByIndex == rhs.state.isConfirmationRenderedInlineByIndex
-            && lhs.state.anchoredThinkingIndex == rhs.state.anchoredThinkingIndex
-            && lhs.state.hasActiveToolCall == rhs.state.hasActiveToolCall
-            && lhs.state.canInlineProcessing == rhs.state.canInlineProcessing
-            && lhs.state.shouldShowThinkingIndicator == rhs.state.shouldShowThinkingIndicator
-            && lhs.state.isStreamingWithoutText == rhs.state.isStreamingWithoutText
-            && lhs.state.hasMessages == rhs.state.hasMessages
+        lhs.state == rhs.state
             && lhs.providerCatalogHash == rhs.providerCatalogHash
             && lhs.typographyGeneration == rhs.typographyGeneration
             && lhs.isLoadingMoreMessages == rhs.isLoadingMoreMessages
@@ -65,7 +49,7 @@ struct MessageListContentView: View, Equatable {
 
     // MARK: - Data properties (compared in ==)
 
-    let state: MessageListDerivedState
+    let state: TranscriptRenderModel
     let providerCatalog: [ProviderCatalogEntry]
     let providerCatalogHash: Int
     let typographyGeneration: Int
@@ -178,39 +162,36 @@ struct MessageListContentView: View, Equatable {
             }
 
             let _ = os_signpost(.event, log: stallLog, name: "MessageList.bodyEval")
+            let isUnanchoredThinking = state.shouldShowThinkingIndicator && !state.rows.contains(where: \.isAnchoredThinkingRow)
             let thinkingLabel = !hasEverSentMessage && state.hasUserMessage
                 ? "Waking up..."
                 : (state.effectiveStatusText ?? "Thinking")
-            ForEach(state.displayMessages, id: \.id) { message in
-                let isLatestAssistant = message.role == .assistant && message.id == state.latestAssistantId
-                let messageIndex = state.messageIndexById[message.id] ?? 0
-                let isAnchored = state.shouldShowThinkingIndicator && state.anchoredThinkingIndex == messageIndex
-                let isUnanchoredThinking = state.shouldShowThinkingIndicator && state.anchoredThinkingIndex == nil
+            ForEach(state.rows) { row in
                 // Only pass activePendingRequestId to cells that could use it:
                 // confirmation bubbles need it for keyboard focus, tool-call messages
                 // need it for inline confirmation rendering in AssistantProgressView.
                 // Text-only cells get nil, so they won't fail == when the ID changes.
                 let cellActivePendingRequestId: String? =
-                    (message.confirmation != nil || !message.toolCalls.isEmpty)
+                    (row.message.confirmation != nil || !row.message.toolCalls.isEmpty)
                     ? state.activePendingRequestId : nil
                 MessageCellView(
-                    message: message,
-                    showTimestamp: state.showTimestamp.contains(message.id),
-                    nextDecidedConfirmation: state.nextDecidedConfirmationByIndex[messageIndex],
-                    isConfirmationRenderedInline: state.isConfirmationRenderedInlineByIndex.contains(messageIndex),
-                    hasPrecedingAssistant: state.hasPrecedingAssistantByIndex.contains(messageIndex),
+                    message: row.message,
+                    showTimestamp: row.showTimestamp,
+                    nextDecidedConfirmation: row.decidedConfirmation,
+                    isConfirmationRenderedInline: row.isConfirmationRenderedInline,
+                    hasPrecedingAssistant: row.hasPrecedingAssistant,
                     activePendingRequestId: cellActivePendingRequestId,
                     subagentsByParent: state.subagentsByParent,
-                    isLatestAssistantMessage: isLatestAssistant,
+                    isLatestAssistantMessage: row.isLatestAssistant,
                     typographyGeneration: typographyGeneration,
-                    isProcessingAfterTools: state.canInlineProcessing && isLatestAssistant,
-                    processingStatusText: state.canInlineProcessing && isLatestAssistant ? state.effectiveStatusText : nil,
-                    hideInlineAvatar: isLatestAssistant && isUnanchoredThinking,
-                    showAnchoredThinkingIndicator: isAnchored,
-                    anchoredThinkingLabel: isAnchored ? thinkingLabel : "",
+                    isProcessingAfterTools: state.canInlineProcessing && row.isLatestAssistant,
+                    processingStatusText: state.canInlineProcessing && row.isLatestAssistant ? state.effectiveStatusText : nil,
+                    hideInlineAvatar: row.isLatestAssistant && isUnanchoredThinking,
+                    showAnchoredThinkingIndicator: row.isAnchoredThinkingRow,
+                    anchoredThinkingLabel: row.isAnchoredThinkingRow ? thinkingLabel : "",
                     dismissedDocumentSurfaceIds: dismissedDocumentSurfaceIds,
                     activeSurfaceId: activeSurfaceId,
-                    isHighlighted: highlightedMessageId == message.id,
+                    isHighlighted: row.isHighlighted,
                     mediaEmbedSettings: mediaEmbedSettings,
                     onConfirmationAllow: onConfirmationAllow,
                     onConfirmationDeny: onConfirmationDeny,
@@ -250,7 +231,7 @@ struct MessageListContentView: View, Equatable {
                     .transition(.opacity.combined(with: .move(edge: .bottom)))
             }
 
-            if state.shouldShowThinkingIndicator && state.anchoredThinkingIndex == nil {
+            if isUnanchoredThinking {
                 if isCompacting {
                     compactingIndicatorRow()
                 } else {

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -264,14 +264,14 @@ final class MessageListScrollState {
     /// tripping SwiftUI's "Modifying state during view update" runtime guard.
     @ObservationIgnored let derivedStateCache = MessageListDerivedStateCache()
 
-    @ObservationIgnored var cachedLayoutKey: PrecomputedCacheKey? {
-        get { derivedStateCache.cachedLayoutKey }
-        set { derivedStateCache.cachedLayoutKey = newValue }
+    @ObservationIgnored var cachedProjectionKey: PrecomputedCacheKey? {
+        get { derivedStateCache.cachedProjectionKey }
+        set { derivedStateCache.cachedProjectionKey = newValue }
     }
 
-    @ObservationIgnored var cachedLayoutMetadata: CachedMessageLayoutMetadata? {
-        get { derivedStateCache.cachedLayoutMetadata }
-        set { derivedStateCache.cachedLayoutMetadata = newValue }
+    @ObservationIgnored var cachedProjection: TranscriptRenderModel? {
+        get { derivedStateCache.cachedProjection }
+        set { derivedStateCache.cachedProjection = newValue }
     }
 
     @ObservationIgnored var messageListVersion: Int {

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListTypes.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListTypes.swift
@@ -131,55 +131,12 @@ final class ScrollGeometryUpdateDispatcher {
     }
 }
 
-// MARK: - Cached Message Layout Metadata
+// MARK: - Message List Derived State (type alias)
 
-/// Structural metadata cached behind a version-counter key on
-/// `MessageListScrollState`. Contains only fields derived from message IDs,
-/// roles, timestamps, and subagent identity — never mutable content like
-/// text segments or confirmation states. Cache invalidation is gated by
-/// `refreshMessageListVersionIfNeeded()` which tracks structural changes.
-struct CachedMessageLayoutMetadata {
-    let displayMessageIds: [UUID]
-    let messageIndexById: [UUID: Int]
-    let showTimestamp: Set<UUID>
-    let hasPrecedingAssistantByIndex: Set<Int>
-    let hasUserMessage: Bool
-    let latestAssistantId: UUID?
-    let subagentsByParent: [UUID: [SubagentInfo]]
-    let orphanSubagents: [SubagentInfo]
-    let effectiveStatusText: String?
-}
-
-// MARK: - Message List Derived State
-
-/// All derived values needed by the message list body. Combines cached
-/// structural metadata (from `CachedMessageLayoutMetadata`) with live
-/// content-derived state computed fresh each body evaluation. Content
-/// fields (message data, confirmation placement, thinking indicators)
-/// are always live so SwiftUI's `.equatable()` diffing sees every mutation.
-struct MessageListDerivedState {
-    // --- Cached structural metadata (from CachedMessageLayoutMetadata) ---
-    let messageIndexById: [UUID: Int]
-    let showTimestamp: Set<UUID>
-    let hasPrecedingAssistantByIndex: Set<Int>
-    let hasUserMessage: Bool
-    let latestAssistantId: UUID?
-    let subagentsByParent: [UUID: [SubagentInfo]]
-    let orphanSubagents: [SubagentInfo]
-    let effectiveStatusText: String?
-
-    // --- Live content-derived state (always fresh) ---
-    let displayMessages: [ChatMessage]
-    let activePendingRequestId: String?
-    let nextDecidedConfirmationByIndex: [Int: ToolConfirmationData]
-    let isConfirmationRenderedInlineByIndex: Set<Int>
-    let anchoredThinkingIndex: Int?
-    let hasActiveToolCall: Bool
-    let canInlineProcessing: Bool
-    let shouldShowThinkingIndicator: Bool
-    let isStreamingWithoutText: Bool
-    let hasMessages: Bool
-}
+/// After the switch to `TranscriptProjector`, the render model is the
+/// canonical derived state for the message list. This alias keeps the
+/// cache storage name stable.
+typealias MessageListDerivedState = TranscriptRenderModel
 
 // MARK: - Derived-State Cache
 
@@ -192,8 +149,8 @@ struct MessageListDerivedState {
 /// observation graph while preserving the existing hot-path behavior.
 @MainActor
 final class MessageListDerivedStateCache {
-    var cachedLayoutKey: PrecomputedCacheKey?
-    var cachedLayoutMetadata: CachedMessageLayoutMetadata?
+    var cachedProjectionKey: PrecomputedCacheKey?
+    var cachedProjection: TranscriptRenderModel?
     var messageListVersion = 0
     var lastKnownRawMessageCount = 0
     var lastKnownVisibleMessageCount = 0
@@ -203,12 +160,12 @@ final class MessageListDerivedStateCache {
     var cachedFirstVisibleMessageId: UUID?
     var bodyEvalTimestamps: [CFAbsoluteTime] = []
     var isThrottled = false
-    var cachedDerivedState: MessageListDerivedState?
+    var cachedDerivedState: TranscriptRenderModel?
     var throttleRecoveryTask: Task<Void, Never>?
 
     func reset() {
-        cachedLayoutKey = nil
-        cachedLayoutMetadata = nil
+        cachedProjectionKey = nil
+        cachedProjection = nil
         messageListVersion = 0
         lastKnownRawMessageCount = 0
         lastKnownVisibleMessageCount = 0

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+DerivedState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+DerivedState.swift
@@ -90,15 +90,14 @@ extension MessageListView {
 
     // MARK: - Derived state
 
-    /// Computes all derived values needed by the message list body.
+    /// Computes all derived values needed by the message list body by
+    /// delegating to `TranscriptProjector.project()`.
     ///
-    /// Structural metadata (IDs, timestamps, role-based indices, subagent
-    /// grouping) is memoized behind a lightweight O(1) cache key stored in a
-    /// non-observable cache attached to `MessageListScrollState`.
-    /// Content-derived state (message data, confirmation placement, thinking indicators) is
-    /// always computed fresh from the live `visibleMessages` array so
-    /// SwiftUI's `.equatable()` diffing sees every mutation.
-    var derivedState: MessageListDerivedState {
+    /// The projector produces a `TranscriptRenderModel` (aliased as
+    /// `MessageListDerivedState`) from the raw chat inputs. A lightweight
+    /// O(1) `PrecomputedCacheKey` gates re-projection so the full O(n)
+    /// scan only runs on structural or state changes.
+    var derivedState: TranscriptRenderModel {
         os_signpost(.begin, log: stallLog, name: "DerivedState.resolve")
         scrollState.recordBodyEvaluation()
         let cache = scrollState.derivedStateCache
@@ -108,7 +107,7 @@ extension MessageListView {
             return cached
         }
 
-        // Compute visible messages first so version tracking and layout
+        // Compute visible messages first so version tracking and projection
         // both operate on the same filtered set.
         let liveMessages = visibleMessages
         cache.cachedFirstVisibleMessageId = liveMessages.first?.id
@@ -124,155 +123,37 @@ extension MessageListView {
             displayedMessageCount: displayedMessageCount
         )
 
-        // --- Stage 1: Cached structural metadata ---
-        let layout: CachedMessageLayoutMetadata
-        if key == cache.cachedLayoutKey,
-           let cached = cache.cachedLayoutMetadata,
-           cached.displayMessageIds.count == liveMessages.count {
-            #if DEBUG
-            var seen = Set<UUID>()
-            let freshIds = liveMessages.map(\.id).filter { seen.insert($0).inserted }
-            assert(
-                cached.displayMessageIds == freshIds,
-                "layout cache stale: IDs \(cached.displayMessageIds.count) vs \(freshIds.count)"
-            )
-            #endif
-            os_signpost(.event, log: stallLog, name: "DerivedState.layoutCacheHit")
-            layout = cached
-        } else {
-            os_signpost(.event, log: stallLog, name: "DerivedState.layoutCacheMiss", "version=%d", cache.messageListVersion)
-
-            let displayMessageIds: [UUID] = {
-                var seen = Set<UUID>()
-                return liveMessages.map(\.id).filter { seen.insert($0).inserted }
-            }()
-            let messageIndexById = Dictionary(liveMessages.enumerated().map { ($1.id, $0) }, uniquingKeysWith: { first, _ in first })
-            let showTimestamp = timestampIds(for: liveMessages)
-            let latestAssistantId = liveMessages.last(where: { $0.role == .assistant })?.id
-
-            var hasPrecedingAssistantByIndex = Set<Int>()
-            for i in liveMessages.indices where i > 0 {
-                if liveMessages[i - 1].role == .assistant {
-                    hasPrecedingAssistantByIndex.insert(i)
-                }
-            }
-
-            let hasUserMessage = liveMessages.contains { $0.role == .user }
-            let subagentsByParent: [UUID: [SubagentInfo]] = Dictionary(
-                grouping: activeSubagents.filter { $0.parentMessageId != nil },
-                by: { $0.parentMessageId! }
-            )
-            let orphanSubagents = activeSubagents.filter { $0.parentMessageId == nil }
-            let effectiveStatusText = isCompacting ? "Compacting context\u{2026}" : assistantStatusText
-
-            layout = CachedMessageLayoutMetadata(
-                displayMessageIds: displayMessageIds,
-                messageIndexById: messageIndexById,
-                showTimestamp: showTimestamp,
-                hasPrecedingAssistantByIndex: hasPrecedingAssistantByIndex,
-                hasUserMessage: hasUserMessage,
-                latestAssistantId: latestAssistantId,
-                subagentsByParent: subagentsByParent,
-                orphanSubagents: orphanSubagents,
-                effectiveStatusText: effectiveStatusText
-            )
-            cache.cachedLayoutKey = key
-            cache.cachedLayoutMetadata = layout
+        // Return cached projection when the key matches and the row count
+        // is consistent with the live messages (guards against stale cache
+        // after pagination window shifts).
+        if key == cache.cachedProjectionKey,
+           let cached = cache.cachedProjection,
+           cached.rows.count == liveMessages.count {
+            os_signpost(.event, log: stallLog, name: "DerivedState.projectionCacheHit")
+            cache.cachedDerivedState = cached
+            os_signpost(.end, log: stallLog, name: "DerivedState.resolve")
+            return cached
         }
 
-        // --- Stage 2: Live content-derived state (always fresh) ---
+        os_signpost(.event, log: stallLog, name: "DerivedState.projectionCacheMiss", "version=%d", cache.messageListVersion)
 
-        let anchoredThinkingIndex = resolvedThinkingAnchorIndex(for: liveMessages)
-
-        var nextDecidedConfirmationByIndex: [Int: ToolConfirmationData] = [:]
-        for i in liveMessages.indices {
-            if i + 1 < liveMessages.count,
-               let conf = liveMessages[i + 1].confirmation,
-               conf.state != .pending {
-                nextDecidedConfirmationByIndex[i] = conf
-            }
-        }
-
-        var isConfirmationRenderedInlineByIndex = Set<Int>()
-        for i in liveMessages.indices {
-            guard let confirmation = liveMessages[i].confirmation,
-                  confirmation.state == .pending,
-                  let confirmationToolUseId = confirmation.toolUseId,
-                  !confirmationToolUseId.isEmpty else { continue }
-            for j in (0..<i).reversed() {
-                let msg = liveMessages[j]
-                guard msg.role == .assistant, msg.confirmation == nil else { continue }
-                if msg.toolCalls.contains(where: { $0.toolUseId == confirmationToolUseId && $0.pendingConfirmation != nil }) {
-                    isConfirmationRenderedInlineByIndex.insert(i)
-                }
-                break
-            }
-        }
-
-        let lastVisible = liveMessages.last
-        let currentTurnMessages: ArraySlice<ChatMessage> = {
-            if isSending, let last = liveMessages.last, last.role == .user {
-                let lastNonUser = liveMessages.last(where: {
-                    $0.role != .user
-                })
-                let isActivelyProcessing = lastNonUser?.isStreaming == true
-                    || lastNonUser?.confirmation?.state == .pending
-                if !isActivelyProcessing {
-                    return liveMessages[liveMessages.endIndex...]
-                }
-            }
-            let lastTurnStart = liveMessages.indices.reversed().first(where: { idx in
-                liveMessages[idx].role == .user
-                    && liveMessages.index(after: idx) < liveMessages.endIndex
-                    && liveMessages[liveMessages.index(after: idx)].role != .user
-            })
-            if let idx = lastTurnStart {
-                return liveMessages[liveMessages.index(after: idx)...]
-            }
-            return liveMessages[liveMessages.startIndex...]
-        }()
-        let hasActiveToolCall = currentTurnMessages.contains(where: {
-            $0.toolCalls.contains(where: { !$0.isComplete })
-        })
-        let wouldShowThinking = isSending
-            && (isThinking || !(lastVisible?.isStreaming == true))
-            && !hasActiveToolCall
-        let lastVisibleIsAssistant = lastVisible?.role == .assistant
-        let canInlineProcessing = wouldShowThinking && lastVisibleIsAssistant
-        let shouldShowThinkingIndicator = wouldShowThinking && !canInlineProcessing
-        let isStreamingWithoutText = isSending
-            && (lastVisible?.isStreaming == true)
-            && (lastVisible?.text.isEmpty ?? true)
-            && !hasActiveToolCall
-            && !canInlineProcessing
-
-        let result = MessageListDerivedState(
-            messageIndexById: layout.messageIndexById,
-            showTimestamp: layout.showTimestamp,
-            hasPrecedingAssistantByIndex: layout.hasPrecedingAssistantByIndex,
-            hasUserMessage: layout.hasUserMessage,
-            latestAssistantId: layout.latestAssistantId,
-            subagentsByParent: layout.subagentsByParent,
-            orphanSubagents: layout.orphanSubagents,
-            effectiveStatusText: layout.effectiveStatusText,
-            displayMessages: {
-                // SwiftUI's ForEach requires unique identity values;
-                // duplicates during streaming or pagination cause
-                // undefined behavior.
-                var seen = Set<UUID>()
-                return liveMessages.filter { seen.insert($0.id).inserted }
-            }(),
+        let result = TranscriptProjector.project(
+            messages: messages,
+            paginatedVisibleMessages: liveMessages,
+            activeSubagents: activeSubagents,
+            isSending: isSending,
+            isThinking: isThinking,
+            isCompacting: isCompacting,
+            assistantStatusText: assistantStatusText,
+            assistantActivityPhase: assistantActivityPhase,
+            assistantActivityAnchor: assistantActivityAnchor,
+            assistantActivityReason: assistantActivityReason,
             activePendingRequestId: activePendingRequestId,
-            nextDecidedConfirmationByIndex: nextDecidedConfirmationByIndex,
-            isConfirmationRenderedInlineByIndex: isConfirmationRenderedInlineByIndex,
-            anchoredThinkingIndex: anchoredThinkingIndex,
-            hasActiveToolCall: hasActiveToolCall,
-            canInlineProcessing: canInlineProcessing,
-            shouldShowThinkingIndicator: shouldShowThinkingIndicator,
-            isStreamingWithoutText: isStreamingWithoutText,
-            hasMessages: !liveMessages.isEmpty
+            highlightedMessageId: highlightedMessageId
         )
 
+        cache.cachedProjectionKey = key
+        cache.cachedProjection = result
         cache.cachedDerivedState = result
         os_signpost(.end, log: stallLog, name: "DerivedState.resolve")
         return result
@@ -293,61 +174,6 @@ extension MessageListView {
         return { daemonMessageId in
             forkFromMessage(daemonMessageId)
         }
-    }
-
-    // MARK: - Timestamp computation
-
-    /// Pre-compute which message IDs should show a timestamp divider.
-    /// Avoids creating a Calendar instance per-message inside the ForEach body.
-    /// Uses UUID-based keys so results are stable across array mutations.
-    func timestampIds(for list: [ChatMessage]) -> Set<UUID> {
-        guard !list.isEmpty else { return [] }
-        var result: Set<UUID> = [list[0].id]
-        var calendar = Calendar.current
-        calendar.timeZone = ChatTimestampTimeZone.resolve()
-        for i in 1..<list.count {
-            let current = list[i].timestamp
-            let previous = list[i - 1].timestamp
-            if !calendar.isDate(current, inSameDayAs: previous) || current.timeIntervalSince(previous) > 300 {
-                result.insert(list[i].id)
-            }
-        }
-        return result
-    }
-
-    // MARK: - Thinking anchor
-
-    var shouldAnchorThinkingToConfirmationChip: Bool {
-        assistantActivityPhase == "thinking"
-            && assistantActivityAnchor == "assistant_turn"
-            && assistantActivityReason == "confirmation_resolved"
-    }
-
-    func resolvedThinkingAnchorIndex(for list: [ChatMessage]) -> Int? {
-        guard shouldAnchorThinkingToConfirmationChip else { return nil }
-        guard !list.isEmpty else { return nil }
-
-        for index in list.indices.reversed() {
-            // Decided confirmation chips are usually rendered inline on the
-            // preceding assistant bubble.
-            if list[index].role == .assistant, list.index(after: index) < list.endIndex {
-                let next = list[list.index(after: index)]
-                if let nextConfirmation = next.confirmation, nextConfirmation.state != .pending {
-                    return index
-                }
-            }
-
-            // Fallback for standalone decided confirmation bubbles.
-            if let confirmation = list[index].confirmation, confirmation.state != .pending {
-                let hasPrecedingAssistant = index > list.startIndex
-                    && list[list.index(before: index)].role == .assistant
-                if !hasPrecedingAssistant {
-                    return index
-                }
-            }
-        }
-
-        return nil
     }
 
     // MARK: - Scroll view content

--- a/clients/macos/vellum-assistantTests/MessageListScrollPerformanceTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListScrollPerformanceTests.swift
@@ -26,12 +26,13 @@ final class MessageListScrollPerformanceTests: XCTestCase {
         }
     }
 
-    // MARK: - Test 1: CachedMessageLayoutMetadata Computation (500 messages)
+    // MARK: - Test 1: TranscriptProjector Full Projection (500 messages)
 
-    /// Measures the wall-clock time to compute CachedMessageLayoutMetadata from
-    /// 500 messages. This exercises the O(n) scans (timestamp indices, subagent
-    /// grouping, preceding-assistant detection) that run on every cache miss.
-    func testCachedMessageLayoutMetadataComputation() {
+    /// Measures the wall-clock time to run `TranscriptProjector.project()` with
+    /// 500 messages. This exercises all O(n) scans (deduplication, timestamp
+    /// grouping, subagent grouping, confirmation detection, preceding-assistant
+    /// detection, thinking state) that run on every cache miss.
+    func testTranscriptProjectorFullProjection() {
         let messages = buildMessages(count: 500)
         let subagents: [SubagentInfo] = (0..<5).map { i in
             SubagentInfo(
@@ -43,60 +44,25 @@ final class MessageListScrollPerformanceTests: XCTestCase {
         }
 
         measure(metrics: [XCTClockMetric()]) {
-            // Replicate the core computation from MessageListView.precomputedState.
-            let displayMessages = messages
-
-            // Timestamp grouping (O(n) scan)
-            var showTimestamp = Set<UUID>()
-            if !displayMessages.isEmpty {
-                showTimestamp.insert(displayMessages[0].id)
-                let calendar = Calendar.current
-                for i in 1..<displayMessages.count {
-                    let current = displayMessages[i].timestamp
-                    let previous = displayMessages[i - 1].timestamp
-                    if !calendar.isDate(current, inSameDayAs: previous)
-                        || current.timeIntervalSince(previous) > 300 {
-                        showTimestamp.insert(displayMessages[i].id)
-                    }
-                }
-            }
-
-            // Index by ID (O(n))
-            let messageIndexById = Dictionary(
-                displayMessages.enumerated().map { ($1.id, $0) },
-                uniquingKeysWith: { _, last in last }
+            let model = TranscriptProjector.project(
+                messages: messages,
+                paginatedVisibleMessages: messages,
+                activeSubagents: subagents,
+                isSending: true,
+                isThinking: false,
+                isCompacting: false,
+                assistantStatusText: nil,
+                assistantActivityPhase: "",
+                assistantActivityAnchor: "",
+                assistantActivityReason: nil,
+                activePendingRequestId: nil,
+                highlightedMessageId: nil
             )
-
-            // Subagent grouping (O(s))
-            let subagentsByParent = Dictionary(
-                grouping: subagents.filter { $0.parentMessageId != nil },
-                by: { $0.parentMessageId! }
-            )
-
-            // Confirmation detection (O(n))
-            var nextDecidedConfirmationByIndex: [Int: ToolConfirmationData] = [:]
-            for i in displayMessages.indices {
-                if i + 1 < displayMessages.count,
-                   let conf = displayMessages[i + 1].confirmation,
-                   conf.state != .pending {
-                    nextDecidedConfirmationByIndex[i] = conf
-                }
-            }
-
-            // Preceding assistant detection (O(n))
-            var hasPrecedingAssistantByIndex = Set<Int>()
-            for i in displayMessages.indices where i > 0 {
-                if displayMessages[i - 1].role == .assistant {
-                    hasPrecedingAssistantByIndex.insert(i)
-                }
-            }
 
             // Prevent the compiler from optimizing away the work.
-            XCTAssertEqual(messageIndexById.count, 500)
-            XCTAssertFalse(showTimestamp.isEmpty)
-            _ = subagentsByParent
-            _ = nextDecidedConfirmationByIndex
-            _ = hasPrecedingAssistantByIndex
+            XCTAssertEqual(model.rows.count, 500)
+            XCTAssertFalse(model.rows.isEmpty)
+            XCTAssertEqual(model.subagentsByParent.count, 5)
         }
     }
 
@@ -163,13 +129,13 @@ final class MessageListScrollPerformanceTests: XCTestCase {
         }
     }
 
-    // MARK: - Test 5: Streaming Text Visible Through Cache Hit
+    // MARK: - Test 5: Streaming Text Visible Through Projection
 
-    /// Verifies that streaming text updates are visible even when the layout
-    /// cache returns a hit. The layout cache key should NOT change when only
-    /// text content changes (same message count, same streaming flag), but
-    /// the live message data passed to the ForEach must reflect the update.
-    @MainActor func testStreamingTextVisibleThroughCacheHit() {
+    /// Verifies that streaming text updates are reflected when the projector
+    /// is called with updated messages. Even when the cache key has not changed
+    /// (same count, same streaming flag), re-projecting with updated message
+    /// content produces rows containing the updated text.
+    func testStreamingTextVisibleThroughProjection() {
         var messages = buildMessages(count: 10)
         // Simulate an assistant message that is actively streaming.
         messages[messages.count - 1] = ChatMessage(
@@ -180,34 +146,25 @@ final class MessageListScrollPerformanceTests: XCTestCase {
             isStreaming: true
         )
 
-        let tracking = MessageListScrollState()
-
-        // Build initial cache.
-        let key = PrecomputedCacheKey(
-            messageListVersion: 1,
+        // Build initial projection.
+        let model1 = TranscriptProjector.project(
+            messages: messages,
+            paginatedVisibleMessages: messages,
+            activeSubagents: [],
             isSending: true,
             isThinking: false,
             isCompacting: false,
             assistantStatusText: nil,
-            activeSubagentFingerprint: 0,
-            displayedMessageCount: .max
+            assistantActivityPhase: "",
+            assistantActivityAnchor: "",
+            assistantActivityReason: nil,
+            activePendingRequestId: nil,
+            highlightedMessageId: nil
         )
-        let layout = CachedMessageLayoutMetadata(
-            displayMessageIds: messages.map(\.id),
-            messageIndexById: Dictionary(messages.enumerated().map { ($1.id, $0) }, uniquingKeysWith: { first, _ in first }),
-            showTimestamp: [messages[0].id],
-            hasPrecedingAssistantByIndex: Set((1..<messages.count).filter { messages[$0 - 1].role == .assistant }),
-            hasUserMessage: true,
-            latestAssistantId: messages.last?.id,
-            subagentsByParent: [:],
-            orphanSubagents: [],
-            effectiveStatusText: nil
-        )
-        tracking.cachedLayoutKey = key
-        tracking.cachedLayoutMetadata = layout
+        XCTAssertEqual(model1.rows.last?.message.text, "Hello")
 
         // Simulate streaming: append text to the last message (same count,
-        // same isStreaming flag — the version counter does NOT bump).
+        // same isStreaming flag).
         messages[messages.count - 1] = ChatMessage(
             id: messages.last!.id,
             role: .assistant,
@@ -216,22 +173,28 @@ final class MessageListScrollPerformanceTests: XCTestCase {
             isStreaming: true
         )
 
-        // Build live message dictionary (as derivedState does on every body eval).
-        let liveMessageById = Dictionary(
-            messages.map { ($0.id, $0) },
-            uniquingKeysWith: { first, _ in first }
+        // Re-project with updated messages.
+        let model2 = TranscriptProjector.project(
+            messages: messages,
+            paginatedVisibleMessages: messages,
+            activeSubagents: [],
+            isSending: true,
+            isThinking: false,
+            isCompacting: false,
+            assistantStatusText: nil,
+            assistantActivityPhase: "",
+            assistantActivityAnchor: "",
+            assistantActivityReason: nil,
+            activePendingRequestId: nil,
+            highlightedMessageId: nil
         )
 
-        // The cache key hasn't changed — layout cache should still hit.
-        XCTAssertEqual(key, tracking.cachedLayoutKey)
-        XCTAssertNotNil(tracking.cachedLayoutMetadata)
-
-        // But the live message must reflect the updated text.
-        let lastId = messages.last!.id
-        let liveMessage = liveMessageById[lastId]
-        XCTAssertNotNil(liveMessage)
-        XCTAssertTrue(liveMessage!.text.contains("more streamed text"),
-                       "Live message must reflect streaming text update even on cache hit")
+        // The projected model must reflect the updated text.
+        XCTAssertTrue(model2.rows.last!.message.text.contains("more streamed text"),
+                       "Projected model must reflect streaming text update")
+        // Row count and identity should be stable.
+        XCTAssertEqual(model1.rows.count, model2.rows.count)
+        XCTAssertEqual(model1.rows.last?.id, model2.rows.last?.id)
     }
 
     // MARK: - Test 6: Confirmation Resolution Updates Live State
@@ -310,61 +273,35 @@ final class MessageListScrollPerformanceTests: XCTestCase {
                           "Subagent slices for the same message ID must differ")
     }
 
-    // MARK: - Test 8: Cache-Hit Steady-State Performance
+    // MARK: - Test 8: Projector Cache-Hit Steady-State Performance
 
-    /// Measures the cost of the live-data stage (message dictionary + confirmation
-    /// scans) that runs on every body evaluation, including cache hits.
-    /// This is the per-frame cost during streaming.
-    func testLiveStateSteadyStatePerformance() {
+    /// Measures the cost of repeated projector calls with identical inputs.
+    /// On cache hits in the real code path, the projector is not called
+    /// (the cached TranscriptRenderModel is returned). This test measures
+    /// re-projection cost as a worst-case baseline for the per-frame cost
+    /// during streaming when the cache misses.
+    func testProjectorSteadyStatePerformance() {
         let messages = buildMessages(count: 200)
 
         measure(metrics: [XCTClockMetric()]) {
             for _ in 0..<100 {
-                // Live message dictionary construction.
-                let liveMessageById = Dictionary(
-                    messages.map { ($0.id, $0) },
-                    uniquingKeysWith: { first, _ in first }
+                let model = TranscriptProjector.project(
+                    messages: messages,
+                    paginatedVisibleMessages: messages,
+                    activeSubagents: [],
+                    isSending: true,
+                    isThinking: false,
+                    isCompacting: false,
+                    assistantStatusText: nil,
+                    assistantActivityPhase: "",
+                    assistantActivityAnchor: "",
+                    assistantActivityReason: nil,
+                    activePendingRequestId: nil,
+                    highlightedMessageId: nil
                 )
 
-                // Confirmation detection (O(n)).
-                var nextDecided: [Int: ToolConfirmationData] = [:]
-                for i in messages.indices {
-                    if i + 1 < messages.count,
-                       let conf = messages[i + 1].confirmation,
-                       conf.state != .pending {
-                        nextDecided[i] = conf
-                    }
-                }
-
-                // Inline confirmation detection (O(n)).
-                var inlineSet = Set<Int>()
-                for i in messages.indices {
-                    guard let confirmation = messages[i].confirmation,
-                          confirmation.state == .pending,
-                          let toolUseId = confirmation.toolUseId,
-                          !toolUseId.isEmpty else { continue }
-                    for j in (0..<i).reversed() {
-                        let msg = messages[j]
-                        guard msg.role == .assistant, msg.confirmation == nil else { continue }
-                        if msg.toolCalls.contains(where: { $0.toolUseId == toolUseId && $0.pendingConfirmation != nil }) {
-                            inlineSet.insert(i)
-                        }
-                        break
-                    }
-                }
-
-                // Current turn detection (O(n)).
-                let lastTurnStart = messages.indices.reversed().first(where: { idx in
-                    messages[idx].role == .user
-                        && messages.index(after: idx) < messages.endIndex
-                        && messages[messages.index(after: idx)].role != .user
-                })
-
                 // Prevent compiler from optimizing away work.
-                XCTAssertEqual(liveMessageById.count, 200)
-                _ = nextDecided
-                _ = inlineSet
-                _ = lastTurnStart
+                XCTAssertEqual(model.rows.count, 200)
             }
         }
     }

--- a/clients/macos/vellum-assistantTests/MessageListScrollStateTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListScrollStateTests.swift
@@ -417,8 +417,8 @@ final class MessageListScrollStateTests: XCTestCase {
         XCTAssertFalse(state.lastKnownLastMessageStreaming)
         XCTAssertEqual(state.lastKnownIncompleteToolCallCount, 0)
         XCTAssertEqual(state.lastKnownVisibleIdFingerprint, 0)
-        XCTAssertNil(state.cachedLayoutKey)
-        XCTAssertNil(state.cachedLayoutMetadata)
+        XCTAssertNil(state.cachedProjectionKey)
+        XCTAssertNil(state.cachedProjection)
     }
 
     // MARK: - cancelAll

--- a/clients/macos/vellum-assistantTests/MessageListTypographyRefreshTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListTypographyRefreshTests.swift
@@ -28,7 +28,7 @@ final class MessageListTypographyRefreshTests: XCTestCase {
         )
     }
 
-    private func makeMessageListContentView(state: MessageListDerivedState, typographyGeneration: Int) -> MessageListContentView {
+    private func makeMessageListContentView(state: TranscriptRenderModel, typographyGeneration: Int) -> MessageListContentView {
         MessageListContentView(
             state: state,
             providerCatalog: [],
@@ -94,27 +94,21 @@ final class MessageListTypographyRefreshTests: XCTestCase {
         )
     }
 
-    private func makeDerivedState() -> MessageListDerivedState {
+    private func makeDerivedState() -> TranscriptRenderModel {
         let message = ChatMessage(role: .assistant, text: "*italic*")
-        return MessageListDerivedState(
-            messageIndexById: [message.id: 0],
-            showTimestamp: [],
-            hasPrecedingAssistantByIndex: [],
-            hasUserMessage: false,
-            latestAssistantId: message.id,
-            subagentsByParent: [:],
-            orphanSubagents: [],
-            effectiveStatusText: nil,
-            displayMessages: [message],
+        return TranscriptProjector.project(
+            messages: [message],
+            paginatedVisibleMessages: [message],
+            activeSubagents: [],
+            isSending: false,
+            isThinking: false,
+            isCompacting: false,
+            assistantStatusText: nil,
+            assistantActivityPhase: "",
+            assistantActivityAnchor: "",
+            assistantActivityReason: nil,
             activePendingRequestId: nil,
-            nextDecidedConfirmationByIndex: [:],
-            isConfirmationRenderedInlineByIndex: [],
-            anchoredThinkingIndex: nil,
-            hasActiveToolCall: false,
-            canInlineProcessing: false,
-            shouldShowThinkingIndicator: false,
-            isStreamingWithoutText: false,
-            hasMessages: true
+            highlightedMessageId: nil
         )
     }
 }


### PR DESCRIPTION
## Summary
- Replace derived-state assembly in MessageListView+DerivedState with TranscriptProjector.project()
- Shrink MessageListTypes to cache key and storage only, removing projector-redundant fields
- Update MessageListContentView to consume projected transcript model directly
- Remove dead code: timestampIds, resolvedThinkingAnchorIndex, CachedMessageLayoutMetadata, MessageListDerivedState struct (replaced with typealias)

Part of plan: macos-chat-surface-stabilization.md (PR 6 of 11)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24396" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
