### PR TITLE
remove legacy browser-relay bearer token fallback

### DIFF
--- a/assistant/src/__tests__/host-browser-e2e-self-hosted-capability.test.ts
+++ b/assistant/src/__tests__/host-browser-e2e-self-hosted-capability.test.ts
@@ -9,8 +9,7 @@
  *
  * Invariants covered:
  *
- *   1. `/v1/browser-relay` accepts capability tokens directly — no
- *      gateway `/v1/browser-relay/token` round-trip required.
+ *   1. `/v1/browser-relay` accepts capability tokens directly.
  *   2. The WS upgrade handler derives the registry-key guardianId from
  *      the capability claims so host_browser_request frames route
  *      back to the right connection.

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -937,7 +937,8 @@ export class RuntimeHttpServer {
     // `sub=svc:gateway:self` with no actor principal id. The gateway
     // parses the downstream edge token's `actorPrincipalId` and forwards
     // it as an explicit `guardianId` query parameter (and/or header) so
-    // we can register the connection under the real guardian.
+    // we can register the connection under the real guardian. Missing
+    // guardian context on this path is rejected (fail closed).
     // Read the client-supplied stable instance id off the handshake.
     // The extension generates this on first run and persists it in
     // chrome.storage so it survives service-worker restarts and
@@ -995,12 +996,10 @@ export class RuntimeHttpServer {
           if (fallbackGuardianId) {
             guardianId = fallbackGuardianId;
           } else {
-            // No guardian context on a service-token upgrade. We log a
-            // warning so operators still see a signal but allow the
-            // upgrade to proceed with `guardianId = undefined`. The
-            // registry skips the scoped registration in that case, and
-            // host_browser_request frames will log a warning downstream
-            // if routing fails.
+            // Fail closed: a service-token relay upgrade without a
+            // guardian context cannot be routed safely. Allowing the
+            // upgrade to proceed creates an unscoped socket that never
+            // registers in the ChromeExtensionRegistry.
             log.warn(
               {
                 principalType: subResult.ok
@@ -1008,7 +1007,12 @@ export class RuntimeHttpServer {
                   : "unknown",
                 sub: jwtResult.claims.sub,
               },
-              "Browser relay upgrade allowed without guardian context (service-token path)",
+              "Browser relay upgrade denied: missing guardian context on service-token path",
+            );
+            return httpError(
+              "UNAUTHORIZED",
+              "Browser relay requires guardian context",
+              401,
             );
           }
         }

--- a/clients/chrome-extension/background/relay-connection.ts
+++ b/clients/chrome-extension/background/relay-connection.ts
@@ -532,11 +532,8 @@ function normaliseReconnectResult(
 //     stored capability token.
 //   - cloud: send the envelope as a `host_browser_result` frame over
 //     the existing browser-relay WebSocket. The gateway proxies the
-//     frame straight through to the runtime — see
-//     `gateway/src/http/routes/browser-relay-websocket.ts`. (Phase 3
-//     will land the runtime-side handler for inbound result frames;
-//     today the runtime drops them, but the cloud CDP path is
-//     feature-flagged off in Phase 2 so this is harmless.)
+//     frame straight through to the runtime, which resolves it through
+//     the same shared resolver used by `/v1/host-browser-result`.
 
 /**
  * Minimal subset of {@link RelayConnection} that {@link postHostBrowserResult}

--- a/clients/chrome-extension/background/worker.ts
+++ b/clients/chrome-extension/background/worker.ts
@@ -217,8 +217,7 @@ async function dispatchHostBrowserResult(
   // Self-hosted fallback: POST directly to the local daemon using live
   // creds. Prefer the capability token from the native-messaging pair
   // flow; fall back to the bearer token stored under the gateway
-  // `/v1/browser-relay/token` path for installs that haven't been
-  // paired via native messaging yet.
+  // pair flow.
   const local = await getStoredLocalToken();
   if (local) {
     const fallbackPort = local.assistantPort ?? (await getRelayPort());
@@ -229,13 +228,9 @@ async function dispatchHostBrowserResult(
     };
     return postHostBrowserResult(fallbackMode, null, result);
   }
-  const [token, port] = await Promise.all([getBearerToken(), getRelayPort()]);
-  const fallbackMode: RelayMode = {
-    kind: 'self-hosted',
-    baseUrl: `http://127.0.0.1:${port}`,
-    token,
-  };
-  return postHostBrowserResult(fallbackMode, null, result);
+  console.warn(
+    '[vellum-relay] host_browser_result dropped: self-hosted relay not paired',
+  );
 }
 
 /**
@@ -279,11 +274,6 @@ const hostBrowserDispatcher: HostBrowserDispatcher = createHostBrowserDispatcher
 
 // ── Storage helpers ─────────────────────────────────────────────────
 
-async function getBearerToken(): Promise<string | null> {
-  const result = await chrome.storage.local.get('bearerToken');
-  return typeof result.bearerToken === 'string' ? result.bearerToken : null;
-}
-
 async function getRelayPort(): Promise<number> {
   const result = await chrome.storage.local.get('relayPort');
   const stored = result.relayPort;
@@ -293,26 +283,6 @@ async function getRelayPort(): Promise<number> {
     if (!isNaN(parsed) && parsed > 0 && parsed <= 65535) return parsed;
   }
   return DEFAULT_RELAY_PORT;
-}
-
-/**
- * Fetch a fresh bearer token from the gateway's localhost-only endpoint
- * and persist it for future connections.
- */
-async function refreshToken(): Promise<boolean> {
-  try {
-    const port = await getRelayPort();
-    const resp = await fetch(`http://127.0.0.1:${port}/v1/browser-relay/token`);
-    if (!resp.ok) return false;
-    const data = await resp.json();
-    if (typeof data.token !== 'string') return false;
-    await chrome.storage.local.set({ bearerToken: data.token });
-    console.log('[vellum-relay] Token refreshed from gateway');
-    return true;
-  } catch {
-    console.warn('[vellum-relay] Failed to refresh token from gateway');
-    return false;
-  }
 }
 
 // ── Relay connection lifecycle ──────────────────────────────────────
@@ -338,10 +308,8 @@ async function buildRelayModeConfig(kind: RelayModeKind): Promise<RelayMode> {
   // carries the assistant runtime port the helper used when it
   // pair-bootstrapped, so we target the runtime directly.
   //
-  // Compatibility branch: if there is no stored capability token yet
-  // (e.g. a chrome profile that hasn't been paired via native
-  // messaging) we fall back to the `bearerToken` / `relayPort` storage
-  // keys so installs without a paired helper keep working.
+  // No compatibility fallback: self-hosted relay now requires pairing
+  // through the native-messaging capability-token flow.
   const local = await getStoredLocalToken();
   if (local) {
     const port = local.assistantPort ?? (await getRelayPort());
@@ -351,14 +319,11 @@ async function buildRelayModeConfig(kind: RelayModeKind): Promise<RelayMode> {
       token: local.token,
     };
   }
-  const [legacyToken, port] = await Promise.all([
-    getBearerToken(),
-    getRelayPort(),
-  ]);
+  const port = await getRelayPort();
   return {
     kind: 'self-hosted',
     baseUrl: `http://127.0.0.1:${port}`,
-    token: legacyToken,
+    token: null,
   };
 }
 
@@ -525,14 +490,10 @@ function createRelayConnection(
       // code. If refresh is impossible we abort the reconnect loop
       // and surface the error to the popup — see cloudReconnectHook.
       //
-      // Self-hosted mode uses a two-step refresh ladder:
-      //  1. Re-read the stored capability token from
-      //     `self-hosted-auth.ts`. The token may have been rotated by
-      //     a re-pair in another tab, or it may simply still be valid
-      //     and the drop was a transient server bounce.
-      //  2. Fall back to the gateway `/v1/browser-relay/token`
-      //     refresh for installs without a paired native-messaging
-      //     helper.
+      // Self-hosted mode re-reads the stored capability token from
+      // `self-hosted-auth.ts` on every reconnect. If pairing data is
+      // missing/expired we abort reconnects and surface an actionable
+      // error.
       //
       // Pull the live mode through getCurrentMode so a setMode() that
       // flipped us to cloud mid-reconnect still routes through the
@@ -542,13 +503,14 @@ function createRelayConnection(
         return cloudReconnectHook(ctx);
       }
       const local = await getStoredLocalToken();
-      if (local?.token) return local.token;
-      const ok = await refreshToken();
-      if (ok) {
-        const refreshed = await getBearerToken();
-        return refreshed;
+      if (local?.token) {
+        return { kind: 'refreshed', token: local.token };
       }
-      return null;
+      return {
+        kind: 'abort',
+        error:
+          'Self-hosted relay token missing or expired. Pair the Vellum assistant again from the extension popup.',
+      };
     },
   });
 }
@@ -744,24 +706,11 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponseFn) => {
 });
 
 // Auto-connect on service worker start if previously connected.
