### PR TITLE
fix(macos,gateway): defensive hardening for retention picker race and GET schema cap

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift
@@ -206,6 +206,13 @@ struct SettingsPrivacyTab: View {
                     llmRequestLogRetentionMs: option.rawValue
                 )
             } catch {
+                // If this task was cancelled (e.g. by a newer user-initiated
+                // syncRetention call), bail out without touching
+                // `hasUserInteracted` — the newer task owns that state and
+                // clearing it here would race with its in-flight PATCH.
+                // Matches the `guard !Task.isCancelled else { return }`
+                // pattern used in `loadPrivacyConfig()` above.
+                guard !Task.isCancelled else { return }
                 // PATCH failed — daemon still has the old value. Clear the
                 // user-interacted flag so the next loadPrivacyConfig() can
                 // reconcile the picker from the authoritative server state
@@ -216,9 +223,7 @@ struct SettingsPrivacyTab: View {
                 privacyTabLog.error(
                     "syncRetention PATCH failed: \(error.localizedDescription, privacy: .public)"
                 )
-                await MainActor.run {
-                    hasUserInteracted = false
-                }
+                hasUserInteracted = false
             }
         }
     }

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -2290,8 +2290,9 @@ export function buildSchema(): Record<string, unknown> {
                       llmRequestLogRetentionMs: {
                         type: "integer",
                         minimum: 0,
+                        maximum: 31536000000,
                         description:
-                          "Retention period for LLM request/response logs in milliseconds. 0 disables pruning.",
+                          "Retention period for LLM request/response logs in milliseconds. 0 disables pruning. Maximum is 365 days (31536000000 ms); server-side clamping enforces this cap on reads.",
                       },
                     },
                     required: [
@@ -2473,8 +2474,9 @@ export function buildSchema(): Record<string, unknown> {
                       llmRequestLogRetentionMs: {
                         type: "integer",
                         minimum: 0,
+                        maximum: 31536000000,
                         description:
-                          "Retention period for LLM request/response logs in milliseconds. 0 disables pruning.",
+                          "Retention period for LLM request/response logs in milliseconds. 0 disables pruning. Maximum is 365 days (31536000000 ms); server-side clamping enforces this cap on reads.",
                       },
                     },
                     required: [


### PR DESCRIPTION
## Summary
- **macOS**: `syncRetention` catch block now guards on `Task.isCancelled` and drops a redundant `MainActor.run` hop. Matches the convention used elsewhere in the same file.
- **Gateway**: Both GET response schemas for the privacy config endpoints now declare `maximum: 31536000000` on `llmRequestLogRetentionMs`, reflecting the server-side clamp.

Addresses round-3 self-review findings from plan: log-retention-setting.md. Both were non-blocking observations (defensive hardening + cosmetic schema drift) but are low-cost to fix for consistency.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24517" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
