### PR TITLE
fix(browser-relay): pair endpoint rate limit ordering + native-host marker sync guard

### DIFF
--- a/assistant/src/__tests__/native-host-marker-sync-guard.test.ts
+++ b/assistant/src/__tests__/native-host-marker-sync-guard.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Sync guard: the `NATIVE_HOST_MARKER_HEADER` and
+ * `NATIVE_HOST_MARKER_VALUE` constants are referenced from two coupled
+ * files that MUST stay in lockstep:
+ *
+ *   - assistant/src/runtime/routes/browser-extension-pair-routes.ts
+ *     (the runtime side that rejects unmarked pair requests with 403)
+ *   - clients/chrome-extension-native-host/src/index.ts
+ *     (the native messaging helper that stamps the marker on every
+ *     pair POST before forwarding to the assistant)
+ *
+ * If either side drifts (typo in the header name, or a different
+ * value), the pair flow silently breaks end-to-end: the native host
+ * sends an unrecognizable header, the runtime rejects the request as
+ * if it came from a drive-by webpage, and the extension never gets a
+ * token.
+ *
+ * This guard reads the raw source text of both files at test time and
+ * uses regexes to extract the literal string values of each constant.
+ * It deliberately does NOT `import` the constants — the whole point is
+ * to catch the physical file divergence that an import-based test
+ * would paper over (a typo'd export still type-checks if both files
+ * are updated independently but inconsistently).
+ *
+ * Modeled on `extension-id-sync-guard.test.ts`.
+ */
+
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { describe, expect, test } from "bun:test";
+
+const repoRoot = resolve(__dirname, "..", "..", "..");
+
+const ASSISTANT_PAIR_ROUTE_PATH =
+  "assistant/src/runtime/routes/browser-extension-pair-routes.ts";
+const NATIVE_HOST_INDEX_PATH =
+  "clients/chrome-extension-native-host/src/index.ts";
+
+/**
+ * Extract the string literal value of an exported const from raw
+ * TypeScript source text. Accepts both single- and double-quoted
+ * forms and is permissive about whitespace so minor formatter changes
+ * don't break the guard.
+ *
+ * Returns the literal string (without quotes) or `null` if the export
+ * cannot be found.
+ */
+function extractExportedConstString(
+  source: string,
+  constName: string,
+): string | null {
+  // Matches: export const FOO = "bar";  (also ' and whitespace
+  // variations). The value group stops at the next matching quote.
+  const re = new RegExp(
+    `export\\s+const\\s+${constName}\\s*=\\s*(['"])([^'"]*)\\1`,
+  );
+  const match = source.match(re);
+  if (!match) return null;
+  return match[2] ?? null;
+}
+
+describe("native-host marker sync guard", () => {
+  test("NATIVE_HOST_MARKER_HEADER matches across runtime route and native host", () => {
+    const assistantSource = readFileSync(
+      join(repoRoot, ASSISTANT_PAIR_ROUTE_PATH),
+      "utf8",
+    );
+    const nativeHostSource = readFileSync(
+      join(repoRoot, NATIVE_HOST_INDEX_PATH),
+      "utf8",
+    );
+
+    const assistantHeader = extractExportedConstString(
+      assistantSource,
+      "NATIVE_HOST_MARKER_HEADER",
+    );
+    const nativeHostHeader = extractExportedConstString(
+      nativeHostSource,
+      "NATIVE_HOST_MARKER_HEADER",
+    );
+
+    expect(assistantHeader).not.toBeNull();
+    expect(nativeHostHeader).not.toBeNull();
+    // Also require a non-empty value so an accidental `""` in either
+    // file trips the guard.
+    expect(assistantHeader!.length).toBeGreaterThan(0);
+    expect(nativeHostHeader!.length).toBeGreaterThan(0);
+
+    if (assistantHeader !== nativeHostHeader) {
+      throw new Error(
+        `NATIVE_HOST_MARKER_HEADER drift detected:\n` +
+          `  ${ASSISTANT_PAIR_ROUTE_PATH}: ${JSON.stringify(
+            assistantHeader,
+          )}\n` +
+          `  ${NATIVE_HOST_INDEX_PATH}: ${JSON.stringify(nativeHostHeader)}\n\n` +
+          `Both files must declare the same header name or pairing ` +
+          `silently breaks (the runtime rejects the native host's ` +
+          `requests as unmarked drive-by browser fetches).`,
+      );
+    }
+  });
+
+  test("NATIVE_HOST_MARKER_VALUE matches across runtime route and native host", () => {
+    const assistantSource = readFileSync(
+      join(repoRoot, ASSISTANT_PAIR_ROUTE_PATH),
+      "utf8",
+    );
+    const nativeHostSource = readFileSync(
+      join(repoRoot, NATIVE_HOST_INDEX_PATH),
+      "utf8",
+    );
+
+    const assistantValue = extractExportedConstString(
+      assistantSource,
+      "NATIVE_HOST_MARKER_VALUE",
+    );
+    const nativeHostValue = extractExportedConstString(
+      nativeHostSource,
+      "NATIVE_HOST_MARKER_VALUE",
+    );
+
+    expect(assistantValue).not.toBeNull();
+    expect(nativeHostValue).not.toBeNull();
+    expect(assistantValue!.length).toBeGreaterThan(0);
+    expect(nativeHostValue!.length).toBeGreaterThan(0);
+
+    if (assistantValue !== nativeHostValue) {
+      throw new Error(
+        `NATIVE_HOST_MARKER_VALUE drift detected:\n` +
+          `  ${ASSISTANT_PAIR_ROUTE_PATH}: ${JSON.stringify(
+            assistantValue,
+          )}\n` +
+          `  ${NATIVE_HOST_INDEX_PATH}: ${JSON.stringify(nativeHostValue)}\n\n` +
+          `Both files must declare the same marker value or pairing ` +
+          `silently breaks (the runtime rejects the native host's ` +
+          `requests as unmarked drive-by browser fetches).`,
+      );
+    }
+  });
+
+  test("extractExportedConstString helper handles both quote styles", () => {
+    // Smoke-test the parser helper itself so a regression in the
+    // regex can't silently mask a real drift in the coupled files.
+    expect(
+      extractExportedConstString(`export const FOO = "hello";`, "FOO"),
+    ).toBe("hello");
+    expect(
+      extractExportedConstString(`export const FOO = 'hello';`, "FOO"),
+    ).toBe("hello");
+    expect(
+      extractExportedConstString(`export  const   FOO   =   "spaced";`, "FOO"),
+    ).toBe("spaced");
+    expect(
+      extractExportedConstString(`export const OTHER = "x";`, "FOO"),
+    ).toBeNull();
+  });
+});

