### PR TITLE
refactor: resolve organization ID at auth time, not as bootstrap side effect

### DIFF
--- a/clients/macos/vellum-assistantTests/ManagedAssistantBootstrapServiceTests.swift
+++ b/clients/macos/vellum-assistantTests/ManagedAssistantBootstrapServiceTests.swift
@@ -214,10 +214,8 @@ private final class MockBootstrapAuthService: ManagedAssistantBootstrapAuthServi
         organizations
     }
 
-    // Mirrors `AuthService.resolveOrganizationId` — reads the persisted
-    // test value from UserDefaults, validates it against `organizations`,
-    // and falls back to the single-org case. Throws the same typed errors
-    // the bootstrap's private wrapper expects to translate.
+    // Mirrors `AuthService.resolveOrganizationId` so the bootstrap's
+    // error-translation layer gets exercised.
     func resolveOrganizationId() async throws -> String {
         let persisted = UserDefaults.standard.string(forKey: "connectedOrganizationId")
         if let persisted, organizations.contains(where: { $0.id == persisted }) {

--- a/clients/macos/vellum-assistantTests/ManagedAssistantBootstrapServiceTests.swift
+++ b/clients/macos/vellum-assistantTests/ManagedAssistantBootstrapServiceTests.swift
@@ -214,6 +214,27 @@ private final class MockBootstrapAuthService: ManagedAssistantBootstrapAuthServi
         organizations
     }
 
+    // Mirrors `AuthService.resolveOrganizationId` — reads the persisted
+    // test value from UserDefaults, validates it against `organizations`,
+    // and falls back to the single-org case. Throws the same typed errors
+    // the bootstrap's private wrapper expects to translate.
+    func resolveOrganizationId() async throws -> String {
+        let persisted = UserDefaults.standard.string(forKey: "connectedOrganizationId")
+        if let persisted, organizations.contains(where: { $0.id == persisted }) {
+            return persisted
+        }
+        switch organizations.count {
+        case 0:
+            throw AuthService.OrganizationResolutionError.noOrganizations
+        case 1:
+            let orgId = organizations[0].id
+            UserDefaults.standard.set(orgId, forKey: "connectedOrganizationId")
+            return orgId
+        default:
+            throw AuthService.OrganizationResolutionError.multipleOrganizations
+        }
+    }
+
     func getAssistant(id: String, organizationId: String) async throws -> PlatformAssistantResult {
         getAssistantCallCount += 1
         return getAssistantResult

--- a/clients/shared/App/Auth/AuthManager.swift
+++ b/clients/shared/App/Auth/AuthManager.swift
@@ -60,6 +60,7 @@ public final class AuthManager {
                 let response = try await authService.getSession(timeout: 10)
                 if response.status == 200, response.meta?.is_authenticated != false, let user = response.data?.user {
                     state = .authenticated(user)
+                    await resolveOrganizationIdAfterAuth()
                     return
                 } else {
                     // Server responded but session is invalid — no retry needed
@@ -164,12 +165,14 @@ public final class AuthManager {
                 if let user = response.data?.user {
                     state = .authenticated(user)
                     log.info("WorkOS login completed from provider-token response for user \(user.id ?? user.email ?? "unknown", privacy: .public)")
+                    await resolveOrganizationIdAfterAuth()
                 } else {
                     log.info("Provider-token auth returned no user payload; validating session via auth/session")
                     let session = try await authService.getSession()
                     if session.status == 200, session.meta?.is_authenticated != false, let user = session.data?.user {
                         state = .authenticated(user)
                         log.info("WorkOS login completed after session revalidation for user \(user.id ?? user.email ?? "unknown", privacy: .public)")
+                        await resolveOrganizationIdAfterAuth()
                     } else {
                         log.error(
                             "Session revalidation after provider-token auth did not return an authenticated user. status=\(session.status, privacy: .public) isAuthenticated=\(session.meta?.is_authenticated == true, privacy: .public) hasUser=\(session.data?.user != nil, privacy: .public)"
@@ -220,6 +223,25 @@ public final class AuthManager {
         UserDefaults.standard.removeObject(forKey: "managed_platform_base_url")
         state = .unauthenticated
         return logoutError
+    }
+
+    /// Best-effort org resolution after a successful authentication.
+    ///
+    /// Called from every `state = .authenticated(user)` transition so
+    /// downstream clients (billing, gateway, OAuth, migration) can read
+    /// `connectedOrganizationId` from `UserDefaults` without each caller
+    /// having to trigger resolution as a side effect of some other flow.
+    ///
+    /// Failures are logged and swallowed — a transient network error here
+    /// must not prevent the user from being considered authenticated, and
+    /// the bootstrap paths will retry resolution if `UserDefaults` is still
+    /// empty by the time they run.
+    private func resolveOrganizationIdAfterAuth() async {
+        do {
+            _ = try await authService.resolveOrganizationId()
+        } catch {
+            log.warning("Failed to resolve organization ID post-auth: \(error.localizedDescription, privacy: .public)")
+        }
     }
 
     private func generateCodeVerifier() -> String {

--- a/clients/shared/App/Auth/AuthManager.swift
+++ b/clients/shared/App/Auth/AuthManager.swift
@@ -226,16 +226,8 @@ public final class AuthManager {
     }
 
     /// Best-effort org resolution after a successful authentication.
-    ///
-    /// Called from every `state = .authenticated(user)` transition so
-    /// downstream clients (billing, gateway, OAuth, migration) can read
-    /// `connectedOrganizationId` from `UserDefaults` without each caller
-    /// having to trigger resolution as a side effect of some other flow.
-    ///
-    /// Failures are logged and swallowed — a transient network error here
-    /// must not prevent the user from being considered authenticated, and
-    /// the bootstrap paths will retry resolution if `UserDefaults` is still
-    /// empty by the time they run.
+    /// Failures are logged, not thrown: a transient network error here
+    /// must not block the transition to `.authenticated`.
     private func resolveOrganizationIdAfterAuth() async {
         do {
             _ = try await authService.resolveOrganizationId()

--- a/clients/shared/App/Auth/AuthService.swift
+++ b/clients/shared/App/Auth/AuthService.swift
@@ -221,6 +221,60 @@ public final class AuthService {
         }
     }
 
+    /// Typed errors raised by `resolveOrganizationId()` when the user's org
+    /// list can't be narrowed to a single organization.
+    public enum OrganizationResolutionError: LocalizedError, Sendable {
+        case noOrganizations
+        case multipleOrganizations
+
+        public var errorDescription: String? {
+            switch self {
+            case .noOrganizations:
+                return "No organizations found for this account"
+            case .multipleOrganizations:
+                return "Multiple organizations found. Multi-org support is not yet available — please contact support."
+            }
+        }
+    }
+
+    /// Resolve the caller's organization ID, persisting the result in
+    /// `UserDefaults` under `connectedOrganizationId` so downstream clients
+    /// (billing, gateway, OAuth, migration) can read it synchronously.
+    ///
+    /// Behavior:
+    /// - Fetches the authenticated user's organization list.
+    /// - If a persisted `connectedOrganizationId` is still present in that
+    ///   list, returns it (validates cache against current server state so
+    ///   stale cross-environment IDs don't leak through).
+    /// - Otherwise, for the single-org case, persists and returns the one
+    ///   org's ID.
+    /// - Throws `OrganizationResolutionError.noOrganizations` for 0 orgs and
+    ///   `.multipleOrganizations` for >1 (multi-org is not yet supported).
+    /// - Network / auth failures surface as `PlatformAPIError`.
+    @discardableResult
+    public func resolveOrganizationId() async throws -> String {
+        let orgs = try await getOrganizations()
+        let persistedOrgId = UserDefaults.standard.string(forKey: "connectedOrganizationId")
+        if let persistedOrgId, orgs.contains(where: { $0.id == persistedOrgId }) {
+            log.info("Validated persisted organization: \(persistedOrgId, privacy: .public)")
+            return persistedOrgId
+        }
+        if persistedOrgId != nil {
+            log.warning("Persisted organization ID not found in user's orgs — re-resolving")
+        }
+        switch orgs.count {
+        case 0:
+            throw OrganizationResolutionError.noOrganizations
+        case 1:
+            let orgId = orgs[0].id
+            UserDefaults.standard.set(orgId, forKey: "connectedOrganizationId")
+            log.info("Resolved organization: \(orgId, privacy: .public)")
+            return orgId
+        default:
+            throw OrganizationResolutionError.multipleOrganizations
+        }
+    }
+
     // MARK: - Platform Request Helper
 
     /// Raw result of a platform HTTP request — status code + body data.

--- a/clients/shared/App/Auth/AuthService.swift
+++ b/clients/shared/App/Auth/AuthService.swift
@@ -221,8 +221,6 @@ public final class AuthService {
         }
     }
 
-    /// Typed errors raised by `resolveOrganizationId()` when the user's org
-    /// list can't be narrowed to a single organization.
     public enum OrganizationResolutionError: LocalizedError, Sendable {
         case noOrganizations
         case multipleOrganizations
@@ -237,20 +235,11 @@ public final class AuthService {
         }
     }
 
-    /// Resolve the caller's organization ID, persisting the result in
-    /// `UserDefaults` under `connectedOrganizationId` so downstream clients
-    /// (billing, gateway, OAuth, migration) can read it synchronously.
+    /// Resolve the caller's organization ID, persisting it under
+    /// `connectedOrganizationId` in UserDefaults for synchronous readers.
     ///
-    /// Behavior:
-    /// - Fetches the authenticated user's organization list.
-    /// - If a persisted `connectedOrganizationId` is still present in that
-    ///   list, returns it (validates cache against current server state so
-    ///   stale cross-environment IDs don't leak through).
-    /// - Otherwise, for the single-org case, persists and returns the one
-    ///   org's ID.
-    /// - Throws `OrganizationResolutionError.noOrganizations` for 0 orgs and
-    ///   `.multipleOrganizations` for >1 (multi-org is not yet supported).
-    /// - Network / auth failures surface as `PlatformAPIError`.
+    /// A persisted value is re-validated against the current org list on
+    /// every call so stale cross-environment IDs don't leak through.
     @discardableResult
     public func resolveOrganizationId() async throws -> String {
         let orgs = try await getOrganizations()

--- a/clients/shared/App/Auth/ManagedAssistantBootstrapService.swift
+++ b/clients/shared/App/Auth/ManagedAssistantBootstrapService.swift
@@ -247,10 +247,9 @@ public final class ManagedAssistantBootstrapService {
         log.warning("Provisioning poll timed out for \(assistantId, privacy: .public) after \(timeout)s — proceeding to health check")
     }
 
-    /// Resolve the organization ID, delegating to `AuthService.resolveOrganizationId()`
-    /// so that `AuthManager` (post-login) and bootstrap share a single
-    /// validator/persister. Translates `AuthService` errors into the bootstrap's
-    /// typed `ManagedBootstrapError` shape so UI surfaces the right message.
+    /// Adapts `AuthService.resolveOrganizationId()` errors into the
+    /// bootstrap's `ManagedBootstrapError` shape so existing UI messages
+    /// keep working.
     private func resolveOrganizationId() async throws -> String {
         do {
             return try await authService.resolveOrganizationId()

--- a/clients/shared/App/Auth/ManagedAssistantBootstrapService.swift
+++ b/clients/shared/App/Auth/ManagedAssistantBootstrapService.swift
@@ -44,6 +44,7 @@ public enum ManagedBootstrapError: LocalizedError, Sendable {
 @MainActor
 public protocol ManagedAssistantBootstrapAuthServicing: AnyObject {
     func getOrganizations() async throws -> [PlatformOrganization]
+    func resolveOrganizationId() async throws -> String
     func getAssistant(id: String, organizationId: String) async throws -> PlatformAssistantResult
     func listAssistants(organizationId: String) async throws -> [PlatformAssistant]
     func hatchAssistant(
@@ -246,30 +247,17 @@ public final class ManagedAssistantBootstrapService {
         log.warning("Provisioning poll timed out for \(assistantId, privacy: .public) after \(timeout)s — proceeding to health check")
     }
 
-    /// Resolve the organization ID, validating any persisted value against the
-    /// user's actual org list to prevent stale cross-environment IDs.
+    /// Resolve the organization ID, delegating to `AuthService.resolveOrganizationId()`
+    /// so that `AuthManager` (post-login) and bootstrap share a single
+    /// validator/persister. Translates `AuthService` errors into the bootstrap's
+    /// typed `ManagedBootstrapError` shape so UI surfaces the right message.
     private func resolveOrganizationId() async throws -> String {
         do {
-            let orgs = try await authService.getOrganizations()
-            let persistedOrgId = UserDefaults.standard.string(forKey: "connectedOrganizationId")
-            if let persistedOrgId, orgs.contains(where: { $0.id == persistedOrgId }) {
-                log.info("Validated persisted organization: \(persistedOrgId, privacy: .public)")
-                return persistedOrgId
-            }
-            if persistedOrgId != nil {
-                log.warning("Persisted organization ID not found in user's orgs — re-resolving")
-            }
-            switch orgs.count {
-            case 0:
-                throw ManagedBootstrapError.serverError(statusCode: 0, detail: "No organizations found for this account")
-            case 1:
-                let orgId = orgs[0].id
-                UserDefaults.standard.set(orgId, forKey: "connectedOrganizationId")
-                log.info("Resolved organization: \(orgId, privacy: .public)")
-                return orgId
-            default:
-                throw ManagedBootstrapError.multipleOrganizations
-            }
+            return try await authService.resolveOrganizationId()
+        } catch AuthService.OrganizationResolutionError.noOrganizations {
+            throw ManagedBootstrapError.serverError(statusCode: 0, detail: "No organizations found for this account")
+        } catch AuthService.OrganizationResolutionError.multipleOrganizations {
+            throw ManagedBootstrapError.multipleOrganizations
         } catch let error as PlatformAPIError {
             throw mapPlatformError(error)
         }


### PR DESCRIPTION
## Summary

Move organization-ID resolution out of `ManagedAssistantBootstrapService` and into `AuthManager`, where it belongs. The persistence side effect used to live inside `ensureManagedAssistant()`, which meant every downstream caller of `connectedOrganizationId` (billing, gateway, OAuth, migration) implicitly depended on bootstrap having run first. Any code path that reached those clients without first triggering bootstrap would hit missing or stale org headers.

## Changes

- **New**: `AuthService.resolveOrganizationId()` — public, reusable validator/persister lifted verbatim from the bootstrap's private copy. Throws a typed `OrganizationResolutionError` (`.noOrganizations`, `.multipleOrganizations`) for the org-count edge cases.
- **New**: `AuthManager.resolveOrganizationIdAfterAuth()` — best-effort helper called immediately after every `state = .authenticated(user)` transition (three sites: one in `checkSession`, two in `startWorkOSLogin`). Failures are logged but do not block the auth state; the bootstrap's retry path still catches the error if the persisted value is still missing by then.
- **Refactor**: `ManagedAssistantBootstrapService.resolveOrganizationId()` is now a thin wrapper that delegates to `authService.resolveOrganizationId()` and translates the typed errors into the existing `ManagedBootstrapError` shape so UI error messages don't change. Net ~16 lines removed from the private copy.
- **Protocol**: `ManagedAssistantBootstrapAuthServicing` gains `resolveOrganizationId()` so the existing DI/mock pattern still works. The test mock mirrors the real semantics against its in-memory `organizations` list.

## Why

Before this refactor, the `connectedOrganizationId` UserDefaults key had exactly one writer on the non-macOS path: a *private* method inside the bootstrap service. That's the wrong place for it. Org resolution is a user/session-level concern, not an assistant-bootstrap concern, and naming it explicitly in `AuthManager` makes the "when does this happen?" answer obvious: right after login.

This also unblocks follow-up work (e.g. emmie/ios-get-active-assistant on PR #24716) where iOS may hit `getActiveAssistant` directly without going through `ensureManagedAssistant` — without this refactor, that path would fail to populate `connectedOrganizationId` and subsequent managed requests would ship bad org headers.

## Tradeoff

`checkSession()` now makes one extra `getOrganizations()` call on every cold-start session restore. This is strictly an addition to cold-start network traffic, but it's required for the freshness validation (catches stale cross-environment IDs), which is exactly what the old bootstrap resolver was also doing on every call.

## Test plan

- [x] `VellumAssistantShared` builds clean on iOS (`generic/platform=iOS`)
- [x] `VellumAssistantShared` builds clean on macOS (`generic/platform=macOS`)
- [x] `ManagedAssistantBootstrapServiceTests`: 5/5 passing (unchanged assertions, new mock method for `resolveOrganizationId`)
- [ ] Manual: sign in fresh on macOS → `connectedOrganizationId` appears in UserDefaults before the assistant bootstrap runs
- [ ] Manual: cold-start with a saved session → `connectedOrganizationId` is re-validated (stale cross-environment IDs should be corrected, not silently reused)
- [ ] Manual: simulate a flaky network during login → auth state still transitions to `.authenticated` and the warning log fires, rather than wedging the user out

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24717" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
