### PR TITLE
fix: correct lockfile path references in extension README

### DIFF
--- a/clients/chrome-extension/README.md
+++ b/clients/chrome-extension/README.md
@@ -164,7 +164,7 @@ The native messaging helper reads the lockfile to discover assistants. If the
 popup shows no assistants:
 
 - Verify at least one assistant is running: check for the lockfile at
-  `~/.vellum/lockfile.json` (or the path appropriate for your OS).
+  `~/.vellum.lock.json` (or `~/.vellum.lockfile.json` for legacy installs).
 - Verify the native messaging host is installed and reachable (see the setup
   section above). The macOS app installs the manifest automatically on launch.
 - Check the service worker console for `native messaging` errors.
@@ -207,7 +207,7 @@ the appropriate auth flow for the newly selected assistant before connecting.
 ### Useful checks
 
 ```bash
-cat ~/.vellum/lockfile.json
+cat ~/.vellum.lock.json
 cat ~/.vellum/runtime-port
 cat "$HOME/Library/Application Support/Google/Chrome/NativeMessagingHosts/com.vellum.daemon.json"
 cat meta/browser-extension/chrome-extension-allowlist.json


### PR DESCRIPTION
## Summary
Fixes incorrect lockfile path in README.

**Gap:** README references ~/.vellum/lockfile.json instead of ~/.vellum.lock.json
**What was expected:** Paths should match what lockfile.ts actually reads
**What was found:** Two references to the wrong path
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24768" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
