### PR TITLE
Fix Anthropic adaptive thinking on unsupported models

### DIFF
--- a/assistant/src/__tests__/anthropic-provider.test.ts
+++ b/assistant/src/__tests__/anthropic-provider.test.ts
@@ -147,6 +147,28 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
     provider = new AnthropicProvider("sk-ant-test", "claude-sonnet-4-6");
   });
 
+  test("passes adaptive thinking through for supported Anthropic models", async () => {
+    await provider.sendMessage([userMsg("Hi")], undefined, undefined, {
+      config: {
+        thinking: { type: "adaptive" },
+      },
+    });
+
+    expect(lastStreamParams!.thinking).toEqual({ type: "adaptive" });
+  });
+
+  test("strips adaptive thinking for older Anthropic models", async () => {
+    provider = new AnthropicProvider("sk-ant-test", "claude-sonnet-4-20250514");
+
+    await provider.sendMessage([userMsg("Hi")], undefined, undefined, {
+      config: {
+        thinking: { type: "adaptive" },
+      },
+    });
+
+    expect(lastStreamParams!.thinking).toBeUndefined();
+  });
+
   // -----------------------------------------------------------------------
   // System prompt cache control
   // -----------------------------------------------------------------------
@@ -307,7 +329,10 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
     // Turn-starting user message (first) keeps 1h
     const turnStart = sent[0];
     const turnStartLast = turnStart.content[turnStart.content.length - 1];
-    expect(turnStartLast.cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
+    expect(turnStartLast.cache_control).toEqual({
+      type: "ephemeral",
+      ttl: "1h",
+    });
 
     // Last message (tool_result) gets 5m advancing tail
     const lastMessage = sent[sent.length - 1];
@@ -398,7 +423,10 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
     }>;
     const user = sent[0];
     expect(user.content[0].cache_control).toBeUndefined();
-    expect(user.content[1].cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
+    expect(user.content[1].cache_control).toEqual({
+      type: "ephemeral",
+      ttl: "1h",
+    });
   });
 
   // -----------------------------------------------------------------------
@@ -442,7 +470,10 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
     // Workspace block (first): no cache_control
     expect(user.content[0].cache_control).toBeUndefined();
     // User text (last): cache_control with 1h TTL
