### PR TITLE
feat(oauth): expose logo_url on oauth_providers API

### DIFF
--- a/assistant/src/__tests__/oauth-provider-serializer.test.ts
+++ b/assistant/src/__tests__/oauth-provider-serializer.test.ts
@@ -248,6 +248,20 @@ describe("serializeProvider", () => {
     const result = serializeProvider(row)!;
     expect(result.revokeBodyTemplate).toEqual(template);
   });
+
+  test("serializeProvider exposes logoUrl", () => {
+    const row = makeRow({
+      logoUrl: "https://cdn.simpleicons.org/notion",
+    });
+    const result = serializeProvider(row)!;
+    expect(result.logoUrl).toBe("https://cdn.simpleicons.org/notion");
+  });
+
+  test("serializeProvider emits logoUrl as null when row value is null", () => {
+    const row = makeRow({ logoUrl: null });
+    const result = serializeProvider(row)!;
+    expect(result.logoUrl).toBeNull();
+  });
 });
 
 describe("serializeProviderSummary", () => {
@@ -271,6 +285,7 @@ describe("serializeProviderSummary", () => {
       dashboard_url: "https://console.cloud.google.com",
       client_id_placeholder: "your-client-id.apps.googleusercontent.com",
       requires_client_secret: true,
+      logo_url: null,
       supports_managed_mode: true,
       feature_flag: null,
     });
@@ -336,5 +351,19 @@ describe("serializeProviderSummary", () => {
     expect(result).not.toHaveProperty("revokeUrl");
     expect(result).not.toHaveProperty("revoke_body_template");
     expect(result).not.toHaveProperty("revokeBodyTemplate");
+  });
+
+  test("serializeProviderSummary exposes logo_url", () => {
+    const row = makeRow({
+      logoUrl: "https://cdn.simpleicons.org/notion",
+    });
+    const result = serializeProviderSummary(row)!;
+    expect(result).toHaveProperty("logo_url");
+    expect(result.logo_url).toBe("https://cdn.simpleicons.org/notion");
+  });
+
+  test("logo_url is null when row logoUrl is null", () => {
+    const result = serializeProviderSummary({ ...makeRow(), logoUrl: null })!;
+    expect(result.logo_url).toBeNull();
   });
 });

--- a/assistant/src/__tests__/oauth-providers-routes.test.ts
+++ b/assistant/src/__tests__/oauth-providers-routes.test.ts
@@ -7,6 +7,7 @@ const mockListProviders = mock(() => [
     description: "Google OAuth provider",
     dashboardUrl: "https://console.cloud.google.com/apis/credentials",
     clientIdPlaceholder: null,
+    logoUrl: "https://cdn.simpleicons.org/google",
     requiresClientSecret: 1,
     managedServiceConfigKey: "google-oauth",
     authorizeUrl: "https://accounts.google.com/o/oauth2/v2/auth",
@@ -47,6 +48,7 @@ const mockListProviders = mock(() => [
     description: "GitHub OAuth provider",
     dashboardUrl: "https://github.com/settings/developers",
     clientIdPlaceholder: null,
+    logoUrl: null,
     requiresClientSecret: 1,
     managedServiceConfigKey: null,
     authorizeUrl: "https://github.com/login/oauth/authorize",
@@ -157,6 +159,7 @@ describe("GET /v1/oauth/providers", () => {
       "dashboard_url",
       "client_id_placeholder",
       "requires_client_secret",
+      "logo_url",
       "supports_managed_mode",
       "feature_flag",
     ];
@@ -164,6 +167,31 @@ describe("GET /v1/oauth/providers", () => {
     for (const provider of body.providers) {
       expect(Object.keys(provider).sort()).toEqual(expectedKeys.sort());
     }
+  });
+
+  test("response includes logo_url for each provider", async () => {
+    const req = new Request("http://localhost/v1/oauth/providers");
+    const url = new URL(req.url);
+    const res = await getRoute("GET", "oauth/providers").handler({
+      req,
+      url,
+      server: null as never,
+      authContext: null as never,
+      params: {},
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      providers: Array<{
+        provider_key: string;
+        logo_url: string | null;
+      }>;
+    };
+
+    expect(body.providers[0]!.logo_url).toBe(
+      "https://cdn.simpleicons.org/google",
+    );
+    expect(body.providers[1]!.logo_url).toBeNull();
   });
 
   test("supports_managed_mode=true returns only managed providers", async () => {

--- a/assistant/src/oauth/provider-serializer.ts
+++ b/assistant/src/oauth/provider-serializer.ts
@@ -30,6 +30,7 @@ export interface SerializedProviderSummary {
   dashboard_url: string | null;
   client_id_placeholder: string | null;
   requires_client_secret: boolean;
+  logo_url: string | null;
   supports_managed_mode: boolean;
   feature_flag: string | null;
 }
@@ -81,6 +82,7 @@ function _serializeProvider(
     displayName: displayLabel ?? null,
     description: row.description ?? null,
     dashboardUrl: row.dashboardUrl ?? null,
+    logoUrl: row.logoUrl ?? null,
     clientIdPlaceholder: row.clientIdPlaceholder ?? null,
     requiresClientSecret: !!(row.requiresClientSecret ?? 1),
     supportsManagedMode: !!row.managedServiceConfigKey,
@@ -136,6 +138,7 @@ export function serializeProviderSummary(
     dashboard_url: row.dashboardUrl ?? null,
     client_id_placeholder: row.clientIdPlaceholder ?? null,
     requires_client_secret: !!(row.requiresClientSecret ?? 1),
+    logo_url: row.logoUrl ?? null,
     supports_managed_mode: !!row.managedServiceConfigKey,
     feature_flag: row.featureFlag ?? null,
   };


### PR DESCRIPTION
## Summary
- Add `logo_url` to `SerializedProviderSummary` (snake_case for API) and `_serializeProvider` output
- Add test coverage for serializer and route shape

Part of plan: oauth-provider-logos.md (PR 4 of 9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24473" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
