### PR TITLE
fix(gateway): default-fallback booleans in PATCH response and clamp parseNestedNumber

### DIFF
--- a/gateway/src/__tests__/privacy-config-route.test.ts
+++ b/gateway/src/__tests__/privacy-config-route.test.ts
@@ -643,3 +643,218 @@ describe("PATCH /v1/config/privacy handler — existing behavior (regression gua
     expect(body.error).toContain("sendDiagnostics");
   });
 });
+
+// Gap 2a-1: the PATCH response must always include collectUsageData and
+// sendDiagnostics — even when config.json lacks the keys — because the
+// OpenAPI schema marks both as `required`. Previously the PATCH handler read
+// the booleans directly from the post-write config, producing `undefined`
+// values that Response.json() silently drops. These regression tests fix the
+// on-disk config to be "empty" before the PATCH and assert the response
+// still has both booleans populated from defaults.
+describe("PATCH /v1/config/privacy handler — Gap 2a-1 boolean defaults in response", () => {
+  test("PATCH with only llmRequestLogRetentionMs returns both booleans as defaults when config.json lacks them", async () => {
+    // Empty config.json — no collectUsageData, no sendDiagnostics.
+    writeFileSync(configPath, JSON.stringify({}));
+
+    const handler = createPrivacyConfigPatchHandler();
+    const res = await handler(makePatch({ llmRequestLogRetentionMs: 60_000 }));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    // The schema contract: these fields are always present in the response.
+    expect(body).toHaveProperty("collectUsageData");
+    expect(body).toHaveProperty("sendDiagnostics");
+    expect(body).toHaveProperty("llmRequestLogRetentionMs");
+    expect(body.collectUsageData).toBe(true);
+    expect(body.sendDiagnostics).toBe(true);
+    expect(body.llmRequestLogRetentionMs).toBe(60_000);
+  });
+
+  test("PATCH with only collectUsageData returns sendDiagnostics as default when config.json lacks it", async () => {
+    writeFileSync(configPath, JSON.stringify({}));
+
+    const handler = createPrivacyConfigPatchHandler();
+    const res = await handler(makePatch({ collectUsageData: false }));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.collectUsageData).toBe(false);
+    // Default from daemon schema.
+    expect(body.sendDiagnostics).toBe(true);
+    // Default from daemon schema when memory.cleanup is missing.
+    expect(body.llmRequestLogRetentionMs).toBe(DEFAULT_RETENTION_MS);
+  });
+
+  test("PATCH with only sendDiagnostics returns collectUsageData as default when config.json lacks it", async () => {
+    writeFileSync(configPath, JSON.stringify({}));
+
+    const handler = createPrivacyConfigPatchHandler();
+    const res = await handler(makePatch({ sendDiagnostics: false }));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    // Default from daemon schema.
+    expect(body.collectUsageData).toBe(true);
+    expect(body.sendDiagnostics).toBe(false);
+  });
+
+  test("PATCH with only llmRequestLogRetentionMs returns default booleans when config.json has non-boolean values", async () => {
+    // A user (or an older version of the code) wrote garbage into the
+    // booleans. We should still respond with valid booleans so the UI
+    // doesn't choke on a missing field.
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        collectUsageData: "yes",
+        sendDiagnostics: 1,
+      }),
+    );
+
+    const handler = createPrivacyConfigPatchHandler();
+    const res = await handler(makePatch({ llmRequestLogRetentionMs: 60_000 }));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    // Fall back to schema defaults.
+    expect(body.collectUsageData).toBe(true);
+    expect(body.sendDiagnostics).toBe(true);
+    expect(body.llmRequestLogRetentionMs).toBe(60_000);
+  });
+});
+
+// Gap 2a-2: parseNestedNumber must clamp values above
+// MAX_LLM_REQUEST_LOG_RETENTION_MS (365 days). A manually-edited config.json
+// containing a 10-year retention (or any bogus large number) would otherwise
+// be served verbatim from GET, and the Swift UI's `closest(toMs:)` would
+// snap it to the nearest supported option, and the next PATCH would silently
+// truncate the on-disk value — data loss with no UI warning.
+describe("GET /v1/config/privacy handler — Gap 2a-2 out-of-range clamp", () => {
+  test("clamps llmRequestLogRetentionMs above 365 days to the default on GET", async () => {
+    const tooBig = 365 * 24 * 60 * 60 * 1000 + 1; // 1ms over max
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        memory: {
+          cleanup: {
+            llmRequestLogRetentionMs: tooBig,
+          },
+        },
+      }),
+    );
+
+    const handler = createPrivacyConfigGetHandler();
+    const res = await handler(
+      new Request("http://gateway.test/v1/config/privacy"),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    // Clamped to default, not the bogus value on disk.
+    expect(body.llmRequestLogRetentionMs).toBe(DEFAULT_RETENTION_MS);
+    expect(body.llmRequestLogRetentionMs).toBe(86_400_000);
+  });
+
+  test("clamps a 10-year retention (e.g. 315360000000) to the default on GET", async () => {
+    const tenYearsMs = 10 * 365 * 24 * 60 * 60 * 1000;
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        memory: {
+          cleanup: {
+            llmRequestLogRetentionMs: tenYearsMs,
+          },
+        },
+      }),
+    );
+
+    const handler = createPrivacyConfigGetHandler();
+    const res = await handler(
+      new Request("http://gateway.test/v1/config/privacy"),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.llmRequestLogRetentionMs).toBe(DEFAULT_RETENTION_MS);
+  });
+
+  test("does NOT clamp the exact 365-day boundary", async () => {
+    const maxMs = 365 * 24 * 60 * 60 * 1000;
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        memory: {
+          cleanup: {
+            llmRequestLogRetentionMs: maxMs,
+          },
+        },
+      }),
+    );
+
+    const handler = createPrivacyConfigGetHandler();
+    const res = await handler(
+      new Request("http://gateway.test/v1/config/privacy"),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    // 365 days exactly is still valid — only values ABOVE the max are clamped.
+    expect(body.llmRequestLogRetentionMs).toBe(maxMs);
+  });
+});
+
+describe("PATCH /v1/config/privacy handler — Gap 2a-2 out-of-range clamp in response", () => {
+  test("PATCH with only collectUsageData against out-of-range config.json clamps retention in response", async () => {
+    const tooBig = 365 * 24 * 60 * 60 * 1000 + 1;
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        memory: {
+          cleanup: {
+            llmRequestLogRetentionMs: tooBig,
+          },
+        },
+      }),
+    );
+
+    const handler = createPrivacyConfigPatchHandler();
+    const res = await handler(makePatch({ collectUsageData: false }));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    // Even though the post-write config still has the out-of-range value
+    // (the PATCH did not touch it), the response must echo the clamped
+    // default. The gateway never serves an out-of-range value to clients.
+    expect(body.llmRequestLogRetentionMs).toBe(DEFAULT_RETENTION_MS);
+    // collectUsageData was updated, should echo.
+    expect(body.collectUsageData).toBe(false);
+
+    // Sanity: the on-disk value is untouched. We only sanitize on read;
+    // we never silently rewrite user data on a PATCH that didn't ask for it.
+    const config = readConfig();
+    const cleanup = (config.memory as Record<string, unknown>)
+      .cleanup as Record<string, unknown>;
+    expect(cleanup.llmRequestLogRetentionMs).toBe(tooBig);
+  });
+
+  test("PATCH with only sendDiagnostics against a 10-year retention clamps response", async () => {
+    const tenYearsMs = 10 * 365 * 24 * 60 * 60 * 1000;
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        memory: {
+          cleanup: {
+            llmRequestLogRetentionMs: tenYearsMs,
+          },
+        },
+      }),
+    );
+
+    const handler = createPrivacyConfigPatchHandler();
+    const res = await handler(makePatch({ sendDiagnostics: false }));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.llmRequestLogRetentionMs).toBe(DEFAULT_RETENTION_MS);
+    expect(body.sendDiagnostics).toBe(false);
+  });
+});

