### PR TITLE
fix: make input borders borderless in dark mode, bordered in light mode

### DIFF
--- a/clients/shared/DesignSystem/Core/Inputs/VTextField.swift
+++ b/clients/shared/DesignSystem/Core/Inputs/VTextField.swift
@@ -60,6 +60,8 @@ public struct VInputChromeModifier: ViewModifier {
     public let isDisabled: Bool
     public let cornerRadius: CGFloat
 
+    @Environment(\.colorScheme) private var colorScheme
+
     public init(isFocused: Bool = false, isError: Bool = false, isDisabled: Bool = false, cornerRadius: CGFloat = VRadius.md) {
         self.isFocused = isFocused
         self.isError = isError
@@ -86,7 +88,7 @@ public struct VInputChromeModifier: ViewModifier {
         if isFocused {
             return VColor.borderActive
         }
-        return VColor.borderElement
+        return colorScheme == .dark ? Color.clear : VColor.borderElement
     }
 }
 


### PR DESCRIPTION
## Summary
- Dark mode inputs: no visible border in default state
- Light mode inputs: borderElement border (unchanged)
- Error/focus borders visible in both modes for accessibility

Part of plan: app-qa-7-4-2026-part1.md (PR 3 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24633" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
