### PR TITLE
fix(macOS): pin zoomed canvas to top-left to prevent sidebar clipping

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -635,6 +635,9 @@ struct MainWindowView: View {
     @ViewBuilder
     private func coreLayoutContent(windowSize: CGSize) -> some View {
         coreLayoutBase(windowSize: windowSize)
+            // Keep the zoomed canvas pinned to the top-left so width changes
+            // do not recenter the layout and clip the sidebar off-screen.
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
             .overlay { preferencesDismissLayer }
             .overlay(alignment: .bottomLeading) { preferencesDrawerLayer }
             .sheet(isPresented: $showEarnCreditsModal) {
@@ -646,9 +649,11 @@ struct MainWindowView: View {
             .ignoresSafeArea(edges: .top)
             .background(VColor.surfaceBase.ignoresSafeArea())
             .frame(width: windowSize.width / zoomManager.zoomLevel,
-                   height: windowSize.height / zoomManager.zoomLevel)
+                   height: windowSize.height / zoomManager.zoomLevel,
+                   alignment: .topLeading)
             .scaleEffect(zoomManager.zoomLevel, anchor: .topLeading)
             .frame(width: windowSize.width, height: windowSize.height, alignment: .topLeading)
+            .clipped()
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary
- Anchor the zoomed canvas to `.topLeading` so width changes don't recenter the layout and clip the sidebar off-screen
- Add `.clipped()` to contain scaled content within the window bounds
- Rebuild `vellum-chrome-native-host` binary
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24559" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
