### PR TITLE
feat(browser-relay): cloud token refresh + reconnect lifecycle (PR8)

### DIFF
--- a/clients/chrome-extension/background/__tests__/cloud-auth.test.ts
+++ b/clients/chrome-extension/background/__tests__/cloud-auth.test.ts
@@ -10,8 +10,13 @@ import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
 
 import {
   getStoredToken,
+  getStoredTokenRaw,
   clearStoredToken,
   signInCloud,
+  refreshCloudToken,
+  isCloudTokenStale,
+  CLOUD_TOKEN_STALE_WINDOW_MS,
+  CLOUD_AUTH_FAILURE_CLOSE_CODES,
   type CloudAuthConfig,
   type StoredCloudToken,
 } from '../cloud-auth.js';
@@ -204,5 +209,144 @@ describe('clearStoredToken', () => {
   test('is a no-op when nothing is stored', async () => {
     await clearStoredToken();
     expect(fakeStorage.data[STORAGE_KEY]).toBeUndefined();
+  });
+});
+
+describe('getStoredTokenRaw', () => {
+  test('returns an expired token (unlike getStoredToken)', async () => {
+    const expired: StoredCloudToken = {
+      token: 'expired',
+      expiresAt: Date.now() - 1_000,
+      guardianId: 'g-1',
+    };
+    fakeStorage.data[STORAGE_KEY] = expired;
+
+    // getStoredToken hides expired tokens…
+    expect(await getStoredToken()).toBeNull();
+    // …but getStoredTokenRaw surfaces them so the reconnect path
+    // can tell "signed in but expired" apart from "never signed in".
+    expect(await getStoredTokenRaw()).toEqual(expired);
+  });
+
+  test('returns null when nothing is stored', async () => {
+    expect(await getStoredTokenRaw()).toBeNull();
+  });
+
+  test('returns null when the stored value is malformed', async () => {
+    fakeStorage.data[STORAGE_KEY] = { token: 42, expiresAt: 'soon' };
+    expect(await getStoredTokenRaw()).toBeNull();
+  });
+});
+
+describe('isCloudTokenStale', () => {
+  test('null token counts as stale', () => {
+    expect(isCloudTokenStale(null)).toBe(true);
+  });
+
+  test('token expiring inside the stale window counts as stale', () => {
+    const now = 1_000_000;
+    const token: StoredCloudToken = {
+      token: 't',
+      expiresAt: now + CLOUD_TOKEN_STALE_WINDOW_MS - 1,
+      guardianId: 'g-1',
+    };
+    expect(isCloudTokenStale(token, now)).toBe(true);
+  });
+
+  test('token expiring well after the stale window is fresh', () => {
+    const now = 1_000_000;
+    const token: StoredCloudToken = {
+      token: 't',
+      expiresAt: now + CLOUD_TOKEN_STALE_WINDOW_MS * 10,
+      guardianId: 'g-1',
+    };
+    expect(isCloudTokenStale(token, now)).toBe(false);
+  });
+
+  test('already-expired token counts as stale', () => {
+    const now = 1_000_000;
+    const token: StoredCloudToken = {
+      token: 't',
+      expiresAt: now - 1,
+      guardianId: 'g-1',
+    };
+    expect(isCloudTokenStale(token, now)).toBe(true);
+  });
+});
+
+describe('CLOUD_AUTH_FAILURE_CLOSE_CODES', () => {
+  test('covers the gateway auth-failure application codes', () => {
+    // Mirrors the codes emitted by the gateway's browser-relay
+    // handshake. Pinned here so a future refactor can't accidentally
+    // drop one without updating this invariant.
+    expect(CLOUD_AUTH_FAILURE_CLOSE_CODES.has(4001)).toBe(true);
+    expect(CLOUD_AUTH_FAILURE_CLOSE_CODES.has(4002)).toBe(true);
+    expect(CLOUD_AUTH_FAILURE_CLOSE_CODES.has(4003)).toBe(true);
+    // 1008 ("policy violation") is included for intermediaries that
+    // rewrite application codes back to the standard range.
+    expect(CLOUD_AUTH_FAILURE_CLOSE_CODES.has(1008)).toBe(true);
+    // Normal close codes are NOT in the set — they represent clean
+    // shutdowns, not auth failures.
+    expect(CLOUD_AUTH_FAILURE_CLOSE_CODES.has(1000)).toBe(false);
+    expect(CLOUD_AUTH_FAILURE_CLOSE_CODES.has(1006)).toBe(false);
+  });
+});
+
+describe('refreshCloudToken', () => {
+  test('happy path: non-interactive flow persists and returns the new token', async () => {
+    let seenInteractive: boolean | undefined;
+    launchWebAuthFlowImpl = async (details) => {
+      seenInteractive = details.interactive;
+      expect(details.url).toContain('https://api.vellum.ai/oauth/chrome-extension/start');
+      return 'https://fakeextid.chromiumapp.org/cloud-auth#token=fresh-jwt&expires_in=3600&guardian_id=g-99';
+    };
+
+    const before = Date.now();
+    const result = await refreshCloudToken(config);
+    expect(result).not.toBeNull();
+    const token = result as StoredCloudToken;
+
+    expect(seenInteractive).toBe(false);
+    expect(token.token).toBe('fresh-jwt');
+    expect(token.guardianId).toBe('g-99');
+    expect(token.expiresAt).toBeGreaterThanOrEqual(before + 3600 * 1000);
+
+    // Token was persisted to storage so future reads see the new one.
+    expect(fakeStorage.data[STORAGE_KEY]).toEqual(token);
+  });
+
+  test('returns null when Chrome rejects for interaction required', async () => {
+    launchWebAuthFlowImpl = async () => {
+      throw new Error('OAuth2 not granted or revoked.');
+    };
+
+    // Pre-seed a stale token so we can verify it isn't clobbered.
+    const stale: StoredCloudToken = {
+      token: 'stale-jwt',
+      expiresAt: Date.now() - 1_000,
+      guardianId: 'g-1',
+    };
+    fakeStorage.data[STORAGE_KEY] = stale;
+
+    const result = await refreshCloudToken(config);
+    expect(result).toBeNull();
+    // The stale token is left in place — the reconnect path uses this
+    // to decide whether to surface a sign-in prompt to the user.
+    expect(fakeStorage.data[STORAGE_KEY]).toEqual(stale);
+  });
+
+  test('returns null when launchWebAuthFlow resolves with undefined', async () => {
+    launchWebAuthFlowImpl = async () => undefined;
+    expect(await refreshCloudToken(config)).toBeNull();
+  });
+
+  test('throws when the gateway returns an incomplete payload', async () => {
+    // A malformed response from the gateway is an unexpected error and
+    // should bubble up to the service-worker logs — we only swallow
+    // the "interaction required" family of Chrome rejections.
+    launchWebAuthFlowImpl = async () =>
+      'https://fakeextid.chromiumapp.org/cloud-auth#guardian_id=g-42';
+
+    await expect(refreshCloudToken(config)).rejects.toThrow('incomplete payload');
   });
 });

