### PR TITLE
test(macos): gate PodRuntimeTests on macOS 26.0 availability

### DIFF
--- a/clients/macos/vellum-assistantTests/PodRuntimeTests.swift
+++ b/clients/macos/vellum-assistantTests/PodRuntimeTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import VellumAssistantLib
 
+@available(macOS 26.0, *)
 final class PodRuntimeTests: XCTestCase {
 
     // MARK: - Configuration defaults


### PR DESCRIPTION
## Summary
- Add \`@available(macOS 26.0, *)\` to \`PodRuntimeTests\` so the test class compiles on CI runners with a deployment target below macOS 26.0.
- \`AppleContainersPodRuntime\` (and its nested types) are macOS 26.0+; the existing test class referenced them without an availability marker, causing compile errors in \`testDefaultConfigurationValues\` and \`testMissingImageRefErrorDescription\`.

## Original prompt
Fix CI compile error: \`'AppleContainersPodRuntime' is only available in macOS 26.0 or newer\` in \`clients/macos/vellum-assistantTests/PodRuntimeTests.swift\`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24447" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
