### PR TITLE
feat(macos): make Usage breakdown conversation rows clickable

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/LogsAndUsagePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/LogsAndUsagePanel.swift
@@ -306,6 +306,7 @@ struct UsageTabContent: View {
 
     @State private var refreshTask: Task<Void, Never>?
     @State private var breakdownTask: Task<Void, Never>?
+    @State private var hoveredConversationGroupId: String?
 
     private var allFailed: Bool {
         store.totalsState.isFailed && store.dailyState.isFailed && store.breakdownState.isFailed
@@ -603,27 +604,75 @@ struct UsageTabContent: View {
         .frame(maxWidth: breakdownTableWidth, alignment: .leading)
     }
 
+    /// Returns the conversation id that a tap on `entry`'s row should
+    /// navigate to, or `nil` if the row is not navigable (non-conversation
+    /// group-by, or the "Other" bucket whose `groupId` is nil). Extracted as a
+    /// pure helper so it can be unit-tested without mounting the view.
+    func navigationTarget(for entry: UsageGroupBreakdownEntry) -> String? {
+        guard store.selectedGroupBy == .conversation else { return nil }
+        return entry.groupId
+    }
+
     @ViewBuilder
     func breakdownRow(_ entry: UsageGroupBreakdownEntry) -> some View {
-        HStack(alignment: .top, spacing: VSpacing.sm) {
-            Text(entry.group)
-                .font(VFont.bodyMediumLighter)
-                .foregroundStyle(VColor.contentDefault)
-                .frame(width: groupColumnWidth, alignment: .leading)
-                .lineLimit(store.selectedGroupBy == .conversation ? 2 : 1)
-            Text(UsageFormatting.formatBreakdownSummary(entry))
-                .font(VFont.labelDefault)
-                .foregroundStyle(VColor.contentSecondary)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .lineLimit(2)
-                .multilineTextAlignment(.leading)
-            Text(formatCost(entry.totalEstimatedCostUsd))
-                .font(VFont.bodyMediumLighter)
-                .foregroundStyle(VColor.contentDefault)
-                .frame(width: 70, alignment: .trailing)
+        let target = navigationTarget(for: entry)
+        let isHovered = target != nil && hoveredConversationGroupId == target
+        let titleColor: Color = isHovered ? VColor.contentEmphasized : VColor.contentDefault
+
+        if let target {
+            HStack(alignment: .top, spacing: VSpacing.sm) {
+                Text(entry.group)
+                    .font(VFont.bodyMediumLighter)
+                    .foregroundStyle(titleColor)
+                    .frame(width: groupColumnWidth, alignment: .leading)
+                    .lineLimit(store.selectedGroupBy == .conversation ? 2 : 1)
+                Text(UsageFormatting.formatBreakdownSummary(entry))
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentSecondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .lineLimit(2)
+                    .multilineTextAlignment(.leading)
+                Text(formatCost(entry.totalEstimatedCostUsd))
+                    .font(VFont.bodyMediumLighter)
+                    .foregroundStyle(VColor.contentDefault)
+                    .frame(width: 70, alignment: .trailing)
+            }
+            .padding(.horizontal, VSpacing.md)
+            .padding(.vertical, VSpacing.sm)
+            .background(VColor.borderBase.opacity(isHovered ? 0.15 : 0))
+            .contentShape(Rectangle())
+            .onTapGesture {
+                onSelectConversation(target)
+            }
+            .onHover { hovering in
+                hoveredConversationGroupId = hovering ? target : nil
+                if hovering {
+                    NSCursor.pointingHand.push()
+                } else {
+                    NSCursor.pop()
+                }
+            }
+        } else {
+            HStack(alignment: .top, spacing: VSpacing.sm) {
+                Text(entry.group)
+                    .font(VFont.bodyMediumLighter)
+                    .foregroundStyle(VColor.contentDefault)
+                    .frame(width: groupColumnWidth, alignment: .leading)
+                    .lineLimit(store.selectedGroupBy == .conversation ? 2 : 1)
+                Text(UsageFormatting.formatBreakdownSummary(entry))
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentSecondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .lineLimit(2)
+                    .multilineTextAlignment(.leading)
+                Text(formatCost(entry.totalEstimatedCostUsd))
+                    .font(VFont.bodyMediumLighter)
+                    .foregroundStyle(VColor.contentDefault)
+                    .frame(width: 70, alignment: .trailing)
+            }
+            .padding(.horizontal, VSpacing.md)
+            .padding(.vertical, VSpacing.sm)
         }
-        .padding(.horizontal, VSpacing.md)
-        .padding(.vertical, VSpacing.sm)
     }
 
     // MARK: - Shared Components

--- a/clients/macos/vellum-assistantTests/UsageDashboardPanelTests.swift
+++ b/clients/macos/vellum-assistantTests/UsageDashboardPanelTests.swift
@@ -271,6 +271,148 @@ struct UsageGroupBreakdownEntryGroupIdDecodingTests {
     }
 }
 
+// MARK: - Conversation Row Interactivity
+
+/// These tests exercise `UsageTabContent.navigationTarget(for:)` — the pure
+/// helper that decides whether a breakdown row should navigate to a
+/// conversation on tap. The row's `.onTapGesture` calls `onSelectConversation`
+/// only when this helper returns a non-nil groupId, so unit-testing the
+/// helper directly is equivalent to testing the tap outcome without
+/// needing a SwiftUI view hosting harness.
+
+@Suite("UsageTabContent — Conversation row interactivity")
+struct UsageTabContentConversationRowInteractivityTests {
+
+    private static let conversationEntry = UsageGroupBreakdownEntry(
+        group: "Designing the usage dashboard",
+        groupId: "conv_abc",
+        totalInputTokens: 1_000,
+        totalOutputTokens: 500,
+        totalCacheCreationTokens: 0,
+        totalCacheReadTokens: 0,
+        totalEstimatedCostUsd: 0.05,
+        eventCount: 3
+    )
+
+    private static let otherBucketEntry = UsageGroupBreakdownEntry(
+        group: "Other",
+        groupId: nil,
+        totalInputTokens: 200,
+        totalOutputTokens: 100,
+        totalCacheCreationTokens: 0,
+        totalCacheReadTokens: 0,
+        totalEstimatedCostUsd: 0.01,
+        eventCount: 1
+    )
+
+    private static let modelEntry = UsageGroupBreakdownEntry(
+        group: "claude-sonnet-4-20250514",
+        totalInputTokens: 1_000,
+        totalOutputTokens: 500,
+        totalCacheCreationTokens: 0,
+        totalCacheReadTokens: 0,
+        totalEstimatedCostUsd: 0.05,
+        eventCount: 3
+    )
+
+    @Test @MainActor
+    func conversationRowWithGroupIdTriggersNavigationAndInvokesClosure() async {
+        let client = MockPanelClient()
+        client.stubbedBreakdown = UsageBreakdownResponse(breakdown: [Self.conversationEntry])
+        let store = UsageDashboardStore()
+        store.updateClient(client)
+        await store.selectGroupBy(.conversation)
+
+        var captured: [String] = []
+        let tab = UsageTabContent(
+            store: store,
+            onSelectConversation: { captured.append($0) }
+        )
+
+        // The pure helper is the single source of truth for whether a tap
+        // navigates — the row's .onTapGesture fires onSelectConversation only
+        // when this returns non-nil.
+        #expect(tab.navigationTarget(for: Self.conversationEntry) == "conv_abc")
+
+        if let target = tab.navigationTarget(for: Self.conversationEntry) {
+            tab.onSelectConversation(target)
+        }
+        #expect(captured == ["conv_abc"])
+    }
+
+    @Test @MainActor
+    func otherBucketWithNilGroupIdDoesNotNavigate() async {
+        let client = MockPanelClient()
+        client.stubbedBreakdown = UsageBreakdownResponse(breakdown: [Self.otherBucketEntry])
+        let store = UsageDashboardStore()
+        store.updateClient(client)
+        await store.selectGroupBy(.conversation)
+
+        var captured: [String] = []
+        let tab = UsageTabContent(
+            store: store,
+            onSelectConversation: { captured.append($0) }
+        )
+
+        #expect(tab.navigationTarget(for: Self.otherBucketEntry) == nil)
+
+        // A tap on an "Other" row never reaches onSelectConversation because
+        // the inert branch of breakdownRow omits .onTapGesture. Mirror that
+        // behavior here: invoke the closure only when the helper returns
+        // non-nil. captured must remain empty.
+        if let target = tab.navigationTarget(for: Self.otherBucketEntry) {
+            tab.onSelectConversation(target)
+        }
+        #expect(captured.isEmpty)
+    }
+
+    @Test @MainActor
+    func modelGroupByDoesNotNavigateEvenWithPopulatedEntry() async {
+        let client = MockPanelClient()
+        client.stubbedBreakdown = UsageBreakdownResponse(breakdown: [Self.modelEntry])
+        let store = UsageDashboardStore()
+        store.updateClient(client)
+        // Default groupBy is .model — do not switch it.
+
+        var captured: [String] = []
+        let tab = UsageTabContent(
+            store: store,
+            onSelectConversation: { captured.append($0) }
+        )
+
+        #expect(store.selectedGroupBy == .model)
+        #expect(tab.navigationTarget(for: Self.modelEntry) == nil)
+
+        if let target = tab.navigationTarget(for: Self.modelEntry) {
+            tab.onSelectConversation(target)
+        }
+        #expect(captured.isEmpty)
+    }
+
+    @Test @MainActor
+    func conversationEntryWithGroupIdInertWhenGroupedByProvider() async {
+        // Even a conversation-shaped entry (groupId non-nil) must not
+        // navigate if the store is grouped by something other than
+        // .conversation — the helper gates on groupBy first.
+        let client = MockPanelClient()
+        let store = UsageDashboardStore()
+        store.updateClient(client)
+        await store.selectGroupBy(.provider)
+
+        var captured: [String] = []
+        let tab = UsageTabContent(
+            store: store,
+            onSelectConversation: { captured.append($0) }
+        )
+
+        #expect(tab.navigationTarget(for: Self.conversationEntry) == nil)
+        if let target = tab.navigationTarget(for: Self.conversationEntry) {
+            tab.onSelectConversation(target)
+        }
+        #expect(captured.isEmpty)
+    }
+}
+
 // MARK: - View Content Helper
 
 /// Dumps the tab's section view trees so that all Text content is captured
@@ -279,7 +421,7 @@ struct UsageGroupBreakdownEntryGroupIdDecodingTests {
 /// each section's body to expand those closures.
 @MainActor
 private func collectTabContent(store: UsageDashboardStore) -> String {
-    let tab = UsageTabContent(store: store)
+    let tab = UsageTabContent(store: store, onSelectConversation: { _ in })
     var output = ""
     dump(tab.totalsSection(store: store).body, to: &output)
     dump(tab.dailySection(store: store).body, to: &output)
@@ -291,7 +433,7 @@ private func collectTabContent(store: UsageDashboardStore) -> String {
 private func collectBreakdownRow(entry: UsageGroupBreakdownEntry) -> String {
     let helperStore = UsageDashboardStore()
     helperStore.updateClient(MockPanelClient())
-    let tab = UsageTabContent(store: helperStore)
+    let tab = UsageTabContent(store: helperStore, onSelectConversation: { _ in })
     let row = tab.breakdownRow(entry)
     var output = ""
     dump(row, to: &output)


### PR DESCRIPTION
## Summary
- Make `breakdownRow` in the Usage panel interactive when grouping by conversation and a non-nil `groupId` is present
- Hover highlight + pointing-hand cursor + link-style emphasis on the title
- Tap invokes the already-plumbed `onSelectConversation` closure, which navigates via `ConversationManager.selectConversationByConversationIdAsync`
- Add panel tests covering the conversation row, the "Other" bucket (`nil` groupId), and non-conversation group-bys

Part of plan: usage-conv-links.md (PR 4 of 4)