### PR TITLE
fix(usage): select NULL as group_id in non-conversation breakdown branch

### DIFF
--- a/assistant/src/memory/llm-usage-store.ts
+++ b/assistant/src/memory/llm-usage-store.ts
@@ -383,6 +383,7 @@ export function getUsageGroupBreakdown(
     /*sql*/ `
     SELECT
       ${column}                                      AS group_key,
+      NULL                                           AS group_id,
       COALESCE(SUM(input_tokens), 0)                 AS total_input_tokens,
       COALESCE(SUM(output_tokens), 0)                AS total_output_tokens,
       COALESCE(SUM(cache_creation_input_tokens), 0)  AS total_cache_creation_tokens,
@@ -401,8 +402,9 @@ export function getUsageGroupBreakdown(
     group: r.group_key,
     // Non-conversation group-bys (actor/provider/model) don't have a
     // separate stable id — the grouping column itself is the identifier
-    // and is already exposed via `group`.
-    groupId: null,
+    // and is already exposed via `group`. The SELECT projects
+    // `NULL AS group_id` so the runtime shape matches `GroupRow`.
+    groupId: r.group_id,
     totalInputTokens: r.total_input_tokens,
     totalOutputTokens: r.total_output_tokens,
     totalCacheCreationTokens: r.total_cache_creation_tokens,


### PR DESCRIPTION
## Summary
Fix a type lie identified during plan review for usage-conv-links.md:
- `GroupRow` declares `group_id: string | null` as required, but the non-conversation SELECT branch (actor/provider/model) did not project it, so runtime rows had `group_id: undefined`.
- Add `NULL AS group_id` to the non-conversation SELECT and read from `r.group_id` in the projection. Behavior is unchanged (still resolves to `null`) but the runtime shape now matches the declared type.

Part of plan: usage-conv-links.md (review remediation)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24729" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
