### PR TITLE
Add character footer illustrations to Before You Start and Waking Up screens

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -27,6 +27,7 @@ struct HatchingStepView: View {
     private var managedSignInEnabled: Bool {
         MacOSClientFeatureFlagManager.shared.isEnabled("managed-sign-in")
     }
+    @State private var showFooterCharacters = false
     @State private var completionTask: Task<Void, Never>?
     @State private var isAnimatingProgress: Bool = false
     @State private var progressStartTime: CFAbsoluteTime?
@@ -51,6 +52,24 @@ struct HatchingStepView: View {
             }
 
             Spacer()
+
+            if let characters = Self.welcomeCharacters {
+                Image(nsImage: characters)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(maxWidth: .infinity)
+                    .clipShape(UnevenRoundedRectangle(
+                        topLeadingRadius: 0,
+                        bottomLeadingRadius: VRadius.window,
+                        bottomTrailingRadius: VRadius.window,
+                        topTrailingRadius: 0
+                    ))
+                    .opacity(showFooterCharacters ? 1 : 0)
+                    .offset(y: showFooterCharacters ? 0 : 30)
+                    .animation(.easeOut(duration: 0.6).delay(0.5), value: showFooterCharacters)
+                    .onAppear { showFooterCharacters = true }
+                    .accessibilityHidden(true)
+            }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .opacity(showContent ? 1 : 0)
@@ -114,6 +133,11 @@ struct HatchingStepView: View {
             }
         }
     }
+
+    private static let welcomeCharacters: NSImage? = {
+        guard let url = ResourceBundle.bundle.url(forResource: "welcome-characters", withExtension: "png") else { return nil }
+        return NSImage(contentsOf: url)
+    }()
 
     // MARK: - Avatar
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
@@ -13,6 +13,12 @@ struct ImproveExperienceStepView: View {
 
     @State private var showTitle = false
     @State private var showContent = false
+    @State private var showCharacters = false
+
+    private static let welcomeCharacters: NSImage? = {
+        guard let url = ResourceBundle.bundle.url(forResource: "welcome-characters", withExtension: "png") else { return nil }
+        return NSImage(contentsOf: url)
+    }()
     @AppStorage("collectUsageData") private var collectUsageData: Bool = true
     @AppStorage("sendDiagnostics") private var sendDiagnostics: Bool = true
     @AppStorage("tosAccepted") private var tosAccepted: Bool = false
@@ -93,6 +99,26 @@ struct ImproveExperienceStepView: View {
             withAnimation(.easeOut(duration: 0.5).delay(0.3)) {
                 showContent = true
             }
+        }
+
+        Spacer()
+
+        if let characters = Self.welcomeCharacters {
+            Image(nsImage: characters)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(maxWidth: .infinity)
+                .clipShape(UnevenRoundedRectangle(
+                    topLeadingRadius: 0,
+                    bottomLeadingRadius: VRadius.window,
+                    bottomTrailingRadius: VRadius.window,
+                    topTrailingRadius: 0
+                ))
+                .opacity(showCharacters ? 1 : 0)
+                .offset(y: showCharacters ? 0 : 30)
+                .animation(.easeOut(duration: 0.6).delay(0.5), value: showCharacters)
+                .onAppear { showCharacters = true }
+                .accessibilityHidden(true)
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -147,9 +147,9 @@ struct OnboardingFlowView: View {
                     .id(isBootstrappingManaged ? -1 : state.currentStep)
 
                     // Bottom padding so content isn't flush with window edge.
-                    // Skip for steps with characters footer (0, 2) where the
+                    // Skip for steps with characters footer (0, 2, 3) where the
                     // graphic is designed to sit flush at the window bottom.
-                    if (state.currentStep != 0 && state.currentStep != 2) || isBootstrappingManaged {
+                    if (state.currentStep != 0 && state.currentStep != 2 && state.currentStep != 3) || isBootstrappingManaged {
                         Color.clear.frame(height: VSpacing.xxl)
                     }
                 }


### PR DESCRIPTION
## Summary
Add the welcome-characters footer image to ImproveExperienceStepView and HatchingStepView to match the Figma mocks, which show character illustrations at the bottom of every onboarding screen.

## Changes
- **ImproveExperienceStepView**: Add welcome-characters image, show animation state, and footer view after the buttons
- **HatchingStepView**: Add welcome-characters image and footer view after the content Spacer
- **OnboardingFlowView**: Update bottom padding skip condition to include step 3

Part of #24382.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24408" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
