### PR TITLE
fix(chrome-ext): resolve extension allowlist in compiled Bun builds

### DIFF
--- a/assistant/src/runtime/routes/browser-extension-pair-routes.ts
+++ b/assistant/src/runtime/routes/browser-extension-pair-routes.ts
@@ -95,47 +95,88 @@ export type PairServerContext = {
 };
 
 const EXTENSION_ID_REGEX = /^[a-p]{32}$/;
-const ALLOWLIST_CONFIG_PATH = resolve(
-  import.meta.dir,
-  "..",
-  "..",
-  "..",
-  "..",
-  "meta",
-  "browser-extension",
-  "chrome-extension-allowlist.json",
-);
+const ALLOWLIST_CONFIG_PATH_CANDIDATES = [
+  // Source-checkout / test path (works when running from repo).
+  resolve(
+    import.meta.dir,
+    "..",
+    "..",
+    "..",
+    "..",
+    "meta",
+    "browser-extension",
+    "chrome-extension-allowlist.json",
+  ),
+  // Repo-root current-working-directory fallback.
+  resolve(
+    process.cwd(),
+    "meta",
+    "browser-extension",
+    "chrome-extension-allowlist.json",
+  ),
+];
 
 type ChromeExtensionAllowlistConfig = {
   version: number;
   allowedExtensionIds: string[];
 };
 
