### PR TITLE
fix(skills): address daemon-side self-review gaps in skill-files-preview

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -6776,7 +6776,9 @@ paths:
                   name:
                     type: string
                   size:
-                    type: number
+                    type: integer
+                    minimum: -9007199254740991
+                    maximum: 9007199254740991
                   mimeType:
                     type: string
                   isBinary:

--- a/assistant/src/__tests__/skills-files-catalog-fallback.test.ts
+++ b/assistant/src/__tests__/skills-files-catalog-fallback.test.ts
@@ -2,16 +2,19 @@
  * Tests for `getSkillFiles` catalog fallback.
  *
  * When a skill id isn't resolvable via `findSkillById` (i.e. not installed
- * locally, not bundled, not a managed skill) or the on-disk directory is
- * missing, `getSkillFiles` now falls back to the Vellum catalog via
- * `readCatalogSkillFiles`. Catalog fallback entries carry `content: null`
- * because the catalog-files helper defers content fetching to a follow-up
- * per-file endpoint.
+ * locally, not bundled, not a managed skill), `getSkillFiles` falls back to
+ * the Vellum catalog via `readCatalogSkillFiles`. Catalog fallback entries
+ * carry `content: null` because the catalog-files helper defers content
+ * fetching to a follow-up per-file endpoint. When a skill IS resolved by
+ * `findSkillById` but its on-disk directory is missing, `getSkillFiles`
+ * returns a 404 without falling through to the catalog so the listing and
+ * detail responses agree on `isInstalled`.
  *
  * Coverage:
  *   - Uninstalled catalog skill: returns `{ skill: catalog/vellum/available, files }` with `content: null` for every entry.
  *   - Neither installed nor in catalog: returns 404.
- *   - Installed skill: preserves the existing disk-read behavior with inline `content`.
+ *   - Installed skill: preserves the disk-read behavior with inline `content`.
+ *   - Installed skill with missing directory: returns 404 without consulting the catalog.
  *   - `catalogSkillToSlim` mapping: `metadata.vellum["display-name"]` wins over `cs.name`.
  */
 
