### PR TITLE
Route relay-server deterministic prompts through provider-aware call speech output

### DIFF
--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -4536,6 +4536,7 @@ describe("relay-server", () => {
       mockTtsSynthesizeStream = null;
 
       ensureConversation("conv-native-callee-fail");
+      ensureConversation("conv-native-callee-fail-origin");
       mockConfig.calls.verification.enabled = true;
       mockConfig.calls.verification.maxAttempts = 1;
 
@@ -4545,6 +4546,7 @@ describe("relay-server", () => {
         fromNumber: "+15551111111",
         toNumber: "+15552222222",
         task: "Call +15552222222",
+        initiatedFromConversationId: "conv-native-callee-fail-origin",
       });
 
       const { ws, relay } = createMockWs(session.id);

--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -97,6 +97,45 @@ const mockConfig = {
 
 mock.module("../config/loader.js", () => ({
   getConfig: () => mockConfig,
+  loadConfig: () => mockConfig,
+}));
+
+// ── TTS provider mocks (for call-speech-output) ─────────────────────
+
+let mockTtsProviderId: string = "elevenlabs";
+let mockTtsSupportsStreaming: boolean = false;
+let mockTtsSynthesizeStream: Mock<any> | null = null;
+
+mock.module("../tts/tts-config-resolver.js", () => ({
+  resolveTtsConfig: () => ({
+    provider: mockTtsProviderId,
+    providerConfig: { voiceId: "test-voice", format: "mp3" },
+  }),
+}));
+
+mock.module("../tts/provider-registry.js", () => ({
+  getTtsProvider: () => ({
+    id: mockTtsProviderId,
+    capabilities: {
+      supportsStreaming: mockTtsSupportsStreaming,
+      supportedFormats: ["mp3"],
+    },
+    synthesize: async () => ({
+      audio: Buffer.from("fake-audio"),
+      contentType: "audio/mpeg",
+    }),
+    synthesizeStream: mockTtsSynthesizeStream
+      ? (...args: unknown[]) => mockTtsSynthesizeStream!(...args)
+      : undefined,
+  }),
+  registerTtsProvider: () => {},
+  listTtsProviders: () => [],
+  _resetTtsProviderRegistry: () => {},
+}));
+
+// Mock public ingress URLs for synthesized TTS path
+mock.module("../inbound/public-ingress-urls.js", () => ({
+  getPublicBaseUrl: () => "https://test.example.com",
 }));
 
 // ── Helpers for building mock provider responses ────────────────────
@@ -335,11 +374,16 @@ describe("relay-server", () => {
     resetTables();
     activeRelayConnections.clear();
     mockUserReference = "my human";
+    mockAssistantName = "Vellum";
     mockSendMessage.mockImplementation(createMockProviderResponse(["Hello"]));
     mockConfig.calls.verification.enabled = false;
     mockConfig.calls.verification.maxAttempts = 3;
     mockConfig.calls.verification.codeLength = 6;
     mockConfig.calls.callerIdentity.userNumber = undefined;
+    // Reset TTS provider mocks to native (non-streaming) path
+    mockTtsProviderId = "elevenlabs";
+    mockTtsSupportsStreaming = false;
+    mockTtsSynthesizeStream = null;
     setVoiceBridgeDeps({
       getOrCreateConversation: async (conversationId) => {
         const session = {
@@ -4235,5 +4279,309 @@ describe("relay-server", () => {
     expect(promptText).toContain("my human");
 
     relay.destroy();
+  });
+
+  // ── Provider-aware call speech output ──────────────────────────────
+
+  describe("provider-aware system prompts", () => {
+    test("native TTS provider: verification prompt uses sendTextToken (text messages)", async () => {
+      // Ensure native (non-streaming) TTS path
+      mockTtsSupportsStreaming = false;
+      mockTtsSynthesizeStream = null;
+
+      ensureConversation("conv-native-tts-verify");
+      const session = createCallSession({
+        conversationId: "conv-native-tts-verify",
+        provider: "twilio",
+        fromNumber: "+15559999999",
+        toNumber: "+15551111111",
+      });
+
+      createPendingVoiceGuardianChallenge("654321");
+
+      const { ws, relay } = createMockWs(session.id);
+
+      await relay.handleMessage(
+        JSON.stringify({
+          type: "setup",
+          callSid: "CA_native_tts_verify",
+          from: "+15559999999",
+          to: "+15551111111",
+        }),
+      );
+
+      expect(relay.getConnectionState()).toBe("verification_pending");
+
+      // With native TTS, the prompt should appear as a text message (not play)
+      const textMessages = ws.sentMessages
+        .map((raw) => JSON.parse(raw) as { type: string; token?: string })
+        .filter((m) => m.type === "text");
+      const playMessages = ws.sentMessages
+        .map((raw) => JSON.parse(raw) as { type: string; source?: string })
+        .filter((m) => m.type === "play");
+
+      expect(
+        textMessages.some((m) => (m.token ?? "").includes("verification code")),
+      ).toBe(true);
+      expect(playMessages.length).toBe(0);
+
+      relay.destroy();
+    });
+
+    test("synthesized TTS provider: verification prompt uses sendPlayUrl (play messages)", async () => {
+      // Enable synthesized (streaming) TTS path
+      mockTtsProviderId = "fish-audio";
+      mockTtsSupportsStreaming = true;
+      mockTtsSynthesizeStream = jest.fn(
+        async (_request: unknown, onChunk: (chunk: Uint8Array) => void) => {
+          onChunk(new Uint8Array([0x01, 0x02, 0x03]));
+          return {
+            audio: Buffer.from([0x01, 0x02, 0x03]),
+            contentType: "audio/mpeg",
+          };
+        },
+      );
+
+      ensureConversation("conv-synth-tts-verify");
+      const session = createCallSession({
+        conversationId: "conv-synth-tts-verify",
+        provider: "twilio",
+        fromNumber: "+15559999998",
+        toNumber: "+15551111111",
+      });
+
+      createPendingVoiceGuardianChallenge("654321");
+
+      const { ws, relay } = createMockWs(session.id);
+
+      await relay.handleMessage(
+        JSON.stringify({
+          type: "setup",
+          callSid: "CA_synth_tts_verify",
+          from: "+15559999998",
+          to: "+15551111111",
+        }),
+      );
+
+      expect(relay.getConnectionState()).toBe("verification_pending");
+
+      // Allow async synthesis to complete
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      // With synthesized TTS, the prompt should appear as a play message
+      const playMessages = ws.sentMessages
+        .map((raw) => JSON.parse(raw) as { type: string; source?: string })
+        .filter((m) => m.type === "play");
+
+      expect(playMessages.length).toBeGreaterThan(0);
+      expect(playMessages[0].source).toContain("/v1/audio/");
+
+      // The synthesizeStream mock should have been called
+      expect(mockTtsSynthesizeStream).toHaveBeenCalled();
+
+      relay.destroy();
+    });
+
+    test("native TTS provider: name capture greeting uses text messages", async () => {
+      // Ensure native (non-streaming) TTS path
+      mockTtsSupportsStreaming = false;
+      mockTtsSynthesizeStream = null;
+
+      ensureConversation("conv-native-name-capture");
+      const session = createCallSession({
+        conversationId: "conv-native-name-capture",
+        provider: "twilio",
+        fromNumber: "+15559990097",
+        toNumber: "+15551111111",
+      });
+
+      mockAssistantName = "Jarvis";
+
+      const { ws, relay } = createMockWs(session.id);
+
+      await relay.handleMessage(
+        JSON.stringify({
+          type: "setup",
+          callSid: "CA_native_name_capture",
+          from: "+15559990097",
+          to: "+15551111111",
+        }),
+      );
+
+      expect(relay.getConnectionState()).toBe("awaiting_name");
+
+      // With native TTS, the greeting should be a text message
+      const textMessages = ws.sentMessages
+        .map((raw) => JSON.parse(raw) as { type: string; token?: string })
+        .filter((m) => m.type === "text");
+      const playMessages = ws.sentMessages
+        .map((raw) => JSON.parse(raw) as { type: string; source?: string })
+        .filter((m) => m.type === "play");
+
+      expect(
+        textMessages.some((m) => (m.token ?? "").includes("don't recognize")),
+      ).toBe(true);
+      expect(playMessages.length).toBe(0);
+
+      // Reset
+      mockAssistantName = "Vellum";
+      relay.destroy();
+    });
+
+    test("synthesized TTS provider: name capture greeting uses play messages", async () => {
+      // Enable synthesized (streaming) TTS path
+      mockTtsProviderId = "fish-audio";
+      mockTtsSupportsStreaming = true;
+      mockTtsSynthesizeStream = jest.fn(
+        async (_request: unknown, onChunk: (chunk: Uint8Array) => void) => {
+          onChunk(new Uint8Array([0x04, 0x05, 0x06]));
+          return {
+            audio: Buffer.from([0x04, 0x05, 0x06]),
+            contentType: "audio/mpeg",
+          };
+        },
+      );
+
+      ensureConversation("conv-synth-name-capture");
+      const session = createCallSession({
+        conversationId: "conv-synth-name-capture",
+        provider: "twilio",
+        fromNumber: "+15559990098",
+        toNumber: "+15551111111",
+      });
+
+      mockAssistantName = "Jarvis";
+
+      const { ws, relay } = createMockWs(session.id);
+
+      await relay.handleMessage(
+        JSON.stringify({
+          type: "setup",
+          callSid: "CA_synth_name_capture",
+          from: "+15559990098",
+          to: "+15551111111",
+        }),
+      );
+
+      expect(relay.getConnectionState()).toBe("awaiting_name");
+
+      // Allow async synthesis to complete
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      // With synthesized TTS, the greeting should be a play message
+      const playMessages = ws.sentMessages
+        .map((raw) => JSON.parse(raw) as { type: string; source?: string })
+        .filter((m) => m.type === "play");
+
+      expect(playMessages.length).toBeGreaterThan(0);
+      expect(playMessages[0].source).toContain("/v1/audio/");
+
+      // The synthesizeStream mock should have been called
+      expect(mockTtsSynthesizeStream).toHaveBeenCalled();
+
+      // Reset
+      mockAssistantName = "Vellum";
+      relay.destroy();
+    });
+
+    test("synthesized TTS provider: falls back to text on synthesis failure", async () => {
+      // Configure synthesized path but make it fail
+      mockTtsProviderId = "fish-audio";
+      mockTtsSupportsStreaming = true;
+      mockTtsSynthesizeStream = jest.fn(async () => {
+        throw new Error("Synthesis service unavailable");
+      });
+
+      ensureConversation("conv-synth-fallback");
+      const session = createCallSession({
+        conversationId: "conv-synth-fallback",
+        provider: "twilio",
+        fromNumber: "+15559990099",
+        toNumber: "+15551111111",
+      });
+
+      createPendingVoiceGuardianChallenge("654321");
+
+      const { ws, relay } = createMockWs(session.id);
+
+      await relay.handleMessage(
+        JSON.stringify({
+          type: "setup",
+          callSid: "CA_synth_fallback",
+          from: "+15559990099",
+          to: "+15551111111",
+        }),
+      );
+
+      expect(relay.getConnectionState()).toBe("verification_pending");
+
+      // Allow async synthesis (and fallback) to complete
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      // Should have fallen back to text messages after synthesis failure
+      const textMessages = ws.sentMessages
+        .map((raw) => JSON.parse(raw) as { type: string; token?: string })
+        .filter((m) => m.type === "text");
+
+      expect(
+        textMessages.some((m) => (m.token ?? "").includes("verification code")),
+      ).toBe(true);
+
+      relay.destroy();
+    });
+
+    test("native TTS provider: DTMF callee verification failure prompt uses text messages", async () => {
+      // Ensure native (non-streaming) TTS path
+      mockTtsSupportsStreaming = false;
+      mockTtsSynthesizeStream = null;
+
+      ensureConversation("conv-native-callee-fail");
+      mockConfig.calls.verification.enabled = true;
+      mockConfig.calls.verification.maxAttempts = 1;
+
+      const session = createCallSession({
+        conversationId: "conv-native-callee-fail",
+        provider: "twilio",
+        fromNumber: "+15551111111",
+        toNumber: "+15552222222",
+        task: "Call +15552222222",
+      });
+
+      const { ws, relay } = createMockWs(session.id);
+
+      await relay.handleMessage(
+        JSON.stringify({
+          type: "setup",
+          callSid: "CA_native_callee_fail",
+          from: "+15551111111",
+          to: "+15552222222",
+        }),
+      );
+
+      expect(relay.getConnectionState()).toBe("verification_pending");
+      expect(relay.getVerificationCode()).not.toBeNull();
+
+      // Send wrong digits
+      for (const digit of "000000") {
+        await relay.handleMessage(JSON.stringify({ type: "dtmf", digit }));
+      }
+
+      // Should have sent "Verification failed" as text (not play)
+      const textMessages = ws.sentMessages
+        .map((raw) => JSON.parse(raw) as { type: string; token?: string })
+        .filter((m) => m.type === "text");
+      const playMessages = ws.sentMessages
+        .map((raw) => JSON.parse(raw) as { type: string; source?: string })
+        .filter((m) => m.type === "play");
+
+      expect(
+        textMessages.some((m) =>
+          (m.token ?? "").includes("Verification failed"),
+        ),
+      ).toBe(true);
+      expect(playMessages.length).toBe(0);
+
+      relay.destroy();
+    });
   });
 });

--- a/assistant/src/calls/call-speech-output.ts
+++ b/assistant/src/calls/call-speech-output.ts
@@ -69,28 +69,31 @@ function resolveCallTtsProvider(): ResolvedCallTts {
 /**
  * Speak a deterministic text prompt through the active TTS provider.
  *
- * For native providers this is equivalent to `relay.sendTextToken(text, true)`.
- * For synthesized providers this synthesizes audio via the provider API and
- * sends the play URL to the relay.
+ * For native providers this is equivalent to `relay.sendTextToken(text, true)`
+ * and resolves immediately (synchronous send).
  *
- * The function is intentionally fire-and-forget for the synthesized path —
- * callers that need to wait for TTS playback to complete should still use
- * `getTtsPlaybackDelayMs()` for scheduling follow-up actions (e.g. ending
- * the session after a goodbye message).
+ * For synthesized providers this synthesizes audio via the provider API,
+ * sends the play URL to the relay, and resolves once synthesis is complete.
+ * Callers in disconnect/teardown flows should `await` the returned promise
+ * before starting teardown timers so that the play URL is delivered to
+ * Twilio before the session ends. Interactive mid-call callers can
+ * fire-and-forget with `void speakSystemPrompt(...)`.
  */
-export function speakSystemPrompt(relay: RelayConnection, text: string): void {
+export function speakSystemPrompt(
+  relay: RelayConnection,
+  text: string,
+): Promise<void> {
   const { provider, useSynthesizedPath, audioFormat } =
     resolveCallTtsProvider();
 
   if (!useSynthesizedPath || !provider) {
     // Native path — send text for Twilio's built-in TTS.
     relay.sendTextToken(text, true);
-    return;
+    return Promise.resolve();
   }
 
   // Synthesized path — synthesize audio and send play URL.
-  // Fire-and-forget: callers use getTtsPlaybackDelayMs() for timing.
-  void synthesizeAndPlay(relay, provider, text, audioFormat);
+  return synthesizeAndPlay(relay, provider, text, audioFormat);
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/calls/call-speech-output.ts
+++ b/assistant/src/calls/call-speech-output.ts
@@ -2,11 +2,9 @@
  * Provider-aware speech output for deterministic call prompts.
  *
  * Deterministic call prompts (verification codes, guardian wait updates,
- * timeout copy, failure copy, etc.) were previously sent directly via
- * `sendTextToken()` which always uses Twilio's built-in TTS. This helper
- * routes them through the same provider abstraction used by the call
- * controller so that configured synthesized providers (e.g. Fish Audio)
- * are respected for all spoken output.
+ * timeout copy, failure copy, etc.) are routed through the same provider
+ * abstraction used by the call controller so that configured synthesized
+ * providers (e.g. Fish Audio) are respected for all spoken output.
  *
  * Two output paths:
  * - **Native**: Provider does not support streaming — text is sent via
@@ -116,7 +114,6 @@ async function synthesizeAndPlay(
     const config = loadConfig();
     const baseUrl = getPublicBaseUrl(config);
     const url = `${baseUrl}/v1/audio/${handle.audioId}`;
-    relay.sendPlayUrl(url);
 
     if (provider.synthesizeStream) {
       await provider.synthesizeStream(
@@ -130,12 +127,25 @@ async function synthesizeAndPlay(
       });
       handle.push(result.audio);
     }
+
+    // Send the play URL only after synthesis succeeds so that Twilio never
+    // receives a play message pointing to empty/broken audio on failure.
+    relay.sendPlayUrl(url);
+
+    // Signal end of this turn's speech.  An empty token with `last: true`
+    // tells ConversationRelay to start listening — it does NOT trigger TTS
+    // synthesis.  This is required even when a synthesized provider handled
+    // all audio playback, because ConversationRelay still needs the
+    // end-of-turn signal to transition from "assistant speaking" to
+    // "caller speaking" state.
+    relay.sendTextToken("", true);
   } catch (err) {
     log.error(
       { err, provider: provider.id },
       "System prompt TTS synthesis failed — falling back to native TTS",
     );
     // Fallback: send text via native TTS so the caller still hears the message.
+    // sendTextToken with last:true includes the end-of-turn signal inherently.
     relay.sendTextToken(text, true);
   } finally {
     handle?.finalize();

--- a/assistant/src/calls/call-speech-output.ts
+++ b/assistant/src/calls/call-speech-output.ts
@@ -1,0 +1,143 @@
+/**
+ * Provider-aware speech output for deterministic call prompts.
+ *
+ * Deterministic call prompts (verification codes, guardian wait updates,
+ * timeout copy, failure copy, etc.) were previously sent directly via
+ * `sendTextToken()` which always uses Twilio's built-in TTS. This helper
+ * routes them through the same provider abstraction used by the call
+ * controller so that configured synthesized providers (e.g. Fish Audio)
+ * are respected for all spoken output.
+ *
+ * Two output paths:
+ * - **Native**: Provider does not support streaming — text is sent via
+ *   `sendTextToken()` for Twilio's built-in TTS engine.
+ * - **Synthesized**: Provider supports streaming — text is synthesized
+ *   via the provider API, streamed through the audio store, and played
+ *   via `sendPlayUrl()`.
+ */
+
+import { loadConfig } from "../config/loader.js";
+import { getPublicBaseUrl } from "../inbound/public-ingress-urls.js";
+import { getTtsProvider } from "../tts/provider-registry.js";
+import { resolveTtsConfig } from "../tts/tts-config-resolver.js";
+import type { TtsProvider } from "../tts/types.js";
+import { getLogger } from "../util/logger.js";
+import { createStreamingEntry } from "./audio-store.js";
+import type { RelayConnection } from "./relay-server.js";
+
+const log = getLogger("call-speech-output");
+
+// ---------------------------------------------------------------------------
+// Provider resolution (shared logic with call-controller)
+// ---------------------------------------------------------------------------
+
+interface ResolvedCallTts {
+  provider: TtsProvider | null;
+  useSynthesizedPath: boolean;
+  audioFormat: "mp3" | "wav" | "opus";
+}
+
+/**
+ * Resolve the active TTS provider via the global provider abstraction.
+ *
+ * Mirrors the resolution logic in CallController.resolveCallTtsProvider()
+ * so deterministic prompts use the same provider path as LLM-generated
+ * speech.
+ */
+function resolveCallTtsProvider(): ResolvedCallTts {
+  try {
+    const config = loadConfig();
+    const resolved = resolveTtsConfig(config);
+    const provider = getTtsProvider(resolved.provider);
+    const useSynthesizedPath = provider.capabilities.supportsStreaming;
+    const configuredFormat = (resolved.providerConfig as { format?: string })
+      .format;
+    const audioFormat = (
+      configuredFormat && ["mp3", "wav", "opus"].includes(configuredFormat)
+        ? configuredFormat
+        : "mp3"
+    ) as "mp3" | "wav" | "opus";
+    return { provider, useSynthesizedPath, audioFormat };
+  } catch {
+    // Config missing or provider not registered — fall back to native path.
+    return { provider: null, useSynthesizedPath: false, audioFormat: "mp3" };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Speak a deterministic text prompt through the active TTS provider.
+ *
+ * For native providers this is equivalent to `relay.sendTextToken(text, true)`.
+ * For synthesized providers this synthesizes audio via the provider API and
+ * sends the play URL to the relay.
+ *
+ * The function is intentionally fire-and-forget for the synthesized path —
+ * callers that need to wait for TTS playback to complete should still use
+ * `getTtsPlaybackDelayMs()` for scheduling follow-up actions (e.g. ending
+ * the session after a goodbye message).
+ */
+export function speakSystemPrompt(relay: RelayConnection, text: string): void {
+  const { provider, useSynthesizedPath, audioFormat } =
+    resolveCallTtsProvider();
+
+  if (!useSynthesizedPath || !provider) {
+    // Native path — send text for Twilio's built-in TTS.
+    relay.sendTextToken(text, true);
+    return;
+  }
+
+  // Synthesized path — synthesize audio and send play URL.
+  // Fire-and-forget: callers use getTtsPlaybackDelayMs() for timing.
+  void synthesizeAndPlay(relay, provider, text, audioFormat);
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Synthesize text via a streaming TTS provider and send the play URL
+ * to the relay. Falls back to sendTextToken on synthesis failure so the
+ * caller always hears something.
+ */
+async function synthesizeAndPlay(
+  relay: RelayConnection,
+  provider: TtsProvider,
+  text: string,
+  format: "mp3" | "wav" | "opus",
+): Promise<void> {
+  let handle: ReturnType<typeof createStreamingEntry> | null = null;
+  try {
+    handle = createStreamingEntry(format);
+    const config = loadConfig();
+    const baseUrl = getPublicBaseUrl(config);
+    const url = `${baseUrl}/v1/audio/${handle.audioId}`;
+    relay.sendPlayUrl(url);
+
+    if (provider.synthesizeStream) {
+      await provider.synthesizeStream(
+        { text, useCase: "phone-call" },
+        (chunk) => handle!.push(chunk),
+      );
+    } else {
+      const result = await provider.synthesize({
+        text,
+        useCase: "phone-call",
+      });
+      handle.push(result.audio);
+    }
+  } catch (err) {
+    log.error(
+      { err, provider: provider.id },
+      "System prompt TTS synthesis failed — falling back to native TTS",
+    );
+    // Fallback: send text via native TTS so the caller still hears the message.
+    relay.sendTextToken(text, true);
+  } finally {
+    handle?.finalize();
+  }
+}

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -595,7 +595,7 @@ export class RelayConnection {
         await this.startVerification(session, outcome.verificationConfig);
         return;
       case "deny":
-        this.denyInboundCall(msg.from, resolved, outcome);
+        await this.denyInboundCall(msg.from, resolved, outcome);
         return;
       case "invite_redemption":
         this.startInviteRedemption(
@@ -691,24 +691,24 @@ export class RelayConnection {
   }
 
   /** Deny an inbound call with a TTS message and schedule disconnect. */
-  private denyInboundCall(
+  private async denyInboundCall(
     from: string,
     resolved: import("./relay-setup-router.js").SetupResolved,
     outcome: { message: string; logReason: string },
-  ): void {
+  ): Promise<void> {
     recordCallEvent(this.callSessionId, "inbound_acl_denied", {
       from,
       trustClass: resolved.actorTrust.trustClass,
       channelId: resolved.actorTrust.memberRecord?.channel.id,
       memberPolicy: resolved.actorTrust.memberRecord?.channel.policy,
     });
-    speakSystemPrompt(this, outcome.message);
     this.connectionState = "disconnecting";
     updateCallSession(this.callSessionId, {
       status: "failed",
       endedAt: Date.now(),
       lastError: outcome.logReason,
     });
+    await speakSystemPrompt(this, outcome.message);
     setTimeout(() => {
       this.endSession(outcome.logReason);
     }, getTtsPlaybackDelayMs());
@@ -741,7 +741,7 @@ export class RelayConnection {
 
     // Send a TTS prompt with the code spoken digit by digit
     const spokenCode = code.split("").join(". ");
-    speakSystemPrompt(
+    void speakSystemPrompt(
       this,
       `Please enter the verification code: ${spokenCode}.`,
     );
@@ -862,7 +862,7 @@ export class RelayConnection {
       handoffText = `Great! ${guardianLabel} said I can speak with you. How can I help?`;
     }
 
-    speakSystemPrompt(this, handoffText);
+    void speakSystemPrompt(this, handoffText);
 
     recordCallEvent(this.callSessionId, "assistant_spoke", {
       text: handoffText,
@@ -905,7 +905,7 @@ export class RelayConnection {
       maxAttempts: this.verificationMaxAttempts,
     });
 
-    speakSystemPrompt(
+    void speakSystemPrompt(
       this,
       "Welcome. Please enter your six-digit verification code using your keypad, or speak the digits now.",
     );
@@ -947,7 +947,7 @@ export class RelayConnection {
       GUARDIAN_VERIFY_TEMPLATE_KEYS.VOICE_CALL_INTRO,
       { codeDigits: this.verificationCodeLength },
     );
-    speakSystemPrompt(this, introText);
+    void speakSystemPrompt(this, introText);
 
     log.info(
       {
@@ -964,7 +964,9 @@ export class RelayConnection {
    * Delegates to the extracted attemptVerificationCode() and
    * interprets the structured result to drive side-effects.
    */
-  private handleVerificationCodeResult(enteredCode: string): void {
+  private async handleVerificationCodeResult(
+    enteredCode: string,
+  ): Promise<void> {
     if (!this.verificationAssistantId || !this.verificationFromNumber) {
       return;
     }
@@ -1103,8 +1105,6 @@ export class RelayConnection {
         "Guardian voice verification failed — max attempts reached",
       );
 
-      speakSystemPrompt(this, result.ttsMessage);
-
       updateCallSession(this.callSessionId, {
         status: "failed",
         endedAt: Date.now(),
@@ -1136,6 +1136,7 @@ export class RelayConnection {
         }
       }
 
+      await speakSystemPrompt(this, result.ttsMessage);
       setTimeout(() => {
         this.endSession("Verification failed — challenge rejected");
       }, getTtsPlaybackDelayMs());
@@ -1152,7 +1153,7 @@ export class RelayConnection {
         },
         "Guardian voice verification attempt failed — retrying",
       );
-      speakSystemPrompt(this, result.ttsMessage);
+      void speakSystemPrompt(this, result.ttsMessage);
     }
   }
 
@@ -1197,7 +1198,7 @@ export class RelayConnection {
     } else {
       promptText = `Welcome ${displayFriend}. Please enter the 6-digit code that ${displayGuardian} provided you to verify your identity.`;
     }
-    speakSystemPrompt(this, promptText);
+    void speakSystemPrompt(this, promptText);
 
     log.info(
       { callSessionId: this.callSessionId, assistantId },
@@ -1222,7 +1223,7 @@ export class RelayConnection {
       ? `Hi, this is ${assistantName}, ${guardianLabel}'s assistant. Sorry, I don't recognize this number. I'll let ${guardianLabel} know you called and see if I have permission to speak with you. Can I get your name?`
       : `Hi, this is ${guardianLabel}'s assistant. Sorry, I don't recognize this number. I'll let ${guardianLabel} know you called and see if I have permission to speak with you. Can I get your name?`;
 
-    speakSystemPrompt(this, greeting);
+    void speakSystemPrompt(this, greeting);
 
     // Start a timeout so silent callers don't keep the call open indefinitely.
     // Uses a 30-second window — enough time to speak a name but short enough
@@ -1230,7 +1231,7 @@ export class RelayConnection {
     const NAME_CAPTURE_TIMEOUT_MS = 30_000;
     this.nameCaptureTimeoutTimer = setTimeout(() => {
       if (this.connectionState !== "awaiting_name") return;
-      this.handleNameCaptureTimeout();
+      void this.handleNameCaptureTimeout();
     }, NAME_CAPTURE_TIMEOUT_MS);
 
     log.info(
@@ -1308,7 +1309,7 @@ export class RelayConnection {
         { callSessionId: this.callSessionId },
         "Access request ID is null after notification attempt — failing closed",
       );
-      this.handleAccessRequestTimeout();
+      void this.handleAccessRequestTimeout();
       return;
     }
 
@@ -1328,7 +1329,7 @@ export class RelayConnection {
     const pollIntervalMs = getAccessRequestPollIntervalMs();
 
     const guardianLabel = this.resolveGuardianLabel();
-    speakSystemPrompt(
+    void speakSystemPrompt(
       this,
       `Thank you. I've let ${guardianLabel} know. Please hold while I check if I have permission to speak with you.`,
     );
@@ -1364,7 +1365,7 @@ export class RelayConnection {
       if (request.status === "approved") {
         this.handleAccessRequestApproved();
       } else if (request.status === "denied") {
-        this.handleAccessRequestDenied();
+        void this.handleAccessRequestDenied();
       }
       // 'pending' continues polling; 'expired'/'cancelled' handled by timeout
     }, pollIntervalMs);
@@ -1378,7 +1379,7 @@ export class RelayConnection {
         "Access request in-call wait timed out",
       );
 
-      this.handleAccessRequestTimeout();
+      void this.handleAccessRequestTimeout();
     }, timeoutMs);
 
     log.info(
@@ -1451,7 +1452,7 @@ export class RelayConnection {
   /**
    * Handle a denied access request: deliver deterministic copy and hang up.
    */
-  private handleAccessRequestDenied(): void {
+  private async handleAccessRequestDenied(): Promise<void> {
     this.clearAccessRequestWait();
 
     const guardianLabel = this.resolveGuardianLabel();
@@ -1460,11 +1461,6 @@ export class RelayConnection {
       from: this.accessRequestFromNumber,
       requestId: this.accessRequestId,
     });
-
-    speakSystemPrompt(
-      this,
-      `Sorry, ${guardianLabel} says I'm not allowed to speak with you. Goodbye.`,
-    );
 
     this.connectionState = "disconnecting";
 
@@ -1479,6 +1475,10 @@ export class RelayConnection {
       "Access request denied — ending call",
     );
 
+    await speakSystemPrompt(
+      this,
+      `Sorry, ${guardianLabel} says I'm not allowed to speak with you. Goodbye.`,
+    );
     setTimeout(() => {
       this.endSession("Access request denied");
     }, getTtsPlaybackDelayMs());
@@ -1487,7 +1487,7 @@ export class RelayConnection {
   /**
    * Handle an access request timeout: deliver deterministic copy and hang up.
    */
-  private handleAccessRequestTimeout(): void {
+  private async handleAccessRequestTimeout(): Promise<void> {
     // Emit callback handoff notification before clearing wait state
     this.emitAccessRequestCallbackHandoffForReason("timeout");
 
@@ -1504,10 +1504,6 @@ export class RelayConnection {
     const callbackNote = this.callbackOptIn
       ? ` I've noted that you'd like a callback — I'll pass that along to ${guardianLabel}.`
       : "";
-    speakSystemPrompt(
-      this,
-      `Sorry, I can't get ahold of ${guardianLabel} right now. I'll let them know you called.${callbackNote}`,
-    );
 
     this.connectionState = "disconnecting";
 
@@ -1522,6 +1518,10 @@ export class RelayConnection {
       "Access request timed out — ending call",
     );
 
+    await speakSystemPrompt(
+      this,
+      `Sorry, I can't get ahold of ${guardianLabel} right now. I'll let them know you called.${callbackNote}`,
+    );
     setTimeout(() => {
       this.endSession("Access request timed out");
     }, getTtsPlaybackDelayMs());
@@ -1547,7 +1547,7 @@ export class RelayConnection {
    * Handle a name capture timeout: the caller never provided their name
    * within the allotted window. Deliver deterministic copy and hang up.
    */
-  private handleNameCaptureTimeout(): void {
+  private async handleNameCaptureTimeout(): Promise<void> {
     if (this.nameCaptureTimeoutTimer) {
       clearTimeout(this.nameCaptureTimeoutTimer);
       this.nameCaptureTimeoutTimer = null;
@@ -1556,11 +1556,6 @@ export class RelayConnection {
     recordCallEvent(this.callSessionId, "inbound_acl_name_capture_timeout", {
       from: this.accessRequestFromNumber,
     });
-
-    speakSystemPrompt(
-      this,
-      "Sorry, I didn't catch your name. Please try calling back. Goodbye.",
-    );
 
     this.connectionState = "disconnecting";
 
@@ -1575,6 +1570,10 @@ export class RelayConnection {
       "Name capture timed out — ending call",
     );
 
+    await speakSystemPrompt(
+      this,
+      "Sorry, I didn't catch your name. Please try calling back. Goodbye.",
+    );
     setTimeout(() => {
       this.endSession("Name capture timed out");
     }, getTtsPlaybackDelayMs());
@@ -1585,7 +1584,9 @@ export class RelayConnection {
    * Delegates to the extracted attemptInviteCodeRedemption() and
    * interprets the structured result to drive side-effects.
    */
-  private handleInviteCodeRedemptionResult(enteredCode: string): void {
+  private async handleInviteCodeRedemptionResult(
+    enteredCode: string,
+  ): Promise<void> {
     if (!this.inviteRedemptionAssistantId || !this.inviteRedemptionFromNumber) {
       return;
     }
@@ -1635,8 +1636,6 @@ export class RelayConnection {
         "Voice invite redemption failed — invalid or expired code",
       );
 
-      speakSystemPrompt(this, result.ttsMessage);
-
       this.connectionState = "disconnecting";
 
       updateCallSession(this.callSessionId, {
@@ -1650,6 +1649,7 @@ export class RelayConnection {
         finalizeCall(this.callSessionId, failSession.conversationId);
       }
 
+      await speakSystemPrompt(this, result.ttsMessage);
       setTimeout(() => {
         this.endSession("Invite redemption failed");
       }, getTtsPlaybackDelayMs());
@@ -1692,7 +1692,7 @@ export class RelayConnection {
       callSessionId: this.callSessionId,
       consumeSequence: () => this.heartbeatSequence++,
       resolveGuardianLabel: () => this.resolveGuardianLabel(),
-      sendTextToken: (text, _last) => speakSystemPrompt(this, text),
+      sendTextToken: (text, _last) => void speakSystemPrompt(this, text),
       scheduleNext: () => this.scheduleNextHeartbeat(),
     });
   }
@@ -1738,7 +1738,7 @@ export class RelayConnection {
           clearTimeout(this.accessRequestHeartbeatTimer);
           this.accessRequestHeartbeatTimer = null;
         }
-        speakSystemPrompt(
+        void speakSystemPrompt(
           this,
           `Noted, I'll make sure ${guardianLabel} knows you'd like a callback. For now, I'll keep trying to reach them.`,
         );
@@ -1757,7 +1757,7 @@ export class RelayConnection {
           clearTimeout(this.accessRequestHeartbeatTimer);
           this.accessRequestHeartbeatTimer = null;
         }
-        speakSystemPrompt(
+        void speakSystemPrompt(
           this,
           `No problem, I'll keep holding. Still waiting on ${guardianLabel}.`,
         );
@@ -1794,13 +1794,13 @@ export class RelayConnection {
             "voice_guardian_wait_callback_offer_sent",
             {},
           );
-          speakSystemPrompt(
+          void speakSystemPrompt(
             this,
             `I understand this is taking a while. I can have ${guardianLabel} call you back once I hear from them. Would you like that, or would you prefer to keep holding?`,
           );
         } else {
           // Already offered callback — just reassure
-          speakSystemPrompt(
+          void speakSystemPrompt(
             this,
             `I hear you, I'm sorry for the wait. Still trying to reach ${guardianLabel}.`,
           );
@@ -1815,7 +1815,7 @@ export class RelayConnection {
           clearTimeout(this.accessRequestHeartbeatTimer);
           this.accessRequestHeartbeatTimer = null;
         }
-        speakSystemPrompt(
+        void speakSystemPrompt(
           this,
           `Yes, I'm still here. Still waiting to hear back from ${guardianLabel}.`,
         );
@@ -1828,7 +1828,7 @@ export class RelayConnection {
           clearTimeout(this.accessRequestHeartbeatTimer);
           this.accessRequestHeartbeatTimer = null;
         }
-        speakSystemPrompt(
+        void speakSystemPrompt(
           this,
           `Thanks for that. I'm still waiting on ${guardianLabel}. I'll let you know as soon as I hear back.`,
         );
@@ -1889,9 +1889,9 @@ export class RelayConnection {
       );
       if (spokenDigits.length >= this.verificationCodeLength) {
         const enteredCode = spokenDigits.slice(0, this.verificationCodeLength);
-        this.handleVerificationCodeResult(enteredCode);
+        void this.handleVerificationCodeResult(enteredCode);
       } else if (spokenDigits.length > 0) {
-        speakSystemPrompt(
+        void speakSystemPrompt(
           this,
           `I heard ${spokenDigits.length} digits. Please enter all ${this.verificationCodeLength} digits of your code.`,
         );
@@ -1919,9 +1919,9 @@ export class RelayConnection {
           0,
           this.inviteRedemptionCodeLength,
         );
-        this.handleInviteCodeRedemptionResult(enteredCode);
+        void this.handleInviteCodeRedemptionResult(enteredCode);
       } else if (spokenDigits.length > 0) {
-        speakSystemPrompt(
+        void speakSystemPrompt(
           this,
           `I heard ${spokenDigits.length} digits. Please enter all ${this.inviteRedemptionCodeLength} digits of your code.`,
         );
@@ -2015,7 +2015,7 @@ export class RelayConnection {
           );
         }
       }
-      speakSystemPrompt(this, "I'm still setting up. Please hold.");
+      void speakSystemPrompt(this, "I'm still setting up. Please hold.");
     }
   }
 
@@ -2074,7 +2074,7 @@ export class RelayConnection {
           this.verificationCodeLength,
         );
         this.dtmfBuffer = "";
-        this.handleVerificationCodeResult(enteredCode);
+        void this.handleVerificationCodeResult(enteredCode);
       }
       return;
     }
@@ -2093,7 +2093,7 @@ export class RelayConnection {
           this.inviteRedemptionCodeLength,
         );
         this.dtmfBuffer = "";
-        this.handleInviteCodeRedemptionResult(enteredCode);
+        void this.handleInviteCodeRedemptionResult(enteredCode);
       }
       return;
     }
@@ -2156,8 +2156,6 @@ export class RelayConnection {
               "Callee verification failed — max attempts reached",
             );
 
-            speakSystemPrompt(this, "Verification failed. Goodbye.");
-
             // Mark failed immediately so a relay close during the goodbye TTS
             // window cannot race this into a terminal "completed" status.
             updateCallSession(this.callSessionId, {
@@ -2189,10 +2187,15 @@ export class RelayConnection {
               }
             }
 
-            // End the call with failed status after TTS plays
-            setTimeout(() => {
-              this.endSession("Verification failed");
-            }, getTtsPlaybackDelayMs());
+            // Wait for synthesis to complete before starting teardown timer
+            // so the caller hears the goodbye message.
+            void speakSystemPrompt(this, "Verification failed. Goodbye.").then(
+              () => {
+                setTimeout(() => {
+                  this.endSession("Verification failed");
+                }, getTtsPlaybackDelayMs());
+              },
+            );
           } else {
             // Allow another attempt
             log.info(
@@ -2203,7 +2206,7 @@ export class RelayConnection {
               },
               "Callee verification attempt failed — retrying",
             );
-            speakSystemPrompt(
+            void speakSystemPrompt(
               this,
               "That code was incorrect. Please try again.",
             );

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -43,6 +43,7 @@ import {
 } from "./call-constants.js";
 import { CallController } from "./call-controller.js";
 import { addPointerMessage, formatDuration } from "./call-pointer-messages.js";
+import { speakSystemPrompt } from "./call-speech-output.js";
 import { fireCallTranscriptNotifier } from "./call-state.js";
 import { isTerminalState } from "./call-state-machine.js";
 import {
@@ -701,7 +702,7 @@ export class RelayConnection {
       channelId: resolved.actorTrust.memberRecord?.channel.id,
       memberPolicy: resolved.actorTrust.memberRecord?.channel.policy,
     });
-    this.sendTextToken(outcome.message, true);
+    speakSystemPrompt(this, outcome.message);
     this.connectionState = "disconnecting";
     updateCallSession(this.callSessionId, {
       status: "failed",
@@ -740,9 +741,9 @@ export class RelayConnection {
 
     // Send a TTS prompt with the code spoken digit by digit
     const spokenCode = code.split("").join(". ");
-    this.sendTextToken(
+    speakSystemPrompt(
+      this,
       `Please enter the verification code: ${spokenCode}.`,
-      true,
     );
 
     // Post the verification code to the initiating conversation so the
@@ -861,7 +862,7 @@ export class RelayConnection {
       handoffText = `Great! ${guardianLabel} said I can speak with you. How can I help?`;
     }
 
-    this.sendTextToken(handoffText, true);
+    speakSystemPrompt(this, handoffText);
 
     recordCallEvent(this.callSessionId, "assistant_spoke", {
       text: handoffText,
@@ -904,9 +905,9 @@ export class RelayConnection {
       maxAttempts: this.verificationMaxAttempts,
     });
 
-    this.sendTextToken(
+    speakSystemPrompt(
+      this,
       "Welcome. Please enter your six-digit verification code using your keypad, or speak the digits now.",
-      true,
     );
 
     log.info(
@@ -946,7 +947,7 @@ export class RelayConnection {
       GUARDIAN_VERIFY_TEMPLATE_KEYS.VOICE_CALL_INTRO,
       { codeDigits: this.verificationCodeLength },
     );
-    this.sendTextToken(introText, true);
+    speakSystemPrompt(this, introText);
 
     log.info(
       {
@@ -1102,7 +1103,7 @@ export class RelayConnection {
         "Guardian voice verification failed — max attempts reached",
       );
 
-      this.sendTextToken(result.ttsMessage, true);
+      speakSystemPrompt(this, result.ttsMessage);
 
       updateCallSession(this.callSessionId, {
         status: "failed",
@@ -1151,7 +1152,7 @@ export class RelayConnection {
         },
         "Guardian voice verification attempt failed — retrying",
       );
-      this.sendTextToken(result.ttsMessage, true);
+      speakSystemPrompt(this, result.ttsMessage);
     }
   }
 
@@ -1196,7 +1197,7 @@ export class RelayConnection {
     } else {
       promptText = `Welcome ${displayFriend}. Please enter the 6-digit code that ${displayGuardian} provided you to verify your identity.`;
     }
-    this.sendTextToken(promptText, true);
+    speakSystemPrompt(this, promptText);
 
     log.info(
       { callSessionId: this.callSessionId, assistantId },
@@ -1221,7 +1222,7 @@ export class RelayConnection {
       ? `Hi, this is ${assistantName}, ${guardianLabel}'s assistant. Sorry, I don't recognize this number. I'll let ${guardianLabel} know you called and see if I have permission to speak with you. Can I get your name?`
       : `Hi, this is ${guardianLabel}'s assistant. Sorry, I don't recognize this number. I'll let ${guardianLabel} know you called and see if I have permission to speak with you. Can I get your name?`;
 
-    this.sendTextToken(greeting, true);
+    speakSystemPrompt(this, greeting);
 
     // Start a timeout so silent callers don't keep the call open indefinitely.
     // Uses a 30-second window — enough time to speak a name but short enough
@@ -1327,9 +1328,9 @@ export class RelayConnection {
     const pollIntervalMs = getAccessRequestPollIntervalMs();
 
     const guardianLabel = this.resolveGuardianLabel();
-    this.sendTextToken(
+    speakSystemPrompt(
+      this,
       `Thank you. I've let ${guardianLabel} know. Please hold while I check if I have permission to speak with you.`,
-      true,
     );
 
     updateCallSession(this.callSessionId, { status: "waiting_on_user" });
@@ -1460,9 +1461,9 @@ export class RelayConnection {
       requestId: this.accessRequestId,
     });
 
-    this.sendTextToken(
+    speakSystemPrompt(
+      this,
       `Sorry, ${guardianLabel} says I'm not allowed to speak with you. Goodbye.`,
-      true,
     );
 
     this.connectionState = "disconnecting";
@@ -1503,9 +1504,9 @@ export class RelayConnection {
     const callbackNote = this.callbackOptIn
       ? ` I've noted that you'd like a callback — I'll pass that along to ${guardianLabel}.`
       : "";
-    this.sendTextToken(
+    speakSystemPrompt(
+      this,
       `Sorry, I can't get ahold of ${guardianLabel} right now. I'll let them know you called.${callbackNote}`,
-      true,
     );
 
     this.connectionState = "disconnecting";
@@ -1556,9 +1557,9 @@ export class RelayConnection {
       from: this.accessRequestFromNumber,
     });
 
-    this.sendTextToken(
+    speakSystemPrompt(
+      this,
       "Sorry, I didn't catch your name. Please try calling back. Goodbye.",
-      true,
     );
 
     this.connectionState = "disconnecting";
@@ -1634,7 +1635,7 @@ export class RelayConnection {
         "Voice invite redemption failed — invalid or expired code",
       );
 
-      this.sendTextToken(result.ttsMessage, true);
+      speakSystemPrompt(this, result.ttsMessage);
 
       this.connectionState = "disconnecting";
 
@@ -1691,7 +1692,7 @@ export class RelayConnection {
       callSessionId: this.callSessionId,
       consumeSequence: () => this.heartbeatSequence++,
       resolveGuardianLabel: () => this.resolveGuardianLabel(),
-      sendTextToken: (text, last) => this.sendTextToken(text, last),
+      sendTextToken: (text, _last) => speakSystemPrompt(this, text),
       scheduleNext: () => this.scheduleNextHeartbeat(),
     });
   }
@@ -1737,9 +1738,9 @@ export class RelayConnection {
           clearTimeout(this.accessRequestHeartbeatTimer);
           this.accessRequestHeartbeatTimer = null;
         }
-        this.sendTextToken(
+        speakSystemPrompt(
+          this,
           `Noted, I'll make sure ${guardianLabel} knows you'd like a callback. For now, I'll keep trying to reach them.`,
-          true,
         );
         this.scheduleNextHeartbeat();
         return;
@@ -1756,9 +1757,9 @@ export class RelayConnection {
           clearTimeout(this.accessRequestHeartbeatTimer);
           this.accessRequestHeartbeatTimer = null;
         }
-        this.sendTextToken(
+        speakSystemPrompt(
+          this,
           `No problem, I'll keep holding. Still waiting on ${guardianLabel}.`,
-          true,
         );
         this.scheduleNextHeartbeat();
         return;
@@ -1793,15 +1794,15 @@ export class RelayConnection {
             "voice_guardian_wait_callback_offer_sent",
             {},
           );
-          this.sendTextToken(
+          speakSystemPrompt(
+            this,
             `I understand this is taking a while. I can have ${guardianLabel} call you back once I hear from them. Would you like that, or would you prefer to keep holding?`,
-            true,
           );
         } else {
           // Already offered callback — just reassure
-          this.sendTextToken(
+          speakSystemPrompt(
+            this,
             `I hear you, I'm sorry for the wait. Still trying to reach ${guardianLabel}.`,
-            true,
           );
         }
         this.scheduleNextHeartbeat();
@@ -1814,9 +1815,9 @@ export class RelayConnection {
           clearTimeout(this.accessRequestHeartbeatTimer);
           this.accessRequestHeartbeatTimer = null;
         }
-        this.sendTextToken(
+        speakSystemPrompt(
+          this,
           `Yes, I'm still here. Still waiting to hear back from ${guardianLabel}.`,
-          true,
         );
         this.scheduleNextHeartbeat();
         break;
@@ -1827,9 +1828,9 @@ export class RelayConnection {
           clearTimeout(this.accessRequestHeartbeatTimer);
           this.accessRequestHeartbeatTimer = null;
         }
-        this.sendTextToken(
+        speakSystemPrompt(
+          this,
           `Thanks for that. I'm still waiting on ${guardianLabel}. I'll let you know as soon as I hear back.`,
-          true,
         );
         this.scheduleNextHeartbeat();
         break;
@@ -1890,9 +1891,9 @@ export class RelayConnection {
         const enteredCode = spokenDigits.slice(0, this.verificationCodeLength);
         this.handleVerificationCodeResult(enteredCode);
       } else if (spokenDigits.length > 0) {
-        this.sendTextToken(
+        speakSystemPrompt(
+          this,
           `I heard ${spokenDigits.length} digits. Please enter all ${this.verificationCodeLength} digits of your code.`,
-          true,
         );
       }
       return;
@@ -1920,9 +1921,9 @@ export class RelayConnection {
         );
         this.handleInviteCodeRedemptionResult(enteredCode);
       } else if (spokenDigits.length > 0) {
-        this.sendTextToken(
+        speakSystemPrompt(
+          this,
           `I heard ${spokenDigits.length} digits. Please enter all ${this.inviteRedemptionCodeLength} digits of your code.`,
-          true,
         );
       }
       return;
@@ -2014,7 +2015,7 @@ export class RelayConnection {
           );
         }
       }
-      this.sendTextToken("I'm still setting up. Please hold.", true);
+      speakSystemPrompt(this, "I'm still setting up. Please hold.");
     }
   }
 
@@ -2155,7 +2156,7 @@ export class RelayConnection {
               "Callee verification failed — max attempts reached",
             );
 
-            this.sendTextToken("Verification failed. Goodbye.", true);
+            speakSystemPrompt(this, "Verification failed. Goodbye.");
 
             // Mark failed immediately so a relay close during the goodbye TTS
             // window cannot race this into a terminal "completed" status.
@@ -2202,9 +2203,9 @@ export class RelayConnection {
               },
               "Callee verification attempt failed — retrying",
             );
-            this.sendTextToken(
+            speakSystemPrompt(
+              this,
               "That code was incorrect. Please try again.",
-              true,
             );
           }
         }


### PR DESCRIPTION
## Summary
- Creates call-speech-output.ts helper abstracting provider-aware text-to-speech for system prompts
- Replaces direct sendTextToken calls in relay-server with the provider-aware helper
- Maintains timing semantics for getTtsPlaybackDelayMs
- Adds tests covering both native and synthesized provider paths

Part of plan: product-tts-provider-abstraction.md (PR 7 of 11)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24779" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
