### PR TITLE
fix(macOS): remove .clipped() that clips top bar

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -653,7 +653,6 @@ struct MainWindowView: View {
                    alignment: .topLeading)
             .scaleEffect(zoomManager.zoomLevel, anchor: .topLeading)
             .frame(width: windowSize.width, height: windowSize.height, alignment: .topLeading)
-            .clipped()
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary
- Removes the `.clipped()` modifier added in #24559 that was clipping the top bar off-screen
- Keeps the `.topLeading` alignment fixes from that PR which correctly prevent sidebar clipping during zoom

## Test plan
- [x] Verified top bar is fully visible after the fix
- [ ] Verify zoom still works correctly without sidebar clipping

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24578" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
