### PR TITLE
fix(usage): respect user timezone in Hourly/Daily Trend charts

### DIFF
--- a/assistant/src/__tests__/llm-usage-store.test.ts
+++ b/assistant/src/__tests__/llm-usage-store.test.ts
@@ -11,6 +11,7 @@ import { getDb, initializeDb } from "../memory/db.js";
 import {
   getUsageDayBuckets,
   getUsageGroupBreakdown,
+  getUsageHourBuckets,
   getUsageTotals,
   listUsageEvents,
   queryUnreportedUsageEvents,
@@ -446,6 +447,220 @@ describe("getUsageDayBuckets", () => {
     expect(buckets).toHaveLength(1);
     expect(buckets[0].totalEstimatedCostUsd).toBeCloseTo(0.05);
     expect(buckets[0].eventCount).toBe(2);
+  });
+});
+
+describe("getUsageDayBuckets — timezone-aware", () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run(`DELETE FROM llm_usage_events`);
+  });
+
+  test("integer offset: anchors daily buckets to local midnight", () => {
+    // 2026-04-10T22:30:00Z is 15:30 PDT (UTC-7) on 2026-04-10.
+    // 2026-04-11T06:30:00Z is 23:30 PDT on 2026-04-10 (same local day).
+    insertEventAt(Date.UTC(2026, 3, 10, 22, 30), { inputTokens: 100 });
+    insertEventAt(Date.UTC(2026, 3, 11, 6, 30), { inputTokens: 200 });
+    // 2026-04-11T08:00:00Z is 01:00 PDT on 2026-04-11 (next local day).
+    insertEventAt(Date.UTC(2026, 3, 11, 8, 0), { inputTokens: 400 });
+
+    const buckets = getUsageDayBuckets(
+      { from: Date.UTC(2026, 3, 10, 0), to: Date.UTC(2026, 3, 12, 0) },
+      "America/Los_Angeles",
+    );
+
+    expect(buckets.map((b) => b.date)).toEqual(["2026-04-10", "2026-04-11"]);
+    expect(buckets[0].totalInputTokens).toBe(300);
+    expect(buckets[1].totalInputTokens).toBe(400);
+    expect(buckets[0].displayLabel).toBeDefined();
+    expect(buckets[1].displayLabel).toBeDefined();
+  });
+
+  test("fractional offset: anchors daily buckets to local midnight in IST", () => {
+    // Asia/Kolkata is UTC+5:30. Local midnight April 10 IST = 18:30 UTC April 9.
+    // Event at 18:31 UTC April 9 = 00:01 IST April 10.
+    // Event at 18:29 UTC April 9 = 23:59 IST April 9.
+    insertEventAt(Date.UTC(2026, 3, 9, 18, 31), { inputTokens: 100 });
+    insertEventAt(Date.UTC(2026, 3, 9, 18, 29), { inputTokens: 50 });
+
+    const buckets = getUsageDayBuckets(
+      { from: Date.UTC(2026, 3, 9, 0), to: Date.UTC(2026, 3, 10, 23) },
+      "Asia/Kolkata",
+    );
+
+    // The 18:31 UTC event should land on 2026-04-10 IST, the 18:29 UTC event
+    // on 2026-04-09 IST.
+    const map = Object.fromEntries(buckets.map((b) => [b.date, b]));
+    expect(map["2026-04-09"]?.totalInputTokens).toBe(50);
+    expect(map["2026-04-10"]?.totalInputTokens).toBe(100);
+  });
+
+  test("backwards compat: default tz is UTC", () => {
+    insertEventAt(Date.UTC(2025, 5, 1, 0, 0), { inputTokens: 111 });
+    insertEventAt(Date.UTC(2025, 5, 1, 23, 59), { inputTokens: 222 });
+    insertEventAt(Date.UTC(2025, 5, 2, 0, 0), { inputTokens: 333 });
+
+    const buckets = getUsageDayBuckets({
+      from: Date.UTC(2025, 5, 1, 0),
+      to: Date.UTC(2025, 5, 2, 12),
+    });
+
+    expect(buckets.map((b) => b.date)).toEqual(["2025-06-01", "2025-06-02"]);
+    expect(buckets[0].totalInputTokens).toBe(333); // 111 + 222
+    expect(buckets[1].totalInputTokens).toBe(333);
+  });
+
+  test("throws on invalid timezone identifier", () => {
+    expect(() =>
+      getUsageDayBuckets({ from: 0, to: 1000 }, "Not/A/Real/Zone"),
+    ).toThrow(/Invalid IANA timezone identifier/);
+  });
+
+  test("fillEmpty seeds zero buckets for empty days", () => {
+    insertEventAt(Date.UTC(2026, 3, 10, 12), { inputTokens: 100 });
+    insertEventAt(Date.UTC(2026, 3, 12, 12), { inputTokens: 200 });
+
+    const buckets = getUsageDayBuckets(
+      { from: Date.UTC(2026, 3, 10, 0), to: Date.UTC(2026, 3, 12, 23) },
+      "UTC",
+      { fillEmpty: true },
+    );
+
+    expect(buckets.map((b) => b.date)).toEqual([
+      "2026-04-10",
+      "2026-04-11",
+      "2026-04-12",
+    ]);
+    expect(buckets[0].totalInputTokens).toBe(100);
+    expect(buckets[1].totalInputTokens).toBe(0);
+    expect(buckets[1].eventCount).toBe(0);
+    expect(buckets[2].totalInputTokens).toBe(200);
+  });
+});
+
+describe("getUsageHourBuckets — timezone-aware", () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run(`DELETE FROM llm_usage_events`);
+  });
+
+  test("integer offset: buckets align to local-hour boundaries in PDT", () => {
+    // 2026-04-10T22:00:00Z = 15:00 PDT = "2026-04-10 15:00" bucket
+    // 2026-04-10T22:30:00Z = 15:30 PDT = same bucket
+    // 2026-04-10T23:00:00Z = 16:00 PDT = next bucket
+    insertEventAt(Date.UTC(2026, 3, 10, 22, 0), { inputTokens: 100 });
+    insertEventAt(Date.UTC(2026, 3, 10, 22, 30), { inputTokens: 200 });
+    insertEventAt(Date.UTC(2026, 3, 10, 23, 0), { inputTokens: 300 });
+
+    const buckets = getUsageHourBuckets(
+      { from: Date.UTC(2026, 3, 10, 21), to: Date.UTC(2026, 3, 11, 0) },
+      "America/Los_Angeles",
+    );
+
+    const map = Object.fromEntries(buckets.map((b) => [b.date, b]));
+    expect(map["2026-04-10 15:00"]?.totalInputTokens).toBe(300);
+    expect(map["2026-04-10 16:00"]?.totalInputTokens).toBe(300);
+    expect(map["2026-04-10 15:00"]?.displayLabel).toBe("3pm");
+    expect(map["2026-04-10 16:00"]?.displayLabel).toBe("4pm");
+  });
+
+  test("fractional offset: events in a half-hour-offset tz bucket to correct local hour", () => {
+    // Asia/Kolkata UTC+5:30.
+    // 13:30 UTC = 19:00 IST → "19:00" bucket
+    // 13:45 UTC = 19:15 IST → "19:00" bucket (same)
+    // 14:15 UTC = 19:45 IST → "19:00" bucket (same)
+    // 14:31 UTC = 20:01 IST → "20:00" bucket
+    insertEventAt(Date.UTC(2026, 3, 10, 13, 30), { inputTokens: 10 });
+    insertEventAt(Date.UTC(2026, 3, 10, 13, 45), { inputTokens: 20 });
+    insertEventAt(Date.UTC(2026, 3, 10, 14, 15), { inputTokens: 30 });
+    insertEventAt(Date.UTC(2026, 3, 10, 14, 31), { inputTokens: 40 });
+
+    const buckets = getUsageHourBuckets(
+      { from: Date.UTC(2026, 3, 10, 12), to: Date.UTC(2026, 3, 10, 16) },
+      "Asia/Kolkata",
+    );
+
+    const map = Object.fromEntries(buckets.map((b) => [b.date, b]));
+    expect(map["2026-04-10 19:00"]?.totalInputTokens).toBe(60);
+    expect(map["2026-04-10 20:00"]?.totalInputTokens).toBe(40);
+  });
+
+  test("DST spring forward: skipped hour does not produce a bucket", () => {
+    // America/New_York 2026-03-08: 2:00 AM EST jumps to 3:00 AM EDT.
+    // Event at 06:30 UTC = 01:30 EST (before jump) → "01:00" bucket
+    // Event at 07:30 UTC = 03:30 EDT (after jump) → "03:00" bucket
+    insertEventAt(Date.UTC(2026, 2, 8, 6, 30), { inputTokens: 100 });
+    insertEventAt(Date.UTC(2026, 2, 8, 7, 30), { inputTokens: 200 });
+
+    const buckets = getUsageHourBuckets(
+      { from: Date.UTC(2026, 2, 8, 5), to: Date.UTC(2026, 2, 8, 9) },
+      "America/New_York",
+      { fillEmpty: true },
+    );
+
+    const bucketLabels = buckets.map((b) => b.date);
+    // The 02:00 local hour should not appear on spring-forward day.
+    expect(bucketLabels).not.toContain("2026-03-08 02:00");
+    // Both 01:00 and 03:00 should be present.
+    expect(bucketLabels).toContain("2026-03-08 01:00");
+    expect(bucketLabels).toContain("2026-03-08 03:00");
+
+    const map = Object.fromEntries(buckets.map((b) => [b.date, b]));
+    expect(map["2026-03-08 01:00"]?.totalInputTokens).toBe(100);
+    expect(map["2026-03-08 03:00"]?.totalInputTokens).toBe(200);
+  });
+
+  test("DST fall back: duplicate 1am local hour is preserved as two buckets", () => {
+    // America/New_York 2026-11-01: 2:00 AM EDT falls back to 1:00 AM EST.
+    // Event at 05:30 UTC = 01:30 EDT (first 1am) → EDT 01:00 bucket
+    // Event at 06:30 UTC = 01:30 EST (second 1am) → EST 01:00 bucket (distinct!)
+    insertEventAt(Date.UTC(2026, 10, 1, 5, 30), { inputTokens: 100 });
+    insertEventAt(Date.UTC(2026, 10, 1, 6, 30), { inputTokens: 200 });
+
+    const buckets = getUsageHourBuckets(
+      { from: Date.UTC(2026, 10, 1, 4), to: Date.UTC(2026, 10, 1, 8) },
+      "America/New_York",
+    );
+
+    // Both events should share the same `date` string but be in different
+    // bucket entries (disambiguated by UTC offset internally).
+    const oneAmBuckets = buckets.filter((b) => b.date === "2026-11-01 01:00");
+    expect(oneAmBuckets).toHaveLength(2);
+    const totalInputs = oneAmBuckets.reduce(
+      (sum, b) => sum + b.totalInputTokens,
+      0,
+    );
+    expect(totalInputs).toBe(300);
+    // Both should share the "1am" display label.
+    expect(oneAmBuckets[0].displayLabel).toBe("1am");
+    expect(oneAmBuckets[1].displayLabel).toBe("1am");
+  });
+
+  test("fillEmpty seeds zero buckets for empty hours in range", () => {
+    insertEventAt(Date.UTC(2026, 3, 10, 14), { inputTokens: 100 });
+
+    const buckets = getUsageHourBuckets(
+      { from: Date.UTC(2026, 3, 10, 12), to: Date.UTC(2026, 3, 10, 16) },
+      "UTC",
+      { fillEmpty: true },
+    );
+
+    // Hours 12, 13, 14, 15, 16 = 5 buckets
+    expect(buckets.length).toBeGreaterThanOrEqual(4);
+    const map = Object.fromEntries(buckets.map((b) => [b.date, b]));
+    expect(map["2026-04-10 14:00"]?.totalInputTokens).toBe(100);
+    expect(map["2026-04-10 13:00"]?.totalInputTokens).toBe(0);
+    expect(map["2026-04-10 12:00"]?.eventCount).toBe(0);
+  });
+
+  test("generates lowercase hour display labels like '3pm'", () => {
+    insertEventAt(Date.UTC(2026, 3, 10, 22, 0), { inputTokens: 100 });
+    const buckets = getUsageHourBuckets(
+      { from: Date.UTC(2026, 3, 10, 22), to: Date.UTC(2026, 3, 10, 23) },
+      "America/Los_Angeles",
+    );
+    const withEvents = buckets.find((b) => b.totalInputTokens === 100);
+    expect(withEvents?.displayLabel).toBe("3pm");
   });
 });
 

