### PR TITLE
feat(onboarding): add PreChatOnboardingContext shared data model

### DIFF
--- a/assistant/src/types/index.ts
+++ b/assistant/src/types/index.ts
@@ -1,0 +1,1 @@
+export type { OnboardingContext } from "./onboarding-context.js";

--- a/assistant/src/types/onboarding-context.ts
+++ b/assistant/src/types/onboarding-context.ts
@@ -1,0 +1,7 @@
+export interface OnboardingContext {
+  tools: string[];
+  tasks: string[];
+  tone: string;
+  userName?: string;
+  assistantName?: string;
+}

--- a/clients/shared/Models/PreChatOnboardingContext.swift
+++ b/clients/shared/Models/PreChatOnboardingContext.swift
@@ -1,0 +1,19 @@
+/// Structured context from the native pre-chat onboarding flow.
+/// Serialized to JSON and sent with the first message so the assistant
+/// can personalize its opener.
+public struct PreChatOnboardingContext: Codable, Sendable {
+    public let tools: [String]       // e.g. ["slack", "linear", "figma"]
+    public let tasks: [String]       // e.g. ["code-building", "writing"]
+    public let tone: String          // "casual", "professional", or "balanced"
+    public let userName: String?     // nil if skipped
+    public let assistantName: String? // nil if kept default
+
+    public init(tools: [String], tasks: [String], tone: String,
+                userName: String?, assistantName: String?) {
+        self.tools = tools
+        self.tasks = tasks
+        self.tone = tone
+        self.userName = userName
+        self.assistantName = assistantName
+    }
+}


### PR DESCRIPTION
## Summary
- Adds Swift `PreChatOnboardingContext` struct (Codable, Sendable) in clients/shared/Models/
- Adds TypeScript `OnboardingContext` interface in assistant/src/types/
- Both types share identical field names and semantics for cross-stack consistency

Part of plan: prechat-onboarding-flow.md (PR 2 of 9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24663" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
