### PR TITLE
fix(oauth): self-review cleanup — test discovery, mock consistency, trim url

### DIFF
--- a/assistant/src/__tests__/oauth-apps-routes.test.ts
+++ b/assistant/src/__tests__/oauth-apps-routes.test.ts
@@ -44,6 +44,7 @@ mock.module("../oauth/oauth-store.js", () => ({
           displayLabel: "Google",
           description: "Google OAuth provider",
           dashboardUrl: "https://console.cloud.google.com/apis/credentials",
+          logoUrl: null,
           clientIdPlaceholder: null,
           requiresClientSecret: 1,
           managedServiceConfigKey: "google-oauth",

--- a/assistant/src/__tests__/oauth-cli.test.ts
+++ b/assistant/src/__tests__/oauth-cli.test.ts
@@ -196,6 +196,7 @@ mock.module("../oauth/oauth-store.js", () => ({
       displayLabel: params.displayLabel ?? null,
       description: params.description ?? null,
       dashboardUrl: params.dashboardUrl ?? null,
+      logoUrl: params.logoUrl ?? null,
       clientIdPlaceholder: params.clientIdPlaceholder ?? null,
       requiresClientSecret: params.requiresClientSecret ?? 1,
       loopbackPort: params.loopbackPort ?? null,
@@ -255,6 +256,9 @@ mock.module("../oauth/oauth-store.js", () => ({
     }
     if (params.displayLabel !== undefined) {
       updated.displayLabel = params.displayLabel;
+    }
+    if (params.logoUrl !== undefined) {
+      updated.logoUrl = params.logoUrl;
     }
     updated.updatedAt = Date.now();
     mockProviderStore.set(provider, updated);

--- a/assistant/src/__tests__/oauth-provider-seed-logos.test.ts
+++ b/assistant/src/__tests__/oauth-provider-seed-logos.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { PROVIDER_SEED_DATA } from "../seed-providers.js";
+import { PROVIDER_SEED_DATA } from "../oauth/seed-providers.js";
 
 describe("PROVIDER_SEED_DATA logo URLs", () => {
   test("every well-known provider has a Simple Icons CDN logoUrl", () => {

--- a/assistant/src/cli/commands/oauth/providers.ts
+++ b/assistant/src/cli/commands/oauth/providers.ts
@@ -48,9 +48,12 @@ function resolveLogoUrlFromFlags(opts: {
     return `https://cdn.simpleicons.org/${encodeURIComponent(slug)}`;
   }
   if (opts.logoUrl !== undefined) {
-    // Empty string clears the stored value (matches --revoke-url semantics
-    // documented in the `update` command help text).
-    return opts.logoUrl === "" ? null : opts.logoUrl;
+    // Trim whitespace so copy-paste-padded URLs don't fail to parse on the
+    // client. Empty string (after trimming) clears the stored value
+    // (matches --revoke-url semantics documented in the `update` command
+    // help text).
+    const trimmed = opts.logoUrl.trim();
+    return trimmed === "" ? null : trimmed;
   }
   return undefined;
 }


### PR DESCRIPTION
## Summary
Gaps identified during plan self-review for oauth-provider-logos.md:

- Move `oauth-provider-profiles.test.ts` to `src/__tests__/oauth-provider-seed-logos.test.ts` so the Simple Icons URL guard runs in CI (previous path was not discovered by `test.sh`)
- Add `logoUrl: null` to `oauth-apps-routes.test.ts` mock for shape consistency
- Mirror real `registerProvider`/`updateProvider` logoUrl handling in `oauth-cli.test.ts` mocks
- Trim `--logo-url` input in `resolveLogoUrlFromFlags` for consistency with `--logo-simpleicons-slug`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24494" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
