### PR TITLE
feat(macos): decode optional groupId on usage breakdown entries

### DIFF
--- a/clients/macos/vellum-assistantTests/UsageDashboardPanelTests.swift
+++ b/clients/macos/vellum-assistantTests/UsageDashboardPanelTests.swift
@@ -220,6 +220,57 @@ struct UsageTabContentPopulatedTests {
     }
 }
 
+@Suite("UsageGroupBreakdownEntry — groupId decoding")
+struct UsageGroupBreakdownEntryGroupIdDecodingTests {
+
+    @Test
+    func decodesGroupIdWhenPresent() throws {
+        let json = """
+        {
+            "breakdown": [
+                {
+                    "group": "Conversation about SwiftUI",
+                    "groupId": "conv_abc",
+                    "totalInputTokens": 1000,
+                    "totalOutputTokens": 500,
+                    "totalCacheCreationTokens": 0,
+                    "totalCacheReadTokens": 0,
+                    "totalEstimatedCostUsd": 0.05,
+                    "eventCount": 3
+                }
+            ]
+        }
+        """.data(using: .utf8)!
+
+        let decoded = try JSONDecoder().decode(UsageBreakdownResponse.self, from: json)
+        #expect(decoded.breakdown.first?.groupId == "conv_abc")
+        #expect(decoded.breakdown.first?.group == "Conversation about SwiftUI")
+    }
+
+    @Test
+    func decodesLegacyJSONWithoutGroupId() throws {
+        let json = """
+        {
+            "breakdown": [
+                {
+                    "group": "claude-sonnet-4-20250514",
+                    "totalInputTokens": 1000,
+                    "totalOutputTokens": 500,
+                    "totalCacheCreationTokens": 0,
+                    "totalCacheReadTokens": 0,
+                    "totalEstimatedCostUsd": 0.05,
+                    "eventCount": 3
+                }
+            ]
+        }
+        """.data(using: .utf8)!
+
+        let decoded = try JSONDecoder().decode(UsageBreakdownResponse.self, from: json)
+        #expect(decoded.breakdown.first?.groupId == nil)
+        #expect(decoded.breakdown.first?.group == "claude-sonnet-4-20250514")
+    }
+}
+
 // MARK: - View Content Helper
 
 /// Dumps the tab's section view trees so that all Text content is captured

--- a/clients/shared/Network/UsageModels.swift
+++ b/clients/shared/Network/UsageModels.swift
@@ -63,6 +63,7 @@ public struct UsageDailyResponse: Decodable, Equatable, Sendable {
 /// A single grouped breakdown row from `GET /v1/usage/breakdown`.
 public struct UsageGroupBreakdownEntry: Decodable, Equatable, Sendable {
     public let group: String
+    public let groupId: String?
     public let totalInputTokens: Int
     public let totalOutputTokens: Int
     public let totalCacheCreationTokens: Int
@@ -72,6 +73,7 @@ public struct UsageGroupBreakdownEntry: Decodable, Equatable, Sendable {
 
     public init(
         group: String,
+        groupId: String? = nil,
         totalInputTokens: Int,
         totalOutputTokens: Int,
         totalCacheCreationTokens: Int = 0,
@@ -80,6 +82,7 @@ public struct UsageGroupBreakdownEntry: Decodable, Equatable, Sendable {
         eventCount: Int
     ) {
         self.group = group
+        self.groupId = groupId
         self.totalInputTokens = totalInputTokens
         self.totalOutputTokens = totalOutputTokens
         self.totalCacheCreationTokens = totalCacheCreationTokens
@@ -90,6 +93,7 @@ public struct UsageGroupBreakdownEntry: Decodable, Equatable, Sendable {
 
     private enum CodingKeys: String, CodingKey {
         case group
+        case groupId
         case totalInputTokens
         case totalOutputTokens
         case totalCacheCreationTokens
@@ -101,6 +105,7 @@ public struct UsageGroupBreakdownEntry: Decodable, Equatable, Sendable {
     public init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         group = try container.decode(String.self, forKey: .group)
+        groupId = try container.decodeIfPresent(String.self, forKey: .groupId)
         totalInputTokens = try container.decode(Int.self, forKey: .totalInputTokens)
         totalOutputTokens = try container.decode(Int.self, forKey: .totalOutputTokens)
         totalCacheCreationTokens = try container.decodeIfPresent(Int.self, forKey: .totalCacheCreationTokens) ?? 0


### PR DESCRIPTION
## Summary
- Add optional `groupId` property to `UsageGroupBreakdownEntry`
- Decode via `decodeIfPresent` so older daemons that don't emit the field still decode cleanly
- Add Swift decoding tests for both the new and legacy JSON shapes

Part of plan: usage-conv-links.md (PR 2 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24719" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
