### PR TITLE
fix: add Array.isArray guard in sanitizeConfigForTransfer

### DIFF
--- a/assistant/src/config/sanitize-for-transfer.ts
+++ b/assistant/src/config/sanitize-for-transfer.ts
@@ -12,7 +12,11 @@ export function sanitizeConfigForTransfer(configJson: string): string {
   let config: Record<string, unknown>;
   try {
     const parsed = JSON.parse(configJson);
-    if (typeof parsed !== "object" || parsed === null) {
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      Array.isArray(parsed)
+    ) {
       return configJson;
     }
     config = parsed;


### PR DESCRIPTION
## Summary
Fixes bug where JSON arrays passed the non-object guard (typeof [] === 'object') and got re-serialized instead of returned as-is.

Fixes gap identified during plan review for filter-config-teleport.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24465" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
