### PR TITLE
perf: remove fixedSize that forces full text measurement in markdown views

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatMarkdownParser.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatMarkdownParser.swift
@@ -401,6 +401,5 @@ struct MarkdownTableView: View {
             .foregroundStyle(VColor.contentDefault)
             .textSelection(.enabled)
             .lineLimit(nil)
-            .fixedSize(horizontal: false, vertical: true)
     }
 }

--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -79,7 +79,6 @@ struct MarkdownSegmentView: View, Equatable {
                             .foregroundStyle(textColor)
                             .tint(tintColor)
                             .lineLimit(nil)
-                            .fixedSize(horizontal: false, vertical: true)
                         Spacer(minLength: 0)
                     }
                     #endif


### PR DESCRIPTION
## Summary
- Remove .fixedSize(horizontal: false, vertical: true) from MarkdownSegmentView and MarkdownTableView
- This modifier forced full unbounded text measurement on every layout pass
- Text still wraps via .lineLimit(nil) and parent width constraints

Part of plan: layout-perf-fix.md (PR 1 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24564" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
