### PR TITLE
[WIP] apple container pod runtime core

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
@@ -113,10 +113,10 @@ extension AppDelegate {
     /// - `apple-container`: dispatches to the `AppleContainersLauncher` which
     ///   manages the full container lifecycle via the Containerization framework.
     func managementClient(for assistant: LockfileAssistant?) -> AssistantManagementClient {
-        guard let assistant, assistant.isAppleContainer else {
+        guard let assistant, assistant.isAppleContainer, let launcher = appleContainersLauncher else {
             return vellumCli
         }
-        return appleContainersLauncher
+        return launcher
     }
 
     // MARK: - Gateway Connection Setup

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -74,7 +74,12 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     var popOutLocalMonitor: Any?
     public let services = AppServices()
     let vellumCli = VellumCli()
-    let appleContainersLauncher = AppleContainersLauncher()
+    let appleContainersLauncher: AssistantManagementClient? = {
+        if #available(macOS 26.0, *) {
+            return AppleContainersLauncher()
+        }
+        return nil
+    }()
     public let updateManager = UpdateManager()
     let debugStateWriter = DebugStateWriter()
     private let telemetryClient: any TelemetryClientProtocol = TelemetryClient()

--- a/clients/macos/vellum-assistant/App/AppleContainersLauncher.swift
+++ b/clients/macos/vellum-assistant/App/AppleContainersLauncher.swift
@@ -67,6 +67,9 @@ final class AppleContainersLauncher: AssistantManagementClient {
             throw LauncherError.unavailable(reason)
         }
 
+        // TODO: Generate a unique assistant ID like the CLI does (e.g. "adjective-noun")
+        // instead of using the user-facing display name. The display name can contain
+        // spaces and duplicates, which makes it a poor filesystem/lockfile key.
         let assistantName = name ?? "apple-container-\(UUID().uuidString.prefix(8).lowercased())"
         let signingKey = Self.generateSigningKey()
 

--- a/clients/macos/vellum-assistant/App/AppleContainersLauncher.swift
+++ b/clients/macos/vellum-assistant/App/AppleContainersLauncher.swift
@@ -13,6 +13,7 @@ private let log = Logger(
 ///
 /// Conforms to `AssistantManagementClient` so `AppDelegate.managementClient(for:)`
 /// can dispatch to it for `isAppleContainer` entries.
+@available(macOS 26.0, *)
 @MainActor
 final class AppleContainersLauncher: AssistantManagementClient {
 
@@ -113,7 +114,8 @@ final class AppleContainersLauncher: AssistantManagementClient {
         Self.writeLockfileEntry(
             assistantId: assistantName,
             hatchedAt: hatchedAt,
-            signingKey: signingKey
+            signingKey: signingKey,
+            runtimeUrl: runtime.gatewayURL
         )
         LockfileAssistant.setActiveAssistantId(assistantName)
         log.info("Apple container '\(assistantName, privacy: .public)' is running")
@@ -154,6 +156,7 @@ final class AppleContainersLauncher: AssistantManagementClient {
         assistantId: String,
         hatchedAt: String,
         signingKey: String,
+        runtimeUrl: String? = nil,
         lockfilePath: String? = nil
     ) -> Bool {
         let path = lockfilePath ?? LockfilePaths.primaryPath
@@ -169,7 +172,7 @@ final class AppleContainersLauncher: AssistantManagementClient {
 
         var assistants = lockfile["assistants"] as? [[String: Any]] ?? []
 
-        let newEntry: [String: Any] = [
+        var newEntry: [String: Any] = [
             "assistantId": assistantId,
             "cloud": "apple-container",
             "hatchedAt": hatchedAt,
@@ -178,6 +181,9 @@ final class AppleContainersLauncher: AssistantManagementClient {
                 "signingKey": signingKey,
             ],
         ]
+        if let runtimeUrl {
+            newEntry["runtimeUrl"] = runtimeUrl
+        }
 
         if let existingIndex = assistants.firstIndex(where: { ($0["assistantId"] as? String) == assistantId }) {
             assistants[existingIndex] = newEntry

--- a/clients/macos/vellum-assistant/App/AppleContainersLauncher.swift
+++ b/clients/macos/vellum-assistant/App/AppleContainersLauncher.swift
@@ -53,6 +53,14 @@ final class AppleContainersLauncher: AssistantManagementClient {
     // MARK: - AssistantManagementClient
 
     func hatch(name: String?, configValues: [String: String]) async throws {
+        try await hatch(name: name, configValues: configValues, progress: nil)
+    }
+
+    func hatch(
+        name: String?,
+        configValues: [String: String],
+        progress onProgress: (@MainActor (String) -> Void)?
+    ) async throws {
         let availability = Self.checkAvailability()
         if case .unavailable(let reason) = availability {
             log.error("Apple Containers not available: \(String(describing: reason), privacy: .public)")
@@ -87,6 +95,7 @@ final class AppleContainersLauncher: AssistantManagementClient {
         do {
             try await runtime.start { message in
                 log.info("\(message, privacy: .public)")
+                await onProgress?(message)
             }
         } catch {
             // Clean up on failure.

--- a/clients/macos/vellum-assistant/App/AppleContainersLauncher.swift
+++ b/clients/macos/vellum-assistant/App/AppleContainersLauncher.swift
@@ -1,8 +1,6 @@
-import Containerization
-import ContainerizationError
-import ContainerizationOCI
 import Foundation
 import os
+import Security
 import VellumAssistantShared
 
 private let log = Logger(
@@ -11,13 +9,10 @@ private let log = Logger(
 )
 
 /// Manages the lifecycle of an assistant running inside an Apple Container
-/// (lightweight Linux VM via the Containerization framework).
+/// (3-service LinuxPod VM via the Containerization framework).
 ///
 /// Conforms to `AssistantManagementClient` so `AppDelegate.managementClient(for:)`
 /// can dispatch to it for `isAppleContainer` entries.
-///
-/// Requires macOS 26+ and Apple Silicon (ARM64). Callers should gate on
-/// `AppleContainersAvailabilityChecker.check()` before using this launcher.
 @MainActor
 final class AppleContainersLauncher: AssistantManagementClient {
 
@@ -25,7 +20,6 @@ final class AppleContainersLauncher: AssistantManagementClient {
 
     enum LauncherError: LocalizedError {
         case unavailable(AppleContainersAvailabilityChecker.UnavailableReason)
-        case kernelNotFound
         case hatchFailed(String)
 
         var errorDescription: String? {
@@ -39,40 +33,17 @@ final class AppleContainersLauncher: AssistantManagementClient {
                 case .unsupportedHardware:
                     return "Apple Containers require Apple Silicon (ARM64)."
                 }
-            case .kernelNotFound:
-                return "The bundled Linux kernel was not found in the app bundle."
             case .hatchFailed(let detail):
                 return "Failed to hatch Apple Container: \(detail)"
             }
         }
     }
 
-    // MARK: - Configuration
-
-    static let initImageVersion = "0.30.1"
-    static let initImageReference = "ghcr.io/apple/containerization/vminit:\(initImageVersion)"
-    nonisolated(unsafe) static let bundledKernelSubdirectory = "DeveloperVM"
-    static let defaultFilesystemSizeInBytes: UInt64 = 2 * 1024 * 1024 * 1024
-
-    /// OCI image for the assistant container. Will be replaced with the
-    /// production assistant image once the container build pipeline ships.
-    static let assistantImageReference = "docker.io/library/ubuntu:24.04"
-
     // MARK: - Running State
 
-    /// Retains the running container so ARC does not tear it down when hatch() returns.
-    private(set) var runningContainer: LinuxContainer?
-    /// Retains the VM manager backing the running container.
-    private(set) var vmManager: VZVirtualMachineManager?
-    /// Name of the currently-running assistant, if any.
-    private(set) var runningAssistantName: String?
+    private var podRuntime: AppleContainersPodRuntime?
 
     // MARK: - Testable Hooks
-
-    /// Locates the bundled Linux kernel. Override in tests.
-    nonisolated(unsafe) static var locateBundledKernel: () -> URL? = {
-        defaultBundledKernelURL()
-    }
 
     /// Checks availability. Override in tests to bypass OS/hardware gates.
     nonisolated(unsafe) static var checkAvailability: () -> AppleContainersAvailabilityChecker.Availability = {
@@ -87,153 +58,75 @@ final class AppleContainersLauncher: AssistantManagementClient {
             log.error("Apple Containers not available: \(String(describing: reason), privacy: .public)")
             throw LauncherError.unavailable(reason)
         }
-        guard case .available = availability else { return }
-
-        guard let kernelURL = Self.locateBundledKernel() else {
-            log.error("Bundled Linux kernel not found")
-            throw LauncherError.kernelNotFound
-        }
 
         let assistantName = name ?? "apple-container-\(UUID().uuidString.prefix(8).lowercased())"
-        let runtimeRoot = Self.runtimeRoot(for: assistantName)
+        let signingKey = Self.generateSigningKey()
 
-        log.info("Hatching apple-container '\(assistantName, privacy: .public)' at \(runtimeRoot.path, privacy: .public)")
+        let kernelStore = KataKernelStore()
+        let instanceDir = Self.instanceDir(for: assistantName)
+
+        let imageRefs = VellumImageReference.defaults(version: "latest")
+        let serviceImageRefs = Dictionary(
+            uniqueKeysWithValues: imageRefs.map { ($0.key, $0.value.fullReference) }
+        )
+
+        let config = AppleContainersPodRuntime.Configuration(
+            instanceName: assistantName,
+            serviceImageRefs: serviceImageRefs,
+            instanceDir: instanceDir,
+            signingKey: signingKey
+        )
+
+        let runtime = AppleContainersPodRuntime(
+            kernelStore: kernelStore,
+            configuration: config
+        )
+
+        log.info("Hatching apple-container '\(assistantName, privacy: .public)'")
 
         do {
-            try FileManager.default.createDirectory(at: runtimeRoot, withIntermediateDirectories: true)
-
-            let kernel = Kernel(path: kernelURL, platform: .linuxArm)
-            let contentStore = try LocalContentStore(
-                path: runtimeRoot.appendingPathComponent("content", isDirectory: true)
-            )
-            let imageStore = try ImageStore(path: runtimeRoot, contentStore: contentStore)
-
-            // Fetch or pull init image
-            let initImage = try await Self.fetchOrPull(
-                reference: Self.initImageReference,
-                store: imageStore,
-                label: "vminit"
-            )
-            let initPath = runtimeRoot.appendingPathComponent("vminit-\(Self.initImageVersion).ext4")
-            let initFilesystem = try await Self.createInitFilesystem(
-                from: InitImage(image: initImage),
-                at: initPath
-            )
-
-            // Fetch or pull assistant image
-            let assistantImage = try await Self.fetchOrPull(
-                reference: Self.assistantImageReference,
-                store: imageStore,
-                label: "assistant"
-            )
-            let rootFSPath = runtimeRoot.appendingPathComponent("rootfs.ext4")
-            let rootFilesystem = try await Self.createRootFilesystem(
-                from: assistantImage,
-                at: rootFSPath
-            )
-
-            let manager = VZVirtualMachineManager(
-                kernel: kernel,
-                initialFilesystem: initFilesystem
-            )
-
-            let containerId = "vellum-\(assistantName)"
-            let imageConfig = try await assistantImage.config(for: .current).config
-            let container = try LinuxContainer(containerId, rootfs: rootFilesystem, vmm: manager) { config in
-                if let imageConfig {
-                    config.process = .init(from: imageConfig)
-                }
-                // Keep the container alive so the assistant processes can run.
-                config.process.arguments = ["/bin/sh", "-lc", "sleep infinity"]
-                config.process.workingDirectory = "/"
-                if !config.process.environmentVariables.contains(where: { $0.hasPrefix("HOME=") }) {
-                    config.process.environmentVariables.append("HOME=/root")
-                }
+            try await runtime.start { message in
+                log.info("\(message, privacy: .public)")
             }
-
-            log.info("Starting container '\(containerId, privacy: .public)'...")
-            try await container.create()
-            try await container.start()
-
-            // Retain the container and VM manager so ARC doesn't tear them down.
-            self.runningContainer = container
-            self.vmManager = manager
-            self.runningAssistantName = assistantName
-            log.info("Apple container '\(assistantName, privacy: .public)' is running")
-
-            let hatchedAt = ISO8601DateFormatter().string(from: Date())
-            Self.writeLockfileEntry(assistantId: assistantName, hatchedAt: hatchedAt)
-            LockfileAssistant.setActiveAssistantId(assistantName)
-            log.info("Lockfile entry written for '\(assistantName, privacy: .public)'")
-        } catch let error as LauncherError {
-            throw error
         } catch {
+            // Clean up on failure.
+            try? await runtime.stop()
             log.error("Apple container hatch failed: \(error.localizedDescription, privacy: .public)")
             throw LauncherError.hatchFailed(error.localizedDescription)
         }
+
+        self.podRuntime = runtime
+
+        let hatchedAt = ISO8601DateFormatter().string(from: Date())
+        Self.writeLockfileEntry(
+            assistantId: assistantName,
+            hatchedAt: hatchedAt,
+            signingKey: signingKey
+        )
+        LockfileAssistant.setActiveAssistantId(assistantName)
+        log.info("Apple container '\(assistantName, privacy: .public)' is running")
     }
 
-    // MARK: - Image Fetching
-
-    private static func fetchOrPull(
-        reference: String,
-        store: ImageStore,
-        label: String
-    ) async throws -> Containerization.Image {
-        do {
-            let image = try await store.get(reference: reference)
-            log.info("Using cached \(label, privacy: .public) image")
-            return image
-        } catch let error as ContainerizationError {
-            guard error.code == .notFound else { throw error }
-            log.info("Pulling \(label, privacy: .public) image: \(reference, privacy: .public)")
-            return try await store.pull(reference: reference)
-        }
+    /// Stops the running pod and clears state.
+    func stop() async throws {
+        guard let runtime = podRuntime else { return }
+        podRuntime = nil
+        try await runtime.stop()
     }
 
-    // MARK: - Filesystem Creation
+    // MARK: - Signing Key
 
-    private static func createInitFilesystem(
-        from initImage: InitImage,
-        at path: URL
-    ) async throws -> Containerization.Mount {
-        do {
-            return try await initImage.initBlock(at: path, for: .linuxArm)
-        } catch let error as ContainerizationError {
-            guard error.code == .exists else { throw error }
-            return .block(
-                format: "ext4",
-                source: path.path,
-                destination: "/",
-                options: ["ro"]
-            )
-        }
-    }
-
-    private static func createRootFilesystem(
-        from image: Containerization.Image,
-        at path: URL
-    ) async throws -> Containerization.Mount {
-        do {
-            let unpacker = EXT4Unpacker(blockSizeInBytes: defaultFilesystemSizeInBytes)
-            return try await unpacker.unpack(image, for: .current, at: path)
-        } catch let error as ContainerizationError {
-            guard error.code == .exists else { throw error }
-            return .block(
-                format: "ext4",
-                source: path.path,
-                destination: "/",
-                options: []
-            )
-        }
+    private static func generateSigningKey() -> String {
+        var bytes = [UInt8](repeating: 0, count: 32)
+        _ = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+        return bytes.map { String(format: "%02x", $0) }.joined()
     }
 
     // MARK: - Paths
 
-    private static func runtimeRoot(for assistantName: String) -> URL {
+    private static func instanceDir(for assistantName: String) -> URL {
         let appSupport = FileManager.default.urls(
-            for: .applicationSupportDirectory,
-            in: .userDomainMask
+            for: .applicationSupportDirectory, in: .userDomainMask
         ).first ?? FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent("Library/Application Support", isDirectory: true)
         return appSupport
@@ -244,13 +137,11 @@ final class AppleContainersLauncher: AssistantManagementClient {
 
     // MARK: - Lockfile
 
-    /// Writes or updates a lockfile entry for this apple-container assistant.
-    /// Kept here (not in the shared `LockfileAssistant`) because apple-container
-    /// logic is macOS-only and should not bleed into the shared/iOS/CLI target.
     @discardableResult
     nonisolated static func writeLockfileEntry(
         assistantId: String,
         hatchedAt: String,
+        signingKey: String,
         lockfilePath: String? = nil
     ) -> Bool {
         let path = lockfilePath ?? LockfilePaths.primaryPath
@@ -266,30 +157,19 @@ final class AppleContainersLauncher: AssistantManagementClient {
 
         var assistants = lockfile["assistants"] as? [[String: Any]] ?? []
 
+        let newEntry: [String: Any] = [
+            "assistantId": assistantId,
+            "cloud": "apple-container",
+            "hatchedAt": hatchedAt,
+            "runtimeBackend": "apple-containers",
+            "resources": [
+                "signingKey": signingKey,
+            ],
+        ]
+
         if let existingIndex = assistants.firstIndex(where: { ($0["assistantId"] as? String) == assistantId }) {
-            var existingEntry = assistants[existingIndex]
-            var didUpdate = false
-
-            if (existingEntry["cloud"] as? String) != "apple-container" {
-                existingEntry["cloud"] = "apple-container"
-                didUpdate = true
-            }
-
-            let existingHatchedAt = (existingEntry["hatchedAt"] as? String)?
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-            if existingHatchedAt?.isEmpty != false {
-                existingEntry["hatchedAt"] = hatchedAt
-                didUpdate = true
-            }
-
-            if !didUpdate { return true }
-            assistants[existingIndex] = existingEntry
+            assistants[existingIndex] = newEntry
         } else {
-            let newEntry: [String: Any] = [
-                "assistantId": assistantId,
-                "cloud": "apple-container",
-                "hatchedAt": hatchedAt,
-            ]
             assistants.append(newEntry)
         }
 
@@ -301,31 +181,11 @@ final class AppleContainersLauncher: AssistantManagementClient {
                 options: [.prettyPrinted, .sortedKeys]
             )
             let directory = fileURL.deletingLastPathComponent()
-            try FileManager.default.createDirectory(
-                at: directory,
-                withIntermediateDirectories: true
-            )
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
             try data.write(to: fileURL, options: .atomic)
             return true
         } catch {
             return false
         }
-    }
-
-    nonisolated static func defaultBundledKernelURL() -> URL? {
-        let relativePath = bundledKernelSubdirectory + "/vmlinux.container"
-
-        if let resourceURL = Bundle.main.resourceURL?
-            .appendingPathComponent(relativePath),
-           FileManager.default.fileExists(atPath: resourceURL.path) {
-            return resourceURL
-        }
-
-        let directBuildURL = Bundle.main.bundleURL.appendingPathComponent(relativePath)
-        if FileManager.default.fileExists(atPath: directBuildURL.path) {
-            return directBuildURL
-        }
-
-        return nil
     }
 }

--- a/clients/macos/vellum-assistant/AppleContainer/PodRuntime.swift
+++ b/clients/macos/vellum-assistant/AppleContainer/PodRuntime.swift
@@ -60,21 +60,24 @@ final class AppleContainersPodRuntime: @unchecked Sendable {
             at: config.instanceDir, withIntermediateDirectories: true
         )
 
-        await progress("Pulling service images...")
         var rootfsMounts: [VellumServiceName: Containerization.Mount] = [:]
-        for service in VellumServiceName.startOrder {
+        let rootfsDir = config.instanceDir.appendingPathComponent(".rootfs", isDirectory: true)
+        try FileManager.default.createDirectory(at: rootfsDir, withIntermediateDirectories: true)
+
+        for (i, service) in VellumServiceName.startOrder.enumerated() {
             guard let ref = config.serviceImageRefs[service] else {
                 throw PodRuntimeError.missingImageRef(service)
             }
+            await progress("Pulling image \(i + 1)/\(VellumServiceName.startOrder.count): \(service.rawValue)...")
             let image = try await pullImage(
                 reference: ref, store: imageStore, progress: progress
             )
-            let rootfsDir = config.instanceDir.appendingPathComponent(".rootfs", isDirectory: true)
-            try FileManager.default.createDirectory(at: rootfsDir, withIntermediateDirectories: true)
+            await progress("Unpacking \(service.rawValue) rootfs...")
             let rootfsPath = rootfsDir.appendingPathComponent("\(service.rawValue).ext4")
             rootfsMounts[service] = try await createRootFilesystem(
                 from: image, sizeInBytes: config.rootfsSizeInBytes, at: rootfsPath
             )
+            log.info("Rootfs ready for \(service.rawValue, privacy: .public)")
         }
 
         // 3. Create host-side shared directories.

--- a/clients/macos/vellum-assistant/AppleContainer/PodRuntime.swift
+++ b/clients/macos/vellum-assistant/AppleContainer/PodRuntime.swift
@@ -1,0 +1,276 @@
+import Containerization
+import ContainerizationError
+import ContainerizationOCI
+import Foundation
+import os
+
+private let log = Logger(
+    subsystem: Bundle.appBundleIdentifier,
+    category: "AppleContainersPodRuntime"
+)
+
+/// Runs the Vellum stack inside a single `LinuxPod` VM.
+///
+/// All three services can communicate over localhost,
+/// similar to container networks in Docker or k8s sidecar.
+final class AppleContainersPodRuntime: @unchecked Sendable {
+
+    struct Configuration: Sendable {
+        var instanceName: String
+        var cpus: Int = 4
+        var memoryInBytes: UInt64 = 2 * 1024 * 1024 * 1024 // 2 GiB
+        var serviceImageRefs: [VellumServiceName: String]
+        var instanceDir: URL
+        var signingKey: String
+        var bootstrapSecret: String?
+        var cesServiceToken: String?
+        /// Size of the ext4 rootfs block device per service container.
+        var rootfsSizeInBytes: UInt64 = 512 * 1024 * 1024 // 512 MiB
+    }
+
+    private let kernelStore: KataKernelStore
+    private let config: Configuration
+
+    private let lock = NSLock()
+    private var _pod: LinuxPod?
+    private var _assistantLogStream: AsyncStream<String>?
+
+    init(kernelStore: KataKernelStore, configuration: Configuration) {
+        self.kernelStore = kernelStore
+        self.config = configuration
+    }
+
+    // MARK: - Public API
+
+    /// Pulls images, assembles the pod, starts all containers, and waits for
+    /// the gateway to become healthy.
+    func start(progress: @escaping KataKernelStore.ProgressHandler) async throws {
+        log.info("Starting pod for '\(self.config.instanceName, privacy: .public)'")
+
+        // 1. Prepare VM boot infrastructure.
+        let kernelURL = try kernelStore.requireKernel()
+        let kernel = Kernel(path: kernelURL, platform: .linuxArm)
+        let imageStore = try await kernelStore.makeImageStore()
+        let initMount = try await kernelStore.prepareInitFilesystem(
+            store: imageStore, progress: progress
+        )
+
+        // 2. Pull and unpack service images.
+        await progress("Pulling service images...")
+        var rootfsMounts: [VellumServiceName: Containerization.Mount] = [:]
+        for service in VellumServiceName.startOrder {
+            guard let ref = config.serviceImageRefs[service] else {
+                throw PodRuntimeError.missingImageRef(service)
+            }
+            let image = try await pullImage(
+                reference: ref, store: imageStore, progress: progress
+            )
+            let rootfsPath = config.instanceDir
+                .appendingPathComponent(".rootfs", isDirectory: true)
+                .appendingPathComponent(service.rawValue, isDirectory: true)
+            rootfsMounts[service] = try await createRootFilesystem(
+                from: image, sizeInBytes: config.rootfsSizeInBytes, at: rootfsPath
+            )
+        }
+
+        // 3. Create host-side shared directories.
+        let workspaceDir = config.instanceDir.appendingPathComponent("workspace", isDirectory: true)
+        let cesBootstrapDir = config.instanceDir.appendingPathComponent("ces-bootstrap", isDirectory: true)
+        let gatewaySecurityDir = config.instanceDir.appendingPathComponent("gateway-security", isDirectory: true)
+        let cesSecurityDir = config.instanceDir.appendingPathComponent("ces-security", isDirectory: true)
+        for dir in [workspaceDir, cesBootstrapDir, gatewaySecurityDir, cesSecurityDir] {
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        }
+
+        // 4. Assemble the LinuxPod.
+        await progress("Starting containers...")
+        let vmm = VZVirtualMachineManager(kernel: kernel, initialFilesystem: initMount)
+        let pod = try LinuxPod("\(config.instanceName)-pod", vmm: vmm) { podConfig in
+            podConfig.cpus = self.config.cpus
+            podConfig.memoryInBytes = self.config.memoryInBytes
+        }
+
+        // Shared virtiofs mounts.
+        let sharedMounts: [Containerization.Mount] = [
+            .share(source: workspaceDir.path, destination: VellumMountPaths.workspace),
+            .share(source: cesBootstrapDir.path, destination: VellumMountPaths.cesBootstrap),
+        ]
+
+        // 5. Register containers.
+        let (logStream, logWriter) = Self.makeLogPipe()
+
+        // Assistant
+        let assistantEnv = VellumContainerEnv.assistant(
+            instanceName: config.instanceName,
+            signingKey: config.signingKey,
+            cesServiceToken: config.cesServiceToken
+        )
+        try await pod.addContainer(
+            containerID(.assistant), rootfs: rootfsMounts[.assistant]!
+        ) { c in
+            c.mounts = sharedMounts + LinuxContainer.defaultMounts()
+            c.process.environmentVariables = Self.buildEnv(assistantEnv)
+            c.process.stdout = logWriter
+            c.process.stderr = logWriter
+        }
+
+        // Gateway
+        let gatewayEnv = VellumContainerEnv.gateway(
+            signingKey: config.signingKey,
+            bootstrapSecret: config.bootstrapSecret,
+            cesServiceToken: config.cesServiceToken
+        )
+        try await pod.addContainer(
+            containerID(.gateway), rootfs: rootfsMounts[.gateway]!
+        ) { c in
+            c.mounts = sharedMounts + [
+                .share(source: gatewaySecurityDir.path, destination: VellumMountPaths.gatewaySecurityDir),
+            ] + LinuxContainer.defaultMounts()
+            c.process.environmentVariables = Self.buildEnv(gatewayEnv)
+        }
+
+        // Credential Executor — workspace mounted read-only to match Docker topology.
+        let cesEnv = VellumContainerEnv.credentialExecutor(
+            cesServiceToken: config.cesServiceToken
+        )
+        try await pod.addContainer(
+            containerID(.credentialExecutor), rootfs: rootfsMounts[.credentialExecutor]!
+        ) { c in
+            c.mounts = [
+                .share(source: workspaceDir.path, destination: VellumMountPaths.workspace, options: ["ro"]),
+                .share(source: cesBootstrapDir.path, destination: VellumMountPaths.cesBootstrap),
+                .share(source: cesSecurityDir.path, destination: VellumMountPaths.cesSecurityDir),
+            ] + LinuxContainer.defaultMounts()
+            c.process.environmentVariables = Self.buildEnv(cesEnv)
+        }
+
+        // 6. Create and start.
+        try await pod.create()
+        for service in VellumServiceName.startOrder {
+            try await pod.startContainer(containerID(service))
+        }
+
+        lock.withLock {
+            _pod = pod
+            _assistantLogStream = logStream
+        }
+
+        log.info("Pod started for '\(self.config.instanceName, privacy: .public)'")
+    }
+
+    /// Stops all containers and shuts down the VM.
+    func stop() async throws {
+        let pod: LinuxPod? = lock.withLock {
+            let p = _pod
+            _pod = nil
+            _assistantLogStream = nil
+            return p
+        }
+        guard let pod else { return }
+        log.info("Stopping pod for '\(self.config.instanceName, privacy: .public)'")
+        try await pod.stop()
+    }
+
+    /// The assistant container's log stream for readiness detection.
+    var assistantLogStream: AsyncStream<String>? {
+        lock.withLock { _assistantLogStream }
+    }
+
+    // MARK: - Errors
+
+    enum PodRuntimeError: LocalizedError {
+        case missingImageRef(VellumServiceName)
+
+        var errorDescription: String? {
+            switch self {
+            case .missingImageRef(let service):
+                return "No image reference provided for \(service.rawValue)."
+            }
+        }
+    }
+
+    // MARK: - Private
+
+    private func containerID(_ service: VellumServiceName) -> String {
+        "\(config.instanceName)-\(service.rawValue)"
+    }
+
+    /// Converts `[String: String]` to `["KEY=VALUE"]` with a default PATH.
+    private static func buildEnv(_ dict: [String: String]) -> [String] {
+        var entries = ["PATH=\(LinuxProcessConfiguration.defaultPath)"]
+        for (key, value) in dict {
+            entries.append("\(key)=\(value)")
+        }
+        return entries
+    }
+
+    /// Pulls an OCI image (or returns it from cache).
+    private func pullImage(
+        reference: String,
+        store: ImageStore,
+        progress: @escaping KataKernelStore.ProgressHandler
+    ) async throws -> Containerization.Image {
+        do {
+            return try await store.get(reference: reference)
+        } catch let error as ContainerizationError where error.code == .notFound {
+            await progress("Pulling \(reference)...")
+            return try await store.pull(reference: reference)
+        }
+    }
+
+    /// Unpacks an OCI image to an ext4 block device.
+    private func createRootFilesystem(
+        from image: Containerization.Image,
+        sizeInBytes: UInt64,
+        at path: URL
+    ) async throws -> Containerization.Mount {
+        do {
+            let unpacker = EXT4Unpacker(blockSizeInBytes: sizeInBytes)
+            return try await unpacker.unpack(image, for: .current, at: path)
+        } catch let error as ContainerizationError where error.code == .exists {
+            return .block(format: "ext4", source: path.path, destination: "/", options: [])
+        }
+    }
+
+    /// Creates a paired async stream + writer for streaming container log lines.
+    private static func makeLogPipe() -> (AsyncStream<String>, LineBufferedWriter) {
+        let (stream, continuation) = AsyncStream<String>.makeStream()
+        return (stream, LineBufferedWriter(continuation: continuation))
+    }
+}
+
+// MARK: - LineBufferedWriter
+
+/// A `Writer` that splits incoming data into lines and yields them to an
+/// `AsyncStream` continuation.
+final class LineBufferedWriter: Writer, @unchecked Sendable {
+    private let lock = NSLock()
+    private var buffer = ""
+    private let continuation: AsyncStream<String>.Continuation
+
+    init(continuation: AsyncStream<String>.Continuation) {
+        self.continuation = continuation
+    }
+
+    func write(_ data: Data) throws {
+        guard let text = String(data: data, encoding: .utf8) else { return }
+        lock.lock()
+        defer { lock.unlock() }
+        buffer += text
+        while let nl = buffer.firstIndex(of: "\n") {
+            let line = String(buffer[buffer.startIndex..<nl])
+            continuation.yield(line)
+            buffer = String(buffer[buffer.index(after: nl)...])
+        }
+    }
+
+    func close() throws {
+        lock.lock()
+        defer { lock.unlock() }
+        if !buffer.isEmpty {
+            continuation.yield(buffer)
+            buffer = ""
+        }
+        continuation.finish()
+    }
+}

--- a/clients/macos/vellum-assistant/AppleContainer/PodRuntime.swift
+++ b/clients/macos/vellum-assistant/AppleContainer/PodRuntime.swift
@@ -25,7 +25,7 @@ final class AppleContainersPodRuntime: @unchecked Sendable {
         var bootstrapSecret: String?
         var cesServiceToken: String?
         /// Size of the ext4 rootfs block device per service container.
-        var rootfsSizeInBytes: UInt64 = 512 * 1024 * 1024 // 512 MiB
+        var rootfsSizeInBytes: UInt64 = 2 * 1024 * 1024 * 1024 // 2 GiB
     }
 
     private let kernelStore: KataKernelStore
@@ -55,7 +55,11 @@ final class AppleContainersPodRuntime: @unchecked Sendable {
             store: imageStore, progress: progress
         )
 
-        // 2. Pull and unpack service images.
+        // 2. Create instance directory and pull/unpack service images.
+        try FileManager.default.createDirectory(
+            at: config.instanceDir, withIntermediateDirectories: true
+        )
+
         await progress("Pulling service images...")
         var rootfsMounts: [VellumServiceName: Containerization.Mount] = [:]
         for service in VellumServiceName.startOrder {
@@ -65,9 +69,9 @@ final class AppleContainersPodRuntime: @unchecked Sendable {
             let image = try await pullImage(
                 reference: ref, store: imageStore, progress: progress
             )
-            let rootfsPath = config.instanceDir
-                .appendingPathComponent(".rootfs", isDirectory: true)
-                .appendingPathComponent(service.rawValue, isDirectory: true)
+            let rootfsDir = config.instanceDir.appendingPathComponent(".rootfs", isDirectory: true)
+            try FileManager.default.createDirectory(at: rootfsDir, withIntermediateDirectories: true)
+            let rootfsPath = rootfsDir.appendingPathComponent("\(service.rawValue).ext4")
             rootfsMounts[service] = try await createRootFilesystem(
                 from: image, sizeInBytes: config.rootfsSizeInBytes, at: rootfsPath
             )

--- a/clients/macos/vellum-assistant/AppleContainer/PodRuntime.swift
+++ b/clients/macos/vellum-assistant/AppleContainer/PodRuntime.swift
@@ -63,6 +63,7 @@ final class AppleContainersPodRuntime: @unchecked Sendable {
         )
 
         var rootfsMounts: [VellumServiceName: Containerization.Mount] = [:]
+        var imageConfigs: [VellumServiceName: ContainerizationOCI.ImageConfig?] = [:]
         let rootfsDir = config.instanceDir.appendingPathComponent(".rootfs", isDirectory: true)
         try FileManager.default.createDirectory(at: rootfsDir, withIntermediateDirectories: true)
 
@@ -74,6 +75,7 @@ final class AppleContainersPodRuntime: @unchecked Sendable {
             let image = try await pullImage(
                 reference: ref, store: imageStore, progress: progress
             )
+            imageConfigs[service] = try await image.config(for: .current).config
             await progress("Unpacking \(service.rawValue) rootfs...")
             let rootfsPath = rootfsDir.appendingPathComponent("\(service.rawValue).ext4")
             rootfsMounts[service] = try await createRootFilesystem(
@@ -108,6 +110,25 @@ final class AppleContainersPodRuntime: @unchecked Sendable {
         // 5. Register containers.
         let (logStream, logWriter) = Self.makeLogPipe()
 
+        // Helper: initialize process from OCI image config, then overlay our env vars.
+        func applyProcess(
+            _ c: inout LinuxPod.ContainerConfiguration,
+            service: VellumServiceName,
+            extraEnv: [String: String]
+        ) {
+            if let imgConfig = imageConfigs[service] ?? nil {
+                c.process = LinuxProcessConfiguration(from: imgConfig)
+            }
+            // Append our env vars on top of whatever the image provides.
+            for (key, value) in extraEnv {
+                c.process.environmentVariables.append("\(key)=\(value)")
+            }
+            // Ensure PATH is set.
+            if !c.process.environmentVariables.contains(where: { $0.hasPrefix("PATH=") }) {
+                c.process.environmentVariables.append("PATH=\(LinuxProcessConfiguration.defaultPath)")
+            }
+        }
+
         // Assistant
         let assistantEnv = VellumContainerEnv.assistant(
             instanceName: config.instanceName,
@@ -117,8 +138,8 @@ final class AppleContainersPodRuntime: @unchecked Sendable {
         try await pod.addContainer(
             containerID(.assistant), rootfs: rootfsMounts[.assistant]!
         ) { c in
+            applyProcess(&c, service: .assistant, extraEnv: assistantEnv)
             c.mounts = sharedMounts + LinuxContainer.defaultMounts()
-            c.process.environmentVariables = Self.buildEnv(assistantEnv)
             c.process.stdout = logWriter
             c.process.stderr = logWriter
         }
@@ -132,10 +153,10 @@ final class AppleContainersPodRuntime: @unchecked Sendable {
         try await pod.addContainer(
             containerID(.gateway), rootfs: rootfsMounts[.gateway]!
         ) { c in
+            applyProcess(&c, service: .gateway, extraEnv: gatewayEnv)
             c.mounts = sharedMounts + [
                 .share(source: gatewaySecurityDir.path, destination: VellumMountPaths.gatewaySecurityDir),
             ] + LinuxContainer.defaultMounts()
-            c.process.environmentVariables = Self.buildEnv(gatewayEnv)
         }
 
         // Credential Executor — workspace mounted read-only to match Docker topology.
@@ -145,12 +166,12 @@ final class AppleContainersPodRuntime: @unchecked Sendable {
         try await pod.addContainer(
             containerID(.credentialExecutor), rootfs: rootfsMounts[.credentialExecutor]!
         ) { c in
+            applyProcess(&c, service: .credentialExecutor, extraEnv: cesEnv)
             c.mounts = [
                 .share(source: workspaceDir.path, destination: VellumMountPaths.workspace, options: ["ro"]),
                 .share(source: cesBootstrapDir.path, destination: VellumMountPaths.cesBootstrap),
                 .share(source: cesSecurityDir.path, destination: VellumMountPaths.cesSecurityDir),
             ] + LinuxContainer.defaultMounts()
-            c.process.environmentVariables = Self.buildEnv(cesEnv)
         }
 
         // 6. Create and start.

--- a/clients/macos/vellum-assistant/AppleContainer/PodRuntime.swift
+++ b/clients/macos/vellum-assistant/AppleContainer/PodRuntime.swift
@@ -25,7 +25,9 @@ final class AppleContainersPodRuntime: @unchecked Sendable {
         var bootstrapSecret: String?
         var cesServiceToken: String?
         /// Size of the ext4 rootfs block device per service container.
-        var rootfsSizeInBytes: UInt64 = 2 * 1024 * 1024 * 1024 // 2 GiB
+        /// Minimum size for ext4 rootfs block devices. The formatter auto-grows
+        /// to fit the actual image content; this just sets the initial allocation.
+        var rootfsSizeInBytes: UInt64 = 256 * 1024 // 256 KiB
     }
 
     private let kernelStore: KataKernelStore

--- a/clients/macos/vellum-assistant/AppleContainer/PodRuntime.swift
+++ b/clients/macos/vellum-assistant/AppleContainer/PodRuntime.swift
@@ -191,9 +191,14 @@ final class AppleContainersPodRuntime: @unchecked Sendable {
         }
 
         // 6. Create and start.
+        log.info("Creating pod VM...")
         try await pod.create()
+        log.info("Pod VM created. Starting containers...")
         for service in VellumServiceName.startOrder {
-            try await pod.startContainer(containerID(service))
+            let cid = containerID(service)
+            log.info("Starting container \(cid, privacy: .public)...")
+            try await pod.startContainer(cid)
+            log.info("Container \(cid, privacy: .public) started")
         }
 
         lock.withLock {

--- a/clients/macos/vellum-assistant/AppleContainer/PodRuntime.swift
+++ b/clients/macos/vellum-assistant/AppleContainer/PodRuntime.swift
@@ -13,6 +13,7 @@ private let log = Logger(
 ///
 /// All three services can communicate over localhost,
 /// similar to container networks in Docker or k8s sidecar.
+@available(macOS 26.0, *)
 final class AppleContainersPodRuntime: @unchecked Sendable {
 
     struct Configuration: Sendable {
@@ -36,7 +37,9 @@ final class AppleContainersPodRuntime: @unchecked Sendable {
 
     private let lock = NSLock()
     private var _pod: LinuxPod?
+    private var _network: VmnetNetwork?
     private var _assistantLogStream: AsyncStream<String>?
+    private var _gatewayURL: String?
 
     init(kernelStore: KataKernelStore, configuration: Configuration) {
         self.kernelStore = kernelStore
@@ -110,12 +113,22 @@ final class AppleContainersPodRuntime: @unchecked Sendable {
             try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         }
 
-        // 4. Assemble the LinuxPod.
+        // 4. Assemble the LinuxPod with vmnet networking.
         await progress("Starting containers...")
         let vmm = VZVirtualMachineManager(kernel: kernel, initialFilesystem: initMount)
-        let pod = try LinuxPod("\(config.instanceName)-pod", vmm: vmm) { podConfig in
+        let podID = "\(config.instanceName)-pod"
+
+        var network = try VmnetNetwork()
+        guard let interface = try network.createInterface(podID) else {
+            throw PodRuntimeError.networkSetupFailed
+        }
+        let podIP = interface.ipv4Address.address.description
+        log.info("Pod network: \(podIP, privacy: .public)")
+
+        let pod = try LinuxPod(podID, vmm: vmm) { podConfig in
             podConfig.cpus = self.config.cpus
             podConfig.memoryInBytes = self.config.memoryInBytes
+            podConfig.interfaces = [interface]
         }
 
         // Shared virtiofs mounts.
@@ -202,25 +215,34 @@ final class AppleContainersPodRuntime: @unchecked Sendable {
             log.info("Container \(cid, privacy: .public) started")
         }
 
+        let gatewayURL = "http://\(podIP):\(VellumContainerPorts.gatewayHTTP)"
         lock.withLock {
             _pod = pod
+            _network = network
             _assistantLogStream = logStream
+            _gatewayURL = gatewayURL
         }
 
-        log.info("Pod started for '\(self.config.instanceName, privacy: .public)'")
+        log.info("Pod started for '\(self.config.instanceName, privacy: .public)' at \(gatewayURL, privacy: .public)")
     }
 
     /// Stops all containers and shuts down the VM.
     func stop() async throws {
-        let pod: LinuxPod? = lock.withLock {
+        let (pod, network): (LinuxPod?, VmnetNetwork?) = lock.withLock {
             let p = _pod
+            let n = _network
             _pod = nil
+            _network = nil
             _assistantLogStream = nil
-            return p
+            _gatewayURL = nil
+            return (p, n)
         }
         guard let pod else { return }
         log.info("Stopping pod for '\(self.config.instanceName, privacy: .public)'")
         try await pod.stop()
+        if var network {
+            try? network.releaseInterface("\(config.instanceName)-pod")
+        }
     }
 
     /// The assistant container's log stream for readiness detection.
@@ -228,15 +250,23 @@ final class AppleContainersPodRuntime: @unchecked Sendable {
         lock.withLock { _assistantLogStream }
     }
 
+    /// The gateway URL reachable from the host.
+    var gatewayURL: String? {
+        lock.withLock { _gatewayURL }
+    }
+
     // MARK: - Errors
 
     enum PodRuntimeError: LocalizedError {
         case missingImageRef(VellumServiceName)
+        case networkSetupFailed
 
         var errorDescription: String? {
             switch self {
             case .missingImageRef(let service):
                 return "No image reference provided for \(service.rawValue)."
+            case .networkSetupFailed:
+                return "Failed to create vmnet network interface for pod."
             }
         }
     }

--- a/clients/macos/vellum-assistant/AppleContainer/PodRuntime.swift
+++ b/clients/macos/vellum-assistant/AppleContainer/PodRuntime.swift
@@ -25,9 +25,10 @@ final class AppleContainersPodRuntime: @unchecked Sendable {
         var bootstrapSecret: String?
         var cesServiceToken: String?
         /// Size of the ext4 rootfs block device per service container.
-        /// Minimum size for ext4 rootfs block devices. The formatter auto-grows
-        /// to fit the actual image content; this just sets the initial allocation.
-        var rootfsSizeInBytes: UInt64 = 256 * 1024 // 256 KiB
+        /// Size declared in ext4 superblock metadata. Must be >= the unpacked
+        /// image content. APFS uses sparse files so this doesn't consume real
+        /// disk space beyond what's written.
+        var rootfsSizeInBytes: UInt64 = 1024 * 1024 * 1024 // 1 GiB
     }
 
     private let kernelStore: KataKernelStore

--- a/clients/macos/vellum-assistant/AppleContainer/PodRuntime.swift
+++ b/clients/macos/vellum-assistant/AppleContainer/PodRuntime.swift
@@ -280,7 +280,29 @@ final class AppleContainersPodRuntime: @unchecked Sendable {
             let unpacker = EXT4Unpacker(blockSizeInBytes: sizeInBytes)
             return try await unpacker.unpack(image, for: .current, at: path)
         } catch let error as ContainerizationError where error.code == .exists {
-            return .block(format: "ext4", source: path.path, destination: "/", options: [])
+            // Validate the cached rootfs is actually ext4 before reusing it.
+            if Self.isValidEXT4(at: path) {
+                return .block(format: "ext4", source: path.path, destination: "/", options: [])
+            }
+            // Corrupt from a previous interrupted unpack — delete and retry.
+            log.warning("Corrupt rootfs at \(path.path, privacy: .public) — deleting and re-unpacking")
+            try? FileManager.default.removeItem(at: path)
+            let unpacker = EXT4Unpacker(blockSizeInBytes: sizeInBytes)
+            return try await unpacker.unpack(image, for: .current, at: path)
+        }
+    }
+
+    /// Quick check: ext4 superblock magic number 0xEF53 at offset 0x438.
+    private static func isValidEXT4(at path: URL) -> Bool {
+        guard let handle = try? FileHandle(forReadingFrom: path) else { return false }
+        defer { try? handle.close() }
+        do {
+            try handle.seek(toOffset: 0x438)
+            guard let data = try handle.read(upToCount: 2), data.count == 2 else { return false }
+            // ext4 magic is 0xEF53 in little-endian
+            return data[0] == 0x53 && data[1] == 0xEF
+        } catch {
+            return false
         }
     }
 

--- a/clients/macos/vellum-assistant/AppleContainer/PodRuntime.swift
+++ b/clients/macos/vellum-assistant/AppleContainer/PodRuntime.swift
@@ -62,27 +62,43 @@ final class AppleContainersPodRuntime: @unchecked Sendable {
             at: config.instanceDir, withIntermediateDirectories: true
         )
 
-        var rootfsMounts: [VellumServiceName: Containerization.Mount] = [:]
-        var imageConfigs: [VellumServiceName: ContainerizationOCI.ImageConfig?] = [:]
         let rootfsDir = config.instanceDir.appendingPathComponent(".rootfs", isDirectory: true)
         try FileManager.default.createDirectory(at: rootfsDir, withIntermediateDirectories: true)
 
-        for (i, service) in VellumServiceName.startOrder.enumerated() {
-            guard let ref = config.serviceImageRefs[service] else {
-                throw PodRuntimeError.missingImageRef(service)
+        await progress("Pulling and unpacking service images...")
+
+        let results = try await withThrowingTaskGroup(
+            of: (VellumServiceName, Containerization.Mount, ContainerizationOCI.ImageConfig?).self
+        ) { group in
+            for service in VellumServiceName.startOrder {
+                guard let ref = config.serviceImageRefs[service] else {
+                    throw PodRuntimeError.missingImageRef(service)
+                }
+                group.addTask {
+                    let image = try await self.pullImage(
+                        reference: ref, store: imageStore, progress: progress
+                    )
+                    let imgConfig = try await image.config(for: .current).config
+                    let rootfsPath = rootfsDir.appendingPathComponent("\(service.rawValue).ext4")
+                    let mount = try await self.createRootFilesystem(
+                        from: image, sizeInBytes: self.config.rootfsSizeInBytes, at: rootfsPath
+                    )
+                    await progress("\(service.rawValue) ready")
+                    return (service, mount, imgConfig)
+                }
             }
-            await progress("Pulling image \(i + 1)/\(VellumServiceName.startOrder.count): \(service.rawValue)...")
-            let image = try await pullImage(
-                reference: ref, store: imageStore, progress: progress
-            )
-            imageConfigs[service] = try await image.config(for: .current).config
-            await progress("Unpacking \(service.rawValue) rootfs...")
-            let rootfsPath = rootfsDir.appendingPathComponent("\(service.rawValue).ext4")
-            rootfsMounts[service] = try await createRootFilesystem(
-                from: image, sizeInBytes: config.rootfsSizeInBytes, at: rootfsPath
-            )
-            log.info("Rootfs ready for \(service.rawValue, privacy: .public)")
+
+            var rootfs: [VellumServiceName: Containerization.Mount] = [:]
+            var configs: [VellumServiceName: ContainerizationOCI.ImageConfig?] = [:]
+            for try await (service, mount, imgConfig) in group {
+                rootfs[service] = mount
+                configs[service] = imgConfig
+            }
+            return (rootfs, configs)
         }
+
+        let rootfsMounts = results.0
+        let imageConfigs = results.1
 
         // 3. Create host-side shared directories.
         let workspaceDir = config.instanceDir.appendingPathComponent("workspace", isDirectory: true)

--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -374,7 +374,10 @@ struct HatchingStepView: View {
                 state.hatchLogLines.append("Starting Apple Container hatch...")
                 try await launcher.hatch(
                     name: state.assistantName.isEmpty ? nil : state.assistantName,
-                    configValues: configValues
+                    configValues: configValues,
+                    progress: { message in
+                        self.state.hatchLogLines.append(message)
+                    }
                 )
                 log.info("Apple container hatch succeeded")
                 handleHatchSuccess()

--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -361,7 +361,8 @@ struct HatchingStepView: View {
     }
 
     private func startAppleContainerHatch() {
-        guard let launcher = AppDelegate.shared?.appleContainersLauncher else {
+        guard #available(macOS 26.0, *),
+              let launcher = AppDelegate.shared?.appleContainersLauncher as? AppleContainersLauncher else {
             log.error("AppleContainersLauncher not available on AppDelegate")
             state.hatchFailed = true
             return

--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -351,10 +351,39 @@ struct HatchingStepView: View {
         // Managed assistants handle daemon connection in OnboardingFlowView;
         // this view only provides the animation and failure UI.
         if state.isManagedHatch { return }
-        if isCustomHardware {
+        if state.cloudProvider == "apple-container" {
+            startAppleContainerHatch()
+        } else if isCustomHardware {
             startPairing()
         } else {
             startRemoteHatch()
+        }
+    }
+
+    private func startAppleContainerHatch() {
+        guard let launcher = AppDelegate.shared?.appleContainersLauncher else {
+            log.error("AppleContainersLauncher not available on AppDelegate")
+            state.hatchFailed = true
+            return
+        }
+
+        let configValues = buildOnboardingConfigValues()
+
+        Task {
+            do {
+                state.hatchLogLines.append("Starting Apple Container hatch...")
+                try await launcher.hatch(
+                    name: state.assistantName.isEmpty ? nil : state.assistantName,
+                    configValues: configValues
+                )
+                log.info("Apple container hatch succeeded")
+                handleHatchSuccess()
+            } catch {
+                log.error("Apple container hatch failed: \(error.localizedDescription, privacy: .public)")
+                state.hatchLogLines.append("Error: \(error.localizedDescription)")
+                failureReason = error.localizedDescription
+                state.hatchFailed = true
+            }
         }
     }
 

--- a/clients/macos/vellum-assistantTests/AppleContainersLauncherTests.swift
+++ b/clients/macos/vellum-assistantTests/AppleContainersLauncherTests.swift
@@ -5,17 +5,14 @@ import XCTest
 final class AppleContainersLauncherTests: XCTestCase {
 
     private var originalCheckAvailability: (() -> AppleContainersAvailabilityChecker.Availability)!
-    private var originalLocateBundledKernel: (() -> URL?)!
 
     override func setUp() {
         super.setUp()
         originalCheckAvailability = AppleContainersLauncher.checkAvailability
-        originalLocateBundledKernel = AppleContainersLauncher.locateBundledKernel
     }
 
     override func tearDown() {
         AppleContainersLauncher.checkAvailability = originalCheckAvailability
-        AppleContainersLauncher.locateBundledKernel = originalLocateBundledKernel
         super.tearDown()
     }
 
@@ -23,96 +20,130 @@ final class AppleContainersLauncherTests: XCTestCase {
 
     func testHatchThrowsWhenFeatureFlagDisabled() async {
         AppleContainersLauncher.checkAvailability = { .unavailable(.featureFlagDisabled) }
-
         let launcher = AppleContainersLauncher()
         do {
             try await launcher.hatch(name: "test", configValues: [:])
-            XCTFail("Expected hatch to throw when feature flag is disabled")
+            XCTFail("Expected throw")
         } catch let error as AppleContainersLauncher.LauncherError {
-            if case .unavailable(.featureFlagDisabled) = error {
-                // expected
-            } else {
-                XCTFail("Expected .unavailable(.featureFlagDisabled), got \(error)")
+            if case .unavailable(.featureFlagDisabled) = error {} else {
+                XCTFail("Expected .featureFlagDisabled, got \(error)")
             }
         } catch {
-            XCTFail("Unexpected error type: \(error)")
+            XCTFail("Unexpected error: \(error)")
         }
     }
 
     func testHatchThrowsWhenOSUnsupported() async {
         AppleContainersLauncher.checkAvailability = { .unavailable(.unsupportedOS) }
-
         let launcher = AppleContainersLauncher()
         do {
             try await launcher.hatch(name: "test", configValues: [:])
-            XCTFail("Expected hatch to throw when OS is unsupported")
+            XCTFail("Expected throw")
         } catch let error as AppleContainersLauncher.LauncherError {
-            if case .unavailable(.unsupportedOS) = error {
-                // expected
-            } else {
-                XCTFail("Expected .unavailable(.unsupportedOS), got \(error)")
+            if case .unavailable(.unsupportedOS) = error {} else {
+                XCTFail("Expected .unsupportedOS, got \(error)")
             }
         } catch {
-            XCTFail("Unexpected error type: \(error)")
+            XCTFail("Unexpected error: \(error)")
         }
     }
 
     func testHatchThrowsWhenHardwareUnsupported() async {
         AppleContainersLauncher.checkAvailability = { .unavailable(.unsupportedHardware) }
-
         let launcher = AppleContainersLauncher()
         do {
             try await launcher.hatch(name: "test", configValues: [:])
-            XCTFail("Expected hatch to throw when hardware is unsupported")
+            XCTFail("Expected throw")
         } catch let error as AppleContainersLauncher.LauncherError {
-            if case .unavailable(.unsupportedHardware) = error {
-                // expected
-            } else {
-                XCTFail("Expected .unavailable(.unsupportedHardware), got \(error)")
+            if case .unavailable(.unsupportedHardware) = error {} else {
+                XCTFail("Expected .unsupportedHardware, got \(error)")
             }
         } catch {
-            XCTFail("Unexpected error type: \(error)")
-        }
-    }
-
-    // MARK: - Kernel not found
-
-    func testHatchThrowsWhenKernelNotFound() async {
-        AppleContainersLauncher.checkAvailability = { .available }
-        AppleContainersLauncher.locateBundledKernel = { nil }
-
-        let launcher = AppleContainersLauncher()
-        do {
-            try await launcher.hatch(name: "test", configValues: [:])
-            XCTFail("Expected hatch to throw when kernel is not found")
-        } catch let error as AppleContainersLauncher.LauncherError {
-            if case .kernelNotFound = error {
-                // expected
-            } else {
-                XCTFail("Expected .kernelNotFound, got \(error)")
-            }
-        } catch {
-            XCTFail("Unexpected error type: \(error)")
+            XCTFail("Unexpected error: \(error)")
         }
     }
 
     // MARK: - Error descriptions
 
     func testErrorDescriptions() {
-        let featureFlagError = AppleContainersLauncher.LauncherError.unavailable(.featureFlagDisabled)
-        XCTAssertTrue(featureFlagError.errorDescription?.contains("feature flag") == true)
+        XCTAssertTrue(
+            AppleContainersLauncher.LauncherError.unavailable(.featureFlagDisabled)
+                .errorDescription!.contains("feature flag")
+        )
+        XCTAssertTrue(
+            AppleContainersLauncher.LauncherError.unavailable(.unsupportedOS)
+                .errorDescription!.contains("macOS 26")
+        )
+        XCTAssertTrue(
+            AppleContainersLauncher.LauncherError.unavailable(.unsupportedHardware)
+                .errorDescription!.contains("ARM64")
+        )
+        XCTAssertTrue(
+            AppleContainersLauncher.LauncherError.hatchFailed("boom")
+                .errorDescription!.contains("boom")
+        )
+    }
 
-        let osError = AppleContainersLauncher.LauncherError.unavailable(.unsupportedOS)
-        XCTAssertTrue(osError.errorDescription?.contains("macOS 26") == true)
+    // MARK: - Lockfile
 
-        let hardwareError = AppleContainersLauncher.LauncherError.unavailable(.unsupportedHardware)
-        XCTAssertTrue(hardwareError.errorDescription?.contains("ARM64") == true)
+    func testWriteLockfileEntryCreatesNewEntry() throws {
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("launcher-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
 
-        let kernelError = AppleContainersLauncher.LauncherError.kernelNotFound
-        XCTAssertTrue(kernelError.errorDescription?.contains("kernel") == true)
+        let lockfilePath = tmpDir.appendingPathComponent(".vellum.lock.json").path
 
-        let hatchError = AppleContainersLauncher.LauncherError.hatchFailed("container crashed")
-        XCTAssertTrue(hatchError.errorDescription?.contains("container crashed") == true)
+        let result = AppleContainersLauncher.writeLockfileEntry(
+            assistantId: "test-ac",
+            hatchedAt: "2026-01-01T00:00:00Z",
+            signingKey: "abc123",
+            lockfilePath: lockfilePath
+        )
+        XCTAssertTrue(result)
+
+        let data = try Data(contentsOf: URL(fileURLWithPath: lockfilePath))
+        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        let assistants = json["assistants"] as! [[String: Any]]
+        XCTAssertEqual(assistants.count, 1)
+        XCTAssertEqual(assistants[0]["assistantId"] as? String, "test-ac")
+        XCTAssertEqual(assistants[0]["cloud"] as? String, "apple-container")
+        XCTAssertEqual(assistants[0]["runtimeBackend"] as? String, "apple-containers")
+        let resources = assistants[0]["resources"] as? [String: Any]
+        XCTAssertEqual(resources?["signingKey"] as? String, "abc123")
+    }
+
+    func testWriteLockfileEntryUpdatesExisting() throws {
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("launcher-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let lockfilePath = tmpDir.appendingPathComponent(".vellum.lock.json").path
+
+        // Write initial entry
+        AppleContainersLauncher.writeLockfileEntry(
+            assistantId: "test-ac",
+            hatchedAt: "2026-01-01T00:00:00Z",
+            signingKey: "old-key",
+            lockfilePath: lockfilePath
+        )
+
+        // Overwrite
+        AppleContainersLauncher.writeLockfileEntry(
+            assistantId: "test-ac",
+            hatchedAt: "2026-02-01T00:00:00Z",
+            signingKey: "new-key",
+            lockfilePath: lockfilePath
+        )
+
+        let data = try Data(contentsOf: URL(fileURLWithPath: lockfilePath))
+        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        let assistants = json["assistants"] as! [[String: Any]]
+        XCTAssertEqual(assistants.count, 1)
+        XCTAssertEqual(assistants[0]["hatchedAt"] as? String, "2026-02-01T00:00:00Z")
+        let resources = assistants[0]["resources"] as? [String: Any]
+        XCTAssertEqual(resources?["signingKey"] as? String, "new-key")
     }
 
     // MARK: - Protocol conformance

--- a/clients/macos/vellum-assistantTests/LockfileAssistantAppleContainerTests.swift
+++ b/clients/macos/vellum-assistantTests/LockfileAssistantAppleContainerTests.swift
@@ -25,6 +25,7 @@ final class LockfileAssistantAppleContainerTests: XCTestCase {
         let result = AppleContainersLauncher.writeLockfileEntry(
             assistantId: "ac-test",
             hatchedAt: "2025-06-01T00:00:00Z",
+            signingKey: "key1",
             lockfilePath: lockfilePath
         )
         XCTAssertTrue(result)
@@ -35,7 +36,10 @@ final class LockfileAssistantAppleContainerTests: XCTestCase {
         XCTAssertEqual(assistants.count, 1)
         XCTAssertEqual(assistants[0]["assistantId"] as? String, "ac-test")
         XCTAssertEqual(assistants[0]["cloud"] as? String, "apple-container")
+        XCTAssertEqual(assistants[0]["runtimeBackend"] as? String, "apple-containers")
         XCTAssertEqual(assistants[0]["hatchedAt"] as? String, "2025-06-01T00:00:00Z")
+        let resources = assistants[0]["resources"] as? [String: Any]
+        XCTAssertEqual(resources?["signingKey"] as? String, "key1")
     }
 
     func testInsertsIntoEmptyLockfile() {
@@ -46,6 +50,7 @@ final class LockfileAssistantAppleContainerTests: XCTestCase {
         let result = AppleContainersLauncher.writeLockfileEntry(
             assistantId: "ac-new",
             hatchedAt: "2025-07-01T00:00:00Z",
+            signingKey: "key2",
             lockfilePath: lockfilePath
         )
         XCTAssertTrue(result)
@@ -59,34 +64,29 @@ final class LockfileAssistantAppleContainerTests: XCTestCase {
 
     // MARK: - writeLockfileEntry: update existing entry
 
-    func testUpdatesCloudOnExistingEntry() {
-        // Pre-populate with a local entry that has the same ID.
-        let existing: [String: Any] = [
-            "assistants": [
-                [
-                    "assistantId": "ac-test",
-                    "cloud": "local",
-                    "hatchedAt": "2025-01-01T00:00:00Z",
-                ] as [String: Any],
-            ]
-        ]
-        let data = try! JSONSerialization.data(withJSONObject: existing)
-        try! data.write(to: URL(fileURLWithPath: lockfilePath))
-
-        let result = AppleContainersLauncher.writeLockfileEntry(
+    func testUpdatesExistingEntry() {
+        AppleContainersLauncher.writeLockfileEntry(
             assistantId: "ac-test",
-            hatchedAt: "2025-06-01T00:00:00Z",
+            hatchedAt: "2025-01-01T00:00:00Z",
+            signingKey: "old-key",
             lockfilePath: lockfilePath
         )
-        XCTAssertTrue(result)
+
+        AppleContainersLauncher.writeLockfileEntry(
+            assistantId: "ac-test",
+            hatchedAt: "2025-06-01T00:00:00Z",
+            signingKey: "new-key",
+            lockfilePath: lockfilePath
+        )
 
         let readData = try! Data(contentsOf: URL(fileURLWithPath: lockfilePath))
         let json = try! JSONSerialization.jsonObject(with: readData) as! [String: Any]
         let assistants = json["assistants"] as! [[String: Any]]
         XCTAssertEqual(assistants.count, 1)
         XCTAssertEqual(assistants[0]["cloud"] as? String, "apple-container")
-        // Original hatchedAt should be preserved.
-        XCTAssertEqual(assistants[0]["hatchedAt"] as? String, "2025-01-01T00:00:00Z")
+        XCTAssertEqual(assistants[0]["hatchedAt"] as? String, "2025-06-01T00:00:00Z")
+        let resources = assistants[0]["resources"] as? [String: Any]
+        XCTAssertEqual(resources?["signingKey"] as? String, "new-key")
     }
 
     // MARK: - writeLockfileEntry: preserves other entries
@@ -107,6 +107,7 @@ final class LockfileAssistantAppleContainerTests: XCTestCase {
         AppleContainersLauncher.writeLockfileEntry(
             assistantId: "ac-id",
             hatchedAt: "2025-06-01T00:00:00Z",
+            signingKey: "key3",
             lockfilePath: lockfilePath
         )
 
@@ -129,40 +130,13 @@ final class LockfileAssistantAppleContainerTests: XCTestCase {
         AppleContainersLauncher.writeLockfileEntry(
             assistantId: "ac-test",
             hatchedAt: "2025-06-01T00:00:00Z",
+            signingKey: "key4",
             lockfilePath: lockfilePath
         )
 
         let readData = try! Data(contentsOf: URL(fileURLWithPath: lockfilePath))
         let json = try! JSONSerialization.jsonObject(with: readData) as! [String: Any]
         XCTAssertEqual(json["version"] as? Int, 1)
-    }
-
-    // MARK: - writeLockfileEntry: no-op when unchanged
-
-    func testNoOpWhenEntryAlreadyCorrect() {
-        AppleContainersLauncher.writeLockfileEntry(
-            assistantId: "ac-test",
-            hatchedAt: "2025-06-01T00:00:00Z",
-            lockfilePath: lockfilePath
-        )
-
-        // Get file modification time.
-        let attrs1 = try! FileManager.default.attributesOfItem(atPath: lockfilePath)
-        let date1 = attrs1[.modificationDate] as! Date
-
-        // Small sleep to ensure a different modification time if the file were rewritten.
-        Thread.sleep(forTimeInterval: 0.05)
-
-        let result = AppleContainersLauncher.writeLockfileEntry(
-            assistantId: "ac-test",
-            hatchedAt: "2025-07-01T00:00:00Z",
-            lockfilePath: lockfilePath
-        )
-        XCTAssertTrue(result)
-
-        let attrs2 = try! FileManager.default.attributesOfItem(atPath: lockfilePath)
-        let date2 = attrs2[.modificationDate] as! Date
-        XCTAssertEqual(date1, date2, "File should not be rewritten when entry is unchanged")
     }
 
     // MARK: - isAppleContainer property

--- a/clients/macos/vellum-assistantTests/PodRuntimeTests.swift
+++ b/clients/macos/vellum-assistantTests/PodRuntimeTests.swift
@@ -1,0 +1,96 @@
+import XCTest
+@testable import VellumAssistantLib
+
+final class PodRuntimeTests: XCTestCase {
+
+    // MARK: - Configuration defaults
+
+    func testDefaultConfigurationValues() {
+        let config = AppleContainersPodRuntime.Configuration(
+            instanceName: "test",
+            serviceImageRefs: [
+                .assistant: "vellumai/vellum-assistant:latest",
+                .gateway: "vellumai/vellum-gateway:latest",
+                .credentialExecutor: "vellumai/vellum-credential-executor:latest",
+            ],
+            instanceDir: URL(fileURLWithPath: "/tmp/test"),
+            signingKey: "abc123"
+        )
+        XCTAssertEqual(config.cpus, 4)
+        XCTAssertEqual(config.memoryInBytes, 2 * 1024 * 1024 * 1024)
+        XCTAssertEqual(config.rootfsSizeInBytes, 512 * 1024 * 1024)
+        XCTAssertNil(config.bootstrapSecret)
+        XCTAssertNil(config.cesServiceToken)
+    }
+
+    // MARK: - Missing image ref
+
+    func testMissingImageRefErrorDescription() {
+        let error = AppleContainersPodRuntime.PodRuntimeError.missingImageRef(.gateway)
+        XCTAssertTrue(error.errorDescription!.contains("vellum-gateway"))
+    }
+
+    // MARK: - LineBufferedWriter
+
+    func testLineBufferedWriterSplitsLines() throws {
+        var received: [String] = []
+        let (stream, continuation) = AsyncStream<String>.makeStream()
+        let writer = LineBufferedWriter(continuation: continuation)
+
+        try writer.write(Data("hello\nworld\n".utf8))
+        try writer.close()
+
+        let expectation = expectation(description: "stream")
+        Task {
+            for await line in stream {
+                received.append(line)
+            }
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1)
+
+        XCTAssertEqual(received, ["hello", "world"])
+    }
+
+    func testLineBufferedWriterFlushesPartialLine() throws {
+        var received: [String] = []
+        let (stream, continuation) = AsyncStream<String>.makeStream()
+        let writer = LineBufferedWriter(continuation: continuation)
+
+        try writer.write(Data("no newline".utf8))
+        try writer.close()
+
+        let expectation = expectation(description: "stream")
+        Task {
+            for await line in stream {
+                received.append(line)
+            }
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1)
+
+        XCTAssertEqual(received, ["no newline"])
+    }
+
+    func testLineBufferedWriterHandlesMultipleWrites() throws {
+        var received: [String] = []
+        let (stream, continuation) = AsyncStream<String>.makeStream()
+        let writer = LineBufferedWriter(continuation: continuation)
+
+        try writer.write(Data("hel".utf8))
+        try writer.write(Data("lo\nwor".utf8))
+        try writer.write(Data("ld\n".utf8))
+        try writer.close()
+
+        let expectation = expectation(description: "stream")
+        Task {
+            for await line in stream {
+                received.append(line)
+            }
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1)
+
+        XCTAssertEqual(received, ["hello", "world"])
+    }
+}


### PR DESCRIPTION
## Context
building off https://github.com/vellum-ai/vellum-assistant/pull/18020 with some simplifications because we can assume macOS 15+ for all users, and can restrict to macOS 26+ ffor apple containers option

Roughly,
1. Spin up a LinuxPod to run 3 containers on the same machine. This API is experimental, but networking topology matches more closely with desired end state. Maybe container networking will be supported first class in the future.
2. Rewire hatch launcher to use service above

## Known gaps + issues
1. We're just pulling and running the latest images. Should pin to specific version in production, and support local builds for dev.
2. Unpacking the images to ext4 block is VERY slow. Took ~5 minutes for the assistant runtime image (2GB) in local dev.
    a. This isn't acceptable for development or for end users. Hoping this is because I was using an unoptimized debug build of the app.
    b. Downloading the image is also very slow which sucks for end users. Took ~10-20s for me.
    c. I downloaded the image and then used CLI `container run`. This only took 3s to start up for the first time (which included unpacking the ext4 block)
3. In current state, the pod spins up correctly.
    In my terminal I can ping the gateway on its health endpoint via apple container IP: `192.168.64.2:7830`, which I persist in the lockfile.
    But client <> gateway interaction is still busted.
    a. Need to double check desktop app's ability to even reach the pod -- review `NSAllowsLocalNetworking` + `NSExceptionDomains` sections in build script
    b. Possible race condition in hatch flow between pod readiness and attempted bootstrap
    c. Pod is killed and recreated if the app restarts. Need to update the IP in lockfile each time this 

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24434" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
