### PR TITLE
fix: reword cdp-inspect backend comment to present tense

### DIFF
--- a/assistant/src/browser-session/backends/cdp-inspect.ts
+++ b/assistant/src/browser-session/backends/cdp-inspect.ts
@@ -7,8 +7,8 @@ import type { BrowserBackend, CdpCommand, CdpResult } from "../types.js";
  * (see `assistant/src/tools/browser/cdp-client/cdp-inspect-client.ts`).
  *
  * The factory in
- * `assistant/src/tools/browser/cdp-client/factory.ts` will construct
- * one per tool invocation in PR 5, paralleling the existing extension
+ * `assistant/src/tools/browser/cdp-client/factory.ts` constructs
+ * one per tool invocation, paralleling the existing extension
  * and local backend wiring.
  */
 export interface CdpInspectBackendDeps {


### PR DESCRIPTION
## Summary
Fixes stale forward reference: rewrites 'will construct in PR 5' to present tense.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24622" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
