### PR TITLE
feat(oauth): enable managed mode for Notion

### DIFF
--- a/assistant/src/config/schemas/services.ts
+++ b/assistant/src/config/schemas/services.ts
@@ -66,6 +66,11 @@ export const GitHubOAuthServiceSchema = BaseServiceSchema.extend({
 });
 export type GitHubOAuthService = z.infer<typeof GitHubOAuthServiceSchema>;
 
+export const NotionOAuthServiceSchema = BaseServiceSchema.extend({
+  mode: ServiceModeSchema.default("your-own"),
+});
+export type NotionOAuthService = z.infer<typeof NotionOAuthServiceSchema>;
+
 export const ServicesSchema = z.object({
   inference: InferenceServiceSchema.default(InferenceServiceSchema.parse({})),
   "image-generation": ImageGenerationServiceSchema.default(
@@ -85,6 +90,9 @@ export const ServicesSchema = z.object({
   ),
   "github-oauth": GitHubOAuthServiceSchema.default(
     GitHubOAuthServiceSchema.parse({}),
+  ),
+  "notion-oauth": NotionOAuthServiceSchema.default(
+    NotionOAuthServiceSchema.parse({}),
   ),
 });
 export type Services = z.infer<typeof ServicesSchema>;

--- a/assistant/src/oauth/seed-providers.ts
+++ b/assistant/src/oauth/seed-providers.ts
@@ -200,6 +200,8 @@ export const PROVIDER_SEED_DATA: Record<
     },
     authorizeParams: { owner: "user" },
     tokenEndpointAuthMethod: "client_secret_basic",
+    tokenExchangeBodyFormat: "json",
+    managedServiceConfigKey: "notion-oauth",
     loopbackPort: 17323,
     injectionTemplates: [
       {

--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -451,6 +451,7 @@ struct HatchingStepView: View {
             configValues["services.outlook-oauth.mode"] = "managed"
             configValues["services.linear-oauth.mode"] = "managed"
             configValues["services.github-oauth.mode"] = "managed"
+            configValues["services.notion-oauth.mode"] = "managed"
         }
         return configValues
     }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -2158,6 +2158,10 @@ public final class SettingsStore: ObservableObject {
            let mode = githubOAuth["mode"] as? String {
             self.managedOAuthMode["github"] = mode
         }
+        if let notionOAuth = services["notion-oauth"] as? [String: Any],
+           let mode = notionOAuth["mode"] as? String {
+            self.managedOAuthMode["notion"] = mode
+        }
     }
 
     @discardableResult


### PR DESCRIPTION
## Summary
- Add managedServiceConfigKey and tokenExchangeBodyFormat to Notion seed provider entry
- Add NotionOAuthServiceSchema to ServicesSchema for managed mode config
- Set managed mode for Notion during macOS onboarding

Part of plan: notion-oauth.md (PR 7 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24690" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
