### PR TITLE
fix: invert Swift polling error logic — only retry 5xx, throw all else

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
@@ -412,13 +412,13 @@ struct AssistantTransferSection: View {
                 } catch is CancellationError {
                     throw CancellationError()
                 } catch let error as PlatformMigrationClient.PlatformMigrationError {
-                    // Only fail fast on permanent 4xx errors
-                    // Retry transient 5xx errors
-                    if case .requestFailed(let statusCode, _) = error, (400..<500).contains(statusCode) {
-                        throw error
+                    // Only retry on transient 5xx server errors
+                    // All other PlatformMigrationError cases (notAuthenticated, 4xx, etc.) are permanent
+                    if case .requestFailed(let statusCode, _) = error, (500..<600).contains(statusCode) {
+                        continue
                     }
-                    // Transient server error — retry on next cycle
-                    continue
+                    // Permanent error — fail fast
+                    throw error
                 } catch {
                     // Transient network errors — retry on next cycle
                     continue

--- a/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
@@ -642,13 +642,13 @@ struct TeleportSection: View {
                 } catch is CancellationError {
                     throw CancellationError()
                 } catch let error as PlatformMigrationClient.PlatformMigrationError {
-                    // Only fail fast on permanent 4xx errors
-                    // Retry transient 5xx errors
-                    if case .requestFailed(let statusCode, _) = error, (400..<500).contains(statusCode) {
-                        throw error
+                    // Only retry on transient 5xx server errors
+                    // All other PlatformMigrationError cases (notAuthenticated, 4xx, etc.) are permanent
+                    if case .requestFailed(let statusCode, _) = error, (500..<600).contains(statusCode) {
+                        continue
                     }
-                    // Transient server error — retry on next cycle
-                    continue
+                    // Permanent error — fail fast
+                    throw error
                 } catch {
                     // Transient network errors — retry on next cycle
                     continue


### PR DESCRIPTION
## Summary
- Invert PlatformMigrationError catch logic: only continue on .requestFailed with 5xx
- All other PlatformMigrationError cases (notAuthenticated, 4xx) throw immediately
- Fixes silent 10-minute retry on auth failures
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24416" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
