### PR TITLE
fix: update test expectations for config re-serialization

### DIFF
--- a/assistant/src/__tests__/migration-cross-version-compatibility.test.ts
+++ b/assistant/src/__tests__/migration-cross-version-compatibility.test.ts
@@ -834,7 +834,9 @@ describe("round-trip: export -> validate -> preflight -> import", () => {
       expect(sha256Hex(writtenDb)).toBe(sha256Hex(dbData));
 
       const writtenConfig = readFileSync(testConfigPath, "utf8");
-      expect(writtenConfig).toBe('{"model":"test-round-trip"}');
+      expect(writtenConfig).toBe(
+        JSON.stringify({ model: "test-round-trip" }, null, 2) + "\n",
+      );
     }
   });
 

--- a/assistant/src/__tests__/migration-import-commit-http.test.ts
+++ b/assistant/src/__tests__/migration-import-commit-http.test.ts
@@ -731,7 +731,9 @@ describe("commitImport", () => {
       expect(writtenDb).toEqual(newDbData);
 
       const writtenConfig = readFileSync(testConfigPath, "utf8");
-      expect(writtenConfig).toBe('{"model":"claude"}');
+      expect(writtenConfig).toBe(
+        JSON.stringify({ model: "claude" }, null, 2) + "\n",
+      );
     }
   });
 });


### PR DESCRIPTION
## Summary
- Updates two tests that expected compact JSON config after import, but sanitizeConfigForTransfer now re-serializes with 2-space indentation + trailing newline
- Fixes CI failures in migration-cross-version-compatibility.test.ts and migration-import-commit-http.test.ts
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24552" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
