### PR TITLE
feat(browser-relay): harden /v1/browser-extension-pair endpoint (PR4)

### DIFF
--- a/assistant/src/runtime/__tests__/browser-extension-pair-routes.test.ts
+++ b/assistant/src/runtime/__tests__/browser-extension-pair-routes.test.ts
@@ -3,6 +3,10 @@
  *
  * Covers:
  *   - Method/host/origin enforcement (405, 403, 400, 401)
+ *   - Native-host marker header requirement (403 when missing)
+ *   - Browser-origin rejection (non-allowlisted Origin header -> 403)
+ *   - Strict per-peer rate limiting (10/min, then 429)
+ *   - Audit logging field shape for denied attempts
  *   - Successful mint on allowed origin (200) for both the preferred
  *     `extensionOrigin` body field and the legacy `origin` alias
  *   - `expiresAt` response field is an ISO 8601 string matching what the
@@ -23,7 +27,10 @@ import {
 } from "../capability-tokens.js";
 import {
   handleBrowserExtensionPair,
+  NATIVE_HOST_MARKER_HEADER,
+  NATIVE_HOST_MARKER_VALUE,
   parseHostHeader,
+  resetPairRateLimiterForTests,
 } from "../routes/browser-extension-pair-routes.js";
 
 // ---------------------------------------------------------------------------
@@ -46,6 +53,14 @@ const loopbackServer = mockServer("127.0.0.1");
 const lanPeerServer = mockServer("192.168.1.10");
 const publicPeerServer = mockServer("203.0.113.50");
 
