### PR TITLE
fix(macOS): live-reload app preview when files change during editing

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
@@ -386,13 +386,18 @@ extension AppDelegate {
                     ))
                 case .appFilesChanged(let msg):
                     self.refreshAppsCache()
-                    // WebView reload is handled by the separate ui_surface_update
-                    // message which triggers updateNSView → reloadGeneration →
-                    // loadHTMLString with fresh compiled HTML. Calling
-                    // webView.reload() here would replay stale inline HTML for
-                    // surfaces loaded via loadHTMLString (isInlineFallback),
-                    // racing with the correct ui_surface_update path.
-                    _ = msg
+                    // Client-created surfaces (opened via sidebar/app grid)
+                    // aren't in the daemon's conversation surfaceState, so the
+                    // daemon's ui_surface_update never reaches them. Re-fetch
+                    // the compiled HTML and update the surface directly.
+                    if self.surfaceManager.surfaceAppIds.values.contains(msg.appId) {
+                        Task {
+                            guard let result = await AppsClient().openApp(id: msg.appId) else { return }
+                            await MainActor.run {
+                                self.surfaceManager.refreshAppSurface(appId: msg.appId, html: result.html)
+                            }
+                        }
+                    }
                 case .uiLayoutConfig(let msg):
                     self.mainWindow?.windowState.applyLayoutConfig(msg)
 

--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
@@ -311,6 +311,55 @@ final class SurfaceManager {
         log.info("Updated surface: id=\(message.surfaceId)")
     }
 
+    // MARK: - App Refresh
+
+    /// Refresh the displayed surface for an app with freshly compiled HTML.
+    /// Called when `app_files_changed` arrives and the affected app has an
+    /// active surface. Updates the in-memory surface state and notifies the
+    /// view layer so `updateNSView` picks up the new HTML via `reloadGeneration`.
+    func refreshAppSurface(appId: String, html: String) {
+        for (surfaceId, trackedAppId) in surfaceAppIds {
+            guard trackedAppId == appId else { continue }
+            guard let existing = activeSurfaces[surfaceId] else { continue }
+            guard case .dynamicPage(let dpData) = existing.data else { continue }
+
+            let updatedData = DynamicPageSurfaceData(
+                html: html,
+                width: dpData.width,
+                height: dpData.height,
+                appId: dpData.appId,
+                dirName: dpData.dirName,
+                appType: dpData.appType,
+                preview: dpData.preview,
+                reloadGeneration: (dpData.reloadGeneration ?? 0) + 1,
+                status: dpData.status
+            )
+
+            let updated = Surface(
+                id: existing.id,
+                conversationId: existing.conversationId,
+                type: existing.type,
+                title: existing.title,
+                data: .dynamicPage(updatedData),
+                actions: existing.actions
+            )
+
+            activeSurfaces[surfaceId] = updated
+
+            if workspaceRoutedSurfaces.contains(surfaceId) {
+                NotificationCenter.default.post(
+                    name: .updateDynamicWorkspace,
+                    object: nil,
+                    userInfo: ["surface": updated]
+                )
+            } else {
+                viewModels[surfaceId]?.surface = updated
+            }
+
+            log.info("Refreshed app surface: surfaceId=\(surfaceId, privacy: .public) appId=\(appId, privacy: .public)")
+        }
+    }
+
     // MARK: - Dismiss
 
     func dismissSurface(_ message: UiSurfaceDismissMessage) {


### PR DESCRIPTION
## Summary

- Fixes app preview not updating live when the assistant modifies files in workspace edit mode
- Client-created surfaces (opened via sidebar/app grid) use a synthetic `conversationId` (`"app-open"`) that's never registered in the daemon's conversation `surfaceState`, so `refreshSurfacesForApp` finds zero surfaces and `ui_surface_update` is never sent
- When `app_files_changed` arrives for an app with an active surface, re-fetch the compiled HTML from the daemon and update the surface state directly — triggering the existing `reloadGeneration` → `updateNSView` → `loadHTMLString` path

## Test plan

- [ ] Open an app from the sidebar/app grid
- [ ] Enter edit mode (click "Edit" or start chatting)
- [ ] Ask the assistant to change styling (e.g. "make it dark mode")
- [ ] Verify the preview updates live on the right without needing to collapse/reopen

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24450" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
