### PR TITLE
feat: edit Role/Description via new thread from Identity panel

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -58,13 +58,24 @@ struct IdentityPanel: View {
                     VStack(spacing: 0) {
                         VStack(spacing: 0) {
                             // Intro heading — show daemon-generated text, fall back to static name
-                            Text(introText ?? (hasRealName ? "I'm \(assistantDisplayName)!" : assistantDisplayName))
-                                .font(VFont.titleMedium)
-                                .foregroundStyle(VColor.contentDefault)
-                                .multilineTextAlignment(.center)
-                                .frame(maxWidth: .infinity, alignment: .center)
-                                .padding(.top, VSpacing.xxl)
-                                .padding(.horizontal, VSpacing.lg)
+                            ZStack(alignment: .topTrailing) {
+                                Text(introText ?? (hasRealName ? "I'm \(assistantDisplayName)!" : assistantDisplayName))
+                                    .font(VFont.titleMedium)
+                                    .foregroundStyle(VColor.contentDefault)
+                                    .multilineTextAlignment(.center)
+                                    .frame(maxWidth: .infinity, alignment: .center)
+                                Button {
+                                    onOpenThread?("I want to change your name")
+                                } label: {
+                                    VIconView(.pencil, size: 10)
+                                        .foregroundStyle(VColor.contentTertiary)
+                                }
+                                .buttonStyle(.plain)
+                                .accessibilityLabel("Edit Name")
+                                .help("Edit Name")
+                            }
+                            .padding(.top, VSpacing.xxl)
+                            .padding(.horizontal, VSpacing.lg)
 
                             Spacer()
 
@@ -95,17 +106,13 @@ struct IdentityPanel: View {
                             // Divider
                             Rectangle().fill(VColor.surfaceOverlay).frame(height: 2)
 
-                            // Role + Description + Hatched date
+                            // Role + Hatched date
                             VStack(alignment: .leading, spacing: VSpacing.lg) {
                                 let role = AssistantDisplayName.firstUserFacing(from: [
                                     identity?.role
                                 ])
                                 editableInfoRow(label: "Role", value: role ?? "Not set") {
-                                    onOpenThread?("I want to change my Role")
-                                }
-                                let personality = identity?.personality ?? ""
-                                editableInfoRow(label: "Description", value: personality.isEmpty ? "Not set" : personality) {
-                                    onOpenThread?("I want to change my Description")
+                                    onOpenThread?("I want to change your role description")
                                 }
                                 if let date = metadata?.createdAt {
                                     identityInfoRow(label: "Hatched", value: formatHatchedDate(date))

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -58,25 +58,25 @@ struct IdentityPanel: View {
                     VStack(spacing: 0) {
                         VStack(spacing: 0) {
                             // Intro heading — show daemon-generated text, fall back to static name
-                            HStack(alignment: .firstTextBaseline, spacing: VSpacing.sm) {
-                                Spacer(minLength: 0)
-                                Text(introText ?? (hasRealName ? "I'm \(assistantDisplayName)!" : assistantDisplayName))
-                                    .font(VFont.titleMedium)
-                                    .foregroundStyle(VColor.contentDefault)
-                                    .multilineTextAlignment(.center)
-                                Button {
-                                    onOpenThread?("I want to change your name")
-                                } label: {
-                                    VIconView(.pencil, size: 13)
-                                        .foregroundStyle(VColor.contentTertiary)
+                            Text(introText ?? (hasRealName ? "I'm \(assistantDisplayName)!" : assistantDisplayName))
+                                .font(VFont.titleMedium)
+                                .foregroundStyle(VColor.contentDefault)
+                                .multilineTextAlignment(.center)
+                                .frame(maxWidth: .infinity, alignment: .center)
+                                .overlay(alignment: .trailing) {
+                                    Button {
+                                        onOpenThread?("I want to change your name")
+                                    } label: {
+                                        VIconView(.pencil, size: 13)
+                                            .foregroundStyle(VColor.contentTertiary)
+                                    }
+                                    .buttonStyle(.plain)
+                                    .accessibilityLabel("Edit Name")
+                                    .help("Edit Name")
+                                    .offset(x: VSpacing.xl)
                                 }
-                                .buttonStyle(.plain)
-                                .accessibilityLabel("Edit Name")
-                                .help("Edit Name")
-                                Spacer(minLength: 0)
-                            }
-                            .padding(.top, VSpacing.xxl)
-                            .padding(.horizontal, VSpacing.lg)
+                                .padding(.top, VSpacing.xxl)
+                                .padding(.horizontal, VSpacing.lg)
 
                             Spacer()
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -58,12 +58,12 @@ struct IdentityPanel: View {
                     VStack(spacing: 0) {
                         VStack(spacing: 0) {
                             // Intro heading — show daemon-generated text, fall back to static name
-                            ZStack(alignment: .topTrailing) {
+                            HStack(alignment: .firstTextBaseline, spacing: VSpacing.xs) {
+                                Spacer(minLength: 0)
                                 Text(introText ?? (hasRealName ? "I'm \(assistantDisplayName)!" : assistantDisplayName))
                                     .font(VFont.titleMedium)
                                     .foregroundStyle(VColor.contentDefault)
                                     .multilineTextAlignment(.center)
-                                    .frame(maxWidth: .infinity, alignment: .center)
                                 Button {
                                     onOpenThread?("I want to change your name")
                                 } label: {
@@ -73,6 +73,7 @@ struct IdentityPanel: View {
                                 .buttonStyle(.plain)
                                 .accessibilityLabel("Edit Name")
                                 .help("Edit Name")
+                                Spacer(minLength: 0)
                             }
                             .padding(.top, VSpacing.xxl)
                             .padding(.horizontal, VSpacing.lg)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -210,9 +210,6 @@ struct IdentityPanel: View {
         }
     }
 
-    // MARK: - Inline Editing
-
-
     // MARK: - Intro Generation
 
     private func generateIntro() {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -344,8 +344,6 @@ struct IdentityPanel: View {
             Text(value)
                 .font(VFont.bodySmallEmphasised)
                 .foregroundStyle(VColor.contentEmphasized)
-                .lineLimit(2)
-                .truncationMode(.tail)
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -65,7 +65,7 @@ struct IdentityPanel: View {
                                     .multilineTextAlignment(.center)
                                     .frame(maxWidth: .infinity)
                                 Button {
-                                    onOpenThread?("I want to change your name")
+                                    onOpenThread?("I would like to change your name")
                                 } label: {
                                     VIconView(.pencil, size: 13)
                                         .foregroundStyle(VColor.contentTertiary)
@@ -113,7 +113,7 @@ struct IdentityPanel: View {
                                     identity?.role
                                 ])
                                 editableInfoRow(label: "Role", value: role ?? "Not set") {
-                                    onOpenThread?("I want to change your role description")
+                                    onOpenThread?("I would like to change your role description")
                                 }
                                 if let date = metadata?.createdAt {
                                     identityInfoRow(label: "Hatched", value: formatHatchedDate(date))

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -415,6 +415,7 @@ struct IdentityPanel: View {
                         .foregroundStyle(VColor.contentTertiary)
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel("Edit \(label)")
                 .help("Edit \(label)")
             }
             Text(value)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -6,6 +6,7 @@ struct IdentityPanel: View {
     let connectionManager: GatewayConnectionManager
     var onNavigateToSkill: ((String) -> Void)?
     var onNavigateToFile: ((String) -> Void)?
+    var onOpenThread: ((String) -> Void)?
     private let btwClient: any BtwClientProtocol = BtwClient()
     var workspaceClient: WorkspaceClientProtocol = WorkspaceClient()
     @State private var appearance = AvatarAppearanceManager.shared
@@ -26,8 +27,6 @@ struct IdentityPanel: View {
     @State private var isBootstrapActive: Bool = true
     @State private var isEditingName: Bool = false
     @State private var editingNameText: String = ""
-    @State private var isEditingRole: Bool = false
-    @State private var editingRoleText: String = ""
     @State private var isSavingIdentityField: Bool = false
 
     private let sidebarMinWidth: CGFloat = 200
@@ -96,12 +95,18 @@ struct IdentityPanel: View {
                             // Divider
                             Rectangle().fill(VColor.surfaceOverlay).frame(height: 2)
 
-                            // Role + Hatched date
+                            // Role + Description + Hatched date
                             VStack(alignment: .leading, spacing: VSpacing.lg) {
-                                                let role = AssistantDisplayName.firstUserFacing(from: [
-                                                    identity?.role
-                                                ])
-                                identityInfoRow(label: "Role", value: role ?? "Not set")
+                                let role = AssistantDisplayName.firstUserFacing(from: [
+                                    identity?.role
+                                ])
+                                editableInfoRow(label: "Role", value: role ?? "Not set") {
+                                    onOpenThread?("I want to change my Role")
+                                }
+                                let personality = identity?.personality ?? ""
+                                editableInfoRow(label: "Description", value: personality.isEmpty ? "Not set" : personality) {
+                                    onOpenThread?("I want to change my Description")
+                                }
                                 if let date = metadata?.createdAt {
                                     identityInfoRow(label: "Hatched", value: formatHatchedDate(date))
                                 }
@@ -244,7 +249,6 @@ struct IdentityPanel: View {
             let fileResponse = await workspaceClient.fetchWorkspaceFile(path: "IDENTITY.md", showHidden: false)
             guard let content = fileResponse?.content else {
                 isEditingName = false
-                isEditingRole = false
                 return
             }
 
@@ -266,7 +270,6 @@ struct IdentityPanel: View {
             if success {
                 identity = await IdentityInfo.loadAsync()
                 isEditingName = false
-                isEditingRole = false
 
                 if field == "Name" {
                     introText = nil
@@ -280,7 +283,6 @@ struct IdentityPanel: View {
                 }
             } else {
                 isEditingName = false
-                isEditingRole = false
             }
         }
     }
@@ -398,6 +400,28 @@ struct IdentityPanel: View {
                     .foregroundStyle(VColor.contentDefault)
                     .textSelection(.enabled)
             }
+        }
+    }
+
+    private func editableInfoRow(label: String, value: String, onEdit: @escaping () -> Void) -> some View {
+        VStack(alignment: .leading, spacing: VSpacing.xxs) {
+            HStack(spacing: VSpacing.xs) {
+                Text(label)
+                    .font(VFont.bodySmallDefault)
+                    .foregroundStyle(VColor.contentTertiary)
+                Spacer()
+                Button(action: onEdit) {
+                    VIconView(.pencil, size: 10)
+                        .foregroundStyle(VColor.contentTertiary)
+                }
+                .buttonStyle(.plain)
+                .help("Edit \(label)")
+            }
+            Text(value)
+                .font(VFont.bodySmallEmphasised)
+                .foregroundStyle(VColor.contentEmphasized)
+                .lineLimit(2)
+                .truncationMode(.tail)
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -25,9 +25,6 @@ struct IdentityPanel: View {
     @State private var bootstrapCheckTask: Task<Void, Never>? = nil
     @State private var skillsTask: Task<Void, Never>? = nil
     @State private var isBootstrapActive: Bool = true
-    @State private var isEditingName: Bool = false
-    @State private var editingNameText: String = ""
-    @State private var isSavingIdentityField: Bool = false
 
     private let sidebarMinWidth: CGFloat = 200
     private let sidebarMaxWidth: CGFloat = 280
@@ -215,85 +212,6 @@ struct IdentityPanel: View {
 
     // MARK: - Inline Editing
 
-    @ViewBuilder
-    private func inlineEditField(
-        text: Binding<String>,
-        placeholder: String,
-        font: Font,
-        isSaving: Bool,
-        onSave: @escaping () -> Void,
-        onCancel: @escaping () -> Void
-    ) -> some View {
-        HStack(spacing: VSpacing.xs) {
-            TextField(placeholder, text: text)
-                .font(font)
-                .foregroundStyle(VColor.contentDefault)
-                .textFieldStyle(.plain)
-                .onSubmit { onSave() }
-
-            if isSaving {
-                ProgressView()
-                    .controlSize(.small)
-            } else {
-                VButton(label: "Save", iconOnly: VIcon.check.rawValue, style: .ghost, size: .compact) {
-                    onSave()
-                }
-                VButton(label: "Cancel", iconOnly: VIcon.x.rawValue, style: .ghost, size: .compact) {
-                    onCancel()
-                }
-            }
-        }
-    }
-
-    /// Save a field in IDENTITY.md (e.g. "Name", "Role") via the workspace API.
-    private func saveIdentityField(field: String, value: String) {
-        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty, !isSavingIdentityField else { return }
-        isSavingIdentityField = true
-
-        Task {
-            defer { isSavingIdentityField = false }
-
-            let fileResponse = await workspaceClient.fetchWorkspaceFile(path: "IDENTITY.md", showHidden: false)
-            guard let content = fileResponse?.content else {
-                isEditingName = false
-                return
-            }
-
-            let key = "- **\(field.lowercased()):**"
-            let lines = content.components(separatedBy: "\n")
-            let updatedLines = lines.map { line -> String in
-                if line.trimmingCharacters(in: .whitespaces).lowercased().hasPrefix(key) {
-                    return "- **\(field):** \(trimmed)"
-                }
-                return line
-            }
-            let updatedContent = updatedLines.joined(separator: "\n")
-
-            let success = await workspaceClient.writeWorkspaceFile(
-                path: "IDENTITY.md",
-                content: updatedContent.data(using: .utf8) ?? Data()
-            )
-
-            if success {
-                identity = await IdentityInfo.loadAsync()
-                isEditingName = false
-
-                if field == "Name" {
-                    introText = nil
-                    if !isBootstrapActive {
-                        if let soulIntro = await IdentityInfo.loadIdentityIntroAsync() {
-                            introText = soulIntro
-                        } else {
-                            generateIntro()
-                        }
-                    }
-                }
-            } else {
-                isEditingName = false
-            }
-        }
-    }
 
     // MARK: - Intro Generation
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -58,25 +58,25 @@ struct IdentityPanel: View {
                     VStack(spacing: 0) {
                         VStack(spacing: 0) {
                             // Intro heading — show daemon-generated text, fall back to static name
-                            Text(introText ?? (hasRealName ? "I'm \(assistantDisplayName)!" : assistantDisplayName))
-                                .font(VFont.titleMedium)
-                                .foregroundStyle(VColor.contentDefault)
-                                .multilineTextAlignment(.center)
-                                .frame(maxWidth: .infinity, alignment: .center)
-                                .overlay(alignment: .trailing) {
-                                    Button {
-                                        onOpenThread?("I want to change your name")
-                                    } label: {
-                                        VIconView(.pencil, size: 13)
-                                            .foregroundStyle(VColor.contentTertiary)
-                                    }
-                                    .buttonStyle(.plain)
-                                    .accessibilityLabel("Edit Name")
-                                    .help("Edit Name")
-                                    .offset(x: VSpacing.xl)
+                            HStack(spacing: VSpacing.sm) {
+                                Text(introText ?? (hasRealName ? "I'm \(assistantDisplayName)!" : assistantDisplayName))
+                                    .font(VFont.titleMedium)
+                                    .foregroundStyle(VColor.contentDefault)
+                                    .multilineTextAlignment(.center)
+                                    .frame(maxWidth: .infinity)
+                                Button {
+                                    onOpenThread?("I want to change your name")
+                                } label: {
+                                    VIconView(.pencil, size: 13)
+                                        .foregroundStyle(VColor.contentTertiary)
                                 }
-                                .padding(.top, VSpacing.xxl)
-                                .padding(.horizontal, VSpacing.lg)
+                                .buttonStyle(.plain)
+                                .accessibilityLabel("Edit Name")
+                                .help("Edit Name")
+                                .fixedSize()
+                            }
+                            .padding(.top, VSpacing.xxl)
+                            .padding(.horizontal, VSpacing.lg)
 
                             Spacer()
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -58,7 +58,7 @@ struct IdentityPanel: View {
                     VStack(spacing: 0) {
                         VStack(spacing: 0) {
                             // Intro heading — show daemon-generated text, fall back to static name
-                            HStack(alignment: .firstTextBaseline, spacing: VSpacing.xs) {
+                            HStack(alignment: .firstTextBaseline, spacing: VSpacing.sm) {
                                 Spacer(minLength: 0)
                                 Text(introText ?? (hasRealName ? "I'm \(assistantDisplayName)!" : assistantDisplayName))
                                     .font(VFont.titleMedium)
@@ -67,7 +67,7 @@ struct IdentityPanel: View {
                                 Button {
                                     onOpenThread?("I want to change your name")
                                 } label: {
-                                    VIconView(.pencil, size: 10)
+                                    VIconView(.pencil, size: 13)
                                         .foregroundStyle(VColor.contentTertiary)
                                 }
                                 .buttonStyle(.plain)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
@@ -122,7 +122,8 @@ struct IntelligencePanel: View {
                 onNavigateToFile: { path in
                     pendingFilePath = path
                     withAnimation(VAnimation.fast) { selectedTab = .workspace }
-                }
+                },
+                onOpenThread: onImportMemory
             )
             .padding(.top, VSpacing.sm)
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)


### PR DESCRIPTION
## Summary
- Added pencil edit icons next to Role and Description fields in the IdentityPanel sidebar
- Clicking an edit icon opens a new conversation thread with a pre-filled prompt (e.g. "I want to change my Role")
- Reuses the existing `onImportMemory` callback pattern for conversation navigation
- Removed unused inline-editing state for Role (`isEditingRole`, `editingRoleText`)

Closes LUM-698

## Original prompt
--safe https://linear.app/vellum/issue/LUM-698/cant-edit-name-and-role-from-settings-in-v061 let's take the same approach we are taking with some of the settings, show edit icon, when user clicks on edit, it should open new thread with prompt saying I want to change Role and likewise for Description
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24598" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
