### PR TITLE
fix(macos/tests): gate LockfileAssistantAppleContainerTests on macOS 26.0

### DIFF
--- a/clients/macos/vellum-assistantTests/LockfileAssistantAppleContainerTests.swift
+++ b/clients/macos/vellum-assistantTests/LockfileAssistantAppleContainerTests.swift
@@ -2,6 +2,9 @@ import VellumAssistantShared
 import XCTest
 @testable import VellumAssistantLib
 
+// MARK: - AppleContainersLauncher.writeLockfileEntry Tests
+
+@available(macOS 26.0, *)
 final class LockfileAssistantAppleContainerTests: XCTestCase {
     private var tempDir: URL!
     private var lockfilePath: String!
@@ -139,7 +142,11 @@ final class LockfileAssistantAppleContainerTests: XCTestCase {
         XCTAssertEqual(json["version"] as? Int, 1)
     }
 
-    // MARK: - isAppleContainer property
+}
+
+// MARK: - LockfileAssistant.isAppleContainer Tests
+
+final class LockfileAssistantIsAppleContainerTests: XCTestCase {
 
     func testIsAppleContainerReturnsTrueForAppleContainerCloud() {
         let assistant = LockfileAssistant(


### PR DESCRIPTION
## Summary
- \`AppleContainersLauncher\` is \`@available(macOS 26.0, *)\`, so \`LockfileAssistantAppleContainerTests\` — which calls \`AppleContainersLauncher.writeLockfileEntry\` — must carry the same gate. Without it, the macOS Tests CI job fails to compile on the macOS 15.x runner ([failing job](https://github.com/vellum-ai/vellum-assistant/actions/runs/24189249370/job/70601810848)).
- Split the file into two classes following the pattern from #24532: \`LockfileAssistantAppleContainerTests\` (\`@available(macOS 26.0, *)\`) for the six \`writeLockfileEntry\` tests, and a new \`LockfileAssistantIsAppleContainerTests\` for the two ungated \`isAppleContainer\` property tests so they still run on macOS 15.x CI.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24189249370/job/70601810848
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24540" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
