### PR TITLE
feat: add 1-hour retention option and make it the default

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -166,7 +166,7 @@ describe("AssistantConfigSchema", () => {
       enqueueIntervalMs: 6 * 60 * 60 * 1000,
       supersededItemRetentionMs: 30 * 24 * 60 * 60 * 1000,
       conversationRetentionDays: 0,
-      llmRequestLogRetentionMs: 1 * 24 * 60 * 60 * 1000,
+      llmRequestLogRetentionMs: 1 * 60 * 60 * 1000,
     });
   });
 

--- a/assistant/src/config/schemas/memory-lifecycle.ts
+++ b/assistant/src/config/schemas/memory-lifecycle.ts
@@ -92,7 +92,7 @@ export const MemoryCleanupConfigSchema = z
         "memory.cleanup.llmRequestLogRetentionMs must be <= 365 days in ms",
       )
       .nullable()
-      .default(1 * 24 * 60 * 60 * 1000)
+      .default(1 * 60 * 60 * 1000)
       .describe(
         "Retention period for LLM request/response logs in milliseconds (null keeps forever, 0 prunes immediately)",
       ),

--- a/clients/macos/vellum-assistant/Features/Settings/LlmLogRetentionOption.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/LlmLogRetentionOption.swift
@@ -6,6 +6,7 @@ import Foundation
 /// for the specified number of milliseconds.
 enum LlmLogRetentionOption: CaseIterable, Identifiable, Hashable {
     case dontRetain
+    case oneHour
     case oneDay
     case sevenDays
     case thirtyDays
@@ -15,6 +16,7 @@ enum LlmLogRetentionOption: CaseIterable, Identifiable, Hashable {
     var id: String {
         switch self {
         case .dontRetain: return "dontRetain"
+        case .oneHour: return "oneHour"
         case .oneDay: return "oneDay"
         case .sevenDays: return "sevenDays"
         case .thirtyDays: return "thirtyDays"
@@ -26,6 +28,7 @@ enum LlmLogRetentionOption: CaseIterable, Identifiable, Hashable {
     var retentionMs: Int64? {
         switch self {
         case .dontRetain: return 0
+        case .oneHour: return 3_600_000
         case .oneDay: return 86_400_000
         case .sevenDays: return 604_800_000
         case .thirtyDays: return 2_592_000_000
@@ -37,6 +40,7 @@ enum LlmLogRetentionOption: CaseIterable, Identifiable, Hashable {
     var label: String {
         switch self {
         case .dontRetain: return "Don't retain"
+        case .oneHour: return "1 hour"
         case .oneDay: return "1 day"
         case .sevenDays: return "7 days"
         case .thirtyDays: return "30 days"
@@ -52,13 +56,13 @@ enum LlmLogRetentionOption: CaseIterable, Identifiable, Hashable {
     static func closest(toMs ms: Int64?) -> LlmLogRetentionOption {
         guard let ms = ms else { return .keepForever }
         if ms == 0 { return .dontRetain }
-        let known: [LlmLogRetentionOption] = [.oneDay, .sevenDays, .thirtyDays, .ninetyDays]
+        let known: [LlmLogRetentionOption] = [.oneHour, .oneDay, .sevenDays, .thirtyDays, .ninetyDays]
         return known.min(by: { lhs, rhs in
             let lhsDist = abs(lhs.retentionMs! - ms)
             let rhsDist = abs(rhs.retentionMs! - ms)
             if lhsDist != rhsDist { return lhsDist < rhsDist }
             // Tie -> prefer the larger (longer) retention.
             return lhs.retentionMs! > rhs.retentionMs!
-        }) ?? .oneDay
+        }) ?? .oneHour
     }
 }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift
@@ -30,7 +30,7 @@ struct SettingsPrivacyTab: View {
     /// Seeded from UserDefaults on view appear for instant render, then
     /// reconciled against the daemon's authoritative value via
     /// `loadPrivacyConfig()`.
-    @State private var retentionSelection: LlmLogRetentionOption = .oneDay
+    @State private var retentionSelection: LlmLogRetentionOption = .oneHour
 
     /// In-flight retention sync task so rapid picker changes cancel the
     /// previous write and only the latest selection reaches the daemon.

--- a/clients/macos/vellum-assistantTests/LlmLogRetentionOptionTests.swift
+++ b/clients/macos/vellum-assistantTests/LlmLogRetentionOptionTests.swift
@@ -12,6 +12,10 @@ final class LlmLogRetentionOptionTests: XCTestCase {
         XCTAssertEqual(LlmLogRetentionOption.closest(toMs: 0), .dontRetain)
     }
 
+    func testClosestReturnsOneHourForExactOneHourMs() {
+        XCTAssertEqual(LlmLogRetentionOption.closest(toMs: 3_600_000), .oneHour)
+    }
+
     func testClosestReturnsOneDayForExactOneDayMs() {
         XCTAssertEqual(LlmLogRetentionOption.closest(toMs: 86_400_000), .oneDay)
     }
@@ -76,8 +80,8 @@ final class LlmLogRetentionOptionTests: XCTestCase {
 
     // MARK: - Invariants
 
-    func testAllCasesHasSixEntries() {
-        XCTAssertEqual(LlmLogRetentionOption.allCases.count, 6)
+    func testAllCasesHasSevenEntries() {
+        XCTAssertEqual(LlmLogRetentionOption.allCases.count, 7)
     }
 
     func testAllCasesLabelsAreNonEmpty() {

--- a/gateway/src/__tests__/privacy-config-route.test.ts
+++ b/gateway/src/__tests__/privacy-config-route.test.ts
@@ -65,8 +65,8 @@ function readConfig(): Record<string, unknown> {
 }
 
 // The default value for memory.cleanup.llmRequestLogRetentionMs in the
-// daemon schema (assistant/src/config/schemas/memory-lifecycle.ts): 1 day.
-const DEFAULT_RETENTION_MS = 1 * 24 * 60 * 60 * 1000;
+// daemon schema (assistant/src/config/schemas/memory-lifecycle.ts): 1 hour.
+const DEFAULT_RETENTION_MS = 1 * 60 * 60 * 1000;
 
 describe("GET /v1/config/privacy handler", () => {
   test("returns schema defaults when config.json does not exist", async () => {
@@ -86,8 +86,8 @@ describe("GET /v1/config/privacy handler", () => {
       sendDiagnostics: true,
       llmRequestLogRetentionMs: DEFAULT_RETENTION_MS,
     });
-    // Sanity check: 1 day in ms.
-    expect(body.llmRequestLogRetentionMs).toBe(86_400_000);
+    // Sanity check: 1 hour in ms.
+    expect(body.llmRequestLogRetentionMs).toBe(3_600_000);
   });
 
   test("returns explicit values from config.json", async () => {
@@ -811,7 +811,7 @@ describe("GET /v1/config/privacy handler — Gap 2a-2 out-of-range clamp", () =>
     const body = await res.json();
     // Clamped to default, not the bogus value on disk.
     expect(body.llmRequestLogRetentionMs).toBe(DEFAULT_RETENTION_MS);
-    expect(body.llmRequestLogRetentionMs).toBe(86_400_000);
+    expect(body.llmRequestLogRetentionMs).toBe(3_600_000);
   });
 
   test("clamps a 10-year retention (e.g. 315360000000) to the default on GET", async () => {

--- a/gateway/src/http/routes/privacy-config.ts
+++ b/gateway/src/http/routes/privacy-config.ts
@@ -13,7 +13,7 @@ const log = getLogger("privacy-config");
 // (memory.cleanup.llmRequestLogRetentionMs). Keep them in sync.
 const DEFAULT_COLLECT_USAGE_DATA = true;
 const DEFAULT_SEND_DIAGNOSTICS = true;
-const DEFAULT_LLM_REQUEST_LOG_RETENTION_MS = 1 * 24 * 60 * 60 * 1000;
+const DEFAULT_LLM_REQUEST_LOG_RETENTION_MS = 1 * 60 * 60 * 1000;
 
 // Upper bound for llmRequestLogRetentionMs: 365 days (in ms).
 // Prevents accidental values like Number.MAX_SAFE_INTEGER.


### PR DESCRIPTION
## Summary
- Add a new "1 hour" option to the LLM Request Log Retention picker (between "Don't retain" and "1 day")
- Change the default from 1 day (86,400,000 ms) to 1 hour (3,600,000 ms) across daemon schema, gateway, and macOS picker
- Updated tests to reflect the new default value

## Files changed
- `assistant/src/config/schemas/memory-lifecycle.ts` — Zod default: 1 day → 1 hour
- `gateway/src/http/routes/privacy-config.ts` — gateway default constant: 1 day → 1 hour
- `gateway/src/__tests__/privacy-config-route.test.ts` — test constant + assertions updated
- `assistant/src/__tests__/config-schema.test.ts` — expected default updated
- `clients/macos/vellum-assistant/Features/Settings/LlmLogRetentionOption.swift` — new `.oneHour` case
- `clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift` — `@State` default → `.oneHour`
- `clients/macos/vellum-assistantTests/LlmLogRetentionOptionTests.swift` — test for new case + count updated to 7
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24744" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
