### PR TITLE
fix: remove borders from all modal and sheet views

### DIFF
--- a/clients/macos/vellum-assistant/Features/Sharing/AppSharePanelView.swift
+++ b/clients/macos/vellum-assistant/Features/Sharing/AppSharePanelView.swift
@@ -33,10 +33,6 @@ struct AppSharePanelView: View {
         }
         .background(VColor.surfaceOverlay)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
-        .overlay(
-            RoundedRectangle(cornerRadius: VRadius.lg)
-                .stroke(VColor.borderBase, lineWidth: 1)
-        )
         .shadow(color: VColor.auxBlack.opacity(0.15), radius: 6, y: 2)
         .task {
             let url = fileURL


### PR DESCRIPTION
## Summary
- Remove .stroke() border overlay from AppSharePanelView
- Modals use shadow only (VModal pattern), no borders

Part of plan: app-qa-7-4-2026-part1.md (PR 2 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24629" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
