### PR TITLE
fix(slack): show ACL denial once per thread

### DIFF
--- a/assistant/src/__tests__/slack-inbound-verification.test.ts
+++ b/assistant/src/__tests__/slack-inbound-verification.test.ts
@@ -340,7 +340,7 @@ describe("Slack inbound trusted contact verification", () => {
     if (!releaseFirstFailure) {
       throw new Error("Expected first Slack denial delivery to block");
     }
-    const rejectFirstFailure = releaseFirstFailure;
+    const rejectFirstFailure: (reason?: unknown) => void = releaseFirstFailure;
 
     const req3 = buildSlackInboundRequest({
       replyCallbackUrl: threadReplyCallbackUrl,

--- a/assistant/src/__tests__/slack-inbound-verification.test.ts
+++ b/assistant/src/__tests__/slack-inbound-verification.test.ts
@@ -46,16 +46,25 @@ const deliverReplyCalls: Array<{
   url: string;
   payload: Record<string, unknown>;
 }> = [];
+let deliverChannelReplyImpl:
+  | ((url: string, payload: Record<string, unknown>) => Promise<void>)
+  | null = null;
 mock.module("../runtime/gateway-client.js", () => ({
   deliverChannelReply: async (
     url: string,
     payload: Record<string, unknown>,
   ) => {
     deliverReplyCalls.push({ url, payload });
+    if (deliverChannelReplyImpl) {
+      await deliverChannelReplyImpl(url, payload);
+    }
   },
 }));
 
-import { createGuardianBinding } from "../contacts/contacts-write.js";
+import {
+  createGuardianBinding,
+  upsertContactChannel,
+} from "../contacts/contacts-write.js";
 import { getDb, initializeDb } from "../memory/db.js";
 import { findActiveSession } from "../runtime/channel-verification-service.js";
 import { handleChannelInbound } from "../runtime/routes/channel-routes.js";
@@ -83,6 +92,7 @@ function resetState(): void {
   db.run("DELETE FROM contacts");
   emitSignalCalls.length = 0;
   deliverReplyCalls.length = 0;
+  deliverChannelReplyImpl = null;
   clearSlackAclDenyNotificationCache();
 }
 
@@ -285,6 +295,109 @@ describe("Slack inbound trusted contact verification", () => {
     expect(deliverReplyCalls[2].url).toBe(secondThreadCallbackUrl);
     expect(deliverReplyCalls[2].payload.ephemeral).toBe(true);
     expect(deliverReplyCalls[2].payload.user).toBe("U0123UNKNOWN");
+  });
+
+  test("failed threaded Slack ACL delivery does not suppress a later retry in the same thread", async () => {
+    const threadReplyCallbackUrl =
+      "http://localhost:7830/deliver/slack?channel=C0123CHANNEL&threadTs=1700000000.000100";
+
+    const req1 = buildSlackInboundRequest({
+      replyCallbackUrl: threadReplyCallbackUrl,
+    });
+    await handleChannelInbound(req1, undefined, TEST_BEARER_TOKEN);
+
+    let releaseFirstFailure: ((reason?: unknown) => void) | null = null;
+    let denialAttemptCount = 0;
+    deliverChannelReplyImpl = async (_url, payload) => {
+      const text = payload.text;
+      if (
+        payload.ephemeral === true &&
+        typeof text === "string" &&
+        text.includes("don't have access to talk to me")
+      ) {
+        denialAttemptCount += 1;
+        if (denialAttemptCount === 1) {
+          await new Promise<never>((_resolve, reject) => {
+            releaseFirstFailure = reject;
+          });
+        }
+      }
+    };
+
+    const req2 = buildSlackInboundRequest({
+      replyCallbackUrl: threadReplyCallbackUrl,
+      externalMessageId: `msg-${Date.now()}-second`,
+    });
+    const resp2Promise = handleChannelInbound(
+      req2,
+      undefined,
+      TEST_BEARER_TOKEN,
+    );
+
+    while (!releaseFirstFailure) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+
+    const req3 = buildSlackInboundRequest({
+      replyCallbackUrl: threadReplyCallbackUrl,
+      externalMessageId: `msg-${Date.now()}-third`,
+    });
+    const resp3Promise = handleChannelInbound(
+      req3,
+      undefined,
+      TEST_BEARER_TOKEN,
+    );
+
+    releaseFirstFailure(new Error("slack delivery failed"));
+
+    const [resp2, resp3] = await Promise.all([resp2Promise, resp3Promise]);
+    const json2 = (await resp2.json()) as Record<string, unknown>;
+    const json3 = (await resp3.json()) as Record<string, unknown>;
+
+    expect(json2.reason).toBe("not_a_member");
+    expect(json3.reason).toBe("not_a_member");
+    expect(denialAttemptCount).toBe(2);
+  });
+
+  test("policy deny uses the same once-per-thread Slack dedupe", async () => {
+    const threadReplyCallbackUrl =
+      "http://localhost:7830/deliver/slack?channel=C0123CHANNEL&threadTs=1700000000.000100";
+
+    upsertContactChannel({
+      channelType: "slack",
+      externalUserId: "U0123UNKNOWN",
+      externalChatId: "C0123CHANNEL",
+      displayName: "Alice Unknown",
+      status: "active",
+      policy: "deny",
+    });
+
+    const req1 = buildSlackInboundRequest({
+      replyCallbackUrl: threadReplyCallbackUrl,
+    });
+    const resp1 = await handleChannelInbound(
+      req1,
+      undefined,
+      TEST_BEARER_TOKEN,
+    );
+    const json1 = (await resp1.json()) as Record<string, unknown>;
+    expect(json1.reason).toBe("policy_deny");
+
+    const req2 = buildSlackInboundRequest({
+      replyCallbackUrl: threadReplyCallbackUrl,
+      externalMessageId: `msg-${Date.now()}-second`,
+    });
+    const resp2 = await handleChannelInbound(
+      req2,
+      undefined,
+      TEST_BEARER_TOKEN,
+    );
+    const json2 = (await resp2.json()) as Record<string, unknown>;
+    expect(json2.reason).toBe("policy_deny");
+
+    expect(deliverReplyCalls).toHaveLength(1);
+    expect(deliverReplyCalls[0].payload.ephemeral).toBe(true);
+    expect(deliverReplyCalls[0].payload.user).toBe("U0123UNKNOWN");
   });
 
   test("different Slack user is not suppressed by existing session for another user", async () => {

--- a/assistant/src/__tests__/slack-inbound-verification.test.ts
+++ b/assistant/src/__tests__/slack-inbound-verification.test.ts
@@ -59,6 +59,7 @@ import { createGuardianBinding } from "../contacts/contacts-write.js";
 import { getDb, initializeDb } from "../memory/db.js";
 import { findActiveSession } from "../runtime/channel-verification-service.js";
 import { handleChannelInbound } from "../runtime/routes/channel-routes.js";
+import { clearSlackAclDenyNotificationCache } from "../runtime/routes/inbound-stages/acl-enforcement.js";
 
 initializeDb();
 
@@ -82,6 +83,7 @@ function resetState(): void {
   db.run("DELETE FROM contacts");
   emitSignalCalls.length = 0;
   deliverReplyCalls.length = 0;
+  clearSlackAclDenyNotificationCache();
 }
 
 function buildSlackInboundRequest(
@@ -198,6 +200,91 @@ describe("Slack inbound trusted contact verification", () => {
     expect(json2.reason).toBe("not_a_member");
 
     // No DM was sent at all
+  });
+
+  test("threaded Slack ACL reply is only shown once per thread after the verification challenge already exists", async () => {
+    const threadReplyCallbackUrl =
+      "http://localhost:7830/deliver/slack?channel=C0123CHANNEL&threadTs=1700000000.000100";
+
+    const req1 = buildSlackInboundRequest({
+      replyCallbackUrl: threadReplyCallbackUrl,
+    });
+    const resp1 = await handleChannelInbound(
+      req1,
+      undefined,
+      TEST_BEARER_TOKEN,
+    );
+    const json1 = (await resp1.json()) as Record<string, unknown>;
+    expect(json1.reason).toBe("verification_challenge_sent");
+
+    const req2 = buildSlackInboundRequest({
+      replyCallbackUrl: threadReplyCallbackUrl,
+      externalMessageId: `msg-${Date.now()}-second`,
+    });
+    const resp2 = await handleChannelInbound(
+      req2,
+      undefined,
+      TEST_BEARER_TOKEN,
+    );
+    const json2 = (await resp2.json()) as Record<string, unknown>;
+    expect(json2.reason).toBe("not_a_member");
+
+    const req3 = buildSlackInboundRequest({
+      replyCallbackUrl: threadReplyCallbackUrl,
+      externalMessageId: `msg-${Date.now()}-third`,
+    });
+    const resp3 = await handleChannelInbound(
+      req3,
+      undefined,
+      TEST_BEARER_TOKEN,
+    );
+    const json3 = (await resp3.json()) as Record<string, unknown>;
+    expect(json3.reason).toBe("not_a_member");
+
+    expect(deliverReplyCalls).toHaveLength(2);
+    expect(deliverReplyCalls[1].url).toBe(threadReplyCallbackUrl);
+    expect(deliverReplyCalls[1].payload.ephemeral).toBe(true);
+    expect(deliverReplyCalls[1].payload.user).toBe("U0123UNKNOWN");
+    expect(
+      (deliverReplyCalls[1].payload.text as string).includes(
+        "don't have access to talk to me",
+      ),
+    ).toBe(true);
+  });
+
+  test("threaded Slack ACL reply is shown again in a different thread", async () => {
+    const firstThreadCallbackUrl =
+      "http://localhost:7830/deliver/slack?channel=C0123CHANNEL&threadTs=1700000000.000100";
+    const secondThreadCallbackUrl =
+      "http://localhost:7830/deliver/slack?channel=C0123CHANNEL&threadTs=1700000000.000200";
+
+    const req1 = buildSlackInboundRequest({
+      replyCallbackUrl: firstThreadCallbackUrl,
+    });
+    await handleChannelInbound(req1, undefined, TEST_BEARER_TOKEN);
+
+    const req2 = buildSlackInboundRequest({
+      replyCallbackUrl: firstThreadCallbackUrl,
+      externalMessageId: `msg-${Date.now()}-second`,
+    });
+    await handleChannelInbound(req2, undefined, TEST_BEARER_TOKEN);
+
+    const req3 = buildSlackInboundRequest({
+      replyCallbackUrl: secondThreadCallbackUrl,
+      externalMessageId: `msg-${Date.now()}-third`,
+    });
+    const resp3 = await handleChannelInbound(
+      req3,
+      undefined,
+      TEST_BEARER_TOKEN,
+    );
+    const json3 = (await resp3.json()) as Record<string, unknown>;
+
+    expect(json3.reason).toBe("not_a_member");
+    expect(deliverReplyCalls).toHaveLength(3);
+    expect(deliverReplyCalls[2].url).toBe(secondThreadCallbackUrl);
+    expect(deliverReplyCalls[2].payload.ephemeral).toBe(true);
+    expect(deliverReplyCalls[2].payload.user).toBe("U0123UNKNOWN");
   });
 
   test("different Slack user is not suppressed by existing session for another user", async () => {

--- a/assistant/src/__tests__/slack-inbound-verification.test.ts
+++ b/assistant/src/__tests__/slack-inbound-verification.test.ts
@@ -337,6 +337,10 @@ describe("Slack inbound trusted contact verification", () => {
     while (!releaseFirstFailure) {
       await new Promise((resolve) => setTimeout(resolve, 0));
     }
+    if (!releaseFirstFailure) {
+      throw new Error("Expected first Slack denial delivery to block");
+    }
+    const rejectFirstFailure = releaseFirstFailure;
 
     const req3 = buildSlackInboundRequest({
       replyCallbackUrl: threadReplyCallbackUrl,
@@ -348,7 +352,7 @@ describe("Slack inbound trusted contact verification", () => {
       TEST_BEARER_TOKEN,
     );
 
-    releaseFirstFailure(new Error("slack delivery failed"));
+    rejectFirstFailure(new Error("slack delivery failed"));
 
     const [resp2, resp3] = await Promise.all([resp2Promise, resp3Promise]);
     const json2 = (await resp2.json()) as Record<string, unknown>;
@@ -364,7 +368,7 @@ describe("Slack inbound trusted contact verification", () => {
       "http://localhost:7830/deliver/slack?channel=C0123CHANNEL&threadTs=1700000000.000100";
 
     upsertContactChannel({
-      channelType: "slack",
+      sourceChannel: "slack",
       externalUserId: "U0123UNKNOWN",
       externalChatId: "C0123CHANNEL",
       displayName: "Alice Unknown",

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
@@ -57,6 +57,7 @@ const inFlightSlackAclDenyNotifications = new Map<
 >();
 
 export const SLACK_ACL_DENY_DEDUP_TTL_MS = 24 * 60 * 60 * 1000;
+const SLACK_ACL_DENY_IN_FLIGHT_WAIT_MS = 250;
 
 /**
  * Resolve the guardian's display name for use in requester-facing messages.
@@ -150,7 +151,11 @@ async function reserveSlackAclDenyNotification(params: {
   canonicalAssistantId: string;
   conversationExternalId: string;
   requesterUserId: string | undefined;
-}): Promise<{ shouldDeliver: boolean; dedupeKey?: string }> {
+}): Promise<{
+  shouldDeliver: boolean;
+  dedupeKey?: string;
+  ownsReservation?: boolean;
+}> {
   const dedupeKey = buildSlackAclDenyNotificationKey(params);
   if (!dedupeKey) {
     return { shouldDeliver: true };
@@ -167,14 +172,50 @@ async function reserveSlackAclDenyNotification(params: {
         dedupeKey,
         createSlackAclDenyNotificationReservation(),
       );
-      return { shouldDeliver: true, dedupeKey };
+      return { shouldDeliver: true, dedupeKey, ownsReservation: true };
     }
 
-    const delivered = await inFlight.settled;
-    if (delivered) {
+    const settled = await Promise.race([
+      inFlight.settled.then(
+        (delivered) =>
+          ({ kind: "settled" as const, delivered }) satisfies {
+            kind: "settled";
+            delivered: boolean;
+          },
+      ),
+      new Promise<{ kind: "timeout" }>((resolve) => {
+        const timer = setTimeout(() => {
+          resolve({ kind: "timeout" });
+        }, SLACK_ACL_DENY_IN_FLIGHT_WAIT_MS);
+        (timer as { unref?: () => void }).unref?.();
+      }),
+    ]);
+
+    if (settled.kind === "timeout") {
+      return { shouldDeliver: true, dedupeKey, ownsReservation: false };
+    }
+
+    if (settled.delivered) {
       return { shouldDeliver: false };
     }
   }
+}
+
+function markSlackAclDenyNotificationDelivered(
+  dedupeKey: string | undefined,
+): void {
+  if (!dedupeKey) return;
+
+  const existingTimer = recentSlackAclDenyNotifications.get(dedupeKey);
+  if (existingTimer) {
+    clearTimeout(existingTimer);
+  }
+
+  const timer = setTimeout(() => {
+    recentSlackAclDenyNotifications.delete(dedupeKey);
+  }, SLACK_ACL_DENY_DEDUP_TTL_MS);
+  (timer as { unref?: () => void }).unref?.();
+  recentSlackAclDenyNotifications.set(dedupeKey, timer);
 }
 
 function finalizeSlackAclDenyNotification(
@@ -184,22 +225,17 @@ function finalizeSlackAclDenyNotification(
   if (!dedupeKey) return;
 
   const inFlight = inFlightSlackAclDenyNotifications.get(dedupeKey);
-  if (!inFlight) return;
+  if (!inFlight) {
+    if (delivered) {
+      markSlackAclDenyNotificationDelivered(dedupeKey);
+    }
+    return;
+  }
 
   inFlightSlackAclDenyNotifications.delete(dedupeKey);
   if (delivered) {
-    const existingTimer = recentSlackAclDenyNotifications.get(dedupeKey);
-    if (existingTimer) {
-      clearTimeout(existingTimer);
-    }
-
-    const timer = setTimeout(() => {
-      recentSlackAclDenyNotifications.delete(dedupeKey);
-    }, SLACK_ACL_DENY_DEDUP_TTL_MS);
-    (timer as { unref?: () => void }).unref?.();
-    recentSlackAclDenyNotifications.set(dedupeKey, timer);
+    markSlackAclDenyNotificationDelivered(dedupeKey);
   }
-
   inFlight.resolve(delivered);
 }
 
@@ -601,9 +637,18 @@ export async function enforceIngressAcl(
                 mintBearerToken(),
               );
               replyDelivered = true;
-              finalizeSlackAclDenyNotification(slackAclReply.dedupeKey, true);
+              if (slackAclReply.ownsReservation) {
+                finalizeSlackAclDenyNotification(slackAclReply.dedupeKey, true);
+              } else {
+                markSlackAclDenyNotificationDelivered(slackAclReply.dedupeKey);
+              }
             } catch (err) {
-              finalizeSlackAclDenyNotification(slackAclReply.dedupeKey, false);
+              if (slackAclReply.ownsReservation) {
+                finalizeSlackAclDenyNotification(
+                  slackAclReply.dedupeKey,
+                  false,
+                );
+              }
               log.error(
                 { err, conversationExternalId },
                 "Failed to deliver ACL rejection reply",
@@ -890,12 +935,23 @@ export async function enforceIngressAcl(
                   mintBearerToken(),
                 );
                 inactiveReplyDelivered = true;
-                finalizeSlackAclDenyNotification(slackAclReply.dedupeKey, true);
+                if (slackAclReply.ownsReservation) {
+                  finalizeSlackAclDenyNotification(
+                    slackAclReply.dedupeKey,
+                    true,
+                  );
+                } else {
+                  markSlackAclDenyNotificationDelivered(
+                    slackAclReply.dedupeKey,
+                  );
+                }
               } catch (err) {
-                finalizeSlackAclDenyNotification(
-                  slackAclReply.dedupeKey,
-                  false,
-                );
+                if (slackAclReply.ownsReservation) {
+                  finalizeSlackAclDenyNotification(
+                    slackAclReply.dedupeKey,
+                    false,
+                  );
+                }
                 log.error(
                   { err, conversationExternalId },
                   "Failed to deliver ACL rejection reply",
@@ -954,9 +1010,18 @@ export async function enforceIngressAcl(
                 mintBearerToken(),
               );
               denyReplyDelivered = true;
-              finalizeSlackAclDenyNotification(slackAclReply.dedupeKey, true);
+              if (slackAclReply.ownsReservation) {
+                finalizeSlackAclDenyNotification(slackAclReply.dedupeKey, true);
+              } else {
+                markSlackAclDenyNotificationDelivered(slackAclReply.dedupeKey);
+              }
             } catch (err) {
-              finalizeSlackAclDenyNotification(slackAclReply.dedupeKey, false);
+              if (slackAclReply.ownsReservation) {
+                finalizeSlackAclDenyNotification(
+                  slackAclReply.dedupeKey,
+                  false,
+                );
+              }
               log.error(
                 { err, conversationExternalId },
                 "Failed to deliver ACL rejection reply",

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
@@ -24,6 +24,7 @@ import {
   findByInviteCodeHash,
   findByInviteCodeHashAnyChannel,
 } from "../../../memory/invite-store.js";
+import { extractThreadTsFromCallbackUrl } from "../../../memory/slack-thread-store.js";
 import { MESSAGE_PREVIEW_MAX_LENGTH } from "../../../notifications/copy-composer.js";
 import { resolveGuardianName } from "../../../prompts/user-reference.js";
 import { getLogger } from "../../../util/logger.js";
@@ -46,6 +47,13 @@ import {
 import { getInviteRedemptionReply } from "../../invite-redemption-templates.js";
 
 const log = getLogger("runtime-http");
+const recentSlackAclDenyNotifications = new Map<
+  string,
+  ReturnType<typeof setTimeout>
+>();
+const inFlightSlackAclDenyNotifications = new Set<string>();
+
+export const SLACK_ACL_DENY_DEDUP_TTL_MS = 24 * 60 * 60 * 1000;
 
 /**
  * Resolve the guardian's display name for use in requester-facing messages.
@@ -81,6 +89,77 @@ function resolveGuardianLabel(
 
   // No anchored guardian found — use generic fallback.
   return resolveGuardianName(undefined);
+}
+
+export function clearSlackAclDenyNotificationCache(): void {
+  for (const timer of recentSlackAclDenyNotifications.values()) {
+    clearTimeout(timer);
+  }
+  recentSlackAclDenyNotifications.clear();
+  inFlightSlackAclDenyNotifications.clear();
+}
+
+function reserveSlackAclDenyNotification(params: {
+  sourceChannel: ChannelId;
+  replyCallbackUrl: string | undefined;
+  canonicalAssistantId: string;
+  conversationExternalId: string;
+  requesterUserId: string | undefined;
+}): { shouldDeliver: boolean; dedupeKey?: string } {
+  const {
+    sourceChannel,
+    replyCallbackUrl,
+    canonicalAssistantId,
+    conversationExternalId,
+    requesterUserId,
+  } = params;
+
+  if (
+    sourceChannel !== "slack" ||
+    !replyCallbackUrl ||
+    !requesterUserId?.trim()
+  ) {
+    return { shouldDeliver: true };
+  }
+
+  const threadTs = extractThreadTsFromCallbackUrl(replyCallbackUrl);
+  if (!threadTs) {
+    return { shouldDeliver: true };
+  }
+
+  const dedupeKey = `slack-acl-deny:${canonicalAssistantId}:${conversationExternalId}:${threadTs}:${requesterUserId}`;
+  if (
+    recentSlackAclDenyNotifications.has(dedupeKey) ||
+    inFlightSlackAclDenyNotifications.has(dedupeKey)
+  ) {
+    return { shouldDeliver: false };
+  }
+
+  inFlightSlackAclDenyNotifications.add(dedupeKey);
+  return { shouldDeliver: true, dedupeKey };
+}
+
+function releaseSlackAclDenyNotification(dedupeKey: string | undefined): void {
+  if (!dedupeKey) return;
+  inFlightSlackAclDenyNotifications.delete(dedupeKey);
+}
+
+function markSlackAclDenyNotificationDelivered(
+  dedupeKey: string | undefined,
+): void {
+  if (!dedupeKey) return;
+
+  inFlightSlackAclDenyNotifications.delete(dedupeKey);
+  const existingTimer = recentSlackAclDenyNotifications.get(dedupeKey);
+  if (existingTimer) {
+    clearTimeout(existingTimer);
+  }
+
+  const timer = setTimeout(() => {
+    recentSlackAclDenyNotifications.delete(dedupeKey);
+  }, SLACK_ACL_DENY_DEDUP_TTL_MS);
+  (timer as { unref?: () => void }).unref?.();
+  recentSlackAclDenyNotifications.set(dedupeKey, timer);
 }
 
 // ---------------------------------------------------------------------------
@@ -451,29 +530,44 @@ export async function enforceIngressAcl(
           ? `Hmm looks like you don't have access to talk to me. I'll let ${resolveGuardianLabel(sourceChannel, canonicalAssistantId)} know you tried talking to me and get back to you.`
           : "Sorry, you haven't been approved to message this assistant.";
         let replyDelivered = false;
+        let replySuppressed = false;
         if (replyCallbackUrl) {
           const replyPayload: Parameters<typeof deliverChannelReply>[1] = {
             chatId: conversationExternalId,
             text: replyText,
             assistantId,
           };
+          const requesterUserId = canonicalSenderId ?? rawSenderId;
+          const slackAclReply = reserveSlackAclDenyNotification({
+            sourceChannel,
+            replyCallbackUrl,
+            canonicalAssistantId,
+            conversationExternalId,
+            requesterUserId,
+          });
           // On Slack, send as ephemeral so only the requester sees the rejection
-          if (sourceChannel === "slack" && (canonicalSenderId ?? rawSenderId)) {
+          if (sourceChannel === "slack" && requesterUserId) {
             replyPayload.ephemeral = true;
-            replyPayload.user = (canonicalSenderId ?? rawSenderId)!;
+            replyPayload.user = requesterUserId;
           }
-          try {
-            await deliverChannelReply(
-              replyCallbackUrl,
-              replyPayload,
-              mintBearerToken(),
-            );
-            replyDelivered = true;
-          } catch (err) {
-            log.error(
-              { err, conversationExternalId },
-              "Failed to deliver ACL rejection reply",
-            );
+          if (!slackAclReply.shouldDeliver) {
+            replySuppressed = true;
+          } else {
+            try {
+              await deliverChannelReply(
+                replyCallbackUrl,
+                replyPayload,
+                mintBearerToken(),
+              );
+              replyDelivered = true;
+              markSlackAclDenyNotificationDelivered(slackAclReply.dedupeKey);
+            } catch (err) {
+              releaseSlackAclDenyNotification(slackAclReply.dedupeKey);
+              log.error(
+                { err, conversationExternalId },
+                "Failed to deliver ACL rejection reply",
+              );
+            }
           }
         }
 
@@ -485,7 +579,7 @@ export async function enforceIngressAcl(
             reason: "not_a_member",
             // Include reply text so the gateway can deliver directly when
             // callback delivery failed (e.g. signing-key mismatch → 401).
-            ...(!replyDelivered && { replyText }),
+            ...(!replyDelivered && !replySuppressed && { replyText }),
           }),
           guardianVerifyCode,
         };
@@ -723,6 +817,7 @@ export async function enforceIngressAcl(
             ? `Hmm looks like you don't have access to talk to me. I'll let ${resolveGuardianLabel(sourceChannel, canonicalAssistantId)} know you tried talking to me and get back to you.`
             : "Sorry, you haven't been approved to message this assistant.";
           let inactiveReplyDelivered = false;
+          let inactiveReplySuppressed = false;
           if (replyCallbackUrl) {
             const inactiveReplyPayload: Parameters<
               typeof deliverChannelReply
@@ -731,26 +826,37 @@ export async function enforceIngressAcl(
               text: inactiveReplyText,
               assistantId,
             };
+            const requesterUserId = canonicalSenderId ?? rawSenderId;
+            const slackAclReply = reserveSlackAclDenyNotification({
+              sourceChannel,
+              replyCallbackUrl,
+              canonicalAssistantId,
+              conversationExternalId,
+              requesterUserId,
+            });
             // On Slack, send as ephemeral so only the requester sees the rejection
-            if (
-              sourceChannel === "slack" &&
-              (canonicalSenderId ?? rawSenderId)
-            ) {
+            if (sourceChannel === "slack" && requesterUserId) {
               inactiveReplyPayload.ephemeral = true;
-              inactiveReplyPayload.user = (canonicalSenderId ?? rawSenderId)!;
+              inactiveReplyPayload.user = requesterUserId;
             }
-            try {
-              await deliverChannelReply(
-                replyCallbackUrl,
-                inactiveReplyPayload,
-                mintBearerToken(),
-              );
-              inactiveReplyDelivered = true;
-            } catch (err) {
-              log.error(
-                { err, conversationExternalId },
-                "Failed to deliver ACL rejection reply",
-              );
+            if (!slackAclReply.shouldDeliver) {
+              inactiveReplySuppressed = true;
+            } else {
+              try {
+                await deliverChannelReply(
+                  replyCallbackUrl,
+                  inactiveReplyPayload,
+                  mintBearerToken(),
+                );
+                inactiveReplyDelivered = true;
+                markSlackAclDenyNotificationDelivered(slackAclReply.dedupeKey);
+              } catch (err) {
+                releaseSlackAclDenyNotification(slackAclReply.dedupeKey);
+                log.error(
+                  { err, conversationExternalId },
+                  "Failed to deliver ACL rejection reply",
+                );
+              }
             }
           }
           return {
@@ -759,7 +865,8 @@ export async function enforceIngressAcl(
               accepted: true,
               denied: true,
               reason: `member_${channelStatusToMemberStatus(resolvedMember.channel.status)}`,
-              ...(!inactiveReplyDelivered && { replyText: inactiveReplyText }),
+              ...(!inactiveReplyDelivered &&
+                !inactiveReplySuppressed && { replyText: inactiveReplyText }),
             }),
             guardianVerifyCode,
           };

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
@@ -51,7 +51,10 @@ const recentSlackAclDenyNotifications = new Map<
   string,
   ReturnType<typeof setTimeout>
 >();
-const inFlightSlackAclDenyNotifications = new Set<string>();
+const inFlightSlackAclDenyNotifications = new Map<
+  string,
+  { settled: Promise<boolean>; resolve: (delivered: boolean) => void }
+>();
 
 export const SLACK_ACL_DENY_DEDUP_TTL_MS = 24 * 60 * 60 * 1000;
 
@@ -99,13 +102,13 @@ export function clearSlackAclDenyNotificationCache(): void {
   inFlightSlackAclDenyNotifications.clear();
 }
 
-function reserveSlackAclDenyNotification(params: {
+function buildSlackAclDenyNotificationKey(params: {
   sourceChannel: ChannelId;
   replyCallbackUrl: string | undefined;
   canonicalAssistantId: string;
   conversationExternalId: string;
   requesterUserId: string | undefined;
-}): { shouldDeliver: boolean; dedupeKey?: string } {
+}): string | null {
   const {
     sourceChannel,
     replyCallbackUrl,
@@ -119,47 +122,85 @@ function reserveSlackAclDenyNotification(params: {
     !replyCallbackUrl ||
     !requesterUserId?.trim()
   ) {
-    return { shouldDeliver: true };
+    return null;
   }
 
   const threadTs = extractThreadTsFromCallbackUrl(replyCallbackUrl);
   if (!threadTs) {
+    return null;
+  }
+
+  return `slack-acl-deny:${canonicalAssistantId}:${conversationExternalId}:${threadTs}:${requesterUserId}`;
+}
+
+function createSlackAclDenyNotificationReservation(): {
+  settled: Promise<boolean>;
+  resolve: (delivered: boolean) => void;
+} {
+  let resolve!: (delivered: boolean) => void;
+  const settled = new Promise<boolean>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { settled, resolve };
+}
+
+async function reserveSlackAclDenyNotification(params: {
+  sourceChannel: ChannelId;
+  replyCallbackUrl: string | undefined;
+  canonicalAssistantId: string;
+  conversationExternalId: string;
+  requesterUserId: string | undefined;
+}): Promise<{ shouldDeliver: boolean; dedupeKey?: string }> {
+  const dedupeKey = buildSlackAclDenyNotificationKey(params);
+  if (!dedupeKey) {
     return { shouldDeliver: true };
   }
 
-  const dedupeKey = `slack-acl-deny:${canonicalAssistantId}:${conversationExternalId}:${threadTs}:${requesterUserId}`;
-  if (
-    recentSlackAclDenyNotifications.has(dedupeKey) ||
-    inFlightSlackAclDenyNotifications.has(dedupeKey)
-  ) {
-    return { shouldDeliver: false };
+  while (true) {
+    if (recentSlackAclDenyNotifications.has(dedupeKey)) {
+      return { shouldDeliver: false };
+    }
+
+    const inFlight = inFlightSlackAclDenyNotifications.get(dedupeKey);
+    if (!inFlight) {
+      inFlightSlackAclDenyNotifications.set(
+        dedupeKey,
+        createSlackAclDenyNotificationReservation(),
+      );
+      return { shouldDeliver: true, dedupeKey };
+    }
+
+    const delivered = await inFlight.settled;
+    if (delivered) {
+      return { shouldDeliver: false };
+    }
   }
-
-  inFlightSlackAclDenyNotifications.add(dedupeKey);
-  return { shouldDeliver: true, dedupeKey };
 }
 
-function releaseSlackAclDenyNotification(dedupeKey: string | undefined): void {
-  if (!dedupeKey) return;
-  inFlightSlackAclDenyNotifications.delete(dedupeKey);
-}
-
-function markSlackAclDenyNotificationDelivered(
+function finalizeSlackAclDenyNotification(
   dedupeKey: string | undefined,
+  delivered: boolean,
 ): void {
   if (!dedupeKey) return;
 
+  const inFlight = inFlightSlackAclDenyNotifications.get(dedupeKey);
+  if (!inFlight) return;
+
   inFlightSlackAclDenyNotifications.delete(dedupeKey);
-  const existingTimer = recentSlackAclDenyNotifications.get(dedupeKey);
-  if (existingTimer) {
-    clearTimeout(existingTimer);
+  if (delivered) {
+    const existingTimer = recentSlackAclDenyNotifications.get(dedupeKey);
+    if (existingTimer) {
+      clearTimeout(existingTimer);
+    }
+
+    const timer = setTimeout(() => {
+      recentSlackAclDenyNotifications.delete(dedupeKey);
+    }, SLACK_ACL_DENY_DEDUP_TTL_MS);
+    (timer as { unref?: () => void }).unref?.();
+    recentSlackAclDenyNotifications.set(dedupeKey, timer);
   }
 
-  const timer = setTimeout(() => {
-    recentSlackAclDenyNotifications.delete(dedupeKey);
-  }, SLACK_ACL_DENY_DEDUP_TTL_MS);
-  (timer as { unref?: () => void }).unref?.();
-  recentSlackAclDenyNotifications.set(dedupeKey, timer);
+  inFlight.resolve(delivered);
 }
 
 // ---------------------------------------------------------------------------
@@ -538,7 +579,7 @@ export async function enforceIngressAcl(
             assistantId,
           };
           const requesterUserId = canonicalSenderId ?? rawSenderId;
-          const slackAclReply = reserveSlackAclDenyNotification({
+          const slackAclReply = await reserveSlackAclDenyNotification({
             sourceChannel,
             replyCallbackUrl,
             canonicalAssistantId,
@@ -560,9 +601,9 @@ export async function enforceIngressAcl(
                 mintBearerToken(),
               );
               replyDelivered = true;
-              markSlackAclDenyNotificationDelivered(slackAclReply.dedupeKey);
+              finalizeSlackAclDenyNotification(slackAclReply.dedupeKey, true);
             } catch (err) {
-              releaseSlackAclDenyNotification(slackAclReply.dedupeKey);
+              finalizeSlackAclDenyNotification(slackAclReply.dedupeKey, false);
               log.error(
                 { err, conversationExternalId },
                 "Failed to deliver ACL rejection reply",
@@ -827,7 +868,7 @@ export async function enforceIngressAcl(
               assistantId,
             };
             const requesterUserId = canonicalSenderId ?? rawSenderId;
-            const slackAclReply = reserveSlackAclDenyNotification({
+            const slackAclReply = await reserveSlackAclDenyNotification({
               sourceChannel,
               replyCallbackUrl,
               canonicalAssistantId,
@@ -849,9 +890,12 @@ export async function enforceIngressAcl(
                   mintBearerToken(),
                 );
                 inactiveReplyDelivered = true;
-                markSlackAclDenyNotificationDelivered(slackAclReply.dedupeKey);
+                finalizeSlackAclDenyNotification(slackAclReply.dedupeKey, true);
               } catch (err) {
-                releaseSlackAclDenyNotification(slackAclReply.dedupeKey);
+                finalizeSlackAclDenyNotification(
+                  slackAclReply.dedupeKey,
+                  false,
+                );
                 log.error(
                   { err, conversationExternalId },
                   "Failed to deliver ACL rejection reply",
@@ -881,28 +925,43 @@ export async function enforceIngressAcl(
         const denyReplyText =
           "Sorry, you haven't been approved to message this assistant.";
         let denyReplyDelivered = false;
+        let denyReplySuppressed = false;
         if (replyCallbackUrl) {
           const denyPayload: Parameters<typeof deliverChannelReply>[1] = {
             chatId: conversationExternalId,
             text: denyReplyText,
             assistantId,
           };
-          if (sourceChannel === "slack" && (canonicalSenderId ?? rawSenderId)) {
+          const requesterUserId = canonicalSenderId ?? rawSenderId;
+          const slackAclReply = await reserveSlackAclDenyNotification({
+            sourceChannel,
+            replyCallbackUrl,
+            canonicalAssistantId,
+            conversationExternalId,
+            requesterUserId,
+          });
+          if (sourceChannel === "slack" && requesterUserId) {
             denyPayload.ephemeral = true;
-            denyPayload.user = (canonicalSenderId ?? rawSenderId)!;
+            denyPayload.user = requesterUserId;
           }
-          try {
-            await deliverChannelReply(
-              replyCallbackUrl,
-              denyPayload,
-              mintBearerToken(),
-            );
-            denyReplyDelivered = true;
-          } catch (err) {
-            log.error(
-              { err, conversationExternalId },
-              "Failed to deliver ACL rejection reply",
-            );
+          if (!slackAclReply.shouldDeliver) {
+            denyReplySuppressed = true;
+          } else {
+            try {
+              await deliverChannelReply(
+                replyCallbackUrl,
+                denyPayload,
+                mintBearerToken(),
+              );
+              denyReplyDelivered = true;
+              finalizeSlackAclDenyNotification(slackAclReply.dedupeKey, true);
+            } catch (err) {
+              finalizeSlackAclDenyNotification(slackAclReply.dedupeKey, false);
+              log.error(
+                { err, conversationExternalId },
+                "Failed to deliver ACL rejection reply",
+              );
+            }
           }
         }
         return {
@@ -911,7 +970,8 @@ export async function enforceIngressAcl(
             accepted: true,
             denied: true,
             reason: "policy_deny",
-            ...(!denyReplyDelivered && { replyText: denyReplyText }),
+            ...(!denyReplyDelivered &&
+              !denyReplySuppressed && { replyText: denyReplyText }),
           }),
           guardianVerifyCode,
         };


### PR DESCRIPTION
## Summary
- suppress repeated Slack ACL denial ephemerals for the same assistant, channel, thread, and requester after the first delivery
- apply the once-per-thread gate to both non-member and inactive-member denial paths without changing guardian request dedupe
- add focused Slack verification coverage for same-thread suppression and cross-thread delivery

## Original prompt
$do this but make sure it's based off of main (we are currently on a feature branch doing other work)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24566" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
