### PR TITLE
feat(assistant): add systemPromptPrefix config for custom system prompt prefix

### DIFF
--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -31,6 +31,10 @@ mock.module("../util/logger.js", () => ({
   pruneOldLogFiles: () => 0,
 }));
 
+// Mutable config used by the mocked loader so individual tests can override
+// specific fields (e.g. systemPromptPrefix) without touching other sections.
+const mockLoadedConfig: Record<string, unknown> = {};
+
 mock.module("../config/loader.js", () => ({
   getConfig: () => ({
     ui: {},
@@ -49,7 +53,7 @@ mock.module("../config/loader.js", () => ({
       "web-search": { mode: "your-own", provider: "inference-provider-native" },
     },
   }),
-  loadConfig: () => ({}),
+  loadConfig: () => mockLoadedConfig,
   loadRawConfig: () => ({}),
   saveConfig: () => {},
   saveRawConfig: () => {},
@@ -123,6 +127,7 @@ describe("buildSystemPrompt", () => {
       const p = join(TEST_DIR, name);
       if (existsSync(p)) rmSync(p, { recursive: true, force: true });
     }
+    delete mockLoadedConfig.systemPromptPrefix;
   });
 
   test("returns empty string when no files exist", () => {
@@ -342,6 +347,72 @@ describe("buildSystemPrompt", () => {
     writeFileSync(join(TEST_DIR, "SOUL.md"), "_ All comments\n_ Nothing else");
     const result = buildSystemPrompt();
     expect(basePrompt(result)).toBe("");
+  });
+
+  describe("custom systemPromptPrefix", () => {
+    test("omits prefix when config value is unset", () => {
+      const result = buildSystemPrompt();
+      // With no prefix, the prompt should start with the parallel tool calls
+      // section (the first static section when no prefix is injected).
+      expect(result.startsWith("<use_parallel_tool_calls>")).toBe(true);
+    });
+
+    test("omits prefix when config value is null", () => {
+      mockLoadedConfig.systemPromptPrefix = null;
+      const result = buildSystemPrompt();
+      expect(result.startsWith("<use_parallel_tool_calls>")).toBe(true);
+    });
+
+    test("omits prefix when config value is an empty string", () => {
+      mockLoadedConfig.systemPromptPrefix = "";
+      const result = buildSystemPrompt();
+      expect(result.startsWith("<use_parallel_tool_calls>")).toBe(true);
+    });
+
+    test("omits prefix when config value is whitespace-only", () => {
+      mockLoadedConfig.systemPromptPrefix = "   \n\n  ";
+      const result = buildSystemPrompt();
+      expect(result.startsWith("<use_parallel_tool_calls>")).toBe(true);
+    });
+
+    test("injects prefix at the very start of the prompt when set", () => {
+      mockLoadedConfig.systemPromptPrefix = "You are operating in demo mode.";
+      const result = buildSystemPrompt();
+      expect(result.startsWith("You are operating in demo mode.")).toBe(true);
+      // The standard static sections should still follow the prefix.
+      expect(result).toContain("<use_parallel_tool_calls>");
+      // Prefix lives in the static (cached) block, not the dynamic block.
+      const boundaryIdx = result.indexOf(SYSTEM_PROMPT_CACHE_BOUNDARY);
+      expect(boundaryIdx).toBeGreaterThan(-1);
+      const staticBlock = result.slice(0, boundaryIdx);
+      expect(staticBlock).toContain("You are operating in demo mode.");
+    });
+
+    test("trims leading/trailing whitespace from the prefix", () => {
+      mockLoadedConfig.systemPromptPrefix =
+        "\n\n  Pretend you are a pirate.  \n\n";
+      const result = buildSystemPrompt();
+      expect(result.startsWith("Pretend you are a pirate.")).toBe(true);
+    });
+
+    test("multi-line prefixes are preserved verbatim after trimming", () => {
+      mockLoadedConfig.systemPromptPrefix =
+        "# Org Guardrails\n\n- Never discuss pricing.\n- Escalate refunds.";
+      const result = buildSystemPrompt();
+      expect(
+        result.startsWith(
+          "# Org Guardrails\n\n- Never discuss pricing.\n- Escalate refunds.",
+        ),
+      ).toBe(true);
+    });
+
+    test("workspace file content still appears after prefix", () => {
+      mockLoadedConfig.systemPromptPrefix = "Custom prefix";
+      writeFileSync(join(TEST_DIR, "IDENTITY.md"), "I am Vellum.");
+      const result = buildSystemPrompt();
+      expect(result.startsWith("Custom prefix")).toBe(true);
+      expect(basePrompt(result)).toBe("I am Vellum.");
+    });
   });
 });
 

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -318,6 +318,13 @@ export const AssistantConfigSchema = z
       .max(200, "maxStepsPerSession must be <= 200")
       .default(50)
       .describe("Maximum number of computer-use steps per session"),
+    systemPromptPrefix: z
+      .string({ error: "systemPromptPrefix must be a string" })
+      .nullable()
+      .default(null)
+      .describe(
+        "Custom text injected at the very beginning of the system prompt. Defaults to null (no injection).",
+      ),
   })
   .superRefine((config, ctx) => {
     if (

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -219,6 +219,8 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
   // the first cache block so they remain cached even when workspace files
   // (IDENTITY.md, SOUL.md, USER.md, etc.) are edited between turns.
   const staticParts: string[] = [];
+  const customPrefix = readCustomSystemPromptPrefix();
+  if (customPrefix) staticParts.push(customPrefix);
   staticParts.push(buildParallelToolCallsSection());
   if (getIsContainerized()) staticParts.push(buildContainerizedSection());
   staticParts.push(buildCliReferenceSection());
@@ -389,6 +391,22 @@ function buildIntegrationSection(): string {
   }
 
   return lines.join("\n");
+}
+
+/**
+ * Read the user-configured custom system prompt prefix.  Returns the trimmed
+ * value when set and non-empty, otherwise null.  Errors (e.g. config file
+ * unavailable) are swallowed so prompt construction never fails.
+ */
+function readCustomSystemPromptPrefix(): string | null {
+  try {
+    const prefix = loadConfig().systemPromptPrefix;
+    if (typeof prefix !== "string") return null;
+    const trimmed = prefix.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  } catch {
+    return null;
+  }
 }
 
 function buildAskBeforeActingSection(): string | null {


### PR DESCRIPTION
## Summary
- New top-level config field `systemPromptPrefix: string | null` (default `null`). When set, the trimmed value is injected as the very first section of the system prompt, before the static instruction sections.
- Lives in the static (cached) block so it benefits from Anthropic prompt caching. When `null`, empty, or whitespace-only, the prompt composition is unchanged — zero runtime cost.
- Backwards compatible: the field defaults to `null`, so existing workspaces continue to work without any config migration.

## Original prompt
Add a config setting to the Vellum assistant for a custom system prompt prefix that gets injected at the very beginning of the system prompt. this should default to null and do nothing
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24565" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
