### PR TITLE
fix: pass assistantId to assistant-scoped token reads in popup.ts

### DIFF
--- a/clients/chrome-extension/popup/popup.ts
+++ b/clients/chrome-extension/popup/popup.ts
@@ -69,6 +69,7 @@ const assistantSelect = document.getElementById(
 // connect and auth-refresh operations use the right assistant context.
 
 let currentAuthProfile: AssistantAuthProfile | null = null;
+let currentAssistantId: string | null = null;
 
 // ── Connection state helpers ────────────────────────────────────────
 
@@ -203,6 +204,8 @@ function loadAssistantCatalog(): void {
     const selected = response.selected ?? null;
     const authProfile = response.authProfile ?? null;
 
+    currentAssistantId = selected?.assistantId ?? null;
+
     renderAssistantSelector(assistants, selected);
     updateAuthSections(authProfile);
 
@@ -235,6 +238,7 @@ assistantSelect.addEventListener('change', () => {
         return;
       }
 
+      currentAssistantId = response.selected?.assistantId ?? assistantId;
       const authProfile = response.authProfile ?? null;
       updateAuthSections(authProfile);
 
@@ -278,7 +282,11 @@ btnConnect.addEventListener('click', async () => {
   // (vellum.cloudAuthToken) directly, so the popup must NOT try to hit
   // localhost — a cloud-only user may not have a local assistant running.
   if (currentAuthProfile === 'local-pair') {
-    const pairedToken = await getStoredLocalToken();
+    if (!currentAssistantId) {
+      showError('No assistant selected — please select an assistant first.');
+      return;
+    }
+    const pairedToken = await getStoredLocalToken(currentAssistantId);
     if (!pairedToken) {
       showError(
         'Local assistant is not paired yet — click "Pair with local assistant" below before connecting.',
@@ -344,8 +352,12 @@ function formatLocalTokenStatus(token: StoredLocalToken): string {
 }
 
 async function refreshLocalStatus(): Promise<void> {
+  if (!currentAssistantId) {
+    setLocalStatus('Not paired', 'neutral');
+    return;
+  }
   try {
-    const existing = await getStoredLocalToken();
+    const existing = await getStoredLocalToken(currentAssistantId);
     if (existing) {
       setLocalStatus(formatLocalTokenStatus(existing), 'paired');
     } else {
@@ -405,8 +417,12 @@ function setCloudStatus(text: string, signedIn: boolean): void {
 }
 
 async function refreshCloudStatus(): Promise<void> {
+  if (!currentAssistantId) {
+    setCloudStatus('Not signed in', false);
+    return;
+  }
   try {
-    const existing = await getStoredToken();
+    const existing = await getStoredToken(currentAssistantId);
     if (existing) {
       setCloudStatus(`Signed in as guardian:${existing.guardianId}`, true);
     } else {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for chrome-extension-multi-assistant-auth.md.

**Gap:** popup.ts calls getStoredLocalToken/getStoredToken without assistantId
**What was expected:** assistant-scoped token functions require assistantId parameter
**What was found:** 3 call sites in popup.ts omit the required argument
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24770" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
