### PR TITLE
build(macos): detect duplicate Vellum processes before launching

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -1362,25 +1362,38 @@ if [ "$CMD" = "run" ]; then
     sleep 0.3
 
     # The kill block above only terminates the same-display-name instance,
-    # so a Vellum bundle built under a *different* `BUNDLE_DISPLAY_NAME`
-    # would survive and race against the freshly-launched one — same
-    # bundle ID, same lockfile, same identity cache, separate in-memory
-    # state. We use `ps -o comm=` rather than `pgrep -f` so the match
-    # runs against the executable path only, never against shell argv
-    # (which would false-positive when build.sh is invoked via `bash -c`
-    # with the script body inlined). The pattern is heuristic: only
-    # catches display names starting with "Vellum".
-    other_vellum=$(ps -ax -o pid=,comm= | awk -v skip="MacOS/$BUNDLE_DISPLAY_NAME$" '
-        /\.app\/Contents\/MacOS\/Vellum/ && $0 !~ skip
-    ' || true)
+    # so any sibling bundle built from this project under a different
+    # `BUNDLE_DISPLAY_NAME` would survive and race against us — they share
+    # bundle ID, lockfile, identity cache, and UserDefaults but hold
+    # separate in-memory state. We identify siblings by reading each
+    # candidate process's `Contents/Info.plist` and matching against our
+    # `$BUNDLE_ID` rather than name-matching, so an unrelated third-party
+    # app that happens to be called "Vellum" (the ebook formatter at
+    # vellum.pub, for example) is correctly ignored.
+    other_vellum=""
+    while IFS= read -r line; do
+        pid=${line%% *}
+        exe_path=${line#* }
+        case "$exe_path" in
+            */Contents/MacOS/*) ;;
+            *) continue ;;
+        esac
+        bundle_root=${exe_path%/Contents/MacOS/*}
+        other_id=$(plutil -extract CFBundleIdentifier raw "$bundle_root/Contents/Info.plist" 2>/dev/null || true)
+        [ "$other_id" = "$BUNDLE_ID" ] || continue
+        [ "$exe_path" != "$bundle_root/Contents/MacOS/$BUNDLE_DISPLAY_NAME" ] || continue
+        other_vellum+="$pid $exe_path"$'\n'
+    done < <(ps -ax -o pid=,comm=)
+    other_vellum=${other_vellum%$'\n'}
+
     if [ -n "$other_vellum" ]; then
         echo ""
-        echo "ERROR: Another Vellum-bundled process is already running:"
+        echo "ERROR: Another process from this project (bundle ID $BUNDLE_ID) is already running:"
         echo "$other_vellum" | sed 's/^/  /'
         echo ""
-        echo "It shares the same bundle ID, lockfile, identity cache, and"
-        echo "UserDefaults as the bundle you're about to launch, and will race"
-        echo "against it on every write. Refusing to launch a duplicate."
+        echo "It shares the lockfile, identity cache, and UserDefaults with"
+        echo "the bundle you're about to launch, and will race against it on"
+        echo "every write. Refusing to launch a duplicate."
         echo ""
         echo "Kill the existing process(es) and re-run:"
         echo "$other_vellum" | awk '{print "  kill " $1}'

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -1361,6 +1361,33 @@ if [ "$CMD" = "run" ]; then
     pkill -x "vellum-assistant" 2>/dev/null || true
     sleep 0.3
 
+    # The kill block above only terminates the same-display-name instance,
+    # so a Vellum bundle built under a *different* `BUNDLE_DISPLAY_NAME`
+    # would survive and race against the freshly-launched one — same
+    # bundle ID, same lockfile, same identity cache, separate in-memory
+    # state. We use `ps -o comm=` rather than `pgrep -f` so the match
+    # runs against the executable path only, never against shell argv
+    # (which would false-positive when build.sh is invoked via `bash -c`
+    # with the script body inlined). The pattern is heuristic: only
+    # catches display names starting with "Vellum".
+    other_vellum=$(ps -ax -o pid=,comm= | awk -v skip="MacOS/$BUNDLE_DISPLAY_NAME$" '
+        /\.app\/Contents\/MacOS\/Vellum/ && $0 !~ skip
+    ' || true)
+    if [ -n "$other_vellum" ]; then
+        echo ""
+        echo "ERROR: Another Vellum-bundled process is already running:"
+        echo "$other_vellum" | sed 's/^/  /'
+        echo ""
+        echo "It shares the same bundle ID, lockfile, identity cache, and"
+        echo "UserDefaults as the bundle you're about to launch, and will race"
+        echo "against it on every write. Refusing to launch a duplicate."
+        echo ""
+        echo "Kill the existing process(es) and re-run:"
+        echo "$other_vellum" | awk '{print "  kill " $1}'
+        echo ""
+        exit 1
+    fi
+
     # Refresh /Applications/$BUNDLE_DISPLAY_NAME.app from the freshly-built
     # dist/ bundle, if a copy already exists. Without this, `./build.sh run`
     # only updates dist/ and a Finder/dock launch silently keeps using the


### PR DESCRIPTION
## Summary
When `./build.sh run` is invoked with `BUNDLE_DISPLAY_NAME` (e.g. `Vellum Staging`), the existing kill block only terminates instances matching that *exact* display name. A forgotten `./build.sh run` from an earlier session that built under a different display name (e.g. plain `Vellum.app` from a default-args invocation) survives and starts silently racing against the freshly-launched bundle.

Both processes share the same bundle ID, the same `~/.vellum.lock.json`, the same identity cache file, and the same `UserDefaults` — but each holds its own in-memory state and stomps on the other on every write. The symptom looks like data loss or a code bug: menus rendering stale data, in-memory caches mismatching disk, "I just clicked switch and the assistant disappeared." This cost ~45 minutes of debugging during the recent #24330 work where the IdentityInfo cache code was actually working correctly the entire time, before the duplicate process was discovered via `pgrep`.

This PR adds a pre-flight check after the existing kill block: enumerate every process whose executable path matches `*.app/Contents/MacOS/Vellum*`, exclude the one matching the current `BUNDLE_DISPLAY_NAME`, and refuse to launch if any others remain. The error message lists the offending PIDs and the exact `kill` commands to remediate.

## Implementation notes
- Uses `ps -ax -o pid=,comm=` rather than `pgrep -f` so the match runs against the executable path only, never against shell argv. `pgrep -f` would false-positive if `build.sh` were ever invoked via `bash -c '<entire script>'` from a CI runner or IDE task, because the script body would contain the literal pattern.
- The pattern matches any executable path containing `Vellum*.app/Contents/MacOS/`, covering `Vellum.app`, `Vellum Staging.app`, `Vellum Dev.app`, etc. A custom `BUNDLE_DISPLAY_NAME` that doesn't start with "Vellum" will not be detected — deliberate trade-off, belt-and-suspenders for the common case rather than a hard guarantee.
- The check runs *after* the existing same-name kill block, so the current display name's previous instance has already been terminated by the time we look for survivors.

## Test plan
- [x] `bash -n clients/macos/build.sh` — syntax OK
- [x] Detection logic verified locally against the running `Vellum Staging` process: correctly flags it when asked about `BUNDLE_DISPLAY_NAME=Vellum`, correctly excludes it when asked about `BUNDLE_DISPLAY_NAME=Vellum Staging`
- [x] Verified `pgrep -f` false-positive scenario: a `bash -c '<body containing pattern>'` invocation does false-positive on `pgrep -f` but is correctly ignored by `ps -o comm` (the chosen approach)
- [x] End-to-end: spawn a sibling `Vellum.app` build, then `./build.sh run BUNDLE_DISPLAY_NAME="Vellum Staging"` and confirm it errors out with the expected message

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24406" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
