### PR TITLE
feat(browser): add CdpInspectClient and cdp-inspect BrowserSession backend adapter

### DIFF
--- a/assistant/src/browser-session/backends/cdp-inspect.ts
+++ b/assistant/src/browser-session/backends/cdp-inspect.ts
@@ -1,0 +1,30 @@
+import type { BrowserBackend, CdpCommand, CdpResult } from "../types.js";
+
+/**
+ * cdp-inspect backend for BrowserSessionManager. Wraps a
+ * caller-provided `sendCdp` transport that talks to an already-running
+ * Chrome via DevTools JSON discovery + a raw WebSocket transport
+ * (see `assistant/src/tools/browser/cdp-client/cdp-inspect-client.ts`).
+ *
+ * The factory in
+ * `assistant/src/tools/browser/cdp-client/factory.ts` will construct
+ * one per tool invocation in PR 5, paralleling the existing extension
+ * and local backend wiring.
+ */
+export interface CdpInspectBackendDeps {
+  /** Sends a CDP command to the user's Chrome via cdp-inspect and returns the CDP result. */
+  sendCdp(command: CdpCommand, signal?: AbortSignal): Promise<CdpResult>;
+  isAvailable(): boolean;
+  dispose(): void;
+}
+
+export function createCdpInspectBackend(
+  deps: CdpInspectBackendDeps,
+): BrowserBackend {
+  return {
+    kind: "cdp-inspect",
+    isAvailable: deps.isAvailable,
+    send: deps.sendCdp,
+    dispose: deps.dispose,
+  };
+}

--- a/assistant/src/browser-session/index.ts
+++ b/assistant/src/browser-session/index.ts
@@ -9,6 +9,7 @@
  * routes `send()` through the manager. This gives every call site a single
  * choke point for session invalidation and future multi-tab routing.
  */
+export * from "./backends/cdp-inspect.js";
 export * from "./backends/extension.js";
 export * from "./backends/local.js";
 export * from "./events.js";

--- a/assistant/src/tools/browser/cdp-client/__tests__/cdp-inspect-client.test.ts
+++ b/assistant/src/tools/browser/cdp-client/__tests__/cdp-inspect-client.test.ts
@@ -686,6 +686,132 @@ describe("CdpInspectClient", () => {
     expect(probeSignalSeen?.aborted).toBe(true);
   });
 
