### PR TITLE
fix(browser-relay): cloud reconnect hardening (review fixes)

### DIFF
--- a/clients/chrome-extension/background/__tests__/relay-connection.test.ts
+++ b/clients/chrome-extension/background/__tests__/relay-connection.test.ts
@@ -373,8 +373,14 @@ describe('RelayConnection', () => {
       // Server-side abnormal close (e.g. the daemon restarted).
       closeSocket(instances[0], 1006, 'abnormal');
 
-      expect(cbs.closeCalls.length).toBe(1);
-      expect(cbs.closeCalls[0].code).toBe(1006);
+      // onClose is now deferred until after the reconnect-with-refresh
+      // decision resolves, so right after the ws 'close' event fires
+      // the caller has NOT yet been notified. See Gap 4 of the
+      // browser-use-main-remediation-plan: the helper fires onClose
+      // exactly once per lifecycle and defers it to the refresh-path
+      // so an abort decision can propagate the auth error through the
+      // same single notification instead of a double-invoke.
+      expect(cbs.closeCalls.length).toBe(0);
 
       // The reconnect is scheduled behind a real setTimeout — wait long
       // enough for it to fire. The base delay is 1000ms; we tolerate
@@ -385,6 +391,13 @@ describe('RelayConnection', () => {
       expect(instances[1].url).toBe(
         'ws://127.0.0.1:7830/v1/browser-relay?token=t',
       );
+
+      // And by the time the reconnect has fired, the single deferred
+      // onClose has been delivered with the original close code.
+      expect(cbs.closeCalls.length).toBe(1);
+      expect(cbs.closeCalls[0].code).toBe(1006);
+      expect(cbs.closeCalls[0].reason).toBe('abnormal');
+      expect(cbs.closeCalls[0].authError).toBeUndefined();
 
       // Clean up.
       conn.close();
@@ -569,14 +582,19 @@ describe('RelayConnection', () => {
       // decision must stop the reconnect loop cold.
       expect(instances.length).toBe(1);
 
-      // The helper surfaced the auth error via onClose with the
-      // original close code + reason so the worker can route it to
-      // the popup without a second close event.
-      const authCloses = cbs.closeCalls.filter((c) => c.authError !== undefined);
-      expect(authCloses.length).toBe(1);
-      expect(authCloses[0].code).toBe(4001);
-      expect(authCloses[0].reason).toBe('token expired');
-      expect(authCloses[0].authError).toBe('Cloud token expired — sign in again.');
+      // onClose must fire exactly once per lifecycle — the non-normal
+      // close listener defers the notification until after the
+      // reconnect refresh decision resolves, so the caller sees a
+      // single call with the auth error populated and never a prior
+      // invocation with authError undefined. This is the contract
+      // the worker relies on to distinguish "refresh succeeded, will
+      // reconnect" from "refresh failed, surface sign-in prompt".
+      expect(cbs.closeCalls.length).toBe(1);
+      expect(cbs.closeCalls[0].code).toBe(4001);
+      expect(cbs.closeCalls[0].reason).toBe('token expired');
+      expect(cbs.closeCalls[0].authError).toBe(
+        'Cloud token expired — sign in again.',
+      );
 
       // isOpen must return false and a subsequent unexpected close
       // event must not restart reconnects — the helper is marked as
@@ -584,6 +602,73 @@ describe('RelayConnection', () => {
       expect(conn.isOpen()).toBe(false);
       await new Promise((r) => setTimeout(r, 1100));
       expect(instances.length).toBe(1);
+    });
+
+    test('cloud reconnect: onClose fires once per lifecycle on non-abort reconnect', async () => {
+      // Sibling of the abort test above: this pins the invariant
+      // that a reconnect-with-refresh cycle produces exactly ONE
+      // onClose notification (with authError undefined), not two.
+      // A prior revision fired onClose eagerly in the ws 'close'
+      // listener and then again from the abort branch — this test
+      // would catch a regression back to that behaviour by seeing
+      // two entries in closeCalls after a 4001 → refreshed cycle.
+      const cbs = makeCallbacks();
+      const conn = makeConn(
+        { kind: 'cloud', baseUrl: 'https://api.vellum.ai', token: 'old-jwt' },
+        cbs,
+        async () => ({ kind: 'refreshed', token: 'fresh-jwt' }),
+      );
+
+      conn.start();
+      openSocket(instances[0]);
+      closeSocket(instances[0], 4001, 'token expired');
+      await new Promise((r) => setTimeout(r, 1100));
+
+      expect(cbs.closeCalls.length).toBe(1);
+      expect(cbs.closeCalls[0].code).toBe(4001);
+      expect(cbs.closeCalls[0].reason).toBe('token expired');
+      expect(cbs.closeCalls[0].authError).toBeUndefined();
+      // And a fresh socket was built with the refreshed token.
+      expect(instances.length).toBe(2);
+      expect(instances[1].url).toContain('token=fresh-jwt');
+
+      conn.close();
+    });
+
+    test('reconnect refresh exception converts to abort decision', async () => {
+      // The catch branch in scheduleReconnectWithRefresh used to
+      // swallow exceptions and fall through to a bare reconnect with
+      // the same (almost certainly invalid) token, which produced a
+      // silent loop that never reached the popup. Post-fix, any
+      // thrown error from the refresh hook is turned into an abort
+      // decision so the worker surfaces a sign-in prompt.
+      const cbs = makeCallbacks();
+      const conn = makeConn(
+        { kind: 'cloud', baseUrl: 'https://api.vellum.ai', token: 'old-jwt' },
+        cbs,
+        async () => {
+          throw new Error('cloud sign-in returned incomplete payload');
+        },
+      );
+
+      conn.start();
+      openSocket(instances[0]);
+      closeSocket(instances[0], 4001, 'token expired');
+
+      await new Promise((r) => setTimeout(r, 1100));
+
+      // Reconnect loop is halted — no second socket.
+      expect(instances.length).toBe(1);
+      // And onClose fires exactly once with an authError populated
+      // from the thrown exception's message.
+      expect(cbs.closeCalls.length).toBe(1);
+      const authError = cbs.closeCalls[0].authError;
+      expect(typeof authError).toBe('string');
+      expect(authError ?? '').toContain(
+        'cloud sign-in returned incomplete payload',
+      );
+
+      expect(conn.isOpen()).toBe(false);
     });
 
     test('cloud reconnect: keep decision reuses the existing token', async () => {

--- a/clients/chrome-extension/background/cloud-auth.ts
+++ b/clients/chrome-extension/background/cloud-auth.ts
@@ -35,18 +35,38 @@ export interface StoredCloudToken {
 export const CLOUD_TOKEN_STALE_WINDOW_MS = 60_000;
 
 /**
- * WebSocket close codes the gateway uses to signal that the handshake was
- * rejected for an auth reason — an expired JWT, a revoked guardian, or a
- * rotated signing key. The relay reconnect path treats these specially and
- * forces a token refresh before the next connect attempt.
+ * WebSocket close codes that the relay reconnect path treats as a
+ * strong signal the server rejected the handshake for an auth reason —
+ * an expired JWT, a revoked guardian, or a rotated signing key. When
+ * any of these fire, the cloudReconnectHook forces a token refresh
+ * before the next connect attempt.
  *
+ * IMPORTANT: the set deliberately does NOT include `1006` because 1006
+ * ("abnormal closure") also fires on transient network blips and can't
+ * be disambiguated from an auth failure by code alone. The gateway
+ * (see `gateway/src/http/routes/browser-relay-websocket.ts`) and the
+ * runtime reject invalid actor tokens with an HTTP 401 BEFORE the
+ * WebSocket upgrade, which browsers surface as close code 1006 (never
+ * 4001/4002/4003). The cloudReconnectHook in worker.ts applies an
+ * attempt-counter heuristic to handle that case separately: it forces
+ * a refresh on the first 1006 after connect, and aborts with a
+ * sign-in prompt after a small number of failed refreshes. See that
+ * hook's `REFRESH_ATTEMPT_CAP` for details.
+ *
+ * Codes that ARE in this set:
+ * - `1008` ("policy violation") — observed in practice when the
+ *   gateway or its upstream runtime rejects a frame after a successful
+ *   handshake (e.g. buffer overflow, explicit policy kicks). The
+ *   runtime may also bubble up 1008 when the actor-token binding
+ *   becomes stale mid-session.
  * - `4001`/`4002`/`4003` are in the RFC 6455 "application" range
- *   (4000–4999) and match the codes emitted by
- *   `gateway/src/http/routes/browser-relay-websocket.ts` for the three
- *   distinct auth-failure paths.
- * - `1008` ("policy violation") is included for robustness — some
- *   intermediaries rewrite application codes back to 1008 when the socket
- *   is torn down mid-handshake.
+ *   (4000–4999). Neither the gateway nor the runtime emits these
+ *   today for the standard pre-upgrade auth rejection (that path is
+ *   HTTP 401 → 1006), but they are retained as a forward-compatible
+ *   contract: future gateway changes may close the socket with a
+ *   4xxx code for post-upgrade auth failures (e.g. a rotated signing
+ *   key invalidating an already-connected socket) without requiring
+ *   a matching extension update.
  */
 export const CLOUD_AUTH_FAILURE_CLOSE_CODES: ReadonlySet<number> = new Set([
   1008, 4001, 4002, 4003,

--- a/clients/chrome-extension/background/relay-connection.ts
+++ b/clients/chrome-extension/background/relay-connection.ts
@@ -269,14 +269,25 @@ export class RelayConnection {
       const code = event.code;
       const reason = event.reason;
       this.ws = null;
-      this.deps.onClose(code, reason);
-      if (!this.closedByCaller) {
-        if (!NORMAL_CLOSE_CODES.has(code)) {
-          this.scheduleReconnectWithRefresh({ code, reason });
-        } else {
-          this.scheduleReconnect();
-        }
+      if (this.closedByCaller) {
+        // The caller tore down this connection (mode switch, explicit
+        // close, etc.) — fire onClose exactly once and stop.
+        this.deps.onClose(code, reason);
+        return;
       }
+      if (NORMAL_CLOSE_CODES.has(code)) {
+        // Clean server-initiated close (e.g. 1000/1001). Notify the
+        // caller and schedule a plain reconnect without going through
+        // the refresh hook.
+        this.deps.onClose(code, reason);
+        this.scheduleReconnect();
+        return;
+      }
+      // Non-normal close: defer the onClose notification until after
+      // the reconnect-with-refresh decision resolves so the caller
+      // sees exactly one onClose call per lifecycle. The helper
+      // surfaces an authError when refresh returns/aborts.
+      this.scheduleReconnectWithRefresh({ code, reason });
     });
 
     ws.addEventListener('error', () => {
@@ -324,50 +335,91 @@ export class RelayConnection {
    *
    * The close `code` / `reason` are forwarded as a
    * {@link RelayReconnectContext} so the handler can tell an
-   * auth-failure close (4001/4002/4003/1008) apart from a transient
-   * network drop. For auth-failure closes in cloud mode the handler
-   * returns `{ kind: 'abort' }` when refresh is impossible — we stop
-   * the reconnect loop, mark the connection closed, and surface the
-   * error through `onClose` so the popup UI can prompt the user to
-   * sign in again instead of silently hammering the gateway.
+   * auth-failure close (4001/4002/4003/1008, or 1006 when the
+   * pre-upgrade HTTP 401 surfaces as abnormal closure) apart from a
+   * transient network drop. For auth-failure closes in cloud mode the
+   * handler returns `{ kind: 'abort' }` when refresh is impossible —
+   * we stop the reconnect loop, mark the connection closed, and
+   * surface the error through `onClose` so the popup UI can prompt
+   * the user to sign in again instead of silently hammering the
+   * gateway.
+   *
+   * `onClose` is invoked EXACTLY ONCE per lifecycle here: either with
+   * `authError` set when the refresh hook aborts, or with `authError`
+   * undefined when we proceed with a reconnect attempt. The
+   * `ws.addEventListener('close', ...)` handler deliberately does NOT
+   * fire onClose for non-normal closes — it defers that
+   * responsibility to this method so the caller never sees a double
+   * invocation on the abort-decision path.
    */
   private scheduleReconnectWithRefresh(ctx: RelayReconnectContext): void {
     if (this.reconnectTimer !== null) return;
     const delay = this.reconnectDelay;
     this.reconnectTimer = setTimeout(async () => {
       this.reconnectTimer = null;
-      if (this.closedByCaller) return;
+      if (this.closedByCaller) {
+        // Caller called close() while we were waiting for the
+        // backoff timer to fire. Notify them once with the original
+        // close code/reason and stop — no reconnect, no refresh.
+        this.deps.onClose(ctx.code, ctx.reason);
+        return;
+      }
+      let decision: RelayReconnectDecision = { kind: 'keep' };
       if (this.deps.onReconnect) {
-        let decision: RelayReconnectDecision | null = null;
         try {
           const result = await this.deps.onReconnect(ctx);
           decision = normaliseReconnectResult(result);
-        } catch {
-          // Refresh failures fall through to a bare reconnect attempt —
-          // the server will reject the handshake and we'll loop.
-          decision = null;
-        }
-        if (decision) {
-          if (decision.kind === 'abort') {
-            // Refresh is impossible (e.g. cloud token expired and
-            // non-interactive renewal failed). Stop reconnecting and
-            // surface the error via onClose so the worker can push an
-            // actionable message into chrome.storage for the popup.
-            this.closedByCaller = true;
-            this.deps.onClose(ctx.code, ctx.reason, decision.error);
-            return;
-          }
-          if (decision.kind === 'refreshed') {
-            this.deps = {
-              ...this.deps,
-              mode: { ...this.deps.mode, token: decision.token },
-            };
-          }
-          // 'keep' → leave mode.token alone and fall through to
-          // connect() with the existing token.
+        } catch (err) {
+          // Refresh threw unexpectedly — log and convert to an abort
+          // so the reconnect loop halts and the popup can surface a
+          // sign-in prompt. Previously we swallowed the error and
+          // reconnected with the same (probably invalid) token,
+          // which produced a silent retry loop that never reached
+          // the user. See browser-use-main-remediation-plan Gap 2.
+          const message = err instanceof Error ? err.message : String(err);
+          console.warn(
+            '[vellum-relay] onReconnect hook threw; aborting reconnect loop',
+            err,
+          );
+          decision = {
+            kind: 'abort',
+            error:
+              `Relay token refresh failed: ${message}. ` +
+              `Sign in with Vellum again from the extension popup to reconnect.`,
+          };
         }
       }
-      if (!this.closedByCaller) this.connect();
+      if (decision.kind === 'abort') {
+        // Refresh is impossible (e.g. cloud token expired and
+        // non-interactive renewal failed, or the refresh hook threw).
+        // Stop reconnecting and surface the error via onClose so the
+        // worker can push an actionable message into chrome.storage
+        // for the popup.
+        this.closedByCaller = true;
+        this.deps.onClose(ctx.code, ctx.reason, decision.error);
+        return;
+      }
+      if (decision.kind === 'refreshed') {
+        this.deps = {
+          ...this.deps,
+          mode: { ...this.deps.mode, token: decision.token },
+        };
+      }
+      // 'keep' → leave mode.token alone and fall through to
+      // connect() with the existing token.
+      //
+      // Caller may have called close() concurrently with the refresh
+      // hook — re-check before firing onClose or reconnecting.
+      if (this.closedByCaller) {
+        this.deps.onClose(ctx.code, ctx.reason);
+        return;
+      }
+      // Fire onClose once for this lifecycle before we start a fresh
+      // connect attempt. The caller sees exactly one onClose per
+      // non-normal close, with authError undefined on the reconnect
+      // path and set on the abort path.
+      this.deps.onClose(ctx.code, ctx.reason);
+      this.connect();
     }, delay);
     this.reconnectDelay = Math.min(this.reconnectDelay * 2, RECONNECT_MAX_MS);
   }

--- a/clients/chrome-extension/background/worker.ts
+++ b/clients/chrome-extension/background/worker.ts
@@ -361,6 +361,42 @@ async function buildRelayModeConfig(kind: RelayModeKind): Promise<RelayMode> {
   };
 }
 
+// WebSocket close code 1006 ("abnormal closure") is what browsers
+// report when a WebSocket connection drops without a clean close
+// frame. Both the gateway and the runtime reject invalid/expired
+// actor tokens with an HTTP 401 BEFORE the WebSocket upgrade, which
+// browsers surface to JS as 1006 — not 4001/4002/4003. So a cloud
+// client with a rotated/expired token sees 1006, not an entry in
+// CLOUD_AUTH_FAILURE_CLOSE_CODES. We can't unconditionally treat 1006
+// as an auth failure, though: it also fires for transient network
+// blips (cable unplugged, Chrome sleep/wake, flaky coffee-shop Wi-Fi).
+//
+// The heuristic below is:
+//   1. On the first 1006 close we haven't successfully recovered
+//      from, try a token refresh — if the token was the problem a
+//      fresh one will let the next connect succeed and the counter
+//      will reset.
+//   2. After CLOUD_REFRESH_ATTEMPT_CAP consecutive failed refresh
+//      attempts we stop reconnecting and abort with an actionable
+//      sign-in prompt instead of silently hammering the gateway.
+//   3. The counter resets to zero every time a socket successfully
+//      opens (see the `onOpen` wiring in `createRelayConnection`).
+const WS_CLOSE_CODE_ABNORMAL = 1006;
+const CLOUD_REFRESH_ATTEMPT_CAP = 3;
+
+/**
+ * Count of consecutive refresh attempts made from
+ * {@link cloudReconnectHook} since the last successful WebSocket open.
+ * Reset to 0 on every `onOpen` callback so a short-lived successful
+ * connection effectively re-arms the 1006 recovery path. Exported via
+ * {@link resetCloudRefreshAttempts} for the worker's own wiring.
+ */
+let cloudRefreshAttempts = 0;
+
+function resetCloudRefreshAttempts(): void {
+  cloudRefreshAttempts = 0;
+}
+
 /**
  * Reconnect hook for cloud mode. Called by {@link RelayConnection} when
  * the WebSocket closes unexpectedly — responsible for deciding whether
@@ -374,6 +410,9 @@ async function buildRelayModeConfig(kind: RelayModeKind): Promise<RelayMode> {
  *   - The close code matches a known auth-failure code emitted by the
  *     gateway's browser-relay handshake (see
  *     `CLOUD_AUTH_FAILURE_CLOSE_CODES`).
+ *   - The close code is 1006 AND we haven't already exhausted the
+ *     1006 refresh budget. See the docstring on
+ *     {@link WS_CLOSE_CODE_ABNORMAL} for the rationale.
  *
  * On successful refresh the new token is persisted to storage by
  * `refreshCloudToken` and returned via `{ kind: 'refreshed' }` so the
@@ -387,7 +426,18 @@ async function cloudReconnectHook(
 ): Promise<RelayReconnectDecision> {
   const stored = await getStoredCloudTokenRaw();
   const authFailure = CLOUD_AUTH_FAILURE_CLOSE_CODES.has(ctx.code);
-  const needsRefresh = authFailure || isCloudTokenStale(stored);
+  const abnormal = ctx.code === WS_CLOSE_CODE_ABNORMAL;
+  // For 1006 we only assume "this is an auth problem" while we
+  // haven't burned through the refresh budget. A mid-session cable
+  // pull will also produce 1006 and we don't want to abort the
+  // reconnect loop on the very first network blip — the attempt
+  // counter resets every time a socket successfully re-opens (see
+  // resetCloudRefreshAttempts in the onOpen hook), so a transient
+  // network outage just racks up attempts we never actually use.
+  const abnormalNeedsRefresh =
+    abnormal && cloudRefreshAttempts < CLOUD_REFRESH_ATTEMPT_CAP;
+  const needsRefresh =
+    authFailure || abnormalNeedsRefresh || isCloudTokenStale(stored);
 
   if (!needsRefresh && stored?.token) {
     // Transient network blip with a still-valid token. Keep the
@@ -395,6 +445,21 @@ async function cloudReconnectHook(
     return { kind: 'keep' };
   }
 
+  // If we've already burned the 1006 refresh budget without a
+  // successful reconnect, stop hammering the gateway and prompt the
+  // user to sign in again. We intentionally check this BEFORE calling
+  // refreshCloudToken so an in-flight reconnect that just flipped us
+  // into the abort branch doesn't rack up a gratuitous refresh.
+  if (abnormal && cloudRefreshAttempts >= CLOUD_REFRESH_ATTEMPT_CAP) {
+    return {
+      kind: 'abort',
+      error:
+        `Cloud relay kept closing with abnormal closure (code 1006) after ${CLOUD_REFRESH_ATTEMPT_CAP} ` +
+        'token refresh attempts. Please sign in with Vellum (cloud) again from the extension popup to reconnect.',
+    };
+  }
+
+  cloudRefreshAttempts += 1;
   const refreshed = await refreshCloudToken({
     gatewayBaseUrl: CLOUD_GATEWAY_BASE_URL,
     clientId: CLOUD_OAUTH_CLIENT_ID,
@@ -407,11 +472,13 @@ async function cloudReconnectHook(
   // Non-interactive refresh is impossible — user must sign in again.
   const reason = authFailure
     ? 'Cloud relay closed with an auth-failure code'
-    : 'Stored cloud token has expired';
+    : abnormal
+      ? 'Cloud relay closed abnormally (code 1006) and token refresh failed'
+      : 'Stored cloud token has expired';
   return {
     kind: 'abort',
     error:
-      `${reason}. Sign in with Vellum (cloud) again from the extension popup to reconnect.`,
+      `${reason}. Please sign in with Vellum (cloud) again from the extension popup to reconnect.`,
   };
 }
 
@@ -431,6 +498,11 @@ function createRelayConnection(
       // A successful connect means any persisted auth-error is stale
       // — clear it so the popup stops showing the sign-in prompt.
       void clearRelayAuthError();
+      // Re-arm the 1006 recovery path. A short-lived successful
+      // connection counts as "we recovered" even if the socket drops
+      // seconds later; the next 1006 should try a fresh refresh
+      // instead of inheriting the previous chain's attempt count.
+      resetCloudRefreshAttempts();
     },
     onMessage: (data) => {
       // Fire-and-forget dispatch — wrap with .catch so a future refactor

--- a/clients/chrome-extension/popup/popup.ts
+++ b/clients/chrome-extension/popup/popup.ts
@@ -59,9 +59,32 @@ function setConnected(connected: boolean): void {
   }
 }
 
-function showError(msg: string): void {
+/**
+ * Render an inline error message without touching any other UI.
+ *
+ * Use this for errors that are not actionable by the self-hosted
+ * manual-token-entry workflow — e.g. cloud OAuth failures, refresh
+ * exceptions, or generic service-worker messages. It's specifically
+ * the variant {@link refreshCloudStatus} uses so a cloud auth error
+ * does not accidentally reveal the self-hosted token input.
+ */
+function showErrorText(msg: string): void {
   errorText.textContent = msg;
   errorText.style.display = 'block';
+}
+
+/**
+ * Render an inline error message AND reveal the self-hosted manual
+ * token entry section. Use this for errors where the user's next
+ * action is to paste a bearer token into the manual-entry box —
+ * e.g. a failed auto-fetch or a missing paired local assistant.
+ *
+ * Do NOT use this for cloud auth errors: the manual token entry
+ * section is a self-hosted-only workflow, and revealing it for a
+ * cloud error would point the user at the wrong remediation.
+ */
+function showError(msg: string): void {
+  showErrorText(msg);
   // Reveal manual token entry on auto-fetch failure
   if (!manualMode) {
     manualMode = true;
@@ -301,6 +324,12 @@ async function refreshCloudStatus(): Promise<void> {
     // reconnect. The worker writes `vellum.relayAuthError` when the
     // cloud token refresh fails (see cloudReconnectHook in worker.ts)
     // and clears it on a successful connect.
+    //
+    // Use showErrorText (NOT showError) here: the self-hosted manual
+    // token entry section is irrelevant to a cloud auth error, and
+    // revealing it would point the user at the wrong remediation.
+    // The error message itself already instructs the user to sign
+    // in with Vellum (cloud) again, which is all they need.
     const authErrResult = await chrome.storage.local.get('vellum.relayAuthError');
     const authErr = authErrResult['vellum.relayAuthError'];
     if (
@@ -308,7 +337,7 @@ async function refreshCloudStatus(): Promise<void> {
       typeof authErr === 'object' &&
       typeof (authErr as { message?: unknown }).message === 'string'
     ) {
-      showError((authErr as { message: string }).message);
+      showErrorText((authErr as { message: string }).message);
     }
   } catch (err) {
     setCloudStatus(`Error: ${err instanceof Error ? err.message : String(err)}`, false);


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan self-review for browser-use-main-remediation-plan-2026-04-08.md:

- 1006 close code no longer causes infinite reconnect loop — after N failed refreshes it aborts with a sign-in prompt
- scheduleReconnectWithRefresh catch block converts refresh exceptions to abort decisions
- CLOUD_AUTH_FAILURE_CLOSE_CODES comment now describes actual close code semantics
- RelayConnection.onClose fires exactly once per lifecycle (no double-invoke on abort path)
- Cloud auth errors in popup no longer reveal self-hosted manual token entry UI
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24507" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
