### PR TITLE
Chrome popup: add assistant dropdown for multi-assistant lockfiles and hide for single

### DIFF
--- a/clients/chrome-extension/popup/popup-state.test.ts
+++ b/clients/chrome-extension/popup/popup-state.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Unit tests for popup-state.ts view-state helpers.
+ *
+ * Exercises the pure display-logic functions without a Chrome runtime:
+ *   - deriveSelectorDisplay: hidden for 0/1 assistants, visible for 2+
+ *   - assistantLabel: readable label derivation
+ *   - shouldShowLocalSection / shouldShowCloudSection: auth-profile gating
+ */
+
+import { describe, test, expect } from 'bun:test';
+
+import {
+  deriveSelectorDisplay,
+  assistantLabel,
+  shouldShowLocalSection,
+  shouldShowCloudSection,
+} from './popup-state.js';
+
+import type { AssistantDescriptor } from '../background/native-host-assistants.js';
+
+// ── Fixtures ───────────────────────────────────────────────────────
+
+function makeDescriptor(
+  overrides: Partial<AssistantDescriptor> & { assistantId: string },
+): AssistantDescriptor {
+  return {
+    cloud: 'local',
+    runtimeUrl: '',
+    daemonPort: undefined,
+    isActive: true,
+    authProfile: 'local-pair',
+    ...overrides,
+  };
+}
+
+const localAssistant = makeDescriptor({ assistantId: 'my-local-assistant' });
+const cloudAssistant = makeDescriptor({
+  assistantId: 'my-cloud-assistant',
+  cloud: 'vellum',
+  runtimeUrl: 'https://runtime.vellum.ai',
+  authProfile: 'cloud-oauth',
+});
+const secondLocal = makeDescriptor({ assistantId: 'second-local' });
+
+// ── deriveSelectorDisplay ──────────────────────────────────────────
+
+describe('deriveSelectorDisplay', () => {
+  test('returns hidden when assistant list is empty', () => {
+    const result = deriveSelectorDisplay([], null);
+    expect(result.kind).toBe('hidden');
+  });
+
+  test('returns hidden when exactly one assistant exists', () => {
+    const result = deriveSelectorDisplay([localAssistant], localAssistant);
+    expect(result.kind).toBe('hidden');
+  });
+
+  test('returns visible with options when two or more assistants exist', () => {
+    const result = deriveSelectorDisplay(
+      [localAssistant, cloudAssistant],
+      localAssistant,
+    );
+    expect(result.kind).toBe('visible');
+    if (result.kind !== 'visible') throw new Error('unreachable');
+
+    expect(result.options.length).toBe(2);
+    expect(result.options[0]!.assistantId).toBe('my-local-assistant');
+    expect(result.options[1]!.assistantId).toBe('my-cloud-assistant');
+    expect(result.selectedId).toBe('my-local-assistant');
+  });
+
+  test('pre-selects the resolved selected assistant', () => {
+    const result = deriveSelectorDisplay(
+      [localAssistant, cloudAssistant],
+      cloudAssistant,
+    );
+    if (result.kind !== 'visible') throw new Error('unreachable');
+    expect(result.selectedId).toBe('my-cloud-assistant');
+  });
+
+  test('defaults to first assistant when selected is null', () => {
+    const result = deriveSelectorDisplay(
+      [localAssistant, cloudAssistant],
+      null,
+    );
+    if (result.kind !== 'visible') throw new Error('unreachable');
+    expect(result.selectedId).toBe('my-local-assistant');
+  });
+
+  test('preserves lockfile order in options', () => {
+    const result = deriveSelectorDisplay(
+      [cloudAssistant, localAssistant, secondLocal],
+      cloudAssistant,
+    );
+    if (result.kind !== 'visible') throw new Error('unreachable');
+    expect(result.options[0]!.assistantId).toBe('my-cloud-assistant');
+    expect(result.options[1]!.assistantId).toBe('my-local-assistant');
+    expect(result.options[2]!.assistantId).toBe('second-local');
+  });
+});
+
+// ── assistantLabel ────────────────────────────────────────────────
+
+describe('assistantLabel', () => {
+  test('returns assistantId as label', () => {
+    expect(assistantLabel(localAssistant)).toBe('my-local-assistant');
+  });
+
+  test('returns assistantId for cloud assistant', () => {
+    expect(assistantLabel(cloudAssistant)).toBe('my-cloud-assistant');
+  });
+});
+
+// ── shouldShowLocalSection / shouldShowCloudSection ────────────────
+
+describe('shouldShowLocalSection', () => {
+  test('returns true for local-pair profile', () => {
+    expect(shouldShowLocalSection('local-pair')).toBe(true);
+  });
+
+  test('returns false for cloud-oauth profile', () => {
+    expect(shouldShowLocalSection('cloud-oauth')).toBe(false);
+  });
+
+  test('returns false for unsupported profile', () => {
+    expect(shouldShowLocalSection('unsupported')).toBe(false);
+  });
+
+  test('returns false for null profile', () => {
+    expect(shouldShowLocalSection(null)).toBe(false);
+  });
+});
+
+describe('shouldShowCloudSection', () => {
+  test('returns true for cloud-oauth profile', () => {
+    expect(shouldShowCloudSection('cloud-oauth')).toBe(true);
+  });
+
+  test('returns false for local-pair profile', () => {
+    expect(shouldShowCloudSection('local-pair')).toBe(false);
+  });
+
+  test('returns false for unsupported profile', () => {
+    expect(shouldShowCloudSection('unsupported')).toBe(false);
+  });
+
+  test('returns false for null profile', () => {
+    expect(shouldShowCloudSection(null)).toBe(false);
+  });
+});

