### PR TITLE
feat(browser-relay): handle host_browser_result frames over relay WS (PR2)

### DIFF
--- a/assistant/src/__tests__/fixtures/mock-chrome-extension.ts
+++ b/assistant/src/__tests__/fixtures/mock-chrome-extension.ts
@@ -68,6 +68,18 @@ export interface MockChromeExtensionOptions {
    * actor principal id).
    */
   extraHandshakeHeaders?: Record<string, string>;
+  /**
+   * Transport used to submit the result back to the runtime.
+   *   - "http" (default): POST to `/v1/host-browser-result`.
+   *   - "ws": send a `host_browser_result` frame back over the same
+   *     `/v1/browser-relay` WebSocket that delivered the request.
+   *
+   * Both transports are expected to be fully functional in the runtime.
+   * The HTTP path is the legacy transport; the WS path was added so the
+   * extension can avoid an extra round-trip through the cloud ingress
+   * stack for each CDP command.
+   */
+  resultTransport?: "http" | "ws";
 }
 
 export interface MockChromeExtension {
@@ -140,6 +152,7 @@ export function createMockChromeExtension(
   const receivedRequests: HostBrowserRequestFrame[] = [];
   const receivedCancels: HostBrowserCancelFrame[] = [];
   const inFlight = new Map<string, AbortController>();
+  const resultTransport = options.resultTransport ?? "http";
 
   async function handleRequestFrame(
     frame: HostBrowserRequestFrame,
@@ -167,6 +180,26 @@ export function createMockChromeExtension(
       content: result.content,
       isError: result.isError,
     };
+    if (resultTransport === "ws") {
+      // Send the result back over the same `/v1/browser-relay` socket
+      // that delivered the request. The runtime WS message handler
+      // parses `host_browser_result` frames and resolves the pending
+      // interaction via the same core resolver the HTTP endpoint uses.
+      const sock = ws;
+      if (sock && sock.readyState === WebSocket.OPEN) {
+        try {
+          sock.send(
+            JSON.stringify({
+              type: "host_browser_result",
+              ...body,
+            }),
+          );
+        } catch {
+          // Best-effort — mirrors the HTTP POST failure mode.
+        }
+      }
+      return;
+    }
     try {
       const res = await fetch(`${baseHttp}/v1/host-browser-result`, {
         method: "POST",

--- a/assistant/src/__tests__/host-browser-e2e-cloud.test.ts
+++ b/assistant/src/__tests__/host-browser-e2e-cloud.test.ts
@@ -216,6 +216,50 @@ describe("host_browser cloud-hosted e2e round-trip", () => {
     await mockExt.stop();
   });
 
+  test("happy path (WS result transport): Browser.getVersion round-trips when the extension returns the result over the same WS", async () => {
+    const guardianId = `test-guardian-${crypto.randomUUID()}`;
+    const token = mintActorToken(guardianId);
+
+    const { createMockChromeExtension } =
+      await import("./fixtures/mock-chrome-extension.js");
+    // Same fixture as the HTTP happy path, but configured to return
+    // results over the /v1/browser-relay WebSocket instead of POSTing
+    // /v1/host-browser-result. This exercises the runtime WS
+    // `message` handler's host_browser_result dispatch path added in
+    // PR2 of the browser-use remediation plan.
+    const mockExt = createMockChromeExtension({
+      runtimeBaseUrl,
+      token,
+      resultTransport: "ws",
+    });
+    await mockExt.start();
+    await mockExt.waitForConnection();
+    await waitForRegistryEntry(guardianId);
+
+    const { proxy } = createBoundProxy(guardianId, "conv-happy-ws");
+
+    const result = await proxy.request(
+      { cdpMethod: "Browser.getVersion" },
+      "conv-happy-ws",
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Chrome/MockTest");
+
+    const received = mockExt.receivedRequests();
+    expect(received).toHaveLength(1);
+    expect(received[0].cdpMethod).toBe("Browser.getVersion");
+    expect(received[0].conversationId).toBe("conv-happy-ws");
+
+    // The pending interaction must be fully consumed — if the WS
+    // handler silently no-op'd, the entry would still be registered
+    // after the proxy resolves.
+    expect(pendingInteractions.get(received[0].requestId)).toBeUndefined();
+
+    proxy.dispose();
+    await mockExt.stop();
+  });
+
   test("abort: AbortSignal resolves to 'Aborted' and extension receives host_browser_cancel", async () => {
     const guardianId = `test-guardian-${crypto.randomUUID()}`;
     const token = mintActorToken(guardianId);

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -159,7 +159,10 @@ import { handleGuardianBootstrap } from "./routes/guardian-bootstrap-routes.js";
 import { handleGuardianRefresh } from "./routes/guardian-refresh-routes.js";
 import { heartbeatRouteDefinitions } from "./routes/heartbeat-routes.js";
 import { hostBashRouteDefinitions } from "./routes/host-bash-routes.js";
-import { hostBrowserRouteDefinitions } from "./routes/host-browser-routes.js";
+import {
+  hostBrowserRouteDefinitions,
+  resolveHostBrowserResultByRequestId,
+} from "./routes/host-browser-routes.js";
 import { hostCuRouteDefinitions } from "./routes/host-cu-routes.js";
 import { hostFileRouteDefinitions } from "./routes/host-file-routes.js";
 import {
@@ -243,9 +246,13 @@ const MAX_REQUEST_BODY_BYTES = 512 * 1024 * 1024;
 
 /**
  * WebSocket data attached to `/v1/browser-relay` connections. The route
- * is used exclusively by the chrome-extension CDP proxy — inbound frames
- * from the extension travel over HTTP (`/v1/host-browser-result`), and
- * outbound frames are pushed through the {@link ChromeExtensionRegistry}.
+ * is used exclusively by the chrome-extension CDP proxy — outbound
+ * `host_browser_request` frames are pushed through the
+ * {@link ChromeExtensionRegistry}, and inbound `host_browser_result`
+ * frames are dispatched through
+ * `resolveHostBrowserResultByRequestId`. The extension may also submit
+ * results via `POST /v1/host-browser-result` (both transports resolve
+ * through the same core function).
  */
 interface BrowserRelayWebSocketData {
   wsType: "browser-relay";
@@ -391,13 +398,64 @@ export class RuntimeHttpServer {
               ? message
               : new TextDecoder().decode(message);
           if ("wsType" in data && data.wsType === "browser-relay") {
-            // The /v1/browser-relay socket is one-way (server → extension).
-            // The extension POSTs results via /v1/host-browser-result;
-            // inbound frames are unexpected.
-            log.debug(
-              { connectionId: data.connectionId },
-              "Unexpected inbound browser-relay message",
-            );
+            // Inbound frames on `/v1/browser-relay` carry
+            // `host_browser_result` envelopes submitted by the Chrome
+            // extension. The extension can also POST results to
+            // `/v1/host-browser-result` over HTTP — both transports
+            // route through `resolveHostBrowserResultByRequestId` so
+            // the validation and resolution semantics stay in lockstep.
+            //
+            // Malformed frames are logged at debug and swallowed — we
+            // never throw out of a WebSocket `message` handler because
+            // an uncaught exception would tear down the whole socket
+            // for an attacker-controlled payload.
+            let parsed: unknown;
+            try {
+              parsed = JSON.parse(raw);
+            } catch (err) {
+              log.debug(
+                {
+                  connectionId: data.connectionId,
+                  error: err instanceof Error ? err.message : String(err),
+                },
+                "browser-relay: dropped non-JSON inbound frame",
+              );
+              return;
+            }
+            if (!parsed || typeof parsed !== "object") {
+              log.debug(
+                { connectionId: data.connectionId },
+                "browser-relay: dropped non-object inbound frame",
+              );
+              return;
+            }
+            const frame = parsed as Record<string, unknown>;
+            if (frame.type !== "host_browser_result") {
+              log.debug(
+                { connectionId: data.connectionId, type: frame.type },
+                "browser-relay: dropped unsupported inbound frame type",
+              );
+              return;
+            }
+            const resolution = resolveHostBrowserResultByRequestId({
+              requestId: frame.requestId,
+              content: frame.content,
+              isError: frame.isError,
+            });
+            if (!resolution.ok) {
+              log.warn(
+                {
+                  connectionId: data.connectionId,
+                  requestId:
+                    typeof frame.requestId === "string"
+                      ? frame.requestId
+                      : undefined,
+                  code: resolution.code,
+                  message: resolution.message,
+                },
+                "browser-relay: host_browser_result frame rejected",
+              );
+            }
             return;
           }
           const callSessionId = (data as RelayWebSocketData).callSessionId;

--- a/assistant/src/runtime/routes/host-browser-routes.ts
+++ b/assistant/src/runtime/routes/host-browser-routes.ts
@@ -13,6 +13,114 @@ import type { RouteDefinition } from "../http-router.js";
 import * as pendingInteractions from "../pending-interactions.js";
 
 /**
+ * Result of attempting to resolve a host browser result frame. Used by both
+ * the HTTP endpoint and the WS relay path so they share the same validation
+ * and resolution semantics.
+ *
+ * Success → the pending interaction was consumed and the conversation (or
+ * CLI shim callback) was notified.
+ *
+ * Error variants mirror the HTTP status codes the `/v1/host-browser-result`
+ * endpoint returns, so the caller can log/translate them consistently.
+ */
+export type HostBrowserResultResolution =
+  | { ok: true }
+  | {
+      ok: false;
+      code: "BAD_REQUEST" | "NOT_FOUND" | "CONFLICT";
+      status: 400 | 404 | 409;
+      message: string;
+    };
+
+/**
+ * Shared resolver used by both the HTTP route handler and the WS
+ * `host_browser_result` frame handler. Looks up the pending interaction
+ * by requestId, validates its kind, and forwards the response to the
+ * owning conversation (or CLI shim callback).
+ *
+ * This function does NOT perform auth — callers are expected to have
+ * already authenticated the caller (the HTTP route uses
+ * `requireBoundGuardian`, the WS path relies on the JWT check performed
+ * at WebSocket upgrade time).
+ */
+export function resolveHostBrowserResultByRequestId(frame: {
+  requestId?: unknown;
+  content?: unknown;
+  isError?: unknown;
+}): HostBrowserResultResolution {
+  const { requestId, content, isError } = frame;
+
+  if (!requestId || typeof requestId !== "string") {
+    return {
+      ok: false,
+      code: "BAD_REQUEST",
+      status: 400,
+      message: "requestId is required",
+    };
+  }
+
+  // Peek first (non-destructive) so we can validate the interaction kind
+  // without accidentally consuming a confirmation or secret interaction.
+  const peeked = pendingInteractions.get(requestId);
+  if (!peeked) {
+    return {
+      ok: false,
+      code: "NOT_FOUND",
+      status: 404,
+      message: "No pending interaction found for this requestId",
+    };
+  }
+
+  if (peeked.kind !== "host_browser") {
+    return {
+      ok: false,
+      code: "CONFLICT",
+      status: 409,
+      message: `Pending interaction is of kind "${peeked.kind}", expected "host_browser"`,
+    };
+  }
+
+  // Validation passed — consume the pending interaction.
+  const interaction = pendingInteractions.resolve(requestId)!;
+
+  const normalizedContent = typeof content === "string" ? content : "";
+  const normalizedIsError = typeof isError === "boolean" ? isError : false;
+
+  // CLI shim path: pending interactions registered by /v1/browser-cdp carry
+  // a directBrowserResolve callback and are not bound to a Conversation.
+  // Resolve them in place without touching the conversation object.
+  if (interaction.directBrowserResolve) {
+    interaction.directBrowserResolve({
+      content: normalizedContent,
+      isError: normalizedIsError,
+    });
+    return { ok: true };
+  }
+
+  // The host_browser kind always has a conversation attached at register time
+  // (HostBrowserProxy.request wires it through), so this guard exists so a
+  // future refactor of pending-interactions can change the type without
+  // silently breaking the host_browser path. Prefer an explicit error over an
+  // optional-chain no-op that would leave the proxy request unresolved.
+  if (!interaction.conversation) {
+    return {
+      ok: false,
+      code: "BAD_REQUEST",
+      status: 400,
+      message:
+        "host_browser pending interaction has no associated conversation",
+    };
+  }
+
+  interaction.conversation.resolveHostBrowser(requestId, {
+    content: normalizedContent,
+    isError: normalizedIsError,
+  });
+
+  return { ok: true };
+}
+
+/**
  * POST /v1/host-browser-result — resolve a pending host browser request by requestId.
  * Requires AuthContext with guardian-bound actor.
  */
@@ -29,62 +137,10 @@ export async function handleHostBrowserResult(
     isError?: boolean;
   };
 
-  const { requestId, content, isError } = body;
-
-  if (!requestId || typeof requestId !== "string") {
-    return httpError("BAD_REQUEST", "requestId is required", 400);
+  const resolution = resolveHostBrowserResultByRequestId(body);
+  if (!resolution.ok) {
+    return httpError(resolution.code, resolution.message, resolution.status);
   }
-
-  // Peek first (non-destructive) so we can validate the interaction kind
-  // without accidentally consuming a confirmation or secret interaction.
-  const peeked = pendingInteractions.get(requestId);
-  if (!peeked) {
-    return httpError(
-      "NOT_FOUND",
-      "No pending interaction found for this requestId",
-      404,
-    );
-  }
-
-  if (peeked.kind !== "host_browser") {
-    return httpError(
-      "CONFLICT",
-      `Pending interaction is of kind "${peeked.kind}", expected "host_browser"`,
-      409,
-    );
-  }
-
-  // Validation passed — consume the pending interaction.
-  const interaction = pendingInteractions.resolve(requestId)!;
-
-  // CLI shim path: pending interactions registered by /v1/browser-cdp carry
-  // a directBrowserResolve callback and are not bound to a Conversation.
-  // Resolve them in place without touching the conversation object.
-  if (interaction.directBrowserResolve) {
-    interaction.directBrowserResolve({
-      content: content ?? "",
-      isError: isError ?? false,
-    });
-    return Response.json({ accepted: true });
-  }
-
-  // The host_browser kind always has a conversation attached at register time
-  // (HostBrowserProxy.request wires it through), so this guard exists so a
-  // future refactor of pending-interactions can change the type without
-  // silently breaking the host_browser path. Prefer an explicit 400 over an
-  // optional-chain no-op that would leave the proxy request unresolved.
-  if (!interaction.conversation) {
-    return httpError(
-      "BAD_REQUEST",
-      "host_browser pending interaction has no associated conversation",
-      400,
-    );
-  }
-
-  interaction.conversation.resolveHostBrowser(requestId, {
-    content: content ?? "",
-    isError: isError ?? false,
-  });
 
   return Response.json({ accepted: true });
 }


### PR DESCRIPTION
## Summary
- Extract shared host-browser result resolution into reusable function
- Handle host_browser_result frames in runtime WS message handler
- Validate frame shape and guard against wrong interaction kind
- Keep HTTP endpoint for backwards compatibility

Part of plan: browser-use-main-remediation-plan-2026-04-08.md (PR 2 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24460" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
