### PR TITLE
fix: standardize divider colors to use borderBase across all contexts

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
@@ -106,7 +106,7 @@ struct DrawerMenuView: View {
     /// used for sections that should sit tight against neighboring rows.
     private var tightDividerLine: some View {
         Rectangle()
-            .fill(VColor.surfaceBase)
+            .fill(VColor.borderBase)
             .frame(height: 1)
     }
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsCard.swift
@@ -77,7 +77,7 @@ private struct ConditionalCardModifier: ViewModifier {
 struct SettingsDivider: View {
     var body: some View {
         Rectangle()
-            .fill(VColor.borderHover)
+            .fill(VColor.borderBase)
             .frame(height: 1)
     }
 }

--- a/clients/shared/DesignSystem/Components/Navigation/VMenu.swift
+++ b/clients/shared/DesignSystem/Components/Navigation/VMenu.swift
@@ -768,7 +768,7 @@ public struct VMenuDivider: View {
     public init() {}
 
     public var body: some View {
-        VColor.surfaceBase.frame(height: 1)
+        VColor.borderBase.frame(height: 1)
             .padding(.horizontal, VSpacing.xs)
             .padding(.vertical, VSpacing.xs)
             .accessibilityHidden(true)


### PR DESCRIPTION
## Summary
- Standardize SettingsDivider, DrawerMenuView divider, VMenuDivider to use VColor.borderBase
- Consistent divider appearance in light and dark mode

Part of plan: app-qa-7-4-2026-part1.md (PR 1 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24628" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
