### PR TITLE
fix(browser): validate webSocketDebuggerUrl host is loopback before use

### DIFF
--- a/assistant/src/tools/browser/cdp-client/cdp-inspect/__tests__/discovery.test.ts
+++ b/assistant/src/tools/browser/cdp-client/cdp-inspect/__tests__/discovery.test.ts
@@ -297,6 +297,59 @@ describe("probeDevToolsJsonVersion — parsing", () => {
 });
 
 // ---------------------------------------------------------------------------
+// probeDevToolsJsonVersion — webSocketDebuggerUrl loopback validation.
+// ---------------------------------------------------------------------------
+
+describe("probeDevToolsJsonVersion — webSocketDebuggerUrl loopback", () => {
+  let fake: FakeDevTools;
+
+  beforeEach(() => {
+    fake = startFakeDevTools();
+  });
+
+  afterEach(() => {
+    fake.stop();
+  });
+
+  test("rejects when webSocketDebuggerUrl host is not loopback", async () => {
+    fake.setHandler(() =>
+      chromeVersionResponse({
+        webSocketDebuggerUrl: "ws://evil.com/devtools/browser/abc",
+      }),
+    );
+
+    const error = await probeDevToolsJsonVersion({
+      host: "127.0.0.1",
+      port: fake.port,
+      timeoutMs: 2000,
+    }).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(DevToolsDiscoveryError);
+    expect((error as DevToolsDiscoveryError).code).toBe("non_loopback");
+    expect((error as DevToolsDiscoveryError).message).toContain("evil.com");
+  });
+
+  test("accepts loopback webSocketDebuggerUrl", async () => {
+    fake.setHandler(() =>
+      chromeVersionResponse({
+        webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/browser/abc",
+      }),
+    );
+
+    const info = await probeDevToolsJsonVersion({
+      host: "127.0.0.1",
+      port: fake.port,
+      timeoutMs: 2000,
+    });
+
+    expect(info.browser).toContain("Chrome");
+    expect(info.webSocketDebuggerUrl).toBe(
+      "ws://127.0.0.1:9222/devtools/browser/abc",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
 // probeDevToolsJsonVersion — network-level error paths.
 // ---------------------------------------------------------------------------
 
@@ -573,6 +626,59 @@ describe("listDevToolsTargets", () => {
 
     expect(error).toBeInstanceOf(DevToolsDiscoveryError);
     expect((error as DevToolsDiscoveryError).code).toBe("invalid_response");
+  });
+
+  test("filters out targets with non-loopback webSocketDebuggerUrl", async () => {
+    fake.setHandler(() =>
+      Response.json([
+        {
+          id: "evil",
+          type: "page",
+          title: "Evil Target",
+          url: "https://example.com/evil",
+          webSocketDebuggerUrl: "ws://evil.com/devtools/page/evil",
+        },
+        {
+          id: "good",
+          type: "page",
+          title: "Good Target",
+          url: "https://example.com/good",
+          webSocketDebuggerUrl: "ws://localhost:9222/devtools/page/good",
+        },
+      ]),
+    );
+
+    const targets = await listDevToolsTargets({
+      host: "127.0.0.1",
+      port: fake.port,
+      timeoutMs: 2000,
+    });
+
+    expect(targets).toHaveLength(1);
+    expect(targets[0]!.id).toBe("good");
+  });
+
+  test("throws no_targets when all targets have non-loopback webSocketDebuggerUrl", async () => {
+    fake.setHandler(() =>
+      Response.json([
+        {
+          id: "evil",
+          type: "page",
+          title: "Evil Target",
+          url: "https://example.com/evil",
+          webSocketDebuggerUrl: "ws://evil.com/devtools/page/evil",
+        },
+      ]),
+    );
+
+    const error = await listDevToolsTargets({
+      host: "127.0.0.1",
+      port: fake.port,
+      timeoutMs: 2000,
+    }).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(DevToolsDiscoveryError);
+    expect((error as DevToolsDiscoveryError).code).toBe("no_targets");
   });
 });
 

--- a/assistant/src/tools/browser/cdp-client/cdp-inspect/discovery.ts
+++ b/assistant/src/tools/browser/cdp-client/cdp-inspect/discovery.ts
@@ -98,6 +98,35 @@ function assertLoopback(host: string): void {
 }
 
 /**
+ * Validate that a `webSocketDebuggerUrl` points to a loopback host.
+ *
+ * Chrome returns this URL in `/json/version` and `/json/list` responses.
+ * A rogue responder on the loopback port could return a ws:// URL
+ * pointing to an attacker-controlled host, tricking the client into
+ * opening a cross-origin WebSocket. This check ensures the hostname
+ * extracted from the URL is in the {@link LOOPBACK_HOSTS} allowlist.
+ */
+function assertWsUrlLoopback(wsUrl: string): void {
+  let url: URL;
+  try {
+    url = new URL(wsUrl);
+  } catch {
+    throw new DevToolsDiscoveryError(
+      "invalid_response",
+      `webSocketDebuggerUrl is not a valid URL: ${wsUrl}`,
+    );
+  }
+
+  const hostname = url.hostname.toLowerCase();
+  if (!LOOPBACK_HOSTS.has(hostname)) {
+    throw new DevToolsDiscoveryError(
+      "non_loopback",
+      `webSocketDebuggerUrl host "${url.hostname}" is not loopback. A rogue responder may be redirecting the connection.`,
+    );
+  }
+}
+
+/**
  * Build a fetch-ready loopback URL. `host` is assumed to have already
  * been validated by {@link assertLoopback}. IPv6 bare form (`::1`) is
  * wrapped in square brackets for URL correctness.
@@ -396,6 +425,8 @@ export async function probeDevToolsJsonVersion(opts: {
     );
   }
 
+  assertWsUrlLoopback(webSocketDebuggerUrl);
+
   return { browser, protocolVersion, webSocketDebuggerUrl };
 }
 
@@ -486,6 +517,12 @@ export async function listDevToolsTargets(opts: {
       "webSocketDebuggerUrl",
     );
     if (!webSocketDebuggerUrl) continue;
+
+    try {
+      assertWsUrlLoopback(webSocketDebuggerUrl);
+    } catch {
+      continue;
+    }
 
     const id = readStringField(record, "id") ?? "";
     const title = readStringField(record, "title") ?? "";


### PR DESCRIPTION
## Summary
- Add `assertWsUrlLoopback` to validate webSocketDebuggerUrl host before connecting
- Reject non-loopback ws URLs in `probeDevToolsJsonVersion`; silently skip bad targets in `listDevToolsTargets`
- 4 new tests covering the security boundary

Part of plan: cdp-inspect-copy-and-ws-val.md (PR 1 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24639" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
