### PR TITLE
feat(browser): propagate turn interface to tool execution context

### DIFF
--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -118,6 +118,8 @@ export interface ToolSetupContext extends SurfaceConversationContext {
   hostFileProxy?: import("./host-file-proxy.js").HostFileProxy;
   /** CES RPC client for credential execution operations. Injected when CES tools are enabled and the CES process is available. */
   cesClient?: CesClient;
+  /** The interface ID of the connected client driving the current turn (e.g. "macos", "chrome-extension"). Propagated into ToolContext for browser backend selection. */
+  readonly transportInterface?: InterfaceId;
 }
 
 // ── buildToolDefinitions ─────────────────────────────────────────────
@@ -202,6 +204,7 @@ export function createToolExecutor(
       hostFileProxy: ctx.hostFileProxy,
       isPlatformHosted: getIsPlatform(),
       cesClient: ctx.cesClient,
+      transportInterface: ctx.transportInterface,
       onToolLifecycleEvent: handleToolLifecycleEvent,
       sendToClient: (msg) => {
         // Tool context's sendToClient uses a loose { type: string; [key: string]: unknown }

--- a/assistant/src/tools/browser/cdp-client/__tests__/factory.test.ts
+++ b/assistant/src/tools/browser/cdp-client/__tests__/factory.test.ts
@@ -374,4 +374,65 @@ describe("getCdpClient", () => {
       code: "disposed",
     });
   });
+
+  // ── transportInterface backwards compatibility ──────────────────────
+
+  test("context without transportInterface still routes to local backend", () => {
+    // Contexts that omit transportInterface (backwards-compat for existing
+    // call sites) must continue to select the correct backend based on
+    // hostBrowserProxy and config alone.
+    const ctx = makeContext({ conversationId: "no-interface" });
+    // Verify the field is truly absent, not just undefined-as-value.
+    expect(ctx.transportInterface).toBeUndefined();
+
+    const client = getCdpClient(ctx);
+
+    expect(client.kind).toBe("local");
+    expect(client.conversationId).toBe("no-interface");
+    expect(createLocalCdpClientMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("context with transportInterface set routes normally to extension backend", () => {
+    const fakeProxy = {
+      request: mock(async () => ({})),
+    } as unknown as HostBrowserProxy;
+    const ctx = makeContext({
+      conversationId: "macos-ext",
+      hostBrowserProxy: fakeProxy,
+      transportInterface: "macos",
+    });
+
+    const client = getCdpClient(ctx);
+
+    expect(client.kind).toBe("extension");
+    expect(client.conversationId).toBe("macos-ext");
+    expect(createExtensionCdpClientMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("context with transportInterface set routes normally to local backend when no proxy", () => {
+    const ctx = makeContext({
+      conversationId: "macos-local",
+      transportInterface: "macos",
+    });
+
+    const client = getCdpClient(ctx);
+
+    expect(client.kind).toBe("local");
+    expect(client.conversationId).toBe("macos-local");
+    expect(createLocalCdpClientMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("context with transportInterface set routes to cdp-inspect when enabled", () => {
+    cdpInspectEnabled = true;
+    const ctx = makeContext({
+      conversationId: "macos-inspect",
+      transportInterface: "macos",
+    });
+
+    const client = getCdpClient(ctx);
+
+    expect(client.kind).toBe("cdp-inspect");
+    expect(client.conversationId).toBe("macos-inspect");
+    expect(createCdpInspectClientMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -1,5 +1,6 @@
 import type { ApprovalRequired } from "@vellumai/ces-contracts";
 
+import type { InterfaceId } from "../channels/types.js";
 import type { CesClient } from "../credential-execution/client.js";
 import type { SecretPromptResult } from "../permissions/secret-prompter.js";
 import type {
@@ -184,6 +185,14 @@ export interface ToolContext {
   isPlatformHosted?: boolean;
   /** CES RPC client for credential execution operations. When present, the executor can bridge CES approval flows. */
   cesClient?: CesClient;
+  /**
+   * The interface ID of the connected client driving the current turn (e.g.
+   * "macos", "chrome-extension"). Browser backend policy uses this to decide
+   * transport preference — for example, macOS-originated turns prefer the
+   * user's real Chrome session via the paired extension before falling back
+   * to cdp-inspect or local Playwright.
+   */
+  transportInterface?: InterfaceId;
 }
 
 export interface DiffInfo {


### PR DESCRIPTION
## Summary
- Add optional transportInterface field to ToolContext for browser backend policy decisions
- Plumb transport interface from conversation context into tool executor
- Update CDP factory tests to cover contexts with and without transportInterface

Part of plan: macos-browser-extension-cdp-fallback.md (PR 1 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24745" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