--- a/gateway/src/http/routes/privacy-config.ts
+++ b/gateway/src/http/routes/privacy-config.ts
@@ -28,11 +28,19 @@ const MAX_LLM_REQUEST_LOG_RETENTION_MS = 365 * 24 * 60 * 60 * 1000;
  * `llmRequestLogRetentionMs`.
  *
  * A value of 0 is valid (it means "never prune") and is returned verbatim.
+ *
+ * When `options.maxValue` is provided, any leaf value exceeding it is treated
+ * as invalid and replaced with `defaultValue`. This prevents the gateway from
+ * serving an out-of-range retention value that a manually-edited config.json
+ * might contain (e.g. someone sets a 10-year retention, the Swift client
+ * snaps it to the nearest supported option, and the next PATCH silently
+ * truncates the on-disk value with no UI warning).
  */
 function parseNestedNumber(
   config: Record<string, unknown>,
   path: readonly string[],
   defaultValue: number,
+  options?: { maxValue?: number },
 ): number {
   let current: unknown = config;
   for (const key of path) {
@@ -46,13 +54,32 @@ function parseNestedNumber(
     current = (current as Record<string, unknown>)[key];
   }
   if (
-    typeof current === "number" &&
-    Number.isInteger(current) &&
-    current >= 0
+    typeof current !== "number" ||
+    !Number.isInteger(current) ||
+    current < 0
   ) {
-    return current;
+    return defaultValue;
   }
-  return defaultValue;
+  if (options?.maxValue !== undefined && current > options.maxValue) {
+    return defaultValue;
+  }
+  return current;
+}
+
+/**
+ * Resolve a privacy-config boolean field from the post-read/post-write config,
+ * falling back to the daemon schema default when the on-disk value is missing
+ * or not a boolean. Shared by GET and PATCH so the OpenAPI contract
+ * (`collectUsageData` and `sendDiagnostics` are both `required`) is honored
+ * regardless of whether config.json has the keys set.
+ */
+function resolveBoolean(
+  config: Record<string, unknown>,
+  key: "collectUsageData" | "sendDiagnostics",
+  defaultValue: boolean,
+): boolean {
+  const raw = config[key];
+  return typeof raw === "boolean" ? raw : defaultValue;
 }
 
 export function createPrivacyConfigPatchHandler() {
@@ -184,16 +211,29 @@ export function createPrivacyConfigPatchHandler() {
           }
           writeConfigFileAtomic(config);
 
-          // Always include llmRequestLogRetentionMs in the response so GET
-          // and PATCH share the same shape. Source it from the post-write
-          // config via the same fallback logic as the GET handler.
+          // Always include all three fields in the response so GET and PATCH
+          // share the same shape and match the OpenAPI schema contract
+          // (`required: [collectUsageData, sendDiagnostics,
+          // llmRequestLogRetentionMs]`). Source each value from the
+          // post-write config via the same fallback logic as the GET handler
+          // so a fresh or manually-edited config.json that lacks any of
+          // these keys still produces a well-formed response.
           const responseData = {
-            collectUsageData: config.collectUsageData,
-            sendDiagnostics: config.sendDiagnostics,
+            collectUsageData: resolveBoolean(
+              config,
+              "collectUsageData",
+              DEFAULT_COLLECT_USAGE_DATA,
+            ),
+            sendDiagnostics: resolveBoolean(
+              config,
+              "sendDiagnostics",
+              DEFAULT_SEND_DIAGNOSTICS,
+            ),
             llmRequestLogRetentionMs: parseNestedNumber(
               config,
               ["memory", "cleanup", "llmRequestLogRetentionMs"],
               DEFAULT_LLM_REQUEST_LOG_RETENTION_MS,
+              { maxValue: MAX_LLM_REQUEST_LOG_RETENTION_MS },
             ),
           };
           log.info(responseData, "Privacy config updated");
@@ -227,26 +267,27 @@ export function createPrivacyConfigGetHandler() {
 
     const config = result.data;
 
-    const rawCollectUsageData = (config as { collectUsageData?: unknown })
-      .collectUsageData;
-    const collectUsageData =
-      typeof rawCollectUsageData === "boolean"
-        ? rawCollectUsageData
-        : DEFAULT_COLLECT_USAGE_DATA;
+    const collectUsageData = resolveBoolean(
+      config,
+      "collectUsageData",
+      DEFAULT_COLLECT_USAGE_DATA,
+    );
 
-    const rawSendDiagnostics = (config as { sendDiagnostics?: unknown })
-      .sendDiagnostics;
-    const sendDiagnostics =
-      typeof rawSendDiagnostics === "boolean"
-        ? rawSendDiagnostics
-        : DEFAULT_SEND_DIAGNOSTICS;
+    const sendDiagnostics = resolveBoolean(
+      config,
+      "sendDiagnostics",
+      DEFAULT_SEND_DIAGNOSTICS,
+    );
 
     // Extract nested memory.cleanup.llmRequestLogRetentionMs safely.
     // A value of 0 is valid (means "never prune") and is returned verbatim.
+    // Clamp out-of-range values to the default so a manually-edited
+    // config.json cannot trick clients into snapping-and-truncating.
     const llmRequestLogRetentionMs = parseNestedNumber(
       config,
       ["memory", "cleanup", "llmRequestLogRetentionMs"],
       DEFAULT_LLM_REQUEST_LOG_RETENTION_MS,
+      { maxValue: MAX_LLM_REQUEST_LOG_RETENTION_MS },
     );
 
     return Response.json({


### PR DESCRIPTION
## Summary
- PATCH response now always returns `collectUsageData` and `sendDiagnostics` with defaults if config.json is missing them, matching the OpenAPI `required` contract
- `parseNestedNumber` gains an optional `maxValue` constraint; both PATCH and GET now pass `MAX_LLM_REQUEST_LOG_RETENTION_MS` to clamp out-of-range values
- New regression tests cover both edge cases

Addresses round-2 self-review gaps from plan: log-retention-setting.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24510" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
