### PR TITLE
fix(browser-relay): deterministic cancel semantics suppress late results (PR6)

### DIFF
--- a/assistant/src/__tests__/host-browser-e2e-cloud.test.ts
+++ b/assistant/src/__tests__/host-browser-e2e-cloud.test.ts
@@ -308,6 +308,90 @@ describe("host_browser cloud-hosted e2e round-trip", () => {
     await mockExt.stop();
   });
 
+  test("abort: late /v1/host-browser-result POST after cancel is ignored (no ghost completion)", async () => {
+    // Regression for PR6 of the browser-use remediation plan. The
+    // daemon-side proxy must treat a late result POST — arriving
+    // after the caller has already been resolved with "Aborted" —
+    // as a benign race, not a noisy false-positive timeout. It must
+    // also NOT resolve the caller a second time.
+    //
+    // We exercise this from the daemon's perspective by:
+    //   1. Starting a request with an AbortSignal.
+    //   2. Aborting the signal so the proxy resolves with "Aborted".
+    //   3. Manually POSTing a host_browser_result for the same
+    //      requestId straight to /v1/host-browser-result (bypassing
+    //      the compliant dispatcher's cancel-suppression).
+    //   4. Verifying the POST is accepted by the runtime (i.e. the
+    //      HTTP layer doesn't explode) and the caller's promise
+    //      never fulfils twice.
+    const guardianId = `test-guardian-${crypto.randomUUID()}`;
+    const token = mintActorToken(guardianId);
+
+    const { createMockChromeExtension } =
+      await import("./fixtures/mock-chrome-extension.js");
+    const mockExt = createMockChromeExtension({
+      runtimeBaseUrl,
+      token,
+      // Hang forever — same gating trick as the plain abort test,
+      // so we can cancel before the handler returns anything.
+      cdpHandler: () => new Promise(() => {}),
+    });
+    await mockExt.start();
+    await mockExt.waitForConnection();
+    await waitForRegistryEntry(guardianId);
+
+    const { proxy } = createBoundProxy(guardianId, "conv-abort-late");
+
+    let resolveCount = 0;
+    const controller = new AbortController();
+    const resultPromise = proxy
+      .request(
+        { cdpMethod: "Browser.getVersion" },
+        "conv-abort-late",
+        controller.signal,
+      )
+      .then((r) => {
+        resolveCount += 1;
+        return r;
+      });
+
+    await waitFor(() => mockExt.receivedRequests().length === 1);
+    const pendingRequestId = mockExt.receivedRequests()[0].requestId;
+
+    controller.abort();
+    const result = await resultPromise;
+    expect(result.content).toBe("Aborted");
+    expect(result.isError).toBe(true);
+    expect(resolveCount).toBe(1);
+
+    // Now manually submit a late result for the same requestId —
+    // simulating a non-compliant client that failed to honour the
+    // cancel envelope. The runtime must accept the POST without
+    // error and the proxy must NOT resolve the caller a second time.
+    const lateResp = await fetch(`${runtimeBaseUrl}/v1/host-browser-result`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        requestId: pendingRequestId,
+        content: JSON.stringify({ product: "Chrome/LateResult" }),
+        isError: false,
+      }),
+    });
+    await lateResp.body?.cancel();
+
+    // Give the runtime a few turns to process the POST and hit its
+    // "no pending request" debug branch. If the proxy resolved a
+    // second time, `resolveCount` would be 2 here.
+    await new Promise((r) => setTimeout(r, 20));
+    expect(resolveCount).toBe(1);
+
+    proxy.dispose();
+    await mockExt.stop();
+  });
+
   test("timeout: proxy.request resolves with timeout error when client never responds", async () => {
     const guardianId = `test-guardian-${crypto.randomUUID()}`;
     const token = mintActorToken(guardianId);

--- a/assistant/src/daemon/host-browser-proxy.ts
+++ b/assistant/src/daemon/host-browser-proxy.ts
@@ -138,7 +138,18 @@ export class HostBrowserProxy {
   ): void {
     const entry = this.pending.get(requestId);
     if (!entry) {
-      log.warn({ requestId }, "No pending host browser request for response");
+      // Benign race, not an error. A late result frame with no matching
+      // pending entry means one of:
+      //   - the proxy-side setTimeout has already resolved the caller;
+      //   - the caller's AbortSignal fired and the entry was torn down;
+      //   - a duplicate result frame was delivered (e.g. retry after a
+      //     transient WS drop).
+      // Log at debug so operators don't chase false-positive "timeout"
+      // alerts on what is actually a cleanly-handled race.
+      log.debug(
+        { requestId },
+        "Ignoring host_browser_result for unknown or already-resolved request",
+      );
       return;
     }
     clearTimeout(entry.timer);

--- a/clients/chrome-extension/background/__tests__/host-browser-dispatcher.test.ts
+++ b/clients/chrome-extension/background/__tests__/host-browser-dispatcher.test.ts
@@ -170,6 +170,27 @@ const sampleRequest: HostBrowserRequestEnvelope = {
   cdpParams: { foo: 'bar' },
 };
 
+/**
+ * Poll-based wait helper used by the cancel-race tests to synchronise
+ * on dispatcher internals (e.g. "wait until proxy.send has been called")
+ * without reaching into private state. Falls back to a wall-clock
+ * deadline so a broken dispatcher can't hang the test suite forever.
+ */
+async function waitFor(
+  predicate: () => boolean,
+  timeoutMs = 1000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() > deadline) {
+      throw new Error(
+        `waitFor: predicate did not become true within ${timeoutMs}ms`,
+      );
+    }
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
 // ── Tests ───────────────────────────────────────────────────────────
 
 describe('createHostBrowserDispatcher', () => {
@@ -559,9 +580,14 @@ describe('createHostBrowserDispatcher', () => {
   });
 
   describe('cancel', () => {
-    test('aborts the in-flight controller for the matching request id', async () => {
-      // Gate resolveTarget on an externally-controllable promise so we can
-      // issue a cancel while the handler is still mid-flight.
+    test('suppresses late postResult delivery for a cancelled request (deterministic-cancel guarantee)', async () => {
+      // Regression: the dispatcher must NOT deliver a result envelope
+      // after the daemon has sent a host_browser_cancel. The daemon
+      // has already resolved the caller with "Aborted" — a late post
+      // would be a ghost completion and trip the daemon's "No pending
+      // host browser request" warning. Gate resolveTarget so we can
+      // issue the cancel mid-flight, then release the gate and verify
+      // that the handler runs to completion without posting anything.
       let releaseResolve: () => void = () => {};
       const gate = new Promise<void>((resolve) => {
         releaseResolve = resolve;
@@ -574,22 +600,240 @@ describe('createHostBrowserDispatcher', () => {
 
       const handlePromise = harness.dispatcher.handle(sampleRequest);
 
-      // Mid-flight cancel.
+      // Mid-flight cancel — arrives BEFORE resolveTarget settles, so the
+      // handler is still awaiting its first internal await.
       const cancelEnvelope: HostBrowserCancelEnvelope = {
         type: 'host_browser_cancel',
         requestId: 'req-1',
       };
       harness.dispatcher.cancel(cancelEnvelope);
 
-      // Release the gate so the handler can run to completion.
+      // Release the gate so the handler can finish its internal work
+      // (proxy.send will still be invoked because resolveTarget runs
+      // before the cancellation check at the postResult site).
       releaseResolve();
       await handlePromise;
 
-      // Handler still ran to completion and posted a result — the dispatcher
-      // does not early-return on cancel; instead it removes the abort
-      // controller from the in-flight map. This matches the plan's acceptance
-      // criteria for the "cancel aborts the in-flight controller" test.
+      // Critical assertion: no result envelope was posted. The cancelled
+      // request is dropped on the floor at the postResult site.
+      expect(harness.results.length).toBe(0);
+    });
+
+    test('suppresses late postResult when cancel races with proxy.send resolution', async () => {
+      // Simulates the window where proxy.send has already been called
+      // but hasn't resolved yet. The cancel lands between send() and
+      // the postResult call. This is the tightest race the dispatcher
+      // needs to handle deterministically.
+      let releaseSend: (frame: {
+        id: number;
+        result: unknown;
+      }) => void = () => {};
+      const sendGate = new Promise<{ id: number; result: unknown }>(
+        (resolve) => {
+          releaseSend = resolve;
+        },
+      );
+      const proxy = harness.proxy;
+      // Override send on the existing mock proxy so we can externally
+      // control when the CDP round-trip resolves.
+      proxy.send = async (target, frame) => {
+        proxy.sendCalls.push({ target, frame });
+        const result = await sendGate;
+        return { ...result, id: frame.id };
+      };
+
+      const handlePromise = harness.dispatcher.handle(sampleRequest);
+
+      // Wait for the handler to reach proxy.send before cancelling.
+      await waitFor(() => proxy.sendCalls.length === 1);
+
+      harness.dispatcher.cancel({
+        type: 'host_browser_cancel',
+        requestId: 'req-1',
+      });
+
+      // Resolve the CDP round-trip — the dispatcher must now notice
+      // the request was cancelled and drop the result instead of
+      // calling postResult.
+      releaseSend({ id: 0, result: { ok: true } });
+      await handlePromise;
+
+      expect(harness.results.length).toBe(0);
+    });
+
+    test('suppresses late postResult when cancel races with a send() that returned an error frame', async () => {
+      // Mirror the previous race test but with the CDP round-trip
+      // returning a JSON-RPC error envelope. The dispatcher must still
+      // drop the error envelope on the floor — both the success and
+      // the error branches of handle() route through the same
+      // postResult call site and must honour the cancellation check.
+      let releaseSend: (frame: {
+        id: number;
+        error: { code: number; message: string };
+      }) => void = () => {};
+      const sendGate = new Promise<{
+        id: number;
+        error: { code: number; message: string };
+      }>((resolve) => {
+        releaseSend = resolve;
+      });
+      const proxy = harness.proxy;
+      proxy.send = async (target, frame) => {
+        proxy.sendCalls.push({ target, frame });
+        const result = await sendGate;
+        return { ...result, id: frame.id };
+      };
+
+      const handlePromise = harness.dispatcher.handle(sampleRequest);
+      await waitFor(() => proxy.sendCalls.length === 1);
+
+      harness.dispatcher.cancel({
+        type: 'host_browser_cancel',
+        requestId: 'req-1',
+      });
+
+      releaseSend({
+        id: 0,
+        error: { code: -32000, message: 'cannot find context with specified id' },
+      });
+      await handlePromise;
+
+      expect(harness.results.length).toBe(0);
+    });
+
+    test('suppresses the error envelope when cancel races with a thrown send', async () => {
+      // Error path: the CDP send throws *after* cancel has arrived.
+      // The catch block in handle() must honour the cancelled set and
+      // skip its postResult call.
+      let rejectSend: (err: Error) => void = () => {};
+      const sendGate = new Promise<never>((_, reject) => {
+        rejectSend = reject;
+      });
+      const proxy = harness.proxy;
+      proxy.send = async (target, frame) => {
+        proxy.sendCalls.push({ target, frame });
+        return sendGate;
+      };
+
+      const handlePromise = harness.dispatcher.handle(sampleRequest);
+      await waitFor(() => proxy.sendCalls.length === 1);
+
+      harness.dispatcher.cancel({
+        type: 'host_browser_cancel',
+        requestId: 'req-1',
+      });
+
+      rejectSend(new Error('debugger detached mid-command'));
+      await handlePromise;
+
+      expect(harness.results.length).toBe(0);
+    });
+
+    test('cancel is idempotent: repeat cancels for the same request id are safe', async () => {
+      // Issue the same cancel twice, then a third time after the
+      // handler has already unwound. None of them must throw, and no
+      // result envelope must be posted for the original request.
+      let releaseResolve: () => void = () => {};
+      const gate = new Promise<void>((resolve) => {
+        releaseResolve = resolve;
+      });
+
+      harness.resolveTargetImpl = async () => {
+        await gate;
+        return { tabId: 7 };
+      };
+
+      const handlePromise = harness.dispatcher.handle(sampleRequest);
+
+      const cancelEnvelope: HostBrowserCancelEnvelope = {
+        type: 'host_browser_cancel',
+        requestId: 'req-1',
+      };
+      expect(() => harness.dispatcher.cancel(cancelEnvelope)).not.toThrow();
+      expect(() => harness.dispatcher.cancel(cancelEnvelope)).not.toThrow();
+
+      releaseResolve();
+      await handlePromise;
+
+      // Post-handler cancel must also be a no-op (nothing in flight,
+      // the cancelled-set entry has been pruned by handle()'s finally
+      // block, but adding it back is harmless because it will be
+      // deleted again at the start of the next handle() for the same id).
+      expect(() => harness.dispatcher.cancel(cancelEnvelope)).not.toThrow();
+
+      expect(harness.results.length).toBe(0);
+    });
+
+    test('cancel for a finished request does not affect a subsequent request with the same id', async () => {
+      // A cancelled request marks its id in the internal cancelled set,
+      // and handle()'s finally block prunes the entry. A subsequent
+      // handle() call for the *same* requestId (e.g. a retry across a
+      // relay reconnect) must NOT inherit the cancelled flag from the
+      // previous invocation — otherwise the retry would silently drop
+      // its result.
+      harness = createHarness({
+        sendResult: { id: 1, result: { ok: true } },
+      });
+
+      // First invocation — cancel it mid-flight.
+      let releaseResolve: () => void = () => {};
+      const gate = new Promise<void>((resolve) => {
+        releaseResolve = resolve;
+      });
+      harness.resolveTargetImpl = async () => {
+        await gate;
+        return { tabId: 42 };
+      };
+
+      const firstPromise = harness.dispatcher.handle(sampleRequest);
+      harness.dispatcher.cancel({
+        type: 'host_browser_cancel',
+        requestId: 'req-1',
+      });
+      releaseResolve();
+      await firstPromise;
+      expect(harness.results.length).toBe(0);
+
+      // Second invocation with the same requestId — must run to
+      // completion and post its result.
+      harness.resolveTargetImpl = async () => ({ tabId: 42 });
+      await harness.dispatcher.handle(sampleRequest);
+
       expect(harness.results.length).toBe(1);
+      expect(harness.results[0].requestId).toBe('req-1');
+      expect(harness.results[0].isError).toBe(false);
+    });
+
+    test('aborts the in-flight controller and removes it from the inFlight map', async () => {
+      // Sanity check on the cancel path's bookkeeping: after cancel()
+      // returns, the in-flight map no longer holds the cancelled entry,
+      // and disposing the dispatcher afterwards must not throw even
+      // though the cancelled handler is still technically awaiting its
+      // internal gate.
+      let releaseResolve: () => void = () => {};
+      const gate = new Promise<void>((resolve) => {
+        releaseResolve = resolve;
+      });
+      harness.resolveTargetImpl = async () => {
+        await gate;
+        return { tabId: 7 };
+      };
+
+      const handlePromise = harness.dispatcher.handle(sampleRequest);
+      harness.dispatcher.cancel({
+        type: 'host_browser_cancel',
+        requestId: 'req-1',
+      });
+
+      // Dispose while the cancelled handler is still in flight — this
+      // is the same path the service worker takes on shutdown.
+      harness.dispatcher.dispose();
+
+      // Release the gate so the promise can settle cleanly.
+      releaseResolve();
+      await handlePromise;
+
+      expect(harness.results.length).toBe(0);
     });
 
     test('is a no-op for unknown request ids', () => {

--- a/clients/chrome-extension/background/host-browser-dispatcher.ts
+++ b/clients/chrome-extension/background/host-browser-dispatcher.ts
@@ -115,6 +115,15 @@ export function createHostBrowserDispatcher(
 ): HostBrowserDispatcher {
   const proxy = deps.cdpProxy ?? createCdpProxy();
   const inFlight = new Map<string, AbortController>();
+  // Track request IDs that were cancelled while in flight so we can
+  // suppress the late `postResult` call when the underlying CDP command
+  // eventually settles. This is the core deterministic-cancel guarantee:
+  // once the daemon has told us a request is cancelled, we must never
+  // deliver a result frame for it — otherwise the daemon can see a
+  // "ghost completion" after it has already returned `"Aborted"` to its
+  // caller. The set is pruned in `handle()`'s finally block so it can't
+  // grow unbounded across long-running dispatcher lifetimes.
+  const cancelledRequestIds = new Set<string>();
   // Track which targets we've already attached to so repeat commands
   // against the same tab/session don't unnecessarily call attach again.
   // Chrome treats a second attach as a hard failure ("Another debugger is
@@ -136,8 +145,17 @@ export function createHostBrowserDispatcher(
   });
 
   async function handle(envelope: HostBrowserRequestEnvelope): Promise<void> {
+    const { requestId } = envelope;
+    // Guard against re-entrant delivery of the same request id: if the
+    // caller hands us the same id twice (or delivers a duplicate frame
+    // across a relay reconnect), the second `handle()` invocation should
+    // not be silently treated as "already cancelled" just because a
+    // previous attempt was aborted. Clear any stale cancel marker at the
+    // start of each new handle so the cancellation state is scoped to
+    // the lifetime of a single handle() call.
+    cancelledRequestIds.delete(requestId);
     const abort = new AbortController();
-    inFlight.set(envelope.requestId, abort);
+    inFlight.set(requestId, abort);
     try {
       const target = await deps.resolveTarget(envelope.cdpSessionId);
       const key = targetKey(target);
@@ -192,40 +210,91 @@ export function createHostBrowserDispatcher(
           attachedTargets.delete(key);
         }
       }
+      // Deterministic-cancel guarantee: if the request was cancelled
+      // while we were awaiting the CDP round-trip, drop the late result
+      // on the floor. The daemon has already resolved its pending entry
+      // with `"Aborted"` (see host-browser-proxy.ts) and would log a
+      // noisy "no pending host browser request for response" warning if
+      // we delivered a stale frame after the fact.
+      if (cancelledRequestIds.has(requestId)) return;
       await deps.postResult({
-        requestId: envelope.requestId,
+        requestId,
         content: JSON.stringify(frame.error ?? frame.result ?? {}),
         isError: frame.error != null,
       });
     } catch (err) {
+      // Same cancellation check as the happy path: a request that was
+      // cancelled mid-flight must not deliver its failure envelope to
+      // the daemon either. The daemon proxy has already resolved its
+      // pending entry, so any late postResult would be a ghost completion.
+      if (cancelledRequestIds.has(requestId)) return;
       // Guard the failure-path postResult in its own try/catch: if the HTTP
       // POST itself fails (e.g. the relay socket is torn down while we're
       // in the error path) we must NOT let that secondary rejection escape
       // to the Chrome service worker as an unhandled promise rejection.
       try {
         await deps.postResult({
-          requestId: envelope.requestId,
+          requestId,
           content: err instanceof Error ? err.message : String(err),
           isError: true,
         });
       } catch (postErr) {
         console.error(
           '[host-browser-dispatcher] Failed to post error result for',
-          envelope.requestId,
+          requestId,
           postErr,
         );
       }
     } finally {
-      inFlight.delete(envelope.requestId);
+      inFlight.delete(requestId);
+      // Prune the cancelled set once the handle() call has fully
+      // unwound. Leaving the entry in place would silently drop the
+      // result of a *subsequent* handle() for the same requestId — see
+      // the `cancelledRequestIds.delete(requestId)` call at the top of
+      // this function for the symmetric guard at the start of a new
+      // call. Deleting it here keeps the set bounded even under
+      // high-churn workloads.
+      cancelledRequestIds.delete(requestId);
     }
   }
 
   function cancel(envelope: HostBrowserCancelEnvelope): void {
-    inFlight.get(envelope.requestId)?.abort();
-    inFlight.delete(envelope.requestId);
+    const { requestId } = envelope;
+    // Record the cancellation BEFORE aborting so that any listener on
+    // the abort signal that races to post a result sees the cancelled
+    // flag first. The suppression check in `handle()` reads from this
+    // set, not from the abort signal, specifically to close the race
+    // between "cancel arrives after proxy.send resolves" and "handle()
+    // reaches its postResult call". Marking here also makes cancel()
+    // idempotent: a repeat cancel for the same id is a no-op because
+    // the set already contains the entry and `abort()` on an
+    // already-aborted controller is safe.
+    cancelledRequestIds.add(requestId);
+    const ctl = inFlight.get(requestId);
+    if (ctl) {
+      try {
+        ctl.abort();
+      } catch {
+        // AbortController.abort() is spec'd to never throw, but we
+        // belt-and-brace here so a pathological polyfill can't derail
+        // the cancel path and leave inFlight in an inconsistent state.
+      }
+      inFlight.delete(requestId);
+    }
   }
 
   function dispose(): void {
+    // Mark every in-flight request as cancelled BEFORE aborting its
+    // controller so that any handler currently suspended at an await
+    // point unwinds through the same deterministic-cancel suppression
+    // path as a regular cancel(). Without this, dispose() would leave
+    // `cancelledRequestIds` empty and a handler that resumes post-
+    // dispose would happily call postResult into a torn-down service
+    // worker (or worse, into a freshly-constructed replacement
+    // dispatcher during a hot reload).
+    for (const requestId of inFlight.keys()) {
+      cancelledRequestIds.add(requestId);
+    }
     for (const abort of inFlight.values()) abort.abort();
     inFlight.clear();
     attachedTargets.clear();


### PR DESCRIPTION
## Summary
- Dispatcher tracks cancelled request IDs and drops late postResult calls
- Cancel path is idempotent and race-safe
- Daemon proxy warning/error logs aligned to avoid false-positive timeouts

Part of plan: browser-use-main-remediation-plan-2026-04-08.md (PR 6 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24481" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
