### PR TITLE
Add sanitizeConfigForTransfer utility to strip environment-specific fields

### DIFF
--- a/assistant/src/__tests__/sanitize-config-for-transfer.test.ts
+++ b/assistant/src/__tests__/sanitize-config-for-transfer.test.ts
@@ -112,6 +112,16 @@ describe("sanitizeConfigForTransfer", () => {
     expect(result).toBe(malformed);
   });
 
+  test("handles JSON null by returning original string", () => {
+    const result = sanitizeConfigForTransfer("null");
+    expect(result).toBe("null");
+  });
+
+  test("handles JSON array by returning original string", () => {
+    const result = sanitizeConfigForTransfer("[1, 2, 3]");
+    expect(result).toBe("[1, 2, 3]");
+  });
+
   test("output uses 2-space indentation with trailing newline", () => {
     const input = { name: "test" };
     const result = sanitizeConfigForTransfer(JSON.stringify(input));

--- a/assistant/src/__tests__/sanitize-config-for-transfer.test.ts
+++ b/assistant/src/__tests__/sanitize-config-for-transfer.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, test } from "bun:test";
+
+import { sanitizeConfigForTransfer } from "../config/sanitize-for-transfer.js";
+
+describe("sanitizeConfigForTransfer", () => {
+  test("strips all four field groups", () => {
+    const input = {
+      ingress: {
+        publicBaseUrl: "https://example.com",
+        enabled: true,
+        webhook: { path: "/hook" },
+      },
+      daemon: { port: 3000, logLevel: "debug" },
+      skills: {
+        load: {
+          extraDirs: ["/custom/skills"],
+          builtIn: true,
+        },
+      },
+      name: "my-assistant",
+    };
+
+    const result = JSON.parse(sanitizeConfigForTransfer(JSON.stringify(input)));
+
+    expect(result.ingress.publicBaseUrl).toBe("");
+    expect(result.ingress.enabled).toBeUndefined();
+    expect(result.daemon).toBeUndefined();
+    expect(result.skills.load.extraDirs).toEqual([]);
+  });
+
+  test("preserves non-target fields unchanged", () => {
+    const input = {
+      name: "test",
+      model: "claude-3",
+      ingress: {
+        publicBaseUrl: "https://example.com",
+        enabled: true,
+        webhook: { path: "/hook" },
+        rateLimit: { max: 100 },
+      },
+      daemon: { port: 3000 },
+      skills: {
+        load: {
+          extraDirs: ["/dir"],
+          builtIn: true,
+        },
+        catalog: ["skill-a"],
+      },
+      memory: { enabled: true },
+    };
+
+    const result = JSON.parse(sanitizeConfigForTransfer(JSON.stringify(input)));
+
+    expect(result.name).toBe("test");
+    expect(result.model).toBe("claude-3");
+    expect(result.memory).toEqual({ enabled: true });
+    expect(result.skills.catalog).toEqual(["skill-a"]);
+    expect(result.skills.load.builtIn).toBe(true);
+  });
+
+  test("preserves nested ingress fields other than publicBaseUrl and enabled", () => {
+    const input = {
+      ingress: {
+        publicBaseUrl: "https://old.url",
+        enabled: false,
+        webhook: { path: "/webhook", secret: "abc" },
+        rateLimit: { max: 50, window: 60 },
+      },
+    };
+
+    const result = JSON.parse(sanitizeConfigForTransfer(JSON.stringify(input)));
+
+    expect(result.ingress.webhook).toEqual({ path: "/webhook", secret: "abc" });
+    expect(result.ingress.rateLimit).toEqual({ max: 50, window: 60 });
+    expect(result.ingress.publicBaseUrl).toBe("");
+    expect(result.ingress.enabled).toBeUndefined();
+  });
+
+  test("handles config missing some target fields", () => {
+    const input = {
+      name: "test",
+      ingress: { webhook: { path: "/hook" } },
+    };
+
+    const result = JSON.parse(sanitizeConfigForTransfer(JSON.stringify(input)));
+
+    expect(result.name).toBe("test");
+    expect(result.ingress.publicBaseUrl).toBe("");
+    expect(result.ingress.webhook).toEqual({ path: "/hook" });
+  });
+
+  test("handles config missing all target fields", () => {
+    const input = {
+      name: "test",
+      model: "claude-3",
+    };
+
+    const result = JSON.parse(sanitizeConfigForTransfer(JSON.stringify(input)));
+
+    expect(result.name).toBe("test");
+    expect(result.model).toBe("claude-3");
+  });
+
+  test("handles empty object", () => {
+    const result = sanitizeConfigForTransfer("{}");
+    expect(JSON.parse(result)).toEqual({});
+  });
+
+  test("handles invalid JSON by returning original string", () => {
+    const malformed = "{ not valid json }}}";
+    const result = sanitizeConfigForTransfer(malformed);
+    expect(result).toBe(malformed);
+  });
+
+  test("output uses 2-space indentation with trailing newline", () => {
+    const input = { name: "test" };
+    const result = sanitizeConfigForTransfer(JSON.stringify(input));
+
+    expect(result).toBe(JSON.stringify(input, null, 2) + "\n");
+    expect(result.endsWith("\n")).toBe(true);
+  });
+});

--- a/assistant/src/config/sanitize-for-transfer.ts
+++ b/assistant/src/config/sanitize-for-transfer.ts
@@ -1,0 +1,39 @@
+/**
+ * Strips environment-specific fields from config JSON before transferring
+ * between local and platform environments (teleport/restore).
+ *
+ * Fields removed or reset:
+ * - `ingress.publicBaseUrl` → set to `""`
+ * - `ingress.enabled` → deleted
+ * - `daemon` → deleted entirely
+ * - `skills.load.extraDirs` → set to `[]`
+ */
+export function sanitizeConfigForTransfer(configJson: string): string {
+  let config: Record<string, unknown>;
+  try {
+    config = JSON.parse(configJson);
+  } catch {
+    return configJson;
+  }
+
+  // Strip ingress environment-specific fields
+  if (config.ingress && typeof config.ingress === "object") {
+    const ingress = config.ingress as Record<string, unknown>;
+    ingress.publicBaseUrl = "";
+    delete ingress.enabled;
+  }
+
+  // Strip daemon entirely
+  delete config.daemon;
+
+  // Strip skills.load.extraDirs
+  if (config.skills && typeof config.skills === "object") {
+    const skills = config.skills as Record<string, unknown>;
+    if (skills.load && typeof skills.load === "object") {
+      const load = skills.load as Record<string, unknown>;
+      load.extraDirs = [];
+    }
+  }
+
+  return JSON.stringify(config, null, 2) + "\n";
+}

--- a/assistant/src/config/sanitize-for-transfer.ts
+++ b/assistant/src/config/sanitize-for-transfer.ts
@@ -11,7 +11,11 @@
 export function sanitizeConfigForTransfer(configJson: string): string {
   let config: Record<string, unknown>;
   try {
-    config = JSON.parse(configJson);
+    const parsed = JSON.parse(configJson);
+    if (typeof parsed !== "object" || parsed === null) {
+      return configJson;
+    }
+    config = parsed;
   } catch {
     return configJson;
   }


### PR DESCRIPTION
## Summary
- Adds sanitizeConfigForTransfer() function that strips environment-specific config fields (ingress.publicBaseUrl, ingress.enabled, daemon.*, skills.load.extraDirs) during workspace transfer
- Includes comprehensive test coverage for all field groups, edge cases, and defensive handling

Part of plan: filter-config-teleport.md (PR 1 of 2)

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24457" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
