### PR TITLE
perf: guard withAnimation calls to prevent layout explosion during message mutations

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
@@ -81,8 +81,10 @@ extension MessageListView {
                         scrollState.anchorSetTime = nil
                         scrollState.anchorTimeoutTask = nil
                         scrollState.transition(to: .followingBottom)
-                        _ = withAnimation(VAnimation.fast) {
-                            scrollState.requestPinToBottom(animated: true, userInitiated: true)
+                        Task { @MainActor in
+                            withAnimation(VAnimation.fast) {
+                                scrollState.requestPinToBottom(animated: true, userInitiated: true)
+                            }
                         }
                     }
             }
@@ -181,8 +183,10 @@ extension MessageListView {
             executeCoordinatorIntents(resolveIntents)
             // Keep scrollState in sync as runtime executor.
             scrollState.transition(to: .programmaticScroll(reason: .deepLinkAnchor(id: id)))
-            withAnimation {
-                scrollState.scrollTo?(id, .center)
+            Task { @MainActor in
+                withAnimation {
+                    scrollState.scrollTo?(id, .center)
+                }
             }
             flashHighlight(messageId: id)
             anchorMessageId = nil
@@ -349,8 +353,10 @@ extension MessageListView {
             // Notify coordinator that the anchor resolved.
             let resolveIntents = scrollCoordinator.handle(.anchorResolved(id: anchorId))
             executeCoordinatorIntents(resolveIntents)
-            withAnimation {
-                scrollState.scrollTo?(id, .center)
+            Task { @MainActor in
+                withAnimation {
+                    scrollState.scrollTo?(id, .center)
+                }
             }
             flashHighlight(messageId: id)
             anchorMessageId = nil
@@ -368,8 +374,10 @@ extension MessageListView {
                 anchorMessageId = nil
                 scrollState.anchorSetTime = nil
                 scrollState.anchorTimeoutTask = nil
-                _ = withAnimation(VAnimation.fast) {
-                    scrollState.requestPinToBottom(animated: true, userInitiated: true)
+                Task { @MainActor in
+                    withAnimation(VAnimation.fast) {
+                        scrollState.requestPinToBottom(animated: true, userInitiated: true)
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Wrap withAnimation calls in lifecycle handlers in Task { @MainActor in } 
- Decouples animation transaction from view update cycle
- Prevents animation context from leaking to LazyVStack and re-enabling motionVectors

Part of plan: layout-explosion-remaining.md (PR 2 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24576" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
