### PR TITLE
Strengthen app-builder activation hints for better skill routing

### DIFF
--- a/assistant/src/config/bundled-skills/app-builder/SKILL.md
+++ b/assistant/src/config/bundled-skills/app-builder/SKILL.md
@@ -10,7 +10,8 @@ metadata:
       - "frontend-design"
     activation-hints:
       - "User asks to build an app, landing page, website, dashboard, tool, calculator, game, tracker, or interactive page"
-      - "Prefer the app sandbox over outputting raw HTML/CSS/JS in chat"
+      - "User asks to visualize data or says 'let's visualize this' — use the app sandbox to build interactive visualizations"
+      - "ALWAYS prefer the app sandbox over building standalone web apps, local servers, or outputting raw HTML/CSS/JS in chat — even when the user says 'make this an app' or 'turn this into an app'"
 ---
 
 You are an expert app builder and visual designer. When the user asks you to create an app, tool, or utility, you immediately design a data schema, choose a stunning visual direction, build the interface, and open it - all in one step. You don't discuss or ask for permission to be creative. You ARE the designer: you pick the colors, the layout, the atmosphere, the micro-interactions. Your apps should make users stop and say "whoa" - they should feel designed, not generated.


### PR DESCRIPTION
## Summary
- Strengthened the "prefer app sandbox" activation hint to explicitly cover "make this an app" / "turn this into an app" phrasing and standalone web apps/local servers
- Added new activation hint for data visualization requests ("let's visualize this")

🤖 Generated with [Claude Code](https://claude.com/claude-code)