### PR TITLE
fix(browser-relay): cloud abort cap ordering + onClose exactly-once on race

### DIFF
--- a/clients/chrome-extension/background/__tests__/cloud-reconnect-decision.test.ts
+++ b/clients/chrome-extension/background/__tests__/cloud-reconnect-decision.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Unit tests for the cloud reconnect decision helper.
+ *
+ * Exercises {@link decideCloudReconnectAction} directly so the ordering
+ * between the `keep`, `refresh`, and `abort` branches is pinned by a
+ * fast, pure test that doesn't drag in the service worker surface.
+ *
+ * The round-2 review gap this file covers:
+ *   - Gap 1: once `attempts` reaches `CLOUD_REFRESH_ATTEMPT_CAP`, a
+ *     subsequent 1006 close MUST produce `{ kind: 'abort' }` even if
+ *     `stored?.token` is still present and not stale. Before the fix
+ *     the helper's "keep" early-return ran ahead of the abort check,
+ *     so a chain of successful refreshes followed by repeated 1006
+ *     closes would silently reconnect forever with the rejected
+ *     token once the cap was reached.
+ */
+
+import { describe, test, expect } from 'bun:test';
+
+import {
+  decideCloudReconnectAction,
+  CLOUD_REFRESH_ATTEMPT_CAP,
+  WS_CLOSE_CODE_ABNORMAL,
+} from '../cloud-reconnect-decision.js';
+import type { StoredCloudToken } from '../cloud-auth.js';
+
+function freshStoredToken(
+  overrides: Partial<StoredCloudToken> = {},
+): StoredCloudToken {
+  return {
+    token: 'jwt-abc',
+    expiresAt: Date.now() + 10 * 60 * 1000, // 10 minutes out
+    guardianId: 'gdn_1',
+    ...overrides,
+  };
+}
+
+describe('decideCloudReconnectAction', () => {
+  test('1006 with fresh token below cap → refresh', () => {
+    const action = decideCloudReconnectAction({
+      ctx: { code: WS_CLOSE_CODE_ABNORMAL, reason: 'abnormal' },
+      stored: freshStoredToken(),
+      attempts: 0,
+    });
+    expect(action.kind).toBe('refresh');
+  });
+
+  test('auth-failure close (4001) → refresh regardless of attempts', () => {
+    const action = decideCloudReconnectAction({
+      ctx: { code: 4001, reason: 'token rotated' },
+      stored: freshStoredToken(),
+      attempts: 0,
+    });
+    expect(action.kind).toBe('refresh');
+  });
+
+  test('non-1006 clean close with fresh token → keep', () => {
+    // Code 1011 is an "internal error" — not a known auth-failure
+    // code and not 1006. The decision helper should preserve the
+    // existing token and let the relay helper retry.
+    const action = decideCloudReconnectAction({
+      ctx: { code: 1011, reason: 'internal error' },
+      stored: freshStoredToken(),
+      attempts: 0,
+    });
+    expect(action.kind).toBe('keep');
+  });
+
+  test('stale stored token → refresh', () => {
+    const action = decideCloudReconnectAction({
+      ctx: { code: 1011, reason: 'internal error' },
+      stored: freshStoredToken({ expiresAt: Date.now() + 1_000 }),
+      attempts: 0,
+    });
+    expect(action.kind).toBe('refresh');
+  });
+
+  test('missing stored token with abnormal close → refresh', () => {
+    const action = decideCloudReconnectAction({
+      ctx: { code: WS_CLOSE_CODE_ABNORMAL, reason: 'abnormal' },
+      stored: null,
+      attempts: 0,
+    });
+    expect(action.kind).toBe('refresh');
+  });
+
+  test('1006 with attempts == cap-1 still refreshes', () => {
+    // Within budget. The caller is expected to bump `attempts` after
+    // taking the refresh action.
+    const action = decideCloudReconnectAction({
+      ctx: { code: WS_CLOSE_CODE_ABNORMAL, reason: 'abnormal' },
+      stored: freshStoredToken(),
+      attempts: CLOUD_REFRESH_ATTEMPT_CAP - 1,
+    });
+    expect(action.kind).toBe('refresh');
+  });
+
+  test('Gap 1: 1006 with attempts == cap and fresh stored token → abort', () => {
+    // This is the exact scenario from the round-2 review. The hook
+    // previously returned { kind: 'keep' } here because
+    // abnormalNeedsRefresh went false, needsRefresh went false, and
+    // the stored token (from a prior successful refresh) was still
+    // present and not stale — so the "keep" early-return fired
+    // before the abort check. The fix folds the budget-exhausted
+    // case into an explicit short-circuit ahead of the keep branch.
+    const action = decideCloudReconnectAction({
+      ctx: { code: WS_CLOSE_CODE_ABNORMAL, reason: 'abnormal' },
+      stored: freshStoredToken(),
+      attempts: CLOUD_REFRESH_ATTEMPT_CAP,
+    });
+    expect(action.kind).toBe('abort');
+    if (action.kind === 'abort') {
+      expect(action.error).toContain('Cloud relay kept closing');
+      expect(action.error).toContain(
+        `after ${CLOUD_REFRESH_ATTEMPT_CAP} token refresh attempts`,
+      );
+      expect(action.error).toContain('sign in');
+    }
+  });
+
+  test('Gap 1 (4th 1006 simulation): cap-exhausted aborts even after three successful refreshes', () => {
+    // Simulates the exact sequence from the bug report:
+    //   1. First 1006 → refresh (attempts 0 → 1)
+    //   2. Second 1006 → refresh (attempts 1 → 2)
+    //   3. Third 1006 → refresh (attempts 2 → 3, now at cap)
+    //   4. Fourth 1006 → MUST abort
+    //
+    // The stored token value is unimportant — what matters is that
+    // it is present and not stale (as it would be after a successful
+    // refresh), because the bug's trigger was "keep" firing ahead of
+    // "abort" specifically when the token looked usable.
+    let attempts = 0;
+    const stored = freshStoredToken();
+    const ctx = { code: WS_CLOSE_CODE_ABNORMAL, reason: 'abnormal' };
+
+    // First three 1006 closes refresh.
+    for (let i = 0; i < CLOUD_REFRESH_ATTEMPT_CAP; i++) {
+      const action = decideCloudReconnectAction({ ctx, stored, attempts });
+      expect(action.kind).toBe('refresh');
+      attempts += 1;
+    }
+
+    // Fourth 1006 close is over budget — must abort.
+    const fourth = decideCloudReconnectAction({ ctx, stored, attempts });
+    expect(fourth.kind).toBe('abort');
+  });
+
+  test('1006 with attempts exceeding cap → still aborts', () => {
+    const action = decideCloudReconnectAction({
+      ctx: { code: WS_CLOSE_CODE_ABNORMAL, reason: 'abnormal' },
+      stored: freshStoredToken(),
+      attempts: CLOUD_REFRESH_ATTEMPT_CAP + 5,
+    });
+    expect(action.kind).toBe('abort');
+  });
+
+  test('1006 with no stored token and budget exhausted still aborts', () => {
+    // Defensive: without a stored token the keep branch is unreachable
+    // anyway, but we pin that the budget-exhausted abort still fires.
+    const action = decideCloudReconnectAction({
+      ctx: { code: WS_CLOSE_CODE_ABNORMAL, reason: 'abnormal' },
+      stored: null,
+      attempts: CLOUD_REFRESH_ATTEMPT_CAP,
+    });
+    expect(action.kind).toBe('abort');
+  });
+
+  test('non-1006 close with attempts at cap does NOT abort (cap is 1006-only)', () => {
+    // The 1006 budget is specific to abnormal-closure recovery. A
+    // 4001 (policy) close should still refresh regardless of the
+    // 1006 attempt counter.
+    const action = decideCloudReconnectAction({
+      ctx: { code: 4001, reason: 'policy violation' },
+      stored: freshStoredToken(),
+      attempts: CLOUD_REFRESH_ATTEMPT_CAP,
+    });
+    expect(action.kind).toBe('refresh');
+  });
+});

