### PR TITLE
feat(browser): route to cdp-inspect client when configured and extension is absent

### DIFF
--- a/assistant/src/browser-session/index.ts
+++ b/assistant/src/browser-session/index.ts
@@ -4,10 +4,20 @@
  * This module is the single CDP backend selector for browser tools. The
  * `cdp-client` factory (`assistant/src/tools/browser/cdp-client/factory.ts`)
  * constructs a BrowserSessionManager per tool invocation, registers the
- * appropriate backend (extension when `hostBrowserProxy` is present, local
- * Playwright-backed backend otherwise), and exposes a `ScopedCdpClient` that
- * routes `send()` through the manager. This gives every call site a single
- * choke point for session invalidation and future multi-tab routing.
+ * appropriate backend from a three-way selection:
+ *
+ *  1. **Extension** — selected when `hostBrowserProxy` is present (macOS
+ *     desktop / cloud-hosted with a chrome-extension bound to the
+ *     conversation).
+ *  2. **cdp-inspect** — selected when the extension is absent and
+ *     `hostBrowser.cdpInspect.enabled` is `true` in config. Attaches to
+ *     an already-running Chrome via `--remote-debugging-port`.
+ *  3. **Local** — default fallback when neither of the above applies.
+ *     Drives a Playwright-backed sacrificial-profile Chromium.
+ *
+ * The factory exposes a `ScopedCdpClient` that routes `send()` through
+ * the manager. This gives every call site a single choke point for
+ * session invalidation and future multi-tab routing.
  */
 export * from "./backends/cdp-inspect.js";
 export * from "./backends/extension.js";

--- a/assistant/src/tools/browser/cdp-client/__tests__/factory.test.ts
+++ b/assistant/src/tools/browser/cdp-client/__tests__/factory.test.ts
@@ -5,7 +5,7 @@ import type { ToolContext } from "../../../types.js";
 import { CdpError } from "../errors.js";
 
 type FakeClient = {
-  kind: "extension" | "local";
+  kind: "extension" | "local" | "cdp-inspect";
   conversationId: string;
   send: ReturnType<typeof mock>;
   dispose: ReturnType<typeof mock>;
@@ -29,8 +29,18 @@ function makeFakeLocalClient(conversationId: string): FakeClient {
   };
 }
 
+function makeFakeCdpInspectClient(conversationId: string): FakeClient {
+  return {
+    kind: "cdp-inspect",
+    conversationId,
+    send: mock(async () => ({ ok: true, via: "cdp-inspect" })),
+    dispose: mock(() => {}),
+  };
+}
+
 let lastExtensionClient: FakeClient | undefined;
 let lastLocalClient: FakeClient | undefined;
