### PR TITLE
feat(macos): decode logo_url on OAuthProviderMetadata

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -3362,10 +3362,17 @@ struct OAuthProviderMetadata: Codable, Sendable {
     let dashboard_url: String?
     let client_id_placeholder: String?
     let requires_client_secret: Bool
+    let logo_url: String?
 
     /// The platform OAuth slug is the provider_key itself (bare name, e.g. "google").
     var platformOAuthSlug: String {
         return provider_key
+    }
+
+    /// Parsed `URL?` for `logo_url`, or `nil` when the field is missing or malformed.
+    var logoURL: URL? {
+        guard let raw = logo_url, !raw.isEmpty else { return nil }
+        return URL(string: raw)
     }
 }
 


### PR DESCRIPTION
## Summary
- Add `logo_url: String?` field to `OAuthProviderMetadata`
- Add `logoURL: URL?` computed helper that validates and parses the raw string

Part of plan: oauth-provider-logos.md (PR 6 of 9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24452" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
