### PR TITLE
fix: update stale scaffolding doc comments on ScrollCoordinator and related types

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ScrollCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ScrollCoordinator.swift
@@ -10,8 +10,9 @@ import Foundation
 /// describing what scroll action the view layer should perform — without owning
 /// `ScrollPosition`, `ScrollGeometrySnapshot`, or any SwiftUI view references.
 ///
-/// **Not yet wired into the live message list.** This PR is additive scaffolding;
-/// existing transcript scrolling is unchanged.
+/// Wired into the live message list in MessageListView, MessageListView+Lifecycle,
+/// and MessageListView+ScrollHandling. Output intents are translated into concrete
+/// ScrollPosition mutations by executeCoordinatorIntents().
 ///
 /// Scroll policy domains modeled:
 ///   - following-bottom vs free-browsing


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for macos-chat-surface-stabilization.md.

**Gap:** Stale scaffolding doc comments
**What was expected:** Doc comments updated after wiring PRs merged
**What was found:** ScrollCoordinator still had 'Not yet wired' comment from scaffolding PR
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24414" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
