### PR TITLE
fix(daemon): sanitize orphaned UTF-16 surrogates in outbound Anthropic requests

### DIFF
--- a/assistant/src/__tests__/anthropic-provider.test.ts
+++ b/assistant/src/__tests__/anthropic-provider.test.ts
@@ -1693,3 +1693,66 @@ describe("AnthropicProvider — Managed Proxy Fallback", () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// Tests — Orphaned UTF-16 surrogate sanitization
+// ---------------------------------------------------------------------------
+
+describe("AnthropicProvider — surrogate sanitization", () => {
+  let provider: AnthropicProvider;
+
+  beforeEach(() => {
+    lastStreamParams = null;
+    provider = new AnthropicProvider("sk-ant-test", "claude-sonnet-4-6");
+  });
+
+  test("strips orphaned high surrogate from a tool result before sending", async () => {
+    // An orphaned high surrogate — the exact shape that triggers Anthropic's
+    // "no low surrogate in string" 400. The mock's JSON.parse(JSON.stringify)
+    // on line ~44 would throw if sanitization didn't happen.
+    const LONE_HIGH = "\uD83C";
+    const messages: Message[] = [
+      toolUseMsg("tu1", "bash"),
+      toolResultMsg("tu1", `shell output ${LONE_HIGH} more output`),
+      userMsg("what happened?"),
+    ];
+
+    await provider.sendMessage(messages);
+
+    const sent = lastStreamParams!.messages as Array<{
+      role: string;
+      content: Array<{ type: string; content?: string; text?: string }>;
+    }>;
+    // Find the tool_result block in the captured payload and assert no orphans.
+    const toolResult = sent
+      .flatMap((m) => m.content)
+      .find((b) => b.type === "tool_result");
+    expect(toolResult).toBeDefined();
+    expect(toolResult!.content).toBeDefined();
+    const content = toolResult!.content as string;
+    for (let i = 0; i < content.length; i++) {
+      const code = content.charCodeAt(i);
+      if (code >= 0xd800 && code <= 0xdbff) {
+        const next = i + 1 < content.length ? content.charCodeAt(i + 1) : 0;
+        expect(next >= 0xdc00 && next <= 0xdfff).toBe(true);
+        i++;
+      } else {
+        expect(code < 0xdc00 || code > 0xdfff).toBe(true);
+      }
+    }
+  });
+
+  test("clean payloads are not copied unnecessarily", async () => {
+    // When there are no orphans, the sanitizer should be a no-op. We can't
+    // easily assert reference equality through the mock boundary (the mock
+    // JSON-round-trips params for capture), but we can at least confirm the
+    // call succeeds without error on ordinary payloads containing valid
+    // surrogate pairs (emoji).
+    const EMOJI = "\uD83C\uDF89";
+    await provider.sendMessage([userMsg(`hello ${EMOJI} world`)]);
+    const sent = lastStreamParams!.messages as Array<{
+      content: Array<{ text?: string }>;
+    }>;
+    expect(sent[0].content[0].text).toContain(EMOJI);
+  });
+});

--- a/assistant/src/__tests__/post-turn-tool-result-truncation.test.ts
+++ b/assistant/src/__tests__/post-turn-tool-result-truncation.test.ts
@@ -294,3 +294,50 @@ describe("derefToolResultReReads", () => {
     expect(b2.content).toBe("normal read content"); // unchanged
   });
 });
+
+function hasOrphanedSurrogate(str: string): boolean {
+  for (let i = 0; i < str.length; i++) {
+    const code = str.charCodeAt(i);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = i + 1 < str.length ? str.charCodeAt(i + 1) : 0;
+      if (next < 0xdc00 || next > 0xdfff) return true;
+      i++;
+    } else if (code >= 0xdc00 && code <= 0xdfff) {
+      return true;
+    }
+  }
+  return false;
+}
+
+describe("buildTruncatedContent surrogate-pair safety", () => {
+  const EMOJI = "\uD83C\uDF89";
+  const half = Math.floor(TARGET_CHARS / 2);
+
+  test("does not orphan a surrogate pair at the prefix cut boundary", () => {
+    // Put the emoji so its high surrogate lands exactly at position half - 1.
+    // The naive slice(0, half) would cut the pair in half.
+    const prefix = "a".repeat(half - 1);
+    const filler = "b".repeat(10_000);
+    const original = prefix + EMOJI + filler;
+    const result = buildTruncatedContent(original, "/tmp/fake");
+    expect(hasOrphanedSurrogate(result)).toBe(false);
+    expect(() => JSON.stringify(result)).not.toThrow();
+  });
+
+  test("does not orphan a surrogate pair at the suffix cut boundary", () => {
+    // Put the emoji so its low surrogate lands exactly at position
+    // original.length - half (the start of the suffix slice). Naive
+    // slice(-half) would start mid-pair and leave a lone low surrogate.
+    const head = "a".repeat(10_000);
+    const suffixTail = "b".repeat(half - 1);
+    // head + EMOJI (2 code units) + suffixTail has length
+    // 10_000 + 2 + (half - 1). The suffix starts at length - half, which
+    // equals 10_000 + 2 + (half - 1) - half = 10_001. That lands on the
+    // low surrogate of the emoji (emoji starts at position 10_000, high at
+    // 10_000, low at 10_001). Exactly the orphan case.
+    const original = head + EMOJI + suffixTail;
+    const result = buildTruncatedContent(original, "/tmp/fake");
+    expect(hasOrphanedSurrogate(result)).toBe(false);
+    expect(() => JSON.stringify(result)).not.toThrow();
+  });
+});

