### PR TITLE
fix(macos): wrap assistant-change observer in MainActor.assumeIsolated

### DIFF
--- a/clients/shared/Network/GatewayConnectionManager.swift
+++ b/clients/shared/Network/GatewayConnectionManager.swift
@@ -153,7 +153,9 @@ public final class GatewayConnectionManager: ObservableObject {
             object: nil,
             queue: .main
         ) { [weak self] _ in
-            self?.refreshCachedAssistant()
+            MainActor.assumeIsolated {
+                self?.refreshCachedAssistant()
+            }
         }
         #endif
     }


### PR DESCRIPTION
## Summary
- Wraps the `refreshCachedAssistant()` call inside the `activeAssistantDidChange` NotificationCenter observer in `MainActor.assumeIsolated` to silence a Swift 6 actor-isolation warning.
- The observer already runs on `.main`, so asserting main-actor isolation is safe and matches the idiomatic pattern used for the sleep/wake observers in `AppDelegate+SleepWake.swift`.

## Original prompt
Fix: ~v/clients/macos (main) ❯❯❯ VELLUM_NO_WATCH=1 ./build.sh run
VELLUM_ENVIRONMENT=local
Building (debug)...
[1/1] Planning build
Building for debugging...
/Users/sidd/vocify/vellum-assistant/clients/shared/Network/GatewayConnectionManager.swift:156:19: warning: call to main actor-isolated instance method 'refreshCachedAssistant()' in a synchronous nonisolated context [#ActorIsolatedCall]
154 |             queue: .main
155 |         ) { [weak self] _ in
156 |             self?.refreshCachedAssistant()
    |                   \`- warning: call to main actor-isolated instance method 'refreshCachedAssistant()' in a synchronous nonisolated context [#ActorIsolatedCall]
157 |         }
158 |         #endif
    :
806 |     /// Synchronously refreshes the cached assistant snapshot from the lockfile.
807 |     /// Called during connect and when \`activeAssistantDidChange\` fires.
808 |     private func refreshCachedAssistant() {
    |                  \`- note: calls to instance method 'refreshCachedAssistant()' from outside of its actor context are implicitly asynchronous
809 |         let id: String?
810 |         if let activeId = LockfileAssistant.loadActiveAssistantId(), !activeId.isEmpty {