### PR TITLE
feat(skills): wire search bar to backend search for all sources

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -152,6 +152,13 @@ struct AgentPanelContent: View {
     private var filterBar: some View {
         HStack(spacing: VSpacing.sm) {
             VSearchBar(placeholder: "Search Skills", text: $skillsManager.searchQuery)
+                .overlay(alignment: .trailing) {
+                    if skillsManager.isSearching {
+                        ProgressView()
+                            .controlSize(.small)
+                            .padding(.trailing, 28)
+                    }
+                }
             VDropdown(
                 options: SkillFilter.allCases.map { VDropdownOption(label: $0.rawValue, value: $0, icon: $0.icon) },
                 selection: $skillsManager.skillFilter,
@@ -259,6 +266,13 @@ struct AgentPanelContent: View {
             )
             .id(skill.id)
         } else if skillsManager.isLoading && skillsManager.baseSkillsEmpty {
+            VStack {
+                Spacer()
+                VLoadingIndicator()
+                Spacer()
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if skillsManager.isSearching && skillsManager.filteredSkills.isEmpty {
             VStack {
                 Spacer()
                 VLoadingIndicator()

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
@@ -49,17 +49,22 @@ final class SkillsManager {
     var loadingFilePaths: Set<String> = []
     var fileContentErrors: [String: String] = [:]
     var installingSkillId: String?
+    var isSearching = false
 
     /// Safety timeout that defensively clears `installingSkillId` if a
     /// wedged `fetchSkills(force:)` response never lands. Without it, the
     /// install spinner can be stuck indefinitely when the confirmation
     /// refresh path is blocked or delayed.
     @ObservationIgnored private var installWatchdogTask: Task<Void, Never>?
+    @ObservationIgnored private var searchDebounceTask: Task<Void, Never>?
 
     // MARK: - Filter Inputs
 
     var searchQuery: String = "" {
-        didSet { recomputeFilteredData() }
+        didSet {
+            recomputeFilteredData()
+            dispatchSearch(query: searchQuery)
+        }
     }
 
     var selectedCategory: SkillCategory? {
@@ -104,9 +109,22 @@ final class SkillsManager {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 guard let self else { return }
-                let skills = self.skillsStore.skills
-                self.skills = skills
-                self.rebuildCategoryMap(from: skills)
+                self.isSearching = self.skillsStore.isSearching
+
+                // Merge local skills with external search results (if any),
+                // deduplicating by skill id so local entries take precedence.
+                let localSkills = self.skillsStore.skills
+                let mergedSkills: [SkillInfo]
+                let hasActiveQuery = !self.searchQuery.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                if hasActiveQuery && !self.skillsStore.searchResults.isEmpty && !self.skillsStore.isSearching {
+                    let localIds = Set(localSkills.map(\.id))
+                    let externalResults = self.skillsStore.searchResults.filter { !localIds.contains($0.id) }
+                    mergedSkills = localSkills + externalResults
+                } else {
+                    mergedSkills = localSkills
+                }
+                self.skills = mergedSkills
+                self.rebuildCategoryMap(from: mergedSkills)
                 self.loadedBodies = self.skillsStore.loadedBodies
                 self.isLoading = self.skillsStore.isLoading
                 self.uninstallResult = self.skillsStore.uninstallResult
@@ -266,6 +284,22 @@ final class SkillsManager {
             return "Custom"
         default:
             return origin.replacingOccurrences(of: "-", with: " ").capitalized
+        }
+    }
+
+    // MARK: - Debounced Search
+
+    private func dispatchSearch(query: String) {
+        searchDebounceTask?.cancel()
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            skillsStore.searchResults = []
+            return
+        }
+        searchDebounceTask = Task {
+            try? await Task.sleep(nanoseconds: 300_000_000)
+            guard !Task.isCancelled else { return }
+            skillsStore.searchSkills(query: trimmed, force: true)
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
@@ -316,9 +316,10 @@ final class SkillsManager {
 
     private func dispatchSearch(query: String) {
         searchDebounceTask?.cancel()
-        // Always clear stale results immediately so previous search terms
-        // don't linger during the debounce window or after clearing the bar.
-        skillsStore.searchResults = []
+        // Cancel any in-flight network search and clear stale results
+        // immediately so previous search terms don't linger during the
+        // debounce window or after clearing the bar.
+        skillsStore.cancelSearch()
         let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else {
             isSearching = false
@@ -331,6 +332,7 @@ final class SkillsManager {
             try? await Task.sleep(nanoseconds: 300_000_000)
             guard !Task.isCancelled else { return }
             skillsStore.searchSkills(query: trimmed, force: true)
+            searchDebounceTask = nil
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
@@ -116,7 +116,8 @@ final class SkillsManager {
                 // Gate spinner on whether there is actually a query; clearing
                 // the search bar should immediately stop the spinner even if
                 // a network request is still in-flight.
-                self.isSearching = hasActiveQuery && self.skillsStore.isSearching
+                let debouncing = self.searchDebounceTask != nil && !(self.searchDebounceTask?.isCancelled ?? true)
+                self.isSearching = hasActiveQuery && (self.skillsStore.isSearching || debouncing)
 
                 // Merge local skills with external search results (if any),
                 // deduplicating by skill id so local entries take precedence.
@@ -241,15 +242,21 @@ final class SkillsManager {
         let searchFiltered: [SkillInfo]
         if hasSearch {
             // When external search results have been merged in, the backend
-            // already performed fuzzy/semantic matching — applying a local
-            // substring filter would silently drop valid results whose query
-            // text doesn't appear as a literal substring (e.g. skills.sh
-            // results with empty descriptions). Skip the local filter in
-            // that case and show the full merged list.
+            // already performed fuzzy/semantic matching — backend-matched
+            // skills pass through unfiltered (they may not contain the query
+            // as a literal substring, e.g. skills.sh results with empty
+            // descriptions). Local-only skills still get the substring
+            // filter so they don't bypass search.
             let backendIds = Set(skillsStore.searchResults.map(\.id))
             let backendResultsPresent = !skillsStore.isSearching && baseSkills.contains(where: { backendIds.contains($0.id) })
             if backendResultsPresent {
-                searchFiltered = baseSkills
+                searchFiltered = baseSkills.filter {
+                    backendIds.contains($0.id) ||
+                    $0.name.lowercased().contains(query) ||
+                    $0.description.lowercased().contains(query) ||
+                    $0.id.lowercased().contains(query) ||
+                    Self.sourceLabel($0.origin).lowercased().contains(query)
+                }
             } else {
                 searchFiltered = baseSkills.filter {
                     $0.name.lowercased().contains(query) ||

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
@@ -62,8 +62,8 @@ final class SkillsManager {
 
     var searchQuery: String = "" {
         didSet {
-            recomputeFilteredData()
             dispatchSearch(query: searchQuery)
+            recomputeFilteredData()
         }
     }
 
@@ -246,7 +246,8 @@ final class SkillsManager {
             // text doesn't appear as a literal substring (e.g. skills.sh
             // results with empty descriptions). Skip the local filter in
             // that case and show the full merged list.
-            let backendResultsPresent = !skillsStore.searchResults.isEmpty && !skillsStore.isSearching
+            let backendIds = Set(skillsStore.searchResults.map(\.id))
+            let backendResultsPresent = !skillsStore.isSearching && baseSkills.contains(where: { backendIds.contains($0.id) })
             if backendResultsPresent {
                 searchFiltered = baseSkills
             } else {
@@ -312,7 +313,13 @@ final class SkillsManager {
         // don't linger during the debounce window or after clearing the bar.
         skillsStore.searchResults = []
         let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return }
+        guard !trimmed.isEmpty else {
+            isSearching = false
+            return
+        }
+        // Show spinner immediately during the debounce window so the user
+        // doesn't see the "No Skills Available" empty state for 300ms.
+        isSearching = true
         searchDebounceTask = Task {
             try? await Task.sleep(nanoseconds: 300_000_000)
             guard !Task.isCancelled else { return }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
@@ -328,11 +328,11 @@ final class SkillsManager {
         // Show spinner immediately during the debounce window so the user
         // doesn't see the "No Skills Available" empty state for 300ms.
         isSearching = true
-        searchDebounceTask = Task {
+        searchDebounceTask = Task { [weak self] in
             try? await Task.sleep(nanoseconds: 300_000_000)
             guard !Task.isCancelled else { return }
-            skillsStore.searchSkills(query: trimmed, force: true)
-            searchDebounceTask = nil
+            self?.skillsStore.searchSkills(query: trimmed, force: true)
+            self?.searchDebounceTask = nil
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
@@ -109,13 +109,19 @@ final class SkillsManager {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 guard let self else { return }
-                self.isSearching = self.skillsStore.isSearching
+
+                // Compute once — used for both isSearching gating and merge guard.
+                let hasActiveQuery = !self.searchQuery.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+
+                // Gate spinner on whether there is actually a query; clearing
+                // the search bar should immediately stop the spinner even if
+                // a network request is still in-flight.
+                self.isSearching = hasActiveQuery && self.skillsStore.isSearching
 
                 // Merge local skills with external search results (if any),
                 // deduplicating by skill id so local entries take precedence.
                 let localSkills = self.skillsStore.skills
                 let mergedSkills: [SkillInfo]
-                let hasActiveQuery = !self.searchQuery.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
                 if hasActiveQuery && !self.skillsStore.searchResults.isEmpty && !self.skillsStore.isSearching {
                     let localIds = Set(localSkills.map(\.id))
                     let externalResults = self.skillsStore.searchResults.filter { !localIds.contains($0.id) }
@@ -234,11 +240,22 @@ final class SkillsManager {
 
         let searchFiltered: [SkillInfo]
         if hasSearch {
-            searchFiltered = baseSkills.filter {
-                $0.name.lowercased().contains(query) ||
-                $0.description.lowercased().contains(query) ||
-                $0.id.lowercased().contains(query) ||
-                Self.sourceLabel($0.origin).lowercased().contains(query)
+            // When external search results have been merged in, the backend
+            // already performed fuzzy/semantic matching — applying a local
+            // substring filter would silently drop valid results whose query
+            // text doesn't appear as a literal substring (e.g. skills.sh
+            // results with empty descriptions). Skip the local filter in
+            // that case and show the full merged list.
+            let backendResultsPresent = !skillsStore.searchResults.isEmpty && !skillsStore.isSearching
+            if backendResultsPresent {
+                searchFiltered = baseSkills
+            } else {
+                searchFiltered = baseSkills.filter {
+                    $0.name.lowercased().contains(query) ||
+                    $0.description.lowercased().contains(query) ||
+                    $0.id.lowercased().contains(query) ||
+                    Self.sourceLabel($0.origin).lowercased().contains(query)
+                }
             }
         } else {
             searchFiltered = baseSkills
@@ -291,11 +308,11 @@ final class SkillsManager {
 
     private func dispatchSearch(query: String) {
         searchDebounceTask?.cancel()
+        // Always clear stale results immediately so previous search terms
+        // don't linger during the debounce window or after clearing the bar.
+        skillsStore.searchResults = []
         let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else {
-            skillsStore.searchResults = []
-            return
-        }
+        guard !trimmed.isEmpty else { return }
         searchDebounceTask = Task {
             try? await Task.sleep(nanoseconds: 300_000_000)
             guard !Task.isCancelled else { return }

--- a/clients/shared/Features/Skills/SkillsStore.swift
+++ b/clients/shared/Features/Skills/SkillsStore.swift
@@ -92,6 +92,7 @@ public final class SkillsStore: ObservableObject {
 
     private let skillsClient: SkillsClientProtocol
     private var lastSearchQuery: String?
+    private var searchTask: Task<Void, Never>?
     private var draftTask: Task<Void, Never>?
     private var createTask: Task<Void, Never>?
     private var skillDetailTask: Task<Void, Never>?
@@ -145,12 +146,15 @@ public final class SkillsStore: ObservableObject {
     // MARK: - Search Skills
 
     public func searchSkills(query: String = "", force: Bool = false) {
-        guard !isSearching else { return }
         if !force && !searchResults.isEmpty && lastSearchQuery == query { return }
+
+        // Cancel any in-flight search so the latest query always wins.
+        searchTask?.cancel()
         isSearching = true
 
-        Task {
+        searchTask = Task {
             let result = await skillsClient.searchSkills(query: query)
+            guard !Task.isCancelled else { return }
             if let result, result.success {
                 searchResults = result.skills
             } else {

--- a/clients/shared/Features/Skills/SkillsStore.swift
+++ b/clients/shared/Features/Skills/SkillsStore.swift
@@ -165,6 +165,17 @@ public final class SkillsStore: ObservableObject {
         }
     }
 
+    /// Cancels any in-flight search task and clears search state.
+    ///
+    /// Called by `SkillsManager.dispatchSearch` when the user types a new
+    /// query before the previous search completes, preventing stale results
+    /// from the earlier query from briefly appearing.
+    public func cancelSearch() {
+        searchTask?.cancel()
+        searchResults = []
+        isSearching = false
+    }
+
     // MARK: - Install Skill
 
     public func installSkill(slug: String) {


### PR DESCRIPTION
## Summary
Wires the macOS Skills page search bar to the backend `/skills/search` endpoint, which queries ClaWHub, Skills.sh, and the local catalog in parallel. Previously, the search bar only did client-side substring filtering on pre-loaded skills.

Key behaviors:
- Instant local filtering on every keystroke (no regression)
- 300ms debounced backend search for external registry results
- Merged/deduplicated results with local skills taking precedence
- Optimistic loading spinner during debounce + network request
- Proper cancellation of stale searches on rapid typing
- Hybrid filter: backend-matched skills bypass substring filter, local skills still get filtered

## Self-review result
PASS after 4 rounds of gap remediation (5 fix PRs total)

## PRs merged into feature branch
- #24749: feat(skills): wire search bar to backend search endpoint for all sources
- #24755: fix: address self-review gaps in skills search wiring (R1)
- #24757: fix: scope filter bypass to surviving results, fix ordering race, optimistic spinner (R2)
- #24761: fix: filter local skills even with backend results, preserve debounce spinner (R3)
- #24764: fix: stuck spinner after search completes, stale results from in-flight search (R4)

Part of plan: skills-search-all-sources.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24765" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