--- a/assistant/src/memory/llm-usage-store.ts
+++ b/assistant/src/memory/llm-usage-store.ts
@@ -9,6 +9,11 @@ import type {
 import { getDb } from "./db.js";
 import { rawAll } from "./raw-query.js";
 import { llmUsageEvents } from "./schema.js";
+import {
+  bucketEventsByDay,
+  bucketEventsByHour,
+  type UsageEventBucketRow,
+} from "./usage-buckets.js";
 
 // ---------------------------------------------------------------------------
 // Write
@@ -152,8 +157,16 @@ export type UsageGranularity = "daily" | "hourly";
 
 /** A single time bucket with its aggregate totals. */
 export interface UsageDayBucket {
-  /** ISO date string: "YYYY-MM-DD" (daily) or "YYYY-MM-DD HH:00" (hourly), UTC. */
+  /**
+   * Local-time bucket key in the requested tz:
+   * "YYYY-MM-DD" (daily) or "YYYY-MM-DD HH:00" (hourly).
+   */
   date: string;
+  /**
+   * Human-readable label for the bucket, formatted in the requested tz.
+   * Hourly: "3pm". Daily: "Apr 11".
+   */
+  displayLabel?: string;
   /** Direct input tokens only; cache traffic is tracked separately in totals. */
   totalInputTokens: number;
   totalOutputTokens: number;
@@ -186,13 +199,6 @@ interface TotalsRow {
   unpriced_event_count: number;
 }
 
-interface DayBucketRow {
-  date: string;
-  total_input_tokens: number;
-  total_output_tokens: number;
-  total_estimated_cost_usd: number | null;
-  event_count: number;
-}
 
 interface GroupRow {
   group_key: string;
@@ -238,67 +244,68 @@ export function getUsageTotals(range: UsageTimeRange): UsageTotals {
   };
 }
 
-/**
- * Return per-day aggregates (UTC) within the given time range, ordered by date ascending.
- *
- * Each bucket key is a YYYY-MM-DD string derived by dividing the epoch-millis
- * timestamp by 86400000 and formatting as a date.
- */
-export function getUsageDayBuckets(range: UsageTimeRange): UsageDayBucket[] {
-  const rows = rawAll<DayBucketRow>(
+/** Fetch raw events in a time range for in-memory bucketing. */
+function fetchRawBucketRows(range: UsageTimeRange): UsageEventBucketRow[] {
+  return rawAll<UsageEventBucketRow>(
     /*sql*/ `
     SELECT
-      strftime('%Y-%m-%d', created_at / 1000, 'unixepoch')  AS date,
-      COALESCE(SUM(input_tokens), 0)                         AS total_input_tokens,
-      COALESCE(SUM(output_tokens), 0)                        AS total_output_tokens,
-      COALESCE(SUM(estimated_cost_usd), 0)                   AS total_estimated_cost_usd,
-      COALESCE(SUM(COALESCE(llm_call_count, 1)), 0)          AS event_count
+      created_at,
+      input_tokens,
+      output_tokens,
+      estimated_cost_usd,
+      llm_call_count
     FROM llm_usage_events
     WHERE created_at >= ?1 AND created_at <= ?2
-    GROUP BY date
-    ORDER BY date ASC
     `,
     range.from,
     range.to,
   );
-  return rows.map((r) => ({
-    date: r.date,
-    totalInputTokens: r.total_input_tokens,
-    totalOutputTokens: r.total_output_tokens,
-    totalEstimatedCostUsd: r.total_estimated_cost_usd ?? 0,
-    eventCount: r.event_count,
-  }));
+}
+
+/** Options for bucket aggregation. */
+export interface UsageBucketOptions {
+  /**
+   * When true, emit a zero-value bucket for every day (or hour) in the range
+   * even if no events fall inside it. Defaults to false so the CLI and other
+   * callers only see active periods; the chart route opts in.
+   */
+  fillEmpty?: boolean;
 }
 
 /**
- * Return per-hour aggregates (UTC) within the given time range, ordered ascending.
+ * Return per-day aggregates within the given time range, keyed by local date
+ * in the requested timezone (default UTC).
  *
- * Each bucket key is a "YYYY-MM-DD HH:00" string.
+ * Each bucket key is a "YYYY-MM-DD" string anchored on local midnight in `tz`.
+ * When `options.fillEmpty` is true, empty days within the range are filled
+ * with zero-value buckets. DST-short and DST-long local days are handled
+ * correctly.
  */
-export function getUsageHourBuckets(range: UsageTimeRange): UsageDayBucket[] {
-  const rows = rawAll<DayBucketRow>(
-    /*sql*/ `
-    SELECT
-      strftime('%Y-%m-%d %H:00', created_at / 1000, 'unixepoch')  AS date,
-      COALESCE(SUM(input_tokens), 0)                               AS total_input_tokens,
-      COALESCE(SUM(output_tokens), 0)                              AS total_output_tokens,
-      COALESCE(SUM(estimated_cost_usd), 0)                         AS total_estimated_cost_usd,
-      COALESCE(SUM(COALESCE(llm_call_count, 1)), 0)                AS event_count
-    FROM llm_usage_events
-    WHERE created_at >= ?1 AND created_at <= ?2
-    GROUP BY date
-    ORDER BY date ASC
-    `,
-    range.from,
-    range.to,
-  );
-  return rows.map((r) => ({
-    date: r.date,
-    totalInputTokens: r.total_input_tokens,
-    totalOutputTokens: r.total_output_tokens,
-    totalEstimatedCostUsd: r.total_estimated_cost_usd ?? 0,
-    eventCount: r.event_count,
-  }));
+export function getUsageDayBuckets(
+  range: UsageTimeRange,
+  tz: string = "UTC",
+  options: UsageBucketOptions = {},
+): UsageDayBucket[] {
+  const rows = fetchRawBucketRows(range);
+  return bucketEventsByDay(rows, range, tz, options);
+}
+
+/**
+ * Return per-hour aggregates within the given time range, keyed by local hour
+ * in the requested timezone (default UTC).
+ *
+ * Each bucket key is a "YYYY-MM-DD HH:00" string anchored on local hour starts.
+ * When `options.fillEmpty` is true, empty hours are filled with zero-value
+ * buckets. DST fall-back produces two distinct buckets for the duplicated hour;
+ * DST spring-forward produces 23 buckets for the affected day.
+ */
+export function getUsageHourBuckets(
+  range: UsageTimeRange,
+  tz: string = "UTC",
+  options: UsageBucketOptions = {},
+): UsageDayBucket[] {
+  const rows = fetchRawBucketRows(range);
+  return bucketEventsByHour(rows, range, tz, options);
 }
 
 type GroupByDimension = "actor" | "provider" | "model" | "conversation";

--- a/assistant/src/memory/usage-buckets.ts
+++ b/assistant/src/memory/usage-buckets.ts
@@ -1,0 +1,386 @@
+/**
+ * Timezone-aware bucketing for usage events.
+ *
+ * SQLite's `strftime(..., 'unixepoch')` is UTC-only, which means bucket
+ * boundaries (both daily and hourly) can't respect the user's timezone when
+ * computed in SQL. This module performs bucketing in JavaScript using
+ * `Intl.DateTimeFormat` so boundaries align to local-hour / local-day in any
+ * IANA timezone — including fractional offsets (e.g. Asia/Kolkata, UTC+5:30)
+ * and DST transitions.
+ */
+
+import type { UsageDayBucket, UsageTimeRange } from "./llm-usage-store.js";
+
+/** Minimal raw row shape needed for bucketing. */
+export interface UsageEventBucketRow {
+  created_at: number;
+  input_tokens: number;
+  output_tokens: number;
+  estimated_cost_usd: number | null;
+  llm_call_count: number | null;
+}
+
+/** Parts extracted from a single Date in a target timezone. */
+interface LocalParts {
+  year: number;
+  month: number;
+  day: number;
+  hour: number;
+  /** UTC offset in minutes at this instant in the target tz. */
+  offsetMinutes: number;
+}
+
+/**
+ * Validate that `tz` is a recognized IANA timezone identifier.
+ * Throws a tagged error the route layer can surface as 400.
+ */
+export function validateTimezone(tz: string): void {
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: tz });
+  } catch {
+    const err = new Error(
+      `Invalid IANA timezone identifier: "${tz}". Expected a value like "America/Los_Angeles" or "UTC".`,
+    );
+    (err as Error & { code?: string }).code = "INVALID_TIMEZONE";
+    throw err;
+  }
+}
+
+/**
+ * Extract local wall-clock parts + UTC offset for a given instant in `tz`.
+ *
+ * Uses `formatToParts` with a fixed format to reliably get numeric fields and
+ * the short GMT offset. The GMT offset disambiguates the duplicate DST
+ * fall-back hour (e.g. 1am EDT and 1am EST both format to "01" in local time
+ * but have different offsets).
+ */
+function getLocalParts(epochMillis: number, tz: string): LocalParts {
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    timeZone: tz,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+    timeZoneName: "shortOffset",
+  });
+  const parts = formatter.formatToParts(new Date(epochMillis));
+  let year = 0;
+  let month = 0;
+  let day = 0;
+  let hour = 0;
+  let offsetMinutes = 0;
+  for (const part of parts) {
+    switch (part.type) {
+      case "year":
+        year = Number(part.value);
+        break;
+      case "month":
+        month = Number(part.value);
+        break;
+      case "day":
+        day = Number(part.value);
+        break;
+      case "hour":
+        // `hour12: false` can still yield "24" at midnight in some locales; clamp.
+        hour = Number(part.value) % 24;
+        break;
+      case "timeZoneName":
+        offsetMinutes = parseShortOffset(part.value);
+        break;
+    }
+  }
+  return { year, month, day, hour, offsetMinutes };
+}
+
+/**
+ * Parse the `shortOffset` string returned by `Intl.DateTimeFormat` into minutes.
+ *
+ * Examples: "GMT-8" → -480, "GMT+5:30" → 330, "GMT" → 0, "UTC" → 0.
+ */
+function parseShortOffset(value: string): number {
+  const match = value.match(/GMT([+-])(\d{1,2})(?::(\d{2}))?/);
+  if (!match) return 0;
+  const sign = match[1] === "-" ? -1 : 1;
+  const hours = Number(match[2]);
+  const minutes = match[3] ? Number(match[3]) : 0;
+  return sign * (hours * 60 + minutes);
+}
+
+function pad2(n: number): string {
+  return n < 10 ? `0${n}` : `${n}`;
+}
+
+/** Build the canonical daily bucket key in `tz`: "YYYY-MM-DD". */
+function dayKey(parts: LocalParts): string {
+  return `${parts.year}-${pad2(parts.month)}-${pad2(parts.day)}`;
+}
+
+/**
+ * Build the canonical hourly bucket key in `tz`: "YYYY-MM-DD HH:00".
+ *
+ * For the DST fall-back hour we need to keep the two physically distinct
+ * hours separate even though they share the same local wall-clock label.
+ * We track them by their UTC offset internally via a separate map key,
+ * but the returned `date` string is identical for both so the display label
+ * matches. The caller uses a compound map key that includes the offset.
+ */
+function hourKey(parts: LocalParts): string {
+  return `${parts.year}-${pad2(parts.month)}-${pad2(parts.day)} ${pad2(parts.hour)}:00`;
+}
+
+/** Compose a map key that separates duplicate DST fall-back hours. */
+function hourMapKey(parts: LocalParts): string {
+  return `${hourKey(parts)}|${parts.offsetMinutes}`;
+}
+
+/**
+ * Advance `parts` by one local hour, returning the UTC instant of the next
+ * hour's start. Used to walk a range and fill empty buckets.
+ *
+ * We compute the next hour by taking the current instant, adding 1 hour of
+ * UTC wall time, and then projecting it back into local parts. This skips the
+ * spring-forward hour (23-hour day) and correctly emits both halves of the
+ * fall-back hour (25-hour day).
+ */
+function addOneHourUtc(epochMillis: number): number {
+  return epochMillis + 60 * 60 * 1000;
+}
+
+function addOneDayUtc(epochMillis: number): number {
+  return epochMillis + 24 * 60 * 60 * 1000;
+}
+
+/**
+ * Find the UTC instant corresponding to the start of the local hour that
+ * contains `epochMillis` in `tz`.
+ *
+ * Because Intl doesn't give us this directly, we approximate by:
+ *   1. Getting the local parts of `epochMillis`
+ *   2. Subtracting the minutes/seconds of the wall clock
+ *
+ * This returns a UTC instant that, when formatted in `tz`, has hour == parts.hour
+ * and minute/second == 0.
+ */
+function alignToLocalHourStart(epochMillis: number, tz: string): number {
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    timeZone: tz,
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  });
+  const parts = formatter.formatToParts(new Date(epochMillis));
+  let minute = 0;
+  let second = 0;
+  for (const part of parts) {
+    if (part.type === "minute") minute = Number(part.value);
+    if (part.type === "second") second = Number(part.value);
+  }
+  return epochMillis - (minute * 60 + second) * 1000;
+}
+
+/**
+ * Find the UTC instant corresponding to local midnight of the day containing
+ * `epochMillis` in `tz`.
+ */
+function alignToLocalDayStart(epochMillis: number, tz: string): number {
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    timeZone: tz,
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  });
+  const parts = formatter.formatToParts(new Date(epochMillis));
+  let hour = 0;
+  let minute = 0;
+  let second = 0;
+  for (const part of parts) {
+    if (part.type === "hour") hour = Number(part.value) % 24;
+    if (part.type === "minute") minute = Number(part.value);
+    if (part.type === "second") second = Number(part.value);
+  }
+  return epochMillis - (hour * 3600 + minute * 60 + second) * 1000;
+}
+
+/** Format a short human-readable hour label in `tz`, e.g. "3pm". */
+function formatHourLabel(epochMillis: number, tz: string): string {
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    timeZone: tz,
+    hour: "numeric",
+    hour12: true,
+  });
+  // "3 PM" → "3pm"
+  return formatter.format(new Date(epochMillis)).replace(/\s/g, "").toLowerCase();
+}
+
+/** Format a short human-readable day label in `tz`, e.g. "Apr 11". */
+function formatDayLabel(epochMillis: number, tz: string): string {
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    timeZone: tz,
+    month: "short",
+    day: "numeric",
+  });
+  return formatter.format(new Date(epochMillis));
+}
+
+interface MutableBucket {
+  date: string;
+  displayLabel: string;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalEstimatedCostUsd: number;
+  eventCount: number;
+  /** Sort key — the UTC instant of the bucket start. */
+  sortKey: number;
+}
+
+function emptyBucket(
+  date: string,
+  displayLabel: string,
+  sortKey: number,
+): MutableBucket {
+  return {
+    date,
+    displayLabel,
+    totalInputTokens: 0,
+    totalOutputTokens: 0,
+    totalEstimatedCostUsd: 0,
+    eventCount: 0,
+    sortKey,
+  };
+}
+
+function addEventToBucket(
+  bucket: MutableBucket,
+  row: UsageEventBucketRow,
+): void {
+  bucket.totalInputTokens += row.input_tokens;
+  bucket.totalOutputTokens += row.output_tokens;
+  bucket.totalEstimatedCostUsd += row.estimated_cost_usd ?? 0;
+  bucket.eventCount += row.llm_call_count ?? 1;
+}
+
+function finalize(buckets: Map<string, MutableBucket>): UsageDayBucket[] {
+  return Array.from(buckets.values())
+    .sort((a, b) => a.sortKey - b.sortKey)
+    .map(({ date, displayLabel, ...rest }) => ({
+      date,
+      displayLabel,
+      totalInputTokens: rest.totalInputTokens,
+      totalOutputTokens: rest.totalOutputTokens,
+      totalEstimatedCostUsd: rest.totalEstimatedCostUsd,
+      eventCount: rest.eventCount,
+    }));
+}
+
+/** Options for bucketing behavior. */
+export interface BucketingOptions {
+  /**
+   * When true, emit a zero-value bucket for every hour (or day) in the
+   * requested range even if no events fall inside it. This produces a
+   * continuous chart axis for empty periods but adds noise to text output
+   * like the CLI. Defaults to false.
+   */
+  fillEmpty?: boolean;
+}
+
+/**
+ * Bucket raw usage events by local hour in the given timezone.
+ *
+ * DST fall-back duplicate hours are preserved as separate buckets with
+ * identical display labels. When `options.fillEmpty` is true, the returned
+ * array contains a zero-value bucket for every local hour in the range.
+ */
+export function bucketEventsByHour(
+  events: UsageEventBucketRow[],
+  range: UsageTimeRange,
+  tz: string,
+  options: BucketingOptions = {},
+): UsageDayBucket[] {
+  validateTimezone(tz);
+  const buckets = new Map<string, MutableBucket>();
+
+  if (options.fillEmpty) {
+    let cursor = alignToLocalHourStart(range.from, tz);
+    let safety = 0;
+    const maxIterations = 200_000;
+    while (cursor <= range.to && safety++ < maxIterations) {
+      const parts = getLocalParts(cursor, tz);
+      const key = hourMapKey(parts);
+      if (!buckets.has(key)) {
+        buckets.set(
+          key,
+          emptyBucket(hourKey(parts), formatHourLabel(cursor, tz), cursor),
+        );
+      }
+      cursor = addOneHourUtc(cursor);
+    }
+  }
+
+  for (const row of events) {
+    const parts = getLocalParts(row.created_at, tz);
+    const key = hourMapKey(parts);
+    let bucket = buckets.get(key);
+    if (!bucket) {
+      const hourStart = alignToLocalHourStart(row.created_at, tz);
+      bucket = emptyBucket(
+        hourKey(parts),
+        formatHourLabel(hourStart, tz),
+        hourStart,
+      );
+      buckets.set(key, bucket);
+    }
+    addEventToBucket(bucket, row);
+  }
+
+  return finalize(buckets);
+}
+
+/**
+ * Bucket raw usage events by local day in the given timezone.
+ *
+ * When `options.fillEmpty` is true, the returned array contains a zero-value
+ * bucket for every local day in the range.
+ */
+export function bucketEventsByDay(
+  events: UsageEventBucketRow[],
+  range: UsageTimeRange,
+  tz: string,
+  options: BucketingOptions = {},
+): UsageDayBucket[] {
+  validateTimezone(tz);
+  const buckets = new Map<string, MutableBucket>();
+
+  if (options.fillEmpty) {
+    let cursor = alignToLocalDayStart(range.from, tz);
+    let safety = 0;
+    const maxIterations = 10_000;
+    while (cursor <= range.to && safety++ < maxIterations) {
+      const parts = getLocalParts(cursor, tz);
+      const key = dayKey(parts);
+      if (!buckets.has(key)) {
+        buckets.set(key, emptyBucket(key, formatDayLabel(cursor, tz), cursor));
+      }
+      // Advance by 24 UTC hours, then realign to local midnight. Handles
+      // DST transitions where a "day" is 23 or 25 hours long in local time.
+      cursor = alignToLocalDayStart(addOneDayUtc(cursor), tz);
+    }
+  }
+
+  for (const row of events) {
+    const parts = getLocalParts(row.created_at, tz);
+    const key = dayKey(parts);
+    let bucket = buckets.get(key);
+    if (!bucket) {
+      const dayStart = alignToLocalDayStart(row.created_at, tz);
+      bucket = emptyBucket(key, formatDayLabel(dayStart, tz), dayStart);
+      buckets.set(key, bucket);
+    }
+    addEventToBucket(bucket, row);
+  }
+
+  return finalize(buckets);
+}

