### PR TITLE
fix(assistant): remove .max() cap from llmRequestLogRetentionMs Zod schema

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -177,33 +177,21 @@ describe("AssistantConfigSchema", () => {
     expect(result.success).toBe(false);
   });
 
-  test("accepts memory.cleanup.llmRequestLogRetentionMs at the 365-day boundary", () => {
-    const max = 365 * 24 * 60 * 60 * 1000;
+  test("accepts memory.cleanup.llmRequestLogRetentionMs above 365 days", () => {
+    // The daemon schema intentionally has no upper bound — existing configs
+    // may have large values set manually, and rejecting them at the Zod layer
+    // would cause validation failure on startup, silently falling back to
+    // 1-day retention and deleting logs the user intended to keep. The 365-day
+    // cap is enforced at the gateway API boundary (PATCH rejects, GET clamps).
+    const tenYears = 10 * 365 * 24 * 60 * 60 * 1000;
     const result = AssistantConfigSchema.safeParse({
-      memory: { cleanup: { llmRequestLogRetentionMs: max } },
+      memory: { cleanup: { llmRequestLogRetentionMs: tenYears } },
     });
     expect(result.success).toBe(true);
     if (result.success) {
-      expect(result.data.memory.cleanup.llmRequestLogRetentionMs).toBe(max);
-    }
-  });
-
-  test("rejects memory.cleanup.llmRequestLogRetentionMs above 365 days", () => {
-    // This must match the gateway's MAX_LLM_REQUEST_LOG_RETENTION_MS. Without
-    // the Zod .max(), a manually edited config.json with a large value would
-    // be silently accepted by the daemon and then truncated by the macOS
-    // picker on the next PATCH — a quiet data-loss bug.
-    const overMax = 365 * 24 * 60 * 60 * 1000 + 1;
-    const result = AssistantConfigSchema.safeParse({
-      memory: { cleanup: { llmRequestLogRetentionMs: overMax } },
-    });
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(
-        result.error.issues.some((i) =>
-          i.path.includes("llmRequestLogRetentionMs"),
-        ),
-      ).toBe(true);
+      expect(result.data.memory.cleanup.llmRequestLogRetentionMs).toBe(
+        tenYears,
+      );
     }
   });
 

--- a/assistant/src/config/schemas/memory-lifecycle.ts
+++ b/assistant/src/config/schemas/memory-lifecycle.ts
@@ -80,20 +80,9 @@ export const MemoryCleanupConfigSchema = z
       .nonnegative(
         "memory.cleanup.llmRequestLogRetentionMs must be non-negative",
       )
-      // Upper bound must match gateway MAX_LLM_REQUEST_LOG_RETENTION_MS in
-      // gateway/src/http/routes/privacy-config.ts. If a manually edited
-      // config.json sets a value larger than this, the gateway GET would
-      // return it and the macOS picker would snap it to its largest known
-      // option, and the next PATCH would silently truncate the value —
-      // causing quiet data loss. Enforcing the same cap here prevents the
-      // daemon from accepting out-of-range values in the first place.
-      .max(
-        365 * 24 * 60 * 60 * 1000,
-        "memory.cleanup.llmRequestLogRetentionMs must be <= 365 days in ms",
-      )
       .default(1 * 24 * 60 * 60 * 1000)
       .describe(
-        "Retention period for LLM request/response logs in milliseconds (0 disables pruning, max 365 days)",
+        "Retention period for LLM request/response logs in milliseconds (0 disables pruning)",
       ),
   })
   .describe("Automatic memory cleanup and garbage collection settings");


### PR DESCRIPTION
## Summary
- Remove `.max(365 * 24 * 60 * 60 * 1000)` from the `llmRequestLogRetentionMs` Zod field in `memory-lifecycle.ts`
- Existing configs with values > 365 days are no longer rejected at the schema layer, preventing silent fallback to the 1-day default
- The 365-day cap remains enforced at the gateway API boundary (PATCH rejects, GET/PATCH echo clamps)
- Updated test: replaced "rejects above 365 days" with "accepts above 365 days" to lock in the backwards-compatible behavior

Addresses P1 review feedback on the log-retention-setting feature branch.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24708" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
