### PR TITLE
Chrome extension: remove relayMode legacy path and document multi-assistant behavior

### DIFF
--- a/clients/chrome-extension/README.md
+++ b/clients/chrome-extension/README.md
@@ -4,15 +4,18 @@ This directory contains the MV3 Chrome extension used for browser relay.
 
 Core pieces:
 - `background/worker.ts`: service worker (relay lifecycle, pairing, CDP dispatch)
-- `popup/`: popup UI (`Pair with local assistant`, `Connect`, cloud sign-in)
-- `native-host/`: native messaging helper (`com.vellum.daemon`) used for self-hosted pairing
+- `background/assistant-auth-profile.ts`: lockfile topology to auth profile mapping
+- `background/native-host-assistants.ts`: native messaging client for assistant catalog
+- `popup/`: popup UI (assistant selector, auth panels, Connect/Disconnect)
+- `popup/popup-state.ts`: pure view-state helpers for the assistant selector
+- `native-host/`: native messaging helper (`com.vellum.daemon`) for self-hosted pairing and assistant discovery
 - `build.sh`: bundles extension assets into `dist/`
 
 ## Prerequisites
 
 - Bun installed and on `PATH`
 - Chrome with Developer mode enabled (`chrome://extensions`)
-- A local assistant running (for self-hosted mode)
+- At least one running assistant (local or cloud-managed)
 
 If you run commands from this repo, use:
 
@@ -33,15 +36,55 @@ Then in Chrome:
 3. Click **Load unpacked**
 4. Select `clients/chrome-extension/dist`
 
-## Self-hosted (Local Assistant) Flow
+## How It Works — Assistant-Centric Model
 
-1. Start your local assistant.
-2. Click the extension icon to open the popup.
-3. Keep mode on **Self-hosted**.
-4. Click **Pair with local assistant**.
-5. Click **Connect**.
+The extension discovers available assistants from the lockfile via the native
+messaging helper (`com.vellum.daemon`). The lockfile lists every assistant
+configured on the machine, along with its hosting topology (`cloud` field),
+runtime URL, and daemon port.
 
-If pairing succeeds, `Local` will show a paired guardian and expiry.
+### Assistant Discovery And Selection
+
+1. On popup open, the worker sends a `list_assistants` request to the native
+   messaging helper, which reads the lockfile and returns the assistant catalog.
+2. The worker resolves a selected assistant using these rules:
+   - **Single assistant**: auto-selected; no dropdown shown.
+   - **Multiple assistants**: dropdown shown in lockfile order. The previously
+     stored selection is reused if still present in the catalog; otherwise the
+     first entry is selected by default.
+   - **No assistants (empty lockfile)**: empty state shown.
+3. Switching assistants in the dropdown persists the new selection and
+   reconnects the relay to the newly selected assistant's endpoint.
+
+### Topology-To-Auth Mapping
+
+Each assistant's `cloud` field in the lockfile determines which auth flow
+the extension uses. The mapping is in `assistant-auth-profile.ts`:
+
+| `cloud` value | Auth profile | Auth flow |
+|---|---|---|
+| `local` | `local-pair` | Native messaging pair (capability token) |
+| `apple-container` | `local-pair` | Native messaging pair (capability token) |
+| `vellum` | `cloud-oauth` | Chrome identity OAuth flow |
+| `platform` | `cloud-oauth` | Chrome identity OAuth flow |
+| *(anything else)* | `unsupported` | Error: update the extension |
+
+- **`local-pair`**: The popup shows the **Local** auth section with a
+  "Pair with local assistant" button. Pairing spawns the native messaging
+  helper, which POSTs to the assistant's `/v1/browser-extension-pair`
+  endpoint and returns a scoped capability token. Connect targets the
+  local assistant at `ws://127.0.0.1:<port>/v1/browser-relay`.
+
+- **`cloud-oauth`**: The popup shows the **Cloud** auth section with a
+  "Sign in with Vellum (cloud)" button. Sign-in runs a
+  `chrome.identity.launchWebAuthFlow` against the cloud gateway. Connect
+  targets the cloud gateway at `wss://<runtimeUrl>/v1/browser-relay`.
+
+- **`unsupported`**: An error message instructs the user to update the
+  extension. No auth panel is shown.
+
+Auth tokens are stored per-assistant under scoped storage keys so
+switching between assistants does not require re-authentication.
 
 ## Native Messaging Host Setup (If Pairing Fails)
 
