### PR TITLE
fix(browser-relay): fix stale tabId / CDP session mismatch

### DIFF
--- a/assistant/src/cli/commands/browser-relay.ts
+++ b/assistant/src/cli/commands/browser-relay.ts
@@ -237,12 +237,15 @@ async function actionNewTab(url: string): Promise<void> {
   }
 }
 
-async function actionNavigate(tabId: string, url: string): Promise<void> {
+async function actionNavigate(
+  tabId: string | undefined,
+  url: string,
+): Promise<void> {
   try {
     await postBrowserCdp({
       cdpMethod: "Page.navigate",
       cdpParams: { url },
-      cdpSessionId: tabId,
+      ...(tabId !== undefined ? { cdpSessionId: tabId } : {}),
     });
     emitOk({});
   } catch (err) {
@@ -250,7 +253,10 @@ async function actionNavigate(tabId: string, url: string): Promise<void> {
   }
 }
 
-async function actionEvaluate(tabId: string, code: string): Promise<void> {
+async function actionEvaluate(
+  tabId: string | undefined,
+  code: string,
+): Promise<void> {
   try {
     const resp = await postBrowserCdp({
       cdpMethod: "Runtime.evaluate",
@@ -259,7 +265,7 @@ async function actionEvaluate(tabId: string, code: string): Promise<void> {
         returnByValue: true,
         awaitPromise: true,
       },
-      cdpSessionId: tabId,
+      ...(tabId !== undefined ? { cdpSessionId: tabId } : {}),
     });
     // CDP Runtime.evaluate returns { result: { type, value }, exceptionDetails? }.
     // Surface exceptions as relay errors so callers don't silently get undefined.
@@ -402,9 +408,12 @@ Examples:
   relay
     .command("navigate")
     .description("Navigate an existing tab to a new URL")
-    .requiredOption("--tab-id <id>", "Target tab ID")
+    .option(
+      "--tab-id <id>",
+      "Target tab ID (defaults to active tab) — run 'assistant browser chrome relay find-tab --url <pattern>' to find it",
+    )
     .requiredOption("--url <url>", "URL to navigate to")
-    .action(async (opts: { tabId: string; url: string }) => {
+    .action(async (opts: { tabId?: string; url: string }) => {
       await actionNavigate(opts.tabId, opts.url);
     });
 
@@ -413,12 +422,15 @@ Examples:
   relay
     .command("evaluate")
     .description("Execute JavaScript in a Chrome tab")
-    .requiredOption("--tab-id <id>", "Target tab ID")
+    .option(
+      "--tab-id <id>",
+      "Target tab ID (defaults to active tab) — run 'assistant browser chrome relay find-tab --url <pattern>' to find it",
+    )
     .option(
       "--code <script>",
       "JavaScript code to evaluate (or read from stdin)",
     )
-    .action(async (opts: { tabId: string; code?: string }) => {
+    .action(async (opts: { tabId?: string; code?: string }) => {
       let code: string;
       if (opts.code) {
         code = opts.code;

--- a/assistant/src/cli/commands/browser-relay.ts
+++ b/assistant/src/cli/commands/browser-relay.ts
@@ -168,52 +168,21 @@ async function readStdin(): Promise<string> {
 }
 
 // ---------------------------------------------------------------------------
-// URL glob matching for find-tab
-// ---------------------------------------------------------------------------
-
-/**
- * Convert a Chrome match-pattern style glob (e.g. `*://*.amazon.com/*`)
- * into a regular expression. Matches the chrome.tabs.query semantics
- * the legacy relay CLI exposed:
- *
- *   - `*` is a wildcard that matches any sequence (including `/` in
- *     the path component, mirroring the legacy minimatch behaviour).
- *   - All other regex metacharacters are escaped.
- */
-function globToRegex(glob: string): RegExp {
-  const escaped = glob.replace(/[.+?^${}()|[\]\\]/g, "\\$&");
-  const pattern = "^" + escaped.replace(/\*/g, ".*") + "$";
-  return new RegExp(pattern);
-}
-
-// ---------------------------------------------------------------------------
 // Action handlers — translate legacy actions into CDP commands
 // ---------------------------------------------------------------------------
 
-interface CdpTarget {
-  targetId: string;
-  type: string;
-  url: string;
-  title?: string;
-  attached?: boolean;
-}
-
-interface CdpTargetsResult {
-  targetInfos: CdpTarget[];
-}
-
 async function actionFindTab(urlPattern: string): Promise<void> {
   try {
-    const resp = await postBrowserCdp({ cdpMethod: "Target.getTargets" });
-    const targets =
-      (resp.result as CdpTargetsResult | undefined)?.targetInfos ?? [];
-    const re = globToRegex(urlPattern);
-    const match = targets.find((t) => t.type === "page" && re.test(t.url));
-    if (!match) {
+    const resp = await postBrowserCdp({
+      cdpMethod: "Vellum.findTab",
+      cdpParams: { urlPattern },
+    });
+    const tab = resp.result as { tabId?: string; url?: string } | undefined;
+    if (!tab?.tabId) {
       emitError(`No tab matched URL pattern: ${urlPattern}`);
       return;
     }
-    emitOk({ tabId: match.targetId });
+    emitOk({ tabId: tab.tabId });
   } catch (err) {
     emitError(err instanceof Error ? err.message : String(err));
   }

--- a/clients/chrome-extension/background/__tests__/host-browser-dispatcher.test.ts
+++ b/clients/chrome-extension/background/__tests__/host-browser-dispatcher.test.ts
@@ -1187,6 +1187,206 @@ describe('createHostBrowserDispatcher', () => {
     });
   });
 
+  // ── resolveHostBrowserTarget: numeric tab ID vs CDP targetId routing ──
+
+  describe('handle — resolveHostBrowserTarget numeric vs non-numeric routing', () => {
+    /**
+     * These tests wire a resolveTarget that mirrors the real
+     * resolveHostBrowserTarget logic from worker.ts: numeric strings
+     * (positive integers) route as { tabId }, non-numeric strings
+     * route as { targetId }, and undefined falls back to the active
+     * tab (simulated as tabId 42 here).
+     */
+    function createHarnessWithRealResolveTarget(
+      options: MockCdpProxyOptions = {},
+    ): DispatcherTestHarness {
+      const h = createHarness(options);
+      h.resolveTargetImpl = async (cdpSessionId) => {
+        if (cdpSessionId) {
+          const asNumber = Number(cdpSessionId);
+          if (Number.isInteger(asNumber) && asNumber > 0) {
+            return { tabId: asNumber };
+          }
+          return { targetId: cdpSessionId };
+        }
+        // Simulate active-tab fallback.
+        return { tabId: 42 };
+      };
+      return h;
+    }
+
+    test('numeric cdpSessionId "12345" resolves to { tabId: 12345 }', async () => {
+      harness = createHarnessWithRealResolveTarget({
+        sendResult: { id: 1, result: {} },
+      });
+
+      await harness.dispatcher.handle({
+        ...sampleRequest,
+        cdpSessionId: '12345',
+      });
+
+      // resolveTarget was called with the numeric string.
+      expect(harness.resolveTargetCalls).toEqual(['12345']);
+
+      // The proxy should have attached using tabId, not targetId.
+      expect(harness.proxy.attachCalls.length).toBe(1);
+      expect(harness.proxy.attachCalls[0].target).toEqual({ tabId: 12345 });
+
+      // send also uses the tabId target.
+      expect(harness.proxy.sendCalls.length).toBe(1);
+      expect(harness.proxy.sendCalls[0].target).toEqual({ tabId: 12345 });
+
+      expect(harness.results.length).toBe(1);
+      expect(harness.results[0].isError).toBe(false);
+    });
+
+    test('non-numeric cdpSessionId "ABC123DEF456" resolves to { targetId: "ABC123DEF456" }', async () => {
+      harness = createHarnessWithRealResolveTarget({
+        sendResult: { id: 1, result: {} },
+      });
+
+      await harness.dispatcher.handle({
+        ...sampleRequest,
+        cdpSessionId: 'ABC123DEF456',
+      });
+
+      expect(harness.resolveTargetCalls).toEqual(['ABC123DEF456']);
+
+      // Non-numeric strings route through the CDP targetId path.
+      expect(harness.proxy.attachCalls.length).toBe(1);
+      expect(harness.proxy.attachCalls[0].target).toEqual({
+        targetId: 'ABC123DEF456',
+      });
+
+      expect(harness.proxy.sendCalls.length).toBe(1);
+      expect(harness.proxy.sendCalls[0].target).toEqual({
+        targetId: 'ABC123DEF456',
+      });
+
+      expect(harness.results.length).toBe(1);
+      expect(harness.results[0].isError).toBe(false);
+    });
+
+    test('UUID-style cdpSessionId routes as targetId', async () => {
+      harness = createHarnessWithRealResolveTarget({
+        sendResult: { id: 1, result: {} },
+      });
+
+      const uuidTarget = '550e8400-e29b-41d4-a716-446655440000';
+      await harness.dispatcher.handle({
+        ...sampleRequest,
+        cdpSessionId: uuidTarget,
+      });
+
+      expect(harness.resolveTargetCalls).toEqual([uuidTarget]);
+      expect(harness.proxy.attachCalls[0].target).toEqual({
+        targetId: uuidTarget,
+      });
+    });
+
+    test('undefined cdpSessionId falls back to active tab (tabId: 42)', async () => {
+      harness = createHarnessWithRealResolveTarget({
+        sendResult: { id: 1, result: {} },
+      });
+
+      await harness.dispatcher.handle(sampleRequest);
+
+      // sampleRequest has no cdpSessionId → undefined.
+      expect(harness.resolveTargetCalls).toEqual([undefined]);
+
+      // Falls back to the simulated active tab.
+      expect(harness.proxy.attachCalls.length).toBe(1);
+      expect(harness.proxy.attachCalls[0].target).toEqual({ tabId: 42 });
+
+      expect(harness.proxy.sendCalls.length).toBe(1);
+      expect(harness.proxy.sendCalls[0].target).toEqual({ tabId: 42 });
+
+      expect(harness.results.length).toBe(1);
+      expect(harness.results[0].isError).toBe(false);
+    });
+
+    test('"0" is not a valid Chrome tab ID and routes as targetId', async () => {
+      harness = createHarnessWithRealResolveTarget({
+        sendResult: { id: 1, result: {} },
+      });
+
+      await harness.dispatcher.handle({
+        ...sampleRequest,
+        cdpSessionId: '0',
+      });
+
+      // 0 is not a positive integer, so it routes as targetId.
+      expect(harness.proxy.attachCalls[0].target).toEqual({ targetId: '0' });
+    });
+
+    test('negative number string routes as targetId', async () => {
+      harness = createHarnessWithRealResolveTarget({
+        sendResult: { id: 1, result: {} },
+      });
+
+      await harness.dispatcher.handle({
+        ...sampleRequest,
+        cdpSessionId: '-5',
+      });
+
+      expect(harness.proxy.attachCalls[0].target).toEqual({ targetId: '-5' });
+    });
+
+    test('floating point string routes as targetId', async () => {
+      harness = createHarnessWithRealResolveTarget({
+        sendResult: { id: 1, result: {} },
+      });
+
+      await harness.dispatcher.handle({
+        ...sampleRequest,
+        cdpSessionId: '12.5',
+      });
+
+      expect(harness.proxy.attachCalls[0].target).toEqual({
+        targetId: '12.5',
+      });
+    });
+
+    test('exponential notation "1e3" routes as targetId, not tabId 1000', async () => {
+      harness = createHarnessWithRealResolveTarget({
+        sendResult: { id: 1, result: {} },
+      });
+
+      await harness.dispatcher.handle({
+        ...sampleRequest,
+        cdpSessionId: '1e3',
+      });
+
+      expect(harness.proxy.attachCalls[0].target).toEqual({ targetId: '1e3' });
+    });
+
+    test('hex literal "0x10" routes as targetId, not tabId 16', async () => {
+      harness = createHarnessWithRealResolveTarget({
+        sendResult: { id: 1, result: {} },
+      });
+
+      await harness.dispatcher.handle({
+        ...sampleRequest,
+        cdpSessionId: '0x10',
+      });
+
+      expect(harness.proxy.attachCalls[0].target).toEqual({ targetId: '0x10' });
+    });
+
+    test('whitespace-padded " 42 " routes as targetId', async () => {
+      harness = createHarnessWithRealResolveTarget({
+        sendResult: { id: 1, result: {} },
+      });
+
+      await harness.dispatcher.handle({
+        ...sampleRequest,
+        cdpSessionId: ' 42 ',
+      });
+
+      expect(harness.proxy.attachCalls[0].target).toEqual({ targetId: ' 42 ' });
+    });
+  });
+
   // ── PR10: CDP event forwarding ─────────────────────────────────────
 
   describe('forwardCdpEvent — chrome.debugger.onEvent forwarding', () => {

--- a/clients/chrome-extension/background/__tests__/host-browser-dispatcher.test.ts
+++ b/clients/chrome-extension/background/__tests__/host-browser-dispatcher.test.ts
@@ -1203,9 +1203,11 @@ describe('createHostBrowserDispatcher', () => {
       const h = createHarness(options);
       h.resolveTargetImpl = async (cdpSessionId) => {
         if (cdpSessionId) {
-          const asNumber = Number(cdpSessionId);
-          if (Number.isInteger(asNumber) && asNumber > 0) {
-            return { tabId: asNumber };
+          if (/^\d+$/.test(cdpSessionId)) {
+            const asNumber = Number(cdpSessionId);
+            if (asNumber > 0 && Number.isSafeInteger(asNumber)) {
+              return { tabId: asNumber };
+            }
           }
           return { targetId: cdpSessionId };
         }

--- a/clients/chrome-extension/background/__tests__/host-browser-dispatcher.test.ts
+++ b/clients/chrome-extension/background/__tests__/host-browser-dispatcher.test.ts
@@ -272,7 +272,7 @@ describe('createHostBrowserDispatcher', () => {
       );
     });
 
-    test('routes via targetId when cdpSessionId is provided', async () => {
+    test('routes via targetId when cdpSessionId is provided but does not forward it as frame.sessionId', async () => {
       harness = createHarness({
         sendResult: { id: 1, result: {} },
       });
@@ -285,7 +285,51 @@ describe('createHostBrowserDispatcher', () => {
 
       expect(harness.resolveTargetCalls).toEqual(['target-xyz']);
       expect(harness.proxy.attachCalls[0].target).toEqual({ targetId: 'target-xyz' });
-      expect(harness.proxy.sendCalls[0].frame.sessionId).toBe('target-xyz');
+      // cdpSessionId must NOT be forwarded as frame.sessionId — it is used
+      // only for target resolution. Forwarding it would cause
+      // chrome.debugger.sendCommand to look up a non-existent flat session.
+      expect(harness.proxy.sendCalls[0].frame.sessionId).toBeUndefined();
+    });
+  });
+
+  describe('handle — cdpSessionId target resolution vs flat-session separation', () => {
+    test('cdpSessionId is passed to resolveTarget but NOT forwarded as frame.sessionId', async () => {
+      harness = createHarness({
+        sendResult: { id: 1, result: {} },
+      });
+      // Override resolveTarget to record calls and return a targetId.
+      harness.resolveTargetImpl = async (cdpSessionId) => {
+        return { targetId: 'test-target-id' };
+      };
+
+      await harness.dispatcher.handle({
+        ...sampleRequest,
+        cdpSessionId: 'test-target-id',
+      });
+
+      // resolveTarget was called with the cdpSessionId.
+      expect(harness.resolveTargetCalls).toEqual(['test-target-id']);
+
+      // The proxy.send() call's frame must NOT carry sessionId — cdpSessionId
+      // is used only for target resolution, not as a CDP flat-session qualifier.
+      expect(harness.proxy.sendCalls.length).toBe(1);
+      expect(harness.proxy.sendCalls[0].frame.sessionId).toBeUndefined();
+    });
+
+    test('when cdpSessionId is omitted, resolveTarget receives undefined and frame.sessionId is also undefined', async () => {
+      harness = createHarness({
+        sendResult: { id: 1, result: {} },
+      });
+
+      await harness.dispatcher.handle(sampleRequest);
+
+      // resolveTarget was called with undefined (active-tab fallback path).
+      expect(harness.resolveTargetCalls).toEqual([undefined]);
+
+      // frame.sessionId is also undefined — the active-tab path never sets
+      // a flat-session qualifier.
+      expect(harness.proxy.sendCalls.length).toBe(1);
+      expect(harness.proxy.sendCalls[0].frame.sessionId).toBeUndefined();
     });
   });
 

--- a/clients/chrome-extension/background/host-browser-dispatcher.ts
+++ b/clients/chrome-extension/background/host-browser-dispatcher.ts
@@ -345,7 +345,12 @@ export function createHostBrowserDispatcher(
         id: nextCdpId++,
         method: envelope.cdpMethod,
         params: envelope.cdpParams,
-        sessionId: envelope.cdpSessionId,
+        // cdpSessionId is used only for target resolution (resolveTarget above).
+        // It must NOT be forwarded as a CDP flat-session sessionId — doing so
+        // causes chrome.debugger.sendCommand to look up a non-existent session
+        // and fail with "Session with given id not found". Flat sessions are
+        // only valid when obtained from Target.attachToTarget with flatten:true,
+        // which this code path does not use.
       });
       // Recovery hint: if the CDP send returned an error indicating the
       // target is no longer attached (tab closed mid-flight, navigated

--- a/clients/chrome-extension/background/host-browser-dispatcher.ts
+++ b/clients/chrome-extension/background/host-browser-dispatcher.ts
@@ -334,6 +334,7 @@ export function createHostBrowserDispatcher(
           return;
         }
         const tabs = await chrome.tabs.query({ url: urlPattern });
+        if (abort.signal.aborted || cancelledRequestIds.has(requestId)) return;
         const tab = tabs[0];
         if (!tab?.id) {
           await deps.postResult({

--- a/clients/chrome-extension/background/host-browser-dispatcher.ts
+++ b/clients/chrome-extension/background/host-browser-dispatcher.ts
@@ -317,6 +317,40 @@ export function createHostBrowserDispatcher(
     const ownController = abort;
     inFlight.set(requestId, ownController);
     try {
+      // Handle synthetic Vellum.* methods that use chrome extension APIs
+      // directly instead of routing through chrome.debugger. These methods
+      // do not require a resolved CDP target, so they must be dispatched
+      // BEFORE `resolveTarget()` — otherwise `resolveTarget(undefined)`
+      // falls back to querying for the active tab, which throws when no
+      // focused window/tab exists (minimized, no active tab, etc.).
+      if (envelope.cdpMethod === 'Vellum.findTab') {
+        const urlPattern = (envelope.cdpParams as { urlPattern?: string } | undefined)?.urlPattern;
+        if (!urlPattern) {
+          await deps.postResult({
+            requestId,
+            content: JSON.stringify({ error: { code: -32602, message: 'urlPattern is required' } }),
+            isError: true,
+          });
+          return;
+        }
+        const tabs = await chrome.tabs.query({ url: urlPattern });
+        const tab = tabs[0];
+        if (!tab?.id) {
+          await deps.postResult({
+            requestId,
+            content: JSON.stringify({ error: { code: -32000, message: `No tab matched URL pattern: ${urlPattern}` } }),
+            isError: true,
+          });
+          return;
+        }
+        await deps.postResult({
+          requestId,
+          content: JSON.stringify({ result: { tabId: String(tab.id), url: tab.url, title: tab.title } }),
+          isError: false,
+        });
+        return;
+      }
+
       const target = await deps.resolveTarget(envelope.cdpSessionId);
       const key = targetKey(target);
       if (!attachedTargets.has(key)) {

--- a/clients/chrome-extension/background/host-browser-dispatcher.ts
+++ b/clients/chrome-extension/background/host-browser-dispatcher.ts
@@ -328,7 +328,7 @@ export function createHostBrowserDispatcher(
         if (!urlPattern) {
           await deps.postResult({
             requestId,
-            content: JSON.stringify({ error: { code: -32602, message: 'urlPattern is required' } }),
+            content: JSON.stringify({ code: -32602, message: 'urlPattern is required' }),
             isError: true,
           });
           return;
@@ -338,14 +338,14 @@ export function createHostBrowserDispatcher(
         if (!tab?.id) {
           await deps.postResult({
             requestId,
-            content: JSON.stringify({ error: { code: -32000, message: `No tab matched URL pattern: ${urlPattern}` } }),
+            content: JSON.stringify({ code: -32000, message: `No tab matched URL pattern: ${urlPattern}` }),
             isError: true,
           });
           return;
         }
         await deps.postResult({
           requestId,
-          content: JSON.stringify({ result: { tabId: String(tab.id), url: tab.url, title: tab.title } }),
+          content: JSON.stringify({ tabId: String(tab.id), url: tab.url, title: tab.title }),
           isError: false,
         });
         return;

--- a/clients/chrome-extension/background/worker.ts
+++ b/clients/chrome-extension/background/worker.ts
@@ -159,11 +159,19 @@ let shouldConnect = false;
 async function resolveHostBrowserTarget(
   cdpSessionId: string | undefined,
 ): Promise<{ tabId?: number; targetId?: string }> {
-  // When the daemon side has an explicit session id (e.g. a flat child
-  // session returned from a prior Target.attachToTarget) we route the
-  // command by targetId. Otherwise fall back to the most recently
-  // active tab in the focused window.
   if (cdpSessionId) {
+    // Chrome tab IDs are positive integers. CDP targetIds are opaque
+    // non-numeric strings (hex, UUIDs, etc.). Route canonical decimal
+    // digit strings as tabId for chrome.debugger.attach({ tabId });
+    // route everything else as targetId. The regex guard rejects hex
+    // literals ("0x10"), exponential notation ("1e3"), and whitespace-
+    // padded values that Number() would silently coerce to integers.
+    if (/^\d+$/.test(cdpSessionId)) {
+      const asNumber = Number(cdpSessionId);
+      if (asNumber > 0 && Number.isSafeInteger(asNumber)) {
+        return { tabId: asNumber };
+      }
+    }
     return { targetId: cdpSessionId };
   }
   const [activeTab] = await chrome.tabs.query({ active: true, lastFocusedWindow: true });


### PR DESCRIPTION
## Summary
Fix the browser relay's `new-tab` command returning a tabId that is immediately invalid for subsequent commands (`screenshot`, `evaluate`, etc.) due to a CDP session ID mismatch.

- **Core fix**: Stop forwarding `cdpSessionId` as a CDP flat-session `sessionId` in `chrome.debugger.sendCommand` — it's now used only for target resolution
- **find-tab fix**: Replace restricted `Target.getTargets` CDP call with synthetic `Vellum.findTab` method using `chrome.tabs.query()` directly
- **Numeric tab ID routing**: `resolveHostBrowserTarget` now detects numeric Chrome tab IDs vs opaque CDP targetIds
- **Active-tab fallback**: `evaluate` and `navigate` now fall back to the active tab when `--tab-id` is omitted (matching `screenshot`)

## Self-review result
GAPS FOUND — 1 gap fixed (double-wrapped Vellum.findTab result serialization)

## PRs merged into feature branch
- #24687: fix(browser-relay): stop forwarding cdpSessionId as CDP flat-session sessionId
- #24688: fix(browser-relay): add active-tab fallback for evaluate; make tab-id optional for navigate
- #24689: fix(browser-relay): use chrome.tabs.query for find-tab instead of restricted CDP Target.getTargets
- #24692: fix(browser-relay): resolve numeric tab IDs as chrome tabId, not CDP targetId

### Fix PRs
- #24698: fix: remove double-wrapping in Vellum.findTab result serialization

Part of plan: browser-relay-stale-tabid-fix.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24699" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
