### PR TITLE
fix: scope filter bypass to surviving results, fix ordering race, optimistic spinner

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
@@ -62,8 +62,8 @@ final class SkillsManager {
 
     var searchQuery: String = "" {
         didSet {
-            recomputeFilteredData()
             dispatchSearch(query: searchQuery)
+            recomputeFilteredData()
         }
     }
 
@@ -246,7 +246,8 @@ final class SkillsManager {
             // text doesn't appear as a literal substring (e.g. skills.sh
             // results with empty descriptions). Skip the local filter in
             // that case and show the full merged list.
-            let backendResultsPresent = !skillsStore.searchResults.isEmpty && !skillsStore.isSearching
+            let backendIds = Set(skillsStore.searchResults.map(\.id))
+            let backendResultsPresent = !skillsStore.isSearching && baseSkills.contains(where: { backendIds.contains($0.id) })
             if backendResultsPresent {
                 searchFiltered = baseSkills
             } else {
@@ -312,7 +313,13 @@ final class SkillsManager {
         // don't linger during the debounce window or after clearing the bar.
         skillsStore.searchResults = []
         let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return }
+        guard !trimmed.isEmpty else {
+            isSearching = false
+            return
+        }
+        // Show spinner immediately during the debounce window so the user
+        // doesn't see the "No Skills Available" empty state for 300ms.
+        isSearching = true
         searchDebounceTask = Task {
             try? await Task.sleep(nanoseconds: 300_000_000)
             guard !Task.isCancelled else { return }


### PR DESCRIPTION
## Summary
Fixes three gaps from self-review round 2 of skills-search-all-sources.md.

**Gap 1:** backendResultsPresent now checks whether backend result IDs exist in baseSkills, not just globally. Fixes search being ignored when Installed/Vellum/Custom filters are active.
**Gap 2:** Swapped didSet order to clear stale searchResults before recomputeFilteredData runs.
**Gap 3:** Set isSearching=true optimistically in dispatchSearch so spinner shows during 300ms debounce.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24757" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
