### PR TITLE
refactor: drive composer popup behavior from composer controller

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerEmojiPicker.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerEmojiPicker.swift
@@ -3,78 +3,12 @@ import VellumAssistantShared
 #if os(macOS)
 import AppKit
 
-// MARK: - Emoji Navigation
-
-enum EmojiNavigation {
-    case up, down, select, tab, dismiss
-}
-
 // MARK: - Emoji Picker Logic (ComposerView extension)
 
 extension ComposerView {
 
-    /// Walks backward from `cursorPosition` through `inputText` to find an
-    /// unmatched `:` followed by 2+ alphanumeric/underscore characters.
-    /// Returns nil if no valid trigger is found.
-    func emojiTriggerRange() -> (colonIndex: String.Index, filter: String)? {
-        guard !showSlashMenu else { return nil }
-        guard cursorPosition > 0, cursorPosition <= inputText.utf16.count else { return nil }
-
-        let cursorIdx = String.Index(utf16Offset: cursorPosition, in: inputText)
-        var idx = cursorIdx
-
-        // Walk backward looking for the triggering `:`
-        while idx > inputText.startIndex {
-            idx = inputText.index(before: idx)
-            let ch = inputText[idx]
-
-            if ch == ":" {
-                // Found the colon — extract the filter between colon and cursor
-                let afterColon = inputText.index(after: idx)
-                let filter = String(inputText[afterColon..<cursorIdx])
-
-                // Must have at least 2 characters after the colon
-                guard filter.count >= 2 else { return nil }
-
-                return (colonIndex: idx, filter: filter)
-            }
-
-            // Only allow alphanumeric characters and underscores between `:` and cursor
-            if ch.isWhitespace || (!ch.isLetter && !ch.isNumber && ch != "_") {
-                return nil
-            }
-        }
-
-        return nil
-    }
-
-    func updateEmojiState() {
-        if suppressEmojiReopen {
-            suppressEmojiReopen = false
-            return
-        }
-        if let trigger = emojiTriggerRange() {
-            let results = EmojiCatalog.search(query: trigger.filter)
-            if !results.isEmpty {
-                showEmojiMenu = true
-                if emojiFilter != trigger.filter {
-                    emojiSelectedIndex = 0
-                }
-                emojiFilter = trigger.filter
-            } else {
-                showEmojiMenu = false
-            }
-        } else {
-            showEmojiMenu = false
-        }
-    }
-
-    func filteredEmoji(_ filter: String) -> [EmojiEntry] {
-        EmojiCatalog.search(query: filter, limit: 8)
-    }
-
     func selectEmoji(_ entry: EmojiEntry) {
-        guard let trigger = emojiTriggerRange() else { return }
+        guard let trigger = composerController.emojiTriggerRange() else { return }
 
         let colonOffset = trigger.colonIndex.utf16Offset(in: inputText)
         let cursorUtf16 = cursorPosition
@@ -82,29 +16,6 @@ extension ComposerView {
         let nsRange = NSRange(location: colonOffset, length: length)
 
         textReplacer.replaceText?(nsRange, entry.emoji)
-
-        showEmojiMenu = false
-        emojiSelectedIndex = 0
-    }
-
-    func handleEmojiNavigation(_ action: EmojiNavigation) {
-        if showEmojiMenu {
-            let filtered = filteredEmoji(emojiFilter)
-            guard !filtered.isEmpty else { return }
-            switch action {
-            case .up:
-                emojiSelectedIndex = (emojiSelectedIndex - 1 + filtered.count) % filtered.count
-            case .down:
-                emojiSelectedIndex = (emojiSelectedIndex + 1) % filtered.count
-            case .select:
-                selectEmoji(filtered[emojiSelectedIndex])
-            case .tab:
-                selectEmoji(filtered[emojiSelectedIndex])
-            case .dismiss:
-                showEmojiMenu = false
-                suppressEmojiReopen = true
-            }
-        }
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerSlashCommands.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerSlashCommands.swift
@@ -40,18 +40,9 @@ struct SlashCommand: Identifiable {
     }
 }
 
-// MARK: - Slash Navigation
-
-enum SlashNavigation {
-    case up, down, select, tab, dismiss
-}
-
 // MARK: - Slash Command Logic (ComposerView extension)
 
 extension ComposerView {
-    static func slashCommandInputTextForSelection(_ command: SlashCommand) -> String {
-        command.selectedInputText
-    }
 
     /// Range of a slash command token (e.g. `/model`) at the start of input.
     var slashCommandRange: Range<String.Index>? {
@@ -75,68 +66,10 @@ extension ComposerView {
         return attr
     }
 
-    func filteredSlashCommands(_ filter: String) -> [SlashCommand] {
-        SlashCommand.all.filter {
-            filter.isEmpty || $0.name.lowercased().hasPrefix(filter.lowercased())
-        }
-    }
-
-    func updateSlashState() {
-        if suppressSlashReopen {
-            suppressSlashReopen = false
-            return
-        }
-        let text = inputText
-
-        if text.hasPrefix("/") && !text.contains(" ") {
-            let filter = String(text.dropFirst())
-            let filtered = filteredSlashCommands(filter)
-            if !filtered.isEmpty {
-                showSlashMenu = true
-                if slashFilter != filter {
-                    slashSelectedIndex = 0
-                }
-                slashFilter = filter
-            } else {
-                showSlashMenu = false
-            }
-        } else {
-            showSlashMenu = false
-        }
-    }
-
     func selectSlashCommand(_ command: SlashCommand) {
-        showSlashMenu = false
-        slashSelectedIndex = 0
-        inputText = Self.slashCommandInputTextForSelection(command)
+        inputText = command.selectedInputText
         if command.shouldAutoSendOnSelect {
             onSend()
-        }
-    }
-
-    func handleSlashNavigation(_ action: SlashNavigation) {
-        if showSlashMenu {
-            let filtered = filteredSlashCommands(slashFilter)
-            guard !filtered.isEmpty else { return }
-            switch action {
-            case .up:
-                slashSelectedIndex = (slashSelectedIndex - 1 + filtered.count) % filtered.count
-            case .down:
-                slashSelectedIndex = (slashSelectedIndex + 1) % filtered.count
-            case .select:
-                selectSlashCommand(filtered[slashSelectedIndex])
-            case .tab:
-                let command = filtered[slashSelectedIndex]
-                let newText = Self.slashCommandInputTextForSelection(command)
-                if inputText != newText {
-                    suppressSlashReopen = true
-                }
-                inputText = newText
-                showSlashMenu = false
-            case .dismiss:
-                showSlashMenu = false
-                inputText = ""
-            }
         }
     }
 }

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -9,24 +9,6 @@ import AppKit
 
 private let composerLog = Logger(subsystem: Bundle.appBundleIdentifier, category: "Composer")
 
-@MainActor
-private final class ComposerMenuRefreshScheduler {
-    private var generation = 0
-
-    func schedule(_ action: @escaping @MainActor () -> Void) {
-        generation += 1
-        let currentGeneration = generation
-        DispatchQueue.main.async { [weak self] in
-            guard let self, self.generation == currentGeneration else { return }
-            action()
-        }
-    }
-
-    func cancel() {
-        generation += 1
-    }
-}
-
 struct ComposerView: View {
     private let composerMaxHeight: CGFloat = 300
     private let composerActionButtonSize: CGFloat = 32
@@ -93,18 +75,8 @@ struct ComposerView: View {
     @State private var textViewIsFocused: Bool = false
     @State var cursorPosition: Int = 0
 
-    @State var showSlashMenu = false
-    @State var slashFilter = ""
-    @State var slashSelectedIndex = 0
-    @State var suppressSlashReopen = false
-    @State var suppressEmojiReopen = false
-    @State var showEmojiMenu = false
-    @State var emojiFilter = ""
-    @State var emojiSelectedIndex = 0
     @State var textReplacer = TextReplacementProxy()
-    @State private var menuRefreshScheduler = ComposerMenuRefreshScheduler()
-    /// Snapshot of inputText captured when dictation starts, used to restore on cancel.
-    @State private var preDictationText: String = ""
+    @State var composerController = ComposerController()
     /// Live amplitude from VoiceInputManager, bypassing ChatViewModel's 100ms coalescing.
     @State private var liveAmplitude: Float = 0
 
@@ -121,34 +93,22 @@ struct ComposerView: View {
         return nil
     }
 
-    private func scheduleComposerMenuRefresh() {
-        menuRefreshScheduler.schedule {
-            if inputText.isEmpty {
-                showSlashMenu = false
-                showEmojiMenu = false
-            } else {
-                updateSlashState()
-                updateEmojiState()
-            }
-        }
-    }
-
     var body: some View {
         VStack(spacing: VSpacing.sm) {
             // Slash command popup (above the composer)
-            if showSlashMenu {
+            if composerController.showSlashMenu {
                 SlashCommandPopup(
-                    commands: filteredSlashCommands(slashFilter),
-                    selectedIndex: slashSelectedIndex,
+                    commands: composerController.slashCommandProvider.filteredCommands(composerController.slashFilter),
+                    selectedIndex: composerController.slashSelectedIndex,
                     onSelect: { command in selectSlashCommand(command) }
                 )
                 .transition(.opacity.combined(with: .move(edge: .bottom)))
             }
 
-            if showEmojiMenu {
+            if composerController.showEmojiMenu {
                 EmojiPickerPopup(
-                    entries: filteredEmoji(emojiFilter),
-                    selectedIndex: emojiSelectedIndex,
+                    entries: composerController.emojiSearchProvider.search(query: composerController.emojiFilter, limit: 8),
+                    selectedIndex: composerController.emojiSelectedIndex,
                     onSelect: { entry in selectEmoji(entry) }
                 )
                 .transition(.opacity.combined(with: .move(edge: .bottom)))
@@ -199,20 +159,12 @@ struct ComposerView: View {
         .onChange(of: currentMode) {
             composerLog.debug("Composer mode: \(String(describing: currentMode))")
             if currentMode == .dictationInline {
-                preDictationText = inputText
+                composerController.dictationStarted()
             }
         }
         .onChange(of: isInteractionEnabled) { _, enabled in
-            if enabled, !hasPendingConfirmation {
-                composerFocus = true
-            } else if !enabled {
-                menuRefreshScheduler.cancel()
-                composerFocus = false
-                showSlashMenu = false
-                showEmojiMenu = false
-                suppressSlashReopen = false
-                suppressEmojiReopen = false
-            }
+            composerController.interactionEnabledChanged(enabled, hasPendingConfirmation: hasPendingConfirmation)
+            composerFocus = composerController.focusIntent
         }
         .onChange(of: hasPendingConfirmation) { _, pending in
             if !pending, isInteractionEnabled {
@@ -286,29 +238,39 @@ struct ComposerView: View {
                     ? NSColor(VColor.contentDefault).withAlphaComponent(0) : nil,
                 onSubmit: { performSendAction() },
                 onTab: {
-                    if showSlashMenu { handleSlashNavigation(.tab); return true }
-                    if showEmojiMenu { handleEmojiNavigation(.tab); return true }
+                    if composerController.showSlashMenu {
+                        if let command = composerController.handleSlashNavigation(.tab) {
+                            inputText = command.selectedInputText
+                        }
+                        return true
+                    }
+                    if composerController.showEmojiMenu {
+                        if let entry = composerController.handleEmojiNavigation(.tab) {
+                            selectEmoji(entry)
+                        }
+                        return true
+                    }
                     if ghostSuffix != nil { onAcceptSuggestion(); return true }
                     return false
                 },
                 onUpArrow: {
-                    if showSlashMenu { handleSlashNavigation(.up); return true }
-                    if showEmojiMenu { handleEmojiNavigation(.up); return true }
+                    if composerController.showSlashMenu { composerController.handleSlashNavigation(.up); return true }
+                    if composerController.showEmojiMenu { composerController.handleEmojiNavigation(.up); return true }
                     return false
                 },
                 onDownArrow: {
-                    if showSlashMenu { handleSlashNavigation(.down); return true }
-                    if showEmojiMenu { handleEmojiNavigation(.down); return true }
+                    if composerController.showSlashMenu { composerController.handleSlashNavigation(.down); return true }
+                    if composerController.showEmojiMenu { composerController.handleEmojiNavigation(.down); return true }
                     return false
                 },
                 onEscape: {
-                    if showSlashMenu { handleSlashNavigation(.dismiss); return true }
-                    if showEmojiMenu { handleEmojiNavigation(.dismiss); return true }
+                    if composerController.showSlashMenu { composerController.handleSlashNavigation(.dismiss); return true }
+                    if composerController.showEmojiMenu { composerController.handleEmojiNavigation(.dismiss); return true }
                     return false
                 },
                 onPasteImage: onPaste,
                 shouldOverrideReturn: {
-                    showSlashMenu || showEmojiMenu
+                    composerController.isPopupVisible
                 },
                 cursorPosition: $cursorPosition,
                 textReplacer: textReplacer
@@ -361,12 +323,10 @@ struct ComposerView: View {
             composerFocus = true
         }
         .onChange(of: inputText) {
-            scheduleComposerMenuRefresh()
+            composerController.textChanged(inputText)
         }
         .onChange(of: cursorPosition) {
-            if !inputText.isEmpty {
-                scheduleComposerMenuRefresh()
-            }
+            composerController.cursorMoved(to: cursorPosition)
         }
     }
 
@@ -375,12 +335,16 @@ struct ComposerView: View {
     /// regardless of how "send" is triggered.
     private func performSendAction() {
         let sendPath: String
-        if showSlashMenu {
+        if composerController.showSlashMenu {
             sendPath = "slashSelection"
-            handleSlashNavigation(.select)
-        } else if showEmojiMenu {
+            if let command = composerController.handleSlashNavigation(.select) {
+                selectSlashCommand(command)
+            }
+        } else if composerController.showEmojiMenu {
             sendPath = "emojiSelection"
-            handleEmojiNavigation(.select)
+            if let entry = composerController.handleEmojiNavigation(.select) {
+                selectEmoji(entry)
+            }
         } else if canSend {
             sendPath = "normalSend"
             onSend()
@@ -589,8 +553,8 @@ VStreamingWaveform(
                         style: .danger,
                         iconSize: composerActionButtonSize,
                         action: {
-                            inputText = preDictationText
-                            preDictationText = ""
+                            inputText = composerController.preDictationText
+                            composerController.dictationStopped()
                             (onDictateToggle ?? onMicrophoneToggle)()
                         }
                     )
@@ -603,7 +567,7 @@ VStreamingWaveform(
                         style: .primary,
                         iconSize: composerActionButtonSize,
                         action: {
-                            preDictationText = ""
+                            composerController.dictationStopped()
                             (onDictateToggle ?? onMicrophoneToggle)()
                         }
                     )

--- a/clients/macos/vellum-assistantTests/ComposerEmojiPickerTests.swift
+++ b/clients/macos/vellum-assistantTests/ComposerEmojiPickerTests.swift
@@ -1,7 +1,7 @@
 #if os(macOS)
 import XCTest
 @testable import VellumAssistantLib
-import VellumAssistantShared
+@preconcurrency import VellumAssistantShared
 
 final class ComposerEmojiPickerTests: XCTestCase {
 
@@ -32,6 +32,98 @@ final class ComposerEmojiPickerTests: XCTestCase {
         XCTAssertNotNil(row)
         XCTAssertEqual(row.entry.shortcode, "thumbsup")
         XCTAssertEqual(row.entry.emoji, "\u{1F44D}")
+    }
+
+    // MARK: - Controller-backed emoji popup regression tests
+
+    /// Verifies the controller-driven emoji popup opens with the expected
+    /// filter when a colon trigger is typed, matching the behavior that
+    /// was previously owned by ComposerView body callbacks.
+    @MainActor
+    func testControllerDrivenEmojiPopupOpensOnColonTrigger() {
+        let controller = ComposerController(
+            emojiSearchProvider: StubEmojiProvider(entries: [
+                EmojiEntry(shortcode: "thumbsup", emoji: "\u{1F44D}"),
+                EmojiEntry(shortcode: "thumbsdown", emoji: "\u{1F44E}"),
+            ])
+        )
+
+        let text = "hello :th"
+        controller.textChanged(text)
+        controller.cursorMoved(to: text.utf16.count)
+        controller.performMenuRefresh()
+
+        XCTAssertTrue(controller.showEmojiMenu,
+                      "Controller should open emoji menu on valid colon trigger")
+        XCTAssertEqual(controller.emojiFilter, "th")
+        XCTAssertEqual(controller.emojiSelectedIndex, 0)
+    }
+
+    /// Verifies that selecting an emoji via the controller returns the entry
+    /// and closes the menu, matching the old view-owned select behavior.
+    @MainActor
+    func testControllerDrivenEmojiSelectClosesMenu() {
+        let controller = ComposerController(
+            emojiSearchProvider: StubEmojiProvider(entries: [
+                EmojiEntry(shortcode: "heart", emoji: "\u{2764}\u{FE0F}"),
+                EmojiEntry(shortcode: "heartbreak", emoji: "\u{1F494}"),
+            ])
+        )
+
+        let text = ":heart"
+        controller.textChanged(text)
+        controller.cursorMoved(to: text.utf16.count)
+        controller.performMenuRefresh()
+        XCTAssertTrue(controller.showEmojiMenu)
+
+        let entry = controller.handleEmojiNavigation(.select)
+        XCTAssertNotNil(entry, "Select should return the highlighted entry")
+        XCTAssertEqual(entry?.shortcode, "heart")
+        XCTAssertFalse(controller.showEmojiMenu,
+                       "Menu should close after selection")
+    }
+
+    /// Regression: dismissing the emoji popup via escape must set the
+    /// suppress-reopen flag so the next text change doesn't reopen it.
+    @MainActor
+    func testControllerDrivenEmojiDismissSuppressesReopen() {
+        let controller = ComposerController(
+            emojiSearchProvider: StubEmojiProvider(entries: [
+                EmojiEntry(shortcode: "fire", emoji: "\u{1F525}"),
+            ])
+        )
+
+        let text = ":fire"
+        controller.textChanged(text)
+        controller.cursorMoved(to: text.utf16.count)
+        controller.performMenuRefresh()
+        XCTAssertTrue(controller.showEmojiMenu)
+
+        controller.handleEmojiNavigation(.dismiss)
+        XCTAssertFalse(controller.showEmojiMenu)
+        XCTAssertTrue(controller.suppressEmojiReopen,
+                      "Dismiss should set suppress flag to prevent immediate reopen")
+
+        // Next refresh consumes the flag and keeps the menu closed
+        controller.textChanged(text)
+        controller.cursorMoved(to: text.utf16.count)
+        controller.performMenuRefresh()
+        XCTAssertFalse(controller.showEmojiMenu,
+                       "Menu should stay closed during suppressed cycle")
+        XCTAssertFalse(controller.suppressEmojiReopen,
+                       "Suppress flag should be consumed after one cycle")
+    }
+}
+
+// MARK: - Test Helpers
+
+/// Minimal emoji search provider for controller-backed popup tests.
+private struct StubEmojiProvider: EmojiSearchProvider {
+    let entries: [EmojiEntry]
+
+    func search(query: String, limit: Int) -> [EmojiEntry] {
+        let matched = entries.filter { $0.shortcode.contains(query.lowercased()) }
+        return Array(matched.prefix(limit))
     }
 }
 #endif

--- a/clients/macos/vellum-assistantTests/ComposerSlashCommandPickerTests.swift
+++ b/clients/macos/vellum-assistantTests/ComposerSlashCommandPickerTests.swift
@@ -29,7 +29,7 @@ final class ComposerSlashCommandPickerTests: XCTestCase {
 
     func testBtwTabCompletionUsesSelectionInsertionText() throws {
         let command = try XCTUnwrap(SlashCommand.all.first(where: { $0.name == "btw" }))
-        XCTAssertEqual(ComposerView.slashCommandInputTextForSelection(command), "/btw ")
+        XCTAssertEqual(command.selectedInputText, "/btw ")
     }
 }
 #endif


### PR DESCRIPTION
## Summary
- Replace local popup state in ComposerView with ComposerController-driven state
- Update ComposerEmojiPicker and ComposerSlashCommands for controller-driven rendering
- Remove per-keystroke view-owned visibility toggles now handled by controller events

Part of plan: macos-chat-surface-stabilization.md (PR 8 of 11)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24397" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
