### PR TITLE
feat(browser): Phase 4 — cdp-inspect fallback backend

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -839,6 +839,125 @@ describe("AssistantConfigSchema", () => {
     });
     expect(result.calls.callerIdentity.allowPerCallOverride).toBe(true);
   });
+
+  // ── hostBrowser.cdpInspect config ─────────────────────────────────
+
+  test("applies hostBrowser.cdpInspect defaults", () => {
+    const result = AssistantConfigSchema.parse({});
+    expect(result.hostBrowser).toEqual({
+      cdpInspect: {
+        enabled: false,
+        host: "localhost",
+        port: 9222,
+        probeTimeoutMs: 500,
+      },
+    });
+  });
+
+  test("accepts hostBrowser.cdpInspect enabled with custom host/port", () => {
+    const result = AssistantConfigSchema.parse({
+      hostBrowser: {
+        cdpInspect: {
+          enabled: true,
+          host: "127.0.0.1",
+          port: 9333,
+        },
+      },
+    });
+    expect(result.hostBrowser.cdpInspect.enabled).toBe(true);
+    expect(result.hostBrowser.cdpInspect.host).toBe("127.0.0.1");
+    expect(result.hostBrowser.cdpInspect.port).toBe(9333);
+    // Unset field should still receive its default.
+    expect(result.hostBrowser.cdpInspect.probeTimeoutMs).toBe(500);
+  });
+
+  test("accepts hostBrowser.cdpInspect custom probeTimeoutMs", () => {
+    const result = AssistantConfigSchema.parse({
+      hostBrowser: { cdpInspect: { probeTimeoutMs: 1000 } },
+    });
+    expect(result.hostBrowser.cdpInspect.probeTimeoutMs).toBe(1000);
+  });
+
+  test("rejects hostBrowser.cdpInspect.port below 1", () => {
+    const result = AssistantConfigSchema.safeParse({
+      hostBrowser: { cdpInspect: { port: 0 } },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(
+        result.error.issues.some((issue) =>
+          issue.path.join(".").includes("hostBrowser.cdpInspect.port"),
+        ),
+      ).toBe(true);
+    }
+  });
+
+  test("rejects hostBrowser.cdpInspect.port above 65535", () => {
+    const result = AssistantConfigSchema.safeParse({
+      hostBrowser: { cdpInspect: { port: 70000 } },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(
+        result.error.issues.some((issue) =>
+          issue.path.join(".").includes("hostBrowser.cdpInspect.port"),
+        ),
+      ).toBe(true);
+    }
+  });
+
+  test("rejects non-integer hostBrowser.cdpInspect.port", () => {
+    const result = AssistantConfigSchema.safeParse({
+      hostBrowser: { cdpInspect: { port: 9222.5 } },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects hostBrowser.cdpInspect.probeTimeoutMs below 50", () => {
+    const result = AssistantConfigSchema.safeParse({
+      hostBrowser: { cdpInspect: { probeTimeoutMs: 10 } },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(
+        result.error.issues.some((issue) =>
+          issue.path
+            .join(".")
+            .includes("hostBrowser.cdpInspect.probeTimeoutMs"),
+        ),
+      ).toBe(true);
+    }
+  });
+
+  test("rejects hostBrowser.cdpInspect.probeTimeoutMs above 5000", () => {
+    const result = AssistantConfigSchema.safeParse({
+      hostBrowser: { cdpInspect: { probeTimeoutMs: 10000 } },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(
+        result.error.issues.some((issue) =>
+          issue.path
+            .join(".")
+            .includes("hostBrowser.cdpInspect.probeTimeoutMs"),
+        ),
+      ).toBe(true);
+    }
+  });
+
+  test("rejects non-integer hostBrowser.cdpInspect.probeTimeoutMs", () => {
+    const result = AssistantConfigSchema.safeParse({
+      hostBrowser: { cdpInspect: { probeTimeoutMs: 500.5 } },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects non-boolean hostBrowser.cdpInspect.enabled", () => {
+    const result = AssistantConfigSchema.safeParse({
+      hostBrowser: { cdpInspect: { enabled: "yes" } },
+    });
+    expect(result.success).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/browser-session/backends/cdp-inspect.ts
+++ b/assistant/src/browser-session/backends/cdp-inspect.ts
@@ -1,0 +1,30 @@
+import type { BrowserBackend, CdpCommand, CdpResult } from "../types.js";
+
+/**
+ * cdp-inspect backend for BrowserSessionManager. Wraps a
+ * caller-provided `sendCdp` transport that talks to an already-running
+ * Chrome via DevTools JSON discovery + a raw WebSocket transport
+ * (see `assistant/src/tools/browser/cdp-client/cdp-inspect-client.ts`).
+ *
+ * The factory in
+ * `assistant/src/tools/browser/cdp-client/factory.ts` will construct
+ * one per tool invocation in PR 5, paralleling the existing extension
+ * and local backend wiring.
+ */
+export interface CdpInspectBackendDeps {
+  /** Sends a CDP command to the user's Chrome via cdp-inspect and returns the CDP result. */
+  sendCdp(command: CdpCommand, signal?: AbortSignal): Promise<CdpResult>;
+  isAvailable(): boolean;
+  dispose(): void;
+}
+
+export function createCdpInspectBackend(
+  deps: CdpInspectBackendDeps,
+): BrowserBackend {
+  return {
+    kind: "cdp-inspect",
+    isAvailable: deps.isAvailable,
+    send: deps.sendCdp,
+    dispose: deps.dispose,
+  };
+}

--- a/assistant/src/browser-session/backends/cdp-inspect.ts
+++ b/assistant/src/browser-session/backends/cdp-inspect.ts
@@ -7,8 +7,8 @@ import type { BrowserBackend, CdpCommand, CdpResult } from "../types.js";
  * (see `assistant/src/tools/browser/cdp-client/cdp-inspect-client.ts`).
  *
  * The factory in
- * `assistant/src/tools/browser/cdp-client/factory.ts` will construct
- * one per tool invocation in PR 5, paralleling the existing extension
+ * `assistant/src/tools/browser/cdp-client/factory.ts` constructs
+ * one per tool invocation, paralleling the existing extension
  * and local backend wiring.
  */
 export interface CdpInspectBackendDeps {

--- a/assistant/src/browser-session/index.ts
+++ b/assistant/src/browser-session/index.ts
@@ -9,6 +9,7 @@
  * routes `send()` through the manager. This gives every call site a single
  * choke point for session invalidation and future multi-tab routing.
  */
+export * from "./backends/cdp-inspect.js";
 export * from "./backends/extension.js";
 export * from "./backends/local.js";
 export * from "./events.js";

--- a/assistant/src/browser-session/index.ts
+++ b/assistant/src/browser-session/index.ts
@@ -4,10 +4,20 @@
  * This module is the single CDP backend selector for browser tools. The
  * `cdp-client` factory (`assistant/src/tools/browser/cdp-client/factory.ts`)
  * constructs a BrowserSessionManager per tool invocation, registers the
- * appropriate backend (extension when `hostBrowserProxy` is present, local
- * Playwright-backed backend otherwise), and exposes a `ScopedCdpClient` that
- * routes `send()` through the manager. This gives every call site a single
- * choke point for session invalidation and future multi-tab routing.
+ * appropriate backend from a three-way selection:
+ *
+ *  1. **Extension** — selected when `hostBrowserProxy` is present (macOS
+ *     desktop / cloud-hosted with a chrome-extension bound to the
+ *     conversation).
+ *  2. **cdp-inspect** — selected when the extension is absent and
+ *     `hostBrowser.cdpInspect.enabled` is `true` in config. Attaches to
+ *     an already-running Chrome via `--remote-debugging-port`.
+ *  3. **Local** — default fallback when neither of the above applies.
+ *     Drives a Playwright-backed sacrificial-profile Chromium.
+ *
+ * The factory exposes a `ScopedCdpClient` that routes `send()` through
+ * the manager. This gives every call site a single choke point for
+ * session invalidation and future multi-tab routing.
  */
 export * from "./backends/cdp-inspect.js";
 export * from "./backends/extension.js";

--- a/assistant/src/browser-session/types.ts
+++ b/assistant/src/browser-session/types.ts
@@ -1,4 +1,4 @@
-export type BrowserBackendKind = "extension" | "local";
+export type BrowserBackendKind = "extension" | "local" | "cdp-inspect";
 
 export interface CdpCommand {
   method: string;

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -50,6 +50,14 @@ export { FishAudioConfigSchema } from "./schemas/fish-audio.js";
 export type { HeartbeatConfig } from "./schemas/heartbeat.js";
 export { HeartbeatConfigSchema } from "./schemas/heartbeat.js";
 export type {
+  HostBrowserCdpInspectConfig,
+  HostBrowserConfig,
+} from "./schemas/host-browser.js";
+export {
+  HostBrowserCdpInspectConfigSchema,
+  HostBrowserConfigSchema,
+} from "./schemas/host-browser.js";
+export type {
   ContextOverflowRecoveryConfig,
   ContextWindowConfig,
   Effort,
@@ -205,6 +213,7 @@ import { ElevenLabsConfigSchema } from "./schemas/elevenlabs.js";
 import { FilingConfigSchema } from "./schemas/filing.js";
 import { FishAudioConfigSchema } from "./schemas/fish-audio.js";
 import { HeartbeatConfigSchema } from "./schemas/heartbeat.js";
+import { HostBrowserConfigSchema } from "./schemas/host-browser.js";
 import {
   ContextWindowConfigSchema,
   EffortSchema,
@@ -278,6 +287,9 @@ export const AssistantConfigSchema = z
       ),
     filing: FilingConfigSchema.default(FilingConfigSchema.parse({})),
     heartbeat: HeartbeatConfigSchema.default(HeartbeatConfigSchema.parse({})),
+    hostBrowser: HostBrowserConfigSchema.default(
+      HostBrowserConfigSchema.parse({}),
+    ),
     journal: JournalConfigSchema.default(JournalConfigSchema.parse({})),
     mcp: McpConfigSchema.default(McpConfigSchema.parse({})),
     acp: AcpConfigSchema.default(AcpConfigSchema.parse({})),

--- a/assistant/src/config/schemas/host-browser.ts
+++ b/assistant/src/config/schemas/host-browser.ts
@@ -1,0 +1,67 @@
+import { z } from "zod";
+
+/**
+ * Configuration for the `cdp-inspect` browser backend — connects directly
+ * to a host Chrome instance that was launched with `--remote-debugging-port`
+ * (e.g. `chrome://inspect`-style remote debugging). Serves as a fallback
+ * between the extension backend (user's Chrome via chrome.debugger) and the
+ * local Playwright-backed backend.
+ */
+export const HostBrowserCdpInspectConfigSchema = z
+  .object({
+    enabled: z
+      .boolean({ error: "hostBrowser.cdpInspect.enabled must be a boolean" })
+      .default(false)
+      .describe(
+        "Whether the cdp-inspect backend is enabled. When true, the browser-session manager will probe the configured host/port before falling back to the local Playwright backend.",
+      ),
+    host: z
+      .string({ error: "hostBrowser.cdpInspect.host must be a string" })
+      .min(1, "hostBrowser.cdpInspect.host must not be empty")
+      .default("localhost")
+      .describe(
+        "Host name or IP address where the host Chrome instance exposes its remote debugging endpoint.",
+      ),
+    port: z
+      .number({ error: "hostBrowser.cdpInspect.port must be a number" })
+      .int("hostBrowser.cdpInspect.port must be an integer")
+      .min(1, "hostBrowser.cdpInspect.port must be >= 1")
+      .max(65535, "hostBrowser.cdpInspect.port must be <= 65535")
+      .default(9222)
+      .describe(
+        "TCP port for the host Chrome remote-debugging endpoint (matches `--remote-debugging-port`).",
+      ),
+    probeTimeoutMs: z
+      .number({
+        error: "hostBrowser.cdpInspect.probeTimeoutMs must be a number",
+      })
+      .int("hostBrowser.cdpInspect.probeTimeoutMs must be an integer")
+      .min(50, "hostBrowser.cdpInspect.probeTimeoutMs must be >= 50")
+      .max(5000, "hostBrowser.cdpInspect.probeTimeoutMs must be <= 5000")
+      .default(500)
+      .describe(
+        "Timeout (in milliseconds) for the backend availability probe. Kept small so the fallback to the local backend stays snappy.",
+      ),
+  })
+  .describe(
+    "Settings for the cdp-inspect backend that connects to a host Chrome instance via its remote-debugging endpoint.",
+  );
+
+export type HostBrowserCdpInspectConfig = z.infer<
+  typeof HostBrowserCdpInspectConfigSchema
+>;
+
+/**
+ * Top-level configuration for host-browser backends. Currently only exposes
+ * `cdpInspect`, but the shape leaves room for additional host-browser knobs
+ * (e.g. extension-specific settings) without another namespace churn.
+ */
+export const HostBrowserConfigSchema = z
+  .object({
+    cdpInspect: HostBrowserCdpInspectConfigSchema.default(
+      HostBrowserCdpInspectConfigSchema.parse({}),
+    ),
+  })
+  .describe("Host-browser backend configuration (cdp-inspect, etc.)");
+
+export type HostBrowserConfig = z.infer<typeof HostBrowserConfigSchema>;

--- a/assistant/src/runtime/assistant-event-hub.ts
+++ b/assistant/src/runtime/assistant-event-hub.ts
@@ -45,7 +45,7 @@ interface SubscriberEntry {
  * events that match their `assistantId` (and optionally `conversationId`).
  *
  * The hub is intentionally simple: synchronous fanout, no buffering, no
- * backpressure. Slow-consumer protection lives in the SSE route (PR 7).
+ * backpressure. Slow-consumer protection lives in the SSE route.
  */
 export class AssistantEventHub {
   private readonly subscribers = new Set<SubscriberEntry>();
@@ -194,6 +194,6 @@ export class AssistantEventHub {
 /**
  * Singleton hub shared across the entire runtime process.
  *
- * Import and use this in daemon send paths (PR 3) and the SSE route (PR 5).
+ * Import and use this in daemon send paths and the SSE route.
  */
 export const assistantEventHub = new AssistantEventHub({ maxSubscribers: 100 });

--- a/assistant/src/runtime/pending-interactions.ts
+++ b/assistant/src/runtime/pending-interactions.ts
@@ -96,7 +96,7 @@ export function get(requestId: string): PendingInteraction | undefined {
 
 /**
  * Return all pending interactions for a given conversation.
- * Needed by channel approval migration (PR 3).
+ * Needed by channel approval migration.
  */
 export function getByConversation(
   conversationId: string,

--- a/assistant/src/tools/browser/cdp-client/__tests__/cdp-inspect-client.test.ts
+++ b/assistant/src/tools/browser/cdp-client/__tests__/cdp-inspect-client.test.ts
@@ -1,0 +1,870 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Silence the logger from cdp-inspect-client.
+mock.module("../../../../util/logger.js", () => ({
+  getLogger: () => ({
+    info: () => {},
+    debug: () => {},
+    warn: () => {},
+    error: () => {},
+  }),
+}));
+
+// Import under test AFTER mock.module calls so that the module's
+// top-level logger import resolves to our fake.
+const { CdpInspectClient, createCdpInspectClient } =
+  await import("../cdp-inspect-client.js");
+const { CdpError } = await import("../errors.js");
+const { CdpWsTransportError } = await import("../cdp-inspect/ws-transport.js");
+
+type CdpInspectClientInstance = InstanceType<typeof CdpInspectClient>;
+
+/**
+ * Minimal fake CdpWsTransport used by the test harness below. The
+ * handler is per-send so individual tests can model success, CDP
+ * errors, transport errors, and abort behavior on specific methods.
+ */
+interface FakeTransportOptions {
+  onSend?: (
+    method: string,
+    params: Record<string, unknown> | undefined,
+    opts: { sessionId?: string; signal?: AbortSignal },
+  ) => unknown | Promise<unknown>;
+  trackSends?: Array<{
+    method: string;
+    params?: Record<string, unknown>;
+    sessionId?: string;
+  }>;
+  trackDisposeCount?: { count: number };
+}
+
+function createFakeTransport(options: FakeTransportOptions) {
+  const transport = {
+    send: async <T = unknown>(
+      method: string,
+      params?: Record<string, unknown>,
+      opts?: { sessionId?: string; signal?: AbortSignal },
+    ): Promise<T> => {
+      options.trackSends?.push({
+        method,
+        params,
+        sessionId: opts?.sessionId,
+      });
+      if (options.onSend) {
+        const result = await options.onSend(method, params, opts ?? {});
+        return result as T;
+      }
+      return undefined as T;
+    },
+    addEventListener: () => () => {},
+    dispose: () => {
+      if (options.trackDisposeCount) {
+        options.trackDisposeCount.count += 1;
+      }
+    },
+  };
+  return transport;
+}
+
+/**
+ * Build a client wired to mocked discovery + transport helpers. The
+ * caller supplies handlers for the moving pieces; everything else
+ * defaults to a happy-path attach.
+ */
+interface HarnessOptions {
+  probeImpl?: (opts: unknown) => Promise<{
+    browser: string;
+    protocolVersion: string;
+    webSocketDebuggerUrl: string;
+  }>;
+  listImpl?: (opts: unknown) => Promise<
+    Array<{
+      id: string;
+      type: string;
+      title: string;
+      url: string;
+      webSocketDebuggerUrl: string;
+    }>
+  >;
+  connectImpl?: (
+    url: string,
+    opts?: { connectTimeoutMs?: number },
+  ) => Promise<ReturnType<typeof createFakeTransport>>;
+  transportOnSend?: FakeTransportOptions["onSend"];
+  conversationId?: string;
+}
+
+interface Harness {
+  client: CdpInspectClientInstance;
+  sends: Array<{
+    method: string;
+    params?: Record<string, unknown>;
+    sessionId?: string;
+  }>;
+  disposeCount: { count: number };
+  probeCalls: number;
+  listCalls: number;
+  connectCalls: number;
+  attachCallCount: () => number;
+}
+
+function createHarness(opts: HarnessOptions = {}): Harness {
+  const sends: Array<{
+    method: string;
+    params?: Record<string, unknown>;
+    sessionId?: string;
+  }> = [];
+  const disposeCount = { count: 0 };
+  let probeCalls = 0;
+  let listCalls = 0;
+  let connectCalls = 0;
+
+  // Track Target.attachToTarget specifically so tests can assert
+  // how many attach attempts the client has made. The counter is
+  // bumped ONLY in the default happy-path branch so tests that
+  // install a custom `transportOnSend` (and therefore model their
+  // own attach semantics) can't accidentally double-count.
+  const attachSends: Array<unknown> = [];
+
+  const defaultOnSend: FakeTransportOptions["onSend"] = (method) => {
+    if (method === "Target.attachToTarget") {
+      attachSends.push(method);
+      return { sessionId: "fake-session-id" };
+    }
+    return { ok: true };
+  };
+
+  const transportOnSend: FakeTransportOptions["onSend"] = async (
+    method,
+    params,
+    o,
+  ) => {
+    if (opts.transportOnSend) {
+      return opts.transportOnSend(method, params, o);
+    }
+    return defaultOnSend!(method, params, o);
+  };
+
+  const client = createCdpInspectClient(opts.conversationId ?? "conv-1", {
+    host: "127.0.0.1",
+    port: 9222,
+    discoveryTimeoutMs: 100,
+    wsConnectTimeoutMs: 100,
+    helpers: {
+      probeDevToolsJsonVersion: async (probeOpts: unknown) => {
+        probeCalls += 1;
+        if (opts.probeImpl) return opts.probeImpl(probeOpts);
+        return {
+          browser: "Chrome/125.0.0.0",
+          protocolVersion: "1.3",
+          webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/browser/fake",
+        };
+      },
+      listDevToolsTargets: async (listOpts: unknown) => {
+        listCalls += 1;
+        if (opts.listImpl) return opts.listImpl(listOpts);
+        return [
+          {
+            id: "target-1",
+            type: "page",
+            title: "Example",
+            url: "https://example.com/",
+            webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/page/target-1",
+          },
+        ];
+      },
+      // pickDefaultTarget uses the real implementation — it's pure.
+      connectCdpWsTransport: async (
+        url: string,
+        connectOpts?: { connectTimeoutMs?: number },
+      ) => {
+        connectCalls += 1;
+        if (opts.connectImpl) return opts.connectImpl(url, connectOpts);
+        return createFakeTransport({
+          onSend: transportOnSend,
+          trackSends: sends,
+          trackDisposeCount: disposeCount,
+        });
+      },
+    },
+  });
+
+  return {
+    client,
+    sends,
+    disposeCount,
+    get probeCalls() {
+      return probeCalls;
+    },
+    get listCalls() {
+      return listCalls;
+    },
+    get connectCalls() {
+      return connectCalls;
+    },
+    attachCallCount: () => attachSends.length,
+  };
+}
+
+describe("CdpInspectClient", () => {
+  beforeEach(() => {
+    // no-op — each test gets its own harness
+  });
+
+  test("kind is 'cdp-inspect' and exposes conversationId", () => {
+    const { client } = createHarness({ conversationId: "conv-kind" });
+    expect(client).toBeInstanceOf(CdpInspectClient);
+    expect(client.kind).toBe("cdp-inspect");
+    expect(client.conversationId).toBe("conv-kind");
+  });
+
+  test("send() probes version, lists targets, attaches, and forwards the call", async () => {
+    const harness = createHarness({
+      transportOnSend: (method) => {
+        if (method === "Target.attachToTarget") {
+          return { sessionId: "session-abc" };
+        }
+        if (method === "Browser.getVersion") {
+          return { product: "HeadlessChrome/125.0.0.0" };
+        }
+        return undefined;
+      },
+    });
+    const result = await harness.client.send<{ product: string }>(
+      "Browser.getVersion",
+    );
+    expect(result).toEqual({ product: "HeadlessChrome/125.0.0.0" });
+    expect(harness.probeCalls).toBe(1);
+    expect(harness.listCalls).toBe(1);
+    expect(harness.connectCalls).toBe(1);
+    // One attach + one forwarded Browser.getVersion.
+    expect(harness.sends).toEqual([
+      {
+        method: "Target.attachToTarget",
+        params: { targetId: "target-1", flatten: true },
+        sessionId: undefined,
+      },
+      {
+        method: "Browser.getVersion",
+        params: undefined,
+        sessionId: "session-abc",
+      },
+    ]);
+  });
+
+  test("multiple send() calls share a single attach", async () => {
+    const harness = createHarness();
+    await harness.client.send("Runtime.enable");
+    await harness.client.send("Page.enable");
+    await harness.client.send("DOM.enable");
+    expect(harness.probeCalls).toBe(1);
+    expect(harness.listCalls).toBe(1);
+    expect(harness.connectCalls).toBe(1);
+    expect(harness.attachCallCount()).toBe(1);
+    expect(harness.sends.length).toBe(4); // 1 attach + 3 forwarded
+  });
+
+  test("concurrent send() calls share a single in-flight attach", async () => {
+    const harness = createHarness();
+    await Promise.all([
+      harness.client.send("Runtime.enable"),
+      harness.client.send("Page.enable"),
+      harness.client.send("DOM.enable"),
+    ]);
+    expect(harness.probeCalls).toBe(1);
+    expect(harness.listCalls).toBe(1);
+    expect(harness.connectCalls).toBe(1);
+    expect(harness.attachCallCount()).toBe(1);
+  });
+
+  test("send() retries ensureSession after an initial attach failure", async () => {
+    // First probe call rejects (simulating e.g. Chrome not yet listening).
+    // Second probe call succeeds. Because the cached sessionPromise must
+    // be cleared on rejection, the second send() performs a full retry.
+    let probeCount = 0;
+    const harness = createHarness({
+      probeImpl: async () => {
+        probeCount += 1;
+        if (probeCount === 1) {
+          throw new Error("connect ECONNREFUSED");
+        }
+        return {
+          browser: "Chrome/125.0.0.0",
+          protocolVersion: "1.3",
+          webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/browser/fake",
+        };
+      },
+    });
+
+    let firstErr: unknown;
+    try {
+      await harness.client.send("Browser.getVersion");
+    } catch (err) {
+      firstErr = err;
+    }
+    expect(firstErr).toBeInstanceOf(CdpError);
+    expect((firstErr as InstanceType<typeof CdpError>).code).toBe(
+      "transport_error",
+    );
+    expect(probeCount).toBe(1);
+    expect(harness.connectCalls).toBe(0);
+
+    // Second call — cached promise was cleared, so probe + list +
+    // connect + attach all run again, then the forwarded call
+    // resolves normally. listCalls is only 1 because the first
+    // attempt threw inside probeDevToolsJsonVersion before it ever
+    // reached listDevToolsTargets.
+    const result = await harness.client.send<{ ok: boolean }>(
+      "Browser.getVersion",
+    );
+    expect(result).toEqual({ ok: true });
+    expect(probeCount).toBe(2);
+    expect(harness.listCalls).toBe(1);
+    expect(harness.connectCalls).toBe(1);
+    expect(harness.attachCallCount()).toBe(1);
+  });
+
+  test("send() maps CDP protocol errors from attach to CdpError 'cdp_error'", async () => {
+    const harness = createHarness({
+      transportOnSend: async (method) => {
+        if (method === "Target.attachToTarget") {
+          throw new CdpWsTransportError(
+            "cdp_error",
+            "No target with given id found",
+            {
+              cdpMethod: "Target.attachToTarget",
+              cdpCode: -32602,
+              cdpMessage: "No target with given id found",
+            },
+          );
+        }
+        return undefined;
+      },
+    });
+
+    let caught: unknown;
+    try {
+      await harness.client.send("Browser.getVersion");
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(CdpError);
+    const cdpErr = caught as InstanceType<typeof CdpError>;
+    expect(cdpErr.code).toBe("cdp_error");
+    expect(cdpErr.message).toBe("No target with given id found");
+    expect(cdpErr.cdpMethod).toBe("Browser.getVersion");
+    expect(cdpErr.underlying).toBeInstanceOf(CdpWsTransportError);
+  });
+
+  test("send() maps transport failures during attach to CdpError 'transport_error'", async () => {
+    const harness = createHarness({
+      connectImpl: async () => {
+        throw new CdpWsTransportError(
+          "transport_error",
+          "websocket closed before open",
+        );
+      },
+    });
+    let caught: unknown;
+    try {
+      await harness.client.send("Browser.getVersion");
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(CdpError);
+    const cdpErr = caught as InstanceType<typeof CdpError>;
+    expect(cdpErr.code).toBe("transport_error");
+    expect(cdpErr.message).toBe("websocket closed before open");
+    expect(cdpErr.cdpMethod).toBe("Browser.getVersion");
+  });
+
+  test("send() with an already-aborted signal throws 'aborted' without touching the transport", async () => {
+    const harness = createHarness();
+    const controller = new AbortController();
+    controller.abort();
+    let caught: unknown;
+    try {
+      await harness.client.send(
+        "Browser.getVersion",
+        undefined,
+        controller.signal,
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(CdpError);
+    const cdpErr = caught as InstanceType<typeof CdpError>;
+    expect(cdpErr.code).toBe("aborted");
+    expect(cdpErr.cdpMethod).toBe("Browser.getVersion");
+    // Nothing ran — no discovery, no connect, no transport sends.
+    expect(harness.probeCalls).toBe(0);
+    expect(harness.listCalls).toBe(0);
+    expect(harness.connectCalls).toBe(0);
+    expect(harness.sends.length).toBe(0);
+  });
+
+  test("send() classifies as 'aborted' when the signal fires during attach", async () => {
+    const controller = new AbortController();
+    const harness = createHarness({
+      probeImpl: async () => {
+        // Simulate caller aborting while discovery is in flight.
+        // Discovery itself throws a generic error (as real fetch
+        // would), and the abort flag is flipped — we expect the
+        // resulting CdpError to carry code "aborted".
+        controller.abort();
+        throw new Error("aborted during fetch");
+      },
+    });
+    let caught: unknown;
+    try {
+      await harness.client.send(
+        "Browser.getVersion",
+        undefined,
+        controller.signal,
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(CdpError);
+    const cdpErr = caught as InstanceType<typeof CdpError>;
+    expect(cdpErr.code).toBe("aborted");
+    expect(cdpErr.cdpMethod).toBe("Browser.getVersion");
+  });
+
+  test("send() classifies as 'aborted' when the signal fires during the forwarded call", async () => {
+    const controller = new AbortController();
+    const harness = createHarness({
+      transportOnSend: async (method) => {
+        if (method === "Target.attachToTarget") {
+          return { sessionId: "session-abc" };
+        }
+        // Simulate the transport throwing an abort error after
+        // the caller aborts mid-call.
+        controller.abort();
+        throw new CdpWsTransportError("aborted", "aborted during send", {
+          cdpMethod: method,
+        });
+      },
+    });
+    let caught: unknown;
+    try {
+      await harness.client.send(
+        "Page.navigate",
+        { url: "about:blank" },
+        controller.signal,
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(CdpError);
+    const cdpErr = caught as InstanceType<typeof CdpError>;
+    expect(cdpErr.code).toBe("aborted");
+    expect(cdpErr.cdpMethod).toBe("Page.navigate");
+  });
+
+  test("send() maps forwarded CDP protocol errors to 'cdp_error'", async () => {
+    const harness = createHarness({
+      transportOnSend: async (method) => {
+        if (method === "Target.attachToTarget") {
+          return { sessionId: "session-abc" };
+        }
+        throw new CdpWsTransportError("cdp_error", "invalid expression", {
+          cdpMethod: method,
+          cdpCode: -32000,
+          cdpMessage: "invalid expression",
+        });
+      },
+    });
+    let caught: unknown;
+    try {
+      await harness.client.send("Runtime.evaluate", { expression: "??" });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(CdpError);
+    const cdpErr = caught as InstanceType<typeof CdpError>;
+    expect(cdpErr.code).toBe("cdp_error");
+    expect(cdpErr.message).toBe("invalid expression");
+    expect(cdpErr.cdpMethod).toBe("Runtime.evaluate");
+    expect(cdpErr.cdpParams).toEqual({ expression: "??" });
+  });
+
+  test("dispose() is idempotent and tears down the underlying transport", async () => {
+    const harness = createHarness();
+    await harness.client.send("Browser.getVersion");
+    harness.client.dispose();
+    // dispose schedules transport.dispose on the resolved attach
+    // promise's then() — flush microtasks.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(harness.disposeCount.count).toBe(1);
+
+    // Second dispose is a no-op.
+    harness.client.dispose();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(harness.disposeCount.count).toBe(1);
+  });
+
+  test("dispose() without any sends does not call connectCdpWsTransport", async () => {
+    const harness = createHarness();
+    harness.client.dispose();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(harness.connectCalls).toBe(0);
+    expect(harness.disposeCount.count).toBe(0);
+  });
+
+  test("send() after dispose throws CdpError with code 'disposed'", async () => {
+    const harness = createHarness();
+    harness.client.dispose();
+    let caught: unknown;
+    try {
+      await harness.client.send("Browser.getVersion");
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(CdpError);
+    const cdpErr = caught as InstanceType<typeof CdpError>;
+    expect(cdpErr.code).toBe("disposed");
+    expect(cdpErr.cdpMethod).toBe("Browser.getVersion");
+    // No discovery or transport activity took place.
+    expect(harness.probeCalls).toBe(0);
+    expect(harness.listCalls).toBe(0);
+    expect(harness.connectCalls).toBe(0);
+  });
+
+  test("attach that returns no sessionId throws 'cdp_error'", async () => {
+    const harness = createHarness({
+      transportOnSend: async (method) => {
+        if (method === "Target.attachToTarget") {
+          // Missing sessionId field — a broken fork response.
+          return {};
+        }
+        return undefined;
+      },
+    });
+    let caught: unknown;
+    try {
+      await harness.client.send("Browser.getVersion");
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(CdpError);
+    const cdpErr = caught as InstanceType<typeof CdpError>;
+    expect(cdpErr.code).toBe("cdp_error");
+    expect(cdpErr.cdpMethod).toBe("Browser.getVersion");
+  });
+
+  test("attach failure tears down the partially-opened transport", async () => {
+    const localDisposeCount = { count: 0 };
+    const transport = createFakeTransport({
+      onSend: async (method) => {
+        if (method === "Target.attachToTarget") {
+          throw new CdpWsTransportError("cdp_error", "attach failed", {
+            cdpMethod: method,
+          });
+        }
+        return undefined;
+      },
+      trackDisposeCount: localDisposeCount,
+    });
+    const client = createCdpInspectClient("conv-attach-fail", {
+      host: "127.0.0.1",
+      port: 9222,
+      helpers: {
+        probeDevToolsJsonVersion: async () => ({
+          browser: "Chrome/125.0.0.0",
+          protocolVersion: "1.3",
+          webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/browser/fake",
+        }),
+        listDevToolsTargets: async () => [
+          {
+            id: "target-1",
+            type: "page",
+            title: "Example",
+            url: "https://example.com/",
+            webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/page/target-1",
+          },
+        ],
+        connectCdpWsTransport: async () => transport,
+      },
+    });
+
+    let caught: unknown;
+    try {
+      await client.send("Browser.getVersion");
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(CdpError);
+    // The transport opened by attach() should have been disposed so
+    // the socket doesn't leak.
+    expect(localDisposeCount.count).toBe(1);
+  });
+
+  test("send() aborts promptly when signal fires during ensureSession", async () => {
+    // Discovery is deliberately stalled so the caller has to rely on
+    // raceAbort() to cut through. If raceAbort worked correctly, the
+    // send() promise rejects with an 'aborted' CdpError the instant
+    // the controller fires — even though probeDevToolsJsonVersion is
+    // still hanging on an unresolved await.
+    const controller = new AbortController();
+    let probeSignalSeen: AbortSignal | undefined;
+    let probeResolve: (() => void) | undefined;
+    const probeStarted = new Promise<void>((resolve) => {
+      probeResolve = resolve;
+    });
+
+    const client = createCdpInspectClient("conv-abort-during-ensure", {
+      host: "127.0.0.1",
+      port: 9222,
+      helpers: {
+        probeDevToolsJsonVersion: async (probeOpts) => {
+          // Capture the signal so we can assert the shared attach
+          // controller actually fired downstream.
+          probeSignalSeen = (probeOpts as { signal?: AbortSignal }).signal;
+          probeResolve?.();
+          // Hang forever unless the shared controller fires.
+          await new Promise<never>((_, reject) => {
+            const onAbort = () => {
+              reject(new Error("probe aborted via shared controller"));
+            };
+            if (probeSignalSeen?.aborted) {
+              onAbort();
+            } else {
+              probeSignalSeen?.addEventListener("abort", onAbort, {
+                once: true,
+              });
+            }
+          });
+          throw new Error("unreachable");
+        },
+        listDevToolsTargets: async () => [
+          {
+            id: "target-1",
+            type: "page",
+            title: "Example",
+            url: "https://example.com/",
+            webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/page/target-1",
+          },
+        ],
+        connectCdpWsTransport: async () =>
+          createFakeTransport({
+            onSend: async (method) => {
+              if (method === "Target.attachToTarget") {
+                return { sessionId: "fake-session-id" };
+              }
+              return undefined;
+            },
+          }),
+      },
+    });
+
+    const sendPromise = client.send(
+      "Browser.getVersion",
+      undefined,
+      controller.signal,
+    );
+    // Wait until probe is actually running, then abort.
+    await probeStarted;
+    controller.abort();
+
+    let caught: unknown;
+    try {
+      await sendPromise;
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(CdpError);
+    const cdpErr = caught as InstanceType<typeof CdpError>;
+    expect(cdpErr.code).toBe("aborted");
+    expect(cdpErr.cdpMethod).toBe("Browser.getVersion");
+    // Probe saw a non-null signal, meaning ensureSession plumbed one
+    // all the way down to the discovery helper.
+    expect(probeSignalSeen).toBeDefined();
+    // After the last (and only) waiter aborted, the shared controller
+    // should have been aborted — downstream probe's await should have
+    // been rejected.
+    expect(probeSignalSeen?.aborted).toBe(true);
+  });
+
+  test("a new send() after all waiters abort starts a fresh attach", async () => {
+    // Regression test for the race condition where onAbort aborts
+    // the shared controller but `this.pending` is only cleared later
+    // via the async `.catch()` handler in startAttach(). A new caller
+    // entering ensureSession() between those two events would reuse
+    // the already-aborted pending attach and immediately fail with an
+    // `aborted` error even though it never aborted its own signal.
+    //
+    // Fix: onAbort now clears `this.pending` synchronously BEFORE
+    // firing the shared controller.abort(), so any new caller after
+    // the abort starts a fresh attach.
+    let probeCount = 0;
+    let listCount = 0;
+    let connectCount = 0;
+
+    // The first probe hangs until the shared controller aborts it.
+    // The second probe (from the fresh attach) resolves normally.
+    const firstProbeStarted = Promise.withResolvers<void>();
+
+    const client = createCdpInspectClient("conv-race", {
+      host: "127.0.0.1",
+      port: 9222,
+      helpers: {
+        probeDevToolsJsonVersion: async (probeOpts) => {
+          probeCount += 1;
+          const signal = (probeOpts as { signal?: AbortSignal }).signal;
+          if (probeCount === 1) {
+            firstProbeStarted.resolve();
+            // Stall until the shared controller aborts us.
+            await new Promise<never>((_, reject) => {
+              const onAbort = () => {
+                reject(new Error("probe aborted via shared controller"));
+              };
+              if (signal?.aborted) {
+                onAbort();
+              } else {
+                signal?.addEventListener("abort", onAbort, { once: true });
+              }
+            });
+            throw new Error("unreachable");
+          }
+          return {
+            browser: "Chrome/125.0.0.0",
+            protocolVersion: "1.3",
+            webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/browser/fake",
+          };
+        },
+        listDevToolsTargets: async () => {
+          listCount += 1;
+          return [
+            {
+              id: "target-1",
+              type: "page",
+              title: "Example",
+              url: "https://example.com/",
+              webSocketDebuggerUrl:
+                "ws://127.0.0.1:9222/devtools/page/target-1",
+            },
+          ];
+        },
+        connectCdpWsTransport: async () => {
+          connectCount += 1;
+          return createFakeTransport({
+            onSend: async (method) => {
+              if (method === "Target.attachToTarget") {
+                return { sessionId: "session-race" };
+              }
+              return { ok: true };
+            },
+          });
+        },
+      },
+    });
+
+    // 1. First caller kicks off the attach with signal A.
+    const signalA = new AbortController();
+    const firstSend = client.send("Runtime.enable", undefined, signalA.signal);
+
+    // 2. Wait until the first probe has actually started so we know
+    //    the attach is in-flight and signal A is the only waiter.
+    await firstProbeStarted.promise;
+
+    // 3. Abort signal A. Because it's the only waiter, onAbort will
+    //    fire the shared controller and (with the fix) clear
+    //    `this.pending` synchronously.
+    signalA.abort();
+
+    // First caller should reject with `aborted`.
+    let firstErr: unknown;
+    try {
+      await firstSend;
+    } catch (err) {
+      firstErr = err;
+    }
+    expect(firstErr).toBeInstanceOf(CdpError);
+    expect((firstErr as InstanceType<typeof CdpError>).code).toBe("aborted");
+
+    // At this point, with the fix, `this.pending` has been cleared
+    // synchronously — but without the fix, it would still be set to
+    // the aborted pending until the `.catch()` handler in
+    // startAttach() runs asynchronously. We intentionally do NOT
+    // flush microtasks here before kicking off the second send() so
+    // that we exercise the race window.
+    //
+    // 4. New send() with its own signal B. With the fix, this should
+    //    start a fresh attach and complete successfully. Without the
+    //    fix, it would reuse the aborted pending and fail with an
+    //    `aborted` error even though signal B was never aborted.
+    const signalB = new AbortController();
+    const secondSend = client.send("Page.enable", undefined, signalB.signal);
+
+    // Second caller should succeed.
+    const secondResult = await secondSend;
+    expect(secondResult).toEqual({ ok: true });
+
+    // 5. Assert that the second send() kicked off a fresh attach —
+    //    probe, list, and connect should all have been called twice.
+    expect(probeCount).toBe(2);
+    expect(listCount).toBe(1);
+    expect(connectCount).toBe(1);
+    // listCount and connectCount are 1 because the first attach
+    // aborted during the probe stage — it never reached list or
+    // connect. The second (fresh) attach ran probe + list + connect
+    // all once.
+  });
+
+  test("concurrent send() callers can abort independently", async () => {
+    // Two callers race the same in-flight attach. The first caller
+    // aborts; the second caller must still complete normally once the
+    // shared attach resolves.
+    const aborter = new AbortController();
+    let probeResolve: (() => void) | undefined;
+    let releaseProbe: (() => void) | undefined;
+    const probeRunning = new Promise<void>((resolve) => {
+      probeResolve = resolve;
+    });
+    const probeCanFinish = new Promise<void>((resolve) => {
+      releaseProbe = resolve;
+    });
+
+    const harness = createHarness({
+      probeImpl: async () => {
+        probeResolve?.();
+        await probeCanFinish;
+        return {
+          browser: "Chrome/125.0.0.0",
+          protocolVersion: "1.3",
+          webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/browser/fake",
+        };
+      },
+    });
+
+    const aborted = harness.client.send(
+      "Runtime.enable",
+      undefined,
+      aborter.signal,
+    );
+    const stable = harness.client.send("Page.enable");
+
+    await probeRunning;
+    aborter.abort();
+
+    // First caller aborts promptly…
+    let firstErr: unknown;
+    try {
+      await aborted;
+    } catch (err) {
+      firstErr = err;
+    }
+    expect(firstErr).toBeInstanceOf(CdpError);
+    expect((firstErr as InstanceType<typeof CdpError>).code).toBe("aborted");
+
+    // …but the second caller is still alive and can make progress
+    // once the shared attach finishes.
+    releaseProbe?.();
+    await stable;
+    expect(harness.probeCalls).toBe(1);
+    expect(harness.listCalls).toBe(1);
+    expect(harness.connectCalls).toBe(1);
+    expect(harness.attachCallCount()).toBe(1);
+  });
+});

--- a/assistant/src/tools/browser/cdp-client/__tests__/factory.test.ts
+++ b/assistant/src/tools/browser/cdp-client/__tests__/factory.test.ts
@@ -5,7 +5,7 @@ import type { ToolContext } from "../../../types.js";
 import { CdpError } from "../errors.js";
 
 type FakeClient = {
-  kind: "extension" | "local";
+  kind: "extension" | "local" | "cdp-inspect";
   conversationId: string;
   send: ReturnType<typeof mock>;
   dispose: ReturnType<typeof mock>;
@@ -29,8 +29,18 @@ function makeFakeLocalClient(conversationId: string): FakeClient {
   };
 }
 
+function makeFakeCdpInspectClient(conversationId: string): FakeClient {
+  return {
+    kind: "cdp-inspect",
+    conversationId,
+    send: mock(async () => ({ ok: true, via: "cdp-inspect" })),
+    dispose: mock(() => {}),
+  };
+}
+
 let lastExtensionClient: FakeClient | undefined;
 let lastLocalClient: FakeClient | undefined;
+let lastCdpInspectClient: FakeClient | undefined;
 
 const createExtensionCdpClientMock = mock(
   (_proxy: HostBrowserProxy, conversationId: string) => {
@@ -46,11 +56,41 @@ const createLocalCdpClientMock = mock((conversationId: string) => {
   return client;
 });
 
+const createCdpInspectClientMock = mock(
+  (conversationId: string, _options: unknown) => {
+    const client = makeFakeCdpInspectClient(conversationId);
+    lastCdpInspectClient = client;
+    return client;
+  },
+);
+
+/**
+ * Mutable config state. Tests flip `cdpInspectEnabled` to control
+ * the factory's config-based selection without needing a real config
+ * file.
+ */
+let cdpInspectEnabled = false;
+
 mock.module("../extension-cdp-client.js", () => ({
   createExtensionCdpClient: createExtensionCdpClientMock,
 }));
 mock.module("../local-cdp-client.js", () => ({
   createLocalCdpClient: createLocalCdpClientMock,
+}));
+mock.module("../cdp-inspect-client.js", () => ({
+  createCdpInspectClient: createCdpInspectClientMock,
+}));
+mock.module("../../../../config/loader.js", () => ({
+  getConfig: () => ({
+    hostBrowser: {
+      cdpInspect: {
+        enabled: cdpInspectEnabled,
+        host: "localhost",
+        port: 9222,
+        probeTimeoutMs: 500,
+      },
+    },
+  }),
 }));
 
 // Import under test AFTER mock.module calls so that the factory's
@@ -72,8 +112,11 @@ describe("getCdpClient", () => {
   beforeEach(() => {
     createExtensionCdpClientMock.mockClear();
     createLocalCdpClientMock.mockClear();
+    createCdpInspectClientMock.mockClear();
     lastExtensionClient = undefined;
     lastLocalClient = undefined;
+    lastCdpInspectClient = undefined;
+    cdpInspectEnabled = false;
   });
 
   test("routes to ExtensionCdpClient when hostBrowserProxy is set", () => {
@@ -95,21 +138,63 @@ describe("getCdpClient", () => {
       "test-convo",
     );
     expect(createLocalCdpClientMock).not.toHaveBeenCalled();
+    expect(createCdpInspectClientMock).not.toHaveBeenCalled();
   });
 
-  test("routes to LocalCdpClient when hostBrowserProxy is undefined", () => {
+  test("extension wins even when cdpInspect is enabled", () => {
+    cdpInspectEnabled = true;
+    const fakeProxy = {
+      request: mock(async () => ({})),
+    } as unknown as HostBrowserProxy;
     const ctx = makeContext({
-      conversationId: "test-convo",
+      conversationId: "ext-wins",
+      hostBrowserProxy: fakeProxy,
+    });
+
+    const client = getCdpClient(ctx);
+
+    expect(client.kind).toBe("extension");
+    expect(createExtensionCdpClientMock).toHaveBeenCalledTimes(1);
+    expect(createCdpInspectClientMock).not.toHaveBeenCalled();
+    expect(createLocalCdpClientMock).not.toHaveBeenCalled();
+  });
+
+  test("routes to CdpInspectClient when cdpInspect is enabled and extension is absent", () => {
+    cdpInspectEnabled = true;
+    const ctx = makeContext({
+      conversationId: "inspect-convo",
+      hostBrowserProxy: undefined,
+    });
+
+    const client = getCdpClient(ctx);
+
+    expect(client.kind).toBe("cdp-inspect");
+    expect(client.conversationId).toBe("inspect-convo");
+    expect(createCdpInspectClientMock).toHaveBeenCalledTimes(1);
+    expect(createCdpInspectClientMock).toHaveBeenCalledWith("inspect-convo", {
+      host: "localhost",
+      port: 9222,
+      discoveryTimeoutMs: 500,
+    });
+    expect(createExtensionCdpClientMock).not.toHaveBeenCalled();
+    expect(createLocalCdpClientMock).not.toHaveBeenCalled();
+  });
+
+  test("routes to LocalCdpClient when cdpInspect is disabled and extension is absent", () => {
+    cdpInspectEnabled = false;
+    const ctx = makeContext({
+      conversationId: "local-convo",
       hostBrowserProxy: undefined,
     });
 
     const client = getCdpClient(ctx);
 
     expect(client.kind).toBe("local");
-    expect(client.conversationId).toBe("test-convo");
+    expect(client.conversationId).toBe("local-convo");
     expect(createLocalCdpClientMock).toHaveBeenCalledTimes(1);
-    expect(createLocalCdpClientMock).toHaveBeenCalledWith("test-convo");
+    expect(createLocalCdpClientMock).toHaveBeenCalledWith("local-convo");
     expect(createExtensionCdpClientMock).not.toHaveBeenCalled();
+    expect(createCdpInspectClientMock).not.toHaveBeenCalled();
   });
 
   test("routes to LocalCdpClient when hostBrowserProxy key is omitted", () => {
@@ -122,6 +207,7 @@ describe("getCdpClient", () => {
     expect(createLocalCdpClientMock).toHaveBeenCalledTimes(1);
     expect(createLocalCdpClientMock).toHaveBeenCalledWith("another-convo");
     expect(createExtensionCdpClientMock).not.toHaveBeenCalled();
+    expect(createCdpInspectClientMock).not.toHaveBeenCalled();
   });
 
   test("forwards send() through the manager to the extension-backed client", async () => {
@@ -147,6 +233,7 @@ describe("getCdpClient", () => {
       undefined,
     );
     expect(lastLocalClient).toBeUndefined();
+    expect(lastCdpInspectClient).toBeUndefined();
   });
 
   test("forwards send() through the manager to the local-backed client", async () => {
@@ -166,6 +253,28 @@ describe("getCdpClient", () => {
       undefined,
     );
     expect(lastExtensionClient).toBeUndefined();
+    expect(lastCdpInspectClient).toBeUndefined();
+  });
+
+  test("forwards send() through the manager to the cdp-inspect-backed client", async () => {
+    cdpInspectEnabled = true;
+    const ctx = makeContext({ conversationId: "send-inspect" });
+
+    const client = getCdpClient(ctx);
+    const result = await client.send<{ ok: boolean; via: string }>(
+      "Page.navigate",
+      { url: "https://example.com" },
+    );
+
+    expect(result).toEqual({ ok: true, via: "cdp-inspect" });
+    expect(lastCdpInspectClient?.send).toHaveBeenCalledTimes(1);
+    expect(lastCdpInspectClient?.send).toHaveBeenCalledWith(
+      "Page.navigate",
+      { url: "https://example.com" },
+      undefined,
+    );
+    expect(lastExtensionClient).toBeUndefined();
+    expect(lastLocalClient).toBeUndefined();
   });
 
   test("propagates CdpError thrown by the underlying client", async () => {
@@ -238,5 +347,31 @@ describe("getCdpClient", () => {
     client.dispose();
 
     expect(lastExtensionClient?.dispose).toHaveBeenCalledTimes(1);
+  });
+
+  test("dispose() on a cdp-inspect-backed client tears down the inspect client", () => {
+    cdpInspectEnabled = true;
+    const ctx = makeContext({ conversationId: "dispose-inspect" });
+
+    const client = getCdpClient(ctx);
+    client.dispose();
+
+    expect(lastCdpInspectClient?.dispose).toHaveBeenCalledTimes(1);
+  });
+
+  test("send() after dispose() on a cdp-inspect-backed client rejects with disposed", async () => {
+    cdpInspectEnabled = true;
+    const ctx = makeContext({ conversationId: "post-dispose-inspect" });
+
+    const client = getCdpClient(ctx);
+    client.dispose();
+
+    // Double dispose is a no-op.
+    client.dispose();
+    expect(lastCdpInspectClient?.dispose).toHaveBeenCalledTimes(1);
+
+    await expect(client.send("Page.navigate")).rejects.toMatchObject({
+      code: "disposed",
+    });
   });
 });

--- a/assistant/src/tools/browser/cdp-client/__tests__/types.test.ts
+++ b/assistant/src/tools/browser/cdp-client/__tests__/types.test.ts
@@ -79,7 +79,7 @@ describe("cdp-client re-exports", () => {
   });
 
   test("ScopedCdpClient exposes kind and conversationId", () => {
-    const kinds: CdpClientKind[] = ["local", "extension"];
+    const kinds: CdpClientKind[] = ["local", "extension", "cdp-inspect"];
     for (const kind of kinds) {
       const scoped: ScopedCdpClient = {
         kind,

--- a/assistant/src/tools/browser/cdp-client/cdp-inspect-client.ts
+++ b/assistant/src/tools/browser/cdp-client/cdp-inspect-client.ts
@@ -1,0 +1,635 @@
+import { getLogger } from "../../../util/logger.js";
+import {
+  type DevToolsTarget,
+  type DevToolsVersionInfo,
+  listDevToolsTargets,
+  pickDefaultTarget,
+  probeDevToolsJsonVersion,
+} from "./cdp-inspect/discovery.js";
+import {
+  type CdpWsTransport,
+  CdpWsTransportError,
+  connectCdpWsTransport,
+} from "./cdp-inspect/ws-transport.js";
+import { CdpError } from "./errors.js";
+import type { CdpClientKind, ScopedCdpClient } from "./types.js";
+
+const log = getLogger("cdp-inspect-client");
+
+/**
+ * Default timeout (ms) for each discovery HTTP probe. Kept short so a
+ * user who has no chrome running on the configured port fails fast
+ * instead of blocking the entire tool invocation. The ws-transport
+ * has its own, separate connect timeout.
+ */
+const DEFAULT_DISCOVERY_TIMEOUT_MS = 2_000;
+
+/**
+ * Subset of DevTools endpoint config the CdpInspectClient needs. The
+ * higher-level factory (PR 5) is responsible for feeding these values
+ * from the user's settings. Everything else — connect timeouts, ws
+ * retries, abort plumbing — is controlled locally here so we don't
+ * leak transport knobs into tool call sites.
+ */
+export interface CdpInspectClientOptions {
+  /** Loopback host — enforced by discovery helpers before any I/O. */
+  host: string;
+  /** Port the user's Chrome is listening on for DevTools HTTP. */
+  port: number;
+  /** Optional per-attach discovery probe timeout. */
+  discoveryTimeoutMs?: number;
+  /**
+   * Optional per-attach ws connect timeout. Forwarded verbatim to
+   * {@link connectCdpWsTransport}.
+   */
+  wsConnectTimeoutMs?: number;
+  /**
+   * Test seam: override the discovery / transport helpers so unit
+   * tests don't need a real Chrome or a Bun.serve-backed fake peer.
+   * The factory (PR 5) does not use this path.
+   */
+  helpers?: CdpInspectHelpers;
+}
+
+/**
+ * Override shape used by tests. Each field defaults to the real
+ * implementation imported at the top of this module when omitted.
+ */
+export interface CdpInspectHelpers {
+  probeDevToolsJsonVersion?: typeof probeDevToolsJsonVersion;
+  listDevToolsTargets?: typeof listDevToolsTargets;
+  pickDefaultTarget?: typeof pickDefaultTarget;
+  connectCdpWsTransport?: typeof connectCdpWsTransport;
+}
+
+interface AttachedSession {
+  transport: CdpWsTransport;
+  sessionId: string;
+  target: DevToolsTarget;
+  version: DevToolsVersionInfo;
+}
+
+/**
+ * In-flight attach handle. Wraps the shared attach promise with a
+ * dedicated {@link AbortController} and a ref-count of live callers
+ * waiting on the attach. When every caller has raced its own signal
+ * and given up, the ref-count drops to zero and the shared controller
+ * aborts so the underlying discovery / ws / `Target.attachToTarget`
+ * work stops promptly instead of wedging the socket.
+ */
+interface PendingAttach {
+  /** Shared attach promise — resolved exactly once per attach attempt. */
+  promise: Promise<AttachedSession>;
+  /** Controller wired through probe / list / connect / attach. */
+  controller: AbortController;
+  /** Number of live callers still awaiting this attach. */
+  waiters: number;
+}
+
+/**
+ * CdpClient backed by the DevTools JSON protocol over a raw
+ * WebSocket (the `cdp-inspect` transport). Composes the discovery
+ * helpers (`probeDevToolsJsonVersion` + `listDevToolsTargets` +
+ * `pickDefaultTarget`) with the shared `connectCdpWsTransport` to
+ * reach an already-running Chrome instance the user has launched
+ * with `--remote-debugging-port`.
+ *
+ * Lifetime mirrors {@link import("./local-cdp-client.js").LocalCdpClient}:
+ *
+ *  - Lazy one-time attach: the first `send()` performs version probe
+ *    + target discovery + ws connect + `Target.attachToTarget`, then
+ *    caches the session for every subsequent call.
+ *  - Concurrent callers share a single in-flight attach promise so
+ *    `Target.attachToTarget` runs exactly once per client instance.
+ *  - Each `send(..., signal)` caller can race its own AbortSignal
+ *    against the shared attach and cut through promptly. When every
+ *    concurrent caller has aborted, the shared attach work is also
+ *    cancelled so we don't leak discovery fetches or a half-open ws.
+ *  - If the attach promise rejects, the cached promise is cleared so
+ *    the next `send()` retries from scratch instead of replaying the
+ *    same failure forever.
+ *  - `dispose()` is idempotent and tears down the ws transport if an
+ *    attach ever resolved.
+ */
+export class CdpInspectClient implements ScopedCdpClient {
+  readonly kind: CdpClientKind = "cdp-inspect";
+
+  private pending: PendingAttach | null = null;
+  private session: AttachedSession | null = null;
+  private disposed = false;
+  private readonly helpers: Required<CdpInspectHelpers>;
+
+  constructor(
+    public readonly conversationId: string,
+    private readonly options: CdpInspectClientOptions,
+  ) {
+    this.helpers = {
+      probeDevToolsJsonVersion:
+        options.helpers?.probeDevToolsJsonVersion ?? probeDevToolsJsonVersion,
+      listDevToolsTargets:
+        options.helpers?.listDevToolsTargets ?? listDevToolsTargets,
+      pickDefaultTarget:
+        options.helpers?.pickDefaultTarget ?? pickDefaultTarget,
+      connectCdpWsTransport:
+        options.helpers?.connectCdpWsTransport ?? connectCdpWsTransport,
+    };
+  }
+
+  /**
+   * Lazily attach (and cache) a CDP session against the configured
+   * DevTools endpoint. Each caller races its own `signal` against the
+   * shared attach so an individual abort always wins promptly; when
+   * every waiter has aborted, the shared attach work is cancelled
+   * too via the pending attach's internal controller. See class-level
+   * docs for the resilience contract — in particular, transient
+   * attach failures must NOT poison the cached promise for subsequent
+   * calls.
+   */
+  private async ensureSession(signal?: AbortSignal): Promise<AttachedSession> {
+    if (this.disposed) {
+      throw new CdpError("disposed", "CdpInspectClient already disposed");
+    }
+    if (this.session) return this.session;
+
+    const pending = this.pending ?? this.startAttach();
+    pending.waiters += 1;
+
+    // `onAbort` fires exactly once if this caller's signal wins the
+    // race. It (a) drops this caller's waiter slot and (b) aborts
+    // the shared controller iff no other caller is still listening,
+    // so the underlying discovery / ws / attach work is cancelled
+    // promptly instead of leaking into the background.
+    let released = false;
+    const onAbort = () => {
+      if (released) return;
+      released = true;
+      pending.waiters -= 1;
+      if (pending.waiters <= 0 && this.pending === pending) {
+        // Clear the cached pending attach synchronously BEFORE
+        // firing the shared controller's abort. Otherwise a new
+        // `send()` that enters `ensureSession` between this abort
+        // and the async `.catch()` handler in `startAttach()` would
+        // reuse this already-aborted attach and immediately fail
+        // with an `aborted` error even though the new caller never
+        // aborted its own signal.
+        this.pending = null;
+        try {
+          pending.controller.abort();
+        } catch {
+          // best effort
+        }
+      }
+    };
+
+    try {
+      return await raceAbort(pending.promise, signal, onAbort);
+    } finally {
+      // Inner attach resolved or rejected before this caller's
+      // signal fired — drop the waiter slot without touching the
+      // shared controller (it's already settled). If `onAbort` ran,
+      // `released` is already true and this is a no-op.
+      if (!released) {
+        released = true;
+        pending.waiters -= 1;
+      }
+    }
+  }
+
+  /**
+   * Kick off a fresh shared attach. The returned {@link PendingAttach}
+   * is cached on `this.pending` until it either resolves (in which
+   * case the session is stashed on `this.session`) or rejects (in
+   * which case the cache is cleared so the next caller retries from
+   * scratch).
+   */
+  private startAttach(): PendingAttach {
+    const controller = new AbortController();
+    const pending: PendingAttach = {
+      controller,
+      waiters: 0,
+      promise: this.attach(controller.signal),
+    };
+    this.pending = pending;
+
+    pending.promise
+      .then((session) => {
+        // Another concurrent attach may have won the race (e.g. after
+        // a dispose + retry). Only cache the result if we're still
+        // the current attempt.
+        if (this.pending === pending) {
+          this.pending = null;
+          if (this.disposed) {
+            // Dispose landed before we could publish the session —
+            // tear down the transport immediately so we don't leak.
+            try {
+              session.transport.dispose();
+            } catch {
+              // best effort
+            }
+            return;
+          }
+          this.session = session;
+        } else {
+          // A stale attempt — drop the transport so we don't leak.
+          try {
+            session.transport.dispose();
+          } catch {
+            // best effort
+          }
+        }
+      })
+      .catch(() => {
+        // Clear the cached pending attach on rejection so the next
+        // call retries from scratch instead of replaying the same
+        // failure forever. Only clear if we're still the current
+        // attempt — a concurrent dispose may have already nulled it.
+        if (this.pending === pending) {
+          this.pending = null;
+        }
+      });
+
+    return pending;
+  }
+
+  /**
+   * Perform the actual discovery + ws-connect + attach sequence. All
+   * underlying errors are rethrown unchanged so the `send()` wrapper
+   * can map them to stable `CdpError` codes without double-wrapping
+   * the already-typed discovery / ws-transport errors.
+   *
+   * The `signal` here is the shared, internal {@link PendingAttach}
+   * signal — NOT the per-caller signal. It is aborted when the last
+   * caller interested in this attach has given up, or when `dispose()`
+   * races an in-flight attach.
+   */
+  private async attach(signal: AbortSignal): Promise<AttachedSession> {
+    const discoveryTimeoutMs =
+      this.options.discoveryTimeoutMs ?? DEFAULT_DISCOVERY_TIMEOUT_MS;
+    const { host, port } = this.options;
+
+    const version = await this.helpers.probeDevToolsJsonVersion({
+      host,
+      port,
+      timeoutMs: discoveryTimeoutMs,
+      signal,
+    });
+    if (signal.aborted) {
+      throw new CdpError("aborted", "CdpInspectClient attach aborted");
+    }
+    const targets = await this.helpers.listDevToolsTargets({
+      host,
+      port,
+      timeoutMs: discoveryTimeoutMs,
+      signal,
+    });
+    if (signal.aborted) {
+      throw new CdpError("aborted", "CdpInspectClient attach aborted");
+    }
+    const target = this.helpers.pickDefaultTarget(targets);
+
+    // Prefer the browser-level ws URL from the version probe because
+    // it lets us multiplex multiple attached targets through a single
+    // transport. Fall back to the target-specific URL if (for some
+    // reason) the version probe omitted it.
+    const wsUrl = version.webSocketDebuggerUrl || target.webSocketDebuggerUrl;
+    const transport = await this.helpers.connectCdpWsTransport(wsUrl, {
+      connectTimeoutMs: this.options.wsConnectTimeoutMs,
+      signal,
+    });
+
+    // If dispose() landed while connect was in flight, tear down the
+    // transport we just opened and surface a "disposed" CdpError to
+    // the caller so we don't leak a half-attached session.
+    if (this.disposed) {
+      try {
+        transport.dispose();
+      } catch {
+        // best effort
+      }
+      throw new CdpError("disposed", "CdpInspectClient disposed during attach");
+    }
+    if (signal.aborted) {
+      try {
+        transport.dispose();
+      } catch {
+        // best effort
+      }
+      throw new CdpError(
+        "aborted",
+        "CdpInspectClient attach aborted after ws connect",
+      );
+    }
+
+    let attachResult: unknown;
+    try {
+      attachResult = await transport.send<unknown>(
+        "Target.attachToTarget",
+        {
+          targetId: target.id,
+          flatten: true,
+        },
+        { signal },
+      );
+    } catch (err) {
+      // Attach failed — drop the transport we just opened so we don't
+      // leak the socket on retry.
+      try {
+        transport.dispose();
+      } catch {
+        // best effort
+      }
+      throw err;
+    }
+
+    const sessionId = extractSessionId(attachResult);
+    if (!sessionId) {
+      try {
+        transport.dispose();
+      } catch {
+        // best effort
+      }
+      throw new CdpError(
+        "cdp_error",
+        "Target.attachToTarget did not return a sessionId",
+        { cdpMethod: "Target.attachToTarget" },
+      );
+    }
+
+    log.debug(
+      {
+        conversationId: this.conversationId,
+        targetId: target.id,
+        sessionId,
+      },
+      "Attached CdpInspectClient session",
+    );
+
+    return { transport, sessionId, target, version };
+  }
+
+  async send<T = unknown>(
+    method: string,
+    params?: Record<string, unknown>,
+    signal?: AbortSignal,
+  ): Promise<T> {
+    if (this.disposed) {
+      throw new CdpError("disposed", "CdpInspectClient already disposed", {
+        cdpMethod: method,
+        cdpParams: params,
+      });
+    }
+    if (signal?.aborted) {
+      throw new CdpError("aborted", "Aborted before send", {
+        cdpMethod: method,
+        cdpParams: params,
+      });
+    }
+
+    let attached: AttachedSession;
+    try {
+      attached = await this.ensureSession(signal);
+    } catch (err) {
+      if (signal?.aborted) {
+        throw new CdpError("aborted", "Aborted during send", {
+          cdpMethod: method,
+          cdpParams: params,
+          underlying: err,
+        });
+      }
+      // If a concurrent dispose() aborted the shared attach under us,
+      // surface a stable "disposed" error instead of the incidental
+      // discovery / transport rejection that the aborted work threw.
+      if (this.disposed) {
+        throw new CdpError("disposed", "CdpInspectClient already disposed", {
+          cdpMethod: method,
+          cdpParams: params,
+          underlying: err,
+        });
+      }
+      throw mapEnsureSessionError(err, method, params);
+    }
+
+    // A late dispose may have landed while ensureSession was in
+    // flight — surface a "disposed" error instead of sending into a
+    // torn-down transport.
+    if (this.disposed) {
+      throw new CdpError("disposed", "CdpInspectClient already disposed", {
+        cdpMethod: method,
+        cdpParams: params,
+      });
+    }
+
+    try {
+      return (await attached.transport.send<T>(method, params, {
+        sessionId: attached.sessionId,
+        signal,
+      })) as T;
+    } catch (err) {
+      if (signal?.aborted) {
+        throw new CdpError("aborted", "Aborted during send", {
+          cdpMethod: method,
+          cdpParams: params,
+          underlying: err,
+        });
+      }
+      if (err instanceof CdpWsTransportError) {
+        if (err.code === "aborted") {
+          throw new CdpError("aborted", err.message, {
+            cdpMethod: method,
+            cdpParams: params,
+            underlying: err,
+          });
+        }
+        if (err.code === "cdp_error") {
+          throw new CdpError("cdp_error", err.cdpMessage ?? err.message, {
+            cdpMethod: method,
+            cdpParams: params,
+            underlying: err,
+          });
+        }
+        // closed / timeout / transport_error all map onto
+        // transport_error in the shared CdpClient taxonomy.
+        throw new CdpError("transport_error", err.message, {
+          cdpMethod: method,
+          cdpParams: params,
+          underlying: err,
+        });
+      }
+      if (err instanceof CdpError) {
+        throw err;
+      }
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new CdpError("cdp_error", msg, {
+        cdpMethod: method,
+        cdpParams: params,
+        underlying: err,
+      });
+    }
+  }
+
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+
+    // Cancel any in-flight attach so discovery / ws / Target.attach
+    // stop promptly. The `.then()` handler in startAttach() will
+    // tear down any transport that managed to open before dispose
+    // landed.
+    const pending = this.pending;
+    this.pending = null;
+    if (pending) {
+      try {
+        pending.controller.abort();
+      } catch {
+        // best effort
+      }
+    }
+
+    const session = this.session;
+    this.session = null;
+    if (session) {
+      try {
+        session.transport.dispose();
+      } catch (err) {
+        log.debug(
+          { err },
+          "CdpInspectClient: transport.dispose threw (ignored)",
+        );
+      }
+    }
+  }
+}
+
+/**
+ * Classify an `ensureSession()` rejection into a stable CdpError
+ * code. Discovery + ws-transport failures become `transport_error`,
+ * while CDP-level errors returned by `Target.attachToTarget` become
+ * `cdp_error`. Already-typed CdpErrors (e.g. a missing-sessionId
+ * attach response or a concurrent dispose) are rewritten so that
+ * the internal `cdpMethod` (`"Target.attachToTarget"`) is replaced
+ * with the caller's method, while preserving the underlying error
+ * shape.
+ */
+function mapEnsureSessionError(
+  err: unknown,
+  method: string,
+  params?: Record<string, unknown>,
+): CdpError {
+  if (err instanceof CdpError) {
+    // Rewrite cdpMethod to the caller's method so attach-stage
+    // metadata (e.g. "Target.attachToTarget") doesn't leak into the
+    // caller-visible error. Preserve code, message, and the original
+    // underlying error so logging / upstream mapping can still
+    // introspect the real cause.
+    return new CdpError(err.code, err.message, {
+      cdpMethod: method,
+      cdpParams: params,
+      underlying: err.underlying ?? err,
+    });
+  }
+  if (err instanceof CdpWsTransportError) {
+    if (err.code === "cdp_error") {
+      return new CdpError("cdp_error", err.cdpMessage ?? err.message, {
+        cdpMethod: method,
+        cdpParams: params,
+        underlying: err,
+      });
+    }
+    return new CdpError("transport_error", err.message, {
+      cdpMethod: method,
+      cdpParams: params,
+      underlying: err,
+    });
+  }
+  // DevToolsDiscoveryError (and any other non-CDP rejection) is
+  // treated as a transport-level failure.
+  const msg = err instanceof Error ? err.message : String(err);
+  return new CdpError("transport_error", msg, {
+    cdpMethod: method,
+    cdpParams: params,
+    underlying: err,
+  });
+}
+
+/**
+ * Race a long-running shared promise against a per-caller
+ * {@link AbortSignal}. When the signal fires first, the returned
+ * promise rejects with a synthetic `abort` error and the optional
+ * `onAbort` hook is invoked exactly once so callers can decrement
+ * ref-counts, release locks, etc. The underlying `inner` promise is
+ * intentionally NOT cancelled here — shared in-flight work is
+ * cancelled separately via the owning {@link PendingAttach}
+ * controller once every waiter has given up.
+ */
+function raceAbort<T>(
+  inner: Promise<T>,
+  signal: AbortSignal | undefined,
+  onAbort: () => void,
+): Promise<T> {
+  if (!signal) return inner;
+  if (signal.aborted) {
+    try {
+      onAbort();
+    } catch {
+      // best effort
+    }
+    return Promise.reject(new Error("aborted"));
+  }
+  return new Promise<T>((resolve, reject) => {
+    let settled = false;
+    const handleAbort = () => {
+      if (settled) return;
+      settled = true;
+      try {
+        onAbort();
+      } catch {
+        // best effort
+      }
+      reject(new Error("aborted"));
+    };
+    signal.addEventListener("abort", handleAbort, { once: true });
+    inner.then(
+      (value) => {
+        if (settled) return;
+        settled = true;
+        signal.removeEventListener("abort", handleAbort);
+        resolve(value);
+      },
+      (err) => {
+        if (settled) return;
+        settled = true;
+        signal.removeEventListener("abort", handleAbort);
+        reject(err);
+      },
+    );
+  });
+}
+
+/**
+ * Pull the `sessionId` field out of a `Target.attachToTarget` CDP
+ * result. CDP returns an object shaped `{ sessionId: string }`; we
+ * guard defensively against malformed replies so a broken Chrome
+ * fork cannot silently send us into an un-typed send loop.
+ */
+function extractSessionId(result: unknown): string | null {
+  if (!result || typeof result !== "object") return null;
+  const record = result as Record<string, unknown>;
+  const sessionId = record.sessionId;
+  if (typeof sessionId === "string" && sessionId.length > 0) {
+    return sessionId;
+  }
+  return null;
+}
+
+/**
+ * Factory for a fresh {@link CdpInspectClient} bound to a
+ * conversation. Keeping the constructor + factory split lets the
+ * cdp-client factory (PR 5) wire this up alongside local / extension
+ * without exposing the class directly to callers.
+ */
+export function createCdpInspectClient(
+  conversationId: string,
+  options: CdpInspectClientOptions,
+): CdpInspectClient {
+  return new CdpInspectClient(conversationId, options);
+}

--- a/assistant/src/tools/browser/cdp-client/cdp-inspect-client.ts
+++ b/assistant/src/tools/browser/cdp-client/cdp-inspect-client.ts
@@ -26,7 +26,7 @@ const DEFAULT_DISCOVERY_TIMEOUT_MS = 2_000;
 
 /**
  * Subset of DevTools endpoint config the CdpInspectClient needs. The
- * higher-level factory (PR 5) is responsible for feeding these values
+ * higher-level factory is responsible for feeding these values
  * from the user's settings. Everything else — connect timeouts, ws
  * retries, abort plumbing — is controlled locally here so we don't
  * leak transport knobs into tool call sites.
@@ -46,7 +46,7 @@ export interface CdpInspectClientOptions {
   /**
    * Test seam: override the discovery / transport helpers so unit
    * tests don't need a real Chrome or a Bun.serve-backed fake peer.
-   * The factory (PR 5) does not use this path.
+   * The factory does not use this path.
    */
   helpers?: CdpInspectHelpers;
 }
@@ -624,7 +624,7 @@ function extractSessionId(result: unknown): string | null {
 /**
  * Factory for a fresh {@link CdpInspectClient} bound to a
  * conversation. Keeping the constructor + factory split lets the
- * cdp-client factory (PR 5) wire this up alongside local / extension
+ * cdp-client factory wires this up alongside local / extension
  * without exposing the class directly to callers.
  */
 export function createCdpInspectClient(

--- a/assistant/src/tools/browser/cdp-client/cdp-inspect/__tests__/discovery.test.ts
+++ b/assistant/src/tools/browser/cdp-client/cdp-inspect/__tests__/discovery.test.ts
@@ -1,0 +1,637 @@
+/**
+ * Unit tests for the DevTools HTTP discovery helpers.
+ *
+ * These tests boot a tiny `Bun.serve` instance per test (or per
+ * describe block) and point the helpers at it. The goal is to cover
+ * every error branch without relying on a real Chrome being present
+ * on the dev machine or CI runner.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  DevToolsDiscoveryError,
+  type DevToolsTarget,
+  listDevToolsTargets,
+  pickDefaultTarget,
+  probeDevToolsJsonVersion,
+} from "../discovery.js";
+
+// ---------------------------------------------------------------------------
+// Test fixture: a tiny Bun.serve that can be reconfigured per test.
+// ---------------------------------------------------------------------------
+
+type Handler = (req: Request) => Response | Promise<Response>;
+
+interface FakeDevTools {
+  server: ReturnType<typeof Bun.serve>;
+  port: number;
+  setHandler: (handler: Handler) => void;
+  stop: () => void;
+}
+
+function startFakeDevTools(): FakeDevTools {
+  let handler: Handler = () => new Response("not configured", { status: 500 });
+  const server = Bun.serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    async fetch(req) {
+      return handler(req);
+    },
+  });
+  return {
+    server,
+    port: server.port as number,
+    setHandler: (h) => {
+      handler = h;
+    },
+    stop: () => server.stop(true),
+  };
+}
+
+function chromeVersionResponse(
+  overrides: Record<string, string> = {},
+): Response {
+  return Response.json({
+    Browser: "Chrome/124.0.6367.91",
+    "Protocol-Version": "1.3",
+    "User-Agent": "Mozilla/5.0",
+    "V8-Version": "12.4.254.13",
+    "WebKit-Version": "537.36",
+    webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/browser/abcd-1234",
+    ...overrides,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Loopback enforcement — must reject BEFORE any fetch call.
+// ---------------------------------------------------------------------------
+
+describe("probeDevToolsJsonVersion — loopback enforcement", () => {
+  test("rejects non-loopback host with non_loopback and does not fetch", async () => {
+    const originalFetch = globalThis.fetch;
+    let fetchCallCount = 0;
+    globalThis.fetch = (async (...args: unknown[]) => {
+      fetchCallCount += 1;
+      return originalFetch(...(args as Parameters<typeof fetch>));
+    }) as typeof fetch;
+
+    try {
+      await expect(
+        probeDevToolsJsonVersion({
+          host: "192.168.1.1",
+          port: 9222,
+          timeoutMs: 1000,
+        }),
+      ).rejects.toMatchObject({
+        name: "DevToolsDiscoveryError",
+        code: "non_loopback",
+      });
+      expect(fetchCallCount).toBe(0);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("rejects public DNS hostname before fetching", async () => {
+    const originalFetch = globalThis.fetch;
+    let fetchCallCount = 0;
+    globalThis.fetch = (async (...args: unknown[]) => {
+      fetchCallCount += 1;
+      return originalFetch(...(args as Parameters<typeof fetch>));
+    }) as typeof fetch;
+
+    try {
+      await expect(
+        probeDevToolsJsonVersion({
+          host: "example.com",
+          port: 9222,
+          timeoutMs: 1000,
+        }),
+      ).rejects.toMatchObject({
+        name: "DevToolsDiscoveryError",
+        code: "non_loopback",
+      });
+      expect(fetchCallCount).toBe(0);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("accepts localhost, 127.0.0.1, ::1 (case-insensitive)", async () => {
+    const fake = startFakeDevTools();
+    fake.setHandler(() => chromeVersionResponse());
+    try {
+      for (const host of ["localhost", "LOCALHOST", "127.0.0.1"]) {
+        const info = await probeDevToolsJsonVersion({
+          host,
+          port: fake.port,
+          timeoutMs: 2000,
+        });
+        expect(info.browser).toContain("Chrome");
+      }
+    } finally {
+      fake.stop();
+    }
+  });
+
+  test("listDevToolsTargets also rejects non-loopback before fetch", async () => {
+    const originalFetch = globalThis.fetch;
+    let fetchCallCount = 0;
+    globalThis.fetch = (async (...args: unknown[]) => {
+      fetchCallCount += 1;
+      return originalFetch(...(args as Parameters<typeof fetch>));
+    }) as typeof fetch;
+
+    try {
+      await expect(
+        listDevToolsTargets({
+          host: "10.0.0.1",
+          port: 9222,
+          timeoutMs: 1000,
+        }),
+      ).rejects.toMatchObject({
+        name: "DevToolsDiscoveryError",
+        code: "non_loopback",
+      });
+      expect(fetchCallCount).toBe(0);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// probeDevToolsJsonVersion — happy paths.
+// ---------------------------------------------------------------------------
+
+describe("probeDevToolsJsonVersion — parsing", () => {
+  let fake: FakeDevTools;
+
+  beforeEach(() => {
+    fake = startFakeDevTools();
+  });
+
+  afterEach(() => {
+    fake.stop();
+  });
+
+  test("parses real Chrome field casing", async () => {
+    fake.setHandler(() =>
+      chromeVersionResponse({
+        Browser: "Chrome/126.0.6478.127",
+        "Protocol-Version": "1.3",
+        webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/browser/xyz",
+      }),
+    );
+
+    const info = await probeDevToolsJsonVersion({
+      host: "127.0.0.1",
+      port: fake.port,
+      timeoutMs: 2000,
+    });
+
+    expect(info.browser).toBe("Chrome/126.0.6478.127");
+    expect(info.protocolVersion).toBe("1.3");
+    expect(info.webSocketDebuggerUrl).toBe(
+      "ws://127.0.0.1:9222/devtools/browser/xyz",
+    );
+  });
+
+  test("parses normalized camelCase field casing", async () => {
+    fake.setHandler(() =>
+      Response.json({
+        browser: "Chromium/125.0.6422.141",
+        protocolVersion: "1.3",
+        webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/browser/normalized",
+      }),
+    );
+
+    const info = await probeDevToolsJsonVersion({
+      host: "127.0.0.1",
+      port: fake.port,
+      timeoutMs: 2000,
+    });
+
+    expect(info.browser).toBe("Chromium/125.0.6422.141");
+    expect(info.protocolVersion).toBe("1.3");
+    expect(info.webSocketDebuggerUrl).toBe(
+      "ws://127.0.0.1:9222/devtools/browser/normalized",
+    );
+  });
+
+  test("rejects non-Chrome responder with non_chrome", async () => {
+    fake.setHandler(() => chromeVersionResponse({ Browser: "Firefox/115.0" }));
+
+    const error = await probeDevToolsJsonVersion({
+      host: "127.0.0.1",
+      port: fake.port,
+      timeoutMs: 2000,
+    }).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(DevToolsDiscoveryError);
+    expect((error as DevToolsDiscoveryError).code).toBe("non_chrome");
+  });
+
+  test("rejects missing required fields with invalid_response", async () => {
+    fake.setHandler(() =>
+      Response.json({
+        Browser: "Chrome/123",
+        // Missing Protocol-Version and webSocketDebuggerUrl
+      }),
+    );
+
+    const error = await probeDevToolsJsonVersion({
+      host: "127.0.0.1",
+      port: fake.port,
+      timeoutMs: 2000,
+    }).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(DevToolsDiscoveryError);
+    expect((error as DevToolsDiscoveryError).code).toBe("invalid_response");
+  });
+
+  test("rejects malformed JSON body with invalid_response", async () => {
+    fake.setHandler(
+      () =>
+        new Response("not json at all {{{", {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+
+    const error = await probeDevToolsJsonVersion({
+      host: "127.0.0.1",
+      port: fake.port,
+      timeoutMs: 2000,
+    }).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(DevToolsDiscoveryError);
+    expect((error as DevToolsDiscoveryError).code).toBe("invalid_response");
+  });
+
+  test("rejects non-object JSON body with invalid_response", async () => {
+    fake.setHandler(() => Response.json(["not", "an", "object"]));
+
+    const error = await probeDevToolsJsonVersion({
+      host: "127.0.0.1",
+      port: fake.port,
+      timeoutMs: 2000,
+    }).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(DevToolsDiscoveryError);
+    expect((error as DevToolsDiscoveryError).code).toBe("invalid_response");
+  });
+
+  test("rejects non-200 status with invalid_response", async () => {
+    fake.setHandler(() => new Response("nope", { status: 404 }));
+
+    const error = await probeDevToolsJsonVersion({
+      host: "127.0.0.1",
+      port: fake.port,
+      timeoutMs: 2000,
+    }).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(DevToolsDiscoveryError);
+    expect((error as DevToolsDiscoveryError).code).toBe("invalid_response");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// probeDevToolsJsonVersion — network-level error paths.
+// ---------------------------------------------------------------------------
+
+describe("probeDevToolsJsonVersion — network errors", () => {
+  test("connection refused (unreachable)", async () => {
+    // Boot a server then stop it to get a guaranteed-free port.
+    const fake = startFakeDevTools();
+    const deadPort = fake.port;
+    fake.stop();
+
+    const error = await probeDevToolsJsonVersion({
+      host: "127.0.0.1",
+      port: deadPort,
+      timeoutMs: 2000,
+    }).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(DevToolsDiscoveryError);
+    expect((error as DevToolsDiscoveryError).code).toBe("unreachable");
+  });
+
+  test("stalled server triggers timeout", async () => {
+    const fake = startFakeDevTools();
+    fake.setHandler(
+      () =>
+        new Promise<Response>(() => {
+          // Intentionally never resolve.
+        }),
+    );
+
+    try {
+      const error = await probeDevToolsJsonVersion({
+        host: "127.0.0.1",
+        port: fake.port,
+        timeoutMs: 50,
+      }).catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(DevToolsDiscoveryError);
+      expect((error as DevToolsDiscoveryError).code).toBe("timeout");
+    } finally {
+      fake.stop();
+    }
+  });
+
+  test("stalled response body triggers timeout (not invalid_response)", async () => {
+    // Regression test: a responder that sends headers + a partial body
+    // and then stalls the stream must still be cancelled by the
+    // discovery timeout. If the timer was cleared right after `fetch()`
+    // resolved, `response.text()` would hang forever. See review on
+    // PR #24601.
+    const fake = startFakeDevTools();
+    const stalledStreams: ReadableStreamDefaultController<Uint8Array>[] = [];
+    fake.setHandler(
+      () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              // Send a partial JSON body so `fetch()` can resolve its
+              // headers promise, then never enqueue more. Keep a ref so
+              // the test can close the stream during cleanup.
+              controller.enqueue(new TextEncoder().encode('{"'));
+              stalledStreams.push(controller);
+              // Intentionally do NOT call controller.close().
+            },
+          }),
+          {
+            status: 200,
+            headers: {
+              "content-type": "application/json",
+              // No content-length so the reader keeps waiting for more.
+              "transfer-encoding": "chunked",
+            },
+          },
+        ),
+    );
+
+    try {
+      const startedAt = Date.now();
+      const error = await probeDevToolsJsonVersion({
+        host: "127.0.0.1",
+        port: fake.port,
+        timeoutMs: 100,
+      }).catch((e: unknown) => e);
+      const elapsed = Date.now() - startedAt;
+
+      expect(error).toBeInstanceOf(DevToolsDiscoveryError);
+      expect((error as DevToolsDiscoveryError).code).toBe("timeout");
+      // Should resolve roughly at `timeoutMs`, not hang indefinitely.
+      // Generous upper bound to keep the test stable under load.
+      expect(elapsed).toBeLessThan(2000);
+    } finally {
+      // Unblock the server's streams so Bun.serve can shut down cleanly.
+      for (const controller of stalledStreams) {
+        try {
+          controller.close();
+        } catch {
+          // Stream may already be in an errored state from the abort.
+        }
+      }
+      fake.stop();
+    }
+  });
+
+  test("stalled response body during listDevToolsTargets triggers timeout", async () => {
+    // Same regression, checked on the /json/list path.
+    const fake = startFakeDevTools();
+    const stalledStreams: ReadableStreamDefaultController<Uint8Array>[] = [];
+    fake.setHandler(
+      () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode("["));
+              stalledStreams.push(controller);
+            },
+          }),
+          {
+            status: 200,
+            headers: {
+              "content-type": "application/json",
+              "transfer-encoding": "chunked",
+            },
+          },
+        ),
+    );
+
+    try {
+      const startedAt = Date.now();
+      const error = await listDevToolsTargets({
+        host: "127.0.0.1",
+        port: fake.port,
+        timeoutMs: 100,
+      }).catch((e: unknown) => e);
+      const elapsed = Date.now() - startedAt;
+
+      expect(error).toBeInstanceOf(DevToolsDiscoveryError);
+      expect((error as DevToolsDiscoveryError).code).toBe("timeout");
+      expect(elapsed).toBeLessThan(2000);
+    } finally {
+      for (const controller of stalledStreams) {
+        try {
+          controller.close();
+        } catch {
+          // Stream may already be in an errored state from the abort.
+        }
+      }
+      fake.stop();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listDevToolsTargets — filtering and parsing.
+// ---------------------------------------------------------------------------
+
+describe("listDevToolsTargets", () => {
+  let fake: FakeDevTools;
+
+  beforeEach(() => {
+    fake = startFakeDevTools();
+  });
+
+  afterEach(() => {
+    fake.stop();
+  });
+
+  test("filters non-page targets and returns parsed pages", async () => {
+    fake.setHandler(() =>
+      Response.json([
+        {
+          id: "A",
+          type: "page",
+          title: "Example",
+          url: "https://example.com/",
+          webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/page/A",
+        },
+        {
+          id: "B",
+          type: "service_worker",
+          title: "sw",
+          url: "https://example.com/sw.js",
+          webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/page/B",
+        },
+        {
+          id: "C",
+          type: "iframe",
+          title: "frame",
+          url: "https://example.com/frame",
+          webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/page/C",
+        },
+        {
+          id: "D",
+          type: "page",
+          title: "Second Page",
+          url: "https://docs.example.com/",
+          webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/page/D",
+        },
+      ]),
+    );
+
+    const targets = await listDevToolsTargets({
+      host: "127.0.0.1",
+      port: fake.port,
+      timeoutMs: 2000,
+    });
+
+    expect(targets).toHaveLength(2);
+    expect(targets.map((t) => t.id)).toEqual(["A", "D"]);
+    expect(targets[0]!.webSocketDebuggerUrl).toBe(
+      "ws://127.0.0.1:9222/devtools/page/A",
+    );
+  });
+
+  test("drops page targets without webSocketDebuggerUrl", async () => {
+    fake.setHandler(() =>
+      Response.json([
+        {
+          id: "A",
+          type: "page",
+          title: "Missing WS",
+          url: "https://example.com/",
+          webSocketDebuggerUrl: "",
+        },
+        {
+          id: "B",
+          type: "page",
+          title: "Good Page",
+          url: "https://example.com/ok",
+          webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/page/B",
+        },
+      ]),
+    );
+
+    const targets = await listDevToolsTargets({
+      host: "127.0.0.1",
+      port: fake.port,
+      timeoutMs: 2000,
+    });
+
+    expect(targets).toHaveLength(1);
+    expect(targets[0]!.id).toBe("B");
+  });
+
+  test("throws no_targets when filtered list is empty", async () => {
+    fake.setHandler(() =>
+      Response.json([
+        {
+          id: "A",
+          type: "service_worker",
+          title: "sw",
+          url: "https://example.com/sw.js",
+          webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/page/A",
+        },
+      ]),
+    );
+
+    const error = await listDevToolsTargets({
+      host: "127.0.0.1",
+      port: fake.port,
+      timeoutMs: 2000,
+    }).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(DevToolsDiscoveryError);
+    expect((error as DevToolsDiscoveryError).code).toBe("no_targets");
+  });
+
+  test("throws invalid_response when body is not a JSON array", async () => {
+    fake.setHandler(() => Response.json({ not: "an array" }));
+
+    const error = await listDevToolsTargets({
+      host: "127.0.0.1",
+      port: fake.port,
+      timeoutMs: 2000,
+    }).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(DevToolsDiscoveryError);
+    expect((error as DevToolsDiscoveryError).code).toBe("invalid_response");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pickDefaultTarget — prefers real pages, falls back to first.
+// ---------------------------------------------------------------------------
+
+describe("pickDefaultTarget", () => {
+  function makeTarget(partial: Partial<DevToolsTarget>): DevToolsTarget {
+    return {
+      id: partial.id ?? "id",
+      type: partial.type ?? "page",
+      title: partial.title ?? "title",
+      url: partial.url ?? "https://example.com/",
+      webSocketDebuggerUrl:
+        partial.webSocketDebuggerUrl ?? "ws://127.0.0.1:9222/devtools/page/id",
+    };
+  }
+
+  test("throws no_targets on empty input", () => {
+    expect(() => pickDefaultTarget([])).toThrow(DevToolsDiscoveryError);
+    try {
+      pickDefaultTarget([]);
+    } catch (e) {
+      expect((e as DevToolsDiscoveryError).code).toBe("no_targets");
+    }
+  });
+
+  test("prefers a real https page over chrome:// targets", () => {
+    const targets: DevToolsTarget[] = [
+      makeTarget({ id: "newtab", url: "chrome://newtab/" }),
+      makeTarget({ id: "devtools", url: "devtools://devtools/bundled/idx" }),
+      makeTarget({ id: "site", url: "https://example.com/docs" }),
+    ];
+    const picked = pickDefaultTarget(targets);
+    expect(picked.id).toBe("site");
+  });
+
+  test("prefers a real page over about:blank", () => {
+    const targets: DevToolsTarget[] = [
+      makeTarget({ id: "blank", url: "about:blank" }),
+      makeTarget({ id: "real", url: "https://example.com/" }),
+    ];
+    const picked = pickDefaultTarget(targets);
+    expect(picked.id).toBe("real");
+  });
+
+  test("falls back to first when every target is a utility page", () => {
+    const targets: DevToolsTarget[] = [
+      makeTarget({ id: "newtab", url: "chrome://newtab/" }),
+      makeTarget({ id: "devtools", url: "devtools://devtools/bundled/idx" }),
+      makeTarget({ id: "blank", url: "about:blank" }),
+    ];
+    const picked = pickDefaultTarget(targets);
+    expect(picked.id).toBe("newtab");
+  });
+
+  test("returns the only candidate when the list has length 1", () => {
+    const targets = [makeTarget({ id: "only", url: "https://example.com/" })];
+    expect(pickDefaultTarget(targets).id).toBe("only");
+  });
+});

--- a/assistant/src/tools/browser/cdp-client/cdp-inspect/__tests__/ws-transport.test.ts
+++ b/assistant/src/tools/browser/cdp-client/cdp-inspect/__tests__/ws-transport.test.ts
@@ -1,0 +1,580 @@
+/**
+ * Tests for the raw CDP JSON-RPC WebSocket transport.
+ *
+ * These tests stand up a fake CDP peer on a random loopback port
+ * with `Bun.serve` so we can exercise every failure mode without
+ * any real Chrome install. The fake peer consumes the JSON-RPC
+ * request frame verbatim, then returns whatever envelope the test
+ * scenario wants (success, CDP error, delayed, etc.).
+ *
+ * Every test is responsible for stopping the fake server in a
+ * `try/finally` (or via `afterEach`) to avoid port leaks across the
+ * suite.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import type { ServerWebSocket } from "bun";
+
+import {
+  type CdpWsTransport,
+  CdpWsTransportError,
+  connectCdpWsTransport,
+} from "../ws-transport.js";
+
+interface WsFrame {
+  id?: number;
+  method?: string;
+  params?: Record<string, unknown>;
+  sessionId?: string;
+}
+
+interface FakeWsServer {
+  url: string;
+  stop(): Promise<void>;
+}
+
+/**
+ * Start a fake websocket server whose inbound-message handler is
+ * controlled by the caller. The caller gets the raw parsed CDP
+ * request frame plus the underlying `ServerWebSocket` so it can
+ * respond, delay, close, or do nothing at all.
+ */
+function startFakeWsServer(options: {
+  onMessage?: (
+    ws: ServerWebSocket<undefined>,
+    frame: WsFrame,
+    raw: string,
+  ) => void;
+  onOpen?: (ws: ServerWebSocket<undefined>) => void;
+}): FakeWsServer {
+  const server = Bun.serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    fetch(req, srv) {
+      if (srv.upgrade(req)) return;
+      return new Response("expected ws", { status: 400 });
+    },
+    websocket: {
+      open(ws) {
+        options.onOpen?.(ws);
+      },
+      message(ws, message) {
+        const raw =
+          typeof message === "string"
+            ? message
+            : new TextDecoder().decode(message);
+        let parsed: WsFrame;
+        try {
+          parsed = JSON.parse(raw) as WsFrame;
+        } catch {
+          return;
+        }
+        options.onMessage?.(ws, parsed, raw);
+      },
+    },
+  });
+  const url = `ws://127.0.0.1:${server.port}`;
+  return {
+    url,
+    async stop() {
+      // Fire-and-forget stop. `await server.stop(true)` can hang
+      // in bun 1.3.x when a ws client has already closed, and
+      // `await server.stop()` waits for in-flight connections to
+      // drain, which can also hang in pathological tests. We don't
+      // need to block on shutdown for correctness — the process
+      // exits after the suite, and every test allocates a fresh
+      // random port.
+      server.stop();
+    },
+  };
+}
+
+/**
+ * Start a fake HTTP (non-ws) server that refuses upgrade requests
+ * with `400`. Used to verify that `connectCdpWsTransport` rejects
+ * (with either `timeout` or `transport_error`) when the peer does
+ * not speak websockets.
+ */
+function startNonWsServer(): FakeWsServer {
+  const server = Bun.serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    fetch() {
+      return new Response("no websocket here", { status: 400 });
+    },
+  });
+  const url = `ws://127.0.0.1:${server.port}`;
+  return {
+    url,
+    async stop() {
+      server.stop();
+    },
+  };
+}
+
+async function withTransport<T>(
+  server: FakeWsServer,
+  fn: (transport: CdpWsTransport) => Promise<T>,
+  connectOpts?: { connectTimeoutMs?: number },
+): Promise<T> {
+  const transport = await connectCdpWsTransport(server.url, connectOpts);
+  try {
+    return await fn(transport);
+  } finally {
+    transport.dispose();
+  }
+}
+
+describe("CdpWsTransportError", () => {
+  test("subclasses Error with code and metadata", () => {
+    const err = new CdpWsTransportError("cdp_error", "boom", {
+      cdpMethod: "Page.navigate",
+      cdpCode: -32000,
+      cdpMessage: "boom",
+      cdpData: { foo: "bar" },
+    });
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(CdpWsTransportError);
+    expect(err.name).toBe("CdpWsTransportError");
+    expect(err.code).toBe("cdp_error");
+    expect(err.cdpMethod).toBe("Page.navigate");
+    expect(err.cdpCode).toBe(-32000);
+    expect(err.cdpMessage).toBe("boom");
+    expect(err.cdpData).toEqual({ foo: "bar" });
+  });
+
+  test("supports all documented codes", () => {
+    const codes = [
+      "closed",
+      "aborted",
+      "timeout",
+      "transport_error",
+      "cdp_error",
+    ] as const;
+    for (const code of codes) {
+      const err = new CdpWsTransportError(code);
+      expect(err.code).toBe(code);
+    }
+  });
+});
+
+describe("connectCdpWsTransport", () => {
+  test("send+receive success — Browser.getVersion style", async () => {
+    const server = startFakeWsServer({
+      onMessage(ws, frame) {
+        if (frame.method === "Browser.getVersion") {
+          ws.send(
+            JSON.stringify({
+              id: frame.id,
+              result: {
+                protocolVersion: "1.3",
+                product: "Chrome/123.0.0.0",
+                revision: "@deadbeef",
+                userAgent: "test",
+                jsVersion: "1.0",
+              },
+            }),
+          );
+        }
+      },
+    });
+    try {
+      await withTransport(server, async (transport) => {
+        const result = await transport.send<{ product: string }>(
+          "Browser.getVersion",
+        );
+        expect(result.product).toBe("Chrome/123.0.0.0");
+      });
+    } finally {
+      await server.stop();
+    }
+  });
+
+  test("rejects with cdp_error when the peer returns a JSON-RPC error", async () => {
+    const server = startFakeWsServer({
+      onMessage(ws, frame) {
+        ws.send(
+          JSON.stringify({
+            id: frame.id,
+            error: {
+              code: -32601,
+              message: "Method not found",
+              data: { method: frame.method },
+            },
+          }),
+        );
+      },
+    });
+    try {
+      await withTransport(server, async (transport) => {
+        await expect(transport.send("Bogus.method")).rejects.toMatchObject({
+          name: "CdpWsTransportError",
+          code: "cdp_error",
+          cdpMethod: "Bogus.method",
+          cdpCode: -32601,
+          cdpMessage: "Method not found",
+        });
+      });
+    } finally {
+      await server.stop();
+    }
+  });
+
+  test("handles concurrent out-of-order responses", async () => {
+    const pendingFrames: WsFrame[] = [];
+    const server = startFakeWsServer({
+      onMessage(ws, frame) {
+        pendingFrames.push(frame);
+        // Respond in reverse order after all three arrive.
+        if (pendingFrames.length === 3) {
+          const [f1, f2, f3] = pendingFrames;
+          ws.send(JSON.stringify({ id: f3!.id, result: { n: 3 } }));
+          ws.send(JSON.stringify({ id: f1!.id, result: { n: 1 } }));
+          ws.send(JSON.stringify({ id: f2!.id, result: { n: 2 } }));
+        }
+      },
+    });
+    try {
+      await withTransport(server, async (transport) => {
+        const p1 = transport.send<{ n: number }>("A.one");
+        const p2 = transport.send<{ n: number }>("B.two");
+        const p3 = transport.send<{ n: number }>("C.three");
+        const results = await Promise.all([p1, p2, p3]);
+        expect(results).toEqual([{ n: 1 }, { n: 2 }, { n: 3 }]);
+      });
+    } finally {
+      await server.stop();
+    }
+  });
+
+  test("fans out events (frames with no id) to listeners", async () => {
+    const server = startFakeWsServer({
+      onOpen(ws) {
+        // Push an unsolicited event shortly after open.
+        setTimeout(() => {
+          ws.send(
+            JSON.stringify({
+              method: "Target.targetCreated",
+              params: { targetId: "abc" },
+              sessionId: "S1",
+            }),
+          );
+        }, 5);
+      },
+    });
+    try {
+      await withTransport(server, async (transport) => {
+        const received: Array<{
+          method: string;
+          params?: unknown;
+          sessionId?: string;
+        }> = [];
+        transport.addEventListener((ev) => {
+          received.push(ev);
+        });
+        // Wait for the event to arrive.
+        await new Promise((r) => setTimeout(r, 50));
+        expect(received).toEqual([
+          {
+            method: "Target.targetCreated",
+            params: { targetId: "abc" },
+            sessionId: "S1",
+          },
+        ]);
+      });
+    } finally {
+      await server.stop();
+    }
+  });
+
+  test("does not resolve any pending request for a no-id event", async () => {
+    let gotRequest = false;
+    const server = startFakeWsServer({
+      onOpen(ws) {
+        // Emit a no-id event before any send() happens.
+        setTimeout(() => {
+          ws.send(
+            JSON.stringify({
+              method: "Target.attachedToTarget",
+              params: {},
+            }),
+          );
+        }, 5);
+      },
+      onMessage(ws, frame) {
+        gotRequest = true;
+        ws.send(JSON.stringify({ id: frame.id, result: { ok: true } }));
+      },
+    });
+    try {
+      await withTransport(server, async (transport) => {
+        await new Promise((r) => setTimeout(r, 20));
+        // Pending-request map must still be empty here — otherwise
+        // a subsequent send would deadlock on a stale entry.
+        const result = await transport.send<{ ok: boolean }>("Test.ping");
+        expect(result.ok).toBe(true);
+        expect(gotRequest).toBe(true);
+      });
+    } finally {
+      await server.stop();
+    }
+  });
+
+  test("forwards sessionId on the wire when opts.sessionId is provided", async () => {
+    let seen: WsFrame | null = null;
+    const server = startFakeWsServer({
+      onMessage(ws, frame) {
+        seen = frame;
+        ws.send(JSON.stringify({ id: frame.id, result: {} }));
+      },
+    });
+    try {
+      await withTransport(server, async (transport) => {
+        await transport.send("Runtime.enable", undefined, {
+          sessionId: "sess-42",
+        });
+      });
+      expect(seen).not.toBeNull();
+      // seen is WsFrame | null; narrow via unknown for the
+      // assertions below (TS narrows `seen` to `null` inside the
+      // closure, which is why a direct cast trips noImplicitAny).
+      const frame = seen as unknown as WsFrame;
+      expect(frame.sessionId).toBe("sess-42");
+      expect(frame.method).toBe("Runtime.enable");
+    } finally {
+      await server.stop();
+    }
+  });
+
+  test("abort mid-request rejects with aborted and drops late response", async () => {
+    let deferredFrameId: number | undefined;
+    let serverWs: ServerWebSocket<undefined> | null = null;
+    const server = startFakeWsServer({
+      onMessage(ws, frame) {
+        // Hold the response indefinitely so the abort can race.
+        deferredFrameId = frame.id;
+        serverWs = ws;
+      },
+    });
+    try {
+      const transport = await connectCdpWsTransport(server.url);
+      try {
+        const controller = new AbortController();
+        const sendPromise = transport.send(
+          "Slow.call",
+          {},
+          {
+            signal: controller.signal,
+          },
+        );
+        // Let the request land on the server.
+        await new Promise((r) => setTimeout(r, 20));
+        controller.abort();
+        await expect(sendPromise).rejects.toMatchObject({
+          name: "CdpWsTransportError",
+          code: "aborted",
+          cdpMethod: "Slow.call",
+        });
+        // Now deliver a response for the dropped id. The transport
+        // should silently ignore it — a subsequent send should
+        // still work and MUST NOT deadlock.
+        if (deferredFrameId !== undefined && serverWs) {
+          (serverWs as ServerWebSocket<undefined>).send(
+            JSON.stringify({ id: deferredFrameId, result: { late: true } }),
+          );
+        }
+        // Follow-up request must still function.
+        await new Promise((r) => setTimeout(r, 10));
+      } finally {
+        transport.dispose();
+      }
+    } finally {
+      await server.stop();
+    }
+  });
+
+  test("server close mid-request rejects pending with closed", async () => {
+    const server = startFakeWsServer({
+      onMessage(ws) {
+        // Close the socket without responding.
+        ws.close();
+      },
+    });
+    try {
+      const transport = await connectCdpWsTransport(server.url);
+      try {
+        let caught: unknown;
+        try {
+          await transport.send("Some.method");
+        } catch (err) {
+          caught = err;
+        }
+        expect(caught).toBeInstanceOf(CdpWsTransportError);
+        expect((caught as CdpWsTransportError).code).toBe("closed");
+
+        // After close, subsequent sends also reject with closed.
+        let caught2: unknown;
+        try {
+          await transport.send("Another.method");
+        } catch (err) {
+          caught2 = err;
+        }
+        expect(caught2).toBeInstanceOf(CdpWsTransportError);
+        expect((caught2 as CdpWsTransportError).code).toBe("closed");
+      } finally {
+        transport.dispose();
+      }
+    } finally {
+      await server.stop();
+    }
+  });
+
+  test("connect rejects with transport_error when peer refuses upgrade", async () => {
+    const server = startNonWsServer();
+    try {
+      await expect(
+        connectCdpWsTransport(server.url, { connectTimeoutMs: 500 }),
+      ).rejects.toMatchObject({
+        name: "CdpWsTransportError",
+      });
+      // Code can be either timeout or transport_error depending on
+      // how the runtime surfaces an HTTP 400 upgrade failure — both
+      // are acceptable per the transport contract.
+      try {
+        await connectCdpWsTransport(server.url, { connectTimeoutMs: 200 });
+      } catch (err) {
+        expect(err).toBeInstanceOf(CdpWsTransportError);
+        const code = (err as CdpWsTransportError).code;
+        expect(["timeout", "transport_error"]).toContain(code);
+      }
+    } finally {
+      await server.stop();
+    }
+  });
+
+  test("connect rejects with timeout when peer never accepts", async () => {
+    // A server that hangs forever (never responds to the upgrade).
+    // We simulate this by pointing at an unroutable port guarded by
+    // a very short connect timeout; expect either timeout or
+    // transport_error since runtimes vary in how they surface a
+    // refused connection.
+    let err: unknown;
+    try {
+      await connectCdpWsTransport("ws://127.0.0.1:1", {
+        connectTimeoutMs: 100,
+      });
+    } catch (caught) {
+      err = caught;
+    }
+    expect(err).toBeInstanceOf(CdpWsTransportError);
+    const code = (err as CdpWsTransportError).code;
+    expect(["timeout", "transport_error"]).toContain(code);
+  });
+
+  test("dispose is idempotent", async () => {
+    const server = startFakeWsServer({});
+    try {
+      const transport = await connectCdpWsTransport(server.url);
+      transport.dispose();
+      expect(() => transport.dispose()).not.toThrow();
+      expect(() => transport.dispose()).not.toThrow();
+      // send after dispose rejects with closed.
+      await expect(transport.send("X")).rejects.toMatchObject({
+        code: "closed",
+      });
+    } finally {
+      await server.stop();
+    }
+  });
+
+  test("dispose rejects any in-flight pending requests with closed", async () => {
+    const server = startFakeWsServer({
+      onMessage() {
+        // Never respond — we want the request to stay pending until
+        // dispose fires.
+      },
+    });
+    try {
+      const transport = await connectCdpWsTransport(server.url);
+      const p = transport.send("Never.responds");
+      // Give the request time to reach the server.
+      await new Promise((r) => setTimeout(r, 20));
+      transport.dispose();
+      await expect(p).rejects.toMatchObject({
+        name: "CdpWsTransportError",
+        code: "closed",
+      });
+    } finally {
+      await server.stop();
+    }
+  });
+
+  test("addEventListener returns an unsubscribe function", async () => {
+    const server = startFakeWsServer({
+      onOpen(ws) {
+        setTimeout(() => {
+          ws.send(JSON.stringify({ method: "Ev.first", params: {} }));
+          setTimeout(() => {
+            ws.send(JSON.stringify({ method: "Ev.second", params: {} }));
+          }, 10);
+        }, 5);
+      },
+    });
+    try {
+      await withTransport(server, async (transport) => {
+        const received: string[] = [];
+        const unsub = transport.addEventListener((ev) => {
+          received.push(ev.method);
+          if (ev.method === "Ev.first") unsub();
+        });
+        await new Promise((r) => setTimeout(r, 60));
+        expect(received).toEqual(["Ev.first"]);
+      });
+    } finally {
+      await server.stop();
+    }
+  });
+
+  test("send after dispose rejects immediately with closed", async () => {
+    const server = startFakeWsServer({});
+    try {
+      const transport = await connectCdpWsTransport(server.url);
+      transport.dispose();
+      await expect(transport.send("Page.enable")).rejects.toMatchObject({
+        name: "CdpWsTransportError",
+        code: "closed",
+        cdpMethod: "Page.enable",
+      });
+    } finally {
+      await server.stop();
+    }
+  });
+
+  test("listener errors are swallowed and do not affect correlation", async () => {
+    const server = startFakeWsServer({
+      onOpen(ws) {
+        setTimeout(() => {
+          ws.send(JSON.stringify({ method: "Boom.event", params: {} }));
+        }, 5);
+      },
+      onMessage(ws, frame) {
+        ws.send(JSON.stringify({ id: frame.id, result: { ok: true } }));
+      },
+    });
+    try {
+      await withTransport(server, async (transport) => {
+        transport.addEventListener(() => {
+          throw new Error("listener crash");
+        });
+        // Wait for the event to arrive and be swallowed.
+        await new Promise((r) => setTimeout(r, 20));
+        // Subsequent requests must still work.
+        const result = await transport.send<{ ok: boolean }>("Page.enable");
+        expect(result.ok).toBe(true);
+      });
+    } finally {
+      await server.stop();
+    }
+  });
+});

--- a/assistant/src/tools/browser/cdp-client/cdp-inspect/discovery.ts
+++ b/assistant/src/tools/browser/cdp-client/cdp-inspect/discovery.ts
@@ -1,0 +1,541 @@
+/**
+ * DevTools HTTP discovery helpers for the `cdp-inspect` backend.
+ *
+ * These helpers are pure HTTP/domain logic — they do not own a
+ * websocket transport, a session manager, or any CDP command state.
+ * They exist so the higher-level `cdp-inspect` client can:
+ *
+ * 1. Probe `/json/version` to verify that a loopback port is actually
+ *    a Chrome/Chromium DevTools endpoint (and not some other service
+ *    that happens to be listening).
+ * 2. Enumerate available page targets via `/json/list`.
+ * 3. Pick a sensible default target when the caller doesn't specify
+ *    one explicitly.
+ *
+ * Safety boundary: **only loopback hosts are allowed**. A non-loopback
+ * host is rejected *before* any network I/O so that this module can
+ * never be coerced into making cross-origin requests on behalf of an
+ * attacker-controlled config value.
+ */
+
+/**
+ * Stable error codes surfaced by discovery helpers.
+ *
+ * Callers branch on these codes instead of string-matching messages so
+ * upstream UX (status bar, toasts, logs) can render a stable, localized
+ * explanation.
+ */
+export type DevToolsDiscoveryErrorCode =
+  | "unreachable"
+  | "non_loopback"
+  | "non_chrome"
+  | "invalid_response"
+  | "no_targets"
+  | "timeout";
+
+/**
+ * Single error type thrown by all discovery helpers. Mirrors the
+ * shape of {@link import("../errors.js").CdpError} so catch sites can
+ * rely on an explicit `code` field and an optional underlying cause.
+ */
+export class DevToolsDiscoveryError extends Error {
+  constructor(
+    public readonly code: DevToolsDiscoveryErrorCode,
+    message: string,
+    public readonly cause?: unknown,
+  ) {
+    super(message);
+    this.name = "DevToolsDiscoveryError";
+  }
+}
+
+/**
+ * Normalized `/json/version` payload. Chrome returns canonical field
+ * names like `Browser` and `Protocol-Version`, but some forks and
+ * tests prefer camelCase. The parser here accepts both and normalizes
+ * to the camelCase shape below.
+ */
+export interface DevToolsVersionInfo {
+  /** Normalized from `"Browser"` or `"browser"`. */
+  browser: string;
+  /** Normalized from `"Protocol-Version"` or `"protocolVersion"`. */
+  protocolVersion: string;
+  /** WebSocket URL for the browser-level debugger endpoint. */
+  webSocketDebuggerUrl: string;
+}
+
+/**
+ * A DevTools page target as returned by `/json/list`, filtered down to
+ * the fields the cdp-inspect backend actually needs.
+ */
+export interface DevToolsTarget {
+  id: string;
+  type: string;
+  title: string;
+  url: string;
+  webSocketDebuggerUrl: string;
+}
+
+/**
+ * Loopback allowlist (exact match, case-insensitive). Any host not in
+ * this list is rejected *before* we touch the network.
+ *
+ * We intentionally do not resolve DNS here — if a config ever gains a
+ * hostname that happens to resolve to 127.0.0.1, we still refuse it,
+ * because DNS rebinding attacks can flip that answer between the
+ * pre-check and the actual fetch.
+ */
+const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
+
+function assertLoopback(host: string): void {
+  const normalized = host.toLowerCase();
+  if (!LOOPBACK_HOSTS.has(normalized)) {
+    throw new DevToolsDiscoveryError(
+      "non_loopback",
+      `Refusing to probe non-loopback DevTools host "${host}". Only loopback hosts (localhost, 127.0.0.1, ::1) are permitted.`,
+    );
+  }
+}
+
+/**
+ * Build a fetch-ready loopback URL. `host` is assumed to have already
+ * been validated by {@link assertLoopback}. IPv6 bare form (`::1`) is
+ * wrapped in square brackets for URL correctness.
+ */
+function buildUrl(host: string, port: number, pathname: string): string {
+  const normalized = host.toLowerCase();
+  const hostSegment = normalized === "::1" ? "[::1]" : normalized;
+  return `http://${hostSegment}:${port}${pathname}`;
+}
+
+/**
+ * Timeout controller handle returned by {@link withTimeout}. `cleanup`
+ * must be called in a `finally` block to avoid leaking the timer and
+ * the abort listener. `timedOut` is flipped to `true` if the timer
+ * fires before `cleanup` runs.
+ */
+interface TimeoutHandle {
+  signal: AbortSignal;
+  cleanup: () => void;
+  readonly timedOut: boolean;
+}
+
+/**
+ * Merge the caller's signal (if any) with a freshly-minted timeout
+ * controller. The flag on the returned handle is the single source of
+ * truth for "timed out vs. aborted vs. network error" — we can't
+ * recover that distinction from the fetch rejection alone.
+ */
+function withTimeout(
+  timeoutMs: number,
+  callerSignal?: AbortSignal,
+): TimeoutHandle {
+  const controller = new AbortController();
+  let timedOut = false;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    controller.abort(new Error("timeout"));
+  }, timeoutMs);
+
+  let onCallerAbort: (() => void) | null = null;
+  if (callerSignal) {
+    if (callerSignal.aborted) {
+      controller.abort(callerSignal.reason);
+    } else {
+      onCallerAbort = () => controller.abort(callerSignal.reason);
+      callerSignal.addEventListener("abort", onCallerAbort, { once: true });
+    }
+  }
+
+  return {
+    signal: controller.signal,
+    get timedOut() {
+      return timedOut;
+    },
+    cleanup: () => {
+      clearTimeout(timer);
+      if (onCallerAbort && callerSignal) {
+        callerSignal.removeEventListener("abort", onCallerAbort);
+      }
+    },
+  };
+}
+
+/**
+ * Classify a `fetch()` rejection into a stable discovery code. We
+ * intentionally do not depend on Node's error code strings here — the
+ * fetch implementation varies between Bun, Node, and undici — so we
+ * look at the name, the message, and the caller-visible abort state
+ * instead.
+ */
+function classifyFetchError(
+  err: unknown,
+  timedOut: boolean,
+  callerAborted: boolean,
+): DevToolsDiscoveryError {
+  if (callerAborted) {
+    return new DevToolsDiscoveryError(
+      "unreachable",
+      "Discovery fetch was aborted by the caller before completion.",
+      err,
+    );
+  }
+  if (timedOut) {
+    return new DevToolsDiscoveryError(
+      "timeout",
+      "Timed out waiting for DevTools HTTP response.",
+      err,
+    );
+  }
+
+  const message = err instanceof Error ? err.message : String(err);
+  const name = err instanceof Error ? err.name : "";
+  if (name === "AbortError" || /aborted/i.test(message)) {
+    // Unspecified abort — most likely the timeout fired but the flag
+    // was not flipped yet. Treat as timeout to give the user the
+    // clearer message.
+    return new DevToolsDiscoveryError(
+      "timeout",
+      "Timed out waiting for DevTools HTTP response.",
+      err,
+    );
+  }
+
+  return new DevToolsDiscoveryError(
+    "unreachable",
+    `Failed to reach DevTools endpoint: ${message}`,
+    err,
+  );
+}
+
+/**
+ * Read the response body as text, propagating abort/timeout errors so
+ * the caller can distinguish them from a merely malformed payload.
+ *
+ * The fetch signal is the same AbortSignal passed to the original
+ * `fetch()` call, so if the timeout fires (or the caller aborts) while
+ * we're still reading the body, the underlying stream is cancelled and
+ * `response.text()` rejects. We rethrow those abort-shaped failures as
+ * a distinct sentinel (`TimeoutDuringBodyReadError`) so the caller can
+ * map them to `timeout` / `unreachable` instead of `invalid_response`.
+ */
+class TimeoutDuringBodyReadError extends Error {
+  constructor(
+    public readonly timedOut: boolean,
+    public readonly callerAborted: boolean,
+    public readonly underlying: unknown,
+  ) {
+    super("Discovery body read aborted.");
+    this.name = "TimeoutDuringBodyReadError";
+  }
+}
+
+function isAbortShaped(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  if (err.name === "AbortError") return true;
+  if (/abort/i.test(err.message)) return true;
+  return false;
+}
+
+async function readResponseText(
+  response: Response,
+  handle: TimeoutHandle,
+  callerSignal: AbortSignal | undefined,
+): Promise<string> {
+  try {
+    return await response.text();
+  } catch (err) {
+    const callerAborted = callerSignal?.aborted === true;
+    if (handle.timedOut || callerAborted || isAbortShaped(err)) {
+      throw new TimeoutDuringBodyReadError(handle.timedOut, callerAborted, err);
+    }
+    throw err;
+  }
+}
+
+/**
+ * Best-effort JSON parser. Returns a parsed object or throws a
+ * discovery error with `invalid_response` so the caller doesn't need
+ * to wrap this itself. Assumes the body text has already been read
+ * (see {@link readResponseText}).
+ */
+function parseJsonText(text: string, endpoint: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch (err) {
+    throw new DevToolsDiscoveryError(
+      "invalid_response",
+      `Expected JSON from ${endpoint} but got: ${text.slice(0, 200)}`,
+      err,
+    );
+  }
+}
+
+/**
+ * Pull a string field out of an arbitrary JSON object, supporting
+ * either of two casings (e.g. `"Browser"` and `"browser"`). Returns
+ * `undefined` if neither key exists or the value is not a string.
+ */
+function readStringField(
+  obj: Record<string, unknown>,
+  ...keys: string[]
+): string | undefined {
+  for (const key of keys) {
+    const value = obj[key];
+    if (typeof value === "string" && value.length > 0) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Probe `/json/version` on a loopback DevTools endpoint and return a
+ * normalized {@link DevToolsVersionInfo}.
+ *
+ * Failure modes:
+ *
+ * - `non_loopback`: host is not one of {localhost, 127.0.0.1, ::1, [::1]}.
+ *   Raised *before* any network I/O.
+ * - `unreachable`: network error, connection refused, DNS failure, etc.
+ * - `timeout`: no response within `timeoutMs`.
+ * - `invalid_response`: HTTP status != 200, non-JSON body, or missing
+ *   required fields.
+ * - `non_chrome`: the responder does not identify itself as Chrome or
+ *   Chromium. Guards against e.g. a dev server happening to listen on
+ *   port 9222.
+ */
+export async function probeDevToolsJsonVersion(opts: {
+  host: string;
+  port: number;
+  timeoutMs: number;
+  signal?: AbortSignal;
+}): Promise<DevToolsVersionInfo> {
+  assertLoopback(opts.host);
+
+  const url = buildUrl(opts.host, opts.port, "/json/version");
+  const handle = withTimeout(opts.timeoutMs, opts.signal);
+
+  // Keep `handle` active until AFTER the body has been read, so the
+  // timeout (and caller abort) still enforce against a server that
+  // stalls mid-body. If we cleared the timer right after `fetch()`
+  // resolved, a chunked response that stalls on the second chunk would
+  // block `response.text()` indefinitely.
+  let text: string;
+  try {
+    let response: Response;
+    try {
+      response = await fetch(url, { signal: handle.signal });
+    } catch (err) {
+      throw classifyFetchError(
+        err,
+        handle.timedOut,
+        opts.signal?.aborted === true,
+      );
+    }
+
+    if (!response.ok) {
+      throw new DevToolsDiscoveryError(
+        "invalid_response",
+        `DevTools /json/version returned HTTP ${response.status}.`,
+      );
+    }
+
+    try {
+      text = await readResponseText(response, handle, opts.signal);
+    } catch (err) {
+      if (err instanceof TimeoutDuringBodyReadError) {
+        throw classifyFetchError(
+          err.underlying,
+          err.timedOut,
+          err.callerAborted,
+        );
+      }
+      throw new DevToolsDiscoveryError(
+        "invalid_response",
+        "Failed to read /json/version response body.",
+        err,
+      );
+    }
+  } finally {
+    handle.cleanup();
+  }
+
+  const parsed = parseJsonText(text, "/json/version");
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new DevToolsDiscoveryError(
+      "invalid_response",
+      "DevTools /json/version payload is not a JSON object.",
+    );
+  }
+
+  const record = parsed as Record<string, unknown>;
+  const browser = readStringField(record, "Browser", "browser");
+  const protocolVersion = readStringField(
+    record,
+    "Protocol-Version",
+    "protocolVersion",
+  );
+  const webSocketDebuggerUrl = readStringField(
+    record,
+    "webSocketDebuggerUrl",
+    "WebSocketDebuggerUrl",
+  );
+
+  if (!browser || !protocolVersion || !webSocketDebuggerUrl) {
+    throw new DevToolsDiscoveryError(
+      "invalid_response",
+      "DevTools /json/version payload is missing required fields (browser, protocolVersion, webSocketDebuggerUrl).",
+    );
+  }
+
+  if (!/chrom(e|ium)/i.test(browser)) {
+    throw new DevToolsDiscoveryError(
+      "non_chrome",
+      `DevTools endpoint is not Chrome or Chromium: ${browser}`,
+    );
+  }
+
+  return { browser, protocolVersion, webSocketDebuggerUrl };
+}
+
+/**
+ * Enumerate `/json/list` and return only usable page targets — i.e.
+ * `type === "page"` with a non-empty `webSocketDebuggerUrl`. Throws
+ * `no_targets` when the filtered list is empty so the caller doesn't
+ * have to decide how to phrase that.
+ *
+ * Sibling failure modes match {@link probeDevToolsJsonVersion}:
+ * `non_loopback`, `unreachable`, `timeout`, `invalid_response`.
+ */
+export async function listDevToolsTargets(opts: {
+  host: string;
+  port: number;
+  timeoutMs: number;
+  signal?: AbortSignal;
+}): Promise<DevToolsTarget[]> {
+  assertLoopback(opts.host);
+
+  const url = buildUrl(opts.host, opts.port, "/json/list");
+  const handle = withTimeout(opts.timeoutMs, opts.signal);
+
+  // Keep `handle` active until AFTER the body has been read, so the
+  // timeout (and caller abort) still enforce against a server that
+  // stalls mid-body. See the matching comment in
+  // probeDevToolsJsonVersion for the exact failure mode this guards
+  // against.
+  let text: string;
+  try {
+    let response: Response;
+    try {
+      response = await fetch(url, { signal: handle.signal });
+    } catch (err) {
+      throw classifyFetchError(
+        err,
+        handle.timedOut,
+        opts.signal?.aborted === true,
+      );
+    }
+
+    if (!response.ok) {
+      throw new DevToolsDiscoveryError(
+        "invalid_response",
+        `DevTools /json/list returned HTTP ${response.status}.`,
+      );
+    }
+
+    try {
+      text = await readResponseText(response, handle, opts.signal);
+    } catch (err) {
+      if (err instanceof TimeoutDuringBodyReadError) {
+        throw classifyFetchError(
+          err.underlying,
+          err.timedOut,
+          err.callerAborted,
+        );
+      }
+      throw new DevToolsDiscoveryError(
+        "invalid_response",
+        "Failed to read /json/list response body.",
+        err,
+      );
+    }
+  } finally {
+    handle.cleanup();
+  }
+
+  const parsed = parseJsonText(text, "/json/list");
+  if (!Array.isArray(parsed)) {
+    throw new DevToolsDiscoveryError(
+      "invalid_response",
+      "DevTools /json/list payload is not a JSON array.",
+    );
+  }
+
+  const targets: DevToolsTarget[] = [];
+  for (const entry of parsed) {
+    if (typeof entry !== "object" || entry === null || Array.isArray(entry)) {
+      continue;
+    }
+    const record = entry as Record<string, unknown>;
+    const type = readStringField(record, "type");
+    if (type !== "page") continue;
+
+    const webSocketDebuggerUrl = readStringField(
+      record,
+      "webSocketDebuggerUrl",
+    );
+    if (!webSocketDebuggerUrl) continue;
+
+    const id = readStringField(record, "id") ?? "";
+    const title = readStringField(record, "title") ?? "";
+    const targetUrl = readStringField(record, "url") ?? "";
+
+    targets.push({
+      id,
+      type,
+      title,
+      url: targetUrl,
+      webSocketDebuggerUrl,
+    });
+  }
+
+  if (targets.length === 0) {
+    throw new DevToolsDiscoveryError(
+      "no_targets",
+      "No usable page targets returned by DevTools /json/list.",
+    );
+  }
+
+  return targets;
+}
+
+/**
+ * Pick a sensible default target from a filtered list. Prefers targets
+ * whose URL is not `chrome://`, `devtools://`, or `about:blank`, then
+ * falls back to the first entry. Callers that need more specific
+ * control should iterate the list themselves.
+ *
+ * Throws `no_targets` on an empty input list — this mirrors the shape
+ * of {@link listDevToolsTargets}, so callers that chain the two can
+ * rely on a single error code path.
+ */
+export function pickDefaultTarget(targets: DevToolsTarget[]): DevToolsTarget {
+  if (targets.length === 0) {
+    throw new DevToolsDiscoveryError(
+      "no_targets",
+      "pickDefaultTarget called with an empty target list.",
+    );
+  }
+
+  const preferred = targets.find((target) => !isUtilityTarget(target));
+  return preferred ?? targets[0]!;
+}
+
+function isUtilityTarget(target: DevToolsTarget): boolean {
+  const url = target.url.toLowerCase();
+  if (url.startsWith("chrome://")) return true;
+  if (url.startsWith("devtools://")) return true;
+  if (url === "about:blank") return true;
+  return false;
+}

--- a/assistant/src/tools/browser/cdp-client/cdp-inspect/ws-transport.ts
+++ b/assistant/src/tools/browser/cdp-client/cdp-inspect/ws-transport.ts
@@ -184,14 +184,20 @@ const DEFAULT_CONNECT_TIMEOUT_MS = 5_000;
 /**
  * Open a raw CDP WebSocket transport against `url`. Resolves only
  * after the socket has reached `OPEN`; rejects with
- * `CdpWsTransportError("timeout")` if the connect-timeout expires or
+ * `CdpWsTransportError("timeout")` if the connect-timeout expires,
+ * `CdpWsTransportError("aborted")` if `opts.signal` fires, or
  * `transport_error` if the socket errors or closes before opening.
  */
 export async function connectCdpWsTransport(
   url: string,
-  opts?: { connectTimeoutMs?: number },
+  opts?: { connectTimeoutMs?: number; signal?: AbortSignal },
 ): Promise<CdpWsTransport> {
   const connectTimeoutMs = opts?.connectTimeoutMs ?? DEFAULT_CONNECT_TIMEOUT_MS;
+  const callerSignal = opts?.signal;
+
+  if (callerSignal?.aborted) {
+    throw new CdpWsTransportError("aborted", "aborted before connect");
+  }
 
   // bun's global `WebSocket` is API-compatible with the browser one.
   const WebSocketCtor: new (url: string) => WsLike = (
@@ -222,6 +228,7 @@ export async function connectCdpWsTransport(
     const timer = setTimeout(() => {
       if (settled) return;
       settled = true;
+      cleanupAbort();
       try {
         ws.close();
       } catch {
@@ -234,12 +241,14 @@ export async function connectCdpWsTransport(
       if (settled) return;
       settled = true;
       clearTimeout(timer);
+      cleanupAbort();
       resolve();
     };
     const onError = (ev: unknown) => {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
+      cleanupAbort();
       try {
         ws.close();
       } catch {
@@ -257,6 +266,7 @@ export async function connectCdpWsTransport(
       if (settled) return;
       settled = true;
       clearTimeout(timer);
+      cleanupAbort();
       reject(
         new CdpWsTransportError(
           "transport_error",
@@ -264,10 +274,30 @@ export async function connectCdpWsTransport(
         ),
       );
     };
+    const onCallerAbort = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      cleanupAbort();
+      try {
+        ws.close();
+      } catch {
+        // best effort
+      }
+      reject(new CdpWsTransportError("aborted", "aborted during connect"));
+    };
+    const cleanupAbort = () => {
+      if (callerSignal) {
+        callerSignal.removeEventListener("abort", onCallerAbort);
+      }
+    };
 
     ws.addEventListener("open", onOpen);
     ws.addEventListener("error", onError);
     ws.addEventListener("close", onCloseBeforeOpen);
+    if (callerSignal) {
+      callerSignal.addEventListener("abort", onCallerAbort, { once: true });
+    }
   });
 
   return createTransport(ws);

--- a/assistant/src/tools/browser/cdp-client/cdp-inspect/ws-transport.ts
+++ b/assistant/src/tools/browser/cdp-client/cdp-inspect/ws-transport.ts
@@ -1,0 +1,549 @@
+/**
+ * Raw CDP JSON-RPC WebSocket transport used by the `cdp-inspect`
+ * backend. This module is intentionally backend-agnostic: it has no
+ * dependency on the browser-session manager, the cdp-inspect client,
+ * or any feature-flag / config plumbing. It simply adapts a CDP
+ * WebSocket URL (as returned from DevTools `/json/version` or
+ * `/json/list`) into an asynchronous request/response + event
+ * interface.
+ *
+ * The transport is deliberately minimal:
+ *   - `send(method, params, opts?)` writes a JSON-RPC 2.0 request
+ *     frame with a monotonic id, registers a pending entry in the
+ *     correlation map, and resolves/rejects when the matching
+ *     response arrives (or the socket dies / the caller aborts).
+ *   - `addEventListener(listener)` subscribes to every inbound frame
+ *     that carries no `id` — these are CDP domain events fanned out
+ *     verbatim to listeners. Listeners do not affect request/response
+ *     correlation.
+ *   - `dispose()` proactively closes the socket and rejects every
+ *     still-pending request exactly once with `CdpWsTransportError(
+ *     "closed")`. It is idempotent.
+ *
+ * Failure modes map 1:1 onto {@link CdpWsTransportError} codes:
+ *   - `closed`         — the socket was closed (remote close,
+ *                        `dispose()`, or a pending send racing an
+ *                        already-closed transport).
+ *   - `aborted`        — the per-request `AbortSignal` fired. Any
+ *                        subsequent CDP response for that id is
+ *                        silently dropped.
+ *   - `timeout`        — the connect timeout expired before the
+ *                        socket reached `OPEN`.
+ *   - `transport_error`— a WebSocket `error` event fired, or a send
+ *                        failed (e.g. serialization failure).
+ *   - `cdp_error`      — the peer returned a JSON-RPC error envelope
+ *                        (`{id, error: {code, message}}`).
+ */
+
+export type CdpWsTransportErrorCode =
+  | "closed"
+  | "aborted"
+  | "timeout"
+  | "transport_error"
+  | "cdp_error";
+
+/**
+ * Error thrown (or used to reject) by {@link CdpWsTransport} and
+ * {@link connectCdpWsTransport}. The `code` discriminates the
+ * category of failure so callers can branch without string-sniffing
+ * the message. For `cdp_error`, the CDP JSON-RPC error envelope
+ * fields are copied through verbatim for logging and upstream
+ * error mapping.
+ */
+export class CdpWsTransportError extends Error {
+  readonly code: CdpWsTransportErrorCode;
+  readonly cdpMethod?: string;
+  readonly cdpCode?: number;
+  readonly cdpMessage?: string;
+  readonly cdpData?: unknown;
+  readonly underlying?: unknown;
+
+  constructor(
+    code: CdpWsTransportErrorCode,
+    message?: string,
+    details?: {
+      cdpMethod?: string;
+      cdpCode?: number;
+      cdpMessage?: string;
+      cdpData?: unknown;
+      underlying?: unknown;
+    },
+  ) {
+    super(message ?? code);
+    this.name = "CdpWsTransportError";
+    this.code = code;
+    this.cdpMethod = details?.cdpMethod;
+    this.cdpCode = details?.cdpCode;
+    this.cdpMessage = details?.cdpMessage;
+    this.cdpData = details?.cdpData;
+    this.underlying = details?.underlying;
+  }
+}
+
+/**
+ * Payload handed to event listeners registered via
+ * {@link CdpWsTransport.addEventListener}. Mirrors the wire-level
+ * shape of a CDP JSON-RPC notification minus the `id` field
+ * (notifications, by definition, carry no id).
+ */
+export interface CdpTransportEvent {
+  method: string;
+  params?: unknown;
+  sessionId?: string;
+}
+
+/**
+ * Public interface exposed by this transport. Deliberately narrower
+ * than the higher-level `CdpClient` type used by tool code — this
+ * layer does not know about conversations, backend selection, or
+ * CDP error mapping to the shared `CdpError` taxonomy.
+ */
+export interface CdpWsTransport {
+  /**
+   * Send a CDP method call over the socket and await its response.
+   *
+   * - `method` / `params` are serialized verbatim into a JSON-RPC
+   *   2.0 request envelope.
+   * - `opts.sessionId`, if provided, is forwarded on the wire as a
+   *   top-level `sessionId` field — required for CDP "flattened"
+   *   session attach mode.
+   * - `opts.signal` cancels the pending request: the returned
+   *   promise rejects with `CdpWsTransportError("aborted")` and any
+   *   subsequent response carrying the matching id is dropped.
+   *
+   * Failure modes:
+   *   - resolves with the `result` field on success.
+   *   - rejects with `cdp_error` if the peer returns a
+   *     `{id, error}` envelope.
+   *   - rejects with `closed` if the socket closes (or is disposed)
+   *     before a response arrives.
+   *   - rejects with `aborted` if the caller cancels.
+   *   - rejects with `transport_error` if the send itself fails
+   *     (e.g. the socket is already in a non-OPEN state and we race
+   *     a close, or JSON serialization fails).
+   */
+  send<T = unknown>(
+    method: string,
+    params?: Record<string, unknown>,
+    opts?: { sessionId?: string; signal?: AbortSignal },
+  ): Promise<T>;
+
+  /**
+   * Register a listener for every inbound JSON-RPC notification
+   * (i.e. any frame whose `id` is missing). Returns an unsubscribe
+   * function. Listener errors are swallowed so one bad consumer
+   * cannot tear down the transport.
+   */
+  addEventListener(listener: (event: CdpTransportEvent) => void): () => void;
+
+  /**
+   * Close the underlying socket and reject every still-pending
+   * request with `CdpWsTransportError("closed")`. Idempotent —
+   * calling `dispose()` twice does nothing on the second call. A
+   * `dispose()` after a remote close is still safe.
+   */
+  dispose(): void;
+}
+
+interface PendingRequest {
+  resolve: (value: unknown) => void;
+  reject: (err: CdpWsTransportError) => void;
+  method: string;
+  // Listener cleanup for the per-request abort signal. May be null if
+  // the caller did not provide a signal.
+  cleanupAbort: (() => void) | null;
+}
+
+/**
+ * Minimal structural shape of the WebSocket we depend on. Using a
+ * local interface (instead of the DOM / bun-types `WebSocket`
+ * global's static constants) lets us stay compatible with either
+ * runtime and keeps the tests free of DOM typing hassles.
+ */
+interface WsLike {
+  readyState: number;
+  send(data: string): void;
+  close(): void;
+  addEventListener(type: "open", listener: () => void): void;
+  addEventListener(type: "close", listener: () => void): void;
+  addEventListener(type: "error", listener: (ev: unknown) => void): void;
+  addEventListener(
+    type: "message",
+    listener: (ev: { data: unknown }) => void,
+  ): void;
+  removeEventListener?: (type: string, listener: unknown) => void;
+}
+
+// WebSocket.readyState constants. We avoid depending on the global
+// WebSocket static (e.g. `WebSocket.OPEN`) because test fakes may not
+// expose the static properties.
+const WS_OPEN = 1;
+
+const DEFAULT_CONNECT_TIMEOUT_MS = 5_000;
+
+/**
+ * Open a raw CDP WebSocket transport against `url`. Resolves only
+ * after the socket has reached `OPEN`; rejects with
+ * `CdpWsTransportError("timeout")` if the connect-timeout expires or
+ * `transport_error` if the socket errors or closes before opening.
+ */
+export async function connectCdpWsTransport(
+  url: string,
+  opts?: { connectTimeoutMs?: number },
+): Promise<CdpWsTransport> {
+  const connectTimeoutMs = opts?.connectTimeoutMs ?? DEFAULT_CONNECT_TIMEOUT_MS;
+
+  // bun's global `WebSocket` is API-compatible with the browser one.
+  const WebSocketCtor: new (url: string) => WsLike = (
+    globalThis as unknown as {
+      WebSocket: new (url: string) => WsLike;
+    }
+  ).WebSocket;
+  if (typeof WebSocketCtor !== "function") {
+    throw new CdpWsTransportError(
+      "transport_error",
+      "global WebSocket is not available in this runtime",
+    );
+  }
+
+  let ws: WsLike;
+  try {
+    ws = new WebSocketCtor(url);
+  } catch (err) {
+    throw new CdpWsTransportError(
+      "transport_error",
+      err instanceof Error ? err.message : String(err),
+      { underlying: err },
+    );
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      try {
+        ws.close();
+      } catch {
+        // best effort
+      }
+      reject(new CdpWsTransportError("timeout", "connect timeout"));
+    }, connectTimeoutMs);
+
+    const onOpen = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve();
+    };
+    const onError = (ev: unknown) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      try {
+        ws.close();
+      } catch {
+        // best effort
+      }
+      reject(
+        new CdpWsTransportError(
+          "transport_error",
+          "websocket error during connect",
+          { underlying: ev },
+        ),
+      );
+    };
+    const onCloseBeforeOpen = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      reject(
+        new CdpWsTransportError(
+          "transport_error",
+          "websocket closed before open",
+        ),
+      );
+    };
+
+    ws.addEventListener("open", onOpen);
+    ws.addEventListener("error", onError);
+    ws.addEventListener("close", onCloseBeforeOpen);
+  });
+
+  return createTransport(ws);
+}
+
+function createTransport(ws: WsLike): CdpWsTransport {
+  const pending = new Map<number, PendingRequest>();
+  const listeners = new Set<(event: CdpTransportEvent) => void>();
+  let nextId = 1;
+  let disposed = false;
+  let closed = false;
+
+  const rejectAllPending = (code: CdpWsTransportErrorCode, message: string) => {
+    if (pending.size === 0) return;
+    // Snapshot entries so that caller `.catch()` handlers invoked
+    // synchronously via `reject` cannot mutate the map we are iterating.
+    const entries = Array.from(pending.entries());
+    pending.clear();
+    for (const [, entry] of entries) {
+      entry.cleanupAbort?.();
+      entry.reject(
+        new CdpWsTransportError(code, message, { cdpMethod: entry.method }),
+      );
+    }
+  };
+
+  const handleMessage = (ev: { data: unknown }) => {
+    if (disposed) return;
+    let raw: string;
+    if (typeof ev.data === "string") {
+      raw = ev.data;
+    } else if (ev.data instanceof ArrayBuffer) {
+      raw = new TextDecoder().decode(ev.data);
+    } else if (
+      typeof (ev.data as { toString?: () => string })?.toString === "function"
+    ) {
+      raw = String(ev.data);
+    } else {
+      // Unknown binary payload — CDP is always JSON text, so drop it.
+      return;
+    }
+    let frame: unknown;
+    try {
+      frame = JSON.parse(raw);
+    } catch {
+      return;
+    }
+    if (!frame || typeof frame !== "object") return;
+    const obj = frame as {
+      id?: unknown;
+      result?: unknown;
+      error?: { code?: unknown; message?: unknown; data?: unknown };
+      method?: unknown;
+      params?: unknown;
+      sessionId?: unknown;
+    };
+
+    if (typeof obj.id === "number") {
+      const entry = pending.get(obj.id);
+      if (!entry) {
+        // Either an unknown id (protocol violation) or an aborted
+        // request whose entry we already removed — drop silently.
+        return;
+      }
+      pending.delete(obj.id);
+      entry.cleanupAbort?.();
+      if (obj.error && typeof obj.error === "object") {
+        const cdpCode =
+          typeof obj.error.code === "number" ? obj.error.code : undefined;
+        const cdpMessage =
+          typeof obj.error.message === "string" ? obj.error.message : undefined;
+        entry.reject(
+          new CdpWsTransportError(
+            "cdp_error",
+            cdpMessage ?? `cdp error for ${entry.method}`,
+            {
+              cdpMethod: entry.method,
+              cdpCode,
+              cdpMessage,
+              cdpData: obj.error.data,
+            },
+          ),
+        );
+      } else {
+        entry.resolve(obj.result);
+      }
+      return;
+    }
+
+    // No id → CDP domain event. Fan out to listeners, swallowing
+    // any listener throws.
+    if (typeof obj.method === "string") {
+      const event: CdpTransportEvent = {
+        method: obj.method,
+        params: obj.params,
+        sessionId:
+          typeof obj.sessionId === "string" ? obj.sessionId : undefined,
+      };
+      for (const listener of listeners) {
+        try {
+          listener(event);
+        } catch {
+          // listener errors are swallowed to keep the transport alive
+        }
+      }
+    }
+  };
+
+  const handleClose = () => {
+    if (closed) return;
+    closed = true;
+    rejectAllPending("closed", "websocket closed");
+  };
+
+  const handleError = (ev: unknown) => {
+    if (closed) return;
+    closed = true;
+    // Best-effort close after an error so we don't leak a half-open
+    // socket. Do not throw on already-closed sockets.
+    try {
+      ws.close();
+    } catch {
+      // ignored
+    }
+    // Reject pending as transport_error so callers can distinguish
+    // a protocol-level peer close from an explicit socket error.
+    if (pending.size > 0) {
+      const entries = Array.from(pending.entries());
+      pending.clear();
+      for (const [, entry] of entries) {
+        entry.cleanupAbort?.();
+        entry.reject(
+          new CdpWsTransportError("transport_error", "websocket error", {
+            cdpMethod: entry.method,
+            underlying: ev,
+          }),
+        );
+      }
+    }
+  };
+
+  ws.addEventListener("message", handleMessage);
+  ws.addEventListener("close", handleClose);
+  ws.addEventListener("error", handleError);
+
+  const transport: CdpWsTransport = {
+    send<T = unknown>(
+      method: string,
+      params?: Record<string, unknown>,
+      opts?: { sessionId?: string; signal?: AbortSignal },
+    ): Promise<T> {
+      if (disposed || closed) {
+        return Promise.reject(
+          new CdpWsTransportError("closed", "transport already closed", {
+            cdpMethod: method,
+          }),
+        );
+      }
+      const signal = opts?.signal;
+      if (signal?.aborted) {
+        return Promise.reject(
+          new CdpWsTransportError("aborted", "aborted before send", {
+            cdpMethod: method,
+          }),
+        );
+      }
+
+      const id = nextId++;
+      const frame: Record<string, unknown> = { id, method };
+      if (params !== undefined) frame.params = params;
+      if (opts?.sessionId !== undefined) frame.sessionId = opts.sessionId;
+
+      let serialized: string;
+      try {
+        serialized = JSON.stringify(frame);
+      } catch (err) {
+        return Promise.reject(
+          new CdpWsTransportError(
+            "transport_error",
+            err instanceof Error ? err.message : String(err),
+            { cdpMethod: method, underlying: err },
+          ),
+        );
+      }
+
+      // Guard against sending on a non-OPEN socket. By construction
+      // the socket is OPEN at the time we hand the transport to
+      // callers (connectCdpWsTransport waits for the `open` event),
+      // so any other readyState means the socket has since moved
+      // past OPEN — treat it as closed so callers can't observe
+      // silently dropped frames.
+      if (ws.readyState !== WS_OPEN) {
+        return Promise.reject(
+          new CdpWsTransportError("closed", "socket not open", {
+            cdpMethod: method,
+          }),
+        );
+      }
+
+      return new Promise<T>((resolve, reject) => {
+        // Register the pending entry FIRST so that an abort or
+        // inbound response racing the rest of this function body
+        // always has a live entry to act on. Without this ordering
+        // a synchronous abort registered below could fire before
+        // the entry exists, silently dropping the cancellation.
+        pending.set(id, {
+          resolve: (value: unknown) => resolve(value as T),
+          reject,
+          method,
+          cleanupAbort: null,
+        });
+
+        if (signal) {
+          const onAbort = () => {
+            const entry = pending.get(id);
+            if (!entry) return;
+            pending.delete(id);
+            entry.cleanupAbort?.();
+            entry.reject(
+              new CdpWsTransportError("aborted", "aborted during send", {
+                cdpMethod: method,
+              }),
+            );
+          };
+          signal.addEventListener("abort", onAbort, { once: true });
+          const entry = pending.get(id);
+          if (entry) {
+            entry.cleanupAbort = () => {
+              signal.removeEventListener("abort", onAbort);
+            };
+          }
+        }
+
+        try {
+          ws.send(serialized);
+        } catch (err) {
+          const entry = pending.get(id);
+          if (entry) {
+            pending.delete(id);
+            entry.cleanupAbort?.();
+          }
+          reject(
+            new CdpWsTransportError(
+              "transport_error",
+              err instanceof Error ? err.message : String(err),
+              { cdpMethod: method, underlying: err },
+            ),
+          );
+        }
+      });
+    },
+
+    addEventListener(listener) {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      // Reject pending requests BEFORE calling close() so that
+      // callers observe the explicit "disposed" signal even if the
+      // underlying `close()` fires a synchronous `close` event.
+      rejectAllPending("closed", "transport disposed");
+      if (!closed) {
+        closed = true;
+        try {
+          ws.close();
+        } catch {
+          // ignored — already-closed sockets may throw
+        }
+      }
+    },
+  };
+
+  return transport;
+}

--- a/assistant/src/tools/browser/cdp-client/factory.ts
+++ b/assistant/src/tools/browser/cdp-client/factory.ts
@@ -85,11 +85,16 @@ function buildManagedClient(
       signal?: AbortSignal,
     ): Promise<T> {
       if (disposed) {
-        throw new CdpError(
-          "disposed",
-          `${kind === "extension" ? "ExtensionCdpClient" : "LocalCdpClient"} already disposed`,
-          { cdpMethod: method, cdpParams: params },
-        );
+        const clientName =
+          kind === "extension"
+            ? "ExtensionCdpClient"
+            : kind === "cdp-inspect"
+              ? "CdpInspectClient"
+              : "LocalCdpClient";
+        throw new CdpError("disposed", `${clientName} already disposed`, {
+          cdpMethod: method,
+          cdpParams: params,
+        });
       }
       const command: CdpCommand = { method, params };
       const envelope = await manager.send(session.id, command, signal);

--- a/assistant/src/tools/browser/cdp-client/factory.ts
+++ b/assistant/src/tools/browser/cdp-client/factory.ts
@@ -3,10 +3,13 @@ import {
   BrowserSessionManager,
   type CdpCommand,
   type CdpResult,
+  createCdpInspectBackend,
   createExtensionBackend,
   createLocalBackend,
 } from "../../../browser-session/index.js";
+import { getConfig } from "../../../config/loader.js";
 import type { ToolContext } from "../../types.js";
+import { createCdpInspectClient } from "./cdp-inspect-client.js";
 import { CdpError } from "./errors.js";
 import { createExtensionCdpClient } from "./extension-cdp-client.js";
 import { createLocalCdpClient } from "./local-cdp-client.js";
@@ -14,19 +17,23 @@ import type { CdpClient, CdpClientKind, ScopedCdpClient } from "./types.js";
 
 /**
  * Select the appropriate CdpClient implementation for a tool
- * invocation based on the ToolContext:
+ * invocation based on the ToolContext and config. Three backends are
+ * considered in priority order:
  *
- *  - When `context.hostBrowserProxy` is set (macOS desktop / cloud-
- *    hosted with a chrome-extension bound to the conversation),
- *    register an extension backend so CDP commands ride the
- *    host_browser_request / host_browser_result round-trip.
- *  - Otherwise (CLI, tests, headless Chromium launched in-process),
- *    register a local backend that drives Playwright's CDPSession
- *    against the sacrificial-profile browser managed by
- *    browserManager.
+ *  1. **Extension** — When `context.hostBrowserProxy` is set (macOS
+ *     desktop / cloud-hosted with a chrome-extension bound to the
+ *     conversation), register an extension backend so CDP commands
+ *     ride the host_browser_request / host_browser_result round-trip.
+ *  2. **cdp-inspect** — When the extension is absent and
+ *     `hostBrowser.cdpInspect.enabled` is `true` in config, construct
+ *     a `CdpInspectClient` that attaches to an already-running Chrome
+ *     via the DevTools JSON protocol (`--remote-debugging-port`).
+ *  3. **Local** — Default fallback. Drives Playwright's CDPSession
+ *     against the sacrificial-profile browser managed by
+ *     browserManager.
  *
- * Both paths go through a per-invocation `BrowserSessionManager` so
- * the manager is the single choke point for CDP routing, session
+ * All three paths go through a per-invocation `BrowserSessionManager`
+ * so the manager is the single choke point for CDP routing, session
  * lifetime, and (future) session invalidation handling. The returned
  * client is `kind`-tagged so tools can branch on transport — e.g.
  * browser_navigate skips Playwright-specific screencast and handoff
@@ -40,6 +47,8 @@ import type { CdpClient, CdpClientKind, ScopedCdpClient } from "./types.js";
  */
 export function getCdpClient(context: ToolContext): ScopedCdpClient {
   const { conversationId, hostBrowserProxy } = context;
+
+  // 1. Extension backend — preferred when a chrome-extension is bound.
   if (hostBrowserProxy) {
     const client = createExtensionCdpClient(hostBrowserProxy, conversationId);
     const backend = createExtensionBackend({
@@ -50,6 +59,25 @@ export function getCdpClient(context: ToolContext): ScopedCdpClient {
     });
     return buildManagedClient("extension", conversationId, backend);
   }
+
+  // 2. cdp-inspect backend — opt-in via config when the extension is absent.
+  const cdpInspectConfig = getConfig().hostBrowser.cdpInspect;
+  if (cdpInspectConfig.enabled) {
+    const client = createCdpInspectClient(conversationId, {
+      host: cdpInspectConfig.host,
+      port: cdpInspectConfig.port,
+      discoveryTimeoutMs: cdpInspectConfig.probeTimeoutMs,
+    });
+    const backend = createCdpInspectBackend({
+      isAvailable: () => true,
+      sendCdp: (command, signal) =>
+        dispatchThroughClient(client, command, signal),
+      dispose: () => client.dispose(),
+    });
+    return buildManagedClient("cdp-inspect", conversationId, backend);
+  }
+
+  // 3. Local backend — default fallback (Playwright-backed Chromium).
   const client = createLocalCdpClient(conversationId);
   const backend = createLocalBackend({
     isAvailable: () => true,

--- a/assistant/src/tools/browser/cdp-client/index.ts
+++ b/assistant/src/tools/browser/cdp-client/index.ts
@@ -1,3 +1,9 @@
+export {
+  CdpInspectClient,
+  type CdpInspectClientOptions,
+  type CdpInspectHelpers,
+  createCdpInspectClient,
+} from "./cdp-inspect-client.js";
 export { CdpError, type CdpErrorCode } from "./errors.js";
 export {
   createExtensionCdpClient,

--- a/assistant/src/tools/browser/cdp-client/local-cdp-client.ts
+++ b/assistant/src/tools/browser/cdp-client/local-cdp-client.ts
@@ -179,7 +179,7 @@ export class LocalCdpClient implements ScopedCdpClient {
 /**
  * Factory for a fresh {@link LocalCdpClient} bound to a conversation.
  * Keeping the constructor + factory split lets the cdp-client factory
- * (PR 6) branch between local and extension transports without
+ * branch between local and extension transports without
  * exposing the class directly to callers.
  */
 export function createLocalCdpClient(conversationId: string): LocalCdpClient {

--- a/assistant/src/tools/browser/cdp-client/types.ts
+++ b/assistant/src/tools/browser/cdp-client/types.ts
@@ -38,7 +38,7 @@ export interface CdpClient {
  * the sacrificial-profile screencast setup when running against the
  * user's own Chrome via the extension).
  */
-export type CdpClientKind = "local" | "extension";
+export type CdpClientKind = "local" | "extension" | "cdp-inspect";
 
 /**
  * Concrete CdpClient instance returned by the factory. Carries the

--- a/assistant/src/tools/browser/cdp-client/types.ts
+++ b/assistant/src/tools/browser/cdp-client/types.ts
@@ -1,10 +1,11 @@
 /**
  * Minimal typed surface over Chrome DevTools Protocol. Implemented by
- * LocalCdpClient (Playwright-backed, same-process Chromium) and by
+ * LocalCdpClient (Playwright-backed, same-process Chromium),
  * ExtensionCdpClient (routes through HostBrowserProxy to the user's
- * Chrome via chrome.debugger). Tools call `send(method, params)` with
- * a CDP method name and return the raw CDP result object; errors are
- * thrown as {@link CdpError}.
+ * Chrome via chrome.debugger), and CdpInspectClient (connects to a
+ * remote browser over a raw CDP WebSocket URL). Tools call
+ * `send(method, params)` with a CDP method name and return the raw
+ * CDP result object; errors are thrown as {@link CdpError}.
  */
 export interface CdpClient {
   /**

--- a/clients/macos/vellum-assistant/App/AppURLs.swift
+++ b/clients/macos/vellum-assistant/App/AppURLs.swift
@@ -67,6 +67,15 @@ public enum AppURLs {
         docsURL(path: "/privacy-policy")
     }
 
+    /// Browser "use your own Chrome" (cdp-inspect host-browser backend) docs
+    /// — linked from the Developer tab `BrowserBackendCard`. The final slug
+    /// may change when the docs page lands in a later PR; this is a
+    /// placeholder that still routes through `docsBaseURL` so it honors
+    /// `VELLUM_DOCS_BASE_URL` overrides.
+    public static var browserCdpInspectDocs: URL {
+        docsURL(path: "/assistant/browser/cdp-inspect-backend")
+    }
+
     // MARK: - Helpers
 
     /// Build a docs URL by appending a path to the (possibly env-overridden) base.

--- a/clients/macos/vellum-assistant/Features/Settings/BrowserBackendCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/BrowserBackendCard.swift
@@ -1,0 +1,248 @@
+import AppKit
+import SwiftUI
+import VellumAssistantShared
+
+/// Developer-only card that lets the user route browser tool calls through a
+/// host Chrome instance launched with `--remote-debugging-port` (the
+/// cdp-inspect host-browser backend).
+///
+/// This is an **advanced** mode: once enabled, the assistant can see and act
+/// on any tab in the user's real Chrome profile, so the card leads with a
+/// prominent security warning and only allows loopback host overrides.
+@MainActor
+struct BrowserBackendCard: View {
+    @ObservedObject var store: SettingsStore
+
+    /// Local draft of the host value — only persisted on Save.
+    @State private var draftHost: String = "localhost"
+    /// Local draft of the port value — only persisted on Save.
+    @State private var draftPortText: String = "9222"
+    @State private var hostError: String?
+    @State private var portError: String?
+    @FocusState private var isHostFocused: Bool
+    @FocusState private var isPortFocused: Bool
+
+    /// Docs URL for the "use your own Chrome" backend. Routed through
+    /// `AppURLs.browserCdpInspectDocs` so it honors `VELLUM_DOCS_BASE_URL`
+    /// overrides (staging / local docs servers) — see
+    /// `clients/macos/AGENTS.md` § External URLs. The real docs page lands
+    /// with a later PR so the slug is a placeholder.
+    private static var learnMoreURL: URL {
+        AppURLs.browserCdpInspectDocs
+    }
+
+    var body: some View {
+        SettingsCard(
+            title: "Use your own Chrome (Advanced)",
+            subtitle: "Route the assistant's browser tools through a Chrome instance you launched with remote debugging. For advanced users only."
+        ) {
+            warningBlock
+
+            SettingsDivider()
+
+            VToggle(
+                isOn: Binding(
+                    get: { store.hostBrowserCdpInspectEnabled },
+                    set: { newValue in
+                        _ = store.setHostBrowserCdpInspectEnabled(newValue)
+                    }
+                ),
+                label: "Enable cdp-inspect backend",
+                helperText: "When on, the assistant probes the host/port below before falling back to the managed browser."
+            )
+            .accessibilityLabel("Enable cdp-inspect backend")
+
+            if store.hostBrowserCdpInspectEnabled {
+                connectionForm
+            }
+
+            learnMoreLink
+        }
+        .onAppear {
+            syncDraftsFromStore()
+        }
+        .onChange(of: store.hostBrowserCdpInspectHost) { _, newValue in
+            if !isHostFocused {
+                draftHost = newValue
+                hostError = nil
+            }
+        }
+        .onChange(of: store.hostBrowserCdpInspectPort) { _, newValue in
+            if !isPortFocused {
+                draftPortText = String(newValue)
+                portError = nil
+            }
+        }
+    }
+
+    // MARK: - Warning Block
+
+    private var warningBlock: some View {
+        HStack(alignment: .top, spacing: VSpacing.sm) {
+            VIconView(.triangleAlert, size: 16)
+                .foregroundStyle(VColor.systemNegativeStrong)
+                .padding(.top, 1)
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                Text("Warning: This mode gives the assistant full control of your real Chrome profile.")
+                    .font(VFont.bodyMediumDefault)
+                    .foregroundStyle(VColor.contentEmphasized)
+
+                Text(
+                    "When enabled, the assistant can read and act on any tab in your real Chrome, including sites you're already signed into (email, banking, chat). The DOM content it observes comes from untrusted web pages, so a malicious page could try to manipulate what the assistant sees or does."
+                )
+                .font(VFont.labelDefault)
+                .foregroundStyle(VColor.contentSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+                Text("Connections are limited to localhost (no remote attach). Only enable this if you understand the risks.")
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(VSpacing.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(VColor.systemNegativeWeak)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+    }
+
+    // MARK: - Connection Form
+
+    private var connectionForm: some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                Text("Host")
+                    .font(VFont.bodySmallDefault)
+                    .foregroundStyle(VColor.contentSecondary)
+                VTextField(
+                    placeholder: "localhost",
+                    text: $draftHost,
+                    errorMessage: hostError,
+                    isFocused: $isHostFocused
+                )
+            }
+
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                Text("Port")
+                    .font(VFont.bodySmallDefault)
+                    .foregroundStyle(VColor.contentSecondary)
+                VTextField(
+                    placeholder: "9222",
+                    text: $draftPortText,
+                    errorMessage: portError,
+                    isFocused: $isPortFocused
+                )
+            }
+
+            HStack {
+                VButton(
+                    label: "Save",
+                    style: .primary,
+                    isDisabled: !hasFormChanges
+                ) {
+                    saveFormChanges()
+                }
+            }
+
+            Text("Only loopback addresses (localhost, 127.0.0.1, ::1, [::1]) are accepted. Ports must be between 1 and 65535.")
+                .font(VFont.labelDefault)
+                .foregroundStyle(VColor.contentTertiary)
+        }
+    }
+
+    // MARK: - Learn more
+
+    private var learnMoreLink: some View {
+        Button {
+            NSWorkspace.shared.open(Self.learnMoreURL)
+        } label: {
+            HStack(spacing: VSpacing.xxs) {
+                VIconView(.info, size: 12)
+                Text("Learn more about the security risks")
+                    .font(VFont.labelDefault)
+            }
+            .foregroundStyle(VColor.primaryBase)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Learn more about the security risks")
+    }
+
+    // MARK: - Drafts / Saving
+
+    private var hasFormChanges: Bool {
+        let trimmedHost = draftHost.trimmingCharacters(in: .whitespacesAndNewlines)
+        let parsedPort = Int(draftPortText.trimmingCharacters(in: .whitespacesAndNewlines))
+        let hostChanged = trimmedHost != store.hostBrowserCdpInspectHost
+        let portChanged = parsedPort != store.hostBrowserCdpInspectPort
+        return hostChanged || portChanged
+    }
+
+    private func syncDraftsFromStore() {
+        draftHost = store.hostBrowserCdpInspectHost
+        draftPortText = String(store.hostBrowserCdpInspectPort)
+        hostError = nil
+        portError = nil
+    }
+
+    private func saveFormChanges() {
+        // Validate BOTH host and port before applying any patches so the save
+        // path is atomic: if either field is invalid, we surface all errors
+        // and persist neither change. Previously, host-only failures still
+        // silently persisted the port, leaving the form in a partially-applied
+        // state that was hard to reason about.
+        let trimmedHost = draftHost.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedPortText = draftPortText.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        var pendingHostError: String?
+        var pendingPortError: String?
+
+        let hostChanged = trimmedHost != store.hostBrowserCdpInspectHost
+        if hostChanged, !SettingsStore.isValidHostBrowserCdpInspectHost(trimmedHost) {
+            pendingHostError = "Only loopback hosts are allowed (localhost, 127.0.0.1, ::1, [::1])."
+        }
+
+        let parsedPort = Int(trimmedPortText)
+        let portChanged: Bool
+        if let parsedPort {
+            portChanged = parsedPort != store.hostBrowserCdpInspectPort
+            if portChanged, !SettingsStore.isValidHostBrowserCdpInspectPort(parsedPort) {
+                pendingPortError = "Port must be between 1 and 65535."
+            }
+        } else {
+            portChanged = false
+            pendingPortError = "Port must be a number between 1 and 65535."
+        }
+
+        // Publish both error slots in one pass so the user sees every issue at
+        // once rather than fixing them sequentially.
+        hostError = pendingHostError
+        portError = pendingPortError
+
+        if pendingHostError != nil || pendingPortError != nil {
+            // Validation failed — do not mutate the store or emit any patches.
+            return
+        }
+
+        // All validation passed — apply only the fields that actually changed.
+        // The setters run their own validation too, but we've already checked
+        // it above so they should return nil. If they don't, we surface the
+        // error instead of silently swallowing it.
+        if hostChanged {
+            if let error = store.setHostBrowserCdpInspectHost(trimmedHost) {
+                hostError = error
+                return
+            }
+        }
+        if portChanged, let parsedPort {
+            if let error = store.setHostBrowserCdpInspectPort(parsedPort) {
+                portError = error
+                return
+            }
+        }
+
+        isHostFocused = false
+        isPortFocused = false
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -125,6 +125,17 @@ struct SettingsDeveloperTab: View {
                 ToolPermissionTesterView(model: model)
             }
 
+            // Browser backend (cdp-inspect host Chrome) — gated behind
+            // `devModeManager.isDevMode` to match the other developer-only
+            // sections (`platformUrlSection`, `revokeAssistantApiKeySection`).
+            // The Developer tab itself is flagged behind `developer`, but this
+            // card bypasses the managed browser sandbox so we require the
+            // additional dev-mode gate to keep regular developer-tab users
+            // from stumbling into it.
+            if devModeManager.isDevMode {
+                browserBackendSection
+            }
+
             // Feature Flags
             featureFlagSection
             // Environment Variables
@@ -887,6 +898,17 @@ struct SettingsDeveloperTab: View {
             withAnimation {
                 if revokeApiKeyStatus == message { revokeApiKeyStatus = nil }
             }
+        }
+    }
+
+    // MARK: - Browser Backend (cdp-inspect)
+
+    private var browserBackendSection: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            Text("Browser backend")
+                .font(VFont.titleSmall)
+                .foregroundStyle(VColor.contentEmphasized)
+            BrowserBackendCard(store: store)
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -3431,7 +3431,22 @@ public final class SettingsStore: ObservableObject {
         if let port = cdpInspect["port"] as? Int {
             rawPort = port
         } else if let portDouble = cdpInspect["port"] as? Double {
-            rawPort = Int(portDouble)
+            if portDouble.truncatingRemainder(dividingBy: 1) == 0 {
+                rawPort = Int(portDouble)
+            } else {
+                log.warning("Ignoring fractional hostBrowser.cdpInspect.port value \(portDouble) from daemon config; falling back to default")
+                rawPort = nil
+                store.hostBrowserCdpInspectPort = defaultHostBrowserCdpInspectPort
+                let settingsClient = store.settingsClient
+                Task {
+                    let success = await settingsClient.patchConfig([
+                        "hostBrowser": ["cdpInspect": ["port": defaultHostBrowserCdpInspectPort]]
+                    ])
+                    if !success {
+                        log.error("Failed to patch sanitized hostBrowser.cdpInspect.port back to daemon config")
+                    }
+                }
+            }
         } else {
             rawPort = nil
         }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -278,6 +278,31 @@ public final class SettingsStore: ObservableObject {
     /// view layer can defer diagnostics until the real config values are available.
     @Published var ingressConfigLoaded: Bool = false
 
+    // MARK: - Host Browser (CDP Inspect) State
+
+    /// Whether the cdp-inspect host-browser backend is enabled.
+    ///
+    /// When true, the browser-session manager probes the configured
+    /// `hostBrowserCdpInspectHost`/`hostBrowserCdpInspectPort` for a running
+    /// Chrome instance exposing `--remote-debugging-port` before falling
+    /// back to the local Playwright backend.
+    @Published var hostBrowserCdpInspectEnabled: Bool = false
+
+    /// Host name or IP address for the host Chrome remote-debugging endpoint.
+    ///
+    /// Only loopback values are accepted (`localhost`, `127.0.0.1`, `::1`,
+    /// `[::1]`) to prevent remote attach attempts.
+    @Published var hostBrowserCdpInspectHost: String = "localhost"
+
+    /// TCP port for the host Chrome remote-debugging endpoint.
+    ///
+    /// Must be in the range `1...65535`.
+    @Published var hostBrowserCdpInspectPort: Int = 9222
+
+    /// Timeout (in milliseconds) for the backend availability probe.
+    /// Defaults to `500` and is preserved verbatim from the fetched config.
+    @Published var hostBrowserCdpInspectProbeTimeoutMs: Int = 500
+
     // MARK: - Connection Health Check State
 
     @Published var gatewayReachable: Bool?
@@ -3298,6 +3323,8 @@ public final class SettingsStore: ObservableObject {
             self.webSearchProvider = provider
         }
 
+        Self.applyHostBrowserCdpInspectConfig(config, into: self)
+
         loadServiceModes(config: config)
 
         // Persist enabledSince when it was defaulted so subsequent loads
@@ -3317,6 +3344,183 @@ public final class SettingsStore: ObservableObject {
             return nil
         }
         return canonicalizeTimeZoneIdentifier(trimmed)
+    }
+
+    // MARK: - Host Browser (CDP Inspect) Loading
+
+    /// Loopback hostnames accepted by the cdp-inspect backend. Non-loopback
+    /// values are rejected at the UI layer to prevent remote attach.
+    static let hostBrowserCdpInspectAllowedHosts: Set<String> = [
+        "localhost",
+        "127.0.0.1",
+        "::1",
+        "[::1]",
+    ]
+
+    /// Returns `true` when `host` is one of the accepted loopback addresses
+    /// for the cdp-inspect backend.
+    static func isValidHostBrowserCdpInspectHost(_ host: String) -> Bool {
+        let trimmed = host.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return hostBrowserCdpInspectAllowedHosts.contains(trimmed)
+    }
+
+    /// Returns `true` when `port` is within the valid TCP port range.
+    static func isValidHostBrowserCdpInspectPort(_ port: Int) -> Bool {
+        return (1...65535).contains(port)
+    }
+
+    /// Default loopback host for the cdp-inspect backend. Used as the fallback
+    /// when the daemon config contains an invalid (non-loopback) host value.
+    static let defaultHostBrowserCdpInspectHost: String = "localhost"
+    /// Default DevTools remote-debugging port for the cdp-inspect backend.
+    /// Used as the fallback when the daemon config contains an out-of-range
+    /// port value.
+    static let defaultHostBrowserCdpInspectPort: Int = 9222
+
+    /// Reads `hostBrowser.cdpInspect.{enabled,host,port,probeTimeoutMs}` from
+    /// the workspace config and copies the values into `store`. Missing keys
+    /// leave the existing values untouched so the defaults set in the
+    /// property declarations apply.
+    ///
+    /// The `host` and `port` values are validated the same way as the UI
+    /// setters (`setHostBrowserCdpInspectHost` / `setHostBrowserCdpInspectPort`)
+    /// to preserve the loopback-only security invariant: if the workspace
+    /// config file is manually edited (or tampered with) to contain a
+    /// non-loopback host like `"attacker.example.com"` or an out-of-range
+    /// port, we fall back to the safe defaults (`localhost` / `9222`) and
+    /// log a warning instead of silently accepting the unsafe value.
+    ///
+    /// When an invalid value is detected, we also patch the sanitized
+    /// default back to the daemon config so the bad value does not
+    /// reappear on the next config reload. The patch only fires when
+    /// validation fails — once the config contains a valid value, no
+    /// patch is emitted, so there is no infinite loop across refreshes.
+    static func applyHostBrowserCdpInspectConfig(
+        _ config: [String: Any],
+        into store: SettingsStore
+    ) {
+        guard let hostBrowser = config["hostBrowser"] as? [String: Any],
+              let cdpInspect = hostBrowser["cdpInspect"] as? [String: Any] else {
+            return
+        }
+        if let enabled = cdpInspect["enabled"] as? Bool {
+            store.hostBrowserCdpInspectEnabled = enabled
+        }
+        if let host = cdpInspect["host"] as? String, !host.isEmpty {
+            if isValidHostBrowserCdpInspectHost(host) {
+                store.hostBrowserCdpInspectHost = host.trimmingCharacters(in: .whitespacesAndNewlines)
+            } else {
+                log.warning("Ignoring invalid hostBrowser.cdpInspect.host value from daemon config (must be loopback); falling back to default and patching daemon")
+                store.hostBrowserCdpInspectHost = defaultHostBrowserCdpInspectHost
+                // Persist the sanitized fallback so the invalid value
+                // does not reappear on the next daemon config reload.
+                let settingsClient = store.settingsClient
+                Task {
+                    let success = await settingsClient.patchConfig([
+                        "hostBrowser": ["cdpInspect": ["host": defaultHostBrowserCdpInspectHost]]
+                    ])
+                    if !success {
+                        log.error("Failed to patch sanitized hostBrowser.cdpInspect.host back to daemon config")
+                    }
+                }
+            }
+        }
+        // JSONSerialization may surface integral numbers as Double, so coerce
+        // through a single path before validating.
+        let rawPort: Int?
+        if let port = cdpInspect["port"] as? Int {
+            rawPort = port
+        } else if let portDouble = cdpInspect["port"] as? Double {
+            rawPort = Int(portDouble)
+        } else {
+            rawPort = nil
+        }
+        if let port = rawPort {
+            if isValidHostBrowserCdpInspectPort(port) {
+                store.hostBrowserCdpInspectPort = port
+            } else {
+                log.warning("Ignoring out-of-range hostBrowser.cdpInspect.port value from daemon config (must be 1..65535); falling back to default and patching daemon")
+                store.hostBrowserCdpInspectPort = defaultHostBrowserCdpInspectPort
+                // Persist the sanitized fallback so the invalid value
+                // does not reappear on the next daemon config reload.
+                let settingsClient = store.settingsClient
+                Task {
+                    let success = await settingsClient.patchConfig([
+                        "hostBrowser": ["cdpInspect": ["port": defaultHostBrowserCdpInspectPort]]
+                    ])
+                    if !success {
+                        log.error("Failed to patch sanitized hostBrowser.cdpInspect.port back to daemon config")
+                    }
+                }
+            }
+        }
+        if let probeTimeout = cdpInspect["probeTimeoutMs"] as? Int {
+            store.hostBrowserCdpInspectProbeTimeoutMs = probeTimeout
+        } else if let probeTimeoutDouble = cdpInspect["probeTimeoutMs"] as? Double {
+            store.hostBrowserCdpInspectProbeTimeoutMs = Int(probeTimeoutDouble)
+        }
+    }
+
+    // MARK: - Host Browser (CDP Inspect) Actions
+
+    /// Persists the cdp-inspect enable flag by patching
+    /// `hostBrowser.cdpInspect.enabled` on the workspace config.
+    ///
+    /// The local `@Published` value is updated optimistically before the
+    /// patch completes so the UI reflects the new state immediately.
+    @discardableResult
+    func setHostBrowserCdpInspectEnabled(_ enabled: Bool) -> Task<Bool, Never> {
+        hostBrowserCdpInspectEnabled = enabled
+        return Task {
+            let success = await settingsClient.patchConfig([
+                "hostBrowser": ["cdpInspect": ["enabled": enabled]]
+            ])
+            if !success {
+                log.error("Failed to patch config for hostBrowser.cdpInspect.enabled")
+            }
+            return success
+        }
+    }
+
+    /// Persists the cdp-inspect host override by patching
+    /// `hostBrowser.cdpInspect.host`. Returns an error string and does not
+    /// emit a patch when `host` is not one of the accepted loopback values.
+    @discardableResult
+    func setHostBrowserCdpInspectHost(_ host: String) -> String? {
+        let trimmed = host.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard Self.isValidHostBrowserCdpInspectHost(trimmed) else {
+            return "Only loopback hosts are allowed (localhost, 127.0.0.1, ::1, [::1])."
+        }
+        hostBrowserCdpInspectHost = trimmed
+        Task {
+            let success = await settingsClient.patchConfig([
+                "hostBrowser": ["cdpInspect": ["host": trimmed]]
+            ])
+            if !success {
+                log.error("Failed to patch config for hostBrowser.cdpInspect.host")
+            }
+        }
+        return nil
+    }
+
+    /// Persists the cdp-inspect port override by patching
+    /// `hostBrowser.cdpInspect.port`. Returns an error string and does not
+    /// emit a patch when `port` is outside the valid TCP range.
+    @discardableResult
+    func setHostBrowserCdpInspectPort(_ port: Int) -> String? {
+        guard Self.isValidHostBrowserCdpInspectPort(port) else {
+            return "Port must be between 1 and 65535."
+        }
+        hostBrowserCdpInspectPort = port
+        Task {
+            let success = await settingsClient.patchConfig([
+                "hostBrowser": ["cdpInspect": ["port": port]]
+            ])
+            if !success {
+                log.error("Failed to patch config for hostBrowser.cdpInspect.port")
+            }
+        }
+        return nil
     }
 
 }

--- a/clients/macos/vellum-assistantTests/SettingsStoreBrowserBackendTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsStoreBrowserBackendTests.swift
@@ -301,6 +301,30 @@ final class SettingsStoreBrowserBackendTests: XCTestCase {
         XCTAssertEqual(store.hostBrowserCdpInspectPort, 9222)
     }
 
+    func testApplyDaemonConfigRejectsFractionalPortDouble() {
+        store.hostBrowserCdpInspectPort = 9333
+        // A fractional Double (e.g. 9222.5) must be rejected rather than
+        // silently truncated to 9222. The store should fall back to the
+        // default port and patch the sanitized value back to the daemon.
+        let config: [String: Any] = [
+            "hostBrowser": [
+                "cdpInspect": [
+                    "port": 9222.5,
+                ]
+            ]
+        ]
+        SettingsStore.applyHostBrowserCdpInspectConfig(config, into: store)
+
+        XCTAssertEqual(store.hostBrowserCdpInspectPort, SettingsStore.defaultHostBrowserCdpInspectPort)
+        XCTAssertEqual(store.hostBrowserCdpInspectPort, 9222)
+
+        // A sanitize-and-patch-back Task should have been fired.
+        waitForPatchCount(1)
+        let patch = lastCdpInspectPatch()
+        XCTAssertNotNil(patch, "expected a hostBrowser.cdpInspect patch payload for fractional port rejection")
+        XCTAssertEqual(patch?["port"] as? Int, 9222)
+    }
+
     func testApplyDaemonConfigRejectsBothInvalidHostAndPort() {
         store.hostBrowserCdpInspectHost = "127.0.0.1"
         store.hostBrowserCdpInspectPort = 9333

--- a/clients/macos/vellum-assistantTests/SettingsStoreBrowserBackendTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsStoreBrowserBackendTests.swift
@@ -1,0 +1,480 @@
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+/// Verifies that `SettingsStore` emits the expected config patch payloads
+/// for the `hostBrowser.cdpInspect` namespace and enforces loopback-only
+/// host / in-range port validation before hitting the settings client.
+@MainActor
+final class SettingsStoreBrowserBackendTests: XCTestCase {
+
+    private var mockSettingsClient: MockSettingsClient!
+    private var store: SettingsStore!
+
+    override func setUp() {
+        super.setUp()
+        mockSettingsClient = MockSettingsClient()
+        mockSettingsClient.patchConfigResponse = true
+        store = SettingsStore(settingsClient: mockSettingsClient)
+    }
+
+    override func tearDown() {
+        store = nil
+        mockSettingsClient = nil
+        super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    /// Returns the most recent `hostBrowser.cdpInspect` patch payload captured
+    /// by the mock client, or `nil` if no such patch has been emitted.
+    private func lastCdpInspectPatch() -> [String: Any]? {
+        for payload in mockSettingsClient.patchConfigCalls.reversed() {
+            if let hostBrowser = payload["hostBrowser"] as? [String: Any],
+               let cdpInspect = hostBrowser["cdpInspect"] as? [String: Any] {
+                return cdpInspect
+            }
+        }
+        return nil
+    }
+
+    /// Waits for the background `Task` started by a store helper to flush
+    /// its patch into the mock client. The helpers fire-and-forget a Task,
+    /// so tests must poll until the captured call count matches expectations.
+    private func waitForPatchCount(_ expected: Int, timeout: TimeInterval = 2.0) {
+        let predicate = NSPredicate { _, _ in
+            self.mockSettingsClient.patchConfigCalls.count >= expected
+        }
+        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: nil)
+        wait(for: [expectation], timeout: timeout)
+    }
+
+    // MARK: - Initial State
+
+    func testInitialStateMatchesConfigDefaults() {
+        XCTAssertFalse(store.hostBrowserCdpInspectEnabled)
+        XCTAssertEqual(store.hostBrowserCdpInspectHost, "localhost")
+        XCTAssertEqual(store.hostBrowserCdpInspectPort, 9222)
+        XCTAssertEqual(store.hostBrowserCdpInspectProbeTimeoutMs, 500)
+    }
+
+    // MARK: - Toggle Enable/Disable
+
+    func testSetEnabledTrueEmitsExpectedPatch() {
+        store.setHostBrowserCdpInspectEnabled(true)
+
+        waitForPatchCount(1)
+
+        XCTAssertTrue(store.hostBrowserCdpInspectEnabled)
+        let patch = lastCdpInspectPatch()
+        XCTAssertNotNil(patch, "expected a hostBrowser.cdpInspect patch payload")
+        XCTAssertEqual(patch?["enabled"] as? Bool, true)
+        // Only `enabled` should be present — other fields are patched independently.
+        XCTAssertNil(patch?["host"])
+        XCTAssertNil(patch?["port"])
+    }
+
+    func testSetEnabledFalseEmitsExpectedPatch() {
+        store.hostBrowserCdpInspectEnabled = true // start from enabled to force a toggle
+        store.setHostBrowserCdpInspectEnabled(false)
+
+        waitForPatchCount(1)
+
+        XCTAssertFalse(store.hostBrowserCdpInspectEnabled)
+        let patch = lastCdpInspectPatch()
+        XCTAssertEqual(patch?["enabled"] as? Bool, false)
+    }
+
+    // MARK: - Host override
+
+    func testSetValidLoopbackHostEmitsExpectedPatch() {
+        let error = store.setHostBrowserCdpInspectHost("127.0.0.1")
+        XCTAssertNil(error)
+        XCTAssertEqual(store.hostBrowserCdpInspectHost, "127.0.0.1")
+
+        waitForPatchCount(1)
+        let patch = lastCdpInspectPatch()
+        XCTAssertEqual(patch?["host"] as? String, "127.0.0.1")
+        XCTAssertNil(patch?["enabled"])
+        XCTAssertNil(patch?["port"])
+    }
+
+    func testSetValidLoopbackHostAcceptsEachAllowedVariant() {
+        let allowed = ["localhost", "127.0.0.1", "::1", "[::1]"]
+        for (index, value) in allowed.enumerated() {
+            let error = store.setHostBrowserCdpInspectHost(value)
+            XCTAssertNil(error, "\(value) should be accepted as a loopback host")
+            waitForPatchCount(index + 1)
+            XCTAssertEqual(store.hostBrowserCdpInspectHost, value)
+        }
+    }
+
+    func testSetHostRejectsNonLoopbackValues() {
+        let rejected = [
+            "example.com",
+            "192.168.1.10",
+            "10.0.0.1",
+            "0.0.0.0",
+            "remote.internal",
+        ]
+        for value in rejected {
+            let error = store.setHostBrowserCdpInspectHost(value)
+            XCTAssertNotNil(error, "\(value) should be rejected as non-loopback")
+        }
+        // No patches should have been emitted for rejected hosts.
+        XCTAssertTrue(mockSettingsClient.patchConfigCalls.isEmpty)
+        XCTAssertEqual(store.hostBrowserCdpInspectHost, "localhost")
+    }
+
+    func testSetHostTrimsWhitespaceBeforeValidation() {
+        let error = store.setHostBrowserCdpInspectHost("  127.0.0.1  ")
+        XCTAssertNil(error)
+        waitForPatchCount(1)
+
+        XCTAssertEqual(store.hostBrowserCdpInspectHost, "127.0.0.1")
+        let patch = lastCdpInspectPatch()
+        XCTAssertEqual(patch?["host"] as? String, "127.0.0.1")
+    }
+
+    // MARK: - Port override
+
+    func testSetValidPortEmitsExpectedPatch() {
+        let error = store.setHostBrowserCdpInspectPort(9333)
+        XCTAssertNil(error)
+        XCTAssertEqual(store.hostBrowserCdpInspectPort, 9333)
+
+        waitForPatchCount(1)
+        let patch = lastCdpInspectPatch()
+        XCTAssertEqual(patch?["port"] as? Int, 9333)
+        XCTAssertNil(patch?["enabled"])
+        XCTAssertNil(patch?["host"])
+    }
+
+    func testSetPortAcceptsBoundaries() {
+        XCTAssertNil(store.setHostBrowserCdpInspectPort(1))
+        waitForPatchCount(1)
+        XCTAssertEqual(lastCdpInspectPatch()?["port"] as? Int, 1)
+
+        XCTAssertNil(store.setHostBrowserCdpInspectPort(65535))
+        waitForPatchCount(2)
+        XCTAssertEqual(lastCdpInspectPatch()?["port"] as? Int, 65535)
+    }
+
+    func testSetPortRejectsOutOfRangeValues() {
+        let rejected = [0, -1, 65536, 100_000]
+        for value in rejected {
+            let error = store.setHostBrowserCdpInspectPort(value)
+            XCTAssertNotNil(error, "\(value) should be rejected as out-of-range")
+        }
+        XCTAssertTrue(mockSettingsClient.patchConfigCalls.isEmpty)
+        XCTAssertEqual(store.hostBrowserCdpInspectPort, 9222)
+    }
+
+    // MARK: - Pure validation helpers
+
+    func testIsValidHostBrowserCdpInspectHost() {
+        XCTAssertTrue(SettingsStore.isValidHostBrowserCdpInspectHost("localhost"))
+        XCTAssertTrue(SettingsStore.isValidHostBrowserCdpInspectHost("127.0.0.1"))
+        XCTAssertTrue(SettingsStore.isValidHostBrowserCdpInspectHost("::1"))
+        XCTAssertTrue(SettingsStore.isValidHostBrowserCdpInspectHost("[::1]"))
+        XCTAssertTrue(SettingsStore.isValidHostBrowserCdpInspectHost("LOCALHOST"))
+        XCTAssertTrue(SettingsStore.isValidHostBrowserCdpInspectHost("  localhost  "))
+
+        XCTAssertFalse(SettingsStore.isValidHostBrowserCdpInspectHost(""))
+        XCTAssertFalse(SettingsStore.isValidHostBrowserCdpInspectHost("example.com"))
+        XCTAssertFalse(SettingsStore.isValidHostBrowserCdpInspectHost("192.168.0.1"))
+        XCTAssertFalse(SettingsStore.isValidHostBrowserCdpInspectHost("0.0.0.0"))
+    }
+
+    func testIsValidHostBrowserCdpInspectPort() {
+        XCTAssertTrue(SettingsStore.isValidHostBrowserCdpInspectPort(1))
+        XCTAssertTrue(SettingsStore.isValidHostBrowserCdpInspectPort(9222))
+        XCTAssertTrue(SettingsStore.isValidHostBrowserCdpInspectPort(65535))
+
+        XCTAssertFalse(SettingsStore.isValidHostBrowserCdpInspectPort(0))
+        XCTAssertFalse(SettingsStore.isValidHostBrowserCdpInspectPort(-1))
+        XCTAssertFalse(SettingsStore.isValidHostBrowserCdpInspectPort(65536))
+    }
+
+    // MARK: - applyHostBrowserCdpInspectConfig
+
+    func testApplyDaemonConfigAcceptsValidValues() {
+        // Reset to known-distinct values so we can verify the apply path
+        // overwrites them with the config payload.
+        store.hostBrowserCdpInspectEnabled = false
+        store.hostBrowserCdpInspectHost = "localhost"
+        store.hostBrowserCdpInspectPort = 9222
+
+        let config: [String: Any] = [
+            "hostBrowser": [
+                "cdpInspect": [
+                    "enabled": true,
+                    "host": "127.0.0.1",
+                    "port": 9333,
+                    "probeTimeoutMs": 750,
+                ]
+            ]
+        ]
+        SettingsStore.applyHostBrowserCdpInspectConfig(config, into: store)
+
+        XCTAssertTrue(store.hostBrowserCdpInspectEnabled)
+        XCTAssertEqual(store.hostBrowserCdpInspectHost, "127.0.0.1")
+        XCTAssertEqual(store.hostBrowserCdpInspectPort, 9333)
+        XCTAssertEqual(store.hostBrowserCdpInspectProbeTimeoutMs, 750)
+    }
+
+    func testApplyDaemonConfigRejectsNonLoopbackHost() {
+        // Pre-seed with a valid non-default value so we can distinguish
+        // "left untouched" from "reset to default" in the assertion.
+        store.hostBrowserCdpInspectHost = "127.0.0.1"
+
+        let config: [String: Any] = [
+            "hostBrowser": [
+                "cdpInspect": [
+                    "host": "attacker.example.com",
+                ]
+            ]
+        ]
+        SettingsStore.applyHostBrowserCdpInspectConfig(config, into: store)
+
+        // Invalid host should fall back to the default, NOT persist
+        // "attacker.example.com" and NOT silently leave the old value.
+        XCTAssertEqual(store.hostBrowserCdpInspectHost, SettingsStore.defaultHostBrowserCdpInspectHost)
+        XCTAssertEqual(store.hostBrowserCdpInspectHost, "localhost")
+    }
+
+    func testApplyDaemonConfigRejectsPublicIPHost() {
+        store.hostBrowserCdpInspectHost = "127.0.0.1"
+        let config: [String: Any] = [
+            "hostBrowser": [
+                "cdpInspect": [
+                    "host": "192.168.1.10",
+                ]
+            ]
+        ]
+        SettingsStore.applyHostBrowserCdpInspectConfig(config, into: store)
+        XCTAssertEqual(store.hostBrowserCdpInspectHost, "localhost")
+    }
+
+    func testApplyDaemonConfigRejectsOutOfRangePort() {
+        store.hostBrowserCdpInspectPort = 9333
+
+        let config: [String: Any] = [
+            "hostBrowser": [
+                "cdpInspect": [
+                    "port": 70000,
+                ]
+            ]
+        ]
+        SettingsStore.applyHostBrowserCdpInspectConfig(config, into: store)
+
+        // Out-of-range port should fall back to the default.
+        XCTAssertEqual(store.hostBrowserCdpInspectPort, SettingsStore.defaultHostBrowserCdpInspectPort)
+        XCTAssertEqual(store.hostBrowserCdpInspectPort, 9222)
+    }
+
+    func testApplyDaemonConfigRejectsZeroPort() {
+        store.hostBrowserCdpInspectPort = 9333
+        let config: [String: Any] = [
+            "hostBrowser": [
+                "cdpInspect": [
+                    "port": 0,
+                ]
+            ]
+        ]
+        SettingsStore.applyHostBrowserCdpInspectConfig(config, into: store)
+        XCTAssertEqual(store.hostBrowserCdpInspectPort, 9222)
+    }
+
+    func testApplyDaemonConfigRejectsOutOfRangePortFromDouble() {
+        store.hostBrowserCdpInspectPort = 9333
+        // JSONSerialization may surface integral numbers as Double; ensure
+        // the validation applies in that path too.
+        let config: [String: Any] = [
+            "hostBrowser": [
+                "cdpInspect": [
+                    "port": Double(70000),
+                ]
+            ]
+        ]
+        SettingsStore.applyHostBrowserCdpInspectConfig(config, into: store)
+        XCTAssertEqual(store.hostBrowserCdpInspectPort, 9222)
+    }
+
+    func testApplyDaemonConfigRejectsBothInvalidHostAndPort() {
+        store.hostBrowserCdpInspectHost = "127.0.0.1"
+        store.hostBrowserCdpInspectPort = 9333
+
+        let config: [String: Any] = [
+            "hostBrowser": [
+                "cdpInspect": [
+                    "host": "attacker.example.com",
+                    "port": -5,
+                ]
+            ]
+        ]
+        SettingsStore.applyHostBrowserCdpInspectConfig(config, into: store)
+
+        XCTAssertEqual(store.hostBrowserCdpInspectHost, "localhost")
+        XCTAssertEqual(store.hostBrowserCdpInspectPort, 9222)
+    }
+
+    func testApplyDaemonConfigIgnoresEmptyHostAndLeavesExistingValue() {
+        store.hostBrowserCdpInspectHost = "127.0.0.1"
+        let config: [String: Any] = [
+            "hostBrowser": [
+                "cdpInspect": [
+                    "host": "",
+                ]
+            ]
+        ]
+        SettingsStore.applyHostBrowserCdpInspectConfig(config, into: store)
+        // Empty host is a "key not set" signal, not invalid — we leave the
+        // existing value untouched (same contract as missing keys).
+        XCTAssertEqual(store.hostBrowserCdpInspectHost, "127.0.0.1")
+    }
+
+    // MARK: - Sanitize-and-patch-back behaviour
+
+    func testApplyDaemonConfigPatchesSanitizedHostBackToDaemon() {
+        // An invalid (non-loopback) host from the daemon must be both
+        // sanitized in-memory AND persisted back to the daemon config so
+        // the bad value does not reappear on the next reload.
+        XCTAssertTrue(mockSettingsClient.patchConfigCalls.isEmpty)
+
+        let config: [String: Any] = [
+            "hostBrowser": [
+                "cdpInspect": [
+                    "host": "attacker.example.com",
+                ]
+            ]
+        ]
+        SettingsStore.applyHostBrowserCdpInspectConfig(config, into: store)
+
+        // In-memory fallback applies immediately.
+        XCTAssertEqual(store.hostBrowserCdpInspectHost, "localhost")
+
+        // A patch with the sanitized default is emitted asynchronously.
+        waitForPatchCount(1)
+        let patch = lastCdpInspectPatch()
+        XCTAssertNotNil(patch, "expected a hostBrowser.cdpInspect patch payload")
+        XCTAssertEqual(patch?["host"] as? String, "localhost")
+        XCTAssertNil(patch?["port"])
+        XCTAssertNil(patch?["enabled"])
+    }
+
+    func testApplyDaemonConfigPatchesSanitizedPortBackToDaemon() {
+        // An out-of-range port from the daemon must be both sanitized
+        // in-memory AND persisted back to the daemon config so the bad
+        // value does not reappear on the next reload.
+        XCTAssertTrue(mockSettingsClient.patchConfigCalls.isEmpty)
+
+        let config: [String: Any] = [
+            "hostBrowser": [
+                "cdpInspect": [
+                    "port": 70000,
+                ]
+            ]
+        ]
+        SettingsStore.applyHostBrowserCdpInspectConfig(config, into: store)
+
+        // In-memory fallback applies immediately.
+        XCTAssertEqual(store.hostBrowserCdpInspectPort, 9222)
+
+        // A patch with the sanitized default is emitted asynchronously.
+        waitForPatchCount(1)
+        let patch = lastCdpInspectPatch()
+        XCTAssertNotNil(patch, "expected a hostBrowser.cdpInspect patch payload")
+        XCTAssertEqual(patch?["port"] as? Int, 9222)
+        XCTAssertNil(patch?["host"])
+        XCTAssertNil(patch?["enabled"])
+    }
+
+    func testApplyDaemonConfigPatchesBothSanitizedHostAndPortBackToDaemon() {
+        XCTAssertTrue(mockSettingsClient.patchConfigCalls.isEmpty)
+
+        let config: [String: Any] = [
+            "hostBrowser": [
+                "cdpInspect": [
+                    "host": "attacker.example.com",
+                    "port": -5,
+                ]
+            ]
+        ]
+        SettingsStore.applyHostBrowserCdpInspectConfig(config, into: store)
+
+        XCTAssertEqual(store.hostBrowserCdpInspectHost, "localhost")
+        XCTAssertEqual(store.hostBrowserCdpInspectPort, 9222)
+
+        // One patch per sanitization path.
+        waitForPatchCount(2)
+
+        // Assert BOTH sanitized fields were patched back, regardless of
+        // which order the two background tasks flushed in.
+        var sawHostPatch = false
+        var sawPortPatch = false
+        for payload in mockSettingsClient.patchConfigCalls {
+            guard let hostBrowser = payload["hostBrowser"] as? [String: Any],
+                  let cdpInspect = hostBrowser["cdpInspect"] as? [String: Any] else {
+                continue
+            }
+            if let host = cdpInspect["host"] as? String {
+                XCTAssertEqual(host, "localhost")
+                sawHostPatch = true
+            }
+            if let port = cdpInspect["port"] as? Int {
+                XCTAssertEqual(port, 9222)
+                sawPortPatch = true
+            }
+        }
+        XCTAssertTrue(sawHostPatch, "expected a patch setting host back to localhost")
+        XCTAssertTrue(sawPortPatch, "expected a patch setting port back to 9222")
+    }
+
+    func testApplyDaemonConfigDoesNotPatchWhenValuesAreValid() {
+        // Valid config values must NOT trigger a patch. This guards
+        // against any infinite-loop regression (patch -> refresh ->
+        // patch -> ...) in the normal happy path.
+        let config: [String: Any] = [
+            "hostBrowser": [
+                "cdpInspect": [
+                    "enabled": true,
+                    "host": "127.0.0.1",
+                    "port": 9333,
+                    "probeTimeoutMs": 750,
+                ]
+            ]
+        ]
+        SettingsStore.applyHostBrowserCdpInspectConfig(config, into: store)
+
+        // Give any stray background Task a chance to flush. If a patch
+        // were incorrectly emitted it would show up within this window.
+        let expectation = XCTestExpectation(description: "allow background tasks to flush")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { expectation.fulfill() }
+        wait(for: [expectation], timeout: 1.0)
+
+        XCTAssertTrue(
+            mockSettingsClient.patchConfigCalls.isEmpty,
+            "valid daemon config values must not trigger any patch"
+        )
+    }
+
+    func testApplyDaemonConfigDoesNotPatchWhenHostKeyIsAbsent() {
+        // Missing host key (or empty string, which is the same contract)
+        // must not trigger a patch — only an *invalid* value should.
+        let config: [String: Any] = [
+            "hostBrowser": [
+                "cdpInspect": [
+                    "enabled": true,
+                ]
+            ]
+        ]
+        SettingsStore.applyHostBrowserCdpInspectConfig(config, into: store)
+
+        let expectation = XCTestExpectation(description: "allow background tasks to flush")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { expectation.fulfill() }
+        wait(for: [expectation], timeout: 1.0)
+
+        XCTAssertTrue(mockSettingsClient.patchConfigCalls.isEmpty)
+    }
+}

--- a/docs/browser-use-architecture-phase2.md
+++ b/docs/browser-use-architecture-phase2.md
@@ -248,5 +248,9 @@ Alternatives considered:
 - Playwright / `chrome --remote-debugging-port` in a sacrificial profile
   avoids the infobar but requires installing Chromium and is out-of-
   scope (Phase 5).
-- Chrome 146+ `chrome://inspect` attach backend may offer a less
-  intrusive UX and is being tracked for Phase 4.
+- The assistant-local `cdp-inspect` backend attaches to an existing
+  Chrome instance via `chrome://inspect` / `--remote-debugging-port`
+  and avoids the per-tab debugger infobar entirely. It is implemented
+  and opt-in via `hostBrowser.cdpInspect.enabled`; see
+  [Browser Use — `cdp-inspect` Backend](./browser-use-cdp-inspect-backend.md)
+  for setup, security trade-offs, and troubleshooting.

--- a/docs/browser-use-cdp-inspect-backend.md
+++ b/docs/browser-use-cdp-inspect-backend.md
@@ -1,0 +1,156 @@
+# Browser Use — `cdp-inspect` Backend
+
+The `cdp-inspect` backend connects the assistant directly to an
+already-running Chrome instance via the DevTools JSON protocol
+(`--remote-debugging-port`). It avoids the per-tab debugger infobar
+that the Chrome extension transport shows, at the cost of broader
+session-level access.
+
+## Backend comparison
+
+| | **Extension** | **cdp-inspect** | **Local** |
+|---|---|---|---|
+| Chrome instance | User's own Chrome via chrome.debugger | User's own Chrome via `--remote-debugging-port` | Sacrificial-profile Chromium managed by Playwright |
+| Requires install | Chrome extension | None (Chrome flag only) | Playwright browser download |
+| Debugger infobar | Yes (per tab) | No | No (dedicated profile) |
+| Tab scope | Single active tab | Any open tab | Dedicated browser |
+| Auth/session access | Active tab only | All tabs, all cookies | Isolated profile |
+| Selection priority | 1st (highest) | 2nd (when enabled) | 3rd (default fallback) |
+
+## When to use this backend
+
+**Prefer the Chrome extension.** It provides the best security boundary
+(single-tab scope, visible debugger infobar, chrome.debugger permission
+model) and requires no special Chrome launch flags.
+
+Use `cdp-inspect` only when:
+
+- You cannot install the Chrome extension (e.g. enterprise policy,
+  Chromium-based browser without extension support).
+- You want to avoid the yellow "started debugging this browser" infobar
+  that `chrome.debugger.attach` displays.
+- You are running in a headless/CI environment where a user-profile
+  Chrome is already running with `--remote-debugging-port`.
+
+## Security considerations
+
+### Real-session control
+
+When the assistant attaches via `cdp-inspect`, it can read and act on
+**any tab** in the target Chrome instance — including tabs with active
+sessions for email, banking, chat, and other authenticated services.
+The extension backend, by contrast, only operates on the single tab the
+user activates.
+
+### Phishing and page-content risk
+
+DOM content retrieved via CDP is untrusted. The extension backend
+mitigates this partially through the `chrome.debugger` permission model
+and the visible infobar, which signals to the user that debugging is
+active. The `cdp-inspect` backend has no equivalent per-site allowlist
+or visible indicator in the browser chrome.
+
+### Loopback-only by policy
+
+The discovery layer (`probeDevToolsJsonVersion`) refuses to connect to
+any host that is not `localhost` or `127.0.0.1`. Remote attach is
+rejected with a `non_loopback` error before any network I/O occurs.
+
+**Warning:** The Chrome DevTools HTTP/WebSocket port has **no
+authentication**. Any process on the same machine can connect to it.
+Only enable `--remote-debugging-port` on machines where you trust all
+running processes.
+
+## Enabling the backend
+
+### macOS Settings UI
+
+Open **macOS Settings → Developer → Browser backend** and select the
+**"Use your own Chrome (Advanced)"** card. This sets the config key
+below automatically.
+
+### JSON config
+
+Add or update the following keys in your assistant config
+(`~/.vellum/workspace/config.json`):
+
+```json
+{
+  "hostBrowser": {
+    "cdpInspect": {
+      "enabled": true,
+      "host": "localhost",
+      "port": 9222,
+      "probeTimeoutMs": 500
+    }
+  }
+}
+```
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `hostBrowser.cdpInspect.enabled` | boolean | `false` | Enable the cdp-inspect backend. |
+| `hostBrowser.cdpInspect.host` | string | `"localhost"` | Loopback host for the DevTools endpoint. Must be `localhost` or `127.0.0.1`. |
+| `hostBrowser.cdpInspect.port` | number | `9222` | TCP port matching `--remote-debugging-port`. |
+| `hostBrowser.cdpInspect.probeTimeoutMs` | number | `500` | Timeout (ms) for the discovery probe. Increase if Chrome is slow to respond. |
+
+## Launching Chrome with remote debugging
+
+You must launch Chrome with `--remote-debugging-port` before the
+assistant can attach. Close all existing Chrome instances first, then
+run one of the commands below.
+
+### macOS
+
+```bash
+/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome \
+  --remote-debugging-port=9222
+```
+
+### Linux
+
+```bash
+google-chrome --remote-debugging-port=9222
+```
+
+### Windows
+
+```powershell
+& "C:\Program Files\Google\Chrome\Application\chrome.exe" `
+  --remote-debugging-port=9222
+```
+
+> **Tip:** If Chrome is already running without the flag, the port will
+> not be opened. Quit Chrome completely and relaunch with the flag.
+
+## Verifying the DevTools endpoint
+
+Once Chrome is running with `--remote-debugging-port`, confirm the
+endpoint is reachable:
+
+```bash
+# Version info — confirms Chrome is listening
+curl http://localhost:9222/json/version
+
+# Open targets — lists all debuggable tabs/pages
+curl http://localhost:9222/json/list
+```
+
+A successful `/json/version` response contains `Browser`, `Protocol-Version`,
+and `webSocketDebuggerUrl` fields. A successful `/json/list` response is
+a JSON array of target objects, each with `id`, `type`, `title`, `url`,
+and `webSocketDebuggerUrl`.
+
+## Troubleshooting
+
+The assistant surfaces `DevToolsDiscoveryError` codes when the
+cdp-inspect backend cannot reach or identify the DevTools endpoint.
+
+| Error code | Likely cause | Fix |
+|---|---|---|
+| `unreachable` | Chrome is not running with `--remote-debugging-port`, or the configured port is wrong. | Launch Chrome with `--remote-debugging-port=9222` and verify with `curl http://localhost:9222/json/version`. |
+| `non_loopback` | The configured `host` is not `localhost` or `127.0.0.1`. | Set `hostBrowser.cdpInspect.host` to `"localhost"`. Remote attach is refused by policy. |
+| `non_chrome` | Something other than Chrome is bound to port 9222. | Check what process is using the port (`lsof -i :9222` on macOS/Linux) and either stop it or change the configured port. |
+| `invalid_response` | The port responds but is not speaking the DevTools protocol. | Verify with `curl http://localhost:9222/json/version`. If the response is not valid JSON with a `Browser` field, another service is using the port. |
+| `no_targets` | Chrome is running but has no open tabs or pages. | Open at least one tab in Chrome before using browser tools. |
+| `timeout` | Chrome is slow to respond to the discovery probe. | Increase `hostBrowser.cdpInspect.probeTimeoutMs` (max 5000). |

--- a/docs/browser-use-cdp-inspect-backend.md
+++ b/docs/browser-use-cdp-inspect-backend.md
@@ -53,7 +53,7 @@ or visible indicator in the browser chrome.
 ### Loopback-only by policy
 
 The discovery layer (`probeDevToolsJsonVersion`) refuses to connect to
-any host that is not `localhost` or `127.0.0.1`. Remote attach is
+any host that is not `localhost`, `127.0.0.1`, `::1`, or `[::1]`. Remote attach is
 rejected with a `non_loopback` error before any network I/O occurs.
 
 **Warning:** The Chrome DevTools HTTP/WebSocket port has **no
@@ -90,7 +90,7 @@ Add or update the following keys in your assistant config
 | Key | Type | Default | Description |
 |---|---|---|---|
 | `hostBrowser.cdpInspect.enabled` | boolean | `false` | Enable the cdp-inspect backend. |
-| `hostBrowser.cdpInspect.host` | string | `"localhost"` | Loopback host for the DevTools endpoint. Must be `localhost` or `127.0.0.1`. |
+| `hostBrowser.cdpInspect.host` | string | `"localhost"` | Loopback host for the DevTools endpoint. Must be `localhost`, `127.0.0.1`, `::1`, or `[::1]`. |
 | `hostBrowser.cdpInspect.port` | number | `9222` | TCP port matching `--remote-debugging-port`. |
 | `hostBrowser.cdpInspect.probeTimeoutMs` | number | `500` | Timeout (ms) for the discovery probe. Increase if Chrome is slow to respond. |
 
@@ -149,7 +149,7 @@ cdp-inspect backend cannot reach or identify the DevTools endpoint.
 | Error code | Likely cause | Fix |
 |---|---|---|
 | `unreachable` | Chrome is not running with `--remote-debugging-port`, or the configured port is wrong. | Launch Chrome with `--remote-debugging-port=9222` and verify with `curl http://localhost:9222/json/version`. |
-| `non_loopback` | The configured `host` is not `localhost` or `127.0.0.1`. | Set `hostBrowser.cdpInspect.host` to `"localhost"`. Remote attach is refused by policy. |
+| `non_loopback` | The configured `host` is not `localhost`, `127.0.0.1`, `::1`, or `[::1]`. | Set `hostBrowser.cdpInspect.host` to `"localhost"`. Remote attach is refused by policy. |
 | `non_chrome` | Something other than Chrome is bound to port 9222. | Check what process is using the port (`lsof -i :9222` on macOS/Linux) and either stop it or change the configured port. |
 | `invalid_response` | The port responds but is not speaking the DevTools protocol. | Verify with `curl http://localhost:9222/json/version`. If the response is not valid JSON with a `Browser` field, another service is using the port. |
 | `no_targets` | Chrome is running but has no open tabs or pages. | Open at least one tab in Chrome before using browser tools. |


### PR DESCRIPTION
## Summary
Implement the `cdp-inspect` browser backend that drives a user's existing Chrome instance via DevTools `--remote-debugging-port`, as an advanced fallback when the Chrome extension is not available.

## Self-review result
GAPS FOUND — 3 minor gaps fixed across 3 fix PRs (stale doc comments + docs missing IPv6 loopback hosts)

## PRs merged into feature branch
- #24602: feat(browser): add reusable CDP JSON-RPC WebSocket transport for cdp-inspect
- #24601: feat(browser): add DevTools discovery and target-selection helpers for cdp-inspect
- #24599: feat(browser): add cdp-inspect type unions and hostBrowser config schema
- #24607: feat(browser): add CdpInspectClient and cdp-inspect BrowserSession backend adapter
- #24608: feat(settings): add advanced Use your own Chrome card with security explainer
- #24619: feat(browser): route to cdp-inspect client when configured and extension is absent

### Fix PRs
- #24620: fix(docs): list all four loopback hosts in cdp-inspect docs
- #24621: fix: mention CdpInspectClient in CdpClient interface JSDoc
- #24622: fix: reword cdp-inspect backend comment to present tense

Part of plan: browser-cdp-inspect-phase4.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24623" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
