### PR TITLE
feat(browser): auto-attempt cdp-inspect on macOS before local backend

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -907,6 +907,10 @@ describe("AssistantConfigSchema", () => {
         host: "localhost",
         port: 9222,
         probeTimeoutMs: 500,
+        desktopAuto: {
+          enabled: true,
+          cooldownMs: 30_000,
+        },
       },
     });
   });
@@ -1014,6 +1018,97 @@ describe("AssistantConfigSchema", () => {
       hostBrowser: { cdpInspect: { enabled: "yes" } },
     });
     expect(result.success).toBe(false);
+  });
+
+  // ── hostBrowser.cdpInspect.desktopAuto config ───────────────────────
+
+  test("applies hostBrowser.cdpInspect.desktopAuto defaults", () => {
+    const result = AssistantConfigSchema.parse({});
+    expect(result.hostBrowser.cdpInspect.desktopAuto).toEqual({
+      enabled: true,
+      cooldownMs: 30_000,
+    });
+  });
+
+  test("accepts hostBrowser.cdpInspect.desktopAuto overrides", () => {
+    const result = AssistantConfigSchema.parse({
+      hostBrowser: {
+        cdpInspect: {
+          desktopAuto: { enabled: false, cooldownMs: 10_000 },
+        },
+      },
+    });
+    expect(result.hostBrowser.cdpInspect.desktopAuto.enabled).toBe(false);
+    expect(result.hostBrowser.cdpInspect.desktopAuto.cooldownMs).toBe(10_000);
+  });
+
+  test("accepts hostBrowser.cdpInspect.desktopAuto.cooldownMs of 0 (disable cooldown)", () => {
+    const result = AssistantConfigSchema.parse({
+      hostBrowser: {
+        cdpInspect: { desktopAuto: { cooldownMs: 0 } },
+      },
+    });
+    expect(result.hostBrowser.cdpInspect.desktopAuto.cooldownMs).toBe(0);
+  });
+
+  test("rejects hostBrowser.cdpInspect.desktopAuto.cooldownMs below 0", () => {
+    const result = AssistantConfigSchema.safeParse({
+      hostBrowser: {
+        cdpInspect: { desktopAuto: { cooldownMs: -1 } },
+      },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(
+        result.error.issues.some((issue) =>
+          issue.path.join(".").includes("cooldownMs"),
+        ),
+      ).toBe(true);
+    }
+  });
+
+  test("rejects hostBrowser.cdpInspect.desktopAuto.cooldownMs above 300000", () => {
+    const result = AssistantConfigSchema.safeParse({
+      hostBrowser: {
+        cdpInspect: { desktopAuto: { cooldownMs: 500_000 } },
+      },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(
+        result.error.issues.some((issue) =>
+          issue.path.join(".").includes("cooldownMs"),
+        ),
+      ).toBe(true);
+    }
+  });
+
+  test("rejects non-integer hostBrowser.cdpInspect.desktopAuto.cooldownMs", () => {
+    const result = AssistantConfigSchema.safeParse({
+      hostBrowser: {
+        cdpInspect: { desktopAuto: { cooldownMs: 5000.5 } },
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects non-boolean hostBrowser.cdpInspect.desktopAuto.enabled", () => {
+    const result = AssistantConfigSchema.safeParse({
+      hostBrowser: {
+        cdpInspect: { desktopAuto: { enabled: "yes" } },
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("desktopAuto defaults preserved when only cdpInspect.enabled is set", () => {
+    const result = AssistantConfigSchema.parse({
+      hostBrowser: { cdpInspect: { enabled: true } },
+    });
+    expect(result.hostBrowser.cdpInspect.desktopAuto).toEqual({
+      enabled: true,
+      cooldownMs: 30_000,
+    });
   });
 });
 

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -50,10 +50,12 @@ export { FishAudioConfigSchema } from "./schemas/fish-audio.js";
 export type { HeartbeatConfig } from "./schemas/heartbeat.js";
 export { HeartbeatConfigSchema } from "./schemas/heartbeat.js";
 export type {
+  DesktopAutoCdpInspectConfig,
   HostBrowserCdpInspectConfig,
   HostBrowserConfig,
 } from "./schemas/host-browser.js";
 export {
+  DesktopAutoCdpInspectConfigSchema,
   HostBrowserCdpInspectConfigSchema,
   HostBrowserConfigSchema,
 } from "./schemas/host-browser.js";

--- a/assistant/src/config/schemas/host-browser.ts
+++ b/assistant/src/config/schemas/host-browser.ts
@@ -1,6 +1,49 @@
 import { z } from "zod";
 
 /**
+ * Configuration for the automatic cdp-inspect attempt on macOS. When a macOS
+ * turn reaches the CDP factory and `desktopAuto.enabled` is true, the factory
+ * includes cdp-inspect as a candidate even when the top-level `enabled` flag
+ * is false. This lets macOS users benefit from direct Chrome attach without
+ * requiring manual `hostBrowser.cdpInspect.enabled = true`.
+ *
+ * If the cdp-inspect probe fails (e.g. Chrome was not launched with
+ * `--remote-debugging-port`), the factory records a cooldown timestamp and
+ * skips the probe for subsequent calls until the cooldown expires. This bounds
+ * the per-call latency penalty to `probeTimeoutMs` once per cooldown window.
+ */
+export const DesktopAutoCdpInspectConfigSchema = z
+  .object({
+    enabled: z
+      .boolean({
+        error: "hostBrowser.cdpInspect.desktopAuto.enabled must be a boolean",
+      })
+      .default(true)
+      .describe(
+        "Whether macOS turns automatically attempt cdp-inspect before falling back to the local Playwright backend. When true (default on macOS), the factory inserts a cdp-inspect candidate between the extension and local backends even when the top-level `cdpInspect.enabled` is false.",
+      ),
+    cooldownMs: z
+      .number({
+        error: "hostBrowser.cdpInspect.desktopAuto.cooldownMs must be a number",
+      })
+      .int("hostBrowser.cdpInspect.desktopAuto.cooldownMs must be an integer")
+      .min(0, "hostBrowser.cdpInspect.desktopAuto.cooldownMs must be >= 0")
+      .max(
+        300_000,
+        "hostBrowser.cdpInspect.desktopAuto.cooldownMs must be <= 300000",
+      )
+      .default(30_000)
+      .describe(
+        "Duration (in milliseconds) to suppress automatic cdp-inspect probes after a transport-level failure. While on cooldown the factory skips the cdp-inspect candidate and goes straight to the local backend. Set to 0 to disable cooldown (always probe).",
+      ),
+  })
+  .describe("Auto-attempt policy for cdp-inspect on macOS-originated turns.");
+
+export type DesktopAutoCdpInspectConfig = z.infer<
+  typeof DesktopAutoCdpInspectConfigSchema
+>;
+
+/**
  * Configuration for the `cdp-inspect` browser backend — connects directly
  * to a host Chrome instance that was launched with `--remote-debugging-port`
  * (e.g. `chrome://inspect`-style remote debugging) as an alternative to the
@@ -41,6 +84,9 @@ export const HostBrowserCdpInspectConfigSchema = z
       .describe(
         "Timeout (in milliseconds) for the backend availability probe. Kept small so browser tool calls fail fast when the endpoint is unreachable.",
       ),
+    desktopAuto: DesktopAutoCdpInspectConfigSchema.default(
+      DesktopAutoCdpInspectConfigSchema.parse({}),
+    ),
   })
   .describe(
     "Settings for the cdp-inspect backend that connects to a host Chrome instance via its remote-debugging endpoint.",

--- a/assistant/src/tools/browser/cdp-client/__tests__/factory.test.ts
+++ b/assistant/src/tools/browser/cdp-client/__tests__/factory.test.ts
@@ -65,11 +65,12 @@ const createCdpInspectClientMock = mock(
 );
 
 /**
- * Mutable config state. Tests flip `cdpInspectEnabled` to control
- * the factory's config-based selection without needing a real config
- * file.
+ * Mutable config state. Tests flip `cdpInspectEnabled` and
+ * `desktopAutoConfig` to control the factory's config-based selection
+ * without needing a real config file.
  */
 let cdpInspectEnabled = false;
+let desktopAutoConfig = { enabled: true, cooldownMs: 30_000 };
 
 mock.module("../extension-cdp-client.js", () => ({
   createExtensionCdpClient: createExtensionCdpClientMock,
@@ -88,6 +89,7 @@ mock.module("../../../../config/loader.js", () => ({
         host: "localhost",
         port: 9222,
         probeTimeoutMs: 500,
+        desktopAuto: desktopAutoConfig,
       },
     },
   }),
@@ -95,8 +97,15 @@ mock.module("../../../../config/loader.js", () => ({
 
 // Import under test AFTER mock.module calls so that the factory's
 // top-level imports resolve to our fakes.
-const { getCdpClient, buildCandidateList, buildChainedClient } =
-  await import("../factory.js");
+const {
+  getCdpClient,
+  buildCandidateList,
+  buildChainedClient,
+  _resetDesktopAutoCooldown,
+  _getDesktopAutoCooldownSince,
+  recordDesktopAutoCooldown,
+  isDesktopAutoCooldownActive,
+} = await import("../factory.js");
 
 /**
  * Minimal ToolContext suitable for factory tests. Only the fields the
@@ -139,6 +148,8 @@ describe("getCdpClient", () => {
     lastLocalClient = undefined;
     lastCdpInspectClient = undefined;
     cdpInspectEnabled = false;
+    desktopAutoConfig = { enabled: true, cooldownMs: 30_000 };
+    _resetDesktopAutoCooldown();
   });
 
   // ── Candidate selection (kind reported before first send) ────────────
@@ -565,6 +576,8 @@ describe("getCdpClient", () => {
 describe("buildCandidateList", () => {
   beforeEach(() => {
     cdpInspectEnabled = false;
+    desktopAutoConfig = { enabled: true, cooldownMs: 30_000 };
+    _resetDesktopAutoCooldown();
   });
 
   test("includes extension candidate when proxy is present and available", () => {
@@ -642,6 +655,8 @@ describe("buildChainedClient failover", () => {
     lastLocalClient = undefined;
     lastCdpInspectClient = undefined;
     cdpInspectEnabled = false;
+    desktopAutoConfig = { enabled: true, cooldownMs: 30_000 };
+    _resetDesktopAutoCooldown();
   });
 
   test("fails over from extension to local on transport_error", async () => {
@@ -937,5 +952,243 @@ describe("buildChainedClient failover", () => {
     // failover (via manager.disposeAll()), and local's dispose should
     // be called now
     expect(lastLocalClient?.dispose).toHaveBeenCalled();
+  });
+});
+
+// ── Desktop-auto cdp-inspect for macOS ──────────────────────────────────
+
+describe("desktop-auto cdp-inspect (macOS)", () => {
+  beforeEach(() => {
+    createExtensionCdpClientMock.mockClear();
+    createLocalCdpClientMock.mockClear();
+    createCdpInspectClientMock.mockClear();
+    lastExtensionClient = undefined;
+    lastLocalClient = undefined;
+    lastCdpInspectClient = undefined;
+    cdpInspectEnabled = false;
+    desktopAutoConfig = { enabled: true, cooldownMs: 30_000 };
+    _resetDesktopAutoCooldown();
+  });
+
+  // ── buildCandidateList with desktopAuto ─────────────────────────────
+
+  test("macOS turn includes cdp-inspect candidate even when enabled is false", () => {
+    const ctx = makeContext({
+      conversationId: "macos-auto",
+      transportInterface: "macos",
+    });
+
+    const candidates = buildCandidateList(ctx);
+
+    expect(candidates.length).toBe(2);
+    expect(candidates[0].kind).toBe("cdp-inspect");
+    expect(candidates[0].reason).toContain("desktopAuto");
+    expect(candidates[1].kind).toBe("local");
+  });
+
+  test("macOS turn with extension available: extension > cdp-inspect > local", () => {
+    const fakeProxy = makeAvailableProxy();
+    const ctx = makeContext({
+      conversationId: "macos-all",
+      hostBrowserProxy: fakeProxy,
+      transportInterface: "macos",
+    });
+
+    const candidates = buildCandidateList(ctx);
+
+    expect(candidates.length).toBe(3);
+    expect(candidates[0].kind).toBe("extension");
+    expect(candidates[1].kind).toBe("cdp-inspect");
+    expect(candidates[1].reason).toContain("desktopAuto");
+    expect(candidates[2].kind).toBe("local");
+  });
+
+  test("macOS turn does NOT include cdp-inspect when desktopAuto.enabled is false", () => {
+    desktopAutoConfig = { enabled: false, cooldownMs: 30_000 };
+    const ctx = makeContext({
+      conversationId: "macos-no-auto",
+      transportInterface: "macos",
+    });
+
+    const candidates = buildCandidateList(ctx);
+
+    expect(candidates.length).toBe(1);
+    expect(candidates[0].kind).toBe("local");
+  });
+
+  test("non-macOS turn does NOT include cdp-inspect when enabled is false", () => {
+    const ctx = makeContext({
+      conversationId: "cli-no-auto",
+      transportInterface: "cli",
+    });
+
+    const candidates = buildCandidateList(ctx);
+
+    expect(candidates.length).toBe(1);
+    expect(candidates[0].kind).toBe("local");
+  });
+
+  test("non-macOS turn without transportInterface does NOT include cdp-inspect", () => {
+    const ctx = makeContext({
+      conversationId: "no-interface-no-auto",
+    });
+
+    const candidates = buildCandidateList(ctx);
+
+    expect(candidates.length).toBe(1);
+    expect(candidates[0].kind).toBe("local");
+  });
+
+  test("explicit cdpInspect.enabled takes precedence over desktopAuto on macOS", () => {
+    cdpInspectEnabled = true;
+    const ctx = makeContext({
+      conversationId: "macos-explicit",
+      transportInterface: "macos",
+    });
+
+    const candidates = buildCandidateList(ctx);
+
+    // Should include cdp-inspect via the explicit path, not desktopAuto
+    expect(candidates.length).toBe(2);
+    expect(candidates[0].kind).toBe("cdp-inspect");
+    expect(candidates[0].reason).toBe("cdpInspect enabled in config");
+    expect(candidates[1].kind).toBe("local");
+  });
+
+  // ── Cooldown behaviour ──────────────────────────────────────────────
+
+  test("macOS turn skips cdp-inspect when cooldown is active", () => {
+    // Record a cooldown
+    recordDesktopAutoCooldown();
+
+    const ctx = makeContext({
+      conversationId: "macos-cooldown",
+      transportInterface: "macos",
+    });
+
+    const candidates = buildCandidateList(ctx);
+
+    // Should skip cdp-inspect and only include local
+    expect(candidates.length).toBe(1);
+    expect(candidates[0].kind).toBe("local");
+  });
+
+  test("macOS turn includes cdp-inspect after cooldown expires", () => {
+    // Set cooldown to 0 (disabled)
+    desktopAutoConfig = { enabled: true, cooldownMs: 0 };
+
+    // Record a "cooldown" -- but with cooldownMs=0 it should be ignored
+    recordDesktopAutoCooldown();
+
+    const ctx = makeContext({
+      conversationId: "macos-expired-cooldown",
+      transportInterface: "macos",
+    });
+
+    const candidates = buildCandidateList(ctx);
+
+    // cooldownMs=0 means never suppress
+    expect(candidates.length).toBe(2);
+    expect(candidates[0].kind).toBe("cdp-inspect");
+    expect(candidates[1].kind).toBe("local");
+  });
+
+  // ── Cooldown recording on transport failures ───────────────────────
+
+  test("desktop-auto cdp-inspect transport failure records cooldown", async () => {
+    // Make cdp-inspect fail with transport_error
+    createCdpInspectClientMock.mockImplementationOnce(
+      (conversationId: string) => {
+        const c = makeFakeCdpInspectClient(conversationId);
+        c.send = mock(async () => {
+          throw new CdpError("transport_error", "Connection refused", {
+            cdpMethod: "Page.navigate",
+          });
+        });
+        lastCdpInspectClient = c;
+        return c;
+      },
+    );
+
+    const ctx = makeContext({
+      conversationId: "macos-cooldown-record",
+      transportInterface: "macos",
+    });
+
+    const client = getCdpClient(ctx);
+
+    // First send: cdp-inspect fails, falls over to local
+    const result = await client.send<{ ok: boolean; via: string }>(
+      "Page.navigate",
+    );
+    expect(result).toEqual({ ok: true, via: "local" });
+
+    // Cooldown should now be active
+    expect(_getDesktopAutoCooldownSince()).toBeGreaterThan(0);
+    expect(isDesktopAutoCooldownActive(30_000)).toBe(true);
+
+    // Subsequent buildCandidateList should skip cdp-inspect
+    client.dispose();
+    const ctx2 = makeContext({
+      conversationId: "macos-after-cooldown",
+      transportInterface: "macos",
+    });
+    const candidates = buildCandidateList(ctx2);
+    expect(candidates.length).toBe(1);
+    expect(candidates[0].kind).toBe("local");
+  });
+
+  test("explicit config cdp-inspect failure does NOT record desktop-auto cooldown", async () => {
+    cdpInspectEnabled = true;
+
+    // Make cdp-inspect fail with transport_error
+    createCdpInspectClientMock.mockImplementationOnce(
+      (conversationId: string) => {
+        const c = makeFakeCdpInspectClient(conversationId);
+        c.send = mock(async () => {
+          throw new CdpError("transport_error", "Connection refused", {
+            cdpMethod: "Page.navigate",
+          });
+        });
+        lastCdpInspectClient = c;
+        return c;
+      },
+    );
+
+    const ctx = makeContext({
+      conversationId: "explicit-no-cooldown",
+      transportInterface: "macos",
+    });
+
+    const client = getCdpClient(ctx);
+    await client.send<{ ok: boolean; via: string }>("Page.navigate");
+    client.dispose();
+
+    // Cooldown should NOT be recorded for explicit config candidates
+    expect(_getDesktopAutoCooldownSince()).toBe(0);
+  });
+
+  // ── Cooldown utility function tests ─────────────────────────────────
+
+  test("isDesktopAutoCooldownActive returns false when no cooldown recorded", () => {
+    expect(isDesktopAutoCooldownActive(30_000)).toBe(false);
+  });
+
+  test("isDesktopAutoCooldownActive returns false when cooldownMs is 0", () => {
+    recordDesktopAutoCooldown();
+    expect(isDesktopAutoCooldownActive(0)).toBe(false);
+  });
+
+  test("isDesktopAutoCooldownActive returns true within the window", () => {
+    recordDesktopAutoCooldown();
+    expect(isDesktopAutoCooldownActive(30_000)).toBe(true);
+  });
+
+  test("_resetDesktopAutoCooldown clears the cooldown", () => {
+    recordDesktopAutoCooldown();
+    expect(isDesktopAutoCooldownActive(30_000)).toBe(true);
+    _resetDesktopAutoCooldown();
+    expect(isDesktopAutoCooldownActive(30_000)).toBe(false);
+    expect(_getDesktopAutoCooldownSince()).toBe(0);
   });
 });

--- a/assistant/src/tools/browser/cdp-client/factory.ts
+++ b/assistant/src/tools/browser/cdp-client/factory.ts
@@ -40,8 +40,8 @@ let _desktopAutoCooldownSince = 0;
 
 /**
  * Record a cooldown after a desktop-auto cdp-inspect transport failure.
- * Exported for testing -- production code should call
- * {@link recordDesktopAutoCooldown} instead.
+ * Called by {@link maybeRecordDesktopAutoCooldown} in production; also
+ * exported directly for use in tests.
  */
 export function recordDesktopAutoCooldown(): void {
   _desktopAutoCooldownSince = Date.now();

--- a/assistant/src/tools/browser/cdp-client/factory.ts
+++ b/assistant/src/tools/browser/cdp-client/factory.ts
@@ -23,6 +23,58 @@ import type {
 
 const log = getLogger("cdp-factory");
 
+// ---------------------------------------------------------------------------
+// Desktop-auto cdp-inspect cooldown tracker
+// ---------------------------------------------------------------------------
+
+/**
+ * Module-level timestamp (epoch ms) of the last transport-level failure for
+ * a desktop-auto cdp-inspect attempt. While `Date.now() - _desktopAutoCooldownSince`
+ * is less than the configured `desktopAuto.cooldownMs`, the factory skips the
+ * automatic cdp-inspect candidate and goes straight to the local backend.
+ *
+ * Reset to 0 when the cooldown expires or when manually cleared via
+ * {@link _resetDesktopAutoCooldown} (for testing).
+ */
+let _desktopAutoCooldownSince = 0;
+
+/**
+ * Record a cooldown after a desktop-auto cdp-inspect transport failure.
+ * Exported for testing -- production code should call
+ * {@link recordDesktopAutoCooldown} instead.
+ */
+export function recordDesktopAutoCooldown(): void {
+  _desktopAutoCooldownSince = Date.now();
+}
+
+/**
+ * Whether the desktop-auto cdp-inspect cooldown is currently active.
+ * Returns `true` if a failure was recorded and the configured cooldown
+ * window has not yet elapsed.
+ */
+export function isDesktopAutoCooldownActive(cooldownMs: number): boolean {
+  if (_desktopAutoCooldownSince === 0 || cooldownMs <= 0) return false;
+  return Date.now() - _desktopAutoCooldownSince < cooldownMs;
+}
+
+/**
+ * Reset the desktop-auto cooldown state. Exported for testing only.
+ */
+export function _resetDesktopAutoCooldown(): void {
+  _desktopAutoCooldownSince = 0;
+}
+
+/**
+ * Get the raw cooldown-since timestamp. Exported for testing only.
+ */
+export function _getDesktopAutoCooldownSince(): number {
+  return _desktopAutoCooldownSince;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
 /**
  * Select the appropriate CdpClient implementation for a tool
  * invocation based on the ToolContext and config. Three backends are
@@ -36,6 +88,9 @@ const log = getLogger("cdp-factory");
  *  2. **cdp-inspect** -- When `hostBrowser.cdpInspect.enabled` is
  *     `true` in config, construct a `CdpInspectClient` that attaches
  *     to an already-running Chrome via the DevTools JSON protocol.
+ *     On macOS, cdp-inspect is also included automatically when
+ *     `desktopAuto.enabled` is true (the default), even when the
+ *     top-level `enabled` flag is false.
  *  3. **Local** -- Default. Drives Playwright's CDPSession against
  *     the sacrificial-profile browser managed by browserManager.
  *
@@ -120,9 +175,10 @@ export function buildCandidateList(context: ToolContext): BackendCandidate[] {
     );
   }
 
-  // 2. cdp-inspect -- opt-in via config.
+  // 2. cdp-inspect -- opt-in via config OR desktop-auto for macOS turns.
   const cdpInspectConfig = getConfig().hostBrowser.cdpInspect;
   if (cdpInspectConfig.enabled) {
+    // Explicitly enabled in config -- always include regardless of platform.
     candidates.push({
       kind: "cdp-inspect",
       reason: "cdpInspect enabled in config",
@@ -141,6 +197,42 @@ export function buildCandidateList(context: ToolContext): BackendCandidate[] {
         return { client, backend };
       },
     });
+  } else if (
+    context.transportInterface === "macos" &&
+    cdpInspectConfig.desktopAuto.enabled
+  ) {
+    // macOS desktop-auto: include cdp-inspect as a candidate unless the
+    // cooldown from a recent failure is still active.
+    const { cooldownMs } = cdpInspectConfig.desktopAuto;
+    if (isDesktopAutoCooldownActive(cooldownMs)) {
+      log.debug(
+        {
+          conversationId,
+          cooldownMs,
+          cooldownSince: _desktopAutoCooldownSince,
+        },
+        "CDP factory: desktop-auto cdp-inspect skipped (cooldown active)",
+      );
+    } else {
+      candidates.push({
+        kind: "cdp-inspect",
+        reason: "desktopAuto: macOS turn, cdp-inspect auto-attempted",
+        create() {
+          const client = createCdpInspectClient(conversationId, {
+            host: cdpInspectConfig.host,
+            port: cdpInspectConfig.port,
+            discoveryTimeoutMs: cdpInspectConfig.probeTimeoutMs,
+          });
+          const backend = createCdpInspectBackend({
+            isAvailable: () => true,
+            sendCdp: (command, signal) =>
+              dispatchThroughClient(client, command, signal),
+            dispose: () => client.dispose(),
+          });
+          return { client, backend };
+        },
+      });
+    }
   }
 
   // 3. Local -- always present as the final fallback.
@@ -271,6 +363,10 @@ export function buildChainedClient(
  * Walk the candidate list attempting to execute a single CDP command.
  * Transport-level failures trigger failover to the next candidate;
  * CDP protocol errors propagate immediately.
+ *
+ * When a desktop-auto cdp-inspect candidate fails with a transport
+ * error, the factory records a cooldown so subsequent calls skip the
+ * probe until the window expires.
  */
 async function sendWithFailover<T>(
   candidates: BackendCandidate[],
@@ -323,6 +419,7 @@ async function sendWithFailover<T>(
         `Backend ${candidate.kind} construction failed: ${err instanceof Error ? err.message : String(err)}`,
         { cdpMethod: method, cdpParams: params, underlying: err },
       );
+      maybeRecordDesktopAutoCooldown(candidate);
       continue;
     }
 
@@ -347,6 +444,7 @@ async function sendWithFailover<T>(
         `Backend ${candidate.kind} send threw: ${err instanceof Error ? err.message : String(err)}`,
         { cdpMethod: method, cdpParams: params, underlying: err },
       );
+      maybeRecordDesktopAutoCooldown(candidate);
       continue;
     }
 
@@ -367,6 +465,7 @@ async function sendWithFailover<T>(
         );
         manager.disposeAll();
         lastError = cdpError;
+        maybeRecordDesktopAutoCooldown(candidate);
         continue;
       }
 
@@ -392,6 +491,22 @@ async function sendWithFailover<T>(
       cdpParams: params,
     })
   );
+}
+
+/**
+ * If the failed candidate is a desktop-auto cdp-inspect attempt,
+ * record the cooldown so subsequent calls skip the probe.
+ */
+function maybeRecordDesktopAutoCooldown(candidate: BackendCandidate): void {
+  if (
+    candidate.kind === "cdp-inspect" &&
+    candidate.reason.startsWith("desktopAuto:")
+  ) {
+    log.debug(
+      "CDP factory: recording desktop-auto cdp-inspect cooldown after transport failure",
+    );
+    recordDesktopAutoCooldown();
+  }
 }
 
 /**

--- a/assistant/src/tools/browser/cdp-client/factory.ts
+++ b/assistant/src/tools/browser/cdp-client/factory.ts
@@ -222,6 +222,7 @@ export function buildCandidateList(context: ToolContext): BackendCandidate[] {
             host: cdpInspectConfig.host,
             port: cdpInspectConfig.port,
             discoveryTimeoutMs: cdpInspectConfig.probeTimeoutMs,
+            wsConnectTimeoutMs: cdpInspectConfig.probeTimeoutMs,
           });
           const backend = createCdpInspectBackend({
             isAvailable: () => true,


### PR DESCRIPTION
## Summary
- Add hostBrowser.cdpInspect.desktopAuto config with cooldown knob for macOS
- Update factory candidate list to include cdp-inspect for macOS turns automatically
- Implement cooldown on unreachable failures to avoid repeated attach penalties
- Preserve non-macOS behavior: no implicit cdp-inspect unless explicitly enabled

Part of plan: macos-browser-extension-cdp-fallback.md (PR 5 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24754" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