--- a/assistant/src/__tests__/tool-result-truncation.test.ts
+++ b/assistant/src/__tests__/tool-result-truncation.test.ts
@@ -11,6 +11,20 @@ import {
 } from "../context/tool-result-truncation.js";
 import type { ContentBlock, ToolResultContent } from "../providers/types.js";
 
+function hasOrphanedSurrogate(str: string): boolean {
+  for (let i = 0; i < str.length; i++) {
+    const code = str.charCodeAt(i);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = i + 1 < str.length ? str.charCodeAt(i + 1) : 0;
+      if (next < 0xdc00 || next > 0xdfff) return true;
+      i++;
+    } else if (code >= 0xdc00 && code <= 0xdfff) {
+      return true;
+    }
+  }
+  return false;
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -99,6 +113,28 @@ describe("truncateToolResultText", () => {
     // Should return original text unchanged — no suffix appended
     expect(result).toBe(text);
     expect(result).not.toContain(TRUNCATION_SUFFIX);
+  });
+
+  test("does not orphan a UTF-16 surrogate pair at the cut boundary", () => {
+    // Regression for the "no low surrogate in string" Anthropic 400 error.
+    // Build a string where the cut point lands inside a surrogate pair:
+    // 4999 padding chars, then an emoji (2 code units), then enough filler
+    // to push the cut inside the pair.
+    const EMOJI = "\uD83C\uDF89";
+    // maxChars = 5_000, so cutPoint = 5_000 - TRUNCATION_SUFFIX.length.
+    // Put the emoji so its high surrogate lands exactly at cutPoint - 1.
+    const maxChars = 5_000;
+    const cutPoint = maxChars - TRUNCATION_SUFFIX.length;
+    // Fill up to cutPoint - 1 with "a"s, then place the emoji so the high
+    // surrogate is the character at cutPoint - 1 and the low is at cutPoint.
+    const prefix = "a".repeat(cutPoint - 1);
+    const text = prefix + EMOJI + "b".repeat(100);
+    // Use a long filler with no newlines so lastIndexOf("\n", cutPoint) === -1
+    // and the function falls back to cutPoint itself.
+    const result = truncateToolResultText(text, maxChars);
+    expect(hasOrphanedSurrogate(result)).toBe(false);
+    // JSON.stringify must not throw on the result.
+    expect(() => JSON.stringify(result)).not.toThrow();
   });
 });
 

