### PR TITLE
feat(skills-ui): refresh files after installing from the preview detail view

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillDetailView.swift
@@ -16,6 +16,10 @@ struct SkillDetailView: View {
     @State private var didSeedExpandedPaths: Bool = false
     @State private var skillFileViewMode: FileViewMode = .source
     @State private var browserNodes: [VFileBrowserNode] = []
+    /// Tracks the previously observed `skill.kind` so an install-from-preview
+    /// transition (catalog → installed/bundled) can be detected and drive a
+    /// refresh of the file tree with eagerly-loaded content.
+    @State private var lastObservedKind: String = ""
 
     /// True when the skill is not installed locally, so file contents must be
     /// fetched lazily rather than delivered inline with the file list.
@@ -33,6 +37,7 @@ struct SkillDetailView: View {
         VStack(alignment: .leading, spacing: VSpacing.md) {
             SkillDetailTitleRow(
                 skill: skill,
+                isInstalling: skillsManager.installingSkillId == skill.id,
                 onBack: onBack,
                 onDelete: { onDelete(skill) },
                 onInstall: { skillsManager.installSkill(slug: skill.id) }
@@ -50,7 +55,26 @@ struct SkillDetailView: View {
             skillDetailFileBrowser
         }
         .onAppear {
+            // Seed `lastObservedKind` with the current kind so a later flip
+            // into "installed"/"bundled" is detected as a true transition
+            // rather than as the initial layout for an already-installed skill.
+            lastObservedKind = skill.kind
             skillsManager.fetchSkillFiles(skillId: skill.id)
+        }
+        .onChange(of: skill.kind) { _, newKind in
+            // Detect an install-from-preview transition: when the kind flips
+            // from "catalog" to "installed"/"bundled", the preview file list
+            // (which has nil `content` fields served lazily) is now stale —
+            // the backend now holds eagerly-loaded inline content for this
+            // skill. Drop the lazy content cache and re-fetch so the file
+            // tree transparently swaps in the full content without the user
+            // having to navigate away and back.
+            let becameInstalled = newKind == "installed" || newKind == "bundled"
+            if becameInstalled && lastObservedKind == "catalog" {
+                skillsManager.clearLoadedFileContents()
+                skillsManager.fetchSkillFiles(skillId: skill.id)
+            }
+            lastObservedKind = newKind
         }
         .onChange(of: skillsManager.selectedSkillFiles?.files.map(\.path)) {
             // 1. Rebuild the browser node tree from the latest file list (moved out of
@@ -126,6 +150,7 @@ struct SkillDetailView: View {
             expandedPaths = []
             didSeedExpandedPaths = false
             browserNodes = []
+            lastObservedKind = ""
             skillsManager.clearSkillDetail()
         }
     }
@@ -370,6 +395,7 @@ struct SkillDetailView: View {
 
 struct SkillDetailTitleRow: View {
     let skill: SkillInfo
+    var isInstalling: Bool = false
     let onBack: () -> Void
     let onDelete: () -> Void
     let onInstall: () -> Void
@@ -410,8 +436,13 @@ struct SkillDetailTitleRow: View {
                     onDelete()
                 }
             } else if skill.kind == "catalog" {
-                VButton(label: "Install", leftIcon: VIcon.arrowDownToLine.rawValue, style: .primary) {
-                    onInstall()
+                if isInstalling {
+                    VLoadingIndicator()
+                        .accessibilityLabel("Installing skill")
+                } else {
+                    VButton(label: "Install", leftIcon: VIcon.arrowDownToLine.rawValue, style: .primary) {
+                        onInstall()
+                    }
                 }
             }
         }

--- a/clients/shared/Tests/SkillsFileContentTests.swift
+++ b/clients/shared/Tests/SkillsFileContentTests.swift
@@ -43,6 +43,12 @@ private actor MockSkillsFileContentStore {
     private var continuations: [String: [CheckedContinuation<SkillFileContentResponse?, Never>]] = [:]
     private var blockingPaths: Set<String> = []
 
+    /// Ordered log of `fetchSkillFiles(skillId:)` calls issued through the
+    /// mock client. Tests use this to assert that the store reissues a
+    /// same-skill re-fetch (e.g. during the install-from-preview transition)
+    /// rather than short-circuiting when `currentFilesSkillId` is unchanged.
+    private(set) var fetchSkillFilesRequests: [String] = []
+
     func setResponse(for path: String, _ response: SkillFileContentResponse?) {
         if let response {
             fileContentResponses[path] = response
@@ -57,6 +63,14 @@ private actor MockSkillsFileContentStore {
 
     func record(skillId: String, path: String) {
         requestedPaths.append((skillId: skillId, path: path))
+    }
+
+    func recordFetchSkillFiles(skillId: String) {
+        fetchSkillFilesRequests.append(skillId)
+    }
+
+    func fetchSkillFilesCount() -> Int {
+        fetchSkillFilesRequests.count
     }
 
     func awaitResponse(skillId: String, path: String) async -> SkillFileContentResponse? {
@@ -105,9 +119,12 @@ private struct MockSkillsClient: SkillsClientProtocol {
     func createSkill(skillId: String, name: String, description: String, emoji: String?, bodyMarkdown: String, overwrite: Bool?) async -> SkillOperationResult? { nil }
     func fetchSkillDetail(skillId: String) async -> SkillDetailHTTPResponse? { nil }
     func fetchSkillFiles(skillId: String) async -> SkillDetailFilesHTTPResponse? {
-        // Tests drive `currentFilesSkillId` via `fetchSkillFiles`; the response
-        // body itself is irrelevant to the loadSkillFileContent code paths.
-        nil
+        // Tests drive `currentFilesSkillId` via `fetchSkillFiles` and count
+        // how many times it is reissued (e.g. for the install-from-preview
+        // re-fetch path); the response body itself is irrelevant to the
+        // loadSkillFileContent code paths.
+        await backing.recordFetchSkillFiles(skillId: skillId)
+        return nil
     }
 
     func fetchSkillFileContent(skillId: String, path: String) async -> SkillFileContentResponse? {
@@ -364,6 +381,37 @@ final class SkillsFileContentStoreTests: XCTestCase {
 
         XCTAssertEqual(store.loadedFileContents["docs/readme.md"], "yay")
         XCTAssertNil(store.fileContentErrors["docs/readme.md"])
+    }
+
+    func testFetchSkillFilesReIssuesRequestForSameSkillId() async throws {
+        // Regression coverage for the install-from-preview transition. When
+        // the detail view re-calls `fetchSkillFiles(skillId:)` for the same
+        // skill (because an install just flipped `skill.kind` from
+        // "catalog" to "installed"/"bundled"), the store must reissue the
+        // request rather than short-circuiting on a `currentFilesSkillId`
+        // match. Otherwise the right pane of the detail view is stuck
+        // showing the lazy/null-content preview payload with no inline
+        // content.
+        let backing = MockSkillsFileContentStore()
+        let mock = MockSkillsClient(backing: backing)
+        let store = SkillsStore(skillsClient: mock)
+
+        store.fetchSkillFiles(skillId: "my-skill")
+        try await waitUntilAsync(timeout: 1.0) {
+            await backing.fetchSkillFilesCount() >= 1
+        }
+
+        store.fetchSkillFiles(skillId: "my-skill")
+        try await waitUntilAsync(timeout: 1.0) {
+            await backing.fetchSkillFilesCount() >= 2
+        }
+
+        let totalRequests = await backing.fetchSkillFilesCount()
+        XCTAssertEqual(
+            totalRequests,
+            2,
+            "Same-skill re-fetch must reissue the request so install-from-preview can replace lazy content"
+        )
     }
 
     func testClearLoadedFileContentsCancelsTasksAndClearsState() async throws {


### PR DESCRIPTION
## Summary
- Detect the install-from-preview transition in `SkillDetailView` by observing `skill.kind`: when it flips from `catalog` to `installed`/`bundled`, clear the lazy file-content cache and re-fetch files so the tree populates with eager inline content without the user having to navigate away.
- Show a loading spinner on the Install button while install is in progress, matching the pattern used by the available-skill row.
- Fixes the gap flagged on the previous preview PR: the right pane no longer degrades to an empty state after install.

## Manual verification
- [ ] Open an uninstalled catalog skill → file tree shows.
- [ ] Click "Install" → spinner replaces the Install button.
- [ ] After install completes, Install → Remove and content refreshes in place.

Part of plan: skill-files-preview.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24524" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
