### PR TITLE
fix: UX polish — avatar size, divider tokens, attachment chip, lightbox close

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
@@ -100,14 +100,14 @@ struct ChatEmptyStateView: View {
         HStack(spacing: VSpacing.md) {
             Group {
                 if appearance.customAvatarImage != nil {
-                    VAvatarImage(image: appearance.chatAvatarImage, size: 32)
+                    VAvatarImage(image: appearance.chatAvatarImage, size: 40)
                 } else if let body = appearance.characterBodyShape,
                    let eyes = appearance.characterEyeStyle,
                    let color = appearance.characterColor {
-                    AnimatedAvatarView(bodyShape: body, eyeStyle: eyes, color: color, size: 32)
-                        .frame(width: 32, height: 32)
+                    AnimatedAvatarView(bodyShape: body, eyeStyle: eyes, color: color, size: 40)
+                        .frame(width: 40, height: 40)
                 } else {
-                    VAvatarImage(image: appearance.chatAvatarImage, size: 32)
+                    VAvatarImage(image: appearance.chatAvatarImage, size: 40)
                 }
             }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerAttachments.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerAttachments.swift
@@ -45,8 +45,8 @@ extension ComposerView {
         let fileSize = formattedFileSize(base64Length: attachment.dataLength)
         let isImage = attachment.mimeType.hasPrefix("image/")
 
-        return HStack(spacing: VSpacing.sm) {
-            HStack(spacing: VSpacing.sm) {
+        return HStack(spacing: VSpacing.xs) {
+            HStack(spacing: VSpacing.xs) {
                 if isImage, let nsImage = attachment.thumbnailImage {
                     Image(nsImage: nsImage)
                         .resizable()
@@ -55,7 +55,7 @@ extension ComposerView {
                         .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
                 } else {
                     RoundedRectangle(cornerRadius: VRadius.sm)
-                        .fill(VColor.borderBase.opacity(0.5))
+                        .fill(VColor.surfaceActive)
                         .frame(width: 28, height: 28)
                         .overlay {
                             VIconView(iconForMimeType(attachment.mimeType, filename: attachment.filename), size: 14)
@@ -64,13 +64,17 @@ extension ComposerView {
                 }
 
                 Text(attachment.filename)
-                    .font(VFont.labelDefault)
+                    .font(VFont.bodySmallDefault)
                     .foregroundStyle(VColor.contentSecondary)
                     .lineLimit(1)
                     .truncationMode(.middle)
 
-                Text("· \(fileSize)")
-                    .font(VFont.labelDefault)
+                Text("·")
+                    .font(VFont.bodySmallDefault)
+                    .foregroundStyle(VColor.contentTertiary)
+
+                Text(fileSize)
+                    .font(VFont.bodySmallDefault)
                     .foregroundStyle(VColor.contentTertiary)
             }
             .contentShape(Rectangle())
@@ -80,19 +84,34 @@ extension ComposerView {
                     .pointerCursor()
             }
 
-            Button {
+            AttachmentRemoveButton {
                 onRemoveAttachment(attachment.id)
-            } label: {
-                VIconView(.x, size: 10)
-                    .foregroundStyle(VColor.contentTertiary)
             }
-            .buttonStyle(.plain)
             .accessibilityLabel("Remove \(attachment.filename)")
         }
-        .padding(VSpacing.xs)
-        .background(VColor.borderBase.opacity(0.3))
+        .padding(.horizontal, VSpacing.sm)
+        .padding(.vertical, VSpacing.xs)
+        .background(VColor.surfaceActive)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+        .overlay(RoundedRectangle(cornerRadius: VRadius.md).strokeBorder(VColor.borderHover, lineWidth: 1))
         .frame(maxWidth: 280)
+    }
+}
+
+// MARK: - Attachment Remove Button
+
+private struct AttachmentRemoveButton: View {
+    let action: () -> Void
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: action) {
+            VIconView(.x, size: 10)
+                .foregroundStyle(isHovered ? VColor.contentDefault : VColor.contentTertiary)
+        }
+        .buttonStyle(.plain)
+        .onHover { isHovered = $0 }
+        .pointerCursor()
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ImageLightbox/ImageLightboxOverlay.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ImageLightbox/ImageLightboxOverlay.swift
@@ -60,18 +60,12 @@ struct ImageLightboxOverlay: View {
     // MARK: - Close Button
 
     private var closeButton: some View {
-        Button { dismiss() } label: {
-            ZStack {
-                Circle()
-                    .fill(.ultraThinMaterial)
-                    .frame(width: 32, height: 32)
-
-                VIconView(.x, size: 14)
-                    .foregroundStyle(VColor.auxWhite.opacity(0.8))
-            }
-        }
-        .buttonStyle(.plain)
-        .shadow(color: VColor.auxBlack.opacity(0.3), radius: 8)
+        VButton(
+            label: "Close",
+            iconOnly: VIcon.x.rawValue,
+            style: .outlined,
+            action: dismiss
+        )
     }
 
     // MARK: - Toolbar

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsCard.swift
@@ -77,7 +77,7 @@ private struct ConditionalCardModifier: ViewModifier {
 struct SettingsDivider: View {
     var body: some View {
         Rectangle()
-            .fill(VColor.borderBase)
+            .fill(VColor.borderHover)
             .frame(height: 1)
     }
 }

--- a/clients/shared/DesignSystem/Components/Navigation/VMenu.swift
+++ b/clients/shared/DesignSystem/Components/Navigation/VMenu.swift
@@ -768,7 +768,7 @@ public struct VMenuDivider: View {
     public init() {}
 
     public var body: some View {
-        VColor.borderBase.frame(height: 1)
+        VColor.borderHover.frame(height: 1)
             .padding(.horizontal, VSpacing.xs)
             .padding(.vertical, VSpacing.xs)
             .accessibilityHidden(true)


### PR DESCRIPTION
## Summary
QA polish fixes that were applied on the feature branch but lost during squash merge of #24635.

- Greeting avatar: 32pt → 40pt
- SettingsDivider + VMenuDivider: `borderHover` for lift-background containers (visible in dark mode)
- Attachment chip: `bodySmallDefault` text, `surfaceActive` bg, `borderHover` border, consistent spacing, hover state on delete button
- Lightbox close: `VButton` outlined instead of custom circle with ultraThinMaterial

## Test plan
- [ ] Greeting screen avatar is larger
- [ ] Settings dividers visible in dark mode
- [ ] Menu dividers visible in dark mode
- [ ] Attachment chip text is 12px, has proper container styling
- [ ] Attachment delete icon changes color on hover
- [ ] Lightbox close button uses standard VButton style

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24650" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
