### PR TITLE
Refactor call-controller assistant speech to use provider abstraction

### DIFF
--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -39,6 +39,36 @@ mock.module("../config/loader.js", () => {
     },
     memory: { enabled: false },
     notifications: { decisionModelIntent: "latency-optimized" },
+    services: {
+      tts: {
+        mode: "your-own" as const,
+        provider: "elevenlabs",
+        providers: {
+          elevenlabs: {
+            voiceId: "ZF6FPAbjXT4488VcRRnw",
+            voiceModelId: "",
+            speed: 1.0,
+            stability: 0.5,
+            similarityBoost: 0.75,
+            conversationTimeoutSeconds: 30,
+          },
+          "fish-audio": {
+            referenceId: "",
+            chunkLength: 200,
+            format: "mp3",
+            latency: "normal",
+            speed: 1.0,
+          },
+        },
+      },
+    },
+    elevenlabs: {
+      voiceId: "ZF6FPAbjXT4488VcRRnw",
+    },
+    fishAudio: {
+      referenceId: "",
+      format: "mp3",
+    },
   };
   return {
     getConfig: () => config,
@@ -53,6 +83,17 @@ mock.module("../config/loader.js", () => {
     API_KEY_PROVIDERS: [],
   };
 });
+
+// ── Credential mock (prevents real key lookups) ──────────────────────
+
+mock.module("../security/secure-keys.js", () => ({
+  getSecureKeyAsync: async () => null,
+  getSecureKey: () => null,
+}));
+
+mock.module("../security/credential-key.js", () => ({
+  credentialKey: (...args: string[]) => args.join("/"),
+}));
 
 // ── Call constants mock ──────────────────────────────────────────────
 
@@ -128,6 +169,48 @@ mock.module("../calls/voice-session-bridge.js", () => {
   };
 });
 
+// ── TTS provider registry setup ──────────────────────────────────────
+// Register test providers so call-controller can resolve the TTS provider
+// abstraction. ElevenLabs is the default native provider (no streaming),
+// while Fish Audio is a synthesized provider (streaming).
+
+import {
+  _resetTtsProviderRegistry,
+  registerTtsProvider,
+} from "../tts/provider-registry.js";
+import type { TtsProvider } from "../tts/types.js";
+
+function registerTestTtsProviders(): void {
+  _resetTtsProviderRegistry();
+
+  const elevenlabs: TtsProvider = {
+    id: "elevenlabs",
+    capabilities: { supportsStreaming: false, supportedFormats: ["mp3"] },
+    async synthesize() {
+      return { audio: Buffer.from(""), contentType: "audio/mpeg" };
+    },
+  };
+  registerTtsProvider(elevenlabs);
+
+  const fishAudio: TtsProvider = {
+    id: "fish-audio",
+    capabilities: {
+      supportsStreaming: true,
+      supportedFormats: ["mp3", "wav", "opus"],
+    },
+    async synthesize() {
+      return { audio: Buffer.from(""), contentType: "audio/mpeg" };
+    },
+    async synthesizeStream(_req, _onChunk) {
+      return { audio: Buffer.from(""), contentType: "audio/mpeg" };
+    },
+  };
+  registerTtsProvider(fishAudio);
+}
+
+// Register providers immediately so they're available for all tests
+registerTestTtsProviders();
+
 // ── Import source modules after all mocks are registered ────────────
 
 import { CallController } from "../calls/call-controller.js";
