### PR TITLE
feat(browser-relay): CDP event and session invalidation protocol envelopes (PR10)

### DIFF
--- a/assistant/src/__tests__/fixtures/mock-chrome-extension.ts
+++ b/assistant/src/__tests__/fixtures/mock-chrome-extension.ts
@@ -103,6 +103,27 @@ export interface MockChromeExtension {
    * Simulates a flaky extension that drops the connection.
    */
   forceDisconnect(): void;
+  /**
+   * Send a `host_browser_event` frame over the active WebSocket,
+   * mirroring what the extension's host-browser-dispatcher does in
+   * response to `chrome.debugger.onEvent`. Used by PR10 acceptance
+   * tests to assert that the runtime's WS handler fans CDP events
+   * out through the browser-session event bus.
+   */
+  sendHostBrowserEvent(event: {
+    method: string;
+    params?: unknown;
+    cdpSessionId?: string;
+  }): void;
+  /**
+   * Send a `host_browser_session_invalidated` frame over the active
+   * WebSocket, mirroring what the extension's host-browser-dispatcher
+   * does in response to `chrome.debugger.onDetach`. Used by PR10
+   * acceptance tests to assert that the runtime-side session
+   * registry evicts stale sessions and forces reattach on the next
+   * command.
+   */
+  sendSessionInvalidated(event: { targetId?: string; reason?: string }): void;
 }
 
 // ── Defaults ────────────────────────────────────────────────────────
@@ -324,6 +345,31 @@ export function createMockChromeExtension(
           // best-effort
         }
       }
+    },
+    sendHostBrowserEvent(event) {
+      const sock = ws;
+      if (!sock || sock.readyState !== WebSocket.OPEN) return;
+      sock.send(
+        JSON.stringify({
+          type: "host_browser_event",
+          method: event.method,
+          ...(event.params !== undefined ? { params: event.params } : {}),
+          ...(event.cdpSessionId !== undefined
+            ? { cdpSessionId: event.cdpSessionId }
+            : {}),
+        }),
+      );
+    },
+    sendSessionInvalidated(event) {
+      const sock = ws;
+      if (!sock || sock.readyState !== WebSocket.OPEN) return;
+      sock.send(
+        JSON.stringify({
+          type: "host_browser_session_invalidated",
+          ...(event.targetId !== undefined ? { targetId: event.targetId } : {}),
+          ...(event.reason !== undefined ? { reason: event.reason } : {}),
+        }),
+      );
     },
   };
 }

