### PR TITLE
feat(skills): add single-file content endpoint for lazy previews

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -6756,6 +6756,55 @@ paths:
           required: true
           schema:
             type: string
+  /v1/skills/{id}/files/content:
+    get:
+      operationId: skills_by_id_files_content_get
+      summary: Get skill file content
+      description: Return the content of a single file belonging to an installed or catalog skill.
+      tags:
+        - skills
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  path:
+                    type: string
+                  name:
+                    type: string
+                  size:
+                    type: number
+                  mimeType:
+                    type: string
+                  isBinary:
+                    type: boolean
+                  content:
+                    anyOf:
+                      - type: string
+                      - type: "null"
+                required:
+                  - path
+                  - name
+                  - size
+                  - mimeType
+                  - isBinary
+                  - content
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: path
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Relative path of the file within the skill directory
   /v1/skills/{id}/inspect:
     get:
       operationId: skills_by_id_inspect_get

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -6801,7 +6801,7 @@ paths:
             type: string
         - name: path
           in: query
-          required: false
+          required: true
           schema:
             type: string
           description: Relative path of the file within the skill directory

--- a/assistant/src/__tests__/catalog-files.test.ts
+++ b/assistant/src/__tests__/catalog-files.test.ts
@@ -222,9 +222,10 @@ describe("sanitizeRelativePath", () => {
   });
 
   test("rejects paths that become absolute after ./ stripping", () => {
-    // The leading `./` strip loop used to leave `/etc/passwd` behind, which
-    // posix.normalize then passed through as an absolute path. The
-    // post-normalization absolute-path check should reject each of these.
+    // `sanitizeRelativePath` performs a post-normalization absolute-path
+    // check so inputs like `.//etc/passwd` cannot reach the filesystem:
+    // the leading `./` strip loop leaves `/etc/passwd`, which
+    // `posix.normalize` would otherwise pass through as an absolute path.
     expect(sanitizeRelativePath(".//etc/passwd")).toBeNull();
     expect(sanitizeRelativePath("./././/etc/passwd")).toBeNull();
     // The backslash normalizes to `/`, so `.\\/etc/passwd` becomes
@@ -287,19 +288,20 @@ describe("readCatalogSkillFiles (dev mode)", () => {
   });
 
   test("rejects a symlinked skill root and falls through to platform mode", async () => {
-    // Reproduces the Codex P2 attack: an attacker (or a misconfigured dev)
-    // creates <repoSkillsDir>/my-skill as a symlink pointing at an external
-    // directory. Without the symlink-root check in `resolveCatalogSource`,
-    // the dev-mode branch would happily walk the external directory,
-    // because the realpath containment check downstream derives `realRoot`
-    // from the already-resolved symlink target.
+    // An attacker (or a misconfigured dev) creates
+    // <repoSkillsDir>/my-skill as a symlink pointing at an external
+    // directory. `resolveCatalogSource` rejects symlinked skill roots so
+    // the dev-mode branch never walks the external directory — the
+    // realpath containment check downstream would otherwise derive
+    // `realRoot` from the already-resolved symlink target and become a
+    // no-op.
     //
     // Expected behavior: the dev-mode shortcut is rejected up-front, and
     // we fall through to platform mode — which in this test is stubbed
-    // to return an empty file list. So `readCatalogSkillFiles` should
-    // return the empty platform response, and `fetch` MUST be called
-    // (proving the fall-through happened, rather than the dev-mode
-    // shortcut silently reading from the external directory).
+    // to return an empty file list. So `readCatalogSkillFiles` returns
+    // the empty platform response, and `fetch` MUST be called (proving
+    // the fall-through happened, rather than the dev-mode shortcut
+    // silently reading from the external directory).
     const root = makeTempSkillsDir();
     const externalRoot = mkdtempSync(join(tmpdir(), "catalog-files-ext-"));
     tempDirs.push(externalRoot);

--- a/assistant/src/__tests__/catalog-files.test.ts
+++ b/assistant/src/__tests__/catalog-files.test.ts
@@ -662,6 +662,74 @@ describe("readCatalogSkillFileContent (dev mode)", () => {
     );
     expect(entry).toBeNull();
   });
+
+  test("rejects dotfile paths and returns null without reading disk", async () => {
+    // `.env` is a valid sanitized path (sanitizeRelativePath accepts it),
+    // but the hidden-segment check must reject it so the catalog content
+    // reader never exposes dotfiles, matching the listing API that hides
+    // them. This preserves parity between listing and content endpoints.
+    const root = makeTempSkillsDir();
+    writeSkill(root, "my-skill", {
+      "SKILL.md": "ok",
+      ".env": "SECRET=abc\n",
+    });
+    mockRepoSkillsDir = root;
+    mockCatalog = [skill("my-skill")];
+    installFetchForbidden();
+
+    expect(await readCatalogSkillFileContent("my-skill", ".env")).toBeNull();
+    expect(
+      await readCatalogSkillFileContent("my-skill", ".git/config"),
+    ).toBeNull();
+    expect(
+      await readCatalogSkillFileContent("my-skill", "docs/.hidden/file.md"),
+    ).toBeNull();
+  });
+
+  test("rejects SKIP_DIRS paths and returns null without reading disk", async () => {
+    const root = makeTempSkillsDir();
+    writeSkill(root, "my-skill", {
+      "SKILL.md": "ok",
+      "node_modules/foo/index.js": "module.exports = {};",
+    });
+    mockRepoSkillsDir = root;
+    mockCatalog = [skill("my-skill")];
+    installFetchForbidden();
+
+    expect(
+      await readCatalogSkillFileContent(
+        "my-skill",
+        "node_modules/foo/index.js",
+      ),
+    ).toBeNull();
+    expect(
+      await readCatalogSkillFileContent("my-skill", "__pycache__/cached.pyc"),
+    ).toBeNull();
+    expect(
+      await readCatalogSkillFileContent(
+        "my-skill",
+        "nested/node_modules/foo.js",
+      ),
+    ).toBeNull();
+  });
+
+  test("regular docs/readme.md still returns content (sanity)", async () => {
+    const root = makeTempSkillsDir();
+    writeSkill(root, "my-skill", {
+      "docs/readme.md": "# readme\n",
+    });
+    mockRepoSkillsDir = root;
+    mockCatalog = [skill("my-skill")];
+    installFetchForbidden();
+
+    const entry = await readCatalogSkillFileContent(
+      "my-skill",
+      "docs/readme.md",
+    );
+    expect(entry).not.toBeNull();
+    expect(entry!.content).toBe("# readme\n");
+    expect(entry!.name).toBe("readme.md");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -757,6 +825,28 @@ describe("readCatalogSkillFileContent (platform mode)", () => {
     expect(await readCatalogSkillFileContent("remote-skill", "..")).toBeNull();
     expect(
       await readCatalogSkillFileContent("remote-skill", "../etc/passwd"),
+    ).toBeNull();
+    expect(fetchCalls.length).toBe(0);
+  });
+
+  test("rejects hidden / SKIP_DIRS paths BEFORE making any fetch call", async () => {
+    // Platform-mode defense in depth: even though the platform endpoint
+    // would refuse these reads server-side, we must short-circuit in
+    // `readCatalogSkillFileContent` so an attacker cannot use the daemon
+    // as a probe channel (and so we avoid unnecessary network traffic).
+    mockCatalog = [skill("remote-skill")];
+    installFetchForbidden();
+    expect(
+      await readCatalogSkillFileContent("remote-skill", ".env"),
+    ).toBeNull();
+    expect(
+      await readCatalogSkillFileContent("remote-skill", ".git/config"),
+    ).toBeNull();
+    expect(
+      await readCatalogSkillFileContent(
+        "remote-skill",
+        "node_modules/foo/index.js",
+      ),
     ).toBeNull();
     expect(fetchCalls.length).toBe(0);
   });

--- a/assistant/src/__tests__/skills-file-content-endpoint.test.ts
+++ b/assistant/src/__tests__/skills-file-content-endpoint.test.ts
@@ -449,3 +449,119 @@ describe("getSkillFileContent — skill not found", () => {
     expect(result.error).toBe("Skill not found");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Hidden / SKIP_DIRS path rejection
+// ---------------------------------------------------------------------------
+//
+// Codex P1: the file-content endpoint previously read any path the caller
+// named, including dotfiles (`.env`) and files inside skipped dirs
+// (`node_modules`, `.git/`) — even though the file-listing endpoint hides
+// those entries. This created a data-exposure path and broke parity with
+// the visible file list. The daemon handler should now reject such paths
+// with a 400 "Invalid path" BEFORE any disk read or network round-trip,
+// regardless of whether the skill is installed locally or only available
+// via the catalog.
+
+describe("getSkillFileContent — hidden / SKIP_DIRS rejection", () => {
+  test("rejects dotfile reads from an installed skill with 400 Invalid path", async () => {
+    // Set up an installed skill where a real `.env` file exists on disk.
+    // Without the hidden-segment rejection, the handler would happily
+    // read its content because sanitizeRelativePath accepts `.env`.
+    const skillDir = makeTempSkillDir("leaky-skill");
+    writeFile(skillDir, "SKILL.md", "# ok\n");
+    writeFile(skillDir, ".env", "SECRET=abc\n");
+    mockResolvedSkills = [installedSkill("leaky-skill", skillDir)];
+    installFetchForbidden();
+
+    const result = await getSkillFileContent("leaky-skill", ".env", dummyCtx);
+    expect("error" in result).toBe(true);
+    if (!("error" in result)) return;
+    expect(result.status).toBe(400);
+    expect(result.error).toBe("Invalid path");
+  });
+
+  test("rejects dotfile reads for an uninstalled catalog skill before any catalog read", async () => {
+    // Same dotfile attack, but the skill id is NOT installed — only
+    // present in the Vellum catalog. The rejection must run in the daemon
+    // handler BEFORE the catalog fallback, so no disk walk or platform
+    // fetch should happen. We use dev-mode with a real `.env` on disk
+    // under the fake repo skills dir to prove that even though the
+    // catalog path WOULD succeed without the check, the daemon
+    // short-circuits.
+    const repoSkillsDir = mkdtempSync(
+      join(tmpdir(), "skill-file-content-hidden-repo-"),
+    );
+    tempDirs.push(repoSkillsDir);
+    const catalogSkillDir = join(repoSkillsDir, "catalog-leaky");
+    mkdirSync(catalogSkillDir, { recursive: true });
+    writeFileSync(join(catalogSkillDir, "SKILL.md"), "# ok\n");
+    writeFileSync(join(catalogSkillDir, ".env"), "SECRET=xyz\n");
+
+    mockRepoSkillsDir = repoSkillsDir;
+    mockResolvedSkills = []; // not installed
+    mockCatalog = [catalogSkill("catalog-leaky")];
+    installFetchForbidden();
+
+    const result = await getSkillFileContent("catalog-leaky", ".env", dummyCtx);
+    expect("error" in result).toBe(true);
+    if (!("error" in result)) return;
+    expect(result.status).toBe(400);
+    expect(result.error).toBe("Invalid path");
+  });
+
+  test("rejects paths whose parent directory is a dotfile segment", async () => {
+    // `.git/config` and `docs/.hidden/file.md` both contain hidden
+    // segments even though the leaf isn't a dotfile.
+    const skillDir = makeTempSkillDir("my-skill");
+    writeFile(skillDir, "SKILL.md", "# ok\n");
+    mockResolvedSkills = [installedSkill("my-skill", skillDir)];
+    installFetchForbidden();
+
+    for (const bad of [".git/config", "docs/.hidden/file.md"]) {
+      const result = await getSkillFileContent("my-skill", bad, dummyCtx);
+      expect("error" in result).toBe(true);
+      if (!("error" in result)) continue;
+      expect(result.status).toBe(400);
+      expect(result.error).toBe("Invalid path");
+    }
+  });
+
+  test("rejects paths inside SKIP_DIRS segments with 400 Invalid path", async () => {
+    const skillDir = makeTempSkillDir("my-skill");
+    writeFile(skillDir, "SKILL.md", "# ok\n");
+    mockResolvedSkills = [installedSkill("my-skill", skillDir)];
+    installFetchForbidden();
+
+    for (const bad of [
+      "node_modules/foo/index.js",
+      "__pycache__/cached.pyc",
+      "nested/node_modules/mod/index.js",
+    ]) {
+      const result = await getSkillFileContent("my-skill", bad, dummyCtx);
+      expect("error" in result).toBe(true);
+      if (!("error" in result)) continue;
+      expect(result.status).toBe(400);
+      expect(result.error).toBe("Invalid path");
+    }
+  });
+
+  test("regular SKILL.md still reads successfully (sanity)", async () => {
+    // Guards against collateral damage from the hidden/SKIP_DIRS filter:
+    // a normal, non-hidden path must continue to work unchanged.
+    const skillDir = makeTempSkillDir("healthy-skill");
+    writeFile(skillDir, "SKILL.md", "# hello\n");
+    mockResolvedSkills = [installedSkill("healthy-skill", skillDir)];
+    installFetchForbidden();
+
+    const result = await getSkillFileContent(
+      "healthy-skill",
+      "SKILL.md",
+      dummyCtx,
+    );
+    expect("error" in result).toBe(false);
+    if ("error" in result) return;
+    expect(result.content).toBe("# hello\n");
+    expect(result.name).toBe("SKILL.md");
+  });
+});

--- a/assistant/src/__tests__/skills-file-content-endpoint.test.ts
+++ b/assistant/src/__tests__/skills-file-content-endpoint.test.ts
@@ -1,6 +1,5 @@
 /**
- * Handler-level tests for `getSkillFileContent` (PR 3 of the
- * `skill-files-preview` plan).
+ * Handler-level tests for `getSkillFileContent`.
  *
  * Covers:
  *   - Installed skill, valid path → returns file content (text + binary).
@@ -454,12 +453,10 @@ describe("getSkillFileContent — skill not found", () => {
 // Hidden / SKIP_DIRS path rejection
 // ---------------------------------------------------------------------------
 //
-// Codex P1: the file-content endpoint previously read any path the caller
-// named, including dotfiles (`.env`) and files inside skipped dirs
-// (`node_modules`, `.git/`) — even though the file-listing endpoint hides
-// those entries. This created a data-exposure path and broke parity with
-// the visible file list. The daemon handler should now reject such paths
-// with a 400 "Invalid path" BEFORE any disk read or network round-trip,
+// The daemon handler rejects paths containing dotfile segments (`.env`,
+// `.git/`) or SKIP_DIRS segments (`node_modules`, `__pycache__`) with a
+// 400 "Invalid path" BEFORE any disk read or network round-trip, matching
+// the file-listing endpoint that hides these entries. This applies
 // regardless of whether the skill is installed locally or only available
 // via the catalog.
 

--- a/assistant/src/__tests__/skills-file-content-endpoint.test.ts
+++ b/assistant/src/__tests__/skills-file-content-endpoint.test.ts
@@ -1,0 +1,451 @@
+/**
+ * Handler-level tests for `getSkillFileContent` (PR 3 of the
+ * `skill-files-preview` plan).
+ *
+ * Covers:
+ *   - Installed skill, valid path → returns file content (text + binary).
+ *   - Installed skill, traversal path → 400 "Invalid path".
+ *   - Installed skill, missing path query handled upstream (route-level).
+ *   - Uninstalled catalog skill, dev mode → content from repo path.
+ *   - Uninstalled catalog skill, platform mode → content proxied from the
+ *     platform file-content endpoint with snake_case → camelCase mapping.
+ *   - Skill not found anywhere → 404.
+ *
+ * The test exercises the daemon handler directly — route wiring is a thin
+ * pass-through to this function.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { SkillSummary } from "../config/skills.js";
+import type { CatalogSkill } from "../skills/catalog-install.js";
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before importing the module under test
+// ---------------------------------------------------------------------------
+
+// Suppress logger output
+const noopLogger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+  trace: () => {},
+  fatal: () => {},
+  child: () => noopLogger,
+};
+mock.module("../util/logger.js", () => ({
+  getLogger: () => noopLogger,
+  getCliLogger: () => noopLogger,
+  truncateForLog: (v: string) => v,
+  initLogger: () => {},
+  pruneOldLogFiles: () => 0,
+}));
+
+// ── Mutable mock state ──────────────────────────────────────────────────────
+
+let mockResolvedSkills: Array<{
+  summary: SkillSummary;
+  state: "enabled" | "disabled";
+}> = [];
+let mockCatalog: CatalogSkill[] = [];
+let mockRepoSkillsDir: string | undefined = undefined;
+
+mock.module("../config/skills.js", () => ({
+  loadSkillCatalog: () => mockResolvedSkills.map((r) => r.summary),
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({}),
+  invalidateConfigCache: () => {},
+  loadRawConfig: () => ({}),
+  saveRawConfig: () => {},
+}));
+
+mock.module("../config/skill-state.js", () => ({
+  resolveSkillStates: () => mockResolvedSkills,
+  skillFlagKey: () => null,
+}));
+
+mock.module("../config/assistant-feature-flags.js", () => ({
+  isAssistantFeatureFlagEnabled: () => true,
+}));
+
+mock.module("../skills/catalog-cache.js", () => ({
+  getCatalog: async () => mockCatalog,
+}));
+
+mock.module("../skills/catalog-install.js", () => ({
+  installSkillLocally: async () => {},
+  upsertSkillsIndex: () => {},
+  getRepoSkillsDir: () => mockRepoSkillsDir,
+}));
+
+mock.module("../skills/catalog-search.js", () => ({
+  filterByQuery: () => [],
+}));
+
+mock.module("../skills/clawhub.js", () => ({
+  clawhubCheckUpdates: mock(async () => []),
+  clawhubInspect: mock(async () => ({})),
+  clawhubInstall: mock(async () => ({ success: true })),
+  clawhubSearch: mock(async () => ({ skills: [] })),
+  clawhubUpdate: mock(async () => ({ success: true })),
+}));
+
+mock.module("../skills/skillssh-registry.js", () => ({
+  installExternalSkill: mock(async () => {}),
+  resolveSkillSource: () => {
+    throw new Error("not used");
+  },
+  searchSkillsRegistry: mock(async () => []),
+}));
+
+mock.module("../skills/install-meta.js", () => ({
+  readInstallMeta: () => null,
+}));
+
+mock.module("../skills/managed-store.js", () => ({
+  createManagedSkill: () => ({ created: true }),
+  deleteManagedSkill: () => ({ deleted: true }),
+  removeSkillsIndexEntry: () => {},
+  validateManagedSkillId: () => null,
+}));
+
+mock.module("../memory/graph/capability-seed.js", () => ({
+  deleteSkillCapabilityNode: () => {},
+  seedSkillGraphNodes: () => {},
+  seedUninstalledCatalogSkillMemories: async () => {},
+}));
+
+mock.module("../providers/provider-send-message.js", () => ({
+  createTimeout: () => ({
+    signal: AbortSignal.timeout(1000),
+    cleanup: () => {},
+  }),
+  extractText: () => "",
+  getConfiguredProvider: async () => null,
+  userMessage: () => ({}),
+}));
+
+// Real isTextMimeType — we want actual classification here.
+// No mock needed; let it fall through to the real implementation.
+
+mock.module("../util/platform.js", () => ({
+  getWorkspaceSkillsDir: () => "/tmp/test-skills",
+  readPlatformToken: () => null,
+}));
+mock.module("../util/platform.ts", () => ({
+  getWorkspaceSkillsDir: () => "/tmp/test-skills",
+  readPlatformToken: () => null,
+}));
+
+let mockPlatformBaseUrl = "https://platform.test";
+mock.module("../config/env.js", () => ({
+  getPlatformBaseUrl: () => mockPlatformBaseUrl,
+}));
+mock.module("../config/env.ts", () => ({
+  getPlatformBaseUrl: () => mockPlatformBaseUrl,
+}));
+
+mock.module("../daemon/handlers/shared.js", () => ({
+  CONFIG_RELOAD_DEBOUNCE_MS: 100,
+  ensureSkillEntry: () => ({ enabled: false }),
+  log: noopLogger,
+}));
+
+// ---------------------------------------------------------------------------
+// Imports (after mocks)
+// ---------------------------------------------------------------------------
+
+import type { SkillOperationContext } from "../daemon/handlers/skills.js";
+import { getSkillFileContent } from "../daemon/handlers/skills.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const dummyCtx = {
+  debounceTimers: { schedule: () => {} },
+  setSuppressConfigReload: () => {},
+  updateConfigFingerprint: () => {},
+  broadcast: () => {},
+} as unknown as SkillOperationContext;
+
+type FetchFn = typeof globalThis.fetch;
+
+interface FetchCall {
+  url: string;
+  init?: RequestInit;
+}
+
+let originalFetch: FetchFn;
+let fetchCalls: FetchCall[] = [];
+
+function installFetchMock(
+  handler: (url: string, init?: RequestInit) => Response | Promise<Response>,
+): void {
+  fetchCalls = [];
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+    fetchCalls.push({ url, init });
+    return handler(url, init);
+  }) as unknown as FetchFn;
+}
+
+function installFetchForbidden(): void {
+  fetchCalls = [];
+  globalThis.fetch = (async () => {
+    throw new Error("fetch should not have been called");
+  }) as unknown as FetchFn;
+}
+
+const tempDirs: string[] = [];
+
+function makeTempSkillDir(skillId: string): string {
+  const root = mkdtempSync(join(tmpdir(), "skill-file-content-test-"));
+  tempDirs.push(root);
+  const skillDir = join(root, skillId);
+  mkdirSync(skillDir, { recursive: true });
+  return skillDir;
+}
+
+function writeFile(dir: string, relPath: string, content: string | Buffer) {
+  const abs = join(dir, relPath);
+  mkdirSync(join(abs, ".."), { recursive: true });
+  writeFileSync(abs, content);
+}
+
+function installedSkill(id: string, directoryPath: string) {
+  return {
+    summary: {
+      id,
+      name: id,
+      displayName: id,
+      description: id,
+      directoryPath,
+      skillFilePath: join(directoryPath, "SKILL.md"),
+      source: "workspace" as const,
+    },
+    state: "enabled" as const,
+  };
+}
+
+function catalogSkill(id: string): CatalogSkill {
+  return { id, name: id, description: id };
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+  fetchCalls = [];
+  mockResolvedSkills = [];
+  mockCatalog = [];
+  mockRepoSkillsDir = undefined;
+  mockPlatformBaseUrl = "https://platform.test";
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  for (const dir of tempDirs) {
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // best effort
+    }
+  }
+  tempDirs.length = 0;
+});
+
+// ---------------------------------------------------------------------------
+// Installed-skill path
+// ---------------------------------------------------------------------------
+
+describe("getSkillFileContent — installed skill", () => {
+  test("returns text file content for a valid path", async () => {
+    const skillDir = makeTempSkillDir("my-skill");
+    writeFile(skillDir, "SKILL.md", "# hello world\n");
+    mockResolvedSkills = [installedSkill("my-skill", skillDir)];
+    installFetchForbidden();
+
+    const result = await getSkillFileContent("my-skill", "SKILL.md", dummyCtx);
+    expect("error" in result).toBe(false);
+    if ("error" in result) return;
+    expect(result.path).toBe("SKILL.md");
+    expect(result.name).toBe("SKILL.md");
+    expect(result.size).toBe("# hello world\n".length);
+    expect(result.isBinary).toBe(false);
+    expect(result.content).toBe("# hello world\n");
+  });
+
+  test("returns content=null for binary files", async () => {
+    const skillDir = makeTempSkillDir("my-skill");
+    writeFile(
+      skillDir,
+      "img.png",
+      Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    );
+    mockResolvedSkills = [installedSkill("my-skill", skillDir)];
+    installFetchForbidden();
+
+    const result = await getSkillFileContent("my-skill", "img.png", dummyCtx);
+    expect("error" in result).toBe(false);
+    if ("error" in result) return;
+    expect(result.isBinary).toBe(true);
+    expect(result.content).toBeNull();
+    expect(result.name).toBe("img.png");
+  });
+
+  test("rejects traversal paths with 400 Invalid path", async () => {
+    const skillDir = makeTempSkillDir("my-skill");
+    writeFile(skillDir, "SKILL.md", "ok");
+    mockResolvedSkills = [installedSkill("my-skill", skillDir)];
+    installFetchForbidden();
+
+    for (const bad of ["../secrets", "..", "/etc/passwd", "./../escape"]) {
+      const result = await getSkillFileContent("my-skill", bad, dummyCtx);
+      expect("error" in result).toBe(true);
+      if (!("error" in result)) continue;
+      expect(result.status).toBe(400);
+      expect(result.error).toBe("Invalid path");
+    }
+  });
+
+  test("rejects paths containing null bytes with 400", async () => {
+    const skillDir = makeTempSkillDir("my-skill");
+    writeFile(skillDir, "SKILL.md", "ok");
+    mockResolvedSkills = [installedSkill("my-skill", skillDir)];
+    installFetchForbidden();
+
+    const result = await getSkillFileContent(
+      "my-skill",
+      "SKILL.md\0.png",
+      dummyCtx,
+    );
+    expect("error" in result).toBe(true);
+    if (!("error" in result)) return;
+    expect(result.status).toBe(400);
+  });
+
+  test("returns 404 for a missing file inside an installed skill", async () => {
+    const skillDir = makeTempSkillDir("my-skill");
+    writeFile(skillDir, "SKILL.md", "ok");
+    mockResolvedSkills = [installedSkill("my-skill", skillDir)];
+    installFetchForbidden();
+
+    const result = await getSkillFileContent("my-skill", "ghost.txt", dummyCtx);
+    expect("error" in result).toBe(true);
+    if (!("error" in result)) return;
+    expect(result.status).toBe(404);
+    expect(result.error).toBe("File not found");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Catalog fallback — dev mode (uninstalled)
+// ---------------------------------------------------------------------------
+
+describe("getSkillFileContent — uninstalled catalog skill (dev mode)", () => {
+  test("reads content from the repo skills dir without hitting the platform", async () => {
+    // Skill is NOT in the installed catalog, but IS in the platform catalog
+    // and exists on disk under the repo skills dir.
+    const repoSkillsDir = mkdtempSync(
+      join(tmpdir(), "skill-file-content-repo-"),
+    );
+    tempDirs.push(repoSkillsDir);
+    const skillDir = join(repoSkillsDir, "dev-skill");
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, "SKILL.md"), "# dev skill\n");
+
+    mockRepoSkillsDir = repoSkillsDir;
+    mockResolvedSkills = []; // not installed
+    mockCatalog = [catalogSkill("dev-skill")];
+    installFetchForbidden();
+
+    const result = await getSkillFileContent("dev-skill", "SKILL.md", dummyCtx);
+    expect("error" in result).toBe(false);
+    if ("error" in result) return;
+    expect(result.path).toBe("SKILL.md");
+    expect(result.name).toBe("SKILL.md");
+    expect(result.content).toBe("# dev skill\n");
+    expect(result.isBinary).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Catalog fallback — platform mode (uninstalled, no repo checkout)
+// ---------------------------------------------------------------------------
+
+describe("getSkillFileContent — uninstalled catalog skill (platform mode)", () => {
+  test("proxies content from the platform preview endpoint and maps snake_case → camelCase", async () => {
+    mockResolvedSkills = []; // not installed
+    mockCatalog = [catalogSkill("remote-skill")];
+    mockRepoSkillsDir = undefined;
+    installFetchMock(() =>
+      Response.json({
+        path: "SKILL.md",
+        name: "SKILL.md",
+        size: 14,
+        mime_type: "text/markdown",
+        is_binary: false,
+        content: "# hello world\n",
+      }),
+    );
+
+    const result = await getSkillFileContent(
+      "remote-skill",
+      "SKILL.md",
+      dummyCtx,
+    );
+    expect("error" in result).toBe(false);
+    if ("error" in result) return;
+    expect(result.path).toBe("SKILL.md");
+    expect(result.name).toBe("SKILL.md");
+    expect(result.size).toBe(14);
+    expect(result.mimeType).toBe("text/markdown");
+    expect(result.isBinary).toBe(false);
+    expect(result.content).toBe("# hello world\n");
+
+    // Verify the platform endpoint was actually called.
+    expect(fetchCalls.length).toBe(1);
+    expect(
+      fetchCalls[0]!.url.startsWith(
+        "https://platform.test/v1/skills/remote-skill/files/content/",
+      ),
+    ).toBe(true);
+    expect(fetchCalls[0]!.url).toContain("path=SKILL.md");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Skill not found anywhere
+// ---------------------------------------------------------------------------
+
+describe("getSkillFileContent — skill not found", () => {
+  test("returns 404 when the skill is neither installed nor in the catalog", async () => {
+    mockResolvedSkills = [];
+    mockCatalog = [];
+    installFetchForbidden();
+
+    const result = await getSkillFileContent(
+      "ghost-skill",
+      "SKILL.md",
+      dummyCtx,
+    );
+    expect("error" in result).toBe(true);
+    if (!("error" in result)) return;
+    expect(result.status).toBe(404);
+    expect(result.error).toBe("Skill not found");
+  });
+});

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -9,7 +9,7 @@ import {
   statSync,
 } from "node:fs";
 import { homedir } from "node:os";
-import { join, relative } from "node:path";
+import { basename, join, relative, sep } from "node:path";
 
 import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
 import {
@@ -33,7 +33,11 @@ import {
 } from "../../providers/provider-send-message.js";
 import { isTextMimeType as isTextMime } from "../../runtime/routes/workspace-utils.js";
 import { getCatalog } from "../../skills/catalog-cache.js";
-import type { SkillFileEntry } from "../../skills/catalog-files.js";
+import {
+  readCatalogSkillFileContent,
+  sanitizeRelativePath,
+  type SkillFileEntry,
+} from "../../skills/catalog-files.js";
 import {
   installSkillLocally,
   upsertSkillsIndex,
@@ -65,6 +69,7 @@ import {
 import { getWorkspaceSkillsDir } from "../../util/platform.js";
 import type {
   SkillDetailResponse,
+  SkillFileContentResponse,
   SlimSkillResponse,
 } from "../message-types/skills.js";
 import {
@@ -565,6 +570,128 @@ function readDirRecursive(dir: string, rootDir: string): SkillFileEntry[] {
     }
   }
   return entries;
+}
+
+/**
+ * Read a single file's content from an installed or catalog skill.
+ *
+ * Installed-skill path (eager): reads the file directly from the skill's
+ * on-disk directory. Applies lexical containment, symlink rejection, and
+ * realpath containment checks for defense in depth.
+ *
+ * Catalog fallback: when the skill id is not backed by a local directory
+ * (e.g. an uninstalled Vellum catalog skill), delegates to
+ * `readCatalogSkillFileContent`, which handles both the dev-mode repo
+ * checkout path and the platform preview API path internally.
+ */
+export async function getSkillFileContent(
+  skillId: string,
+  relativePath: string,
+  _ctx: SkillOperationContext,
+): Promise<SkillFileContentResponse | { error: string; status: number }> {
+  const sanitized = sanitizeRelativePath(relativePath);
+  if (!sanitized) {
+    return { error: "Invalid path", status: 400 };
+  }
+
+  const found = findSkillById(skillId);
+  if (found && existsSync(found.summary.directoryPath)) {
+    const dir = found.summary.directoryPath;
+    const abs = join(dir, sanitized);
+
+    // Lexical containment: the resolved absolute path must stay inside the
+    // skill directory even after `join` normalization. Cheap short-circuit
+    // before any fs calls.
+    if (!(abs === dir || abs.startsWith(dir + sep))) {
+      return { error: "Invalid path", status: 400 };
+    }
+
+    // Defense-in-depth symlink rejection: refuse to follow a symlinked file
+    // inside the skill dir that could point outside the root. Also catches
+    // symlinked parent directories via a realpath containment check.
+    let lstat;
+    try {
+      lstat = lstatSync(abs);
+    } catch {
+      return { error: "File not found", status: 404 };
+    }
+    if (lstat.isSymbolicLink()) {
+      return { error: "File not found", status: 404 };
+    }
+    if (!lstat.isFile()) {
+      return { error: "File not found", status: 404 };
+    }
+
+    let realAbs: string;
+    let realDir: string;
+    try {
+      realAbs = realpathSync(abs);
+      realDir = realpathSync(dir);
+    } catch {
+      return { error: "File not found", status: 404 };
+    }
+    if (!(realAbs === realDir || realAbs.startsWith(realDir + sep))) {
+      return { error: "File not found", status: 404 };
+    }
+
+    let stat;
+    try {
+      stat = statSync(abs);
+    } catch {
+      return { error: "File not found", status: 404 };
+    }
+    if (!stat.isFile()) {
+      return { error: "File not found", status: 404 };
+    }
+
+    const name = basename(sanitized);
+    const mimeType = Bun.file(abs).type;
+    const isText = isTextMime(mimeType, name);
+    const isBinary = !isText;
+    let content: string | null = null;
+    if (isText && stat.size <= MAX_INLINE_SIZE) {
+      try {
+        content = readFileSync(abs, "utf-8");
+      } catch {
+        content = null;
+      }
+    }
+    return {
+      path: sanitized,
+      name,
+      size: stat.size,
+      mimeType,
+      isBinary,
+      content,
+    };
+  }
+
+  // Catalog fallback: skill is not installed locally (or its directory is
+  // missing on disk). Try the catalog preview helper, which handles both
+  // dev-mode repo checkouts and the platform preview API.
+  let catalog: Awaited<ReturnType<typeof getCatalog>> = [];
+  try {
+    catalog = await getCatalog();
+  } catch {
+    catalog = [];
+  }
+  const inCatalog = catalog.some((s) => s.id === skillId);
+  if (!inCatalog) {
+    return { error: "Skill not found", status: 404 };
+  }
+
+  const result = await readCatalogSkillFileContent(skillId, sanitized);
+  if (!result) {
+    return { error: "File not found", status: 404 };
+  }
+  return {
+    path: result.path,
+    name: result.name,
+    size: result.size,
+    mimeType: result.mimeType,
+    isBinary: result.isBinary,
+    content: result.content,
+  };
 }
 
 export function getSkillFiles(

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -34,9 +34,11 @@ import {
 import { isTextMimeType as isTextMime } from "../../runtime/routes/workspace-utils.js";
 import { getCatalog } from "../../skills/catalog-cache.js";
 import {
+  hasHiddenOrSkippedSegment,
   readCatalogSkillFileContent,
   sanitizeRelativePath,
   type SkillFileEntry,
+  SKIP_DIRS,
 } from "../../skills/catalog-files.js";
 import {
   installSkillLocally,
@@ -507,8 +509,6 @@ export async function getSkill(
 // the other skill handler exports.
 export type { SkillFileEntry } from "../../skills/catalog-files.js";
 
-const SKIP_DIRS = new Set(["node_modules", "__pycache__", ".git"]);
-
 /**
  * Returns true if `filePath` is a symlink whose resolved real path escapes
  * `rootDir`. Symlinks that stay within `rootDir` are allowed; only those that
@@ -591,6 +591,18 @@ export async function getSkillFileContent(
 ): Promise<SkillFileContentResponse | { error: string; status: number }> {
   const sanitized = sanitizeRelativePath(relativePath);
   if (!sanitized) {
+    return { error: "Invalid path", status: 400 };
+  }
+
+  // Reject any sanitized path that references a hidden segment (dotfiles
+  // like `.env`, dot-dirs like `.git`) or a SKIP_DIRS segment (e.g.
+  // `node_modules`, `__pycache__`). Both file-listing endpoints (installed
+  // and catalog) intentionally omit these entries, so allowing the content
+  // endpoint to read them would create a data-exposure path and break
+  // parity with the visible file list. This check runs BEFORE both the
+  // installed-skill disk read and the catalog fallback so the rejection
+  // is uniform regardless of source.
+  if (hasHiddenOrSkippedSegment(sanitized)) {
     return { error: "Invalid path", status: 400 };
   }
 

--- a/assistant/src/daemon/message-types/skills.ts
+++ b/assistant/src/daemon/message-types/skills.ts
@@ -189,6 +189,16 @@ export type SkillDetailResponse =
   | SkillsshSkillDetail
   | CustomSkillDetail;
 
+// ─── Single-file content response (HTTP API) ─────────────────────────────
+export interface SkillFileContentResponse {
+  path: string;
+  name: string;
+  size: number;
+  mimeType: string;
+  isBinary: boolean;
+  content: string | null;
+}
+
 export interface SkillsDraftResponse {
   type: "skills_draft_response";
   success: boolean;

--- a/assistant/src/runtime/routes/skills-routes.ts
+++ b/assistant/src/runtime/routes/skills-routes.ts
@@ -166,6 +166,7 @@ export function skillRouteDefinitions(deps: SkillRouteDeps): RouteDefinition[] {
         {
           name: "path",
           schema: { type: "string" },
+          required: true,
           description: "Relative path of the file within the skill directory",
         },
       ],

--- a/assistant/src/runtime/routes/skills-routes.ts
+++ b/assistant/src/runtime/routes/skills-routes.ts
@@ -19,6 +19,7 @@ import {
   draftSkill,
   enableSkill,
   getSkill,
+  getSkillFileContent,
   getSkillFiles,
   inspectSkill,
   installSkill,
@@ -148,6 +149,54 @@ export function skillRouteDefinitions(deps: SkillRouteDeps): RouteDefinition[] {
             ? await listSkillsWithCatalog(ctx())
             : listSkills(ctx());
         return Response.json({ skills });
+      },
+    },
+
+    // Registered BEFORE `skills/:id/files` so the more-specific pattern is
+    // matched first even if the router's matching rule ever changes.
+    {
+      endpoint: "skills/:id/files/content",
+      method: "GET",
+      policyKey: "skills",
+      summary: "Get skill file content",
+      description:
+        "Return the content of a single file belonging to an installed or catalog skill.",
+      tags: ["skills"],
+      queryParams: [
+        {
+          name: "path",
+          schema: { type: "string" },
+          description: "Relative path of the file within the skill directory",
+        },
+      ],
+      responseBody: z.object({
+        path: z.string(),
+        name: z.string(),
+        size: z.number(),
+        mimeType: z.string(),
+        isBinary: z.boolean(),
+        content: z.string().nullable(),
+      }),
+      handler: async ({ params, url }) => {
+        const path = url.searchParams.get("path");
+        if (!path) {
+          return httpError(
+            "BAD_REQUEST",
+            "path query parameter is required",
+            400,
+          );
+        }
+        const result = await getSkillFileContent(params.id, path, ctx());
+        if ("error" in result) {
+          if (result.status === 400) {
+            return httpError("BAD_REQUEST", result.error, 400);
+          }
+          if (result.status === 404) {
+            return httpError("NOT_FOUND", result.error, 404);
+          }
+          return httpError("INTERNAL_ERROR", result.error, 500);
+        }
+        return Response.json(result);
       },
     },
 

--- a/assistant/src/skills/catalog-files.ts
+++ b/assistant/src/skills/catalog-files.ts
@@ -268,13 +268,32 @@ async function fetchPlatformJson<T>(
 // ─── Dev-mode directory walker ───────────────────────────────────────────────
 
 // Directory names that are always skipped when walking a catalog skill dir in
-// dev mode. Kept in sync with `SKIP_DIRS` in
-// `src/daemon/handlers/skills.ts` (which performs the same filter for
-// installed skills). Duplicated here rather than imported to avoid a
-// circular dependency: `daemon/handlers/skills.ts` already imports the
-// `SkillFileEntry` type from this module. If you add or remove an entry,
-// update the other copy as well.
-const SKIP_DIRS = new Set(["node_modules", "__pycache__", ".git"]);
+// dev mode. Also used by `daemon/handlers/skills.ts` — both for the
+// installed-skill walker and for the single-file content endpoint's
+// hidden/skipped path rejection. Exported so the daemon handler can
+// import this single source of truth and stay in sync.
+export const SKIP_DIRS = new Set(["node_modules", "__pycache__", ".git"]);
+
+/**
+ * Returns true if the given sanitized posix path contains any segment that
+ * is hidden (starts with `.`) or present in `SKIP_DIRS`. Used to reject
+ * file-content reads for paths the listing APIs intentionally hide, so
+ * callers cannot fetch `.env`, `.git/config`, `node_modules/...`, etc. via
+ * the content endpoint even though the listing never surfaces them.
+ *
+ * The input MUST already be a normalized posix path (i.e. the return value
+ * of `sanitizeRelativePath`). This helper does not re-normalize — it splits
+ * on `/` and inspects each segment directly.
+ */
+export function hasHiddenOrSkippedSegment(sanitized: string): boolean {
+  const segments = sanitized.split("/");
+  for (const segment of segments) {
+    if (segment.length === 0) continue;
+    if (segment.startsWith(".")) return true;
+    if (SKIP_DIRS.has(segment)) return true;
+  }
+  return false;
+}
 
 function walkSkillDir(dir: string, rootDir: string): SkillFileEntry[] {
   const out: SkillFileEntry[] = [];
@@ -380,6 +399,12 @@ export async function readCatalogSkillFileContent(
 ): Promise<SkillFileEntry | null> {
   const sanitized = sanitizeRelativePath(relativePath);
   if (!sanitized) return null;
+
+  // Defense in depth: reject any path that references a hidden or
+  // SKIP_DIRS segment. The daemon handler performs the same check before
+  // calling us, but we repeat it here so direct callers of this module
+  // short-circuit without a network round trip and without touching disk.
+  if (hasHiddenOrSkippedSegment(sanitized)) return null;
 
   const source = await resolveCatalogSource(skillId);
   if (!source) return null;

--- a/assistant/src/skills/catalog-files.ts
+++ b/assistant/src/skills/catalog-files.ts
@@ -3,15 +3,14 @@
  * skills, including ones that are NOT installed locally.
  *
  * This module is pure library code: it does NOT wire itself into any handler
- * or route. It is consumed by higher-level daemon handlers introduced in
- * later PRs of the `skill-files-preview` plan.
+ * or route. Higher-level daemon handlers consume it via the exported
+ * `readCatalogSkillFiles` / `readCatalogSkillFileContent` functions.
  *
  * Data sources:
  *   - In `VELLUM_DEV` mode, when `<repo>/skills/<id>/` exists on disk, we
  *     read the skill files directly from the repo checkout (matching the
  *     behavior of `getCatalog()` in dev).
- *   - Otherwise, we call the platform preview endpoints introduced by
- *     vellum-assistant-platform PR #4103:
+ *   - Otherwise, we call the platform preview endpoints:
  *       GET /v1/skills/{skill_id}/files/
  *       GET /v1/skills/{skill_id}/files/content/?path=...
  *
@@ -74,9 +73,9 @@ export interface SkillFileEntry {
 
 // ─── Platform response contracts ─────────────────────────────────────────────
 //
-// Wire format is snake_case (vellum-assistant-platform PR #4103). We map to
-// the daemon's camelCase shape inside this module so nothing downstream needs
-// to know about the platform contract.
+// The platform preview API uses snake_case on the wire. We map to the
+// daemon's camelCase shape inside this module so nothing downstream needs to
+// know about the platform contract.
 
 interface PlatformFileListResponse {
   skill_id: string;


### PR DESCRIPTION
## Summary
- New GET endpoint `/assistants/{assistantId}/skills/:id/files/content?path=...` returning one file's content.
- Works for both installed skills (eager disk read) and uninstalled Vellum catalog skills (delegated to PR 1's `readCatalogSkillFileContent`, which hits the new platform preview endpoints in production).
- Strict path sanitization + defense-in-depth symlink rejection; 400 on bad input, 404 on missing file.

Part of plan: skill-files-preview.md (PR 3 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24489" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
