### PR TITLE
fix: add tokenExchangeBodyFormat to test fixture types

### DIFF
--- a/assistant/src/__tests__/oauth-cli.test.ts
+++ b/assistant/src/__tests__/oauth-cli.test.ts
@@ -173,6 +173,8 @@ mock.module("../oauth/oauth-store.js", () => ({
       tokenEndpointAuthMethod:
         (params.tokenEndpointAuthMethod as string | undefined) ||
         "client_secret_post",
+      tokenExchangeBodyFormat:
+        (params.tokenExchangeBodyFormat as string | undefined) ?? "form",
       userinfoUrl: params.userinfoUrl ?? null,
       baseUrl: params.baseUrl ?? null,
       defaultScopes: JSON.stringify(params.defaultScopes ?? []),

--- a/assistant/src/__tests__/oauth-connect-orchestrator.test.ts
+++ b/assistant/src/__tests__/oauth-connect-orchestrator.test.ts
@@ -91,6 +91,7 @@ type ProviderRow = {
   tokenExchangeUrl: string;
   refreshUrl: string | null;
   tokenEndpointAuthMethod: string;
+  tokenExchangeBodyFormat: string;
   userinfoUrl: string | null;
   baseUrl: string | null;
   defaultScopes: string;
@@ -169,6 +170,7 @@ function makeProviderRow(
     tokenExchangeUrl: "https://provider.example.com/token",
     refreshUrl: null,
     tokenEndpointAuthMethod: "client_secret_post",
+    tokenExchangeBodyFormat: "form",
     userinfoUrl: null,
     baseUrl: null,
     defaultScopes: '["openid","email"]',

--- a/assistant/src/cli/commands/oauth/__tests__/providers-register.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/providers-register.test.ts
@@ -144,6 +144,7 @@ const sampleProviderRow = {
   tokenExchangeUrl: "https://custom-api.example.com/oauth/token",
   refreshUrl: null,
   tokenEndpointAuthMethod: "client_secret_post",
+  tokenExchangeBodyFormat: "form",
   userinfoUrl: null,
   baseUrl: null,
   defaultScopes: "[]",

--- a/assistant/src/cli/commands/oauth/__tests__/providers-update.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/providers-update.test.ts
@@ -144,6 +144,7 @@ const sampleProviderRow = {
   tokenExchangeUrl: "https://custom-api.example.com/oauth/token",
   refreshUrl: null,
   tokenEndpointAuthMethod: "client_secret_post",
+  tokenExchangeBodyFormat: "form",
   userinfoUrl: null,
   baseUrl: null,
   defaultScopes: "[]",


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for notion-oauth.md.

**Gap:** Test fixture types missing tokenExchangeBodyFormat
**What was expected:** Test fixtures should include tokenExchangeBodyFormat to match schema
**What was found:** Multiple test files had local types out of sync with actual schema
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24695" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
