### PR TITLE
feat(skills): wire search bar to backend search endpoint for all sources

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -152,6 +152,13 @@ struct AgentPanelContent: View {
     private var filterBar: some View {
         HStack(spacing: VSpacing.sm) {
             VSearchBar(placeholder: "Search Skills", text: $skillsManager.searchQuery)
+                .overlay(alignment: .trailing) {
+                    if skillsManager.isSearching {
+                        ProgressView()
+                            .controlSize(.small)
+                            .padding(.trailing, 28)
+                    }
+                }
             VDropdown(
                 options: SkillFilter.allCases.map { VDropdownOption(label: $0.rawValue, value: $0, icon: $0.icon) },
                 selection: $skillsManager.skillFilter,
@@ -259,6 +266,13 @@ struct AgentPanelContent: View {
             )
             .id(skill.id)
         } else if skillsManager.isLoading && skillsManager.baseSkillsEmpty {
+            VStack {
+                Spacer()
+                VLoadingIndicator()
+                Spacer()
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if skillsManager.isSearching && skillsManager.filteredSkills.isEmpty {
             VStack {
                 Spacer()
                 VLoadingIndicator()

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
@@ -115,7 +115,8 @@ final class SkillsManager {
                 // deduplicating by skill id so local entries take precedence.
                 let localSkills = self.skillsStore.skills
                 let mergedSkills: [SkillInfo]
-                if !self.skillsStore.searchResults.isEmpty && !self.skillsStore.isSearching {
+                let hasActiveQuery = !self.searchQuery.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                if hasActiveQuery && !self.skillsStore.searchResults.isEmpty && !self.skillsStore.isSearching {
                     let localIds = Set(localSkills.map(\.id))
                     let externalResults = self.skillsStore.searchResults.filter { !localIds.contains($0.id) }
                     mergedSkills = localSkills + externalResults

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
@@ -49,17 +49,22 @@ final class SkillsManager {
     var loadingFilePaths: Set<String> = []
     var fileContentErrors: [String: String] = [:]
     var installingSkillId: String?
+    var isSearching = false
 
     /// Safety timeout that defensively clears `installingSkillId` if a
     /// wedged `fetchSkills(force:)` response never lands. Without it, the
     /// install spinner can be stuck indefinitely when the confirmation
     /// refresh path is blocked or delayed.
     @ObservationIgnored private var installWatchdogTask: Task<Void, Never>?
+    @ObservationIgnored private var searchDebounceTask: Task<Void, Never>?
 
     // MARK: - Filter Inputs
 
     var searchQuery: String = "" {
-        didSet { recomputeFilteredData() }
+        didSet {
+            recomputeFilteredData()
+            dispatchSearch(query: searchQuery)
+        }
     }
 
     var selectedCategory: SkillCategory? {
@@ -104,9 +109,21 @@ final class SkillsManager {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 guard let self else { return }
-                let skills = self.skillsStore.skills
-                self.skills = skills
-                self.rebuildCategoryMap(from: skills)
+                self.isSearching = self.skillsStore.isSearching
+
+                // Merge local skills with external search results (if any),
+                // deduplicating by skill id so local entries take precedence.
+                let localSkills = self.skillsStore.skills
+                let mergedSkills: [SkillInfo]
+                if !self.skillsStore.searchResults.isEmpty && !self.skillsStore.isSearching {
+                    let localIds = Set(localSkills.map(\.id))
+                    let externalResults = self.skillsStore.searchResults.filter { !localIds.contains($0.id) }
+                    mergedSkills = localSkills + externalResults
+                } else {
+                    mergedSkills = localSkills
+                }
+                self.skills = mergedSkills
+                self.rebuildCategoryMap(from: mergedSkills)
                 self.loadedBodies = self.skillsStore.loadedBodies
                 self.isLoading = self.skillsStore.isLoading
                 self.uninstallResult = self.skillsStore.uninstallResult
@@ -266,6 +283,22 @@ final class SkillsManager {
             return "Custom"
         default:
             return origin.replacingOccurrences(of: "-", with: " ").capitalized
+        }
+    }
+
+    // MARK: - Debounced Search
+
+    private func dispatchSearch(query: String) {
+        searchDebounceTask?.cancel()
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            skillsStore.searchResults = []
+            return
+        }
+        searchDebounceTask = Task {
+            try? await Task.sleep(nanoseconds: 300_000_000)
+            guard !Task.isCancelled else { return }
+            skillsStore.searchSkills(query: trimmed, force: true)
         }
     }
 

--- a/clients/shared/Features/Skills/SkillsStore.swift
+++ b/clients/shared/Features/Skills/SkillsStore.swift
@@ -92,6 +92,7 @@ public final class SkillsStore: ObservableObject {
 
     private let skillsClient: SkillsClientProtocol
     private var lastSearchQuery: String?
+    private var searchTask: Task<Void, Never>?
     private var draftTask: Task<Void, Never>?
     private var createTask: Task<Void, Never>?
     private var skillDetailTask: Task<Void, Never>?
@@ -145,12 +146,15 @@ public final class SkillsStore: ObservableObject {
     // MARK: - Search Skills
 
     public func searchSkills(query: String = "", force: Bool = false) {
-        guard !isSearching else { return }
         if !force && !searchResults.isEmpty && lastSearchQuery == query { return }
+
+        // Cancel any in-flight search so the latest query always wins.
+        searchTask?.cancel()
         isSearching = true
 
-        Task {
+        searchTask = Task {
             let result = await skillsClient.searchSkills(query: query)
+            guard !Task.isCancelled else { return }
             if let result, result.success {
                 searchResults = result.skills
             } else {


### PR DESCRIPTION
## Summary
- Wire SkillsManager search bar to SkillsStore.searchSkills() backend endpoint with 300ms debounce
- Merge external search results (ClaWHub, Skills.sh) into the local skills list for unified display
- Add loading indicator during network search

Part of plan: skills-search-all-sources.md (PR 1 of 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24749" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
