### PR TITLE
feat(apple-containers): add stack definition types mirroring Docker topology

### DIFF
--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -194,6 +194,10 @@ jobs:
           git checkout -b "$BRANCH"
 
           # Bump all package.json files
+          # NOTE: All service + client versions must stay in sync — Apple Containers
+          # assumes the assistant runtime, gateway, and credential executor versions
+          # match the macOS app version.
+          # If we relax this assumption, adjust the container image logic accordingly.
           for pkg in assistant cli credential-executor gateway meta; do
             jq --arg v "$VERSION" '.version = $v' $pkg/package.json > tmp && mv tmp $pkg/package.json
           done

--- a/clients/macos/vellum-assistant/AppleContainer/StackDefinition.swift
+++ b/clients/macos/vellum-assistant/AppleContainer/StackDefinition.swift
@@ -1,0 +1,145 @@
+import Foundation
+
+// MARK: - Service Names
+
+/// The three services that make up a Vellum assistant stack.
+enum VellumServiceName: String, CaseIterable, Sendable {
+    case assistant = "vellum-assistant"
+    case gateway = "vellum-gateway"
+    case credentialExecutor = "vellum-credential-executor"
+}
+
+// MARK: - Image References
+
+/// An OCI image reference for a Vellum service container.
+struct VellumImageReference: Sendable, Equatable {
+    let registry: String
+    let repository: String
+    let tag: String
+
+    var fullReference: String {
+        "\(registry)/\(repository):\(tag)"
+    }
+
+    /// Default image references for a given service group version, pulled from Docker Hub.
+    static func defaults(version: String) -> [VellumServiceName: VellumImageReference] {
+        let org = "vellumai"
+        return [
+            .assistant: VellumImageReference(
+                registry: "docker.io",
+                repository: "\(org)/vellum-assistant",
+                tag: version
+            ),
+            .gateway: VellumImageReference(
+                registry: "docker.io",
+                repository: "\(org)/vellum-gateway",
+                tag: version
+            ),
+            .credentialExecutor: VellumImageReference(
+                registry: "docker.io",
+                repository: "\(org)/vellum-credential-executor",
+                tag: version
+            ),
+        ]
+    }
+}
+
+// MARK: - Ports
+
+/// Internal ports exposed by each service's container.
+enum VellumContainerPorts {
+    static let assistantHTTP: UInt16 = 3001
+    static let gatewayHTTP: UInt16 = 7830
+    static let cesHTTP: UInt16 = 8090
+}
+
+// MARK: - Mount Paths
+
+/// Well-known mount paths inside the pod VM shared across services.
+enum VellumMountPaths {
+    /// Persistent assistant workspace data (rw for assistant + gateway, ro for CES).
+    static let workspace = "/workspace"
+    /// CES bootstrap unix-socket directory.
+    static let cesBootstrap = "/run/ces-bootstrap"
+    /// Gateway security directory (gateway-private).
+    static let gatewaySecurityDir = "/gateway-security"
+    /// CES credential security directory (CES-private).
+    static let cesSecurityDir = "/ces-security"
+}
+
+// MARK: - Environment Keys
+
+/// Environment variable keys passed to each container.
+enum VellumContainerEnv {
+    static func assistant(
+        instanceName: String,
+        signingKey: String?,
+        cesServiceToken: String?
+    ) -> [String: String] {
+        var env: [String: String] = [
+            "IS_CONTAINERIZED": "true",
+            "VELLUM_ASSISTANT_NAME": instanceName,
+            "VELLUM_CLOUD": "apple-container",
+            "RUNTIME_HTTP_HOST": "0.0.0.0",
+            "VELLUM_WORKSPACE_DIR": VellumMountPaths.workspace,
+            "CES_CREDENTIAL_URL": "http://localhost:\(VellumContainerPorts.cesHTTP)",
+            "GATEWAY_INTERNAL_URL": "http://localhost:\(VellumContainerPorts.gatewayHTTP)",
+        ]
+        if let signingKey {
+            env["ACTOR_TOKEN_SIGNING_KEY"] = signingKey
+        }
+        if let cesServiceToken {
+            env["CES_SERVICE_TOKEN"] = cesServiceToken
+        }
+        return env
+    }
+
+    static func gateway(
+        signingKey: String?,
+        bootstrapSecret: String?,
+        cesServiceToken: String?
+    ) -> [String: String] {
+        var env: [String: String] = [
+            "VELLUM_WORKSPACE_DIR": VellumMountPaths.workspace,
+            "GATEWAY_SECURITY_DIR": VellumMountPaths.gatewaySecurityDir,
+            "GATEWAY_PORT": String(VellumContainerPorts.gatewayHTTP),
+            "ASSISTANT_HOST": "localhost",
+            "RUNTIME_HTTP_PORT": String(VellumContainerPorts.assistantHTTP),
+            "RUNTIME_PROXY_ENABLED": "true",
+            "CES_CREDENTIAL_URL": "http://localhost:\(VellumContainerPorts.cesHTTP)",
+        ]
+        if let signingKey {
+            env["ACTOR_TOKEN_SIGNING_KEY"] = signingKey
+        }
+        if let bootstrapSecret {
+            env["GUARDIAN_BOOTSTRAP_SECRET"] = bootstrapSecret
+        }
+        if let cesServiceToken {
+            env["CES_SERVICE_TOKEN"] = cesServiceToken
+        }
+        return env
+    }
+
+    static func credentialExecutor(cesServiceToken: String?) -> [String: String] {
+        var env: [String: String] = [
+            "CES_MODE": "managed",
+            "VELLUM_WORKSPACE_DIR": VellumMountPaths.workspace,
+            "CES_BOOTSTRAP_SOCKET_DIR": VellumMountPaths.cesBootstrap,
+            "CREDENTIAL_SECURITY_DIR": VellumMountPaths.cesSecurityDir,
+        ]
+        if let cesServiceToken {
+            env["CES_SERVICE_TOKEN"] = cesServiceToken
+        }
+        return env
+    }
+}
+
+// MARK: - Service Start Order
+
+extension VellumServiceName {
+    static let startOrder: [VellumServiceName] = [
+        .assistant,
+        .gateway,
+        .credentialExecutor,
+    ]
+}

