### PR TITLE
feat(gateway): add GET /v1/config/privacy returning current privacy config

### DIFF
--- a/gateway/src/__tests__/privacy-config-route.test.ts
+++ b/gateway/src/__tests__/privacy-config-route.test.ts
@@ -1,0 +1,287 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { writeFileSync, mkdirSync, rmSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomBytes } from "node:crypto";
+
+// Use an isolated temp directory so tests don't touch the real workspace config.
+const testDir = join(
+  tmpdir(),
+  `vellum-privacy-test-${randomBytes(6).toString("hex")}`,
+);
+const vellumRoot = join(testDir, ".vellum");
+const workspaceDir = join(vellumRoot, "workspace");
+const configPath = join(workspaceDir, "config.json");
+
+const savedBaseDataDir = process.env.BASE_DATA_DIR;
+const savedWorkspaceDir = process.env.VELLUM_WORKSPACE_DIR;
+
+beforeEach(() => {
+  process.env.BASE_DATA_DIR = testDir;
+  // Ensure we do not inherit a VELLUM_WORKSPACE_DIR override from the test runner;
+  // we want config.json to resolve under testDir/.vellum/workspace.
+  delete process.env.VELLUM_WORKSPACE_DIR;
+  mkdirSync(workspaceDir, { recursive: true });
+});
+
+afterEach(() => {
+  if (savedBaseDataDir === undefined) {
+    delete process.env.BASE_DATA_DIR;
+  } else {
+    process.env.BASE_DATA_DIR = savedBaseDataDir;
+  }
+  if (savedWorkspaceDir === undefined) {
+    delete process.env.VELLUM_WORKSPACE_DIR;
+  } else {
+    process.env.VELLUM_WORKSPACE_DIR = savedWorkspaceDir;
+  }
+  try {
+    rmSync(testDir, { recursive: true, force: true });
+  } catch {
+    // best effort cleanup
+  }
+});
+
+const { createPrivacyConfigGetHandler } =
+  await import("../http/routes/privacy-config.js");
+
+// The default value for memory.cleanup.llmRequestLogRetentionMs in the
+// daemon schema (assistant/src/config/schemas/memory-lifecycle.ts): 1 day.
+const DEFAULT_RETENTION_MS = 1 * 24 * 60 * 60 * 1000;
+
+describe("GET /v1/config/privacy handler", () => {
+  test("returns schema defaults when config.json does not exist", async () => {
+    if (existsSync(configPath)) {
+      rmSync(configPath);
+    }
+
+    const handler = createPrivacyConfigGetHandler();
+    const res = await handler(
+      new Request("http://gateway.test/v1/config/privacy"),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({
+      collectUsageData: true,
+      sendDiagnostics: true,
+      llmRequestLogRetentionMs: DEFAULT_RETENTION_MS,
+    });
+    // Sanity check: 1 day in ms.
+    expect(body.llmRequestLogRetentionMs).toBe(86_400_000);
+  });
+
+  test("returns explicit values from config.json", async () => {
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        collectUsageData: false,
+        sendDiagnostics: false,
+        memory: {
+          cleanup: {
+            llmRequestLogRetentionMs: 3 * 24 * 60 * 60 * 1000,
+          },
+        },
+      }),
+    );
+
+    const handler = createPrivacyConfigGetHandler();
+    const res = await handler(
+      new Request("http://gateway.test/v1/config/privacy"),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({
+      collectUsageData: false,
+      sendDiagnostics: false,
+      llmRequestLogRetentionMs: 3 * 24 * 60 * 60 * 1000,
+    });
+  });
+
+  test("falls back to default when llmRequestLogRetentionMs is a string", async () => {
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        collectUsageData: true,
+        sendDiagnostics: true,
+        memory: {
+          cleanup: {
+            llmRequestLogRetentionMs: "not-a-number",
+          },
+        },
+      }),
+    );
+
+    const handler = createPrivacyConfigGetHandler();
+    const res = await handler(
+      new Request("http://gateway.test/v1/config/privacy"),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.llmRequestLogRetentionMs).toBe(DEFAULT_RETENTION_MS);
+  });
+
+  test("returns 0 verbatim when llmRequestLogRetentionMs is 0 (never prune)", async () => {
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        memory: {
+          cleanup: {
+            llmRequestLogRetentionMs: 0,
+          },
+        },
+      }),
+    );
+
+    const handler = createPrivacyConfigGetHandler();
+    const res = await handler(
+      new Request("http://gateway.test/v1/config/privacy"),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.llmRequestLogRetentionMs).toBe(0);
+    // Other fields fall back to their schema defaults.
+    expect(body.collectUsageData).toBe(true);
+    expect(body.sendDiagnostics).toBe(true);
+  });
+
+  test("falls back to defaults when collectUsageData/sendDiagnostics are non-boolean", async () => {
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        collectUsageData: "yes",
+        sendDiagnostics: 1,
+      }),
+    );
+
+    const handler = createPrivacyConfigGetHandler();
+    const res = await handler(
+      new Request("http://gateway.test/v1/config/privacy"),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.collectUsageData).toBe(true);
+    expect(body.sendDiagnostics).toBe(true);
+  });
+
+  test("falls back to default when llmRequestLogRetentionMs is a negative number", async () => {
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        memory: {
+          cleanup: {
+            llmRequestLogRetentionMs: -100,
+          },
+        },
+      }),
+    );
+
+    const handler = createPrivacyConfigGetHandler();
+    const res = await handler(
+      new Request("http://gateway.test/v1/config/privacy"),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.llmRequestLogRetentionMs).toBe(DEFAULT_RETENTION_MS);
+  });
+
+  test("falls back to default when llmRequestLogRetentionMs is a non-integer number", async () => {
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        memory: {
+          cleanup: {
+            llmRequestLogRetentionMs: 1.5,
+          },
+        },
+      }),
+    );
+
+    const handler = createPrivacyConfigGetHandler();
+    const res = await handler(
+      new Request("http://gateway.test/v1/config/privacy"),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.llmRequestLogRetentionMs).toBe(DEFAULT_RETENTION_MS);
+  });
+
+  test("falls back to default when memory.cleanup is missing entirely", async () => {
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        collectUsageData: false,
+      }),
+    );
+
+    const handler = createPrivacyConfigGetHandler();
+    const res = await handler(
+      new Request("http://gateway.test/v1/config/privacy"),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({
+      collectUsageData: false,
+      sendDiagnostics: true,
+      llmRequestLogRetentionMs: DEFAULT_RETENTION_MS,
+    });
+  });
+
+  test("returns 500 when config.json is malformed JSON", async () => {
+    writeFileSync(configPath, "{not valid json");
+
+    const handler = createPrivacyConfigGetHandler();
+    const res = await handler(
+      new Request("http://gateway.test/v1/config/privacy"),
+    );
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("Config file is malformed");
+  });
+
+  test("returns 500 when config.json is an array (not an object)", async () => {
+    writeFileSync(configPath, JSON.stringify([1, 2, 3]));
+
+    const handler = createPrivacyConfigGetHandler();
+    const res = await handler(
+      new Request("http://gateway.test/v1/config/privacy"),
+    );
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("Config file is malformed");
+  });
+
+  test("handles assistant-scoped path (no trailing slash stripping needed)", async () => {
+    // The assistant-scoped route uses a regex that matches the trailing
+    // slash variant; handler logic itself does not care about the URL.
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        collectUsageData: false,
+        sendDiagnostics: false,
+      }),
+    );
+
+    const handler = createPrivacyConfigGetHandler();
+    const res = await handler(
+      new Request(
+        "http://gateway.test/v1/assistants/some-assistant-id/config/privacy/",
+      ),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.collectUsageData).toBe(false);
+    expect(body.sendDiagnostics).toBe(false);
+    expect(body.llmRequestLogRetentionMs).toBe(DEFAULT_RETENTION_MS);
+  });
+});

