### PR TITLE
fix: extract IPv6 host helper, document cooldown scope, clarify abort path

### DIFF
--- a/assistant/src/tools/browser/cdp-client/cdp-inspect-client.ts
+++ b/assistant/src/tools/browser/cdp-client/cdp-inspect-client.ts
@@ -314,6 +314,13 @@ export class CdpInspectClient implements ScopedCdpClient {
       throw httpResult.error;
     }
 
+    // Guard against the narrow race where tryHttpDiscovery returned a
+    // fallback-eligible error (unreachable / invalid_response) but the
+    // signal was aborted between that return and this check. The abort
+    // CdpError from tryHttpDiscovery itself only surfaces when the signal
+    // is already aborted *during* a fetch/probe; this covers the gap
+    // between the last await inside tryHttpDiscovery and the fallback
+    // eligibility check above.
     if (signal.aborted) {
       throw new CdpError("aborted", "CdpInspectClient attach aborted");
     }

--- a/assistant/src/tools/browser/cdp-client/cdp-inspect/discovery.ts
+++ b/assistant/src/tools/browser/cdp-client/cdp-inspect/discovery.ts
@@ -135,13 +135,25 @@ function assertWsUrlLoopback(wsUrl: string): void {
 }
 
 /**
+ * Normalize a loopback host string for use in a URL. IPv6 bare form
+ * (`::1`) is wrapped in square brackets (`[::1]`) as required by
+ * RFC 3986; all other hosts are lowercased and returned as-is.
+ *
+ * This is the single source of truth for IPv6 bracket normalization
+ * across both HTTP and WS URL construction in this module.
+ */
+function normalizeHostForWsUrl(host: string): string {
+  const normalized = host.toLowerCase();
+  return normalized === "::1" ? "[::1]" : normalized;
+}
+
+/**
  * Build a fetch-ready loopback URL. `host` is assumed to have already
  * been validated by {@link assertLoopback}. IPv6 bare form (`::1`) is
  * wrapped in square brackets for URL correctness.
  */
 function buildUrl(host: string, port: number, pathname: string): string {
-  const normalized = host.toLowerCase();
-  const hostSegment = normalized === "::1" ? "[::1]" : normalized;
+  const hostSegment = normalizeHostForWsUrl(host);
   return `http://${hostSegment}:${port}${pathname}`;
 }
 
@@ -603,8 +615,7 @@ function isUtilityTarget(target: DevToolsTarget): boolean {
  */
 export function buildBrowserWsUrl(host: string, port: number): string {
   assertLoopback(host);
-  const normalized = host.toLowerCase();
-  const hostSegment = normalized === "::1" ? "[::1]" : normalized;
+  const hostSegment = normalizeHostForWsUrl(host);
   return `ws://${hostSegment}:${port}/devtools/browser`;
 }
 
@@ -676,8 +687,7 @@ export async function discoverTargetsViaWs(opts: {
     );
   }
 
-  const normalized = opts.host.toLowerCase();
-  const hostSegment = normalized === "::1" ? "[::1]" : normalized;
+  const hostSegment = normalizeHostForWsUrl(opts.host);
 
   const targets: DevToolsTarget[] = [];
   for (const info of targetInfos) {

--- a/assistant/src/tools/browser/cdp-client/factory.ts
+++ b/assistant/src/tools/browser/cdp-client/factory.ts
@@ -33,6 +33,13 @@ const log = getLogger("cdp-factory");
  * is less than the configured `desktopAuto.cooldownMs`, the factory skips the
  * automatic cdp-inspect candidate and goes straight to the local backend.
  *
+ * **Process-global scope**: this is a module-level singleton that affects ALL
+ * conversations in the process. A cdp-inspect failure on any conversation
+ * suppresses desktop-auto probes for every conversation in this daemon until
+ * the cooldown expires. This is intentional -- the local loopback CDP
+ * endpoint is per-machine, not per-conversation, so a failure on one
+ * conversation implies all others would fail the same way.
+ *
  * Reset to 0 when the cooldown expires or when manually cleared via
  * {@link _resetDesktopAutoCooldown} (for testing).
  */


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for macos-browser-extension-cdp-fallback.md.

**Gap 1:** Duplicated IPv6 bracket logic
**What was expected:** Single source of truth
**What was found:** Identical normalization in two functions

**Gap 2:** Undocumented cross-conversation cooldown scope
**What was expected:** Clear documentation of process-global scope
**What was found:** No comment on cross-conversation semantics

**Gap 3:** Dead code in abort path
**What was expected:** Clear control flow
**What was found:** Unreachable signal.aborted check without explanation
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24771" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