-function loadAllowedExtensionOrigins(): ReadonlySet<string> {
-  try {
-    const raw = readFileSync(ALLOWLIST_CONFIG_PATH, "utf8");
-    const parsed = JSON.parse(raw) as Partial<ChromeExtensionAllowlistConfig>;
-    if (!Array.isArray(parsed.allowedExtensionIds)) {
-      throw new Error("allowedExtensionIds is not an array");
-    }
-    const origins = parsed.allowedExtensionIds
-      .filter((id): id is string => typeof id === "string")
-      .filter((id) => EXTENSION_ID_REGEX.test(id))
-      .map((id) => `chrome-extension://${id}/`);
-    if (origins.length === 0) {
-      throw new Error("allowedExtensionIds has no valid extension ids");
-    }
-    return new Set<string>(origins);
-  } catch (err) {
-    log.error(
-      {
-        err,
-        allowlistConfigPath: ALLOWLIST_CONFIG_PATH,
-      },
-      "Failed to load Chrome extension allowlist config; pairing will reject all origins",
-    );
-    return new Set<string>();
+function parseAllowedExtensionIds(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    throw new Error("allowedExtensionIds is not an array");
   }
+  const ids = value
+    .filter((id): id is string => typeof id === "string")
+    .filter((id) => EXTENSION_ID_REGEX.test(id));
+  if (ids.length === 0) {
+    throw new Error("allowedExtensionIds has no valid extension ids");
+  }
+  return ids;
+}
+
+function loadAllowedExtensionIdsFromEnv(): string[] {
+  const raw =
+    process.env.VELLUM_CHROME_EXTENSION_IDS ??
+    process.env.VELLUM_CHROME_EXTENSION_ID;
+  if (!raw) return [];
+  const ids = raw
+    .split(/[,\s]+/)
+    .map((id) => id.trim())
+    .filter((id) => id.length > 0)
+    .filter((id) => EXTENSION_ID_REGEX.test(id));
+  return Array.from(new Set(ids));
+}
+
+function loadAllowedExtensionOrigins(): ReadonlySet<string> {
+  const loadErrors: string[] = [];
+  for (const configPath of ALLOWLIST_CONFIG_PATH_CANDIDATES) {
+    try {
+      const raw = readFileSync(configPath, "utf8");
+      const parsed = JSON.parse(raw) as Partial<ChromeExtensionAllowlistConfig>;
+      const ids = parseAllowedExtensionIds(parsed.allowedExtensionIds);
+      return new Set<string>(ids.map((id) => `chrome-extension://${id}/`));
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      loadErrors.push(`${configPath}: ${detail}`);
+    }
+  }
+
+  // Compiled Bun binaries run from a virtual FS root (import.meta.dir is
+  // usually `/$bunfs/root`), so repo-relative config paths can disappear in
+  // packaged builds. In that case, allow a build-time injected env fallback.
+  const envIds = loadAllowedExtensionIdsFromEnv();
+  if (envIds.length > 0) {
+    return new Set<string>(envIds.map((id) => `chrome-extension://${id}/`));
+  }
+
+  log.error(
+    {
+      allowlistConfigPathCandidates: ALLOWLIST_CONFIG_PATH_CANDIDATES,
+      loadErrors,
+    },
+    "Failed to load Chrome extension allowlist config; pairing will reject all origins",
+  );
+  return new Set<string>();
 }
 
 /**

--- a/clients/chrome-extension/README.md
+++ b/clients/chrome-extension/README.md
@@ -65,11 +65,23 @@ chmod +x dist/index.js
 
 ```bash
 mkdir -p "$HOME/Library/Application Support/Google/Chrome/NativeMessagingHosts"
+NODE_BIN="$(command -v node)"
+if [ -z "$NODE_BIN" ]; then
+  echo "node not found on PATH"
+  exit 1
+fi
+cat > "$HOME/Library/Application Support/Google/Chrome/NativeMessagingHosts/com.vellum.daemon.sh" <<'BASH'
+#!/bin/bash
+exec "__NODE_BIN__" "/ABSOLUTE/PATH/TO/clients/chrome-extension/native-host/dist/index.js" "$@"
+BASH
+sed -i '' "s|__NODE_BIN__|$NODE_BIN|g" "$HOME/Library/Application Support/Google/Chrome/NativeMessagingHosts/com.vellum.daemon.sh"
+chmod 755 "$HOME/Library/Application Support/Google/Chrome/NativeMessagingHosts/com.vellum.daemon.sh"
+
 cat > "$HOME/Library/Application Support/Google/Chrome/NativeMessagingHosts/com.vellum.daemon.json" <<'JSON'
 {
   "name": "com.vellum.daemon",
   "description": "Vellum assistant native messaging host",
-  "path": "/ABSOLUTE/PATH/TO/clients/chrome-extension/native-host/dist/index.js",
+  "path": "/Users/<you>/Library/Application Support/Google/Chrome/NativeMessagingHosts/com.vellum.daemon.sh",
   "type": "stdio",
   "allowed_origins": ["chrome-extension://YOUR_EXTENSION_ID/"]
 }
@@ -77,7 +89,9 @@ JSON
 chmod 644 "$HOME/Library/Application Support/Google/Chrome/NativeMessagingHosts/com.vellum.daemon.json"
 ```
 
-Note: the `dist/index.js` host path uses `#!/usr/bin/env node`, so `node` must be installed and on `PATH`.
+Note: prefer a wrapper script with an absolute Node path (above). Chrome launches
+native hosts with a minimal environment, so `#!/usr/bin/env node` often fails even
+when `node` works in your terminal.
 
 5. Fully quit and relaunch Chrome.
 
@@ -108,6 +122,10 @@ Then in `chrome://extensions`, click **Reload** on the unpacked extension.
 Common failures:
 - `Access to the specified native messaging host is forbidden`
   - Manifest missing/invalid, `allowed_origins` mismatch, or extension ID not allowlisted in `meta/browser-extension/chrome-extension-allowlist.json`
+- `Native host has exited`
+  - Chrome could not launch Node for a `dist/index.js` host path. Use a wrapper script with an absolute Node path in the manifest `path`.
+- `assistant pair request failed with HTTP 401`
+  - The pair endpoint rejected `extensionOrigin`. Verify your extension ID is in `meta/browser-extension/chrome-extension-allowlist.json`, then restart the assistant so it reloads allowlist config.
 - `Self-hosted relay is not paired yet`
   - Click **Pair with local assistant** first
 - `failed to reach assistant at http://127.0.0.1:<port>/v1/browser-extension-pair`

--- a/clients/chrome-extension/native-host/README.md
+++ b/clients/chrome-extension/native-host/README.md
@@ -192,6 +192,19 @@ The canonical manifest shape is checked in at
 humans reading the checked-in file — the actual install never
 performs template substitution.
 
+### Allowlist resolution in compiled builds
+
+The helper enforces its own extension-ID allowlist before it calls the
+assistant pair endpoint. It resolves IDs in this order:
+
+1. `meta/browser-extension/chrome-extension-allowlist.json` (repo checkout paths)
+2. `VELLUM_CHROME_EXTENSION_IDS` (comma/space-separated)
+3. `VELLUM_CHROME_EXTENSION_ID` (single ID)
+
+`clients/macos/build.sh` injects `VELLUM_CHROME_EXTENSION_IDS` at compile
+time from the canonical JSON allowlist so packaged binaries continue to work
+even when repo-relative paths are unavailable.
+
 ## Testing
 
 ```bash

--- a/clients/chrome-extension/native-host/src/index.ts
+++ b/clients/chrome-extension/native-host/src/index.ts
@@ -52,41 +52,81 @@ import { decodeFrames, encodeFrame, FrameDecodeError } from "./protocol.js";
 const EXTENSION_ID_REGEX = /^[a-p]{32}$/;
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
-const ALLOWLIST_CONFIG_PATH = resolve(
-  __dirname,
-  "..",
-  "..",
-  "..",
-  "..",
-  "meta",
-  "browser-extension",
-  "chrome-extension-allowlist.json",
-);
+const ALLOWLIST_CONFIG_PATH_CANDIDATES = [
+  // Source-checkout / test path (works when running from repo).
+  resolve(
+    __dirname,
+    "..",
+    "..",
+    "..",
+    "..",
+    "meta",
+    "browser-extension",
+    "chrome-extension-allowlist.json",
+  ),
+  // Repo-root current-working-directory fallback.
+  resolve(
+    process.cwd(),
+    "meta",
+    "browser-extension",
+    "chrome-extension-allowlist.json",
+  ),
+];
+
+function parseAllowedExtensionIds(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    throw new Error("allowedExtensionIds is not an array");
+  }
+  const ids = value
+    .filter((id): id is string => typeof id === "string")
+    .filter((id) => EXTENSION_ID_REGEX.test(id));
+  if (ids.length === 0) {
+    throw new Error("allowedExtensionIds has no valid extension ids");
+  }
+  return ids;
+}
+
+function loadAllowedExtensionIdsFromEnv(): string[] {
+  const raw =
+    process.env.VELLUM_CHROME_EXTENSION_IDS ??
+    process.env.VELLUM_CHROME_EXTENSION_ID;
+  if (!raw) return [];
+  const ids = raw
+    .split(/[,\s]+/)
+    .map((id) => id.trim())
+    .filter((id) => id.length > 0)
+    .filter((id) => EXTENSION_ID_REGEX.test(id));
+  return Array.from(new Set(ids));
+}
 
 function loadAllowedExtensionIds(): ReadonlySet<string> {
-  try {
-    const raw = readFileSync(ALLOWLIST_CONFIG_PATH, "utf8");
-    const parsed = JSON.parse(raw) as {
-      allowedExtensionIds?: unknown;
-    };
-    if (!Array.isArray(parsed.allowedExtensionIds)) {
-      throw new Error("allowedExtensionIds is not an array");
+  const loadErrors: string[] = [];
+  for (const configPath of ALLOWLIST_CONFIG_PATH_CANDIDATES) {
+    try {
+      const raw = readFileSync(configPath, "utf8");
+      const parsed = JSON.parse(raw) as {
+        allowedExtensionIds?: unknown;
+      };
+      return new Set<string>(parseAllowedExtensionIds(parsed.allowedExtensionIds));
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      loadErrors.push(`${configPath}: ${detail}`);
     }
-    const ids = parsed.allowedExtensionIds
-      .filter((id): id is string => typeof id === "string")
-      .filter((id) => EXTENSION_ID_REGEX.test(id));
-    if (ids.length === 0) {
-      throw new Error("allowedExtensionIds has no valid extension ids");
-    }
-    return new Set<string>(ids);
-  } catch (err) {
-    process.stderr.write(
-      `vellum-chrome-native-host: failed to load allowlist config at ${ALLOWLIST_CONFIG_PATH}: ${
-        err instanceof Error ? err.message : String(err)
-      }\n`,
-    );
-    return new Set<string>();
   }
+
+  // Compiled Bun binaries run from a virtual FS root (import.meta.dir is
+  // usually `/$bunfs/root`), so repo-relative config paths can disappear in
+  // packaged builds. In that case, allow a build-time injected env fallback.
+  const envIds = loadAllowedExtensionIdsFromEnv();
+  if (envIds.length > 0) {
+    return new Set<string>(envIds);
+  }
+
+  process.stderr.write(
+    "vellum-chrome-native-host: failed to load allowlist config from any candidate path " +
+      `(${ALLOWLIST_CONFIG_PATH_CANDIDATES.join(", ")}); details: ${loadErrors.join(" | ")}\n`,
+  );
+  return new Set<string>();
 }
 
 const ALLOWED_EXTENSION_IDS: ReadonlySet<string> = loadAllowedExtensionIds();

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -237,6 +237,27 @@ CLI_SRC_DIR="$SCRIPT_DIR/../../cli"
 GATEWAY_SRC_DIR="$SCRIPT_DIR/../../gateway"
 NATIVE_HOST_SRC_DIR="$SCRIPT_DIR/../chrome-extension/native-host"
 
+# Chrome extension allowlist IDs injected into compiled binaries as a fallback
+# for packaged runs where repo-relative `meta/browser-extension/...` paths are
+# unavailable (Bun compiled binaries often resolve import.meta.dir to /$bunfs/root).
+CHROME_EXTENSION_ALLOWLIST_PATH="$_repo_root/meta/browser-extension/chrome-extension-allowlist.json"
+CHROME_EXTENSION_IDS_CSV=""
+if [ -f "$CHROME_EXTENSION_ALLOWLIST_PATH" ] && command -v bun &>/dev/null; then
+    CHROME_EXTENSION_IDS_CSV=$(
+        CHROME_ALLOWLIST_PATH="$CHROME_EXTENSION_ALLOWLIST_PATH" bun --eval '
+            const fs = require("node:fs");
+            const raw = fs.readFileSync(process.env.CHROME_ALLOWLIST_PATH, "utf8");
+            const parsed = JSON.parse(raw);
+            if (!Array.isArray(parsed.allowedExtensionIds)) process.exit(1);
+            const ids = parsed.allowedExtensionIds.filter(
+              (id) => typeof id === "string" && /^[a-p]{32}$/.test(id),
+            );
+            if (ids.length === 0) process.exit(1);
+            process.stdout.write(ids.join(","));
+        ' 2>/dev/null || true
+    )
+fi
+
 # Packages that must stay external in compiled Bun binaries.
 # playwright-core has optional requires (electron, chromium-bidi) that cannot
 # be resolved at bundle time.  Mark them external so bun --compile skips them.
@@ -287,10 +308,11 @@ build_bun_binary() {
 }
 
 # ---------------------------------------------------------------------------
-# build_binaries — build all Bun binaries (daemon, CLI, gateway).
+# build_binaries — build all Bun binaries (daemon, assistant CLI, CLI, gateway,
+# and chrome native host helper).
 #
 # Installs dependencies once per source directory upfront, then compiles all
-# four binaries in parallel to reduce wall-clock time.
+# all binaries in parallel to reduce wall-clock time.
 # ---------------------------------------------------------------------------
 build_binaries() {
     command -v bun &>/dev/null || { echo "ERROR: bun is required but not found"; exit 1; }
@@ -313,6 +335,9 @@ build_binaries() {
     if [ -n "${COMMIT_SHA:-}" ]; then
         daemon_flags+=(--define "process.env.COMMIT_SHA='$COMMIT_SHA'")
     fi
+    if [ -n "${CHROME_EXTENSION_IDS_CSV:-}" ]; then
+        daemon_flags+=(--define "process.env.VELLUM_CHROME_EXTENSION_IDS='$CHROME_EXTENSION_IDS_CSV'")
+    fi
 
     local cli_flags=("${BUN_EXTERNAL_FLAGS[@]}")
     if [ -n "${DISPLAY_VERSION:-}" ] && [ "$DISPLAY_VERSION" != "0.1.0" ]; then
@@ -321,8 +346,16 @@ build_binaries() {
     if [ -n "${COMMIT_SHA:-}" ]; then
         cli_flags+=(--define "process.env.COMMIT_SHA='$COMMIT_SHA'")
     fi
+    if [ -n "${CHROME_EXTENSION_IDS_CSV:-}" ]; then
+        cli_flags+=(--define "process.env.VELLUM_CHROME_EXTENSION_IDS='$CHROME_EXTENSION_IDS_CSV'")
+    fi
 
-    # Build all four binaries in parallel. Each writes to its own output
+    local native_host_flags=()
+    if [ -n "${CHROME_EXTENSION_IDS_CSV:-}" ]; then
+        native_host_flags+=(--define "process.env.VELLUM_CHROME_EXTENSION_IDS='$CHROME_EXTENSION_IDS_CSV'")
+    fi
+
+    # Build binaries in parallel. Each writes to its own output
     # directory so there are no filesystem conflicts. SKIP_BUN_INSTALL=1
     # tells build_bun_binary to skip `bun install` (already done above).
     echo "Building binaries in parallel..."
@@ -346,7 +379,7 @@ build_binaries() {
 
     if [ -d "$NATIVE_HOST_SRC_DIR/src" ]; then
         SKIP_BUN_INSTALL=1 build_bun_binary "$NATIVE_HOST_SRC_DIR" "$NATIVE_HOST_SRC_DIR/src/index.ts" \
-            "$SCRIPT_DIR/native-host-bin" "vellum-chrome-native-host" &
+            "$SCRIPT_DIR/native-host-bin" "vellum-chrome-native-host" "${native_host_flags[@]}" &
         pids+=($!)
     fi
 
@@ -606,6 +639,9 @@ if [ "$DAEMON_BIN_NEEDS_BUILD" = true ]; then
     if [ -n "${COMMIT_SHA:-}" ]; then
         local_daemon_flags+=(--define "process.env.COMMIT_SHA='$COMMIT_SHA'")
     fi
+    if [ -n "${CHROME_EXTENSION_IDS_CSV:-}" ]; then
+        local_daemon_flags+=(--define "process.env.VELLUM_CHROME_EXTENSION_IDS='$CHROME_EXTENSION_IDS_CSV'")
+    fi
     build_bun_binary "$ASSISTANT_SRC_DIR" "$ASSISTANT_SRC_DIR/src/daemon/main.ts" \
         "$SCRIPT_DIR/daemon-bin" "vellum-daemon" "${local_daemon_flags[@]}"
     cp "$ASSISTANT_SRC_DIR/node_modules/web-tree-sitter/web-tree-sitter.wasm" "$SCRIPT_DIR/daemon-bin/"
@@ -660,8 +696,12 @@ if [ "${SKIP_BUN_REBUILD:-}" != "1" ] && [ -d "$ASSISTANT_SRC_DIR/src" ] && comm
     fi
 fi
 if [ "$ASSISTANT_CLI_BIN_NEEDS_BUILD" = true ]; then
+    local_assistant_flags=("${BUN_EXTERNAL_FLAGS[@]}")
+    if [ -n "${CHROME_EXTENSION_IDS_CSV:-}" ]; then
+        local_assistant_flags+=(--define "process.env.VELLUM_CHROME_EXTENSION_IDS='$CHROME_EXTENSION_IDS_CSV'")
+    fi
     build_bun_binary "$ASSISTANT_SRC_DIR" "$ASSISTANT_SRC_DIR/src/index.ts" \
-        "$SCRIPT_DIR/assistant-bin" "vellum-assistant" "${BUN_EXTERNAL_FLAGS[@]}"
+        "$SCRIPT_DIR/assistant-bin" "vellum-assistant" "${local_assistant_flags[@]}"
 fi
 
 # Also rebuild if assistant CLI binary changed or newly added
@@ -737,8 +777,12 @@ if [ "${SKIP_BUN_REBUILD:-}" != "1" ] && [ -d "$NATIVE_HOST_SRC_DIR/src" ] && co
     fi
 fi
 if [ "$NATIVE_HOST_BIN_NEEDS_BUILD" = true ]; then
+    local_native_host_flags=()
+    if [ -n "${CHROME_EXTENSION_IDS_CSV:-}" ]; then
+        local_native_host_flags+=(--define "process.env.VELLUM_CHROME_EXTENSION_IDS='$CHROME_EXTENSION_IDS_CSV'")
+    fi
     build_bun_binary "$NATIVE_HOST_SRC_DIR" "$NATIVE_HOST_SRC_DIR/src/index.ts" \
-        "$SCRIPT_DIR/native-host-bin" "vellum-chrome-native-host"
+        "$SCRIPT_DIR/native-host-bin" "vellum-chrome-native-host" "${local_native_host_flags[@]}"
 fi
 
 # Also rebuild if native host binary changed or newly added


### PR DESCRIPTION
## Summary
- Compiled Bun binaries can't find the repo-relative `chrome-extension-allowlist.json` because `import.meta.dir` resolves to `/$bunfs/root`. This adds multiple candidate paths plus an env var fallback (`VELLUM_CHROME_EXTENSION_IDS`) that `build.sh` injects at compile time via `--define`.
- Extracts shared `parseAllowedExtensionIds` and `loadAllowedExtensionIdsFromEnv` helpers in both the native host and the assistant pair routes.
- Updates Chrome extension READMEs with wrapper script setup instructions and additional troubleshooting entries.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24680" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
