### PR TITLE
feat(browser): add DevTools discovery and target-selection helpers for cdp-inspect

### DIFF
--- a/assistant/src/tools/browser/cdp-client/cdp-inspect/__tests__/discovery.test.ts
+++ b/assistant/src/tools/browser/cdp-client/cdp-inspect/__tests__/discovery.test.ts
@@ -1,0 +1,531 @@
+/**
+ * Unit tests for the DevTools HTTP discovery helpers.
+ *
+ * These tests boot a tiny `Bun.serve` instance per test (or per
+ * describe block) and point the helpers at it. The goal is to cover
+ * every error branch without relying on a real Chrome being present
+ * on the dev machine or CI runner.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  DevToolsDiscoveryError,
+  type DevToolsTarget,
+  listDevToolsTargets,
+  pickDefaultTarget,
+  probeDevToolsJsonVersion,
+} from "../discovery.js";
+
+// ---------------------------------------------------------------------------
+// Test fixture: a tiny Bun.serve that can be reconfigured per test.
+// ---------------------------------------------------------------------------
+
+type Handler = (req: Request) => Response | Promise<Response>;
+
+interface FakeDevTools {
+  server: ReturnType<typeof Bun.serve>;
+  port: number;
+  setHandler: (handler: Handler) => void;
+  stop: () => void;
+}
+
+function startFakeDevTools(): FakeDevTools {
+  let handler: Handler = () => new Response("not configured", { status: 500 });
+  const server = Bun.serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    async fetch(req) {
+      return handler(req);
+    },
+  });
+  return {
+    server,
+    port: server.port as number,
+    setHandler: (h) => {
+      handler = h;
+    },
+    stop: () => server.stop(true),
+  };
+}
+
+function chromeVersionResponse(
+  overrides: Record<string, string> = {},
+): Response {
+  return Response.json({
+    Browser: "Chrome/124.0.6367.91",
+    "Protocol-Version": "1.3",
+    "User-Agent": "Mozilla/5.0",
+    "V8-Version": "12.4.254.13",
+    "WebKit-Version": "537.36",
+    webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/browser/abcd-1234",
+    ...overrides,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Loopback enforcement — must reject BEFORE any fetch call.
+// ---------------------------------------------------------------------------
+
+describe("probeDevToolsJsonVersion — loopback enforcement", () => {
+  test("rejects non-loopback host with non_loopback and does not fetch", async () => {
+    const originalFetch = globalThis.fetch;
+    let fetchCallCount = 0;
+    globalThis.fetch = (async (...args: unknown[]) => {
+      fetchCallCount += 1;
+      return originalFetch(...(args as Parameters<typeof fetch>));
+    }) as typeof fetch;
+
+    try {
+      await expect(
+        probeDevToolsJsonVersion({
+          host: "192.168.1.1",
+          port: 9222,
+          timeoutMs: 1000,
+        }),
+      ).rejects.toMatchObject({
+        name: "DevToolsDiscoveryError",
+        code: "non_loopback",
+      });
+      expect(fetchCallCount).toBe(0);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("rejects public DNS hostname before fetching", async () => {
+    const originalFetch = globalThis.fetch;
+    let fetchCallCount = 0;
+    globalThis.fetch = (async (...args: unknown[]) => {
+      fetchCallCount += 1;
+      return originalFetch(...(args as Parameters<typeof fetch>));
+    }) as typeof fetch;
+
+    try {
+      await expect(
+        probeDevToolsJsonVersion({
+          host: "example.com",
+          port: 9222,
+          timeoutMs: 1000,
+        }),
+      ).rejects.toMatchObject({
+        name: "DevToolsDiscoveryError",
+        code: "non_loopback",
+      });
+      expect(fetchCallCount).toBe(0);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("accepts localhost, 127.0.0.1, ::1 (case-insensitive)", async () => {
+    const fake = startFakeDevTools();
+    fake.setHandler(() => chromeVersionResponse());
+    try {
+      for (const host of ["localhost", "LOCALHOST", "127.0.0.1"]) {
+        const info = await probeDevToolsJsonVersion({
+          host,
+          port: fake.port,
+          timeoutMs: 2000,
+        });
+        expect(info.browser).toContain("Chrome");
+      }
+    } finally {
+      fake.stop();
+    }
+  });
+
+  test("listDevToolsTargets also rejects non-loopback before fetch", async () => {
+    const originalFetch = globalThis.fetch;
+    let fetchCallCount = 0;
+    globalThis.fetch = (async (...args: unknown[]) => {
+      fetchCallCount += 1;
+      return originalFetch(...(args as Parameters<typeof fetch>));
+    }) as typeof fetch;
+
+    try {
+      await expect(
+        listDevToolsTargets({
+          host: "10.0.0.1",
+          port: 9222,
+          timeoutMs: 1000,
+        }),
+      ).rejects.toMatchObject({
+        name: "DevToolsDiscoveryError",
+        code: "non_loopback",
+      });
+      expect(fetchCallCount).toBe(0);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// probeDevToolsJsonVersion — happy paths.
+// ---------------------------------------------------------------------------
+
+describe("probeDevToolsJsonVersion — parsing", () => {
+  let fake: FakeDevTools;
+
+  beforeEach(() => {
+    fake = startFakeDevTools();
+  });
+
+  afterEach(() => {
+    fake.stop();
+  });
+
+  test("parses real Chrome field casing", async () => {
+    fake.setHandler(() =>
+      chromeVersionResponse({
+        Browser: "Chrome/126.0.6478.127",
+        "Protocol-Version": "1.3",
+        webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/browser/xyz",
+      }),
+    );
+
+    const info = await probeDevToolsJsonVersion({
+      host: "127.0.0.1",
+      port: fake.port,
+      timeoutMs: 2000,
+    });
+
+    expect(info.browser).toBe("Chrome/126.0.6478.127");
+    expect(info.protocolVersion).toBe("1.3");
+    expect(info.webSocketDebuggerUrl).toBe(
+      "ws://127.0.0.1:9222/devtools/browser/xyz",
+    );
+  });
+
+  test("parses normalized camelCase field casing", async () => {
+    fake.setHandler(() =>
+      Response.json({
+        browser: "Chromium/125.0.6422.141",
+        protocolVersion: "1.3",
+        webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/browser/normalized",
+      }),
+    );
+
+    const info = await probeDevToolsJsonVersion({
+      host: "127.0.0.1",
+      port: fake.port,
+      timeoutMs: 2000,
+    });
+
+    expect(info.browser).toBe("Chromium/125.0.6422.141");
+    expect(info.protocolVersion).toBe("1.3");
+    expect(info.webSocketDebuggerUrl).toBe(
+      "ws://127.0.0.1:9222/devtools/browser/normalized",
+    );
+  });
+
+  test("rejects non-Chrome responder with non_chrome", async () => {
+    fake.setHandler(() => chromeVersionResponse({ Browser: "Firefox/115.0" }));
+
+    const error = await probeDevToolsJsonVersion({
+      host: "127.0.0.1",
+      port: fake.port,
+      timeoutMs: 2000,
+    }).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(DevToolsDiscoveryError);
+    expect((error as DevToolsDiscoveryError).code).toBe("non_chrome");
+  });
+
+  test("rejects missing required fields with invalid_response", async () => {
+    fake.setHandler(() =>
+      Response.json({
+        Browser: "Chrome/123",
+        // Missing Protocol-Version and webSocketDebuggerUrl
+      }),
+    );
+
+    const error = await probeDevToolsJsonVersion({
+      host: "127.0.0.1",
+      port: fake.port,
+      timeoutMs: 2000,
+    }).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(DevToolsDiscoveryError);
+    expect((error as DevToolsDiscoveryError).code).toBe("invalid_response");
+  });
+
+  test("rejects malformed JSON body with invalid_response", async () => {
+    fake.setHandler(
+      () =>
+        new Response("not json at all {{{", {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+
+    const error = await probeDevToolsJsonVersion({
+      host: "127.0.0.1",
+      port: fake.port,
+      timeoutMs: 2000,
+    }).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(DevToolsDiscoveryError);
+    expect((error as DevToolsDiscoveryError).code).toBe("invalid_response");
+  });
+
+  test("rejects non-object JSON body with invalid_response", async () => {
+    fake.setHandler(() => Response.json(["not", "an", "object"]));
+
+    const error = await probeDevToolsJsonVersion({
+      host: "127.0.0.1",
+      port: fake.port,
+      timeoutMs: 2000,
+    }).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(DevToolsDiscoveryError);
+    expect((error as DevToolsDiscoveryError).code).toBe("invalid_response");
+  });
+
+  test("rejects non-200 status with invalid_response", async () => {
+    fake.setHandler(() => new Response("nope", { status: 404 }));
+
+    const error = await probeDevToolsJsonVersion({
+      host: "127.0.0.1",
+      port: fake.port,
+      timeoutMs: 2000,
+    }).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(DevToolsDiscoveryError);
+    expect((error as DevToolsDiscoveryError).code).toBe("invalid_response");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// probeDevToolsJsonVersion — network-level error paths.
+// ---------------------------------------------------------------------------
+
+describe("probeDevToolsJsonVersion — network errors", () => {
+  test("connection refused (unreachable)", async () => {
+    // Boot a server then stop it to get a guaranteed-free port.
+    const fake = startFakeDevTools();
+    const deadPort = fake.port;
+    fake.stop();
+
+    const error = await probeDevToolsJsonVersion({
+      host: "127.0.0.1",
+      port: deadPort,
+      timeoutMs: 2000,
+    }).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(DevToolsDiscoveryError);
+    expect((error as DevToolsDiscoveryError).code).toBe("unreachable");
+  });
+
+  test("stalled server triggers timeout", async () => {
+    const fake = startFakeDevTools();
+    fake.setHandler(
+      () =>
+        new Promise<Response>(() => {
+          // Intentionally never resolve.
+        }),
+    );
+
+    try {
+      const error = await probeDevToolsJsonVersion({
+        host: "127.0.0.1",
+        port: fake.port,
+        timeoutMs: 50,
+      }).catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(DevToolsDiscoveryError);
+      expect((error as DevToolsDiscoveryError).code).toBe("timeout");
+    } finally {
+      fake.stop();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listDevToolsTargets — filtering and parsing.
+// ---------------------------------------------------------------------------
+
+describe("listDevToolsTargets", () => {
+  let fake: FakeDevTools;
+
+  beforeEach(() => {
+    fake = startFakeDevTools();
+  });
+
+  afterEach(() => {
+    fake.stop();
+  });
+
+  test("filters non-page targets and returns parsed pages", async () => {
+    fake.setHandler(() =>
+      Response.json([
+        {
+          id: "A",
+          type: "page",
+          title: "Example",
+          url: "https://example.com/",
+          webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/page/A",
+        },
+        {
+          id: "B",
+          type: "service_worker",
+          title: "sw",
+          url: "https://example.com/sw.js",
+          webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/page/B",
+        },
+        {
+          id: "C",
+          type: "iframe",
+          title: "frame",
+          url: "https://example.com/frame",
+          webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/page/C",
+        },
+        {
+          id: "D",
+          type: "page",
+          title: "Second Page",
+          url: "https://docs.example.com/",
+          webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/page/D",
+        },
+      ]),
+    );
+
+    const targets = await listDevToolsTargets({
+      host: "127.0.0.1",
+      port: fake.port,
+      timeoutMs: 2000,
+    });
+
+    expect(targets).toHaveLength(2);
+    expect(targets.map((t) => t.id)).toEqual(["A", "D"]);
+    expect(targets[0]!.webSocketDebuggerUrl).toBe(
+      "ws://127.0.0.1:9222/devtools/page/A",
+    );
+  });
+
+  test("drops page targets without webSocketDebuggerUrl", async () => {
+    fake.setHandler(() =>
+      Response.json([
+        {
+          id: "A",
+          type: "page",
+          title: "Missing WS",
+          url: "https://example.com/",
+          webSocketDebuggerUrl: "",
+        },
+        {
+          id: "B",
+          type: "page",
+          title: "Good Page",
+          url: "https://example.com/ok",
+          webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/page/B",
+        },
+      ]),
+    );
+
+    const targets = await listDevToolsTargets({
+      host: "127.0.0.1",
+      port: fake.port,
+      timeoutMs: 2000,
+    });
+
+    expect(targets).toHaveLength(1);
+    expect(targets[0]!.id).toBe("B");
+  });
+
+  test("throws no_targets when filtered list is empty", async () => {
+    fake.setHandler(() =>
+      Response.json([
+        {
+          id: "A",
+          type: "service_worker",
+          title: "sw",
+          url: "https://example.com/sw.js",
+          webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/page/A",
+        },
+      ]),
+    );
+
+    const error = await listDevToolsTargets({
+      host: "127.0.0.1",
+      port: fake.port,
+      timeoutMs: 2000,
+    }).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(DevToolsDiscoveryError);
+    expect((error as DevToolsDiscoveryError).code).toBe("no_targets");
+  });
+
+  test("throws invalid_response when body is not a JSON array", async () => {
+    fake.setHandler(() => Response.json({ not: "an array" }));
+
+    const error = await listDevToolsTargets({
+      host: "127.0.0.1",
+      port: fake.port,
+      timeoutMs: 2000,
+    }).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(DevToolsDiscoveryError);
+    expect((error as DevToolsDiscoveryError).code).toBe("invalid_response");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pickDefaultTarget — prefers real pages, falls back to first.
+// ---------------------------------------------------------------------------
+
+describe("pickDefaultTarget", () => {
+  function makeTarget(partial: Partial<DevToolsTarget>): DevToolsTarget {
+    return {
+      id: partial.id ?? "id",
+      type: partial.type ?? "page",
+      title: partial.title ?? "title",
+      url: partial.url ?? "https://example.com/",
+      webSocketDebuggerUrl:
+        partial.webSocketDebuggerUrl ?? "ws://127.0.0.1:9222/devtools/page/id",
+    };
+  }
+
+  test("throws no_targets on empty input", () => {
+    expect(() => pickDefaultTarget([])).toThrow(DevToolsDiscoveryError);
+    try {
+      pickDefaultTarget([]);
+    } catch (e) {
+      expect((e as DevToolsDiscoveryError).code).toBe("no_targets");
+    }
+  });
+
+  test("prefers a real https page over chrome:// targets", () => {
+    const targets: DevToolsTarget[] = [
+      makeTarget({ id: "newtab", url: "chrome://newtab/" }),
+      makeTarget({ id: "devtools", url: "devtools://devtools/bundled/idx" }),
+      makeTarget({ id: "site", url: "https://example.com/docs" }),
+    ];
+    const picked = pickDefaultTarget(targets);
+    expect(picked.id).toBe("site");
+  });
+
+  test("prefers a real page over about:blank", () => {
+    const targets: DevToolsTarget[] = [
+      makeTarget({ id: "blank", url: "about:blank" }),
+      makeTarget({ id: "real", url: "https://example.com/" }),
+    ];
+    const picked = pickDefaultTarget(targets);
+    expect(picked.id).toBe("real");
+  });
+
+  test("falls back to first when every target is a utility page", () => {
+    const targets: DevToolsTarget[] = [
+      makeTarget({ id: "newtab", url: "chrome://newtab/" }),
+      makeTarget({ id: "devtools", url: "devtools://devtools/bundled/idx" }),
+      makeTarget({ id: "blank", url: "about:blank" }),
+    ];
+    const picked = pickDefaultTarget(targets);
+    expect(picked.id).toBe("newtab");
+  });
+
+  test("returns the only candidate when the list has length 1", () => {
+    const targets = [makeTarget({ id: "only", url: "https://example.com/" })];
+    expect(pickDefaultTarget(targets).id).toBe("only");
+  });
+});

--- a/assistant/src/tools/browser/cdp-client/cdp-inspect/__tests__/discovery.test.ts
+++ b/assistant/src/tools/browser/cdp-client/cdp-inspect/__tests__/discovery.test.ts
@@ -339,6 +339,112 @@ describe("probeDevToolsJsonVersion — network errors", () => {
       fake.stop();
     }
   });
+
+  test("stalled response body triggers timeout (not invalid_response)", async () => {
+    // Regression test: a responder that sends headers + a partial body
+    // and then stalls the stream must still be cancelled by the
+    // discovery timeout. If the timer was cleared right after `fetch()`
+    // resolved, `response.text()` would hang forever. See review on
+    // PR #24601.
+    const fake = startFakeDevTools();
+    const stalledStreams: ReadableStreamDefaultController<Uint8Array>[] = [];
+    fake.setHandler(
+      () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              // Send a partial JSON body so `fetch()` can resolve its
+              // headers promise, then never enqueue more. Keep a ref so
+              // the test can close the stream during cleanup.
+              controller.enqueue(new TextEncoder().encode('{"'));
+              stalledStreams.push(controller);
+              // Intentionally do NOT call controller.close().
+            },
+          }),
+          {
+            status: 200,
+            headers: {
+              "content-type": "application/json",
+              // No content-length so the reader keeps waiting for more.
+              "transfer-encoding": "chunked",
+            },
+          },
+        ),
+    );
+
+    try {
+      const startedAt = Date.now();
+      const error = await probeDevToolsJsonVersion({
+        host: "127.0.0.1",
+        port: fake.port,
+        timeoutMs: 100,
+      }).catch((e: unknown) => e);
+      const elapsed = Date.now() - startedAt;
+
+      expect(error).toBeInstanceOf(DevToolsDiscoveryError);
+      expect((error as DevToolsDiscoveryError).code).toBe("timeout");
+      // Should resolve roughly at `timeoutMs`, not hang indefinitely.
+      // Generous upper bound to keep the test stable under load.
+      expect(elapsed).toBeLessThan(2000);
+    } finally {
+      // Unblock the server's streams so Bun.serve can shut down cleanly.
+      for (const controller of stalledStreams) {
+        try {
+          controller.close();
+        } catch {
+          // Stream may already be in an errored state from the abort.
+        }
+      }
+      fake.stop();
+    }
+  });
+
+  test("stalled response body during listDevToolsTargets triggers timeout", async () => {
+    // Same regression, checked on the /json/list path.
+    const fake = startFakeDevTools();
+    const stalledStreams: ReadableStreamDefaultController<Uint8Array>[] = [];
+    fake.setHandler(
+      () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode("["));
+              stalledStreams.push(controller);
+            },
+          }),
+          {
+            status: 200,
+            headers: {
+              "content-type": "application/json",
+              "transfer-encoding": "chunked",
+            },
+          },
+        ),
+    );
+
+    try {
+      const startedAt = Date.now();
+      const error = await listDevToolsTargets({
+        host: "127.0.0.1",
+        port: fake.port,
+        timeoutMs: 100,
+      }).catch((e: unknown) => e);
+      const elapsed = Date.now() - startedAt;
+
+      expect(error).toBeInstanceOf(DevToolsDiscoveryError);
+      expect((error as DevToolsDiscoveryError).code).toBe("timeout");
+      expect(elapsed).toBeLessThan(2000);
+    } finally {
+      for (const controller of stalledStreams) {
+        try {
+          controller.close();
+        } catch {
+          // Stream may already be in an errored state from the abort.
+        }
+      }
+      fake.stop();
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/tools/browser/cdp-client/cdp-inspect/discovery.ts
+++ b/assistant/src/tools/browser/cdp-client/cdp-inspect/discovery.ts
@@ -209,24 +209,57 @@ function classifyFetchError(
 }
 
 /**
+ * Read the response body as text, propagating abort/timeout errors so
+ * the caller can distinguish them from a merely malformed payload.
+ *
+ * The fetch signal is the same AbortSignal passed to the original
+ * `fetch()` call, so if the timeout fires (or the caller aborts) while
+ * we're still reading the body, the underlying stream is cancelled and
+ * `response.text()` rejects. We rethrow those abort-shaped failures as
+ * a distinct sentinel (`TimeoutDuringBodyReadError`) so the caller can
+ * map them to `timeout` / `unreachable` instead of `invalid_response`.
+ */
+class TimeoutDuringBodyReadError extends Error {
+  constructor(
+    public readonly timedOut: boolean,
+    public readonly callerAborted: boolean,
+    public readonly underlying: unknown,
+  ) {
+    super("Discovery body read aborted.");
+    this.name = "TimeoutDuringBodyReadError";
+  }
+}
+
+function isAbortShaped(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  if (err.name === "AbortError") return true;
+  if (/abort/i.test(err.message)) return true;
+  return false;
+}
+
+async function readResponseText(
+  response: Response,
+  handle: TimeoutHandle,
+  callerSignal: AbortSignal | undefined,
+): Promise<string> {
+  try {
+    return await response.text();
+  } catch (err) {
+    const callerAborted = callerSignal?.aborted === true;
+    if (handle.timedOut || callerAborted || isAbortShaped(err)) {
+      throw new TimeoutDuringBodyReadError(handle.timedOut, callerAborted, err);
+    }
+    throw err;
+  }
+}
+
+/**
  * Best-effort JSON parser. Returns a parsed object or throws a
  * discovery error with `invalid_response` so the caller doesn't need
- * to wrap this itself.
+ * to wrap this itself. Assumes the body text has already been read
+ * (see {@link readResponseText}).
  */
