### PR TITLE
fix(macos): drop spurious await on main-actor onProgress call

### DIFF
--- a/clients/macos/vellum-assistant/App/AppleContainersLauncher.swift
+++ b/clients/macos/vellum-assistant/App/AppleContainersLauncher.swift
@@ -136,7 +136,7 @@ final class AppleContainersLauncher: AssistantManagementClient {
         // call. If we fail here, the fallback path in performInitialBootstrap()
         // generates a new random secret that the gateway will reject with 403.
         if let gatewayURL = runtime.gatewayURL {
-            await onProgress?("Securing connection...")
+            onProgress?("Securing connection...")
             let tokenLeased = await Self.leaseGuardianToken(
                 gatewayURL: gatewayURL,
                 assistantId: assistantName,


### PR DESCRIPTION
## Summary
- Remove unnecessary \`await\` on the \`onProgress?(\"Securing connection...\")\` call in \`AppleContainersLauncher.hatch\`. The enclosing method is already main-actor isolated, so calling the \`@MainActor\` closure is synchronous and the compiler flagged the \`await\` as having no async effect.
- The other two \`onProgress\` call sites remain unchanged — they run inside closures passed to \`runtime.start\` / \`LocalImageBuilder.buildAndLoadImages\`, which execute off the main actor and legitimately need \`await\` to hop back.

## Original prompt
\`\`\`
Fix: ~v/clients/macos (main) ❯❯❯ VELLUM_NO_WATCH=1 ./build.sh run
VELLUM_ENVIRONMENT=local
Building (debug)...
[1/1] Planning build
Building for debugging...
/Users/sidd/vocify/vellum-assistant/clients/macos/vellum-assistant/App/AppleContainersLauncher.swift:139:13: warning: no 'async' operations occur within 'await' expression
137 |         // generates a new random secret that the gateway will reject with 403.
138 |         if let gatewayURL = runtime.gatewayURL {
139 |             await onProgress?("Securing connection...")
    |             \`- warning: no 'async' operations occur within 'await' expression
140 |             let tokenLeased = await Self.leaseGuardianToken(
141 |                 gatewayURL: gatewayURL,
\`\`\`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24625" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
