### PR TITLE
fix: add fork-from-message feature flag to registry (default false)

### DIFF
--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -320,7 +320,14 @@
       "label": "Fork from Message",
       "description": "Show the 'Fork from here' option in message overflow menus",
       "defaultEnabled": false
+    },
+    {
+      "id": "fork-from-message",
+      "scope": "macos",
+      "key": "fork-from-message",
+      "label": "Fork from Message",
+      "description": "Show the Fork from here option in message overflow menus",
+      "defaultEnabled": false
     }
   ]
 }
-


### PR DESCRIPTION
## Summary
The flag check was added to ChatBubbleOverflowMenu and ChatBubble in #24635 but the registry entry was lost during squash merge. This adds it back so the fork option is hidden by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24649" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
