### PR TITLE
Revert "test(macos): gate PodRuntimeTests on macOS 26.0 availability"

### DIFF
--- a/clients/macos/vellum-assistantTests/PodRuntimeTests.swift
+++ b/clients/macos/vellum-assistantTests/PodRuntimeTests.swift
@@ -1,7 +1,6 @@
 import XCTest
 @testable import VellumAssistantLib
 
-@available(macOS 26.0, *)
 final class PodRuntimeTests: XCTestCase {
 
     // MARK: - Configuration defaults


### PR DESCRIPTION
Reverts vellum-ai/vellum-assistant#24447
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24449" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
