### PR TITLE
fix(macOS): fix scroll white space and push-to-top during assistant streaming

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 import VellumAssistantShared
 
 private let stallLog = OSLog(subsystem: "com.vellum.assistant", category: "LayoutStall")
+private let scrollDiag = Logger(subsystem: Bundle.appBundleIdentifier, category: "ScrollDiag")
 
 // MARK: - MessageListContentView
 
@@ -179,6 +180,22 @@ struct MessageListContentView: View, Equatable {
             let turnMinHeight: CGFloat = scrollState.viewportHeight.isFinite
                 ? max(0, scrollState.viewportHeight - 150)
                 : 0
+            // Track whether the minHeight wrapper is applied so
+            // executeScrollToBottom can target the content-bottom marker.
+            let minHeightApplied: Bool = {
+                guard state.isActiveTurn, let lastRow = state.rows.last else { return false }
+                return lastRow.isLatestAssistant && lastRow.message.id == state.rows.last?.message.id
+            }()
+            let _ = {
+                let wasApplied = scrollState.isActiveTurnMinHeightApplied
+                scrollState.isActiveTurnMinHeightApplied = minHeightApplied
+                // Reset the push-to-top flag when the active turn ends so
+                // the next turn gets a fresh initial pin with lastMessageId.
+                if !minHeightApplied { scrollState.hasCompletedInitialPushToTop = false }
+                if wasApplied != minHeightApplied {
+                    scrollDiag.debug("minHeightApplied changed: \(wasApplied, privacy: .public) → \(minHeightApplied, privacy: .public) isActiveTurn=\(state.isActiveTurn, privacy: .public) rowCount=\(state.rows.count, privacy: .public)")
+                }
+            }()
             let isUnanchoredThinking = state.shouldShowThinkingIndicator && !state.rows.contains(where: \.isAnchoredThinkingRow)
             let thinkingLabel = !hasEverSentMessage && state.hasUserMessage
                 ? "Waking up..."
@@ -238,8 +255,12 @@ struct MessageListContentView: View, Equatable {
                 // message sits at top. Only applies while the assistant has an
                 // active turn (sending, thinking, streaming, tool running).
                 .if(state.isActiveTurn && row.isLatestAssistant && row.message.id == state.rows.last?.message.id) { view in
-                    VStack(spacing: 0) { view }
-                        .frame(minHeight: turnMinHeight, alignment: .top)
+                    VStack(spacing: 0) {
+                        view
+                        Color.clear.frame(height: 1)
+                            .id("active-turn-content-bottom")
+                    }
+                    .frame(minHeight: turnMinHeight, alignment: .top)
                 }
             }
 

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
@@ -184,7 +184,7 @@ struct MessageListContentView: View, Equatable {
             // executeScrollToBottom can target the content-bottom marker.
             let minHeightApplied: Bool = {
                 guard state.isActiveTurn, let lastRow = state.rows.last else { return false }
-                return lastRow.isLatestAssistant && lastRow.message.id == state.rows.last?.message.id
+                return lastRow.isLatestAssistant
             }()
             let _ = {
                 let wasApplied = scrollState.isActiveTurnMinHeightApplied

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -743,8 +743,19 @@ final class MessageListScrollState {
             }
         }
         scrollDiag.debug("executeScrollToBottom: target=\(targetName, privacy: .public) minHeightApplied=\(self.isActiveTurnMinHeightApplied, privacy: .public) pushToTopDone=\(self.hasCompletedInitialPushToTop, privacy: .public) path=\(path, privacy: .public) userInit=\(userInitiated, privacy: .public)")
+        // User-initiated (CTA): use edge-based scroll to reliably reach
+        // the bottom even when LazyVStack hasn't materialized the target
+        // message. May overshoot into blank estimated space, but the
+        // recovery window fires immediately after and converges with
+        // ID-based scrolls. ID-based scroll alone can fail silently
+        // when the target is unmaterialized (seen as distBottom=3000+).
+        if userInitiated {
+            scrollDiag.debug("executeScrollToBottom: using scrollToEdge(.bottom) for CTA reliability")
+            scrollToEdge?(.bottom)
+            return
+        }
         if let target {
-            if animated && !userInitiated {
+            if animated {
                 withAnimation(VAnimation.fast) {
                     scrollTo?(target, .bottom)
                 }
@@ -754,7 +765,7 @@ final class MessageListScrollState {
         } else {
             // No ForEach items to target (empty conversation).
             // Fall back to edge-based scroll.
-            if animated && !userInitiated {
+            if animated {
                 withAnimation(VAnimation.fast) {
                     scrollToEdge?(.bottom)
                 }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -268,6 +268,21 @@ final class MessageListScrollState {
     /// `.followingBottom` and creating a "scroll lock" effect.
     @ObservationIgnored var lastUserInitiatedPinTime: Date?
 
+    /// True when the active assistant turn's `minHeight` frame is applied
+    /// to the last message cell. When set, `executeScrollToBottom` targets
+    /// the `"active-turn-content-bottom"` marker (real content edge) instead
+    /// of `lastMessageId` (whose `.bottom` includes the minHeight padding) —
+    /// but only after the initial push-to-top has completed.
+    @ObservationIgnored var isActiveTurnMinHeightApplied: Bool = false
+
+    /// Set after the first `executeScrollToBottom` fires with `lastMessageId`
+    /// during an active turn. The initial pin uses `lastMessageId` (whose
+    /// `.bottom` includes the minHeight frame) to push the user message to
+    /// the top. Subsequent auto-follow calls use the content-bottom marker
+    /// so `.bottom` targets real content, avoiding visible white space.
+    /// Cleared in `reset()` and when the active turn ends.
+    @ObservationIgnored var hasCompletedInitialPushToTop: Bool = false
+
     // MARK: - Layout Cache Fields
 
     /// Memoization state intentionally lives outside the observed object so
@@ -695,7 +710,28 @@ final class MessageListScrollState {
         //     would override the spring with VAnimation.fast.
         //   - auto-follow / recovery: no outer withAnimation, so we wrap
         //     in VAnimation.fast when animated == true.
-        if let target = lastMessageId {
+        // When the active turn's minHeight frame is applied, choose the
+        // scroll target based on whether the initial push-to-top has fired:
+        //   - First pin: use lastMessageId — its .bottom includes the
+        //     minHeight frame, which fills the viewport and pushes the
+        //     user message to the top.
+        //   - Subsequent pins: use the content-bottom marker — its .bottom
+        //     lands on real content, avoiding the minHeight white space.
+        let target: (any Hashable)?
+        let targetName: String
+        if isActiveTurnMinHeightApplied && hasCompletedInitialPushToTop {
+            target = "active-turn-content-bottom" as String
+            targetName = "marker"
+        } else {
+            target = lastMessageId
+            targetName = "lastMessageId"
+            if isActiveTurnMinHeightApplied {
+                hasCompletedInitialPushToTop = true
+                scrollDiag.debug("executeScrollToBottom: initial push-to-top completed, subsequent calls will use marker")
+            }
+        }
+        scrollDiag.debug("executeScrollToBottom: target=\(targetName, privacy: .public) minHeightApplied=\(self.isActiveTurnMinHeightApplied, privacy: .public) pushToTopDone=\(self.hasCompletedInitialPushToTop, privacy: .public) path=\(path, privacy: .public) userInit=\(userInitiated, privacy: .public)")
+        if let target {
             if animated && !userInitiated {
                 withAnimation(VAnimation.fast) {
                     scrollTo?(target, .bottom)
@@ -830,6 +866,8 @@ final class MessageListScrollState {
         derivedStateCache.reset()
         currentConversationId = newConversationId
         lastMessageId = nil
+        isActiveTurnMinHeightApplied = false
+        hasCompletedInitialPushToTop = false
         mode = .initialLoad
         activeStabilizationCount = 0
         // False: scroll geometry hasn't updated for the new content yet.

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -730,8 +730,9 @@ final class MessageListScrollState {
         let path = userInitiated ? "userInitiated" : (forRecovery ? "recovery" : "autoFollow")
         scrollDiag.debug("executeScrollToBottom: path=\(path, privacy: .public) animated=\(animated, privacy: .public) lastMsgId=\(self.lastMessageId?.uuidString ?? "nil", privacy: .public)")
 
-        // ID-based scroll: targets a real ForEach item. Falls back to
-        // edge-based only for empty conversations (lastMessageId == nil).
+        // ID-based scroll for auto-follow/recovery. Edge-based scroll
+        // for CTA (reliability) and empty conversations (no lastMessageId).
+        // Initial send uses scheduleDeferredEdgeScroll (separate path).
         //
         // Animation handling:
         //   - userInitiated (CTA): caller wraps in withAnimation(VAnimation.spring),

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -283,13 +283,10 @@ final class MessageListScrollState {
     /// Cleared in `reset()` and when the active turn ends.
     @ObservationIgnored var hasCompletedInitialPushToTop: Bool = false
 
-    /// When set, the next `executeScrollToBottom` uses `scrollToEdge(.bottom)`
-    /// to reach the actual content bottom (including the thinking indicator's
-    /// `minHeight`) rather than `scrollTo(lastMessageId, .bottom)` which only
-    /// reaches the last ForEach item. Consumed on first use. Set by
-    /// `handleSendingChanged` so the initial send immediately pushes the
-    /// user message to the top without waiting for the assistant message.
-    @ObservationIgnored var pendingEdgeScrollOnSend: Bool = false
+    /// Generation counter for `scheduleDeferredEdgeScroll`. Uses its own
+    /// counter (separate from `deferredBottomPinGeneration`) so the two
+    /// deferred mechanisms don't interfere with each other.
+    @ObservationIgnored private var deferredEdgeScrollGeneration: UInt64 = 0
 
     // MARK: - Layout Cache Fields
 
@@ -644,6 +641,29 @@ final class MessageListScrollState {
         deferredBottomPinGeneration &+= 1
     }
 
+    /// Schedules an edge-based scroll-to-bottom for the next main-queue
+    /// turn. Uses its own generation counter so intervening
+    /// `scheduleDeferredBottomPin` calls (e.g. from `handleMessagesCountChanged`)
+    /// don't consume or cancel it. The edge-based scroll reaches past the
+    /// thinking indicator's `minHeight` to push the user message to the top.
+    func scheduleDeferredEdgeScroll(animated: Bool) {
+        deferredEdgeScrollGeneration &+= 1
+        let generation = deferredEdgeScrollGeneration
+        DispatchQueue.main.async { [weak self] in
+            Task { @MainActor [weak self] in
+                guard let self, self.deferredEdgeScrollGeneration == generation else { return }
+                scrollDiag.debug("scheduleDeferredEdgeScroll: firing (generation matched)")
+                if animated {
+                    withAnimation(VAnimation.fast) {
+                        self.scrollToEdge?(.bottom)
+                    }
+                } else {
+                    self.scrollToEdge?(.bottom)
+                }
+            }
+        }
+    }
+
     // MARK: - Scroll Execution
 
     /// Executes a bottom-pin scroll if the current mode allows it.
@@ -692,10 +712,12 @@ final class MessageListScrollState {
     ///   ForEach items (`lastMessageId` or the `active-turn-content-bottom`
     ///   marker). Lands short rather than overshooting; recovery
     ///   converges monotonically as LazyVStack materializes views.
-    /// - **Initial send (`pendingEdgeScrollOnSend`):** Edge-based scroll
+    /// - **Initial send (`scheduleDeferredEdgeScroll`):** Edge-based scroll
     ///   (`scrollToEdge(.bottom)`) to reach past the thinking indicator's
     ///   `minHeight` — the thinking indicator is outside the ForEach and
-    ///   unreachable by ID-based scroll on `lastMessageId`.
+    ///   unreachable by ID-based scroll on `lastMessageId`. Uses its own
+    ///   generation counter so it can't be consumed by intervening
+    ///   `scheduleDeferredBottomPin` calls.
     /// - **User-initiated CTA:** Edge-based scroll for reliability when
     ///   the target message is unmaterialized (observed as distBottom=3000+
     ///   with ID-based scroll on long conversations).
@@ -726,28 +748,14 @@ final class MessageListScrollState {
         //   - Subsequent pins: use the content-bottom marker — its .bottom
         //     lands on real content, avoiding the minHeight white space.
         // Target selection:
-        //   - Initial send (pendingEdgeScroll): use scrollToEdge(.bottom)
-        //     to reach past the thinking indicator's minHeight. scrollTo
-        //     (lastMessageId, .bottom) only reaches the last ForEach item
-        //     (the user message), missing the thinking indicator below it.
+        //   - Initial send: handled by scheduleDeferredEdgeScroll
+        //     (separate deferred path, not in executeScrollToBottom).
         //   - User-initiated (CTA): use scrollToEdge for reliability.
         //   - First auto-follow pin with minHeight: use lastMessageId to
         //     push the user message to the top via the minHeight frame.
         //   - Subsequent auto-follow pins with minHeight: use the content-
         //     bottom marker so .bottom lands on real content.
         //   - No minHeight: use lastMessageId (normal behavior).
-        if pendingEdgeScrollOnSend {
-            pendingEdgeScrollOnSend = false
-            scrollDiag.debug("executeScrollToBottom: using scrollToEdge(.bottom) for initial send push-to-top")
-            if animated {
-                withAnimation(VAnimation.fast) {
-                    scrollToEdge?(.bottom)
-                }
-            } else {
-                scrollToEdge?(.bottom)
-            }
-            return
-        }
         let target: (any Hashable)?
         let targetName: String
         if userInitiated {
@@ -913,7 +921,7 @@ final class MessageListScrollState {
         lastMessageId = nil
         isActiveTurnMinHeightApplied = false
         hasCompletedInitialPushToTop = false
-        pendingEdgeScrollOnSend = false
+        deferredEdgeScrollGeneration &+= 1
         mode = .initialLoad
         activeStabilizationCount = 0
         // False: scroll geometry hasn't updated for the new content yet.
@@ -987,7 +995,7 @@ final class MessageListScrollState {
         lastMessageId = nil
         isActiveTurnMinHeightApplied = false
         hasCompletedInitialPushToTop = false
-        pendingEdgeScrollOnSend = false
+        deferredEdgeScrollGeneration &+= 1
         isAtBottom = false
         lastContentOffsetY = 0
         scrollContentHeight = 0

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -717,9 +717,21 @@ final class MessageListScrollState {
         //     user message to the top.
         //   - Subsequent pins: use the content-bottom marker — its .bottom
         //     lands on real content, avoiding the minHeight white space.
+        // Target selection:
+        //   - User-initiated (CTA): always use lastMessageId for reliable
+        //     bottom reach. Recovery + auto-follow correct any transient
+        //     white space from the minHeight frame.
+        //   - First auto-follow pin with minHeight: use lastMessageId to
+        //     push the user message to the top via the minHeight frame.
+        //   - Subsequent auto-follow pins with minHeight: use the content-
+        //     bottom marker so .bottom lands on real content.
+        //   - No minHeight: use lastMessageId (normal behavior).
         let target: (any Hashable)?
         let targetName: String
-        if isActiveTurnMinHeightApplied && hasCompletedInitialPushToTop {
+        if userInitiated {
+            target = lastMessageId
+            targetName = "lastMessageId(userInitiated)"
+        } else if isActiveTurnMinHeightApplied && hasCompletedInitialPushToTop {
             target = "active-turn-content-bottom" as String
             targetName = "marker"
         } else {

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -687,20 +687,20 @@ final class MessageListScrollState {
     /// imperative `.scrollTo()` mutating methods on the ScrollPosition
     /// binding — Apple's recommended pattern for programmatic scrolling.
     ///
-    /// **ID-only strategy:** All paths use ID-based scroll targeting
-    /// real ForEach items. Edge-based scroll (`scrollToEdge(.bottom)`)
-    /// is NEVER used when `lastMessageId` is available — it computes
-    /// total content height from LazyVStack estimates, which overshoot
-    /// into blank space for long conversations with unmaterialized
-    /// items. ID-based scroll targets a specific item that SwiftUI can
-    /// locate even when not materialized, so it lands short (showing
-    /// messages) rather than overshooting (showing blank space).
-    /// Each recovery attempt materializes views near the target,
-    /// improving LazyVStack estimates for the next attempt —
-    /// converging monotonically to the actual bottom.
-    ///
-    /// Edge-based scroll is only used as a fallback for empty
-    /// conversations where `lastMessageId == nil`.
+    /// **Scroll target strategy:**
+    /// - **Auto-follow / recovery:** ID-based scroll targeting real
+    ///   ForEach items (`lastMessageId` or the `active-turn-content-bottom`
+    ///   marker). Lands short rather than overshooting; recovery
+    ///   converges monotonically as LazyVStack materializes views.
+    /// - **Initial send (`pendingEdgeScrollOnSend`):** Edge-based scroll
+    ///   (`scrollToEdge(.bottom)`) to reach past the thinking indicator's
+    ///   `minHeight` — the thinking indicator is outside the ForEach and
+    ///   unreachable by ID-based scroll on `lastMessageId`.
+    /// - **User-initiated CTA:** Edge-based scroll for reliability when
+    ///   the target message is unmaterialized (observed as distBottom=3000+
+    ///   with ID-based scroll on long conversations).
+    /// - **Empty conversation:** Edge-based scroll as fallback when
+    ///   `lastMessageId == nil`.
     ///
     /// - SeeAlso: https://stackoverflow.com/q/79884780 (ScrollPosition unreliable with variable heights)
     /// - SeeAlso: https://developer.apple.com/documentation/swiftui/scrollposition/scrollto(edge:)
@@ -985,6 +985,9 @@ final class MessageListScrollState {
         lastAutoFollowAttempt = .distantPast
         lastUserInitiatedPinTime = nil
         lastMessageId = nil
+        isActiveTurnMinHeightApplied = false
+        hasCompletedInitialPushToTop = false
+        pendingEdgeScrollOnSend = false
         isAtBottom = false
         lastContentOffsetY = 0
         scrollContentHeight = 0

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -283,6 +283,14 @@ final class MessageListScrollState {
     /// Cleared in `reset()` and when the active turn ends.
     @ObservationIgnored var hasCompletedInitialPushToTop: Bool = false
 
+    /// When set, the next `executeScrollToBottom` uses `scrollToEdge(.bottom)`
+    /// to reach the actual content bottom (including the thinking indicator's
+    /// `minHeight`) rather than `scrollTo(lastMessageId, .bottom)` which only
+    /// reaches the last ForEach item. Consumed on first use. Set by
+    /// `handleSendingChanged` so the initial send immediately pushes the
+    /// user message to the top without waiting for the assistant message.
+    @ObservationIgnored var pendingEdgeScrollOnSend: Bool = false
+
     // MARK: - Layout Cache Fields
 
     /// Memoization state intentionally lives outside the observed object so
@@ -718,14 +726,28 @@ final class MessageListScrollState {
         //   - Subsequent pins: use the content-bottom marker — its .bottom
         //     lands on real content, avoiding the minHeight white space.
         // Target selection:
-        //   - User-initiated (CTA): always use lastMessageId for reliable
-        //     bottom reach. Recovery + auto-follow correct any transient
-        //     white space from the minHeight frame.
+        //   - Initial send (pendingEdgeScroll): use scrollToEdge(.bottom)
+        //     to reach past the thinking indicator's minHeight. scrollTo
+        //     (lastMessageId, .bottom) only reaches the last ForEach item
+        //     (the user message), missing the thinking indicator below it.
+        //   - User-initiated (CTA): use scrollToEdge for reliability.
         //   - First auto-follow pin with minHeight: use lastMessageId to
         //     push the user message to the top via the minHeight frame.
         //   - Subsequent auto-follow pins with minHeight: use the content-
         //     bottom marker so .bottom lands on real content.
         //   - No minHeight: use lastMessageId (normal behavior).
+        if pendingEdgeScrollOnSend {
+            pendingEdgeScrollOnSend = false
+            scrollDiag.debug("executeScrollToBottom: using scrollToEdge(.bottom) for initial send push-to-top")
+            if animated {
+                withAnimation(VAnimation.fast) {
+                    scrollToEdge?(.bottom)
+                }
+            } else {
+                scrollToEdge?(.bottom)
+            }
+            return
+        }
         let target: (any Hashable)?
         let targetName: String
         if userInitiated {
@@ -891,6 +913,7 @@ final class MessageListScrollState {
         lastMessageId = nil
         isActiveTurnMinHeightApplied = false
         hasCompletedInitialPushToTop = false
+        pendingEdgeScrollOnSend = false
         mode = .initialLoad
         activeStabilizationCount = 0
         // False: scroll geometry hasn't updated for the new content yet.

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
@@ -152,20 +152,18 @@ extension MessageListView {
             if isDaemonConfirmationResume && !scrollState.isFollowingBottom {
                 // Daemon resumed from confirmation while user was scrolled up.
             } else {
-                // Defer the actual bottom-pin to the next main-queue turn.
-                // Both `isSending` and `messages.count` can change in the
-                // same SwiftUI update cycle after the user sends a message;
-                // issuing immediate `ScrollPosition` writes here can trip
-                // SwiftUI's "Modifying state during view update" guard.
-                // Use edge-based scroll for the initial send so it
-                // reaches past the thinking indicator's minHeight,
-                // pushing the user message to the top immediately.
-                scrollState.pendingEdgeScrollOnSend = true
-                scrollState.scheduleDeferredBottomPin(
-                    animated: true,
-                    forceFollowingBottom: true,
-                    refreshRecoveryWindow: true
-                )
+                // Apply mode transition and recovery window inline so
+                // they can't be lost by generation coalescing when
+                // handleMessagesCountChanged's deferred pin supersedes
+                // this one in the same SwiftUI update cycle.
+                scrollState.transition(to: .followingBottom)
+                scrollState.bottomAnchorAppeared = false
+                scrollState.recoveryDeadline = Date().addingTimeInterval(2.0)
+                // Defer the actual scroll to the next main-queue turn.
+                // Use edge-based scroll to reach past the thinking
+                // indicator's minHeight, pushing the user message to
+                // the top immediately.
+                scrollState.scheduleDeferredEdgeScroll(animated: true)
                 os_signpost(.event, log: PerfSignposts.log, name: "scrollToRequested",
                             "target=edgeBottom reason=sendPushToTop")
             }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
@@ -131,6 +131,7 @@ extension MessageListView {
         // hasn't run yet). Animated pins targeting stale content
         // accumulate and corrupt SwiftUI's scroll position.
         guard conversationId == scrollState.currentConversationId else { return }
+        scrollDiag.debug("handleSendingChanged: isSending=\(self.isSending, privacy: .public) phase=\(self.assistantActivityPhase, privacy: .public) minHeightApplied=\(self.scrollState.isActiveTurnMinHeightApplied, privacy: .public) pushToTopDone=\(self.scrollState.hasCompletedInitialPushToTop, privacy: .public)")
         if isSending {
             // Clear stale confirmation marker: if the phase left "awaiting_confirmation"
             // while not sending, the marker is stale.

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
@@ -157,18 +157,17 @@ extension MessageListView {
                 // same SwiftUI update cycle after the user sends a message;
                 // issuing immediate `ScrollPosition` writes here can trip
                 // SwiftUI's "Modifying state during view update" guard.
+                // Use edge-based scroll for the initial send so it
+                // reaches past the thinking indicator's minHeight,
+                // pushing the user message to the top immediately.
+                scrollState.pendingEdgeScrollOnSend = true
                 scrollState.scheduleDeferredBottomPin(
                     animated: true,
                     forceFollowingBottom: true,
                     refreshRecoveryWindow: true
                 )
                 os_signpost(.event, log: PerfSignposts.log, name: "scrollToRequested",
-                            "target=bottom reason=sendFollowingBottom")
-
-                // Also scroll the user message to top for Claude-style behavior
-                if let userMessage = messages.last(where: { $0.role == .user }) {
-                    scrollPosition.scrollTo(id: userMessage.id, anchor: .top)
-                }
+                            "target=edgeBottom reason=sendPushToTop")
             }
         } else {
             // Capture the activity phase at the moment sending stops.


### PR DESCRIPTION
## Summary
- Fix visible white space during assistant streaming caused by `scrollTo(lastMessageId, .bottom)` targeting the `minHeight` frame bottom instead of the actual content edge
- Add a content-bottom marker inside the `minHeight` wrapper so auto-follow tracks real content, not padding
- Use `scrollToEdge(.bottom)` for CTA taps and initial send to reliably reach the bottom past thinking indicators
- Push user message to the top immediately on send instead of waiting for the assistant message to appear

## Details
The active assistant turn wraps the last message in a `minHeight` frame (~viewport height) to push the user message to the top. But `scrollTo(id, .bottom)` targets the frame bottom (including empty padding), creating visible white space and causing content to appear to flow upward.

**Content-bottom marker**: A 1pt invisible view inside the `minHeight` wrapper, right after the message content. Auto-follow targets this marker so `.bottom` lands on real content.

**Push-to-top sequencing**: The first `executeScrollToBottom` uses the full `lastMessageId` (with `minHeight` frame) for the initial push-to-top. Subsequent calls switch to the marker to avoid white space.

**Edge-based scroll for CTA + send**: `scrollToEdge(.bottom)` reliably reaches the actual content bottom even when LazyVStack hasn't materialized the target message. Used for CTA taps and the initial send (to reach past the thinking indicator's `minHeight`).

## Test plan
- [ ] Send a message — user message should push to the top immediately (not after assistant starts replying)
- [ ] During streaming, content should flow downward naturally with no white space below
- [ ] After tool calls complete and assistant continues, no layout shift or upward flow
- [ ] "Scroll to latest" CTA should reliably scroll to bottom
- [ ] Conversation switching should scroll to bottom correctly
- [ ] Scrolling up during streaming should show the CTA; tapping it should work

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24712" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
