### PR TITLE
fix stale bearer-token fallback comment in worker.ts

### DIFF
--- a/clients/chrome-extension/background/worker.ts
+++ b/clients/chrome-extension/background/worker.ts
@@ -214,10 +214,9 @@ async function dispatchHostBrowserResult(
     return;
   }
 
-  // Self-hosted fallback: POST directly to the local daemon using live
-  // creds. Prefer the capability token from the native-messaging pair
-  // flow; fall back to the bearer token stored under the gateway
-  // pair flow.
+  // Self-hosted fallback: POST directly to the local daemon using the
+  // capability token from the native-messaging pair flow. If no paired
+  // token is available the result is dropped.
   const local = await getStoredLocalToken();
   if (local) {
     const fallbackPort = local.assistantPort ?? (await getRelayPort());


### PR DESCRIPTION
## Summary
- Updates the comment block in \`dispatchHostBrowserResult\` to match the current behavior: the function now drops self-hosted results via \`console.warn\` when no paired capability token is available, rather than falling back to a gateway-minted bearer token (that path was removed in #24541).
- Addresses Devin review comment on #24541 flagging the stale comment as a violation of the \`clients/AGENTS.md\` and \`assistant/AGENTS.md\` rules against referencing removed code in comments.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24597" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