--- a/assistant/src/runtime/__tests__/browser-extension-pair-routes.test.ts
+++ b/assistant/src/runtime/__tests__/browser-extension-pair-routes.test.ts
@@ -328,26 +328,49 @@ describe("handleBrowserExtensionPair", () => {
     expect(payload.error?.code).toBe("RATE_LIMITED");
   });
 
-  test("rate limit applies BEFORE native-host marker check (can't probe without spending budget)", async () => {
-    // Attackers shouldn't be able to distinguish "unauthenticated
-    // endpoint" from "endpoint doesn't exist" without consuming a
-    // rate-limit slot. Send 12 unauthenticated probes; after the 10th
-    // request is rate limited, they should get 429 — not 403 — which
-    // proves the limiter runs first.
-    const results: number[] = [];
-    for (let i = 0; i < 12; i++) {
+  test("native-host marker check runs BEFORE the rate limiter (unmarked requests don't burn budget)", async () => {
+    // Security invariant: an unmarked drive-by POST from a malicious
+    // webpage must NOT consume the legitimate 10/min quota. If the
+    // rate limiter ran first, a cross-origin page could issue 10
+    // unmarked requests per minute and starve the native messaging
+    // helper's real pair attempts with 429s until the window reset.
+    //
+    // We send a large burst of UNMARKED requests (well beyond the
+    // 10/min budget). Every single one must return 403 (missing
+    // marker), NOT 429 — because the marker check runs first and
+    // unmarked requests are supposed to short-circuit the handler
+    // without touching the limiter at all.
+    const unmarkedResults: number[] = [];
+    for (let i = 0; i < 30; i++) {
       const req = buildRequest({
         body: { extensionOrigin: ALLOWED_ORIGIN },
-        nativeHost: false, // forces a 403 if rate-limiter doesn't run first
+        nativeHost: false, // no marker header
       });
       const res = await handleBrowserExtensionPair(req, loopbackServer);
-      results.push(res.status);
+      unmarkedResults.push(res.status);
       await res.text();
     }
-    // The first 10 should be 403 (missing marker). Beyond that the
-    // rate limiter kicks in and returns 429.
-    expect(results.slice(0, 10).every((s) => s === 403)).toBe(true);
-    expect(results.slice(10).every((s) => s === 429)).toBe(true);
+    // Every unmarked request should be 403. If any 429 appeared, the
+    // limiter was burning budget on unauthenticated probes.
+    expect(unmarkedResults.every((s) => s === 403)).toBe(true);
+    expect(unmarkedResults.some((s) => s === 429)).toBe(false);
+
+    // After 30 unmarked requests, the legitimate native-messaging
+    // helper must still have its full 10/min budget intact. Issue 10
+    // MARKED requests: all 10 should succeed. The 11th should be the
+    // first 429 — proving the limiter only counts marker-carrying
+    // requests.
+    const markedResults: number[] = [];
+    for (let i = 0; i < 11; i++) {
+      const req = buildRequest({
+        body: { extensionOrigin: ALLOWED_ORIGIN },
+      });
+      const res = await handleBrowserExtensionPair(req, loopbackServer);
+      markedResults.push(res.status);
+      await res.text();
+    }
+    expect(markedResults.slice(0, 10).every((s) => s === 200)).toBe(true);
+    expect(markedResults[10]).toBe(429);
   });
 
   // ─────────────────────────────────────────────────────────────────────

--- a/assistant/src/runtime/routes/browser-extension-pair-routes.ts
+++ b/assistant/src/runtime/routes/browser-extension-pair-routes.ts
@@ -280,12 +280,31 @@ export async function handleBrowserExtensionPair(
     return httpError("FORBIDDEN", "endpoint is local-only", 403);
   }
 
+  // Primary marker-header gate. The native messaging helper sets this
+  // header on every pair request; browsers cannot (without CORS
+  // preflight, which this endpoint does not serve). Reject when the
+  // header is absent or set to an unexpected value.
+  //
+  // IMPORTANT: this check runs BEFORE the rate limiter so that
+  // unmarked drive-by POSTs from a malicious webpage cannot burn the
+  // legitimate 10/min budget. If the rate limiter ran first, a
+  // cross-origin page could issue 10 unmarked requests per minute and
+  // starve the native messaging helper's real pair attempts with 429s
+  // until the window reset. Unmarked requests therefore return 403
+  // without touching the limiter at all.
+  const marker = req.headers.get(NATIVE_HOST_MARKER_HEADER);
+  if (marker !== NATIVE_HOST_MARKER_VALUE) {
+    auditDeny(req, peerIp, "missing_native_host_marker");
+    return httpError("FORBIDDEN", "native host marker required", 403);
+  }
+
   // Strict rate limit by peer IP. The limiter is keyed on the loopback
   // peer address; browsers (even local ones) all appear as 127.0.0.1
   // here, which is intentional — a single compromised local process
   // should not be able to hammer the mint endpoint. We evaluate this
-  // BEFORE the native-host marker / origin checks so an attacker can't
-  // use those 403s as an unmetered probe for liveness.
+  // AFTER the native-host marker check so that unauthenticated
+  // drive-by POSTs can't consume the legitimate 10/min quota (see
+  // comment above the marker check for the DoS rationale).
   const rateResult = pairRateLimiter.check(
     peerIp,
     "/v1/browser-extension-pair",
@@ -321,16 +340,6 @@ export async function handleBrowserExtensionPair(
         },
       },
     );
-  }
-
-  // Primary marker-header gate. The native messaging helper sets this
-  // header on every pair request; browsers cannot (without CORS
-  // preflight, which this endpoint does not serve). Reject when the
-  // header is absent or set to an unexpected value.
-  const marker = req.headers.get(NATIVE_HOST_MARKER_HEADER);
-  if (marker !== NATIVE_HOST_MARKER_VALUE) {
-    auditDeny(req, peerIp, "missing_native_host_marker");
-    return httpError("FORBIDDEN", "native host marker required", 403);
   }
 
   // Browser-origin rejection. Any non-empty `Origin` header that isn't


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan self-review:

- Move pair endpoint rate limiter to run AFTER the x-vellum-native-host marker check so unauthenticated drive-by POSTs don't burn the legitimate 10/min quota (P1 DoS fix)
- Add sync guard test that verifies NATIVE_HOST_MARKER_HEADER/VALUE match between the runtime pair route and the native-host helper, modeled on the existing extension-id sync guard

Part of plan: browser-use-main-remediation-plan-2026-04-08.md (review fixes)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24503" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
