### PR TITLE
fix(assistant): reset cleanup-scheduler throttle on retention config change

### DIFF
--- a/assistant/src/__tests__/config-watcher-cleanup-throttle.test.ts
+++ b/assistant/src/__tests__/config-watcher-cleanup-throttle.test.ts
@@ -1,0 +1,308 @@
+/**
+ * Regression test for Gap D: ConfigWatcher.refreshConfigFromSources must
+ * reset the cleanup-scheduler throttle when memory.cleanup retention
+ * settings change. Without this, a user flipping their retention setting
+ * in the UI would have to wait up to 6 hours (the default
+ * enqueueIntervalMs) before the change takes effect, because
+ * maybeEnqueueScheduledCleanupJobs (in jobs-worker) early-returns while
+ * the throttle is still within its window.
+ *
+ * The shared throttle state lives in memory/cleanup-schedule-state.ts so
+ * that config-watcher can reset it without pulling jobs-worker's large
+ * transitive import graph into test modules. This test stubs the
+ * schedule-state module so calls from config-watcher can be counted
+ * directly.
+ *
+ * Two layers are exercised:
+ *   1. Pure helper test for cleanupSettingsChanged().
+ *   2. Integration test asserting ConfigWatcher.refreshConfigFromSources
+ *      invokes resetCleanupScheduleThrottle at the right times.
+ *
+ * memory-jobs-worker-backoff.test.ts covers the jobs-worker throttle
+ * semantics directly.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { MemoryCleanupConfig } from "../config/schemas/memory-lifecycle.js";
+import { cleanupSettingsChanged } from "../daemon/config-watcher.js";
+
+// ---------------------------------------------------------------------------
+// 1. Pure helper test — cleanupSettingsChanged
+// ---------------------------------------------------------------------------
+
+describe("cleanupSettingsChanged", () => {
+  const base: MemoryCleanupConfig = {
+    enabled: true,
+    enqueueIntervalMs: 6 * 60 * 60 * 1000,
+    supersededItemRetentionMs: 30 * 24 * 60 * 60 * 1000,
+    conversationRetentionDays: 0,
+    llmRequestLogRetentionMs: 1 * 24 * 60 * 60 * 1000,
+  };
+
+  test("returns false when either side is undefined", () => {
+    expect(cleanupSettingsChanged(undefined, base)).toBe(false);
+    expect(cleanupSettingsChanged(base, undefined)).toBe(false);
+    expect(cleanupSettingsChanged(undefined, undefined)).toBe(false);
+  });
+
+  test("returns false when all fields are equal", () => {
+    expect(cleanupSettingsChanged(base, { ...base })).toBe(false);
+  });
+
+  test("returns true when llmRequestLogRetentionMs changes", () => {
+    expect(
+      cleanupSettingsChanged(base, {
+        ...base,
+        llmRequestLogRetentionMs: 7 * 24 * 60 * 60 * 1000,
+      }),
+    ).toBe(true);
+  });
+
+  test("returns true when conversationRetentionDays changes", () => {
+    expect(
+      cleanupSettingsChanged(base, {
+        ...base,
+        conversationRetentionDays: 30,
+      }),
+    ).toBe(true);
+  });
+
+  test("returns true when cleanup.enabled toggles", () => {
+    expect(cleanupSettingsChanged(base, { ...base, enabled: false })).toBe(
+      true,
+    );
+  });
+
+  test("returns false when only non-tracked fields change", () => {
+    // enqueueIntervalMs and supersededItemRetentionMs are intentionally
+    // excluded — they are daemon tunables, not user-facing UI settings.
+    expect(
+      cleanupSettingsChanged(base, {
+        ...base,
+        enqueueIntervalMs: 1_000,
+        supersededItemRetentionMs: 0,
+      }),
+    ).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Integration test — ConfigWatcher calls resetCleanupScheduleThrottle
+// ---------------------------------------------------------------------------
+
+// Track calls from config-watcher into the (mocked) cleanup-schedule-state.
+let resetCleanupScheduleThrottleCalls = 0;
+
+mock.module("../memory/cleanup-schedule-state.js", () => ({
+  resetCleanupScheduleThrottle: () => {
+    resetCleanupScheduleThrottleCalls++;
+  },
+  getLastScheduledCleanupEnqueueMs: () => 0,
+  markScheduledCleanupEnqueued: () => {},
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+  truncateForLog: (v: string) => v,
+}));
+
+// Simulate a config-cache layer: `diskConfig` is the on-disk value,
+// `cachedConfig` is what getConfig() returns until invalidateConfigCache()
+// is called. This matches the production behavior where getConfig() returns
+// a memoized value that only refreshes after explicit invalidation. Tests
+// mutate `diskConfig` to simulate a user writing a new config.json.
+interface TestConfig {
+  memory: {
+    enabled: boolean;
+    cleanup: {
+      enabled: boolean;
+      enqueueIntervalMs: number;
+      supersededItemRetentionMs: number;
+      conversationRetentionDays: number;
+      llmRequestLogRetentionMs: number;
+    };
+  };
+}
+
+let diskConfig: TestConfig = makeConfig();
+let cachedConfig: TestConfig | null = null;
+
+function makeConfig(
+  overrides: Partial<TestConfig["memory"]["cleanup"]> = {},
+): TestConfig {
+  return {
+    memory: {
+      enabled: true,
+      cleanup: {
+        enabled: true,
+        enqueueIntervalMs: 6 * 60 * 60 * 1000,
+        supersededItemRetentionMs: 30 * 24 * 60 * 60 * 1000,
+        conversationRetentionDays: 0,
+        llmRequestLogRetentionMs: 1 * 24 * 60 * 60 * 1000,
+        ...overrides,
+      },
+    },
+  };
+}
+
+function primeConfigCache(): void {
+  cachedConfig = diskConfig;
+}
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => {
+    if (!cachedConfig) {
+      cachedConfig = diskConfig;
+    }
+    return cachedConfig;
+  },
+  invalidateConfigCache: () => {
+    cachedConfig = null;
+  },
+}));
+
+mock.module("../config/assistant-feature-flags.js", () => ({
+  clearFeatureFlagOverridesCache: () => {},
+}));
+
+mock.module("../memory/embedding-backend.js", () => ({
+  clearEmbeddingBackendCache: () => {},
+}));
+
+mock.module("../permissions/trust-store.js", () => ({
+  clearCache: () => {},
+}));
+
+mock.module("../providers/registry.js", () => ({
+  initializeProviders: async () => {},
+}));
+
+mock.module("../signals/bash.js", () => ({
+  handleBashSignal: () => {},
+}));
+
+mock.module("../signals/cancel.js", () => ({
+  handleCancelSignal: () => {},
+}));
+
+mock.module("../signals/conversation-undo.js", () => ({
+  handleConversationUndoSignal: () => {},
+}));
+
+mock.module("../signals/emit-event.js", () => ({
+  handleEmitEventSignal: () => {},
+}));
+
+mock.module("../signals/mcp-reload.js", () => ({
+  handleMcpReloadSignal: () => {},
+}));
+
+mock.module("../signals/shotgun.js", () => ({
+  handleShotgunSignal: () => {},
+}));
+
+mock.module("../signals/user-message.js", () => ({
+  handleUserMessageSignal: () => {},
+}));
+
+// Import ConfigWatcher AFTER mocks are declared.
+const { ConfigWatcher } = await import("../daemon/config-watcher.js");
+
+describe("ConfigWatcher.refreshConfigFromSources cleanup throttle reset", () => {
+  beforeEach(() => {
+    resetCleanupScheduleThrottleCalls = 0;
+    diskConfig = makeConfig();
+    cachedConfig = null;
+  });
+
+  test("resets throttle when llmRequestLogRetentionMs changes", async () => {
+    const watcher = new ConfigWatcher();
+    // Seed the initial fingerprint and prime the cache so refreshConfigFromSources
+    // can compare the prev (cached) and next (fresh-from-disk) snapshots.
+    watcher.initFingerprint(diskConfig as never);
+    primeConfigCache();
+
+    // Simulate user changing retention from 1d to 7d via the UI — this
+    // writes to disk and is ONLY visible to getConfig() after a cache
+    // invalidation.
+    diskConfig = makeConfig({
+      llmRequestLogRetentionMs: 7 * 24 * 60 * 60 * 1000,
+    });
+
+    const changed = await watcher.refreshConfigFromSources();
+    expect(changed).toBe(true);
+    expect(resetCleanupScheduleThrottleCalls).toBe(1);
+  });
+
+  test("does NOT reset throttle when config is identical (no fingerprint change)", async () => {
+    const watcher = new ConfigWatcher();
+    watcher.initFingerprint(diskConfig as never);
+    primeConfigCache();
+
+    // No change: diskConfig is the same value.
+    const changed = await watcher.refreshConfigFromSources();
+    expect(changed).toBe(false);
+    expect(resetCleanupScheduleThrottleCalls).toBe(0);
+  });
+
+  test("does NOT reset throttle when an unrelated cleanup field changes", async () => {
+    const watcher = new ConfigWatcher();
+    watcher.initFingerprint(diskConfig as never);
+    primeConfigCache();
+
+    // enqueueIntervalMs is a daemon tunable, not a user-facing setting.
+    // The fingerprint changes but the tracked cleanup retention fields
+    // don't, so the throttle should NOT be reset.
+    diskConfig = makeConfig({ enqueueIntervalMs: 30_000 });
+
+    const changed = await watcher.refreshConfigFromSources();
+    expect(changed).toBe(true);
+    expect(resetCleanupScheduleThrottleCalls).toBe(0);
+  });
+
+  test("resets throttle when conversationRetentionDays changes", async () => {
+    const watcher = new ConfigWatcher();
+    watcher.initFingerprint(diskConfig as never);
+    primeConfigCache();
+
+    diskConfig = makeConfig({ conversationRetentionDays: 30 });
+
+    const changed = await watcher.refreshConfigFromSources();
+    expect(changed).toBe(true);
+    expect(resetCleanupScheduleThrottleCalls).toBe(1);
+  });
+
+  test("end-to-end: retention change via watcher triggers repeated resets", async () => {
+    // This is the user-facing regression guarantee: each time the user
+    // changes retention via the UI, refreshConfigFromSources calls the
+    // cleanup-schedule-state throttle reset so the next scheduler tick
+    // re-evaluates without waiting out the 6-hour window.
+    //
+    // Because cleanup-schedule-state is mocked here, we verify the
+    // CONTRACT (resetCleanupScheduleThrottle is called) rather than the
+    // internal state. memory-jobs-worker-backoff tests cover the
+    // jobs-worker throttle semantics independently.
+    const watcher = new ConfigWatcher();
+    watcher.initFingerprint(diskConfig as never);
+    primeConfigCache();
+
+    expect(resetCleanupScheduleThrottleCalls).toBe(0);
+
+    diskConfig = makeConfig({
+      llmRequestLogRetentionMs: 3 * 24 * 60 * 60 * 1000,
+    });
+    await watcher.refreshConfigFromSources();
+    expect(resetCleanupScheduleThrottleCalls).toBe(1);
+
+    // Changing retention again should trigger another reset, confirming
+    // the wiring holds up for repeated edits.
+    diskConfig = makeConfig({
+      llmRequestLogRetentionMs: 14 * 24 * 60 * 60 * 1000,
+    });
+    await watcher.refreshConfigFromSources();
+    expect(resetCleanupScheduleThrottleCalls).toBe(2);
+  });
+});

--- a/assistant/src/daemon/config-watcher.ts
+++ b/assistant/src/daemon/config-watcher.ts
@@ -15,6 +15,8 @@ import { join } from "node:path";
 
 import { clearFeatureFlagOverridesCache } from "../config/assistant-feature-flags.js";
 import { getConfig, invalidateConfigCache } from "../config/loader.js";
+import type { MemoryCleanupConfig } from "../config/schemas/memory-lifecycle.js";
+import { resetCleanupScheduleThrottle } from "../memory/cleanup-schedule-state.js";
 import { clearEmbeddingBackendCache } from "../memory/embedding-backend.js";
 import { clearCache as clearTrustCache } from "../permissions/trust-store.js";
 import { initializeProviders } from "../providers/registry.js";
@@ -94,6 +96,7 @@ export class ConfigWatcher {
    * Returns true if config actually changed.
    */
   async refreshConfigFromSources(): Promise<boolean> {
+    const prevCleanup = safeGetCleanupConfig();
     invalidateConfigCache();
     const config = getConfig();
     const fingerprint = this.configFingerprint(config);
@@ -102,6 +105,13 @@ export class ConfigWatcher {
     }
     clearTrustCache();
     clearEmbeddingBackendCache();
+    // If cleanup retention settings changed, reset the cleanup scheduler
+    // throttle so the next worker tick re-enqueues jobs with the new values
+    // instead of waiting out the remaining enqueueIntervalMs (default 6h).
+    const nextCleanup = config.memory?.cleanup;
+    if (cleanupSettingsChanged(prevCleanup, nextCleanup)) {
+      resetCleanupScheduleThrottle();
+    }
     const isFirstInit = this.lastFingerprint === "";
     await initializeProviders(config);
     this.lastFingerprint = fingerprint;
@@ -480,4 +490,38 @@ export class ConfigWatcher {
       "Watching skills directory with non-recursive fallback",
     );
   }
