### PR TITLE
fix(macos/tests): gate AppleContainersLauncherTests on macOS 26.0

### DIFF
--- a/clients/macos/vellum-assistantTests/AppleContainersLauncherTests.swift
+++ b/clients/macos/vellum-assistantTests/AppleContainersLauncherTests.swift
@@ -2,6 +2,7 @@ import XCTest
 @testable import VellumAssistantLib
 
 @MainActor
+@available(macOS 26.0, *)
 final class AppleContainersLauncherTests: XCTestCase {
 
     private var originalCheckAvailability: (() -> AppleContainersAvailabilityChecker.Availability)!


### PR DESCRIPTION
## Summary
- Add \`@available(macOS 26.0, *)\` to \`AppleContainersLauncherTests\` so the class compiles on CI's macOS 15.x runner.
- Every test in this class instantiates or references \`AppleContainersLauncher\`, which is \`@available(macOS 26.0, *)\`, so the whole class needs the gate (no split required, unlike #24540).
- Follows the pattern established in #24540 and #24532.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24189766602/job/70603609651
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24543" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
