### PR TITLE
fix: trigger share directly instead of showing single-action popover

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/DynamicWorkspaceWrapper.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/DynamicWorkspaceWrapper.swift
@@ -81,7 +81,11 @@ struct DynamicWorkspaceWrapper: View {
                                     .frame(height: 32)
                             } else {
                                 VButton(label: "Share", iconOnly: VIcon.share.rawValue, style: .outlined, iconSize: 32, tooltip: "Share") {
-                                    showShareDrawer.toggle()
+                                    if isDeployToVercelEnabled {
+                                        showShareDrawer.toggle()
+                                    } else if let appId = data.appId {
+                                        onBundleAndShare(appId)
+                                    }
                                 }
                                 .onGeometryChange(for: CGRect.self) { proxy in
                                     proxy.frame(in: .named("appPageContainer"))


### PR DESCRIPTION
## Summary
- Share button triggers system share directly instead of showing popover
- Removes intermediate single-action share drawer

Part of plan: app-qa-7-4-2026-part1.md (PR 5 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24634" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
