### PR TITLE
fix(contacts): share user_file across sibling contacts with same principal_id

### DIFF
--- a/assistant/src/__tests__/contact-store-user-file.test.ts
+++ b/assistant/src/__tests__/contact-store-user-file.test.ts
@@ -1,0 +1,325 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import {
+  generateUserFileSlug,
+  upsertContact,
+} from "../contacts/contact-store.js";
+import { getDb, getSqlite, initializeDb } from "../memory/db.js";
+import { migrateNormalizeUserFileByPrincipal } from "../memory/migrations/220-normalize-user-file-by-principal.js";
+
+initializeDb();
+
+function resetContactTables(): void {
+  const sqlite = getSqlite();
+  sqlite.run("DELETE FROM contact_channels");
+  sqlite.run("DELETE FROM contacts");
+  sqlite.run(
+    "DELETE FROM memory_checkpoints WHERE key = 'migration_normalize_user_file_by_principal_v1'",
+  );
+}
+
+function insertContact(params: {
+  id: string;
+  displayName: string;
+  role: string;
+  principalId: string | null;
+  userFile: string | null;
+  createdAt: number;
+}): void {
+  const sqlite = getSqlite();
+  sqlite.run(
+    "INSERT INTO contacts (id, display_name, role, contact_type, principal_id, user_file, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+    [
+      params.id,
+      params.displayName,
+      params.role,
+      "human",
+      params.principalId,
+      params.userFile,
+      params.createdAt,
+      params.createdAt,
+    ],
+  );
+}
+
+function fetchUserFilesByPrincipal(
+  principalId: string,
+): Array<{ id: string; user_file: string | null }> {
+  const sqlite = getSqlite();
+  return sqlite
+    .query(
+      "SELECT id, user_file FROM contacts WHERE principal_id = ? ORDER BY id",
+    )
+    .all(principalId) as Array<{ id: string; user_file: string | null }>;
+}
+
+describe("upsertContact user_file selection", () => {
+  beforeEach(() => {
+    resetContactTables();
+  });
+
+  test("reuses an existing sibling's userFile when principalId matches", () => {
+    const primary = upsertContact({
+      displayName: "Sidd",
+      role: "guardian",
+      principalId: "principal-abc",
+      channels: [
+        {
+          type: "vellum",
+          address: "vellum-principal-abc",
+          externalUserId: "vellum-principal-abc",
+        },
+      ],
+    });
+    expect(primary.userFile).toBe("sidd.md");
+
+    // Second contact for the same principal on Slack — must inherit the
+    // first contact's userFile, NOT auto-increment to sidd-2.md.
+    const slack = upsertContact({
+      displayName: "sidd",
+      role: "guardian",
+      principalId: "principal-abc",
+      channels: [
+        {
+          type: "slack",
+          address: "u123456",
+          externalUserId: "U123456",
+          externalChatId: "D987654",
+        },
+      ],
+    });
+    expect(slack.userFile).toBe("sidd.md");
+    expect(slack.id).not.toBe(primary.id);
+  });
+
+  test("falls back to generateUserFileSlug when principalId has no existing sibling", () => {
+    const contact = upsertContact({
+      displayName: "Alice",
+      role: "contact",
+      principalId: "principal-alone",
+      channels: [
+        {
+          type: "slack",
+          address: "ualice",
+          externalUserId: "UALICE",
+          externalChatId: "DALICE",
+        },
+      ],
+    });
+    expect(contact.userFile).toBe("alice.md");
+  });
+
+  test("still auto-increments when principalId is not set and displayName collides", () => {
+    const first = upsertContact({
+      displayName: "Akash",
+      role: "contact",
+      channels: [
+        {
+          type: "slack",
+          address: "uakash1",
+          externalUserId: "UAKASH1",
+          externalChatId: "DAKASH1",
+        },
+      ],
+    });
+    const second = upsertContact({
+      displayName: "Akash",
+      role: "contact",
+      channels: [
+        {
+          type: "slack",
+          address: "uakash2",
+          externalUserId: "UAKASH2",
+          externalChatId: "DAKASH2",
+        },
+      ],
+    });
+    expect(first.userFile).toBe("akash.md");
+    expect(second.userFile).toBe("akash-2.md");
+  });
+
+  test("ignores a sibling whose userFile is null and generates a new slug", () => {
+    insertContact({
+      id: "seed-null",
+      displayName: "legacy",
+      role: "guardian",
+      principalId: "principal-null",
+      userFile: null,
+      createdAt: Date.now(),
+    });
+
+    const contact = upsertContact({
+      displayName: "Legacy",
+      role: "guardian",
+      principalId: "principal-null",
+      channels: [
+        {
+          type: "phone",
+          address: "+15550000",
+          externalUserId: "+15550000",
+          externalChatId: "+15550000",
+        },
+      ],
+    });
+    expect(contact.userFile).toBe("legacy.md");
+  });
+});
+
+describe("generateUserFileSlug", () => {
+  beforeEach(() => {
+    resetContactTables();
+  });
+
+  test("returns base slug when unused", () => {
+    expect(generateUserFileSlug("Alice")).toBe("alice.md");
+  });
+
+  test("auto-increments on collision", () => {
+    insertContact({
+      id: "a",
+      displayName: "Alice",
+      role: "contact",
+      principalId: null,
+      userFile: "alice.md",
+      createdAt: Date.now(),
+    });
+    expect(generateUserFileSlug("Alice")).toBe("alice-2.md");
+  });
+});
+
+describe("migrateNormalizeUserFileByPrincipal", () => {
+  beforeEach(() => {
+    resetContactTables();
+  });
+
+  test("normalizes split user_file values across sibling contacts", () => {
+    const now = Date.now();
+    insertContact({
+      id: "c1",
+      displayName: "sidd",
+      role: "guardian",
+      principalId: "principal-x",
+      userFile: "sidd.md",
+      createdAt: now - 1000,
+    });
+    insertContact({
+      id: "c2",
+      displayName: "sidd",
+      role: "guardian",
+      principalId: "principal-x",
+      userFile: "sidd-2.md",
+      createdAt: now,
+    });
+
+    migrateNormalizeUserFileByPrincipal(getDb());
+
+    const rows = fetchUserFilesByPrincipal("principal-x");
+    expect(rows).toHaveLength(2);
+    expect(rows[0]?.user_file).toBe("sidd.md");
+    expect(rows[1]?.user_file).toBe("sidd.md");
+  });
+
+  test("propagates a sibling's user_file to NULL rows", () => {
+    const now = Date.now();
+    insertContact({
+      id: "c1",
+      displayName: "sidd",
+      role: "guardian",
+      principalId: "principal-y",
+      userFile: "sidd.md",
+      createdAt: now - 1000,
+    });
+    insertContact({
+      id: "c2",
+      displayName: "sidd",
+      role: "guardian",
+      principalId: "principal-y",
+      userFile: null,
+      createdAt: now,
+    });
+
+    migrateNormalizeUserFileByPrincipal(getDb());
+
+    const rows = fetchUserFilesByPrincipal("principal-y");
+    expect(rows[0]?.user_file).toBe("sidd.md");
+    expect(rows[1]?.user_file).toBe("sidd.md");
+  });
+
+  test("prefers non-auto-incremented candidate over auto-incremented older row", () => {
+    // Older contact has an auto-incremented name, newer has the clean one.
+    // Heuristic should pick the clean one regardless of age.
+    const now = Date.now();
+    insertContact({
+      id: "c1",
+      displayName: "sidd",
+      role: "guardian",
+      principalId: "principal-z",
+      userFile: "sidd-3.md",
+      createdAt: now - 2000,
+    });
+    insertContact({
+      id: "c2",
+      displayName: "sidd",
+      role: "guardian",
+      principalId: "principal-z",
+      userFile: "sidd.md",
+      createdAt: now,
+    });
+
+    migrateNormalizeUserFileByPrincipal(getDb());
+
+    const rows = fetchUserFilesByPrincipal("principal-z");
+    expect(rows[0]?.user_file).toBe("sidd.md");
+    expect(rows[1]?.user_file).toBe("sidd.md");
+  });
+
+  test("leaves untouched when only one contact exists for a principal", () => {
+    insertContact({
+      id: "solo",
+      displayName: "Alone",
+      role: "contact",
+      principalId: "principal-solo",
+      userFile: "alone.md",
+      createdAt: Date.now(),
+    });
+
+    migrateNormalizeUserFileByPrincipal(getDb());
+
+    const rows = fetchUserFilesByPrincipal("principal-solo");
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.user_file).toBe("alone.md");
+  });
+
+  test("is idempotent", () => {
+    const now = Date.now();
+    insertContact({
+      id: "c1",
+      displayName: "sidd",
+      role: "guardian",
+      principalId: "principal-i",
+      userFile: "sidd.md",
+      createdAt: now - 1000,
+    });
+    insertContact({
+      id: "c2",
+      displayName: "sidd",
+      role: "guardian",
+      principalId: "principal-i",
+      userFile: "sidd-2.md",
+      createdAt: now,
+    });
+
+    migrateNormalizeUserFileByPrincipal(getDb());
+    migrateNormalizeUserFileByPrincipal(getDb());
+
+    const rows = fetchUserFilesByPrincipal("principal-i");
+    for (const row of rows) expect(row.user_file).toBe("sidd.md");
+  });
+});

