### PR TITLE
Rename Record/Unbind shortcut labels to Change/Remove

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
@@ -172,11 +172,11 @@ struct SettingsAppearanceTab: View {
                         }
                     } else {
                         HStack(spacing: VSpacing.sm) {
-                            VButton(label: "Record", style: .outlined) {
+                            VButton(label: "Change", style: .outlined) {
                                 startRecording()
                             }
                             if !store.globalHotkeyShortcut.isEmpty {
-                                VButton(label: "Unbind", style: .outlined) {
+                                VButton(label: "Remove", style: .outlined) {
                                     store.globalHotkeyShortcut = ""
                                 }
                             }
@@ -212,11 +212,11 @@ struct SettingsAppearanceTab: View {
                         }
                     } else {
                         HStack(spacing: VSpacing.sm) {
-                            VButton(label: "Record", style: .outlined) {
+                            VButton(label: "Change", style: .outlined) {
                                 startRecordingQuickInput()
                             }
                             if !store.quickInputHotkeyShortcut.isEmpty {
-                                VButton(label: "Unbind", style: .outlined) {
+                                VButton(label: "Remove", style: .outlined) {
                                     store.quickInputHotkeyShortcut = ""
                                     store.quickInputHotkeyKeyCode = 0
                                 }
@@ -244,11 +244,11 @@ struct SettingsAppearanceTab: View {
                     } else {
                         VShortcutTag(activator.kind != .none ? "Hold \(activator.displayName)" : "Disabled")
                         HStack(spacing: VSpacing.sm) {
-                            VButton(label: "Record", style: .outlined) {
+                            VButton(label: "Change", style: .outlined) {
                                 startRecordingVoiceInput()
                             }
                             if activator.kind != .none {
-                                VButton(label: "Unbind", style: .outlined) {
+                                VButton(label: "Remove", style: .outlined) {
                                     PTTActivator.off.store()
                                     PTTActivator.updateCache(.off)
                                     activationKey = "none"
@@ -280,11 +280,11 @@ struct SettingsAppearanceTab: View {
                         }
                     } else {
                         HStack(spacing: VSpacing.sm) {
-                            VButton(label: "Record", style: .outlined) {
+                            VButton(label: "Change", style: .outlined) {
                                 startRecordingNewChat()
                             }
                             if !store.newChatShortcut.isEmpty {
-                                VButton(label: "Unbind", style: .outlined) {
+                                VButton(label: "Remove", style: .outlined) {
                                     store.newChatShortcut = ""
                                 }
                             }
@@ -313,11 +313,11 @@ struct SettingsAppearanceTab: View {
                         }
                     } else {
                         HStack(spacing: VSpacing.sm) {
-                            VButton(label: "Record", style: .outlined) {
+                            VButton(label: "Change", style: .outlined) {
                                 startRecordingCurrentConversation()
                             }
                             if !store.currentConversationShortcut.isEmpty {
-                                VButton(label: "Unbind", style: .outlined) {
+                                VButton(label: "Remove", style: .outlined) {
                                     store.currentConversationShortcut = ""
                                 }
                             }
@@ -346,11 +346,11 @@ struct SettingsAppearanceTab: View {
                         }
                     } else {
                         HStack(spacing: VSpacing.sm) {
-                            VButton(label: "Record", style: .outlined) {
+                            VButton(label: "Change", style: .outlined) {
                                 startRecordingSidebarToggle()
                             }
                             if !store.sidebarToggleShortcut.isEmpty {
-                                VButton(label: "Unbind", style: .outlined) {
+                                VButton(label: "Remove", style: .outlined) {
                                     store.sidebarToggleShortcut = ""
                                 }
                             }
@@ -379,11 +379,11 @@ struct SettingsAppearanceTab: View {
                         }
                     } else {
                         HStack(spacing: VSpacing.sm) {
-                            VButton(label: "Record", style: .outlined) {
+                            VButton(label: "Change", style: .outlined) {
                                 startRecordingPopOut()
                             }
                             if !store.popOutShortcut.isEmpty {
-                                VButton(label: "Unbind", style: .outlined) {
+                                VButton(label: "Remove", style: .outlined) {
                                     store.popOutShortcut = ""
                                 }
                             }


### PR DESCRIPTION
## Summary
- Renamed "Record" button labels to "Change" across all 7 keyboard shortcut settings
- Renamed "Unbind" button labels to "Remove" across all 7 keyboard shortcut settings
- Makes the shortcut configuration UI more intuitive for users

Closes LUM-737

## Original prompt
--safe https://linear.app/vellum/issue/LUM-737/rename-record-unbind-shortcut-labels-to-something-more-intuitive do Change" / "Remove
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24605" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
