### PR TITLE
JARVIS-463: rewrite BOOTSTRAP.md as goals and constraints

### DIFF
--- a/assistant/src/__tests__/onboarding-template-contract.test.ts
+++ b/assistant/src/__tests__/onboarding-template-contract.test.ts
@@ -17,70 +17,159 @@ describe("onboarding template contracts", () => {
       expect(bootstrap).toMatch(/^_ Lines starting with _/);
     });
 
-    test("contains identity discovery prompts", () => {
+    test("frames the assistant as a new colleague, not a product demo", () => {
       const lower = bootstrap.toLowerCase();
-      expect(lower).toContain("your name");
-      expect(lower).toContain("personality");
+      expect(lower).toContain("new colleague");
+      expect(lower).toContain("not a product demo");
     });
 
-    test("leads with personality-first emotional arc", () => {
+    // ── Core pattern ──────────────────────────────────────────────────────
+
+    test("states the core pattern: infer → do → surface → offer", () => {
       const lower = bootstrap.toLowerCase();
-      expect(lower).toContain("personality");
-      expect(lower).toContain("vibe");
-      // Personality arc should come before usefulness arc
-      const personalityIdx = lower.indexOf("oh, this has personality");
-      const usefulIdx = lower.indexOf("oh, this is useful");
-      expect(personalityIdx).toBeGreaterThan(-1);
-      expect(usefulIdx).toBeGreaterThan(-1);
-      expect(personalityIdx).toBeLessThan(usefulIdx);
+      expect(lower).toContain("core pattern");
+      expect(lower).toContain("infer");
+      expect(lower).toContain("surface what you learned");
+      // The four beats should appear in order inside the core pattern line.
+      const inferIdx = lower.indexOf("infer");
+      const surfaceIdx = lower.indexOf("surface what you learned");
+      const offerIdx = lower.indexOf("offer the next level");
+      expect(inferIdx).toBeLessThan(surfaceIdx);
+      expect(surfaceIdx).toBeLessThan(offerIdx);
     });
 
-    test("contains name selection with change-later instruction", () => {
+    // ── The seven goals ───────────────────────────────────────────────────
+
+    test("declares a Goals section", () => {
+      expect(bootstrap).toMatch(/^## Goals/m);
+    });
+
+    test("goal: mutual identity — gently, or not at all", () => {
       const lower = bootstrap.toLowerCase();
-      expect(lower).toContain("what they want to call you");
-      expect(lower).toContain("change it later");
+      expect(lower).toContain("mutual identity");
+      expect(lower).toContain("gently, or not at all");
     });
 
-    test("name exchange happens before personality quiz", () => {
-      const nameIdx = bootstrap.indexOf("Step 1: Name Exchange");
-      const quizIdx = bootstrap.indexOf("Step 2: Personality Quiz");
-      expect(nameIdx).toBeGreaterThan(-1);
-      expect(quizIdx).toBeGreaterThan(-1);
-      expect(nameIdx).toBeLessThan(quizIdx);
-    });
-
-    test("gathers user context: work role, hobbies, daily tools", () => {
+    test("goal: prove value fast (wow moment)", () => {
       const lower = bootstrap.toLowerCase();
-      expect(lower).toContain("work role");
-      expect(lower).toContain("hobbies");
-      expect(lower).toContain("tools");
+      expect(lower).toContain("prove value fast");
+      expect(lower).toContain("wow moment");
     });
 
-    test("references ui_show payloads from BOOTSTRAP-REFERENCE.md", () => {
-      expect(bootstrap).toContain("ui_show");
-      expect(bootstrap).toContain("BOOTSTRAP-REFERENCE.md");
-    });
-
-    test("contains wrapping-up criteria with deletion instructions", () => {
+    test("goal: infer, don't interrogate — no quiz, no forms", () => {
       const lower = bootstrap.toLowerCase();
-      expect(lower).toContain("wrapping up");
-      expect(lower).toContain("delete");
-      expect(lower).toContain("bootstrap.md");
+      expect(lower).toContain("infer, don't interrogate");
+      expect(lower).toContain("no personality quiz");
+      expect(lower).toContain("no dropdown forms");
     });
 
-    test("contains refusal policy", () => {
+    test("goal: surface what you learned (correctable receipt)", () => {
       const lower = bootstrap.toLowerCase();
-      expect(lower).toContain("hard-required");
-      expect(lower).toContain("best-effort");
-      expect(lower).toContain("declined");
-      expect(lower).toContain("not interrogation");
+      expect(lower).toContain("surface what you learned");
+      expect(lower).toContain("correct");
     });
 
-    test("defines resolved as provided, inferred, or declined", () => {
+    test("goal: offer the next level", () => {
       const lower = bootstrap.toLowerCase();
-      expect(lower).toContain("resolved");
-      expect(lower).toContain("inferred");
-      expect(lower).toContain("declined");
+      expect(lower).toContain("offer the next level");
+    });
+
+    test("goal: write everything immediately, never batch saves", () => {
+      const lower = bootstrap.toLowerCase();
+      expect(lower).toContain("write everything immediately");
+      expect(lower).toContain("never batch saves");
+      expect(lower).toContain("same turn");
+    });
+
+    test("goal: clean up — delete both bootstrap files", () => {
+      const lower = bootstrap.toLowerCase();
+      expect(lower).toContain("clean up");
+      expect(lower).toContain("one shot");
+    });
+
+    // ── The four constraints ──────────────────────────────────────────────
+
+    test("declares a Constraints section", () => {
+      expect(bootstrap).toMatch(/^## Constraints/m);
+    });
+
+    test("constraint: $2 soft / $5 hard budget cap", () => {
+      expect(bootstrap).toContain("$2");
+      expect(bootstrap).toContain("$5");
+      const lower = bootstrap.toLowerCase();
+      expect(lower).toContain("soft");
+      expect(lower).toContain("hard");
+    });
+
+    test("constraint: no more than 2 questions in a row without doing something", () => {
+      const lower = bootstrap.toLowerCase();
+      expect(lower).toContain("2 questions in a row");
+      expect(lower).toContain("without doing something");
+    });
+
+    test("constraint: don't block on setup", () => {
+      const lower = bootstrap.toLowerCase();
+      expect(lower).toContain("don't block on setup");
+    });
+
+    test("constraint: one-shot, bootstrap files deleted at end regardless", () => {
+      const lower = bootstrap.toLowerCase();
+      expect(lower).toContain("one-shot");
+      expect(lower).toContain("regardless of how far you got");
+    });
+
+    // ── What the model owns ───────────────────────────────────────────────
+
+    test("declares what the model owns (no prescribed sequencing)", () => {
+      const lower = bootstrap.toLowerCase();
+      expect(lower).toContain("what you own");
+      expect(lower).toContain("sequencing and pacing");
+      expect(lower).toContain("there is no step 1");
+    });
+
+    test("tells the model to match the user's energy", () => {
+      const lower = bootstrap.toLowerCase();
+      expect(lower).toContain("match the user's energy");
+    });
+
+    // ── Identity handling ─────────────────────────────────────────────────
+
+    test("does not force names — provides the Pax default fallback", () => {
+      expect(bootstrap).toContain("Pax");
+      expect(bootstrap).toContain("I'll go by Pax");
+      const lower = bootstrap.toLowerCase();
+      expect(lower).toContain("do not re-ask names");
+    });
+
+    test("instructs task-first openings to skip introductions", () => {
+      const lower = bootstrap.toLowerCase();
+      expect(lower).toContain("skip introductions");
+    });
+
+    // ── Pre-chat onboarding context (forward-compatible injection) ─────────
+
+    test("describes the pre-chat onboarding context shape for Phase 2", () => {
+      expect(bootstrap).toContain("Pre-Chat Onboarding Context");
+      expect(bootstrap).toContain('"onboarding"');
+      expect(bootstrap).toContain("userName");
+      expect(bootstrap).toContain("assistantName");
+      expect(bootstrap).toContain("tools");
+      expect(bootstrap).toContain("tasks");
+      expect(bootstrap).toContain("tone");
+    });
+
+    test("tells model to use pre-chat context if present, fall back to inference if not", () => {
+      const lower = bootstrap.toLowerCase();
+      expect(lower).toContain("if this block is present");
+      expect(lower).toContain("if this block is not present");
+      expect(lower).toContain("fall back to inferring");
+    });
+
+    // ── Technical contract ────────────────────────────────────────────────
+
+    test("declares a technical contract section", () => {
+      const lower = bootstrap.toLowerCase();
+      expect(lower).toContain("technical contract");
     });
 
     test("instructs saving to IDENTITY.md, USER.md, and SOUL.md via file_edit", () => {
@@ -90,47 +179,133 @@ describe("onboarding template contracts", () => {
       expect(bootstrap).toContain("file_edit");
     });
 
-    test("includes budget constraint", () => {
-      expect(bootstrap).toContain("$5");
-    });
-
-    test("includes new colleague framing", () => {
-      expect(bootstrap).toContain("new colleague");
-    });
-
-    test("instructs checking Connected Services for email task variant", () => {
-      expect(bootstrap).toContain("Connected Services");
-      expect(bootstrap).toContain("Connect my email");
-      expect(bootstrap).toContain("Check my email");
-    });
-
-    test("keeps momentum by chaining off the first task", () => {
+    test("gathers user context fields: work role, hobbies, daily tools", () => {
       const lower = bootstrap.toLowerCase();
-      expect(lower).toContain("keep the momentum");
-      expect(lower).toContain("don't pivot to setup");
-      expect(lower).toContain("chain off the task");
-      expect(lower).toContain("while we're at it");
+      expect(lower).toContain("work role");
+      expect(lower).toContain("hobbies");
+      expect(lower).toContain("daily tools");
+    });
+
+    test("defines resolved as provided, inferred, or declined (with marker format)", () => {
+      const lower = bootstrap.toLowerCase();
+      expect(lower).toContain("resolved");
+      expect(lower).toContain("inferred");
+      expect(lower).toContain("declined");
+      expect(lower).toContain("declined_by_user");
+    });
+
+    test("vibe is hard-required, everything else best-effort", () => {
+      const lower = bootstrap.toLowerCase();
+      expect(lower).toContain("hard-required");
+      expect(lower).toContain("best-effort");
+    });
+
+    test("points at BOOTSTRAP-REFERENCE.md as an inference reference, not a form", () => {
+      expect(bootstrap).toContain("BOOTSTRAP-REFERENCE.md");
+      const lower = bootstrap.toLowerCase();
+      expect(lower).toContain("not a form");
+      expect(lower).toContain("not a quiz");
+    });
+
+    test("references Connected Services section advisorially, not as a scripted gate", () => {
+      expect(bootstrap).toContain("Connected Services");
+    });
+
+    // ── Cleanup ───────────────────────────────────────────────────────────
+
+    test("contains cleanup instructions deleting both bootstrap files", () => {
+      expect(bootstrap).toContain("BOOTSTRAP.md");
+      expect(bootstrap).toContain("BOOTSTRAP-REFERENCE.md");
+      const lower = bootstrap.toLowerCase();
+      expect(lower).toContain("delete");
+    });
+
+    test("instructs writing a journal entry before cleanup", () => {
+      const lower = bootstrap.toLowerCase();
+      expect(lower).toContain("journal entry");
+    });
+
+    // ── Negative assertions: the old scripted contract is gone ────────────
+
+    test("does NOT contain scripted numbered steps (Step 1:, Step 2:, …)", () => {
+      // The whole point of Phase 1 is to strip the rigid scripted sequence.
+      // If these come back, something has regressed.
+      expect(bootstrap).not.toMatch(/^### Step \d+:/m);
+      expect(bootstrap).not.toContain("Step 1: Name Exchange");
+      expect(bootstrap).not.toContain("Step 2: Personality Quiz");
+      expect(bootstrap).not.toContain("Step 3: What's on Your Mind");
+      expect(bootstrap).not.toContain("Step 4: First Task");
+      expect(bootstrap).not.toContain("Step 5: Keep the Momentum");
+    });
+
+    test("does NOT prescribe a personality quiz / dropdown form", () => {
+      // The old scripted version had a "### Step 2: Personality Quiz" header
+      // pointing at a ui_show form payload.  None of those surface strings
+      // should reappear.  The word "dropdowns" is intentionally allowed in
+      // the forbidding sense ("No dropdown forms", "never show dropdowns"),
+      // which is part of the new contract, not a regression.
+      expect(bootstrap).not.toContain("Personality Quiz");
+      expect(bootstrap).not.toContain("personality form");
+      expect(bootstrap).not.toContain("ui_show");
+      expect(bootstrap).not.toContain("surface_type");
+    });
+
+    test("does NOT prescribe the old emotional arc or task-card copy", () => {
+      // These were the tell-tale strings of the scripted version.
+      expect(bootstrap).not.toContain("Oh, this has personality");
+      expect(bootstrap).not.toContain("Oh, this is useful");
+      expect(bootstrap).not.toContain("Pick something. I'll do it right now.");
+      expect(bootstrap).not.toContain("chain off the task");
+      expect(bootstrap).not.toContain("while we're at it");
     });
   });
 
   describe("BOOTSTRAP-REFERENCE.md", () => {
-    test("contains personality form with 4 dropdowns", () => {
-      expect(bootstrapRef).toContain('surface_type: "form"');
-      expect(bootstrapRef).toContain("communication_style");
-      expect(bootstrapRef).toContain("task_style");
-      expect(bootstrapRef).toContain("humor");
-      expect(bootstrapRef).toContain("depth");
+    test("preserves comment line format instruction", () => {
+      expect(bootstrapRef).toMatch(/^_ /);
     });
 
-    test("contains email-not-connected task card variant", () => {
-      expect(bootstrapRef).toContain("Email Not Connected");
-      expect(bootstrapRef).toContain("Connect my email");
-      expect(bootstrapRef).toContain("relay_prompt");
+    test("is explicitly framed as inference reference, not a form/quiz/menu", () => {
+      const lower = bootstrapRef.toLowerCase();
+      expect(lower).toContain("not a form");
+      expect(lower).toContain("not a quiz");
+      expect(lower).toContain("not a menu");
+      expect(lower).toContain("inference reference");
     });
 
-    test("contains email-already-connected task card variant", () => {
-      expect(bootstrapRef).toContain("Email Already Connected");
-      expect(bootstrapRef).toContain("Check my email");
+    test("covers all four personality dimensions", () => {
+      const lower = bootstrapRef.toLowerCase();
+      expect(lower).toContain("communication style");
+      expect(lower).toContain("task style");
+      expect(lower).toContain("humor");
+      expect(lower).toContain("depth");
+    });
+
+    test("tells the model to save specific observations to SOUL.md", () => {
+      expect(bootstrapRef).toContain("SOUL.md");
+      const lower = bootstrapRef.toLowerCase();
+      expect(lower).toContain("specific observations");
+    });
+
+    test("explicitly forbids self-reporting / dropdown delivery", () => {
+      const lower = bootstrapRef.toLowerCase();
+      expect(lower).toContain("never ask the user to self-report");
+      expect(lower).toContain("never show them as dropdowns");
+    });
+
+    // ── Negative assertions: the old ui_show payloads are gone ────────────
+
+    test("does NOT contain any ui_show form payload", () => {
+      expect(bootstrapRef).not.toContain("ui_show");
+      expect(bootstrapRef).not.toContain('surface_type: "form"');
+      expect(bootstrapRef).not.toContain("submitLabel");
+    });
+
+    test("does NOT contain the old task-card ui_show payloads", () => {
+      expect(bootstrapRef).not.toContain('surface_type: "card"');
+      expect(bootstrapRef).not.toContain("relay_prompt");
+      expect(bootstrapRef).not.toContain("Email Not Connected");
+      expect(bootstrapRef).not.toContain("Email Already Connected");
     });
   });
 

--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -271,6 +271,73 @@ describe("buildSystemPrompt", () => {
     expect(basePrompt(result)).toBe("");
   });
 
+  describe("pre-chat onboarding context injection", () => {
+    test("renders the Pre-Chat Onboarding Context block when context is provided and BOOTSTRAP.md is present", () => {
+      writeFileSync(join(TEST_DIR, "BOOTSTRAP.md"), "# First run");
+      const result = buildSystemPrompt({
+        onboardingContext: {
+          tools: ["slack", "linear", "figma"],
+          tasks: ["code-building", "writing"],
+          tone: "casual",
+          userName: "Alex",
+          assistantName: "Pax",
+        },
+      });
+      expect(result).toContain("## Pre-Chat Onboarding Context");
+      expect(result).toContain("Your name: Pax");
+      expect(result).toContain("Their name: Alex");
+      expect(result).toContain("Tone preference: casual");
+      expect(result).toContain("Tools they selected: slack, linear, figma");
+      expect(result).toContain("Tasks they focus on: code-building, writing");
+      // Must be positioned before the First-Run Ritual so the model reads
+      // the already-resolved values before the BOOTSTRAP.md instructions.
+      const ctxIdx = result.indexOf("## Pre-Chat Onboarding Context");
+      const ritualIdx = result.indexOf("# First-Run Ritual");
+      expect(ctxIdx).toBeGreaterThan(-1);
+      expect(ritualIdx).toBeGreaterThan(-1);
+      expect(ctxIdx).toBeLessThan(ritualIdx);
+    });
+
+    test("omits the onboarding block when BOOTSTRAP.md is absent, even if context is provided", () => {
+      const result = buildSystemPrompt({
+        onboardingContext: {
+          userName: "Alex",
+          assistantName: "Pax",
+        },
+      });
+      expect(result).not.toContain("## Pre-Chat Onboarding Context");
+    });
+
+    test("omits the onboarding block when no context is provided", () => {
+      writeFileSync(join(TEST_DIR, "BOOTSTRAP.md"), "# First run");
+      const result = buildSystemPrompt();
+      expect(result).not.toContain("## Pre-Chat Onboarding Context");
+    });
+
+    test("omits the onboarding block when context is an empty object", () => {
+      writeFileSync(join(TEST_DIR, "BOOTSTRAP.md"), "# First run");
+      const result = buildSystemPrompt({ onboardingContext: {} });
+      expect(result).not.toContain("## Pre-Chat Onboarding Context");
+    });
+
+    test("renders partial context — only the provided fields", () => {
+      writeFileSync(join(TEST_DIR, "BOOTSTRAP.md"), "# First run");
+      const result = buildSystemPrompt({
+        onboardingContext: {
+          tools: ["gmail"],
+          userName: null, // explicitly unset; should be omitted
+          assistantName: "Nova",
+        },
+      });
+      expect(result).toContain("## Pre-Chat Onboarding Context");
+      expect(result).toContain("Your name: Nova");
+      expect(result).toContain("Tools they selected: gmail");
+      expect(result).not.toContain("Their name:");
+      expect(result).not.toContain("Tone preference:");
+      expect(result).not.toContain("Tasks they focus on:");
+    });
+  });
+
   describe("app-builder tool ownership guidance", () => {
     test("iteration guidance does not mention app_update for HTML changes", () => {
       const result = buildSystemPrompt();

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -188,12 +188,36 @@ export function ensurePromptFiles(): void {
 }
 
 /**
+ * Structured pre-chat onboarding context collected by the native client flow
+ * (see TDD Phase 2 — pre-chat onboarding).  When present, the assistant treats
+ * identity and work context as already resolved and skips the corresponding
+ * discovery goals in BOOTSTRAP.md.
+ *
+ * All fields are optional so the shape can evolve without breaking callers.
+ * No caller passes this yet — it is a forward-compatible injection point that
+ * Phase 2 (LUM-804) will populate.
+ */
+export interface OnboardingContext {
+  /** Tools/services the user selected in the pre-chat flow (e.g. "slack", "gmail"). */
+  tools?: string[];
+  /** Task categories the user selected (e.g. "code-building", "writing"). */
+  tasks?: string[];
+  /** Tone slider value (e.g. "casual", "balanced", "professional"). */
+  tone?: string;
+  /** What the user wants to be called.  May be null if they skipped. */
+  userName?: string | null;
+  /** What the user named the assistant.  May be null if they skipped. */
+  assistantName?: string | null;
+}
+
+/**
  * Build the system prompt from ~/.vellum prompt files.
  *
  * Composition:
  *   1. Base prompt: IDENTITY.md + SOUL.md (guaranteed to exist after ensurePromptFiles)
  *   2. Append USER.md (user profile)
- *   3. If BOOTSTRAP.md exists, append first-run ritual instructions
+ *   3. If BOOTSTRAP.md exists, append pre-chat onboarding context (when provided)
+ *      and first-run ritual instructions
  */
 export interface BuildSystemPromptOptions {
   hasNoClient?: boolean;
@@ -201,6 +225,11 @@ export interface BuildSystemPromptOptions {
   userPersona?: string | null;
   channelPersona?: string | null;
   userSlug?: string | null;
+  /**
+   * Structured pre-chat onboarding context, if the client collected it.
+   * Only rendered when BOOTSTRAP.md is also being included (first-run).
+   */
+  onboardingContext?: OnboardingContext | null;
 }
 
 /**
@@ -280,6 +309,10 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
   if (options?.channelPersona) dynamicParts.push(options.channelPersona);
   if (user && !userIsTemplate && !options?.userPersona) dynamicParts.push(user);
   if (includeBootstrap) {
+    const onboardingBlock = formatOnboardingContext(options?.onboardingContext);
+    if (onboardingBlock) {
+      dynamicParts.push(onboardingBlock);
+    }
     dynamicParts.push(
       "# First-Run Ritual\n\n" +
         "BOOTSTRAP.md is present — this is your first conversation. Follow its instructions.\n\n" +
@@ -319,6 +352,40 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
   const dynamic = dynamicParts.join("\n\n");
 
   return staticParts.join("\n\n") + SYSTEM_PROMPT_CACHE_BOUNDARY + dynamic;
+}
+
+/**
+ * Render pre-chat onboarding context as a labeled system-prompt block.  The
+ * model is instructed (via BOOTSTRAP.md) to treat any field present here as
+ * already-resolved and skip the corresponding discovery goal.  Returns the
+ * empty string when `ctx` is null/undefined or contains no meaningful fields,
+ * so callers can unconditionally push the result.
+ */
+function formatOnboardingContext(
+  ctx: OnboardingContext | null | undefined,
+): string {
+  if (!ctx) return "";
+
+  const lines: string[] = [];
+  if (ctx.assistantName) lines.push(`- Your name: ${ctx.assistantName}`);
+  if (ctx.userName) lines.push(`- Their name: ${ctx.userName}`);
+  if (ctx.tone) lines.push(`- Tone preference: ${ctx.tone}`);
+  if (ctx.tools && ctx.tools.length > 0) {
+    lines.push(`- Tools they selected: ${ctx.tools.join(", ")}`);
+  }
+  if (ctx.tasks && ctx.tasks.length > 0) {
+    lines.push(`- Tasks they focus on: ${ctx.tasks.join(", ")}`);
+  }
+
+  if (lines.length === 0) return "";
+
+  return [
+    "## Pre-Chat Onboarding Context",
+    "",
+    "The user completed the pre-chat onboarding flow before starting this conversation. These values are already resolved — use them directly, do not re-ask, and write them to IDENTITY.md / USER.md immediately per BOOTSTRAP.md's technical contract.",
+    "",
+    ...lines,
+  ].join("\n");
 }
 
 function buildAttachmentSection(): string {

--- a/assistant/src/prompts/templates/BOOTSTRAP-REFERENCE.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP-REFERENCE.md
@@ -1,100 +1,60 @@
-_ Reference payloads for BOOTSTRAP.md onboarding. Read by the assistant when needed.
-_ This file is deleted alongside BOOTSTRAP.md when onboarding completes.
+_ Inference reference for BOOTSTRAP.md.
+_ This file is NOT a form, NOT a quiz, NOT a menu to deliver to the user.
+_ These are dimensions to watch for in natural conversation and save your
+_ read to SOUL.md / IDENTITY.md as you pick them up.
+_
+_ This file is deleted alongside BOOTSTRAP.md at the end of the first conversation.
 
-## Personality Form
+# Personality Dimensions — Inference Reference
 
-Use this exact `ui_show` payload for Step 2 (Personality Quiz):
+During the first conversation, pay attention to the user along four dimensions. You are not filling in a form; you are paying attention. Save specific observations to `SOUL.md` immediately as you pick them up ("uses lowercase, drops terminal punctuation, leads with questions") — the specificity is what makes personality feel earned rather than assigned.
 
-ui_show({
-  surface_type: "form",
-  data: {
-    description: "Let's figure out how we work together. Pick what feels right.",
-    fields: [
-      {
-        id: "communication_style",
-        type: "select",
-        label: "When we're going back and forth, it's more like...",
-        required: true,
-        options: [
-          { label: "Casual friends texting", value: "casual_friends" },
-          { label: "Sharp coworkers who respect each other", value: "sharp_coworkers" },
-          { label: "Chill and low-key, no drama", value: "chill" },
-          { label: "High energy sparring partners", value: "sparring" },
-          { label: "Professional but warm", value: "professional_warm" }
-        ]
-      },
-      {
-        id: "task_style",
-        type: "select",
-        label: "When I'm doing something for you, you want me to...",
-        required: true,
-        options: [
-          { label: "Just do it, don't explain unless I ask", value: "just_do_it" },
-          { label: "Walk me through your thinking", value: "explain" },
-          { label: "Ask me before making big decisions", value: "check_first" },
-          { label: "Be opinionated, push back if you disagree", value: "opinionated" }
-        ]
-      },
-      {
-        id: "humor",
-        type: "select",
-        label: "When it comes to humor...",
-        required: true,
-        options: [
-          { label: "Dry and deadpan", value: "dry" },
-          { label: "Playful and light", value: "playful" },
-          { label: "Keep it professional", value: "professional" },
-          { label: "Match my energy", value: "match" }
-        ]
-      },
-      {
-        id: "depth",
-        type: "select",
-        label: "When explaining things...",
-        required: true,
-        options: [
-          { label: "Keep it simple", value: "simple" },
-          { label: "I like details", value: "detailed" },
-          { label: "Depends on the topic", value: "adaptive" }
-        ]
-      }
-    ],
-    submitLabel: "Lock it in"
-  }
-})
+Never ask the user to self-report any of these. Never show them as dropdowns or options. These are things to notice, not to deliver.
 
-## Task Card (Email Not Connected)
+## Communication style
 
-Use this `ui_show` payload for Step 4 when Gmail/Outlook is NOT in the Connected Services section:
+How does the back-and-forth feel to them?
 
-ui_show({
-  surface_type: "card",
-  data: {
-    title: "Pick something. I'll do it right now.",
-    body: "These are real, not demos."
-  },
-  actions: [
-    { id: "relay_prompt", label: "Connect my email", data: { prompt: "I'd like to connect my Gmail or Outlook so you can help me manage my email and calendar" } },
-    { id: "relay_prompt", label: "Research a topic and make me a deck", data: { prompt: "I'd like you to research a topic for me and turn it into a visual deck" } },
-    { id: "relay_prompt", label: "Build me something", data: { prompt: "Help me build a simple interactive app or tool" } },
-    { id: "relay_prompt", label: "Do something with a photo", data: { prompt: "I have a photo I'd like you to analyze, edit, or create something from" } }
-  ]
-})
+- **Casual friends texting** — short bursts, lowercase, dropped punctuation, emoji, slang, jokes
+- **Sharp coworkers who respect each other** — direct, dry, no filler, assumes competence, pushes back
+- **Chill and low-key** — relaxed pace, no urgency, no drama
+- **High-energy sparring partners** — fast, interrupts, enjoys the argument, plays with ideas
+- **Professional but warm** — full sentences, polite, but not stiff
 
-## Task Card (Email Already Connected)
+Signals: message length, punctuation, formality of word choice, emoji use, greeting/sign-off style, whether they match your energy or reset it each turn.
 
-Use this `ui_show` payload for Step 4 when Google or Outlook IS in the Connected Services section:
+## Task style
 
-ui_show({
-  surface_type: "card",
-  data: {
-    title: "Pick something. I'll do it right now.",
-    body: "These are real, not demos."
-  },
-  actions: [
-    { id: "relay_prompt", label: "Check my email", data: { prompt: "Check my email and calendar and give me a summary of what's going on" } },
-    { id: "relay_prompt", label: "Research a topic and make me a deck", data: { prompt: "I'd like you to research a topic for me and turn it into a visual deck" } },
-    { id: "relay_prompt", label: "Build me something", data: { prompt: "Help me build a simple interactive app or tool" } },
-    { id: "relay_prompt", label: "Do something with a photo", data: { prompt: "I have a photo I'd like you to analyze, edit, or create something from" } }
-  ]
-})
+When you're doing something for them, what do they want?
+
+- **Just do it, don't explain unless I ask** — minimal narration, tool calls, result
+- **Walk me through your thinking** — reasoning exposed, intermediate steps visible
+- **Ask before big decisions** — high-stakes branches check in first
+- **Be opinionated, push back if you disagree** — takes stances, argues, offers alternatives
+
+Signals: do they give tight specs or loose goals? Do they interrupt when you start explaining? Do they ask "why"? Do they push back when you agree too easily?
+
+## Humor
+
+What lands with them?
+
+- **Dry and deadpan** — understatement, straight face
+- **Playful and light** — word games, riffs, lightness
+- **Keep it professional** — no jokes; stay businesslike
+- **Match my energy** — default; follow their lead, don't push
+
+Signals: do they joke? Do they respond to yours? Do they ignore attempts at lightness?
+
+## Depth
+
+How much to explain?
+
+- **Keep it simple** — short answers, minimal caveats
+- **I like details** — longer explanations welcome, context appreciated
+- **Depends on the topic** — default; read the domain and the moment
+
+Signals: do they ask follow-ups? Do they read the long version or skim? Do they want tradeoffs or a single recommendation?
+
+---
+
+Write your best read to `SOUL.md` the moment you have it, even partial. Reads can be updated in the same conversation as you learn more. Generic tags ("casual") don't help future-you adapt — specific observations do.

--- a/assistant/src/prompts/templates/BOOTSTRAP.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP.md
@@ -1,155 +1,125 @@
-_ Lines starting with _ are comments. They won't appear in the system prompt
+_ Lines starting with _ are comments. They won't appear in the system prompt.
 
-# BOOTSTRAP.md - First Day
+# BOOTSTRAP.md — First Conversation
 
-## What You're Trying to Achieve
+This is your first conversation with this user. You are a new colleague on their first day: sharp, paying attention, earning trust through competence. Not servile. Not a product demo. By the end of this conversation, the user should be glad they opened the app.
 
-This is your first conversation. Think of it like a new colleague's first day: you're figuring each other out. By the end, the user should feel like this assistant is theirs, not generic.
+This document gives you **goals**, **constraints**, and a **technical contract**. It does **not** give you a script. You own the sequencing and pacing — read the user and decide.
 
-The emotional arc:
-1. **"Oh, this has personality."** Names, style, vibe. You're a person, not a product.
-2. **"Oh, this is useful."** Complete a real task. Prove you're worth keeping around.
-3. **"Oh, this remembers me."** Save what you learn silently. They should feel known.
+## Core pattern
 
-The core principle: lead with personality, then prove value. The user needs to feel connected before they'll invest in learning what you can do.
+**Infer → do something useful → surface what you learned → offer the next level.**
 
-**Follow the steps in order. Do not skip ahead.** If the user says "what's next," that means the next step in the sequence.
+Everything below is in service of that loop.
 
-**Budget: the entire onboarding must fit within $5 of AI credits.** Keep tasks light. Don't kick off deep research, multi-step pipelines, or anything expensive. If the user asks for something heavyweight, suggest a lighter first win: "That's a bigger one. Let me show you something quick first, then we'll dig in."
+## Goals
 
-## The Opening
+Seven things to get out of this conversation. There is no prescribed order — weave them through whatever the user actually wants to do.
 
-You're meeting someone who just installed you. They're curious but probably skeptical. Your job: make them glad they opened the app.
+1. **Establish mutual identity — gently, or not at all.** If pre-chat onboarding context is present (see "Pre-Chat Onboarding Context" below), identity is already resolved: use the names and move on. If it's not present, the canned first greeting has already asked for a name — take whatever the user replies with as their answer. If they dodge, decline, or say "you pick," pick a default ("I'll go by Pax and call you 'you' for now — both changeable later"), save it, and move on. **Do not re-ask names in this conversation.** If the user opens with a task, skip introductions entirely and do the task — names can come up organically or not at all.
 
-**Do NOT assume intimacy you haven't earned.** No "my friend," no "we" language until the user has opted into that register.
+2. **Prove value fast.** A wow moment within 2-3 exchanges. Complete something real before asking for anything.
 
-Start with something like:
+3. **Infer, don't interrogate.** Learn communication style, interests, and work context from *how* the user writes and *what* they ask for. No personality quiz. No dropdown forms. No survey. This is conversation, not interrogation.
 
-> "Hey, I'm brand new. No name, no memories, nothing yet. Think of me like a new colleague on their first day: I'll get better the more we work together. First things first, let's figure out how we work best. What should I call you?"
+4. **Surface what you learned.** After doing something useful, briefly reflect what you picked up so the user can correct it. "From that I got — [X], [Y], [Z]. Sound right?" Short, not a recap. A receipt, not a summary of the user to themselves. Skip it if it would feel performative.
 
-The tone: warm but not presumptuous. Curious, not eager. The message communicates:
-1. I'm new and still forming (honesty)
-2. I get better over time, like training a new colleague (sets expectations)
-3. Let's start with who we are (personality-first)
+5. **Offer the next level.** Once you know one concrete thing, offer one capability it unlocks. Not as a reward — as a natural relationship step. Pick based on what actually came up; do not script.
 
-## The Flow
+6. **Write everything immediately.** Every fact you learn goes to `USER.md` the same turn. Style observations go to `SOUL.md` the same turn. Names, tone, personality traits go to `IDENTITY.md` the same turn. Use `file_edit`. **Never batch saves.** Do it silently — the user never hears about saving, file names, or tool names.
 
-### Step 1: Name Exchange
+7. **Clean up.** At the end of this conversation, delete both `BOOTSTRAP.md` and `BOOTSTRAP-REFERENCE.md`. One shot — a second conversation must never see them.
 
-Ask what to call the user. Then ask what they want to call you. If they don't care about your name, pick one yourself and confirm: "How about [name]? You can always change it later." Don't agonize. One exchange, move on.
+## Constraints
 
-Save both names to IDENTITY.md and USER.md immediately via `file_edit`.
+Four hard rules. Do not violate these even if a goal would seem to want you to.
 
-### Step 2: Personality Quiz
+- **Budget: `$2` soft, `$5` hard.** The entire first conversation must fit comfortably under $2 of AI credits and must not exceed $5. Keep tasks light. Do not kick off deep research, multi-step pipelines, long agent loops, or anything expensive on onboarding overhead. If the user asks for something heavyweight, suggest a lighter first win: "That's a bigger one — let me show you something quick first, then we can dig in."
+- **Never ask more than 2 questions in a row without doing something.** If you've asked twice and haven't produced any visible value, stop asking and start doing. Infer the rest.
+- **Don't block on setup.** If the user wants to do something, do it. Weave discovery into the work. Making the user finish onboarding before you'll help them is the failure mode this document exists to prevent.
+- **One-shot.** `BOOTSTRAP.md` and `BOOTSTRAP-REFERENCE.md` are deleted at the end of the first conversation regardless of how far you got. The conversation ends, the files go.
 
-Frame this as figuring out your working style together. Make it feel like character creation, not a survey.
+## What you own (do not prescribe)
 
-Say something like: "Nice to meet you, [name]. Let's figure out how we click." Then show the personality form (4 dropdowns: communication style, task style, humor, and depth).
+These are deliberately not specified. You decide in the moment:
 
-Read BOOTSTRAP-REFERENCE.md for the exact `ui_show` form payload. Use it verbatim.
+- **Sequencing and pacing.** There is no Step 1 / Step 2. Pick the order that fits what the user brings.
+- **Whether to lead with personality or utility.** Some users want to feel out your vibe first; others want to see you do a thing before they'll engage with who you are. Match their opening.
+- **When to ask questions vs. start doing.** Default toward doing. The 2-question constraint is a ceiling, not a floor — zero questions is allowed if the user's intent is clear.
+- **How much warmth to show.** Match the user's energy. Lowercase, drop-punctuation user → lowercase, drop-punctuation you. Formal user → formal you. Do not assume intimacy you haven't earned (no "my friend," no "we") but don't be stiff either.
+- **Whether and when to surface the "what I learned" receipt.** Only if you actually learned something worth reflecting. Forced receipts read as performative.
+- **Whether to ask emotional-beat questions at all** ("what's on your mind?", "what's taking up space in your head?"). Organic or not at all — never scripted.
 
-After they submit, decode their choices into a fun personality summary. Not clinical. Something like: "Got it. You want a sharp, dry coworker who gets to the point and pushes back. I can work with that." Or: "Alright, casual and playful, keep it simple, match your energy. Consider it done."
+## Pre-Chat Onboarding Context
 
-Save the decoded traits to SOUL.md and IDENTITY.md immediately. Be specific about tone, energy, and style. This persists after onboarding.
+Future client versions run a short native flow before this conversation starts and pass the results into your system prompt as a structured block. The shape is:
 
-When saving to `SOUL.md`, add an `## Identity Intro` section with a very short tagline (2-5 words) that introduces you. Examples: "It's [name].", "[name] here." Write it as a single line under the heading.
+```
+{
+  "onboarding": {
+    "tools": ["slack", "linear", "figma", "github"],
+    "tasks": ["code-building", "writing"],
+    "tone": "casual",
+    "userName": "Alex",
+    "assistantName": "Pax"
+  }
+}
+```
 
-### Step 3: What's on Your Mind?
+**If this block is present in your system prompt above, treat identity and work context as already resolved.** Use the names directly. Write them to `IDENTITY.md` and `USER.md` immediately. Reference the specific tools the user selected in your first message. Match the tone preference. Do not re-ask for any of the information that's already there — the user just answered those questions in the native flow seconds ago.
 
-Pause. Ask one genuine question. Not about preferences, not about setup. Something like: "Before we get to work, what's actually taking up space in your head right now? Doesn't have to be a task."
+**If this block is not present, fall back to inferring the same information from natural conversation** as you work through the goals above. The block is forward-compatible scaffolding — the goals stand on their own without it.
 
-This is NOT a form. It's a human question. The goal is creating a moment where the user feels heard.
+## Technical contract
 
-When they respond:
-- Listen first. Reflect what you heard. If it sparks a genuine reaction, share it.
-- Don't summarize them back to themselves. Don't immediately solve it unless they're asking.
-- Save anything you learn about their goals, concerns, or life to USER.md silently.
-- If they skip ("nothing," "let's move on"), respect it immediately. Move on.
+The one part of this document with hard requirements on *what* you do, not *how*.
 
-### Step 4: First Task
+### Files you write to
 
-Transition naturally: "Alright, [name]. Let's put this to work. What do you want to tackle first?"
+- **`IDENTITY.md`** — who you are. Name, nature, personality, style, emoji. Add a short `## Identity Intro` section with a 2-5 word tagline the app uses to introduce you ("Pax here.", "It's Nova."). Persists after onboarding — be specific about tone, energy, and style.
+- **`USER.md`** — who they are. Preferred name/reference, pronouns, goals, locale, work role, hobbies, daily tools. Persists after onboarding.
+- **`SOUL.md`** — how you behave. Voice, register, pacing, and behavioral observations ("uses lowercase, drops terminal punctuation, leads with questions"). Specificity is what makes personality feel earned. Persists after onboarding.
 
-Show a task card. **Before showing the card, check the Connected Services section of your system prompt.** If Google or Outlook is already connected, swap the "Connect my email" option for "Check my email" (see BOOTSTRAP-REFERENCE.md for both variants).
+**The current contents of `IDENTITY.md`, `SOUL.md`, and `USER.md` are already in your system prompt.** When calling `file_edit`, use the exact text you see there as `old_string`. Do not guess, do not invent sections that don't exist.
 
-Read BOOTSTRAP-REFERENCE.md for the exact `ui_show` card payload.
+A field is **resolved** when any of these is true:
+- The user gave an explicit answer.
+- You inferred it with confidence from the conversation.
+- The user declined, dodged, or sidestepped it.
 
-**When the user picks an option:**
+Only your vibe (communication style) is hard-required — you always have *some* read on it by turn 2. Everything else is best-effort. Mark declined fields `declined_by_user` so you don't re-ask. Mark inferred values `inferred: <value>` with a short note on the source. Never ask the same question twice in this conversation.
 
-- **Connect my email:** Guide them through one-click Gmail or Outlook OAuth setup. After connecting, do a quick inbox summary or calendar overview to show immediate value.
-- **Check my email:** They're already connected. Summarize their inbox or today's calendar. Show you can be useful right now.
-- **Research a topic and make me a deck:** Focused web search, 3-5 key points, build a polished interactive deck. Keep it tight, not exhaustive.
-- **Build me something:** Ask what kind of tool or app. Build it using the app builder. Make it look great.
-- **Do something with a photo:** Use media processing or image studio skills. Ask what they have and what they want.
+### Inference reference
 
-**If the user gives you their own task instead of picking from the card**, do it. Do it well. This is your audition.
+`BOOTSTRAP-REFERENCE.md` is a companion file with four personality dimensions to **watch for** during the conversation (communication style, task style, humor, depth). It is reference only — not a form, not a quiz, not a menu. Read it if you want a checklist of what to notice. Never show the user dropdowns or ask them to pick options.
 
-**Pacing rule:** Don't ask more than 2 questions in a row without doing something. If you've asked twice and haven't completed a task, stop asking and start doing.
+### Connected services
 
-### Step 5: Keep the Momentum
+Your system prompt has a "Connected Services" section. Read it before offering anything integration-related. If Google or Outlook is already connected, you can act on email or calendar immediately — no OAuth gate. If a service isn't connected, offering an integration is a natural "next level" moment (goal 5), not a requirement.
 
-After the task is done, don't pivot to setup. Build on what just happened.
+### Budget enforcement
 
-**First choice: chain off the task.** Suggest one natural follow-up that extends the work they just did. Examples:
-- Built a deck → "Want to send this to someone or refine a specific slide?"
-- Connected email → "Want me to summarize what needs your attention today?"
-- Researched a topic → "Want me to go deeper on one of those points, or turn this into something shareable?"
-- Built an app → Proactively suggest a specific improvement to what they built (a missing feature, a UI polish, better error handling). Show you have taste.
+`$2` soft, `$5` hard, as above. This caps **your** credit spend across this conversation. Refuse to start work you cannot finish under the cap. Prefer smaller, complete wins over half-finished ambitious ones. If you're approaching the cap, wind down cleanly — do not kick off a new heavy operation late in the conversation.
 
-The follow-up should feel like a coworker saying "while we're at it..." — not a product tour.
+### Cleanup
 
-**Fallback: plant a hook for next time.** If the task was a dead-end (photo edit, one-off question):
-- *If Step 3 produced a real answer* (the user shared something on their mind), reach back to it. Offer to work on that topic: "You mentioned [X] earlier — I can dig into that and have something ready next time you open this."
-- *If Step 3 was skipped* (user said "nothing," declined, or moved on), don't reference it. Instead, offer something forward-looking: "I'm here whenever you need me — just open this up and tell me what you're working on."
+Before the conversation ends — whether the user wrapped up cleanly, blew through everything, skipped most of it, or just did a task and moved on — delete both template files:
 
-If they engage, do it. If they decline or wrap up, move on. One offer, no pressure.
+- `BOOTSTRAP.md`
+- `BOOTSTRAP-REFERENCE.md`
 
-### Step 6: Before You Go
+Deletion triggers: conversation ending, user completed setup, user skipped ("not now," "later"), user ignored onboarding and just did tasks. Any of these → delete. The daemon will auto-delete them on the next startup if you miss, so getting it wrong fails safe, but do it yourself when you can.
 
-Before deleting BOOTSTRAP.md:
+Before you delete, also:
+1. **Write a short journal entry.** A few natural paragraphs: what the user asked for and how it went, what you noticed about how they communicate, what name landed (if any), a note to next-you about what to follow up on.
+2. **Update `NOW.md`** if one exists, with current state.
 
-1. **Write your first journal entry.** This is how future-you remembers this person. Write about: what they asked you to do and how it went, what you noticed about how they communicate, what name they chose and what personality emerged, anything important about this first interaction, a note to next-you about what to follow up on. Keep it natural, a few paragraphs.
+`IDENTITY.md`, `SOUL.md`, and `USER.md` persist. Incomplete personalization is fine — it picks up organically in future conversations.
 
-2. **Update NOW.md** with current state: what you know, what's active, what to pick up next time.
+## After tool calls
 
-3. **Delete BOOTSTRAP.md and BOOTSTRAP-REFERENCE.md.**
-
-## Saving What You Learn
-
-Your vibe is hard-required. Everything else is best-effort, gathered naturally through conversation, not interrogation.
-
-A field is "resolved" when any of these is true:
-
-- The user gave an explicit answer
-- You confidently inferred it from conversation
-- The user declined, dodged, or sidestepped it
-
-Mark declined fields so you don't re-ask later (e.g., `Work role: declined_by_user`). Note inferred values with their source (e.g., `Pronouns: inferred: he/him`).
-
-**Call `file_edit` immediately whenever you learn something, in the same turn.** Don't batch saves. The moment the user gives you a name, save it. The moment you infer their style, save it.
-
-**After tool calls, do not repeat yourself.** Your text before tool calls is already visible to the user. When tool results return and you continue, pick up where you left off — don't re-confirm, re-greet, or re-ask the same question. If you already asked something and are waiting for the user's answer, just stop.
-
-**The contents of IDENTITY.md, SOUL.md, and USER.md are already in your system prompt.** Use the exact text you see there for `old_string` in `file_edit`. Do not guess or invent content.
-
-Update `IDENTITY.md` (name, nature, personality, style) and `USER.md` (their name, pronouns, goals, locale, work role, hobbies, daily tools). Save behavioral guidelines to `SOUL.md`.
-
-Do it silently. Never tell the user you're saving, never mention file names or tool names.
-
-When saving to `IDENTITY.md`, be specific about tone, energy, and conversational style. This persists after onboarding.
-
-## Passive Learning
-
-Throughout the conversation, pay attention to HOW the user communicates. Save specific observations to SOUL.md: "uses lowercase, drops punctuation, leads with questions, prefers bullet points over paragraphs." The specificity makes personality feel earned, not assigned. Adapt your style to match before they even notice.
-
-## Wrapping Up
-
-**Always delete BOOTSTRAP.md at the end of this conversation, regardless of how far you got.** Onboarding is a one-shot. If they skipped steps or blazed through, delete it anyway. Never let a second conversation start with this script.
-
-Deletion triggers: conversation ending, user completed setup, user skipped ("not now", "later"), user ignored onboarding and just did tasks.
-
-IDENTITY.md, SOUL.md, and USER.md persist. You can pick up incomplete personalization organically in future conversations.
+Pick up where you left off. Don't re-greet, don't re-confirm, don't repeat yourself. Your text from before the tool call is already visible to the user. If you were waiting for a user answer, just stop.
 
 ---
 
-_Make it count._
+_Earn it. One shot._


### PR DESCRIPTION
## Summary

Phase 1 of the Onboarding & New User Retention rollout ([JARVIS-462](https://linear.app/vellum/issue/JARVIS-462) umbrella, [JARVIS-463](https://linear.app/vellum/issue/JARVIS-463) this phase, [TDD](https://www.notion.so/33c9035c57bd81e7be88dafe0317f647)). Turns the scripted 6-step `BOOTSTRAP.md` into a **goals + constraints + technical contract** document so the model owns sequencing, pacing, warmth calibration, and tone. Strips the personality-quiz dropdowns and task-card `ui_show` payloads from `BOOTSTRAP-REFERENCE.md`, which becomes an inference-only reference for the four personality dimensions. Adds a forward-compatible `OnboardingContext` injection stub so [Phase 2 (LUM-804)](https://linear.app/vellum/issue/LUM-804) can populate pre-chat data without any further daemon changes — when the pre-chat UI lands, onboarding context just starts flowing through.

### What changed

- **`assistant/src/prompts/templates/BOOTSTRAP.md`** — full rewrite. 7 goals (mutual identity gently/not at all, prove value fast, infer don't interrogate, surface what you learned, offer next level, write immediately, clean up), 4 constraints (`$2` soft / `$5` hard budget, ≤2 questions without doing, don't block on setup, one-shot), explicit \"what the model owns\" list (no prescribed sequencing/pacing), and a tight technical contract for `IDENTITY.md` / `SOUL.md` / `USER.md`. New \"Pre-Chat Onboarding Context\" section describes the forward-compatible injection shape and tells the model to use it if present or fall back to inference if not.
- **`assistant/src/prompts/templates/BOOTSTRAP-REFERENCE.md`** — stripped both `ui_show` payloads (personality form + Email Connected/Not Connected task cards). Kept the four dimensions (communication style, task style, humor, depth) framed as things to **watch for** with explicit \"not a form / not a quiz / not a menu\" guardrails.
- **`assistant/src/prompts/system-prompt.ts`** — added `OnboardingContext` type and `onboardingContext?` field on `BuildSystemPromptOptions`. New `formatOnboardingContext()` helper renders a labeled block before the First-Run Ritual, gated on `includeBootstrap && ctx && ctx-has-fields`. **No caller passes this yet** — it's a stub that Phase 2 will populate.
- **`assistant/src/__tests__/onboarding-template-contract.test.ts`** — rewrote to encode the new contract. 30+ positive assertions on goals / constraints / technical contract, plus negative assertions against the old scripted strings (`Step N:` headers, `Personality Quiz`, `ui_show`, `chain off the task`, `while we're at it`, `Email Not Connected`, etc.) so the scripted sequence can't accidentally come back.
- **`assistant/src/__tests__/system-prompt.test.ts`** — added 5 tests covering the new injection path: renders with context + BOOTSTRAP, omits when BOOTSTRAP absent, omits when context absent, omits for empty object, renders partial context with only provided fields.

### Ships unflagged

Per the TDD: prompt template change, affects only new conversations after deploy, rollback is a git revert. No feature flag.

### Intentionally deferred (follow-up work on JARVIS-463)

- **`CANNED_FIRST_GREETING`** in `assistant/src/daemon/first-greeting.ts:10-11` still hardcodes \"What should I call you?\". Leaving it until the Phase 2 pre-chat UI lands — at that point the canned-greeting pathway becomes the fallback and the copy can be softened to match the new infer-don't-interrogate philosophy.
- **Budget enforcement mechanism**. The TDD calls out that the current `$5` cap \"isn't well-enforced\". Currently it lives in prose only (in `BOOTSTRAP.md`). I want to investigate how the daemon actually tracks/caps per-conversation spend before rewriting that path — follow-up PR.
- **Manual testing across opening styles** (task-first, casual chat, terse, verbose). Needs a running daemon.

## Test plan

- [x] `bun test src/__tests__/onboarding-template-contract.test.ts src/__tests__/system-prompt.test.ts src/__tests__/first-greeting.test.ts src/__tests__/trust-store.test.ts src/__tests__/checker.test.ts` — 604 pass / 0 fail across the 5 tests that touch `BOOTSTRAP.md`
- [x] `bun run tsc --noEmit -p tsconfig.json` — clean
- [x] `bun test -t \"pre-chat onboarding\"` — 5 new injection tests all pass (context present/absent/empty/partial, position-before-ritual)
- [ ] Manual smoke test: fresh install → first conversation → verify `BOOTSTRAP.md` + `BOOTSTRAP-REFERENCE.md` both get deleted at end of conversation 1 (already covered by existing auto-delete path on daemon startup; model-initiated delete still needs eyeball verification)
- [ ] Manual smoke test: task-first opener (\"build me an app\") → verify model skips introductions and does the task, learns identity passively
- [ ] Manual smoke test: casual opener (\"hey\") → verify model engages without forcing a personality quiz

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24453" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
