### PR TITLE
fix: only fail fast on 4xx polling errors, retry 5xx as transient

### DIFF
--- a/cli/src/commands/teleport.ts
+++ b/cli/src/commands/teleport.ts
@@ -510,11 +510,19 @@ async function exportFromAssistant(
         status = await platformPollExportStatus(jobId, token, entry.runtimeUrl);
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
-        // Re-throw permanent errors (not found, auth failures, etc.)
-        // Only retry on transient network/connection errors
-        if (msg.includes("not found") || msg.includes("status check failed")) {
+        if (msg.includes("not found")) {
           throw err;
         }
+        // Re-throw permanent 4xx errors (auth, forbidden, etc.)
+        // but retry transient 5xx errors
+        const statusMatch = msg.match(/status check failed: (\d+)/);
+        if (statusMatch) {
+          const statusCode = parseInt(statusMatch[1], 10);
+          if (statusCode >= 400 && statusCode < 500) {
+            throw err;
+          }
+        }
+        // Transient error — retry
         console.warn(`Polling failed, retrying... (${msg})`);
         await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
         continue;
@@ -745,14 +753,19 @@ async function importToAssistant(
           );
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
-          // Re-throw permanent errors (not found, auth failures, etc.)
-          // Only retry on transient network/connection errors
-          if (
-            msg.includes("not found") ||
-            msg.includes("status check failed")
-          ) {
+          if (msg.includes("not found")) {
             throw err;
           }
+          // Re-throw permanent 4xx errors (auth, forbidden, etc.)
+          // but retry transient 5xx errors
+          const statusMatch = msg.match(/status check failed: (\d+)/);
+          if (statusMatch) {
+            const statusCode = parseInt(statusMatch[1], 10);
+            if (statusCode >= 400 && statusCode < 500) {
+              throw err;
+            }
+          }
+          // Transient error — retry
           console.warn(`Polling failed, retrying... (${msg})`);
           continue;
         }

--- a/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
@@ -412,8 +412,13 @@ struct AssistantTransferSection: View {
                 } catch is CancellationError {
                     throw CancellationError()
                 } catch let error as PlatformMigrationClient.PlatformMigrationError {
-                    // Permanent HTTP errors (auth, not found, etc.) — fail fast
-                    throw error
+                    // Only fail fast on permanent 4xx errors
+                    // Retry transient 5xx errors
+                    if case .requestFailed(let statusCode, _) = error, (400..<500).contains(statusCode) {
+                        throw error
+                    }
+                    // Transient server error — retry on next cycle
+                    continue
                 } catch {
                     // Transient network errors — retry on next cycle
                     continue

--- a/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
@@ -642,8 +642,13 @@ struct TeleportSection: View {
                 } catch is CancellationError {
                     throw CancellationError()
                 } catch let error as PlatformMigrationClient.PlatformMigrationError {
-                    // Permanent HTTP errors (auth, not found, etc.) — fail fast
-                    throw error
+                    // Only fail fast on permanent 4xx errors
+                    // Retry transient 5xx errors
+                    if case .requestFailed(let statusCode, _) = error, (400..<500).contains(statusCode) {
+                        throw error
+                    }
+                    // Transient server error — retry on next cycle
+                    continue
                 } catch {
                     // Transient network errors — retry on next cycle
                     continue


### PR DESCRIPTION
## Summary
- CLI: parse status code from polling error message, only re-throw for 4xx (permanent), retry 5xx (transient)
- macOS: check PlatformMigrationError.requestFailed status code, only throw for 400-499 range
- Preserves transient error resilience for 5xx/network errors during long polling windows
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24405" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