--- a/clients/chrome-extension/background/__tests__/relay-connection.test.ts
+++ b/clients/chrome-extension/background/__tests__/relay-connection.test.ts
@@ -9,7 +9,12 @@
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
 
-import { RelayConnection, type RelayMode } from '../relay-connection.js';
+import {
+  RelayConnection,
+  type RelayMode,
+  type RelayReconnectContext,
+  type RelayReconnectDecision,
+} from '../relay-connection.js';
 
 // ── Fake WebSocket ──────────────────────────────────────────────────
 
@@ -105,7 +110,7 @@ function closeSocket(ws: FakeWebSocket, code = 1006, reason = 'abnormal'): void 
 
 interface Callbacks {
   openCalls: number;
-  closeCalls: Array<{ code: number; reason: string }>;
+  closeCalls: Array<{ code: number; reason: string; authError?: string }>;
   messages: string[];
 }
 
@@ -113,7 +118,15 @@ function makeCallbacks(): Callbacks {
   return { openCalls: 0, closeCalls: [], messages: [] };
 }
 
-function makeConn(mode: RelayMode, callbacks: Callbacks, onReconnect?: () => Promise<string | null | void>): RelayConnection {
+type ReconnectHook = (
+  ctx: RelayReconnectContext,
+) => Promise<string | null | void | RelayReconnectDecision>;
+
+function makeConn(
+  mode: RelayMode,
+  callbacks: Callbacks,
+  onReconnect?: ReconnectHook,
+): RelayConnection {
   return new RelayConnection({
     mode,
     onOpen: () => {
@@ -122,8 +135,8 @@ function makeConn(mode: RelayMode, callbacks: Callbacks, onReconnect?: () => Pro
     onMessage: (data) => {
       callbacks.messages.push(data);
     },
-    onClose: (code, reason) => {
-      callbacks.closeCalls.push({ code, reason });
+    onClose: (code, reason, authError) => {
+      callbacks.closeCalls.push({ code, reason, authError });
     },
     onReconnect,
   });
@@ -468,6 +481,158 @@ describe('RelayConnection', () => {
 
       // No second socket should have been constructed.
       expect(instances.length).toBe(1);
+    });
+
+    test('cloud reconnect: token refresh replaces URL token on next connect', async () => {
+      const cbs = makeCallbacks();
+      let seenCtx: RelayReconnectContext | null = null;
+      const conn = makeConn(
+        { kind: 'cloud', baseUrl: 'https://api.vellum.ai', token: 'old-jwt' },
+        cbs,
+        async (ctx) => {
+          seenCtx = ctx;
+          // New-style return: explicit refreshed decision. Mimics
+          // the cloudReconnectHook in worker.ts.
+          return { kind: 'refreshed', token: 'fresh-jwt' } satisfies RelayReconnectDecision;
+        },
+      );
+
+      conn.start();
+      openSocket(instances[0]);
+      expect(instances[0].url).toBe(
+        'wss://api.vellum.ai/v1/browser-relay?token=old-jwt',
+      );
+
+      // Simulate the gateway rejecting the JWT with 4001.
+      closeSocket(instances[0], 4001, 'token expired');
+      await new Promise((r) => setTimeout(r, 1100));
+
+      expect(seenCtx).not.toBeNull();
+      expect(seenCtx!.code).toBe(4001);
+      expect(seenCtx!.reason).toBe('token expired');
+
+      expect(instances.length).toBe(2);
+      expect(instances[1].url).toBe(
+        'wss://api.vellum.ai/v1/browser-relay?token=fresh-jwt',
+      );
+
+      conn.close();
+    });
+
+    test('cloud reconnect: getCurrentMode reflects the refreshed token after reconnect', async () => {
+      // The worker relies on getCurrentMode() to pick up the freshly
+      // minted token for subsequent host_browser_result POSTs. This
+      // pins the invariant that a reconnect-with-refresh cycle swaps
+      // the mode's token in place so callers don't need to capture
+      // snapshots themselves.
+      const cbs = makeCallbacks();
+      const conn = makeConn(
+        { kind: 'cloud', baseUrl: 'https://api.vellum.ai', token: 'old-jwt' },
+        cbs,
+        async () => ({ kind: 'refreshed', token: 'fresh-jwt' }),
+      );
+
+      conn.start();
+      openSocket(instances[0]);
+      expect(conn.getCurrentMode().token).toBe('old-jwt');
+
+      closeSocket(instances[0], 4001, 'auth');
+      await new Promise((r) => setTimeout(r, 1100));
+
+      // Mode accessor returns the refreshed token for any future
+      // dispatch reading through it.
+      expect(conn.getCurrentMode().kind).toBe('cloud');
+      expect(conn.getCurrentMode().token).toBe('fresh-jwt');
+
+      conn.close();
+    });
+
+    test('cloud reconnect: abort decision halts reconnect and propagates auth error', async () => {
+      const cbs = makeCallbacks();
+      const conn = makeConn(
+        { kind: 'cloud', baseUrl: 'https://api.vellum.ai', token: 'old-jwt' },
+        cbs,
+        async () => ({
+          kind: 'abort',
+          error: 'Cloud token expired — sign in again.',
+        }),
+      );
+
+      conn.start();
+      openSocket(instances[0]);
+      closeSocket(instances[0], 4001, 'token expired');
+
+      // Wait long enough for the reconnect timer to fire.
+      await new Promise((r) => setTimeout(r, 1100));
+
+      // No second socket should have been constructed — the abort
+      // decision must stop the reconnect loop cold.
+      expect(instances.length).toBe(1);
+
+      // The helper surfaced the auth error via onClose with the
+      // original close code + reason so the worker can route it to
+      // the popup without a second close event.
+      const authCloses = cbs.closeCalls.filter((c) => c.authError !== undefined);
+      expect(authCloses.length).toBe(1);
+      expect(authCloses[0].code).toBe(4001);
+      expect(authCloses[0].reason).toBe('token expired');
+      expect(authCloses[0].authError).toBe('Cloud token expired — sign in again.');
+
+      // isOpen must return false and a subsequent unexpected close
+      // event must not restart reconnects — the helper is marked as
+      // closed by the caller.
+      expect(conn.isOpen()).toBe(false);
+      await new Promise((r) => setTimeout(r, 1100));
+      expect(instances.length).toBe(1);
+    });
+
+    test('cloud reconnect: keep decision reuses the existing token', async () => {
+      const cbs = makeCallbacks();
+      let refreshCalls = 0;
+      const conn = makeConn(
+        { kind: 'cloud', baseUrl: 'https://api.vellum.ai', token: 'still-good' },
+        cbs,
+        async () => {
+          refreshCalls += 1;
+          return { kind: 'keep' };
+        },
+      );
+
+      conn.start();
+      openSocket(instances[0]);
+      // A transient 1006 (abnormal close) shouldn't force a refresh.
+      closeSocket(instances[0], 1006, 'network blip');
+      await new Promise((r) => setTimeout(r, 1100));
+
+      expect(refreshCalls).toBe(1);
+      expect(instances.length).toBe(2);
+      expect(instances[1].url).toContain('token=still-good');
+
+      conn.close();
+    });
+
+    test('reconnect hook receives the close code and reason as context', async () => {
+      const cbs = makeCallbacks();
+      const seen: RelayReconnectContext[] = [];
+      const conn = makeConn(
+        { kind: 'cloud', baseUrl: 'https://api.vellum.ai', token: 't' },
+        cbs,
+        async (ctx) => {
+          seen.push(ctx);
+          return { kind: 'refreshed', token: 't2' };
+        },
+      );
+
+      conn.start();
+      openSocket(instances[0]);
+      closeSocket(instances[0], 4003, 'guardian revoked');
+      await new Promise((r) => setTimeout(r, 1100));
+
+      expect(seen.length).toBe(1);
+      expect(seen[0].code).toBe(4003);
+      expect(seen[0].reason).toBe('guardian revoked');
+
+      conn.close();
     });
   });
 

--- a/clients/chrome-extension/background/cloud-auth.ts
+++ b/clients/chrome-extension/background/cloud-auth.ts
@@ -3,8 +3,15 @@
  *
  * Launches chrome.identity.launchWebAuthFlow against the Vellum gateway and
  * persists the guardian-bound JWT in chrome.storage.local. The token is used
- * by later PRs to authenticate the browser-relay WebSocket against the cloud
- * gateway — this module is the storage + state machine layer only.
+ * to authenticate the browser-relay WebSocket against the cloud gateway.
+ *
+ * Also exposes {@link refreshCloudToken}, the non-interactive refresh helper
+ * used by the relay reconnect path when the stored token has expired or the
+ * server closed the socket with an auth-failure code. Non-interactive means
+ * it calls `launchWebAuthFlow({ interactive: false })` — Chrome will either
+ * return a fresh token from an existing provider session or immediately
+ * reject with "interaction required", in which case the caller must prompt
+ * the user to sign in again instead of silently looping.
  */
 
 export interface CloudAuthConfig {
@@ -19,6 +26,31 @@ export interface StoredCloudToken {
   expiresAt: number; // ms since epoch
   guardianId: string;
 }
+
+/**
+ * Window (ms) before `expiresAt` inside which we treat the stored token as
+ * "stale" and proactively refresh it. 60 seconds gives us enough headroom
+ * that an in-flight reconnect doesn't race the gateway's own expiry check.
+ */
+export const CLOUD_TOKEN_STALE_WINDOW_MS = 60_000;
+
+/**
+ * WebSocket close codes the gateway uses to signal that the handshake was
+ * rejected for an auth reason — an expired JWT, a revoked guardian, or a
+ * rotated signing key. The relay reconnect path treats these specially and
+ * forces a token refresh before the next connect attempt.
+ *
+ * - `4001`/`4002`/`4003` are in the RFC 6455 "application" range
+ *   (4000–4999) and match the codes emitted by
+ *   `gateway/src/http/routes/browser-relay-websocket.ts` for the three
+ *   distinct auth-failure paths.
+ * - `1008` ("policy violation") is included for robustness — some
+ *   intermediaries rewrite application codes back to 1008 when the socket
+ *   is torn down mid-handshake.
+ */
+export const CLOUD_AUTH_FAILURE_CLOSE_CODES: ReadonlySet<number> = new Set([
+  1008, 4001, 4002, 4003,
+]);
 
 const STORAGE_KEY = 'vellum.cloudAuthToken';
 
@@ -38,6 +70,41 @@ export async function getStoredToken(): Promise<StoredCloudToken | null> {
   return token;
 }
 
+/**
+ * Return the raw stored cloud token without the "is this currently valid"
+ * check in {@link getStoredToken}. This is used by the reconnect helper so
+ * an expired token can still surface its `expiresAt` / `guardianId` for the
+ * refresh decision — a `null` return from `getStoredToken()` would
+ * indiscriminately conflate "never signed in" with "signed in but expired".
+ */
+export async function getStoredTokenRaw(): Promise<StoredCloudToken | null> {
+  const result = await chrome.storage.local.get(STORAGE_KEY);
+  const raw = result[STORAGE_KEY];
+  if (!raw || typeof raw !== 'object') return null;
+  const token = raw as StoredCloudToken;
+  if (
+    typeof token.token !== 'string' ||
+    typeof token.expiresAt !== 'number' ||
+    typeof token.guardianId !== 'string'
+  ) {
+    return null;
+  }
+  return token;
+}
+
+/**
+ * Return `true` when the stored token is expired or within
+ * {@link CLOUD_TOKEN_STALE_WINDOW_MS} of expiring. `null`/missing tokens
+ * also count as stale so callers can treat them uniformly.
+ */
+export function isCloudTokenStale(
+  token: StoredCloudToken | null,
+  now: number = Date.now(),
+): boolean {
+  if (!token) return true;
+  return token.expiresAt - now <= CLOUD_TOKEN_STALE_WINDOW_MS;
+}
+
 export async function clearStoredToken(): Promise<void> {
   await chrome.storage.local.remove(STORAGE_KEY);
 }
@@ -46,20 +113,7 @@ async function persistToken(token: StoredCloudToken): Promise<void> {
   await chrome.storage.local.set({ [STORAGE_KEY]: token });
 }
 
-/**
- * Launches chrome.identity.launchWebAuthFlow to obtain a guardian-bound JWT.
- * The extension receives the token via the redirect URI fragment.
- */
-export async function signInCloud(config: CloudAuthConfig): Promise<StoredCloudToken> {
-  const redirectUri = chrome.identity.getRedirectURL('cloud-auth');
-  const authUrl =
-    `${config.gatewayBaseUrl.replace(/\/$/, '')}/oauth/chrome-extension/start` +
-    `?client_id=${encodeURIComponent(config.clientId)}` +
-    `&redirect_uri=${encodeURIComponent(redirectUri)}`;
-
-  const responseUrl = await chrome.identity.launchWebAuthFlow({ url: authUrl, interactive: true });
-  if (!responseUrl) throw new Error('cloud sign-in cancelled');
-
+function parseAuthResponseUrl(responseUrl: string): StoredCloudToken {
   const hash = new URL(responseUrl).hash.replace(/^#/, '');
   const params = new URLSearchParams(hash);
   const token = params.get('token');
@@ -68,11 +122,84 @@ export async function signInCloud(config: CloudAuthConfig): Promise<StoredCloudT
   if (!token || !expiresIn || !guardianId) {
     throw new Error('cloud sign-in returned incomplete payload');
   }
-  const stored: StoredCloudToken = {
+  return {
     token,
     expiresAt: Date.now() + expiresIn * 1000,
     guardianId,
   };
+}
+
+function buildAuthUrl(config: CloudAuthConfig): string {
+  const redirectUri = chrome.identity.getRedirectURL('cloud-auth');
+  return (
+    `${config.gatewayBaseUrl.replace(/\/$/, '')}/oauth/chrome-extension/start` +
+    `?client_id=${encodeURIComponent(config.clientId)}` +
+    `&redirect_uri=${encodeURIComponent(redirectUri)}`
+  );
+}
+
+/**
+ * Launches chrome.identity.launchWebAuthFlow to obtain a guardian-bound JWT.
+ * The extension receives the token via the redirect URI fragment.
+ */
+export async function signInCloud(config: CloudAuthConfig): Promise<StoredCloudToken> {
+  const authUrl = buildAuthUrl(config);
+
+  const responseUrl = await chrome.identity.launchWebAuthFlow({ url: authUrl, interactive: true });
+  if (!responseUrl) throw new Error('cloud sign-in cancelled');
+
+  const stored = parseAuthResponseUrl(responseUrl);
+  await persistToken(stored);
+  return stored;
+}
+
+/**
+ * Attempt a non-interactive renewal of the stored cloud token.
+ *
+ * Calls `chrome.identity.launchWebAuthFlow` with `interactive: false` so
+ * Chrome will return a fresh token if the user still has a live provider
+ * session, and will reject immediately with an "interaction required"
+ * style error otherwise. This is the happy path used by the relay
+ * reconnect hook — the caller falls back to surfacing a sign-in prompt in
+ * the popup when this returns `null`.
+ *
+ * Returns the freshly persisted token on success, or `null` when Chrome
+ * reports that interactive sign-in is required (or any other non-fatal
+ * refresh failure). Throws for truly unexpected errors (e.g. malformed
+ * gateway response) so they bubble up to the service worker logs.
+ */
+export async function refreshCloudToken(
+  config: CloudAuthConfig,
+): Promise<StoredCloudToken | null> {
+  const authUrl = buildAuthUrl(config);
+
+  let responseUrl: string | undefined;
+  try {
+    responseUrl = await chrome.identity.launchWebAuthFlow({
+      url: authUrl,
+      interactive: false,
+    });
+  } catch (err) {
+    // Chrome rejects non-interactive flows with messages like
+    // "OAuth2 not granted or revoked", "user interaction required",
+    // or "The user did not approve access". Normalise all of these
+    // to a null return so the caller falls back to prompting the
+    // user to sign in again. Unexpected shapes still log through.
+    console.warn(
+      '[vellum-cloud-auth] non-interactive refresh rejected:',
+      err instanceof Error ? err.message : String(err),
+    );
+    return null;
+  }
+
+  if (!responseUrl) {
+    // Some Chrome builds resolve with undefined instead of throwing when
+    // interaction is required. Treat it the same way.
+    console.warn('[vellum-cloud-auth] non-interactive refresh returned no URL');
+    return null;
+  }
+
+  const stored = parseAuthResponseUrl(responseUrl);
   await persistToken(stored);
   return stored;
 }

--- a/clients/chrome-extension/background/relay-connection.ts
+++ b/clients/chrome-extension/background/relay-connection.ts
@@ -43,6 +43,39 @@ export type RelayMode =
   | { kind: 'self-hosted'; baseUrl: string; token: string | null }
   | { kind: 'cloud'; baseUrl: string; token: string | null };
 
+/**
+ * Context passed to {@link RelayConnectionDeps.onReconnect}. Includes the
+ * close code / reason so the handler can tell an authentication failure
+ * (e.g. expired JWT closed with a 4001 policy code) apart from a
+ * transient network blip — the cloud refresh path uses this to decide
+ * whether to force a non-interactive OAuth renewal.
+ */
+export interface RelayReconnectContext {
+  /** Close code from the unexpected WebSocket close. */
+  code: number;
+  /** Close reason string from the unexpected WebSocket close. */
+  reason: string;
+}
+
+/**
+ * Outcome of a reconnect refresh attempt.
+ *
+ * - `{ kind: 'refreshed', token }`: the stored token was successfully
+ *   rotated — the relay helper rebuilds `mode.token` and schedules the
+ *   next connect attempt.
+ * - `{ kind: 'keep' }`: nothing to refresh; reuse the current token for
+ *   the next connect attempt (e.g. a transient network drop where the
+ *   existing token is still valid).
+ * - `{ kind: 'abort', error }`: refresh is impossible and reconnects
+ *   must stop. The relay helper marks itself closed and propagates the
+ *   error to its `onClose` hook so the worker can surface an actionable
+ *   UI error.
+ */
+export type RelayReconnectDecision =
+  | { kind: 'refreshed'; token: string }
+  | { kind: 'keep' }
+  | { kind: 'abort'; error: string };
+
 export interface RelayConnectionDeps {
   /**
    * Mode + token. The token is pre-fetched by the caller (so the caller
@@ -54,15 +87,37 @@ export interface RelayConnectionDeps {
   onMessage: (data: string) => void;
   /** Invoked when the socket transitions to OPEN. */
   onOpen: () => void;
-  /** Invoked when the socket closes (user-initiated or unexpected). */
-  onClose: (code: number, reason: string) => void;
+  /**
+   * Invoked when the socket closes (user-initiated or unexpected).
+   * `authError` is populated when the reconnect path aborted because the
+   * refresh hook returned `{ kind: 'abort' }` — callers should surface
+   * the message verbatim to the user and leave the extension disconnected.
+   */
+  onClose: (code: number, reason: string, authError?: string) => void;
   /**
    * Optional: invoked right before a reconnect attempt is scheduled for
    * an unexpected close. Callers use this to refresh stale tokens before
-   * the next `start()` attempt. If this returns a string, the new token
-   * replaces `mode.token` for the next URL build.
+   * the next `start()` attempt.
+   *
+   * The legacy shape (`Promise<string | null | void>`) is preserved for
+   * backwards compatibility:
+   *
+   *   - `string` → treated as `{ kind: 'refreshed', token: <string> }`.
+   *   - `null` / `undefined` → treated as `{ kind: 'keep' }`.
+   *
+   * New callers should return a {@link RelayReconnectDecision} so they
+   * can abort the reconnect loop entirely when refresh is impossible
+   * (e.g. the cloud OAuth flow can no longer renew non-interactively
+   * and the user must sign in again).
+   *
+   * The {@link RelayReconnectContext} argument carries the close code
+   * / reason so handlers can distinguish auth-failure closes from
+   * transient network drops without stashing state in module-level
+   * variables.
    */
-  onReconnect?: () => Promise<string | null | void>;
+  onReconnect?: (
+    ctx: RelayReconnectContext,
+  ) => Promise<string | null | void | RelayReconnectDecision>;
 }
 
 /**
@@ -202,7 +257,7 @@ export class RelayConnection {
       this.deps.onClose(code, reason);
       if (!this.closedByCaller) {
         if (!NORMAL_CLOSE_CODES.has(code)) {
-          this.scheduleReconnectWithRefresh();
+          this.scheduleReconnectWithRefresh({ code, reason });
         } else {
           this.scheduleReconnect();
         }
@@ -242,31 +297,74 @@ export class RelayConnection {
    * Unexpected close path: give the caller a chance to refresh the
    * token (e.g. the self-hosted daemon rotated its edge JWT, or the
    * cloud OAuth flow expired) before the next connect attempt.
+   *
+   * The close `code` / `reason` are forwarded as a
+   * {@link RelayReconnectContext} so the handler can tell an
+   * auth-failure close (4001/4002/4003/1008) apart from a transient
+   * network drop. For auth-failure closes in cloud mode the handler
+   * returns `{ kind: 'abort' }` when refresh is impossible — we stop
+   * the reconnect loop, mark the connection closed, and surface the
+   * error through `onClose` so the popup UI can prompt the user to
+   * sign in again instead of silently hammering the gateway.
    */
-  private scheduleReconnectWithRefresh(): void {
+  private scheduleReconnectWithRefresh(ctx: RelayReconnectContext): void {
     if (this.reconnectTimer !== null) return;
     const delay = this.reconnectDelay;
     this.reconnectTimer = setTimeout(async () => {
       this.reconnectTimer = null;
       if (this.closedByCaller) return;
       if (this.deps.onReconnect) {
+        let decision: RelayReconnectDecision | null = null;
         try {
-          const newToken = await this.deps.onReconnect();
-          if (typeof newToken === 'string') {
-            this.deps = {
-              ...this.deps,
-              mode: { ...this.deps.mode, token: newToken },
-            };
-          }
+          const result = await this.deps.onReconnect(ctx);
+          decision = normaliseReconnectResult(result);
         } catch {
           // Refresh failures fall through to a bare reconnect attempt —
           // the server will reject the handshake and we'll loop.
+          decision = null;
+        }
+        if (decision) {
+          if (decision.kind === 'abort') {
+            // Refresh is impossible (e.g. cloud token expired and
+            // non-interactive renewal failed). Stop reconnecting and
+            // surface the error via onClose so the worker can push an
+            // actionable message into chrome.storage for the popup.
+            this.closedByCaller = true;
+            this.deps.onClose(ctx.code, ctx.reason, decision.error);
+            return;
+          }
+          if (decision.kind === 'refreshed') {
+            this.deps = {
+              ...this.deps,
+              mode: { ...this.deps.mode, token: decision.token },
+            };
+          }
+          // 'keep' → leave mode.token alone and fall through to
+          // connect() with the existing token.
         }
       }
       if (!this.closedByCaller) this.connect();
     }, delay);
     this.reconnectDelay = Math.min(this.reconnectDelay * 2, RECONNECT_MAX_MS);
   }
+}
+
+/**
+ * Coerce the flexible `onReconnect` return shape into a canonical
+ * {@link RelayReconnectDecision}. The legacy shape supported a plain
+ * `string` (treated as a fresh token) or `null`/`undefined` (treated as
+ * "keep the existing token"). New callers return a
+ * {@link RelayReconnectDecision} directly and get access to the
+ * `{ kind: 'abort' }` branch that stops the reconnect loop.
+ */
+function normaliseReconnectResult(
+  result: string | null | void | RelayReconnectDecision,
+): RelayReconnectDecision {
+  if (typeof result === 'string') return { kind: 'refreshed', token: result };
+  if (result && typeof result === 'object' && 'kind' in result) {
+    return result;
+  }
+  return { kind: 'keep' };
 }
 
 // ── host_browser result poster ─────────────────────────────────────

--- a/clients/chrome-extension/background/worker.ts
+++ b/clients/chrome-extension/background/worker.ts
@@ -22,7 +22,11 @@
 
 import {
   signInCloud,
+  refreshCloudToken,
   getStoredToken as getStoredCloudToken,
+  getStoredTokenRaw as getStoredCloudTokenRaw,
+  isCloudTokenStale,
+  CLOUD_AUTH_FAILURE_CLOSE_CODES,
   type CloudAuthConfig,
   type StoredCloudToken,
 } from './cloud-auth.js';
@@ -42,6 +46,8 @@ import {
   RelayConnection,
   postHostBrowserResult,
   type RelayMode,
+  type RelayReconnectContext,
+  type RelayReconnectDecision,
 } from './relay-connection.js';
 
 // Cloud OAuth defaults — kept here so the popup can stay a thin client and the
@@ -52,6 +58,34 @@ const CLOUD_GATEWAY_BASE_URL = 'https://api.vellum.ai';
 const CLOUD_OAUTH_CLIENT_ID = 'vellum-chrome-extension';
 
 const DEFAULT_RELAY_PORT = 7830;
+
+// Storage key used to surface the most recent auth-related relay error
+// to the popup. The popup reads this on open and shows it next to the
+// cloud sign-in button. Cleared on a successful connect so stale errors
+// don't linger after the user re-signs in.
+const RELAY_AUTH_ERROR_KEY = 'vellum.relayAuthError';
+
+interface RelayAuthError {
+  message: string;
+  mode: 'cloud' | 'self-hosted';
+  at: number;
+}
+
+async function setRelayAuthError(error: RelayAuthError): Promise<void> {
+  try {
+    await chrome.storage.local.set({ [RELAY_AUTH_ERROR_KEY]: error });
+  } catch (err) {
+    console.warn('[vellum-relay] Failed to persist relay auth error', err);
+  }
+}
+
+async function clearRelayAuthError(): Promise<void> {
+  try {
+    await chrome.storage.local.remove(RELAY_AUTH_ERROR_KEY);
+  } catch (err) {
+    console.warn('[vellum-relay] Failed to clear relay auth error', err);
+  }
+}
 
 // ── Mode selection ─────────────────────────────────────────────────
 //
@@ -250,6 +284,60 @@ async function buildRelayModeConfig(kind: RelayModeKind): Promise<RelayMode> {
 }
 
 /**
+ * Reconnect hook for cloud mode. Called by {@link RelayConnection} when
+ * the WebSocket closes unexpectedly — responsible for deciding whether
+ * to reuse the existing token, swap in a freshly refreshed one, or
+ * abort the reconnect loop entirely so the popup can prompt the user
+ * to sign in again.
+ *
+ * Refresh is forced when:
+ *   - The stored token is missing, expired, or within the stale
+ *     window (see `isCloudTokenStale`).
+ *   - The close code matches a known auth-failure code emitted by the
+ *     gateway's browser-relay handshake (see
+ *     `CLOUD_AUTH_FAILURE_CLOSE_CODES`).
+ *
+ * On successful refresh the new token is persisted to storage by
+ * `refreshCloudToken` and returned via `{ kind: 'refreshed' }` so the
+ * {@link RelayConnection} rebuilds the URL for the next connect. On
+ * failure we return `{ kind: 'abort' }` which halts the reconnect
+ * loop, marks the socket closed, and propagates the error through
+ * `onClose` for the UI to surface.
+ */
+async function cloudReconnectHook(
+  ctx: RelayReconnectContext,
+): Promise<RelayReconnectDecision> {
+  const stored = await getStoredCloudTokenRaw();
+  const authFailure = CLOUD_AUTH_FAILURE_CLOSE_CODES.has(ctx.code);
+  const needsRefresh = authFailure || isCloudTokenStale(stored);
+
+  if (!needsRefresh && stored?.token) {
+    // Transient network blip with a still-valid token. Keep the
+    // existing token and let the relay helper retry.
+    return { kind: 'keep' };
+  }
+
+  const refreshed = await refreshCloudToken({
+    gatewayBaseUrl: CLOUD_GATEWAY_BASE_URL,
+    clientId: CLOUD_OAUTH_CLIENT_ID,
+  });
+  if (refreshed) {
+    console.log('[vellum-relay] Cloud token refreshed after reconnect');
+    return { kind: 'refreshed', token: refreshed.token };
+  }
+
+  // Non-interactive refresh is impossible — user must sign in again.
+  const reason = authFailure
+    ? 'Cloud relay closed with an auth-failure code'
+    : 'Stored cloud token has expired';
+  return {
+    kind: 'abort',
+    error:
+      `${reason}. Sign in with Vellum (cloud) again from the extension popup to reconnect.`,
+  };
+}
+
+/**
  * Wire a RelayConnection up with the worker's message/open/close
  * callbacks. Does NOT start it.
  */
@@ -258,6 +346,9 @@ function createRelayConnection(mode: RelayMode): RelayConnection {
     mode,
     onOpen: () => {
       console.log(`[vellum-relay] Connected (${mode.kind})`);
+      // A successful connect means any persisted auth-error is stale
+      // — clear it so the popup stops showing the sign-in prompt.
+      void clearRelayAuthError();
     },
     onMessage: (data) => {
       // Fire-and-forget dispatch — wrap with .catch so a future refactor
@@ -267,29 +358,61 @@ function createRelayConnection(mode: RelayMode): RelayConnection {
         console.warn('[vellum-relay] handleServerMessage failed', err);
       });
     },
-    onClose: (code, reason) => {
-      console.log(`[vellum-relay] Disconnected (code=${code}, reason=${reason || 'n/a'})`);
+    onClose: (code, reason, authError) => {
+      console.log(
+        `[vellum-relay] Disconnected (code=${code}, reason=${reason || 'n/a'})`,
+      );
+      if (authError) {
+        // The reconnect hook decided refresh is impossible — persist
+        // the error so the popup can surface it, and mark ourselves
+        // as not-trying-to-connect. The user will press Connect again
+        // after re-signing in.
+        console.warn(`[vellum-relay] Auth refresh impossible: ${authError}`);
+        shouldConnect = false;
+        void setRelayAuthError({
+          message: authError,
+          // Read the live mode from the connection if it's still
+          // around — by the time onClose fires the connection will
+          // have already flipped its own closedByCaller flag, so the
+          // module-level `relayMode` is a safe fallback.
+          mode: relayMode === 'cloud' ? 'cloud' : 'self-hosted',
+          at: Date.now(),
+        });
+        // Clear the module-level reference so a subsequent
+        // connect() starts from a clean slate instead of trying to
+        // reuse a connection we've already marked dead.
+        relayConnection = null;
+      }
     },
-    onReconnect: async () => {
-      // Self-hosted refresh order:
+    onReconnect: async (ctx) => {
+      // Cloud mode: refresh the stored OAuth JWT non-interactively
+      // when it's stale or the server closed with an auth-failure
+      // code. If refresh is impossible we abort the reconnect loop
+      // and surface the error to the popup — see cloudReconnectHook.
+      //
+      // Self-hosted mode keeps the legacy refresh ladder:
       //  1. Re-read the stored capability token from
       //     `self-hosted-auth.ts`. The token may have been rotated by
       //     a re-pair in another tab, or it may simply still be valid
       //     and the drop was a transient server bounce.
       //  2. Fall back to the legacy gateway `/v1/browser-relay/token`
       //     refresh for installs that haven't migrated yet.
-      // Cloud: no-op for now — the cloud token is stored
-      // independently via OAuth and we'd rather surface the failure to
-      // the user than silently loop.
-      if (mode.kind === 'self-hosted') {
-        const local = await getStoredLocalToken();
-        if (local?.token) return local.token;
-        const ok = await refreshToken();
-        if (ok) {
-          const refreshed = await getBearerToken();
-          return refreshed;
-        }
+      //
+      // Pull the live mode through getCurrentMode so a setMode() that
+      // flipped us to cloud mid-reconnect still routes through the
+      // right branch — mirrors dispatchHostBrowserResult's pattern.
+      const liveMode = relayConnection?.getCurrentMode()?.kind ?? mode.kind;
+      if (liveMode === 'cloud') {
+        return cloudReconnectHook(ctx);
       }
+      const local = await getStoredLocalToken();
+      if (local?.token) return local.token;
+      const ok = await refreshToken();
+      if (ok) {
+        const refreshed = await getBearerToken();
+        return refreshed;
+      }
+      return null;
     },
   });
 }
@@ -317,6 +440,10 @@ function missingTokenMessage(kind: RelayModeKind): string {
 
 async function connect(): Promise<void> {
   if (relayConnection && relayConnection.isOpen()) return;
+  // A fresh connect attempt supersedes any previously persisted
+  // auth-error — the user either just signed back in or is explicitly
+  // retrying, and we want the popup to stop nagging.
+  await clearRelayAuthError();
   // Re-read the live relay mode from storage at connect time. The
   // module-level `relayMode` variable is only refreshed asynchronously
   // via chrome.storage.onChanged, so trusting it races against a popup

--- a/clients/chrome-extension/popup/popup.ts
+++ b/clients/chrome-extension/popup/popup.ts
@@ -297,6 +297,19 @@ async function refreshCloudStatus(): Promise<void> {
     } else {
       setCloudStatus('Not signed in', false);
     }
+    // Surface any auth error the service worker persisted during a
+    // reconnect. The worker writes `vellum.relayAuthError` when the
+    // cloud token refresh fails (see cloudReconnectHook in worker.ts)
+    // and clears it on a successful connect.
+    const authErrResult = await chrome.storage.local.get('vellum.relayAuthError');
+    const authErr = authErrResult['vellum.relayAuthError'];
+    if (
+      authErr &&
+      typeof authErr === 'object' &&
+      typeof (authErr as { message?: unknown }).message === 'string'
+    ) {
+      showError((authErr as { message: string }).message);
+    }
   } catch (err) {
     setCloudStatus(`Error: ${err instanceof Error ? err.message : String(err)}`, false);
   }
@@ -323,6 +336,10 @@ function requestCloudSignIn(): Promise<CloudSignInResponse> {
 btnCloudSignIn.addEventListener('click', async () => {
   btnCloudSignIn.disabled = true;
   setCloudStatus('Signing in…', false);
+  errorText.style.display = 'none';
+  // Clear any stale auth-error the worker persisted during a failed
+  // reconnect — the user is explicitly retrying sign-in now.
+  await chrome.storage.local.remove('vellum.relayAuthError');
   // Delegate to the service worker — see header comment for the rationale.
   const response = await requestCloudSignIn();
   if (response.ok && response.token) {


### PR DESCRIPTION
## Summary
- Add non-interactive refresh helper in cloud-auth.ts
- Worker onReconnect refreshes token when stale or on auth-failure close codes
- Persist refreshed token and avoid stale-token posts via live getCurrentMode
- Actionable UI error when refresh impossible

Part of plan: browser-use-main-remediation-plan-2026-04-08.md (PR 8 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24480" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
