### PR TITLE
fix: correct llmRequestLogRetentionMs semantics — null=forever, 0=prune immediately

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -214,6 +214,26 @@ describe("AssistantConfigSchema", () => {
     expect(result.success).toBe(false);
   });
 
+  test("accepts null memory.cleanup.llmRequestLogRetentionMs (keep forever)", () => {
+    const result = AssistantConfigSchema.safeParse({
+      memory: { cleanup: { llmRequestLogRetentionMs: null } },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.memory.cleanup.llmRequestLogRetentionMs).toBeNull();
+    }
+  });
+
+  test("accepts memory.cleanup.llmRequestLogRetentionMs: 0 (prune immediately)", () => {
+    const result = AssistantConfigSchema.safeParse({
+      memory: { cleanup: { llmRequestLogRetentionMs: 0 } },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.memory.cleanup.llmRequestLogRetentionMs).toBe(0);
+    }
+  });
+
   test("rejects invalid provider", () => {
     const result = AssistantConfigSchema.safeParse({
       services: { inference: { provider: "invalid" } },

--- a/assistant/src/__tests__/config-watcher-cleanup-throttle.test.ts
+++ b/assistant/src/__tests__/config-watcher-cleanup-throttle.test.ts
@@ -84,6 +84,25 @@ describe("cleanupSettingsChanged", () => {
       }),
     ).toBe(false);
   });
+
+  test("returns true when llmRequestLogRetentionMs changes from number to null", () => {
+    expect(
+      cleanupSettingsChanged(base, {
+        ...base,
+        llmRequestLogRetentionMs: null,
+      }),
+    ).toBe(true);
+  });
+
+  test("returns true when llmRequestLogRetentionMs changes from null to number", () => {
+    const nullBase = { ...base, llmRequestLogRetentionMs: null };
+    expect(
+      cleanupSettingsChanged(nullBase, {
+        ...nullBase,
+        llmRequestLogRetentionMs: 86_400_000,
+      }),
+    ).toBe(true);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -122,7 +141,7 @@ interface TestConfig {
       enqueueIntervalMs: number;
       supersededItemRetentionMs: number;
       conversationRetentionDays: number;
-      llmRequestLogRetentionMs: number;
+      llmRequestLogRetentionMs: number | null;
     };
   };
 }
@@ -269,6 +288,18 @@ describe("ConfigWatcher.refreshConfigFromSources cleanup throttle reset", () => 
     primeConfigCache();
 
     diskConfig = makeConfig({ conversationRetentionDays: 30 });
+
+    const changed = await watcher.refreshConfigFromSources();
+    expect(changed).toBe(true);
+    expect(resetCleanupScheduleThrottleCalls).toBe(1);
+  });
+
+  test("resets throttle when llmRequestLogRetentionMs changes from number to null", async () => {
+    const watcher = new ConfigWatcher();
+    watcher.initFingerprint(diskConfig as never);
+    primeConfigCache();
+
+    diskConfig = makeConfig({ llmRequestLogRetentionMs: null });
 
     const changed = await watcher.refreshConfigFromSources();
     expect(changed).toBe(true);

--- a/assistant/src/config/schemas/memory-lifecycle.ts
+++ b/assistant/src/config/schemas/memory-lifecycle.ts
@@ -91,9 +91,10 @@ export const MemoryCleanupConfigSchema = z
         365 * 24 * 60 * 60 * 1000,
         "memory.cleanup.llmRequestLogRetentionMs must be <= 365 days in ms",
       )
+      .nullable()
       .default(1 * 24 * 60 * 60 * 1000)
       .describe(
-        "Retention period for LLM request/response logs in milliseconds (0 disables pruning, max 365 days)",
+        "Retention period for LLM request/response logs in milliseconds (null keeps forever, 0 prunes immediately)",
       ),
   })
   .describe("Automatic memory cleanup and garbage collection settings");

