### PR TITLE
Chrome native host: expose lockfile assistants and support assistantId pairing

### DIFF
--- a/clients/chrome-extension/native-host/src/__tests__/index.test.ts
+++ b/clients/chrome-extension/native-host/src/__tests__/index.test.ts
@@ -16,15 +16,27 @@
  *      exit non-zero and emit an error frame, preventing a malformed
  *      token from reaching the extension's bootstrap path.
  *
+ *   4. `list_assistants` frames return the lockfile assistant inventory.
+ *
+ *   5. `request_token` frames with `assistantId` resolve the daemon port
+ *      from the lockfile and target the correct assistant.
+ *
  * The suite skips gracefully when `dist/index.js` is missing so cold
  * checkouts don't break CI.
  */
 
-import { existsSync, readFileSync } from "node:fs";
-import { dirname, resolve } from "node:path";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from "bun:test";
 
 import { decodeFrames, encodeFrame } from "../protocol.js";
 
@@ -161,23 +173,25 @@ interface HelperRunResult {
  */
 async function runHelper(options: {
   extensionOrigin: string;
-  assistantPort: number;
+  assistantPort?: number;
   stdinBytes: Buffer;
   timeoutMs?: number;
+  env?: Record<string, string | undefined>;
 }): Promise<HelperRunResult> {
   const args = [
     "node",
     HELPER_BINARY,
     options.extensionOrigin,
-    "--assistant-port",
-    String(options.assistantPort),
   ];
+  if (options.assistantPort !== undefined) {
+    args.push("--assistant-port", String(options.assistantPort));
+  }
 
   const proc = Bun.spawn(args, {
     stdin: "pipe",
     stdout: "pipe",
     stderr: "pipe",
-    env: { ...process.env },
+    env: { ...process.env, ...options.env },
   });
 
   proc.stdin.write(options.stdinBytes);
@@ -380,5 +394,320 @@ describe("native host — subprocess regression coverage", () => {
     expect(frame.type).toBe("error");
     expect(typeof frame.message).toBe("string");
     expect(frame.message).toMatch(/guardianId/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// list_assistants and assistant-scoped token request tests
+// ---------------------------------------------------------------------------
+
+describe("native host — list_assistants response framing", () => {
+  let pair: MockPairServer | null = null;
+  let lockfileDir: string;
+
+  beforeAll(() => {
+    if (!HELPER_EXISTS) return;
+    pair = startMockPairServer();
+  });
+
+  afterAll(() => {
+    if (pair) pair.stop();
+  });
+
+  beforeEach(() => {
+    lockfileDir = mkdtempSync(join(tmpdir(), "native-host-lockfile-test-"));
+  });
+
+  afterEach(() => {
+    try {
+      rmSync(lockfileDir, { recursive: true, force: true });
+    } catch {
+      // Best-effort cleanup.
+    }
+  });
+
+  if (!HELPER_EXISTS) {
+    test.skip(`native helper binary not built — ${SKIP_REASON}`, () => {
+      /* intentionally empty */
+    });
+    return;
+  }
+
+  test("list_assistants returns assistant inventory from lockfile", async () => {
+    const lockfileData = {
+      assistants: [
+        {
+          assistantId: "local-one",
+          cloud: "local",
+          runtimeUrl: "http://localhost:7830",
+          resources: { daemonPort: 7821 },
+        },
+        {
+          assistantId: "cloud-one",
+          cloud: "vellum",
+          runtimeUrl: "https://cloud.example.com",
+        },
+      ],
+      activeAssistant: "local-one",
+    };
+    writeFileSync(
+      join(lockfileDir, ".vellum.lock.json"),
+      JSON.stringify(lockfileData),
+    );
+
+    const result = await runHelper({
+      extensionOrigin: ALLOWED_ORIGIN,
+      assistantPort: pair!.port,
+      stdinBytes: encodeFrame({ type: "list_assistants" }),
+      timeoutMs: 2000,
+      env: { VELLUM_LOCKFILE_DIR: lockfileDir },
+    });
+
+    expect(result.exitCode, `helper stderr: ${result.stderr}`).toBe(0);
+    expect(result.frames).toHaveLength(1);
+
+    const frame = result.frames[0] as {
+      type: string;
+      assistants: Array<{
+        assistantId: string;
+        cloud: string;
+        runtimeUrl: string;
+        daemonPort: number | null;
+        isActive: boolean;
+      }>;
+      activeAssistantId: string | null;
+    };
+
+    expect(frame.type).toBe("assistants_response");
+    expect(frame.activeAssistantId).toBe("local-one");
+    expect(frame.assistants).toHaveLength(2);
+
+    expect(frame.assistants[0]!.assistantId).toBe("local-one");
+    expect(frame.assistants[0]!.cloud).toBe("local");
+    expect(frame.assistants[0]!.daemonPort).toBe(7821);
+    expect(frame.assistants[0]!.isActive).toBe(true);
+
+    expect(frame.assistants[1]!.assistantId).toBe("cloud-one");
+    expect(frame.assistants[1]!.cloud).toBe("vellum");
+    expect(frame.assistants[1]!.isActive).toBe(false);
+  });
+
+  test("list_assistants returns empty inventory when no lockfile exists", async () => {
+    // Don't write any lockfile — the temp dir is empty.
+    const result = await runHelper({
+      extensionOrigin: ALLOWED_ORIGIN,
+      assistantPort: pair!.port,
+      stdinBytes: encodeFrame({ type: "list_assistants" }),
+      timeoutMs: 2000,
+      env: { VELLUM_LOCKFILE_DIR: lockfileDir },
+    });
+
+    expect(result.exitCode, `helper stderr: ${result.stderr}`).toBe(0);
+    expect(result.frames).toHaveLength(1);
+
+    const frame = result.frames[0] as {
+      type: string;
+      assistants: unknown[];
+      activeAssistantId: unknown;
+    };
+    expect(frame.type).toBe("assistants_response");
+    expect(frame.assistants).toEqual([]);
+    expect(frame.activeAssistantId).toBeNull();
+  });
+});
+
+describe("native host — assistant-scoped token request", () => {
+  let pairA: MockPairServer | null = null;
+  let pairB: MockPairServer | null = null;
+  let lockfileDir: string;
+
+  beforeAll(() => {
+    if (!HELPER_EXISTS) return;
+    pairA = startMockPairServer();
+    pairB = startMockPairServer();
+  });
+
+  afterAll(() => {
+    if (pairA) pairA.stop();
+    if (pairB) pairB.stop();
+  });
+
+  beforeEach(() => {
+    lockfileDir = mkdtempSync(join(tmpdir(), "native-host-scoped-test-"));
+  });
+
+  afterEach(() => {
+    try {
+      rmSync(lockfileDir, { recursive: true, force: true });
+    } catch {
+      // Best-effort cleanup.
+    }
+  });
+
+  if (!HELPER_EXISTS) {
+    test.skip(`native helper binary not built — ${SKIP_REASON}`, () => {
+      /* intentionally empty */
+    });
+    return;
+  }
+
+  test("request_token with assistantId uses the lockfile daemon port", async () => {
+    const srvA = pairA!;
+    const srvB = pairB!;
+    srvA.requests.length = 0;
+    srvB.requests.length = 0;
+
+    srvA.nextResponseBody = () => ({
+      token: "tok-a",
+      expiresAt: "2026-12-31T00:00:00Z",
+      guardianId: "g-a",
+    });
+    srvB.nextResponseBody = () => ({
+      token: "tok-b",
+      expiresAt: "2026-12-31T00:00:00Z",
+      guardianId: "g-b",
+    });
+
+    // Write a lockfile where assistant-b's daemonPort points at srvB.
+    const lockfileData = {
+      assistants: [
+        {
+          assistantId: "assistant-a",
+          cloud: "local",
+          runtimeUrl: "http://localhost:7830",
+          resources: { daemonPort: srvA.port },
+        },
+        {
+          assistantId: "assistant-b",
+          cloud: "local",
+          runtimeUrl: "http://localhost:7831",
+          resources: { daemonPort: srvB.port },
+        },
+      ],
+    };
+    writeFileSync(
+      join(lockfileDir, ".vellum.lock.json"),
+      JSON.stringify(lockfileData),
+    );
+
+    // Request a token scoped to assistant-b. The helper should use
+    // srvB's port (from the lockfile) rather than the --assistant-port
+    // flag, which we intentionally set to srvA's port to prove the
+    // lockfile takes precedence.
+    const result = await runHelper({
+      extensionOrigin: ALLOWED_ORIGIN,
+      assistantPort: srvA.port,
+      stdinBytes: encodeFrame({
+        type: "request_token",
+        assistantId: "assistant-b",
+      }),
+      timeoutMs: 2000,
+      env: { VELLUM_LOCKFILE_DIR: lockfileDir },
+    });
+
+    expect(result.exitCode, `helper stderr: ${result.stderr}`).toBe(0);
+    expect(result.frames).toHaveLength(1);
+
+    const frame = result.frames[0] as {
+      type: string;
+      token: string;
+      assistantPort: number;
+    };
+    expect(frame.type).toBe("token_response");
+    expect(frame.token).toBe("tok-b");
+    expect(frame.assistantPort).toBe(srvB.port);
+
+    // srvB should have received the pair request, not srvA.
+    expect(srvB.requests).toHaveLength(1);
+    expect(srvA.requests).toHaveLength(0);
+  });
+
+  test("request_token without assistantId falls back to --assistant-port", async () => {
+    const srvA = pairA!;
+    srvA.requests.length = 0;
+    srvA.nextResponseBody = () => ({
+      token: "tok-fallback",
+      expiresAt: "2026-12-31T00:00:00Z",
+      guardianId: "g-fallback",
+    });
+
+    // Even with a lockfile present, omitting assistantId from the
+    // frame should fall back to the --assistant-port CLI arg.
+    const lockfileData = {
+      assistants: [
+        {
+          assistantId: "some-assistant",
+          cloud: "local",
+          runtimeUrl: "http://localhost:7830",
+          resources: { daemonPort: 55555 }, // unreachable port
+        },
+      ],
+    };
+    writeFileSync(
+      join(lockfileDir, ".vellum.lock.json"),
+      JSON.stringify(lockfileData),
+    );
+
+    const result = await runHelper({
+      extensionOrigin: ALLOWED_ORIGIN,
+      assistantPort: srvA.port,
+      stdinBytes: encodeFrame({ type: "request_token" }),
+      timeoutMs: 2000,
+      env: { VELLUM_LOCKFILE_DIR: lockfileDir },
+    });
+
+    expect(result.exitCode, `helper stderr: ${result.stderr}`).toBe(0);
+    expect(result.frames).toHaveLength(1);
+
+    const frame = result.frames[0] as { type: string; token: string };
+    expect(frame.type).toBe("token_response");
+    expect(frame.token).toBe("tok-fallback");
+
+    // The request went to srvA (via --assistant-port), not the
+    // lockfile's unreachable port.
+    expect(srvA.requests).toHaveLength(1);
+  });
+
+  test("request_token with unknown assistantId falls back to --assistant-port", async () => {
+    const srvA = pairA!;
+    srvA.requests.length = 0;
+    srvA.nextResponseBody = () => ({
+      token: "tok-unknown-fallback",
+      expiresAt: "2026-12-31T00:00:00Z",
+      guardianId: "g-unknown",
+    });
+
+    // Lockfile has assistant-a but we request token for "nonexistent".
+    const lockfileData = {
+      assistants: [
+        {
+          assistantId: "assistant-a",
+          cloud: "local",
+          runtimeUrl: "http://localhost:7830",
+          resources: { daemonPort: 55555 },
+        },
+      ],
+    };
+    writeFileSync(
+      join(lockfileDir, ".vellum.lock.json"),
+      JSON.stringify(lockfileData),
+    );
+
+    const result = await runHelper({
+      extensionOrigin: ALLOWED_ORIGIN,
+      assistantPort: srvA.port,
+      stdinBytes: encodeFrame({
+        type: "request_token",
+        assistantId: "nonexistent",
+      }),
+      timeoutMs: 2000,
+      env: { VELLUM_LOCKFILE_DIR: lockfileDir },
+    });
+
+    expect(result.exitCode, `helper stderr: ${result.stderr}`).toBe(0);
+    const frame = result.frames[0] as { type: string; token: string };
+    expect(frame.type).toBe("token_response");
+    expect(frame.token).toBe("tok-unknown-fallback");
+    expect(srvA.requests).toHaveLength(1);
   });
 });

--- a/clients/chrome-extension/native-host/src/__tests__/lockfile.test.ts
+++ b/clients/chrome-extension/native-host/src/__tests__/lockfile.test.ts
@@ -1,0 +1,395 @@
+/**
+ * Unit tests for the lockfile reader (`src/lockfile.ts`).
+ *
+ * These tests exercise:
+ *   - Fallback from `.vellum.lock.json` to `.vellum.lockfile.json`
+ *   - Parsing of assistant entries with and without `resources.daemonPort`
+ *   - Active-assistant resolution
+ *   - Graceful handling of missing, empty, and malformed lockfiles
+ *   - The `resolveDaemonPort` convenience helper
+ *
+ * Each test creates a temporary directory via `mkdtemp`, sets
+ * `VELLUM_LOCKFILE_DIR` to point at it, and cleans up after itself.
+ * This avoids touching the user's real `~/.vellum.lock.json`.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  readAssistantInventory,
+  resolveDaemonPort,
+  type AssistantSummary,
+} from "../lockfile.js";
+
+// ---------------------------------------------------------------------------
+// Test scaffold — temp directory & env override
+// ---------------------------------------------------------------------------
+
+let tempDir: string;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "lockfile-test-"));
+  process.env.VELLUM_LOCKFILE_DIR = tempDir;
+});
+
+afterEach(() => {
+  delete process.env.VELLUM_LOCKFILE_DIR;
+  try {
+    rmSync(tempDir, { recursive: true, force: true });
+  } catch {
+    // Best-effort cleanup.
+  }
+});
+
+/** Write a lockfile to the temp directory under the given filename. */
+function writeLockfile(
+  filename: string,
+  data: Record<string, unknown>,
+): void {
+  writeFileSync(join(tempDir, filename), JSON.stringify(data, null, 2));
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("lockfile — readAssistantInventory", () => {
+  test("returns empty inventory when no lockfile exists", () => {
+    const result = readAssistantInventory();
+    expect(result.assistants).toEqual([]);
+    expect(result.activeAssistantId).toBeNull();
+  });
+
+  test("reads from .vellum.lock.json (primary)", () => {
+    writeLockfile(".vellum.lock.json", {
+      assistants: [
+        {
+          assistantId: "alpha",
+          cloud: "local",
+          runtimeUrl: "http://localhost:7830",
+          resources: { daemonPort: 7821 },
+        },
+      ],
+      activeAssistant: "alpha",
+    });
+
+    const result = readAssistantInventory();
+    expect(result.assistants).toHaveLength(1);
+    expect(result.assistants[0]!.assistantId).toBe("alpha");
+    expect(result.assistants[0]!.daemonPort).toBe(7821);
+    expect(result.assistants[0]!.isActive).toBe(true);
+    expect(result.activeAssistantId).toBe("alpha");
+  });
+
+  test("falls back to .vellum.lockfile.json when primary is missing", () => {
+    writeLockfile(".vellum.lockfile.json", {
+      assistants: [
+        {
+          assistantId: "beta",
+          cloud: "local",
+          runtimeUrl: "http://localhost:7831",
+          resources: { daemonPort: 7822 },
+        },
+      ],
+    });
+
+    const result = readAssistantInventory();
+    expect(result.assistants).toHaveLength(1);
+    expect(result.assistants[0]!.assistantId).toBe("beta");
+    expect(result.assistants[0]!.daemonPort).toBe(7822);
+  });
+
+  test("prefers .vellum.lock.json over .vellum.lockfile.json when both exist", () => {
+    writeLockfile(".vellum.lock.json", {
+      assistants: [
+        {
+          assistantId: "primary",
+          cloud: "local",
+          runtimeUrl: "http://localhost:7830",
+        },
+      ],
+    });
+    writeLockfile(".vellum.lockfile.json", {
+      assistants: [
+        {
+          assistantId: "legacy",
+          cloud: "local",
+          runtimeUrl: "http://localhost:7831",
+        },
+      ],
+    });
+
+    const result = readAssistantInventory();
+    expect(result.assistants).toHaveLength(1);
+    expect(result.assistants[0]!.assistantId).toBe("primary");
+  });
+
+  test("filters entries missing required fields", () => {
+    writeLockfile(".vellum.lock.json", {
+      assistants: [
+        // Valid entry
+        {
+          assistantId: "good",
+          cloud: "local",
+          runtimeUrl: "http://localhost:7830",
+        },
+        // Missing runtimeUrl
+        { assistantId: "no-url", cloud: "local" },
+        // Missing assistantId
+        { cloud: "local", runtimeUrl: "http://localhost:7832" },
+        // Missing cloud
+        { assistantId: "no-cloud", runtimeUrl: "http://localhost:7833" },
+        // Not an object
+        "just-a-string",
+        null,
+        42,
+      ],
+    });
+
+    const result = readAssistantInventory();
+    expect(result.assistants).toHaveLength(1);
+    expect(result.assistants[0]!.assistantId).toBe("good");
+  });
+
+  test("returns daemonPort as undefined when resources block is absent", () => {
+    writeLockfile(".vellum.lock.json", {
+      assistants: [
+        {
+          assistantId: "cloud-only",
+          cloud: "gcp",
+          runtimeUrl: "https://example.com:443",
+        },
+      ],
+    });
+
+    const result = readAssistantInventory();
+    expect(result.assistants[0]!.daemonPort).toBeUndefined();
+  });
+
+  test("returns daemonPort as undefined when resources.daemonPort is not a number", () => {
+    writeLockfile(".vellum.lock.json", {
+      assistants: [
+        {
+          assistantId: "bad-port",
+          cloud: "local",
+          runtimeUrl: "http://localhost:7830",
+          resources: { daemonPort: "not-a-number" },
+        },
+      ],
+    });
+
+    const result = readAssistantInventory();
+    expect(result.assistants[0]!.daemonPort).toBeUndefined();
+  });
+
+  test("returns daemonPort as undefined when port is out of range", () => {
+    writeLockfile(".vellum.lock.json", {
+      assistants: [
+        {
+          assistantId: "high-port",
+          cloud: "local",
+          runtimeUrl: "http://localhost:7830",
+          resources: { daemonPort: 70000 },
+        },
+        {
+          assistantId: "zero-port",
+          cloud: "local",
+          runtimeUrl: "http://localhost:7831",
+          resources: { daemonPort: 0 },
+        },
+        {
+          assistantId: "negative-port",
+          cloud: "local",
+          runtimeUrl: "http://localhost:7832",
+          resources: { daemonPort: -1 },
+        },
+      ],
+    });
+
+    const result = readAssistantInventory();
+    expect(result.assistants[0]!.daemonPort).toBeUndefined();
+    expect(result.assistants[1]!.daemonPort).toBeUndefined();
+    expect(result.assistants[2]!.daemonPort).toBeUndefined();
+  });
+
+  test("marks only the active assistant with isActive=true", () => {
+    writeLockfile(".vellum.lock.json", {
+      assistants: [
+        {
+          assistantId: "one",
+          cloud: "local",
+          runtimeUrl: "http://localhost:7830",
+        },
+        {
+          assistantId: "two",
+          cloud: "local",
+          runtimeUrl: "http://localhost:7831",
+        },
+        {
+          assistantId: "three",
+          cloud: "local",
+          runtimeUrl: "http://localhost:7832",
+        },
+      ],
+      activeAssistant: "two",
+    });
+
+    const result = readAssistantInventory();
+    expect(result.assistants).toHaveLength(3);
+    expect(result.assistants[0]!.isActive).toBe(false);
+    expect(result.assistants[1]!.isActive).toBe(true);
+    expect(result.assistants[2]!.isActive).toBe(false);
+    expect(result.activeAssistantId).toBe("two");
+  });
+
+  test("handles lockfile with no assistants array", () => {
+    writeLockfile(".vellum.lock.json", {
+      platformBaseUrl: "https://platform.example.com",
+    });
+
+    const result = readAssistantInventory();
+    expect(result.assistants).toEqual([]);
+    expect(result.activeAssistantId).toBeNull();
+  });
+
+  test("handles lockfile with assistants as non-array", () => {
+    writeLockfile(".vellum.lock.json", {
+      assistants: "not-an-array",
+    });
+
+    const result = readAssistantInventory();
+    expect(result.assistants).toEqual([]);
+  });
+
+  test("handles malformed JSON gracefully", () => {
+    writeFileSync(
+      join(tempDir, ".vellum.lock.json"),
+      "{ this is not valid JSON }",
+    );
+
+    const result = readAssistantInventory();
+    expect(result.assistants).toEqual([]);
+    expect(result.activeAssistantId).toBeNull();
+  });
+
+  test("handles lockfile that is an array (not an object)", () => {
+    writeFileSync(
+      join(tempDir, ".vellum.lock.json"),
+      JSON.stringify([1, 2, 3]),
+    );
+
+    const result = readAssistantInventory();
+    expect(result.assistants).toEqual([]);
+    expect(result.activeAssistantId).toBeNull();
+  });
+
+  test("multi-assistant inventory with mixed cloud types and resources", () => {
+    writeLockfile(".vellum.lock.json", {
+      assistants: [
+        {
+          assistantId: "local-one",
+          cloud: "local",
+          runtimeUrl: "http://localhost:7830",
+          resources: {
+            daemonPort: 7821,
+            gatewayPort: 7830,
+            instanceDir: "/home/user",
+          },
+        },
+        {
+          assistantId: "local-two",
+          cloud: "local",
+          runtimeUrl: "http://localhost:7831",
+          resources: {
+            daemonPort: 7823,
+            gatewayPort: 7831,
+          },
+        },
+        {
+          assistantId: "cloud-one",
+          cloud: "vellum",
+          runtimeUrl: "https://cloud.example.com",
+        },
+      ],
+      activeAssistant: "local-one",
+    });
+
+    const result = readAssistantInventory();
+    expect(result.assistants).toHaveLength(3);
+
+    const [localOne, localTwo, cloudOne] = result.assistants as [
+      AssistantSummary,
+      AssistantSummary,
+      AssistantSummary,
+    ];
+
+    expect(localOne.assistantId).toBe("local-one");
+    expect(localOne.cloud).toBe("local");
+    expect(localOne.runtimeUrl).toBe("http://localhost:7830");
+    expect(localOne.daemonPort).toBe(7821);
+    expect(localOne.isActive).toBe(true);
+
+    expect(localTwo.assistantId).toBe("local-two");
+    expect(localTwo.daemonPort).toBe(7823);
+    expect(localTwo.isActive).toBe(false);
+
+    expect(cloudOne.assistantId).toBe("cloud-one");
+    expect(cloudOne.cloud).toBe("vellum");
+    expect(cloudOne.daemonPort).toBeUndefined();
+    expect(cloudOne.isActive).toBe(false);
+  });
+});
+
+describe("lockfile — resolveDaemonPort", () => {
+  test("returns the daemon port for a known assistant", () => {
+    writeLockfile(".vellum.lock.json", {
+      assistants: [
+        {
+          assistantId: "target",
+          cloud: "local",
+          runtimeUrl: "http://localhost:7830",
+          resources: { daemonPort: 9999 },
+        },
+      ],
+    });
+
+    expect(resolveDaemonPort("target")).toBe(9999);
+  });
+
+  test("returns undefined for an unknown assistant", () => {
+    writeLockfile(".vellum.lock.json", {
+      assistants: [
+        {
+          assistantId: "other",
+          cloud: "local",
+          runtimeUrl: "http://localhost:7830",
+          resources: { daemonPort: 7821 },
+        },
+      ],
+    });
+
+    expect(resolveDaemonPort("nonexistent")).toBeUndefined();
+  });
+
+  test("returns undefined when assistant has no daemon port", () => {
+    writeLockfile(".vellum.lock.json", {
+      assistants: [
+        {
+          assistantId: "cloud",
+          cloud: "vellum",
+          runtimeUrl: "https://cloud.example.com",
+        },
+      ],
+    });
+
+    expect(resolveDaemonPort("cloud")).toBeUndefined();
+  });
+
+  test("returns undefined when lockfile is missing", () => {
+    expect(resolveDaemonPort("anything")).toBeUndefined();
+  });
+});

--- a/clients/chrome-extension/native-host/src/index.ts
+++ b/clients/chrome-extension/native-host/src/index.ts
@@ -12,14 +12,18 @@
  *   1. Verify that the calling extension's origin (passed by Chrome as the
  *      first command-line argument, e.g. `chrome-extension://<id>/`) is on a
  *      hard-coded allowlist of known Vellum extension IDs.
- *   2. Listen on stdin for `{ type: "request_token" }` frames.
- *   3. POST the calling extension's origin to the running assistant's
- *      `/v1/browser-extension-pair` endpoint (port resolved from
- *      `--assistant-port`, then `~/.vellum/runtime-port`, then defaulting to
- *      7821).
- *   4. Echo the assistant's response back to Chrome as a
+ *   2. Listen on stdin for `{ type: "request_token" }` and
+ *      `{ type: "list_assistants" }` frames.
+ *   3. For `request_token`: POST the calling extension's origin to the
+ *      running assistant's `/v1/browser-extension-pair` endpoint (port
+ *      resolved from optional `assistantId` lockfile lookup, then
+ *      `--assistant-port`, then `~/.vellum/runtime-port`, then defaulting
+ *      to 7821).
+ *   4. For `list_assistants`: read the lockfile and return the assistant
+ *      inventory as `{ type: "assistants_response", assistants, activeAssistantId }`.
+ *   5. Echo the assistant's response back to Chrome as a
  *      `{ type: "token_response", token, expiresAt, guardianId }` frame.
- *   5. On any unrecoverable error, write a `{ type: "error", message }` frame
+ *   6. On any unrecoverable error, write a `{ type: "error", message }` frame
  *      and exit with a non-zero status.
  *
  * The helper deliberately does NOT persist tokens — the extension is
@@ -37,6 +41,7 @@ import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { readAssistantInventory, resolveDaemonPort } from "./lockfile.js";
 import { decodeFrames, encodeFrame, FrameDecodeError } from "./protocol.js";
 
 /**
@@ -323,8 +328,25 @@ function fail(message: string, code = 1): never {
 async function requestToken(
   extensionOrigin: string,
   argv: readonly string[],
+  assistantId?: string,
 ): Promise<TokenResponse> {
-  const port = resolveAssistantPort(argv);
+  // When an assistantId is provided, attempt to resolve the daemon port
+  // from the lockfile first. This lets the extension target a specific
+  // assistant in multi-instance setups. Falls back to the standard
+  // resolution chain (--assistant-port, runtime-port file, default) when
+  // the assistantId is absent or the lockfile doesn't have a daemon port
+  // for that assistant.
+  let port: number;
+  if (assistantId) {
+    const lockfilePort = resolveDaemonPort(assistantId);
+    if (lockfilePort !== undefined) {
+      port = lockfilePort;
+    } else {
+      port = resolveAssistantPort(argv);
+    }
+  } else {
+    port = resolveAssistantPort(argv);
+  }
   const url = `http://127.0.0.1:${port}/v1/browser-extension-pair`;
 
   let response: Response;
@@ -436,30 +458,57 @@ async function main(): Promise<void> {
         }
         handling = true;
 
-        if (
-          !frame ||
-          typeof frame !== "object" ||
-          (frame as { type?: unknown }).type !== "request_token"
-        ) {
+        if (!frame || typeof frame !== "object") {
           fail("unsupported_frame_type");
         }
 
-        try {
-          const { token, expiresAt, guardianId, assistantPort } =
-            await requestToken(extensionOrigin!, process.argv);
-          await writeFrameAndExitAsync(
-            {
-              type: "token_response",
-              token,
-              expiresAt,
-              guardianId,
-              assistantPort,
-            },
-            0,
-          );
-        } catch (err) {
-          const message = err instanceof Error ? err.message : String(err);
-          fail(message);
+        const frameType = (frame as { type?: unknown }).type;
+
+        if (frameType === "list_assistants") {
+          // Return the assistant inventory from the lockfile. This is a
+          // synchronous read — no network call needed.
+          try {
+            const inventory = readAssistantInventory();
+            await writeFrameAndExitAsync(
+              {
+                type: "assistants_response",
+                assistants: inventory.assistants,
+                activeAssistantId: inventory.activeAssistantId,
+              },
+              0,
+            );
+          } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            fail(message);
+          }
+        } else if (frameType === "request_token") {
+          // Extract optional assistantId from the request frame. When
+          // present, the helper resolves the target daemon port from the
+          // lockfile instead of the default resolution chain.
+          const assistantId =
+            typeof (frame as { assistantId?: unknown }).assistantId === "string"
+              ? ((frame as { assistantId: string }).assistantId)
+              : undefined;
+
+          try {
+            const { token, expiresAt, guardianId, assistantPort } =
+              await requestToken(extensionOrigin!, process.argv, assistantId);
+            await writeFrameAndExitAsync(
+              {
+                type: "token_response",
+                token,
+                expiresAt,
+                guardianId,
+                assistantPort,
+              },
+              0,
+            );
+          } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            fail(message);
+          }
+        } else {
+          fail("unsupported_frame_type");
         }
       }
     } catch (err) {

--- a/clients/chrome-extension/native-host/src/lockfile.ts
+++ b/clients/chrome-extension/native-host/src/lockfile.ts
@@ -1,0 +1,178 @@
+/**
+ * Lockfile reader for the Chrome native messaging helper.
+ *
+ * Reads `~/.vellum.lock.json` (preferred) with fallback to
+ * `~/.vellum.lockfile.json` (legacy), parses the `assistants[]` array and
+ * `activeAssistant` field, and returns a normalized assistant summary shape
+ * that downstream consumers (e.g. the `list_assistants` frame handler and
+ * the assistant-scoped `request_token` path) can use without coupling to
+ * the full lockfile schema.
+ *
+ * The lockfile filenames and priority order are kept in sync with
+ * `cli/src/lib/constants.ts` (`LOCKFILE_NAMES`).
+ */
+
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Lockfile candidate filenames, checked in priority order.
+ * `.vellum.lock.json` is the current name; `.vellum.lockfile.json` is the
+ * legacy name kept for backwards compatibility with older installs.
+ *
+ * Mirrors `LOCKFILE_NAMES` in `cli/src/lib/constants.ts`.
+ */
+const LOCKFILE_NAMES = [
+  ".vellum.lock.json",
+  ".vellum.lockfile.json",
+] as const;
+
+/** Normalized summary of a single assistant from the lockfile. */
+export interface AssistantSummary {
+  assistantId: string;
+  cloud: string;
+  runtimeUrl: string;
+  /** The daemon HTTP port for this assistant, derived from
+   *  `resources.daemonPort` when present. `undefined` when the entry
+   *  has no resources block (e.g. remote/cloud assistants). */
+  daemonPort: number | undefined;
+  /** Whether this assistant is the currently active one
+   *  (matches `activeAssistant` in the lockfile root). */
+  isActive: boolean;
+}
+
+/** Result of reading the lockfile's assistant inventory. */
+export interface LockfileInventory {
+  assistants: AssistantSummary[];
+  activeAssistantId: string | null;
+}
+
+/**
+ * Raw lockfile shape — just enough to extract assistant entries.
+ * Kept deliberately loose to tolerate forward-compatible fields.
+ */
+interface RawLockfile {
+  assistants?: unknown[];
+  activeAssistant?: string;
+  [key: string]: unknown;
+}
+
+/** Minimal shape we need from a raw assistant entry. */
+interface RawAssistantEntry {
+  assistantId?: unknown;
+  cloud?: unknown;
+  runtimeUrl?: unknown;
+  resources?: { daemonPort?: unknown; [key: string]: unknown };
+  [key: string]: unknown;
+}
+
+/**
+ * Resolve the directory containing the lockfile. Respects
+ * `VELLUM_LOCKFILE_DIR` for testing, falling back to the user's home
+ * directory.
+ */
+function getLockfileDir(): string {
+  return process.env.VELLUM_LOCKFILE_DIR?.trim() || homedir();
+}
+
+/**
+ * Read and parse the lockfile from the first candidate path that exists
+ * and contains valid JSON. Returns `null` if no valid lockfile is found.
+ */
+function readRawLockfile(): RawLockfile | null {
+  const base = getLockfileDir();
+  for (const name of LOCKFILE_NAMES) {
+    const filePath = join(base, name);
+    try {
+      const raw = readFileSync(filePath, "utf8");
+      const parsed: unknown = JSON.parse(raw);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return parsed as RawLockfile;
+      }
+    } catch {
+      // File doesn't exist or isn't valid JSON; try next candidate.
+    }
+  }
+  return null;
+}
+
+/**
+ * Type-guard: returns `true` if the raw entry has the minimum fields
+ * needed to produce an `AssistantSummary`.
+ */
+function isValidEntry(
+  entry: unknown,
+): entry is RawAssistantEntry & {
+  assistantId: string;
+  runtimeUrl: string;
+  cloud: string;
+} {
+  if (!entry || typeof entry !== "object") return false;
+  const e = entry as RawAssistantEntry;
+  return (
+    typeof e.assistantId === "string" &&
+    typeof e.runtimeUrl === "string" &&
+    typeof e.cloud === "string"
+  );
+}
+
+/**
+ * Extract `daemonPort` from a raw entry's `resources` block.
+ * Returns `undefined` if the block is absent or the port is not a
+ * positive finite integer.
+ */
+function extractDaemonPort(entry: RawAssistantEntry): number | undefined {
+  const res = entry.resources;
+  if (!res || typeof res !== "object") return undefined;
+  const port = res.daemonPort;
+  if (typeof port !== "number") return undefined;
+  if (!Number.isFinite(port) || port <= 0 || port >= 65536) return undefined;
+  return port;
+}
+
+/**
+ * Read the lockfile and return a normalized assistant inventory.
+ *
+ * This is the main entry point for consumers. It handles:
+ * - Fallback from `.vellum.lock.json` to `.vellum.lockfile.json`
+ * - Filtering entries that lack required fields
+ * - Extracting `daemonPort` from `resources` when present
+ * - Resolving which assistant is active
+ */
+export function readAssistantInventory(): LockfileInventory {
+  const raw = readRawLockfile();
+  if (!raw) {
+    return { assistants: [], activeAssistantId: null };
+  }
+
+  const activeAssistantId =
+    typeof raw.activeAssistant === "string" ? raw.activeAssistant : null;
+
+  const rawEntries = Array.isArray(raw.assistants) ? raw.assistants : [];
+
+  const assistants: AssistantSummary[] = rawEntries
+    .filter(isValidEntry)
+    .map((entry) => ({
+      assistantId: entry.assistantId,
+      cloud: entry.cloud,
+      runtimeUrl: entry.runtimeUrl,
+      daemonPort: extractDaemonPort(entry),
+      isActive: entry.assistantId === activeAssistantId,
+    }));
+
+  return { assistants, activeAssistantId };
+}
+
+/**
+ * Look up a specific assistant by ID and return its daemon port.
+ * Returns `undefined` if the assistant is not found or has no daemon port.
+ *
+ * This is a convenience wrapper used by the `request_token` handler when
+ * an `assistantId` is provided in the request frame.
+ */
+export function resolveDaemonPort(assistantId: string): number | undefined {
+  const { assistants } = readAssistantInventory();
+  const match = assistants.find((a) => a.assistantId === assistantId);
+  return match?.daemonPort;
+}


### PR DESCRIPTION
## Summary
- Add lockfile.ts to read assistant inventory from ~/.vellum.lock.json with fallback
- Extend native messaging with list_assistants request and assistantId-scoped token requests
- Add tests for lockfile parsing, assistant listing, and assistant-specific pairing

Part of plan: chrome-extension-multi-assistant-auth.md (PR 1 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24751" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
