### PR TITLE
fix(skills-ui): address self-review gaps in preview + install-from-preview flow

### DIFF
--- a/clients/ios/Views/Intelligence/SkillDetailView.swift
+++ b/clients/ios/Views/Intelligence/SkillDetailView.swift
@@ -114,9 +114,8 @@ struct SkillDetailView: View {
         .navigationTitle(skill.name)
         .navigationBarTitleDisplayMode(.inline)
         .task {
-            // Only fetch detail and files for locally available skills (bundled or installed).
-            // Remote catalog search results are not in the local resolved catalog, so
-            // GET /skills/:id and GET /skills/:id/files would 404 for them.
+            // iOS does not yet surface catalog previews; file and detail
+            // fetches are gated on locally-installed skills.
             if skill.isInstalled {
                 skillsStore.fetchSkillDetail(skillId: skill.id)
                 skillsStore.fetchSkillFiles(skillId: skill.id)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -95,13 +95,22 @@ struct AgentPanelContent: View {
         .onChange(of: skillsManager.skills.map(\.id)) {
             onSkillsChanged?()
             if let selectedId = selectedSkillId,
+               skillsManager.installingSkillId != selectedId,
                !skillsManager.skills.contains(where: { $0.id == selectedId }) {
                 selectedSkillId = nil
             }
         }
         .onChange(of: skillsManager.filteredSkills.map(\.id)) {
+            // Preserve the detail selection across post-install refreshes:
+            // after an install, the skill's status flips from "available"
+            // to "enabled", which may remove it from the active
+            // `filteredSkills` (e.g. under the `.available` filter). The
+            // detail view still needs the skill to render its content, so
+            // we only clear the selection when the skill is truly gone
+            // from the unfiltered `skills` list (and not mid-install).
             if let selectedId = selectedSkillId,
-               !skillsManager.filteredSkills.contains(where: { $0.id == selectedId }) {
+               skillsManager.installingSkillId != selectedId,
+               !skillsManager.skills.contains(where: { $0.id == selectedId }) {
                 selectedSkillId = nil
             }
         }
@@ -228,8 +237,14 @@ struct AgentPanelContent: View {
 
     @ViewBuilder
     private var contentView: some View {
+        // Fall back to the unfiltered `skills` list so a detail view that
+        // would otherwise be hidden by the active filter (e.g. a just-
+        // installed skill viewed under the `.available` filter) still
+        // renders. Pair with `.id(skill.id)` so SwiftUI creates a fresh
+        // view instance when the selected skill changes.
         if let selectedId = selectedSkillId,
-           let skill = skillsManager.filteredSkills.first(where: { $0.id == selectedId }) {
+           let skill = skillsManager.filteredSkills.first(where: { $0.id == selectedId })
+            ?? skillsManager.skills.first(where: { $0.id == selectedId }) {
             SkillDetailView(
                 skill: skill,
                 skillsManager: skillsManager,
@@ -242,6 +257,7 @@ struct AgentPanelContent: View {
                     skillToDelete = skill
                 }
             )
+            .id(skill.id)
         } else if skillsManager.isLoading && skillsManager.baseSkillsEmpty {
             VStack {
                 Spacer()
@@ -395,5 +411,10 @@ struct AvailableSkillItemRow: View {
                 }
             }
         }
+        .accessibilityElement(children: .combine)
+        .accessibilityAddTraits(.isButton)
+        .accessibilityLabel("\(skill.name). \(skill.description)")
+        .accessibilityAction { onSelect() }
+        .accessibilityAction(named: "Install") { onInstall() }
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillDetailView.swift
@@ -76,11 +76,14 @@ struct SkillDetailView: View {
             }
             lastObservedKind = newKind
         }
-        .onChange(of: skillsManager.selectedSkillFiles?.files.map(\.path)) {
+        .onChange(of: skillsManager.selectedSkillFiles?.files.map { "\($0.path):\($0.content == nil)" }) {
             // 1. Rebuild the browser node tree from the latest file list (moved out of
             //    view body per clients/AGENTS.md: no heavy transformation in body).
             //    In preview mode the `content` field is always nil — files are
             //    fetched lazily on click — so the tree filter must tolerate that.
+            //    The key includes each file's content-nullness so the rebuild
+            //    fires after an install-from-preview refresh, where the path
+            //    list is unchanged but content transitions from null to inline.
             let textFiles: [SkillFileEntry]
             if let files = skillsManager.selectedSkillFiles?.files {
                 textFiles = files.filter { file in

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
@@ -50,6 +50,12 @@ final class SkillsManager {
     var fileContentErrors: [String: String] = [:]
     var installingSkillId: String?
 
+    /// Safety timeout that defensively clears `installingSkillId` if a
+    /// wedged `fetchSkills(force:)` response never lands. Without it, the
+    /// install spinner can be stuck indefinitely when the confirmation
+    /// refresh path is blocked or delayed.
+    @ObservationIgnored private var installWatchdogTask: Task<Void, Never>?
+
     // MARK: - Filter Inputs
 
     var searchQuery: String = "" {
@@ -113,7 +119,25 @@ final class SkillsManager {
                 self.fileContentErrors = self.skillsStore.fileContentErrors
                 if let result = self.skillsStore.installResult,
                    result.slug == self.installingSkillId {
-                    self.installingSkillId = nil
+                    if !result.success {
+                        // Failure: release the spinner immediately so the
+                        // Install button returns and the user can retry.
+                        self.installingSkillId = nil
+                        self.installWatchdogTask?.cancel()
+                        self.installWatchdogTask = nil
+                    } else if self.skillsStore.skills
+                        .first(where: { $0.id == result.slug })?.kind != "catalog" {
+                        // Success confirmed: the refreshed skills list has
+                        // flipped the kind away from "catalog", so the
+                        // detail view will render the installed UI on the
+                        // next body pass without flicker.
+                        self.installingSkillId = nil
+                        self.installWatchdogTask?.cancel()
+                        self.installWatchdogTask = nil
+                    }
+                    // Otherwise: keep the spinner up until fetchSkills(force:)
+                    // lands — see `installSkill(slug:)` for the watchdog that
+                    // clears the spinner defensively if the refresh wedges.
                 }
                 self.recomputeFilteredData()
             }
@@ -241,6 +265,20 @@ final class SkillsManager {
     func installSkill(slug: String) {
         installingSkillId = slug
         skillsStore.installSkill(slug: slug)
+
+        // Defensive watchdog: a wedged `fetchSkills(force:)` response
+        // after install would otherwise leave the spinner stuck forever.
+        // Clear `installingSkillId` after 15 seconds if the confirmation
+        // path has not already cleared it.
+        installWatchdogTask?.cancel()
+        installWatchdogTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: 15_000_000_000)
+            guard !Task.isCancelled else { return }
+            guard let self else { return }
+            if self.installingSkillId == slug {
+                self.installingSkillId = nil
+            }
+        }
     }
 
     func fetchSkillFiles(skillId: String) {

--- a/clients/shared/Features/Skills/SkillsStore.swift
+++ b/clients/shared/Features/Skills/SkillsStore.swift
@@ -356,26 +356,36 @@ public final class SkillsStore: ObservableObject {
     // MARK: - Lazy File Content
 
     public func loadSkillFileContent(skillId: String, path: String) {
-        // Cancel any in-flight task for the same path so a second click replaces the first.
+        // Cancel any in-flight task for the same path so a second click
+        // replaces the first. The task body mirrors the structure of
+        // `fetchSkillDetail`/`fetchSkillFiles` above: a single
+        // `Task.isCancelled` check gates every state mutation, and the
+        // `SkillsStore` actor isolation (`@MainActor`) removes the need
+        // for an explicit `MainActor.run` hop.
         fileContentTasks[path]?.cancel()
         loadingFilePaths.insert(path)
         fileContentErrors[path] = nil
 
-        let task = Task { [weak self] in
-            guard let self else { return }
+        let task = Task {
             let result = await self.skillsClient.fetchSkillFileContent(skillId: skillId, path: path)
             guard !Task.isCancelled else { return }
-            await MainActor.run {
-                guard self.currentFilesSkillId == skillId else { return }
-                self.loadingFilePaths.remove(path)
-                if let result, let content = result.content {
-                    self.loadedFileContents[path] = content
-                } else if let result, result.content == nil, result.isBinary {
-                    // Binary file — no preview available is expected, not an error.
-                    self.loadedFileContents.removeValue(forKey: path)
-                } else {
-                    self.fileContentErrors[path] = "Failed to load file content"
-                }
+            guard self.currentFilesSkillId == skillId else { return }
+
+            self.loadingFilePaths.remove(path)
+            if let result, let content = result.content {
+                self.loadedFileContents[path] = content
+            } else if let result, result.isBinary {
+                // Binary file: no preview available is expected, not an error.
+                self.loadedFileContents.removeValue(forKey: path)
+            } else if let result, result.content == nil {
+                // Oversized text file: the daemon returns `content: null`
+                // for text files above the inline-content size threshold.
+                // Treat this as "no preview available" rather than an
+                // error — the detail view falls through to its existing
+                // "Select a file to view" empty state.
+                self.loadedFileContents.removeValue(forKey: path)
+            } else {
+                self.fileContentErrors[path] = "Failed to load file content"
             }
         }
         fileContentTasks[path] = task


### PR DESCRIPTION
## Summary
Batch fixes from self-review of the skill-files-preview plan:

- **AgentPanel**: preserve `selectedSkillId` across install when the skill is mid-install or still in the unfiltered skills list; fall back to the full skills list in `contentView` so an installed skill stays visible even when filtered out.
- **SkillDetailView**: add `.id(skill.id)` at the call site so view identity tracks the selected skill; rebuild browser tree on post-install content transitions by keying onChange on path + content-nullness.
- **SkillsStore**: align `loadSkillFileContent` with `fetchSkillDetail`/`fetchSkillFiles` conventions — drop the redundant `MainActor.run` hop and close the cancellation race; treat oversized-text responses as 'no preview' rather than errors.
- **SkillsManager**: defer `installingSkillId` reset until the skills list actually reflects the transition, with a safety timeout to avoid a wedged spinner.
- **AvailableSkillItemRow**: add accessibility modifiers so the tappable row is reachable via VoiceOver, matching sibling row conventions.
- **iOS SkillDetailView**: refresh stale comment to reflect the current catalog-aware fetch behavior.

Part of plan: skill-files-preview.md (self-review round 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24536" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
