### PR TITLE
feat(macos): add getPrivacyConfig and retention to FeatureFlagClient

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
@@ -600,7 +600,11 @@ extension AppDelegate {
             let syncCollectUsageData = hasExplicitCollectUsageData ? collectUsageData : nil
             let syncSendDiagnostics = hasExplicitSendDiagnostics ? sendDiagnostics : nil
             if syncCollectUsageData != nil || syncSendDiagnostics != nil {
-                try? await FeatureFlagClient().setPrivacyConfig(collectUsageData: syncCollectUsageData, sendDiagnostics: syncSendDiagnostics)
+                try? await FeatureFlagClient().setPrivacyConfig(
+                    collectUsageData: syncCollectUsageData,
+                    sendDiagnostics: syncSendDiagnostics,
+                    llmRequestLogRetentionMs: nil
+                )
             }
 
             let tosAccepted = UserDefaults.standard.bool(forKey: "tosAccepted")

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift
@@ -70,7 +70,8 @@ struct SettingsPrivacyTab: View {
         privacySyncTask = Task {
             try? await featureFlagClient.setPrivacyConfig(
                 collectUsageData: store.collectUsageData,
-                sendDiagnostics: store.sendDiagnostics
+                sendDiagnostics: store.sendDiagnostics,
+                llmRequestLogRetentionMs: nil
             )
         }
     }

--- a/clients/macos/vellum-assistantTests/FeatureFlagClientPrivacyTests.swift
+++ b/clients/macos/vellum-assistantTests/FeatureFlagClientPrivacyTests.swift
@@ -1,0 +1,92 @@
+import XCTest
+@testable import VellumAssistantShared
+
+/// Pure-Swift decode tests for `PrivacyConfig` — validates the JSON schema
+/// contract with the gateway's `{assistantId}/config/privacy` endpoint and the
+/// struct's `Equatable` conformance. No network mocking required.
+final class FeatureFlagClientPrivacyTests: XCTestCase {
+
+    // MARK: - Decode
+
+    /// Decodes a representative payload with a 1-day retention window.
+    func testPrivacyConfigDecodesFromRepresentativeJSON() throws {
+        // GIVEN a JSON payload matching the gateway response shape
+        let json = """
+        {
+            "collectUsageData": true,
+            "sendDiagnostics": false,
+            "llmRequestLogRetentionMs": 86400000
+        }
+        """.data(using: .utf8)!
+
+        // WHEN we decode it into a PrivacyConfig
+        let config = try JSONDecoder().decode(PrivacyConfig.self, from: json)
+
+        // THEN each field matches the payload
+        XCTAssertTrue(config.collectUsageData)
+        XCTAssertFalse(config.sendDiagnostics)
+        XCTAssertEqual(config.llmRequestLogRetentionMs, 86_400_000)
+    }
+
+    /// A retention value of 0 (meaning "never retain") must round-trip through
+    /// the decoder unchanged. This guards against accidental truthy-coercion
+    /// regressions if someone swaps `Int64` for a Boolean-ish type.
+    func testPrivacyConfigDecodesZeroRetention() throws {
+        // GIVEN a payload with llmRequestLogRetentionMs = 0
+        let json = """
+        {
+            "collectUsageData": false,
+            "sendDiagnostics": true,
+            "llmRequestLogRetentionMs": 0
+        }
+        """.data(using: .utf8)!
+
+        // WHEN we decode it
+        let config = try JSONDecoder().decode(PrivacyConfig.self, from: json)
+
+        // THEN retention is exactly 0
+        XCTAssertFalse(config.collectUsageData)
+        XCTAssertTrue(config.sendDiagnostics)
+        XCTAssertEqual(config.llmRequestLogRetentionMs, 0)
+    }
+
+    // MARK: - Equatable
+
+    /// Two configs constructed with the same fields must compare equal.
+    func testPrivacyConfigEquatableSameFields() {
+        // GIVEN two identically-constructed configs
+        let a = PrivacyConfig(
+            collectUsageData: true,
+            sendDiagnostics: false,
+            llmRequestLogRetentionMs: 86_400_000
+        )
+        let b = PrivacyConfig(
+            collectUsageData: true,
+            sendDiagnostics: false,
+            llmRequestLogRetentionMs: 86_400_000
+        )
+
+        // THEN they are equal
+        XCTAssertEqual(a, b)
+    }
+
+    /// Two configs that differ only in retention must NOT compare equal —
+    /// critical because the UI picker diffs against the current value to
+    /// decide whether to send a PATCH.
+    func testPrivacyConfigEquatableDifferentRetention() {
+        // GIVEN two configs that differ only in retention
+        let a = PrivacyConfig(
+            collectUsageData: true,
+            sendDiagnostics: false,
+            llmRequestLogRetentionMs: 86_400_000
+        )
+        let b = PrivacyConfig(
+            collectUsageData: true,
+            sendDiagnostics: false,
+            llmRequestLogRetentionMs: 604_800_000
+        )
+
+        // THEN they are not equal
+        XCTAssertNotEqual(a, b)
+    }
+}

--- a/clients/shared/Network/FeatureFlagClient.swift
+++ b/clients/shared/Network/FeatureFlagClient.swift
@@ -7,10 +7,36 @@ private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "Featu
 public protocol FeatureFlagClientProtocol {
     func getFeatureFlags() async throws -> [AssistantFeatureFlag]
     func setFeatureFlag(key: String, enabled: Bool) async throws
-    func setPrivacyConfig(collectUsageData: Bool?, sendDiagnostics: Bool?) async throws
+    func getPrivacyConfig() async throws -> PrivacyConfig
+    func setPrivacyConfig(
+        collectUsageData: Bool?,
+        sendDiagnostics: Bool?,
+        llmRequestLogRetentionMs: Int64?
+    ) async throws
 }
 
 // MARK: - Response Types
+
+/// Privacy configuration sourced from the gateway API.
+///
+/// Mirrors the `{assistantId}/config/privacy` response shape and carries the
+/// three user-facing privacy toggles: usage data, diagnostics, and LLM request
+/// log retention (in milliseconds).
+public struct PrivacyConfig: Decodable, Sendable, Equatable {
+    public let collectUsageData: Bool
+    public let sendDiagnostics: Bool
+    public let llmRequestLogRetentionMs: Int64
+
+    public init(
+        collectUsageData: Bool,
+        sendDiagnostics: Bool,
+        llmRequestLogRetentionMs: Int64
+    ) {
+        self.collectUsageData = collectUsageData
+        self.sendDiagnostics = sendDiagnostics
+        self.llmRequestLogRetentionMs = llmRequestLogRetentionMs
+    }
+}
 
 /// A feature flag sourced from the gateway API, used by the settings UI.
 public struct AssistantFeatureFlag: Decodable, Identifiable, Sendable {
@@ -121,10 +147,29 @@ public struct FeatureFlagClient: FeatureFlagClientProtocol {
         }
     }
 
-    public func setPrivacyConfig(collectUsageData: Bool? = nil, sendDiagnostics: Bool? = nil) async throws {
+    public func getPrivacyConfig() async throws -> PrivacyConfig {
+        let response = try await GatewayHTTPClient.get(
+            path: "assistants/{assistantId}/config/privacy",
+            timeout: 10
+        )
+        guard response.isSuccess else {
+            log.error("getPrivacyConfig failed (HTTP \(response.statusCode))")
+            throw FeatureFlagError.requestFailed(response.statusCode)
+        }
+        return try JSONDecoder().decode(PrivacyConfig.self, from: response.data)
+    }
+
+    public func setPrivacyConfig(
+        collectUsageData: Bool? = nil,
+        sendDiagnostics: Bool? = nil,
+        llmRequestLogRetentionMs: Int64? = nil
+    ) async throws {
         var body: [String: Any] = [:]
         if let collectUsageData { body["collectUsageData"] = collectUsageData }
         if let sendDiagnostics { body["sendDiagnostics"] = sendDiagnostics }
+        if let llmRequestLogRetentionMs {
+            body["llmRequestLogRetentionMs"] = llmRequestLogRetentionMs
+        }
 
         let response = try await GatewayHTTPClient.patch(
             path: "assistants/{assistantId}/config/privacy",


### PR DESCRIPTION
## Summary
- New `PrivacyConfig` struct with `collectUsageData`, `sendDiagnostics`, and `llmRequestLogRetentionMs` fields
- New `getPrivacyConfig()` method on `FeatureFlagClient` for reading the current state from the gateway
- Extended `setPrivacyConfig(...)` with an optional `llmRequestLogRetentionMs` parameter (default `nil` — callers that only set booleans compile unchanged)
- New decode tests covering the JSON schema contract

Part of plan: log-retention-setting.md (PR 4 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24478" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
