### PR TITLE
fix(macos/chat): invalidate transcript cache on in-place message edits

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -309,6 +309,7 @@ struct ChatView: View {
             MessageListView(
                 // -- TranscriptProjector inputs --
                 messages: viewModel.messages,
+                messagesRevision: viewModel.messagesRevision,
                 isSending: viewModel.isSending,
                 isThinking: viewModel.isThinking,
                 isCompacting: viewModel.isCompacting,

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -279,29 +279,9 @@ final class MessageListScrollState {
         set { derivedStateCache.messageListVersion = newValue }
     }
 
-    @ObservationIgnored var lastKnownRawMessageCount: Int {
-        get { derivedStateCache.lastKnownRawMessageCount }
-        set { derivedStateCache.lastKnownRawMessageCount = newValue }
-    }
-
-    @ObservationIgnored var lastKnownVisibleMessageCount: Int {
-        get { derivedStateCache.lastKnownVisibleMessageCount }
-        set { derivedStateCache.lastKnownVisibleMessageCount = newValue }
-    }
-
-    @ObservationIgnored var lastKnownLastMessageStreaming: Bool {
-        get { derivedStateCache.lastKnownLastMessageStreaming }
-        set { derivedStateCache.lastKnownLastMessageStreaming = newValue }
-    }
-
-    @ObservationIgnored var lastKnownIncompleteToolCallCount: Int {
-        get { derivedStateCache.lastKnownIncompleteToolCallCount }
-        set { derivedStateCache.lastKnownIncompleteToolCallCount = newValue }
-    }
-
-    @ObservationIgnored var lastKnownVisibleIdFingerprint: Int {
-        get { derivedStateCache.lastKnownVisibleIdFingerprint }
-        set { derivedStateCache.lastKnownVisibleIdFingerprint = newValue }
+    @ObservationIgnored var lastKnownMessagesRevision: UInt64 {
+        get { derivedStateCache.lastKnownMessagesRevision }
+        set { derivedStateCache.lastKnownMessagesRevision = newValue }
     }
 
     @ObservationIgnored var cachedFirstVisibleMessageId: UUID? {

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListTypes.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListTypes.swift
@@ -150,12 +150,7 @@ final class ProjectionCache {
     var cachedProjectionKey: PrecomputedCacheKey?
     var cachedProjection: TranscriptRenderModel?
     var messageListVersion = 0
-    var lastKnownRawMessageCount = 0
-    var lastKnownVisibleMessageCount = 0
-    var lastKnownLastMessageStreaming = false
-    var lastKnownIncompleteToolCallCount = 0
-    var lastKnownVisibleIdFingerprint = 0
-    var lastKnownTextFingerprint = 0
+    var lastKnownMessagesRevision: UInt64 = 0
     var cachedFirstVisibleMessageId: UUID?
     var bodyEvalTimestamps: [CFAbsoluteTime] = []
     var isThrottled = false
@@ -165,12 +160,7 @@ final class ProjectionCache {
         cachedProjectionKey = nil
         cachedProjection = nil
         messageListVersion = 0
-        lastKnownRawMessageCount = 0
-        lastKnownVisibleMessageCount = 0
-        lastKnownLastMessageStreaming = false
-        lastKnownIncompleteToolCallCount = 0
-        lastKnownVisibleIdFingerprint = 0
-        lastKnownTextFingerprint = 0
+        lastKnownMessagesRevision = 0
         cachedFirstVisibleMessageId = nil
         bodyEvalTimestamps.removeAll()
         throttleRecoveryTask?.cancel()

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+DerivedState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+DerivedState.swift
@@ -20,69 +20,14 @@ extension MessageListView {
 
     // MARK: - Version tracking
 
-    /// Checks whether observable message-level inputs have changed since the
-    /// last body evaluation and, if so, bumps `scrollState.messageListVersion`.
-    /// Over-invalidation is safe (triggers a recompute); under-invalidation
-    /// is not.
-    ///
-    /// Tracks both the raw `messages.count` (catches new arrivals and
-    /// paginated-window shifts at fixed length) and the filtered
-    /// `visibleMessages.count` (catches hidden/subagent visibility
-    /// transitions). All checks are O(1). `isSending` / `isThinking`
-    /// transitions are handled via `PrecomputedCacheKey` fields directly.
-    func refreshMessageListVersionIfNeeded(visibleMessages: [ChatMessage]) {
+    /// Checks whether the shared message model has published a new snapshot
+    /// since the last body evaluation and, if so, bumps the projection cache
+    /// version. This exact signal covers content-only edits to an already-
+    /// streaming message, which count/ID heuristics can miss.
+    func refreshMessageListVersionIfNeeded(messagesRevision: UInt64) {
         let cache = scrollState.derivedStateCache
-        let currentRawCount = messages.count
-        let currentVisibleCount = visibleMessages.count
-        let currentLastStreaming = visibleMessages.last?.isStreaming ?? false
-        let currentIncompleteToolCalls = visibleMessages.last?.toolCalls.filter { !$0.isComplete }.count ?? 0
-
-        // O(n) hash of visible message IDs — catches "same count, different
-        // IDs" scenarios (e.g. mid-array swaps during streaming or pagination).
-        var idHasher = Hasher()
-        for msg in visibleMessages { idHasher.combine(msg.id) }
-        let currentIdFingerprint = idHasher.finalize()
-
-        var changed = false
-
-        if currentRawCount != cache.lastKnownRawMessageCount {
-            cache.lastKnownRawMessageCount = currentRawCount
-            changed = true
-        }
-        if currentVisibleCount != cache.lastKnownVisibleMessageCount {
-            cache.lastKnownVisibleMessageCount = currentVisibleCount
-            changed = true
-        }
-        if currentLastStreaming != cache.lastKnownLastMessageStreaming {
-            cache.lastKnownLastMessageStreaming = currentLastStreaming
-            changed = true
-        }
-        if currentIncompleteToolCalls != cache.lastKnownIncompleteToolCallCount {
-            cache.lastKnownIncompleteToolCallCount = currentIncompleteToolCalls
-            changed = true
-        }
-        if currentIdFingerprint != cache.lastKnownVisibleIdFingerprint {
-            cache.lastKnownVisibleIdFingerprint = currentIdFingerprint
-            changed = true
-        }
-
-        // O(1) text content fingerprint — segment count + last segment byte length.
-        // Busts cache on every streaming flush (~50ms) without scanning all text.
-        let currentTextFingerprint: Int = {
-            guard let last = visibleMessages.last else { return 0 }
-            let segCount = last.textSegments.count
-            let lastLen = last.textSegments.last?.utf8.count ?? 0
-            let thinkSegCount = last.thinkingSegments.count
-            let thinkLastLen = last.thinkingSegments.last?.utf8.count ?? 0
-            let toolCallsRev = last.toolCallsRevision
-            return segCount &* 1_000_003 &+ lastLen &* 101 &+ thinkSegCount &* 11 &+ thinkLastLen &* 7 &+ toolCallsRev
-        }()
-        if currentTextFingerprint != cache.lastKnownTextFingerprint {
-            cache.lastKnownTextFingerprint = currentTextFingerprint
-            changed = true
-        }
-
-        if changed {
+        if messagesRevision != cache.lastKnownMessagesRevision {
+            cache.lastKnownMessagesRevision = messagesRevision
             cache.messageListVersion += 1
         }
     }
@@ -127,7 +72,7 @@ extension MessageListView {
         // both operate on the same filtered set.
         let liveMessages = visibleMessages
         cache.cachedFirstVisibleMessageId = liveMessages.first?.id
-        refreshMessageListVersionIfNeeded(visibleMessages: liveMessages)
+        refreshMessageListVersionIfNeeded(messagesRevision: messagesRevision)
 
         let key = PrecomputedCacheKey(
             messageListVersion: cache.messageListVersion,

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -8,6 +8,7 @@ import VellumAssistantShared
 struct MessageListView: View {
 
     let messages: [ChatMessage]
+    let messagesRevision: UInt64
     let isSending: Bool
     let isThinking: Bool
     let isCompacting: Bool

--- a/clients/macos/vellum-assistantTests/MessageListForkActionTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListForkActionTests.swift
@@ -37,6 +37,7 @@ final class MessageListForkActionTests: XCTestCase {
     ) -> MessageListView {
         MessageListView(
             messages: messages,
+            messagesRevision: 0,
             isSending: false,
             isThinking: false,
             isCompacting: false,

--- a/clients/macos/vellum-assistantTests/MessageListProjectionCacheTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListProjectionCacheTests.swift
@@ -1,0 +1,94 @@
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+@MainActor
+final class MessageListProjectionCacheTests: XCTestCase {
+    func testMessageRevisionInvalidatesProjectionCacheForStreamingTextGrowth() {
+        let messageId = UUID()
+        let sharedScrollState = MessageListScrollState()
+
+        let initialMessage = ChatMessage(
+            id: messageId,
+            role: .assistant,
+            text: "Hello",
+            isStreaming: true
+        )
+        let initialView = makeView(
+            messages: [initialMessage],
+            messagesRevision: 1
+        )
+        initialView.scrollState = sharedScrollState
+
+        let initialProjection = initialView.derivedState
+        XCTAssertEqual(initialProjection.rows.last?.message.text, "Hello")
+        XCTAssertEqual(sharedScrollState.messageListVersion, 1)
+
+        let updatedMessage = ChatMessage(
+            id: messageId,
+            role: .assistant,
+            text: "Hello, world",
+            isStreaming: true
+        )
+        let updatedView = makeView(
+            messages: [updatedMessage],
+            messagesRevision: 2
+        )
+        updatedView.scrollState = sharedScrollState
+
+        let updatedProjection = updatedView.derivedState
+        XCTAssertEqual(updatedProjection.rows.last?.message.text, "Hello, world")
+        XCTAssertEqual(sharedScrollState.messageListVersion, 2)
+    }
+
+    private func makeView(
+        messages: [ChatMessage],
+        messagesRevision: UInt64
+    ) -> MessageListView {
+        MessageListView(
+            messages: messages,
+            messagesRevision: messagesRevision,
+            isSending: true,
+            isThinking: false,
+            isCompacting: false,
+            assistantActivityPhase: "streaming",
+            assistantActivityAnchor: "assistant_turn",
+            assistantActivityReason: nil,
+            assistantStatusText: nil,
+            selectedModel: "",
+            configuredProviders: [],
+            providerCatalog: [],
+            activeSubagents: [],
+            dismissedDocumentSurfaceIds: [],
+            onConfirmationAllow: nil,
+            onConfirmationDeny: nil,
+            onAlwaysAllow: nil,
+            onTemporaryAllow: nil,
+            onSurfaceAction: nil,
+            onGuardianAction: nil,
+            onDismissDocumentWidget: nil,
+            onForkFromMessage: nil,
+            showInspectButton: false,
+            onInspectMessage: nil,
+            mediaEmbedSettings: nil,
+            onAbortSubagent: nil,
+            onSubagentTap: nil,
+            onRehydrateMessage: nil,
+            onSurfaceRefetch: nil,
+            onRetryFailedMessage: nil,
+            onRetryConversationError: nil,
+            subagentDetailStore: SubagentDetailStore(),
+            activePendingRequestId: nil,
+            paginatedVisibleMessages: messages,
+            displayedMessageCount: .max,
+            hasMoreMessages: false,
+            isLoadingMoreMessages: false,
+            loadPreviousMessagePage: nil,
+            conversationId: nil,
+            anchorMessageId: .constant(nil),
+            highlightedMessageId: .constant(nil),
+            isInteractionEnabled: true,
+            containerWidth: 800
+        )
+    }
+}

--- a/clients/macos/vellum-assistantTests/MessageListScrollPerformanceTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListScrollPerformanceTests.swift
@@ -413,11 +413,7 @@ final class MessageListScrollPerformanceTests: XCTestCase {
             highlightedMessageId: nil
         )
         cache.messageListVersion = 42
-        cache.lastKnownRawMessageCount = 50
-        cache.lastKnownVisibleMessageCount = 50
-        cache.lastKnownLastMessageStreaming = true
-        cache.lastKnownIncompleteToolCallCount = 3
-        cache.lastKnownVisibleIdFingerprint = 999
+        cache.lastKnownMessagesRevision = 99
         cache.cachedFirstVisibleMessageId = UUID()
         cache.isThrottled = true
 
@@ -428,11 +424,7 @@ final class MessageListScrollPerformanceTests: XCTestCase {
         XCTAssertNil(cache.cachedProjectionKey)
         XCTAssertNil(cache.cachedProjection)
         XCTAssertEqual(cache.messageListVersion, 0)
-        XCTAssertEqual(cache.lastKnownRawMessageCount, 0)
-        XCTAssertEqual(cache.lastKnownVisibleMessageCount, 0)
-        XCTAssertFalse(cache.lastKnownLastMessageStreaming)
-        XCTAssertEqual(cache.lastKnownIncompleteToolCallCount, 0)
-        XCTAssertEqual(cache.lastKnownVisibleIdFingerprint, 0)
+        XCTAssertEqual(cache.lastKnownMessagesRevision, 0)
         XCTAssertNil(cache.cachedFirstVisibleMessageId)
         XCTAssertFalse(cache.isThrottled)
     }

--- a/clients/macos/vellum-assistantTests/MessageListScrollStateTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListScrollStateTests.swift
@@ -403,20 +403,12 @@ final class MessageListScrollStateTests: XCTestCase {
 
     func testResetClearsLayoutCache() {
         state.messageListVersion = 5
-        state.lastKnownRawMessageCount = 10
-        state.lastKnownVisibleMessageCount = 8
-        state.lastKnownLastMessageStreaming = true
-        state.lastKnownIncompleteToolCallCount = 3
-        state.lastKnownVisibleIdFingerprint = 42
+        state.lastKnownMessagesRevision = 10
 
         state.reset(for: UUID())
 
         XCTAssertEqual(state.messageListVersion, 0)
-        XCTAssertEqual(state.lastKnownRawMessageCount, 0)
-        XCTAssertEqual(state.lastKnownVisibleMessageCount, 0)
-        XCTAssertFalse(state.lastKnownLastMessageStreaming)
-        XCTAssertEqual(state.lastKnownIncompleteToolCallCount, 0)
-        XCTAssertEqual(state.lastKnownVisibleIdFingerprint, 0)
+        XCTAssertEqual(state.lastKnownMessagesRevision, 0)
         XCTAssertNil(state.cachedProjectionKey)
         XCTAssertNil(state.cachedProjection)
     }

--- a/clients/shared/Features/Chat/ChatMessageManager.swift
+++ b/clients/shared/Features/Chat/ChatMessageManager.swift
@@ -50,6 +50,7 @@ public final class ChatMessageManager {
             withMutation(keyPath: \.messages) {
                 _messagesStorage = newValue
             }
+            advanceMessagesRevision()
             _deferredPublishTask?.cancel()
             _deferredPublishTask = nil
             _messagesSubject.send(newValue)
@@ -59,12 +60,22 @@ public final class ChatMessageManager {
             _$observationRegistrar.willSet(self, keyPath: \.messages)
             defer {
                 _$observationRegistrar.didSet(self, keyPath: \.messages)
+                advanceMessagesRevision()
                 scheduleDeferredPublish()
             }
             yield &_messagesStorage
         }
     }
     @ObservationIgnored private var _messagesStorage: [ChatMessage] = []
+
+    /// Monotonically increasing revision for any `messages` mutation.
+    /// Transcript caches use this to invalidate on content-only edits to
+    /// existing messages, not just count or ID changes.
+    public private(set) var messagesRevision: UInt64 = 0
+
+    private func advanceMessagesRevision() {
+        messagesRevision &+= 1
+    }
 
     /// Apply multiple mutations to the message array in a single batch,
     /// emitting only one Observation notification and one Combine publish
@@ -74,6 +85,7 @@ public final class ChatMessageManager {
         withMutation(keyPath: \.messages) {
             body(&_messagesStorage)
         }
+        advanceMessagesRevision()
         // Cancel any pending deferred publish — this synchronous publish
         // supersedes it with the final post-batch snapshot.
         _deferredPublishTask?.cancel()

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -175,6 +175,9 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
         get { messageManager.messages }
         set { messageManager.messages = newValue }
     }
+    public var messagesRevision: UInt64 {
+        messageManager.messagesRevision
+    }
     public var inputText: String {
         get { messageManager.inputText }
         set { messageManager.inputText = newValue }

--- a/clients/shared/Tests/RenderChurnTests.swift
+++ b/clients/shared/Tests/RenderChurnTests.swift
@@ -36,6 +36,22 @@ final class RenderChurnTests: XCTestCase {
         XCTAssertTrue(events[0].content.contains("chunk-9"), "Final chunk should be present in accumulated text")
     }
 
+    // MARK: - ChatMessageManager message revisions
+
+    /// In-place transcript mutations must advance the shared message revision so
+    /// transcript caches invalidate even when message IDs and counts stay the same.
+    func testChatMessageManagerAdvancesRevisionForInPlaceMessageEdits() {
+        let manager = ChatMessageManager()
+
+        XCTAssertEqual(manager.messagesRevision, 0)
+
+        manager.messages.append(ChatMessage(role: .assistant, text: "Hello", isStreaming: true))
+        XCTAssertEqual(manager.messagesRevision, 1)
+
+        manager.messages[0].textSegments[0] += ", world"
+        XCTAssertEqual(manager.messagesRevision, 2)
+    }
+
     // MARK: - stripHeavyContent surface stripping
 
     /// Completed surfaces (non-nil completionState) should have their data replaced


### PR DESCRIPTION
## Summary
- Add a monotonic `messagesRevision` counter on `ChatMessageManager` that advances on every `messages` mutation (setter, in-place `_modify`, batch edits).
- Plumb the revision through `ChatViewModel` → `MessageListView` and use it as the sole signal for bumping `messageListVersion`, replacing the previous pile of count/ID/streaming/tool-call/text-fingerprint heuristics that could miss content-only edits to an already-streaming message.
- Add regression tests: `RenderChurnTests` verifies the revision advances on append + in-place text edit; `MessageListProjectionCacheTests` verifies streaming text growth actually busts the projection cache.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24537" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
