### PR TITLE
M3: Update HatchingStepView to match Figma Waking Up screen

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -181,10 +181,10 @@ struct HatchingStepView: View {
                     .font(VFont.titleLarge)
                     .foregroundStyle(VColor.contentDefault)
             } else {
-                Text("Waking up...")
+                Text("Waking Up")
                     .font(VFont.titleLarge)
                     .foregroundStyle(VColor.contentDefault)
-                Text("Hang tight \u{2014} your assistant will have a few\nquestions for you once it\u{2019}s up.")
+                Text("Hang tight - your assistant will have a few questions once it's up.")
                     .font(VFont.bodySmallDefault)
                     .foregroundStyle(VColor.contentTertiary)
                     .multilineTextAlignment(.center)


### PR DESCRIPTION
Update hatching screen copy: title to 'Waking Up', updated subtitle with regular punctuation. Progress bar kept as-is. Part of #24382.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24398" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