--- a/assistant/src/__tests__/unicode.test.ts
+++ b/assistant/src/__tests__/unicode.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  safeStringSlice,
+  stripOrphanedSurrogates,
+  stripOrphanedSurrogatesDeep,
+} from "../util/unicode.js";
+
+// U+1F389 PARTY POPPER = "\uD83C\uDF89" (a surrogate pair).
+const EMOJI = "\uD83C\uDF89";
+const HIGH = "\uD83C";
+const LOW = "\uDF89";
+const REPLACEMENT = "\uFFFD";
+
+describe("safeStringSlice", () => {
+  test("no-op when string has no surrogates", () => {
+    expect(safeStringSlice("hello world", 0, 5)).toBe("hello");
+  });
+
+  test("behaves like slice when no surrogates on the boundary", () => {
+    const s = `abc${EMOJI}xyz`;
+    // slice at position 0-3: "abc", no boundary trouble
+    expect(safeStringSlice(s, 0, 3)).toBe("abc");
+  });
+
+  test("backs off high surrogate at end when more string follows", () => {
+    // "abc" + high surrogate at position 3, low at position 4, then "xyz".
+    // Cutting at end=4 would land between the pair — back off to 3.
+    const s = `abc${EMOJI}xyz`;
+    const result = safeStringSlice(s, 0, 4);
+    expect(result).toBe("abc");
+  });
+
+  test("preserves a complete surrogate pair at end", () => {
+    const s = `abc${EMOJI}xyz`;
+    // end=5 includes both code units of the pair (positions 3 and 4).
+    const result = safeStringSlice(s, 0, 5);
+    expect(result).toBe(`abc${EMOJI}`);
+  });
+
+  test("does NOT repair trailing high surrogate when end === length", () => {
+    // An already-orphaned high surrogate at the tail must not be silently
+    // dropped by safeStringSlice — that's the sanitizer's job. safeStringSlice
+    // only protects against creating NEW orphans at a cut boundary.
+    const s = `abc${HIGH}`;
+    expect(safeStringSlice(s, 0, s.length)).toBe(`abc${HIGH}`);
+  });
+
+  test("advances start past orphaned low surrogate", () => {
+    const s = `abc${EMOJI}xyz`;
+    // Starting at position 4 would begin mid-pair (on the low surrogate) —
+    // advance to position 5.
+    const result = safeStringSlice(s, 4, s.length);
+    expect(result).toBe("xyz");
+  });
+
+  test("does NOT advance when start === 0", () => {
+    // start=0 can never land mid-pair — leave leading orphans alone.
+    const s = `${LOW}abc`;
+    expect(safeStringSlice(s, 0, s.length)).toBe(`${LOW}abc`);
+  });
+
+  test("handles both start mid-pair and end mid-pair in one call", () => {
+    const s = `${EMOJI}abc${EMOJI}xyz`;
+    // Slice from position 1 (low surrogate) to 6 (high surrogate of second emoji).
+    // Should advance start to 2 and back off end to 5.
+    const result = safeStringSlice(s, 1, 6);
+    expect(result).toBe("abc");
+  });
+
+  test("clamps start and end into range", () => {
+    expect(safeStringSlice("hello", -5, 100)).toBe("hello");
+  });
+
+  test("returns empty string when start > end after adjustment", () => {
+    const s = EMOJI;
+    // start=1 (low surrogate) advances to 2. end=1 (clamped to length=2). Empty range.
+    const result = safeStringSlice(s, 1, 1);
+    expect(result).toBe("");
+  });
+});
+
+describe("stripOrphanedSurrogates", () => {
+  test("returns same reference for ASCII", () => {
+    const s = "hello world";
+    expect(stripOrphanedSurrogates(s)).toBe(s);
+  });
+
+  test("returns same reference for BMP-only text", () => {
+    const s = "héllo wörld";
+    expect(stripOrphanedSurrogates(s)).toBe(s);
+  });
+
+  test("returns same reference when all surrogates are paired", () => {
+    const s = `hello ${EMOJI} world ${EMOJI}`;
+    expect(stripOrphanedSurrogates(s)).toBe(s);
+  });
+
+  test("replaces a lone high surrogate with U+FFFD", () => {
+    const s = `abc${HIGH}xyz`;
+    expect(stripOrphanedSurrogates(s)).toBe(`abc${REPLACEMENT}xyz`);
+  });
+
+  test("replaces a lone low surrogate with U+FFFD", () => {
+    const s = `abc${LOW}xyz`;
+    expect(stripOrphanedSurrogates(s)).toBe(`abc${REPLACEMENT}xyz`);
+  });
+
+  test("replaces a lone high surrogate at the very end", () => {
+    const s = `abc${HIGH}`;
+    expect(stripOrphanedSurrogates(s)).toBe(`abc${REPLACEMENT}`);
+  });
+
+  test("replaces a lone low surrogate at the very start", () => {
+    const s = `${LOW}abc`;
+    expect(stripOrphanedSurrogates(s)).toBe(`${REPLACEMENT}abc`);
+  });
+
+  test("preserves valid pairs while replacing orphans", () => {
+    const s = `${EMOJI}${HIGH}${EMOJI}`;
+    expect(stripOrphanedSurrogates(s)).toBe(`${EMOJI}${REPLACEMENT}${EMOJI}`);
+  });
+
+  test("handles two high surrogates in a row (both orphans)", () => {
+    const s = `${HIGH}${HIGH}xyz`;
+    expect(stripOrphanedSurrogates(s)).toBe(
+      `${REPLACEMENT}${REPLACEMENT}xyz`,
+    );
+  });
+
+  test("produces output that round-trips through JSON", () => {
+    const s = `abc${HIGH}xyz`;
+    const cleaned = stripOrphanedSurrogates(s);
+    expect(() => JSON.stringify(cleaned)).not.toThrow();
+    // And the serialized string is valid JSON that parses back.
+    const json = JSON.stringify(cleaned);
+    expect(JSON.parse(json)).toBe(cleaned);
+  });
+});
+
+describe("stripOrphanedSurrogatesDeep", () => {
+  test("returns same reference on a clean string", () => {
+    const input = "hello";
+    const result = stripOrphanedSurrogatesDeep(input);
+    expect(result.changed).toBe(false);
+    expect(result.value).toBe(input);
+    expect(result.fixedStringCount).toBe(0);
+  });
+
+  test("returns same reference on a clean object tree", () => {
+    const input = {
+      a: "hello",
+      b: { c: ["world", 42, null, { d: EMOJI }] },
+    };
+    const result = stripOrphanedSurrogatesDeep(input);
+    expect(result.changed).toBe(false);
+    expect(result.value).toBe(input);
+    expect(result.fixedStringCount).toBe(0);
+  });
+
+  test("rewrites nested strings with orphans", () => {
+    const input: { a: string; b: Array<{ c: string } | string> } = {
+      a: "clean",
+      b: [{ c: `bad${HIGH}` }, "also clean"],
+    };
+    const result = stripOrphanedSurrogatesDeep(input);
+    expect(result.changed).toBe(true);
+    expect(result.fixedStringCount).toBe(1);
+    const firstChild = result.value.b[0] as { c: string };
+    expect(firstChild.c).toBe(`bad${REPLACEMENT}`);
+    // Clean siblings are preserved by value (structural equality).
+    expect(result.value.a).toBe("clean");
+    expect(result.value.b[1]).toBe("also clean");
+  });
+
+  test("leaves non-plain objects untouched", () => {
+    class Custom {
+      value = `bad${HIGH}`;
+    }
+    const inst = new Custom();
+    const result = stripOrphanedSurrogatesDeep({ inst });
+    // We don't walk class instances — they pass through unchanged.
+    expect(result.changed).toBe(false);
+    expect(result.value.inst).toBe(inst);
+  });
+
+  test("counts multiple fixed strings", () => {
+    const input = {
+      a: `one${HIGH}`,
+      b: `two${LOW}`,
+      c: "clean",
+    };
+    const result = stripOrphanedSurrogatesDeep(input);
+    expect(result.changed).toBe(true);
+    expect(result.fixedStringCount).toBe(2);
+  });
+
+  test("rewritten output can be JSON-stringified end-to-end", () => {
+    // This is the exact shape of the bug: a payload with an orphaned high
+    // surrogate buried in a tool_result content string. After sanitization,
+    // JSON.stringify must succeed and the JSON must parse back cleanly.
+    const payload = {
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "abc",
+              content: `shell output before ${HIGH} shell output after`,
+            },
+          ],
+        },
+      ],
+    };
+    const result = stripOrphanedSurrogatesDeep(payload);
+    expect(result.changed).toBe(true);
+    const json = JSON.stringify(result.value);
+    expect(() => JSON.parse(json)).not.toThrow();
+  });
+});

