### PR TITLE
feat(skills-ui): preview uninstalled Vellum skills in the detail view

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -13,7 +13,7 @@ struct AgentPanelContent: View {
     @Binding var focusedSkillId: String?
 
     @State private var skillsManager: SkillsManager
-    @State private var selectedInstalledSkillId: String?
+    @State private var selectedSkillId: String?
     @State private var skillToDelete: SkillInfo?
     @AppStorage("skillsBannerDismissed") private var bannerDismissed = false
 
@@ -27,7 +27,7 @@ struct AgentPanelContent: View {
     }
 
     private var isShowingDetail: Bool {
-        selectedInstalledSkillId != nil
+        selectedSkillId != nil
     }
 
     var body: some View {
@@ -82,27 +82,27 @@ struct AgentPanelContent: View {
         .onAppear {
             skillsManager.fetchSkills()
             if let skillId = focusedSkillId {
-                selectedInstalledSkillId = skillId
+                selectedSkillId = skillId
                 focusedSkillId = nil
             }
         }
         .onChange(of: focusedSkillId) {
             if let skillId = focusedSkillId {
-                selectedInstalledSkillId = skillId
+                selectedSkillId = skillId
                 focusedSkillId = nil
             }
         }
         .onChange(of: skillsManager.skills.map(\.id)) {
             onSkillsChanged?()
-            if let selectedId = selectedInstalledSkillId,
+            if let selectedId = selectedSkillId,
                !skillsManager.skills.contains(where: { $0.id == selectedId }) {
-                selectedInstalledSkillId = nil
+                selectedSkillId = nil
             }
         }
         .onChange(of: skillsManager.filteredSkills.map(\.id)) {
-            if let selectedId = selectedInstalledSkillId,
+            if let selectedId = selectedSkillId,
                !skillsManager.filteredSkills.contains(where: { $0.id == selectedId }) {
-                selectedInstalledSkillId = nil
+                selectedSkillId = nil
             }
         }
         .sheet(item: $skillToDelete) { skill in
@@ -228,14 +228,14 @@ struct AgentPanelContent: View {
 
     @ViewBuilder
     private var contentView: some View {
-        if let selectedId = selectedInstalledSkillId,
+        if let selectedId = selectedSkillId,
            let skill = skillsManager.filteredSkills.first(where: { $0.id == selectedId }) {
             SkillDetailView(
                 skill: skill,
                 skillsManager: skillsManager,
                 onBack: {
                     withAnimation(VAnimation.standard) {
-                        selectedInstalledSkillId = nil
+                        selectedSkillId = nil
                     }
                 },
                 onDelete: { skill in
@@ -262,6 +262,11 @@ struct AgentPanelContent: View {
                         if skill.isAvailable {
                             AvailableSkillItemRow(
                                 skill: skill,
+                                onSelect: {
+                                    withAnimation(VAnimation.fast) {
+                                        selectedSkillId = skill.id
+                                    }
+                                },
                                 onInstall: { skillsManager.installSkill(slug: skill.id) },
                                 isInstalling: skillsManager.installingSkillId == skill.id
                             )
@@ -270,7 +275,7 @@ struct AgentPanelContent: View {
                                 skill: skill,
                                 onSelect: {
                                     withAnimation(VAnimation.fast) {
-                                        selectedInstalledSkillId = skill.id
+                                        selectedSkillId = skill.id
                                     }
                                 },
                                 onDelete: {
@@ -351,11 +356,12 @@ struct SkillItemRow: View {
 
 struct AvailableSkillItemRow: View {
     let skill: SkillInfo
+    let onSelect: () -> Void
     let onInstall: () -> Void
     var isInstalling: Bool = false
 
     var body: some View {
-        VCard {
+        VCard(action: onSelect) {
             HStack(alignment: .center, spacing: VSpacing.lg) {
                 if let emoji = skill.emoji, !emoji.isEmpty {
                     Text(emoji)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillDetailView.swift
@@ -1,7 +1,10 @@
 import SwiftUI
 import VellumAssistantShared
 
-/// Full-page detail view for an installed skill, showing metadata and a two-pane file browser.
+/// Full-page detail view for a skill, showing metadata and a two-pane file
+/// browser. Works for both installed skills (file contents delivered inline
+/// with the file list) and uninstalled catalog skills (file contents fetched
+/// lazily on click).
 struct SkillDetailView: View {
     let skill: SkillInfo
     var skillsManager: SkillsManager
@@ -14,8 +17,15 @@ struct SkillDetailView: View {
     @State private var skillFileViewMode: FileViewMode = .source
     @State private var browserNodes: [VFileBrowserNode] = []
 
+    /// True when the skill is not installed locally, so file contents must be
+    /// fetched lazily rather than delivered inline with the file list.
+    private var isPreview: Bool { !skill.isInstalled }
+
     private var hasViewableFiles: Bool {
         guard let files = skillsManager.selectedSkillFiles else { return true }
+        if isPreview {
+            return files.files.contains { !$0.isBinary }
+        }
         return files.files.contains { !$0.isBinary && $0.content != nil }
     }
 
@@ -24,7 +34,8 @@ struct SkillDetailView: View {
             SkillDetailTitleRow(
                 skill: skill,
                 onBack: onBack,
-                onDelete: { onDelete(skill) }
+                onDelete: { onDelete(skill) },
+                onInstall: { skillsManager.installSkill(slug: skill.id) }
             )
 
             if !skill.description.isEmpty {
@@ -39,19 +50,18 @@ struct SkillDetailView: View {
             skillDetailFileBrowser
         }
         .onAppear {
-            // Only fetch files for locally available skills (bundled or installed).
-            // Remote catalog search results are not in the local resolved catalog, so
-            // GET /skills/:id/files would 404 for them.
-            if skill.isInstalled {
-                skillsManager.fetchSkillFiles(skillId: skill.id)
-            }
+            skillsManager.fetchSkillFiles(skillId: skill.id)
         }
         .onChange(of: skillsManager.selectedSkillFiles?.files.map(\.path)) {
             // 1. Rebuild the browser node tree from the latest file list (moved out of
             //    view body per clients/AGENTS.md: no heavy transformation in body).
+            //    In preview mode the `content` field is always nil — files are
+            //    fetched lazily on click — so the tree filter must tolerate that.
             let textFiles: [SkillFileEntry]
             if let files = skillsManager.selectedSkillFiles?.files {
-                textFiles = files.filter { !$0.isBinary && $0.content != nil }
+                textFiles = files.filter { file in
+                    isPreview ? !file.isBinary : (!file.isBinary && file.content != nil)
+                }
                 browserNodes = Self.buildSkillNodeTree(from: textFiles)
             } else {
                 textFiles = []
@@ -60,8 +70,11 @@ struct SkillDetailView: View {
 
             // 2. Auto-select SKILL.md (or the first text file) on first load.
             if expandedFilePath == nil, let files = skillsManager.selectedSkillFiles?.files {
-                let skillMd = files.first { $0.path == "SKILL.md" && !$0.isBinary && $0.content != nil }
-                let firstText = files.first { !$0.isBinary && $0.content != nil }
+                let matchesTextFilter: (SkillFileEntry) -> Bool = { file in
+                    isPreview ? !file.isBinary : (!file.isBinary && file.content != nil)
+                }
+                let skillMd = files.first { $0.path == "SKILL.md" && matchesTextFilter($0) }
+                let firstText = files.first(where: matchesTextFilter)
                 if let selectedFile = skillMd ?? firstText {
                     expandedFilePath = selectedFile.path
                     let autoModes = availableViewModes(for: selectedFile.path, mimeType: selectedFile.mimeType)
@@ -95,6 +108,17 @@ struct SkillDetailView: View {
                 expandedPaths.formUnion(Self.ancestorPaths(of: selectedPath))
                 let selectedModes = availableViewModes(for: file.path, mimeType: file.mimeType)
                 skillFileViewMode = selectedModes.first ?? .source
+
+                // In preview mode the file list is served without inline
+                // content, so kick off a lazy content fetch the first time a
+                // text file is selected.
+                if isPreview,
+                   !file.isBinary,
+                   skillsManager.loadedFileContents[selectedPath] == nil,
+                   !skillsManager.loadingFilePaths.contains(selectedPath),
+                   skillsManager.fileContentErrors[selectedPath] == nil {
+                    skillsManager.loadSkillFileContent(skillId: skill.id, path: selectedPath)
+                }
             }
         }
         .onDisappear {
@@ -244,11 +268,16 @@ struct SkillDetailView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .overlay { ProgressView().controlSize(.small) }
         } else if let error = skillsManager.skillFilesError {
-            VEmptyState(
-                title: "Failed to load files",
-                subtitle: error,
-                icon: VIcon.circleAlert.rawValue
-            )
+            VStack(spacing: VSpacing.md) {
+                VEmptyState(
+                    title: "Failed to load files",
+                    subtitle: error,
+                    icon: VIcon.circleAlert.rawValue
+                )
+                retryButton(label: "Retry") {
+                    skillsManager.fetchSkillFiles(skillId: skill.id)
+                }
+            }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else {
             VFileBrowser(
@@ -256,24 +285,84 @@ struct SkillDetailView: View {
                 expandedPaths: $expandedPaths,
                 selectedPath: $expandedFilePath
             ) { selectedNode in
-                if let selectedNode,
-                   let file = skillsManager.selectedSkillFiles?.files.first(where: { $0.path == selectedNode.path }),
-                   let content = file.content {
-                    FileContentView(
-                        fileName: file.path,
-                        mimeType: file.mimeType,
-                        content: .constant(content),
-                        viewMode: $skillFileViewMode,
-                        isActivelyEditing: .constant(false)
-                    )
-                } else {
-                    VEmptyState(
-                        title: hasViewableFiles ? "Select a file to view" : "No viewable files",
-                        icon: VIcon.fileText.rawValue
-                    )
-                }
+                fileContentPane(for: selectedNode)
             }
         }
+    }
+
+    @ViewBuilder
+    private func fileContentPane(for selectedNode: VFileBrowserNode?) -> some View {
+        if let selectedNode,
+           let file = skillsManager.selectedSkillFiles?.files.first(where: { $0.path == selectedNode.path }) {
+            if isPreview && !file.isBinary {
+                previewFileContent(for: file, nodePath: selectedNode.path)
+            } else if let content = file.content {
+                FileContentView(
+                    fileName: file.path,
+                    mimeType: file.mimeType,
+                    content: .constant(content),
+                    viewMode: $skillFileViewMode,
+                    isActivelyEditing: .constant(false)
+                )
+            } else {
+                VEmptyState(
+                    title: hasViewableFiles ? "Select a file to view" : "No viewable files",
+                    icon: VIcon.fileText.rawValue
+                )
+            }
+        } else {
+            VEmptyState(
+                title: hasViewableFiles ? "Select a file to view" : "No viewable files",
+                icon: VIcon.fileText.rawValue
+            )
+        }
+    }
+
+    @ViewBuilder
+    private func previewFileContent(for file: SkillFileEntry, nodePath: String) -> some View {
+        if let content = skillsManager.loadedFileContents[nodePath] {
+            FileContentView(
+                fileName: file.path,
+                mimeType: file.mimeType,
+                content: .constant(content),
+                viewMode: $skillFileViewMode,
+                isActivelyEditing: .constant(false)
+            )
+        } else if skillsManager.loadingFilePaths.contains(nodePath) {
+            VEmptyState(
+                title: "Loading file...",
+                icon: VIcon.fileText.rawValue
+            )
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .overlay { ProgressView().controlSize(.small) }
+        } else if let error = skillsManager.fileContentErrors[nodePath] {
+            VStack(spacing: VSpacing.md) {
+                VEmptyState(
+                    title: "Failed to load file",
+                    subtitle: error,
+                    icon: VIcon.circleAlert.rawValue
+                )
+                retryButton(label: "Retry") {
+                    skillsManager.loadSkillFileContent(skillId: skill.id, path: nodePath)
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else {
+            VEmptyState(
+                title: hasViewableFiles ? "Select a file to view" : "No viewable files",
+                icon: VIcon.fileText.rawValue
+            )
+        }
+    }
+
+    @ViewBuilder
+    private func retryButton(label: String, action: @escaping () -> Void) -> some View {
+        VButton(
+            label: label,
+            leftIcon: VIcon.refreshCw.rawValue,
+            style: .outlined,
+            action: action
+        )
     }
 }
 
@@ -283,6 +372,7 @@ struct SkillDetailTitleRow: View {
     let skill: SkillInfo
     let onBack: () -> Void
     let onDelete: () -> Void
+    let onInstall: () -> Void
 
     var body: some View {
         HStack {
@@ -318,6 +408,10 @@ struct SkillDetailTitleRow: View {
             if skill.kind == "installed" {
                 VButton(label: "Remove", leftIcon: VIcon.trash.rawValue, style: .dangerOutline) {
                     onDelete()
+                }
+            } else if skill.kind == "catalog" {
+                VButton(label: "Install", leftIcon: VIcon.arrowDownToLine.rawValue, style: .primary) {
+                    onInstall()
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Tapping an uninstalled Vellum catalog skill in the "Available" filter now opens `SkillDetailView` with a browsable file tree.
- Preview mode lazily fetches individual file content via `SkillsManager.loadSkillFileContent`, with loading and retryable error states for both the file list and per-file reads.
- The detail view title row shows a primary "Install" button for catalog skills and the existing "Remove" button for installed skills; file browser is read-only in preview mode.

## Manual verification
- [ ] Open Skills tab, filter to "Available", tap a Vellum catalog skill → file tree loads, SKILL.md auto-selected, content renders.
- [ ] Tap a sub-folder file → loading spinner → content.
- [ ] Force a network error → retry button restores.

Part of plan: skill-files-preview.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24520" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