+let lastCdpInspectClient: FakeClient | undefined;
 
 const createExtensionCdpClientMock = mock(
   (_proxy: HostBrowserProxy, conversationId: string) => {
@@ -46,11 +56,41 @@ const createLocalCdpClientMock = mock((conversationId: string) => {
   return client;
 });
 
+const createCdpInspectClientMock = mock(
+  (conversationId: string, _options: unknown) => {
+    const client = makeFakeCdpInspectClient(conversationId);
+    lastCdpInspectClient = client;
+    return client;
+  },
+);
+
+/**
+ * Mutable config state. Tests flip `cdpInspectEnabled` to control
+ * the factory's config-based selection without needing a real config
+ * file.
+ */
+let cdpInspectEnabled = false;
+
 mock.module("../extension-cdp-client.js", () => ({
   createExtensionCdpClient: createExtensionCdpClientMock,
 }));
 mock.module("../local-cdp-client.js", () => ({
   createLocalCdpClient: createLocalCdpClientMock,
+}));
+mock.module("../cdp-inspect-client.js", () => ({
+  createCdpInspectClient: createCdpInspectClientMock,
+}));
+mock.module("../../../../config/loader.js", () => ({
+  getConfig: () => ({
+    hostBrowser: {
+      cdpInspect: {
+        enabled: cdpInspectEnabled,
+        host: "localhost",
+        port: 9222,
+        probeTimeoutMs: 500,
+      },
+    },
+  }),
 }));
 
 // Import under test AFTER mock.module calls so that the factory's
@@ -72,8 +112,11 @@ describe("getCdpClient", () => {
   beforeEach(() => {
     createExtensionCdpClientMock.mockClear();
     createLocalCdpClientMock.mockClear();
+    createCdpInspectClientMock.mockClear();
     lastExtensionClient = undefined;
     lastLocalClient = undefined;
+    lastCdpInspectClient = undefined;
+    cdpInspectEnabled = false;
   });
 
   test("routes to ExtensionCdpClient when hostBrowserProxy is set", () => {
@@ -95,21 +138,63 @@ describe("getCdpClient", () => {
       "test-convo",
     );
     expect(createLocalCdpClientMock).not.toHaveBeenCalled();
+    expect(createCdpInspectClientMock).not.toHaveBeenCalled();
   });
 
-  test("routes to LocalCdpClient when hostBrowserProxy is undefined", () => {
+  test("extension wins even when cdpInspect is enabled", () => {
+    cdpInspectEnabled = true;
+    const fakeProxy = {
+      request: mock(async () => ({})),
+    } as unknown as HostBrowserProxy;
     const ctx = makeContext({
-      conversationId: "test-convo",
+      conversationId: "ext-wins",
+      hostBrowserProxy: fakeProxy,
+    });
+
+    const client = getCdpClient(ctx);
+
+    expect(client.kind).toBe("extension");
+    expect(createExtensionCdpClientMock).toHaveBeenCalledTimes(1);
+    expect(createCdpInspectClientMock).not.toHaveBeenCalled();
+    expect(createLocalCdpClientMock).not.toHaveBeenCalled();
+  });
+
+  test("routes to CdpInspectClient when cdpInspect is enabled and extension is absent", () => {
+    cdpInspectEnabled = true;
+    const ctx = makeContext({
+      conversationId: "inspect-convo",
+      hostBrowserProxy: undefined,
+    });
+
+    const client = getCdpClient(ctx);
+
+    expect(client.kind).toBe("cdp-inspect");
+    expect(client.conversationId).toBe("inspect-convo");
+    expect(createCdpInspectClientMock).toHaveBeenCalledTimes(1);
+    expect(createCdpInspectClientMock).toHaveBeenCalledWith("inspect-convo", {
+      host: "localhost",
+      port: 9222,
+      discoveryTimeoutMs: 500,
+    });
+    expect(createExtensionCdpClientMock).not.toHaveBeenCalled();
+    expect(createLocalCdpClientMock).not.toHaveBeenCalled();
+  });
+
+  test("routes to LocalCdpClient when cdpInspect is disabled and extension is absent", () => {
+    cdpInspectEnabled = false;
+    const ctx = makeContext({
+      conversationId: "local-convo",
       hostBrowserProxy: undefined,
     });
 
     const client = getCdpClient(ctx);
 
     expect(client.kind).toBe("local");
-    expect(client.conversationId).toBe("test-convo");
+    expect(client.conversationId).toBe("local-convo");
     expect(createLocalCdpClientMock).toHaveBeenCalledTimes(1);
-    expect(createLocalCdpClientMock).toHaveBeenCalledWith("test-convo");
+    expect(createLocalCdpClientMock).toHaveBeenCalledWith("local-convo");
     expect(createExtensionCdpClientMock).not.toHaveBeenCalled();
+    expect(createCdpInspectClientMock).not.toHaveBeenCalled();
   });
 
   test("routes to LocalCdpClient when hostBrowserProxy key is omitted", () => {
@@ -122,6 +207,7 @@ describe("getCdpClient", () => {
     expect(createLocalCdpClientMock).toHaveBeenCalledTimes(1);
     expect(createLocalCdpClientMock).toHaveBeenCalledWith("another-convo");
     expect(createExtensionCdpClientMock).not.toHaveBeenCalled();
+    expect(createCdpInspectClientMock).not.toHaveBeenCalled();
   });
 
   test("forwards send() through the manager to the extension-backed client", async () => {
@@ -147,6 +233,7 @@ describe("getCdpClient", () => {
       undefined,
     );
     expect(lastLocalClient).toBeUndefined();
+    expect(lastCdpInspectClient).toBeUndefined();
   });
 
   test("forwards send() through the manager to the local-backed client", async () => {
@@ -166,6 +253,28 @@ describe("getCdpClient", () => {
       undefined,
     );
     expect(lastExtensionClient).toBeUndefined();
+    expect(lastCdpInspectClient).toBeUndefined();
+  });
+
+  test("forwards send() through the manager to the cdp-inspect-backed client", async () => {
+    cdpInspectEnabled = true;
+    const ctx = makeContext({ conversationId: "send-inspect" });
+
+    const client = getCdpClient(ctx);
+    const result = await client.send<{ ok: boolean; via: string }>(
+      "Page.navigate",
+      { url: "https://example.com" },
+    );
+
+    expect(result).toEqual({ ok: true, via: "cdp-inspect" });
+    expect(lastCdpInspectClient?.send).toHaveBeenCalledTimes(1);
+    expect(lastCdpInspectClient?.send).toHaveBeenCalledWith(
+      "Page.navigate",
+      { url: "https://example.com" },
+      undefined,
+    );
+    expect(lastExtensionClient).toBeUndefined();
+    expect(lastLocalClient).toBeUndefined();
   });
 
   test("propagates CdpError thrown by the underlying client", async () => {
@@ -238,5 +347,31 @@ describe("getCdpClient", () => {
     client.dispose();
 
     expect(lastExtensionClient?.dispose).toHaveBeenCalledTimes(1);
+  });
+
+  test("dispose() on a cdp-inspect-backed client tears down the inspect client", () => {
+    cdpInspectEnabled = true;
+    const ctx = makeContext({ conversationId: "dispose-inspect" });
+
+    const client = getCdpClient(ctx);
+    client.dispose();
+
+    expect(lastCdpInspectClient?.dispose).toHaveBeenCalledTimes(1);
+  });
+
+  test("send() after dispose() on a cdp-inspect-backed client rejects with disposed", async () => {
+    cdpInspectEnabled = true;
+    const ctx = makeContext({ conversationId: "post-dispose-inspect" });
+
+    const client = getCdpClient(ctx);
+    client.dispose();
+
+    // Double dispose is a no-op.
+    client.dispose();
+    expect(lastCdpInspectClient?.dispose).toHaveBeenCalledTimes(1);
+
+    await expect(client.send("Page.navigate")).rejects.toMatchObject({
+      code: "disposed",
+    });
   });
 });

--- a/assistant/src/tools/browser/cdp-client/factory.ts
+++ b/assistant/src/tools/browser/cdp-client/factory.ts
@@ -3,10 +3,13 @@ import {
   BrowserSessionManager,
   type CdpCommand,
   type CdpResult,
+  createCdpInspectBackend,
   createExtensionBackend,
   createLocalBackend,
 } from "../../../browser-session/index.js";
+import { getConfig } from "../../../config/loader.js";
 import type { ToolContext } from "../../types.js";
+import { createCdpInspectClient } from "./cdp-inspect-client.js";
 import { CdpError } from "./errors.js";
 import { createExtensionCdpClient } from "./extension-cdp-client.js";
 import { createLocalCdpClient } from "./local-cdp-client.js";
@@ -14,19 +17,23 @@ import type { CdpClient, CdpClientKind, ScopedCdpClient } from "./types.js";
 
 /**
  * Select the appropriate CdpClient implementation for a tool
- * invocation based on the ToolContext:
+ * invocation based on the ToolContext and config. Three backends are
+ * considered in priority order:
  *
- *  - When `context.hostBrowserProxy` is set (macOS desktop / cloud-
- *    hosted with a chrome-extension bound to the conversation),
- *    register an extension backend so CDP commands ride the
- *    host_browser_request / host_browser_result round-trip.
- *  - Otherwise (CLI, tests, headless Chromium launched in-process),
- *    register a local backend that drives Playwright's CDPSession
- *    against the sacrificial-profile browser managed by
- *    browserManager.
+ *  1. **Extension** — When `context.hostBrowserProxy` is set (macOS
+ *     desktop / cloud-hosted with a chrome-extension bound to the
+ *     conversation), register an extension backend so CDP commands
+ *     ride the host_browser_request / host_browser_result round-trip.
+ *  2. **cdp-inspect** — When the extension is absent and
+ *     `hostBrowser.cdpInspect.enabled` is `true` in config, construct
+ *     a `CdpInspectClient` that attaches to an already-running Chrome
+ *     via the DevTools JSON protocol (`--remote-debugging-port`).
+ *  3. **Local** — Default fallback. Drives Playwright's CDPSession
+ *     against the sacrificial-profile browser managed by
+ *     browserManager.
  *
- * Both paths go through a per-invocation `BrowserSessionManager` so
- * the manager is the single choke point for CDP routing, session
+ * All three paths go through a per-invocation `BrowserSessionManager`
+ * so the manager is the single choke point for CDP routing, session
  * lifetime, and (future) session invalidation handling. The returned
  * client is `kind`-tagged so tools can branch on transport — e.g.
  * browser_navigate skips Playwright-specific screencast and handoff
@@ -40,6 +47,8 @@ import type { CdpClient, CdpClientKind, ScopedCdpClient } from "./types.js";
  */
 export function getCdpClient(context: ToolContext): ScopedCdpClient {
   const { conversationId, hostBrowserProxy } = context;
+
+  // 1. Extension backend — preferred when a chrome-extension is bound.
   if (hostBrowserProxy) {
     const client = createExtensionCdpClient(hostBrowserProxy, conversationId);
     const backend = createExtensionBackend({
@@ -50,6 +59,25 @@ export function getCdpClient(context: ToolContext): ScopedCdpClient {
     });
     return buildManagedClient("extension", conversationId, backend);
   }
+
+  // 2. cdp-inspect backend — opt-in via config when the extension is absent.
+  const cdpInspectConfig = getConfig().hostBrowser.cdpInspect;
+  if (cdpInspectConfig.enabled) {
+    const client = createCdpInspectClient(conversationId, {
+      host: cdpInspectConfig.host,
+      port: cdpInspectConfig.port,
+      discoveryTimeoutMs: cdpInspectConfig.probeTimeoutMs,
+    });
+    const backend = createCdpInspectBackend({
+      isAvailable: () => true,
+      sendCdp: (command, signal) =>
+        dispatchThroughClient(client, command, signal),
+      dispose: () => client.dispose(),
+    });
+    return buildManagedClient("cdp-inspect", conversationId, backend);
+  }
+
+  // 3. Local backend — default fallback (Playwright-backed Chromium).
   const client = createLocalCdpClient(conversationId);
   const backend = createLocalBackend({
     isAvailable: () => true,

--- a/docs/browser-use-architecture-phase2.md
+++ b/docs/browser-use-architecture-phase2.md
@@ -248,5 +248,9 @@ Alternatives considered:
 - Playwright / `chrome --remote-debugging-port` in a sacrificial profile
   avoids the infobar but requires installing Chromium and is out-of-
   scope (Phase 5).
-- Chrome 146+ `chrome://inspect` attach backend may offer a less
-  intrusive UX and is being tracked for Phase 4.
+- The assistant-local `cdp-inspect` backend attaches to an existing
+  Chrome instance via `chrome://inspect` / `--remote-debugging-port`
+  and avoids the per-tab debugger infobar entirely. It is implemented
+  and opt-in via `hostBrowser.cdpInspect.enabled`; see
+  [Browser Use — `cdp-inspect` Backend](./browser-use-cdp-inspect-backend.md)
+  for setup, security trade-offs, and troubleshooting.

--- a/docs/browser-use-cdp-inspect-backend.md
+++ b/docs/browser-use-cdp-inspect-backend.md
@@ -1,0 +1,156 @@
+# Browser Use — `cdp-inspect` Backend
+
+The `cdp-inspect` backend connects the assistant directly to an
+already-running Chrome instance via the DevTools JSON protocol
+(`--remote-debugging-port`). It avoids the per-tab debugger infobar
+that the Chrome extension transport shows, at the cost of broader
+session-level access.
+
+## Backend comparison
+
+| | **Extension** | **cdp-inspect** | **Local** |
+|---|---|---|---|
+| Chrome instance | User's own Chrome via chrome.debugger | User's own Chrome via `--remote-debugging-port` | Sacrificial-profile Chromium managed by Playwright |
+| Requires install | Chrome extension | None (Chrome flag only) | Playwright browser download |
+| Debugger infobar | Yes (per tab) | No | No (dedicated profile) |
+| Tab scope | Single active tab | Any open tab | Dedicated browser |
+| Auth/session access | Active tab only | All tabs, all cookies | Isolated profile |
+| Selection priority | 1st (highest) | 2nd (when enabled) | 3rd (default fallback) |
+
+## When to use this backend
+
+**Prefer the Chrome extension.** It provides the best security boundary
+(single-tab scope, visible debugger infobar, chrome.debugger permission
+model) and requires no special Chrome launch flags.
+
+Use `cdp-inspect` only when:
+
+- You cannot install the Chrome extension (e.g. enterprise policy,
+  Chromium-based browser without extension support).
+- You want to avoid the yellow "started debugging this browser" infobar
+  that `chrome.debugger.attach` displays.
+- You are running in a headless/CI environment where a user-profile
+  Chrome is already running with `--remote-debugging-port`.
+
+## Security considerations
+
+### Real-session control
+
+When the assistant attaches via `cdp-inspect`, it can read and act on
+**any tab** in the target Chrome instance — including tabs with active
+sessions for email, banking, chat, and other authenticated services.
+The extension backend, by contrast, only operates on the single tab the
+user activates.
+
+### Phishing and page-content risk
+
+DOM content retrieved via CDP is untrusted. The extension backend
+mitigates this partially through the `chrome.debugger` permission model
+and the visible infobar, which signals to the user that debugging is
+active. The `cdp-inspect` backend has no equivalent per-site allowlist
+or visible indicator in the browser chrome.
+
+### Loopback-only by policy
+
+The discovery layer (`probeDevToolsJsonVersion`) refuses to connect to
+any host that is not `localhost` or `127.0.0.1`. Remote attach is
+rejected with a `non_loopback` error before any network I/O occurs.
+
+**Warning:** The Chrome DevTools HTTP/WebSocket port has **no
+authentication**. Any process on the same machine can connect to it.
+Only enable `--remote-debugging-port` on machines where you trust all
+running processes.
+
+## Enabling the backend
+
+### macOS Settings UI
+
+Open **macOS Settings → Developer → Browser backend** and select the
+**"Use your own Chrome (Advanced)"** card. This sets the config key
+below automatically.
+
+### JSON config
+
+Add or update the following keys in your assistant config
+(`~/.vellum/workspace/config.json`):
+
+```json
+{
+  "hostBrowser": {
+    "cdpInspect": {
+      "enabled": true,
+      "host": "localhost",
+      "port": 9222,
+      "probeTimeoutMs": 500
+    }
+  }
+}
+```
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `hostBrowser.cdpInspect.enabled` | boolean | `false` | Enable the cdp-inspect backend. |
+| `hostBrowser.cdpInspect.host` | string | `"localhost"` | Loopback host for the DevTools endpoint. Must be `localhost` or `127.0.0.1`. |
+| `hostBrowser.cdpInspect.port` | number | `9222` | TCP port matching `--remote-debugging-port`. |
+| `hostBrowser.cdpInspect.probeTimeoutMs` | number | `500` | Timeout (ms) for the discovery probe. Increase if Chrome is slow to respond. |
+
+## Launching Chrome with remote debugging
+
+You must launch Chrome with `--remote-debugging-port` before the
+assistant can attach. Close all existing Chrome instances first, then
+run one of the commands below.
+
+### macOS
+
+```bash
+/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome \
+  --remote-debugging-port=9222
+```
+
+### Linux
+
+```bash
+google-chrome --remote-debugging-port=9222
+```
+
+### Windows
+
+```powershell
+& "C:\Program Files\Google\Chrome\Application\chrome.exe" `
+  --remote-debugging-port=9222
+```
+
+> **Tip:** If Chrome is already running without the flag, the port will
+> not be opened. Quit Chrome completely and relaunch with the flag.
+
+## Verifying the DevTools endpoint
+
+Once Chrome is running with `--remote-debugging-port`, confirm the
+endpoint is reachable:
+
+```bash
+# Version info — confirms Chrome is listening
+curl http://localhost:9222/json/version
+
+# Open targets — lists all debuggable tabs/pages
+curl http://localhost:9222/json/list
+```
+
+A successful `/json/version` response contains `Browser`, `Protocol-Version`,
+and `webSocketDebuggerUrl` fields. A successful `/json/list` response is
+a JSON array of target objects, each with `id`, `type`, `title`, `url`,
+and `webSocketDebuggerUrl`.
+
+## Troubleshooting
+
+The assistant surfaces `DevToolsDiscoveryError` codes when the
+cdp-inspect backend cannot reach or identify the DevTools endpoint.
+
+| Error code | Likely cause | Fix |
+|---|---|---|
+| `unreachable` | Chrome is not running with `--remote-debugging-port`, or the configured port is wrong. | Launch Chrome with `--remote-debugging-port=9222` and verify with `curl http://localhost:9222/json/version`. |
+| `non_loopback` | The configured `host` is not `localhost` or `127.0.0.1`. | Set `hostBrowser.cdpInspect.host` to `"localhost"`. Remote attach is refused by policy. |
+| `non_chrome` | Something other than Chrome is bound to port 9222. | Check what process is using the port (`lsof -i :9222` on macOS/Linux) and either stop it or change the configured port. |
+| `invalid_response` | The port responds but is not speaking the DevTools protocol. | Verify with `curl http://localhost:9222/json/version`. If the response is not valid JSON with a `Browser` field, another service is using the port. |
+| `no_targets` | Chrome is running but has no open tabs or pages. | Open at least one tab in Chrome before using browser tools. |
+| `timeout` | Chrome is slow to respond to the discovery probe. | Increase `hostBrowser.cdpInspect.probeTimeoutMs` (max 5000). |


### PR DESCRIPTION
## Summary
- Three-way factory selection: extension (preferred) → cdp-inspect (when enabled) → local (default)
- Factory tests covering all selection paths + dispose behavior
- Updated browser-session docblock to reflect 3-way routing
- New docs/browser-use-cdp-inspect-backend.md with setup, security, and troubleshooting
- Updated Phase 2 architecture doc to mark cdp-inspect as implemented

Part of plan: browser-cdp-inspect-phase4.md (PR 5 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24619" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
