### PR TITLE
fix(browser-relay): forward clientInstanceId through gateway + registry tie-breaker

### DIFF
--- a/assistant/src/runtime/__tests__/chrome-extension-registry.test.ts
+++ b/assistant/src/runtime/__tests__/chrome-extension-registry.test.ts
@@ -352,6 +352,116 @@ describe("ChromeExtensionRegistry", () => {
       expect(registry.get("guardian-alpha")).toBeUndefined();
       expect(registry.listInstances("guardian-alpha")).toHaveLength(0);
     });
+
+    test("ties on lastActiveAt are broken by registrationSeq (newest wins)", () => {
+      // Freeze Date.now so both instances stamp the exact same
+      // lastActiveAt. Without the registrationSeq tiebreaker, the
+      // strict `>` comparison in get() would keep whichever entry
+      // Map#values() yields first — i.e. the earlier-inserted one,
+      // which is the opposite of the "most recently registered"
+      // semantics a caller would expect.
+      const registry = new ChromeExtensionRegistry();
+      const { conn: connA, fakeWs: fakeWsA } = makeConnection(
+        "guardian-alpha",
+        "conn-A",
+        "install-A",
+      );
+      const { conn: connB, fakeWs: fakeWsB } = makeConnection(
+        "guardian-alpha",
+        "conn-B",
+        "install-B",
+      );
+      const originalNow = Date.now;
+      const frozenNow = originalNow();
+      Date.now = () => frozenNow;
+      try {
+        registry.register(connA);
+        registry.register(connB);
+        // Both should hold the same lastActiveAt because Date.now is frozen.
+        expect(connA.lastActiveAt).toBe(connB.lastActiveAt);
+        // connB registered second, so its registrationSeq must be higher.
+        expect(connB.registrationSeq).toBeGreaterThan(
+          connA.registrationSeq ?? 0,
+        );
+        const msg: ServerMessage = {
+          type: "host_browser_cancel",
+          requestId: "req-1",
+        } as ServerMessage;
+        expect(registry.send("guardian-alpha", msg)).toBe(true);
+      } finally {
+        Date.now = originalNow;
+      }
+      // Default send should have landed on the newer instance (B),
+      // not the older insertion-order winner (A).
+      expect(fakeWsA.sent).toHaveLength(0);
+      expect(fakeWsB.sent).toHaveLength(1);
+    });
+
+    test("registrationSeq is monotonically increasing across registrations", () => {
+      // Sanity check on the counter itself — new registrations should
+      // always stamp a strictly greater sequence number than anything
+      // that came before, including re-registrations of the same
+      // instance after a supersede.
+      const registry = new ChromeExtensionRegistry();
+      const { conn: connA } = makeConnection(
+        "guardian-alpha",
+        "conn-A",
+        "install-A",
+      );
+      const { conn: connB } = makeConnection(
+        "guardian-alpha",
+        "conn-B",
+        "install-B",
+      );
+      const { conn: connC } = makeConnection(
+        "guardian-alpha",
+        "conn-C",
+        "install-A",
+      );
+      registry.register(connA);
+      registry.register(connB);
+      registry.register(connC); // supersedes install-A → conn-A closes
+      expect(connA.registrationSeq).toBeDefined();
+      expect(connB.registrationSeq).toBeDefined();
+      expect(connC.registrationSeq).toBeDefined();
+      expect(connB.registrationSeq!).toBeGreaterThan(connA.registrationSeq!);
+      expect(connC.registrationSeq!).toBeGreaterThan(connB.registrationSeq!);
+    });
+
+    test("same-millisecond supersede leaves the new connection as default", () => {
+      // Re-registering the same install within the same millisecond
+      // window must still promote the new connection to the default
+      // target — the tie-breaker should apply to re-registrations of
+      // the same instance just as it applies to sibling instances.
+      const registry = new ChromeExtensionRegistry();
+      const { conn: old } = makeConnection(
+        "guardian-alpha",
+        "old-id",
+        "install-A",
+      );
+      const { conn: fresh, fakeWs: fakeWsFresh } = makeConnection(
+        "guardian-alpha",
+        "fresh-id",
+        "install-A",
+      );
+      const originalNow = Date.now;
+      const frozenNow = originalNow();
+      Date.now = () => frozenNow;
+      try {
+        registry.register(old);
+        registry.register(fresh);
+        const msg: ServerMessage = {
+          type: "host_browser_cancel",
+          requestId: "req-1",
+        } as ServerMessage;
+        expect(registry.send("guardian-alpha", msg)).toBe(true);
+      } finally {
+        Date.now = originalNow;
+      }
+      // The fresh connection must receive the default send even though
+      // both entries stamped the exact same lastActiveAt.
+      expect(fakeWsFresh.sent).toHaveLength(1);
+    });
   });
 
   // ── Backwards compatibility ─────────────────────────────────────────

