### PR TITLE
fix: simplify scroll — open threads at top, persist minHeight, remove jarring fallbacks

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
@@ -237,7 +237,7 @@ struct MessageListContentView: View, Equatable {
                 // Active assistant turn: wrap in VStack with minHeight so user
                 // message sits at top. Only applies while the assistant has an
                 // active turn (sending, thinking, streaming, tool running).
-                .if(state.isActiveTurn && row.isLatestAssistant && row.message.id == state.rows.last?.message.id) { view in
+                .if(row.isLatestAssistant && row.message.id == state.rows.last?.message.id) { view in
                     VStack(spacing: 0) { view }
                         .frame(minHeight: turnMinHeight, alignment: .top)
                 }
@@ -287,9 +287,6 @@ struct MessageListContentView: View, Equatable {
             Color.clear.frame(height: 1)
                 .id("scroll-bottom-anchor")
                 .onAppear {
-                    // Signal that the bottom anchor has materialized —
-                    // isAtBottom is now reliable (based on actual content
-                    // height, not LazyVStack estimates).
                     scrollState.bottomAnchorAppeared = true
                     if !scrollState.hasBeenInteracted {
                         scrollState.handleReachedBottom()

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -484,8 +484,10 @@ final class MessageListScrollState {
     func beginStabilization(_ reason: StabilizationReason) {
         let previousMode: StabilizedMode
         switch mode {
-        case .followingBottom, .initialLoad:
+        case .followingBottom:
             previousMode = .followingBottom
+        case .initialLoad:
+            previousMode = .freeBrowsing
         case .freeBrowsing:
             previousMode = .freeBrowsing
         case .stabilizing(let prev, let activeReason):

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -51,7 +51,7 @@ enum ScrollMode: Equatable, CustomStringConvertible {
     /// until the layout mutation completes.
     var allowsAutoScroll: Bool {
         switch self {
-        case .initialLoad, .followingBottom: true
+        case .followingBottom: true
         default: false
         }
     }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
@@ -27,15 +27,7 @@ extension MessageListView {
         if isConversationSwitch {
             handleConversationSwitched()
         } else {
-            // Start the recovery window for the initial load — LazyVStack
-            // height estimates are unreliable until views materialize.
-            // (For conversation switches, reset() inside handleConversationSwitched
-            // already sets recoveryDeadline.)
-            scrollState.recoveryDeadline = Date().addingTimeInterval(2.0)
-            // Seed lastMessageId so the CTA and executeScrollToBottom always
-            // have a valid ForEach target. Without this, the initial load
-            // leaves lastMessageId nil — a CTA tap would fall back to the
-            // standalone "scroll-bottom-anchor" which may not be materialized.
+            // Seed lastMessageId for scroll-to-latest targeting.
             if let lastId = paginatedVisibleMessages.last?.id {
                 scrollState.lastMessageId = lastId
             }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
@@ -96,11 +96,7 @@ extension MessageListView {
             // yanked again by the imperative call, potentially overshooting
             // into blank LazyVStack estimated space.
             //
-            // The delayed `restoreScrollToBottom()` (100ms) acts as a safety
-            // net: if `.defaultScrollAnchor` didn't fully resolve (e.g. very
-            // long conversation with unreliable height estimates), the
-            // recovery window + restore fallback will catch it.
-            restoreScrollToBottom()
+            // Let .defaultScrollAnchor handle it — no fallback needed.
         }
     }
 
@@ -313,17 +309,8 @@ extension MessageListView {
         // "scroll-bottom-anchor" (outside ForEach) is only locatable when materialized.
         // https://developer.apple.com/documentation/swiftui/scrollposition
         scrollState.scrollRestoreTask?.cancel()
-        if anchorMessageId == nil {
-            if let lastId = paginatedVisibleMessages.last?.id {
-                scrollPosition = ScrollPosition(id: lastId, anchor: .bottom)
-            } else {
-                // Empty conversation — no ForEach items to target.
-                // Use edge-based position; the standalone "scroll-bottom-anchor"
-                // is outside ForEach and only locatable when materialized.
-                scrollPosition = ScrollPosition(edge: .bottom)
-            }
-        }
-        restoreScrollToBottom()
+        // Let .defaultScrollAnchor(.bottom, for: .initialOffset) handle
+        // initial positioning — no explicit scroll needed.
     }
 
     func handleAnchorMessageTask() async {

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -146,7 +146,7 @@ struct MessageListView: View {
             // user has entered freeBrowsing. Our explicit content-height
             // auto-follow handles streaming growth with proper mode checks.
             // https://developer.apple.com/documentation/swiftui/view/defaultscrollanchor(_:for:)
-            .defaultScrollAnchor(.bottom, for: .initialOffset)
+            .defaultScrollAnchor(.top, for: .initialOffset)
             .scrollPosition($scrollPosition)
             .environment(\.suppressAutoScroll, { [self] in
                 os_signpost(.event, log: PerfSignposts.log, name: "scrollSuppressionChanged", "on reason=manualExpansionDetach")


### PR DESCRIPTION
## Summary
- Open threads at the top instead of bottom — eliminates blank screen on thread switch caused by LazyVStack height estimation errors
- Remove explicit `scrollPosition` write and `restoreScrollToBottom()` fallback on conversation switch — no more jarring scroll jumps
- Remove `isActiveTurn` gate on minHeight so it persists after streaming ends

## Test plan
- [ ] Switch between threads — no blank screen, opens at top
- [ ] Send a message — user message scrolls to top, response streams below
- [ ] Scroll to latest button works when scrolled up
- [ ] Long conversations don't hang

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24676" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
