### PR TITLE
refactor(browser-session): integrate BrowserSessionManager as CDP backend selector (PR7)

### DIFF
--- a/assistant/src/browser-session/__tests__/manager.test.ts
+++ b/assistant/src/browser-session/__tests__/manager.test.ts
@@ -6,6 +6,7 @@ import {
   type CdpCommand,
   type CdpResult,
   createExtensionBackend,
+  createLocalBackend,
 } from "../index.js";
 
 interface MockBackendState {
@@ -24,6 +25,21 @@ function createMockExtensionBackend(state: MockBackendState): BrowserBackend {
       state.lastSignal = signal;
       if (state.sendImpl) return state.sendImpl(command, signal);
       return { result: { ok: true } };
+    },
+    dispose: () => {
+      state.disposed = true;
+    },
+  });
+}
+
+function createMockLocalBackend(state: MockBackendState): BrowserBackend {
+  return createLocalBackend({
+    isAvailable: () => state.available,
+    sendCdp: async (command, signal) => {
+      state.lastCommand = command;
+      state.lastSignal = signal;
+      if (state.sendImpl) return state.sendImpl(command, signal);
+      return { result: { ok: true, kind: "local" } };
     },
     dispose: () => {
       state.disposed = true;
@@ -166,5 +182,116 @@ describe("BrowserSessionManager", () => {
       manager.send(session.id, { method: "Browser.getVersion" }),
     ).rejects.toThrow(`Unknown browser session: ${session.id}`);
     expect(state.lastCommand).toBeUndefined();
+  });
+
+  test("selectBackend returns a local backend when it is the only registration", () => {
+    const state: MockBackendState = { available: true, disposed: false };
+    const backend = createMockLocalBackend(state);
+    const manager = new BrowserSessionManager({ backends: [backend] });
+    const selected = manager.selectBackend();
+    expect(selected.kind).toBe("local");
+    expect(selected).toBe(backend);
+  });
+
+  test("createSession tags sessions with the local backend kind", () => {
+    const state: MockBackendState = { available: true, disposed: false };
+    const manager = new BrowserSessionManager({
+      backends: [createMockLocalBackend(state)],
+    });
+    const session = manager.createSession();
+    expect(session.backendKind).toBe("local");
+  });
+
+  test("send routes through local backend when its session is used", async () => {
+    const state: MockBackendState = { available: true, disposed: false };
+    const manager = new BrowserSessionManager({
+      backends: [createMockLocalBackend(state)],
+    });
+    const session = manager.createSession();
+    const result = await manager.send(session.id, {
+      method: "Runtime.evaluate",
+      params: { expression: "1+1" },
+    });
+    expect(result).toEqual({ result: { ok: true, kind: "local" } });
+    expect(state.lastCommand).toEqual({
+      method: "Runtime.evaluate",
+      params: { expression: "1+1" },
+    });
+  });
+
+  test("selectBackend falls back to the first available backend when earlier ones are unavailable", () => {
+    const extState: MockBackendState = { available: false, disposed: false };
+    const localState: MockBackendState = { available: true, disposed: false };
+    const ext = createMockExtensionBackend(extState);
+    const local = createMockLocalBackend(localState);
+    const manager = new BrowserSessionManager({ backends: [ext, local] });
+    const selected = manager.selectBackend();
+    expect(selected.kind).toBe("local");
+    expect(selected).toBe(local);
+  });
+
+  test("selectBackend prefers the first available backend", () => {
+    const extState: MockBackendState = { available: true, disposed: false };
+    const localState: MockBackendState = { available: true, disposed: false };
+    const ext = createMockExtensionBackend(extState);
+    const local = createMockLocalBackend(localState);
+    const manager = new BrowserSessionManager({ backends: [ext, local] });
+    const selected = manager.selectBackend();
+    expect(selected.kind).toBe("extension");
+    expect(selected).toBe(ext);
+  });
+
+  test("send routes to the backend matching the session's backendKind when multiple backends are registered", async () => {
+    const extState: MockBackendState = {
+      available: true,
+      disposed: false,
+      sendImpl: async () => ({ result: { from: "extension" } }),
+    };
+    const localState: MockBackendState = {
+      available: true,
+      disposed: false,
+      sendImpl: async () => ({ result: { from: "local" } }),
+    };
+    const ext = createMockExtensionBackend(extState);
+    const local = createMockLocalBackend(localState);
+    const manager = new BrowserSessionManager({ backends: [ext, local] });
+
+    // createSession picks the first available backend (extension), but we
+    // can also force the local one by passing a backendKind via direct
+    // session construction. To keep this test self-contained we verify the
+    // default path and then mark the extension unavailable to force the
+    // local backend for a new session.
+    const extSession = manager.createSession();
+    expect(extSession.backendKind).toBe("extension");
+    const extResult = await manager.send(extSession.id, {
+      method: "Browser.getVersion",
+    });
+    expect(extResult).toEqual({ result: { from: "extension" } });
+    expect(extState.lastCommand).toEqual({ method: "Browser.getVersion" });
+    expect(localState.lastCommand).toBeUndefined();
+
+    extState.available = false;
+    const localSession = manager.createSession();
+    expect(localSession.backendKind).toBe("local");
+    const localResult = await manager.send(localSession.id, {
+      method: "Runtime.evaluate",
+    });
+    expect(localResult).toEqual({ result: { from: "local" } });
+    expect(localState.lastCommand).toEqual({ method: "Runtime.evaluate" });
+  });
+
+  test("disposeAll disposes every registered backend", () => {
+    const extState: MockBackendState = { available: true, disposed: false };
+    const localState: MockBackendState = { available: true, disposed: false };
+    const manager = new BrowserSessionManager({
+      backends: [
+        createMockExtensionBackend(extState),
+        createMockLocalBackend(localState),
+      ],
+    });
+    manager.createSession();
+    manager.disposeAll();
+    expect(extState.disposed).toBe(true);
+    expect(localState.disposed).toBe(true);
   });
 });

--- a/assistant/src/browser-session/backends/extension.ts
+++ b/assistant/src/browser-session/backends/extension.ts
@@ -1,10 +1,11 @@
 import type { BrowserBackend, CdpCommand, CdpResult } from "../types.js";
 
 /**
- * Extension backend stub. Phase 2 Wave 2 will wire this to the runtime's
- * chrome-extension WebSocket connection registry. For now this is a pure
- * interface implementation so BrowserSessionManager and its tests can be
- * written without depending on runtime internals.
+ * Extension backend for BrowserSessionManager. Wraps a caller-provided
+ * `sendCdp` transport that routes CDP commands through the daemon's
+ * HostBrowserProxy to an attached chrome extension. The factory in
+ * `assistant/src/tools/browser/cdp-client/factory.ts` constructs one
+ * per tool invocation using the conversation's `hostBrowserProxy`.
  */
 export interface ExtensionBackendDeps {
   /** Sends a CDP command to an attached chrome extension and returns the CDP result. */

--- a/assistant/src/browser-session/backends/local.ts
+++ b/assistant/src/browser-session/backends/local.ts
@@ -1,0 +1,24 @@
+import type { BrowserBackend, CdpCommand, CdpResult } from "../types.js";
+
+/**
+ * Local backend for BrowserSessionManager. Wraps a caller-provided
+ * `sendCdp` transport that drives a Playwright CDPSession against the
+ * sacrificial-profile Chromium managed by `browserManager`. The factory
+ * in `assistant/src/tools/browser/cdp-client/factory.ts` constructs one
+ * per tool invocation using the per-conversation LocalCdpClient.
+ */
+export interface LocalBackendDeps {
+  /** Sends a CDP command to a Playwright CDPSession and returns the CDP result. */
+  sendCdp(command: CdpCommand, signal?: AbortSignal): Promise<CdpResult>;
+  isAvailable(): boolean;
+  dispose(): void;
+}
+
+export function createLocalBackend(deps: LocalBackendDeps): BrowserBackend {
+  return {
+    kind: "local",
+    isAvailable: deps.isAvailable,
+    send: deps.sendCdp,
+    dispose: deps.dispose,
+  };
+}

--- a/assistant/src/browser-session/index.ts
+++ b/assistant/src/browser-session/index.ts
@@ -1,19 +1,15 @@
 /**
  * BrowserSessionManager — multi-backend session router for host_browser.
  *
- * Phase 2 hand-off: this module has no production consumers yet. The
- * `extension` backend is wired structurally so the daemon's HostBrowserProxy
- * can delegate to it in Phase 3. Phase 3 will:
- *   1. Migrate `assistant/src/tools/browser/browser-execution.ts` to call
- *      `BrowserSessionManager.send()` instead of the legacy `browserManager`
- *      sacrificial-profile path.
- *   2. Add a Playwright backend for cloud-runtime headless sessions (Phase 5).
- *
- * Until Phase 3 lands, the only consumers are the unit tests in
- * `__tests__/manager.test.ts`.
- *
- * See `docs/browser-use-architecture-phase2.md` for the full hand-off context.
+ * This module is the single CDP backend selector for browser tools. The
+ * `cdp-client` factory (`assistant/src/tools/browser/cdp-client/factory.ts`)
+ * constructs a BrowserSessionManager per tool invocation, registers the
+ * appropriate backend (extension when `hostBrowserProxy` is present, local
+ * Playwright-backed backend otherwise), and exposes a `ScopedCdpClient` that
+ * routes `send()` through the manager. This gives every call site a single
+ * choke point for session invalidation and future multi-tab routing.
  */
 export * from "./backends/extension.js";
+export * from "./backends/local.js";
 export * from "./manager.js";
 export * from "./types.js";

--- a/assistant/src/browser-session/manager.ts
+++ b/assistant/src/browser-session/manager.ts
@@ -8,7 +8,7 @@ import type {
 } from "./types.js";
 
 export interface BrowserSessionManagerOptions {
-  /** Ordered list of backends to try; first available wins. Phase 2 only has extension. */
+  /** Ordered list of backends to try; first available wins. */
   backends: BrowserBackend[];
 }
 
@@ -44,12 +44,11 @@ export class BrowserSessionManager {
    * - If `sessionId` is provided, the session must exist in the manager; otherwise this throws.
    *   The command is routed through the backend whose `kind` matches the session's `backendKind`,
    *   ensuring per-session backend isolation and making `disposeSession()` an actual enforcement
-   *   boundary against stale ids.
-   * - If `sessionId` is `undefined`, the first available backend is selected (legacy advisory
-   *   behavior used for one-off commands without a session handle).
-   *
-   * Phase 2 only has the extension backend so routing is effectively a no-op, but Phase 4 will
-   * rely on this contract once multi-backend / multi-tab multiplexing lands.
+   *   boundary against stale ids. If the session has an opaque `targetId` and the command does
+   *   not already carry its own CDP `sessionId`, the manager injects the session's `targetId`
+   *   as the CDP `sessionId` so backends can multiplex commands across multiple tabs/targets.
+   * - If `sessionId` is `undefined`, the first available backend is selected for one-off
+   *   commands without a session handle (e.g. transport health probes).
    */
   async send(
     sessionId: string | undefined,
@@ -57,6 +56,7 @@ export class BrowserSessionManager {
     signal?: AbortSignal,
   ): Promise<CdpResult> {
     let backend: BrowserBackend;
+    let outgoing = command;
     if (sessionId !== undefined) {
       const session = this.sessions.get(sessionId);
       if (!session) {
@@ -69,10 +69,18 @@ export class BrowserSessionManager {
         );
       }
       backend = matched;
+      // If the session has an opaque targetId and the command does not
+      // carry its own CDP sessionId, inject the session's targetId as
+      // the CDP sessionId. Backends that support multi-target routing
+      // will forward it; backends that ignore it will treat the call
+      // as "most-recent-tab" as before.
+      if (session.targetId !== undefined && command.sessionId === undefined) {
+        outgoing = { ...command, sessionId: session.targetId };
+      }
     } else {
       backend = this.selectBackend();
     }
-    return backend.send(command, signal);
+    return backend.send(outgoing, signal);
   }
 
   disposeSession(id: string): void {

--- a/assistant/src/browser-session/types.ts
+++ b/assistant/src/browser-session/types.ts
@@ -1,4 +1,4 @@
-export type BrowserBackendKind = "extension"; // Phase 4/5 will add "cdp-inspect", "playwright".
+export type BrowserBackendKind = "extension" | "local";
 
 export interface CdpCommand {
   method: string;

--- a/assistant/src/tools/browser/cdp-client/__tests__/factory.test.ts
+++ b/assistant/src/tools/browser/cdp-client/__tests__/factory.test.ts
@@ -2,22 +2,49 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { HostBrowserProxy } from "../../../../daemon/host-browser-proxy.js";
 import type { ToolContext } from "../../../types.js";
+import { CdpError } from "../errors.js";
+
+type FakeClient = {
+  kind: "extension" | "local";
+  conversationId: string;
+  send: ReturnType<typeof mock>;
+  dispose: ReturnType<typeof mock>;
+};
+
+function makeFakeExtensionClient(conversationId: string): FakeClient {
+  return {
+    kind: "extension",
+    conversationId,
+    send: mock(async () => ({ ok: true, via: "extension" })),
+    dispose: mock(() => {}),
+  };
+}
+
+function makeFakeLocalClient(conversationId: string): FakeClient {
+  return {
+    kind: "local",
+    conversationId,
+    send: mock(async () => ({ ok: true, via: "local" })),
+    dispose: mock(() => {}),
+  };
+}
+
+let lastExtensionClient: FakeClient | undefined;
+let lastLocalClient: FakeClient | undefined;
 
 const createExtensionCdpClientMock = mock(
-  (_proxy: HostBrowserProxy, conversationId: string) => ({
-    kind: "extension" as const,
-    conversationId,
-    send: async () => ({}),
-    dispose: () => {},
-  }),
+  (_proxy: HostBrowserProxy, conversationId: string) => {
+    const client = makeFakeExtensionClient(conversationId);
+    lastExtensionClient = client;
+    return client;
+  },
 );
 
-const createLocalCdpClientMock = mock((conversationId: string) => ({
-  kind: "local" as const,
-  conversationId,
-  send: async () => ({}),
-  dispose: () => {},
-}));
+const createLocalCdpClientMock = mock((conversationId: string) => {
+  const client = makeFakeLocalClient(conversationId);
+  lastLocalClient = client;
+  return client;
+});
 
 mock.module("../extension-cdp-client.js", () => ({
   createExtensionCdpClient: createExtensionCdpClientMock,
@@ -45,6 +72,8 @@ describe("getCdpClient", () => {
   beforeEach(() => {
     createExtensionCdpClientMock.mockClear();
     createLocalCdpClientMock.mockClear();
+    lastExtensionClient = undefined;
+    lastLocalClient = undefined;
   });
 
   test("routes to ExtensionCdpClient when hostBrowserProxy is set", () => {
@@ -93,5 +122,121 @@ describe("getCdpClient", () => {
     expect(createLocalCdpClientMock).toHaveBeenCalledTimes(1);
     expect(createLocalCdpClientMock).toHaveBeenCalledWith("another-convo");
     expect(createExtensionCdpClientMock).not.toHaveBeenCalled();
+  });
+
+  test("forwards send() through the manager to the extension-backed client", async () => {
+    const fakeProxy = {
+      request: mock(async () => ({})),
+    } as unknown as HostBrowserProxy;
+    const ctx = makeContext({
+      conversationId: "send-ext",
+      hostBrowserProxy: fakeProxy,
+    });
+
+    const client = getCdpClient(ctx);
+    const result = await client.send<{ ok: boolean; via: string }>(
+      "Page.navigate",
+      { url: "https://example.com" },
+    );
+
+    expect(result).toEqual({ ok: true, via: "extension" });
+    expect(lastExtensionClient?.send).toHaveBeenCalledTimes(1);
+    expect(lastExtensionClient?.send).toHaveBeenCalledWith(
+      "Page.navigate",
+      { url: "https://example.com" },
+      undefined,
+    );
+    expect(lastLocalClient).toBeUndefined();
+  });
+
+  test("forwards send() through the manager to the local-backed client", async () => {
+    const ctx = makeContext({ conversationId: "send-local" });
+
+    const client = getCdpClient(ctx);
+    const result = await client.send<{ ok: boolean; via: string }>(
+      "Runtime.evaluate",
+      { expression: "1+1" },
+    );
+
+    expect(result).toEqual({ ok: true, via: "local" });
+    expect(lastLocalClient?.send).toHaveBeenCalledTimes(1);
+    expect(lastLocalClient?.send).toHaveBeenCalledWith(
+      "Runtime.evaluate",
+      { expression: "1+1" },
+      undefined,
+    );
+    expect(lastExtensionClient).toBeUndefined();
+  });
+
+  test("propagates CdpError thrown by the underlying client", async () => {
+    const ctx = makeContext({ conversationId: "err-local" });
+    const client = getCdpClient(ctx);
+    const thrown = new CdpError("cdp_error", "kaboom", {
+      cdpMethod: "Page.navigate",
+    });
+    lastLocalClient!.send = mock(async () => {
+      throw thrown;
+    });
+
+    await expect(
+      client.send("Page.navigate", { url: "https://example.com" }),
+    ).rejects.toBe(thrown);
+  });
+
+  test("propagates caller AbortSignal to the underlying client", async () => {
+    const ctx = makeContext({ conversationId: "abort-local" });
+    const client = getCdpClient(ctx);
+    const controller = new AbortController();
+    let sawSignal: AbortSignal | undefined;
+    lastLocalClient!.send = mock(
+      async (
+        _method: string,
+        _params?: Record<string, unknown>,
+        signal?: AbortSignal,
+      ) => {
+        sawSignal = signal;
+        if (signal?.aborted) {
+          throw new CdpError("aborted", "aborted before send");
+        }
+        return {};
+      },
+    );
+
+    controller.abort();
+    await expect(
+      client.send("Page.navigate", { url: "https://x" }, controller.signal),
+    ).rejects.toMatchObject({ code: "aborted" });
+    expect(sawSignal).toBe(controller.signal);
+  });
+
+  test("dispose() tears down the underlying client and rejects further sends", async () => {
+    const ctx = makeContext({ conversationId: "dispose-local" });
+    const client = getCdpClient(ctx);
+
+    client.dispose();
+    expect(lastLocalClient?.dispose).toHaveBeenCalledTimes(1);
+
+    // A second dispose is a no-op.
+    client.dispose();
+    expect(lastLocalClient?.dispose).toHaveBeenCalledTimes(1);
+
+    await expect(client.send("Runtime.evaluate")).rejects.toMatchObject({
+      code: "disposed",
+    });
+  });
+
+  test("dispose() on an extension-backed client tears down the extension client", () => {
+    const fakeProxy = {
+      request: mock(async () => ({})),
+    } as unknown as HostBrowserProxy;
+    const ctx = makeContext({
+      conversationId: "dispose-ext",
+      hostBrowserProxy: fakeProxy,
+    });
+
+    const client = getCdpClient(ctx);
+    client.dispose();
+
+    expect(lastExtensionClient?.dispose).toHaveBeenCalledTimes(1);
   });
 });

--- a/assistant/src/tools/browser/cdp-client/factory.ts
+++ b/assistant/src/tools/browser/cdp-client/factory.ts
@@ -1,7 +1,16 @@
+import {
+  type BrowserBackend,
+  BrowserSessionManager,
+  type CdpCommand,
+  type CdpResult,
+  createExtensionBackend,
+  createLocalBackend,
+} from "../../../browser-session/index.js";
 import type { ToolContext } from "../../types.js";
+import { CdpError } from "./errors.js";
 import { createExtensionCdpClient } from "./extension-cdp-client.js";
 import { createLocalCdpClient } from "./local-cdp-client.js";
-import type { ScopedCdpClient } from "./types.js";
+import type { CdpClient, CdpClientKind, ScopedCdpClient } from "./types.js";
 
 /**
  * Select the appropriate CdpClient implementation for a tool
@@ -9,29 +18,154 @@ import type { ScopedCdpClient } from "./types.js";
  *
  *  - When `context.hostBrowserProxy` is set (macOS desktop / cloud-
  *    hosted with a chrome-extension bound to the conversation),
- *    return an ExtensionCdpClient so CDP commands ride the
+ *    register an extension backend so CDP commands ride the
  *    host_browser_request / host_browser_result round-trip.
  *  - Otherwise (CLI, tests, headless Chromium launched in-process),
- *    return a LocalCdpClient that drives Playwright's CDPSession
+ *    register a local backend that drives Playwright's CDPSession
  *    against the sacrificial-profile browser managed by
  *    browserManager.
  *
- * The returned client is `kind`-tagged so tools can branch on
- * transport — e.g. browser_navigate skips the Playwright-specific
- * screencast and handoff hooks when `kind === "extension"`.
+ * Both paths go through a per-invocation `BrowserSessionManager` so
+ * the manager is the single choke point for CDP routing, session
+ * lifetime, and (future) session invalidation handling. The returned
+ * client is `kind`-tagged so tools can branch on transport — e.g.
+ * browser_navigate skips Playwright-specific screencast and handoff
+ * hooks when `kind === "extension"`.
  *
  * IMPORTANT: the returned client is per-invocation. Tools MUST call
- * `dispose()` in a finally block to release the CDP session (local
- * path) or mark the wrapper disposed (extension path). Disposing
- * an ExtensionCdpClient does NOT dispose the underlying
- * HostBrowserProxy — that is owned by the conversation.
+ * `dispose()` in a finally block. Dispose tears down the manager's
+ * session and the underlying CDP client. Disposing an extension-backed
+ * client does NOT dispose the underlying HostBrowserProxy — that is
+ * owned by the conversation.
  */
 export function getCdpClient(context: ToolContext): ScopedCdpClient {
-  if (context.hostBrowserProxy) {
-    return createExtensionCdpClient(
-      context.hostBrowserProxy,
-      context.conversationId,
-    );
+  const { conversationId, hostBrowserProxy } = context;
+  if (hostBrowserProxy) {
+    const client = createExtensionCdpClient(hostBrowserProxy, conversationId);
+    const backend = createExtensionBackend({
+      isAvailable: () => true,
+      sendCdp: (command, signal) =>
+        dispatchThroughClient(client, command, signal),
+      dispose: () => client.dispose(),
+    });
+    return buildManagedClient("extension", conversationId, backend);
   }
-  return createLocalCdpClient(context.conversationId);
+  const client = createLocalCdpClient(conversationId);
+  const backend = createLocalBackend({
+    isAvailable: () => true,
+    sendCdp: (command, signal) =>
+      dispatchThroughClient(client, command, signal),
+    dispose: () => client.dispose(),
+  });
+  return buildManagedClient("local", conversationId, backend);
+}
+
+/**
+ * Build a ScopedCdpClient whose `send()` routes through a
+ * BrowserSessionManager seeded with a single backend + session. This
+ * lets tool call sites remain backend-agnostic while giving the
+ * manager a seam for future session-invalidation and multi-target
+ * routing work.
+ */
+function buildManagedClient(
+  kind: CdpClientKind,
+  conversationId: string,
+  backend: BrowserBackend,
+): ScopedCdpClient {
+  const manager = new BrowserSessionManager({ backends: [backend] });
+  const session = manager.createSession();
+  let disposed = false;
+
+  return {
+    kind,
+    conversationId,
+    async send<T = unknown>(
+      method: string,
+      params?: Record<string, unknown>,
+      signal?: AbortSignal,
+    ): Promise<T> {
+      if (disposed) {
+        throw new CdpError(
+          "disposed",
+          `${kind === "extension" ? "ExtensionCdpClient" : "LocalCdpClient"} already disposed`,
+          { cdpMethod: method, cdpParams: params },
+        );
+      }
+      const command: CdpCommand = { method, params };
+      const envelope = await manager.send(session.id, command, signal);
+      return unwrapResult<T>(envelope, method, params);
+    },
+    dispose(): void {
+      if (disposed) return;
+      disposed = true;
+      // disposeAll() tears down the per-invocation backend (which in
+      // turn disposes the underlying CdpClient) and clears the single
+      // session we created in buildManagedClient.
+      manager.disposeAll();
+    },
+  };
+}
+
+/**
+ * Adapter that makes an existing `CdpClient` look like a
+ * `BrowserBackend.send`. Converts thrown CdpErrors back into a
+ * `CdpResult` envelope with an `error` payload so the manager does
+ * not need to know about our thrown-error convention, then the
+ * envelope is unwrapped again on the way out of the managed client.
+ *
+ * The per-command `command.sessionId` (populated by the manager from
+ * a session's opaque `targetId`) is intentionally not forwarded to
+ * the underlying CdpClient today — both LocalCdpClient and
+ * ExtensionCdpClient take their CDP sessionId at construction time
+ * and tools run one client per invocation. The seam is preserved so
+ * a future multi-target backend can read it off the CdpCommand.
+ */
+async function dispatchThroughClient(
+  client: CdpClient,
+  command: CdpCommand,
+  signal: AbortSignal | undefined,
+): Promise<CdpResult> {
+  try {
+    const result = await client.send(command.method, command.params, signal);
+    return { result };
+  } catch (err) {
+    if (err instanceof CdpError) {
+      // Preserve the original CdpError so unwrapResult can re-throw it
+      // verbatim. CdpResult's error channel is opaque to the manager,
+      // so stashing the instance under `data` is safe.
+      return {
+        error: {
+          code: -1,
+          message: err.message,
+          data: err,
+        },
+      };
+    }
+    throw err;
+  }
+}
+
+/**
+ * Unwrap a CdpResult envelope into the raw CDP result `T` or throw
+ * the underlying CdpError. If the envelope carries an error but the
+ * `data` is not a CdpError (e.g. a future backend surfaces a JSON-RPC
+ * error envelope directly), synthesize a transport_error CdpError so
+ * call sites keep their uniform error handling.
+ */
+function unwrapResult<T>(
+  envelope: CdpResult,
+  method: string,
+  params?: Record<string, unknown>,
+): T {
+  if (envelope.error) {
+    if (envelope.error.data instanceof CdpError) {
+      throw envelope.error.data;
+    }
+    throw new CdpError("cdp_error", envelope.error.message, {
+      cdpMethod: method,
+      cdpParams: params,
+      underlying: envelope.error,
+    });
+  }
+  return envelope.result as T;
 }

--- a/docs/browser-use-architecture-phase2.md
+++ b/docs/browser-use-architecture-phase2.md
@@ -161,9 +161,11 @@ The new modules that implement Phase 2:
   (`loadOrCreateCapabilityTokenSecret`, legacy workspace →
   protected-directory migration, mode enforcement on write,
   corruption-triggered regeneration, per-test injection).
-- **`assistant/src/browser-session/`** — Phase 3 `BrowserSessionManager`
-  scaffold (types, backends, manager). No consumers yet — the
-  in-turn browser-execution loop still uses the legacy path in Phase 2.
+- **`assistant/src/browser-session/`** — `BrowserSessionManager` and its
+  `extension` + `local` backends. The cdp-client factory constructs a
+  per-invocation manager for each browser tool call, which is the single
+  choke point for CDP backend selection, session lifetime, and future
+  session-invalidation handling.
 - **`clients/chrome-extension/background/cdp-proxy.ts`** — CDP JSON-RPC
   wrapper around `chrome.debugger`. Tracks attach state per target so
   concurrent commands don't double-attach.


### PR DESCRIPTION
## Summary
- BrowserSessionManager is now the single CDP backend selector
- Register extension backend when hostBrowserProxy present, local otherwise
- Route cdp-session-aware calls through manager for future session invalidation
- Remove duplicate selection logic from factory

Part of plan: browser-use-main-remediation-plan-2026-04-08.md (PR 7 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24487" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
