### PR TITLE
refactor(macOS): deterministic TimelineView typing indicator with a11y support

### DIFF
--- a/clients/shared/Features/Chat/TypingIndicatorView.swift
+++ b/clients/shared/Features/Chat/TypingIndicatorView.swift
@@ -3,24 +3,28 @@ import SwiftUI
 /// Animated three-dot typing bubble shown while the assistant is thinking
 /// (before the first token or tool call arrives).
 public struct TypingIndicatorView: View {
-    @State private var animate = false
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    private let dotSize: CGFloat = 8
+    private let dotSpacing: CGFloat = 5
+    private let tickInterval: TimeInterval = 0.18
 
     public init() {}
 
     public var body: some View {
-        HStack(spacing: 5) {
-            ForEach(0..<3, id: \.self) { index in
-                Circle()
-                    .fill(VColor.contentTertiary)
-                    .frame(width: 8, height: 8)
-                    .scaleEffect(animate ? 1.0 : 0.5)
-                    .animation(
-                        .easeInOut(duration: 0.5)
-                            .repeatForever(autoreverses: true)
-                            .delay(Double(index) * 0.18),
-                        value: animate
-                    )
+        TimelineView(.periodic(from: .now, by: tickInterval)) { context in
+            let activeIndex = reduceMotion ? -1 : animationPhase(at: context.date)
+
+            HStack(spacing: dotSpacing) {
+                ForEach(0..<3, id: \.self) { index in
+                    Circle()
+                        .fill(VColor.contentTertiary)
+                        .frame(width: dotSize, height: dotSize)
+                        .scaleEffect(reduceMotion ? 1.0 : (activeIndex == index ? 1.0 : 0.6))
+                        .opacity(reduceMotion ? 0.7 : (activeIndex == index ? 1.0 : 0.45))
+                }
             }
+            .frame(width: intrinsicDotsWidth, height: dotSize, alignment: .center)
         }
         .padding(.horizontal, VSpacing.md)
         .padding(.vertical, VSpacing.sm)
@@ -28,11 +32,16 @@ public struct TypingIndicatorView: View {
             RoundedRectangle(cornerRadius: VRadius.lg)
                 .fill(VColor.surfaceOverlay)
         )
-        .onAppear {
-            animate = true
-        }
-        .onDisappear {
-            animate = false
-        }
+        .fixedSize()
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Assistant is thinking")
+    }
+
+    private var intrinsicDotsWidth: CGFloat {
+        dotSize * 3 + dotSpacing * 2
+    }
+
+    private func animationPhase(at date: Date) -> Int {
+        Int(date.timeIntervalSinceReferenceDate / tickInterval) % 3
     }
 }


### PR DESCRIPTION
## Summary
- Replace `@State animate` + `.repeatForever` with `TimelineView(.periodic)` for deterministic, phase-based dot animation
- Respect `accessibilityReduceMotion` — static dots at uniform opacity when enabled
- Add `accessibilityLabel("Assistant is thinking")` and `fixedSize()` for stable layout