--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, like, sql } from "drizzle-orm";
+import { and, asc, desc, eq, isNotNull, like, sql } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import { getDb } from "../memory/db.js";
@@ -273,10 +273,27 @@ export function upsertContact(params: {
 
   // Create new contact
   contactId = contactId ?? uuid();
-  const userFileValue =
-    params.userFile !== undefined
-      ? params.userFile
-      : generateUserFileSlug(params.displayName);
+  // Sibling contacts sharing a principal_id must share a user_file so every
+  // channel for one principal resolves to the same persona + journal slug.
+  let resolvedUserFile: string | null;
+  if (params.userFile !== undefined) {
+    resolvedUserFile = params.userFile;
+  } else if (params.principalId) {
+    const sibling = db
+      .select({ userFile: contacts.userFile })
+      .from(contacts)
+      .where(
+        and(
+          eq(contacts.principalId, params.principalId),
+          isNotNull(contacts.userFile),
+        ),
+      )
+      .get();
+    resolvedUserFile =
+      sibling?.userFile ?? generateUserFileSlug(params.displayName);
+  } else {
+    resolvedUserFile = generateUserFileSlug(params.displayName);
+  }
   db.insert(contacts)
     .values({
       id: contactId,
@@ -285,7 +302,7 @@ export function upsertContact(params: {
       role: params.role ?? "contact",
       contactType: params.contactType ?? "human",
       principalId: params.principalId ?? null,
-      userFile: userFileValue ?? null,
+      userFile: resolvedUserFile,
       createdAt: now,
       updatedAt: now,
     })

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -106,6 +106,7 @@ import {
   migrateMessagesConversationCreatedAtIndex,
   migrateMessagesFtsBackfill,
   migrateNormalizePhoneIdentities,
+  migrateNormalizeUserFileByPrincipal,
   migrateNotificationDeliveryThreadDecision,
   migrateOAuthAppsClientSecretPath,
   migrateOAuthProvidersBehaviorColumns,
@@ -366,6 +367,7 @@ export function initializeDb(): void {
     migrateConversationHostAccess,
     migrateOAuthProvidersLogoUrl,
     migrateOAuthProvidersTokenExchangeBodyFormat,
+    migrateNormalizeUserFileByPrincipal,
   ];
 
   // Run each migration step, catching and logging individual failures so one

--- a/assistant/src/memory/migrations/220-normalize-user-file-by-principal.ts
+++ b/assistant/src/memory/migrations/220-normalize-user-file-by-principal.ts
@@ -1,0 +1,126 @@
+import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
+import { withCrashRecovery } from "./validate-migration-state.js";
+
+/**
+ * Reverse is a no-op. This migration only consolidates `user_file` across
+ * contacts sharing the same `principal_id`; the pre-migration split values
+ * cannot be reconstructed after normalization, and no schema changes.
+ */
+export function downNormalizeUserFileByPrincipal(_database: DrizzleDb): void {
+  /* no-op */
+}
+
+/**
+ * Normalize `contacts.user_file` across contact rows that share the same
+ * `principal_id`.
+ *
+ * Multiple contact rows may represent the same principal (one per channel:
+ * desktop, phone, Slack, etc.). When a new row was created for a second
+ * channel, `generateUserFileSlug(displayName)` auto-incremented to avoid a
+ * filename collision (e.g. `sidd.md` → `sidd-2.md`), even though no
+ * `sidd-2.md` file ever existed on disk. The persona resolver then silently
+ * fell back to `users/default.md` for that channel's messages — and the same
+ * slug is used for the journal directory, so the user lost per-principal
+ * continuity on every non-primary channel.
+ *
+ * This migration picks one canonical `user_file` per principal and updates
+ * every sibling row to match. Selection heuristic:
+ *
+ *   1. Prefer values that do NOT look auto-incremented (no `-<digit>.md` tail).
+ *   2. Among those, prefer the oldest contact row (earliest `created_at`).
+ *   3. Ties broken by `id` for determinism.
+ *
+ * Skips principals where only one distinct (non-null) value exists — nothing
+ * to normalize. Principals whose contacts all have `user_file = NULL` are
+ * left untouched; the code path in `upsertContact` will populate them on the
+ * next write.
+ */
+export function migrateNormalizeUserFileByPrincipal(
+  database: DrizzleDb,
+): void {
+  withCrashRecovery(
+    database,
+    "migration_normalize_user_file_by_principal_v1",
+    () => {
+      const raw = getSqliteFrom(database);
+
+      const tableExists = raw
+        .query(
+          `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'contacts'`,
+        )
+        .get();
+      if (!tableExists) return;
+
+      const userFileColExists = raw
+        .query(
+          `SELECT 1 FROM pragma_table_info('contacts') WHERE name = 'user_file'`,
+        )
+        .get();
+      const principalColExists = raw
+        .query(
+          `SELECT 1 FROM pragma_table_info('contacts') WHERE name = 'principal_id'`,
+        )
+        .get();
+      if (!userFileColExists || !principalColExists) return;
+
+      try {
+        raw.exec("BEGIN");
+
+        const principals = raw
+          .query(
+            /*sql*/ `
+            SELECT principal_id
+            FROM contacts
+            WHERE principal_id IS NOT NULL
+            GROUP BY principal_id
+            HAVING COUNT(DISTINCT COALESCE(user_file, '')) > 1
+          `,
+          )
+          .all() as Array<{ principal_id: string }>;
+
+        const selectCanonical = raw.prepare(
+          /*sql*/ `
+          SELECT user_file FROM contacts
+          WHERE principal_id = ? AND user_file IS NOT NULL
+          ORDER BY
+            CASE WHEN user_file GLOB '*-[0-9]*.md' THEN 1 ELSE 0 END,
+            created_at ASC,
+            id ASC
+          LIMIT 1
+          `,
+        );
+
+        const updateSiblings = raw.prepare(
+          /*sql*/ `
+          UPDATE contacts
+          SET user_file = ?, updated_at = ?
+          WHERE principal_id = ?
+            AND (user_file IS NULL OR user_file != ?)
+          `,
+        );
+
+        for (const { principal_id } of principals) {
+          const canonical = selectCanonical.get(principal_id) as {
+            user_file: string;
+          } | null;
+          if (!canonical?.user_file) continue;
+          updateSiblings.run(
+            canonical.user_file,
+            Date.now(),
+            principal_id,
+            canonical.user_file,
+          );
+        }
+
+        raw.exec("COMMIT");
+      } catch (e) {
+        try {
+          raw.exec("ROLLBACK");
+        } catch {
+          /* no active transaction */
+        }
+        throw e;
+      }
+    },
+  );
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -162,6 +162,10 @@ export { migrateConversationHostAccess } from "./217-conversation-host-access.js
 export { migrateOAuthProvidersLogoUrl } from "./218-oauth-providers-logo-url.js";
 export { migrateOAuthProvidersTokenExchangeBodyFormat } from "./219-oauth-providers-token-exchange-body-format.js";
 export {
+  downNormalizeUserFileByPrincipal,
+  migrateNormalizeUserFileByPrincipal,
+} from "./220-normalize-user-file-by-principal.js";
+export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,
   type MigrationValidationResult,

--- a/assistant/src/memory/migrations/registry.ts
+++ b/assistant/src/memory/migrations/registry.ts
@@ -42,6 +42,7 @@ import { migrateStripIntegrationPrefixFromProviderKeysDown } from "./196-strip-i
 import { migrateRenameMemoryGraphTypeValuesDown } from "./204-rename-memory-graph-type-values.js";
 import { migrateScrubCorruptedImageAttachmentsDown } from "./206-scrub-corrupted-image-attachments.js";
 import { downConversationHostAccess } from "./217-conversation-host-access.js";
+import { downNormalizeUserFileByPrincipal } from "./220-normalize-user-file-by-principal.js";
 
 export interface MigrationRegistryEntry {
   /** The checkpoint key written to memory_checkpoints on completion. */
@@ -364,6 +365,13 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     description:
       "Add a host_access column to conversations so computer access is persisted per conversation with a safe default of disabled",
     down: downConversationHostAccess,
+  },
+  {
+    key: "migration_normalize_user_file_by_principal_v1",
+    version: 42,
+    description:
+      "Normalize contacts.user_file across rows sharing the same principal_id so every channel for one principal loads the same users/<slug>.md persona and journal directory",
+    down: downNormalizeUserFileByPrincipal,
   },
 ];
 


### PR DESCRIPTION
## Summary
- New contact rows created for a principal that already has siblings now inherit the existing user_file instead of auto-incrementing to a filename that doesn't exist on disk.
- Migration 220 backfills historical split values across rows sharing a principal_id so existing instances self-heal on next daemon startup.
- Tests cover the inheritance path, the collision-with-unrelated-contacts path, and each migration branch (split values, NULL propagation, clean-name preference, idempotency).

## Original prompt
When I send Velissa a message in Slack, users/sidd.md doesn't load and users/default.md loads instead. When I'm DMing Velissa, sidd.md should load. Whenever someone else is DMing her (and they don't have a user file configured) default.md should load.

## Root cause
Velissa's contacts DB had three guardian rows sharing one principal_id (desktop/phone/slack). The Slack row was created after the desktop row already owned sidd.md, so generateUserFileSlug assigned it sidd-2.md. That file never existed, so persona-resolver fell back to users/default.md — and resolveUserSlug similarly resolved to "sidd-2", breaking the journal directory lookup for every Slack message.