+}
+
+/**
+ * Snapshot the current cleanup config so we can compare it against the
+ * post-reload value. Tolerant of config-load failures — if the config can't
+ * be read (e.g. first-load), returns undefined so the comparison below
+ * treats it as "no previous value".
+ */
+function safeGetCleanupConfig(): MemoryCleanupConfig | undefined {
+  try {
+    return getConfig().memory?.cleanup;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Return true if any cleanup field the user can change via the UI differs
+ * between the previous and next config snapshots. Used to decide whether to
+ * reset the cleanup-scheduler throttle after a config reload so retention
+ * changes take effect immediately instead of waiting up to 6 hours.
+ *
+ * Exported for unit testing.
+ */
+export function cleanupSettingsChanged(
+  prev: MemoryCleanupConfig | undefined,
+  next: MemoryCleanupConfig | undefined,
+): boolean {
+  if (!prev || !next) return false;
+  return (
+    prev.llmRequestLogRetentionMs !== next.llmRequestLogRetentionMs ||
+    prev.conversationRetentionDays !== next.conversationRetentionDays ||
+    prev.enabled !== next.enabled
+  );
 }

--- a/assistant/src/memory/cleanup-schedule-state.ts
+++ b/assistant/src/memory/cleanup-schedule-state.ts
@@ -1,0 +1,37 @@
+/**
+ * Shared state for the cleanup-scheduler throttle.
+ *
+ * `maybeEnqueueScheduledCleanupJobs` in jobs-worker.ts gates cleanup-job
+ * enqueueing behind a 6-hour window (configurable via
+ * memory.cleanup.enqueueIntervalMs). This module owns the "last enqueue"
+ * timestamp so that code paths outside jobs-worker — notably
+ * ConfigWatcher.refreshConfigFromSources — can reset the throttle without
+ * pulling in jobs-worker's large transitive import graph.
+ *
+ * The ConfigWatcher uses resetCleanupScheduleThrottle() to ensure that
+ * retention changes made via the UI (which flow through config.json →
+ * invalidateConfigCache → refreshConfigFromSources) take effect on the
+ * very next scheduler tick instead of waiting out the remaining window.
+ */
+
+let lastScheduledCleanupEnqueueMs = 0;
+
+/** Read the timestamp of the most recent enqueue (0 if never/reset). */
+export function getLastScheduledCleanupEnqueueMs(): number {
+  return lastScheduledCleanupEnqueueMs;
+}
+
+/** Record that an enqueue just happened at `nowMs`. */
+export function markScheduledCleanupEnqueued(nowMs: number): void {
+  lastScheduledCleanupEnqueueMs = nowMs;
+}
+
+/**
+ * Clear the throttle so the next `maybeEnqueueScheduledCleanupJobs` call
+ * bypasses the `enqueueIntervalMs` window. Used by ConfigWatcher when
+ * retention settings change, and by tests that need deterministic
+ * scheduling.
+ */
+export function resetCleanupScheduleThrottle(): void {
+  lastScheduledCleanupEnqueueMs = 0;
+}

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -2,6 +2,11 @@ import { getConfig } from "../config/loader.js";
 import type { AssistantConfig } from "../config/types.js";
 import { getLogger } from "../util/logger.js";
 import { getMemoryCheckpoint, setMemoryCheckpoint } from "./checkpoints.js";
+import {
+  getLastScheduledCleanupEnqueueMs,
+  markScheduledCleanupEnqueued,
+  resetCleanupScheduleThrottle as resetCleanupScheduleThrottleImpl,
+} from "./cleanup-schedule-state.js";
 import { bootstrapFromHistory } from "./graph/bootstrap.js";
 import { runConsolidation } from "./graph/consolidation.js";
 import { runDecayTick } from "./graph/decay.js";
@@ -449,12 +454,13 @@ async function processJob(
 
 // ── Cleanup scheduling ─────────────────────────────────────────────
 
-let lastScheduledCleanupEnqueueMs = 0;
-
-/** Reset the cleanup enqueue throttle so tests can run deterministic checks. */
-export function resetCleanupScheduleThrottle(): void {
-  lastScheduledCleanupEnqueueMs = 0;
-}
+/**
+ * Re-export of the shared throttle-reset helper. The underlying state lives
+ * in cleanup-schedule-state.ts so that lighter-weight callers (e.g.
+ * ConfigWatcher) can reset it without pulling in jobs-worker's transitive
+ * imports.
+ */
+export const resetCleanupScheduleThrottle = resetCleanupScheduleThrottleImpl;
 
 /**
  * Enqueue periodic cleanup jobs using config-driven retention windows.
@@ -466,7 +472,7 @@ export function maybeEnqueueScheduledCleanupJobs(
 ): boolean {
   const cleanup = config.memory.cleanup;
   if (!cleanup.enabled) return false;
-  if (nowMs - lastScheduledCleanupEnqueueMs < cleanup.enqueueIntervalMs)
+  if (nowMs - getLastScheduledCleanupEnqueueMs() < cleanup.enqueueIntervalMs)
     return false;
 
   const pruneConversationsJobId =
@@ -477,7 +483,7 @@ export function maybeEnqueueScheduledCleanupJobs(
     cleanup.llmRequestLogRetentionMs > 0
       ? enqueuePruneOldLlmRequestLogsJob(cleanup.llmRequestLogRetentionMs)
       : null;
-  lastScheduledCleanupEnqueueMs = nowMs;
+  markScheduledCleanupEnqueued(nowMs);
   log.debug(
     {
       pruneConversationsJobId,


### PR DESCRIPTION
## Summary
- `ConfigWatcher.refreshConfigFromSources` now detects when `memory.cleanup.llmRequestLogRetentionMs` changes and resets `lastScheduledCleanupEnqueueMs` so the next scheduler tick bypasses the 6-hour throttle
- Preserves the existing throttle for the common case (no config change) so idle daemons don't thrash
- Regression test locks in the contract

Addresses self-review gap from plan: log-retention-setting.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24500" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
