### PR TITLE
fix(feature-flags): scope multi-platform-assistant as assistant flag

### DIFF
--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -179,7 +179,7 @@
     },
     {
       "id": "multi-platform-assistant",
-      "scope": "macos",
+      "scope": "assistant",
       "key": "multi-platform-assistant",
       "label": "Multi-Platform Assistant Switcher",
       "description": "Enable the menu-bar assistant switcher for managing multiple platform-hosted assistants (new/switch/retire)",


### PR DESCRIPTION
## Summary
- The `multi-platform-assistant` flag was registered with `scope: "macos"`, which routes it through the macOS-only client store. The gateway filters out non-assistant-scope flags in `gateway/src/feature-flag-defaults.ts` and never serves it, so the existing `featureFlagStore.isEnabled(...)` and `AssistantFeatureFlagResolver.isEnabled(...)` call sites couldn't find the key in their registry defaults and fell through to the unknown-key default of `true` — silently enabling the feature for everyone.
- The flag is already declared as an assistant-tagged flag in the `vellum-assistant-platform` infra repo, so the registry scope was the side that was wrong.
- Switching to `scope: "assistant"` makes the gateway register it with `defaultEnabled: false` and serve it through the per-assistant feature-flag endpoint. The feature is now off by default and can be enabled per-account via the platform's existing assistant feature-flag rollout mechanism. The existing call sites need no code change — they already read through the assistant-scope readers, which will now find the key in `registryDefaults`.

## Test plan
- [ ] Launch a clean build with no platform overrides — assistant switcher menu does not appear
- [ ] Enable the flag for a test account in the platform feature-flag system, relaunch — switcher appears for that account only
- [ ] Verify `ManagedAssistantConnectionCoordinator` gating matches the menu state
- [ ] Confirm gateway logs show `multi-platform-assistant` in the assistant feature-flag response

## Rollout
1. Merge this PR and ship a build.
2. Enable the flag for internal QA accounts in the platform feature-flag system.
3. Once verified, expand to design partners / beta customers.
4. Gradually roll out to all customers; kill-switch via the same dashboard if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)