### PR TITLE
fix(browser-relay): accept capability tokens on /v1/host-browser-result POST

### DIFF
--- a/assistant/src/__tests__/host-browser-e2e-self-hosted-capability.test.ts
+++ b/assistant/src/__tests__/host-browser-e2e-self-hosted-capability.test.ts
@@ -146,7 +146,7 @@ describe("host_browser self-hosted capability-token e2e round-trip", () => {
     __resetChromeExtensionRegistryForTests();
   });
 
-  test("capability token round-trips Browser.getVersion", async () => {
+  test("capability token round-trips Browser.getVersion over WS result transport", async () => {
     const guardianId = `self-hosted-guardian-${crypto.randomUUID()}`;
 
     // Mint the capability token the chrome extension would have
@@ -157,13 +157,10 @@ describe("host_browser self-hosted capability-token e2e round-trip", () => {
 
     const { createMockChromeExtension } =
       await import("./fixtures/mock-chrome-extension.js");
-    // Use the WS result transport (PR 2 of the remediation plan)
-    // rather than the HTTP POST fallback. The POST path goes through
-    // the JWT-bearer auth middleware which doesn't currently accept
-    // capability tokens; the WS frame path is the canonical
-    // self-hosted return transport and works without any additional
-    // auth because the WS connection is already authenticated by the
-    // same capability token.
+    // WS result transport: the extension returns results over the same
+    // `/v1/browser-relay` WebSocket it received the request on. This
+    // is the canonical self-hosted return path when the socket is
+    // healthy.
     const mockExt = createMockChromeExtension({
       runtimeBaseUrl,
       token,
@@ -178,11 +175,11 @@ describe("host_browser self-hosted capability-token e2e round-trip", () => {
     // before the Browser.getVersion call runs.
     await waitForRegistryEntry(guardianId);
 
-    const { proxy } = createBoundProxy(guardianId, "conv-cap-happy");
+    const { proxy } = createBoundProxy(guardianId, "conv-cap-happy-ws");
 
     const result = await proxy.request(
       { cdpMethod: "Browser.getVersion" },
-      "conv-cap-happy",
+      "conv-cap-happy-ws",
     );
 
     expect(result.isError).toBe(false);
@@ -191,7 +188,49 @@ describe("host_browser self-hosted capability-token e2e round-trip", () => {
     const received = mockExt.receivedRequests();
     expect(received).toHaveLength(1);
     expect(received[0].cdpMethod).toBe("Browser.getVersion");
-    expect(received[0].conversationId).toBe("conv-cap-happy");
+    expect(received[0].conversationId).toBe("conv-cap-happy-ws");
+
+    proxy.dispose();
+    await mockExt.stop();
+  });
+
+  test("capability token round-trips Browser.getVersion over HTTP POST fallback", async () => {
+    // HTTP result transport: the extension POSTs results back to
+    // `/v1/host-browser-result` with the same capability token as the
+    // WS handshake. This exercises the fix added on top of the PR3
+    // cutover — before the fix the POST route's JWT-only auth
+    // middleware 401'd every capability-token-bearing request and
+    // silently dropped the CDP result whenever the relay WS was
+    // unavailable. The test must prove the HTTP fallback actually
+    // resolves the pending interaction end-to-end.
+    const guardianId = `self-hosted-guardian-${crypto.randomUUID()}`;
+    const { token } = mintHostBrowserCapability(guardianId);
+
+    const { createMockChromeExtension } =
+      await import("./fixtures/mock-chrome-extension.js");
+    const mockExt = createMockChromeExtension({
+      runtimeBaseUrl,
+      token,
+      resultTransport: "http",
+    });
+    await mockExt.start();
+    await mockExt.waitForConnection();
+    await waitForRegistryEntry(guardianId);
+
+    const { proxy } = createBoundProxy(guardianId, "conv-cap-happy-http");
+
+    const result = await proxy.request(
+      { cdpMethod: "Browser.getVersion" },
+      "conv-cap-happy-http",
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Chrome/MockTest");
+
+    const received = mockExt.receivedRequests();
+    expect(received).toHaveLength(1);
+    expect(received[0].cdpMethod).toBe("Browser.getVersion");
+    expect(received[0].conversationId).toBe("conv-cap-happy-http");
 
     proxy.dispose();
     await mockExt.stop();

--- a/assistant/src/runtime/auth/__tests__/middleware.test.ts
+++ b/assistant/src/runtime/auth/__tests__/middleware.test.ts
@@ -34,7 +34,15 @@ mock.module("../../../config/env.js", () => ({
 }));
 
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../../assistant-scope.js";
-import { authenticateRequest } from "../middleware.js";
+import {
+  mintHostBrowserCapability,
+  resetCapabilityTokenSecretForTests,
+  setCapabilityTokenSecretForTests,
+} from "../../capability-tokens.js";
+import {
+  authenticateHostBrowserResultRequest,
+  authenticateRequest,
+} from "../middleware.js";
 import { initAuthSigningKey, mintToken } from "../token-service.js";
 import type { ScopeProfile, TokenAudience } from "../types.js";
 
@@ -259,6 +267,113 @@ describe("authenticateRequest", () => {
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.response.status).toBe(401);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// authenticateHostBrowserResultRequest — capability-token-aware auth for the
+// /v1/host-browser-result POST route. Verifies that both the capability-token
+// and JWT paths are accepted, and that a garbage bearer falls through to the
+// JWT path and emits a 401 like any other invalid token.
+// ---------------------------------------------------------------------------
+
+describe("authenticateHostBrowserResultRequest", () => {
+  const CAPABILITY_SECRET = Buffer.alloc(32, 7);
+
+  beforeEach(() => {
+    // Pin the capability-token HMAC secret so mint/verify agree across
+    // the test run. The module-level secret cache is reset between
+    // tests so dev-bypass flipping doesn't leak stale state.
+    setCapabilityTokenSecretForTests(CAPABILITY_SECRET);
+  });
+
+  afterAll(() => {
+    resetCapabilityTokenSecretForTests();
+  });
+
+  test("accepts a valid capability token and synthesizes an actor AuthContext", () => {
+    const { token } = mintHostBrowserCapability("guardian-cap-happy");
+    const req = new Request("http://localhost/v1/host-browser-result", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    const result = authenticateHostBrowserResultRequest(req);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.context.principalType).toBe("actor");
+      expect(result.context.assistantId).toBe(DAEMON_INTERNAL_ASSISTANT_ID);
+      expect(result.context.actorPrincipalId).toBe("guardian-cap-happy");
+      expect(result.context.scopeProfile).toBe("actor_client_v1");
+      // The synthetic context must carry the scopes the route policy
+      // requires — otherwise the router would 403 the POST even though
+      // auth succeeded.
+      expect(result.context.scopes.has("approval.write")).toBe(true);
+    }
+  });
+
+  test("accepts a valid daemon-audience JWT (regression for the legacy path)", () => {
+    const token = mintValidToken({ sub: "actor:self:jwt-principal" });
+    const req = new Request("http://localhost/v1/host-browser-result", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    const result = authenticateHostBrowserResultRequest(req);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.context.principalType).toBe("actor");
+      expect(result.context.actorPrincipalId).toBe("jwt-principal");
+      expect(result.context.scopes.has("approval.write")).toBe(true);
+    }
+  });
+
+  test("returns 401 when the Authorization header is missing entirely", () => {
+    const req = new Request("http://localhost/v1/host-browser-result", {
+      method: "POST",
+    });
+
+    const result = authenticateHostBrowserResultRequest(req);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.status).toBe(401);
+    }
+  });
+
+  test("malformed bearer falls through to JWT path and 401s", () => {
+    // A bearer that is neither a valid capability token (bad HMAC) nor a
+    // parseable JWT must fail the JWT path and return 401. This is the
+    // primary regression guard against someone accidentally making the
+    // capability-token branch "allow-anything" by swallowing
+    // verification failures.
+    const req = new Request("http://localhost/v1/host-browser-result", {
+      method: "POST",
+      headers: { Authorization: "Bearer not-a-token.xxxxxxxxxxxxx" },
+    });
+
+    const result = authenticateHostBrowserResultRequest(req);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.status).toBe(401);
+    }
+  });
+
+  test("dev bypass returns synthetic AuthContext without Authorization header", () => {
+    authDisabled = true;
+
+    const req = new Request("http://localhost/v1/host-browser-result", {
+      method: "POST",
+    });
+
+    const result = authenticateHostBrowserResultRequest(req);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      // Same synthetic context shape as authenticateRequest's dev
+      // bypass — the tests share the same invariant because a single
+      // helper builds both.
+      expect(result.context.principalType).toBe("actor");
+      expect(result.context.actorPrincipalId).toBe("dev-bypass");
     }
   });
 });

--- a/assistant/src/runtime/auth/middleware.ts
+++ b/assistant/src/runtime/auth/middleware.ts
@@ -25,6 +25,7 @@
 import { isHttpAuthDisabled } from "../../config/env.js";
 import { getLogger } from "../../util/logger.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../assistant-scope.js";
+import { verifyHostBrowserCapability } from "../capability-tokens.js";
 import { extractBearerToken } from "../middleware/auth.js";
 import { buildAuthContext } from "./context.js";
 import { resolveScopeProfile } from "./scopes.js";
@@ -185,4 +186,101 @@ export function authenticateRequest(req: Request): AuthenticateResult {
   }
 
   return { ok: true, context: contextResult.context };
+}
+
+// ---------------------------------------------------------------------------
+// Capability-token-aware auth for /v1/host-browser-result
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a synthetic AuthContext from a verified host_browser capability
+ * claim. The resulting context is shaped to look like an
+ * `actor_client_v1` actor so downstream route policy (which requires
+ * `approval.write`) and `requireBoundGuardian` (which compares
+ * `actorPrincipalId` against the bound guardian) both accept it.
+ *
+ * The capability token already carries its own HMAC-checked expiry, so
+ * there is no policy-epoch gate to apply here — we pin `policyEpoch` to
+ * `Number.MAX_SAFE_INTEGER` the same way the dev-bypass context does.
+ */
+function buildCapabilityAuthContext(guardianId: string): AuthContext {
+  return {
+    subject: `actor:${DAEMON_INTERNAL_ASSISTANT_ID}:${guardianId}`,
+    principalType: "actor",
+    assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
+    actorPrincipalId: guardianId,
+    scopeProfile: "actor_client_v1",
+    scopes: resolveScopeProfile("actor_client_v1"),
+    policyEpoch: Number.MAX_SAFE_INTEGER,
+  };
+}
+
+/**
+ * Authenticate a request that is allowed to present either a JWT or a
+ * host_browser capability token. This is the auth entry point for
+ * `/v1/host-browser-result` POST specifically — the chrome extension
+ * stores a capability token (minted by the
+ * `/v1/browser-extension-pair` flow) rather than a daemon JWT, so the
+ * POST fallback used when the `/v1/browser-relay` WebSocket is
+ * unavailable would otherwise 401 through the JWT-only
+ * `authenticateRequest` path.
+ *
+ * Order of operations (mirrors `handleBrowserRelayUpgrade`):
+ *   1. Extract the bearer token. Missing header → 401.
+ *   2. Try `verifyHostBrowserCapability(token)` first. If it succeeds,
+ *      derive `guardianId` from the capability claims and synthesize an
+ *      AuthContext.
+ *   3. Otherwise fall through to the standard JWT path so daemon-minted
+ *      JWTs (gateway-proxied or direct) continue to work as a
+ *      regression-safe compatibility path.
+ *
+ * Dev bypass (`isHttpAuthDisabled()`) is honored the same way as
+ * `authenticateRequest` — we delegate to it directly to pick up the
+ * shared synthetic dev-bypass context.
+ */
+export function authenticateHostBrowserResultRequest(
+  req: Request,
+): AuthenticateResult {
+  if (isHttpAuthDisabled()) {
+    return { ok: true, context: buildDevBypassContext() };
+  }
+
+  const rawToken = extractBearerToken(req);
+  if (!rawToken) {
+    log.warn(
+      { reason: "missing_token", path: "/v1/host-browser-result" },
+      "Host browser result auth denied: missing Authorization header",
+    );
+    return {
+      ok: false,
+      response: Response.json(
+        {
+          error: {
+            code: "UNAUTHORIZED",
+            message: "Missing Authorization header",
+          },
+        },
+        { status: 401 },
+      ),
+    };
+  }
+
+  // 1) Capability-token path (self-hosted default). The chrome
+  //    extension presents the token it received from the native
+  //    messaging pair flow. We derive `actorPrincipalId` from the
+  //    capability claims directly — the claims are HMAC-signed by the
+  //    same daemon so there is no cross-tenant risk.
+  const capabilityClaims = verifyHostBrowserCapability(rawToken);
+  if (capabilityClaims) {
+    return {
+      ok: true,
+      context: buildCapabilityAuthContext(capabilityClaims.guardianId),
+    };
+  }
+
+  // 2) JWT compatibility path. Fall back to the existing daemon/gateway
+  //    JWT verification so cloud callers and any legacy self-hosted
+  //    clients still holding a daemon JWT continue to work. Any 401
+  //    emitted here already includes the JWT-specific reason.
+  return authenticateRequest(req);
 }

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -73,7 +73,10 @@ import { buildAssistantEvent } from "./assistant-event.js";
 import { assistantEventHub } from "./assistant-event-hub.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "./assistant-scope.js";
 // Auth
-import { authenticateRequest } from "./auth/middleware.js";
+import {
+  authenticateHostBrowserResultRequest,
+  authenticateRequest,
+} from "./auth/middleware.js";
 import { parseSub } from "./auth/subject.js";
 import {
   mintDaemonDeliveryToken,
@@ -800,7 +803,19 @@ export class RuntimeHttpServer {
 
     // JWT bearer authentication — replaces the old shared-secret comparison.
     // authenticateRequest handles dev bypass (DISABLE_HTTP_AUTH) internally.
-    const authResult = authenticateRequest(req);
+    //
+    // Special-case: /v1/host-browser-result POST accepts either a
+    // daemon-minted JWT (legacy/cloud) or a host_browser capability
+    // token (self-hosted chrome extension). The chrome extension's
+    // HTTP fallback (`postHostBrowserResult`) hands over the same
+    // capability token it presented to `/v1/browser-relay`, so the
+    // POST route must understand both auth shapes. Every other route
+    // keeps the JWT-only flow via `authenticateRequest`.
+    const normalizedPath = path.endsWith("/") ? path.slice(0, -1) : path;
+    const authResult =
+      normalizedPath === "/v1/host-browser-result" && req.method === "POST"
+        ? authenticateHostBrowserResultRequest(req)
+        : authenticateRequest(req);
     if (!authResult.ok) {
       return authResult.response;
     }


### PR DESCRIPTION
## Summary
Fixes a P1 gap identified during plan self-review. After PR3's capability token cutover, the self-hosted chrome extension uses an HMAC capability token as its Bearer, but the /v1/host-browser-result route's JWT-only auth rejected it with 401 — silently dropping every CDP result when the relay WS was unavailable.

The route now tries verifyHostBrowserCapability first (deriving guardianId from capability claims) and falls back to JWT auth. Regression tests cover both auth paths.

Part of plan: browser-use-main-remediation-plan-2026-04-08.md (review fix)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24509" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
