### PR TITLE
fix: update export test config fixture to include trailing newline

### DIFF
--- a/assistant/src/__tests__/migration-export-http.test.ts
+++ b/assistant/src/__tests__/migration-export-http.test.ts
@@ -75,7 +75,7 @@ beforeAll(() => {
   // Write test fixture files so the export reads real data
   mkdirSync(testDbDir, { recursive: true });
   writeFileSync(testDbPath, SQLITE_HEADER);
-  writeFileSync(testConfigPath, JSON.stringify(TEST_CONFIG, null, 2));
+  writeFileSync(testConfigPath, JSON.stringify(TEST_CONFIG, null, 2) + "\n");
 });
 
 // ---------------------------------------------------------------------------
@@ -323,7 +323,7 @@ describe("export data population", () => {
     );
     expect(configFile).toBeDefined();
     const expectedConfigSize = Buffer.byteLength(
-      JSON.stringify(TEST_CONFIG, null, 2),
+      JSON.stringify(TEST_CONFIG, null, 2) + "\n",
     );
     expect(configFile!.size).toBe(expectedConfigSize);
   });


### PR DESCRIPTION
## Summary
Updates the export test config fixture to include trailing newline, matching what sanitizeConfigForTransfer produces and real config files on disk.

Fixes gap identified during plan review for filter-config-teleport.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24464" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
