### PR TITLE
Add /v1/tts/synthesize for provider-agnostic ad hoc speech synthesis

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -7831,24 +7831,25 @@ paths:
     post:
       operationId: tts_synthesize_post
       summary: Synthesize text to speech
-      description: >-
-        Synthesize arbitrary text to audio using the configured TTS provider.
-        Provider selection is resolved globally via config — callers do not
-        specify a provider.
+      description:
+        Synthesize arbitrary text to audio using the configured TTS provider. Provider selection is resolved
+        globally via config — callers do not specify a provider.
       tags:
         - tts
       responses:
         "200":
-          description: Audio binary response
+          description: Successful response
           content:
-            audio/*:
+            application/json:
               schema:
-                type: string
-                format: binary
-        "400":
-          description: Invalid request (missing or empty text)
-        "503":
-          description: TTS provider is not configured
+                type: object
+                properties:
+                  audio:
+                    type: string
+                    description: Raw audio binary (response body)
+                required:
+                  - audio
+                additionalProperties: false
       requestBody:
         required: true
         content:
@@ -7860,14 +7861,13 @@ paths:
                   type: string
                   description: Text to synthesize into speech
                 context:
-                  type: string
-                  description: >-
-                    Optional context hint for output policy or capability
-                    selection (e.g. voice-mode). Does not affect provider
+                  description:
+                    Optional context hint for output policy or capability selection (e.g. voice-mode). Does not affect provider
                     selection.
-                conversationId:
                   type: string
+                conversationId:
                   description: Optional conversation ID for scoping or analytics.
+                  type: string
               required:
                 - text
               additionalProperties: false

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -7827,6 +7827,50 @@ paths:
                 - decision
                 - priority
               additionalProperties: false
+  /v1/tts/synthesize:
+    post:
+      operationId: tts_synthesize_post
+      summary: Synthesize text to speech
+      description: >-
+        Synthesize arbitrary text to audio using the configured TTS provider.
+        Provider selection is resolved globally via config — callers do not
+        specify a provider.
+      tags:
+        - tts
+      responses:
+        "200":
+          description: Audio binary response
+          content:
+            audio/*:
+              schema:
+                type: string
+                format: binary
+        "400":
+          description: Invalid request (missing or empty text)
+        "503":
+          description: TTS provider is not configured
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                text:
+                  type: string
+                  description: Text to synthesize into speech
+                context:
+                  type: string
+                  description: >-
+                    Optional context hint for output policy or capability
+                    selection (e.g. voice-mode). Does not affect provider
+                    selection.
+                conversationId:
+                  type: string
+                  description: Optional conversation ID for scoping or analytics.
+              required:
+                - text
+              additionalProperties: false
   /v1/usage/breakdown:
     get:
       operationId: usage_breakdown_get

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -380,6 +380,7 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: "messages/llm-context", scopes: ["chat.read"] },
   { endpoint: "llm-request-logs/payload", scopes: ["chat.read"] },
   { endpoint: "messages/tts", scopes: ["chat.read"] },
+  { endpoint: "tts/synthesize", scopes: ["chat.read"] },
 
   // Queued message deletion
   { endpoint: "messages/queued", scopes: ["chat.write"] },

--- a/assistant/src/runtime/routes/__tests__/tts-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/tts-routes.test.ts
@@ -89,9 +89,14 @@ import { ttsRouteDefinitions } from "../tts-routes.js";
 // Helpers
 // ---------------------------------------------------------------------------
 
-function getHandler() {
+function getMessageTtsHandler() {
   const routes = ttsRouteDefinitions();
   return routes[0].handler;
+}
+
+function getSynthesizeHandler() {
+  const routes = ttsRouteDefinitions();
+  return routes[1].handler;
 }
 
 function makeRouteContext(
@@ -127,6 +132,28 @@ function makeRouteContext(
   } as unknown as RouteContext;
 }
 
+function makeSynthesizeContext(body: Record<string, unknown>): RouteContext {
+  const url = new URL("http://localhost/v1/tts/synthesize");
+  return {
+    req: new Request(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+    url,
+    server: {} as RouteContext["server"],
+    authContext: {
+      subject: "test-user",
+      principalType: "local",
+      assistantId: "self",
+      scopeProfile: "local_v1",
+      scopes: new Set(["local.all" as const]),
+      policyEpoch: 0,
+    },
+    params: {},
+  } as unknown as RouteContext;
+}
+
 async function readErrorBody(
   response: Response,
 ): Promise<{ error: { code: string; message: string } }> {
@@ -159,11 +186,13 @@ afterEach(() => {
 describe("tts-routes", () => {
   // -- Route metadata -------------------------------------------------------
 
-  test("exports a single route definition for messages/:id/tts", () => {
+  test("exports route definitions for messages/:id/tts and tts/synthesize", () => {
     const routes = ttsRouteDefinitions();
-    expect(routes).toHaveLength(1);
+    expect(routes).toHaveLength(2);
     expect(routes[0].endpoint).toBe("messages/:id/tts");
     expect(routes[0].method).toBe("POST");
+    expect(routes[1].endpoint).toBe("tts/synthesize");
+    expect(routes[1].method).toBe("POST");
   });
 
   test("route description is provider-agnostic", () => {
@@ -177,7 +206,7 @@ describe("tts-routes", () => {
   test("returns 403 when message-tts flag is disabled", async () => {
     mockFeatureFlagEnabled = false;
 
-    const handler = getHandler();
+    const handler = getMessageTtsHandler();
     const res = await handler(makeRouteContext());
 
     expect(res.status).toBe(403);
@@ -191,7 +220,7 @@ describe("tts-routes", () => {
   test("returns 404 when message is not found", async () => {
     mockMessageContent = null;
 
-    const handler = getHandler();
+    const handler = getMessageTtsHandler();
     const res = await handler(makeRouteContext({ messageId: "missing-id" }));
 
     expect(res.status).toBe(404);
@@ -203,7 +232,7 @@ describe("tts-routes", () => {
   test("returns 400 when message has no text content", async () => {
     mockMessageContent = { text: undefined };
 
-    const handler = getHandler();
+    const handler = getMessageTtsHandler();
     const res = await handler(makeRouteContext());
 
     expect(res.status).toBe(400);
@@ -215,7 +244,7 @@ describe("tts-routes", () => {
   test("returns 400 when sanitized text is empty", async () => {
     mockMessageContent = { text: "   " };
 
-    const handler = getHandler();
+    const handler = getMessageTtsHandler();
     const res = await handler(makeRouteContext());
 
     expect(res.status).toBe(400);
@@ -227,7 +256,7 @@ describe("tts-routes", () => {
   // -- Provider selection via orchestration layer ---------------------------
 
   test("delegates to synthesizeText with message-playback use case", async () => {
-    const handler = getHandler();
+    const handler = getMessageTtsHandler();
     const res = await handler(makeRouteContext());
 
     expect(res.status).toBe(200);
@@ -242,7 +271,7 @@ describe("tts-routes", () => {
       contentType: "audio/wav",
     };
 
-    const handler = getHandler();
+    const handler = getMessageTtsHandler();
     const res = await handler(makeRouteContext());
 
     expect(res.status).toBe(200);
@@ -259,7 +288,7 @@ describe("tts-routes", () => {
     Object.assign(err, { code: "TTS_PROVIDER_NOT_CONFIGURED" });
     mockSynthesizeError = err;
 
-    const handler = getHandler();
+    const handler = getMessageTtsHandler();
     const res = await handler(makeRouteContext());
 
     expect(res.status).toBe(503);
@@ -273,8 +302,169 @@ describe("tts-routes", () => {
   test("returns 502 when synthesis fails with generic error", async () => {
     mockSynthesizeError = new Error("upstream failure");
 
-    const handler = getHandler();
+    const handler = getMessageTtsHandler();
     const res = await handler(makeRouteContext());
+
+    expect(res.status).toBe(502);
+    const body = await readErrorBody(res);
+    expect(body.error.code).toBe("INTERNAL_ERROR");
+    expect(body.error.message).toContain("synthesis failed");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /v1/tts/synthesize tests
+// ---------------------------------------------------------------------------
+
+describe("tts/synthesize", () => {
+  // -- Route metadata -------------------------------------------------------
+
+  test("route description is provider-agnostic", () => {
+    const routes = ttsRouteDefinitions();
+    const synthesizeRoute = routes[1];
+    expect(synthesizeRoute.description).not.toMatch(/elevenlabs/i);
+    expect(synthesizeRoute.description).not.toMatch(/fish/i);
+    expect(synthesizeRoute.description).toContain("configured TTS provider");
+  });
+
+  // -- Body validation ------------------------------------------------------
+
+  test("returns 400 for invalid JSON body", async () => {
+    const url = new URL("http://localhost/v1/tts/synthesize");
+    const ctx = {
+      req: new Request(url, {
+        method: "POST",
+        body: "not-json",
+      }),
+      url,
+      server: {} as RouteContext["server"],
+      authContext: {
+        subject: "test-user",
+        principalType: "local",
+        assistantId: "self",
+        scopeProfile: "local_v1",
+        scopes: new Set(["local.all" as const]),
+        policyEpoch: 0,
+      },
+      params: {},
+    } as unknown as RouteContext;
+
+    const handler = getSynthesizeHandler();
+    const res = await handler(ctx);
+
+    expect(res.status).toBe(400);
+    const body = await readErrorBody(res);
+    expect(body.error.code).toBe("BAD_REQUEST");
+    expect(body.error.message).toContain("Invalid JSON");
+  });
+
+  test("returns 400 when text is missing", async () => {
+    const handler = getSynthesizeHandler();
+    const res = await handler(makeSynthesizeContext({}));
+
+    expect(res.status).toBe(400);
+    const body = await readErrorBody(res);
+    expect(body.error.code).toBe("BAD_REQUEST");
+    expect(body.error.message).toContain("text is required");
+  });
+
+  test("returns 400 when text is not a string", async () => {
+    const handler = getSynthesizeHandler();
+    const res = await handler(makeSynthesizeContext({ text: 42 }));
+
+    expect(res.status).toBe(400);
+    const body = await readErrorBody(res);
+    expect(body.error.code).toBe("BAD_REQUEST");
+    expect(body.error.message).toContain("text is required");
+  });
+
+  test("returns 400 when text is empty after sanitization", async () => {
+    const handler = getSynthesizeHandler();
+    const res = await handler(makeSynthesizeContext({ text: "   " }));
+
+    expect(res.status).toBe(400);
+    const body = await readErrorBody(res);
+    expect(body.error.code).toBe("BAD_REQUEST");
+    expect(body.error.message).toContain("no speakable content");
+  });
+
+  // -- Context handling -----------------------------------------------------
+
+  test("accepts optional context without affecting synthesis", async () => {
+    const handler = getSynthesizeHandler();
+    const res = await handler(
+      makeSynthesizeContext({ text: "Hello", context: "voice-mode" }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(lastSynthesizeOptions).not.toBeNull();
+    expect(lastSynthesizeOptions!.text).toBe("Hello");
+    // context does not influence provider selection — useCase stays message-playback
+    expect(lastSynthesizeOptions!.useCase).toBe("message-playback");
+  });
+
+  test("accepts optional conversationId", async () => {
+    const handler = getSynthesizeHandler();
+    const res = await handler(
+      makeSynthesizeContext({ text: "Hello", conversationId: "conv-789" }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(lastSynthesizeOptions).not.toBeNull();
+    expect(lastSynthesizeOptions!.text).toBe("Hello");
+  });
+
+  // -- Provider-agnostic response behavior ----------------------------------
+
+  test("delegates to synthesizeText with message-playback use case", async () => {
+    const handler = getSynthesizeHandler();
+    const res = await handler(makeSynthesizeContext({ text: "Say this" }));
+
+    expect(res.status).toBe(200);
+    expect(lastSynthesizeOptions).not.toBeNull();
+    expect(lastSynthesizeOptions!.text).toBe("Say this");
+    expect(lastSynthesizeOptions!.useCase).toBe("message-playback");
+  });
+
+  test("returns audio response with correct content type", async () => {
+    mockSynthesizeResult = {
+      audio: Buffer.from("opus-audio"),
+      contentType: "audio/opus",
+    };
+
+    const handler = getSynthesizeHandler();
+    const res = await handler(makeSynthesizeContext({ text: "Say this" }));
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("audio/opus");
+
+    const body = await res.arrayBuffer();
+    expect(Buffer.from(body).toString()).toBe("opus-audio");
+  });
+
+  // -- Provider not configured ----------------------------------------------
+
+  test("returns 503 when TTS provider is not configured", async () => {
+    const err = new Error("TTS provider not configured");
+    Object.assign(err, { code: "TTS_PROVIDER_NOT_CONFIGURED" });
+    mockSynthesizeError = err;
+
+    const handler = getSynthesizeHandler();
+    const res = await handler(makeSynthesizeContext({ text: "Say this" }));
+
+    expect(res.status).toBe(503);
+    const body = await readErrorBody(res);
+    expect(body.error.code).toBe("SERVICE_UNAVAILABLE");
+    expect(body.error.message).toContain("not configured");
+  });
+
+  // -- Synthesis failure ----------------------------------------------------
+
+  test("returns 502 when synthesis fails with generic error", async () => {
+    mockSynthesizeError = new Error("upstream failure");
+
+    const handler = getSynthesizeHandler();
+    const res = await handler(makeSynthesizeContext({ text: "Say this" }));
 
     expect(res.status).toBe(502);
     const body = await readErrorBody(res);

--- a/assistant/src/runtime/routes/tts-routes.ts
+++ b/assistant/src/runtime/routes/tts-routes.ts
@@ -1,11 +1,16 @@
 /**
- * HTTP route definitions for message text-to-speech synthesis.
+ * HTTP route definitions for text-to-speech synthesis.
  *
  * POST /v1/messages/:id/tts?conversationId=... — synthesize message text to audio
+ * POST /v1/tts/synthesize                      — synthesize arbitrary text to audio
  *
- * Gated behind the `message-tts` assistant feature flag.
- * Uses the globally configured TTS provider via the provider abstraction.
+ * Both endpoints use the globally configured TTS provider via the provider
+ * abstraction. The message endpoint is gated behind the `message-tts`
+ * assistant feature flag; the generic endpoint is always available when a
+ * TTS provider is configured.
  */
