### PR TITLE
Strip legacy approval affordances from v2 host prompts

### DIFF
--- a/assistant/src/__tests__/approval-routes-http.test.ts
+++ b/assistant/src/__tests__/approval-routes-http.test.ts
@@ -68,6 +68,7 @@ mock.module("../permissions/trust-store.js", () => ({
 }));
 
 import { getDb, initializeDb } from "../memory/db.js";
+import { CONVERSATION_HOST_ACCESS_PROMPT } from "../permissions/v2-consent-policy.js";
 import { AssistantEventHub } from "../runtime/assistant-event-hub.js";
 import { RuntimeHttpServer } from "../runtime/http-server.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
@@ -370,6 +371,49 @@ describe("standalone approval endpoints — HTTP layer", () => {
       });
 
       expect(res.status).toBe(400);
+
+      await stopServer();
+    });
+
+    test("rejects temporal approval decisions for conversation host-access prompts", async () => {
+      let confirmedDecision: string | undefined;
+
+      const session = makeIdleSession({
+        onConfirmation: (_reqId, dec) => {
+          confirmedDecision = dec;
+        },
+      });
+
+      await startServer(() => session);
+
+      pendingInteractions.register("req-host-access", {
+        conversation: session,
+        conversationId: "conv-1",
+        kind: "confirmation",
+        confirmationDetails: {
+          toolName: "host_bash",
+          input: { command: "ls" },
+          riskLevel: "medium",
+          ...CONVERSATION_HOST_ACCESS_PROMPT,
+        },
+      });
+
+      const res = await fetch(url("confirm"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
+        body: JSON.stringify({
+          requestId: "req-host-access",
+          decision: "allow_10m",
+        }),
+      });
+      const body = (await res.json()) as { error?: { message?: string } };
+
+      expect(res.status).toBe(403);
+      expect(body.error?.message).toContain(
+        "Conversation host-access prompts only accept allow or deny",
+      );
+      expect(confirmedDecision).toBeUndefined();
+      expect(pendingInteractions.get("req-host-access")).toBeDefined();
 
       await stopServer();
     });

