### PR TITLE
feat(macos): add log retention picker to Permissions & Privacy settings

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/LlmLogRetentionOption.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/LlmLogRetentionOption.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// User-selectable LLM request log retention periods shown in the
+/// Permissions & Privacy settings picker. Mirrors the server-side default
+/// of 1 day and allows users to disable pruning entirely.
+enum LlmLogRetentionOption: Int64, CaseIterable, Identifiable {
+    case oneDay = 86_400_000          // 1 * 24 * 60 * 60 * 1000
+    case sevenDays = 604_800_000      // 7 * 24 * 60 * 60 * 1000
+    case thirtyDays = 2_592_000_000   // 30 * 24 * 60 * 60 * 1000
+    case ninetyDays = 7_776_000_000   // 90 * 24 * 60 * 60 * 1000
+    case never = 0
+
+    var id: Int64 { rawValue }
+
+    var label: String {
+        switch self {
+        case .oneDay: return "1 day"
+        case .sevenDays: return "7 days"
+        case .thirtyDays: return "30 days"
+        case .ninetyDays: return "90 days"
+        case .never: return "Never (keep forever)"
+        }
+    }
+
+    /// Returns the closest option for an arbitrary millisecond value read from the daemon.
+    /// Unknown / out-of-band values snap to the closest known period; `0` is special-cased to `.never`.
+    static func closest(toMs ms: Int64) -> LlmLogRetentionOption {
+        if ms == 0 { return .never }
+        let known = allCases.filter { $0 != .never }
+        return known.min(by: { abs($0.rawValue - ms) < abs($1.rawValue - ms) }) ?? .oneDay
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Settings/LlmLogRetentionOption.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/LlmLogRetentionOption.swift
@@ -23,10 +23,18 @@ enum LlmLogRetentionOption: Int64, CaseIterable, Identifiable {
     }
 
     /// Returns the closest option for an arbitrary millisecond value read from the daemon.
-    /// Unknown / out-of-band values snap to the closest known period; `0` is special-cased to `.never`.
+    /// Unknown / out-of-band values snap to the nearest known period; `0` is special-cased to `.never`.
+    /// Ties (e.g. a value exactly halfway between two options) snap to the *larger* retention to avoid
+    /// silently shortening a user's retention when the UI reconciles an out-of-band value.
     static func closest(toMs ms: Int64) -> LlmLogRetentionOption {
         if ms == 0 { return .never }
         let known = allCases.filter { $0 != .never }
-        return known.min(by: { abs($0.rawValue - ms) < abs($1.rawValue - ms) }) ?? .oneDay
+        return known.min(by: { lhs, rhs in
+            let lhsDist = abs(lhs.rawValue - ms)
+            let rhsDist = abs(rhs.rawValue - ms)
+            if lhsDist != rhsDist { return lhsDist < rhsDist }
+            // Tie → prefer the larger (longer) retention.
+            return lhs.rawValue > rhs.rawValue
+        }) ?? .oneDay
     }
 }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift
@@ -1,5 +1,16 @@
 import SwiftUI
 import VellumAssistantShared
+import os
+
+private let privacyTabLog = Logger(
+    subsystem: Bundle.appBundleIdentifier,
+    category: "SettingsPrivacyTab"
+)
+
+/// UserDefaults key for the cached LLM request log retention value (Int64 ms).
+/// Seeded from the last known daemon value so the picker renders instantly
+/// on next open before the GET completes.
+private let llmRequestLogRetentionMsDefaultsKey = "llmRequestLogRetentionMs"
 
 /// Privacy settings tab — lets the user control usage analytics and
 /// crash/error diagnostics independently.
@@ -14,6 +25,20 @@ struct SettingsPrivacyTab: View {
     /// both current store values, so cancelling one toggle's task cannot
     /// silently drop the other toggle's change.
     @State private var privacySyncTask: Task<Void, Never>?
+
+    /// Current selection for the LLM request log retention picker.
+    /// Seeded from UserDefaults on view appear for instant render, then
+    /// reconciled against the daemon's authoritative value via
+    /// `loadPrivacyConfig()`.
+    @State private var retentionSelection: LlmLogRetentionOption = .oneDay
+
+    /// In-flight retention sync task so rapid picker changes cancel the
+    /// previous write and only the latest selection reaches the daemon.
+    @State private var retentionSyncTask: Task<Void, Never>?
+
+    /// In-flight retention load task so repeated view appearances don't
+    /// stack concurrent GETs against the gateway.
+    @State private var retentionLoadTask: Task<Void, Never>?
 
     var body: some View {
         privacySection
@@ -55,7 +80,29 @@ struct SettingsPrivacyTab: View {
                 helperText: "Send crash reports and performance metrics. Your conversations and personal data are never included."
             )
             .frame(maxWidth: .infinity, alignment: .leading)
+
+            SettingsDivider()
+
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                Text("LLM Request Log Retention")
+                    .font(VFont.bodyMediumDefault)
+                    .foregroundStyle(VColor.contentDefault)
+                Picker("", selection: $retentionSelection) {
+                    ForEach(LlmLogRetentionOption.allCases) { option in
+                        Text(option.label).tag(option)
+                    }
+                }
+                .labelsHidden()
+                .onChange(of: retentionSelection) { _, newValue in
+                    syncRetention(newValue)
+                }
+                Text("How long to keep LLM request and response logs on this device. These logs record the prompts and completions sent to model providers and are used for debugging. Shorter retention improves privacy; longer retention helps troubleshoot issues.")
+                    .font(VFont.bodySmallDefault)
+                    .foregroundStyle(VColor.contentTertiary)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
+        .task { await loadPrivacyConfig() }
     }
 
     // MARK: - Privacy Config Sync
@@ -74,5 +121,70 @@ struct SettingsPrivacyTab: View {
                 llmRequestLogRetentionMs: nil
             )
         }
+    }
+
+    // MARK: - Retention Picker Sync
+
+    /// Loads the current privacy config from the daemon and reconciles the
+    /// retention picker selection. First seeds from UserDefaults so the picker
+    /// renders instantly on view appear even before the GET completes.
+    /// Errors are logged and swallowed — the picker gracefully keeps the
+    /// default if the GET fails.
+    private func loadPrivacyConfig() async {
+        // Seed from UserDefaults for instant render.
+        if let cachedMs = readCachedRetentionMs() {
+            retentionSelection = LlmLogRetentionOption.closest(toMs: cachedMs)
+        }
+
+        retentionLoadTask?.cancel()
+        let task = Task { @MainActor in
+            do {
+                let config = try await featureFlagClient.getPrivacyConfig()
+                guard !Task.isCancelled else { return }
+                retentionSelection = LlmLogRetentionOption.closest(
+                    toMs: config.llmRequestLogRetentionMs
+                )
+                UserDefaults.standard.set(
+                    config.llmRequestLogRetentionMs,
+                    forKey: llmRequestLogRetentionMsDefaultsKey
+                )
+            } catch {
+                privacyTabLog.error(
+                    "getPrivacyConfig failed: \(error.localizedDescription, privacy: .public)"
+                )
+            }
+        }
+        retentionLoadTask = task
+        await task.value
+    }
+
+    /// Syncs the selected retention option to the daemon and persists the
+    /// selection locally so the picker renders instantly on next open.
+    private func syncRetention(_ option: LlmLogRetentionOption) {
+        UserDefaults.standard.set(
+            option.rawValue,
+            forKey: llmRequestLogRetentionMsDefaultsKey
+        )
+        retentionSyncTask?.cancel()
+        retentionSyncTask = Task {
+            try? await featureFlagClient.setPrivacyConfig(
+                collectUsageData: nil,
+                sendDiagnostics: nil,
+                llmRequestLogRetentionMs: option.rawValue
+            )
+        }
+    }
+
+    /// Reads the cached retention milliseconds from UserDefaults, handling
+    /// both `Int64` and `Int` coercion since `UserDefaults` cannot directly
+    /// store `Int64` and may round-trip it through `NSNumber`.
+    private func readCachedRetentionMs() -> Int64? {
+        guard let raw = UserDefaults.standard.object(
+            forKey: llmRequestLogRetentionMsDefaultsKey
+        ) else { return nil }
+        if let asInt64 = raw as? Int64 { return asInt64 }
+        if let asInt = raw as? Int { return Int64(asInt) }
+        if let asNumber = raw as? NSNumber { return asNumber.int64Value }
+        return nil
     }
 }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift
