### PR TITLE
fix(browser-relay): use chrome.tabs.query for find-tab instead of restricted CDP Target.getTargets

### DIFF
--- a/assistant/src/cli/commands/browser-relay.ts
+++ b/assistant/src/cli/commands/browser-relay.ts
@@ -168,52 +168,21 @@ async function readStdin(): Promise<string> {
 }
 
 // ---------------------------------------------------------------------------
-// URL glob matching for find-tab
-// ---------------------------------------------------------------------------
-
-/**
- * Convert a Chrome match-pattern style glob (e.g. `*://*.amazon.com/*`)
- * into a regular expression. Matches the chrome.tabs.query semantics
- * the legacy relay CLI exposed:
- *
- *   - `*` is a wildcard that matches any sequence (including `/` in
- *     the path component, mirroring the legacy minimatch behaviour).
- *   - All other regex metacharacters are escaped.
- */
-function globToRegex(glob: string): RegExp {
-  const escaped = glob.replace(/[.+?^${}()|[\]\\]/g, "\\$&");
-  const pattern = "^" + escaped.replace(/\*/g, ".*") + "$";
-  return new RegExp(pattern);
-}
-
-// ---------------------------------------------------------------------------
 // Action handlers — translate legacy actions into CDP commands
 // ---------------------------------------------------------------------------
 
-interface CdpTarget {
-  targetId: string;
-  type: string;
-  url: string;
-  title?: string;
-  attached?: boolean;
-}
-
-interface CdpTargetsResult {
-  targetInfos: CdpTarget[];
-}
-
 async function actionFindTab(urlPattern: string): Promise<void> {
   try {
-    const resp = await postBrowserCdp({ cdpMethod: "Target.getTargets" });
-    const targets =
-      (resp.result as CdpTargetsResult | undefined)?.targetInfos ?? [];
-    const re = globToRegex(urlPattern);
-    const match = targets.find((t) => t.type === "page" && re.test(t.url));
-    if (!match) {
+    const resp = await postBrowserCdp({
+      cdpMethod: "Vellum.findTab",
+      cdpParams: { urlPattern },
+    });
+    const tab = resp.result as { tabId?: string; url?: string } | undefined;
+    if (!tab?.tabId) {
       emitError(`No tab matched URL pattern: ${urlPattern}`);
       return;
     }
-    emitOk({ tabId: match.targetId });
+    emitOk({ tabId: tab.tabId });
   } catch (err) {
     emitError(err instanceof Error ? err.message : String(err));
   }

--- a/clients/chrome-extension/background/host-browser-dispatcher.ts
+++ b/clients/chrome-extension/background/host-browser-dispatcher.ts
@@ -317,10 +317,12 @@ export function createHostBrowserDispatcher(
     const ownController = abort;
     inFlight.set(requestId, ownController);
     try {
-      const target = await deps.resolveTarget(envelope.cdpSessionId);
-
       // Handle synthetic Vellum.* methods that use chrome extension APIs
-      // directly instead of routing through chrome.debugger.
+      // directly instead of routing through chrome.debugger. These methods
+      // do not require a resolved CDP target, so they must be dispatched
+      // BEFORE `resolveTarget()` — otherwise `resolveTarget(undefined)`
+      // falls back to querying for the active tab, which throws when no
+      // focused window/tab exists (minimized, no active tab, etc.).
       if (envelope.cdpMethod === 'Vellum.findTab') {
         const urlPattern = (envelope.cdpParams as { urlPattern?: string } | undefined)?.urlPattern;
         if (!urlPattern) {
@@ -349,6 +351,7 @@ export function createHostBrowserDispatcher(
         return;
       }
 
+      const target = await deps.resolveTarget(envelope.cdpSessionId);
       const key = targetKey(target);
       if (!attachedTargets.has(key)) {
         try {

--- a/clients/chrome-extension/background/host-browser-dispatcher.ts
+++ b/clients/chrome-extension/background/host-browser-dispatcher.ts
@@ -318,6 +318,37 @@ export function createHostBrowserDispatcher(
     inFlight.set(requestId, ownController);
     try {
       const target = await deps.resolveTarget(envelope.cdpSessionId);
+
+      // Handle synthetic Vellum.* methods that use chrome extension APIs
+      // directly instead of routing through chrome.debugger.
+      if (envelope.cdpMethod === 'Vellum.findTab') {
+        const urlPattern = (envelope.cdpParams as { urlPattern?: string } | undefined)?.urlPattern;
+        if (!urlPattern) {
+          await deps.postResult({
+            requestId,
+            content: JSON.stringify({ error: { code: -32602, message: 'urlPattern is required' } }),
+            isError: true,
+          });
+          return;
+        }
+        const tabs = await chrome.tabs.query({ url: urlPattern });
+        const tab = tabs[0];
+        if (!tab?.id) {
+          await deps.postResult({
+            requestId,
+            content: JSON.stringify({ error: { code: -32000, message: `No tab matched URL pattern: ${urlPattern}` } }),
+            isError: true,
+          });
+          return;
+        }
+        await deps.postResult({
+          requestId,
+          content: JSON.stringify({ result: { tabId: String(tab.id), url: tab.url, title: tab.title } }),
+          isError: false,
+        });
+        return;
+      }
+
       const key = targetKey(target);
       if (!attachedTargets.has(key)) {
         try {


### PR DESCRIPTION
## Summary
- Replace `Target.getTargets` CDP call with synthetic `Vellum.findTab` method in the CLI
- Add `Vellum.findTab` handler in the extension dispatcher that uses `chrome.tabs.query()` directly
- Remove dead code (`CdpTarget`, `CdpTargetsResult`, `globToRegex` if unused)

Part of plan: browser-relay-stale-tabid-fix.md (PR 2 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24689" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
