### PR TITLE
feat(macOS): add labeled YOUR GROUPS divider in sidebar

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -608,13 +608,16 @@ extension MainWindowView {
         HStack(spacing: VSpacing.sm) {
             VColor.surfaceActive
                 .frame(height: 1)
+                .accessibilityHidden(true)
             Text(label)
                 .font(VFont.labelSmall)
                 .foregroundStyle(VColor.contentTertiary)
                 .tracking(1.2)
                 .fixedSize()
+                .accessibilityAddTraits(.isHeader)
             VColor.surfaceActive
                 .frame(height: 1)
+                .accessibilityHidden(true)
         }
         .padding(.vertical, VSpacing.sm)
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -280,8 +280,19 @@ extension MainWindowView {
             }
 
             let groupEntries = conversationManager.sidebarGroupEntries
-            ForEach(groupEntries) { entry in
+            let systemEntries = groupEntries.filter { $0.group.isSystemGroup }
+            let customEntries = groupEntries.filter { !$0.group.isSystemGroup }
+
+            ForEach(systemEntries) { entry in
                 makeSectionView(group: entry.group, conversations: entry.conversations)
+            }
+
+            if !customEntries.isEmpty {
+                sidebarLabeledDivider(label: "YOUR GROUPS")
+
+                ForEach(customEntries) { entry in
+                    makeSectionView(group: entry.group, conversations: entry.conversations)
+                }
             }
 
             // Pagination fallback sentinel: when every section fits within its
@@ -590,6 +601,22 @@ extension MainWindowView {
         VColor.surfaceActive
             .frame(height: 1)
             .padding(.vertical, SidebarLayoutMetrics.dividerVerticalPadding)
+    }
+
+    @ViewBuilder
+    func sidebarLabeledDivider(label: String) -> some View {
+        HStack(spacing: VSpacing.sm) {
+            VColor.surfaceActive
+                .frame(height: 1)
+            Text(label)
+                .font(VFont.labelSmall)
+                .foregroundStyle(VColor.contentTertiary)
+                .tracking(1.2)
+                .fixedSize()
+            VColor.surfaceActive
+                .frame(height: 1)
+        }
+        .padding(.vertical, VSpacing.sm)
     }
 
     // MARK: - App View Helpers


### PR DESCRIPTION
## Summary
- Adds a labeled "YOUR GROUPS" divider between system groups (Pinned, Scheduled, Background, Recents) and custom user groups in the sidebar
- Uses existing design tokens (`VColor.surfaceActive`, `VFont.labelSmall`, `VColor.contentTertiary`) for consistency
- Naturally gated behind the `conversation-groups-ui` feature flag — divider only renders when custom groups exist

## Test plan
- [ ] Enable `conversation-groups-ui` feature flag
- [ ] Create at least one custom group
- [ ] Verify "YOUR GROUPS" labeled divider appears between Recents and custom groups
- [ ] Verify divider does not appear when no custom groups exist
- [ ] Verify divider does not appear when feature flag is disabled
- [ ] Check light and dark mode rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24436" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
