### PR TITLE
feat(onboarding): wire pre-chat flow into app launch and send context to daemon

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
@@ -463,6 +463,10 @@ extension AppDelegate {
             // read the randomly-generated avatar traits and sync them to the daemon.
             self?.onboardingState = state
 
+            // Store pre-chat onboarding context (if collected) so it can be
+            // forwarded to the first conversation's message POST.
+            self?.pendingPreChatContext = state.preChatContext
+
             // By this point the user has either entered an API key (steps 0→1→2)
             // or authenticated via Vellum Account (WorkOS). Proceed directly —
             // don't re-check auth, which would show the auth gate again.
@@ -498,6 +502,12 @@ extension AppDelegate {
             assistantFeatureFlagStore: featureFlagStore,
             isFirstLaunch: isFirstLaunch
         )
+        // Forward pending pre-chat onboarding context to the conversation
+        // manager so the first draft conversation includes it in its POST.
+        if let context = pendingPreChatContext {
+            main.conversationManager.preChatContext = context
+            pendingPreChatContext = nil
+        }
         main.onMicrophoneToggle = { [weak self] in
             self?.voiceInput?.toggleRecording()
         }

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -207,6 +207,11 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     /// can access the randomly-generated avatar traits.
     var onboardingState: OnboardingState?
 
+    /// Pre-chat onboarding context collected after hatching. Stored here
+    /// temporarily and forwarded to ConversationManager when the first
+    /// conversation is created, so the first message POST includes it.
+    var pendingPreChatContext: PreChatOnboardingContext?
+
     /// Guards `.appOpen` sound so it fires only once per app session,
     /// even if `proceedToApp()` is called again after assistant switches
     /// or re-authentication flows.

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -60,6 +60,13 @@ final class ConversationManager: ConversationRestorerDelegate {
     private let conversationAnalysisClient: ConversationAnalysisClientProtocol
     private let conversationRestorer: ConversationRestorer
 
+    // MARK: - Pre-Chat Onboarding
+
+    /// Pre-chat onboarding context from the onboarding flow. Set by AppDelegate
+    /// on first launch; consumed by the first draft ChatViewModel so the first
+    /// message POST includes it for assistant personalization.
+    var preChatContext: PreChatOnboardingContext?
+
     // MARK: - Notification Catch-Up
 
     /// Daemon conversation IDs that need a notification catch-up (history fetch)
@@ -489,6 +496,13 @@ final class ConversationManager: ConversationRestorerDelegate {
         }
         let viewModel = makeViewModel()
         viewModel.isHistoryLoaded = true
+        // Forward pending pre-chat onboarding context to the draft VM so
+        // the first message POST includes it. Consume from the manager so
+        // only the first draft conversation gets the context.
+        if let context = preChatContext {
+            viewModel.pendingOnboardingContext = context
+            preChatContext = nil
+        }
         viewModel.onUserMessageSent = { [weak self] in
             self?.promoteDraft(fromUserSend: true)
         }

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -19,6 +19,7 @@ struct OnboardingFlowView: View {
     @State private var managedBootstrapError: String?
     @State private var didCallComplete = false
     @State private var completionDelayTask: Task<Void, Never>?
+    @State private var isShowingPreChat = false
 
     private static let appIcon: NSImage? = {
         guard let path = ResourceBundle.bundle.path(forResource: "vellum-app-icon", ofType: "png") else { return nil }
@@ -27,6 +28,10 @@ struct OnboardingFlowView: View {
 
     private var managedSignInEnabled: Bool {
         MacOSClientFeatureFlagManager.shared.isEnabled("managed-sign-in")
+    }
+
+    private var preChatOnboardingEnabled: Bool {
+        MacOSClientFeatureFlagManager.shared.isEnabled("onboarding-pre-chat")
     }
 
     private var maxOnboardingStep: Int {
@@ -38,7 +43,31 @@ struct OnboardingFlowView: View {
         ZStack {
             VColor.surfaceOverlay.ignoresSafeArea()
 
-            if state.isHatching {
+            if isShowingPreChat {
+                PreChatOnboardingFlow { context in
+                    state.preChatContext = context
+                    // Update assistant name if user changed it during pre-chat
+                    if let newName = context?.assistantName, !newName.isEmpty, newName != state.assistantName {
+                        state.assistantName = newName
+                    }
+                    isShowingPreChat = false
+                    onComplete()
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(
+                    RadialGradient(
+                        colors: [
+                            VColor.surfaceBase,
+                            VColor.surfaceOverlay
+                        ],
+                        center: .center,
+                        startRadius: 0,
+                        endRadius: 500
+                    )
+                    .ignoresSafeArea()
+                )
+                .transition(.opacity)
+            } else if state.isHatching {
                 HatchingStepView(state: state)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .background(
@@ -264,7 +293,13 @@ struct OnboardingFlowView: View {
                     try? await Task.sleep(nanoseconds: 1_000_000_000)
                     guard !Task.isCancelled else { return }
                     guard state.hatchCompleted else { return }
-                    onComplete()
+                    if preChatOnboardingEnabled {
+                        withAnimation(.spring(duration: 0.6, bounce: 0.15)) {
+                            isShowingPreChat = true
+                        }
+                    } else {
+                        onComplete()
+                    }
                 }
             }
         }

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -108,6 +108,12 @@ final class OnboardingState {
     var hatchTotalSteps: Int = 1
     var hatchCurrentStep: Int = 0
 
+    /// Pre-chat onboarding context collected after hatching when the
+    /// `onboarding-pre-chat` feature flag is enabled. Threaded through
+    /// AppDelegate → ConversationManager → ChatViewModel so the first
+    /// message POST includes it for assistant personalization.
+    var preChatContext: PreChatOnboardingContext?
+
     /// Avatar traits generated during the hatching animation. Stored here
     /// (rather than as @State in HatchingStepView) so they survive view
     /// disappearance and are available to the post-hatch sync logic.

--- a/clients/macos/vellum-assistant/Features/Onboarding/PreChat/TaskToneSelectionView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/PreChat/TaskToneSelectionView.swift
@@ -96,7 +96,7 @@ struct TaskToneSelectionView: View {
                 }
 
                 Text(toneLabel)
-                    .font(VFont.labelStrong)
+                    .font(VFont.bodySmallEmphasised)
                     .foregroundStyle(VColor.contentDefault)
                     .frame(maxWidth: .infinity, alignment: .center)
             }

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -623,6 +623,9 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
     /// Skill IDs to pre-activate in the conversation. Included in the
     /// `conversation_create` request for deterministic skill activation.
     public var preactivatedSkillIds: [String]?
+    /// Pre-chat onboarding context to include in the first message POST.
+    /// Consumed (nilled out) by MessageSendCoordinator on the first send.
+    public var pendingOnboardingContext: PreChatOnboardingContext?
     /// Whether this view model is currently bootstrapping a new conversation
     /// (conversation_create sent, awaiting conversation_info). Used by ConversationManager
     /// to decide whether it's safe to release the VM on archive.

--- a/clients/shared/Features/Chat/MessageSendCoordinator.swift
+++ b/clients/shared/Features/Chat/MessageSendCoordinator.swift
@@ -47,6 +47,7 @@ protocol MessageSendCoordinatorDelegate: AnyObject {
     var needsOfflineFlush: Bool { get set }
     var preactivatedSkillIds: [String]? { get set }
     var pendingSuggestionRequestId: String? { get set }
+    var pendingOnboardingContext: PreChatOnboardingContext? { get set }
     var hasIncompleteToolCalls: Bool { get }
     var isAssistantBusy: Bool { get }
 
@@ -467,13 +468,22 @@ final class MessageSendCoordinator {
             delegate.startMessageLoop()
         }
 
+        // Consume pending onboarding context on the first send so it's
+        // included in the POST body. Nil it out immediately so subsequent
+        // messages do not include the onboarding payload.
+        let onboarding = delegate.pendingOnboardingContext
+        if onboarding != nil {
+            delegate.pendingOnboardingContext = nil
+        }
+
         delegate.eventStreamClient.sendUserMessage(
             content: text,
             conversationId: conversationId,
             attachments: attachments,
             conversationType: nil,
             automated: automated ? true : nil,
-            bypassSecretCheck: bypassSecretCheck ? true : nil
+            bypassSecretCheck: bypassSecretCheck ? true : nil,
+            onboarding: onboarding
         )
     }
 

--- a/clients/shared/Network/EventStreamClient.swift
+++ b/clients/shared/Network/EventStreamClient.swift
@@ -137,7 +137,8 @@ public final class EventStreamClient {
         attachments: [UserMessageAttachment]? = nil,
         conversationType: String? = nil,
         automated: Bool? = nil,
-        bypassSecretCheck: Bool? = nil
+        bypassSecretCheck: Bool? = nil,
+        onboarding: PreChatOnboardingContext? = nil
     ) {
         locallyOwnedConversationIds.insert(conversationId)
         pendingMappingLocalIds.insert(conversationId)
@@ -187,7 +188,8 @@ public final class EventStreamClient {
                 attachmentIds: attachmentIds,
                 conversationType: resolvedConversationType,
                 automated: automated,
-                bypassSecretCheck: bypassSecretCheck
+                bypassSecretCheck: bypassSecretCheck,
+                onboarding: onboarding
             )
 
             switch sendResult {

--- a/clients/shared/Network/MessageClient.swift
+++ b/clients/shared/Network/MessageClient.swift
@@ -27,7 +27,7 @@ public enum MessageSendResult: Sendable {
 /// Focused client for uploading attachments and sending user messages.
 public protocol MessageClientProtocol {
     func uploadAttachment(filename: String, mimeType: String, data: String, filePath: String?) async -> AttachmentUploadResult
-    func sendMessage(content: String?, conversationKey: String, attachmentIds: [String], conversationType: String?, automated: Bool?, bypassSecretCheck: Bool?) async -> MessageSendResult
+    func sendMessage(content: String?, conversationKey: String, attachmentIds: [String], conversationType: String?, automated: Bool?, bypassSecretCheck: Bool?, onboarding: PreChatOnboardingContext?) async -> MessageSendResult
 }
 
 /// Gateway-backed implementation of ``MessageClientProtocol``.
@@ -101,7 +101,7 @@ public struct MessageClient: MessageClientProtocol {
         }
     }
 
-    public func sendMessage(content: String?, conversationKey: String, attachmentIds: [String] = [], conversationType: String? = nil, automated: Bool? = nil, bypassSecretCheck: Bool? = nil) async -> MessageSendResult {
+    public func sendMessage(content: String?, conversationKey: String, attachmentIds: [String] = [], conversationType: String? = nil, automated: Bool? = nil, bypassSecretCheck: Bool? = nil, onboarding: PreChatOnboardingContext? = nil) async -> MessageSendResult {
         log.info("[send-pipeline] message request start — uploadedAttachmentIds=\(attachmentIds.count)")
 
         var body: [String: Any] = [
@@ -129,6 +129,20 @@ public struct MessageClient: MessageClientProtocol {
         }
         if let hostUsername = Self.hostUsername {
             body["hostUsername"] = hostUsername
+        }
+        if let onboarding {
+            var onboardingDict: [String: Any] = [
+                "tools": onboarding.tools,
+                "tasks": onboarding.tasks,
+                "tone": onboarding.tone
+            ]
+            if let userName = onboarding.userName {
+                onboardingDict["userName"] = userName
+            }
+            if let assistantName = onboarding.assistantName {
+                onboardingDict["assistantName"] = assistantName
+            }
+            body["onboarding"] = onboardingDict
         }
 
         do {


### PR DESCRIPTION
## Summary
- Inserts PreChatOnboardingFlow after hatching when feature flag is enabled
- Threads PreChatOnboardingContext through AppDelegate → ConversationManager → ChatViewModel → MessageSendCoordinator
- Extends MessageClient.sendMessage to include onboarding JSON in first message POST
- Clears onboarding context after first send (subsequent messages are clean)
- Fixes pre-existing build error: VFont.labelStrong → VFont.bodySmallEmphasised in TaskToneSelectionView

Part of plan: prechat-onboarding-flow.md (PR 8 of 9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24668" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
