### PR TITLE
feat(skills): add catalog-files helper for previewing uninstalled catalog skill files

### DIFF
--- a/assistant/src/__tests__/catalog-files.test.ts
+++ b/assistant/src/__tests__/catalog-files.test.ts
@@ -286,6 +286,108 @@ describe("readCatalogSkillFiles (dev mode)", () => {
     expect(fetchCalls.length).toBe(0);
   });
 
+  test("rejects a symlinked skill root and falls through to platform mode", async () => {
+    // Reproduces the Codex P2 attack: an attacker (or a misconfigured dev)
+    // creates <repoSkillsDir>/my-skill as a symlink pointing at an external
+    // directory. Without the symlink-root check in `resolveCatalogSource`,
+    // the dev-mode branch would happily walk the external directory,
+    // because the realpath containment check downstream derives `realRoot`
+    // from the already-resolved symlink target.
+    //
+    // Expected behavior: the dev-mode shortcut is rejected up-front, and
+    // we fall through to platform mode — which in this test is stubbed
+    // to return an empty file list. So `readCatalogSkillFiles` should
+    // return the empty platform response, and `fetch` MUST be called
+    // (proving the fall-through happened, rather than the dev-mode
+    // shortcut silently reading from the external directory).
+    const root = makeTempSkillsDir();
+    const externalRoot = mkdtempSync(join(tmpdir(), "catalog-files-ext-"));
+    tempDirs.push(externalRoot);
+
+    // External directory populated with a real SKILL.md + a secret file
+    // that must NOT be exposed by the listing.
+    writeFileSync(join(externalRoot, "SKILL.md"), "# EXTERNAL SKILL");
+    writeFileSync(join(externalRoot, "secret.txt"), "EXTERNAL_SECRET");
+
+    // Symlink the skill root at `<root>/my-skill` to the external dir.
+    symlinkSync(externalRoot, join(root, "my-skill"));
+
+    mockRepoSkillsDir = root;
+    mockCatalog = [skill("my-skill")];
+    installFetchMock(() => Response.json({ skill_id: "my-skill", files: [] }));
+
+    const entries = await readCatalogSkillFiles("my-skill");
+
+    // Fall-through should produce the platform response (empty array),
+    // NOT the external directory contents.
+    expect(entries).toEqual([]);
+
+    // Confirm the dev-mode shortcut was bypassed: platform fetch was
+    // called against the preview endpoint.
+    expect(fetchCalls.length).toBe(1);
+    expect(fetchCalls[0]!.url).toBe(
+      "https://platform.test/v1/skills/my-skill/files/",
+    );
+  });
+
+  test("rejects a symlinked skill root for content reads and falls through to platform mode", async () => {
+    // Direct reproduction for `readCatalogSkillFileContent`: with a
+    // symlinked skill root, the dev branch must not read the external
+    // file. Instead we should fall through to the platform endpoint and
+    // return whatever the platform says.
+    const root = makeTempSkillsDir();
+    const externalRoot = mkdtempSync(join(tmpdir(), "catalog-files-ext-"));
+    tempDirs.push(externalRoot);
+
+    writeFileSync(join(externalRoot, "SKILL.md"), "EXTERNAL_SKILL_CONTENT");
+    symlinkSync(externalRoot, join(root, "my-skill"));
+
+    mockRepoSkillsDir = root;
+    mockCatalog = [skill("my-skill")];
+    installFetchMock(() =>
+      Response.json({
+        path: "SKILL.md",
+        name: "SKILL.md",
+        size: 14,
+        mime_type: "text/markdown",
+        is_binary: false,
+        content: "PLATFORM_CONTENT",
+      }),
+    );
+
+    const entry = await readCatalogSkillFileContent("my-skill", "SKILL.md");
+    expect(entry).not.toBeNull();
+    // Content must be the platform payload, NOT the external file's
+    // bytes — otherwise the fall-through didn't happen.
+    expect(entry!.content).toBe("PLATFORM_CONTENT");
+    expect(entry!.mimeType).toBe("text/markdown");
+
+    // And fetch was called, confirming dev-mode was bypassed.
+    expect(fetchCalls.length).toBe(1);
+    const url = fetchCalls[0]!.url;
+    expect(
+      url.startsWith("https://platform.test/v1/skills/my-skill/files/content/"),
+    ).toBe(true);
+  });
+
+  test("non-symlinked skill root still uses the dev-mode shortcut", async () => {
+    // Sanity check: a normal directory-based skill root must still be
+    // served from disk without touching fetch. This guards against the
+    // symlink-rejection path collateral-damaging regular dev flows.
+    const root = makeTempSkillsDir();
+    writeSkill(root, "normal-skill", { "SKILL.md": "# normal\n" });
+    mockRepoSkillsDir = root;
+    mockCatalog = [skill("normal-skill")];
+    installFetchForbidden();
+
+    const entries = await readCatalogSkillFiles("normal-skill");
+    expect(entries).not.toBeNull();
+    const paths = entries!.map((e) => e.path).sort();
+    expect(paths).toEqual(["SKILL.md"]);
+    // No platform round-trip happened.
+    expect(fetchCalls.length).toBe(0);
+  });
+
   test("filters hidden files and SKIP_DIRS from the listing", async () => {
     // Simulates a dev working on a catalog skill locally who has a
     // node_modules/, a .git/, and a .hidden.md file sitting next to

--- a/assistant/src/__tests__/catalog-files.test.ts
+++ b/assistant/src/__tests__/catalog-files.test.ts
@@ -1,0 +1,556 @@
+/**
+ * Unit tests for `skills/catalog-files.ts` — preview listings and single-file
+ * content for catalog skills (installed or not).
+ *
+ * Covers:
+ *   - sanitizeRelativePath (accepts safe, rejects traversal / absolute / null)
+ *   - readCatalogSkillFiles dev-mode (reads from a temp fake repo skills dir,
+ *     does NOT touch fetch)
+ *   - readCatalogSkillFiles platform-mode (stubbed fetch with success + 500
+ *     + 404 + network-error)
+ *   - readCatalogSkillFileContent dev-mode (text, traversal rejection,
+ *     binary, oversized)
+ *   - readCatalogSkillFileContent platform-mode (text, binary, oversized,
+ *     404, pre-fetch traversal rejection)
+ *   - catalog-miss short-circuit (no fetch call when id unknown)
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { CatalogSkill } from "../skills/catalog-install.js";
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before importing the module under test
+// ---------------------------------------------------------------------------
+
+// Suppress logger output
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+let mockCatalog: CatalogSkill[] = [];
+let mockRepoSkillsDir: string | undefined = undefined;
+
+mock.module("../skills/catalog-cache.js", () => ({
+  getCatalog: async () => mockCatalog,
+}));
+
+mock.module("../skills/catalog-install.js", () => ({
+  getRepoSkillsDir: () => mockRepoSkillsDir,
+}));
+
+let mockPlatformToken: string | null = null;
+mock.module("../util/platform.ts", () => ({
+  readPlatformToken: () => mockPlatformToken,
+}));
+mock.module("../util/platform.js", () => ({
+  readPlatformToken: () => mockPlatformToken,
+}));
+
+let mockPlatformBaseUrl = "https://platform.test";
+mock.module("../config/env.ts", () => ({
+  getPlatformBaseUrl: () => mockPlatformBaseUrl,
+}));
+mock.module("../config/env.js", () => ({
+  getPlatformBaseUrl: () => mockPlatformBaseUrl,
+}));
+
+// ---------------------------------------------------------------------------
+// Imports (after mocks)
+// ---------------------------------------------------------------------------
+
+import {
+  readCatalogSkillFileContent,
+  readCatalogSkillFiles,
+  sanitizeRelativePath,
+} from "../skills/catalog-files.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type FetchFn = typeof globalThis.fetch;
+
+interface FetchCall {
+  url: string;
+  init?: RequestInit;
+}
+
+let originalFetch: FetchFn;
+let fetchCalls: FetchCall[] = [];
+
+function installFetchMock(
+  handler: (url: string, init?: RequestInit) => Response | Promise<Response>,
+): void {
+  fetchCalls = [];
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+    fetchCalls.push({ url, init });
+    return handler(url, init);
+  }) as unknown as FetchFn;
+}
+
+function installFetchThrow(error: Error): void {
+  fetchCalls = [];
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+    fetchCalls.push({ url, init });
+    throw error;
+  }) as unknown as FetchFn;
+}
+
+function installFetchForbidden(): void {
+  fetchCalls = [];
+  globalThis.fetch = (async () => {
+    throw new Error("fetch should not have been called");
+  }) as unknown as FetchFn;
+}
+
+// Temp directories created during tests, cleaned up in afterEach.
+const tempDirs: string[] = [];
+
+function makeTempSkillsDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "catalog-files-test-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function writeSkill(
+  root: string,
+  skillId: string,
+  files: Record<string, string | Buffer>,
+): string {
+  const skillDir = join(root, skillId);
+  mkdirSync(skillDir, { recursive: true });
+  for (const [relPath, content] of Object.entries(files)) {
+    const abs = join(skillDir, relPath);
+    mkdirSync(join(abs, ".."), { recursive: true });
+    writeFileSync(abs, content);
+  }
+  return skillDir;
+}
+
+function skill(id: string): CatalogSkill {
+  return { id, name: id, description: id };
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+  fetchCalls = [];
+  mockCatalog = [];
+  mockRepoSkillsDir = undefined;
+  mockPlatformToken = null;
+  mockPlatformBaseUrl = "https://platform.test";
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  for (const dir of tempDirs) {
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // best effort
+    }
+  }
+  tempDirs.length = 0;
+});
+
+// ---------------------------------------------------------------------------
+// sanitizeRelativePath
+// ---------------------------------------------------------------------------
+
+describe("sanitizeRelativePath", () => {
+  test("accepts simple posix paths", () => {
+    expect(sanitizeRelativePath("SKILL.md")).toBe("SKILL.md");
+    expect(sanitizeRelativePath("tools/run.sh")).toBe("tools/run.sh");
+    expect(sanitizeRelativePath("a/b/c.txt")).toBe("a/b/c.txt");
+  });
+
+  test("normalizes leading ./", () => {
+    expect(sanitizeRelativePath("./x")).toBe("x");
+    expect(sanitizeRelativePath("./tools/run.sh")).toBe("tools/run.sh");
+  });
+
+  test("normalizes backslashes to forward slashes", () => {
+    expect(sanitizeRelativePath("tools\\run.sh")).toBe("tools/run.sh");
+  });
+
+  test("rejects empty strings", () => {
+    expect(sanitizeRelativePath("")).toBeNull();
+  });
+
+  test("rejects parent-traversal", () => {
+    expect(sanitizeRelativePath("..")).toBeNull();
+    expect(sanitizeRelativePath("../x")).toBeNull();
+    expect(sanitizeRelativePath("../../etc/passwd")).toBeNull();
+  });
+
+  test("rejects absolute unix paths", () => {
+    expect(sanitizeRelativePath("/etc/passwd")).toBeNull();
+    expect(sanitizeRelativePath("/")).toBeNull();
+  });
+
+  test("rejects windows drive-prefixed paths", () => {
+    expect(sanitizeRelativePath("C:/win")).toBeNull();
+    expect(sanitizeRelativePath("C:\\Windows")).toBeNull();
+  });
+
+  test("rejects paths containing null bytes", () => {
+    expect(sanitizeRelativePath("SKILL.md\0.png")).toBeNull();
+    expect(sanitizeRelativePath("\0")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// readCatalogSkillFiles — dev mode
+// ---------------------------------------------------------------------------
+
+describe("readCatalogSkillFiles (dev mode)", () => {
+  test("lists files from the repo skills dir without touching fetch", async () => {
+    const root = makeTempSkillsDir();
+    writeSkill(root, "my-skill", {
+      "SKILL.md": "# hello",
+      "tools/run.sh": "#!/bin/sh\necho hi\n",
+      "data/img.png": Buffer.from([0x89, 0x50, 0x4e, 0x47]),
+    });
+    mockRepoSkillsDir = root;
+    mockCatalog = [skill("my-skill")];
+    installFetchForbidden();
+
+    const entries = await readCatalogSkillFiles("my-skill");
+    expect(entries).not.toBeNull();
+    const paths = entries!.map((e) => e.path).sort();
+    expect(paths).toEqual(["SKILL.md", "data/img.png", "tools/run.sh"]);
+
+    const md = entries!.find((e) => e.path === "SKILL.md")!;
+    expect(md.name).toBe("SKILL.md");
+    expect(md.size).toBe("# hello".length);
+    expect(md.isBinary).toBe(false);
+    expect(md.content).toBeNull();
+
+    const png = entries!.find((e) => e.path === "data/img.png")!;
+    expect(png.name).toBe("img.png");
+    expect(png.isBinary).toBe(true);
+    expect(png.content).toBeNull();
+
+    expect(fetchCalls.length).toBe(0);
+  });
+
+  test("returns null when skill id is not in the catalog (dev mode)", async () => {
+    const root = makeTempSkillsDir();
+    writeSkill(root, "my-skill", { "SKILL.md": "x" });
+    mockRepoSkillsDir = root;
+    mockCatalog = []; // not in catalog
+    installFetchForbidden();
+
+    expect(await readCatalogSkillFiles("my-skill")).toBeNull();
+    expect(fetchCalls.length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// readCatalogSkillFiles — platform mode
+// ---------------------------------------------------------------------------
+
+describe("readCatalogSkillFiles (platform mode)", () => {
+  test("fetches file listing from the platform and maps it", async () => {
+    mockRepoSkillsDir = undefined;
+    mockCatalog = [skill("remote-skill")];
+    mockPlatformToken = "tok-123";
+    installFetchMock(() =>
+      Response.json({
+        skill_id: "remote-skill",
+        files: [
+          { path: "SKILL.md", name: "SKILL.md", size: 12, sha: "a" },
+          { path: "data/img.png", name: "img.png", size: 200, sha: "b" },
+        ],
+      }),
+    );
+
+    const entries = await readCatalogSkillFiles("remote-skill");
+    expect(entries).not.toBeNull();
+    expect(entries!.length).toBe(2);
+
+    // URL + headers
+    expect(fetchCalls.length).toBe(1);
+    expect(fetchCalls[0]!.url).toBe(
+      "https://platform.test/v1/skills/remote-skill/files/",
+    );
+    const headers = (fetchCalls[0]!.init?.headers ?? {}) as Record<
+      string,
+      string
+    >;
+    expect(headers["Accept"]).toBe("application/json");
+    expect(headers["X-Conversation-Token"]).toBe("tok-123");
+
+    // Mapped entries: always content === null, isBinary from filename.
+    const md = entries!.find((e) => e.path === "SKILL.md")!;
+    expect(md.isBinary).toBe(false);
+    expect(md.content).toBeNull();
+    expect(md.mimeType).toBe("");
+
+    const png = entries!.find((e) => e.path === "data/img.png")!;
+    expect(png.isBinary).toBe(true);
+    expect(png.content).toBeNull();
+    expect(png.mimeType).toBe("");
+  });
+
+  test("does not set X-Conversation-Token when no token is present", async () => {
+    mockCatalog = [skill("remote-skill")];
+    mockPlatformToken = null;
+    installFetchMock(() =>
+      Response.json({ skill_id: "remote-skill", files: [] }),
+    );
+
+    await readCatalogSkillFiles("remote-skill");
+    const headers = (fetchCalls[0]!.init?.headers ?? {}) as Record<
+      string,
+      string
+    >;
+    expect(headers["X-Conversation-Token"]).toBeUndefined();
+  });
+
+  test("returns null on 500", async () => {
+    mockCatalog = [skill("remote-skill")];
+    installFetchMock(
+      () => new Response("boom", { status: 500, statusText: "Server Error" }),
+    );
+    expect(await readCatalogSkillFiles("remote-skill")).toBeNull();
+    expect(fetchCalls.length).toBe(1);
+  });
+
+  test("returns null on 404", async () => {
+    mockCatalog = [skill("remote-skill")];
+    installFetchMock(
+      () => new Response("missing", { status: 404, statusText: "Not Found" }),
+    );
+    expect(await readCatalogSkillFiles("remote-skill")).toBeNull();
+  });
+
+  test("returns null on network error", async () => {
+    mockCatalog = [skill("remote-skill")];
+    installFetchThrow(new Error("ECONNRESET"));
+    expect(await readCatalogSkillFiles("remote-skill")).toBeNull();
+  });
+
+  test("returns null without fetching when skill id missing from catalog", async () => {
+    mockCatalog = [];
+    installFetchForbidden();
+    expect(await readCatalogSkillFiles("unknown")).toBeNull();
+    expect(fetchCalls.length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// readCatalogSkillFileContent — dev mode
+// ---------------------------------------------------------------------------
+
+describe("readCatalogSkillFileContent (dev mode)", () => {
+  test("returns inline UTF-8 content for a text file", async () => {
+    const root = makeTempSkillsDir();
+    writeSkill(root, "my-skill", { "SKILL.md": "# hello world\n" });
+    mockRepoSkillsDir = root;
+    mockCatalog = [skill("my-skill")];
+    installFetchForbidden();
+
+    const entry = await readCatalogSkillFileContent("my-skill", "SKILL.md");
+    expect(entry).not.toBeNull();
+    expect(entry!.path).toBe("SKILL.md");
+    expect(entry!.name).toBe("SKILL.md");
+    expect(entry!.isBinary).toBe(false);
+    expect(entry!.content).toBe("# hello world\n");
+    expect(fetchCalls.length).toBe(0);
+  });
+
+  test("rejects traversal paths without touching the filesystem", async () => {
+    const root = makeTempSkillsDir();
+    writeSkill(root, "my-skill", { "SKILL.md": "ok" });
+    mockRepoSkillsDir = root;
+    mockCatalog = [skill("my-skill")];
+    installFetchForbidden();
+
+    expect(
+      await readCatalogSkillFileContent("my-skill", "../escape"),
+    ).toBeNull();
+    expect(
+      await readCatalogSkillFileContent("my-skill", "/etc/passwd"),
+    ).toBeNull();
+    expect(await readCatalogSkillFileContent("my-skill", "..")).toBeNull();
+    expect(await readCatalogSkillFileContent("my-skill", "")).toBeNull();
+  });
+
+  test("returns content=null for a binary file", async () => {
+    const root = makeTempSkillsDir();
+    writeSkill(root, "my-skill", {
+      "img.png": Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    });
+    mockRepoSkillsDir = root;
+    mockCatalog = [skill("my-skill")];
+    installFetchForbidden();
+
+    const entry = await readCatalogSkillFileContent("my-skill", "img.png");
+    expect(entry).not.toBeNull();
+    expect(entry!.isBinary).toBe(true);
+    expect(entry!.content).toBeNull();
+  });
+
+  test("returns content=null for oversized text files", async () => {
+    const root = makeTempSkillsDir();
+    // Just over 2 MB of 'a'
+    const oversized = "a".repeat(2 * 1024 * 1024 + 1);
+    writeSkill(root, "my-skill", { "big.txt": oversized });
+    mockRepoSkillsDir = root;
+    mockCatalog = [skill("my-skill")];
+    installFetchForbidden();
+
+    const entry = await readCatalogSkillFileContent("my-skill", "big.txt");
+    expect(entry).not.toBeNull();
+    expect(entry!.isBinary).toBe(false);
+    expect(entry!.content).toBeNull();
+    expect(entry!.size).toBe(oversized.length);
+  });
+
+  test("returns null for a missing file", async () => {
+    const root = makeTempSkillsDir();
+    writeSkill(root, "my-skill", { "SKILL.md": "ok" });
+    mockRepoSkillsDir = root;
+    mockCatalog = [skill("my-skill")];
+    installFetchForbidden();
+
+    expect(
+      await readCatalogSkillFileContent("my-skill", "does/not/exist.txt"),
+    ).toBeNull();
+  });
+
+  test("returns null without fetching when skill id missing from catalog", async () => {
+    mockCatalog = [];
+    installFetchForbidden();
+    expect(await readCatalogSkillFileContent("unknown", "SKILL.md")).toBeNull();
+    expect(fetchCalls.length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// readCatalogSkillFileContent — platform mode
+// ---------------------------------------------------------------------------
+
+describe("readCatalogSkillFileContent (platform mode)", () => {
+  test("maps snake_case text response to camelCase entry", async () => {
+    mockCatalog = [skill("remote-skill")];
+    installFetchMock(() =>
+      Response.json({
+        path: "SKILL.md",
+        name: "SKILL.md",
+        size: 14,
+        mime_type: "text/markdown",
+        is_binary: false,
+        content: "# hello world\n",
+      }),
+    );
+
+    const entry = await readCatalogSkillFileContent("remote-skill", "SKILL.md");
+    expect(entry).not.toBeNull();
+    expect(entry!.path).toBe("SKILL.md");
+    expect(entry!.name).toBe("SKILL.md");
+    expect(entry!.size).toBe(14);
+    expect(entry!.mimeType).toBe("text/markdown");
+    expect(entry!.isBinary).toBe(false);
+    expect(entry!.content).toBe("# hello world\n");
+
+    expect(fetchCalls.length).toBe(1);
+    const url = fetchCalls[0]!.url;
+    expect(
+      url.startsWith(
+        "https://platform.test/v1/skills/remote-skill/files/content/",
+      ),
+    ).toBe(true);
+    expect(url).toContain("path=SKILL.md");
+  });
+
+  test("preserves binary response (content=null, isBinary=true)", async () => {
+    mockCatalog = [skill("remote-skill")];
+    installFetchMock(() =>
+      Response.json({
+        path: "img.png",
+        name: "img.png",
+        size: 1024,
+        mime_type: "image/png",
+        is_binary: true,
+        content: null,
+      }),
+    );
+
+    const entry = await readCatalogSkillFileContent("remote-skill", "img.png");
+    expect(entry).not.toBeNull();
+    expect(entry!.isBinary).toBe(true);
+    expect(entry!.content).toBeNull();
+    expect(entry!.mimeType).toBe("image/png");
+  });
+
+  test("preserves oversized text response (content=null)", async () => {
+    mockCatalog = [skill("remote-skill")];
+    installFetchMock(() =>
+      Response.json({
+        path: "big.txt",
+        name: "big.txt",
+        size: 3 * 1024 * 1024,
+        mime_type: "text/plain",
+        is_binary: false,
+        content: null,
+      }),
+    );
+
+    const entry = await readCatalogSkillFileContent("remote-skill", "big.txt");
+    expect(entry).not.toBeNull();
+    expect(entry!.isBinary).toBe(false);
+    expect(entry!.content).toBeNull();
+    expect(entry!.size).toBe(3 * 1024 * 1024);
+  });
+
+  test("returns null on 404", async () => {
+    mockCatalog = [skill("remote-skill")];
+    installFetchMock(
+      () => new Response("missing", { status: 404, statusText: "Not Found" }),
+    );
+    expect(
+      await readCatalogSkillFileContent("remote-skill", "ghost.md"),
+    ).toBeNull();
+  });
+
+  test("rejects traversal BEFORE making any fetch call", async () => {
+    mockCatalog = [skill("remote-skill")];
+    installFetchForbidden();
+    expect(await readCatalogSkillFileContent("remote-skill", "..")).toBeNull();
+    expect(
+      await readCatalogSkillFileContent("remote-skill", "../etc/passwd"),
+    ).toBeNull();
+    expect(fetchCalls.length).toBe(0);
+  });
+
+  test("returns null without fetching when skill id missing from catalog", async () => {
+    mockCatalog = [];
+    installFetchForbidden();
+    expect(await readCatalogSkillFileContent("unknown", "SKILL.md")).toBeNull();
+    expect(fetchCalls.length).toBe(0);
+  });
+});

--- a/assistant/src/__tests__/catalog-files.test.ts
+++ b/assistant/src/__tests__/catalog-files.test.ts
@@ -285,6 +285,34 @@ describe("readCatalogSkillFiles (dev mode)", () => {
     expect(await readCatalogSkillFiles("my-skill")).toBeNull();
     expect(fetchCalls.length).toBe(0);
   });
+
+  test("filters hidden files and SKIP_DIRS from the listing", async () => {
+    // Simulates a dev working on a catalog skill locally who has a
+    // node_modules/, a .git/, and a .hidden.md file sitting next to
+    // SKILL.md. The preview listing must only show SKILL.md — matching
+    // the behavior of `readDirRecursive` in `daemon/handlers/skills.ts`
+    // for installed skills.
+    const root = makeTempSkillsDir();
+    writeSkill(root, "my-skill", {
+      "SKILL.md": "# hello",
+      "node_modules/foo.js": "module.exports = {};",
+      "node_modules/nested/bar.js": "module.exports = {};",
+      "__pycache__/cached.pyc": Buffer.from([0x00, 0x01, 0x02]),
+      ".git/HEAD": "ref: refs/heads/main\n",
+      ".git/config": "[core]\n",
+      ".hidden.md": "secret",
+      ".DS_Store": Buffer.from([0x00, 0x00]),
+    });
+    mockRepoSkillsDir = root;
+    mockCatalog = [skill("my-skill")];
+    installFetchForbidden();
+
+    const entries = await readCatalogSkillFiles("my-skill");
+    expect(entries).not.toBeNull();
+    const paths = entries!.map((e) => e.path).sort();
+    expect(paths).toEqual(["SKILL.md"]);
+    expect(fetchCalls.length).toBe(0);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/__tests__/catalog-files.test.ts
+++ b/assistant/src/__tests__/catalog-files.test.ts
@@ -15,7 +15,13 @@
  *   - catalog-miss short-circuit (no fetch call when id unknown)
  */
 
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -447,6 +453,71 @@ describe("readCatalogSkillFileContent (dev mode)", () => {
     installFetchForbidden();
     expect(await readCatalogSkillFileContent("unknown", "SKILL.md")).toBeNull();
     expect(fetchCalls.length).toBe(0);
+  });
+
+  test("rejects symlinked files that point outside the skill root", async () => {
+    // Create a temp skill root AND a separate external directory.
+    const root = makeTempSkillsDir();
+    const externalRoot = mkdtempSync(join(tmpdir(), "catalog-files-ext-"));
+    tempDirs.push(externalRoot);
+
+    // Write an "external secret" file completely outside the skill tree.
+    const externalSecret = join(externalRoot, "secret.txt");
+    writeFileSync(externalSecret, "EXTERNAL_SECRET");
+
+    // Create the skill directory itself with a legitimate file.
+    const skillDir = writeSkill(root, "my-skill", { "SKILL.md": "ok" });
+
+    // Create a symlink INSIDE the skill dir pointing at the external file.
+    const linkPath = join(skillDir, "link-to-secret.md");
+    symlinkSync(externalSecret, linkPath);
+
+    mockRepoSkillsDir = root;
+    mockCatalog = [skill("my-skill")];
+    installFetchForbidden();
+
+    const entry = await readCatalogSkillFileContent(
+      "my-skill",
+      "link-to-secret.md",
+    );
+    expect(entry).toBeNull();
+
+    // And the legitimate file is still readable, so the check didn't
+    // collateral-damage normal requests.
+    const ok = await readCatalogSkillFileContent("my-skill", "SKILL.md");
+    expect(ok).not.toBeNull();
+    expect(ok!.content).toBe("ok");
+  });
+
+  test("rejects files accessed through a symlinked parent directory", async () => {
+    const root = makeTempSkillsDir();
+    const externalRoot = mkdtempSync(join(tmpdir(), "catalog-files-ext-"));
+    tempDirs.push(externalRoot);
+
+    // External directory with a real file inside it.
+    const externalDir = join(externalRoot, "external-dir");
+    mkdirSync(externalDir, { recursive: true });
+    writeFileSync(join(externalDir, "payload.txt"), "EXTERNAL_PAYLOAD");
+
+    // Legitimate skill dir with a normal file.
+    const skillDir = writeSkill(root, "my-skill", { "SKILL.md": "ok" });
+
+    // Inside the skill dir, create a symlinked subdirectory that points at
+    // the external directory. Then try to request
+    // `escape/payload.txt` — lexically this is inside the skill root, but
+    // the physical file lives outside.
+    const escapeLink = join(skillDir, "escape");
+    symlinkSync(externalDir, escapeLink);
+
+    mockRepoSkillsDir = root;
+    mockCatalog = [skill("my-skill")];
+    installFetchForbidden();
+
+    const entry = await readCatalogSkillFileContent(
+      "my-skill",
+      "escape/payload.txt",
+    );
+    expect(entry).toBeNull();
   });
 });
 