--- a/assistant/src/__tests__/host-browser-event-routes.test.ts
+++ b/assistant/src/__tests__/host-browser-event-routes.test.ts
@@ -1,0 +1,350 @@
+/**
+ * Unit tests for the PR10 client-message envelopes:
+ *   - `host_browser_event`
+ *   - `host_browser_session_invalidated`
+ *
+ * The resolvers exported from `host-browser-routes.ts` are the single
+ * entry point for both the WS and any future HTTP transport. These
+ * tests drive them directly (bypassing the WS upgrade + frame parse
+ * machinery) so we can assert:
+ *
+ *   1. A well-formed `host_browser_event` frame fans out to the
+ *      browser-session event bus — a listener subscribed via
+ *      `onCdpEvent` observes the forwarded event with method + params
+ *      + sessionId preserved.
+ *
+ *   2. A well-formed `host_browser_session_invalidated` frame marks
+ *      the target as invalidated in the runtime-side registry. The
+ *      next `BrowserSessionManager.send()` against a session with
+ *      that targetId evicts the session and throws, forcing the
+ *      owning tool to create a fresh one (which, on the extension
+ *      side, triggers a reattach).
+ *
+ *   3. Malformed frames return a well-typed `BAD_REQUEST` resolution
+ *      so the WS dispatcher in `http-server.ts` can log them without
+ *      tearing down the socket.
+ *
+ * The invalidated-target set is consumed on first lookup (see
+ * `consumeInvalidatedTargetId`), so every test that touches it calls
+ * `__resetBrowserSessionEventsForTests()` in `beforeEach` to start
+ * from a clean slate.
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  __resetBrowserSessionEventsForTests,
+  type BrowserBackend,
+  BrowserSessionManager,
+  consumeInvalidatedTargetId,
+  createExtensionBackend,
+  type ForwardedCdpEvent,
+  isTargetInvalidated,
+  onCdpEvent,
+} from "../browser-session/index.js";
+import {
+  resolveHostBrowserEvent,
+  resolveHostBrowserSessionInvalidated,
+} from "../runtime/routes/host-browser-routes.js";
+
+// ---------------------------------------------------------------------------
+// Shared fixtures
+// ---------------------------------------------------------------------------
+
+function makeBackend(): BrowserBackend {
+  return createExtensionBackend({
+    isAvailable: () => true,
+    sendCdp: async () => ({ result: { ok: true } }),
+    dispose: () => {},
+  });
+}
+
+describe("resolveHostBrowserEvent", () => {
+  beforeEach(() => {
+    __resetBrowserSessionEventsForTests();
+  });
+
+  test("publishes well-formed frames to subscribers", () => {
+    const observed: ForwardedCdpEvent[] = [];
+    const unsubscribe = onCdpEvent((event) => observed.push(event));
+
+    const resolution = resolveHostBrowserEvent({
+      method: "Page.frameNavigated",
+      params: { frame: { id: "frame-1", url: "https://example.com" } },
+      cdpSessionId: "target-abc",
+    });
+
+    expect(resolution.ok).toBe(true);
+    expect(observed).toHaveLength(1);
+    expect(observed[0].method).toBe("Page.frameNavigated");
+    expect(observed[0].params).toEqual({
+      frame: { id: "frame-1", url: "https://example.com" },
+    });
+    expect(observed[0].cdpSessionId).toBe("target-abc");
+
+    unsubscribe();
+  });
+
+  test("tolerates missing params — publishes with params undefined", () => {
+    const observed: ForwardedCdpEvent[] = [];
+    const unsubscribe = onCdpEvent((event) => observed.push(event));
+
+    const resolution = resolveHostBrowserEvent({
+      method: "Target.targetDestroyed",
+    });
+
+    expect(resolution.ok).toBe(true);
+    expect(observed).toHaveLength(1);
+    expect(observed[0].method).toBe("Target.targetDestroyed");
+    expect(observed[0].params).toBeUndefined();
+    expect(observed[0].cdpSessionId).toBeUndefined();
+
+    unsubscribe();
+  });
+
+  test("treats empty-string cdpSessionId as absent", () => {
+    const observed: ForwardedCdpEvent[] = [];
+    const unsubscribe = onCdpEvent((event) => observed.push(event));
+
+    resolveHostBrowserEvent({
+      method: "Runtime.consoleAPICalled",
+      cdpSessionId: "",
+    });
+
+    expect(observed[0].cdpSessionId).toBeUndefined();
+    unsubscribe();
+  });
+
+  test("rejects frames missing a method", () => {
+    const observed: ForwardedCdpEvent[] = [];
+    const unsubscribe = onCdpEvent((event) => observed.push(event));
+
+    const resolution = resolveHostBrowserEvent({});
+
+    expect(resolution.ok).toBe(false);
+    expect(observed).toHaveLength(0);
+
+    unsubscribe();
+  });
+
+  test("rejects frames with a non-string method", () => {
+    const resolution = resolveHostBrowserEvent({ method: 42 });
+    expect(resolution.ok).toBe(false);
+    if (!resolution.ok) {
+      expect(resolution.code).toBe("BAD_REQUEST");
+      expect(resolution.status).toBe(400);
+    }
+  });
+
+  test("multiple subscribers all receive the event", () => {
+    const a: ForwardedCdpEvent[] = [];
+    const b: ForwardedCdpEvent[] = [];
+    const unsubA = onCdpEvent((event) => a.push(event));
+    const unsubB = onCdpEvent((event) => b.push(event));
+
+    resolveHostBrowserEvent({
+      method: "Network.responseReceived",
+      params: { requestId: "r1" },
+    });
+
+    expect(a).toHaveLength(1);
+    expect(b).toHaveLength(1);
+    expect(a[0].method).toBe("Network.responseReceived");
+    expect(b[0].method).toBe("Network.responseReceived");
+
+    unsubA();
+    unsubB();
+  });
+
+  test("unsubscribe stops delivery", () => {
+    const observed: ForwardedCdpEvent[] = [];
+    const unsubscribe = onCdpEvent((event) => observed.push(event));
+
+    resolveHostBrowserEvent({ method: "Page.loadEventFired" });
+    expect(observed).toHaveLength(1);
+
+    unsubscribe();
+    resolveHostBrowserEvent({ method: "Page.loadEventFired" });
+    expect(observed).toHaveLength(1);
+  });
+
+  test("a throwing listener does not block subsequent listeners", () => {
+    const observed: ForwardedCdpEvent[] = [];
+    const unsubA = onCdpEvent(() => {
+      throw new Error("listener exploded");
+    });
+    const unsubB = onCdpEvent((event) => observed.push(event));
+
+    // Must not throw
+    const resolution = resolveHostBrowserEvent({
+      method: "Page.frameNavigated",
+    });
+
+    expect(resolution.ok).toBe(true);
+    expect(observed).toHaveLength(1);
+
+    unsubA();
+    unsubB();
+  });
+});
+
+describe("resolveHostBrowserSessionInvalidated", () => {
+  beforeEach(() => {
+    __resetBrowserSessionEventsForTests();
+  });
+
+  test("marks the target as invalidated in the registry", () => {
+    const resolution = resolveHostBrowserSessionInvalidated({
+      targetId: "tab-42",
+      reason: "target_closed",
+    });
+
+    expect(resolution.ok).toBe(true);
+    expect(isTargetInvalidated("tab-42")).toBe(true);
+  });
+
+  test("tolerates frames with no targetId (advisory only)", () => {
+    const resolution = resolveHostBrowserSessionInvalidated({
+      reason: "canceled_by_user",
+    });
+
+    expect(resolution.ok).toBe(true);
+  });
+
+  test("rejects frames whose targetId is not a string", () => {
+    const resolution = resolveHostBrowserSessionInvalidated({
+      targetId: 42 as unknown as string,
+    });
+
+    expect(resolution.ok).toBe(false);
+    if (!resolution.ok) {
+      expect(resolution.code).toBe("BAD_REQUEST");
+    }
+  });
+
+  test("BrowserSessionManager evicts a session whose targetId was invalidated and next send forces reattach", async () => {
+    // Track every CDP command the backend sees so we can assert that
+    // the first send (post-invalidation) never reached the backend
+    // while the second send (after reattach) did.
+    const sent: Array<{ method: string }> = [];
+    const backend = createExtensionBackend({
+      isAvailable: () => true,
+      sendCdp: async (command) => {
+        sent.push({ method: command.method });
+        return { result: { ok: true } };
+      },
+      dispose: () => {},
+    });
+
+    const manager = new BrowserSessionManager({ backends: [backend] });
+    const session = manager.createSession();
+    // Tag the session with a targetId — this is how a real tool
+    // invocation would bind its runtime-side session to the
+    // extension's debuggee target.
+    session.targetId = "tab-42";
+
+    // Fire the invalidation envelope as if the extension just
+    // forwarded a detach over the relay WebSocket.
+    const resolution = resolveHostBrowserSessionInvalidated({
+      targetId: "tab-42",
+      reason: "target_closed",
+    });
+    expect(resolution.ok).toBe(true);
+
+    // The next send against the invalidated session MUST throw —
+    // the manager consumes the invalidation flag, evicts the
+    // session, and rejects the command so the caller can create a
+    // fresh session (which triggers a reattach on the extension
+    // side).
+    await expect(
+      manager.send(session.id, { method: "Page.navigate" }),
+    ).rejects.toThrow(/invalidated/);
+
+    // Sanity: the backend never saw the doomed command.
+    expect(sent).toHaveLength(0);
+
+    // The evicted session is gone — sending again throws
+    // "Unknown browser session".
+    await expect(
+      manager.send(session.id, { method: "Page.navigate" }),
+    ).rejects.toThrow(/Unknown browser session/);
+
+    // Creating a fresh session proves the reattach path works: the
+    // caller bounces through `createSession` and a subsequent send
+    // dispatches normally through the backend.
+    const fresh = manager.createSession();
+    const result = await manager.send(fresh.id, { method: "Page.navigate" });
+    expect(result.result).toEqual({ ok: true });
+    expect(sent).toEqual([{ method: "Page.navigate" }]);
+  });
+
+  test("invalidation is consumed on first lookup (set never grows unbounded)", async () => {
+    // Registering the invalidation once should affect only the next
+    // send against that target. A second send against a brand-new
+    // session with the same targetId must NOT be evicted — the entry
+    // was already consumed by the first eviction.
+    const sent: Array<{ method: string }> = [];
+    const backend = createExtensionBackend({
+      isAvailable: () => true,
+      sendCdp: async (command) => {
+        sent.push({ method: command.method });
+        return { result: { ok: true } };
+      },
+      dispose: () => {},
+    });
+    const manager = new BrowserSessionManager({ backends: [backend] });
+
+    resolveHostBrowserSessionInvalidated({ targetId: "tab-99" });
+
+    const first = manager.createSession();
+    first.targetId = "tab-99";
+    await expect(
+      manager.send(first.id, { method: "Page.navigate" }),
+    ).rejects.toThrow(/invalidated/);
+
+    // Second session bound to the same targetId — should dispatch
+    // normally because the registry entry was consumed.
+    const second = manager.createSession();
+    second.targetId = "tab-99";
+    const result = await manager.send(second.id, {
+      method: "Page.navigate",
+    });
+    expect(result.result).toEqual({ ok: true });
+    expect(sent).toHaveLength(1);
+  });
+
+  test("consumeInvalidatedTargetId drains the entry", () => {
+    resolveHostBrowserSessionInvalidated({ targetId: "tab-1" });
+    expect(consumeInvalidatedTargetId("tab-1")).toBe(true);
+    // Second consume is a no-op — the entry was already drained.
+    expect(consumeInvalidatedTargetId("tab-1")).toBe(false);
+  });
+
+  test("invalidateSession on BrowserSessionManager evicts by id", () => {
+    const manager = new BrowserSessionManager({ backends: [makeBackend()] });
+    const session = manager.createSession();
+    expect(manager.getSession(session.id)).toBeDefined();
+    expect(manager.invalidateSession(session.id)).toBe(true);
+    expect(manager.getSession(session.id)).toBeUndefined();
+    // Second invalidate returns false — nothing to remove.
+    expect(manager.invalidateSession(session.id)).toBe(false);
+  });
+
+  test("invalidateByTargetId evicts every session matching the target", () => {
+    const manager = new BrowserSessionManager({ backends: [makeBackend()] });
+    const a = manager.createSession();
+    a.targetId = "tab-7";
+    const b = manager.createSession();
+    b.targetId = "tab-7";
+    const c = manager.createSession();
+    c.targetId = "tab-8";
+
+    expect(manager.invalidateByTargetId("tab-7")).toBe(2);
+    expect(manager.getSession(a.id)).toBeUndefined();
+    expect(manager.getSession(b.id)).toBeUndefined();
+    expect(manager.getSession(c.id)).toBeDefined();
+
+    // Second invalidate returns 0 — both matching sessions are gone.
+    expect(manager.invalidateByTargetId("tab-7")).toBe(0);
+  });
+});

--- a/assistant/src/__tests__/host-browser-ws-events-e2e.test.ts
+++ b/assistant/src/__tests__/host-browser-ws-events-e2e.test.ts
@@ -1,0 +1,320 @@
+/**
+ * End-to-end WebSocket dispatch test for the PR10 envelopes:
+ *
+ *   - `host_browser_event` — the extension forwards every
+ *     `chrome.debugger.onEvent` firing to the runtime over the
+ *     browser-relay WebSocket. This test asserts that the runtime's
+ *     inbound frame handler fans the event out to subscribers of the
+ *     module-level browser-session event bus with the method + params
+ *     + cdpSessionId preserved.
+ *
+ *   - `host_browser_session_invalidated` — the extension forwards a
+ *     detach notification over the same socket. This test asserts
+ *     that the runtime-side `BrowserSessionManager` evicts any stale
+ *     session whose `targetId` matches the invalidated envelope and
+ *     that the next CDP command against that session throws, forcing
+ *     the owning tool to create a fresh session (which in production
+ *     triggers a reattach on the extension's dispatcher).
+ *
+ * Unlike the unit test in `host-browser-event-routes.test.ts`, this
+ * file stands up the full `RuntimeHttpServer` so the WS upgrade,
+ * frame parse, dispatch switch, and resolver helpers all run through
+ * their production code paths. The capability-token transport is
+ * used so the test does not depend on a valid guardian-bound JWT.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ── Module mocks (must be declared before the real imports below) ───
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    ui: {},
+    model: "test",
+    provider: "test",
+    memory: { enabled: false },
+    rateLimit: { maxRequestsPerMinute: 0 },
+    secretDetection: { enabled: false },
+    contextWindow: { maxInputTokens: 200000 },
+    services: {
+      inference: {
+        mode: "your-own",
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+      },
+      "image-generation": {
+        mode: "your-own",
+        provider: "gemini",
+        model: "gemini-3.1-flash-image-preview",
+      },
+      "web-search": { mode: "your-own", provider: "inference-provider-native" },
+    },
+  }),
+}));
+
+// ── Real imports (after mocks) ──────────────────────────────────────
+
+import {
+  __resetBrowserSessionEventsForTests,
+  BrowserSessionManager,
+  createExtensionBackend,
+  type ForwardedCdpEvent,
+  onCdpEvent,
+} from "../browser-session/index.js";
+import { getDb, initializeDb } from "../memory/db.js";
+import { mintHostBrowserCapability } from "../runtime/capability-tokens.js";
+import {
+  __resetChromeExtensionRegistryForTests,
+  getChromeExtensionRegistry,
+} from "../runtime/chrome-extension-registry.js";
+import { RuntimeHttpServer } from "../runtime/http-server.js";
+import * as pendingInteractions from "../runtime/pending-interactions.js";
+
+initializeDb();
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+async function waitFor(
+  predicate: () => boolean,
+  timeoutMs = 2000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() > deadline) {
+      throw new Error(
+        `waitFor: predicate did not become true within ${timeoutMs}ms`,
+      );
+    }
+    await new Promise((r) => setTimeout(r, 10));
+  }
+}
+
+async function waitForRegistryEntry(
+  guardianId: string,
+  timeoutMs = 2000,
+): Promise<void> {
+  await waitFor(
+    () => getChromeExtensionRegistry().get(guardianId) !== undefined,
+    timeoutMs,
+  );
+}
+
+// ── Tests ───────────────────────────────────────────────────────────
+
+describe("host_browser WS event + invalidation e2e", () => {
+  let server: RuntimeHttpServer;
+  let port: number;
+  let runtimeBaseUrl: string;
+
+  beforeEach(async () => {
+    const db = getDb();
+    db.run("DELETE FROM contact_channels");
+    db.run("DELETE FROM contacts");
+    pendingInteractions.clear();
+    __resetChromeExtensionRegistryForTests();
+    __resetBrowserSessionEventsForTests();
+
+    // Pick a non-colliding port in the same band as the other
+    // host-browser e2e tests but offset so parallel runs don't
+    // step on one another.
+    port = 19900 + Math.floor(Math.random() * 200);
+    runtimeBaseUrl = `http://127.0.0.1:${port}`;
+    server = new RuntimeHttpServer({ port });
+    await server.start();
+  });
+
+  afterEach(async () => {
+    await server?.stop();
+    pendingInteractions.clear();
+    __resetChromeExtensionRegistryForTests();
+    __resetBrowserSessionEventsForTests();
+  });
+
+  test("host_browser_event frame fans out to browser-session event bus subscribers", async () => {
+    const guardianId = `guardian-${crypto.randomUUID()}`;
+    const { token } = mintHostBrowserCapability(guardianId);
+
+    const { createMockChromeExtension } =
+      await import("./fixtures/mock-chrome-extension.js");
+    const mockExt = createMockChromeExtension({
+      runtimeBaseUrl,
+      token,
+      resultTransport: "ws",
+    });
+    await mockExt.start();
+    await mockExt.waitForConnection();
+    await waitForRegistryEntry(guardianId);
+
+    // Subscribe BEFORE sending the frame so we're guaranteed to see
+    // the fanout. The subscription is module-level so it survives
+    // across the WS round-trip naturally.
+    const observed: ForwardedCdpEvent[] = [];
+    const unsubscribe = onCdpEvent((event) => observed.push(event));
+
+    mockExt.sendHostBrowserEvent({
+      method: "Page.frameNavigated",
+      params: { frame: { id: "frame-1", url: "https://example.com" } },
+      cdpSessionId: "target-abc",
+    });
+
+    // The WS dispatch hop is asynchronous — poll until the event
+    // lands or the test times out.
+    await waitFor(() => observed.length === 1);
+
+    expect(observed[0].method).toBe("Page.frameNavigated");
+    expect(observed[0].params).toEqual({
+      frame: { id: "frame-1", url: "https://example.com" },
+    });
+    expect(observed[0].cdpSessionId).toBe("target-abc");
+
+    unsubscribe();
+    await mockExt.stop();
+  });
+
+  test("host_browser_event frames with no params are still routed", async () => {
+    const guardianId = `guardian-${crypto.randomUUID()}`;
+    const { token } = mintHostBrowserCapability(guardianId);
+
+    const { createMockChromeExtension } =
+      await import("./fixtures/mock-chrome-extension.js");
+    const mockExt = createMockChromeExtension({
+      runtimeBaseUrl,
+      token,
+      resultTransport: "ws",
+    });
+    await mockExt.start();
+    await mockExt.waitForConnection();
+    await waitForRegistryEntry(guardianId);
+
+    const observed: ForwardedCdpEvent[] = [];
+    const unsubscribe = onCdpEvent((event) => observed.push(event));
+
+    mockExt.sendHostBrowserEvent({ method: "Target.targetDestroyed" });
+
+    await waitFor(() => observed.length === 1);
+    expect(observed[0].method).toBe("Target.targetDestroyed");
+    expect(observed[0].params).toBeUndefined();
+    expect(observed[0].cdpSessionId).toBeUndefined();
+
+    unsubscribe();
+    await mockExt.stop();
+  });
+
+  test("host_browser_session_invalidated frame evicts stale sessions and the next command forces reattach", async () => {
+    const guardianId = `guardian-${crypto.randomUUID()}`;
+    const { token } = mintHostBrowserCapability(guardianId);
+
+    const { createMockChromeExtension } =
+      await import("./fixtures/mock-chrome-extension.js");
+    const mockExt = createMockChromeExtension({
+      runtimeBaseUrl,
+      token,
+      resultTransport: "ws",
+    });
+    await mockExt.start();
+    await mockExt.waitForConnection();
+    await waitForRegistryEntry(guardianId);
+
+    // Stand up a BrowserSessionManager that mirrors what a tool
+    // invocation would build. The backend counts dispatch attempts
+    // so we can assert the first post-invalidation send never
+    // reached the backend while the second (after reattach) did.
+    const sent: Array<{ method: string }> = [];
+    const backend = createExtensionBackend({
+      isAvailable: () => true,
+      sendCdp: async (command) => {
+        sent.push({ method: command.method });
+        return { result: { ok: true } };
+      },
+      dispose: () => {},
+    });
+    const manager = new BrowserSessionManager({ backends: [backend] });
+    const session = manager.createSession();
+    session.targetId = "tab-77";
+
+    // Fire the invalidation envelope from the extension side.
+    mockExt.sendSessionInvalidated({
+      targetId: "tab-77",
+      reason: "target_closed",
+    });
+
+    // Wait until the WS dispatch hop lands — `isTargetInvalidated`
+    // peeks at the registry without consuming the entry, so we can
+    // poll safely.
+    const { isTargetInvalidated } =
+      await import("../browser-session/events.js");
+    await waitFor(() => isTargetInvalidated("tab-77"));
+
+    // The next send against the invalidated session MUST throw —
+    // the manager consumes the invalidation flag, evicts the
+    // session, and rejects the command so the caller can create a
+    // fresh session (which triggers a reattach on the extension
+    // side).
+    await expect(
+      manager.send(session.id, { method: "Page.navigate" }),
+    ).rejects.toThrow(/invalidated/);
+
+    // Sanity: the backend never saw the doomed command.
+    expect(sent).toHaveLength(0);
+
+    // The evicted session is gone — sending again throws
+    // "Unknown browser session", which is the signal a tool uses
+    // to rebuild a fresh session.
+    await expect(
+      manager.send(session.id, { method: "Page.navigate" }),
+    ).rejects.toThrow(/Unknown browser session/);
+
+    // Creating a fresh session proves the reattach path works:
+    // the caller bounces through `createSession` and a subsequent
+    // send dispatches normally through the backend.
+    const fresh = manager.createSession();
+    const result = await manager.send(fresh.id, {
+      method: "Page.navigate",
+    });
+    expect(result.result).toEqual({ ok: true });
+    expect(sent).toEqual([{ method: "Page.navigate" }]);
+
+    await mockExt.stop();
+  });
+
+  test("malformed host_browser_event frames are dropped without tearing down the socket", async () => {
+    const guardianId = `guardian-${crypto.randomUUID()}`;
+    const { token } = mintHostBrowserCapability(guardianId);
+
+    const { createMockChromeExtension } =
+      await import("./fixtures/mock-chrome-extension.js");
+    const mockExt = createMockChromeExtension({
+      runtimeBaseUrl,
+      token,
+      resultTransport: "ws",
+    });
+    await mockExt.start();
+    await mockExt.waitForConnection();
+    await waitForRegistryEntry(guardianId);
+
+    const observed: ForwardedCdpEvent[] = [];
+    const unsubscribe = onCdpEvent((event) => observed.push(event));
+
+    // Send a frame with no method — the resolver must reject it
+    // and the WS dispatcher must swallow the rejection.
+    mockExt.sendHostBrowserEvent({ method: "" });
+
+    // Follow up with a valid frame and assert that ONLY the valid
+    // frame was published — proving the socket survived the bad
+    // frame and the dispatcher kept processing subsequent messages.
+    mockExt.sendHostBrowserEvent({ method: "Page.loadEventFired" });
+
+    await waitFor(() => observed.length === 1);
+    expect(observed[0].method).toBe("Page.loadEventFired");
+
+    unsubscribe();
+    await mockExt.stop();
+  });
+});

--- a/assistant/src/browser-session/events.ts
+++ b/assistant/src/browser-session/events.ts
@@ -1,0 +1,164 @@
+/**
+ * Module-level event bus for out-of-band browser-session signals.
+ *
+ * The `host_browser_event` and `host_browser_session_invalidated`
+ * envelopes (see `assistant/src/daemon/message-types/host-browser.ts`)
+ * carry unsolicited CDP events and detach notifications from the
+ * chrome extension to the daemon. Unlike `host_browser_result`, these
+ * frames are not tied to a specific in-flight request and cannot be
+ * routed through `pending-interactions`. Instead they publish into
+ * this bus, where tool-side consumers subscribe to react to the signal.
+ *
+ * Two distinct surfaces:
+ *
+ *   1. **CDP event listeners** — free-form subscribers that observe
+ *      every incoming `host_browser_event`. Primarily a seam for
+ *      future work (event-driven session tracking, lifecycle
+ *      instrumentation, tool-side reactive hooks) and for tests that
+ *      need to assert that events were routed.
+ *
+ *   2. **Invalidated target registry** — a short-lived set of target
+ *      ids that the extension has reported as detached. The
+ *      `BrowserSessionManager` checks this set on its next `send()`
+ *      and evicts any matching session before dispatch so the
+ *      extension dispatcher can re-attach fresh. Entries are
+ *      consumed on first lookup to keep the set from growing
+ *      unbounded across long-running processes.
+ *
+ * Both surfaces are intentionally transport-agnostic — the WS and
+ * HTTP paths both publish through the same module so the routing
+ * semantics stay in lockstep.
+ */
+
+import { getLogger } from "../util/logger.js";
+
+const log = getLogger("browser-session-events");
+
+// ---------------------------------------------------------------------------
+// CDP event listener surface
+// ---------------------------------------------------------------------------
+
+/**
+ * A forwarded CDP event as consumed by runtime-side subscribers. The
+ * wire shape comes from `HostBrowserEvent` in
+ * `assistant/src/daemon/message-types/host-browser.ts` and is stripped
+ * of its `type` discriminator here for ergonomic subscriber code.
+ */
+export interface ForwardedCdpEvent {
+  /** CDP event method name, e.g. "Page.frameNavigated". */
+  method: string;
+  /** CDP event params forwarded verbatim. Opaque to the bus. */
+  params?: unknown;
+  /**
+   * Optional CDP session id — present for flat child sessions routed
+   * through `Target.attachToTarget` with `flatten: true`.
+   */
+  cdpSessionId?: string;
+}
+
+export type CdpEventListener = (event: ForwardedCdpEvent) => void;
+
+const cdpEventListeners = new Set<CdpEventListener>();
+
+/**
+ * Subscribe to forwarded CDP events. Returns an unsubscribe function;
+ * callers MUST invoke it at end-of-lifecycle to avoid leaking closures
+ * into the module-level set. Listener errors are caught and logged so
+ * a broken subscriber cannot take down the WS dispatch path.
+ */
+export function onCdpEvent(listener: CdpEventListener): () => void {
+  cdpEventListeners.add(listener);
+  return () => {
+    cdpEventListeners.delete(listener);
+  };
+}
+
+/**
+ * Fan an incoming CDP event out to all registered listeners. Called
+ * by the WS frame dispatcher in
+ * `assistant/src/runtime/routes/host-browser-routes.ts` after a
+ * `host_browser_event` envelope has been validated.
+ */
+export function publishCdpEvent(event: ForwardedCdpEvent): void {
+  for (const listener of cdpEventListeners) {
+    try {
+      listener(event);
+    } catch (err) {
+      log.warn(
+        { err, method: event.method },
+        "CDP event listener threw — suppressing to protect dispatcher",
+      );
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Invalidated target registry
+// ---------------------------------------------------------------------------
+
+/**
+ * Short-lived set of target ids the chrome extension has reported as
+ * detached since the last `consumeInvalidatedTargetId` lookup. The
+ * `BrowserSessionManager.invalidateByTargetId` path reads entries
+ * out of this set on each `send()` and evicts any matching session
+ * before dispatch.
+ *
+ * Entries are consumed on first read so the set never grows
+ * unbounded. If a future consumer needs multiple reads of the same
+ * invalidation, a separate long-lived registry should be introduced
+ * — this set is scoped to the minimum viable behaviour for
+ * "next command forces reattach".
+ */
+const invalidatedTargetIds = new Set<string>();
+
+/**
+ * Record that the chrome extension has reported a target as
+ * detached. Idempotent — re-marking a target is a no-op. Logs at
+ * debug because the signal is benign (just a lifecycle notification)
+ * and noisy in high-churn workloads.
+ */
+export function markTargetInvalidated(targetId: string, reason?: string): void {
+  invalidatedTargetIds.add(targetId);
+  log.debug({ targetId, reason }, "browser-session target invalidated");
+}
+
+/**
+ * Peek at whether a given target id is currently marked invalidated
+ * without consuming the entry. Primarily used by tests — production
+ * consumers should call {@link consumeInvalidatedTargetId} so the
+ * set stays bounded.
+ */
+export function isTargetInvalidated(targetId: string): boolean {
+  return invalidatedTargetIds.has(targetId);
+}
+
+/**
+ * Test-only helper: snapshot the current invalidated set without
+ * draining it. Exported so unit tests can assert exact set contents
+ * across multiple frames; production code must not rely on this.
+ */
+export function __peekInvalidatedTargetIdsForTests(): string[] {
+  return Array.from(invalidatedTargetIds);
+}
+
+/**
+ * Atomically remove and return a target id from the invalidated set.
+ * Returns `true` when the id was present (and has now been removed),
+ * `false` otherwise. Designed to be called by
+ * `BrowserSessionManager.send()` so the first dispatch after a
+ * detach forces a reattach and subsequent dispatches proceed normally.
+ */
+export function consumeInvalidatedTargetId(targetId: string): boolean {
+  return invalidatedTargetIds.delete(targetId);
+}
+
+/**
+ * Test-only helper: clear the entire invalidated set. Not exported
+ * from any public index — used by unit tests that need a clean slate
+ * between cases. Not safe to call from production code because it
+ * would race against concurrent invalidations.
+ */
+export function __resetBrowserSessionEventsForTests(): void {
+  cdpEventListeners.clear();
+  invalidatedTargetIds.clear();
+}

--- a/assistant/src/browser-session/index.ts
+++ b/assistant/src/browser-session/index.ts
@@ -11,5 +11,6 @@
  */
 export * from "./backends/extension.js";
 export * from "./backends/local.js";
+export * from "./events.js";
 export * from "./manager.js";
 export * from "./types.js";

--- a/assistant/src/browser-session/manager.ts
+++ b/assistant/src/browser-session/manager.ts
@@ -1,5 +1,6 @@
 import { v4 as uuid } from "uuid";
 
+import { consumeInvalidatedTargetId } from "./events.js";
 import type {
   BrowserBackend,
   BrowserSession,
@@ -62,6 +63,23 @@ export class BrowserSessionManager {
       if (!session) {
         throw new Error(`Unknown browser session: ${sessionId}`);
       }
+      // If the chrome extension has reported this session's target
+      // as detached since the last dispatch, evict the session and
+      // throw so the caller can create a fresh one. Reading (and
+      // consuming) the invalidation flag here keeps the "next
+      // command forces reattach" semantics in lockstep with the
+      // host_browser_session_invalidated envelope handler — without
+      // this check the manager would happily forward a CDP command
+      // against a torn-down target and hit a permanent failure.
+      if (
+        session.targetId !== undefined &&
+        consumeInvalidatedTargetId(session.targetId)
+      ) {
+        this.sessions.delete(sessionId);
+        throw new Error(
+          `Browser session ${sessionId} was invalidated (target ${session.targetId} detached)`,
+        );
+      }
       const matched = this.backends.find((b) => b.kind === session.backendKind);
       if (!matched) {
         throw new Error(
@@ -85,6 +103,53 @@ export class BrowserSessionManager {
 
   disposeSession(id: string): void {
     this.sessions.delete(id);
+  }
+
+  /**
+   * Evict a session that the backend has informed us is no longer
+   * valid — e.g. the chrome extension dispatched a
+   * `host_browser_session_invalidated` envelope after Chrome detached
+   * the debugger from the underlying tab/target.
+   *
+   * Functionally equivalent to {@link disposeSession} today (both
+   * remove the session from the manager's map so a subsequent
+   * `send()` throws "Unknown browser session") but preserved as a
+   * distinct method so call sites can stay explicit about intent.
+   * Callers that receive a detach/invalidated signal should use this
+   * method; callers that are cleaning up at end-of-lifecycle should
+   * use {@link disposeSession}.
+   *
+   * Returns `true` when a session was actually removed, `false` when
+   * no session with that id was tracked. Returning a boolean lets
+   * transport-level dispatchers (see
+   * `resolveHostBrowserSessionInvalidated`) log at the right level
+   * based on whether the invalidation had any effect.
+   */
+  invalidateSession(id: string): boolean {
+    return this.sessions.delete(id);
+  }
+
+  /**
+   * Evict every session whose opaque `targetId` matches the supplied
+   * id. Used by the WS dispatcher when a `host_browser_session_invalidated`
+   * envelope arrives without a manager-level session id: the
+   * extension-side dispatcher only knows its own `tabId` / `targetId`
+   * and does not carry our uuid session handle.
+   *
+   * Returns the number of sessions removed. A zero return does not
+   * necessarily indicate an error — the target may not have a
+   * runtime-side session attached to it yet, or the session may
+   * already have been disposed by its owning tool.
+   */
+  invalidateByTargetId(targetId: string): number {
+    let removed = 0;
+    for (const [id, session] of this.sessions) {
+      if (session.targetId === targetId) {
+        this.sessions.delete(id);
+        removed += 1;
+      }
+    }
+    return removed;
   }
 
   disposeAll(): void {

--- a/assistant/src/daemon/message-protocol.ts
+++ b/assistant/src/daemon/message-protocol.ts
@@ -78,7 +78,10 @@ import type {
   _GuardianActionsServerMessages,
 } from "./message-types/guardian-actions.js";
 import type { _HostBashServerMessages } from "./message-types/host-bash.js";
-import type { _HostBrowserServerMessages } from "./message-types/host-browser.js";
+import type {
+  _HostBrowserClientMessages,
+  _HostBrowserServerMessages,
+} from "./message-types/host-browser.js";
 import type { _HostCuServerMessages } from "./message-types/host-cu.js";
 import type { _HostFileServerMessages } from "./message-types/host-file.js";
 import type {
@@ -159,6 +162,7 @@ export type ClientMessage =
   | _ContactsClientMessages
   | _WorkItemsClientMessages
   | _BrowserClientMessages
+  | _HostBrowserClientMessages
   | _SubagentsClientMessages
   | _DocumentsClientMessages
   | _GuardianActionsClientMessages

--- a/assistant/src/daemon/message-types/host-browser.ts
+++ b/assistant/src/daemon/message-types/host-browser.ts
@@ -23,8 +23,78 @@ export interface HostBrowserCancelRequest {
   requestId: string;
 }
 
+// === Client → Server ===
+
+/**
+ * Unsolicited CDP event forwarded from the chrome extension to the
+ * runtime. The extension subscribes to `chrome.debugger.onEvent` and
+ * pushes each event here so the runtime can observe lifecycle signals
+ * (e.g. `Target.targetDestroyed`, `Page.frameNavigated`,
+ * `Network.requestWillBeSent`) without having to round-trip a CDP
+ * command. Events are routed through the relay WebSocket using the
+ * same envelope vocabulary as `host_browser_result`.
+ *
+ * The envelope is transport-level only — the runtime dispatcher in
+ * `resolveHostBrowserEvent` fans out into a module-level event bus
+ * that tool-side consumers (currently just the
+ * BrowserSessionRegistry) subscribe to by method name. No request/
+ * response contract is implied; events can arrive at any time while
+ * a chrome extension is attached and there is no ordering guarantee
+ * relative to `host_browser_result` frames.
+ */
+export interface HostBrowserEvent {
+  type: "host_browser_event";
+  /** CDP event method name, e.g. "Page.frameNavigated", "Target.targetDestroyed". */
+  method: string;
+  /** CDP event params forwarded verbatim. Opaque to the runtime. */
+  params?: unknown;
+  /**
+   * Optional CDP session id — populated for flat child sessions
+   * routed through `Target.attachToTarget` with `flatten: true`.
+   * Matches the `source.sessionId` field surfaced by Chrome 125+ in
+   * its `chrome.debugger.onEvent` callback.
+   */
+  cdpSessionId?: string;
+}
+
+/**
+ * Notification that the chrome extension has lost its debugger
+ * attachment to a target (tab closed, user clicked Cancel on the
+ * infobar, navigation across origins, another debugger took over
+ * via `Target.attachToTarget`, or the extension itself tore the
+ * session down on worker shutdown).
+ *
+ * The runtime dispatcher evicts any in-memory session state that
+ * references the invalidated target so the next CDP command from a
+ * tool force a fresh attach on the extension side. The extension's
+ * `host-browser-dispatcher` clears its local attach cache in the
+ * same way — the two signals are symmetric and together make
+ * reattach deterministic across the round-trip.
+ */
+export interface HostBrowserSessionInvalidated {
+  type: "host_browser_session_invalidated";
+  /**
+   * Opaque target identifier. When the extension detached from a
+   * top-level tab target, this is the tab's id as a string. For a
+   * flat child session it is the CDP sessionId. Matches the shape
+   * used on the `cdpSessionId` field of outbound
+   * `host_browser_request` frames so runtime-side session lookups
+   * can use either field interchangeably.
+   */
+  targetId?: string;
+  /**
+   * Free-form human-readable reason surfaced by Chrome via
+   * `chrome.debugger.onDetach`. Used only for logging.
+   */
+  reason?: string;
+}
+
 // --- Domain-level union aliases (consumed by the barrel file) ---
 
 export type _HostBrowserServerMessages =
   | HostBrowserRequest
   | HostBrowserCancelRequest;
+
+export type _HostBrowserClientMessages =
+  | HostBrowserEvent
+  | HostBrowserSessionInvalidated;

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -160,7 +160,9 @@ import { heartbeatRouteDefinitions } from "./routes/heartbeat-routes.js";
 import { hostBashRouteDefinitions } from "./routes/host-bash-routes.js";
 import {
   hostBrowserRouteDefinitions,
+  resolveHostBrowserEvent,
   resolveHostBrowserResultByRequestId,
+  resolveHostBrowserSessionInvalidated,
 } from "./routes/host-browser-routes.js";
 import { hostCuRouteDefinitions } from "./routes/host-cu-routes.js";
 import { hostFileRouteDefinitions } from "./routes/host-file-routes.js";
@@ -411,17 +413,24 @@ export class RuntimeHttpServer {
               ? message
               : new TextDecoder().decode(message);
           if ("wsType" in data && data.wsType === "browser-relay") {
-            // Inbound frames on `/v1/browser-relay` carry
-            // `host_browser_result` envelopes submitted by the Chrome
-            // extension. The extension can also POST results to
-            // `/v1/host-browser-result` over HTTP — both transports
-            // route through `resolveHostBrowserResultByRequestId` so
-            // the validation and resolution semantics stay in lockstep.
+            // Inbound frames on `/v1/browser-relay` carry one of:
+            //   - `host_browser_result` — paired response to an outbound
+            //     `host_browser_request` (see PR2).
+            //   - `host_browser_event` — unsolicited CDP event forwarded
+            //     from the extension's `chrome.debugger.onEvent`
+            //     subscription (PR10).
+            //   - `host_browser_session_invalidated` — detach
+            //     notification forwarded from the extension's
+            //     `chrome.debugger.onDetach` subscription (PR10).
             //
-            // Malformed frames are logged at debug and swallowed — we
-            // never throw out of a WebSocket `message` handler because
-            // an uncaught exception would tear down the whole socket
-            // for an attacker-controlled payload.
+            // Every supported frame type delegates into a shared
+            // resolver exported from `host-browser-routes.ts` so the
+            // validation and resolution semantics stay in lockstep
+            // with the HTTP path. Malformed or unsupported frames are
+            // logged at debug and swallowed — we never throw out of a
+            // WebSocket `message` handler because an uncaught
+            // exception would tear down the whole socket for an
+            // attacker-controlled payload.
             let parsed: unknown;
             try {
               parsed = JSON.parse(raw);
@@ -443,33 +452,80 @@ export class RuntimeHttpServer {
               return;
             }
             const frame = parsed as Record<string, unknown>;
-            if (frame.type !== "host_browser_result") {
-              log.debug(
-                { connectionId: data.connectionId, type: frame.type },
-                "browser-relay: dropped unsupported inbound frame type",
-              );
-              return;
+            switch (frame.type) {
+              case "host_browser_result": {
+                const resolution = resolveHostBrowserResultByRequestId({
+                  requestId: frame.requestId,
+                  content: frame.content,
+                  isError: frame.isError,
+                });
+                if (!resolution.ok) {
+                  log.warn(
+                    {
+                      connectionId: data.connectionId,
+                      requestId:
+                        typeof frame.requestId === "string"
+                          ? frame.requestId
+                          : undefined,
+                      code: resolution.code,
+                      message: resolution.message,
+                    },
+                    "browser-relay: host_browser_result frame rejected",
+                  );
+                }
+                return;
+              }
+              case "host_browser_event": {
+                const resolution = resolveHostBrowserEvent({
+                  method: frame.method,
+                  params: frame.params,
+                  cdpSessionId: frame.cdpSessionId,
+                });
+                if (!resolution.ok) {
+                  log.warn(
+                    {
+                      connectionId: data.connectionId,
+                      method:
+                        typeof frame.method === "string"
+                          ? frame.method
+                          : undefined,
+                      code: resolution.code,
+                      message: resolution.message,
+                    },
+                    "browser-relay: host_browser_event frame rejected",
+                  );
+                }
+                return;
+              }
+              case "host_browser_session_invalidated": {
+                const resolution = resolveHostBrowserSessionInvalidated({
+                  targetId: frame.targetId,
+                  reason: frame.reason,
+                });
+                if (!resolution.ok) {
+                  log.warn(
+                    {
+                      connectionId: data.connectionId,
+                      targetId:
+                        typeof frame.targetId === "string"
+                          ? frame.targetId
+                          : undefined,
+                      code: resolution.code,
+                      message: resolution.message,
+                    },
+                    "browser-relay: host_browser_session_invalidated frame rejected",
+                  );
+                }
+                return;
+              }
+              default: {
+                log.debug(
+                  { connectionId: data.connectionId, type: frame.type },
+                  "browser-relay: dropped unsupported inbound frame type",
+                );
+                return;
+              }
             }
-            const resolution = resolveHostBrowserResultByRequestId({
-              requestId: frame.requestId,
-              content: frame.content,
-              isError: frame.isError,
-            });
-            if (!resolution.ok) {
-              log.warn(
-                {
-                  connectionId: data.connectionId,
-                  requestId:
-                    typeof frame.requestId === "string"
-                      ? frame.requestId
-                      : undefined,
-                  code: resolution.code,
-                  message: resolution.message,
-                },
-                "browser-relay: host_browser_result frame rejected",
-              );
-            }
-            return;
           }
           const callSessionId = (data as RelayWebSocketData).callSessionId;
           if (callSessionId) {

--- a/assistant/src/runtime/routes/host-browser-routes.ts
+++ b/assistant/src/runtime/routes/host-browser-routes.ts
@@ -6,6 +6,10 @@
  */
 import { z } from "zod";
 
+import {
+  markTargetInvalidated,
+  publishCdpEvent,
+} from "../../browser-session/events.js";
 import { requireBoundGuardian } from "../auth/require-bound-guardian.js";
 import type { AuthContext } from "../auth/types.js";
 import { httpError } from "../http-errors.js";
@@ -116,6 +120,109 @@ export function resolveHostBrowserResultByRequestId(frame: {
     content: normalizedContent,
     isError: normalizedIsError,
   });
+
+  return { ok: true };
+}
+
+/**
+ * Result of attempting to resolve a `host_browser_event` frame. The
+ * event surface never fails — every well-formed frame is published
+ * to the runtime-side CDP event bus — so the resolution is either
+ * `ok: true` or a `BAD_REQUEST` when the frame is malformed. Kept as
+ * a discriminated union (rather than `void`) so the WS dispatcher
+ * can log rejected frames with a consistent shape.
+ */
+export type HostBrowserEventResolution =
+  | { ok: true }
+  | {
+      ok: false;
+      code: "BAD_REQUEST";
+      status: 400;
+      message: string;
+    };
+
+/**
+ * Shared resolver for `host_browser_event` envelopes. Publishes the
+ * event into the module-level browser-session event bus where
+ * runtime-side consumers can subscribe. Validation is intentionally
+ * minimal — the frame is opaque to the bus and the bus's listeners
+ * are the ones that care about params shape.
+ */
+export function resolveHostBrowserEvent(frame: {
+  method?: unknown;
+  params?: unknown;
+  cdpSessionId?: unknown;
+}): HostBrowserEventResolution {
+  const { method, params, cdpSessionId } = frame;
+
+  if (!method || typeof method !== "string") {
+    return {
+      ok: false,
+      code: "BAD_REQUEST",
+      status: 400,
+      message: "method is required",
+    };
+  }
+
+  publishCdpEvent({
+    method,
+    params,
+    cdpSessionId:
+      typeof cdpSessionId === "string" && cdpSessionId.length > 0
+        ? cdpSessionId
+        : undefined,
+  });
+
+  return { ok: true };
+}
+
+/**
+ * Result of attempting to resolve a `host_browser_session_invalidated`
+ * frame. Mirrors {@link HostBrowserEventResolution} — publishing into
+ * the invalidated-target registry never fails, so the resolution is
+ * either `ok: true` or a `BAD_REQUEST` on a malformed frame.
+ */
+export type HostBrowserSessionInvalidatedResolution =
+  | { ok: true }
+  | {
+      ok: false;
+      code: "BAD_REQUEST";
+      status: 400;
+      message: string;
+    };
+
+/**
+ * Shared resolver for `host_browser_session_invalidated` envelopes.
+ * Marks the target as invalidated in the runtime-side registry; the
+ * next `BrowserSessionManager.send()` against that target will
+ * evict the stale session and force the owning tool to reattach.
+ *
+ * A frame without a `targetId` is tolerated (some detach notifications
+ * carry only a `reason`) but logged at info because it is less
+ * actionable than a targeted invalidation — the caller can still
+ * subscribe to the event bus to observe the signal.
+ */
+export function resolveHostBrowserSessionInvalidated(frame: {
+  targetId?: unknown;
+  reason?: unknown;
+}): HostBrowserSessionInvalidatedResolution {
+  const { targetId, reason } = frame;
+
+  if (targetId !== undefined && typeof targetId !== "string") {
+    return {
+      ok: false,
+      code: "BAD_REQUEST",
+      status: 400,
+      message: "targetId must be a string when present",
+    };
+  }
+
+  if (typeof targetId === "string" && targetId.length > 0) {
+    markTargetInvalidated(
+      targetId,
+      typeof reason === "string" ? reason : undefined,
+    );
+  }
 
   return { ok: true };
 }

--- a/clients/chrome-extension/background/__tests__/host-browser-dispatcher.test.ts
+++ b/clients/chrome-extension/background/__tests__/host-browser-dispatcher.test.ts
@@ -12,9 +12,11 @@ import { describe, test, expect, beforeEach } from 'bun:test';
 import {
   createHostBrowserDispatcher,
   type HostBrowserDispatcher,
+  type HostBrowserEventEnvelope,
   type HostBrowserRequestEnvelope,
   type HostBrowserCancelEnvelope,
   type HostBrowserResultEnvelope,
+  type HostBrowserSessionInvalidatedEnvelope,
 } from '../host-browser-dispatcher.js';
 import type {
   CdpProxy,
@@ -54,8 +56,15 @@ interface MockCdpProxy extends CdpProxy {
    * calling these directly via the `fireDetach` helper below.
    */
   detachHandlers: Set<(target: CdpDebuggee, reason: string) => void>;
+  /**
+   * Currently-registered onEvent handlers. Tests fire CDP events by
+   * calling these directly via the `fireEvent` helper below.
+   */
+  eventHandlers: Set<(event: CdpEventFrame) => void>;
   /** Synthetically dispatch a detach event to all registered handlers. */
   fireDetach(target: CdpDebuggee, reason?: string): void;
+  /** Synthetically dispatch a CDP event to all registered handlers. */
+  fireEvent(event: CdpEventFrame): void;
 }
 
 function createMockCdpProxy(options: MockCdpProxyOptions = {}): MockCdpProxy {
@@ -75,6 +84,7 @@ function createMockCdpProxy(options: MockCdpProxyOptions = {}): MockCdpProxy {
     sendCalls,
     detachCalls,
     detachHandlers,
+    eventHandlers,
     get disposeCalls() {
       return disposeCalls;
     },
@@ -107,6 +117,9 @@ function createMockCdpProxy(options: MockCdpProxyOptions = {}): MockCdpProxy {
     fireDetach(target, reason = 'target_closed') {
       for (const h of detachHandlers) h(target, reason);
     },
+    fireEvent(event) {
+      for (const h of eventHandlers) h(event);
+    },
     dispose() {
       disposeCalls += 1;
       eventHandlers.clear();
@@ -120,6 +133,8 @@ interface DispatcherTestHarness {
   dispatcher: HostBrowserDispatcher;
   proxy: MockCdpProxy;
   results: HostBrowserResultEnvelope[];
+  forwardedEvents: HostBrowserEventEnvelope[];
+  forwardedInvalidations: HostBrowserSessionInvalidatedEnvelope[];
   resolveTargetCalls: Array<string | undefined>;
   /** Override this to throw from resolveTarget. */
   resolveTargetImpl: (
@@ -127,17 +142,27 @@ interface DispatcherTestHarness {
   ) => Promise<{ tabId?: number; targetId?: string }>;
   /** Override this to throw from postResult. */
   postResultImpl: (result: HostBrowserResultEnvelope) => Promise<void>;
+  /** Optional override that lets a test simulate forwardCdpEvent throwing. */
+  forwardCdpEventImpl?: (event: HostBrowserEventEnvelope) => void;
+  /** Optional override that lets a test simulate forwardSessionInvalidated throwing. */
+  forwardSessionInvalidatedImpl?: (
+    event: HostBrowserSessionInvalidatedEnvelope,
+  ) => void;
 }
 
 function createHarness(options: MockCdpProxyOptions = {}): DispatcherTestHarness {
   const proxy = createMockCdpProxy(options);
   const results: HostBrowserResultEnvelope[] = [];
+  const forwardedEvents: HostBrowserEventEnvelope[] = [];
+  const forwardedInvalidations: HostBrowserSessionInvalidatedEnvelope[] = [];
   const resolveTargetCalls: Array<string | undefined> = [];
 
   const harness: DispatcherTestHarness = {
     dispatcher: null as unknown as HostBrowserDispatcher,
     proxy,
     results,
+    forwardedEvents,
+    forwardedInvalidations,
     resolveTargetCalls,
     resolveTargetImpl: async (cdpSessionId) => {
       if (cdpSessionId) return { targetId: cdpSessionId };
@@ -156,6 +181,20 @@ function createHarness(options: MockCdpProxyOptions = {}): DispatcherTestHarness
     },
     postResult: async (result) => {
       await harness.postResultImpl(result);
+    },
+    forwardCdpEvent: (event) => {
+      if (harness.forwardCdpEventImpl) {
+        harness.forwardCdpEventImpl(event);
+        return;
+      }
+      forwardedEvents.push(event);
+    },
+    forwardSessionInvalidated: (event) => {
+      if (harness.forwardSessionInvalidatedImpl) {
+        harness.forwardSessionInvalidatedImpl(event);
+        return;
+      }
+      forwardedInvalidations.push(event);
     },
   });
 
@@ -907,6 +946,177 @@ describe('createHostBrowserDispatcher', () => {
       // the proxy isn't left holding a stale closure that references the
       // disposed dispatcher's `attachedTargets` set.
       expect(harness.proxy.detachHandlers.size).toBe(0);
+    });
+
+    test('unsubscribes the onEvent handler', async () => {
+      harness = createHarness({ sendResult: { id: 1, result: {} } });
+
+      // PR10: the dispatcher subscribes to proxy.onEvent so it can
+      // forward CDP events to the runtime. After dispose, the
+      // subscription must be released — otherwise the proxy keeps
+      // a stale closure referencing the disposed dispatcher's hooks.
+      expect(harness.proxy.eventHandlers.size).toBe(1);
+
+      harness.dispatcher.dispose();
+
+      expect(harness.proxy.eventHandlers.size).toBe(0);
+    });
+  });
+
+  // ── PR10: CDP event forwarding ─────────────────────────────────────
+
+  describe('forwardCdpEvent — chrome.debugger.onEvent forwarding', () => {
+    test('forwards CDP events to the worker hook with method, params, and sessionId', () => {
+      // Fire a flat-session event from chrome.debugger and assert
+      // that the dispatcher's `forwardCdpEvent` hook was invoked
+      // with a host_browser_event envelope carrying the same fields.
+      // The CdpEventFrame's `sessionId` field maps to the envelope's
+      // `cdpSessionId` field — see host-browser-dispatcher.ts for
+      // the rationale on the rename.
+      harness.proxy.fireEvent({
+        method: 'Page.frameNavigated',
+        params: { frame: { id: 'frame-1', url: 'https://example.com' } },
+        sessionId: 'flat-session-xyz',
+      });
+
+      expect(harness.forwardedEvents.length).toBe(1);
+      expect(harness.forwardedEvents[0]).toEqual({
+        type: 'host_browser_event',
+        method: 'Page.frameNavigated',
+        params: { frame: { id: 'frame-1', url: 'https://example.com' } },
+        cdpSessionId: 'flat-session-xyz',
+      });
+    });
+
+    test('forwards events with no params and no sessionId', () => {
+      harness.proxy.fireEvent({ method: 'Target.targetDestroyed' });
+
+      expect(harness.forwardedEvents.length).toBe(1);
+      expect(harness.forwardedEvents[0]).toEqual({
+        type: 'host_browser_event',
+        method: 'Target.targetDestroyed',
+        params: undefined,
+        cdpSessionId: undefined,
+      });
+    });
+
+    test('multiple events fired in sequence are forwarded in order', () => {
+      harness.proxy.fireEvent({ method: 'Page.loadEventFired' });
+      harness.proxy.fireEvent({ method: 'Network.responseReceived' });
+      harness.proxy.fireEvent({ method: 'Runtime.consoleAPICalled' });
+
+      expect(harness.forwardedEvents.length).toBe(3);
+      expect(harness.forwardedEvents.map((e) => e.method)).toEqual([
+        'Page.loadEventFired',
+        'Network.responseReceived',
+        'Runtime.consoleAPICalled',
+      ]);
+    });
+
+    test('a throwing forwardCdpEvent hook does not crash the dispatcher', () => {
+      harness.forwardCdpEventImpl = () => {
+        throw new Error('forwarder exploded');
+      };
+
+      // Must not throw out of the proxy's onEvent firing path —
+      // otherwise an unhandled exception in the worker's relay
+      // helper would tear down the chrome.debugger.onEvent listener
+      // and silently break event forwarding.
+      expect(() =>
+        harness.proxy.fireEvent({ method: 'Page.frameNavigated' }),
+      ).not.toThrow();
+    });
+
+    test('a dispatcher with no forwardCdpEvent hook still tolerates events', () => {
+      // Build a fresh dispatcher that omits the hook entirely. The
+      // proxy still notifies its event handlers (since the dispatcher
+      // subscribes unconditionally so unsubscribe is symmetric on
+      // dispose) — the handler must short-circuit when no hook is
+      // wired.
+      const proxy = createMockCdpProxy();
+      const dispatcher = createHostBrowserDispatcher({
+        cdpProxy: proxy,
+        resolveTarget: async () => ({ tabId: 1 }),
+        postResult: async () => {},
+      });
+      expect(() =>
+        proxy.fireEvent({ method: 'Page.frameNavigated' }),
+      ).not.toThrow();
+      dispatcher.dispose();
+    });
+  });
+
+  // ── PR10: detach → host_browser_session_invalidated forwarding ────
+
+  describe('forwardSessionInvalidated — chrome.debugger.onDetach forwarding', () => {
+    test('forwards a tabId detach as a stringified targetId envelope', () => {
+      // Sanity-check the runtime's expectation: the wire envelope
+      // always carries `targetId` as a string, even when the
+      // underlying detach was for a numeric tabId.
+      harness.proxy.fireDetach({ tabId: 42 }, 'target_closed');
+
+      expect(harness.forwardedInvalidations.length).toBe(1);
+      expect(harness.forwardedInvalidations[0]).toEqual({
+        type: 'host_browser_session_invalidated',
+        targetId: '42',
+        reason: 'target_closed',
+      });
+    });
+
+    test('forwards a targetId detach with the targetId preserved verbatim', () => {
+      harness.proxy.fireDetach(
+        { targetId: 'target-xyz' },
+        'canceled_by_user',
+      );
+
+      expect(harness.forwardedInvalidations.length).toBe(1);
+      expect(harness.forwardedInvalidations[0]).toEqual({
+        type: 'host_browser_session_invalidated',
+        targetId: 'target-xyz',
+        reason: 'canceled_by_user',
+      });
+    });
+
+    test('forwards detaches with neither tabId nor targetId as advisory envelopes', () => {
+      // The dispatcher tolerates this shape (e.g. an extensionId-only
+      // detach) and surfaces it without a targetId so the runtime
+      // logger has visibility into the signal.
+      harness.proxy.fireDetach({}, 'extension_unloaded');
+
+      expect(harness.forwardedInvalidations.length).toBe(1);
+      expect(harness.forwardedInvalidations[0]).toEqual({
+        type: 'host_browser_session_invalidated',
+        targetId: undefined,
+        reason: 'extension_unloaded',
+      });
+    });
+
+    test('still clears the local attach cache when forwarding fails', async () => {
+      // Wire a forwarder that throws to assert that local cache
+      // eviction (the legacy onDetach behaviour) is unaffected by a
+      // broken runtime forwarder. The forward and the local
+      // bookkeeping must be independent.
+      harness = createHarness({ sendResult: { id: 1, result: {} } });
+      harness.forwardSessionInvalidatedImpl = () => {
+        throw new Error('forwarder exploded');
+      };
+
+      await harness.dispatcher.handle(sampleRequest);
+      expect(harness.proxy.attachCalls.length).toBe(1);
+
+      // The fire-detach call must NOT throw despite the forwarder
+      // exploding internally — the dispatcher catches and logs.
+      expect(() =>
+        harness.proxy.fireDetach({ tabId: 42 }, 'target_closed'),
+      ).not.toThrow();
+
+      // The next request should still re-attach because the local
+      // attachedTargets cache was cleared by onDetach.
+      await harness.dispatcher.handle({
+        ...sampleRequest,
+        requestId: 'req-2',
+      });
+      expect(harness.proxy.attachCalls.length).toBe(2);
     });
   });
 });

--- a/clients/chrome-extension/background/host-browser-dispatcher.ts
+++ b/clients/chrome-extension/background/host-browser-dispatcher.ts
@@ -16,6 +16,7 @@
 import {
   createCdpProxy,
   type CdpDebuggee,
+  type CdpEventFrame,
   type CdpProxy,
   type CdpTarget,
 } from './cdp-proxy.js';
@@ -59,6 +60,42 @@ export interface HostBrowserResultEnvelope {
   isError: boolean;
 }
 
+/**
+ * Unsolicited CDP event envelope forwarded from the extension to the
+ * runtime. Mirrors the `HostBrowserEvent` client-message type in
+ * `assistant/src/daemon/message-types/host-browser.ts`. The dispatcher
+ * builds one of these for every `chrome.debugger.onEvent` firing and
+ * hands it off to the worker's `onCdpEvent` hook, which is responsible
+ * for pushing the frame onto the browser-relay WebSocket.
+ */
+export interface HostBrowserEventEnvelope {
+  type: 'host_browser_event';
+  method: string;
+  params?: unknown;
+  cdpSessionId?: string;
+}
+
+/**
+ * Session-invalidation envelope forwarded from the extension to the
+ * runtime. Mirrors the `HostBrowserSessionInvalidated` client-message
+ * type in `assistant/src/daemon/message-types/host-browser.ts`. The
+ * dispatcher builds one of these whenever
+ * `chrome.debugger.onDetach` fires and hands it off to the worker's
+ * `onSessionInvalidated` hook; the worker ships it over the relay
+ * WebSocket so the runtime can evict any stale `BrowserSessionManager`
+ * session and force a reattach on the next command.
+ *
+ * `targetId` is the string form of the detached debuggee's `tabId`
+ * (most common) or `targetId` (flat-session path). When the detach
+ * carries neither the field is omitted — the runtime tolerates the
+ * shape but the invalidation becomes advisory.
+ */
+export interface HostBrowserSessionInvalidatedEnvelope {
+  type: 'host_browser_session_invalidated';
+  targetId?: string;
+  reason?: string;
+}
+
 export interface HostBrowserDispatcherDeps {
   /**
    * Target resolver. When `cdpSessionId` is provided it is treated as an
@@ -71,6 +108,31 @@ export interface HostBrowserDispatcherDeps {
   ): Promise<{ tabId?: number; targetId?: string }>;
   /** POST result envelope back to /v1/host-browser-result. */
   postResult(result: HostBrowserResultEnvelope): Promise<void>;
+  /**
+   * Optional hook invoked for every `chrome.debugger.onEvent` firing.
+   * The worker wires this to {@link postHostBrowserEvent} so the
+   * envelope is forwarded over the active relay WebSocket. Errors
+   * thrown from the hook are caught and logged — a broken forwarder
+   * must never take down the dispatcher's event subscription.
+   *
+   * When omitted, CDP events are observed and dropped. Useful for
+   * unit tests that don't care about the forwarding side.
+   */
+  forwardCdpEvent?: (event: HostBrowserEventEnvelope) => void;
+  /**
+   * Optional hook invoked for every `chrome.debugger.onDetach` firing
+   * after the dispatcher has evicted its local attach cache. The
+   * worker wires this to {@link postHostBrowserSessionInvalidated}
+   * so the runtime-side session state can be evicted in lockstep.
+   * Errors thrown from the hook are caught and logged.
+   *
+   * When omitted, detach signals still clear the local cache but are
+   * not forwarded to the runtime — useful for unit tests that exercise
+   * the cache eviction semantics in isolation.
+   */
+  forwardSessionInvalidated?: (
+    event: HostBrowserSessionInvalidatedEnvelope,
+  ) => void;
   /** Optional injected CdpProxy for tests. Defaults to a real proxy at runtime. */
   cdpProxy?: CdpProxy;
 }
@@ -139,9 +201,66 @@ export function createHostBrowserDispatcher(
   // Target.attachToTarget. Without this subscription the cache would hold
   // a stale entry forever and subsequent commands against the same target
   // would skip the re-attach and hit a permanent CDP failure.
-  const unsubscribeOnDetach = proxy.onDetach((debuggee) => {
+  //
+  // PR10: when a `forwardSessionInvalidated` hook is wired in, we ALSO
+  // ship a `host_browser_session_invalidated` envelope over the relay
+  // WebSocket so the runtime-side `BrowserSessionManager` can evict its
+  // own session state in lockstep. The runtime's eviction is advisory —
+  // tools create sessions per-invocation and the extension is the
+  // source of truth for attach state — but without the forward the
+  // runtime cannot know to force a reattach after a cross-origin
+  // navigation closed the previous tab under it.
+  const unsubscribeOnDetach = proxy.onDetach((debuggee, reason) => {
     const key = debuggeeKey(debuggee);
     if (key !== null) attachedTargets.delete(key);
+    if (deps.forwardSessionInvalidated) {
+      // Stringify tabId so the wire shape is always a string — the
+      // runtime's resolver does not try to coerce between number and
+      // string, and tabId is conceptually opaque once it crosses the
+      // browser/runtime boundary.
+      const targetId = debuggee.targetId
+        ? debuggee.targetId
+        : debuggee.tabId !== undefined
+          ? String(debuggee.tabId)
+          : undefined;
+      try {
+        deps.forwardSessionInvalidated({
+          type: 'host_browser_session_invalidated',
+          targetId,
+          reason,
+        });
+      } catch (err) {
+        console.error(
+          '[host-browser-dispatcher] forwardSessionInvalidated threw',
+          err,
+        );
+      }
+    }
+  });
+
+  // Subscribe to CDP events and forward each one to the worker's
+  // `forwardCdpEvent` hook when one is wired. This is the sibling of
+  // the session-invalidated forwarding above — together they give the
+  // runtime visibility into every chrome.debugger signal the extension
+  // sees, even when no `host_browser_request` is currently in flight.
+  // When no hook is provided the event subscription is still registered
+  // (cdp-proxy only delivers to registered handlers anyway) so there
+  // is no cost to the cold path.
+  const unsubscribeOnEvent = proxy.onEvent((event: CdpEventFrame) => {
+    if (!deps.forwardCdpEvent) return;
+    try {
+      deps.forwardCdpEvent({
+        type: 'host_browser_event',
+        method: event.method,
+        params: event.params,
+        cdpSessionId: event.sessionId,
+      });
+    } catch (err) {
+      console.error(
+        '[host-browser-dispatcher] forwardCdpEvent threw',
+        err,
+      );
+    }
   });
 
   async function handle(envelope: HostBrowserRequestEnvelope): Promise<void> {
@@ -299,6 +418,7 @@ export function createHostBrowserDispatcher(
     inFlight.clear();
     attachedTargets.clear();
     unsubscribeOnDetach();
+    unsubscribeOnEvent();
     proxy.dispose();
   }
 

--- a/clients/chrome-extension/background/relay-connection.ts
+++ b/clients/chrome-extension/background/relay-connection.ts
@@ -22,7 +22,11 @@
  * docstring for the current Phase 2 behaviour.
  */
 
-import type { HostBrowserResultEnvelope } from './host-browser-dispatcher.js';
+import type {
+  HostBrowserEventEnvelope,
+  HostBrowserResultEnvelope,
+  HostBrowserSessionInvalidatedEnvelope,
+} from './host-browser-dispatcher.js';
 
 /** Reconnect backoff bounds mirror the legacy inline worker.ts values. */
 const RECONNECT_BASE_MS = 1_000;
@@ -417,6 +421,70 @@ export interface RelayConnectionLike {
   isOpen(): boolean;
   send(data: string): void;
   getCurrentMode(): RelayMode;
+}
+
+/**
+ * Send a `host_browser_event` frame over the relay WebSocket.
+ *
+ * Unlike {@link postHostBrowserResult}, event frames are unsolicited
+ * and do not have an HTTP fallback — the runtime only accepts them
+ * through the `/v1/browser-relay` WebSocket's inbound frame handler
+ * (see `resolveHostBrowserEvent` in host-browser-routes.ts). When
+ * the socket is missing or not currently OPEN the frame is silently
+ * dropped: events are inherently lossy (Chrome will fire many more
+ * before the next reconnect) and the caller has no useful recovery
+ * path.
+ *
+ * This function is intentionally synchronous — `relay.send()` is
+ * fire-and-forget — but the return type stays `void` so callers
+ * don't accidentally `await` it and tie the dispatcher's fast path
+ * to the microtask queue.
+ */
+export function postHostBrowserEvent(
+  connection: RelayConnectionLike | null,
+  event: HostBrowserEventEnvelope,
+): void {
+  if (!connection || !connection.isOpen()) {
+    // Events are lossy — the extension will fire many more of them on
+    // the next reconnect, so dropping is the correct behaviour.
+    return;
+  }
+  try {
+    connection.send(JSON.stringify(event));
+  } catch (err) {
+    // Same swallow-and-log posture as the other fire-and-forget
+    // helpers: a send failure here must never surface as an unhandled
+    // rejection in the service worker.
+    console.warn(
+      '[vellum-relay] host-browser-event send failed',
+      err,
+    );
+  }
+}
+
+/**
+ * Send a `host_browser_session_invalidated` frame over the relay
+ * WebSocket. Same lossy semantics as {@link postHostBrowserEvent}:
+ * when the socket is missing or not OPEN the signal is dropped
+ * silently, because the runtime-side session-invalidation registry
+ * is advisory and the next successful reconnect will re-establish
+ * attach state from scratch anyway.
+ */
+export function postHostBrowserSessionInvalidated(
+  connection: RelayConnectionLike | null,
+  event: HostBrowserSessionInvalidatedEnvelope,
+): void {
+  if (!connection || !connection.isOpen()) {
+    return;
+  }
+  try {
+    connection.send(JSON.stringify(event));
+  } catch (err) {
+    console.warn(
+      '[vellum-relay] host-browser-session-invalidated send failed',
+      err,
+    );
+  }
 }
 
 /**

--- a/clients/chrome-extension/background/worker.ts
+++ b/clients/chrome-extension/background/worker.ts
@@ -38,13 +38,17 @@ import {
 import {
   createHostBrowserDispatcher,
   type HostBrowserDispatcher,
+  type HostBrowserEventEnvelope,
   type HostBrowserRequestEnvelope,
   type HostBrowserCancelEnvelope,
   type HostBrowserResultEnvelope,
+  type HostBrowserSessionInvalidatedEnvelope,
 } from './host-browser-dispatcher.js';
 import {
   RelayConnection,
+  postHostBrowserEvent,
   postHostBrowserResult,
+  postHostBrowserSessionInvalidated,
   type RelayMode,
   type RelayReconnectContext,
   type RelayReconnectDecision,
@@ -231,9 +235,43 @@ async function dispatchHostBrowserResult(
   return postHostBrowserResult(fallbackMode, null, result);
 }
 
+/**
+ * Forward a `host_browser_event` envelope over the active relay
+ * WebSocket. Events are fire-and-forget: if no connection is open the
+ * envelope is dropped. The extension-side dispatcher calls this hook
+ * for every `chrome.debugger.onEvent` firing (see PR10); the runtime
+ * receives the frame via the WS handler in `http-server.ts` and fans
+ * it out through the module-level browser-session event bus.
+ *
+ * We intentionally do NOT fall back to a POST here because CDP events
+ * are lossy — Chrome will emit many more before the next reconnect,
+ * so queuing a POST during a WebSocket outage just piles up stale
+ * notifications that the runtime cannot act on.
+ */
+function dispatchHostBrowserEvent(envelope: HostBrowserEventEnvelope): void {
+  postHostBrowserEvent(relayConnection, envelope);
+}
+
+/**
+ * Forward a `host_browser_session_invalidated` envelope over the
+ * active relay WebSocket. Same fire-and-forget semantics as
+ * {@link dispatchHostBrowserEvent} — a dropped invalidation is
+ * recoverable because the extension's own attach cache is cleared
+ * in lockstep (see `host-browser-dispatcher.ts`), and the runtime's
+ * next command will fail fast with "Unknown browser session" when
+ * a stale session handle is reused after a reconnect.
+ */
+function dispatchHostBrowserSessionInvalidated(
+  envelope: HostBrowserSessionInvalidatedEnvelope,
+): void {
+  postHostBrowserSessionInvalidated(relayConnection, envelope);
+}
+
 const hostBrowserDispatcher: HostBrowserDispatcher = createHostBrowserDispatcher({
   resolveTarget: resolveHostBrowserTarget,
   postResult: dispatchHostBrowserResult,
+  forwardCdpEvent: dispatchHostBrowserEvent,
+  forwardSessionInvalidated: dispatchHostBrowserSessionInvalidated,
 });
 
 // ── Storage helpers ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- New client-message envelopes: host_browser_event and host_browser_session_invalidated
- Extension forwards chrome.debugger.onEvent and onDetach over relay WS
- Runtime consumes envelopes and updates session state via BrowserSessionManager
- Invalidated sessions are evicted and next command forces reattach

Part of plan: browser-use-main-remediation-plan-2026-04-08.md (PR 10 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24495" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
