### PR TITLE
feat(browser): chain backend selection with transport-aware failover

### DIFF
--- a/assistant/src/tools/browser/cdp-client/__tests__/factory.test.ts
+++ b/assistant/src/tools/browser/cdp-client/__tests__/factory.test.ts
@@ -95,7 +95,8 @@ mock.module("../../../../config/loader.js", () => ({
 
 // Import under test AFTER mock.module calls so that the factory's
 // top-level imports resolve to our fakes.
-const { getCdpClient } = await import("../factory.js");
+const { getCdpClient, buildCandidateList, buildChainedClient } =
+  await import("../factory.js");
 
 /**
  * Minimal ToolContext suitable for factory tests. Only the fields the
@@ -106,6 +107,27 @@ function makeContext(
   overrides: Partial<ToolContext> & { conversationId: string },
 ): ToolContext {
   return overrides as unknown as ToolContext;
+}
+
+/**
+ * Create a fake HostBrowserProxy that reports as available.
+ */
+function makeAvailableProxy(): HostBrowserProxy {
+  return {
+    request: mock(async () => ({})),
+    isAvailable: () => true,
+  } as unknown as HostBrowserProxy;
+}
+
+/**
+ * Create a fake HostBrowserProxy that reports as unavailable
+ * (proxy exists but client is disconnected).
+ */
+function makeUnavailableProxy(): HostBrowserProxy {
+  return {
+    request: mock(async () => ({})),
+    isAvailable: () => false,
+  } as unknown as HostBrowserProxy;
 }
 
 describe("getCdpClient", () => {
@@ -119,10 +141,10 @@ describe("getCdpClient", () => {
     cdpInspectEnabled = false;
   });
 
-  test("routes to ExtensionCdpClient when hostBrowserProxy is set", () => {
-    const fakeProxy = {
-      request: mock(async () => ({})),
-    } as unknown as HostBrowserProxy;
+  // ── Candidate selection (kind reported before first send) ────────────
+
+  test("routes to ExtensionCdpClient when hostBrowserProxy is set and available", async () => {
+    const fakeProxy = makeAvailableProxy();
     const ctx = makeContext({
       conversationId: "test-convo",
       hostBrowserProxy: fakeProxy,
@@ -130,8 +152,16 @@ describe("getCdpClient", () => {
 
     const client = getCdpClient(ctx);
 
+    // kind should reflect extension before first send (top candidate)
     expect(client.kind).toBe("extension");
     expect(client.conversationId).toBe("test-convo");
+
+    // Lazy creation: client is not created until first send
+    const result = await client.send<{ ok: boolean; via: string }>(
+      "Page.navigate",
+      { url: "https://example.com" },
+    );
+    expect(result).toEqual({ ok: true, via: "extension" });
     expect(createExtensionCdpClientMock).toHaveBeenCalledTimes(1);
     expect(createExtensionCdpClientMock).toHaveBeenCalledWith(
       fakeProxy,
@@ -141,11 +171,50 @@ describe("getCdpClient", () => {
     expect(createCdpInspectClientMock).not.toHaveBeenCalled();
   });
 
-  test("extension wins even when cdpInspect is enabled", () => {
+  test("skips extension when hostBrowserProxy is present but unavailable", async () => {
+    const fakeProxy = makeUnavailableProxy();
+    const ctx = makeContext({
+      conversationId: "disconnected-proxy",
+      hostBrowserProxy: fakeProxy,
+    });
+
+    const client = getCdpClient(ctx);
+
+    // Should fall through to local since extension is not available
+    expect(client.kind).toBe("local");
+    expect(client.conversationId).toBe("disconnected-proxy");
+
+    const result = await client.send<{ ok: boolean; via: string }>(
+      "Page.navigate",
+    );
+    expect(result).toEqual({ ok: true, via: "local" });
+    expect(createExtensionCdpClientMock).not.toHaveBeenCalled();
+    expect(createLocalCdpClientMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("skips extension but uses cdp-inspect when proxy unavailable and cdp-inspect enabled", async () => {
     cdpInspectEnabled = true;
-    const fakeProxy = {
-      request: mock(async () => ({})),
-    } as unknown as HostBrowserProxy;
+    const fakeProxy = makeUnavailableProxy();
+    const ctx = makeContext({
+      conversationId: "disconnected-inspect",
+      hostBrowserProxy: fakeProxy,
+    });
+
+    const client = getCdpClient(ctx);
+
+    expect(client.kind).toBe("cdp-inspect");
+
+    const result = await client.send<{ ok: boolean; via: string }>(
+      "Page.navigate",
+    );
+    expect(result).toEqual({ ok: true, via: "cdp-inspect" });
+    expect(createExtensionCdpClientMock).not.toHaveBeenCalled();
+    expect(createCdpInspectClientMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("extension wins even when cdpInspect is enabled", async () => {
+    cdpInspectEnabled = true;
+    const fakeProxy = makeAvailableProxy();
     const ctx = makeContext({
       conversationId: "ext-wins",
       hostBrowserProxy: fakeProxy,
@@ -154,12 +223,16 @@ describe("getCdpClient", () => {
     const client = getCdpClient(ctx);
 
     expect(client.kind).toBe("extension");
+    const result = await client.send<{ ok: boolean; via: string }>(
+      "Page.navigate",
+    );
+    expect(result).toEqual({ ok: true, via: "extension" });
     expect(createExtensionCdpClientMock).toHaveBeenCalledTimes(1);
     expect(createCdpInspectClientMock).not.toHaveBeenCalled();
     expect(createLocalCdpClientMock).not.toHaveBeenCalled();
   });
 
-  test("routes to CdpInspectClient when cdpInspect is enabled and extension is absent", () => {
+  test("routes to CdpInspectClient when cdpInspect is enabled and extension is absent", async () => {
     cdpInspectEnabled = true;
     const ctx = makeContext({
       conversationId: "inspect-convo",
@@ -170,6 +243,12 @@ describe("getCdpClient", () => {
 
     expect(client.kind).toBe("cdp-inspect");
     expect(client.conversationId).toBe("inspect-convo");
+
+    const result = await client.send<{ ok: boolean; via: string }>(
+      "Page.navigate",
+      { url: "https://example.com" },
+    );
+    expect(result).toEqual({ ok: true, via: "cdp-inspect" });
     expect(createCdpInspectClientMock).toHaveBeenCalledTimes(1);
     expect(createCdpInspectClientMock).toHaveBeenCalledWith("inspect-convo", {
       host: "localhost",
@@ -180,7 +259,7 @@ describe("getCdpClient", () => {
     expect(createLocalCdpClientMock).not.toHaveBeenCalled();
   });
 
-  test("routes to LocalCdpClient when cdpInspect is disabled and extension is absent", () => {
+  test("routes to LocalCdpClient when cdpInspect is disabled and extension is absent", async () => {
     cdpInspectEnabled = false;
     const ctx = makeContext({
       conversationId: "local-convo",
@@ -191,29 +270,37 @@ describe("getCdpClient", () => {
 
     expect(client.kind).toBe("local");
     expect(client.conversationId).toBe("local-convo");
+
+    const result = await client.send<{ ok: boolean; via: string }>(
+      "Runtime.evaluate",
+      { expression: "1+1" },
+    );
+    expect(result).toEqual({ ok: true, via: "local" });
     expect(createLocalCdpClientMock).toHaveBeenCalledTimes(1);
     expect(createLocalCdpClientMock).toHaveBeenCalledWith("local-convo");
     expect(createExtensionCdpClientMock).not.toHaveBeenCalled();
     expect(createCdpInspectClientMock).not.toHaveBeenCalled();
   });
 
-  test("routes to LocalCdpClient when hostBrowserProxy key is omitted", () => {
+  test("routes to LocalCdpClient when hostBrowserProxy key is omitted", async () => {
     const ctx = makeContext({ conversationId: "another-convo" });
 
     const client = getCdpClient(ctx);
 
     expect(client.kind).toBe("local");
     expect(client.conversationId).toBe("another-convo");
+
+    await client.send("Runtime.evaluate");
     expect(createLocalCdpClientMock).toHaveBeenCalledTimes(1);
     expect(createLocalCdpClientMock).toHaveBeenCalledWith("another-convo");
     expect(createExtensionCdpClientMock).not.toHaveBeenCalled();
     expect(createCdpInspectClientMock).not.toHaveBeenCalled();
   });
 
+  // ── send() forwarding ────────────────────────────────────────────────
+
   test("forwards send() through the manager to the extension-backed client", async () => {
-    const fakeProxy = {
-      request: mock(async () => ({})),
-    } as unknown as HostBrowserProxy;
+    const fakeProxy = makeAvailableProxy();
     const ctx = makeContext({
       conversationId: "send-ext",
       hostBrowserProxy: fakeProxy,
@@ -277,25 +364,43 @@ describe("getCdpClient", () => {
     expect(lastLocalClient).toBeUndefined();
   });
 
-  test("propagates CdpError thrown by the underlying client", async () => {
-    const ctx = makeContext({ conversationId: "err-local" });
+  // ── Error propagation ────────────────────────────────────────────────
+
+  test("propagates CdpError (cdp_error) thrown by the underlying client without failover", async () => {
+    cdpInspectEnabled = true;
+    const ctx = makeContext({ conversationId: "err-no-failover" });
     const client = getCdpClient(ctx);
-    const thrown = new CdpError("cdp_error", "kaboom", {
-      cdpMethod: "Page.navigate",
-    });
-    lastLocalClient!.send = mock(async () => {
-      throw thrown;
-    });
+
+    // Override cdp-inspect client to throw a cdp_error
+    createCdpInspectClientMock.mockImplementationOnce(
+      (conversationId: string) => {
+        const c = makeFakeCdpInspectClient(conversationId);
+        c.send = mock(async () => {
+          throw new CdpError("cdp_error", "kaboom", {
+            cdpMethod: "Page.navigate",
+          });
+        });
+        lastCdpInspectClient = c;
+        return c;
+      },
+    );
 
     await expect(
       client.send("Page.navigate", { url: "https://example.com" }),
-    ).rejects.toBe(thrown);
+    ).rejects.toMatchObject({ code: "cdp_error", message: "kaboom" });
+
+    // Should NOT have fallen through to local
+    expect(createLocalCdpClientMock).not.toHaveBeenCalled();
   });
 
   test("propagates caller AbortSignal to the underlying client", async () => {
     const ctx = makeContext({ conversationId: "abort-local" });
     const client = getCdpClient(ctx);
     const controller = new AbortController();
+
+    // First, do a normal send to establish the sticky backend
+    await client.send("Runtime.evaluate", { expression: "1" });
+
     let sawSignal: AbortSignal | undefined;
     lastLocalClient!.send = mock(
       async (
@@ -318,9 +423,15 @@ describe("getCdpClient", () => {
     expect(sawSignal).toBe(controller.signal);
   });
 
+  // ── Dispose ──────────────────────────────────────────────────────────
+
   test("dispose() tears down the underlying client and rejects further sends", async () => {
     const ctx = makeContext({ conversationId: "dispose-local" });
     const client = getCdpClient(ctx);
+
+    // Trigger client creation via send
+    await client.send("Runtime.evaluate");
+    expect(lastLocalClient).toBeDefined();
 
     client.dispose();
     expect(lastLocalClient?.dispose).toHaveBeenCalledTimes(1);
@@ -334,26 +445,26 @@ describe("getCdpClient", () => {
     });
   });
 
-  test("dispose() on an extension-backed client tears down the extension client", () => {
-    const fakeProxy = {
-      request: mock(async () => ({})),
-    } as unknown as HostBrowserProxy;
+  test("dispose() on an extension-backed client tears down the extension client", async () => {
+    const fakeProxy = makeAvailableProxy();
     const ctx = makeContext({
       conversationId: "dispose-ext",
       hostBrowserProxy: fakeProxy,
     });
 
     const client = getCdpClient(ctx);
+    await client.send("Page.navigate");
     client.dispose();
 
     expect(lastExtensionClient?.dispose).toHaveBeenCalledTimes(1);
   });
 
-  test("dispose() on a cdp-inspect-backed client tears down the inspect client", () => {
+  test("dispose() on a cdp-inspect-backed client tears down the inspect client", async () => {
     cdpInspectEnabled = true;
     const ctx = makeContext({ conversationId: "dispose-inspect" });
 
     const client = getCdpClient(ctx);
+    await client.send("Page.navigate");
     client.dispose();
 
     expect(lastCdpInspectClient?.dispose).toHaveBeenCalledTimes(1);
@@ -364,6 +475,7 @@ describe("getCdpClient", () => {
     const ctx = makeContext({ conversationId: "post-dispose-inspect" });
 
     const client = getCdpClient(ctx);
+    await client.send("Page.navigate");
     client.dispose();
 
     // Double dispose is a no-op.
@@ -375,27 +487,35 @@ describe("getCdpClient", () => {
     });
   });
 
+  test("dispose() before first send still rejects further sends", async () => {
+    const ctx = makeContext({ conversationId: "dispose-before-send" });
+    const client = getCdpClient(ctx);
+
+    client.dispose();
+
+    await expect(client.send("Runtime.evaluate")).rejects.toMatchObject({
+      code: "disposed",
+    });
+    // No clients should have been created
+    expect(createLocalCdpClientMock).not.toHaveBeenCalled();
+  });
+
   // ── transportInterface backwards compatibility ──────────────────────
 
-  test("context without transportInterface still routes to local backend", () => {
-    // Contexts that omit transportInterface (backwards-compat for existing
-    // call sites) must continue to select the correct backend based on
-    // hostBrowserProxy and config alone.
+  test("context without transportInterface still routes to local backend", async () => {
     const ctx = makeContext({ conversationId: "no-interface" });
-    // Verify the field is truly absent, not just undefined-as-value.
     expect(ctx.transportInterface).toBeUndefined();
 
     const client = getCdpClient(ctx);
 
     expect(client.kind).toBe("local");
     expect(client.conversationId).toBe("no-interface");
+    await client.send("Runtime.evaluate");
     expect(createLocalCdpClientMock).toHaveBeenCalledTimes(1);
   });
 
-  test("context with transportInterface set routes normally to extension backend", () => {
-    const fakeProxy = {
-      request: mock(async () => ({})),
-    } as unknown as HostBrowserProxy;
+  test("context with transportInterface set routes normally to extension backend", async () => {
+    const fakeProxy = makeAvailableProxy();
     const ctx = makeContext({
       conversationId: "macos-ext",
       hostBrowserProxy: fakeProxy,
@@ -406,10 +526,11 @@ describe("getCdpClient", () => {
 
     expect(client.kind).toBe("extension");
     expect(client.conversationId).toBe("macos-ext");
+    await client.send("Page.navigate");
     expect(createExtensionCdpClientMock).toHaveBeenCalledTimes(1);
   });
 
-  test("context with transportInterface set routes normally to local backend when no proxy", () => {
+  test("context with transportInterface set routes normally to local backend when no proxy", async () => {
     const ctx = makeContext({
       conversationId: "macos-local",
       transportInterface: "macos",
@@ -419,10 +540,11 @@ describe("getCdpClient", () => {
 
     expect(client.kind).toBe("local");
     expect(client.conversationId).toBe("macos-local");
+    await client.send("Runtime.evaluate");
     expect(createLocalCdpClientMock).toHaveBeenCalledTimes(1);
   });
 
-  test("context with transportInterface set routes to cdp-inspect when enabled", () => {
+  test("context with transportInterface set routes to cdp-inspect when enabled", async () => {
     cdpInspectEnabled = true;
     const ctx = makeContext({
       conversationId: "macos-inspect",
@@ -433,6 +555,387 @@ describe("getCdpClient", () => {
 
     expect(client.kind).toBe("cdp-inspect");
     expect(client.conversationId).toBe("macos-inspect");
+    await client.send("Page.navigate");
     expect(createCdpInspectClientMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ── buildCandidateList tests ─────────────────────────────────────────────
+
+describe("buildCandidateList", () => {
+  beforeEach(() => {
+    cdpInspectEnabled = false;
+  });
+
+  test("includes extension candidate when proxy is present and available", () => {
+    const fakeProxy = makeAvailableProxy();
+    const ctx = makeContext({
+      conversationId: "candidates-ext",
+      hostBrowserProxy: fakeProxy,
+    });
+
+    const candidates = buildCandidateList(ctx);
+
+    expect(candidates.length).toBeGreaterThanOrEqual(2);
+    expect(candidates[0].kind).toBe("extension");
+    // Local is always present as fallback
+    expect(candidates[candidates.length - 1].kind).toBe("local");
+  });
+
+  test("excludes extension candidate when proxy is present but unavailable", () => {
+    const fakeProxy = makeUnavailableProxy();
+    const ctx = makeContext({
+      conversationId: "candidates-no-ext",
+      hostBrowserProxy: fakeProxy,
+    });
+
+    const candidates = buildCandidateList(ctx);
+
+    expect(candidates.every((c) => c.kind !== "extension")).toBe(true);
+    expect(candidates[0].kind).toBe("local");
+  });
+
+  test("includes cdp-inspect candidate when enabled in config", () => {
+    cdpInspectEnabled = true;
+    const ctx = makeContext({ conversationId: "candidates-inspect" });
+
+    const candidates = buildCandidateList(ctx);
+
+    expect(candidates[0].kind).toBe("cdp-inspect");
+    expect(candidates[1].kind).toBe("local");
+  });
+
+  test("candidate order: extension > cdp-inspect > local when all present", () => {
+    cdpInspectEnabled = true;
+    const fakeProxy = makeAvailableProxy();
+    const ctx = makeContext({
+      conversationId: "candidates-all",
+      hostBrowserProxy: fakeProxy,
+    });
+
+    const candidates = buildCandidateList(ctx);
+
+    expect(candidates.length).toBe(3);
+    expect(candidates[0].kind).toBe("extension");
+    expect(candidates[1].kind).toBe("cdp-inspect");
+    expect(candidates[2].kind).toBe("local");
+  });
+
+  test("local is always included as final candidate", () => {
+    const ctx = makeContext({ conversationId: "candidates-local-only" });
+
+    const candidates = buildCandidateList(ctx);
+
+    expect(candidates.length).toBe(1);
+    expect(candidates[0].kind).toBe("local");
+  });
+});
+
+// ── buildChainedClient failover tests ────────────────────────────────────
+
+describe("buildChainedClient failover", () => {
+  beforeEach(() => {
+    createExtensionCdpClientMock.mockClear();
+    createLocalCdpClientMock.mockClear();
+    createCdpInspectClientMock.mockClear();
+    lastExtensionClient = undefined;
+    lastLocalClient = undefined;
+    lastCdpInspectClient = undefined;
+    cdpInspectEnabled = false;
+  });
+
+  test("fails over from extension to local on transport_error", async () => {
+    const fakeProxy = makeAvailableProxy();
+
+    // Make extension client fail with transport_error
+    createExtensionCdpClientMock.mockImplementationOnce(
+      (_proxy: HostBrowserProxy, conversationId: string) => {
+        const c = makeFakeExtensionClient(conversationId);
+        c.send = mock(async () => {
+          throw new CdpError(
+            "transport_error",
+            "Extension WebSocket disconnected",
+            {
+              cdpMethod: "Page.navigate",
+            },
+          );
+        });
+        lastExtensionClient = c;
+        return c;
+      },
+    );
+
+    const ctx = makeContext({
+      conversationId: "failover-ext-to-local",
+      hostBrowserProxy: fakeProxy,
+    });
+
+    const client = getCdpClient(ctx);
+    const result = await client.send<{ ok: boolean; via: string }>(
+      "Page.navigate",
+      { url: "https://example.com" },
+    );
+
+    expect(result).toEqual({ ok: true, via: "local" });
+    // Extension was tried first
+    expect(createExtensionCdpClientMock).toHaveBeenCalledTimes(1);
+    // Then local was used as fallback
+    expect(createLocalCdpClientMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("fails over from extension to cdp-inspect to local on transport errors", async () => {
+    cdpInspectEnabled = true;
+    const fakeProxy = makeAvailableProxy();
+
+    // Make extension fail with transport_error
+    createExtensionCdpClientMock.mockImplementationOnce(
+      (_proxy: HostBrowserProxy, conversationId: string) => {
+        const c = makeFakeExtensionClient(conversationId);
+        c.send = mock(async () => {
+          throw new CdpError("transport_error", "Extension disconnected", {
+            cdpMethod: "Page.navigate",
+          });
+        });
+        lastExtensionClient = c;
+        return c;
+      },
+    );
+
+    // Make cdp-inspect also fail with transport_error
+    createCdpInspectClientMock.mockImplementationOnce(
+      (conversationId: string) => {
+        const c = makeFakeCdpInspectClient(conversationId);
+        c.send = mock(async () => {
+          throw new CdpError("transport_error", "Chrome not running", {
+            cdpMethod: "Page.navigate",
+          });
+        });
+        lastCdpInspectClient = c;
+        return c;
+      },
+    );
+
+    const ctx = makeContext({
+      conversationId: "failover-chain",
+      hostBrowserProxy: fakeProxy,
+    });
+
+    const client = getCdpClient(ctx);
+    const result = await client.send<{ ok: boolean; via: string }>(
+      "Page.navigate",
+      { url: "https://example.com" },
+    );
+
+    expect(result).toEqual({ ok: true, via: "local" });
+    expect(createExtensionCdpClientMock).toHaveBeenCalledTimes(1);
+    expect(createCdpInspectClientMock).toHaveBeenCalledTimes(1);
+    expect(createLocalCdpClientMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("does NOT fail over on cdp_error -- propagates immediately", async () => {
+    cdpInspectEnabled = true;
+    const fakeProxy = makeAvailableProxy();
+
+    // Make extension fail with cdp_error (not transport_error)
+    createExtensionCdpClientMock.mockImplementationOnce(
+      (_proxy: HostBrowserProxy, conversationId: string) => {
+        const c = makeFakeExtensionClient(conversationId);
+        c.send = mock(async () => {
+          throw new CdpError("cdp_error", "Protocol error", {
+            cdpMethod: "Page.navigate",
+          });
+        });
+        lastExtensionClient = c;
+        return c;
+      },
+    );
+
+    const ctx = makeContext({
+      conversationId: "no-failover-cdp-error",
+      hostBrowserProxy: fakeProxy,
+    });
+
+    const client = getCdpClient(ctx);
+
+    await expect(
+      client.send("Page.navigate", { url: "https://example.com" }),
+    ).rejects.toMatchObject({
+      code: "cdp_error",
+      message: "Protocol error",
+    });
+
+    // cdp-inspect and local should NOT have been tried
+    expect(createCdpInspectClientMock).not.toHaveBeenCalled();
+    expect(createLocalCdpClientMock).not.toHaveBeenCalled();
+  });
+
+  test("transport_error on last candidate propagates the error", async () => {
+    // Only local is available (no extension, no cdp-inspect)
+    const ctx = makeContext({ conversationId: "last-candidate-fail" });
+
+    // Make local fail with transport_error
+    createLocalCdpClientMock.mockImplementationOnce(
+      (conversationId: string) => {
+        const c = makeFakeLocalClient(conversationId);
+        c.send = mock(async () => {
+          throw new CdpError("transport_error", "Playwright failed to launch", {
+            cdpMethod: "Page.navigate",
+          });
+        });
+        lastLocalClient = c;
+        return c;
+      },
+    );
+
+    const client = getCdpClient(ctx);
+
+    await expect(client.send("Page.navigate")).rejects.toMatchObject({
+      code: "transport_error",
+      message: "Playwright failed to launch",
+    });
+  });
+
+  // ── Sticky backend tests ─────────────────────────────────────────────
+
+  test("backend becomes sticky after first successful command", async () => {
+    cdpInspectEnabled = true;
+    const fakeProxy = makeAvailableProxy();
+
+    // Make extension fail on first call with transport_error
+    createExtensionCdpClientMock.mockImplementationOnce(
+      (_proxy: HostBrowserProxy, conversationId: string) => {
+        const c = makeFakeExtensionClient(conversationId);
+        c.send = mock(async () => {
+          throw new CdpError("transport_error", "Extension disconnected", {
+            cdpMethod: "Page.navigate",
+          });
+        });
+        lastExtensionClient = c;
+        return c;
+      },
+    );
+
+    const ctx = makeContext({
+      conversationId: "sticky-test",
+      hostBrowserProxy: fakeProxy,
+    });
+
+    const client = getCdpClient(ctx);
+
+    // First send fails over from extension to cdp-inspect
+    const result1 = await client.send<{ ok: boolean; via: string }>(
+      "Page.navigate",
+      { url: "https://example.com" },
+    );
+    expect(result1).toEqual({ ok: true, via: "cdp-inspect" });
+
+    // Second send should reuse cdp-inspect without trying extension again
+    const result2 = await client.send<{ ok: boolean; via: string }>(
+      "Runtime.evaluate",
+      { expression: "1+1" },
+    );
+    expect(result2).toEqual({ ok: true, via: "cdp-inspect" });
+
+    // Extension should only have been constructed once (during failover)
+    expect(createExtensionCdpClientMock).toHaveBeenCalledTimes(1);
+    // cdp-inspect should only have been constructed once (sticky)
+    expect(createCdpInspectClientMock).toHaveBeenCalledTimes(1);
+    // Local should never have been constructed
+    expect(createLocalCdpClientMock).not.toHaveBeenCalled();
+
+    // Verify the sticky client's send was called for both commands
+    // The first call is from failover, the second from sticky path
+    expect(lastCdpInspectClient?.send).toHaveBeenCalledTimes(2);
+  });
+
+  test("sticky backend does not change on subsequent transport errors", async () => {
+    const ctx = makeContext({ conversationId: "sticky-err" });
+
+    const client = getCdpClient(ctx);
+
+    // First send succeeds, establishing local as sticky
+    await client.send("Runtime.evaluate", { expression: "1" });
+    expect(client.kind).toBe("local");
+
+    // Now make local throw a transport error on second send
+    lastLocalClient!.send = mock(async () => {
+      throw new CdpError("transport_error", "Connection lost");
+    });
+
+    // The error should propagate without failover since backend is sticky
+    await expect(client.send("Page.navigate")).rejects.toMatchObject({
+      code: "transport_error",
+    });
+  });
+
+  // ── Edge cases ───────────────────────────────────────────────────────
+
+  test("buildChainedClient throws on empty candidate list", () => {
+    expect(() => buildChainedClient("test", [])).toThrow(
+      "CDP factory: no backend candidates available",
+    );
+  });
+
+  test("kind reflects the active backend after failover", async () => {
+    const fakeProxy = makeAvailableProxy();
+
+    // Make extension fail
+    createExtensionCdpClientMock.mockImplementationOnce(
+      (_proxy: HostBrowserProxy, conversationId: string) => {
+        const c = makeFakeExtensionClient(conversationId);
+        c.send = mock(async () => {
+          throw new CdpError("transport_error", "disconnected");
+        });
+        lastExtensionClient = c;
+        return c;
+      },
+    );
+
+    const ctx = makeContext({
+      conversationId: "kind-after-failover",
+      hostBrowserProxy: fakeProxy,
+    });
+
+    const client = getCdpClient(ctx);
+
+    // Before first send, kind reflects the first candidate
+    expect(client.kind).toBe("extension");
+
+    // After failover, kind should reflect the local backend
+    await client.send("Page.navigate");
+    expect(client.kind).toBe("local");
+  });
+
+  test("dispose cleans up failed backends from failover chain", async () => {
+    const fakeProxy = makeAvailableProxy();
+
+    // Make extension fail
+    createExtensionCdpClientMock.mockImplementationOnce(
+      (_proxy: HostBrowserProxy, conversationId: string) => {
+        const c = makeFakeExtensionClient(conversationId);
+        c.send = mock(async () => {
+          throw new CdpError("transport_error", "disconnected");
+        });
+        lastExtensionClient = c;
+        return c;
+      },
+    );
+
+    const ctx = makeContext({
+      conversationId: "dispose-failover",
+      hostBrowserProxy: fakeProxy,
+    });
+
+    const client = getCdpClient(ctx);
+    await client.send("Page.navigate");
+
+    // Now dispose -- both the failed extension backend and the
+    // successful local backend should be cleaned up.
+    client.dispose();
+
+    // The extension client's dispose was already called during
+    // failover (via manager.disposeAll()), and local's dispose should
+    // be called now
+    expect(lastLocalClient?.dispose).toHaveBeenCalled();
   });
 });

--- a/assistant/src/tools/browser/cdp-client/factory.ts
+++ b/assistant/src/tools/browser/cdp-client/factory.ts
@@ -8,135 +8,426 @@ import {
   createLocalBackend,
 } from "../../../browser-session/index.js";
 import { getConfig } from "../../../config/loader.js";
+import { getLogger } from "../../../util/logger.js";
 import type { ToolContext } from "../../types.js";
 import { createCdpInspectClient } from "./cdp-inspect-client.js";
 import { CdpError } from "./errors.js";
 import { createExtensionCdpClient } from "./extension-cdp-client.js";
 import { createLocalCdpClient } from "./local-cdp-client.js";
-import type { CdpClient, CdpClientKind, ScopedCdpClient } from "./types.js";
+import type {
+  BackendCandidate,
+  CdpClient,
+  CdpClientKind,
+  ScopedCdpClient,
+} from "./types.js";
+
+const log = getLogger("cdp-factory");
 
 /**
  * Select the appropriate CdpClient implementation for a tool
  * invocation based on the ToolContext and config. Three backends are
  * considered in priority order:
  *
- *  1. **Extension** — When `context.hostBrowserProxy` is set (macOS
- *     desktop / cloud-hosted with a chrome-extension bound to the
- *     conversation), register an extension backend so CDP commands
- *     ride the host_browser_request / host_browser_result round-trip.
- *  2. **cdp-inspect** — When the extension is absent and
- *     `hostBrowser.cdpInspect.enabled` is `true` in config, construct
- *     a `CdpInspectClient` that attaches to an already-running Chrome
- *     via the DevTools JSON protocol (`--remote-debugging-port`).
- *  3. **Local** — Default. Drives Playwright's CDPSession
- *     against the sacrificial-profile browser managed by
- *     browserManager.
+ *  1. **Extension** -- When `context.hostBrowserProxy` is set AND
+ *     `hostBrowserProxy.isAvailable()` returns `true` (i.e. the
+ *     proxy exists and the client is actually connected). This
+ *     prevents selecting the extension transport when the proxy
+ *     object exists but the underlying WebSocket is disconnected.
+ *  2. **cdp-inspect** -- When `hostBrowser.cdpInspect.enabled` is
+ *     `true` in config, construct a `CdpInspectClient` that attaches
+ *     to an already-running Chrome via the DevTools JSON protocol.
+ *  3. **Local** -- Default. Drives Playwright's CDPSession against
+ *     the sacrificial-profile browser managed by browserManager.
  *
- * All three paths go through a per-invocation `BrowserSessionManager`
- * so the manager is the single choke point for CDP routing, session
- * lifetime, and (future) session invalidation handling. The returned
- * client is `kind`-tagged so tools can branch on transport — e.g.
- * browser_navigate skips Playwright-specific screencast and handoff
- * hooks when `kind === "extension"`.
+ * The factory builds an ordered candidate list and returns a
+ * {@link ScopedCdpClient} with per-invocation failover semantics:
+ *
+ *  - On the first `send()`, the top-ranked candidate is selected and
+ *    its backend is materialised.
+ *  - If the first command fails with a **transport-level** error
+ *    (`transport_error`), the factory tears down the failed backend
+ *    and retries the same command against the next candidate.
+ *  - **CDP protocol errors** (`cdp_error`) do NOT trigger failover --
+ *    they indicate the browser understood the command and rejected it,
+ *    so hopping transports would not help.
+ *  - After the first successful CDP command, the backend becomes
+ *    **sticky** for the remainder of the invocation. Subsequent
+ *    commands always route through the same backend so multi-command
+ *    tool flows do not hop transports mid-step.
  *
  * IMPORTANT: the returned client is per-invocation. Tools MUST call
  * `dispose()` in a finally block. Dispose tears down the manager's
  * session and the underlying CDP client. Disposing an extension-backed
- * client does NOT dispose the underlying HostBrowserProxy — that is
+ * client does NOT dispose the underlying HostBrowserProxy -- that is
  * owned by the conversation.
  */
 export function getCdpClient(context: ToolContext): ScopedCdpClient {
-  const { conversationId, hostBrowserProxy } = context;
+  const candidates = buildCandidateList(context);
 
-  // 1. Extension backend — preferred when a chrome-extension is bound.
-  if (hostBrowserProxy) {
-    const client = createExtensionCdpClient(hostBrowserProxy, conversationId);
-    const backend = createExtensionBackend({
-      isAvailable: () => true,
-      sendCdp: (command, signal) =>
-        dispatchThroughClient(client, command, signal),
-      dispose: () => client.dispose(),
-    });
-    return buildManagedClient("extension", conversationId, backend);
-  }
+  log.debug(
+    {
+      conversationId: context.conversationId,
+      candidates: candidates.map((c) => ({ kind: c.kind, reason: c.reason })),
+    },
+    "CDP factory: built candidate list",
+  );
 
-  // 2. cdp-inspect backend — opt-in via config when the extension is absent.
-  const cdpInspectConfig = getConfig().hostBrowser.cdpInspect;
-  if (cdpInspectConfig.enabled) {
-    const client = createCdpInspectClient(conversationId, {
-      host: cdpInspectConfig.host,
-      port: cdpInspectConfig.port,
-      discoveryTimeoutMs: cdpInspectConfig.probeTimeoutMs,
-    });
-    const backend = createCdpInspectBackend({
-      isAvailable: () => true,
-      sendCdp: (command, signal) =>
-        dispatchThroughClient(client, command, signal),
-      dispose: () => client.dispose(),
-    });
-    return buildManagedClient("cdp-inspect", conversationId, backend);
-  }
-
-  // 3. Local backend — default (Playwright-backed Chromium).
-  const client = createLocalCdpClient(conversationId);
-  const backend = createLocalBackend({
-    isAvailable: () => true,
-    sendCdp: (command, signal) =>
-      dispatchThroughClient(client, command, signal),
-    dispose: () => client.dispose(),
-  });
-  return buildManagedClient("local", conversationId, backend);
+  return buildChainedClient(context.conversationId, candidates);
 }
 
+// ---------------------------------------------------------------------------
+// Candidate list construction
+// ---------------------------------------------------------------------------
+
 /**
- * Build a ScopedCdpClient whose `send()` routes through a
- * BrowserSessionManager seeded with a single backend + session. This
- * lets tool call sites remain backend-agnostic while giving the
- * manager a seam for future session-invalidation and multi-target
- * routing work.
+ * Build an ordered list of backend candidates from the tool context
+ * and config. Candidates are evaluated lazily -- `create()` is only
+ * called when the candidate is actually selected.
+ *
+ * Exported for testing.
  */
-function buildManagedClient(
-  kind: CdpClientKind,
+export function buildCandidateList(context: ToolContext): BackendCandidate[] {
+  const { conversationId, hostBrowserProxy } = context;
+  const candidates: BackendCandidate[] = [];
+
+  // 1. Extension -- preferred when a chrome-extension is bound AND
+  //    the proxy reports it is connected. Checking isAvailable()
+  //    prevents selecting the extension transport when the proxy
+  //    object exists (e.g. it was provisioned at conversation start)
+  //    but the client has since disconnected.
+  if (hostBrowserProxy && hostBrowserProxy.isAvailable()) {
+    candidates.push({
+      kind: "extension",
+      reason: "hostBrowserProxy present and available",
+      create() {
+        const client = createExtensionCdpClient(
+          hostBrowserProxy,
+          conversationId,
+        );
+        const backend = createExtensionBackend({
+          isAvailable: () => true,
+          sendCdp: (command, signal) =>
+            dispatchThroughClient(client, command, signal),
+          dispose: () => client.dispose(),
+        });
+        return { client, backend };
+      },
+    });
+  } else if (hostBrowserProxy) {
+    log.debug(
+      { conversationId },
+      "CDP factory: hostBrowserProxy present but not available, skipping extension candidate",
+    );
+  }
+
+  // 2. cdp-inspect -- opt-in via config.
+  const cdpInspectConfig = getConfig().hostBrowser.cdpInspect;
+  if (cdpInspectConfig.enabled) {
+    candidates.push({
+      kind: "cdp-inspect",
+      reason: "cdpInspect enabled in config",
+      create() {
+        const client = createCdpInspectClient(conversationId, {
+          host: cdpInspectConfig.host,
+          port: cdpInspectConfig.port,
+          discoveryTimeoutMs: cdpInspectConfig.probeTimeoutMs,
+        });
+        const backend = createCdpInspectBackend({
+          isAvailable: () => true,
+          sendCdp: (command, signal) =>
+            dispatchThroughClient(client, command, signal),
+          dispose: () => client.dispose(),
+        });
+        return { client, backend };
+      },
+    });
+  }
+
+  // 3. Local -- always present as the final fallback.
+  candidates.push({
+    kind: "local",
+    reason: "default Playwright fallback",
+    create() {
+      const client = createLocalCdpClient(conversationId);
+      const backend = createLocalBackend({
+        isAvailable: () => true,
+        sendCdp: (command, signal) =>
+          dispatchThroughClient(client, command, signal),
+        dispose: () => client.dispose(),
+      });
+      return { client, backend };
+    },
+  });
+
+  return candidates;
+}
+
+// ---------------------------------------------------------------------------
+// Chained client with per-invocation failover
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a {@link ScopedCdpClient} that walks the candidate list on
+ * the first command, failing over on transport-level errors, and
+ * becomes sticky after the first successful CDP command.
+ *
+ * Exported for testing.
+ */
+export function buildChainedClient(
   conversationId: string,
-  backend: BrowserBackend,
+  candidates: BackendCandidate[],
 ): ScopedCdpClient {
-  const manager = new BrowserSessionManager({ backends: [backend] });
-  const session = manager.createSession();
+  if (candidates.length === 0) {
+    throw new Error("CDP factory: no backend candidates available");
+  }
+
+  /** Active backend state -- populated after first successful command. */
+  let active: {
+    kind: CdpClientKind;
+    manager: BrowserSessionManager;
+    sessionId: string;
+  } | null = null;
+
+  /** Set to true after the first successful CDP command. */
+  let sticky = false;
+
   let disposed = false;
 
-  return {
-    kind,
+  /**
+   * Track all materialised backends so dispose() can tear them all
+   * down, even ones that were tried and failed before the sticky
+   * backend was established.
+   */
+  const materialisedManagers: BrowserSessionManager[] = [];
+
+  /**
+   * The kind of the currently active (or last attempted) backend.
+   * Before the first send this reflects the first candidate; after
+   * the sticky backend is established it reflects the chosen kind.
+   */
+  let currentKind: CdpClientKind = candidates[0].kind;
+
+  const scopedClient: ScopedCdpClient = {
+    get kind(): CdpClientKind {
+      return active?.kind ?? currentKind;
+    },
     conversationId,
+
     async send<T = unknown>(
       method: string,
       params?: Record<string, unknown>,
       signal?: AbortSignal,
     ): Promise<T> {
       if (disposed) {
-        const clientName =
-          kind === "extension"
-            ? "ExtensionCdpClient"
-            : kind === "cdp-inspect"
-              ? "CdpInspectClient"
-              : "LocalCdpClient";
-        throw new CdpError("disposed", `${clientName} already disposed`, {
+        throw new CdpError("disposed", "CdpClient already disposed", {
           cdpMethod: method,
           cdpParams: params,
         });
       }
-      const command: CdpCommand = { method, params };
-      const envelope = await manager.send(session.id, command, signal);
-      return unwrapResult<T>(envelope, method, params);
+
+      // Fast path: backend is already sticky -- route directly.
+      if (sticky && active) {
+        const command: CdpCommand = { method, params };
+        const envelope = await active.manager.send(
+          active.sessionId,
+          command,
+          signal,
+        );
+        return unwrapResult<T>(envelope, method, params);
+      }
+
+      // Slow path: walk the candidate list with failover.
+      return sendWithFailover<T>(
+        candidates,
+        materialisedManagers,
+        method,
+        params,
+        signal,
+        (established) => {
+          active = established;
+          sticky = true;
+          currentKind = established.kind;
+        },
+        () => disposed,
+        conversationId,
+      );
     },
+
     dispose(): void {
       if (disposed) return;
       disposed = true;
-      // disposeAll() tears down the per-invocation backend (which in
-      // turn disposes the underlying CdpClient) and clears the single
-      // session we created in buildManagedClient.
-      manager.disposeAll();
+      for (const m of materialisedManagers) {
+        m.disposeAll();
+      }
+      materialisedManagers.length = 0;
+      active = null;
     },
   };
+
+  return scopedClient;
+}
+
+/**
+ * Walk the candidate list attempting to execute a single CDP command.
+ * Transport-level failures trigger failover to the next candidate;
+ * CDP protocol errors propagate immediately.
+ */
+async function sendWithFailover<T>(
+  candidates: BackendCandidate[],
+  materialisedManagers: BrowserSessionManager[],
+  method: string,
+  params: Record<string, unknown> | undefined,
+  signal: AbortSignal | undefined,
+  onEstablished: (active: {
+    kind: CdpClientKind;
+    manager: BrowserSessionManager;
+    sessionId: string;
+  }) => void,
+  isDisposed: () => boolean,
+  conversationId: string,
+): Promise<T> {
+  let lastError: CdpError | undefined;
+
+  for (let i = 0; i < candidates.length; i++) {
+    const candidate = candidates[i];
+    if (isDisposed()) {
+      throw new CdpError("disposed", "CdpClient already disposed", {
+        cdpMethod: method,
+        cdpParams: params,
+      });
+    }
+
+    log.debug(
+      {
+        conversationId,
+        candidateKind: candidate.kind,
+        candidateIndex: i,
+        method,
+      },
+      "CDP factory: attempting candidate",
+    );
+
+    let backend: BrowserBackend;
+    try {
+      const created = candidate.create();
+      backend = created.backend;
+    } catch (err) {
+      // Backend construction failed -- treat as transport error and
+      // try the next candidate.
+      log.debug(
+        { conversationId, candidateKind: candidate.kind, err },
+        "CDP factory: candidate construction failed, trying next",
+      );
+      lastError = new CdpError(
+        "transport_error",
+        `Backend ${candidate.kind} construction failed: ${err instanceof Error ? err.message : String(err)}`,
+        { cdpMethod: method, cdpParams: params, underlying: err },
+      );
+      continue;
+    }
+
+    const manager = new BrowserSessionManager({ backends: [backend] });
+    materialisedManagers.push(manager);
+    const session = manager.createSession();
+
+    const command: CdpCommand = { method, params };
+    let envelope: CdpResult;
+    try {
+      envelope = await manager.send(session.id, command, signal);
+    } catch (err) {
+      // Manager-level errors (unknown session, no available backend)
+      // are transport-level problems -- try the next candidate.
+      log.debug(
+        { conversationId, candidateKind: candidate.kind, err },
+        "CDP factory: candidate send threw, trying next",
+      );
+      manager.disposeAll();
+      lastError = new CdpError(
+        "transport_error",
+        `Backend ${candidate.kind} send threw: ${err instanceof Error ? err.message : String(err)}`,
+        { cdpMethod: method, cdpParams: params, underlying: err },
+      );
+      continue;
+    }
+
+    // Inspect the envelope for errors. Transport-level errors trigger
+    // failover; CDP protocol errors propagate immediately.
+    if (envelope.error) {
+      const cdpError = extractCdpError(envelope, method, params);
+
+      if (isTransportFailover(cdpError) && i < candidates.length - 1) {
+        log.debug(
+          {
+            conversationId,
+            candidateKind: candidate.kind,
+            errorCode: cdpError.code,
+            errorMessage: cdpError.message,
+          },
+          "CDP factory: transport-level failure, failing over to next candidate",
+        );
+        manager.disposeAll();
+        lastError = cdpError;
+        continue;
+      }
+
+      // Either a CDP protocol error or we've exhausted candidates --
+      // propagate the error as-is.
+      throw cdpError;
+    }
+
+    // Success! Establish this backend as the sticky choice.
+    log.debug(
+      { conversationId, candidateKind: candidate.kind, method },
+      "CDP factory: candidate succeeded, backend is now sticky",
+    );
+    onEstablished({ kind: candidate.kind, manager, sessionId: session.id });
+    return envelope.result as T;
+  }
+
+  // All candidates exhausted -- throw the last transport error.
+  throw (
+    lastError ??
+    new CdpError("transport_error", "All backend candidates exhausted", {
+      cdpMethod: method,
+      cdpParams: params,
+    })
+  );
+}
+
+/**
+ * Determine whether a CdpError should trigger failover to the next
+ * candidate. Only transport-level failures are eligible -- CDP
+ * protocol errors indicate the browser understood the command and
+ * rejected it, so retrying on a different transport would not help.
+ */
+function isTransportFailover(err: CdpError): boolean {
+  return err.code === "transport_error";
+}
+
+// ---------------------------------------------------------------------------
+// Helpers (shared with the old implementation)
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract a CdpError from a CdpResult envelope that carries an error.
+ */
+function extractCdpError(
+  envelope: CdpResult,
+  method: string,
+  params?: Record<string, unknown>,
+): CdpError {
+  if (envelope.error?.data instanceof CdpError) {
+    return envelope.error.data;
+  }
+  return new CdpError(
+    "cdp_error",
+    envelope.error?.message ?? "Unknown CDP error",
+    {
+      cdpMethod: method,
+      cdpParams: params,
+      underlying: envelope.error,
+    },
+  );
 }
 
 /**
@@ -148,7 +439,7 @@ function buildManagedClient(
  *
  * The per-command `command.sessionId` (populated by the manager from
  * a session's opaque `targetId`) is intentionally not forwarded to
- * the underlying CdpClient today — both LocalCdpClient and
+ * the underlying CdpClient today -- both LocalCdpClient and
  * ExtensionCdpClient take their CDP sessionId at construction time
  * and tools run one client per invocation. The seam is preserved so
  * a future multi-target backend can read it off the CdpCommand.
@@ -163,9 +454,9 @@ async function dispatchThroughClient(
     return { result };
   } catch (err) {
     if (err instanceof CdpError) {
-      // Preserve the original CdpError so unwrapResult can re-throw it
-      // verbatim. CdpResult's error channel is opaque to the manager,
-      // so stashing the instance under `data` is safe.
+      // Preserve the original CdpError so extractCdpError can
+      // re-throw it verbatim. CdpResult's error channel is opaque
+      // to the manager, so stashing the instance under `data` is safe.
       return {
         error: {
           code: -1,
@@ -191,14 +482,7 @@ function unwrapResult<T>(
   params?: Record<string, unknown>,
 ): T {
   if (envelope.error) {
-    if (envelope.error.data instanceof CdpError) {
-      throw envelope.error.data;
-    }
-    throw new CdpError("cdp_error", envelope.error.message, {
-      cdpMethod: method,
-      cdpParams: params,
-      underlying: envelope.error,
-    });
+    throw extractCdpError(envelope, method, params);
   }
   return envelope.result as T;
 }

--- a/assistant/src/tools/browser/cdp-client/index.ts
+++ b/assistant/src/tools/browser/cdp-client/index.ts
@@ -9,6 +9,15 @@ export {
   createExtensionCdpClient,
   ExtensionCdpClient,
 } from "./extension-cdp-client.js";
-export { getCdpClient } from "./factory.js";
+export {
+  buildCandidateList,
+  buildChainedClient,
+  getCdpClient,
+} from "./factory.js";
 export { createLocalCdpClient, LocalCdpClient } from "./local-cdp-client.js";
-export type { CdpClient, CdpClientKind, ScopedCdpClient } from "./types.js";
+export type {
+  BackendCandidate,
+  CdpClient,
+  CdpClientKind,
+  ScopedCdpClient,
+} from "./types.js";

--- a/assistant/src/tools/browser/cdp-client/types.ts
+++ b/assistant/src/tools/browser/cdp-client/types.ts
@@ -50,3 +50,26 @@ export interface ScopedCdpClient extends CdpClient {
   /** Stable conversation id this client is bound to. */
   readonly conversationId: string;
 }
+
+/**
+ * A deferred backend candidate used by the chained factory. Each
+ * candidate carries a `kind` label and a `create` thunk that
+ * materialises the underlying {@link CdpClient} + {@link BrowserBackend}
+ * on demand. The factory only calls `create()` when the candidate is
+ * actually selected (either as the primary or as a failover target),
+ * so backends that are never reached pay zero setup cost.
+ */
+export interface BackendCandidate {
+  readonly kind: CdpClientKind;
+  /** Human-readable reason this candidate was included. */
+  readonly reason: string;
+  /**
+   * Materialise the backend. Called at most once — the factory caches
+   * the result after the first successful CDP command so subsequent
+   * commands reuse the same backend (sticky semantics).
+   */
+  create(): {
+    client: CdpClient;
+    backend: import("../../../browser-session/types.js").BrowserBackend;
+  };
+}


### PR DESCRIPTION
## Summary
- Refactor getCdpClient() to build ordered candidate list with failover semantics
- Add extension availability check (isAvailable()) to prevent selecting disconnected proxies
- Implement per-invocation failover with sticky backend after first successful command

Part of plan: macos-browser-extension-cdp-fallback.md (PR 3 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24747" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
