### PR TITLE
Persist computer access as conversation state

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -2406,7 +2406,12 @@ paths:
                     description: Total number of available starters
                   status:
                     type: string
-                    description: "One of: ready, empty, generating"
+                    enum:
+                      - ready
+                      - refreshing
+                      - empty
+                      - generating
+                    description: "One of: ready, refreshing, empty, generating"
                 required:
                   - starters
                   - total

--- a/assistant/src/__tests__/conversation-fork-crud.test.ts
+++ b/assistant/src/__tests__/conversation-fork-crud.test.ts
@@ -35,6 +35,7 @@ import {
   addMessage,
   createConversation,
   forkConversation,
+  getConversationHostAccess,
   getMessages,
   PRIVATE_CONVERSATION_FORK_ERROR,
 } from "../memory/conversation-crud.js";
@@ -136,6 +137,22 @@ describe("forkConversation", () => {
         (message, index) => message.id !== sourceMessages[index]?.id,
       ),
     ).toBe(true);
+  });
+
+  test("forked conversations start with host access disabled", async () => {
+    const source = createConversation({
+      title: "Computer-enabled thread",
+      hostAccess: true,
+    });
+    await addMessage(source.id, "user", "Use the computer", undefined, {
+      skipIndexing: true,
+    });
+
+    const fork = forkConversation({ conversationId: source.id });
+
+    expect(getConversationHostAccess(source.id)).toBe(true);
+    expect(getConversationHostAccess(fork.id)).toBe(false);
+    expect(fork.hostAccess).toBe(0);
   });
 
   test("preserves source order when source messages share a timestamp", () => {

--- a/assistant/src/__tests__/conversation-store.test.ts
+++ b/assistant/src/__tests__/conversation-store.test.ts
@@ -1,4 +1,7 @@
+import { Database } from "bun:sqlite";
 import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
 
 mock.module("../util/logger.js", () => ({
   getLogger: () =>
@@ -19,15 +22,27 @@ import {
   createConversation,
   deleteLastExchange,
   getConversation,
+  getConversationHostAccess,
   getConversationMemoryScopeId,
   getConversationType,
   getMessages,
+  updateConversationHostAccess,
 } from "../memory/conversation-crud.js";
 import { isLastUserMessageToolResult } from "../memory/conversation-queries.js";
 import { getDb, initializeDb } from "../memory/db.js";
+import { getSqliteFrom } from "../memory/db-connection.js";
+import { migrateConversationHostAccess } from "../memory/migrations/217-conversation-host-access.js";
+import * as schema from "../memory/schema.js";
 
 // Initialize db once before all tests
 initializeDb();
+
+function createMigrationTestDb() {
+  const sqlite = new Database(":memory:");
+  sqlite.exec("PRAGMA journal_mode=WAL");
+  sqlite.exec("PRAGMA foreign_keys = ON");
+  return drizzle(sqlite, { schema });
+}
 
 describe("deleteLastExchange", () => {
   beforeEach(() => {
@@ -406,6 +421,7 @@ describe("conversation metadata defaults", () => {
     expect(loaded).not.toBeNull();
     expect(loaded!.conversationType).toBe("standard");
     expect(loaded!.memoryScopeId).toBe("default");
+    expect(loaded!.hostAccess).toBe(0);
   });
 
   test("existing conversations without explicit values get defaults via migration", () => {
@@ -422,6 +438,7 @@ describe("conversation metadata defaults", () => {
     expect(loaded).not.toBeNull();
     expect(loaded!.conversationType).toBe("standard");
     expect(loaded!.memoryScopeId).toBe("default");
+    expect(loaded!.hostAccess).toBe(0);
   });
 });
 
@@ -505,6 +522,163 @@ describe("conversation metadata read helpers", () => {
 
   test("getConversationMemoryScopeId returns default for missing conversation", () => {
     expect(getConversationMemoryScopeId("nonexistent-id")).toBe("default");
+  });
+
+  test("getConversationHostAccess returns false by default", () => {
+    const conv = createConversation("test");
+    expect(getConversationHostAccess(conv.id)).toBe(false);
+  });
+
+  test("getConversationHostAccess returns false for missing conversation", () => {
+    expect(getConversationHostAccess("nonexistent-id")).toBe(false);
+  });
+});
+
+describe("conversation host access persistence", () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run(`DELETE FROM messages`);
+    db.run(`DELETE FROM conversations`);
+  });
+
+  test("new conversations default host access to disabled", () => {
+    const conv = createConversation("test");
+    const loaded = getConversation(conv.id);
+
+    expect(conv.hostAccess).toBe(0);
+    expect(loaded).not.toBeNull();
+    expect(loaded!.hostAccess).toBe(0);
+    expect(getConversationHostAccess(conv.id)).toBe(false);
+  });
+
+  test("updateConversationHostAccess persists mutations", () => {
+    const conv = createConversation("test");
+
+    updateConversationHostAccess(conv.id, true);
+    expect(getConversationHostAccess(conv.id)).toBe(true);
+    expect(getConversation(conv.id)?.hostAccess).toBe(1);
+
+    updateConversationHostAccess(conv.id, false);
+    expect(getConversationHostAccess(conv.id)).toBe(false);
+    expect(getConversation(conv.id)?.hostAccess).toBe(0);
+  });
+});
+
+describe("conversation host access migration", () => {
+  function bootstrapPreHostAccessConversations(raw: Database): void {
+    raw.exec(/*sql*/ `
+      CREATE TABLE conversations (
+        id TEXT PRIMARY KEY,
+        title TEXT,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL,
+        total_input_tokens INTEGER NOT NULL DEFAULT 0,
+        total_output_tokens INTEGER NOT NULL DEFAULT 0,
+        total_estimated_cost REAL NOT NULL DEFAULT 0,
+        context_summary TEXT,
+        context_compacted_message_count INTEGER NOT NULL DEFAULT 0,
+        context_compacted_at INTEGER,
+        conversation_type TEXT NOT NULL DEFAULT 'standard',
+        source TEXT NOT NULL DEFAULT 'user',
+        memory_scope_id TEXT NOT NULL DEFAULT 'default',
+        origin_channel TEXT,
+        origin_interface TEXT,
+        fork_parent_conversation_id TEXT,
+        fork_parent_message_id TEXT,
+        is_auto_title INTEGER NOT NULL DEFAULT 1,
+        schedule_job_id TEXT,
+        last_message_at INTEGER
+      )
+    `);
+  }
+
+  test("migration adds host access with disabled default for existing rows", () => {
+    const db = createMigrationTestDb();
+    const raw = getSqliteFrom(db);
+    const now = Date.now();
+
+    bootstrapPreHostAccessConversations(raw);
+    raw.exec(/*sql*/ `
+      INSERT INTO conversations (
+        id,
+        title,
+        created_at,
+        updated_at,
+        conversation_type,
+        source,
+        memory_scope_id,
+        is_auto_title
+      ) VALUES (
+        'conv-upgrade',
+        'Existing conversation',
+        ${now},
+        ${now},
+        'standard',
+        'user',
+        'default',
+        1
+      )
+    `);
+
+    migrateConversationHostAccess(db);
+
+    const row = raw
+      .query(
+        `SELECT id, title, host_access FROM conversations WHERE id = 'conv-upgrade'`,
+      )
+      .get() as {
+      id: string;
+      title: string | null;
+      host_access: number;
+    } | null;
+
+    expect(row).toEqual({
+      id: "conv-upgrade",
+      title: "Existing conversation",
+      host_access: 0,
+    });
+  });
+
+  test("re-running the migration preserves existing host access values", () => {
+    const db = createMigrationTestDb();
+    const raw = getSqliteFrom(db);
+    const now = Date.now();
+
+    bootstrapPreHostAccessConversations(raw);
+    raw.exec(/*sql*/ `
+      INSERT INTO conversations (
+        id,
+        title,
+        created_at,
+        updated_at,
+        conversation_type,
+        source,
+        memory_scope_id,
+        is_auto_title
+      ) VALUES (
+        'conv-rerun',
+        'Existing conversation',
+        ${now},
+        ${now},
+        'standard',
+        'user',
+        'default',
+        1
+      )
+    `);
+
+    migrateConversationHostAccess(db);
+    raw.exec(
+      `UPDATE conversations SET host_access = 1 WHERE id = 'conv-rerun'`,
+    );
+
+    expect(() => migrateConversationHostAccess(db)).not.toThrow();
+
+    const row = raw
+      .query(`SELECT host_access FROM conversations WHERE id = 'conv-rerun'`)
+      .get() as { host_access: number } | null;
+
+    expect(row).toEqual({ host_access: 1 });
   });
 });
 

--- a/assistant/src/__tests__/conversation-store.test.ts
+++ b/assistant/src/__tests__/conversation-store.test.ts
@@ -567,6 +567,14 @@ describe("conversation host access persistence", () => {
 describe("conversation host access migration", () => {
   function bootstrapPreHostAccessConversations(raw: Database): void {
     raw.exec(/*sql*/ `
+      CREATE TABLE memory_checkpoints (
+        key TEXT PRIMARY KEY,
+        value TEXT NOT NULL,
+        updated_at INTEGER NOT NULL
+      )
+    `);
+
+    raw.exec(/*sql*/ `
       CREATE TABLE conversations (
         id TEXT PRIMARY KEY,
         title TEXT,
@@ -637,6 +645,13 @@ describe("conversation host access migration", () => {
       title: "Existing conversation",
       host_access: 0,
     });
+
+    const checkpoint = raw
+      .query(
+        `SELECT value FROM memory_checkpoints WHERE key = 'migration_conversation_host_access_v1'`,
+      )
+      .get() as { value: string } | null;
+    expect(checkpoint?.value).toBe("1");
   });
 
   test("re-running the migration preserves existing host access values", () => {
@@ -677,8 +692,14 @@ describe("conversation host access migration", () => {
     const row = raw
       .query(`SELECT host_access FROM conversations WHERE id = 'conv-rerun'`)
       .get() as { host_access: number } | null;
+    const checkpoint = raw
+      .query(
+        `SELECT value FROM memory_checkpoints WHERE key = 'migration_conversation_host_access_v1'`,
+      )
+      .get() as { value: string } | null;
 
     expect(row).toEqual({ host_access: 1 });
+    expect(checkpoint?.value).toBe("1");
   });
 });
 

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -170,6 +170,7 @@ export interface ConversationRow {
   originInterface: string | null;
   forkParentConversationId: string | null;
   forkParentMessageId: string | null;
+  hostAccess: number;
   isAutoTitle: number;
   scheduleJobId: string | null;
   lastMessageAt: number | null;
@@ -196,6 +197,7 @@ export const parseConversation = createRowMapper<
   originInterface: "originInterface",
   forkParentConversationId: "forkParentConversationId",
   forkParentMessageId: "forkParentMessageId",
+  hostAccess: "hostAccess",
   isAutoTitle: "isAutoTitle",
   scheduleJobId: "scheduleJobId",
   lastMessageAt: "lastMessageAt",
@@ -245,6 +247,7 @@ export function createConversation(
         source?: string;
         scheduleJobId?: string;
         groupId?: string;
+        hostAccess?: boolean;
       },
 ) {
   const db = getDb();
@@ -276,6 +279,7 @@ export function createConversation(
     contextSummary: null as string | null,
     contextCompactedMessageCount: 0,
     contextCompactedAt: null as number | null,
+    hostAccess: opts.hostAccess ? 1 : 0,
     conversationType,
     source,
     memoryScopeId,
@@ -386,6 +390,11 @@ export function getConversationType(
 export function getConversationMemoryScopeId(conversationId: string): string {
   const conv = getConversation(conversationId);
   return conv?.memoryScopeId ?? "default";
+}
+
+export function getConversationHostAccess(conversationId: string): boolean {
+  const conv = getConversation(conversationId);
+  return conv?.hostAccess === 1;
 }
 
 /**
@@ -1117,6 +1126,20 @@ export function updateConversationContextWindow(
       contextSummary,
       contextCompactedMessageCount,
       contextCompactedAt: Date.now(),
+      updatedAt: Date.now(),
+    })
+    .where(eq(conversations.id, id))
+    .run();
+}
+
+export function updateConversationHostAccess(
+  id: string,
+  hostAccess: boolean,
+): void {
+  const db = getDb();
+  db.update(conversations)
+    .set({
+      hostAccess: hostAccess ? 1 : 0,
       updatedAt: Date.now(),
     })
     .where(eq(conversations.id, id))

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -58,6 +58,7 @@ import {
   migrateContactsRolePrincipal,
   migrateContactsUserFileColumn,
   migrateConversationForkLineage,
+  migrateConversationHostAccess,
   migrateConversationsLastMessageAt,
   migrateConversationsThreadTypeIndex,
   migrateCreateConversationGraphMemoryState,
@@ -360,6 +361,7 @@ export function initializeDb(): void {
     migrateOAuthProvidersRefreshUrl,
     migrateOAuthProvidersRevoke,
     migrateOAuthProvidersTokenAuthMethodDefault,
+    migrateConversationHostAccess,
   ];
 
   // Run each migration step, catching and logging individual failures so one

--- a/assistant/src/memory/migrations/217-conversation-host-access.ts
+++ b/assistant/src/memory/migrations/217-conversation-host-access.ts
@@ -1,5 +1,8 @@
 import type { DrizzleDb } from "../db-connection.js";
 import { getSqliteFrom } from "../db-connection.js";
+import { withCrashRecovery } from "./validate-migration-state.js";
+
+const CHECKPOINT_KEY = "migration_conversation_host_access_v1";
 
 /**
  * Add conversation-scoped host access state with a safe default of disabled.
@@ -7,21 +10,23 @@ import { getSqliteFrom } from "../db-connection.js";
  * Idempotent: ALTER TABLE is guarded and the backfill only touches NULL rows.
  */
 export function migrateConversationHostAccess(database: DrizzleDb): void {
-  const raw = getSqliteFrom(database);
+  withCrashRecovery(database, CHECKPOINT_KEY, () => {
+    const raw = getSqliteFrom(database);
 
-  try {
-    raw.exec(
-      `ALTER TABLE conversations ADD COLUMN host_access INTEGER NOT NULL DEFAULT 0`,
-    );
-  } catch {
-    // Column already exists.
-  }
+    try {
+      raw.exec(
+        `ALTER TABLE conversations ADD COLUMN host_access INTEGER NOT NULL DEFAULT 0`,
+      );
+    } catch {
+      // Column already exists.
+    }
 
-  raw.exec(`
-    UPDATE conversations
-    SET host_access = 0
-    WHERE host_access IS NULL
-  `);
+    raw.exec(`
+      UPDATE conversations
+      SET host_access = 0
+      WHERE host_access IS NULL
+    `);
+  });
 }
 
 /**

--- a/assistant/src/memory/migrations/217-conversation-host-access.ts
+++ b/assistant/src/memory/migrations/217-conversation-host-access.ts
@@ -1,0 +1,35 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+
+/**
+ * Add conversation-scoped host access state with a safe default of disabled.
+ *
+ * Idempotent: ALTER TABLE is guarded and the backfill only touches NULL rows.
+ */
+export function migrateConversationHostAccess(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+
+  try {
+    raw.exec(
+      `ALTER TABLE conversations ADD COLUMN host_access INTEGER NOT NULL DEFAULT 0`,
+    );
+  } catch {
+    // Column already exists.
+  }
+
+  raw.exec(`
+    UPDATE conversations
+    SET host_access = 0
+    WHERE host_access IS NULL
+  `);
+}
+
+/**
+ * Reverse: no-op.
+ *
+ * The forward migration is additive and SQLite cannot drop one column without
+ * rebuilding the table.
+ */
+export function downConversationHostAccess(_database: DrizzleDb): void {
+  // Intentionally empty.
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -158,6 +158,7 @@ export { migrateOAuthProvidersScopeSeparator } from "./213-oauth-providers-scope
 export { migrateOAuthProvidersRefreshUrl } from "./214-oauth-providers-refresh-url.js";
 export { migrateOAuthProvidersRevoke } from "./215-oauth-providers-revoke.js";
 export { migrateOAuthProvidersTokenAuthMethodDefault } from "./216-oauth-providers-token-auth-method.js";
+export { migrateConversationHostAccess } from "./217-conversation-host-access.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/migrations/registry.ts
+++ b/assistant/src/memory/migrations/registry.ts
@@ -41,6 +41,7 @@ import { migrateAddSourceTypeColumnsDown } from "./193-add-source-type-columns.j
 import { migrateStripIntegrationPrefixFromProviderKeysDown } from "./196-strip-integration-prefix-from-provider-keys.js";
 import { migrateRenameMemoryGraphTypeValuesDown } from "./204-rename-memory-graph-type-values.js";
 import { migrateScrubCorruptedImageAttachmentsDown } from "./206-scrub-corrupted-image-attachments.js";
+import { downConversationHostAccess } from "./217-conversation-host-access.js";
 
 export interface MigrationRegistryEntry {
   /** The checkpoint key written to memory_checkpoints on completion. */
@@ -356,6 +357,13 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     description:
       "Remove image attachments containing HTML error pages instead of image data",
     down: migrateScrubCorruptedImageAttachmentsDown,
+  },
+  {
+    key: "migration_conversation_host_access_v1",
+    version: 41,
+    description:
+      "Add a host_access column to conversations so computer access is persisted per conversation with a safe default of disabled",
+    down: downConversationHostAccess,
   },
 ];
 

--- a/assistant/src/memory/schema/conversations.ts
+++ b/assistant/src/memory/schema/conversations.ts
@@ -28,6 +28,7 @@ export const conversations = sqliteTable(
     originInterface: text("origin_interface"),
     forkParentConversationId: text("fork_parent_conversation_id"),
     forkParentMessageId: text("fork_parent_message_id"),
+    hostAccess: integer("host_access").notNull().default(0),
     isAutoTitle: integer("is_auto_title").notNull().default(1),
     scheduleJobId: text("schedule_job_id"),
     lastMessageAt: integer("last_message_at"),


### PR DESCRIPTION
## Summary
- add persisted conversation host access state to the conversations schema and CRUD helpers
- register the migration and cover defaults plus mutations in conversation store tests

Part of plan: v2-model-mediated-consent.md (PR 1 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24448" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
