### PR TITLE
fix(macos): resolve Swift 6 nonisolated context warning

### DIFF
--- a/clients/macos/vellum-assistant/App/AppleContainersLauncher.swift
+++ b/clients/macos/vellum-assistant/App/AppleContainersLauncher.swift
@@ -51,7 +51,7 @@ final class AppleContainersLauncher: AssistantManagementClient {
 
     static let initImageVersion = "0.30.1"
     static let initImageReference = "ghcr.io/apple/containerization/vminit:\(initImageVersion)"
-    static let bundledKernelSubdirectory = "DeveloperVM"
+    nonisolated(unsafe) static let bundledKernelSubdirectory = "DeveloperVM"
     static let defaultFilesystemSizeInBytes: UInt64 = 2 * 1024 * 1024 * 1024
 
     /// OCI image for the assistant container. Will be replaced with the


### PR DESCRIPTION
## Summary

- Mark `bundledKernelSubdirectory` as `nonisolated(unsafe)` to fix Swift 6 warning about accessing a `@MainActor`-isolated static property from a `nonisolated` context
- The property is a compile-time string constant (`"DeveloperVM"`) with no mutation concern, so actor isolation is unnecessary

## Original prompt

Fix Swift 6 warning: main actor-isolated static property `bundledKernelSubdirectory` can not be referenced from a nonisolated context in `AppleContainersLauncher.swift:316`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24432" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
