### PR TITLE
fix: hide fork option behind feature flag defaulting to false

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -232,7 +232,7 @@ struct ChatBubble: View, Equatable {
     }
 
     var canForkFromMessage: Bool {
-        onForkFromMessage != nil && message.daemonMessageId != nil && !message.isStreaming
+        onForkFromMessage != nil && message.daemonMessageId != nil && !message.isStreaming && MacOSClientFeatureFlagManager.shared.isEnabled("fork-from-message")
     }
 
     var canInspectMessage: Bool {

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleOverflowMenu.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleOverflowMenu.swift
@@ -43,7 +43,7 @@ struct ChatBubbleOverflowMenu: View {
     }
 
     private var canForkFromMessage: Bool {
-        onForkFromMessage != nil && message.daemonMessageId != nil && !message.isStreaming
+        onForkFromMessage != nil && message.daemonMessageId != nil && !message.isStreaming && MacOSClientFeatureFlagManager.shared.isEnabled("fork-from-message")
     }
 
     private var hasOverflowActions: Bool {

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -312,6 +312,14 @@
       "label": "Managed Gemini Embeddings Enabled",
       "description": "Route embedding requests through the platform runtime proxy using Vellum-managed Gemini credentials when available",
       "defaultEnabled": false
+    },
+    {
+      "id": "fork-from-message",
+      "scope": "macos",
+      "key": "fork-from-message",
+      "label": "Fork from Message",
+      "description": "Show the 'Fork from here' option in message overflow menus",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Register fork-from-message feature flag (default: false)
- Gate fork button in overflow menu and ChatBubble behind the flag
- Settable via VELLUM_FLAG_FORK_FROM_MESSAGE=true or UserDefaults

Part of plan: app-qa-7-4-2026-part1.md (PR 4 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24631" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
