### PR TITLE
fix(agent): rescale images by dimension, not just byte size

### DIFF
--- a/assistant/src/__tests__/agent-image-optimize.test.ts
+++ b/assistant/src/__tests__/agent-image-optimize.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "bun:test";
+
+import { shouldRescaleImage } from "../agent/image-optimize.js";
+
+describe("shouldRescaleImage", () => {
+  it("rescales when any side exceeds the max dimension, regardless of file size", () => {
+    // Regression: a sparse screenshot can be tiny in bytes but 3000+ px wide,
+    // which Anthropic rejects in many-image requests with a 2000 px cap.
+    expect(shouldRescaleImage({ width: 3000, height: 900 }, 50_000)).toBe(true);
+    expect(shouldRescaleImage({ width: 900, height: 3000 }, 50_000)).toBe(true);
+  });
+
+  it("skips rescale when dimensions are known and within limits", () => {
+    expect(shouldRescaleImage({ width: 1200, height: 800 }, 50_000)).toBe(
+      false,
+    );
+    // Even a large file is fine as long as dimensions are within limits —
+    // Anthropic's constraint is per-side pixels, not bytes.
+    expect(shouldRescaleImage({ width: 1568, height: 1568 }, 5_000_000)).toBe(
+      false,
+    );
+  });
+
+  it("falls back to file size when dimensions are unparseable", () => {
+    expect(shouldRescaleImage(null, 50_000)).toBe(false);
+    expect(shouldRescaleImage(null, 5_000_000)).toBe(true);
+  });
+});

--- a/assistant/src/agent/image-optimize.ts
+++ b/assistant/src/agent/image-optimize.ts
@@ -127,24 +127,36 @@ function runSips(inputBytes: Buffer): Buffer | null {
  * Results are cached on disk by content hash so repeated sends of the same
  * image (or daemon restarts) skip the sips call entirely.
  */
+/**
+ * Decide whether an image needs to be rescaled before sending.
+ *
+ * Anthropic rejects many-image requests when any image exceeds 2000 px on a
+ * side, so dimensions — not file size — are the authoritative gate. A sparse
+ * screenshot can be under 300 KB while still being 3000+ px wide, which the
+ * byte-size heuristic alone would let slip through.
+ *
+ * Exported for unit testing.
+ */
+export function shouldRescaleImage(
+  dims: { width: number; height: number } | null,
+  byteLength: number,
+): boolean {
+  if (dims) {
+    // Dimensions known — they are the authoritative check.
+    return dims.width > MAX_DIMENSION || dims.height > MAX_DIMENSION;
+  }
+  // Dimensions unparseable — fall back to file size as a rough proxy.
+  return byteLength > OPTIMIZE_THRESHOLD_BYTES;
+}
+
 export function optimizeImageForTransport(
   base64Data: string,
   mediaType: string,
 ): { data: string; mediaType: string } {
   const rawBytes = Buffer.from(base64Data, "base64");
-
-  // Small images don't need optimization.
-  if (rawBytes.length <= OPTIMIZE_THRESHOLD_BYTES) {
-    return { data: base64Data, mediaType };
-  }
-
-  // If dimensions are already within limits, skip.
   const dims = parseImageDimensions(base64Data, mediaType);
-  if (
-    dims &&
-    dims.width <= MAX_DIMENSION &&
-    dims.height <= MAX_DIMENSION
-  ) {
+
+  if (!shouldRescaleImage(dims, rawBytes.length)) {
     return { data: base64Data, mediaType };
   }
 


### PR DESCRIPTION
## Summary
- Rescale images based on dimensions (not file size) so small-byte but large-pixel screenshots can't slip through and fail Anthropic's 2000 px many-image cap.
- Extract the gate into a `shouldRescaleImage` helper and add a unit test covering the regression.

## Original prompt
it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24718" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
