### PR TITLE
feat(settings): add advanced Use your own Chrome card with security explainer

### DIFF
--- a/clients/macos/vellum-assistant/App/AppURLs.swift
+++ b/clients/macos/vellum-assistant/App/AppURLs.swift
@@ -67,6 +67,15 @@ public enum AppURLs {
         docsURL(path: "/privacy-policy")
     }
 
+    /// Browser "use your own Chrome" (cdp-inspect host-browser backend) docs
+    /// — linked from the Developer tab `BrowserBackendCard`. The final slug
+    /// may change when the docs page lands in a later PR; this is a
+    /// placeholder that still routes through `docsBaseURL` so it honors
+    /// `VELLUM_DOCS_BASE_URL` overrides.
+    public static var browserCdpInspectDocs: URL {
+        docsURL(path: "/assistant/browser/cdp-inspect-backend")
+    }
+
     // MARK: - Helpers
 
     /// Build a docs URL by appending a path to the (possibly env-overridden) base.

--- a/clients/macos/vellum-assistant/Features/Settings/BrowserBackendCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/BrowserBackendCard.swift
@@ -1,0 +1,226 @@
+import AppKit
+import SwiftUI
+import VellumAssistantShared
+
+/// Developer-only card that lets the user route browser tool calls through a
+/// host Chrome instance launched with `--remote-debugging-port` (the
+/// cdp-inspect host-browser backend).
+///
+/// This is an **advanced** mode: once enabled, the assistant can see and act
+/// on any tab in the user's real Chrome profile, so the card leads with a
+/// prominent security warning and only allows loopback host overrides.
+@MainActor
+struct BrowserBackendCard: View {
+    @ObservedObject var store: SettingsStore
+
+    /// Local draft of the host value — only persisted on Save.
+    @State private var draftHost: String = "localhost"
+    /// Local draft of the port value — only persisted on Save.
+    @State private var draftPortText: String = "9222"
+    @State private var hostError: String?
+    @State private var portError: String?
+    @FocusState private var isHostFocused: Bool
+    @FocusState private var isPortFocused: Bool
+
+    /// Placeholder docs URL. The real docs page lands with the browser CDP
+    /// inspect docs PR so the exact slug may change before the docs ship.
+    private static let learnMoreURL = URL(
+        string: "https://docs.vellum.ai/assistant/browser/use-your-own-chrome"
+    )
+
+    var body: some View {
+        SettingsCard(
+            title: "Use your own Chrome (Advanced)",
+            subtitle: "Route the assistant's browser tools through a Chrome instance you launched with remote debugging. For advanced users only."
+        ) {
+            warningBlock
+
+            SettingsDivider()
+
+            VToggle(
+                isOn: Binding(
+                    get: { store.hostBrowserCdpInspectEnabled },
+                    set: { newValue in
+                        _ = store.setHostBrowserCdpInspectEnabled(newValue)
+                    }
+                ),
+                label: "Enable cdp-inspect backend",
+                helperText: "When on, the assistant probes the host/port below before falling back to the managed browser."
+            )
+            .accessibilityLabel("Enable cdp-inspect backend")
+
+            if store.hostBrowserCdpInspectEnabled {
+                connectionForm
+            }
+
+            learnMoreLink
+        }
+        .onAppear {
+            syncDraftsFromStore()
+        }
+        .onChange(of: store.hostBrowserCdpInspectHost) { _, newValue in
+            if !isHostFocused {
+                draftHost = newValue
+                hostError = nil
+            }
+        }
+        .onChange(of: store.hostBrowserCdpInspectPort) { _, newValue in
+            if !isPortFocused {
+                draftPortText = String(newValue)
+                portError = nil
+            }
+        }
+    }
+
+    // MARK: - Warning Block
+
+    private var warningBlock: some View {
+        HStack(alignment: .top, spacing: VSpacing.sm) {
+            VIconView(.triangleAlert, size: 16)
+                .foregroundStyle(VColor.systemNegativeStrong)
+                .padding(.top, 1)
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                Text("Warning: This mode gives the assistant full control of your real Chrome profile.")
+                    .font(VFont.bodyMediumDefault)
+                    .foregroundStyle(VColor.contentEmphasized)
+
+                Text(
+                    "When enabled, the assistant can read and act on any tab in your real Chrome, including sites you're already signed into (email, banking, chat). The DOM content it observes comes from untrusted web pages, so a malicious page could try to manipulate what the assistant sees or does."
+                )
+                .font(VFont.labelDefault)
+                .foregroundStyle(VColor.contentSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+                Text("Connections are limited to localhost (no remote attach). Only enable this if you understand the risks.")
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(VSpacing.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(VColor.systemNegativeWeak)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+    }
+
+    // MARK: - Connection Form
+
+    private var connectionForm: some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                Text("Host")
+                    .font(VFont.bodySmallDefault)
+                    .foregroundStyle(VColor.contentSecondary)
+                VTextField(
+                    placeholder: "localhost",
+                    text: $draftHost,
+                    errorMessage: hostError,
+                    isFocused: $isHostFocused
+                )
+            }
+
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                Text("Port")
+                    .font(VFont.bodySmallDefault)
+                    .foregroundStyle(VColor.contentSecondary)
+                VTextField(
+                    placeholder: "9222",
+                    text: $draftPortText,
+                    errorMessage: portError,
+                    isFocused: $isPortFocused
+                )
+            }
+
+            HStack {
+                VButton(
+                    label: "Save",
+                    style: .primary,
+                    isDisabled: !hasFormChanges
+                ) {
+                    saveFormChanges()
+                }
+            }
+
+            Text("Only loopback addresses (localhost, 127.0.0.1, ::1, [::1]) are accepted. Ports must be between 1 and 65535.")
+                .font(VFont.labelDefault)
+                .foregroundStyle(VColor.contentTertiary)
+        }
+    }
+
+    // MARK: - Learn more
+
+    private var learnMoreLink: some View {
+        Button {
+            if let url = Self.learnMoreURL {
+                NSWorkspace.shared.open(url)
+            }
+        } label: {
+            HStack(spacing: VSpacing.xxs) {
+                VIconView(.info, size: 12)
+                Text("Learn more about the security risks")
+                    .font(VFont.labelDefault)
+            }
+            .foregroundStyle(VColor.primaryBase)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Learn more about the security risks")
+    }
+
+    // MARK: - Drafts / Saving
+
+    private var hasFormChanges: Bool {
+        let trimmedHost = draftHost.trimmingCharacters(in: .whitespacesAndNewlines)
+        let parsedPort = Int(draftPortText.trimmingCharacters(in: .whitespacesAndNewlines))
+        let hostChanged = trimmedHost != store.hostBrowserCdpInspectHost
+        let portChanged = parsedPort != store.hostBrowserCdpInspectPort
+        return hostChanged || portChanged
+    }
+
+    private func syncDraftsFromStore() {
+        draftHost = store.hostBrowserCdpInspectHost
+        draftPortText = String(store.hostBrowserCdpInspectPort)
+        hostError = nil
+        portError = nil
+    }
+
+    private func saveFormChanges() {
+        let trimmedHost = draftHost.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedPortText = draftPortText.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        var blockedByValidation = false
+
+        if trimmedHost != store.hostBrowserCdpInspectHost {
+            if let error = store.setHostBrowserCdpInspectHost(trimmedHost) {
+                hostError = error
+                blockedByValidation = true
+            } else {
+                hostError = nil
+            }
+        } else {
+            hostError = nil
+        }
+
+        if let parsedPort = Int(trimmedPortText) {
+            if parsedPort != store.hostBrowserCdpInspectPort {
+                if let error = store.setHostBrowserCdpInspectPort(parsedPort) {
+                    portError = error
+                    blockedByValidation = true
+                } else {
+                    portError = nil
+                }
+            } else {
+                portError = nil
+            }
+        } else {
+            portError = "Port must be a number between 1 and 65535."
+            blockedByValidation = true
+        }
+
+        if !blockedByValidation {
+            isHostFocused = false
+            isPortFocused = false
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Settings/BrowserBackendCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/BrowserBackendCard.swift
@@ -22,11 +22,14 @@ struct BrowserBackendCard: View {
     @FocusState private var isHostFocused: Bool
     @FocusState private var isPortFocused: Bool
 
-    /// Placeholder docs URL. The real docs page lands with the browser CDP
-    /// inspect docs PR so the exact slug may change before the docs ship.
-    private static let learnMoreURL = URL(
-        string: "https://docs.vellum.ai/assistant/browser/use-your-own-chrome"
-    )
+    /// Docs URL for the "use your own Chrome" backend. Routed through
+    /// `AppURLs.browserCdpInspectDocs` so it honors `VELLUM_DOCS_BASE_URL`
+    /// overrides (staging / local docs servers) — see
+    /// `clients/macos/AGENTS.md` § External URLs. The real docs page lands
+    /// with a later PR so the slug is a placeholder.
+    private static var learnMoreURL: URL {
+        AppURLs.browserCdpInspectDocs
+    }
 
     var body: some View {
         SettingsCard(
@@ -153,9 +156,7 @@ struct BrowserBackendCard: View {
 
     private var learnMoreLink: some View {
         Button {
-            if let url = Self.learnMoreURL {
-                NSWorkspace.shared.open(url)
-            }
+            NSWorkspace.shared.open(Self.learnMoreURL)
         } label: {
             HStack(spacing: VSpacing.xxs) {
                 VIconView(.info, size: 12)
@@ -186,41 +187,62 @@ struct BrowserBackendCard: View {
     }
 
     private func saveFormChanges() {
+        // Validate BOTH host and port before applying any patches so the save
+        // path is atomic: if either field is invalid, we surface all errors
+        // and persist neither change. Previously, host-only failures still
+        // silently persisted the port, leaving the form in a partially-applied
+        // state that was hard to reason about.
         let trimmedHost = draftHost.trimmingCharacters(in: .whitespacesAndNewlines)
         let trimmedPortText = draftPortText.trimmingCharacters(in: .whitespacesAndNewlines)
 
-        var blockedByValidation = false
+        var pendingHostError: String?
+        var pendingPortError: String?
 
-        if trimmedHost != store.hostBrowserCdpInspectHost {
+        let hostChanged = trimmedHost != store.hostBrowserCdpInspectHost
+        if hostChanged, !SettingsStore.isValidHostBrowserCdpInspectHost(trimmedHost) {
+            pendingHostError = "Only loopback hosts are allowed (localhost, 127.0.0.1, ::1, [::1])."
+        }
+
+        let parsedPort = Int(trimmedPortText)
+        let portChanged: Bool
+        if let parsedPort {
+            portChanged = parsedPort != store.hostBrowserCdpInspectPort
+            if portChanged, !SettingsStore.isValidHostBrowserCdpInspectPort(parsedPort) {
+                pendingPortError = "Port must be between 1 and 65535."
+            }
+        } else {
+            portChanged = false
+            pendingPortError = "Port must be a number between 1 and 65535."
+        }
+
+        // Publish both error slots in one pass so the user sees every issue at
+        // once rather than fixing them sequentially.
+        hostError = pendingHostError
+        portError = pendingPortError
+
+        if pendingHostError != nil || pendingPortError != nil {
+            // Validation failed — do not mutate the store or emit any patches.
+            return
+        }
+
+        // All validation passed — apply only the fields that actually changed.
+        // The setters run their own validation too, but we've already checked
+        // it above so they should return nil. If they don't, we surface the
+        // error instead of silently swallowing it.
+        if hostChanged {
             if let error = store.setHostBrowserCdpInspectHost(trimmedHost) {
                 hostError = error
-                blockedByValidation = true
-            } else {
-                hostError = nil
+                return
             }
-        } else {
-            hostError = nil
+        }
+        if portChanged, let parsedPort {
+            if let error = store.setHostBrowserCdpInspectPort(parsedPort) {
+                portError = error
+                return
+            }
         }
 
-        if let parsedPort = Int(trimmedPortText) {
-            if parsedPort != store.hostBrowserCdpInspectPort {
-                if let error = store.setHostBrowserCdpInspectPort(parsedPort) {
-                    portError = error
-                    blockedByValidation = true
-                } else {
-                    portError = nil
-                }
-            } else {
-                portError = nil
-            }
-        } else {
-            portError = "Port must be a number between 1 and 65535."
-            blockedByValidation = true
-        }
-
-        if !blockedByValidation {
-            isHostFocused = false
-            isPortFocused = false
-        }
+        isHostFocused = false
+        isPortFocused = false
     }
 }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -125,6 +125,9 @@ struct SettingsDeveloperTab: View {
                 ToolPermissionTesterView(model: model)
             }
 
+            // Browser backend (cdp-inspect host Chrome)
+            browserBackendSection
+
             // Feature Flags
             featureFlagSection
             // Environment Variables
@@ -887,6 +890,17 @@ struct SettingsDeveloperTab: View {
             withAnimation {
                 if revokeApiKeyStatus == message { revokeApiKeyStatus = nil }
             }
+        }
+    }
+
+    // MARK: - Browser Backend (cdp-inspect)
+
+    private var browserBackendSection: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            Text("Browser backend")
+                .font(VFont.titleSmall)
+                .foregroundStyle(VColor.contentEmphasized)
+            BrowserBackendCard(store: store)
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -125,8 +125,16 @@ struct SettingsDeveloperTab: View {
                 ToolPermissionTesterView(model: model)
             }
 
-            // Browser backend (cdp-inspect host Chrome)
-            browserBackendSection
+            // Browser backend (cdp-inspect host Chrome) — gated behind
+            // `devModeManager.isDevMode` to match the other developer-only
+            // sections (`platformUrlSection`, `revokeAssistantApiKeySection`).
+            // The Developer tab itself is flagged behind `developer`, but this
+            // card bypasses the managed browser sandbox so we require the
+            // additional dev-mode gate to keep regular developer-tab users
+            // from stumbling into it.
+            if devModeManager.isDevMode {
+                browserBackendSection
+            }
 
             // Feature Flags
             featureFlagSection

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -3369,11 +3369,27 @@ public final class SettingsStore: ObservableObject {
         return (1...65535).contains(port)
     }
 
+    /// Default loopback host for the cdp-inspect backend. Used as the fallback
+    /// when the daemon config contains an invalid (non-loopback) host value.
+    static let defaultHostBrowserCdpInspectHost: String = "localhost"
+    /// Default DevTools remote-debugging port for the cdp-inspect backend.
+    /// Used as the fallback when the daemon config contains an out-of-range
+    /// port value.
+    static let defaultHostBrowserCdpInspectPort: Int = 9222
+
     /// Reads `hostBrowser.cdpInspect.{enabled,host,port,probeTimeoutMs}` from
     /// the workspace config and copies the values into `store`. Missing keys
     /// leave the existing values untouched so the defaults set in the
     /// property declarations apply.
-    private static func applyHostBrowserCdpInspectConfig(
+    ///
+    /// The `host` and `port` values are validated the same way as the UI
+    /// setters (`setHostBrowserCdpInspectHost` / `setHostBrowserCdpInspectPort`)
+    /// to preserve the loopback-only security invariant: if the workspace
+    /// config file is manually edited (or tampered with) to contain a
+    /// non-loopback host like `"attacker.example.com"` or an out-of-range
+    /// port, we fall back to the safe defaults (`localhost` / `9222`) and
+    /// log a warning instead of silently accepting the unsafe value.
+    static func applyHostBrowserCdpInspectConfig(
         _ config: [String: Any],
         into store: SettingsStore
     ) {
@@ -3385,13 +3401,30 @@ public final class SettingsStore: ObservableObject {
             store.hostBrowserCdpInspectEnabled = enabled
         }
         if let host = cdpInspect["host"] as? String, !host.isEmpty {
-            store.hostBrowserCdpInspectHost = host
+            if isValidHostBrowserCdpInspectHost(host) {
+                store.hostBrowserCdpInspectHost = host.trimmingCharacters(in: .whitespacesAndNewlines)
+            } else {
+                log.warning("Ignoring invalid hostBrowser.cdpInspect.host value from daemon config (must be loopback); falling back to default")
+                store.hostBrowserCdpInspectHost = defaultHostBrowserCdpInspectHost
+            }
         }
+        // JSONSerialization may surface integral numbers as Double, so coerce
+        // through a single path before validating.
+        let rawPort: Int?
         if let port = cdpInspect["port"] as? Int {
-            store.hostBrowserCdpInspectPort = port
+            rawPort = port
         } else if let portDouble = cdpInspect["port"] as? Double {
-            // JSONSerialization may surface integral numbers as Double.
-            store.hostBrowserCdpInspectPort = Int(portDouble)
+            rawPort = Int(portDouble)
+        } else {
+            rawPort = nil
+        }
+        if let port = rawPort {
+            if isValidHostBrowserCdpInspectPort(port) {
+                store.hostBrowserCdpInspectPort = port
+            } else {
+                log.warning("Ignoring out-of-range hostBrowser.cdpInspect.port value from daemon config (must be 1..65535); falling back to default")
+                store.hostBrowserCdpInspectPort = defaultHostBrowserCdpInspectPort
+            }
         }
         if let probeTimeout = cdpInspect["probeTimeoutMs"] as? Int {
             store.hostBrowserCdpInspectProbeTimeoutMs = probeTimeout

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -278,6 +278,31 @@ public final class SettingsStore: ObservableObject {
     /// view layer can defer diagnostics until the real config values are available.
     @Published var ingressConfigLoaded: Bool = false
 
+    // MARK: - Host Browser (CDP Inspect) State
+
+    /// Whether the cdp-inspect host-browser backend is enabled.
+    ///
+    /// When true, the browser-session manager probes the configured
+    /// `hostBrowserCdpInspectHost`/`hostBrowserCdpInspectPort` for a running
+    /// Chrome instance exposing `--remote-debugging-port` before falling
+    /// back to the local Playwright backend.
+    @Published var hostBrowserCdpInspectEnabled: Bool = false
+
+    /// Host name or IP address for the host Chrome remote-debugging endpoint.
+    ///
+    /// Only loopback values are accepted (`localhost`, `127.0.0.1`, `::1`,
+    /// `[::1]`) to prevent remote attach attempts.
+    @Published var hostBrowserCdpInspectHost: String = "localhost"
+
+    /// TCP port for the host Chrome remote-debugging endpoint.
+    ///
+    /// Must be in the range `1...65535`.
+    @Published var hostBrowserCdpInspectPort: Int = 9222
+
+    /// Timeout (in milliseconds) for the backend availability probe.
+    /// Defaults to `500` and is preserved verbatim from the fetched config.
+    @Published var hostBrowserCdpInspectProbeTimeoutMs: Int = 500
+
     // MARK: - Connection Health Check State
 
     @Published var gatewayReachable: Bool?
@@ -3298,6 +3323,8 @@ public final class SettingsStore: ObservableObject {
             self.webSearchProvider = provider
         }
 
+        Self.applyHostBrowserCdpInspectConfig(config, into: self)
+
         loadServiceModes(config: config)
 
         // Persist enabledSince when it was defaulted so subsequent loads
@@ -3317,6 +3344,122 @@ public final class SettingsStore: ObservableObject {
             return nil
         }
         return canonicalizeTimeZoneIdentifier(trimmed)
+    }
+
+    // MARK: - Host Browser (CDP Inspect) Loading
+
+    /// Loopback hostnames accepted by the cdp-inspect backend. Non-loopback
+    /// values are rejected at the UI layer to prevent remote attach.
+    static let hostBrowserCdpInspectAllowedHosts: Set<String> = [
+        "localhost",
+        "127.0.0.1",
+        "::1",
+        "[::1]",
+    ]
+
+    /// Returns `true` when `host` is one of the accepted loopback addresses
+    /// for the cdp-inspect backend.
+    static func isValidHostBrowserCdpInspectHost(_ host: String) -> Bool {
+        let trimmed = host.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return hostBrowserCdpInspectAllowedHosts.contains(trimmed)
+    }
+
+    /// Returns `true` when `port` is within the valid TCP port range.
+    static func isValidHostBrowserCdpInspectPort(_ port: Int) -> Bool {
+        return (1...65535).contains(port)
+    }
+
+    /// Reads `hostBrowser.cdpInspect.{enabled,host,port,probeTimeoutMs}` from
+    /// the workspace config and copies the values into `store`. Missing keys
+    /// leave the existing values untouched so the defaults set in the
+    /// property declarations apply.
+    private static func applyHostBrowserCdpInspectConfig(
+        _ config: [String: Any],
+        into store: SettingsStore
+    ) {
+        guard let hostBrowser = config["hostBrowser"] as? [String: Any],
+              let cdpInspect = hostBrowser["cdpInspect"] as? [String: Any] else {
+            return
+        }
+        if let enabled = cdpInspect["enabled"] as? Bool {
+            store.hostBrowserCdpInspectEnabled = enabled
+        }
+        if let host = cdpInspect["host"] as? String, !host.isEmpty {
+            store.hostBrowserCdpInspectHost = host
+        }
+        if let port = cdpInspect["port"] as? Int {
+            store.hostBrowserCdpInspectPort = port
+        } else if let portDouble = cdpInspect["port"] as? Double {
+            // JSONSerialization may surface integral numbers as Double.
+            store.hostBrowserCdpInspectPort = Int(portDouble)
+        }
+        if let probeTimeout = cdpInspect["probeTimeoutMs"] as? Int {
+            store.hostBrowserCdpInspectProbeTimeoutMs = probeTimeout
+        } else if let probeTimeoutDouble = cdpInspect["probeTimeoutMs"] as? Double {
+            store.hostBrowserCdpInspectProbeTimeoutMs = Int(probeTimeoutDouble)
+        }
+    }
+
+    // MARK: - Host Browser (CDP Inspect) Actions
+
+    /// Persists the cdp-inspect enable flag by patching
+    /// `hostBrowser.cdpInspect.enabled` on the workspace config.
+    ///
+    /// The local `@Published` value is updated optimistically before the
+    /// patch completes so the UI reflects the new state immediately.
+    @discardableResult
+    func setHostBrowserCdpInspectEnabled(_ enabled: Bool) -> Task<Bool, Never> {
+        hostBrowserCdpInspectEnabled = enabled
+        return Task {
+            let success = await settingsClient.patchConfig([
+                "hostBrowser": ["cdpInspect": ["enabled": enabled]]
+            ])
+            if !success {
+                log.error("Failed to patch config for hostBrowser.cdpInspect.enabled")
+            }
+            return success
+        }
+    }
+
+    /// Persists the cdp-inspect host override by patching
+    /// `hostBrowser.cdpInspect.host`. Returns an error string and does not
+    /// emit a patch when `host` is not one of the accepted loopback values.
+    @discardableResult
+    func setHostBrowserCdpInspectHost(_ host: String) -> String? {
+        let trimmed = host.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard Self.isValidHostBrowserCdpInspectHost(trimmed) else {
+            return "Only loopback hosts are allowed (localhost, 127.0.0.1, ::1, [::1])."
+        }
+        hostBrowserCdpInspectHost = trimmed
+        Task {
+            let success = await settingsClient.patchConfig([
+                "hostBrowser": ["cdpInspect": ["host": trimmed]]
+            ])
+            if !success {
+                log.error("Failed to patch config for hostBrowser.cdpInspect.host")
+            }
+        }
+        return nil
+    }
+
+    /// Persists the cdp-inspect port override by patching
+    /// `hostBrowser.cdpInspect.port`. Returns an error string and does not
+    /// emit a patch when `port` is outside the valid TCP range.
+    @discardableResult
+    func setHostBrowserCdpInspectPort(_ port: Int) -> String? {
+        guard Self.isValidHostBrowserCdpInspectPort(port) else {
+            return "Port must be between 1 and 65535."
+        }
+        hostBrowserCdpInspectPort = port
+        Task {
+            let success = await settingsClient.patchConfig([
+                "hostBrowser": ["cdpInspect": ["port": port]]
+            ])
+            if !success {
+                log.error("Failed to patch config for hostBrowser.cdpInspect.port")
+            }
+        }
+        return nil
     }
 
 }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -3389,6 +3389,12 @@ public final class SettingsStore: ObservableObject {
     /// non-loopback host like `"attacker.example.com"` or an out-of-range
     /// port, we fall back to the safe defaults (`localhost` / `9222`) and
     /// log a warning instead of silently accepting the unsafe value.
+    ///
+    /// When an invalid value is detected, we also patch the sanitized
+    /// default back to the daemon config so the bad value does not
+    /// reappear on the next config reload. The patch only fires when
+    /// validation fails — once the config contains a valid value, no
+    /// patch is emitted, so there is no infinite loop across refreshes.
     static func applyHostBrowserCdpInspectConfig(
         _ config: [String: Any],
         into store: SettingsStore
@@ -3404,8 +3410,19 @@ public final class SettingsStore: ObservableObject {
             if isValidHostBrowserCdpInspectHost(host) {
                 store.hostBrowserCdpInspectHost = host.trimmingCharacters(in: .whitespacesAndNewlines)
             } else {
-                log.warning("Ignoring invalid hostBrowser.cdpInspect.host value from daemon config (must be loopback); falling back to default")
+                log.warning("Ignoring invalid hostBrowser.cdpInspect.host value from daemon config (must be loopback); falling back to default and patching daemon")
                 store.hostBrowserCdpInspectHost = defaultHostBrowserCdpInspectHost
+                // Persist the sanitized fallback so the invalid value
+                // does not reappear on the next daemon config reload.
+                let settingsClient = store.settingsClient
+                Task {
+                    let success = await settingsClient.patchConfig([
+                        "hostBrowser": ["cdpInspect": ["host": defaultHostBrowserCdpInspectHost]]
+                    ])
+                    if !success {
+                        log.error("Failed to patch sanitized hostBrowser.cdpInspect.host back to daemon config")
+                    }
+                }
             }
         }
         // JSONSerialization may surface integral numbers as Double, so coerce
@@ -3422,8 +3439,19 @@ public final class SettingsStore: ObservableObject {
             if isValidHostBrowserCdpInspectPort(port) {
                 store.hostBrowserCdpInspectPort = port
             } else {
-                log.warning("Ignoring out-of-range hostBrowser.cdpInspect.port value from daemon config (must be 1..65535); falling back to default")
+                log.warning("Ignoring out-of-range hostBrowser.cdpInspect.port value from daemon config (must be 1..65535); falling back to default and patching daemon")
                 store.hostBrowserCdpInspectPort = defaultHostBrowserCdpInspectPort
+                // Persist the sanitized fallback so the invalid value
+                // does not reappear on the next daemon config reload.
+                let settingsClient = store.settingsClient
+                Task {
+                    let success = await settingsClient.patchConfig([
+                        "hostBrowser": ["cdpInspect": ["port": defaultHostBrowserCdpInspectPort]]
+                    ])
+                    if !success {
+                        log.error("Failed to patch sanitized hostBrowser.cdpInspect.port back to daemon config")
+                    }
+                }
             }
         }
         if let probeTimeout = cdpInspect["probeTimeoutMs"] as? Int {

--- a/clients/macos/vellum-assistantTests/SettingsStoreBrowserBackendTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsStoreBrowserBackendTests.swift
@@ -195,4 +195,142 @@ final class SettingsStoreBrowserBackendTests: XCTestCase {
         XCTAssertFalse(SettingsStore.isValidHostBrowserCdpInspectPort(-1))
         XCTAssertFalse(SettingsStore.isValidHostBrowserCdpInspectPort(65536))
     }
+
+    // MARK: - applyHostBrowserCdpInspectConfig
+
+    func testApplyDaemonConfigAcceptsValidValues() {
+        // Reset to known-distinct values so we can verify the apply path
+        // overwrites them with the config payload.
+        store.hostBrowserCdpInspectEnabled = false
+        store.hostBrowserCdpInspectHost = "localhost"
+        store.hostBrowserCdpInspectPort = 9222
+
+        let config: [String: Any] = [
+            "hostBrowser": [
+                "cdpInspect": [
+                    "enabled": true,
+                    "host": "127.0.0.1",
+                    "port": 9333,
+                    "probeTimeoutMs": 750,
+                ]
+            ]
+        ]
+        SettingsStore.applyHostBrowserCdpInspectConfig(config, into: store)
+
+        XCTAssertTrue(store.hostBrowserCdpInspectEnabled)
+        XCTAssertEqual(store.hostBrowserCdpInspectHost, "127.0.0.1")
+        XCTAssertEqual(store.hostBrowserCdpInspectPort, 9333)
+        XCTAssertEqual(store.hostBrowserCdpInspectProbeTimeoutMs, 750)
+    }
+
+    func testApplyDaemonConfigRejectsNonLoopbackHost() {
+        // Pre-seed with a valid non-default value so we can distinguish
+        // "left untouched" from "reset to default" in the assertion.
+        store.hostBrowserCdpInspectHost = "127.0.0.1"
+
+        let config: [String: Any] = [
+            "hostBrowser": [
+                "cdpInspect": [
+                    "host": "attacker.example.com",
+                ]
+            ]
+        ]
+        SettingsStore.applyHostBrowserCdpInspectConfig(config, into: store)
+
+        // Invalid host should fall back to the default, NOT persist
+        // "attacker.example.com" and NOT silently leave the old value.
+        XCTAssertEqual(store.hostBrowserCdpInspectHost, SettingsStore.defaultHostBrowserCdpInspectHost)
+        XCTAssertEqual(store.hostBrowserCdpInspectHost, "localhost")
+    }
+
+    func testApplyDaemonConfigRejectsPublicIPHost() {
+        store.hostBrowserCdpInspectHost = "127.0.0.1"
+        let config: [String: Any] = [
+            "hostBrowser": [
+                "cdpInspect": [
+                    "host": "192.168.1.10",
+                ]
+            ]
+        ]
+        SettingsStore.applyHostBrowserCdpInspectConfig(config, into: store)
+        XCTAssertEqual(store.hostBrowserCdpInspectHost, "localhost")
+    }
+
+    func testApplyDaemonConfigRejectsOutOfRangePort() {
+        store.hostBrowserCdpInspectPort = 9333
+
+        let config: [String: Any] = [
+            "hostBrowser": [
+                "cdpInspect": [
+                    "port": 70000,
+                ]
+            ]
+        ]
+        SettingsStore.applyHostBrowserCdpInspectConfig(config, into: store)
+
+        // Out-of-range port should fall back to the default.
+        XCTAssertEqual(store.hostBrowserCdpInspectPort, SettingsStore.defaultHostBrowserCdpInspectPort)
+        XCTAssertEqual(store.hostBrowserCdpInspectPort, 9222)
+    }
+
+    func testApplyDaemonConfigRejectsZeroPort() {
+        store.hostBrowserCdpInspectPort = 9333
+        let config: [String: Any] = [
+            "hostBrowser": [
+                "cdpInspect": [
+                    "port": 0,
+                ]
+            ]
+        ]
+        SettingsStore.applyHostBrowserCdpInspectConfig(config, into: store)
+        XCTAssertEqual(store.hostBrowserCdpInspectPort, 9222)
+    }
+
+    func testApplyDaemonConfigRejectsOutOfRangePortFromDouble() {
+        store.hostBrowserCdpInspectPort = 9333
+        // JSONSerialization may surface integral numbers as Double; ensure
+        // the validation applies in that path too.
+        let config: [String: Any] = [
+            "hostBrowser": [
+                "cdpInspect": [
+                    "port": Double(70000),
+                ]
+            ]
+        ]
+        SettingsStore.applyHostBrowserCdpInspectConfig(config, into: store)
+        XCTAssertEqual(store.hostBrowserCdpInspectPort, 9222)
+    }
+
+    func testApplyDaemonConfigRejectsBothInvalidHostAndPort() {
+        store.hostBrowserCdpInspectHost = "127.0.0.1"
+        store.hostBrowserCdpInspectPort = 9333
+
+        let config: [String: Any] = [
+            "hostBrowser": [
+                "cdpInspect": [
+                    "host": "attacker.example.com",
+                    "port": -5,
+                ]
+            ]
+        ]
+        SettingsStore.applyHostBrowserCdpInspectConfig(config, into: store)
+
+        XCTAssertEqual(store.hostBrowserCdpInspectHost, "localhost")
+        XCTAssertEqual(store.hostBrowserCdpInspectPort, 9222)
+    }
+
+    func testApplyDaemonConfigIgnoresEmptyHostAndLeavesExistingValue() {
+        store.hostBrowserCdpInspectHost = "127.0.0.1"
+        let config: [String: Any] = [
+            "hostBrowser": [
+                "cdpInspect": [
+                    "host": "",
+                ]
+            ]
+        ]
+        SettingsStore.applyHostBrowserCdpInspectConfig(config, into: store)
+        // Empty host is a "key not set" signal, not invalid — we leave the
+        // existing value untouched (same contract as missing keys).
+        XCTAssertEqual(store.hostBrowserCdpInspectHost, "127.0.0.1")
+    }
 }

--- a/clients/macos/vellum-assistantTests/SettingsStoreBrowserBackendTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsStoreBrowserBackendTests.swift
@@ -333,4 +333,148 @@ final class SettingsStoreBrowserBackendTests: XCTestCase {
         // existing value untouched (same contract as missing keys).
         XCTAssertEqual(store.hostBrowserCdpInspectHost, "127.0.0.1")
     }
+
+    // MARK: - Sanitize-and-patch-back behaviour
+
+    func testApplyDaemonConfigPatchesSanitizedHostBackToDaemon() {
+        // An invalid (non-loopback) host from the daemon must be both
+        // sanitized in-memory AND persisted back to the daemon config so
+        // the bad value does not reappear on the next reload.
+        XCTAssertTrue(mockSettingsClient.patchConfigCalls.isEmpty)
+
+        let config: [String: Any] = [
+            "hostBrowser": [
+                "cdpInspect": [
+                    "host": "attacker.example.com",
+                ]
+            ]
+        ]
+        SettingsStore.applyHostBrowserCdpInspectConfig(config, into: store)
+
+        // In-memory fallback applies immediately.
+        XCTAssertEqual(store.hostBrowserCdpInspectHost, "localhost")
+
+        // A patch with the sanitized default is emitted asynchronously.
+        waitForPatchCount(1)
+        let patch = lastCdpInspectPatch()
+        XCTAssertNotNil(patch, "expected a hostBrowser.cdpInspect patch payload")
+        XCTAssertEqual(patch?["host"] as? String, "localhost")
+        XCTAssertNil(patch?["port"])
+        XCTAssertNil(patch?["enabled"])
+    }
+
+    func testApplyDaemonConfigPatchesSanitizedPortBackToDaemon() {
+        // An out-of-range port from the daemon must be both sanitized
+        // in-memory AND persisted back to the daemon config so the bad
+        // value does not reappear on the next reload.
+        XCTAssertTrue(mockSettingsClient.patchConfigCalls.isEmpty)
+
+        let config: [String: Any] = [
+            "hostBrowser": [
+                "cdpInspect": [
+                    "port": 70000,
+                ]
+            ]
+        ]
+        SettingsStore.applyHostBrowserCdpInspectConfig(config, into: store)
+
+        // In-memory fallback applies immediately.
+        XCTAssertEqual(store.hostBrowserCdpInspectPort, 9222)
+
+        // A patch with the sanitized default is emitted asynchronously.
+        waitForPatchCount(1)
+        let patch = lastCdpInspectPatch()
+        XCTAssertNotNil(patch, "expected a hostBrowser.cdpInspect patch payload")
+        XCTAssertEqual(patch?["port"] as? Int, 9222)
+        XCTAssertNil(patch?["host"])
+        XCTAssertNil(patch?["enabled"])
+    }
+
+    func testApplyDaemonConfigPatchesBothSanitizedHostAndPortBackToDaemon() {
+        XCTAssertTrue(mockSettingsClient.patchConfigCalls.isEmpty)
+
+        let config: [String: Any] = [
+            "hostBrowser": [
+                "cdpInspect": [
+                    "host": "attacker.example.com",
+                    "port": -5,
+                ]
+            ]
+        ]
+        SettingsStore.applyHostBrowserCdpInspectConfig(config, into: store)
+
+        XCTAssertEqual(store.hostBrowserCdpInspectHost, "localhost")
+        XCTAssertEqual(store.hostBrowserCdpInspectPort, 9222)
+
+        // One patch per sanitization path.
+        waitForPatchCount(2)
+
+        // Assert BOTH sanitized fields were patched back, regardless of
+        // which order the two background tasks flushed in.
+        var sawHostPatch = false
+        var sawPortPatch = false
+        for payload in mockSettingsClient.patchConfigCalls {
+            guard let hostBrowser = payload["hostBrowser"] as? [String: Any],
+                  let cdpInspect = hostBrowser["cdpInspect"] as? [String: Any] else {
+                continue
+            }
+            if let host = cdpInspect["host"] as? String {
+                XCTAssertEqual(host, "localhost")
+                sawHostPatch = true
+            }
+            if let port = cdpInspect["port"] as? Int {
+                XCTAssertEqual(port, 9222)
+                sawPortPatch = true
+            }
+        }
+        XCTAssertTrue(sawHostPatch, "expected a patch setting host back to localhost")
+        XCTAssertTrue(sawPortPatch, "expected a patch setting port back to 9222")
+    }
+
+    func testApplyDaemonConfigDoesNotPatchWhenValuesAreValid() {
+        // Valid config values must NOT trigger a patch. This guards
+        // against any infinite-loop regression (patch -> refresh ->
+        // patch -> ...) in the normal happy path.
+        let config: [String: Any] = [
+            "hostBrowser": [
+                "cdpInspect": [
+                    "enabled": true,
+                    "host": "127.0.0.1",
+                    "port": 9333,
+                    "probeTimeoutMs": 750,
+                ]
+            ]
+        ]
+        SettingsStore.applyHostBrowserCdpInspectConfig(config, into: store)
+
+        // Give any stray background Task a chance to flush. If a patch
+        // were incorrectly emitted it would show up within this window.
+        let expectation = XCTestExpectation(description: "allow background tasks to flush")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { expectation.fulfill() }
+        wait(for: [expectation], timeout: 1.0)
+
+        XCTAssertTrue(
+            mockSettingsClient.patchConfigCalls.isEmpty,
+            "valid daemon config values must not trigger any patch"
+        )
+    }
+
+    func testApplyDaemonConfigDoesNotPatchWhenHostKeyIsAbsent() {
+        // Missing host key (or empty string, which is the same contract)
+        // must not trigger a patch — only an *invalid* value should.
+        let config: [String: Any] = [
+            "hostBrowser": [
+                "cdpInspect": [
+                    "enabled": true,
+                ]
+            ]
+        ]
+        SettingsStore.applyHostBrowserCdpInspectConfig(config, into: store)
+
+        let expectation = XCTestExpectation(description: "allow background tasks to flush")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { expectation.fulfill() }
+        wait(for: [expectation], timeout: 1.0)
+
+        XCTAssertTrue(mockSettingsClient.patchConfigCalls.isEmpty)
+    }
 }

--- a/clients/macos/vellum-assistantTests/SettingsStoreBrowserBackendTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsStoreBrowserBackendTests.swift
@@ -1,0 +1,198 @@
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+/// Verifies that `SettingsStore` emits the expected config patch payloads
+/// for the `hostBrowser.cdpInspect` namespace and enforces loopback-only
+/// host / in-range port validation before hitting the settings client.
+@MainActor
+final class SettingsStoreBrowserBackendTests: XCTestCase {
+
+    private var mockSettingsClient: MockSettingsClient!
+    private var store: SettingsStore!
+
+    override func setUp() {
+        super.setUp()
+        mockSettingsClient = MockSettingsClient()
+        mockSettingsClient.patchConfigResponse = true
+        store = SettingsStore(settingsClient: mockSettingsClient)
+    }
+
+    override func tearDown() {
+        store = nil
+        mockSettingsClient = nil
+        super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    /// Returns the most recent `hostBrowser.cdpInspect` patch payload captured
+    /// by the mock client, or `nil` if no such patch has been emitted.
+    private func lastCdpInspectPatch() -> [String: Any]? {
+        for payload in mockSettingsClient.patchConfigCalls.reversed() {
+            if let hostBrowser = payload["hostBrowser"] as? [String: Any],
+               let cdpInspect = hostBrowser["cdpInspect"] as? [String: Any] {
+                return cdpInspect
+            }
+        }
+        return nil
+    }
+
+    /// Waits for the background `Task` started by a store helper to flush
+    /// its patch into the mock client. The helpers fire-and-forget a Task,
+    /// so tests must poll until the captured call count matches expectations.
+    private func waitForPatchCount(_ expected: Int, timeout: TimeInterval = 2.0) {
+        let predicate = NSPredicate { _, _ in
+            self.mockSettingsClient.patchConfigCalls.count >= expected
+        }
+        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: nil)
+        wait(for: [expectation], timeout: timeout)
+    }
+
+    // MARK: - Initial State
+
+    func testInitialStateMatchesConfigDefaults() {
+        XCTAssertFalse(store.hostBrowserCdpInspectEnabled)
+        XCTAssertEqual(store.hostBrowserCdpInspectHost, "localhost")
+        XCTAssertEqual(store.hostBrowserCdpInspectPort, 9222)
+        XCTAssertEqual(store.hostBrowserCdpInspectProbeTimeoutMs, 500)
+    }
+
+    // MARK: - Toggle Enable/Disable
+
+    func testSetEnabledTrueEmitsExpectedPatch() {
+        store.setHostBrowserCdpInspectEnabled(true)
+
+        waitForPatchCount(1)
+
+        XCTAssertTrue(store.hostBrowserCdpInspectEnabled)
+        let patch = lastCdpInspectPatch()
+        XCTAssertNotNil(patch, "expected a hostBrowser.cdpInspect patch payload")
+        XCTAssertEqual(patch?["enabled"] as? Bool, true)
+        // Only `enabled` should be present — other fields are patched independently.
+        XCTAssertNil(patch?["host"])
+        XCTAssertNil(patch?["port"])
+    }
+
+    func testSetEnabledFalseEmitsExpectedPatch() {
+        store.hostBrowserCdpInspectEnabled = true // start from enabled to force a toggle
+        store.setHostBrowserCdpInspectEnabled(false)
+
+        waitForPatchCount(1)
+
+        XCTAssertFalse(store.hostBrowserCdpInspectEnabled)
+        let patch = lastCdpInspectPatch()
+        XCTAssertEqual(patch?["enabled"] as? Bool, false)
+    }
+
+    // MARK: - Host override
+
+    func testSetValidLoopbackHostEmitsExpectedPatch() {
+        let error = store.setHostBrowserCdpInspectHost("127.0.0.1")
+        XCTAssertNil(error)
+        XCTAssertEqual(store.hostBrowserCdpInspectHost, "127.0.0.1")
+
+        waitForPatchCount(1)
+        let patch = lastCdpInspectPatch()
+        XCTAssertEqual(patch?["host"] as? String, "127.0.0.1")
+        XCTAssertNil(patch?["enabled"])
+        XCTAssertNil(patch?["port"])
+    }
+
+    func testSetValidLoopbackHostAcceptsEachAllowedVariant() {
+        let allowed = ["localhost", "127.0.0.1", "::1", "[::1]"]
+        for (index, value) in allowed.enumerated() {
+            let error = store.setHostBrowserCdpInspectHost(value)
+            XCTAssertNil(error, "\(value) should be accepted as a loopback host")
+            waitForPatchCount(index + 1)
+            XCTAssertEqual(store.hostBrowserCdpInspectHost, value)
+        }
+    }
+
+    func testSetHostRejectsNonLoopbackValues() {
+        let rejected = [
+            "example.com",
+            "192.168.1.10",
+            "10.0.0.1",
+            "0.0.0.0",
+            "remote.internal",
+        ]
+        for value in rejected {
+            let error = store.setHostBrowserCdpInspectHost(value)
+            XCTAssertNotNil(error, "\(value) should be rejected as non-loopback")
+        }
+        // No patches should have been emitted for rejected hosts.
+        XCTAssertTrue(mockSettingsClient.patchConfigCalls.isEmpty)
+        XCTAssertEqual(store.hostBrowserCdpInspectHost, "localhost")
+    }
+
+    func testSetHostTrimsWhitespaceBeforeValidation() {
+        let error = store.setHostBrowserCdpInspectHost("  127.0.0.1  ")
+        XCTAssertNil(error)
+        waitForPatchCount(1)
+
+        XCTAssertEqual(store.hostBrowserCdpInspectHost, "127.0.0.1")
+        let patch = lastCdpInspectPatch()
+        XCTAssertEqual(patch?["host"] as? String, "127.0.0.1")
+    }
+
+    // MARK: - Port override
+
+    func testSetValidPortEmitsExpectedPatch() {
+        let error = store.setHostBrowserCdpInspectPort(9333)
+        XCTAssertNil(error)
+        XCTAssertEqual(store.hostBrowserCdpInspectPort, 9333)
+
+        waitForPatchCount(1)
+        let patch = lastCdpInspectPatch()
+        XCTAssertEqual(patch?["port"] as? Int, 9333)
+        XCTAssertNil(patch?["enabled"])
+        XCTAssertNil(patch?["host"])
+    }
+
+    func testSetPortAcceptsBoundaries() {
+        XCTAssertNil(store.setHostBrowserCdpInspectPort(1))
+        waitForPatchCount(1)
+        XCTAssertEqual(lastCdpInspectPatch()?["port"] as? Int, 1)
+
+        XCTAssertNil(store.setHostBrowserCdpInspectPort(65535))
+        waitForPatchCount(2)
+        XCTAssertEqual(lastCdpInspectPatch()?["port"] as? Int, 65535)
+    }
+
+    func testSetPortRejectsOutOfRangeValues() {
+        let rejected = [0, -1, 65536, 100_000]
+        for value in rejected {
+            let error = store.setHostBrowserCdpInspectPort(value)
+            XCTAssertNotNil(error, "\(value) should be rejected as out-of-range")
+        }
+        XCTAssertTrue(mockSettingsClient.patchConfigCalls.isEmpty)
+        XCTAssertEqual(store.hostBrowserCdpInspectPort, 9222)
+    }
+
+    // MARK: - Pure validation helpers
+
+    func testIsValidHostBrowserCdpInspectHost() {
+        XCTAssertTrue(SettingsStore.isValidHostBrowserCdpInspectHost("localhost"))
+        XCTAssertTrue(SettingsStore.isValidHostBrowserCdpInspectHost("127.0.0.1"))
+        XCTAssertTrue(SettingsStore.isValidHostBrowserCdpInspectHost("::1"))
+        XCTAssertTrue(SettingsStore.isValidHostBrowserCdpInspectHost("[::1]"))
+        XCTAssertTrue(SettingsStore.isValidHostBrowserCdpInspectHost("LOCALHOST"))
+        XCTAssertTrue(SettingsStore.isValidHostBrowserCdpInspectHost("  localhost  "))
+
+        XCTAssertFalse(SettingsStore.isValidHostBrowserCdpInspectHost(""))
+        XCTAssertFalse(SettingsStore.isValidHostBrowserCdpInspectHost("example.com"))
+        XCTAssertFalse(SettingsStore.isValidHostBrowserCdpInspectHost("192.168.0.1"))
+        XCTAssertFalse(SettingsStore.isValidHostBrowserCdpInspectHost("0.0.0.0"))
+    }
+
+    func testIsValidHostBrowserCdpInspectPort() {
+        XCTAssertTrue(SettingsStore.isValidHostBrowserCdpInspectPort(1))
+        XCTAssertTrue(SettingsStore.isValidHostBrowserCdpInspectPort(9222))
+        XCTAssertTrue(SettingsStore.isValidHostBrowserCdpInspectPort(65535))
+
+        XCTAssertFalse(SettingsStore.isValidHostBrowserCdpInspectPort(0))
+        XCTAssertFalse(SettingsStore.isValidHostBrowserCdpInspectPort(-1))
+        XCTAssertFalse(SettingsStore.isValidHostBrowserCdpInspectPort(65536))
+    }
+}


### PR DESCRIPTION
## Summary
- New `BrowserBackendCard` in Developer tab with loopback-only validation
- Settings store helpers for `hostBrowser.cdpInspect` config
- Unit tests verifying patch payloads for toggle, host, port overrides + validation

Part of plan: browser-cdp-inspect-phase4.md (PR 6 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24608" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