--- a/clients/chrome-extension/background/__tests__/relay-connection.test.ts
+++ b/clients/chrome-extension/background/__tests__/relay-connection.test.ts
@@ -496,6 +496,48 @@ describe('RelayConnection', () => {
       expect(instances.length).toBe(1);
     });
 
+    test('close during pending deferred reconnect still fires onClose exactly once (Gap 2)', async () => {
+      // Regression guard for Gap 2 of the round-2 cloud-cap review:
+      // the ws 'close' listener defers onClose into
+      // scheduleReconnectWithRefresh for non-normal closes so the
+      // caller sees exactly one notification per lifecycle. Before
+      // the fix, calling close() before the reconnect timer fired
+      // would clear the timer WITHOUT flushing the pending deferred
+      // close — leaving the caller with ZERO onClose callbacks and
+      // quietly turning the "exactly once" contract into "at most
+      // once."
+      const cbs = makeCallbacks();
+      const conn = makeConn(
+        { kind: 'self-hosted', baseUrl: 'http://127.0.0.1:7830', token: 't' },
+        cbs,
+      );
+
+      conn.start();
+      openSocket(instances[0]);
+      // Server closes with 1006 → close listener arms the reconnect
+      // timer and stashes the deferred close ctx.
+      closeSocket(instances[0], 1006, 'abnormal');
+      // Nothing should have fired yet — the onClose is deferred.
+      expect(cbs.closeCalls.length).toBe(0);
+
+      // Caller tears the connection down before the reconnect timer
+      // fires. The fix flushes the pending deferred close once and
+      // then clears the timer so no reconnect happens.
+      conn.close();
+
+      expect(cbs.closeCalls.length).toBe(1);
+      expect(cbs.closeCalls[0].code).toBe(1006);
+      expect(cbs.closeCalls[0].reason).toBe('abnormal');
+      // caller-initiated close path → no authError expected.
+      expect(cbs.closeCalls[0].authError).toBeUndefined();
+
+      // Wait past the reconnect timer to make sure nothing else
+      // fires: no double onClose, no spurious reconnect.
+      await new Promise((r) => setTimeout(r, 1100));
+      expect(cbs.closeCalls.length).toBe(1);
+      expect(instances.length).toBe(1);
+    });
+
     test('cloud reconnect: token refresh replaces URL token on next connect', async () => {
       const cbs = makeCallbacks();
       let seenCtx: RelayReconnectContext | null = null;

--- a/clients/chrome-extension/background/cloud-reconnect-decision.ts
+++ b/clients/chrome-extension/background/cloud-reconnect-decision.ts
@@ -1,0 +1,89 @@
+/**
+ * Pure decision helper for the cloud-mode relay reconnect path.
+ *
+ * Factored out of worker.ts's `cloudReconnectHook` so the ordering
+ * between the three possible outcomes (`keep`, `refreshed`, `abort`)
+ * can be unit-tested directly without dragging in the chrome.* service
+ * worker surface. The hook in worker.ts is a thin async wrapper that
+ * reads the stored token + attempt counter, calls
+ * {@link decideCloudReconnectAction} synchronously to pick an action,
+ * and then actually fires the refresh / returns the decision.
+ *
+ * The key invariant this file pins (and the round-2 review gap fix
+ * that motivated extracting it) is that `kind: 'abort'` MUST be
+ * reachable whenever the 1006 refresh budget has been burned through,
+ * regardless of whether a previous refresh stashed a still-present
+ * token in storage. Before the fix, the hook checked the "keep"
+ * early-return before the abort check — so a chain of successful
+ * refreshes followed by repeated 1006 closes would silently reuse the
+ * same (still-rejected) token forever once the cap was reached,
+ * because `abnormalNeedsRefresh` went false and `stored?.token` was
+ * still truthy, triggering the keep branch before abort ever ran.
+ */
+import type { RelayReconnectContext } from './relay-connection.js';
+import { CLOUD_AUTH_FAILURE_CLOSE_CODES, isCloudTokenStale, type StoredCloudToken } from './cloud-auth.js';
+
+/** WebSocket close code browsers emit on "abnormal closure". */
+export const WS_CLOSE_CODE_ABNORMAL = 1006;
+
+/** Hard cap on consecutive 1006-triggered token refresh attempts. */
+export const CLOUD_REFRESH_ATTEMPT_CAP = 3;
+
+/**
+ * Possible synchronous outcomes from
+ * {@link decideCloudReconnectAction}. The worker hook then:
+ *   - `keep`: returns `{ kind: 'keep' }` to the RelayConnection and
+ *     lets the helper reuse the existing token.
+ *   - `refresh`: calls `refreshCloudToken` and maps the result to
+ *     either `{ kind: 'refreshed', token }` or an error abort.
+ *   - `abort`: returns `{ kind: 'abort', error }` without touching
+ *     the refresh endpoint — used when the budget is exhausted.
+ */
+export type CloudReconnectAction =
+  | { kind: 'keep' }
+  | { kind: 'refresh' }
+  | { kind: 'abort'; error: string };
+
+export interface CloudReconnectDecisionInput {
+  ctx: RelayReconnectContext;
+  stored: StoredCloudToken | null;
+  /** Consecutive 1006 refresh attempts since the last successful open. */
+  attempts: number;
+  /** Passed through to {@link isCloudTokenStale} for tests. */
+  now?: number;
+}
+
+/**
+ * Pick a synchronous action for the cloud reconnect hook. See the
+ * module docstring for the rationale behind the ordering — in
+ * particular, the `budgetExhausted` short-circuit MUST run before the
+ * `keep` early-return so a still-present token does not mask the cap.
+ */
+export function decideCloudReconnectAction(
+  input: CloudReconnectDecisionInput,
+): CloudReconnectAction {
+  const { ctx, stored, attempts, now } = input;
+  const authFailure = CLOUD_AUTH_FAILURE_CLOSE_CODES.has(ctx.code);
+  const abnormal = ctx.code === WS_CLOSE_CODE_ABNORMAL;
+  const abnormalNeedsRefresh = abnormal && attempts < CLOUD_REFRESH_ATTEMPT_CAP;
+  const budgetExhausted = abnormal && attempts >= CLOUD_REFRESH_ATTEMPT_CAP;
+  const needsRefresh =
+    authFailure || abnormalNeedsRefresh || isCloudTokenStale(stored, now);
+
+  // Budget-exhausted short-circuit: MUST run before the keep
+  // early-return so a still-present token does not mask the abort.
+  if (budgetExhausted) {
+    return {
+      kind: 'abort',
+      error:
+        `Cloud relay kept closing with abnormal closure (code 1006) after ${CLOUD_REFRESH_ATTEMPT_CAP} ` +
+        'token refresh attempts. Please sign in with Vellum (cloud) again from the extension popup to reconnect.',
+    };
+  }
+
+  if (!needsRefresh && stored?.token) {
+    return { kind: 'keep' };
+  }
+
+  return { kind: 'refresh' };
+}

--- a/clients/chrome-extension/background/relay-connection.ts
+++ b/clients/chrome-extension/background/relay-connection.ts
@@ -145,6 +145,21 @@ export class RelayConnection {
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private reconnectDelay = RECONNECT_BASE_MS;
   private closedByCaller = false;
+  /**
+   * Context of a non-normal ws close whose onClose notification has
+   * been deferred into the reconnect-with-refresh timer. Populated
+   * from the ws 'close' listener BEFORE arming the timer, and cleared
+   * right before the timer's setTimeout callback fires onClose (on
+   * abort/keep/refreshed branches). When {@link close} is called
+   * while this is non-null the caller is racing the deferred
+   * notification — we fire the single pending onClose before
+   * clearing the timer to keep the exactly-once invariant.
+   *
+   * Without this guard, `close()` would silently cancel the timer
+   * and the caller would see ZERO onClose calls for the lifecycle,
+   * turning the contract from "exactly once" into "at most once".
+   */
+  private pendingDeferredCloseCtx: RelayReconnectContext | null = null;
 
   constructor(deps: RelayConnectionDeps) {
     this.deps = deps;
@@ -219,9 +234,23 @@ export class RelayConnection {
   /**
    * Close the socket permanently. After this the connection will not
    * reconnect on its own; call `start()` again to resume.
+   *
+   * If a non-normal ws close already fired and deferred its onClose
+   * notification into a reconnect timer that hasn't executed yet,
+   * fire that single pending notification before clearing the timer
+   * so the caller still sees exactly one onClose per lifecycle. The
+   * previous behaviour silently cancelled the timer and left the
+   * caller with zero close callbacks for the aborted lifecycle,
+   * which broke the invariant documented on
+   * {@link scheduleReconnectWithRefresh}.
    */
   close(code = 1000, reason = 'closed by caller'): void {
     this.closedByCaller = true;
+    if (this.pendingDeferredCloseCtx !== null) {
+      const deferred = this.pendingDeferredCloseCtx;
+      this.pendingDeferredCloseCtx = null;
+      this.deps.onClose(deferred.code, deferred.reason);
+    }
     if (this.reconnectTimer !== null) {
       clearTimeout(this.reconnectTimer);
       this.reconnectTimer = null;
@@ -287,7 +316,14 @@ export class RelayConnection {
       // the reconnect-with-refresh decision resolves so the caller
       // sees exactly one onClose call per lifecycle. The helper
       // surfaces an authError when refresh returns/aborts.
-      this.scheduleReconnectWithRefresh({ code, reason });
+      //
+      // Track the pending deferred close so that a concurrent
+      // close() call that clears the timer can still fire onClose
+      // once before tearing down — otherwise the caller would see
+      // zero close notifications for this lifecycle.
+      const deferredCtx = { code, reason };
+      this.pendingDeferredCloseCtx = deferredCtx;
+      this.scheduleReconnectWithRefresh(deferredCtx);
     });
 
     ws.addEventListener('error', () => {
@@ -359,9 +395,19 @@ export class RelayConnection {
       this.reconnectTimer = null;
       if (this.closedByCaller) {
         // Caller called close() while we were waiting for the
-        // backoff timer to fire. Notify them once with the original
-        // close code/reason and stop — no reconnect, no refresh.
-        this.deps.onClose(ctx.code, ctx.reason);
+        // backoff timer to fire. close() already fired the single
+        // pending onClose via pendingDeferredCloseCtx before
+        // clearing the timer, so there is nothing left to do here.
+        // (Historically this branch was reachable because
+        // close() left the deferred notification unfired; now
+        // close() always flushes it synchronously, so if we somehow
+        // still observe closedByCaller without a pending ctx the
+        // notification was already delivered.)
+        if (this.pendingDeferredCloseCtx !== null) {
+          const pending = this.pendingDeferredCloseCtx;
+          this.pendingDeferredCloseCtx = null;
+          this.deps.onClose(pending.code, pending.reason);
+        }
         return;
       }
       let decision: RelayReconnectDecision = { kind: 'keep' };
@@ -396,6 +442,7 @@ export class RelayConnection {
         // worker can push an actionable message into chrome.storage
         // for the popup.
         this.closedByCaller = true;
+        this.pendingDeferredCloseCtx = null;
         this.deps.onClose(ctx.code, ctx.reason, decision.error);
         return;
       }
@@ -411,13 +458,25 @@ export class RelayConnection {
       // Caller may have called close() concurrently with the refresh
       // hook — re-check before firing onClose or reconnecting.
       if (this.closedByCaller) {
-        this.deps.onClose(ctx.code, ctx.reason);
+        // Same reasoning as the pre-refresh closedByCaller branch
+        // above: close() normally flushes the pending onClose, so
+        // the pending ctx should already be null. Defensive flush
+        // guards against a rare race where closedByCaller was set
+        // via another path.
+        if (this.pendingDeferredCloseCtx !== null) {
+          const pending = this.pendingDeferredCloseCtx;
+          this.pendingDeferredCloseCtx = null;
+          this.deps.onClose(pending.code, pending.reason);
+        }
         return;
       }
       // Fire onClose once for this lifecycle before we start a fresh
       // connect attempt. The caller sees exactly one onClose per
       // non-normal close, with authError undefined on the reconnect
-      // path and set on the abort path.
+      // path and set on the abort path. Clear the pending deferred
+      // close ctx so a later close() doesn't re-deliver the same
+      // notification.
+      this.pendingDeferredCloseCtx = null;
       this.deps.onClose(ctx.code, ctx.reason);
       this.connect();
     }, delay);

--- a/clients/chrome-extension/background/worker.ts
+++ b/clients/chrome-extension/background/worker.ts
@@ -25,11 +25,13 @@ import {
   refreshCloudToken,
   getStoredToken as getStoredCloudToken,
   getStoredTokenRaw as getStoredCloudTokenRaw,
-  isCloudTokenStale,
   CLOUD_AUTH_FAILURE_CLOSE_CODES,
   type CloudAuthConfig,
   type StoredCloudToken,
 } from './cloud-auth.js';
+import {
+  decideCloudReconnectAction,
+} from './cloud-reconnect-decision.js';
 import {
   bootstrapLocalToken,
   getStoredLocalToken,
@@ -381,8 +383,11 @@ async function buildRelayModeConfig(kind: RelayModeKind): Promise<RelayMode> {
 //      sign-in prompt instead of silently hammering the gateway.
 //   3. The counter resets to zero every time a socket successfully
 //      opens (see the `onOpen` wiring in `createRelayConnection`).
-const WS_CLOSE_CODE_ABNORMAL = 1006;
-const CLOUD_REFRESH_ATTEMPT_CAP = 3;
+//
+// The pure action-picker lives in `cloud-reconnect-decision.ts` so
+// unit tests can exercise the ordering without dragging in the
+// service worker surface. This module is responsible for the async
+// side effects (reading storage, calling refreshCloudToken, etc.).
 
 /**
  * Count of consecutive refresh attempts made from
@@ -404,61 +409,36 @@ function resetCloudRefreshAttempts(): void {
  * abort the reconnect loop entirely so the popup can prompt the user
  * to sign in again.
  *
- * Refresh is forced when:
- *   - The stored token is missing, expired, or within the stale
- *     window (see `isCloudTokenStale`).
- *   - The close code matches a known auth-failure code emitted by the
- *     gateway's browser-relay handshake (see
- *     `CLOUD_AUTH_FAILURE_CLOSE_CODES`).
- *   - The close code is 1006 AND we haven't already exhausted the
- *     1006 refresh budget. See the docstring on
- *     {@link WS_CLOSE_CODE_ABNORMAL} for the rationale.
- *
- * On successful refresh the new token is persisted to storage by
- * `refreshCloudToken` and returned via `{ kind: 'refreshed' }` so the
- * {@link RelayConnection} rebuilds the URL for the next connect. On
- * failure we return `{ kind: 'abort' }` which halts the reconnect
- * loop, marks the socket closed, and propagates the error through
- * `onClose` for the UI to surface.
+ * The pure decision (keep / refresh / abort) is delegated to
+ * {@link decideCloudReconnectAction}, which is covered by a direct
+ * unit test. This function is the async side-effect wrapper that
+ * reads the stored token, consults the decision helper, fires the
+ * refresh network call on the `refresh` branch, and maps the
+ * outcomes onto a {@link RelayReconnectDecision} for
+ * {@link RelayConnection}.
  */
 async function cloudReconnectHook(
   ctx: RelayReconnectContext,
 ): Promise<RelayReconnectDecision> {
   const stored = await getStoredCloudTokenRaw();
-  const authFailure = CLOUD_AUTH_FAILURE_CLOSE_CODES.has(ctx.code);
-  const abnormal = ctx.code === WS_CLOSE_CODE_ABNORMAL;
-  // For 1006 we only assume "this is an auth problem" while we
-  // haven't burned through the refresh budget. A mid-session cable
-  // pull will also produce 1006 and we don't want to abort the
-  // reconnect loop on the very first network blip — the attempt
-  // counter resets every time a socket successfully re-opens (see
-  // resetCloudRefreshAttempts in the onOpen hook), so a transient
-  // network outage just racks up attempts we never actually use.
-  const abnormalNeedsRefresh =
-    abnormal && cloudRefreshAttempts < CLOUD_REFRESH_ATTEMPT_CAP;
-  const needsRefresh =
-    authFailure || abnormalNeedsRefresh || isCloudTokenStale(stored);
-
-  if (!needsRefresh && stored?.token) {
+  const action = decideCloudReconnectAction({
+    ctx,
+    stored,
+    attempts: cloudRefreshAttempts,
+  });
+  if (action.kind === 'keep') {
     // Transient network blip with a still-valid token. Keep the
     // existing token and let the relay helper retry.
     return { kind: 'keep' };
   }
-
-  // If we've already burned the 1006 refresh budget without a
-  // successful reconnect, stop hammering the gateway and prompt the
-  // user to sign in again. We intentionally check this BEFORE calling
-  // refreshCloudToken so an in-flight reconnect that just flipped us
-  // into the abort branch doesn't rack up a gratuitous refresh.
-  if (abnormal && cloudRefreshAttempts >= CLOUD_REFRESH_ATTEMPT_CAP) {
-    return {
-      kind: 'abort',
-      error:
-        `Cloud relay kept closing with abnormal closure (code 1006) after ${CLOUD_REFRESH_ATTEMPT_CAP} ` +
-        'token refresh attempts. Please sign in with Vellum (cloud) again from the extension popup to reconnect.',
-    };
+  if (action.kind === 'abort') {
+    // Budget-exhausted short-circuit for repeated 1006 closes — the
+    // decision helper has already generated an actionable sign-in
+    // prompt message.
+    return { kind: 'abort', error: action.error };
   }
 
+  // action.kind === 'refresh'
   cloudRefreshAttempts += 1;
   const refreshed = await refreshCloudToken({
     gatewayBaseUrl: CLOUD_GATEWAY_BASE_URL,
@@ -470,6 +450,8 @@ async function cloudReconnectHook(
   }
 
   // Non-interactive refresh is impossible — user must sign in again.
+  const authFailure = CLOUD_AUTH_FAILURE_CLOSE_CODES.has(ctx.code);
+  const abnormal = ctx.code === 1006;
   const reason = authFailure
     ? 'Cloud relay closed with an auth-failure code'
     : abnormal
@@ -594,6 +576,15 @@ function missingTokenMessage(kind: RelayModeKind): string {
 
 async function connect(): Promise<void> {
   if (relayConnection && relayConnection.isOpen()) return;
+  // Defensive: a fresh connect() always starts the 1006 refresh
+  // budget from scratch. The counter is normally reset from onOpen,
+  // but if a previous session exhausted the cap (so onOpen never
+  // fired for the aborted attempt) and the user then signed in again
+  // and clicked Connect, the carried-over counter would cause the
+  // first 1006 in the new session to immediately land in the abort
+  // branch. Resetting here guarantees a fresh Connect gets the full
+  // refresh budget regardless of prior session state.
+  resetCloudRefreshAttempts();
   // A fresh connect attempt supersedes any previously persisted
   // auth-error — the user either just signed back in or is explicitly
   // retrying, and we want the popup to stop nagging.


### PR DESCRIPTION
## Summary
Fixes round-2 review gaps in cloud reconnect handling:

- cloudReconnectHook: the abort-cap check now runs before the keep early-return, so 1006 closes that happen after the cap is reached correctly surface an abort (sign-in prompt) instead of silently reconnecting forever with the rejected token.
- RelayConnection.onClose: fires exactly once per lifecycle even when close() races with a pending deferred reconnect timer. Previously, the timer would be cleared without firing the deferred onClose, leaving the caller with zero close notifications.
- cloudRefreshAttempts: reset at the top of connect() so a fresh Connect always starts with a fresh counter even if a prior session exhausted the cap.

Part of plan: browser-use-main-remediation-plan-2026-04-08.md (review round 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24519" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
