### PR TITLE
Chrome extension: add assistant-scoped auth token storage primitives

### DIFF
--- a/clients/chrome-extension/background/__tests__/assistant-auth-profile.test.ts
+++ b/clients/chrome-extension/background/__tests__/assistant-auth-profile.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Tests for the auth-profile derivation helper.
+ *
+ * Verifies that each known lockfile `cloud` value maps to the correct
+ * auth profile, and that unknown values yield `unsupported`.
+ */
+
+import { describe, test, expect } from 'bun:test';
+
+import {
+  resolveAuthProfile,
+  type AssistantAuthProfile,
+  type LockfileTopology,
+} from '../assistant-auth-profile.js';
+
+describe('resolveAuthProfile', () => {
+  test('maps "local" to local-pair', () => {
+    const result = resolveAuthProfile({ cloud: 'local' });
+    expect(result).toBe('local-pair' satisfies AssistantAuthProfile);
+  });
+
+  test('maps "apple-container" to local-pair', () => {
+    const result = resolveAuthProfile({ cloud: 'apple-container' });
+    expect(result).toBe('local-pair' satisfies AssistantAuthProfile);
+  });
+
+  test('maps "vellum" to cloud-oauth', () => {
+    const result = resolveAuthProfile({ cloud: 'vellum' });
+    expect(result).toBe('cloud-oauth' satisfies AssistantAuthProfile);
+  });
+
+  test('maps legacy "platform" to cloud-oauth', () => {
+    const result = resolveAuthProfile({ cloud: 'platform' });
+    expect(result).toBe('cloud-oauth' satisfies AssistantAuthProfile);
+  });
+
+  test('unknown cloud value yields unsupported', () => {
+    const result = resolveAuthProfile({ cloud: 'some-future-topology' });
+    expect(result).toBe('unsupported' satisfies AssistantAuthProfile);
+  });
+
+  test('empty string yields unsupported', () => {
+    const result = resolveAuthProfile({ cloud: '' });
+    expect(result).toBe('unsupported' satisfies AssistantAuthProfile);
+  });
+
+  test('runtimeUrl presence does not affect the mapping', () => {
+    // The auth profile is derived from the `cloud` value alone. The
+    // runtimeUrl field is part of the topology shape for downstream
+    // consumers but does not change the auth decision.
+    const withUrl: LockfileTopology = { cloud: 'local', runtimeUrl: 'http://127.0.0.1:7831' };
+    const withoutUrl: LockfileTopology = { cloud: 'local' };
+    expect(resolveAuthProfile(withUrl)).toBe('local-pair');
+    expect(resolveAuthProfile(withoutUrl)).toBe('local-pair');
+
+    const cloudWithUrl: LockfileTopology = {
+      cloud: 'vellum',
+      runtimeUrl: 'https://rt.vellum.cloud',
+    };
+    const cloudWithoutUrl: LockfileTopology = { cloud: 'vellum' };
+    expect(resolveAuthProfile(cloudWithUrl)).toBe('cloud-oauth');
+    expect(resolveAuthProfile(cloudWithoutUrl)).toBe('cloud-oauth');
+  });
+
+  test('is stable across all known cloud values', () => {
+    // Pin the full mapping so a future refactor that accidentally
+    // changes a mapping is caught by this test.
+    const expected: Array<[string, AssistantAuthProfile]> = [
+      ['local', 'local-pair'],
+      ['apple-container', 'local-pair'],
+      ['vellum', 'cloud-oauth'],
+      ['platform', 'cloud-oauth'],
+    ];
+    for (const [cloud, profile] of expected) {
+      expect(resolveAuthProfile({ cloud })).toBe(profile);
+    }
+  });
+});

--- a/clients/chrome-extension/background/__tests__/cloud-auth.test.ts
+++ b/clients/chrome-extension/background/__tests__/cloud-auth.test.ts
@@ -401,3 +401,122 @@ describe('assistant token isolation', () => {
     expect(fakeStorage.data[cloudTokenStorageKey(ASSISTANT_A)]).toBeUndefined();
   });
 });
+
+describe('legacy token migration (cloud)', () => {
+  const LEGACY_KEY = 'vellum.cloudAuthToken';
+
+  test('getStoredToken migrates a valid legacy token to the scoped key', async () => {
+    const legacyToken: StoredCloudToken = {
+      token: 'legacy-jwt',
+      expiresAt: Date.now() + 60_000,
+      guardianId: 'g-legacy',
+    };
+    fakeStorage.data[LEGACY_KEY] = legacyToken;
+
+    const result = await getStoredToken(ASSISTANT_A);
+    expect(result).toEqual(legacyToken);
+
+    // Legacy key was removed.
+    expect(fakeStorage.data[LEGACY_KEY]).toBeUndefined();
+    // Scoped key was populated.
+    expect(fakeStorage.data[cloudTokenStorageKey(ASSISTANT_A)]).toEqual(legacyToken);
+  });
+
+  test('getStoredTokenRaw migrates a valid legacy token to the scoped key', async () => {
+    const legacyToken: StoredCloudToken = {
+      token: 'legacy-raw',
+      expiresAt: Date.now() + 60_000,
+      guardianId: 'g-legacy-raw',
+    };
+    fakeStorage.data[LEGACY_KEY] = legacyToken;
+
+    const result = await getStoredTokenRaw(ASSISTANT_A);
+    expect(result).toEqual(legacyToken);
+
+    // Legacy key was removed, scoped key was populated.
+    expect(fakeStorage.data[LEGACY_KEY]).toBeUndefined();
+    expect(fakeStorage.data[cloudTokenStorageKey(ASSISTANT_A)]).toEqual(legacyToken);
+  });
+
+  test('getStoredTokenRaw migrates an expired legacy token (returns it without expiry check)', async () => {
+    const expiredLegacy: StoredCloudToken = {
+      token: 'expired-legacy',
+      expiresAt: Date.now() - 1_000,
+      guardianId: 'g-expired',
+    };
+    fakeStorage.data[LEGACY_KEY] = expiredLegacy;
+
+    // getStoredTokenRaw does not filter by expiry, but validateCloudToken
+    // also does not filter by expiry — only getStoredToken does. However,
+    // the migration helper uses validateCloudToken which does NOT check
+    // expiry, so getStoredTokenRaw will surface the expired token.
+    const result = await getStoredTokenRaw(ASSISTANT_A);
+    expect(result).toEqual(expiredLegacy);
+  });
+
+  test('getStoredToken returns null for an expired legacy token', async () => {
+    const expiredLegacy: StoredCloudToken = {
+      token: 'expired-legacy',
+      expiresAt: Date.now() - 1_000,
+      guardianId: 'g-expired',
+    };
+    fakeStorage.data[LEGACY_KEY] = expiredLegacy;
+
+    // getStoredToken applies the expiry check, so expired legacy tokens
+    // are not surfaced (but they are still migrated).
+    const result = await getStoredToken(ASSISTANT_A);
+    expect(result).toBeNull();
+  });
+
+  test('migration does not clobber an existing scoped token', async () => {
+    const scopedToken: StoredCloudToken = {
+      token: 'scoped-jwt',
+      expiresAt: Date.now() + 60_000,
+      guardianId: 'g-scoped',
+    };
+    const legacyToken: StoredCloudToken = {
+      token: 'legacy-jwt',
+      expiresAt: Date.now() + 60_000,
+      guardianId: 'g-legacy',
+    };
+    fakeStorage.data[cloudTokenStorageKey(ASSISTANT_A)] = scopedToken;
+    fakeStorage.data[LEGACY_KEY] = legacyToken;
+
+    const result = await getStoredToken(ASSISTANT_A);
+    expect(result).toEqual(scopedToken);
+    // Legacy key is NOT removed because the scoped key already existed.
+    expect(fakeStorage.data[LEGACY_KEY]).toEqual(legacyToken);
+  });
+
+  test('migration is idempotent — second call is a no-op', async () => {
+    const legacyToken: StoredCloudToken = {
+      token: 'legacy-jwt',
+      expiresAt: Date.now() + 60_000,
+      guardianId: 'g-legacy',
+    };
+    fakeStorage.data[LEGACY_KEY] = legacyToken;
+
+    // First call migrates.
+    await getStoredToken(ASSISTANT_A);
+    expect(fakeStorage.data[LEGACY_KEY]).toBeUndefined();
+
+    // Second call is a no-op — the scoped key exists and the legacy key
+    // is gone, so migration does nothing.
+    const result = await getStoredToken(ASSISTANT_A);
+    expect(result).toEqual(legacyToken);
+    expect(fakeStorage.data[cloudTokenStorageKey(ASSISTANT_A)]).toEqual(legacyToken);
+  });
+
+  test('migration ignores a malformed legacy value', async () => {
+    fakeStorage.data[LEGACY_KEY] = { token: 42, expiresAt: 'soon' };
+
+    const result = await getStoredToken(ASSISTANT_A);
+    expect(result).toBeNull();
+    // Malformed legacy key is not cleaned up — only valid tokens are migrated.
+  });
+
+  test('migration returns null when no legacy key exists', async () => {
+    const result = await getStoredToken(ASSISTANT_A);
+    expect(result).toBeNull();
+  });
+});

