### PR TITLE
fix: render fallback placeholder with skills icon for missing skill images

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
@@ -179,7 +179,7 @@ struct AppsGridView: View {
                         ZStack {
                             VColor.surfaceBase
 
-                            VIconView(appIcon, size: 32)
+                            VIconView(.puzzle, size: 32)
                                 .foregroundStyle(VColor.contentTertiary)
                         }
                         .aspectRatio(16.0 / 10.0, contentMode: .fit)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillDetailView.swift
@@ -420,6 +420,9 @@ struct SkillDetailTitleRow: View {
                     if let emoji = skill.emoji, !emoji.isEmpty {
                         Text(emoji)
                             .font(.system(size: 20))
+                    } else {
+                        VIconView(.puzzle, size: 20)
+                            .foregroundStyle(VColor.contentTertiary)
                     }
 
                     Text(skill.name)


### PR DESCRIPTION
## Summary
- Add meaningful skill icon fallback when emoji is missing in SkillDetailView
- Update AppsGridView generic fallback to use skill-appropriate icon

Part of plan: app-qa-7-4-2026-part1.md (PR 6 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24630" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
