### PR TITLE
Route /v1/messages/:id/tts through provider abstraction

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -4801,7 +4801,7 @@ paths:
     post:
       operationId: messages_by_id_tts_post
       summary: Synthesize message to speech
-      description: Synthesize a message's text content to audio using Fish Audio TTS.
+      description: Synthesize a message's text content to audio using the configured TTS provider.
       tags:
         - messages
       responses:

--- a/assistant/src/runtime/routes/__tests__/tts-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/tts-routes.test.ts
@@ -117,14 +117,14 @@ function makeRouteContext(
     server: {} as RouteContext["server"],
     authContext: {
       subject: "test-user",
-      principalType: "host",
+      principalType: "local",
       assistantId: "self",
-      scopeProfile: "host",
-      scopes: new Set(),
+      scopeProfile: "local_v1",
+      scopes: new Set(["local.all" as const]),
       policyEpoch: 0,
     },
     params: { id: messageId },
-  } as RouteContext;
+  } as unknown as RouteContext;
 }
 
 async function readErrorBody(

--- a/assistant/src/runtime/routes/__tests__/tts-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/tts-routes.test.ts
@@ -1,0 +1,284 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Module mocks — must appear before any imports of the modules under test
+// ---------------------------------------------------------------------------
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// -- Feature flag mock -----------------------------------------------------
+
+let mockFeatureFlagEnabled = true;
+
+mock.module("../../../config/assistant-feature-flags.js", () => ({
+  isAssistantFeatureFlagEnabled: () => mockFeatureFlagEnabled,
+}));
+
+// -- Config mock -----------------------------------------------------------
+
+const mockConfig = {
+  services: {
+    tts: {
+      provider: "elevenlabs",
+      providers: {
+        elevenlabs: { voiceId: "test-voice" },
+        "fish-audio": { referenceId: "test-ref" },
+      },
+    },
+  },
+};
+
+mock.module("../../../config/loader.js", () => ({
+  getConfig: () => mockConfig,
+}));
+
+// -- Conversation history mock ---------------------------------------------
+
+let mockMessageContent: { text?: string } | null = {
+  text: "Hello, world!",
+};
+
+mock.module("../../../daemon/handlers/conversation-history.js", () => ({
+  getMessageContent: () => mockMessageContent,
+}));
+
+// -- TTS text sanitizer mock -----------------------------------------------
+
+mock.module("../../../calls/tts-text-sanitizer.js", () => ({
+  sanitizeForTts: (text: string) => text,
+}));
+
+// -- synthesizeText mock ---------------------------------------------------
+
+let mockSynthesizeResult: { audio: Buffer; contentType: string } = {
+  audio: Buffer.from("fake-audio"),
+  contentType: "audio/mpeg",
+};
+let mockSynthesizeError: Error | null = null;
+let lastSynthesizeOptions: Record<string, unknown> | null = null;
+
+mock.module("../../../tts/synthesize-text.js", () => ({
+  synthesizeText: async (options: Record<string, unknown>) => {
+    lastSynthesizeOptions = options;
+    if (mockSynthesizeError) throw mockSynthesizeError;
+    return mockSynthesizeResult;
+  },
+  TtsSynthesisError: class TtsSynthesisError extends Error {
+    readonly code: string;
+    constructor(code: string, message: string) {
+      super(message);
+      this.name = "TtsSynthesisError";
+      this.code = code;
+    }
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Import under test — after mocks
+// ---------------------------------------------------------------------------
+
+import type { RouteContext } from "../../http-router.js";
+import { ttsRouteDefinitions } from "../tts-routes.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function getHandler() {
+  const routes = ttsRouteDefinitions();
+  return routes[0].handler;
+}
+
+function makeRouteContext(
+  overrides: Partial<{
+    messageId: string;
+    conversationId: string | null;
+  }> = {},
+): RouteContext {
+  const messageId = overrides.messageId ?? "msg-123";
+  const conversationId = overrides.conversationId ?? "conv-456";
+
+  const searchParams = new URLSearchParams();
+  if (conversationId !== null) {
+    searchParams.set("conversationId", conversationId);
+  }
+  const url = new URL(
+    `http://localhost/v1/messages/${messageId}/tts?${searchParams.toString()}`,
+  );
+
+  return {
+    req: new Request(url, { method: "POST" }),
+    url,
+    server: {} as RouteContext["server"],
+    authContext: {
+      subject: "test-user",
+      principalType: "host",
+      assistantId: "self",
+      scopeProfile: "host",
+      scopes: new Set(),
+      policyEpoch: 0,
+    },
+    params: { id: messageId },
+  } as RouteContext;
+}
+
+async function readErrorBody(
+  response: Response,
+): Promise<{ error: { code: string; message: string } }> {
+  return response.json();
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  mockFeatureFlagEnabled = true;
+  mockMessageContent = { text: "Hello, world!" };
+  mockSynthesizeResult = {
+    audio: Buffer.from("fake-audio"),
+    contentType: "audio/mpeg",
+  };
+  mockSynthesizeError = null;
+  lastSynthesizeOptions = null;
+});
+
+afterEach(() => {
+  // Reset mocks to defaults
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("tts-routes", () => {
+  // -- Route metadata -------------------------------------------------------
+
+  test("exports a single route definition for messages/:id/tts", () => {
+    const routes = ttsRouteDefinitions();
+    expect(routes).toHaveLength(1);
+    expect(routes[0].endpoint).toBe("messages/:id/tts");
+    expect(routes[0].method).toBe("POST");
+  });
+
+  test("route description is provider-agnostic", () => {
+    const routes = ttsRouteDefinitions();
+    expect(routes[0].description).not.toMatch(/fish/i);
+    expect(routes[0].description).toContain("configured TTS provider");
+  });
+
+  // -- Feature flag gating --------------------------------------------------
+
+  test("returns 403 when message-tts flag is disabled", async () => {
+    mockFeatureFlagEnabled = false;
+
+    const handler = getHandler();
+    const res = await handler(makeRouteContext());
+
+    expect(res.status).toBe(403);
+    const body = await readErrorBody(res);
+    expect(body.error.code).toBe("FORBIDDEN");
+    expect(body.error.message).toContain("not enabled");
+  });
+
+  // -- Message lookup -------------------------------------------------------
+
+  test("returns 404 when message is not found", async () => {
+    mockMessageContent = null;
+
+    const handler = getHandler();
+    const res = await handler(makeRouteContext({ messageId: "missing-id" }));
+
+    expect(res.status).toBe(404);
+    const body = await readErrorBody(res);
+    expect(body.error.code).toBe("NOT_FOUND");
+    expect(body.error.message).toContain("missing-id");
+  });
+
+  test("returns 400 when message has no text content", async () => {
+    mockMessageContent = { text: undefined };
+
+    const handler = getHandler();
+    const res = await handler(makeRouteContext());
+
+    expect(res.status).toBe(400);
+    const body = await readErrorBody(res);
+    expect(body.error.code).toBe("BAD_REQUEST");
+    expect(body.error.message).toContain("no text content");
+  });
+
+  test("returns 400 when sanitized text is empty", async () => {
+    mockMessageContent = { text: "   " };
+
+    const handler = getHandler();
+    const res = await handler(makeRouteContext());
+
+    expect(res.status).toBe(400);
+    const body = await readErrorBody(res);
+    expect(body.error.code).toBe("BAD_REQUEST");
+    expect(body.error.message).toContain("no speakable text");
+  });
+
+  // -- Provider selection via orchestration layer ---------------------------
+
+  test("delegates to synthesizeText with message-playback use case", async () => {
+    const handler = getHandler();
+    const res = await handler(makeRouteContext());
+
+    expect(res.status).toBe(200);
+    expect(lastSynthesizeOptions).not.toBeNull();
+    expect(lastSynthesizeOptions!.text).toBe("Hello, world!");
+    expect(lastSynthesizeOptions!.useCase).toBe("message-playback");
+  });
+
+  test("returns audio response with correct content type", async () => {
+    mockSynthesizeResult = {
+      audio: Buffer.from("wav-audio"),
+      contentType: "audio/wav",
+    };
+
+    const handler = getHandler();
+    const res = await handler(makeRouteContext());
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("audio/wav");
+
+    const body = await res.arrayBuffer();
+    expect(Buffer.from(body).toString()).toBe("wav-audio");
+  });
+
+  // -- Provider not configured ----------------------------------------------
+
+  test("returns 503 when TTS provider is not configured", async () => {
+    const err = new Error("TTS provider not configured");
+    Object.assign(err, { code: "TTS_PROVIDER_NOT_CONFIGURED" });
+    mockSynthesizeError = err;
+
+    const handler = getHandler();
+    const res = await handler(makeRouteContext());
+
+    expect(res.status).toBe(503);
+    const body = await readErrorBody(res);
+    expect(body.error.code).toBe("SERVICE_UNAVAILABLE");
+    expect(body.error.message).toContain("not configured");
+  });
+
+  // -- Synthesis failure ----------------------------------------------------
+
+  test("returns 502 when synthesis fails with generic error", async () => {
+    mockSynthesizeError = new Error("upstream failure");
+
+    const handler = getHandler();
+    const res = await handler(makeRouteContext());
+
+    expect(res.status).toBe(502);
+    const body = await readErrorBody(res);
+    expect(body.error.code).toBe("INTERNAL_ERROR");
+    expect(body.error.message).toContain("synthesis failed");
+  });
+});

--- a/assistant/src/runtime/routes/tts-routes.ts
+++ b/assistant/src/runtime/routes/tts-routes.ts
@@ -4,14 +4,14 @@
  * POST /v1/messages/:id/tts?conversationId=... — synthesize message text to audio
  *
  * Gated behind the `message-tts` assistant feature flag.
- * Uses Fish Audio for synthesis when configured.
+ * Uses the globally configured TTS provider via the provider abstraction.
  */
 
-import { synthesizeWithFishAudio } from "../../calls/fish-audio-client.js";
 import { sanitizeForTts } from "../../calls/tts-text-sanitizer.js";
 import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
 import { getConfig } from "../../config/loader.js";
 import { getMessageContent } from "../../daemon/handlers/conversation-history.js";
+import { synthesizeText } from "../../tts/synthesize-text.js";
 import { getLogger } from "../../util/logger.js";
 import { httpError } from "../http-errors.js";
 import type { RouteDefinition } from "../http-router.js";
@@ -32,7 +32,7 @@ export function ttsRouteDefinitions(): RouteDefinition[] {
       policyKey: "messages/tts",
       summary: "Synthesize message to speech",
       description:
-        "Synthesize a message's text content to audio using Fish Audio TTS.",
+        "Synthesize a message's text content to audio using the configured TTS provider.",
       tags: ["messages"],
       queryParams: [
         {
@@ -70,35 +70,32 @@ export function ttsRouteDefinitions(): RouteDefinition[] {
           );
         }
 
-        const { fishAudio } = config;
-        if (!fishAudio?.referenceId) {
-          return httpError(
-            "SERVICE_UNAVAILABLE",
-            "Fish Audio TTS is not configured",
-            503,
-          );
-        }
-
         try {
-          const audioBuffer = await synthesizeWithFishAudio(
-            sanitizedText,
-            fishAudio,
-          );
+          const { audio, contentType } = await synthesizeText({
+            text: sanitizedText,
+            useCase: "message-playback",
+          });
 
-          const format = fishAudio.format ?? "mp3";
-          const contentType =
-            format === "wav"
-              ? "audio/wav"
-              : format === "opus"
-                ? "audio/opus"
-                : "audio/mpeg";
-
-          return new Response(new Uint8Array(audioBuffer), {
+          return new Response(new Uint8Array(audio), {
             status: 200,
             headers: { "Content-Type": contentType },
           });
         } catch (err) {
           log.error({ err, messageId }, "TTS synthesis failed");
+
+          // Surface provider-not-configured as 503
+          if (
+            err instanceof Error &&
+            "code" in err &&
+            (err as { code: string }).code === "TTS_PROVIDER_NOT_CONFIGURED"
+          ) {
+            return httpError(
+              "SERVICE_UNAVAILABLE",
+              "TTS provider is not configured",
+              503,
+            );
+          }
+
           return httpError("INTERNAL_ERROR", "TTS synthesis failed", 502);
         }
       },

--- a/assistant/src/tts/synthesize-text.ts
+++ b/assistant/src/tts/synthesize-text.ts
@@ -1,0 +1,110 @@
+/**
+ * Top-level TTS orchestration layer.
+ *
+ * Resolves the globally configured provider via {@link resolveTtsConfig},
+ * looks up the provider adapter in the registry, and delegates synthesis.
+ * Callers supply the pre-sanitized text and a use-case discriminator;
+ * provider selection is always global — per-use-case policy only gates
+ * capabilities (e.g. format checks), never overrides the chosen provider.
+ */
+
+import { getConfig } from "../config/loader.js";
+import { getLogger } from "../util/logger.js";
+import { getTtsProvider } from "./provider-registry.js";
+import { resolveTtsConfig } from "./tts-config-resolver.js";
+import type { TtsSynthesisResult, TtsUseCase } from "./types.js";
+
+const log = getLogger("tts:synthesize");
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface SynthesizeTextOptions {
+  /** Pre-sanitized text to speak. */
+  text: string;
+
+  /** Product surface requesting synthesis. */
+  useCase: TtsUseCase;
+
+  /** Optional voice override (provider-specific identifier). */
+  voiceId?: string;
+
+  /** Optional abort signal. */
+  signal?: AbortSignal;
+}
+
+// ---------------------------------------------------------------------------
+// Error types
+// ---------------------------------------------------------------------------
+
+export type TtsSynthesisErrorCode =
+  | "TTS_PROVIDER_NOT_CONFIGURED"
+  | "TTS_SYNTHESIS_FAILED";
+
+export class TtsSynthesisError extends Error {
+  readonly code: TtsSynthesisErrorCode;
+
+  constructor(code: TtsSynthesisErrorCode, message: string) {
+    super(message);
+    this.name = "TtsSynthesisError";
+    this.code = code;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Synthesize text to audio using the globally configured TTS provider.
+ *
+ * 1. Resolves the active provider and its config via `tts-config-resolver`.
+ * 2. Looks up the provider adapter in the registry.
+ * 3. Delegates to the adapter's `synthesize` method.
+ *
+ * Throws {@link TtsSynthesisError} when the provider is not registered
+ * or synthesis fails.
+ */
+export async function synthesizeText(
+  options: SynthesizeTextOptions,
+): Promise<TtsSynthesisResult> {
+  const config = getConfig();
+  const { provider: providerId } = resolveTtsConfig(config);
+
+  let provider;
+  try {
+    provider = getTtsProvider(providerId);
+  } catch {
+    throw new TtsSynthesisError(
+      "TTS_PROVIDER_NOT_CONFIGURED",
+      `TTS provider "${providerId}" is not configured or not registered.`,
+    );
+  }
+
+  log.info(
+    {
+      provider: providerId,
+      useCase: options.useCase,
+      textLength: options.text.length,
+    },
+    "Synthesizing text with TTS provider",
+  );
+
+  try {
+    return await provider.synthesize({
+      text: options.text,
+      useCase: options.useCase,
+      voiceId: options.voiceId,
+      signal: options.signal,
+    });
+  } catch (err) {
+    // Re-throw TtsSynthesisError as-is (e.g. from inner adapter errors).
+    if (err instanceof TtsSynthesisError) throw err;
+
+    throw new TtsSynthesisError(
+      "TTS_SYNTHESIS_FAILED",
+      `TTS synthesis failed (provider: ${providerId}): ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Adds synthesize-text.ts orchestration layer that resolves provider via config and calls registry adapters
- Refactors tts-routes.ts to remove direct Fish Audio imports and use the orchestration layer
- Updates OpenAPI docs to be provider-agnostic

Part of plan: product-tts-provider-abstraction.md (PR 4 of 11)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24767" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