--- a/assistant/src/runtime/routes/usage-routes.ts
+++ b/assistant/src/runtime/routes/usage-routes.ts
@@ -14,10 +14,29 @@ import {
   getUsageHourBuckets,
   getUsageTotals,
 } from "../../memory/llm-usage-store.js";
+import { validateTimezone } from "../../memory/usage-buckets.js";
 import { httpError } from "../http-errors.js";
 import type { RouteDefinition } from "../http-router.js";
 
 const VALID_GROUP_BY = new Set(["actor", "provider", "model", "conversation"]);
+
+/**
+ * Resolve the optional `tz` query param to a validated IANA identifier.
+ * Returns the tz string, or an error Response if the value is not a valid tz.
+ */
+function resolveTimezone(url: URL): string | Response {
+  const tz = url.searchParams.get("tz") ?? "UTC";
+  try {
+    validateTimezone(tz);
+  } catch (err) {
+    return httpError(
+      "BAD_REQUEST",
+      (err as Error).message,
+      400,
+    );
+  }
+  return tz;
+}
 
 /**
  * Parse and validate the `from` and `to` epoch-millis query parameters.
@@ -110,6 +129,12 @@ export function usageRouteDefinitions(): RouteDefinition[] {
           schema: { type: "string", enum: ["daily", "hourly"] },
           description: 'Bucket granularity: "daily" (default) or "hourly"',
         },
+        {
+          name: "tz",
+          schema: { type: "string" },
+          description:
+            'IANA timezone identifier (e.g. "America/Los_Angeles"). Bucket boundaries and display labels are computed in this timezone. Defaults to "UTC" for backwards compatibility.',
+        },
       ],
       responseBody: z.object({
         buckets: z.array(z.unknown()).describe("Usage bucket objects"),
@@ -125,10 +150,13 @@ export function usageRouteDefinitions(): RouteDefinition[] {
             400,
           );
         }
+        const tz = resolveTimezone(url);
+        if (tz instanceof Response) return tz;
+        // The chart wants a continuous time axis, so fill empty buckets.
         const buckets =
           granularity === "hourly"
-            ? getUsageHourBuckets(range)
-            : getUsageDayBuckets(range);
+            ? getUsageHourBuckets(range, tz, { fillEmpty: true })
+            : getUsageDayBuckets(range, tz, { fillEmpty: true });
         return Response.json({ buckets });
       },
     },

--- a/clients/ios/Tests/UsageDashboardViewTests.swift
+++ b/clients/ios/Tests/UsageDashboardViewTests.swift
@@ -208,7 +208,7 @@ final class UsageDashboardViewTests: XCTestCase {
 @MainActor
 private final class NilUsageClient: UsageClientProtocol {
     func fetchUsageTotals(from: Int, to: Int) async -> UsageTotalsResponse? { nil }
-    func fetchUsageDaily(from: Int, to: Int, granularity: String) async -> UsageDailyResponse? { nil }
+    func fetchUsageDaily(from: Int, to: Int, granularity: String, tz: String) async -> UsageDailyResponse? { nil }
     func fetchUsageBreakdown(from: Int, to: Int, groupBy: String) async -> UsageBreakdownResponse? { nil }
 }
 
@@ -228,10 +228,10 @@ private final class StubUsageClient: UsageClientProtocol {
         )
     }
 
-    func fetchUsageDaily(from: Int, to: Int, granularity: String) async -> UsageDailyResponse? {
+    func fetchUsageDaily(from: Int, to: Int, granularity: String, tz: String) async -> UsageDailyResponse? {
         UsageDailyResponse(buckets: [
-            UsageDayBucket(date: "2026-03-04", totalInputTokens: 600, totalOutputTokens: 300, totalEstimatedCostUsd: 0.0025, eventCount: 2),
-            UsageDayBucket(date: "2026-03-05", totalInputTokens: 400, totalOutputTokens: 200, totalEstimatedCostUsd: 0.0017, eventCount: 1),
+            UsageDayBucket(date: "2026-03-04", displayLabel: "Mar 4", totalInputTokens: 600, totalOutputTokens: 300, totalEstimatedCostUsd: 0.0025, eventCount: 2),
+            UsageDayBucket(date: "2026-03-05", displayLabel: "Mar 5", totalInputTokens: 400, totalOutputTokens: 200, totalEstimatedCostUsd: 0.0017, eventCount: 1),
         ])
     }
 

--- a/clients/ios/Views/UsageDashboardView.swift
+++ b/clients/ios/Views/UsageDashboardView.swift
@@ -99,7 +99,7 @@ struct UsageDashboardView: View {
                 } else {
                     ForEach(daily.buckets, id: \.date) { bucket in
                         HStack {
-                            Text(Self.formatBucketLabel(bucket.date, isHourly: isHourly))
+                            Text(bucket.displayLabel ?? bucket.date)
                                 .font(.footnote.monospaced())
                             Spacer()
                             Text(UsageFormatting.formatCost(bucket.totalEstimatedCostUsd))
@@ -172,47 +172,5 @@ struct UsageDashboardView: View {
         }
     }
 
-    // MARK: - Formatters
-
-    private static let shortDateFormatter: DateFormatter = {
-        let f = DateFormatter()
-        f.dateFormat = "MMM d"
-        f.timeZone = TimeZone(identifier: "UTC")!
-        return f
-    }()
-
-    private static let isoDateParser: DateFormatter = {
-        let f = DateFormatter()
-        f.dateFormat = "yyyy-MM-dd"
-        f.locale = Locale(identifier: "en_US_POSIX")
-        f.timeZone = TimeZone(identifier: "UTC")!
-        return f
-    }()
-
-    private static let isoHourParser: DateFormatter = {
-        let f = DateFormatter()
-        f.dateFormat = "yyyy-MM-dd HH:mm"
-        f.locale = Locale(identifier: "en_US_POSIX")
-        f.timeZone = TimeZone(identifier: "UTC")!
-        return f
-    }()
-
-    private static let shortHourFormatter: DateFormatter = {
-        let f = DateFormatter()
-        f.dateFormat = "ha"
-        f.locale = Locale(identifier: "en_US_POSIX")
-        f.timeZone = TimeZone(identifier: "UTC")!
-        return f
-    }()
-
-    private static func formatBucketLabel(_ dateString: String, isHourly: Bool) -> String {
-        if isHourly {
-            guard let date = isoHourParser.date(from: dateString) else { return dateString }
-            return shortHourFormatter.string(from: date).lowercased()
-        } else {
-            guard let date = isoDateParser.date(from: dateString) else { return dateString }
-            return shortDateFormatter.string(from: date)
-        }
-    }
 }
 #endif

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -296,6 +296,9 @@ public final class MainWindow {
 
     /// Tracks daemon reconnects so trace state can be reset on stream restart.
     private var connectionCancellable: AnyCancellable?
+    /// Tracks changes to `SettingsStore.userTimezone` so the usage dashboard
+    /// re-fetches with the new timezone when the user changes it in settings.
+    private var userTimezoneCancellable: AnyCancellable?
     private var layoutObserver: NSObjectProtocol?
     private var defaultTrafficLightOrigin: NSPoint?
     private var hasConnectedOnce = false
@@ -325,6 +328,7 @@ public final class MainWindow {
             isFirstLaunch: isFirstLaunch
         )
         self.usageDashboardStore = UsageDashboardStore()
+        self.usageDashboardStore.updateTimezone(services.settingsStore.userTimezone)
         self.conversationManager.ambientAgent = services.ambientAgent
         documentManager.connectionManager = connectionManager
         Task { @MainActor [weak self] in
@@ -341,6 +345,19 @@ public final class MainWindow {
             }
         }
         observeDaemonReconnects()
+        observeUserTimezoneChanges()
+    }
+
+    /// Keep `UsageDashboardStore.resolvedTimezone` in sync with the user's
+    /// configured timezone in Settings. When the user updates or clears the
+    /// setting, the store resets and re-fetches on the next render.
+    private func observeUserTimezoneChanges() {
+        userTimezoneCancellable = services.settingsStore.$userTimezone
+            .dropFirst()
+            .removeDuplicates()
+            .sink { [weak self] newIdentifier in
+                self?.usageDashboardStore.updateTimezone(newIdentifier)
+            }
     }
 
     /// Reset trace state when the daemon reconnects after a disconnect.

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/LogsAndUsagePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/LogsAndUsagePanel.swift
@@ -486,7 +486,7 @@ struct UsageTabContent: View {
                             Text(formatCost(bucket.totalEstimatedCostUsd))
                                 .font(VFont.labelSmall)
                                 .foregroundStyle(VColor.contentSecondary)
-                            Text(formatBucketLabel(bucket.date, isHourly: isHourly))
+                            Text(formatBucketLabel(bucket))
                                 .font(VFont.labelSmall)
                                 .foregroundStyle(VColor.contentTertiary)
                         }
@@ -498,45 +498,11 @@ struct UsageTabContent: View {
         }
     }
 
-    private static let shortDateFormatter: DateFormatter = {
-        let f = DateFormatter()
-        f.dateFormat = "MMM d"
-        f.timeZone = TimeZone(identifier: "UTC")!
-        return f
-    }()
-
-    private static let isoDateParser: DateFormatter = {
-        let f = DateFormatter()
-        f.dateFormat = "yyyy-MM-dd"
-        f.locale = Locale(identifier: "en_US_POSIX")
-        f.timeZone = TimeZone(identifier: "UTC")!
-        return f
-    }()
-
-    private static let isoHourParser: DateFormatter = {
-        let f = DateFormatter()
-        f.dateFormat = "yyyy-MM-dd HH:mm"
-        f.locale = Locale(identifier: "en_US_POSIX")
-        f.timeZone = TimeZone(identifier: "UTC")!
-        return f
-    }()
-
-    private static let shortHourFormatter: DateFormatter = {
-        let f = DateFormatter()
-        f.dateFormat = "ha"
-        f.locale = Locale(identifier: "en_US_POSIX")
-        f.timeZone = TimeZone(identifier: "UTC")!
-        return f
-    }()
-
-    private func formatBucketLabel(_ dateString: String, isHourly: Bool) -> String {
-        if isHourly {
-            guard let date = Self.isoHourParser.date(from: dateString) else { return dateString }
-            return Self.shortHourFormatter.string(from: date).lowercased()
-        } else {
-            guard let date = Self.isoDateParser.date(from: dateString) else { return dateString }
-            return Self.shortDateFormatter.string(from: date)
-        }
+    /// The daemon emits `displayLabel` already formatted in the requested
+    /// timezone. We fall back to the raw `date` string for responses from
+    /// older daemons that don't include the label.
+    private func formatBucketLabel(_ bucket: UsageDayBucket) -> String {
+        bucket.displayLabel ?? bucket.date
     }
 
     // MARK: - Breakdown Section

--- a/clients/macos/vellum-assistantTests/UsageDashboardPanelTests.swift
+++ b/clients/macos/vellum-assistantTests/UsageDashboardPanelTests.swift
@@ -459,7 +459,7 @@ private final class MockPanelClient: UsageClientProtocol {
         return stubbedTotals
     }
 
-    func fetchUsageDaily(from: Int, to: Int, granularity: String) async -> UsageDailyResponse? {
+    func fetchUsageDaily(from: Int, to: Int, granularity: String, tz: String) async -> UsageDailyResponse? {
         lastDailyFrom = from
         return stubbedDaily
     }

--- a/clients/macos/vellum-assistantTests/UsageDashboardStoreTests.swift
+++ b/clients/macos/vellum-assistantTests/UsageDashboardStoreTests.swift
@@ -14,6 +14,8 @@ private final class MockUsageClient: UsageClientProtocol {
     var lastTotalsTo: Int?
     var lastDailyFrom: Int?
     var lastDailyTo: Int?
+    var lastDailyTz: String?
+    var lastDailyGranularity: String?
     var lastBreakdownFrom: Int?
     var lastBreakdownTo: Int?
     var lastBreakdownGroupBy: String?
@@ -24,9 +26,11 @@ private final class MockUsageClient: UsageClientProtocol {
         return stubbedTotals
     }
 
-    func fetchUsageDaily(from: Int, to: Int, granularity: String) async -> UsageDailyResponse? {
+    func fetchUsageDaily(from: Int, to: Int, granularity: String, tz: String) async -> UsageDailyResponse? {
         lastDailyFrom = from
         lastDailyTo = to
+        lastDailyGranularity = granularity
+        lastDailyTz = tz
         return stubbedDaily
     }
 
@@ -362,7 +366,7 @@ private final class DelayedMockUsageClient: UsageClientProtocol {
         }
     }
 
-    func fetchUsageDaily(from: Int, to: Int, granularity: String) async -> UsageDailyResponse? {
+    func fetchUsageDaily(from: Int, to: Int, granularity: String, tz: String) async -> UsageDailyResponse? {
         await withCheckedContinuation { continuation in
             dailyContinuations.append(continuation)
         }
@@ -589,7 +593,7 @@ struct UsageTimeRangeTests {
     func todayRangeStartsAtMidnightUTC() {
         // Use a mid-day timestamp so UTC midnight differs from most local timezones
         let now = Date(timeIntervalSince1970: 1709733600) // 2024-03-06 14:00:00 UTC
-        let range = UsageTimeRange.today.epochMillisRange(now: now)
+        let range = UsageTimeRange.today.epochMillisRange(now: now, timeZone: TimeZone(identifier: "UTC")!)
 
         var calendar = Calendar(identifier: .gregorian)
         calendar.timeZone = TimeZone(identifier: "UTC")!
@@ -603,9 +607,32 @@ struct UsageTimeRangeTests {
     }
 
     @Test
+    func todayRangeStartsAtMidnightInUserTimezone() {
+        // 2024-03-06 14:00:00 UTC is 2024-03-06 06:00:00 PST (UTC-8).
+        // Midnight PST that day is 2024-03-06 08:00:00 UTC = 1709712000.
+        let now = Date(timeIntervalSince1970: 1709733600)
+        let pst = TimeZone(identifier: "America/Los_Angeles")!
+        let range = UsageTimeRange.today.epochMillisRange(now: now, timeZone: pst)
+
+        #expect(range.from == 1709712000 * 1000)
+        #expect(range.to == Int(now.timeIntervalSince1970 * 1000))
+    }
+
+    @Test
+    func todayRangeHandlesFractionalOffset() {
+        // Asia/Kolkata is UTC+5:30. 2024-03-06 14:00:00 UTC is 2024-03-06 19:30:00 IST.
+        // Midnight IST that day is 2024-03-05 18:30:00 UTC = 1709663400.
+        let now = Date(timeIntervalSince1970: 1709733600)
+        let ist = TimeZone(identifier: "Asia/Kolkata")!
+        let range = UsageTimeRange.today.epochMillisRange(now: now, timeZone: ist)
+
+        #expect(range.from == 1709663400 * 1000)
+    }
+
+    @Test
     func last7DaysSpansSixDaysBack() {
         let now = Date(timeIntervalSince1970: 1709733600) // 2024-03-06 14:00:00 UTC
-        let range = UsageTimeRange.last7Days.epochMillisRange(now: now)
+        let range = UsageTimeRange.last7Days.epochMillisRange(now: now, timeZone: TimeZone(identifier: "UTC")!)
 
         var calendar = Calendar(identifier: .gregorian)
         calendar.timeZone = TimeZone(identifier: "UTC")!
@@ -622,6 +649,120 @@ struct UsageTimeRangeTests {
         for timeRange in UsageTimeRange.allCases {
             let range = timeRange.epochMillisRange()
             #expect(range.from <= range.to, "from should be <= to for \(timeRange.rawValue)")
+        }
+    }
+}
+
+// MARK: - Timezone Wiring
+
+@Suite("UsageDashboardStore — Timezone Wiring")
+@MainActor
+struct UsageDashboardStoreTimezoneTests {
+
+    @Test
+    func defaultsToCurrentSystemTimezone() {
+        let store = UsageDashboardStore()
+        #expect(store.resolvedTimezoneIdentifier == TimeZone.current.identifier)
+    }
+
+    @Test
+    func updateTimezoneAcceptsIanaIdentifier() {
+        let store = UsageDashboardStore()
+        store.updateTimezone("America/New_York")
+        #expect(store.resolvedTimezoneIdentifier == "America/New_York")
+        #expect(store.resolvedTimezone.identifier == "America/New_York")
+    }
+
+    @Test
+    func updateTimezoneWithNilFallsBackToCurrent() {
+        let store = UsageDashboardStore()
+        store.updateTimezone("Europe/Berlin")
+        store.updateTimezone(nil)
+        #expect(store.resolvedTimezoneIdentifier == TimeZone.current.identifier)
+    }
+
+    @Test
+    func updateTimezoneWithInvalidIdentifierFallsBackToCurrent() {
+        let store = UsageDashboardStore()
+        store.updateTimezone("Not/A/Real/Zone")
+        #expect(store.resolvedTimezoneIdentifier == TimeZone.current.identifier)
+    }
+
+    @Test
+    func refreshPassesTimezoneToFetchUsageDaily() async {
+        let client = MockUsageClient()
+        client.stubbedTotals = UsageTotalsResponse(
+            totalInputTokens: 0, totalOutputTokens: 0,
+            totalCacheCreationTokens: 0, totalCacheReadTokens: 0,
+            totalEstimatedCostUsd: 0, eventCount: 0,
+            pricedEventCount: 0, unpricedEventCount: 0
+        )
+        client.stubbedDaily = UsageDailyResponse(buckets: [])
+        client.stubbedBreakdown = UsageBreakdownResponse(breakdown: [])
+
+        let store = UsageDashboardStore()
+        store.updateClient(client)
+        store.updateTimezone("Europe/Berlin")
+        await store.refresh()
+
+        #expect(client.lastDailyTz == "Europe/Berlin")
+    }
+
+    @Test
+    func updateTimezoneResetsLoadedData() async {
+        let client = MockUsageClient()
+        client.stubbedTotals = UsageTotalsResponse(
+            totalInputTokens: 100, totalOutputTokens: 50,
+            totalCacheCreationTokens: 0, totalCacheReadTokens: 0,
+            totalEstimatedCostUsd: 0.01, eventCount: 1,
+            pricedEventCount: 1, unpricedEventCount: 0
+        )
+        client.stubbedDaily = UsageDailyResponse(buckets: [])
+        client.stubbedBreakdown = UsageBreakdownResponse(breakdown: [])
+
+        let store = UsageDashboardStore()
+        store.updateClient(client)
+        await store.refresh()
+
+        // Loaded after refresh.
+        if case .loaded = store.totalsState {
+            // ok
+        } else {
+            Issue.record("Expected totals to be loaded")
+        }
+
+        store.updateTimezone("Asia/Tokyo")
+
+        // Reset back to idle after tz change.
+        #expect(store.totalsState == .idle)
+        #expect(store.dailyState == .idle)
+        #expect(store.breakdownState == .idle)
+    }
+
+    @Test
+    func updateTimezoneWithSameIdentifierDoesNotReset() async {
+        let client = MockUsageClient()
+        client.stubbedTotals = UsageTotalsResponse(
+            totalInputTokens: 100, totalOutputTokens: 50,
+            totalCacheCreationTokens: 0, totalCacheReadTokens: 0,
+            totalEstimatedCostUsd: 0.01, eventCount: 1,
+            pricedEventCount: 1, unpricedEventCount: 0
+        )
+        client.stubbedDaily = UsageDailyResponse(buckets: [])
+        client.stubbedBreakdown = UsageBreakdownResponse(breakdown: [])
+
+        let store = UsageDashboardStore()
+        store.updateClient(client)
+        store.updateTimezone("America/Chicago")
+        await store.refresh()
+
+        store.updateTimezone("America/Chicago") // same value — should be a no-op
+
+        // Remains loaded.
+        if case .loaded = store.totalsState {
+            // ok
+        } else {
+            Issue.record("Expected totals to remain loaded after no-op timezone update")
         }
     }
 }

--- a/clients/shared/Features/Usage/UsageDashboardStore.swift
+++ b/clients/shared/Features/Usage/UsageDashboardStore.swift
@@ -5,7 +5,7 @@ import Foundation
 /// Abstraction for fetching usage data, decoupled from the full GatewayConnectionManager.
 public protocol UsageClientProtocol {
     func fetchUsageTotals(from: Int, to: Int) async -> UsageTotalsResponse?
-    func fetchUsageDaily(from: Int, to: Int, granularity: String) async -> UsageDailyResponse?
+    func fetchUsageDaily(from: Int, to: Int, granularity: String, tz: String) async -> UsageDailyResponse?
     func fetchUsageBreakdown(from: Int, to: Int, groupBy: String) async -> UsageBreakdownResponse?
 }
 
@@ -29,9 +29,10 @@ public struct UsageClient: UsageClientProtocol {
         return result?.0
     }
 
-    public func fetchUsageDaily(from: Int, to: Int, granularity: String = "daily") async -> UsageDailyResponse? {
+    public func fetchUsageDaily(from: Int, to: Int, granularity: String = "daily", tz: String) async -> UsageDailyResponse? {
+        let encodedTz = tz.addingPercentEncoding(withAllowedCharacters: Self.queryValueAllowed) ?? tz
         let result: (UsageDailyResponse?, GatewayHTTPClient.Response)? = try? await GatewayHTTPClient.get(
-            path: "assistants/{assistantId}/usage/daily?from=\(from)&to=\(to)&granularity=\(granularity)", timeout: 10
+            path: "assistants/{assistantId}/usage/daily?from=\(from)&to=\(to)&granularity=\(granularity)&tz=\(encodedTz)", timeout: 10
         )
         return result?.0
     }
@@ -55,11 +56,17 @@ public enum UsageTimeRange: String, CaseIterable, Sendable {
     case last90Days = "Last 90 Days"
 
     /// Compute the epoch-millisecond `from` and `to` bounds for this range.
-    /// `to` is always the current instant; `from` is midnight UTC of the starting day.
-    public func epochMillisRange(now: Date = Date()) -> (from: Int, to: Int) {
+    /// `to` is always the current instant; `from` is midnight in `timeZone` of
+    /// the starting day. The timezone parameter controls where the range
+    /// anchors — e.g. "Today" means midnight in the user's local timezone, not
+    /// midnight UTC.
+    public func epochMillisRange(
+        now: Date = Date(),
+        timeZone: TimeZone = .current
+    ) -> (from: Int, to: Int) {
         let to = Int(now.timeIntervalSince1970 * 1000)
         var calendar = Calendar(identifier: .gregorian)
-        calendar.timeZone = TimeZone(identifier: "UTC")!
+        calendar.timeZone = timeZone
         let startOfToday = calendar.startOfDay(for: now)
 
         let startDate: Date
@@ -165,6 +172,16 @@ public final class UsageDashboardStore {
     /// Whether the current daily data uses hourly granularity (true when range is "Today").
     public var isHourlyGranularity: Bool { selectedRange == .today }
 
+    /// IANA identifier of the timezone used for bucket boundaries and labels.
+    /// Defaults to the system timezone; callers override via `updateTimezone`
+    /// when the user sets an explicit `ui.userTimezone`.
+    public private(set) var resolvedTimezoneIdentifier: String = TimeZone.current.identifier
+
+    /// The resolved `TimeZone` that matches `resolvedTimezoneIdentifier`.
+    public var resolvedTimezone: TimeZone {
+        TimeZone(identifier: resolvedTimezoneIdentifier) ?? .current
+    }
+
     // MARK: - Dependencies
 
     private var client: any UsageClientProtocol = UsageClient()
@@ -180,6 +197,18 @@ public final class UsageDashboardStore {
     public func updateClient(_ newClient: any UsageClientProtocol) {
         client = newClient
         reset()
+    }
+
+    /// Update the effective timezone used for range calculation and bucket
+    /// labels. If `identifier` is nil or unrecognized, falls back to
+    /// `TimeZone.current`. Resets any loaded data so the next refresh
+    /// re-fetches with the new timezone.
+    public func updateTimezone(_ identifier: String?) {
+        let resolved = identifier.flatMap { TimeZone(identifier: $0) } ?? .current
+        if resolved.identifier != resolvedTimezoneIdentifier {
+            resolvedTimezoneIdentifier = resolved.identifier
+            reset()
+        }
     }
 
     /// Reset all loaded data so the next `refresh()` re-fetches.
@@ -208,7 +237,9 @@ public final class UsageDashboardStore {
         breakdownGeneration &+= 1
         let capturedBreakdownGen = breakdownGeneration
 
-        let range = selectedRange.epochMillisRange()
+        let tz = resolvedTimezone
+        let tzIdentifier = resolvedTimezoneIdentifier
+        let range = selectedRange.epochMillisRange(timeZone: tz)
 
         totalsState = .loading
         dailyState = .loading
@@ -216,7 +247,9 @@ public final class UsageDashboardStore {
 
         let granularity = isHourlyGranularity ? "hourly" : "daily"
         async let totalsResult = client.fetchUsageTotals(from: range.from, to: range.to)
-        async let dailyResult = client.fetchUsageDaily(from: range.from, to: range.to, granularity: granularity)
+        async let dailyResult = client.fetchUsageDaily(
+            from: range.from, to: range.to, granularity: granularity, tz: tzIdentifier
+        )
         async let breakdownResult = client.fetchUsageBreakdown(
             from: range.from, to: range.to, groupBy: selectedGroupBy.rawValue
         )
@@ -260,7 +293,7 @@ public final class UsageDashboardStore {
         breakdownGeneration &+= 1
         let capturedGeneration = breakdownGeneration
 
-        let range = selectedRange.epochMillisRange()
+        let range = selectedRange.epochMillisRange(timeZone: resolvedTimezone)
         breakdownState = .loading
 
         let result = await client.fetchUsageBreakdown(

--- a/clients/shared/Network/UsageModels.swift
+++ b/clients/shared/Network/UsageModels.swift
@@ -36,18 +36,51 @@ public struct UsageTotalsResponse: Decodable, Equatable, Sendable {
 
 /// A single day bucket from `GET /v1/usage/daily`.
 public struct UsageDayBucket: Decodable, Equatable, Sendable {
+    /// Local-time bucket key in the requested tz: "YYYY-MM-DD" (daily) or
+    /// "YYYY-MM-DD HH:00" (hourly). Clients should treat this as an opaque
+    /// identifier and prefer `displayLabel` for rendering.
     public let date: String
+    /// Pre-formatted human-readable label from the daemon, formatted in the
+    /// requested timezone. Absent for responses from older daemons.
+    public let displayLabel: String?
     public let totalInputTokens: Int
     public let totalOutputTokens: Int
     public let totalEstimatedCostUsd: Double
     public let eventCount: Int
 
-    public init(date: String, totalInputTokens: Int, totalOutputTokens: Int, totalEstimatedCostUsd: Double, eventCount: Int) {
+    public init(
+        date: String,
+        displayLabel: String? = nil,
+        totalInputTokens: Int,
+        totalOutputTokens: Int,
+        totalEstimatedCostUsd: Double,
+        eventCount: Int
+    ) {
         self.date = date
+        self.displayLabel = displayLabel
         self.totalInputTokens = totalInputTokens
         self.totalOutputTokens = totalOutputTokens
         self.totalEstimatedCostUsd = totalEstimatedCostUsd
         self.eventCount = eventCount
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case date
+        case displayLabel
+        case totalInputTokens
+        case totalOutputTokens
+        case totalEstimatedCostUsd
+        case eventCount
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        date = try container.decode(String.self, forKey: .date)
+        displayLabel = try container.decodeIfPresent(String.self, forKey: .displayLabel)
+        totalInputTokens = try container.decode(Int.self, forKey: .totalInputTokens)
+        totalOutputTokens = try container.decode(Int.self, forKey: .totalOutputTokens)
+        totalEstimatedCostUsd = try container.decode(Double.self, forKey: .totalEstimatedCostUsd)
+        eventCount = try container.decode(Int.self, forKey: .eventCount)
     }
 }
 


### PR DESCRIPTION
## Summary

- Bucket usage events by local hour/day in the user's configured timezone (falling back to the system timezone) instead of always UTC. Fixes the Hourly Trend chart showing UTC-offset bars for non-UTC users — including fractional-offset timezones (India, Nepal, Newfoundland) where simple relabeling would produce :30 labels and misaligned hour boundaries.
- Move bucketing out of SQLite \`strftime\` into a new \`usage-buckets.ts\` TypeScript helper that uses \`Intl.DateTimeFormat\` with IANA timezones. Handles DST spring-forward (23-hour day skips the missing hour) and fall-back (25-hour day preserves the duplicated 1am as two distinct buckets via UTC-offset disambiguation).
- Add optional \`tz\` query param to \`GET /v1/usage/daily\` (defaults to \`"UTC"\` for backwards compat) and an optional \`displayLabel\` field on \`UsageDayBucket\` so clients render labels formatted server-side. macOS/iOS clients now use \`bucket.displayLabel ?? bucket.date\` and delete their UTC-hardcoded \`DateFormatter\`s.
- Wire \`SettingsStore.userTimezone\` (macOS Appearance tab) into \`UsageDashboardStore\` via a new \`updateTimezone\` method; \`UsageTimeRange.epochMillisRange\` now takes a \`TimeZone\` so "Today" / "Last 7 Days" anchor on user-local midnight.
- Chart route opts into zero-fill (\`fillEmpty: true\`) so the x-axis is continuous. CLI \`assistant usage daily\` keeps its old sparse output since \`fillEmpty\` defaults to false.

## Test plan

- [x] \`bun test src/__tests__/llm-usage-store.test.ts\` — 42 tests pass, including 11 new timezone-aware cases (PDT, IST, DST spring forward, DST fall back, fill-empty, invalid tz, backwards compat).
- [x] \`bunx tsc --noEmit\` clean.
- [ ] Manual: set \`ui.userTimezone\` in Settings → Appearance, open Logs & Usage → Today, verify bar labels match local hours.

## Original prompt

> These times should be in the timezone I've configured in the app (falling back to my local timezone), not UTC

🤖 Generated with [Claude Code](https://claude.com/claude-code)