### PR TITLE
fix(macos): enable text selection in step technical details

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -865,6 +865,7 @@ private struct StepDetailRow: View {
             }
         }
         .padding(.bottom, VSpacing.sm)
+        .textSelection(.enabled)
     }
 
     // MARK: - Output Block


### PR DESCRIPTION
## Summary
- Add `.textSelection(.enabled)` to `StepDetailRow.stepDetailContent` so users can drag-select and copy text inside expanded step technical details (input block, live output, diff-colored output, and surrounding labels).
- SwiftUI propagates the modifier to every descendant `Text`, so a single modifier on the container covers all detail text at once. The Button header is a sibling, not a parent, so click-to-expand behavior is unaffected.

## Original prompt
it