### PR TITLE
feat(browser): add reusable CDP JSON-RPC WebSocket transport for cdp-inspect

### DIFF
--- a/assistant/src/tools/browser/cdp-client/cdp-inspect/__tests__/ws-transport.test.ts
+++ b/assistant/src/tools/browser/cdp-client/cdp-inspect/__tests__/ws-transport.test.ts
@@ -1,0 +1,580 @@
+/**
+ * Tests for the raw CDP JSON-RPC WebSocket transport.
+ *
+ * These tests stand up a fake CDP peer on a random loopback port
+ * with `Bun.serve` so we can exercise every failure mode without
+ * any real Chrome install. The fake peer consumes the JSON-RPC
+ * request frame verbatim, then returns whatever envelope the test
+ * scenario wants (success, CDP error, delayed, etc.).
+ *
+ * Every test is responsible for stopping the fake server in a
+ * `try/finally` (or via `afterEach`) to avoid port leaks across the
+ * suite.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import type { ServerWebSocket } from "bun";
+
+import {
+  type CdpWsTransport,
+  CdpWsTransportError,
+  connectCdpWsTransport,
+} from "../ws-transport.js";
+
+interface WsFrame {
+  id?: number;
+  method?: string;
+  params?: Record<string, unknown>;
+  sessionId?: string;
+}
+
+interface FakeWsServer {
+  url: string;
+  stop(): Promise<void>;
+}
+
+/**
+ * Start a fake websocket server whose inbound-message handler is
+ * controlled by the caller. The caller gets the raw parsed CDP
+ * request frame plus the underlying `ServerWebSocket` so it can
+ * respond, delay, close, or do nothing at all.
+ */
+function startFakeWsServer(options: {
+  onMessage?: (
+    ws: ServerWebSocket<undefined>,
+    frame: WsFrame,
+    raw: string,
+  ) => void;
+  onOpen?: (ws: ServerWebSocket<undefined>) => void;
+}): FakeWsServer {
+  const server = Bun.serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    fetch(req, srv) {
+      if (srv.upgrade(req)) return;
+      return new Response("expected ws", { status: 400 });
+    },
+    websocket: {
+      open(ws) {
+        options.onOpen?.(ws);
+      },
+      message(ws, message) {
+        const raw =
+          typeof message === "string"
+            ? message
+            : new TextDecoder().decode(message);
+        let parsed: WsFrame;
+        try {
+          parsed = JSON.parse(raw) as WsFrame;
+        } catch {
+          return;
+        }
+        options.onMessage?.(ws, parsed, raw);
+      },
+    },
+  });
+  const url = `ws://127.0.0.1:${server.port}`;
+  return {
+    url,
+    async stop() {
+      // Fire-and-forget stop. `await server.stop(true)` can hang
+      // in bun 1.3.x when a ws client has already closed, and
+      // `await server.stop()` waits for in-flight connections to
+      // drain, which can also hang in pathological tests. We don't
+      // need to block on shutdown for correctness — the process
+      // exits after the suite, and every test allocates a fresh
+      // random port.
+      server.stop();
+    },
+  };
+}
+
+/**
+ * Start a fake HTTP (non-ws) server that refuses upgrade requests
+ * with `400`. Used to verify that `connectCdpWsTransport` rejects
+ * (with either `timeout` or `transport_error`) when the peer does
+ * not speak websockets.
+ */
+function startNonWsServer(): FakeWsServer {
+  const server = Bun.serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    fetch() {
+      return new Response("no websocket here", { status: 400 });
+    },
+  });
+  const url = `ws://127.0.0.1:${server.port}`;
+  return {
+    url,
+    async stop() {
+      server.stop();
+    },
+  };
+}
+
+async function withTransport<T>(
+  server: FakeWsServer,
+  fn: (transport: CdpWsTransport) => Promise<T>,
+  connectOpts?: { connectTimeoutMs?: number },
+): Promise<T> {
+  const transport = await connectCdpWsTransport(server.url, connectOpts);
+  try {
+    return await fn(transport);
+  } finally {
+    transport.dispose();
+  }
+}
+
+describe("CdpWsTransportError", () => {
+  test("subclasses Error with code and metadata", () => {
+    const err = new CdpWsTransportError("cdp_error", "boom", {
+      cdpMethod: "Page.navigate",
+      cdpCode: -32000,
+      cdpMessage: "boom",
+      cdpData: { foo: "bar" },
+    });
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(CdpWsTransportError);
+    expect(err.name).toBe("CdpWsTransportError");
+    expect(err.code).toBe("cdp_error");
+    expect(err.cdpMethod).toBe("Page.navigate");
+    expect(err.cdpCode).toBe(-32000);
+    expect(err.cdpMessage).toBe("boom");
+    expect(err.cdpData).toEqual({ foo: "bar" });
+  });
+
+  test("supports all documented codes", () => {
+    const codes = [
+      "closed",
+      "aborted",
+      "timeout",
+      "transport_error",
+      "cdp_error",
+    ] as const;
+    for (const code of codes) {
+      const err = new CdpWsTransportError(code);
+      expect(err.code).toBe(code);
+    }
+  });
+});
+
+describe("connectCdpWsTransport", () => {
+  test("send+receive success — Browser.getVersion style", async () => {
+    const server = startFakeWsServer({
+      onMessage(ws, frame) {
+        if (frame.method === "Browser.getVersion") {
+          ws.send(
+            JSON.stringify({
+              id: frame.id,
+              result: {
+                protocolVersion: "1.3",
+                product: "Chrome/123.0.0.0",
+                revision: "@deadbeef",
+                userAgent: "test",
+                jsVersion: "1.0",
+              },
+            }),
+          );
+        }
+      },
+    });
+    try {
+      await withTransport(server, async (transport) => {
+        const result = await transport.send<{ product: string }>(
+          "Browser.getVersion",
+        );
+        expect(result.product).toBe("Chrome/123.0.0.0");
+      });
+    } finally {
+      await server.stop();
+    }
+  });
+
+  test("rejects with cdp_error when the peer returns a JSON-RPC error", async () => {
+    const server = startFakeWsServer({
+      onMessage(ws, frame) {
+        ws.send(
+          JSON.stringify({
+            id: frame.id,
+            error: {
+              code: -32601,
+              message: "Method not found",
+              data: { method: frame.method },
+            },
+          }),
+        );
+      },
+    });
+    try {
+      await withTransport(server, async (transport) => {
+        await expect(transport.send("Bogus.method")).rejects.toMatchObject({
+          name: "CdpWsTransportError",
+          code: "cdp_error",
+          cdpMethod: "Bogus.method",
+          cdpCode: -32601,
+          cdpMessage: "Method not found",
+        });
+      });
+    } finally {
+      await server.stop();
+    }
+  });
+
+  test("handles concurrent out-of-order responses", async () => {
+    const pendingFrames: WsFrame[] = [];
+    const server = startFakeWsServer({
+      onMessage(ws, frame) {
+        pendingFrames.push(frame);
+        // Respond in reverse order after all three arrive.
+        if (pendingFrames.length === 3) {
+          const [f1, f2, f3] = pendingFrames;
+          ws.send(JSON.stringify({ id: f3!.id, result: { n: 3 } }));
+          ws.send(JSON.stringify({ id: f1!.id, result: { n: 1 } }));
+          ws.send(JSON.stringify({ id: f2!.id, result: { n: 2 } }));
+        }
+      },
+    });
+    try {
+      await withTransport(server, async (transport) => {
+        const p1 = transport.send<{ n: number }>("A.one");
+        const p2 = transport.send<{ n: number }>("B.two");
+        const p3 = transport.send<{ n: number }>("C.three");
+        const results = await Promise.all([p1, p2, p3]);
+        expect(results).toEqual([{ n: 1 }, { n: 2 }, { n: 3 }]);
+      });
+    } finally {
+      await server.stop();
+    }
+  });
+
+  test("fans out events (frames with no id) to listeners", async () => {
+    const server = startFakeWsServer({
+      onOpen(ws) {
+        // Push an unsolicited event shortly after open.
+        setTimeout(() => {
+          ws.send(
+            JSON.stringify({
+              method: "Target.targetCreated",
+              params: { targetId: "abc" },
+              sessionId: "S1",
+            }),
+          );
+        }, 5);
+      },
+    });
+    try {
+      await withTransport(server, async (transport) => {
+        const received: Array<{
+          method: string;
+          params?: unknown;
+          sessionId?: string;
+        }> = [];
+        transport.addEventListener((ev) => {
+          received.push(ev);
+        });
+        // Wait for the event to arrive.
+        await new Promise((r) => setTimeout(r, 50));
+        expect(received).toEqual([
+          {
+            method: "Target.targetCreated",
+            params: { targetId: "abc" },
+            sessionId: "S1",
+          },
+        ]);
+      });
+    } finally {
+      await server.stop();
+    }
+  });
+
+  test("does not resolve any pending request for a no-id event", async () => {
+    let gotRequest = false;
+    const server = startFakeWsServer({
+      onOpen(ws) {
+        // Emit a no-id event before any send() happens.
+        setTimeout(() => {
+          ws.send(
+            JSON.stringify({
+              method: "Target.attachedToTarget",
+              params: {},
+            }),
+          );
+        }, 5);
+      },
+      onMessage(ws, frame) {
+        gotRequest = true;
+        ws.send(JSON.stringify({ id: frame.id, result: { ok: true } }));
+      },
+    });
+    try {
+      await withTransport(server, async (transport) => {
+        await new Promise((r) => setTimeout(r, 20));
+        // Pending-request map must still be empty here — otherwise
+        // a subsequent send would deadlock on a stale entry.
+        const result = await transport.send<{ ok: boolean }>("Test.ping");
+        expect(result.ok).toBe(true);
+        expect(gotRequest).toBe(true);
+      });
+    } finally {
+      await server.stop();
+    }
+  });
+
+  test("forwards sessionId on the wire when opts.sessionId is provided", async () => {
+    let seen: WsFrame | null = null;
+    const server = startFakeWsServer({
+      onMessage(ws, frame) {
+        seen = frame;
+        ws.send(JSON.stringify({ id: frame.id, result: {} }));
+      },
+    });
+    try {
+      await withTransport(server, async (transport) => {
+        await transport.send("Runtime.enable", undefined, {
+          sessionId: "sess-42",
+        });
+      });
+      expect(seen).not.toBeNull();
+      // seen is WsFrame | null; narrow via unknown for the
+      // assertions below (TS narrows `seen` to `null` inside the
+      // closure, which is why a direct cast trips noImplicitAny).
+      const frame = seen as unknown as WsFrame;
+      expect(frame.sessionId).toBe("sess-42");
+      expect(frame.method).toBe("Runtime.enable");
+    } finally {
+      await server.stop();
+    }
+  });
+
+  test("abort mid-request rejects with aborted and drops late response", async () => {
+    let deferredFrameId: number | undefined;
+    let serverWs: ServerWebSocket<undefined> | null = null;
+    const server = startFakeWsServer({
+      onMessage(ws, frame) {
+        // Hold the response indefinitely so the abort can race.
+        deferredFrameId = frame.id;
+        serverWs = ws;
+      },
+    });
+    try {
+      const transport = await connectCdpWsTransport(server.url);
+      try {
+        const controller = new AbortController();
+        const sendPromise = transport.send(
+          "Slow.call",
+          {},
+          {
+            signal: controller.signal,
+          },
+        );
+        // Let the request land on the server.
+        await new Promise((r) => setTimeout(r, 20));
+        controller.abort();
+        await expect(sendPromise).rejects.toMatchObject({
+          name: "CdpWsTransportError",
+          code: "aborted",
+          cdpMethod: "Slow.call",
+        });
+        // Now deliver a response for the dropped id. The transport
+        // should silently ignore it — a subsequent send should
+        // still work and MUST NOT deadlock.
+        if (deferredFrameId !== undefined && serverWs) {
+          (serverWs as ServerWebSocket<undefined>).send(
+            JSON.stringify({ id: deferredFrameId, result: { late: true } }),
+          );
+        }
+        // Follow-up request must still function.
+        await new Promise((r) => setTimeout(r, 10));
+      } finally {
+        transport.dispose();
+      }
+    } finally {
+      await server.stop();
+    }
+  });
+
+  test("server close mid-request rejects pending with closed", async () => {
+    const server = startFakeWsServer({
+      onMessage(ws) {
+        // Close the socket without responding.
+        ws.close();
+      },
+    });
+    try {
+      const transport = await connectCdpWsTransport(server.url);
+      try {
+        let caught: unknown;
+        try {
+          await transport.send("Some.method");
+        } catch (err) {
+          caught = err;
+        }
+        expect(caught).toBeInstanceOf(CdpWsTransportError);
+        expect((caught as CdpWsTransportError).code).toBe("closed");
+
+        // After close, subsequent sends also reject with closed.
+        let caught2: unknown;
+        try {
+          await transport.send("Another.method");
+        } catch (err) {
+          caught2 = err;
+        }
+        expect(caught2).toBeInstanceOf(CdpWsTransportError);
+        expect((caught2 as CdpWsTransportError).code).toBe("closed");
+      } finally {
+        transport.dispose();
+      }
+    } finally {
+      await server.stop();
+    }
+  });
+
+  test("connect rejects with transport_error when peer refuses upgrade", async () => {
+    const server = startNonWsServer();
+    try {
+      await expect(
+        connectCdpWsTransport(server.url, { connectTimeoutMs: 500 }),
+      ).rejects.toMatchObject({
+        name: "CdpWsTransportError",
+      });
+      // Code can be either timeout or transport_error depending on
+      // how the runtime surfaces an HTTP 400 upgrade failure — both
+      // are acceptable per the transport contract.
+      try {
+        await connectCdpWsTransport(server.url, { connectTimeoutMs: 200 });
+      } catch (err) {
+        expect(err).toBeInstanceOf(CdpWsTransportError);
+        const code = (err as CdpWsTransportError).code;
+        expect(["timeout", "transport_error"]).toContain(code);
+      }
+    } finally {
+      await server.stop();
+    }
+  });
+
+  test("connect rejects with timeout when peer never accepts", async () => {
+    // A server that hangs forever (never responds to the upgrade).
+    // We simulate this by pointing at an unroutable port guarded by
+    // a very short connect timeout; expect either timeout or
+    // transport_error since runtimes vary in how they surface a
+    // refused connection.
+    let err: unknown;
+    try {
+      await connectCdpWsTransport("ws://127.0.0.1:1", {
+        connectTimeoutMs: 100,
+      });
+    } catch (caught) {
+      err = caught;
+    }
+    expect(err).toBeInstanceOf(CdpWsTransportError);
+    const code = (err as CdpWsTransportError).code;
+    expect(["timeout", "transport_error"]).toContain(code);
+  });
+
+  test("dispose is idempotent", async () => {
+    const server = startFakeWsServer({});
+    try {
+      const transport = await connectCdpWsTransport(server.url);
+      transport.dispose();
+      expect(() => transport.dispose()).not.toThrow();
+      expect(() => transport.dispose()).not.toThrow();
+      // send after dispose rejects with closed.
+      await expect(transport.send("X")).rejects.toMatchObject({
+        code: "closed",
+      });
+    } finally {
+      await server.stop();
+    }
+  });
+
+  test("dispose rejects any in-flight pending requests with closed", async () => {
+    const server = startFakeWsServer({
+      onMessage() {
+        // Never respond — we want the request to stay pending until
+        // dispose fires.
+      },
+    });
+    try {
+      const transport = await connectCdpWsTransport(server.url);
+      const p = transport.send("Never.responds");
+      // Give the request time to reach the server.
+      await new Promise((r) => setTimeout(r, 20));
+      transport.dispose();
+      await expect(p).rejects.toMatchObject({
+        name: "CdpWsTransportError",
+        code: "closed",
+      });
+    } finally {
+      await server.stop();
+    }
+  });
+
+  test("addEventListener returns an unsubscribe function", async () => {
+    const server = startFakeWsServer({
+      onOpen(ws) {
+        setTimeout(() => {
+          ws.send(JSON.stringify({ method: "Ev.first", params: {} }));
+          setTimeout(() => {
+            ws.send(JSON.stringify({ method: "Ev.second", params: {} }));
+          }, 10);
+        }, 5);
+      },
+    });
+    try {
+      await withTransport(server, async (transport) => {
+        const received: string[] = [];
+        const unsub = transport.addEventListener((ev) => {
+          received.push(ev.method);
+          if (ev.method === "Ev.first") unsub();
+        });
+        await new Promise((r) => setTimeout(r, 60));
+        expect(received).toEqual(["Ev.first"]);
+      });
+    } finally {
+      await server.stop();
+    }
+  });
+
+  test("send after dispose rejects immediately with closed", async () => {
+    const server = startFakeWsServer({});
+    try {
+      const transport = await connectCdpWsTransport(server.url);
+      transport.dispose();
+      await expect(transport.send("Page.enable")).rejects.toMatchObject({
+        name: "CdpWsTransportError",
+        code: "closed",
+        cdpMethod: "Page.enable",
+      });
+    } finally {
+      await server.stop();
+    }
+  });
+
+  test("listener errors are swallowed and do not affect correlation", async () => {
+    const server = startFakeWsServer({
+      onOpen(ws) {
+        setTimeout(() => {
+          ws.send(JSON.stringify({ method: "Boom.event", params: {} }));
+        }, 5);
+      },
+      onMessage(ws, frame) {
+        ws.send(JSON.stringify({ id: frame.id, result: { ok: true } }));
+      },
+    });
+    try {
+      await withTransport(server, async (transport) => {
+        transport.addEventListener(() => {
+          throw new Error("listener crash");
+        });
+        // Wait for the event to arrive and be swallowed.
+        await new Promise((r) => setTimeout(r, 20));
+        // Subsequent requests must still work.
+        const result = await transport.send<{ ok: boolean }>("Page.enable");
+        expect(result.ok).toBe(true);
+      });
+    } finally {
+      await server.stop();
+    }
+  });
+});

