### PR TITLE
Suppress non-host approval cards under v2

### DIFF
--- a/assistant/src/__tests__/acp-session.test.ts
+++ b/assistant/src/__tests__/acp-session.test.ts
@@ -253,6 +253,25 @@ describe("VellumAcpClientHandler", () => {
       expect(handler.pendingRequestIds.size).toBe(0);
     });
 
+    test("suppresses ACP confirmation UI under v2 and cancels when no reject option exists", async () => {
+      _setOverridesForTesting({ "permission-controls-v2": true });
+
+      const result = await handler.requestPermission({
+        toolCall: {
+          title: "Read file",
+          kind: "read",
+          rawInput: "/tmp/example.txt",
+        },
+        options: [{ optionId: "allow", name: "Allow", kind: "allow_once" }],
+      } as any);
+
+      expect(result).toEqual({
+        outcome: { outcome: "cancelled" },
+      });
+      expect(sent).toHaveLength(0);
+      expect(handler.pendingRequestIds.size).toBe(0);
+    });
+
     test("ACP registration survives sendToVellum overwrite (makeEventSender race)", async () => {
       // Simulate makeEventSender: when sendToVellum is called with a
       // confirmation_request, it overwrites the pendingInteractions entry

--- a/assistant/src/__tests__/acp-session.test.ts
+++ b/assistant/src/__tests__/acp-session.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { VellumAcpClientHandler } from "../acp/client-handler.js";
 import { AcpSessionManager } from "../acp/session-manager.js";
+import { _setOverridesForTesting } from "../config/assistant-feature-flags.js";
 import type { ServerMessage } from "../daemon/message-protocol.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 
@@ -15,6 +16,7 @@ describe("VellumAcpClientHandler", () => {
   let handler: VellumAcpClientHandler;
 
   beforeEach(() => {
+    _setOverridesForTesting({});
     sent = [];
     sendToVellum = (msg) => sent.push(msg);
     handler = new VellumAcpClientHandler(
@@ -227,6 +229,28 @@ describe("VellumAcpClientHandler", () => {
 
       const msg = sent[0] as any;
       expect(msg.riskLevel).toBe("medium");
+    });
+
+    test("suppresses ACP confirmation UI under v2 and chooses the reject option", async () => {
+      _setOverridesForTesting({ "permission-controls-v2": true });
+
+      const result = await handler.requestPermission({
+        toolCall: {
+          title: "Read file",
+          kind: "read",
+          rawInput: "/tmp/example.txt",
+        },
+        options: [
+          { optionId: "allow", name: "Allow", kind: "allow_once" },
+          { optionId: "deny", name: "Deny", kind: "reject_once" },
+        ],
+      } as any);
+
+      expect(result).toEqual({
+        outcome: { outcome: "selected", optionId: "deny" },
+      });
+      expect(sent).toHaveLength(0);
+      expect(handler.pendingRequestIds.size).toBe(0);
     });
 
     test("ACP registration survives sendToVellum overwrite (makeEventSender race)", async () => {

--- a/assistant/src/__tests__/context-overflow-approval.test.ts
+++ b/assistant/src/__tests__/context-overflow-approval.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { _setOverridesForTesting } from "../config/assistant-feature-flags.js";
 import {
   CONTEXT_OVERFLOW_TOOL_NAME,
   requestCompressionApproval,
@@ -20,7 +21,21 @@ function createMockPrompter(decision: UserDecision): PermissionPrompter {
 }
 
 describe("requestCompressionApproval", () => {
+  beforeEach(() => {
+    _setOverridesForTesting({});
+  });
+
   // ── Prompt shape ──
+
+  test("auto-approves without prompting under v2", async () => {
+    _setOverridesForTesting({ "permission-controls-v2": true });
+
+    const prompter = createMockPrompter("deny");
+    const result = await requestCompressionApproval(prompter);
+
+    expect(result).toEqual({ approved: true });
+    expect(prompter.prompt).not.toHaveBeenCalled();
+  });
 
   test("uses the reserved pseudo tool name", async () => {
     const prompter = createMockPrompter("allow");

--- a/assistant/src/__tests__/credential-execution-approval-bridge.test.ts
+++ b/assistant/src/__tests__/credential-execution-approval-bridge.test.ts
@@ -12,7 +12,7 @@
  * 7. Error handling: record_grant RPC failure returns error outcome.
  */
 
-import { describe, expect, test } from "bun:test";
+import { beforeEach, describe, expect, test } from "bun:test";
 
 import type {
   ApprovalRequired,
@@ -22,6 +22,7 @@ import type {
   RecordGrantResponse,
 } from "@vellumai/ces-contracts";
 
+import { _setOverridesForTesting } from "../config/assistant-feature-flags.js";
 import { bridgeCesApproval } from "../credential-execution/approval-bridge.js";
 import type { CesClient } from "../credential-execution/client.js";
 import type { PermissionPrompter } from "../permissions/prompter.js";
@@ -166,6 +167,31 @@ function makeCesClient(
 // ---------------------------------------------------------------------------
 
 describe("CES approval bridge", () => {
+  beforeEach(() => {
+    _setOverridesForTesting({});
+  });
+
+  test("suppresses deterministic CES approval prompts under v2", async () => {
+    _setOverridesForTesting({ "permission-controls-v2": true });
+
+    const prompter = makePrompter("allow");
+    const cesClient = makeCesClient();
+
+    const result = await bridgeCesApproval(
+      makeApprovalRequired(),
+      prompter,
+      cesClient,
+      { isInteractive: true, conversationId: "session-1" },
+    );
+
+    expect(result.outcome).toBe("denied");
+    if (result.outcome === "denied") {
+      expect(result.userDecision).toBe("deny");
+    }
+    expect(prompter.promptCalls).toHaveLength(0);
+    expect(cesClient.recordGrantCalls).toHaveLength(0);
+  });
+
   describe("single-use approval", () => {
     test("allow decision commits grant to CES and returns grantId", async () => {
       const prompter = makePrompter("allow");

--- a/assistant/src/__tests__/proxy-approval-callback.test.ts
+++ b/assistant/src/__tests__/proxy-approval-callback.test.ts
@@ -114,7 +114,7 @@ describe("createProxyApprovalCallback", () => {
     _setOverridesForTesting({});
   });
 
-  test("suppresses network approval cards under v2 and returns false", async () => {
+  test("suppresses network approval cards under v2 and auto-allows", async () => {
     _setOverridesForTesting({ "permission-controls-v2": true });
 
     const ctx = makeContext();
@@ -124,7 +124,7 @@ describe("createProxyApprovalCallback", () => {
     const callback = createProxyApprovalCallback(prompter, ctx);
     const result = await callback(makeAskMissingCredentialRequest());
 
-    expect(result).toBe(false);
+    expect(result).toBe(true);
     expect(prompterSendToClient).not.toHaveBeenCalled();
     expect(findHighestPriorityRuleMock).not.toHaveBeenCalled();
     expect(addRuleMock).not.toHaveBeenCalled();

--- a/assistant/src/__tests__/proxy-approval-callback.test.ts
+++ b/assistant/src/__tests__/proxy-approval-callback.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { _setOverridesForTesting } from "../config/assistant-feature-flags.js";
 import type { ProxyApprovalRequest } from "../outbound-proxy/index.js";
 
 // ---------------------------------------------------------------------------
@@ -110,6 +111,23 @@ describe("createProxyApprovalCallback", () => {
     addRuleMock.mockClear();
     findHighestPriorityRuleMock.mockClear();
     findHighestPriorityRuleMock.mockReturnValue(null);
+    _setOverridesForTesting({});
+  });
+
+  test("suppresses network approval cards under v2 and returns false", async () => {
+    _setOverridesForTesting({ "permission-controls-v2": true });
+
+    const ctx = makeContext();
+    const prompterSendToClient = mock(() => {});
+    const prompter = new PermissionPrompter(prompterSendToClient);
+
+    const callback = createProxyApprovalCallback(prompter, ctx);
+    const result = await callback(makeAskMissingCredentialRequest());
+
+    expect(result).toBe(false);
+    expect(prompterSendToClient).not.toHaveBeenCalled();
+    expect(findHighestPriorityRuleMock).not.toHaveBeenCalled();
+    expect(addRuleMock).not.toHaveBeenCalled();
   });
 
   test("returns true when user allows an ask_missing_credential request", async () => {

--- a/assistant/src/__tests__/secret-detection-handler.test.ts
+++ b/assistant/src/__tests__/secret-detection-handler.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { _setOverridesForTesting } from "../config/assistant-feature-flags.js";
+
+const triggerMock = mock(async () => {});
+const scanTextMock = mock(() => [
+  { type: "api_key", redactedValue: "sk-***redacted***" },
+]);
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    secretDetection: {
+      enabled: true,
+      action: "prompt",
+      entropyThreshold: 4.5,
+      customPatterns: [],
+    },
+  }),
+}));
+
+mock.module("../hooks/manager.js", () => ({
+  getHookManager: () => ({
+    trigger: triggerMock,
+  }),
+}));
+
+mock.module("../security/secret-scanner.js", () => ({
+  compileCustomPatterns: () => [],
+  redactSecrets: (content: string) => content,
+  scanText: scanTextMock,
+}));
+
+import { SecretDetectionHandler } from "../tools/secret-detection-handler.js";
+
+describe("SecretDetectionHandler under v2", () => {
+  beforeEach(() => {
+    _setOverridesForTesting({});
+    triggerMock.mockClear();
+    scanTextMock.mockClear();
+  });
+
+  test("blocks secret output without opening a deterministic approval prompt", async () => {
+    _setOverridesForTesting({ "permission-controls-v2": true });
+
+    const promptMock = mock(async () => ({ decision: "allow" as const }));
+    const handler = new SecretDetectionHandler({
+      prompt: promptMock,
+    } as never);
+    const emitLifecycleEvent = mock(() => {});
+
+    const result = await handler.handle(
+      { content: "secret output", isError: false },
+      "bash",
+      { command: "print-secret" },
+      {
+        conversationId: "conv-1",
+        workingDir: "/tmp",
+        requestId: "req-1",
+        isInteractive: true,
+      } as never,
+      "sandbox",
+      "medium",
+      "allow",
+      Date.now(),
+      emitLifecycleEvent,
+      (_toolName, input) => input,
+    );
+
+    expect(result.earlyReturn).toBe(true);
+    expect(result.result.isError).toBe(true);
+    expect(result.result.content).toContain(
+      "Secret-output approval cards are disabled under v2",
+    );
+    expect(promptMock).not.toHaveBeenCalled();
+    expect(emitLifecycleEvent).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        type: "permission_denied",
+        decision: "deny",
+      }),
+    );
+    expect(triggerMock).toHaveBeenCalled();
+  });
+});

--- a/assistant/src/acp/client-handler.ts
+++ b/assistant/src/acp/client-handler.ts
@@ -32,6 +32,7 @@ import type {
 
 import type { ServerMessage } from "../daemon/message-protocol.js";
 import type { UserDecision } from "../permissions/types.js";
+import { isPermissionControlsV2Enabled } from "../permissions/v2-consent-policy.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 import { getLogger } from "../util/logger.js";
 
@@ -183,6 +184,15 @@ export class VellumAcpClientHandler implements Client {
       name: opt.name,
       kind: opt.kind,
     }));
+
+    if (isPermissionControlsV2Enabled()) {
+      return {
+        outcome: {
+          outcome: "selected",
+          optionId: mapDecisionToOptionId("deny", options),
+        },
+      };
+    }
 
     // Send the confirmation_request first — this triggers makeEventSender
     // which registers a normal "confirmation" entry in pendingInteractions.

--- a/assistant/src/acp/client-handler.ts
+++ b/assistant/src/acp/client-handler.ts
@@ -186,11 +186,11 @@ export class VellumAcpClientHandler implements Client {
     }));
 
     if (isPermissionControlsV2Enabled()) {
+      const rejectOptionId = findRejectOptionId(options);
       return {
-        outcome: {
-          outcome: "selected",
-          optionId: mapDecisionToOptionId("deny", options),
-        },
+        outcome: rejectOptionId
+          ? { outcome: "selected", optionId: rejectOptionId }
+          : { outcome: "cancelled" },
       };
     }
 
@@ -432,13 +432,20 @@ function mapDecisionToOptionId(
     const alwaysDeny = options.find((o) => o.kind === "reject_always");
     if (alwaysDeny) return alwaysDeny.optionId;
   }
-  const denyOpt =
-    options.find((o) => o.kind === "reject_once") ??
-    options.find((o) => o.kind === "reject_always");
-  if (denyOpt) return denyOpt.optionId;
+  const denyOpt = findRejectOptionId(options);
+  if (denyOpt) return denyOpt;
 
   // Fallback: return first option
   return options[0]?.optionId ?? "deny";
+}
+
+function findRejectOptionId(
+  options: Array<{ optionId: string; kind: string }>,
+): string | undefined {
+  return (
+    options.find((o) => o.kind === "reject_once")?.optionId ??
+    options.find((o) => o.kind === "reject_always")?.optionId
+  );
 }
 
 /**

--- a/assistant/src/credential-execution/approval-bridge.ts
+++ b/assistant/src/credential-execution/approval-bridge.ts
@@ -21,6 +21,7 @@ import type {
 
 import type { PermissionPrompter } from "../permissions/prompter.js";
 import type { UserDecision } from "../permissions/types.js";
+import { isPermissionControlsV2Enabled } from "../permissions/v2-consent-policy.js";
 import { getLogger } from "../util/logger.js";
 import type { CesClient } from "./client.js";
 
@@ -190,6 +191,18 @@ export async function bridgeCesApproval(
         sessionId,
       },
       "CES approval request denied: non-interactive session",
+    );
+    return { outcome: "denied", userDecision: "deny" };
+  }
+
+  if (isPermissionControlsV2Enabled()) {
+    log.info(
+      {
+        event: "ces_approval_bridge_v2_suppressed",
+        proposalHash,
+        sessionId,
+      },
+      "CES approval request denied without deterministic prompt under v2",
     );
     return { outcome: "denied", userDecision: "deny" };
   }

--- a/assistant/src/daemon/context-overflow-approval.ts
+++ b/assistant/src/daemon/context-overflow-approval.ts
@@ -1,5 +1,6 @@
 import type { PermissionPrompter } from "../permissions/prompter.js";
 import { isAllowDecision } from "../permissions/types.js";
+import { isPermissionControlsV2Enabled } from "../permissions/v2-consent-policy.js";
 
 /**
  * Reserved pseudo tool name used for context overflow compression approval
@@ -26,6 +27,10 @@ export async function requestCompressionApproval(
   prompter: PermissionPrompter,
   opts?: { signal?: AbortSignal },
 ): Promise<CompressionApprovalResult> {
+  if (isPermissionControlsV2Enabled()) {
+    return { approved: true };
+  }
+
   const result = await prompter.prompt(
     CONTEXT_OVERFLOW_TOOL_NAME,
     {

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -322,7 +322,10 @@ export function createProxyApprovalCallback(
     const url = `${scheme}://${hostname}${port ? ":" + port : ""}${path}`;
 
     if (isPermissionControlsV2Enabled()) {
-      return false;
+      // Under v2 we suppress deterministic network approval cards entirely.
+      // Proxied asks should follow the same non-host auto-allow contract as
+      // regular network_request invocations instead of turning into hard blocks.
+      return true;
     }
 
     const input: Record<string, unknown> = {

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -27,6 +27,7 @@ import {
   findHighestPriorityRule,
 } from "../permissions/trust-store.js";
 import { isAllowDecision } from "../permissions/types.js";
+import { isPermissionControlsV2Enabled } from "../permissions/v2-consent-policy.js";
 import type { Message, ToolDefinition } from "../providers/types.js";
 import type { TrustClass } from "../runtime/actor-trust-resolver.js";
 import { coreAppProxyTools } from "../tools/apps/definitions.js";
@@ -319,6 +320,10 @@ export function createProxyApprovalCallback(
     const toolName = "network_request";
     const { scheme } = decision.target;
     const url = `${scheme}://${hostname}${port ? ":" + port : ""}${path}`;
+
+    if (isPermissionControlsV2Enabled()) {
+      return false;
+    }
 
     const input: Record<string, unknown> = {
       url,

--- a/assistant/src/tools/secret-detection-handler.ts
+++ b/assistant/src/tools/secret-detection-handler.ts
@@ -2,6 +2,7 @@ import { getConfig } from "../config/loader.js";
 import { getHookManager } from "../hooks/manager.js";
 import { PermissionPrompter } from "../permissions/prompter.js";
 import { RiskLevel } from "../permissions/types.js";
+import { isPermissionControlsV2Enabled } from "../permissions/v2-consent-policy.js";
 import type { SecretPattern } from "../security/secret-scanner.js";
 import {
   compileCustomPatterns,
@@ -268,6 +269,39 @@ export class SecretDetectionHandler {
     ) => Record<string, unknown>,
   ): Promise<{ result: ToolExecutionResult; earlyReturn: boolean }> {
     const types = [...new Set(allMatches.map((m) => m.type))].join(", ");
+
+    if (isPermissionControlsV2Enabled()) {
+      const blockedContent = `Tool output blocked: detected ${allMatches.length} potential secret(s) (${types}). Secret-output approval cards are disabled under v2. Ask the user for confirmation conversationally before retrying.`;
+      const durationMs = Date.now() - startTime;
+
+      emitLifecycleEvent(context, {
+        type: "permission_denied",
+        toolName: name,
+        executionTarget,
+        input,
+        workingDir: context.workingDir,
+        conversationId: context.conversationId,
+        requestId: context.requestId,
+        riskLevel: RiskLevel.High,
+        decision: "deny",
+        reason: "Secret output blocked without deterministic prompt under v2",
+        durationMs,
+      });
+
+      void getHookManager().trigger("post-tool-execute", {
+        toolName: name,
+        input: sanitizeToolInput(name, input),
+        riskLevel,
+        isError: true,
+        durationMs,
+        conversationId: context.conversationId,
+      });
+
+      return {
+        result: { content: blockedContent, isError: true },
+        earlyReturn: true,
+      };
+    }
 
     // Non-interactive sessions: auto-block secret output instead of waiting for prompt
     if (context.isInteractive === false) {


### PR DESCRIPTION
## Summary
- suppress non-host deterministic approval cards under v2 for proxied network approvals, CES approval bridging, ACP permission requests, and secret-output prompting
- treat context-overflow compression as an internal recovery path under v2 and auto-approve it instead of surfacing a card
- add focused regression coverage for each v2-suppressed approval path

## Testing
- `cd assistant && bunx tsc --noEmit`
- `cd assistant && bun test src/__tests__/proxy-approval-callback.test.ts`
- `cd assistant && bun test src/__tests__/credential-execution-approval-bridge.test.ts`
- `cd assistant && bun test src/__tests__/context-overflow-approval.test.ts`
- `cd assistant && bun test src/__tests__/acp-session.test.ts`
- `cd assistant && bun test src/__tests__/secret-detection-handler.test.ts`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24486" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
