### PR TITLE
auth: point DEBUG default base URL at dev-platform

### DIFF
--- a/clients/shared/App/Auth/AuthService.swift
+++ b/clients/shared/App/Auth/AuthService.swift
@@ -10,8 +10,8 @@ private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "AuthS
 private let _platformURLOverrideEnvironmentKey = "VELLUM_PLATFORM_URL"
 private let _authServiceBaseURLDefaultsName = "authServiceBaseURL"
 private let _defaultBaseURL: String = {
-    #if DEBUG && os(macOS)
-    return "http://localhost:8000"
+    #if DEBUG
+    return "https://dev-platform.vellum.ai"
     #else
     return "https://platform.vellum.ai"
     #endif


### PR DESCRIPTION
## Summary
- Previously the `_defaultBaseURL` DEBUG branch only matched on macOS (`#if DEBUG && os(macOS)`) and returned `http://localhost:8000`. On iOS DEBUG builds it silently fell through to the production `platform.vellum.ai`.
- Widens the DEBUG condition to all platforms and points it at `https://dev-platform.vellum.ai` so development builds consistently hit the dev backend.

## Test plan
- [ ] iOS DEBUG build: verify `AuthService.shared.baseURL` resolves to `https://dev-platform.vellum.ai` when no `VELLUM_PLATFORM_URL` override and no stored user default.
- [ ] macOS DEBUG build: same as above.
- [ ] Release build (both platforms): verify the baseURL is still `https://platform.vellum.ai`.
- [ ] Confirm the `VELLUM_PLATFORM_URL` env override and `authServiceBaseURL` user default still take precedence over the compiled-in default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24715" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
