### PR TITLE
fix(browser-relay): resolve numeric tab IDs as chrome tabId, not CDP targetId

### DIFF
--- a/clients/chrome-extension/background/__tests__/host-browser-dispatcher.test.ts
+++ b/clients/chrome-extension/background/__tests__/host-browser-dispatcher.test.ts
@@ -1346,6 +1346,45 @@ describe('createHostBrowserDispatcher', () => {
         targetId: '12.5',
       });
     });
+
+    test('exponential notation "1e3" routes as targetId, not tabId 1000', async () => {
+      harness = createHarnessWithRealResolveTarget({
+        sendResult: { id: 1, result: {} },
+      });
+
+      await harness.dispatcher.handle({
+        ...sampleRequest,
+        cdpSessionId: '1e3',
+      });
+
+      expect(harness.proxy.attachCalls[0].target).toEqual({ targetId: '1e3' });
+    });
+
+    test('hex literal "0x10" routes as targetId, not tabId 16', async () => {
+      harness = createHarnessWithRealResolveTarget({
+        sendResult: { id: 1, result: {} },
+      });
+
+      await harness.dispatcher.handle({
+        ...sampleRequest,
+        cdpSessionId: '0x10',
+      });
+
+      expect(harness.proxy.attachCalls[0].target).toEqual({ targetId: '0x10' });
+    });
+
+    test('whitespace-padded " 42 " routes as targetId', async () => {
+      harness = createHarnessWithRealResolveTarget({
+        sendResult: { id: 1, result: {} },
+      });
+
+      await harness.dispatcher.handle({
+        ...sampleRequest,
+        cdpSessionId: ' 42 ',
+      });
+
+      expect(harness.proxy.attachCalls[0].target).toEqual({ targetId: ' 42 ' });
+    });
   });
 
   // ── PR10: CDP event forwarding ─────────────────────────────────────

--- a/clients/chrome-extension/background/__tests__/host-browser-dispatcher.test.ts
+++ b/clients/chrome-extension/background/__tests__/host-browser-dispatcher.test.ts
@@ -1187,6 +1187,167 @@ describe('createHostBrowserDispatcher', () => {
     });
   });
 
