### PR TITLE
feat(memory): reclaim orphaned embed workers on startup

### DIFF
--- a/assistant/src/memory/embedding-local.ts
+++ b/assistant/src/memory/embedding-local.ts
@@ -481,8 +481,13 @@ export class LocalEmbeddingBackend implements EmbeddingBackend {
    */
   private isOurEmbedWorker(pid: number, workerPath: string): boolean {
     try {
+      // `-ww` disables column-width truncation. Without it, macOS `ps` clips
+      // the command field to the terminal width, which can cut off the
+      // workerPath argument and cause this check to spuriously return false
+      // for genuine orphans. Same flag is used by daemon-control.ts:123 for
+      // exactly this reason.
       const result = Bun.spawnSync({
-        cmd: ["ps", "-p", String(pid), "-o", "command="],
+        cmd: ["ps", "-ww", "-p", String(pid), "-o", "command="],
         stdout: "pipe",
         stderr: "ignore",
       });

--- a/assistant/src/memory/embedding-local.ts
+++ b/assistant/src/memory/embedding-local.ts
@@ -225,7 +225,7 @@ export class LocalEmbeddingBackend implements EmbeddingBackend {
     // (e.g. one that crashed without cleanup) may still be running and
     // holding the workspace's PID file. Detect and reclaim it before
     // spawning so we never leave duplicate workers eating CPU/memory.
-    this.reclaimStaleWorker();
+    this.reclaimStaleWorker(workerPath);
 
     log.info(
       { bunPath, workerPath, model: this.model },
@@ -470,15 +470,16 @@ export class LocalEmbeddingBackend implements EmbeddingBackend {
   }
 
   /**
-   * Verify a PID looks like one of our embed workers before sending signals
-   * to it — defends against PID-reuse killing an unrelated process if the
+   * Verify a PID belongs to this workspace's embed worker before sending
+   * signals — defends against PID reuse killing an unrelated process if the
    * original worker exited and the OS recycled the PID.
    *
-   * The generated worker script sets `process.title = 'embed-worker'` and is
-   * always invoked via the `embed-worker.mjs` path under
-   * `~/.vellum/workspace/embedding-models/`, so either marker is conclusive.
+   * Matching `embed-worker` alone would also match a sibling assistant
+   * instance's worker (different VELLUM_WORKSPACE_DIR), so we match against
+   * the absolute worker script path, which lives under THIS workspace's
+   * embedding-models directory and is therefore unique per instance.
    */
-  private isLikelyEmbedWorker(pid: number): boolean {
+  private isOurEmbedWorker(pid: number, workerPath: string): boolean {
     try {
       const result = Bun.spawnSync({
         cmd: ["ps", "-p", String(pid), "-o", "command="],
@@ -488,7 +489,7 @@ export class LocalEmbeddingBackend implements EmbeddingBackend {
       if (result.exitCode !== 0) return false;
       const cmd = new TextDecoder().decode(result.stdout).trim();
       if (!cmd) return false;
-      return cmd.includes("embed-worker");
+      return cmd.includes(workerPath);
     } catch {
       return false;
     }
@@ -500,9 +501,10 @@ export class LocalEmbeddingBackend implements EmbeddingBackend {
    * so we never end up with duplicate workers competing for the same workspace.
    *
    * Stale PID files (process no longer exists) are silently cleaned up.
-   * PIDs that have been recycled to unrelated processes are left untouched.
+   * PIDs that have been recycled to unrelated processes — including embed
+   * workers belonging to *other* assistant instances — are left untouched.
    */
-  private reclaimStaleWorker(): void {
+  private reclaimStaleWorker(workerPath: string): void {
     const pid = this.readPidFile();
     if (pid == null) return;
 
@@ -531,13 +533,14 @@ export class LocalEmbeddingBackend implements EmbeddingBackend {
       return;
     }
 
-    if (!this.isLikelyEmbedWorker(pid)) {
-      // PID points to something that isn't ours (likely PID reuse after a
-      // prior worker exited). Don't kill an unrelated process — just drop
-      // the stale file and let the new worker take over the slot.
+    if (!this.isOurEmbedWorker(pid, workerPath)) {
+      // PID points to something that isn't this workspace's embed worker —
+      // either an unrelated process (PID reuse after the original worker
+      // exited) or another assistant instance's worker. Either way, don't
+      // signal it; just drop the stale file so the new worker can claim it.
       log.warn(
         { pid, model: this.model },
-        "PID file points to a non-embed-worker process; clearing without killing",
+        "PID file points to a process that is not this workspace's embed worker; clearing without killing",
       );
       this.removePidFile();
       return;

--- a/assistant/src/memory/embedding-local.ts
+++ b/assistant/src/memory/embedding-local.ts
@@ -1,4 +1,10 @@
-import { existsSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  readFileSync,
+  rmSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 
 import { getIsContainerized } from "../config/env-registry.js";
@@ -214,6 +220,12 @@ export class LocalEmbeddingBackend implements EmbeddingBackend {
   ): Promise<void> {
     const embeddingModelsDir = getEmbeddingModelsDir();
     const modelCacheDir = `${embeddingModelsDir}/model-cache`;
+
+    // Singleton guard: an orphaned embed worker from a previous daemon
+    // (e.g. one that crashed without cleanup) may still be running and
+    // holding the workspace's PID file. Detect and reclaim it before
+    // spawning so we never leave duplicate workers eating CPU/memory.
+    this.reclaimStaleWorker();
 
     log.info(
       { bunPath, workerPath, model: this.model },
@@ -443,6 +455,104 @@ export class LocalEmbeddingBackend implements EmbeddingBackend {
     } catch {
       // Best-effort
     }
+  }
+
+  /** Read the PID from the on-disk PID file, or null if missing/invalid. */
+  private readPidFile(): number | null {
+    const path = this.getPidFilePath();
+    if (!existsSync(path)) return null;
+    try {
+      const pid = parseInt(readFileSync(path, "utf-8").trim(), 10);
+      return Number.isFinite(pid) && pid > 0 ? pid : null;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Verify a PID looks like one of our embed workers before sending signals
+   * to it — defends against PID-reuse killing an unrelated process if the
+   * original worker exited and the OS recycled the PID.
+   *
+   * The generated worker script sets `process.title = 'embed-worker'` and is
+   * always invoked via the `embed-worker.mjs` path under
+   * `~/.vellum/workspace/embedding-models/`, so either marker is conclusive.
+   */
+  private isLikelyEmbedWorker(pid: number): boolean {
+    try {
+      const result = Bun.spawnSync({
+        cmd: ["ps", "-p", String(pid), "-o", "command="],
+        stdout: "pipe",
+        stderr: "ignore",
+      });
+      if (result.exitCode !== 0) return false;
+      const cmd = new TextDecoder().decode(result.stdout).trim();
+      if (!cmd) return false;
+      return cmd.includes("embed-worker");
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * If a previous embed worker is still running for this workspace (orphaned
+   * by a crashed daemon, for example), terminate it before spawning a new one
+   * so we never end up with duplicate workers competing for the same workspace.
+   *
+   * Stale PID files (process no longer exists) are silently cleaned up.
+   * PIDs that have been recycled to unrelated processes are left untouched.
+   */
+  private reclaimStaleWorker(): void {
+    const pid = this.readPidFile();
+    if (pid == null) return;
+
+    // Never signal ourselves — should not happen since the worker is a child
+    // process, but guard against logic bugs that would deadlock the daemon.
+    if (pid === process.pid) {
+      this.removePidFile();
+      return;
+    }
+
+    let isAlive = false;
+    try {
+      // Signal 0 just probes for liveness without delivering a signal.
+      process.kill(pid, 0);
+      isAlive = true;
+    } catch {
+      // ESRCH — no such process. PID file is stale.
+    }
+
+    if (!isAlive) {
+      log.info(
+        { pid, model: this.model },
+        "Removing stale embed worker PID file (process no longer exists)",
+      );
+      this.removePidFile();
+      return;
+    }
+
+    if (!this.isLikelyEmbedWorker(pid)) {
+      // PID points to something that isn't ours (likely PID reuse after a
+      // prior worker exited). Don't kill an unrelated process — just drop
+      // the stale file and let the new worker take over the slot.
+      log.warn(
+        { pid, model: this.model },
+        "PID file points to a non-embed-worker process; clearing without killing",
+      );
+      this.removePidFile();
+      return;
+    }
+
+    log.warn(
+      { pid, model: this.model },
+      "Found orphaned embed worker from a previous daemon, terminating it",
+    );
+    try {
+      process.kill(pid, "SIGTERM");
+    } catch {
+      // Race: it exited between the liveness check and the kill — fine.
+    }
+    this.removePidFile();
   }
 
   private disposeIfIdle(): void {


### PR DESCRIPTION
## Summary
- Adds a singleton guard to `LocalEmbeddingBackend.startWorker()` that detects an orphaned embed worker (e.g. one left behind by a crashed daemon) via the existing workspace-scoped PID file and SIGTERMs it before spawning a fresh worker — so we never end up with duplicates competing over the same workspace.
- Verifies the PID belongs to an embed worker (via `ps -p <pid> -o command=` matching the `embed-worker` title/script path) before sending any signals, defending against PID reuse killing an unrelated process.
- Stays multi-instance safe: the PID path is already scoped via `getEmbedWorkerPidPath()` (which honors `VELLUM_WORKSPACE_DIR` and the containerized `/tmp` override), so each daemon only reclaims workers from its own workspace.

## Original prompt
can you make sure theres no way duplicate embed workers can get created like do a check on startup of the embed worker or something smart
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24438" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
