### PR TITLE
fix(browser): cdp-inspect copy corrections + webSocketDebuggerUrl loopback validation

### DIFF
--- a/assistant/src/browser-session/index.ts
+++ b/assistant/src/browser-session/index.ts
@@ -12,7 +12,7 @@
  *  2. **cdp-inspect** — selected when the extension is absent and
  *     `hostBrowser.cdpInspect.enabled` is `true` in config. Attaches to
  *     an already-running Chrome via `--remote-debugging-port`.
- *  3. **Local** — default fallback when neither of the above applies.
+ *  3. **Local** — default when neither of the above applies.
  *     Drives a Playwright-backed sacrificial-profile Chromium.
  *
  * The factory exposes a `ScopedCdpClient` that routes `send()` through

--- a/assistant/src/config/schemas/host-browser.ts
+++ b/assistant/src/config/schemas/host-browser.ts
@@ -3,9 +3,8 @@ import { z } from "zod";
 /**
  * Configuration for the `cdp-inspect` browser backend — connects directly
  * to a host Chrome instance that was launched with `--remote-debugging-port`
- * (e.g. `chrome://inspect`-style remote debugging). Serves as a fallback
- * between the extension backend (user's Chrome via chrome.debugger) and the
- * local Playwright-backed backend.
+ * (e.g. `chrome://inspect`-style remote debugging) as an alternative to the
+ * extension or local Playwright backend.
  */
 export const HostBrowserCdpInspectConfigSchema = z
   .object({
@@ -13,7 +12,7 @@ export const HostBrowserCdpInspectConfigSchema = z
       .boolean({ error: "hostBrowser.cdpInspect.enabled must be a boolean" })
       .default(false)
       .describe(
-        "Whether the cdp-inspect backend is enabled. When true, the browser-session manager will probe the configured host/port before falling back to the local Playwright backend.",
+        "Whether the cdp-inspect backend is enabled. When true, the factory will route browser tool calls through the configured host/port instead of the local Playwright backend.",
       ),
     host: z
       .string({ error: "hostBrowser.cdpInspect.host must be a string" })
@@ -40,7 +39,7 @@ export const HostBrowserCdpInspectConfigSchema = z
       .max(5000, "hostBrowser.cdpInspect.probeTimeoutMs must be <= 5000")
       .default(500)
       .describe(
-        "Timeout (in milliseconds) for the backend availability probe. Kept small so the fallback to the local backend stays snappy.",
+        "Timeout (in milliseconds) for the backend availability probe. Kept small so browser tool calls fail fast when the endpoint is unreachable.",
       ),
   })
   .describe(

--- a/assistant/src/tools/browser/cdp-client/cdp-inspect/__tests__/discovery.test.ts
+++ b/assistant/src/tools/browser/cdp-client/cdp-inspect/__tests__/discovery.test.ts
@@ -297,6 +297,59 @@ describe("probeDevToolsJsonVersion — parsing", () => {
 });
 
 // ---------------------------------------------------------------------------
+// probeDevToolsJsonVersion — webSocketDebuggerUrl loopback validation.
+// ---------------------------------------------------------------------------
+
+describe("probeDevToolsJsonVersion — webSocketDebuggerUrl loopback", () => {
+  let fake: FakeDevTools;
+
+  beforeEach(() => {
+    fake = startFakeDevTools();
+  });
+
+  afterEach(() => {
+    fake.stop();
+  });
+
+  test("rejects when webSocketDebuggerUrl host is not loopback", async () => {
+    fake.setHandler(() =>
+      chromeVersionResponse({
+        webSocketDebuggerUrl: "ws://evil.com/devtools/browser/abc",
+      }),
+    );
+
+    const error = await probeDevToolsJsonVersion({
+      host: "127.0.0.1",
+      port: fake.port,
+      timeoutMs: 2000,
+    }).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(DevToolsDiscoveryError);
+    expect((error as DevToolsDiscoveryError).code).toBe("non_loopback");
+    expect((error as DevToolsDiscoveryError).message).toContain("evil.com");
+  });
+
+  test("accepts loopback webSocketDebuggerUrl", async () => {
+    fake.setHandler(() =>
+      chromeVersionResponse({
+        webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/browser/abc",
+      }),
+    );
+
+    const info = await probeDevToolsJsonVersion({
+      host: "127.0.0.1",
+      port: fake.port,
+      timeoutMs: 2000,
+    });
+
+    expect(info.browser).toContain("Chrome");
+    expect(info.webSocketDebuggerUrl).toBe(
+      "ws://127.0.0.1:9222/devtools/browser/abc",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
 // probeDevToolsJsonVersion — network-level error paths.
 // ---------------------------------------------------------------------------
 
@@ -573,6 +626,59 @@ describe("listDevToolsTargets", () => {
 
     expect(error).toBeInstanceOf(DevToolsDiscoveryError);
     expect((error as DevToolsDiscoveryError).code).toBe("invalid_response");
+  });
+
+  test("filters out targets with non-loopback webSocketDebuggerUrl", async () => {
+    fake.setHandler(() =>
+      Response.json([
+        {
+          id: "evil",
+          type: "page",
+          title: "Evil Target",
+          url: "https://example.com/evil",
+          webSocketDebuggerUrl: "ws://evil.com/devtools/page/evil",
+        },
+        {
+          id: "good",
+          type: "page",
+          title: "Good Target",
+          url: "https://example.com/good",
+          webSocketDebuggerUrl: "ws://localhost:9222/devtools/page/good",
+        },
+      ]),
+    );
+
+    const targets = await listDevToolsTargets({
+      host: "127.0.0.1",
+      port: fake.port,
+      timeoutMs: 2000,
+    });
+
+    expect(targets).toHaveLength(1);
+    expect(targets[0]!.id).toBe("good");
+  });
+
+  test("throws no_targets when all targets have non-loopback webSocketDebuggerUrl", async () => {
+    fake.setHandler(() =>
+      Response.json([
+        {
+          id: "evil",
+          type: "page",
+          title: "Evil Target",
+          url: "https://example.com/evil",
+          webSocketDebuggerUrl: "ws://evil.com/devtools/page/evil",
+        },
+      ]),
+    );
+
+    const error = await listDevToolsTargets({
+      host: "127.0.0.1",
+      port: fake.port,
+      timeoutMs: 2000,
+    }).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(DevToolsDiscoveryError);
+    expect((error as DevToolsDiscoveryError).code).toBe("no_targets");
   });
 });
 

--- a/assistant/src/tools/browser/cdp-client/cdp-inspect/discovery.ts
+++ b/assistant/src/tools/browser/cdp-client/cdp-inspect/discovery.ts
@@ -98,6 +98,35 @@ function assertLoopback(host: string): void {
 }
 
 /**
+ * Validate that a `webSocketDebuggerUrl` points to a loopback host.
+ *
+ * Chrome returns this URL in `/json/version` and `/json/list` responses.
+ * A rogue responder on the loopback port could return a ws:// URL
+ * pointing to an attacker-controlled host, tricking the client into
+ * opening a cross-origin WebSocket. This check ensures the hostname
+ * extracted from the URL is in the {@link LOOPBACK_HOSTS} allowlist.
+ */
+function assertWsUrlLoopback(wsUrl: string): void {
+  let url: URL;
+  try {
+    url = new URL(wsUrl);
+  } catch {
+    throw new DevToolsDiscoveryError(
+      "invalid_response",
+      `webSocketDebuggerUrl is not a valid URL: ${wsUrl}`,
+    );
+  }
+
+  const hostname = url.hostname.toLowerCase();
+  if (!LOOPBACK_HOSTS.has(hostname)) {
+    throw new DevToolsDiscoveryError(
+      "non_loopback",
+      `webSocketDebuggerUrl host "${url.hostname}" is not loopback. A rogue responder may be redirecting the connection.`,
+    );
+  }
+}
+
+/**
  * Build a fetch-ready loopback URL. `host` is assumed to have already
  * been validated by {@link assertLoopback}. IPv6 bare form (`::1`) is
  * wrapped in square brackets for URL correctness.
@@ -396,6 +425,8 @@ export async function probeDevToolsJsonVersion(opts: {
     );
   }
 
+  assertWsUrlLoopback(webSocketDebuggerUrl);
+
   return { browser, protocolVersion, webSocketDebuggerUrl };
 }
 
@@ -486,6 +517,12 @@ export async function listDevToolsTargets(opts: {
       "webSocketDebuggerUrl",
     );
     if (!webSocketDebuggerUrl) continue;
+
+    try {
+      assertWsUrlLoopback(webSocketDebuggerUrl);
+    } catch {
+      continue;
+    }
 
     const id = readStringField(record, "id") ?? "";
     const title = readStringField(record, "title") ?? "";

--- a/assistant/src/tools/browser/cdp-client/factory.ts
+++ b/assistant/src/tools/browser/cdp-client/factory.ts
@@ -28,7 +28,7 @@ import type { CdpClient, CdpClientKind, ScopedCdpClient } from "./types.js";
  *     `hostBrowser.cdpInspect.enabled` is `true` in config, construct
  *     a `CdpInspectClient` that attaches to an already-running Chrome
  *     via the DevTools JSON protocol (`--remote-debugging-port`).
- *  3. **Local** — Default fallback. Drives Playwright's CDPSession
+ *  3. **Local** — Default. Drives Playwright's CDPSession
  *     against the sacrificial-profile browser managed by
  *     browserManager.
  *
@@ -77,7 +77,7 @@ export function getCdpClient(context: ToolContext): ScopedCdpClient {
     return buildManagedClient("cdp-inspect", conversationId, backend);
   }
 
-  // 3. Local backend — default fallback (Playwright-backed Chromium).
+  // 3. Local backend — default (Playwright-backed Chromium).
   const client = createLocalCdpClient(conversationId);
   const backend = createLocalBackend({
     isAvailable: () => true,

--- a/clients/macos/vellum-assistant/Features/Settings/BrowserBackendCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/BrowserBackendCard.swift
@@ -48,7 +48,7 @@ struct BrowserBackendCard: View {
                     }
                 ),
                 label: "Enable cdp-inspect backend",
-                helperText: "When on, the assistant probes the host/port below before falling back to the managed browser."
+                helperText: "When on, the assistant connects to Chrome at the host/port below instead of using the managed browser."
             )
             .accessibilityLabel("Enable cdp-inspect backend")
 

--- a/docs/browser-use-cdp-inspect-backend.md
+++ b/docs/browser-use-cdp-inspect-backend.md
@@ -15,7 +15,7 @@ session-level access.
 | Debugger infobar | Yes (per tab) | No | No (dedicated profile) |
 | Tab scope | Single active tab | Any open tab | Dedicated browser |
 | Auth/session access | Active tab only | All tabs, all cookies | Isolated profile |
-| Selection priority | 1st (highest) | 2nd (when enabled) | 3rd (default fallback) |
+| Selection priority | 1st (highest) | 2nd (when enabled) | 3rd (default) |
 
 ## When to use this backend
 


### PR DESCRIPTION
## Summary
Fixes two post-merge issues from the cdp-inspect Phase 4 feature (#24623):

1. **Security**: Validate `webSocketDebuggerUrl` host is loopback before connecting — prevents a rogue localhost responder from redirecting the WS connection to a remote host
2. **Copy**: Remove incorrect "fallback" language from config schema, docs, macOS settings toggle, factory comments, and browser-session docblock

## PRs merged into feature branch
- #24639: fix(browser): validate webSocketDebuggerUrl host is loopback before use
- #24638: fix(browser): remove incorrect fallback claims from cdp-inspect schema and docs
- #24637: fix(settings): remove fallback claim from cdp-inspect toggle helper text

Part of plan: cdp-inspect-copy-and-ws-val.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24640" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
