### PR TITLE
fix(macOS): sort archived conversations by archive time, newest first

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationListStore.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationListStore.swift
@@ -115,24 +115,97 @@ final class ConversationListStore {
     private static let archivedConversationsKey = "archivedSessionIds"
     // Intermediate builds may have written under this key before the compat fix.
     private static let archivedConversationsNewKey = "archivedConversationIds"
+    // [String: TimeInterval] mapping conversationId -> archive time (seconds since 1970).
+    // Used to sort the Settings → Archived Conversations tab by most-recently-archived.
+    private static let archivedConversationsSortKey = "archivedConversationTimestamps"
 
+    /// Timestamped archive state: conversationId -> archivedAt. Source of truth for both
+    /// "is this conversation archived?" and the sort order in the Settings tab. Persisted
+    /// to UserDefaults via `didSet` as `[String: TimeInterval]`.
+    var archivedConversationTimestamps: [String: Date] = [:] {
+        didSet {
+            let encoded = archivedConversationTimestamps.mapValues { $0.timeIntervalSince1970 }
+            UserDefaults.standard.set(encoded, forKey: Self.archivedConversationsSortKey)
+        }
+    }
+
+    /// Backwards-compatible view of archived ids as a `Set<String>`. Reads return the
+    /// current keyset; writes preserve existing timestamps for ids that stay archived
+    /// and assign `Date.distantPast` for newly-added ids (since the caller doesn't know
+    /// the archive time). Production code should prefer `markArchived`/`unmarkArchived`.
     var archivedConversationIds: Set<String> {
-        get {
-            let legacy = Set(UserDefaults.standard.stringArray(forKey: Self.archivedConversationsKey) ?? [])
-            let newer = Set(UserDefaults.standard.stringArray(forKey: Self.archivedConversationsNewKey) ?? [])
-            let merged = legacy.union(newer)
-            // Migrate: consolidate into the canonical key and remove the intermediate key.
-            if !newer.isEmpty {
-                UserDefaults.standard.set(Array(merged), forKey: Self.archivedConversationsKey)
-                UserDefaults.standard.removeObject(forKey: Self.archivedConversationsNewKey)
-            }
-            return merged
-        }
+        get { Set(archivedConversationTimestamps.keys) }
         set {
-            UserDefaults.standard.set(Array(newValue), forKey: Self.archivedConversationsKey)
-            // Clean up the intermediate key if it exists.
-            UserDefaults.standard.removeObject(forKey: Self.archivedConversationsNewKey)
+            var updated = archivedConversationTimestamps
+            for id in newValue where updated[id] == nil {
+                updated[id] = .distantPast
+            }
+            for id in Set(updated.keys).subtracting(newValue) {
+                updated.removeValue(forKey: id)
+            }
+            archivedConversationTimestamps = updated
         }
+    }
+
+    /// Mark a conversation as archived, recording the archive time.
+    func markArchived(_ conversationId: String, at date: Date = Date()) {
+        var updated = archivedConversationTimestamps
+        updated[conversationId] = date
+        archivedConversationTimestamps = updated
+    }
+
+    /// Mark multiple conversations as archived in one write, all at the same timestamp.
+    func markArchived(_ conversationIds: some Sequence<String>, at date: Date = Date()) {
+        var updated = archivedConversationTimestamps
+        for id in conversationIds {
+            updated[id] = date
+        }
+        archivedConversationTimestamps = updated
+    }
+
+    /// Remove a conversation's archive entry.
+    func unmarkArchived(_ conversationId: String) {
+        guard archivedConversationTimestamps[conversationId] != nil else { return }
+        var updated = archivedConversationTimestamps
+        updated.removeValue(forKey: conversationId)
+        archivedConversationTimestamps = updated
+    }
+
+    /// Re-key an archive entry when a synthetic conversation id is resolved to a real one.
+    /// Preserves the original archive timestamp so the item keeps its sort position.
+    func replaceArchivedKey(from oldId: String, to newId: String) {
+        guard let date = archivedConversationTimestamps[oldId] else { return }
+        var updated = archivedConversationTimestamps
+        updated.removeValue(forKey: oldId)
+        updated[newId] = date
+        archivedConversationTimestamps = updated
+    }
+
+    init() {
+        self.archivedConversationTimestamps = Self.loadAndMigrateArchivedTimestamps()
+    }
+
+    /// One-shot loader: if the new timestamp dict is present, return it. Otherwise,
+    /// migrate from the legacy `Set<String>` format by assigning `Date.distantPast` to
+    /// each legacy id so they sort to the bottom of the archive list (below any
+    /// newly-archived items). Runs once from `init()` to avoid mutating-getter hazards
+    /// under `@Observable`.
+    private static func loadAndMigrateArchivedTimestamps() -> [String: Date] {
+        let defaults = UserDefaults.standard
+
+        if let raw = defaults.dictionary(forKey: archivedConversationsSortKey) as? [String: TimeInterval] {
+            return raw.mapValues { Date(timeIntervalSince1970: $0) }
+        }
+
+        let legacy = Set(defaults.stringArray(forKey: archivedConversationsKey) ?? [])
+        let newer = Set(defaults.stringArray(forKey: archivedConversationsNewKey) ?? [])
+        let merged = legacy.union(newer)
+        guard !merged.isEmpty else { return [:] }
+
+        let migrated = Dictionary(uniqueKeysWithValues: merged.map { ($0, Date.distantPast) })
+        let encoded = migrated.mapValues { $0.timeIntervalSince1970 }
+        defaults.set(encoded, forKey: archivedConversationsSortKey)
+        return migrated
     }
 
     // MARK: - Cached Derived Properties
@@ -154,7 +227,25 @@ final class ConversationListStore {
     /// Count of visible conversations with unseen assistant messages (dock badge).
     private(set) var unseenVisibleConversationCount: Int = 0
 
-    private(set) var archivedConversations: [ConversationModel] = []
+    /// Archived conversations ordered by most-recently-archived first. Items whose
+    /// archive timestamp is unknown (legacy, pre-migration) sort to the bottom with
+    /// `createdAt` as a stable tiebreaker. Computed on read — only consumed by the
+    /// Settings → Archived Conversations tab, which is not a hot path. Under
+    /// `@Observable`, reading this re-computes when either `conversations` or
+    /// `archivedConversationTimestamps` changes.
+    var archivedConversations: [ConversationModel] {
+        let timestamps = archivedConversationTimestamps
+        return conversations
+            .filter { $0.isArchived }
+            .sorted { lhs, rhs in
+                let lhsDate = lhs.conversationId.flatMap { timestamps[$0] } ?? .distantPast
+                let rhsDate = rhs.conversationId.flatMap { timestamps[$0] } ?? .distantPast
+                if lhsDate == rhsDate {
+                    return lhs.createdAt > rhs.createdAt
+                }
+                return lhsDate > rhsDate
+            }
+    }
 
     /// Pre-computed sidebar group entries with feature-flag-aware folding applied.
     /// When custom groups are disabled, non-system-group conversations are folded
@@ -172,7 +263,6 @@ final class ConversationListStore {
             groupedConversations = []
             visibleConversations = []
             unseenVisibleConversationCount = 0
-            archivedConversations = []
             sidebarGroupEntries = []
             return
         }
@@ -189,8 +279,6 @@ final class ConversationListStore {
             !$0.isArchived && $0.kind != .private && $0.hasUnseenLatestAssistantMessage
                 && !$0.shouldSuppressUnreadIndicator
         }
-
-        archivedConversations = conversations.filter { $0.isArchived }
 
         // Bucket visible conversations by group in a single pass (O(N)).
         let knownGroupIds = Set(groups.map(\.id))

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -673,9 +673,7 @@ final class ConversationManager: ConversationRestorerDelegate {
 
         if let conversationId = listStore.conversations[index].conversationId {
             selectionStore.chatViewModels[id]?.stopGenerating()
-            var archived = listStore.archivedConversationIds
-            archived.insert(conversationId)
-            listStore.archivedConversationIds = archived
+            listStore.markArchived(conversationId)
             selectionStore.removeChatViewModel(for: id)
         } else if selectionStore.chatViewModels[id]?.messages.contains(where: { $0.role == .user }) != true
                     && selectionStore.chatViewModels[id]?.isBootstrapping != true {
@@ -722,9 +720,7 @@ final class ConversationManager: ConversationRestorerDelegate {
         listStore.conversations = draft
 
         if !newlyArchivedServerIds.isEmpty {
-            var archived = listStore.archivedConversationIds
-            archived.formUnion(newlyArchivedServerIds)
-            listStore.archivedConversationIds = archived
+            listStore.markArchived(newlyArchivedServerIds)
         }
 
         for id in ids {
@@ -771,9 +767,7 @@ final class ConversationManager: ConversationRestorerDelegate {
         listStore.conversations[index].isArchived = false
         selectionStore.getOrCreateViewModel(for: id)
         if let conversationId = listStore.conversations[index].conversationId {
-            var archived = listStore.archivedConversationIds
-            archived.remove(conversationId)
-            listStore.archivedConversationIds = archived
+            listStore.unmarkArchived(conversationId)
         }
         log.info("Unarchived conversation \(id)")
     }
@@ -857,9 +851,7 @@ final class ConversationManager: ConversationRestorerDelegate {
         guard conversation.conversationType != "private" else { return false }
 
         if listStore.isConversationArchived(conversation.id) {
-            var archived = listStore.archivedConversationIds
-            archived.remove(conversation.id)
-            listStore.archivedConversationIds = archived
+            listStore.unmarkArchived(conversation.id)
         }
 
         guard let localConversationId = upsertConversation(from: conversation, isArchived: false) else {
@@ -898,9 +890,7 @@ final class ConversationManager: ConversationRestorerDelegate {
         }
 
         if listStore.isConversationArchived(conversation.id) {
-            var archived = listStore.archivedConversationIds
-            archived.remove(conversation.id)
-            listStore.archivedConversationIds = archived
+            listStore.unmarkArchived(conversation.id)
         }
 
         guard let localConversationId = upsertConversation(from: conversation, isArchived: false) else {
@@ -1020,9 +1010,7 @@ final class ConversationManager: ConversationRestorerDelegate {
         listStore.conversations = updated
 
         if !newlyArchivedServerIds.isEmpty {
-            var archived = listStore.archivedConversationIds
-            archived.formUnion(newlyArchivedServerIds)
-            listStore.archivedConversationIds = archived
+            listStore.markArchived(newlyArchivedServerIds)
         }
 
         for id in idsToArchive {
@@ -1244,9 +1232,7 @@ final class ConversationManager: ConversationRestorerDelegate {
         guard item.conversationType != "private" else { return nil }
 
         if !isArchived && listStore.isConversationArchived(item.id) {
-            var archived = listStore.archivedConversationIds
-            archived.remove(item.id)
-            listStore.archivedConversationIds = archived
+            listStore.unmarkArchived(item.id)
         }
 
         if let existingIdx = listStore.conversations.firstIndex(where: { $0.conversationId == item.id }) {
@@ -1304,12 +1290,8 @@ final class ConversationManager: ConversationRestorerDelegate {
         if let override = listStore.pendingAttentionOverrides.removeValue(forKey: syntheticId) {
             listStore.pendingAttentionOverrides[serverId] = override
         }
-        if listStore.archivedConversationIds.contains(syntheticId) {
-            var archived = listStore.archivedConversationIds
-            archived.remove(syntheticId)
-            archived.insert(serverId)
-            listStore.archivedConversationIds = archived
-        }
+        // Preserves the original archive timestamp across the synthetic → server id swap.
+        listStore.replaceArchivedKey(from: syntheticId, to: serverId)
         if let idx = listStore.pendingSeenConversationIds.firstIndex(of: syntheticId) {
             listStore.pendingSeenConversationIds[idx] = serverId
         }
@@ -1350,9 +1332,7 @@ final class ConversationManager: ConversationRestorerDelegate {
 
         // Persist archive state now that we have a server ID.
         if listStore.conversations[index].isArchived {
-            var archived = listStore.archivedConversationIds
-            archived.insert(conversationId)
-            listStore.archivedConversationIds = archived
+            listStore.markArchived(conversationId)
             // The conversation was archived while waiting for a server ID.
             // Now that backfill is complete, release the ViewModel we were
             // keeping alive solely for the correlation ID callback.

--- a/clients/macos/vellum-assistantTests/ConversationListStoreArchiveSortTests.swift
+++ b/clients/macos/vellum-assistantTests/ConversationListStoreArchiveSortTests.swift
@@ -1,0 +1,148 @@
+import Foundation
+import Testing
+@testable import VellumAssistantLib
+import VellumAssistantShared
+
+// UserDefaults keys touched by ConversationListStore's archive state. Kept in sync
+// with the private constants in ConversationListStore.swift so these tests can
+// seed and clean up the defaults independently.
+private let legacyArchivedIdsKey = "archivedSessionIds"
+private let intermediateArchivedIdsKey = "archivedConversationIds"
+private let archivedTimestampsKey = "archivedConversationTimestamps"
+
+private func clearArchiveDefaults() {
+    let defaults = UserDefaults.standard
+    defaults.removeObject(forKey: legacyArchivedIdsKey)
+    defaults.removeObject(forKey: intermediateArchivedIdsKey)
+    defaults.removeObject(forKey: archivedTimestampsKey)
+}
+
+private func makeArchived(conversationId: String, title: String = "Test", createdAt: Date = Date()) -> ConversationModel {
+    ConversationModel(
+        title: title,
+        createdAt: createdAt,
+        conversationId: conversationId,
+        isArchived: true
+    )
+}
+
+@Suite("ConversationListStore archive sort", .serialized)
+@MainActor
+struct ConversationListStoreArchiveSortTests {
+
+    init() {
+        clearArchiveDefaults()
+    }
+
+    @Test
+    func archivedConversationsSortedByArchiveTimeDescending() {
+        defer { clearArchiveDefaults() }
+
+        let store = ConversationListStore()
+        let base = Date(timeIntervalSince1970: 1_700_000_000)
+
+        store.conversations = [
+            makeArchived(conversationId: "a", title: "First archived"),
+            makeArchived(conversationId: "b", title: "Second archived"),
+            makeArchived(conversationId: "c", title: "Third archived"),
+        ]
+
+        store.markArchived("a", at: base)
+        store.markArchived("b", at: base.addingTimeInterval(1))
+        store.markArchived("c", at: base.addingTimeInterval(2))
+
+        let titles = store.archivedConversations.map(\.title)
+        #expect(titles == ["Third archived", "Second archived", "First archived"])
+    }
+
+    @Test
+    func preMigrationItemsSortBelowNewlyArchived() {
+        defer { clearArchiveDefaults() }
+
+        // Seed the legacy Set<String> format so init() runs the migration path.
+        UserDefaults.standard.set(["legacy1", "legacy2"], forKey: legacyArchivedIdsKey)
+
+        let store = ConversationListStore()
+
+        #expect(store.archivedConversationTimestamps["legacy1"] == .distantPast)
+        #expect(store.archivedConversationTimestamps["legacy2"] == .distantPast)
+
+        store.conversations = [
+            makeArchived(conversationId: "legacy1", title: "Legacy one", createdAt: Date(timeIntervalSince1970: 1_600_000_000)),
+            makeArchived(conversationId: "legacy2", title: "Legacy two", createdAt: Date(timeIntervalSince1970: 1_600_000_100)),
+            makeArchived(conversationId: "fresh", title: "Freshly archived"),
+        ]
+        store.markArchived("fresh", at: Date())
+
+        let titles = store.archivedConversations.map(\.title)
+        // Fresh first; legacy items follow, ordered by createdAt desc as the tiebreaker.
+        #expect(titles == ["Freshly archived", "Legacy two", "Legacy one"])
+    }
+
+    @Test
+    func replaceArchivedKeyPreservesTimestamp() {
+        defer { clearArchiveDefaults() }
+
+        let store = ConversationListStore()
+        let archivedAt = Date(timeIntervalSince1970: 1_700_000_500)
+
+        store.markArchived("synthetic", at: archivedAt)
+        store.replaceArchivedKey(from: "synthetic", to: "real-server-id")
+
+        #expect(store.archivedConversationTimestamps["synthetic"] == nil)
+        #expect(store.archivedConversationTimestamps["real-server-id"] == archivedAt)
+    }
+
+    @Test
+    func unmarkArchivedRemovesTimestamp() {
+        defer { clearArchiveDefaults() }
+
+        let store = ConversationListStore()
+        store.markArchived("a", at: Date())
+        #expect(store.archivedConversationTimestamps["a"] != nil)
+
+        store.unmarkArchived("a")
+        #expect(store.archivedConversationTimestamps["a"] == nil)
+    }
+
+    @Test
+    func markArchivedBulkSharesSingleTimestamp() {
+        defer { clearArchiveDefaults() }
+
+        let store = ConversationListStore()
+        let sharedTime = Date(timeIntervalSince1970: 1_700_000_999)
+
+        store.markArchived(["x", "y", "z"], at: sharedTime)
+
+        #expect(store.archivedConversationTimestamps["x"] == sharedTime)
+        #expect(store.archivedConversationTimestamps["y"] == sharedTime)
+        #expect(store.archivedConversationTimestamps["z"] == sharedTime)
+    }
+
+    @Test
+    func archivedConversationIdsWrapperReflectsTimestampDict() {
+        defer { clearArchiveDefaults() }
+
+        let store = ConversationListStore()
+        store.markArchived("a")
+        store.markArchived("b")
+
+        #expect(store.archivedConversationIds == ["a", "b"])
+        #expect(store.isConversationArchived("a"))
+        #expect(!store.isConversationArchived("c"))
+    }
+
+    @Test
+    func timestampsPersistAcrossStoreInstances() {
+        defer { clearArchiveDefaults() }
+
+        let archivedAt = Date(timeIntervalSince1970: 1_700_001_234)
+        do {
+            let store = ConversationListStore()
+            store.markArchived("persisted-id", at: archivedAt)
+        }
+
+        let reopened = ConversationListStore()
+        #expect(reopened.archivedConversationTimestamps["persisted-id"] == archivedAt)
+    }
+}


### PR DESCRIPTION
## Summary
- Settings → Archived Conversations now orders items by when they were archived, with most-recently-archived at the top (previously unordered).
- Introduces a timestamped archive store (\`[String: Date]\`) in \`ConversationListStore\`, replacing the bare \`Set<String>\`. Pre-existing archived items (no recorded timestamp) migrate to \`Date.distantPast\` so they sort below any newly-archived item, with \`createdAt\` as a stable tiebreaker.
- Makes \`archivedConversations\` a computed property so sort order recomputes lazily when either \`conversations\` or the timestamp dict changes — no cross-cutting ordering rule required across the ~9 archive call sites in \`ConversationManager\`. \`resolveConversationId\` now preserves the original archive timestamp across the synthetic → server id swap (prior behavior dropped it).

## Original prompt
it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24562" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