-async function parseJsonResponse(
-  response: Response,
-  endpoint: string,
-): Promise<unknown> {
-  let text: string;
-  try {
-    text = await response.text();
-  } catch (err) {
-    throw new DevToolsDiscoveryError(
-      "invalid_response",
-      `Failed to read ${endpoint} response body.`,
-      err,
-    );
-  }
+function parseJsonText(text: string, endpoint: string): unknown {
   try {
     return JSON.parse(text);
   } catch (err) {
@@ -283,27 +316,52 @@ export async function probeDevToolsJsonVersion(opts: {
   const url = buildUrl(opts.host, opts.port, "/json/version");
   const handle = withTimeout(opts.timeoutMs, opts.signal);
 
-  let response: Response;
+  // Keep `handle` active until AFTER the body has been read, so the
+  // timeout (and caller abort) still enforce against a server that
+  // stalls mid-body. If we cleared the timer right after `fetch()`
+  // resolved, a chunked response that stalls on the second chunk would
+  // block `response.text()` indefinitely.
+  let text: string;
   try {
-    response = await fetch(url, { signal: handle.signal });
-  } catch (err) {
-    throw classifyFetchError(
-      err,
-      handle.timedOut,
-      opts.signal?.aborted === true,
-    );
+    let response: Response;
+    try {
+      response = await fetch(url, { signal: handle.signal });
+    } catch (err) {
+      throw classifyFetchError(
+        err,
+        handle.timedOut,
+        opts.signal?.aborted === true,
+      );
+    }
+
+    if (!response.ok) {
+      throw new DevToolsDiscoveryError(
+        "invalid_response",
+        `DevTools /json/version returned HTTP ${response.status}.`,
+      );
+    }
+
+    try {
+      text = await readResponseText(response, handle, opts.signal);
+    } catch (err) {
+      if (err instanceof TimeoutDuringBodyReadError) {
+        throw classifyFetchError(
+          err.underlying,
+          err.timedOut,
+          err.callerAborted,
+        );
+      }
+      throw new DevToolsDiscoveryError(
+        "invalid_response",
+        "Failed to read /json/version response body.",
+        err,
+      );
+    }
   } finally {
     handle.cleanup();
   }
 
-  if (!response.ok) {
-    throw new DevToolsDiscoveryError(
-      "invalid_response",
-      `DevTools /json/version returned HTTP ${response.status}.`,
-    );
-  }
-
-  const parsed = await parseJsonResponse(response, "/json/version");
+  const parsed = parseJsonText(text, "/json/version");
   if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
     throw new DevToolsDiscoveryError(
       "invalid_response",
@@ -361,27 +419,52 @@ export async function listDevToolsTargets(opts: {
   const url = buildUrl(opts.host, opts.port, "/json/list");
   const handle = withTimeout(opts.timeoutMs, opts.signal);
 
-  let response: Response;
+  // Keep `handle` active until AFTER the body has been read, so the
+  // timeout (and caller abort) still enforce against a server that
+  // stalls mid-body. See the matching comment in
+  // probeDevToolsJsonVersion for the exact failure mode this guards
+  // against.
+  let text: string;
   try {
-    response = await fetch(url, { signal: handle.signal });
-  } catch (err) {
-    throw classifyFetchError(
-      err,
-      handle.timedOut,
-      opts.signal?.aborted === true,
-    );
+    let response: Response;
+    try {
+      response = await fetch(url, { signal: handle.signal });
+    } catch (err) {
+      throw classifyFetchError(
+        err,
+        handle.timedOut,
+        opts.signal?.aborted === true,
+      );
+    }
+
+    if (!response.ok) {
+      throw new DevToolsDiscoveryError(
+        "invalid_response",
+        `DevTools /json/list returned HTTP ${response.status}.`,
+      );
+    }
+
+    try {
+      text = await readResponseText(response, handle, opts.signal);
+    } catch (err) {
+      if (err instanceof TimeoutDuringBodyReadError) {
+        throw classifyFetchError(
+          err.underlying,
+          err.timedOut,
+          err.callerAborted,
+        );
+      }
+      throw new DevToolsDiscoveryError(
+        "invalid_response",
+        "Failed to read /json/list response body.",
+        err,
+      );
+    }
   } finally {
     handle.cleanup();
   }
 
-  if (!response.ok) {
-    throw new DevToolsDiscoveryError(
-      "invalid_response",
-      `DevTools /json/list returned HTTP ${response.status}.`,
-    );
-  }
-
-  const parsed = await parseJsonResponse(response, "/json/list");
+  const parsed = parseJsonText(text, "/json/list");
   if (!Array.isArray(parsed)) {
     throw new DevToolsDiscoveryError(
       "invalid_response",

--- a/assistant/src/tools/browser/cdp-client/cdp-inspect/discovery.ts
+++ b/assistant/src/tools/browser/cdp-client/cdp-inspect/discovery.ts
@@ -1,0 +1,458 @@
+/**
+ * DevTools HTTP discovery helpers for the `cdp-inspect` backend.
+ *
+ * These helpers are pure HTTP/domain logic — they do not own a
+ * websocket transport, a session manager, or any CDP command state.
+ * They exist so the higher-level `cdp-inspect` client can:
+ *
+ * 1. Probe `/json/version` to verify that a loopback port is actually
+ *    a Chrome/Chromium DevTools endpoint (and not some other service
+ *    that happens to be listening).
+ * 2. Enumerate available page targets via `/json/list`.
+ * 3. Pick a sensible default target when the caller doesn't specify
+ *    one explicitly.
+ *
+ * Safety boundary: **only loopback hosts are allowed**. A non-loopback
+ * host is rejected *before* any network I/O so that this module can
+ * never be coerced into making cross-origin requests on behalf of an
+ * attacker-controlled config value.
+ */
+
+/**
+ * Stable error codes surfaced by discovery helpers.
+ *
+ * Callers branch on these codes instead of string-matching messages so
+ * upstream UX (status bar, toasts, logs) can render a stable, localized
+ * explanation.
+ */
+export type DevToolsDiscoveryErrorCode =
+  | "unreachable"
+  | "non_loopback"
+  | "non_chrome"
+  | "invalid_response"
+  | "no_targets"
+  | "timeout";
+
+/**
+ * Single error type thrown by all discovery helpers. Mirrors the
+ * shape of {@link import("../errors.js").CdpError} so catch sites can
+ * rely on an explicit `code` field and an optional underlying cause.
+ */
+export class DevToolsDiscoveryError extends Error {
+  constructor(
+    public readonly code: DevToolsDiscoveryErrorCode,
+    message: string,
+    public readonly cause?: unknown,
+  ) {
+    super(message);
+    this.name = "DevToolsDiscoveryError";
+  }
+}
+
+/**
+ * Normalized `/json/version` payload. Chrome returns canonical field
+ * names like `Browser` and `Protocol-Version`, but some forks and
+ * tests prefer camelCase. The parser here accepts both and normalizes
+ * to the camelCase shape below.
+ */
+export interface DevToolsVersionInfo {
+  /** Normalized from `"Browser"` or `"browser"`. */
+  browser: string;
+  /** Normalized from `"Protocol-Version"` or `"protocolVersion"`. */
+  protocolVersion: string;
+  /** WebSocket URL for the browser-level debugger endpoint. */
+  webSocketDebuggerUrl: string;
+}
+
+/**
+ * A DevTools page target as returned by `/json/list`, filtered down to
+ * the fields the cdp-inspect backend actually needs.
+ */
+export interface DevToolsTarget {
+  id: string;
+  type: string;
+  title: string;
+  url: string;
+  webSocketDebuggerUrl: string;
+}
+
+/**
+ * Loopback allowlist (exact match, case-insensitive). Any host not in
+ * this list is rejected *before* we touch the network.
+ *
+ * We intentionally do not resolve DNS here — if a config ever gains a
+ * hostname that happens to resolve to 127.0.0.1, we still refuse it,
+ * because DNS rebinding attacks can flip that answer between the
+ * pre-check and the actual fetch.
+ */
+const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
+
+function assertLoopback(host: string): void {
+  const normalized = host.toLowerCase();
+  if (!LOOPBACK_HOSTS.has(normalized)) {
+    throw new DevToolsDiscoveryError(
+      "non_loopback",
+      `Refusing to probe non-loopback DevTools host "${host}". Only loopback hosts (localhost, 127.0.0.1, ::1) are permitted.`,
+    );
+  }
+}
+
+/**
+ * Build a fetch-ready loopback URL. `host` is assumed to have already
+ * been validated by {@link assertLoopback}. IPv6 bare form (`::1`) is
+ * wrapped in square brackets for URL correctness.
+ */
+function buildUrl(host: string, port: number, pathname: string): string {
+  const normalized = host.toLowerCase();
+  const hostSegment = normalized === "::1" ? "[::1]" : normalized;
+  return `http://${hostSegment}:${port}${pathname}`;
+}
+
+/**
+ * Timeout controller handle returned by {@link withTimeout}. `cleanup`
+ * must be called in a `finally` block to avoid leaking the timer and
+ * the abort listener. `timedOut` is flipped to `true` if the timer
+ * fires before `cleanup` runs.
+ */
+interface TimeoutHandle {
+  signal: AbortSignal;
+  cleanup: () => void;
+  readonly timedOut: boolean;
+}
+
+/**
+ * Merge the caller's signal (if any) with a freshly-minted timeout
+ * controller. The flag on the returned handle is the single source of
+ * truth for "timed out vs. aborted vs. network error" — we can't
+ * recover that distinction from the fetch rejection alone.
+ */
+function withTimeout(
+  timeoutMs: number,
+  callerSignal?: AbortSignal,
+): TimeoutHandle {
+  const controller = new AbortController();
+  let timedOut = false;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    controller.abort(new Error("timeout"));
+  }, timeoutMs);
+
+  let onCallerAbort: (() => void) | null = null;
+  if (callerSignal) {
+    if (callerSignal.aborted) {
+      controller.abort(callerSignal.reason);
+    } else {
+      onCallerAbort = () => controller.abort(callerSignal.reason);
+      callerSignal.addEventListener("abort", onCallerAbort, { once: true });
+    }
+  }
+
+  return {
+    signal: controller.signal,
+    get timedOut() {
+      return timedOut;
+    },
+    cleanup: () => {
+      clearTimeout(timer);
+      if (onCallerAbort && callerSignal) {
+        callerSignal.removeEventListener("abort", onCallerAbort);
+      }
+    },
+  };
+}
+
+/**
+ * Classify a `fetch()` rejection into a stable discovery code. We
+ * intentionally do not depend on Node's error code strings here — the
+ * fetch implementation varies between Bun, Node, and undici — so we
+ * look at the name, the message, and the caller-visible abort state
+ * instead.
+ */
+function classifyFetchError(
+  err: unknown,
+  timedOut: boolean,
+  callerAborted: boolean,
+): DevToolsDiscoveryError {
+  if (callerAborted) {
+    return new DevToolsDiscoveryError(
+      "unreachable",
+      "Discovery fetch was aborted by the caller before completion.",
+      err,
+    );
+  }
+  if (timedOut) {
+    return new DevToolsDiscoveryError(
+      "timeout",
+      "Timed out waiting for DevTools HTTP response.",
+      err,
+    );
+  }
+
+  const message = err instanceof Error ? err.message : String(err);
+  const name = err instanceof Error ? err.name : "";
+  if (name === "AbortError" || /aborted/i.test(message)) {
+    // Unspecified abort — most likely the timeout fired but the flag
+    // was not flipped yet. Treat as timeout to give the user the
+    // clearer message.
+    return new DevToolsDiscoveryError(
+      "timeout",
+      "Timed out waiting for DevTools HTTP response.",
+      err,
+    );
+  }
+
+  return new DevToolsDiscoveryError(
+    "unreachable",
+    `Failed to reach DevTools endpoint: ${message}`,
+    err,
+  );
+}
+
+/**
+ * Best-effort JSON parser. Returns a parsed object or throws a
+ * discovery error with `invalid_response` so the caller doesn't need
+ * to wrap this itself.
+ */
+async function parseJsonResponse(
+  response: Response,
+  endpoint: string,
+): Promise<unknown> {
+  let text: string;
+  try {
+    text = await response.text();
+  } catch (err) {
+    throw new DevToolsDiscoveryError(
+      "invalid_response",
+      `Failed to read ${endpoint} response body.`,
+      err,
+    );
+  }
+  try {
+    return JSON.parse(text);
+  } catch (err) {
+    throw new DevToolsDiscoveryError(
+      "invalid_response",
+      `Expected JSON from ${endpoint} but got: ${text.slice(0, 200)}`,
+      err,
+    );
+  }
+}
+
+/**
+ * Pull a string field out of an arbitrary JSON object, supporting
+ * either of two casings (e.g. `"Browser"` and `"browser"`). Returns
+ * `undefined` if neither key exists or the value is not a string.
+ */
+function readStringField(
+  obj: Record<string, unknown>,
+  ...keys: string[]
+): string | undefined {
+  for (const key of keys) {
+    const value = obj[key];
+    if (typeof value === "string" && value.length > 0) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Probe `/json/version` on a loopback DevTools endpoint and return a
+ * normalized {@link DevToolsVersionInfo}.
+ *
+ * Failure modes:
+ *
+ * - `non_loopback`: host is not one of {localhost, 127.0.0.1, ::1, [::1]}.
+ *   Raised *before* any network I/O.
+ * - `unreachable`: network error, connection refused, DNS failure, etc.
+ * - `timeout`: no response within `timeoutMs`.
+ * - `invalid_response`: HTTP status != 200, non-JSON body, or missing
+ *   required fields.
+ * - `non_chrome`: the responder does not identify itself as Chrome or
+ *   Chromium. Guards against e.g. a dev server happening to listen on
+ *   port 9222.
+ */
+export async function probeDevToolsJsonVersion(opts: {
+  host: string;
+  port: number;
+  timeoutMs: number;
+  signal?: AbortSignal;
+}): Promise<DevToolsVersionInfo> {
+  assertLoopback(opts.host);
+
+  const url = buildUrl(opts.host, opts.port, "/json/version");
+  const handle = withTimeout(opts.timeoutMs, opts.signal);
+
+  let response: Response;
+  try {
+    response = await fetch(url, { signal: handle.signal });
+  } catch (err) {
+    throw classifyFetchError(
+      err,
+      handle.timedOut,
+      opts.signal?.aborted === true,
+    );
+  } finally {
+    handle.cleanup();
+  }
+
+  if (!response.ok) {
+    throw new DevToolsDiscoveryError(
+      "invalid_response",
+      `DevTools /json/version returned HTTP ${response.status}.`,
+    );
+  }
+
+  const parsed = await parseJsonResponse(response, "/json/version");
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new DevToolsDiscoveryError(
+      "invalid_response",
+      "DevTools /json/version payload is not a JSON object.",
+    );
+  }
+
+  const record = parsed as Record<string, unknown>;
+  const browser = readStringField(record, "Browser", "browser");
+  const protocolVersion = readStringField(
+    record,
+    "Protocol-Version",
+    "protocolVersion",
+  );
+  const webSocketDebuggerUrl = readStringField(
+    record,
+    "webSocketDebuggerUrl",
+    "WebSocketDebuggerUrl",
+  );
+
+  if (!browser || !protocolVersion || !webSocketDebuggerUrl) {
+    throw new DevToolsDiscoveryError(
+      "invalid_response",
+      "DevTools /json/version payload is missing required fields (browser, protocolVersion, webSocketDebuggerUrl).",
+    );
+  }
+
+  if (!/chrom(e|ium)/i.test(browser)) {
+    throw new DevToolsDiscoveryError(
+      "non_chrome",
+      `DevTools endpoint is not Chrome or Chromium: ${browser}`,
+    );
+  }
+
+  return { browser, protocolVersion, webSocketDebuggerUrl };
+}
+
+/**
+ * Enumerate `/json/list` and return only usable page targets — i.e.
+ * `type === "page"` with a non-empty `webSocketDebuggerUrl`. Throws
+ * `no_targets` when the filtered list is empty so the caller doesn't
+ * have to decide how to phrase that.
+ *
+ * Sibling failure modes match {@link probeDevToolsJsonVersion}:
+ * `non_loopback`, `unreachable`, `timeout`, `invalid_response`.
+ */
+export async function listDevToolsTargets(opts: {
+  host: string;
+  port: number;
+  timeoutMs: number;
+  signal?: AbortSignal;
+}): Promise<DevToolsTarget[]> {
+  assertLoopback(opts.host);
+
+  const url = buildUrl(opts.host, opts.port, "/json/list");
+  const handle = withTimeout(opts.timeoutMs, opts.signal);
+
+  let response: Response;
+  try {
+    response = await fetch(url, { signal: handle.signal });
+  } catch (err) {
+    throw classifyFetchError(
+      err,
+      handle.timedOut,
+      opts.signal?.aborted === true,
+    );
+  } finally {
+    handle.cleanup();
+  }
+
+  if (!response.ok) {
+    throw new DevToolsDiscoveryError(
+      "invalid_response",
+      `DevTools /json/list returned HTTP ${response.status}.`,
+    );
+  }
+
+  const parsed = await parseJsonResponse(response, "/json/list");
+  if (!Array.isArray(parsed)) {
+    throw new DevToolsDiscoveryError(
+      "invalid_response",
+      "DevTools /json/list payload is not a JSON array.",
+    );
+  }
+
+  const targets: DevToolsTarget[] = [];
+  for (const entry of parsed) {
+    if (typeof entry !== "object" || entry === null || Array.isArray(entry)) {
+      continue;
+    }
+    const record = entry as Record<string, unknown>;
+    const type = readStringField(record, "type");
+    if (type !== "page") continue;
+
+    const webSocketDebuggerUrl = readStringField(
+      record,
+      "webSocketDebuggerUrl",
+    );
+    if (!webSocketDebuggerUrl) continue;
+
+    const id = readStringField(record, "id") ?? "";
+    const title = readStringField(record, "title") ?? "";
+    const targetUrl = readStringField(record, "url") ?? "";
+
+    targets.push({
+      id,
+      type,
+      title,
+      url: targetUrl,
+      webSocketDebuggerUrl,
+    });
+  }
+
+  if (targets.length === 0) {
+    throw new DevToolsDiscoveryError(
+      "no_targets",
+      "No usable page targets returned by DevTools /json/list.",
+    );
+  }
+
+  return targets;
+}
+
+/**
+ * Pick a sensible default target from a filtered list. Prefers targets
+ * whose URL is not `chrome://`, `devtools://`, or `about:blank`, then
+ * falls back to the first entry. Callers that need more specific
+ * control should iterate the list themselves.
+ *
+ * Throws `no_targets` on an empty input list — this mirrors the shape
+ * of {@link listDevToolsTargets}, so callers that chain the two can
+ * rely on a single error code path.
+ */
+export function pickDefaultTarget(targets: DevToolsTarget[]): DevToolsTarget {
+  if (targets.length === 0) {
+    throw new DevToolsDiscoveryError(
+      "no_targets",
+      "pickDefaultTarget called with an empty target list.",
+    );
+  }
+
+  const preferred = targets.find((target) => !isUtilityTarget(target));
+  return preferred ?? targets[0]!;
+}
+
+function isUtilityTarget(target: DevToolsTarget): boolean {
+  const url = target.url.toLowerCase();
+  if (url.startsWith("chrome://")) return true;
+  if (url.startsWith("devtools://")) return true;
+  if (url === "about:blank") return true;
+  return false;
+}


### PR DESCRIPTION
## Summary
- Add `probeDevToolsJsonVersion` with loopback-only host enforcement and non-Chrome responder rejection
- Add `listDevToolsTargets` and `pickDefaultTarget` for page target selection
- `DevToolsDiscoveryError` with codes: unreachable, non_loopback, non_chrome, invalid_response, no_targets, timeout

Part of plan: browser-cdp-inspect-phase4.md (PR 3 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24601" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
