### PR TITLE
chore(daemon): rename turn_context `timestamp:` → `current_time:` with full weekday names

### DIFF
--- a/assistant/docs/architecture/memory.md
+++ b/assistant/docs/architecture/memory.md
@@ -566,7 +566,7 @@ The Anthropic provider places `cache_control: { type: 'ephemeral' }` on the **la
 
 The session injects a unified `<turn_context>` block into every user message, giving the model awareness of the current timestamp (with timezone), interface, channel, and actor identity. This replaces the former separate `<temporal_context>`, `<inbound_actor_context>`, and per-channel turn context blocks. The unified block persists in conversation history so the assistant retains temporal and actor grounding across turns. Legacy blocks from pre-change history are stripped for backward compatibility.
 
-The `timestamp:` field format is: `2026-04-02 (Wed) 14:30:00 -05:00 (America/Chicago)` — date, abbreviated weekday, local time, UTC offset, and IANA timezone name.
+The `current_time:` field format is: `2026-04-02 (Wednesday) 14:30:00 -05:00 (America/Chicago)` — date, weekday name, local time, UTC offset, and IANA timezone name.
 
 ### Per-turn flow
 

--- a/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
@@ -212,7 +212,7 @@ mock.module("../daemon/conversation-runtime-assembly.js", () => ({
 }));
 
 mock.module("../daemon/date-context.js", () => ({
-  formatTurnTimestamp: () => "2026-01-01 (Thu) 00:00:00 +00:00 (UTC)",
+  formatTurnTimestamp: () => "2026-01-01 (Thursday) 00:00:00 +00:00 (UTC)",
 }));
 
 mock.module("../daemon/history-repair.js", () => ({

--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -201,7 +201,7 @@ mock.module("../daemon/conversation-runtime-assembly.js", () => ({
 }));
 
 mock.module("../daemon/date-context.js", () => ({
-  formatTurnTimestamp: () => "2026-01-01 (Thu) 00:00:00 +00:00 (UTC)",
+  formatTurnTimestamp: () => "2026-01-01 (Thursday) 00:00:00 +00:00 (UTC)",
 }));
 
 mock.module("../daemon/history-repair.js", () => ({

--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -604,7 +604,7 @@ describe("applyRuntimeInjections — injection mode", () => {
       supportsVoiceInput: false,
     } as ChannelCapabilities,
     unifiedTurnContext:
-      "<turn_context>\ntimestamp: 2026-03-04 (Tue) 12:00:00 +00:00 (UTC)\ninterface: telegram\n</turn_context>",
+      "<turn_context>\ncurrent_time: 2026-03-04 (Tuesday) 12:00:00 +00:00 (UTC)\ninterface: telegram\n</turn_context>",
     nowScratchpad: "Current focus: shipping PR 3",
     pkbContext: "essentials content here",
     pkbActive: true,
@@ -898,7 +898,7 @@ describe("stripInjectionsForCompaction preserves persistent blocks", () => {
         content: [
           {
             type: "text",
-            text: "<turn_context>\ntimestamp: 2026-04-02 (Thu) 01:52:33 -05:00 (America/Chicago)\ninterface: macos\n</turn_context>",
+            text: "<turn_context>\ncurrent_time: 2026-04-02 (Thursday) 01:52:33 -05:00 (America/Chicago)\ninterface: macos\n</turn_context>",
           },
           { type: "text", text: "Hello" },
         ],
@@ -1087,7 +1087,7 @@ describe("buildUnifiedTurnContextBlock", () => {
     const text = buildUnifiedTurnContextBlock(options);
     const lines = text.split("\n");
     expect(lines[0]).toBe("<turn_context>");
-    expect(lines[1]).toBe("timestamp: 2026-04-02T12:00:00Z");
+    expect(lines[1]).toBe("current_time: 2026-04-02T12:00:00Z");
     expect(lines[2]).toBe("interface: macos");
     expect(lines[3]).toBe("</turn_context>");
     expect(lines).toHaveLength(4);
@@ -1118,7 +1118,7 @@ describe("buildUnifiedTurnContextBlock", () => {
 
     const text = buildUnifiedTurnContextBlock(options);
     expect(text).toContain("<turn_context>");
-    expect(text).toContain("timestamp: 2026-04-02T12:00:00Z");
+    expect(text).toContain("current_time: 2026-04-02T12:00:00Z");
     expect(text).toContain("interface: telegram");
     expect(text).toContain("source_channel: telegram");
     expect(text).toContain("canonical_actor_identity: trusted-user-1");
@@ -1154,7 +1154,7 @@ describe("buildUnifiedTurnContextBlock", () => {
 
     const text = buildUnifiedTurnContextBlock(options);
     expect(text).toContain("<turn_context>");
-    expect(text).toContain("timestamp: 2026-04-02T12:00:00Z");
+    expect(text).toContain("current_time: 2026-04-02T12:00:00Z");
     expect(text).toContain("canonical_actor_identity: unknown");
     expect(text).toContain("trust_class: unknown");
     expect(text).toContain("non-guardian account");
@@ -1315,7 +1315,7 @@ describe("buildUnifiedTurnContextBlock", () => {
     expect(text).not.toContain("interface:");
     const lines = text.split("\n");
     expect(lines[0]).toBe("<turn_context>");
-    expect(lines[1]).toBe("timestamp: 2026-04-02T12:00:00Z");
+    expect(lines[1]).toBe("current_time: 2026-04-02T12:00:00Z");
     expect(lines[2]).toBe("</turn_context>");
   });
 
@@ -1362,7 +1362,7 @@ describe("applyRuntimeInjections with unifiedTurnContext", () => {
   ];
 
   const sampleBlock =
-    "<turn_context>\ntimestamp: 2026-04-02T12:00:00Z\ninterface: macos\n</turn_context>";
+    "<turn_context>\ncurrent_time: 2026-04-02T12:00:00Z\ninterface: macos\n</turn_context>";
 
   test("injects unifiedTurnContext when provided", () => {
     const result = applyRuntimeInjections(baseMessages, {

--- a/assistant/src/__tests__/date-context.test.ts
+++ b/assistant/src/__tests__/date-context.test.ts
@@ -115,7 +115,7 @@ describe("formatTurnTimestamp", () => {
       timeZone: "America/Chicago",
     });
     expect(result).toBe(
-      "2026-04-02 (Thu) 01:52:33 -05:00 (America/Chicago)",
+      "2026-04-02 (Thursday) 01:52:33 -05:00 (America/Chicago)",
     );
   });
 
@@ -124,7 +124,7 @@ describe("formatTurnTimestamp", () => {
       nowMs: THU_APR_02_0652,
       hostTimeZone: "UTC",
     });
-    expect(result).toBe("2026-04-02 (Thu) 06:52:33 +00:00 (UTC)");
+    expect(result).toBe("2026-04-02 (Thursday) 06:52:33 +00:00 (UTC)");
   });
 
   test("handles user timezone override", () => {
@@ -133,7 +133,7 @@ describe("formatTurnTimestamp", () => {
       hostTimeZone: "UTC",
       userTimeZone: "Asia/Tokyo",
     });
-    expect(result).toBe("2026-04-02 (Thu) 15:52:33 +09:00 (Asia/Tokyo)");
+    expect(result).toBe("2026-04-02 (Thursday) 15:52:33 +09:00 (Asia/Tokyo)");
   });
 
   test("handles DST correctly", () => {
@@ -144,7 +144,7 @@ describe("formatTurnTimestamp", () => {
       timeZone: "America/New_York",
     });
     expect(result).toBe(
-      "2026-07-01 (Wed) 08:00:30 -04:00 (America/New_York)",
+      "2026-07-01 (Wednesday) 08:00:30 -04:00 (America/New_York)",
     );
   });
 

--- a/assistant/src/config/bundled-skills/gmail/SKILL.md
+++ b/assistant/src/config/bundled-skills/gmail/SKILL.md
@@ -161,7 +161,7 @@ Scan tools (`gmail_sender_digest`, `gmail_outreach_scan`) return a `scan_id` tha
 
 Before composing any email that references a date or time:
 
-1. Check the `timestamp:` field in the `<turn_context>` block for today's date and timezone
+1. Check the `current_time:` field in the `<turn_context>` block for today's date and timezone
 2. Verify that "tomorrow" means the day after today's date, "next week" means the upcoming Monday–Friday, etc.
 3. If the email references a date from another message, cross-check it against the turn context to ensure it's in the future
 

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -904,7 +904,7 @@ export function buildUnifiedTurnContextBlock(
   };
 
   const lines: string[] = ["<turn_context>"];
-  lines.push(`timestamp: ${options.timestamp}`);
+  lines.push(`current_time: ${options.timestamp}`);
   if (options.interfaceName) {
     lines.push(`interface: ${options.interfaceName}`);
   }

--- a/assistant/src/daemon/date-context.ts
+++ b/assistant/src/daemon/date-context.ts
@@ -18,14 +18,14 @@ export interface TemporalContextOptions {
   userTimeZone?: string | null;
 }
 
-const WEEKDAY_SHORT = [
-  "Sun",
-  "Mon",
-  "Tue",
-  "Wed",
-  "Thu",
-  "Fri",
-  "Sat",
+const WEEKDAY_LONG = [
+  "Sunday",
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
 ] as const;
 const UTC_GMT_OFFSET_TOKEN_RE = /^(?:UTC|GMT)([+-])(\d{1,2})(?::?(\d{2}))?$/i;
 
@@ -295,7 +295,7 @@ function formatLocalDate(date: Date, timeZone: string): string {
  * Uses the timezone resolution cascade:
  * explicit override → configured user tz → profile user tz → host fallback.
  *
- * Returns format: `2026-04-02 (Thu) 01:52:33 -05:00 (America/Chicago)`
+ * Returns format: `2026-04-02 (Thursday) 01:52:33 -05:00 (America/Chicago)`
  */
 export function formatTurnTimestamp(
   options: TemporalContextOptions = {},
@@ -322,7 +322,7 @@ export function formatTurnTimestamp(
 
   const dateStr = formatLocalDate(now, timeZone);
   const todayParts = localDateParts(now, timeZone);
-  const dayName = WEEKDAY_SHORT[todayParts.weekday];
+  const dayName = WEEKDAY_LONG[todayParts.weekday];
 
   const fmt = new Intl.DateTimeFormat("en-US", {
     timeZone,

--- a/skills/time-based-actions/SKILL.md
+++ b/skills/time-based-actions/SKILL.md
@@ -45,13 +45,13 @@ If you use `send_notification` for any of these, the notification fires immediat
 
 ## Time Grounding Source
 
-Use the `timestamp:` field from the injected `<turn_context>` block as the authoritative clock source. The timestamp format is:
+Use the `current_time:` field from the injected `<turn_context>` block as the authoritative clock source. The format is:
 
 ```
-timestamp: 2026-04-02 (Wed) 14:30:00 -05:00 (America/Chicago)
+current_time: 2026-04-02 (Wednesday) 14:30:00 -05:00 (America/Chicago)
 ```
 
-It contains the date, abbreviated weekday, local time (HH:MM:SS), UTC offset, and IANA timezone name in parentheses.
+It contains the date, weekday name, local time (HH:MM:SS), UTC offset, and IANA timezone name in parentheses.
 
 **Timezone confidence check:** The timezone shown may be the assistant host's timezone rather than the user's actual timezone (this happens when the user hasn't configured `Settings → Appearance → User timezone`). If you have no prior confirmation of the user's timezone (from conversation history or memory) and the request is locale-specific (e.g. "at 3pm", "tomorrow morning", "tonight"), confirm the timezone once before scheduling. If the user confirms, suggest saving it in Settings → Appearance → User timezone so future requests resolve correctly without re-asking.
 
@@ -59,7 +59,7 @@ It contains the date, abbreviated weekday, local time (HH:MM:SS), UTC offset, an
 
 When the user says "in X minutes/hours", compute the ISO 8601 timestamp yourself:
 
-- Take the time and offset from the `timestamp:` field (e.g. `23:26:00 -05:00`)
+- Take the time and offset from the `current_time:` field (e.g. `23:26:00 -05:00`)
 - Add the requested offset
 - Format as ISO 8601 with timezone: `2025-03-15T09:05:00-05:00`
 - Pass to `reminder_create` as `fire_at`


### PR DESCRIPTION
## Summary

- Rename the first field of the injected `<turn_context>` block from `timestamp:` to `current_time:` for schema coherence with the other snake_case fields in the block (`source_channel:`, `actor_display_name:`, etc.).
- Emit the full weekday name (`Thursday`) instead of the abbreviation (`Thu`) so the line reads more naturally for the model.
- Cascade updates to the snapshot tests that lock the format and to the two SKILL.md files (`time-based-actions`, `gmail`) plus `assistant/docs/architecture/memory.md` that instruct the model to read this field.

Before:
```
timestamp: 2026-04-09 (Thu) 14:30:00 -05:00 (America/Chicago)
```

After:
```
current_time: 2026-04-09 (Thursday) 14:30:00 -05:00 (America/Chicago)
```

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bun test src/__tests__/date-context.test.ts` (15 pass)
- [x] `bun test src/__tests__/conversation-runtime-assembly.test.ts` (95 pass)
- [x] `bun test src/__tests__/conversation-agent-loop.test.ts` (35 pass)
- [x] `bun test src/__tests__/conversation-agent-loop-overflow.test.ts` (3 pass + 7 todo)
- [x] Grep-sweep: zero hits for `timestamp: 20`, `(Thu)`/`(Wed)`/etc., or backtick-`timestamp:` in docs/skills
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24542" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
