### PR TITLE
docs: add release note for LLM log retention setting

### DIFF
--- a/assistant/src/prompts/templates/UPDATES.md
+++ b/assistant/src/prompts/templates/UPDATES.md
@@ -36,3 +36,9 @@ Some Slack image attachments were stored incorrectly due to a missing OAuth scop
 This has been fixed automatically: the corrupted attachments were removed from affected conversations during this update, and the OAuth scope issue has been resolved so new image uploads work correctly. If your user mentions missing images from earlier conversations, this is why — the images were never successfully received in the first place.
 <!-- /vellum-update-release:corrupted-attachment-cleanup -->
 
+<!-- vellum-update-release:llm-log-retention-setting -->
+## LLM request log retention is now configurable
+
+Your user can now choose how long LLM request logs are kept on their device from Settings → Permissions & Privacy on the macOS app. The default stays at 1 day, but they can pick 7, 30, or 90 days, or "Never" to retain logs indefinitely. If your user asks about managing their privacy or controlling how much LLM request history is retained locally, point them at this new picker.
+<!-- /vellum-update-release:llm-log-retention-setting -->
+


### PR DESCRIPTION
## Summary
- Add a release note to `assistant/src/prompts/templates/UPDATES.md` announcing the new LLM Request Log Retention setting
- Completes the log-retention-setting plan (PR 6 of 6)

Part of plan: log-retention-setting.md (PR 6 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24490" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
