### PR TITLE
fix: remove Copy/Save/Preview actions from attachment viewing surface

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
@@ -171,10 +171,6 @@ private struct AttachmentImageGrid<Fallback: View>: View {
     /// racing with the final decode failure always transitions the attachment out of the
     /// gray-placeholder state.
     @State private var failedIds: Set<String> = []
-    /// Sharing services pre-loaded per file extension so the context menu Share
-    /// submenu never triggers a synchronous XPC call during body evaluation.
-    @State private var sharingServicesByExt: [String: [NSSharingService]] = [:]
-
     @Environment(\.displayScale) private var displayScale
 
     /// Single images render at full width; multiple images use a compact grid.
@@ -198,17 +194,6 @@ private struct AttachmentImageGrid<Fallback: View>: View {
                     }
                         .onTapGesture {
                             onTap(attachment, nsImage)
-                        }
-                        .contextMenu {
-                            let ext = (attachment.filename as NSString).pathExtension.lowercased()
-                            let key = ext.isEmpty ? "png" : ext
-                            ImageActions.contextMenuItems(
-                                image: nsImage,
-                                filename: attachment.filename,
-                                base64Data: attachment.data.isEmpty ? nil : attachment.data,
-                                lazyAttachmentId: attachment.isLazyLoad ? attachment.id : nil,
-                                sharingServices: sharingServicesByExt[key] ?? []
-                            )
                         }
                         .onDrag {
                             NotificationCenter.default.post(name: .internalImageDragStarted, object: nil)
@@ -373,16 +358,8 @@ private struct AttachmentImageGrid<Fallback: View>: View {
                 }
             }
         }
-        .task(id: imageAttachments.map(\.filename)) {
-            let extensions = Set(imageAttachments.map {
-                let ext = ($0.filename as NSString).pathExtension.lowercased()
-                return ext.isEmpty ? "png" : ext
-            })
-            for ext in extensions where sharingServicesByExt[ext] == nil {
-                let services = await ImageActions.loadSharingServices(for: "probe.\(ext)")
-                sharingServicesByExt[ext] = services
-            }
-        }
+
+
     }
 
     /// Full-width rendering for a single image attachment, matching tool-generated image sizing.


### PR DESCRIPTION
## Summary
- Remove context menu (Copy/Save/Preview) from inline attachment images in chat
- Attachment images display without action overlay

Part of plan: app-qa-7-4-2026-part1.md (PR 7 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24632" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
