### PR TITLE
docs: improve integration logos license clarity and README attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ We're not accepting external contributions yet. See the [Contributing](https://g
 
 ## License
 
-MIT — see [License](https://github.com/vellum-ai/vellum-assistant?tab=MIT-1-ov-file).
+MIT — see [License](https://github.com/vellum-ai/vellum-assistant?tab=MIT-1-ov-file). Integration logos are sourced from [Simple Icons](https://github.com/simple-icons/simple-icons) and licensed under [CC0 1.0 Universal](https://creativecommons.org/publicdomain/zero/1.0/).
 
 Vellum Assistant is open-source software built by [Vellum AI](https://vellum.ai), a for-profit company. We also offer a managed product — the [Vellum Platform](https://vellum.ai/platform) — which sustains the business. This project is free to use and modify under the MIT license, and we're committed to keeping it that way.
 

--- a/clients/shared/Resources/INTEGRATION-LOGOS-LICENSE
+++ b/clients/shared/Resources/INTEGRATION-LOGOS-LICENSE
@@ -1,14 +1,11 @@
-The Simple Icons logos are licensed under CC0 1.0 Universal.
+The integration logos in this directory are sourced from Simple Icons
+(https://github.com/simple-icons/simple-icons) and are licensed under
+CC0 1.0 Universal.
 
-Permission is granted, free of charge, to any person obtaining a copy
-of the Simple Icons logos (the "Logos"), to deal in the Logos without
-restriction, including without limitation the rights to use, copy,
-modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Logos, and to permit persons to whom the Logos are furnished to do
-so, subject to no conditions.
+See https://creativecommons.org/publicdomain/zero/1.0/ for the full
+CC0 1.0 Universal legal text, and
+https://github.com/simple-icons/simple-icons/blob/develop/LICENSE.md
+for the Simple Icons license.
 
-See https://github.com/simple-icons/simple-icons/blob/develop/LICENSE.md
-for the full CC0 1.0 Universal license.
-
-Brand icons are the trademarks of their respective owners. Usage of
-these icons does not imply endorsement by the respective brands.
+Brand icons are trademarks of their respective owners. Usage of these
+icons does not imply endorsement by the respective brands.


### PR DESCRIPTION
## Summary

- Rewrote `INTEGRATION-LOGOS-LICENSE` to use accurate CC0 language instead of MIT-style paraphrase, and added the canonical Creative Commons URL alongside the Simple Icons GitHub link
- Added a one-liner to the README License section noting that integration logos are sourced from Simple Icons under CC0 1.0

## Original prompt

Make three minor improvements to license/attribution files:

1. **Update `clients/shared/Resources/INTEGRATION-LOGOS-LICENSE`** — Replace the current MIT-style paraphrase of CC0 with a cleaner, accurate statement.

2. **Update `README.md`** — In the License section, add a one-liner mentioning the integration logos license.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24636" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
