### PR TITLE
feat: refresh stale conversation starters in background

### DIFF
--- a/assistant/src/__tests__/conversation-starter-routes.test.ts
+++ b/assistant/src/__tests__/conversation-starter-routes.test.ts
@@ -11,6 +11,7 @@ mock.module("../util/logger.js", () => ({
 
 import { getSqlite, initializeDb } from "../memory/db.js";
 import {
+  CONVERSATION_STARTERS_STALE_TTL_MS,
   conversationStarterRouteDefinitions,
   orderStrongestFirst,
 } from "../runtime/routes/conversation-starter-routes.js";
@@ -89,22 +90,57 @@ function insertMemoryItem(scopeId = "default") {
   );
 }
 
+function setCheckpoint(key: string, value: string, updatedAt = Date.now()) {
+  getSqlite().run(
+    `INSERT OR REPLACE INTO memory_checkpoints (key, value, updated_at) VALUES (?, ?, ?)`,
+    [key, value, updatedAt],
+  );
+}
+
+function insertStarterJob(scopeId = "default", status = "pending") {
+  const now = Date.now();
+  getSqlite().run(
+    `INSERT INTO memory_jobs (
+      id, type, payload, status, attempts, deferrals, run_after, last_error,
+      started_at, created_at, updated_at
+    ) VALUES (?, 'generate_conversation_starters', ?, ?, 0, 0, ?, NULL, NULL, ?, ?)`,
+    [uuid(), JSON.stringify({ scopeId }), status, now, now, now],
+  );
+}
+
+function countStarterJobs() {
+  return (
+    getSqlite()
+      .prepare(
+        `SELECT COUNT(*) AS c FROM memory_jobs WHERE type = 'generate_conversation_starters'`,
+      )
+      .get() as { c: number }
+  ).c;
+}
+
 beforeEach(() => {
   clearTables();
 });
 
 describe("GET /v1/conversation-starters", () => {
   test("returns ready status with starters when they exist", async () => {
+    const now = Date.now();
     insertStarter({
       label: "Draft a PR summary",
       prompt: "Draft a summary for my latest PR",
       category: "development",
+      createdAt: now,
     });
     insertStarter({
       label: "Check Slack threads",
       prompt: "Check my unread Slack threads",
       category: "communication",
+      createdAt: now,
     });
+    setCheckpoint("conversation_starters:last_gen_at:default", String(now));
+    setCheckpoint("conversation_starters:item_count_at_last_gen:default", "2");
+    insertMemoryItem();
+    insertMemoryItem();
 
     const res = await dispatch("conversation-starters");
     const body = (await res.json()) as {
@@ -117,6 +153,96 @@ describe("GET /v1/conversation-starters", () => {
     expect(body.status).toBe("ready");
     expect(body.starters).toHaveLength(2);
     expect(body.total).toBe(2);
+  });
+
+  test("returns refreshing with existing starters when the batch is stale and enqueues one refresh job", async () => {
+    const now = Date.now();
+    insertStarter({
+      label: "Draft a PR summary",
+      prompt: "Draft a summary for my latest PR",
+      category: "development",
+      createdAt: now - 1_000,
+    });
+    insertStarter({
+      label: "Check Slack threads",
+      prompt: "Check my unread Slack threads",
+      category: "communication",
+      createdAt: now - 2_000,
+    });
+    setCheckpoint(
+      "conversation_starters:last_gen_at:default",
+      String(now - CONVERSATION_STARTERS_STALE_TTL_MS - 1_000),
+    );
+    setCheckpoint("conversation_starters:item_count_at_last_gen:default", "2");
+    insertMemoryItem();
+    insertMemoryItem();
+
+    const res = await dispatch("conversation-starters");
+    const body = (await res.json()) as {
+      starters: unknown[];
+      total: number;
+      status: string;
+    };
+
+    expect(res.status).toBe(200);
+    expect(body.status).toBe("refreshing");
+    expect(body.starters).toHaveLength(2);
+    expect(countStarterJobs()).toBe(1);
+  });
+
+  test("returns refreshing with existing starters when the checkpoint count is ahead of active memory and enqueues one refresh job", async () => {
+    const now = Date.now();
+    insertStarter({
+      label: "Draft a PR summary",
+      prompt: "Draft a summary for my latest PR",
+      category: "development",
+      createdAt: now,
+    });
+    setCheckpoint("conversation_starters:last_gen_at:default", String(now));
+    setCheckpoint("conversation_starters:item_count_at_last_gen:default", "5");
+    insertMemoryItem();
+    insertMemoryItem();
+
+    const res = await dispatch("conversation-starters");
+    const body = (await res.json()) as {
+      starters: unknown[];
+      total: number;
+      status: string;
+    };
+
+    expect(res.status).toBe(200);
+    expect(body.status).toBe("refreshing");
+    expect(body.starters).toHaveLength(1);
+    expect(countStarterJobs()).toBe(1);
+  });
+
+  test("does not enqueue duplicate refresh jobs when a starter job is already active", async () => {
+    const now = Date.now();
+    insertStarter({
+      label: "Draft a PR summary",
+      prompt: "Draft a summary for my latest PR",
+      category: "development",
+      createdAt: now,
+    });
+    setCheckpoint(
+      "conversation_starters:last_gen_at:default",
+      String(now - CONVERSATION_STARTERS_STALE_TTL_MS - 1_000),
+    );
+    setCheckpoint("conversation_starters:item_count_at_last_gen:default", "1");
+    insertMemoryItem();
+    insertStarterJob("default");
+
+    const res = await dispatch("conversation-starters");
+    const body = (await res.json()) as {
+      starters: unknown[];
+      total: number;
+      status: string;
+    };
+
+    expect(res.status).toBe(200);
+    expect(body.status).toBe("refreshing");
+    expect(body.starters).toHaveLength(1);
+    expect(countStarterJobs()).toBe(1);
   });
 
   test("returns empty status when no memory items exist", async () => {

--- a/assistant/src/__tests__/conversation-starters-cadence.test.ts
+++ b/assistant/src/__tests__/conversation-starters-cadence.test.ts
@@ -117,7 +117,7 @@ describe("maybeEnqueueConversationStartersJob", () => {
     expect(getPendingJobs()).toHaveLength(1);
   });
 
-  test("enqueues after pruning reduces totalActive below lastCount", () => {
+  test("enqueues when active memory count drops below the last-generation checkpoint", () => {
     // Start with 5 nodes and set checkpoint to 5
     for (let i = 0; i < 5; i++) insertMemoryNode();
     setCheckpoint("conversation_starters:item_count_at_last_gen:default", "5");
@@ -135,18 +135,8 @@ describe("maybeEnqueueConversationStartersJob", () => {
       );
     }
 
-    // totalActive=2, lastCount=5 → delta would be -3 without clamp
-    // With clamp, delta=0 which is below threshold=1, so no job yet
-    maybeEnqueueConversationStartersJob("default");
-    expect(getPendingJobs()).toHaveLength(0);
-
-    // Add a new node → totalActive=3, lastCount=5, clamped delta=0, still no job
-    insertMemoryNode();
-    maybeEnqueueConversationStartersJob("default");
-    expect(getPendingJobs()).toHaveLength(0);
-
-    // Add 3 more nodes → totalActive=6, lastCount=5, delta=1 >= threshold=1
-    for (let i = 0; i < 3; i++) insertMemoryNode();
+    // The checkpoint is now ahead of the active memory count. This should
+    // enqueue a refresh immediately so stale starters can recover.
     maybeEnqueueConversationStartersJob("default");
     expect(getPendingJobs()).toHaveLength(1);
   });

--- a/assistant/src/memory/conversation-starters-cadence.ts
+++ b/assistant/src/memory/conversation-starters-cadence.ts
@@ -37,7 +37,8 @@ export function maybeEnqueueConversationStartersJob(scopeId: string): void {
     .from(memoryCheckpoints)
     .where(eq(memoryCheckpoints.key, checkpointKey))
     .get();
-  const lastCount = checkpoint ? parseInt(checkpoint.value, 10) : 0;
+  const parsedLastCount = checkpoint ? parseInt(checkpoint.value, 10) : 0;
+  const lastCount = Number.isFinite(parsedLastCount) ? parsedLastCount : 0;
 
   // Cadence formula
   let threshold: number;
@@ -49,8 +50,9 @@ export function maybeEnqueueConversationStartersJob(scopeId: string): void {
     threshold = 10;
   }
 
+  const checkpointAhead = totalActive < lastCount;
   const delta = Math.max(0, totalActive - lastCount);
-  if (delta < threshold) return;
+  if (!checkpointAhead && delta < threshold) return;
 
   // Dedup: don't enqueue if a pending/running job for this scope already exists
   const existing = db
@@ -68,7 +70,7 @@ export function maybeEnqueueConversationStartersJob(scopeId: string): void {
 
   enqueueMemoryJob("generate_conversation_starters", { scopeId });
   log.info(
-    { totalActive, lastCount, delta, threshold, scopeId },
+    { totalActive, lastCount, delta, threshold, scopeId, checkpointAhead },
     "Enqueued conversation starters generation job",
   );
 }

--- a/assistant/src/runtime/routes/conversation-starter-routes.ts
+++ b/assistant/src/runtime/routes/conversation-starter-routes.ts
@@ -4,13 +4,17 @@
  * GET /v1/conversation-starters — list conversation starters (chips)
  */
 
-import { and, desc, eq, inArray, like } from "drizzle-orm";
+import { and, desc, eq, inArray, sql } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb } from "../../memory/db.js";
 import { enqueueMemoryJob } from "../../memory/jobs-store.js";
 import { rawGet } from "../../memory/raw-query.js";
-import { conversationStarters, memoryJobs } from "../../memory/schema.js";
+import {
+  conversationStarters,
+  memoryCheckpoints,
+  memoryJobs,
+} from "../../memory/schema.js";
 import type { RouteDefinition } from "../http-router.js";
 
 // ---------------------------------------------------------------------------
@@ -24,6 +28,39 @@ interface StarterItem {
   prompt: string;
   category: string | null;
   batch: number;
+}
+
+const CK_ITEM_COUNT = "conversation_starters:item_count_at_last_gen";
+const CK_LAST_GEN_AT = "conversation_starters:last_gen_at";
+export const CONVERSATION_STARTERS_STALE_TTL_MS = 24 * 60 * 60 * 1000;
+
+function checkpointKey(base: string, scopeId: string): string {
+  return `${base}:${scopeId}`;
+}
+
+function parseCheckpointInt(value: string | undefined): number | null {
+  if (!value) return null;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function hasActiveConversationStarterJob(
+  db: ReturnType<typeof getDb>,
+  scopeId: string,
+): boolean {
+  return (
+    db
+      .select({ id: memoryJobs.id })
+      .from(memoryJobs)
+      .where(
+        and(
+          eq(memoryJobs.type, "generate_conversation_starters"),
+          inArray(memoryJobs.status, ["pending", "running"]),
+          sql`json_extract(${memoryJobs.payload}, '$.scopeId') = ${scopeId}`,
+        ),
+      )
+      .get() != null
+  );
 }
 
 /**
@@ -150,14 +187,47 @@ function handleListConversationStarters(url: URL): Response {
 
   const total = allItems.length;
 
-  // If starters exist, reorder for category diversity then paginate.
+  // If starters exist, return them immediately. If the batch is stale or
+  // the generation checkpoint is ahead of the current active memory count,
+  // kick off a background refresh but keep the existing chips visible.
   if (total > 0) {
+    const totalActive =
+      rawGet<{ c: number }>(
+        `SELECT COUNT(*) AS c FROM memory_graph_nodes WHERE fidelity != 'gone' AND scope_id = ?`,
+        scopeId,
+      )?.c ?? 0;
+    const lastCount = parseCheckpointInt(
+      db
+        .select({ value: memoryCheckpoints.value })
+        .from(memoryCheckpoints)
+        .where(eq(memoryCheckpoints.key, checkpointKey(CK_ITEM_COUNT, scopeId)))
+        .get()?.value,
+    );
+    const lastGenAt = parseCheckpointInt(
+      db
+        .select({ value: memoryCheckpoints.value })
+        .from(memoryCheckpoints)
+        .where(eq(memoryCheckpoints.key, checkpointKey(CK_LAST_GEN_AT, scopeId)))
+        .get()?.value,
+    );
+    const staleByAge =
+      lastGenAt == null ||
+      Date.now() - lastGenAt >= CONVERSATION_STARTERS_STALE_TTL_MS;
+    const checkpointAhead = lastCount != null && totalActive < lastCount;
+    let hasActiveJob = hasActiveConversationStarterJob(db, scopeId);
+    const shouldRefresh = staleByAge || checkpointAhead;
+
+    if (shouldRefresh && !hasActiveJob) {
+      enqueueMemoryJob("generate_conversation_starters", { scopeId });
+      hasActiveJob = true;
+    }
+
     const ordered = orderStrongestFirst(allItems);
     const page = ordered.slice(offsetParam, offsetParam + limitParam);
     return Response.json({
       starters: page,
       total,
-      status: "ready",
+      status: hasActiveJob ? "refreshing" : "ready",
     });
   }
 
@@ -172,17 +242,7 @@ function handleListConversationStarters(url: URL): Response {
   }
 
   // Memory items exist but no starters yet — ensure a generation job is queued.
-  const existing = db
-    .select({ id: memoryJobs.id })
-    .from(memoryJobs)
-    .where(
-      and(
-        eq(memoryJobs.type, "generate_conversation_starters"),
-        inArray(memoryJobs.status, ["pending", "running"]),
-        like(memoryJobs.payload, `%"scopeId":"${scopeId}"%`),
-      ),
-    )
-    .get();
+  const existing = hasActiveConversationStarterJob(db, scopeId);
 
   if (!existing) {
     enqueueMemoryJob("generate_conversation_starters", { scopeId });
@@ -227,7 +287,9 @@ export function conversationStarterRouteDefinitions(): RouteDefinition[] {
           .array(z.unknown())
           .describe("Ordered list of starter chips"),
         total: z.number().int().describe("Total number of available starters"),
-        status: z.string().describe("One of: ready, empty, generating"),
+        status: z
+          .enum(["ready", "refreshing", "empty", "generating"])
+          .describe("One of: ready, refreshing, empty, generating"),
       }),
     },
   ];

--- a/clients/shared/Features/Chat/ChatGreetingState.swift
+++ b/clients/shared/Features/Chat/ChatGreetingState.swift
@@ -48,15 +48,18 @@ public final class ChatGreetingState {
 
     @ObservationIgnored private let btwClient: any BtwClientProtocol
     @ObservationIgnored private let conversationStarterClient: any ConversationStarterClientProtocol
+    @ObservationIgnored private let conversationStarterPollIntervalNanoseconds: UInt64
 
     // MARK: - Init
 
     init(
         btwClient: any BtwClientProtocol = BtwClient(),
-        conversationStarterClient: any ConversationStarterClientProtocol = ConversationStarterClient()
+        conversationStarterClient: any ConversationStarterClientProtocol = ConversationStarterClient(),
+        conversationStarterPollIntervalNanoseconds: UInt64 = 3_000_000_000
     ) {
         self.btwClient = btwClient
         self.conversationStarterClient = conversationStarterClient
+        self.conversationStarterPollIntervalNanoseconds = conversationStarterPollIntervalNanoseconds
     }
 
     // MARK: - Empty-State Greeting Generation
@@ -113,34 +116,28 @@ public final class ChatGreetingState {
             let response = await self.conversationStarterClient.fetchConversationStarters(limit: 4)
             guard !Task.isCancelled else { return }
 
-            if let response, !response.starters.isEmpty {
-                self.conversationStarters = response.starters
-                self.conversationStartersLoading = false
-                return
-            }
-
-            if response?.status == "generating" {
-                self.conversationStartersLoading = true
-                // Poll every 3 seconds until ready
+            if self.applyConversationStarterResponse(response) {
                 while !Task.isCancelled {
-                    try? await Task.sleep(nanoseconds: 3_000_000_000)
+                    try? await Task.sleep(nanoseconds: self.conversationStarterPollIntervalNanoseconds)
                     guard !Task.isCancelled else { return }
                     let poll = await self.conversationStarterClient.fetchConversationStarters(limit: 4)
                     guard !Task.isCancelled else { return }
-                    if let poll, !poll.starters.isEmpty {
-                        self.conversationStarters = poll.starters
-                        self.conversationStartersLoading = false
-                        return
-                    }
-                    if poll?.status != "generating" {
-                        self.conversationStartersLoading = false
+                    if !self.applyConversationStarterResponse(poll) {
                         return
                     }
                 }
-            } else {
-                self.conversationStartersLoading = false
             }
         }
+    }
+
+    private func applyConversationStarterResponse(_ response: ConversationStartersResponse?) -> Bool {
+        if let response, !response.starters.isEmpty {
+            conversationStarters = response.starters
+        }
+
+        let shouldPoll = response?.status == "generating" || response?.status == "refreshing"
+        conversationStartersLoading = shouldPoll
+        return shouldPoll
     }
 
     /// Cancel all in-flight tasks. Called from ChatViewModel's nonisolated deinit.

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -36,7 +36,7 @@ public struct ConversationStarter: Identifiable, Codable {
 struct ConversationStartersResponse: Codable {
     let starters: [ConversationStarter]
     let total: Int
-    let status: String  // "ready", "generating", "empty"
+    let status: String  // "ready", "refreshing", "generating", "empty"
 }
 
 @MainActor

--- a/clients/shared/Tests/ChatGreetingStateTests.swift
+++ b/clients/shared/Tests/ChatGreetingStateTests.swift
@@ -1,0 +1,73 @@
+import XCTest
+@testable import VellumAssistantShared
+
+@MainActor
+final class ChatGreetingStateTests: XCTestCase {
+
+    private final class StubConversationStarterClient: ConversationStarterClientProtocol {
+        var responses: [ConversationStartersResponse?] = []
+        var fetchCallCount = 0
+
+        func fetchConversationStarters(limit: Int) async -> ConversationStartersResponse? {
+            fetchCallCount += 1
+            guard !responses.isEmpty else { return nil }
+            return responses.removeFirst()
+        }
+    }
+
+    private func makeStarter(id: String, label: String) -> ConversationStarter {
+        ConversationStarter(
+            id: id,
+            label: label,
+            prompt: "prompt for \(label)",
+            category: "productivity",
+            batch: 1
+        )
+    }
+
+    func testRefreshingResponseKeepsExistingStartersVisibleAndPollsUntilReady() async {
+        let staleStarters = [
+            makeStarter(id: "old-1", label: "Old starter 1"),
+            makeStarter(id: "old-2", label: "Old starter 2"),
+        ]
+        let freshStarters = [
+            makeStarter(id: "new-1", label: "New starter 1"),
+            makeStarter(id: "new-2", label: "New starter 2"),
+        ]
+
+        let client = StubConversationStarterClient()
+        client.responses = [
+            ConversationStartersResponse(
+                starters: staleStarters,
+                total: staleStarters.count,
+                status: "refreshing"
+            ),
+            ConversationStartersResponse(
+                starters: freshStarters,
+                total: freshStarters.count,
+                status: "ready"
+            ),
+        ]
+
+        let state = ChatGreetingState(
+            conversationStarterClient: client,
+            conversationStarterPollIntervalNanoseconds: 50_000_000
+        )
+
+        state.fetchConversationStarters()
+        await Task.yield()
+        await Task.yield()
+
+        XCTAssertEqual(state.conversationStarters.map(\.id), ["old-1", "old-2"])
+        XCTAssertTrue(state.conversationStartersLoading)
+        XCTAssertEqual(client.fetchCallCount, 1)
+
+        try? await Task.sleep(nanoseconds: 80_000_000)
+
+        XCTAssertEqual(state.conversationStarters.map(\.id), ["new-1", "new-2"])
+        XCTAssertFalse(state.conversationStartersLoading)
+        XCTAssertEqual(client.fetchCallCount, 2)
+
+        state.cancelAll()
+    }
+}


### PR DESCRIPTION
## Summary
- Backend: the conversation starters endpoint now detects stale batches (age > 24h or memory count below checkpoint) and enqueues a background refresh while serving existing starters with a new `"refreshing"` status
- Backend: the cadence module triggers a refresh immediately when active memory drops below the last-generation checkpoint, instead of only firing on net-new growth past a threshold
- Client: `ChatGreetingState` handles the `"refreshing"` status by keeping existing chips visible and polling until ready, so users see stale-but-useful starters rather than a loading spinner
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24445" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
