### PR TITLE
perf: add estimated row heights to prevent full LazyVStack re-measurement

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
@@ -226,6 +226,7 @@ struct MessageListContentView: View, Equatable {
                     providerCatalogHash: providerCatalogHash
                 )
                 .equatable()
+                .frame(minHeight: 60, alignment: .top)
             }
 
             ForEach(state.orphanSubagents) { subagent in


### PR DESCRIPTION
## Summary
- Add frame(minHeight: 60, alignment: .top) on each MessageCellView in the ForEach
- Gives LazyVStack an initial height estimate for unmeasured cells
- Reduces measureEstimates cost from O(n * depth) to O(n) for off-screen cells

Part of plan: layout-perf-fix.md (PR 4 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24567" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
