### PR TITLE
feat(iOS): use GET /v1/assistants/active/ to resolve active assistant

### DIFF
--- a/clients/ios/Views/OnboardingView.swift
+++ b/clients/ios/Views/OnboardingView.swift
@@ -133,10 +133,6 @@ struct OnboardingView: View {
         managedBootstrapError = nil
 
         do {
-            // Ask the platform for the user's active assistant before falling
-            // through to the bootstrap service. Single-org is the only
-            // supported shape on iOS today; multi-org or zero-org cases fall
-            // through to `ensureManagedAssistant()` which surfaces a typed error.
             let orgs = try await AuthService.shared.getOrganizations()
             if orgs.count == 1, let orgId = orgs.first?.id {
                 let activeResult = try await AuthService.shared.getActiveAssistant(organizationId: orgId)
@@ -146,8 +142,6 @@ struct OnboardingView: View {
                 }
             }
 
-            // No active assistant or non-single-org shape — delegate to the
-            // shared bootstrap, which hatches on iOS.
             let outcome = try await ManagedAssistantBootstrapService.shared.ensureManagedAssistant()
 
             let assistant: PlatformAssistant

--- a/clients/ios/Views/OnboardingView.swift
+++ b/clients/ios/Views/OnboardingView.swift
@@ -133,13 +133,10 @@ struct OnboardingView: View {
         managedBootstrapError = nil
 
         do {
-            // Ask the platform for the user's active assistant via
-            // GET /v1/assistants/active/ before falling through to the bootstrap
-            // service. The server resolves the active assistant via
-            // `get_presumably_unique_assistant()`, so the client doesn't need
-            // to enumerate or pick. Single-org is the only supported shape on
-            // iOS today; multi-org or zero-org cases fall through to
-            // `ensureManagedAssistant()` which surfaces a typed error.
+            // Ask the platform for the user's active assistant before falling
+            // through to the bootstrap service. Single-org is the only
+            // supported shape on iOS today; multi-org or zero-org cases fall
+            // through to `ensureManagedAssistant()` which surfaces a typed error.
             let orgs = try await AuthService.shared.getOrganizations()
             if orgs.count == 1, let orgId = orgs.first?.id {
                 let activeResult = try await AuthService.shared.getActiveAssistant(organizationId: orgId)
@@ -149,8 +146,8 @@ struct OnboardingView: View {
                 }
             }
 
-            // No active assistant (first-run) or non-single-org shape —
-            // delegate to the shared bootstrap, which hatches on iOS.
+            // No active assistant or non-single-org shape — delegate to the
+            // shared bootstrap, which hatches on iOS.
             let outcome = try await ManagedAssistantBootstrapService.shared.ensureManagedAssistant()
 
             let assistant: PlatformAssistant

--- a/clients/ios/Views/OnboardingView.swift
+++ b/clients/ios/Views/OnboardingView.swift
@@ -114,12 +114,10 @@ struct OnboardingView: View {
     private func finalizeAssistantSelection(_ assistant: PlatformAssistant) {
         let platformBaseURL = AuthService.shared.baseURL
 
-        // Persist managed assistant config so DaemonConfig.fromUserDefaults() picks it up.
+        // Persist managed assistant config so GatewayHTTPClient.resolveConnection()
+        // can build a ConnectionInfo for outbound requests.
         UserDefaults.standard.set(assistant.id, forKey: UserDefaultsKeys.managedAssistantId)
         UserDefaults.standard.set(platformBaseURL, forKey: UserDefaultsKeys.managedPlatformBaseURL)
-        // TODO: Migrate to LockfileAssistant.setActiveAssistantId() when
-        // LockfileAssistant is available on iOS (currently macOS-only).
-        UserDefaults.standard.set(assistant.id, forKey: "connectedAssistantId")
 
         // Rebuild the daemon client with managed transport config.
         // ContentView.attemptInitialConnection() handles connecting with

--- a/clients/ios/Views/OnboardingView.swift
+++ b/clients/ios/Views/OnboardingView.swift
@@ -133,13 +133,11 @@ struct OnboardingView: View {
         managedBootstrapError = nil
 
         do {
-            let orgs = try await AuthService.shared.getOrganizations()
-            if orgs.count == 1, let orgId = orgs.first?.id {
-                let activeResult = try await AuthService.shared.getActiveAssistant(organizationId: orgId)
-                if case .found(let existing) = activeResult {
-                    finalizeAssistantSelection(existing)
-                    return
-                }
+            let orgId = try await AuthService.shared.resolveOrganizationId()
+            let activeResult = try await AuthService.shared.getActiveAssistant(organizationId: orgId)
+            if case .found(let existing) = activeResult {
+                finalizeAssistantSelection(existing)
+                return
             }
 
             let outcome = try await ManagedAssistantBootstrapService.shared.ensureManagedAssistant()

--- a/clients/ios/Views/OnboardingView.swift
+++ b/clients/ios/Views/OnboardingView.swift
@@ -109,11 +109,50 @@ struct OnboardingView: View {
         .padding(VSpacing.xl)
     }
 
+    /// Persist the selected assistant's config, rebuild the daemon client,
+    /// and advance to the permissions step.
+    private func finalizeAssistantSelection(_ assistant: PlatformAssistant) {
+        let platformBaseURL = AuthService.shared.baseURL
+
+        // Persist managed assistant config so DaemonConfig.fromUserDefaults() picks it up.
+        UserDefaults.standard.set(assistant.id, forKey: UserDefaultsKeys.managedAssistantId)
+        UserDefaults.standard.set(platformBaseURL, forKey: UserDefaultsKeys.managedPlatformBaseURL)
+        // TODO: Migrate to LockfileAssistant.setActiveAssistantId() when
+        // LockfileAssistant is available on iOS (currently macOS-only).
+        UserDefaults.standard.set(assistant.id, forKey: "connectedAssistantId")
+
+        // Rebuild the daemon client with managed transport config.
+        // ContentView.attemptInitialConnection() handles connecting with
+        // proper retries and timeout once onboarding completes.
+        clientProvider.rebuildClient()
+
+        isBootstrappingManaged = false
+        currentStep = .permissions
+    }
+
     private func performManagedBootstrap() async {
         isBootstrappingManaged = true
         managedBootstrapError = nil
 
         do {
+            // Ask the platform for the user's active assistant via
+            // GET /v1/assistants/active/ before falling through to the bootstrap
+            // service. The server resolves the active assistant via
+            // `get_presumably_unique_assistant()`, so the client doesn't need
+            // to enumerate or pick. Single-org is the only supported shape on
+            // iOS today; multi-org or zero-org cases fall through to
+            // `ensureManagedAssistant()` which surfaces a typed error.
+            let orgs = try await AuthService.shared.getOrganizations()
+            if orgs.count == 1, let orgId = orgs.first?.id {
+                let activeResult = try await AuthService.shared.getActiveAssistant(organizationId: orgId)
+                if case .found(let existing) = activeResult {
+                    finalizeAssistantSelection(existing)
+                    return
+                }
+            }
+
+            // No active assistant (first-run) or non-single-org shape —
+            // delegate to the shared bootstrap, which hatches on iOS.
             let outcome = try await ManagedAssistantBootstrapService.shared.ensureManagedAssistant()
 
             let assistant: PlatformAssistant
@@ -124,22 +163,7 @@ struct OnboardingView: View {
                 assistant = created
             }
 
-            let platformBaseURL = AuthService.shared.baseURL
-
-            // Persist managed assistant config so DaemonConfig.fromUserDefaults() picks it up.
-            UserDefaults.standard.set(assistant.id, forKey: UserDefaultsKeys.managedAssistantId)
-            UserDefaults.standard.set(platformBaseURL, forKey: UserDefaultsKeys.managedPlatformBaseURL)
-            // TODO: Migrate to LockfileAssistant.setActiveAssistantId() when
-            // LockfileAssistant is available on iOS (currently macOS-only).
-            UserDefaults.standard.set(assistant.id, forKey: "connectedAssistantId")
-
-            // Rebuild the daemon client with managed transport config.
-            // ContentView.attemptInitialConnection() handles connecting with
-            // proper retries and timeout once onboarding completes.
-            clientProvider.rebuildClient()
-
-            isBootstrappingManaged = false
-            currentStep = .permissions
+            finalizeAssistantSelection(assistant)
         } catch {
             managedBootstrapError = error.localizedDescription
         }

--- a/clients/shared/App/Auth/AuthService.swift
+++ b/clients/shared/App/Auth/AuthService.swift
@@ -380,6 +380,41 @@ public final class AuthService {
         }
     }
 
+    /// Retrieve the user's currently active managed assistant for the given
+    /// organization.
+    ///
+    /// The platform resolves the active assistant server-side via
+    /// `get_presumably_unique_assistant()`, so the client doesn't need to
+    /// enumerate or pick. Returns `.notFound` when the user has no active
+    /// assistant yet (e.g. first-time login before hatch).
+    public func getActiveAssistant(organizationId: String) async throws -> PlatformAssistantResult {
+        let response = try await performPlatformRequest(
+            path: "v1/assistants/active/",
+            method: "GET",
+            organizationId: organizationId
+        )
+
+        switch response.statusCode {
+        case 404:
+            return .notFound
+        case 403:
+            return .accessDenied
+        case 401:
+            throw PlatformAPIError.authenticationRequired
+        case 200..<300:
+            do {
+                return .found(try JSONDecoder().decode(PlatformAssistant.self, from: response.data))
+            } catch {
+                throw PlatformAPIError.decodingError(error.localizedDescription)
+            }
+        default:
+            throw PlatformAPIError.serverError(
+                statusCode: response.statusCode,
+                detail: String(data: response.data, encoding: .utf8)
+            )
+        }
+    }
+
     /// List managed assistants visible to the caller in the given organization.
     ///
     /// Used by the multi-assistant bootstrap flow to discover existing assistants

--- a/clients/shared/App/Auth/AuthService.swift
+++ b/clients/shared/App/Auth/AuthService.swift
@@ -351,14 +351,14 @@ public final class AuthService {
 
     // MARK: - Platform Assistant API
 
-    /// Retrieve a specific managed assistant by ID.
-    public func getAssistant(id: String, organizationId: String) async throws -> PlatformAssistantResult {
-        let response = try await performPlatformRequest(
-            path: "v1/assistants/\(id)/",
-            method: "GET",
-            organizationId: organizationId
-        )
-
+    /// Map a platform assistant `GET` response into a `PlatformAssistantResult`.
+    ///
+    /// Shared by single-assistant lookup endpoints (`getAssistant`,
+    /// `getActiveAssistant`) that all use the same `.found` / `.notFound` /
+    /// `.accessDenied` status-code contract.
+    private func decodeAssistantResult(
+        _ response: PlatformResponse
+    ) throws -> PlatformAssistantResult {
         switch response.statusCode {
         case 404:
             return .notFound
@@ -380,6 +380,16 @@ public final class AuthService {
         }
     }
 
+    /// Retrieve a specific managed assistant by ID.
+    public func getAssistant(id: String, organizationId: String) async throws -> PlatformAssistantResult {
+        let response = try await performPlatformRequest(
+            path: "v1/assistants/\(id)/",
+            method: "GET",
+            organizationId: organizationId
+        )
+        return try decodeAssistantResult(response)
+    }
+
     /// Retrieve the user's currently active managed assistant for the given
     /// organization.
     ///
@@ -393,26 +403,7 @@ public final class AuthService {
             method: "GET",
             organizationId: organizationId
         )
-
-        switch response.statusCode {
-        case 404:
-            return .notFound
-        case 403:
-            return .accessDenied
-        case 401:
-            throw PlatformAPIError.authenticationRequired
-        case 200..<300:
-            do {
-                return .found(try JSONDecoder().decode(PlatformAssistant.self, from: response.data))
-            } catch {
-                throw PlatformAPIError.decodingError(error.localizedDescription)
-            }
-        default:
-            throw PlatformAPIError.serverError(
-                statusCode: response.statusCode,
-                detail: String(data: response.data, encoding: .utf8)
-            )
-        }
+        return try decodeAssistantResult(response)
     }
 
     /// List managed assistants visible to the caller in the given organization.

--- a/clients/shared/App/Auth/AuthService.swift
+++ b/clients/shared/App/Auth/AuthService.swift
@@ -392,11 +392,6 @@ public final class AuthService {
 
     /// Retrieve the user's currently active managed assistant for the given
     /// organization.
-    ///
-    /// The platform resolves the active assistant server-side via
-    /// `get_presumably_unique_assistant()`, so the client doesn't need to
-    /// enumerate or pick. Returns `.notFound` when the user has no active
-    /// assistant yet (e.g. first-time login before hatch).
     public func getActiveAssistant(organizationId: String) async throws -> PlatformAssistantResult {
         let response = try await performPlatformRequest(
             path: "v1/assistants/active/",

--- a/clients/shared/App/Auth/AuthService.swift
+++ b/clients/shared/App/Auth/AuthService.swift
@@ -390,8 +390,7 @@ public final class AuthService {
         return try decodeAssistantResult(response)
     }
 
-    /// Retrieve the user's currently active managed assistant for the given
-    /// organization.
+    /// Retrieve the user's currently active managed assistant.
     public func getActiveAssistant(organizationId: String) async throws -> PlatformAssistantResult {
         let response = try await performPlatformRequest(
             path: "v1/assistants/active/",


### PR DESCRIPTION
## Summary

- After login, iOS onboarding now asks the platform for the user's currently active assistant via `GET /v1/assistants/active/` before falling through to the bootstrap/hatch path. The platform resolves this server-side via `get_presumably_unique_assistant()`, so the client doesn't need to enumerate or pick.
- Adds `AuthService.getActiveAssistant(organizationId:)` and wires it into `OnboardingView.performManagedBootstrap()`. When the user belongs to a single org and the platform returns a found assistant, we short-circuit and use it; otherwise we fall through to `ensureManagedAssistant()` which hatches on iOS as a first-run fallback.
- Extracts `finalizeAssistantSelection(_:)` in `OnboardingView` to dedupe the persist + rebuild-client + advance-step logic across both code paths.

The iOS-specific active-lookup lives at the iOS call site rather than inside the shared `ManagedAssistantBootstrapService`, keeping that service's existing single responsibility (lockfile → `listAssistants` → hatch) intact. macOS behavior is unchanged.

## Test plan

- [x] `VellumAssistantShared` builds on iOS (`generic/platform=iOS`)
- [x] `VellumAssistantShared` builds on macOS (`generic/platform=macOS`)
- [x] `VellumAssistantIOS` builds on iOS Simulator (no-signing)
- [x] `ManagedAssistantBootstrapServiceTests` passes on macOS (5/5, no regressions)
- [ ] Manual: sign in on iOS as a single-org user who already has a hatched assistant → onboarding skips straight to Permissions without re-hatching
- [ ] Manual: sign in on iOS as a single-org user with no prior assistant → onboarding falls through to hatch (first-run UX unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24716" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