+const ALLOWED_ORIGIN = "chrome-extension://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/";
+
+/**
+ * Build a pair request. By default includes the native-host marker
+ * header so existing tests exercising other invariants continue to
+ * pass. Tests that want to exercise the marker-header gate pass
+ * `nativeHost: false` (or an explicit override value).
+ */
 function buildRequest(
   options: {
     method?: string;
@@ -54,6 +69,12 @@ function buildRequest(
     origin?: string;
     forwardedFor?: string;
     rawBody?: string;
+    /**
+     * When `false`, omits the native-host marker header entirely.
+     * When a string, sets the header to that value (for testing
+     * unexpected values). Defaults to including the expected value.
+     */
+    nativeHost?: boolean | string;
   } = {},
 ): Request {
   const headers = new Headers();
@@ -63,6 +84,15 @@ function buildRequest(
   if (options.forwardedFor) {
     headers.set("x-forwarded-for", options.forwardedFor);
   }
+  if (options.origin !== undefined) {
+    headers.set("origin", options.origin);
+  }
+  if (options.nativeHost === undefined || options.nativeHost === true) {
+    headers.set(NATIVE_HOST_MARKER_HEADER, NATIVE_HOST_MARKER_VALUE);
+  } else if (typeof options.nativeHost === "string") {
+    headers.set(NATIVE_HOST_MARKER_HEADER, options.nativeHost);
+  }
+  // else: nativeHost === false — omit the header entirely.
   let bodyStr: string | undefined;
   if (options.rawBody !== undefined) {
     bodyStr = options.rawBody;
@@ -86,13 +116,16 @@ describe("handleBrowserExtensionPair", () => {
   beforeEach(() => {
     resetCapabilityTokenSecretForTests();
     setCapabilityTokenSecretForTests(randomBytes(32));
+    // Reset the per-peer rate limiter so one test's burst of requests
+    // cannot leak budget into the next test.
+    resetPairRateLimiterForTests();
   });
 
   test("rejects non-POST methods with 405", async () => {
     const req = buildRequest({
       method: "GET",
       body: {
-        extensionOrigin: "chrome-extension://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/",
+        extensionOrigin: ALLOWED_ORIGIN,
       },
     });
     const res = await handleBrowserExtensionPair(req, loopbackServer);
@@ -102,7 +135,7 @@ describe("handleBrowserExtensionPair", () => {
   test("rejects non-loopback peer with 403", async () => {
     const req = buildRequest({
       body: {
-        extensionOrigin: "chrome-extension://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/",
+        extensionOrigin: ALLOWED_ORIGIN,
       },
     });
     const res = await handleBrowserExtensionPair(req, publicPeerServer);
@@ -112,7 +145,7 @@ describe("handleBrowserExtensionPair", () => {
   test("rejects LAN peer (not loopback) with 403", async () => {
     const req = buildRequest({
       body: {
-        extensionOrigin: "chrome-extension://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/",
+        extensionOrigin: ALLOWED_ORIGIN,
       },
     });
     const res = await handleBrowserExtensionPair(req, lanPeerServer);
@@ -122,7 +155,7 @@ describe("handleBrowserExtensionPair", () => {
   test("rejects request with non-loopback Host header", async () => {
     const req = buildRequest({
       body: {
-        extensionOrigin: "chrome-extension://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/",
+        extensionOrigin: ALLOWED_ORIGIN,
       },
       host: "vellum.example.com",
     });
@@ -133,13 +166,193 @@ describe("handleBrowserExtensionPair", () => {
   test("rejects request with x-forwarded-for header", async () => {
     const req = buildRequest({
       body: {
-        extensionOrigin: "chrome-extension://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/",
+        extensionOrigin: ALLOWED_ORIGIN,
       },
       forwardedFor: "1.2.3.4",
     });
     const res = await handleBrowserExtensionPair(req, loopbackServer);
     expect(res.status).toBe(403);
   });
+
+  // ─────────────────────────────────────────────────────────────────────
+  // Native-host marker header enforcement
+  // ─────────────────────────────────────────────────────────────────────
+
+  test("rejects request missing native-host marker header with 403", async () => {
+    const req = buildRequest({
+      body: { extensionOrigin: ALLOWED_ORIGIN },
+      nativeHost: false,
+    });
+    const res = await handleBrowserExtensionPair(req, loopbackServer);
+    expect(res.status).toBe(403);
+    const payload = (await res.json()) as {
+      error?: { code?: string; message?: string };
+    };
+    expect(payload.error?.code).toBe("FORBIDDEN");
+  });
+
+  test("rejects request with wrong native-host marker header value", async () => {
+    const req = buildRequest({
+      body: { extensionOrigin: ALLOWED_ORIGIN },
+      nativeHost: "bogus",
+    });
+    const res = await handleBrowserExtensionPair(req, loopbackServer);
+    expect(res.status).toBe(403);
+  });
+
+  test("rejects request with empty native-host marker header value", async () => {
+    const req = buildRequest({
+      body: { extensionOrigin: ALLOWED_ORIGIN },
+      nativeHost: "",
+    });
+    const res = await handleBrowserExtensionPair(req, loopbackServer);
+    expect(res.status).toBe(403);
+  });
+
+  // ─────────────────────────────────────────────────────────────────────
+  // Browser-origin rejection
+  // ─────────────────────────────────────────────────────────────────────
+
+  test("rejects request with a non-allowlisted Origin header", async () => {
+    const req = buildRequest({
+      body: { extensionOrigin: ALLOWED_ORIGIN },
+      origin: "https://evil.example.com",
+    });
+    const res = await handleBrowserExtensionPair(req, loopbackServer);
+    expect(res.status).toBe(403);
+    const payload = (await res.json()) as {
+      error?: { code?: string };
+    };
+    expect(payload.error?.code).toBe("FORBIDDEN");
+  });
+
+  test("rejects request with http://localhost Origin header (browser-originated)", async () => {
+    // A web page served from http://localhost:8080 that POSTs to the
+    // pair endpoint would attach this Origin header. The endpoint must
+    // refuse it even though the host itself is loopback — a local web
+    // page in another browser tab is NOT the native messaging helper.
+    const req = buildRequest({
+      body: { extensionOrigin: ALLOWED_ORIGIN },
+      origin: "http://localhost:8080",
+    });
+    const res = await handleBrowserExtensionPair(req, loopbackServer);
+    expect(res.status).toBe(403);
+  });
+
+  test("accepts request with no Origin header (native-host default)", async () => {
+    // Node fetch does not set an Origin header unless explicitly told
+    // to — the native messaging helper's `fetch(...)` call therefore
+    // ships without one. This is the common-case allowed path.
+    const req = buildRequest({
+      body: { extensionOrigin: ALLOWED_ORIGIN },
+      // origin intentionally omitted
+    });
+    const res = await handleBrowserExtensionPair(req, loopbackServer);
+    expect(res.status).toBe(200);
+  });
+
+  test("accepts request when Origin header equals an allowlisted extension origin", async () => {
+    // The allowlist stores entries with a trailing slash. Browsers'
+    // Origin headers never carry a path segment, so both the exact
+    // match and the bare form should succeed.
+    const reqExact = buildRequest({
+      body: { extensionOrigin: ALLOWED_ORIGIN },
+      origin: ALLOWED_ORIGIN,
+    });
+    expect(
+      (await handleBrowserExtensionPair(reqExact, loopbackServer)).status,
+    ).toBe(200);
+
+    const reqBare = buildRequest({
+      body: { extensionOrigin: ALLOWED_ORIGIN },
+      origin: "chrome-extension://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    });
+    expect(
+      (await handleBrowserExtensionPair(reqBare, loopbackServer)).status,
+    ).toBe(200);
+  });
+
+  // ─────────────────────────────────────────────────────────────────────
+  // Rate limiting
+  // ─────────────────────────────────────────────────────────────────────
+
+  test("rate limits successive pair requests (429 after burst)", async () => {
+    // Fire a tight burst of requests and assert that once the per-peer
+    // budget is exhausted, the endpoint returns 429 with the standard
+    // error envelope and a Retry-After hint. The rate limiter budget
+    // is 10/min per peer IP; we send 12 to ensure we hit it.
+    const results: number[] = [];
+    for (let i = 0; i < 12; i++) {
+      const req = buildRequest({
+        body: { extensionOrigin: ALLOWED_ORIGIN },
+      });
+      const res = await handleBrowserExtensionPair(req, loopbackServer);
+      results.push(res.status);
+      // Drain the body so any async internal state settles (and so
+      // we don't leak unconsumed Response bodies).
+      await res.text();
+    }
+
+    // The first 10 requests should succeed (200). The 11th and 12th
+    // should be rate limited (429).
+    const successes = results.filter((s) => s === 200).length;
+    const rateLimited = results.filter((s) => s === 429).length;
+    expect(successes).toBe(10);
+    expect(rateLimited).toBe(2);
+  });
+
+  test("rate-limited response carries Retry-After and RATE_LIMITED error code", async () => {
+    // Exhaust the budget.
+    for (let i = 0; i < 10; i++) {
+      const req = buildRequest({
+        body: { extensionOrigin: ALLOWED_ORIGIN },
+      });
+      const res = await handleBrowserExtensionPair(req, loopbackServer);
+      await res.text();
+    }
+    // The next request should be rate limited.
+    const req = buildRequest({
+      body: { extensionOrigin: ALLOWED_ORIGIN },
+    });
+    const res = await handleBrowserExtensionPair(req, loopbackServer);
+    expect(res.status).toBe(429);
+    const retryAfter = res.headers.get("Retry-After");
+    expect(retryAfter).not.toBeNull();
+    // Retry-After should be a positive integer of seconds.
+    expect(Number(retryAfter)).toBeGreaterThan(0);
+    expect(res.headers.get("X-RateLimit-Limit")).toBe("10");
+    expect(res.headers.get("X-RateLimit-Remaining")).toBe("0");
+    const payload = (await res.json()) as {
+      error?: { code?: string };
+    };
+    expect(payload.error?.code).toBe("RATE_LIMITED");
+  });
+
+  test("rate limit applies BEFORE native-host marker check (can't probe without spending budget)", async () => {
+    // Attackers shouldn't be able to distinguish "unauthenticated
+    // endpoint" from "endpoint doesn't exist" without consuming a
+    // rate-limit slot. Send 12 unauthenticated probes; after the 10th
+    // request is rate limited, they should get 429 — not 403 — which
+    // proves the limiter runs first.
+    const results: number[] = [];
+    for (let i = 0; i < 12; i++) {
+      const req = buildRequest({
+        body: { extensionOrigin: ALLOWED_ORIGIN },
+        nativeHost: false, // forces a 403 if rate-limiter doesn't run first
+      });
+      const res = await handleBrowserExtensionPair(req, loopbackServer);
+      results.push(res.status);
+      await res.text();
+    }
+    // The first 10 should be 403 (missing marker). Beyond that the
+    // rate limiter kicks in and returns 429.
+    expect(results.slice(0, 10).every((s) => s === 403)).toBe(true);
+    expect(results.slice(10).every((s) => s === 429)).toBe(true);
+  });
+
+  // ─────────────────────────────────────────────────────────────────────
+  // Body validation
+  // ─────────────────────────────────────────────────────────────────────
 
   test("returns 400 when body is missing", async () => {
     const req = buildRequest({});
@@ -182,7 +395,7 @@ describe("handleBrowserExtensionPair", () => {
   test("returns 200 with a valid token for the preferred extensionOrigin field", async () => {
     const req = buildRequest({
       body: {
-        extensionOrigin: "chrome-extension://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/",
+        extensionOrigin: ALLOWED_ORIGIN,
       },
     });
     const res = await handleBrowserExtensionPair(req, loopbackServer);
@@ -222,7 +435,7 @@ describe("handleBrowserExtensionPair", () => {
 
   test("returns 200 using the legacy `origin` field for backwards compat", async () => {
     const req = buildRequest({
-      body: { origin: "chrome-extension://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/" },
+      body: { origin: ALLOWED_ORIGIN },
     });
     const res = await handleBrowserExtensionPair(req, loopbackServer);
     expect(res.status).toBe(200);
@@ -239,7 +452,7 @@ describe("handleBrowserExtensionPair", () => {
     // request must succeed because we honor `extensionOrigin` first.
     const req = buildRequest({
       body: {
-        extensionOrigin: "chrome-extension://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/",
+        extensionOrigin: ALLOWED_ORIGIN,
         origin: "chrome-extension://not-allowed/",
       },
     });
@@ -259,10 +472,12 @@ describe("handleBrowserExtensionPair", () => {
       "::1",
     ];
     for (const host of variants) {
+      // Reset the limiter between iterations so the last few variants
+      // don't fall over the 10/min budget.
+      resetPairRateLimiterForTests();
       const req = buildRequest({
         body: {
-          extensionOrigin:
-            "chrome-extension://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/",
+          extensionOrigin: ALLOWED_ORIGIN,
         },
         host,
       });
@@ -274,7 +489,7 @@ describe("handleBrowserExtensionPair", () => {
   test("rejects malformed bracketed Host header", async () => {
     const req = buildRequest({
       body: {
-        extensionOrigin: "chrome-extension://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/",
+        extensionOrigin: ALLOWED_ORIGIN,
       },
       host: "[::1", // missing closing bracket
     });
@@ -289,7 +504,7 @@ describe("handleBrowserExtensionPair", () => {
     // host while still passing the loopback Host header check.
     const req = buildRequest({
       body: {
-        extensionOrigin: "chrome-extension://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/",
+        extensionOrigin: ALLOWED_ORIGIN,
       },
       host: "[::1]attacker.com",
     });
@@ -300,7 +515,7 @@ describe("handleBrowserExtensionPair", () => {
   test("rejects non-loopback IPv6 Host header", async () => {
     const req = buildRequest({
       body: {
-        extensionOrigin: "chrome-extension://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/",
+        extensionOrigin: ALLOWED_ORIGIN,
       },
       host: "[2001:db8::1]:8765",
     });
@@ -328,7 +543,7 @@ describe("handleBrowserExtensionPair", () => {
   test("tampered tokens fail verification", async () => {
     const req = buildRequest({
       body: {
-        extensionOrigin: "chrome-extension://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/",
+        extensionOrigin: ALLOWED_ORIGIN,
       },
     });
     const res = await handleBrowserExtensionPair(req, loopbackServer);
@@ -352,7 +567,7 @@ describe("handleBrowserExtensionPair", () => {
     // Mint a token, then swap the secret — verification should fail.
     const req = buildRequest({
       body: {
-        extensionOrigin: "chrome-extension://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/",
+        extensionOrigin: ALLOWED_ORIGIN,
       },
     });
     const res = await handleBrowserExtensionPair(req, loopbackServer);
@@ -367,7 +582,7 @@ describe("handleBrowserExtensionPair", () => {
   test("rejects tampered payload even with matching signature length", async () => {
     const req = buildRequest({
       body: {
-        extensionOrigin: "chrome-extension://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/",
+        extensionOrigin: ALLOWED_ORIGIN,
       },
     });
     const res = await handleBrowserExtensionPair(req, loopbackServer);

--- a/assistant/src/runtime/routes/browser-extension-pair-routes.ts
+++ b/assistant/src/runtime/routes/browser-extension-pair-routes.ts
@@ -9,14 +9,30 @@
  *   - **Localhost-only**: enforced by both the TCP peer IP (via
  *     `server.requestIP`) and the `Host` header. Non-localhost callers
  *     receive a 403.
+ *   - **Native-host marker header**: the request must carry the
+ *     `x-vellum-native-host: 1` marker. Only the native messaging helper
+ *     sets this header; browsers cannot attach custom request headers to
+ *     fetches from web pages (custom headers trip CORS preflight, which
+ *     this endpoint does not accept). Missing marker header is rejected
+ *     with 403.
+ *   - **Browser-origin rejection**: if an `Origin` header is present it
+ *     must be either empty or explicitly on the
+ *     `ALLOWED_EXTENSION_ORIGINS` allowlist. This defends against a
+ *     malicious web page in another tab issuing a cross-origin POST from
+ *     the user's browser — such a request would carry the page's origin
+ *     and would be rejected here even if it somehow reached loopback.
+ *   - **Strict rate limiting**: a dedicated per-peer sliding-window
+ *     limiter caps pair requests at 10/minute per peer IP. This is
+ *     separate from the global API limiter because the pair endpoint
+ *     is pre-auth and extra abuse-sensitive.
+ *   - **Audit logs on denial**: every rejected request emits a structured
+ *     warn log including peer IP, Host header, Origin header, native-host
+ *     marker presence, and a reason code so operators can triage denied
+ *     attempts.
  *   - **Origin allowlist**: the body must include `extensionOrigin`
  *     matching a hard-coded allowlist of known Vellum chrome extension
- *     ids. This is a minimal check; real enforcement happens in the
- *     native messaging helper which vets the extension id that spawned
- *     it (PR 7).
- *   - **No auth header required**: the native messaging bootstrap flow
- *     runs before the extension has any token. The localhost + origin
- *     checks are the only gate.
+ *     ids. This is treated as a secondary defense — the primary gate is
+ *     the native-host marker header plus localhost peer check.
  *
  * Request body:  `{ extensionOrigin: string }` (also accepts the legacy
  *                 `{ origin: string }` for backwards compatibility).
@@ -30,8 +46,43 @@ import { getLogger } from "../../util/logger.js";
 import { mintHostBrowserCapability } from "../capability-tokens.js";
 import { httpError } from "../http-errors.js";
 import { isLoopbackAddress } from "../middleware/auth.js";
+import { TokenRateLimiter } from "../middleware/rate-limiter.js";
 
 const log = getLogger("browser-extension-pair");
+
+/**
+ * Header name the native messaging helper MUST set on pair requests.
+ * Exported for tests and for the helper to keep in sync. Browsers cannot
+ * attach custom headers to fetches from web pages without tripping CORS
+ * preflight, which this endpoint does not handle — so a request carrying
+ * this header is (by construction) not a drive-by browser call.
+ */
+export const NATIVE_HOST_MARKER_HEADER = "x-vellum-native-host";
+
+/** Expected value for the native-host marker header. */
+export const NATIVE_HOST_MARKER_VALUE = "1";
+
+/**
+ * Strict per-peer rate limit for pair requests: 10 requests/minute per
+ * loopback peer IP. The native messaging flow only issues one pair
+ * request per extension spawn, so this budget is generous for normal
+ * use (account for retries on transient failures) while still clamping
+ * any abuse surface if a local attacker somehow invokes the endpoint
+ * in a tight loop. Exported for tests that need to reset state.
+ */
+const PAIR_RATE_LIMIT_MAX_REQUESTS = 10;
+const PAIR_RATE_LIMIT_WINDOW_MS = 60_000;
+
+/**
+ * Dedicated rate limiter instance for the pair endpoint. Keyed on the
+ * TCP peer IP (always loopback here, so the key space is tiny and a
+ * handful of tracked keys is plenty).
+ */
+const pairRateLimiter = new TokenRateLimiter(
+  PAIR_RATE_LIMIT_MAX_REQUESTS,
+  PAIR_RATE_LIMIT_WINDOW_MS,
+  64,
+);
 
 /** Bun server shape needed for requestIP. */
 export type PairServerContext = {
@@ -59,6 +110,24 @@ export const ALLOWED_EXTENSION_ORIGINS: ReadonlySet<string> = new Set<string>([
   // id before release.
   "chrome-extension://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/",
 ]);
+
+/**
+ * Reset the dedicated pair-endpoint rate limiter. Exported for tests
+ * so one test's burst can't bleed into another. Production code never
+ * calls this.
+ *
+ * We reach into the private `requests` map via a typed cast rather
+ * than adding a `reset()` method to the shared `TokenRateLimiter` —
+ * the limiter is a general-purpose utility that other routes also
+ * use, and we don't want to pollute its public API with a test-only
+ * escape hatch.
+ */
+export function resetPairRateLimiterForTests(): void {
+  const limiter = pairRateLimiter as unknown as {
+    requests: Map<string, unknown>;
+  };
+  limiter.requests.clear();
+}
 
 /**
  * Parse an HTTP `Host` header value and extract the hostname portion.
@@ -140,6 +209,35 @@ function resolveLocalGuardianId(): string {
 }
 
 /**
+ * Emit an audit log for a denied pair attempt. Centralizes the field
+ * shape (peer IP, host header, origin header, native-host marker
+ * presence, reason) so operators can grep for a single log signature
+ * when triaging abuse.
+ */
+function auditDeny(
+  req: Request,
+  peerIp: string,
+  reason: string,
+  extra?: Record<string, unknown>,
+): void {
+  const host = req.headers.get("host");
+  const origin = req.headers.get("origin");
+  const nativeHostMarker = req.headers.get(NATIVE_HOST_MARKER_HEADER);
+  log.warn(
+    {
+      audit: "browser-extension-pair-denied",
+      peerIp,
+      host,
+      origin,
+      nativeHostMarkerPresent: nativeHostMarker !== null,
+      reason,
+      ...extra,
+    },
+    `pair_denied: ${reason}`,
+  );
+}
+
+/**
  * Handle POST /v1/browser-extension-pair.
  *
  * Body:    `{ extensionOrigin: string }` (also accepts legacy
@@ -163,7 +261,7 @@ export async function handleBrowserExtensionPair(
   const peer = server.requestIP(req);
   const peerIp = peer?.address ?? "";
   if (!peerIp || !isLoopbackAddress(peerIp)) {
-    log.warn({ peerIp }, "Rejecting browser-extension-pair from non-loopback");
+    auditDeny(req, peerIp, "non_loopback_peer");
     return httpError("FORBIDDEN", "endpoint is local-only", 403);
   }
 
@@ -171,27 +269,104 @@ export async function handleBrowserExtensionPair(
   // TCP-level check via proxies that rewrite the peer address.
   const host = req.headers.get("host");
   if (!isLoopbackHostHeader(host)) {
-    log.warn(
-      { host },
-      "Rejecting browser-extension-pair with non-loopback Host header",
-    );
+    auditDeny(req, peerIp, "non_loopback_host_header");
     return httpError("FORBIDDEN", "endpoint is local-only", 403);
   }
 
   // Any `x-forwarded-for` header indicates the request was proxied from a
   // non-local client. Reject — the pair endpoint is strictly machine-local.
   if (req.headers.get("x-forwarded-for")) {
+    auditDeny(req, peerIp, "x_forwarded_for_present");
     return httpError("FORBIDDEN", "endpoint is local-only", 403);
+  }
+
+  // Strict rate limit by peer IP. The limiter is keyed on the loopback
+  // peer address; browsers (even local ones) all appear as 127.0.0.1
+  // here, which is intentional — a single compromised local process
+  // should not be able to hammer the mint endpoint. We evaluate this
+  // BEFORE the native-host marker / origin checks so an attacker can't
+  // use those 403s as an unmetered probe for liveness.
+  const rateResult = pairRateLimiter.check(
+    peerIp,
+    "/v1/browser-extension-pair",
+  );
+  if (!rateResult.allowed) {
+    auditDeny(req, peerIp, "rate_limited", {
+      limit: rateResult.limit,
+      resetAt: rateResult.resetAt,
+    });
+    const retryAfter = Math.max(
+      1,
+      rateResult.resetAt - Math.ceil(Date.now() / 1000),
+    );
+    // Return the same error envelope shape as `httpError` but with
+    // Retry-After + X-RateLimit-* headers attached so the native
+    // host can back off sensibly. We construct the body inline to
+    // avoid cloning / re-consuming a Response returned by
+    // `httpError` (Response bodies are one-shot streams).
+    return Response.json(
+      {
+        error: {
+          code: "RATE_LIMITED",
+          message: "too many pair requests",
+        },
+      },
+      {
+        status: 429,
+        headers: {
+          "Retry-After": String(retryAfter),
+          "X-RateLimit-Limit": String(rateResult.limit),
+          "X-RateLimit-Remaining": "0",
+          "X-RateLimit-Reset": String(rateResult.resetAt),
+        },
+      },
+    );
+  }
+
+  // Primary marker-header gate. The native messaging helper sets this
+  // header on every pair request; browsers cannot (without CORS
+  // preflight, which this endpoint does not serve). Reject when the
+  // header is absent or set to an unexpected value.
+  const marker = req.headers.get(NATIVE_HOST_MARKER_HEADER);
+  if (marker !== NATIVE_HOST_MARKER_VALUE) {
+    auditDeny(req, peerIp, "missing_native_host_marker");
+    return httpError("FORBIDDEN", "native host marker required", 403);
+  }
+
+  // Browser-origin rejection. Any non-empty `Origin` header that isn't
+  // on the extension origin allowlist is a cross-origin browser fetch
+  // and must be rejected. The native messaging helper sends no Origin
+  // header at all (it's a plain node fetch, not a browser fetch), so
+  // the common case is `origin === null`.
+  const originHeader = req.headers.get("origin");
+  if (originHeader !== null && originHeader.length > 0) {
+    // Normalize by stripping any trailing slash mismatch: the
+    // allowlist entries end with `/` but browsers' Origin headers
+    // never include a trailing slash (per RFC 6454 an origin is
+    // scheme+host+port with no path). Compare both the bare origin
+    // and the `/`-suffixed form against the allowlist.
+    const withSlash = `${originHeader}/`;
+    if (
+      !ALLOWED_EXTENSION_ORIGINS.has(originHeader) &&
+      !ALLOWED_EXTENSION_ORIGINS.has(withSlash)
+    ) {
+      auditDeny(req, peerIp, "browser_origin_not_allowlisted", {
+        originHeader,
+      });
+      return httpError("FORBIDDEN", "origin not allowed", 403);
+    }
   }
 
   let body: unknown;
   try {
     body = await req.json();
   } catch {
+    auditDeny(req, peerIp, "invalid_json_body");
     return httpError("BAD_REQUEST", "invalid JSON body", 400);
   }
 
   if (!body || typeof body !== "object") {
+    auditDeny(req, peerIp, "body_not_object");
     return httpError("BAD_REQUEST", "body must be an object", 400);
   }
 
@@ -209,14 +384,19 @@ export async function handleBrowserExtensionPair(
         ? raw.origin
         : null;
   if (extensionOrigin === null) {
+    auditDeny(req, peerIp, "missing_extension_origin");
     return httpError("BAD_REQUEST", "extensionOrigin is required", 400);
   }
 
+  // Secondary defense: body-level extension origin allowlist. The
+  // primary gate is the native-host marker + loopback peer check; this
+  // check catches the failure mode where a compromised extension id
+  // that doesn't match a known Vellum build still manages to reach
+  // the endpoint.
   if (!ALLOWED_EXTENSION_ORIGINS.has(extensionOrigin)) {
-    log.warn(
-      { extensionOrigin },
-      "Rejecting browser-extension-pair for disallowed origin",
-    );
+    auditDeny(req, peerIp, "extension_origin_not_allowlisted", {
+      extensionOrigin,
+    });
     return httpError("UNAUTHORIZED", "unauthorized origin", 401);
   }
 

--- a/clients/chrome-extension-native-host/src/__tests__/index.test.ts
+++ b/clients/chrome-extension-native-host/src/__tests__/index.test.ts
@@ -58,7 +58,11 @@ interface MockPairServer {
   server: ReturnType<typeof Bun.serve>;
   port: number;
   /** All requests received by the mock server, in order. */
-  requests: Array<{ pathname: string; body: unknown }>;
+  requests: Array<{
+    pathname: string;
+    body: unknown;
+    headers: Record<string, string>;
+  }>;
   /** Body the next pair request should return. */
   nextResponseBody: () => Record<string, unknown>;
   stop: () => void;
@@ -97,7 +101,13 @@ function startMockPairServer(): MockPairServer {
       } catch {
         body = null;
       }
-      state.requests.push({ pathname: url.pathname, body });
+      // Snapshot the headers as a plain object so the assertion
+      // surface stays stable across Headers iteration quirks.
+      const headers: Record<string, string> = {};
+      req.headers.forEach((value, key) => {
+        headers[key.toLowerCase()] = value;
+      });
+      state.requests.push({ pathname: url.pathname, body, headers });
 
       if (
         url.pathname !== "/v1/browser-extension-pair" ||
@@ -171,7 +181,9 @@ async function runHelper(options: {
   const exitCode = await proc.exited;
   clearTimeout(timer);
 
-  const stdoutBuffer = Buffer.from(await new Response(proc.stdout).arrayBuffer());
+  const stdoutBuffer = Buffer.from(
+    await new Response(proc.stdout).arrayBuffer(),
+  );
   const stderrText = await new Response(proc.stderr).text();
 
   if (timedOut) {
@@ -289,6 +301,42 @@ describe("native host — subprocess regression coverage", () => {
     expect(srv.requests).toHaveLength(1);
     expect(srv.requests[0]!.pathname).toBe("/v1/browser-extension-pair");
     expect(srv.requests[0]!.body).toEqual({ extensionOrigin: ALLOWED_ORIGIN });
+
+    // PR4 of the browser-use remediation plan: the helper MUST set
+    // the `x-vellum-native-host: 1` marker header on every pair
+    // request. The assistant rejects pair requests that omit it, so
+    // if this assertion fails the extension would stop pairing even
+    // though the rest of the flow looks healthy.
+    expect(srv.requests[0]!.headers["x-vellum-native-host"]).toBe("1");
+  });
+
+  test("native host helper sets the x-vellum-native-host marker header", async () => {
+    // Dedicated regression test that pins down the marker-header
+    // contract independent of the token/guardian assertions above.
+    // If a future refactor accidentally drops the header, this test
+    // fails in isolation rather than as a side effect of another
+    // assertion.
+    const srv = pair!;
+    srv.requests.length = 0;
+    srv.nextResponseBody = () => ({
+      token: "marker-test-token",
+      expiresAt: "2026-12-31T00:00:00Z",
+      guardianId: "marker-g-1",
+    });
+
+    const result = await runHelper({
+      extensionOrigin: ALLOWED_ORIGIN,
+      assistantPort: srv.port,
+      stdinBytes: encodeFrame({ type: "request_token" }),
+      timeoutMs: 2000,
+    });
+
+    expect(result.exitCode, `helper stderr: ${result.stderr}`).toBe(0);
+    expect(srv.requests).toHaveLength(1);
+    expect(srv.requests[0]!.headers["x-vellum-native-host"]).toBe("1");
+    expect(srv.requests[0]!.headers["content-type"]).toContain(
+      "application/json",
+    );
   });
 
   test("missing guardianId in the pair response is rejected with an error frame", async () => {

--- a/clients/chrome-extension-native-host/src/__tests__/integration.test.ts
+++ b/clients/chrome-extension-native-host/src/__tests__/integration.test.ts
@@ -62,7 +62,12 @@ interface MockPairServer {
   server: Server;
   port: number;
   /** Requests received by the mock server, in order. */
-  requests: Array<{ path: string; body: unknown; host: string | null }>;
+  requests: Array<{
+    path: string;
+    body: unknown;
+    host: string | null;
+    headers: Record<string, string>;
+  }>;
   /** Token value returned by the next successful pair request. */
   nextToken: { token: string; expiresAt: string };
   /** If set, the mock returns this HTTP status instead of 200 on pair. */
@@ -92,10 +97,19 @@ async function startMockPairServer(): Promise<MockPairServer> {
       } catch {
         body = raw;
       }
+      // Snapshot the headers as a plain object so tests can assert
+      // on a stable surface. node:http lowercases header names, so
+      // the keys are already the canonical wire form.
+      const headers: Record<string, string> = {};
+      for (const [key, value] of Object.entries(req.headers)) {
+        if (typeof value === "string") headers[key] = value;
+        else if (Array.isArray(value)) headers[key] = value.join(", ");
+      }
       state.requests.push({
         path: req.url ?? "",
         body,
         host: req.headers.host ?? null,
+        headers,
       });
 
       if (req.url !== "/v1/browser-extension-pair" || req.method !== "POST") {
@@ -285,6 +299,12 @@ describe("native host helper — subprocess integration", () => {
     expect(pair.requests.length).toBe(1);
     expect(pair.requests[0]!.path).toBe("/v1/browser-extension-pair");
     expect(pair.requests[0]!.body).toEqual({ extensionOrigin: ALLOWED_ORIGIN });
+
+    // PR4 of the browser-use remediation plan: the helper must set
+    // the `x-vellum-native-host: 1` marker header on every pair
+    // request so the assistant's pre-auth endpoint can reject
+    // drive-by browser fetches.
+    expect(pair.requests[0]!.headers["x-vellum-native-host"]).toBe("1");
   });
 
   test("rejects disallowed extension origin with an error frame", async () => {

--- a/clients/chrome-extension-native-host/src/index.ts
+++ b/clients/chrome-extension-native-host/src/index.ts
@@ -63,6 +63,18 @@ const ALLOWED_EXTENSION_IDS: ReadonlySet<string> = new Set<string>([
 const DEFAULT_ASSISTANT_PORT = 7821;
 const RUNTIME_PORT_FILE = join(homedir(), ".vellum", "runtime-port");
 
+/**
+ * Marker header the pair endpoint requires on every request. The assistant
+ * rejects pair attempts without this header to rule out drive-by browser
+ * fetches (browsers cannot set custom headers on cross-origin requests
+ * without a CORS preflight, which the pair endpoint does not serve). Kept
+ * in sync with `NATIVE_HOST_MARKER_HEADER` /
+ * `NATIVE_HOST_MARKER_VALUE` in
+ * `assistant/src/runtime/routes/browser-extension-pair-routes.ts`.
+ */
+export const NATIVE_HOST_MARKER_HEADER = "x-vellum-native-host";
+export const NATIVE_HOST_MARKER_VALUE = "1";
+
 interface TokenResponse {
   token: string;
   expiresAt: string;
@@ -204,9 +216,7 @@ function writeFrameAndExitAsync(
     });
     const safety = setTimeout(() => {
       reject(
-        new Error(
-          "writeFrameAndExitAsync timed out waiting for stdout flush",
-        ),
+        new Error("writeFrameAndExitAsync timed out waiting for stdout flush"),
       );
     }, 5000);
     safety.unref?.();
@@ -250,7 +260,14 @@ async function requestToken(
   try {
     response = await fetch(url, {
       method: "POST",
-      headers: { "content-type": "application/json" },
+      headers: {
+        "content-type": "application/json",
+        // Required by the pair endpoint (PR4 of the browser-use
+        // remediation plan). The assistant rejects requests that
+        // omit or misspell this header so a drive-by browser fetch
+        // can't pair silently.
+        [NATIVE_HOST_MARKER_HEADER]: NATIVE_HOST_MARKER_VALUE,
+      },
       body: JSON.stringify({ extensionOrigin }),
     });
   } catch (err) {


### PR DESCRIPTION
## Summary
- Require x-vellum-native-host marker header on pair requests
- Reject browser-originated requests with non-null Origin unless allowlisted
- Strict rate limiting on pair requests (loopback still required)
- Audit logs for denied pair attempts
- Native-host helper sets required header

Part of plan: browser-use-main-remediation-plan-2026-04-08.md (PR 4 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24483" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
