### PR TITLE
Update onboarding setup flow to match Figma mocks

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
@@ -89,7 +89,7 @@ struct APIKeyEntryStepView: View {
 
     var body: some View {
         Text("Connect a Model Provider")
-            .font(VFont.displayLarge)
+            .font(VFont.titleLarge)
             .foregroundStyle(VColor.contentDefault)
             .opacity(showTitle ? 1 : 0)
             .offset(y: showTitle ? 0 : 8)
@@ -129,7 +129,7 @@ struct APIKeyEntryStepView: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
                 }
 
-                VButton(label: "Start", style: .primary, isFullWidth: true, isDisabled: providerRequiresKey && apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty) {
+                VButton(label: "Continue", style: .primary, isFullWidth: true, isDisabled: providerRequiresKey && apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty) {
                     saveAndHatch()
                 }
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
@@ -103,8 +103,8 @@ struct APIKeyEntryStepView: View {
             .offset(y: showTitle ? 0 : 8)
             .padding(.bottom, VSpacing.xxl)
 
-        VStack(spacing: VSpacing.md) {
-            VStack(spacing: VSpacing.md) {
+        VStack(spacing: 0) {
+            VStack(spacing: VSpacing.lg) {
                 providerPicker
 
                 if providerRequiresKey {
@@ -128,7 +128,9 @@ struct APIKeyEntryStepView: View {
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
                 }
+            }
 
+            VStack(spacing: VSpacing.sm) {
                 VButton(label: "Continue", style: .primary, isFullWidth: true, isDisabled: providerRequiresKey && apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty) {
                     saveAndHatch()
                 }
@@ -137,6 +139,7 @@ struct APIKeyEntryStepView: View {
                     goBack()
                 }
             }
+            .padding(.top, VSpacing.xxl)
         }
         .padding(.horizontal, VSpacing.xxl)
         .opacity(showContent ? 1 : 0)

--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
@@ -130,7 +130,7 @@ struct APIKeyEntryStepView: View {
                     saveAndHatch()
                 }
 
-                VButton(label: "Back", style: .outlined) {
+                VButton(label: "Back", style: .outlined, isFullWidth: true) {
                     goBack()
                 }
             }

--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
@@ -10,7 +10,13 @@ struct APIKeyEntryStepView: View {
     @State private var isEditing = false
     @State private var showTitle = false
     @State private var showContent = false
+    @State private var showCharacters = false
     @FocusState private var keyFieldFocused: Bool
+
+    private static let welcomeCharacters: NSImage? = {
+        guard let url = ResourceBundle.bundle.url(forResource: "welcome-characters", withExtension: "png") else { return nil }
+        return NSImage(contentsOf: url)
+    }()
 
     // MARK: - Provider Catalog
 
@@ -105,18 +111,26 @@ struct APIKeyEntryStepView: View {
                     apiKeyField
                 }
 
-                VButton(label: "Continue", style: .primary, isFullWidth: true, isDisabled: providerRequiresKey && apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty) {
-                    saveAndHatch()
-                }
-
                 if let apiKeyUrl = currentProviderEntry?.apiKeyUrl,
                    let url = URL(string: apiKeyUrl) {
-                    VButton(label: "Get an API key", style: .ghost) {
-                        NSWorkspace.shared.open(url)
+                    HStack(spacing: VSpacing.sm) {
+                        Text("Don't have it?")
+                            .font(VFont.bodyMediumDefault)
+                            .foregroundStyle(VColor.contentSecondary)
+                        Text("Get an API key here")
+                            .font(VFont.bodyMediumDefault)
+                            .foregroundStyle(VColor.contentDefault)
+                            .onTapGesture {
+                                NSWorkspace.shared.open(url)
+                            }
                     }
                 }
 
-                VButton(label: "Back", style: .ghost) {
+                VButton(label: "Start", style: .primary, isFullWidth: true, isDisabled: providerRequiresKey && apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty) {
+                    saveAndHatch()
+                }
+
+                VButton(label: "Back", style: .outlined) {
                     goBack()
                 }
             }
@@ -154,6 +168,26 @@ struct APIKeyEntryStepView: View {
                 hasExistingKey = false
                 isEditing = false
             }
+        }
+
+        Spacer()
+
+        if let characters = Self.welcomeCharacters {
+            Image(nsImage: characters)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(maxWidth: .infinity)
+                .clipShape(UnevenRoundedRectangle(
+                    topLeadingRadius: 0,
+                    bottomLeadingRadius: VRadius.window,
+                    bottomTrailingRadius: VRadius.window,
+                    topTrailingRadius: 0
+                ))
+                .opacity(showCharacters ? 1 : 0)
+                .offset(y: showCharacters ? 0 : 30)
+                .animation(.easeOut(duration: 0.6).delay(0.5), value: showCharacters)
+                .onAppear { showCharacters = true }
+                .accessibilityHidden(true)
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
@@ -96,7 +96,7 @@ struct APIKeyEntryStepView: View {
             .padding(.bottom, VSpacing.md)
 
         Text("Enter an API key to connect your model provider.")
-            .font(VFont.titleSmall)
+            .font(VFont.bodyMediumLighter)
             .multilineTextAlignment(.center)
             .foregroundStyle(VColor.contentSecondary)
             .opacity(showTitle ? 1 : 0)

--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
@@ -121,6 +121,7 @@ struct APIKeyEntryStepView: View {
                             .font(VFont.bodyMediumDefault)
                             .foregroundStyle(VColor.contentDefault)
                             .underline()
+                            .accessibilityAddTraits(.isLink)
                             .onTapGesture {
                                 NSWorkspace.shared.open(url)
                             }

--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
@@ -120,10 +120,13 @@ struct APIKeyEntryStepView: View {
                         Text("Get an API key here")
                             .font(VFont.bodyMediumDefault)
                             .foregroundStyle(VColor.contentDefault)
+                            .underline()
                             .onTapGesture {
                                 NSWorkspace.shared.open(url)
                             }
+                            .pointerCursor()
                     }
+                    .frame(maxWidth: .infinity, alignment: .leading)
                 }
 
                 VButton(label: "Start", style: .primary, isFullWidth: true, isDisabled: providerRequiresKey && apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty) {

--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -75,6 +75,12 @@ struct APIKeyStepView: View {
 
     @State private var showTitle = false
     @State private var showContent = false
+    @State private var showCharacters = false
+
+    private static let welcomeCharacters: NSImage? = {
+        guard let url = ResourceBundle.bundle.url(forResource: "welcome-characters", withExtension: "png") else { return nil }
+        return NSImage(contentsOf: url)
+    }()
 
     private var userHostedEnabled: Bool {
         MacOSClientFeatureFlagManager.shared.isEnabled("user-hosted-enabled")
@@ -133,6 +139,26 @@ struct APIKeyStepView: View {
             withAnimation(.easeOut(duration: 0.5).delay(0.3)) {
                 showContent = true
             }
+        }
+
+        Spacer()
+
+        if let characters = Self.welcomeCharacters {
+            Image(nsImage: characters)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(maxWidth: .infinity)
+                .clipShape(UnevenRoundedRectangle(
+                    topLeadingRadius: 0,
+                    bottomLeadingRadius: VRadius.window,
+                    bottomTrailingRadius: VRadius.window,
+                    topTrailingRadius: 0
+                ))
+                .opacity(showCharacters ? 1 : 0)
+                .offset(y: showCharacters ? 0 : 30)
+                .animation(.easeOut(duration: 0.6).delay(0.5), value: showCharacters)
+                .onAppear { showCharacters = true }
+                .accessibilityHidden(true)
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -96,13 +96,13 @@ struct APIKeyStepView: View {
 
     var body: some View {
         Text("Hosting")
-            .font(VFont.displayLarge)
+            .font(VFont.titleLarge)
             .foregroundStyle(VColor.contentDefault)
             .opacity(showTitle ? 1 : 0)
             .offset(y: showTitle ? 0 : 8)
             .padding(.bottom, VSpacing.md)
 
-        Text("Where do you want your assistant to run?")
+        Text("Where do you want your assistant to live?")
             .font(VFont.titleSmall)
             .foregroundStyle(VColor.contentSecondary)
             .opacity(showTitle ? 1 : 0)
@@ -117,16 +117,20 @@ struct APIKeyStepView: View {
                     handleContinue()
                 }
 
-                VButton(label: "Need help deciding?", style: .ghost) {
-                    NSWorkspace.shared.open(AppURLs.hostingOptionsDocs)
-                }
-
                 if !isAuthenticated {
-                    VButton(label: "Back", style: .ghost) {
+                    VButton(label: "Back", style: .outlined, isFullWidth: true) {
                         goBack()
                     }
-                    .padding(.top, VSpacing.xs)
                 }
+
+                Text("Need help choosing?")
+                    .font(VFont.bodyMediumDefault)
+                    .foregroundStyle(VColor.contentDefault)
+                    .underline()
+                    .onTapGesture {
+                        NSWorkspace.shared.open(AppURLs.hostingOptionsDocs)
+                    }
+                    .pointerCursor()
             }
         }
         .padding(.horizontal, VSpacing.xxl)
@@ -172,16 +176,6 @@ struct APIKeyStepView: View {
         )
     }
 
-    private func chipLabel(for mode: OnboardingState.HostingMode) -> String? {
-        switch mode {
-        case .vellumCloud:
-            if !isAuthenticated { return "Requires Account" }
-            return nil
-        default:
-            return nil
-        }
-    }
-
     private var hostingCards: some View {
         VStack(spacing: VSpacing.sm) {
             ForEach(availableHostingModes, id: \.rawValue) { mode in
@@ -198,8 +192,7 @@ struct APIKeyStepView: View {
                     icon: iconForMode(mode),
                     title: title,
                     subtitle: subtitle,
-                    mode: mode,
-                    chipLabel: chipLabel(for: mode)
+                    mode: mode
                 )
             }
         }
@@ -220,76 +213,58 @@ struct APIKeyStepView: View {
         icon: VIcon,
         title: String,
         subtitle: String,
-        mode: OnboardingState.HostingMode,
-        chipLabel: String?
+        mode: OnboardingState.HostingMode
     ) -> some View {
-        let isDisabled = chipLabel != nil
-        let isSelected = state.selectedHostingMode == mode && !isDisabled
+        let isSelected = state.selectedHostingMode == mode
 
         return Button(action: {
-            guard !isDisabled else { return }
             state.selectedHostingMode = mode
         }) {
-            HStack(spacing: VSpacing.md) {
-                VIconView(icon, size: 18)
-                    .foregroundStyle(isDisabled ? VColor.contentTertiary : (isSelected ? VColor.primaryBase : VColor.contentSecondary))
+            HStack(spacing: VSpacing.sm) {
+                HStack(spacing: VSpacing.md) {
+                    VIconView(icon, size: 14)
+                        .foregroundStyle(VColor.contentTertiary)
+                        .frame(width: 20, height: 20)
 
-                VStack(alignment: .leading, spacing: 2) {
-                    HStack(spacing: VSpacing.sm) {
+                    VStack(alignment: .leading, spacing: VSpacing.xxs) {
                         Text(title)
-                            .font(VFont.bodyLargeEmphasised)
-                            .foregroundStyle(isDisabled ? VColor.contentTertiary : VColor.contentDefault)
-
-                        Spacer()
-
-                        if let chipLabel {
-                            Text(chipLabel)
-                                .font(VFont.labelDefault)
-                                .foregroundStyle(VColor.contentTertiary)
-                                .padding(.horizontal, VSpacing.sm)
-                                .padding(.vertical, VSpacing.xxs)
-                                .background(VColor.surfaceActive)
-                                .clipShape(Capsule())
-                        }
+                            .font(VFont.bodyMediumEmphasised)
+                            .foregroundStyle(VColor.contentEmphasized)
+                        Text(subtitle)
+                            .font(VFont.labelDefault)
+                            .foregroundStyle(VColor.contentTertiary)
+                            .lineLimit(2)
                     }
-                    Text(subtitle)
-                        .font(VFont.bodySmallDefault)
-                        .foregroundStyle(isDisabled ? VColor.contentTertiary : VColor.contentSecondary)
                 }
 
-                if chipLabel == nil {
-                    Spacer()
+                Spacer()
 
-                    Circle()
-                        .fill(isSelected ? VColor.primaryBase : Color.clear)
-                        .overlay(
-                            Circle().stroke(isSelected ? VColor.primaryBase : VColor.borderBase, lineWidth: 1.5)
-                        )
-                        .overlay(
-                            isSelected
-                                ? Circle().fill(VColor.auxWhite).frame(width: 6, height: 6)
-                                : nil
-                        )
-                        .frame(width: 18, height: 18)
-                }
+                Circle()
+                    .fill(isSelected ? VColor.primaryBase : Color.clear)
+                    .overlay(
+                        Circle().stroke(isSelected ? VColor.primaryBase : VColor.borderElement, lineWidth: 1.5)
+                    )
+                    .overlay(
+                        isSelected
+                            ? Circle().fill(VColor.auxWhite).frame(width: 6, height: 6)
+                            : nil
+                    )
+                    .frame(width: 16, height: 16)
             }
-            .padding(.horizontal, VSpacing.lg)
-            .padding(.vertical, VSpacing.md)
-            .frame(minHeight: 80)
+            .padding(VSpacing.md)
+            .frame(height: 72)
             .contentShape(Rectangle())
             .background(
-                RoundedRectangle(cornerRadius: VRadius.xl)
-                    .fill(isSelected ? VColor.primaryBase.opacity(0.1) : Color.clear)
+                RoundedRectangle(cornerRadius: VRadius.lg)
+                    .fill(isSelected ? VColor.primaryBase.opacity(0.05) : Color.clear)
                     .overlay(
-                        RoundedRectangle(cornerRadius: VRadius.xl)
+                        RoundedRectangle(cornerRadius: VRadius.lg)
                             .stroke(
-                                isSelected ? VColor.primaryBase.opacity(0.5)
-                                    : (isDisabled ? VColor.borderDisabled : VColor.borderBase),
-                                lineWidth: 2
+                                isSelected ? VColor.primaryBase.opacity(0.5) : VColor.borderDisabled,
+                                lineWidth: 1
                             )
                     )
             )
-            .opacity(isDisabled ? 0.85 : 1.0)
         }
         .buttonStyle(.plain)
         .disabled(isDisabled)

--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -267,7 +267,6 @@ struct APIKeyStepView: View {
             )
         }
         .buttonStyle(.plain)
-        .disabled(isDisabled)
         .pointerCursor()
     }
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -103,7 +103,7 @@ struct APIKeyStepView: View {
             .padding(.bottom, VSpacing.md)
 
         Text("Where do you want your assistant to live?")
-            .font(VFont.titleSmall)
+            .font(VFont.bodyMediumLighter)
             .foregroundStyle(VColor.contentSecondary)
             .opacity(showTitle ? 1 : 0)
             .offset(y: showTitle ? 0 : 8)

--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -109,10 +109,10 @@ struct APIKeyStepView: View {
             .offset(y: showTitle ? 0 : 8)
             .padding(.bottom, VSpacing.xxl)
 
-        VStack(spacing: VSpacing.md) {
-            VStack(spacing: VSpacing.md) {
-                hostingCards
+        VStack(spacing: 0) {
+            hostingCards
 
+            VStack(spacing: VSpacing.sm) {
                 VButton(label: continueButtonTitle, style: .primary, isFullWidth: true, isDisabled: !canContinue) {
                     handleContinue()
                 }
@@ -122,16 +122,18 @@ struct APIKeyStepView: View {
                         goBack()
                     }
                 }
-
-                Text("Need help choosing?")
-                    .font(VFont.bodyMediumDefault)
-                    .foregroundStyle(VColor.contentDefault)
-                    .underline()
-                    .onTapGesture {
-                        NSWorkspace.shared.open(AppURLs.hostingOptionsDocs)
-                    }
-                    .pointerCursor()
             }
+            .padding(.top, VSpacing.xxl)
+
+            Text("Need help choosing?")
+                .font(VFont.bodyMediumDefault)
+                .foregroundStyle(VColor.contentDefault)
+                .underline()
+                .onTapGesture {
+                    NSWorkspace.shared.open(AppURLs.hostingOptionsDocs)
+                }
+                .pointerCursor()
+                .padding(.top, VSpacing.xl)
         }
         .padding(.horizontal, VSpacing.xxl)
         .opacity(showContent ? 1 : 0)

--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -191,7 +191,7 @@ struct APIKeyStepView: View {
                     for: mode,
                     appleContainerEnabled: appleContainerEnabled
                 )
-                let requiresAccount = mode == .vellumCloud && (!isAuthenticated || state.skippedAuth)
+                let requiresAccount = mode == .vellumCloud && !isAuthenticated
                 hostingCard(
                     icon: iconForMode(mode),
                     title: title,

--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -129,6 +129,7 @@ struct APIKeyStepView: View {
                 .font(VFont.bodyMediumDefault)
                 .foregroundStyle(VColor.contentDefault)
                 .underline()
+                .accessibilityAddTraits(.isLink)
                 .onTapGesture {
                     NSWorkspace.shared.open(AppURLs.hostingOptionsDocs)
                 }
@@ -190,11 +191,14 @@ struct APIKeyStepView: View {
                     for: mode,
                     appleContainerEnabled: appleContainerEnabled
                 )
+                let requiresAccount = mode == .vellumCloud && (!isAuthenticated || state.skippedAuth)
                 hostingCard(
                     icon: iconForMode(mode),
                     title: title,
                     subtitle: subtitle,
-                    mode: mode
+                    mode: mode,
+                    isDisabled: requiresAccount,
+                    chipLabel: requiresAccount ? "Requires Account" : nil
                 )
             }
         }
@@ -215,11 +219,14 @@ struct APIKeyStepView: View {
         icon: VIcon,
         title: String,
         subtitle: String,
-        mode: OnboardingState.HostingMode
+        mode: OnboardingState.HostingMode,
+        isDisabled: Bool = false,
+        chipLabel: String? = nil
     ) -> some View {
-        let isSelected = state.selectedHostingMode == mode
+        let isSelected = state.selectedHostingMode == mode && !isDisabled
 
         return Button(action: {
+            guard !isDisabled else { return }
             state.selectedHostingMode = mode
         }) {
             HStack(spacing: VSpacing.sm) {
@@ -229,9 +236,20 @@ struct APIKeyStepView: View {
                         .frame(width: 20, height: 20)
 
                     VStack(alignment: .leading, spacing: VSpacing.xxs) {
-                        Text(title)
-                            .font(VFont.bodyMediumEmphasised)
-                            .foregroundStyle(VColor.contentEmphasized)
+                        HStack(spacing: VSpacing.sm) {
+                            Text(title)
+                                .font(VFont.bodyMediumEmphasised)
+                                .foregroundStyle(isDisabled ? VColor.contentTertiary : VColor.contentEmphasized)
+                            if let chipLabel {
+                                Text(chipLabel)
+                                    .font(VFont.labelDefault)
+                                    .foregroundStyle(VColor.contentTertiary)
+                                    .padding(.horizontal, VSpacing.sm)
+                                    .padding(.vertical, VSpacing.xxs)
+                                    .background(VColor.surfaceBase)
+                                    .clipShape(Capsule())
+                            }
+                        }
                         Text(subtitle)
                             .font(VFont.labelDefault)
                             .foregroundStyle(VColor.contentTertiary)
@@ -241,17 +259,19 @@ struct APIKeyStepView: View {
 
                 Spacer()
 
-                Circle()
-                    .fill(isSelected ? VColor.primaryBase : Color.clear)
-                    .overlay(
-                        Circle().stroke(isSelected ? VColor.primaryBase : VColor.borderElement, lineWidth: 1.5)
-                    )
-                    .overlay(
-                        isSelected
-                            ? Circle().fill(VColor.auxWhite).frame(width: 6, height: 6)
-                            : nil
-                    )
-                    .frame(width: 16, height: 16)
+                if !isDisabled {
+                    Circle()
+                        .fill(isSelected ? VColor.primaryBase : Color.clear)
+                        .overlay(
+                            Circle().stroke(isSelected ? VColor.primaryBase : VColor.borderElement, lineWidth: 1.5)
+                        )
+                        .overlay(
+                            isSelected
+                                ? Circle().fill(VColor.auxWhite).frame(width: 6, height: 6)
+                                : nil
+                        )
+                        .frame(width: 16, height: 16)
+                }
             }
             .padding(VSpacing.md)
             .frame(height: 72)
@@ -269,6 +289,8 @@ struct APIKeyStepView: View {
             )
         }
         .buttonStyle(.plain)
+        .disabled(isDisabled)
+        .opacity(isDisabled ? 0.7 : 1.0)
         .pointerCursor()
     }
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -181,10 +181,10 @@ struct HatchingStepView: View {
                     .font(VFont.titleLarge)
                     .foregroundStyle(VColor.contentDefault)
             } else {
-                Text("Waking up...")
+                Text("Waking Up")
                     .font(VFont.titleLarge)
                     .foregroundStyle(VColor.contentDefault)
-                Text("Hang tight \u{2014} your assistant will have a few\nquestions for you once it\u{2019}s up.")
+                Text("Hang tight - your assistant will have a few questions once it's up.")
                     .font(VFont.bodySmallDefault)
                     .foregroundStyle(VColor.contentTertiary)
                     .multilineTextAlignment(.center)

--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -243,7 +243,7 @@ struct HatchingStepView: View {
             }
             if let label = state.hatchStepLabel {
                 Text(label)
-                    .font(VFont.labelSmallDefault)
+                    .font(VFont.labelSmall)
                     .foregroundStyle(VColor.contentTertiary)
             }
         }

--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -36,12 +36,13 @@ struct HatchingStepView: View {
 
     var body: some View {
         VStack(spacing: VSpacing.lg) {
+            statusText
+
             Spacer()
 
             characterAnimation
-                .padding(.bottom, VSpacing.xl)
 
-            statusText
+            Spacer()
 
             if showProgressBar {
                 progressSection
@@ -50,8 +51,6 @@ struct HatchingStepView: View {
             if state.hatchFailed {
                 failureButtons
             }
-
-            Spacer()
 
             if let characters = Self.welcomeCharacters {
                 Image(nsImage: characters)
@@ -205,12 +204,12 @@ struct HatchingStepView: View {
                     .font(VFont.titleLarge)
                     .foregroundStyle(VColor.contentDefault)
             } else {
-                Text("Waking Up")
+                Text("Waking up...")
                     .font(VFont.titleLarge)
                     .foregroundStyle(VColor.contentDefault)
-                Text("Hang tight - your assistant will have a few questions once it's up.")
-                    .font(VFont.bodySmallDefault)
-                    .foregroundStyle(VColor.contentTertiary)
+                Text("Hang tight - your assistant will have a few questions for you once it's up.")
+                    .font(VFont.bodyMediumLighter)
+                    .foregroundStyle(VColor.contentSecondary)
                     .multilineTextAlignment(.center)
             }
         }

--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -127,7 +127,9 @@ struct HatchingStepView: View {
         .onChange(of: state.hatchFailed) { _, failed in
             if failed {
                 // Stop the pulse animation but keep the character visible.
-                pulseScale = 1.0
+                withAnimation(.easeOut(duration: 0.3)) {
+                    pulseScale = 1.0
+                }
             }
         }
     }
@@ -238,6 +240,9 @@ struct HatchingStepView: View {
                     }
                 }
                 .frame(maxWidth: 200, maxHeight: 6)
+                .accessibilityElement()
+                .accessibilityValue("\(Int(progress * 100)) percent")
+                .accessibilityLabel("Setup progress")
             }
             if let label = state.hatchStepLabel {
                 Text(label)

--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -226,16 +226,24 @@ struct HatchingStepView: View {
     }
 
     private var progressSection: some View {
-        VStack(spacing: VSpacing.xs) {
+        VStack(spacing: VSpacing.lg) {
             TimelineView(.animation) { context in
-                ProgressView(value: progressValue(at: context.date))
-                    .progressViewStyle(.linear)
-                    .tint(VColor.primaryBase)
-                    .frame(maxWidth: 240)
+                let progress = progressValue(at: context.date)
+                GeometryReader { geo in
+                    ZStack(alignment: .leading) {
+                        Capsule()
+                            .fill(VColor.surfaceBase)
+                            .frame(height: 6)
+                        Capsule()
+                            .fill(VColor.primaryBase)
+                            .frame(width: geo.size.width * progress, height: 6)
+                    }
+                }
+                .frame(maxWidth: 200, maxHeight: 6)
             }
             if let label = state.hatchStepLabel {
                 Text(label)
-                    .font(VFont.bodySmallDefault)
+                    .font(VFont.labelSmallDefault)
                     .foregroundStyle(VColor.contentTertiary)
             }
         }

--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -126,11 +126,8 @@ struct HatchingStepView: View {
         }
         .onChange(of: state.hatchFailed) { _, failed in
             if failed {
-                // Stop the pulse animation and fade out the character
-                // so it doesn't keep pulsing behind the error text.
-                withAnimation(.easeOut(duration: 0.3)) {
-                    showCharacter = false
-                }
+                // Stop the pulse animation but keep the character visible.
+                pulseScale = 1.0
             }
         }
     }

--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -27,6 +27,7 @@ struct HatchingStepView: View {
     private var managedSignInEnabled: Bool {
         MacOSClientFeatureFlagManager.shared.isEnabled("managed-sign-in")
     }
+    @State private var showFooterCharacters = false
     @State private var completionTask: Task<Void, Never>?
     @State private var isAnimatingProgress: Bool = false
     @State private var progressStartTime: CFAbsoluteTime?
@@ -51,6 +52,24 @@ struct HatchingStepView: View {
             }
 
             Spacer()
+
+            if let characters = Self.welcomeCharacters {
+                Image(nsImage: characters)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(maxWidth: .infinity)
+                    .clipShape(UnevenRoundedRectangle(
+                        topLeadingRadius: 0,
+                        bottomLeadingRadius: VRadius.window,
+                        bottomTrailingRadius: VRadius.window,
+                        topTrailingRadius: 0
+                    ))
+                    .opacity(showFooterCharacters ? 1 : 0)
+                    .offset(y: showFooterCharacters ? 0 : 30)
+                    .animation(.easeOut(duration: 0.6).delay(0.5), value: showFooterCharacters)
+                    .onAppear { showFooterCharacters = true }
+                    .accessibilityHidden(true)
+            }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .opacity(showContent ? 1 : 0)
@@ -114,6 +133,11 @@ struct HatchingStepView: View {
             }
         }
     }
+
+    private static let welcomeCharacters: NSImage? = {
+        guard let url = ResourceBundle.bundle.url(forResource: "welcome-characters", withExtension: "png") else { return nil }
+        return NSImage(contentsOf: url)
+    }()
 
     // MARK: - Avatar
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -36,6 +36,8 @@ struct HatchingStepView: View {
 
     var body: some View {
         VStack(spacing: VSpacing.lg) {
+            Color.clear.frame(height: VSpacing.xxxl)
+
             statusText
 
             Spacer()

--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -36,7 +36,7 @@ struct HatchingStepView: View {
 
     var body: some View {
         VStack(spacing: VSpacing.lg) {
-            Color.clear.frame(height: VSpacing.xxxl)
+            Color.clear.frame(height: VSpacing.xxl)
 
             statusText
 
@@ -154,14 +154,14 @@ struct HatchingStepView: View {
                 Image(nsImage: image)
                     .resizable()
                     .aspectRatio(contentMode: .fit)
-                    .frame(width: 100, height: 100)
+                    .frame(width: 122, height: 125)
                     .scaleEffect(characterAwake ? 1.1 : pulseScale)
                     .opacity(showCharacter ? (characterAwake ? 1.0 : 0.6) : 0)
                     .animation(.spring(duration: 0.6, bounce: 0.3), value: characterAwake)
                     .accessibilityHidden(true)
             }
         }
-        .frame(width: 120, height: 120)
+        .frame(width: 140, height: 140)
     }
 
     private func startPulse() {

--- a/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
@@ -25,13 +25,13 @@ struct ImproveExperienceStepView: View {
 
     var body: some View {
         Text("Before You Start")
-            .font(VFont.displayLarge)
+            .font(VFont.titleLarge)
             .foregroundStyle(VColor.contentDefault)
             .opacity(showTitle ? 1 : 0)
             .offset(y: showTitle ? 0 : 8)
             .padding(.bottom, VSpacing.md)
 
-        Text("Choose your privacy preferences. You can update these anytime in the settings.")
+        Text("Choose your privacy preferences. You can update these anytime in the Settings.")
             .font(VFont.titleSmall)
             .multilineTextAlignment(.center)
             .foregroundStyle(VColor.contentSecondary)
@@ -40,9 +40,7 @@ struct ImproveExperienceStepView: View {
             .padding(.bottom, VSpacing.xxl)
 
         VStack(spacing: VSpacing.md) {
-            VStack(spacing: VSpacing.md) {
-                SettingsDivider()
-
+            VStack(spacing: VSpacing.sm) {
                 // Usage analytics toggle
                 VToggle(
                     isOn: $collectUsageData,
@@ -50,6 +48,15 @@ struct ImproveExperienceStepView: View {
                     helperText: "Send anonymous product usage data."
                 )
                 .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(VSpacing.md)
+                .background(
+                    RoundedRectangle(cornerRadius: VRadius.lg)
+                        .fill(VColor.surfaceLift)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: VRadius.lg)
+                                .stroke(VColor.surfaceBase, lineWidth: 1)
+                        )
+                )
 
                 // Diagnostics toggle
                 VToggle(
@@ -58,6 +65,15 @@ struct ImproveExperienceStepView: View {
                     helperText: "Send crash reports and performance metrics."
                 )
                 .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(VSpacing.md)
+                .background(
+                    RoundedRectangle(cornerRadius: VRadius.lg)
+                        .fill(VColor.surfaceLift)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: VRadius.lg)
+                                .stroke(VColor.surfaceBase, lineWidth: 1)
+                        )
+                )
 
                 // Privacy note bar
                 HStack(spacing: VSpacing.xs) {

--- a/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
@@ -84,7 +84,7 @@ struct ImproveExperienceStepView: View {
                     saveAndContinue()
                 }
 
-                VButton(label: "Back", style: .outlined) {
+                VButton(label: "Back", style: .outlined, isFullWidth: true) {
                     goBack()
                 }
             }

--- a/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
@@ -32,7 +32,7 @@ struct ImproveExperienceStepView: View {
             .padding(.bottom, VSpacing.md)
 
         Text("Choose your privacy preferences. You can update these anytime in the Settings.")
-            .font(VFont.titleSmall)
+            .font(VFont.bodyMediumLighter)
             .multilineTextAlignment(.center)
             .foregroundStyle(VColor.contentSecondary)
             .opacity(showTitle ? 1 : 0)

--- a/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
@@ -84,8 +84,7 @@ struct ImproveExperienceStepView: View {
                         .font(VFont.bodySmallDefault)
                         .foregroundStyle(VColor.contentTertiary)
                 }
-                .padding(.horizontal, VSpacing.sm)
-                .padding(.vertical, VSpacing.xs)
+                .padding(EdgeInsets(top: VSpacing.xs, leading: VSpacing.sm, bottom: VSpacing.xs, trailing: VSpacing.sm))
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .background(VColor.surfaceBase)
                 .clipShape(RoundedRectangle(cornerRadius: VRadius.md))

--- a/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
@@ -25,7 +25,7 @@ struct ImproveExperienceStepView: View {
             .offset(y: showTitle ? 0 : 8)
             .padding(.bottom, VSpacing.md)
 
-        Text("Choose your privacy preferences.\nYou can update these anytime in Settings.")
+        Text("Choose your privacy preferences. You can update these anytime in the settings.")
             .font(VFont.titleSmall)
             .multilineTextAlignment(.center)
             .foregroundStyle(VColor.contentSecondary)
@@ -35,46 +35,52 @@ struct ImproveExperienceStepView: View {
 
         VStack(spacing: VSpacing.md) {
             VStack(spacing: VSpacing.md) {
-                // Privacy toggles card
-                VCard {
-                    VStack(spacing: VSpacing.lg) {
-                        // Usage analytics toggle
-                        VToggle(
-                            isOn: $collectUsageData,
-                            label: "Share Analytics",
-                            helperText: "Send anonymous product usage data. Your conversations and personal data are never included."
-                        )
-                        .frame(maxWidth: .infinity, alignment: .leading)
+                SettingsDivider()
 
-                        SettingsDivider()
+                // Usage analytics toggle
+                VToggle(
+                    isOn: $collectUsageData,
+                    label: "Share Analytics",
+                    helperText: "Send anonymous product usage data."
+                )
+                .frame(maxWidth: .infinity, alignment: .leading)
 
-                        // Diagnostics toggle
-                        VToggle(
-                            isOn: $sendDiagnostics,
-                            label: "Share Diagnostics",
-                            helperText: "Send crash reports and performance metrics. Your conversations and personal data are never included."
-                        )
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                    }
+                // Diagnostics toggle
+                VToggle(
+                    isOn: $sendDiagnostics,
+                    label: "Share Diagnostics",
+                    helperText: "Send crash reports and performance metrics."
+                )
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+                // Privacy note bar
+                HStack(spacing: VSpacing.xs) {
+                    VIconView(.eyeOff, size: 14)
+                        .foregroundStyle(VColor.contentTertiary)
+                    Text("Your conversations and personal data are never included.")
+                        .font(VFont.bodySmallDefault)
+                        .foregroundStyle(VColor.contentTertiary)
                 }
+                .padding(.horizontal, VSpacing.sm)
+                .padding(.vertical, VSpacing.xs)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(VColor.surfaceBase)
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
 
                 // ToS consent checkbox
-                VCard {
-                    HStack(spacing: VSpacing.md) {
-                        tosCheckbox
-                        tosConsentText
-                    }
-                    .frame(maxWidth: .infinity, alignment: .leading)
+                HStack(spacing: VSpacing.md) {
+                    tosCheckbox
+                    tosConsentText
                 }
+                .frame(maxWidth: .infinity, alignment: .leading)
 
-                VButton(label: "Accept and Start", style: .primary, isFullWidth: true, isDisabled: !tosAccepted) {
+                VButton(label: "Start", style: .primary, isFullWidth: true, isDisabled: !tosAccepted) {
                     saveAndContinue()
                 }
 
-                VButton(label: "Back", style: .ghost) {
+                VButton(label: "Back", style: .outlined) {
                     goBack()
                 }
-                .padding(.top, VSpacing.xs)
             }
         }
         .padding(.horizontal, VSpacing.xxl)

--- a/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
@@ -37,9 +37,10 @@ struct ImproveExperienceStepView: View {
             .foregroundStyle(VColor.contentSecondary)
             .opacity(showTitle ? 1 : 0)
             .offset(y: showTitle ? 0 : 8)
+            .padding(.horizontal, VSpacing.xxl)
             .padding(.bottom, VSpacing.xxl)
 
-        VStack(spacing: VSpacing.md) {
+        VStack(spacing: 0) {
             VStack(spacing: VSpacing.sm) {
                 // Usage analytics toggle
                 VToggle(
@@ -95,7 +96,9 @@ struct ImproveExperienceStepView: View {
                     tosConsentText
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
+            }
 
+            VStack(spacing: VSpacing.sm) {
                 VButton(label: "Start", style: .primary, isFullWidth: true, isDisabled: !tosAccepted) {
                     saveAndContinue()
                 }
@@ -104,6 +107,7 @@ struct ImproveExperienceStepView: View {
                     goBack()
                 }
             }
+            .padding(.top, VSpacing.xxl)
         }
         .padding(.horizontal, VSpacing.xxl)
         .opacity(showContent ? 1 : 0)

--- a/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
@@ -13,6 +13,12 @@ struct ImproveExperienceStepView: View {
 
     @State private var showTitle = false
     @State private var showContent = false
+    @State private var showCharacters = false
+
+    private static let welcomeCharacters: NSImage? = {
+        guard let url = ResourceBundle.bundle.url(forResource: "welcome-characters", withExtension: "png") else { return nil }
+        return NSImage(contentsOf: url)
+    }()
     @AppStorage("collectUsageData") private var collectUsageData: Bool = true
     @AppStorage("sendDiagnostics") private var sendDiagnostics: Bool = true
     @AppStorage("tosAccepted") private var tosAccepted: Bool = false
@@ -93,6 +99,26 @@ struct ImproveExperienceStepView: View {
             withAnimation(.easeOut(duration: 0.5).delay(0.3)) {
                 showContent = true
             }
+        }
+
+        Spacer()
+
+        if let characters = Self.welcomeCharacters {
+            Image(nsImage: characters)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(maxWidth: .infinity)
+                .clipShape(UnevenRoundedRectangle(
+                    topLeadingRadius: 0,
+                    bottomLeadingRadius: VRadius.window,
+                    bottomTrailingRadius: VRadius.window,
+                    topTrailingRadius: 0
+                ))
+                .opacity(showCharacters ? 1 : 0)
+                .offset(y: showCharacters ? 0 : 30)
+                .animation(.easeOut(duration: 0.6).delay(0.5), value: showCharacters)
+                .onAppear { showCharacters = true }
+                .accessibilityHidden(true)
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
@@ -89,6 +89,7 @@ struct ImproveExperienceStepView: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .background(VColor.surfaceBase)
                 .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                .padding(.bottom, VSpacing.sm)
 
                 // ToS consent checkbox
                 HStack(spacing: VSpacing.md) {

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -59,7 +59,7 @@ struct OnboardingFlowView: View {
                 VStack(spacing: 0) {
                     // Fixed top inset — positions the icon 93px from the
                     // top of the container, matching the Figma spec.
-                    Color.clear.frame(height: 93)
+                    Color.clear.frame(height: 80)
 
                     if let nsImage = Self.appIcon {
                         Image(nsImage: nsImage)

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -68,7 +68,7 @@ struct OnboardingFlowView: View {
                             .frame(width: 80, height: 80)
                             .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
                             .shadow(color: .black.opacity(0.15), radius: 1, x: 0, y: 1)
-                            .padding(.bottom, VSpacing.xxxl)
+                            .padding(.bottom, 78)
                     }
 
                     // Step content — Group flattens into parent VStack so

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -57,18 +57,22 @@ struct OnboardingFlowView: View {
                 // Onboarding flow: WakeUp → HostingSelector → APIKeyEntry → ImproveExperience (steps 0–3)
                 ScrollView(.vertical, showsIndicators: false) {
                 VStack(spacing: 0) {
-                    // Fixed top inset — positions the icon 93px from the
-                    // top of the container, matching the Figma spec.
-                    Color.clear.frame(height: 80)
+                    if state.currentStep == 0 {
+                        // Step 0 only: top inset + app icon
+                        Color.clear.frame(height: 80)
 
-                    if let nsImage = Self.appIcon {
-                        Image(nsImage: nsImage)
-                            .resizable()
-                            .aspectRatio(contentMode: .fit)
-                            .frame(width: 80, height: 80)
-                            .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
-                            .shadow(color: .black.opacity(0.15), radius: 1, x: 0, y: 1)
-                            .padding(.bottom, 78)
+                        if let nsImage = Self.appIcon {
+                            Image(nsImage: nsImage)
+                                .resizable()
+                                .aspectRatio(contentMode: .fit)
+                                .frame(width: 80, height: 80)
+                                .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+                                .shadow(color: .black.opacity(0.15), radius: 1, x: 0, y: 1)
+                                .padding(.bottom, 78)
+                        }
+                    } else {
+                        // Steps 1–3: top inset only (no icon)
+                        Color.clear.frame(height: VSpacing.xxxl)
                     }
 
                     // Step content — Group flattens into parent VStack so

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -147,9 +147,10 @@ struct OnboardingFlowView: View {
                     .id(isBootstrappingManaged ? -1 : state.currentStep)
 
                     // Bottom padding so content isn't flush with window edge.
-                    // Skip for steps with characters footer (0, 2, 3) where the
-                    // graphic is designed to sit flush at the window bottom.
-                    if (state.currentStep != 0 && state.currentStep != 2 && state.currentStep != 3) || isBootstrappingManaged {
+                    // All onboarding steps now have a characters footer that sits
+                    // flush at the window bottom, so only add padding for the
+                    // managed bootstrap view.
+                    if isBootstrappingManaged {
                         Color.clear.frame(height: VSpacing.xxl)
                     }
                 }

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -65,9 +65,10 @@ struct OnboardingFlowView: View {
                         Image(nsImage: nsImage)
                             .resizable()
                             .aspectRatio(contentMode: .fit)
-                            .frame(width: 96, height: 96)
-                            .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
-                            .padding(.bottom, VSpacing.xl)
+                            .frame(width: 80, height: 80)
+                            .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+                            .shadow(color: .black.opacity(0.15), radius: 1, x: 0, y: 1)
+                            .padding(.bottom, VSpacing.xxxl)
                     }
 
                     // Step content — Group flattens into parent VStack so

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -174,7 +174,7 @@ struct OnboardingFlowView: View {
             }
         }
         }
-        .frame(minWidth: 460, minHeight: 700)
+        .frame(minWidth: 440, minHeight: 630)
         .task {
             if !authManager.isAuthenticated {
                 await authManager.checkSession()

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -57,9 +57,9 @@ struct OnboardingFlowView: View {
                 // Onboarding flow: WakeUp → HostingSelector → APIKeyEntry → ImproveExperience (steps 0–3)
                 ScrollView(.vertical, showsIndicators: false) {
                 VStack(spacing: 0) {
-                    // Fixed top inset — positions the icon consistently
-                    // across all steps regardless of bottom content weight.
-                    Color.clear.frame(height: VSpacing.xxxl)
+                    // Fixed top inset — positions the icon 93px from the
+                    // top of the container, matching the Figma spec.
+                    Color.clear.frame(height: 93)
 
                     if let nsImage = Self.appIcon {
                         Image(nsImage: nsImage)

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -147,9 +147,9 @@ struct OnboardingFlowView: View {
                     .id(isBootstrappingManaged ? -1 : state.currentStep)
 
                     // Bottom padding so content isn't flush with window edge.
-                    // Skip for steps with characters footer (0, 2) where the
+                    // Skip for steps with characters footer (0, 2, 3) where the
                     // graphic is designed to sit flush at the window bottom.
-                    if (state.currentStep != 0 && state.currentStep != 2) || isBootstrappingManaged {
+                    if (state.currentStep != 0 && state.currentStep != 2 && state.currentStep != 3) || isBootstrappingManaged {
                         Color.clear.frame(height: VSpacing.xxl)
                     }
                 }

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingWindow.swift
@@ -41,7 +41,7 @@ final class OnboardingWindow {
         let hostingController = NSHostingController(rootView: flowView)
 
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 520, height: 740),
+            contentRect: NSRect(x: 0, y: 0, width: 440, height: 630),
             styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
             backing: .buffered,
             defer: false

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingWindow.swift
@@ -54,10 +54,10 @@ final class OnboardingWindow {
         window.backgroundColor = NSColor(VColor.surfaceOverlay)
         window.isReleasedWhenClosed = false
 
-        window.contentMinSize = NSSize(width: 460, height: 700)
+        window.contentMinSize = NSSize(width: 440, height: 630)
 
-        let startWidth: CGFloat = 520
-        let startHeight: CGFloat = 740
+        let startWidth: CGFloat = 440
+        let startHeight: CGFloat = 630
         if let visibleFrame = Self.visibleScreenFrame() {
             let x = visibleFrame.midX - startWidth / 2
             let y = visibleFrame.midY - startHeight / 2

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingWindow.swift
@@ -53,6 +53,9 @@ final class OnboardingWindow {
         window.isMovableByWindowBackground = true
         window.backgroundColor = NSColor(VColor.surfaceOverlay)
         window.isReleasedWhenClosed = false
+        window.contentView?.wantsLayer = true
+        window.contentView?.layer?.cornerRadius = 24
+        window.contentView?.layer?.masksToBounds = true
 
         window.contentMinSize = NSSize(width: 440, height: 630)
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingWindow.swift
@@ -53,9 +53,6 @@ final class OnboardingWindow {
         window.isMovableByWindowBackground = true
         window.backgroundColor = NSColor(VColor.surfaceOverlay)
         window.isReleasedWhenClosed = false
-        window.contentView?.wantsLayer = true
-        window.contentView?.layer?.cornerRadius = 24
-        window.contentView?.layer?.masksToBounds = true
 
         window.contentMinSize = NSSize(width: 440, height: 630)
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
@@ -39,7 +39,7 @@ struct WakeUpStepView: View {
     var body: some View {
         // Title
         Text("Welcome to Vellum")
-            .font(VFont.displayLarge)
+            .font(VFont.titleLarge)
             .foregroundStyle(VColor.contentDefault)
             .opacity(showTitle ? 1 : 0)
             .offset(y: showTitle ? 0 : 8)
@@ -54,10 +54,8 @@ struct WakeUpStepView: View {
             .offset(y: showSubtext ? 0 : 8)
             .padding(.bottom, VSpacing.xxl)
 
-        Color.clear.frame(height: VSpacing.xxl)
-
         // Buttons
-        VStack(spacing: VSpacing.md) {
+        VStack(spacing: VSpacing.sm) {
             if authManager?.isLoading == true {
                 HStack(spacing: VSpacing.sm) {
                     ProgressView()
@@ -79,17 +77,13 @@ struct WakeUpStepView: View {
                 }
                 .frame(height: 36)
             } else if managedSignInEnabled {
-                HStack(spacing: VSpacing.sm) {
-                    VButton(label: "Sign In", style: .primary) {
-                        onContinueWithVellum()
-                    }
-                    .frame(maxWidth: .infinity)
+                VButton(label: "Log In", style: .primary, isFullWidth: true) {
+                    onContinueWithVellum()
+                }
 
-                    VButton(label: "Self-Host", style: .outlined) {
-                        state?.skippedAuth = true
-                        onStartWithAPIKey()
-                    }
-                    .frame(maxWidth: .infinity)
+                VButton(label: "Continue Without Account", style: .outlined, isFullWidth: true) {
+                    state?.skippedAuth = true
+                    onStartWithAPIKey()
                 }
             } else {
                 VButton(label: "Get Started", style: .primary, isFullWidth: true) {
@@ -105,7 +99,8 @@ struct WakeUpStepView: View {
                     .multilineTextAlignment(.center)
             }
         }
-        .frame(maxWidth: 280)
+        .frame(maxWidth: .infinity)
+        .padding(.horizontal, VSpacing.xxl)
         .opacity(showButtons ? 1 : 0)
         .offset(y: showButtons ? 0 : 12)
         .disabled(isAdvancing || authManager?.isSubmitting == true)
@@ -123,7 +118,7 @@ struct WakeUpStepView: View {
 
         Spacer()
 
-        Text("\u{00A9} 2026 Vellum Inc.")
+        Text("2026 Vellum Inc.")
             .font(VFont.bodySmallDefault)
             .foregroundStyle(VColor.borderElement)
             .padding(.bottom, VSpacing.sm)

--- a/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
@@ -47,12 +47,12 @@ struct WakeUpStepView: View {
 
         // Subtitle
         Text("The safest way to create your personal assistant.")
-            .font(VFont.titleSmall)
+            .font(VFont.bodyMediumLighter)
             .foregroundStyle(VColor.contentSecondary)
             .multilineTextAlignment(.center)
             .opacity(showSubtext ? 1 : 0)
             .offset(y: showSubtext ? 0 : 8)
-            .padding(.bottom, VSpacing.xxl)
+            .padding(.bottom, VSpacing.xxxl)
 
         // Buttons
         VStack(spacing: VSpacing.sm) {

--- a/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
@@ -52,7 +52,7 @@ struct WakeUpStepView: View {
             .multilineTextAlignment(.center)
             .opacity(showSubtext ? 1 : 0)
             .offset(y: showSubtext ? 0 : 8)
-            .padding(.bottom, VSpacing.xxxl)
+            .padding(.bottom, VSpacing.xxl)
 
         // Buttons
         VStack(spacing: VSpacing.sm) {

--- a/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
@@ -46,7 +46,7 @@ struct WakeUpStepView: View {
             .padding(.bottom, VSpacing.md)
 
         // Subtitle
-        Text("Your personal AI assistant,\nrunning on your terms.")
+        Text("The safest way to create your personal assistant.")
             .font(VFont.titleSmall)
             .foregroundStyle(VColor.contentSecondary)
             .multilineTextAlignment(.center)
@@ -79,13 +79,17 @@ struct WakeUpStepView: View {
                 }
                 .frame(height: 36)
             } else if managedSignInEnabled {
-                VButton(label: "Log In", style: .primary, isFullWidth: true) {
-                    onContinueWithVellum()
-                }
+                HStack(spacing: VSpacing.sm) {
+                    VButton(label: "Sign In", style: .primary) {
+                        onContinueWithVellum()
+                    }
+                    .frame(maxWidth: .infinity)
 
-                VButton(label: "Continue without account", style: .ghost) {
-                    state?.skippedAuth = true
-                    onStartWithAPIKey()
+                    VButton(label: "Self-Host", style: .outlined) {
+                        state?.skippedAuth = true
+                        onStartWithAPIKey()
+                    }
+                    .frame(maxWidth: .infinity)
                 }
             } else {
                 VButton(label: "Get Started", style: .primary, isFullWidth: true) {
@@ -121,7 +125,7 @@ struct WakeUpStepView: View {
 
         Text("\u{00A9} 2026 Vellum Inc.")
             .font(VFont.bodySmallDefault)
-            .foregroundStyle(VColor.contentTertiary.opacity(0.5))
+            .foregroundStyle(VColor.borderElement)
             .padding(.bottom, VSpacing.sm)
 
         // Characters peeking up from the bottom — single composed image


### PR DESCRIPTION
## Summary
Updates the macOS onboarding/setup flow across three screens to match the latest Figma designs. All changes are cosmetic — copy updates, layout adjustments, and style changes. No logic or navigation changes.

## Changes
- **WakeUpStepView (Welcome)**: New subtitle copy, side-by-side "Sign In" / "Self-Host" buttons, updated copyright color
- **ImproveExperienceStepView (Before You Start)**: Removed VCard wrappers, shorter toggle helper text, new privacy note bar with eye icon, "Start" button (was "Accept and Start"), outlined Back button
- **HatchingStepView (Waking Up)**: Updated title to "Waking Up" (was "Waking up..."), simplified subtitle punctuation

## Milestone PRs (merged into feature branch)
- #24386: M1: Update WakeUpStepView to match Figma welcome screen
- #24395: M2: Update ImproveExperienceStepView to match Figma Before You Start screen
- #24398: M3: Update HatchingStepView to match Figma Waking Up screen

## Project issue
Closes #24382

## Test plan
- [ ] Launch app, verify Welcome screen shows updated subtitle and side-by-side buttons
- [ ] Verify Sign In triggers managed auth, Self-Host advances to hosting step
- [ ] Navigate to Before You Start screen, verify simplified toggles with privacy note bar
- [ ] Verify Start button and outlined Back button work correctly
- [ ] Trigger hatching flow, verify "Waking Up" title and progress bar still appears
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24399" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
