### PR TITLE
fix: fail fast on permanent errors during import polling

### DIFF
--- a/cli/src/commands/teleport.ts
+++ b/cli/src/commands/teleport.ts
@@ -510,7 +510,9 @@ async function exportFromAssistant(
         status = await platformPollExportStatus(jobId, token, entry.runtimeUrl);
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
-        if (msg.includes("not found")) {
+        // Re-throw permanent errors (not found, auth failures, etc.)
+        // Only retry on transient network/connection errors
+        if (msg.includes("not found") || msg.includes("status check failed")) {
           throw err;
         }
         console.warn(`Polling failed, retrying... (${msg})`);
@@ -743,7 +745,12 @@ async function importToAssistant(
           );
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
-          if (msg.includes("not found")) {
+          // Re-throw permanent errors (not found, auth failures, etc.)
+          // Only retry on transient network/connection errors
+          if (
+            msg.includes("not found") ||
+            msg.includes("status check failed")
+          ) {
             throw err;
           }
           console.warn(`Polling failed, retrying... (${msg})`);

--- a/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
@@ -411,8 +411,11 @@ struct AssistantTransferSection: View {
                     status = try await PlatformMigrationClient.pollImportStatus(jobId: jobId)
                 } catch is CancellationError {
                     throw CancellationError()
+                } catch let error as PlatformMigrationClient.PlatformMigrationError {
+                    // Permanent HTTP errors (auth, not found, etc.) — fail fast
+                    throw error
                 } catch {
-                    // Transient polling error — retry on next cycle
+                    // Transient network errors — retry on next cycle
                     continue
                 }
 

--- a/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
@@ -641,8 +641,11 @@ struct TeleportSection: View {
                     status = try await PlatformMigrationClient.pollImportStatus(jobId: jobId)
                 } catch is CancellationError {
                     throw CancellationError()
+                } catch let error as PlatformMigrationClient.PlatformMigrationError {
+                    // Permanent HTTP errors (auth, not found, etc.) — fail fast
+                    throw error
                 } catch {
-                    // Transient polling error — retry on next cycle
+                    // Transient network errors — retry on next cycle
                     continue
                 }
 


### PR DESCRIPTION
## Summary
- CLI: re-throw HTTP status errors from polling (auth failures, not found) instead of retrying
- macOS: re-throw PlatformMigrationError during polling instead of silently retrying
- Only retry on transient network/connection errors