### PR TITLE
feat: add async import polling to platform restore flow

### DIFF
--- a/cli/src/commands/restore.ts
+++ b/cli/src/commands/restore.ts
@@ -429,21 +429,17 @@ async function restorePlatform(
         status = await platformPollImportStatus(jobId, token, entry.runtimeUrl);
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
-        if (msg.includes("not found")) {
-          throw err;
-        }
-        // Re-throw permanent 4xx errors (auth, forbidden, etc.)
-        // but retry transient 5xx errors
+        // Only retry errors we can positively identify as transient 5xx
         const statusMatch = msg.match(/status check failed: (\d+)/);
         if (statusMatch) {
           const statusCode = parseInt(statusMatch[1], 10);
-          if (statusCode >= 400 && statusCode < 500) {
-            throw err;
+          if (statusCode >= 500) {
+            console.warn(`Polling failed, retrying... (${msg})`);
+            continue;
           }
         }
-        // Transient error — retry
-        console.warn(`Polling failed, retrying... (${msg})`);
-        continue;
+        // Everything else (4xx, auth errors, not found) — fail fast
+        throw err;
       }
 
       if (status.status === "complete") {

--- a/cli/src/commands/restore.ts
+++ b/cli/src/commands/restore.ts
@@ -15,6 +15,7 @@ import {
   platformUploadToSignedUrl,
   platformImportPreflightFromGcs,
   platformImportBundleFromGcs,
+  platformPollImportStatus,
 } from "../lib/platform-client.js";
 import { performDockerRollback } from "../lib/upgrade-lifecycle.js";
 
@@ -395,9 +396,77 @@ async function restorePlatform(
     process.exit(1);
   }
 
-  if (importResult.statusCode < 200 || importResult.statusCode >= 300) {
+  if (
+    importResult.statusCode !== 202 &&
+    (importResult.statusCode < 200 || importResult.statusCode >= 300)
+  ) {
     console.error(`Error: Import failed (${importResult.statusCode})`);
     process.exit(1);
+  }
+
+  // Async import — poll until complete
+  if (importResult.statusCode === 202) {
+    const jobId = (importResult.body as { job_id?: string }).job_id;
+    if (!jobId) {
+      console.error("Error: Import accepted but no job ID returned.");
+      process.exit(1);
+    }
+
+    const POLL_INTERVAL_MS = 5_000;
+    const TIMEOUT_MS = 10 * 60 * 1_000; // 10 minutes
+    const startTime = Date.now();
+    const deadline = startTime + TIMEOUT_MS;
+
+    while (Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+
+      let status: {
+        status: string;
+        result?: Record<string, unknown>;
+        error?: string;
+      };
+      try {
+        status = await platformPollImportStatus(jobId, token, entry.runtimeUrl);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (msg.includes("not found")) {
+          throw err;
+        }
+        // Re-throw permanent 4xx errors (auth, forbidden, etc.)
+        // but retry transient 5xx errors
+        const statusMatch = msg.match(/status check failed: (\d+)/);
+        if (statusMatch) {
+          const statusCode = parseInt(statusMatch[1], 10);
+          if (statusCode >= 400 && statusCode < 500) {
+            throw err;
+          }
+        }
+        // Transient error — retry
+        console.warn(`Polling failed, retrying... (${msg})`);
+        continue;
+      }
+
+      if (status.status === "complete") {
+        importResult = { statusCode: 200, body: status.result ?? {} };
+        break;
+      }
+
+      if (status.status === "failed") {
+        console.error(`Import failed: ${status.error ?? "unknown error"}`);
+        process.exit(1);
+      }
+
+      const elapsed = Math.round((Date.now() - startTime) / 1000);
+      process.stdout.write(`\rImporting... ${elapsed}s elapsed`);
+    }
+
+    // Clear the progress line
+    process.stdout.write("\r" + " ".repeat(40) + "\r");
+
+    if (importResult.statusCode === 202) {
+      console.error("Import timed out after 10 minutes.");
+      process.exit(1);
+    }
   }
 
   const result = importResult.body as unknown as ImportResponse;

--- a/cli/src/commands/restore.ts
+++ b/cli/src/commands/restore.ts
@@ -429,17 +429,25 @@ async function restorePlatform(
         status = await platformPollImportStatus(jobId, token, entry.runtimeUrl);
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
-        // Only retry errors we can positively identify as transient 5xx
+        if (msg.includes("not found")) {
+          throw err;
+        }
+        // Fail fast on auth errors from authHeaders() which don't
+        // match the "status check failed: NNN" format
+        if (msg.includes("401") || msg.includes("403")) {
+          throw err;
+        }
+        // Re-throw permanent 4xx errors, retry transient 5xx
         const statusMatch = msg.match(/status check failed: (\d+)/);
         if (statusMatch) {
           const statusCode = parseInt(statusMatch[1], 10);
-          if (statusCode >= 500) {
-            console.warn(`Polling failed, retrying... (${msg})`);
-            continue;
+          if (statusCode >= 400 && statusCode < 500) {
+            throw err;
           }
         }
-        // Everything else (4xx, auth errors, not found) — fail fast
-        throw err;
+        // Transient error (5xx, network) — retry
+        console.warn(`Polling failed, retrying... (${msg})`);
+        continue;
       }
 
       if (status.status === "complete") {


### PR DESCRIPTION
## Summary
- Add 202 + polling support to the platform restore path, matching the existing teleport implementation
- When `platformImportBundleFromGcs` returns 202 with a `job_id`, restore now polls `platformPollImportStatus` every 5s (10min timeout) with progress indicator
- Handles transient 5xx errors with retry and permanent 4xx errors with fail-fast, consistent with teleport and macOS app

## Original prompt
align the import logic for restore with all the teleport implementations
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24430" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
