### PR TITLE
fix: stuck spinner after search completes, stale results from in-flight search

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
@@ -316,9 +316,10 @@ final class SkillsManager {
 
     private func dispatchSearch(query: String) {
         searchDebounceTask?.cancel()
-        // Always clear stale results immediately so previous search terms
-        // don't linger during the debounce window or after clearing the bar.
-        skillsStore.searchResults = []
+        // Cancel any in-flight network search and clear stale results
+        // immediately so previous search terms don't linger during the
+        // debounce window or after clearing the bar.
+        skillsStore.cancelSearch()
         let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else {
             isSearching = false
@@ -331,6 +332,7 @@ final class SkillsManager {
             try? await Task.sleep(nanoseconds: 300_000_000)
             guard !Task.isCancelled else { return }
             skillsStore.searchSkills(query: trimmed, force: true)
+            searchDebounceTask = nil
         }
     }
 

--- a/clients/shared/Features/Skills/SkillsStore.swift
+++ b/clients/shared/Features/Skills/SkillsStore.swift
@@ -165,6 +165,17 @@ public final class SkillsStore: ObservableObject {
         }
     }
 
+    /// Cancels any in-flight search task and clears search state.
+    ///
+    /// Called by `SkillsManager.dispatchSearch` when the user types a new
+    /// query before the previous search completes, preventing stale results
+    /// from the earlier query from briefly appearing.
+    public func cancelSearch() {
+        searchTask?.cancel()
+        searchResults = []
+        isSearching = false
+    }
+
     // MARK: - Install Skill
 
     public func installSkill(slug: String) {


### PR DESCRIPTION
## Summary
Fixes two gaps from self-review round 4 of skills-search-all-sources.md.

**Gap 1 (critical):** searchDebounceTask was never set to nil after firing, causing the debouncing flag in bindStore to stay true forever and the spinner to never stop.
**Gap 2:** Added cancelSearch() to SkillsStore so dispatchSearch can cancel in-flight network requests, preventing stale results from appearing during type-pause-type sequences.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24764" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
