### PR TITLE
feat(usage): return groupId in conversation breakdown rows

### DIFF
--- a/assistant/src/__tests__/llm-usage-store.test.ts
+++ b/assistant/src/__tests__/llm-usage-store.test.ts
@@ -453,6 +453,7 @@ describe("getUsageGroupBreakdown", () => {
   beforeEach(() => {
     const db = getDb();
     db.run(`DELETE FROM llm_usage_events`);
+    db.run(`DELETE FROM conversations`);
   });
 
   test("returns empty array when no events exist", () => {
@@ -598,6 +599,81 @@ describe("getUsageGroupBreakdown", () => {
     expect(groups[0].group).toBe("title_generator");
     expect(groups[1].group).toBe("context_compactor");
     expect(groups[2].group).toBe("main_agent");
+  });
+
+  test("returns groupId matching the seeded conversation id when grouping by conversation", () => {
+    const db = getDb();
+    const conversationId = "conv-breakdown-1";
+    const now = Date.now();
+    db.run(
+      `INSERT INTO conversations (id, title, created_at, updated_at) VALUES ('${conversationId}', 'Debug session', ${now}, ${now})`,
+    );
+
+    insertEventAt(
+      1000,
+      { conversationId, inputTokens: 100, outputTokens: 50 },
+      { estimatedCostUsd: 0.02, pricingStatus: "priced" },
+    );
+    insertEventAt(
+      2000,
+      { conversationId, inputTokens: 200, outputTokens: 75 },
+      { estimatedCostUsd: 0.03, pricingStatus: "priced" },
+    );
+
+    const groups = getUsageGroupBreakdown(
+      { from: 0, to: 5000 },
+      "conversation",
+    );
+    expect(groups).toHaveLength(1);
+    expect(groups[0].group).toBe("Debug session");
+    expect(groups[0].groupId).toBe(conversationId);
+    expect(groups[0].totalInputTokens).toBe(300);
+    expect(groups[0].totalOutputTokens).toBe(125);
+    expect(groups[0].totalEstimatedCostUsd).toBeCloseTo(0.05);
+    expect(groups[0].eventCount).toBe(2);
+  });
+
+  test("returns groupId null for the Other bucket when grouping by conversation and events have no conversation id", () => {
+    insertEventAt(
+      1000,
+      { conversationId: null, inputTokens: 100 },
+      { estimatedCostUsd: 0.01, pricingStatus: "priced" },
+    );
+    insertEventAt(
+      2000,
+      { conversationId: null, inputTokens: 200 },
+      { estimatedCostUsd: 0.02, pricingStatus: "priced" },
+    );
+
+    const groups = getUsageGroupBreakdown(
+      { from: 0, to: 5000 },
+      "conversation",
+    );
+    expect(groups).toHaveLength(1);
+    expect(groups[0].group).toBe("Other");
+    expect(groups[0].groupId).toBeNull();
+    expect(groups[0].totalInputTokens).toBe(300);
+    expect(groups[0].eventCount).toBe(2);
+  });
+
+  test("returns groupId null for every row when grouping by a non-conversation dimension", () => {
+    insertEventAt(
+      1000,
+      { model: "claude-sonnet-4-20250514", conversationId: "conv-a" },
+      { estimatedCostUsd: 0.03, pricingStatus: "priced" },
+    );
+    insertEventAt(
+      2000,
+      { model: "claude-sonnet-4-20250514", conversationId: "conv-b" },
+      { estimatedCostUsd: 0.02, pricingStatus: "priced" },
+    );
+    insertEventAt(3000, { model: "llama3" }, unpricedResult);
+
+    const groups = getUsageGroupBreakdown({ from: 0, to: 5000 }, "model");
+    expect(groups.length).toBeGreaterThan(0);
+    for (const row of groups) {
+      expect(row.groupId).toBeNull();
+    }
   });
 });
 

--- a/assistant/src/memory/llm-usage-store.ts
+++ b/assistant/src/memory/llm-usage-store.ts
@@ -164,6 +164,14 @@ export interface UsageDayBucket {
 /** A grouped breakdown row (by actor, provider, or model). */
 export interface UsageGroupBreakdown {
   group: string;
+  /**
+   * Stable identifier for the group. Populated with the conversation id when
+   * `groupBy === "conversation"` (and `null` for that mode's "Other" bucket,
+   * which aggregates events with no conversation id). For all other group-bys
+   * (`actor`, `provider`, `model`) this is always `null` — the raw grouping
+   * column is already exposed via `group`.
+   */
+  groupId: string | null;
   /** Direct input tokens only; cache traffic is reported separately below. */
   totalInputTokens: number;
   totalOutputTokens: number;
@@ -196,6 +204,7 @@ interface DayBucketRow {
 
 interface GroupRow {
   group_key: string;
+  group_id: string | null;
   total_input_tokens: number;
   total_output_tokens: number;
   total_cache_creation_tokens: number;
@@ -330,6 +339,7 @@ export function getUsageGroupBreakdown(
         CASE WHEN e.conversation_id IS NULL THEN 'Other'
              ELSE COALESCE(c.title, 'Untitled')
         END AS group_key,
+        e.conversation_id                                AS group_id,
         COALESCE(SUM(e.input_tokens), 0)                 AS total_input_tokens,
         COALESCE(SUM(e.output_tokens), 0)                AS total_output_tokens,
         COALESCE(SUM(e.cache_creation_input_tokens), 0)  AS total_cache_creation_tokens,
@@ -348,6 +358,10 @@ export function getUsageGroupBreakdown(
     );
     return rows.map((r) => ({
       group: r.group_key,
+      // `GROUP BY e.conversation_id` makes `e.conversation_id` unambiguous
+      // inside each group — it is the seeded conversation id for real rows
+      // and `null` for the "Other" bucket (events with no conversation).
+      groupId: r.group_id,
       totalInputTokens: r.total_input_tokens,
       totalOutputTokens: r.total_output_tokens,
       totalCacheCreationTokens: r.total_cache_creation_tokens,
@@ -378,6 +392,10 @@ export function getUsageGroupBreakdown(
   );
   return rows.map((r) => ({
     group: r.group_key,
+    // Non-conversation group-bys (actor/provider/model) don't have a
+    // separate stable id — the grouping column itself is the identifier
+    // and is already exposed via `group`.
+    groupId: null,
     totalInputTokens: r.total_input_tokens,
     totalOutputTokens: r.total_output_tokens,
     totalCacheCreationTokens: r.total_cache_creation_tokens,


### PR DESCRIPTION
## Summary
- Surface `conversation_id` as `groupId` on `getUsageGroupBreakdown` results when grouping by conversation
- Return `groupId: null` for the "Other" bucket and all non-conversation group-bys
- Add unit tests covering conversation, null-conversation, and non-conversation paths

Part of plan: usage-conv-links.md (PR 1 of 4)