### PR TITLE
Preserve SPM checkouts during build clean

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -453,7 +453,18 @@ case "$CMD" in
         ;;
     clean)
         echo "Cleaning..."
-        rm -rf "$SCRIPT_DIR/dist" "$SCRIPT_DIR/../.build"
+        rm -rf "$SCRIPT_DIR/dist"
+        # Preserve checkouts/ and repositories/ so SPM doesn't re-clone all
+        # dependencies (swift-protobuf alone pulls ~400 MB of git submodules).
+        # SPM automatically re-fetches any checkout whose version has drifted.
+        # Use 'clean --full' to nuke everything when you suspect corruption.
+        if [ "${2:-}" = "--full" ]; then
+            rm -rf "$SCRIPT_DIR/../.build"
+        else
+            find "$SCRIPT_DIR/../.build" -maxdepth 1 \
+                ! -name .build ! -name checkouts ! -name repositories ! -name artifacts \
+                -exec rm -rf {} + 2>/dev/null || true
+        fi
         rm -rf "$SCRIPT_DIR/daemon-bin" "$SCRIPT_DIR/assistant-bin" "$SCRIPT_DIR/cli-bin" "$SCRIPT_DIR/gateway-bin" "$SCRIPT_DIR/native-host-bin"
         rm -rf "$SPM_MODULE_CACHE"
         echo "Done."
@@ -494,7 +505,10 @@ if [ "$CMD" = "release" ] || [ "$CMD" = "release-application" ]; then
     else
         # Force clean for release builds to prevent stale artifacts in production
         echo "Release build: forcing clean to ensure no stale artifacts..."
-        rm -rf "$SCRIPT_DIR/dist" "$SCRIPT_DIR/../.build"
+        rm -rf "$SCRIPT_DIR/dist"
+        find "$SCRIPT_DIR/../.build" -maxdepth 1 \
+            ! -name .build ! -name checkouts ! -name repositories ! -name artifacts \
+            -exec rm -rf {} + 2>/dev/null || true
         # Also clean compiled Bun binaries to prevent architecture mismatches
         # (e.g. arm64 binaries from a previous build being bundled into an x86_64 release).
         # Skip when SKIP_BUN_REBUILD=1, since pre-built binaries are intentionally provided.


### PR DESCRIPTION
## Summary

- `build clean` now preserves `checkouts/`, `repositories/`, and `artifacts/` in `.build/`, only removing compiled build products
- `build clean --full` retains the old nuke-everything behavior for corruption recovery
- Same change applied to the release build clean path

## Why

The `containerization` package (#24253, merged today) transitively depends on `swift-protobuf`, which has ~400 MB of git submodules (`protocolbuffers/protobuf` + `abseil/abseil-cpp`). Every `build clean` was nuking the entire `.build` directory, forcing SPM to re-clone all 20+ dependencies from scratch — adding minutes of network I/O to every clean+rebuild cycle.

SPM already handles version drift automatically: it compares `workspace-state.json` against `Package.resolved` and re-fetches any checkout whose version doesn't match. So preserving checkouts is safe.

## Test plan

- [ ] `build clean && build run` — should skip "Creating working copy" for all deps
- [ ] `build clean --full && build run` — should re-clone everything (old behavior)
- [ ] Change a dependency version in `Package.swift`, run `build clean && build run` — SPM should re-fetch the changed dep

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24506" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