+
+import { z } from "zod";
 
 import { sanitizeForTts } from "../../calls/tts-text-sanitizer.js";
 import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
@@ -82,6 +87,87 @@ export function ttsRouteDefinitions(): RouteDefinition[] {
           });
         } catch (err) {
           log.error({ err, messageId }, "TTS synthesis failed");
+
+          // Surface provider-not-configured as 503
+          if (
+            err instanceof Error &&
+            "code" in err &&
+            (err as { code: string }).code === "TTS_PROVIDER_NOT_CONFIGURED"
+          ) {
+            return httpError(
+              "SERVICE_UNAVAILABLE",
+              "TTS provider is not configured",
+              503,
+            );
+          }
+
+          return httpError("INTERNAL_ERROR", "TTS synthesis failed", 502);
+        }
+      },
+    },
+
+    // -- Generic text synthesis -----------------------------------------------
+
+    {
+      endpoint: "tts/synthesize",
+      method: "POST",
+      policyKey: "tts/synthesize",
+      summary: "Synthesize text to speech",
+      description:
+        "Synthesize arbitrary text to audio using the configured TTS provider. " +
+        "Provider selection is resolved globally via config — callers do not " +
+        "specify a provider.",
+      tags: ["tts"],
+      requestBody: z.object({
+        text: z.string().describe("Text to synthesize into speech"),
+        context: z
+          .string()
+          .optional()
+          .describe(
+            "Optional context hint for output policy or capability selection (e.g. voice-mode). " +
+              "Does not affect provider selection.",
+          ),
+        conversationId: z
+          .string()
+          .optional()
+          .describe("Optional conversation ID for scoping or analytics."),
+      }),
+      responseBody: z.object({
+        audio: z.string().describe("Raw audio binary (response body)"),
+      }),
+      handler: async ({ req }) => {
+        let body: { text?: string; context?: string; conversationId?: string };
+        try {
+          body = (await req.json()) as typeof body;
+        } catch {
+          return httpError("BAD_REQUEST", "Invalid JSON body", 400);
+        }
+
+        if (!body.text || typeof body.text !== "string") {
+          return httpError("BAD_REQUEST", "text is required", 400);
+        }
+
+        const sanitizedText = sanitizeForTts(body.text).trim();
+        if (!sanitizedText) {
+          return httpError(
+            "BAD_REQUEST",
+            "Text has no speakable content after sanitization",
+            400,
+          );
+        }
+
+        try {
+          const { audio, contentType } = await synthesizeText({
+            text: sanitizedText,
+            useCase: "message-playback",
+          });
+
+          return new Response(new Uint8Array(audio), {
+            status: 200,
+            headers: { "Content-Type": contentType },
+          });
+        } catch (err) {
+          log.error({ err, context: body.context }, "TTS synthesis failed");
 
           // Surface provider-not-configured as 503
           if (

--- a/clients/shared/Network/TTSClient.swift
+++ b/clients/shared/Network/TTSClient.swift
@@ -3,7 +3,7 @@ import os
 
 private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "TTSClient")
 
-/// Result of a message TTS synthesis request.
+/// Result of a TTS synthesis request.
 public enum TTSResult: Sendable {
     /// Audio binary returned successfully.
     case success(data: Data)
@@ -17,9 +17,13 @@ public enum TTSResult: Sendable {
     case error(statusCode: Int?, message: String)
 }
 
-/// Focused client for message text-to-speech synthesis routed through the gateway.
+/// Client for text-to-speech synthesis routed through the gateway.
 public protocol TTSClientProtocol {
+    /// Synthesize a specific message's text to audio.
     func synthesize(messageId: String, conversationId: String?) async -> TTSResult
+
+    /// Synthesize arbitrary text to audio via the generic TTS endpoint.
+    func synthesizeText(_ text: String, context: String?, conversationId: String?) async -> TTSResult
 }
 
 /// Gateway-backed implementation of ``TTSClientProtocol``.
@@ -36,24 +40,48 @@ public struct TTSClient: TTSClientProtocol {
             }
 
             let response = try await GatewayHTTPClient.post(path: path, params: params, timeout: 60)
-
-            switch response.statusCode {
-            case 200:
-                return .success(data: response.data)
-            case 403:
-                return .featureDisabled
-            case 404:
-                return .notFound
-            case 503:
-                return .notConfigured
-            default:
-                let body = String(data: response.data, encoding: .utf8) ?? "unknown"
-                log.error("TTS synthesis failed (HTTP \(response.statusCode)): \(body)")
-                return .error(statusCode: response.statusCode, message: "TTS synthesis failed (HTTP \(response.statusCode))")
-            }
+            return Self.mapResponse(response)
         } catch {
             log.error("TTS synthesis error: \(error.localizedDescription)")
             return .error(statusCode: nil, message: error.localizedDescription)
+        }
+    }
+
+    public func synthesizeText(_ text: String, context: String? = nil, conversationId: String? = nil) async -> TTSResult {
+        do {
+            var json: [String: Any] = ["text": text]
+            if let context, !context.isEmpty {
+                json["context"] = context
+            }
+            if let conversationId, !conversationId.isEmpty {
+                json["conversationId"] = conversationId
+            }
+
+            let path = "assistants/{assistantId}/tts/synthesize"
+            let response = try await GatewayHTTPClient.post(path: path, json: json, timeout: 60)
+            return Self.mapResponse(response)
+        } catch {
+            log.error("TTS synthesizeText error: \(error.localizedDescription)")
+            return .error(statusCode: nil, message: error.localizedDescription)
+        }
+    }
+
+    // MARK: - Private
+
+    private static func mapResponse(_ response: GatewayHTTPClient.Response) -> TTSResult {
+        switch response.statusCode {
+        case 200:
+            return .success(data: response.data)
+        case 403:
+            return .featureDisabled
+        case 404:
+            return .notFound
+        case 503:
+            return .notConfigured
+        default:
+            let body = String(data: response.data, encoding: .utf8) ?? "unknown"
+            log.error("TTS synthesis failed (HTTP \(response.statusCode)): \(body)")
+            return .error(statusCode: response.statusCode, message: "TTS synthesis failed (HTTP \(response.statusCode))")
         }
     }
 }


### PR DESCRIPTION
## Summary
- Adds POST /v1/tts/synthesize endpoint accepting text, optional context, and conversationId
- Adds route policy entry with chat-read scope profile
- Extends TTSClient.swift with synthesizeText method
- Updates OpenAPI spec with request/response schema

Part of plan: product-tts-provider-abstraction.md (PR 5 of 11)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24778" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