-// Refresh the self-hosted token first so we don't reconnect with stale
-// credentials — cloud-mode auto-connect just reads the stored OAuth
-// token and trusts the caller to re-sign in if it's expired.
 async function bootstrap(): Promise<void> {
   relayMode = await loadRelayMode();
   const { autoConnect } = await chrome.storage.local.get('autoConnect');
   if (autoConnect !== true) return;
   shouldConnect = true;
-  if (relayMode === 'self-hosted') {
-    // Only mint a fresh gateway JWT if the capability-token path isn't
-    // usable yet. The capability token is the default auth for
-    // self-hosted installs with a paired native-messaging helper; the
-    // gateway refresh is only needed for installs without one.
-    const local = await getStoredLocalToken();
-    if (!local) {
-      await refreshToken();
-    }
-  }
   try {
     await connect();
   } catch (err) {

--- a/clients/chrome-extension/popup/popup.html
+++ b/clients/chrome-extension/popup/popup.html
@@ -53,8 +53,7 @@
       margin-bottom: 4px;
     }
 
-    input[type="text"],
-    input[type="password"] {
+    input[type="text"] {
       width: 100%;
       border: 1px solid #d1d5db;
       border-radius: 6px;
@@ -177,22 +176,6 @@
       line-height: 1.5;
     }
 
-    .manual-toggle {
-      font-size: 12px;
-      color: #6366f1;
-      cursor: pointer;
-      background: none;
-      border: none;
-      padding: 0;
-      margin-bottom: 8px;
-      text-decoration: underline;
-      display: inline-block;
-    }
-    .manual-toggle:hover { color: #4f46e5; }
-
-    .token-group { display: none; }
-    .token-group.visible { display: block; }
-
     .error-text {
       font-size: 12px;
       color: #ef4444;
@@ -224,18 +207,6 @@
     </div>
   </div>
 
-  <button class="manual-toggle" id="manual-toggle" type="button">Manual token entry</button>
-  <div class="token-group" id="token-group">
-    <label for="token-input">Bearer token</label>
-    <input
-      type="password"
-      id="token-input"
-      placeholder="Paste your JWT bearer token"
-      autocomplete="off"
-      spellcheck="false"
-    />
-  </div>
-
   <label for="port-input">Relay port</label>
   <input
     type="text"
@@ -250,7 +221,7 @@
     <button id="btn-disconnect" disabled>Disconnect</button>
   </div>
 
-  <p class="hint">Token is auto-fetched from the local gateway. Port defaults to 7830.</p>
+  <p class="hint">Self-hosted mode requires pairing. Relay port defaults to 7830.</p>
 
   <div class="divider"></div>
 

--- a/clients/chrome-extension/popup/popup.ts
+++ b/clients/chrome-extension/popup/popup.ts
@@ -4,10 +4,8 @@
  * Self-hosted pairing is governed by the "Pair local assistant" button,
  * which spawns the native messaging helper and persists a capability
  * token (see self-hosted-auth.ts). Connect then reads that stored
- * capability token directly — it does NOT fall back to the legacy
- * `/v1/browser-relay/token` gateway endpoint. If the user hasn't
- * paired yet we surface an inline error pointing them at the Pair
- * button instead of silently auto-fetching a JWT.
+ * capability token directly. If the user hasn't paired yet we surface
+ * an inline error pointing them at the Pair button.
  *
  * Also exposes a "Sign in with Vellum (cloud)" button. The actual OAuth
  * flow runs in the background service worker (see worker.ts) — the popup
@@ -26,15 +24,12 @@ import {
 
 const DEFAULT_RELAY_PORT = 7830;
 
-const tokenInput = document.getElementById('token-input') as HTMLInputElement;
 const portInput = document.getElementById('port-input') as HTMLInputElement;
 const btnConnect = document.getElementById('btn-connect') as HTMLButtonElement;
 const btnDisconnect = document.getElementById('btn-disconnect') as HTMLButtonElement;
 const statusDot = document.getElementById('status-dot') as HTMLDivElement;
 const statusText = document.getElementById('status-text') as HTMLParagraphElement;
 const errorText = document.getElementById('error-text') as HTMLParagraphElement;
-const manualToggle = document.getElementById('manual-toggle') as HTMLButtonElement;
-const tokenGroup = document.getElementById('token-group') as HTMLDivElement;
 const btnCloudSignIn = document.getElementById('btn-cloud-signin') as HTMLButtonElement;
 const cloudStatus = document.getElementById('cloud-status') as HTMLParagraphElement;
 const btnPairLocal = document.getElementById('btn-pair-local') as HTMLButtonElement;
@@ -45,14 +40,11 @@ const modeCloud = document.getElementById('mode-cloud') as HTMLInputElement;
 const RELAY_MODE_KEY = 'vellum.relayMode';
 type RelayModeKind = 'self-hosted' | 'cloud';
 
-let manualMode = false;
-
 function setConnected(connected: boolean): void {
   statusDot.className = `status-dot ${connected ? 'connected' : 'disconnected'}`;
   statusText.textContent = connected ? 'Connected to relay server' : 'Not connected';
   btnConnect.disabled = connected;
   btnDisconnect.disabled = !connected;
-  tokenInput.disabled = connected;
   portInput.disabled = connected;
   if (connected) {
     errorText.style.display = 'none';
@@ -62,48 +54,20 @@ function setConnected(connected: boolean): void {
 /**
  * Render an inline error message without touching any other UI.
  *
- * Use this for errors that are not actionable by the self-hosted
- * manual-token-entry workflow — e.g. cloud OAuth failures, refresh
- * exceptions, or generic service-worker messages. It's specifically
- * the variant {@link refreshCloudStatus} uses so a cloud auth error
- * does not accidentally reveal the self-hosted token input.
+ * Use this for generic popup errors — e.g. cloud OAuth failures,
+ * refresh exceptions, or generic service-worker messages.
  */
 function showErrorText(msg: string): void {
   errorText.textContent = msg;
   errorText.style.display = 'block';
 }
 
-/**
- * Render an inline error message AND reveal the self-hosted manual
- * token entry section. Use this for errors where the user's next
- * action is to paste a bearer token into the manual-entry box —
- * e.g. a failed auto-fetch or a missing paired local assistant.
- *
- * Do NOT use this for cloud auth errors: the manual token entry
- * section is a self-hosted-only workflow, and revealing it for a
- * cloud error would point the user at the wrong remediation.
- */
 function showError(msg: string): void {
   showErrorText(msg);
-  // Reveal manual token entry on auto-fetch failure
-  if (!manualMode) {
-    manualMode = true;
-    tokenGroup.classList.add('visible');
-    manualToggle.textContent = 'Hide manual token entry';
-  }
 }
 
-manualToggle.addEventListener('click', () => {
-  manualMode = !manualMode;
-  tokenGroup.classList.toggle('visible', manualMode);
-  manualToggle.textContent = manualMode ? 'Hide manual token entry' : 'Manual token entry';
-});
-
-// Load saved token and port on open
-chrome.storage.local.get(['bearerToken', 'relayPort']).then((result) => {
-  if (typeof result.bearerToken === 'string' && result.bearerToken) {
-    tokenInput.value = result.bearerToken;
-  }
+// Load saved relay port on open.
+chrome.storage.local.get(['relayPort']).then((result) => {
   if (result.relayPort !== undefined) {
     portInput.value = String(result.relayPort);
   }
@@ -130,8 +94,8 @@ btnConnect.addEventListener('click', async () => {
 
   errorText.style.display = 'none';
 
-  // Read the current relay mode so we know whether to auto-fetch a local
-  // daemon token. In cloud mode the worker uses the stored cloud token
+  // Read the current relay mode so we know whether self-hosted pairing
+  // is required. In cloud mode the worker uses the stored cloud token
   // (vellum.cloudAuthToken) directly, so the popup must NOT try to hit
   // localhost — a cloud-only user may not have a local assistant running.
   //
@@ -149,49 +113,18 @@ btnConnect.addEventListener('click', async () => {
         ? 'cloud'
         : 'self-hosted';
 
-  // Only honour the manual token input when the user has explicitly revealed
-  // it. When manual mode is hidden and we're in self-hosted mode, we now
-  // rely on the native-messaging Pair flow (PR 3 of the browser-remediation
-  // plan): the stored capability token is what authenticates the relay
-  // WebSocket, not a gateway-minted JWT. If the user hasn't paired yet we
-  // refuse to auto-fetch from the gateway and instead surface an error
-  // pointing them at the Pair button.
-  //
-  // Legacy compatibility: if a `bearerToken` was already written to storage
-  // by a pre-PR 3 install, we still honour it (the worker's fallback branch
-  // in buildRelayModeConfig will pick it up) so existing installs keep
-  // working until they re-pair.
-  let token = manualMode ? tokenInput.value.trim() : '';
-
-  if (!token && relayMode === 'self-hosted') {
+  // Self-hosted now requires native-messaging pairing. There is no
+  // gateway JWT fallback path.
+  if (relayMode === 'self-hosted') {
     const pairedToken = await getStoredLocalToken();
     if (!pairedToken) {
-      // No capability token yet. Check for a legacy bearer token — that
-      // path is honoured by the service worker's buildRelayModeConfig
-      // fallback, so we let the worker take the connect attempt and
-      // surface its MissingTokenError if there's nothing usable.
-      const legacy = await chrome.storage.local.get('bearerToken');
-      if (typeof legacy.bearerToken !== 'string' || !legacy.bearerToken) {
-        showError(
-          'Self-hosted relay is not paired yet — click "Pair local assistant" below before connecting.',
-        );
-        return;
-      }
-      // Fall through: the worker will read the legacy bearer token and
-      // connect to the compatibility branch.
+      showError(
+        'Self-hosted relay is not paired yet — click "Pair local assistant" below before connecting.',
+      );
+      return;
     }
-    // When we have a paired capability token we deliberately do NOT
-    // write anything to the legacy `bearerToken` storage key — the
-    // worker's buildRelayModeConfig reads the capability token
-    // directly and persisting a stale bearer token here would just
-    // leave orphaned state around after a future clearLocalToken.
   }
 
-  // In cloud mode with no manual token we proceed with no bearerToken —
-  // the worker reads vellum.cloudAuthToken from chrome.storage when it
-  // builds the relay mode config in buildRelayModeConfig().
-
-  if (token) storageUpdate.bearerToken = token;
   if (portInput.value.trim()) {
     storageUpdate.relayPort = port;
   } else {
@@ -231,9 +164,8 @@ btnDisconnect.addEventListener('click', () => {
 // which POSTs the extension's origin to the assistant's
 // `/v1/browser-extension-pair` endpoint and returns a capability token.
 // The token is persisted in chrome.storage.local under
-// `vellum.localCapabilityToken`. It is NOT yet used on any WebSocket —
-// PR 14 will read it when opening the relay connection in self-hosted
-// mode.
+// `vellum.localCapabilityToken` and is used directly by the
+// self-hosted relay WebSocket connection.
 
 function setLocalStatus(text: string, state: 'neutral' | 'paired' | 'error'): void {
   localStatus.textContent = text;
@@ -302,10 +234,8 @@ refreshLocalStatus();
 
 // ── Cloud sign-in (new in Phase 2 PR 8) ────────────────────────────
 //
-// This is a skeleton: the token is persisted but not yet used on any
-// WebSocket. A later PR will plumb it through the relay connection so
-// cloud-hosted users can connect to the Vellum gateway without running
-// a local daemon.
+// The token is persisted and consumed by the background worker when
+// opening cloud relay WebSocket connections.
 
 function setCloudStatus(text: string, signedIn: boolean): void {
   cloudStatus.textContent = text;
@@ -325,11 +255,8 @@ async function refreshCloudStatus(): Promise<void> {
     // cloud token refresh fails (see cloudReconnectHook in worker.ts)
     // and clears it on a successful connect.
     //
-    // Use showErrorText (NOT showError) here: the self-hosted manual
-    // token entry section is irrelevant to a cloud auth error, and
-    // revealing it would point the user at the wrong remediation.
-    // The error message itself already instructs the user to sign
-    // in with Vellum (cloud) again, which is all they need.
+    // Use showErrorText directly: the message already instructs the
+    // user to sign in with Vellum (cloud) again, which is all they need.
     const authErrResult = await chrome.storage.local.get('vellum.relayAuthError');
     const authErr = authErrResult['vellum.relayAuthError'];
     if (
@@ -383,10 +310,10 @@ refreshCloudStatus();
 
 // ── Relay mode switcher (Phase 2 PR 14) ────────────────────────────
 //
-// Flips `vellum.relayMode` in chrome.storage.local between "self-hosted"
-// (default, back-compat) and "cloud". The service worker listens for
-// storage changes via chrome.storage.onChanged and closes the current
-// socket + reopens a new one against the selected transport.
+// Flips `vellum.relayMode` in chrome.storage.local between
+// "self-hosted" (default) and "cloud". The service worker listens
+// for storage changes via chrome.storage.onChanged and closes the
+// current socket + reopens a new one against the selected transport.
 
 function isRelayModeKind(v: unknown): v is RelayModeKind {
   return v === 'self-hosted' || v === 'cloud';

--- a/docs/browser-use-architecture-phase2.md
+++ b/docs/browser-use-architecture-phase2.md
@@ -71,7 +71,7 @@ and the handshake differ.
           │  http-server.ts open/close │
           │        │                   │
           │        ▼                   │
-          │  ChromeExtensionRegistry   │  (guardianId → ws)
+         │  ChromeExtensionRegistry   │  (guardianId, clientInstanceId → ws)
           │        │                   │
           │        ▼                   │
           │  HostBrowserProxy          │
@@ -85,10 +85,11 @@ and the handshake differ.
           └────────────────────────────┘
 ```
 
-Result envelopes flow back via `POST /v1/host-browser-result`, which
-resolves the pending interaction keyed by `requestId` and feeds the
-result into the current agent turn exactly like the macOS host proxies
-do.
+Result envelopes normally flow back over the same `/v1/browser-relay`
+WebSocket as `host_browser_result` frames (cloud + self-hosted). The
+runtime resolves these through the same shared resolver used by
+`POST /v1/host-browser-result`. The HTTP route remains as a self-hosted
+fallback when no relay socket is available.
 
 ## Cloud transport
 
@@ -107,7 +108,7 @@ Handshake:
 3. On success, the gateway returns a guardian-bound JWT and the
    extension persists it via `cloud-auth.ts::getStoredToken`.
 4. The extension opens `wss://api.vellum.ai/v1/browser-relay` with the
-   JWT as the `Authorization: Bearer …` header.
+   JWT on the `token=...` query parameter.
 5. The gateway verifies the JWT, extracts the guardian id, and forwards
    the upgrade to the assistant runtime. The runtime registers the
    connection under that guardian id in the `ChromeExtensionRegistry`.
@@ -136,8 +137,8 @@ Handshake:
       mint a scoped capability token bound to the caller's guardian.
    d. Writes a `token_response` frame to stdout and exits.
 4. The extension persists the token and opens
-   `ws://127.0.0.1:<port>/v1/browser-relay` with the token as a bearer
-   header.
+   `ws://127.0.0.1:<port>/v1/browser-relay` with the token on the
+   `token=...` query parameter.
 5. The daemon verifies the token via
    `verifyHostBrowserCapability`, registers the connection in the
    `ChromeExtensionRegistry`, and starts routing `host_browser_request`
@@ -154,8 +155,9 @@ The new modules that implement Phase 2:
 
 - **`assistant/src/runtime/chrome-extension-registry.ts`** — Singleton
   tracking active `chrome-extension` WebSocket connections keyed by
-  guardian id. Reconnects from the same guardian supersede the prior
-  entry, closing the older socket cleanly.
+  `(guardianId, clientInstanceId)`. Reconnects from the same instance
+  supersede only that instance's prior entry, leaving sibling installs
+  under the same guardian intact.
 - **`assistant/src/runtime/routes/browser-extension-pair-routes.ts`** —
   `POST /v1/browser-extension-pair` endpoint. Loopback-only. Mints a
   capability token bound to the caller's guardian id and the
@@ -175,7 +177,8 @@ The new modules that implement Phase 2:
   concurrent commands don't double-attach.
 - **`clients/chrome-extension/background/host-browser-dispatcher.ts`** —
   Consumes `host_browser_request` envelopes, drives the `cdp-proxy`, and
-  hands results to the worker for POST-back.
+  hands results to the worker for relay-aware delivery (WS first, HTTP
+  fallback in self-hosted mode).
 - **`clients/chrome-extension/background/relay-connection.ts`** —
   WebSocket relay with heartbeat, reconnect-with-token-refresh, and
   mode-aware bearer injection.

--- a/gateway/src/__tests__/browser-relay-websocket.test.ts
+++ b/gateway/src/__tests__/browser-relay-websocket.test.ts
@@ -27,8 +27,8 @@ function mintEdgeToken(actorPrincipalId: string = "test-user"): string {
 
 /**
  * Mint a service-style browser-relay edge token (svc:browser-relay:self).
- * This mirrors `mintBrowserRelayToken()` — the token is valid for the
- * gateway audience but carries no actor principal in its sub claim.
+ * This token is valid for the gateway audience but carries no actor
+ * principal in its sub claim.
  */
 function mintServiceEdgeToken(): string {
   return mintToken({
@@ -275,7 +275,7 @@ describe("getBrowserRelayWebsocketHandlers", () => {
       config: makeConfig({
         assistantRuntimeBaseUrl: "http://runtime.internal:7821",
       }),
-      auth: { authenticated: true, authBypassed: false },
+      auth: { authenticated: false, authBypassed: true },
     });
 
     handlers.open(ws as never);
@@ -320,7 +320,7 @@ describe("getBrowserRelayWebsocketHandlers", () => {
     expect(parsed.searchParams.get("guardianId")).toBe(TEST_ACTOR_PRINCIPAL);
   });
 
-  test("open omits guardianId query param when auth context has none (service-token path)", () => {
+  test("open omits guardianId query param when auth context has none (auth-bypass context)", () => {
     const ws = createFakeDownstreamWs({
       wsType: "browser-relay",
       config: makeConfig({
@@ -334,9 +334,8 @@ describe("getBrowserRelayWebsocketHandlers", () => {
     const MockWS = globalThis.WebSocket as unknown as ReturnType<typeof mock>;
     const calledUrl = (MockWS.mock.calls[0] as unknown[])[0] as string;
     const parsed = new URL(calledUrl);
-    // When the edge token has no actor principal, the gateway
-    // propagates nothing for guardianId and the runtime accepts the
-    // upgrade with `guardianId = undefined`.
+    // Auth-bypass contexts may omit guardianId; open() should not
+    // synthesize one.
     expect(parsed.searchParams.has("guardianId")).toBe(false);
   });
 
@@ -368,7 +367,7 @@ describe("getBrowserRelayWebsocketHandlers", () => {
   });
 
   test("open forwards clientInstanceId even without a guardianId", () => {
-    // Auth-bypass / service-token paths can still carry a
+    // Auth-bypass paths can still carry a
     // clientInstanceId lifted from the downstream handshake. The
     // gateway must propagate it so the runtime's multi-instance
     // registry keys the connection correctly.
@@ -378,8 +377,8 @@ describe("getBrowserRelayWebsocketHandlers", () => {
         assistantRuntimeBaseUrl: "http://runtime.internal:7821",
       }),
       auth: {
-        authenticated: true,
-        authBypassed: false,
+        authenticated: false,
+        authBypassed: true,
         clientInstanceId: "install-XYZ-789",
       },
     });
@@ -438,10 +437,7 @@ describe("checkBrowserRelayAuth", () => {
     expect(result.context.guardianId).toBe(TEST_ACTOR_PRINCIPAL);
   });
 
-  test("returns ok with undefined guardianId for service-style edge tokens", () => {
-    // Reflects the `mintBrowserRelayToken()` path where the edge token
-    // sub is `svc:browser-relay:self`. The gateway accepts the token but
-    // cannot resolve an actor principal to propagate upstream.
+  test("rejects service-style edge tokens with no actor principal", () => {
     const token = mintServiceEdgeToken();
     const config = makeConfig({});
     const req = new Request(
@@ -452,10 +448,9 @@ describe("checkBrowserRelayAuth", () => {
 
     const result = checkBrowserRelayAuth(req, url, config);
 
-    expect(result.ok).toBe(true);
-    if (!result.ok) throw new Error("expected ok");
-    expect(result.context.authenticated).toBe(true);
-    expect(result.context.guardianId).toBeUndefined();
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected error");
+    expect(result.response.status).toBe(401);
   });
 
   test("returns error response when token is missing and auth is required", () => {
@@ -642,7 +637,7 @@ describe("createBrowserRelayWebsocketHandler guardian propagation", () => {
     });
   });
 
-  test("upgrades with undefined guardianId for service-style edge tokens", () => {
+  test("rejects service-style edge tokens before upgrade", () => {
     const token = mintServiceEdgeToken();
     const config = makeConfig({});
     const handler = createBrowserRelayWebsocketHandler(config);
@@ -651,40 +646,26 @@ describe("createBrowserRelayWebsocketHandler guardian propagation", () => {
       { headers: { upgrade: "websocket" } },
     );
 
-    let capturedData: unknown = null;
     const fakeServer = {
       requestIP: mock(() => ({
         address: "127.0.0.1",
         family: "IPv4",
         port: 54000,
       })),
-      upgrade: mock((_req: Request, opts?: { data?: unknown }) => {
-        capturedData = opts?.data;
-        return true;
-      }),
+      upgrade: mock(() => true),
     } as unknown as import("bun").Server<any>;
 
     const res = handler(req, fakeServer);
 
-    expect(res).toBeUndefined();
-    expect(fakeServer.upgrade).toHaveBeenCalledTimes(1);
-    // The gateway still upgrades the connection, but propagates no
-    // guardianId. The runtime allows the upgrade to proceed with an
-    // unscoped connection when no fallback guardian context is
-    // available.
-    expect(capturedData).toMatchObject({
-      wsType: "browser-relay",
-      auth: { authenticated: true, authBypassed: false },
-    });
-    expect(
-      (capturedData as { auth: { guardianId?: string } }).auth.guardianId,
-    ).toBeUndefined();
+    expect(res).toBeInstanceOf(Response);
+    expect(res!.status).toBe(401);
+    expect(fakeServer.upgrade).not.toHaveBeenCalled();
   });
 });
 
 describe("isLoopbackPeer", () => {
   test("uses x-forwarded-for first hop when trustProxy is enabled", () => {
-    const req = new Request("http://localhost:7830/v1/browser-relay/token", {
+    const req = new Request("http://localhost:7830/v1/browser-relay", {
       headers: { "x-forwarded-for": "203.0.113.5, 127.0.0.1" },
     });
 
@@ -700,7 +681,7 @@ describe("isLoopbackPeer", () => {
   });
 
   test("falls back to peer IP when trustProxy is disabled", () => {
-    const req = new Request("http://localhost:7830/v1/browser-relay/token", {
+    const req = new Request("http://localhost:7830/v1/browser-relay", {
       headers: { "x-forwarded-for": "203.0.113.5, 127.0.0.1" },
     });
 

--- a/gateway/src/__tests__/slack-deliver.test.ts
+++ b/gateway/src/__tests__/slack-deliver.test.ts
@@ -20,7 +20,6 @@ mock.module("../auth/token-exchange.js", () => ({
   mintIngressToken: () => "mock-ingress-token",
   mintServiceToken: () => "mock-service-token",
   mintExchangeToken: () => "mock-exchange-token",
-  mintBrowserRelayToken: () => "mock-browser-relay-token",
   validateEdgeToken: () => ({ ok: true }),
 }));
 

--- a/gateway/src/auth/token-exchange.ts
+++ b/gateway/src/auth/token-exchange.ts
@@ -22,9 +22,6 @@ const log = getLogger("token-exchange");
 /** TTL for exchange tokens — short-lived, minted per-request. */
 const EXCHANGE_TOKEN_TTL_SECONDS = 60;
 
-/** TTL for browser relay tokens — longer-lived for extension use. */
-const BROWSER_RELAY_TOKEN_TTL_SECONDS = 3600;
-
 // ---------------------------------------------------------------------------
 // Edge token validation
 // ---------------------------------------------------------------------------
@@ -129,22 +126,5 @@ export function mintServiceToken(): string {
     scope_profile: "gateway_service_v1",
     policy_epoch: CURRENT_POLICY_EPOCH,
     ttlSeconds: EXCHANGE_TOKEN_TTL_SECONDS,
-  });
-}
-
-/**
- * Mint a long-lived token for the Chrome extension to connect to the
- * browser relay WebSocket. Uses gateway audience so it passes
- * validateEdgeToken() on the WS upgrade path.
- *
- * sub=svc:browser-relay:self, scope_profile=gateway_service_v1, TTL=1h
- */
-export function mintBrowserRelayToken(): string {
-  return mintToken({
-    aud: "vellum-gateway",
-    sub: "svc:browser-relay:self",
-    scope_profile: "gateway_service_v1",
-    policy_epoch: CURRENT_POLICY_EPOCH,
-    ttlSeconds: BROWSER_RELAY_TOKEN_TTL_SECONDS,
   });
 }

--- a/gateway/src/http/middleware/rate-limit.ts
+++ b/gateway/src/http/middleware/rate-limit.ts
@@ -43,8 +43,6 @@ function isRateLimitedRoute(url: URL): boolean {
     url.pathname === "/deliver/slack" ||
     url.pathname.startsWith("/pairing/") ||
     url.pathname === "/webhooks/oauth/callback" ||
-    (url.pathname.startsWith("/v1/") &&
-      url.pathname !== "/v1/browser-relay" &&
-      url.pathname !== "/v1/browser-relay/token")
+    (url.pathname.startsWith("/v1/") && url.pathname !== "/v1/browser-relay")
   );
 }

--- a/gateway/src/http/routes/browser-relay-websocket.ts
+++ b/gateway/src/http/routes/browser-relay-websocket.ts
@@ -161,8 +161,9 @@ type AuthCheckResult =
  * The gateway accepts the token via `Authorization: Bearer <jwt>` or a
  * `?token=` query parameter (browser WebSocket upgrades cannot set custom
  * headers, so the query param is the primary mechanism for the Chrome
- * extension). When the token carries an actor principal in its sub claim,
- * we propagate the `actorPrincipalId` forward as the guardian identity so
+ * extension). Tokens must carry an actor principal in `sub`; service
+ * subjects (`svc:*:*`) are rejected on this route. The extracted
+ * `actorPrincipalId` is propagated forward as the guardian identity so
  * the runtime can register the connection under the correct guardian.
  */
 export function checkBrowserRelayAuth(
@@ -218,20 +219,25 @@ export function checkBrowserRelayAuth(
   }
 
   const parsed = parseSub(result.claims.sub);
-  let guardianId: string | undefined;
   if (
-    parsed.ok &&
-    parsed.principalType === "actor" &&
-    parsed.actorPrincipalId
+    !parsed.ok ||
+    parsed.principalType !== "actor" ||
+    !parsed.actorPrincipalId
   ) {
-    guardianId = parsed.actorPrincipalId;
-  } else if (!parsed.ok) {
-    // Not fatal — service tokens (svc:*:*) and unknown subs still reach
-    // the runtime, where they are rejected if no guardian is available.
-    log.debug(
-      { reason: parsed.reason, sub: result.claims.sub },
-      "Browser relay WS: edge token sub did not yield actor principal",
+    // Fail closed: browser-relay sockets must be guardian-scoped.
+    // Service tokens (`svc:*:*`) do not carry an actor principal and are
+    // therefore rejected on this path.
+    log.warn(
+      {
+        reason: parsed.ok ? "missing_actor_principal" : parsed.reason,
+        sub: result.claims.sub,
+      },
+      "Browser relay WS: denied token without actor principal",
     );
+    return {
+      ok: false,
+      response: new Response("Unauthorized", { status: 401 }),
+    };
   }
 
   return {
@@ -239,7 +245,7 @@ export function checkBrowserRelayAuth(
     context: {
       authenticated: true,
       authBypassed: false,
-      guardianId,
+      guardianId: parsed.actorPrincipalId,
       clientInstanceId,
     },
   };

--- a/gateway/src/http/routes/log-export.test.ts
+++ b/gateway/src/http/routes/log-export.test.ts
@@ -46,7 +46,6 @@ mock.module("../../auth/token-exchange.js", () => ({
   validateEdgeToken: () => ({ ok: true, claims: {} }),
   mintExchangeToken: () => "mock-exchange",
   mintIngressToken: () => "mock-ingress",
-  mintBrowserRelayToken: () => "mock-browser-relay",
 }));
 
 mock.module("../../logger.js", () => {

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -6,11 +6,7 @@ import {
   loadOrCreateSigningKey,
   initSigningKey,
 } from "./auth/token-service.js";
-import {
-  validateEdgeToken,
-  mintBrowserRelayToken,
-  mintServiceToken,
-} from "./auth/token-exchange.js";
+import { validateEdgeToken, mintServiceToken } from "./auth/token-exchange.js";
 import { ConfigFileCache } from "./config-file-cache.js";
 import { ConfigFileWatcher } from "./config-file-watcher.js";
 import { FeatureFlagWatcher } from "./feature-flag-watcher.js";
@@ -26,7 +22,6 @@ import { createRuntimeProxyHandler } from "./http/routes/runtime-proxy.js";
 import {
   createBrowserRelayWebsocketHandler,
   getBrowserRelayWebsocketHandlers,
-  isLoopbackPeer,
   type BrowserRelaySocketData,
 } from "./http/routes/browser-relay-websocket.js";
 import { createTelegramDeliverHandler } from "./http/routes/telegram-deliver.js";
@@ -1165,22 +1160,6 @@ async function main() {
         const upgradeResult = handleBrowserRelayWs(req, server);
         if (upgradeResult !== undefined) return upgradeResult;
         return undefined as unknown as Response;
-      }
-
-      // ── Pre-router: browser relay token endpoint ──
-      if (
-        config.runtimeProxyEnabled &&
-        url.pathname === "/v1/browser-relay/token" &&
-        req.method === "GET"
-      ) {
-        if (!isLoopbackPeer(svr, req, { trustProxy: config.trustProxy })) {
-          return Response.json(
-            { error: "Browser relay token only available from localhost" },
-            { status: 403 },
-          );
-        }
-        const token = mintBrowserRelayToken();
-        return Response.json({ token });
       }
 
       // Attach a trace ID to every non-healthcheck request for

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -70,43 +70,6 @@ export function buildSchema(): Record<string, unknown> {
           },
         },
       },
-      "/v1/browser-relay/token": {
-        get: {
-          summary: "Browser relay bearer token",
-          description:
-            "Returns a short-lived JWT that the Chrome extension can use to authenticate its WebSocket connection to `/v1/browser-relay`. Only accessible from localhost (private network peers).",
-          operationId: "getBrowserRelayToken",
-          responses: {
-            "200": {
-              description: "Token minted successfully",
-              content: {
-                "application/json": {
-                  schema: {
-                    type: "object",
-                    properties: {
-                      token: {
-                        type: "string",
-                        description:
-                          "JWT bearer token for browser relay WebSocket authentication",
-                      },
-                    },
-                    required: ["token"],
-                  },
-                },
-              },
-            },
-            "403": {
-              description:
-                "Forbidden — only accessible from localhost / private network",
-              content: {
-                "application/json": {
-                  schema: { $ref: "#/components/schemas/ErrorResponse" },
-                },
-              },
-            },
-          },
-        },
-      },
       "/v1/health": {
         get: {
           summary: "Runtime health (via gateway)",


### PR DESCRIPTION
## Summary
- Removes the legacy `GET /v1/browser-relay/token` endpoint, `mintBrowserRelayToken`, and the service-token path through the browser-relay WS. Self-hosted now requires native-messaging pairing; service tokens without an actor principal are rejected with 401 (fail closed).
- Cleans the chrome-extension popup/worker of the `bearerToken` storage key, manual token entry UI, and gateway token-refresh ladder — reconnects now re-read the stored capability token or abort with an actionable error.
- Updates tests, architecture docs, and the gateway rate-limit allowlist to match the new shape.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24541" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
