### PR TITLE
feat(apple-containers): add KataKernelStore for kernel and vminit image management

### DIFF
--- a/clients/macos/vellum-assistant/AppleContainer/KernelStore.swift
+++ b/clients/macos/vellum-assistant/AppleContainer/KernelStore.swift
@@ -1,0 +1,110 @@
+import Containerization
+import ContainerizationError
+import ContainerizationOCI
+import Foundation
+
+/// Manages the VM boot infrastructure: the bundled Kata kernel and the
+/// vminit guest-init image pulled from the containerization registry.
+struct KataKernelStore: Sendable {
+
+    typealias ProgressHandler = @Sendable (String) async -> Void
+
+    private static let initImageVersion = "0.30.1"
+    static let initImageReference = "ghcr.io/apple/containerization/vminit:\(initImageVersion)"
+    static let bundledKernelSubdirectory = "DeveloperVM"
+
+    /// Root directory for runtime data (image store, init filesystem, etc.).
+    let runtimeRoot: URL
+
+    /// Locates the bundled Kata kernel. Injectable for testing.
+    let locateKernel: @Sendable () -> URL?
+
+    init(
+        runtimeRoot: URL = Self.defaultRuntimeRoot(),
+        locateKernel: @escaping @Sendable () -> URL? = { Self.defaultBundledKernelURL() }
+    ) {
+        self.runtimeRoot = runtimeRoot
+        self.locateKernel = locateKernel
+    }
+
+    /// Returns the URL of the bundled Kata kernel, or throws if not found.
+    func requireKernel() throws -> URL {
+        guard let url = locateKernel() else {
+            throw KernelStoreError.kernelNotFound
+        }
+        return url
+    }
+
+    /// Creates an `ImageStore` rooted at `runtimeRoot`.
+    func makeImageStore() async throws -> ImageStore {
+        try FileManager.default.createDirectory(at: runtimeRoot, withIntermediateDirectories: true)
+        let contentStore = try LocalContentStore(
+            path: runtimeRoot.appendingPathComponent("content", isDirectory: true)
+        )
+        return try ImageStore(path: runtimeRoot, contentStore: contentStore)
+    }
+
+    /// Prepares the vminit ext4 block device, pulling the image if needed.
+    func prepareInitFilesystem(
+        store: ImageStore,
+        progress: @escaping ProgressHandler
+    ) async throws -> Containerization.Mount {
+        let initImage: InitImage
+        do {
+            let image = try await store.get(reference: Self.initImageReference)
+            initImage = InitImage(image: image)
+        } catch let error as ContainerizationError where error.code == .notFound {
+            await progress("Downloading vminit guest image...")
+            let image = try await store.pull(reference: Self.initImageReference)
+            initImage = InitImage(image: image)
+        }
+
+        let initPath = runtimeRoot.appendingPathComponent("vminit-\(Self.initImageVersion).ext4")
+        do {
+            return try await initImage.initBlock(at: initPath, for: .linuxArm)
+        } catch let error as ContainerizationError where error.code == .exists {
+            return .block(format: "ext4", source: initPath.path, destination: "/", options: ["ro"])
+        }
+    }
+
+    enum KernelStoreError: LocalizedError, Equatable {
+        case kernelNotFound
+
+        var errorDescription: String? {
+            switch self {
+            case .kernelNotFound:
+                return "The bundled Kata kernel was not found in the app bundle."
+            }
+        }
+    }
+
+    // MARK: - Default Locations
+
+    static func defaultRuntimeRoot() -> URL {
+        let appSupport = FileManager.default.urls(
+            for: .applicationSupportDirectory, in: .userDomainMask
+        ).first ?? FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Application Support", isDirectory: true)
+
+        return appSupport
+            .appendingPathComponent("vellum-assistant", isDirectory: true)
+            .appendingPathComponent("apple-containers", isDirectory: true)
+    }
+
+    static func defaultBundledKernelURL() -> URL? {
+        let relativePath = bundledKernelSubdirectory + "/vmlinux.container"
+
+        if let resourceURL = Bundle.main.resourceURL?
+            .appendingPathComponent(relativePath),
+            FileManager.default.fileExists(atPath: resourceURL.path) {
+            return resourceURL
+        }
+
+        let directBuildURL = Bundle.main.bundleURL.appendingPathComponent(relativePath)
+        if FileManager.default.fileExists(atPath: directBuildURL.path) {
+            return directBuildURL
+        }
+
+        return nil
+    }
+}

--- a/clients/macos/vellum-assistantTests/KernelStoreTests.swift
+++ b/clients/macos/vellum-assistantTests/KernelStoreTests.swift
@@ -1,0 +1,47 @@
+import XCTest
+@testable import VellumAssistantLib
+
+final class KernelStoreTests: XCTestCase {
+
+    func testRequireKernelSucceedsWhenFound() throws {
+        let fakeURL = URL(fileURLWithPath: "/tmp/fake-kernel")
+        let store = KataKernelStore(
+            runtimeRoot: URL(fileURLWithPath: "/tmp/test-runtime"),
+            locateKernel: { fakeURL }
+        )
+        XCTAssertEqual(try store.requireKernel(), fakeURL)
+    }
+
+    func testRequireKernelThrowsWhenNotFound() {
+        let store = KataKernelStore(
+            runtimeRoot: URL(fileURLWithPath: "/tmp/test-runtime"),
+            locateKernel: { nil }
+        )
+        XCTAssertThrowsError(try store.requireKernel()) { error in
+            XCTAssertEqual(error as? KataKernelStore.KernelStoreError, .kernelNotFound)
+        }
+    }
+
+    func testKernelNotFoundErrorDescription() {
+        let error = KataKernelStore.KernelStoreError.kernelNotFound
+        XCTAssertTrue(error.errorDescription!.contains("kernel"))
+    }
+
+    func testInitImageReferenceContainsVersion() {
+        let ref = KataKernelStore.initImageReference
+        XCTAssertTrue(ref.hasPrefix("ghcr.io/apple/containerization/vminit:"))
+        // Version appears exactly once (no duplication)
+        let version = ref.split(separator: ":").last!
+        XCTAssertFalse(version.isEmpty)
+    }
+
+    func testDefaultRuntimeRootPath() {
+        let root = KataKernelStore.defaultRuntimeRoot()
+        XCTAssertTrue(root.path.hasSuffix("apple-containers"))
+        XCTAssertTrue(root.path.contains("vellum-assistant"))
+    }
+
+    func testBundledKernelSubdirectory() {
+        XCTAssertEqual(KataKernelStore.bundledKernelSubdirectory, "DeveloperVM")
+    }
+}


### PR DESCRIPTION
## Summary
- Add `KataKernelStore` struct for managing the bundled Kata kernel and Apple vminit image
- Handles kernel discovery from app bundle, init filesystem creation/caching, and image store setup
- Add unit tests for kernel location and store initialization

## Test plan
- [x] Unit tests in `KernelStoreTests.swift`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24427" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
