### PR TITLE
fix: remove double-wrapping in Vellum.findTab result serialization

### DIFF
--- a/clients/chrome-extension/background/host-browser-dispatcher.ts
+++ b/clients/chrome-extension/background/host-browser-dispatcher.ts
@@ -328,7 +328,7 @@ export function createHostBrowserDispatcher(
         if (!urlPattern) {
           await deps.postResult({
             requestId,
-            content: JSON.stringify({ error: { code: -32602, message: 'urlPattern is required' } }),
+            content: JSON.stringify({ code: -32602, message: 'urlPattern is required' }),
             isError: true,
           });
           return;
@@ -338,14 +338,14 @@ export function createHostBrowserDispatcher(
         if (!tab?.id) {
           await deps.postResult({
             requestId,
-            content: JSON.stringify({ error: { code: -32000, message: `No tab matched URL pattern: ${urlPattern}` } }),
+            content: JSON.stringify({ code: -32000, message: `No tab matched URL pattern: ${urlPattern}` }),
             isError: true,
           });
           return;
         }
         await deps.postResult({
           requestId,
-          content: JSON.stringify({ result: { tabId: String(tab.id), url: tab.url, title: tab.title } }),
+          content: JSON.stringify({ tabId: String(tab.id), url: tab.url, title: tab.title }),
           isError: false,
         });
         return;


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for browser-relay-stale-tabid-fix.md.

**Gap:** Double-wrapped result causes Vellum.findTab to always report no tab matched
**What was expected:** resp.result should contain { tabId, url, title } directly
**What was found:** resp.result contained { result: { tabId, url, title } } due to double-wrapping
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24698" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