@@ -87,15 +87,22 @@ struct SettingsPrivacyTab: View {
                 Text("LLM Request Log Retention")
                     .font(VFont.bodyMediumDefault)
                     .foregroundStyle(VColor.contentDefault)
-                Picker("", selection: $retentionSelection) {
+                Picker(
+                    "LLM Request Log Retention",
+                    selection: Binding(
+                        get: { retentionSelection },
+                        set: { newValue in
+                            retentionSelection = newValue
+                            syncRetention(newValue)
+                        }
+                    )
+                ) {
                     ForEach(LlmLogRetentionOption.allCases) { option in
                         Text(option.label).tag(option)
                     }
                 }
                 .labelsHidden()
-                .onChange(of: retentionSelection) { _, newValue in
-                    syncRetention(newValue)
-                }
+                .accessibilityLabel("LLM Request Log Retention")
                 Text("How long to keep LLM request and response logs on this device. These logs record the prompts and completions sent to model providers and are used for debugging. Shorter retention improves privacy; longer retention helps troubleshoot issues.")
                     .font(VFont.bodySmallDefault)
                     .foregroundStyle(VColor.contentTertiary)

--- a/clients/macos/vellum-assistantTests/LlmLogRetentionOptionTests.swift
+++ b/clients/macos/vellum-assistantTests/LlmLogRetentionOptionTests.swift
@@ -31,14 +31,32 @@ final class LlmLogRetentionOptionTests: XCTestCase {
 
     // MARK: - Off-grid snapping
 
-    /// 2 days (172_800_000 ms) is closer to 1 day than to 7 days.
+    /// 2 days (172_800_000 ms) is closer to 1 day (1 day away) than to 7 days (5 days away).
+    /// Not a tie — `.oneDay` is genuinely closer.
     func testClosestSnapsTwoDaysToOneDay() {
         XCTAssertEqual(LlmLogRetentionOption.closest(toMs: 172_800_000), .oneDay)
     }
 
-    /// 4 days (345_600_000 ms) is closer to 7 days than to 1 day.
-    func testClosestSnapsFourDaysToSevenDays() {
+    // MARK: - Tie-breaking (snap up to larger retention)
+
+    /// 4 days (345_600_000 ms) is exactly halfway between 1 day and 7 days.
+    /// Tie-breaking rule: snap up to the larger retention → `.sevenDays`.
+    func testClosestSnapsExactMidpointBetweenOneAndSevenDaysToSevenDays() {
         XCTAssertEqual(LlmLogRetentionOption.closest(toMs: 345_600_000), .sevenDays)
+    }
+
+    /// Exact midpoint between 7 days (604_800_000) and 30 days (2_592_000_000):
+    /// (604_800_000 + 2_592_000_000) / 2 = 1_598_400_000 ms (≈18.5 days).
+    /// Tie-breaking rule: snap up to the larger retention → `.thirtyDays`.
+    func testClosestSnapsExactMidpointBetweenSevenAndThirtyDaysToThirtyDays() {
+        XCTAssertEqual(LlmLogRetentionOption.closest(toMs: 1_598_400_000), .thirtyDays)
+    }
+
+    /// Exact midpoint between 30 days (2_592_000_000) and 90 days (7_776_000_000):
+    /// (2_592_000_000 + 7_776_000_000) / 2 = 5_184_000_000 ms (60 days).
+    /// Tie-breaking rule: snap up to the larger retention → `.ninetyDays`.
+    func testClosestSnapsExactMidpointBetweenThirtyAndNinetyDaysToNinetyDays() {
+        XCTAssertEqual(LlmLogRetentionOption.closest(toMs: 5_184_000_000), .ninetyDays)
     }
 
     // MARK: - Invariants

--- a/clients/macos/vellum-assistantTests/LlmLogRetentionOptionTests.swift
+++ b/clients/macos/vellum-assistantTests/LlmLogRetentionOptionTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+@testable import VellumAssistantLib
+
+/// Unit tests for `LlmLogRetentionOption` — covers `closest(toMs:)` snapping
+/// logic, label/case invariants, and the `.never` zero-value special case.
+final class LlmLogRetentionOptionTests: XCTestCase {
+
+    // MARK: - Exact raw-value matches
+
+    func testClosestReturnsOneDayForExactOneDayMs() {
+        XCTAssertEqual(LlmLogRetentionOption.closest(toMs: 86_400_000), .oneDay)
+    }
+
+    func testClosestReturnsSevenDaysForExactSevenDaysMs() {
+        XCTAssertEqual(LlmLogRetentionOption.closest(toMs: 604_800_000), .sevenDays)
+    }
+
+    func testClosestReturnsThirtyDaysForExactThirtyDaysMs() {
+        XCTAssertEqual(LlmLogRetentionOption.closest(toMs: 2_592_000_000), .thirtyDays)
+    }
+
+    func testClosestReturnsNinetyDaysForExactNinetyDaysMs() {
+        XCTAssertEqual(LlmLogRetentionOption.closest(toMs: 7_776_000_000), .ninetyDays)
+    }
+
+    // MARK: - Zero / never
+
+    func testClosestReturnsNeverForZero() {
+        XCTAssertEqual(LlmLogRetentionOption.closest(toMs: 0), .never)
+    }
+
+    // MARK: - Off-grid snapping
+
+    /// 2 days (172_800_000 ms) is closer to 1 day than to 7 days.
+    func testClosestSnapsTwoDaysToOneDay() {
+        XCTAssertEqual(LlmLogRetentionOption.closest(toMs: 172_800_000), .oneDay)
+    }
+
+    /// 4 days (345_600_000 ms) is closer to 7 days than to 1 day.
+    func testClosestSnapsFourDaysToSevenDays() {
+        XCTAssertEqual(LlmLogRetentionOption.closest(toMs: 345_600_000), .sevenDays)
+    }
+
+    // MARK: - Invariants
+
+    func testAllCasesHasFiveEntries() {
+        XCTAssertEqual(LlmLogRetentionOption.allCases.count, 5)
+    }
+
+    func testAllCasesLabelsAreNonEmpty() {
+        for option in LlmLogRetentionOption.allCases {
+            XCTAssertFalse(option.label.isEmpty, "Label for \(option) should not be empty")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- New LlmLogRetentionOption enum (1 day / 7 days / 30 days / 90 days / Never)
- Picker added to SettingsPrivacyTab under the existing privacy toggles
- Loads current value from daemon via getPrivacyConfig() on appear; seeds from UserDefaults for instant render
- Writes changes via setPrivacyConfig(llmRequestLogRetentionMs:)
- Unit tests cover closest(toMs:) snapping and label/case invariants

Part of plan: log-retention-setting.md (PR 5 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24484" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
