### PR TITLE
feat(macos): render inline <thinking> tags as collapsible blocks

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -364,7 +364,13 @@ struct ChatBubble: View, Equatable {
                             onRetry: onRetryConversationError
                         )
                     } else if shouldShowBubble {
-                        bubbleContent
+                        if !isUser,
+                           containsInlineThinkingTag(message.text),
+                           MacOSClientFeatureFlagManager.shared.isEnabled("show-thinking-blocks") {
+                            bubbleContentWithInlineThinking
+                        } else {
+                            bubbleContent
+                        }
                     }
 
                     // Inline surfaces render below the bubble as full-width cards
@@ -570,11 +576,52 @@ struct ChatBubble: View, Equatable {
 
     @ViewBuilder
     private var bubbleContent: some View {
+        bubbleContent(renderingText: message.text, hasRenderedText: hasText)
+    }
+
+    /// Assistant-only wrapper that lifts inline `<thinking>...</thinking>`
+    /// tags out of `message.text` into collapsible `ThinkingBlockView`s
+    /// rendered alongside a bubble that contains the remaining content.
+    /// This keeps the transformation at the presentation layer — the
+    /// streaming pipeline and `ChatMessage` data model are unchanged.
+    @ViewBuilder
+    private var bubbleContentWithInlineThinking: some View {
+        let chunks = parseInlineThinkingTags(message.text)
+        let thinkingChunks: [String] = chunks.compactMap { chunk in
+            if case .thinking(let body) = chunk { return body }
+            return nil
+        }
+        let textChunks: [String] = chunks.compactMap { chunk in
+            if case .text(let body) = chunk { return body }
+            return nil
+        }
+        let joinedText = textChunks
+            .joined(separator: "\n\n")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let hasRenderedText = !joinedText.isEmpty
+        let hasAttachments = !message.attachments.isEmpty
+
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            ForEach(Array(thinkingChunks.enumerated()), id: \.offset) { _, content in
+                ThinkingBlockView(
+                    content: content,
+                    isStreaming: message.isStreaming,
+                    typographyGeneration: typographyGeneration
+                )
+            }
+            if hasRenderedText || hasAttachments {
+                bubbleContent(renderingText: joinedText, hasRenderedText: hasRenderedText)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func bubbleContent(renderingText: String, hasRenderedText: Bool) -> some View {
         let partitioned = partitionedAttachments
         let chrome = bubbleChrome {
             VStack(alignment: .leading, spacing: VSpacing.sm) {
-                if hasText {
-                    let segments = resolveSegments(for: message.text, isStreaming: message.isStreaming)
+                if hasRenderedText {
+                    let segments = resolveSegments(for: renderingText, isStreaming: message.isStreaming)
                     // Always render through MarkdownSegmentView to keep view
                     // identity stable across async segment parsing transitions.
                     // When a large message first renders, resolveSegments returns

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
@@ -7,8 +7,47 @@ extension ChatBubble {
     /// Render a single text segment as a styled bubble, with table and image support.
     /// For large messages (>500 chars) with a segment cache miss, renders plain text
     /// immediately and parses rich formatting asynchronously to avoid blocking scroll.
+    ///
+    /// When the text contains inline `<thinking>...</thinking>` tags (and the
+    /// `show-thinking-blocks` feature flag is enabled for assistant messages),
+    /// the tagged sections are lifted into collapsible `ThinkingBlockView`s
+    /// rendered alongside text bubbles for the remaining content. This keeps
+    /// the transformation entirely at the presentation layer — no changes to
+    /// the message data model or streaming pipeline.
     @ViewBuilder
     func textBubble(for segmentText: String) -> some View {
+        if !isUser,
+           containsInlineThinkingTag(segmentText),
+           MacOSClientFeatureFlagManager.shared.isEnabled("show-thinking-blocks") {
+            let chunks = parseInlineThinkingTags(segmentText)
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
+                ForEach(Array(chunks.enumerated()), id: \.offset) { _, chunk in
+                    switch chunk {
+                    case .text(let body):
+                        let trimmed = body.trimmingCharacters(in: .whitespacesAndNewlines)
+                        if !trimmed.isEmpty {
+                            textBubbleChrome(for: trimmed)
+                        }
+                    case .thinking(let body):
+                        ThinkingBlockView(
+                            content: body,
+                            isStreaming: message.isStreaming,
+                            typographyGeneration: typographyGeneration
+                        )
+                    }
+                }
+            }
+        } else {
+            textBubbleChrome(for: segmentText)
+        }
+    }
+
+    /// Renders a single text segment inside the shared bubble chrome with
+    /// markdown parsing. Extracted from `textBubble(for:)` so the thinking-
+    /// tag dispatcher can reuse the same rendering for the text chunks it
+    /// produces.
+    @ViewBuilder
+    fileprivate func textBubbleChrome(for segmentText: String) -> some View {
         let streaming = message.isStreaming
         let segments = resolveSegments(for: segmentText, isStreaming: streaming)
 

--- a/clients/macos/vellum-assistant/Features/Chat/InlineThinkingTagParser.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/InlineThinkingTagParser.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+/// A parsed chunk of assistant text — either regular text or extracted
+/// `<thinking>` content that should render inside a collapsible
+/// ThinkingBlockView. This lets the UI lift inline thinking tags out of
+/// the text bubble without requiring any backend or view-model changes.
+enum InlineContentChunk: Hashable {
+    case text(String)
+    case thinking(String)
+}
+
+/// Parses assistant response text for `<thinking>...</thinking>` tags,
+/// returning an ordered list of chunks. Chunks preserve source order so
+/// the caller can render thinking blocks inline at the position they
+/// appear in the text.
+///
+/// An unclosed `<thinking>` tag (common while a response is still
+/// streaming in) is treated as an in-progress thinking block containing
+/// all remaining text — this way the thinking content streams into the
+/// collapsible block as soon as the opening tag arrives, instead of
+/// flashing the raw tag until the close tag finally shows up.
+///
+/// The parser is case-sensitive and only matches the exact lowercase
+/// `<thinking>` / `</thinking>` pair emitted by the model.
+func parseInlineThinkingTags(_ text: String) -> [InlineContentChunk] {
+    // Fast path: no opening tag, return the whole string as a single
+    // text chunk. Cheap contains check avoids the full scan below for
+    // the vast majority of messages that don't use thinking tags.
+    guard text.contains("<thinking>") else {
+        return [.text(text)]
+    }
+
+    var chunks: [InlineContentChunk] = []
+    var cursor = text.startIndex
+
+    while let openRange = text.range(of: "<thinking>", range: cursor..<text.endIndex) {
+        // Capture any text between the previous cursor and the opening
+        // tag. Keep the original substring (not trimmed) so markdown
+        // spacing is preserved when it renders.
+        if openRange.lowerBound > cursor {
+            let preceding = String(text[cursor..<openRange.lowerBound])
+            if !preceding.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                chunks.append(.text(preceding))
+            }
+        }
+
+        if let closeRange = text.range(of: "</thinking>", range: openRange.upperBound..<text.endIndex) {
+            let body = String(text[openRange.upperBound..<closeRange.lowerBound])
+            let bodyTrimmed = body.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !bodyTrimmed.isEmpty {
+                chunks.append(.thinking(bodyTrimmed))
+            }
+            cursor = closeRange.upperBound
+        } else {
+            // Unclosed tag: treat the remainder of the text as
+            // streaming thinking content so the user sees it accumulate
+            // inside the collapsible block rather than as raw markup.
+            let body = String(text[openRange.upperBound..<text.endIndex])
+            let bodyTrimmed = body.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !bodyTrimmed.isEmpty {
+                chunks.append(.thinking(bodyTrimmed))
+            }
+            return chunks
+        }
+    }
+
+    // Flush any trailing text after the last closing tag.
+    if cursor < text.endIndex {
+        let trailing = String(text[cursor..<text.endIndex])
+        if !trailing.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            chunks.append(.text(trailing))
+        }
+    }
+
+    return chunks
+}
+
+/// Whether the given text contains at least one `<thinking>` opening
+/// tag. Exposed as a cheap check callers can run before calling
+/// `parseInlineThinkingTags` to decide whether to take the fast path.
+func containsInlineThinkingTag(_ text: String) -> Bool {
+    text.contains("<thinking>")
+}

--- a/clients/macos/vellum-assistantTests/InlineThinkingTagParserTests.swift
+++ b/clients/macos/vellum-assistantTests/InlineThinkingTagParserTests.swift
@@ -1,0 +1,105 @@
+import XCTest
+@testable import VellumAssistantLib
+
+final class InlineThinkingTagParserTests: XCTestCase {
+    func testNoTagsReturnsSingleTextChunk() {
+        let chunks = parseInlineThinkingTags("just a normal response")
+        XCTAssertEqual(chunks, [.text("just a normal response")])
+    }
+
+    func testEmptyInputReturnsSingleEmptyTextChunk() {
+        // Fast path: no `<thinking>` substring, returns whole string as-is.
+        let chunks = parseInlineThinkingTags("")
+        XCTAssertEqual(chunks, [.text("")])
+    }
+
+    func testSingleClosedThinkingBlockAtStart() {
+        let input = "<thinking>planning the response</thinking>\n\nhere's my answer"
+        let chunks = parseInlineThinkingTags(input)
+        XCTAssertEqual(chunks.count, 2)
+        XCTAssertEqual(chunks[0], .thinking("planning the response"))
+        if case .text(let body) = chunks[1] {
+            XCTAssertEqual(body.trimmingCharacters(in: .whitespacesAndNewlines), "here's my answer")
+        } else {
+            XCTFail("expected second chunk to be text")
+        }
+    }
+
+    func testThinkingOnlyProducesSingleThinkingChunk() {
+        let input = "<thinking>just reasoning, no response yet</thinking>"
+        let chunks = parseInlineThinkingTags(input)
+        XCTAssertEqual(chunks, [.thinking("just reasoning, no response yet")])
+    }
+
+    func testUnclosedTagTreatsRemainderAsStreamingThinking() {
+        // During streaming the closing tag may not have arrived yet.
+        // The partial thinking content should still render inside a
+        // collapsible block instead of flashing raw markup.
+        let input = "<thinking>still figuring this out"
+        let chunks = parseInlineThinkingTags(input)
+        XCTAssertEqual(chunks, [.thinking("still figuring this out")])
+    }
+
+    func testTextBeforeUnclosedTagIsPreserved() {
+        let input = "prelude text <thinking>mid-thought"
+        let chunks = parseInlineThinkingTags(input)
+        XCTAssertEqual(chunks.count, 2)
+        if case .text(let body) = chunks[0] {
+            XCTAssertEqual(body.trimmingCharacters(in: .whitespacesAndNewlines), "prelude text")
+        } else {
+            XCTFail("expected first chunk to be text")
+        }
+        XCTAssertEqual(chunks[1], .thinking("mid-thought"))
+    }
+
+    func testMultipleThinkingBlocksInterleavedWithText() {
+        let input = "<thinking>first</thinking>one<thinking>second</thinking>two"
+        let chunks = parseInlineThinkingTags(input)
+        XCTAssertEqual(chunks.count, 4)
+        XCTAssertEqual(chunks[0], .thinking("first"))
+        if case .text(let a) = chunks[1] {
+            XCTAssertEqual(a.trimmingCharacters(in: .whitespacesAndNewlines), "one")
+        } else {
+            XCTFail("expected chunk[1] to be text")
+        }
+        XCTAssertEqual(chunks[2], .thinking("second"))
+        if case .text(let b) = chunks[3] {
+            XCTAssertEqual(b.trimmingCharacters(in: .whitespacesAndNewlines), "two")
+        } else {
+            XCTFail("expected chunk[3] to be text")
+        }
+    }
+
+    func testWhitespaceOnlyTextBetweenTagsIsDropped() {
+        // When the model's output is `</thinking>\n\n<thinking>` back to back,
+        // the whitespace between the tags shouldn't produce an empty text
+        // chunk that would waste a rendering slot.
+        let input = "<thinking>a</thinking>\n\n<thinking>b</thinking>"
+        let chunks = parseInlineThinkingTags(input)
+        XCTAssertEqual(chunks, [.thinking("a"), .thinking("b")])
+    }
+
+    func testThinkingContentIsTrimmedButTextContentIsNot() {
+        // Thinking content is trimmed so the collapsed block doesn't have
+        // stray leading/trailing blank lines from tag positioning. Text
+        // content preserves original whitespace so markdown spacing isn't
+        // corrupted — it's up to the caller to trim when rendering.
+        let input = "<thinking>\n  padded reasoning  \n</thinking>   some reply  "
+        let chunks = parseInlineThinkingTags(input)
+        XCTAssertEqual(chunks.count, 2)
+        XCTAssertEqual(chunks[0], .thinking("padded reasoning"))
+        if case .text(let body) = chunks[1] {
+            XCTAssertEqual(body, "   some reply  ")
+        } else {
+            XCTFail("expected text chunk")
+        }
+    }
+
+    func testContainsInlineThinkingTag() {
+        XCTAssertFalse(containsInlineThinkingTag("plain text"))
+        XCTAssertTrue(containsInlineThinkingTag("<thinking>foo</thinking>"))
+        XCTAssertTrue(containsInlineThinkingTag("prelude <thinking>mid"))
+        // Close tag alone (no open) does not count as inline thinking.
+        XCTAssertFalse(containsInlineThinkingTag("</thinking> stray"))
+    }
+}


### PR DESCRIPTION
## Summary
- Adds \`InlineThinkingTagParser\` that splits assistant text into ordered text/thinking chunks, with a fast path for the common no-tag case and graceful handling of unclosed tags during streaming.
- Updates \`ChatBubble\` and \`ChatBubbleTextContent\` to dispatch to a new inline-thinking rendering path for assistant messages, lifting \`<thinking>...</thinking>\` into collapsible \`ThinkingBlockView\`s. Gated behind the existing \`show-thinking-blocks\` feature flag.
- Pure presentation-layer change — streaming pipeline and \`ChatMessage\` data model are untouched. Tests cover no-tag fast path, closed/unclosed tags, multiple interleaved blocks, and whitespace handling.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24624" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