--- a/assistant/src/__tests__/conversation-attachments.test.ts
+++ b/assistant/src/__tests__/conversation-attachments.test.ts
@@ -1,6 +1,8 @@
 import { existsSync } from "node:fs";
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { _setOverridesForTesting } from "../config/assistant-feature-flags.js";
+
 mock.module("../util/logger.js", () => ({
   getLogger: () =>
     new Proxy({} as Record<string, unknown>, {
@@ -25,15 +27,18 @@ mock.module("../daemon/video-thumbnail.js", () => ({
 }));
 
 // Stub out permission checker / trust store
+const checkSpy = mock(() => Promise.resolve({ decision: "allow" }));
+const addRuleSpy = mock(() => {});
+
 mock.module("../permissions/checker.js", () => ({
-  check: () => Promise.resolve({ decision: "allow" }),
+  check: checkSpy,
   classifyRisk: () => Promise.resolve("low"),
   generateAllowlistOptions: () => Promise.resolve([]),
   generateScopeOptions: () => [],
 }));
 
 mock.module("../permissions/trust-store.js", () => ({
-  addRule: () => {},
+  addRule: addRuleSpy,
 }));
 
 mock.module("../permissions/types.js", () => ({
@@ -47,7 +52,11 @@ mock.module("../permissions/types.js", () => ({
 
 import type { AssistantAttachmentDraft } from "../daemon/assistant-attachments.js";
 import { getFilePathForAttachment } from "../memory/attachments-store.js";
-import { addMessage, createConversation } from "../memory/conversation-crud.js";
+import {
+  addMessage,
+  createConversation,
+  updateConversationHostAccess,
+} from "../memory/conversation-crud.js";
 import { getDb, initializeDb } from "../memory/db.js";
 
 initializeDb();
@@ -73,7 +82,12 @@ function makeBase64(bytes: number): string {
 // ---------------------------------------------------------------------------
 
 describe("resolveAssistantAttachments", () => {
-  beforeEach(resetTables);
+  beforeEach(() => {
+    resetTables();
+    _setOverridesForTesting({});
+    checkSpy.mockClear();
+    addRuleSpy.mockClear();
+  });
 
   test("small attachments are stored on disk via uploadAttachment", async () => {
     const conv = createConversation("test-conv");
@@ -194,5 +208,67 @@ describe("resolveAssistantAttachments", () => {
 
     // fileBacked flag is always true now
     expect(emitted.fileBacked).toBe(true);
+  });
+});
+
+describe("approveHostAttachmentRead", () => {
+  beforeEach(() => {
+    resetTables();
+    _setOverridesForTesting({});
+    checkSpy.mockClear();
+    addRuleSpy.mockClear();
+  });
+
+  test("uses the conversation-scoped host-access prompt under v2", async () => {
+    _setOverridesForTesting({ "permission-controls-v2": true });
+    const conversation = createConversation("attachment-host-gate");
+    const promptSpy = mock(() =>
+      Promise.resolve({ decision: "allow" as const }),
+    );
+
+    const { approveHostAttachmentRead } =
+      await import("../daemon/conversation-attachments.js");
+
+    const allowed = await approveHostAttachmentRead(
+      "/tmp/example.txt",
+      "/tmp",
+      { prompt: promptSpy } as never,
+      conversation.id,
+      false,
+    );
+
+    expect(allowed).toBe(true);
+    expect(checkSpy).not.toHaveBeenCalled();
+    expect(addRuleSpy).not.toHaveBeenCalled();
+    const call = promptSpy.mock.calls[0] as unknown as unknown[];
+    expect(call[3]).toEqual([]);
+    expect(call[4]).toEqual([]);
+    expect(call[8]).toBe(false);
+    expect(call[10]).toBeUndefined();
+    expect(call[12]).toBe(true);
+  });
+
+  test("auto-allows host attachment reads when the conversation already has host access", async () => {
+    _setOverridesForTesting({ "permission-controls-v2": true });
+    const conversation = createConversation("attachment-host-allowed");
+    updateConversationHostAccess(conversation.id, true);
+    const promptSpy = mock(() =>
+      Promise.resolve({ decision: "deny" as const }),
+    );
+
+    const { approveHostAttachmentRead } =
+      await import("../daemon/conversation-attachments.js");
+
+    const allowed = await approveHostAttachmentRead(
+      "/tmp/example.txt",
+      "/tmp",
+      { prompt: promptSpy } as never,
+      conversation.id,
+      false,
+    );
+
+    expect(allowed).toBe(true);
+    expect(promptSpy).not.toHaveBeenCalled();
+    expect(checkSpy).not.toHaveBeenCalled();
   });
 });

--- a/assistant/src/__tests__/conversation-queue.test.ts
+++ b/assistant/src/__tests__/conversation-queue.test.ts
@@ -1,5 +1,13 @@
 import { rmSync, writeFileSync } from "node:fs";
-import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
 
 import type {
   AgentEvent,
@@ -95,6 +103,8 @@ mock.module("../config/loader.js", () => ({
   invalidateConfigCache: () => {},
 }));
 
+const mockedConversationHostAccess = new Map<string, boolean>();
+
 mock.module("../prompts/system-prompt.js", () => ({
   buildSystemPrompt: () => "system prompt",
 }));
@@ -113,6 +123,7 @@ mock.module("../permissions/trust-store.js", () => ({
   addRule: () => {},
   findHighestPriorityRule: () => null,
   clearCache: () => {},
+  patternMatchesCandidate: () => false,
 }));
 
 mock.module("../security/secret-allowlist.js", () => ({
@@ -123,6 +134,14 @@ mock.module("../memory/conversation-crud.js", () => ({
   getConversationType: () => "default",
   setConversationOriginChannelIfUnset: () => {},
   updateConversationContextWindow: () => {},
+  getConversationHostAccess: (conversationId: string) =>
+    mockedConversationHostAccess.get(conversationId) ?? false,
+  updateConversationHostAccess: (
+    conversationId: string,
+    hostAccess: boolean,
+  ) => {
+    mockedConversationHostAccess.set(conversationId, hostAccess);
+  },
   deleteMessageById: () => {},
   provenanceFromTrustContext: () => ({
     source: "user",
@@ -1315,8 +1334,18 @@ describe("Terminal trace events on rejection/failure", () => {
 // ---------------------------------------------------------------------------
 
 describe("Conversation host attachment directives", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     pendingRuns = [];
+    mockedConversationHostAccess.clear();
+    const { _setOverridesForTesting } =
+      await import("../config/assistant-feature-flags.js");
+    _setOverridesForTesting({ "permission-controls-v2": true });
+  });
+
+  afterEach(async () => {
+    const { _setOverridesForTesting } =
+      await import("../config/assistant-feature-flags.js");
+    _setOverridesForTesting({});
   });
 
   test("host attachment prompts and resolves when user allows", async () => {
@@ -1364,6 +1393,19 @@ describe("Conversation host attachment directives", () => {
         (e) => e.type === "confirmation_request",
       );
       expect(confirmation).toBeDefined();
+      expect(
+        (confirmation as { persistentDecisionsAllowed?: boolean })
+          .persistentDecisionsAllowed,
+      ).toBe(false);
+      expect(
+        (
+          confirmation as {
+            temporaryOptionsAvailable?: Array<
+              "allow_10m" | "allow_conversation"
+            >;
+          }
+        ).temporaryOptionsAvailable ?? [],
+      ).toEqual([]);
       conversation.handleConfirmationResponse(
         (confirmation as { requestId: string }).requestId,
         "allow",
@@ -1371,6 +1413,7 @@ describe("Conversation host attachment directives", () => {
 
       await p1;
 
+      expect(mockedConversationHostAccess.get("conv-1")).toBe(true);
       expect(conversation.lastAssistantAttachments).toHaveLength(1);
       expect(conversation.lastAssistantAttachments[0].sourceType).toBe(
         "host_file",

--- a/assistant/src/__tests__/permission-checker-host-gate.test.ts
+++ b/assistant/src/__tests__/permission-checker-host-gate.test.ts
@@ -42,10 +42,11 @@ mock.module("../hooks/manager.js", () => ({
   }),
 }));
 
-let hostAccessEnabled = false;
+const hostAccessByConversation = new Map<string, boolean>();
 
 mock.module("../memory/conversation-crud.js", () => ({
-  getConversationHostAccess: () => hostAccessEnabled,
+  getConversationHostAccess: (conversationId: string) =>
+    hostAccessByConversation.get(conversationId) ?? false,
 }));
 
 // ---------------------------------------------------------------------------
@@ -97,12 +98,12 @@ const executionTarget: ExecutionTarget = "host";
 
 beforeEach(() => {
   _setOverridesForTesting({});
-  hostAccessEnabled = false;
+  hostAccessByConversation.clear();
 });
 
 afterEach(() => {
   _setOverridesForTesting({});
-  hostAccessEnabled = false;
+  hostAccessByConversation.clear();
 });
 
 // ---------------------------------------------------------------------------
@@ -125,7 +126,7 @@ describe("permission-checker host-access gate (v2)", () => {
 
     describe("host tools with hostAccess=false", () => {
       beforeEach(() => {
-        hostAccessEnabled = false;
+        hostAccessByConversation.set("test-conv", false);
       });
 
       for (const toolName of HOST_TOOL_NAMES) {
@@ -151,6 +152,12 @@ describe("permission-checker host-access gate (v2)", () => {
 
           // The prompter should have been called (interactive dialog)
           expect(promptSpy).toHaveBeenCalled();
+          const call = promptSpy.mock.calls[0] as unknown as unknown[];
+          expect(call[3]).toEqual([]);
+          expect(call[4]).toEqual([]);
+          expect(call[8]).toBe(false);
+          expect(call[10]).toBeUndefined();
+          expect(call[12]).toBe(true);
           // Since the mock prompter returns "allow", the result should be allowed
           expect(result.allowed).toBe(true);
           expect(result.decision).toBe("allow");
@@ -185,7 +192,7 @@ describe("permission-checker host-access gate (v2)", () => {
 
     describe("host tools with hostAccess=true", () => {
       beforeEach(() => {
-        hostAccessEnabled = true;
+        hostAccessByConversation.set("test-conv", true);
       });
 
       for (const toolName of HOST_TOOL_NAMES) {
@@ -217,7 +224,7 @@ describe("permission-checker host-access gate (v2)", () => {
         "web_search",
       ]) {
         test(`${toolName} is auto-allowed regardless of hostAccess`, async () => {
-          hostAccessEnabled = false;
+          hostAccessByConversation.set("test-conv", false);
           const checker = new PermissionChecker(makePrompter());
           const result = await checker.checkPermission(
             toolName,
@@ -239,7 +246,7 @@ describe("permission-checker host-access gate (v2)", () => {
 
     describe("requireFreshApproval bypasses v2 auto-allow", () => {
       beforeEach(() => {
-        hostAccessEnabled = true;
+        hostAccessByConversation.set("test-conv", true);
       });
 
       test("host tool with requireFreshApproval falls through to prompter", async () => {
@@ -295,7 +302,7 @@ describe("permission-checker host-access gate (v2)", () => {
 
     describe("non-interactive guardian session with hostAccess=false", () => {
       beforeEach(() => {
-        hostAccessEnabled = false;
+        hostAccessByConversation.set("test-conv", false);
       });
 
       test("host tool is NOT auto-approved (denies instead of guardian_auto_approve)", async () => {
@@ -329,7 +336,7 @@ describe("permission-checker host-access gate (v2)", () => {
 
     describe("forcePromptSideEffects bypasses v2 auto-allow for side-effect tools", () => {
       beforeEach(() => {
-        hostAccessEnabled = true;
+        hostAccessByConversation.set("test-conv", true);
       });
 
       test("host side-effect tool with forcePromptSideEffects falls through to prompter", async () => {
@@ -400,6 +407,47 @@ describe("permission-checker host-access gate (v2)", () => {
         expect(result.allowed).toBe(true);
         expect(result.decision).toBe("allow");
       });
+    });
+
+    test("host access is evaluated per conversation", async () => {
+      hostAccessByConversation.set("allow-conv", true);
+      hostAccessByConversation.set("deny-conv", false);
+
+      const promptSpy = mock(() =>
+        Promise.resolve({ decision: "deny" as const }),
+      );
+      const checker = new PermissionChecker({
+        prompt: promptSpy,
+      } as unknown as PermissionPrompter);
+
+      const allowed = await checker.checkPermission(
+        "host_bash",
+        {},
+        makeTool("host_bash"),
+        makeContext({ conversationId: "allow-conv" }),
+        executionTarget,
+        noopEmit,
+        noopSanitize,
+        Date.now(),
+        noopDiff,
+      );
+      const denied = await checker.checkPermission(
+        "host_bash",
+        {},
+        makeTool("host_bash"),
+        makeContext({ conversationId: "deny-conv" }),
+        executionTarget,
+        noopEmit,
+        noopSanitize,
+        Date.now(),
+        noopDiff,
+      );
+
+      expect(allowed.allowed).toBe(true);
+      expect(allowed.decision).toBe("allow");
+      expect(denied.allowed).toBe(false);
+      expect(denied.decision).toBe("deny");
+      expect(promptSpy).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/assistant/src/__tests__/v2-consent-policy.test.ts
+++ b/assistant/src/__tests__/v2-consent-policy.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { _setOverridesForTesting } from "../config/assistant-feature-flags.js";
+import type { ToolContext } from "../tools/types.js";
+
+const hostAccessByConversation = new Map<string, boolean>();
+
+mock.module("../memory/conversation-crud.js", () => ({
+  getConversationHostAccess: (conversationId: string) =>
+    hostAccessByConversation.get(conversationId) ?? false,
+}));
+
+function makeContext(overrides?: Partial<ToolContext>): ToolContext {
+  return {
+    workingDir: "/tmp/test",
+    conversationId: "test-conv",
+    trustClass: "guardian",
+    isInteractive: true,
+    ...overrides,
+  } as ToolContext;
+}
+
+beforeEach(() => {
+  _setOverridesForTesting({});
+  hostAccessByConversation.clear();
+});
+
+afterEach(() => {
+  _setOverridesForTesting({});
+  hostAccessByConversation.clear();
+});
+
+describe("v2-consent-policy", () => {
+  test("returns legacy when the flag is disabled", async () => {
+    const { evaluateV2ConsentDisposition } =
+      await import("../permissions/v2-consent-policy.js");
+
+    expect(evaluateV2ConsentDisposition("host_bash", {}, makeContext())).toBe(
+      "legacy",
+    );
+  });
+
+  test("auto-allows non-host tools when the flag is enabled", async () => {
+    _setOverridesForTesting({ "permission-controls-v2": true });
+    const { evaluateV2ConsentDisposition } =
+      await import("../permissions/v2-consent-policy.js");
+
+    expect(evaluateV2ConsentDisposition("bash", {}, makeContext())).toBe(
+      "auto_allow",
+    );
+  });
+
+  test("uses conversation-scoped host access when the flag is enabled", async () => {
+    _setOverridesForTesting({ "permission-controls-v2": true });
+    hostAccessByConversation.set("allowed-conv", true);
+    hostAccessByConversation.set("blocked-conv", false);
+    const { evaluateV2ConsentDisposition } =
+      await import("../permissions/v2-consent-policy.js");
+
+    expect(
+      evaluateV2ConsentDisposition(
+        "host_bash",
+        {},
+        makeContext({ conversationId: "allowed-conv" }),
+      ),
+    ).toBe("auto_allow");
+    expect(
+      evaluateV2ConsentDisposition(
+        "host_bash",
+        {},
+        makeContext({ conversationId: "blocked-conv" }),
+      ),
+    ).toBe("prompt_host_access");
+  });
+
+  test("host-access prompts are identified by the stripped-down prompt shape", async () => {
+    _setOverridesForTesting({ "permission-controls-v2": true });
+    const {
+      CONVERSATION_HOST_ACCESS_PROMPT,
+      isConversationHostAccessEnablePrompt,
+    } = await import("../permissions/v2-consent-policy.js");
+
+    expect(
+      isConversationHostAccessEnablePrompt({
+        toolName: "host_bash",
+        ...CONVERSATION_HOST_ACCESS_PROMPT,
+      }),
+    ).toBe(true);
+    expect(
+      isConversationHostAccessEnablePrompt({
+        toolName: "host_bash",
+        ...CONVERSATION_HOST_ACCESS_PROMPT,
+        allowlistOptions: [
+          {
+            label: "Specific command",
+            description: "legacy rule",
+            pattern: "bash:*",
+          },
+        ],
+      }),
+    ).toBe(false);
+  });
+});

--- a/assistant/src/daemon/conversation-attachments.ts
+++ b/assistant/src/daemon/conversation-attachments.ts
@@ -13,6 +13,11 @@ import {
 import type { PermissionPrompter } from "../permissions/prompter.js";
 import { addRule } from "../permissions/trust-store.js";
 import { isAllowDecision } from "../permissions/types.js";
+import {
+  CONVERSATION_HOST_ACCESS_PROMPT,
+  isConversationHostAccessEnabled,
+  isPermissionControlsV2Enabled,
+} from "../permissions/v2-consent-policy.js";
 import type { ContentBlock } from "../providers/types.js";
 import { getLogger } from "../util/logger.js";
 import {
@@ -45,6 +50,41 @@ export async function approveHostAttachmentRead(
 ): Promise<boolean> {
   const toolName = "host_file_read";
   const input = { path: filePath };
+
+  if (isPermissionControlsV2Enabled()) {
+    if (isConversationHostAccessEnabled(conversationId)) {
+      return true;
+    }
+
+    // HTTP-created sessions use a no-op sendToClient — prompting would
+    // block for the full permission timeout before auto-denying.
+    if (hasNoClient) {
+      log.info(
+        { filePath },
+        "Denying host attachment read: no interactive client connected",
+      );
+      return false;
+    }
+
+    const response = await prompter.prompt(
+      toolName,
+      input,
+      "low",
+      CONVERSATION_HOST_ACCESS_PROMPT.allowlistOptions,
+      CONVERSATION_HOST_ACCESS_PROMPT.scopeOptions,
+      undefined,
+      conversationId,
+      "host",
+      CONVERSATION_HOST_ACCESS_PROMPT.persistentDecisionsAllowed,
+      undefined,
+      CONVERSATION_HOST_ACCESS_PROMPT.temporaryOptionsAvailable,
+      undefined,
+      true,
+    );
+
+    return response.decision === "allow";
+  }
+
   const decision = await check(toolName, input, workingDir);
 
   if (decision.decision === "allow") {

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -44,12 +44,20 @@ import {
 import { registerToolTraceListener } from "../events/tool-trace-listener.js";
 import { getHookManager } from "../hooks/manager.js";
 import { resolveCanonicalGuardianRequest } from "../memory/canonical-guardian-store.js";
-import { updateConversationContextWindow } from "../memory/conversation-crud.js";
+import {
+  updateConversationContextWindow,
+  updateConversationHostAccess,
+} from "../memory/conversation-crud.js";
 import { ConversationGraphMemory } from "../memory/graph/conversation-graph-memory.js";
 import { PermissionPrompter } from "../permissions/prompter.js";
 import { SecretPrompter } from "../permissions/secret-prompter.js";
 import { patternMatchesCandidate } from "../permissions/trust-store.js";
 import type { UserDecision } from "../permissions/types.js";
+import {
+  isConversationHostAccessDecision,
+  isConversationHostAccessEnabled,
+  isConversationHostAccessEnablePrompt,
+} from "../permissions/v2-consent-policy.js";
 import { resolvePersonaContext } from "../prompts/persona-resolver.js";
 import { buildSystemPrompt } from "../prompts/system-prompt.js";
 import type { Message } from "../providers/types.js";
@@ -769,12 +777,35 @@ export class Conversation {
       return;
     }
 
+    const hostAccessEnablePrompt =
+      this.prompter.isHostAccessEnablePrompt(requestId) ||
+      isConversationHostAccessEnablePrompt(
+        pendingInteractions.get(requestId)?.confirmationDetails,
+      );
+    const effectiveDecision =
+      hostAccessEnablePrompt && !isConversationHostAccessDecision(decision)
+        ? "deny"
+        : decision;
+
+    if (
+      hostAccessEnablePrompt &&
+      effectiveDecision === "allow" &&
+      !isConversationHostAccessEnabled(this.conversationId)
+    ) {
+      updateConversationHostAccess(this.conversationId, true);
+      this.sendToClient({
+        type: "conversation_host_access_updated",
+        conversationId: this.conversationId,
+        hostAccess: true,
+      });
+    }
+
     // Capture toolUseId before resolving (resolution deletes the pending entry)
     const toolUseId = this.prompter.getToolUseId(requestId);
 
     this.prompter.resolveConfirmation(
       requestId,
-      decision,
+      effectiveDecision,
       selectedPattern,
       selectedScope,
       decisionContext,
@@ -788,7 +819,7 @@ export class Conversation {
     // so ALL callers (HTTP handlers, /v1/confirm, channel bridges) get
     // consistent events without duplicating emission logic.
     const resolvedState =
-      decision === "deny" || decision === "always_deny"
+      effectiveDecision === "deny" || effectiveDecision === "always_deny"
         ? ("denied" as const)
         : ("approved" as const);
     this.emitConfirmationStateChanged({
@@ -832,7 +863,12 @@ export class Conversation {
     }
 
     // Cascade to other pending confirmations that match this decision
-    this.cascadePendingApprovals(requestId, decision, selectedPattern);
+    this.cascadePendingApprovals(
+      requestId,
+      effectiveDecision,
+      selectedPattern,
+      hostAccessEnablePrompt,
+    );
   }
 
   /**
@@ -848,9 +884,14 @@ export class Conversation {
     primaryRequestId: string,
     decision: UserDecision,
     selectedPattern?: string,
+    hostAccessEnablePrompt = false,
   ): void {
     // Single-action decisions don't cascade
-    if (decision === "allow" || decision === "deny") return;
+    if (decision === "allow" || decision === "deny") {
+      if (!hostAccessEnablePrompt || decision !== "allow") {
+        return;
+      }
+    }
 
     const pendingRequestIds = this.prompter.getPendingRequestIds();
     if (pendingRequestIds.length === 0) return;
@@ -862,6 +903,28 @@ export class Conversation {
       if (!interaction) continue;
       if (interaction.conversationId !== this.conversationId) continue;
       if (interaction.kind !== "confirmation") continue;
+
+      if (
+        hostAccessEnablePrompt &&
+        (this.prompter.isHostAccessEnablePrompt(candidateId) ||
+          isConversationHostAccessEnablePrompt(interaction.confirmationDetails))
+      ) {
+        // Enabling computer access is conversation-scoped, so sibling host
+        // prompts should resolve immediately once the first approval lands.
+        pendingInteractions.resolve(candidateId);
+        this.handleConfirmationResponse(
+          candidateId,
+          "allow",
+          undefined,
+          undefined,
+          undefined,
+          {
+            source: "system",
+            causedByRequestId: primaryRequestId,
+          },
+        );
+        continue;
+      }
 
       const cascadeResult = this.shouldCascade(
         decision,

--- a/assistant/src/permissions/prompter.ts
+++ b/assistant/src/permissions/prompter.ts
@@ -20,6 +20,7 @@ interface PendingPrompt {
   reject: (reason: Error) => void;
   timer: ReturnType<typeof setTimeout>;
   toolUseId?: string;
+  hostAccessEnablePrompt?: boolean;
 }
 
 export type ConfirmationStateCallback = (
@@ -64,6 +65,7 @@ export class PermissionPrompter {
     signal?: AbortSignal,
     temporaryOptionsAvailable?: Array<"allow_10m" | "allow_conversation">,
     toolUseId?: string,
+    hostAccessEnablePrompt?: boolean,
   ): Promise<{
     decision: UserDecision;
     selectedPattern?: string;
@@ -89,7 +91,13 @@ export class PermissionPrompter {
         });
       }, timeoutMs);
 
-      this.pending.set(requestId, { resolve, reject, timer, toolUseId });
+      this.pending.set(requestId, {
+        resolve,
+        reject,
+        timer,
+        toolUseId,
+        hostAccessEnablePrompt,
+      });
 
       if (signal) {
         const onAbort = () => {
@@ -141,6 +149,10 @@ export class PermissionPrompter {
   /** Returns the toolUseId associated with a pending request, if any. */
   getToolUseId(requestId: string): string | undefined {
     return this.pending.get(requestId)?.toolUseId;
+  }
+
+  isHostAccessEnablePrompt(requestId: string): boolean {
+    return this.pending.get(requestId)?.hostAccessEnablePrompt === true;
   }
 
   resolveConfirmation(

--- a/assistant/src/permissions/v2-consent-policy.ts
+++ b/assistant/src/permissions/v2-consent-policy.ts
@@ -67,7 +67,7 @@ export function evaluateV2ConsentDisposition(
 export function isConversationHostAccessEnablePrompt(
   details: PromptLike | undefined,
 ): boolean {
-  if (!details || !isPermissionControlsV2Enabled()) {
+  if (!details) {
     return false;
   }
 

--- a/assistant/src/permissions/v2-consent-policy.ts
+++ b/assistant/src/permissions/v2-consent-policy.ts
@@ -1,0 +1,87 @@
+import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
+import { getConfig } from "../config/loader.js";
+import { getConversationHostAccess as loadConversationHostAccess } from "../memory/conversation-crud.js";
+import { isSideEffectTool } from "../tools/side-effects.js";
+import type { ToolContext } from "../tools/types.js";
+import type { AllowlistOption, ScopeOption, UserDecision } from "./types.js";
+import { isHostTool } from "./workspace-policy.js";
+
+export type V2ConsentDisposition =
+  | "legacy"
+  | "auto_allow"
+  | "prompt_host_access";
+
+type PromptLike = {
+  toolName: string;
+  allowlistOptions?: readonly AllowlistOption[];
+  scopeOptions?: readonly ScopeOption[];
+  persistentDecisionsAllowed?: boolean;
+  temporaryOptionsAvailable?: readonly ("allow_10m" | "allow_conversation")[];
+};
+
+export const CONVERSATION_HOST_ACCESS_PROMPT = Object.freeze({
+  allowlistOptions: [] as AllowlistOption[],
+  scopeOptions: [] as ScopeOption[],
+  persistentDecisionsAllowed: false as const,
+  temporaryOptionsAvailable: undefined as
+    | Array<"allow_10m" | "allow_conversation">
+    | undefined,
+});
+
+export function isPermissionControlsV2Enabled(): boolean {
+  return isAssistantFeatureFlagEnabled("permission-controls-v2", getConfig());
+}
+
+export function isConversationHostAccessEnabled(
+  conversationId: string,
+): boolean {
+  return loadConversationHostAccess(conversationId);
+}
+
+export function evaluateV2ConsentDisposition(
+  toolName: string,
+  input: Record<string, unknown>,
+  context: ToolContext,
+): V2ConsentDisposition {
+  if (!isPermissionControlsV2Enabled()) {
+    return "legacy";
+  }
+
+  if (context.requireFreshApproval) {
+    return "legacy";
+  }
+
+  if (context.forcePromptSideEffects && isSideEffectTool(toolName, input)) {
+    return "legacy";
+  }
+
+  if (!isHostTool(toolName)) {
+    return "auto_allow";
+  }
+
+  return loadConversationHostAccess(context.conversationId)
+    ? "auto_allow"
+    : "prompt_host_access";
+}
+
+export function isConversationHostAccessEnablePrompt(
+  details: PromptLike | undefined,
+): boolean {
+  if (!details || !isPermissionControlsV2Enabled()) {
+    return false;
+  }
+
+  return (
+    isHostTool(details.toolName) &&
+    (details.allowlistOptions?.length ?? 0) === 0 &&
+    (details.scopeOptions?.length ?? 0) === 0 &&
+    details.persistentDecisionsAllowed === false &&
+    (details.temporaryOptionsAvailable?.length ?? 0) === 0
+  );
+}
+
+export function isConversationHostAccessDecision(
+  decision: UserDecision,
+): decision is "allow" | "deny" {
+  return decision === "allow" || decision === "deny";
+}

--- a/assistant/src/runtime/routes/approval-routes.ts
+++ b/assistant/src/runtime/routes/approval-routes.ts
@@ -13,6 +13,10 @@ import { z } from "zod";
 import { getConversationByKey } from "../../memory/conversation-key-store.js";
 import { addRule } from "../../permissions/trust-store.js";
 import type { UserDecision } from "../../permissions/types.js";
+import {
+  isConversationHostAccessDecision,
+  isConversationHostAccessEnablePrompt,
+} from "../../permissions/v2-consent-policy.js";
 import { getTool } from "../../tools/registry.js";
 import { getLogger } from "../../util/logger.js";
 import { requireBoundGuardian } from "../auth/require-bound-guardian.js";
@@ -79,6 +83,18 @@ export async function handleConfirm(
       "NOT_FOUND",
       "No pending interaction found for this requestId",
       404,
+    );
+  }
+
+  if (
+    peeked.confirmationDetails &&
+    isConversationHostAccessEnablePrompt(peeked.confirmationDetails) &&
+    !isConversationHostAccessDecision(decision as UserDecision)
+  ) {
+    return httpError(
+      "FORBIDDEN",
+      "Conversation host-access prompts only accept allow or deny",
+      403,
     );
   }
 

--- a/assistant/src/tools/permission-checker.ts
+++ b/assistant/src/tools/permission-checker.ts
@@ -1,7 +1,6 @@
 import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import { getConfig } from "../config/loader.js";
 import { getHookManager } from "../hooks/manager.js";
-import { getConversationHostAccess } from "../memory/conversation-crud.js";
 import {
   check,
   classifyRisk,
@@ -11,7 +10,11 @@ import {
 import type { PermissionPrompter } from "../permissions/prompter.js";
 import { addRule } from "../permissions/trust-store.js";
 import { RiskLevel } from "../permissions/types.js";
-import { isHostTool } from "../permissions/workspace-policy.js";
+import {
+  CONVERSATION_HOST_ACCESS_PROMPT,
+  evaluateV2ConsentDisposition,
+  isConversationHostAccessDecision,
+} from "../permissions/v2-consent-policy.js";
 import {
   getEffectiveMode,
   setConversationMode,
@@ -67,49 +70,25 @@ export class PermissionChecker {
         }
       | undefined,
   ): Promise<PermissionDecision> {
-    // ── permission-controls-v2 early gate ──────────────────────────────
-    // When the v2 flag is enabled, replace the entire risk-classification
-    // path with a simple binary check: is it a host tool + is host access
-    // enabled? Certain security gates (requireFreshApproval,
-    // forcePromptSideEffects, hostAccess=false) fall through to the v1
-    // prompt flow so the interactive prompter is engaged.
-    const cfg = getConfig();
     let v2ForcePrompt = false;
+    const cfg = getConfig();
     if (isAssistantFeatureFlagEnabled("permission-controls-v2", cfg)) {
-      // requireFreshApproval demands an interactive prompt every time —
-      // fall through to v1 so the prompter is engaged.
-      const needsFreshApproval = !!context.requireFreshApproval;
-
-      // forcePromptSideEffects (private conversations, untrusted actors)
-      // requires explicit approval for side-effect tools.
-      const needsSideEffectPrompt =
-        !!context.forcePromptSideEffects && isSideEffectTool(name, input);
-
-      if (!needsFreshApproval && !needsSideEffectPrompt) {
-        if (isHostTool(name)) {
-          if (getConversationHostAccess(context.conversationId)) {
-            return {
-              allowed: true,
-              decision: "allow",
-              riskLevel: RiskLevel.Low,
-            };
-          }
-          // Host tool with hostAccess disabled — fall through to v1 so the
-          // interactive prompter is engaged (returning allowed:false here
-          // would surface an error string instead of a permission dialog).
-          // The v2ForcePrompt flag ensures check()'s allow decision is
-          // promoted to prompt so the user sees a permission dialog.
-          v2ForcePrompt = true;
-        } else {
-          // Non-host tools are auto-allowed when v2 is on
-          return {
-            allowed: true,
-            decision: "allow",
-            riskLevel: RiskLevel.Low,
-          };
-        }
+      const v2Disposition = evaluateV2ConsentDisposition(name, input, context);
+      if (v2Disposition === "auto_allow") {
+        return {
+          allowed: true,
+          decision: "allow",
+          riskLevel: RiskLevel.Low,
+        };
       }
-      // Falls through to the v1 risk-classification + prompter path
+      if (v2Disposition === "prompt_host_access") {
+        // Host tool with hostAccess disabled — fall through to v1 so the
+        // interactive prompter is engaged (returning allowed:false here
+        // would surface an error string instead of a permission dialog).
+        // The v2ForcePrompt flag ensures check()'s allow decision is
+        // promoted to prompt so the user sees a permission dialog.
+        v2ForcePrompt = true;
+      }
     }
 
     const risk = await classifyRisk(
@@ -300,25 +279,25 @@ export class PermissionChecker {
           return { allowed: true, decision: "temporary_override", riskLevel };
         }
 
-        const allowlistOptions = await generateAllowlistOptions(
-          name,
-          input,
-          context.signal,
-        );
-        const scopeOptions = generateScopeOptions(context.workingDir, name);
         const previewDiff = computePreviewDiff(name, input, context.workingDir);
-
-        const persistentDecisionsAllowed = !context.requireFreshApproval;
-
-        // Offer temporary approval options to guardians. Suppressed when
-        // requireFreshApproval is true - temporary overrides would be
-        // misleading since future invocations still require fresh approval.
-        const temporaryOptionsAvailable:
-          | Array<"allow_10m" | "allow_conversation">
-          | undefined =
-          context.trustClass === "guardian" && !context.requireFreshApproval
-            ? ["allow_10m", "allow_conversation"]
-            : undefined;
+        const promptOptions = v2ForcePrompt
+          ? CONVERSATION_HOST_ACCESS_PROMPT
+          : {
+              allowlistOptions: await generateAllowlistOptions(
+                name,
+                input,
+                context.signal,
+              ),
+              scopeOptions: generateScopeOptions(context.workingDir, name),
+              persistentDecisionsAllowed: !context.requireFreshApproval,
+              temporaryOptionsAvailable:
+                context.trustClass === "guardian" &&
+                !context.requireFreshApproval
+                  ? (["allow_10m", "allow_conversation"] as Array<
+                      "allow_10m" | "allow_conversation"
+                    >)
+                  : undefined,
+            };
 
         emitLifecycleEvent({
           type: "permission_prompt",
@@ -330,10 +309,10 @@ export class PermissionChecker {
           requestId: context.requestId,
           riskLevel,
           reason: result.reason,
-          allowlistOptions,
-          scopeOptions,
+          allowlistOptions: promptOptions.allowlistOptions,
+          scopeOptions: promptOptions.scopeOptions,
           diff: previewDiff,
-          persistentDecisionsAllowed,
+          persistentDecisionsAllowed: promptOptions.persistentDecisionsAllowed,
         });
 
         await getHookManager().trigger("permission-request", {
@@ -347,22 +326,26 @@ export class PermissionChecker {
           name,
           input,
           riskLevel,
-          allowlistOptions,
-          scopeOptions,
+          promptOptions.allowlistOptions,
+          promptOptions.scopeOptions,
           previewDiff,
           context.conversationId,
           executionTarget,
-          persistentDecisionsAllowed,
+          promptOptions.persistentDecisionsAllowed,
           context.signal,
-          temporaryOptionsAvailable,
+          promptOptions.temporaryOptionsAvailable,
           context.toolUseId,
+          v2ForcePrompt,
         );
 
-        const decision = response.decision;
+        const decision =
+          v2ForcePrompt && !isConversationHostAccessDecision(response.decision)
+            ? "deny"
+            : response.decision;
 
         await getHookManager().trigger("permission-resolve", {
           toolName: name,
-          decision: response.decision,
+          decision,
           riskLevel,
           conversationId: context.conversationId,
         });
@@ -406,11 +389,11 @@ export class PermissionChecker {
           // For non-scoped tools (empty scopeOptions), default to 'everywhere' since
           // the client has no scope picker and will send undefined.
           const effectiveDenyScope =
-            scopeOptions.length === 0
+            promptOptions.scopeOptions.length === 0
               ? (response.selectedScope ?? "everywhere")
               : response.selectedScope;
           const ruleSaved = !!(
-            persistentDecisionsAllowed &&
+            promptOptions.persistentDecisionsAllowed &&
             response.selectedPattern &&
             effectiveDenyScope
           );
@@ -451,9 +434,9 @@ export class PermissionChecker {
         }
 
         if (
-          persistentDecisionsAllowed &&
-          (response.decision === "always_allow" ||
-            response.decision === "always_allow_high_risk") &&
+          promptOptions.persistentDecisionsAllowed &&
+          (decision === "always_allow" ||
+            decision === "always_allow_high_risk") &&
           response.selectedPattern
         ) {
           const ruleOptions: {
@@ -461,7 +444,7 @@ export class PermissionChecker {
             executionTarget?: string;
           } = {};
 
-          if (response.decision === "always_allow_high_risk") {
+          if (decision === "always_allow_high_risk") {
             ruleOptions.allowHighRisk = true;
           }
 
@@ -473,7 +456,7 @@ export class PermissionChecker {
           // Only default to 'everywhere' for non-scoped tools (empty scopeOptions).
           // For scoped tools, require an explicit scope to prevent silent permission widening.
           const effectiveScope =
-            scopeOptions.length === 0
+            promptOptions.scopeOptions.length === 0
               ? (response.selectedScope ?? "everywhere")
               : response.selectedScope;
           if (effectiveScope) {
@@ -492,13 +475,13 @@ export class PermissionChecker {
         // time-limited or conversation-scoped override. Subsequent tool
         // invocations in this conversation will auto-approve without
         // prompting (checked above in the temporary override block).
-        if (response.decision === "allow_10m") {
+        if (decision === "allow_10m") {
           setTimedMode(context.conversationId);
           log.info(
             { toolName: name, conversationId: context.conversationId },
             "Activated timed (10m) temporary approval mode",
           );
-        } else if (response.decision === "allow_conversation") {
+        } else if (decision === "allow_conversation") {
           setConversationMode(context.conversationId);
           log.info(
             { toolName: name, conversationId: context.conversationId },


### PR DESCRIPTION
## Summary
- add a shared v2 consent policy helper so host-target tools collapse to a single conversation host-access gate
- strip legacy persistent and temporal approval affordances from v2 host prompts and reject non-allow/deny HTTP decisions for those prompts
- add focused coverage for v2 host gating across permission checking, host attachments, queue handling, and approval routes

## Testing
- `cd assistant && bunx tsc --noEmit`
- `cd assistant && bun test src/__tests__/v2-consent-policy.test.ts`
- `cd assistant && bun test src/__tests__/permission-checker-host-gate.test.ts`
- `cd assistant && bun test src/__tests__/conversation-attachments.test.ts`
- `cd assistant && bun test src/__tests__/conversation-queue.test.ts`
- `cd assistant && bun test src/__tests__/approval-routes-http.test.ts`
- `cd assistant && bun test src/__tests__/conversation-confirmation-signals.test.ts`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24485" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
