### PR TITLE
fix(settings): remove fallback claim from cdp-inspect toggle helper text

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/BrowserBackendCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/BrowserBackendCard.swift
@@ -48,7 +48,7 @@ struct BrowserBackendCard: View {
                     }
                 ),
                 label: "Enable cdp-inspect backend",
-                helperText: "When on, the assistant probes the host/port below before falling back to the managed browser."
+                helperText: "When on, the assistant connects to Chrome at the host/port below instead of using the managed browser."
             )
             .accessibilityLabel("Enable cdp-inspect backend")
 


### PR DESCRIPTION
## Summary
- Change toggle helperText from fallback language to hard-select language

Part of plan: cdp-inspect-copy-and-ws-val.md (PR 3 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24637" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
