### PR TITLE
feat(onboarding): add `onboarding-pre-chat` feature flag

### DIFF
--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -328,6 +328,14 @@
       "label": "Fork from Message",
       "description": "Show the Fork from here option in message overflow menus",
       "defaultEnabled": false
+    },
+    {
+      "id": "onboarding-pre-chat",
+      "scope": "macos",
+      "key": "onboarding-pre-chat",
+      "label": "Pre-Chat Onboarding Flow",
+      "description": "Gates the 3-screen pre-chat onboarding flow (tools, tasks/tone, name exchange) shown before the first conversation",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds `onboarding-pre-chat` feature flag to the registry (scope: macos, defaultEnabled: false)
- Syncs the registry to the assistant-bundled copy

Part of plan: prechat-onboarding-flow.md (PR 1 of 9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24658" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
