### PR TITLE
fix: replace toBeDefined/toHaveLength with type-compatible matchers in tests

### DIFF
--- a/clients/chrome-extension/background/__tests__/cloud-auth.test.ts
+++ b/clients/chrome-extension/background/__tests__/cloud-auth.test.ts
@@ -397,7 +397,7 @@ describe('assistant token isolation', () => {
     await signInCloud(ASSISTANT_B, config);
 
     // Only ASSISTANT_B's key should be populated.
-    expect(fakeStorage.data[cloudTokenStorageKey(ASSISTANT_B)]).toBeDefined();
+    expect(fakeStorage.data[cloudTokenStorageKey(ASSISTANT_B)]).not.toBeUndefined();
     expect(fakeStorage.data[cloudTokenStorageKey(ASSISTANT_A)]).toBeUndefined();
   });
 });

--- a/clients/chrome-extension/background/__tests__/self-hosted-auth.test.ts
+++ b/clients/chrome-extension/background/__tests__/self-hosted-auth.test.ts
@@ -584,7 +584,7 @@ describe('assistant token isolation', () => {
     await bootstrapLocalToken(ASSISTANT_B);
 
     // Only ASSISTANT_B's key should be populated.
-    expect(fakeStorage.data[localTokenStorageKey(ASSISTANT_B)]).toBeDefined();
+    expect(fakeStorage.data[localTokenStorageKey(ASSISTANT_B)]).not.toBeUndefined();
     expect(fakeStorage.data[localTokenStorageKey(ASSISTANT_A)]).toBeUndefined();
   });
 });

--- a/clients/chrome-extension/background/__tests__/worker-assistant-catalog.test.ts
+++ b/clients/chrome-extension/background/__tests__/worker-assistant-catalog.test.ts
@@ -213,7 +213,7 @@ describe('listAssistants', () => {
 
     const catalog = await listAssistants();
 
-    expect(catalog.assistants).toHaveLength(2);
+    expect(catalog.assistants.length).toBe(2);
     expect(catalog.activeAssistantId).toBe('a-1');
 
     // First assistant: local with daemon port
@@ -245,7 +245,7 @@ describe('listAssistants', () => {
     };
 
     const catalog = await listAssistants();
-    expect(catalog.assistants).toHaveLength(0);
+    expect(catalog.assistants.length).toBe(0);
     expect(catalog.activeAssistantId).toBeNull();
   });
 
@@ -267,7 +267,7 @@ describe('listAssistants', () => {
     };
 
     const catalog = await listAssistants();
-    expect(catalog.assistants).toHaveLength(2);
+    expect(catalog.assistants.length).toBe(2);
     expect(catalog.assistants[0]!.assistantId).toBe('valid');
     expect(catalog.assistants[1]!.assistantId).toBe('also-valid');
   });
@@ -321,7 +321,7 @@ describe('listAssistants', () => {
     };
 
     const catalog = await listAssistants();
-    expect(catalog.assistants).toHaveLength(0);
+    expect(catalog.assistants.length).toBe(0);
     expect(catalog.activeAssistantId).toBe('orphan');
   });
 


### PR DESCRIPTION
## Summary
Fixes type errors in test files.

**Gap:** Test files use matchers not in extension's TypeScript type declarations
**What was expected:** Tests should compile with tsconfig types: []
**What was found:** toBeDefined and toHaveLength cause TS2551/TS2339 errors
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24772" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
