### PR TITLE
Preview files for uninstalled Vellum catalog skills

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -6756,6 +6756,55 @@ paths:
           required: true
           schema:
             type: string
+  /v1/skills/{id}/files/content:
+    get:
+      operationId: skills_by_id_files_content_get
+      summary: Get skill file content
+      description: Return the content of a single file belonging to an installed or catalog skill.
+      tags:
+        - skills
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  path:
+                    type: string
+                  name:
+                    type: string
+                  size:
+                    type: number
+                  mimeType:
+                    type: string
+                  isBinary:
+                    type: boolean
+                  content:
+                    anyOf:
+                      - type: string
+                      - type: "null"
+                required:
+                  - path
+                  - name
+                  - size
+                  - mimeType
+                  - isBinary
+                  - content
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: path
+          in: query
+          required: true
+          schema:
+            type: string
+          description: Relative path of the file within the skill directory
   /v1/skills/{id}/inspect:
     get:
       operationId: skills_by_id_inspect_get

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -6776,7 +6776,9 @@ paths:
                   name:
                     type: string
                   size:
-                    type: number
+                    type: integer
+                    minimum: -9007199254740991
+                    maximum: 9007199254740991
                   mimeType:
                     type: string
                   isBinary:

--- a/assistant/src/__tests__/catalog-files.test.ts
+++ b/assistant/src/__tests__/catalog-files.test.ts
@@ -222,9 +222,10 @@ describe("sanitizeRelativePath", () => {
   });
 
   test("rejects paths that become absolute after ./ stripping", () => {
-    // The leading `./` strip loop used to leave `/etc/passwd` behind, which
-    // posix.normalize then passed through as an absolute path. The
-    // post-normalization absolute-path check should reject each of these.
+    // `sanitizeRelativePath` performs a post-normalization absolute-path
+    // check so inputs like `.//etc/passwd` cannot reach the filesystem:
+    // the leading `./` strip loop leaves `/etc/passwd`, which
+    // `posix.normalize` would otherwise pass through as an absolute path.
     expect(sanitizeRelativePath(".//etc/passwd")).toBeNull();
     expect(sanitizeRelativePath("./././/etc/passwd")).toBeNull();
     // The backslash normalizes to `/`, so `.\\/etc/passwd` becomes
@@ -287,19 +288,20 @@ describe("readCatalogSkillFiles (dev mode)", () => {
   });
 
   test("rejects a symlinked skill root and falls through to platform mode", async () => {
-    // Reproduces the Codex P2 attack: an attacker (or a misconfigured dev)
-    // creates <repoSkillsDir>/my-skill as a symlink pointing at an external
-    // directory. Without the symlink-root check in `resolveCatalogSource`,
-    // the dev-mode branch would happily walk the external directory,
-    // because the realpath containment check downstream derives `realRoot`
-    // from the already-resolved symlink target.
+    // An attacker (or a misconfigured dev) creates
+    // <repoSkillsDir>/my-skill as a symlink pointing at an external
+    // directory. `resolveCatalogSource` rejects symlinked skill roots so
+    // the dev-mode branch never walks the external directory — the
+    // realpath containment check downstream would otherwise derive
+    // `realRoot` from the already-resolved symlink target and become a
+    // no-op.
     //
     // Expected behavior: the dev-mode shortcut is rejected up-front, and
     // we fall through to platform mode — which in this test is stubbed
-    // to return an empty file list. So `readCatalogSkillFiles` should
-    // return the empty platform response, and `fetch` MUST be called
-    // (proving the fall-through happened, rather than the dev-mode
-    // shortcut silently reading from the external directory).
+    // to return an empty file list. So `readCatalogSkillFiles` returns
+    // the empty platform response, and `fetch` MUST be called (proving
+    // the fall-through happened, rather than the dev-mode shortcut
+    // silently reading from the external directory).
     const root = makeTempSkillsDir();
     const externalRoot = mkdtempSync(join(tmpdir(), "catalog-files-ext-"));
     tempDirs.push(externalRoot);
@@ -662,6 +664,74 @@ describe("readCatalogSkillFileContent (dev mode)", () => {
     );
     expect(entry).toBeNull();
   });
+
+  test("rejects dotfile paths and returns null without reading disk", async () => {
+    // `.env` is a valid sanitized path (sanitizeRelativePath accepts it),
+    // but the hidden-segment check must reject it so the catalog content
+    // reader never exposes dotfiles, matching the listing API that hides
+    // them. This preserves parity between listing and content endpoints.
+    const root = makeTempSkillsDir();
+    writeSkill(root, "my-skill", {
+      "SKILL.md": "ok",
+      ".env": "SECRET=abc\n",
+    });
+    mockRepoSkillsDir = root;
+    mockCatalog = [skill("my-skill")];
+    installFetchForbidden();
+
+    expect(await readCatalogSkillFileContent("my-skill", ".env")).toBeNull();
+    expect(
+      await readCatalogSkillFileContent("my-skill", ".git/config"),
+    ).toBeNull();
+    expect(
+      await readCatalogSkillFileContent("my-skill", "docs/.hidden/file.md"),
+    ).toBeNull();
+  });
+
+  test("rejects SKIP_DIRS paths and returns null without reading disk", async () => {
+    const root = makeTempSkillsDir();
+    writeSkill(root, "my-skill", {
+      "SKILL.md": "ok",
+      "node_modules/foo/index.js": "module.exports = {};",
+    });
+    mockRepoSkillsDir = root;
+    mockCatalog = [skill("my-skill")];
+    installFetchForbidden();
+
+    expect(
+      await readCatalogSkillFileContent(
+        "my-skill",
+        "node_modules/foo/index.js",
+      ),
+    ).toBeNull();
+    expect(
+      await readCatalogSkillFileContent("my-skill", "__pycache__/cached.pyc"),
+    ).toBeNull();
+    expect(
+      await readCatalogSkillFileContent(
+        "my-skill",
+        "nested/node_modules/foo.js",
+      ),
+    ).toBeNull();
+  });
+
+  test("regular docs/readme.md still returns content (sanity)", async () => {
+    const root = makeTempSkillsDir();
+    writeSkill(root, "my-skill", {
+      "docs/readme.md": "# readme\n",
+    });
+    mockRepoSkillsDir = root;
+    mockCatalog = [skill("my-skill")];
+    installFetchForbidden();
+
+    const entry = await readCatalogSkillFileContent(
+      "my-skill",
+      "docs/readme.md",
+    );
+    expect(entry).not.toBeNull();
+    expect(entry!.content).toBe("# readme\n");
+    expect(entry!.name).toBe("readme.md");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -757,6 +827,28 @@ describe("readCatalogSkillFileContent (platform mode)", () => {
     expect(await readCatalogSkillFileContent("remote-skill", "..")).toBeNull();
     expect(
       await readCatalogSkillFileContent("remote-skill", "../etc/passwd"),
+    ).toBeNull();
+    expect(fetchCalls.length).toBe(0);
+  });
+
+  test("rejects hidden / SKIP_DIRS paths BEFORE making any fetch call", async () => {
+    // Platform-mode defense in depth: even though the platform endpoint
+    // would refuse these reads server-side, we must short-circuit in
+    // `readCatalogSkillFileContent` so an attacker cannot use the daemon
+    // as a probe channel (and so we avoid unnecessary network traffic).
+    mockCatalog = [skill("remote-skill")];
+    installFetchForbidden();
+    expect(
+      await readCatalogSkillFileContent("remote-skill", ".env"),
+    ).toBeNull();
+    expect(
+      await readCatalogSkillFileContent("remote-skill", ".git/config"),
+    ).toBeNull();
+    expect(
+      await readCatalogSkillFileContent(
+        "remote-skill",
+        "node_modules/foo/index.js",
+      ),
     ).toBeNull();
     expect(fetchCalls.length).toBe(0);
   });

--- a/assistant/src/__tests__/catalog-files.test.ts
+++ b/assistant/src/__tests__/catalog-files.test.ts
@@ -1,0 +1,770 @@
+/**
+ * Unit tests for `skills/catalog-files.ts` — preview listings and single-file
+ * content for catalog skills (installed or not).
+ *
+ * Covers:
+ *   - sanitizeRelativePath (accepts safe, rejects traversal / absolute / null)
+ *   - readCatalogSkillFiles dev-mode (reads from a temp fake repo skills dir,
+ *     does NOT touch fetch)
+ *   - readCatalogSkillFiles platform-mode (stubbed fetch with success + 500
+ *     + 404 + network-error)
+ *   - readCatalogSkillFileContent dev-mode (text, traversal rejection,
+ *     binary, oversized)
+ *   - readCatalogSkillFileContent platform-mode (text, binary, oversized,
+ *     404, pre-fetch traversal rejection)
+ *   - catalog-miss short-circuit (no fetch call when id unknown)
+ */
+
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { CatalogSkill } from "../skills/catalog-install.js";
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before importing the module under test
+// ---------------------------------------------------------------------------
+
+// Suppress logger output
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+let mockCatalog: CatalogSkill[] = [];
+let mockRepoSkillsDir: string | undefined = undefined;
+
+mock.module("../skills/catalog-cache.js", () => ({
+  getCatalog: async () => mockCatalog,
+}));
+
+mock.module("../skills/catalog-install.js", () => ({
+  getRepoSkillsDir: () => mockRepoSkillsDir,
+}));
+
+let mockPlatformToken: string | null = null;
+mock.module("../util/platform.ts", () => ({
+  readPlatformToken: () => mockPlatformToken,
+}));
+mock.module("../util/platform.js", () => ({
+  readPlatformToken: () => mockPlatformToken,
+}));
+
+let mockPlatformBaseUrl = "https://platform.test";
+mock.module("../config/env.ts", () => ({
+  getPlatformBaseUrl: () => mockPlatformBaseUrl,
+}));
+mock.module("../config/env.js", () => ({
+  getPlatformBaseUrl: () => mockPlatformBaseUrl,
+}));
+
+// ---------------------------------------------------------------------------
+// Imports (after mocks)
+// ---------------------------------------------------------------------------
+
+import {
+  readCatalogSkillFileContent,
+  readCatalogSkillFiles,
+  sanitizeRelativePath,
+} from "../skills/catalog-files.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type FetchFn = typeof globalThis.fetch;
+
+interface FetchCall {
+  url: string;
+  init?: RequestInit;
+}
+
+let originalFetch: FetchFn;
+let fetchCalls: FetchCall[] = [];
+
+function installFetchMock(
+  handler: (url: string, init?: RequestInit) => Response | Promise<Response>,
+): void {
+  fetchCalls = [];
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+    fetchCalls.push({ url, init });
+    return handler(url, init);
+  }) as unknown as FetchFn;
+}
+
+function installFetchThrow(error: Error): void {
+  fetchCalls = [];
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+    fetchCalls.push({ url, init });
+    throw error;
+  }) as unknown as FetchFn;
+}
+
+function installFetchForbidden(): void {
+  fetchCalls = [];
+  globalThis.fetch = (async () => {
+    throw new Error("fetch should not have been called");
+  }) as unknown as FetchFn;
+}
+
+// Temp directories created during tests, cleaned up in afterEach.
+const tempDirs: string[] = [];
+
+function makeTempSkillsDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "catalog-files-test-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function writeSkill(
+  root: string,
+  skillId: string,
+  files: Record<string, string | Buffer>,
+): string {
+  const skillDir = join(root, skillId);
+  mkdirSync(skillDir, { recursive: true });
+  for (const [relPath, content] of Object.entries(files)) {
+    const abs = join(skillDir, relPath);
+    mkdirSync(join(abs, ".."), { recursive: true });
+    writeFileSync(abs, content);
+  }
+  return skillDir;
+}
+
+function skill(id: string): CatalogSkill {
+  return { id, name: id, description: id };
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+  fetchCalls = [];
+  mockCatalog = [];
+  mockRepoSkillsDir = undefined;
+  mockPlatformToken = null;
+  mockPlatformBaseUrl = "https://platform.test";
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  for (const dir of tempDirs) {
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // best effort
+    }
+  }
+  tempDirs.length = 0;
+});
+
+// ---------------------------------------------------------------------------
+// sanitizeRelativePath
+// ---------------------------------------------------------------------------
+
+describe("sanitizeRelativePath", () => {
+  test("accepts simple posix paths", () => {
+    expect(sanitizeRelativePath("SKILL.md")).toBe("SKILL.md");
+    expect(sanitizeRelativePath("tools/run.sh")).toBe("tools/run.sh");
+    expect(sanitizeRelativePath("a/b/c.txt")).toBe("a/b/c.txt");
+  });
+
+  test("normalizes leading ./", () => {
+    expect(sanitizeRelativePath("./x")).toBe("x");
+    expect(sanitizeRelativePath("./tools/run.sh")).toBe("tools/run.sh");
+  });
+
+  test("normalizes backslashes to forward slashes", () => {
+    expect(sanitizeRelativePath("tools\\run.sh")).toBe("tools/run.sh");
+  });
+
+  test("rejects empty strings", () => {
+    expect(sanitizeRelativePath("")).toBeNull();
+  });
+
+  test("rejects parent-traversal", () => {
+    expect(sanitizeRelativePath("..")).toBeNull();
+    expect(sanitizeRelativePath("../x")).toBeNull();
+    expect(sanitizeRelativePath("../../etc/passwd")).toBeNull();
+  });
+
+  test("rejects absolute unix paths", () => {
+    expect(sanitizeRelativePath("/etc/passwd")).toBeNull();
+    expect(sanitizeRelativePath("/")).toBeNull();
+  });
+
+  test("rejects windows drive-prefixed paths", () => {
+    expect(sanitizeRelativePath("C:/win")).toBeNull();
+    expect(sanitizeRelativePath("C:\\Windows")).toBeNull();
+  });
+
+  test("rejects paths that become absolute after ./ stripping", () => {
+    // The leading `./` strip loop used to leave `/etc/passwd` behind, which
+    // posix.normalize then passed through as an absolute path. The
+    // post-normalization absolute-path check should reject each of these.
+    expect(sanitizeRelativePath(".//etc/passwd")).toBeNull();
+    expect(sanitizeRelativePath("./././/etc/passwd")).toBeNull();
+    // The backslash normalizes to `/`, so `.\\/etc/passwd` becomes
+    // `.//etc/passwd` before the strip loop, then `/etc/passwd`.
+    expect(sanitizeRelativePath(".\\/etc/passwd")).toBeNull();
+    // Windows-drive bypass via the same mechanism.
+    expect(sanitizeRelativePath(".//C:/Windows/system32")).toBeNull();
+  });
+
+  test("rejects paths containing null bytes", () => {
+    expect(sanitizeRelativePath("SKILL.md\0.png")).toBeNull();
+    expect(sanitizeRelativePath("\0")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// readCatalogSkillFiles — dev mode
+// ---------------------------------------------------------------------------
+
+describe("readCatalogSkillFiles (dev mode)", () => {
+  test("lists files from the repo skills dir without touching fetch", async () => {
+    const root = makeTempSkillsDir();
+    writeSkill(root, "my-skill", {
+      "SKILL.md": "# hello",
+      "tools/run.sh": "#!/bin/sh\necho hi\n",
+      "data/img.png": Buffer.from([0x89, 0x50, 0x4e, 0x47]),
+    });
+    mockRepoSkillsDir = root;
+    mockCatalog = [skill("my-skill")];
+    installFetchForbidden();
+
+    const entries = await readCatalogSkillFiles("my-skill");
+    expect(entries).not.toBeNull();
+    const paths = entries!.map((e) => e.path).sort();
+    expect(paths).toEqual(["SKILL.md", "data/img.png", "tools/run.sh"]);
+
+    const md = entries!.find((e) => e.path === "SKILL.md")!;
+    expect(md.name).toBe("SKILL.md");
+    expect(md.size).toBe("# hello".length);
+    expect(md.isBinary).toBe(false);
+    expect(md.content).toBeNull();
+
+    const png = entries!.find((e) => e.path === "data/img.png")!;
+    expect(png.name).toBe("img.png");
+    expect(png.isBinary).toBe(true);
+    expect(png.content).toBeNull();
+
+    expect(fetchCalls.length).toBe(0);
+  });
+
+  test("returns null when skill id is not in the catalog (dev mode)", async () => {
+    const root = makeTempSkillsDir();
+    writeSkill(root, "my-skill", { "SKILL.md": "x" });
+    mockRepoSkillsDir = root;
+    mockCatalog = []; // not in catalog
+    installFetchForbidden();
+
+    expect(await readCatalogSkillFiles("my-skill")).toBeNull();
+    expect(fetchCalls.length).toBe(0);
+  });
+
+  test("rejects a symlinked skill root and falls through to platform mode", async () => {
+    // Reproduces the Codex P2 attack: an attacker (or a misconfigured dev)
+    // creates <repoSkillsDir>/my-skill as a symlink pointing at an external
+    // directory. Without the symlink-root check in `resolveCatalogSource`,
+    // the dev-mode branch would happily walk the external directory,
+    // because the realpath containment check downstream derives `realRoot`
+    // from the already-resolved symlink target.
+    //
+    // Expected behavior: the dev-mode shortcut is rejected up-front, and
+    // we fall through to platform mode — which in this test is stubbed
+    // to return an empty file list. So `readCatalogSkillFiles` should
+    // return the empty platform response, and `fetch` MUST be called
+    // (proving the fall-through happened, rather than the dev-mode
+    // shortcut silently reading from the external directory).
+    const root = makeTempSkillsDir();
+    const externalRoot = mkdtempSync(join(tmpdir(), "catalog-files-ext-"));
+    tempDirs.push(externalRoot);
+
+    // External directory populated with a real SKILL.md + a secret file
+    // that must NOT be exposed by the listing.
+    writeFileSync(join(externalRoot, "SKILL.md"), "# EXTERNAL SKILL");
+    writeFileSync(join(externalRoot, "secret.txt"), "EXTERNAL_SECRET");
+
+    // Symlink the skill root at `<root>/my-skill` to the external dir.
+    symlinkSync(externalRoot, join(root, "my-skill"));
+
+    mockRepoSkillsDir = root;
+    mockCatalog = [skill("my-skill")];
+    installFetchMock(() => Response.json({ skill_id: "my-skill", files: [] }));
+
+    const entries = await readCatalogSkillFiles("my-skill");
+
+    // Fall-through should produce the platform response (empty array),
+    // NOT the external directory contents.
+    expect(entries).toEqual([]);
+
+    // Confirm the dev-mode shortcut was bypassed: platform fetch was
+    // called against the preview endpoint.
+    expect(fetchCalls.length).toBe(1);
+    expect(fetchCalls[0]!.url).toBe(
+      "https://platform.test/v1/skills/my-skill/files/",
+    );
+  });
+
+  test("rejects a symlinked skill root for content reads and falls through to platform mode", async () => {
+    // Direct reproduction for `readCatalogSkillFileContent`: with a
+    // symlinked skill root, the dev branch must not read the external
+    // file. Instead we should fall through to the platform endpoint and
+    // return whatever the platform says.
+    const root = makeTempSkillsDir();
+    const externalRoot = mkdtempSync(join(tmpdir(), "catalog-files-ext-"));
+    tempDirs.push(externalRoot);
+
+    writeFileSync(join(externalRoot, "SKILL.md"), "EXTERNAL_SKILL_CONTENT");
+    symlinkSync(externalRoot, join(root, "my-skill"));
+
+    mockRepoSkillsDir = root;
+    mockCatalog = [skill("my-skill")];
+    installFetchMock(() =>
+      Response.json({
+        path: "SKILL.md",
+        name: "SKILL.md",
+        size: 14,
+        mime_type: "text/markdown",
+        is_binary: false,
+        content: "PLATFORM_CONTENT",
+      }),
+    );
+
+    const entry = await readCatalogSkillFileContent("my-skill", "SKILL.md");
+    expect(entry).not.toBeNull();
+    // Content must be the platform payload, NOT the external file's
+    // bytes — otherwise the fall-through didn't happen.
+    expect(entry!.content).toBe("PLATFORM_CONTENT");
+    expect(entry!.mimeType).toBe("text/markdown");
+
+    // And fetch was called, confirming dev-mode was bypassed.
+    expect(fetchCalls.length).toBe(1);
+    const url = fetchCalls[0]!.url;
+    expect(
+      url.startsWith("https://platform.test/v1/skills/my-skill/files/content/"),
+    ).toBe(true);
+  });
+
+  test("non-symlinked skill root still uses the dev-mode shortcut", async () => {
+    // Sanity check: a normal directory-based skill root must still be
+    // served from disk without touching fetch. This guards against the
+    // symlink-rejection path collateral-damaging regular dev flows.
+    const root = makeTempSkillsDir();
+    writeSkill(root, "normal-skill", { "SKILL.md": "# normal\n" });
+    mockRepoSkillsDir = root;
+    mockCatalog = [skill("normal-skill")];
+    installFetchForbidden();
+
+    const entries = await readCatalogSkillFiles("normal-skill");
+    expect(entries).not.toBeNull();
+    const paths = entries!.map((e) => e.path).sort();
+    expect(paths).toEqual(["SKILL.md"]);
+    // No platform round-trip happened.
+    expect(fetchCalls.length).toBe(0);
+  });
+
+  test("filters hidden files and SKIP_DIRS from the listing", async () => {
+    // Simulates a dev working on a catalog skill locally who has a
+    // node_modules/, a .git/, and a .hidden.md file sitting next to
+    // SKILL.md. The preview listing must only show SKILL.md — matching
+    // the behavior of `readDirRecursive` in `daemon/handlers/skills.ts`
+    // for installed skills.
+    const root = makeTempSkillsDir();
+    writeSkill(root, "my-skill", {
+      "SKILL.md": "# hello",
+      "node_modules/foo.js": "module.exports = {};",
+      "node_modules/nested/bar.js": "module.exports = {};",
+      "__pycache__/cached.pyc": Buffer.from([0x00, 0x01, 0x02]),
+      ".git/HEAD": "ref: refs/heads/main\n",
+      ".git/config": "[core]\n",
+      ".hidden.md": "secret",
+      ".DS_Store": Buffer.from([0x00, 0x00]),
+    });
+    mockRepoSkillsDir = root;
+    mockCatalog = [skill("my-skill")];
+    installFetchForbidden();
+
+    const entries = await readCatalogSkillFiles("my-skill");
+    expect(entries).not.toBeNull();
+    const paths = entries!.map((e) => e.path).sort();
+    expect(paths).toEqual(["SKILL.md"]);
+    expect(fetchCalls.length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// readCatalogSkillFiles — platform mode
+// ---------------------------------------------------------------------------
+
+describe("readCatalogSkillFiles (platform mode)", () => {
+  test("fetches file listing from the platform and maps it", async () => {
+    mockRepoSkillsDir = undefined;
+    mockCatalog = [skill("remote-skill")];
+    mockPlatformToken = "tok-123";
+    installFetchMock(() =>
+      Response.json({
+        skill_id: "remote-skill",
+        files: [
+          { path: "SKILL.md", name: "SKILL.md", size: 12, sha: "a" },
+          { path: "data/img.png", name: "img.png", size: 200, sha: "b" },
+        ],
+      }),
+    );
+
+    const entries = await readCatalogSkillFiles("remote-skill");
+    expect(entries).not.toBeNull();
+    expect(entries!.length).toBe(2);
+
+    // URL + headers
+    expect(fetchCalls.length).toBe(1);
+    expect(fetchCalls[0]!.url).toBe(
+      "https://platform.test/v1/skills/remote-skill/files/",
+    );
+    const headers = (fetchCalls[0]!.init?.headers ?? {}) as Record<
+      string,
+      string
+    >;
+    expect(headers["Accept"]).toBe("application/json");
+    expect(headers["X-Conversation-Token"]).toBe("tok-123");
+
+    // Mapped entries: always content === null, isBinary from filename.
+    const md = entries!.find((e) => e.path === "SKILL.md")!;
+    expect(md.isBinary).toBe(false);
+    expect(md.content).toBeNull();
+    expect(md.mimeType).toBe("");
+
+    const png = entries!.find((e) => e.path === "data/img.png")!;
+    expect(png.isBinary).toBe(true);
+    expect(png.content).toBeNull();
+    expect(png.mimeType).toBe("");
+  });
+
+  test("does not set X-Conversation-Token when no token is present", async () => {
+    mockCatalog = [skill("remote-skill")];
+    mockPlatformToken = null;
+    installFetchMock(() =>
+      Response.json({ skill_id: "remote-skill", files: [] }),
+    );
+
+    await readCatalogSkillFiles("remote-skill");
+    const headers = (fetchCalls[0]!.init?.headers ?? {}) as Record<
+      string,
+      string
+    >;
+    expect(headers["X-Conversation-Token"]).toBeUndefined();
+  });
+
+  test("returns null on 500", async () => {
+    mockCatalog = [skill("remote-skill")];
+    installFetchMock(
+      () => new Response("boom", { status: 500, statusText: "Server Error" }),
+    );
+    expect(await readCatalogSkillFiles("remote-skill")).toBeNull();
+    expect(fetchCalls.length).toBe(1);
+  });
+
+  test("returns null on 404", async () => {
+    mockCatalog = [skill("remote-skill")];
+    installFetchMock(
+      () => new Response("missing", { status: 404, statusText: "Not Found" }),
+    );
+    expect(await readCatalogSkillFiles("remote-skill")).toBeNull();
+  });
+
+  test("returns null on network error", async () => {
+    mockCatalog = [skill("remote-skill")];
+    installFetchThrow(new Error("ECONNRESET"));
+    expect(await readCatalogSkillFiles("remote-skill")).toBeNull();
+  });
+
+  test("returns null without fetching when skill id missing from catalog", async () => {
+    mockCatalog = [];
+    installFetchForbidden();
+    expect(await readCatalogSkillFiles("unknown")).toBeNull();
+    expect(fetchCalls.length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// readCatalogSkillFileContent — dev mode
+// ---------------------------------------------------------------------------
+
+describe("readCatalogSkillFileContent (dev mode)", () => {
+  test("returns inline UTF-8 content for a text file", async () => {
+    const root = makeTempSkillsDir();
+    writeSkill(root, "my-skill", { "SKILL.md": "# hello world\n" });
+    mockRepoSkillsDir = root;
+    mockCatalog = [skill("my-skill")];
+    installFetchForbidden();
+
+    const entry = await readCatalogSkillFileContent("my-skill", "SKILL.md");
+    expect(entry).not.toBeNull();
+    expect(entry!.path).toBe("SKILL.md");
+    expect(entry!.name).toBe("SKILL.md");
+    expect(entry!.isBinary).toBe(false);
+    expect(entry!.content).toBe("# hello world\n");
+    expect(fetchCalls.length).toBe(0);
+  });
+
+  test("rejects traversal paths without touching the filesystem", async () => {
+    const root = makeTempSkillsDir();
+    writeSkill(root, "my-skill", { "SKILL.md": "ok" });
+    mockRepoSkillsDir = root;
+    mockCatalog = [skill("my-skill")];
+    installFetchForbidden();
+
+    expect(
+      await readCatalogSkillFileContent("my-skill", "../escape"),
+    ).toBeNull();
+    expect(
+      await readCatalogSkillFileContent("my-skill", "/etc/passwd"),
+    ).toBeNull();
+    expect(await readCatalogSkillFileContent("my-skill", "..")).toBeNull();
+    expect(await readCatalogSkillFileContent("my-skill", "")).toBeNull();
+  });
+
+  test("returns content=null for a binary file", async () => {
+    const root = makeTempSkillsDir();
+    writeSkill(root, "my-skill", {
+      "img.png": Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    });
+    mockRepoSkillsDir = root;
+    mockCatalog = [skill("my-skill")];
+    installFetchForbidden();
+
+    const entry = await readCatalogSkillFileContent("my-skill", "img.png");
+    expect(entry).not.toBeNull();
+    expect(entry!.isBinary).toBe(true);
+    expect(entry!.content).toBeNull();
+  });
+
+  test("returns content=null for oversized text files", async () => {
+    const root = makeTempSkillsDir();
+    // Just over 2 MB of 'a'
+    const oversized = "a".repeat(2 * 1024 * 1024 + 1);
+    writeSkill(root, "my-skill", { "big.txt": oversized });
+    mockRepoSkillsDir = root;
+    mockCatalog = [skill("my-skill")];
+    installFetchForbidden();
+
+    const entry = await readCatalogSkillFileContent("my-skill", "big.txt");
+    expect(entry).not.toBeNull();
+    expect(entry!.isBinary).toBe(false);
+    expect(entry!.content).toBeNull();
+    expect(entry!.size).toBe(oversized.length);
+  });
+
+  test("returns null for a missing file", async () => {
+    const root = makeTempSkillsDir();
+    writeSkill(root, "my-skill", { "SKILL.md": "ok" });
+    mockRepoSkillsDir = root;
+    mockCatalog = [skill("my-skill")];
+    installFetchForbidden();
+
+    expect(
+      await readCatalogSkillFileContent("my-skill", "does/not/exist.txt"),
+    ).toBeNull();
+  });
+
+  test("returns null without fetching when skill id missing from catalog", async () => {
+    mockCatalog = [];
+    installFetchForbidden();
+    expect(await readCatalogSkillFileContent("unknown", "SKILL.md")).toBeNull();
+    expect(fetchCalls.length).toBe(0);
+  });
+
+  test("rejects symlinked files that point outside the skill root", async () => {
+    // Create a temp skill root AND a separate external directory.
+    const root = makeTempSkillsDir();
+    const externalRoot = mkdtempSync(join(tmpdir(), "catalog-files-ext-"));
+    tempDirs.push(externalRoot);
+
+    // Write an "external secret" file completely outside the skill tree.
+    const externalSecret = join(externalRoot, "secret.txt");
+    writeFileSync(externalSecret, "EXTERNAL_SECRET");
+
+    // Create the skill directory itself with a legitimate file.
+    const skillDir = writeSkill(root, "my-skill", { "SKILL.md": "ok" });
+
+    // Create a symlink INSIDE the skill dir pointing at the external file.
+    const linkPath = join(skillDir, "link-to-secret.md");
+    symlinkSync(externalSecret, linkPath);
+
+    mockRepoSkillsDir = root;
+    mockCatalog = [skill("my-skill")];
+    installFetchForbidden();
+
+    const entry = await readCatalogSkillFileContent(
+      "my-skill",
+      "link-to-secret.md",
+    );
+    expect(entry).toBeNull();
+
+    // And the legitimate file is still readable, so the check didn't
+    // collateral-damage normal requests.
+    const ok = await readCatalogSkillFileContent("my-skill", "SKILL.md");
+    expect(ok).not.toBeNull();
+    expect(ok!.content).toBe("ok");
+  });
+
+  test("rejects files accessed through a symlinked parent directory", async () => {
+    const root = makeTempSkillsDir();
+    const externalRoot = mkdtempSync(join(tmpdir(), "catalog-files-ext-"));
+    tempDirs.push(externalRoot);
+
+    // External directory with a real file inside it.
+    const externalDir = join(externalRoot, "external-dir");
+    mkdirSync(externalDir, { recursive: true });
+    writeFileSync(join(externalDir, "payload.txt"), "EXTERNAL_PAYLOAD");
+
+    // Legitimate skill dir with a normal file.
+    const skillDir = writeSkill(root, "my-skill", { "SKILL.md": "ok" });
+
+    // Inside the skill dir, create a symlinked subdirectory that points at
+    // the external directory. Then try to request
+    // `escape/payload.txt` — lexically this is inside the skill root, but
+    // the physical file lives outside.
+    const escapeLink = join(skillDir, "escape");
+    symlinkSync(externalDir, escapeLink);
+
+    mockRepoSkillsDir = root;
+    mockCatalog = [skill("my-skill")];
+    installFetchForbidden();
+
+    const entry = await readCatalogSkillFileContent(
+      "my-skill",
+      "escape/payload.txt",
+    );
+    expect(entry).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// readCatalogSkillFileContent — platform mode
+// ---------------------------------------------------------------------------
+
+describe("readCatalogSkillFileContent (platform mode)", () => {
+  test("maps snake_case text response to camelCase entry", async () => {
+    mockCatalog = [skill("remote-skill")];
+    installFetchMock(() =>
+      Response.json({
+        path: "SKILL.md",
+        name: "SKILL.md",
+        size: 14,
+        mime_type: "text/markdown",
+        is_binary: false,
+        content: "# hello world\n",
+      }),
+    );
+
+    const entry = await readCatalogSkillFileContent("remote-skill", "SKILL.md");
+    expect(entry).not.toBeNull();
+    expect(entry!.path).toBe("SKILL.md");
+    expect(entry!.name).toBe("SKILL.md");
+    expect(entry!.size).toBe(14);
+    expect(entry!.mimeType).toBe("text/markdown");
+    expect(entry!.isBinary).toBe(false);
+    expect(entry!.content).toBe("# hello world\n");
+
+    expect(fetchCalls.length).toBe(1);
+    const url = fetchCalls[0]!.url;
+    expect(
+      url.startsWith(
+        "https://platform.test/v1/skills/remote-skill/files/content/",
+      ),
+    ).toBe(true);
+    expect(url).toContain("path=SKILL.md");
+  });
+
+  test("preserves binary response (content=null, isBinary=true)", async () => {
+    mockCatalog = [skill("remote-skill")];
+    installFetchMock(() =>
+      Response.json({
+        path: "img.png",
+        name: "img.png",
+        size: 1024,
+        mime_type: "image/png",
+        is_binary: true,
+        content: null,
+      }),
+    );
+
+    const entry = await readCatalogSkillFileContent("remote-skill", "img.png");
+    expect(entry).not.toBeNull();
+    expect(entry!.isBinary).toBe(true);
+    expect(entry!.content).toBeNull();
+    expect(entry!.mimeType).toBe("image/png");
+  });
+
+  test("preserves oversized text response (content=null)", async () => {
+    mockCatalog = [skill("remote-skill")];
+    installFetchMock(() =>
+      Response.json({
+        path: "big.txt",
+        name: "big.txt",
+        size: 3 * 1024 * 1024,
+        mime_type: "text/plain",
+        is_binary: false,
+        content: null,
+      }),
+    );
+
+    const entry = await readCatalogSkillFileContent("remote-skill", "big.txt");
+    expect(entry).not.toBeNull();
+    expect(entry!.isBinary).toBe(false);
+    expect(entry!.content).toBeNull();
+    expect(entry!.size).toBe(3 * 1024 * 1024);
+  });
+
+  test("returns null on 404", async () => {
+    mockCatalog = [skill("remote-skill")];
+    installFetchMock(
+      () => new Response("missing", { status: 404, statusText: "Not Found" }),
+    );
+    expect(
+      await readCatalogSkillFileContent("remote-skill", "ghost.md"),
+    ).toBeNull();
+  });
+
+  test("rejects traversal BEFORE making any fetch call", async () => {
+    mockCatalog = [skill("remote-skill")];
+    installFetchForbidden();
+    expect(await readCatalogSkillFileContent("remote-skill", "..")).toBeNull();
+    expect(
+      await readCatalogSkillFileContent("remote-skill", "../etc/passwd"),
+    ).toBeNull();
+    expect(fetchCalls.length).toBe(0);
+  });
+
+  test("returns null without fetching when skill id missing from catalog", async () => {
+    mockCatalog = [];
+    installFetchForbidden();
+    expect(await readCatalogSkillFileContent("unknown", "SKILL.md")).toBeNull();
+    expect(fetchCalls.length).toBe(0);
+  });
+});

--- a/assistant/src/__tests__/skills-file-content-endpoint.test.ts
+++ b/assistant/src/__tests__/skills-file-content-endpoint.test.ts
@@ -1,0 +1,564 @@
+/**
+ * Handler-level tests for `getSkillFileContent`.
+ *
+ * Covers:
+ *   - Installed skill, valid path → returns file content (text + binary).
+ *   - Installed skill, traversal path → 400 "Invalid path".
+ *   - Installed skill, missing path query handled upstream (route-level).
+ *   - Uninstalled catalog skill, dev mode → content from repo path.
+ *   - Uninstalled catalog skill, platform mode → content proxied from the
+ *     platform file-content endpoint with snake_case → camelCase mapping.
+ *   - Skill not found anywhere → 404.
+ *
+ * The test exercises the daemon handler directly — route wiring is a thin
+ * pass-through to this function.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { SkillSummary } from "../config/skills.js";
+import type { CatalogSkill } from "../skills/catalog-install.js";
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before importing the module under test
+// ---------------------------------------------------------------------------
+
+// Suppress logger output
+const noopLogger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+  trace: () => {},
+  fatal: () => {},
+  child: () => noopLogger,
+};
+mock.module("../util/logger.js", () => ({
+  getLogger: () => noopLogger,
+  getCliLogger: () => noopLogger,
+  truncateForLog: (v: string) => v,
+  initLogger: () => {},
+  pruneOldLogFiles: () => 0,
+}));
+
+// ── Mutable mock state ──────────────────────────────────────────────────────
+
+let mockResolvedSkills: Array<{
+  summary: SkillSummary;
+  state: "enabled" | "disabled";
+}> = [];
+let mockCatalog: CatalogSkill[] = [];
+let mockRepoSkillsDir: string | undefined = undefined;
+
+mock.module("../config/skills.js", () => ({
+  loadSkillCatalog: () => mockResolvedSkills.map((r) => r.summary),
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({}),
+  invalidateConfigCache: () => {},
+  loadRawConfig: () => ({}),
+  saveRawConfig: () => {},
+}));
+
+mock.module("../config/skill-state.js", () => ({
+  resolveSkillStates: () => mockResolvedSkills,
+  skillFlagKey: () => null,
+}));
+
+mock.module("../config/assistant-feature-flags.js", () => ({
+  isAssistantFeatureFlagEnabled: () => true,
+}));
+
+mock.module("../skills/catalog-cache.js", () => ({
+  getCatalog: async () => mockCatalog,
+}));
+
+mock.module("../skills/catalog-install.js", () => ({
+  installSkillLocally: async () => {},
+  upsertSkillsIndex: () => {},
+  getRepoSkillsDir: () => mockRepoSkillsDir,
+}));
+
+mock.module("../skills/catalog-search.js", () => ({
+  filterByQuery: () => [],
+}));
+
+mock.module("../skills/clawhub.js", () => ({
+  clawhubCheckUpdates: mock(async () => []),
+  clawhubInspect: mock(async () => ({})),
+  clawhubInstall: mock(async () => ({ success: true })),
+  clawhubSearch: mock(async () => ({ skills: [] })),
+  clawhubUpdate: mock(async () => ({ success: true })),
+}));
+
+mock.module("../skills/skillssh-registry.js", () => ({
+  installExternalSkill: mock(async () => {}),
+  resolveSkillSource: () => {
+    throw new Error("not used");
+  },
+  searchSkillsRegistry: mock(async () => []),
+}));
+
+mock.module("../skills/install-meta.js", () => ({
+  readInstallMeta: () => null,
+}));
+
+mock.module("../skills/managed-store.js", () => ({
+  createManagedSkill: () => ({ created: true }),
+  deleteManagedSkill: () => ({ deleted: true }),
+  removeSkillsIndexEntry: () => {},
+  validateManagedSkillId: () => null,
+}));
+
+mock.module("../memory/graph/capability-seed.js", () => ({
+  deleteSkillCapabilityNode: () => {},
+  seedSkillGraphNodes: () => {},
+  seedUninstalledCatalogSkillMemories: async () => {},
+}));
+
+mock.module("../providers/provider-send-message.js", () => ({
+  createTimeout: () => ({
+    signal: AbortSignal.timeout(1000),
+    cleanup: () => {},
+  }),
+  extractText: () => "",
+  getConfiguredProvider: async () => null,
+  userMessage: () => ({}),
+}));
+
+// Real isTextMimeType — we want actual classification here.
+// No mock needed; let it fall through to the real implementation.
+
+mock.module("../util/platform.js", () => ({
+  getWorkspaceSkillsDir: () => "/tmp/test-skills",
+  readPlatformToken: () => null,
+}));
+mock.module("../util/platform.ts", () => ({
+  getWorkspaceSkillsDir: () => "/tmp/test-skills",
+  readPlatformToken: () => null,
+}));
+
+let mockPlatformBaseUrl = "https://platform.test";
+mock.module("../config/env.js", () => ({
+  getPlatformBaseUrl: () => mockPlatformBaseUrl,
+}));
+mock.module("../config/env.ts", () => ({
+  getPlatformBaseUrl: () => mockPlatformBaseUrl,
+}));
+
+mock.module("../daemon/handlers/shared.js", () => ({
+  CONFIG_RELOAD_DEBOUNCE_MS: 100,
+  ensureSkillEntry: () => ({ enabled: false }),
+  log: noopLogger,
+}));
+
+// ---------------------------------------------------------------------------
+// Imports (after mocks)
+// ---------------------------------------------------------------------------
+
+import type { SkillOperationContext } from "../daemon/handlers/skills.js";
+import { getSkillFileContent } from "../daemon/handlers/skills.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const dummyCtx = {
+  debounceTimers: { schedule: () => {} },
+  setSuppressConfigReload: () => {},
+  updateConfigFingerprint: () => {},
+  broadcast: () => {},
+} as unknown as SkillOperationContext;
+
+type FetchFn = typeof globalThis.fetch;
+
+interface FetchCall {
+  url: string;
+  init?: RequestInit;
+}
+
+let originalFetch: FetchFn;
+let fetchCalls: FetchCall[] = [];
+
+function installFetchMock(
+  handler: (url: string, init?: RequestInit) => Response | Promise<Response>,
+): void {
+  fetchCalls = [];
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+    fetchCalls.push({ url, init });
+    return handler(url, init);
+  }) as unknown as FetchFn;
+}
+
+function installFetchForbidden(): void {
+  fetchCalls = [];
+  globalThis.fetch = (async () => {
+    throw new Error("fetch should not have been called");
+  }) as unknown as FetchFn;
+}
+
+const tempDirs: string[] = [];
+
+function makeTempSkillDir(skillId: string): string {
+  const root = mkdtempSync(join(tmpdir(), "skill-file-content-test-"));
+  tempDirs.push(root);
+  const skillDir = join(root, skillId);
+  mkdirSync(skillDir, { recursive: true });
+  return skillDir;
+}
+
+function writeFile(dir: string, relPath: string, content: string | Buffer) {
+  const abs = join(dir, relPath);
+  mkdirSync(join(abs, ".."), { recursive: true });
+  writeFileSync(abs, content);
+}
+
+function installedSkill(id: string, directoryPath: string) {
+  return {
+    summary: {
+      id,
+      name: id,
+      displayName: id,
+      description: id,
+      directoryPath,
+      skillFilePath: join(directoryPath, "SKILL.md"),
+      source: "workspace" as const,
+    },
+    state: "enabled" as const,
+  };
+}
+
+function catalogSkill(id: string): CatalogSkill {
+  return { id, name: id, description: id };
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+  fetchCalls = [];
+  mockResolvedSkills = [];
+  mockCatalog = [];
+  mockRepoSkillsDir = undefined;
+  mockPlatformBaseUrl = "https://platform.test";
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  for (const dir of tempDirs) {
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // best effort
+    }
+  }
+  tempDirs.length = 0;
+});
+
+// ---------------------------------------------------------------------------
+// Installed-skill path
+// ---------------------------------------------------------------------------
+
+describe("getSkillFileContent — installed skill", () => {
+  test("returns text file content for a valid path", async () => {
+    const skillDir = makeTempSkillDir("my-skill");
+    writeFile(skillDir, "SKILL.md", "# hello world\n");
+    mockResolvedSkills = [installedSkill("my-skill", skillDir)];
+    installFetchForbidden();
+
+    const result = await getSkillFileContent("my-skill", "SKILL.md", dummyCtx);
+    expect("error" in result).toBe(false);
+    if ("error" in result) return;
+    expect(result.path).toBe("SKILL.md");
+    expect(result.name).toBe("SKILL.md");
+    expect(result.size).toBe("# hello world\n".length);
+    expect(result.isBinary).toBe(false);
+    expect(result.content).toBe("# hello world\n");
+  });
+
+  test("returns content=null for binary files", async () => {
+    const skillDir = makeTempSkillDir("my-skill");
+    writeFile(
+      skillDir,
+      "img.png",
+      Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    );
+    mockResolvedSkills = [installedSkill("my-skill", skillDir)];
+    installFetchForbidden();
+
+    const result = await getSkillFileContent("my-skill", "img.png", dummyCtx);
+    expect("error" in result).toBe(false);
+    if ("error" in result) return;
+    expect(result.isBinary).toBe(true);
+    expect(result.content).toBeNull();
+    expect(result.name).toBe("img.png");
+  });
+
+  test("rejects traversal paths with 400 Invalid path", async () => {
+    const skillDir = makeTempSkillDir("my-skill");
+    writeFile(skillDir, "SKILL.md", "ok");
+    mockResolvedSkills = [installedSkill("my-skill", skillDir)];
+    installFetchForbidden();
+
+    for (const bad of ["../secrets", "..", "/etc/passwd", "./../escape"]) {
+      const result = await getSkillFileContent("my-skill", bad, dummyCtx);
+      expect("error" in result).toBe(true);
+      if (!("error" in result)) continue;
+      expect(result.status).toBe(400);
+      expect(result.error).toBe("Invalid path");
+    }
+  });
+
+  test("rejects paths containing null bytes with 400", async () => {
+    const skillDir = makeTempSkillDir("my-skill");
+    writeFile(skillDir, "SKILL.md", "ok");
+    mockResolvedSkills = [installedSkill("my-skill", skillDir)];
+    installFetchForbidden();
+
+    const result = await getSkillFileContent(
+      "my-skill",
+      "SKILL.md\0.png",
+      dummyCtx,
+    );
+    expect("error" in result).toBe(true);
+    if (!("error" in result)) return;
+    expect(result.status).toBe(400);
+  });
+
+  test("returns 404 for a missing file inside an installed skill", async () => {
+    const skillDir = makeTempSkillDir("my-skill");
+    writeFile(skillDir, "SKILL.md", "ok");
+    mockResolvedSkills = [installedSkill("my-skill", skillDir)];
+    installFetchForbidden();
+
+    const result = await getSkillFileContent("my-skill", "ghost.txt", dummyCtx);
+    expect("error" in result).toBe(true);
+    if (!("error" in result)) return;
+    expect(result.status).toBe(404);
+    expect(result.error).toBe("File not found");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Catalog fallback — dev mode (uninstalled)
+// ---------------------------------------------------------------------------
+
+describe("getSkillFileContent — uninstalled catalog skill (dev mode)", () => {
+  test("reads content from the repo skills dir without hitting the platform", async () => {
+    // Skill is NOT in the installed catalog, but IS in the platform catalog
+    // and exists on disk under the repo skills dir.
+    const repoSkillsDir = mkdtempSync(
+      join(tmpdir(), "skill-file-content-repo-"),
+    );
+    tempDirs.push(repoSkillsDir);
+    const skillDir = join(repoSkillsDir, "dev-skill");
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, "SKILL.md"), "# dev skill\n");
+
+    mockRepoSkillsDir = repoSkillsDir;
+    mockResolvedSkills = []; // not installed
+    mockCatalog = [catalogSkill("dev-skill")];
+    installFetchForbidden();
+
+    const result = await getSkillFileContent("dev-skill", "SKILL.md", dummyCtx);
+    expect("error" in result).toBe(false);
+    if ("error" in result) return;
+    expect(result.path).toBe("SKILL.md");
+    expect(result.name).toBe("SKILL.md");
+    expect(result.content).toBe("# dev skill\n");
+    expect(result.isBinary).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Catalog fallback — platform mode (uninstalled, no repo checkout)
+// ---------------------------------------------------------------------------
+
+describe("getSkillFileContent — uninstalled catalog skill (platform mode)", () => {
+  test("proxies content from the platform preview endpoint and maps snake_case → camelCase", async () => {
+    mockResolvedSkills = []; // not installed
+    mockCatalog = [catalogSkill("remote-skill")];
+    mockRepoSkillsDir = undefined;
+    installFetchMock(() =>
+      Response.json({
+        path: "SKILL.md",
+        name: "SKILL.md",
+        size: 14,
+        mime_type: "text/markdown",
+        is_binary: false,
+        content: "# hello world\n",
+      }),
+    );
+
+    const result = await getSkillFileContent(
+      "remote-skill",
+      "SKILL.md",
+      dummyCtx,
+    );
+    expect("error" in result).toBe(false);
+    if ("error" in result) return;
+    expect(result.path).toBe("SKILL.md");
+    expect(result.name).toBe("SKILL.md");
+    expect(result.size).toBe(14);
+    expect(result.mimeType).toBe("text/markdown");
+    expect(result.isBinary).toBe(false);
+    expect(result.content).toBe("# hello world\n");
+
+    // Verify the platform endpoint was actually called.
+    expect(fetchCalls.length).toBe(1);
+    expect(
+      fetchCalls[0]!.url.startsWith(
+        "https://platform.test/v1/skills/remote-skill/files/content/",
+      ),
+    ).toBe(true);
+    expect(fetchCalls[0]!.url).toContain("path=SKILL.md");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Skill not found anywhere
+// ---------------------------------------------------------------------------
+
+describe("getSkillFileContent — skill not found", () => {
+  test("returns 404 when the skill is neither installed nor in the catalog", async () => {
+    mockResolvedSkills = [];
+    mockCatalog = [];
+    installFetchForbidden();
+
+    const result = await getSkillFileContent(
+      "ghost-skill",
+      "SKILL.md",
+      dummyCtx,
+    );
+    expect("error" in result).toBe(true);
+    if (!("error" in result)) return;
+    expect(result.status).toBe(404);
+    expect(result.error).toBe("Skill not found");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Hidden / SKIP_DIRS path rejection
+// ---------------------------------------------------------------------------
+//
+// The daemon handler rejects paths containing dotfile segments (`.env`,
+// `.git/`) or SKIP_DIRS segments (`node_modules`, `__pycache__`) with a
+// 400 "Invalid path" BEFORE any disk read or network round-trip, matching
+// the file-listing endpoint that hides these entries. This applies
+// regardless of whether the skill is installed locally or only available
+// via the catalog.
+
+describe("getSkillFileContent — hidden / SKIP_DIRS rejection", () => {
+  test("rejects dotfile reads from an installed skill with 400 Invalid path", async () => {
+    // Set up an installed skill where a real `.env` file exists on disk.
+    // Without the hidden-segment rejection, the handler would happily
+    // read its content because sanitizeRelativePath accepts `.env`.
+    const skillDir = makeTempSkillDir("leaky-skill");
+    writeFile(skillDir, "SKILL.md", "# ok\n");
+    writeFile(skillDir, ".env", "SECRET=abc\n");
+    mockResolvedSkills = [installedSkill("leaky-skill", skillDir)];
+    installFetchForbidden();
+
+    const result = await getSkillFileContent("leaky-skill", ".env", dummyCtx);
+    expect("error" in result).toBe(true);
+    if (!("error" in result)) return;
+    expect(result.status).toBe(400);
+    expect(result.error).toBe("Invalid path");
+  });
+
+  test("rejects dotfile reads for an uninstalled catalog skill before any catalog read", async () => {
+    // Same dotfile attack, but the skill id is NOT installed — only
+    // present in the Vellum catalog. The rejection must run in the daemon
+    // handler BEFORE the catalog fallback, so no disk walk or platform
+    // fetch should happen. We use dev-mode with a real `.env` on disk
+    // under the fake repo skills dir to prove that even though the
+    // catalog path WOULD succeed without the check, the daemon
+    // short-circuits.
+    const repoSkillsDir = mkdtempSync(
+      join(tmpdir(), "skill-file-content-hidden-repo-"),
+    );
+    tempDirs.push(repoSkillsDir);
+    const catalogSkillDir = join(repoSkillsDir, "catalog-leaky");
+    mkdirSync(catalogSkillDir, { recursive: true });
+    writeFileSync(join(catalogSkillDir, "SKILL.md"), "# ok\n");
+    writeFileSync(join(catalogSkillDir, ".env"), "SECRET=xyz\n");
+
+    mockRepoSkillsDir = repoSkillsDir;
+    mockResolvedSkills = []; // not installed
+    mockCatalog = [catalogSkill("catalog-leaky")];
+    installFetchForbidden();
+
+    const result = await getSkillFileContent("catalog-leaky", ".env", dummyCtx);
+    expect("error" in result).toBe(true);
+    if (!("error" in result)) return;
+    expect(result.status).toBe(400);
+    expect(result.error).toBe("Invalid path");
+  });
+
+  test("rejects paths whose parent directory is a dotfile segment", async () => {
+    // `.git/config` and `docs/.hidden/file.md` both contain hidden
+    // segments even though the leaf isn't a dotfile.
+    const skillDir = makeTempSkillDir("my-skill");
+    writeFile(skillDir, "SKILL.md", "# ok\n");
+    mockResolvedSkills = [installedSkill("my-skill", skillDir)];
+    installFetchForbidden();
+
+    for (const bad of [".git/config", "docs/.hidden/file.md"]) {
+      const result = await getSkillFileContent("my-skill", bad, dummyCtx);
+      expect("error" in result).toBe(true);
+      if (!("error" in result)) continue;
+      expect(result.status).toBe(400);
+      expect(result.error).toBe("Invalid path");
+    }
+  });
+
+  test("rejects paths inside SKIP_DIRS segments with 400 Invalid path", async () => {
+    const skillDir = makeTempSkillDir("my-skill");
+    writeFile(skillDir, "SKILL.md", "# ok\n");
+    mockResolvedSkills = [installedSkill("my-skill", skillDir)];
+    installFetchForbidden();
+
+    for (const bad of [
+      "node_modules/foo/index.js",
+      "__pycache__/cached.pyc",
+      "nested/node_modules/mod/index.js",
+    ]) {
+      const result = await getSkillFileContent("my-skill", bad, dummyCtx);
+      expect("error" in result).toBe(true);
+      if (!("error" in result)) continue;
+      expect(result.status).toBe(400);
+      expect(result.error).toBe("Invalid path");
+    }
+  });
+
+  test("regular SKILL.md still reads successfully (sanity)", async () => {
+    // Guards against collateral damage from the hidden/SKIP_DIRS filter:
+    // a normal, non-hidden path must continue to work unchanged.
+    const skillDir = makeTempSkillDir("healthy-skill");
+    writeFile(skillDir, "SKILL.md", "# hello\n");
+    mockResolvedSkills = [installedSkill("healthy-skill", skillDir)];
+    installFetchForbidden();
+
+    const result = await getSkillFileContent(
+      "healthy-skill",
+      "SKILL.md",
+      dummyCtx,
+    );
+    expect("error" in result).toBe(false);
+    if ("error" in result) return;
+    expect(result.content).toBe("# hello\n");
+    expect(result.name).toBe("SKILL.md");
+  });
+});

--- a/assistant/src/__tests__/skills-file-content-endpoint.test.ts
+++ b/assistant/src/__tests__/skills-file-content-endpoint.test.ts
@@ -4,14 +4,19 @@
  * Covers:
  *   - Installed skill, valid path → returns file content (text + binary).
  *   - Installed skill, traversal path → 400 "Invalid path".
- *   - Installed skill, missing path query handled upstream (route-level).
- *   - Uninstalled catalog skill, dev mode → content from repo path.
- *   - Uninstalled catalog skill, platform mode → content proxied from the
- *     platform file-content endpoint with snake_case → camelCase mapping.
+ *   - Installed skill, missing file → 404 "File not found".
+ *   - Installed skill with missing on-disk directory → 404 "Skill directory
+ *     missing" without consulting the catalog fallback.
+ *   - Uninstalled catalog skill → delegates to `readCatalogSkillFileContent`
+ *     and returns its payload; null result → 404.
  *   - Skill not found anywhere → 404.
+ *   - Hidden / SKIP_DIRS path segments → rejected with 400 before touching
+ *     either the installed-skill disk read or the catalog fallback.
  *
  * The test exercises the daemon handler directly — route wiring is a thin
- * pass-through to this function.
+ * pass-through to this function. The catalog-files module is mocked so the
+ * handler's wiring is exercised in isolation; the helper's own dev-mode /
+ * platform-mode behavior is covered in `catalog-files.test.ts`.
  */
 
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
@@ -20,6 +25,7 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { SkillSummary } from "../config/skills.js";
+import type { SkillFileEntry } from "../skills/catalog-files.js";
 import type { CatalogSkill } from "../skills/catalog-install.js";
 
 // ---------------------------------------------------------------------------
@@ -51,7 +57,18 @@ let mockResolvedSkills: Array<{
   state: "enabled" | "disabled";
 }> = [];
 let mockCatalog: CatalogSkill[] = [];
-let mockRepoSkillsDir: string | undefined = undefined;
+// Ordered log of `readCatalogSkillFileContent` invocations so individual
+// tests can assert that the catalog-fallback helper was (or was not)
+// consulted. Mirrors the `catalogFilesCalls` array pattern used in
+// `skills-files-catalog-fallback.test.ts` for `readCatalogSkillFiles`.
+const catalogFileContentCalls: Array<{ skillId: string; path: string }> = [];
+// Per-test override for the catalog fallback helper. When set, the
+// `catalog-files.js` mock's `readCatalogSkillFileContent` delegates to
+// this function, letting tests return canned payloads without touching
+// disk or the network.
+let mockCatalogFileContentResponder:
+  | ((skillId: string, path: string) => Promise<SkillFileEntry | null>)
+  | null = null;
 
 mock.module("../config/skills.js", () => ({
   loadSkillCatalog: () => mockResolvedSkills.map((r) => r.summary),
@@ -77,10 +94,76 @@ mock.module("../skills/catalog-cache.js", () => ({
   getCatalog: async () => mockCatalog,
 }));
 
+// The `catalog-files.js` mock replaces `readCatalogSkillFileContent` with
+// a spy wrapper that logs invocations and delegates to a per-test
+// responder. Other exports (`sanitizeRelativePath`,
+// `hasHiddenOrSkippedSegment`, `SKIP_DIRS`, `readCatalogSkillFiles`) are
+// re-implemented inline from the production module so the handler's
+// path-validation code still runs against equivalent logic without
+// recursing back through the mocked module.
+//
+// The spy gives the new "installed skill directory missing" regression
+// test a way to assert that the catalog fallback helper is NOT consulted
+// when `findSkillById` resolves a ghost install — mirroring the
+// `catalogFilesCalls.length === 0` assertion in
+// `skills-files-catalog-fallback.test.ts`.
+const INLINE_SKIP_DIRS = new Set(["node_modules", "__pycache__", ".git"]);
+
+function inlineSanitizeRelativePath(rawPath: string): string | null {
+  if (typeof rawPath !== "string" || rawPath.length === 0) return null;
+  if (rawPath.includes("\0")) return null;
+  if (rawPath.startsWith("/")) return null;
+  if (/^[a-zA-Z]:[/\\]/.test(rawPath)) return null;
+  let candidate = rawPath.replace(/\\/g, "/");
+  while (candidate.startsWith("./")) {
+    candidate = candidate.slice(2);
+  }
+  if (candidate.length === 0) return null;
+  // posix.normalize without the node import: collapse segments manually.
+  const segments: string[] = [];
+  for (const seg of candidate.split("/")) {
+    if (seg === "" || seg === ".") continue;
+    if (seg === "..") {
+      if (segments.length === 0) return null;
+      segments.pop();
+      continue;
+    }
+    segments.push(seg);
+  }
+  if (segments.length === 0) return null;
+  const normalized = segments.join("/");
+  if (normalized.startsWith("/")) return null;
+  if (/^[a-zA-Z]:[/\\]/.test(normalized)) return null;
+  return normalized;
+}
+
+function inlineHasHiddenOrSkippedSegment(sanitized: string): boolean {
+  for (const segment of sanitized.split("/")) {
+    if (segment.length === 0) continue;
+    if (segment.startsWith(".")) return true;
+    if (INLINE_SKIP_DIRS.has(segment)) return true;
+  }
+  return false;
+}
+
+mock.module("../skills/catalog-files.js", () => ({
+  SKIP_DIRS: INLINE_SKIP_DIRS,
+  sanitizeRelativePath: inlineSanitizeRelativePath,
+  hasHiddenOrSkippedSegment: inlineHasHiddenOrSkippedSegment,
+  readCatalogSkillFiles: async () => null,
+  readCatalogSkillFileContent: async (skillId: string, path: string) => {
+    catalogFileContentCalls.push({ skillId, path });
+    if (mockCatalogFileContentResponder) {
+      return mockCatalogFileContentResponder(skillId, path);
+    }
+    return null;
+  },
+}));
+
 mock.module("../skills/catalog-install.js", () => ({
   installSkillLocally: async () => {},
   upsertSkillsIndex: () => {},
-  getRepoSkillsDir: () => mockRepoSkillsDir,
+  getRepoSkillsDir: () => undefined,
 }));
 
 mock.module("../skills/catalog-search.js", () => ({
@@ -176,32 +259,9 @@ const dummyCtx = {
 
 type FetchFn = typeof globalThis.fetch;
 
-interface FetchCall {
-  url: string;
-  init?: RequestInit;
-}
-
 let originalFetch: FetchFn;
-let fetchCalls: FetchCall[] = [];
-
-function installFetchMock(
-  handler: (url: string, init?: RequestInit) => Response | Promise<Response>,
-): void {
-  fetchCalls = [];
-  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
-    const url =
-      typeof input === "string"
-        ? input
-        : input instanceof URL
-          ? input.toString()
-          : input.url;
-    fetchCalls.push({ url, init });
-    return handler(url, init);
-  }) as unknown as FetchFn;
-}
 
 function installFetchForbidden(): void {
-  fetchCalls = [];
   globalThis.fetch = (async () => {
     throw new Error("fetch should not have been called");
   }) as unknown as FetchFn;
@@ -248,11 +308,11 @@ function catalogSkill(id: string): CatalogSkill {
 
 beforeEach(() => {
   originalFetch = globalThis.fetch;
-  fetchCalls = [];
   mockResolvedSkills = [];
   mockCatalog = [];
-  mockRepoSkillsDir = undefined;
   mockPlatformBaseUrl = "https://platform.test";
+  catalogFileContentCalls.length = 0;
+  mockCatalogFileContentResponder = null;
 });
 
 afterEach(() => {
@@ -352,55 +412,31 @@ describe("getSkillFileContent — installed skill", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Catalog fallback — dev mode (uninstalled)
+// Catalog fallback — helper invocation
 // ---------------------------------------------------------------------------
+//
+// The daemon handler delegates to `readCatalogSkillFileContent` for any
+// skill id that is not resolved locally but is present in the platform
+// catalog. The helper's own dev-mode / platform-mode behavior is covered
+// in detail in `catalog-files.test.ts`; these tests assert the handler
+// wiring: the helper is invoked with the sanitized path, and the
+// helper's result is returned on the response shape.
 
-describe("getSkillFileContent — uninstalled catalog skill (dev mode)", () => {
-  test("reads content from the repo skills dir without hitting the platform", async () => {
-    // Skill is NOT in the installed catalog, but IS in the platform catalog
-    // and exists on disk under the repo skills dir.
-    const repoSkillsDir = mkdtempSync(
-      join(tmpdir(), "skill-file-content-repo-"),
-    );
-    tempDirs.push(repoSkillsDir);
-    const skillDir = join(repoSkillsDir, "dev-skill");
-    mkdirSync(skillDir, { recursive: true });
-    writeFileSync(join(skillDir, "SKILL.md"), "# dev skill\n");
-
-    mockRepoSkillsDir = repoSkillsDir;
-    mockResolvedSkills = []; // not installed
-    mockCatalog = [catalogSkill("dev-skill")];
+describe("getSkillFileContent — uninstalled catalog skill", () => {
+  test("delegates to readCatalogSkillFileContent and returns the helper payload", async () => {
+    // Skill is NOT in the installed catalog, but IS in the platform catalog.
+    mockResolvedSkills = [];
+    mockCatalog = [catalogSkill("remote-skill")];
     installFetchForbidden();
 
-    const result = await getSkillFileContent("dev-skill", "SKILL.md", dummyCtx);
-    expect("error" in result).toBe(false);
-    if ("error" in result) return;
-    expect(result.path).toBe("SKILL.md");
-    expect(result.name).toBe("SKILL.md");
-    expect(result.content).toBe("# dev skill\n");
-    expect(result.isBinary).toBe(false);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Catalog fallback — platform mode (uninstalled, no repo checkout)
-// ---------------------------------------------------------------------------
-
-describe("getSkillFileContent — uninstalled catalog skill (platform mode)", () => {
-  test("proxies content from the platform preview endpoint and maps snake_case → camelCase", async () => {
-    mockResolvedSkills = []; // not installed
-    mockCatalog = [catalogSkill("remote-skill")];
-    mockRepoSkillsDir = undefined;
-    installFetchMock(() =>
-      Response.json({
-        path: "SKILL.md",
-        name: "SKILL.md",
-        size: 14,
-        mime_type: "text/markdown",
-        is_binary: false,
-        content: "# hello world\n",
-      }),
-    );
+    mockCatalogFileContentResponder = async (_skillId, path) => ({
+      path,
+      name: "SKILL.md",
+      size: 14,
+      mimeType: "text/markdown",
+      isBinary: false,
+      content: "# hello world\n",
+    });
 
     const result = await getSkillFileContent(
       "remote-skill",
@@ -416,14 +452,32 @@ describe("getSkillFileContent — uninstalled catalog skill (platform mode)", ()
     expect(result.isBinary).toBe(false);
     expect(result.content).toBe("# hello world\n");
 
-    // Verify the platform endpoint was actually called.
-    expect(fetchCalls.length).toBe(1);
-    expect(
-      fetchCalls[0]!.url.startsWith(
-        "https://platform.test/v1/skills/remote-skill/files/content/",
-      ),
-    ).toBe(true);
-    expect(fetchCalls[0]!.url).toContain("path=SKILL.md");
+    expect(catalogFileContentCalls).toEqual([
+      { skillId: "remote-skill", path: "SKILL.md" },
+    ]);
+  });
+
+  test("returns 404 when readCatalogSkillFileContent resolves to null", async () => {
+    // Catalog helper returns null for a missing or unreadable file —
+    // daemon handler translates that to 404 "File not found".
+    mockResolvedSkills = [];
+    mockCatalog = [catalogSkill("remote-skill")];
+    installFetchForbidden();
+
+    mockCatalogFileContentResponder = async () => null;
+
+    const result = await getSkillFileContent(
+      "remote-skill",
+      "missing.md",
+      dummyCtx,
+    );
+    expect("error" in result).toBe(true);
+    if (!("error" in result)) return;
+    expect(result.status).toBe(404);
+    expect(result.error).toBe("File not found");
+    expect(catalogFileContentCalls).toEqual([
+      { skillId: "remote-skill", path: "missing.md" },
+    ]);
   });
 });
 
@@ -446,6 +500,59 @@ describe("getSkillFileContent — skill not found", () => {
     if (!("error" in result)) return;
     expect(result.status).toBe(404);
     expect(result.error).toBe("Skill not found");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Installed skill with missing directory (ghost install)
+// ---------------------------------------------------------------------------
+//
+// When `findSkillById` resolves a skill as installed but the on-disk
+// directory has disappeared (corrupted install, mid-delete race,
+// external unmount), the handler must return a distinct 404 "Skill
+// directory missing" instead of falling through to the catalog path.
+// Falling through would flip the content response to a catalog payload
+// even though `listSkillsWithCatalog` still classifies the same id as
+// `kind: "installed"`, breaking the `isInstalled` contract between the
+// listing and content responses. Mirrors the same fix on
+// `getSkillFiles` verified by
+// `skills-files-catalog-fallback.test.ts`.
+
+describe("getSkillFileContent — installed skill with missing directory", () => {
+  test("returns 404 without consulting the catalog when the installed dir is gone", async () => {
+    mockResolvedSkills = [
+      installedSkill(
+        "ghost-installed",
+        "/tmp/definitely-does-not-exist-" + Date.now(),
+      ),
+    ];
+    // Even if the same id is present in the catalog, the handler must NOT
+    // fall through. Prime both the catalog and a responder that would
+    // return a successful payload to prove the short-circuit is active.
+    mockCatalog = [catalogSkill("ghost-installed")];
+    mockCatalogFileContentResponder = async () => ({
+      path: "SKILL.md",
+      name: "SKILL.md",
+      size: 10,
+      mimeType: "text/markdown",
+      isBinary: false,
+      content: "# from catalog\n",
+    });
+    installFetchForbidden();
+
+    const result = await getSkillFileContent(
+      "ghost-installed",
+      "SKILL.md",
+      dummyCtx,
+    );
+
+    expect("error" in result).toBe(true);
+    if (!("error" in result)) return;
+    expect(result.status).toBe(404);
+    expect(result.error).toContain("ghost-installed");
+    expect(result.error).toContain("directory missing");
+    // Catalog fallback must not have been consulted.
+    expect(catalogFileContentCalls).toEqual([]);
   });
 });
 
@@ -481,30 +588,29 @@ describe("getSkillFileContent — hidden / SKIP_DIRS rejection", () => {
   test("rejects dotfile reads for an uninstalled catalog skill before any catalog read", async () => {
     // Same dotfile attack, but the skill id is NOT installed — only
     // present in the Vellum catalog. The rejection must run in the daemon
-    // handler BEFORE the catalog fallback, so no disk walk or platform
-    // fetch should happen. We use dev-mode with a real `.env` on disk
-    // under the fake repo skills dir to prove that even though the
-    // catalog path WOULD succeed without the check, the daemon
-    // short-circuits.
-    const repoSkillsDir = mkdtempSync(
-      join(tmpdir(), "skill-file-content-hidden-repo-"),
-    );
-    tempDirs.push(repoSkillsDir);
-    const catalogSkillDir = join(repoSkillsDir, "catalog-leaky");
-    mkdirSync(catalogSkillDir, { recursive: true });
-    writeFileSync(join(catalogSkillDir, "SKILL.md"), "# ok\n");
-    writeFileSync(join(catalogSkillDir, ".env"), "SECRET=xyz\n");
-
-    mockRepoSkillsDir = repoSkillsDir;
+    // handler BEFORE the catalog fallback, so the catalog helper should
+    // never be consulted. We prime the responder with content that WOULD
+    // succeed to prove that even though the fallback path would return a
+    // payload, the daemon short-circuits first.
     mockResolvedSkills = []; // not installed
     mockCatalog = [catalogSkill("catalog-leaky")];
     installFetchForbidden();
+    mockCatalogFileContentResponder = async () => ({
+      path: ".env",
+      name: ".env",
+      size: 12,
+      mimeType: "text/plain",
+      isBinary: false,
+      content: "SECRET=xyz\n",
+    });
 
     const result = await getSkillFileContent("catalog-leaky", ".env", dummyCtx);
     expect("error" in result).toBe(true);
     if (!("error" in result)) return;
     expect(result.status).toBe(400);
     expect(result.error).toBe("Invalid path");
+    // The hidden-segment check must run before the catalog helper.
+    expect(catalogFileContentCalls).toEqual([]);
   });
 
   test("rejects paths whose parent directory is a dotfile segment", async () => {

--- a/assistant/src/__tests__/skills-files-catalog-fallback.test.ts
+++ b/assistant/src/__tests__/skills-files-catalog-fallback.test.ts
@@ -1,0 +1,394 @@
+/**
+ * Tests for `getSkillFiles` catalog fallback.
+ *
+ * When a skill id isn't resolvable via `findSkillById` (i.e. not installed
+ * locally, not bundled, not a managed skill) or the on-disk directory is
+ * missing, `getSkillFiles` now falls back to the Vellum catalog via
+ * `readCatalogSkillFiles`. Catalog fallback entries carry `content: null`
+ * because the catalog-files helper defers content fetching to a follow-up
+ * per-file endpoint.
+ *
+ * Coverage:
+ *   - Uninstalled catalog skill: returns `{ skill: catalog/vellum/available, files }` with `content: null` for every entry.
+ *   - Neither installed nor in catalog: returns 404.
+ *   - Installed skill: preserves the existing disk-read behavior with inline `content`.
+ *   - `catalogSkillToSlim` mapping: `metadata.vellum["display-name"]` wins over `cs.name`.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { SkillSummary } from "../config/skills.js";
+import type { SkillFileEntry } from "../skills/catalog-files.js";
+import type { CatalogSkill } from "../skills/catalog-install.js";
+
+// ---------------------------------------------------------------------------
+// Mock state — mutated by individual tests via reset helpers below
+// ---------------------------------------------------------------------------
+
+type ResolvedSkillEntry = {
+  summary: SkillSummary;
+  state: "enabled" | "disabled";
+};
+
+let mockResolvedStates: ResolvedSkillEntry[] = [];
+let mockCatalog: CatalogSkill[] = [];
+let mockCatalogFiles: SkillFileEntry[] | null = null;
+const catalogFilesCalls: string[] = [];
+
+// ---------------------------------------------------------------------------
+// Module mocks — must be declared before importing the module under test
+// ---------------------------------------------------------------------------
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({}),
+  invalidateConfigCache: () => {},
+  loadRawConfig: () => ({}),
+  saveRawConfig: () => {},
+}));
+
+mock.module("../config/skills.js", () => ({
+  loadSkillCatalog: () => [],
+}));
+
+mock.module("../config/skill-state.js", () => ({
+  resolveSkillStates: () => mockResolvedStates,
+  skillFlagKey: () => null,
+}));
+
+mock.module("../config/assistant-feature-flags.js", () => ({
+  isAssistantFeatureFlagEnabled: () => true,
+}));
+
+mock.module("../skills/install-meta.js", () => ({
+  readInstallMeta: () => null,
+}));
+
+mock.module("../skills/catalog-cache.js", () => ({
+  getCatalog: async () => mockCatalog,
+}));
+
+mock.module("../skills/catalog-files.js", () => ({
+  readCatalogSkillFiles: async (skillId: string) => {
+    catalogFilesCalls.push(skillId);
+    return mockCatalogFiles;
+  },
+}));
+
+mock.module("../skills/catalog-install.js", () => ({
+  installSkillLocally: async () => {},
+  upsertSkillsIndex: () => {},
+}));
+
+mock.module("../skills/catalog-search.js", () => ({
+  filterByQuery: () => [],
+}));
+
+mock.module("../skills/clawhub.js", () => ({
+  clawhubCheckUpdates: async () => [],
+  clawhubInspect: async () => ({}),
+  clawhubInstall: async () => ({ success: true }),
+  clawhubSearch: async () => ({ skills: [] }),
+  clawhubUpdate: async () => ({ success: true }),
+}));
+
+mock.module("../skills/skillssh-registry.js", () => ({
+  installExternalSkill: async () => {},
+  resolveSkillSource: () => ({ owner: "", repo: "", skillSlug: "" }),
+  searchSkillsRegistry: async () => [],
+}));
+
+mock.module("../skills/managed-store.js", () => ({
+  createManagedSkill: () => ({ created: true }),
+  deleteManagedSkill: () => ({ deleted: true }),
+  removeSkillsIndexEntry: () => {},
+  validateManagedSkillId: () => null,
+}));
+
+mock.module("../memory/graph/capability-seed.js", () => ({
+  deleteSkillCapabilityNode: () => {},
+  seedSkillGraphNodes: () => {},
+  seedUninstalledCatalogSkillMemories: async () => {},
+}));
+
+mock.module("../providers/provider-send-message.js", () => ({
+  createTimeout: () => ({
+    signal: AbortSignal.timeout(1000),
+    cleanup: () => {},
+  }),
+  extractText: () => "",
+  getConfiguredProvider: async () => null,
+  userMessage: () => ({}),
+}));
+
+mock.module("../util/platform.js", () => ({
+  getWorkspaceSkillsDir: () => "/tmp/test-skills-fallback",
+}));
+
+mock.module("../daemon/handlers/shared.js", () => ({
+  CONFIG_RELOAD_DEBOUNCE_MS: 100,
+  ensureSkillEntry: (_raw: Record<string, unknown>, _id: string) => ({
+    enabled: false,
+  }),
+  log: {
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Import after mocks
+// ---------------------------------------------------------------------------
+
+import { getSkillFiles } from "../daemon/handlers/skills.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const dummyCtx = {
+  debounceTimers: { schedule: () => {} },
+  setSuppressConfigReload: () => {},
+  updateConfigFingerprint: () => {},
+  broadcast: () => {},
+} as unknown as Parameters<typeof getSkillFiles>[1];
+
+function makeSummary(overrides: Partial<SkillSummary>): SkillSummary {
+  return {
+    id: overrides.id ?? "summary-id",
+    name: overrides.name ?? "summary-id",
+    displayName: overrides.displayName ?? "Summary",
+    description: overrides.description ?? "",
+    directoryPath: overrides.directoryPath ?? "/tmp/nonexistent-skill-dir",
+    skillFilePath:
+      overrides.skillFilePath ??
+      join(overrides.directoryPath ?? "/tmp/nonexistent-skill-dir", "SKILL.md"),
+    source: overrides.source ?? "workspace",
+    bundled: overrides.bundled,
+    icon: overrides.icon,
+    emoji: overrides.emoji,
+    toolManifest: overrides.toolManifest,
+    includes: overrides.includes,
+    featureFlag: overrides.featureFlag,
+    activationHints: overrides.activationHints,
+    avoidWhen: overrides.avoidWhen,
+    inlineCommandExpansions: overrides.inlineCommandExpansions,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("getSkillFiles — catalog fallback", () => {
+  beforeEach(() => {
+    mockResolvedStates = [];
+    mockCatalog = [];
+    mockCatalogFiles = null;
+    catalogFilesCalls.length = 0;
+  });
+
+  test("returns catalog skill with files (content: null) when skill is uninstalled but present in catalog", async () => {
+    mockCatalog = [
+      {
+        id: "acme-seo",
+        name: "acme-seo",
+        description: "SEO helper",
+        emoji: "\u{1F50D}",
+        metadata: { vellum: { "display-name": "Acme SEO" } },
+      },
+    ];
+    mockCatalogFiles = [
+      {
+        path: "SKILL.md",
+        name: "SKILL.md",
+        size: 42,
+        mimeType: "",
+        isBinary: false,
+        content: null,
+      },
+      {
+        path: "assets/logo.png",
+        name: "logo.png",
+        size: 1024,
+        mimeType: "",
+        isBinary: true,
+        content: null,
+      },
+    ];
+
+    const result = await getSkillFiles("acme-seo", dummyCtx);
+
+    expect("error" in result).toBe(false);
+    if ("error" in result) return;
+
+    expect(result.skill).toEqual({
+      id: "acme-seo",
+      name: "Acme SEO",
+      description: "SEO helper",
+      emoji: "\u{1F50D}",
+      kind: "catalog",
+      origin: "vellum",
+      status: "available",
+    });
+    expect(result.files).toHaveLength(2);
+    for (const entry of result.files) {
+      expect(entry.content).toBeNull();
+    }
+    // Files should be sorted by path via localeCompare (not codepoint) —
+    // so "assets/logo.png" sorts before "SKILL.md" under default collation.
+    expect(result.files.map((f) => f.path)).toEqual(
+      [...result.files.map((f) => f.path)].sort((a, b) => a.localeCompare(b)),
+    );
+    expect(new Set(result.files.map((f) => f.path))).toEqual(
+      new Set(["SKILL.md", "assets/logo.png"]),
+    );
+    expect(catalogFilesCalls).toEqual(["acme-seo"]);
+  });
+
+  test("returns 404 when skill is neither installed nor in the catalog", async () => {
+    mockResolvedStates = [];
+    mockCatalog = [];
+
+    const result = await getSkillFiles("ghost-skill", dummyCtx);
+
+    expect("error" in result).toBe(true);
+    if (!("error" in result)) return;
+    expect(result.status).toBe(404);
+    expect(result.error).toContain("ghost-skill");
+    expect(catalogFilesCalls).toEqual([]);
+  });
+
+  test("returns 404 when skill is in catalog but readCatalogSkillFiles returns null", async () => {
+    mockCatalog = [
+      {
+        id: "broken-skill",
+        name: "broken-skill",
+        description: "",
+      },
+    ];
+    mockCatalogFiles = null;
+
+    const result = await getSkillFiles("broken-skill", dummyCtx);
+
+    expect("error" in result).toBe(true);
+    if (!("error" in result)) return;
+    expect(result.status).toBe(404);
+    expect(result.error).toContain("broken-skill");
+  });
+
+  test("installed skill returns inline disk content (no catalog call)", async () => {
+    // Create a real temp directory for the installed-skill path to read.
+    const workspaceRoot = mkdtempSync(
+      join(tmpdir(), "vellum-skill-files-test-"),
+    );
+    const installedDir = join(workspaceRoot, "installed-skill");
+    mkdirSync(installedDir, { recursive: true });
+    writeFileSync(
+      join(installedDir, "SKILL.md"),
+      "# Installed\n\nBody of the installed skill.",
+    );
+    writeFileSync(
+      join(installedDir, "notes.txt"),
+      "Some notes about the skill.",
+    );
+
+    try {
+      mockResolvedStates = [
+        {
+          summary: makeSummary({
+            id: "installed-skill",
+            name: "installed-skill",
+            displayName: "Installed Skill",
+            description: "A pre-installed skill",
+            directoryPath: installedDir,
+            source: "workspace",
+          }),
+          state: "enabled",
+        },
+      ];
+
+      const result = await getSkillFiles("installed-skill", dummyCtx);
+
+      expect("error" in result).toBe(false);
+      if ("error" in result) return;
+
+      // Catalog fallback should NOT have been consulted for an installed skill.
+      expect(catalogFilesCalls).toEqual([]);
+
+      expect(result.files).toHaveLength(2);
+      const skillMd = result.files.find((f) => f.path === "SKILL.md");
+      const notes = result.files.find((f) => f.path === "notes.txt");
+      expect(skillMd).toBeDefined();
+      expect(notes).toBeDefined();
+      expect(skillMd!.content).toBe(
+        "# Installed\n\nBody of the installed skill.",
+      );
+      expect(notes!.content).toBe("Some notes about the skill.");
+
+      // Sort-by-path behavior (localeCompare order) is preserved.
+      expect(result.files.map((f) => f.path)).toEqual(
+        [...result.files.map((f) => f.path)].sort((a, b) => a.localeCompare(b)),
+      );
+    } finally {
+      rmSync(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("catalogSkillToSlim falls back to cs.name when metadata.vellum.display-name is absent", async () => {
+    mockCatalog = [
+      {
+        id: "plain-skill",
+        name: "plain-skill",
+        description: "Minimal",
+      },
+    ];
+    mockCatalogFiles = [];
+
+    const result = await getSkillFiles("plain-skill", dummyCtx);
+
+    expect("error" in result).toBe(false);
+    if ("error" in result) return;
+    expect(result.skill.name).toBe("plain-skill");
+    expect(result.skill.kind).toBe("catalog");
+    expect(result.skill.origin).toBe("vellum");
+    expect(result.skill.status).toBe("available");
+  });
+
+  test("catalogSkillToSlim prefers metadata.vellum.display-name over cs.name", async () => {
+    mockCatalog = [
+      {
+        id: "fancy-skill",
+        name: "raw-fancy-name",
+        description: "",
+        metadata: { vellum: { "display-name": "Pretty Fancy Name" } },
+      },
+    ];
+    mockCatalogFiles = [];
+
+    const result = await getSkillFiles("fancy-skill", dummyCtx);
+
+    expect("error" in result).toBe(false);
+    if ("error" in result) return;
+    expect(result.skill.name).toBe("Pretty Fancy Name");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cleanup: ensure we don't leak temp dirs if a test fails mid-way.
+// ---------------------------------------------------------------------------
+
+afterEach(() => {
+  // Nothing to clean up outside test scope — temp dirs are cleaned per-test.
+});

--- a/assistant/src/__tests__/skills-files-catalog-fallback.test.ts
+++ b/assistant/src/__tests__/skills-files-catalog-fallback.test.ts
@@ -2,16 +2,19 @@
  * Tests for `getSkillFiles` catalog fallback.
  *
  * When a skill id isn't resolvable via `findSkillById` (i.e. not installed
- * locally, not bundled, not a managed skill) or the on-disk directory is
- * missing, `getSkillFiles` now falls back to the Vellum catalog via
- * `readCatalogSkillFiles`. Catalog fallback entries carry `content: null`
- * because the catalog-files helper defers content fetching to a follow-up
- * per-file endpoint.
+ * locally, not bundled, not a managed skill), `getSkillFiles` falls back to
+ * the Vellum catalog via `readCatalogSkillFiles`. Catalog fallback entries
+ * carry `content: null` because the catalog-files helper defers content
+ * fetching to a follow-up per-file endpoint. When a skill IS resolved by
+ * `findSkillById` but its on-disk directory is missing, `getSkillFiles`
+ * returns a 404 without falling through to the catalog so the listing and
+ * detail responses agree on `isInstalled`.
  *
  * Coverage:
  *   - Uninstalled catalog skill: returns `{ skill: catalog/vellum/available, files }` with `content: null` for every entry.
  *   - Neither installed nor in catalog: returns 404.
- *   - Installed skill: preserves the existing disk-read behavior with inline `content`.
+ *   - Installed skill: preserves the disk-read behavior with inline `content`.
+ *   - Installed skill with missing directory: returns 404 without consulting the catalog.
  *   - `catalogSkillToSlim` mapping: `metadata.vellum["display-name"]` wins over `cs.name`.
  */
 
@@ -344,6 +347,59 @@ describe("getSkillFiles — catalog fallback", () => {
     } finally {
       rmSync(workspaceRoot, { recursive: true, force: true });
     }
+  });
+
+  test("returns 404 without catalog fallback when installed skill directory is missing on disk", async () => {
+    // `findSkillById` resolves the skill (resolver lists it as installed)
+    // but the on-disk directoryPath does not exist — simulates a corrupted
+    // install, mid-delete race, or external unmount. The handler must
+    // return 404 so the listing response (`kind: "installed"`) and the
+    // detail response stay consistent; falling through to the catalog
+    // would flip the detail to `kind: "catalog"` and break the
+    // client-side `isInstalled` contract.
+    mockResolvedStates = [
+      {
+        summary: makeSummary({
+          id: "ghost-installed",
+          name: "ghost-installed",
+          displayName: "Ghost Installed",
+          description: "Installed in resolver but directory is gone",
+          directoryPath: "/tmp/definitely-does-not-exist-" + Date.now(),
+          source: "workspace",
+        }),
+        state: "enabled",
+      },
+    ];
+    // Even if the same id is present in the catalog, the handler must NOT
+    // fall through — return 404 instead to avoid masking the missing
+    // install directory with a catalog response.
+    mockCatalog = [
+      {
+        id: "ghost-installed",
+        name: "ghost-installed",
+        description: "Also present in catalog",
+      },
+    ];
+    mockCatalogFiles = [
+      {
+        path: "SKILL.md",
+        name: "SKILL.md",
+        size: 10,
+        mimeType: "",
+        isBinary: false,
+        content: null,
+      },
+    ];
+
+    const result = await getSkillFiles("ghost-installed", dummyCtx);
+
+    expect("error" in result).toBe(true);
+    if (!("error" in result)) return;
+    expect(result.status).toBe(404);
+    expect(result.error).toContain("ghost-installed");
+    expect(result.error).toContain("directory missing");
+    // Catalog fallback must not have been consulted.
+    expect(catalogFilesCalls).toEqual([]);
   });
 
   test("catalogSkillToSlim falls back to cs.name when metadata.vellum.display-name is absent", async () => {

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -619,7 +619,18 @@ export async function getSkillFileContent(
   }
 
   const found = findSkillById(skillId);
-  if (found && existsSync(found.summary.directoryPath)) {
+  if (found) {
+    if (!existsSync(found.summary.directoryPath)) {
+      // Resolver lists the skill as installed but the directory is missing
+      // on disk (corrupted install, mid-delete race, external unmount, etc.).
+      // Return a distinct 404 instead of falling through to the catalog path
+      // so the content response stays consistent with `listSkillsWithCatalog`
+      // and `getSkillFiles`, which classify the same id as `kind: "installed"`.
+      return {
+        error: `Skill directory missing for "${skillId}"`,
+        status: 404,
+      };
+    }
     const dir = found.summary.directoryPath;
     const abs = join(dir, sanitized);
 
@@ -690,9 +701,9 @@ export async function getSkillFileContent(
     };
   }
 
-  // Catalog fallback: skill is not installed locally (or its directory is
-  // missing on disk). Try the catalog preview helper, which handles both
-  // dev-mode repo checkouts and the platform preview API.
+  // Catalog fallback: skill is not installed locally. Try the catalog
+  // preview helper, which handles both dev-mode repo checkouts and the
+  // platform preview API.
   let catalog: Awaited<ReturnType<typeof getCatalog>> = [];
   try {
     catalog = await getCatalog();

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -31,7 +31,10 @@ import {
   getConfiguredProvider,
   userMessage,
 } from "../../providers/provider-send-message.js";
-import { isTextMimeType as isTextMime } from "../../runtime/routes/workspace-utils.js";
+import {
+  isTextMimeType as isTextMime,
+  MAX_INLINE_TEXT_SIZE,
+} from "../../runtime/routes/workspace-utils.js";
 import { getCatalog } from "../../skills/catalog-cache.js";
 import {
   hasHiddenOrSkippedSegment,
@@ -82,10 +85,6 @@ import {
   type HandlerContext,
   log,
 } from "./shared.js";
-
-// ─── MIME detection helpers ───────────────────────────────────────────────────
-
-const MAX_INLINE_SIZE = 2 * 1024 * 1024; // 2 MB
 
 // ─── Shared context for standalone functions ─────────────────────────────────
 
@@ -548,7 +547,7 @@ function readDirRecursive(dir: string, rootDir: string): SkillFileEntry[] {
       const mimeType = Bun.file(fullPath).type;
       const isText = isTextMime(mimeType, dirent.name);
       let content: string | null = null;
-      if (isText && stat.size <= MAX_INLINE_SIZE) {
+      if (isText && stat.size <= MAX_INLINE_TEXT_SIZE) {
         content = readFileSync(fullPath, "utf-8");
       }
       entries.push({
@@ -674,7 +673,7 @@ export async function getSkillFileContent(
     const isText = isTextMime(mimeType, name);
     const isBinary = !isText;
     let content: string | null = null;
-    if (isText && stat.size <= MAX_INLINE_SIZE) {
+    if (isText && stat.size <= MAX_INLINE_TEXT_SIZE) {
       try {
         content = readFileSync(abs, "utf-8");
       } catch {
@@ -728,18 +727,29 @@ export async function getSkillFiles(
 > {
   // Preferred path: the skill is resolved locally (bundled, managed,
   // workspace, or extra) AND its directory exists on disk. Read files
-  // eagerly with inline content exactly as before.
+  // eagerly with inline content.
   const found = findSkillById(skillId);
-  if (found && existsSync(found.summary.directoryPath)) {
-    const dirPath = found.summary.directoryPath;
-    const files = readDirRecursive(dirPath, dirPath);
-    files.sort((a, b) => a.path.localeCompare(b.path));
-    return { skill: found.item, files };
+  if (found) {
+    if (existsSync(found.summary.directoryPath)) {
+      const dirPath = found.summary.directoryPath;
+      const files = readDirRecursive(dirPath, dirPath);
+      files.sort((a, b) => a.path.localeCompare(b.path));
+      return { skill: found.item, files };
+    }
+    // Resolver lists the skill as installed but the directory is missing
+    // on disk (corrupted install, mid-delete race, external unmount, etc.).
+    // Return a distinct 404 instead of falling through to the catalog path
+    // so the detail response stays consistent with `listSkillsWithCatalog`,
+    // which classifies the same id as `kind: "installed"`.
+    return {
+      error: `Skill directory missing for "${skillId}"`,
+      status: 404,
+    };
   }
 
-  // Fallback: skill is not installed (or its directory is missing). Try
-  // the Vellum catalog — this covers previewing files for an uninstalled
-  // catalog skill without touching the install flow.
+  // Fallback: skill is not installed. Try the Vellum catalog — this covers
+  // previewing files for an uninstalled catalog skill without touching the
+  // install flow.
   let catalog: CatalogSkill[];
   try {
     catalog = await getCatalog();

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -33,8 +33,12 @@ import {
 } from "../../providers/provider-send-message.js";
 import { isTextMimeType as isTextMime } from "../../runtime/routes/workspace-utils.js";
 import { getCatalog } from "../../skills/catalog-cache.js";
-import type { SkillFileEntry } from "../../skills/catalog-files.js";
 import {
+  readCatalogSkillFiles,
+  type SkillFileEntry,
+} from "../../skills/catalog-files.js";
+import {
+  type CatalogSkill,
   installSkillLocally,
   upsertSkillsIndex,
 } from "../../skills/catalog-install.js";
@@ -365,7 +369,7 @@ export async function listSkillsWithCatalog(
   const installed = listSkills(ctx);
   const installedIds = new Set(installed.map((s) => s.id));
 
-  let catalogSkills: import("../../skills/catalog-install.js").CatalogSkill[];
+  let catalogSkills: CatalogSkill[];
   try {
     catalogSkills = await getCatalog();
   } catch {
@@ -377,15 +381,7 @@ export async function listSkillsWithCatalog(
   // Create SlimSkillResponses for catalog skills not already installed.
   const available: SlimSkillResponse[] = catalogSkills
     .filter((cs) => !installedIds.has(cs.id))
-    .map((cs) => ({
-      id: cs.id,
-      name: cs.metadata?.vellum?.["display-name"] ?? cs.name,
-      description: cs.description,
-      emoji: cs.emoji,
-      kind: "catalog" as const,
-      origin: "vellum" as const,
-      status: "available" as const,
-    }));
+    .map((cs) => catalogSkillToSlim(cs));
 
   const merged = [...installed, ...available];
 
@@ -567,26 +563,68 @@ function readDirRecursive(dir: string, rootDir: string): SkillFileEntry[] {
   return entries;
 }
 
-export function getSkillFiles(
+/**
+ * Map a `CatalogSkill` (from the Vellum platform API) to a `SlimSkillResponse`
+ * shaped for the "available catalog skill" case. Shared between
+ * `listSkillsWithCatalog` (merging catalog entries into the installed list)
+ * and `getSkillFiles` (catalog fallback for preview listings). Keeping the
+ * mapping in one place avoids divergence between the list and detail paths.
+ */
+function catalogSkillToSlim(cs: CatalogSkill): SlimSkillResponse {
+  return {
+    id: cs.id,
+    name: cs.metadata?.vellum?.["display-name"] ?? cs.name,
+    description: cs.description,
+    emoji: cs.emoji,
+    kind: "catalog",
+    origin: "vellum",
+    status: "available",
+  };
+}
+
+export async function getSkillFiles(
   skillId: string,
   _ctx: SkillOperationContext,
-):
+): Promise<
   | { skill: SlimSkillResponse; files: SkillFileEntry[] }
-  | { error: string; status: number } {
+  | { error: string; status: number }
+> {
+  // Preferred path: the skill is resolved locally (bundled, managed,
+  // workspace, or extra) AND its directory exists on disk. Read files
+  // eagerly with inline content exactly as before.
   const found = findSkillById(skillId);
-  if (!found) {
+  if (found && existsSync(found.summary.directoryPath)) {
+    const dirPath = found.summary.directoryPath;
+    const files = readDirRecursive(dirPath, dirPath);
+    files.sort((a, b) => a.path.localeCompare(b.path));
+    return { skill: found.item, files };
+  }
+
+  // Fallback: skill is not installed (or its directory is missing). Try
+  // the Vellum catalog — this covers previewing files for an uninstalled
+  // catalog skill without touching the install flow.
+  let catalog: CatalogSkill[];
+  try {
+    catalog = await getCatalog();
+  } catch {
+    return { error: `Skill "${skillId}" not found`, status: 404 };
+  }
+  const cs = catalog.find((c) => c.id === skillId);
+  if (!cs) {
     return { error: `Skill "${skillId}" not found`, status: 404 };
   }
 
-  const dirPath = found.summary.directoryPath;
-  if (!existsSync(dirPath)) {
-    return { error: `Skill directory not found for "${skillId}"`, status: 404 };
+  const files = await readCatalogSkillFiles(skillId);
+  if (files === null) {
+    return {
+      error: `Skill files unavailable for "${skillId}"`,
+      status: 404,
+    };
   }
 
-  const files = readDirRecursive(dirPath, dirPath);
+  const skill = catalogSkillToSlim(cs);
   files.sort((a, b) => a.path.localeCompare(b.path));
-
-  return { skill: found.item, files };
+  return { skill, files };
 }
 
 export function enableSkill(

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -33,6 +33,7 @@ import {
 } from "../../providers/provider-send-message.js";
 import { isTextMimeType as isTextMime } from "../../runtime/routes/workspace-utils.js";
 import { getCatalog } from "../../skills/catalog-cache.js";
+import type { SkillFileEntry } from "../../skills/catalog-files.js";
 import {
   installSkillLocally,
   upsertSkillsIndex,
@@ -494,14 +495,12 @@ export async function getSkill(
 
 // ─── Skill file listing ──────────────────────────────────────────────────────
 
-export interface SkillFileEntry {
-  path: string; // relative to skill directory root (e.g. "SKILL.md", "tools/foo.ts")
-  name: string; // basename
-  size: number;
-  mimeType: string;
-  isBinary: boolean;
-  content: string | null; // inline text if ≤ 2 MB and text MIME, else null
-}
+// `SkillFileEntry` lives in `../../skills/catalog-files.ts` to keep a single
+// source of truth for the shape and avoid a circular import (catalog-files
+// depends on `catalog-cache.ts`, which would otherwise be reachable via this
+// handler module). Re-exported here so handlers can import it alongside
+// the other skill handler exports.
+export type { SkillFileEntry } from "../../skills/catalog-files.js";
 
 const SKIP_DIRS = new Set(["node_modules", "__pycache__", ".git"]);
 

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -9,7 +9,7 @@ import {
   statSync,
 } from "node:fs";
 import { homedir } from "node:os";
-import { join, relative } from "node:path";
+import { basename, join, relative, sep } from "node:path";
 
 import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
 import {
@@ -34,8 +34,12 @@ import {
 import { isTextMimeType as isTextMime } from "../../runtime/routes/workspace-utils.js";
 import { getCatalog } from "../../skills/catalog-cache.js";
 import {
+  hasHiddenOrSkippedSegment,
+  readCatalogSkillFileContent,
   readCatalogSkillFiles,
+  sanitizeRelativePath,
   type SkillFileEntry,
+  SKIP_DIRS,
 } from "../../skills/catalog-files.js";
 import {
   type CatalogSkill,
@@ -69,6 +73,7 @@ import {
 import { getWorkspaceSkillsDir } from "../../util/platform.js";
 import type {
   SkillDetailResponse,
+  SkillFileContentResponse,
   SlimSkillResponse,
 } from "../message-types/skills.js";
 import {
@@ -498,8 +503,6 @@ export async function getSkill(
 // the other skill handler exports.
 export type { SkillFileEntry } from "../../skills/catalog-files.js";
 
-const SKIP_DIRS = new Set(["node_modules", "__pycache__", ".git"]);
-
 /**
  * Returns true if `filePath` is a symlink whose resolved real path escapes
  * `rootDir`. Symlinks that stay within `rootDir` are allowed; only those that
@@ -579,6 +582,140 @@ function catalogSkillToSlim(cs: CatalogSkill): SlimSkillResponse {
     kind: "catalog",
     origin: "vellum",
     status: "available",
+  };
+}
+
+/**
+ * Read a single file's content from an installed or catalog skill.
+ *
+ * Installed-skill path (eager): reads the file directly from the skill's
+ * on-disk directory. Applies lexical containment, symlink rejection, and
+ * realpath containment checks for defense in depth.
+ *
+ * Catalog fallback: when the skill id is not backed by a local directory
+ * (e.g. an uninstalled Vellum catalog skill), delegates to
+ * `readCatalogSkillFileContent`, which handles both the dev-mode repo
+ * checkout path and the platform preview API path internally.
+ */
+export async function getSkillFileContent(
+  skillId: string,
+  relativePath: string,
+  _ctx: SkillOperationContext,
+): Promise<SkillFileContentResponse | { error: string; status: number }> {
+  const sanitized = sanitizeRelativePath(relativePath);
+  if (!sanitized) {
+    return { error: "Invalid path", status: 400 };
+  }
+
+  // Reject any sanitized path that references a hidden segment (dotfiles
+  // like `.env`, dot-dirs like `.git`) or a SKIP_DIRS segment (e.g.
+  // `node_modules`, `__pycache__`). Both file-listing endpoints (installed
+  // and catalog) intentionally omit these entries, so allowing the content
+  // endpoint to read them would create a data-exposure path and break
+  // parity with the visible file list. This check runs BEFORE both the
+  // installed-skill disk read and the catalog fallback so the rejection
+  // is uniform regardless of source.
+  if (hasHiddenOrSkippedSegment(sanitized)) {
+    return { error: "Invalid path", status: 400 };
+  }
+
+  const found = findSkillById(skillId);
+  if (found && existsSync(found.summary.directoryPath)) {
+    const dir = found.summary.directoryPath;
+    const abs = join(dir, sanitized);
+
+    // Lexical containment: the resolved absolute path must stay inside the
+    // skill directory even after `join` normalization. Cheap short-circuit
+    // before any fs calls.
+    if (!(abs === dir || abs.startsWith(dir + sep))) {
+      return { error: "Invalid path", status: 400 };
+    }
+
+    // Defense-in-depth symlink rejection: refuse to follow a symlinked file
+    // inside the skill dir that could point outside the root. Also catches
+    // symlinked parent directories via a realpath containment check.
+    let lstat;
+    try {
+      lstat = lstatSync(abs);
+    } catch {
+      return { error: "File not found", status: 404 };
+    }
+    if (lstat.isSymbolicLink()) {
+      return { error: "File not found", status: 404 };
+    }
+    if (!lstat.isFile()) {
+      return { error: "File not found", status: 404 };
+    }
+
+    let realAbs: string;
+    let realDir: string;
+    try {
+      realAbs = realpathSync(abs);
+      realDir = realpathSync(dir);
+    } catch {
+      return { error: "File not found", status: 404 };
+    }
+    if (!(realAbs === realDir || realAbs.startsWith(realDir + sep))) {
+      return { error: "File not found", status: 404 };
+    }
+
+    let stat;
+    try {
+      stat = statSync(abs);
+    } catch {
+      return { error: "File not found", status: 404 };
+    }
+    if (!stat.isFile()) {
+      return { error: "File not found", status: 404 };
+    }
+
+    const name = basename(sanitized);
+    const mimeType = Bun.file(abs).type;
+    const isText = isTextMime(mimeType, name);
+    const isBinary = !isText;
+    let content: string | null = null;
+    if (isText && stat.size <= MAX_INLINE_SIZE) {
+      try {
+        content = readFileSync(abs, "utf-8");
+      } catch {
+        content = null;
+      }
+    }
+    return {
+      path: sanitized,
+      name,
+      size: stat.size,
+      mimeType,
+      isBinary,
+      content,
+    };
+  }
+
+  // Catalog fallback: skill is not installed locally (or its directory is
+  // missing on disk). Try the catalog preview helper, which handles both
+  // dev-mode repo checkouts and the platform preview API.
+  let catalog: Awaited<ReturnType<typeof getCatalog>> = [];
+  try {
+    catalog = await getCatalog();
+  } catch {
+    catalog = [];
+  }
+  const inCatalog = catalog.some((s) => s.id === skillId);
+  if (!inCatalog) {
+    return { error: "Skill not found", status: 404 };
+  }
+
+  const result = await readCatalogSkillFileContent(skillId, sanitized);
+  if (!result) {
+    return { error: "File not found", status: 404 };
+  }
+  return {
+    path: result.path,
+    name: result.name,
+    size: result.size,
+    mimeType: result.mimeType,
+    isBinary: result.isBinary,
+    content: result.content,
   };
 }
 

--- a/assistant/src/daemon/message-types/skills.ts
+++ b/assistant/src/daemon/message-types/skills.ts
@@ -189,6 +189,16 @@ export type SkillDetailResponse =
   | SkillsshSkillDetail
   | CustomSkillDetail;
 
+// ─── Single-file content response (HTTP API) ─────────────────────────────
+export interface SkillFileContentResponse {
+  path: string;
+  name: string;
+  size: number;
+  mimeType: string;
+  isBinary: boolean;
+  content: string | null;
+}
+
 export interface SkillsDraftResponse {
   type: "skills_draft_response";
   success: boolean;

--- a/assistant/src/runtime/routes/skills-routes.ts
+++ b/assistant/src/runtime/routes/skills-routes.ts
@@ -19,6 +19,7 @@ import {
   draftSkill,
   enableSkill,
   getSkill,
+  getSkillFileContent,
   getSkillFiles,
   inspectSkill,
   installSkill,
@@ -148,6 +149,55 @@ export function skillRouteDefinitions(deps: SkillRouteDeps): RouteDefinition[] {
             ? await listSkillsWithCatalog(ctx())
             : listSkills(ctx());
         return Response.json({ skills });
+      },
+    },
+
+    // Registered BEFORE `skills/:id/files` so the more-specific pattern is
+    // matched first even if the router's matching rule ever changes.
+    {
+      endpoint: "skills/:id/files/content",
+      method: "GET",
+      policyKey: "skills",
+      summary: "Get skill file content",
+      description:
+        "Return the content of a single file belonging to an installed or catalog skill.",
+      tags: ["skills"],
+      queryParams: [
+        {
+          name: "path",
+          schema: { type: "string" },
+          required: true,
+          description: "Relative path of the file within the skill directory",
+        },
+      ],
+      responseBody: z.object({
+        path: z.string(),
+        name: z.string(),
+        size: z.number(),
+        mimeType: z.string(),
+        isBinary: z.boolean(),
+        content: z.string().nullable(),
+      }),
+      handler: async ({ params, url }) => {
+        const path = url.searchParams.get("path");
+        if (!path) {
+          return httpError(
+            "BAD_REQUEST",
+            "path query parameter is required",
+            400,
+          );
+        }
+        const result = await getSkillFileContent(params.id, path, ctx());
+        if ("error" in result) {
+          if (result.status === 400) {
+            return httpError("BAD_REQUEST", result.error, 400);
+          }
+          if (result.status === 404) {
+            return httpError("NOT_FOUND", result.error, 404);
+          }
+          return httpError("INTERNAL_ERROR", result.error, 500);
+        }
+        return Response.json(result);
       },
     },
 

--- a/assistant/src/runtime/routes/skills-routes.ts
+++ b/assistant/src/runtime/routes/skills-routes.ts
@@ -158,8 +158,8 @@ export function skillRouteDefinitions(deps: SkillRouteDeps): RouteDefinition[] {
       summary: "Get skill files",
       description: "Return skill metadata and directory contents.",
       tags: ["skills"],
-      handler: ({ params }) => {
-        const result = getSkillFiles(params.id, ctx());
+      handler: async ({ params }) => {
+        const result = await getSkillFiles(params.id, ctx());
         if ("error" in result) {
           if (result.status === 404) {
             return httpError("NOT_FOUND", result.error, 404);

--- a/assistant/src/runtime/routes/skills-routes.ts
+++ b/assistant/src/runtime/routes/skills-routes.ts
@@ -152,8 +152,8 @@ export function skillRouteDefinitions(deps: SkillRouteDeps): RouteDefinition[] {
       },
     },
 
-    // Registered BEFORE `skills/:id/files` so the more-specific pattern is
-    // matched first even if the router's matching rule ever changes.
+    // The router uses strict anchored-regex matching, so this route is never
+    // ambiguous with skills/:id/files.
     {
       endpoint: "skills/:id/files/content",
       method: "GET",
@@ -173,7 +173,7 @@ export function skillRouteDefinitions(deps: SkillRouteDeps): RouteDefinition[] {
       responseBody: z.object({
         path: z.string(),
         name: z.string(),
-        size: z.number(),
+        size: z.number().int(),
         mimeType: z.string(),
         isBinary: z.boolean(),
         content: z.string().nullable(),

--- a/assistant/src/skills/catalog-files.ts
+++ b/assistant/src/skills/catalog-files.ts
@@ -29,15 +29,16 @@ import {
 import { basename, join, posix, sep } from "node:path";
 
 import { getPlatformBaseUrl } from "../config/env.js";
-import { isTextMimeType as isTextMime } from "../runtime/routes/workspace-utils.js";
+import {
+  isTextMimeType as isTextMime,
+  MAX_INLINE_TEXT_SIZE,
+} from "../runtime/routes/workspace-utils.js";
 import { getLogger } from "../util/logger.js";
 import { readPlatformToken } from "../util/platform.js";
 import { getCatalog } from "./catalog-cache.js";
 import { getRepoSkillsDir } from "./catalog-install.js";
 
 const log = getLogger("catalog-files");
-
-const MAX_INLINE_SIZE = 2 * 1024 * 1024; // 2 MB
 
 /**
  * Classify a file as text/binary from its name alone. Used by the preview
@@ -387,7 +388,7 @@ export async function readCatalogSkillFiles(
  *
  * Returns `null` if the skill is missing from the catalog, the path fails
  * sanitization, the underlying source rejects the request, or the file does
- * not exist. In dev mode, text files up to `MAX_INLINE_SIZE` are returned
+ * not exist. In dev mode, text files up to `MAX_INLINE_TEXT_SIZE` are returned
  * with their UTF-8 content inline; anything larger or flagged as binary
  * returns with `content === null`. In platform mode, the server enforces
  * the same contract and we pass its response through unchanged.
@@ -457,7 +458,7 @@ export async function readCatalogSkillFileContent(
     const mimeType = Bun.file(abs).type;
     const isBinary = !isTextMime(mimeType, name);
     let content: string | null = null;
-    if (!isBinary && stat.size <= MAX_INLINE_SIZE) {
+    if (!isBinary && stat.size <= MAX_INLINE_TEXT_SIZE) {
       try {
         content = readFileSync(abs, "utf-8");
       } catch {

--- a/assistant/src/skills/catalog-files.ts
+++ b/assistant/src/skills/catalog-files.ts
@@ -3,15 +3,14 @@
  * skills, including ones that are NOT installed locally.
  *
  * This module is pure library code: it does NOT wire itself into any handler
- * or route. It is consumed by higher-level daemon handlers introduced in
- * later PRs of the `skill-files-preview` plan.
+ * or route. Higher-level daemon handlers consume it via the exported
+ * `readCatalogSkillFiles` / `readCatalogSkillFileContent` functions.
  *
  * Data sources:
  *   - In `VELLUM_DEV` mode, when `<repo>/skills/<id>/` exists on disk, we
  *     read the skill files directly from the repo checkout (matching the
  *     behavior of `getCatalog()` in dev).
- *   - Otherwise, we call the platform preview endpoints introduced by
- *     vellum-assistant-platform PR #4103:
+ *   - Otherwise, we call the platform preview endpoints:
  *       GET /v1/skills/{skill_id}/files/
  *       GET /v1/skills/{skill_id}/files/content/?path=...
  *
@@ -74,9 +73,9 @@ export interface SkillFileEntry {
 
 // ─── Platform response contracts ─────────────────────────────────────────────
 //
-// Wire format is snake_case (vellum-assistant-platform PR #4103). We map to
-// the daemon's camelCase shape inside this module so nothing downstream needs
-// to know about the platform contract.
+// The platform preview API uses snake_case on the wire. We map to the
+// daemon's camelCase shape inside this module so nothing downstream needs to
+// know about the platform contract.
 
 interface PlatformFileListResponse {
   skill_id: string;
@@ -268,13 +267,32 @@ async function fetchPlatformJson<T>(
 // ─── Dev-mode directory walker ───────────────────────────────────────────────
 
 // Directory names that are always skipped when walking a catalog skill dir in
-// dev mode. Kept in sync with `SKIP_DIRS` in
-// `src/daemon/handlers/skills.ts` (which performs the same filter for
-// installed skills). Duplicated here rather than imported to avoid a
-// circular dependency: `daemon/handlers/skills.ts` already imports the
-// `SkillFileEntry` type from this module. If you add or remove an entry,
-// update the other copy as well.
-const SKIP_DIRS = new Set(["node_modules", "__pycache__", ".git"]);
+// dev mode. Also used by `daemon/handlers/skills.ts` — both for the
+// installed-skill walker and for the single-file content endpoint's
+// hidden/skipped path rejection. Exported so the daemon handler can
+// import this single source of truth and stay in sync.
+export const SKIP_DIRS = new Set(["node_modules", "__pycache__", ".git"]);
+
+/**
+ * Returns true if the given sanitized posix path contains any segment that
+ * is hidden (starts with `.`) or present in `SKIP_DIRS`. Used to reject
+ * file-content reads for paths the listing APIs intentionally hide, so
+ * callers cannot fetch `.env`, `.git/config`, `node_modules/...`, etc. via
+ * the content endpoint even though the listing never surfaces them.
+ *
+ * The input MUST already be a normalized posix path (i.e. the return value
+ * of `sanitizeRelativePath`). This helper does not re-normalize — it splits
+ * on `/` and inspects each segment directly.
+ */
+export function hasHiddenOrSkippedSegment(sanitized: string): boolean {
+  const segments = sanitized.split("/");
+  for (const segment of segments) {
+    if (segment.length === 0) continue;
+    if (segment.startsWith(".")) return true;
+    if (SKIP_DIRS.has(segment)) return true;
+  }
+  return false;
+}
 
 function walkSkillDir(dir: string, rootDir: string): SkillFileEntry[] {
   const out: SkillFileEntry[] = [];
@@ -380,6 +398,12 @@ export async function readCatalogSkillFileContent(
 ): Promise<SkillFileEntry | null> {
   const sanitized = sanitizeRelativePath(relativePath);
   if (!sanitized) return null;
+
+  // Defense in depth: reject any path that references a hidden or
+  // SKIP_DIRS segment. The daemon handler performs the same check before
+  // calling us, but we repeat it here so direct callers of this module
+  // short-circuit without a network round trip and without touching disk.
+  if (hasHiddenOrSkippedSegment(sanitized)) return null;
 
   const source = await resolveCatalogSource(skillId);
   if (!source) return null;

--- a/assistant/src/skills/catalog-files.ts
+++ b/assistant/src/skills/catalog-files.ts
@@ -1,0 +1,467 @@
+/**
+ * catalog-files — preview file listings and single-file content for catalog
+ * skills, including ones that are NOT installed locally.
+ *
+ * This module is pure library code: it does NOT wire itself into any handler
+ * or route. It is consumed by higher-level daemon handlers introduced in
+ * later PRs of the `skill-files-preview` plan.
+ *
+ * Data sources:
+ *   - In `VELLUM_DEV` mode, when `<repo>/skills/<id>/` exists on disk, we
+ *     read the skill files directly from the repo checkout (matching the
+ *     behavior of `getCatalog()` in dev).
+ *   - Otherwise, we call the platform preview endpoints introduced by
+ *     vellum-assistant-platform PR #4103:
+ *       GET /v1/skills/{skill_id}/files/
+ *       GET /v1/skills/{skill_id}/files/content/?path=...
+ *
+ * Crucially, this code does NOT extract any tar/gzip archives. Previewing a
+ * skill's files never installs it or touches the install flow.
+ */
+
+import {
+  existsSync,
+  lstatSync,
+  readdirSync,
+  readFileSync,
+  realpathSync,
+  statSync,
+} from "node:fs";
+import { basename, join, posix, sep } from "node:path";
+
+import { getPlatformBaseUrl } from "../config/env.js";
+import { isTextMimeType as isTextMime } from "../runtime/routes/workspace-utils.js";
+import { getLogger } from "../util/logger.js";
+import { readPlatformToken } from "../util/platform.js";
+import { getCatalog } from "./catalog-cache.js";
+import { getRepoSkillsDir } from "./catalog-install.js";
+
+const log = getLogger("catalog-files");
+
+const MAX_INLINE_SIZE = 2 * 1024 * 1024; // 2 MB
+
+/**
+ * Classify a file as text/binary from its name alone. Used by the preview
+ * listings where we do not have the file's bytes on hand (platform mode) or
+ * where we want to defer reading content until explicitly requested (dev
+ * mode listings). Bun derives the mime type from the file extension, so
+ * this works for non-existent paths too.
+ */
+function classifyByName(name: string): boolean {
+  const mime = Bun.file(name).type;
+  return !isTextMime(mime, name);
+}
+
+// ─── Shared types ────────────────────────────────────────────────────────────
+
+/**
+ * A single file entry in a skill directory or preview listing.
+ *
+ * This module owns the canonical shape; `daemon/handlers/skills.ts`
+ * re-exports it so handler consumers can import it from either location.
+ * Keeping the definition here avoids a circular import — catalog-files
+ * depends on `catalog-cache.ts`, which would otherwise be reachable via
+ * the handler module.
+ */
+export interface SkillFileEntry {
+  path: string; // relative to skill directory root (e.g. "SKILL.md", "tools/foo.ts")
+  name: string; // basename
+  size: number;
+  mimeType: string;
+  isBinary: boolean;
+  content: string | null; // inline text if ≤ 2 MB and text MIME, else null
+}
+
+// ─── Platform response contracts ─────────────────────────────────────────────
+//
+// Wire format is snake_case (vellum-assistant-platform PR #4103). We map to
+// the daemon's camelCase shape inside this module so nothing downstream needs
+// to know about the platform contract.
+
+interface PlatformFileListResponse {
+  skill_id: string;
+  files: Array<{ path: string; name: string; size: number; sha: string }>;
+}
+
+interface PlatformFileContentResponse {
+  path: string;
+  name: string;
+  size: number;
+  mime_type: string;
+  is_binary: boolean;
+  content: string | null;
+}
+
+// ─── Path sanitization ───────────────────────────────────────────────────────
+
+/**
+ * Normalize and validate a relative path coming from untrusted input. Returns
+ * the normalized posix path on success, or `null` if the input is unsafe.
+ *
+ * Rules:
+ *   - Reject empty strings and strings containing null bytes.
+ *   - Reject absolute paths (unix or windows drive-prefixed).
+ *   - Normalize backslashes to forward slashes, strip leading `./`, and
+ *     run `posix.normalize` to collapse redundant segments.
+ *   - Reject paths that escape the root (normalized result equals `..` or
+ *     begins with `../`).
+ *
+ * The platform also validates these server-side; client-side sanitization is
+ * defense in depth and short-circuits obvious bad requests before a network
+ * round trip.
+ */
+export function sanitizeRelativePath(rawPath: string): string | null {
+  if (typeof rawPath !== "string" || rawPath.length === 0) return null;
+  if (rawPath.includes("\0")) return null;
+  if (rawPath.startsWith("/")) return null;
+  if (/^[a-zA-Z]:[/\\]/.test(rawPath)) return null;
+
+  // Normalize separators and strip any leading "./" before posix.normalize
+  // (which would otherwise preserve it in some cases).
+  let candidate = rawPath.replace(/\\/g, "/");
+  while (candidate.startsWith("./")) {
+    candidate = candidate.slice(2);
+  }
+  if (candidate.length === 0) return null;
+
+  const normalized = posix.normalize(candidate);
+  if (normalized === "..") return null;
+  if (normalized.startsWith("../")) return null;
+  // posix.normalize can still return "." for purely no-op paths.
+  if (normalized === ".") return null;
+  // Reject if normalization produced an absolute or Windows-drive path.
+  // Covers bypasses like `.//etc/passwd` where the leading `./` strip loop
+  // leaves `/etc/passwd`, which `posix.normalize` then passes through as an
+  // absolute path. The pre-normalization absolute-path check above only
+  // catches inputs that were absolute to begin with.
+  if (normalized.startsWith("/")) return null;
+  if (/^[a-zA-Z]:[/\\]/.test(normalized)) return null;
+
+  return normalized;
+}
+
+// ─── Source resolution ───────────────────────────────────────────────────────
+
+type CatalogSource =
+  | { kind: "dir"; dirPath: string }
+  | { kind: "platform"; skillId: string };
+
+/**
+ * Resolve where to read files for a given catalog skill id. Performs NO
+ * network calls — network requests happen only inside `readCatalogSkillFiles`
+ * and `readCatalogSkillFileContent` on the platform path.
+ *
+ * Dev-mode safety: when a `<repoSkillsDir>/<skillId>` entry exists on disk,
+ * we verify that the skill root is a real directory physically located
+ * inside `repoSkillsDir` — rejecting symlinks and anything whose realpath
+ * escapes the repo skills dir. This prevents a symlinked skill root from
+ * pointing at an external directory and bypassing the later realpath
+ * containment check in `readCatalogSkillFileContent` (the check there
+ * derives `realRoot` from the already-resolved skill dir, so if the skill
+ * root itself is a symlink, `realRoot` resolves through the symlink target
+ * and the containment check becomes a no-op). On any violation we silently
+ * fall through to platform mode, which is the safe default — the dev-mode
+ * shortcut is an optimization, not a required code path.
+ */
+async function resolveCatalogSource(
+  skillId: string,
+): Promise<CatalogSource | null> {
+  const catalog = await getCatalog();
+  const inCatalog = catalog.some((skill) => skill.id === skillId);
+  if (!inCatalog) return null;
+
+  const repoSkillsDir = getRepoSkillsDir();
+  if (repoSkillsDir) {
+    const candidate = join(repoSkillsDir, skillId);
+    if (existsSync(candidate) && isSafeDevSkillRoot(candidate, repoSkillsDir)) {
+      return { kind: "dir", dirPath: candidate };
+    }
+  }
+  return { kind: "platform", skillId };
+}
+
+/**
+ * Verify that a dev-mode skill root candidate is a real directory physically
+ * located inside `repoSkillsDir`. Returns `false` for any of:
+ *
+ *   - `candidate` is itself a symbolic link (even if the target is still
+ *     "nearby" — following it would break the realpath containment check
+ *     in `readCatalogSkillFileContent`).
+ *   - `candidate` is not a directory.
+ *   - `realpath(candidate)` escapes `realpath(repoSkillsDir)`.
+ *   - Any fs call throws (EACCES, ENOENT race, etc.).
+ *
+ * Callers should fall through to platform mode on `false`.
+ */
+function isSafeDevSkillRoot(candidate: string, repoSkillsDir: string): boolean {
+  let lstat;
+  try {
+    lstat = lstatSync(candidate);
+  } catch {
+    return false;
+  }
+  if (lstat.isSymbolicLink()) return false;
+  if (!lstat.isDirectory()) return false;
+
+  let realCandidate: string;
+  let realRepoSkillsDir: string;
+  try {
+    realCandidate = realpathSync(candidate);
+    realRepoSkillsDir = realpathSync(repoSkillsDir);
+  } catch {
+    return false;
+  }
+  if (
+    !(
+      realCandidate === realRepoSkillsDir ||
+      realCandidate.startsWith(realRepoSkillsDir + sep)
+    )
+  ) {
+    return false;
+  }
+  return true;
+}
+
+// ─── Platform fetch helper ───────────────────────────────────────────────────
+
+/**
+ * Fetch JSON from the platform preview API. Returns `null` on any failure
+ * (non-2xx, network error, abort). The query string is stripped from log
+ * messages to avoid leaking user-supplied file paths.
+ */
+async function fetchPlatformJson<T>(
+  path: string,
+  query?: Record<string, string>,
+): Promise<T | null> {
+  const base = getPlatformBaseUrl();
+  const url = new URL(`${base}${path}`);
+  if (query) {
+    const params = new URLSearchParams(query);
+    url.search = params.toString();
+  }
+
+  const headers: Record<string, string> = { Accept: "application/json" };
+  const token = readPlatformToken();
+  if (token) {
+    headers["X-Conversation-Token"] = token;
+  }
+
+  try {
+    const response = await fetch(url.toString(), {
+      headers,
+      signal: AbortSignal.timeout(15000),
+    });
+    if (!response.ok) {
+      log.warn(
+        { status: response.status, path },
+        "Platform preview API returned non-2xx",
+      );
+      return null;
+    }
+    return (await response.json()) as T;
+  } catch (err) {
+    log.warn({ err, path }, "Platform preview API request failed");
+    return null;
+  }
+}
+
+// ─── Dev-mode directory walker ───────────────────────────────────────────────
+
+// Directory names that are always skipped when walking a catalog skill dir in
+// dev mode. Kept in sync with `SKIP_DIRS` in
+// `src/daemon/handlers/skills.ts` (which performs the same filter for
+// installed skills). Duplicated here rather than imported to avoid a
+// circular dependency: `daemon/handlers/skills.ts` already imports the
+// `SkillFileEntry` type from this module. If you add or remove an entry,
+// update the other copy as well.
+const SKIP_DIRS = new Set(["node_modules", "__pycache__", ".git"]);
+
+function walkSkillDir(dir: string, rootDir: string): SkillFileEntry[] {
+  const out: SkillFileEntry[] = [];
+  let dirents;
+  try {
+    dirents = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const dirent of dirents) {
+    // Skip dot-prefixed entries (hidden files like `.DS_Store` and dot-dirs
+    // like `.git`, `.venv`). Matches the behavior of the installed-skill
+    // walker in `daemon/handlers/skills.ts`.
+    if (dirent.name.startsWith(".")) continue;
+    const abs = join(dir, dirent.name);
+    // Silently skip symlinks, sockets, devices, etc.
+    if (dirent.isSymbolicLink()) continue;
+    if (dirent.isDirectory()) {
+      // Skip well-known heavyweight directories (node_modules, __pycache__,
+      // ...) so a dev working on a catalog skill locally doesn't see
+      // thousands of spurious entries in the preview listing.
+      if (SKIP_DIRS.has(dirent.name)) continue;
+      out.push(...walkSkillDir(abs, rootDir));
+      continue;
+    }
+    if (!dirent.isFile()) continue;
+    try {
+      const stat = statSync(abs);
+      // Convert absolute → relative with manual separator normalization so
+      // the result is always posix-style regardless of the host platform.
+      const relFromRoot = abs.slice(rootDir.length);
+      const cleaned = relFromRoot.startsWith(sep)
+        ? relFromRoot.slice(sep.length)
+        : relFromRoot;
+      const posixPath = cleaned.split(sep).join("/");
+      out.push({
+        path: posixPath,
+        name: basename(posixPath),
+        size: stat.size,
+        mimeType: "",
+        isBinary: classifyByName(dirent.name),
+        content: null,
+      });
+    } catch {
+      // Skip unreadable files silently.
+    }
+  }
+  return out;
+}
+
+// ─── Public API ──────────────────────────────────────────────────────────────
+
+/**
+ * List files for a catalog skill (installed or not).
+ *
+ * Returns `null` if the skill id is not in the catalog at all. Otherwise
+ * returns an array of `SkillFileEntry` with `content === null` for every
+ * entry (single-file content is fetched on demand via
+ * `readCatalogSkillFileContent`).
+ */
+export async function readCatalogSkillFiles(
+  skillId: string,
+): Promise<SkillFileEntry[] | null> {
+  const source = await resolveCatalogSource(skillId);
+  if (!source) return null;
+
+  if (source.kind === "dir") {
+    const entries = walkSkillDir(source.dirPath, source.dirPath);
+    entries.sort((a, b) => a.path.localeCompare(b.path));
+    return entries;
+  }
+
+  const response = await fetchPlatformJson<PlatformFileListResponse>(
+    `/v1/skills/${encodeURIComponent(skillId)}/files/`,
+  );
+  if (!response) return null;
+
+  const entries: SkillFileEntry[] = response.files.map((file) => ({
+    path: file.path,
+    name: file.name,
+    size: file.size,
+    mimeType: "",
+    isBinary: classifyByName(file.name),
+    content: null,
+  }));
+  entries.sort((a, b) => a.path.localeCompare(b.path));
+  return entries;
+}
+
+/**
+ * Read a single file's content from a catalog skill (installed or not).
+ *
+ * Returns `null` if the skill is missing from the catalog, the path fails
+ * sanitization, the underlying source rejects the request, or the file does
+ * not exist. In dev mode, text files up to `MAX_INLINE_SIZE` are returned
+ * with their UTF-8 content inline; anything larger or flagged as binary
+ * returns with `content === null`. In platform mode, the server enforces
+ * the same contract and we pass its response through unchanged.
+ */
+export async function readCatalogSkillFileContent(
+  skillId: string,
+  relativePath: string,
+): Promise<SkillFileEntry | null> {
+  const sanitized = sanitizeRelativePath(relativePath);
+  if (!sanitized) return null;
+
+  const source = await resolveCatalogSource(skillId);
+  if (!source) return null;
+
+  if (source.kind === "dir") {
+    const abs = join(source.dirPath, sanitized);
+    // Defense in depth: make absolutely sure the resolved absolute path is
+    // still inside the skill root, even after `join` normalization. This is
+    // a cheap lexical short-circuit that runs before any fs stat calls.
+    if (!(abs === source.dirPath || abs.startsWith(source.dirPath + sep))) {
+      return null;
+    }
+    if (!existsSync(abs)) return null;
+
+    // Reject symlinks at the target path directly: we do NOT want to follow
+    // a symlinked file inside a catalog skill dir out of the skill root.
+    let lstat;
+    try {
+      lstat = lstatSync(abs);
+    } catch {
+      return null;
+    }
+    if (lstat.isSymbolicLink()) return null;
+    if (!lstat.isFile()) return null;
+
+    // Also resolve any intermediate symlinks in the parent path via
+    // realpath and verify the result is still contained within the skill
+    // root's own realpath. This catches symlinked parent directories that
+    // the lexical check above can't see through.
+    let realAbs: string;
+    let realRoot: string;
+    try {
+      realAbs = realpathSync(abs);
+      realRoot = realpathSync(source.dirPath);
+    } catch {
+      return null;
+    }
+    if (!(realAbs === realRoot || realAbs.startsWith(realRoot + sep))) {
+      return null;
+    }
+
+    let stat;
+    try {
+      stat = statSync(abs);
+    } catch {
+      return null;
+    }
+    if (!stat.isFile()) return null;
+
+    const name = basename(abs);
+    const mimeType = Bun.file(abs).type;
+    const isBinary = !isTextMime(mimeType, name);
+    let content: string | null = null;
+    if (!isBinary && stat.size <= MAX_INLINE_SIZE) {
+      try {
+        content = readFileSync(abs, "utf-8");
+      } catch {
+        content = null;
+      }
+    }
+    return {
+      path: sanitized,
+      name,
+      size: stat.size,
+      mimeType,
+      isBinary,
+      content,
+    };
+  }
+
+  const response = await fetchPlatformJson<PlatformFileContentResponse>(
+    `/v1/skills/${encodeURIComponent(skillId)}/files/content/`,
+    { path: sanitized },
+  );
+  if (!response) return null;
+
+  return {
+    path: response.path,
+    name: response.name,
+    size: response.size,
+    mimeType: response.mime_type,
+    isBinary: response.is_binary,
+    content: response.content,
+  };
+}

--- a/clients/ios/Views/Intelligence/SkillDetailView.swift
+++ b/clients/ios/Views/Intelligence/SkillDetailView.swift
@@ -114,9 +114,8 @@ struct SkillDetailView: View {
         .navigationTitle(skill.name)
         .navigationBarTitleDisplayMode(.inline)
         .task {
-            // Only fetch detail and files for locally available skills (bundled or installed).
-            // Remote catalog search results are not in the local resolved catalog, so
-            // GET /skills/:id and GET /skills/:id/files would 404 for them.
+            // iOS does not yet surface catalog previews; file and detail
+            // fetches are gated on locally-installed skills.
             if skill.isInstalled {
                 skillsStore.fetchSkillDetail(skillId: skill.id)
                 skillsStore.fetchSkillFiles(skillId: skill.id)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -95,13 +95,22 @@ struct AgentPanelContent: View {
         .onChange(of: skillsManager.skills.map(\.id)) {
             onSkillsChanged?()
             if let selectedId = selectedSkillId,
+               skillsManager.installingSkillId != selectedId,
                !skillsManager.skills.contains(where: { $0.id == selectedId }) {
                 selectedSkillId = nil
             }
         }
         .onChange(of: skillsManager.filteredSkills.map(\.id)) {
+            // Preserve the detail selection across post-install refreshes:
+            // after an install, the skill's status flips from "available"
+            // to "enabled", which may remove it from the active
+            // `filteredSkills` (e.g. under the `.available` filter). The
+            // detail view still needs the skill to render its content, so
+            // we only clear the selection when the skill is truly gone
+            // from the unfiltered `skills` list (and not mid-install).
             if let selectedId = selectedSkillId,
-               !skillsManager.filteredSkills.contains(where: { $0.id == selectedId }) {
+               skillsManager.installingSkillId != selectedId,
+               !skillsManager.skills.contains(where: { $0.id == selectedId }) {
                 selectedSkillId = nil
             }
         }
@@ -228,8 +237,14 @@ struct AgentPanelContent: View {
 
     @ViewBuilder
     private var contentView: some View {
+        // Fall back to the unfiltered `skills` list so a detail view that
+        // would otherwise be hidden by the active filter (e.g. a just-
+        // installed skill viewed under the `.available` filter) still
+        // renders. Pair with `.id(skill.id)` so SwiftUI creates a fresh
+        // view instance when the selected skill changes.
         if let selectedId = selectedSkillId,
-           let skill = skillsManager.filteredSkills.first(where: { $0.id == selectedId }) {
+           let skill = skillsManager.filteredSkills.first(where: { $0.id == selectedId })
+            ?? skillsManager.skills.first(where: { $0.id == selectedId }) {
             SkillDetailView(
                 skill: skill,
                 skillsManager: skillsManager,
@@ -242,6 +257,7 @@ struct AgentPanelContent: View {
                     skillToDelete = skill
                 }
             )
+            .id(skill.id)
         } else if skillsManager.isLoading && skillsManager.baseSkillsEmpty {
             VStack {
                 Spacer()
@@ -395,5 +411,10 @@ struct AvailableSkillItemRow: View {
                 }
             }
         }
+        .accessibilityElement(children: .combine)
+        .accessibilityAddTraits(.isButton)
+        .accessibilityLabel("\(skill.name). \(skill.description)")
+        .accessibilityAction { onSelect() }
+        .accessibilityAction(named: "Install") { onInstall() }
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -13,7 +13,7 @@ struct AgentPanelContent: View {
     @Binding var focusedSkillId: String?
 
     @State private var skillsManager: SkillsManager
-    @State private var selectedInstalledSkillId: String?
+    @State private var selectedSkillId: String?
     @State private var skillToDelete: SkillInfo?
     @AppStorage("skillsBannerDismissed") private var bannerDismissed = false
 
@@ -27,7 +27,7 @@ struct AgentPanelContent: View {
     }
 
     private var isShowingDetail: Bool {
-        selectedInstalledSkillId != nil
+        selectedSkillId != nil
     }
 
     var body: some View {
@@ -82,27 +82,27 @@ struct AgentPanelContent: View {
         .onAppear {
             skillsManager.fetchSkills()
             if let skillId = focusedSkillId {
-                selectedInstalledSkillId = skillId
+                selectedSkillId = skillId
                 focusedSkillId = nil
             }
         }
         .onChange(of: focusedSkillId) {
             if let skillId = focusedSkillId {
-                selectedInstalledSkillId = skillId
+                selectedSkillId = skillId
                 focusedSkillId = nil
             }
         }
         .onChange(of: skillsManager.skills.map(\.id)) {
             onSkillsChanged?()
-            if let selectedId = selectedInstalledSkillId,
+            if let selectedId = selectedSkillId,
                !skillsManager.skills.contains(where: { $0.id == selectedId }) {
-                selectedInstalledSkillId = nil
+                selectedSkillId = nil
             }
         }
         .onChange(of: skillsManager.filteredSkills.map(\.id)) {
-            if let selectedId = selectedInstalledSkillId,
+            if let selectedId = selectedSkillId,
                !skillsManager.filteredSkills.contains(where: { $0.id == selectedId }) {
-                selectedInstalledSkillId = nil
+                selectedSkillId = nil
             }
         }
         .sheet(item: $skillToDelete) { skill in
@@ -228,14 +228,14 @@ struct AgentPanelContent: View {
 
     @ViewBuilder
     private var contentView: some View {
-        if let selectedId = selectedInstalledSkillId,
+        if let selectedId = selectedSkillId,
            let skill = skillsManager.filteredSkills.first(where: { $0.id == selectedId }) {
             SkillDetailView(
                 skill: skill,
                 skillsManager: skillsManager,
                 onBack: {
                     withAnimation(VAnimation.standard) {
-                        selectedInstalledSkillId = nil
+                        selectedSkillId = nil
                     }
                 },
                 onDelete: { skill in
@@ -262,6 +262,11 @@ struct AgentPanelContent: View {
                         if skill.isAvailable {
                             AvailableSkillItemRow(
                                 skill: skill,
+                                onSelect: {
+                                    withAnimation(VAnimation.fast) {
+                                        selectedSkillId = skill.id
+                                    }
+                                },
                                 onInstall: { skillsManager.installSkill(slug: skill.id) },
                                 isInstalling: skillsManager.installingSkillId == skill.id
                             )
@@ -270,7 +275,7 @@ struct AgentPanelContent: View {
                                 skill: skill,
                                 onSelect: {
                                     withAnimation(VAnimation.fast) {
-                                        selectedInstalledSkillId = skill.id
+                                        selectedSkillId = skill.id
                                     }
                                 },
                                 onDelete: {
@@ -351,11 +356,12 @@ struct SkillItemRow: View {
 
 struct AvailableSkillItemRow: View {
     let skill: SkillInfo
+    let onSelect: () -> Void
     let onInstall: () -> Void
     var isInstalling: Bool = false
 
     var body: some View {
-        VCard {
+        VCard(action: onSelect) {
             HStack(alignment: .center, spacing: VSpacing.lg) {
                 if let emoji = skill.emoji, !emoji.isEmpty {
                     Text(emoji)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillDetailView.swift
@@ -16,6 +16,10 @@ struct SkillDetailView: View {
     @State private var didSeedExpandedPaths: Bool = false
     @State private var skillFileViewMode: FileViewMode = .source
     @State private var browserNodes: [VFileBrowserNode] = []
+    /// Tracks the previously observed `skill.kind` so an install-from-preview
+    /// transition (catalog → installed/bundled) can be detected and drive a
+    /// refresh of the file tree with eagerly-loaded content.
+    @State private var lastObservedKind: String = ""
 
     /// True when the skill is not installed locally, so file contents must be
     /// fetched lazily rather than delivered inline with the file list.
@@ -33,6 +37,7 @@ struct SkillDetailView: View {
         VStack(alignment: .leading, spacing: VSpacing.md) {
             SkillDetailTitleRow(
                 skill: skill,
+                isInstalling: skillsManager.installingSkillId == skill.id,
                 onBack: onBack,
                 onDelete: { onDelete(skill) },
                 onInstall: { skillsManager.installSkill(slug: skill.id) }
@@ -50,7 +55,26 @@ struct SkillDetailView: View {
             skillDetailFileBrowser
         }
         .onAppear {
+            // Seed `lastObservedKind` with the current kind so a later flip
+            // into "installed"/"bundled" is detected as a true transition
+            // rather than as the initial layout for an already-installed skill.
+            lastObservedKind = skill.kind
             skillsManager.fetchSkillFiles(skillId: skill.id)
+        }
+        .onChange(of: skill.kind) { _, newKind in
+            // Detect an install-from-preview transition: when the kind flips
+            // from "catalog" to "installed"/"bundled", the preview file list
+            // (which has nil `content` fields served lazily) is now stale —
+            // the backend now holds eagerly-loaded inline content for this
+            // skill. Drop the lazy content cache and re-fetch so the file
+            // tree transparently swaps in the full content without the user
+            // having to navigate away and back.
+            let becameInstalled = newKind == "installed" || newKind == "bundled"
+            if becameInstalled && lastObservedKind == "catalog" {
+                skillsManager.clearLoadedFileContents()
+                skillsManager.fetchSkillFiles(skillId: skill.id)
+            }
+            lastObservedKind = newKind
         }
         .onChange(of: skillsManager.selectedSkillFiles?.files.map(\.path)) {
             // 1. Rebuild the browser node tree from the latest file list (moved out of
@@ -126,6 +150,7 @@ struct SkillDetailView: View {
             expandedPaths = []
             didSeedExpandedPaths = false
             browserNodes = []
+            lastObservedKind = ""
             skillsManager.clearSkillDetail()
         }
     }
@@ -370,6 +395,7 @@ struct SkillDetailView: View {
 
 struct SkillDetailTitleRow: View {
     let skill: SkillInfo
+    var isInstalling: Bool = false
     let onBack: () -> Void
     let onDelete: () -> Void
     let onInstall: () -> Void
@@ -410,8 +436,13 @@ struct SkillDetailTitleRow: View {
                     onDelete()
                 }
             } else if skill.kind == "catalog" {
-                VButton(label: "Install", leftIcon: VIcon.arrowDownToLine.rawValue, style: .primary) {
-                    onInstall()
+                if isInstalling {
+                    VLoadingIndicator()
+                        .accessibilityLabel("Installing skill")
+                } else {
+                    VButton(label: "Install", leftIcon: VIcon.arrowDownToLine.rawValue, style: .primary) {
+                        onInstall()
+                    }
                 }
             }
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillDetailView.swift
@@ -76,11 +76,14 @@ struct SkillDetailView: View {
             }
             lastObservedKind = newKind
         }
-        .onChange(of: skillsManager.selectedSkillFiles?.files.map(\.path)) {
+        .onChange(of: skillsManager.selectedSkillFiles?.files.map { "\($0.path):\($0.content == nil)" }) {
             // 1. Rebuild the browser node tree from the latest file list (moved out of
             //    view body per clients/AGENTS.md: no heavy transformation in body).
             //    In preview mode the `content` field is always nil — files are
             //    fetched lazily on click — so the tree filter must tolerate that.
+            //    The key includes each file's content-nullness so the rebuild
+            //    fires after an install-from-preview refresh, where the path
+            //    list is unchanged but content transitions from null to inline.
             let textFiles: [SkillFileEntry]
             if let files = skillsManager.selectedSkillFiles?.files {
                 textFiles = files.filter { file in

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillDetailView.swift
@@ -1,7 +1,10 @@
 import SwiftUI
 import VellumAssistantShared
 
-/// Full-page detail view for an installed skill, showing metadata and a two-pane file browser.
+/// Full-page detail view for a skill, showing metadata and a two-pane file
+/// browser. Works for both installed skills (file contents delivered inline
+/// with the file list) and uninstalled catalog skills (file contents fetched
+/// lazily on click).
 struct SkillDetailView: View {
     let skill: SkillInfo
     var skillsManager: SkillsManager
@@ -14,8 +17,15 @@ struct SkillDetailView: View {
     @State private var skillFileViewMode: FileViewMode = .source
     @State private var browserNodes: [VFileBrowserNode] = []
 
+    /// True when the skill is not installed locally, so file contents must be
+    /// fetched lazily rather than delivered inline with the file list.
+    private var isPreview: Bool { !skill.isInstalled }
+
     private var hasViewableFiles: Bool {
         guard let files = skillsManager.selectedSkillFiles else { return true }
+        if isPreview {
+            return files.files.contains { !$0.isBinary }
+        }
         return files.files.contains { !$0.isBinary && $0.content != nil }
     }
 
@@ -24,7 +34,8 @@ struct SkillDetailView: View {
             SkillDetailTitleRow(
                 skill: skill,
                 onBack: onBack,
-                onDelete: { onDelete(skill) }
+                onDelete: { onDelete(skill) },
+                onInstall: { skillsManager.installSkill(slug: skill.id) }
             )
 
             if !skill.description.isEmpty {
@@ -39,19 +50,18 @@ struct SkillDetailView: View {
             skillDetailFileBrowser
         }
         .onAppear {
-            // Only fetch files for locally available skills (bundled or installed).
-            // Remote catalog search results are not in the local resolved catalog, so
-            // GET /skills/:id/files would 404 for them.
-            if skill.isInstalled {
-                skillsManager.fetchSkillFiles(skillId: skill.id)
-            }
+            skillsManager.fetchSkillFiles(skillId: skill.id)
         }
         .onChange(of: skillsManager.selectedSkillFiles?.files.map(\.path)) {
             // 1. Rebuild the browser node tree from the latest file list (moved out of
             //    view body per clients/AGENTS.md: no heavy transformation in body).
+            //    In preview mode the `content` field is always nil — files are
+            //    fetched lazily on click — so the tree filter must tolerate that.
             let textFiles: [SkillFileEntry]
             if let files = skillsManager.selectedSkillFiles?.files {
-                textFiles = files.filter { !$0.isBinary && $0.content != nil }
+                textFiles = files.filter { file in
+                    isPreview ? !file.isBinary : (!file.isBinary && file.content != nil)
+                }
                 browserNodes = Self.buildSkillNodeTree(from: textFiles)
             } else {
                 textFiles = []
@@ -60,8 +70,11 @@ struct SkillDetailView: View {
 
             // 2. Auto-select SKILL.md (or the first text file) on first load.
             if expandedFilePath == nil, let files = skillsManager.selectedSkillFiles?.files {
-                let skillMd = files.first { $0.path == "SKILL.md" && !$0.isBinary && $0.content != nil }
-                let firstText = files.first { !$0.isBinary && $0.content != nil }
+                let matchesTextFilter: (SkillFileEntry) -> Bool = { file in
+                    isPreview ? !file.isBinary : (!file.isBinary && file.content != nil)
+                }
+                let skillMd = files.first { $0.path == "SKILL.md" && matchesTextFilter($0) }
+                let firstText = files.first(where: matchesTextFilter)
                 if let selectedFile = skillMd ?? firstText {
                     expandedFilePath = selectedFile.path
                     let autoModes = availableViewModes(for: selectedFile.path, mimeType: selectedFile.mimeType)
@@ -95,6 +108,17 @@ struct SkillDetailView: View {
                 expandedPaths.formUnion(Self.ancestorPaths(of: selectedPath))
                 let selectedModes = availableViewModes(for: file.path, mimeType: file.mimeType)
                 skillFileViewMode = selectedModes.first ?? .source
+
+                // In preview mode the file list is served without inline
+                // content, so kick off a lazy content fetch the first time a
+                // text file is selected.
+                if isPreview,
+                   !file.isBinary,
+                   skillsManager.loadedFileContents[selectedPath] == nil,
+                   !skillsManager.loadingFilePaths.contains(selectedPath),
+                   skillsManager.fileContentErrors[selectedPath] == nil {
+                    skillsManager.loadSkillFileContent(skillId: skill.id, path: selectedPath)
+                }
             }
         }
         .onDisappear {
@@ -244,11 +268,16 @@ struct SkillDetailView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .overlay { ProgressView().controlSize(.small) }
         } else if let error = skillsManager.skillFilesError {
-            VEmptyState(
-                title: "Failed to load files",
-                subtitle: error,
-                icon: VIcon.circleAlert.rawValue
-            )
+            VStack(spacing: VSpacing.md) {
+                VEmptyState(
+                    title: "Failed to load files",
+                    subtitle: error,
+                    icon: VIcon.circleAlert.rawValue
+                )
+                retryButton(label: "Retry") {
+                    skillsManager.fetchSkillFiles(skillId: skill.id)
+                }
+            }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else {
             VFileBrowser(
@@ -256,24 +285,84 @@ struct SkillDetailView: View {
                 expandedPaths: $expandedPaths,
                 selectedPath: $expandedFilePath
             ) { selectedNode in
-                if let selectedNode,
-                   let file = skillsManager.selectedSkillFiles?.files.first(where: { $0.path == selectedNode.path }),
-                   let content = file.content {
-                    FileContentView(
-                        fileName: file.path,
-                        mimeType: file.mimeType,
-                        content: .constant(content),
-                        viewMode: $skillFileViewMode,
-                        isActivelyEditing: .constant(false)
-                    )
-                } else {
-                    VEmptyState(
-                        title: hasViewableFiles ? "Select a file to view" : "No viewable files",
-                        icon: VIcon.fileText.rawValue
-                    )
-                }
+                fileContentPane(for: selectedNode)
             }
         }
+    }
+
+    @ViewBuilder
+    private func fileContentPane(for selectedNode: VFileBrowserNode?) -> some View {
+        if let selectedNode,
+           let file = skillsManager.selectedSkillFiles?.files.first(where: { $0.path == selectedNode.path }) {
+            if isPreview && !file.isBinary {
+                previewFileContent(for: file, nodePath: selectedNode.path)
+            } else if let content = file.content {
+                FileContentView(
+                    fileName: file.path,
+                    mimeType: file.mimeType,
+                    content: .constant(content),
+                    viewMode: $skillFileViewMode,
+                    isActivelyEditing: .constant(false)
+                )
+            } else {
+                VEmptyState(
+                    title: hasViewableFiles ? "Select a file to view" : "No viewable files",
+                    icon: VIcon.fileText.rawValue
+                )
+            }
+        } else {
+            VEmptyState(
+                title: hasViewableFiles ? "Select a file to view" : "No viewable files",
+                icon: VIcon.fileText.rawValue
+            )
+        }
+    }
+
+    @ViewBuilder
+    private func previewFileContent(for file: SkillFileEntry, nodePath: String) -> some View {
+        if let content = skillsManager.loadedFileContents[nodePath] {
+            FileContentView(
+                fileName: file.path,
+                mimeType: file.mimeType,
+                content: .constant(content),
+                viewMode: $skillFileViewMode,
+                isActivelyEditing: .constant(false)
+            )
+        } else if skillsManager.loadingFilePaths.contains(nodePath) {
+            VEmptyState(
+                title: "Loading file...",
+                icon: VIcon.fileText.rawValue
+            )
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .overlay { ProgressView().controlSize(.small) }
+        } else if let error = skillsManager.fileContentErrors[nodePath] {
+            VStack(spacing: VSpacing.md) {
+                VEmptyState(
+                    title: "Failed to load file",
+                    subtitle: error,
+                    icon: VIcon.circleAlert.rawValue
+                )
+                retryButton(label: "Retry") {
+                    skillsManager.loadSkillFileContent(skillId: skill.id, path: nodePath)
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else {
+            VEmptyState(
+                title: hasViewableFiles ? "Select a file to view" : "No viewable files",
+                icon: VIcon.fileText.rawValue
+            )
+        }
+    }
+
+    @ViewBuilder
+    private func retryButton(label: String, action: @escaping () -> Void) -> some View {
+        VButton(
+            label: label,
+            leftIcon: VIcon.refreshCw.rawValue,
+            style: .outlined,
+            action: action
+        )
     }
 }
 
@@ -283,6 +372,7 @@ struct SkillDetailTitleRow: View {
     let skill: SkillInfo
     let onBack: () -> Void
     let onDelete: () -> Void
+    let onInstall: () -> Void
 
     var body: some View {
         HStack {
@@ -318,6 +408,10 @@ struct SkillDetailTitleRow: View {
             if skill.kind == "installed" {
                 VButton(label: "Remove", leftIcon: VIcon.trash.rawValue, style: .dangerOutline) {
                     onDelete()
+                }
+            } else if skill.kind == "catalog" {
+                VButton(label: "Install", leftIcon: VIcon.arrowDownToLine.rawValue, style: .primary) {
+                    onInstall()
                 }
             }
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
@@ -45,6 +45,9 @@ final class SkillsManager {
     var selectedSkillFiles: SkillDetailFilesHTTPResponse?
     var isLoadingSkillFiles = false
     var skillFilesError: String?
+    var loadedFileContents: [String: String] = [:]
+    var loadingFilePaths: Set<String> = []
+    var fileContentErrors: [String: String] = [:]
     var installingSkillId: String?
 
     // MARK: - Filter Inputs
@@ -105,6 +108,9 @@ final class SkillsManager {
                 self.selectedSkillFiles = self.skillsStore.selectedSkillFiles
                 self.isLoadingSkillFiles = self.skillsStore.isLoadingSkillFiles
                 self.skillFilesError = self.skillsStore.skillFilesError
+                self.loadedFileContents = self.skillsStore.loadedFileContents
+                self.loadingFilePaths = self.skillsStore.loadingFilePaths
+                self.fileContentErrors = self.skillsStore.fileContentErrors
                 if let result = self.skillsStore.installResult,
                    result.slug == self.installingSkillId {
                     self.installingSkillId = nil
@@ -239,6 +245,14 @@ final class SkillsManager {
 
     func fetchSkillFiles(skillId: String) {
         skillsStore.fetchSkillFiles(skillId: skillId)
+    }
+
+    func loadSkillFileContent(skillId: String, path: String) {
+        skillsStore.loadSkillFileContent(skillId: skillId, path: path)
+    }
+
+    func clearLoadedFileContents() {
+        skillsStore.clearLoadedFileContents()
     }
 
     func clearSkillDetail() {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
@@ -50,6 +50,12 @@ final class SkillsManager {
     var fileContentErrors: [String: String] = [:]
     var installingSkillId: String?
 
+    /// Safety timeout that defensively clears `installingSkillId` if a
+    /// wedged `fetchSkills(force:)` response never lands. Without it, the
+    /// install spinner can be stuck indefinitely when the confirmation
+    /// refresh path is blocked or delayed.
+    @ObservationIgnored private var installWatchdogTask: Task<Void, Never>?
+
     // MARK: - Filter Inputs
 
     var searchQuery: String = "" {
@@ -113,7 +119,25 @@ final class SkillsManager {
                 self.fileContentErrors = self.skillsStore.fileContentErrors
                 if let result = self.skillsStore.installResult,
                    result.slug == self.installingSkillId {
-                    self.installingSkillId = nil
+                    if !result.success {
+                        // Failure: release the spinner immediately so the
+                        // Install button returns and the user can retry.
+                        self.installingSkillId = nil
+                        self.installWatchdogTask?.cancel()
+                        self.installWatchdogTask = nil
+                    } else if self.skillsStore.skills
+                        .first(where: { $0.id == result.slug })?.kind != "catalog" {
+                        // Success confirmed: the refreshed skills list has
+                        // flipped the kind away from "catalog", so the
+                        // detail view will render the installed UI on the
+                        // next body pass without flicker.
+                        self.installingSkillId = nil
+                        self.installWatchdogTask?.cancel()
+                        self.installWatchdogTask = nil
+                    }
+                    // Otherwise: keep the spinner up until fetchSkills(force:)
+                    // lands — see `installSkill(slug:)` for the watchdog that
+                    // clears the spinner defensively if the refresh wedges.
                 }
                 self.recomputeFilteredData()
             }
@@ -241,6 +265,20 @@ final class SkillsManager {
     func installSkill(slug: String) {
         installingSkillId = slug
         skillsStore.installSkill(slug: slug)
+
+        // Defensive watchdog: a wedged `fetchSkills(force:)` response
+        // after install would otherwise leave the spinner stuck forever.
+        // Clear `installingSkillId` after 15 seconds if the confirmation
+        // path has not already cleared it.
+        installWatchdogTask?.cancel()
+        installWatchdogTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: 15_000_000_000)
+            guard !Task.isCancelled else { return }
+            guard let self else { return }
+            if self.installingSkillId == slug {
+                self.installingSkillId = nil
+            }
+        }
     }
 
     func fetchSkillFiles(skillId: String) {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
@@ -139,6 +139,27 @@ final class SkillsManager {
                     // lands — see `installSkill(slug:)` for the watchdog that
                     // clears the spinner defensively if the refresh wedges.
                 }
+
+                // Independent skills-list-driven clear: `SkillsStore.installSkill`
+                // expires `installResult` after 3 seconds, so on a slow-network
+                // install where `fetchSkills(force:)` lands after the expiry
+                // the branch above will not fire — `installResult` is already
+                // nil by the time the refreshed list arrives. Clear the
+                // spinner here based solely on the skills list: if the
+                // currently-installing id is now a non-catalog entry, the
+                // install has confirmed and the spinner must come down.
+                // `installingSkillId` is only set by `installSkill(slug:)`
+                // for a catalog skill, so any transition away from "catalog"
+                // for that id is a legitimate success signal. Idempotent
+                // with the branch above: the `if let` guard short-circuits
+                // when the first branch has already cleared the id.
+                if let installingId = self.installingSkillId,
+                   self.skillsStore.skills
+                    .first(where: { $0.id == installingId })?.kind != "catalog" {
+                    self.installingSkillId = nil
+                    self.installWatchdogTask?.cancel()
+                    self.installWatchdogTask = nil
+                }
                 self.recomputeFilteredData()
             }
             .store(in: &cancellables)

--- a/clients/shared/Features/Skills/SkillsStore.swift
+++ b/clients/shared/Features/Skills/SkillsStore.swift
@@ -356,26 +356,36 @@ public final class SkillsStore: ObservableObject {
     // MARK: - Lazy File Content
 
     public func loadSkillFileContent(skillId: String, path: String) {
-        // Cancel any in-flight task for the same path so a second click replaces the first.
+        // Cancel any in-flight task for the same path so a second click
+        // replaces the first. The task body mirrors the structure of
+        // `fetchSkillDetail`/`fetchSkillFiles` above: a single
+        // `Task.isCancelled` check gates every state mutation, and the
+        // `SkillsStore` actor isolation (`@MainActor`) removes the need
+        // for an explicit `MainActor.run` hop.
         fileContentTasks[path]?.cancel()
         loadingFilePaths.insert(path)
         fileContentErrors[path] = nil
 
-        let task = Task { [weak self] in
-            guard let self else { return }
+        let task = Task {
             let result = await self.skillsClient.fetchSkillFileContent(skillId: skillId, path: path)
             guard !Task.isCancelled else { return }
-            await MainActor.run {
-                guard self.currentFilesSkillId == skillId else { return }
-                self.loadingFilePaths.remove(path)
-                if let result, let content = result.content {
-                    self.loadedFileContents[path] = content
-                } else if let result, result.content == nil, result.isBinary {
-                    // Binary file — no preview available is expected, not an error.
-                    self.loadedFileContents.removeValue(forKey: path)
-                } else {
-                    self.fileContentErrors[path] = "Failed to load file content"
-                }
+            guard self.currentFilesSkillId == skillId else { return }
+
+            self.loadingFilePaths.remove(path)
+            if let result, let content = result.content {
+                self.loadedFileContents[path] = content
+            } else if let result, result.isBinary {
+                // Binary file: no preview available is expected, not an error.
+                self.loadedFileContents.removeValue(forKey: path)
+            } else if let result, result.content == nil {
+                // Oversized text file: the daemon returns `content: null`
+                // for text files above the inline-content size threshold.
+                // Treat this as "no preview available" rather than an
+                // error — the detail view falls through to its existing
+                // "Select a file to view" empty state.
+                self.loadedFileContents.removeValue(forKey: path)
+            } else {
+                self.fileContentErrors[path] = "Failed to load file content"
             }
         }
         fileContentTasks[path] = task

--- a/clients/shared/Features/Skills/SkillsStore.swift
+++ b/clients/shared/Features/Skills/SkillsStore.swift
@@ -37,6 +37,13 @@ public final class SkillsStore: ObservableObject {
     @Published public var skillDetailError: String?
     @Published public var skillFilesError: String?
 
+    /// Per-file loaded content keyed by the file's relative path within the skill.
+    @Published public var loadedFileContents: [String: String] = [:]
+    /// Paths with an in-flight content fetch.
+    @Published public var loadingFilePaths: Set<String> = []
+    /// Per-path error messages from failed content fetches.
+    @Published public var fileContentErrors: [String: String] = [:]
+
     // MARK: - Result Types
 
     public struct InstallResult: Sendable {
@@ -89,6 +96,7 @@ public final class SkillsStore: ObservableObject {
     private var createTask: Task<Void, Never>?
     private var skillDetailTask: Task<Void, Never>?
     private var skillFilesTask: Task<Void, Never>?
+    private var fileContentTasks: [String: Task<Void, Never>] = [:]
     private var draftGeneration: Int = 0
     private var createGeneration: Int = 0
     private var currentDetailSkillId: String?
@@ -318,9 +326,15 @@ public final class SkillsStore: ObservableObject {
     // MARK: - Fetch Skill Files
 
     public func fetchSkillFiles(skillId: String) {
+        // Cancel any in-flight files task and start a new one. Intentionally do
+        // not early-return when `currentFilesSkillId == skillId`: a re-fetch
+        // for the same skill replaces stale (lazy/null) file content with
+        // fresh content after an install transition, so the store must always
+        // reissue the request rather than reuse the prior response.
         skillFilesTask?.cancel()
         if currentFilesSkillId != skillId {
             selectedSkillFiles = nil
+            clearLoadedFileContents()
         }
         currentFilesSkillId = skillId
         isLoadingSkillFiles = true
@@ -339,6 +353,42 @@ public final class SkillsStore: ObservableObject {
         }
     }
 
+    // MARK: - Lazy File Content
+
+    public func loadSkillFileContent(skillId: String, path: String) {
+        // Cancel any in-flight task for the same path so a second click replaces the first.
+        fileContentTasks[path]?.cancel()
+        loadingFilePaths.insert(path)
+        fileContentErrors[path] = nil
+
+        let task = Task { [weak self] in
+            guard let self else { return }
+            let result = await self.skillsClient.fetchSkillFileContent(skillId: skillId, path: path)
+            guard !Task.isCancelled else { return }
+            await MainActor.run {
+                guard self.currentFilesSkillId == skillId else { return }
+                self.loadingFilePaths.remove(path)
+                if let result, let content = result.content {
+                    self.loadedFileContents[path] = content
+                } else if let result, result.content == nil, result.isBinary {
+                    // Binary file — no preview available is expected, not an error.
+                    self.loadedFileContents.removeValue(forKey: path)
+                } else {
+                    self.fileContentErrors[path] = "Failed to load file content"
+                }
+            }
+        }
+        fileContentTasks[path] = task
+    }
+
+    public func clearLoadedFileContents() {
+        for task in fileContentTasks.values { task.cancel() }
+        fileContentTasks.removeAll()
+        loadedFileContents.removeAll()
+        loadingFilePaths.removeAll()
+        fileContentErrors.removeAll()
+    }
+
     // MARK: - Clear Skill Detail
 
     public func clearSkillDetail() {
@@ -354,6 +404,7 @@ public final class SkillsStore: ObservableObject {
         isLoadingSkillFiles = false
         skillDetailError = nil
         skillFilesError = nil
+        clearLoadedFileContents()
     }
 
     // MARK: - Reset Draft State

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -4191,6 +4191,26 @@ public struct SkillFileEntry: Codable, Sendable {
     }
 }
 
+// MARK: - Skill File Content Response (GET /v1/skills/:id/files/content)
+
+public struct SkillFileContentResponse: Codable, Sendable {
+    public let path: String
+    public let name: String
+    public let size: Int
+    public let mimeType: String
+    public let isBinary: Bool
+    public let content: String?
+
+    public init(path: String, name: String, size: Int, mimeType: String, isBinary: Bool, content: String? = nil) {
+        self.path = path
+        self.name = name
+        self.size = size
+        self.mimeType = mimeType
+        self.isBinary = isBinary
+        self.content = content
+    }
+}
+
 public struct SkillsOperationResponse: Codable, Sendable {
     public let type: String
     public let operation: String

--- a/clients/shared/Network/SkillsClient.swift
+++ b/clients/shared/Network/SkillsClient.swift
@@ -21,6 +21,7 @@ public protocol SkillsClientProtocol {
     func createSkill(skillId: String, name: String, description: String, emoji: String?, bodyMarkdown: String, overwrite: Bool?) async -> SkillOperationResult?
     func fetchSkillDetail(skillId: String) async -> SkillDetailHTTPResponse?
     func fetchSkillFiles(skillId: String) async -> SkillDetailFilesHTTPResponse?
+    func fetchSkillFileContent(skillId: String, path: String) async -> SkillFileContentResponse?
 }
 
 /// Gateway-backed implementation of ``SkillsClientProtocol``.
@@ -308,6 +309,24 @@ public struct SkillsClient: SkillsClientProtocol {
             return try JSONDecoder().decode(SkillDetailFilesHTTPResponse.self, from: response.data)
         } catch {
             log.error("fetchSkillFiles error: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    public func fetchSkillFileContent(skillId: String, path: String) async -> SkillFileContentResponse? {
+        do {
+            let response = try await GatewayHTTPClient.get(
+                path: "assistants/{assistantId}/skills/\(Self.encodePath(skillId))/files/content",
+                params: ["path": path],
+                timeout: 15
+            )
+            guard response.isSuccess else {
+                log.error("fetchSkillFileContent failed (HTTP \(response.statusCode))")
+                return nil
+            }
+            return try JSONDecoder().decode(SkillFileContentResponse.self, from: response.data)
+        } catch {
+            log.error("fetchSkillFileContent error: \(error.localizedDescription)")
             return nil
         }
     }

--- a/clients/shared/Tests/SkillsFileContentTests.swift
+++ b/clients/shared/Tests/SkillsFileContentTests.swift
@@ -323,6 +323,56 @@ final class SkillsFileContentStoreTests: XCTestCase {
         XCTAssertFalse(store.loadingFilePaths.contains("missing.txt"))
     }
 
+    func testLoadSkillFileContentTreatsOversizedTextAsNoPreview() async throws {
+        // The daemon returns `content: null` for text files above
+        // `MAX_INLINE_TEXT_SIZE`. `loadSkillFileContent` must treat that as
+        // "no preview available" and clear the loading flag without
+        // surfacing a spurious error or populating `loadedFileContents`.
+        // The detail view then falls through to its "Select a file to
+        // view" empty state for the oversized file.
+        let backing = MockSkillsFileContentStore()
+        await backing.setBlocking(for: "large.md")
+        let mock = MockSkillsClient(backing: backing)
+        let store = SkillsStore(skillsClient: mock)
+
+        // Seed `currentFilesSkillId` so `loadSkillFileContent`'s
+        // same-skill guard lets the result reach the completion branch.
+        store.fetchSkillFiles(skillId: "test-skill")
+        try await Task.sleep(nanoseconds: 20_000_000)
+
+        store.loadSkillFileContent(skillId: "test-skill", path: "large.md")
+        XCTAssertTrue(store.loadingFilePaths.contains("large.md"))
+
+        // Unblock the mock with a text-file response that has
+        // `content: nil` — the oversized-text shape the daemon emits.
+        let oversizedResponse = SkillFileContentResponse(
+            path: "large.md",
+            name: "large.md",
+            size: 10_000_000,
+            mimeType: "text/markdown",
+            isBinary: false,
+            content: nil
+        )
+        await backing.unblock(path: "large.md", with: oversizedResponse)
+
+        try await waitUntil(timeout: 1.0) {
+            !store.loadingFilePaths.contains("large.md")
+        }
+
+        XCTAssertNil(
+            store.loadedFileContents["large.md"],
+            "Oversized text file must not populate loadedFileContents"
+        )
+        XCTAssertNil(
+            store.fileContentErrors["large.md"],
+            "Oversized text file must not be surfaced as an error"
+        )
+        XCTAssertFalse(
+            store.loadingFilePaths.contains("large.md"),
+            "Loading flag must be cleared after the response is handled"
+        )
+    }
+
     func testLoadSkillFileContentIgnoresStaleCancelledTaskCompletion() async throws {
         let backing = MockSkillsFileContentStore()
         await backing.setBlocking(for: "docs/readme.md")

--- a/clients/shared/Tests/SkillsFileContentTests.swift
+++ b/clients/shared/Tests/SkillsFileContentTests.swift
@@ -1,0 +1,422 @@
+import Foundation
+import XCTest
+
+@testable import VellumAssistantShared
+
+// MARK: - Mock URLProtocol for SkillsClient HTTP tests
+
+private final class MockSkillsFileContentURLProtocol: URLProtocol {
+    static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        guard let handler = Self.requestHandler else {
+            XCTFail("requestHandler not set")
+            return
+        }
+
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+// MARK: - Mock SkillsClient for SkillsStore tests
+
+private actor MockSkillsFileContentStore {
+    private var fileContentResponses: [String: SkillFileContentResponse] = [:]
+    private(set) var requestedPaths: [(skillId: String, path: String)] = []
+    private var continuations: [String: [CheckedContinuation<SkillFileContentResponse?, Never>]] = [:]
+    private var blockingPaths: Set<String> = []
+
+    func setResponse(for path: String, _ response: SkillFileContentResponse?) {
+        if let response {
+            fileContentResponses[path] = response
+        } else {
+            fileContentResponses.removeValue(forKey: path)
+        }
+    }
+
+    func setBlocking(for path: String) {
+        blockingPaths.insert(path)
+    }
+
+    func record(skillId: String, path: String) {
+        requestedPaths.append((skillId: skillId, path: path))
+    }
+
+    func awaitResponse(skillId: String, path: String) async -> SkillFileContentResponse? {
+        record(skillId: skillId, path: path)
+        if blockingPaths.contains(path) {
+            return await withCheckedContinuation { cont in
+                continuations[path, default: []].append(cont)
+            }
+        }
+        // Default to nil when no response has been configured.
+        return fileContentResponses[path]
+    }
+
+    func pendingContinuationCount(for path: String) -> Int {
+        continuations[path]?.count ?? 0
+    }
+
+    func unblock(path: String, with response: SkillFileContentResponse?) {
+        guard var queue = continuations[path], !queue.isEmpty else { return }
+        let cont = queue.removeFirst()
+        if queue.isEmpty {
+            continuations.removeValue(forKey: path)
+            blockingPaths.remove(path)
+        } else {
+            continuations[path] = queue
+        }
+        cont.resume(returning: response)
+    }
+
+    func requestCount() -> Int { requestedPaths.count }
+}
+
+private struct MockSkillsClient: SkillsClientProtocol {
+    let backing: MockSkillsFileContentStore
+
+    func fetchSkillsList(includeCatalog: Bool) async -> SkillsListResponseMessage? { nil }
+    func enableSkill(name: String) async -> SkillOperationResult? { nil }
+    func disableSkill(name: String) async -> SkillOperationResult? { nil }
+    func configureSkill(name: String, env: [String: String]?, apiKey: String?, config: [String: AnyCodable]?) async -> SkillOperationResult? { nil }
+    func installSkill(slug: String, version: String?) async -> SkillOperationResult? { nil }
+    func uninstallSkill(name: String) async -> SkillOperationResult? { nil }
+    func updateSkill(name: String) async -> SkillOperationResult? { nil }
+    func checkSkillUpdates() async -> SkillOperationResult? { nil }
+    func searchSkills(query: String) async -> SkillSearchResult? { nil }
+    func draftSkill(sourceText: String) async -> SkillsDraftResponseMessage? { nil }
+    func createSkill(skillId: String, name: String, description: String, emoji: String?, bodyMarkdown: String, overwrite: Bool?) async -> SkillOperationResult? { nil }
+    func fetchSkillDetail(skillId: String) async -> SkillDetailHTTPResponse? { nil }
+    func fetchSkillFiles(skillId: String) async -> SkillDetailFilesHTTPResponse? {
+        // Tests drive `currentFilesSkillId` via `fetchSkillFiles`; the response
+        // body itself is irrelevant to the loadSkillFileContent code paths.
+        nil
+    }
+
+    func fetchSkillFileContent(skillId: String, path: String) async -> SkillFileContentResponse? {
+        await backing.awaitResponse(skillId: skillId, path: path)
+    }
+}
+
+// MARK: - SkillsClient HTTP tests
+
+@MainActor
+final class SkillsFileContentClientTests: XCTestCase {
+    private let assistantId = "assistant-skill-file-content-test"
+    private let gatewayPort = 7841
+    private var originalPrimaryLockfileData: Data?
+    private var primaryLockfileExisted = false
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        MockSkillsFileContentURLProtocol.requestHandler = nil
+        URLProtocol.registerClass(MockSkillsFileContentURLProtocol.self)
+
+        let primaryLockfileURL = LockfilePaths.primary
+        primaryLockfileExisted = FileManager.default.fileExists(atPath: primaryLockfileURL.path)
+        if primaryLockfileExisted {
+            originalPrimaryLockfileData = try Data(contentsOf: primaryLockfileURL)
+        }
+
+        try installLockfileFixture()
+    }
+
+    override func tearDownWithError() throws {
+        URLProtocol.unregisterClass(MockSkillsFileContentURLProtocol.self)
+        MockSkillsFileContentURLProtocol.requestHandler = nil
+
+        if primaryLockfileExisted {
+            try originalPrimaryLockfileData?.write(to: LockfilePaths.primary, options: .atomic)
+        } else {
+            try? FileManager.default.removeItem(at: LockfilePaths.primary)
+        }
+
+        try super.tearDownWithError()
+    }
+
+    func testFetchSkillFileContentDecodesSuccessResponse() async throws {
+        let requestExpectation = expectation(description: "skill file content request")
+        var capturedRequest: URLRequest?
+
+        MockSkillsFileContentURLProtocol.requestHandler = { request in
+            capturedRequest = request
+            requestExpectation.fulfill()
+
+            let response = HTTPURLResponse(
+                url: try XCTUnwrap(request.url),
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            let data = Data(
+                #"""
+                {
+                  "path": "scripts/run.py",
+                  "name": "run.py",
+                  "size": 42,
+                  "mimeType": "text/x-python",
+                  "isBinary": false,
+                  "content": "print('hi')"
+                }
+                """#.utf8
+            )
+            return (response, data)
+        }
+
+        let client = SkillsClient()
+        let result = await client.fetchSkillFileContent(
+            skillId: "my-skill",
+            path: "scripts/run.py"
+        )
+
+        await fulfillment(of: [requestExpectation], timeout: 1.0)
+
+        let url = try XCTUnwrap(capturedRequest?.url)
+        let components = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        XCTAssertEqual(components.host, "127.0.0.1")
+        XCTAssertEqual(components.port, gatewayPort)
+        XCTAssertTrue(
+            components.path.hasPrefix(
+                "/v1/assistants/\(assistantId)/skills/my-skill/files/content"
+            ),
+            "Unexpected path: \(components.path)"
+        )
+        XCTAssertEqual(components.queryItems?.first(where: { $0.name == "path" })?.value, "scripts/run.py")
+        XCTAssertEqual(capturedRequest?.httpMethod, "GET")
+
+        XCTAssertEqual(result?.path, "scripts/run.py")
+        XCTAssertEqual(result?.name, "run.py")
+        XCTAssertEqual(result?.size, 42)
+        XCTAssertEqual(result?.mimeType, "text/x-python")
+        XCTAssertFalse(result?.isBinary ?? true)
+        XCTAssertEqual(result?.content, "print('hi')")
+    }
+
+    func testFetchSkillFileContentReturnsNilForNonSuccessStatus() async {
+        MockSkillsFileContentURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 500,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data(#"{"error":{"message":"boom"}}"#.utf8))
+        }
+
+        let client = SkillsClient()
+        let result = await client.fetchSkillFileContent(
+            skillId: "my-skill",
+            path: "scripts/run.py"
+        )
+        XCTAssertNil(result)
+    }
+
+    private func installLockfileFixture() throws {
+        let lockfile: [String: Any] = [
+            "activeAssistant": assistantId,
+            "assistants": [
+                [
+                    "assistantId": assistantId,
+                    "cloud": "local",
+                    "hatchedAt": "2026-03-19T12:00:00Z",
+                    "resources": [
+                        "gatewayPort": gatewayPort,
+                    ],
+                ],
+            ],
+        ]
+        let data = try JSONSerialization.data(withJSONObject: lockfile, options: [.sortedKeys])
+        try data.write(to: LockfilePaths.primary, options: .atomic)
+    }
+}
+
+// MARK: - SkillsStore tests
+
+@MainActor
+final class SkillsFileContentStoreTests: XCTestCase {
+
+    func testLoadSkillFileContentTracksLoadingThenPopulatesContent() async throws {
+        let backing = MockSkillsFileContentStore()
+        await backing.setBlocking(for: "docs/intro.md")
+        let mock = MockSkillsClient(backing: backing)
+        let store = SkillsStore(skillsClient: mock)
+
+        // Seed currentFilesSkillId via a fetchSkillFiles call so loadSkillFileContent
+        // can satisfy its "same skillId" guard when storing the result.
+        store.fetchSkillFiles(skillId: "my-skill")
+        try await Task.sleep(nanoseconds: 20_000_000)
+
+        store.loadSkillFileContent(skillId: "my-skill", path: "docs/intro.md")
+        XCTAssertTrue(store.loadingFilePaths.contains("docs/intro.md"))
+        XCTAssertNil(store.loadedFileContents["docs/intro.md"])
+
+        let response = SkillFileContentResponse(
+            path: "docs/intro.md",
+            name: "intro.md",
+            size: 5,
+            mimeType: "text/markdown",
+            isBinary: false,
+            content: "hello"
+        )
+        await backing.unblock(path: "docs/intro.md", with: response)
+
+        // Yield to let the Task finish its MainActor.run block.
+        try await waitUntil(timeout: 1.0) {
+            !store.loadingFilePaths.contains("docs/intro.md")
+        }
+
+        XCTAssertEqual(store.loadedFileContents["docs/intro.md"], "hello")
+        XCTAssertNil(store.fileContentErrors["docs/intro.md"])
+    }
+
+    func testLoadSkillFileContentSetsErrorOnFailure() async throws {
+        let backing = MockSkillsFileContentStore()
+        await backing.setResponse(for: "missing.txt", nil)
+        let mock = MockSkillsClient(backing: backing)
+        let store = SkillsStore(skillsClient: mock)
+
+        store.fetchSkillFiles(skillId: "my-skill")
+        try await Task.sleep(nanoseconds: 20_000_000)
+
+        store.loadSkillFileContent(skillId: "my-skill", path: "missing.txt")
+
+        try await waitUntil(timeout: 1.0) {
+            store.fileContentErrors["missing.txt"] != nil
+        }
+
+        XCTAssertEqual(store.fileContentErrors["missing.txt"], "Failed to load file content")
+        XCTAssertNil(store.loadedFileContents["missing.txt"])
+        XCTAssertFalse(store.loadingFilePaths.contains("missing.txt"))
+    }
+
+    func testLoadSkillFileContentIgnoresStaleCancelledTaskCompletion() async throws {
+        let backing = MockSkillsFileContentStore()
+        await backing.setBlocking(for: "docs/readme.md")
+        let mock = MockSkillsClient(backing: backing)
+        let store = SkillsStore(skillsClient: mock)
+
+        store.fetchSkillFiles(skillId: "my-skill")
+        try await Task.sleep(nanoseconds: 20_000_000)
+
+        // Task A: starts the first fetch and parks on the continuation.
+        store.loadSkillFileContent(skillId: "my-skill", path: "docs/readme.md")
+        try await waitUntilAsync(timeout: 1.0) {
+            await backing.pendingContinuationCount(for: "docs/readme.md") >= 1
+        }
+
+        // Task B: a second call for the same path cancels Task A and parks
+        // on its own continuation.
+        store.loadSkillFileContent(skillId: "my-skill", path: "docs/readme.md")
+        try await waitUntilAsync(timeout: 1.0) {
+            await backing.pendingContinuationCount(for: "docs/readme.md") >= 2
+        }
+
+        XCTAssertTrue(store.loadingFilePaths.contains("docs/readme.md"))
+
+        // Resume Task A with a failure-shaped response. Because Task A was
+        // cancelled, the Task.isCancelled guard in loadSkillFileContent must
+        // prevent it from mutating loadingFilePaths/fileContentErrors.
+        await backing.unblock(path: "docs/readme.md", with: nil)
+
+        // Give Task A a chance to run its (guarded) completion.
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertTrue(
+            store.loadingFilePaths.contains("docs/readme.md"),
+            "Cancelled Task A must not clear the loading flag"
+        )
+        XCTAssertNil(
+            store.fileContentErrors["docs/readme.md"],
+            "Cancelled Task A must not set a spurious error"
+        )
+
+        // Resume Task B with a success response and verify it wins.
+        let success = SkillFileContentResponse(
+            path: "docs/readme.md",
+            name: "readme.md",
+            size: 3,
+            mimeType: "text/markdown",
+            isBinary: false,
+            content: "yay"
+        )
+        await backing.unblock(path: "docs/readme.md", with: success)
+
+        try await waitUntil(timeout: 1.0) {
+            !store.loadingFilePaths.contains("docs/readme.md")
+        }
+
+        XCTAssertEqual(store.loadedFileContents["docs/readme.md"], "yay")
+        XCTAssertNil(store.fileContentErrors["docs/readme.md"])
+    }
+
+    func testClearLoadedFileContentsCancelsTasksAndClearsState() async throws {
+        let backing = MockSkillsFileContentStore()
+        await backing.setBlocking(for: "long-path.md")
+        let mock = MockSkillsClient(backing: backing)
+        let store = SkillsStore(skillsClient: mock)
+
+        store.fetchSkillFiles(skillId: "my-skill")
+        try await Task.sleep(nanoseconds: 20_000_000)
+
+        store.loadSkillFileContent(skillId: "my-skill", path: "long-path.md")
+        XCTAssertTrue(store.loadingFilePaths.contains("long-path.md"))
+
+        // Prime loadedFileContents and fileContentErrors directly so we can verify
+        // that clearLoadedFileContents wipes all three dictionaries.
+        store.loadedFileContents["existing.md"] = "cached"
+        store.fileContentErrors["broken.md"] = "oops"
+
+        store.clearLoadedFileContents()
+
+        XCTAssertTrue(store.loadedFileContents.isEmpty)
+        XCTAssertTrue(store.loadingFilePaths.isEmpty)
+        XCTAssertTrue(store.fileContentErrors.isEmpty)
+
+        // Unblock the (now-cancelled) request so the actor isn't left waiting —
+        // even if the task already observed cancellation, this is a no-op.
+        await backing.unblock(path: "long-path.md", with: nil)
+    }
+
+    // MARK: - Helpers
+
+    private func waitUntil(
+        timeout: TimeInterval,
+        _ condition: @MainActor () -> Bool
+    ) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if condition() { return }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        XCTFail("Condition not met within \(timeout) seconds")
+    }
+
+    private func waitUntilAsync(
+        timeout: TimeInterval,
+        _ condition: @Sendable () async -> Bool
+    ) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if await condition() { return }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        XCTFail("Condition not met within \(timeout) seconds")
+    }
+}

--- a/clients/shared/Tests/SkillsFileContentTests.swift
+++ b/clients/shared/Tests/SkillsFileContentTests.swift
@@ -43,6 +43,12 @@ private actor MockSkillsFileContentStore {
     private var continuations: [String: [CheckedContinuation<SkillFileContentResponse?, Never>]] = [:]
     private var blockingPaths: Set<String> = []
 
+    /// Ordered log of `fetchSkillFiles(skillId:)` calls issued through the
+    /// mock client. Tests use this to assert that the store reissues a
+    /// same-skill re-fetch (e.g. during the install-from-preview transition)
+    /// rather than short-circuiting when `currentFilesSkillId` is unchanged.
+    private(set) var fetchSkillFilesRequests: [String] = []
+
     func setResponse(for path: String, _ response: SkillFileContentResponse?) {
         if let response {
             fileContentResponses[path] = response
@@ -57,6 +63,14 @@ private actor MockSkillsFileContentStore {
 
     func record(skillId: String, path: String) {
         requestedPaths.append((skillId: skillId, path: path))
+    }
+
+    func recordFetchSkillFiles(skillId: String) {
+        fetchSkillFilesRequests.append(skillId)
+    }
+
+    func fetchSkillFilesCount() -> Int {
+        fetchSkillFilesRequests.count
     }
 
     func awaitResponse(skillId: String, path: String) async -> SkillFileContentResponse? {
@@ -105,9 +119,12 @@ private struct MockSkillsClient: SkillsClientProtocol {
     func createSkill(skillId: String, name: String, description: String, emoji: String?, bodyMarkdown: String, overwrite: Bool?) async -> SkillOperationResult? { nil }
     func fetchSkillDetail(skillId: String) async -> SkillDetailHTTPResponse? { nil }
     func fetchSkillFiles(skillId: String) async -> SkillDetailFilesHTTPResponse? {
-        // Tests drive `currentFilesSkillId` via `fetchSkillFiles`; the response
-        // body itself is irrelevant to the loadSkillFileContent code paths.
-        nil
+        // Tests drive `currentFilesSkillId` via `fetchSkillFiles` and count
+        // how many times it is reissued (e.g. for the install-from-preview
+        // re-fetch path); the response body itself is irrelevant to the
+        // loadSkillFileContent code paths.
+        await backing.recordFetchSkillFiles(skillId: skillId)
+        return nil
     }
 
     func fetchSkillFileContent(skillId: String, path: String) async -> SkillFileContentResponse? {
@@ -364,6 +381,37 @@ final class SkillsFileContentStoreTests: XCTestCase {
 
         XCTAssertEqual(store.loadedFileContents["docs/readme.md"], "yay")
         XCTAssertNil(store.fileContentErrors["docs/readme.md"])
+    }
+
+    func testFetchSkillFilesReIssuesRequestForSameSkillId() async throws {
+        // Regression coverage for the install-from-preview transition. When
+        // the detail view re-calls `fetchSkillFiles(skillId:)` for the same
+        // skill (because an install just flipped `skill.kind` from
+        // "catalog" to "installed"/"bundled"), the store must reissue the
+        // request rather than short-circuiting on a `currentFilesSkillId`
+        // match. Otherwise the right pane of the detail view is stuck
+        // showing the lazy/null-content preview payload with no inline
+        // content.
+        let backing = MockSkillsFileContentStore()
+        let mock = MockSkillsClient(backing: backing)
+        let store = SkillsStore(skillsClient: mock)
+
+        store.fetchSkillFiles(skillId: "my-skill")
+        try await waitUntilAsync(timeout: 1.0) {
+            await backing.fetchSkillFilesCount() >= 1
+        }
+
+        store.fetchSkillFiles(skillId: "my-skill")
+        try await waitUntilAsync(timeout: 1.0) {
+            await backing.fetchSkillFilesCount() >= 2
+        }
+
+        let totalRequests = await backing.fetchSkillFilesCount()
+        XCTAssertEqual(
+            totalRequests,
+            2,
+            "Same-skill re-fetch must reissue the request so install-from-preview can replace lazy content"
+        )
     }
 
     func testClearLoadedFileContentsCancelsTasksAndClearsState() async throws {


### PR DESCRIPTION
## Summary

Adds a read-only preview of files for uninstalled Vellum catalog skills in the macOS Skills tab. Users can now click an "Available" skill card, browse its file tree, and lazily load individual file content before deciding to install — the Install button transitions seamlessly into the installed state without a visible reload.

The daemon gains a new `GET /skills/:id/files/content?path=...` endpoint that proxies to the dedicated platform preview endpoints (`/v1/skills/{id}/files/` and `/v1/skills/{id}/files/content/`) introduced by [vellum-assistant-platform PR #4103](https://github.com/vellum-ai/vellum-assistant-platform/pull/4103). In `VELLUM_DEV` mode, the daemon reads directly from the local `<repo>/skills/` directory instead. The existing install tarball endpoint is unchanged — previews and installs are now on independent network paths.

## Self-review result

**PASS** after 3 review rounds. 3 remediation PRs fixed 12 gaps across two rounds:
- Round 1 daemon: MAX_INLINE_TEXT_SIZE consolidation, integer size field, 404 for missing installed dir, route comment
- Round 1 client: selectedSkillId preservation, view identity, SkillsStore refactor, oversized-text handling, install button defer + watchdog, accessibility, browser rebuild key, iOS comment
- Round 2: symmetric 404 for missing installed dir in `getSkillFileContent`, oversized-text Swift test

## Core PRs merged into this branch

- #24477 — feat(skills): add catalog-files helper for previewing uninstalled catalog skill files
- #24488 — feat(skills): return file listings for uninstalled Vellum catalog skills
- #24489 — feat(skills): add single-file content endpoint for lazy previews
- #24511 — feat(skills-client): add fetchSkillFileContent for lazy file previews
- #24520 — feat(skills-ui): preview uninstalled Vellum skills in the detail view
- #24524 — feat(skills-ui): refresh files after installing from the preview detail view

## Remediation PRs

- #24535 — fix(skills): address daemon-side self-review gaps (round 1)
- #24536 — fix(skills-ui): address self-review gaps in preview + install-from-preview flow (round 1)
- #24544 — fix(skills): symmetric 404 for missing installed dir in getSkillFileContent + oversized-text Swift test (round 2)

## Key design decisions

- **Lazy file content**: file lists always return `content: null` for catalog skills; content is fetched per-file on-click via `GET /files/content?path=...`. Installed skills keep eager content.
- **Defense-in-depth security**: path sanitization in the catalog-files module + platform-side validation + symlink rejection (lstat + realpath containment) + hidden/SKIP_DIRS segment rejection in both the handler and helper layers.
- **`VELLUM_DEV` short-circuit**: when `<repo>/skills/<id>/` exists on disk, dev-mode reads bypass the platform preview API. Symlinked skill roots are rejected up-front so a dev skill dir can't leak files outside the repo.
- **Install-from-preview transition**: `SkillDetailView` observes `skill.kind` flipping from `catalog` to `installed`/`bundled`, clears the lazy cache, and re-fetches eager content in place. `SkillsManager` defers clearing `installingSkillId` until the refreshed skills list reflects the transition, preventing an Install-button flicker. A 15-second watchdog prevents stuck spinners.
- **`SKIP_DIRS` single source of truth**: lives in `catalog-files.ts`, imported by the daemon handler — no duplication.
- **Scoped to `origin == "vellum"`**: Clawhub and Skills.sh previews are deferred to later plans per the scope guard in the original plan.

Part of plan: `.private/plans/skill-files-preview.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24545" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