+  // ── resolveHostBrowserTarget: numeric tab ID vs CDP targetId routing ──
+
+  describe('handle — resolveHostBrowserTarget numeric vs non-numeric routing', () => {
+    /**
+     * These tests wire a resolveTarget that mirrors the real
+     * resolveHostBrowserTarget logic from worker.ts: numeric strings
+     * (positive integers) route as { tabId }, non-numeric strings
+     * route as { targetId }, and undefined falls back to the active
+     * tab (simulated as tabId 42 here).
+     */
+    function createHarnessWithRealResolveTarget(
+      options: MockCdpProxyOptions = {},
+    ): DispatcherTestHarness {
+      const h = createHarness(options);
+      h.resolveTargetImpl = async (cdpSessionId) => {
+        if (cdpSessionId) {
+          const asNumber = Number(cdpSessionId);
+          if (Number.isInteger(asNumber) && asNumber > 0) {
+            return { tabId: asNumber };
+          }
+          return { targetId: cdpSessionId };
+        }
+        // Simulate active-tab fallback.
+        return { tabId: 42 };
+      };
+      return h;
+    }
+
+    test('numeric cdpSessionId "12345" resolves to { tabId: 12345 }', async () => {
+      harness = createHarnessWithRealResolveTarget({
+        sendResult: { id: 1, result: {} },
+      });
+
+      await harness.dispatcher.handle({
+        ...sampleRequest,
+        cdpSessionId: '12345',
+      });
+
+      // resolveTarget was called with the numeric string.
+      expect(harness.resolveTargetCalls).toEqual(['12345']);
+
+      // The proxy should have attached using tabId, not targetId.
+      expect(harness.proxy.attachCalls.length).toBe(1);
+      expect(harness.proxy.attachCalls[0].target).toEqual({ tabId: 12345 });
+
+      // send also uses the tabId target.
+      expect(harness.proxy.sendCalls.length).toBe(1);
+      expect(harness.proxy.sendCalls[0].target).toEqual({ tabId: 12345 });
+
+      expect(harness.results.length).toBe(1);
+      expect(harness.results[0].isError).toBe(false);
+    });
+
+    test('non-numeric cdpSessionId "ABC123DEF456" resolves to { targetId: "ABC123DEF456" }', async () => {
+      harness = createHarnessWithRealResolveTarget({
+        sendResult: { id: 1, result: {} },
+      });
+
+      await harness.dispatcher.handle({
+        ...sampleRequest,
+        cdpSessionId: 'ABC123DEF456',
+      });
+
+      expect(harness.resolveTargetCalls).toEqual(['ABC123DEF456']);
+
+      // Non-numeric strings route through the CDP targetId path.
+      expect(harness.proxy.attachCalls.length).toBe(1);
+      expect(harness.proxy.attachCalls[0].target).toEqual({
+        targetId: 'ABC123DEF456',
+      });
+
+      expect(harness.proxy.sendCalls.length).toBe(1);
+      expect(harness.proxy.sendCalls[0].target).toEqual({
+        targetId: 'ABC123DEF456',
+      });
+
+      expect(harness.results.length).toBe(1);
+      expect(harness.results[0].isError).toBe(false);
+    });
+
+    test('UUID-style cdpSessionId routes as targetId', async () => {
+      harness = createHarnessWithRealResolveTarget({
+        sendResult: { id: 1, result: {} },
+      });
+
+      const uuidTarget = '550e8400-e29b-41d4-a716-446655440000';
+      await harness.dispatcher.handle({
+        ...sampleRequest,
+        cdpSessionId: uuidTarget,
+      });
+
+      expect(harness.resolveTargetCalls).toEqual([uuidTarget]);
+      expect(harness.proxy.attachCalls[0].target).toEqual({
+        targetId: uuidTarget,
+      });
+    });
+
+    test('undefined cdpSessionId falls back to active tab (tabId: 42)', async () => {
+      harness = createHarnessWithRealResolveTarget({
+        sendResult: { id: 1, result: {} },
+      });
+
+      await harness.dispatcher.handle(sampleRequest);
+
+      // sampleRequest has no cdpSessionId → undefined.
+      expect(harness.resolveTargetCalls).toEqual([undefined]);
+
+      // Falls back to the simulated active tab.
+      expect(harness.proxy.attachCalls.length).toBe(1);
+      expect(harness.proxy.attachCalls[0].target).toEqual({ tabId: 42 });
+
+      expect(harness.proxy.sendCalls.length).toBe(1);
+      expect(harness.proxy.sendCalls[0].target).toEqual({ tabId: 42 });
+
+      expect(harness.results.length).toBe(1);
+      expect(harness.results[0].isError).toBe(false);
+    });
+
+    test('"0" is not a valid Chrome tab ID and routes as targetId', async () => {
+      harness = createHarnessWithRealResolveTarget({
+        sendResult: { id: 1, result: {} },
+      });
+
+      await harness.dispatcher.handle({
+        ...sampleRequest,
+        cdpSessionId: '0',
+      });
+
+      // 0 is not a positive integer, so it routes as targetId.
+      expect(harness.proxy.attachCalls[0].target).toEqual({ targetId: '0' });
+    });
+
+    test('negative number string routes as targetId', async () => {
+      harness = createHarnessWithRealResolveTarget({
+        sendResult: { id: 1, result: {} },
+      });
+
+      await harness.dispatcher.handle({
+        ...sampleRequest,
+        cdpSessionId: '-5',
+      });
+
+      expect(harness.proxy.attachCalls[0].target).toEqual({ targetId: '-5' });
+    });
+
+    test('floating point string routes as targetId', async () => {
+      harness = createHarnessWithRealResolveTarget({
+        sendResult: { id: 1, result: {} },
+      });
+
+      await harness.dispatcher.handle({
+        ...sampleRequest,
+        cdpSessionId: '12.5',
+      });
+
+      expect(harness.proxy.attachCalls[0].target).toEqual({
+        targetId: '12.5',
+      });
+    });
+  });
+
   // ── PR10: CDP event forwarding ─────────────────────────────────────
 
   describe('forwardCdpEvent — chrome.debugger.onEvent forwarding', () => {

--- a/clients/chrome-extension/background/worker.ts
+++ b/clients/chrome-extension/background/worker.ts
@@ -161,13 +161,16 @@ async function resolveHostBrowserTarget(
 ): Promise<{ tabId?: number; targetId?: string }> {
   if (cdpSessionId) {
     // Chrome tab IDs are positive integers. CDP targetIds are opaque
-    // non-numeric strings (hex, UUIDs, etc.). Route numeric strings
-    // as tabId for chrome.debugger.attach({ tabId }) which is the
-    // standard path; route non-numeric strings as targetId for the
-    // CDP flat-session path.
-    const asNumber = Number(cdpSessionId);
-    if (Number.isInteger(asNumber) && asNumber > 0) {
-      return { tabId: asNumber };
+    // non-numeric strings (hex, UUIDs, etc.). Route canonical decimal
+    // digit strings as tabId for chrome.debugger.attach({ tabId });
+    // route everything else as targetId. The regex guard rejects hex
+    // literals ("0x10"), exponential notation ("1e3"), and whitespace-
+    // padded values that Number() would silently coerce to integers.
+    if (/^\d+$/.test(cdpSessionId)) {
+      const asNumber = Number(cdpSessionId);
+      if (asNumber > 0 && Number.isSafeInteger(asNumber)) {
+        return { tabId: asNumber };
+      }
     }
     return { targetId: cdpSessionId };
   }

--- a/clients/chrome-extension/background/worker.ts
+++ b/clients/chrome-extension/background/worker.ts
@@ -159,11 +159,16 @@ let shouldConnect = false;
 async function resolveHostBrowserTarget(
   cdpSessionId: string | undefined,
 ): Promise<{ tabId?: number; targetId?: string }> {
-  // When the daemon side has an explicit session id (e.g. a flat child
-  // session returned from a prior Target.attachToTarget) we route the
-  // command by targetId. Otherwise fall back to the most recently
-  // active tab in the focused window.
   if (cdpSessionId) {
+    // Chrome tab IDs are positive integers. CDP targetIds are opaque
+    // non-numeric strings (hex, UUIDs, etc.). Route numeric strings
+    // as tabId for chrome.debugger.attach({ tabId }) which is the
+    // standard path; route non-numeric strings as targetId for the
+    // CDP flat-session path.
+    const asNumber = Number(cdpSessionId);
+    if (Number.isInteger(asNumber) && asNumber > 0) {
+      return { tabId: asNumber };
+    }
     return { targetId: cdpSessionId };
   }
   const [activeTab] = await chrome.tabs.query({ active: true, lastFocusedWindow: true });


### PR DESCRIPTION
## Summary
- Update `resolveHostBrowserTarget` to detect numeric Chrome tab IDs vs opaque CDP targetIds
- Numeric strings route as `{ tabId: N }`, non-numeric strings route as `{ targetId }`
- Add tests verifying the three resolution paths

Part of plan: browser-relay-stale-tabid-fix.md (PR 3 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24692" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
