### PR TITLE
fix(browser/cdp): close navigateAndWait commit races + expand key map

### DIFF
--- a/assistant/src/__tests__/headless-browser-navigate.test.ts
+++ b/assistant/src/__tests__/headless-browser-navigate.test.ts
@@ -135,6 +135,18 @@ function resetMockPage() {
  * Default CDP handler. Returns values in the CDP response shape
  * (`{ result: { value } }`) for `Runtime.evaluate` calls and resolves
  * with `{}` for other methods.
+ *
+ * navigateAndWait now reads the pre-nav URL, then polls readyState +
+ * href in a single combined evaluate. The default flow:
+ *
+ *   1. Pre-nav `document.location.href` → "about:blank" (the baseline
+ *      used by navigateAndWait's commit detection).
+ *   2. `Page.navigate`
+ *   3. Combined poll `({ readyState, href })` → `{ readyState:
+ *      "complete", href: "https://example.com/page" }`. Because the
+ *      href changed from the pre-nav value, commit detection fires
+ *      on the first poll.
+ *   4. `document.title` → "Example".
  */
 function defaultCdpHandler(
   method: string,
@@ -143,14 +155,28 @@ function defaultCdpHandler(
   if (method === "Page.navigate") return { frameId: "f1" };
   if (method === "Runtime.evaluate") {
     const expression = String(params?.["expression"] ?? "");
-    if (expression === "document.readyState") {
-      return { result: { value: "complete" } };
-    }
     if (expression === "document.location.href") {
-      return { result: { value: "https://example.com/page" } };
+      return { result: { value: "about:blank" } };
     }
     if (expression === "document.title") {
       return { result: { value: "Example" } };
+    }
+    // Combined readyState + href polling expression from
+    // navigateAndWait. The commit-detection logic requires a
+    // different href from the pre-nav baseline so we return the
+    // requested page URL here.
+    if (
+      expression.includes("readyState") &&
+      expression.includes("document.location.href")
+    ) {
+      return {
+        result: {
+          value: {
+            readyState: "complete",
+            href: "https://example.com/page",
+          },
+        },
+      };
     }
     // DOM_DETECT / CAPTCHA_DETECT / DISMISS_MODALS IIFEs fall through
     // to a generic "no challenge" result. The auth-detector IIFE
@@ -269,14 +295,16 @@ describe("executeBrowserNavigate", () => {
     expect(navigateCall).toBeDefined();
     expect(navigateCall!.params).toEqual({ url: "https://example.com/page" });
 
-    // document.readyState was polled, and document.title / href were read
+    // navigateAndWait polls readyState+href in a single combined
+    // evaluate and also reads `document.location.href` pre-nav; the
+    // caller separately reads `document.title` after the nav.
     const evaluateCalls = cdpSendCalls.filter(
       (c) => c.method === "Runtime.evaluate",
     );
     const expressions = evaluateCalls.map(
       (c) => (c.params as Record<string, unknown>)["expression"] as string,
     );
-    expect(expressions).toContain("document.readyState");
+    expect(expressions.some((e) => e.includes("readyState"))).toBe(true);
     expect(expressions).toContain("document.location.href");
     expect(expressions).toContain("document.title");
 
@@ -286,17 +314,31 @@ describe("executeBrowserNavigate", () => {
 
   test("notes redirect when final URL differs", async () => {
     parseUrlResult = new URL("https://example.com/old");
+    // Pre-nav URL is about:blank so commit detection fires on the
+    // first poll. The combined poll returns a different href than
+    // the requested URL — that's what triggers the "redirected" note.
     cdpSendHandler = (method, params) => {
+      if (method === "Page.navigate") return { frameId: "f1" };
       if (method === "Runtime.evaluate") {
         const expression = String(params?.["expression"] ?? "");
-        if (expression === "document.readyState") {
-          return { result: { value: "complete" } };
-        }
         if (expression === "document.location.href") {
-          return { result: { value: "https://example.com/new" } };
+          return { result: { value: "about:blank" } };
         }
         if (expression === "document.title") {
           return { result: { value: "New" } };
+        }
+        if (
+          expression.includes("readyState") &&
+          expression.includes("document.location.href")
+        ) {
+          return {
+            result: {
+              value: {
+                readyState: "complete",
+                href: "https://example.com/new",
+              },
+            },
+          };
         }
         return { result: { value: null } };
       }
@@ -316,20 +358,33 @@ describe("executeBrowserNavigate", () => {
   test("reports a timeout note when document.readyState never completes", async () => {
     parseUrlResult = new URL("https://example.com/slow");
     cdpSendHandler = (method, params) => {
+      if (method === "Page.navigate") return { frameId: "f1" };
       if (method === "Runtime.evaluate") {
         const expression = String(params?.["expression"] ?? "");
-        if (expression === "document.readyState") {
-          // Always stuck in "loading" — forces navigateAndWait to
-          // exhaust its timeout budget.
-          return { result: { value: "loading" } };
-        }
         if (expression === "document.location.href") {
-          // After timeout, the final URL read returns the navigated
-          // URL — this prevents the "page never moved" re-throw.
-          return { result: { value: "https://example.com/slow" } };
+          // Pre-nav URL read. Returning the same URL as the target
+          // would trigger the same-URL reload fallback; using
+          // about:blank keeps the cross-URL commit-detection path
+          // active so the polling loop actually exercises readyState.
+          return { result: { value: "about:blank" } };
         }
         if (expression === "document.title") {
           return { result: { value: "Loading" } };
+        }
+        if (
+          expression.includes("readyState") &&
+          expression.includes("document.location.href")
+        ) {
+          // Stuck in "loading" — forces navigateAndWait to exhaust
+          // its timeout budget (or get aborted by the test's signal).
+          return {
+            result: {
+              value: {
+                readyState: "loading",
+                href: "https://example.com/slow",
+              },
+            },
+          };
         }
         return { result: { value: null } };
       }
@@ -428,13 +483,18 @@ describe("executeBrowserNavigate", () => {
     expect(cdpDisposed).toBe(true);
 
     // Should NOT have polled readyState — navigate failed before the
-    // wait loop ran.
-    const readyStateCalls = cdpSendCalls.filter(
-      (c) =>
-        c.method === "Runtime.evaluate" &&
-        (c.params as { expression?: string } | undefined)?.expression ===
-          "document.readyState",
-    );
+    // wait loop ran. navigateAndWait combines readyState + href into a
+    // single evaluate, so we look for any expression containing both.
+    const readyStateCalls = cdpSendCalls.filter((c) => {
+      if (c.method !== "Runtime.evaluate") return false;
+      const expr = (c.params as { expression?: string } | undefined)
+        ?.expression;
+      return (
+        typeof expr === "string" &&
+        expr.includes("readyState") &&
+        expr.includes("document.location.href")
+      );
+    });
     expect(readyStateCalls).toHaveLength(0);
   });
 

--- a/assistant/src/tools/browser/cdp-client/__tests__/cdp-dom-helpers.test.ts
+++ b/assistant/src/tools/browser/cdp-client/__tests__/cdp-dom-helpers.test.ts
@@ -831,14 +831,12 @@ describe("navigateAndWait", () => {
     // Should NOT have polled readyState (only the pre-nav
     // `document.location.href` read is allowed before the navigate
     // attempt).
-    const pollEvals = cdp.calls.filter(
-      (c) =>
-        c.method === "Runtime.evaluate" &&
-        typeof (c.params as { expression?: string })?.expression === "string" &&
-        ((c.params as { expression: string }).expression.includes(
-          "readyState",
-        ) as boolean),
-    );
+    const pollEvals = cdp.calls.filter((c) => {
+      if (c.method !== "Runtime.evaluate") return false;
+      const expr = (c.params as { expression?: string } | undefined)
+        ?.expression;
+      return typeof expr === "string" && expr.includes("readyState");
+    });
     expect(pollEvals).toHaveLength(0);
   });
 

--- a/assistant/src/tools/browser/cdp-client/__tests__/cdp-dom-helpers.test.ts
+++ b/assistant/src/tools/browser/cdp-client/__tests__/cdp-dom-helpers.test.ts
@@ -376,9 +376,98 @@ describe("dispatchKeyPress", () => {
     expect(params.text).toBeUndefined();
   });
 
+  test("'Space' (Playwright convention) sends code 'Space' and keyCode 32", async () => {
+    // Playwright callers pass "Space" as the key name, but
+    // `event.key` is actually " ". Verify both invariants.
+    const cdp = fakeCdp(() => ({}));
+
+    await dispatchKeyPress(cdp, "Space");
+
+    expect(cdp.calls).toHaveLength(3);
+    for (const call of cdp.calls) {
+      const params = call.params as Record<string, unknown>;
+      expect(params.key).toBe(" ");
+      expect(params.code).toBe("Space");
+      expect(params.windowsVirtualKeyCode).toBe(32);
+      expect(params.text).toBe(" ");
+    }
+    expect((cdp.calls[1]!.params as Record<string, unknown>).type).toBe("char");
+  });
+
+  test("literal ' ' also maps to code 'Space'", async () => {
+    // Passing a literal space character should produce the same
+    // event shape as "Space" — not fall through to the generic
+    // printable-ASCII path which emits `code: ""`.
+    const cdp = fakeCdp(() => ({}));
+
+    await dispatchKeyPress(cdp, " ");
+
+    const params = cdp.calls[0]!.params as Record<string, unknown>;
+    expect(params.code).toBe("Space");
+    expect(params.windowsVirtualKeyCode).toBe(32);
+    expect(params.text).toBe(" ");
+  });
+
+  test("Home/End/PageUp/PageDown send the right keyCodes (no char event)", async () => {
+    const cases: Array<[string, number]> = [
+      ["Home", 36],
+      ["End", 35],
+      ["PageUp", 33],
+      ["PageDown", 34],
+    ];
+    for (const [key, expectedKeyCode] of cases) {
+      const cdp = fakeCdp(() => ({}));
+      await dispatchKeyPress(cdp, key);
+      // Navigation keys are non-printing → keyDown + keyUp only.
+      expect(cdp.calls).toHaveLength(2);
+      const params = cdp.calls[0]!.params as Record<string, unknown>;
+      expect(params.key).toBe(key);
+      expect(params.code).toBe(key);
+      expect(params.windowsVirtualKeyCode).toBe(expectedKeyCode);
+      expect(params.text).toBeUndefined();
+    }
+  });
+
+  test("Insert sends keyCode 45 and no char event", async () => {
+    const cdp = fakeCdp(() => ({}));
+    await dispatchKeyPress(cdp, "Insert");
+    expect(cdp.calls).toHaveLength(2);
+    const params = cdp.calls[0]!.params as Record<string, unknown>;
+    expect(params.windowsVirtualKeyCode).toBe(45);
+    expect(params.text).toBeUndefined();
+  });
+
+  test("F1-F12 send the right Windows virtual keyCodes", async () => {
+    const cases: Array<[string, number]> = [
+      ["F1", 112],
+      ["F2", 113],
+      ["F3", 114],
+      ["F4", 115],
+      ["F5", 116],
+      ["F6", 117],
+      ["F7", 118],
+      ["F8", 119],
+      ["F9", 120],
+      ["F10", 121],
+      ["F11", 122],
+      ["F12", 123],
+    ];
+    for (const [key, expectedKeyCode] of cases) {
+      const cdp = fakeCdp(() => ({}));
+      await dispatchKeyPress(cdp, key);
+      expect(cdp.calls).toHaveLength(2);
+      const params = cdp.calls[0]!.params as Record<string, unknown>;
+      expect(params.key).toBe(key);
+      expect(params.code).toBe(key);
+      expect(params.windowsVirtualKeyCode).toBe(expectedKeyCode);
+      expect(params.text).toBeUndefined();
+    }
+  });
+
   test("unknown multi-character key falls back to minimal payload", async () => {
     const cdp = fakeCdp(() => ({}));
-    // Suppress the console.warn for the duration of the call.
+    // Suppress the console.warn for the duration of the call. F19
+    // is not in the static map and cannot be derived dynamically.
     const originalWarn = console.warn;
     console.warn = () => {};
     try {
@@ -595,21 +684,61 @@ describe("captureScreenshotJpeg", () => {
 
 // ── navigateAndWait ───────────────────────────────────────────────────
 
-describe("navigateAndWait", () => {
-  test("calls Page.navigate and returns finalUrl once readyState is complete", async () => {
-    const cdp = fakeCdp((method, params) => {
-      if (method === "Page.navigate") return {};
-      if (method === "Runtime.evaluate") {
-        const expr = (params as { expression: string }).expression;
-        if (expr === "document.readyState")
-          return { result: { value: "complete" } };
-        if (expr === "document.location.href")
-          return { result: { value: "https://example.com/final" } };
+/**
+ * Build a programmable fake for `navigateAndWait` tests. Handles the
+ * standard shape: pre-nav `document.location.href` read, then
+ * `Page.navigate`, then any number of combined `readyState + href`
+ * poll evaluations.
+ *
+ * The `poll` handler is invoked once per combined readyState/href
+ * evaluate and must return `{ readyState, href }` (to continue the
+ * poll) or throw (to simulate a transient CDP error).
+ */
+function fakeNavCdp(opts: {
+  urlBeforeNav?: string;
+  navResponse?: { frameId?: string; errorText?: string };
+  poll: (
+    callIndex: number,
+  ) => { readyState: string; href: string } | { throwError: CdpError };
+  onNavigate?: () => void;
+}) {
+  let pollCalls = 0;
+  return fakeCdp((method, params) => {
+    if (method === "Page.navigate") {
+      opts.onNavigate?.();
+      return opts.navResponse ?? {};
+    }
+    if (method === "Runtime.evaluate") {
+      const expr = (params as { expression: string }).expression;
+      if (expr === "document.location.href") {
+        return { result: { value: opts.urlBeforeNav ?? "about:blank" } };
       }
-      throw new Error(`unexpected: ${method}`);
+      if (expr === "document.title") {
+        return { result: { value: "" } };
+      }
+      if (expr.includes("readyState") && expr.includes("href")) {
+        const res = opts.poll(pollCalls++);
+        if ("throwError" in res) throw res.throwError;
+        return { result: { value: res } };
+      }
+    }
+    throw new Error(
+      `unexpected: ${method} ${JSON.stringify((params as Record<string, unknown>)?.expression ?? params)}`,
+    );
+  });
+}
+
+describe("navigateAndWait", () => {
+  test("calls Page.navigate and returns finalUrl once readyState is complete and URL has committed", async () => {
+    const cdp = fakeNavCdp({
+      urlBeforeNav: "https://example.com/start",
+      poll: () => ({
+        readyState: "complete",
+        href: "https://example.com/final",
+      }),
     });
 
-    const result = await navigateAndWait(cdp, "https://example.com/start", {
+    const result = await navigateAndWait(cdp, "https://example.com/target", {
       timeoutMs: 5_000,
     });
 
@@ -621,62 +750,45 @@ describe("navigateAndWait", () => {
     const navigateCalls = cdp.calls.filter((c) => c.method === "Page.navigate");
     expect(navigateCalls).toHaveLength(1);
     expect(navigateCalls[0]!.params).toEqual({
-      url: "https://example.com/start",
+      url: "https://example.com/target",
     });
   });
 
   test("resolves when readyState becomes interactive (not just complete)", async () => {
-    const cdp = fakeCdp((method, params) => {
-      if (method === "Page.navigate") return {};
-      if (method === "Runtime.evaluate") {
-        const expr = (params as { expression: string }).expression;
-        if (expr === "document.readyState")
-          return { result: { value: "interactive" } };
-        if (expr === "document.location.href")
-          return { result: { value: "https://x" } };
-      }
-      throw new Error(`unexpected: ${method}`);
+    const cdp = fakeNavCdp({
+      urlBeforeNav: "https://prev",
+      poll: () => ({ readyState: "interactive", href: "https://x" }),
     });
 
     const result = await navigateAndWait(cdp, "https://x", {
       timeoutMs: 5_000,
     });
     expect(result.timedOut).toBe(false);
+    expect(result.finalUrl).toBe("https://x");
   });
 
   test("returns timedOut: true when readyState never becomes ready", async () => {
-    const cdp = fakeCdp((method, params) => {
-      if (method === "Page.navigate") return {};
-      if (method === "Runtime.evaluate") {
-        const expr = (params as { expression: string }).expression;
-        if (expr === "document.readyState")
-          return { result: { value: "loading" } };
-        if (expr === "document.location.href")
-          return { result: { value: "https://slow" } };
-      }
-      throw new Error(`unexpected: ${method}`);
+    const cdp = fakeNavCdp({
+      urlBeforeNav: "about:blank",
+      poll: () => ({ readyState: "loading", href: "https://slow" }),
     });
 
     // Use a tiny timeout so the test finishes quickly.
     const result = await navigateAndWait(cdp, "https://slow", {
       timeoutMs: 50,
     });
-    expect(result).toEqual({
-      finalUrl: "https://slow",
-      timedOut: true,
-    });
+    expect(result.timedOut).toBe(true);
+    // finalUrl should come from the in-loop observations (the last
+    // href we successfully saw), not a post-loop fresh read.
+    expect(result.finalUrl).toBe("https://slow");
   });
 
   test("throws CdpError with code 'aborted' when signal fires", async () => {
     const controller = new AbortController();
-    const cdp = fakeCdp((method) => {
-      if (method === "Page.navigate") {
-        controller.abort();
-        return {};
-      }
-      if (method === "Runtime.evaluate")
-        return { result: { value: "loading" } };
-      throw new Error(`unexpected: ${method}`);
+    const cdp = fakeNavCdp({
+      urlBeforeNav: "about:blank",
+      onNavigate: () => controller.abort(),
+      poll: () => ({ readyState: "loading", href: "https://x" }),
     });
 
     await expect(
@@ -697,10 +809,13 @@ describe("navigateAndWait", () => {
     // throwing — navigateAndWait must surface this instead of polling
     // the OLD page's readyState (which is "complete") and reporting
     // success with the stale URL.
-    const cdp = fakeCdp((method) => {
-      if (method === "Page.navigate")
-        return { frameId: "f1", errorText: "net::ERR_CONNECTION_REFUSED" };
-      throw new Error(`unexpected: ${method}`);
+    const cdp = fakeNavCdp({
+      urlBeforeNav: "about:blank",
+      navResponse: {
+        frameId: "f1",
+        errorText: "net::ERR_CONNECTION_REFUSED",
+      },
+      poll: () => ({ readyState: "complete", href: "should not be read" }),
     });
 
     await expect(
@@ -713,10 +828,196 @@ describe("navigateAndWait", () => {
       cdpParams: { url: "https://nope.invalid" },
     });
 
-    // Should NOT have polled readyState or read final URL after the
-    // navigate failed.
-    const evals = cdp.calls.filter((c) => c.method === "Runtime.evaluate");
-    expect(evals).toHaveLength(0);
+    // Should NOT have polled readyState (only the pre-nav
+    // `document.location.href` read is allowed before the navigate
+    // attempt).
+    const pollEvals = cdp.calls.filter(
+      (c) =>
+        c.method === "Runtime.evaluate" &&
+        typeof (c.params as { expression?: string })?.expression === "string" &&
+        ((c.params as { expression: string }).expression.includes(
+          "readyState",
+        ) as boolean),
+    );
+    expect(pollEvals).toHaveLength(0);
+  });
+
+  test("waits for URL to commit before accepting readyState=complete (same-origin race)", async () => {
+    // Reproduces the bug where a same-origin navigation resolves
+    // `Page.navigate` but the polling loop sees the OLD page's
+    // "complete" readyState and the OLD URL for the first few polls
+    // before the new document commits.
+    //
+    // First 3 polls: old page's "complete" + old URL.
+    // Fourth poll: new document fully committed.
+    const cdp = fakeNavCdp({
+      urlBeforeNav: "https://example.com/page1",
+      poll: (callIndex) => {
+        if (callIndex < 3) {
+          return {
+            readyState: "complete",
+            href: "https://example.com/page1",
+          };
+        }
+        return { readyState: "complete", href: "https://example.com/page2" };
+      },
+    });
+
+    const result = await navigateAndWait(cdp, "https://example.com/page2", {
+      timeoutMs: 5_000,
+    });
+
+    expect(result).toEqual({
+      finalUrl: "https://example.com/page2",
+      timedOut: false,
+    });
+
+    // The loop must have polled at least 4 times — proof that it
+    // did not break on the first "complete" observation against the
+    // old URL.
+    const pollEvals = cdp.calls.filter(
+      (c) =>
+        c.method === "Runtime.evaluate" &&
+        typeof (c.params as { expression?: string })?.expression === "string" &&
+        (c.params as { expression: string }).expression.includes("readyState"),
+    );
+    expect(pollEvals.length).toBeGreaterThanOrEqual(4);
+  });
+
+  test("retries on transient CdpError during context transition", async () => {
+    // After `Page.navigate`, `Runtime.evaluate` can fail transiently
+    // while the old execution context is torn down and before the
+    // new one is created. navigateAndWait must catch that error and
+    // keep polling.
+    const cdp = fakeNavCdp({
+      urlBeforeNav: "https://prev",
+      poll: (callIndex) => {
+        if (callIndex === 0) {
+          return {
+            throwError: new CdpError(
+              "cdp_error",
+              "Execution context was destroyed.",
+            ),
+          };
+        }
+        if (callIndex === 1) {
+          return {
+            throwError: new CdpError(
+              "cdp_error",
+              "Cannot find context with specified id",
+            ),
+          };
+        }
+        return { readyState: "complete", href: "https://new" };
+      },
+    });
+
+    const result = await navigateAndWait(cdp, "https://new", {
+      timeoutMs: 5_000,
+    });
+    expect(result).toEqual({
+      finalUrl: "https://new",
+      timedOut: false,
+    });
+  });
+
+  test("same-URL reload falls back to readyState-only polling", async () => {
+    // When the target URL matches the pre-nav URL (e.g. a reload),
+    // there's no URL-change signal to wait for. The commit check
+    // must fall back to readyState-only so reloads don't loop
+    // forever.
+    const cdp = fakeNavCdp({
+      urlBeforeNav: "https://example.com/same",
+      poll: () => ({
+        readyState: "complete",
+        href: "https://example.com/same",
+      }),
+    });
+
+    const result = await navigateAndWait(cdp, "https://example.com/same", {
+      timeoutMs: 5_000,
+    });
+
+    expect(result).toEqual({
+      finalUrl: "https://example.com/same",
+      timedOut: false,
+    });
+  });
+
+  test("falls back to readyState-only when pre-nav URL read fails", async () => {
+    // If we can't read the pre-nav URL (e.g. fresh about:blank with
+    // no Runtime context), commit detection has no baseline and must
+    // fall back to readyState-only.
+    let sawPreNavRead = false;
+    const cdp = fakeCdp((method, params) => {
+      if (method === "Page.navigate") return {};
+      if (method === "Runtime.evaluate") {
+        const expr = (params as { expression: string }).expression;
+        if (expr === "document.location.href" && !sawPreNavRead) {
+          sawPreNavRead = true;
+          throw new CdpError("cdp_error", "no context");
+        }
+        if (expr.includes("readyState") && expr.includes("href")) {
+          return {
+            result: { value: { readyState: "complete", href: "https://x" } },
+          };
+        }
+      }
+      throw new Error(
+        `unexpected: ${method} ${JSON.stringify((params as Record<string, unknown>)?.expression ?? params)}`,
+      );
+    });
+
+    const result = await navigateAndWait(cdp, "https://x", {
+      timeoutMs: 5_000,
+    });
+
+    expect(result).toEqual({
+      finalUrl: "https://x",
+      timedOut: false,
+    });
+  });
+
+  test("reports last observed href on timeout instead of racing a post-loop read", async () => {
+    // If polling never reaches readyState-ready + committed, the
+    // final URL should come from the last in-loop observation (so
+    // the caller doesn't race the commit window again via a
+    // post-loop `getCurrentUrl`).
+    const observedHrefs: string[] = [];
+    const cdp = fakeNavCdp({
+      urlBeforeNav: "https://pre",
+      poll: (callIndex) => {
+        // Keep returning "loading" but advance the URL so we can
+        // verify the fallback uses the last observation.
+        const href = `https://loading/${callIndex}`;
+        observedHrefs.push(href);
+        return { readyState: "loading", href };
+      },
+    });
+
+    const result = await navigateAndWait(cdp, "https://target", {
+      timeoutMs: 50,
+    });
+    expect(result.timedOut).toBe(true);
+    // finalUrl should match the last href we returned from the poll
+    // handler (not the pre-nav URL, and not a separately-read value).
+    expect(observedHrefs.length).toBeGreaterThan(0);
+    expect(result.finalUrl).toBe(observedHrefs[observedHrefs.length - 1]!);
+  });
+
+  test("re-throws non-CdpError exceptions from the polling evaluate", async () => {
+    // Only CdpErrors are retry-worthy; unexpected JS errors should
+    // propagate so they're not swallowed.
+    const cdp = fakeNavCdp({
+      urlBeforeNav: "https://pre",
+      poll: () => {
+        throw new Error("unexpected programmer error");
+      },
+    });
+
+    await expect(
+      navigateAndWait(cdp, "https://target", { timeoutMs: 5_000 }),
+    ).rejects.toThrow("unexpected programmer error");
   });
 });
 

--- a/assistant/src/tools/browser/cdp-client/cdp-dom-helpers.ts
+++ b/assistant/src/tools/browser/cdp-client/cdp-dom-helpers.ts
@@ -190,6 +190,7 @@ const KEY_DESCRIPTORS: Record<string, KeyDescriptor> = {
     windowsVirtualKeyCode: 8,
   },
   Delete: { key: "Delete", code: "Delete", windowsVirtualKeyCode: 46 },
+  Insert: { key: "Insert", code: "Insert", windowsVirtualKeyCode: 45 },
   ArrowUp: { key: "ArrowUp", code: "ArrowUp", windowsVirtualKeyCode: 38 },
   ArrowDown: {
     key: "ArrowDown",
@@ -206,6 +207,36 @@ const KEY_DESCRIPTORS: Record<string, KeyDescriptor> = {
     code: "ArrowRight",
     windowsVirtualKeyCode: 39,
   },
+  // Navigation keys. Sites commonly check `event.keyCode` for these
+  // (PageDown = 34 to scroll a page, Home = 36 to jump to top, etc.)
+  // so omitting `code`/`windowsVirtualKeyCode` makes the press a
+  // silent no-op on those handlers.
+  Home: { key: "Home", code: "Home", windowsVirtualKeyCode: 36 },
+  End: { key: "End", code: "End", windowsVirtualKeyCode: 35 },
+  PageUp: { key: "PageUp", code: "PageUp", windowsVirtualKeyCode: 33 },
+  PageDown: { key: "PageDown", code: "PageDown", windowsVirtualKeyCode: 34 },
+  // Space is special: Playwright callers use "Space" as the key name
+  // but `event.key` is actually " ". Accept both spellings so either
+  // calling convention works, and always emit `code: "Space"` +
+  // `windowsVirtualKeyCode: 32` so Space-to-activate / Space-to-scroll
+  // handlers fire correctly.
+  Space: { key: " ", code: "Space", windowsVirtualKeyCode: 32, text: " " },
+  " ": { key: " ", code: "Space", windowsVirtualKeyCode: 32, text: " " },
+  // Function keys (F1-F12). Virtual key codes 112-123 per the Windows
+  // input API. `resolveKeyDescriptor` cannot derive these dynamically
+  // because they are multi-character names with no 1:1 char mapping.
+  F1: { key: "F1", code: "F1", windowsVirtualKeyCode: 112 },
+  F2: { key: "F2", code: "F2", windowsVirtualKeyCode: 113 },
+  F3: { key: "F3", code: "F3", windowsVirtualKeyCode: 114 },
+  F4: { key: "F4", code: "F4", windowsVirtualKeyCode: 115 },
+  F5: { key: "F5", code: "F5", windowsVirtualKeyCode: 116 },
+  F6: { key: "F6", code: "F6", windowsVirtualKeyCode: 117 },
+  F7: { key: "F7", code: "F7", windowsVirtualKeyCode: 118 },
+  F8: { key: "F8", code: "F8", windowsVirtualKeyCode: 119 },
+  F9: { key: "F9", code: "F9", windowsVirtualKeyCode: 120 },
+  F10: { key: "F10", code: "F10", windowsVirtualKeyCode: 121 },
+  F11: { key: "F11", code: "F11", windowsVirtualKeyCode: 122 },
+  F12: { key: "F12", code: "F12", windowsVirtualKeyCode: 123 },
 };
 
 /**
@@ -429,19 +460,32 @@ export async function captureScreenshotJpeg(
 // ── Navigation / waiting ──────────────────────────────────────────────
 
 /**
- * Navigate to `url` and wait until `document.readyState` reaches
+ * Navigate to `url` and wait until the new document has committed
+ * (the URL has changed from the pre-navigation URL, or it's a
+ * same-URL reload) AND `document.readyState` has reached
  * `interactive` or `complete`, or the timeout elapses.
  *
  * CDP's `Page.navigate` resolves as soon as the request is sent, not
  * when the page has loaded. Subscribing to lifecycle events would
  * require a long-lived event channel that the extension-backed
- * CdpClient cannot currently provide, so this helper polls
- * `document.readyState` via {@link evaluateExpression} — which works
- * uniformly across both Playwright-backed and extension-backed
- * clients.
+ * CdpClient cannot currently provide, so this helper polls both
+ * `document.readyState` and `document.location.href` via
+ * {@link evaluateExpression} — which works uniformly across both
+ * Playwright-backed and extension-backed clients.
  *
- * Returns `{ finalUrl, timedOut }`. `finalUrl` is read after the wait
- * completes and may differ from `url` if the page redirected.
+ * The commit-detection step is the interesting part: on same-origin
+ * navigations or cached responses, the browser can return
+ * `readyState === "complete"` from the OLD execution context for a
+ * brief window after `Page.navigate` resolves but before the new
+ * document has been installed. Reading only `readyState` would
+ * accept that stale state and report success against the old URL.
+ * Combining the two observations in a single evaluate and requiring
+ * an observed URL change closes that race.
+ *
+ * Returns `{ finalUrl, timedOut }`. `finalUrl` is the last `href`
+ * observed inside the polling loop (so it reflects the new document
+ * even on commit races) and may differ from `url` if the page
+ * redirected.
  */
 export async function navigateAndWait(
   cdp: CdpClient,
@@ -450,6 +494,20 @@ export async function navigateAndWait(
   signal?: AbortSignal,
 ): Promise<{ finalUrl: string; timedOut: boolean }> {
   const timeoutMs = opts.timeoutMs ?? 15_000;
+
+  // Capture the pre-navigation URL so the polling loop can detect
+  // when the new document has committed. If the pre-read fails (rare
+  // — e.g. a fresh about:blank that hasn't initialized a Runtime
+  // context yet), we fall back to readyState-only polling because we
+  // have no baseline to compare against.
+  let urlBeforeNav = "";
+  try {
+    urlBeforeNav = await getCurrentUrl(cdp, signal);
+  } catch {
+    // Non-fatal: urlBeforeNav stays empty and commit detection becomes
+    // a no-op (see `committed` below).
+  }
+
   // CDP's `Page.navigate` does NOT throw on transport-layer errors
   // (DNS failure, connection refused, etc.). Instead it resolves with
   // `{ frameId, errorText? }` and we have to surface the failure
@@ -467,30 +525,91 @@ export async function navigateAndWait(
       cdpParams: { url },
     });
   }
+
+  // Same-URL reloads (including `about:blank` → `about:blank`) can't
+  // be detected via URL change. Fall back to readyState-only polling
+  // in that case, matching the pre-commit-detection behavior.
+  const sameUrlReload = urlBeforeNav !== "" && url === urlBeforeNav;
+
   const startedAt = Date.now();
   // Track exit reason explicitly so the post-loop classification does
-  // not race against `Date.now()` after a successful break (the final
-  // readyState read could otherwise push us across the timeout
-  // boundary and falsely flip `timedOut` back to true).
+  // not race against `Date.now()` (the final read could otherwise
+  // push us across the timeout boundary and falsely flip `timedOut`
+  // back to true).
   let completed = false;
+  // Track the last href we successfully observed from inside the
+  // loop. We prefer this to a post-loop `getCurrentUrl` call because
+  // the latter races the very same commit window that motivates the
+  // in-loop commit check.
+  let lastKnownHref = urlBeforeNav;
+
   while (Date.now() - startedAt < timeoutMs) {
     if (signal?.aborted) {
       throw new CdpError("aborted", "Navigation aborted");
     }
-    const state = await evaluateExpression<string>(
-      cdp,
-      "document.readyState",
-      {},
-      signal,
-    );
-    if (state === "interactive" || state === "complete") {
-      completed = true;
-      break;
+
+    // Query `readyState` and `location.href` in a single evaluate so
+    // the two observations come from the same execution context and
+    // cannot straddle a commit boundary.
+    try {
+      const snapshot = await evaluateExpression<{
+        readyState: string;
+        href: string;
+      }>(
+        cdp,
+        "({ readyState: document.readyState, href: document.location.href })",
+        {},
+        signal,
+      );
+      if (snapshot && typeof snapshot.href === "string") {
+        lastKnownHref = snapshot.href;
+      }
+      const readyStateOk =
+        snapshot?.readyState === "interactive" ||
+        snapshot?.readyState === "complete";
+      // On cross-URL navigations, require BOTH a ready readyState
+      // AND an observed URL change so we don't accept the OLD
+      // page's "complete" state before the new document has
+      // committed. Same-URL reloads and missing pre-nav URLs fall
+      // back to readyState-only because there's nothing to compare.
+      const committed =
+        sameUrlReload ||
+        urlBeforeNav === "" ||
+        (typeof snapshot?.href === "string" && snapshot.href !== urlBeforeNav);
+      if (readyStateOk && committed) {
+        completed = true;
+        break;
+      }
+    } catch (err) {
+      // `Runtime.evaluate` can fail transiently while the old
+      // execution context is being torn down and the new one has
+      // not yet been created ("Execution context was destroyed" /
+      // "Cannot find context with specified id"). Treat CDP errors
+      // as retry-worthy; the timeout bound below guarantees we
+      // don't loop forever. Abort errors are re-thrown so the
+      // caller's AbortSignal is still honoured promptly.
+      if (err instanceof CdpError && err.code === "aborted") throw err;
+      if (!(err instanceof CdpError)) throw err;
     }
+
     await new Promise((r) => setTimeout(r, 100));
   }
+
   const timedOut = !completed;
-  const finalUrl = await getCurrentUrl(cdp, signal);
+
+  // Prefer the last href observed inside the loop. If the loop never
+  // produced a successful observation (e.g. all evaluates failed to
+  // transient context errors), fall back to `getCurrentUrl` as a
+  // best-effort read.
+  let finalUrl = lastKnownHref;
+  if (finalUrl === "") {
+    try {
+      finalUrl = await getCurrentUrl(cdp, signal);
+    } catch {
+      // Nothing more to do — surface empty string and let the caller
+      // decide how to render it.
+    }
+  }
   return { finalUrl, timedOut };
 }
 


### PR DESCRIPTION
## Summary
- **Gap A — `navigateAndWait` commit races**: catch transient `CdpError` from `Runtime.evaluate` during context transitions ("Execution context was destroyed"), query `readyState` + `location.href` in a single evaluate, and only accept `readyState=complete` when the URL has actually committed (or the target is a same-URL reload). Return the last in-loop `href` as `finalUrl` instead of racing the commit window with a post-loop read. Addresses Devin comments on PR #24331 about same-origin navigations returning the old page's state.
- **Gap B — `dispatchKeyPress` key map**: add descriptors for `Space` (both `"Space"` and literal `" "`), `Home`, `End`, `PageUp`, `PageDown`, `Insert`, and `F1`-`F12` so sites checking `event.keyCode` for these keys stop silently ignoring them. Addresses Devin comment on PR #24331 about limited key map coverage.

## Original prompt
gaps A + B
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24425" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
