### PR TITLE
feat(macos): thread onSelectConversation closure through Logs & Usage panel

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -42,7 +42,14 @@ extension MainWindowView {
                 connectionManager: connectionManager,
                 activeSessionId: conversationManager.activeViewModel?.conversationId,
                 usageDashboardStore: usageDashboardStore,
-                onClose: { windowState.selection = nil }
+                onClose: { windowState.selection = nil },
+                onSelectConversation: { conversationId in
+                    Task { @MainActor in
+                        let found = await conversationManager.selectConversationByConversationIdAsync(conversationId)
+                        guard found, let id = conversationManager.activeConversationId else { return }
+                        windowState.selection = .conversation(id)
+                    }
+                }
             )
         case .generated:
             GeneratedPanel(
@@ -507,7 +514,14 @@ extension MainWindowView {
                 connectionManager: connectionManager,
                 activeSessionId: conversationManager.activeViewModel?.conversationId,
                 usageDashboardStore: usageDashboardStore,
-                onClose: { windowState.dismissOverlay() }
+                onClose: { windowState.dismissOverlay() },
+                onSelectConversation: { conversationId in
+                    Task { @MainActor in
+                        let found = await conversationManager.selectConversationByConversationIdAsync(conversationId)
+                        guard found, let id = conversationManager.activeConversationId else { return }
+                        windowState.selection = .conversation(id)
+                    }
+                }
             )
         case .avatarCustomization:
             AvatarCustomizationPanel(onClose: { windowState.selection = .panel(windowState.avatarCustomizationReturnPanel) })

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/LogsAndUsagePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/LogsAndUsagePanel.swift
@@ -22,6 +22,7 @@ struct LogsAndUsagePanel: View {
     let activeSessionId: String?
     let usageDashboardStore: UsageDashboardStore
     var onClose: () -> Void
+    var onSelectConversation: (String) -> Void
 
     @State private var selectedTab: LogsAndUsageTab = .logs
 
@@ -97,7 +98,7 @@ struct LogsAndUsagePanel: View {
                 activeSessionId: activeSessionId
             )
         case .usage:
-            UsageTabContent(store: usageDashboardStore)
+            UsageTabContent(store: usageDashboardStore, onSelectConversation: onSelectConversation)
         }
     }
 }
@@ -301,6 +302,7 @@ struct LogsTabContent: View {
 @MainActor
 struct UsageTabContent: View {
     let store: UsageDashboardStore
+    let onSelectConversation: (String) -> Void
 
     @State private var refreshTask: Task<Void, Never>?
     @State private var breakdownTask: Task<Void, Never>?


### PR DESCRIPTION
## Summary
- Add `onSelectConversation: (String) -> Void` to `LogsAndUsagePanel` and `UsageTabContent`
- Wire real navigation via `ConversationManager.selectConversationByConversationIdAsync` in both `PanelCoordinator` call sites (closure is latent until PR 4 makes `breakdownRow` interactive)

Part of plan: usage-conv-links.md (PR 3 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24720" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
