### PR TITLE
fix(host-browser): drop host_browser from macos capability set so bare-metal uses local Chromium

### DIFF
--- a/assistant/src/__tests__/host-proxy-interface.test.ts
+++ b/assistant/src/__tests__/host-proxy-interface.test.ts
@@ -46,9 +46,6 @@ describe("supportsHostProxy (runtime)", () => {
     expect(supportsHostProxy("macos", "host_bash")).toBe(true);
     expect(supportsHostProxy("macos", "host_file")).toBe(true);
     expect(supportsHostProxy("macos", "host_cu")).toBe(true);
-    // Browser tools fall back to the local Playwright Chromium on macos
-    // because the host_browser proxy path requires a Chrome extension
-    // that isn't guaranteed to be attached.
     expect(supportsHostProxy("macos", "host_browser")).toBe(false);
   });
 

--- a/assistant/src/__tests__/host-proxy-interface.test.ts
+++ b/assistant/src/__tests__/host-proxy-interface.test.ts
@@ -42,11 +42,14 @@ describe("supportsHostProxy (runtime)", () => {
     expect(supportsHostProxy("chrome-extension", "host_cu")).toBe(false);
   });
 
-  test("capability form grants everything to macOS", () => {
+  test("capability form grants host_bash/file/cu to macOS but not host_browser", () => {
     expect(supportsHostProxy("macos", "host_bash")).toBe(true);
     expect(supportsHostProxy("macos", "host_file")).toBe(true);
     expect(supportsHostProxy("macos", "host_cu")).toBe(true);
-    expect(supportsHostProxy("macos", "host_browser")).toBe(true);
+    // Browser tools fall back to the local Playwright Chromium on macos
+    // because the host_browser proxy path requires a Chrome extension
+    // that isn't guaranteed to be attached.
+    expect(supportsHostProxy("macos", "host_browser")).toBe(false);
   });
 
   test("capability form rejects everything for non-host-proxy interfaces", () => {

--- a/assistant/src/channels/__tests__/types.test.ts
+++ b/assistant/src/channels/__tests__/types.test.ts
@@ -58,7 +58,10 @@ describe("isInterfaceId", () => {
 });
 
 describe("supportsHostProxy", () => {
-  // ── macOS: supports every capability, and the no-arg form returns true. ──
+  // ── macOS: supports host_bash / host_file / host_cu, but NOT host_browser.
+  // The no-arg form still returns true (macos is a desktop host-proxy client),
+  // but host_browser is omitted because the proxy path needs a Chrome
+  // extension that isn't guaranteed to be attached. ──
   test("macos returns true (no capability)", () => {
     expect(supportsHostProxy("macos")).toBe(true);
   });
@@ -75,8 +78,11 @@ describe("supportsHostProxy", () => {
     expect(supportsHostProxy("macos", "host_cu")).toBe(true);
   });
 
-  test("macos returns true for host_browser", () => {
-    expect(supportsHostProxy("macos", "host_browser")).toBe(true);
+  test("macos returns false for host_browser", () => {
+    // macos-interface conversations fall back to the local Playwright
+    // Chromium for browser tools instead of relaying CDP through a
+    // Chrome extension that may not be attached.
+    expect(supportsHostProxy("macos", "host_browser")).toBe(false);
   });
 
   // ── chrome-extension: only host_browser. ──

--- a/assistant/src/channels/__tests__/types.test.ts
+++ b/assistant/src/channels/__tests__/types.test.ts
@@ -58,10 +58,7 @@ describe("isInterfaceId", () => {
 });
 
 describe("supportsHostProxy", () => {
-  // ── macOS: supports host_bash / host_file / host_cu, but NOT host_browser.
-  // The no-arg form still returns true (macos is a desktop host-proxy client),
-  // but host_browser is omitted because the proxy path needs a Chrome
-  // extension that isn't guaranteed to be attached. ──
+  // ── macOS: supports host_bash / host_file / host_cu, but NOT host_browser. ──
   test("macos returns true (no capability)", () => {
     expect(supportsHostProxy("macos")).toBe(true);
   });
@@ -79,9 +76,6 @@ describe("supportsHostProxy", () => {
   });
 
   test("macos returns false for host_browser", () => {
-    // macos-interface conversations fall back to the local Playwright
-    // Chromium for browser tools instead of relaying CDP through a
-    // Chrome extension that may not be attached.
     expect(supportsHostProxy("macos", "host_browser")).toBe(false);
   });
 

--- a/assistant/src/channels/types.ts
+++ b/assistant/src/channels/types.ts
@@ -117,16 +117,18 @@ export type HostProxyInterfaceId = "macos";
 /**
  * Whether the interface supports a host proxy capability.
  *
- * The no-arg form `supportsHostProxy(id)` asks "does this interface support
- * the full desktop host proxy set?" — it returns `true` only for macOS, which
- * supports all four capabilities, and is the type predicate that narrows
- * `InterfaceId` to `HostProxyInterfaceId`. It returns `false` for
- * chrome-extension because chrome-extension only supports `host_browser`,
- * and the no-arg form is the gate that legacy desktop-only call sites use
- * (e.g. preactivating computer-use, restoring all four proxies in the drain
- * queue). Callers that want to check a single capability — for example, to
- * decide whether to keep `hostBrowserProxy` available for chrome-extension —
- * should pass the capability explicitly: `supportsHostProxy(id, "host_browser")`.
+ * The no-arg form `supportsHostProxy(id)` asks "is this interface a desktop
+ * host-proxy client?" — it returns `true` only for macOS and is the type
+ * predicate that narrows `InterfaceId` to `HostProxyInterfaceId`. It returns
+ * `false` for chrome-extension because chrome-extension only supports
+ * `host_browser`, and the no-arg form is the gate that legacy desktop-only
+ * call sites use (e.g. preactivating computer-use, restoring host proxies
+ * in the drain queue). Callers that want to check a single capability —
+ * for example, to decide whether to keep `hostBrowserProxy` available for
+ * chrome-extension — should pass the capability explicitly:
+ * `supportsHostProxy(id, "host_browser")`. Note that macOS does NOT
+ * advertise `host_browser` support (browser tools fall back to the local
+ * Playwright Chromium); see the implementation comment below.
  */
 export function supportsHostProxy(id: InterfaceId): id is HostProxyInterfaceId;
 export function supportsHostProxy(
@@ -137,7 +139,15 @@ export function supportsHostProxy(
   id: InterfaceId,
   capability?: HostProxyCapability,
 ): boolean {
-  if (id === "macos") return true;
+  // macos supports host_bash / host_file / host_cu (serviced directly by
+  // the macOS app), but NOT host_browser. The host_browser proxy path
+  // requires a Chrome extension to be attached, which is not guaranteed
+  // for macos-interface conversations. Without this exclusion, browser
+  // tools would route CDP through host_browser_request and time out on
+  // bare-metal installs (and the e2e harness) where no extension is
+  // connected. Conversations that originate from the chrome-extension
+  // interface still get host_browser support below.
+  if (id === "macos") return capability !== "host_browser";
   if (id === "chrome-extension" && capability === "host_browser") return true;
   return false;
 }

--- a/assistant/src/channels/types.ts
+++ b/assistant/src/channels/types.ts
@@ -126,9 +126,7 @@ export type HostProxyInterfaceId = "macos";
  * in the drain queue). Callers that want to check a single capability —
  * for example, to decide whether to keep `hostBrowserProxy` available for
  * chrome-extension — should pass the capability explicitly:
- * `supportsHostProxy(id, "host_browser")`. Note that macOS does NOT
- * advertise `host_browser` support (browser tools fall back to the local
- * Playwright Chromium); see the implementation comment below.
+ * `supportsHostProxy(id, "host_browser")`.
  */
 export function supportsHostProxy(id: InterfaceId): id is HostProxyInterfaceId;
 export function supportsHostProxy(
@@ -139,14 +137,9 @@ export function supportsHostProxy(
   id: InterfaceId,
   capability?: HostProxyCapability,
 ): boolean {
-  // macos supports host_bash / host_file / host_cu (serviced directly by
-  // the macOS app), but NOT host_browser. The host_browser proxy path
-  // requires a Chrome extension to be attached, which is not guaranteed
-  // for macos-interface conversations. Without this exclusion, browser
-  // tools would route CDP through host_browser_request and time out on
-  // bare-metal installs (and the e2e harness) where no extension is
-  // connected. Conversations that originate from the chrome-extension
-  // interface still get host_browser support below.
+  // host_browser is excluded for macos because the proxy path requires a
+  // Chrome extension that isn't guaranteed to be attached; browser tools
+  // fall back to the local Playwright Chromium instead.
   if (id === "macos") return capability !== "host_browser";
   if (id === "chrome-extension" && capability === "host_browser") return true;
   return false;

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -139,6 +139,10 @@ export interface ProcessConversationContext {
   restoreProxyAvailability(): void;
   /** Restore only the host browser proxy (used by chrome-extension drains). */
   restoreBrowserProxyAvailability(): void;
+  /** Replace or clear the conversation's host browser proxy. */
+  setHostBrowserProxy(
+    proxy: import("./host-browser-proxy.js").HostBrowserProxy | undefined,
+  ): void;
   emitActivityState(
     phase:
       | "idle"
@@ -352,6 +356,18 @@ export async function drainQueue(
     if (sourceInterface && supportsHostProxy(sourceInterface)) {
       conversation.restoreProxyAvailability();
       conversation.addPreactivatedSkillId("computer-use");
+    }
+    // Tear down a stale hostBrowserProxy inherited from a prior turn on a
+    // different interface (e.g. chrome-extension installed one, then a
+    // macos turn drains). Without this, restoreProxyAvailability() above
+    // would re-enable the proxy and getCdpClient() would route browser
+    // tools through host_browser_request and hang waiting for a client
+    // that this turn's interface can't service.
+    if (
+      sourceInterface &&
+      !supportsHostProxy(sourceInterface, "host_browser")
+    ) {
+      conversation.setHostBrowserProxy(undefined);
     }
   }
 


### PR DESCRIPTION
## Summary

- Excludes \`host_browser\` from the macos host-proxy capability set in \`assistant/src/channels/types.ts\`. macos-interface conversations no longer install a \`HostBrowserProxy\`, so \`getCdpClient()\` falls through to \`createLocalCdpClient(...)\` and bare-metal browser tools drive the daemon's local Playwright Chromium directly (the pre-Phase-3 behavior).
- Updates the two unit tests that pinned the old unconditional-true behavior (\`channels/__tests__/types.test.ts\`, \`__tests__/host-proxy-interface.test.ts\`).
- The chrome-extension interface is unaffected — conversations that originate from the extension still get \`host_browser\` support and the CDP relay path.

## Why

Phase 2 of the host-browser-proxy rollout (#24159) made \`supportsHostProxy(\"macos\", \"host_browser\")\` return \`true\` unconditionally. Phase 3 (#24331) then routed every browser tool through \`getCdpClient()\`, which picks the extension transport whenever \`context.hostBrowserProxy\` is set on the conversation. On bare metal — including the desktop e2e Playwright case \`qa/cases/browser-skill.md\` in vellum-assistant-platform — the macOS app connects but no Chrome extension is attached, so \`host_browser_request\` messages time out after 30s and \`browser_navigate\` fails three times in a row before the test gives up.

The capability table conflated \"interface is macos\" with \"chrome extension is reachable.\" Those are not the same thing: extension presence is runtime state, not a compile-time fact about the interface.

## Fix shape

The minimal correct change is one line in \`supportsHostProxy\`:

\`\`\`ts
- if (id === \"macos\") return true;
+ if (id === \"macos\") return capability !== \"host_browser\";
\`\`\`

Effects:
- \`daemon/server.ts:1148\` no longer installs \`HostBrowserProxy\` for macos conversations.
- \`tools/browser/cdp-client/factory.ts:43\` sees \`context.hostBrowserProxy === undefined\` and returns \`createLocalCdpClient(...)\`.
- The no-arg form \`supportsHostProxy(\"macos\")\` still returns \`true\` (\`undefined !== \"host_browser\"\`), so the type predicate and all desktop-only call sites that gate on \"is this a desktop client?\" continue to work unchanged.
- \`host_bash\` / \`host_file\` / \`host_cu\` are unaffected — those are serviced directly by the macOS app, not via a separate extension leg.

## What this gives up

Desktop-app conversations can no longer relay browser commands to a Chrome extension running on the same Mac. Users who want \"drive my real Chrome\" still get it by connecting through the chrome-extension interface directly, which keeps the proxy path. If we want the desktop-app→extension relay back later, the right shape is for the macOS client to advertise extension presence at runtime (e.g. on transport metadata or via a \`client_capabilities\` message) and gate \`HostBrowserProxy\` installation on that runtime signal in \`server.ts:1148\`.

## Test plan

- [ ] \`bun test assistant/src/channels/__tests__/types.test.ts\`
- [ ] \`bun test assistant/src/__tests__/host-proxy-interface.test.ts\`
- [ ] \`bun test assistant/src/__tests__/host-browser-e2e-self-hosted-capability.test.ts\` (uses chrome-extension interface, should be unaffected)
- [ ] Run the \`browser-skill\` Playwright case in vellum-assistant-platform against a daemon built from this branch — expect \`browser_navigate\` to use the local Chromium and the screenshot step to succeed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24571" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
