### PR TITLE
Apply config sanitization during vbundle export and import

### DIFF
--- a/assistant/src/__tests__/migration-export-http.test.ts
+++ b/assistant/src/__tests__/migration-export-http.test.ts
@@ -429,6 +429,65 @@ describe("export graceful fallback", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Config sanitization tests
+// ---------------------------------------------------------------------------
+
+describe("export config sanitization", () => {
+  test("exported config.json has environment-specific fields stripped", async () => {
+    // Write a config with environment-specific fields that should be stripped
+    const configWithEnvFields = {
+      provider: "anthropic",
+      model: "test-model",
+      ingress: {
+        publicBaseUrl: "https://my-tunnel.example.com",
+        enabled: true,
+        port: 8080,
+      },
+      daemon: {
+        autoStart: true,
+        logLevel: "debug",
+      },
+      skills: {
+        load: {
+          extraDirs: ["/home/user/custom-skills", "/opt/skills"],
+          autoReload: true,
+        },
+      },
+      memory: { enabled: true },
+    };
+    writeFileSync(testConfigPath, JSON.stringify(configWithEnvFields, null, 2));
+
+    const req = new Request("http://localhost/v1/migrations/export", {
+      method: "POST",
+    });
+
+    const res = await handleMigrationExport(req);
+    const archiveData = new Uint8Array(await res.arrayBuffer());
+    const entries = parseTarEntries(archiveData);
+
+    const configEntry = entries.find((e) => e.name === "workspace/config.json");
+    expect(configEntry).toBeDefined();
+
+    const parsedConfig = JSON.parse(
+      new TextDecoder().decode(configEntry!.data),
+    );
+
+    // Environment-specific fields should be stripped/reset
+    expect(parsedConfig.ingress.publicBaseUrl).toBe("");
+    expect(parsedConfig.ingress.enabled).toBeUndefined();
+    expect(parsedConfig.daemon).toBeUndefined();
+    expect(parsedConfig.skills.load.extraDirs).toEqual([]);
+
+    // Non-environment-specific fields should be preserved
+    expect(parsedConfig.provider).toBe("anthropic");
+    expect(parsedConfig.model).toBe("test-model");
+    expect(parsedConfig.ingress.port).toBe(8080);
+    expect(parsedConfig.skills.load.autoReload).toBe(true);
+    expect(parsedConfig.memory.enabled).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Auth policy registration tests
 // ---------------------------------------------------------------------------
 

--- a/assistant/src/__tests__/migration-import-commit-http.test.ts
+++ b/assistant/src/__tests__/migration-import-commit-http.test.ts
@@ -873,6 +873,104 @@ describe("commitImport — workspace clearing", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Config sanitization tests
+// ---------------------------------------------------------------------------
+
+describe("commitImport — config sanitization", () => {
+  test("imported workspace/config.json has environment-specific fields stripped", () => {
+    const configWithEnvFields = {
+      provider: "anthropic",
+      model: "test-model",
+      ingress: {
+        publicBaseUrl: "https://my-tunnel.example.com",
+        enabled: true,
+        port: 8080,
+      },
+      daemon: {
+        autoStart: true,
+        logLevel: "debug",
+      },
+      skills: {
+        load: {
+          extraDirs: ["/home/user/custom-skills"],
+          autoReload: true,
+        },
+      },
+      memory: { enabled: true },
+    };
+    const configData = new TextEncoder().encode(
+      JSON.stringify(configWithEnvFields, null, 2),
+    );
+
+    const vbundle = createValidVBundle([
+      { path: "workspace/config.json", data: configData },
+    ]);
+
+    const resolver = new DefaultPathResolver(testDir);
+    const result = commitImport({
+      archiveData: vbundle,
+      pathResolver: resolver,
+      workspaceDir: testDir,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    // Read the written config from disk and verify sanitization
+    const writtenConfig = JSON.parse(readFileSync(testConfigPath, "utf8"));
+
+    // Environment-specific fields should be stripped/reset
+    expect(writtenConfig.ingress.publicBaseUrl).toBe("");
+    expect(writtenConfig.ingress.enabled).toBeUndefined();
+    expect(writtenConfig.daemon).toBeUndefined();
+    expect(writtenConfig.skills.load.extraDirs).toEqual([]);
+
+    // Non-environment-specific fields should be preserved
+    expect(writtenConfig.provider).toBe("anthropic");
+    expect(writtenConfig.model).toBe("test-model");
+    expect(writtenConfig.ingress.port).toBe(8080);
+    expect(writtenConfig.skills.load.autoReload).toBe(true);
+    expect(writtenConfig.memory.enabled).toBe(true);
+  });
+
+  test("imported config/settings.json (legacy) has environment-specific fields stripped", () => {
+    const configWithEnvFields = {
+      provider: "openai",
+      daemon: { autoStart: false },
+      ingress: {
+        publicBaseUrl: "https://old-tunnel.example.com",
+        enabled: false,
+      },
+      skills: { load: { extraDirs: ["/legacy/skills"] } },
+    };
+    const configData = new TextEncoder().encode(
+      JSON.stringify(configWithEnvFields, null, 2),
+    );
+
+    const vbundle = createValidVBundle([
+      { path: "config/settings.json", data: configData },
+    ]);
+
+    const resolver = new DefaultPathResolver(testDir);
+    const result = commitImport({
+      archiveData: vbundle,
+      pathResolver: resolver,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const writtenConfig = JSON.parse(readFileSync(testConfigPath, "utf8"));
+
+    expect(writtenConfig.ingress.publicBaseUrl).toBe("");
+    expect(writtenConfig.ingress.enabled).toBeUndefined();
+    expect(writtenConfig.daemon).toBeUndefined();
+    expect(writtenConfig.skills.load.extraDirs).toEqual([]);
+    expect(writtenConfig.provider).toBe("openai");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Auth policy registration tests
 // ---------------------------------------------------------------------------
 

--- a/assistant/src/runtime/migrations/vbundle-builder.ts
+++ b/assistant/src/runtime/migrations/vbundle-builder.ts
@@ -28,6 +28,7 @@ import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { createGzip, gzipSync } from "node:zlib";
 
+import { sanitizeConfigForTransfer } from "../../config/sanitize-for-transfer.js";
 import type {
   ManifestFileEntryType,
   ManifestType,
@@ -506,6 +507,14 @@ export function buildExportVBundle(
     );
   }
 
+  // Sanitize workspace/config.json to strip environment-specific fields
+  const configEntry = files.find((f) => f.path === "workspace/config.json");
+  if (configEntry) {
+    const configJson = new TextDecoder().decode(configEntry.data);
+    const sanitized = sanitizeConfigForTransfer(configJson);
+    configEntry.data = new TextEncoder().encode(sanitized);
+  }
+
   // Include hooks directory if it exists (lives at ~/.vellum/hooks/, outside workspace).
   if (hooksDir && existsSync(hooksDir) && lstatSync(hooksDir).isDirectory()) {
     files.push(...walkDirectory(hooksDir, "hooks"));
@@ -853,6 +862,29 @@ export async function streamExportVBundle(
     }
   }
 
+  // Sanitize workspace/config.json: read from disk, sanitize, and replace the
+  // disk-backed metadata entry with an in-memory entry so the streaming tar
+  // writes sanitized content instead of the raw file.
+  const configMetadataIdx = allFileMetadata.findIndex(
+    (f) => f.archivePath === "workspace/config.json",
+  );
+
+  const sanitizedConfigEntries: InMemoryEntry[] = [];
+  if (configMetadataIdx !== -1) {
+    const configMeta = allFileMetadata[configMetadataIdx];
+    const rawConfigData = readFileSync(configMeta.diskPath, "utf8");
+    const sanitized = sanitizeConfigForTransfer(rawConfigData);
+    const sanitizedData = new TextEncoder().encode(sanitized);
+
+    // Remove the disk-backed entry and replace with an in-memory entry
+    allFileMetadata.splice(configMetadataIdx, 1);
+    sanitizedConfigEntries.push({
+      archivePath: "workspace/config.json",
+      data: sanitizedData,
+      size: sanitizedData.length,
+    });
+  }
+
   // Build in-memory entries for credentials (not disk-backed)
   const inMemoryEntries: InMemoryEntry[] = [];
   if (credentials?.length) {
@@ -880,8 +912,8 @@ export async function streamExportVBundle(
     });
   }
 
-  // Add in-memory credential entries to the manifest
-  for (const entry of inMemoryEntries) {
+  // Add in-memory entries (sanitized config, credentials) to the manifest
+  for (const entry of [...sanitizedConfigEntries, ...inMemoryEntries]) {
     const sha256 = sha256Hex(entry.data);
     fileEntries.push({
       path: entry.archivePath,
@@ -912,7 +944,11 @@ export async function streamExportVBundle(
 
   const tempPath = join(tmpdir(), `vbundle-export-${randomUUID()}.tmp`);
 
-  const allEntries: TarStreamEntry[] = [...allFileMetadata, ...inMemoryEntries];
+  const allEntries: TarStreamEntry[] = [
+    ...allFileMetadata,
+    ...sanitizedConfigEntries,
+    ...inMemoryEntries,
+  ];
   const tarGenerator = generateTarStream(manifestData, allEntries);
   const tarReadable = Readable.from(tarGenerator);
   const gzipStream = createGzip();

--- a/assistant/src/runtime/migrations/vbundle-importer.ts
+++ b/assistant/src/runtime/migrations/vbundle-importer.ts
@@ -353,14 +353,17 @@ export function commitImport(options: ImportCommitOptions): ImportCommitResult {
     }
 
     // Step 3: Post-write integrity check — verify the written file
+    // Use the SHA of the data we actually wrote (which may differ from the
+    // manifest SHA if the config was sanitized during import).
+    const expectedSha256 = sha256Hex(dataToWrite);
     try {
       const writtenData = new Uint8Array(readFileSync(diskPath));
       const writtenSha256 = sha256Hex(writtenData);
 
-      if (writtenSha256 !== fileEntry.sha256) {
+      if (writtenSha256 !== expectedSha256) {
         warnings.push(
           `Post-write integrity warning for "${fileEntry.path}": ` +
-            `expected SHA-256 ${fileEntry.sha256}, got ${writtenSha256}`,
+            `expected SHA-256 ${expectedSha256}, got ${writtenSha256}`,
         );
       }
     } catch {
@@ -373,8 +376,8 @@ export function commitImport(options: ImportCommitOptions): ImportCommitResult {
       path: fileEntry.path,
       disk_path: diskPath,
       action,
-      size: archiveEntry.size,
-      sha256: fileEntry.sha256,
+      size: dataToWrite.length,
+      sha256: expectedSha256,
       backup_path: backupPath,
     });
   }

--- a/assistant/src/runtime/migrations/vbundle-importer.ts
+++ b/assistant/src/runtime/migrations/vbundle-importer.ts
@@ -24,6 +24,7 @@ import {
 } from "node:fs";
 import { dirname, join } from "node:path";
 
+import { sanitizeConfigForTransfer } from "../../config/sanitize-for-transfer.js";
 import type { PathResolver } from "./vbundle-import-analyzer.js";
 import type { ManifestType, VBundleTarEntry } from "./vbundle-validator.js";
 import { validateVBundle } from "./vbundle-validator.js";
@@ -321,9 +322,20 @@ export function commitImport(options: ImportCommitOptions): ImportCommitResult {
       }
     }
 
+    // Sanitize config files to strip environment-specific fields (defense-in-depth)
+    let dataToWrite: Uint8Array = archiveEntry.data;
+    if (
+      fileEntry.path === "workspace/config.json" ||
+      fileEntry.path === "config/settings.json"
+    ) {
+      const configJson = new TextDecoder().decode(archiveEntry.data);
+      const sanitized = sanitizeConfigForTransfer(configJson);
+      dataToWrite = new TextEncoder().encode(sanitized);
+    }
+
     // Write the file
     try {
-      writeFileSync(diskPath, archiveEntry.data);
+      writeFileSync(diskPath, dataToWrite);
     } catch (err) {
       return {
         ok: false,


### PR DESCRIPTION
## Summary
- Wires sanitizeConfigForTransfer into both non-streaming and streaming vbundle export paths to strip environment-specific fields before archiving
- Adds defense-in-depth sanitization during vbundle import for workspace/config.json and legacy config/settings.json
- Adds integration tests for both export and import config sanitization

Part of plan: filter-config-teleport.md (PR 2 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24458" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
