### PR TITLE
fix(browser): remove incorrect fallback claims from cdp-inspect schema and docs

### DIFF
--- a/assistant/src/browser-session/index.ts
+++ b/assistant/src/browser-session/index.ts
@@ -12,7 +12,7 @@
  *  2. **cdp-inspect** — selected when the extension is absent and
  *     `hostBrowser.cdpInspect.enabled` is `true` in config. Attaches to
  *     an already-running Chrome via `--remote-debugging-port`.
- *  3. **Local** — default fallback when neither of the above applies.
+ *  3. **Local** — default when neither of the above applies.
  *     Drives a Playwright-backed sacrificial-profile Chromium.
  *
  * The factory exposes a `ScopedCdpClient` that routes `send()` through

--- a/assistant/src/config/schemas/host-browser.ts
+++ b/assistant/src/config/schemas/host-browser.ts
@@ -3,9 +3,8 @@ import { z } from "zod";
 /**
  * Configuration for the `cdp-inspect` browser backend — connects directly
  * to a host Chrome instance that was launched with `--remote-debugging-port`
- * (e.g. `chrome://inspect`-style remote debugging). Connects directly to a
- * host Chrome instance as an alternative to the extension or local Playwright
- * backend.
+ * (e.g. `chrome://inspect`-style remote debugging) as an alternative to the
+ * extension or local Playwright backend.
  */
 export const HostBrowserCdpInspectConfigSchema = z
   .object({

--- a/assistant/src/config/schemas/host-browser.ts
+++ b/assistant/src/config/schemas/host-browser.ts
@@ -3,9 +3,9 @@ import { z } from "zod";
 /**
  * Configuration for the `cdp-inspect` browser backend — connects directly
  * to a host Chrome instance that was launched with `--remote-debugging-port`
- * (e.g. `chrome://inspect`-style remote debugging). Serves as a fallback
- * between the extension backend (user's Chrome via chrome.debugger) and the
- * local Playwright-backed backend.
+ * (e.g. `chrome://inspect`-style remote debugging). Connects directly to a
+ * host Chrome instance as an alternative to the extension or local Playwright
+ * backend.
  */
 export const HostBrowserCdpInspectConfigSchema = z
   .object({
@@ -13,7 +13,7 @@ export const HostBrowserCdpInspectConfigSchema = z
       .boolean({ error: "hostBrowser.cdpInspect.enabled must be a boolean" })
       .default(false)
       .describe(
-        "Whether the cdp-inspect backend is enabled. When true, the browser-session manager will probe the configured host/port before falling back to the local Playwright backend.",
+        "Whether the cdp-inspect backend is enabled. When true, the factory will route browser tool calls through the configured host/port instead of the local Playwright backend.",
       ),
     host: z
       .string({ error: "hostBrowser.cdpInspect.host must be a string" })
@@ -40,7 +40,7 @@ export const HostBrowserCdpInspectConfigSchema = z
       .max(5000, "hostBrowser.cdpInspect.probeTimeoutMs must be <= 5000")
       .default(500)
       .describe(
-        "Timeout (in milliseconds) for the backend availability probe. Kept small so the fallback to the local backend stays snappy.",
+        "Timeout (in milliseconds) for the backend availability probe. Kept small so browser tool calls fail fast when the endpoint is unreachable.",
       ),
   })
   .describe(

--- a/assistant/src/tools/browser/cdp-client/factory.ts
+++ b/assistant/src/tools/browser/cdp-client/factory.ts
@@ -28,7 +28,7 @@ import type { CdpClient, CdpClientKind, ScopedCdpClient } from "./types.js";
  *     `hostBrowser.cdpInspect.enabled` is `true` in config, construct
  *     a `CdpInspectClient` that attaches to an already-running Chrome
  *     via the DevTools JSON protocol (`--remote-debugging-port`).
- *  3. **Local** — Default fallback. Drives Playwright's CDPSession
+ *  3. **Local** — Default. Drives Playwright's CDPSession
  *     against the sacrificial-profile browser managed by
  *     browserManager.
  *
@@ -77,7 +77,7 @@ export function getCdpClient(context: ToolContext): ScopedCdpClient {
     return buildManagedClient("cdp-inspect", conversationId, backend);
   }
 
-  // 3. Local backend — default fallback (Playwright-backed Chromium).
+  // 3. Local backend — default (Playwright-backed Chromium).
   const client = createLocalCdpClient(conversationId);
   const backend = createLocalBackend({
     isAvailable: () => true,

--- a/docs/browser-use-cdp-inspect-backend.md
+++ b/docs/browser-use-cdp-inspect-backend.md
@@ -15,7 +15,7 @@ session-level access.
 | Debugger infobar | Yes (per tab) | No | No (dedicated profile) |
 | Tab scope | Single active tab | Any open tab | Dedicated browser |
 | Auth/session access | Active tab only | All tabs, all cookies | Isolated profile |
-| Selection priority | 1st (highest) | 2nd (when enabled) | 3rd (default fallback) |
+| Selection priority | 1st (highest) | 2nd (when enabled) | 3rd (default) |
 
 ## When to use this backend
 


### PR DESCRIPTION
## Summary
- Remove fallback language from `host-browser.ts` JSDoc and schema descriptions
- Update docs comparison table and prose to reflect hard-select (no-fallback) behavior

Part of plan: cdp-inspect-copy-and-ws-val.md (PR 2 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24638" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
