### PR TITLE
fix(macos/chat): let transcript scroll from the centered gutters

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
@@ -33,7 +33,7 @@ struct MessageListContentView: View, Equatable {
             && lhs.isLoadingMoreMessages == rhs.isLoadingMoreMessages
             && lhs.isCompacting == rhs.isCompacting
             && lhs.isInteractionEnabled == rhs.isInteractionEnabled
-            && lhs.containerWidth == rhs.containerWidth
+            && lhs.layoutMetrics == rhs.layoutMetrics
             && lhs.dismissedDocumentSurfaceIds == rhs.dismissedDocumentSurfaceIds
             && lhs.activeSurfaceId == rhs.activeSurfaceId
             && lhs.highlightedMessageId == rhs.highlightedMessageId
@@ -56,7 +56,7 @@ struct MessageListContentView: View, Equatable {
     let isLoadingMoreMessages: Bool
     let isCompacting: Bool
     let isInteractionEnabled: Bool
-    let containerWidth: CGFloat
+    let layoutMetrics: MessageListLayoutMetrics
     let dismissedDocumentSurfaceIds: Set<String>
     let activeSurfaceId: String?
     let highlightedMessageId: UUID?
@@ -94,9 +94,7 @@ struct MessageListContentView: View, Equatable {
     // MARK: - Thinking indicator helpers
 
     private var effectiveBubbleMaxWidth: CGFloat {
-        containerWidth > 0
-            ? min(VSpacing.chatBubbleMaxWidth, max(containerWidth - 2 * VSpacing.xl, 0))
-            : VSpacing.chatBubbleMaxWidth
+        layoutMetrics.bubbleMaxWidth
     }
 
     @ViewBuilder
@@ -280,8 +278,6 @@ struct MessageListContentView: View, Equatable {
         .transaction { $0.animation = nil }
         .padding(EdgeInsets(top: VSpacing.md, leading: VSpacing.xl,
                             bottom: VSpacing.md, trailing: VSpacing.xl))
-        .environment(\.bubbleMaxWidth, containerWidth > 0
-            ? min(VSpacing.chatBubbleMaxWidth, max(containerWidth - 2 * VSpacing.xl, 0))
-            : VSpacing.chatBubbleMaxWidth)
+        .environment(\.bubbleMaxWidth, layoutMetrics.bubbleMaxWidth)
     }
 }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListLayoutMetrics.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListLayoutMetrics.swift
@@ -1,0 +1,28 @@
+import CoreGraphics
+import VellumAssistantShared
+
+/// Shared width calculations for the chat transcript.
+///
+/// The transcript scroll surface spans the full available pane width so wheel
+/// input works in the gutters, while the rendered chat column stays centered
+/// and capped to the existing max width.
+struct MessageListLayoutMetrics: Equatable {
+    let scrollSurfaceWidth: CGFloat
+    let chatColumnWidth: CGFloat
+    let bubbleMaxWidth: CGFloat
+
+    init(containerWidth: CGFloat) {
+        let scrollSurfaceWidth =
+            (containerWidth.isFinite && containerWidth > 0)
+            ? containerWidth
+            : VSpacing.chatColumnMaxWidth
+        let chatColumnWidth = min(scrollSurfaceWidth, VSpacing.chatColumnMaxWidth)
+
+        self.scrollSurfaceWidth = scrollSurfaceWidth
+        self.chatColumnWidth = chatColumnWidth
+        self.bubbleMaxWidth = min(
+            VSpacing.chatBubbleMaxWidth,
+            max(chatColumnWidth - 2 * VSpacing.xl, 0)
+        )
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -201,8 +201,8 @@ final class MessageListScrollState {
     /// Captures the `assistantActivityPhase` at the moment `isSending` goes false.
     @ObservationIgnored var lastActivityPhaseWhenIdle: String = ""
 
-    /// Last container width that triggered a resize scroll handler.
-    @ObservationIgnored var lastHandledContainerWidth: CGFloat = 0
+    /// Last transcript column width that triggered a resize scroll handler.
+    @ObservationIgnored var lastHandledChatColumnWidth: CGFloat = 0
 
     /// Tracks the last pending confirmation request ID that triggered an
     /// auto-focus handoff.

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+DerivedState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+DerivedState.swift
@@ -155,7 +155,7 @@ extension MessageListView {
             isLoadingMoreMessages: isLoadingMoreMessages,
             isCompacting: isCompacting,
             isInteractionEnabled: isInteractionEnabled,
-            containerWidth: containerWidth,
+            layoutMetrics: layoutMetrics,
             dismissedDocumentSurfaceIds: dismissedDocumentSurfaceIds,
             activeSurfaceId: taskProgressManager.activeSurfaceId,
             highlightedMessageId: highlightedMessageId,

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
@@ -218,16 +218,19 @@ extension MessageListView {
     }
 
     func handleContainerWidthChanged() {
-        guard containerWidth > 0, abs(containerWidth - scrollState.lastHandledContainerWidth) > 2 else { return }
-        // First real measurement (0 → actual width) is not a resize — just
-        // record the width so subsequent changes are detected as real resizes.
-        // This avoids spurious resize stabilization during initial load when
-        // containerWidth starts at 0 (e.g. from @State + .onGeometryChange).
-        guard scrollState.lastHandledContainerWidth > 0 else {
-            scrollState.lastHandledContainerWidth = containerWidth
+        let trackedWidth = layoutMetrics.chatColumnWidth
+        guard containerWidth > 0,
+              abs(trackedWidth - scrollState.lastHandledChatColumnWidth) > 2 else { return }
+        // First real pane measurement (0 → actual width) is not a resize — just
+        // record the transcript column width so subsequent reflows are treated
+        // as real resizes. Once the pane exceeds chatColumnMaxWidth, widening
+        // only the outer gutters leaves trackedWidth unchanged and skips the
+        // resize recovery path entirely.
+        guard scrollState.lastHandledChatColumnWidth > 0 else {
+            scrollState.lastHandledChatColumnWidth = trackedWidth
             return
         }
-        scrollState.lastHandledContainerWidth = containerWidth
+        scrollState.lastHandledChatColumnWidth = trackedWidth
         // Route through coordinator for policy decision.
         let intents = scrollCoordinator.handle(.containerWidthChanged)
         executeCoordinatorIntents(intents)
@@ -285,7 +288,9 @@ extension MessageListView {
         // Capture the new conversation's activity phase so a conversation
         // already paused in awaiting_confirmation is correctly tracked.
         scrollState.lastActivityPhaseWhenIdle = isSending ? "" : assistantActivityPhase
-        scrollState.lastHandledContainerWidth = containerWidth
+        scrollState.lastHandledChatColumnWidth = containerWidth > 0
+            ? layoutMetrics.chatColumnWidth
+            : 0
         scrollState.anchorTimeoutTask?.cancel()
         scrollState.anchorTimeoutTask = nil
         scrollState.lastAutoFocusedRequestId = nil

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -71,12 +71,15 @@ struct MessageListView: View {
     @Binding var anchorMessageId: UUID?
     /// Message ID to visually highlight after an anchor scroll completes.
     @Binding var highlightedMessageId: UUID?
-    /// Measured width of the chat container, used to detect sidebar/split resizes
-    /// and stabilize scroll position during layout width changes.
     /// When false, disables interactive controls (buttons, actions) inside the
     /// message list while keeping scrolling and text selection functional.
     var isInteractionEnabled: Bool = true
+    /// Measured width of the full chat pane. `layoutMetrics` derives the
+    /// centered transcript column width from this value.
     var containerWidth: CGFloat = 0
+    var layoutMetrics: MessageListLayoutMetrics {
+        MessageListLayoutMetrics(containerWidth: containerWidth)
+    }
     /// Cached in `@State` to avoid `UserDefaults` IPC on every view body
     /// evaluation. Seeded once from `UserDefaults` when SwiftUI first creates
     /// the state; persisted back in `handleSendingChanged()` when flipped.
@@ -111,18 +114,25 @@ struct MessageListView: View {
         #if DEBUG
         let _ = os_signpost(.event, log: PerfSignposts.log, name: "MessageListView.body")
         #endif
+            let widths = layoutMetrics
             // .frame(width:) creates _FrameLayout (not _FlexFrameLayout). FrameLayout
             // returns bounds.midX for alignment without querying children, stopping the
             // alignment cascade. The old .frame(maxWidth:) pattern created FlexFrameLayout
             // which queried explicitAlignment on the entire LazyVStack subtree — O(n) per
             // layout pass, causing 34-70s hangs. See AGENTS.md.
             ScrollView {
-                scrollViewContent
-                    .background(
-                        MessageListScrollObserver { newState in
-                            enqueueScrollGeometryUpdate(newState)
-                        }
-                    )
+                HStack(spacing: 0) {
+                    Spacer(minLength: 0)
+                    scrollViewContent
+                        .frame(width: widths.chatColumnWidth)
+                        .background(
+                            MessageListScrollObserver { newState in
+                                enqueueScrollGeometryUpdate(newState)
+                            }
+                        )
+                    Spacer(minLength: 0)
+                }
+                .frame(width: widths.scrollSurfaceWidth)
             }
             .scrollContentBackground(.hidden)
             .scrollDisabled(messages.isEmpty && !isSending)
@@ -157,7 +167,7 @@ struct MessageListView: View {
             }
             .scrollIndicators(scrollState.scrollIndicatorsHidden ? .hidden : .automatic)
             .id(conversationId)
-            .frame(width: containerWidth > 0 ? min(containerWidth, VSpacing.chatColumnMaxWidth) : VSpacing.chatColumnMaxWidth)
+            .frame(width: widths.scrollSurfaceWidth)
             .overlay(alignment: .bottom) {
                 ScrollToLatestOverlayView(scrollState: scrollState)
             }

--- a/clients/macos/vellum-assistantTests/MessageListLayoutMetricsTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListLayoutMetricsTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+@testable import VellumAssistantLib
+
+final class MessageListLayoutMetricsTests: XCTestCase {
+
+    func testZeroWidthFallsBackToChatColumnMaxWidth() {
+        let metrics = MessageListLayoutMetrics(containerWidth: 0)
+        let capped = MessageListLayoutMetrics(containerWidth: 10_000)
+
+        XCTAssertEqual(metrics.scrollSurfaceWidth, metrics.chatColumnWidth)
+        XCTAssertEqual(metrics.chatColumnWidth, capped.chatColumnWidth)
+    }
+
+    func testNarrowPaneUsesAvailableWidthForSurfaceAndColumn() {
+        let metrics = MessageListLayoutMetrics(containerWidth: 640)
+
+        XCTAssertEqual(metrics.scrollSurfaceWidth, 640)
+        XCTAssertEqual(metrics.chatColumnWidth, 640)
+    }
+
+    func testWidePaneKeepsFullSurfaceAndCapsChatColumn() {
+        let paneWidth = 1200.0
+        let metrics = MessageListLayoutMetrics(containerWidth: paneWidth)
+
+        XCTAssertEqual(metrics.scrollSurfaceWidth, paneWidth)
+        XCTAssertLessThan(metrics.chatColumnWidth, metrics.scrollSurfaceWidth)
+    }
+
+    func testTrackedChatColumnWidthStopsChangingAfterCap() {
+        let base = MessageListLayoutMetrics(containerWidth: 1200)
+        let wider = MessageListLayoutMetrics(containerWidth: 1600)
+
+        XCTAssertNotEqual(base.scrollSurfaceWidth, wider.scrollSurfaceWidth)
+        XCTAssertEqual(base.chatColumnWidth, wider.chatColumnWidth)
+    }
+}

--- a/clients/macos/vellum-assistantTests/MessageListTypographyRefreshTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListTypographyRefreshTests.swift
@@ -37,7 +37,7 @@ final class MessageListTypographyRefreshTests: XCTestCase {
             isLoadingMoreMessages: false,
             isCompacting: false,
             isInteractionEnabled: true,
-            containerWidth: 800,
+            layoutMetrics: MessageListLayoutMetrics(containerWidth: 800),
             dismissedDocumentSurfaceIds: [],
             activeSurfaceId: nil,
             highlightedMessageId: nil,


### PR DESCRIPTION
## Summary
- Extract `MessageListLayoutMetrics` to centralize the scroll surface, chat column, and bubble max width calculations (with unit tests).
- Scroll surface now spans the full pane so wheel input works in the centered gutters; the transcript column stays capped at `chatColumnMaxWidth`.
- Resize recovery tracks the derived chat column width instead of raw pane width, so widening only the outer gutters past the cap no longer triggers spurious resize handling.