### PR TITLE
Implement ElevenLabs and Fish Audio adapters on the new TTS interface

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -217,6 +217,7 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "providers/speech-to-text/resolve.ts", // STT provider API key lookup
       "daemon/lifecycle.ts", // CES client injection into secure-keys at startup
       "inbound/platform-callback-registration.ts", // managed credential lookup for platform base URL, assistant ID, and API key
+      "tts/providers/elevenlabs-provider.ts", // ElevenLabs TTS API key lookup
     ]);
 
     const thisDir = dirname(fileURLToPath(import.meta.url));

--- a/assistant/src/tts/__tests__/provider-adapters.test.ts
+++ b/assistant/src/tts/__tests__/provider-adapters.test.ts
@@ -1,0 +1,567 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Module mocks — must appear before any imports of the modules under test
+// ---------------------------------------------------------------------------
+
+mock.module("../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// -- Config mock -----------------------------------------------------------
+
+let mockElevenLabsConfig = {
+  voiceId: "test-voice-id",
+  voiceModelId: "",
+  speed: 1.0,
+  stability: 0.5,
+  similarityBoost: 0.75,
+  conversationTimeoutSeconds: 30,
+};
+
+let mockFishAudioConfig = {
+  referenceId: "test-reference-id",
+  chunkLength: 200,
+  format: "mp3" as "mp3" | "wav" | "opus",
+  latency: "normal" as "normal" | "balanced",
+  speed: 1.0,
+};
+
+mock.module("../../config/loader.js", () => ({
+  getConfig: () => ({
+    elevenlabs: mockElevenLabsConfig,
+    fishAudio: mockFishAudioConfig,
+  }),
+}));
+
+// -- Secure keys mock ------------------------------------------------------
+
+let mockApiKey: string | null = "test-elevenlabs-api-key";
+
+mock.module("../../security/secure-keys.js", () => ({
+  getSecureKeyAsync: async () => mockApiKey,
+}));
+
+mock.module("../../security/credential-key.js", () => ({
+  credentialKey: (service: string, field: string) =>
+    `credential/${service}/${field}`,
+}));
+
+// -- Fish Audio client mock ------------------------------------------------
+
+const mockSynthesizeWithFishAudio = mock(
+  async (
+    _text: string,
+    _config: unknown,
+    options?: { onChunk?: (chunk: Uint8Array) => void; signal?: AbortSignal },
+  ) => {
+    const audioData = Buffer.from("fake-fish-audio-data");
+    if (options?.onChunk) {
+      options.onChunk(new Uint8Array(audioData));
+    }
+    return audioData;
+  },
+);
+
+mock.module("../../calls/fish-audio-client.js", () => ({
+  synthesizeWithFishAudio: mockSynthesizeWithFishAudio,
+}));
+
+// ---------------------------------------------------------------------------
+// Imports (after mocks)
+// ---------------------------------------------------------------------------
+
+import {
+  _resetTtsProviderRegistry,
+  getTtsProvider,
+  listTtsProviders,
+} from "../provider-registry.js";
+import { createElevenLabsProvider } from "../providers/elevenlabs-provider.js";
+import { ElevenLabsTtsError } from "../providers/elevenlabs-provider.js";
+import { createFishAudioProvider } from "../providers/fish-audio-provider.js";
+import { FishAudioTtsError } from "../providers/fish-audio-provider.js";
+import {
+  _resetBuiltinRegistration,
+  registerBuiltinTtsProviders,
+} from "../providers/register-builtins.js";
+import type { TtsSynthesisRequest } from "../types.js";
+
+// ---------------------------------------------------------------------------
+// Fetch mock helpers
+// ---------------------------------------------------------------------------
+
+let originalFetch: typeof globalThis.fetch;
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+  mockApiKey = "test-elevenlabs-api-key";
+  mockElevenLabsConfig = {
+    voiceId: "test-voice-id",
+    voiceModelId: "",
+    speed: 1.0,
+    stability: 0.5,
+    similarityBoost: 0.75,
+    conversationTimeoutSeconds: 30,
+  };
+  mockFishAudioConfig = {
+    referenceId: "test-reference-id",
+    chunkLength: 200,
+    format: "mp3",
+    latency: "normal",
+    speed: 1.0,
+  };
+  mockSynthesizeWithFishAudio.mockClear();
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  _resetTtsProviderRegistry();
+  _resetBuiltinRegistration();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeRequest(
+  overrides?: Partial<TtsSynthesisRequest>,
+): TtsSynthesisRequest {
+  return {
+    text: "Hello world",
+    useCase: "message-playback",
+    ...overrides,
+  };
+}
+
+function mockFetchReturning(audioBytes: Uint8Array, status = 200): void {
+  globalThis.fetch = mock(
+    async () =>
+      new Response(audioBytes.buffer as ArrayBuffer, {
+        status,
+        headers: { "Content-Type": "audio/mpeg" },
+      }),
+  ) as unknown as typeof globalThis.fetch;
+}
+
+function mockFetchError(status: number, body: string): void {
+  globalThis.fetch = mock(
+    async () => new Response(body, { status }),
+  ) as unknown as typeof globalThis.fetch;
+}
+
+// ===========================================================================
+// ElevenLabs provider adapter
+// ===========================================================================
+
+describe("ElevenLabs TTS provider adapter", () => {
+  // -- Interface conformance -----------------------------------------------
+
+  test("has correct provider ID", () => {
+    const provider = createElevenLabsProvider();
+    expect(provider.id).toBe("elevenlabs");
+  });
+
+  test("advertises mp3 format support without streaming", () => {
+    const provider = createElevenLabsProvider();
+    expect(provider.capabilities.supportsStreaming).toBe(false);
+    expect(provider.capabilities.supportedFormats).toEqual(["mp3"]);
+  });
+
+  // -- Request mapping -----------------------------------------------------
+
+  test("synthesize sends request to ElevenLabs REST API with correct voice ID", async () => {
+    const audioPayload = new Uint8Array([0x49, 0x44, 0x33]); // Fake MP3 header
+    let capturedUrl = "";
+    let capturedHeaders: Headers | null = null;
+    let capturedBody = "";
+
+    globalThis.fetch = mock(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        capturedUrl = typeof input === "string" ? input : input.toString();
+        capturedHeaders = new Headers(init?.headers);
+        capturedBody = init?.body as string;
+        return new Response(audioPayload, {
+          status: 200,
+          headers: { "Content-Type": "audio/mpeg" },
+        });
+      },
+    ) as unknown as typeof globalThis.fetch;
+
+    const provider = createElevenLabsProvider();
+    await provider.synthesize(makeRequest());
+
+    expect(capturedUrl).toContain("/v1/text-to-speech/test-voice-id");
+    expect(capturedUrl).toContain("output_format=mp3_44100_128");
+    expect(capturedHeaders!.get("xi-api-key")).toBe("test-elevenlabs-api-key");
+    expect(capturedHeaders!.get("Content-Type")).toBe("application/json");
+
+    const body = JSON.parse(capturedBody);
+    expect(body.text).toBe("Hello world");
+    expect(body.voice_settings).toEqual({
+      stability: 0.5,
+      similarity_boost: 0.75,
+      speed: 1.0,
+    });
+  });
+
+  test("uses lower-quality format for phone-call use case", async () => {
+    const audioPayload = new Uint8Array([0x49, 0x44, 0x33]);
+    let capturedUrl = "";
+
+    globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+      capturedUrl = typeof input === "string" ? input : input.toString();
+      return new Response(audioPayload, { status: 200 });
+    }) as unknown as typeof globalThis.fetch;
+
+    const provider = createElevenLabsProvider();
+    await provider.synthesize(makeRequest({ useCase: "phone-call" }));
+
+    expect(capturedUrl).toContain("output_format=mp3_22050_32");
+  });
+
+  test("request voiceId overrides config voiceId", async () => {
+    const audioPayload = new Uint8Array([0x49, 0x44, 0x33]);
+    let capturedUrl = "";
+
+    globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+      capturedUrl = typeof input === "string" ? input : input.toString();
+      return new Response(audioPayload, { status: 200 });
+    }) as unknown as typeof globalThis.fetch;
+
+    const provider = createElevenLabsProvider();
+    await provider.synthesize(makeRequest({ voiceId: "override-voice" }));
+
+    expect(capturedUrl).toContain("/v1/text-to-speech/override-voice");
+  });
+
+  test("uses configured voiceModelId when set", async () => {
+    mockElevenLabsConfig.voiceModelId = "eleven_turbo_v2_5";
+
+    const audioPayload = new Uint8Array([0x49, 0x44, 0x33]);
+    let capturedBody = "";
+
+    globalThis.fetch = mock(
+      async (_input: RequestInfo | URL, init?: RequestInit) => {
+        capturedBody = init?.body as string;
+        return new Response(audioPayload, { status: 200 });
+      },
+    ) as unknown as typeof globalThis.fetch;
+
+    const provider = createElevenLabsProvider();
+    await provider.synthesize(makeRequest());
+
+    const body = JSON.parse(capturedBody);
+    expect(body.model_id).toBe("eleven_turbo_v2_5");
+  });
+
+  // -- Content type / format -----------------------------------------------
+
+  test("returns audio/mpeg content type for mp3 format", async () => {
+    const audioPayload = new Uint8Array([0x49, 0x44, 0x33]);
+    mockFetchReturning(audioPayload);
+
+    const provider = createElevenLabsProvider();
+    const result = await provider.synthesize(makeRequest());
+
+    expect(result.contentType).toBe("audio/mpeg");
+    expect(result.audio.byteLength).toBeGreaterThan(0);
+  });
+
+  // -- Required config validation ------------------------------------------
+
+  test("throws ELEVENLABS_TTS_NO_API_KEY when API key is missing", async () => {
+    mockApiKey = null;
+
+    const provider = createElevenLabsProvider();
+
+    try {
+      await provider.synthesize(makeRequest());
+      throw new Error("Expected synthesize to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ElevenLabsTtsError);
+      expect((err as ElevenLabsTtsError).code).toBe(
+        "ELEVENLABS_TTS_NO_API_KEY",
+      );
+      expect((err as ElevenLabsTtsError).message).toContain(
+        "API key not configured",
+      );
+    }
+  });
+
+  // -- Error handling ------------------------------------------------------
+
+  test("throws ELEVENLABS_TTS_HTTP_ERROR on non-200 response", async () => {
+    mockFetchError(401, "Unauthorized");
+
+    const provider = createElevenLabsProvider();
+
+    try {
+      await provider.synthesize(makeRequest());
+      throw new Error("Expected synthesize to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ElevenLabsTtsError);
+      expect((err as ElevenLabsTtsError).code).toBe(
+        "ELEVENLABS_TTS_HTTP_ERROR",
+      );
+      expect((err as ElevenLabsTtsError).statusCode).toBe(401);
+    }
+  });
+
+  test("throws ELEVENLABS_TTS_EMPTY_RESPONSE on empty audio body", async () => {
+    mockFetchReturning(new Uint8Array(0));
+
+    const provider = createElevenLabsProvider();
+
+    try {
+      await provider.synthesize(makeRequest());
+      throw new Error("Expected synthesize to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ElevenLabsTtsError);
+      expect((err as ElevenLabsTtsError).code).toBe(
+        "ELEVENLABS_TTS_EMPTY_RESPONSE",
+      );
+    }
+  });
+
+  test("throws ELEVENLABS_TTS_REQUEST_FAILED on network error", async () => {
+    globalThis.fetch = mock(async () => {
+      throw new Error("Network unreachable");
+    }) as unknown as typeof globalThis.fetch;
+
+    const provider = createElevenLabsProvider();
+
+    try {
+      await provider.synthesize(makeRequest());
+      throw new Error("Expected synthesize to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ElevenLabsTtsError);
+      expect((err as ElevenLabsTtsError).code).toBe(
+        "ELEVENLABS_TTS_REQUEST_FAILED",
+      );
+      expect((err as ElevenLabsTtsError).message).toContain(
+        "Network unreachable",
+      );
+    }
+  });
+});
+
+// ===========================================================================
+// Fish Audio TTS provider adapter
+// ===========================================================================
+
+describe("Fish Audio TTS provider adapter", () => {
+  // -- Interface conformance -----------------------------------------------
+
+  test("has correct provider ID", () => {
+    const provider = createFishAudioProvider();
+    expect(provider.id).toBe("fish-audio");
+  });
+
+  test("advertises streaming support with multiple formats", () => {
+    const provider = createFishAudioProvider();
+    expect(provider.capabilities.supportsStreaming).toBe(true);
+    expect(provider.capabilities.supportedFormats).toEqual([
+      "mp3",
+      "wav",
+      "opus",
+    ]);
+  });
+
+  test("implements synthesizeStream", () => {
+    const provider = createFishAudioProvider();
+    expect(typeof provider.synthesizeStream).toBe("function");
+  });
+
+  // -- Request mapping -----------------------------------------------------
+
+  test("synthesize passes text and config to underlying client", async () => {
+    const provider = createFishAudioProvider();
+    await provider.synthesize(makeRequest({ text: "Test speech" }));
+
+    expect(mockSynthesizeWithFishAudio).toHaveBeenCalledTimes(1);
+    const [text, config, options] = mockSynthesizeWithFishAudio.mock.calls[0]!;
+    expect(text).toBe("Test speech");
+    expect((config as { referenceId: string }).referenceId).toBe(
+      "test-reference-id",
+    );
+    expect(
+      (options as { signal?: AbortSignal } | undefined)?.signal,
+    ).toBeUndefined();
+  });
+
+  test("request voiceId overrides config referenceId", async () => {
+    const provider = createFishAudioProvider();
+    await provider.synthesize(makeRequest({ voiceId: "custom-ref-id" }));
+
+    const [, config] = mockSynthesizeWithFishAudio.mock.calls[0]!;
+    expect((config as { referenceId: string }).referenceId).toBe(
+      "custom-ref-id",
+    );
+  });
+
+  test("passes abort signal to underlying client", async () => {
+    const controller = new AbortController();
+    const provider = createFishAudioProvider();
+    await provider.synthesize(makeRequest({ signal: controller.signal }));
+
+    const [, , options] = mockSynthesizeWithFishAudio.mock.calls[0]!;
+    expect((options as { signal?: AbortSignal } | undefined)?.signal).toBe(
+      controller.signal,
+    );
+  });
+
+  // -- Streaming -----------------------------------------------------------
+
+  test("synthesizeStream passes onChunk callback through", async () => {
+    const chunks: Uint8Array[] = [];
+    const provider = createFishAudioProvider();
+    await provider.synthesizeStream!(makeRequest(), (chunk) =>
+      chunks.push(chunk),
+    );
+
+    expect(mockSynthesizeWithFishAudio).toHaveBeenCalledTimes(1);
+    const [, , options] = mockSynthesizeWithFishAudio.mock.calls[0]!;
+    expect(typeof (options as { onChunk?: unknown } | undefined)?.onChunk).toBe(
+      "function",
+    );
+    // The mock calls onChunk once; verify it was received
+    expect(chunks.length).toBeGreaterThan(0);
+  });
+
+  // -- Content type / format -----------------------------------------------
+
+  test("returns audio/mpeg content type for mp3 format", async () => {
+    mockFishAudioConfig.format = "mp3";
+    const provider = createFishAudioProvider();
+    const result = await provider.synthesize(makeRequest());
+    expect(result.contentType).toBe("audio/mpeg");
+  });
+
+  test("returns audio/wav content type for wav format", async () => {
+    mockFishAudioConfig.format = "wav";
+    const provider = createFishAudioProvider();
+    const result = await provider.synthesize(makeRequest());
+    expect(result.contentType).toBe("audio/wav");
+  });
+
+  test("returns audio/opus content type for opus format", async () => {
+    mockFishAudioConfig.format = "opus";
+    const provider = createFishAudioProvider();
+    const result = await provider.synthesize(makeRequest());
+    expect(result.contentType).toBe("audio/opus");
+  });
+
+  // -- Required config validation ------------------------------------------
+
+  test("throws FISH_AUDIO_TTS_NO_REFERENCE_ID when no reference ID is available", async () => {
+    mockFishAudioConfig.referenceId = "";
+
+    const provider = createFishAudioProvider();
+
+    try {
+      await provider.synthesize(makeRequest());
+      throw new Error("Expected synthesize to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(FishAudioTtsError);
+      expect((err as FishAudioTtsError).code).toBe(
+        "FISH_AUDIO_TTS_NO_REFERENCE_ID",
+      );
+      expect((err as FishAudioTtsError).message).toContain("reference ID");
+    }
+  });
+
+  test("throws FISH_AUDIO_TTS_NO_REFERENCE_ID in synthesizeStream when no reference ID", async () => {
+    mockFishAudioConfig.referenceId = "";
+
+    const provider = createFishAudioProvider();
+
+    try {
+      await provider.synthesizeStream!(makeRequest(), () => {});
+      throw new Error("Expected synthesizeStream to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(FishAudioTtsError);
+      expect((err as FishAudioTtsError).code).toBe(
+        "FISH_AUDIO_TTS_NO_REFERENCE_ID",
+      );
+    }
+  });
+
+  // -- Error handling ------------------------------------------------------
+
+  test("wraps underlying client errors with FISH_AUDIO_TTS_SYNTHESIS_FAILED", async () => {
+    mockSynthesizeWithFishAudio.mockImplementationOnce(async () => {
+      throw new Error("API key not configured");
+    });
+
+    const provider = createFishAudioProvider();
+
+    try {
+      await provider.synthesize(makeRequest());
+      throw new Error("Expected synthesize to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(FishAudioTtsError);
+      expect((err as FishAudioTtsError).code).toBe(
+        "FISH_AUDIO_TTS_SYNTHESIS_FAILED",
+      );
+      expect((err as FishAudioTtsError).message).toContain(
+        "API key not configured",
+      );
+    }
+  });
+
+  test("wraps streaming client errors with FISH_AUDIO_TTS_SYNTHESIS_FAILED", async () => {
+    mockSynthesizeWithFishAudio.mockImplementationOnce(async () => {
+      throw new Error("Connection reset");
+    });
+
+    const provider = createFishAudioProvider();
+
+    try {
+      await provider.synthesizeStream!(makeRequest(), () => {});
+      throw new Error("Expected synthesizeStream to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(FishAudioTtsError);
+      expect((err as FishAudioTtsError).code).toBe(
+        "FISH_AUDIO_TTS_SYNTHESIS_FAILED",
+      );
+      expect((err as FishAudioTtsError).message).toContain("Connection reset");
+    }
+  });
+});
+
+// ===========================================================================
+// Built-in registration
+// ===========================================================================
+
+describe("registerBuiltinTtsProviders", () => {
+  test("registers elevenlabs and fish-audio providers", () => {
+    registerBuiltinTtsProviders();
+
+    const providers = listTtsProviders();
+    const ids = providers.map((p) => p.id);
+    expect(ids).toContain("elevenlabs");
+    expect(ids).toContain("fish-audio");
+  });
+
+  test("providers are discoverable via getTtsProvider after registration", () => {
+    registerBuiltinTtsProviders();
+
+    const el = getTtsProvider("elevenlabs");
+    expect(el.id).toBe("elevenlabs");
+
+    const fa = getTtsProvider("fish-audio");
+    expect(fa.id).toBe("fish-audio");
+  });
+
+  test("idempotent — calling twice does not throw", () => {
+    // First call registers; second should be a no-op due to the guard flag.
+    // However, because tests reset the registry via afterEach, the internal
+    // `registered` flag may still be true. We call it once here and verify
+    // it does not throw — that exercises the guard path.
+    registerBuiltinTtsProviders();
+    expect(() => registerBuiltinTtsProviders()).not.toThrow();
+  });
+});

--- a/assistant/src/tts/providers/elevenlabs-provider.ts
+++ b/assistant/src/tts/providers/elevenlabs-provider.ts
@@ -1,0 +1,198 @@
+/**
+ * ElevenLabs TTS provider adapter.
+ *
+ * Wraps the ElevenLabs REST text-to-speech API (`/v1/text-to-speech/:voiceId`)
+ * behind the uniform {@link TtsProvider} interface. Reads the API key from the
+ * secure credential store (`elevenlabs/api_key`) and the voice configuration
+ * from the workspace `elevenlabs` config section.
+ */
+
+import { getConfig } from "../../config/loader.js";
+import type { ElevenLabsConfig } from "../../config/schemas/elevenlabs.js";
+import { DEFAULT_ELEVENLABS_VOICE_ID } from "../../config/schemas/elevenlabs.js";
+import { credentialKey } from "../../security/credential-key.js";
+import { getSecureKeyAsync } from "../../security/secure-keys.js";
+import { getLogger } from "../../util/logger.js";
+import type {
+  TtsProvider,
+  TtsProviderCapabilities,
+  TtsSynthesisRequest,
+  TtsSynthesisResult,
+} from "../types.js";
+
+const log = getLogger("tts:elevenlabs");
+
+// ---------------------------------------------------------------------------
+// Error types
+// ---------------------------------------------------------------------------
+
+export type ElevenLabsTtsErrorCode =
+  | "ELEVENLABS_TTS_NO_API_KEY"
+  | "ELEVENLABS_TTS_NO_VOICE_ID"
+  | "ELEVENLABS_TTS_HTTP_ERROR"
+  | "ELEVENLABS_TTS_EMPTY_RESPONSE"
+  | "ELEVENLABS_TTS_REQUEST_FAILED";
+
+export class ElevenLabsTtsError extends Error {
+  readonly code: ElevenLabsTtsErrorCode;
+  readonly statusCode?: number;
+
+  constructor(
+    code: ElevenLabsTtsErrorCode,
+    message: string,
+    statusCode?: number,
+  ) {
+    super(message);
+    this.name = "ElevenLabsTtsError";
+    this.code = code;
+    this.statusCode = statusCode;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const ELEVENLABS_API_BASE = "https://api.elevenlabs.io";
+
+/** Map from request output format identifiers to MIME content types. */
+const FORMAT_CONTENT_TYPE: Record<string, string> = {
+  mp3_44100_128: "audio/mpeg",
+  mp3_22050_32: "audio/mpeg",
+  pcm_16000: "audio/pcm",
+  pcm_22050: "audio/pcm",
+  pcm_24000: "audio/pcm",
+  pcm_44100: "audio/pcm",
+  ulaw_8000: "audio/basic",
+};
+
+// ---------------------------------------------------------------------------
+// Provider implementation
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the effective voice ID for a synthesis request.
+ *
+ * Priority: request-level `voiceId` > config `voiceId` > built-in default.
+ */
+function resolveVoiceId(
+  request: TtsSynthesisRequest,
+  config: ElevenLabsConfig,
+): string {
+  const voiceId =
+    request.voiceId?.trim() || config.voiceId || DEFAULT_ELEVENLABS_VOICE_ID;
+  if (!voiceId) {
+    throw new ElevenLabsTtsError(
+      "ELEVENLABS_TTS_NO_VOICE_ID",
+      "No voice ID provided and no default configured. " +
+        "Set elevenlabs.voiceId in config or pass voiceId in the request.",
+    );
+  }
+  return voiceId;
+}
+
+/**
+ * Choose the ElevenLabs output format based on the use case.
+ *
+ * Phone calls benefit from lower-latency, smaller payloads (mp3 at 22050/32).
+ * Message playback uses higher quality (mp3 at 44100/128).
+ */
+function resolveOutputFormat(request: TtsSynthesisRequest): string {
+  return request.useCase === "phone-call" ? "mp3_22050_32" : "mp3_44100_128";
+}
+
+export function createElevenLabsProvider(): TtsProvider {
+  const capabilities: TtsProviderCapabilities = {
+    supportsStreaming: false,
+    supportedFormats: ["mp3"],
+  };
+
+  return {
+    id: "elevenlabs",
+    capabilities,
+
+    async synthesize(
+      request: TtsSynthesisRequest,
+    ): Promise<TtsSynthesisResult> {
+      const apiKey = await getSecureKeyAsync(
+        credentialKey("elevenlabs", "api_key"),
+      );
+      if (!apiKey) {
+        throw new ElevenLabsTtsError(
+          "ELEVENLABS_TTS_NO_API_KEY",
+          "ElevenLabs API key not configured. " +
+            "Store it via: assistant credentials set --service elevenlabs --field api_key <key>",
+        );
+      }
+
+      const config = getConfig().elevenlabs;
+      const voiceId = resolveVoiceId(request, config);
+      const outputFormat = resolveOutputFormat(request);
+
+      const url = `${ELEVENLABS_API_BASE}/v1/text-to-speech/${voiceId}`;
+
+      const body: Record<string, unknown> = {
+        text: request.text,
+        model_id: config.voiceModelId?.trim() || "eleven_multilingual_v2",
+        voice_settings: {
+          stability: config.stability,
+          similarity_boost: config.similarityBoost,
+          speed: config.speed,
+        },
+      };
+
+      log.info(
+        { voiceId, outputFormat, textLength: request.text.length },
+        "Starting ElevenLabs TTS synthesis",
+      );
+
+      let response: Response;
+      try {
+        response = await fetch(`${url}?output_format=${outputFormat}`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "xi-api-key": apiKey,
+            Accept: "audio/mpeg",
+          },
+          body: JSON.stringify(body),
+          signal: request.signal,
+        });
+      } catch (err) {
+        throw new ElevenLabsTtsError(
+          "ELEVENLABS_TTS_REQUEST_FAILED",
+          `ElevenLabs TTS request failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+
+      if (!response.ok) {
+        const errorText = await response.text().catch(() => "");
+        throw new ElevenLabsTtsError(
+          "ELEVENLABS_TTS_HTTP_ERROR",
+          `ElevenLabs TTS returned ${response.status}: ${errorText}`,
+          response.status,
+        );
+      }
+
+      const arrayBuffer = await response.arrayBuffer();
+      if (arrayBuffer.byteLength === 0) {
+        throw new ElevenLabsTtsError(
+          "ELEVENLABS_TTS_EMPTY_RESPONSE",
+          "ElevenLabs TTS returned an empty audio response",
+        );
+      }
+
+      const contentType = FORMAT_CONTENT_TYPE[outputFormat] ?? "audio/mpeg";
+
+      log.debug(
+        { bytes: arrayBuffer.byteLength },
+        "ElevenLabs TTS synthesis complete",
+      );
+
+      return {
+        audio: Buffer.from(arrayBuffer),
+        contentType,
+      };
+    },
+  };
+}

--- a/assistant/src/tts/providers/fish-audio-provider.ts
+++ b/assistant/src/tts/providers/fish-audio-provider.ts
@@ -1,0 +1,166 @@
+/**
+ * Fish Audio TTS provider adapter.
+ *
+ * Wraps the existing {@link synthesizeWithFishAudio} function behind the
+ * uniform {@link TtsProvider} interface, preserving its streaming chunk
+ * callbacks for real-time call playback.
+ *
+ * Config comes from the workspace `fishAudio` section. The API key is read
+ * from the secure credential store (`fish-audio/api_key`) by the underlying
+ * client.
+ */
+
+import { synthesizeWithFishAudio } from "../../calls/fish-audio-client.js";
+import { getConfig } from "../../config/loader.js";
+import type { FishAudioConfig } from "../../config/schemas/fish-audio.js";
+import { getLogger } from "../../util/logger.js";
+import type {
+  TtsProvider,
+  TtsProviderCapabilities,
+  TtsSynthesisRequest,
+  TtsSynthesisResult,
+} from "../types.js";
+
+const log = getLogger("tts:fish-audio");
+
+// ---------------------------------------------------------------------------
+// Error types
+// ---------------------------------------------------------------------------
+
+export type FishAudioTtsErrorCode =
+  | "FISH_AUDIO_TTS_NO_REFERENCE_ID"
+  | "FISH_AUDIO_TTS_SYNTHESIS_FAILED";
+
+export class FishAudioTtsError extends Error {
+  readonly code: FishAudioTtsErrorCode;
+
+  constructor(code: FishAudioTtsErrorCode, message: string) {
+    super(message);
+    this.name = "FishAudioTtsError";
+    this.code = code;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Map Fish Audio format names to MIME content types. */
+const FORMAT_CONTENT_TYPE: Record<string, string> = {
+  mp3: "audio/mpeg",
+  wav: "audio/wav",
+  opus: "audio/opus",
+};
+
+/**
+ * Resolve the effective reference ID.
+ *
+ * Priority: request-level `voiceId` > config `referenceId`.
+ */
+function resolveReferenceId(
+  request: TtsSynthesisRequest,
+  config: FishAudioConfig,
+): string {
+  const referenceId = request.voiceId?.trim() || config.referenceId;
+  if (!referenceId) {
+    throw new FishAudioTtsError(
+      "FISH_AUDIO_TTS_NO_REFERENCE_ID",
+      "No Fish Audio reference ID provided. " +
+        "Set fishAudio.referenceId in config or pass voiceId in the request.",
+    );
+  }
+  return referenceId;
+}
+
+// ---------------------------------------------------------------------------
+// Provider implementation
+// ---------------------------------------------------------------------------
+
+export function createFishAudioProvider(): TtsProvider {
+  const capabilities: TtsProviderCapabilities = {
+    supportsStreaming: true,
+    supportedFormats: ["mp3", "wav", "opus"],
+  };
+
+  return {
+    id: "fish-audio",
+    capabilities,
+
+    async synthesize(
+      request: TtsSynthesisRequest,
+    ): Promise<TtsSynthesisResult> {
+      const config = getConfig().fishAudio;
+      const referenceId = resolveReferenceId(request, config);
+
+      // Build an effective config with the resolved reference ID
+      const effectiveConfig: FishAudioConfig = {
+        ...config,
+        referenceId,
+      };
+
+      log.info(
+        {
+          referenceId,
+          format: config.format,
+          textLength: request.text.length,
+        },
+        "Starting Fish Audio TTS synthesis",
+      );
+
+      let audio: Buffer;
+      try {
+        audio = await synthesizeWithFishAudio(request.text, effectiveConfig, {
+          signal: request.signal,
+        });
+      } catch (err) {
+        throw new FishAudioTtsError(
+          "FISH_AUDIO_TTS_SYNTHESIS_FAILED",
+          `Fish Audio TTS synthesis failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+
+      const contentType = FORMAT_CONTENT_TYPE[config.format] ?? "audio/mpeg";
+
+      return { audio, contentType };
+    },
+
+    async synthesizeStream(
+      request: TtsSynthesisRequest,
+      onChunk: (chunk: Uint8Array) => void,
+    ): Promise<TtsSynthesisResult> {
+      const config = getConfig().fishAudio;
+      const referenceId = resolveReferenceId(request, config);
+
+      const effectiveConfig: FishAudioConfig = {
+        ...config,
+        referenceId,
+      };
+
+      log.info(
+        {
+          referenceId,
+          format: config.format,
+          textLength: request.text.length,
+        },
+        "Starting Fish Audio TTS streaming synthesis",
+      );
+
+      let audio: Buffer;
+      try {
+        audio = await synthesizeWithFishAudio(request.text, effectiveConfig, {
+          onChunk,
+          signal: request.signal,
+        });
+      } catch (err) {
+        throw new FishAudioTtsError(
+          "FISH_AUDIO_TTS_SYNTHESIS_FAILED",
+          `Fish Audio TTS streaming synthesis failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+
+      const contentType = FORMAT_CONTENT_TYPE[config.format] ?? "audio/mpeg";
+
+      return { audio, contentType };
+    },
+  };
+}

--- a/assistant/src/tts/providers/register-builtins.ts
+++ b/assistant/src/tts/providers/register-builtins.ts
@@ -1,0 +1,44 @@
+/**
+ * Register built-in TTS providers at startup.
+ *
+ * Call {@link registerBuiltinTtsProviders} once during daemon initialization
+ * to make `elevenlabs` and `fish-audio` discoverable via the provider registry.
+ *
+ * This module is the single entry point for built-in registration — new
+ * providers should be added here so they are available from first request.
+ */
+
+import { registerTtsProvider } from "../provider-registry.js";
+import { createElevenLabsProvider } from "./elevenlabs-provider.js";
+import { createFishAudioProvider } from "./fish-audio-provider.js";
+
+let registered = false;
+
+/**
+ * Register all built-in TTS providers with the global registry.
+ *
+ * Safe to call multiple times — subsequent calls are no-ops. This prevents
+ * double-registration when the daemon restarts hot-module paths.
+ */
+export function registerBuiltinTtsProviders(): void {
+  if (registered) return;
+
+  registerTtsProvider(createElevenLabsProvider());
+  registerTtsProvider(createFishAudioProvider());
+
+  registered = true;
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Reset the registration guard so {@link registerBuiltinTtsProviders} can
+ * re-register providers after a test clears the global registry.
+ *
+ * **Test-only** — must not be called in production code.
+ */
+export function _resetBuiltinRegistration(): void {
+  registered = false;
+}


### PR DESCRIPTION
## Summary
- Adds ElevenLabs provider adapter wrapping REST synthesis with uniform error handling
- Adds Fish Audio provider adapter preserving streaming chunk callbacks for call playback
- Registers both providers via register-builtins.ts for startup discovery

Part of plan: product-tts-provider-abstraction.md (PR 2 of 11)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24759" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
