### PR TITLE
fix(auth): sync local env signing key to disk to prevent relay invalid_signature

### DIFF
--- a/assistant/src/__tests__/docker-signing-key-bootstrap.test.ts
+++ b/assistant/src/__tests__/docker-signing-key-bootstrap.test.ts
@@ -1,9 +1,17 @@
 /**
- * Tests for resolveSigningKey() covering env var injection (Docker)
- * and file-based load/create (local mode).
+ * Tests for resolveSigningKey() covering env var injection (Docker),
+ * file-based load/create (local mode), and env-to-disk sync for CLI
+ * signing-key convergence.
  */
 
-import { existsSync, rmSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 mock.module("../util/logger.js", () => ({
@@ -13,7 +21,15 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
-const { resolveSigningKey } = await import("../runtime/auth/token-service.js");
+const {
+  resolveSigningKey,
+  initAuthSigningKey,
+  loadSigningKey,
+  mintToken,
+  verifyToken,
+  _resetSigningKeyForTesting,
+} = await import("../runtime/auth/token-service.js");
+const { CURRENT_POLICY_EPOCH } = await import("../runtime/auth/policy.js");
 const { getDeprecatedDir } = await import("../util/platform.js");
 
 const VALID_HEX_KEY = "ab".repeat(32); // 64 hex chars = 32 bytes
@@ -22,6 +38,7 @@ const savedEnv: Record<string, string | undefined> = {};
 
 beforeEach(() => {
   savedEnv.ACTOR_TOKEN_SIGNING_KEY = process.env.ACTOR_TOKEN_SIGNING_KEY;
+  savedEnv.IS_CONTAINERIZED = process.env.IS_CONTAINERIZED;
   // Clean up key files from previous tests so they don't leak between cases.
   const deprecatedDir = getDeprecatedDir();
   if (existsSync(deprecatedDir))
@@ -34,6 +51,13 @@ afterEach(() => {
   } else {
     process.env.ACTOR_TOKEN_SIGNING_KEY = savedEnv.ACTOR_TOKEN_SIGNING_KEY;
   }
+  if (savedEnv.IS_CONTAINERIZED === undefined) {
+    delete process.env.IS_CONTAINERIZED;
+  } else {
+    process.env.IS_CONTAINERIZED = savedEnv.IS_CONTAINERIZED;
+  }
+  // Reset signing key so interop tests don't leak state
+  _resetSigningKeyForTesting();
 });
 
 describe("resolveSigningKey", () => {
@@ -74,5 +98,144 @@ describe("resolveSigningKey", () => {
 
     expect(key2.toString("hex")).toBe("cd".repeat(32));
     expect(key2.toString("hex")).not.toBe(key1.toString("hex"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Env-to-disk signing key sync
+// ---------------------------------------------------------------------------
+
+describe("env-to-disk signing key sync", () => {
+  test("env key syncs to canonical disk path in non-containerized mode", () => {
+    delete process.env.IS_CONTAINERIZED;
+    process.env.ACTOR_TOKEN_SIGNING_KEY = VALID_HEX_KEY;
+
+    const key = resolveSigningKey();
+
+    expect(key.toString("hex")).toBe(VALID_HEX_KEY);
+
+    const keyPath = join(getDeprecatedDir(), "actor-token-signing-key");
+    expect(existsSync(keyPath)).toBe(true);
+    const diskKey = readFileSync(keyPath);
+    expect(diskKey.length).toBe(32);
+    expect(diskKey.toString("hex")).toBe(VALID_HEX_KEY);
+  });
+
+  test("env key does NOT sync to disk in containerized mode", () => {
+    process.env.IS_CONTAINERIZED = "true";
+    process.env.ACTOR_TOKEN_SIGNING_KEY = VALID_HEX_KEY;
+
+    const key = resolveSigningKey();
+
+    expect(key.toString("hex")).toBe(VALID_HEX_KEY);
+
+    const keyPath = join(getDeprecatedDir(), "actor-token-signing-key");
+    expect(existsSync(keyPath)).toBe(false);
+  });
+
+  test("mismatched disk key is updated to env key in non-containerized mode", () => {
+    delete process.env.IS_CONTAINERIZED;
+
+    // Write a mismatched key to disk first
+    const keyPath = join(getDeprecatedDir(), "actor-token-signing-key");
+    const dir = dirname(keyPath);
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
+    const mismatchedKey = Buffer.from("ff".repeat(32), "hex");
+    writeFileSync(keyPath, mismatchedKey, { mode: 0o600 });
+
+    // Set a different env key
+    process.env.ACTOR_TOKEN_SIGNING_KEY = VALID_HEX_KEY;
+
+    const key = resolveSigningKey();
+    expect(key.toString("hex")).toBe(VALID_HEX_KEY);
+
+    // Disk key should now match env key
+    const diskKey = readFileSync(keyPath);
+    expect(diskKey.toString("hex")).toBe(VALID_HEX_KEY);
+  });
+
+  test("matching disk key is not rewritten (no-op)", () => {
+    delete process.env.IS_CONTAINERIZED;
+    process.env.ACTOR_TOKEN_SIGNING_KEY = VALID_HEX_KEY;
+
+    // First call writes the key
+    resolveSigningKey();
+    const keyPath = join(getDeprecatedDir(), "actor-token-signing-key");
+    expect(existsSync(keyPath)).toBe(true);
+
+    // Second call with same key should not throw or fail
+    const key2 = resolveSigningKey();
+    expect(key2.toString("hex")).toBe(VALID_HEX_KEY);
+
+    const diskKey = readFileSync(keyPath);
+    expect(diskKey.toString("hex")).toBe(VALID_HEX_KEY);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Signature interoperability between daemon (env key) and CLI (disk key)
+// ---------------------------------------------------------------------------
+
+describe("daemon/CLI signing key interoperability", () => {
+  test("token minted via CLI disk-load path verifies with daemon env key after sync", () => {
+    delete process.env.IS_CONTAINERIZED;
+
+    // Pre-seed a mismatched "legacy" disk key to simulate the pre-fix state
+    const keyPath = join(getDeprecatedDir(), "actor-token-signing-key");
+    const dir = dirname(keyPath);
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
+    const legacyKey = Buffer.from("ee".repeat(32), "hex");
+    writeFileSync(keyPath, legacyKey, { mode: 0o600 });
+
+    // --- Daemon startup path ---
+    // Set the env key and call resolveSigningKey (daemon behavior).
+    // This syncs the env key to disk.
+    process.env.ACTOR_TOKEN_SIGNING_KEY = VALID_HEX_KEY;
+    const daemonKey = resolveSigningKey();
+    initAuthSigningKey(daemonKey);
+
+    // Mint a token using the daemon's key
+    const daemonToken = mintToken({
+      aud: "vellum-daemon",
+      sub: "svc:daemon:self",
+      scope_profile: "gateway_service_v1",
+      policy_epoch: CURRENT_POLICY_EPOCH,
+      ttlSeconds: 60,
+    });
+
+    // --- CLI subprocess path ---
+    // Reset signing key to simulate a fresh CLI subprocess context
+    _resetSigningKeyForTesting();
+
+    // CLI loads key from disk (post-sync, disk now matches env key)
+    const cliDiskKey = loadSigningKey();
+    expect(cliDiskKey).toBeDefined();
+    initAuthSigningKey(cliDiskKey!);
+
+    // Mint a token using the CLI's disk-loaded key
+    const cliToken = mintToken({
+      aud: "vellum-daemon",
+      sub: "svc:daemon:self",
+      scope_profile: "gateway_service_v1",
+      policy_epoch: CURRENT_POLICY_EPOCH,
+      ttlSeconds: 60,
+    });
+
+    // --- Cross-verification ---
+    // CLI-minted token must verify with daemon key
+    _resetSigningKeyForTesting();
+    initAuthSigningKey(daemonKey);
+    const cliResult = verifyToken(cliToken, "vellum-daemon");
+    expect(cliResult.ok).toBe(true);
+
+    // Daemon-minted token must verify with CLI disk key
+    _resetSigningKeyForTesting();
+    initAuthSigningKey(cliDiskKey!);
+    const daemonResult = verifyToken(daemonToken, "vellum-daemon");
+    expect(daemonResult.ok).toBe(true);
   });
 });

--- a/assistant/src/cli/commands/browser-relay.ts
+++ b/assistant/src/cli/commands/browser-relay.ts
@@ -73,6 +73,10 @@ function resolveRuntimePort(): number {
  * Mirrors `mintDaemonDeliveryToken` (sub=svc:daemon:self,
  * scope_profile=gateway_service_v1, aud=vellum-daemon) but is minted
  * out-of-process by the CLI using the on-disk signing key.
+ *
+ * Relies on the daemon's `resolveSigningKey()` having synced the
+ * env-resolved signing key to the canonical disk path so the key
+ * loaded here matches the daemon's verifier key.
  */
 function mintCliToken(): string {
   if (!isSigningKeyInitialized()) {

--- a/assistant/src/runtime/auth/token-service.ts
+++ b/assistant/src/runtime/auth/token-service.ts
@@ -22,6 +22,7 @@ import {
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 
+import { getIsContainerized } from "../../config/env-registry.js";
 import { getLogger } from "../../util/logger.js";
 import { getDeprecatedDir } from "../../util/platform.js";
 import { CURRENT_POLICY_EPOCH, isStaleEpoch } from "./policy.js";
@@ -116,6 +117,58 @@ export function loadOrCreateSigningKey(): Buffer {
 }
 
 /**
+ * Best-effort sync of the env-resolved signing key to the canonical disk
+ * path so out-of-process CLI commands (e.g. browser relay) that load from
+ * disk converge on the same key the daemon uses.
+ *
+ * Security note: this does NOT expand the signing key's exposure surface.
+ * `loadOrCreateSigningKey()` already writes a signing key to the exact same
+ * disk path (getSigningKeyPath()) with the same mode (0600). A signing key
+ * is always on disk for CLI subprocesses to read — this function just
+ * ensures the disk key matches the env-provided key so those subprocesses
+ * mint tokens the daemon will actually accept.
+ *
+ * Skipped in containerized mode where disk key files are not used.
+ * Uses atomic write (tmp + rename) with mode 0600 for safe persistence.
+ * Never throws -- logs a warning on write failure and continues with
+ * the in-memory key.
+ */
+function syncEnvSigningKeyToDiskIfNeeded(key: Buffer): void {
+  if (getIsContainerized()) {
+    return;
+  }
+
+  const keyPath = getSigningKeyPath();
+
+  try {
+    // If the file already exists and is byte-equal, no-op.
+    if (existsSync(keyPath)) {
+      const existing = readFileSync(keyPath);
+      if (existing.length === key.length && timingSafeEqual(existing, key)) {
+        return;
+      }
+    }
+
+    // Write atomically: tmp file + rename.
+    const dir = dirname(keyPath);
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
+    const tmpPath = keyPath + ".tmp." + process.pid;
+    writeFileSync(tmpPath, key, { mode: 0o600 });
+    renameSync(tmpPath, keyPath);
+    chmodSync(keyPath, 0o600);
+
+    log.info("Synced env signing key to disk for CLI convergence");
+  } catch (err) {
+    log.warn(
+      { err },
+      "Failed to sync env signing key to disk — continuing with in-memory key",
+    );
+  }
+}
+
+/**
  * Resolve the signing key for the daemon from the `ACTOR_TOKEN_SIGNING_KEY`
  * env var (hex-encoded, 64 chars). The CLI launcher sets this before
  * spawning the daemon; in Docker the gateway injects it.
@@ -128,8 +181,10 @@ export function resolveSigningKey(): Buffer {
         `Invalid ACTOR_TOKEN_SIGNING_KEY: expected 64 hex characters, got ${envKey.length} chars`,
       );
     }
+    const key = Buffer.from(envKey, "hex");
+    syncEnvSigningKeyToDiskIfNeeded(key);
     log.info("Signing key loaded from ACTOR_TOKEN_SIGNING_KEY env var");
-    return Buffer.from(envKey, "hex");
+    return key;
   }
 
   // Fallback: env var not set (e.g. daemon spawned by cli/src/lib/local.ts


### PR DESCRIPTION
## Summary
Fix the deterministic `invalid_signature` failure for `assistant browser chrome relay` by syncing the daemon's env-resolved signing key to the canonical disk path in non-containerized mode, so out-of-process CLI commands that load from disk converge on the same key material.

## Self-review result
PASS — all three review passes (external feedback, plan faithfulness, repo integration) returned PASS with no gaps.

## PRs merged into feature branch
- #24682: fix(auth): sync local env signing key to disk to prevent relay invalid_signature

### Fix PRs
None needed.

Part of plan: browser-relay-invalid-signature-low-risk-remediation-plan-2026-04-10.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24683" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
