### PR TITLE
fix: App QA 7-4-2026 Part 1 — dividers, modals, inputs, fork, share, skills, attachments

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -232,7 +232,7 @@ struct ChatBubble: View, Equatable {
     }
 
     var canForkFromMessage: Bool {
-        onForkFromMessage != nil && message.daemonMessageId != nil && !message.isStreaming
+        onForkFromMessage != nil && message.daemonMessageId != nil && !message.isStreaming && MacOSClientFeatureFlagManager.shared.isEnabled("fork-from-message")
     }
 
     var canInspectMessage: Bool {

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
@@ -171,10 +171,6 @@ private struct AttachmentImageGrid<Fallback: View>: View {
     /// racing with the final decode failure always transitions the attachment out of the
     /// gray-placeholder state.
     @State private var failedIds: Set<String> = []
-    /// Sharing services pre-loaded per file extension so the context menu Share
-    /// submenu never triggers a synchronous XPC call during body evaluation.
-    @State private var sharingServicesByExt: [String: [NSSharingService]] = [:]
-
     @Environment(\.displayScale) private var displayScale
 
     /// Single images render at full width; multiple images use a compact grid.
@@ -198,17 +194,6 @@ private struct AttachmentImageGrid<Fallback: View>: View {
                     }
                         .onTapGesture {
                             onTap(attachment, nsImage)
-                        }
-                        .contextMenu {
-                            let ext = (attachment.filename as NSString).pathExtension.lowercased()
-                            let key = ext.isEmpty ? "png" : ext
-                            ImageActions.contextMenuItems(
-                                image: nsImage,
-                                filename: attachment.filename,
-                                base64Data: attachment.data.isEmpty ? nil : attachment.data,
-                                lazyAttachmentId: attachment.isLazyLoad ? attachment.id : nil,
-                                sharingServices: sharingServicesByExt[key] ?? []
-                            )
                         }
                         .onDrag {
                             NotificationCenter.default.post(name: .internalImageDragStarted, object: nil)
@@ -373,16 +358,8 @@ private struct AttachmentImageGrid<Fallback: View>: View {
                 }
             }
         }
-        .task(id: imageAttachments.map(\.filename)) {
-            let extensions = Set(imageAttachments.map {
-                let ext = ($0.filename as NSString).pathExtension.lowercased()
-                return ext.isEmpty ? "png" : ext
-            })
-            for ext in extensions where sharingServicesByExt[ext] == nil {
-                let services = await ImageActions.loadSharingServices(for: "probe.\(ext)")
-                sharingServicesByExt[ext] = services
-            }
-        }
+
+
     }
 
     /// Full-width rendering for a single image attachment, matching tool-generated image sizing.

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleOverflowMenu.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleOverflowMenu.swift
@@ -43,7 +43,7 @@ struct ChatBubbleOverflowMenu: View {
     }
 
     private var canForkFromMessage: Bool {
-        onForkFromMessage != nil && message.daemonMessageId != nil && !message.isStreaming
+        onForkFromMessage != nil && message.daemonMessageId != nil && !message.isStreaming && MacOSClientFeatureFlagManager.shared.isEnabled("fork-from-message")
     }
 
     private var hasOverflowActions: Bool {

--- a/clients/macos/vellum-assistant/Features/MainWindow/DynamicWorkspaceWrapper.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/DynamicWorkspaceWrapper.swift
@@ -81,7 +81,11 @@ struct DynamicWorkspaceWrapper: View {
                                     .frame(height: 32)
                             } else {
                                 VButton(label: "Share", iconOnly: VIcon.share.rawValue, style: .outlined, iconSize: 32, tooltip: "Share") {
-                                    showShareDrawer.toggle()
+                                    if isDeployToVercelEnabled {
+                                        showShareDrawer.toggle()
+                                    } else if let appId = data.appId {
+                                        onBundleAndShare(appId)
+                                    }
                                 }
                                 .onGeometryChange(for: CGRect.self) { proxy in
                                     proxy.frame(in: .named("appPageContainer"))

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
@@ -179,7 +179,7 @@ struct AppsGridView: View {
                         ZStack {
                             VColor.surfaceBase
 
-                            VIconView(appIcon, size: 32)
+                            VIconView(.puzzle, size: 32)
                                 .foregroundStyle(VColor.contentTertiary)
                         }
                         .aspectRatio(16.0 / 10.0, contentMode: .fit)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillDetailView.swift
@@ -420,6 +420,9 @@ struct SkillDetailTitleRow: View {
                     if let emoji = skill.emoji, !emoji.isEmpty {
                         Text(emoji)
                             .font(.system(size: 20))
+                    } else {
+                        VIconView(.puzzle, size: 20)
+                            .foregroundStyle(VColor.contentTertiary)
                     }
 
                     Text(skill.name)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
@@ -106,7 +106,7 @@ struct DrawerMenuView: View {
     /// used for sections that should sit tight against neighboring rows.
     private var tightDividerLine: some View {
         Rectangle()
-            .fill(VColor.surfaceBase)
+            .fill(VColor.borderBase)
             .frame(height: 1)
     }
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsCard.swift
@@ -77,7 +77,7 @@ private struct ConditionalCardModifier: ViewModifier {
 struct SettingsDivider: View {
     var body: some View {
         Rectangle()
-            .fill(VColor.borderHover)
+            .fill(VColor.borderBase)
             .frame(height: 1)
     }
 }

--- a/clients/macos/vellum-assistant/Features/Sharing/AppSharePanelView.swift
+++ b/clients/macos/vellum-assistant/Features/Sharing/AppSharePanelView.swift
@@ -33,10 +33,6 @@ struct AppSharePanelView: View {
         }
         .background(VColor.surfaceOverlay)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
-        .overlay(
-            RoundedRectangle(cornerRadius: VRadius.lg)
-                .stroke(VColor.borderBase, lineWidth: 1)
-        )
         .shadow(color: VColor.auxBlack.opacity(0.15), radius: 6, y: 2)
         .task {
             let url = fileURL

--- a/clients/shared/DesignSystem/Components/Navigation/VMenu.swift
+++ b/clients/shared/DesignSystem/Components/Navigation/VMenu.swift
@@ -768,7 +768,7 @@ public struct VMenuDivider: View {
     public init() {}
 
     public var body: some View {
-        VColor.surfaceBase.frame(height: 1)
+        VColor.borderBase.frame(height: 1)
             .padding(.horizontal, VSpacing.xs)
             .padding(.vertical, VSpacing.xs)
             .accessibilityHidden(true)

--- a/clients/shared/DesignSystem/Core/Inputs/VTextField.swift
+++ b/clients/shared/DesignSystem/Core/Inputs/VTextField.swift
@@ -60,6 +60,8 @@ public struct VInputChromeModifier: ViewModifier {
     public let isDisabled: Bool
     public let cornerRadius: CGFloat
 
+    @Environment(\.colorScheme) private var colorScheme
+
     public init(isFocused: Bool = false, isError: Bool = false, isDisabled: Bool = false, cornerRadius: CGFloat = VRadius.md) {
         self.isFocused = isFocused
         self.isError = isError
@@ -86,7 +88,7 @@ public struct VInputChromeModifier: ViewModifier {
         if isFocused {
             return VColor.borderActive
         }
-        return VColor.borderElement
+        return colorScheme == .dark ? Color.clear : VColor.borderElement
     }
 }
 

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -312,6 +312,14 @@
       "label": "Managed Gemini Embeddings Enabled",
       "description": "Route embedding requests through the platform runtime proxy using Vellum-managed Gemini credentials when available",
       "defaultEnabled": false
+    },
+    {
+      "id": "fork-from-message",
+      "scope": "macos",
+      "key": "fork-from-message",
+      "label": "Fork from Message",
+      "description": "Show the 'Fork from here' option in message overflow menus",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
Consolidated QA fixes from App QA 7-4-2026 Part 1.

## PRs merged
- #24628: Standardize divider colors to borderBase
- #24629: Remove borders from modals
- #24633: Input borders borderless in dark mode
- #24631: Hide fork behind feature flag (default false)
- #24634: Share triggers directly (skip single-action popover)
- #24630: Skill placeholder with puzzle icon
- #24632: Remove Copy/Save/Preview from attachment view

## Deferred
- Steps contrast redesign
- Version control UI help
- General redesign items

Part of plan: app-qa-7-4-2026-part1.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24635" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