+  test("a new send() after all waiters abort starts a fresh attach", async () => {
+    // Regression test for the race condition where onAbort aborts
+    // the shared controller but `this.pending` is only cleared later
+    // via the async `.catch()` handler in startAttach(). A new caller
+    // entering ensureSession() between those two events would reuse
+    // the already-aborted pending attach and immediately fail with an
+    // `aborted` error even though it never aborted its own signal.
+    //
+    // Fix: onAbort now clears `this.pending` synchronously BEFORE
+    // firing the shared controller.abort(), so any new caller after
+    // the abort starts a fresh attach.
+    let probeCount = 0;
+    let listCount = 0;
+    let connectCount = 0;
+
+    // The first probe hangs until the shared controller aborts it.
+    // The second probe (from the fresh attach) resolves normally.
+    const firstProbeStarted = Promise.withResolvers<void>();
+
+    const client = createCdpInspectClient("conv-race", {
+      host: "127.0.0.1",
+      port: 9222,
+      helpers: {
+        probeDevToolsJsonVersion: async (probeOpts) => {
+          probeCount += 1;
+          const signal = (probeOpts as { signal?: AbortSignal }).signal;
+          if (probeCount === 1) {
+            firstProbeStarted.resolve();
+            // Stall until the shared controller aborts us.
+            await new Promise<never>((_, reject) => {
+              const onAbort = () => {
+                reject(new Error("probe aborted via shared controller"));
+              };
+              if (signal?.aborted) {
+                onAbort();
+              } else {
+                signal?.addEventListener("abort", onAbort, { once: true });
+              }
+            });
+            throw new Error("unreachable");
+          }
+          return {
+            browser: "Chrome/125.0.0.0",
+            protocolVersion: "1.3",
+            webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/browser/fake",
+          };
+        },
+        listDevToolsTargets: async () => {
+          listCount += 1;
+          return [
+            {
+              id: "target-1",
+              type: "page",
+              title: "Example",
+              url: "https://example.com/",
+              webSocketDebuggerUrl:
+                "ws://127.0.0.1:9222/devtools/page/target-1",
+            },
+          ];
+        },
+        connectCdpWsTransport: async () => {
+          connectCount += 1;
+          return createFakeTransport({
+            onSend: async (method) => {
+              if (method === "Target.attachToTarget") {
+                return { sessionId: "session-race" };
+              }
+              return { ok: true };
+            },
+          });
+        },
+      },
+    });
+
+    // 1. First caller kicks off the attach with signal A.
+    const signalA = new AbortController();
+    const firstSend = client.send("Runtime.enable", undefined, signalA.signal);
+
+    // 2. Wait until the first probe has actually started so we know
+    //    the attach is in-flight and signal A is the only waiter.
+    await firstProbeStarted.promise;
+
+    // 3. Abort signal A. Because it's the only waiter, onAbort will
+    //    fire the shared controller and (with the fix) clear
+    //    `this.pending` synchronously.
+    signalA.abort();
+
+    // First caller should reject with `aborted`.
+    let firstErr: unknown;
+    try {
+      await firstSend;
+    } catch (err) {
+      firstErr = err;
+    }
+    expect(firstErr).toBeInstanceOf(CdpError);
+    expect((firstErr as InstanceType<typeof CdpError>).code).toBe("aborted");
+
+    // At this point, with the fix, `this.pending` has been cleared
+    // synchronously — but without the fix, it would still be set to
+    // the aborted pending until the `.catch()` handler in
+    // startAttach() runs asynchronously. We intentionally do NOT
+    // flush microtasks here before kicking off the second send() so
+    // that we exercise the race window.
+    //
+    // 4. New send() with its own signal B. With the fix, this should
+    //    start a fresh attach and complete successfully. Without the
+    //    fix, it would reuse the aborted pending and fail with an
+    //    `aborted` error even though signal B was never aborted.
+    const signalB = new AbortController();
+    const secondSend = client.send("Page.enable", undefined, signalB.signal);
+
+    // Second caller should succeed.
+    const secondResult = await secondSend;
+    expect(secondResult).toEqual({ ok: true });
+
+    // 5. Assert that the second send() kicked off a fresh attach —
+    //    probe, list, and connect should all have been called twice.
+    expect(probeCount).toBe(2);
+    expect(listCount).toBe(1);
+    expect(connectCount).toBe(1);
+    // listCount and connectCount are 1 because the first attach
+    // aborted during the probe stage — it never reached list or
+    // connect. The second (fresh) attach ran probe + list + connect
+    // all once.
+  });
+
   test("concurrent send() callers can abort independently", async () => {
     // Two callers race the same in-flight attach. The first caller
     // aborts; the second caller must still complete normally once the

--- a/assistant/src/tools/browser/cdp-client/__tests__/cdp-inspect-client.test.ts
+++ b/assistant/src/tools/browser/cdp-client/__tests__/cdp-inspect-client.test.ts
@@ -1,0 +1,600 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Silence the logger from cdp-inspect-client.
+mock.module("../../../../util/logger.js", () => ({
+  getLogger: () => ({
+    info: () => {},
+    debug: () => {},
+    warn: () => {},
+    error: () => {},
+  }),
+}));
+
+// Import under test AFTER mock.module calls so that the module's
+// top-level logger import resolves to our fake.
+const { CdpInspectClient, createCdpInspectClient } =
+  await import("../cdp-inspect-client.js");
+const { CdpError } = await import("../errors.js");
+const { CdpWsTransportError } = await import("../cdp-inspect/ws-transport.js");
+
+type CdpInspectClientInstance = InstanceType<typeof CdpInspectClient>;
+
+/**
+ * Minimal fake CdpWsTransport used by the test harness below. The
+ * handler is per-send so individual tests can model success, CDP
+ * errors, transport errors, and abort behavior on specific methods.
+ */
+interface FakeTransportOptions {
+  onSend?: (
+    method: string,
+    params: Record<string, unknown> | undefined,
+    opts: { sessionId?: string; signal?: AbortSignal },
+  ) => unknown | Promise<unknown>;
+  trackSends?: Array<{
+    method: string;
+    params?: Record<string, unknown>;
+    sessionId?: string;
+  }>;
+  trackDisposeCount?: { count: number };
+}
+
+function createFakeTransport(options: FakeTransportOptions) {
+  const transport = {
+    send: async <T = unknown>(
+      method: string,
+      params?: Record<string, unknown>,
+      opts?: { sessionId?: string; signal?: AbortSignal },
+    ): Promise<T> => {
+      options.trackSends?.push({
+        method,
+        params,
+        sessionId: opts?.sessionId,
+      });
+      if (options.onSend) {
+        const result = await options.onSend(method, params, opts ?? {});
+        return result as T;
+      }
+      return undefined as T;
+    },
+    addEventListener: () => () => {},
+    dispose: () => {
+      if (options.trackDisposeCount) {
+        options.trackDisposeCount.count += 1;
+      }
+    },
+  };
+  return transport;
+}
+
+/**
+ * Build a client wired to mocked discovery + transport helpers. The
+ * caller supplies handlers for the moving pieces; everything else
+ * defaults to a happy-path attach.
+ */
+interface HarnessOptions {
+  probeImpl?: (opts: unknown) => Promise<{
+    browser: string;
+    protocolVersion: string;
+    webSocketDebuggerUrl: string;
+  }>;
+  listImpl?: (opts: unknown) => Promise<
+    Array<{
+      id: string;
+      type: string;
+      title: string;
+      url: string;
+      webSocketDebuggerUrl: string;
+    }>
+  >;
+  connectImpl?: (
+    url: string,
+    opts?: { connectTimeoutMs?: number },
+  ) => Promise<ReturnType<typeof createFakeTransport>>;
+  transportOnSend?: FakeTransportOptions["onSend"];
+  conversationId?: string;
+}
+
+interface Harness {
+  client: CdpInspectClientInstance;
+  sends: Array<{
+    method: string;
+    params?: Record<string, unknown>;
+    sessionId?: string;
+  }>;
+  disposeCount: { count: number };
+  probeCalls: number;
+  listCalls: number;
+  connectCalls: number;
+  attachCallCount: () => number;
+}
+
+function createHarness(opts: HarnessOptions = {}): Harness {
+  const sends: Array<{
+    method: string;
+    params?: Record<string, unknown>;
+    sessionId?: string;
+  }> = [];
+  const disposeCount = { count: 0 };
+  let probeCalls = 0;
+  let listCalls = 0;
+  let connectCalls = 0;
+
+  // Track Target.attachToTarget specifically so tests can assert
+  // how many attach attempts the client has made.
+  const attachSends: Array<unknown> = [];
+
+  const defaultOnSend: FakeTransportOptions["onSend"] = (method) => {
+    if (method === "Target.attachToTarget") {
+      attachSends.push(method);
+      return { sessionId: "fake-session-id" };
+    }
+    return { ok: true };
+  };
+
+  const transportOnSend: FakeTransportOptions["onSend"] = async (
+    method,
+    params,
+    o,
+  ) => {
+    if (method === "Target.attachToTarget") {
+      attachSends.push(method);
+    }
+    if (opts.transportOnSend) {
+      return opts.transportOnSend(method, params, o);
+    }
+    return defaultOnSend!(method, params, o);
+  };
+
+  const client = createCdpInspectClient(opts.conversationId ?? "conv-1", {
+    host: "127.0.0.1",
+    port: 9222,
+    discoveryTimeoutMs: 100,
+    wsConnectTimeoutMs: 100,
+    helpers: {
+      probeDevToolsJsonVersion: async (probeOpts: unknown) => {
+        probeCalls += 1;
+        if (opts.probeImpl) return opts.probeImpl(probeOpts);
+        return {
+          browser: "Chrome/125.0.0.0",
+          protocolVersion: "1.3",
+          webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/browser/fake",
+        };
+      },
+      listDevToolsTargets: async (listOpts: unknown) => {
+        listCalls += 1;
+        if (opts.listImpl) return opts.listImpl(listOpts);
+        return [
+          {
+            id: "target-1",
+            type: "page",
+            title: "Example",
+            url: "https://example.com/",
+            webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/page/target-1",
+          },
+        ];
+      },
+      // pickDefaultTarget uses the real implementation — it's pure.
+      connectCdpWsTransport: async (
+        url: string,
+        connectOpts?: { connectTimeoutMs?: number },
+      ) => {
+        connectCalls += 1;
+        if (opts.connectImpl) return opts.connectImpl(url, connectOpts);
+        return createFakeTransport({
+          onSend: transportOnSend,
+          trackSends: sends,
+          trackDisposeCount: disposeCount,
+        });
+      },
+    },
+  });
+
+  return {
+    client,
+    sends,
+    disposeCount,
+    get probeCalls() {
+      return probeCalls;
+    },
+    get listCalls() {
+      return listCalls;
+    },
+    get connectCalls() {
+      return connectCalls;
+    },
+    attachCallCount: () => attachSends.length,
+  };
+}
+
+describe("CdpInspectClient", () => {
+  beforeEach(() => {
+    // no-op — each test gets its own harness
+  });
+
+  test("kind is 'cdp-inspect' and exposes conversationId", () => {
+    const { client } = createHarness({ conversationId: "conv-kind" });
+    expect(client).toBeInstanceOf(CdpInspectClient);
+    expect(client.kind).toBe("cdp-inspect");
+    expect(client.conversationId).toBe("conv-kind");
+  });
+
+  test("send() probes version, lists targets, attaches, and forwards the call", async () => {
+    const harness = createHarness({
+      transportOnSend: (method) => {
+        if (method === "Target.attachToTarget") {
+          return { sessionId: "session-abc" };
+        }
+        if (method === "Browser.getVersion") {
+          return { product: "HeadlessChrome/125.0.0.0" };
+        }
+        return undefined;
+      },
+    });
+    const result = await harness.client.send<{ product: string }>(
+      "Browser.getVersion",
+    );
+    expect(result).toEqual({ product: "HeadlessChrome/125.0.0.0" });
+    expect(harness.probeCalls).toBe(1);
+    expect(harness.listCalls).toBe(1);
+    expect(harness.connectCalls).toBe(1);
+    // One attach + one forwarded Browser.getVersion.
+    expect(harness.sends).toEqual([
+      {
+        method: "Target.attachToTarget",
+        params: { targetId: "target-1", flatten: true },
+        sessionId: undefined,
+      },
+      {
+        method: "Browser.getVersion",
+        params: undefined,
+        sessionId: "session-abc",
+      },
+    ]);
+  });
+
+  test("multiple send() calls share a single attach", async () => {
+    const harness = createHarness();
+    await harness.client.send("Runtime.enable");
+    await harness.client.send("Page.enable");
+    await harness.client.send("DOM.enable");
+    expect(harness.probeCalls).toBe(1);
+    expect(harness.listCalls).toBe(1);
+    expect(harness.connectCalls).toBe(1);
+    expect(harness.attachCallCount()).toBe(1);
+    expect(harness.sends.length).toBe(4); // 1 attach + 3 forwarded
+  });
+
+  test("concurrent send() calls share a single in-flight attach", async () => {
+    const harness = createHarness();
+    await Promise.all([
+      harness.client.send("Runtime.enable"),
+      harness.client.send("Page.enable"),
+      harness.client.send("DOM.enable"),
+    ]);
+    expect(harness.probeCalls).toBe(1);
+    expect(harness.listCalls).toBe(1);
+    expect(harness.connectCalls).toBe(1);
+    expect(harness.attachCallCount()).toBe(1);
+  });
+
+  test("send() retries ensureSession after an initial attach failure", async () => {
+    // First probe call rejects (simulating e.g. Chrome not yet listening).
+    // Second probe call succeeds. Because the cached sessionPromise must
+    // be cleared on rejection, the second send() performs a full retry.
+    let probeCount = 0;
+    const harness = createHarness({
+      probeImpl: async () => {
+        probeCount += 1;
+        if (probeCount === 1) {
+          throw new Error("connect ECONNREFUSED");
+        }
+        return {
+          browser: "Chrome/125.0.0.0",
+          protocolVersion: "1.3",
+          webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/browser/fake",
+        };
+      },
+    });
+
+    let firstErr: unknown;
+    try {
+      await harness.client.send("Browser.getVersion");
+    } catch (err) {
+      firstErr = err;
+    }
+    expect(firstErr).toBeInstanceOf(CdpError);
+    expect((firstErr as InstanceType<typeof CdpError>).code).toBe(
+      "transport_error",
+    );
+    expect(probeCount).toBe(1);
+    expect(harness.connectCalls).toBe(0);
+
+    // Second call — cached promise was cleared, so probe + list +
+    // connect + attach all run again, then the forwarded call
+    // resolves normally.
+    const result = await harness.client.send<{ ok: boolean }>(
+      "Browser.getVersion",
+    );
+    expect(result).toEqual({ ok: true });
+    expect(probeCount).toBe(2);
+    expect(harness.listCalls).toBe(2);
+    expect(harness.connectCalls).toBe(1);
+    expect(harness.attachCallCount()).toBe(1);
+  });
+
+  test("send() maps CDP protocol errors from attach to CdpError 'cdp_error'", async () => {
+    const harness = createHarness({
+      transportOnSend: async (method) => {
+        if (method === "Target.attachToTarget") {
+          throw new CdpWsTransportError(
+            "cdp_error",
+            "No target with given id found",
+            {
+              cdpMethod: "Target.attachToTarget",
+              cdpCode: -32602,
+              cdpMessage: "No target with given id found",
+            },
+          );
+        }
+        return undefined;
+      },
+    });
+
+    let caught: unknown;
+    try {
+      await harness.client.send("Browser.getVersion");
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(CdpError);
+    const cdpErr = caught as InstanceType<typeof CdpError>;
+    expect(cdpErr.code).toBe("cdp_error");
+    expect(cdpErr.message).toBe("No target with given id found");
+    expect(cdpErr.cdpMethod).toBe("Browser.getVersion");
+    expect(cdpErr.underlying).toBeInstanceOf(CdpWsTransportError);
+  });
+
+  test("send() maps transport failures during attach to CdpError 'transport_error'", async () => {
+    const harness = createHarness({
+      connectImpl: async () => {
+        throw new CdpWsTransportError(
+          "transport_error",
+          "websocket closed before open",
+        );
+      },
+    });
+    let caught: unknown;
+    try {
+      await harness.client.send("Browser.getVersion");
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(CdpError);
+    const cdpErr = caught as InstanceType<typeof CdpError>;
+    expect(cdpErr.code).toBe("transport_error");
+    expect(cdpErr.message).toBe("websocket closed before open");
+    expect(cdpErr.cdpMethod).toBe("Browser.getVersion");
+  });
+
+  test("send() with an already-aborted signal throws 'aborted' without touching the transport", async () => {
+    const harness = createHarness();
+    const controller = new AbortController();
+    controller.abort();
+    let caught: unknown;
+    try {
+      await harness.client.send(
+        "Browser.getVersion",
+        undefined,
+        controller.signal,
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(CdpError);
+    const cdpErr = caught as InstanceType<typeof CdpError>;
+    expect(cdpErr.code).toBe("aborted");
+    expect(cdpErr.cdpMethod).toBe("Browser.getVersion");
+    // Nothing ran — no discovery, no connect, no transport sends.
+    expect(harness.probeCalls).toBe(0);
+    expect(harness.listCalls).toBe(0);
+    expect(harness.connectCalls).toBe(0);
+    expect(harness.sends.length).toBe(0);
+  });
+
+  test("send() classifies as 'aborted' when the signal fires during attach", async () => {
+    const controller = new AbortController();
+    const harness = createHarness({
+      probeImpl: async () => {
+        // Simulate caller aborting while discovery is in flight.
+        // Discovery itself throws a generic error (as real fetch
+        // would), and the abort flag is flipped — we expect the
+        // resulting CdpError to carry code "aborted".
+        controller.abort();
+        throw new Error("aborted during fetch");
+      },
+    });
+    let caught: unknown;
+    try {
+      await harness.client.send(
+        "Browser.getVersion",
+        undefined,
+        controller.signal,
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(CdpError);
+    const cdpErr = caught as InstanceType<typeof CdpError>;
+    expect(cdpErr.code).toBe("aborted");
+    expect(cdpErr.cdpMethod).toBe("Browser.getVersion");
+  });
+
+  test("send() classifies as 'aborted' when the signal fires during the forwarded call", async () => {
+    const controller = new AbortController();
+    const harness = createHarness({
+      transportOnSend: async (method) => {
+        if (method === "Target.attachToTarget") {
+          return { sessionId: "session-abc" };
+        }
+        // Simulate the transport throwing an abort error after
+        // the caller aborts mid-call.
+        controller.abort();
+        throw new CdpWsTransportError("aborted", "aborted during send", {
+          cdpMethod: method,
+        });
+      },
+    });
+    let caught: unknown;
+    try {
+      await harness.client.send(
+        "Page.navigate",
+        { url: "about:blank" },
+        controller.signal,
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(CdpError);
+    const cdpErr = caught as InstanceType<typeof CdpError>;
+    expect(cdpErr.code).toBe("aborted");
+    expect(cdpErr.cdpMethod).toBe("Page.navigate");
+  });
+
+  test("send() maps forwarded CDP protocol errors to 'cdp_error'", async () => {
+    const harness = createHarness({
+      transportOnSend: async (method) => {
+        if (method === "Target.attachToTarget") {
+          return { sessionId: "session-abc" };
+        }
+        throw new CdpWsTransportError("cdp_error", "invalid expression", {
+          cdpMethod: method,
+          cdpCode: -32000,
+          cdpMessage: "invalid expression",
+        });
+      },
+    });
+    let caught: unknown;
+    try {
+      await harness.client.send("Runtime.evaluate", { expression: "??" });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(CdpError);
+    const cdpErr = caught as InstanceType<typeof CdpError>;
+    expect(cdpErr.code).toBe("cdp_error");
+    expect(cdpErr.message).toBe("invalid expression");
+    expect(cdpErr.cdpMethod).toBe("Runtime.evaluate");
+    expect(cdpErr.cdpParams).toEqual({ expression: "??" });
+  });
+
+  test("dispose() is idempotent and tears down the underlying transport", async () => {
+    const harness = createHarness();
+    await harness.client.send("Browser.getVersion");
+    harness.client.dispose();
+    // dispose schedules transport.dispose on the resolved attach
+    // promise's then() — flush microtasks.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(harness.disposeCount.count).toBe(1);
+
+    // Second dispose is a no-op.
+    harness.client.dispose();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(harness.disposeCount.count).toBe(1);
+  });
+
+  test("dispose() without any sends does not call connectCdpWsTransport", async () => {
+    const harness = createHarness();
+    harness.client.dispose();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(harness.connectCalls).toBe(0);
+    expect(harness.disposeCount.count).toBe(0);
+  });
+
+  test("send() after dispose throws CdpError with code 'disposed'", async () => {
+    const harness = createHarness();
+    harness.client.dispose();
+    let caught: unknown;
+    try {
+      await harness.client.send("Browser.getVersion");
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(CdpError);
+    const cdpErr = caught as InstanceType<typeof CdpError>;
+    expect(cdpErr.code).toBe("disposed");
+    expect(cdpErr.cdpMethod).toBe("Browser.getVersion");
+    // No discovery or transport activity took place.
+    expect(harness.probeCalls).toBe(0);
+    expect(harness.listCalls).toBe(0);
+    expect(harness.connectCalls).toBe(0);
+  });
+
+  test("attach that returns no sessionId throws 'cdp_error'", async () => {
+    const harness = createHarness({
+      transportOnSend: async (method) => {
+        if (method === "Target.attachToTarget") {
+          // Missing sessionId field — a broken fork response.
+          return {};
+        }
+        return undefined;
+      },
+    });
+    let caught: unknown;
+    try {
+      await harness.client.send("Browser.getVersion");
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(CdpError);
+    const cdpErr = caught as InstanceType<typeof CdpError>;
+    expect(cdpErr.code).toBe("cdp_error");
+    expect(cdpErr.cdpMethod).toBe("Browser.getVersion");
+  });
+
+  test("attach failure tears down the partially-opened transport", async () => {
+    const localDisposeCount = { count: 0 };
+    const transport = createFakeTransport({
+      onSend: async (method) => {
+        if (method === "Target.attachToTarget") {
+          throw new CdpWsTransportError("cdp_error", "attach failed", {
+            cdpMethod: method,
+          });
+        }
+        return undefined;
+      },
+      trackDisposeCount: localDisposeCount,
+    });
+    const client = createCdpInspectClient("conv-attach-fail", {
+      host: "127.0.0.1",
+      port: 9222,
+      helpers: {
+        probeDevToolsJsonVersion: async () => ({
+          browser: "Chrome/125.0.0.0",
+          protocolVersion: "1.3",
+          webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/browser/fake",
+        }),
+        listDevToolsTargets: async () => [
+          {
+            id: "target-1",
+            type: "page",
+            title: "Example",
+            url: "https://example.com/",
+            webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/page/target-1",
+          },
+        ],
+        connectCdpWsTransport: async () => transport,
+      },
+    });
+
+    let caught: unknown;
+    try {
+      await client.send("Browser.getVersion");
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(CdpError);
+    // The transport opened by attach() should have been disposed so
+    // the socket doesn't leak.
+    expect(localDisposeCount.count).toBe(1);
+  });
+});

--- a/assistant/src/tools/browser/cdp-client/__tests__/cdp-inspect-client.test.ts
+++ b/assistant/src/tools/browser/cdp-client/__tests__/cdp-inspect-client.test.ts
@@ -120,7 +120,10 @@ function createHarness(opts: HarnessOptions = {}): Harness {
   let connectCalls = 0;
 
   // Track Target.attachToTarget specifically so tests can assert
-  // how many attach attempts the client has made.
+  // how many attach attempts the client has made. The counter is
+  // bumped ONLY in the default happy-path branch so tests that
+  // install a custom `transportOnSend` (and therefore model their
+  // own attach semantics) can't accidentally double-count.
   const attachSends: Array<unknown> = [];
 
   const defaultOnSend: FakeTransportOptions["onSend"] = (method) => {
@@ -136,9 +139,6 @@ function createHarness(opts: HarnessOptions = {}): Harness {
     params,
     o,
   ) => {
-    if (method === "Target.attachToTarget") {
-      attachSends.push(method);
-    }
     if (opts.transportOnSend) {
       return opts.transportOnSend(method, params, o);
     }
@@ -311,13 +311,15 @@ describe("CdpInspectClient", () => {
 
     // Second call — cached promise was cleared, so probe + list +
     // connect + attach all run again, then the forwarded call
-    // resolves normally.
+    // resolves normally. listCalls is only 1 because the first
+    // attempt threw inside probeDevToolsJsonVersion before it ever
+    // reached listDevToolsTargets.
     const result = await harness.client.send<{ ok: boolean }>(
       "Browser.getVersion",
     );
     expect(result).toEqual({ ok: true });
     expect(probeCount).toBe(2);
-    expect(harness.listCalls).toBe(2);
+    expect(harness.listCalls).toBe(1);
     expect(harness.connectCalls).toBe(1);
     expect(harness.attachCallCount()).toBe(1);
   });
@@ -596,5 +598,147 @@ describe("CdpInspectClient", () => {
     // The transport opened by attach() should have been disposed so
     // the socket doesn't leak.
     expect(localDisposeCount.count).toBe(1);
+  });
+
+  test("send() aborts promptly when signal fires during ensureSession", async () => {
+    // Discovery is deliberately stalled so the caller has to rely on
+    // raceAbort() to cut through. If raceAbort worked correctly, the
+    // send() promise rejects with an 'aborted' CdpError the instant
+    // the controller fires — even though probeDevToolsJsonVersion is
+    // still hanging on an unresolved await.
+    const controller = new AbortController();
+    let probeSignalSeen: AbortSignal | undefined;
+    let probeResolve: (() => void) | undefined;
+    const probeStarted = new Promise<void>((resolve) => {
+      probeResolve = resolve;
+    });
+
+    const client = createCdpInspectClient("conv-abort-during-ensure", {
+      host: "127.0.0.1",
+      port: 9222,
+      helpers: {
+        probeDevToolsJsonVersion: async (probeOpts) => {
+          // Capture the signal so we can assert the shared attach
+          // controller actually fired downstream.
+          probeSignalSeen = (probeOpts as { signal?: AbortSignal }).signal;
+          probeResolve?.();
+          // Hang forever unless the shared controller fires.
+          await new Promise<never>((_, reject) => {
+            const onAbort = () => {
+              reject(new Error("probe aborted via shared controller"));
+            };
+            if (probeSignalSeen?.aborted) {
+              onAbort();
+            } else {
+              probeSignalSeen?.addEventListener("abort", onAbort, {
+                once: true,
+              });
+            }
+          });
+          throw new Error("unreachable");
+        },
+        listDevToolsTargets: async () => [
+          {
+            id: "target-1",
+            type: "page",
+            title: "Example",
+            url: "https://example.com/",
+            webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/page/target-1",
+          },
+        ],
+        connectCdpWsTransport: async () =>
+          createFakeTransport({
+            onSend: async (method) => {
+              if (method === "Target.attachToTarget") {
+                return { sessionId: "fake-session-id" };
+              }
+              return undefined;
+            },
+          }),
+      },
+    });
+
+    const sendPromise = client.send(
+      "Browser.getVersion",
+      undefined,
+      controller.signal,
+    );
+    // Wait until probe is actually running, then abort.
+    await probeStarted;
+    controller.abort();
+
+    let caught: unknown;
+    try {
+      await sendPromise;
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(CdpError);
+    const cdpErr = caught as InstanceType<typeof CdpError>;
+    expect(cdpErr.code).toBe("aborted");
+    expect(cdpErr.cdpMethod).toBe("Browser.getVersion");
+    // Probe saw a non-null signal, meaning ensureSession plumbed one
+    // all the way down to the discovery helper.
+    expect(probeSignalSeen).toBeDefined();
+    // After the last (and only) waiter aborted, the shared controller
+    // should have been aborted — downstream probe's await should have
+    // been rejected.
+    expect(probeSignalSeen?.aborted).toBe(true);
+  });
+
+  test("concurrent send() callers can abort independently", async () => {
+    // Two callers race the same in-flight attach. The first caller
+    // aborts; the second caller must still complete normally once the
+    // shared attach resolves.
+    const aborter = new AbortController();
+    let probeResolve: (() => void) | undefined;
+    let releaseProbe: (() => void) | undefined;
+    const probeRunning = new Promise<void>((resolve) => {
+      probeResolve = resolve;
+    });
+    const probeCanFinish = new Promise<void>((resolve) => {
+      releaseProbe = resolve;
+    });
+
+    const harness = createHarness({
+      probeImpl: async () => {
+        probeResolve?.();
+        await probeCanFinish;
+        return {
+          browser: "Chrome/125.0.0.0",
+          protocolVersion: "1.3",
+          webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/browser/fake",
+        };
+      },
+    });
+
+    const aborted = harness.client.send(
+      "Runtime.enable",
+      undefined,
+      aborter.signal,
+    );
+    const stable = harness.client.send("Page.enable");
+
+    await probeRunning;
+    aborter.abort();
+
+    // First caller aborts promptly…
+    let firstErr: unknown;
+    try {
+      await aborted;
+    } catch (err) {
+      firstErr = err;
+    }
+    expect(firstErr).toBeInstanceOf(CdpError);
+    expect((firstErr as InstanceType<typeof CdpError>).code).toBe("aborted");
+
+    // …but the second caller is still alive and can make progress
+    // once the shared attach finishes.
+    releaseProbe?.();
+    await stable;
+    expect(harness.probeCalls).toBe(1);
+    expect(harness.listCalls).toBe(1);
+    expect(harness.connectCalls).toBe(1);
+    expect(harness.attachCallCount()).toBe(1);
   });
 });

--- a/assistant/src/tools/browser/cdp-client/cdp-inspect-client.ts
+++ b/assistant/src/tools/browser/cdp-client/cdp-inspect-client.ts
@@ -70,6 +70,23 @@ interface AttachedSession {
 }
 
 /**
+ * In-flight attach handle. Wraps the shared attach promise with a
+ * dedicated {@link AbortController} and a ref-count of live callers
+ * waiting on the attach. When every caller has raced its own signal
+ * and given up, the ref-count drops to zero and the shared controller
+ * aborts so the underlying discovery / ws / `Target.attachToTarget`
+ * work stops promptly instead of wedging the socket.
+ */
+interface PendingAttach {
+  /** Shared attach promise — resolved exactly once per attach attempt. */
+  promise: Promise<AttachedSession>;
+  /** Controller wired through probe / list / connect / attach. */
+  controller: AbortController;
+  /** Number of live callers still awaiting this attach. */
+  waiters: number;
+}
+
+/**
  * CdpClient backed by the DevTools JSON protocol over a raw
  * WebSocket (the `cdp-inspect` transport). Composes the discovery
  * helpers (`probeDevToolsJsonVersion` + `listDevToolsTargets` +
@@ -84,6 +101,10 @@ interface AttachedSession {
  *    caches the session for every subsequent call.
  *  - Concurrent callers share a single in-flight attach promise so
  *    `Target.attachToTarget` runs exactly once per client instance.
+ *  - Each `send(..., signal)` caller can race its own AbortSignal
+ *    against the shared attach and cut through promptly. When every
+ *    concurrent caller has aborted, the shared attach work is also
+ *    cancelled so we don't leak discovery fetches or a half-open ws.
  *  - If the attach promise rejects, the cached promise is cleared so
  *    the next `send()` retries from scratch instead of replaying the
  *    same failure forever.
@@ -93,7 +114,8 @@ interface AttachedSession {
 export class CdpInspectClient implements ScopedCdpClient {
   readonly kind: CdpClientKind = "cdp-inspect";
 
-  private sessionPromise: Promise<AttachedSession> | null = null;
+  private pending: PendingAttach | null = null;
+  private session: AttachedSession | null = null;
   private disposed = false;
   private readonly helpers: Required<CdpInspectHelpers>;
 
@@ -115,27 +137,110 @@ export class CdpInspectClient implements ScopedCdpClient {
 
   /**
    * Lazily attach (and cache) a CDP session against the configured
-   * DevTools endpoint. See class-level docs for the resilience
-   * contract — in particular, transient attach failures must NOT
-   * poison the cached promise for subsequent calls.
+   * DevTools endpoint. Each caller races its own `signal` against the
+   * shared attach so an individual abort always wins promptly; when
+   * every waiter has aborted, the shared attach work is cancelled
+   * too via the pending attach's internal controller. See class-level
+   * docs for the resilience contract — in particular, transient
+   * attach failures must NOT poison the cached promise for subsequent
+   * calls.
    */
-  private async ensureSession(): Promise<AttachedSession> {
+  private async ensureSession(signal?: AbortSignal): Promise<AttachedSession> {
     if (this.disposed) {
       throw new CdpError("disposed", "CdpInspectClient already disposed");
     }
-    if (this.sessionPromise) return this.sessionPromise;
-    const created = this.attach();
-    this.sessionPromise = created;
-    // Clear the cached promise on rejection so the next call retries
-    // from scratch instead of replaying the same failure forever. Only
-    // clear if `created` is still the cached promise — a concurrent
-    // dispose may have already nulled it.
-    created.catch(() => {
-      if (this.sessionPromise === created) {
-        this.sessionPromise = null;
+    if (this.session) return this.session;
+
+    const pending = this.pending ?? this.startAttach();
+    pending.waiters += 1;
+
+    // `onAbort` fires exactly once if this caller's signal wins the
+    // race. It (a) drops this caller's waiter slot and (b) aborts
+    // the shared controller iff no other caller is still listening,
+    // so the underlying discovery / ws / attach work is cancelled
+    // promptly instead of leaking into the background.
+    let released = false;
+    const onAbort = () => {
+      if (released) return;
+      released = true;
+      pending.waiters -= 1;
+      if (pending.waiters <= 0 && this.pending === pending) {
+        try {
+          pending.controller.abort();
+        } catch {
+          // best effort
+        }
       }
-    });
-    return created;
+    };
+
+    try {
+      return await raceAbort(pending.promise, signal, onAbort);
+    } finally {
+      // Inner attach resolved or rejected before this caller's
+      // signal fired — drop the waiter slot without touching the
+      // shared controller (it's already settled). If `onAbort` ran,
+      // `released` is already true and this is a no-op.
+      if (!released) {
+        released = true;
+        pending.waiters -= 1;
+      }
+    }
+  }
+
+  /**
+   * Kick off a fresh shared attach. The returned {@link PendingAttach}
+   * is cached on `this.pending` until it either resolves (in which
+   * case the session is stashed on `this.session`) or rejects (in
+   * which case the cache is cleared so the next caller retries from
+   * scratch).
+   */
+  private startAttach(): PendingAttach {
+    const controller = new AbortController();
+    const pending: PendingAttach = {
+      controller,
+      waiters: 0,
+      promise: this.attach(controller.signal),
+    };
+    this.pending = pending;
+
+    pending.promise
+      .then((session) => {
+        // Another concurrent attach may have won the race (e.g. after
+        // a dispose + retry). Only cache the result if we're still
+        // the current attempt.
+        if (this.pending === pending) {
+          this.pending = null;
+          if (this.disposed) {
+            // Dispose landed before we could publish the session —
+            // tear down the transport immediately so we don't leak.
+            try {
+              session.transport.dispose();
+            } catch {
+              // best effort
+            }
+            return;
+          }
+          this.session = session;
+        } else {
+          // A stale attempt — drop the transport so we don't leak.
+          try {
+            session.transport.dispose();
+          } catch {
+            // best effort
+          }
+        }
+      })
+      .catch(() => {
+        // Clear the cached pending attach on rejection so the next
+        // call retries from scratch instead of replaying the same
+        // failure forever. Only clear if we're still the current
+        // attempt — a concurrent dispose may have already nulled it.
+        if (this.pending === pending) {
+          this.pending = null;
+        }
+      });
+
+    return pending;
   }
 
   /**
@@ -143,8 +248,13 @@ export class CdpInspectClient implements ScopedCdpClient {
    * underlying errors are rethrown unchanged so the `send()` wrapper
    * can map them to stable `CdpError` codes without double-wrapping
    * the already-typed discovery / ws-transport errors.
+   *
+   * The `signal` here is the shared, internal {@link PendingAttach}
+   * signal — NOT the per-caller signal. It is aborted when the last
+   * caller interested in this attach has given up, or when `dispose()`
+   * races an in-flight attach.
    */
-  private async attach(): Promise<AttachedSession> {
+  private async attach(signal: AbortSignal): Promise<AttachedSession> {
     const discoveryTimeoutMs =
       this.options.discoveryTimeoutMs ?? DEFAULT_DISCOVERY_TIMEOUT_MS;
     const { host, port } = this.options;
@@ -153,12 +263,20 @@ export class CdpInspectClient implements ScopedCdpClient {
       host,
       port,
       timeoutMs: discoveryTimeoutMs,
+      signal,
     });
+    if (signal.aborted) {
+      throw new CdpError("aborted", "CdpInspectClient attach aborted");
+    }
     const targets = await this.helpers.listDevToolsTargets({
       host,
       port,
       timeoutMs: discoveryTimeoutMs,
+      signal,
     });
+    if (signal.aborted) {
+      throw new CdpError("aborted", "CdpInspectClient attach aborted");
+    }
     const target = this.helpers.pickDefaultTarget(targets);
 
     // Prefer the browser-level ws URL from the version probe because
@@ -168,6 +286,7 @@ export class CdpInspectClient implements ScopedCdpClient {
     const wsUrl = version.webSocketDebuggerUrl || target.webSocketDebuggerUrl;
     const transport = await this.helpers.connectCdpWsTransport(wsUrl, {
       connectTimeoutMs: this.options.wsConnectTimeoutMs,
+      signal,
     });
 
     // If dispose() landed while connect was in flight, tear down the
@@ -181,13 +300,28 @@ export class CdpInspectClient implements ScopedCdpClient {
       }
       throw new CdpError("disposed", "CdpInspectClient disposed during attach");
     }
+    if (signal.aborted) {
+      try {
+        transport.dispose();
+      } catch {
+        // best effort
+      }
+      throw new CdpError(
+        "aborted",
+        "CdpInspectClient attach aborted after ws connect",
+      );
+    }
 
     let attachResult: unknown;
     try {
-      attachResult = await transport.send<unknown>("Target.attachToTarget", {
-        targetId: target.id,
-        flatten: true,
-      });
+      attachResult = await transport.send<unknown>(
+        "Target.attachToTarget",
+        {
+          targetId: target.id,
+          flatten: true,
+        },
+        { signal },
+      );
     } catch (err) {
       // Attach failed — drop the transport we just opened so we don't
       // leak the socket on retry.
@@ -245,10 +379,20 @@ export class CdpInspectClient implements ScopedCdpClient {
 
     let attached: AttachedSession;
     try {
-      attached = await this.ensureSession();
+      attached = await this.ensureSession(signal);
     } catch (err) {
       if (signal?.aborted) {
         throw new CdpError("aborted", "Aborted during send", {
+          cdpMethod: method,
+          cdpParams: params,
+          underlying: err,
+        });
+      }
+      // If a concurrent dispose() aborted the shared attach under us,
+      // surface a stable "disposed" error instead of the incidental
+      // discovery / transport rejection that the aborted work threw.
+      if (this.disposed) {
+        throw new CdpError("disposed", "CdpInspectClient already disposed", {
           cdpMethod: method,
           cdpParams: params,
           underlying: err,
@@ -318,25 +462,33 @@ export class CdpInspectClient implements ScopedCdpClient {
   dispose(): void {
     if (this.disposed) return;
     this.disposed = true;
-    const pending = this.sessionPromise;
-    this.sessionPromise = null;
-    if (!pending) return;
-    pending
-      .then((attached) => {
-        try {
-          attached.transport.dispose();
-        } catch (err) {
-          log.debug(
-            { err },
-            "CdpInspectClient: transport.dispose threw (ignored)",
-          );
-        }
-      })
-      .catch(() => {
-        // Attach never resolved — nothing to tear down here. The
-        // attach() helper is responsible for disposing the transport
-        // on its own failure paths.
-      });
+
+    // Cancel any in-flight attach so discovery / ws / Target.attach
+    // stop promptly. The `.then()` handler in startAttach() will
+    // tear down any transport that managed to open before dispose
+    // landed.
+    const pending = this.pending;
+    this.pending = null;
+    if (pending) {
+      try {
+        pending.controller.abort();
+      } catch {
+        // best effort
+      }
+    }
+
+    const session = this.session;
+    this.session = null;
+    if (session) {
+      try {
+        session.transport.dispose();
+      } catch (err) {
+        log.debug(
+          { err },
+          "CdpInspectClient: transport.dispose threw (ignored)",
+        );
+      }
+    }
   }
 }
 
@@ -344,8 +496,11 @@ export class CdpInspectClient implements ScopedCdpClient {
  * Classify an `ensureSession()` rejection into a stable CdpError
  * code. Discovery + ws-transport failures become `transport_error`,
  * while CDP-level errors returned by `Target.attachToTarget` become
- * `cdp_error`. Already-typed CdpErrors (e.g. a concurrent dispose
- * surfacing as "disposed") are re-thrown unchanged.
+ * `cdp_error`. Already-typed CdpErrors (e.g. a missing-sessionId
+ * attach response or a concurrent dispose) are rewritten so that
+ * the internal `cdpMethod` (`"Target.attachToTarget"`) is replaced
+ * with the caller's method, while preserving the underlying error
+ * shape.
  */
 function mapEnsureSessionError(
   err: unknown,
@@ -353,7 +508,16 @@ function mapEnsureSessionError(
   params?: Record<string, unknown>,
 ): CdpError {
   if (err instanceof CdpError) {
-    return err;
+    // Rewrite cdpMethod to the caller's method so attach-stage
+    // metadata (e.g. "Target.attachToTarget") doesn't leak into the
+    // caller-visible error. Preserve code, message, and the original
+    // underlying error so logging / upstream mapping can still
+    // introspect the real cause.
+    return new CdpError(err.code, err.message, {
+      cdpMethod: method,
+      cdpParams: params,
+      underlying: err.underlying ?? err,
+    });
   }
   if (err instanceof CdpWsTransportError) {
     if (err.code === "cdp_error") {
@@ -376,6 +540,60 @@ function mapEnsureSessionError(
     cdpMethod: method,
     cdpParams: params,
     underlying: err,
+  });
+}
+
+/**
+ * Race a long-running shared promise against a per-caller
+ * {@link AbortSignal}. When the signal fires first, the returned
+ * promise rejects with a synthetic `abort` error and the optional
+ * `onAbort` hook is invoked exactly once so callers can decrement
+ * ref-counts, release locks, etc. The underlying `inner` promise is
+ * intentionally NOT cancelled here — shared in-flight work is
+ * cancelled separately via the owning {@link PendingAttach}
+ * controller once every waiter has given up.
+ */
+function raceAbort<T>(
+  inner: Promise<T>,
+  signal: AbortSignal | undefined,
+  onAbort: () => void,
+): Promise<T> {
+  if (!signal) return inner;
+  if (signal.aborted) {
+    try {
+      onAbort();
+    } catch {
+      // best effort
+    }
+    return Promise.reject(new Error("aborted"));
+  }
+  return new Promise<T>((resolve, reject) => {
+    let settled = false;
+    const handleAbort = () => {
+      if (settled) return;
+      settled = true;
+      try {
+        onAbort();
+      } catch {
+        // best effort
+      }
+      reject(new Error("aborted"));
+    };
+    signal.addEventListener("abort", handleAbort, { once: true });
+    inner.then(
+      (value) => {
+        if (settled) return;
+        settled = true;
+        signal.removeEventListener("abort", handleAbort);
+        resolve(value);
+      },
+      (err) => {
+        if (settled) return;
+        settled = true;
+        signal.removeEventListener("abort", handleAbort);
+        reject(err);
+      },
+    );
   });
 }
 

--- a/assistant/src/tools/browser/cdp-client/cdp-inspect-client.ts
+++ b/assistant/src/tools/browser/cdp-client/cdp-inspect-client.ts
@@ -1,0 +1,409 @@
+import { getLogger } from "../../../util/logger.js";
+import {
+  type DevToolsTarget,
+  type DevToolsVersionInfo,
+  listDevToolsTargets,
+  pickDefaultTarget,
+  probeDevToolsJsonVersion,
+} from "./cdp-inspect/discovery.js";
+import {
+  type CdpWsTransport,
+  CdpWsTransportError,
+  connectCdpWsTransport,
+} from "./cdp-inspect/ws-transport.js";
+import { CdpError } from "./errors.js";
+import type { CdpClientKind, ScopedCdpClient } from "./types.js";
+
+const log = getLogger("cdp-inspect-client");
+
+/**
+ * Default timeout (ms) for each discovery HTTP probe. Kept short so a
+ * user who has no chrome running on the configured port fails fast
+ * instead of blocking the entire tool invocation. The ws-transport
+ * has its own, separate connect timeout.
+ */
+const DEFAULT_DISCOVERY_TIMEOUT_MS = 2_000;
+
+/**
+ * Subset of DevTools endpoint config the CdpInspectClient needs. The
+ * higher-level factory (PR 5) is responsible for feeding these values
+ * from the user's settings. Everything else — connect timeouts, ws
+ * retries, abort plumbing — is controlled locally here so we don't
+ * leak transport knobs into tool call sites.
+ */
+export interface CdpInspectClientOptions {
+  /** Loopback host — enforced by discovery helpers before any I/O. */
+  host: string;
+  /** Port the user's Chrome is listening on for DevTools HTTP. */
+  port: number;
+  /** Optional per-attach discovery probe timeout. */
+  discoveryTimeoutMs?: number;
+  /**
+   * Optional per-attach ws connect timeout. Forwarded verbatim to
+   * {@link connectCdpWsTransport}.
+   */
+  wsConnectTimeoutMs?: number;
+  /**
+   * Test seam: override the discovery / transport helpers so unit
+   * tests don't need a real Chrome or a Bun.serve-backed fake peer.
+   * The factory (PR 5) does not use this path.
+   */
+  helpers?: CdpInspectHelpers;
+}
+
+/**
+ * Override shape used by tests. Each field defaults to the real
+ * implementation imported at the top of this module when omitted.
+ */
+export interface CdpInspectHelpers {
+  probeDevToolsJsonVersion?: typeof probeDevToolsJsonVersion;
+  listDevToolsTargets?: typeof listDevToolsTargets;
+  pickDefaultTarget?: typeof pickDefaultTarget;
+  connectCdpWsTransport?: typeof connectCdpWsTransport;
+}
+
+interface AttachedSession {
+  transport: CdpWsTransport;
+  sessionId: string;
+  target: DevToolsTarget;
+  version: DevToolsVersionInfo;
+}
+
+/**
+ * CdpClient backed by the DevTools JSON protocol over a raw
+ * WebSocket (the `cdp-inspect` transport). Composes the discovery
+ * helpers (`probeDevToolsJsonVersion` + `listDevToolsTargets` +
+ * `pickDefaultTarget`) with the shared `connectCdpWsTransport` to
+ * reach an already-running Chrome instance the user has launched
+ * with `--remote-debugging-port`.
+ *
+ * Lifetime mirrors {@link import("./local-cdp-client.js").LocalCdpClient}:
+ *
+ *  - Lazy one-time attach: the first `send()` performs version probe
+ *    + target discovery + ws connect + `Target.attachToTarget`, then
+ *    caches the session for every subsequent call.
+ *  - Concurrent callers share a single in-flight attach promise so
+ *    `Target.attachToTarget` runs exactly once per client instance.
+ *  - If the attach promise rejects, the cached promise is cleared so
+ *    the next `send()` retries from scratch instead of replaying the
+ *    same failure forever.
+ *  - `dispose()` is idempotent and tears down the ws transport if an
+ *    attach ever resolved.
+ */
+export class CdpInspectClient implements ScopedCdpClient {
+  readonly kind: CdpClientKind = "cdp-inspect";
+
+  private sessionPromise: Promise<AttachedSession> | null = null;
+  private disposed = false;
+  private readonly helpers: Required<CdpInspectHelpers>;
+
+  constructor(
+    public readonly conversationId: string,
+    private readonly options: CdpInspectClientOptions,
+  ) {
+    this.helpers = {
+      probeDevToolsJsonVersion:
+        options.helpers?.probeDevToolsJsonVersion ?? probeDevToolsJsonVersion,
+      listDevToolsTargets:
+        options.helpers?.listDevToolsTargets ?? listDevToolsTargets,
+      pickDefaultTarget:
+        options.helpers?.pickDefaultTarget ?? pickDefaultTarget,
+      connectCdpWsTransport:
+        options.helpers?.connectCdpWsTransport ?? connectCdpWsTransport,
+    };
+  }
+
+  /**
+   * Lazily attach (and cache) a CDP session against the configured
+   * DevTools endpoint. See class-level docs for the resilience
+   * contract — in particular, transient attach failures must NOT
+   * poison the cached promise for subsequent calls.
+   */
+  private async ensureSession(): Promise<AttachedSession> {
+    if (this.disposed) {
+      throw new CdpError("disposed", "CdpInspectClient already disposed");
+    }
+    if (this.sessionPromise) return this.sessionPromise;
+    const created = this.attach();
+    this.sessionPromise = created;
+    // Clear the cached promise on rejection so the next call retries
+    // from scratch instead of replaying the same failure forever. Only
+    // clear if `created` is still the cached promise — a concurrent
+    // dispose may have already nulled it.
+    created.catch(() => {
+      if (this.sessionPromise === created) {
+        this.sessionPromise = null;
+      }
+    });
+    return created;
+  }
+
+  /**
+   * Perform the actual discovery + ws-connect + attach sequence. All
+   * underlying errors are rethrown unchanged so the `send()` wrapper
+   * can map them to stable `CdpError` codes without double-wrapping
+   * the already-typed discovery / ws-transport errors.
+   */
+  private async attach(): Promise<AttachedSession> {
+    const discoveryTimeoutMs =
+      this.options.discoveryTimeoutMs ?? DEFAULT_DISCOVERY_TIMEOUT_MS;
+    const { host, port } = this.options;
+
+    const version = await this.helpers.probeDevToolsJsonVersion({
+      host,
+      port,
+      timeoutMs: discoveryTimeoutMs,
+    });
+    const targets = await this.helpers.listDevToolsTargets({
+      host,
+      port,
+      timeoutMs: discoveryTimeoutMs,
+    });
+    const target = this.helpers.pickDefaultTarget(targets);
+
+    // Prefer the browser-level ws URL from the version probe because
+    // it lets us multiplex multiple attached targets through a single
+    // transport. Fall back to the target-specific URL if (for some
+    // reason) the version probe omitted it.
+    const wsUrl = version.webSocketDebuggerUrl || target.webSocketDebuggerUrl;
+    const transport = await this.helpers.connectCdpWsTransport(wsUrl, {
+      connectTimeoutMs: this.options.wsConnectTimeoutMs,
+    });
+
+    // If dispose() landed while connect was in flight, tear down the
+    // transport we just opened and surface a "disposed" CdpError to
+    // the caller so we don't leak a half-attached session.
+    if (this.disposed) {
+      try {
+        transport.dispose();
+      } catch {
+        // best effort
+      }
+      throw new CdpError("disposed", "CdpInspectClient disposed during attach");
+    }
+
+    let attachResult: unknown;
+    try {
+      attachResult = await transport.send<unknown>("Target.attachToTarget", {
+        targetId: target.id,
+        flatten: true,
+      });
+    } catch (err) {
+      // Attach failed — drop the transport we just opened so we don't
+      // leak the socket on retry.
+      try {
+        transport.dispose();
+      } catch {
+        // best effort
+      }
+      throw err;
+    }
+
+    const sessionId = extractSessionId(attachResult);
+    if (!sessionId) {
+      try {
+        transport.dispose();
+      } catch {
+        // best effort
+      }
+      throw new CdpError(
+        "cdp_error",
+        "Target.attachToTarget did not return a sessionId",
+        { cdpMethod: "Target.attachToTarget" },
+      );
+    }
+
+    log.debug(
+      {
+        conversationId: this.conversationId,
+        targetId: target.id,
+        sessionId,
+      },
+      "Attached CdpInspectClient session",
+    );
+
+    return { transport, sessionId, target, version };
+  }
+
+  async send<T = unknown>(
+    method: string,
+    params?: Record<string, unknown>,
+    signal?: AbortSignal,
+  ): Promise<T> {
+    if (this.disposed) {
+      throw new CdpError("disposed", "CdpInspectClient already disposed", {
+        cdpMethod: method,
+        cdpParams: params,
+      });
+    }
+    if (signal?.aborted) {
+      throw new CdpError("aborted", "Aborted before send", {
+        cdpMethod: method,
+        cdpParams: params,
+      });
+    }
+
+    let attached: AttachedSession;
+    try {
+      attached = await this.ensureSession();
+    } catch (err) {
+      if (signal?.aborted) {
+        throw new CdpError("aborted", "Aborted during send", {
+          cdpMethod: method,
+          cdpParams: params,
+          underlying: err,
+        });
+      }
+      throw mapEnsureSessionError(err, method, params);
+    }
+
+    // A late dispose may have landed while ensureSession was in
+    // flight — surface a "disposed" error instead of sending into a
+    // torn-down transport.
+    if (this.disposed) {
+      throw new CdpError("disposed", "CdpInspectClient already disposed", {
+        cdpMethod: method,
+        cdpParams: params,
+      });
+    }
+
+    try {
+      return (await attached.transport.send<T>(method, params, {
+        sessionId: attached.sessionId,
+        signal,
+      })) as T;
+    } catch (err) {
+      if (signal?.aborted) {
+        throw new CdpError("aborted", "Aborted during send", {
+          cdpMethod: method,
+          cdpParams: params,
+          underlying: err,
+        });
+      }
+      if (err instanceof CdpWsTransportError) {
+        if (err.code === "aborted") {
+          throw new CdpError("aborted", err.message, {
+            cdpMethod: method,
+            cdpParams: params,
+            underlying: err,
+          });
+        }
+        if (err.code === "cdp_error") {
+          throw new CdpError("cdp_error", err.cdpMessage ?? err.message, {
+            cdpMethod: method,
+            cdpParams: params,
+            underlying: err,
+          });
+        }
+        // closed / timeout / transport_error all map onto
+        // transport_error in the shared CdpClient taxonomy.
+        throw new CdpError("transport_error", err.message, {
+          cdpMethod: method,
+          cdpParams: params,
+          underlying: err,
+        });
+      }
+      if (err instanceof CdpError) {
+        throw err;
+      }
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new CdpError("cdp_error", msg, {
+        cdpMethod: method,
+        cdpParams: params,
+        underlying: err,
+      });
+    }
+  }
+
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    const pending = this.sessionPromise;
+    this.sessionPromise = null;
+    if (!pending) return;
+    pending
+      .then((attached) => {
+        try {
+          attached.transport.dispose();
+        } catch (err) {
+          log.debug(
+            { err },
+            "CdpInspectClient: transport.dispose threw (ignored)",
+          );
+        }
+      })
+      .catch(() => {
+        // Attach never resolved — nothing to tear down here. The
+        // attach() helper is responsible for disposing the transport
+        // on its own failure paths.
+      });
+  }
+}
+
+/**
+ * Classify an `ensureSession()` rejection into a stable CdpError
+ * code. Discovery + ws-transport failures become `transport_error`,
+ * while CDP-level errors returned by `Target.attachToTarget` become
+ * `cdp_error`. Already-typed CdpErrors (e.g. a concurrent dispose
+ * surfacing as "disposed") are re-thrown unchanged.
+ */
+function mapEnsureSessionError(
+  err: unknown,
+  method: string,
+  params?: Record<string, unknown>,
+): CdpError {
+  if (err instanceof CdpError) {
+    return err;
+  }
+  if (err instanceof CdpWsTransportError) {
+    if (err.code === "cdp_error") {
+      return new CdpError("cdp_error", err.cdpMessage ?? err.message, {
+        cdpMethod: method,
+        cdpParams: params,
+        underlying: err,
+      });
+    }
+    return new CdpError("transport_error", err.message, {
+      cdpMethod: method,
+      cdpParams: params,
+      underlying: err,
+    });
+  }
+  // DevToolsDiscoveryError (and any other non-CDP rejection) is
+  // treated as a transport-level failure.
+  const msg = err instanceof Error ? err.message : String(err);
+  return new CdpError("transport_error", msg, {
+    cdpMethod: method,
+    cdpParams: params,
+    underlying: err,
+  });
+}
+
+/**
+ * Pull the `sessionId` field out of a `Target.attachToTarget` CDP
+ * result. CDP returns an object shaped `{ sessionId: string }`; we
+ * guard defensively against malformed replies so a broken Chrome
+ * fork cannot silently send us into an un-typed send loop.
+ */
+function extractSessionId(result: unknown): string | null {
+  if (!result || typeof result !== "object") return null;
+  const record = result as Record<string, unknown>;
+  const sessionId = record.sessionId;
+  if (typeof sessionId === "string" && sessionId.length > 0) {
+    return sessionId;
+  }
+  return null;
+}
+
+/**
+ * Factory for a fresh {@link CdpInspectClient} bound to a
+ * conversation. Keeping the constructor + factory split lets the
+ * cdp-client factory (PR 5) wire this up alongside local / extension
+ * without exposing the class directly to callers.
+ */
+export function createCdpInspectClient(
+  conversationId: string,
+  options: CdpInspectClientOptions,
+): CdpInspectClient {
+  return new CdpInspectClient(conversationId, options);
+}

--- a/assistant/src/tools/browser/cdp-client/cdp-inspect-client.ts
+++ b/assistant/src/tools/browser/cdp-client/cdp-inspect-client.ts
@@ -165,6 +165,14 @@ export class CdpInspectClient implements ScopedCdpClient {
       released = true;
       pending.waiters -= 1;
       if (pending.waiters <= 0 && this.pending === pending) {
+        // Clear the cached pending attach synchronously BEFORE
+        // firing the shared controller's abort. Otherwise a new
+        // `send()` that enters `ensureSession` between this abort
+        // and the async `.catch()` handler in `startAttach()` would
+        // reuse this already-aborted attach and immediately fail
+        // with an `aborted` error even though the new caller never
+        // aborted its own signal.
+        this.pending = null;
         try {
           pending.controller.abort();
         } catch {

--- a/assistant/src/tools/browser/cdp-client/cdp-inspect/ws-transport.ts
+++ b/assistant/src/tools/browser/cdp-client/cdp-inspect/ws-transport.ts
@@ -184,14 +184,20 @@ const DEFAULT_CONNECT_TIMEOUT_MS = 5_000;
 /**
  * Open a raw CDP WebSocket transport against `url`. Resolves only
  * after the socket has reached `OPEN`; rejects with
- * `CdpWsTransportError("timeout")` if the connect-timeout expires or
+ * `CdpWsTransportError("timeout")` if the connect-timeout expires,
+ * `CdpWsTransportError("aborted")` if `opts.signal` fires, or
  * `transport_error` if the socket errors or closes before opening.
  */
 export async function connectCdpWsTransport(
   url: string,
-  opts?: { connectTimeoutMs?: number },
+  opts?: { connectTimeoutMs?: number; signal?: AbortSignal },
 ): Promise<CdpWsTransport> {
   const connectTimeoutMs = opts?.connectTimeoutMs ?? DEFAULT_CONNECT_TIMEOUT_MS;
+  const callerSignal = opts?.signal;
+
+  if (callerSignal?.aborted) {
+    throw new CdpWsTransportError("aborted", "aborted before connect");
+  }
 
   // bun's global `WebSocket` is API-compatible with the browser one.
   const WebSocketCtor: new (url: string) => WsLike = (
@@ -222,6 +228,7 @@ export async function connectCdpWsTransport(
     const timer = setTimeout(() => {
       if (settled) return;
       settled = true;
+      cleanupAbort();
       try {
         ws.close();
       } catch {
@@ -234,12 +241,14 @@ export async function connectCdpWsTransport(
       if (settled) return;
       settled = true;
       clearTimeout(timer);
+      cleanupAbort();
       resolve();
     };
     const onError = (ev: unknown) => {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
+      cleanupAbort();
       try {
         ws.close();
       } catch {
@@ -257,6 +266,7 @@ export async function connectCdpWsTransport(
       if (settled) return;
       settled = true;
       clearTimeout(timer);
+      cleanupAbort();
       reject(
         new CdpWsTransportError(
           "transport_error",
@@ -264,10 +274,30 @@ export async function connectCdpWsTransport(
         ),
       );
     };
+    const onCallerAbort = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      cleanupAbort();
+      try {
+        ws.close();
+      } catch {
+        // best effort
+      }
+      reject(new CdpWsTransportError("aborted", "aborted during connect"));
+    };
+    const cleanupAbort = () => {
+      if (callerSignal) {
+        callerSignal.removeEventListener("abort", onCallerAbort);
+      }
+    };
 
     ws.addEventListener("open", onOpen);
     ws.addEventListener("error", onError);
     ws.addEventListener("close", onCloseBeforeOpen);
+    if (callerSignal) {
+      callerSignal.addEventListener("abort", onCallerAbort, { once: true });
+    }
   });
 
   return createTransport(ws);

--- a/assistant/src/tools/browser/cdp-client/index.ts
+++ b/assistant/src/tools/browser/cdp-client/index.ts
@@ -1,3 +1,9 @@
+export {
+  CdpInspectClient,
+  type CdpInspectClientOptions,
+  type CdpInspectHelpers,
+  createCdpInspectClient,
+} from "./cdp-inspect-client.js";
 export { CdpError, type CdpErrorCode } from "./errors.js";
 export {
   createExtensionCdpClient,


### PR DESCRIPTION
## Summary
- Add `CdpInspectClient` with lazy attach via discovery + ws-transport, following `LocalCdpClient` resilience pattern
- Add `createCdpInspectBackend` browser-session adapter
- Unit tests for success, retry, cdp_error mapping, abort, dispose idempotence

Part of plan: browser-cdp-inspect-phase4.md (PR 4 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24607" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
