### PR TITLE
refactor: unify transport host env around supportsHostProxy

### DIFF
--- a/assistant/src/__tests__/conversation-workspace-cache-state.test.ts
+++ b/assistant/src/__tests__/conversation-workspace-cache-state.test.ts
@@ -338,6 +338,130 @@ describe("Conversation workspace cache state", () => {
     expect(block!).not.toContain("Host username: alice");
   });
 
+  // -------------------------------------------------------------------------
+  // applyHostEnvFromTransport — capability-gated setter
+  // -------------------------------------------------------------------------
+
+  test("applyHostEnvFromTransport populates fields for host-proxy transports", () => {
+    conversation.applyHostEnvFromTransport({
+      channelId: "vellum",
+      interfaceId: "macos",
+      hostHomeDir: "/Users/alice",
+      hostUsername: "alice",
+    });
+
+    expect(conversation.hostHomeDir).toBe("/Users/alice");
+    expect(conversation.hostUsername).toBe("alice");
+    expect(conversation.isWorkspaceTopLevelDirty()).toBe(true);
+
+    conversation.refreshWorkspaceTopLevelContextIfNeeded();
+    const block = conversation.getWorkspaceTopLevelContext();
+    expect(block!).toContain("Host home directory: /Users/alice");
+    expect(block!).toContain("Host username: alice");
+  });
+
+  test("applyHostEnvFromTransport clears fields for non-host-proxy transports", () => {
+    // Seed with a host-proxy turn.
+    conversation.applyHostEnvFromTransport({
+      channelId: "vellum",
+      interfaceId: "macos",
+      hostHomeDir: "/Users/alice",
+      hostUsername: "alice",
+    });
+    expect(conversation.hostHomeDir).toBe("/Users/alice");
+
+    // Apply a non-host-proxy transport — should clear the stored values so
+    // the next render doesn't leak them from a cross-interface reuse.
+    conversation.applyHostEnvFromTransport({
+      channelId: "vellum",
+      interfaceId: "ios",
+    });
+
+    expect(conversation.hostHomeDir).toBeUndefined();
+    expect(conversation.hostUsername).toBeUndefined();
+    expect(conversation.isWorkspaceTopLevelDirty()).toBe(true);
+  });
+
+  test("applyHostEnvFromTransport clears fields for chrome-extension (browser-only)", () => {
+    // chrome-extension supports only host_browser — the no-arg supportsHostProxy
+    // returns false for it, so the gate treats it as a non-host-proxy transport
+    // for the purposes of host env (no local filesystem to address).
+    conversation.applyHostEnvFromTransport({
+      channelId: "vellum",
+      interfaceId: "macos",
+      hostHomeDir: "/Users/alice",
+      hostUsername: "alice",
+    });
+
+    conversation.applyHostEnvFromTransport({
+      channelId: "vellum",
+      interfaceId: "chrome-extension",
+    });
+
+    expect(conversation.hostHomeDir).toBeUndefined();
+    expect(conversation.hostUsername).toBeUndefined();
+  });
+
+  test("applyHostEnvFromTransport handles transport with no interfaceId", () => {
+    // Seed and then apply a transport without an interfaceId (legacy/channel
+    // paths may omit it). The gate should clear any stored host env.
+    conversation.applyHostEnvFromTransport({
+      channelId: "vellum",
+      interfaceId: "macos",
+      hostHomeDir: "/Users/alice",
+      hostUsername: "alice",
+    });
+
+    conversation.applyHostEnvFromTransport({
+      channelId: "vellum",
+    });
+
+    expect(conversation.hostHomeDir).toBeUndefined();
+    expect(conversation.hostUsername).toBeUndefined();
+  });
+
+  test("applyHostEnvFromTransport does not mark dirty when values are unchanged", () => {
+    conversation.applyHostEnvFromTransport({
+      channelId: "vellum",
+      interfaceId: "macos",
+      hostHomeDir: "/Users/alice",
+      hostUsername: "alice",
+    });
+    // Render once so the dirty flag clears.
+    conversation.refreshWorkspaceTopLevelContextIfNeeded();
+    expect(conversation.isWorkspaceTopLevelDirty()).toBe(false);
+
+    // Re-apply the same values — dirty flag should remain false so we don't
+    // thrash the cached workspace block on every message.
+    conversation.applyHostEnvFromTransport({
+      channelId: "vellum",
+      interfaceId: "macos",
+      hostHomeDir: "/Users/alice",
+      hostUsername: "alice",
+    });
+    expect(conversation.isWorkspaceTopLevelDirty()).toBe(false);
+  });
+
+  test("applyHostEnvFromTransport marks dirty when macOS values change", () => {
+    conversation.applyHostEnvFromTransport({
+      channelId: "vellum",
+      interfaceId: "macos",
+      hostHomeDir: "/Users/alice",
+      hostUsername: "alice",
+    });
+    conversation.refreshWorkspaceTopLevelContextIfNeeded();
+    expect(conversation.isWorkspaceTopLevelDirty()).toBe(false);
+
+    // New values — should mark dirty so the next render picks them up.
+    conversation.applyHostEnvFromTransport({
+      channelId: "vellum",
+      interfaceId: "macos",
+      hostHomeDir: "/Users/bob",
+      hostUsername: "bob",
+    });
+    expect(conversation.isWorkspaceTopLevelDirty()).toBe(true);
+  });
+
   test("workspace hints follow the resolved legacy directory when canonical is absent", () => {
     const workspaceRoot = mkdtempSync(
       join(tmpdir(), "conversation-workspace-cache-state-"),

--- a/assistant/src/__tests__/host-proxy-interface.test.ts
+++ b/assistant/src/__tests__/host-proxy-interface.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from "bun:test";
+
+import type { HostProxyInterfaceId, InterfaceId } from "../channels/types.js";
+import { supportsHostProxy } from "../channels/types.js";
+import type {
+  ConversationTransportMetadata,
+  HostProxyTransportMetadata,
+  NonHostProxyTransportMetadata,
+} from "../daemon/message-types/conversations.js";
+
+// ---------------------------------------------------------------------------
+// supportsHostProxy — runtime behavior
+// ---------------------------------------------------------------------------
+
+describe("supportsHostProxy (runtime)", () => {
+  test("no-arg form returns true for host-proxy interfaces", () => {
+    expect(supportsHostProxy("macos")).toBe(true);
+  });
+
+  test("no-arg form returns false for interfaces without host-proxy support", () => {
+    const nonHostProxyIds: InterfaceId[] = [
+      "ios",
+      "cli",
+      "telegram",
+      "phone",
+      "vellum",
+      "whatsapp",
+      "slack",
+      "email",
+      "chrome-extension",
+    ];
+    for (const id of nonHostProxyIds) {
+      expect(supportsHostProxy(id)).toBe(false);
+    }
+  });
+
+  test("capability form grants host_browser to chrome-extension", () => {
+    expect(supportsHostProxy("chrome-extension", "host_browser")).toBe(true);
+    expect(supportsHostProxy("chrome-extension", "host_bash")).toBe(false);
+    expect(supportsHostProxy("chrome-extension", "host_file")).toBe(false);
+    expect(supportsHostProxy("chrome-extension", "host_cu")).toBe(false);
+  });
+
+  test("capability form grants everything to macOS", () => {
+    expect(supportsHostProxy("macos", "host_bash")).toBe(true);
+    expect(supportsHostProxy("macos", "host_file")).toBe(true);
+    expect(supportsHostProxy("macos", "host_cu")).toBe(true);
+    expect(supportsHostProxy("macos", "host_browser")).toBe(true);
+  });
+
+  test("capability form rejects everything for non-host-proxy interfaces", () => {
+    expect(supportsHostProxy("ios", "host_bash")).toBe(false);
+    expect(supportsHostProxy("cli", "host_file")).toBe(false);
+    expect(supportsHostProxy("telegram", "host_browser")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// supportsHostProxy — type predicate (compile-time contract)
+// ---------------------------------------------------------------------------
+
+describe("supportsHostProxy (type predicate)", () => {
+  test("no-arg form narrows InterfaceId to HostProxyInterfaceId", () => {
+    const id: InterfaceId = "macos";
+    if (supportsHostProxy(id)) {
+      // Inside this branch, TypeScript narrows `id` to HostProxyInterfaceId.
+      // If the overload were wrong, this assignment would fail to type-check
+      // and the test file wouldn't compile.
+      const narrowed: HostProxyInterfaceId = id;
+      expect(narrowed).toBe("macos");
+    } else {
+      throw new Error("expected narrowing branch to be taken for macos");
+    }
+  });
+
+  test("narrowing reaches through discriminated transport union", () => {
+    // Build a value typed as the full union so TypeScript can't cheat.
+    const transport: ConversationTransportMetadata = {
+      channelId: "vellum",
+      interfaceId: "macos",
+      hostHomeDir: "/Users/alice",
+      hostUsername: "alice",
+    };
+
+    if (transport.interfaceId && supportsHostProxy(transport.interfaceId)) {
+      // Narrowing the discriminant narrows the union member — after this
+      // check, `transport` should be HostProxyTransportMetadata and the
+      // host-env fields are directly accessible.
+      const narrowed: HostProxyTransportMetadata = transport;
+      expect(narrowed.hostHomeDir).toBe("/Users/alice");
+      expect(narrowed.hostUsername).toBe("alice");
+    } else {
+      throw new Error("expected host-proxy branch for macos transport");
+    }
+  });
+
+  test("non-host-proxy branch narrows to NonHostProxyTransportMetadata", () => {
+    const transport: ConversationTransportMetadata = {
+      channelId: "vellum",
+      interfaceId: "ios",
+    };
+
+    if (transport.interfaceId && supportsHostProxy(transport.interfaceId)) {
+      throw new Error("expected non-host-proxy branch for ios transport");
+    } else {
+      // `transport` is NonHostProxyTransportMetadata here.
+      const narrowed: NonHostProxyTransportMetadata = transport;
+      expect(narrowed.interfaceId).toBe("ios");
+    }
+  });
+});

--- a/assistant/src/__tests__/host-proxy-interface.test.ts
+++ b/assistant/src/__tests__/host-proxy-interface.test.ts
@@ -7,6 +7,7 @@ import type {
   HostProxyTransportMetadata,
   NonHostProxyTransportMetadata,
 } from "../daemon/message-types/conversations.js";
+import { isHostProxyTransport } from "../daemon/message-types/conversations.js";
 
 // ---------------------------------------------------------------------------
 // supportsHostProxy — runtime behavior
@@ -107,5 +108,58 @@ describe("supportsHostProxy (type predicate)", () => {
       const narrowed: NonHostProxyTransportMetadata = transport;
       expect(narrowed.interfaceId).toBe("ios");
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isHostProxyTransport — type guard on ConversationTransportMetadata
+// ---------------------------------------------------------------------------
+
+describe("isHostProxyTransport", () => {
+  test("returns true for macOS transport and narrows to HostProxyTransportMetadata", () => {
+    const transport: ConversationTransportMetadata = {
+      channelId: "vellum",
+      interfaceId: "macos",
+      hostHomeDir: "/Users/alice",
+      hostUsername: "alice",
+    };
+
+    expect(isHostProxyTransport(transport)).toBe(true);
+
+    if (isHostProxyTransport(transport)) {
+      const narrowed: HostProxyTransportMetadata = transport;
+      expect(narrowed.hostHomeDir).toBe("/Users/alice");
+      expect(narrowed.hostUsername).toBe("alice");
+    } else {
+      throw new Error("narrowing branch not taken");
+    }
+  });
+
+  test("returns false for every non-host-proxy interface", () => {
+    const nonHostProxyIds: Array<Exclude<InterfaceId, HostProxyInterfaceId>> = [
+      "ios",
+      "cli",
+      "telegram",
+      "phone",
+      "vellum",
+      "whatsapp",
+      "slack",
+      "email",
+      "chrome-extension",
+    ];
+    for (const interfaceId of nonHostProxyIds) {
+      const transport: ConversationTransportMetadata = {
+        channelId: "vellum",
+        interfaceId,
+      };
+      expect(isHostProxyTransport(transport)).toBe(false);
+    }
+  });
+
+  test("returns false when interfaceId is absent", () => {
+    const transport: ConversationTransportMetadata = {
+      channelId: "vellum",
+    };
+    expect(isHostProxyTransport(transport)).toBe(false);
   });
 });

--- a/assistant/src/__tests__/transport-hints-queue.test.ts
+++ b/assistant/src/__tests__/transport-hints-queue.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from "bun:test";
 
 import type {
-  MacosTransportMetadata,
-  NonMacosTransportMetadata,
+  HostProxyTransportMetadata,
+  NonHostProxyTransportMetadata,
 } from "../daemon/message-types/conversations.js";
 import { buildTransportHints } from "../daemon/transport-hints.js";
 
@@ -11,8 +11,8 @@ import { buildTransportHints } from "../daemon/transport-hints.js";
 // ---------------------------------------------------------------------------
 
 describe("buildTransportHints", () => {
-  test("returns empty array for macOS transport without client hints", () => {
-    const transport: MacosTransportMetadata = {
+  test("returns empty array for host-proxy transport without client hints", () => {
+    const transport: HostProxyTransportMetadata = {
       channelId: "vellum",
       interfaceId: "macos",
       hostHomeDir: "/Users/alice",
@@ -24,8 +24,8 @@ describe("buildTransportHints", () => {
     expect(hints).toHaveLength(0);
   });
 
-  test("returns empty array for non-macOS transport without client hints", () => {
-    const transport: NonMacosTransportMetadata = {
+  test("returns empty array for non-host-proxy transport without client hints", () => {
+    const transport: NonHostProxyTransportMetadata = {
       channelId: "vellum",
       interfaceId: "ios",
     };
@@ -36,7 +36,7 @@ describe("buildTransportHints", () => {
   });
 
   test("forwards client-provided hints", () => {
-    const transport: MacosTransportMetadata = {
+    const transport: HostProxyTransportMetadata = {
       channelId: "vellum",
       interfaceId: "macos",
       hostHomeDir: "/Users/bob",
@@ -50,7 +50,7 @@ describe("buildTransportHints", () => {
   });
 
   test("returns empty array when no hints field present", () => {
-    const transport: MacosTransportMetadata = {
+    const transport: HostProxyTransportMetadata = {
       channelId: "vellum",
       interfaceId: "macos",
     };

--- a/assistant/src/channels/types.ts
+++ b/assistant/src/channels/types.ts
@@ -103,11 +103,24 @@ export type HostProxyCapability =
   | "host_browser";
 
 /**
+ * Interfaces that support the full desktop host-proxy set (all four
+ * `HostProxyCapability` values). This is the capability-level identity used
+ * by the discriminated transport metadata union and by the
+ * `supportsHostProxy(id)` type predicate.
+ *
+ * Extend this literal type AND the `supportsHostProxy` implementation
+ * below in lock-step when adding a new host-capable client (e.g. a native
+ * Linux or Windows desktop).
+ */
+export type HostProxyInterfaceId = "macos";
+
+/**
  * Whether the interface supports a host proxy capability.
  *
  * The no-arg form `supportsHostProxy(id)` asks "does this interface support
  * the full desktop host proxy set?" — it returns `true` only for macOS, which
- * supports all four capabilities. It returns `false` for
+ * supports all four capabilities, and is the type predicate that narrows
+ * `InterfaceId` to `HostProxyInterfaceId`. It returns `false` for
  * chrome-extension because chrome-extension only supports `host_browser`,
  * and the no-arg form is the gate that legacy desktop-only call sites use
  * (e.g. preactivating computer-use, restoring all four proxies in the drain
@@ -115,6 +128,11 @@ export type HostProxyCapability =
  * decide whether to keep `hostBrowserProxy` available for chrome-extension —
  * should pass the capability explicitly: `supportsHostProxy(id, "host_browser")`.
  */
+export function supportsHostProxy(id: InterfaceId): id is HostProxyInterfaceId;
+export function supportsHostProxy(
+  id: InterfaceId,
+  capability: HostProxyCapability,
+): boolean;
 export function supportsHostProxy(
   id: InterfaceId,
   capability?: HostProxyCapability,

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -47,6 +47,7 @@ import type {
   UsageStats,
   UserMessageAttachment,
 } from "./message-protocol.js";
+import type { ConversationTransportMetadata } from "./message-types/conversations.js";
 import type { TraceEmitter } from "./trace-emitter.js";
 import { buildTransportHints } from "./transport-hints.js";
 import { resolveVerificationSessionIntent } from "./verification-session-intent.js";
@@ -167,19 +168,12 @@ export interface ProcessConversationContext {
   /** Set transport-derived hints for the conversation. */
   setTransportHints(hints: string[] | undefined): void;
   /**
-   * Client-reported host home directory from macOS transport metadata.
-   * Used by the workspace block renderer so platform-managed daemons show
-   * the user's actual Mac home instead of the container's `os.homedir()`.
+   * Apply client-reported host env (home dir, username) from transport
+   * metadata, gating on `supportsHostProxy` so non-host-proxy interfaces
+   * clear any stale values. Shared between the create/reuse path in
+   * `DaemonServer.applyTransportMetadata` and the queue-drain path below.
    */
-  hostHomeDir?: string;
-  /** Client-reported host username. See `hostHomeDir`. */
-  hostUsername?: string;
-  /**
-   * Workspace top-level cache dirty flag. The queue-drain path sets this
-   * when client-reported host env changes so the next render picks up the
-   * new values.
-   */
-  workspaceTopLevelDirty: boolean;
+  applyHostEnvFromTransport(transport: ConversationTransportMetadata): void;
 }
 
 function resolveQueuedTurnContext(
@@ -320,25 +314,10 @@ export async function drainQueue(
   // environment context for internal turns.
   if (next.transport) {
     conversation.setTransportHints(buildTransportHints(next.transport));
-    // Mirror applyTransportMetadata: populate client-reported host env for
-    // macOS transports, and clear it for non-macOS transports so a
-    // conversation reused across interfaces doesn't keep rendering stale
-    // Mac paths in its `<workspace>` block.
-    const prevHomeDir = conversation.hostHomeDir;
-    const prevUsername = conversation.hostUsername;
-    if (next.transport.interfaceId === "macos") {
-      conversation.hostHomeDir = next.transport.hostHomeDir;
-      conversation.hostUsername = next.transport.hostUsername;
-    } else {
-      conversation.hostHomeDir = undefined;
-      conversation.hostUsername = undefined;
-    }
-    if (
-      prevHomeDir !== conversation.hostHomeDir ||
-      prevUsername !== conversation.hostUsername
-    ) {
-      conversation.workspaceTopLevelDirty = true;
-    }
+    // Route client-reported host env through the same capability-gated
+    // setter used by DaemonServer.applyTransportMetadata so create/reuse
+    // and queue-drain stay in sync without duplicating the gate logic.
+    conversation.applyHostEnvFromTransport(next.transport);
   }
 
   // Non-interactive queued messages (channel requests) must not execute tools

--- a/assistant/src/daemon/conversation-workspace.ts
+++ b/assistant/src/daemon/conversation-workspace.ts
@@ -14,10 +14,11 @@ export interface WorkspaceConversationContext {
   workspaceTopLevelContext: string | null;
   workspaceTopLevelDirty: boolean;
   /**
-   * Client-reported host home directory, populated from macOS transport
-   * metadata. Used to render the `<workspace>` block correctly for
-   * platform-managed daemons where `os.homedir()` would return the
-   * container's home instead of the user's actual Mac.
+   * Client-reported host home directory, populated from host-proxy
+   * transport metadata (see `supportsHostProxy` / `HostProxyInterfaceId`).
+   * Used to render the `<workspace>` block correctly for platform-managed
+   * daemons where `os.homedir()` would return the container's home instead
+   * of the user's actual client-side home.
    */
   hostHomeDir?: string;
   /** Client-reported host username. See `hostHomeDir`. */

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -22,7 +22,6 @@ import type {
   TurnChannelContext,
   TurnInterfaceContext,
 } from "../channels/types.js";
-import { supportsHostProxy } from "../channels/types.js";
 import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import { getConfig } from "../config/loader.js";
 import type { Speed } from "../config/schemas/inference.js";
@@ -118,6 +117,7 @@ import type {
   UserMessageAttachment,
 } from "./message-protocol.js";
 import type { ConversationTransportMetadata } from "./message-types/conversations.js";
+import { isHostProxyTransport } from "./message-types/conversations.js";
 import type {
   AssistantActivityState,
   ConfirmationStateChanged,
@@ -1112,7 +1112,7 @@ export class Conversation {
   applyHostEnvFromTransport(transport: ConversationTransportMetadata): void {
     const prevHomeDir = this.hostHomeDir;
     const prevUsername = this.hostUsername;
-    if (transport.interfaceId && supportsHostProxy(transport.interfaceId)) {
+    if (isHostProxyTransport(transport)) {
       this.hostHomeDir = transport.hostHomeDir;
       this.hostUsername = transport.hostUsername;
     } else {

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -22,6 +22,7 @@ import type {
   TurnChannelContext,
   TurnInterfaceContext,
 } from "../channels/types.js";
+import { supportsHostProxy } from "../channels/types.js";
 import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import { getConfig } from "../config/loader.js";
 import type { Speed } from "../config/schemas/inference.js";
@@ -1090,6 +1091,40 @@ export class Conversation {
 
   setTransportHints(hints: string[] | undefined): void {
     this.transportHints = hints;
+  }
+
+  /**
+   * Apply client-reported host environment (home dir, username) from
+   * transport metadata onto the conversation. Only interfaces whose
+   * interfaceId passes `supportsHostProxy()` contribute values — all other
+   * interfaces (CLI, channels, iOS, chrome-extension) clear any previously
+   * stored values so a conversation reused across interfaces doesn't leak
+   * stale paths into later `<workspace>` blocks.
+   *
+   * Gating on `supportsHostProxy` (rather than a specific interface name)
+   * keeps this in lock-step with the capability set defined in
+   * `HostProxyInterfaceId` — adding a new host-capable client only requires
+   * extending those two, not touching this method.
+   *
+   * Invalidates the cached workspace top-level block when values change so
+   * the next render picks up the new host env.
+   */
+  applyHostEnvFromTransport(transport: ConversationTransportMetadata): void {
+    const prevHomeDir = this.hostHomeDir;
+    const prevUsername = this.hostUsername;
+    if (transport.interfaceId && supportsHostProxy(transport.interfaceId)) {
+      this.hostHomeDir = transport.hostHomeDir;
+      this.hostUsername = transport.hostUsername;
+    } else {
+      this.hostHomeDir = undefined;
+      this.hostUsername = undefined;
+    }
+    if (
+      prevHomeDir !== this.hostHomeDir ||
+      prevUsername !== this.hostUsername
+    ) {
+      this.workspaceTopLevelDirty = true;
+    }
   }
 
   setAssistantId(assistantId: string | null): void {

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -264,16 +264,18 @@ export class Conversation {
   /** @internal */ workspaceTopLevelContext: string | null = null;
   /** @internal */ workspaceTopLevelDirty = true;
   /**
-   * Host home directory reported by the client (macOS `NSHomeDirectory()`).
-   * Populated from `MacosTransportMetadata` when a message arrives. Consumed
-   * by the `<workspace>` block renderer so platform-managed (containerized)
-   * daemons show the user's actual Mac home dir instead of the container's.
+   * Host home directory reported by the client (e.g. macOS
+   * `NSHomeDirectory()`). Populated from `HostProxyTransportMetadata` when
+   * a message arrives from an interface that supports host-proxy tools
+   * (see `supportsHostProxy`). Consumed by the `<workspace>` block renderer
+   * so platform-managed (containerized) daemons show the user's actual
+   * client-side home dir instead of the container's `os.homedir()`.
    * @internal
    */
   hostHomeDir?: string;
   /**
-   * Host username reported by the client (macOS `NSUserName()`). See
-   * `hostHomeDir`.
+   * Host username reported by the client (e.g. macOS `NSUserName()`).
+   * See `hostHomeDir`.
    * @internal
    */
   hostUsername?: string;

--- a/assistant/src/daemon/message-types/conversations.ts
+++ b/assistant/src/daemon/message-types/conversations.ts
@@ -5,6 +5,7 @@ import type {
   HostProxyInterfaceId,
   InterfaceId,
 } from "../../channels/types.js";
+import { supportsHostProxy } from "../../channels/types.js";
 import type { ConversationType } from "./shared.js";
 import type { UserMessageAttachment } from "./shared.js";
 
@@ -70,6 +71,21 @@ export interface NonHostProxyTransportMetadata extends BaseTransportMetadata {
 export type ConversationTransportMetadata =
   | HostProxyTransportMetadata
   | NonHostProxyTransportMetadata;
+
+/**
+ * Type guard: does this transport belong to an interface that supports the
+ * full host-proxy set? Wraps `supportsHostProxy` so the capability logic
+ * stays in one place (channels/types.ts) and narrows the discriminated
+ * union to `HostProxyTransportMetadata` for safe field access.
+ */
+export function isHostProxyTransport(
+  transport: ConversationTransportMetadata,
+): transport is HostProxyTransportMetadata {
+  return (
+    transport.interfaceId !== undefined &&
+    supportsHostProxy(transport.interfaceId)
+  );
+}
 
 export interface ConversationCreateRequest {
   type: "conversation_create";

--- a/assistant/src/daemon/message-types/conversations.ts
+++ b/assistant/src/daemon/message-types/conversations.ts
@@ -1,6 +1,10 @@
 // Conversation lifecycle, auth, model config, and history types.
 
-import type { ChannelId, InterfaceId } from "../../channels/types.js";
+import type {
+  ChannelId,
+  HostProxyInterfaceId,
+  InterfaceId,
+} from "../../channels/types.js";
 import type { ConversationType } from "./shared.js";
 import type { UserMessageAttachment } from "./shared.js";
 
@@ -26,26 +30,46 @@ interface BaseTransportMetadata {
   chatType?: string;
 }
 
-/** Transport metadata for macOS desktop clients, including host environment fields. */
-export interface MacosTransportMetadata extends BaseTransportMetadata {
-  /** Interface identifier for macOS transport. */
-  interfaceId: "macos";
-  /** Home directory of the host macOS user. */
+/**
+ * Transport metadata for interfaces that support the full desktop host-proxy
+ * set (see `HostProxyInterfaceId` / `supportsHostProxy`). Carries the host
+ * environment fields the client reports so the `<workspace>` block renders
+ * the user's actual machine rather than a containerized daemon's own OS.
+ *
+ * Today this variant is populated only by the macOS client, but the shape
+ * is capability-keyed (not interface-name-keyed) so future host-capable
+ * clients (e.g. a native Linux or Windows desktop) get the same treatment
+ * automatically when added to `HostProxyInterfaceId`.
+ */
+export interface HostProxyTransportMetadata extends BaseTransportMetadata {
+  /** Interface identifier — restricted to interfaces that support host proxies. */
+  interfaceId: HostProxyInterfaceId;
+  /** Home directory of the user on the host machine (e.g. `NSHomeDirectory()`). */
   hostHomeDir?: string;
-  /** Username of the host macOS user. */
+  /** Username of the user on the host machine (e.g. `NSUserName()`). */
   hostUsername?: string;
 }
 
-/** Transport metadata for non-macOS transports. */
-export interface NonMacosTransportMetadata extends BaseTransportMetadata {
+/**
+ * Transport metadata for interfaces that do NOT support host-proxy tools
+ * (iOS, CLI, channel ingress, chrome-extension, etc.). No host environment
+ * because the assistant has no local filesystem to address on the client.
+ */
+export interface NonHostProxyTransportMetadata extends BaseTransportMetadata {
   /** Interface identifier for this transport (e.g. "ios", "cli"). */
-  interfaceId?: Exclude<InterfaceId, "macos">;
+  interfaceId?: Exclude<InterfaceId, HostProxyInterfaceId>;
 }
 
-/** Lightweight conversation transport metadata for channel identity and natural-language guidance. */
+/**
+ * Discriminated union of transport metadata variants, keyed on whether the
+ * interface supports host-proxy tools (`supportsHostProxy`). The daemon uses
+ * that same predicate at runtime to decide whether to populate / read host
+ * environment fields on the conversation, so the type system and the runtime
+ * gate stay in lock-step as new host-capable interfaces are added.
+ */
 export type ConversationTransportMetadata =
-  | MacosTransportMetadata
-  | NonMacosTransportMetadata;
+  | HostProxyTransportMetadata
+  | NonHostProxyTransportMetadata;
 
 export interface ConversationCreateRequest {
   type: "conversation_create";

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -387,29 +387,13 @@ export class DaemonServer {
       "Transport metadata received",
     );
     conversation.setTransportHints(buildTransportHints(transport));
-    // Client-reported host env flows into the `<workspace>` block so
-    // platform-managed (containerized) daemons show the user's actual
-    // Mac paths instead of the container's `os.homedir()`. Non-macOS
-    // transports (iOS, CLI, channels) carry no host env, so we clear
-    // any previously-stored macOS values — otherwise a conversation
-    // reused across interfaces would keep rendering stale macOS paths.
-    // Invalidate the cached workspace block when the values change so
-    // the next render picks them up.
-    const prevHomeDir = conversation.hostHomeDir;
-    const prevUsername = conversation.hostUsername;
-    if (transport.interfaceId === "macos") {
-      conversation.hostHomeDir = transport.hostHomeDir;
-      conversation.hostUsername = transport.hostUsername;
-    } else {
-      conversation.hostHomeDir = undefined;
-      conversation.hostUsername = undefined;
-    }
-    if (
-      prevHomeDir !== conversation.hostHomeDir ||
-      prevUsername !== conversation.hostUsername
-    ) {
-      conversation.workspaceTopLevelDirty = true;
-    }
+    // Route client-reported host env through the capability-gated setter on
+    // Conversation so both the create/reuse path here and the queue-drain
+    // path in conversation-process share one implementation. The method
+    // gates on `supportsHostProxy` (not a specific interface name), so any
+    // new host-capable client added to `HostProxyInterfaceId` will flow its
+    // host env through automatically.
+    conversation.applyHostEnvFromTransport(transport);
   }
 
   constructor() {

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -41,8 +41,8 @@ import { HostCuProxy } from "../../daemon/host-cu-proxy.js";
 import { HostFileProxy } from "../../daemon/host-file-proxy.js";
 import type { ServerMessage } from "../../daemon/message-protocol.js";
 import type {
-  MacosTransportMetadata,
-  NonMacosTransportMetadata,
+  HostProxyTransportMetadata,
+  NonHostProxyTransportMetadata,
 } from "../../daemon/message-types/conversations.js";
 import type { HeartbeatService } from "../../heartbeat/heartbeat-service.js";
 import * as attachmentsStore from "../../memory/attachments-store.js";
@@ -1066,18 +1066,21 @@ export async function handleSendMessage(
 
   // Build transport metadata from the request so the daemon can inject
   // host environment hints (home directory, username) into the LLM context.
-  const transport =
-    sourceInterface === "macos"
-      ? ({
-          channelId: sourceChannel,
-          interfaceId: "macos" as const,
-          hostHomeDir: body.hostHomeDir,
-          hostUsername: body.hostUsername,
-        } satisfies MacosTransportMetadata)
-      : ({
-          channelId: sourceChannel,
-          interfaceId: sourceInterface,
-        } satisfies NonMacosTransportMetadata);
+  // The `supportsHostProxy` type predicate narrows `sourceInterface` to
+  // `HostProxyInterfaceId` in the truthy branch, which is exactly the
+  // discriminant the `HostProxyTransportMetadata` variant expects — so the
+  // construction site stays in lock-step with the runtime capability gate.
+  const transport = supportsHostProxy(sourceInterface)
+    ? ({
+        channelId: sourceChannel,
+        interfaceId: sourceInterface,
+        hostHomeDir: body.hostHomeDir,
+        hostUsername: body.hostUsername,
+      } satisfies HostProxyTransportMetadata)
+    : ({
+        channelId: sourceChannel,
+        interfaceId: sourceInterface,
+      } satisfies NonHostProxyTransportMetadata);
 
   const conversation = await smDeps.getOrCreateConversation(
     mapping.conversationId,


### PR DESCRIPTION
## Summary
- Replace hard-coded `interfaceId === \"macos\"` checks on the host env path with `supportsHostProxy()`, and introduce a `HostProxyInterfaceId` literal type so the transport metadata discriminated union and the runtime gate share one capability-keyed source of truth. Adding a future host-capable client (native Linux/Windows, etc.) now only requires extending `HostProxyInterfaceId` and the `supportsHostProxy` body — the type graph, the `handleSendMessage` construction site, and both the create/reuse and queue-drain apply paths follow automatically.
- Rename the transport metadata variants to `HostProxyTransportMetadata` / `NonHostProxyTransportMetadata` (from `Macos` / `NonMacos`), overload `supportsHostProxy(id)` as a type predicate narrowing `InterfaceId` to `HostProxyInterfaceId`, add an `isHostProxyTransport` type guard that narrows the union, and extract the gate logic into a new `Conversation.applyHostEnvFromTransport()` method so `DaemonServer.applyTransportMetadata` and the queue-drain path share one implementation instead of duplicating the prev/next-change/dirty bookkeeping.
- Add a dedicated `host-proxy-interface.test.ts` covering `supportsHostProxy` runtime behavior for every `InterfaceId`, the type predicate narrowing through the discriminated union, capability-form semantics, and `isHostProxyTransport` directly. Extend `conversation-workspace-cache-state.test.ts` with six new tests exercising `applyHostEnvFromTransport` end-to-end: populate on host-proxy, clear on non-host-proxy reuse, chrome-extension treated as non-host-proxy (browser-only), transports without `interfaceId` clear stored values, no-op on unchanged values (no cache thrash), and dirty on value change.

## Original prompt
it with tests. The previous PR was merged to main already
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24442" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
