### PR TITLE
feat(skills): return file listings for uninstalled Vellum catalog skills

### DIFF
--- a/assistant/src/__tests__/skills-files-catalog-fallback.test.ts
+++ b/assistant/src/__tests__/skills-files-catalog-fallback.test.ts
@@ -1,0 +1,394 @@
+/**
+ * Tests for `getSkillFiles` catalog fallback.
+ *
+ * When a skill id isn't resolvable via `findSkillById` (i.e. not installed
+ * locally, not bundled, not a managed skill) or the on-disk directory is
+ * missing, `getSkillFiles` now falls back to the Vellum catalog via
+ * `readCatalogSkillFiles`. Catalog fallback entries carry `content: null`
+ * because the catalog-files helper defers content fetching to a follow-up
+ * per-file endpoint.
+ *
+ * Coverage:
+ *   - Uninstalled catalog skill: returns `{ skill: catalog/vellum/available, files }` with `content: null` for every entry.
+ *   - Neither installed nor in catalog: returns 404.
+ *   - Installed skill: preserves the existing disk-read behavior with inline `content`.
+ *   - `catalogSkillToSlim` mapping: `metadata.vellum["display-name"]` wins over `cs.name`.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { SkillSummary } from "../config/skills.js";
+import type { SkillFileEntry } from "../skills/catalog-files.js";
+import type { CatalogSkill } from "../skills/catalog-install.js";
+
+// ---------------------------------------------------------------------------
+// Mock state — mutated by individual tests via reset helpers below
+// ---------------------------------------------------------------------------
+
+type ResolvedSkillEntry = {
+  summary: SkillSummary;
+  state: "enabled" | "disabled";
+};
+
+let mockResolvedStates: ResolvedSkillEntry[] = [];
+let mockCatalog: CatalogSkill[] = [];
+let mockCatalogFiles: SkillFileEntry[] | null = null;
+const catalogFilesCalls: string[] = [];
+
+// ---------------------------------------------------------------------------
+// Module mocks — must be declared before importing the module under test
+// ---------------------------------------------------------------------------
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({}),
+  invalidateConfigCache: () => {},
+  loadRawConfig: () => ({}),
+  saveRawConfig: () => {},
+}));
+
+mock.module("../config/skills.js", () => ({
+  loadSkillCatalog: () => [],
+}));
+
+mock.module("../config/skill-state.js", () => ({
+  resolveSkillStates: () => mockResolvedStates,
+  skillFlagKey: () => null,
+}));
+
+mock.module("../config/assistant-feature-flags.js", () => ({
+  isAssistantFeatureFlagEnabled: () => true,
+}));
+
+mock.module("../skills/install-meta.js", () => ({
+  readInstallMeta: () => null,
+}));
+
+mock.module("../skills/catalog-cache.js", () => ({
+  getCatalog: async () => mockCatalog,
+}));
+
+mock.module("../skills/catalog-files.js", () => ({
+  readCatalogSkillFiles: async (skillId: string) => {
+    catalogFilesCalls.push(skillId);
+    return mockCatalogFiles;
+  },
+}));
+
+mock.module("../skills/catalog-install.js", () => ({
+  installSkillLocally: async () => {},
+  upsertSkillsIndex: () => {},
+}));
+
+mock.module("../skills/catalog-search.js", () => ({
+  filterByQuery: () => [],
+}));
+
+mock.module("../skills/clawhub.js", () => ({
+  clawhubCheckUpdates: async () => [],
+  clawhubInspect: async () => ({}),
+  clawhubInstall: async () => ({ success: true }),
+  clawhubSearch: async () => ({ skills: [] }),
+  clawhubUpdate: async () => ({ success: true }),
+}));
+
+mock.module("../skills/skillssh-registry.js", () => ({
+  installExternalSkill: async () => {},
+  resolveSkillSource: () => ({ owner: "", repo: "", skillSlug: "" }),
+  searchSkillsRegistry: async () => [],
+}));
+
+mock.module("../skills/managed-store.js", () => ({
+  createManagedSkill: () => ({ created: true }),
+  deleteManagedSkill: () => ({ deleted: true }),
+  removeSkillsIndexEntry: () => {},
+  validateManagedSkillId: () => null,
+}));
+
+mock.module("../memory/graph/capability-seed.js", () => ({
+  deleteSkillCapabilityNode: () => {},
+  seedSkillGraphNodes: () => {},
+  seedUninstalledCatalogSkillMemories: async () => {},
+}));
+
+mock.module("../providers/provider-send-message.js", () => ({
+  createTimeout: () => ({
+    signal: AbortSignal.timeout(1000),
+    cleanup: () => {},
+  }),
+  extractText: () => "",
+  getConfiguredProvider: async () => null,
+  userMessage: () => ({}),
+}));
+
+mock.module("../util/platform.js", () => ({
+  getWorkspaceSkillsDir: () => "/tmp/test-skills-fallback",
+}));
+
+mock.module("../daemon/handlers/shared.js", () => ({
+  CONFIG_RELOAD_DEBOUNCE_MS: 100,
+  ensureSkillEntry: (_raw: Record<string, unknown>, _id: string) => ({
+    enabled: false,
+  }),
+  log: {
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Import after mocks
+// ---------------------------------------------------------------------------
+
+import { getSkillFiles } from "../daemon/handlers/skills.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const dummyCtx = {
+  debounceTimers: { schedule: () => {} },
+  setSuppressConfigReload: () => {},
+  updateConfigFingerprint: () => {},
+  broadcast: () => {},
+} as unknown as Parameters<typeof getSkillFiles>[1];
+
+function makeSummary(overrides: Partial<SkillSummary>): SkillSummary {
+  return {
+    id: overrides.id ?? "summary-id",
+    name: overrides.name ?? "summary-id",
+    displayName: overrides.displayName ?? "Summary",
+    description: overrides.description ?? "",
+    directoryPath: overrides.directoryPath ?? "/tmp/nonexistent-skill-dir",
+    skillFilePath:
+      overrides.skillFilePath ??
+      join(overrides.directoryPath ?? "/tmp/nonexistent-skill-dir", "SKILL.md"),
+    source: overrides.source ?? "workspace",
+    bundled: overrides.bundled,
+    icon: overrides.icon,
+    emoji: overrides.emoji,
+    toolManifest: overrides.toolManifest,
+    includes: overrides.includes,
+    featureFlag: overrides.featureFlag,
+    activationHints: overrides.activationHints,
+    avoidWhen: overrides.avoidWhen,
+    inlineCommandExpansions: overrides.inlineCommandExpansions,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("getSkillFiles — catalog fallback", () => {
+  beforeEach(() => {
+    mockResolvedStates = [];
+    mockCatalog = [];
+    mockCatalogFiles = null;
+    catalogFilesCalls.length = 0;
+  });
+
+  test("returns catalog skill with files (content: null) when skill is uninstalled but present in catalog", async () => {
+    mockCatalog = [
+      {
+        id: "acme-seo",
+        name: "acme-seo",
+        description: "SEO helper",
+        emoji: "\u{1F50D}",
+        metadata: { vellum: { "display-name": "Acme SEO" } },
+      },
+    ];
+    mockCatalogFiles = [
+      {
+        path: "SKILL.md",
+        name: "SKILL.md",
+        size: 42,
+        mimeType: "",
+        isBinary: false,
+        content: null,
+      },
+      {
+        path: "assets/logo.png",
+        name: "logo.png",
+        size: 1024,
+        mimeType: "",
+        isBinary: true,
+        content: null,
+      },
+    ];
+
+    const result = await getSkillFiles("acme-seo", dummyCtx);
+
+    expect("error" in result).toBe(false);
+    if ("error" in result) return;
+
+    expect(result.skill).toEqual({
+      id: "acme-seo",
+      name: "Acme SEO",
+      description: "SEO helper",
+      emoji: "\u{1F50D}",
+      kind: "catalog",
+      origin: "vellum",
+      status: "available",
+    });
+    expect(result.files).toHaveLength(2);
+    for (const entry of result.files) {
+      expect(entry.content).toBeNull();
+    }
+    // Files should be sorted by path via localeCompare (not codepoint) —
+    // so "assets/logo.png" sorts before "SKILL.md" under default collation.
+    expect(result.files.map((f) => f.path)).toEqual(
+      [...result.files.map((f) => f.path)].sort((a, b) => a.localeCompare(b)),
+    );
+    expect(new Set(result.files.map((f) => f.path))).toEqual(
+      new Set(["SKILL.md", "assets/logo.png"]),
+    );
+    expect(catalogFilesCalls).toEqual(["acme-seo"]);
+  });
+
+  test("returns 404 when skill is neither installed nor in the catalog", async () => {
+    mockResolvedStates = [];
+    mockCatalog = [];
+
+    const result = await getSkillFiles("ghost-skill", dummyCtx);
+
+    expect("error" in result).toBe(true);
+    if (!("error" in result)) return;
+    expect(result.status).toBe(404);
+    expect(result.error).toContain("ghost-skill");
+    expect(catalogFilesCalls).toEqual([]);
+  });
+
+  test("returns 404 when skill is in catalog but readCatalogSkillFiles returns null", async () => {
+    mockCatalog = [
+      {
+        id: "broken-skill",
+        name: "broken-skill",
+        description: "",
+      },
+    ];
+    mockCatalogFiles = null;
+
+    const result = await getSkillFiles("broken-skill", dummyCtx);
+
+    expect("error" in result).toBe(true);
+    if (!("error" in result)) return;
+    expect(result.status).toBe(404);
+    expect(result.error).toContain("broken-skill");
+  });
+
+  test("installed skill returns inline disk content (no catalog call)", async () => {
+    // Create a real temp directory for the installed-skill path to read.
+    const workspaceRoot = mkdtempSync(
+      join(tmpdir(), "vellum-skill-files-test-"),
+    );
+    const installedDir = join(workspaceRoot, "installed-skill");
+    mkdirSync(installedDir, { recursive: true });
+    writeFileSync(
+      join(installedDir, "SKILL.md"),
+      "# Installed\n\nBody of the installed skill.",
+    );
+    writeFileSync(
+      join(installedDir, "notes.txt"),
+      "Some notes about the skill.",
+    );
+
+    try {
+      mockResolvedStates = [
+        {
+          summary: makeSummary({
+            id: "installed-skill",
+            name: "installed-skill",
+            displayName: "Installed Skill",
+            description: "A pre-installed skill",
+            directoryPath: installedDir,
+            source: "workspace",
+          }),
+          state: "enabled",
+        },
+      ];
+
+      const result = await getSkillFiles("installed-skill", dummyCtx);
+
+      expect("error" in result).toBe(false);
+      if ("error" in result) return;
+
+      // Catalog fallback should NOT have been consulted for an installed skill.
+      expect(catalogFilesCalls).toEqual([]);
+
+      expect(result.files).toHaveLength(2);
+      const skillMd = result.files.find((f) => f.path === "SKILL.md");
+      const notes = result.files.find((f) => f.path === "notes.txt");
+      expect(skillMd).toBeDefined();
+      expect(notes).toBeDefined();
+      expect(skillMd!.content).toBe(
+        "# Installed\n\nBody of the installed skill.",
+      );
+      expect(notes!.content).toBe("Some notes about the skill.");
+
+      // Sort-by-path behavior (localeCompare order) is preserved.
+      expect(result.files.map((f) => f.path)).toEqual(
+        [...result.files.map((f) => f.path)].sort((a, b) => a.localeCompare(b)),
+      );
+    } finally {
+      rmSync(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("catalogSkillToSlim falls back to cs.name when metadata.vellum.display-name is absent", async () => {
+    mockCatalog = [
+      {
+        id: "plain-skill",
+        name: "plain-skill",
+        description: "Minimal",
+      },
+    ];
+    mockCatalogFiles = [];
+
+    const result = await getSkillFiles("plain-skill", dummyCtx);
+
+    expect("error" in result).toBe(false);
+    if ("error" in result) return;
+    expect(result.skill.name).toBe("plain-skill");
+    expect(result.skill.kind).toBe("catalog");
+    expect(result.skill.origin).toBe("vellum");
+    expect(result.skill.status).toBe("available");
+  });
+
+  test("catalogSkillToSlim prefers metadata.vellum.display-name over cs.name", async () => {
+    mockCatalog = [
+      {
+        id: "fancy-skill",
+        name: "raw-fancy-name",
+        description: "",
+        metadata: { vellum: { "display-name": "Pretty Fancy Name" } },
+      },
+    ];
+    mockCatalogFiles = [];
+
+    const result = await getSkillFiles("fancy-skill", dummyCtx);
+
+    expect("error" in result).toBe(false);
+    if ("error" in result) return;
+    expect(result.skill.name).toBe("Pretty Fancy Name");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cleanup: ensure we don't leak temp dirs if a test fails mid-way.
+// ---------------------------------------------------------------------------
+
+afterEach(() => {
+  // Nothing to clean up outside test scope — temp dirs are cleaned per-test.
+});

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -33,8 +33,12 @@ import {
 } from "../../providers/provider-send-message.js";
 import { isTextMimeType as isTextMime } from "../../runtime/routes/workspace-utils.js";
 import { getCatalog } from "../../skills/catalog-cache.js";
-import type { SkillFileEntry } from "../../skills/catalog-files.js";
 import {
+  readCatalogSkillFiles,
+  type SkillFileEntry,
+} from "../../skills/catalog-files.js";
+import {
+  type CatalogSkill,
   installSkillLocally,
   upsertSkillsIndex,
 } from "../../skills/catalog-install.js";
@@ -365,7 +369,7 @@ export async function listSkillsWithCatalog(
   const installed = listSkills(ctx);
   const installedIds = new Set(installed.map((s) => s.id));
 
-  let catalogSkills: import("../../skills/catalog-install.js").CatalogSkill[];
+  let catalogSkills: CatalogSkill[];
   try {
     catalogSkills = await getCatalog();
   } catch {
@@ -377,15 +381,7 @@ export async function listSkillsWithCatalog(
   // Create SlimSkillResponses for catalog skills not already installed.
   const available: SlimSkillResponse[] = catalogSkills
     .filter((cs) => !installedIds.has(cs.id))
-    .map((cs) => ({
-      id: cs.id,
-      name: cs.metadata?.vellum?.["display-name"] ?? cs.name,
-      description: cs.description,
-      emoji: cs.emoji,
-      kind: "catalog" as const,
-      origin: "vellum" as const,
-      status: "available" as const,
-    }));
+    .map((cs) => catalogSkillToSlim(cs));
 
   const merged = [...installed, ...available];
 
@@ -567,26 +563,68 @@ function readDirRecursive(dir: string, rootDir: string): SkillFileEntry[] {
   return entries;
 }
 
-export function getSkillFiles(
+/**
+ * Map a `CatalogSkill` (from the Vellum platform API) to a `SlimSkillResponse`
+ * shaped for the "available catalog skill" case. Shared between
+ * `listSkillsWithCatalog` (merging catalog entries into the installed list)
+ * and `getSkillFiles` (catalog fallback for preview listings). Keeping the
+ * mapping in one place avoids divergence between the list and detail paths.
+ */
+function catalogSkillToSlim(cs: CatalogSkill): SlimSkillResponse {
+  return {
+    id: cs.id,
+    name: cs.metadata?.vellum?.["display-name"] ?? cs.name,
+    description: cs.description,
+    emoji: cs.emoji,
+    kind: "catalog",
+    origin: "vellum",
+    status: "available",
+  };
+}
+
+export async function getSkillFiles(
   skillId: string,
   _ctx: SkillOperationContext,
-):
+): Promise<
   | { skill: SlimSkillResponse; files: SkillFileEntry[] }