--- a/clients/macos/vellum-assistant/AppleContainer/StackDefinition.swift
+++ b/clients/macos/vellum-assistant/AppleContainer/StackDefinition.swift
@@ -75,7 +75,8 @@ enum VellumContainerEnv {
     static func assistant(
         instanceName: String,
         signingKey: String?,
-        cesServiceToken: String?
+        cesServiceToken: String?,
+        platformURL: String?
     ) -> [String: String] {
         var env: [String: String] = [
             "IS_CONTAINERIZED": "true",
@@ -92,15 +93,20 @@ enum VellumContainerEnv {
         if let cesServiceToken {
             env["CES_SERVICE_TOKEN"] = cesServiceToken
         }
+        if let platformURL {
+            env["VELLUM_PLATFORM_URL"] = platformURL
+        }
         return env
     }
 
     static func gateway(
         signingKey: String?,
         bootstrapSecret: String?,
-        cesServiceToken: String?
+        cesServiceToken: String?,
+        platformURL: String?
     ) -> [String: String] {
         var env: [String: String] = [
+            "IS_CONTAINERIZED": "true",
             "VELLUM_WORKSPACE_DIR": VellumMountPaths.workspace,
             "GATEWAY_SECURITY_DIR": VellumMountPaths.gatewaySecurityDir,
             "GATEWAY_PORT": String(VellumContainerPorts.gatewayHTTP),
@@ -117,6 +123,9 @@ enum VellumContainerEnv {
         }
         if let cesServiceToken {
             env["CES_SERVICE_TOKEN"] = cesServiceToken
+        }
+        if let platformURL {
+            env["VELLUM_PLATFORM_URL"] = platformURL
         }
         return env
     }

--- a/clients/macos/vellum-assistant/AppleContainer/StackDefinition.swift
+++ b/clients/macos/vellum-assistant/AppleContainer/StackDefinition.swift
@@ -22,6 +22,7 @@ struct VellumImageReference: Sendable, Equatable {
     }
 
     /// Default image references for a given service group version, pulled from Docker Hub.
+    /// This assumes the image tags are kept in sync.
     static func defaults(version: String) -> [VellumServiceName: VellumImageReference] {
         let org = "vellumai"
         return [

--- a/clients/macos/vellum-assistantTests/StackDefinitionTests.swift
+++ b/clients/macos/vellum-assistantTests/StackDefinitionTests.swift
@@ -61,7 +61,7 @@ final class StackDefinitionTests: XCTestCase {
     // MARK: - Environment
 
     func testAssistantEnvRequiredKeys() {
-        let env = VellumContainerEnv.assistant(instanceName: "test", signingKey: nil, cesServiceToken: nil)
+        let env = VellumContainerEnv.assistant(instanceName: "test", signingKey: nil, cesServiceToken: nil, platformURL: nil)
         XCTAssertEqual(env["IS_CONTAINERIZED"], "true")
         XCTAssertEqual(env["VELLUM_ASSISTANT_NAME"], "test")
         XCTAssertEqual(env["VELLUM_CLOUD"], "apple-container")
@@ -72,19 +72,22 @@ final class StackDefinitionTests: XCTestCase {
     }
 
     func testAssistantEnvOptionalKeys() {
-        let env = VellumContainerEnv.assistant(instanceName: "x", signingKey: "key123", cesServiceToken: "tok456")
+        let env = VellumContainerEnv.assistant(instanceName: "x", signingKey: "key123", cesServiceToken: "tok456", platformURL: "https://custom.vellum.ai")
         XCTAssertEqual(env["ACTOR_TOKEN_SIGNING_KEY"], "key123")
         XCTAssertEqual(env["CES_SERVICE_TOKEN"], "tok456")
+        XCTAssertEqual(env["VELLUM_PLATFORM_URL"], "https://custom.vellum.ai")
     }
 
     func testAssistantEnvOmitsNilOptionals() {
-        let env = VellumContainerEnv.assistant(instanceName: "x", signingKey: nil, cesServiceToken: nil)
+        let env = VellumContainerEnv.assistant(instanceName: "x", signingKey: nil, cesServiceToken: nil, platformURL: nil)
         XCTAssertNil(env["ACTOR_TOKEN_SIGNING_KEY"])
         XCTAssertNil(env["CES_SERVICE_TOKEN"])
+        XCTAssertNil(env["VELLUM_PLATFORM_URL"])
     }
 
     func testGatewayEnvRequiredKeys() {
-        let env = VellumContainerEnv.gateway(signingKey: nil, bootstrapSecret: nil, cesServiceToken: nil)
+        let env = VellumContainerEnv.gateway(signingKey: nil, bootstrapSecret: nil, cesServiceToken: nil, platformURL: nil)
+        XCTAssertEqual(env["IS_CONTAINERIZED"], "true")
         XCTAssertEqual(env["GATEWAY_PORT"], "7830")
         XCTAssertEqual(env["ASSISTANT_HOST"], "localhost")
         XCTAssertEqual(env["RUNTIME_HTTP_PORT"], "3001")
@@ -93,10 +96,11 @@ final class StackDefinitionTests: XCTestCase {
     }
 
     func testGatewayEnvOptionalKeys() {
-        let env = VellumContainerEnv.gateway(signingKey: "sk", bootstrapSecret: "bs", cesServiceToken: "ct")
+        let env = VellumContainerEnv.gateway(signingKey: "sk", bootstrapSecret: "bs", cesServiceToken: "ct", platformURL: "https://custom.vellum.ai")
         XCTAssertEqual(env["ACTOR_TOKEN_SIGNING_KEY"], "sk")
         XCTAssertEqual(env["GUARDIAN_BOOTSTRAP_SECRET"], "bs")
         XCTAssertEqual(env["CES_SERVICE_TOKEN"], "ct")
+        XCTAssertEqual(env["VELLUM_PLATFORM_URL"], "https://custom.vellum.ai")
     }
 
     func testCredentialExecutorEnvRequiredKeys() {

--- a/clients/macos/vellum-assistantTests/StackDefinitionTests.swift
+++ b/clients/macos/vellum-assistantTests/StackDefinitionTests.swift
@@ -1,0 +1,113 @@
+import XCTest
+@testable import VellumAssistantLib
+
+final class StackDefinitionTests: XCTestCase {
+
+    // MARK: - VellumServiceName
+
+    func testAllServicesPresent() {
+        let names = VellumServiceName.allCases
+        XCTAssertEqual(names.count, 3)
+        XCTAssertTrue(names.contains(.assistant))
+        XCTAssertTrue(names.contains(.gateway))
+        XCTAssertTrue(names.contains(.credentialExecutor))
+    }
+
+    func testServiceRawValues() {
+        XCTAssertEqual(VellumServiceName.assistant.rawValue, "vellum-assistant")
+        XCTAssertEqual(VellumServiceName.gateway.rawValue, "vellum-gateway")
+        XCTAssertEqual(VellumServiceName.credentialExecutor.rawValue, "vellum-credential-executor")
+    }
+
+    func testStartOrderContainsAllServices() {
+        let ordered = Set(VellumServiceName.startOrder)
+        let all = Set(VellumServiceName.allCases)
+        XCTAssertEqual(ordered, all)
+    }
+
+    func testStartOrderBeginsWithAssistant() {
+        XCTAssertEqual(VellumServiceName.startOrder.first, .assistant)
+    }
+
+    // MARK: - VellumImageReference
+
+    func testFullReferenceFormat() {
+        let ref = VellumImageReference(registry: "docker.io", repository: "vellumai/vellum-assistant", tag: "1.2.3")
+        XCTAssertEqual(ref.fullReference, "docker.io/vellumai/vellum-assistant:1.2.3")
+    }
+
+    func testDefaultsContainAllServices() {
+        let refs = VellumImageReference.defaults(version: "0.1.0")
+        for service in VellumServiceName.allCases {
+            XCTAssertNotNil(refs[service], "Missing default image ref for \(service)")
+        }
+    }
+
+    func testDefaultsUseRequestedVersion() {
+        let refs = VellumImageReference.defaults(version: "42.0.0")
+        for (_, ref) in refs {
+            XCTAssertEqual(ref.tag, "42.0.0")
+        }
+    }
+
+    // MARK: - Ports
+
+    func testPortValues() {
+        XCTAssertEqual(VellumContainerPorts.assistantHTTP, 3001)
+        XCTAssertEqual(VellumContainerPorts.gatewayHTTP, 7830)
+        XCTAssertEqual(VellumContainerPorts.cesHTTP, 8090)
+    }
+
+    // MARK: - Environment
+
+    func testAssistantEnvRequiredKeys() {
+        let env = VellumContainerEnv.assistant(instanceName: "test", signingKey: nil, cesServiceToken: nil)
+        XCTAssertEqual(env["IS_CONTAINERIZED"], "true")
+        XCTAssertEqual(env["VELLUM_ASSISTANT_NAME"], "test")
+        XCTAssertEqual(env["VELLUM_CLOUD"], "apple-container")
+        XCTAssertEqual(env["RUNTIME_HTTP_HOST"], "0.0.0.0")
+        XCTAssertEqual(env["VELLUM_WORKSPACE_DIR"], "/workspace")
+        XCTAssertNotNil(env["CES_CREDENTIAL_URL"])
+        XCTAssertNotNil(env["GATEWAY_INTERNAL_URL"])
+    }
+
+    func testAssistantEnvOptionalKeys() {
+        let env = VellumContainerEnv.assistant(instanceName: "x", signingKey: "key123", cesServiceToken: "tok456")
+        XCTAssertEqual(env["ACTOR_TOKEN_SIGNING_KEY"], "key123")
+        XCTAssertEqual(env["CES_SERVICE_TOKEN"], "tok456")
+    }
+
+    func testAssistantEnvOmitsNilOptionals() {
+        let env = VellumContainerEnv.assistant(instanceName: "x", signingKey: nil, cesServiceToken: nil)
+        XCTAssertNil(env["ACTOR_TOKEN_SIGNING_KEY"])
+        XCTAssertNil(env["CES_SERVICE_TOKEN"])
+    }
+
+    func testGatewayEnvRequiredKeys() {
+        let env = VellumContainerEnv.gateway(signingKey: nil, bootstrapSecret: nil, cesServiceToken: nil)
+        XCTAssertEqual(env["GATEWAY_PORT"], "7830")
+        XCTAssertEqual(env["ASSISTANT_HOST"], "localhost")
+        XCTAssertEqual(env["RUNTIME_HTTP_PORT"], "3001")
+        XCTAssertEqual(env["RUNTIME_PROXY_ENABLED"], "true")
+        XCTAssertNotNil(env["CES_CREDENTIAL_URL"])
+    }
+
+    func testGatewayEnvOptionalKeys() {
+        let env = VellumContainerEnv.gateway(signingKey: "sk", bootstrapSecret: "bs", cesServiceToken: "ct")
+        XCTAssertEqual(env["ACTOR_TOKEN_SIGNING_KEY"], "sk")
+        XCTAssertEqual(env["GUARDIAN_BOOTSTRAP_SECRET"], "bs")
+        XCTAssertEqual(env["CES_SERVICE_TOKEN"], "ct")
+    }
+
+    func testCredentialExecutorEnvRequiredKeys() {
+        let env = VellumContainerEnv.credentialExecutor(cesServiceToken: nil)
+        XCTAssertEqual(env["CES_MODE"], "managed")
+        XCTAssertEqual(env["CES_BOOTSTRAP_SOCKET_DIR"], "/run/ces-bootstrap")
+        XCTAssertEqual(env["CREDENTIAL_SECURITY_DIR"], "/ces-security")
+    }
+
+    func testCredentialExecutorEnvOptionalToken() {
+        let env = VellumContainerEnv.credentialExecutor(cesServiceToken: "mytoken")
+        XCTAssertEqual(env["CES_SERVICE_TOKEN"], "mytoken")
+    }
+}


### PR DESCRIPTION
## Summary
- Add `StackDefinition.swift` with `VellumServiceName`, `VellumImageReference`, `VellumContainerPorts`, `VellumMountPaths`, and `VellumContainerEnv` types that mirror the Docker topology from `cli/src/lib/docker.ts`
- Add unit tests for image reference formatting, port values, and env completeness

## Test plan
- [x] Unit tests in `StackDefinitionTests.swift`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24426" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
