### PR TITLE
feat(macos/chat): make ComposerController @Observable

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerController.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerController.swift
@@ -1,5 +1,6 @@
 #if os(macOS)
 import Foundation
+import Observation
 import VellumAssistantShared
 
 // MARK: - ComposerController
@@ -11,6 +12,7 @@ import VellumAssistantShared
 /// `interactionEnabledChanged`, `dictationStarted`, `dictationStopped`)
 /// instead of reading SwiftUI bindings directly. All popup/focus decisions
 /// live here so they can be unit-tested without importing SwiftUI view types.
+@Observable
 @MainActor
 final class ComposerController {
 
@@ -37,36 +39,36 @@ final class ComposerController {
 
     /// When true, the next text-change cycle skips reopening the slash menu.
     /// Survives exactly one `textChanged` call (user-driven close).
-    private(set) var suppressSlashReopen = false
+    @ObservationIgnored private(set) var suppressSlashReopen = false
     /// When true, the next text-change cycle skips reopening the emoji menu.
     /// Survives exactly one `textChanged` call (user-driven close).
-    private(set) var suppressEmojiReopen = false
+    @ObservationIgnored private(set) var suppressEmojiReopen = false
 
     // MARK: - Internal bookkeeping
 
     /// Snapshot of input text captured when dictation starts, used to restore on cancel.
-    private(set) var preDictationText: String = ""
+    @ObservationIgnored private(set) var preDictationText: String = ""
 
     /// Current cursor position (UTF-16 offset).
-    private var cursorPosition: Int = 0
+    @ObservationIgnored private var cursorPosition: Int = 0
     /// Current input text (kept in sync via events).
-    private var inputText: String = ""
+    @ObservationIgnored private var inputText: String = ""
     /// Whether the composer interaction is enabled.
-    private var isInteractionEnabled: Bool = true
+    @ObservationIgnored private var isInteractionEnabled: Bool = true
 
     // MARK: - Menu refresh scheduling
 
     /// Generation counter for deferred menu-refresh scheduling.
     /// Incremented on every schedule; the deferred block only executes if
     /// its captured generation still matches, superseding stale refreshes.
-    private var menuRefreshGeneration: Int = 0
+    @ObservationIgnored private var menuRefreshGeneration: Int = 0
 
     // MARK: - Dependencies
 
     /// Pluggable slash-command catalog for testability.
-    let slashCommandProvider: SlashCommandProvider
+    @ObservationIgnored let slashCommandProvider: SlashCommandProvider
     /// Pluggable emoji search for testability.
-    let emojiSearchProvider: EmojiSearchProvider
+    @ObservationIgnored let emojiSearchProvider: EmojiSearchProvider
 
     // MARK: - Initialization
 

--- a/clients/macos/vellum-assistantTests/ComposerControllerTests.swift
+++ b/clients/macos/vellum-assistantTests/ComposerControllerTests.swift
@@ -1,4 +1,5 @@
 #if os(macOS)
+import Observation
 import XCTest
 @testable import VellumAssistantLib
 @preconcurrency import VellumAssistantShared
@@ -555,6 +556,31 @@ final class ComposerControllerTests: XCTestCase {
         let selected = controller.selectedEmojiEntry
         XCTAssertNotNil(selected)
         XCTAssertEqual(selected?.shortcode, "thumbsup")
+    }
+
+    @MainActor
+    func testEmojiSelectionNavigationTriggersObservation() {
+        let controller = makeController()
+        let text = ":thumbs"
+        controller.textChanged(text)
+        controller.cursorMoved(to: text.utf16.count)
+        controller.performMenuRefresh()
+
+        let didChangeSelection = expectation(description: "emoji selection change observed")
+        var observedIndex = -1
+
+        withObservationTracking {
+            observedIndex = controller.emojiSelectedIndex
+        } onChange: {
+            didChangeSelection.fulfill()
+        }
+
+        XCTAssertEqual(observedIndex, 0)
+
+        controller.handleEmojiNavigation(.down)
+
+        wait(for: [didChangeSelection], timeout: 1.0)
+        XCTAssertEqual(controller.emojiSelectedIndex, 1)
     }
 
     // MARK: - Emoji popup freeze regression


### PR DESCRIPTION
## Summary
- Annotates \`ComposerController\` with \`@Observable\` so SwiftUI views can react to menu/selection state via the Observation framework
- Marks internal bookkeeping and dependency properties with \`@ObservationIgnored\` to keep observation scoped to the public surface
- Adds a regression test verifying that emoji navigation triggers observation tracking on \`emojiSelectedIndex\`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24538" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
