### PR TITLE
feat(cli): add --logo-url and --logo-simpleicons-slug to oauth providers

### DIFF
--- a/assistant/src/cli/commands/oauth/__tests__/providers-register.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/providers-register.test.ts
@@ -1,0 +1,329 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { Command } from "commander";
+
+// ---------------------------------------------------------------------------
+// Mock state
+// ---------------------------------------------------------------------------
+
+let mockRegisterProvider: (
+  params: Record<string, unknown>,
+) => Record<string, unknown> = () => ({});
+
+let mockRegisterProviderCalls: Array<{
+  params: Record<string, unknown>;
+}> = [];
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+mock.module("../../../../config/loader.js", () => ({
+  getConfig: () => ({ services: {} }),
+  loadConfig: () => ({ services: {} }),
+  API_KEY_PROVIDERS: [],
+}));
+
+mock.module("../../../../oauth/oauth-store.js", () => ({
+  getProvider: () => undefined,
+  updateProvider: () => undefined,
+  listProviders: () => [],
+  registerProvider: (params: Record<string, unknown>) => {
+    mockRegisterProviderCalls.push({ params });
+    return mockRegisterProvider(params);
+  },
+  deleteProvider: () => false,
+  disconnectOAuthProvider: async () => "ok",
+  seedProviders: () => {},
+  getConnection: () => undefined,
+  getConnectionByProvider: () => undefined,
+  getActiveConnection: () => undefined,
+  listActiveConnectionsByProvider: () => [],
+  isProviderConnected: () => false,
+  createConnection: () => ({}),
+  updateConnection: () => ({}),
+  deleteConnection: () => false,
+  upsertApp: async () => ({}),
+  getApp: () => undefined,
+  getAppByProviderAndClientId: () => undefined,
+  getMostRecentAppByProvider: () => undefined,
+  listApps: () => [],
+  deleteApp: async () => false,
+  listConnections: () => [],
+}));
+
+mock.module("../../../../oauth/seed-providers.js", () => ({
+  SEEDED_PROVIDER_KEYS: new Set<string>(["google", "slack", "github"]),
+  PROVIDER_SEED_DATA: {},
+  seedAllProviders: () => {},
+}));
+
+mock.module("../../../../inbound/public-ingress-urls.js", () => ({
+  getOAuthCallbackUrl: () => null,
+}));
+
+mock.module("../../../../util/logger.js", () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+  getCliLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Import module under test (after mocks are registered)
+// ---------------------------------------------------------------------------
+
+const { registerProviderCommands } = await import("../providers.js");
+
+// ---------------------------------------------------------------------------
+// Test helper
+// ---------------------------------------------------------------------------
+
+async function runCommand(
+  args: string[],
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+  const originalStderrWrite = process.stderr.write.bind(process.stderr);
+  const stdoutChunks: string[] = [];
+  const stderrChunks: string[] = [];
+
+  process.stdout.write = ((chunk: unknown) => {
+    stdoutChunks.push(typeof chunk === "string" ? chunk : String(chunk));
+    return true;
+  }) as typeof process.stdout.write;
+
+  process.stderr.write = ((chunk: unknown) => {
+    stderrChunks.push(typeof chunk === "string" ? chunk : String(chunk));
+    return true;
+  }) as typeof process.stderr.write;
+
+  process.exitCode = 0;
+
+  try {
+    const program = new Command();
+    program.exitOverride();
+    program.option("--json", "JSON output");
+    program.configureOutput({
+      writeErr: (str: string) => stderrChunks.push(str),
+      writeOut: (str: string) => stdoutChunks.push(str),
+    });
+    registerProviderCommands(program);
+    await program.parseAsync(["node", "assistant", ...args]);
+  } catch {
+    if (process.exitCode === 0) process.exitCode = 1;
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+  }
+
+  const exitCode = process.exitCode ?? 0;
+  process.exitCode = 0;
+
+  return {
+    exitCode,
+    stdout: stdoutChunks.join(""),
+    stderr: stderrChunks.join(""),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Sample provider row
+// ---------------------------------------------------------------------------
+
+const sampleProviderRow = {
+  provider: "custom-api",
+  authorizeUrl: "https://custom-api.example.com/oauth/authorize",
+  tokenExchangeUrl: "https://custom-api.example.com/oauth/token",
+  refreshUrl: null,
+  tokenEndpointAuthMethod: "client_secret_post",
+  userinfoUrl: null,
+  baseUrl: null,
+  defaultScopes: "[]",
+  scopePolicy: "{}",
+  scopeSeparator: null,
+  authorizeParams: null,
+  managedServiceConfigKey: null,
+  pingUrl: null,
+  pingMethod: null,
+  pingHeaders: null,
+  pingBody: null,
+  revokeUrl: null,
+  revokeBodyTemplate: null,
+  displayLabel: null,
+  description: null,
+  dashboardUrl: null,
+  logoUrl: null,
+  clientIdPlaceholder: null,
+  requiresClientSecret: 1,
+  loopbackPort: null,
+  injectionTemplates: null,
+  appType: null,
+  setupNotes: null,
+  identityUrl: null,
+  identityMethod: null,
+  identityHeaders: null,
+  identityBody: null,
+  identityResponsePaths: null,
+  identityFormat: null,
+  identityOkField: null,
+  featureFlag: null,
+  createdAt: Date.now(),
+  updatedAt: Date.now(),
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("assistant oauth providers register", () => {
+  beforeEach(() => {
+    mockRegisterProvider = () => ({ ...sampleProviderRow });
+    mockRegisterProviderCalls = [];
+    process.exitCode = 0;
+  });
+
+  // -------------------------------------------------------------------------
+  // --logo-url
+  // -------------------------------------------------------------------------
+
+  test("register accepts --logo-url and passes it to registerProvider", async () => {
+    mockRegisterProvider = () => ({
+      ...sampleProviderRow,
+      logoUrl: "https://example.com/logo.png",
+    });
+
+    const { exitCode } = await runCommand([
+      "providers",
+      "register",
+      "--provider-key",
+      "custom-api",
+      "--auth-url",
+      "https://custom-api.example.com/oauth/authorize",
+      "--token-url",
+      "https://custom-api.example.com/oauth/token",
+      "--logo-url",
+      "https://example.com/logo.png",
+      "--json",
+    ]);
+    expect(exitCode).toBe(0);
+    expect(mockRegisterProviderCalls).toHaveLength(1);
+    expect(mockRegisterProviderCalls[0].params.logoUrl).toBe(
+      "https://example.com/logo.png",
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // --logo-simpleicons-slug
+  // -------------------------------------------------------------------------
+
+  test("register accepts --logo-simpleicons-slug and expands it to the CDN URL", async () => {
+    mockRegisterProvider = () => ({
+      ...sampleProviderRow,
+      logoUrl: "https://cdn.simpleicons.org/notion",
+    });
+
+    const { exitCode } = await runCommand([
+      "providers",
+      "register",
+      "--provider-key",
+      "custom-api",
+      "--auth-url",
+      "https://custom-api.example.com/oauth/authorize",
+      "--token-url",
+      "https://custom-api.example.com/oauth/token",
+      "--logo-simpleicons-slug",
+      "notion",
+      "--json",
+    ]);
+    expect(exitCode).toBe(0);
+    expect(mockRegisterProviderCalls).toHaveLength(1);
+    expect(mockRegisterProviderCalls[0].params.logoUrl).toBe(
+      "https://cdn.simpleicons.org/notion",
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // Mutual exclusion
+  // -------------------------------------------------------------------------
+
+  test("register rejects both --logo-url and --logo-simpleicons-slug simultaneously", async () => {
+    const { exitCode, stdout } = await runCommand([
+      "providers",
+      "register",
+      "--provider-key",
+      "custom-api",
+      "--auth-url",
+      "https://custom-api.example.com/oauth/authorize",
+      "--token-url",
+      "https://custom-api.example.com/oauth/token",
+      "--logo-url",
+      "https://example.com/logo.png",
+      "--logo-simpleicons-slug",
+      "notion",
+      "--json",
+    ]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("mutually exclusive");
+    expect(mockRegisterProviderCalls).toHaveLength(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // Empty slug rejection
+  // -------------------------------------------------------------------------
+
+  test("register rejects empty --logo-simpleicons-slug", async () => {
+    const { exitCode, stdout } = await runCommand([
+      "providers",
+      "register",
+      "--provider-key",
+      "custom-api",
+      "--auth-url",
+      "https://custom-api.example.com/oauth/authorize",
+      "--token-url",
+      "https://custom-api.example.com/oauth/token",
+      "--logo-simpleicons-slug",
+      "",
+      "--json",
+    ]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("cannot be empty");
+    expect(mockRegisterProviderCalls).toHaveLength(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // Empty --logo-url rejection at registration time
+  // -------------------------------------------------------------------------
+
+  test("register rejects empty --logo-url (clearing is only valid at update time)", async () => {
+    const { exitCode, stdout } = await runCommand([
+      "providers",
+      "register",
+      "--provider-key",
+      "custom-api",
+      "--auth-url",
+      "https://custom-api.example.com/oauth/authorize",
+      "--token-url",
+      "https://custom-api.example.com/oauth/token",
+      "--logo-url",
+      "",
+      "--json",
+    ]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Cannot clear logo_url");
+    expect(mockRegisterProviderCalls).toHaveLength(0);
+  });
+});

--- a/assistant/src/cli/commands/oauth/__tests__/providers-update.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/providers-update.test.ts
@@ -40,6 +40,8 @@ mock.module("../../../../oauth/oauth-store.js", () => ({
   },
   listProviders: () => [],
   registerProvider: () => ({}),
+  deleteProvider: () => false,
+  disconnectOAuthProvider: async () => "ok",
   seedProviders: () => {},
   getConnection: () => undefined,
   getConnectionByProvider: () => undefined,
@@ -319,6 +321,104 @@ describe("assistant oauth providers update", () => {
       defaultScopes: ["read", "write"],
       authorizeUrl: "https://new.example.com/auth",
     });
+  });
+
+  // -------------------------------------------------------------------------
+  // Successful update with injection templates, identity config, and setup metadata
+  // -------------------------------------------------------------------------
+
+  // -------------------------------------------------------------------------
+  // --logo-url
+  // -------------------------------------------------------------------------
+
+  test("update --logo-url sets params.logoUrl to the given string", async () => {
+    mockGetProvider = () => ({ ...sampleProviderRow });
+    mockUpdateProvider = (_key, _params) => ({
+      ...sampleProviderRow,
+      logoUrl: "https://example.com/logo.png",
+      updatedAt: Date.now(),
+    });
+
+    const { exitCode } = await runCommand([
+      "providers",
+      "update",
+      "custom-api",
+      "--logo-url",
+      "https://example.com/logo.png",
+      "--json",
+    ]);
+    expect(exitCode).toBe(0);
+    expect(mockUpdateProviderCalls).toHaveLength(1);
+    expect(mockUpdateProviderCalls[0].key).toBe("custom-api");
+    expect(mockUpdateProviderCalls[0].params).toEqual({
+      logoUrl: "https://example.com/logo.png",
+    });
+  });
+
+  test("update --logo-simpleicons-slug expands to CDN URL and passes as params.logoUrl", async () => {
+    mockGetProvider = () => ({ ...sampleProviderRow });
+    mockUpdateProvider = (_key, _params) => ({
+      ...sampleProviderRow,
+      logoUrl: "https://cdn.simpleicons.org/notion",
+      updatedAt: Date.now(),
+    });
+
+    const { exitCode } = await runCommand([
+      "providers",
+      "update",
+      "custom-api",
+      "--logo-simpleicons-slug",
+      "notion",
+      "--json",
+    ]);
+    expect(exitCode).toBe(0);
+    expect(mockUpdateProviderCalls).toHaveLength(1);
+    expect(mockUpdateProviderCalls[0].params).toEqual({
+      logoUrl: "https://cdn.simpleicons.org/notion",
+    });
+  });
+
+  test('update --logo-url "" clears params.logoUrl to null', async () => {
+    mockGetProvider = () => ({ ...sampleProviderRow });
+    mockUpdateProvider = (_key, _params) => ({
+      ...sampleProviderRow,
+      logoUrl: null,
+      updatedAt: Date.now(),
+    });
+
+    const { exitCode } = await runCommand([
+      "providers",
+      "update",
+      "custom-api",
+      "--logo-url",
+      "",
+      "--json",
+    ]);
+    expect(exitCode).toBe(0);
+    expect(mockUpdateProviderCalls).toHaveLength(1);
+    expect(mockUpdateProviderCalls[0].params).toEqual({
+      logoUrl: null,
+    });
+  });
+
+  test("update rejects both --logo-url and --logo-simpleicons-slug simultaneously", async () => {
+    mockGetProvider = () => ({ ...sampleProviderRow });
+
+    const { exitCode, stdout } = await runCommand([
+      "providers",
+      "update",
+      "custom-api",
+      "--logo-url",
+      "https://example.com/logo.png",
+      "--logo-simpleicons-slug",
+      "notion",
+      "--json",
+    ]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("mutually exclusive");
+    expect(mockUpdateProviderCalls).toHaveLength(0);
   });
 
   // -------------------------------------------------------------------------

--- a/assistant/src/cli/commands/oauth/providers.ts
+++ b/assistant/src/cli/commands/oauth/providers.ts
@@ -24,6 +24,38 @@ const log = getCliLogger("cli");
 const LOOPBACK_CALLBACK_PATH = "/oauth/callback";
 
 /**
+ * Resolve a logo URL from CLI flags, enforcing mutual exclusion between
+ * --logo-url and --logo-simpleicons-slug. Returns:
+ *   - `undefined` when neither flag is set (caller should leave the field unchanged)
+ *   - `null` when `--logo-url ""` is passed (clear the stored value)
+ *   - a non-empty string URL otherwise
+ * Throws when both flags are set simultaneously.
+ */
+function resolveLogoUrlFromFlags(opts: {
+  logoUrl?: string;
+  logoSimpleiconsSlug?: string;
+}): string | null | undefined {
+  if (opts.logoUrl !== undefined && opts.logoSimpleiconsSlug !== undefined) {
+    throw new Error(
+      "--logo-url and --logo-simpleicons-slug are mutually exclusive. Provide at most one.",
+    );
+  }
+  if (opts.logoSimpleiconsSlug !== undefined) {
+    const slug = opts.logoSimpleiconsSlug.trim();
+    if (!slug) {
+      throw new Error("--logo-simpleicons-slug cannot be empty.");
+    }
+    return `https://cdn.simpleicons.org/${encodeURIComponent(slug)}`;
+  }
+  if (opts.logoUrl !== undefined) {
+    // Empty string clears the stored value (matches --revoke-url semantics
+    // documented in the `update` command help text).
+    return opts.logoUrl === "" ? null : opts.logoUrl;
+  }
+  return undefined;
+}
+
+/**
  * Resolve the redirect URI for a provider based on its loopback port.
  *
  * Resolves the loopback redirect URI for display purposes. Gateway
@@ -272,6 +304,14 @@ Examples:
       "URL to the provider's developer console / dashboard",
     )
     .option(
+      "--logo-url <url>",
+      "URL to the provider's logo image (SVG or PNG). Mutually exclusive with --logo-simpleicons-slug.",
+    )
+    .option(
+      "--logo-simpleicons-slug <slug>",
+      'Simple Icons slug (e.g. "notion", "linear"). Resolves to https://cdn.simpleicons.org/<slug>. Mutually exclusive with --logo-url.',
+    )
+    .option(
       "--client-id-placeholder <text>",
       "Placeholder text shown in the client ID input field",
     )
@@ -380,7 +420,12 @@ Examples:
       --auth-url https://example.com/oauth/authorize \\
       --token-url https://example.com/oauth/token \\
       --revoke-url https://example.com/oauth/revoke \\
-      --revoke-body-template '{"token":"{access_token}","client_id":"{client_id}"}'`,
+      --revoke-body-template '{"token":"{access_token}","client_id":"{client_id}"}'
+  $ assistant oauth providers register \\
+      --provider-key notion-custom \\
+      --auth-url https://api.notion.com/v1/oauth/authorize \\
+      --token-url https://api.notion.com/v1/oauth/token \\
+      --logo-simpleicons-slug notion`,
     )
     .action(
       (
@@ -403,6 +448,8 @@ Examples:
           displayName?: string;
           description?: string;
           dashboardUrl?: string;
+          logoUrl?: string;
+          logoSimpleiconsSlug?: string;
           clientIdPlaceholder?: string;
           clientSecret: boolean;
           loopbackPort?: string;
@@ -420,6 +467,13 @@ Examples:
         cmd: Command,
       ) => {
         try {
+          const resolvedLogoUrl = resolveLogoUrlFromFlags(opts);
+          if (resolvedLogoUrl === null) {
+            throw new Error(
+              "Cannot clear logo_url with empty --logo-url during registration. Omit the flag instead.",
+            );
+          }
+
           const row = registerProvider({
             provider: opts.providerKey,
             authorizeUrl: opts.authUrl,
@@ -444,6 +498,7 @@ Examples:
             displayLabel: opts.displayName,
             description: opts.description,
             dashboardUrl: opts.dashboardUrl,
+            logoUrl: resolvedLogoUrl,
             clientIdPlaceholder: opts.clientIdPlaceholder,
             requiresClientSecret: opts.clientSecret ? 1 : 0,
             loopbackPort: opts.loopbackPort
@@ -550,6 +605,14 @@ Examples:
       "URL to the provider's developer console / dashboard",
     )
     .option(
+      "--logo-url <url>",
+      "URL to the provider's logo image (SVG or PNG). Mutually exclusive with --logo-simpleicons-slug.",
+    )
+    .option(
+      "--logo-simpleicons-slug <slug>",
+      'Simple Icons slug (e.g. "notion", "linear"). Resolves to https://cdn.simpleicons.org/<slug>. Mutually exclusive with --logo-url.',
+    )
+    .option(
       "--client-id-placeholder <text>",
       "Placeholder text shown in the client ID input field",
     )
@@ -630,7 +693,9 @@ Examples:
       --injection-templates '[{"hostPattern":"api.example.com","injectionType":"header","headerName":"Authorization","valuePrefix":"Bearer "}]'
   $ assistant oauth providers update custom-api \\
       --revoke-url https://api.example.com/oauth/revoke \\
-      --revoke-body-template '{"token":"{access_token}"}'`,
+      --revoke-body-template '{"token":"{access_token}"}'
+  $ assistant oauth providers update custom-api --logo-simpleicons-slug notion
+  $ assistant oauth providers update custom-api --logo-url ""`,
     )
     .action(
       (
@@ -653,6 +718,8 @@ Examples:
           displayName?: string;
           description?: string;
           dashboardUrl?: string;
+          logoUrl?: string;
+          logoSimpleiconsSlug?: string;
           clientIdPlaceholder?: string;
           clientSecret: boolean;
           loopbackPort?: string;
@@ -748,6 +815,11 @@ Examples:
             params.dashboardUrl = opts.dashboardUrl;
           if (opts.clientIdPlaceholder !== undefined)
             params.clientIdPlaceholder = opts.clientIdPlaceholder;
+
+          const resolvedLogoUrl = resolveLogoUrlFromFlags(opts);
+          if (resolvedLogoUrl !== undefined) {
+            params.logoUrl = resolvedLogoUrl;
+          }
 
           // Handle the negated --no-client-* flag: Commander defaults
           // opts.clientSecret to true; the negated form sets it to false.


### PR DESCRIPTION
## Summary
- Add mutually exclusive `--logo-url` and `--logo-simpleicons-slug` flags to `providers register` and `providers update`
- Simple Icons slugs resolve to `https://cdn.simpleicons.org/<slug>` server-side
- Empty `--logo-url` clears stored value on update (rejected on register)

Part of plan: oauth-provider-logos.md (PR 3 of 9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24474" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
