### PR TITLE
feat: migrate platform restore to use signed-URL upload path

### DIFF
--- a/cli/src/commands/restore.ts
+++ b/cli/src/commands/restore.ts
@@ -11,6 +11,10 @@ import {
   rollbackPlatformAssistant,
   platformImportPreflight,
   platformImportBundle,
+  platformRequestUploadUrl,
+  platformUploadToSignedUrl,
+  platformImportPreflightFromGcs,
+  platformImportBundleFromGcs,
 } from "../lib/platform-client.js";
 import { performDockerRollback } from "../lib/upgrade-lifecycle.js";
 
@@ -176,6 +180,25 @@ async function restorePlatform(
     process.exit(1);
   }
 
+  // Step 1.5 — Upload to GCS via signed URL (with fallback to inline)
+  let bundleKey: string | null = null;
+  try {
+    const { uploadUrl, bundleKey: key } = await platformRequestUploadUrl(
+      token,
+      entry.runtimeUrl,
+    );
+    bundleKey = key;
+    console.log("Uploading bundle...");
+    await platformUploadToSignedUrl(uploadUrl, new Uint8Array(bundleData));
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (msg.includes("not available")) {
+      bundleKey = null;
+    } else {
+      throw err;
+    }
+  }
+
   // Step 2 — Dry-run path
   if (opts.dryRun) {
     if (opts.version) {
@@ -189,11 +212,17 @@ async function restorePlatform(
 
     let preflightResult: { statusCode: number; body: Record<string, unknown> };
     try {
-      preflightResult = await platformImportPreflight(
-        new Uint8Array(bundleData),
-        token,
-        entry.runtimeUrl,
-      );
+      preflightResult = bundleKey
+        ? await platformImportPreflightFromGcs(
+            bundleKey,
+            token,
+            entry.runtimeUrl,
+          )
+        : await platformImportPreflight(
+            new Uint8Array(bundleData),
+            token,
+            entry.runtimeUrl,
+          );
     } catch (err) {
       if (err instanceof Error && err.name === "TimeoutError") {
         console.error("Error: Preflight request timed out after 2 minutes.");
@@ -323,14 +352,16 @@ async function restorePlatform(
 
   let importResult: { statusCode: number; body: Record<string, unknown> };
   try {
-    importResult = await platformImportBundle(
-      new Uint8Array(bundleData),
-      token,
-      entry.runtimeUrl,
-    );
+    importResult = bundleKey
+      ? await platformImportBundleFromGcs(bundleKey, token, entry.runtimeUrl)
+      : await platformImportBundle(
+          new Uint8Array(bundleData),
+          token,
+          entry.runtimeUrl,
+        );
   } catch (err) {
     if (err instanceof Error && err.name === "TimeoutError") {
-      console.error("Error: Import request timed out after 2 minutes.");
+      console.error("Error: Import request timed out after 5 minutes.");
       process.exit(1);
     }
     throw err;


### PR DESCRIPTION
## Summary
Migrates the platform restore flow (`restorePlatform()` in `restore.ts`) to upload bundles via GCS signed URLs — the same path already used by the teleport command — with automatic fallback to inline upload when signed URLs are unavailable (503/404).

## Self-review result
PASS — no gaps found across plan faithfulness and repo integration reviews.

## PRs merged into feature branch
- #24421: feat: migrate platform restore to use signed-URL upload path

Part of plan: restore-upload-url-migration.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24424" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
