### PR TITLE
feat(macos): render logo_url in IntegrationIcon with initials fallback

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/IntegrationIcon.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/IntegrationIcon.swift
@@ -1,8 +1,15 @@
 import SwiftUI
 import VellumAssistantShared
 
-/// Renders a colorful initials avatar for an integration provider.
-/// Uses the first two letters of the display name with a deterministic
+/// Renders an icon for an integration provider.
+///
+/// When `provider.logoURL` is non-nil, the image is fetched through
+/// `VCachedRemoteImage` (which shares `VRemoteImageCache.session`) and the
+/// initials avatar is shown as a placeholder while loading. When `logoURL`
+/// is nil, the initials avatar is rendered directly.
+///
+/// The initials avatar uses the first two letters of the display name (or
+/// provider key when the display name is missing) with a deterministic
 /// background color derived from the provider key.
 enum IntegrationIcon {
 
@@ -18,7 +25,36 @@ enum IntegrationIcon {
     ]
 
     @ViewBuilder
-    static func image(for providerKey: String, size: CGFloat = 24, displayName: String? = nil) -> some View {
+    static func image(for provider: OAuthProviderMetadata, size: CGFloat = 24) -> some View {
+        if let url = provider.logoURL {
+            VCachedRemoteImage(
+                url: url,
+                content: { image in
+                    image
+                        .resizable()
+                        .interpolation(.high)
+                        .aspectRatio(contentMode: .fit)
+                },
+                placeholder: {
+                    initialsAvatar(
+                        providerKey: provider.provider_key,
+                        displayName: provider.display_name,
+                        size: size
+                    )
+                }
+            )
+            .frame(width: size, height: size)
+        } else {
+            initialsAvatar(
+                providerKey: provider.provider_key,
+                displayName: provider.display_name,
+                size: size
+            )
+        }
+    }
+
+    @ViewBuilder
+    private static func initialsAvatar(providerKey: String, displayName: String?, size: CGFloat) -> some View {
         let name = displayName ?? providerKey
         let initials = String(name.prefix(2)).uppercased()
         let color = palette[Int(providerKey.utf8.reduce(0 as UInt32) { $0 &+ UInt32($1) }) % palette.count]

--- a/clients/macos/vellum-assistant/Features/Settings/IntegrationsPanelContent.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/IntegrationsPanelContent.swift
@@ -288,11 +288,7 @@ private struct IntegrationItemRow: View {
     var body: some View {
         VCard {
             HStack(alignment: .center, spacing: VSpacing.lg) {
-                IntegrationIcon.image(
-                    for: provider.provider_key,
-                    size: 32,
-                    displayName: provider.display_name
-                )
+                IntegrationIcon.image(for: provider, size: 32)
 
                 VStack(alignment: .leading, spacing: VSpacing.xs) {
                     Text(provider.display_name ?? provider.provider_key)


### PR DESCRIPTION
## Summary
- IntegrationIcon now takes the full `OAuthProviderMetadata` and renders URL-based logos via `VCachedRemoteImage`, falling back to the existing initials avatar when `logo_url` is nil
- Remove the legacy string-based `image(for:size:displayName:)` overload
- Update the Integrations panel row to pass the full metadata

Part of plan: oauth-provider-logos.md (PR 8 of 9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24470" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