--- a/assistant/src/context/post-turn-tool-result-truncation.ts
+++ b/assistant/src/context/post-turn-tool-result-truncation.ts
@@ -8,6 +8,7 @@ import type {
   ToolResultContent,
   ToolUseContent,
 } from "../providers/types.js";
+import { safeStringSlice } from "../util/unicode.js";
 
 /** Minimum content length (chars) before a tool result is eligible for truncation. ~2000 tokens at 4 chars/token. */
 export const THRESHOLD_CHARS = 8_000;
@@ -43,8 +44,8 @@ export function buildTruncatedContent(
   filePath: string,
 ): string {
   const half = Math.floor(TARGET_CHARS / 2);
-  const prefix = original.slice(0, half);
-  const suffix = original.slice(-half);
+  const prefix = safeStringSlice(original, 0, half);
+  const suffix = safeStringSlice(original, original.length - half, original.length);
   const omittedChars = original.length - TARGET_CHARS;
   const estimatedTokens = Math.round(omittedChars / 4);
   return `${prefix}\n\n...(${estimatedTokens} tokens omitted ${TRUNCATION_MARKER} ${filePath})\n\n${suffix}`;

--- a/assistant/src/context/tool-result-truncation.ts
+++ b/assistant/src/context/tool-result-truncation.ts
@@ -3,6 +3,7 @@ import type {
   Message,
   ToolResultContent,
 } from "../providers/types.js";
+import { safeStringSlice } from "../util/unicode.js";
 
 /**
  * Maximum share of the context window that a single tool result may occupy.
@@ -53,7 +54,7 @@ export function truncateToolResultText(text: string, maxChars: number): string {
     return text;
   }
 
-  return text.slice(0, sliceEnd) + TRUNCATION_SUFFIX;
+  return safeStringSlice(text, 0, sliceEnd) + TRUNCATION_SUFFIX;
 }
 
 /**

--- a/assistant/src/context/window-manager.ts
+++ b/assistant/src/context/window-manager.ts
@@ -6,6 +6,7 @@ import type {
   Provider,
 } from "../providers/types.js";
 import { getLogger } from "../util/logger.js";
+import { safeStringSlice } from "../util/unicode.js";
 import {
   estimateContentBlockTokens,
   estimatePromptTokens,
@@ -752,7 +753,7 @@ export class ContextWindowManager {
     // Budget in tokens → approximate char limit (4 chars ≈ 1 token).
     const maxChars = this.summaryMaxTokens * 4;
     if (summary.length <= maxChars) return summary;
-    return `${summary.slice(0, maxChars)}...`;
+    return `${safeStringSlice(summary, 0, maxChars)}...`;
   }
 }
 
@@ -1025,7 +1026,7 @@ function serializeBlock(block: ContentBlock): string {
 
 function clampText(text: string): string {
   if (text.length <= MAX_BLOCK_PREVIEW_CHARS) return text;
-  return `${text.slice(0, MAX_BLOCK_PREVIEW_CHARS)}... [truncated ${
+  return `${safeStringSlice(text, 0, MAX_BLOCK_PREVIEW_CHARS)}... [truncated ${
     text.length - MAX_BLOCK_PREVIEW_CHARS
   } chars]`;
 }

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -4,6 +4,7 @@ import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../../prompts/system-prompt.js";
 import { ProviderError } from "../../util/errors.js";
 import { getLogger } from "../../util/logger.js";
 import { extractRetryAfterMs } from "../../util/retry.js";
+import { stripOrphanedSurrogatesDeep } from "../../util/unicode.js";
 import { createStreamTimeout } from "../stream-timeout.js";
 import type {
   ContentBlock,
@@ -18,6 +19,35 @@ const log = getLogger("anthropic-client");
 
 /** Validation-specific timeout (10s) so a stalled network doesn't block key submission. */
 const VALIDATION_TIMEOUT_MS = 10_000;
+
+/** Rate-limit the orphaned-surrogate warning so a single bad stream can't flood logs. */
+const ORPHAN_WARNING_THROTTLE_MS = 60_000;
+let lastOrphanWarningMs = 0;
+
+function logOrphanedSurrogateWarning(
+  fixedStringCount: number,
+  messages: Anthropic.MessageParam[],
+): void {
+  const now = Date.now();
+  if (now - lastOrphanWarningMs < ORPHAN_WARNING_THROTTLE_MS) return;
+  lastOrphanWarningMs = now;
+  const blockTypes = new Set<string>();
+  for (const msg of messages) {
+    if (!Array.isArray(msg.content)) continue;
+    for (const block of msg.content) {
+      if (typeof block !== "object" || block == null) continue;
+      const type = (block as { type?: string }).type;
+      if (type) blockTypes.add(type);
+    }
+  }
+  log.warn(
+    {
+      fixedStringCount,
+      blockTypes: Array.from(blockTypes),
+    },
+    "stripped orphaned UTF-16 surrogates from outbound Anthropic request — upstream truncation is not surrogate-aware",
+  );
+}
 
 /**
  * Validate an Anthropic API key by making a lightweight GET /v1/models call.
@@ -705,7 +735,7 @@ export class AnthropicProvider implements Provider {
         ...(output_config ?? {}),
         ...(effort && supportsEffort ? { effort } : {}),
       };
-      const params: Anthropic.MessageStreamParams = {
+      let params: Anthropic.MessageStreamParams = {
         model: this.model,
         max_tokens: 64000,
         messages: sentMessages,
@@ -873,6 +903,15 @@ export class AnthropicProvider implements Provider {
         hasToolCacheBreakpoint
       ) {
         delete (params.system[0] as unknown as Record<string, unknown>).cache_control;
+      }
+
+      // Strip orphaned UTF-16 surrogates so the Anthropic JSON parser never
+      // sees invalid strings produced by upstream surrogate-splitting `.slice()` calls.
+      const sanitized = stripOrphanedSurrogatesDeep(params);
+      if (sanitized.changed) {
+        logOrphanedSurrogateWarning(sanitized.fixedStringCount, sentMessages);
+        params = sanitized.value;
+        sentMessages = params.messages;
       }
 
       const { signal: timeoutSignal, cleanup: cleanupTimeout } =

--- a/assistant/src/tools/browser/browser-execution.ts
+++ b/assistant/src/tools/browser/browser-execution.ts
@@ -1,6 +1,7 @@
 import type { ImageContent } from "../../providers/types.js";
 import { getLogger } from "../../util/logger.js";
 import { truncate } from "../../util/truncate.js";
+import { safeStringSlice } from "../../util/unicode.js";
 import { credentialBroker } from "../credentials/broker.js";
 import {
   isPrivateOrLocalHost,
@@ -1257,7 +1258,7 @@ export async function executeBrowserExtract(
 
     if (textContent.length > MAX_EXTRACT_LENGTH) {
       textContent =
-        textContent.slice(0, MAX_EXTRACT_LENGTH) + "\n... (truncated)";
+        safeStringSlice(textContent, 0, MAX_EXTRACT_LENGTH) + "\n... (truncated)";
     }
 
     const lines: string[] = [

--- a/assistant/src/tools/network/web-fetch.ts
+++ b/assistant/src/tools/network/web-fetch.ts
@@ -8,6 +8,7 @@ import { Readable } from "node:stream";
 import { RiskLevel } from "../../permissions/types.js";
 import type { ToolDefinition } from "../../providers/types.js";
 import { getLogger } from "../../util/logger.js";
+import { safeStringSlice } from "../../util/unicode.js";
 import { registerTool } from "../registry.js";
 import type { Tool, ToolContext, ToolExecutionResult } from "../types.js";
 import {
@@ -357,11 +358,13 @@ function extractHtmlMetadata(html: string): {
   // regex backtracking on large HTML documents.
   // Strip <script> blocks first so that a literal "</head>" inside a script
   // doesn't cause a false match that truncates the search region prematurely.
-  const candidate = html.slice(0, 200_000);
+  const candidate = safeStringSlice(html, 0, 200_000);
   const stripped = candidate.replace(/<script[\s>][\s\S]*?<\/script>/gi, "");
   const headEnd = stripped.search(/<\/head[\s>]/i);
   const searchRegion =
-    headEnd >= 0 ? stripped.slice(0, headEnd + 10) : stripped.slice(0, 50_000);
+    headEnd >= 0
+      ? safeStringSlice(stripped, 0, headEnd + 10)
+      : safeStringSlice(stripped, 0, 50_000);
 
   const title = extractFirstMatch(
     searchRegion,

--- a/assistant/src/tools/shared/shell-output.ts
+++ b/assistant/src/tools/shared/shell-output.ts
@@ -3,6 +3,8 @@ import { unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import { safeStringSlice } from "../../util/unicode.js";
+
 export const MAX_OUTPUT_LENGTH = 20_000;
 
 /** Tracks temp files created for truncated shell output so they can be cleaned up on shutdown. */
@@ -63,7 +65,7 @@ export function formatShellOutput(
     }
     const fileAttr = fullOutputPath ? ` file="${fullOutputPath}"` : "";
     const msg = `<output_truncated limit="20K"${fileAttr} />`;
-    output = output.slice(0, MAX_OUTPUT_LENGTH) + `\n${msg}`;
+    output = safeStringSlice(output, 0, MAX_OUTPUT_LENGTH) + `\n${msg}`;
     statusParts.push(msg);
   }
 

