### PR TITLE
feat(oauth): persist logoUrl in registerProvider, updateProvider, seedProviders

### DIFF
--- a/assistant/src/__tests__/oauth-store.test.ts
+++ b/assistant/src/__tests__/oauth-store.test.ts
@@ -452,6 +452,57 @@ describe("provider operations", () => {
       expect(row!.revokeBodyTemplate).toBeNull();
     });
 
+    test("writes logoUrl on insert", () => {
+      seedProviders([
+        {
+          provider: "google",
+          authorizeUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+          tokenExchangeUrl: "https://oauth2.googleapis.com/token",
+          defaultScopes: ["openid"],
+          scopePolicy: {},
+          logoUrl: "https://cdn.simpleicons.org/google",
+        },
+      ]);
+
+      const row = getProvider("google");
+      expect(row).toBeDefined();
+      expect(row!.logoUrl).toBe("https://cdn.simpleicons.org/google");
+    });
+
+    test("overwrites logoUrl on conflict", () => {
+      seedProviders([
+        {
+          provider: "google",
+          authorizeUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+          tokenExchangeUrl: "https://oauth2.googleapis.com/token",
+          defaultScopes: ["openid"],
+          scopePolicy: {},
+          logoUrl: "https://cdn.simpleicons.org/google",
+        },
+      ]);
+
+      expect(getProvider("google")!.logoUrl).toBe(
+        "https://cdn.simpleicons.org/google",
+      );
+
+      // Re-seed with a different logoUrl — it should be overwritten,
+      // proving logoUrl is in the onConflictDoUpdate set clause alongside
+      // the other display-metadata fields.
+      seedProviders([
+        {
+          provider: "google",
+          authorizeUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+          tokenExchangeUrl: "https://oauth2.googleapis.com/token",
+          defaultScopes: ["openid"],
+          scopePolicy: {},
+          logoUrl: "https://cdn.simpleicons.org/google-v2",
+        },
+      ]);
+
+      const row = getProvider("google");
+      expect(row!.logoUrl).toBe("https://cdn.simpleicons.org/google-v2");
+    });
+
     test("re-seeding with a changed revokeUrl overwrites the stored value", () => {
       seedProviders([
         {
@@ -761,6 +812,35 @@ describe("provider operations", () => {
       });
       expect(row.tokenEndpointAuthMethod).toBe("client_secret_basic");
     });
+
+    test("stores logoUrl when provided", () => {
+      registerProvider({
+        provider: "notion",
+        authorizeUrl: "https://api.notion.com/v1/oauth/authorize",
+        tokenExchangeUrl: "https://api.notion.com/v1/oauth/token",
+        defaultScopes: ["read"],
+        scopePolicy: {},
+        logoUrl: "https://cdn.simpleicons.org/notion",
+      });
+
+      const fetched = getProvider("notion");
+      expect(fetched).toBeDefined();
+      expect(fetched!.logoUrl).toBe("https://cdn.simpleicons.org/notion");
+    });
+
+    test("defaults logoUrl to null when omitted", () => {
+      registerProvider({
+        provider: "linear",
+        authorizeUrl: "https://linear.app/oauth/authorize",
+        tokenExchangeUrl: "https://api.linear.app/oauth/token",
+        defaultScopes: ["read"],
+        scopePolicy: {},
+      });
+
+      const fetched = getProvider("linear");
+      expect(fetched).toBeDefined();
+      expect(fetched!.logoUrl).toBeNull();
+    });
   });
 
   describe("updateProvider", () => {
@@ -977,6 +1057,71 @@ describe("provider operations", () => {
 
       const row = getProvider("update-empty-test");
       expect(row!.tokenEndpointAuthMethod).toBe("client_secret_post");
+    });
+
+    test("sets logoUrl on an existing row where it was previously null", () => {
+      registerProvider({
+        provider: "linear",
+        authorizeUrl: "https://linear.app/oauth/authorize",
+        tokenExchangeUrl: "https://api.linear.app/oauth/token",
+        defaultScopes: ["read"],
+        scopePolicy: {},
+      });
+
+      expect(getProvider("linear")!.logoUrl).toBeNull();
+
+      const updated = updateProvider("linear", {
+        logoUrl: "https://cdn.simpleicons.org/linear",
+      });
+      expect(updated).toBeDefined();
+      expect(updated!.logoUrl).toBe("https://cdn.simpleicons.org/linear");
+
+      const fetched = getProvider("linear");
+      expect(fetched!.logoUrl).toBe("https://cdn.simpleicons.org/linear");
+    });
+
+    test("clears logoUrl when passed null", () => {
+      registerProvider({
+        provider: "notion",
+        authorizeUrl: "https://api.notion.com/v1/oauth/authorize",
+        tokenExchangeUrl: "https://api.notion.com/v1/oauth/token",
+        defaultScopes: ["read"],
+        scopePolicy: {},
+        logoUrl: "https://cdn.simpleicons.org/notion",
+      });
+
+      expect(getProvider("notion")!.logoUrl).toBe(
+        "https://cdn.simpleicons.org/notion",
+      );
+
+      const updated = updateProvider("notion", { logoUrl: null });
+      expect(updated).toBeDefined();
+      expect(updated!.logoUrl).toBeNull();
+
+      expect(getProvider("notion")!.logoUrl).toBeNull();
+    });
+
+    test("leaves logoUrl unchanged when not passed to updateProvider", () => {
+      registerProvider({
+        provider: "notion",
+        authorizeUrl: "https://api.notion.com/v1/oauth/authorize",
+        tokenExchangeUrl: "https://api.notion.com/v1/oauth/token",
+        defaultScopes: ["read"],
+        scopePolicy: {},
+        logoUrl: "https://cdn.simpleicons.org/notion",
+      });
+
+      expect(getProvider("notion")!.logoUrl).toBe(
+        "https://cdn.simpleicons.org/notion",
+      );
+
+      // Update a different field — logoUrl should be left alone.
+      const updated = updateProvider("notion", {
+        displayLabel: "Notion (updated)",
+      });
+      expect(updated).toBeDefined();
+      expect(updated!.logoUrl).toBe("https://cdn.simpleicons.org/notion");
+      expect(updated!.displayLabel).toBe("Notion (updated)");
     });
   });
 

--- a/assistant/src/oauth/oauth-store.ts
+++ b/assistant/src/oauth/oauth-store.ts
@@ -58,7 +58,7 @@ export type OAuthConnectionRow = typeof oauthConnections.$inferSelect;
  * identityResponsePaths, identityFormat, identityOkField, featureFlag,
  * scopeSeparator)
  * and display metadata (displayLabel, description, dashboardUrl,
- * clientIdPlaceholder, requiresClientSecret) propagate to existing
+ * clientIdPlaceholder, logoUrl, requiresClientSecret) propagate to existing
  * installations on every startup, while user-customizable fields
  * (defaultScopes, scopePolicy) are only written on the
  * initial insert. baseUrl is backfilled from seed data when null
