### PR TITLE
fix(browser-relay): identity-guard dispatcher finally + setMode lifecycle flush

### DIFF
--- a/clients/chrome-extension/background/__tests__/host-browser-dispatcher.test.ts
+++ b/clients/chrome-extension/background/__tests__/host-browser-dispatcher.test.ts
@@ -933,6 +933,96 @@ describe('createHostBrowserDispatcher', () => {
       );
     });
 
+    test('overlap-retry reverse ordering: cancelled call A unwinding does not evict call B from inFlight', async () => {
+      // Companion to the overlap-retry test above, exercising the
+      // reverse ordering: call A's proxy.send resolves BEFORE call
+      // B's, i.e. the cancelled invocation unwinds while the live
+      // retry is still suspended. The dispatcher's finally block
+      // guards `inFlight.delete` on identity: A must not evict B's
+      // controller from inFlight, otherwise a subsequent `cancel("req-1")`
+      // would find nothing and silently no-op, leaving B uncancellable.
+      //
+      // Ordering:
+      //   1. handle("req-1") — call A, suspends inside proxy.send at gateA
+      //   2. cancel("req-1") — marks req-1 cancelled, aborts A's
+      //      controller, removes A from inFlight (A still suspended)
+      //   3. handle("req-1") — call B, retry starts, inserts controllerB
+      //      into inFlight, suspends inside proxy.send at gateB
+      //   4. Release gateA FIRST — call A resumes, sees its own
+      //      AbortController is aborted, drops the result, and runs
+      //      its finally block while B is still suspended. The guard
+      //      must leave inFlight[req-1] pointing at controllerB.
+      //   5. cancel("req-1") — must find B's controller in inFlight
+      //      and abort it. B then unwinds and drops its (cancelled)
+      //      result on the floor.
+      harness = createHarness();
+
+      type SendFrame = { id: number; result: unknown };
+      let resolveGateA: (frame: SendFrame) => void = () => {};
+      let resolveGateB: (frame: SendFrame) => void = () => {};
+      const gateA = new Promise<SendFrame>((resolve) => {
+        resolveGateA = resolve;
+      });
+      const gateB = new Promise<SendFrame>((resolve) => {
+        resolveGateB = resolve;
+      });
+      const gates: Array<Promise<SendFrame>> = [gateA, gateB];
+
+      const proxy = harness.proxy;
+      proxy.send = async (target, frame) => {
+        proxy.sendCalls.push({ target, frame });
+        const gate = gates.shift();
+        if (!gate) {
+          throw new Error('unexpected additional proxy.send call');
+        }
+        const result = await gate;
+        return { ...result, id: frame.id };
+      };
+
+      // Start call A and wait for it to suspend inside proxy.send.
+      const callA = harness.dispatcher.handle(sampleRequest);
+      await waitFor(() => proxy.sendCalls.length === 1);
+
+      // Cancel call A while it is still suspended at gateA.
+      harness.dispatcher.cancel({
+        type: 'host_browser_cancel',
+        requestId: 'req-1',
+      });
+
+      // Start call B with the same requestId — the retry inserts its
+      // own controller into inFlight[req-1] and suspends at gateB.
+      const callB = harness.dispatcher.handle(sampleRequest);
+      await waitFor(() => proxy.sendCalls.length === 2);
+
+      // Release call A's gate FIRST so A unwinds while B is still
+      // suspended. A's finally runs against an inFlight entry that
+      // now belongs to B; the identity guard must leave it in place.
+      resolveGateA({ id: 0, result: { fromCancelledA: true } });
+      await callA;
+
+      // A dropped its result on the floor (cancelled-invocation
+      // suppression), so no envelope has been posted yet.
+      expect(harness.results.length).toBe(0);
+
+      // Issuing a cancel for B must still find B's controller live
+      // in inFlight — if A's finally had evicted B, this cancel
+      // would be a silent no-op and B would deliver its result on
+      // gateB release. We want the opposite: B must be cancelled.
+      harness.dispatcher.cancel({
+        type: 'host_browser_cancel',
+        requestId: 'req-1',
+      });
+
+      // Release B's gate. B's happy path must notice its own
+      // AbortController is aborted and drop the result instead of
+      // posting it — proving the cancel above reached B's live
+      // controller rather than no-oping against an evicted entry.
+      resolveGateB({ id: 0, result: { fromRetry: true } });
+      await callB;
+
+      expect(harness.results.length).toBe(0);
+    });
+
     test('aborts the in-flight controller and removes it from the inFlight map', async () => {
       // Sanity check on the cancel path's bookkeeping: after cancel()
       // returns, the in-flight map no longer holds the cancelled entry,

--- a/clients/chrome-extension/background/__tests__/relay-connection.test.ts
+++ b/clients/chrome-extension/background/__tests__/relay-connection.test.ts
@@ -856,6 +856,75 @@ describe('RelayConnection', () => {
 
       conn.close();
     });
+
+    test('flushes pending deferred close from prior lifecycle before switching modes', async () => {
+      // Regression guard for the setMode lifecycle leak: when a
+      // non-normal close arms the reconnect-with-refresh timer it
+      // stashes a deferred onClose ctx so the caller sees exactly
+      // one onClose per lifecycle. If setMode then tears down the
+      // current socket without flushing that pending ctx, the
+      // caller sees zero onClose calls for the prior lifecycle and
+      // a subsequent close() on the new lifecycle would re-deliver
+      // the stale ctx as if it belonged to the new socket.
+      //
+      // This test pins both halves of the invariant: setMode MUST
+      // fire the deferred onClose exactly once with the original
+      // 1006 code/reason, and the new lifecycle's eventual close
+      // MUST NOT re-deliver that same ctx.
+      const cbs = makeCallbacks();
+      const conn = makeConn(
+        { kind: 'self-hosted', baseUrl: 'http://127.0.0.1:7830', token: 't' },
+        cbs,
+      );
+
+      conn.start();
+      openSocket(instances[0]);
+
+      // Server-initiated abnormal close on the prior lifecycle. The
+      // close listener arms the reconnect timer and stashes the
+      // deferred ctx — the caller has not been notified yet.
+      closeSocket(instances[0], 1006, 'abnormal');
+      expect(cbs.closeCalls.length).toBe(0);
+
+      // Switch modes before the reconnect timer fires. setMode must
+      // flush the single pending onClose with the ORIGINAL 1006
+      // code/reason (not 1000 / 'mode switched'), then tear down
+      // the old socket and construct a new one for the cloud mode.
+      conn.setMode({
+        kind: 'cloud',
+        baseUrl: 'https://api.vellum.ai',
+        token: 'cloud-jwt',
+      });
+
+      expect(cbs.closeCalls.length).toBe(1);
+      expect(cbs.closeCalls[0].code).toBe(1006);
+      expect(cbs.closeCalls[0].reason).toBe('abnormal');
+      expect(cbs.closeCalls[0].authError).toBeUndefined();
+
+      // New socket was constructed for the cloud mode.
+      expect(instances.length).toBe(2);
+      expect(instances[1].url).toBe(
+        'wss://api.vellum.ai/v1/browser-relay?token=cloud-jwt',
+      );
+
+      // Wait past the old reconnect timer to make sure it does not
+      // fire and nothing else surfaces onto the caller.
+      await new Promise((r) => setTimeout(r, 1100));
+      expect(cbs.closeCalls.length).toBe(1);
+
+      // A subsequent explicit close() on the new lifecycle must not
+      // re-deliver the stale 1006 ctx. Without the flush in setMode,
+      // `pendingDeferredCloseCtx` would still carry the prior
+      // lifecycle's 1006/'abnormal' at this point and close() would
+      // fire a second onClose with that stale code — the assertion
+      // below catches that regression.
+      openSocket(instances[1]);
+      conn.close();
+
+      expect(cbs.closeCalls.length).toBe(1);
+      expect(cbs.closeCalls[0].code).toBe(1006);
+      expect(cbs.closeCalls[0].reason).toBe('abnormal');
+    });
   });
 
   describe('send', () => {

--- a/clients/chrome-extension/background/host-browser-dispatcher.ts
+++ b/clients/chrome-extension/background/host-browser-dispatcher.ts
@@ -186,12 +186,25 @@ export function createHostBrowserDispatcher(
   // to its caller.
   //
   // Invariant: entries are only added by `cancel()` when the requestId
-  // is currently present in `inFlight`, and they are always pruned in
-  // `handle()`'s finally block once the handler unwinds. Together these
-  // bound the set size to at most the current in-flight count, so the
-  // set cannot grow unbounded across long-running service-worker
-  // lifetimes even under duplicate/late cancel churn around relay
-  // reconnects.
+  // is currently present in `inFlight`. Entries are pruned in two
+  // places:
+  //   1. At the top of `handle()`, where a fresh invocation clears any
+  //      stale marker left behind by a prior invocation of the same
+  //      requestId — this prevents an overlap-retry from inheriting a
+  //      cancelled-by-a-previous-call flag that would silently drop its
+  //      legitimate result.
+  //   2. In `handle()`'s finally block, guarded on identity: the marker
+  //      is removed only when the unwinding invocation still owns the
+  //      `inFlight` entry for this requestId (or there is no entry at
+  //      all, i.e. the invocation was cancelled and no retry has
+  //      arrived). If a later invocation has overwritten the entry with
+  //      its own controller, the finally block leaves the marker alone
+  //      so that later invocation's cancel state is preserved.
+  //
+  // Together these bound the set size to at most the current in-flight
+  // count, so the set cannot grow unbounded across long-running
+  // service-worker lifetimes even under duplicate/late cancel churn
+  // around relay reconnects.
   const cancelledRequestIds = new Set<string>();
   // Track which targets we've already attached to so repeat commands
   // against the same tab/session don't unnecessarily call attach again.
@@ -292,7 +305,17 @@ export function createHostBrowserDispatcher(
     // to cover the non-overlapping case.
     cancelledRequestIds.delete(requestId);
     const abort = new AbortController();
-    inFlight.set(requestId, abort);
+    // Capture the controller created for THIS invocation so the
+    // finally block can tell its own `inFlight` entry apart from one
+    // written by a later overlapping invocation. When two calls for
+    // the same requestId overlap (call A is suspended at proxy.send
+    // while call B starts and overwrites `inFlight[requestId]` with
+    // its own controller), the finally block must leave B's live
+    // entry alone — otherwise a cancel() arriving after A unwinds
+    // would find nothing in `inFlight` and silently no-op, leaving
+    // B uncancellable.
+    const ownController = abort;
+    inFlight.set(requestId, ownController);
     try {
       const target = await deps.resolveTarget(envelope.cdpSessionId);
       const key = targetKey(target);
@@ -394,15 +417,43 @@ export function createHostBrowserDispatcher(
         );
       }
     } finally {
-      inFlight.delete(requestId);
-      // Prune the cancelled marker once the handle() call has fully
-      // unwound. Leaving the entry in place would silently drop the
-      // result of a *subsequent* handle() for the same requestId (e.g.
-      // a retry across a relay reconnect). Deleting it here is the
-      // symmetric counterpart to the `cancel()` guard that only adds
-      // markers for in-flight requests, and together they bound
-      // `cancelledRequestIds` by the current in-flight count.
-      cancelledRequestIds.delete(requestId);
+      // Identity-guarded cleanup: only prune `inFlight` and
+      // `cancelledRequestIds` when this invocation still owns the
+      // `inFlight` entry for the requestId (or there is no entry at
+      // all, which means this invocation was cancelled and no
+      // overlapping retry has taken the slot).
+      //
+      // The overlap-retry scenario is the one this guard exists for:
+      //
+      //   1. handle(req) — call A creates controllerA, puts it in
+      //      inFlight[req], suspends at proxy.send.
+      //   2. cancel(req) — aborts controllerA, removes the entry
+      //      from inFlight, marks req in cancelledRequestIds.
+      //   3. handle(req) — call B clears the marker at the top,
+      //      creates controllerB, puts it in inFlight[req], suspends
+      //      at its own proxy.send.
+      //   4. Call A's proxy.send resolves first (before B's) and A
+      //      begins unwinding. The finally block runs while B's
+      //      controllerB is the live `inFlight` entry. A unconditional
+      //      delete would evict B's entry, and a subsequent cancel(req)
+      //      would find nothing to cancel and silently no-op, leaving
+      //      B uncancellable.
+      //
+      // So: leave `inFlight` alone unless this invocation still owns
+      // it. And leave `cancelledRequestIds` alone when a later
+      // invocation owns the entry — that later invocation's cancel
+      // state belongs to it, not to the unwinding invocation. When
+      // there is no `inFlight` entry at all (cancel() already removed
+      // this invocation's entry and no retry has arrived), prune the
+      // marker so it does not leak into a future handle() that races
+      // the top-of-handle() cleanup.
+      const currentEntry = inFlight.get(requestId);
+      if (currentEntry === ownController) {
+        inFlight.delete(requestId);
+        cancelledRequestIds.delete(requestId);
+      } else if (currentEntry === undefined) {
+        cancelledRequestIds.delete(requestId);
+      }
     }
   }
 

--- a/clients/chrome-extension/background/relay-connection.ts
+++ b/clients/chrome-extension/background/relay-connection.ts
@@ -199,9 +199,30 @@ export class RelayConnection {
    * Swap the connection mode / token without destroying the class
    * instance. The current socket is closed cleanly and a fresh one is
    * opened for the new mode. Used by the popup's mode switcher.
+   *
+   * A mode switch ends the previous lifecycle: any pending deferred
+   * close notification left over from a non-normal ws close on the
+   * old lifecycle is flushed synchronously before the new socket is
+   * constructed, so the caller still sees exactly one onClose per
+   * lifecycle and the stale ctx cannot cross into the new lifecycle
+   * (where a later explicit `close()` would otherwise re-deliver it
+   * with the wrong code/reason).
    */
   setMode(mode: RelayMode): void {
     this.deps = { ...this.deps, mode };
+    // Flush any pending deferred close from the prior lifecycle first.
+    // When the previous socket hit a non-normal close the ws listener
+    // stashed its ctx into `pendingDeferredCloseCtx` and armed the
+    // reconnect-with-refresh timer. Clearing the timer below without
+    // firing the deferred notification would leave the caller with
+    // zero onClose calls for the prior lifecycle, and any subsequent
+    // `close()` on the new lifecycle would re-deliver the old ctx as
+    // if it belonged to the new socket.
+    if (this.pendingDeferredCloseCtx !== null) {
+      const deferred = this.pendingDeferredCloseCtx;
+      this.pendingDeferredCloseCtx = null;
+      this.deps.onClose(deferred.code, deferred.reason);
+    }
     // Tear down the current socket without marking the caller as having
     // closed us permanently — `start()` below re-arms shouldConnect.
     if (this.reconnectTimer !== null) {


### PR DESCRIPTION
## Summary
Closes latent races identified in round-3 review:

- Dispatcher handle() finally block guards inFlight/cancelledRequestIds cleanup on identity, so a cancelled invocation unwinding cannot delete a live retry invocation's entry.
- RelayConnection.setMode() flushes any pending deferred close notification before tearing down the current lifecycle, preventing a stale ctx from crossing lifecycles.
- cancelledRequestIds invariant docstring updated to accurately describe the two pruning sites.

Includes regression tests for the overlap-retry reverse-ordering case and the setMode lifecycle boundary.

Part of plan: browser-use-main-remediation-plan-2026-04-08.md (review round 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24523" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
