### PR TITLE
fix: validate resolved refresh URL instead of raw token_url

### DIFF
--- a/credential-executor/src/materializers/local-token-refresh.ts
+++ b/credential-executor/src/materializers/local-token-refresh.ts
@@ -119,7 +119,10 @@ async function resolveRefreshConfig(
       return { error: `No OAuth provider found for "${conn.provider_key}"` };
     }
 
-    if (!provider.token_url || !app.client_id) {
+    // Resolve the effective token URL: prefer refresh_url, fall back to token_url
+    const tokenUrl = provider.refresh_url || provider.token_url;
+
+    if (!tokenUrl || !app.client_id) {
       return { error: `Missing OAuth2 refresh config for "${conn.provider_key}"` };
     }
 
@@ -132,7 +135,7 @@ async function resolveRefreshConfig(
     const bodyFormat = (provider.token_exchange_body_format as "form" | "json" | null) ?? "form";
 
     return {
-      tokenUrl: provider.refresh_url || provider.token_url,
+      tokenUrl,
       clientId: app.client_id,
       clientSecret,
       authMethod,


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for ces-refresh-url-parity.md.

**Gap:** Validation checks token_url instead of the resolved URL
**What was expected:** Validation should check the resolved URL after refresh_url fallback
**What was found:** Line 122 checked raw token_url before resolution
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24706" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