@@ -89,6 +89,7 @@ export function seedProviders(
     description?: string;
     dashboardUrl?: string | null;
     clientIdPlaceholder?: string | null;
+    logoUrl?: string | null;
     requiresClientSecret?: boolean;
     loopbackPort?: number;
     injectionTemplates?: Array<{
@@ -146,6 +147,7 @@ export function seedProviders(
     const description = p.description ?? null;
     const dashboardUrl = p.dashboardUrl ?? null;
     const clientIdPlaceholder = p.clientIdPlaceholder ?? null;
+    const logoUrl = p.logoUrl ?? null;
     const requiresClientSecret = p.requiresClientSecret !== false ? 1 : 0;
     const loopbackPort = p.loopbackPort ?? null;
     const injectionTemplates = p.injectionTemplates
@@ -191,6 +193,7 @@ export function seedProviders(
         description,
         dashboardUrl,
         clientIdPlaceholder,
+        logoUrl,
         requiresClientSecret,
         loopbackPort,
         injectionTemplates,
@@ -229,6 +232,7 @@ export function seedProviders(
           description,
           dashboardUrl,
           clientIdPlaceholder,
+          logoUrl,
           requiresClientSecret,
           loopbackPort,
           injectionTemplates,
@@ -292,6 +296,7 @@ export function registerProvider(params: {
   description?: string;
   dashboardUrl?: string;
   clientIdPlaceholder?: string;
+  logoUrl?: string | null;
   requiresClientSecret?: number;
   loopbackPort?: number;
   injectionTemplates?: Array<{
@@ -349,7 +354,7 @@ export function registerProvider(params: {
     description: params.description ?? null,
     dashboardUrl: params.dashboardUrl ?? null,
     clientIdPlaceholder: params.clientIdPlaceholder ?? null,
-    logoUrl: null,
+    logoUrl: params.logoUrl ?? null,
     requiresClientSecret: params.requiresClientSecret ?? 1,
     loopbackPort: params.loopbackPort ?? null,
     injectionTemplates: params.injectionTemplates
@@ -413,6 +418,7 @@ export function updateProvider(
     description: string;
     dashboardUrl: string;
     clientIdPlaceholder: string;
+    logoUrl: string | null;
     requiresClientSecret: boolean;
     loopbackPort: number;
     injectionTemplates: Array<{
@@ -474,6 +480,7 @@ export function updateProvider(
   if (params.dashboardUrl !== undefined) set.dashboardUrl = params.dashboardUrl;
   if (params.clientIdPlaceholder !== undefined)
     set.clientIdPlaceholder = params.clientIdPlaceholder;
+  if (params.logoUrl !== undefined) set.logoUrl = params.logoUrl;
   if (params.requiresClientSecret !== undefined)
     set.requiresClientSecret = params.requiresClientSecret ? 1 : 0;
   if (params.loopbackPort !== undefined) set.loopbackPort = params.loopbackPort;


### PR DESCRIPTION
## Summary
- Add `logoUrl?: string | null` parameter to `registerProvider`, persisting via the existing Drizzle insert
- Add `logoUrl: string | null` to `updateProvider` params (null clears, undefined leaves unchanged, matching `revokeUrl`)
- Extend `seedProviders` to accept and persist `logoUrl`, treated as display metadata that overwrites on conflict

Part of plan: oauth-provider-logos.md (PR 2 of 9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24471" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