-  | { error: string; status: number } {
+  | { error: string; status: number }
+> {
+  // Preferred path: the skill is resolved locally (bundled, managed,
+  // workspace, or extra) AND its directory exists on disk. Read files
+  // eagerly with inline content exactly as before.
   const found = findSkillById(skillId);
-  if (!found) {
+  if (found && existsSync(found.summary.directoryPath)) {
+    const dirPath = found.summary.directoryPath;
+    const files = readDirRecursive(dirPath, dirPath);
+    files.sort((a, b) => a.path.localeCompare(b.path));
+    return { skill: found.item, files };
+  }
+
+  // Fallback: skill is not installed (or its directory is missing). Try
+  // the Vellum catalog — this covers previewing files for an uninstalled
+  // catalog skill without touching the install flow.
+  let catalog: CatalogSkill[];
+  try {
+    catalog = await getCatalog();
+  } catch {
+    return { error: `Skill "${skillId}" not found`, status: 404 };
+  }
+  const cs = catalog.find((c) => c.id === skillId);
+  if (!cs) {
     return { error: `Skill "${skillId}" not found`, status: 404 };
   }
 
-  const dirPath = found.summary.directoryPath;
-  if (!existsSync(dirPath)) {
-    return { error: `Skill directory not found for "${skillId}"`, status: 404 };
+  const files = await readCatalogSkillFiles(skillId);
+  if (files === null) {
+    return {
+      error: `Skill files unavailable for "${skillId}"`,
+      status: 404,
+    };
   }
 
-  const files = readDirRecursive(dirPath, dirPath);
+  const skill = catalogSkillToSlim(cs);
   files.sort((a, b) => a.path.localeCompare(b.path));
-
-  return { skill: found.item, files };
+  return { skill, files };
 }
 
 export function enableSkill(

--- a/assistant/src/runtime/routes/skills-routes.ts
+++ b/assistant/src/runtime/routes/skills-routes.ts
@@ -158,8 +158,8 @@ export function skillRouteDefinitions(deps: SkillRouteDeps): RouteDefinition[] {
       summary: "Get skill files",
       description: "Return skill metadata and directory contents.",
       tags: ["skills"],
-      handler: ({ params }) => {
-        const result = getSkillFiles(params.id, ctx());
+      handler: async ({ params }) => {
+        const result = await getSkillFiles(params.id, ctx());
         if ("error" in result) {
           if (result.status === 404) {
             return httpError("NOT_FOUND", result.error, 404);


### PR DESCRIPTION
## Summary
- Extend the existing `GET /assistants/{assistantId}/skills/:id/files` endpoint to fall back to the Vellum catalog when a skill is not installed locally.
- Catalog fallback uses `readCatalogSkillFiles` from PR 1, returning entries with `content: null` (lazy content fetching comes in PR 3).
- Extract `catalogSkillToSlim` so the catalog→SlimSkillResponse mapping lives in one place, reused from `listSkillsWithCatalog`.

Part of plan: skill-files-preview.md (PR 2 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24488" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
