### PR TITLE
fix(macos): seed thinking-block segment cache on appear when expanded

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ThinkingBlockView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ThinkingBlockView.swift
@@ -26,6 +26,20 @@ struct ThinkingBlockView: View {
         expansionStore.isExpanded(expansionKey)
     }
 
+    /// Seed the segment cache when the block is (or becomes) expanded and the
+    /// content has drifted from the cache. Called from `onAppear` as well as
+    /// `onChange` — `onAppear` is the critical one: when `MessageListContentView`
+    /// tears down and rebuilds the view subtree at the end of an active turn,
+    /// the view is recreated with `isExpanded == true` (from the store) but
+    /// empty `@State` caches, and neither `onChange` handler fires on initial
+    /// values. Without this, expanded blocks go blank at turn end until the
+    /// user collapses and re-expands them.
+    private func syncCacheIfExpanded() {
+        guard isExpanded, cachedContent != content else { return }
+        cachedContent = content
+        cachedSegments = parseMarkdownSegments(content)
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             headerRow
@@ -54,16 +68,9 @@ struct ThinkingBlockView: View {
         .background(VColor.surfaceOverlay)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
         .animation(VAnimation.fast, value: isExpanded)
-        .onChange(of: content) { _, newContent in
-            guard isExpanded, newContent != cachedContent else { return }
-            cachedContent = newContent
-            cachedSegments = parseMarkdownSegments(newContent)
-        }
-        .onChange(of: isExpanded) { _, expanded in
-            guard expanded, cachedContent != content else { return }
-            cachedContent = content
-            cachedSegments = parseMarkdownSegments(content)
-        }
+        .onAppear { syncCacheIfExpanded() }
+        .onChange(of: content) { _, _ in syncCacheIfExpanded() }
+        .onChange(of: isExpanded) { _, _ in syncCacheIfExpanded() }
     }
 
     // MARK: - Header

--- a/clients/macos/vellum-assistantTests/ThinkingBlockViewTests.swift
+++ b/clients/macos/vellum-assistantTests/ThinkingBlockViewTests.swift
@@ -29,4 +29,35 @@ final class ThinkingBlockViewTests: XCTestCase {
 
         _ = view.body
     }
+
+    /// Regression test for expanded thinking blocks going blank at the end of
+    /// an active turn. When `MessageListContentView` tears down and rebuilds
+    /// the wrapped subtree as `isActiveTurn` flips true → false, a freshly
+    /// constructed `ThinkingBlockView` reads `isExpanded == true` from the
+    /// store (preserved by commit `54e20c80b`) but its `@State` segment cache
+    /// is empty. Neither `onChange(of: content)` nor `onChange(of: isExpanded)`
+    /// fires on initial values, so the block rendered blank until the user
+    /// manually toggled it. `.onAppear` now seeds the cache in that case.
+    /// This test evaluates the body of an already-expanded view with
+    /// non-trivial markdown content to exercise the seeding path.
+    func testThinkingBlockExpandedOnAppearSeedsSegmentCache() {
+        let store = ThinkingBlockExpansionStore()
+        store.toggle("turn-end-key")
+
+        let view = ThinkingBlockView(
+            content: """
+            # Reasoning
+
+            Step one: consider the input.
+
+            *pauses*
+
+            Step two: produce the output.
+            """,
+            isStreaming: false,
+            expansionKey: "turn-end-key"
+        )
+
+        _ = view.body
+    }
 }


### PR DESCRIPTION
## Summary
- Expanded thinking blocks went blank the instant the active turn ended because `ThinkingBlockView`'s segment cache (`@State`) was reset by `MessageListContentView`'s `.if` wrapper teardown, and neither `onChange` handler fires on initial values.
- Extract the cache-seeding logic into `syncCacheIfExpanded()` and call it from `.onAppear` in addition to the existing `onChange(of: content)` and `onChange(of: isExpanded)` handlers. This is a direct follow-up to #24734, which preserved the expansion *boolean* across the same teardown but left the content cache behind.
- Added a regression test that evaluates the body of an already-expanded `ThinkingBlockView` with non-trivial markdown content.

## Original prompt
it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24740" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