--- a/assistant/src/runtime/chrome-extension-registry.ts
+++ b/assistant/src/runtime/chrome-extension-registry.ts
@@ -67,6 +67,19 @@ export interface ChromeExtensionConnection {
    * active" instance when the caller does not pin a specific one.
    */
   lastActiveAt: number;
+  /**
+   * Monotonic registration sequence number assigned by the registry
+   * on each `register()` call. Used as a tuple-secondary tiebreaker
+   * after `lastActiveAt` when picking the default active instance, so
+   * two sibling instances that share the same millisecond timestamp
+   * deterministically resolve to the most recently registered entry.
+   *
+   * Not used when the registry routes to an explicit instance via
+   * `sendToInstance` / `getInstance`. Clients should treat this as an
+   * internal field — it's assigned by `register()` and callers don't
+   * need to populate it when constructing a connection.
+   */
+  registrationSeq?: number;
 }
 
 /**
@@ -81,6 +94,22 @@ export class ChromeExtensionRegistry {
     string,
     Map<string, ChromeExtensionConnection>
   >();
+  /**
+   * Monotonic counter stamped onto each registration as
+   * `registrationSeq`, used as a secondary tiebreaker after
+   * `lastActiveAt` in the default routing path. Starts at 0 and
+   * increments before stamping so the first registered connection has
+   * `registrationSeq === 1`.
+   *
+   * This exists because `lastActiveAt` is `Date.now()`, which has
+   * millisecond resolution at best; two sibling instances that
+   * register (or transmit) in the same millisecond would otherwise
+   * resolve ties via insertion order of `Map#values()`, which is
+   * technically well-defined but is not the "most recently registered"
+   * behavior a caller would expect. A monotonic counter fixes that
+   * deterministically.
+   */
+  private seqCounter = 0;
 
   /**
    * Resolve the effective instance key for a connection. Prefers the
@@ -118,14 +147,18 @@ export class ChromeExtensionRegistry {
     }
     // Stamp lastActiveAt on (re-)register so the "most recently active"
     // routing heuristic treats a fresh connection as the current default
-    // target for its guardian.
+    // target for its guardian. Stamp a monotonic registrationSeq
+    // alongside it so two registrations that land in the same
+    // millisecond resolve deterministically to the newer one.
     conn.lastActiveAt = Date.now();
+    conn.registrationSeq = ++this.seqCounter;
     instances.set(instanceKey, conn);
     log.info(
       {
         guardianId: conn.guardianId,
         connectionId: conn.id,
         clientInstanceId: conn.clientInstanceId,
+        registrationSeq: conn.registrationSeq,
         instanceCount: instances.size,
       },
       "chrome extension registered",
@@ -167,8 +200,12 @@ export class ChromeExtensionRegistry {
 
   /**
    * Return the default "active" connection for a guardian — the
-   * instance with the most recent `lastActiveAt` timestamp. Returns
-   * `undefined` when no instances are registered for the guardian.
+   * instance with the most recent `lastActiveAt` timestamp. Ties on
+   * `lastActiveAt` (common when two sibling instances register or
+   * transmit within the same millisecond) are broken by the monotonic
+   * `registrationSeq` counter, which deterministically prefers the
+   * most recently registered instance. Returns `undefined` when no
+   * instances are registered for the guardian.
    *
    * Callers that want to pin a specific instance should use
    * {@link getInstance} instead.
@@ -178,7 +215,16 @@ export class ChromeExtensionRegistry {
     if (!instances || instances.size === 0) return undefined;
     let best: ChromeExtensionConnection | undefined;
     for (const conn of instances.values()) {
-      if (!best || conn.lastActiveAt > best.lastActiveAt) {
+      if (!best) {
+        best = conn;
+        continue;
+      }
+      if (conn.lastActiveAt > best.lastActiveAt) {
+        best = conn;
+      } else if (
+        conn.lastActiveAt === best.lastActiveAt &&
+        (conn.registrationSeq ?? 0) > (best.registrationSeq ?? 0)
+      ) {
         best = conn;
       }
     }

--- a/gateway/src/__tests__/browser-relay-websocket.test.ts
+++ b/gateway/src/__tests__/browser-relay-websocket.test.ts
@@ -339,6 +339,84 @@ describe("getBrowserRelayWebsocketHandlers", () => {
     // upgrade with `guardianId = undefined`.
     expect(parsed.searchParams.has("guardianId")).toBe(false);
   });
+
+  test("open appends clientInstanceId query param when auth context carries one", () => {
+    const ws = createFakeDownstreamWs({
+      wsType: "browser-relay",
+      config: makeConfig({
+        assistantRuntimeBaseUrl: "http://runtime.internal:7821",
+      }),
+      auth: {
+        authenticated: true,
+        authBypassed: false,
+        guardianId: TEST_ACTOR_PRINCIPAL,
+        clientInstanceId: "install-ABC-123",
+      },
+    });
+
+    handlers.open(ws as never);
+
+    const MockWS = globalThis.WebSocket as unknown as ReturnType<typeof mock>;
+    const calledUrl = (MockWS.mock.calls[0] as unknown[])[0] as string;
+    const parsed = new URL(calledUrl);
+    expect(parsed.pathname).toBe("/v1/browser-relay");
+    // Both guardianId and clientInstanceId should ride alongside the
+    // upstream service token, matching the runtime's accepted query
+    // param names.
+    expect(parsed.searchParams.get("guardianId")).toBe(TEST_ACTOR_PRINCIPAL);
+    expect(parsed.searchParams.get("clientInstanceId")).toBe("install-ABC-123");
+  });
+
+  test("open forwards clientInstanceId even without a guardianId", () => {
+    // Auth-bypass / service-token paths can still carry a
+    // clientInstanceId lifted from the downstream handshake. The
+    // gateway must propagate it so the runtime's multi-instance
+    // registry keys the connection correctly.
+    const ws = createFakeDownstreamWs({
+      wsType: "browser-relay",
+      config: makeConfig({
+        assistantRuntimeBaseUrl: "http://runtime.internal:7821",
+      }),
+      auth: {
+        authenticated: true,
+        authBypassed: false,
+        clientInstanceId: "install-XYZ-789",
+      },
+    });
+
+    handlers.open(ws as never);
+
+    const MockWS = globalThis.WebSocket as unknown as ReturnType<typeof mock>;
+    const calledUrl = (MockWS.mock.calls[0] as unknown[])[0] as string;
+    const parsed = new URL(calledUrl);
+    expect(parsed.searchParams.has("guardianId")).toBe(false);
+    expect(parsed.searchParams.get("clientInstanceId")).toBe("install-XYZ-789");
+  });
+
+  test("open omits clientInstanceId query param when auth context has none", () => {
+    const ws = createFakeDownstreamWs({
+      wsType: "browser-relay",
+      config: makeConfig({
+        assistantRuntimeBaseUrl: "http://runtime.internal:7821",
+      }),
+      auth: {
+        authenticated: true,
+        authBypassed: false,
+        guardianId: TEST_ACTOR_PRINCIPAL,
+      },
+    });
+
+    handlers.open(ws as never);
+
+    const MockWS = globalThis.WebSocket as unknown as ReturnType<typeof mock>;
+    const calledUrl = (MockWS.mock.calls[0] as unknown[])[0] as string;
+    const parsed = new URL(calledUrl);
+    // Older extension builds (or dev bypass paths) do not emit a
+    // clientInstanceId — the gateway must not synthesize one or send
+    // an empty string, both of which would break the runtime's
+    // legacy-key fallback semantics.
+    expect(parsed.searchParams.has("clientInstanceId")).toBe(false);
+  });
 });
 
 describe("checkBrowserRelayAuth", () => {
@@ -408,6 +486,122 @@ describe("checkBrowserRelayAuth", () => {
     expect(result.context.authBypassed).toBe(true);
     expect(result.context.authenticated).toBe(false);
     expect(result.context.guardianId).toBeUndefined();
+  });
+
+  test("lifts clientInstanceId from the query param on the downstream handshake", () => {
+    // Primary path: the Chrome extension sets clientInstanceId as a
+    // query param via `buildUrl`. The gateway must lift it off the
+    // handshake and expose it on the auth context so the open()
+    // handler can forward it to the runtime.
+    const token = mintEdgeToken(TEST_ACTOR_PRINCIPAL);
+    const config = makeConfig({});
+    const req = new Request(
+      `http://localhost:7830/v1/browser-relay?token=${token}&clientInstanceId=install-QUERY`,
+      { headers: { upgrade: "websocket" } },
+    );
+    const url = new URL(req.url);
+
+    const result = checkBrowserRelayAuth(req, url, config);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("expected ok");
+    expect(result.context.clientInstanceId).toBe("install-QUERY");
+    expect(result.context.guardianId).toBe(TEST_ACTOR_PRINCIPAL);
+  });
+
+  test("lifts clientInstanceId from the x-client-instance-id header", () => {
+    const token = mintEdgeToken(TEST_ACTOR_PRINCIPAL);
+    const config = makeConfig({});
+    const req = new Request(
+      `http://localhost:7830/v1/browser-relay?token=${token}`,
+      {
+        headers: {
+          upgrade: "websocket",
+          "x-client-instance-id": "install-HEADER",
+        },
+      },
+    );
+    const url = new URL(req.url);
+
+    const result = checkBrowserRelayAuth(req, url, config);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("expected ok");
+    expect(result.context.clientInstanceId).toBe("install-HEADER");
+  });
+
+  test("prefers x-client-instance-id header over query param when both are present", () => {
+    const token = mintEdgeToken(TEST_ACTOR_PRINCIPAL);
+    const config = makeConfig({});
+    const req = new Request(
+      `http://localhost:7830/v1/browser-relay?token=${token}&clientInstanceId=install-QUERY`,
+      {
+        headers: {
+          upgrade: "websocket",
+          "x-client-instance-id": "install-HEADER",
+        },
+      },
+    );
+    const url = new URL(req.url);
+
+    const result = checkBrowserRelayAuth(req, url, config);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("expected ok");
+    // The header form is considered the more explicit signal when
+    // both are set, matching the runtime's own precedence.
+    expect(result.context.clientInstanceId).toBe("install-HEADER");
+  });
+
+  test("treats an empty clientInstanceId query param as absent", () => {
+    const token = mintEdgeToken(TEST_ACTOR_PRINCIPAL);
+    const config = makeConfig({});
+    const req = new Request(
+      `http://localhost:7830/v1/browser-relay?token=${token}&clientInstanceId=`,
+      { headers: { upgrade: "websocket" } },
+    );
+    const url = new URL(req.url);
+
+    const result = checkBrowserRelayAuth(req, url, config);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("expected ok");
+    expect(result.context.clientInstanceId).toBeUndefined();
+  });
+
+  test("returns undefined clientInstanceId when neither form is present", () => {
+    const token = mintEdgeToken(TEST_ACTOR_PRINCIPAL);
+    const config = makeConfig({});
+    const req = new Request(
+      `http://localhost:7830/v1/browser-relay?token=${token}`,
+      { headers: { upgrade: "websocket" } },
+    );
+    const url = new URL(req.url);
+
+    const result = checkBrowserRelayAuth(req, url, config);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("expected ok");
+    expect(result.context.clientInstanceId).toBeUndefined();
+  });
+
+  test("lifts clientInstanceId even on the auth-bypass path", () => {
+    // When runtime proxy auth is disabled, the gateway still needs to
+    // propagate the per-install identifier so multi-instance routing
+    // continues to work in dev-bypass environments.
+    const config = makeConfig({ runtimeProxyRequireAuth: false });
+    const req = new Request(
+      "http://localhost:7830/v1/browser-relay?clientInstanceId=install-BYPASS",
+      { headers: { upgrade: "websocket" } },
+    );
+    const url = new URL(req.url);
+
+    const result = checkBrowserRelayAuth(req, url, config);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("expected ok");
+    expect(result.context.authBypassed).toBe(true);
+    expect(result.context.clientInstanceId).toBe("install-BYPASS");
   });
 });
 

--- a/gateway/src/http/routes/browser-relay-websocket.ts
+++ b/gateway/src/http/routes/browser-relay-websocket.ts
@@ -77,9 +77,23 @@ export function isLoopbackPeer(
  * Service tokens — which intentionally do not carry a guardian — will have
  * `guardianId === undefined` and are expected to be rejected at upstream
  * upgrade time unless an alternate guardian-plumbing path is wired up.
+ *
+ * `clientInstanceId` is a stable per-extension-install identifier lifted
+ * off the downstream handshake and forwarded to the runtime verbatim so
+ * the multi-instance registry can key connections by (guardianId,
+ * clientInstanceId). Without this forwarding, cloud reconnects from the
+ * same extension install would each land in a fresh
+ * `legacy:<connectionId>` slot and fail to supersede the prior socket.
  */
 export interface BrowserRelayAuthContext {
   guardianId?: string;
+  /**
+   * Per-install identifier sourced from the downstream handshake — either
+   * the `clientInstanceId` query param (primary path, set by the Chrome
+   * extension via `buildUrl`) or the `x-client-instance-id` header.
+   * Propagated verbatim to the upstream runtime URL.
+   */
+  clientInstanceId?: string;
   /** True when auth was checked and succeeded. */
   authenticated: boolean;
   /** True when runtime proxy auth is globally disabled (dev bypass). */
@@ -156,10 +170,22 @@ export function checkBrowserRelayAuth(
   url: URL,
   config: GatewayConfig,
 ): AuthCheckResult {
+  // Lift the per-install identifier off the downstream handshake so we
+  // can propagate it to the runtime regardless of the auth path below.
+  // The Chrome extension sets it as a query param via `buildUrl`; we
+  // also accept the `x-client-instance-id` header for parity with the
+  // runtime's own accepted forms. Empty strings are treated as absent
+  // so sparse clients don't all collapse into the same key.
+  const clientInstanceId = extractClientInstanceId(req, url);
+
   if (!config.runtimeProxyRequireAuth) {
     return {
       ok: true,
-      context: { authenticated: false, authBypassed: true },
+      context: {
+        authenticated: false,
+        authBypassed: true,
+        clientInstanceId,
+      },
     };
   }
 
@@ -210,8 +236,28 @@ export function checkBrowserRelayAuth(
 
   return {
     ok: true,
-    context: { authenticated: true, authBypassed: false, guardianId },
+    context: {
+      authenticated: true,
+      authBypassed: false,
+      guardianId,
+      clientInstanceId,
+    },
   };
+}
+
+/**
+ * Extract the per-extension-install identifier from a downstream
+ * browser-relay WS handshake. Query param is the primary path (the
+ * Chrome extension sets it via `buildUrl` because WebSocket upgrades
+ * cannot set custom headers from the browser); the header form is
+ * accepted for completeness so non-browser clients have a consistent
+ * contract. Empty strings are normalized to `undefined`.
+ */
+function extractClientInstanceId(req: Request, url: URL): string | undefined {
+  const rawHeader = req.headers.get("x-client-instance-id")?.trim();
+  const rawQuery = url.searchParams.get("clientInstanceId")?.trim();
+  const picked = (rawHeader ?? "") || (rawQuery ?? "") || undefined;
+  return picked;
 }
 
 /**
@@ -231,13 +277,30 @@ export function getBrowserRelayWebsocketHandlers() {
       if (auth.guardianId) {
         query.set("guardianId", auth.guardianId);
       }
+      // Forward the per-install identifier so the runtime's
+      // multi-instance registry can key connections by
+      // (guardianId, clientInstanceId). Without this, cloud
+      // reconnects from the same extension install would each fall
+      // through to a fresh `legacy:<connectionId>` key and fail to
+      // supersede the prior socket, leaving stale entries as default
+      // send targets.
+      if (auth.clientInstanceId) {
+        query.set("clientInstanceId", auth.clientInstanceId);
+      }
       const upstreamUrl = `${runtimeBase}/v1/browser-relay?${query.toString()}`;
       const logSafeUpstreamUrl =
         `${runtimeBase}/v1/browser-relay?token=<redacted>` +
-        (auth.guardianId ? `&guardianId=${auth.guardianId}` : "");
+        (auth.guardianId ? `&guardianId=${auth.guardianId}` : "") +
+        (auth.clientInstanceId
+          ? `&clientInstanceId=${auth.clientInstanceId}`
+          : "");
 
       log.info(
-        { upstreamUrl: logSafeUpstreamUrl, guardianId: auth.guardianId },
+        {
+          upstreamUrl: logSafeUpstreamUrl,
+          guardianId: auth.guardianId,
+          clientInstanceId: auth.clientInstanceId,
+        },
         "Opening upstream browser relay WS to runtime",
       );
 


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan self-review:

- Gateway now parses clientInstanceId from the downstream WS URL and forwards it in the upstream URL query param, so cloud reconnects from the same extension install correctly supersede prior connections (P1 — was silently defeating PR5's multi-instance routing for cloud users)
- Registry tie-breaker: introduces a monotonic registrationSeq counter so two instances registering in the same millisecond resolve deterministically to the newer one

Part of plan: browser-use-main-remediation-plan-2026-04-08.md (review fixes)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24505" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
