### PR TITLE
docs(browser-relay): remove history-narrating comments per CLAUDE.md

### DIFF
--- a/assistant/src/__tests__/host-browser-e2e-self-hosted-capability.test.ts
+++ b/assistant/src/__tests__/host-browser-e2e-self-hosted-capability.test.ts
@@ -196,12 +196,9 @@ describe("host_browser self-hosted capability-token e2e round-trip", () => {
 
   test("capability token round-trips Browser.getVersion over HTTP POST fallback", async () => {
     // HTTP result transport: the extension POSTs results back to
-    // `/v1/host-browser-result` with the same capability token as the
-    // WS handshake. This exercises the fix added on top of the PR3
-    // cutover — before the fix the POST route's JWT-only auth
-    // middleware 401'd every capability-token-bearing request and
-    // silently dropped the CDP result whenever the relay WS was
-    // unavailable. The test must prove the HTTP fallback actually
+    // `/v1/host-browser-result` with the same capability token used
+    // for the WS handshake. This exercises the capability-token-aware
+    // auth on the POST route and proves the HTTP fallback path
     // resolves the pending interaction end-to-end.
     const guardianId = `self-hosted-guardian-${crypto.randomUUID()}`;
     const { token } = mintHostBrowserCapability(guardianId);

--- a/clients/chrome-extension/background/__tests__/host-browser-dispatcher.test.ts
+++ b/clients/chrome-extension/background/__tests__/host-browser-dispatcher.test.ts
@@ -1093,9 +1093,9 @@ describe('createHostBrowserDispatcher', () => {
 
     test('still clears the local attach cache when forwarding fails', async () => {
       // Wire a forwarder that throws to assert that local cache
-      // eviction (the legacy onDetach behaviour) is unaffected by a
-      // broken runtime forwarder. The forward and the local
-      // bookkeeping must be independent.
+      // eviction on onDetach is unaffected by a broken runtime
+      // forwarder. The forward and the local bookkeeping must be
+      // independent.
       harness = createHarness({ sendResult: { id: 1, result: {} } });
       harness.forwardSessionInvalidatedImpl = () => {
         throw new Error('forwarder exploded');

--- a/clients/chrome-extension/background/__tests__/self-hosted-auth.test.ts
+++ b/clients/chrome-extension/background/__tests__/self-hosted-auth.test.ts
@@ -248,10 +248,10 @@ describe('bootstrapLocalToken', () => {
   });
 
   test('omits assistantPort when the helper frame is missing it', async () => {
-    // Older native helpers pre-dating PR 3 don't emit the
-    // assistantPort field. Those frames must still produce a valid
-    // StoredLocalToken — the worker will fall back to the stored
-    // `relayPort` / default value when assistantPort is undefined.
+    // Native helpers that omit the optional assistantPort field must
+    // still produce a valid StoredLocalToken — the worker will fall
+    // back to the stored `relayPort` / default value when
+    // assistantPort is undefined.
     const expiresAtIso = new Date(Date.now() + 60_000).toISOString();
 
     fakeRuntime.onConnect = (port) => {

--- a/clients/chrome-extension/background/relay-connection.ts
+++ b/clients/chrome-extension/background/relay-connection.ts
@@ -1,11 +1,11 @@
 /**
  * Relay WebSocket connection helper.
  *
- * Extracted from worker.ts so we can share the open/close/reconnect
- * lifecycle between the two relay transports:
+ * Shares the open/close/reconnect lifecycle between the two relay
+ * transports:
  *
  *   - `self-hosted` — ws://127.0.0.1:<port>/v1/browser-relay, token minted
- *     by the local daemon (legacy path; default for back-compat).
+ *     by the local daemon.
  *   - `cloud`       — wss://<cloud-gateway>/v1/browser-relay, token from
  *     the cloud OAuth flow (see cloud-auth.ts).
  *
@@ -17,9 +17,9 @@
  * This module also exports {@link postHostBrowserResult}, the relay-aware
  * helper used by the host-browser dispatcher to ship CDP result envelopes
  * back to the daemon. In self-hosted mode the result is POSTed to the
- * local `/v1/host-browser-result` HTTP endpoint; in cloud mode it would
- * round-trip back through the gateway WebSocket — see the function
- * docstring for the current Phase 2 behaviour.
+ * local `/v1/host-browser-result` HTTP endpoint; in cloud mode it
+ * round-trips back through the gateway WebSocket — see the function
+ * docstring for the full behaviour.
  */
 
 import type {
@@ -28,7 +28,7 @@ import type {
   HostBrowserSessionInvalidatedEnvelope,
 } from './host-browser-dispatcher.js';
 
-/** Reconnect backoff bounds mirror the legacy inline worker.ts values. */
+/** Reconnect backoff bounds for transient relay disconnects. */
 const RECONNECT_BASE_MS = 1_000;
 const RECONNECT_MAX_MS = 30_000;
 
@@ -114,16 +114,15 @@ export interface RelayConnectionDeps {
    * an unexpected close. Callers use this to refresh stale tokens before
    * the next `start()` attempt.
    *
-   * The legacy shape (`Promise<string | null | void>`) is preserved for
-   * backwards compatibility:
+   * Two return shapes are accepted:
    *
-   *   - `string` → treated as `{ kind: 'refreshed', token: <string> }`.
-   *   - `null` / `undefined` → treated as `{ kind: 'keep' }`.
-   *
-   * New callers should return a {@link RelayReconnectDecision} so they
-   * can abort the reconnect loop entirely when refresh is impossible
-   * (e.g. the cloud OAuth flow can no longer renew non-interactively
-   * and the user must sign in again).
+   *   - A plain `Promise<string | null | void>`, where:
+   *     - `string` is treated as `{ kind: 'refreshed', token: <string> }`.
+   *     - `null` / `undefined` is treated as `{ kind: 'keep' }`.
+   *   - A {@link RelayReconnectDecision}, which additionally lets the
+   *     hook abort the reconnect loop entirely when refresh is
+   *     impossible (e.g. the cloud OAuth flow can no longer renew
+   *     non-interactively and the user must sign in again).
    *
    * The {@link RelayReconnectContext} argument carries the close code
    * / reason so handlers can distinguish auth-failure closes from
@@ -427,11 +426,11 @@ export class RelayConnection {
 
 /**
  * Coerce the flexible `onReconnect` return shape into a canonical
- * {@link RelayReconnectDecision}. The legacy shape supported a plain
- * `string` (treated as a fresh token) or `null`/`undefined` (treated as
- * "keep the existing token"). New callers return a
- * {@link RelayReconnectDecision} directly and get access to the
- * `{ kind: 'abort' }` branch that stops the reconnect loop.
+ * {@link RelayReconnectDecision}. A plain `string` is treated as a
+ * fresh token; `null`/`undefined` is treated as "keep the existing
+ * token"; a {@link RelayReconnectDecision} is returned as-is and gives
+ * the caller access to the `{ kind: 'abort' }` branch that stops the
+ * reconnect loop.
  */
 function normaliseReconnectResult(
   result: string | null | void | RelayReconnectDecision,

--- a/clients/chrome-extension/background/worker.ts
+++ b/clients/chrome-extension/background/worker.ts
@@ -214,8 +214,9 @@ async function dispatchHostBrowserResult(
 
   // Self-hosted fallback: POST directly to the local daemon using live
   // creds. Prefer the capability token from the native-messaging pair
-  // flow (PR 3 cutover); fall back to the legacy bearer token for
-  // compatibility.
+  // flow; fall back to the bearer token stored under the gateway
+  // `/v1/browser-relay/token` path for installs that haven't been
+  // paired via native messaging yet.
   const local = await getStoredLocalToken();
   if (local) {
     const fallbackPort = local.assistantPort ?? (await getRelayPort());
@@ -331,16 +332,14 @@ async function buildRelayModeConfig(kind: RelayModeKind): Promise<RelayMode> {
   }
 
   // Self-hosted: prefer the capability token the native-messaging pair
-  // flow persisted (see self-hosted-auth.ts and PR 3 of the
-  // browser-remediation plan). The stored token already carries the
-  // assistant runtime port the helper used when it pair-bootstrapped,
-  // so we target the runtime directly without going through the
-  // legacy gateway `/v1/browser-relay/token` fallback.
+  // flow persisted (see self-hosted-auth.ts). The stored token already
+  // carries the assistant runtime port the helper used when it
+  // pair-bootstrapped, so we target the runtime directly.
   //
   // Compatibility branch: if there is no stored capability token yet
-  // (e.g. a chrome profile that hasn't re-paired after the cutover)
-  // we fall back to the legacy `bearerToken` / `relayPort` storage
-  // keys so existing installs keep working until the user re-pairs.
+  // (e.g. a chrome profile that hasn't been paired via native
+  // messaging) we fall back to the `bearerToken` / `relayPort` storage
+  // keys so installs without a paired helper keep working.
   const local = await getStoredLocalToken();
   if (local) {
     const port = local.assistantPort ?? (await getRelayPort());
@@ -544,13 +543,14 @@ function createRelayConnection(
       // code. If refresh is impossible we abort the reconnect loop
       // and surface the error to the popup — see cloudReconnectHook.
       //
-      // Self-hosted mode keeps the legacy refresh ladder:
+      // Self-hosted mode uses a two-step refresh ladder:
       //  1. Re-read the stored capability token from
       //     `self-hosted-auth.ts`. The token may have been rotated by
       //     a re-pair in another tab, or it may simply still be valid
       //     and the drop was a transient server bounce.
-      //  2. Fall back to the legacy gateway `/v1/browser-relay/token`
-      //     refresh for installs that haven't migrated yet.
+      //  2. Fall back to the gateway `/v1/browser-relay/token`
+      //     refresh for installs without a paired native-messaging
+      //     helper.
       //
       // Pull the live mode through getCurrentMode so a setMode() that
       // flipped us to cloud mid-reconnect still routes through the
@@ -763,9 +763,9 @@ async function bootstrap(): Promise<void> {
   shouldConnect = true;
   if (relayMode === 'self-hosted') {
     // Only mint a fresh gateway JWT if the capability-token path isn't
-    // usable yet. The capability token is the default post-cutover —
-    // the legacy refresh is only needed for installs that haven't been
-    // re-paired since the PR 3 transport change.
+    // usable yet. The capability token is the default auth for
+    // self-hosted installs with a paired native-messaging helper; the
+    // gateway refresh is only needed for installs without one.
     const local = await getStoredLocalToken();
     if (!local) {
       await refreshToken();


### PR DESCRIPTION
## Summary
Rewrites a test comment in host-browser-e2e-self-hosted-capability.test.ts that narrated PR history ('the fix', 'PR3 cutover', 'before the fix') to describe current state only, per the assistant/CLAUDE.md comment convention.

Also sweeps worker.ts, relay-connection.ts, host-browser-dispatcher.test.ts, and self-hosted-auth.test.ts for the same pattern (references to 'PR 3', 'cutover', 'legacy path for back-compat', 'older helpers pre-dating PR 3', etc.) and rewrites each to describe the current branching behavior without narrating history.

Part of plan: browser-use-main-remediation-plan-2026-04-08.md (review round 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24516" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