--- a/clients/chrome-extension/popup/popup-state.ts
+++ b/clients/chrome-extension/popup/popup-state.ts
@@ -1,0 +1,114 @@
+/**
+ * Pure view-state helpers for the popup assistant selector.
+ *
+ * These functions derive display state from the assistant catalog and
+ * selection data returned by the worker's `assistants-get` message.
+ * They are deliberately side-effect-free so they can be unit tested
+ * without a Chrome runtime environment.
+ */
+
+import type { AssistantDescriptor } from '../background/native-host-assistants.js';
+import type { AssistantAuthProfile } from '../background/assistant-auth-profile.js';
+
+// ── Types ──────────────────────────────────────────────────────────
+
+/**
+ * Response shape from the worker's `assistants-get` message. Mirrors
+ * the return type of `getAssistantCatalogAndSelection()` in worker.ts
+ * with an `ok` envelope.
+ */
+export interface AssistantsGetResponse {
+  ok: boolean;
+  assistants?: AssistantDescriptor[];
+  selected?: AssistantDescriptor | null;
+  authProfile?: AssistantAuthProfile | null;
+  error?: string;
+}
+
+/**
+ * Response shape from the worker's `assistant-select` message.
+ */
+export interface AssistantSelectResponse {
+  ok: boolean;
+  selected?: AssistantDescriptor | null;
+  authProfile?: AssistantAuthProfile | null;
+  error?: string;
+}
+
+/**
+ * Describes how the popup should render the assistant selector area.
+ *
+ * - `hidden`:  No selector shown. Applies when a single assistant
+ *              exists (auto-selected) or when the catalog is empty.
+ * - `visible`: The dropdown should be rendered with the given option
+ *              list and pre-selected value.
+ */
+export type SelectorDisplay =
+  | { kind: 'hidden' }
+  | { kind: 'visible'; options: AssistantOption[]; selectedId: string };
+
+export interface AssistantOption {
+  assistantId: string;
+  label: string;
+}
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+/**
+ * Build a human-readable label for an assistant descriptor.
+ *
+ * Uses the `assistantId` as the display label. This keeps the dropdown
+ * consistent with the lockfile's assistant identifiers.
+ */
+export function assistantLabel(descriptor: AssistantDescriptor): string {
+  return descriptor.assistantId;
+}
+
+/**
+ * Derive the selector display state from the assistant catalog.
+ *
+ * Rules:
+ *   - 0 or 1 assistant: hidden (auto-select handled by worker).
+ *   - 2+ assistants: visible dropdown with options in lockfile order
+ *     and the resolved `selected` pre-selected.
+ */
+export function deriveSelectorDisplay(
+  assistants: AssistantDescriptor[],
+  selected: AssistantDescriptor | null,
+): SelectorDisplay {
+  if (assistants.length <= 1) {
+    return { kind: 'hidden' };
+  }
+
+  const options: AssistantOption[] = assistants.map((a) => ({
+    assistantId: a.assistantId,
+    label: assistantLabel(a),
+  }));
+
+  const selectedId = selected?.assistantId ?? assistants[0]!.assistantId;
+
+  return { kind: 'visible', options, selectedId };
+}
+
+/**
+ * Determine which auth status text and style to show for the Local
+ * section based on the current auth profile.
+ *
+ * Returns `null` when the local section is irrelevant (cloud-only
+ * assistant).
+ */
+export function shouldShowLocalSection(
+  authProfile: AssistantAuthProfile | null,
+): boolean {
+  return authProfile === 'local-pair';
+}
+
+/**
+ * Determine whether the Cloud section should be shown based on the
+ * current auth profile.
+ */
+export function shouldShowCloudSection(
+  authProfile: AssistantAuthProfile | null,
+): boolean {
+  return authProfile === 'cloud-oauth';
+}

