### PR TITLE
fix(macOS): drop redundant await on MainActor-isolated onProgress call

### DIFF
--- a/clients/macos/vellum-assistant/App/AppleContainersLauncher.swift
+++ b/clients/macos/vellum-assistant/App/AppleContainersLauncher.swift
@@ -206,7 +206,7 @@ final class AppleContainersLauncher: AssistantManagementClient {
             )
         } catch {
             log.warning("Local image build failed, falling back to registry pull: \(error.localizedDescription, privacy: .public)")
-            await onProgress?("Local build failed — will pull images from registry")
+            onProgress?("Local build failed — will pull images from registry")
         }
     }
 


### PR DESCRIPTION
## Summary
- `buildLocalImagesIfAvailable` is a method on `@MainActor`-isolated `AppleContainersLauncher`, so calls to `onProgress?(...)` from the top-level `catch` block already run on the MainActor — no actor hop is needed.
- Removed the unnecessary `await` to silence the Swift compiler warning "no 'async' operations occur within 'await' expression".
- Nested closures on lines 117 and 204 legitimately need `await` because they execute in non-MainActor contexts passed into other APIs; those are unchanged.

## Original prompt
fix: \`~v/clients/macos (main) ❯❯❯ VELLUM_NO_WATCH=1 ./build.sh run\`

\`\`\`
VELLUM_ENVIRONMENT=local
Building (debug)...
Building for debugging...
/Users/sidd/vocify/vellum-assistant/clients/macos/vellum-assistant/App/AppleContainersLauncher.swift:183:13: warning: no 'async' operations occur within 'await' expression
181 |         } catch {
182 |             log.warning("Local image build failed, falling back to registry pull: \(error.localizedDescription, privacy: .public)")
183 |             await onProgress?("Local build failed — will pull images from registry")
    |             \`- warning: no 'async' operations occur within 'await' expression
184 |         }
185 |     }
\`\`\`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24585" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
