### PR TITLE
Add provider-agnostic TTS contracts and runtime registry

### DIFF
--- a/assistant/src/tts/__tests__/provider-registry.test.ts
+++ b/assistant/src/tts/__tests__/provider-registry.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import {
+  _resetTtsProviderRegistry,
+  getTtsProvider,
+  listTtsProviders,
+  registerTtsProvider,
+} from "../provider-registry.js";
+import type { TtsProvider } from "../types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function stubProvider(id: string): TtsProvider {
+  return {
+    id,
+    capabilities: {
+      supportsStreaming: false,
+      supportedFormats: ["mp3"],
+    },
+    async synthesize() {
+      return { audio: Buffer.alloc(0), contentType: "audio/mpeg" };
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("TTS provider registry", () => {
+  afterEach(() => {
+    _resetTtsProviderRegistry();
+  });
+
+  // -- Registration & lookup ------------------------------------------------
+
+  test("registers and resolves a provider by ID", () => {
+    const provider = stubProvider("test-provider");
+    registerTtsProvider(provider);
+
+    const resolved = getTtsProvider("test-provider");
+    expect(resolved).toBe(provider);
+  });
+
+  test("rejects duplicate registration with an explicit error", () => {
+    registerTtsProvider(stubProvider("dup"));
+
+    expect(() => registerTtsProvider(stubProvider("dup"))).toThrow(
+      /already registered/,
+    );
+  });
+
+  // -- Unknown provider errors ----------------------------------------------
+
+  test("throws for unknown provider ID when registry is empty", () => {
+    expect(() => getTtsProvider("nope")).toThrow(/Unknown TTS provider "nope"/);
+  });
+
+  test("throws for unknown provider ID and lists known providers", () => {
+    registerTtsProvider(stubProvider("alpha"));
+    registerTtsProvider(stubProvider("beta"));
+
+    try {
+      getTtsProvider("gamma");
+      throw new Error("Expected getTtsProvider to throw");
+    } catch (err) {
+      const msg = (err as Error).message;
+      expect(msg).toMatch(/Unknown TTS provider "gamma"/);
+      expect(msg).toMatch(/alpha/);
+      expect(msg).toMatch(/beta/);
+    }
+  });
+
+  // -- Listing order --------------------------------------------------------
+
+  test("listTtsProviders returns providers in registration order", () => {
+    registerTtsProvider(stubProvider("charlie"));
+    registerTtsProvider(stubProvider("alpha"));
+    registerTtsProvider(stubProvider("bravo"));
+
+    const ids = listTtsProviders().map((p) => p.id);
+    expect(ids).toEqual(["charlie", "alpha", "bravo"]);
+  });
+
+  test("listTtsProviders returns empty array when nothing is registered", () => {
+    expect(listTtsProviders()).toEqual([]);
+  });
+});

--- a/assistant/src/tts/provider-registry.ts
+++ b/assistant/src/tts/provider-registry.ts
@@ -1,0 +1,73 @@
+/**
+ * Runtime TTS provider registry.
+ *
+ * Providers self-register at startup via `registerTtsProvider`. Callers
+ * resolve a provider by ID with `getTtsProvider`, which throws an explicit
+ * error for unknown IDs so misconfiguration surfaces immediately rather
+ * than producing silent fallback behavior.
+ */
+
+import type { TtsProvider, TtsProviderId } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Internal state
+// ---------------------------------------------------------------------------
+
+/** Insertion-ordered map of registered providers. */
+const providers = new Map<TtsProviderId, TtsProvider>();
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Register a TTS provider.
+ *
+ * @throws if a provider with the same ID is already registered — this
+ *   prevents silent overwrites caused by duplicate registrations.
+ */
+export function registerTtsProvider(provider: TtsProvider): void {
+  if (providers.has(provider.id)) {
+    throw new Error(
+      `TTS provider "${provider.id}" is already registered. ` +
+        "Duplicate registrations are not allowed.",
+    );
+  }
+  providers.set(provider.id, provider);
+}
+
+/**
+ * Look up a registered TTS provider by ID.
+ *
+ * @throws if no provider with the given ID has been registered.
+ */
+export function getTtsProvider(id: TtsProviderId): TtsProvider {
+  const provider = providers.get(id);
+  if (!provider) {
+    const known = [...providers.keys()];
+    const knownList =
+      known.length > 0 ? ` Known providers: ${known.join(", ")}` : "";
+    throw new Error(`Unknown TTS provider "${id}".${knownList}`);
+  }
+  return provider;
+}
+
+/**
+ * List all registered providers in deterministic (registration) order.
+ */
+export function listTtsProviders(): TtsProvider[] {
+  return [...providers.values()];
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Clear all registered providers.
+ *
+ * **Test-only** — must not be called in production code.
+ */
+export function _resetTtsProviderRegistry(): void {
+  providers.clear();
+}

--- a/assistant/src/tts/types.ts
+++ b/assistant/src/tts/types.ts
@@ -1,0 +1,117 @@
+/**
+ * Core domain types for the provider-agnostic TTS abstraction.
+ *
+ * These contracts decouple callers (phone calls, message TTS routes, native
+ * clients) from concrete TTS backends (ElevenLabs, Fish Audio, etc.).
+ */
+
+// ---------------------------------------------------------------------------
+// Provider identity
+// ---------------------------------------------------------------------------
+
+/**
+ * Unique identifier for a registered TTS provider.
+ *
+ * Values correspond to the provider names already used in config schemas
+ * (e.g. `"elevenlabs"`, `"fish-audio"`). New providers simply add a new
+ * string to this union — the registry enforces uniqueness at runtime.
+ */
+export type TtsProviderId = "elevenlabs" | "fish-audio" | (string & {});
+
+// ---------------------------------------------------------------------------
+// Use-case discriminator
+// ---------------------------------------------------------------------------
+
+/**
+ * Describes the product surface that is requesting synthesis so providers
+ * can tailor format, latency, and quality trade-offs.
+ */
+export type TtsUseCase =
+  /** Real-time phone call — prioritize low latency and streaming. */
+  | "phone-call"
+  /** In-app message playback — buffer-oriented, higher quality acceptable. */
+  | "message-playback";
+
+// ---------------------------------------------------------------------------
+// Synthesis request / result
+// ---------------------------------------------------------------------------
+
+/** Input to a TTS synthesis call. */
+export interface TtsSynthesisRequest {
+  /** Pre-sanitized text to synthesize. */
+  text: string;
+
+  /** Product surface requesting synthesis. */
+  useCase: TtsUseCase;
+
+  /**
+   * Optional voice identifier whose format is provider-specific
+   * (e.g. an ElevenLabs voice ID or a Fish Audio reference ID).
+   */
+  voiceId?: string;
+
+  /** Optional abort signal for cancelling in-flight synthesis. */
+  signal?: AbortSignal;
+}
+
+/** Output of a completed TTS synthesis call. */
+export interface TtsSynthesisResult {
+  /** Complete audio buffer. */
+  audio: Buffer;
+
+  /** MIME type of the returned audio (e.g. `"audio/mpeg"`, `"audio/wav"`). */
+  contentType: string;
+}
+
+// ---------------------------------------------------------------------------
+// Provider capabilities
+// ---------------------------------------------------------------------------
+
+/** Advertised capabilities of a TTS provider. */
+export interface TtsProviderCapabilities {
+  /** Whether the provider supports chunk-level streaming via `synthesizeStream`. */
+  supportsStreaming: boolean;
+
+  /** Audio formats the provider can produce (e.g. `["mp3", "wav", "opus"]`). */
+  supportedFormats: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Provider interface
+// ---------------------------------------------------------------------------
+
+/**
+ * Contract that every TTS provider adapter must implement.
+ *
+ * At minimum a provider must support buffer-oriented synthesis. Streaming
+ * synthesis is optional — providers that support it set
+ * `capabilities.supportsStreaming` to `true` and implement
+ * `synthesizeStream`.
+ */
+export interface TtsProvider {
+  /** Unique provider identifier used for registry lookup. */
+  readonly id: TtsProviderId;
+
+  /** Static capability advertisement. */
+  readonly capabilities: TtsProviderCapabilities;
+
+  /**
+   * Synthesize text and return the complete audio buffer.
+   *
+   * This is the universal code-path — every provider must implement it.
+   */
+  synthesize(request: TtsSynthesisRequest): Promise<TtsSynthesisResult>;
+
+  /**
+   * Synthesize text with chunk-level streaming.
+   *
+   * Only required when `capabilities.supportsStreaming` is `true`.
+   * The `onChunk` callback is invoked with each audio chunk as it arrives
+   * from the upstream provider. The returned promise resolves with the
+   * complete concatenated result once all chunks have been delivered.
+   */
+  synthesizeStream?(
+    request: TtsSynthesisRequest,
+    onChunk: (chunk: Uint8Array) => void,
+  ): Promise<TtsSynthesisResult>;
+}


### PR DESCRIPTION
## Summary
- Introduces core TTS domain types (TtsProviderId, TtsUseCase, TtsSynthesisRequest, TtsSynthesisResult, TtsProviderCapabilities, TtsProvider)
- Adds deterministic provider registry with registration, lookup, and listing
- Includes comprehensive tests for duplicate registration, unknown provider errors, and listing order

Part of plan: product-tts-provider-abstraction.md (PR 1 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24753" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
