### PR TITLE
fix: eliminate double browser proxy restore and extract interface helper

### DIFF
--- a/assistant/src/channels/types.ts
+++ b/assistant/src/channels/types.ts
@@ -145,6 +145,22 @@ export function supportsHostProxy(
   return false;
 }
 
+/**
+ * Whether the interface can service host_browser frames via the
+ * ChromeExtensionRegistry (WebSocket) when an extension connection exists.
+ *
+ * Returns `true` for interfaces where the daemon should set
+ * `hostBrowserSenderOverride` and provision a `HostBrowserProxy` when the
+ * guardian has an active extension connection — currently `chrome-extension`
+ * and `macos`.
+ *
+ * Use this instead of hard-coding interface checks so new desktop interfaces
+ * only need to be added in one place.
+ */
+export function canServiceRegistryBrowser(id: InterfaceId): boolean {
+  return id === "chrome-extension" || id === "macos";
+}
+
 export interface TurnInterfaceContext {
   userMessageInterface: InterfaceId;
   assistantMessageInterface: InterfaceId;

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -390,7 +390,7 @@ export async function drainQueue(
     // inherit a stale override left by a prior extension-connected turn
     // and keep the proxy alive, causing cross-interface misrouting.
     const currentTurnCanServiceBrowser =
-      canServiceRegistryBrowser(sourceInterface);
+      !!sourceInterface && canServiceRegistryBrowser(sourceInterface);
     if (
       sourceInterface &&
       !supportsHostProxy(sourceInterface, "host_browser") &&

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -11,14 +11,13 @@ import {
   createAssistantMessage,
   createUserMessage,
 } from "../agent/message-types.js";
-import type {
-  TurnChannelContext,
-  TurnInterfaceContext,
-} from "../channels/types.js";
 import {
+  canServiceRegistryBrowser,
   parseChannelId,
   parseInterfaceId,
   supportsHostProxy,
+  type TurnChannelContext,
+  type TurnInterfaceContext,
 } from "../channels/types.js";
 import { getConfig } from "../config/loader.js";
 import type { ContextWindowResult } from "../context/window-manager.js";
@@ -135,8 +134,13 @@ export interface ProcessConversationContext {
   setTurnInterfaceContext(ctx: TurnInterfaceContext): void;
   /** Mark host proxies as unavailable so tool execution uses local fallback. */
   clearProxyAvailability(): void;
-  /** Restore host proxy availability based on whether a real client is connected. */
-  restoreProxyAvailability(): void;
+  /**
+   * Restore host proxy availability based on whether a real client is connected.
+   * When `skipBrowser` is true, the browser proxy is left untouched — use this
+   * when `restoreBrowserProxyAvailability()` will handle the browser proxy
+   * separately with the correct registry-routed sender.
+   */
+  restoreProxyAvailability(options?: { skipBrowser?: boolean }): void;
   /** Restore only the host browser proxy (used by chrome-extension and macOS+extension drains). */
   restoreBrowserProxyAvailability(): void;
   /**
@@ -361,7 +365,14 @@ export async function drainQueue(
       queuedInterfaceCtx ?? conversation.getTurnInterfaceContext();
     const sourceInterface = interfaceCtx?.userMessageInterface;
     if (sourceInterface && supportsHostProxy(sourceInterface)) {
-      conversation.restoreProxyAvailability();
+      // When hostBrowserSenderOverride is set, skip the browser proxy here
+      // — restoreBrowserProxyAvailability() below will handle it with the
+      // correct registry-routed sender instead of the SSE hub emitter.
+      conversation.restoreProxyAvailability(
+        conversation.hostBrowserSenderOverride
+          ? { skipBrowser: true }
+          : undefined,
+      );
       conversation.addPreactivatedSkillId("computer-use");
     }
     // Tear down a stale hostBrowserProxy inherited from a prior turn on a
@@ -379,7 +390,7 @@ export async function drainQueue(
     // inherit a stale override left by a prior extension-connected turn
     // and keep the proxy alive, causing cross-interface misrouting.
     const currentTurnCanServiceBrowser =
-      sourceInterface === "chrome-extension" || sourceInterface === "macos";
+      canServiceRegistryBrowser(sourceInterface);
     if (
       sourceInterface &&
       !supportsHostProxy(sourceInterface, "host_browser") &&

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -574,11 +574,18 @@ export class Conversation {
     this.hostFileProxy?.updateSender(this.sendToClient, false);
   }
 
-  /** Restore host proxy availability based on whether a real client is connected. */
-  restoreProxyAvailability(): void {
+  /**
+   * Restore host proxy availability based on whether a real client is connected.
+   * When `skipBrowser` is true, the browser proxy is left untouched — use this
+   * when `restoreBrowserProxyAvailability()` will handle the browser proxy
+   * separately with the correct registry-routed sender.
+   */
+  restoreProxyAvailability(options?: { skipBrowser?: boolean }): void {
     if (!this.hasNoClient) {
       this.hostBashProxy?.updateSender(this.sendToClient, true);
-      this.hostBrowserProxy?.updateSender(this.sendToClient, true);
+      if (!options?.skipBrowser) {
+        this.hostBrowserProxy?.updateSender(this.sendToClient, true);
+      }
       this.hostCuProxy?.updateSender(this.sendToClient, true);
       this.hostFileProxy?.updateSender(this.sendToClient, true);
     }

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -12,6 +12,7 @@ import {
   createUserMessage,
 } from "../../agent/message-types.js";
 import {
+  canServiceRegistryBrowser,
   CHANNEL_IDS,
   INTERFACE_IDS,
   type InterfaceId,
@@ -1432,7 +1433,7 @@ export async function handleSendMessage(
   // provisioning and browser tools fall through to cdp-inspect/local.
   const shouldProvisionBrowserProxy =
     supportsHostProxy(sourceInterface, "host_browser") ||
-    (sourceInterface === "macos" && isRegistryRouted);
+    (canServiceRegistryBrowser(sourceInterface) && isRegistryRouted);
   if (shouldProvisionBrowserProxy) {
     if (!conversation.isProcessing() || !conversation.hostBrowserProxy) {
       const browserProxy = new HostBrowserProxy(


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for macos-browser-extension-cdp-fallback.md.

**Gap 1:** Double restoreBrowserProxyAvailability() call in drain queue
**What was expected:** Browser proxy restored once with correct sender
**What was found:** Restored twice — first with SSE hub sender, then overwritten with registry override

**Gap 2:** Hard-coded macOS interface checks
**What was expected:** Maintainable interface checks using shared helper
**What was found:** Duplicated sourceInterface === 'macos' checks in process and routes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24774" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
