### PR TITLE
feat(browser): support WS-only CDP endpoints when HTTP discovery is unavailable

### DIFF
--- a/assistant/src/tools/browser/cdp-client/__tests__/cdp-inspect-client.test.ts
+++ b/assistant/src/tools/browser/cdp-client/__tests__/cdp-inspect-client.test.ts
@@ -16,6 +16,7 @@ const { CdpInspectClient, createCdpInspectClient } =
   await import("../cdp-inspect-client.js");
 const { CdpError } = await import("../errors.js");
 const { CdpWsTransportError } = await import("../cdp-inspect/ws-transport.js");
+const { DevToolsDiscoveryError } = await import("../cdp-inspect/discovery.js");
 
 type CdpInspectClientInstance = InstanceType<typeof CdpInspectClient>;
 
@@ -866,5 +867,397 @@ describe("CdpInspectClient", () => {
     expect(harness.listCalls).toBe(1);
     expect(harness.connectCalls).toBe(1);
     expect(harness.attachCallCount()).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// WS-only fallback — HTTP discovery absent, WS fallback succeeds.
+// ---------------------------------------------------------------------------
+
+describe("CdpInspectClient — WS-only fallback", () => {
+  test("falls back to WS when HTTP discovery returns invalid_response", async () => {
+    const sends: Array<{
+      method: string;
+      params?: Record<string, unknown>;
+      sessionId?: string;
+    }> = [];
+    let connectCount = 0;
+    let discoverViaWsCalls = 0;
+
+    const client = createCdpInspectClient("conv-ws-fallback", {
+      host: "127.0.0.1",
+      port: 9222,
+      discoveryTimeoutMs: 100,
+      wsConnectTimeoutMs: 100,
+      helpers: {
+        probeDevToolsJsonVersion: async () => {
+          throw new DevToolsDiscoveryError(
+            "invalid_response",
+            "DevTools /json/version returned HTTP 404.",
+          );
+        },
+        listDevToolsTargets: async () => {
+          throw new Error("listDevToolsTargets should not be called");
+        },
+        connectCdpWsTransport: async () => {
+          connectCount += 1;
+          return createFakeTransport({
+            onSend: async (method) => {
+              if (method === "Target.attachToTarget") {
+                return { sessionId: "ws-session" };
+              }
+              return { ok: true };
+            },
+            trackSends: sends,
+          });
+        },
+        discoverTargetsViaWs: async () => {
+          discoverViaWsCalls += 1;
+          return [
+            {
+              id: "ws-target-1",
+              type: "page",
+              title: "WS Page",
+              url: "https://example.com/",
+              webSocketDebuggerUrl:
+                "ws://127.0.0.1:9222/devtools/page/ws-target-1",
+            },
+          ];
+        },
+        buildBrowserWsUrl: (host: string, port: number) =>
+          `ws://${host}:${port}/devtools/browser`,
+      },
+    });
+
+    const result = await client.send<{ ok: boolean }>("Browser.getVersion");
+    expect(result).toEqual({ ok: true });
+    expect(connectCount).toBe(1);
+    expect(discoverViaWsCalls).toBe(1);
+    // attach + forwarded call
+    expect(sends).toEqual([
+      {
+        method: "Target.attachToTarget",
+        params: { targetId: "ws-target-1", flatten: true },
+        sessionId: undefined,
+      },
+      {
+        method: "Browser.getVersion",
+        params: undefined,
+        sessionId: "ws-session",
+      },
+    ]);
+  });
+
+  test("falls back to WS when HTTP discovery is unreachable", async () => {
+    let discoverViaWsCalls = 0;
+
+    const client = createCdpInspectClient("conv-ws-unreachable", {
+      host: "127.0.0.1",
+      port: 9222,
+      discoveryTimeoutMs: 100,
+      helpers: {
+        probeDevToolsJsonVersion: async () => {
+          throw new DevToolsDiscoveryError(
+            "unreachable",
+            "Failed to reach DevTools endpoint: ECONNREFUSED",
+          );
+        },
+        listDevToolsTargets: async () => {
+          throw new Error("should not be called");
+        },
+        connectCdpWsTransport: async () =>
+          createFakeTransport({
+            onSend: async (method) => {
+              if (method === "Target.attachToTarget") {
+                return { sessionId: "ws-session" };
+              }
+              return { ok: true };
+            },
+          }),
+        discoverTargetsViaWs: async () => {
+          discoverViaWsCalls += 1;
+          return [
+            {
+              id: "ws-target-1",
+              type: "page",
+              title: "Page",
+              url: "https://example.com/",
+              webSocketDebuggerUrl:
+                "ws://127.0.0.1:9222/devtools/page/ws-target-1",
+            },
+          ];
+        },
+        buildBrowserWsUrl: (host: string, port: number) =>
+          `ws://${host}:${port}/devtools/browser`,
+      },
+    });
+
+    const result = await client.send<{ ok: boolean }>("Runtime.enable");
+    expect(result).toEqual({ ok: true });
+    expect(discoverViaWsCalls).toBe(1);
+  });
+
+  test("does NOT fall back to WS on non_loopback error (safety constraint)", async () => {
+    let connectCalled = false;
+
+    const client = createCdpInspectClient("conv-no-fallback-loopback", {
+      host: "127.0.0.1",
+      port: 9222,
+      discoveryTimeoutMs: 100,
+      helpers: {
+        probeDevToolsJsonVersion: async () => {
+          throw new DevToolsDiscoveryError(
+            "non_loopback",
+            "Refusing to probe non-loopback host",
+          );
+        },
+        listDevToolsTargets: async () => {
+          throw new Error("should not be called");
+        },
+        connectCdpWsTransport: async () => {
+          connectCalled = true;
+          return createFakeTransport({});
+        },
+        discoverTargetsViaWs: async () => {
+          throw new Error("should not be called");
+        },
+        buildBrowserWsUrl: () => "ws://127.0.0.1:9222/devtools/browser",
+      },
+    });
+
+    let caught: unknown;
+    try {
+      await client.send("Browser.getVersion");
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(CdpError);
+    const cdpErr = caught as InstanceType<typeof CdpError>;
+    expect(cdpErr.code).toBe("transport_error");
+    expect(cdpErr.message).toContain("non-loopback");
+    expect(connectCalled).toBe(false);
+  });
+
+  test("does NOT fall back to WS on non_chrome error", async () => {
+    let connectCalled = false;
+
+    const client = createCdpInspectClient("conv-no-fallback-chrome", {
+      host: "127.0.0.1",
+      port: 9222,
+      discoveryTimeoutMs: 100,
+      helpers: {
+        probeDevToolsJsonVersion: async () => {
+          throw new DevToolsDiscoveryError(
+            "non_chrome",
+            "Not Chrome: Firefox/115.0",
+          );
+        },
+        listDevToolsTargets: async () => {
+          throw new Error("should not be called");
+        },
+        connectCdpWsTransport: async () => {
+          connectCalled = true;
+          return createFakeTransport({});
+        },
+        discoverTargetsViaWs: async () => {
+          throw new Error("should not be called");
+        },
+        buildBrowserWsUrl: () => "ws://127.0.0.1:9222/devtools/browser",
+      },
+    });
+
+    let caught: unknown;
+    try {
+      await client.send("Browser.getVersion");
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(CdpError);
+    const cdpErr = caught as InstanceType<typeof CdpError>;
+    expect(cdpErr.code).toBe("transport_error");
+    expect(connectCalled).toBe(false);
+  });
+
+  test("does NOT fall back to WS on timeout error", async () => {
+    let connectCalled = false;
+
+    const client = createCdpInspectClient("conv-no-fallback-timeout", {
+      host: "127.0.0.1",
+      port: 9222,
+      discoveryTimeoutMs: 100,
+      helpers: {
+        probeDevToolsJsonVersion: async () => {
+          throw new DevToolsDiscoveryError(
+            "timeout",
+            "Timed out waiting for DevTools HTTP response.",
+          );
+        },
+        listDevToolsTargets: async () => {
+          throw new Error("should not be called");
+        },
+        connectCdpWsTransport: async () => {
+          connectCalled = true;
+          return createFakeTransport({});
+        },
+        discoverTargetsViaWs: async () => {
+          throw new Error("should not be called");
+        },
+        buildBrowserWsUrl: () => "ws://127.0.0.1:9222/devtools/browser",
+      },
+    });
+
+    let caught: unknown;
+    try {
+      await client.send("Browser.getVersion");
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(CdpError);
+    const cdpErr = caught as InstanceType<typeof CdpError>;
+    expect(cdpErr.code).toBe("transport_error");
+    expect(connectCalled).toBe(false);
+  });
+
+  test("full fallback failure: HTTP invalid_response + WS connect fails", async () => {
+    const client = createCdpInspectClient("conv-full-fail", {
+      host: "127.0.0.1",
+      port: 9222,
+      discoveryTimeoutMs: 100,
+      helpers: {
+        probeDevToolsJsonVersion: async () => {
+          throw new DevToolsDiscoveryError(
+            "invalid_response",
+            "DevTools /json/version returned HTTP 404.",
+          );
+        },
+        listDevToolsTargets: async () => {
+          throw new Error("should not be called");
+        },
+        connectCdpWsTransport: async () => {
+          throw new CdpWsTransportError(
+            "transport_error",
+            "websocket closed before open",
+          );
+        },
+        discoverTargetsViaWs: async () => {
+          throw new Error("should not be called");
+        },
+        buildBrowserWsUrl: (host: string, port: number) =>
+          `ws://${host}:${port}/devtools/browser`,
+      },
+    });
+
+    let caught: unknown;
+    try {
+      await client.send("Browser.getVersion");
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(CdpError);
+    const cdpErr = caught as InstanceType<typeof CdpError>;
+    expect(cdpErr.code).toBe("transport_error");
+    // Error message should explain both HTTP and WS failures
+    expect(cdpErr.message).toContain("HTTP discovery failed");
+    expect(cdpErr.message).toContain("WS-only fallback also failed");
+    expect(cdpErr.message).toContain("127.0.0.1:9222");
+  });
+
+  test("WS fallback: no page targets yields stable error", async () => {
+    const client = createCdpInspectClient("conv-ws-no-targets", {
+      host: "127.0.0.1",
+      port: 9222,
+      discoveryTimeoutMs: 100,
+      helpers: {
+        probeDevToolsJsonVersion: async () => {
+          throw new DevToolsDiscoveryError("unreachable", "ECONNREFUSED");
+        },
+        listDevToolsTargets: async () => {
+          throw new Error("should not be called");
+        },
+        connectCdpWsTransport: async () =>
+          createFakeTransport({
+            onSend: async () => ({ ok: true }),
+          }),
+        discoverTargetsViaWs: async () => {
+          throw new DevToolsDiscoveryError(
+            "no_targets",
+            "No usable page targets returned by CDP Target.getTargets.",
+          );
+        },
+        buildBrowserWsUrl: (host: string, port: number) =>
+          `ws://${host}:${port}/devtools/browser`,
+      },
+    });
+
+    let caught: unknown;
+    try {
+      await client.send("Browser.getVersion");
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(CdpError);
+    const cdpErr = caught as InstanceType<typeof CdpError>;
+    expect(cdpErr.code).toBe("transport_error");
+    expect(cdpErr.message).toContain("No usable page targets");
+  });
+
+  test("WS fallback caches session for subsequent calls", async () => {
+    let connectCount = 0;
+    let discoverViaWsCalls = 0;
+
+    const client = createCdpInspectClient("conv-ws-cache", {
+      host: "127.0.0.1",
+      port: 9222,
+      discoveryTimeoutMs: 100,
+      helpers: {
+        probeDevToolsJsonVersion: async () => {
+          throw new DevToolsDiscoveryError(
+            "invalid_response",
+            "no HTTP discovery",
+          );
+        },
+        listDevToolsTargets: async () => {
+          throw new Error("should not be called");
+        },
+        connectCdpWsTransport: async () => {
+          connectCount += 1;
+          return createFakeTransport({
+            onSend: async (method) => {
+              if (method === "Target.attachToTarget") {
+                return { sessionId: "ws-session-cached" };
+              }
+              return { ok: true };
+            },
+          });
+        },
+        discoverTargetsViaWs: async () => {
+          discoverViaWsCalls += 1;
+          return [
+            {
+              id: "t1",
+              type: "page",
+              title: "Page",
+              url: "https://example.com/",
+              webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/page/t1",
+            },
+          ];
+        },
+        buildBrowserWsUrl: (host: string, port: number) =>
+          `ws://${host}:${port}/devtools/browser`,
+      },
+    });
+
+    await client.send("Runtime.enable");
+    await client.send("Page.enable");
+    await client.send("DOM.enable");
+
+    // Only one WS fallback discovery + one connect + one attach
+    expect(connectCount).toBe(1);
+    expect(discoverViaWsCalls).toBe(1);
   });
 });

--- a/assistant/src/tools/browser/cdp-client/cdp-inspect-client.ts
+++ b/assistant/src/tools/browser/cdp-client/cdp-inspect-client.ts
@@ -1,7 +1,10 @@
 import { getLogger } from "../../../util/logger.js";
 import {
+  buildBrowserWsUrl,
   type DevToolsTarget,
   type DevToolsVersionInfo,
+  discoverTargetsViaWs,
+  isHttpDiscoveryFallbackEligible,
   listDevToolsTargets,
   pickDefaultTarget,
   probeDevToolsJsonVersion,
@@ -60,13 +63,21 @@ export interface CdpInspectHelpers {
   listDevToolsTargets?: typeof listDevToolsTargets;
   pickDefaultTarget?: typeof pickDefaultTarget;
   connectCdpWsTransport?: typeof connectCdpWsTransport;
+  /** Override for the WS-only fallback target discovery. */
+  discoverTargetsViaWs?: typeof discoverTargetsViaWs;
+  /** Override for building the well-known browser WS URL. */
+  buildBrowserWsUrl?: typeof buildBrowserWsUrl;
 }
 
 interface AttachedSession {
   transport: CdpWsTransport;
   sessionId: string;
   target: DevToolsTarget;
-  version: DevToolsVersionInfo;
+  /**
+   * Version info from HTTP `/json/version`. `null` when the session
+   * was established via the WS-only fallback path (no HTTP discovery).
+   */
+  version: DevToolsVersionInfo | null;
 }
 
 /**
@@ -132,6 +143,10 @@ export class CdpInspectClient implements ScopedCdpClient {
         options.helpers?.pickDefaultTarget ?? pickDefaultTarget,
       connectCdpWsTransport:
         options.helpers?.connectCdpWsTransport ?? connectCdpWsTransport,
+      discoverTargetsViaWs:
+        options.helpers?.discoverTargetsViaWs ?? discoverTargetsViaWs,
+      buildBrowserWsUrl:
+        options.helpers?.buildBrowserWsUrl ?? buildBrowserWsUrl,
     };
   }
 
@@ -257,6 +272,13 @@ export class CdpInspectClient implements ScopedCdpClient {
    * can map them to stable `CdpError` codes without double-wrapping
    * the already-typed discovery / ws-transport errors.
    *
+   * Two discovery strategies are tried in order:
+   *
+   * 1. **HTTP discovery** (primary): `/json/version` + `/json/list`.
+   * 2. **WS-only fallback**: direct WebSocket connect to the well-known
+   *    browser endpoint + CDP `Target.getTargets`. Only attempted when
+   *    HTTP discovery fails with `invalid_response` or `unreachable`.
+   *
    * The `signal` here is the shared, internal {@link PendingAttach}
    * signal — NOT the per-caller signal. It is aborted when the last
    * caller interested in this attach has given up, or when `dispose()`
@@ -267,39 +289,230 @@ export class CdpInspectClient implements ScopedCdpClient {
       this.options.discoveryTimeoutMs ?? DEFAULT_DISCOVERY_TIMEOUT_MS;
     const { host, port } = this.options;
 
-    const version = await this.helpers.probeDevToolsJsonVersion({
+    // --- Try HTTP discovery first ---
+    const httpResult = await this.tryHttpDiscovery(
       host,
       port,
-      timeoutMs: discoveryTimeoutMs,
+      discoveryTimeoutMs,
       signal,
-    });
+    );
+
+    if (httpResult.ok) {
+      return this.connectAndAttach(
+        httpResult.wsUrl,
+        httpResult.target,
+        httpResult.version,
+        signal,
+      );
+    }
+
+    // HTTP discovery failed — check if the error is eligible for the
+    // WS-only fallback.
+    if (!isHttpDiscoveryFallbackEligible(httpResult.error)) {
+      // Non-recoverable error (non_loopback, non_chrome, timeout) —
+      // rethrow without attempting the WS fallback.
+      throw httpResult.error;
+    }
+
     if (signal.aborted) {
       throw new CdpError("aborted", "CdpInspectClient attach aborted");
     }
-    const targets = await this.helpers.listDevToolsTargets({
-      host,
-      port,
-      timeoutMs: discoveryTimeoutMs,
-      signal,
-    });
-    if (signal.aborted) {
-      throw new CdpError("aborted", "CdpInspectClient attach aborted");
+
+    // --- WS-only fallback path ---
+    log.debug(
+      {
+        conversationId: this.conversationId,
+        httpErrorCode: httpResult.error.code,
+        httpErrorMessage: httpResult.error.message,
+      },
+      "HTTP discovery unavailable, attempting WS-only fallback",
+    );
+
+    return this.tryWsFallback(host, port, httpResult.error, signal);
+  }
+
+  /**
+   * Attempt HTTP-based discovery (probe `/json/version` + enumerate
+   * `/json/list`). Returns a discriminated result so the caller can
+   * branch on success vs. failure without try/catch nesting.
+   */
+  private async tryHttpDiscovery(
+    host: string,
+    port: number,
+    discoveryTimeoutMs: number,
+    signal: AbortSignal,
+  ): Promise<
+    | {
+        ok: true;
+        version: DevToolsVersionInfo;
+        target: DevToolsTarget;
+        wsUrl: string;
+      }
+    | { ok: false; error: unknown }
+  > {
+    try {
+      const version = await this.helpers.probeDevToolsJsonVersion({
+        host,
+        port,
+        timeoutMs: discoveryTimeoutMs,
+        signal,
+      });
+      if (signal.aborted) {
+        return {
+          ok: false,
+          error: new CdpError("aborted", "CdpInspectClient attach aborted"),
+        };
+      }
+      const targets = await this.helpers.listDevToolsTargets({
+        host,
+        port,
+        timeoutMs: discoveryTimeoutMs,
+        signal,
+      });
+      if (signal.aborted) {
+        return {
+          ok: false,
+          error: new CdpError("aborted", "CdpInspectClient attach aborted"),
+        };
+      }
+      const target = this.helpers.pickDefaultTarget(targets);
+      const wsUrl = version.webSocketDebuggerUrl || target.webSocketDebuggerUrl;
+      return { ok: true, version, target, wsUrl };
+    } catch (err) {
+      return { ok: false, error: err };
     }
+  }
+
+  /**
+   * WS-only fallback: connect directly to the well-known browser
+   * WebSocket endpoint, enumerate targets via CDP `Target.getTargets`,
+   * pick a default, and attach. Used when HTTP discovery endpoints
+   * (`/json/version`, `/json/list`) are absent.
+   */
+  private async tryWsFallback(
+    host: string,
+    port: number,
+    httpError: unknown,
+    signal: AbortSignal,
+  ): Promise<AttachedSession> {
+    let wsUrl: string;
+    try {
+      wsUrl = this.helpers.buildBrowserWsUrl(host, port);
+    } catch (err) {
+      // buildBrowserWsUrl enforces loopback — if it throws, the host
+      // is non-loopback and we should not attempt any WS connection.
+      throw err;
+    }
+
+    let transport: CdpWsTransport;
+    try {
+      transport = await this.helpers.connectCdpWsTransport(wsUrl, {
+        connectTimeoutMs: this.options.wsConnectTimeoutMs,
+        signal,
+      });
+    } catch (wsConnectErr) {
+      // WS connect also failed — surface a classified error that
+      // explains both the HTTP and WS failures.
+      const wsMsg =
+        wsConnectErr instanceof Error
+          ? wsConnectErr.message
+          : String(wsConnectErr);
+      const httpMsg =
+        httpError instanceof Error ? httpError.message : String(httpError);
+      throw new CdpError(
+        "transport_error",
+        `CDP endpoint unreachable: HTTP discovery failed (${httpMsg}) ` +
+          `and WS-only fallback also failed (${wsMsg}). ` +
+          `Ensure a Chrome/Chromium instance is listening on ${host}:${port} ` +
+          `with --remote-debugging-port or a compatible CDP proxy.`,
+        { underlying: wsConnectErr },
+      );
+    }
+
+    // dispose / abort checks after successful WS connect.
+    if (this.disposed) {
+      try {
+        transport.dispose();
+      } catch {
+        // best effort
+      }
+      throw new CdpError(
+        "disposed",
+        "CdpInspectClient disposed during WS fallback attach",
+      );
+    }
+    if (signal.aborted) {
+      try {
+        transport.dispose();
+      } catch {
+        // best effort
+      }
+      throw new CdpError(
+        "aborted",
+        "CdpInspectClient attach aborted during WS fallback",
+      );
+    }
+
+    // Discover targets via CDP Target.getTargets on the browser socket.
+    let targets: DevToolsTarget[];
+    try {
+      targets = await this.helpers.discoverTargetsViaWs({
+        transport,
+        host,
+        port,
+        signal,
+      });
+    } catch (err) {
+      try {
+        transport.dispose();
+      } catch {
+        // best effort
+      }
+      throw err;
+    }
+
+    if (signal.aborted) {
+      try {
+        transport.dispose();
+      } catch {
+        // best effort
+      }
+      throw new CdpError(
+        "aborted",
+        "CdpInspectClient attach aborted after WS target discovery",
+      );
+    }
+
     const target = this.helpers.pickDefaultTarget(targets);
 
-    // Prefer the browser-level ws URL from the version probe because
-    // it lets us multiplex multiple attached targets through a single
-    // transport. Fall back to the target-specific URL if (for some
-    // reason) the version probe omitted it.
-    const wsUrl = version.webSocketDebuggerUrl || target.webSocketDebuggerUrl;
+    log.debug(
+      {
+        conversationId: this.conversationId,
+        targetId: target.id,
+        targetCount: targets.length,
+      },
+      "WS-only fallback: discovered targets via CDP Target.getTargets",
+    );
+
+    // Attach to the selected target using the browser-level transport.
+    return this.attachToTarget(transport, target, null, signal);
+  }
+
+  /**
+   * Shared attach-to-target + session-id extraction logic. Used by both
+   * the HTTP discovery path and the WS-only fallback path.
+   */
+  private async connectAndAttach(
+    wsUrl: string,
+    target: DevToolsTarget,
+    version: DevToolsVersionInfo | null,
+    signal: AbortSignal,
+  ): Promise<AttachedSession> {
     const transport = await this.helpers.connectCdpWsTransport(wsUrl, {
       connectTimeoutMs: this.options.wsConnectTimeoutMs,
       signal,
     });
 
-    // If dispose() landed while connect was in flight, tear down the
-    // transport we just opened and surface a "disposed" CdpError to
-    // the caller so we don't leak a half-attached session.
     if (this.disposed) {
       try {
         transport.dispose();
@@ -320,6 +533,20 @@ export class CdpInspectClient implements ScopedCdpClient {
       );
     }
 
+    return this.attachToTarget(transport, target, version, signal);
+  }
+
+  /**
+   * Send `Target.attachToTarget` over the transport and extract the
+   * session ID. Disposes the transport on failure so we don't leak
+   * sockets.
+   */
+  private async attachToTarget(
+    transport: CdpWsTransport,
+    target: DevToolsTarget,
+    version: DevToolsVersionInfo | null,
+    signal: AbortSignal,
+  ): Promise<AttachedSession> {
     let attachResult: unknown;
     try {
       attachResult = await transport.send<unknown>(
@@ -331,8 +558,6 @@ export class CdpInspectClient implements ScopedCdpClient {
         { signal },
       );
     } catch (err) {
-      // Attach failed — drop the transport we just opened so we don't
-      // leak the socket on retry.
       try {
         transport.dispose();
       } catch {
@@ -360,6 +585,7 @@ export class CdpInspectClient implements ScopedCdpClient {
         conversationId: this.conversationId,
         targetId: target.id,
         sessionId,
+        discoveryMode: version ? "http" : "ws-only",
       },
       "Attached CdpInspectClient session",
     );

--- a/assistant/src/tools/browser/cdp-client/cdp-inspect/__tests__/discovery.test.ts
+++ b/assistant/src/tools/browser/cdp-client/cdp-inspect/__tests__/discovery.test.ts
@@ -9,8 +9,11 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import {
+  buildBrowserWsUrl,
   DevToolsDiscoveryError,
   type DevToolsTarget,
+  discoverTargetsViaWs,
+  isHttpDiscoveryFallbackEligible,
   listDevToolsTargets,
   pickDefaultTarget,
   probeDevToolsJsonVersion,
@@ -739,5 +742,266 @@ describe("pickDefaultTarget", () => {
   test("returns the only candidate when the list has length 1", () => {
     const targets = [makeTarget({ id: "only", url: "https://example.com/" })];
     expect(pickDefaultTarget(targets).id).toBe("only");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildBrowserWsUrl — loopback enforcement and URL construction.
+// ---------------------------------------------------------------------------
+
+describe("buildBrowserWsUrl", () => {
+  test("builds ws URL for localhost", () => {
+    expect(buildBrowserWsUrl("localhost", 9222)).toBe(
+      "ws://localhost:9222/devtools/browser",
+    );
+  });
+
+  test("builds ws URL for 127.0.0.1", () => {
+    expect(buildBrowserWsUrl("127.0.0.1", 9333)).toBe(
+      "ws://127.0.0.1:9333/devtools/browser",
+    );
+  });
+
+  test("wraps bare ::1 in brackets", () => {
+    expect(buildBrowserWsUrl("::1", 9222)).toBe(
+      "ws://[::1]:9222/devtools/browser",
+    );
+  });
+
+  test("accepts [::1] (already bracketed)", () => {
+    expect(buildBrowserWsUrl("[::1]", 9222)).toBe(
+      "ws://[::1]:9222/devtools/browser",
+    );
+  });
+
+  test("is case-insensitive for LOCALHOST", () => {
+    expect(buildBrowserWsUrl("LOCALHOST", 9222)).toBe(
+      "ws://localhost:9222/devtools/browser",
+    );
+  });
+
+  test("rejects non-loopback hosts with non_loopback", () => {
+    expect(() => buildBrowserWsUrl("192.168.1.1", 9222)).toThrow(
+      DevToolsDiscoveryError,
+    );
+    try {
+      buildBrowserWsUrl("evil.com", 9222);
+    } catch (e) {
+      expect((e as DevToolsDiscoveryError).code).toBe("non_loopback");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isHttpDiscoveryFallbackEligible — determines which errors trigger fallback.
+// ---------------------------------------------------------------------------
+
+describe("isHttpDiscoveryFallbackEligible", () => {
+  test("returns true for invalid_response", () => {
+    const err = new DevToolsDiscoveryError("invalid_response", "bad");
+    expect(isHttpDiscoveryFallbackEligible(err)).toBe(true);
+  });
+
+  test("returns true for unreachable", () => {
+    const err = new DevToolsDiscoveryError("unreachable", "gone");
+    expect(isHttpDiscoveryFallbackEligible(err)).toBe(true);
+  });
+
+  test("returns false for non_loopback", () => {
+    const err = new DevToolsDiscoveryError("non_loopback", "nope");
+    expect(isHttpDiscoveryFallbackEligible(err)).toBe(false);
+  });
+
+  test("returns false for non_chrome", () => {
+    const err = new DevToolsDiscoveryError("non_chrome", "Firefox");
+    expect(isHttpDiscoveryFallbackEligible(err)).toBe(false);
+  });
+
+  test("returns false for timeout", () => {
+    const err = new DevToolsDiscoveryError("timeout", "too slow");
+    expect(isHttpDiscoveryFallbackEligible(err)).toBe(false);
+  });
+
+  test("returns false for no_targets", () => {
+    const err = new DevToolsDiscoveryError("no_targets", "empty");
+    expect(isHttpDiscoveryFallbackEligible(err)).toBe(false);
+  });
+
+  test("returns false for non-DevToolsDiscoveryError", () => {
+    expect(isHttpDiscoveryFallbackEligible(new Error("random"))).toBe(false);
+    expect(isHttpDiscoveryFallbackEligible("string")).toBe(false);
+    expect(isHttpDiscoveryFallbackEligible(null)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// discoverTargetsViaWs — target enumeration via CDP Target.getTargets.
+// ---------------------------------------------------------------------------
+
+describe("discoverTargetsViaWs", () => {
+  /**
+   * Minimal fake transport that resolves Target.getTargets with the
+   * provided target infos.
+   */
+  function fakeTransport(targetInfos: unknown[]) {
+    return {
+      send: async () => ({ targetInfos }),
+      addEventListener: () => () => {},
+      dispose: () => {},
+    } as unknown as import("../../cdp-inspect/ws-transport.js").CdpWsTransport;
+  }
+
+  test("filters page targets and constructs ws URLs", async () => {
+    const transport = fakeTransport([
+      {
+        targetId: "A",
+        type: "page",
+        title: "Example",
+        url: "https://example.com/",
+      },
+      {
+        targetId: "B",
+        type: "service_worker",
+        title: "sw",
+        url: "https://example.com/sw.js",
+      },
+      {
+        targetId: "C",
+        type: "page",
+        title: "Another",
+        url: "https://another.com/",
+      },
+    ]);
+
+    const targets = await discoverTargetsViaWs({
+      transport,
+      host: "127.0.0.1",
+      port: 9222,
+    });
+
+    expect(targets).toHaveLength(2);
+    expect(targets[0]!.id).toBe("A");
+    expect(targets[0]!.webSocketDebuggerUrl).toBe(
+      "ws://127.0.0.1:9222/devtools/page/A",
+    );
+    expect(targets[1]!.id).toBe("C");
+    expect(targets[1]!.webSocketDebuggerUrl).toBe(
+      "ws://127.0.0.1:9222/devtools/page/C",
+    );
+  });
+
+  test("throws no_targets when no page targets exist", async () => {
+    const transport = fakeTransport([
+      {
+        targetId: "B",
+        type: "service_worker",
+        title: "sw",
+        url: "https://example.com/sw.js",
+      },
+    ]);
+
+    const error = await discoverTargetsViaWs({
+      transport,
+      host: "127.0.0.1",
+      port: 9222,
+    }).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(DevToolsDiscoveryError);
+    expect((error as DevToolsDiscoveryError).code).toBe("no_targets");
+  });
+
+  test("throws no_targets when targetInfos is empty", async () => {
+    const transport = fakeTransport([]);
+
+    const error = await discoverTargetsViaWs({
+      transport,
+      host: "127.0.0.1",
+      port: 9222,
+    }).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(DevToolsDiscoveryError);
+    expect((error as DevToolsDiscoveryError).code).toBe("no_targets");
+  });
+
+  test("throws ws_fallback_failed when targetInfos is missing", async () => {
+    const transport = {
+      send: async () => ({}),
+      addEventListener: () => () => {},
+      dispose: () => {},
+    } as unknown as import("../../cdp-inspect/ws-transport.js").CdpWsTransport;
+
+    const error = await discoverTargetsViaWs({
+      transport,
+      host: "127.0.0.1",
+      port: 9222,
+    }).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(DevToolsDiscoveryError);
+    expect((error as DevToolsDiscoveryError).code).toBe("ws_fallback_failed");
+  });
+
+  test("rejects non-loopback host before calling transport", async () => {
+    let transportCalled = false;
+    const transport = {
+      send: async () => {
+        transportCalled = true;
+        return { targetInfos: [] };
+      },
+      addEventListener: () => () => {},
+      dispose: () => {},
+    } as unknown as import("../../cdp-inspect/ws-transport.js").CdpWsTransport;
+
+    const error = await discoverTargetsViaWs({
+      transport,
+      host: "evil.com",
+      port: 9222,
+    }).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(DevToolsDiscoveryError);
+    expect((error as DevToolsDiscoveryError).code).toBe("non_loopback");
+    expect(transportCalled).toBe(false);
+  });
+
+  test("skips entries with empty or missing targetId", async () => {
+    const transport = fakeTransport([
+      { targetId: "", type: "page", title: "Empty ID", url: "https://a.com/" },
+      { type: "page", title: "Missing ID", url: "https://b.com/" },
+      {
+        targetId: "valid",
+        type: "page",
+        title: "Valid",
+        url: "https://c.com/",
+      },
+    ]);
+
+    const targets = await discoverTargetsViaWs({
+      transport,
+      host: "127.0.0.1",
+      port: 9222,
+    });
+
+    expect(targets).toHaveLength(1);
+    expect(targets[0]!.id).toBe("valid");
+  });
+
+  test("constructs IPv6 ws URLs with brackets", async () => {
+    const transport = fakeTransport([
+      {
+        targetId: "A",
+        type: "page",
+        title: "Page",
+        url: "https://example.com/",
+      },
+    ]);
+
+    const targets = await discoverTargetsViaWs({
+      transport,
+      host: "::1",
+      port: 9222,
+    });
+
+    expect(targets[0]!.webSocketDebuggerUrl).toBe(
+      "ws://[::1]:9222/devtools/page/A",
+    );
   });
 });

--- a/assistant/src/tools/browser/cdp-client/cdp-inspect/discovery.ts
+++ b/assistant/src/tools/browser/cdp-client/cdp-inspect/discovery.ts
@@ -1,21 +1,28 @@
 /**
- * DevTools HTTP discovery helpers for the `cdp-inspect` backend.
+ * DevTools discovery helpers for the `cdp-inspect` backend.
  *
- * These helpers are pure HTTP/domain logic — they do not own a
- * websocket transport, a session manager, or any CDP command state.
- * They exist so the higher-level `cdp-inspect` client can:
+ * Two discovery strategies are provided:
  *
- * 1. Probe `/json/version` to verify that a loopback port is actually
- *    a Chrome/Chromium DevTools endpoint (and not some other service
- *    that happens to be listening).
- * 2. Enumerate available page targets via `/json/list`.
- * 3. Pick a sensible default target when the caller doesn't specify
- *    one explicitly.
+ * **HTTP discovery** (primary path):
+ *   1. Probe `/json/version` to verify that a loopback port is actually
+ *      a Chrome/Chromium DevTools endpoint.
+ *   2. Enumerate available page targets via `/json/list`.
+ *   3. Pick a sensible default target when the caller doesn't specify
+ *      one explicitly.
  *
- * Safety boundary: **only loopback hosts are allowed**. A non-loopback
- * host is rejected *before* any network I/O so that this module can
- * never be coerced into making cross-origin requests on behalf of an
- * attacker-controlled config value.
+ * **WS-only discovery** (fallback path):
+ *   When the HTTP endpoints (`/json/version`, `/json/list`) are
+ *   unavailable (e.g. extension/proxy environments that expose only
+ *   the WebSocket debugger), the client can fall back to a direct
+ *   WebSocket connection to the well-known browser endpoint
+ *   (`ws://<host>:<port>/devtools/browser`) and use CDP
+ *   `Target.getTargets` to enumerate targets instead.
+ *
+ * Safety boundary: **only loopback hosts are allowed** for both
+ * strategies. A non-loopback host is rejected *before* any network
+ * I/O so that this module can never be coerced into making
+ * cross-origin requests on behalf of an attacker-controlled config
+ * value.
  */
 
 /**
@@ -31,7 +38,8 @@ export type DevToolsDiscoveryErrorCode =
   | "non_chrome"
   | "invalid_response"
   | "no_targets"
-  | "timeout";
+  | "timeout"
+  | "ws_fallback_failed";
 
 /**
  * Single error type thrown by all discovery helpers. Mirrors the
@@ -575,4 +583,138 @@ function isUtilityTarget(target: DevToolsTarget): boolean {
   if (url.startsWith("devtools://")) return true;
   if (url === "about:blank") return true;
   return false;
+}
+
+// ---------------------------------------------------------------------------
+// WS-only discovery fallback
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a well-known browser-level WebSocket debugger URL from a
+ * loopback host and port. The resulting URL follows the standard
+ * Chrome DevTools pattern: `ws://<host>:<port>/devtools/browser`.
+ *
+ * Enforces the same loopback check as {@link probeDevToolsJsonVersion}
+ * so this function can never produce a URL that points outside the
+ * local machine. IPv6 bare form (`::1`) is wrapped in square brackets.
+ *
+ * Exported for use by the `cdp-inspect` client's WS fallback path and
+ * for unit testing.
+ */
+export function buildBrowserWsUrl(host: string, port: number): string {
+  assertLoopback(host);
+  const normalized = host.toLowerCase();
+  const hostSegment = normalized === "::1" ? "[::1]" : normalized;
+  return `ws://${hostSegment}:${port}/devtools/browser`;
+}
+
+/**
+ * Determine whether an HTTP discovery error is eligible for the
+ * WS-only fallback. Only `invalid_response` and `unreachable` qualify
+ * — these indicate the HTTP endpoints are absent or the server doesn't
+ * speak the JSON discovery protocol. Errors like `non_loopback`,
+ * `non_chrome`, and `timeout` should *not* trigger the fallback because
+ * they indicate a fundamental safety or configuration problem.
+ */
+export function isHttpDiscoveryFallbackEligible(
+  err: unknown,
+): err is DevToolsDiscoveryError {
+  if (!(err instanceof DevToolsDiscoveryError)) return false;
+  return err.code === "invalid_response" || err.code === "unreachable";
+}
+
+/**
+ * Target info returned by CDP `Target.getTargets`. A subset of the
+ * full `TargetInfo` — we only need enough to build a
+ * {@link DevToolsTarget} for the attach step.
+ */
+interface CdpTargetInfo {
+  targetId: string;
+  type: string;
+  title: string;
+  url: string;
+}
+
+/**
+ * Enumerate page targets via a direct WebSocket connection to the
+ * browser-level DevTools endpoint. Uses CDP `Target.getTargets` instead
+ * of the HTTP `/json/list` endpoint.
+ *
+ * This function is the core of the WS-only fallback: when the HTTP
+ * discovery endpoints are absent, the caller connects to the well-known
+ * `ws://<host>:<port>/devtools/browser` URL and uses this function to
+ * discover page targets.
+ *
+ * The transport is provided by the caller (the cdp-inspect client's
+ * attach method) so this function doesn't own the socket lifecycle.
+ *
+ * Returns a filtered list of page targets. Throws `no_targets` when no
+ * page targets are found.
+ *
+ * @param transport - An already-connected {@link CdpWsTransport}.
+ * @param host - The loopback host, used to construct per-target ws URLs.
+ * @param port - The port, used to construct per-target ws URLs.
+ * @param signal - Optional abort signal for the CDP call.
+ */
+export async function discoverTargetsViaWs(opts: {
+  transport: import("./ws-transport.js").CdpWsTransport;
+  host: string;
+  port: number;
+  signal?: AbortSignal;
+}): Promise<DevToolsTarget[]> {
+  assertLoopback(opts.host);
+
+  const result = await opts.transport.send<{
+    targetInfos?: CdpTargetInfo[];
+  }>("Target.getTargets", undefined, { signal: opts.signal });
+
+  const targetInfos = result?.targetInfos;
+  if (!Array.isArray(targetInfos)) {
+    throw new DevToolsDiscoveryError(
+      "ws_fallback_failed",
+      "Target.getTargets did not return a targetInfos array.",
+    );
+  }
+
+  const normalized = opts.host.toLowerCase();
+  const hostSegment = normalized === "::1" ? "[::1]" : normalized;
+
+  const targets: DevToolsTarget[] = [];
+  for (const info of targetInfos) {
+    if (
+      typeof info !== "object" ||
+      info === null ||
+      typeof info.type !== "string"
+    ) {
+      continue;
+    }
+    if (info.type !== "page") continue;
+
+    const id =
+      typeof info.targetId === "string" && info.targetId.length > 0
+        ? info.targetId
+        : "";
+    if (!id) continue;
+
+    const title = typeof info.title === "string" ? info.title : "";
+    const url = typeof info.url === "string" ? info.url : "";
+    // In WS-only mode, Chrome does not provide per-target ws URLs via
+    // the HTTP API. Construct the standard DevTools per-page URL so
+    // downstream code has a consistent shape. Note: the cdp-inspect
+    // client does not actually use this URL to connect — it uses
+    // Target.attachToTarget on the browser-level transport instead.
+    const webSocketDebuggerUrl = `ws://${hostSegment}:${opts.port}/devtools/page/${id}`;
+
+    targets.push({ id, type: "page", title, url, webSocketDebuggerUrl });
+  }
+
+  if (targets.length === 0) {
+    throw new DevToolsDiscoveryError(
+      "no_targets",
+      "No usable page targets returned by CDP Target.getTargets. " +
+        "Ensure at least one browser tab is open.",
+    );
+  }
+
+  return targets;
 }


### PR DESCRIPTION
## Summary
- Add WS-only fallback path when HTTP discovery (/json/version, /json/list) is unavailable
- Enumerate targets via CDP Target.getTargets in WS-only mode
- Preserve strict loopback safety constraints for both HTTP and WS paths
- Add classified error messages for clear assistant-facing diagnostics

Part of plan: macos-browser-extension-cdp-fallback.md (PR 4 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24750" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
