### PR TITLE
fix: re-throw non-MissingTokenError in assistant-select handler

### DIFF
--- a/clients/chrome-extension/background/worker.ts
+++ b/clients/chrome-extension/background/worker.ts
@@ -1028,6 +1028,8 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponseFn) => {
               console.warn(
                 `[vellum-relay] Assistant switch left disconnected: ${err.message}`,
               );
+            } else {
+              throw err;
             }
           }
         }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review.

**Gap:** Non-MissingTokenError silently swallowed during assistant switch
**What was expected:** Unexpected errors should propagate to outer error handler
**What was found:** catch block returns ok:true for non-MissingTokenError
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24769" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
