### PR TITLE
fix(macOS): use VColor.auxBlack for onboarding app icon shadow

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -67,7 +67,7 @@ struct OnboardingFlowView: View {
                                 .aspectRatio(contentMode: .fit)
                                 .frame(width: 80, height: 80)
                                 .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
-                                .shadow(color: .black.opacity(0.15), radius: 1, x: 0, y: 1)
+                                .shadow(color: VColor.auxBlack.opacity(0.15), radius: 1, x: 0, y: 1)
                                 .padding(.bottom, 78)
                         }
                     } else {


### PR DESCRIPTION
## Summary
- The \`Design token guard\` step of the \`macOS Build\` job on main was failing with a Rule F violation: \`OnboardingFlowView.swift:70\` used \`.black.opacity(0.15)\` directly.
- Replaced the raw color literal with \`VColor.auxBlack.opacity(0.15)\`, matching the pattern used by every other \`.shadow(color:)\` call in the macOS codebase.
- Verified locally: \`bash clients/scripts/check-design-tokens.sh --mode=strict\` now reports \"No design token violations found.\"

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24207681444/job/70667823516
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24588" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
