### PR TITLE
test: add oauth-store unit tests for tokenExchangeBodyFormat

### DIFF
--- a/assistant/src/__tests__/oauth-store.test.ts
+++ b/assistant/src/__tests__/oauth-store.test.ts
@@ -592,6 +592,38 @@ describe("provider operations", () => {
       expect(row!.tokenEndpointAuthMethod).toBe("client_secret_post");
     });
 
+    test("defaults tokenExchangeBodyFormat to 'form' when omitted from seed", () => {
+      seedProviders([
+        {
+          provider: "no-body-format-provider",
+          authorizeUrl: "https://example.com/authorize",
+          tokenExchangeUrl: "https://example.com/token",
+          defaultScopes: [],
+          scopePolicy: {},
+          // Note: tokenExchangeBodyFormat intentionally omitted
+        },
+      ]);
+      const row = getProvider("no-body-format-provider");
+      expect(row).toBeDefined();
+      expect(row!.tokenExchangeBodyFormat).toBe("form");
+    });
+
+    test("persists explicit tokenExchangeBodyFormat value on seed", () => {
+      seedProviders([
+        {
+          provider: "json-body-format-provider",
+          authorizeUrl: "https://example.com/authorize",
+          tokenExchangeUrl: "https://example.com/token",
+          defaultScopes: [],
+          scopePolicy: {},
+          tokenExchangeBodyFormat: "json",
+        },
+      ]);
+      const row = getProvider("json-body-format-provider");
+      expect(row).toBeDefined();
+      expect(row!.tokenExchangeBodyFormat).toBe("json");
+    });
+
     test("migration 216 backfills NULL token_endpoint_auth_method to client_secret_post", () => {
       // Use raw SQLite to bypass Drizzle's NOT NULL enforcement and insert
       // a legacy-shaped row with NULL token_endpoint_auth_method.
@@ -811,6 +843,33 @@ describe("provider operations", () => {
         tokenEndpointAuthMethod: "client_secret_basic",
       });
       expect(row.tokenEndpointAuthMethod).toBe("client_secret_basic");
+    });
+
+    test("defaults tokenExchangeBodyFormat to 'form' when omitted", () => {
+      const row = registerProvider({
+        provider: "no-body-format-test",
+        authorizeUrl: "https://example.com/authorize",
+        tokenExchangeUrl: "https://example.com/token",
+        defaultScopes: [],
+        scopePolicy: {},
+        // Note: tokenExchangeBodyFormat intentionally omitted
+      });
+      expect(row.tokenExchangeBodyFormat).toBe("form");
+
+      const fetched = getProvider("no-body-format-test");
+      expect(fetched!.tokenExchangeBodyFormat).toBe("form");
+    });
+
+    test("persists explicit tokenExchangeBodyFormat 'json' when registering a provider", () => {
+      const row = registerProvider({
+        provider: "json-body-format-test",
+        authorizeUrl: "https://example.com/authorize",
+        tokenExchangeUrl: "https://example.com/token",
+        defaultScopes: [],
+        scopePolicy: {},
+        tokenExchangeBodyFormat: "json",
+      });
+      expect(row.tokenExchangeBodyFormat).toBe("json");
     });
 
     test("stores logoUrl when provided", () => {
@@ -1057,6 +1116,32 @@ describe("provider operations", () => {
 
       const row = getProvider("update-empty-test");
       expect(row!.tokenEndpointAuthMethod).toBe("client_secret_post");
+    });
+
+    test("coerces empty string tokenExchangeBodyFormat to 'form'", () => {
+      seedProviders([
+        {
+          provider: "update-empty-body-format-test",
+          authorizeUrl: "https://example.com/authorize",
+          tokenExchangeUrl: "https://example.com/token",
+          tokenExchangeBodyFormat: "json",
+          defaultScopes: [],
+          scopePolicy: {},
+        },
+      ]);
+
+      expect(
+        getProvider("update-empty-body-format-test")!.tokenExchangeBodyFormat,
+      ).toBe("json");
+
+      const updated = updateProvider("update-empty-body-format-test", {
+        tokenExchangeBodyFormat: "",
+      });
+      expect(updated).toBeDefined();
+      expect(updated!.tokenExchangeBodyFormat).toBe("form");
+
+      const row = getProvider("update-empty-body-format-test");
+      expect(row!.tokenExchangeBodyFormat).toBe("form");
     });
 
     test("sets logoUrl on an existing row where it was previously null", () => {


### PR DESCRIPTION
## Summary
Adds unit tests for tokenExchangeBodyFormat defaulting in oauth-store.

**Gap:** Missing oauth-store unit tests for tokenExchangeBodyFormat
**Fix:** Added tests for default, explicit value, and empty-string coercion
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24701" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
