### PR TITLE
feat(browser): add cdp-inspect type unions and hostBrowser config schema

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -839,6 +839,125 @@ describe("AssistantConfigSchema", () => {
     });
     expect(result.calls.callerIdentity.allowPerCallOverride).toBe(true);
   });
+
+  // ── hostBrowser.cdpInspect config ─────────────────────────────────
+
+  test("applies hostBrowser.cdpInspect defaults", () => {
+    const result = AssistantConfigSchema.parse({});
+    expect(result.hostBrowser).toEqual({
+      cdpInspect: {
+        enabled: false,
+        host: "localhost",
+        port: 9222,
+        probeTimeoutMs: 500,
+      },
+    });
+  });
+
+  test("accepts hostBrowser.cdpInspect enabled with custom host/port", () => {
+    const result = AssistantConfigSchema.parse({
+      hostBrowser: {
+        cdpInspect: {
+          enabled: true,
+          host: "127.0.0.1",
+          port: 9333,
+        },
+      },
+    });
+    expect(result.hostBrowser.cdpInspect.enabled).toBe(true);
+    expect(result.hostBrowser.cdpInspect.host).toBe("127.0.0.1");
+    expect(result.hostBrowser.cdpInspect.port).toBe(9333);
+    // Unset field should still receive its default.
+    expect(result.hostBrowser.cdpInspect.probeTimeoutMs).toBe(500);
+  });
+
+  test("accepts hostBrowser.cdpInspect custom probeTimeoutMs", () => {
+    const result = AssistantConfigSchema.parse({
+      hostBrowser: { cdpInspect: { probeTimeoutMs: 1000 } },
+    });
+    expect(result.hostBrowser.cdpInspect.probeTimeoutMs).toBe(1000);
+  });
+
+  test("rejects hostBrowser.cdpInspect.port below 1", () => {
+    const result = AssistantConfigSchema.safeParse({
+      hostBrowser: { cdpInspect: { port: 0 } },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(
+        result.error.issues.some((issue) =>
+          issue.path.join(".").includes("hostBrowser.cdpInspect.port"),
+        ),
+      ).toBe(true);
+    }
+  });
+
+  test("rejects hostBrowser.cdpInspect.port above 65535", () => {
+    const result = AssistantConfigSchema.safeParse({
+      hostBrowser: { cdpInspect: { port: 70000 } },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(
+        result.error.issues.some((issue) =>
+          issue.path.join(".").includes("hostBrowser.cdpInspect.port"),
+        ),
+      ).toBe(true);
+    }
+  });
+
+  test("rejects non-integer hostBrowser.cdpInspect.port", () => {
+    const result = AssistantConfigSchema.safeParse({
+      hostBrowser: { cdpInspect: { port: 9222.5 } },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects hostBrowser.cdpInspect.probeTimeoutMs below 50", () => {
+    const result = AssistantConfigSchema.safeParse({
+      hostBrowser: { cdpInspect: { probeTimeoutMs: 10 } },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(
+        result.error.issues.some((issue) =>
+          issue.path
+            .join(".")
+            .includes("hostBrowser.cdpInspect.probeTimeoutMs"),
+        ),
+      ).toBe(true);
+    }
+  });
+
+  test("rejects hostBrowser.cdpInspect.probeTimeoutMs above 5000", () => {
+    const result = AssistantConfigSchema.safeParse({
+      hostBrowser: { cdpInspect: { probeTimeoutMs: 10000 } },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(
+        result.error.issues.some((issue) =>
+          issue.path
+            .join(".")
+            .includes("hostBrowser.cdpInspect.probeTimeoutMs"),
+        ),
+      ).toBe(true);
+    }
+  });
+
+  test("rejects non-integer hostBrowser.cdpInspect.probeTimeoutMs", () => {
+    const result = AssistantConfigSchema.safeParse({
+      hostBrowser: { cdpInspect: { probeTimeoutMs: 500.5 } },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects non-boolean hostBrowser.cdpInspect.enabled", () => {
+    const result = AssistantConfigSchema.safeParse({
+      hostBrowser: { cdpInspect: { enabled: "yes" } },
+    });
+    expect(result.success).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/browser-session/index.ts
+++ b/assistant/src/browser-session/index.ts
@@ -3,19 +3,11 @@
  *
  * This module is the single CDP backend selector for browser tools. The
  * `cdp-client` factory (`assistant/src/tools/browser/cdp-client/factory.ts`)
- * constructs a BrowserSessionManager per tool invocation, registers one of
- * three backends, and exposes a `ScopedCdpClient` that routes `send()`
- * through the manager. This gives every call site a single choke point for
- * session invalidation and future multi-tab routing.
- *
- * Backend selection (3-way):
- *   - `extension`  — routes CDP through `hostBrowserProxy` (chrome.debugger)
- *     when the extension is connected. Used for the user's own Chrome.
- *   - `cdp-inspect` — connects directly to a host Chrome instance launched
- *     with `--remote-debugging-port` when the `hostBrowser.cdpInspect`
- *     probe succeeds. Used as a fallback before falling through to local.
- *   - `local`      — Playwright-backed headless Chromium in the same
- *     process. Used when neither extension nor cdp-inspect is available.
+ * constructs a BrowserSessionManager per tool invocation, registers the
+ * appropriate backend (extension when `hostBrowserProxy` is present, local
+ * Playwright-backed backend otherwise), and exposes a `ScopedCdpClient` that
+ * routes `send()` through the manager. This gives every call site a single
+ * choke point for session invalidation and future multi-tab routing.
  */
 export * from "./backends/extension.js";
 export * from "./backends/local.js";

--- a/assistant/src/browser-session/index.ts
+++ b/assistant/src/browser-session/index.ts
@@ -3,11 +3,19 @@
  *
  * This module is the single CDP backend selector for browser tools. The
  * `cdp-client` factory (`assistant/src/tools/browser/cdp-client/factory.ts`)
- * constructs a BrowserSessionManager per tool invocation, registers the
- * appropriate backend (extension when `hostBrowserProxy` is present, local
- * Playwright-backed backend otherwise), and exposes a `ScopedCdpClient` that
- * routes `send()` through the manager. This gives every call site a single
- * choke point for session invalidation and future multi-tab routing.
+ * constructs a BrowserSessionManager per tool invocation, registers one of
+ * three backends, and exposes a `ScopedCdpClient` that routes `send()`
+ * through the manager. This gives every call site a single choke point for
+ * session invalidation and future multi-tab routing.
+ *
+ * Backend selection (3-way):
+ *   - `extension`  — routes CDP through `hostBrowserProxy` (chrome.debugger)
+ *     when the extension is connected. Used for the user's own Chrome.
+ *   - `cdp-inspect` — connects directly to a host Chrome instance launched
+ *     with `--remote-debugging-port` when the `hostBrowser.cdpInspect`
+ *     probe succeeds. Used as a fallback before falling through to local.
+ *   - `local`      — Playwright-backed headless Chromium in the same
+ *     process. Used when neither extension nor cdp-inspect is available.
  */
 export * from "./backends/extension.js";
 export * from "./backends/local.js";

--- a/assistant/src/browser-session/types.ts
+++ b/assistant/src/browser-session/types.ts
@@ -1,4 +1,4 @@
-export type BrowserBackendKind = "extension" | "local";
+export type BrowserBackendKind = "extension" | "local" | "cdp-inspect";
 
 export interface CdpCommand {
   method: string;

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -50,6 +50,14 @@ export { FishAudioConfigSchema } from "./schemas/fish-audio.js";
 export type { HeartbeatConfig } from "./schemas/heartbeat.js";
 export { HeartbeatConfigSchema } from "./schemas/heartbeat.js";
 export type {
+  HostBrowserCdpInspectConfig,
+  HostBrowserConfig,
+} from "./schemas/host-browser.js";
+export {
+  HostBrowserCdpInspectConfigSchema,
+  HostBrowserConfigSchema,
+} from "./schemas/host-browser.js";
+export type {
   ContextOverflowRecoveryConfig,
   ContextWindowConfig,
   Effort,
@@ -205,6 +213,7 @@ import { ElevenLabsConfigSchema } from "./schemas/elevenlabs.js";
 import { FilingConfigSchema } from "./schemas/filing.js";
 import { FishAudioConfigSchema } from "./schemas/fish-audio.js";
 import { HeartbeatConfigSchema } from "./schemas/heartbeat.js";
+import { HostBrowserConfigSchema } from "./schemas/host-browser.js";
 import {
   ContextWindowConfigSchema,
   EffortSchema,
@@ -278,6 +287,9 @@ export const AssistantConfigSchema = z
       ),
     filing: FilingConfigSchema.default(FilingConfigSchema.parse({})),
     heartbeat: HeartbeatConfigSchema.default(HeartbeatConfigSchema.parse({})),
+    hostBrowser: HostBrowserConfigSchema.default(
+      HostBrowserConfigSchema.parse({}),
+    ),
     journal: JournalConfigSchema.default(JournalConfigSchema.parse({})),
     mcp: McpConfigSchema.default(McpConfigSchema.parse({})),
     acp: AcpConfigSchema.default(AcpConfigSchema.parse({})),

--- a/assistant/src/config/schemas/host-browser.ts
+++ b/assistant/src/config/schemas/host-browser.ts
@@ -1,0 +1,67 @@
+import { z } from "zod";
+
+/**
+ * Configuration for the `cdp-inspect` browser backend — connects directly
+ * to a host Chrome instance that was launched with `--remote-debugging-port`
+ * (e.g. `chrome://inspect`-style remote debugging). Serves as a fallback
+ * between the extension backend (user's Chrome via chrome.debugger) and the
+ * local Playwright-backed backend.
+ */
+export const HostBrowserCdpInspectConfigSchema = z
+  .object({
+    enabled: z
+      .boolean({ error: "hostBrowser.cdpInspect.enabled must be a boolean" })
+      .default(false)
+      .describe(
+        "Whether the cdp-inspect backend is enabled. When true, the browser-session manager will probe the configured host/port before falling back to the local Playwright backend.",
+      ),
+    host: z
+      .string({ error: "hostBrowser.cdpInspect.host must be a string" })
+      .min(1, "hostBrowser.cdpInspect.host must not be empty")
+      .default("localhost")
+      .describe(
+        "Host name or IP address where the host Chrome instance exposes its remote debugging endpoint.",
+      ),
+    port: z
+      .number({ error: "hostBrowser.cdpInspect.port must be a number" })
+      .int("hostBrowser.cdpInspect.port must be an integer")
+      .min(1, "hostBrowser.cdpInspect.port must be >= 1")
+      .max(65535, "hostBrowser.cdpInspect.port must be <= 65535")
+      .default(9222)
+      .describe(
+        "TCP port for the host Chrome remote-debugging endpoint (matches `--remote-debugging-port`).",
+      ),
+    probeTimeoutMs: z
+      .number({
+        error: "hostBrowser.cdpInspect.probeTimeoutMs must be a number",
+      })
+      .int("hostBrowser.cdpInspect.probeTimeoutMs must be an integer")
+      .min(50, "hostBrowser.cdpInspect.probeTimeoutMs must be >= 50")
+      .max(5000, "hostBrowser.cdpInspect.probeTimeoutMs must be <= 5000")
+      .default(500)
+      .describe(
+        "Timeout (in milliseconds) for the backend availability probe. Kept small so the fallback to the local backend stays snappy.",
+      ),
+  })
+  .describe(
+    "Settings for the cdp-inspect backend that connects to a host Chrome instance via its remote-debugging endpoint.",
+  );
+
+export type HostBrowserCdpInspectConfig = z.infer<
+  typeof HostBrowserCdpInspectConfigSchema
+>;
+
+/**
+ * Top-level configuration for host-browser backends. Currently only exposes
+ * `cdpInspect`, but the shape leaves room for additional host-browser knobs
+ * (e.g. extension-specific settings) without another namespace churn.
+ */
+export const HostBrowserConfigSchema = z
+  .object({
+    cdpInspect: HostBrowserCdpInspectConfigSchema.default(
+      HostBrowserCdpInspectConfigSchema.parse({}),
+    ),
+  })
+  .describe("Host-browser backend configuration (cdp-inspect, etc.)");
+
+export type HostBrowserConfig = z.infer<typeof HostBrowserConfigSchema>;

--- a/assistant/src/tools/browser/cdp-client/__tests__/types.test.ts
+++ b/assistant/src/tools/browser/cdp-client/__tests__/types.test.ts
@@ -79,7 +79,7 @@ describe("cdp-client re-exports", () => {
   });
 
   test("ScopedCdpClient exposes kind and conversationId", () => {
-    const kinds: CdpClientKind[] = ["local", "extension"];
+    const kinds: CdpClientKind[] = ["local", "extension", "cdp-inspect"];
     for (const kind of kinds) {
       const scoped: ScopedCdpClient = {
         kind,

--- a/assistant/src/tools/browser/cdp-client/factory.ts
+++ b/assistant/src/tools/browser/cdp-client/factory.ts
@@ -85,11 +85,16 @@ function buildManagedClient(
       signal?: AbortSignal,
     ): Promise<T> {
       if (disposed) {
-        throw new CdpError(
-          "disposed",
-          `${kind === "extension" ? "ExtensionCdpClient" : "LocalCdpClient"} already disposed`,
-          { cdpMethod: method, cdpParams: params },
-        );
+        const clientName =
+          kind === "extension"
+            ? "ExtensionCdpClient"
+            : kind === "cdp-inspect"
+              ? "CdpInspectClient"
+              : "LocalCdpClient";
+        throw new CdpError("disposed", `${clientName} already disposed`, {
+          cdpMethod: method,
+          cdpParams: params,
+        });
       }
       const command: CdpCommand = { method, params };
       const envelope = await manager.send(session.id, command, signal);

--- a/assistant/src/tools/browser/cdp-client/types.ts
+++ b/assistant/src/tools/browser/cdp-client/types.ts
@@ -38,7 +38,7 @@ export interface CdpClient {
  * the sacrificial-profile screencast setup when running against the
  * user's own Chrome via the extension).
  */
-export type CdpClientKind = "local" | "extension";
+export type CdpClientKind = "local" | "extension" | "cdp-inspect";
 
 /**
  * Concrete CdpClient instance returned by the factory. Carries the


### PR DESCRIPTION
## Summary
- Extend BrowserBackendKind and CdpClientKind unions with `cdp-inspect` variant
- Add `hostBrowser.cdpInspect` config schema (enabled/host/port/probeTimeoutMs) with validation
- Wire config schema into AssistantConfigSchema with tests

Part of plan: browser-cdp-inspect-phase4.md (PR 1 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24599" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
