### PR TITLE
Update APIKeyEntryStepView and add character footers to all onboarding steps

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
@@ -10,7 +10,13 @@ struct APIKeyEntryStepView: View {
     @State private var isEditing = false
     @State private var showTitle = false
     @State private var showContent = false
+    @State private var showCharacters = false
     @FocusState private var keyFieldFocused: Bool
+
+    private static let welcomeCharacters: NSImage? = {
+        guard let url = ResourceBundle.bundle.url(forResource: "welcome-characters", withExtension: "png") else { return nil }
+        return NSImage(contentsOf: url)
+    }()
 
     // MARK: - Provider Catalog
 
@@ -105,18 +111,26 @@ struct APIKeyEntryStepView: View {
                     apiKeyField
                 }
 
-                VButton(label: "Continue", style: .primary, isFullWidth: true, isDisabled: providerRequiresKey && apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty) {
-                    saveAndHatch()
-                }
-
                 if let apiKeyUrl = currentProviderEntry?.apiKeyUrl,
                    let url = URL(string: apiKeyUrl) {
-                    VButton(label: "Get an API key", style: .ghost) {
-                        NSWorkspace.shared.open(url)
+                    HStack(spacing: VSpacing.sm) {
+                        Text("Don't have it?")
+                            .font(VFont.bodyMediumDefault)
+                            .foregroundStyle(VColor.contentSecondary)
+                        Text("Get an API key here")
+                            .font(VFont.bodyMediumDefault)
+                            .foregroundStyle(VColor.contentDefault)
+                            .onTapGesture {
+                                NSWorkspace.shared.open(url)
+                            }
                     }
                 }
 
-                VButton(label: "Back", style: .ghost) {
+                VButton(label: "Start", style: .primary, isFullWidth: true, isDisabled: providerRequiresKey && apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty) {
+                    saveAndHatch()
+                }
+
+                VButton(label: "Back", style: .outlined) {
                     goBack()
                 }
             }
@@ -154,6 +168,26 @@ struct APIKeyEntryStepView: View {
                 hasExistingKey = false
                 isEditing = false
             }
+        }
+
+        Spacer()
+
+        if let characters = Self.welcomeCharacters {
+            Image(nsImage: characters)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(maxWidth: .infinity)
+                .clipShape(UnevenRoundedRectangle(
+                    topLeadingRadius: 0,
+                    bottomLeadingRadius: VRadius.window,
+                    bottomTrailingRadius: VRadius.window,
+                    topTrailingRadius: 0
+                ))
+                .opacity(showCharacters ? 1 : 0)
+                .offset(y: showCharacters ? 0 : 30)
+                .animation(.easeOut(duration: 0.6).delay(0.5), value: showCharacters)
+                .onAppear { showCharacters = true }
+                .accessibilityHidden(true)
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -75,6 +75,12 @@ struct APIKeyStepView: View {
 
     @State private var showTitle = false
     @State private var showContent = false
+    @State private var showCharacters = false
+
+    private static let welcomeCharacters: NSImage? = {
+        guard let url = ResourceBundle.bundle.url(forResource: "welcome-characters", withExtension: "png") else { return nil }
+        return NSImage(contentsOf: url)
+    }()
 
     private var userHostedEnabled: Bool {
         MacOSClientFeatureFlagManager.shared.isEnabled("user-hosted-enabled")
@@ -133,6 +139,26 @@ struct APIKeyStepView: View {
             withAnimation(.easeOut(duration: 0.5).delay(0.3)) {
                 showContent = true
             }
+        }
+
+        Spacer()
+
+        if let characters = Self.welcomeCharacters {
+            Image(nsImage: characters)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(maxWidth: .infinity)
+                .clipShape(UnevenRoundedRectangle(
+                    topLeadingRadius: 0,
+                    bottomLeadingRadius: VRadius.window,
+                    bottomTrailingRadius: VRadius.window,
+                    topTrailingRadius: 0
+                ))
+                .opacity(showCharacters ? 1 : 0)
+                .offset(y: showCharacters ? 0 : 30)
+                .animation(.easeOut(duration: 0.6).delay(0.5), value: showCharacters)
+                .onAppear { showCharacters = true }
+                .accessibilityHidden(true)
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -147,9 +147,10 @@ struct OnboardingFlowView: View {
                     .id(isBootstrappingManaged ? -1 : state.currentStep)
 
                     // Bottom padding so content isn't flush with window edge.
-                    // Skip for steps with characters footer (0, 2, 3) where the
-                    // graphic is designed to sit flush at the window bottom.
-                    if (state.currentStep != 0 && state.currentStep != 2 && state.currentStep != 3) || isBootstrappingManaged {
+                    // All onboarding steps now have a characters footer that sits
+                    // flush at the window bottom, so only add padding for the
+                    // managed bootstrap view.
+                    if isBootstrappingManaged {
                         Color.clear.frame(height: VSpacing.xxl)
                     }
                 }


### PR DESCRIPTION
## Summary
Updates APIKeyEntryStepView to match Figma mock (2341:20252) and adds character footer illustrations to all remaining onboarding steps.

## Changes
- **APIKeyEntryStepView**: Rename "Continue" to "Start", change Back to outlined style, change "Get an API key" button to inline "Don't have it? Get an API key here" text, add character footer
- **APIKeyStepView**: Add character footer
- **OnboardingFlowView**: Simplify bottom padding — all steps now have character footers

Part of #24382.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24413" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