--- a/clients/chrome-extension/popup/popup.html
+++ b/clients/chrome-extension/popup/popup.html
@@ -142,32 +142,23 @@
     .local-status.paired { color: #0f766e; }
     .local-status.error { color: #ef4444; }
 
-    .mode-group {
+    .assistant-selector-group {
       margin-bottom: 14px;
     }
 
-    .mode-radio-row {
-      display: flex;
-      gap: 14px;
-      margin-top: 4px;
-    }
-
-    .mode-radio-row label {
-      display: flex;
-      align-items: center;
-      gap: 6px;
-      font-size: 12px;
-      font-weight: 500;
-      color: #374151;
-      cursor: pointer;
-      user-select: none;
-      margin-bottom: 0;
-    }
-
-    .mode-radio-row input[type="radio"] {
-      margin: 0;
+    select {
+      width: 100%;
+      border: 1px solid #d1d5db;
+      border-radius: 6px;
+      padding: 7px 10px;
+      font-size: 13px;
+      outline: none;
+      transition: border-color 0.15s;
+      background: #fff;
+      color: #1a1a1a;
       cursor: pointer;
     }
+    select:focus { border-color: #6366f1; }
 
     .hint {
       font-size: 11px;
@@ -193,18 +184,9 @@
 
   <p class="error-text" id="error-text" style="display:none"></p>
 
-  <div class="mode-group">
-    <label>Connection mode</label>
-    <div class="mode-radio-row">
-      <label>
-        <input type="radio" name="relay-mode" value="self-hosted" id="mode-self-hosted" />
-        Self-hosted
-      </label>
-      <label>
-        <input type="radio" name="relay-mode" value="cloud" id="mode-cloud" />
-        Cloud
-      </label>
-    </div>
+  <div class="assistant-selector-group" id="assistant-selector-group" style="display:none">
+    <label for="assistant-select">Assistant</label>
+    <select id="assistant-select"></select>
   </div>
 
   <label for="port-input">Relay port</label>
@@ -221,7 +203,7 @@
     <button id="btn-disconnect" disabled>Disconnect</button>
   </div>
 
-  <p class="hint">Self-hosted mode requires pairing. Relay port defaults to 7830.</p>
+  <p class="hint">Relay port defaults to 7830.</p>
 
   <div class="divider"></div>
 

--- a/clients/chrome-extension/popup/popup.ts
+++ b/clients/chrome-extension/popup/popup.ts
@@ -1,6 +1,16 @@
 /**
  * Popup UI for the Vellum browser-relay extension.
  *
+ * On open the popup loads the assistant catalog from the worker via the
+ * `assistants-get` message. When exactly one assistant exists it is
+ * auto-selected and no selector dropdown is shown. When multiple
+ * assistants exist a `<select>` dropdown is rendered in lockfile order.
+ *
+ * Switching assistants sends an `assistant-select` message to the
+ * worker, which persists the selection and returns the resolved
+ * descriptor + auth profile. The popup then refreshes the local/cloud
+ * auth status panels to match the newly selected assistant.
+ *
  * Self-hosted pairing is governed by the "Pair local assistant" button,
  * which spawns the native messaging helper and persists a capability
  * token (see self-hosted-auth.ts). Connect then reads that stored
@@ -21,8 +31,19 @@ import {
   getStoredLocalToken,
   type StoredLocalToken,
 } from '../background/self-hosted-auth.js';
+import type { AssistantDescriptor } from '../background/native-host-assistants.js';
+import type { AssistantAuthProfile } from '../background/assistant-auth-profile.js';
+import {
+  deriveSelectorDisplay,
+  shouldShowLocalSection,
+  shouldShowCloudSection,
+  type AssistantsGetResponse,
+  type AssistantSelectResponse,
+} from './popup-state.js';
 
 const DEFAULT_RELAY_PORT = 7830;
+
+// ── DOM references ──────────────────────────────────────────────────
 
 const portInput = document.getElementById('port-input') as HTMLInputElement;
 const btnConnect = document.getElementById('btn-connect') as HTMLButtonElement;
@@ -34,11 +55,22 @@ const btnCloudSignIn = document.getElementById('btn-cloud-signin') as HTMLButton
 const cloudStatus = document.getElementById('cloud-status') as HTMLParagraphElement;
 const btnPairLocal = document.getElementById('btn-pair-local') as HTMLButtonElement;
 const localStatus = document.getElementById('local-status') as HTMLParagraphElement;
-const modeSelfHosted = document.getElementById('mode-self-hosted') as HTMLInputElement;
-const modeCloud = document.getElementById('mode-cloud') as HTMLInputElement;
 
-const RELAY_MODE_KEY = 'vellum.relayMode';
-type RelayModeKind = 'self-hosted' | 'cloud';
+const assistantSelectorGroup = document.getElementById(
+  'assistant-selector-group',
+) as HTMLDivElement;
+const assistantSelect = document.getElementById(
+  'assistant-select',
+) as HTMLSelectElement;
+
+// ── Current assistant state ─────────────────────────────────────────
+//
+// Tracks the currently selected assistant and its auth profile so
+// connect and auth-refresh operations use the right assistant context.
+
+let currentAuthProfile: AssistantAuthProfile | null = null;
+
+// ── Connection state helpers ────────────────────────────────────────
 
 function setConnected(connected: boolean): void {
   statusDot.className = `status-dot ${connected ? 'connected' : 'disconnected'}`;
@@ -65,6 +97,153 @@ function showErrorText(msg: string): void {
 function showError(msg: string): void {
   showErrorText(msg);
 }
+
+// ── Assistant selector ──────────────────────────────────────────────
+
+/**
+ * Render the assistant dropdown based on the catalog from the worker.
+ * Hides the dropdown when only one assistant exists.
+ */
+function renderAssistantSelector(
+  assistants: AssistantDescriptor[],
+  selected: AssistantDescriptor | null,
+): void {
+  const display = deriveSelectorDisplay(assistants, selected);
+
+  if (display.kind === 'hidden') {
+    assistantSelectorGroup.style.display = 'none';
+    return;
+  }
+
+  // Build <option> elements in lockfile order.
+  assistantSelect.innerHTML = '';
+  for (const opt of display.options) {
+    const el = document.createElement('option');
+    el.value = opt.assistantId;
+    el.textContent = opt.label;
+    if (opt.assistantId === display.selectedId) {
+      el.selected = true;
+    }
+    assistantSelect.appendChild(el);
+  }
+
+  assistantSelectorGroup.style.display = 'block';
+}
+
+/**
+ * Update the visibility of the Local and Cloud auth sections based on
+ * the selected assistant's auth profile.
+ */
+function updateAuthSections(authProfile: AssistantAuthProfile | null): void {
+  currentAuthProfile = authProfile;
+
+  // Find the section containers by walking from the section-label elements.
+  // The Local section = section-label "Local" + local-status + btn-pair-local + preceding divider.
+  // The Cloud section = section-label "Cloud" + cloud-status + btn-cloud-signin + preceding divider.
+  //
+  // We use a simpler approach: show/hide the local and cloud elements
+  // individually based on the auth profile.
+
+  const showLocal = shouldShowLocalSection(authProfile);
+  const showCloud = shouldShowCloudSection(authProfile);
+
+  // Walk DOM to find the divider before each section label.
+  const sectionLabels = document.querySelectorAll('.section-label');
+
+  // Find the local section's divider (the one before "Local")
+  // and the cloud section's divider (the one before "Cloud")
+  let localDividerEl: Element | null = null;
+  let cloudDividerEl: Element | null = null;
+  let localLabelEl: Element | null = null;
+  let cloudLabelEl: Element | null = null;
+
+  for (const label of sectionLabels) {
+    if (label.textContent?.trim() === 'Local') localLabelEl = label;
+    if (label.textContent?.trim() === 'Cloud') cloudLabelEl = label;
+  }
+
+  // The divider immediately before the Local label
+  if (localLabelEl?.previousElementSibling?.classList.contains('divider')) {
+    localDividerEl = localLabelEl.previousElementSibling;
+  }
+  // The divider immediately before the Cloud label
+  if (cloudLabelEl?.previousElementSibling?.classList.contains('divider')) {
+    cloudDividerEl = cloudLabelEl.previousElementSibling;
+  }
+
+  // Toggle Local section visibility
+  const localElements = [localDividerEl, localLabelEl, localStatus, btnPairLocal];
+  for (const el of localElements) {
+    if (el instanceof HTMLElement) {
+      el.style.display = showLocal ? '' : 'none';
+    }
+  }
+
+  // Toggle Cloud section visibility
+  const cloudElements = [cloudDividerEl, cloudLabelEl, cloudStatus, btnCloudSignIn];
+  for (const el of cloudElements) {
+    if (el instanceof HTMLElement) {
+      el.style.display = showCloud ? '' : 'none';
+    }
+  }
+}
+
+/**
+ * Load the assistant catalog from the worker and render the selector.
+ */
+function loadAssistantCatalog(): void {
+  chrome.runtime.sendMessage({ type: 'assistants-get' }, (response: AssistantsGetResponse) => {
+    if (chrome.runtime.lastError || !response?.ok) {
+      const errMsg = response?.error ?? chrome.runtime.lastError?.message ?? 'Failed to load assistants';
+      showError(errMsg);
+      return;
+    }
+
+    const assistants = response.assistants ?? [];
+    const selected = response.selected ?? null;
+    const authProfile = response.authProfile ?? null;
+
+    renderAssistantSelector(assistants, selected);
+    updateAuthSections(authProfile);
+
+    // Refresh status panels for the selected assistant.
+    void refreshLocalStatus();
+    void refreshCloudStatus();
+  });
+}
+
+// Load on popup open.
+loadAssistantCatalog();
+
+// ── Assistant selection change ──────────────────────────────────────
+
+assistantSelect.addEventListener('change', () => {
+  const assistantId = assistantSelect.value;
+  if (!assistantId) return;
+
+  errorText.style.display = 'none';
+
+  chrome.runtime.sendMessage(
+    { type: 'assistant-select', assistantId },
+    (response: AssistantSelectResponse) => {
+      if (chrome.runtime.lastError || !response?.ok) {
+        showError(
+          response?.error ??
+            chrome.runtime.lastError?.message ??
+            'Failed to select assistant',
+        );
+        return;
+      }
+
+      const authProfile = response.authProfile ?? null;
+      updateAuthSections(authProfile);
+
+      // Refresh both status panels to reflect the new assistant.
+      void refreshLocalStatus();
+      void refreshCloudStatus();
+    },
+  );
+});
 
 // Load saved relay port on open.
 chrome.storage.local.get(['relayPort']).then((result) => {
@@ -94,32 +273,15 @@ btnConnect.addEventListener('click', async () => {
 
   errorText.style.display = 'none';
 
-  // Read the current relay mode so we know whether self-hosted pairing
-  // is required. In cloud mode the worker uses the stored cloud token
+  // Check whether pairing is required based on the selected assistant's
+  // auth profile. In cloud mode the worker uses the stored cloud token
   // (vellum.cloudAuthToken) directly, so the popup must NOT try to hit
   // localhost — a cloud-only user may not have a local assistant running.
-  //
-  // We prefer the radio button's checked state as a tiebreaker: if the
-  // user just toggled the radio, the async chrome.storage.local.set from
-  // handleModeChange() may not have landed yet. The DOM is the source of
-  // truth for the user's current intent.
-  const modeStorage = await chrome.storage.local.get(RELAY_MODE_KEY);
-  const storedMode = modeStorage[RELAY_MODE_KEY];
-  const relayMode: RelayModeKind = modeCloud.checked
-    ? 'cloud'
-    : modeSelfHosted.checked
-      ? 'self-hosted'
-      : storedMode === 'cloud'
-        ? 'cloud'
-        : 'self-hosted';
-
-  // Self-hosted now requires native-messaging pairing. There is no
-  // gateway JWT fallback path.
-  if (relayMode === 'self-hosted') {
+  if (currentAuthProfile === 'local-pair') {
     const pairedToken = await getStoredLocalToken();
     if (!pairedToken) {
       showError(
-        'Self-hosted relay is not paired yet — click "Pair local assistant" below before connecting.',
+        'Local assistant is not paired yet — click "Pair with local assistant" below before connecting.',
       );
       return;
     }
@@ -158,7 +320,7 @@ btnDisconnect.addEventListener('click', () => {
   });
 });
 
-// ── Self-hosted native-messaging pairing (new in Phase 2 PR 13) ─────
+// ── Self-hosted native-messaging pairing ────────────────────────────
 //
 // Pairing runs the local native messaging helper (com.vellum.daemon),
 // which POSTs the extension's origin to the assistant's
@@ -232,7 +394,7 @@ btnPairLocal.addEventListener('click', async () => {
 
 refreshLocalStatus();
 
-// ── Cloud sign-in (new in Phase 2 PR 8) ────────────────────────────
+// ── Cloud sign-in ───────────────────────────────────────────────────
 //
 // The token is persisted and consumed by the background worker when
 // opening cloud relay WebSocket connections.
@@ -307,43 +469,3 @@ btnCloudSignIn.addEventListener('click', async () => {
 });
 
 refreshCloudStatus();
-
-// ── Relay mode switcher (Phase 2 PR 14) ────────────────────────────
-//
-// Flips `vellum.relayMode` in chrome.storage.local between
-// "self-hosted" (default) and "cloud". The service worker listens
-// for storage changes via chrome.storage.onChanged and closes the
-// current socket + reopens a new one against the selected transport.
-
-function isRelayModeKind(v: unknown): v is RelayModeKind {
-  return v === 'self-hosted' || v === 'cloud';
-}
-
-chrome.storage.local.get(RELAY_MODE_KEY).then((result) => {
-  const stored = result[RELAY_MODE_KEY];
-  const mode: RelayModeKind = isRelayModeKind(stored) ? stored : 'self-hosted';
-  if (mode === 'cloud') {
-    modeCloud.checked = true;
-  } else {
-    modeSelfHosted.checked = true;
-  }
-});
-
-async function handleModeChange(newMode: RelayModeKind): Promise<void> {
-  await chrome.storage.local.set({ [RELAY_MODE_KEY]: newMode });
-  // The service worker reacts to the storage change via
-  // chrome.storage.onChanged — we don't need to send an explicit
-  // disconnect/connect message here.
-}
-
-modeSelfHosted.addEventListener('change', () => {
-  if (modeSelfHosted.checked) {
-    void handleModeChange('self-hosted');
-  }
-});
-
-modeCloud.addEventListener('change', () => {
-  if (modeCloud.checked) {
-    void handleModeChange('cloud');
-  }
-});


### PR DESCRIPTION
## Summary
- Replace mode selector UI with assistant dropdown in popup.html
- Auto-select single assistant, show dropdown for multiple
- On switch, refresh auth status and connect target via worker messages
- Extract popup-state.ts helpers with unit tests

Part of plan: chrome-extension-multi-assistant-auth.md (PR 5 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24762" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
