### PR TITLE
perf: remove .transition() modifiers inside LazyVStack to prevent motionVectors

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
@@ -113,7 +113,6 @@ struct MessageListContentView: View, Equatable {
         }
         .frame(width: effectiveBubbleMaxWidth)
         .id("thinking-indicator")
-        .transition(.opacity)
     }
 
     @ViewBuilder
@@ -124,7 +123,6 @@ struct MessageListContentView: View, Equatable {
         )
         .frame(width: effectiveBubbleMaxWidth)
         .id("compacting-indicator")
-        .transition(.opacity)
     }
 
     @ViewBuilder
@@ -251,7 +249,6 @@ struct MessageListContentView: View, Equatable {
                     Spacer(minLength: 0)
                 }
                     .id("subagent-\(subagent.id)")
-                    .transition(.opacity)
             }
 
             if isUnanchoredThinking {
@@ -274,7 +271,6 @@ struct MessageListContentView: View, Equatable {
                 }
                 .frame(minHeight: turnMinHeight, alignment: .top)
                 .id("streaming-without-text-indicator")
-                .transition(.opacity)
             } else if isCompacting && !state.shouldShowThinkingIndicator && !state.canInlineProcessing {
                 VStack(spacing: 0) { compactingIndicatorRow() }
                     .frame(minHeight: turnMinHeight, alignment: .top)


### PR DESCRIPTION
## Summary
- Remove all .transition() modifiers from views inside the LazyVStack ForEach
- These bypass .transaction { animation = nil } and trigger motionVectors() on all children
- Views now appear/disappear instantly instead of fading

Part of plan: layout-explosion-remaining.md (PR 1 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24575" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
