### PR TITLE
feat(onboarding): add PreChatOnboardingFlow container with navigation

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/PreChat/PreChatOnboardingFlow.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/PreChat/PreChatOnboardingFlow.swift
@@ -1,0 +1,102 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Container view that sequences the three pre-chat onboarding screens
+/// (tool selection → task/tone → name exchange) with slide transitions.
+///
+/// Calls `onComplete` with a populated `PreChatOnboardingContext` when the
+/// user finishes the flow, or `nil` when the user skips everything.
+@MainActor
+struct PreChatOnboardingFlow: View {
+    @State private var state = PreChatOnboardingState()
+    let onComplete: (PreChatOnboardingContext?) -> Void
+
+    var body: some View {
+        Group {
+            switch state.currentScreen {
+            case 0:
+                ToolSelectionView(
+                    selectedTools: $state.selectedTools,
+                    onContinue: { advanceTo(1) },
+                    onSkip: { skipAll() }
+                )
+            case 1:
+                VStack(spacing: 0) {
+                    backButton { advanceTo(0) }
+                    TaskToneSelectionView(
+                        selectedTasks: $state.selectedTasks,
+                        toneValue: $state.toneValue,
+                        onContinue: { advanceTo(2) },
+                        onSkip: { skipAll() }
+                    )
+                }
+            default:
+                VStack(spacing: 0) {
+                    backButton { advanceTo(1) }
+                    NameExchangeView(
+                        contextSummary: state.contextSummary,
+                        userName: $state.userName,
+                        assistantName: $state.assistantName,
+                        onComplete: { finish() },
+                        onSkip: { skipAll() }
+                    )
+                }
+            }
+        }
+        .animation(.spring(duration: 0.5, bounce: 0.1), value: state.currentScreen)
+        .transition(.asymmetric(
+            insertion: .move(edge: .trailing).combined(with: .opacity),
+            removal: .move(edge: .leading).combined(with: .opacity)
+        ))
+    }
+
+    // MARK: - Back Button
+
+    @ViewBuilder
+    private func backButton(action: @escaping () -> Void) -> some View {
+        HStack {
+            Button {
+                action()
+            } label: {
+                HStack(spacing: VSpacing.xs) {
+                    Image(systemName: "chevron.left")
+                        .font(.system(size: 12, weight: .semibold))
+                    Text("Back")
+                        .font(VFont.bodyMediumDefault)
+                }
+                .foregroundStyle(VColor.contentSecondary)
+            }
+            .buttonStyle(.plain)
+            Spacer()
+        }
+        .padding(EdgeInsets(top: VSpacing.md, leading: VSpacing.lg, bottom: 0, trailing: VSpacing.lg))
+    }
+
+    // MARK: - Navigation
+
+    private func advanceTo(_ screen: Int) {
+        withAnimation(.spring(duration: 0.5, bounce: 0.1)) {
+            state.currentScreen = screen
+        }
+        state.persist()
+    }
+
+    // MARK: - Completion
+
+    private func finish() {
+        let context = PreChatOnboardingContext(
+            tools: Array(state.selectedTools).sorted(),
+            tasks: Array(state.selectedTasks).sorted(),
+            tone: state.toneLabel,
+            userName: state.userName.isEmpty ? nil : state.userName,
+            assistantName: state.assistantName.isEmpty ? nil : state.assistantName
+        )
+        PreChatOnboardingState.clearPersistedState()
+        onComplete(context)
+    }
+
+    private func skipAll() {
+        PreChatOnboardingState.clearPersistedState()
+        onComplete(nil)
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Onboarding/PreChat/PreChatOnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/PreChat/PreChatOnboardingState.swift
@@ -1,0 +1,114 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Aggregated state for the pre-chat onboarding flow.
+///
+/// Persists all selections to UserDefaults with an `onboarding.prechat.` prefix
+/// so the flow survives app crashes mid-flow. Cleared on completion.
+@Observable
+@MainActor
+final class PreChatOnboardingState {
+    /// Bump when the screen order changes so stale persisted indices are reset.
+    private static let currentFlowVersion = 1
+
+    var currentScreen: Int = 0 // 0 = tools, 1 = tasks/tone, 2 = names
+    var selectedTools: Set<String> = []
+    var selectedTasks: Set<String> = []
+    var toneValue: Double = 0.5 // 0 = casual, 0.5 = balanced, 1 = professional
+    var userName: String = ""
+    var assistantName: String = RandomNameGenerator.generateInstanceName()
+    var skippedAll: Bool = false
+
+    var toneLabel: String {
+        if toneValue < 0.25 { return "casual" }
+        if toneValue > 0.75 { return "professional" }
+        return "balanced"
+    }
+
+    var contextSummary: String {
+        var parts: [String] = []
+        if !selectedTasks.isEmpty {
+            let taskLabels = selectedTasks.sorted().prefix(3).joined(separator: ", ")
+            parts.append("focused on \(taskLabels)")
+        }
+        if !selectedTools.isEmpty {
+            let toolLabels = selectedTools.sorted().prefix(3).joined(separator: ", ")
+            parts.append("mostly in \(toolLabels)")
+        }
+        if parts.isEmpty { return "Let's get to know each other." }
+        return "You're \(parts.joined(separator: ", ")). Let's make that easier."
+    }
+
+    // MARK: - Persistence Keys
+
+    private static let prefix = "onboarding.prechat."
+    private static let screenKey = "\(prefix)currentScreen"
+    private static let toolsKey = "\(prefix)selectedTools"
+    private static let tasksKey = "\(prefix)selectedTasks"
+    private static let toneKey = "\(prefix)toneValue"
+    private static let userNameKey = "\(prefix)userName"
+    private static let assistantNameKey = "\(prefix)assistantName"
+    private static let flowVersionKey = "\(prefix)flowVersion"
+
+    private static let allKeys: [String] = [
+        screenKey, toolsKey, tasksKey, toneKey,
+        userNameKey, assistantNameKey, flowVersionKey,
+    ]
+
+    // MARK: - Init (restore from UserDefaults)
+
+    init() {
+        let defaults = UserDefaults.standard
+        let storedVersion = defaults.integer(forKey: Self.flowVersionKey)
+
+        guard storedVersion == Self.currentFlowVersion else {
+            // No persisted state or version mismatch — start fresh.
+            // Pre-fill userName from system account.
+            userName = NameExchangeView.defaultUserName()
+            return
+        }
+
+        currentScreen = min(defaults.integer(forKey: Self.screenKey), 2)
+
+        if let tools = defaults.stringArray(forKey: Self.toolsKey) {
+            selectedTools = Set(tools)
+        }
+        if let tasks = defaults.stringArray(forKey: Self.tasksKey) {
+            selectedTasks = Set(tasks)
+        }
+
+        toneValue = defaults.double(forKey: Self.toneKey)
+
+        if let name = defaults.string(forKey: Self.userNameKey) {
+            userName = name
+        } else {
+            userName = NameExchangeView.defaultUserName()
+        }
+
+        if let name = defaults.string(forKey: Self.assistantNameKey), !name.isEmpty {
+            assistantName = name
+        }
+    }
+
+    // MARK: - Persist
+
+    func persist() {
+        let defaults = UserDefaults.standard
+        defaults.set(Self.currentFlowVersion, forKey: Self.flowVersionKey)
+        defaults.set(currentScreen, forKey: Self.screenKey)
+        defaults.set(Array(selectedTools), forKey: Self.toolsKey)
+        defaults.set(Array(selectedTasks), forKey: Self.tasksKey)
+        defaults.set(toneValue, forKey: Self.toneKey)
+        defaults.set(userName, forKey: Self.userNameKey)
+        defaults.set(assistantName, forKey: Self.assistantNameKey)
+    }
+
+    // MARK: - Clear
+
+    static func clearPersistedState() {
+        let defaults = UserDefaults.standard
+        for key in allKeys {
+            defaults.removeObject(forKey: key)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds PreChatOnboardingState with UserDefaults persistence for crash recovery
- Adds PreChatOnboardingFlow container that sequences 3 screens with slide transitions
- Back navigation, skip-all, and completion produce a PreChatOnboardingContext

Part of plan: prechat-onboarding-flow.md (PR 7 of 9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24665" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
