### PR TITLE
fix(macos): remove unused 'usage' binding warning

### DIFF
--- a/clients/shared/Features/Chat/SubagentDetailStore.swift
+++ b/clients/shared/Features/Chat/SubagentDetailStore.swift
@@ -239,7 +239,7 @@ public final class SubagentDetailStore {
 
     /// Record a status change with optional usage stats.
     public func recordStatusChanged(subagentId: String, status: SubagentStatus, usage: UsageStats?) {
-        if let usage, status.isTerminal {
+        if usage != nil, status.isTerminal {
             terminalUsageReceivedIds.insert(subagentId)
         }
         if let usage {


### PR DESCRIPTION
## Summary
- Replace `if let usage` with `if usage != nil` in `SubagentDetailStore.recordStatusChanged` where the bound value is never used, eliminating the Swift `#no-usage` compiler warning.

## Original prompt
Fix Swift compiler warning: `immutable value 'usage' was never used` in `SubagentDetailStore.swift:242`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24431" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
