### PR TITLE
feat(skills-client): add fetchSkillFileContent for lazy file previews

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
@@ -45,6 +45,9 @@ final class SkillsManager {
     var selectedSkillFiles: SkillDetailFilesHTTPResponse?
     var isLoadingSkillFiles = false
     var skillFilesError: String?
+    var loadedFileContents: [String: String] = [:]
+    var loadingFilePaths: Set<String> = []
+    var fileContentErrors: [String: String] = [:]
     var installingSkillId: String?
 
     // MARK: - Filter Inputs
@@ -105,6 +108,9 @@ final class SkillsManager {
                 self.selectedSkillFiles = self.skillsStore.selectedSkillFiles
                 self.isLoadingSkillFiles = self.skillsStore.isLoadingSkillFiles
                 self.skillFilesError = self.skillsStore.skillFilesError
+                self.loadedFileContents = self.skillsStore.loadedFileContents
+                self.loadingFilePaths = self.skillsStore.loadingFilePaths
+                self.fileContentErrors = self.skillsStore.fileContentErrors
                 if let result = self.skillsStore.installResult,
                    result.slug == self.installingSkillId {
                     self.installingSkillId = nil
@@ -239,6 +245,14 @@ final class SkillsManager {
 
     func fetchSkillFiles(skillId: String) {
         skillsStore.fetchSkillFiles(skillId: skillId)
+    }
+
+    func loadSkillFileContent(skillId: String, path: String) {
+        skillsStore.loadSkillFileContent(skillId: skillId, path: path)
+    }
+
+    func clearLoadedFileContents() {
+        skillsStore.clearLoadedFileContents()
     }
 
     func clearSkillDetail() {

--- a/clients/shared/Features/Skills/SkillsStore.swift
+++ b/clients/shared/Features/Skills/SkillsStore.swift
@@ -37,6 +37,13 @@ public final class SkillsStore: ObservableObject {
     @Published public var skillDetailError: String?
     @Published public var skillFilesError: String?
 
+    /// Per-file loaded content keyed by the file's relative path within the skill.
+    @Published public var loadedFileContents: [String: String] = [:]
+    /// Paths with an in-flight content fetch.
+    @Published public var loadingFilePaths: Set<String> = []
+    /// Per-path error messages from failed content fetches.
+    @Published public var fileContentErrors: [String: String] = [:]
+
     // MARK: - Result Types
 
     public struct InstallResult: Sendable {
@@ -89,6 +96,7 @@ public final class SkillsStore: ObservableObject {
     private var createTask: Task<Void, Never>?
     private var skillDetailTask: Task<Void, Never>?
     private var skillFilesTask: Task<Void, Never>?
+    private var fileContentTasks: [String: Task<Void, Never>] = [:]
     private var draftGeneration: Int = 0
     private var createGeneration: Int = 0
     private var currentDetailSkillId: String?
@@ -318,9 +326,15 @@ public final class SkillsStore: ObservableObject {
     // MARK: - Fetch Skill Files
 
     public func fetchSkillFiles(skillId: String) {
+        // Cancel any in-flight files task and start a new one. Intentionally do
+        // not early-return when `currentFilesSkillId == skillId`: a re-fetch
+        // for the same skill replaces stale (lazy/null) file content with
+        // fresh content after an install transition, so the store must always
+        // reissue the request rather than reuse the prior response.
         skillFilesTask?.cancel()
         if currentFilesSkillId != skillId {
             selectedSkillFiles = nil
+            clearLoadedFileContents()
         }
         currentFilesSkillId = skillId
         isLoadingSkillFiles = true
@@ -339,6 +353,41 @@ public final class SkillsStore: ObservableObject {
         }
     }
 
+    // MARK: - Lazy File Content
+
+    public func loadSkillFileContent(skillId: String, path: String) {
+        // Cancel any in-flight task for the same path so a second click replaces the first.
+        fileContentTasks[path]?.cancel()
+        loadingFilePaths.insert(path)
+        fileContentErrors[path] = nil
+
+        let task = Task { [weak self] in
+            guard let self else { return }
+            let result = await self.skillsClient.fetchSkillFileContent(skillId: skillId, path: path)
+            await MainActor.run {
+                guard self.currentFilesSkillId == skillId else { return }
+                self.loadingFilePaths.remove(path)
+                if let result, let content = result.content {
+                    self.loadedFileContents[path] = content
+                } else if let result, result.content == nil, result.isBinary {
+                    // Binary file — no preview available is expected, not an error.
+                    self.loadedFileContents.removeValue(forKey: path)
+                } else {
+                    self.fileContentErrors[path] = "Failed to load file content"
+                }
+            }
+        }
+        fileContentTasks[path] = task
+    }
+
+    public func clearLoadedFileContents() {
+        for task in fileContentTasks.values { task.cancel() }
+        fileContentTasks.removeAll()
+        loadedFileContents.removeAll()
+        loadingFilePaths.removeAll()
+        fileContentErrors.removeAll()
+    }
+
     // MARK: - Clear Skill Detail
 
     public func clearSkillDetail() {
@@ -354,6 +403,7 @@ public final class SkillsStore: ObservableObject {
         isLoadingSkillFiles = false
         skillDetailError = nil
         skillFilesError = nil
+        clearLoadedFileContents()
     }
 
     // MARK: - Reset Draft State

--- a/clients/shared/Features/Skills/SkillsStore.swift
+++ b/clients/shared/Features/Skills/SkillsStore.swift
@@ -364,6 +364,7 @@ public final class SkillsStore: ObservableObject {
         let task = Task { [weak self] in
             guard let self else { return }
             let result = await self.skillsClient.fetchSkillFileContent(skillId: skillId, path: path)
+            guard !Task.isCancelled else { return }
             await MainActor.run {
                 guard self.currentFilesSkillId == skillId else { return }
                 self.loadingFilePaths.remove(path)

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -4191,6 +4191,26 @@ public struct SkillFileEntry: Codable, Sendable {
     }
 }
 
+// MARK: - Skill File Content Response (GET /v1/skills/:id/files/content)
+
+public struct SkillFileContentResponse: Codable, Sendable {
+    public let path: String
+    public let name: String
+    public let size: Int
+    public let mimeType: String
+    public let isBinary: Bool
+    public let content: String?
+
+    public init(path: String, name: String, size: Int, mimeType: String, isBinary: Bool, content: String? = nil) {
+        self.path = path
+        self.name = name
+        self.size = size
+        self.mimeType = mimeType
+        self.isBinary = isBinary
+        self.content = content
+    }
+}
+
 public struct SkillsOperationResponse: Codable, Sendable {
     public let type: String
     public let operation: String

--- a/clients/shared/Network/SkillsClient.swift
+++ b/clients/shared/Network/SkillsClient.swift
@@ -21,6 +21,7 @@ public protocol SkillsClientProtocol {
     func createSkill(skillId: String, name: String, description: String, emoji: String?, bodyMarkdown: String, overwrite: Bool?) async -> SkillOperationResult?
     func fetchSkillDetail(skillId: String) async -> SkillDetailHTTPResponse?
     func fetchSkillFiles(skillId: String) async -> SkillDetailFilesHTTPResponse?
+    func fetchSkillFileContent(skillId: String, path: String) async -> SkillFileContentResponse?
 }
 
 /// Gateway-backed implementation of ``SkillsClientProtocol``.
@@ -308,6 +309,24 @@ public struct SkillsClient: SkillsClientProtocol {
             return try JSONDecoder().decode(SkillDetailFilesHTTPResponse.self, from: response.data)
         } catch {
             log.error("fetchSkillFiles error: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    public func fetchSkillFileContent(skillId: String, path: String) async -> SkillFileContentResponse? {
+        do {
+            let response = try await GatewayHTTPClient.get(
+                path: "assistants/{assistantId}/skills/\(Self.encodePath(skillId))/files/content",
+                params: ["path": path],
+                timeout: 15
+            )
+            guard response.isSuccess else {
+                log.error("fetchSkillFileContent failed (HTTP \(response.statusCode))")
+                return nil
+            }
+            return try JSONDecoder().decode(SkillFileContentResponse.self, from: response.data)
+        } catch {
+            log.error("fetchSkillFileContent error: \(error.localizedDescription)")
             return nil
         }
     }

--- a/clients/shared/Tests/SkillsFileContentTests.swift
+++ b/clients/shared/Tests/SkillsFileContentTests.swift
@@ -40,7 +40,7 @@ private final class MockSkillsFileContentURLProtocol: URLProtocol {
 private actor MockSkillsFileContentStore {
     private var fileContentResponses: [String: SkillFileContentResponse] = [:]
     private(set) var requestedPaths: [(skillId: String, path: String)] = []
-    private var continuations: [String: CheckedContinuation<SkillFileContentResponse?, Never>] = [:]
+    private var continuations: [String: [CheckedContinuation<SkillFileContentResponse?, Never>]] = [:]
     private var blockingPaths: Set<String> = []
 
     func setResponse(for path: String, _ response: SkillFileContentResponse?) {
@@ -63,16 +63,26 @@ private actor MockSkillsFileContentStore {
         record(skillId: skillId, path: path)
         if blockingPaths.contains(path) {
             return await withCheckedContinuation { cont in
-                continuations[path] = cont
+                continuations[path, default: []].append(cont)
             }
         }
         // Default to nil when no response has been configured.
         return fileContentResponses[path]
     }
 
+    func pendingContinuationCount(for path: String) -> Int {
+        continuations[path]?.count ?? 0
+    }
+
     func unblock(path: String, with response: SkillFileContentResponse?) {
-        guard let cont = continuations.removeValue(forKey: path) else { return }
-        blockingPaths.remove(path)
+        guard var queue = continuations[path], !queue.isEmpty else { return }
+        let cont = queue.removeFirst()
+        if queue.isEmpty {
+            continuations.removeValue(forKey: path)
+            blockingPaths.remove(path)
+        } else {
+            continuations[path] = queue
+        }
         cont.resume(returning: response)
     }
 
@@ -296,6 +306,66 @@ final class SkillsFileContentStoreTests: XCTestCase {
         XCTAssertFalse(store.loadingFilePaths.contains("missing.txt"))
     }
 
+    func testLoadSkillFileContentIgnoresStaleCancelledTaskCompletion() async throws {
+        let backing = MockSkillsFileContentStore()
+        await backing.setBlocking(for: "docs/readme.md")
+        let mock = MockSkillsClient(backing: backing)
+        let store = SkillsStore(skillsClient: mock)
+
+        store.fetchSkillFiles(skillId: "my-skill")
+        try await Task.sleep(nanoseconds: 20_000_000)
+
+        // Task A: starts the first fetch and parks on the continuation.
+        store.loadSkillFileContent(skillId: "my-skill", path: "docs/readme.md")
+        try await waitUntilAsync(timeout: 1.0) {
+            await backing.pendingContinuationCount(for: "docs/readme.md") >= 1
+        }
+
+        // Task B: a second call for the same path cancels Task A and parks
+        // on its own continuation.
+        store.loadSkillFileContent(skillId: "my-skill", path: "docs/readme.md")
+        try await waitUntilAsync(timeout: 1.0) {
+            await backing.pendingContinuationCount(for: "docs/readme.md") >= 2
+        }
+
+        XCTAssertTrue(store.loadingFilePaths.contains("docs/readme.md"))
+
+        // Resume Task A with a failure-shaped response. Because Task A was
+        // cancelled, the Task.isCancelled guard in loadSkillFileContent must
+        // prevent it from mutating loadingFilePaths/fileContentErrors.
+        await backing.unblock(path: "docs/readme.md", with: nil)
+
+        // Give Task A a chance to run its (guarded) completion.
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertTrue(
+            store.loadingFilePaths.contains("docs/readme.md"),
+            "Cancelled Task A must not clear the loading flag"
+        )
+        XCTAssertNil(
+            store.fileContentErrors["docs/readme.md"],
+            "Cancelled Task A must not set a spurious error"
+        )
+
+        // Resume Task B with a success response and verify it wins.
+        let success = SkillFileContentResponse(
+            path: "docs/readme.md",
+            name: "readme.md",
+            size: 3,
+            mimeType: "text/markdown",
+            isBinary: false,
+            content: "yay"
+        )
+        await backing.unblock(path: "docs/readme.md", with: success)
+
+        try await waitUntil(timeout: 1.0) {
+            !store.loadingFilePaths.contains("docs/readme.md")
+        }
+
+        XCTAssertEqual(store.loadedFileContents["docs/readme.md"], "yay")
+        XCTAssertNil(store.fileContentErrors["docs/readme.md"])
+    }
+
     func testClearLoadedFileContentsCancelsTasksAndClearsState() async throws {
         let backing = MockSkillsFileContentStore()
         await backing.setBlocking(for: "long-path.md")
@@ -333,6 +403,18 @@ final class SkillsFileContentStoreTests: XCTestCase {
         let deadline = Date().addingTimeInterval(timeout)
         while Date() < deadline {
             if condition() { return }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        XCTFail("Condition not met within \(timeout) seconds")
+    }
+
+    private func waitUntilAsync(
+        timeout: TimeInterval,
+        _ condition: @Sendable () async -> Bool
+    ) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if await condition() { return }
             try await Task.sleep(nanoseconds: 10_000_000)
         }
         XCTFail("Condition not met within \(timeout) seconds")

--- a/clients/shared/Tests/SkillsFileContentTests.swift
+++ b/clients/shared/Tests/SkillsFileContentTests.swift
@@ -1,0 +1,340 @@
+import Foundation
+import XCTest
+
+@testable import VellumAssistantShared
+
+// MARK: - Mock URLProtocol for SkillsClient HTTP tests
+
+private final class MockSkillsFileContentURLProtocol: URLProtocol {
+    static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        guard let handler = Self.requestHandler else {
+            XCTFail("requestHandler not set")
+            return
+        }
+
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+// MARK: - Mock SkillsClient for SkillsStore tests
+
+private actor MockSkillsFileContentStore {
+    private var fileContentResponses: [String: SkillFileContentResponse] = [:]
+    private(set) var requestedPaths: [(skillId: String, path: String)] = []
+    private var continuations: [String: CheckedContinuation<SkillFileContentResponse?, Never>] = [:]
+    private var blockingPaths: Set<String> = []
+
+    func setResponse(for path: String, _ response: SkillFileContentResponse?) {
+        if let response {
+            fileContentResponses[path] = response
+        } else {
+            fileContentResponses.removeValue(forKey: path)
+        }
+    }
+
+    func setBlocking(for path: String) {
+        blockingPaths.insert(path)
+    }
+
+    func record(skillId: String, path: String) {
+        requestedPaths.append((skillId: skillId, path: path))
+    }
+
+    func awaitResponse(skillId: String, path: String) async -> SkillFileContentResponse? {
+        record(skillId: skillId, path: path)
+        if blockingPaths.contains(path) {
+            return await withCheckedContinuation { cont in
+                continuations[path] = cont
+            }
+        }
+        // Default to nil when no response has been configured.
+        return fileContentResponses[path]
+    }
+
+    func unblock(path: String, with response: SkillFileContentResponse?) {
+        guard let cont = continuations.removeValue(forKey: path) else { return }
+        blockingPaths.remove(path)
+        cont.resume(returning: response)
+    }
+
+    func requestCount() -> Int { requestedPaths.count }
+}
+
+private struct MockSkillsClient: SkillsClientProtocol {
+    let backing: MockSkillsFileContentStore
+
+    func fetchSkillsList(includeCatalog: Bool) async -> SkillsListResponseMessage? { nil }
+    func enableSkill(name: String) async -> SkillOperationResult? { nil }
+    func disableSkill(name: String) async -> SkillOperationResult? { nil }
+    func configureSkill(name: String, env: [String: String]?, apiKey: String?, config: [String: AnyCodable]?) async -> SkillOperationResult? { nil }
+    func installSkill(slug: String, version: String?) async -> SkillOperationResult? { nil }
+    func uninstallSkill(name: String) async -> SkillOperationResult? { nil }
+    func updateSkill(name: String) async -> SkillOperationResult? { nil }
+    func checkSkillUpdates() async -> SkillOperationResult? { nil }
+    func searchSkills(query: String) async -> SkillSearchResult? { nil }
+    func draftSkill(sourceText: String) async -> SkillsDraftResponseMessage? { nil }
+    func createSkill(skillId: String, name: String, description: String, emoji: String?, bodyMarkdown: String, overwrite: Bool?) async -> SkillOperationResult? { nil }
+    func fetchSkillDetail(skillId: String) async -> SkillDetailHTTPResponse? { nil }
+    func fetchSkillFiles(skillId: String) async -> SkillDetailFilesHTTPResponse? {
+        // Tests drive `currentFilesSkillId` via `fetchSkillFiles`; the response
+        // body itself is irrelevant to the loadSkillFileContent code paths.
+        nil
+    }
+
+    func fetchSkillFileContent(skillId: String, path: String) async -> SkillFileContentResponse? {
+        await backing.awaitResponse(skillId: skillId, path: path)
+    }
+}
+
+// MARK: - SkillsClient HTTP tests
+
+@MainActor
+final class SkillsFileContentClientTests: XCTestCase {
+    private let assistantId = "assistant-skill-file-content-test"
+    private let gatewayPort = 7841
+    private var originalPrimaryLockfileData: Data?
+    private var primaryLockfileExisted = false
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        MockSkillsFileContentURLProtocol.requestHandler = nil
+        URLProtocol.registerClass(MockSkillsFileContentURLProtocol.self)
+
+        let primaryLockfileURL = LockfilePaths.primary
+        primaryLockfileExisted = FileManager.default.fileExists(atPath: primaryLockfileURL.path)
+        if primaryLockfileExisted {
+            originalPrimaryLockfileData = try Data(contentsOf: primaryLockfileURL)
+        }
+
+        try installLockfileFixture()
+    }
+
+    override func tearDownWithError() throws {
+        URLProtocol.unregisterClass(MockSkillsFileContentURLProtocol.self)
+        MockSkillsFileContentURLProtocol.requestHandler = nil
+
+        if primaryLockfileExisted {
+            try originalPrimaryLockfileData?.write(to: LockfilePaths.primary, options: .atomic)
+        } else {
+            try? FileManager.default.removeItem(at: LockfilePaths.primary)
+        }
+
+        try super.tearDownWithError()
+    }
+
+    func testFetchSkillFileContentDecodesSuccessResponse() async throws {
+        let requestExpectation = expectation(description: "skill file content request")
+        var capturedRequest: URLRequest?
+
+        MockSkillsFileContentURLProtocol.requestHandler = { request in
+            capturedRequest = request
+            requestExpectation.fulfill()
+
+            let response = HTTPURLResponse(
+                url: try XCTUnwrap(request.url),
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            let data = Data(
+                #"""
+                {
+                  "path": "scripts/run.py",
+                  "name": "run.py",
+                  "size": 42,
+                  "mimeType": "text/x-python",
+                  "isBinary": false,
+                  "content": "print('hi')"
+                }
+                """#.utf8
+            )
+            return (response, data)
+        }
+
+        let client = SkillsClient()
+        let result = await client.fetchSkillFileContent(
+            skillId: "my-skill",
+            path: "scripts/run.py"
+        )
+
+        await fulfillment(of: [requestExpectation], timeout: 1.0)
+
+        let url = try XCTUnwrap(capturedRequest?.url)
+        let components = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        XCTAssertEqual(components.host, "127.0.0.1")
+        XCTAssertEqual(components.port, gatewayPort)
+        XCTAssertTrue(
+            components.path.hasPrefix(
+                "/v1/assistants/\(assistantId)/skills/my-skill/files/content"
+            ),
+            "Unexpected path: \(components.path)"
+        )
+        XCTAssertEqual(components.queryItems?.first(where: { $0.name == "path" })?.value, "scripts/run.py")
+        XCTAssertEqual(capturedRequest?.httpMethod, "GET")
+
+        XCTAssertEqual(result?.path, "scripts/run.py")
+        XCTAssertEqual(result?.name, "run.py")
+        XCTAssertEqual(result?.size, 42)
+        XCTAssertEqual(result?.mimeType, "text/x-python")
+        XCTAssertFalse(result?.isBinary ?? true)
+        XCTAssertEqual(result?.content, "print('hi')")
+    }
+
+    func testFetchSkillFileContentReturnsNilForNonSuccessStatus() async {
+        MockSkillsFileContentURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 500,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data(#"{"error":{"message":"boom"}}"#.utf8))
+        }
+
+        let client = SkillsClient()
+        let result = await client.fetchSkillFileContent(
+            skillId: "my-skill",
+            path: "scripts/run.py"
+        )
+        XCTAssertNil(result)
+    }
+
+    private func installLockfileFixture() throws {
+        let lockfile: [String: Any] = [
+            "activeAssistant": assistantId,
+            "assistants": [
+                [
+                    "assistantId": assistantId,
+                    "cloud": "local",
+                    "hatchedAt": "2026-03-19T12:00:00Z",
+                    "resources": [
+                        "gatewayPort": gatewayPort,
+                    ],
+                ],
+            ],
+        ]
+        let data = try JSONSerialization.data(withJSONObject: lockfile, options: [.sortedKeys])
+        try data.write(to: LockfilePaths.primary, options: .atomic)
+    }
+}
+
+// MARK: - SkillsStore tests
+
+@MainActor
+final class SkillsFileContentStoreTests: XCTestCase {
+
+    func testLoadSkillFileContentTracksLoadingThenPopulatesContent() async throws {
+        let backing = MockSkillsFileContentStore()
+        await backing.setBlocking(for: "docs/intro.md")
+        let mock = MockSkillsClient(backing: backing)
+        let store = SkillsStore(skillsClient: mock)
+
+        // Seed currentFilesSkillId via a fetchSkillFiles call so loadSkillFileContent
+        // can satisfy its "same skillId" guard when storing the result.
+        store.fetchSkillFiles(skillId: "my-skill")
+        try await Task.sleep(nanoseconds: 20_000_000)
+
+        store.loadSkillFileContent(skillId: "my-skill", path: "docs/intro.md")
+        XCTAssertTrue(store.loadingFilePaths.contains("docs/intro.md"))
+        XCTAssertNil(store.loadedFileContents["docs/intro.md"])
+
+        let response = SkillFileContentResponse(
+            path: "docs/intro.md",
+            name: "intro.md",
+            size: 5,
+            mimeType: "text/markdown",
+            isBinary: false,
+            content: "hello"
+        )
+        await backing.unblock(path: "docs/intro.md", with: response)
+
+        // Yield to let the Task finish its MainActor.run block.
+        try await waitUntil(timeout: 1.0) {
+            !store.loadingFilePaths.contains("docs/intro.md")
+        }
+
+        XCTAssertEqual(store.loadedFileContents["docs/intro.md"], "hello")
+        XCTAssertNil(store.fileContentErrors["docs/intro.md"])
+    }
+
+    func testLoadSkillFileContentSetsErrorOnFailure() async throws {
+        let backing = MockSkillsFileContentStore()
+        await backing.setResponse(for: "missing.txt", nil)
+        let mock = MockSkillsClient(backing: backing)
+        let store = SkillsStore(skillsClient: mock)
+
+        store.fetchSkillFiles(skillId: "my-skill")
+        try await Task.sleep(nanoseconds: 20_000_000)
+
+        store.loadSkillFileContent(skillId: "my-skill", path: "missing.txt")
+
+        try await waitUntil(timeout: 1.0) {
+            store.fileContentErrors["missing.txt"] != nil
+        }
+
+        XCTAssertEqual(store.fileContentErrors["missing.txt"], "Failed to load file content")
+        XCTAssertNil(store.loadedFileContents["missing.txt"])
+        XCTAssertFalse(store.loadingFilePaths.contains("missing.txt"))
+    }
+
+    func testClearLoadedFileContentsCancelsTasksAndClearsState() async throws {
+        let backing = MockSkillsFileContentStore()
+        await backing.setBlocking(for: "long-path.md")
+        let mock = MockSkillsClient(backing: backing)
+        let store = SkillsStore(skillsClient: mock)
+
+        store.fetchSkillFiles(skillId: "my-skill")
+        try await Task.sleep(nanoseconds: 20_000_000)
+
+        store.loadSkillFileContent(skillId: "my-skill", path: "long-path.md")
+        XCTAssertTrue(store.loadingFilePaths.contains("long-path.md"))
+
+        // Prime loadedFileContents and fileContentErrors directly so we can verify
+        // that clearLoadedFileContents wipes all three dictionaries.
+        store.loadedFileContents["existing.md"] = "cached"
+        store.fileContentErrors["broken.md"] = "oops"
+
+        store.clearLoadedFileContents()
+
+        XCTAssertTrue(store.loadedFileContents.isEmpty)
+        XCTAssertTrue(store.loadingFilePaths.isEmpty)
+        XCTAssertTrue(store.fileContentErrors.isEmpty)
+
+        // Unblock the (now-cancelled) request so the actor isn't left waiting —
+        // even if the task already observed cancellation, this is a no-op.
+        await backing.unblock(path: "long-path.md", with: nil)
+    }
+
+    // MARK: - Helpers
+
+    private func waitUntil(
+        timeout: TimeInterval,
+        _ condition: @MainActor () -> Bool
+    ) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if condition() { return }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        XCTFail("Condition not met within \(timeout) seconds")
+    }
+}


### PR DESCRIPTION
## Summary
- Add `SkillsClient.fetchSkillFileContent(skillId:path:)` that calls the new `GET /v1/skills/:id/files/content` daemon endpoint and decodes `SkillFileContentResponse`.
- Plumb `loadSkillFileContent`, `clearLoadedFileContents`, and the `loadedFileContents` / `loadingFilePaths` / `fileContentErrors` state through `SkillsStore` and `SkillsManager` so the UI can drive lazy per-file fetches.
- No UI wiring yet — `SkillDetailView` and `AgentPanel` are untouched.

Part of plan: skill-files-preview.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24511" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
