### PR TITLE
fix(macos): remove unnecessary await on sync @MainActor progress closure

### DIFF
--- a/clients/macos/vellum-assistant/App/AppleContainersLauncher.swift
+++ b/clients/macos/vellum-assistant/App/AppleContainersLauncher.swift
@@ -69,7 +69,7 @@ final class AppleContainersLauncher: AssistantManagementClient {
             throw LauncherError.unavailable(reason)
         }
 
-        await onProgress?("Preparing environment...")
+        onProgress?("Preparing environment...")
 
         let assistantName = RandomNameGenerator.generateInstanceName(
             species: "vellum",
@@ -114,7 +114,7 @@ final class AppleContainersLauncher: AssistantManagementClient {
         )
 
         log.info("Hatching apple-container '\(assistantName, privacy: .public)'")
-        await onProgress?("Starting container...")
+        onProgress?("Starting container...")
 
         do {
             try await runtime.start { message in
@@ -129,7 +129,7 @@ final class AppleContainersLauncher: AssistantManagementClient {
         }
 
         self.podRuntime = runtime
-        await onProgress?("Container started")
+        onProgress?("Container started")
 
         // Lease a guardian token so the desktop app can authenticate with the
         // gateway. The CLI does this in hatch-local.ts after the gateway starts;
@@ -140,7 +140,7 @@ final class AppleContainersLauncher: AssistantManagementClient {
         // call. If we fail here, the fallback path in performInitialBootstrap()
         // generates a new random secret that the gateway will reject with 403.
         if let gatewayURL = runtime.gatewayURL {
-            await onProgress?("Securing connection...")
+            onProgress?("Securing connection...")
 
             let gatewayReady = await Self.waitForGatewayReady(
                 gatewayURL: gatewayURL,
@@ -169,7 +169,7 @@ final class AppleContainersLauncher: AssistantManagementClient {
             }
         }
 
-        await onProgress?("Finalizing setup...")
+        onProgress?("Finalizing setup...")
 
         let hatchedAt = ISO8601DateFormatter().string(from: Date())
         Self.writeLockfileEntry(


### PR DESCRIPTION
## Summary
- Remove unnecessary \`await\` from five call sites in \`AppleContainersLauncher.hatch()\` that invoke the sync \`@MainActor\` \`onProgress\` closure from an already-\`@MainActor\` context.
- Silences \`warning: no 'async' operations occur within 'await' expression\` (Swift 6 concurrency diagnostic).
- Leaves \`await\` in place on the call sites inside nonisolated contexts (the \`runtime.start\` and \`buildAndLoadImages\` progress closures, and the static \`waitForGatewayReady\` / \`leaseGuardianToken\` helpers) — those still need to hop to the MainActor.

## Original prompt
Fix: ~v/clients/macos (main) ❯❯❯ VELLUM_NO_WATCH=1 ./build.sh run
VELLUM_ENVIRONMENT=local
Building (debug)...
[1/1] Planning build
Building for debugging...
/Users/sidd/vocify/vellum-assistant/clients/macos/vellum-assistant/App/AppleContainersLauncher.swift:72:9: warning: no 'async' operations occur within 'await' expression
 70 |         }
 71 |
 72 |         await onProgress?("Preparing environment...")
    |         \`- warning: no 'async' operations occur within 'await' expression
 73 |
 74 |         let assistantName = RandomNameGenerator.generateInstanceName(
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24737" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
