### PR TITLE
fix: chat content resizing and sidebar hit-testing in dock layout

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -123,6 +123,19 @@ struct ChatView: View {
         let _ = os_signpost(.event, log: PerfSignposts.log, name: "ChatView.body")
         #endif
         ZStack {
+            // Color.clear always fills the proposed size, so measuring it
+            // gives the true available width from the parent — unlike the
+            // ZStack whose intrinsic size is driven by its children. This
+            // breaks the circular dependency where fixed-width frames inside
+            // mainContentStack would inflate the ZStack beyond the parent's
+            // proposal (e.g. 808pt default in a 300pt dock).
+            Color.clear
+                .onGeometryChange(for: CGFloat.self) { proxy in
+                    proxy.size.width
+                } action: { newWidth in
+                    containerWidth = newWidth
+                }
+
             mainContentStack(containerWidth: containerWidth)
                 .background(alignment: .bottom) {
                     chatBackground
@@ -134,11 +147,6 @@ struct ChatView: View {
                 .animation(VAnimation.fast, value: viewModel.btwResponse != nil)
 
             dropTargetOverlay
-        }
-        .onGeometryChange(for: CGFloat.self) { proxy in
-            proxy.size.width
-        } action: { newWidth in
-            containerWidth = newWidth
         }
         .environment(\.dropActions, currentDropActions)
         .onDrop(of: [.fileURL, .image, .png, .tiff], isTargeted: $isDropTargeted) { providers in

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -101,7 +101,6 @@ struct ChatView: View {
     @State private var currentMatchIndex = 0
     @State private var showSkeleton = false
     @State private var skeletonDebounceTask: Task<Void, Never>? = nil
-    @State private var containerWidth: CGFloat = 0
 
     private var isEmptyState: Bool {
         viewModel.paginatedVisibleMessages.isEmpty && viewModel.isHistoryLoaded
@@ -122,31 +121,25 @@ struct ChatView: View {
         #if DEBUG
         let _ = os_signpost(.event, log: PerfSignposts.log, name: "ChatView.body")
         #endif
-        ZStack {
-            // Color.clear always fills the proposed size, so measuring it
-            // gives the true available width from the parent — unlike the
-            // ZStack whose intrinsic size is driven by its children. This
-            // breaks the circular dependency where fixed-width frames inside
-            // mainContentStack would inflate the ZStack beyond the parent's
-            // proposal (e.g. 808pt default in a 300pt dock).
-            Color.clear
-                .onGeometryChange(for: CGFloat.self) { proxy in
-                    proxy.size.width
-                } action: { newWidth in
-                    containerWidth = newWidth
-                }
+        // GeometryReader reliably reports the parent's proposed width,
+        // even during interactive drag resizing of the dock. Using
+        // onGeometryChange on a ZStack or Color.clear can miss updates
+        // when the ZStack's intrinsic size is inflated by fixed-width
+        // children (808pt fallback) or when rapid drag updates are batched.
+        GeometryReader { proxy in
+            ZStack {
+                mainContentStack(containerWidth: proxy.size.width)
+                    .background(alignment: .bottom) {
+                        chatBackground
+                    }
+                    .background(VColor.surfaceBase)
+                    .overlay(alignment: .bottom) {
+                        btwOverlay
+                    }
+                    .animation(VAnimation.fast, value: viewModel.btwResponse != nil)
 
-            mainContentStack(containerWidth: containerWidth)
-                .background(alignment: .bottom) {
-                    chatBackground
-                }
-                .background(VColor.surfaceBase)
-                .overlay(alignment: .bottom) {
-                    btwOverlay
-                }
-                .animation(VAnimation.fast, value: viewModel.btwResponse != nil)
-
-            dropTargetOverlay
+                dropTargetOverlay
+            }
         }
         .environment(\.dropActions, currentDropActions)
         .onDrop(of: [.fileURL, .image, .png, .tiff], isTargeted: $isDropTargeted) { providers in

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListLayoutMetrics.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListLayoutMetrics.swift
@@ -15,8 +15,8 @@ struct MessageListLayoutMetrics: Equatable {
         // Use the container width directly when valid. When unknown (0 or
         // non-finite), fall back to 0 instead of chatColumnMaxWidth to avoid
         // rendering 808pt-wide content inside a narrow container (e.g. the
-        // chat dock). The content becomes visible once onGeometryChange
-        // supplies the true width on the next layout pass.
+        // chat dock). The content becomes visible once GeometryReader
+        // supplies the true width on the first layout pass.
         let scrollSurfaceWidth =
             (containerWidth.isFinite && containerWidth > 0)
             ? containerWidth

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListLayoutMetrics.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListLayoutMetrics.swift
@@ -12,10 +12,15 @@ struct MessageListLayoutMetrics: Equatable {
     let bubbleMaxWidth: CGFloat
 
     init(containerWidth: CGFloat) {
+        // Use the container width directly when valid. When unknown (0 or
+        // non-finite), fall back to 0 instead of chatColumnMaxWidth to avoid
+        // rendering 808pt-wide content inside a narrow container (e.g. the
+        // chat dock). The content becomes visible once onGeometryChange
+        // supplies the true width on the next layout pass.
         let scrollSurfaceWidth =
             (containerWidth.isFinite && containerWidth > 0)
             ? containerWidth
-            : VSpacing.chatColumnMaxWidth
+            : 0
         let chatColumnWidth = min(scrollSurfaceWidth, VSpacing.chatColumnMaxWidth)
 
         self.scrollSurfaceWidth = scrollSurfaceWidth

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -673,6 +673,7 @@ struct MainWindowView: View {
 
                 chatContentView(windowSize: windowSize)
                     .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
+                    .clipped()
                     .animation(VAnimation.panel, value: sidebarExpanded)
                     .animation(VAnimation.panel, value: isSettingsOpen)
                     .overlay {

--- a/clients/macos/vellum-assistantTests/MessageListLayoutMetricsTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListLayoutMetricsTests.swift
@@ -3,12 +3,12 @@ import XCTest
 
 final class MessageListLayoutMetricsTests: XCTestCase {
 
-    func testZeroWidthFallsBackToChatColumnMaxWidth() {
+    func testZeroWidthFallsBackToZero() {
         let metrics = MessageListLayoutMetrics(containerWidth: 0)
-        let capped = MessageListLayoutMetrics(containerWidth: 10_000)
 
-        XCTAssertEqual(metrics.scrollSurfaceWidth, metrics.chatColumnWidth)
-        XCTAssertEqual(metrics.chatColumnWidth, capped.chatColumnWidth)
+        XCTAssertEqual(metrics.scrollSurfaceWidth, 0)
+        XCTAssertEqual(metrics.chatColumnWidth, 0)
+        XCTAssertEqual(metrics.bubbleMaxWidth, 0)
     }
 
     func testNarrowPaneUsesAvailableWidthForSurfaceAndColumn() {


### PR DESCRIPTION
## Summary
- Move `onGeometryChange` in `ChatView` from the ZStack to a `Color.clear` child that always fills the parent's proposed width, breaking the circular dependency where fixed-width frames inside `mainContentStack` would inflate the ZStack beyond narrow containers (e.g. 808pt in a 300pt dock)
- Change `MessageListLayoutMetrics` fallback from `chatColumnMaxWidth` (808pt) to 0 to prevent oversized initial renders
- Add `.clipped()` to `chatContentView` in `MainWindowView` to ensure hit-testing stays within bounds and doesn't block the sidebar

## Original prompt
chat content isn't properly resizing and getting cutoff on left and right sides both for composer and conversation fully. Composer and conversation should be dependent on dock size and adapted to different sizes. Also sidebar menu isn't clickable when app and chat are opened, looks like content in chat covering it over. https://linear.app/vellum/issue/LUM-822/chat-view-cut-off-when-clicking-edit-app-non-full-width-window

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24586" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