--- a/gateway/src/http/routes/privacy-config.ts
+++ b/gateway/src/http/routes/privacy-config.ts
@@ -7,6 +7,72 @@ import {
 
 const log = getLogger("privacy-config");
 
+// These defaults MUST match the daemon's Zod schema defaults. See
+// `assistant/src/config/schema.ts` (collectUsageData, sendDiagnostics) and
+// `assistant/src/config/schemas/memory-lifecycle.ts`
+// (memory.cleanup.llmRequestLogRetentionMs). Keep them in sync.
+const DEFAULT_COLLECT_USAGE_DATA = true;
+const DEFAULT_SEND_DIAGNOSTICS = true;
+const DEFAULT_LLM_REQUEST_LOG_RETENTION_MS = 1 * 24 * 60 * 60 * 1000;
+
+export function createPrivacyConfigGetHandler() {
+  return async (_req: Request): Promise<Response> => {
+    const result = readConfigFile();
+    if (!result.ok) {
+      log.error(
+        { detail: result.detail },
+        "Failed to read config.json for privacy config GET",
+      );
+      return Response.json(
+        { error: "Config file is malformed" },
+        { status: 500 },
+      );
+    }
+
+    const config = result.data;
+
+    const rawCollectUsageData = (config as { collectUsageData?: unknown })
+      .collectUsageData;
+    const collectUsageData =
+      typeof rawCollectUsageData === "boolean"
+        ? rawCollectUsageData
+        : DEFAULT_COLLECT_USAGE_DATA;
+
+    const rawSendDiagnostics = (config as { sendDiagnostics?: unknown })
+      .sendDiagnostics;
+    const sendDiagnostics =
+      typeof rawSendDiagnostics === "boolean"
+        ? rawSendDiagnostics
+        : DEFAULT_SEND_DIAGNOSTICS;
+
+    // Extract nested memory.cleanup.llmRequestLogRetentionMs safely.
+    const memory = (config as { memory?: unknown }).memory;
+    const cleanup =
+      memory && typeof memory === "object" && !Array.isArray(memory)
+        ? (memory as { cleanup?: unknown }).cleanup
+        : undefined;
+    const rawRetention =
+      cleanup && typeof cleanup === "object" && !Array.isArray(cleanup)
+        ? (cleanup as { llmRequestLogRetentionMs?: unknown })
+            .llmRequestLogRetentionMs
+        : undefined;
+    // Must be a non-negative integer. A value of 0 is valid (means
+    // "never prune") and should be returned verbatim.
+    const llmRequestLogRetentionMs =
+      typeof rawRetention === "number" &&
+      Number.isInteger(rawRetention) &&
+      rawRetention >= 0
+        ? rawRetention
+        : DEFAULT_LLM_REQUEST_LOG_RETENTION_MS;
+
+    return Response.json({
+      collectUsageData,
+      sendDiagnostics,
+      llmRequestLogRetentionMs,
+    });
+  };
+}
+
 export function createPrivacyConfigPatchHandler() {
   return async (req: Request): Promise<Response> => {
     let body: unknown;

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -49,7 +49,10 @@ import {
   createFeatureFlagsGetHandler,
   createFeatureFlagsPatchHandler,
 } from "./http/routes/feature-flags.js";
-import { createPrivacyConfigPatchHandler } from "./http/routes/privacy-config.js";
+import {
+  createPrivacyConfigGetHandler,
+  createPrivacyConfigPatchHandler,
+} from "./http/routes/privacy-config.js";
 import { createChannelVerificationSessionProxyHandler } from "./http/routes/channel-verification-session-proxy.js";
 import { createTelegramControlPlaneProxyHandler } from "./http/routes/telegram-control-plane-proxy.js";
 import { createTwilioControlPlaneProxyHandler } from "./http/routes/twilio-control-plane-proxy.js";
@@ -299,6 +302,7 @@ async function main() {
   const handleLogExport = createLogExportHandler(config);
   const handleFeatureFlagsGet = createFeatureFlagsGetHandler();
   const handleFeatureFlagsPatch = createFeatureFlagsPatchHandler();
+  const handlePrivacyConfigGet = createPrivacyConfigGetHandler();
   const handlePrivacyConfigPatch = createPrivacyConfigPatchHandler();
   const handleTrustRulesList = createTrustRulesListHandler();
   const handleTrustRulesAdd = createTrustRulesAddHandler();
@@ -927,6 +931,20 @@ async function main() {
     },
 
     // ── Privacy config (scope-protected) ──
+    {
+      path: "/v1/config/privacy",
+      method: "GET",
+      auth: "edge-scoped",
+      scope: "settings.read",
+      handler: (req) => handlePrivacyConfigGet(req),
+    },
+    {
+      path: /^\/v1\/assistants\/([^/]+)\/config\/privacy\/$/,
+      method: "GET",
+      auth: "edge-scoped",
+      scope: "settings.read",
+      handler: (req) => handlePrivacyConfigGet(req),
+    },
     {
       path: "/v1/config/privacy",
       method: "PATCH",

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -2308,7 +2308,7 @@ export function buildSchema(): Record<string, unknown> {
         patch: {
           summary: "Update privacy config",
           description:
-            "Scope-protected gateway endpoint that updates privacy configuration (collectUsageData, sendDiagnostics). Requires a bearer token with `feature_flags.write` scope.",
+            "Scope-protected gateway endpoint that updates privacy configuration (collectUsageData, sendDiagnostics). Requires a bearer token with `settings.write` scope.",
           operationId: "privacyConfigPatch",
           security: [{ BearerAuth: [] }],
           requestBody: {

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -2271,6 +2271,40 @@ export function buildSchema(): Record<string, unknown> {
         },
       },
       "/v1/config/privacy": {
+        get: {
+          summary: "Get privacy config",
+          description:
+            "Scope-protected gateway endpoint that returns the current privacy configuration (collectUsageData, sendDiagnostics, llmRequestLogRetentionMs). Missing or malformed values fall back to the daemon schema defaults. Requires a bearer token with `settings.read` scope.",
+          operationId: "privacyConfigGet",
+          security: [{ BearerAuth: [] }],
+          responses: {
+            "200": {
+              description: "Privacy config returned",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      collectUsageData: { type: "boolean" },
+                      sendDiagnostics: { type: "boolean" },
+                      llmRequestLogRetentionMs: {
+                        type: "integer",
+                        minimum: 0,
+                        description:
+                          "Retention period for LLM request/response logs in milliseconds. 0 disables pruning.",
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            "401": {
+              description: "Unauthorized — missing or invalid bearer token",
+            },
+            "403": { description: "Insufficient scope" },
+            "500": { description: "Config file is malformed" },
+          },
+        },
         patch: {
           summary: "Update privacy config",
           description:
@@ -2386,6 +2420,49 @@ export function buildSchema(): Record<string, unknown> {
         },
       },
       "/v1/assistants/{assistantId}/config/privacy/": {
+        get: {
+          summary: "Get privacy config (assistant-scoped)",
+          description:
+            "Assistant-scoped variant of the privacy config read endpoint. Returns the current privacy configuration (collectUsageData, sendDiagnostics, llmRequestLogRetentionMs). Missing or malformed values fall back to the daemon schema defaults. Requires a bearer token with `settings.read` scope.",
+          operationId: "assistantPrivacyConfigGet",
+          security: [{ BearerAuth: [] }],
+          parameters: [
+            {
+              name: "assistantId",
+              in: "path",
+              required: true,
+              schema: { type: "string" },
+              description: "The assistant identifier.",
+            },
+          ],
+          responses: {
+            "200": {
+              description: "Privacy config returned",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      collectUsageData: { type: "boolean" },
+                      sendDiagnostics: { type: "boolean" },
+                      llmRequestLogRetentionMs: {
+                        type: "integer",
+                        minimum: 0,
+                        description:
+                          "Retention period for LLM request/response logs in milliseconds. 0 disables pruning.",
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            "401": {
+              description: "Unauthorized — missing or invalid bearer token",
+            },
+            "403": { description: "Insufficient scope" },
+            "500": { description: "Config file is malformed" },
+          },
+        },
         patch: {
           summary: "Update privacy config (assistant-scoped)",
           description:


### PR DESCRIPTION
## Summary
- New `GET /v1/config/privacy` endpoint returning `{ collectUsageData, sendDiagnostics, llmRequestLogRetentionMs }`
- Falls back to daemon Zod schema defaults when values are missing or malformed
- Preserves `0` as a valid retention value (means "never prune")
- Tests cover default fallback, explicit values, malformed nested values, and 500 on unreadable config

Part of plan: log-retention-setting.md (PR 2 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24462" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
