### PR TITLE
fix(macos): use .pointerCursor and dedup Usage breakdown row

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/LogsAndUsagePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/LogsAndUsagePanel.swift
@@ -619,59 +619,38 @@ struct UsageTabContent: View {
         let isHovered = target != nil && hoveredConversationGroupId == target
         let titleColor: Color = isHovered ? VColor.contentEmphasized : VColor.contentDefault
 
+        let row = HStack(alignment: .top, spacing: VSpacing.sm) {
+            Text(entry.group)
+                .font(VFont.bodyMediumLighter)
+                .foregroundStyle(titleColor)
+                .frame(width: groupColumnWidth, alignment: .leading)
+                .lineLimit(store.selectedGroupBy == .conversation ? 2 : 1)
+            Text(UsageFormatting.formatBreakdownSummary(entry))
+                .font(VFont.labelDefault)
+                .foregroundStyle(VColor.contentSecondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .lineLimit(2)
+                .multilineTextAlignment(.leading)
+            Text(formatCost(entry.totalEstimatedCostUsd))
+                .font(VFont.bodyMediumLighter)
+                .foregroundStyle(VColor.contentDefault)
+                .frame(width: 70, alignment: .trailing)
+        }
+        .padding(.horizontal, VSpacing.md)
+        .padding(.vertical, VSpacing.sm)
+
         if let target {
-            HStack(alignment: .top, spacing: VSpacing.sm) {
-                Text(entry.group)
-                    .font(VFont.bodyMediumLighter)
-                    .foregroundStyle(titleColor)
-                    .frame(width: groupColumnWidth, alignment: .leading)
-                    .lineLimit(store.selectedGroupBy == .conversation ? 2 : 1)
-                Text(UsageFormatting.formatBreakdownSummary(entry))
-                    .font(VFont.labelDefault)
-                    .foregroundStyle(VColor.contentSecondary)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .lineLimit(2)
-                    .multilineTextAlignment(.leading)
-                Text(formatCost(entry.totalEstimatedCostUsd))
-                    .font(VFont.bodyMediumLighter)
-                    .foregroundStyle(VColor.contentDefault)
-                    .frame(width: 70, alignment: .trailing)
-            }
-            .padding(.horizontal, VSpacing.md)
-            .padding(.vertical, VSpacing.sm)
-            .background(VColor.borderBase.opacity(isHovered ? 0.15 : 0))
-            .contentShape(Rectangle())
-            .onTapGesture {
-                onSelectConversation(target)
-            }
-            .onHover { hovering in
-                hoveredConversationGroupId = hovering ? target : nil
-                if hovering {
-                    NSCursor.pointingHand.push()
-                } else {
-                    NSCursor.pop()
+            row
+                .background(VColor.borderBase.opacity(isHovered ? 0.15 : 0))
+                .contentShape(Rectangle())
+                .onTapGesture {
+                    onSelectConversation(target)
                 }
-            }
+                .pointerCursor { hovering in
+                    hoveredConversationGroupId = hovering ? target : nil
+                }
         } else {
-            HStack(alignment: .top, spacing: VSpacing.sm) {
-                Text(entry.group)
-                    .font(VFont.bodyMediumLighter)
-                    .foregroundStyle(VColor.contentDefault)
-                    .frame(width: groupColumnWidth, alignment: .leading)
-                    .lineLimit(store.selectedGroupBy == .conversation ? 2 : 1)
-                Text(UsageFormatting.formatBreakdownSummary(entry))
-                    .font(VFont.labelDefault)
-                    .foregroundStyle(VColor.contentSecondary)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .lineLimit(2)
-                    .multilineTextAlignment(.leading)
-                Text(formatCost(entry.totalEstimatedCostUsd))
-                    .font(VFont.bodyMediumLighter)
-                    .foregroundStyle(VColor.contentDefault)
-                    .frame(width: 70, alignment: .trailing)
-            }
-            .padding(.horizontal, VSpacing.md)
-            .padding(.vertical, VSpacing.sm)
+            row
         }
     }
 


### PR DESCRIPTION
## Summary
Fixes two gaps identified during plan review for usage-conv-links.md:
- Replace manual `NSCursor.pointingHand.push()/pop()` in `breakdownRow` with the repo-standard `.pointerCursor` SwiftUI view modifier (as used in `VCard` and `SidebarConversationItem`). Manual NSCursor stack management is vulnerable to unbalanced operations on rapid row transitions or view disappearance.
- Collapse the duplicated `HStack` body between the interactive and inert branches of `breakdownRow` into a single shared body with conditional modifiers on top.

Part of plan: usage-conv-links.md (review remediation)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24730" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
