### PR TITLE
Cherry-pick fixes into release/v0.6.3

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatMarkdownParser.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatMarkdownParser.swift
@@ -320,6 +320,7 @@ struct MarkdownTableView: View {
     @MainActor static func clearCellAttributedStringCache() {
         cellCache.removeAll()
         cellCacheLruCounter = 0
+        heightCache.removeAll()
     }
 
     @MainActor private static func cachedAttributedString(for text: String) -> AttributedString {
@@ -350,8 +351,50 @@ struct MarkdownTableView: View {
         return attributed
     }
 
+    // MARK: - Height Cache
+    //
+    // During scrolling, LazyVStack.measureEstimates calls sizeThatFits on
+    // each cell to estimate content height. For tables with N rows × M
+    // columns, this triggers a recursive explicitAlignment cascade through
+    // every nested VStack/HStack — O(N × M × depth) per measurement.
+    //
+    // By caching the rendered height after the first layout pass and
+    // applying it as a definite .frame(width:height:), subsequent
+    // sizeThatFits calls from measureEstimates return in O(1) because
+    // _FrameLayout with both dimensions set doesn't query children.
+    //
+    // The cache is content-addressed (keyed by headers + rows + width),
+    // so it works correctly across conversation switches — identical
+    // tables produce cache hits regardless of which conversation they
+    // appear in.
+    //
+    // References:
+    // - WWDC23: Demystify SwiftUI performance (https://developer.apple.com/videos/play/wwdc2023/10160/)
+    // - _FrameLayout vs _FlexFrameLayout alignment behavior (see AGENTS.md)
+
+    @MainActor private static var heightCache: [Int: CGFloat] = [:]
+
+    /// Content-based hash for height cache lookup. Includes maxWidth so
+    /// window resizing naturally invalidates stale entries.
+    private var contentHash: Int {
+        var hasher = Hasher()
+        hasher.combine(headers)
+        hasher.combine(rows)
+        hasher.combine(maxWidth)
+        return hasher.finalize()
+    }
+
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
+        let usableWidth = maxWidth.isFinite
+        let hash = usableWidth ? contentHash : 0
+        let cachedHeight = usableWidth ? Self.heightCache[hash] : nil
+
+        // Default alignment (.center) avoids explicitAlignment(.leading)
+        // queries during sizing. Rows are full-width HStacks with
+        // Spacer(minLength: 0), so content is already left-aligned
+        // internally — the VStack alignment is visually redundant but
+        // was previously triggering O(N) alignment queries per pass.
+        VStack(spacing: 0) {
             // Header row
             HStack(spacing: 0) {
                 ForEach(Array(headers.enumerated()), id: \.offset) { _, header in
@@ -390,8 +433,21 @@ struct MarkdownTableView: View {
             RoundedRectangle(cornerRadius: VRadius.md)
                 .stroke(VColor.borderBase, lineWidth: 0.5)
         )
+        .onGeometryChange(for: CGFloat.self) { proxy in
+            proxy.size.height
+        } action: { newHeight in
+            if usableWidth {
+                Self.heightCache[hash] = newHeight
+            }
+        }
         // ⚠️ No .frame(maxWidth:) in LazyVStack cells — see AGENTS.md.
-        .frame(width: maxWidth.isFinite ? maxWidth : nil, alignment: .leading)
+        // Both width AND height are set (after first render) so _FrameLayout
+        // returns the cached size in O(1) without querying children.
+        .frame(
+            width: maxWidth.isFinite ? maxWidth : nil,
+            height: cachedHeight,
+            alignment: .leading
+        )
     }
 
     private func inlineMarkdownCell(_ text: String) -> some View {

--- a/clients/macos/vellum-assistant/Features/MainWindow/DocumentEditorView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/DocumentEditorView.swift
@@ -247,8 +247,8 @@ private func generateEditorHTML(title: String, initialContent: String) -> String
 
     body {
       font-family: "DM Sans", -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", sans-serif;
-      background: var(--v-bg);
-      color: var(--v-text);
+      background: var(--v-surface-base);
+      color: var(--v-content-default);
       height: 100vh;
       display: flex;
       flex-direction: column;
@@ -263,17 +263,17 @@ private func generateEditorHTML(title: String, initialContent: String) -> String
       font-weight: 600;
       background: transparent;
       border: none;
-      color: var(--v-text);
+      color: var(--v-content-default);
       outline: none;
       flex: 1;
       min-width: 0;
     }
 
-    .title-input::placeholder { color: var(--v-text-muted); }
+    .title-input::placeholder { color: var(--v-content-tertiary); }
 
     .status {
       font-size: 12px;
-      color: var(--v-text-secondary);
+      color: var(--v-content-secondary);
       margin-left: 16px;
       white-space: nowrap;
     }
@@ -288,37 +288,37 @@ private func generateEditorHTML(title: String, initialContent: String) -> String
     }
 
     /* Override Toast UI Editor theme colors to match Vellum */
-    .toastui-editor-defaultUI { border: none !important; background: var(--v-bg) !important; }
-    .toastui-editor-defaultUI-toolbar { background: var(--v-surface) !important; border-bottom: 1px solid var(--v-surface-border) !important; }
-    .toastui-editor-toolbar { background: var(--v-surface) !important; border-top: 1px solid var(--v-surface-border) !important; border-bottom: 1px solid var(--v-surface-border) !important; }
-    .toastui-editor-toolbar-icons { color: var(--v-text) !important; background-color: transparent !important; border: none !important; }
-    .toastui-editor-toolbar-icons:hover { background-color: var(--v-surface-border) !important; }
-    .toastui-editor-toolbar-icons.active { background-color: var(--v-surface-border) !important; }
-    .toastui-editor-toolbar-divider { background: var(--v-surface-border) !important; }
-    .toastui-editor-toolbar-group { border-right-color: var(--v-surface-border) !important; }
-    .toastui-editor-popup { background: var(--v-surface) !important; border-color: var(--v-surface-border) !important; }
-    .toastui-editor-popup-body { background: var(--v-surface) !important; }
+    .toastui-editor-defaultUI { border: none !important; background: var(--v-surface-base) !important; }
+    .toastui-editor-defaultUI-toolbar { background: var(--v-surface-overlay) !important; border-bottom: 1px solid var(--v-border-base) !important; }
+    .toastui-editor-toolbar { background: var(--v-surface-overlay) !important; border-top: 1px solid var(--v-border-base) !important; border-bottom: 1px solid var(--v-border-base) !important; }
+    .toastui-editor-toolbar-icons { color: var(--v-content-default) !important; background-color: transparent !important; border: none !important; }
+    .toastui-editor-toolbar-icons:hover { background-color: var(--v-border-base) !important; }
+    .toastui-editor-toolbar-icons.active { background-color: var(--v-border-base) !important; }
+    .toastui-editor-toolbar-divider { background: var(--v-border-base) !important; }
+    .toastui-editor-toolbar-group { border-right-color: var(--v-border-base) !important; }
+    .toastui-editor-popup { background: var(--v-surface-overlay) !important; border-color: var(--v-border-base) !important; }
+    .toastui-editor-popup-body { background: var(--v-surface-overlay) !important; }
     .toastui-editor-md-container,
-    .toastui-editor-ww-container { background: var(--v-bg) !important; color: var(--v-text) !important; }
-    .toastui-editor-contents { color: var(--v-text) !important; font-family: "DM Sans", -apple-system, BlinkMacSystemFont, sans-serif !important; font-size: 14px !important; line-height: 1.7 !important; padding: 24px 32px !important; }
+    .toastui-editor-ww-container { background: var(--v-surface-base) !important; color: var(--v-content-default) !important; }
+    .toastui-editor-contents { color: var(--v-content-default) !important; font-family: "DM Sans", -apple-system, BlinkMacSystemFont, sans-serif !important; font-size: 14px !important; line-height: 1.7 !important; padding: 24px 32px !important; }
     .toastui-editor-ww-content { padding: 24px 32px !important; }
     .ProseMirror { padding: 24px 32px !important; }
     .toastui-editor-md-container .toastui-editor { padding: 24px 32px !important; }
-    .toastui-editor-contents h1 { font-family: "DM Sans", -apple-system, BlinkMacSystemFont, sans-serif !important; font-size: 28px !important; font-weight: 600 !important; color: var(--v-text) !important; border-bottom: none !important; margin-top: 32px !important; margin-bottom: 12px !important; }
-    .toastui-editor-contents h2 { font-family: "DM Sans", -apple-system, BlinkMacSystemFont, sans-serif !important; font-size: 22px !important; font-weight: 600 !important; color: var(--v-text) !important; border-bottom: none !important; margin-top: 28px !important; margin-bottom: 10px !important; }
-    .toastui-editor-contents h3 { font-family: "DM Sans", -apple-system, BlinkMacSystemFont, sans-serif !important; font-size: 18px !important; font-weight: 600 !important; color: var(--v-text) !important; border-bottom: none !important; margin-top: 24px !important; margin-bottom: 8px !important; }
+    .toastui-editor-contents h1 { font-family: "DM Sans", -apple-system, BlinkMacSystemFont, sans-serif !important; font-size: 28px !important; font-weight: 600 !important; color: var(--v-content-default) !important; border-bottom: none !important; margin-top: 32px !important; margin-bottom: 12px !important; }
+    .toastui-editor-contents h2 { font-family: "DM Sans", -apple-system, BlinkMacSystemFont, sans-serif !important; font-size: 22px !important; font-weight: 600 !important; color: var(--v-content-default) !important; border-bottom: none !important; margin-top: 28px !important; margin-bottom: 10px !important; }
+    .toastui-editor-contents h3 { font-family: "DM Sans", -apple-system, BlinkMacSystemFont, sans-serif !important; font-size: 18px !important; font-weight: 600 !important; color: var(--v-content-default) !important; border-bottom: none !important; margin-top: 24px !important; margin-bottom: 8px !important; }
     .toastui-editor-contents p { margin-bottom: 12px !important; }
-    .toastui-editor-contents pre { background: var(--v-surface) !important; border-radius: 8px !important; padding: 12px 16px !important; }
-    .toastui-editor-contents code { background: var(--v-surface) !important; color: var(--v-text) !important; font-family: "DMMono-Regular", "SF Mono", monospace !important; border-radius: 4px !important; padding: 2px 5px !important; font-size: 13px !important; }
-    .toastui-editor-contents blockquote { border-left-color: var(--v-accent) !important; color: var(--v-text-secondary) !important; }
+    .toastui-editor-contents pre { background: var(--v-surface-overlay) !important; border-radius: 8px !important; padding: 12px 16px !important; }
+    .toastui-editor-contents code { background: var(--v-surface-overlay) !important; color: var(--v-content-default) !important; font-family: "DMMono-Regular", "SF Mono", monospace !important; border-radius: 4px !important; padding: 2px 5px !important; font-size: 13px !important; }
+    .toastui-editor-contents blockquote { border-left-color: var(--v-primary-base) !important; color: var(--v-content-secondary) !important; }
     .toastui-editor-contents table td,
-    .toastui-editor-contents table th { border-color: var(--v-surface-border) !important; }
+    .toastui-editor-contents table th { border-color: var(--v-border-base) !important; }
     /* Hide mode switch (Markdown / WYSIWYG toggle) */
     .toastui-editor-mode-switch { display: none !important; }
     /* Scrollbar styling */
     .toastui-editor-contents::-webkit-scrollbar { width: 6px; }
     .toastui-editor-contents::-webkit-scrollbar-track { background: transparent; }
-    .toastui-editor-contents::-webkit-scrollbar-thumb { background: var(--v-surface-border); border-radius: 3px; }
+    .toastui-editor-contents::-webkit-scrollbar-thumb { background: var(--v-border-base); border-radius: 3px; }
   </style>
 </head>
 <body>
@@ -412,7 +412,7 @@ private func generateEditorHTML(title: String, initialContent: String) -> String
     } catch (e) {
       var msg = String(e && e.message ? e.message : e).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
       document.getElementById('editor').innerHTML =
-        '<div style="padding: 32px; color: var(--v-text-secondary); font-size: 14px;">' +
+        '<div style="padding: 32px; color: var(--v-content-secondary); font-size: 14px;">' +
         '<strong>Editor failed to load</strong><br><br>' +
         'The document editor could not be initialized. This may be due to a network issue preventing ' +
         'external assets from loading.<br><br>' +


### PR DESCRIPTION
## Summary
- Cherry-pick `7ed1d77` — fix(chrome-ext): resolve extension allowlist in compiled Bun builds (#24680)
- Cherry-pick `5b510ee` — perf(macOS): cache MarkdownTableView height to eliminate O(N×M) sizing hang during scroll (#24705)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24709" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
