### PR TITLE
fix(browser-relay): dispatcher overlap-retry race + bounded cancel growth

### DIFF
--- a/clients/chrome-extension/background/__tests__/host-browser-dispatcher.test.ts
+++ b/clients/chrome-extension/background/__tests__/host-browser-dispatcher.test.ts
@@ -843,6 +843,96 @@ describe('createHostBrowserDispatcher', () => {
       expect(harness.results[0].isError).toBe(false);
     });
 
+    test('overlap-retry: cancelled call A cannot suppress call B retrying the same requestId', async () => {
+      // Regression: there is a race where a cancelled-but-still-
+      // suspended call A can leak its cancel marker onto an overlapping
+      // retry (call B) for the same requestId. The ordering is:
+      //
+      //   1. handle("req-1") — call A, suspends inside proxy.send at gate_A
+      //   2. cancel("req-1") — marks req-1 cancelled, aborts A's
+      //      controller, removes A from inFlight (A is still suspended)
+      //   3. handle("req-1") — call B, retry arrives before A unwinds
+      //   4. B's proxy.send resolves first (gate_B released) — B must
+      //      deliver its legitimate result
+      //   5. A's proxy.send resolves later (gate_A released) — A must
+      //      still be suppressed (it was cancelled)
+      //
+      // Before the fix, A's cancel marker lived in `cancelledRequestIds`
+      // past the start of call B, so B's happy path would see the stale
+      // marker and silently drop the result. The fix:
+      //   (a) clears any stale marker at the top of handle(), so B's
+      //       post-send check sees a clean state
+      //   (b) uses the per-invocation AbortController signal to
+      //       authoritatively suppress call A without relying on a
+      //       shared-by-id flag that B would stomp on
+      harness = createHarness();
+
+      // Per-invocation send gates, one for call A and one for call B.
+      // The dispatcher's proxy.send override shifts the next gate off
+      // the FIFO queue each time it fires, so call A awaits gateA
+      // (index 0) and call B awaits gateB (index 1).
+      type SendFrame = { id: number; result: unknown };
+      let resolveGateA: (frame: SendFrame) => void = () => {};
+      let resolveGateB: (frame: SendFrame) => void = () => {};
+      const gateA = new Promise<SendFrame>((resolve) => {
+        resolveGateA = resolve;
+      });
+      const gateB = new Promise<SendFrame>((resolve) => {
+        resolveGateB = resolve;
+      });
+      const gates: Array<Promise<SendFrame>> = [gateA, gateB];
+
+      const proxy = harness.proxy;
+      proxy.send = async (target, frame) => {
+        proxy.sendCalls.push({ target, frame });
+        const gate = gates.shift();
+        if (!gate) {
+          throw new Error('unexpected additional proxy.send call');
+        }
+        const result = await gate;
+        return { ...result, id: frame.id };
+      };
+
+      // Start call A and wait for it to suspend inside proxy.send.
+      const callA = harness.dispatcher.handle(sampleRequest);
+      await waitFor(() => proxy.sendCalls.length === 1);
+
+      // Cancel call A. At this point A is still suspended at gateA.
+      harness.dispatcher.cancel({
+        type: 'host_browser_cancel',
+        requestId: 'req-1',
+      });
+
+      // Start call B with the SAME requestId. B is a retry that
+      // arrives before A has unwound through its finally block — the
+      // exact overlap the race test exercises.
+      const callB = harness.dispatcher.handle(sampleRequest);
+      await waitFor(() => proxy.sendCalls.length === 2);
+
+      // Resolve call B's proxy.send FIRST with a legitimate success
+      // frame. B must deliver this result via postResult.
+      resolveGateB({ id: 0, result: { fromRetry: true } });
+      await callB;
+
+      expect(harness.results.length).toBe(1);
+      expect(harness.results[0].requestId).toBe('req-1');
+      expect(harness.results[0].isError).toBe(false);
+      expect(harness.results[0].content).toBe(
+        JSON.stringify({ fromRetry: true }),
+      );
+
+      // Now release call A's gate. A's happy path must notice its own
+      // AbortController is aborted and drop the result on the floor —
+      // i.e. we should still only have B's single result in the log.
+      resolveGateA({ id: 0, result: { fromCancelledA: true } });
+      await callA;
+
+      expect(harness.results.length).toBe(1);
+      expect(harness.results[0].content).toBe(
+        JSON.stringify({ fromRetry: true }),
+      );
+    });
+
     test('aborts the in-flight controller and removes it from the inFlight map', async () => {
       // Sanity check on the cancel path's bookkeeping: after cancel()
       // returns, the in-flight map no longer holds the cancelled entry,

--- a/clients/chrome-extension/background/host-browser-dispatcher.ts
+++ b/clients/chrome-extension/background/host-browser-dispatcher.ts
@@ -272,13 +272,25 @@ export function createHostBrowserDispatcher(
 
   async function handle(envelope: HostBrowserRequestEnvelope): Promise<void> {
     const { requestId } = envelope;
-    // Re-entrant delivery of the same request id (e.g. a duplicate frame
-    // across a relay reconnect after a previous handle() was cancelled)
-    // is naturally safe without a stale-marker delete here: `cancel()`
-    // only records cancellations for requests currently in `inFlight`,
-    // and the finally block below prunes the entry before the handler
-    // returns, so by the time a retry reaches this point no leftover
-    // marker can exist for this requestId.
+    // Clear any stale cancel marker from a prior invocation of this
+    // same requestId before we start processing. This matters for the
+    // overlap-retry race: if a previous handle() for `requestId` was
+    // cancelled while suspended at an await inside proxy.send(), its
+    // finally block has not yet pruned the marker from
+    // `cancelledRequestIds`. A fresh handle() for the same id (e.g. a
+    // retry frame replayed across a relay reconnect) must not inherit
+    // that stale marker — otherwise call B's legitimate result would
+    // be suppressed at the postResult site by call A's leftover flag.
+    //
+    // This delete is safe to pair with the in-flight-only guard in
+    // `cancel()`: together they still bound `cancelledRequestIds` by
+    // the current in-flight count. cancel() only adds markers for
+    // requests present in `inFlight`, so non-in-flight cancels remain
+    // no-ops that cannot grow the set. The delete here strictly
+    // reduces the set size (or is a no-op if no stale entry exists),
+    // and the finally block below still prunes our own entry on unwind
+    // to cover the non-overlapping case.
+    cancelledRequestIds.delete(requestId);
     const abort = new AbortController();
     inFlight.set(requestId, abort);
     try {
@@ -335,13 +347,24 @@ export function createHostBrowserDispatcher(
           attachedTargets.delete(key);
         }
       }
-      // Deterministic-cancel guarantee: if the request was cancelled
-      // while we were awaiting the CDP round-trip, drop the late result
-      // on the floor. The daemon has already resolved its pending entry
-      // with `"Aborted"` (see host-browser-proxy.ts), so delivering a
-      // frame here would be a ghost completion against an entry that
-      // no longer exists.
-      if (cancelledRequestIds.has(requestId)) return;
+      // Deterministic-cancel guarantee: if this specific invocation
+      // was cancelled while we were awaiting the CDP round-trip, drop
+      // the late result on the floor. The daemon has already resolved
+      // its pending entry with `"Aborted"` (see host-browser-proxy.ts),
+      // so delivering a frame here would be a ghost completion against
+      // an entry that no longer exists.
+      //
+      // We check this invocation's own `abort.signal.aborted` first so
+      // that an overlapping retry (call B starting while call A is
+      // still suspended at a later await) does not have call A's
+      // suppression leak into call B's result — each call has its own
+      // AbortController captured in closure, so the per-call signal is
+      // the authoritative "was this specific invocation cancelled?"
+      // check. The `cancelledRequestIds.has(...)` fallback still matters
+      // for the case where no retry has arrived yet: the set is the
+      // mechanism that survives the cancel-to-finally window while the
+      // handler unwinds.
+      if (abort.signal.aborted || cancelledRequestIds.has(requestId)) return;
       await deps.postResult({
         requestId,
         content: JSON.stringify(frame.error ?? frame.result ?? {}),
@@ -352,7 +375,7 @@ export function createHostBrowserDispatcher(
       // cancelled mid-flight must not deliver its failure envelope to
       // the daemon either. The daemon proxy has already resolved its
       // pending entry, so any late postResult would be a ghost completion.
-      if (cancelledRequestIds.has(requestId)) return;
+      if (abort.signal.aborted || cancelledRequestIds.has(requestId)) return;
       // Guard the failure-path postResult in its own try/catch: if the HTTP
       // POST itself fails (e.g. the relay socket is torn down while we're
       // in the error path) we must NOT let that secondary rejection escape
@@ -400,15 +423,20 @@ export function createHostBrowserDispatcher(
     // difference from the caller's point of view.
     const ctl = inFlight.get(requestId);
     if (!ctl) return;
-    // Record the cancellation BEFORE aborting so that any listener on
-    // the abort signal that races to post a result sees the cancelled
-    // flag first. The suppression check in `handle()` reads from this
-    // set, not from the abort signal, specifically to close the race
-    // between "cancel arrives after proxy.send resolves" and "handle()
-    // reaches its postResult call". Marking here also makes cancel()
-    // idempotent within the in-flight window: a repeat cancel for the
-    // same id is a no-op because the set already contains the entry and
-    // the controller has already been removed from `inFlight`.
+    // Record the cancellation in both the per-id set and the per-call
+    // abort signal. The handle() suppression check reads from
+    // `abort.signal.aborted` first (per-invocation, survives overlap
+    // retries) and falls back to `cancelledRequestIds.has(...)`
+    // (per-id, survives the cancel-to-finally window). Updating both
+    // here keeps the two paths in sync: the per-id set is what a
+    // suspended handler sees while its finally block hasn't yet run,
+    // and the per-call signal is what an overlapping retry for the
+    // same id uses to tell "am I the cancelled invocation?" apart
+    // from "has some invocation of this id been cancelled?".
+    //
+    // Marking here also makes cancel() idempotent within the
+    // in-flight window: a repeat cancel for the same id is a no-op
+    // because the controller has already been removed from `inFlight`.
     cancelledRequestIds.add(requestId);
     try {
       ctl.abort();


### PR DESCRIPTION
## Summary
Restores the delete-on-entry behavior in the dispatcher's handle() that round 1 accidentally removed, fixing a race where an overlapping retry for a cancelled-but-still-suspended request could have its legitimate result suppressed by the stale cancel marker.

- cancel() keeps the round 1 in-flight-only guard (bounded set size)
- handle() restores delete-on-entry to clear any stale marker before processing a re-entrant invocation
- Adds a regression test exercising the overlap-retry race directly

Part of plan: browser-use-main-remediation-plan-2026-04-08.md (review round 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24515" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
