### PR TITLE
fix(browser-relay): add active-tab fallback for evaluate; make tab-id optional for navigate

### DIFF
--- a/assistant/src/cli/commands/browser-relay.ts
+++ b/assistant/src/cli/commands/browser-relay.ts
@@ -237,12 +237,15 @@ async function actionNewTab(url: string): Promise<void> {
   }
 }
 
-async function actionNavigate(tabId: string, url: string): Promise<void> {
+async function actionNavigate(
+  tabId: string | undefined,
+  url: string,
+): Promise<void> {
   try {
     await postBrowserCdp({
       cdpMethod: "Page.navigate",
       cdpParams: { url },
-      cdpSessionId: tabId,
+      ...(tabId !== undefined ? { cdpSessionId: tabId } : {}),
     });
     emitOk({});
   } catch (err) {
@@ -250,7 +253,10 @@ async function actionNavigate(tabId: string, url: string): Promise<void> {
   }
 }
 
-async function actionEvaluate(tabId: string, code: string): Promise<void> {
+async function actionEvaluate(
+  tabId: string | undefined,
+  code: string,
+): Promise<void> {
   try {
     const resp = await postBrowserCdp({
       cdpMethod: "Runtime.evaluate",
@@ -259,7 +265,7 @@ async function actionEvaluate(tabId: string, code: string): Promise<void> {
         returnByValue: true,
         awaitPromise: true,
       },
-      cdpSessionId: tabId,
+      ...(tabId !== undefined ? { cdpSessionId: tabId } : {}),
     });
     // CDP Runtime.evaluate returns { result: { type, value }, exceptionDetails? }.
     // Surface exceptions as relay errors so callers don't silently get undefined.
@@ -402,9 +408,9 @@ Examples:
   relay
     .command("navigate")
     .description("Navigate an existing tab to a new URL")
-    .requiredOption("--tab-id <id>", "Target tab ID")
+    .option("--tab-id <id>", "Target tab ID (defaults to active tab)")
     .requiredOption("--url <url>", "URL to navigate to")
-    .action(async (opts: { tabId: string; url: string }) => {
+    .action(async (opts: { tabId?: string; url: string }) => {
       await actionNavigate(opts.tabId, opts.url);
     });
 
@@ -413,12 +419,12 @@ Examples:
   relay
     .command("evaluate")
     .description("Execute JavaScript in a Chrome tab")
-    .requiredOption("--tab-id <id>", "Target tab ID")
+    .option("--tab-id <id>", "Target tab ID (defaults to active tab)")
     .option(
       "--code <script>",
       "JavaScript code to evaluate (or read from stdin)",
     )
-    .action(async (opts: { tabId: string; code?: string }) => {
+    .action(async (opts: { tabId?: string; code?: string }) => {
       let code: string;
       if (opts.code) {
         code = opts.code;

--- a/assistant/src/cli/commands/browser-relay.ts
+++ b/assistant/src/cli/commands/browser-relay.ts
@@ -408,7 +408,10 @@ Examples:
   relay
     .command("navigate")
     .description("Navigate an existing tab to a new URL")
-    .option("--tab-id <id>", "Target tab ID (defaults to active tab)")
+    .option(
+      "--tab-id <id>",
+      "Target tab ID (defaults to active tab) — run 'assistant browser chrome relay find-tab --url <pattern>' to find it",
+    )
     .requiredOption("--url <url>", "URL to navigate to")
     .action(async (opts: { tabId?: string; url: string }) => {
       await actionNavigate(opts.tabId, opts.url);
@@ -419,7 +422,10 @@ Examples:
   relay
     .command("evaluate")
     .description("Execute JavaScript in a Chrome tab")
-    .option("--tab-id <id>", "Target tab ID (defaults to active tab)")
+    .option(
+      "--tab-id <id>",
+      "Target tab ID (defaults to active tab) — run 'assistant browser chrome relay find-tab --url <pattern>' to find it",
+    )
     .option(
       "--code <script>",
       "JavaScript code to evaluate (or read from stdin)",


### PR DESCRIPTION
## Summary
- Make `--tab-id` optional for `evaluate` and `navigate` relay subcommands
- When omitted, commands fall back to the active tab (matching `screenshot` behavior)
- Both commands still accept `--tab-id` for targeting a specific tab

Part of plan: browser-relay-stale-tabid-fix.md (PR 4 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24688" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
