### PR TITLE
fix(macOS): prevent chat view clipping in non-full-width dock

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -123,6 +123,24 @@ struct ChatView: View {
         let _ = os_signpost(.event, log: PerfSignposts.log, name: "ChatView.body")
         #endif
         ZStack {
+            // Invisible sizer that fills the parent's proposed width.
+            // A ZStack proposes its received proposal to each child, so
+            // Color.clear (greedy) reports the *container* width (e.g. the
+            // dock frame) regardless of the content's inflated size. This
+            // breaks the self-reinforcing loop where content renders at the
+            // 808pt chatColumnMaxWidth fallback, the ZStack expands to fit,
+            // and onGeometryChange on the ZStack locks containerWidth to
+            // that inflated value — causing permanent clipping in narrow
+            // containers like the app-editing chat dock.
+            Color.clear
+                .allowsHitTesting(false)
+                .accessibilityHidden(true)
+                .onGeometryChange(for: CGFloat.self) { proxy in
+                    proxy.size.width
+                } action: { newWidth in
+                    containerWidth = newWidth
+                }
+
             mainContentStack(containerWidth: containerWidth)
                 .background(alignment: .bottom) {
                     chatBackground
@@ -134,11 +152,6 @@ struct ChatView: View {
                 .animation(VAnimation.fast, value: viewModel.btwResponse != nil)
 
             dropTargetOverlay
-        }
-        .onGeometryChange(for: CGFloat.self) { proxy in
-            proxy.size.width
-        } action: { newWidth in
-            containerWidth = newWidth
         }
         .environment(\.dropActions, currentDropActions)
         .onDrop(of: [.fileURL, .image, .png, .tiff], isTargeted: $isDropTargeted) { providers in

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -138,6 +138,7 @@ struct ChatView: View {
                 .onGeometryChange(for: CGFloat.self) { proxy in
                     proxy.size.width
                 } action: { newWidth in
+                    guard newWidth.isFinite, newWidth > 0 else { return }
                     containerWidth = newWidth
                 }
 

--- a/clients/shared/DesignSystem/Components/Layout/VAppWorkspaceDockLayout.swift
+++ b/clients/shared/DesignSystem/Components/Layout/VAppWorkspaceDockLayout.swift
@@ -1,5 +1,11 @@
 import SwiftUI
 
+private enum DockLayoutConstants {
+    static let minDockWidth: CGFloat = 300
+    static let minWorkspaceWidth: CGFloat = 300
+    static let dividerAndPadding: CGFloat = VSpacing.xs + 12
+}
+
 public struct VAppWorkspaceDockLayout<Dock: View, Workspace: View>: View {
     // MARK: - Properties
 
@@ -19,10 +25,21 @@ public struct VAppWorkspaceDockLayout<Dock: View, Workspace: View>: View {
     // MARK: - Body
 
     public var body: some View {
+        // Clamp dock width to the measured available space so the workspace
+        // is never crushed below its minimum during layout transitions
+        // (e.g. sidebar collapse animation where the binding computes for
+        // the final sidebar width while the layout still uses the animated
+        // intermediate width).
+        let effectiveDockWidth: CGFloat = {
+            guard showDock, availableWidth > 0 else { return CGFloat(dockWidth) }
+            let maxAllowed = availableWidth - DockLayoutConstants.minWorkspaceWidth - DockLayoutConstants.dividerAndPadding
+            return min(CGFloat(dockWidth), max(maxAllowed, 0))
+        }()
+
         HStack(spacing: 0) {
             if showDock {
                 dock
-                    .frame(width: dockWidth)
+                    .frame(width: effectiveDockWidth)
                     .animation(nil, value: dockWidth)
                     .background(dockBackground ?? VColor.surfaceBase)
                     .clipShape(RoundedRectangle(cornerRadius: dockCornerRadius ?? VRadius.lg))
@@ -103,15 +120,12 @@ public struct VAppWorkspaceDockLayout<Dock: View, Workspace: View>: View {
         // Dragging right grows the dock (opposite of VSplitView's panel)
         let newWidth = initialWidth + Double(deltaX)
 
-        let minDockWidth: CGFloat = 300
-        let minWorkspaceWidth: CGFloat = 300
-        let dividerAndPadding = VSpacing.xs + 12
-        let maxAllowed = initialAvailableWidth - minWorkspaceWidth - dividerAndPadding
+        let maxAllowed = initialAvailableWidth - DockLayoutConstants.minWorkspaceWidth - DockLayoutConstants.dividerAndPadding
 
         var transaction = Transaction()
         transaction.disablesAnimations = true
         withTransaction(transaction) {
-            dockWidth = min(max(newWidth, minDockWidth), maxAllowed)
+            dockWidth = min(max(newWidth, DockLayoutConstants.minDockWidth), maxAllowed)
         }
     }
 

--- a/clients/shared/DesignSystem/Components/Layout/VAppWorkspaceDockLayout.swift
+++ b/clients/shared/DesignSystem/Components/Layout/VAppWorkspaceDockLayout.swift
@@ -106,7 +106,11 @@ public struct VAppWorkspaceDockLayout<Dock: View, Workspace: View>: View {
 
     private func handleDragChanged(_ value: DragGesture.Value, availableWidth: CGFloat) {
         if dragStartWidth == nil || !isDragging {
-            dragStartWidth = dockWidth
+            // Use the effective (clamped) width so drag math matches
+            // what is visually rendered, avoiding a dead-drag region
+            // when the container is narrower than the stored dockWidth.
+            let maxAllowedNow = availableWidth - DockLayoutConstants.minWorkspaceWidth - DockLayoutConstants.dividerAndPadding
+            dragStartWidth = min(dockWidth, max(Double(maxAllowedNow), 0))
             dragStartAvailableWidth = availableWidth
             isDragging = true
         }

--- a/clients/shared/DesignSystem/Components/Layout/VAppWorkspaceDockLayout.swift
+++ b/clients/shared/DesignSystem/Components/Layout/VAppWorkspaceDockLayout.swift
@@ -31,7 +31,7 @@ public struct VAppWorkspaceDockLayout<Dock: View, Workspace: View>: View {
         // the final sidebar width while the layout still uses the animated
         // intermediate width).
         let effectiveDockWidth: CGFloat = {
-            guard showDock, availableWidth > 0 else { return CGFloat(dockWidth) }
+            guard showDock, availableWidth > 0, availableWidth.isFinite else { return CGFloat(dockWidth) }
             let maxAllowed = availableWidth - DockLayoutConstants.minWorkspaceWidth - DockLayoutConstants.dividerAndPadding
             return min(CGFloat(dockWidth), max(maxAllowed, 0))
         }()


### PR DESCRIPTION
## Summary
- Move `containerWidth` geometry measurement in `ChatView` from the ZStack to a `Color.clear` child inside it, breaking a self-reinforcing width inflation loop that caused permanent clipping in narrow containers like the app-editing chat dock
- Clamp dock width in `VAppWorkspaceDockLayout` to measured available space so the workspace is never crushed below its minimum during layout transitions (e.g. sidebar collapse animation)
- Extract shared layout constants (`minDockWidth`, `minWorkspaceWidth`, `dividerAndPadding`) into a `DockLayoutConstants` enum

## Original prompt
--safe https://linear.app/vellum/issue/LUM-822/chat-view-cut-off-when-clicking-edit-app-non-full-width-window

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24579" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
