### PR TITLE
fix(macos): drop spurious await on MainActor onProgress in static helpers

### DIFF
--- a/clients/macos/vellum-assistant/App/AppleContainersLauncher.swift
+++ b/clients/macos/vellum-assistant/App/AppleContainersLauncher.swift
@@ -280,7 +280,7 @@ final class AppleContainersLauncher: AssistantManagementClient {
 
             if attempt < gatewayReadyMaxAttempts {
                 if attempt % 5 == 0 {
-                    await onProgress?("Waiting for gateway to start (attempt \(attempt)/\(gatewayReadyMaxAttempts))...")
+                    onProgress?("Waiting for gateway to start (attempt \(attempt)/\(gatewayReadyMaxAttempts))...")
                 }
                 try? await Task.sleep(nanoseconds: gatewayReadyRetryDelay)
                 guard !Task.isCancelled else { return false }
@@ -357,7 +357,7 @@ final class AppleContainersLauncher: AssistantManagementClient {
 
                     if attempt < guardianInitMaxAttempts {
                         if attempt % 5 == 0 {
-                            await onProgress?("Waiting for assistant runtime (attempt \(attempt)/\(guardianInitMaxAttempts))...")
+                            onProgress?("Waiting for assistant runtime (attempt \(attempt)/\(guardianInitMaxAttempts))...")
                         }
                         try? await Task.sleep(nanoseconds: currentDelay)
                         guard !Task.isCancelled else { return false }
@@ -393,7 +393,7 @@ final class AppleContainersLauncher: AssistantManagementClient {
                 log.warning("Guardian token lease attempt \(attempt)/\(guardianInitMaxAttempts) error (\(elapsed, privacy: .public)): \(error.localizedDescription, privacy: .public)")
                 if attempt < guardianInitMaxAttempts {
                     if attempt % 5 == 0 {
-                        await onProgress?("Waiting for assistant runtime (attempt \(attempt)/\(guardianInitMaxAttempts))...")
+                        onProgress?("Waiting for assistant runtime (attempt \(attempt)/\(guardianInitMaxAttempts))...")
                     }
                     try? await Task.sleep(nanoseconds: currentDelay)
                     guard !Task.isCancelled else { return false }


### PR DESCRIPTION
## Summary
- Removes `await` from three `onProgress?(...)` call sites inside `waitForGatewayReady()` and `leaseGuardianToken()` that triggered the Swift warning `no 'async' operations occur within 'await' expression`.
- The static helpers inherit `@MainActor` isolation from the enclosing class, so calling the synchronous `@MainActor` closure needs no actor hop. Follow-up to #24737, which cleaned up `hatch()` but left these three.
- Verified with `swift build --product vellum-assistant -Xswiftc -strict-concurrency=complete`: the three "no async operations" warnings are gone and the product still builds cleanly. The remaining two warnings on lines 122/224 are separate `@Sendable` capture diagnostics, untouched here.

## Original prompt
Fix: /Users/sidd/vocify/vellum-assistant/clients/macos/vellum-assistant/App/AppleContainersLauncher.swift:283:21: warning: no 'async' operations occur within 'await' expression
281 |             if attempt < gatewayReadyMaxAttempts {
282 |                 if attempt % 5 == 0 {
283 |                     await onProgress?(\"Waiting for gateway to start (attempt \(attempt)/\(gatewayReadyMaxAttempts))...\")
    |                     \`- warning: no 'async' operations occur within 'await' expression
284 |                 }
285 |                 try? await Task.sleep(nanoseconds: gatewayReadyRetryDelay)