### PR TITLE
fix: add missing PrecomputedCacheKey parameters to scroll perf tests

### DIFF
--- a/clients/macos/vellum-assistantTests/MessageListScrollPerformanceTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListScrollPerformanceTests.swift
@@ -96,6 +96,9 @@ final class MessageListScrollPerformanceTests: XCTestCase {
                     isThinking: version.isMultiple(of: 7),
                     isCompacting: false,
                     assistantStatusText: nil,
+                    assistantActivityPhase: "",
+                    assistantActivityAnchor: "",
+                    assistantActivityReason: nil,
                     activeSubagentFingerprint: version % 5,
                     displayedMessageCount: version % 1000
                 )
@@ -395,6 +398,9 @@ final class MessageListScrollPerformanceTests: XCTestCase {
             isThinking: false,
             isCompacting: false,
             assistantStatusText: nil,
+            assistantActivityPhase: "",
+            assistantActivityAnchor: "",
+            assistantActivityReason: nil,
             activeSubagentFingerprint: 7,
             displayedMessageCount: 100
         )


### PR DESCRIPTION
## Summary
- Add missing `assistantActivityPhase`, `assistantActivityAnchor`, and `assistantActivityReason` parameters to `PrecomputedCacheKey` initializer calls in `MessageListScrollPerformanceTests.swift`
- The production `PrecomputedCacheKey` struct gained these fields but the two test call sites weren't updated

## Test plan
- [ ] `swift test --filter MessageListScrollPerformanceTests` compiles and passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24611" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
