### PR TITLE
docs(browser-relay): clean up stale comments and architecture doc

### DIFF
--- a/assistant/src/runtime/capability-tokens.ts
+++ b/assistant/src/runtime/capability-tokens.ts
@@ -316,15 +316,13 @@ export function mintHostBrowserCapability(
  * Signature comparison uses `timingSafeEqual` to avoid leaking the secret
  * through timing side channels.
  *
- * Phase 2 hand-off: this function has no production caller yet. The
- * `/v1/browser-relay` WebSocket upgrade handler currently authenticates
- * with guardian-bound JWTs only. Phase 3 will extend the upgrade handler
- * to accept capability tokens minted by `mintHostBrowserCapability` so
- * the chrome extension can present the token from the
- * `/v1/browser-extension-pair` flow on its WebSocket handshake — at
- * which point this function becomes the authoritative verifier for
- * chrome-extension host_browser connections. Until then the tests in
- * `browser-extension-pair-routes.test.ts` are the only call site.
+ * The `/v1/browser-relay` WebSocket upgrade handler in `http-server.ts`
+ * (`handleBrowserRelayUpgrade`) calls this to authenticate self-hosted
+ * chrome extensions on the capability-token branch before falling
+ * through to the JWT compatibility path. The `/v1/host-browser-result`
+ * POST route may also call it (see that route's auth handling) when a
+ * result is posted back with a capability-token bearer instead of a
+ * guardian-bound JWT.
  */
 export function verifyHostBrowserCapability(
   token: string,

--- a/clients/chrome-extension/background/self-hosted-auth.ts
+++ b/clients/chrome-extension/background/self-hosted-auth.ts
@@ -12,9 +12,12 @@
  * locally running assistant without needing an external OAuth round-trip.
  * Users with a local assistant can pair their extension entirely offline.
  *
- * The token is not yet wired into the relay WebSocket — that plumbing
- * lands in PR 14 of the host-browser-proxy Phase 2 plan. This module is
- * the storage + bootstrap state machine layer only.
+ * This module owns the storage + bootstrap state machine for the
+ * self-hosted capability token. The relay connection consumes the
+ * stored token via `worker.ts::buildRelayModeConfig`, which reads it
+ * (along with the assistant runtime port echoed by the native helper)
+ * and hands both off to the `RelayConnection` when opening the
+ * self-hosted `/v1/browser-relay` WebSocket.
  *
  * Wire format notes: the native helper sends
  * `{ type: "token_response", token, expiresAt }` where `expiresAt` is an

--- a/docs/browser-use-architecture-phase2.md
+++ b/docs/browser-use-architecture-phase2.md
@@ -201,11 +201,6 @@ Runtime wiring:
 
 ## Open follow-ups
 
-- Cloud-side `host_browser_result` inbound routing on the gateway
-  WebSocket. In self-hosted mode the extension POSTs results directly
-  to the runtime; in cloud mode this needs to traverse the gateway.
-- Deriving `x-guardian-id` from the edge JWT inside the gateway rather
-  than trusting it from the runtime headers.
 - Production extension allowlist: the native messaging helper, the
   assistant's pair endpoint, and the macOS `NativeMessagingInstaller`
   all contain a dev placeholder extension id pending the first public


### PR DESCRIPTION
## Summary
Fixes stale-comment gaps identified during plan self-review. All three instances violated the assistant/CLAUDE.md rule: 'When writing or updating comments, do not reference code that has been removed. Comments should describe the current state of the codebase, not narrate its history.'

- self-hosted-auth.ts: removed obsolete 'PR 14 of Phase 2 plan' comment
- capability-tokens.ts: rewrote verifyHostBrowserCapability docstring to reflect its current production caller in handleBrowserRelayUpgrade
- browser-use-architecture-phase2.md: removed two 'Open follow-ups' bullets that were resolved by PR1 and PR2

Part of plan: browser-use-main-remediation-plan-2026-04-08.md (review fixes)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24502" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