@@ -158,6 +241,7 @@ afterAll(() => {
 
 interface MockRelay extends RelayConnection {
   sentTokens: Array<{ token: string; last: boolean }>;
+  sentPlayUrls: string[];
   endCalled: boolean;
   endReason: string | undefined;
   mockConnectionState: string;
@@ -166,6 +250,7 @@ interface MockRelay extends RelayConnection {
 function createMockRelay(): MockRelay {
   const state = {
     sentTokens: [] as Array<{ token: string; last: boolean }>,
+    sentPlayUrls: [] as string[],
     _endCalled: false,
     _endReason: undefined as string | undefined,
     _connectionState: "connected",
@@ -174,6 +259,9 @@ function createMockRelay(): MockRelay {
   return {
     get sentTokens() {
       return state.sentTokens;
+    },
+    get sentPlayUrls() {
+      return state.sentPlayUrls;
     },
     get endCalled() {
       return state._endCalled;
@@ -189,6 +277,9 @@ function createMockRelay(): MockRelay {
     },
     sendTextToken(token: string, last: boolean) {
       state.sentTokens.push({ token, last });
+    },
+    sendPlayUrl(url: string) {
+      state.sentPlayUrls.push(url);
     },
     endSession(reason?: string) {
       state._endCalled = true;
@@ -345,6 +436,8 @@ describe("call-controller", () => {
     // Reset consultation timeout to the default (long) value
     mockConsultationTimeoutMs = 90_000;
     mockSilenceTimeoutMs = 30_000;
+    // Reset TTS provider registry to ensure clean state
+    registerTestTtsProviders();
   });
 
   // ── handleCallerUtterance ─────────────────────────────────────────
@@ -2288,6 +2381,118 @@ describe("call-controller", () => {
     expect(text).not.toBeNull();
     expect(text!).toContain("+15552222222");
     expect(text!).toContain("completed");
+
+    controller.destroy();
+  });
+
+  // ── TTS provider abstraction: native-token path ─────────────────────
+
+  test("native provider (ElevenLabs): streams text tokens directly to relay", async () => {
+    // Default config uses ElevenLabs (native, no streaming) — the text
+    // tokens should flow directly through sendTextToken to the relay.
+    mockStartVoiceTurn.mockImplementation(
+      createMockVoiceTurn(["Hello", ", how", " are you?"]),
+    );
+    const { relay, controller } = setupController();
+
+    await controller.handleCallerUtterance("Hi");
+
+    // Verify text tokens were sent directly (not empty — real text content)
+    const nonEmptyTokens = relay.sentTokens.filter((t) => t.token.length > 0);
+    expect(nonEmptyTokens.length).toBeGreaterThan(0);
+    // At least one token should contain actual text content
+    const allText = nonEmptyTokens.map((t) => t.token).join("");
+    expect(allText).toContain("Hello");
+    expect(allText).toContain("how");
+    expect(allText).toContain("are you");
+
+    // The final token should signal end of turn
+    const lastToken = relay.sentTokens[relay.sentTokens.length - 1];
+    expect(lastToken.last).toBe(true);
+
+    controller.destroy();
+  });
+
+  test("native provider (ElevenLabs): strips control markers from streamed text tokens", async () => {
+    mockStartVoiceTurn.mockImplementation(
+      createMockVoiceTurn([
+        "I will check on that. ",
+        "[ASK_GUARDIAN: Is 3pm ok?]",
+      ]),
+    );
+    const { relay, controller } = setupController();
+
+    await controller.handleCallerUtterance("Book an appointment");
+
+    const allText = relay.sentTokens.map((t) => t.token).join("");
+    expect(allText).toContain("I will check on that.");
+    expect(allText).not.toContain("[ASK_GUARDIAN:");
+
+    controller.destroy();
+  });
+
+  test("native provider (ElevenLabs): END_CALL marker handled correctly with text tokens", async () => {
+    mockStartVoiceTurn.mockImplementation(
+      createMockVoiceTurn(["Thanks for calling! ", "[END_CALL]"]),
+    );
+    const { session, relay, controller } = setupController();
+
+    await controller.handleCallerUtterance("Goodbye");
+
+    expect(relay.endCalled).toBe(true);
+    const updatedSession = getCallSession(session.id);
+    expect(updatedSession!.status).toBe("completed");
+
+    const allText = relay.sentTokens.map((t) => t.token).join("");
+    expect(allText).not.toContain("[END_CALL]");
+    expect(allText).toContain("Thanks for calling!");
+
+    controller.destroy();
+  });
+
+  // ── TTS provider abstraction: interruption behavior ─────────────────
+
+  test("handleInterrupt: cancels synthesis abort controller for native provider path", async () => {
+    // Using the default native provider (ElevenLabs) — no synthesis abort
+    // controller should be active, but interrupt should still work cleanly.
+    mockStartVoiceTurn.mockImplementation(
+      async (opts: {
+        signal?: AbortSignal;
+        onTextDelta: (t: string) => void;
+        onComplete: () => void;
+      }) => {
+        return new Promise((resolve) => {
+          const timeout = setTimeout(() => {
+            opts.onTextDelta("This should be interrupted");
+            opts.onComplete();
+            resolve({ turnId: "run-1", abort: () => {} });
+          }, 1000);
+
+          opts.signal?.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(timeout);
+              opts.onComplete();
+              resolve({ turnId: "run-1", abort: () => {} });
+            },
+            { once: true },
+          );
+        });
+      },
+    );
+
+    const { relay, controller } = setupController();
+    const turnPromise = controller.handleCallerUtterance("Start speaking");
+    await new Promise((r) => setTimeout(r, 5));
+    controller.handleInterrupt();
+    await turnPromise;
+
+    // Should have sent an end-of-turn marker
+    const endTurnMarkers = relay.sentTokens.filter(
+      (t) => t.token === "" && t.last === true,
+    );
+    expect(endTurnMarkers.length).toBeGreaterThan(0);
+    expect(controller.getState()).toBe("idle");
 
     controller.destroy();
   });

--- a/assistant/src/__tests__/voice-quality.test.ts
+++ b/assistant/src/__tests__/voice-quality.test.ts
@@ -1,16 +1,81 @@
-import { describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ── Logger mock ──────────────────────────────────────────────────────
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// ── Credential mock (prevents real key lookups) ──────────────────────
+
+mock.module("../security/secure-keys.js", () => ({
+  getSecureKeyAsync: async () => null,
+  getSecureKey: () => null,
+}));
+
+mock.module("../security/credential-key.js", () => ({
+  credentialKey: (...args: string[]) => args.join("/"),
+}));
+
+// ── Config mock ──────────────────────────────────────────────────────
 
 let mockConfig: Record<string, unknown> = {};
 
 mock.module("../config/loader.js", () => ({
+  getConfig: () => mockConfig,
   loadConfig: () => mockConfig,
 }));
+
+// ── TTS registry setup ───────────────────────────────────────────────
+
+import {
+  _resetTtsProviderRegistry,
+  registerTtsProvider,
+} from "../tts/provider-registry.js";
+import type { TtsProvider } from "../tts/types.js";
+
+function registerTestProviders(): void {
+  _resetTtsProviderRegistry();
+
+  // ElevenLabs: native provider (no streaming)
+  const elevenlabs: TtsProvider = {
+    id: "elevenlabs",
+    capabilities: { supportsStreaming: false, supportedFormats: ["mp3"] },
+    async synthesize() {
+      return { audio: Buffer.from(""), contentType: "audio/mpeg" };
+    },
+  };
+  registerTtsProvider(elevenlabs);
+
+  // Fish Audio: synthesized provider (streaming)
+  const fishAudio: TtsProvider = {
+    id: "fish-audio",
+    capabilities: {
+      supportsStreaming: true,
+      supportedFormats: ["mp3", "wav", "opus"],
+    },
+    async synthesize() {
+      return { audio: Buffer.from(""), contentType: "audio/mpeg" };
+    },
+    async synthesizeStream(_req, _onChunk) {
+      return { audio: Buffer.from(""), contentType: "audio/mpeg" };
+    },
+  };
+  registerTtsProvider(fishAudio);
+}
+
+// ── Import subjects after mocks ──────────────────────────────────────
 
 import {
   buildElevenLabsVoiceSpec,
   resolveVoiceQualityProfile,
 } from "../calls/voice-quality.js";
 import { DEFAULT_ELEVENLABS_VOICE_ID } from "../config/schemas/elevenlabs.js";
+
+// ── Tests ────────────────────────────────────────────────────────────
 
 describe("buildElevenLabsVoiceSpec", () => {
   test("returns bare voiceId when no model is set", () => {
@@ -62,7 +127,13 @@ describe("buildElevenLabsVoiceSpec", () => {
 });
 
 describe("resolveVoiceQualityProfile", () => {
-  test("always returns ElevenLabs ttsProvider", () => {
+  beforeEach(() => {
+    registerTestProviders();
+  });
+
+  // ── Native provider path (ElevenLabs) ─────────────────────────────
+
+  test("returns ElevenLabs ttsProvider for native provider", () => {
     mockConfig = {
       elevenlabs: { voiceId: DEFAULT_ELEVENLABS_VOICE_ID },
       calls: {
@@ -71,18 +142,36 @@ describe("resolveVoiceQualityProfile", () => {
           transcriptionProvider: "Deepgram",
         },
       },
+      services: {
+        tts: {
+          provider: "elevenlabs",
+          providers: {
+            elevenlabs: { voiceId: DEFAULT_ELEVENLABS_VOICE_ID },
+            "fish-audio": { referenceId: "" },
+          },
+        },
+      },
     };
     const profile = resolveVoiceQualityProfile();
     expect(profile.ttsProvider).toBe("ElevenLabs");
   });
 
-  test("voice ID comes from elevenlabs.voiceId", () => {
+  test("voice ID comes from elevenlabs.voiceId for native provider", () => {
     mockConfig = {
       elevenlabs: { voiceId: "custom-voice-123" },
       calls: {
         voice: {
           language: "en-US",
           transcriptionProvider: "Deepgram",
+        },
+      },
+      services: {
+        tts: {
+          provider: "elevenlabs",
+          providers: {
+            elevenlabs: { voiceId: "custom-voice-123" },
+            "fish-audio": { referenceId: "" },
+          },
         },
       },
     };
@@ -97,6 +186,15 @@ describe("resolveVoiceQualityProfile", () => {
         voice: {
           language: "es-MX",
           transcriptionProvider: "Google",
+        },
+      },
+      services: {
+        tts: {
+          provider: "elevenlabs",
+          providers: {
+            elevenlabs: { voiceId: "abc" },
+            "fish-audio": { referenceId: "" },
+          },
         },
       },
     };
@@ -120,6 +218,15 @@ describe("resolveVoiceQualityProfile", () => {
           transcriptionProvider: "Deepgram",
         },
       },
+      services: {
+        tts: {
+          provider: "elevenlabs",
+          providers: {
+            elevenlabs: { voiceId: "voice1" },
+            "fish-audio": { referenceId: "" },
+          },
+        },
+      },
     };
     const profile = resolveVoiceQualityProfile();
     expect(profile.voice).toBe("voice1-turbo_v2_5-0.9_0.8_0.9");
@@ -132,6 +239,15 @@ describe("resolveVoiceQualityProfile", () => {
         voice: {
           language: "en-US",
           transcriptionProvider: "Deepgram",
+        },
+      },
+      services: {
+        tts: {
+          provider: "elevenlabs",
+          providers: {
+            elevenlabs: { voiceId: "abc" },
+            "fish-audio": { referenceId: "" },
+          },
         },
       },
     };
@@ -149,6 +265,15 @@ describe("resolveVoiceQualityProfile", () => {
           interruptSensitivity: "high",
         },
       },
+      services: {
+        tts: {
+          provider: "elevenlabs",
+          providers: {
+            elevenlabs: { voiceId: "abc" },
+            "fish-audio": { referenceId: "" },
+          },
+        },
+      },
     };
     const profile = resolveVoiceQualityProfile();
     expect(profile.interruptSensitivity).toBe("high");
@@ -161,6 +286,15 @@ describe("resolveVoiceQualityProfile", () => {
         voice: {
           language: "en-US",
           transcriptionProvider: "Deepgram",
+        },
+      },
+      services: {
+        tts: {
+          provider: "elevenlabs",
+          providers: {
+            elevenlabs: { voiceId: "abc" },
+            "fish-audio": { referenceId: "" },
+          },
         },
       },
     };
@@ -178,8 +312,103 @@ describe("resolveVoiceQualityProfile", () => {
           hints: ["Vellum", "Nova", "AI assistant"],
         },
       },
+      services: {
+        tts: {
+          provider: "elevenlabs",
+          providers: {
+            elevenlabs: { voiceId: "abc" },
+            "fish-audio": { referenceId: "" },
+          },
+        },
+      },
     };
     const profile = resolveVoiceQualityProfile();
     expect(profile.hints).toEqual(["Vellum", "Nova", "AI assistant"]);
+  });
+
+  // ── Synthesized provider path (Fish Audio) ────────────────────────
+
+  test("returns Google placeholder ttsProvider for synthesized provider (Fish Audio)", () => {
+    mockConfig = {
+      elevenlabs: { voiceId: DEFAULT_ELEVENLABS_VOICE_ID },
+      fishAudio: { referenceId: "ref-123" },
+      calls: {
+        voice: {
+          language: "en-US",
+          transcriptionProvider: "Deepgram",
+          ttsProvider: "fish-audio",
+        },
+      },
+      services: {
+        tts: {
+          provider: "fish-audio",
+          providers: {
+            elevenlabs: { voiceId: DEFAULT_ELEVENLABS_VOICE_ID },
+            "fish-audio": { referenceId: "ref-123" },
+          },
+        },
+      },
+    };
+    const profile = resolveVoiceQualityProfile();
+    expect(profile.ttsProvider).toBe("Google");
+    expect(profile.voice).toBe("");
+  });
+
+  test("preserves transcription and language settings for synthesized providers", () => {
+    mockConfig = {
+      elevenlabs: { voiceId: DEFAULT_ELEVENLABS_VOICE_ID },
+      fishAudio: { referenceId: "ref-123" },
+      calls: {
+        voice: {
+          language: "ja-JP",
+          transcriptionProvider: "Google",
+          ttsProvider: "fish-audio",
+          speechModel: "nova-3",
+        },
+      },
+      services: {
+        tts: {
+          provider: "fish-audio",
+          providers: {
+            elevenlabs: { voiceId: DEFAULT_ELEVENLABS_VOICE_ID },
+            "fish-audio": { referenceId: "ref-123" },
+          },
+        },
+      },
+    };
+    const profile = resolveVoiceQualityProfile();
+    expect(profile.language).toBe("ja-JP");
+    expect(profile.transcriptionProvider).toBe("Google");
+    // speechModel "nova-3" is treated as unset for Google transcription
+    expect(profile.speechModel).toBeUndefined();
+  });
+
+  // ── Legacy fallback (calls.voice.ttsProvider disagrees with services.tts.provider) ──
+
+  test("falls back to legacy calls.voice.ttsProvider when services.tts.provider is still default", () => {
+    mockConfig = {
+      elevenlabs: { voiceId: DEFAULT_ELEVENLABS_VOICE_ID },
+      fishAudio: { referenceId: "ref-abc" },
+      calls: {
+        voice: {
+          language: "en-US",
+          transcriptionProvider: "Deepgram",
+          ttsProvider: "fish-audio", // legacy key set to fish-audio
+        },
+      },
+      services: {
+        tts: {
+          provider: "elevenlabs", // canonical still at default
+          providers: {
+            elevenlabs: { voiceId: DEFAULT_ELEVENLABS_VOICE_ID },
+            "fish-audio": { referenceId: "ref-abc" },
+          },
+        },
+      },
+    };
+    const profile = resolveVoiceQualityProfile();
+    // Should resolve to fish-audio (legacy override)
+    expect(profile.ttsProvider).toBe("Google");
+    expect(profile.voice).toBe("");
   });
 });

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -539,6 +539,7 @@ export class CallController {
   private resolveCallTtsProvider(): {
     provider: TtsProvider | null;
     useSynthesizedPath: boolean;
+    audioFormat: "mp3" | "wav" | "opus";
   } {
     try {
       const config = loadConfig();
@@ -547,12 +548,22 @@ export class CallController {
       // Providers with streaming support synthesize audio themselves; others
       // rely on the relay's native (Twilio-managed) TTS engine.
       const useSynthesizedPath = provider.capabilities.supportsStreaming;
-      return { provider, useSynthesizedPath };
+      // Read the user-configured audio format from the resolved provider
+      // config so the streaming store entry's content-type matches the
+      // actual audio bytes the provider produces.
+      const configuredFormat = (resolved.providerConfig as { format?: string })
+        .format;
+      const audioFormat = (
+        configuredFormat && ["mp3", "wav", "opus"].includes(configuredFormat)
+          ? configuredFormat
+          : "mp3"
+      ) as "mp3" | "wav" | "opus";
+      return { provider, useSynthesizedPath, audioFormat };
     } catch {
       // Config missing `services.tts` block or provider not registered
       // (e.g. unit tests or early startup) — fall back to the native
       // (non-streaming) path where the provider object is not used.
-      return { provider: null, useSynthesizedPath: false };
+      return { provider: null, useSynthesizedPath: false, audioFormat: "mp3" };
     }
   }
 
@@ -571,7 +582,8 @@ export class CallController {
     // path (buffer text, synthesize via provider API, stream audio chunks
     // to Twilio via play-URL). Native providers stream text tokens to
     // the relay for Twilio's built-in TTS.
-    const { provider, useSynthesizedPath } = this.resolveCallTtsProvider();
+    const { provider, useSynthesizedPath, audioFormat } =
+      this.resolveCallTtsProvider();
 
     // Buffer incoming tokens so we can strip control markers ([ASK_GUARDIAN:...], [END_CALL])
     // before they reach TTS. We hold text whenever an unmatched '[' appears, since it
@@ -713,6 +725,7 @@ export class CallController {
         provider,
         sanitizedSynthText,
         runVersion,
+        audioFormat,
       );
     }
 
@@ -741,15 +754,10 @@ export class CallController {
     provider: TtsProvider,
     text: string,
     _runVersion: number,
+    format: "mp3" | "wav" | "opus" = "mp3",
   ): Promise<void> {
     let handle: ReturnType<typeof createStreamingEntry> | null = null;
     try {
-      // Determine audio format from provider capabilities (prefer mp3).
-      const formats = provider.capabilities.supportedFormats;
-      const format = (
-        formats.includes("mp3") ? "mp3" : (formats[0] ?? "mp3")
-      ) as "mp3" | "wav" | "opus";
-
       handle = createStreamingEntry(format);
       const config = loadConfig();
       const baseUrl = getPublicBaseUrl(config);

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -537,16 +537,23 @@ export class CallController {
    * built-in TTS.
    */
   private resolveCallTtsProvider(): {
-    provider: TtsProvider;
+    provider: TtsProvider | null;
     useSynthesizedPath: boolean;
   } {
-    const config = loadConfig();
-    const resolved = resolveTtsConfig(config);
-    const provider = getTtsProvider(resolved.provider);
-    // Providers with streaming support synthesize audio themselves; others
-    // rely on the relay's native (Twilio-managed) TTS engine.
-    const useSynthesizedPath = provider.capabilities.supportsStreaming;
-    return { provider, useSynthesizedPath };
+    try {
+      const config = loadConfig();
+      const resolved = resolveTtsConfig(config);
+      const provider = getTtsProvider(resolved.provider);
+      // Providers with streaming support synthesize audio themselves; others
+      // rely on the relay's native (Twilio-managed) TTS engine.
+      const useSynthesizedPath = provider.capabilities.supportsStreaming;
+      return { provider, useSynthesizedPath };
+    } catch {
+      // Config missing `services.tts` block or provider not registered
+      // (e.g. unit tests or early startup) — fall back to the native
+      // (non-streaming) path where the provider object is not used.
+      return { provider: null, useSynthesizedPath: false };
+    }
   }
 
   /**
@@ -700,7 +707,7 @@ export class CallController {
     // and intonation. Audio streams back via chunked transfer encoding
     // and is forwarded to Twilio as it arrives.
     const sanitizedSynthText = sanitizeForTts(synthesizedTextBuffer.trim());
-    if (useSynthesizedPath && sanitizedSynthText.length > 0) {
+    if (useSynthesizedPath && provider && sanitizedSynthText.length > 0) {
       if (!this.isCurrentRun(runVersion)) return fullResponseText;
       await this.synthesizeAndStreamAudio(
         provider,

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -23,6 +23,9 @@ import { revokeScopedApprovalGrantsForContext } from "../memory/scoped-approval-
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { mintDaemonDeliveryToken } from "../runtime/auth/token-service.js";
 import { computeToolApprovalDigest } from "../security/tool-approval-digest.js";
+import { getTtsProvider } from "../tts/provider-registry.js";
+import { resolveTtsConfig } from "../tts/tts-config-resolver.js";
+import type { TtsProvider } from "../tts/types.js";
 import { getLogger } from "../util/logger.js";
 import { createStreamingEntry } from "./audio-store.js";
 import {
@@ -45,7 +48,6 @@ import {
   updateCallSession,
 } from "./call-store.js";
 import { finalizeCall } from "./finalize-call.js";
-import { synthesizeWithFishAudio } from "./fish-audio-client.js";
 import { sendGuardianExpiryNotices } from "./guardian-action-sweep.js";
 import { dispatchGuardianQuestion } from "./guardian-dispatch.js";
 import type { RelayConnection } from "./relay-server.js";
@@ -61,7 +63,6 @@ import {
   extractBalancedJson,
   stripInternalSpeechMarkers,
 } from "./voice-control-protocol.js";
-import { isFishAudioTts } from "./voice-quality.js";
 import {
   startVoiceTurn,
   type VoiceTurnHandle,
@@ -139,8 +140,8 @@ export class CallController {
    * without blocking the caller.
    */
   private guardianUnavailableForCall = false;
-  /** Active Fish Audio session — tracked so interrupt handling can close it. */
-  private activeFishAbort: AbortController | null = null;
+  /** Active synthesized-TTS session — tracked so interrupt handling can close it. */
+  private activeSynthesisAbort: AbortController | null = null;
 
   constructor(
     callSessionId: string,
@@ -351,10 +352,10 @@ export class CallController {
     const wasSpeaking = this.state === "speaking";
     this.abortCurrentTurn();
     this.llmRunVersion++;
-    // Cancel in-flight Fish Audio synthesis on barge-in
-    if (this.activeFishAbort) {
-      this.activeFishAbort.abort();
-      this.activeFishAbort = null;
+    // Cancel in-flight synthesized TTS on barge-in
+    if (this.activeSynthesisAbort) {
+      this.activeSynthesisAbort.abort();
+      this.activeSynthesisAbort = null;
     }
     // Explicitly terminate the in-progress TTS turn so the relay can
     // immediately hand control back to the caller after barge-in.
@@ -386,9 +387,9 @@ export class CallController {
     this.pendingInstructions = [];
     this.llmRunVersion++;
     this.abortCurrentTurn();
-    if (this.activeFishAbort) {
-      this.activeFishAbort.abort();
-      this.activeFishAbort = null;
+    if (this.activeSynthesisAbort) {
+      this.activeSynthesisAbort.abort();
+      this.activeSynthesisAbort = null;
     }
     this.currentTurnPromise = null;
     unregisterCallController(this.callSessionId);
@@ -527,6 +528,28 @@ export class CallController {
   }
 
   /**
+   * Resolve the active TTS provider via the global provider abstraction.
+   *
+   * Providers that declare streaming support are treated as "synthesized"
+   * providers — their audio is streamed through the audio store and played
+   * via `sendPlayUrl`. Providers without streaming support are "native"
+   * providers — text tokens are streamed directly to the relay for Twilio's
+   * built-in TTS.
+   */
+  private resolveCallTtsProvider(): {
+    provider: TtsProvider;
+    useSynthesizedPath: boolean;
+  } {
+    const config = loadConfig();
+    const resolved = resolveTtsConfig(config);
+    const provider = getTtsProvider(resolved.provider);
+    // Providers with streaming support synthesize audio themselves; others
+    // rely on the relay's native (Twilio-managed) TTS engine.
+    const useSynthesizedPath = provider.capabilities.supportsStreaming;
+    return { provider, useSynthesizedPath };
+  }
+
+  /**
    * Stream TTS tokens from the conversation pipeline, buffering to strip
    * control markers before they reach the relay. Returns the full
    * accumulated response text for post-turn marker detection.
@@ -536,11 +559,12 @@ export class CallController {
     runVersion: number,
     runSignal: AbortSignal,
   ): Promise<string> {
-    // Fish Audio TTS routing: when configured, buffer text by sentence
-    // boundaries and synthesize via Fish Audio instead of streaming text
-    // tokens for ElevenLabs TTS.
-    const config = loadConfig();
-    const useFishAudio = isFishAudioTts(config);
+    // Resolve the active TTS provider through the global abstraction.
+    // Providers that declare streaming support use the synthesized-play
+    // path (buffer text, synthesize via provider API, stream audio chunks
+    // to Twilio via play-URL). Native providers stream text tokens to
+    // the relay for Twilio's built-in TTS.
+    const { provider, useSynthesizedPath } = this.resolveCallTtsProvider();
 
     // Buffer incoming tokens so we can strip control markers ([ASK_GUARDIAN:...], [END_CALL])
     // before they reach TTS. We hold text whenever an unmatched '[' appears, since it
@@ -548,16 +572,16 @@ export class CallController {
     let ttsBuffer = "";
     let fullResponseText = "";
 
-    // When using Fish Audio, we accumulate all text and synthesize
+    // When using the synthesized path, we accumulate all text and synthesize
     // the complete response at the end of the turn (better prosody).
-    let fishAudioTextBuffer = "";
+    let synthesizedTextBuffer = "";
 
     /** Emit a chunk of safe text to the appropriate TTS backend. */
     const emitSafeChunk = (safeText: string): void => {
       const cleaned = sanitizeForTts(safeText);
       if (cleaned.length === 0) return;
-      if (useFishAudio) {
-        fishAudioTextBuffer += cleaned;
+      if (useSynthesizedPath) {
+        synthesizedTextBuffer += cleaned;
       } else {
         this.relay.sendTextToken(cleaned, false);
       }
@@ -670,47 +694,27 @@ export class CallController {
       emitSafeChunk(ttsBuffer);
     }
 
-    // When using Fish Audio, synthesize the complete response text in a
-    // single REST API call. The full text gives Fish Audio better context
-    // for prosody and intonation. Audio streams back via chunked transfer
-    // encoding and is forwarded to Twilio as it arrives.
-    const sanitizedFishText = sanitizeForTts(fishAudioTextBuffer.trim());
-    if (useFishAudio && sanitizedFishText.length > 0) {
+    // Synthesized-play path: when the active provider supports streaming,
+    // synthesize the complete response text via the provider's streaming
+    // API. The full text gives the provider better context for prosody
+    // and intonation. Audio streams back via chunked transfer encoding
+    // and is forwarded to Twilio as it arrives.
+    const sanitizedSynthText = sanitizeForTts(synthesizedTextBuffer.trim());
+    if (useSynthesizedPath && sanitizedSynthText.length > 0) {
       if (!this.isCurrentRun(runVersion)) return fullResponseText;
-      let handle: ReturnType<typeof createStreamingEntry> | null = null;
-      try {
-        const format = config.fishAudio.format ?? "mp3";
-        handle = createStreamingEntry(format as "mp3" | "wav" | "opus");
-        const baseUrl = getPublicBaseUrl(config);
-        const url = `${baseUrl}/v1/audio/${handle.audioId}`;
-        this.relay.sendPlayUrl(url);
-        const abortController = new AbortController();
-        this.activeFishAbort = abortController;
-        await synthesizeWithFishAudio(
-          sanitizedFishText,
-          config.fishAudio,
-          {
-            onChunk: (chunk) => handle!.push(chunk),
-            signal: abortController.signal,
-          },
-        );
-      } catch (err) {
-        if (err instanceof DOMException && err.name === "AbortError") {
-          log.debug("Fish Audio synthesis aborted (barge-in)");
-        } else {
-          log.error({ err }, "Fish Audio synthesis failed — skipping");
-        }
-      } finally {
-        this.activeFishAbort = null;
-        handle?.finalize();
-      }
+      await this.synthesizeAndStreamAudio(
+        provider,
+        sanitizedSynthText,
+        runVersion,
+      );
     }
 
     // Signal end of this turn's speech.  An empty token with `last: true`
     // tells ConversationRelay to start listening — it does NOT trigger TTS
-    // synthesis.  This is required even when Fish Audio handled all audio
-    // playback, because ConversationRelay still needs the end-of-turn signal
-    // to transition from "assistant speaking" to "caller speaking" state.
+    // synthesis.  This is required even when a synthesized provider handled
+    // all audio playback, because ConversationRelay still needs the
+    // end-of-turn signal to transition from "assistant speaking" to
+    // "caller speaking" state.
     this.relay.sendTextToken("", true);
 
     // Mark the greeting's first response as awaiting ack
@@ -720,6 +724,70 @@ export class CallController {
     }
 
     return fullResponseText;
+  }
+
+  /**
+   * Synthesize text via a streaming TTS provider and forward audio chunks
+   * to Twilio through the audio store / play-URL mechanism.
+   */
+  private async synthesizeAndStreamAudio(
+    provider: TtsProvider,
+    text: string,
+    _runVersion: number,
+  ): Promise<void> {
+    let handle: ReturnType<typeof createStreamingEntry> | null = null;
+    try {
+      // Determine audio format from provider capabilities (prefer mp3).
+      const formats = provider.capabilities.supportedFormats;
+      const format = (
+        formats.includes("mp3") ? "mp3" : (formats[0] ?? "mp3")
+      ) as "mp3" | "wav" | "opus";
+
+      handle = createStreamingEntry(format);
+      const config = loadConfig();
+      const baseUrl = getPublicBaseUrl(config);
+      const url = `${baseUrl}/v1/audio/${handle.audioId}`;
+      this.relay.sendPlayUrl(url);
+
+      const abortController = new AbortController();
+      this.activeSynthesisAbort = abortController;
+
+      if (provider.synthesizeStream) {
+        await provider.synthesizeStream(
+          {
+            text,
+            useCase: "phone-call",
+            signal: abortController.signal,
+          },
+          (chunk) => handle!.push(chunk),
+        );
+      } else {
+        // Fallback: buffer-oriented synthesis for providers that don't
+        // implement streaming (shouldn't normally reach here since
+        // useSynthesizedPath is gated on supportsStreaming).
+        const result = await provider.synthesize({
+          text,
+          useCase: "phone-call",
+          signal: abortController.signal,
+        });
+        handle.push(result.audio);
+      }
+    } catch (err) {
+      if (err instanceof DOMException && err.name === "AbortError") {
+        log.debug(
+          { provider: provider.id },
+          "TTS synthesis aborted (barge-in)",
+        );
+      } else {
+        log.error(
+          { err, provider: provider.id },
+          "TTS synthesis failed — skipping",
+        );
+      }
+    } finally {
+      this.activeSynthesisAbort = null;
+      handle?.finalize();
+    }
   }
 
   /**
@@ -734,7 +802,9 @@ export class CallController {
     recordCallEvent(this.callSessionId, "assistant_spoke", {
       text: responseText,
     });
-    const spokenText = sanitizeForTts(stripInternalSpeechMarkers(responseText)).trim();
+    const spokenText = sanitizeForTts(
+      stripInternalSpeechMarkers(responseText),
+    ).trim();
     if (spokenText.length > 0) {
       const session = getCallSession(this.callSessionId);
       if (session) {

--- a/assistant/src/calls/voice-quality.ts
+++ b/assistant/src/calls/voice-quality.ts
@@ -63,9 +63,17 @@ export function resolveVoiceQualityProfile(
   const voice = cfg.calls.voice;
 
   // Resolve the active TTS provider through the global abstraction.
-  const resolved = resolveTtsConfig(cfg);
-  const provider = getTtsProvider(resolved.provider);
-  const usesSynthesizedPath = provider.capabilities.supportsStreaming;
+  // When the config lacks the `services.tts` block (e.g. test mocks or
+  // pre-migration configs) or the provider registry has not been initialised,
+  // we fall back to the native ElevenLabs profile.
+  let usesSynthesizedPath = false;
+  try {
+    const resolved = resolveTtsConfig(cfg);
+    const provider = getTtsProvider(resolved.provider);
+    usesSynthesizedPath = provider.capabilities.supportsStreaming;
+  } catch {
+    // Config or provider not available — default to native (ElevenLabs) path.
+  }
 
   const isGoogle = voice.transcriptionProvider === "Google";
   // Treat the legacy Deepgram default ("nova-3") as unset when provider is

--- a/assistant/src/calls/voice-quality.ts
+++ b/assistant/src/calls/voice-quality.ts
@@ -1,4 +1,6 @@
 import { loadConfig } from "../config/loader.js";
+import { getTtsProvider } from "../tts/provider-registry.js";
+import { resolveTtsConfig } from "../tts/tts-config-resolver.js";
 
 export interface VoiceQualityProfile {
   language: string;
@@ -45,28 +47,31 @@ export function buildElevenLabsVoiceSpec(config: {
 /**
  * Resolve the effective voice quality profile from config.
  *
- * Supports ElevenLabs (default) and Fish Audio TTS providers.
- * When Fish Audio is selected, `ttsProvider` is set to `"Google"` as a
- * placeholder — ConversationRelay requires a valid provider in TwiML, but
- * actual audio is delivered via `play` messages from the call-controller.
- * The voice string is left empty since it is unused in that mode.
+ * Uses the global TTS provider abstraction to determine which provider is
+ * active. Providers that declare streaming support (e.g. Fish Audio) use
+ * the synthesized-play path — ConversationRelay needs a valid TTS provider
+ * in TwiML, so we set `ttsProvider` to `"Google"` as a placeholder and
+ * leave `voice` empty since actual audio is delivered via `play` messages.
  *
- * For ElevenLabs, the voice ID comes from the shared `elevenlabs.voiceId`
- * config (defaults to Amelia — ZF6FPAbjXT4488VcRRnw).
+ * For native providers (e.g. ElevenLabs), `ttsProvider` and `voice` are
+ * populated from config so Twilio handles TTS natively.
  */
 export function resolveVoiceQualityProfile(
   config?: ReturnType<typeof loadConfig>,
 ): VoiceQualityProfile {
   const cfg = config ?? loadConfig();
   const voice = cfg.calls.voice;
-  const configuredTts = voice.ttsProvider ?? "elevenlabs";
-  const fishAudio = configuredTts === "fish-audio";
+
+  // Resolve the active TTS provider through the global abstraction.
+  const resolved = resolveTtsConfig(cfg);
+  const provider = getTtsProvider(resolved.provider);
+  const usesSynthesizedPath = provider.capabilities.supportsStreaming;
+
   const isGoogle = voice.transcriptionProvider === "Google";
   // Treat the legacy Deepgram default ("nova-3") as unset when provider is
   // Google — upgraded workspaces may still have it persisted from prior defaults.
   const effectiveSpeechModel =
-    voice.speechModel == null ||
-    (voice.speechModel === "nova-3" && isGoogle)
+    voice.speechModel == null || (voice.speechModel === "nova-3" && isGoogle)
       ? isGoogle
         ? undefined
         : "nova-3"
@@ -75,19 +80,9 @@ export function resolveVoiceQualityProfile(
     language: voice.language,
     transcriptionProvider: voice.transcriptionProvider,
     speechModel: effectiveSpeechModel,
-    ttsProvider: fishAudio ? "Google" : "ElevenLabs",
-    voice: fishAudio ? "" : buildElevenLabsVoiceSpec(cfg.elevenlabs),
+    ttsProvider: usesSynthesizedPath ? "Google" : "ElevenLabs",
+    voice: usesSynthesizedPath ? "" : buildElevenLabsVoiceSpec(cfg.elevenlabs),
     interruptSensitivity: voice.interruptSensitivity ?? "low",
     hints: voice.hints ?? [],
   };
-}
-
-/**
- * Check whether Fish Audio TTS is configured for phone calls.
- */
-export function isFishAudioTts(
-  config?: ReturnType<typeof loadConfig>,
-): boolean {
-  const cfg = config ?? loadConfig();
-  return cfg.calls.voice?.ttsProvider === "fish-audio";
 }

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -89,6 +89,7 @@ import {
   setCesReconnect,
 } from "../security/secure-keys.js";
 import { UsageTelemetryReporter } from "../telemetry/usage-telemetry-reporter.js";
+import { registerBuiltinTtsProviders } from "../tts/providers/register-builtins.js";
 import { getDeviceId } from "../util/device-id.js";
 import { getLogger, initLogger } from "../util/logger.js";
 import {
@@ -1206,6 +1207,17 @@ export async function runDaemon(): Promise<void> {
         "Failed to start runtime HTTP server, continuing without it",
       );
       runtimeHttp = null;
+    }
+
+    // Register built-in TTS providers so the provider abstraction can resolve
+    // them by ID. Must happen before call controllers or routes are created.
+    try {
+      registerBuiltinTtsProviders();
+    } catch (err) {
+      log.warn(
+        { err },
+        "TTS provider registration failed — continuing with degraded TTS",
+      );
     }
 
     // Initialize providers and tools after the HTTP server is listening so


### PR DESCRIPTION
## Summary
- Replaces direct isFishAudioTts branching with global provider resolution
- Updates voice-quality.ts to use TTS resolver while preserving Twilio requirements
- Expands tests to cover both native-token and synthesized-play provider paths

Part of plan: product-tts-provider-abstraction.md (PR 6 of 11)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24775" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