@@ -344,6 +347,59 @@ describe("getSkillFiles — catalog fallback", () => {
     } finally {
       rmSync(workspaceRoot, { recursive: true, force: true });
     }
+  });
+
+  test("returns 404 without catalog fallback when installed skill directory is missing on disk", async () => {
+    // `findSkillById` resolves the skill (resolver lists it as installed)
+    // but the on-disk directoryPath does not exist — simulates a corrupted
+    // install, mid-delete race, or external unmount. The handler must
+    // return 404 so the listing response (`kind: "installed"`) and the
+    // detail response stay consistent; falling through to the catalog
+    // would flip the detail to `kind: "catalog"` and break the
+    // client-side `isInstalled` contract.
+    mockResolvedStates = [
+      {
+        summary: makeSummary({
+          id: "ghost-installed",
+          name: "ghost-installed",
+          displayName: "Ghost Installed",
+          description: "Installed in resolver but directory is gone",
+          directoryPath: "/tmp/definitely-does-not-exist-" + Date.now(),
+          source: "workspace",
+        }),
+        state: "enabled",
+      },
+    ];
+    // Even if the same id is present in the catalog, the handler must NOT
+    // fall through — return 404 instead to avoid masking the missing
+    // install directory with a catalog response.
+    mockCatalog = [
+      {
+        id: "ghost-installed",
+        name: "ghost-installed",
+        description: "Also present in catalog",
+      },
+    ];
+    mockCatalogFiles = [
+      {
+        path: "SKILL.md",
+        name: "SKILL.md",
+        size: 10,
+        mimeType: "",
+        isBinary: false,
+        content: null,
+      },
+    ];
+
+    const result = await getSkillFiles("ghost-installed", dummyCtx);
+
+    expect("error" in result).toBe(true);
+    if (!("error" in result)) return;
+    expect(result.status).toBe(404);
+    expect(result.error).toContain("ghost-installed");
+    expect(result.error).toContain("directory missing");
+    // Catalog fallback must not have been consulted.
+    expect(catalogFilesCalls).toEqual([]);
   });
 
   test("catalogSkillToSlim falls back to cs.name when metadata.vellum.display-name is absent", async () => {

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -31,7 +31,10 @@ import {
   getConfiguredProvider,
   userMessage,
 } from "../../providers/provider-send-message.js";
-import { isTextMimeType as isTextMime } from "../../runtime/routes/workspace-utils.js";
+import {
+  isTextMimeType as isTextMime,
+  MAX_INLINE_TEXT_SIZE,
+} from "../../runtime/routes/workspace-utils.js";
 import { getCatalog } from "../../skills/catalog-cache.js";
 import {
   hasHiddenOrSkippedSegment,
@@ -82,10 +85,6 @@ import {
   type HandlerContext,
   log,
 } from "./shared.js";
-
-// ─── MIME detection helpers ───────────────────────────────────────────────────
-
-const MAX_INLINE_SIZE = 2 * 1024 * 1024; // 2 MB
 
 // ─── Shared context for standalone functions ─────────────────────────────────
 
@@ -548,7 +547,7 @@ function readDirRecursive(dir: string, rootDir: string): SkillFileEntry[] {
       const mimeType = Bun.file(fullPath).type;
       const isText = isTextMime(mimeType, dirent.name);
       let content: string | null = null;
-      if (isText && stat.size <= MAX_INLINE_SIZE) {
+      if (isText && stat.size <= MAX_INLINE_TEXT_SIZE) {
         content = readFileSync(fullPath, "utf-8");
       }
       entries.push({
@@ -674,7 +673,7 @@ export async function getSkillFileContent(
     const isText = isTextMime(mimeType, name);
     const isBinary = !isText;
     let content: string | null = null;
-    if (isText && stat.size <= MAX_INLINE_SIZE) {
+    if (isText && stat.size <= MAX_INLINE_TEXT_SIZE) {
       try {
         content = readFileSync(abs, "utf-8");
       } catch {
@@ -728,18 +727,29 @@ export async function getSkillFiles(
 > {
   // Preferred path: the skill is resolved locally (bundled, managed,
   // workspace, or extra) AND its directory exists on disk. Read files
-  // eagerly with inline content exactly as before.
+  // eagerly with inline content.
   const found = findSkillById(skillId);
-  if (found && existsSync(found.summary.directoryPath)) {
-    const dirPath = found.summary.directoryPath;
-    const files = readDirRecursive(dirPath, dirPath);
-    files.sort((a, b) => a.path.localeCompare(b.path));
-    return { skill: found.item, files };
+  if (found) {
+    if (existsSync(found.summary.directoryPath)) {
+      const dirPath = found.summary.directoryPath;
+      const files = readDirRecursive(dirPath, dirPath);
+      files.sort((a, b) => a.path.localeCompare(b.path));
+      return { skill: found.item, files };
+    }
+    // Resolver lists the skill as installed but the directory is missing
+    // on disk (corrupted install, mid-delete race, external unmount, etc.).
+    // Return a distinct 404 instead of falling through to the catalog path
+    // so the detail response stays consistent with `listSkillsWithCatalog`,
+    // which classifies the same id as `kind: "installed"`.
+    return {
+      error: `Skill directory missing for "${skillId}"`,
+      status: 404,
+    };
   }
 
-  // Fallback: skill is not installed (or its directory is missing). Try
-  // the Vellum catalog — this covers previewing files for an uninstalled
-  // catalog skill without touching the install flow.
+  // Fallback: skill is not installed. Try the Vellum catalog — this covers
+  // previewing files for an uninstalled catalog skill without touching the
+  // install flow.
   let catalog: CatalogSkill[];
   try {
     catalog = await getCatalog();

--- a/assistant/src/runtime/routes/skills-routes.ts
+++ b/assistant/src/runtime/routes/skills-routes.ts
@@ -152,8 +152,8 @@ export function skillRouteDefinitions(deps: SkillRouteDeps): RouteDefinition[] {
       },
     },
 
-    // Registered BEFORE `skills/:id/files` so the more-specific pattern is
-    // matched first even if the router's matching rule ever changes.
+    // The router uses strict anchored-regex matching, so this route is never
+    // ambiguous with skills/:id/files.
     {
       endpoint: "skills/:id/files/content",
       method: "GET",
@@ -173,7 +173,7 @@ export function skillRouteDefinitions(deps: SkillRouteDeps): RouteDefinition[] {
       responseBody: z.object({
         path: z.string(),
         name: z.string(),
-        size: z.number(),
+        size: z.number().int(),
         mimeType: z.string(),
         isBinary: z.boolean(),
         content: z.string().nullable(),

--- a/assistant/src/skills/catalog-files.ts
+++ b/assistant/src/skills/catalog-files.ts
@@ -29,15 +29,16 @@ import {
 import { basename, join, posix, sep } from "node:path";
 
 import { getPlatformBaseUrl } from "../config/env.js";
-import { isTextMimeType as isTextMime } from "../runtime/routes/workspace-utils.js";
+import {
+  isTextMimeType as isTextMime,
+  MAX_INLINE_TEXT_SIZE,
+} from "../runtime/routes/workspace-utils.js";
 import { getLogger } from "../util/logger.js";
 import { readPlatformToken } from "../util/platform.js";
 import { getCatalog } from "./catalog-cache.js";
 import { getRepoSkillsDir } from "./catalog-install.js";
 
 const log = getLogger("catalog-files");
-
-const MAX_INLINE_SIZE = 2 * 1024 * 1024; // 2 MB
 
 /**
  * Classify a file as text/binary from its name alone. Used by the preview
@@ -387,7 +388,7 @@ export async function readCatalogSkillFiles(
  *
  * Returns `null` if the skill is missing from the catalog, the path fails
  * sanitization, the underlying source rejects the request, or the file does
- * not exist. In dev mode, text files up to `MAX_INLINE_SIZE` are returned
+ * not exist. In dev mode, text files up to `MAX_INLINE_TEXT_SIZE` are returned
  * with their UTF-8 content inline; anything larger or flagged as binary
  * returns with `content === null`. In platform mode, the server enforces
  * the same contract and we pass its response through unchanged.
@@ -457,7 +458,7 @@ export async function readCatalogSkillFileContent(
     const mimeType = Bun.file(abs).type;
     const isBinary = !isTextMime(mimeType, name);
     let content: string | null = null;
-    if (!isBinary && stat.size <= MAX_INLINE_SIZE) {
+    if (!isBinary && stat.size <= MAX_INLINE_TEXT_SIZE) {
       try {
         content = readFileSync(abs, "utf-8");
       } catch {


### PR DESCRIPTION
## Summary
Batch fixes from self-review of the skill-files-preview plan:

- Consolidate the 2 MB inline-text budget to the canonical `MAX_INLINE_TEXT_SIZE` export in `workspace-utils.ts` and remove the two duplicated constants in `skills.ts` and `catalog-files.ts`.
- Type the `size` field in the `skills/:id/files/content` response as `z.number().int()` so the generated OpenAPI spec emits `type: integer`; regenerate `openapi.yaml`.
- Return 404 when `getSkillFiles` finds a skill whose install directory is missing on disk, so the daemon's listing and detail responses agree on `isInstalled`. Add a regression test.
- Replace the misleading route-ordering comment with a description of the router's actual matching behavior.

Part of plan: skill-files-preview.md (self-review round 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24535" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
