### PR TITLE
fix: integrations panel UI feedback improvements

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -27,7 +27,7 @@ extension MainWindowView {
         case .settings:
             SettingsPanel(onClose: { windowState.selection = nil }, store: settingsStore, connectionManager: connectionManager, conversationManager: conversationManager, authManager: authManager, assistantFeatureFlagStore: assistantFeatureFlagStore, showToast: { msg, style in windowState.showToast(message: msg, style: style) }, onEnableIntegration: {
                     conversationManager.openConversation(
-                        message: "Which integration would you like to enable?",
+                        message: "I'd like to enable an integration. What integrations are available for me to connect?",
                         forceNew: true
                     )
                     if let id = conversationManager.activeConversationId {
@@ -488,7 +488,7 @@ extension MainWindowView {
         case .settings:
             SettingsPanel(onClose: { windowState.dismissOverlay() }, store: settingsStore, connectionManager: connectionManager, conversationManager: conversationManager, authManager: authManager, assistantFeatureFlagStore: assistantFeatureFlagStore, showToast: { msg, style in windowState.showToast(message: msg, style: style) }, onEnableIntegration: {
                     conversationManager.openConversation(
-                        message: "Which integration would you like to enable?",
+                        message: "I'd like to enable an integration. What integrations are available for me to connect?",
                         forceNew: true
                     )
                     if let id = conversationManager.activeConversationId {

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -486,7 +486,18 @@ extension MainWindowView {
     func fullWindowPanel(_ panel: SidePanelType) -> some View {
         switch panel {
         case .settings:
-            SettingsPanel(onClose: { windowState.dismissOverlay() }, store: settingsStore, connectionManager: connectionManager, conversationManager: conversationManager, authManager: authManager, assistantFeatureFlagStore: assistantFeatureFlagStore, showToast: { msg, style in windowState.showToast(message: msg, style: style) })
+            SettingsPanel(onClose: { windowState.dismissOverlay() }, store: settingsStore, connectionManager: connectionManager, conversationManager: conversationManager, authManager: authManager, assistantFeatureFlagStore: assistantFeatureFlagStore, showToast: { msg, style in windowState.showToast(message: msg, style: style) }, onEnableIntegration: {
+                    conversationManager.openConversation(
+                        message: "Which integration would you like to enable?",
+                        forceNew: true
+                    )
+                    if let id = conversationManager.activeConversationId {
+                        windowState.selection = .conversation(id)
+                    } else {
+                        windowState.selection = nil
+                    }
+                    windowState.dismissOverlay()
+                })
         case .debug:
             DebugPanel(
                 traceStore: traceStore,

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -27,7 +27,7 @@ extension MainWindowView {
         case .settings:
             SettingsPanel(onClose: { windowState.selection = nil }, store: settingsStore, connectionManager: connectionManager, conversationManager: conversationManager, authManager: authManager, assistantFeatureFlagStore: assistantFeatureFlagStore, showToast: { msg, style in windowState.showToast(message: msg, style: style) }, onEnableIntegration: {
                     conversationManager.openConversation(
-                        message: "I'd like to enable an integration. What integrations are available for me to connect?",
+                        message: "I'd like to enable an oauth integration. What integrations are available for me to connect to?",
                         forceNew: true
                     )
                     if let id = conversationManager.activeConversationId {
@@ -488,7 +488,7 @@ extension MainWindowView {
         case .settings:
             SettingsPanel(onClose: { windowState.dismissOverlay() }, store: settingsStore, connectionManager: connectionManager, conversationManager: conversationManager, authManager: authManager, assistantFeatureFlagStore: assistantFeatureFlagStore, showToast: { msg, style in windowState.showToast(message: msg, style: style) }, onEnableIntegration: {
                     conversationManager.openConversation(
-                        message: "I'd like to enable an integration. What integrations are available for me to connect?",
+                        message: "I'd like to enable an oauth integration. What integrations are available for me to connect to?",
                         forceNew: true
                     )
                     if let id = conversationManager.activeConversationId {

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -25,7 +25,17 @@ extension MainWindowView {
         case .chat:
             chatView
         case .settings:
-            SettingsPanel(onClose: { windowState.selection = nil }, store: settingsStore, connectionManager: connectionManager, conversationManager: conversationManager, authManager: authManager, assistantFeatureFlagStore: assistantFeatureFlagStore, showToast: { msg, style in windowState.showToast(message: msg, style: style) })
+            SettingsPanel(onClose: { windowState.selection = nil }, store: settingsStore, connectionManager: connectionManager, conversationManager: conversationManager, authManager: authManager, assistantFeatureFlagStore: assistantFeatureFlagStore, showToast: { msg, style in windowState.showToast(message: msg, style: style) }, onEnableIntegration: {
+                    conversationManager.openConversation(
+                        message: "Which integration would you like to enable?",
+                        forceNew: true
+                    )
+                    if let id = conversationManager.activeConversationId {
+                        windowState.selection = .conversation(id)
+                    } else {
+                        windowState.selection = nil
+                    }
+                })
         case .debug:
             DebugPanel(
                 traceStore: traceStore,

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -51,6 +51,7 @@ struct SettingsPanel: View {
     var authManager: AuthManager
     @ObservedObject var assistantFeatureFlagStore: AssistantFeatureFlagStore
     var showToast: (String, ToastInfo.Style) -> Void
+    var onEnableIntegration: (() -> Void)?
     var featureFlagClient: FeatureFlagClientProtocol = FeatureFlagClient()
 
     // MARK: - Init
@@ -63,6 +64,7 @@ struct SettingsPanel: View {
         authManager: AuthManager,
         assistantFeatureFlagStore: AssistantFeatureFlagStore,
         showToast: @escaping (String, ToastInfo.Style) -> Void,
+        onEnableIntegration: (() -> Void)? = nil,
         featureFlagClient: FeatureFlagClientProtocol = FeatureFlagClient()
     ) {
         self.onClose = onClose
@@ -72,6 +74,7 @@ struct SettingsPanel: View {
         self.authManager = authManager
         self._assistantFeatureFlagStore = ObservedObject(wrappedValue: assistantFeatureFlagStore)
         self.showToast = showToast
+        self.onEnableIntegration = onEnableIntegration
         self.featureFlagClient = featureFlagClient
 
         // Pre-compute the billing flag so the first render already has the
@@ -414,12 +417,7 @@ struct SettingsPanel: View {
                 store: store,
                 authManager: authManager,
                 showToast: showToast,
-                onEnableIntegration: {
-                    conversationManager.openConversation(
-                        message: "I'd like to enable an integration. What integrations are available?",
-                        forceNew: true
-                    )
-                }
+                onEnableIntegration: onEnableIntegration
             )
         case .voice:
             VoiceSettingsView(store: store)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -413,7 +413,13 @@ struct SettingsPanel: View {
             IntegrationsPanelContent(
                 store: store,
                 authManager: authManager,
-                showToast: showToast
+                showToast: showToast,
+                onEnableIntegration: {
+                    conversationManager.openConversation(
+                        message: "I'd like to enable an integration. What integrations are available?",
+                        forceNew: true
+                    )
+                }
             )
         case .voice:
             VoiceSettingsView(store: store)

--- a/clients/macos/vellum-assistant/Features/Settings/IntegrationDetailModal.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/IntegrationDetailModal.swift
@@ -242,7 +242,7 @@ struct IntegrationDetailModal: View {
 
     private var managedConnectionCard: some View {
         VCard {
-            VStack(alignment: .leading, spacing: VSpacing.sm) {
+            VStack(alignment: .leading, spacing: VSpacing.md) {
                 // Connection rows
                 if connections.isEmpty {
                     Text("No connected accounts")
@@ -399,7 +399,7 @@ struct IntegrationDetailModal: View {
 
     private func yourOwnAppCard(for app: YourOwnOAuthApp) -> some View {
         VCard {
-            VStack(alignment: .leading, spacing: VSpacing.sm) {
+            VStack(alignment: .leading, spacing: VSpacing.md) {
                 // Header: client ID, date, trash
                 HStack(alignment: .center, spacing: VSpacing.lg) {
                     Text(maskedClientId(app.client_id))

--- a/clients/macos/vellum-assistant/Features/Settings/IntegrationDetailModal.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/IntegrationDetailModal.swift
@@ -216,17 +216,19 @@ struct IntegrationDetailModal: View {
             } else {
                 managedConnectionsList
 
-                // Connect another account inside card area
-                if isConnecting {
-                    HStack(spacing: VSpacing.sm) {
-                        VBusyIndicator(size: 8, color: VColor.contentTertiary)
-                        Text("Waiting for authorization...")
-                            .font(VFont.bodyMediumDefault)
-                            .foregroundStyle(VColor.contentTertiary)
-                    }
-                } else {
-                    VButton(label: "Connect another account", leftIcon: VIcon.plus.rawValue, style: .outlined) {
-                        store.startManagedOAuthConnect(providerKey: providerKey, userId: currentUserId)
+                // Connect account button inside a card
+                VCard {
+                    if isConnecting {
+                        HStack(spacing: VSpacing.sm) {
+                            VBusyIndicator(size: 8, color: VColor.contentTertiary)
+                            Text("Waiting for authorization...")
+                                .font(VFont.bodyMediumDefault)
+                                .foregroundStyle(VColor.contentTertiary)
+                        }
+                    } else {
+                        VButton(label: "Connect account", leftIcon: "lucide-external-link", style: .outlined) {
+                            store.startManagedOAuthConnect(providerKey: providerKey, userId: currentUserId)
+                        }
                     }
                 }
             }
@@ -438,7 +440,7 @@ struct IntegrationDetailModal: View {
                     }
                 } else {
                     VButton(
-                        label: "Connect another account",
+                        label: "Connect account",
                         leftIcon: "lucide-external-link",
                         style: .outlined,
                         isDisabled: store.yourOwnOAuthConnectingAppId != nil

--- a/clients/macos/vellum-assistant/Features/Settings/IntegrationDetailModal.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/IntegrationDetailModal.swift
@@ -242,7 +242,7 @@ struct IntegrationDetailModal: View {
 
     private var managedConnectionCard: some View {
         VCard {
-            VStack(alignment: .leading, spacing: VSpacing.md) {
+            VStack(alignment: .leading, spacing: VSpacing.lg) {
                 // Connection rows
                 if connections.isEmpty {
                     Text("No connected accounts")
@@ -399,7 +399,7 @@ struct IntegrationDetailModal: View {
 
     private func yourOwnAppCard(for app: YourOwnOAuthApp) -> some View {
         VCard {
-            VStack(alignment: .leading, spacing: VSpacing.md) {
+            VStack(alignment: .leading, spacing: VSpacing.lg) {
                 // Header: client ID, date, trash
                 HStack(alignment: .center, spacing: VSpacing.lg) {
                     Text(maskedClientId(app.client_id))

--- a/clients/macos/vellum-assistant/Features/Settings/IntegrationDetailModal.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/IntegrationDetailModal.swift
@@ -214,23 +214,7 @@ struct IntegrationDetailModal: View {
                     }
                 }
             } else {
-                managedConnectionsList
-
-                // Connect account button inside a card
-                VCard {
-                    if isConnecting {
-                        HStack(spacing: VSpacing.sm) {
-                            VBusyIndicator(size: 8, color: VColor.contentTertiary)
-                            Text("Waiting for authorization...")
-                                .font(VFont.bodyMediumDefault)
-                                .foregroundStyle(VColor.contentTertiary)
-                        }
-                    } else {
-                        VButton(label: "Connect account", leftIcon: "lucide-external-link", style: .outlined) {
-                            store.startManagedOAuthConnect(providerKey: providerKey, userId: currentUserId)
-                        }
-                    }
-                }
+                managedConnectionCard
             }
 
             if let error = store.managedError(for: providerKey) {
@@ -256,33 +240,50 @@ struct IntegrationDetailModal: View {
     }
 
 
-    private var managedConnectionsList: some View {
-        VStack(alignment: .leading, spacing: VSpacing.xs) {
-            ForEach(connections, id: \.id) { entry in
-                managedConnectionRow(for: entry)
-            }
-        }
-    }
-
-    private func managedConnectionRow(for entry: OAuthConnectionEntry) -> some View {
+    private var managedConnectionCard: some View {
         VCard {
-            HStack(alignment: .center, spacing: VSpacing.lg) {
-                VIconView(.circleUser, size: 14)
-                    .foregroundStyle(VColor.contentSecondary)
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
+                // Connection rows
+                if connections.isEmpty {
+                    Text("No connected accounts")
+                        .font(VFont.labelDefault)
+                        .foregroundStyle(VColor.contentTertiary)
+                } else {
+                    ForEach(connections, id: \.id) { entry in
+                        HStack(alignment: .center, spacing: VSpacing.lg) {
+                            VIconView(.circleUser, size: 14)
+                                .foregroundStyle(VColor.contentSecondary)
 
-                Text(entry.account_label ?? "\(displayName) Account")
-                    .font(VFont.bodyMediumDefault)
-                    .foregroundStyle(VColor.contentDefault)
-                    .lineLimit(1)
-                    .truncationMode(.tail)
+                            Text(entry.account_label ?? "\(displayName) Account")
+                                .font(VFont.bodyMediumDefault)
+                                .foregroundStyle(VColor.contentDefault)
+                                .lineLimit(1)
+                                .truncationMode(.tail)
 
-                Spacer()
+                            Spacer()
 
-                VButton(label: "", iconOnly: VIcon.trash.rawValue, style: .dangerOutline, size: .compact) {
-                    connectionToDisconnect = entry
-                    showDisconnectAlert = true
+                            VButton(label: "", iconOnly: VIcon.trash.rawValue, style: .dangerOutline, size: .compact) {
+                                connectionToDisconnect = entry
+                                showDisconnectAlert = true
+                            }
+                            .accessibilityLabel("Disconnect Account")
+                        }
+                    }
                 }
-                .accessibilityLabel("Disconnect Account")
+
+                // Connect account button
+                if isConnecting {
+                    HStack(spacing: VSpacing.sm) {
+                        VBusyIndicator(size: 8, color: VColor.contentTertiary)
+                        Text("Waiting for authorization...")
+                            .font(VFont.bodyMediumDefault)
+                            .foregroundStyle(VColor.contentTertiary)
+                    }
+                } else {
+                    VButton(label: "Connect account", leftIcon: "lucide-external-link", style: .outlined) {
+                        store.startManagedOAuthConnect(providerKey: providerKey, userId: currentUserId)
+                    }
+                }
             }
         }
     }

--- a/clients/macos/vellum-assistant/Features/Settings/IntegrationDetailModal.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/IntegrationDetailModal.swift
@@ -249,7 +249,10 @@ struct IntegrationDetailModal: View {
                         .font(VFont.labelDefault)
                         .foregroundStyle(VColor.contentTertiary)
                 } else {
-                    ForEach(connections, id: \.id) { entry in
+                    ForEach(Array(connections.enumerated()), id: \.element.id) { index, entry in
+                        if index > 0 {
+                            Divider()
+                        }
                         HStack(alignment: .center, spacing: VSpacing.lg) {
                             VIconView(.circleUser, size: 14)
                                 .foregroundStyle(VColor.contentSecondary)
@@ -270,6 +273,8 @@ struct IntegrationDetailModal: View {
                         }
                     }
                 }
+
+                Divider()
 
                 // Connect account button
                 if isConnecting {
@@ -423,10 +428,15 @@ struct IntegrationDetailModal: View {
                         .font(VFont.labelDefault)
                         .foregroundStyle(VColor.contentTertiary)
                 } else {
-                    ForEach(appConnections) { conn in
+                    ForEach(Array(appConnections.enumerated()), id: \.element.id) { index, conn in
+                        if index > 0 {
+                            Divider()
+                        }
                         yourOwnConnectionRow(for: conn, appId: app.id)
                     }
                 }
+
+                Divider()
 
                 // Connect button
                 if store.yourOwnOAuthConnectingAppId == app.id {

--- a/clients/macos/vellum-assistant/Features/Settings/IntegrationDetailModal.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/IntegrationDetailModal.swift
@@ -94,7 +94,7 @@ struct IntegrationDetailModal: View {
         } footer: {
             HStack {
                 Spacer()
-                VButton(label: "Close", style: .outlined, action: onClose)
+                VButton(label: "Confirm", style: .outlined, action: onClose)
             }
         }
         .frame(width: 520)
@@ -214,29 +214,26 @@ struct IntegrationDetailModal: View {
                     }
                 }
             } else {
-                // Connection count + add button row
-                HStack {
-                    Text("\(connections.count) connected")
-                        .font(VFont.bodyMediumDefault)
-                        .foregroundStyle(VColor.contentSecondary)
-
-                    Spacer()
-
-                    if isConnecting {
-                        HStack(spacing: VSpacing.sm) {
-                            VBusyIndicator(size: 8, color: VColor.contentTertiary)
-                            Text("Waiting for authorization...")
-                                .font(VFont.bodyMediumDefault)
-                                .foregroundStyle(VColor.contentTertiary)
-                        }
-                    } else {
-                        VButton(label: "Add Another App", leftIcon: VIcon.plus.rawValue, style: .outlined) {
-                            store.startManagedOAuthConnect(providerKey: providerKey, userId: currentUserId)
-                        }
-                    }
-                }
+                // Connection count
+                Text("\(connections.count) connected")
+                    .font(VFont.bodyMediumDefault)
+                    .foregroundStyle(VColor.contentSecondary)
 
                 managedConnectionsList
+
+                // Connect another account inside card area
+                if isConnecting {
+                    HStack(spacing: VSpacing.sm) {
+                        VBusyIndicator(size: 8, color: VColor.contentTertiary)
+                        Text("Waiting for authorization...")
+                            .font(VFont.bodyMediumDefault)
+                            .foregroundStyle(VColor.contentTertiary)
+                    }
+                } else {
+                    VButton(label: "Connect another account", leftIcon: VIcon.plus.rawValue, style: .outlined) {
+                        store.startManagedOAuthConnect(providerKey: providerKey, userId: currentUserId)
+                    }
+                }
             }
 
             if let error = store.managedError(for: providerKey) {
@@ -321,20 +318,10 @@ struct IntegrationDetailModal: View {
                     // Form only, no top row
                     yourOwnFormStep
                 } else {
-                    // Top row: count + add button
-                    HStack {
-                        Text("\(apps.count) connected")
-                            .font(VFont.bodyMediumDefault)
-                            .foregroundStyle(VColor.contentSecondary)
-
-                        Spacer()
-
-                        VButton(label: "Add Another App", leftIcon: VIcon.plus.rawValue, style: .outlined) {
-                            createAppClientId = ""
-                            createAppClientSecret = ""
-                            isShowingAddAppForm = true
-                        }
-                    }
+                    // Top row: count
+                    Text("\(apps.count) connected")
+                        .font(VFont.bodyMediumDefault)
+                        .foregroundStyle(VColor.contentSecondary)
                 }
 
                 // App list

--- a/clients/macos/vellum-assistant/Features/Settings/IntegrationDetailModal.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/IntegrationDetailModal.swift
@@ -329,6 +329,14 @@ struct IntegrationDetailModal: View {
                     ForEach(apps) { app in
                         yourOwnAppCard(for: app)
                     }
+
+                    if !isShowingAddAppForm {
+                        VButton(label: "Add another app", leftIcon: VIcon.plus.rawValue, style: .outlined) {
+                            createAppClientId = ""
+                            createAppClientSecret = ""
+                            isShowingAddAppForm = true
+                        }
+                    }
                 }
             }
 

--- a/clients/macos/vellum-assistant/Features/Settings/IntegrationDetailModal.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/IntegrationDetailModal.swift
@@ -214,11 +214,6 @@ struct IntegrationDetailModal: View {
                     }
                 }
             } else {
-                // Connection count
-                Text("\(connections.count) connected")
-                    .font(VFont.bodyMediumDefault)
-                    .foregroundStyle(VColor.contentSecondary)
-
                 managedConnectionsList
 
                 // Connect another account inside card area
@@ -315,27 +310,13 @@ struct IntegrationDetailModal: View {
                 }
             } else {
                 if isShowingAddAppForm {
-                    // Form only, no top row
                     yourOwnFormStep
-                } else {
-                    // Top row: count
-                    Text("\(apps.count) connected")
-                        .font(VFont.bodyMediumDefault)
-                        .foregroundStyle(VColor.contentSecondary)
                 }
 
                 // App list
                 if !apps.isEmpty {
                     ForEach(apps) { app in
                         yourOwnAppCard(for: app)
-                    }
-
-                    if !isShowingAddAppForm {
-                        VButton(label: "Add another app", leftIcon: VIcon.plus.rawValue, style: .outlined) {
-                            createAppClientId = ""
-                            createAppClientSecret = ""
-                            isShowingAddAppForm = true
-                        }
                     }
                 }
             }
@@ -457,7 +438,7 @@ struct IntegrationDetailModal: View {
                     }
                 } else {
                     VButton(
-                        label: "Connect Account",
+                        label: "Connect another account",
                         leftIcon: "lucide-external-link",
                         style: .outlined,
                         isDisabled: store.yourOwnOAuthConnectingAppId != nil

--- a/clients/macos/vellum-assistant/Features/Settings/IntegrationsPanelContent.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/IntegrationsPanelContent.swift
@@ -15,6 +15,7 @@ struct IntegrationsPanelContent: View {
     @ObservedObject var store: SettingsStore
     var authManager: AuthManager
     var showToast: (String, ToastInfo.Style) -> Void
+    var onEnableIntegration: (() -> Void)?
 
     @State private var searchText: String = ""
     @State private var selectedProviderKey: String? = nil
@@ -115,13 +116,25 @@ struct IntegrationsPanelContent: View {
 
     // MARK: - Tip Banner
 
+    private static let enableIntegrationURL = URL(string: "vellum://enable-integration")!
+
     private var integrationsTipBanner: some View {
         HStack(spacing: VSpacing.xs) {
             VIconView(.sparkles, size: 14)
                 .foregroundStyle(VColor.primaryBase)
-            Text("**Tip:** You can enable integrations by mentioning them in chat.")
-                .font(VFont.bodyMediumDefault)
-                .foregroundStyle(VColor.contentDefault)
+            HStack(spacing: 0) {
+                Text("**Tip:** You can ")
+                VLink(
+                    "enable integrations",
+                    destination: Self.enableIntegrationURL,
+                    font: VFont.bodyMediumDefault,
+                    underline: true
+                )
+                .tint(VColor.primaryBase)
+                Text(" by mentioning them in chat.")
+            }
+            .font(VFont.bodyMediumDefault)
+            .foregroundStyle(VColor.contentDefault)
             Spacer()
             Button(action: {
                 withAnimation(VAnimation.fast) { bannerDismissed = true }
@@ -141,8 +154,13 @@ struct IntegrationsPanelContent: View {
             RoundedRectangle(cornerRadius: VRadius.md)
                 .stroke(VColor.primaryBase.opacity(0.18), lineWidth: 1)
         )
+        .environment(\.openURL, OpenURLAction { _ in
+            onEnableIntegration?()
+            return .handled
+        })
         .accessibilityElement(children: .combine)
         .accessibilityLabel("Tip: You can enable integrations by mentioning them in chat.")
+        .accessibilityAddTraits(.isButton)
     }
 
     // MARK: - Filter Bar

--- a/clients/macos/vellum-assistant/Features/Settings/IntegrationsPanelContent.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/IntegrationsPanelContent.swift
@@ -19,6 +19,7 @@ struct IntegrationsPanelContent: View {
     @State private var searchText: String = ""
     @State private var selectedProviderKey: String? = nil
     @State private var selectedFilter: IntegrationFilter = .all
+    @AppStorage("integrationsBannerDismissed") private var bannerDismissed = false
 
     // MARK: - Filtering & Sorting
 
@@ -78,6 +79,10 @@ struct IntegrationsPanelContent: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
+            if !bannerDismissed {
+                integrationsTipBanner
+                    .padding(.bottom, VSpacing.lg)
+            }
             filterBar
             contentView
                 .padding(.top, VSpacing.lg)
@@ -106,6 +111,38 @@ struct IntegrationsPanelContent: View {
                 )
             }
         }
+    }
+
+    // MARK: - Tip Banner
+
+    private var integrationsTipBanner: some View {
+        HStack(spacing: VSpacing.xs) {
+            VIconView(.sparkles, size: 14)
+                .foregroundStyle(VColor.primaryBase)
+            Text("**Tip:** You can enable integrations by mentioning them in chat.")
+                .font(VFont.bodyMediumDefault)
+                .foregroundStyle(VColor.contentDefault)
+            Spacer()
+            Button(action: {
+                withAnimation(VAnimation.fast) { bannerDismissed = true }
+            }) {
+                VIconView(.x, size: 12)
+                    .foregroundStyle(VColor.contentTertiary)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Dismiss tip")
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, VSpacing.md)
+        .padding(.vertical, VSpacing.sm)
+        .background(VColor.primaryBase.opacity(0.10))
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.md)
+                .stroke(VColor.primaryBase.opacity(0.18), lineWidth: 1)
+        )
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Tip: You can enable integrations by mentioning them in chat.")
     }
 
     // MARK: - Filter Bar
@@ -157,7 +194,7 @@ struct IntegrationsPanelContent: View {
                                 selectedProviderKey = provider.provider_key
                             },
                             onDisable: {
-                                selectedProviderKey = provider.provider_key
+                                disableIntegration(providerKey: provider.provider_key)
                             }
                         )
                     }
@@ -192,6 +229,24 @@ struct IntegrationsPanelContent: View {
         }
     }
 
+    // MARK: - Disable Integration
+
+    private func disableIntegration(providerKey: String) {
+        let userId = authManager.currentUser?.id
+
+        // Disconnect all managed connections
+        let managedConnections = store.managedOAuthConnections[providerKey] ?? []
+        for connection in managedConnections {
+            store.disconnectManagedOAuthConnection(connection.id, providerKey: providerKey, userId: userId)
+        }
+
+        // Delete all your-own apps (which cascades to their connections)
+        let yourOwnApps = store.yourOwnApps(for: providerKey)
+        for app in yourOwnApps {
+            Task { await store.deleteYourOwnOAuthApp(id: app.id, providerKey: providerKey) }
+        }
+    }
+
     // MARK: - Data Fetching
 
     private func fetchAllConnections() {
@@ -216,6 +271,7 @@ private struct IntegrationItemRow: View {
     @State private var isMenuOpen = false
     @State private var activePanel: VMenuPanel?
     @State private var triggerFrame: CGRect = .zero
+    @State private var showDisableAlert = false
 
     var body: some View {
         VCard {
@@ -245,7 +301,7 @@ private struct IntegrationItemRow: View {
                 Spacer()
 
                 if isConnected {
-                    VButton(label: "Manage", rightIcon: VIcon.chevronDown.rawValue, style: .outlined) {
+                    VButton(label: "Configure", rightIcon: VIcon.chevronDown.rawValue, style: .outlined) {
                         if isMenuOpen {
                             activePanel?.close()
                             activePanel = nil
@@ -271,6 +327,14 @@ private struct IntegrationItemRow: View {
             }
         }
         .accessibilityElement(children: .combine)
+        .alert("Disable \(provider.display_name ?? provider.provider_key)?", isPresented: $showDisableAlert) {
+            Button("Cancel", role: .cancel) {}
+            Button("Disable", role: .destructive) {
+                onDisable()
+            }
+        } message: {
+            Text("This will disconnect all accounts for \(provider.display_name ?? provider.provider_key). You can re-enable it later.")
+        }
     }
 
     private func showMenu() {
@@ -306,7 +370,7 @@ private struct IntegrationItemRow: View {
                     onEdit()
                 }
                 VMenuItem(icon: VIcon.circleX.rawValue, label: "Disable", variant: .destructive) {
-                    onDisable()
+                    showDisableAlert = true
                 }
             }
         } onDismiss: {


### PR DESCRIPTION
## Summary
- Rename "Manage" button to "Configure" on integration cards
- Remove "Add Another App" buttons; replace managed tab's with "Connect another account" positioned inside the connections list
- Add dismissible tip banner for enabling integrations via prompt (matching skills page pattern)
- Change modal footer button from "Close" to "Confirm"
- Fix "Disable" menu item: now shows confirmation dialog and actually disconnects all accounts instead of just reopening the modal

## Original prompt
changes for integrations based on some of the feedback 1. Manage -> Configure
2. Managed and You Own state
3. Remove Add Another App button 
4. Move Connect another account inside of the card for Managed
5. Tip for enabling integrations via prompt same as it's on skills page
6. Close -> Confirm
7. Disable menu doesn't show confirmation dialog to remove integration nor it's working at all (just opens modal)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24404" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
