### PR TITLE
fix: add tokenExchangeBodyFormat support to CES local-token-refresh

### DIFF
--- a/credential-executor/src/materializers/local-token-refresh.ts
+++ b/credential-executor/src/materializers/local-token-refresh.ts
@@ -47,6 +47,7 @@ interface OAuthProviderRow {
   provider_key: string;
   token_url: string;
   token_endpoint_auth_method: string | null;
+  token_exchange_body_format: string | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -64,6 +65,7 @@ interface RefreshConfig {
   clientId: string;
   clientSecret?: string;
   authMethod: TokenEndpointAuthMethod;
+  bodyFormat: "form" | "json";
 }
 
 /**
@@ -108,7 +110,7 @@ async function resolveRefreshConfig(
     // 3. Look up the provider to get token_url and auth method
     const provider = db
       .query<OAuthProviderRow, [string]>(
-        `SELECT provider_key, token_url, token_endpoint_auth_method FROM oauth_providers WHERE provider_key = ? LIMIT 1`,
+        `SELECT provider_key, token_url, token_endpoint_auth_method, token_exchange_body_format FROM oauth_providers WHERE provider_key = ? LIMIT 1`,
       )
       .get(conn.provider_key);
 
@@ -126,12 +128,14 @@ async function resolveRefreshConfig(
     );
 
     const authMethod = (provider.token_endpoint_auth_method as TokenEndpointAuthMethod | null) ?? "client_secret_post";
+    const bodyFormat = (provider.token_exchange_body_format as "form" | "json" | null) ?? "form";
 
     return {
       tokenUrl: provider.token_url,
       clientId: app.client_id,
       clientSecret,
       authMethod,
+      bodyFormat,
     };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
@@ -161,7 +165,10 @@ async function performTokenRefresh(
   };
 
   const headers: Record<string, string> = {
-    "Content-Type": "application/x-www-form-urlencoded",
+    "Content-Type":
+      config.bodyFormat === "json"
+        ? "application/json"
+        : "application/x-www-form-urlencoded",
   };
 
   if (config.clientSecret && config.authMethod === "client_secret_basic") {
@@ -179,7 +186,10 @@ async function performTokenRefresh(
   const resp = await fetch(config.tokenUrl, {
     method: "POST",
     headers,
-    body: new URLSearchParams(body),
+    body:
+      config.bodyFormat === "json"
+        ? JSON.stringify(body)
+        : new URLSearchParams(body),
   });
 
   if (!resp.ok) {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for notion-oauth.md.

**Gap:** credential-executor local-token-refresh.ts not updated for JSON body format
**What was expected:** CES local-mode refresh should support JSON body format like assistant oauth2.ts
**What was found:** Hardcoded form-encoded body in CES refresh
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24694" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