--- a/assistant/src/tools/skills/sandbox-runner.ts
+++ b/assistant/src/tools/skills/sandbox-runner.ts
@@ -4,6 +4,7 @@ import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 
 import { computeSkillVersionHash } from "../../skills/version-hash.js";
+import { safeStringSlice } from "../../util/unicode.js";
 import { buildSanitizedEnv } from "../terminal/safe-env.js";
 import { wrapCommand } from "../terminal/sandbox.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
@@ -218,7 +219,7 @@ function spawnRunner(
       if (code !== 0) {
         const truncatedStderr =
           stderr.length > MAX_OUTPUT_CHARS
-            ? stderr.slice(0, MAX_OUTPUT_CHARS) + "\n[stderr truncated]"
+            ? safeStringSlice(stderr, 0, MAX_OUTPUT_CHARS) + "\n[stderr truncated]"
             : stderr;
         resolve({
           content: `Skill tool script "${executorPath}" exited with code ${code}:\n${truncatedStderr}`,
@@ -229,7 +230,7 @@ function spawnRunner(
 
       const truncatedStdout =
         stdout.length > MAX_OUTPUT_CHARS
-          ? stdout.slice(0, MAX_OUTPUT_CHARS) + "\n[stdout truncated]"
+          ? safeStringSlice(stdout, 0, MAX_OUTPUT_CHARS) + "\n[stdout truncated]"
           : stdout;
       resolve({ content: truncatedStdout, isError: false });
     });

--- a/assistant/src/util/truncate.ts
+++ b/assistant/src/util/truncate.ts
@@ -1,6 +1,8 @@
+import { safeStringSlice } from "./unicode.js";
+
 /** Truncate a string to `maxLen` characters, appending `suffix` if truncated. */
 export function truncate(str: string, maxLen: number, suffix = "..."): string {
   if (str.length <= maxLen) return str;
-  if (maxLen < suffix.length) return str.slice(0, maxLen);
-  return str.slice(0, maxLen - suffix.length) + suffix;
+  if (maxLen < suffix.length) return safeStringSlice(str, 0, maxLen);
+  return safeStringSlice(str, 0, maxLen - suffix.length) + suffix;
 }

--- a/assistant/src/util/unicode.ts
+++ b/assistant/src/util/unicode.ts
@@ -1,0 +1,181 @@
+/**
+ * UTF-16 surrogate-pair-safe string utilities.
+ *
+ * JavaScript strings are UTF-16. Code points above the BMP (emoji, many CJK
+ * characters, mathematical symbols, etc.) are stored as surrogate pairs — a
+ * high surrogate (U+D800–U+DBFF) followed by a low surrogate (U+DC00–U+DFFF).
+ * `String.prototype.slice` operates on code units, not code points, so naive
+ * slicing can split a pair and leave an orphaned surrogate. Orphaned
+ * surrogates are invalid UTF-16 and cause `JSON.stringify` output to be
+ * rejected by strict JSON parsers (including Anthropic's API).
+ */
+
+const HIGH_SURROGATE_START = 0xd800;
+const HIGH_SURROGATE_END = 0xdbff;
+const LOW_SURROGATE_START = 0xdc00;
+const LOW_SURROGATE_END = 0xdfff;
+const REPLACEMENT_CHAR = "\ufffd";
+
+function isHighSurrogate(code: number): boolean {
+  return code >= HIGH_SURROGATE_START && code <= HIGH_SURROGATE_END;
+}
+
+function isLowSurrogate(code: number): boolean {
+  return code >= LOW_SURROGATE_START && code <= LOW_SURROGATE_END;
+}
+
+/**
+ * Slice a string like `String.prototype.slice`, but never cut a UTF-16
+ * surrogate pair in half.
+ *
+ * If the character at `end - 1` is a high surrogate *and* there is more of
+ * the string beyond `end` (so cutting would actually orphan it), `end` is
+ * decremented by one.
+ *
+ * If the character at `start` is a low surrogate *and* `start > 0` (so we
+ * would be starting mid-pair), `start` is incremented by one.
+ *
+ * When `end === str.length` we do not touch a trailing high surrogate: if it
+ * was already orphaned upstream, repairing it here would silently mutate
+ * content. That is the sanitizer's job, not this function's.
+ */
+export function safeStringSlice(
+  str: string,
+  start = 0,
+  end: number = str.length,
+): string {
+  let safeStart = Math.max(0, Math.min(str.length, start));
+  let safeEnd = Math.max(safeStart, Math.min(str.length, end));
+
+  if (safeEnd < str.length && safeEnd > safeStart) {
+    const lastCode = str.charCodeAt(safeEnd - 1);
+    if (isHighSurrogate(lastCode)) {
+      safeEnd--;
+    }
+  }
+
+  if (safeStart > 0 && safeStart < str.length) {
+    const firstCode = str.charCodeAt(safeStart);
+    if (isLowSurrogate(firstCode)) {
+      safeStart++;
+      if (safeStart > safeEnd) safeEnd = safeStart;
+    }
+  }
+
+  return str.slice(safeStart, safeEnd);
+}
+
+/**
+ * Replace every orphaned UTF-16 surrogate in `str` with U+FFFD
+ * (REPLACEMENT CHARACTER).
+ *
+ * Returns the original reference if no changes were needed, so callers can
+ * check `result === input` as a cheap "nothing was stripped" signal.
+ */
+export function stripOrphanedSurrogates(str: string): string {
+  let needsFix = false;
+  for (let i = 0; i < str.length; i++) {
+    const code = str.charCodeAt(i);
+    if (isHighSurrogate(code)) {
+      const next = i + 1 < str.length ? str.charCodeAt(i + 1) : 0;
+      if (!isLowSurrogate(next)) {
+        needsFix = true;
+        break;
+      }
+      i++;
+    } else if (isLowSurrogate(code)) {
+      needsFix = true;
+      break;
+    }
+  }
+  if (!needsFix) return str;
+
+  let out = "";
+  for (let i = 0; i < str.length; i++) {
+    const code = str.charCodeAt(i);
+    if (isHighSurrogate(code)) {
+      const next = i + 1 < str.length ? str.charCodeAt(i + 1) : 0;
+      if (isLowSurrogate(next)) {
+        out += str[i] + str[i + 1];
+        i++;
+      } else {
+        out += REPLACEMENT_CHAR;
+      }
+    } else if (isLowSurrogate(code)) {
+      out += REPLACEMENT_CHAR;
+    } else {
+      out += str[i];
+    }
+  }
+  return out;
+}
+
+/**
+ * Result of a deep sanitization walk. If `changed` is false the caller should
+ * use the original reference it passed in; `value` is only meaningful when
+ * `changed` is true.
+ */
+export interface DeepSanitizeResult<T> {
+  value: T;
+  changed: boolean;
+  /** Count of string values that had at least one orphan replaced. */
+  fixedStringCount: number;
+}
+
+/**
+ * Recursively walk arrays and plain objects, replacing orphaned surrogates in
+ * every string value. Non-plain objects (class instances, Date, Buffer, Map,
+ * Set, etc.) and non-string primitives are returned unchanged.
+ *
+ * On the happy path (no orphans found anywhere in the tree) the original
+ * reference is returned verbatim — no copies are made.
+ */
+export function stripOrphanedSurrogatesDeep<T>(input: T): DeepSanitizeResult<T> {
+  let fixedStringCount = 0;
+
+  const walk = (value: unknown): { value: unknown; changed: boolean } => {
+    if (typeof value === "string") {
+      const cleaned = stripOrphanedSurrogates(value);
+      if (cleaned !== value) {
+        fixedStringCount++;
+        return { value: cleaned, changed: true };
+      }
+      return { value, changed: false };
+    }
+
+    if (Array.isArray(value)) {
+      let arrChanged = false;
+      const next: unknown[] = new Array(value.length);
+      for (let i = 0; i < value.length; i++) {
+        const result = walk(value[i]);
+        next[i] = result.value;
+        if (result.changed) arrChanged = true;
+      }
+      return arrChanged ? { value: next, changed: true } : { value, changed: false };
+    }
+
+    if (value != null && typeof value === "object") {
+      const proto = Object.getPrototypeOf(value);
+      if (proto !== Object.prototype && proto !== null) {
+        return { value, changed: false };
+      }
+      let objChanged = false;
+      const next: Record<string, unknown> = {};
+      for (const key of Object.keys(value as Record<string, unknown>)) {
+        const result = walk((value as Record<string, unknown>)[key]);
+        next[key] = result.value;
+        if (result.changed) objChanged = true;
+      }
+      return objChanged ? { value: next, changed: true } : { value, changed: false };
+    }
+
+    return { value, changed: false };
+  };
+
+  const result = walk(input);
+  return {
+    value: result.value as T,
+    changed: result.changed,
+    fixedStringCount,
+  };
+}


### PR DESCRIPTION
## Summary
- Fixes `400 invalid_request_error: no low surrogate in string` from Anthropic when outbound content containing non-BMP characters (emoji, many CJK, mathematical symbols) is truncated at an unsafe boundary. `String.prototype.slice` operates on UTF-16 code units and can split a surrogate pair; the orphan makes the JSON invalid.
- Adds `assistant/src/util/unicode.ts` with `safeStringSlice` (surrogate-pair-aware slice) and `stripOrphanedSurrogatesDeep` (payload sanitizer that returns the input reference unchanged on the happy path).
- Sanitizes the final payload at the Anthropic client boundary (`providers/anthropic/client.ts`), the single choke point before `.stream()`. Rate-limited warning log fires when stripping actually happens so we can trace any future offenders without spamming.
- Replaces naive `.slice()` with `safeStringSlice` at the known hot truncation sites: tool-result truncation (including the post-turn prefix/suffix stub), shell output formatting, `util/truncate` (which feeds into summarization and conversation-starter jobs), web-fetch HTML extraction, browser extract text, skill sandbox stdout/stderr capture, and window-manager summary/preview clamping.
- Unit tests for the new utility plus regression tests that force each tool-result truncation path to cut inside a surrogate pair and assert no orphans remain. The Anthropic provider mock test passes a lone high surrogate through `sendMessage()` and verifies the captured payload is sanitized.

## Original prompt
it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24691" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
