### PR TITLE
feat(oauth): support JSON body format for token exchange and refresh

### DIFF
--- a/assistant/src/__tests__/oauth-provider-serializer.test.ts
+++ b/assistant/src/__tests__/oauth-provider-serializer.test.ts
@@ -15,6 +15,7 @@ function makeRow(overrides: Partial<OAuthProviderRow> = {}): OAuthProviderRow {
     tokenExchangeUrl: "https://auth.example.com/token",
     refreshUrl: null,
     tokenEndpointAuthMethod: "client_secret_post",
+    tokenExchangeBodyFormat: "form",
     userinfoUrl: null,
     baseUrl: null,
     defaultScopes: "[]",

--- a/assistant/src/__tests__/oauth2-gateway-transport.test.ts
+++ b/assistant/src/__tests__/oauth2-gateway-transport.test.ts
@@ -83,6 +83,7 @@ mock.module("../inbound/platform-callback-registration.js", () => ({
 // Track token exchange request
 let lastTokenRequestBody: URLSearchParams | null = null;
 let lastTokenRequestHeaders: Record<string, string> = {};
+let lastTokenRequestRawBody: string | null = null;
 
 // Mock fetch for token exchange
 let mockTokenResponse: {
@@ -112,7 +113,12 @@ globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
   if (url.includes("token")) {
     // Capture request body and headers for assertions
     if (init?.body) {
-      lastTokenRequestBody = new URLSearchParams(init.body as string);
+      lastTokenRequestRawBody = String(init.body);
+      try {
+        lastTokenRequestBody = new URLSearchParams(init.body as string);
+      } catch {
+        lastTokenRequestBody = null;
+      }
     }
     if (init?.headers) {
       lastTokenRequestHeaders = init.headers as Record<string, string>;
@@ -151,6 +157,7 @@ beforeEach(() => {
   pendingCallbacks.clear();
   lastTokenRequestBody = null;
   lastTokenRequestHeaders = {};
+  lastTokenRequestRawBody = null;
   mockTokenResponse = {
     ok: true,
     status: 200,
@@ -842,6 +849,147 @@ describe("OAuth2 gateway transport", () => {
 
       const result = await flowPromise;
       expect(result.grantedScopes).toEqual(["read", "write", "admin"]);
+    });
+  });
+
+  describe("tokenExchangeBodyFormat", () => {
+    test("sends JSON body when tokenExchangeBodyFormat is 'json'", async () => {
+      mockPublicBaseUrl = "https://gw.example.com";
+
+      const jsonConfig: OAuth2Config = {
+        ...BASE_OAUTH_CONFIG,
+        clientSecret: "test-client-secret",
+        tokenExchangeBodyFormat: "json",
+      };
+
+      const flowPromise = startOAuth2Flow(
+        jsonConfig,
+        { openUrl: () => {} },
+        { callbackTransport: "gateway" },
+      );
+
+      await new Promise((r) => setTimeout(r, 10));
+
+      const entries = Array.from(pendingCallbacks.entries());
+      entries[0][1].resolve("json-body-code");
+
+      await flowPromise;
+
+      // Content-Type should be application/json
+      expect(lastTokenRequestHeaders["Content-Type"]).toBe("application/json");
+
+      // Body should be valid JSON
+      expect(lastTokenRequestRawBody).not.toBeNull();
+      const parsed = JSON.parse(lastTokenRequestRawBody!);
+      expect(parsed.grant_type).toBe("authorization_code");
+      expect(parsed.client_id).toBe("test-client-id");
+      expect(parsed.client_secret).toBe("test-client-secret");
+      expect(parsed.code).toBe("json-body-code");
+      expect(parsed.code_verifier).toBeTruthy();
+    });
+
+    test("sends form-encoded body by default (tokenExchangeBodyFormat omitted)", async () => {
+      mockPublicBaseUrl = "https://gw.example.com";
+
+      const flowPromise = startOAuth2Flow(
+        BASE_OAUTH_CONFIG,
+        { openUrl: () => {} },
+        { callbackTransport: "gateway" },
+      );
+
+      await new Promise((r) => setTimeout(r, 10));
+
+      const entries = Array.from(pendingCallbacks.entries());
+      entries[0][1].resolve("form-body-code");
+
+      await flowPromise;
+
+      // Content-Type should be form-encoded
+      expect(lastTokenRequestHeaders["Content-Type"]).toBe(
+        "application/x-www-form-urlencoded",
+      );
+
+      // Body should be parseable as URLSearchParams
+      expect(lastTokenRequestBody).not.toBeNull();
+      expect(lastTokenRequestBody!.get("grant_type")).toBe(
+        "authorization_code",
+      );
+      expect(lastTokenRequestBody!.get("client_id")).toBe("test-client-id");
+    });
+
+    test("sends form-encoded body when tokenExchangeBodyFormat is explicitly 'form'", async () => {
+      mockPublicBaseUrl = "https://gw.example.com";
+
+      const formConfig: OAuth2Config = {
+        ...BASE_OAUTH_CONFIG,
+        tokenExchangeBodyFormat: "form",
+      };
+
+      const flowPromise = startOAuth2Flow(
+        formConfig,
+        { openUrl: () => {} },
+        { callbackTransport: "gateway" },
+      );
+
+      await new Promise((r) => setTimeout(r, 10));
+
+      const entries = Array.from(pendingCallbacks.entries());
+      entries[0][1].resolve("explicit-form-code");
+
+      await flowPromise;
+
+      // Content-Type should be form-encoded
+      expect(lastTokenRequestHeaders["Content-Type"]).toBe(
+        "application/x-www-form-urlencoded",
+      );
+
+      // Body should be parseable as URLSearchParams
+      expect(lastTokenRequestBody).not.toBeNull();
+      expect(lastTokenRequestBody!.get("grant_type")).toBe(
+        "authorization_code",
+      );
+    });
+
+    test("JSON body format works with client_secret_basic auth method", async () => {
+      mockPublicBaseUrl = "https://gw.example.com";
+
+      const jsonBasicConfig: OAuth2Config = {
+        ...BASE_OAUTH_CONFIG,
+        clientSecret: "test-client-secret",
+        tokenEndpointAuthMethod: "client_secret_basic",
+        tokenExchangeBodyFormat: "json",
+      };
+
+      const flowPromise = startOAuth2Flow(
+        jsonBasicConfig,
+        { openUrl: () => {} },
+        { callbackTransport: "gateway" },
+      );
+
+      await new Promise((r) => setTimeout(r, 10));
+
+      const entries = Array.from(pendingCallbacks.entries());
+      entries[0][1].resolve("json-basic-code");
+
+      await flowPromise;
+
+      // Content-Type should be application/json
+      expect(lastTokenRequestHeaders["Content-Type"]).toBe("application/json");
+
+      // Should have Basic Auth header
+      const expectedCredentials = Buffer.from(
+        "test-client-id:test-client-secret",
+      ).toString("base64");
+      expect(lastTokenRequestHeaders["Authorization"]).toBe(
+        `Basic ${expectedCredentials}`,
+      );
+
+      // Body should be valid JSON without client_id/client_secret
+      const parsed = JSON.parse(lastTokenRequestRawBody!);
+      expect(parsed.grant_type).toBe("authorization_code");
+      expect(parsed.client_id).toBeUndefined();
+      expect(parsed.client_secret).toBeUndefined();
+      expect(parsed.code_verifier).toBeTruthy();
     });
   });
 });

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -119,6 +119,7 @@ import {
   migrateOAuthProvidersRevoke,
   migrateOAuthProvidersScopeSeparator,
   migrateOAuthProvidersTokenAuthMethodDefault,
+  migrateOAuthProvidersTokenExchangeBodyFormat,
   migrateReminderRoutingIntent,
   migrateRemindersToSchedules,
   migrateRenameConversationTypeColumn,
@@ -364,6 +365,7 @@ export function initializeDb(): void {
     migrateOAuthProvidersTokenAuthMethodDefault,
     migrateConversationHostAccess,
     migrateOAuthProvidersLogoUrl,
+    migrateOAuthProvidersTokenExchangeBodyFormat,
   ];
 
   // Run each migration step, catching and logging individual failures so one

--- a/assistant/src/memory/migrations/219-oauth-providers-token-exchange-body-format.ts
+++ b/assistant/src/memory/migrations/219-oauth-providers-token-exchange-body-format.ts
@@ -1,0 +1,15 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+
+export function migrateOAuthProvidersTokenExchangeBodyFormat(
+  database: DrizzleDb,
+): void {
+  const raw = getSqliteFrom(database);
+  try {
+    raw.exec(
+      /*sql*/ `ALTER TABLE oauth_providers ADD COLUMN token_exchange_body_format TEXT NOT NULL DEFAULT 'form'`,
+    );
+  } catch {
+    // Column already exists — nothing to do.
+  }
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -160,6 +160,7 @@ export { migrateOAuthProvidersRevoke } from "./215-oauth-providers-revoke.js";
 export { migrateOAuthProvidersTokenAuthMethodDefault } from "./216-oauth-providers-token-auth-method.js";
 export { migrateConversationHostAccess } from "./217-conversation-host-access.js";
 export { migrateOAuthProvidersLogoUrl } from "./218-oauth-providers-logo-url.js";
+export { migrateOAuthProvidersTokenExchangeBodyFormat } from "./219-oauth-providers-token-exchange-body-format.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema/oauth.ts
+++ b/assistant/src/memory/schema/oauth.ts
@@ -14,6 +14,9 @@ export const oauthProviders = sqliteTable("oauth_providers", {
   tokenEndpointAuthMethod: text("token_endpoint_auth_method")
     .notNull()
     .default("client_secret_post"),
+  tokenExchangeBodyFormat: text("token_exchange_body_format")
+    .notNull()
+    .default("form"),
   userinfoUrl: text("userinfo_url"),
   baseUrl: text("base_url"),
   defaultScopes: text("default_scopes").notNull().default("[]"),

--- a/assistant/src/oauth/__tests__/identity-verifier.test.ts
+++ b/assistant/src/oauth/__tests__/identity-verifier.test.ts
@@ -34,6 +34,7 @@ function makeProviderRow(
     tokenExchangeUrl: "https://example.com/token",
     refreshUrl: null,
     tokenEndpointAuthMethod: "client_secret_post",
+    tokenExchangeBodyFormat: "form",
     userinfoUrl: null,
     baseUrl: null,
     defaultScopes: "[]",

--- a/assistant/src/oauth/connect-orchestrator.ts
+++ b/assistant/src/oauth/connect-orchestrator.ts
@@ -209,6 +209,8 @@ export async function orchestrateOAuthConnect(
     authorizeParams,
     userinfoUrl,
     tokenEndpointAuthMethod,
+    tokenExchangeBodyFormat:
+      (providerRow.tokenExchangeBodyFormat as "form" | "json") ?? "form",
   };
 
   const storageParams = {

--- a/assistant/src/oauth/oauth-store.ts
+++ b/assistant/src/oauth/oauth-store.ts
@@ -72,6 +72,7 @@ export function seedProviders(
     tokenExchangeUrl: string;
     refreshUrl?: string;
     tokenEndpointAuthMethod?: string;
+    tokenExchangeBodyFormat?: string;
     userinfoUrl?: string;
     pingUrl?: string;
     pingMethod?: string;
@@ -122,6 +123,7 @@ export function seedProviders(
     // token endpoint auth method.
     const tokenEndpointAuthMethod =
       p.tokenEndpointAuthMethod || "client_secret_post";
+    const tokenExchangeBodyFormat = p.tokenExchangeBodyFormat || "form";
     const userinfoUrl = p.userinfoUrl ?? null;
     const pingUrl = p.pingUrl ?? null;
     const pingMethod = p.pingMethod ?? null;
@@ -176,6 +178,7 @@ export function seedProviders(
         tokenExchangeUrl,
         refreshUrl,
         tokenEndpointAuthMethod,
+        tokenExchangeBodyFormat,
         userinfoUrl,
         baseUrl,
         defaultScopes,
@@ -217,6 +220,7 @@ export function seedProviders(
           tokenExchangeUrl,
           refreshUrl,
           tokenEndpointAuthMethod,
+          tokenExchangeBodyFormat,
           userinfoUrl,
           baseUrl: sql`COALESCE(${oauthProviders.baseUrl}, ${baseUrl})`,
           scopeSeparator,

--- a/assistant/src/oauth/oauth-store.ts
+++ b/assistant/src/oauth/oauth-store.ts
@@ -335,6 +335,7 @@ export function registerProvider(params: {
     refreshUrl: params.refreshUrl ?? null,
     tokenEndpointAuthMethod:
       params.tokenEndpointAuthMethod || "client_secret_post",
+    tokenExchangeBodyFormat: "form",
     userinfoUrl: params.userinfoUrl ?? null,
     baseUrl: params.baseUrl ?? null,
     defaultScopes: JSON.stringify(params.defaultScopes),

--- a/assistant/src/oauth/oauth-store.ts
+++ b/assistant/src/oauth/oauth-store.ts
@@ -283,6 +283,7 @@ export function registerProvider(params: {
   tokenExchangeUrl: string;
   refreshUrl?: string;
   tokenEndpointAuthMethod?: string;
+  tokenExchangeBodyFormat?: string;
   userinfoUrl?: string;
   pingUrl?: string;
   pingMethod?: string;
@@ -335,7 +336,7 @@ export function registerProvider(params: {
     refreshUrl: params.refreshUrl ?? null,
     tokenEndpointAuthMethod:
       params.tokenEndpointAuthMethod || "client_secret_post",
-    tokenExchangeBodyFormat: "form",
+    tokenExchangeBodyFormat: params.tokenExchangeBodyFormat || "form",
     userinfoUrl: params.userinfoUrl ?? null,
     baseUrl: params.baseUrl ?? null,
     defaultScopes: JSON.stringify(params.defaultScopes),
@@ -407,6 +408,7 @@ export function updateProvider(
     tokenExchangeUrl: string;
     refreshUrl: string;
     tokenEndpointAuthMethod: string;
+    tokenExchangeBodyFormat: string;
     userinfoUrl: string;
     pingUrl: string;
     pingMethod: string;
@@ -457,6 +459,8 @@ export function updateProvider(
   if (params.tokenEndpointAuthMethod !== undefined)
     set.tokenEndpointAuthMethod =
       params.tokenEndpointAuthMethod || "client_secret_post";
+  if (params.tokenExchangeBodyFormat !== undefined)
+    set.tokenExchangeBodyFormat = params.tokenExchangeBodyFormat || "form";
   if (params.userinfoUrl !== undefined) set.userinfoUrl = params.userinfoUrl;
   if (params.pingUrl !== undefined) set.pingUrl = params.pingUrl;
   if (params.pingMethod !== undefined) set.pingMethod = params.pingMethod;

--- a/assistant/src/oauth/seed-providers.ts
+++ b/assistant/src/oauth/seed-providers.ts
@@ -27,6 +27,7 @@ export const PROVIDER_SEED_DATA: Record<
     tokenExchangeUrl: string;
     refreshUrl?: string;
     tokenEndpointAuthMethod?: string;
+    tokenExchangeBodyFormat?: string;
     userinfoUrl?: string;
     pingUrl?: string;
     pingMethod?: string;

--- a/assistant/src/security/oauth2.ts
+++ b/assistant/src/security/oauth2.ts
@@ -56,6 +56,13 @@ export interface OAuth2Config {
    * use `","` (comma).
    */
   scopeSeparator: string;
+  /**
+   * Body encoding format for the token exchange and refresh requests.
+   * - `"form"` (default): `application/x-www-form-urlencoded` with `URLSearchParams`.
+   * - `"json"`: `application/json` with `JSON.stringify`.
+   * Providers like Notion require JSON-encoded bodies at their token endpoint.
+   */
+  tokenExchangeBodyFormat?: "form" | "json";
 }
 
 export interface OAuth2TokenResult {
@@ -113,6 +120,7 @@ async function exchangeCodeForTokens(
   codeVerifier: string,
 ): Promise<OAuth2FlowResult> {
   const authMethod = config.tokenEndpointAuthMethod ?? "client_secret_post";
+  const bodyFormat = config.tokenExchangeBodyFormat ?? "form";
 
   const tokenBody: Record<string, string> = {
     grant_type: "authorization_code",
@@ -122,7 +130,10 @@ async function exchangeCodeForTokens(
   };
 
   const headers: Record<string, string> = {
-    "Content-Type": "application/x-www-form-urlencoded",
+    "Content-Type":
+      bodyFormat === "json"
+        ? "application/json"
+        : "application/x-www-form-urlencoded",
   };
 
   if (config.clientSecret && authMethod === "client_secret_basic") {
@@ -140,7 +151,10 @@ async function exchangeCodeForTokens(
   const tokenResp = await fetch(config.tokenExchangeUrl, {
     method: "POST",
     headers,
-    body: new URLSearchParams(tokenBody),
+    body:
+      bodyFormat === "json"
+        ? JSON.stringify(tokenBody)
+        : new URLSearchParams(tokenBody),
   });
 
   if (!tokenResp.ok) {
@@ -785,8 +799,10 @@ export async function refreshOAuth2Token(
   refreshToken: string,
   clientSecret?: string,
   tokenEndpointAuthMethod?: TokenEndpointAuthMethod,
+  tokenExchangeBodyFormat?: "form" | "json",
 ): Promise<OAuth2TokenResult> {
   const authMethod = tokenEndpointAuthMethod ?? "client_secret_post";
+  const bodyFormat = tokenExchangeBodyFormat ?? "form";
 
   const body: Record<string, string> = {
     grant_type: "refresh_token",
@@ -794,7 +810,10 @@ export async function refreshOAuth2Token(
   };
 
   const headers: Record<string, string> = {
-    "Content-Type": "application/x-www-form-urlencoded",
+    "Content-Type":
+      bodyFormat === "json"
+        ? "application/json"
+        : "application/x-www-form-urlencoded",
   };
 
   if (clientSecret && authMethod === "client_secret_basic") {
@@ -812,7 +831,8 @@ export async function refreshOAuth2Token(
   const resp = await fetch(tokenExchangeUrl, {
     method: "POST",
     headers,
-    body: new URLSearchParams(body),
+    body:
+      bodyFormat === "json" ? JSON.stringify(body) : new URLSearchParams(body),
   });
 
   if (!resp.ok) {

--- a/assistant/src/security/token-manager.ts
+++ b/assistant/src/security/token-manager.ts
@@ -101,6 +101,7 @@ interface RefreshConfig {
   secret?: string;
   refreshToken?: string;
   authMethod?: TokenEndpointAuthMethod;
+  tokenExchangeBodyFormat?: "form" | "json";
   connId: string;
 }
 
@@ -166,6 +167,10 @@ async function resolveRefreshConfig(
     | TokenEndpointAuthMethod
     | undefined;
 
+  const tokenExchangeBodyFormat =
+    (provider.tokenExchangeBodyFormat as "form" | "json" | undefined) ??
+    undefined;
+
   return {
     connId: conn.id,
     tokenExchangeUrl,
@@ -173,6 +178,7 @@ async function resolveRefreshConfig(
     secret,
     refreshToken,
     authMethod,
+    tokenExchangeBodyFormat,
   };
 }
 
@@ -192,6 +198,7 @@ async function doRefresh(service: string, connId: string): Promise<string> {
     clientId: resolvedClientId,
     secret,
     authMethod,
+    tokenExchangeBodyFormat,
     refreshToken,
   } = refreshConfig;
 
@@ -222,6 +229,7 @@ async function doRefresh(service: string, connId: string): Promise<string> {
       refreshToken,
       secret,
       authMethod,
+      tokenExchangeBodyFormat,
     );
   } catch (err) {
     circuitBreaker.recordFailure(connId);


### PR DESCRIPTION
## Summary
- Add tokenExchangeBodyFormat field to OAuth provider schema, migration, and seed data
- Support JSON-encoded body for token exchange and refresh when configured
- Default behavior (form-encoded) unchanged for existing providers

Part of plan: notion-oauth.md (PR 6 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24686" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
