### PR TITLE
refactor: remove obsolete chat surface state and lock regression coverage

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -285,10 +285,26 @@ struct ChatView: View {
         }
     }
 
+    /// Active conversation content stack.
+    ///
+    /// Data flow is narrowed to the three stabilized subsystems:
+    /// - **TranscriptProjector** — `MessageListView` calls `TranscriptProjector.project()`
+    ///   to produce an immutable `TranscriptRenderModel` from the raw messages.
+    /// - **ComposerController** — popup state (slash/emoji) and focus intents flow
+    ///   through the controller's event-driven state machine, not raw bindings.
+    /// - **ScrollCoordinator** — scroll policy decisions (follow-bottom, anchor jumps,
+    ///   stabilization) flow through the coordinator's `handle(_:)` method and are
+    ///   translated into concrete `ScrollPosition` mutations by the view layer.
+    ///
+    /// The raw viewModel properties passed here (`messages`, `isSending`, etc.)
+    /// are the projector's inputs — `MessageListView` does not observe them
+    /// individually; it feeds them into the projector and renders the resulting
+    /// `TranscriptRenderModel` via `MessageListContentView`.
     @ViewBuilder
     private func activeConversationContent(containerWidth: CGFloat) -> some View {
         VStack(spacing: 0) {
             MessageListView(
+                // -- TranscriptProjector inputs --
                 messages: viewModel.messages,
                 isSending: viewModel.isSending,
                 isThinking: viewModel.isThinking,
@@ -302,6 +318,7 @@ struct ChatView: View {
                 providerCatalog: providerCatalog,
                 activeSubagents: viewModel.activeSubagents,
                 dismissedDocumentSurfaceIds: viewModel.dismissedDocumentSurfaceIds,
+                // -- Interaction callbacks --
                 onConfirmationAllow: isReadonly ? nil : { requestId in viewModel.respondToConfirmation(requestId: requestId, decision: "allow") },
                 onConfirmationDeny: isReadonly ? nil : { requestId in viewModel.respondToConfirmation(requestId: requestId, decision: "deny") },
                 onAlwaysAllow: isReadonly ? nil : { requestId, selectedPattern, selectedScope, decision in
@@ -325,12 +342,15 @@ struct ChatView: View {
                 onRetryFailedMessage: isReadonly ? nil : { messageId in viewModel.retryFailedMessage(id: messageId) },
                 onRetryConversationError: isReadonly ? nil : { messageId in viewModel.retryAfterConversationError(messageId: messageId) },
                 subagentDetailStore: viewModel.subagentDetailStore,
+                // -- Projector-resolved state --
                 activePendingRequestId: viewModel.activePendingRequestId,
+                // -- Pagination --
                 paginatedVisibleMessages: viewModel.paginatedVisibleMessages,
                 displayedMessageCount: viewModel.displayedMessageCount,
                 hasMoreMessages: viewModel.hasMoreMessages,
                 isLoadingMoreMessages: viewModel.isLoadingMoreMessages,
                 loadPreviousMessagePage: { await viewModel.loadPreviousMessagePage() },
+                // -- ScrollCoordinator inputs --
                 conversationId: conversationId,
                 anchorMessageId: $anchorMessageId,
                 highlightedMessageId: $highlightedMessageId,

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -262,7 +262,7 @@ final class MessageListScrollState {
     /// Memoization state intentionally lives outside the observed object so
     /// `MessageListView` can update caches during body evaluation without
     /// tripping SwiftUI's "Modifying state during view update" runtime guard.
-    @ObservationIgnored let derivedStateCache = MessageListDerivedStateCache()
+    @ObservationIgnored let derivedStateCache = ProjectionCache()
 
     @ObservationIgnored var cachedProjectionKey: PrecomputedCacheKey? {
         get { derivedStateCache.cachedProjectionKey }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListTypes.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListTypes.swift
@@ -131,14 +131,7 @@ final class ScrollGeometryUpdateDispatcher {
     }
 }
 
-// MARK: - Message List Derived State (type alias)
-
-/// After the switch to `TranscriptProjector`, the render model is the
-/// canonical derived state for the message list. This alias keeps the
-/// cache storage name stable.
-typealias MessageListDerivedState = TranscriptRenderModel
-
-// MARK: - Derived-State Cache
+// MARK: - Projection Cache
 
 /// Non-observable cache used by `MessageListView` during body evaluation.
 ///
@@ -147,8 +140,13 @@ typealias MessageListDerivedState = TranscriptRenderModel
 /// pipeline needs memoization for performance, but those cache writes must not
 /// flow through SwiftUI-managed state. This helper keeps the cache off the
 /// observation graph while preserving the existing hot-path behavior.
+///
+/// All derived transcript state flows through `TranscriptProjector` which
+/// produces a `TranscriptRenderModel`. This cache gates re-projection with
+/// an O(1) `PrecomputedCacheKey` and stores the circuit-breaker state that
+/// protects against runaway body evaluations.
 @MainActor
-final class MessageListDerivedStateCache {
+final class ProjectionCache {
     var cachedProjectionKey: PrecomputedCacheKey?
     var cachedProjection: TranscriptRenderModel?
     var messageListVersion = 0
@@ -160,7 +158,6 @@ final class MessageListDerivedStateCache {
     var cachedFirstVisibleMessageId: UUID?
     var bodyEvalTimestamps: [CFAbsoluteTime] = []
     var isThrottled = false
-    var cachedDerivedState: TranscriptRenderModel?
     var throttleRecoveryTask: Task<Void, Never>?
 
     func reset() {
@@ -173,7 +170,6 @@ final class MessageListDerivedStateCache {
         lastKnownIncompleteToolCallCount = 0
         lastKnownVisibleIdFingerprint = 0
         cachedFirstVisibleMessageId = nil
-        cachedDerivedState = nil
         bodyEvalTimestamps.removeAll()
         throttleRecoveryTask?.cancel()
         throttleRecoveryTask = nil

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+DerivedState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+DerivedState.swift
@@ -93,16 +93,16 @@ extension MessageListView {
     /// Computes all derived values needed by the message list body by
     /// delegating to `TranscriptProjector.project()`.
     ///
-    /// The projector produces a `TranscriptRenderModel` (aliased as
-    /// `MessageListDerivedState`) from the raw chat inputs. A lightweight
-    /// O(1) `PrecomputedCacheKey` gates re-projection so the full O(n)
-    /// scan only runs on structural or state changes.
+    /// The projector produces a `TranscriptRenderModel` from the raw
+    /// chat inputs. A lightweight O(1) `PrecomputedCacheKey` gates
+    /// re-projection so the full O(n) scan only runs on structural or
+    /// state changes.
     var derivedState: TranscriptRenderModel {
         os_signpost(.begin, log: stallLog, name: "DerivedState.resolve")
         scrollState.recordBodyEvaluation()
         let cache = scrollState.derivedStateCache
 
-        if cache.isThrottled, let cached = cache.cachedDerivedState {
+        if cache.isThrottled, let cached = cache.cachedProjection {
             os_signpost(.end, log: stallLog, name: "DerivedState.resolve")
             return cached
         }
@@ -130,7 +130,6 @@ extension MessageListView {
            let cached = cache.cachedProjection,
            cached.rows.count == liveMessages.count {
             os_signpost(.event, log: stallLog, name: "DerivedState.projectionCacheHit")
-            cache.cachedDerivedState = cached
             os_signpost(.end, log: stallLog, name: "DerivedState.resolve")
             return cached
         }
@@ -154,7 +153,6 @@ extension MessageListView {
 
         cache.cachedProjectionKey = key
         cache.cachedProjection = result
-        cache.cachedDerivedState = result
         os_signpost(.end, log: stallLog, name: "DerivedState.resolve")
         return result
     }

--- a/clients/macos/vellum-assistant/Features/Chat/TranscriptRenderModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/TranscriptRenderModel.swift
@@ -4,9 +4,9 @@ import VellumAssistantShared
 // MARK: - Transcript Render Model
 
 /// Top-level immutable render model for the entire chat transcript.
-/// Mirrors what `MessageListDerivedState` currently provides but
-/// expresses the layout as pure data — no SwiftUI state, no caching
-/// bookkeeping, no closure callbacks.
+/// Expresses the layout as pure data — no SwiftUI state, no caching
+/// bookkeeping, no closure callbacks. Produced by `TranscriptProjector`
+/// and consumed by `MessageListContentView`.
 ///
 /// - SeeAlso: `TranscriptProjector` which produces this from raw inputs.
 struct TranscriptRenderModel: Equatable {

--- a/clients/macos/vellum-assistantTests/ChatSurfaceStabilityRegressionTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatSurfaceStabilityRegressionTests.swift
@@ -1,0 +1,443 @@
+#if os(macOS)
+import XCTest
+@testable import VellumAssistantLib
+@preconcurrency import VellumAssistantShared
+
+// MARK: - Chat Surface Stability Regression Tests
+//
+// Deterministic regression tests for the five field-observed freeze
+// families in the chat surface. Each scenario exercises the final
+// projected/controller/coordinator architecture end-to-end to ensure
+// the interaction produces valid, non-degenerate state.
+//
+// All data flows through:
+//   TranscriptProjector  — transcript render model
+//   ComposerController   — popup state machine
+//   ScrollCoordinator    — scroll policy decisions
+//
+// No legacy compatibility layers (MessageListDerivedState alias,
+// cachedDerivedState field, or dispatcher wrappers) are involved.
+//
+// Run with:
+//   cd clients/macos && ./build.sh test --filter ChatSurfaceStabilityRegressionTests
+
+@MainActor
+final class ChatSurfaceStabilityRegressionTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    /// Builds an array of ChatMessage instances with alternating user/assistant roles.
+    private func buildMessages(count: Int, startIndex: Int = 0) -> [ChatMessage] {
+        (startIndex..<startIndex + count).map { i in
+            ChatMessage(
+                role: i.isMultiple(of: 2) ? .user : .assistant,
+                text: "Message \(i)",
+                timestamp: Date(timeIntervalSince1970: TimeInterval(1_700_000_000 + i * 10))
+            )
+        }
+    }
+
+    /// Builds a streaming assistant message appended to an existing transcript.
+    private func appendStreamingAssistantMessage(to messages: inout [ChatMessage], text: String = "") {
+        messages.append(ChatMessage(
+            role: .assistant,
+            text: text,
+            timestamp: Date(timeIntervalSince1970: TimeInterval(1_700_000_000 + messages.count * 10)),
+            isStreaming: true
+        ))
+    }
+
+    /// Projects the given messages through TranscriptProjector with standard defaults.
+    private func project(
+        messages: [ChatMessage],
+        isSending: Bool = false,
+        isThinking: Bool = false,
+        activeSubagents: [SubagentInfo] = [],
+        assistantStatusText: String? = nil,
+        assistantActivityPhase: String = "",
+        assistantActivityAnchor: String = "",
+        assistantActivityReason: String? = nil,
+        activePendingRequestId: String? = nil,
+        highlightedMessageId: UUID? = nil
+    ) -> TranscriptRenderModel {
+        TranscriptProjector.project(
+            messages: messages,
+            paginatedVisibleMessages: messages,
+            activeSubagents: activeSubagents,
+            isSending: isSending,
+            isThinking: isThinking,
+            isCompacting: false,
+            assistantStatusText: assistantStatusText,
+            assistantActivityPhase: assistantActivityPhase,
+            assistantActivityAnchor: assistantActivityAnchor,
+            assistantActivityReason: assistantActivityReason,
+            activePendingRequestId: activePendingRequestId,
+            highlightedMessageId: highlightedMessageId
+        )
+    }
+
+    // MARK: - Scenario 1: Send While Transcript Is Visible
+    //
+    // Freeze family: user sends a message while the transcript is rendering
+    // a streaming response. The projector must produce a stable render model
+    // that includes the new user message without degenerate row counts.
+
+    func testSendWhileTranscriptIsVisible() {
+        // Start with a visible transcript with an active streaming response.
+        var messages = buildMessages(count: 10)
+        appendStreamingAssistantMessage(to: &messages, text: "Streaming response...")
+
+        let model1 = project(messages: messages, isSending: true)
+        XCTAssertEqual(model1.rows.count, messages.count,
+                       "All messages including streaming must appear in rows")
+        XCTAssertFalse(model1.shouldShowThinkingIndicator,
+                       "Streaming message is visible — no standalone thinking indicator")
+
+        // User sends a new message while the assistant is still streaming.
+        messages.append(ChatMessage(
+            role: .user,
+            text: "New user message",
+            timestamp: Date(timeIntervalSince1970: 1_700_000_200)
+        ))
+
+        let model2 = project(messages: messages, isSending: true, isThinking: true)
+        XCTAssertEqual(model2.rows.count, messages.count,
+                       "New user message must appear in projection")
+        XCTAssertTrue(model2.hasUserMessage)
+
+        // The scroll coordinator must handle the send event without panic.
+        let coordinator = ScrollCoordinator()
+        let intents = coordinator.handle(.sendingChanged(isSending: true))
+        XCTAssertTrue(coordinator.isFollowingBottom,
+                      "Send must reattach to bottom")
+        XCTAssertTrue(intents.contains(.scrollToBottom(animated: true)),
+                      "Send must scroll to bottom")
+
+        // The projector must produce equal results for identical inputs
+        // (idempotency — no hidden mutation).
+        let model3 = project(messages: messages, isSending: true, isThinking: true)
+        XCTAssertEqual(model2, model3,
+                       "Projector must be idempotent for identical inputs")
+    }
+
+    // MARK: - Scenario 2: Scroll During a Streaming Response
+    //
+    // Freeze family: user scrolls up during an active streaming response.
+    // The scroll coordinator must detach from follow-bottom without
+    // fight-back or mode oscillation.
+
+    func testScrollDuringStreamingResponse() {
+        let coordinator = ScrollCoordinator()
+
+        // Simulate initial load and sending.
+        coordinator.handle(.appeared)
+        coordinator.handle(.sendingChanged(isSending: true))
+        XCTAssertTrue(coordinator.isFollowingBottom)
+
+        // New messages arrive during streaming.
+        coordinator.handle(.messageCountChanged)
+        coordinator.handle(.messageCountChanged)
+        coordinator.handle(.messageCountChanged)
+
+        // User starts scrolling — enters interacting phase.
+        let _ = coordinator.handle(.scrollPhaseChanged(phase: .interacting))
+
+        // User scrolls up — manual browse intent.
+        let browseIntents = coordinator.handle(.manualBrowseIntent)
+        XCTAssertEqual(coordinator.mode, .freeBrowsing,
+                       "Manual scroll must enter free browsing")
+        XCTAssertTrue(browseIntents.contains(.cancelRecoveryWindow),
+                      "Must cancel recovery on manual browse")
+        XCTAssertTrue(browseIntents.contains(.showScrollToLatest),
+                      "Must show CTA in free browsing")
+
+        // More messages arrive while in free browsing.
+        let msgIntents = coordinator.handle(.messageCountChanged)
+        XCTAssertEqual(coordinator.mode, .freeBrowsing,
+                       "New messages must not reattach in free browsing")
+        XCTAssertFalse(msgIntents.contains(.scrollToBottom(animated: true)),
+                       "Must not auto-scroll in free browsing")
+
+        // The projector must still produce valid state during free browsing.
+        var messages = buildMessages(count: 20)
+        appendStreamingAssistantMessage(to: &messages, text: "Streaming text")
+        let model = project(messages: messages, isSending: true)
+        XCTAssertEqual(model.rows.count, messages.count)
+        XCTAssertFalse(model.rows.isEmpty)
+    }
+
+    // MARK: - Scenario 3: Expand a Tool Block During Streaming
+    //
+    // Freeze family: user clicks to expand a tool-call details block
+    // while a streaming response is active. The scroll coordinator must
+    // enter stabilization and detach from follow-bottom.
+
+    func testExpandToolBlockDuringStreaming() {
+        let coordinator = ScrollCoordinator()
+        coordinator.handle(.appeared)
+        coordinator.handle(.sendingChanged(isSending: true))
+        XCTAssertTrue(coordinator.isFollowingBottom)
+
+        // User expands a tool block.
+        let expandIntents = coordinator.handle(.manualExpansion)
+        XCTAssertEqual(coordinator.mode, .freeBrowsing,
+                       "Manual expansion must detach to free browsing")
+        XCTAssertTrue(expandIntents.contains(.cancelRecoveryWindow),
+                      "Must cancel recovery on expansion")
+        XCTAssertTrue(expandIntents.contains(.showScrollToLatest),
+                      "Must show CTA after expansion")
+
+        // New streaming content arrives — must not fight back.
+        let msgIntents = coordinator.handle(.messageCountChanged)
+        XCTAssertEqual(coordinator.mode, .freeBrowsing)
+        XCTAssertFalse(msgIntents.contains(.scrollToBottom(animated: true)))
+
+        // Verify the projector handles tool calls correctly.
+        var messages = buildMessages(count: 6)
+        // Add a message with an incomplete tool call.
+        messages.append(ChatMessage(
+            role: .assistant,
+            text: "",
+            timestamp: Date(timeIntervalSince1970: 1_700_000_100),
+            isStreaming: true,
+            toolCalls: [
+                ToolCallData(toolName: "bash", inputSummary: "ls -la", isComplete: false)
+            ]
+        ))
+
+        let model = project(messages: messages, isSending: true)
+        XCTAssertTrue(model.hasActiveToolCall,
+                      "Must detect active tool call")
+        XCTAssertFalse(model.shouldShowThinkingIndicator,
+                       "Must not show thinking indicator during active tool call")
+        XCTAssertEqual(model.rows.count, messages.count)
+    }
+
+    // MARK: - Scenario 4: Type With Emoji or Slash Popup Open
+    //
+    // Freeze family: user types while the emoji picker or slash command
+    // popup is visible. The ComposerController must maintain consistent
+    // popup state without degenerate menu-refresh scheduling.
+
+    func testTypeWithEmojiPopupOpen() {
+        let controller = ComposerController(
+            slashCommandProvider: StubSlashCommandProvider(commands: []),
+            emojiSearchProvider: StubEmojiSearchProvider(entries: [
+                EmojiEntry(shortcode: "party_popper", emoji: "\u{1F389}"),
+                EmojiEntry(shortcode: "partying_face", emoji: "\u{1F973}"),
+            ])
+        )
+
+        // Type `:par` to trigger the emoji popup (needs 2+ chars after colon).
+        controller.textChanged(":par")
+        controller.cursorMoved(to: 4)
+        controller.performMenuRefresh()
+
+        XCTAssertTrue(controller.showEmojiMenu,
+                      "Emoji menu must be visible after trigger")
+        XCTAssertEqual(controller.emojiFilter, "par")
+        XCTAssertFalse(controller.showSlashMenu)
+
+        // Continue typing while emoji popup is visible.
+        controller.textChanged(":part")
+        controller.cursorMoved(to: 5)
+        controller.performMenuRefresh()
+
+        XCTAssertTrue(controller.showEmojiMenu,
+                      "Emoji menu must stay visible during typing")
+        XCTAssertEqual(controller.emojiFilter, "part")
+
+        // The projector must remain stable during popup interactions.
+        let messages = buildMessages(count: 5)
+        let model1 = project(messages: messages)
+        let model2 = project(messages: messages)
+        XCTAssertEqual(model1, model2,
+                       "Projector must be stable during popup interactions")
+    }
+
+    func testTypeWithSlashPopupOpen() {
+        let slashDescriptors = [
+            ChatSlashCommandDescriptor(
+                name: "help",
+                description: "Show help",
+                icon: "questionmark.circle",
+                selectionBehavior: .autoSend,
+                pickerPlatforms: [.macos],
+                helpBubblePlatforms: [.macos],
+                sendPathPlatforms: [.macos]
+            ),
+            ChatSlashCommandDescriptor(
+                name: "history",
+                description: "Show history",
+                icon: "clock",
+                selectionBehavior: .autoSend,
+                pickerPlatforms: [.macos],
+                helpBubblePlatforms: [.macos],
+                sendPathPlatforms: [.macos]
+            ),
+        ]
+
+        let controller = ComposerController(
+            slashCommandProvider: StubSlashCommandProvider(
+                commands: slashDescriptors.map(SlashCommand.init(descriptor:))
+            ),
+            emojiSearchProvider: StubEmojiSearchProvider(entries: [])
+        )
+
+        // Type `/h` to trigger the slash popup.
+        controller.textChanged("/h")
+        controller.cursorMoved(to: 2)
+        controller.performMenuRefresh()
+
+        XCTAssertTrue(controller.showSlashMenu,
+                      "Slash menu must be visible after trigger")
+        XCTAssertEqual(controller.slashFilter, "h")
+        XCTAssertFalse(controller.showEmojiMenu)
+
+        // Continue typing while slash popup is visible.
+        controller.textChanged("/he")
+        controller.cursorMoved(to: 3)
+        controller.performMenuRefresh()
+
+        XCTAssertTrue(controller.showSlashMenu,
+                      "Slash menu must stay visible during typing")
+        XCTAssertEqual(controller.slashFilter, "he")
+
+        // Navigate and dismiss — state must be clean.
+        controller.handleSlashNavigation(.dismiss)
+        XCTAssertFalse(controller.showSlashMenu)
+        XCTAssertFalse(controller.isPopupVisible)
+    }
+
+    // MARK: - Scenario 5: Typing With Completed Progress Cards
+    //
+    // Freeze family: user types in the composer while the transcript
+    // contains completed progress cards (assistant tool call messages
+    // with isComplete=true). The projector and scroll coordinator must
+    // produce stable state without cross-subtree observation.
+
+    func testTypingWithCompletedProgressCards() {
+        // Build a transcript with completed tool calls.
+        var messages = buildMessages(count: 4)
+        messages.append(ChatMessage(
+            role: .assistant,
+            text: "Running command...",
+            timestamp: Date(timeIntervalSince1970: 1_700_000_080),
+            toolCalls: [
+                ToolCallData(toolName: "bash", inputSummary: "echo hello", result: "hello", isComplete: true),
+                ToolCallData(toolName: "bash", inputSummary: "ls", result: "file1.txt\nfile2.txt", isComplete: true)
+            ]
+        ))
+        messages.append(ChatMessage(
+            role: .assistant,
+            text: "Done! Both commands completed successfully.",
+            timestamp: Date(timeIntervalSince1970: 1_700_000_090)
+        ))
+
+        // Project with completed progress cards and no active sending.
+        let model1 = project(messages: messages, isSending: false)
+        XCTAssertEqual(model1.rows.count, messages.count)
+        XCTAssertFalse(model1.hasActiveToolCall,
+                       "Completed tool calls must not be flagged as active")
+        XCTAssertFalse(model1.shouldShowThinkingIndicator)
+        XCTAssertFalse(model1.isStreamingWithoutText)
+
+        // Simulate user typing — re-project with identical transcript.
+        // The projection must be identical (no hidden typing-related
+        // side effects on the render model).
+        let model2 = project(messages: messages, isSending: false)
+        XCTAssertEqual(model1, model2,
+                       "Re-projection with identical inputs must be stable during typing")
+
+        // The scroll coordinator must be in a stable state.
+        let coordinator = ScrollCoordinator()
+        coordinator.handle(.appeared)
+        // Simulate that the user has been reading (not at bottom).
+        coordinator.handle(.manualBrowseIntent)
+        XCTAssertEqual(coordinator.mode, .freeBrowsing)
+
+        // Message count hasn't changed — no scroll events.
+        let intents = coordinator.handle(.messageCountChanged)
+        XCTAssertFalse(intents.contains(.scrollToBottom(animated: true)),
+                       "Must not auto-scroll in free browsing during typing")
+
+        // Verify the ComposerController handles typing cleanly
+        // without affecting the transcript state.
+        let controller = ComposerController(
+            slashCommandProvider: StubSlashCommandProvider(commands: []),
+            emojiSearchProvider: StubEmojiSearchProvider(entries: [])
+        )
+        controller.textChanged("Hello")
+        controller.cursorMoved(to: 5)
+        controller.performMenuRefresh()
+        XCTAssertFalse(controller.isPopupVisible,
+                       "Normal typing must not trigger any popup")
+
+        // Final re-projection must still match.
+        let model3 = project(messages: messages, isSending: false)
+        XCTAssertEqual(model1, model3,
+                       "Projection must be fully deterministic across typing cycles")
+    }
+
+    // MARK: - Cross-Subsystem Integration
+
+    /// Verifies that the three subsystems (projector, controller, coordinator)
+    /// can all operate in the same scenario without interfering with each other.
+    func testAllSubsystemsOperateIndependently() {
+        // Set up all three subsystems.
+        var messages = buildMessages(count: 10)
+        appendStreamingAssistantMessage(to: &messages, text: "Streaming...")
+
+        let coordinator = ScrollCoordinator()
+        coordinator.handle(.appeared)
+        coordinator.handle(.sendingChanged(isSending: true))
+
+        let controller = ComposerController(
+            slashCommandProvider: StubSlashCommandProvider(commands: []),
+            emojiSearchProvider: StubEmojiSearchProvider(entries: [
+                EmojiEntry(shortcode: "thumbsup", emoji: "\u{1F44D}"),
+            ])
+        )
+
+        // Project the transcript.
+        let model = project(messages: messages, isSending: true)
+        XCTAssertEqual(model.rows.count, messages.count)
+
+        // Operate the controller.
+        controller.textChanged(":thumbsup")
+        controller.cursorMoved(to: 9)
+        controller.performMenuRefresh()
+        XCTAssertTrue(controller.showEmojiMenu)
+
+        // Operate the coordinator.
+        coordinator.handle(.messageCountChanged)
+        XCTAssertTrue(coordinator.isFollowingBottom)
+
+        // Re-project — must be unaffected by controller/coordinator state.
+        let model2 = project(messages: messages, isSending: true)
+        XCTAssertEqual(model, model2,
+                       "Projector output must be independent of controller/coordinator state")
+    }
+}
+
+// MARK: - Test Stubs
+
+/// Stub slash command provider for deterministic testing.
+private struct StubSlashCommandProvider: SlashCommandProvider {
+    let commands: [SlashCommand]
+
+    func filteredCommands(_ filter: String) -> [SlashCommand] {
+        commands.filter { filter.isEmpty || $0.name.lowercased().hasPrefix(filter.lowercased()) }
+    }
+}
+
+/// Stub emoji search provider for deterministic testing.
+private struct StubEmojiSearchProvider: EmojiSearchProvider {
+    let entries: [EmojiEntry]
+
+    func search(query: String, limit: Int) -> [EmojiEntry] {
+        let matched = entries.filter { $0.shortcode.contains(query.lowercased()) }
+        return Array(matched.prefix(limit))
+    }
+}
+#endif

--- a/clients/macos/vellum-assistantTests/MessageListScrollPerformanceTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListScrollPerformanceTests.swift
@@ -4,9 +4,17 @@ import XCTest
 
 // MARK: - Scroll Performance Regression Tests
 //
-// Baselines for scroll-critical code paths. All tests use `measure {}` with
-// XCTest baselines — no hard-coded timing thresholds. CI detects regressions
-// as statistical deviations from the recorded baseline.
+// Baselines for scroll-critical code paths in the final
+// projected/controller/coordinator architecture.
+//
+// All transcript derivation flows through `TranscriptProjector`, gated by
+// `ProjectionCache`. Scroll policy flows through `ScrollCoordinator`. These
+// tests assert that the measured hot paths stay on these implementations
+// rather than any removed compatibility layer.
+//
+// All tests use `measure {}` with XCTest baselines — no hard-coded timing
+// thresholds. CI detects regressions as statistical deviations from the
+// recorded baseline.
 //
 // Run with:
 //   cd clients/macos && ./build.sh test --filter ScrollPerformance
@@ -368,5 +376,140 @@ final class MessageListScrollPerformanceTests: XCTestCase {
                 _ = view.resolveSelectableRunMeasurement(segments)
             }
         }
+    }
+
+    // MARK: - Test 11: ProjectionCache Reset Clears All State
+
+    /// Verifies that `ProjectionCache.reset()` clears all cached state,
+    /// ensuring no stale projections survive a conversation switch. This is
+    /// the final architecture's cache — no legacy `cachedDerivedState` field
+    /// or `MessageListDerivedState` alias involved.
+    @MainActor
+    func testProjectionCacheResetClearsAllState() {
+        let cache = ProjectionCache()
+
+        // Populate the cache with representative state.
+        cache.cachedProjectionKey = PrecomputedCacheKey(
+            messageListVersion: 42,
+            isSending: true,
+            isThinking: false,
+            isCompacting: false,
+            assistantStatusText: nil,
+            activeSubagentFingerprint: 7,
+            displayedMessageCount: 100
+        )
+        cache.cachedProjection = TranscriptProjector.project(
+            messages: buildMessages(count: 5),
+            paginatedVisibleMessages: buildMessages(count: 5),
+            activeSubagents: [],
+            isSending: false,
+            isThinking: false,
+            isCompacting: false,
+            assistantStatusText: nil,
+            assistantActivityPhase: "",
+            assistantActivityAnchor: "",
+            assistantActivityReason: nil,
+            activePendingRequestId: nil,
+            highlightedMessageId: nil
+        )
+        cache.messageListVersion = 42
+        cache.lastKnownRawMessageCount = 50
+        cache.lastKnownVisibleMessageCount = 50
+        cache.lastKnownLastMessageStreaming = true
+        cache.lastKnownIncompleteToolCallCount = 3
+        cache.lastKnownVisibleIdFingerprint = 999
+        cache.cachedFirstVisibleMessageId = UUID()
+        cache.isThrottled = true
+
+        // Reset.
+        cache.reset()
+
+        // All fields must be zeroed.
+        XCTAssertNil(cache.cachedProjectionKey)
+        XCTAssertNil(cache.cachedProjection)
+        XCTAssertEqual(cache.messageListVersion, 0)
+        XCTAssertEqual(cache.lastKnownRawMessageCount, 0)
+        XCTAssertEqual(cache.lastKnownVisibleMessageCount, 0)
+        XCTAssertFalse(cache.lastKnownLastMessageStreaming)
+        XCTAssertEqual(cache.lastKnownIncompleteToolCallCount, 0)
+        XCTAssertEqual(cache.lastKnownVisibleIdFingerprint, 0)
+        XCTAssertNil(cache.cachedFirstVisibleMessageId)
+        XCTAssertFalse(cache.isThrottled)
+    }
+
+    // MARK: - Test 12: ScrollCoordinator Policy Hot Path
+
+    /// Measures the synchronous hot path of ScrollCoordinator event handling.
+    /// All scroll policy decisions now flow through the coordinator's
+    /// `handle(_:)` method — this test establishes the baseline cost.
+    @MainActor
+    func testScrollCoordinatorPolicyHotPath() {
+        measure(metrics: [XCTClockMetric()]) {
+            let coordinator = ScrollCoordinator()
+
+            // Simulate a realistic event sequence: appear, send, stream,
+            // scroll, reattach — repeated 100 times.
+            for _ in 0..<100 {
+                coordinator.handle(.appeared)
+                coordinator.handle(.sendingChanged(isSending: true))
+                coordinator.handle(.messageCountChanged)
+                coordinator.handle(.messageCountChanged)
+                coordinator.handle(.scrollPhaseChanged(phase: .interacting))
+                coordinator.handle(.manualBrowseIntent)
+                coordinator.handle(.scrollPhaseChanged(phase: .idle))
+                let _ = coordinator.requestUserInitiatedPin()
+                coordinator.handle(.messageCountChanged)
+                coordinator.handle(.sendingChanged(isSending: false))
+                coordinator.reset()
+            }
+
+            // Prevent optimizer from eliding.
+            XCTAssertEqual(coordinator.mode, .initialLoad)
+        }
+    }
+
+    // MARK: - Test 13: Projector Produces Stable Output for Coordinator Inputs
+
+    /// Verifies that the projector produces identical output when called
+    /// with the same inputs, proving that scroll coordinator decisions
+    /// can safely cache on projector output equality.
+    func testProjectorOutputStableForCoordinatorCaching() {
+        let messages = buildMessages(count: 100)
+
+        let model1 = TranscriptProjector.project(
+            messages: messages,
+            paginatedVisibleMessages: messages,
+            activeSubagents: [],
+            isSending: true,
+            isThinking: false,
+            isCompacting: false,
+            assistantStatusText: "Processing...",
+            assistantActivityPhase: "thinking",
+            assistantActivityAnchor: "assistant_turn",
+            assistantActivityReason: nil,
+            activePendingRequestId: nil,
+            highlightedMessageId: nil
+        )
+
+        let model2 = TranscriptProjector.project(
+            messages: messages,
+            paginatedVisibleMessages: messages,
+            activeSubagents: [],
+            isSending: true,
+            isThinking: false,
+            isCompacting: false,
+            assistantStatusText: "Processing...",
+            assistantActivityPhase: "thinking",
+            assistantActivityAnchor: "assistant_turn",
+            assistantActivityReason: nil,
+            activePendingRequestId: nil,
+            highlightedMessageId: nil
+        )
+
+        XCTAssertEqual(model1, model2,
+                       "Projector must produce identical output for identical inputs")
+        XCTAssertEqual(model1.rows.count, model2.rows.count)
+        XCTAssertEqual(model1.hasActiveToolCall, model2.hasActiveToolCall)
+        XCTAssertEqual(model1.shouldShowThinkingIndicator, model2.shouldShowThinkingIndicator)
     }
 }


### PR DESCRIPTION
## Summary
- Remove obsolete MessageListDerivedState adapter types and stale cache fields
- Narrow ChatView composition to projected transcript, controller, and coordinator interfaces
- Add ChatSurfaceStabilityRegressionTests for send, scroll, expand, and popup freeze scenarios

Part of plan: macos-chat-surface-stabilization.md (PR 11 of 11)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24409" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
