### PR TITLE
fix(macOS): guard against non-finite viewportHeight in message list minHeight

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
@@ -173,7 +173,12 @@ struct MessageListContentView: View, Equatable {
             let _ = os_signpost(.event, log: stallLog, name: "MessageList.bodyEval")
             // Min height for the active assistant turn — ensures the user message
             // can reach the top of the viewport when content is short.
-            let turnMinHeight: CGFloat = max(0, scrollState.viewportHeight - 150)
+            // viewportHeight is initialized to .infinity until the scroll view lays
+            // out; guard against non-finite values so we never pass NaN/∞ into
+            // .frame(minHeight:), which trips _NSViewValidateGeometry in AppKit.
+            let turnMinHeight: CGFloat = scrollState.viewportHeight.isFinite
+                ? max(0, scrollState.viewportHeight - 150)
+                : 0
             let isUnanchoredThinking = state.shouldShowThinkingIndicator && !state.rows.contains(where: \.isAnchoredThinkingRow)
             let thinkingLabel = !hasEverSentMessage && state.hasUserMessage
                 ? "Waking up..."


### PR DESCRIPTION
## Summary
- Velissa was crashing on launch (`EXC_BREAKPOINT` in `_NSViewValidateGeometry` → `NSClipView.setBoundsOrigin` → `SwiftUI.HostingScrollView.updateContext`) after #24570 landed.
- Root cause: `MessageListScrollState.viewportHeight` is initialized to `.infinity` and only populated after the scroll view's first layout. The new `turnMinHeight = max(0, viewportHeight - 150)` forwarded `.infinity` straight into `.frame(minHeight:)` on the trailing assistant turn, which AppKit traps on.
- Fix: gate the subtraction on `.isFinite` and fall back to `0` until a real viewport height arrives. The rest of the code already guards this value the same way (see `MessageListPaginationTriggerPolicy.isInTriggerBand`).