### PR TITLE
feat(oauth): add nullable `logo_url` column to oauth_providers

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -2406,7 +2406,12 @@ paths:
                     description: Total number of available starters
                   status:
                     type: string
-                    description: "One of: ready, empty, generating"
+                    enum:
+                      - ready
+                      - refreshing
+                      - empty
+                      - generating
+                    description: "One of: ready, refreshing, empty, generating"
                 required:
                   - starters
                   - total

--- a/assistant/src/__tests__/oauth-provider-serializer.test.ts
+++ b/assistant/src/__tests__/oauth-provider-serializer.test.ts
@@ -32,6 +32,7 @@ function makeRow(overrides: Partial<OAuthProviderRow> = {}): OAuthProviderRow {
     description: null,
     dashboardUrl: null,
     clientIdPlaceholder: null,
+    logoUrl: null,
     requiresClientSecret: 1,
     loopbackPort: null,
     injectionTemplates: null,

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -110,6 +110,7 @@ import {
   migrateOAuthProvidersBehaviorColumns,
   migrateOAuthProvidersDisplayMetadata,
   migrateOAuthProvidersFeatureFlag,
+  migrateOAuthProvidersLogoUrl,
   migrateOAuthProvidersManagedServiceConfigKey,
   migrateOAuthProvidersPingConfig,
   migrateOAuthProvidersPingUrl,
@@ -360,6 +361,7 @@ export function initializeDb(): void {
     migrateOAuthProvidersRefreshUrl,
     migrateOAuthProvidersRevoke,
     migrateOAuthProvidersTokenAuthMethodDefault,
+    migrateOAuthProvidersLogoUrl,
   ];
 
   // Run each migration step, catching and logging individual failures so one

--- a/assistant/src/memory/migrations/217-oauth-providers-logo-url.ts
+++ b/assistant/src/memory/migrations/217-oauth-providers-logo-url.ts
@@ -1,0 +1,11 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+
+export function migrateOAuthProvidersLogoUrl(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+  try {
+    raw.exec(`ALTER TABLE oauth_providers ADD COLUMN logo_url TEXT`);
+  } catch {
+    // Column already exists — nothing to do.
+  }
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -158,6 +158,7 @@ export { migrateOAuthProvidersScopeSeparator } from "./213-oauth-providers-scope
 export { migrateOAuthProvidersRefreshUrl } from "./214-oauth-providers-refresh-url.js";
 export { migrateOAuthProvidersRevoke } from "./215-oauth-providers-revoke.js";
 export { migrateOAuthProvidersTokenAuthMethodDefault } from "./216-oauth-providers-token-auth-method.js";
+export { migrateOAuthProvidersLogoUrl } from "./217-oauth-providers-logo-url.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema/oauth.ts
+++ b/assistant/src/memory/schema/oauth.ts
@@ -31,6 +31,7 @@ export const oauthProviders = sqliteTable("oauth_providers", {
   description: text("description"),
   dashboardUrl: text("dashboard_url"),
   clientIdPlaceholder: text("client_id_placeholder"),
+  logoUrl: text("logo_url"),
   requiresClientSecret: integer("requires_client_secret").notNull().default(1),
   loopbackPort: integer("loopback_port"),
   injectionTemplates: text("injection_templates"),

--- a/assistant/src/oauth/__tests__/identity-verifier.test.ts
+++ b/assistant/src/oauth/__tests__/identity-verifier.test.ts
@@ -51,6 +51,7 @@ function makeProviderRow(
     description: null,
     dashboardUrl: null,
     clientIdPlaceholder: null,
+    logoUrl: null,
     requiresClientSecret: 1,
     loopbackPort: null,
     injectionTemplates: null,

--- a/assistant/src/oauth/oauth-store.ts
+++ b/assistant/src/oauth/oauth-store.ts
@@ -349,6 +349,7 @@ export function registerProvider(params: {
     description: params.description ?? null,
     dashboardUrl: params.dashboardUrl ?? null,
     clientIdPlaceholder: params.clientIdPlaceholder ?? null,
+    logoUrl: null,
     requiresClientSecret: params.requiresClientSecret ?? 1,
     loopbackPort: params.loopbackPort ?? null,
     injectionTemplates: params.injectionTemplates


### PR DESCRIPTION
## Summary
- Add nullable `logo_url` TEXT column to `oauth_providers` via migration 217
- Extend Drizzle schema with `logoUrl: text("logo_url")`
- Wire migration into `db-init.ts` `migrationSteps` array

Part of plan: oauth-provider-logos.md (PR 1 of 9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24451" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