--- a/assistant/src/tools/browser/cdp-client/cdp-inspect/ws-transport.ts
+++ b/assistant/src/tools/browser/cdp-client/cdp-inspect/ws-transport.ts
@@ -1,0 +1,549 @@
+/**
+ * Raw CDP JSON-RPC WebSocket transport used by the `cdp-inspect`
+ * backend. This module is intentionally backend-agnostic: it has no
+ * dependency on the browser-session manager, the cdp-inspect client,
+ * or any feature-flag / config plumbing. It simply adapts a CDP
+ * WebSocket URL (as returned from DevTools `/json/version` or
+ * `/json/list`) into an asynchronous request/response + event
+ * interface.
+ *
+ * The transport is deliberately minimal:
+ *   - `send(method, params, opts?)` writes a JSON-RPC 2.0 request
+ *     frame with a monotonic id, registers a pending entry in the
+ *     correlation map, and resolves/rejects when the matching
+ *     response arrives (or the socket dies / the caller aborts).
+ *   - `addEventListener(listener)` subscribes to every inbound frame
+ *     that carries no `id` — these are CDP domain events fanned out
+ *     verbatim to listeners. Listeners do not affect request/response
+ *     correlation.
+ *   - `dispose()` proactively closes the socket and rejects every
+ *     still-pending request exactly once with `CdpWsTransportError(
+ *     "closed")`. It is idempotent.
+ *
+ * Failure modes map 1:1 onto {@link CdpWsTransportError} codes:
+ *   - `closed`         — the socket was closed (remote close,
+ *                        `dispose()`, or a pending send racing an
+ *                        already-closed transport).
+ *   - `aborted`        — the per-request `AbortSignal` fired. Any
+ *                        subsequent CDP response for that id is
+ *                        silently dropped.
+ *   - `timeout`        — the connect timeout expired before the
+ *                        socket reached `OPEN`.
+ *   - `transport_error`— a WebSocket `error` event fired, or a send
+ *                        failed (e.g. serialization failure).
+ *   - `cdp_error`      — the peer returned a JSON-RPC error envelope
+ *                        (`{id, error: {code, message}}`).
+ */
+
+export type CdpWsTransportErrorCode =
+  | "closed"
+  | "aborted"
+  | "timeout"
+  | "transport_error"
+  | "cdp_error";
+
+/**
+ * Error thrown (or used to reject) by {@link CdpWsTransport} and
+ * {@link connectCdpWsTransport}. The `code` discriminates the
+ * category of failure so callers can branch without string-sniffing
+ * the message. For `cdp_error`, the CDP JSON-RPC error envelope
+ * fields are copied through verbatim for logging and upstream
+ * error mapping.
+ */
+export class CdpWsTransportError extends Error {
+  readonly code: CdpWsTransportErrorCode;
+  readonly cdpMethod?: string;
+  readonly cdpCode?: number;
+  readonly cdpMessage?: string;
+  readonly cdpData?: unknown;
+  readonly underlying?: unknown;
+
+  constructor(
+    code: CdpWsTransportErrorCode,
+    message?: string,
+    details?: {
+      cdpMethod?: string;
+      cdpCode?: number;
+      cdpMessage?: string;
+      cdpData?: unknown;
+      underlying?: unknown;
+    },
+  ) {
+    super(message ?? code);
+    this.name = "CdpWsTransportError";
+    this.code = code;
+    this.cdpMethod = details?.cdpMethod;
+    this.cdpCode = details?.cdpCode;
+    this.cdpMessage = details?.cdpMessage;
+    this.cdpData = details?.cdpData;
+    this.underlying = details?.underlying;
+  }
+}
+
+/**
+ * Payload handed to event listeners registered via
+ * {@link CdpWsTransport.addEventListener}. Mirrors the wire-level
+ * shape of a CDP JSON-RPC notification minus the `id` field
+ * (notifications, by definition, carry no id).
+ */
+export interface CdpTransportEvent {
+  method: string;
+  params?: unknown;
+  sessionId?: string;
+}
+
+/**
+ * Public interface exposed by this transport. Deliberately narrower
+ * than the higher-level `CdpClient` type used by tool code — this
+ * layer does not know about conversations, backend selection, or
+ * CDP error mapping to the shared `CdpError` taxonomy.
+ */
+export interface CdpWsTransport {
+  /**
+   * Send a CDP method call over the socket and await its response.
+   *
+   * - `method` / `params` are serialized verbatim into a JSON-RPC
+   *   2.0 request envelope.
+   * - `opts.sessionId`, if provided, is forwarded on the wire as a
+   *   top-level `sessionId` field — required for CDP "flattened"
+   *   session attach mode.
+   * - `opts.signal` cancels the pending request: the returned
+   *   promise rejects with `CdpWsTransportError("aborted")` and any
+   *   subsequent response carrying the matching id is dropped.
+   *
+   * Failure modes:
+   *   - resolves with the `result` field on success.
+   *   - rejects with `cdp_error` if the peer returns a
+   *     `{id, error}` envelope.
+   *   - rejects with `closed` if the socket closes (or is disposed)
+   *     before a response arrives.
+   *   - rejects with `aborted` if the caller cancels.
+   *   - rejects with `transport_error` if the send itself fails
+   *     (e.g. the socket is already in a non-OPEN state and we race
+   *     a close, or JSON serialization fails).
+   */
+  send<T = unknown>(
+    method: string,
+    params?: Record<string, unknown>,
+    opts?: { sessionId?: string; signal?: AbortSignal },
+  ): Promise<T>;
+
+  /**
+   * Register a listener for every inbound JSON-RPC notification
+   * (i.e. any frame whose `id` is missing). Returns an unsubscribe
+   * function. Listener errors are swallowed so one bad consumer
+   * cannot tear down the transport.
+   */
+  addEventListener(listener: (event: CdpTransportEvent) => void): () => void;
+
+  /**
+   * Close the underlying socket and reject every still-pending
+   * request with `CdpWsTransportError("closed")`. Idempotent —
+   * calling `dispose()` twice does nothing on the second call. A
+   * `dispose()` after a remote close is still safe.
+   */
+  dispose(): void;
+}
+
+interface PendingRequest {
+  resolve: (value: unknown) => void;
+  reject: (err: CdpWsTransportError) => void;
+  method: string;
+  // Listener cleanup for the per-request abort signal. May be null if
+  // the caller did not provide a signal.
+  cleanupAbort: (() => void) | null;
+}
+
+/**
+ * Minimal structural shape of the WebSocket we depend on. Using a
+ * local interface (instead of the DOM / bun-types `WebSocket`
+ * global's static constants) lets us stay compatible with either
+ * runtime and keeps the tests free of DOM typing hassles.
+ */
+interface WsLike {
+  readyState: number;
+  send(data: string): void;
+  close(): void;
+  addEventListener(type: "open", listener: () => void): void;
+  addEventListener(type: "close", listener: () => void): void;
+  addEventListener(type: "error", listener: (ev: unknown) => void): void;
+  addEventListener(
+    type: "message",
+    listener: (ev: { data: unknown }) => void,
+  ): void;
+  removeEventListener?: (type: string, listener: unknown) => void;
+}
+
+// WebSocket.readyState constants. We avoid depending on the global
+// WebSocket static (e.g. `WebSocket.OPEN`) because test fakes may not
+// expose the static properties.
+const WS_OPEN = 1;
+
+const DEFAULT_CONNECT_TIMEOUT_MS = 5_000;
+
+/**
+ * Open a raw CDP WebSocket transport against `url`. Resolves only
+ * after the socket has reached `OPEN`; rejects with
+ * `CdpWsTransportError("timeout")` if the connect-timeout expires or
+ * `transport_error` if the socket errors or closes before opening.
+ */
+export async function connectCdpWsTransport(
+  url: string,
+  opts?: { connectTimeoutMs?: number },
+): Promise<CdpWsTransport> {
+  const connectTimeoutMs = opts?.connectTimeoutMs ?? DEFAULT_CONNECT_TIMEOUT_MS;
+
+  // bun's global `WebSocket` is API-compatible with the browser one.
+  const WebSocketCtor: new (url: string) => WsLike = (
+    globalThis as unknown as {
+      WebSocket: new (url: string) => WsLike;
+    }
+  ).WebSocket;
+  if (typeof WebSocketCtor !== "function") {
+    throw new CdpWsTransportError(
+      "transport_error",
+      "global WebSocket is not available in this runtime",
+    );
+  }
+
+  let ws: WsLike;
+  try {
+    ws = new WebSocketCtor(url);
+  } catch (err) {
+    throw new CdpWsTransportError(
+      "transport_error",
+      err instanceof Error ? err.message : String(err),
+      { underlying: err },
+    );
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      try {
+        ws.close();
+      } catch {
+        // best effort
+      }
+      reject(new CdpWsTransportError("timeout", "connect timeout"));
+    }, connectTimeoutMs);
+
+    const onOpen = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve();
+    };
+    const onError = (ev: unknown) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      try {
+        ws.close();
+      } catch {
+        // best effort
+      }
+      reject(
+        new CdpWsTransportError(
+          "transport_error",
+          "websocket error during connect",
+          { underlying: ev },
+        ),
+      );
+    };
+    const onCloseBeforeOpen = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      reject(
+        new CdpWsTransportError(
+          "transport_error",
+          "websocket closed before open",
+        ),
+      );
+    };
+
+    ws.addEventListener("open", onOpen);
+    ws.addEventListener("error", onError);
+    ws.addEventListener("close", onCloseBeforeOpen);
+  });
+
+  return createTransport(ws);
+}
+
+function createTransport(ws: WsLike): CdpWsTransport {
+  const pending = new Map<number, PendingRequest>();
+  const listeners = new Set<(event: CdpTransportEvent) => void>();
+  let nextId = 1;
+  let disposed = false;
+  let closed = false;
+
+  const rejectAllPending = (code: CdpWsTransportErrorCode, message: string) => {
+    if (pending.size === 0) return;
+    // Snapshot entries so that caller `.catch()` handlers invoked
+    // synchronously via `reject` cannot mutate the map we are iterating.
+    const entries = Array.from(pending.entries());
+    pending.clear();
+    for (const [, entry] of entries) {
+      entry.cleanupAbort?.();
+      entry.reject(
+        new CdpWsTransportError(code, message, { cdpMethod: entry.method }),
+      );
+    }
+  };
+
+  const handleMessage = (ev: { data: unknown }) => {
+    if (disposed) return;
+    let raw: string;
+    if (typeof ev.data === "string") {
+      raw = ev.data;
+    } else if (ev.data instanceof ArrayBuffer) {
+      raw = new TextDecoder().decode(ev.data);
+    } else if (
+      typeof (ev.data as { toString?: () => string })?.toString === "function"
+    ) {
+      raw = String(ev.data);
+    } else {
+      // Unknown binary payload — CDP is always JSON text, so drop it.
+      return;
+    }
+    let frame: unknown;
+    try {
+      frame = JSON.parse(raw);
+    } catch {
+      return;
+    }
+    if (!frame || typeof frame !== "object") return;
+    const obj = frame as {
+      id?: unknown;
+      result?: unknown;
+      error?: { code?: unknown; message?: unknown; data?: unknown };
+      method?: unknown;
+      params?: unknown;
+      sessionId?: unknown;
+    };
+
+    if (typeof obj.id === "number") {
+      const entry = pending.get(obj.id);
+      if (!entry) {
+        // Either an unknown id (protocol violation) or an aborted
+        // request whose entry we already removed — drop silently.
+        return;
+      }
+      pending.delete(obj.id);
+      entry.cleanupAbort?.();
+      if (obj.error && typeof obj.error === "object") {
+        const cdpCode =
+          typeof obj.error.code === "number" ? obj.error.code : undefined;
+        const cdpMessage =
+          typeof obj.error.message === "string" ? obj.error.message : undefined;
+        entry.reject(
+          new CdpWsTransportError(
+            "cdp_error",
+            cdpMessage ?? `cdp error for ${entry.method}`,
+            {
+              cdpMethod: entry.method,
+              cdpCode,
+              cdpMessage,
+              cdpData: obj.error.data,
+            },
+          ),
+        );
+      } else {
+        entry.resolve(obj.result);
+      }
+      return;
+    }
+
+    // No id → CDP domain event. Fan out to listeners, swallowing
+    // any listener throws.
+    if (typeof obj.method === "string") {
+      const event: CdpTransportEvent = {
+        method: obj.method,
+        params: obj.params,
+        sessionId:
+          typeof obj.sessionId === "string" ? obj.sessionId : undefined,
+      };
+      for (const listener of listeners) {
+        try {
+          listener(event);
+        } catch {
+          // listener errors are swallowed to keep the transport alive
+        }
+      }
+    }
+  };
+
+  const handleClose = () => {
+    if (closed) return;
+    closed = true;
+    rejectAllPending("closed", "websocket closed");
+  };
+
+  const handleError = (ev: unknown) => {
+    if (closed) return;
+    closed = true;
+    // Best-effort close after an error so we don't leak a half-open
+    // socket. Do not throw on already-closed sockets.
+    try {
+      ws.close();
+    } catch {
+      // ignored
+    }
+    // Reject pending as transport_error so callers can distinguish
+    // a protocol-level peer close from an explicit socket error.
+    if (pending.size > 0) {
+      const entries = Array.from(pending.entries());
+      pending.clear();
+      for (const [, entry] of entries) {
+        entry.cleanupAbort?.();
+        entry.reject(
+          new CdpWsTransportError("transport_error", "websocket error", {
+            cdpMethod: entry.method,
+            underlying: ev,
+          }),
+        );
+      }
+    }
+  };
+
+  ws.addEventListener("message", handleMessage);
+  ws.addEventListener("close", handleClose);
+  ws.addEventListener("error", handleError);
+
+  const transport: CdpWsTransport = {
+    send<T = unknown>(
+      method: string,
+      params?: Record<string, unknown>,
+      opts?: { sessionId?: string; signal?: AbortSignal },
+    ): Promise<T> {
+      if (disposed || closed) {
+        return Promise.reject(
+          new CdpWsTransportError("closed", "transport already closed", {
+            cdpMethod: method,
+          }),
+        );
+      }
+      const signal = opts?.signal;
+      if (signal?.aborted) {
+        return Promise.reject(
+          new CdpWsTransportError("aborted", "aborted before send", {
+            cdpMethod: method,
+          }),
+        );
+      }
+
+      const id = nextId++;
+      const frame: Record<string, unknown> = { id, method };
+      if (params !== undefined) frame.params = params;
+      if (opts?.sessionId !== undefined) frame.sessionId = opts.sessionId;
+
+      let serialized: string;
+      try {
+        serialized = JSON.stringify(frame);
+      } catch (err) {
+        return Promise.reject(
+          new CdpWsTransportError(
+            "transport_error",
+            err instanceof Error ? err.message : String(err),
+            { cdpMethod: method, underlying: err },
+          ),
+        );
+      }
+
+      // Guard against sending on a non-OPEN socket. By construction
+      // the socket is OPEN at the time we hand the transport to
+      // callers (connectCdpWsTransport waits for the `open` event),
+      // so any other readyState means the socket has since moved
+      // past OPEN — treat it as closed so callers can't observe
+      // silently dropped frames.
+      if (ws.readyState !== WS_OPEN) {
+        return Promise.reject(
+          new CdpWsTransportError("closed", "socket not open", {
+            cdpMethod: method,
+          }),
+        );
+      }
+
+      return new Promise<T>((resolve, reject) => {
+        // Register the pending entry FIRST so that an abort or
+        // inbound response racing the rest of this function body
+        // always has a live entry to act on. Without this ordering
+        // a synchronous abort registered below could fire before
+        // the entry exists, silently dropping the cancellation.
+        pending.set(id, {
+          resolve: (value: unknown) => resolve(value as T),
+          reject,
+          method,
+          cleanupAbort: null,
+        });
+
+        if (signal) {
+          const onAbort = () => {
+            const entry = pending.get(id);
+            if (!entry) return;
+            pending.delete(id);
+            entry.cleanupAbort?.();
+            entry.reject(
+              new CdpWsTransportError("aborted", "aborted during send", {
+                cdpMethod: method,
+              }),
+            );
+          };
+          signal.addEventListener("abort", onAbort, { once: true });
+          const entry = pending.get(id);
+          if (entry) {
+            entry.cleanupAbort = () => {
+              signal.removeEventListener("abort", onAbort);
+            };
+          }
+        }
+
+        try {
+          ws.send(serialized);
+        } catch (err) {
+          const entry = pending.get(id);
+          if (entry) {
+            pending.delete(id);
+            entry.cleanupAbort?.();
+          }
+          reject(
+            new CdpWsTransportError(
+              "transport_error",
+              err instanceof Error ? err.message : String(err),
+              { cdpMethod: method, underlying: err },
+            ),
+          );
+        }
+      });
+    },
+
+    addEventListener(listener) {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      // Reject pending requests BEFORE calling close() so that
+      // callers observe the explicit "disposed" signal even if the
+      // underlying `close()` fires a synchronous `close` event.
+      rejectAllPending("closed", "transport disposed");
+      if (!closed) {
+        closed = true;
+        try {
+          ws.close();
+        } catch {
+          // ignored — already-closed sockets may throw
+        }
+      }
+    },
+  };
+
+  return transport;
+}


### PR DESCRIPTION
## Summary
- Add `connectCdpWsTransport` raw CDP JSON-RPC client with id correlation, event fanout, and timeout handling
- Define `CdpWsTransportError` with codes: closed, aborted, timeout, transport_error, cdp_error
- Bun fake-ws-server test suite covering success, cdp errors, concurrency, abort, close, timeout, idempotent dispose

Part of plan: browser-cdp-inspect-phase4.md (PR 2 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24602" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
