### PR TITLE
fix(macos): add missing .tracking case to ScrollPhase switch

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+ScrollHandling.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+ScrollHandling.swift
@@ -13,6 +13,7 @@ extension ScrollCoordinator.Phase {
         switch phase {
         case .idle: .idle
         case .interacting: .interacting
+        case .tracking: .interacting
         case .decelerating: .decelerating
         case .animating: .animating
         @unknown default: .idle


### PR DESCRIPTION
## Summary
- Add explicit `.tracking` → `.interacting` mapping in the `ScrollCoordinator.Phase.from(_:)` bridge to fix the "switch must be exhaustive" compiler warning introduced by the macOS 26 SDK adding `.tracking` to `ScrollPhase`
- `.tracking` (finger on trackpad, not yet scrolling) maps to `.interacting` since both represent active user contact

## Original prompt
Fix: /Users/sidd/vocify/vellum-assistant/clients/macos/vellum-assistant/Features/Chat/MessageListView+ScrollHandling.swift:13:9: warning: switch must be exhaustive — add missing case: '.tracking'
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24433" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
