### PR TITLE
fix(macOS): align composer and banners with transcript width

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -305,6 +305,7 @@ struct ChatView: View {
     /// `TranscriptRenderModel` via `MessageListContentView`.
     @ViewBuilder
     private func activeConversationContent(containerWidth: CGFloat) -> some View {
+        let layoutMetrics = MessageListLayoutMetrics(containerWidth: containerWidth)
         VStack(spacing: 0) {
             MessageListView(
                 // -- TranscriptProjector inputs --
@@ -363,82 +364,101 @@ struct ChatView: View {
             )
 
             if let error = viewModel.errorManager.conversationError, error.isCreditsExhausted {
-                CreditsExhaustedBanner(
-                    onAddFunds: { onAddFunds?() }
-                )
-                .frame(maxWidth: VSpacing.chatColumnMaxWidth - 2 * VSpacing.xl)
-                .frame(maxWidth: .infinity)
+                centeredChatColumn(width: max(layoutMetrics.chatColumnWidth - 2 * VSpacing.xl, 0)) {
+                    CreditsExhaustedBanner(
+                        onAddFunds: { onAddFunds?() }
+                    )
+                }
                 .padding(.bottom, -VSpacing.sm)
             }
 
             if let error = viewModel.errorManager.conversationError, error.isProviderNotConfigured {
-                MissingApiKeyBanner(
-                    onOpenSettings: { onOpenModelsAndServices?() },
-                    onDismiss: { viewModel.dismissConversationError() }
-                )
-                .frame(maxWidth: VSpacing.chatColumnMaxWidth - 2 * VSpacing.xl)
-                .frame(maxWidth: .infinity)
+                centeredChatColumn(width: max(layoutMetrics.chatColumnWidth - 2 * VSpacing.xl, 0)) {
+                    MissingApiKeyBanner(
+                        onOpenSettings: { onOpenModelsAndServices?() },
+                        onDismiss: { viewModel.dismissConversationError() }
+                    )
+                }
                 .padding(.bottom, -VSpacing.sm)
             }
 
             if let mode = recoveryMode, mode.enabled {
-                RecoveryModeBanner(
-                    recoveryMode: mode,
-                    onResumeAssistant: { onResumeAssistant?() },
-                    onOpenSSHSettings: { onOpenSSHSettings?() },
-                    isExiting: isRecoveryModeExiting
-                )
-                .frame(maxWidth: VSpacing.chatColumnMaxWidth - 2 * VSpacing.xl)
-                .frame(maxWidth: .infinity)
+                centeredChatColumn(width: max(layoutMetrics.chatColumnWidth - 2 * VSpacing.xl, 0)) {
+                    RecoveryModeBanner(
+                        recoveryMode: mode,
+                        onResumeAssistant: { onResumeAssistant?() },
+                        onOpenSSHSettings: { onOpenSSHSettings?() },
+                        isExiting: isRecoveryModeExiting
+                    )
+                }
                 .padding(.bottom, -VSpacing.sm)
             }
 
             if isReadonly {
-                HStack(spacing: VSpacing.xs) {
-                    VIconView(.eye, size: 14)
-                    Text("Read-only conversation")
-                        .font(VFont.bodySmallDefault)
+                centeredChatColumn(width: layoutMetrics.chatColumnWidth) {
+                    HStack(spacing: VSpacing.xs) {
+                        VIconView(.eye, size: 14)
+                        Text("Read-only conversation")
+                            .font(VFont.bodySmallDefault)
+                        Spacer(minLength: 0)
+                    }
+                    .foregroundStyle(VColor.contentTertiary)
+                    .padding(.vertical, VSpacing.md)
                 }
-                .foregroundStyle(VColor.contentTertiary)
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, VSpacing.md)
             } else {
-                ComposerSection(
-                    inputText: $viewModel.inputText,
-                    isSending: viewModel.isSending,
-                    isAssistantBusy: viewModel.isAssistantBusy,
-                    hasPendingConfirmation: viewModel.activePendingRequestId != nil,
-                    onAllowPendingConfirmation: {
-                        if let requestId = viewModel.activePendingRequestId {
-                            viewModel.respondToConfirmation(requestId: requestId, decision: "allow")
-                        }
-                    },
-                    isRecording: viewModel.isRecording,
-                    suggestion: viewModel.suggestion,
-                    pendingAttachments: viewModel.pendingAttachments,
-                    isLoadingAttachment: viewModel.isLoadingAttachment,
-                    onSend: { sendMessage() },
-                    onStop: { viewModel.stopGenerating() },
-                    onAcceptSuggestion: { viewModel.acceptSuggestion() },
-                    onAttach: { presentFilePicker() },
-                    onRemoveAttachment: { viewModel.removeAttachment(id: $0) },
-                    onPaste: { viewModel.addAttachmentFromPasteboard() },
-                    onMicrophoneToggle: onMicrophoneToggle,
-                    watchSession: watchSession,
-                    onStopWatch: { viewModel.stopWatchSession() },
-                    voiceModeManager: voiceModeManager,
-                    voiceService: voiceService,
-                    onEndVoiceMode: onEndVoiceMode,
-                    recordingAmplitude: viewModel.recordingAmplitude,
-                    onDictateToggle: onDictateToggle,
-                    onVoiceModeToggle: onVoiceModeToggle,
-                    conversationId: conversationId,
-                    isInteractionEnabled: isInteractionEnabled,
-                    contextWindowFillRatio: viewModel.contextWindowFillRatio,
-                    contextWindowTokens: viewModel.contextWindowTokens,
-                    contextWindowMaxTokens: viewModel.contextWindowMaxTokens
-                )
+                centeredChatColumn(width: layoutMetrics.chatColumnWidth) {
+                    ComposerSection(
+                        inputText: $viewModel.inputText,
+                        isSending: viewModel.isSending,
+                        isAssistantBusy: viewModel.isAssistantBusy,
+                        hasPendingConfirmation: viewModel.activePendingRequestId != nil,
+                        onAllowPendingConfirmation: {
+                            if let requestId = viewModel.activePendingRequestId {
+                                viewModel.respondToConfirmation(requestId: requestId, decision: "allow")
+                            }
+                        },
+                        isRecording: viewModel.isRecording,
+                        suggestion: viewModel.suggestion,
+                        pendingAttachments: viewModel.pendingAttachments,
+                        isLoadingAttachment: viewModel.isLoadingAttachment,
+                        onSend: { sendMessage() },
+                        onStop: { viewModel.stopGenerating() },
+                        onAcceptSuggestion: { viewModel.acceptSuggestion() },
+                        onAttach: { presentFilePicker() },
+                        onRemoveAttachment: { viewModel.removeAttachment(id: $0) },
+                        onPaste: { viewModel.addAttachmentFromPasteboard() },
+                        onMicrophoneToggle: onMicrophoneToggle,
+                        watchSession: watchSession,
+                        onStopWatch: { viewModel.stopWatchSession() },
+                        voiceModeManager: voiceModeManager,
+                        voiceService: voiceService,
+                        onEndVoiceMode: onEndVoiceMode,
+                        recordingAmplitude: viewModel.recordingAmplitude,
+                        onDictateToggle: onDictateToggle,
+                        onVoiceModeToggle: onVoiceModeToggle,
+                        conversationId: conversationId,
+                        isInteractionEnabled: isInteractionEnabled,
+                        contextWindowFillRatio: viewModel.contextWindowFillRatio,
+                        contextWindowTokens: viewModel.contextWindowTokens,
+                        contextWindowMaxTokens: viewModel.contextWindowMaxTokens
+                    )
+                }
             }
+        }
+    }
+
+    /// Centers chat chrome to the same fixed transcript width using _FrameLayout
+    /// rather than nested max-width flex frames.
+    @ViewBuilder
+    private func centeredChatColumn<Content: View>(
+        width: CGFloat,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        HStack(spacing: 0) {
+            Spacer(minLength: 0)
+            content()
+                .frame(width: width)
+            Spacer(minLength: 0)
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -134,8 +134,6 @@ struct ComposerView: View {
         .fixedSize(horizontal: false, vertical: true)
         .padding(.horizontal, VSpacing.lg)
         .padding(.top, VSpacing.sm)
-        .frame(maxWidth: VSpacing.chatColumnMaxWidth)
-        .frame(maxWidth: .infinity)
         .disabled(!isInteractionEnabled)
         .animation(VAnimation.fast, value: isComposerFocused)
         .task {


### PR DESCRIPTION
## Summary
- Compute `MessageListLayoutMetrics` once in `activeConversationContent` and reuse `chatColumnWidth` for the banners, read-only label, and composer so chat chrome tracks the transcript width when the container is narrower than `chatColumnMaxWidth`.
- Replace the nested `.frame(maxWidth:).frame(maxWidth: .infinity)` centering pattern with a `centeredChatColumn(width:)` helper that pins content to a fixed width between two zero-min `Spacer`s.
- Drop the now-redundant max-width frames from `ComposerView` since the parent enforces the width.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24561" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