-    expect(user.content[1].cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
+    expect(user.content[1].cache_control).toEqual({
+      type: "ephemeral",
+      ttl: "1h",
+    });
   });
 
   test("workspace + multi-block single user message: cache on last block only", async () => {
@@ -476,7 +507,10 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
     // Only last block gets cache_control
     expect(user.content[0].cache_control).toBeUndefined();
     expect(user.content[1].cache_control).toBeUndefined();
-    expect(user.content[2].cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
+    expect(user.content[2].cache_control).toEqual({
+      type: "ephemeral",
+      ttl: "1h",
+    });
   });
 
   // -----------------------------------------------------------------------
@@ -1408,7 +1442,10 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
     // Last user message (turn 3): 1h cache on last block only
     const lastUser = userMsgs[userMsgs.length - 1];
     expect(lastUser.content[0].cache_control).toBeUndefined();
-    expect(lastUser.content[1].cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
+    expect(lastUser.content[1].cache_control).toEqual({
+      type: "ephemeral",
+      ttl: "1h",
+    });
 
     // No top-level cache_control — breakpoints are set directly on blocks
     expect(
@@ -1437,14 +1474,19 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
 
     // First message is the turn-starting user text — gets 1h cache
     expect(sent[0].role).toBe("user");
-    expect(sent[0].content[0].cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
+    expect(sent[0].content[0].cache_control).toEqual({
+      type: "ephemeral",
+      ttl: "1h",
+    });
 
     // Non-last tool result messages do NOT get cache_control
     const toolResultMsgs = sent.filter(
       (m) =>
         m.role === "user" &&
         Array.isArray(m.content) &&
-        m.content.every((b) => typeof b !== "string" && b.type === "tool_result"),
+        m.content.every(
+          (b) => typeof b !== "string" && b.type === "tool_result",
+        ),
     );
     expect(toolResultMsgs.length).toBeGreaterThan(0);
     for (const tr of toolResultMsgs.slice(0, -1)) {

--- a/assistant/src/__tests__/provider-error-scenarios.test.ts
+++ b/assistant/src/__tests__/provider-error-scenarios.test.ts
@@ -563,6 +563,37 @@ describe("RetryProvider — streaming corruption retries", () => {
 // ---------------------------------------------------------------------------
 
 describe("RetryProvider — streaming response handling", () => {
+  test("repairs unsupported Anthropic adaptive thinking by retrying once without it", async () => {
+    const seenThinking: unknown[] = [];
+    let callCount = 0;
+    const inner: Provider = {
+      name: "anthropic",
+      async sendMessage(_m, _t, _s, options) {
+        callCount++;
+        seenThinking.push(options?.config?.thinking);
+        if (callCount === 1) {
+          throw new ProviderError(
+            "Anthropic API error (400): adaptive thinking is not supported on this model",
+            "anthropic",
+            400,
+          );
+        }
+        return successResponse();
+      },
+    };
+    const provider = new RetryProvider(inner);
+
+    await provider.sendMessage(MESSAGES, undefined, undefined, {
+      config: {
+        model: "claude-sonnet-4-20250514",
+        thinking: { type: "adaptive" },
+      },
+    });
+
+    expect(callCount).toBe(2);
+    expect(seenThinking).toEqual([{ type: "adaptive" }, undefined]);
+  });
+
   test("passes onEvent callback through to inner provider", async () => {
     const events: ProviderEvent[] = [];
     const inner: Provider = {

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -101,6 +101,29 @@ const ANTHROPIC_SUPPORTED_IMAGE_TYPES = new Set([
   "image/webp",
 ]);
 
+/**
+ * Adaptive thinking is currently limited to Anthropic's newest Claude 4.6
+ * models plus Mythos Preview. Older Claude models still require manual
+ * thinking budgets or no thinking parameter at all.
+ */
+function supportsAdaptiveThinkingModel(model: string): boolean {
+  const normalized = model.trim().toLowerCase();
+  return (
+    /claude-(?:opus|sonnet)-4-6(?:-|@|$)/i.test(normalized) ||
+    /claude-mythos-preview(?:-|@|$)/i.test(normalized)
+  );
+}
+
+function isAdaptiveThinkingConfig(
+  value: unknown,
+): value is { type: "adaptive" } & Record<string, unknown> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as { type?: unknown }).type === "adaptive"
+  );
+}
+
 function isTextBasedMimeType(mediaType: string): boolean {
   return (
     mediaType.startsWith("text/") ||
@@ -609,7 +632,10 @@ export class AnthropicProvider implements Provider {
     options?: SendMessageOptions,
   ): Promise<ProviderResponse> {
     const { config, onEvent, signal } = options ?? {};
-    const cacheTtl: "5m" | "1h" = ((config as Record<string, unknown> | undefined)?.cacheTtl as "5m" | "1h") ?? "1h";
+    const cacheTtl: "5m" | "1h" =
+      ((config as Record<string, unknown> | undefined)?.cacheTtl as
+        | "5m"
+        | "1h") ?? "1h";
     let sentMessages: Anthropic.MessageParam[] | undefined;
     try {
       const formatted = messages
@@ -719,11 +745,18 @@ export class AnthropicProvider implements Provider {
       // — the API accepts them. No provider-side stripping needed.
 
       sentMessages = ensureToolPairing(repairOrphanedServerToolUse(formatted));
-      const { effort, speed, output_config, cacheTtl: _cacheTtl, ...restConfig } = (config ??
-        {}) as Record<string, unknown> & {
+      const {
+        effort,
+        speed,
+        output_config,
+        cacheTtl: _cacheTtl,
+        thinking,
+        ...restConfig
+      } = (config ?? {}) as Record<string, unknown> & {
         effort?: Anthropic.OutputConfig["effort"];
         speed?: "standard" | "fast";
         output_config?: Record<string, unknown>;
+        thinking?: Anthropic.MessageStreamParams["thinking"];
       };
       // Haiku does not support the effort / output_config parameter.
       // Determine the effective model (per-call override or provider default)
@@ -731,6 +764,15 @@ export class AnthropicProvider implements Provider {
       const effectiveModel =
         (restConfig as Record<string, unknown>).model?.toString() ?? this.model;
       const supportsEffort = !effectiveModel.includes("haiku");
+      const adaptiveThinkingUnsupported =
+        isAdaptiveThinkingConfig(thinking) &&
+        !supportsAdaptiveThinkingModel(effectiveModel);
+      if (adaptiveThinkingUnsupported) {
+        log.debug(
+          { model: effectiveModel },
+          "Skipping adaptive thinking for unsupported Anthropic model",
+        );
+      }
       const mergedOutputConfig = {
         ...(output_config ?? {}),
         ...(effort && supportsEffort ? { effort } : {}),
@@ -740,6 +782,9 @@ export class AnthropicProvider implements Provider {
         max_tokens: 64000,
         messages: sentMessages,
         ...restConfig,
+        ...(thinking !== undefined && !adaptiveThinkingUnsupported
+          ? { thinking }
+          : {}),
         ...(Object.keys(mergedOutputConfig).length > 0
           ? { output_config: mergedOutputConfig }
           : {}),
@@ -862,7 +907,10 @@ export class AnthropicProvider implements Provider {
       if (turnStartIdx >= 0 && turnStartIdx < sentMessages.length - 1) {
         const lastMsg = sentMessages[sentMessages.length - 1];
         if (Array.isArray(lastMsg.content) && lastMsg.content.length > 0) {
-          const NON_CACHEABLE_TYPES = new Set(["thinking", "redacted_thinking"]);
+          const NON_CACHEABLE_TYPES = new Set([
+            "thinking",
+            "redacted_thinking",
+          ]);
           let tailBlock: (typeof lastMsg.content)[number] | undefined;
           for (let j = lastMsg.content.length - 1; j >= 0; j--) {
             const block = lastMsg.content[j];
@@ -902,7 +950,8 @@ export class AnthropicProvider implements Provider {
         params.system.length === 2 &&
         hasToolCacheBreakpoint
       ) {
-        delete (params.system[0] as unknown as Record<string, unknown>).cache_control;
+        delete (params.system[0] as unknown as Record<string, unknown>)
+          .cache_control;
       }
 
       // Strip orphaned UTF-16 surrogates so the Anthropic JSON parser never
@@ -1021,7 +1070,9 @@ export class AnthropicProvider implements Provider {
               type: "server_tool_complete",
               toolUseId: block.tool_use_id,
               isError: !!isError,
-              ...(Array.isArray(block.content) ? { content: block.content } : {}),
+              ...(Array.isArray(block.content)
+                ? { content: block.content }
+                : {}),
             });
           }
           if (event.type === "content_block_stop") {

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -41,6 +41,46 @@ const RETRYABLE_STREAM_PATTERNS = [
  */
 const RETRYABLE_PROVIDER_MESSAGE_PATTERNS = [/overloaded/i];
 
+const ANTHROPIC_ADAPTIVE_THINKING_UNSUPPORTED_PATTERN =
+  /adaptive thinking is not supported on this model/i;
+
+function isAdaptiveThinkingConfig(value: unknown): boolean {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as { type?: unknown }).type === "adaptive"
+  );
+}
+
+function stripThinkingFromOptions(
+  options?: SendMessageOptions,
+): SendMessageOptions | undefined {
+  const config = options?.config;
+  if (!config || config.thinking === undefined) return options;
+
+  const nextConfig: Record<string, unknown> = { ...config };
+  delete nextConfig.thinking;
+  return {
+    ...options,
+    config: nextConfig,
+  };
+}
+
+function shouldRepairAnthropicAdaptiveThinking(
+  providerName: string,
+  error: unknown,
+  options?: SendMessageOptions,
+): boolean {
+  return (
+    providerName === "anthropic" &&
+    error instanceof ProviderError &&
+    error.provider === "anthropic" &&
+    error.statusCode === 400 &&
+    ANTHROPIC_ADAPTIVE_THINKING_UNSUPPORTED_PATTERN.test(error.message) &&
+    isAdaptiveThinkingConfig(options?.config?.thinking)
+  );
+}
+
 function isRetryableStreamError(error: unknown): boolean {
   if (!(error instanceof ProviderError)) return false;
   if (error.statusCode !== undefined) return false; // has a real HTTP status — not a stream error
@@ -81,7 +121,8 @@ function normalizeSendMessageOptions(
   const needsThinkingStrip =
     providerName !== "anthropic" && config.thinking !== undefined;
   const needsEffortStrip =
-    !EFFORT_SUPPORTED_PROVIDERS.has(providerName) && config.effort !== undefined;
+    !EFFORT_SUPPORTED_PROVIDERS.has(providerName) &&
+    config.effort !== undefined;
   const needsSpeedStrip =
     providerName !== "anthropic" && config.speed !== undefined;
 
@@ -145,19 +186,37 @@ export class RetryProvider implements Provider {
   ): Promise<ProviderResponse> {
     let lastError: unknown;
 
-    const normalizedOptions = normalizeSendMessageOptions(this.name, options);
+    let currentOptions = normalizeSendMessageOptions(this.name, options);
+    let repairedAdaptiveThinking = false;
 
-    for (let attempt = 0; attempt <= DEFAULT_MAX_RETRIES; attempt++) {
+    for (let attempt = 0; attempt <= DEFAULT_MAX_RETRIES; ) {
       try {
         const result = await this.inner.sendMessage(
           messages,
           tools,
           systemPrompt,
-          normalizedOptions,
+          currentOptions,
         );
         return result;
       } catch (error) {
         lastError = error;
+
+        if (
+          !repairedAdaptiveThinking &&
+          shouldRepairAnthropicAdaptiveThinking(
+            this.name,
+            error,
+            currentOptions,
+          )
+        ) {
+          repairedAdaptiveThinking = true;
+          currentOptions = stripThinkingFromOptions(currentOptions);
+          log.warn(
+            { provider: this.name },
+            "Retrying once without adaptive thinking after unsupported-model error",
+          );
+          continue;
+        }
 
         if (attempt < DEFAULT_MAX_RETRIES && isRetryableError(error)) {
           // Prefer server-provided Retry-After; fall back to exponential backoff.
@@ -191,6 +250,7 @@ export class RetryProvider implements Provider {
             },
             "Retrying after transient error",
           );
+          attempt++;
           await sleep(delay);
           continue;
         }


### PR DESCRIPTION
## Summary
- Guard Anthropic adaptive thinking so it is only sent to models that currently support it, including handling older Claude snapshots safely.
- Retry once without adaptive thinking when Anthropic returns the specific unsupported-model 400, so stale or drifted model config does not hard-fail a turn.
- Add regression coverage for the older Sonnet snapshot path seen in the feedback bundle.

## Original prompt
put the fix up in a new PR, do this all from a worktree, clean up the current directory
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24711" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
