### PR TITLE
feat(onboarding): inject pre-chat onboarding context into system prompt

### DIFF
--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -67,6 +67,7 @@ import type { AuthContext } from "../runtime/auth/types.js";
 import * as approvalOverrides from "../runtime/conversation-approval-overrides.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 import { ToolExecutor } from "../tools/executor.js";
+import type { OnboardingContext } from "../types/onboarding-context.js";
 import { getLogger } from "../util/logger.js";
 import type { AssistantAttachmentDraft } from "./assistant-attachments.js";
 import { runAgentLoopImpl } from "./conversation-agent-loop.js";
@@ -297,6 +298,14 @@ export class Conversation {
   /** @internal */ turnCount = 0;
   public lastAssistantAttachments: AssistantAttachmentDraft[] = [];
   public lastAttachmentWarnings: string[] = [];
+  /**
+   * Pre-chat onboarding context provided by the native client.
+   * In-memory only — not persisted to the DB. Only relevant for the first
+   * turn of a brand-new conversation so the system prompt can personalize
+   * the opener and skip redundant discovery.
+   * @internal
+   */
+  private onboardingContext?: OnboardingContext;
   /** @internal */ currentTurnChannelContext: TurnChannelContext | null = null;
   /** @internal */ currentTurnInterfaceContext: TurnInterfaceContext | null =
     null;
@@ -440,6 +449,7 @@ export class Conversation {
                 userPersona: persona.userPersona,
                 channelPersona: persona.channelPersona,
                 userSlug: persona.userSlug,
+                onboardingContext: this.getOnboardingContext(),
               });
             })(),
         maxTokens: configuredMaxTokens,
@@ -479,6 +489,16 @@ export class Conversation {
       conversationId: this.conversationId,
       workingDir: this.workingDir,
     });
+  }
+
+  // ── Onboarding context ───────────────────────────────────────────
+
+  setOnboardingContext(ctx: OnboardingContext): void {
+    this.onboardingContext = ctx;
+  }
+
+  getOnboardingContext(): OnboardingContext | undefined {
+    return this.onboardingContext;
   }
 
   // ── Lifecycle ────────────────────────────────────────────────────

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -11,6 +11,7 @@ import { join } from "node:path";
 import { getIsContainerized } from "../config/env-registry.js";
 import { loadConfig } from "../config/loader.js";
 import { listConnections } from "../oauth/oauth-store.js";
+import type { OnboardingContext } from "../types/onboarding-context.js";
 import { resolveBundledDir } from "../util/bundled-asset.js";
 import { getLogger } from "../util/logger.js";
 import {
@@ -199,6 +200,7 @@ export interface BuildSystemPromptOptions {
   userPersona?: string | null;
   channelPersona?: string | null;
   userSlug?: string | null;
+  onboardingContext?: OnboardingContext;
 }
 
 /**
@@ -285,6 +287,17 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
         "BOOTSTRAP.md is present — this is your first conversation. Follow its instructions.\n\n" +
         bootstrap,
     );
+
+    if (options?.onboardingContext) {
+      dynamicParts.push(
+        "## Pre-chat Onboarding Context\n\n" +
+          "The user completed the native pre-chat onboarding. Here is their context:\n\n" +
+          "```json\n" +
+          JSON.stringify(options.onboardingContext, null, 2) +
+          "\n```\n\n" +
+          "Use this to personalize your opener and skip redundant discovery.",
+      );
+    }
   }
   if (updates) {
     dynamicParts.push(

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1120,6 +1120,13 @@ export async function handleSendMessage(
     bypassSecretCheck?: boolean;
     hostHomeDir?: string;
     hostUsername?: string;
+    onboarding?: {
+      tools: string[];
+      tasks: string[];
+      tone: string;
+      userName?: string;
+      assistantName?: string;
+    };
   };
 
   const { conversationKey, content, attachmentIds } = body;
@@ -1246,6 +1253,13 @@ export async function handleSendMessage(
     mapping.conversationId,
     { transport },
   );
+
+  // Store pre-chat onboarding context on the conversation when this is the
+  // very first message (no prior messages loaded). The context is in-memory
+  // only and used to personalize the system prompt for the first turn.
+  if (body.onboarding && conversation.messages.length === 0) {
+    conversation.setOnboardingContext(body.onboarding);
+  }
 
   // Resolve guardian context from the AuthContext's actorPrincipalId.
   // The JWT-verified principal is used as the sender identity through


### PR DESCRIPTION
## Summary
- Extends POST /v1/messages to accept optional `onboarding` field
- Stores onboarding context on Conversation object (in-memory, first message only)
- Injects structured onboarding JSON into system prompt alongside BOOTSTRAP.md

Part of plan: prechat-onboarding-flow.md (PR 6 of 9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24666" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
