### PR TITLE
chore: sync catalog.json with document-writer includes metadata

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -70,7 +70,10 @@
       "metadata": {
         "emoji": "📝",
         "vellum": {
-          "display-name": "Document Writer"
+          "display-name": "Document Writer",
+          "includes": [
+            "document"
+          ]
         }
       },
       "compatibility": "Designed for Vellum personal assistants"
@@ -463,7 +466,7 @@
     },
     {
       "id": "watch-together",
-      "name": "Watch Together",
+      "name": "watch-together",
       "description": "Watch TV shows and movies with the user in real time by processing screen captures into frames and audio analysis.",
       "metadata": {
         "vellum": {


### PR DESCRIPTION
## Summary
- Regenerate `skills/catalog.json` to pick up the `includes: ["document"]` field added to `document-writer/SKILL.md` in #24388
- Also fixes `watch-together` name field (was incorrectly capitalized)

## Original prompt
can you address the feedback in this PR comment? https://github.com/vellum-ai/vellum-assistant/pull/24388

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24402" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