--- a/assistant/src/__tests__/catalog-files.test.ts
+++ b/assistant/src/__tests__/catalog-files.test.ts
@@ -221,6 +221,19 @@ describe("sanitizeRelativePath", () => {
     expect(sanitizeRelativePath("C:\\Windows")).toBeNull();
   });
 
+  test("rejects paths that become absolute after ./ stripping", () => {
+    // The leading `./` strip loop used to leave `/etc/passwd` behind, which
+    // posix.normalize then passed through as an absolute path. The
+    // post-normalization absolute-path check should reject each of these.
+    expect(sanitizeRelativePath(".//etc/passwd")).toBeNull();
+    expect(sanitizeRelativePath("./././/etc/passwd")).toBeNull();
+    // The backslash normalizes to `/`, so `.\\/etc/passwd` becomes
+    // `.//etc/passwd` before the strip loop, then `/etc/passwd`.
+    expect(sanitizeRelativePath(".\\/etc/passwd")).toBeNull();
+    // Windows-drive bypass via the same mechanism.
+    expect(sanitizeRelativePath(".//C:/Windows/system32")).toBeNull();
+  });
+
   test("rejects paths containing null bytes", () => {
     expect(sanitizeRelativePath("SKILL.md\0.png")).toBeNull();
     expect(sanitizeRelativePath("\0")).toBeNull();

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -33,6 +33,7 @@ import {
 } from "../../providers/provider-send-message.js";
 import { isTextMimeType as isTextMime } from "../../runtime/routes/workspace-utils.js";
 import { getCatalog } from "../../skills/catalog-cache.js";
+import type { SkillFileEntry } from "../../skills/catalog-files.js";
 import {
   installSkillLocally,
   upsertSkillsIndex,
@@ -494,14 +495,12 @@ export async function getSkill(
 
 // ─── Skill file listing ──────────────────────────────────────────────────────
 
-export interface SkillFileEntry {
-  path: string; // relative to skill directory root (e.g. "SKILL.md", "tools/foo.ts")
-  name: string; // basename
-  size: number;
-  mimeType: string;
-  isBinary: boolean;
-  content: string | null; // inline text if ≤ 2 MB and text MIME, else null
-}
+// `SkillFileEntry` lives in `../../skills/catalog-files.ts` to keep a single
+// source of truth for the shape and avoid a circular import (catalog-files
+// depends on `catalog-cache.ts`, which would otherwise be reachable via this
+// handler module). Re-exported here so handlers can import it alongside
+// the other skill handler exports.
+export type { SkillFileEntry } from "../../skills/catalog-files.js";
 
 const SKIP_DIRS = new Set(["node_modules", "__pycache__", ".git"]);
 

--- a/assistant/src/skills/catalog-files.ts
+++ b/assistant/src/skills/catalog-files.ts
@@ -213,6 +213,15 @@ async function fetchPlatformJson<T>(
 
 // ─── Dev-mode directory walker ───────────────────────────────────────────────
 
+// Directory names that are always skipped when walking a catalog skill dir in
+// dev mode. Kept in sync with `SKIP_DIRS` in
+// `src/daemon/handlers/skills.ts` (which performs the same filter for
+// installed skills). Duplicated here rather than imported to avoid a
+// circular dependency: `daemon/handlers/skills.ts` already imports the
+// `SkillFileEntry` type from this module. If you add or remove an entry,
+// update the other copy as well.
+const SKIP_DIRS = new Set(["node_modules", "__pycache__", ".git"]);
+
 function walkSkillDir(dir: string, rootDir: string): SkillFileEntry[] {
   const out: SkillFileEntry[] = [];
   let dirents;
@@ -222,10 +231,18 @@ function walkSkillDir(dir: string, rootDir: string): SkillFileEntry[] {
     return out;
   }
   for (const dirent of dirents) {
+    // Skip dot-prefixed entries (hidden files like `.DS_Store` and dot-dirs
+    // like `.git`, `.venv`). Matches the behavior of the installed-skill
+    // walker in `daemon/handlers/skills.ts`.
+    if (dirent.name.startsWith(".")) continue;
     const abs = join(dir, dirent.name);
     // Silently skip symlinks, sockets, devices, etc.
     if (dirent.isSymbolicLink()) continue;
     if (dirent.isDirectory()) {
+      // Skip well-known heavyweight directories (node_modules, __pycache__,
+      // ...) so a dev working on a catalog skill locally doesn't see
+      // thousands of spurious entries in the preview listing.
+      if (SKIP_DIRS.has(dirent.name)) continue;
       out.push(...walkSkillDir(abs, rootDir));
       continue;
     }

--- a/assistant/src/skills/catalog-files.ts
+++ b/assistant/src/skills/catalog-files.ts
@@ -129,6 +129,13 @@ export function sanitizeRelativePath(rawPath: string): string | null {
   if (normalized.startsWith("../")) return null;
   // posix.normalize can still return "." for purely no-op paths.
   if (normalized === ".") return null;
+  // Reject if normalization produced an absolute or Windows-drive path.
+  // Covers bypasses like `.//etc/passwd` where the leading `./` strip loop
+  // leaves `/etc/passwd`, which `posix.normalize` then passes through as an
+  // absolute path. The pre-normalization absolute-path check above only
+  // catches inputs that were absolute to begin with.
+  if (normalized.startsWith("/")) return null;
+  if (/^[a-zA-Z]:[/\\]/.test(normalized)) return null;
 
   return normalized;
 }

--- a/assistant/src/skills/catalog-files.ts
+++ b/assistant/src/skills/catalog-files.ts
@@ -1,0 +1,353 @@
+/**
+ * catalog-files — preview file listings and single-file content for catalog
+ * skills, including ones that are NOT installed locally.
+ *
+ * This module is pure library code: it does NOT wire itself into any handler
+ * or route. It is consumed by higher-level daemon handlers introduced in
+ * later PRs of the `skill-files-preview` plan.
+ *
+ * Data sources:
+ *   - In `VELLUM_DEV` mode, when `<repo>/skills/<id>/` exists on disk, we
+ *     read the skill files directly from the repo checkout (matching the
+ *     behavior of `getCatalog()` in dev).
+ *   - Otherwise, we call the platform preview endpoints introduced by
+ *     vellum-assistant-platform PR #4103:
+ *       GET /v1/skills/{skill_id}/files/
+ *       GET /v1/skills/{skill_id}/files/content/?path=...
+ *
+ * Crucially, this code does NOT extract any tar/gzip archives. Previewing a
+ * skill's files never installs it or touches the install flow.
+ */
+
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { basename, join, posix, sep } from "node:path";
+
+import { getPlatformBaseUrl } from "../config/env.js";
+import { isTextMimeType as isTextMime } from "../runtime/routes/workspace-utils.js";
+import { getLogger } from "../util/logger.js";
+import { readPlatformToken } from "../util/platform.js";
+import { getCatalog } from "./catalog-cache.js";
+import { getRepoSkillsDir } from "./catalog-install.js";
+
+const log = getLogger("catalog-files");
+
+const MAX_INLINE_SIZE = 2 * 1024 * 1024; // 2 MB
+
+/**
+ * Classify a file as text/binary from its name alone. Used by the preview
+ * listings where we do not have the file's bytes on hand (platform mode) or
+ * where we want to defer reading content until explicitly requested (dev
+ * mode listings). Bun derives the mime type from the file extension, so
+ * this works for non-existent paths too.
+ */
+function classifyByName(name: string): boolean {
+  const mime = Bun.file(name).type;
+  return !isTextMime(mime, name);
+}
+
+// ─── Shared types ────────────────────────────────────────────────────────────
+
+/**
+ * A single file entry in a skill directory or preview listing.
+ *
+ * This module owns the canonical shape; `daemon/handlers/skills.ts`
+ * re-exports it so handler consumers can import it from either location.
+ * Keeping the definition here avoids a circular import — catalog-files
+ * depends on `catalog-cache.ts`, which would otherwise be reachable via
+ * the handler module.
+ */
+export interface SkillFileEntry {
+  path: string; // relative to skill directory root (e.g. "SKILL.md", "tools/foo.ts")
+  name: string; // basename
+  size: number;
+  mimeType: string;
+  isBinary: boolean;
+  content: string | null; // inline text if ≤ 2 MB and text MIME, else null
+}
+
+// ─── Platform response contracts ─────────────────────────────────────────────
+//
+// Wire format is snake_case (vellum-assistant-platform PR #4103). We map to
+// the daemon's camelCase shape inside this module so nothing downstream needs
+// to know about the platform contract.
+
+interface PlatformFileListResponse {
+  skill_id: string;
+  files: Array<{ path: string; name: string; size: number; sha: string }>;
+}
+
+interface PlatformFileContentResponse {
+  path: string;
+  name: string;
+  size: number;
+  mime_type: string;
+  is_binary: boolean;
+  content: string | null;
+}
+
+// ─── Path sanitization ───────────────────────────────────────────────────────
+
+/**
+ * Normalize and validate a relative path coming from untrusted input. Returns
+ * the normalized posix path on success, or `null` if the input is unsafe.
+ *
+ * Rules:
+ *   - Reject empty strings and strings containing null bytes.
+ *   - Reject absolute paths (unix or windows drive-prefixed).
+ *   - Normalize backslashes to forward slashes, strip leading `./`, and
+ *     run `posix.normalize` to collapse redundant segments.
+ *   - Reject paths that escape the root (normalized result equals `..` or
+ *     begins with `../`).
+ *
+ * The platform also validates these server-side; client-side sanitization is
+ * defense in depth and short-circuits obvious bad requests before a network
+ * round trip.
+ */
+export function sanitizeRelativePath(rawPath: string): string | null {
+  if (typeof rawPath !== "string" || rawPath.length === 0) return null;
+  if (rawPath.includes("\0")) return null;
+  if (rawPath.startsWith("/")) return null;
+  if (/^[a-zA-Z]:[/\\]/.test(rawPath)) return null;
+
+  // Normalize separators and strip any leading "./" before posix.normalize
+  // (which would otherwise preserve it in some cases).
+  let candidate = rawPath.replace(/\\/g, "/");
+  while (candidate.startsWith("./")) {
+    candidate = candidate.slice(2);
+  }
+  if (candidate.length === 0) return null;
+
+  const normalized = posix.normalize(candidate);
+  if (normalized === "..") return null;
+  if (normalized.startsWith("../")) return null;
+  // posix.normalize can still return "." for purely no-op paths.
+  if (normalized === ".") return null;
+
+  return normalized;
+}
+
+// ─── Source resolution ───────────────────────────────────────────────────────
+
+type CatalogSource =
+  | { kind: "dir"; dirPath: string }
+  | { kind: "platform"; skillId: string };
+
+/**
+ * Resolve where to read files for a given catalog skill id. Performs NO
+ * network calls — network requests happen only inside `readCatalogSkillFiles`
+ * and `readCatalogSkillFileContent` on the platform path.
+ */
+async function resolveCatalogSource(
+  skillId: string,
+): Promise<CatalogSource | null> {
+  const catalog = await getCatalog();
+  const inCatalog = catalog.some((skill) => skill.id === skillId);
+  if (!inCatalog) return null;
+
+  const repoSkillsDir = getRepoSkillsDir();
+  if (repoSkillsDir) {
+    const candidate = join(repoSkillsDir, skillId);
+    if (existsSync(candidate)) {
+      return { kind: "dir", dirPath: candidate };
+    }
+  }
+  return { kind: "platform", skillId };
+}
+
+// ─── Platform fetch helper ───────────────────────────────────────────────────
+
+/**
+ * Fetch JSON from the platform preview API. Returns `null` on any failure
+ * (non-2xx, network error, abort). The query string is stripped from log
+ * messages to avoid leaking user-supplied file paths.
+ */
+async function fetchPlatformJson<T>(
+  path: string,
+  query?: Record<string, string>,
+): Promise<T | null> {
+  const base = getPlatformBaseUrl();
+  const url = new URL(`${base}${path}`);
+  if (query) {
+    const params = new URLSearchParams(query);
+    url.search = params.toString();
+  }
+
+  const headers: Record<string, string> = { Accept: "application/json" };
+  const token = readPlatformToken();
+  if (token) {
+    headers["X-Conversation-Token"] = token;
+  }
+
+  try {
+    const response = await fetch(url.toString(), {
+      headers,
+      signal: AbortSignal.timeout(15000),
+    });
+    if (!response.ok) {
+      log.warn(
+        { status: response.status, path },
+        "Platform preview API returned non-2xx",
+      );
+      return null;
+    }
+    return (await response.json()) as T;
+  } catch (err) {
+    log.warn({ err, path }, "Platform preview API request failed");
+    return null;
+  }
+}
+
+// ─── Dev-mode directory walker ───────────────────────────────────────────────
+
+function walkSkillDir(dir: string, rootDir: string): SkillFileEntry[] {
+  const out: SkillFileEntry[] = [];
+  let dirents;
+  try {
+    dirents = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const dirent of dirents) {
+    const abs = join(dir, dirent.name);
+    // Silently skip symlinks, sockets, devices, etc.
+    if (dirent.isSymbolicLink()) continue;
+    if (dirent.isDirectory()) {
+      out.push(...walkSkillDir(abs, rootDir));
+      continue;
+    }
+    if (!dirent.isFile()) continue;
+    try {
+      const stat = statSync(abs);
+      // Convert absolute → relative with manual separator normalization so
+      // the result is always posix-style regardless of the host platform.
+      const relFromRoot = abs.slice(rootDir.length);
+      const cleaned = relFromRoot.startsWith(sep)
+        ? relFromRoot.slice(sep.length)
+        : relFromRoot;
+      const posixPath = cleaned.split(sep).join("/");
+      out.push({
+        path: posixPath,
+        name: basename(posixPath),
+        size: stat.size,
+        mimeType: "",
+        isBinary: classifyByName(dirent.name),
+        content: null,
+      });
+    } catch {
+      // Skip unreadable files silently.
+    }
+  }
+  return out;
+}
+
+// ─── Public API ──────────────────────────────────────────────────────────────
+
+/**
+ * List files for a catalog skill (installed or not).
+ *
+ * Returns `null` if the skill id is not in the catalog at all. Otherwise
+ * returns an array of `SkillFileEntry` with `content === null` for every
+ * entry (single-file content is fetched on demand via
+ * `readCatalogSkillFileContent`).
+ */
+export async function readCatalogSkillFiles(
+  skillId: string,
+): Promise<SkillFileEntry[] | null> {
+  const source = await resolveCatalogSource(skillId);
+  if (!source) return null;
+
+  if (source.kind === "dir") {
+    const entries = walkSkillDir(source.dirPath, source.dirPath);
+    entries.sort((a, b) => a.path.localeCompare(b.path));
+    return entries;
+  }
+
+  const response = await fetchPlatformJson<PlatformFileListResponse>(
+    `/v1/skills/${encodeURIComponent(skillId)}/files/`,
+  );
+  if (!response) return null;
+
+  const entries: SkillFileEntry[] = response.files.map((file) => ({
+    path: file.path,
+    name: file.name,
+    size: file.size,
+    mimeType: "",
+    isBinary: classifyByName(file.name),
+    content: null,
+  }));
+  entries.sort((a, b) => a.path.localeCompare(b.path));
+  return entries;
+}
+
+/**
+ * Read a single file's content from a catalog skill (installed or not).
+ *
+ * Returns `null` if the skill is missing from the catalog, the path fails
+ * sanitization, the underlying source rejects the request, or the file does
+ * not exist. In dev mode, text files up to `MAX_INLINE_SIZE` are returned
+ * with their UTF-8 content inline; anything larger or flagged as binary
+ * returns with `content === null`. In platform mode, the server enforces
+ * the same contract and we pass its response through unchanged.
+ */
+export async function readCatalogSkillFileContent(
+  skillId: string,
+  relativePath: string,
+): Promise<SkillFileEntry | null> {
+  const sanitized = sanitizeRelativePath(relativePath);
+  if (!sanitized) return null;
+
+  const source = await resolveCatalogSource(skillId);
+  if (!source) return null;
+
+  if (source.kind === "dir") {
+    const abs = join(source.dirPath, sanitized);
+    // Defense in depth: make absolutely sure the resolved absolute path is
+    // still inside the skill root, even after `join` normalization.
+    if (!(abs === source.dirPath || abs.startsWith(source.dirPath + sep))) {
+      return null;
+    }
+    if (!existsSync(abs)) return null;
+    let stat;
+    try {
+      stat = statSync(abs);
+    } catch {
+      return null;
+    }
+    if (!stat.isFile()) return null;
+
+    const name = basename(abs);
+    const mimeType = Bun.file(abs).type;
+    const isBinary = !isTextMime(mimeType, name);
+    let content: string | null = null;
+    if (!isBinary && stat.size <= MAX_INLINE_SIZE) {
+      try {
+        content = readFileSync(abs, "utf-8");
+      } catch {
+        content = null;
+      }
+    }
+    return {
+      path: sanitized,
+      name,
+      size: stat.size,
+      mimeType,
+      isBinary,
+      content,
+    };
+  }
+
+  const response = await fetchPlatformJson<PlatformFileContentResponse>(
+    `/v1/skills/${encodeURIComponent(skillId)}/files/content/`,
+    { path: sanitized },
+  );
+  if (!response) return null;
+
+  return {
+    path: response.path,
+    name: response.name,
+    size: response.size,
+    mimeType: response.mime_type,
+    isBinary: response.is_binary,
+    content: response.content,
+  };
+}

--- a/assistant/src/skills/catalog-files.ts
+++ b/assistant/src/skills/catalog-files.ts
@@ -19,7 +19,14 @@
  * skill's files never installs it or touches the install flow.
  */
 
-import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import {
+  existsSync,
+  lstatSync,
+  readdirSync,
+  readFileSync,
+  realpathSync,
+  statSync,
+} from "node:fs";
 import { basename, join, posix, sep } from "node:path";
 
 import { getPlatformBaseUrl } from "../config/env.js";
@@ -302,11 +309,40 @@ export async function readCatalogSkillFileContent(
   if (source.kind === "dir") {
     const abs = join(source.dirPath, sanitized);
     // Defense in depth: make absolutely sure the resolved absolute path is
-    // still inside the skill root, even after `join` normalization.
+    // still inside the skill root, even after `join` normalization. This is
+    // a cheap lexical short-circuit that runs before any fs stat calls.
     if (!(abs === source.dirPath || abs.startsWith(source.dirPath + sep))) {
       return null;
     }
     if (!existsSync(abs)) return null;
+
+    // Reject symlinks at the target path directly: we do NOT want to follow
+    // a symlinked file inside a catalog skill dir out of the skill root.
+    let lstat;
+    try {
+      lstat = lstatSync(abs);
+    } catch {
+      return null;
+    }
+    if (lstat.isSymbolicLink()) return null;
+    if (!lstat.isFile()) return null;
+
+    // Also resolve any intermediate symlinks in the parent path via
+    // realpath and verify the result is still contained within the skill
+    // root's own realpath. This catches symlinked parent directories that
+    // the lexical check above can't see through.
+    let realAbs: string;
+    let realRoot: string;
+    try {
+      realAbs = realpathSync(abs);
+      realRoot = realpathSync(source.dirPath);
+    } catch {
+      return null;
+    }
+    if (!(realAbs === realRoot || realAbs.startsWith(realRoot + sep))) {
+      return null;
+    }
+
     let stat;
     try {
       stat = statSync(abs);

--- a/assistant/src/skills/catalog-files.ts
+++ b/assistant/src/skills/catalog-files.ts
@@ -150,6 +150,18 @@ type CatalogSource =
  * Resolve where to read files for a given catalog skill id. Performs NO
  * network calls — network requests happen only inside `readCatalogSkillFiles`
  * and `readCatalogSkillFileContent` on the platform path.
+ *
+ * Dev-mode safety: when a `<repoSkillsDir>/<skillId>` entry exists on disk,
+ * we verify that the skill root is a real directory physically located
+ * inside `repoSkillsDir` — rejecting symlinks and anything whose realpath
+ * escapes the repo skills dir. This prevents a symlinked skill root from
+ * pointing at an external directory and bypassing the later realpath
+ * containment check in `readCatalogSkillFileContent` (the check there
+ * derives `realRoot` from the already-resolved skill dir, so if the skill
+ * root itself is a symlink, `realRoot` resolves through the symlink target
+ * and the containment check becomes a no-op). On any violation we silently
+ * fall through to platform mode, which is the safe default — the dev-mode
+ * shortcut is an optimization, not a required code path.
  */
 async function resolveCatalogSource(
   skillId: string,
@@ -161,11 +173,53 @@ async function resolveCatalogSource(
   const repoSkillsDir = getRepoSkillsDir();
   if (repoSkillsDir) {
     const candidate = join(repoSkillsDir, skillId);
-    if (existsSync(candidate)) {
+    if (existsSync(candidate) && isSafeDevSkillRoot(candidate, repoSkillsDir)) {
       return { kind: "dir", dirPath: candidate };
     }
   }
   return { kind: "platform", skillId };
+}
+
+/**
+ * Verify that a dev-mode skill root candidate is a real directory physically
+ * located inside `repoSkillsDir`. Returns `false` for any of:
+ *
+ *   - `candidate` is itself a symbolic link (even if the target is still
+ *     "nearby" — following it would break the realpath containment check
+ *     in `readCatalogSkillFileContent`).
+ *   - `candidate` is not a directory.
+ *   - `realpath(candidate)` escapes `realpath(repoSkillsDir)`.
+ *   - Any fs call throws (EACCES, ENOENT race, etc.).
+ *
+ * Callers should fall through to platform mode on `false`.
+ */
+function isSafeDevSkillRoot(candidate: string, repoSkillsDir: string): boolean {
+  let lstat;
+  try {
+    lstat = lstatSync(candidate);
+  } catch {
+    return false;
+  }
+  if (lstat.isSymbolicLink()) return false;
+  if (!lstat.isDirectory()) return false;
+
+  let realCandidate: string;
+  let realRepoSkillsDir: string;
+  try {
+    realCandidate = realpathSync(candidate);
+    realRepoSkillsDir = realpathSync(repoSkillsDir);
+  } catch {
+    return false;
+  }
+  if (
+    !(
+      realCandidate === realRepoSkillsDir ||
+      realCandidate.startsWith(realRepoSkillsDir + sep)
+    )
+  ) {
+    return false;
+  }
+  return true;
 }
 
 // ─── Platform fetch helper ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Pure library module that reads file listings and single-file content for uninstalled Vellum catalog skills.
- In production, calls the new platform preview endpoints introduced by vellum-assistant-platform PR #4103; in VELLUM_DEV mode, falls back to on-disk reads from <repo>/skills/<id>/.
- No tar/gzip parsing; install flow is untouched. Includes bun:test coverage for path sanitization, dev-mode, platform-mode, and error/traversal paths.

Part of plan: skill-files-preview.md (PR 1 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24477" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
