### PR TITLE
fix(macos): preserve thinking block expansion across active-turn transitions

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -665,10 +665,11 @@ struct ChatBubble: View, Equatable {
         let hasAttachments = !message.attachments.isEmpty
 
         VStack(alignment: .leading, spacing: VSpacing.sm) {
-            ForEach(Array(thinkingChunks.enumerated()), id: \.offset) { _, content in
+            ForEach(Array(thinkingChunks.enumerated()), id: \.offset) { offset, content in
                 ThinkingBlockView(
                     content: content,
                     isStreaming: message.isStreaming,
+                    expansionKey: "\(message.id.uuidString)-inline-\(offset)",
                     typographyGeneration: typographyGeneration
                 )
             }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
@@ -467,6 +467,7 @@ extension ChatBubble {
                         ThinkingBlockView(
                             content: joined,
                             isStreaming: message.isStreaming,
+                            expansionKey: "\(message.id.uuidString)-th\(indices.first ?? 0)",
                             typographyGeneration: typographyGeneration
                         )
                     }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
@@ -21,7 +21,7 @@ extension ChatBubble {
            MacOSClientFeatureFlagManager.shared.isEnabled("show-thinking-blocks") {
             let chunks = parseInlineThinkingTags(segmentText)
             VStack(alignment: .leading, spacing: VSpacing.sm) {
-                ForEach(Array(chunks.enumerated()), id: \.offset) { _, chunk in
+                ForEach(Array(chunks.enumerated()), id: \.offset) { offset, chunk in
                     switch chunk {
                     case .text(let body):
                         let trimmed = body.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -32,6 +32,7 @@ extension ChatBubble {
                         ThinkingBlockView(
                             content: body,
                             isStreaming: message.isStreaming,
+                            expansionKey: "\(message.id.uuidString)-txt\(segmentText.hashValue)-\(offset)",
                             typographyGeneration: typographyGeneration
                         )
                     }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -109,6 +109,12 @@ struct MessageListView: View {
     /// Native SwiftUI scroll position struct (macOS 15+). Replaces
     /// `ScrollViewReader` + `proxy.scrollTo()` and distance-from-bottom math.
     @State var scrollPosition = ScrollPosition()
+    /// Tracks expand/collapse state for every thinking block in this list.
+    /// Owned here (above the `.if` min-height wrapper in
+    /// `MessageListContentView`) so the state survives the view-tree
+    /// destruction that happens when `state.isActiveTurn` flips at the
+    /// start/end of an active turn. See `ThinkingBlockExpansionStore.swift`.
+    @State var thinkingBlockExpansionStore = ThinkingBlockExpansionStore()
 
     // MARK: - Body
 
@@ -150,6 +156,7 @@ struct MessageListView: View {
             // https://developer.apple.com/documentation/swiftui/view/defaultscrollanchor(_:for:)
             .defaultScrollAnchor(.bottom, for: .initialOffset)
             .scrollPosition($scrollPosition)
+            .environment(\.thinkingBlockExpansionStore, thinkingBlockExpansionStore)
             .environment(\.suppressAutoScroll, { [self] in
                 os_signpost(.event, log: PerfSignposts.log, name: "scrollSuppressionChanged", "on reason=manualExpansionDetach")
                 let intents = scrollCoordinator.handle(.manualExpansion)

--- a/clients/macos/vellum-assistant/Features/Chat/ThinkingBlockExpansionStore.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ThinkingBlockExpansionStore.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+
+/// Persists the expand/collapse state of thinking blocks across view
+/// destruction and recreation. `ThinkingBlockView` uses `@State` internally,
+/// but that state is lost whenever the hosting view subtree is torn down —
+/// for example when `MessageListContentView` flips its `.if` min-height
+/// wrapper at the start/end of an active turn, which destroys every
+/// descendant `@State`. Lifting the state into this store, owned at the
+/// `MessageListView` level (above the wrapper), lets expansion survive
+/// those tree changes.
+///
+/// Only accessed from SwiftUI view bodies, which are implicitly
+/// main-actor-isolated, so the mutations are safe in practice. The class
+/// is not annotated `@MainActor` because `EnvironmentKey.defaultValue`
+/// is a nonisolated protocol requirement and main-actor-isolated default
+/// values violate Swift 6 isolation checking.
+@Observable
+final class ThinkingBlockExpansionStore: @unchecked Sendable {
+    private var expandedKeys: Set<String> = []
+
+    func isExpanded(_ key: String) -> Bool {
+        expandedKeys.contains(key)
+    }
+
+    func toggle(_ key: String) {
+        if expandedKeys.contains(key) {
+            expandedKeys.remove(key)
+        } else {
+            expandedKeys.insert(key)
+        }
+    }
+}
+
+private struct ThinkingBlockExpansionStoreKey: EnvironmentKey {
+    static let defaultValue = ThinkingBlockExpansionStore()
+}
+
+extension EnvironmentValues {
+    var thinkingBlockExpansionStore: ThinkingBlockExpansionStore {
+        get { self[ThinkingBlockExpansionStoreKey.self] }
+        set { self[ThinkingBlockExpansionStoreKey.self] = newValue }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Chat/ThinkingBlockView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ThinkingBlockView.swift
@@ -4,29 +4,26 @@ import VellumAssistantShared
 /// A collapsible card that displays LLM thinking/reasoning content.
 /// Starts collapsed by default. Shows "Thinking..." during streaming
 /// and "Thought process" when complete.
+///
+/// Expansion state lives in a `ThinkingBlockExpansionStore` injected via
+/// `@Environment` rather than local `@State`, so manual expansion survives
+/// the view-tree destruction that happens when `MessageListContentView`
+/// flips its `.if` min-height wrapper at the start/end of an active turn.
 struct ThinkingBlockView: View {
     let content: String
     let isStreaming: Bool
+    let expansionKey: String
     var typographyGeneration: Int = 0
 
-    @State private var isExpanded: Bool
+    @Environment(\.thinkingBlockExpansionStore) private var expansionStore
+
     /// Cached parsed markdown segments — parsed lazily only when the block is
     /// expanded, avoiding synchronous O(n) work while collapsed (the default).
-    @State private var cachedSegments: [MarkdownSegment]
-    @State private var cachedContent: String
+    @State private var cachedSegments: [MarkdownSegment] = []
+    @State private var cachedContent: String = ""
 
-    init(content: String, isStreaming: Bool, typographyGeneration: Int = 0, initiallyExpanded: Bool = false) {
-        self.content = content
-        self.isStreaming = isStreaming
-        self.typographyGeneration = typographyGeneration
-        _isExpanded = State(initialValue: initiallyExpanded)
-        if initiallyExpanded {
-            _cachedSegments = State(initialValue: parseMarkdownSegments(content))
-            _cachedContent = State(initialValue: content)
-        } else {
-            _cachedSegments = State(initialValue: [])
-            _cachedContent = State(initialValue: "")
-        }
+    private var isExpanded: Bool {
+        expansionStore.isExpanded(expansionKey)
     }
 
     var body: some View {
@@ -74,7 +71,7 @@ struct ThinkingBlockView: View {
     private var headerRow: some View {
         Button(action: {
             withAnimation(VAnimation.fast) {
-                isExpanded.toggle()
+                expansionStore.toggle(expansionKey)
             }
         }) {
             HStack(spacing: VSpacing.sm) {

--- a/clients/macos/vellum-assistantTests/ThinkingBlockViewTests.swift
+++ b/clients/macos/vellum-assistantTests/ThinkingBlockViewTests.swift
@@ -3,15 +3,28 @@ import XCTest
 
 @MainActor
 final class ThinkingBlockViewTests: XCTestCase {
-    func testExpandedThinkingBlockBodyDoesNotCrashWithMarkdown() {
-        let view = ThinkingBlockView(
-            content: """
-            *gasps against the fabric*
+    /// Regression test for a crash where `parseMarkdownSegments` applied to
+    /// thinking-block content with italics separated by blank lines tripped
+    /// an NSRange assertion during expanded-card seeding.
+    /// (See commit `adaf6e796`.)
+    func testParseMarkdownSegmentsDoesNotCrashOnItalicsAcrossBlankLines() {
+        _ = parseMarkdownSegments("""
+        *gasps against the fabric*
 
-            *muffled, breathless*
-            """,
+        *muffled, breathless*
+        """)
+    }
+
+    /// Smoke test that `ThinkingBlockView.body` can be evaluated against
+    /// the store-backed expansion without crashing.
+    func testThinkingBlockBodyEvaluatesWithStoreInjection() {
+        let store = ThinkingBlockExpansionStore()
+        store.toggle("test-key")
+
+        let view = ThinkingBlockView(
+            content: "thinking content",
             isStreaming: false,
-            initiallyExpanded: true
+            expansionKey: "test-key"
         )
 
         _ = view.body


### PR DESCRIPTION
## Summary

- Thinking blocks collapsed when the assistant finished responding because `MessageListContentView`'s `.if` min-height wrapper flips on `state.isActiveTurn` change, destroying the entire wrapped subtree (including `ThinkingBlockView`'s `@State isExpanded`).
- Introduces `ThinkingBlockExpansionStore` (@Observable) owned by `MessageListView` — above the `.if` wrapper — and injects it via `@Environment`. `ThinkingBlockView` now reads/writes expansion state through the store using a stable `expansionKey` per message+block, so manual expansion survives the turn boundary.
- Applies the fix to all three `ThinkingBlockView` call sites (interleaved thinking segments, inline `<thinking>` tags in text, and inline tags in per-segment text bubbles).

## Original prompt

> these thinking blocks shouldn't auto-collapse whenever the assistant finishes responding
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24734" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
