### PR TITLE
fix(browser-relay): stop forwarding cdpSessionId as CDP flat-session sessionId

### DIFF
--- a/clients/chrome-extension/background/__tests__/host-browser-dispatcher.test.ts
+++ b/clients/chrome-extension/background/__tests__/host-browser-dispatcher.test.ts
@@ -272,7 +272,7 @@ describe('createHostBrowserDispatcher', () => {
       );
     });
 
-    test('routes via targetId when cdpSessionId is provided', async () => {
+    test('routes via targetId when cdpSessionId is provided but does not forward it as frame.sessionId', async () => {
       harness = createHarness({
         sendResult: { id: 1, result: {} },
       });
@@ -285,7 +285,51 @@ describe('createHostBrowserDispatcher', () => {
 
       expect(harness.resolveTargetCalls).toEqual(['target-xyz']);
       expect(harness.proxy.attachCalls[0].target).toEqual({ targetId: 'target-xyz' });
-      expect(harness.proxy.sendCalls[0].frame.sessionId).toBe('target-xyz');
+      // cdpSessionId must NOT be forwarded as frame.sessionId — it is used
+      // only for target resolution. Forwarding it would cause
+      // chrome.debugger.sendCommand to look up a non-existent flat session.
+      expect(harness.proxy.sendCalls[0].frame.sessionId).toBeUndefined();
+    });
+  });
+
+  describe('handle — cdpSessionId target resolution vs flat-session separation', () => {
+    test('cdpSessionId is passed to resolveTarget but NOT forwarded as frame.sessionId', async () => {
+      harness = createHarness({
+        sendResult: { id: 1, result: {} },
+      });
+      // Override resolveTarget to record calls and return a targetId.
+      harness.resolveTargetImpl = async (cdpSessionId) => {
+        return { targetId: 'test-target-id' };
+      };
+
+      await harness.dispatcher.handle({
+        ...sampleRequest,
+        cdpSessionId: 'test-target-id',
+      });
+
+      // resolveTarget was called with the cdpSessionId.
+      expect(harness.resolveTargetCalls).toEqual(['test-target-id']);
+
+      // The proxy.send() call's frame must NOT carry sessionId — cdpSessionId
+      // is used only for target resolution, not as a CDP flat-session qualifier.
+      expect(harness.proxy.sendCalls.length).toBe(1);
+      expect(harness.proxy.sendCalls[0].frame.sessionId).toBeUndefined();
+    });
+
+    test('when cdpSessionId is omitted, resolveTarget receives undefined and frame.sessionId is also undefined', async () => {
+      harness = createHarness({
+        sendResult: { id: 1, result: {} },
+      });
+
+      await harness.dispatcher.handle(sampleRequest);
+
+      // resolveTarget was called with undefined (active-tab fallback path).
+      expect(harness.resolveTargetCalls).toEqual([undefined]);
+
+      // frame.sessionId is also undefined — the active-tab path never sets
+      // a flat-session qualifier.
+      expect(harness.proxy.sendCalls.length).toBe(1);
+      expect(harness.proxy.sendCalls[0].frame.sessionId).toBeUndefined();
     });
   });
 

--- a/clients/chrome-extension/background/host-browser-dispatcher.ts
+++ b/clients/chrome-extension/background/host-browser-dispatcher.ts
@@ -345,7 +345,12 @@ export function createHostBrowserDispatcher(
         id: nextCdpId++,
         method: envelope.cdpMethod,
         params: envelope.cdpParams,
-        sessionId: envelope.cdpSessionId,
+        // cdpSessionId is used only for target resolution (resolveTarget above).
+        // It must NOT be forwarded as a CDP flat-session sessionId — doing so
+        // causes chrome.debugger.sendCommand to look up a non-existent session
+        // and fail with "Session with given id not found". Flat sessions are
+        // only valid when obtained from Target.attachToTarget with flatten:true,
+        // which this code path does not use.
       });
       // Recovery hint: if the CDP send returned an error indicating the
       // target is no longer attached (tab closed mid-flight, navigated


### PR DESCRIPTION
## Summary
- Stop forwarding `envelope.cdpSessionId` as `frame.sessionId` in the host-browser dispatcher's `proxy.send()` call
- `cdpSessionId` is now used only for target resolution via `resolveTarget()`, not as a CDP flat-session qualifier
- Add tests verifying the separation of target resolution from flat-session qualification

Part of plan: browser-relay-stale-tabid-fix.md (PR 1 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24687" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