@@ -95,12 +138,6 @@ when `node` works in your terminal.
 
 5. Fully quit and relaunch Chrome.
 
-## Cloud Flow (Optional)
-
-1. In popup, switch mode to **Cloud**
-2. Click **Sign in with Vellum (cloud)**
-3. Click **Connect**
-
 ## Dev Loop
 
 After editing extension code:
@@ -119,21 +156,58 @@ Then in `chrome://extensions`, click **Reload** on the unpacked extension.
 - Popup logs:
   - Open popup → right-click → **Inspect**
 
-Common failures:
+## Troubleshooting
+
+### Empty lockfile / no assistants shown
+
+The native messaging helper reads the lockfile to discover assistants. If the
+popup shows no assistants:
+
+- Verify at least one assistant is running: check for the lockfile at
+  `~/.vellum/lockfile.json` (or the path appropriate for your OS).
+- Verify the native messaging host is installed and reachable (see the setup
+  section above). The macOS app installs the manifest automatically on launch.
+- Check the service worker console for `native messaging` errors.
+
+### Unsupported topology
+
+If the popup shows "This assistant uses an unsupported topology", the
+assistant's `cloud` field in the lockfile is not recognized by this version
+of the extension. Update the extension to the latest version.
+
+### Per-assistant auth mismatch
+
+Each assistant requires its own auth token scoped to its topology:
+
+- A `local` assistant requires a **local pair** token (click "Pair with
+  local assistant").
+- A `vellum`/`platform` assistant requires a **cloud sign-in** token
+  (click "Sign in with Vellum (cloud)").
+
+Switching between assistants with different topologies may require completing
+the appropriate auth flow for the newly selected assistant before connecting.
+
+### Common error messages
+
 - `Access to the specified native messaging host is forbidden`
   - Manifest missing/invalid, `allowed_origins` mismatch, or extension ID not allowlisted in `meta/browser-extension/chrome-extension-allowlist.json`
 - `Native host has exited`
   - Chrome could not launch Node for a `dist/index.js` host path. Use a wrapper script with an absolute Node path in the manifest `path`.
 - `assistant pair request failed with HTTP 401`
   - The pair endpoint rejected `extensionOrigin`. Verify your extension ID is in `meta/browser-extension/chrome-extension-allowlist.json`, then restart the assistant so it reloads allowlist config.
-- `Self-hosted relay is not paired yet`
-  - Click **Pair with local assistant** first
+- `Sign in with Vellum (cloud) before connecting`
+  - The selected assistant uses cloud-oauth but no cloud token is stored. Click "Sign in with Vellum (cloud)" first.
+- `Pair the Vellum assistant (self-hosted) before connecting`
+  - The selected assistant uses local-pair but no capability token is stored. Click "Pair with local assistant" first.
+- `Select an assistant before connecting`
+  - No assistant is selected. The lockfile may be empty or the native messaging helper is unreachable.
 - `failed to reach assistant at http://127.0.0.1:<port>/v1/browser-extension-pair`
   - Assistant not running, wrong runtime port, or local firewall/network policy
 
-Useful checks:
+### Useful checks
 
 ```bash
+cat ~/.vellum/lockfile.json
 cat ~/.vellum/runtime-port
 cat "$HOME/Library/Application Support/Google/Chrome/NativeMessagingHosts/com.vellum.daemon.json"
 cat meta/browser-extension/chrome-extension-allowlist.json
@@ -147,6 +221,8 @@ Extension:
 cd clients/chrome-extension
 bunx tsc --noEmit
 bun test background/__tests__/self-hosted-auth.test.ts
+bun test background/__tests__/worker-selected-assistant-connect.test.ts
+bun test background/__tests__/relay-connection.test.ts
 ```
 
 Native host helper:

--- a/clients/chrome-extension/README.md
+++ b/clients/chrome-extension/README.md
@@ -41,7 +41,7 @@ Then in Chrome:
 The extension discovers available assistants from the lockfile via the native
 messaging helper (`com.vellum.daemon`). The lockfile lists every assistant
 configured on the machine, along with its hosting topology (`cloud` field),
-runtime URL, and daemon port.
+runtime URL, and local assistant port.
 
 ### Assistant Discovery And Selection
 

--- a/clients/chrome-extension/background/__tests__/worker-selected-assistant-connect.test.ts
+++ b/clients/chrome-extension/background/__tests__/worker-selected-assistant-connect.test.ts
@@ -1,10 +1,10 @@
 /**
  * Tests for the worker's assistant-driven connect routing.
  *
- * Exercises the connect path logic introduced in PR 4 — the worker now
- * resolves the selected assistant's auth profile to determine the relay
- * transport and token source, replacing the old global `vellum.relayMode`
- * toggle.
+ * Exercises the connect path logic where the worker resolves the selected
+ * assistant's auth profile to determine the relay transport and token
+ * source. The auth profile is derived from the assistant's lockfile
+ * topology — there is no separate relay-mode toggle.
  *
  * Coverage:
  *   - Connect routes to `local-pair` (self-hosted) when the selected

--- a/clients/chrome-extension/background/worker.ts
+++ b/clients/chrome-extension/background/worker.ts
@@ -234,13 +234,9 @@ async function getAssistantCatalogAndSelection(): Promise<{
 // ── Connection state ───────────────────────────────────────────────
 //
 // The connect path is driven entirely by the selected assistant's auth
-// profile. The legacy `vellum.relayMode` storage key is no longer the
-// source of truth — the auth profile (`local-pair` | `cloud-oauth` |
-// `unsupported`) derived from the selected assistant's lockfile
-// topology determines both the relay target and the token source.
-//
-// Legacy relay-mode storage is preserved read-only for backward
-// compatibility during the deprecation window (PR 6 will remove it).
+// profile (`local-pair` | `cloud-oauth` | `unsupported`) derived from
+// the selected assistant's lockfile topology. This determines both the
+// relay target and the token source.
 
 /**
  * The auth profile of the currently connected (or last-attempted)

--- a/clients/chrome-extension/native-host/README.md
+++ b/clients/chrome-extension/native-host/README.md
@@ -2,19 +2,20 @@
 
 A tiny Node CLI binary that bridges the Vellum Chrome extension and the
 locally-running Vellum assistant via [Chrome Native Messaging][cnm]. It
-exists so the extension can bootstrap a scoped capability token for the
-self-hosted (local-assistant) transport without ever shipping a long-lived
-secret in the extension package itself.
+serves two purposes:
 
-The macOS installer wiring landed in PR 12: the helper is now bundled
-into the Mac `.app` under `Contents/MacOS/vellum-chrome-native-host`
-via `clients/macos/build.sh` (see the "Bundling into the macOS app"
-section below), and `NativeMessagingInstaller` writes the
-`com.vellum.daemon.json` manifest into Chrome's per-user
-`NativeMessagingHosts` directory at launch time. The extension-side
-bootstrap flow that actually spawns this helper lands in PR 13, and the
-runtime HTTP endpoint it talks to (`/v1/browser-extension-pair`) lands
-in PR 11.
+1. **Assistant discovery** (`list_assistants`): reads the lockfile and
+   returns the full assistant catalog so the extension can populate its
+   assistant selector dropdown.
+2. **Self-hosted pairing** (`request_token`): bootstraps a scoped
+   capability token for the local-assistant transport without shipping a
+   long-lived secret in the extension package.
+
+The macOS installer bundles this helper into the Mac `.app` under
+`Contents/MacOS/vellum-chrome-native-host` via `clients/macos/build.sh`
+(see the "Bundling into the macOS app" section below), and
+`NativeMessagingInstaller` writes the `com.vellum.daemon.json` manifest
+into Chrome's per-user `NativeMessagingHosts` directory at launch time.
 
 [cnm]: https://developer.chrome.com/docs/extensions/develop/concepts/native-messaging
 
@@ -34,7 +35,7 @@ Keeping the helper as its own package gives us:
   ID against a hard-coded allowlist before doing any work.
 - A small, auditable surface: ~200 lines of TypeScript that compile to a
   single Node CLI entry point.
-- Simple distribution: the macOS installer (PR 12) just drops the
+- Simple distribution: the macOS installer just drops the
   compiled `dist/index.js` and a manifest into `~/Library/Application
   Support/Google/Chrome/NativeMessagingHosts/`.
 
@@ -56,15 +57,56 @@ Every message in either direction is framed as:
 ```
 
 `encodeFrame(payload)` and `decodeFrames(buf)` in `src/protocol.ts` are
-the canonical implementations. They are pure functions — no I/O — and are
+the canonical implementations. They are pure functions -- no I/O -- and are
 covered by `src/__tests__/protocol.test.ts`.
 
 ### Messages
+
+#### Assistant catalog (`list_assistants`)
+
+The extension sends:
+
+```json
+{ "type": "list_assistants" }
+```
+
+On success, the helper reads the lockfile and writes:
+
+```json
+{
+  "type": "assistants_response",
+  "assistants": [
+    {
+      "assistantId": "<id>",
+      "cloud": "local",
+      "runtimeUrl": "http://127.0.0.1:7831",
+      "daemonPort": 7821,
+      "isActive": true
+    }
+  ],
+  "activeAssistantId": "<id-of-active-assistant-or-null>"
+}
+```
+
+Each entry in the `assistants` array corresponds to an assistant in the
+lockfile. The extension maps the `cloud` field to an auth profile
+(`local-pair`, `cloud-oauth`, or `unsupported`) via
+`assistant-auth-profile.ts`. When the `assistantId` is supplied alongside
+a `request_token` frame, the helper pairs against the specified
+assistant's port rather than the default.
+
+#### Self-hosted pairing (`request_token`)
 
 The extension sends:
 
 ```json
 { "type": "request_token" }
+```
+
+Optionally with an `assistantId` to target a specific assistant:
+
+```json
+{ "type": "request_token", "assistantId": "<id>" }
 ```
 
 On success, the helper writes:
@@ -77,18 +119,20 @@ On success, the helper writes:
 }
 ```
 
+#### Error responses
+
 On any failure, the helper writes:
 
 ```json
 { "type": "error", "message": "<reason>" }
 ```
 
-…and exits with a non-zero status code. Possible `message` values
+...and exits with a non-zero status code. Possible `message` values
 include `unauthorized_origin`, `unsupported_frame_type`,
-`unexpected_additional_frame`, `protocol_error: malformed_frame_json: …`
+`unexpected_additional_frame`, `protocol_error: malformed_frame_json: ...`
 (returned when stdin contains a frame whose body is not valid JSON), and
 any error string surfaced by the underlying `fetch` to the assistant
-(`failed to reach assistant at …`, `assistant pair request failed with
+(`failed to reach assistant at ...`, `assistant pair request failed with
 HTTP 503`, etc.). Per the project-wide terminology rule in `AGENTS.md`,
 all user-visible strings refer to the local process as the "assistant".
 
@@ -102,7 +146,7 @@ extracts the bare extension ID, and rejects anything not in
 bytes.
 
 Today the allowlist contains a single dev placeholder ID. The production
-ID will be added before release — see the `// TODO: production id before
+ID will be added before release -- see the `// TODO: production id before
 release` comment in `src/index.ts`.
 
 ## Assistant port resolution
@@ -110,18 +154,18 @@ release` comment in `src/index.ts`.
 The helper looks up the assistant's HTTP port using the following
 precedence (highest first):
 
-1. **`--assistant-port <port>`** CLI flag — accepts either
+1. **`--assistant-port <port>`** CLI flag -- accepts either
    `--assistant-port 7822` or `--assistant-port=7822`. This exists so a
    wrapper script registered in Chrome's `NativeMessagingHosts` manifest
    can pin the helper to a known port for non-default installs (e.g.
    named local instances spawned by `cli/src/lib/local.ts` which set
    `RUNTIME_HTTP_PORT` from `resources.daemonPort`).
-2. **`~/.vellum/runtime-port`** lockfile — a single integer written by
+2. **`~/.vellum/runtime-port`** lockfile -- a single integer written by
    the assistant on startup via
    `RuntimeHttpServer.writeRuntimePortFile()`. Default installs (and any
    setup with a single running assistant) resolve their port through
    this file without any manifest-side configuration.
-3. **`7821`** — the well-known default port.
+3. **`7821`** -- the well-known default port.
 
 If a step fails (file missing, parse error, etc.), resolution falls
 through to the next step. The subsequent HTTP request will surface a
@@ -144,7 +188,7 @@ development and unit tests.
 ## Bundling into the macOS app
 
 The production macOS `.app` does **not** ship the `dist/index.js` form
-— Chrome's native messaging `path` field must point at a runnable
+-- Chrome's native messaging `path` field must point at a runnable
 executable, and we do not want to assume that the user has `node` on
 their `$PATH`. Instead, `clients/macos/build.sh` uses
 `bun build --compile` (via its shared `build_bun_binary` helper) to
@@ -169,7 +213,7 @@ new helper location without a manual re-pair step.
 The plan initially considered shipping `dist/index.js` plus a wrapper
 shell script. That approach was dropped because:
 
-1. Chrome's native messaging host `path` must be executable — it does
+1. Chrome's native messaging host `path` must be executable -- it does
    not support shell interpretation of script shebangs beyond the OS's
    own `execve`, which means we would still need a compiled wrapper.
 2. Every other binary the macOS app ships (daemon, CLI, gateway) uses
@@ -189,7 +233,7 @@ The canonical manifest shape is checked in at
 (idempotent) so that upgrading the app bundle automatically updates the
 `path` and `allowed_origins` entries. The `__HELPER_BINARY_PATH__` and
 `__VELLUM_EXTENSION_ID__` placeholders in the template are for
-humans reading the checked-in file — the actual install never
+humans reading the checked-in file -- the actual install never
 performs template substitution.
 
 ### Allowlist resolution in compiled builds
@@ -213,14 +257,12 @@ bun test src/__tests__/protocol.test.ts
 ```
 
 The current test suite covers the framing protocol (round-trips,
-multi-frame buffers, partial frames, empty buffers). The CLI itself does
-not yet have integration tests — those land alongside PR 13 when the
-extension-side bootstrap flow is wired up.
+multi-frame buffers, partial frames, empty buffers).
 
 ## Local manual smoke test
 
-Once the assistant is running and exposing `/v1/browser-extension-pair`
-(PR 11), you can exercise the helper end-to-end without Chrome by piping
+Once the assistant is running and exposing `/v1/browser-extension-pair`,
+you can exercise the helper end-to-end without Chrome by piping
 a framed request to it on stdin. If you need to rotate the extension ID,
 edit `meta/browser-extension/chrome-extension-allowlist.json`.
 Then run:
@@ -232,7 +274,7 @@ node --input-type=module -e "
 " | node dist/index.js "chrome-extension://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/"
 ```
 
-(The package is ESM — `"type": "module"` in `package.json` — so the
+(The package is ESM -- `"type": "module"` in `package.json` -- so the
 inline snippet uses `--input-type=module` and dynamic `import()` rather
 than `require()`, which would fail with `ERR_REQUIRE_ESM`.)
 
@@ -250,14 +292,11 @@ node --input-type=module -e "
     --assistant-port 7822
 ```
 
-## Related PRs
+To list assistants from the lockfile:
 
-- **PR 11** — Assistant `/v1/browser-extension-pair` endpoint that mints
-  the capability token this helper requests.
-- **PR 12** — macOS installer changes that drop the compiled binary and
-  the native messaging host manifest into Chrome's well-known
-  `NativeMessagingHosts` directory.
-- **PR 13** — Chrome extension changes that call
-  `chrome.runtime.connectNative("com.vellum.daemon")`, send a
-  `request_token` frame, and persist the response in
-  `chrome.storage.local`.
+```bash
+node --input-type=module -e "
+  import { encodeFrame } from './dist/protocol.js';
+  process.stdout.write(encodeFrame({ type: 'list_assistants' }));
+" | node dist/index.js "chrome-extension://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/"
+```


### PR DESCRIPTION
## Summary
- Remove remaining relayMode storage/constants and mode-switch handlers
- Delete compatibility branches for legacy mode keys
- Update extension and native-host READMEs with new assistant-centric flow
- Add troubleshooting guidance for common scenarios

Part of plan: chrome-extension-multi-assistant-auth.md (PR 6 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24766" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