--- a/assistant/src/memory/job-handlers/cleanup.ts
+++ b/assistant/src/memory/job-handlers/cleanup.ts
@@ -17,15 +17,18 @@ export function pruneOldLlmRequestLogsJob(
   job: MemoryJob,
   config: AssistantConfig,
 ): void {
+  const rawRetention = job.payload.retentionMs;
   const retentionMs =
-    typeof job.payload.retentionMs === "number" &&
-    Number.isFinite(job.payload.retentionMs) &&
-    job.payload.retentionMs >= 0
-      ? job.payload.retentionMs
-      : config.memory.cleanup.llmRequestLogRetentionMs;
+    rawRetention === null
+      ? null
+      : typeof rawRetention === "number" &&
+          Number.isFinite(rawRetention) &&
+          rawRetention >= 0
+        ? rawRetention
+        : config.memory.cleanup.llmRequestLogRetentionMs;
 
-  // 0 means disabled
-  if (retentionMs === 0) return;
+  // null means "keep forever" — skip pruning entirely
+  if (retentionMs === null || retentionMs === undefined) return;
 
   const cutoffMs = Date.now() - retentionMs;
 

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -480,7 +480,7 @@ export function maybeEnqueueScheduledCleanupJobs(
       ? enqueuePruneOldConversationsJob(cleanup.conversationRetentionDays)
       : null;
   const pruneLlmRequestLogsJobId =
-    cleanup.llmRequestLogRetentionMs > 0
+    cleanup.llmRequestLogRetentionMs !== null
       ? enqueuePruneOldLlmRequestLogsJob(cleanup.llmRequestLogRetentionMs)
       : null;
   markScheduledCleanupEnqueued(nowMs);

--- a/assistant/src/workspace/migrations/031-llm-log-retention-zero-to-null.ts
+++ b/assistant/src/workspace/migrations/031-llm-log-retention-zero-to-null.ts
@@ -1,0 +1,73 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { WorkspaceMigration } from "./types.js";
+
+/**
+ * Convert `memory.cleanup.llmRequestLogRetentionMs: 0` to `null`.
+ *
+ * Under the old semantics `0` meant "keep forever" (never prune). The new
+ * semantics use `null` for "keep forever" and `0` for "prune immediately".
+ * Without this migration, users who previously set the retention to "keep
+ * forever" would be silently switched to "prune everything on next cleanup
+ * run" after upgrading.
+ */
+export const llmLogRetentionZeroToNullMigration: WorkspaceMigration = {
+  id: "031-llm-log-retention-zero-to-null",
+  description:
+    "Convert llmRequestLogRetentionMs: 0 (old 'keep forever') to null (new 'keep forever')",
+  run(workspaceDir: string): void {
+    const configPath = join(workspaceDir, "config.json");
+    if (!existsSync(configPath)) return;
+
+    let config: Record<string, unknown>;
+    try {
+      const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+      if (!raw || typeof raw !== "object" || Array.isArray(raw)) return;
+      config = raw as Record<string, unknown>;
+    } catch {
+      return; // Malformed config — skip
+    }
+
+    const memory = config.memory;
+    if (!memory || typeof memory !== "object" || Array.isArray(memory)) return;
+    const memoryObj = memory as Record<string, unknown>;
+
+    const cleanup = memoryObj.cleanup;
+    if (!cleanup || typeof cleanup !== "object" || Array.isArray(cleanup))
+      return;
+    const cleanupObj = cleanup as Record<string, unknown>;
+
+    if (cleanupObj.llmRequestLogRetentionMs !== 0) return;
+
+    cleanupObj.llmRequestLogRetentionMs = null;
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+  },
+  down(workspaceDir: string): void {
+    const configPath = join(workspaceDir, "config.json");
+    if (!existsSync(configPath)) return;
+
+    let config: Record<string, unknown>;
+    try {
+      const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+      if (!raw || typeof raw !== "object" || Array.isArray(raw)) return;
+      config = raw as Record<string, unknown>;
+    } catch {
+      return;
+    }
+
+    const memory = config.memory;
+    if (!memory || typeof memory !== "object" || Array.isArray(memory)) return;
+    const memoryObj = memory as Record<string, unknown>;
+
+    const cleanup = memoryObj.cleanup;
+    if (!cleanup || typeof cleanup !== "object" || Array.isArray(cleanup))
+      return;
+    const cleanupObj = cleanup as Record<string, unknown>;
+
+    if (cleanupObj.llmRequestLogRetentionMs !== null) return;
+
+    cleanupObj.llmRequestLogRetentionMs = 0;
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+  },
+};

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -27,6 +27,7 @@ import { removeOrphanedOptimizedImagesCacheMigration } from "./027-remove-orphan
 import { recoverConversationsFromDiskViewMigration } from "./028-recover-conversations-from-disk-view.js";
 import { seedPkbMigration } from "./029-seed-pkb.js";
 import { seedPkbAutoinjectMigration } from "./030-seed-pkb-autoinject.js";
+import { llmLogRetentionZeroToNullMigration } from "./031-llm-log-retention-zero-to-null.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -65,4 +66,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   recoverConversationsFromDiskViewMigration,
   seedPkbMigration,
   seedPkbAutoinjectMigration,
+  llmLogRetentionZeroToNullMigration,
 ];

--- a/clients/macos/vellum-assistant/Features/Settings/LlmLogRetentionOption.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/LlmLogRetentionOption.swift
@@ -1,40 +1,64 @@
 import Foundation
 
 /// User-selectable LLM request log retention periods shown in the
-/// Permissions & Privacy settings picker. Mirrors the server-side default
-/// of 1 day and allows users to disable pruning entirely.
-enum LlmLogRetentionOption: Int64, CaseIterable, Identifiable {
-    case oneDay = 86_400_000          // 1 * 24 * 60 * 60 * 1000
-    case sevenDays = 604_800_000      // 7 * 24 * 60 * 60 * 1000
-    case thirtyDays = 2_592_000_000   // 30 * 24 * 60 * 60 * 1000
-    case ninetyDays = 7_776_000_000   // 90 * 24 * 60 * 60 * 1000
-    case never = 0
+/// Permissions & Privacy settings picker. `null` (nil) means "keep forever",
+/// `0` means "don't retain" (prune immediately), and positive values retain
+/// for the specified number of milliseconds.
+enum LlmLogRetentionOption: CaseIterable, Identifiable, Hashable {
+    case dontRetain
+    case oneDay
+    case sevenDays
+    case thirtyDays
+    case ninetyDays
+    case keepForever
 
-    var id: Int64 { rawValue }
+    var id: String {
+        switch self {
+        case .dontRetain: return "dontRetain"
+        case .oneDay: return "oneDay"
+        case .sevenDays: return "sevenDays"
+        case .thirtyDays: return "thirtyDays"
+        case .ninetyDays: return "ninetyDays"
+        case .keepForever: return "keepForever"
+        }
+    }
+
+    var retentionMs: Int64? {
+        switch self {
+        case .dontRetain: return 0
+        case .oneDay: return 86_400_000
+        case .sevenDays: return 604_800_000
+        case .thirtyDays: return 2_592_000_000
+        case .ninetyDays: return 7_776_000_000
+        case .keepForever: return nil
+        }
+    }
 
     var label: String {
         switch self {
+        case .dontRetain: return "Don't retain"
         case .oneDay: return "1 day"
         case .sevenDays: return "7 days"
         case .thirtyDays: return "30 days"
         case .ninetyDays: return "90 days"
-        case .never: return "Never (keep forever)"
+        case .keepForever: return "Keep forever"
         }
     }
 
     /// Returns the closest option for an arbitrary millisecond value read from the daemon.
-    /// Unknown / out-of-band values snap to the nearest known period; `0` is special-cased to `.never`.
-    /// Ties (e.g. a value exactly halfway between two options) snap to the *larger* retention to avoid
+    /// `nil` maps to `.keepForever`, `0` maps to `.dontRetain`. Unknown / out-of-band positive
+    /// values snap to the nearest known period; ties snap to the *larger* retention to avoid
     /// silently shortening a user's retention when the UI reconciles an out-of-band value.
-    static func closest(toMs ms: Int64) -> LlmLogRetentionOption {
-        if ms == 0 { return .never }
-        let known = allCases.filter { $0 != .never }
+    static func closest(toMs ms: Int64?) -> LlmLogRetentionOption {
+        guard let ms = ms else { return .keepForever }
+        if ms == 0 { return .dontRetain }
+        let known: [LlmLogRetentionOption] = [.oneDay, .sevenDays, .thirtyDays, .ninetyDays]
         return known.min(by: { lhs, rhs in
-            let lhsDist = abs(lhs.rawValue - ms)
-            let rhsDist = abs(rhs.rawValue - ms)
+            let lhsDist = abs(lhs.retentionMs! - ms)
+            let rhsDist = abs(rhs.retentionMs! - ms)
             if lhsDist != rhsDist { return lhsDist < rhsDist }
-            // Tie → prefer the larger (longer) retention.
-            return lhs.rawValue > rhs.rawValue
+            // Tie -> prefer the larger (longer) retention.
+            return lhs.retentionMs! > rhs.retentionMs!
         }) ?? .oneDay
     }
 }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift
@@ -151,10 +151,10 @@ struct SettingsPrivacyTab: View {
     /// just-made selection. The `Binding(get:set:)` on the picker handles the
     /// inverse race (programmatic assignments do not trigger `syncRetention`).
     private func loadPrivacyConfig() async {
-        // Seed from UserDefaults for instant render.
-        if let cachedMs = readCachedRetentionMs() {
-            retentionSelection = LlmLogRetentionOption.closest(toMs: cachedMs)
-        }
+        // Seed from UserDefaults for instant render. When UserDefaults has
+        // no entry (key removed for .keepForever), readCachedRetentionMs()
+        // returns nil, mapping through closest(toMs: nil) -> .keepForever.
+        retentionSelection = LlmLogRetentionOption.closest(toMs: readCachedRetentionMs())
 
         retentionLoadTask?.cancel()
         let task = Task { @MainActor in
@@ -169,10 +169,11 @@ struct SettingsPrivacyTab: View {
                 retentionSelection = LlmLogRetentionOption.closest(
                     toMs: config.llmRequestLogRetentionMs
                 )
-                UserDefaults.standard.set(
-                    config.llmRequestLogRetentionMs,
-                    forKey: llmRequestLogRetentionMsDefaultsKey
-                )
+                if let ms = config.llmRequestLogRetentionMs {
+                    UserDefaults.standard.set(ms, forKey: llmRequestLogRetentionMsDefaultsKey)
+                } else {
+                    UserDefaults.standard.removeObject(forKey: llmRequestLogRetentionMsDefaultsKey)
+                }
             } catch {
                 privacyTabLog.error(
                     "getPrivacyConfig failed: \(error.localizedDescription, privacy: .public)"
@@ -193,17 +194,18 @@ struct SettingsPrivacyTab: View {
     /// the user's attempted value forever while the daemon still holds the
     /// old value, and closing/reopening the Settings tab wouldn't recover.
     private func syncRetention(_ option: LlmLogRetentionOption) {
-        UserDefaults.standard.set(
-            option.rawValue,
-            forKey: llmRequestLogRetentionMsDefaultsKey
-        )
+        if let ms = option.retentionMs {
+            UserDefaults.standard.set(ms, forKey: llmRequestLogRetentionMsDefaultsKey)
+        } else {
+            UserDefaults.standard.removeObject(forKey: llmRequestLogRetentionMsDefaultsKey)
+        }
         retentionSyncTask?.cancel()
         retentionSyncTask = Task {
             do {
                 try await featureFlagClient.setPrivacyConfig(
                     collectUsageData: nil,
                     sendDiagnostics: nil,
-                    llmRequestLogRetentionMs: option.rawValue
+                    llmRequestLogRetentionMs: .some(option.retentionMs)
                 )
             } catch {
                 // If this task was cancelled (e.g. by a newer user-initiated

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift
@@ -151,10 +151,13 @@ struct SettingsPrivacyTab: View {
     /// just-made selection. The `Binding(get:set:)` on the picker handles the
     /// inverse race (programmatic assignments do not trigger `syncRetention`).
     private func loadPrivacyConfig() async {
-        // Seed from UserDefaults for instant render. When UserDefaults has
-        // no entry (key removed for .keepForever), readCachedRetentionMs()
-        // returns nil, mapping through closest(toMs: nil) -> .keepForever.
-        retentionSelection = LlmLogRetentionOption.closest(toMs: readCachedRetentionMs())
+        // Seed from UserDefaults for instant render. Only override the
+        // @State default (.oneDay, matching the daemon schema default)
+        // when a cache entry actually exists — a missing key means "no
+        // prior user choice" (fresh install), not "user chose keep forever."
+        if UserDefaults.standard.object(forKey: llmRequestLogRetentionMsDefaultsKey) != nil {
+            retentionSelection = LlmLogRetentionOption.closest(toMs: readCachedRetentionMs())
+        }
 
         retentionLoadTask?.cancel()
         let task = Task { @MainActor in

--- a/clients/macos/vellum-assistantTests/FeatureFlagClientPrivacyTests.swift
+++ b/clients/macos/vellum-assistantTests/FeatureFlagClientPrivacyTests.swift
@@ -28,9 +28,9 @@ final class FeatureFlagClientPrivacyTests: XCTestCase {
         XCTAssertEqual(config.llmRequestLogRetentionMs, 86_400_000)
     }
 
-    /// A retention value of 0 (meaning "never retain") must round-trip through
-    /// the decoder unchanged. This guards against accidental truthy-coercion
-    /// regressions if someone swaps `Int64` for a Boolean-ish type.
+    /// A retention value of 0 (meaning "prune immediately") must round-trip
+    /// through the decoder unchanged. This guards against accidental
+    /// truthy-coercion regressions if someone swaps `Int64?` for a Boolean-ish type.
     func testPrivacyConfigDecodesZeroRetention() throws {
         // GIVEN a payload with llmRequestLogRetentionMs = 0
         let json = """
@@ -48,6 +48,26 @@ final class FeatureFlagClientPrivacyTests: XCTestCase {
         XCTAssertFalse(config.collectUsageData)
         XCTAssertTrue(config.sendDiagnostics)
         XCTAssertEqual(config.llmRequestLogRetentionMs, 0)
+    }
+
+    /// A retention value of null (meaning "keep forever") must decode to nil.
+    func testPrivacyConfigDecodesNullRetention() throws {
+        // GIVEN a payload with llmRequestLogRetentionMs = null
+        let json = """
+        {
+            "collectUsageData": true,
+            "sendDiagnostics": true,
+            "llmRequestLogRetentionMs": null
+        }
+        """.data(using: .utf8)!
+
+        // WHEN we decode it
+        let config = try JSONDecoder().decode(PrivacyConfig.self, from: json)
+
+        // THEN retention is nil (keep forever)
+        XCTAssertTrue(config.collectUsageData)
+        XCTAssertTrue(config.sendDiagnostics)
+        XCTAssertNil(config.llmRequestLogRetentionMs)
     }
 
     // MARK: - Equatable

--- a/clients/macos/vellum-assistantTests/LlmLogRetentionOptionTests.swift
+++ b/clients/macos/vellum-assistantTests/LlmLogRetentionOptionTests.swift
@@ -2,10 +2,15 @@ import XCTest
 @testable import VellumAssistantLib
 
 /// Unit tests for `LlmLogRetentionOption` — covers `closest(toMs:)` snapping
-/// logic, label/case invariants, and the `.never` zero-value special case.
+/// logic, label/case invariants, the `.keepForever` nil-value special case,
+/// and the `.dontRetain` zero-value special case.
 final class LlmLogRetentionOptionTests: XCTestCase {
 
-    // MARK: - Exact raw-value matches
+    // MARK: - Exact value matches
+
+    func testClosestReturnsDontRetainForZero() {
+        XCTAssertEqual(LlmLogRetentionOption.closest(toMs: 0), .dontRetain)
+    }
 
     func testClosestReturnsOneDayForExactOneDayMs() {
         XCTAssertEqual(LlmLogRetentionOption.closest(toMs: 86_400_000), .oneDay)
@@ -23,10 +28,20 @@ final class LlmLogRetentionOptionTests: XCTestCase {
         XCTAssertEqual(LlmLogRetentionOption.closest(toMs: 7_776_000_000), .ninetyDays)
     }
 
-    // MARK: - Zero / never
+    // MARK: - Nil / keep forever
 
-    func testClosestReturnsNeverForZero() {
-        XCTAssertEqual(LlmLogRetentionOption.closest(toMs: 0), .never)
+    func testClosestReturnsKeepForeverForNil() {
+        XCTAssertEqual(LlmLogRetentionOption.closest(toMs: nil), .keepForever)
+    }
+
+    // MARK: - retentionMs values
+
+    func testDontRetainRetentionMsIsZero() {
+        XCTAssertEqual(LlmLogRetentionOption.dontRetain.retentionMs, 0)
+    }
+
+    func testKeepForeverRetentionMsIsNil() {
+        XCTAssertNil(LlmLogRetentionOption.keepForever.retentionMs)
     }
 
     // MARK: - Off-grid snapping
@@ -40,29 +55,29 @@ final class LlmLogRetentionOptionTests: XCTestCase {
     // MARK: - Tie-breaking (snap up to larger retention)
 
     /// 4 days (345_600_000 ms) is exactly halfway between 1 day and 7 days.
-    /// Tie-breaking rule: snap up to the larger retention → `.sevenDays`.
+    /// Tie-breaking rule: snap up to the larger retention -> `.sevenDays`.
     func testClosestSnapsExactMidpointBetweenOneAndSevenDaysToSevenDays() {
         XCTAssertEqual(LlmLogRetentionOption.closest(toMs: 345_600_000), .sevenDays)
     }
 
     /// Exact midpoint between 7 days (604_800_000) and 30 days (2_592_000_000):
-    /// (604_800_000 + 2_592_000_000) / 2 = 1_598_400_000 ms (≈18.5 days).
-    /// Tie-breaking rule: snap up to the larger retention → `.thirtyDays`.
+    /// (604_800_000 + 2_592_000_000) / 2 = 1_598_400_000 ms.
+    /// Tie-breaking rule: snap up to the larger retention -> `.thirtyDays`.
     func testClosestSnapsExactMidpointBetweenSevenAndThirtyDaysToThirtyDays() {
         XCTAssertEqual(LlmLogRetentionOption.closest(toMs: 1_598_400_000), .thirtyDays)
     }
 
     /// Exact midpoint between 30 days (2_592_000_000) and 90 days (7_776_000_000):
     /// (2_592_000_000 + 7_776_000_000) / 2 = 5_184_000_000 ms (60 days).
-    /// Tie-breaking rule: snap up to the larger retention → `.ninetyDays`.
+    /// Tie-breaking rule: snap up to the larger retention -> `.ninetyDays`.
     func testClosestSnapsExactMidpointBetweenThirtyAndNinetyDaysToNinetyDays() {
         XCTAssertEqual(LlmLogRetentionOption.closest(toMs: 5_184_000_000), .ninetyDays)
     }
 
     // MARK: - Invariants
 
-    func testAllCasesHasFiveEntries() {
-        XCTAssertEqual(LlmLogRetentionOption.allCases.count, 5)
+    func testAllCasesHasSixEntries() {
+        XCTAssertEqual(LlmLogRetentionOption.allCases.count, 6)
     }
 
     func testAllCasesLabelsAreNonEmpty() {

--- a/clients/shared/Network/FeatureFlagClient.swift
+++ b/clients/shared/Network/FeatureFlagClient.swift
@@ -11,7 +11,7 @@ public protocol FeatureFlagClientProtocol {
     func setPrivacyConfig(
         collectUsageData: Bool?,
         sendDiagnostics: Bool?,
-        llmRequestLogRetentionMs: Int64?
+        llmRequestLogRetentionMs: Int64??
     ) async throws
 }
 
@@ -21,16 +21,16 @@ public protocol FeatureFlagClientProtocol {
 ///
 /// Mirrors the `{assistantId}/config/privacy` response shape and carries the
 /// three user-facing privacy toggles: usage data, diagnostics, and LLM request
-/// log retention (in milliseconds).
+/// log retention (in milliseconds). `null` means "keep forever".
 public struct PrivacyConfig: Decodable, Sendable, Equatable {
     public let collectUsageData: Bool
     public let sendDiagnostics: Bool
-    public let llmRequestLogRetentionMs: Int64
+    public let llmRequestLogRetentionMs: Int64?
 
     public init(
         collectUsageData: Bool,
         sendDiagnostics: Bool,
-        llmRequestLogRetentionMs: Int64
+        llmRequestLogRetentionMs: Int64?
     ) {
         self.collectUsageData = collectUsageData
         self.sendDiagnostics = sendDiagnostics
@@ -162,13 +162,17 @@ public struct FeatureFlagClient: FeatureFlagClientProtocol {
     public func setPrivacyConfig(
         collectUsageData: Bool? = nil,
         sendDiagnostics: Bool? = nil,
-        llmRequestLogRetentionMs: Int64? = nil
+        llmRequestLogRetentionMs: Int64?? = nil
     ) async throws {
         var body: [String: Any] = [:]
         if let collectUsageData { body["collectUsageData"] = collectUsageData }
         if let sendDiagnostics { body["sendDiagnostics"] = sendDiagnostics }
-        if let llmRequestLogRetentionMs {
-            body["llmRequestLogRetentionMs"] = llmRequestLogRetentionMs
+        if let retentionOuter = llmRequestLogRetentionMs {
+            if let value = retentionOuter {
+                body["llmRequestLogRetentionMs"] = value
+            } else {
+                body["llmRequestLogRetentionMs"] = NSNull()
+            }
         }
 
         let response = try await GatewayHTTPClient.patch(

--- a/gateway/src/__tests__/privacy-config-route.test.ts
+++ b/gateway/src/__tests__/privacy-config-route.test.ts
@@ -142,7 +142,7 @@ describe("GET /v1/config/privacy handler", () => {
     expect(body.llmRequestLogRetentionMs).toBe(DEFAULT_RETENTION_MS);
   });
 
-  test("returns 0 verbatim when llmRequestLogRetentionMs is 0 (never prune)", async () => {
+  test("returns 0 verbatim when llmRequestLogRetentionMs is 0 (prune immediately)", async () => {
     writeFileSync(
       configPath,
       JSON.stringify({
@@ -303,10 +303,33 @@ describe("GET /v1/config/privacy handler", () => {
     expect(body.sendDiagnostics).toBe(false);
     expect(body.llmRequestLogRetentionMs).toBe(DEFAULT_RETENTION_MS);
   });
+  test("returns null when config has llmRequestLogRetentionMs: null (keep forever)", async () => {
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        memory: {
+          cleanup: {
+            llmRequestLogRetentionMs: null,
+          },
+        },
+      }),
+    );
+
+    const handler = createPrivacyConfigGetHandler();
+    const res = await handler(
+      new Request("http://gateway.test/v1/config/privacy"),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.llmRequestLogRetentionMs).toBeNull();
+    expect(body.collectUsageData).toBe(true);
+    expect(body.sendDiagnostics).toBe(true);
+  });
 });
 
 describe("PATCH /v1/config/privacy handler — llmRequestLogRetentionMs", () => {
-  test("persists llmRequestLogRetentionMs: 0 (never prune) to memory.cleanup.llmRequestLogRetentionMs", async () => {
+  test("persists llmRequestLogRetentionMs: 0 (prune immediately) to memory.cleanup.llmRequestLogRetentionMs", async () => {
     const handler = createPrivacyConfigPatchHandler();
     const res = await handler(makePatch({ llmRequestLogRetentionMs: 0 }));
 
@@ -486,18 +509,25 @@ describe("PATCH /v1/config/privacy handler — llmRequestLogRetentionMs", () => 
     expect(body.error).toContain("llmRequestLogRetentionMs");
   });
 
-  test("rejects NaN and Infinity with 400", async () => {
+  test("NaN and Infinity serialize to null in JSON, which is now accepted as 'keep forever'", async () => {
+    // JSON.stringify(NaN) = "null" and JSON.stringify(Infinity) = "null",
+    // so these values are received as null by the handler. Under the new
+    // semantics null is a valid value meaning "keep forever".
     const handler = createPrivacyConfigPatchHandler();
 
     const res1 = await handler(
       makePatch({ llmRequestLogRetentionMs: Number.NaN }),
     );
-    expect(res1.status).toBe(400);
+    expect(res1.status).toBe(200);
+    const body1 = await res1.json();
+    expect(body1.llmRequestLogRetentionMs).toBeNull();
 
     const res2 = await handler(
       makePatch({ llmRequestLogRetentionMs: Number.POSITIVE_INFINITY }),
     );
-    expect(res2.status).toBe(400);
+    expect(res2.status).toBe(200);
+    const body2 = await res2.json();
+    expect(body2.llmRequestLogRetentionMs).toBeNull();
   });
 
   test("when only llmRequestLogRetentionMs is provided, existing collectUsageData/sendDiagnostics are unchanged", async () => {
@@ -517,6 +547,36 @@ describe("PATCH /v1/config/privacy handler — llmRequestLogRetentionMs", () => 
     const cleanup = (config.memory as Record<string, unknown>)
       .cleanup as Record<string, unknown>;
     expect(cleanup.llmRequestLogRetentionMs).toBe(60_000);
+  });
+  test("persists llmRequestLogRetentionMs: null (keep forever) and returns null in response", async () => {
+    const handler = createPrivacyConfigPatchHandler();
+    const res = await handler(makePatch({ llmRequestLogRetentionMs: null }));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.llmRequestLogRetentionMs).toBeNull();
+
+    expect(existsSync(configPath)).toBe(true);
+    const config = readConfig();
+    const cleanup = (config.memory as Record<string, unknown>)
+      .cleanup as Record<string, unknown>;
+    expect(cleanup.llmRequestLogRetentionMs).toBeNull();
+  });
+
+  test("PATCH null then GET returns null", async () => {
+    const patchHandler = createPrivacyConfigPatchHandler();
+    const patchRes = await patchHandler(
+      makePatch({ llmRequestLogRetentionMs: null }),
+    );
+    expect(patchRes.status).toBe(200);
+
+    const getHandler = createPrivacyConfigGetHandler();
+    const getRes = await getHandler(
+      new Request("http://gateway.test/v1/config/privacy"),
+    );
+    expect(getRes.status).toBe(200);
+    const body = await getRes.json();
+    expect(body.llmRequestLogRetentionMs).toBeNull();
   });
 });
 

--- a/gateway/src/http/routes/privacy-config.ts
+++ b/gateway/src/http/routes/privacy-config.ts
@@ -17,7 +17,7 @@ const DEFAULT_LLM_REQUEST_LOG_RETENTION_MS = 1 * 24 * 60 * 60 * 1000;
 
 // Upper bound for llmRequestLogRetentionMs: 365 days (in ms).
 // Prevents accidental values like Number.MAX_SAFE_INTEGER.
-// The daemon treats 0 as "never prune".
+// The daemon treats null as "keep forever" and 0 as "prune immediately".
 const MAX_LLM_REQUEST_LOG_RETENTION_MS = 365 * 24 * 60 * 60 * 1000;
 
 /**
@@ -27,7 +27,8 @@ const MAX_LLM_REQUEST_LOG_RETENTION_MS = 365 * 24 * 60 * 60 * 1000;
  * handlers so both endpoints produce the same response shape for
  * `llmRequestLogRetentionMs`.
  *
- * A value of 0 is valid (it means "never prune") and is returned verbatim.
+ * A value of 0 is valid (it means "prune immediately") and is returned
+ * verbatim. A `null` leaf means "keep forever" and is returned as `null`.
  *
  * When `options.maxValue` is provided, any leaf value exceeding it is treated
  * as invalid and replaced with `defaultValue`. This prevents the gateway from
@@ -36,12 +37,12 @@ const MAX_LLM_REQUEST_LOG_RETENTION_MS = 365 * 24 * 60 * 60 * 1000;
  * snaps it to the nearest supported option, and the next PATCH silently
  * truncates the on-disk value with no UI warning).
  */
-function parseNestedNumber(
+function parseNestedNullableNumber(
   config: Record<string, unknown>,
   path: readonly string[],
   defaultValue: number,
   options?: { maxValue?: number },
-): number {
+): number | null {
   let current: unknown = config;
   for (const key of path) {
     if (
@@ -53,6 +54,10 @@ function parseNestedNumber(
     }
     current = (current as Record<string, unknown>)[key];
   }
+  // null means "keep forever"
+  if (current === null) return null;
+  // undefined or missing path → default
+  if (current === undefined) return defaultValue;
   if (
     typeof current !== "number" ||
     !Number.isInteger(current) ||
@@ -142,33 +147,38 @@ export function createPrivacyConfigPatchHandler() {
     }
 
     if (hasLlmRequestLogRetentionMs) {
-      if (
-        typeof llmRequestLogRetentionMs !== "number" ||
-        !Number.isFinite(llmRequestLogRetentionMs) ||
-        !Number.isInteger(llmRequestLogRetentionMs)
-      ) {
-        return Response.json(
-          { error: '"llmRequestLogRetentionMs" must be an integer' },
-          { status: 400 },
-        );
+      if (llmRequestLogRetentionMs !== null) {
+        if (
+          typeof llmRequestLogRetentionMs !== "number" ||
+          !Number.isFinite(llmRequestLogRetentionMs) ||
+          !Number.isInteger(llmRequestLogRetentionMs)
+        ) {
+          return Response.json(
+            {
+              error: '"llmRequestLogRetentionMs" must be an integer or null',
+            },
+            { status: 400 },
+          );
+        }
+        if (llmRequestLogRetentionMs < 0) {
+          return Response.json(
+            {
+              error:
+                '"llmRequestLogRetentionMs" must be greater than or equal to 0',
+            },
+            { status: 400 },
+          );
+        }
+        if (llmRequestLogRetentionMs > MAX_LLM_REQUEST_LOG_RETENTION_MS) {
+          return Response.json(
+            {
+              error: `"llmRequestLogRetentionMs" must be less than or equal to ${MAX_LLM_REQUEST_LOG_RETENTION_MS} (365 days)`,
+            },
+            { status: 400 },
+          );
+        }
       }
-      if (llmRequestLogRetentionMs < 0) {
-        return Response.json(
-          {
-            error:
-              '"llmRequestLogRetentionMs" must be greater than or equal to 0',
-          },
-          { status: 400 },
-        );
-      }
-      if (llmRequestLogRetentionMs > MAX_LLM_REQUEST_LOG_RETENTION_MS) {
-        return Response.json(
-          {
-            error: `"llmRequestLogRetentionMs" must be less than or equal to ${MAX_LLM_REQUEST_LOG_RETENTION_MS} (365 days)`,
-          },
-          { status: 400 },
-        );
-      }
+      // null passes through without validation — it means "keep forever"
     }
 
     const writeResult = new Promise<Response>((resolve) => {
@@ -229,7 +239,7 @@ export function createPrivacyConfigPatchHandler() {
               "sendDiagnostics",
               DEFAULT_SEND_DIAGNOSTICS,
             ),
-            llmRequestLogRetentionMs: parseNestedNumber(
+            llmRequestLogRetentionMs: parseNestedNullableNumber(
               config,
               ["memory", "cleanup", "llmRequestLogRetentionMs"],
               DEFAULT_LLM_REQUEST_LOG_RETENTION_MS,
@@ -280,10 +290,11 @@ export function createPrivacyConfigGetHandler() {
     );
 
     // Extract nested memory.cleanup.llmRequestLogRetentionMs safely.
-    // A value of 0 is valid (means "never prune") and is returned verbatim.
-    // Clamp out-of-range values to the default so a manually-edited
-    // config.json cannot trick clients into snapping-and-truncating.
-    const llmRequestLogRetentionMs = parseNestedNumber(
+    // A value of 0 is valid (means "prune immediately") and is returned
+    // verbatim. null means "keep forever". Clamp out-of-range values to the
+    // default so a manually-edited config.json cannot trick clients into
+    // snapping-and-truncating.
+    const llmRequestLogRetentionMs = parseNestedNullableNumber(
       config,
       ["memory", "cleanup", "llmRequestLogRetentionMs"],
       DEFAULT_LLM_REQUEST_LOG_RETENTION_MS,

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -2251,11 +2251,11 @@ export function buildSchema(): Record<string, unknown> {
                       collectUsageData: { type: "boolean" },
                       sendDiagnostics: { type: "boolean" },
                       llmRequestLogRetentionMs: {
-                        type: "integer",
+                        type: ["integer", "null"],
                         minimum: 0,
                         maximum: 31536000000,
                         description:
-                          "Retention period for LLM request/response logs in milliseconds. 0 disables pruning. Maximum is 365 days (31536000000 ms); server-side clamping enforces this cap on reads.",
+                          "Retention period for LLM request/response logs in milliseconds. null keeps forever, 0 prunes immediately. Maximum is 365 days (31536000000 ms); server-side clamping enforces this cap on reads.",
                       },
                     },
                     required: [
@@ -2290,11 +2290,11 @@ export function buildSchema(): Record<string, unknown> {
                     collectUsageData: { type: "boolean" },
                     sendDiagnostics: { type: "boolean" },
                     llmRequestLogRetentionMs: {
-                      type: "integer",
+                      type: ["integer", "null"],
                       minimum: 0,
                       maximum: 31536000000,
                       description:
-                        "Retention window for LLM request logs, in milliseconds. 0 means never prune. Maximum is 365 days (31536000000 ms).",
+                        "Retention window for LLM request logs, in milliseconds. null keeps forever, 0 prunes immediately. Maximum is 365 days (31536000000 ms).",
                     },
                   },
                   anyOf: [
@@ -2435,11 +2435,11 @@ export function buildSchema(): Record<string, unknown> {
                       collectUsageData: { type: "boolean" },
                       sendDiagnostics: { type: "boolean" },
                       llmRequestLogRetentionMs: {
-                        type: "integer",
+                        type: ["integer", "null"],
                         minimum: 0,
                         maximum: 31536000000,
                         description:
-                          "Retention period for LLM request/response logs in milliseconds. 0 disables pruning. Maximum is 365 days (31536000000 ms); server-side clamping enforces this cap on reads.",
+                          "Retention period for LLM request/response logs in milliseconds. null keeps forever, 0 prunes immediately. Maximum is 365 days (31536000000 ms); server-side clamping enforces this cap on reads.",
                       },
                     },
                     required: [
@@ -2483,11 +2483,11 @@ export function buildSchema(): Record<string, unknown> {
                     collectUsageData: { type: "boolean" },
                     sendDiagnostics: { type: "boolean" },
                     llmRequestLogRetentionMs: {
-                      type: "integer",
+                      type: ["integer", "null"],
                       minimum: 0,
                       maximum: 31536000000,
                       description:
-                        "Retention window for LLM request logs, in milliseconds. 0 means never prune. Maximum is 365 days (31536000000 ms).",
+                        "Retention window for LLM request logs, in milliseconds. null keeps forever, 0 prunes immediately. Maximum is 365 days (31536000000 ms).",
                     },
                   },
                   anyOf: [

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -2317,11 +2317,11 @@ export function buildSchema(): Record<string, unknown> {
                       collectUsageData: { type: "boolean" },
                       sendDiagnostics: { type: "boolean" },
                       llmRequestLogRetentionMs: {
-                        type: "integer",
+                        type: ["integer", "null"],
                         minimum: 0,
                         maximum: 31536000000,
                         description:
-                          "Retention window for LLM request logs, in milliseconds. 0 means never prune. Maximum is 365 days (31536000000 ms).",
+                          "Retention window for LLM request logs, in milliseconds. null keeps logs forever, 0 prunes immediately. Maximum is 365 days (31536000000 ms).",
                       },
                     },
                     required: [
@@ -2510,11 +2510,11 @@ export function buildSchema(): Record<string, unknown> {
                       collectUsageData: { type: "boolean" },
                       sendDiagnostics: { type: "boolean" },
                       llmRequestLogRetentionMs: {
-                        type: "integer",
+                        type: ["integer", "null"],
                         minimum: 0,
                         maximum: 31536000000,
                         description:
-                          "Retention window for LLM request logs, in milliseconds. 0 means never prune. Maximum is 365 days (31536000000 ms).",
+                          "Retention window for LLM request logs, in milliseconds. null keeps logs forever, 0 prunes immediately. Maximum is 365 days (31536000000 ms).",
                       },
                     },
                     required: [


### PR DESCRIPTION
## Summary
- **New semantics**: `null` = keep forever, `0` = don't retain (prune immediately), positive = retain N ms
- **Workspace migration 031**: converts existing `0` (old 'keep forever') to `null` (new 'keep forever')
- **Daemon**: job handler and scheduler updated; null skips pruning, 0 prunes everything
- **Gateway**: PATCH/GET accept and return null; OpenAPI schema updated to `type: ['integer', 'null']`
- **macOS client**: new 'Don't retain' picker option; `PrivacyConfig.llmRequestLogRetentionMs` is now nullable; double-optional plumbing sends JSON null for 'keep forever'
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24710" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