--- a/clients/chrome-extension/background/__tests__/cloud-auth.test.ts
+++ b/clients/chrome-extension/background/__tests__/cloud-auth.test.ts
@@ -15,13 +15,15 @@ import {
   signInCloud,
   refreshCloudToken,
   isCloudTokenStale,
+  cloudTokenStorageKey,
   CLOUD_TOKEN_STALE_WINDOW_MS,
   CLOUD_AUTH_FAILURE_CLOSE_CODES,
   type CloudAuthConfig,
   type StoredCloudToken,
 } from '../cloud-auth.js';
 
-const STORAGE_KEY = 'vellum.cloudAuthToken';
+const ASSISTANT_A = 'assistant-alpha';
+const ASSISTANT_B = 'assistant-beta';
 
 interface FakeStorage {
   data: Record<string, unknown>;
@@ -80,6 +82,14 @@ const config: CloudAuthConfig = {
   clientId: 'test-client-id',
 };
 
+describe('cloudTokenStorageKey', () => {
+  test('builds a colon-separated key', () => {
+    expect(cloudTokenStorageKey('my-assistant')).toBe(
+      'vellum.cloudAuthToken:my-assistant',
+    );
+  });
+});
+
 describe('signInCloud', () => {
   test('happy path stores a token and returns it', async () => {
     launchWebAuthFlowImpl = async (details) => {
@@ -91,7 +101,7 @@ describe('signInCloud', () => {
     };
 
     const before = Date.now();
-    const result = await signInCloud(config);
+    const result = await signInCloud(ASSISTANT_A, config);
     const after = Date.now();
 
     expect(result.token).toBe('abc123');
@@ -99,37 +109,37 @@ describe('signInCloud', () => {
     expect(result.expiresAt).toBeGreaterThanOrEqual(before + 3600 * 1000);
     expect(result.expiresAt).toBeLessThanOrEqual(after + 3600 * 1000);
 
-    // Verify it was persisted.
-    expect(fakeStorage.data[STORAGE_KEY]).toEqual(result);
+    // Verify it was persisted under the assistant-scoped key.
+    expect(fakeStorage.data[cloudTokenStorageKey(ASSISTANT_A)]).toEqual(result);
   });
 
   test('missing token rejects with "incomplete payload"', async () => {
     launchWebAuthFlowImpl = async () =>
       'https://fakeextid.chromiumapp.org/cloud-auth#expires_in=3600&guardian_id=g-42';
 
-    await expect(signInCloud(config)).rejects.toThrow('incomplete payload');
-    expect(fakeStorage.data[STORAGE_KEY]).toBeUndefined();
+    await expect(signInCloud(ASSISTANT_A, config)).rejects.toThrow('incomplete payload');
+    expect(fakeStorage.data[cloudTokenStorageKey(ASSISTANT_A)]).toBeUndefined();
   });
 
   test('missing expires_in rejects with "incomplete payload"', async () => {
     launchWebAuthFlowImpl = async () =>
       'https://fakeextid.chromiumapp.org/cloud-auth#token=abc123&guardian_id=g-42';
 
-    await expect(signInCloud(config)).rejects.toThrow('incomplete payload');
+    await expect(signInCloud(ASSISTANT_A, config)).rejects.toThrow('incomplete payload');
   });
 
   test('missing guardian_id rejects with "incomplete payload"', async () => {
     launchWebAuthFlowImpl = async () =>
       'https://fakeextid.chromiumapp.org/cloud-auth#token=abc123&expires_in=3600';
 
-    await expect(signInCloud(config)).rejects.toThrow('incomplete payload');
+    await expect(signInCloud(ASSISTANT_A, config)).rejects.toThrow('incomplete payload');
   });
 
   test('cancelled flow rejects with "cancelled"', async () => {
     launchWebAuthFlowImpl = async () => undefined;
 
-    await expect(signInCloud(config)).rejects.toThrow('cancelled');
-    expect(fakeStorage.data[STORAGE_KEY]).toBeUndefined();
+    await expect(signInCloud(ASSISTANT_A, config)).rejects.toThrow('cancelled');
+    expect(fakeStorage.data[cloudTokenStorageKey(ASSISTANT_A)]).toBeUndefined();
   });
 
   test('trims trailing slash on gatewayBaseUrl', async () => {
@@ -138,7 +148,7 @@ describe('signInCloud', () => {
       seenUrl = details.url;
       return 'https://fakeextid.chromiumapp.org/cloud-auth#token=abc&expires_in=60&guardian_id=g1';
     };
-    await signInCloud({ gatewayBaseUrl: 'https://api.vellum.ai/', clientId: 'cid' });
+    await signInCloud(ASSISTANT_A, { gatewayBaseUrl: 'https://api.vellum.ai/', clientId: 'cid' });
     expect(seenUrl).toContain('https://api.vellum.ai/oauth/chrome-extension/start');
     expect(seenUrl).not.toContain('api.vellum.ai//oauth');
   });
@@ -146,7 +156,7 @@ describe('signInCloud', () => {
 
 describe('getStoredToken', () => {
   test('returns null when nothing is stored', async () => {
-    expect(await getStoredToken()).toBeNull();
+    expect(await getStoredToken(ASSISTANT_A)).toBeNull();
   });
 
   test('returns the stored token when valid', async () => {
@@ -155,60 +165,61 @@ describe('getStoredToken', () => {
       expiresAt: Date.now() + 60_000,
       guardianId: 'g-1',
     };
-    fakeStorage.data[STORAGE_KEY] = token;
+    fakeStorage.data[cloudTokenStorageKey(ASSISTANT_A)] = token;
 
-    expect(await getStoredToken()).toEqual(token);
+    expect(await getStoredToken(ASSISTANT_A)).toEqual(token);
   });
 
   test('returns null when the token is expired', async () => {
-    fakeStorage.data[STORAGE_KEY] = {
+    fakeStorage.data[cloudTokenStorageKey(ASSISTANT_A)] = {
       token: 'expired',
       expiresAt: Date.now() - 1_000,
       guardianId: 'g-1',
     } satisfies StoredCloudToken;
 
-    expect(await getStoredToken()).toBeNull();
+    expect(await getStoredToken(ASSISTANT_A)).toBeNull();
   });
 
   test('returns null when the stored value is malformed', async () => {
-    fakeStorage.data[STORAGE_KEY] = { token: 42, expiresAt: 'soon' };
+    fakeStorage.data[cloudTokenStorageKey(ASSISTANT_A)] = { token: 42, expiresAt: 'soon' };
 
-    expect(await getStoredToken()).toBeNull();
+    expect(await getStoredToken(ASSISTANT_A)).toBeNull();
   });
 
   test('returns null when guardianId is missing or non-string', async () => {
-    // Missing guardianId entirely — would otherwise render as "guardian:undefined" in the popup.
-    fakeStorage.data[STORAGE_KEY] = {
+    // Missing guardianId entirely.
+    fakeStorage.data[cloudTokenStorageKey(ASSISTANT_A)] = {
       token: 'valid-token',
       expiresAt: Date.now() + 60_000,
     };
-    expect(await getStoredToken()).toBeNull();
+    expect(await getStoredToken(ASSISTANT_A)).toBeNull();
 
     // Non-string guardianId (e.g. a number).
-    fakeStorage.data[STORAGE_KEY] = {
+    fakeStorage.data[cloudTokenStorageKey(ASSISTANT_A)] = {
       token: 'valid-token',
       expiresAt: Date.now() + 60_000,
       guardianId: 42,
     };
-    expect(await getStoredToken()).toBeNull();
+    expect(await getStoredToken(ASSISTANT_A)).toBeNull();
   });
 });
 
 describe('clearStoredToken', () => {
   test('removes the key from storage', async () => {
-    fakeStorage.data[STORAGE_KEY] = {
+    const key = cloudTokenStorageKey(ASSISTANT_A);
+    fakeStorage.data[key] = {
       token: 'to-clear',
       expiresAt: Date.now() + 60_000,
       guardianId: 'g-1',
     } satisfies StoredCloudToken;
 
-    await clearStoredToken();
-    expect(fakeStorage.data[STORAGE_KEY]).toBeUndefined();
+    await clearStoredToken(ASSISTANT_A);
+    expect(fakeStorage.data[key]).toBeUndefined();
   });
 
   test('is a no-op when nothing is stored', async () => {
-    await clearStoredToken();
-    expect(fakeStorage.data[STORAGE_KEY]).toBeUndefined();
+    await clearStoredToken(ASSISTANT_A);
+    expect(fakeStorage.data[cloudTokenStorageKey(ASSISTANT_A)]).toBeUndefined();
   });
 });
 
@@ -219,22 +230,22 @@ describe('getStoredTokenRaw', () => {
       expiresAt: Date.now() - 1_000,
       guardianId: 'g-1',
     };
-    fakeStorage.data[STORAGE_KEY] = expired;
+    fakeStorage.data[cloudTokenStorageKey(ASSISTANT_A)] = expired;
 
-    // getStoredToken hides expired tokens…
-    expect(await getStoredToken()).toBeNull();
-    // …but getStoredTokenRaw surfaces them so the reconnect path
+    // getStoredToken hides expired tokens.
+    expect(await getStoredToken(ASSISTANT_A)).toBeNull();
+    // getStoredTokenRaw surfaces them so the reconnect path
     // can tell "signed in but expired" apart from "never signed in".
-    expect(await getStoredTokenRaw()).toEqual(expired);
+    expect(await getStoredTokenRaw(ASSISTANT_A)).toEqual(expired);
   });
 
   test('returns null when nothing is stored', async () => {
-    expect(await getStoredTokenRaw()).toBeNull();
+    expect(await getStoredTokenRaw(ASSISTANT_A)).toBeNull();
   });
 
   test('returns null when the stored value is malformed', async () => {
-    fakeStorage.data[STORAGE_KEY] = { token: 42, expiresAt: 'soon' };
-    expect(await getStoredTokenRaw()).toBeNull();
+    fakeStorage.data[cloudTokenStorageKey(ASSISTANT_A)] = { token: 42, expiresAt: 'soon' };
+    expect(await getStoredTokenRaw(ASSISTANT_A)).toBeNull();
   });
 });
 
@@ -276,17 +287,10 @@ describe('isCloudTokenStale', () => {
 
 describe('CLOUD_AUTH_FAILURE_CLOSE_CODES', () => {
   test('covers the gateway auth-failure application codes', () => {
-    // Mirrors the codes emitted by the gateway's browser-relay
-    // handshake. Pinned here so a future refactor can't accidentally
-    // drop one without updating this invariant.
     expect(CLOUD_AUTH_FAILURE_CLOSE_CODES.has(4001)).toBe(true);
     expect(CLOUD_AUTH_FAILURE_CLOSE_CODES.has(4002)).toBe(true);
     expect(CLOUD_AUTH_FAILURE_CLOSE_CODES.has(4003)).toBe(true);
-    // 1008 ("policy violation") is included for intermediaries that
-    // rewrite application codes back to the standard range.
     expect(CLOUD_AUTH_FAILURE_CLOSE_CODES.has(1008)).toBe(true);
-    // Normal close codes are NOT in the set — they represent clean
-    // shutdowns, not auth failures.
     expect(CLOUD_AUTH_FAILURE_CLOSE_CODES.has(1000)).toBe(false);
     expect(CLOUD_AUTH_FAILURE_CLOSE_CODES.has(1006)).toBe(false);
   });
@@ -302,7 +306,7 @@ describe('refreshCloudToken', () => {
     };
 
     const before = Date.now();
-    const result = await refreshCloudToken(config);
+    const result = await refreshCloudToken(ASSISTANT_A, config);
     expect(result).not.toBeNull();
     const token = result as StoredCloudToken;
 
@@ -311,8 +315,8 @@ describe('refreshCloudToken', () => {
     expect(token.guardianId).toBe('g-99');
     expect(token.expiresAt).toBeGreaterThanOrEqual(before + 3600 * 1000);
 
-    // Token was persisted to storage so future reads see the new one.
-    expect(fakeStorage.data[STORAGE_KEY]).toEqual(token);
+    // Token was persisted to storage under the assistant-scoped key.
+    expect(fakeStorage.data[cloudTokenStorageKey(ASSISTANT_A)]).toEqual(token);
   });
 
   test('returns null when Chrome rejects for interaction required', async () => {
@@ -326,27 +330,74 @@ describe('refreshCloudToken', () => {
       expiresAt: Date.now() - 1_000,
       guardianId: 'g-1',
     };
-    fakeStorage.data[STORAGE_KEY] = stale;
+    fakeStorage.data[cloudTokenStorageKey(ASSISTANT_A)] = stale;
 
-    const result = await refreshCloudToken(config);
+    const result = await refreshCloudToken(ASSISTANT_A, config);
     expect(result).toBeNull();
-    // The stale token is left in place — the reconnect path uses this
-    // to decide whether to surface a sign-in prompt to the user.
-    expect(fakeStorage.data[STORAGE_KEY]).toEqual(stale);
+    // The stale token is left in place.
+    expect(fakeStorage.data[cloudTokenStorageKey(ASSISTANT_A)]).toEqual(stale);
   });
 
   test('returns null when launchWebAuthFlow resolves with undefined', async () => {
     launchWebAuthFlowImpl = async () => undefined;
-    expect(await refreshCloudToken(config)).toBeNull();
+    expect(await refreshCloudToken(ASSISTANT_A, config)).toBeNull();
   });
 
   test('throws when the gateway returns an incomplete payload', async () => {
-    // A malformed response from the gateway is an unexpected error and
-    // should bubble up to the service-worker logs — we only swallow
-    // the "interaction required" family of Chrome rejections.
     launchWebAuthFlowImpl = async () =>
       'https://fakeextid.chromiumapp.org/cloud-auth#guardian_id=g-42';
 
-    await expect(refreshCloudToken(config)).rejects.toThrow('incomplete payload');
+    await expect(refreshCloudToken(ASSISTANT_A, config)).rejects.toThrow('incomplete payload');
+  });
+});
+
+describe('assistant token isolation', () => {
+  test('tokens stored for different assistants do not interfere', async () => {
+    const tokenA: StoredCloudToken = {
+      token: 'cloud-alpha',
+      expiresAt: Date.now() + 60_000,
+      guardianId: 'g-alpha',
+    };
+    const tokenB: StoredCloudToken = {
+      token: 'cloud-beta',
+      expiresAt: Date.now() + 60_000,
+      guardianId: 'g-beta',
+    };
+    fakeStorage.data[cloudTokenStorageKey(ASSISTANT_A)] = tokenA;
+    fakeStorage.data[cloudTokenStorageKey(ASSISTANT_B)] = tokenB;
+
+    expect(await getStoredToken(ASSISTANT_A)).toEqual(tokenA);
+    expect(await getStoredToken(ASSISTANT_B)).toEqual(tokenB);
+  });
+
+  test('clearing one assistant token does not affect another', async () => {
+    const tokenA: StoredCloudToken = {
+      token: 'cloud-alpha',
+      expiresAt: Date.now() + 60_000,
+      guardianId: 'g-alpha',
+    };
+    const tokenB: StoredCloudToken = {
+      token: 'cloud-beta',
+      expiresAt: Date.now() + 60_000,
+      guardianId: 'g-beta',
+    };
+    fakeStorage.data[cloudTokenStorageKey(ASSISTANT_A)] = tokenA;
+    fakeStorage.data[cloudTokenStorageKey(ASSISTANT_B)] = tokenB;
+
+    await clearStoredToken(ASSISTANT_A);
+
+    expect(await getStoredToken(ASSISTANT_A)).toBeNull();
+    expect(await getStoredToken(ASSISTANT_B)).toEqual(tokenB);
+  });
+
+  test('signInCloud persists under the correct assistant-scoped key', async () => {
+    launchWebAuthFlowImpl = async () =>
+      'https://fakeextid.chromiumapp.org/cloud-auth#token=scoped-jwt&expires_in=3600&guardian_id=g-scoped';
+
+    await signInCloud(ASSISTANT_B, config);
+
+    // Only ASSISTANT_B's key should be populated.
+    expect(fakeStorage.data[cloudTokenStorageKey(ASSISTANT_B)]).toBeDefined();
+    expect(fakeStorage.data[cloudTokenStorageKey(ASSISTANT_A)]).toBeUndefined();
   });
 });

--- a/clients/chrome-extension/background/__tests__/self-hosted-auth.test.ts
+++ b/clients/chrome-extension/background/__tests__/self-hosted-auth.test.ts
@@ -588,3 +588,103 @@ describe('assistant token isolation', () => {
     expect(fakeStorage.data[localTokenStorageKey(ASSISTANT_A)]).toBeUndefined();
   });
 });
+
+describe('legacy token migration (self-hosted)', () => {
+  const LEGACY_KEY = 'vellum.localCapabilityToken';
+
+  test('getStoredLocalToken migrates a valid legacy token to the scoped key', async () => {
+    const legacyToken: StoredLocalToken = {
+      token: 'legacy-cap',
+      expiresAt: Date.now() + 60_000,
+      guardianId: 'g-legacy',
+    };
+    fakeStorage.data[LEGACY_KEY] = legacyToken;
+
+    const result = await getStoredLocalToken(ASSISTANT_A);
+    expect(result).toEqual(legacyToken);
+
+    // Legacy key was removed.
+    expect(fakeStorage.data[LEGACY_KEY]).toBeUndefined();
+    // Scoped key was populated.
+    expect(fakeStorage.data[localTokenStorageKey(ASSISTANT_A)]).toEqual(legacyToken);
+  });
+
+  test('migration preserves assistantPort from the legacy token', async () => {
+    const legacyToken: StoredLocalToken = {
+      token: 'legacy-with-port',
+      expiresAt: Date.now() + 60_000,
+      guardianId: 'g-legacy-port',
+      assistantPort: 7821,
+    };
+    fakeStorage.data[LEGACY_KEY] = legacyToken;
+
+    const result = await getStoredLocalToken(ASSISTANT_A);
+    expect(result?.assistantPort).toBe(7821);
+    expect(fakeStorage.data[LEGACY_KEY]).toBeUndefined();
+    expect(fakeStorage.data[localTokenStorageKey(ASSISTANT_A)]).toEqual(legacyToken);
+  });
+
+  test('migration does not clobber an existing scoped token', async () => {
+    const scopedToken: StoredLocalToken = {
+      token: 'scoped-cap',
+      expiresAt: Date.now() + 60_000,
+      guardianId: 'g-scoped',
+    };
+    const legacyToken: StoredLocalToken = {
+      token: 'legacy-cap',
+      expiresAt: Date.now() + 60_000,
+      guardianId: 'g-legacy',
+    };
+    fakeStorage.data[localTokenStorageKey(ASSISTANT_A)] = scopedToken;
+    fakeStorage.data[LEGACY_KEY] = legacyToken;
+
+    const result = await getStoredLocalToken(ASSISTANT_A);
+    expect(result).toEqual(scopedToken);
+    // Legacy key is NOT removed because the scoped key already existed.
+    expect(fakeStorage.data[LEGACY_KEY]).toEqual(legacyToken);
+  });
+
+  test('migration is idempotent — second call is a no-op', async () => {
+    const legacyToken: StoredLocalToken = {
+      token: 'legacy-cap',
+      expiresAt: Date.now() + 60_000,
+      guardianId: 'g-legacy',
+    };
+    fakeStorage.data[LEGACY_KEY] = legacyToken;
+
+    // First call migrates.
+    await getStoredLocalToken(ASSISTANT_A);
+    expect(fakeStorage.data[LEGACY_KEY]).toBeUndefined();
+
+    // Second call is a no-op — the scoped key exists and the legacy key
+    // is gone.
+    const result = await getStoredLocalToken(ASSISTANT_A);
+    expect(result).toEqual(legacyToken);
+    expect(fakeStorage.data[localTokenStorageKey(ASSISTANT_A)]).toEqual(legacyToken);
+  });
+
+  test('migration ignores a malformed legacy value', async () => {
+    fakeStorage.data[LEGACY_KEY] = { token: 42, expiresAt: 'soon' };
+
+    const result = await getStoredLocalToken(ASSISTANT_A);
+    expect(result).toBeNull();
+  });
+
+  test('migration returns null for an expired legacy token', async () => {
+    fakeStorage.data[LEGACY_KEY] = {
+      token: 'expired-legacy',
+      expiresAt: Date.now() - 1_000,
+      guardianId: 'g-expired',
+    } satisfies StoredLocalToken;
+
+    // validateLocalToken checks expiry, so expired legacy tokens are
+    // not migrated.
+    const result = await getStoredLocalToken(ASSISTANT_A);
+    expect(result).toBeNull();
+  });
+
+  test('migration returns null when no legacy key exists', async () => {
+    const result = await getStoredLocalToken(ASSISTANT_A);
+    expect(result).toBeNull();
+  });
+});

--- a/clients/chrome-extension/background/__tests__/self-hosted-auth.test.ts
+++ b/clients/chrome-extension/background/__tests__/self-hosted-auth.test.ts
@@ -13,10 +13,12 @@ import {
   getStoredLocalToken,
   clearLocalToken,
   bootstrapLocalToken,
+  localTokenStorageKey,
   type StoredLocalToken,
 } from '../self-hosted-auth.js';
 
-const STORAGE_KEY = 'vellum.localCapabilityToken';
+const ASSISTANT_A = 'assistant-alpha';
+const ASSISTANT_B = 'assistant-beta';
 
 interface FakeStorage {
   data: Record<string, unknown>;
@@ -165,6 +167,14 @@ afterEach(() => {
   (globalThis as { chrome?: unknown }).chrome = originalChrome;
 });
 
+describe('localTokenStorageKey', () => {
+  test('builds a colon-separated key', () => {
+    expect(localTokenStorageKey('my-assistant')).toBe(
+      'vellum.localCapabilityToken:my-assistant',
+    );
+  });
+});
+
 describe('bootstrapLocalToken', () => {
   test('happy path persists and returns the token', async () => {
     const issuedAt = Date.now();
@@ -183,7 +193,7 @@ describe('bootstrapLocalToken', () => {
       });
     };
 
-    const result = await bootstrapLocalToken();
+    const result = await bootstrapLocalToken(ASSISTANT_A);
     expect(result.token).toBe('abc123');
     expect(result.guardianId).toBe('g-42');
     expect(result.expiresAt).toBe(Date.parse(expiresAtIso));
@@ -192,8 +202,9 @@ describe('bootstrapLocalToken', () => {
     expect(fakeRuntime.connectCalls).toEqual(['com.vellum.daemon']);
     expect(fakeRuntime.currentPort?.sent).toEqual([{ type: 'request_token' }]);
 
-    // Token was persisted.
-    expect(fakeStorage.data[STORAGE_KEY]).toEqual(result);
+    // Token was persisted under assistant-scoped key.
+    const key = localTokenStorageKey(ASSISTANT_A);
+    expect(fakeStorage.data[key]).toEqual(result);
 
     // Port was cleaned up.
     expect(fakeRuntime.currentPort?.disconnected).toBe(true);
@@ -213,16 +224,11 @@ describe('bootstrapLocalToken', () => {
       });
     };
 
-    const result = await bootstrapLocalToken();
+    const result = await bootstrapLocalToken(ASSISTANT_A);
     expect(result.expiresAt).toBe(expiresAt);
   });
 
   test('persists assistantPort when the helper frame includes it', async () => {
-    // PR 3 of the browser-use remediation plan added `assistantPort`
-    // to the native-messaging `token_response` frame so the worker
-    // can open the relay socket against the runtime port the helper
-    // actually used (instead of the hard-coded DEFAULT_RELAY_PORT).
-    // This test exercises that round-trip end-to-end.
     const expiresAtIso = new Date(Date.now() + 60_000).toISOString();
 
     fakeRuntime.onConnect = (port) => {
@@ -237,21 +243,17 @@ describe('bootstrapLocalToken', () => {
       });
     };
 
-    const result = await bootstrapLocalToken();
+    const result = await bootstrapLocalToken(ASSISTANT_A);
     expect(result.assistantPort).toBe(7821);
     expect(result.guardianId).toBe('g-port');
 
     // And the stored value must round-trip through getStoredLocalToken.
-    const loaded = await getStoredLocalToken();
+    const loaded = await getStoredLocalToken(ASSISTANT_A);
     expect(loaded).not.toBeNull();
     expect(loaded!.assistantPort).toBe(7821);
   });
 
   test('omits assistantPort when the helper frame is missing it', async () => {
-    // Native helpers that omit the optional assistantPort field must
-    // still produce a valid StoredLocalToken — the worker will fall
-    // back to the stored `relayPort` / default value when
-    // assistantPort is undefined.
     const expiresAtIso = new Date(Date.now() + 60_000).toISOString();
 
     fakeRuntime.onConnect = (port) => {
@@ -265,16 +267,12 @@ describe('bootstrapLocalToken', () => {
       });
     };
 
-    const result = await bootstrapLocalToken();
+    const result = await bootstrapLocalToken(ASSISTANT_A);
     expect(result.assistantPort).toBeUndefined();
     expect(result.guardianId).toBe('g-legacy');
   });
 
   test('drops malformed assistantPort from the helper frame', async () => {
-    // Belt-and-braces: if a future native helper ships a value we
-    // can't parse (e.g. a string or an out-of-range port), we must
-    // still accept the token and drop the malformed port rather than
-    // rejecting the whole frame.
     const expiresAtIso = new Date(Date.now() + 60_000).toISOString();
 
     fakeRuntime.onConnect = (port) => {
@@ -290,7 +288,7 @@ describe('bootstrapLocalToken', () => {
       });
     };
 
-    const result = await bootstrapLocalToken();
+    const result = await bootstrapLocalToken(ASSISTANT_A);
     expect(result.assistantPort).toBeUndefined();
   });
 
@@ -306,8 +304,8 @@ describe('bootstrapLocalToken', () => {
       });
     };
 
-    await expect(bootstrapLocalToken()).rejects.toThrow('malformed token_response');
-    expect(fakeStorage.data[STORAGE_KEY]).toBeUndefined();
+    await expect(bootstrapLocalToken(ASSISTANT_A)).rejects.toThrow('malformed token_response');
+    expect(fakeStorage.data[localTokenStorageKey(ASSISTANT_A)]).toBeUndefined();
     expect(fakeRuntime.currentPort?.disconnected).toBe(true);
   });
 
@@ -318,8 +316,8 @@ describe('bootstrapLocalToken', () => {
       });
     };
 
-    await expect(bootstrapLocalToken()).rejects.toThrow('unauthorized_origin');
-    expect(fakeStorage.data[STORAGE_KEY]).toBeUndefined();
+    await expect(bootstrapLocalToken(ASSISTANT_A)).rejects.toThrow('unauthorized_origin');
+    expect(fakeStorage.data[localTokenStorageKey(ASSISTANT_A)]).toBeUndefined();
     expect(fakeRuntime.currentPort?.disconnected).toBe(true);
   });
 
@@ -330,7 +328,7 @@ describe('bootstrapLocalToken', () => {
       });
     };
 
-    await expect(bootstrapLocalToken()).rejects.toThrow('native messaging error');
+    await expect(bootstrapLocalToken(ASSISTANT_A)).rejects.toThrow('native messaging error');
   });
 
   test('timeout rejects and disconnects the port', async () => {
@@ -339,10 +337,10 @@ describe('bootstrapLocalToken', () => {
       // Intentionally silent.
     };
 
-    await expect(bootstrapLocalToken({ timeoutMs: 20 })).rejects.toThrow(
+    await expect(bootstrapLocalToken(ASSISTANT_A, { timeoutMs: 20 })).rejects.toThrow(
       'native messaging timeout',
     );
-    expect(fakeStorage.data[STORAGE_KEY]).toBeUndefined();
+    expect(fakeStorage.data[localTokenStorageKey(ASSISTANT_A)]).toBeUndefined();
     expect(fakeRuntime.currentPort?.disconnected).toBe(true);
   });
 
@@ -354,10 +352,10 @@ describe('bootstrapLocalToken', () => {
       });
     };
 
-    await expect(bootstrapLocalToken()).rejects.toThrow(
+    await expect(bootstrapLocalToken(ASSISTANT_A)).rejects.toThrow(
       'Specified native messaging host not found.',
     );
-    expect(fakeStorage.data[STORAGE_KEY]).toBeUndefined();
+    expect(fakeStorage.data[localTokenStorageKey(ASSISTANT_A)]).toBeUndefined();
   });
 
   test('disconnect with no lastError falls back to generic message', async () => {
@@ -367,7 +365,7 @@ describe('bootstrapLocalToken', () => {
       });
     };
 
-    await expect(bootstrapLocalToken()).rejects.toThrow(
+    await expect(bootstrapLocalToken(ASSISTANT_A)).rejects.toThrow(
       'native messaging disconnected before response',
     );
   });
@@ -387,31 +385,19 @@ describe('bootstrapLocalToken', () => {
       });
     };
 
-    // The caller should still receive a usable token even though we
-    // failed to save it to chrome.storage.local. Persistence is
-    // best-effort from the pair flow's perspective — the in-memory
-    // token is still valid for the current session and the popup
-    // surfaces the same record to the user.
-    const result = await bootstrapLocalToken();
+    const result = await bootstrapLocalToken(ASSISTANT_A);
     expect(result.token).toBe('persist-fail');
     expect(result.guardianId).toBe('g-persist');
     expect(result.expiresAt).toBe(Date.parse(expiresAtIso));
 
     // But nothing was actually written to storage.
-    expect(fakeStorage.data[STORAGE_KEY]).toBeUndefined();
+    expect(fakeStorage.data[localTokenStorageKey(ASSISTANT_A)]).toBeUndefined();
 
     // And the port was torn down as part of marking the promise settled.
     expect(fakeRuntime.currentPort?.disconnected).toBe(true);
   });
 
   test('ignores onDisconnect after a valid token_response (race)', async () => {
-    // Simulates the real-world race where the native helper writes its
-    // token_response frame and then immediately exits, causing Chrome
-    // to fire onDisconnect on the same turn as onMessage. Before the
-    // fix, `settled` was only flipped after the async storage write
-    // resolved, so a fast disconnect could win the race and reject a
-    // valid pairing. Now `settled` is set synchronously the moment the
-    // token frame is validated, so the subsequent disconnect is a no-op.
     fakeRuntime.lastError = { message: 'port closed' };
 
     const expiresAtIso = new Date(Date.now() + 60_000).toISOString();
@@ -424,18 +410,15 @@ describe('bootstrapLocalToken', () => {
           expiresAt: expiresAtIso,
           guardianId: 'g-race',
         });
-        // Emitted on the same microtask turn as the token frame, before
-        // the persistLocalToken promise has a chance to resolve. If the
-        // disconnect handler rejects here, the test fails.
         port.emitDisconnect();
       });
     };
 
-    const result = await bootstrapLocalToken();
+    const result = await bootstrapLocalToken(ASSISTANT_A);
     expect(result.token).toBe('race-winner');
     expect(result.guardianId).toBe('g-race');
     // Token was still persisted despite the racing disconnect.
-    expect(fakeStorage.data[STORAGE_KEY]).toEqual(result);
+    expect(fakeStorage.data[localTokenStorageKey(ASSISTANT_A)]).toEqual(result);
   });
 
   test('ignores unknown frame types until a recognised frame arrives', async () => {
@@ -455,14 +438,14 @@ describe('bootstrapLocalToken', () => {
       });
     };
 
-    const result = await bootstrapLocalToken();
+    const result = await bootstrapLocalToken(ASSISTANT_A);
     expect(result.token).toBe('late');
   });
 });
 
 describe('getStoredLocalToken', () => {
   test('returns null when nothing is stored', async () => {
-    expect(await getStoredLocalToken()).toBeNull();
+    expect(await getStoredLocalToken(ASSISTANT_A)).toBeNull();
   });
 
   test('returns the stored token when valid', async () => {
@@ -471,30 +454,30 @@ describe('getStoredLocalToken', () => {
       expiresAt: Date.now() + 60_000,
       guardianId: 'g-1',
     };
-    fakeStorage.data[STORAGE_KEY] = token;
-    expect(await getStoredLocalToken()).toEqual(token);
+    fakeStorage.data[localTokenStorageKey(ASSISTANT_A)] = token;
+    expect(await getStoredLocalToken(ASSISTANT_A)).toEqual(token);
   });
 
   test('returns null when the token is expired', async () => {
-    fakeStorage.data[STORAGE_KEY] = {
+    fakeStorage.data[localTokenStorageKey(ASSISTANT_A)] = {
       token: 'expired',
       expiresAt: Date.now() - 1_000,
       guardianId: 'g-1',
     } satisfies StoredLocalToken;
-    expect(await getStoredLocalToken()).toBeNull();
+    expect(await getStoredLocalToken(ASSISTANT_A)).toBeNull();
   });
 
   test('returns null when the stored value is malformed', async () => {
-    fakeStorage.data[STORAGE_KEY] = { token: 42, expiresAt: 'soon' };
-    expect(await getStoredLocalToken()).toBeNull();
+    fakeStorage.data[localTokenStorageKey(ASSISTANT_A)] = { token: 42, expiresAt: 'soon' };
+    expect(await getStoredLocalToken(ASSISTANT_A)).toBeNull();
   });
 
   test('returns null when guardianId is missing', async () => {
-    fakeStorage.data[STORAGE_KEY] = {
+    fakeStorage.data[localTokenStorageKey(ASSISTANT_A)] = {
       token: 'valid',
       expiresAt: Date.now() + 60_000,
     };
-    expect(await getStoredLocalToken()).toBeNull();
+    expect(await getStoredLocalToken(ASSISTANT_A)).toBeNull();
   });
 
   test('returns the stored token including assistantPort when present', async () => {
@@ -504,19 +487,19 @@ describe('getStoredLocalToken', () => {
       guardianId: 'g-port',
       assistantPort: 7821,
     };
-    fakeStorage.data[STORAGE_KEY] = token;
-    const loaded = await getStoredLocalToken();
+    fakeStorage.data[localTokenStorageKey(ASSISTANT_A)] = token;
+    const loaded = await getStoredLocalToken(ASSISTANT_A);
     expect(loaded?.assistantPort).toBe(7821);
   });
 
   test('strips a malformed assistantPort rather than rejecting the token', async () => {
-    fakeStorage.data[STORAGE_KEY] = {
+    fakeStorage.data[localTokenStorageKey(ASSISTANT_A)] = {
       token: 'bad-port',
       expiresAt: Date.now() + 60_000,
       guardianId: 'g-bad',
       assistantPort: -1,
     };
-    const loaded = await getStoredLocalToken();
+    const loaded = await getStoredLocalToken(ASSISTANT_A);
     // Token still loads, but the bogus port was dropped.
     expect(loaded).not.toBeNull();
     expect(loaded?.token).toBe('bad-port');
@@ -526,17 +509,82 @@ describe('getStoredLocalToken', () => {
 
 describe('clearLocalToken', () => {
   test('removes the key from storage', async () => {
-    fakeStorage.data[STORAGE_KEY] = {
+    const key = localTokenStorageKey(ASSISTANT_A);
+    fakeStorage.data[key] = {
       token: 'to-clear',
       expiresAt: Date.now() + 60_000,
       guardianId: 'g-1',
     } satisfies StoredLocalToken;
-    await clearLocalToken();
-    expect(fakeStorage.data[STORAGE_KEY]).toBeUndefined();
+    await clearLocalToken(ASSISTANT_A);
+    expect(fakeStorage.data[key]).toBeUndefined();
   });
 
   test('is a no-op when nothing is stored', async () => {
-    await clearLocalToken();
-    expect(fakeStorage.data[STORAGE_KEY]).toBeUndefined();
+    await clearLocalToken(ASSISTANT_A);
+    expect(fakeStorage.data[localTokenStorageKey(ASSISTANT_A)]).toBeUndefined();
+  });
+});
+
+describe('assistant token isolation', () => {
+  test('tokens stored for different assistants do not interfere', async () => {
+    const tokenA: StoredLocalToken = {
+      token: 'token-for-alpha',
+      expiresAt: Date.now() + 60_000,
+      guardianId: 'g-alpha',
+    };
+    const tokenB: StoredLocalToken = {
+      token: 'token-for-beta',
+      expiresAt: Date.now() + 60_000,
+      guardianId: 'g-beta',
+    };
+    fakeStorage.data[localTokenStorageKey(ASSISTANT_A)] = tokenA;
+    fakeStorage.data[localTokenStorageKey(ASSISTANT_B)] = tokenB;
+
+    const loadedA = await getStoredLocalToken(ASSISTANT_A);
+    const loadedB = await getStoredLocalToken(ASSISTANT_B);
+
+    expect(loadedA?.token).toBe('token-for-alpha');
+    expect(loadedB?.token).toBe('token-for-beta');
+  });
+
+  test('clearing one assistant token does not affect another', async () => {
+    const tokenA: StoredLocalToken = {
+      token: 'alpha-token',
+      expiresAt: Date.now() + 60_000,
+      guardianId: 'g-alpha',
+    };
+    const tokenB: StoredLocalToken = {
+      token: 'beta-token',
+      expiresAt: Date.now() + 60_000,
+      guardianId: 'g-beta',
+    };
+    fakeStorage.data[localTokenStorageKey(ASSISTANT_A)] = tokenA;
+    fakeStorage.data[localTokenStorageKey(ASSISTANT_B)] = tokenB;
+
+    await clearLocalToken(ASSISTANT_A);
+
+    expect(await getStoredLocalToken(ASSISTANT_A)).toBeNull();
+    expect(await getStoredLocalToken(ASSISTANT_B)).toEqual(tokenB);
+  });
+
+  test('bootstrap persists under the correct assistant-scoped key', async () => {
+    const expiresAtIso = new Date(Date.now() + 60_000).toISOString();
+
+    fakeRuntime.onConnect = (port) => {
+      queueMicrotask(() => {
+        port.emitMessage({
+          type: 'token_response',
+          token: 'scoped-token',
+          expiresAt: expiresAtIso,
+          guardianId: 'g-scoped',
+        });
+      });
+    };
+
+    await bootstrapLocalToken(ASSISTANT_B);
+
+    // Only ASSISTANT_B's key should be populated.
+    expect(fakeStorage.data[localTokenStorageKey(ASSISTANT_B)]).toBeDefined();
+    expect(fakeStorage.data[localTokenStorageKey(ASSISTANT_A)]).toBeUndefined();
   });
 });

--- a/clients/chrome-extension/background/assistant-auth-profile.ts
+++ b/clients/chrome-extension/background/assistant-auth-profile.ts
@@ -1,0 +1,66 @@
+/**
+ * Maps lockfile topology into an explicit auth profile enum used by the
+ * chrome extension to decide which auth flow to use for a given assistant.
+ *
+ * The lockfile's `cloud` field describes the hosting topology:
+ *   - `"local"` — a locally running assistant (bare-metal or dev mode).
+ *   - `"apple-container"` — a locally running assistant inside an Apple
+ *     Virtualization.framework container.
+ *   - `"vellum"` — a Vellum-cloud-managed assistant.
+ *   - `"platform"` — legacy alias for `"vellum"` (older lockfiles).
+ *
+ * The auth profile simplifies downstream decision-making: rather than
+ * checking `cloud` values and `runtimeUrl` presence in multiple places,
+ * callers resolve the profile once and branch on the three-case enum.
+ */
+
+/**
+ * Auth profile enum that the extension uses to decide which auth flow
+ * to invoke for a given assistant.
+ *
+ * - `local-pair` — pair via the native messaging helper
+ *   (`chrome.runtime.connectNative`). Used for locally running assistants
+ *   where the extension can reach the assistant over loopback.
+ * - `cloud-oauth` — sign in via `chrome.identity.launchWebAuthFlow`
+ *   against the Vellum cloud gateway. Used for cloud-managed assistants.
+ * - `unsupported` — the lockfile topology is not recognised by this
+ *   version of the extension. The caller should surface a user-facing
+ *   message suggesting an extension update.
+ */
+export type AssistantAuthProfile = 'local-pair' | 'cloud-oauth' | 'unsupported';
+
+/**
+ * The subset of lockfile topology fields needed to derive the auth profile.
+ * Matches the shape of `AssistantEntry` from `cli/src/lib/assistant-config.ts`
+ * without introducing a hard import dependency on the CLI package.
+ */
+export interface LockfileTopology {
+  /** Hosting topology value, e.g. `"local"`, `"apple-container"`, `"vellum"`, `"platform"`. */
+  cloud: string;
+  /** Gateway runtime URL. Present for cloud-managed assistants. */
+  runtimeUrl?: string;
+}
+
+/** Cloud values that map to local native-messaging pairing. */
+const LOCAL_CLOUD_VALUES = new Set(['local', 'apple-container']);
+
+/** Cloud values that map to cloud OAuth sign-in. */
+const CLOUD_CLOUD_VALUES = new Set(['vellum', 'platform']);
+
+/**
+ * Derive the auth profile for a given assistant's lockfile topology.
+ *
+ * The mapping is intentionally strict — only known `cloud` values produce
+ * a usable profile. Unknown values yield `unsupported` so a stale
+ * extension doesn't silently try the wrong auth flow against a new
+ * topology introduced in a future release.
+ */
+export function resolveAuthProfile(topology: LockfileTopology): AssistantAuthProfile {
+  if (LOCAL_CLOUD_VALUES.has(topology.cloud)) {
+    return 'local-pair';
+  }
+  if (CLOUD_CLOUD_VALUES.has(topology.cloud)) {
+    return 'cloud-oauth';
+  }
+  return 'unsupported';
+}

--- a/clients/chrome-extension/background/cloud-auth.ts
+++ b/clients/chrome-extension/background/cloud-auth.ts
@@ -79,12 +79,49 @@ export const CLOUD_AUTH_FAILURE_CLOSE_CODES: ReadonlySet<number> = new Set([
 const STORAGE_KEY_PREFIX = 'vellum.cloudAuthToken';
 
 /**
+ * The legacy unscoped storage key used before assistant-scoped keys were
+ * introduced. Existing users may have a token stored under this key from
+ * a previous version of the extension. The migration helpers below
+ * transparently promote it to the new scoped key on first read.
+ */
+const LEGACY_CLOUD_STORAGE_KEY = 'vellum.cloudAuthToken';
+
+/**
  * Build the assistant-scoped chrome.storage.local key for a cloud auth
  * token. Uses a colon separator so the key is
  * `vellum.cloudAuthToken:<assistantId>`.
  */
 export function cloudTokenStorageKey(assistantId: string): string {
   return `${STORAGE_KEY_PREFIX}:${assistantId}`;
+}
+
+/**
+ * Check for a token stored under the legacy unscoped key
+ * (`vellum.cloudAuthToken`). If found and valid, migrate it to the new
+ * assistant-scoped key and remove the legacy key. The migration is
+ * idempotent — once the legacy key is removed, subsequent calls are a
+ * no-op.
+ *
+ * Returns the migrated token (without expiry check) or `null`.
+ */
+async function migrateLegacyCloudToken(assistantId: string): Promise<StoredCloudToken | null> {
+  const scopedKey = cloudTokenStorageKey(assistantId);
+
+  // Only migrate when the scoped key is still empty — avoids clobbering
+  // a token that was stored directly under the scoped key after sign-in.
+  const scopedResult = await chrome.storage.local.get(scopedKey);
+  if (scopedResult[scopedKey] !== undefined) return null;
+
+  const legacyResult = await chrome.storage.local.get(LEGACY_CLOUD_STORAGE_KEY);
+  const legacyToken = validateCloudToken(legacyResult[LEGACY_CLOUD_STORAGE_KEY]);
+  if (!legacyToken) return null;
+
+  // Write to the new scoped key and remove the legacy key atomically
+  // (as atomic as chrome.storage.local allows — both ops are awaited).
+  await chrome.storage.local.set({ [scopedKey]: legacyToken });
+  await chrome.storage.local.remove(LEGACY_CLOUD_STORAGE_KEY);
+
+  return legacyToken;
 }
 
 /**
@@ -109,7 +146,13 @@ function validateCloudToken(raw: unknown): StoredCloudToken | null {
 export async function getStoredToken(assistantId: string): Promise<StoredCloudToken | null> {
   const key = cloudTokenStorageKey(assistantId);
   const result = await chrome.storage.local.get(key);
-  const token = validateCloudToken(result[key]);
+  let token = validateCloudToken(result[key]);
+
+  // Fallback: migrate a legacy unscoped token if no scoped token exists.
+  if (!token) {
+    token = await migrateLegacyCloudToken(assistantId);
+  }
+
   if (!token) return null;
   if (token.expiresAt <= Date.now()) return null;
   return token;
@@ -125,7 +168,11 @@ export async function getStoredToken(assistantId: string): Promise<StoredCloudTo
 export async function getStoredTokenRaw(assistantId: string): Promise<StoredCloudToken | null> {
   const key = cloudTokenStorageKey(assistantId);
   const result = await chrome.storage.local.get(key);
-  return validateCloudToken(result[key]);
+  const token = validateCloudToken(result[key]);
+  if (token) return token;
+
+  // Fallback: migrate a legacy unscoped token if no scoped token exists.
+  return migrateLegacyCloudToken(assistantId);
 }
 
 /**

--- a/clients/chrome-extension/background/cloud-auth.ts
+++ b/clients/chrome-extension/background/cloud-auth.ts
@@ -12,6 +12,10 @@
  * return a fresh token from an existing provider session or immediately
  * reject with "interaction required", in which case the caller must prompt
  * the user to sign in again instead of silently looping.
+ *
+ * Storage is assistant-scoped: each assistant ID gets its own storage key
+ * (`vellum.cloudAuthToken:<assistantId>`) so switching between assistants
+ * never clobbers another assistant's credentials.
  */
 
 export interface CloudAuthConfig {
@@ -72,11 +76,24 @@ export const CLOUD_AUTH_FAILURE_CLOSE_CODES: ReadonlySet<number> = new Set([
   1008, 4001, 4002, 4003,
 ]);
 
-const STORAGE_KEY = 'vellum.cloudAuthToken';
+const STORAGE_KEY_PREFIX = 'vellum.cloudAuthToken';
 
-export async function getStoredToken(): Promise<StoredCloudToken | null> {
-  const result = await chrome.storage.local.get(STORAGE_KEY);
-  const raw = result[STORAGE_KEY];
+/**
+ * Build the assistant-scoped chrome.storage.local key for a cloud auth
+ * token. Uses a colon separator so the key is
+ * `vellum.cloudAuthToken:<assistantId>`.
+ */
+export function cloudTokenStorageKey(assistantId: string): string {
+  return `${STORAGE_KEY_PREFIX}:${assistantId}`;
+}
+
+/**
+ * Validate and return a parsed {@link StoredCloudToken} from a raw storage
+ * value, or `null` when the value is missing, malformed, or does not pass
+ * type checks. Does NOT check expiry — callers that need expiry filtering
+ * should check separately.
+ */
+function validateCloudToken(raw: unknown): StoredCloudToken | null {
   if (!raw || typeof raw !== 'object') return null;
   const token = raw as StoredCloudToken;
   if (
@@ -86,6 +103,14 @@ export async function getStoredToken(): Promise<StoredCloudToken | null> {
   ) {
     return null;
   }
+  return token;
+}
+
+export async function getStoredToken(assistantId: string): Promise<StoredCloudToken | null> {
+  const key = cloudTokenStorageKey(assistantId);
+  const result = await chrome.storage.local.get(key);
+  const token = validateCloudToken(result[key]);
+  if (!token) return null;
   if (token.expiresAt <= Date.now()) return null;
   return token;
 }
@@ -97,19 +122,10 @@ export async function getStoredToken(): Promise<StoredCloudToken | null> {
  * refresh decision — a `null` return from `getStoredToken()` would
  * indiscriminately conflate "never signed in" with "signed in but expired".
  */
-export async function getStoredTokenRaw(): Promise<StoredCloudToken | null> {
-  const result = await chrome.storage.local.get(STORAGE_KEY);
-  const raw = result[STORAGE_KEY];
-  if (!raw || typeof raw !== 'object') return null;
-  const token = raw as StoredCloudToken;
-  if (
-    typeof token.token !== 'string' ||
-    typeof token.expiresAt !== 'number' ||
-    typeof token.guardianId !== 'string'
-  ) {
-    return null;
-  }
-  return token;
+export async function getStoredTokenRaw(assistantId: string): Promise<StoredCloudToken | null> {
+  const key = cloudTokenStorageKey(assistantId);
+  const result = await chrome.storage.local.get(key);
+  return validateCloudToken(result[key]);
 }
 
 /**
@@ -125,12 +141,12 @@ export function isCloudTokenStale(
   return token.expiresAt - now <= CLOUD_TOKEN_STALE_WINDOW_MS;
 }
 
-export async function clearStoredToken(): Promise<void> {
-  await chrome.storage.local.remove(STORAGE_KEY);
+export async function clearStoredToken(assistantId: string): Promise<void> {
+  await chrome.storage.local.remove(cloudTokenStorageKey(assistantId));
 }
 
-async function persistToken(token: StoredCloudToken): Promise<void> {
-  await chrome.storage.local.set({ [STORAGE_KEY]: token });
+async function persistToken(assistantId: string, token: StoredCloudToken): Promise<void> {
+  await chrome.storage.local.set({ [cloudTokenStorageKey(assistantId)]: token });
 }
 
 function parseAuthResponseUrl(responseUrl: string): StoredCloudToken {
@@ -162,14 +178,14 @@ function buildAuthUrl(config: CloudAuthConfig): string {
  * Launches chrome.identity.launchWebAuthFlow to obtain a guardian-bound JWT.
  * The extension receives the token via the redirect URI fragment.
  */
-export async function signInCloud(config: CloudAuthConfig): Promise<StoredCloudToken> {
+export async function signInCloud(assistantId: string, config: CloudAuthConfig): Promise<StoredCloudToken> {
   const authUrl = buildAuthUrl(config);
 
   const responseUrl = await chrome.identity.launchWebAuthFlow({ url: authUrl, interactive: true });
   if (!responseUrl) throw new Error('cloud sign-in cancelled');
 
   const stored = parseAuthResponseUrl(responseUrl);
-  await persistToken(stored);
+  await persistToken(assistantId, stored);
   return stored;
 }
 
@@ -189,6 +205,7 @@ export async function signInCloud(config: CloudAuthConfig): Promise<StoredCloudT
  * gateway response) so they bubble up to the service worker logs.
  */
 export async function refreshCloudToken(
+  assistantId: string,
   config: CloudAuthConfig,
 ): Promise<StoredCloudToken | null> {
   const authUrl = buildAuthUrl(config);
@@ -220,6 +237,6 @@ export async function refreshCloudToken(
   }
 
   const stored = parseAuthResponseUrl(responseUrl);
-  await persistToken(stored);
+  await persistToken(assistantId, stored);
   return stored;
 }

--- a/clients/chrome-extension/background/self-hosted-auth.ts
+++ b/clients/chrome-extension/background/self-hosted-auth.ts
@@ -50,6 +50,14 @@ const NATIVE_HOST_NAME = 'com.vellum.daemon';
 const DEFAULT_BOOTSTRAP_TIMEOUT_MS = 5_000;
 
 /**
+ * The legacy unscoped storage key used before assistant-scoped keys were
+ * introduced. Existing users may have a token stored under this key from
+ * a previous version of the extension. The migration helpers below
+ * transparently promote it to the new scoped key on first read.
+ */
+const LEGACY_LOCAL_STORAGE_KEY = 'vellum.localCapabilityToken';
+
+/**
  * Build the assistant-scoped chrome.storage.local key for a local
  * capability token. Uses a colon separator so the key is
  * `vellum.localCapabilityToken:<assistantId>`.
@@ -100,14 +108,51 @@ function validateLocalToken(raw: unknown): StoredLocalToken | null {
 }
 
 /**
+ * Check for a token stored under the legacy unscoped key
+ * (`vellum.localCapabilityToken`). If found and valid, migrate it to the
+ * new assistant-scoped key and remove the legacy key. The migration is
+ * idempotent — once the legacy key is removed, subsequent calls are a
+ * no-op.
+ *
+ * Returns the migrated token or `null`.
+ */
+async function migrateLegacyLocalToken(assistantId: string): Promise<StoredLocalToken | null> {
+  const scopedKey = localTokenStorageKey(assistantId);
+
+  // Only migrate when the scoped key is still empty — avoids clobbering
+  // a token that was stored directly under the scoped key after pairing.
+  const scopedResult = await chrome.storage.local.get(scopedKey);
+  if (scopedResult[scopedKey] !== undefined) return null;
+
+  const legacyResult = await chrome.storage.local.get(LEGACY_LOCAL_STORAGE_KEY);
+  const legacyToken = validateLocalToken(legacyResult[LEGACY_LOCAL_STORAGE_KEY]);
+  if (!legacyToken) return null;
+
+  // Write to the new scoped key and remove the legacy key atomically
+  // (as atomic as chrome.storage.local allows — both ops are awaited).
+  await chrome.storage.local.set({ [scopedKey]: legacyToken });
+  await chrome.storage.local.remove(LEGACY_LOCAL_STORAGE_KEY);
+
+  return legacyToken;
+}
+
+/**
  * Read the stored local capability token for a specific assistant.
  * Returns `null` when nothing is stored, the value is malformed, or it
  * has expired.
+ *
+ * On the first call after the extension upgrades to assistant-scoped
+ * storage keys, this function transparently migrates any token stored
+ * under the legacy unscoped key to the new scoped key.
  */
 export async function getStoredLocalToken(assistantId: string): Promise<StoredLocalToken | null> {
   const key = localTokenStorageKey(assistantId);
   const result = await chrome.storage.local.get(key);
-  return validateLocalToken(result[key]);
+  const token = validateLocalToken(result[key]);
+  if (token) return token;
+
+  // Fallback: migrate a legacy unscoped token if no scoped token exists.
+  return migrateLegacyLocalToken(assistantId);
 }
 
 /**

--- a/clients/chrome-extension/background/self-hosted-auth.ts
+++ b/clients/chrome-extension/background/self-hosted-auth.ts
@@ -25,6 +25,10 @@
  * We parse it into an epoch-millis number here so the in-memory and
  * on-disk representation matches `StoredCloudToken` and downstream code
  * can rely on a single numeric expiry type across both transports.
+ *
+ * Storage is assistant-scoped: each assistant ID gets its own storage key
+ * (`vellum.localCapabilityToken:<assistantId>`) so switching between
+ * assistants never clobbers another assistant's credentials.
  */
 
 export interface StoredLocalToken {
@@ -41,9 +45,18 @@ export interface StoredLocalToken {
   assistantPort?: number;
 }
 
-const STORAGE_KEY = 'vellum.localCapabilityToken';
+const STORAGE_KEY_PREFIX = 'vellum.localCapabilityToken';
 const NATIVE_HOST_NAME = 'com.vellum.daemon';
 const DEFAULT_BOOTSTRAP_TIMEOUT_MS = 5_000;
+
+/**
+ * Build the assistant-scoped chrome.storage.local key for a local
+ * capability token. Uses a colon separator so the key is
+ * `vellum.localCapabilityToken:<assistantId>`.
+ */
+export function localTokenStorageKey(assistantId: string): string {
+  return `${STORAGE_KEY_PREFIX}:${assistantId}`;
+}
 
 export interface BootstrapLocalTokenOptions {
   /**
@@ -54,9 +67,11 @@ export interface BootstrapLocalTokenOptions {
   timeoutMs?: number;
 }
 
-export async function getStoredLocalToken(): Promise<StoredLocalToken | null> {
-  const result = await chrome.storage.local.get(STORAGE_KEY);
-  const raw = result[STORAGE_KEY];
+/**
+ * Validate and return a parsed {@link StoredLocalToken} from a raw storage
+ * value, or `null` when the value is missing, malformed, or expired.
+ */
+function validateLocalToken(raw: unknown): StoredLocalToken | null {
   if (!raw || typeof raw !== 'object') return null;
   const token = raw as StoredLocalToken;
   if (
@@ -84,12 +99,26 @@ export async function getStoredLocalToken(): Promise<StoredLocalToken | null> {
   return token;
 }
 
-export async function clearLocalToken(): Promise<void> {
-  await chrome.storage.local.remove(STORAGE_KEY);
+/**
+ * Read the stored local capability token for a specific assistant.
+ * Returns `null` when nothing is stored, the value is malformed, or it
+ * has expired.
+ */
+export async function getStoredLocalToken(assistantId: string): Promise<StoredLocalToken | null> {
+  const key = localTokenStorageKey(assistantId);
+  const result = await chrome.storage.local.get(key);
+  return validateLocalToken(result[key]);
 }
 
-async function persistLocalToken(token: StoredLocalToken): Promise<void> {
-  await chrome.storage.local.set({ [STORAGE_KEY]: token });
+/**
+ * Remove the stored local capability token for a specific assistant.
+ */
+export async function clearLocalToken(assistantId: string): Promise<void> {
+  await chrome.storage.local.remove(localTokenStorageKey(assistantId));
+}
+
+async function persistLocalToken(assistantId: string, token: StoredLocalToken): Promise<void> {
+  await chrome.storage.local.set({ [localTokenStorageKey(assistantId)]: token });
 }
 
 /**
@@ -129,6 +158,7 @@ function parseExpiresAt(raw: unknown): number | null {
  *   process doesn't leak.
  */
 export async function bootstrapLocalToken(
+  assistantId: string,
   options: BootstrapLocalTokenOptions = {},
 ): Promise<StoredLocalToken> {
   const timeoutMs = options.timeoutMs ?? DEFAULT_BOOTSTRAP_TIMEOUT_MS;
@@ -226,7 +256,7 @@ export async function bootstrapLocalToken(
         // couldn't durably save it. This also matches the comment
         // above: a storage failure shouldn't block the caller from
         // getting a token they just successfully negotiated.
-        persistLocalToken(stored).then(
+        persistLocalToken(assistantId, stored).then(
           () => resolve(stored),
           (err: unknown) => {
             const detail = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Summary
- Add assistant-auth-profile.ts to map lockfile topology to auth profile enum
- Update self-hosted-auth.ts and cloud-auth.ts storage to be assistant-scoped
- Add tests for token isolation, malformed-token rejection, and auth-profile mapping

Part of plan: chrome-extension-multi-assistant-auth.md (PR 2 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24752" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
