### PR TITLE
chore(openapi): regenerate spec for usage tz query param

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -7862,6 +7862,14 @@ paths:
               - daily
               - hourly
           description: 'Bucket granularity: "daily" (default) or "hourly"'
+        - name: tz
+          in: query
+          required: false
+          schema:
+            type: string
+          description:
+            IANA timezone identifier (e.g. "America/Los_Angeles"). Bucket boundaries and display labels are computed in
+            this timezone. Defaults to "UTC" for backwards compatibility.
   /v1/usage/totals:
     get:
       operationId: usage_totals_get


### PR DESCRIPTION
## Summary
- Regenerate `assistant/openapi.yaml` to include the `tz` query parameter on `/v1/usage/trend` that was added in deed6a41b but not committed to the spec.
- Unblocks the `OpenAPI Spec Check` job on `CI Main Assistant Checks` which was failing on main with `openapi.yaml is stale`.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24272751227/job/70880819782