### PR TITLE
fix: mention CdpInspectClient in CdpClient interface JSDoc

### DIFF
--- a/assistant/src/tools/browser/cdp-client/types.ts
+++ b/assistant/src/tools/browser/cdp-client/types.ts
@@ -1,10 +1,11 @@
 /**
  * Minimal typed surface over Chrome DevTools Protocol. Implemented by
- * LocalCdpClient (Playwright-backed, same-process Chromium) and by
+ * LocalCdpClient (Playwright-backed, same-process Chromium),
  * ExtensionCdpClient (routes through HostBrowserProxy to the user's
- * Chrome via chrome.debugger). Tools call `send(method, params)` with
- * a CDP method name and return the raw CDP result object; errors are
- * thrown as {@link CdpError}.
+ * Chrome via chrome.debugger), and CdpInspectClient (connects to a
+ * remote browser over a raw CDP WebSocket URL). Tools call
+ * `send(method, params)` with a CDP method name and return the raw
+ * CDP result object; errors are thrown as {@link CdpError}.
  */
 export interface CdpClient {
   /**


### PR DESCRIPTION
## Summary
Fixes gap: CdpClient interface doc comment was missing CdpInspectClient.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24621" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
