### PR TITLE
Chrome worker: make Connect interactive and auto-bootstrap assistant auth

### DIFF
--- a/clients/chrome-extension/background/__tests__/worker-connect-preflight.test.ts
+++ b/clients/chrome-extension/background/__tests__/worker-connect-preflight.test.ts
@@ -1,0 +1,612 @@
+/**
+ * Tests for the worker's connect preflight logic.
+ *
+ * The preflight resolves credentials for the selected assistant before
+ * the relay socket opens. When `interactive=true`, missing credentials
+ * trigger an auto-bootstrap (pair for local, sign-in for cloud). When
+ * `interactive=false`, only non-interactive refresh is attempted for
+ * cloud; missing credentials produce an error.
+ *
+ * Since the worker module is side-effectful (registers listeners, calls
+ * bootstrap), these tests exercise the preflight logic by replicating
+ * the key functions under test in isolation — the same approach used by
+ * `worker-selected-assistant-connect.test.ts`.
+ *
+ * Coverage:
+ *   - Local interactive: auto-pairs when token is missing.
+ *   - Local non-interactive: fails when token is missing.
+ *   - Cloud interactive: auto-signs-in when token is missing/stale.
+ *   - Cloud non-interactive: attempts refresh, succeeds if provider
+ *     session is live.
+ *   - Cloud non-interactive: fails when refresh also fails.
+ *   - Preflight is a no-op when valid token already exists.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+
+import { resolveAuthProfile, type AssistantAuthProfile } from '../assistant-auth-profile.js';
+import type { AssistantDescriptor } from '../native-host-assistants.js';
+import { isCloudTokenStale, type StoredCloudToken } from '../cloud-auth.js';
+import type { StoredLocalToken } from '../self-hosted-auth.js';
+
+// ── Types mirroring worker.ts internals ─────────────────────────────
+
+type RelayMode =
+  | { kind: 'self-hosted'; baseUrl: string; token: string | null }
+  | { kind: 'cloud'; baseUrl: string; token: string | null };
+
+interface ConnectOptions {
+  interactive: boolean;
+}
+
+class MissingTokenError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'MissingTokenError';
+  }
+}
+
+function missingTokenMessage(profile: AssistantAuthProfile | null): string {
+  if (profile === 'cloud-oauth') {
+    return 'Sign in with Vellum (cloud) before connecting';
+  }
+  if (profile === 'local-pair') {
+    return 'Pair the Vellum assistant (self-hosted) before connecting';
+  }
+  if (profile === 'unsupported') {
+    return 'This assistant uses an unsupported topology. Please update the Vellum extension.';
+  }
+  return 'Select an assistant before connecting';
+}
+
+// ── Controllable fakes ──────────────────────────────────────────────
+
+/**
+ * Fake implementations for the auth functions the preflight calls.
+ * Tests configure these per-case to control the preflight's behavior.
+ */
+interface PreflightDeps {
+  bootstrapLocalToken: (assistantId: string | null) => Promise<StoredLocalToken>;
+  signInCloud: (assistantId: string, config: { gatewayBaseUrl: string; clientId: string }) => Promise<StoredCloudToken>;
+  refreshCloudToken: (assistantId: string, config: { gatewayBaseUrl: string; clientId: string }) => Promise<StoredCloudToken | null>;
+  getStoredCloudToken: (assistantId: string) => Promise<StoredCloudToken | null>;
+  getRelayPort: () => Promise<number>;
+}
+
+const CLOUD_GATEWAY_BASE_URL = 'https://api.vellum.ai';
+const CLOUD_OAUTH_CLIENT_ID = 'vellum-chrome-extension';
+
+/**
+ * Standalone preflight implementation that mirrors the worker's
+ * `connectPreflight` function but accepts injectable deps so tests
+ * can control the auth function outcomes without mocking globals.
+ */
+async function connectPreflight(
+  assistant: AssistantDescriptor | null,
+  authProfile: AssistantAuthProfile | null,
+  mode: RelayMode,
+  options: ConnectOptions,
+  deps: PreflightDeps,
+): Promise<RelayMode> {
+  if (mode.token) {
+    if (mode.kind === 'cloud' && assistant) {
+      const stored = await deps.getStoredCloudToken(assistant.assistantId);
+      if (!isCloudTokenStale(stored)) {
+        return mode;
+      }
+    } else {
+      return mode;
+    }
+  }
+
+  if (authProfile === 'local-pair') {
+    if (!options.interactive) {
+      throw new MissingTokenError(missingTokenMessage('local-pair'));
+    }
+    const assistantId = assistant?.assistantId ?? null;
+    const stored = await deps.bootstrapLocalToken(assistantId);
+    const port = stored.assistantPort ?? assistant?.daemonPort ?? (await deps.getRelayPort());
+    return {
+      kind: 'self-hosted',
+      baseUrl: `http://127.0.0.1:${port}`,
+      token: stored.token,
+    };
+  }
+
+  if (authProfile === 'cloud-oauth') {
+    const assistantId = assistant?.assistantId ?? null;
+    if (!assistantId) {
+      throw new MissingTokenError(missingTokenMessage(null));
+    }
+
+    if (!options.interactive) {
+      const gatewayBaseUrl = assistant?.runtimeUrl || CLOUD_GATEWAY_BASE_URL;
+      const refreshed = await deps.refreshCloudToken(assistantId, {
+        gatewayBaseUrl,
+        clientId: CLOUD_OAUTH_CLIENT_ID,
+      });
+      if (refreshed) {
+        const baseUrl = assistant?.runtimeUrl || CLOUD_GATEWAY_BASE_URL;
+        return { kind: 'cloud', baseUrl, token: refreshed.token };
+      }
+      throw new MissingTokenError(missingTokenMessage('cloud-oauth'));
+    }
+
+    const gatewayBaseUrl = assistant?.runtimeUrl || CLOUD_GATEWAY_BASE_URL;
+    const stored = await deps.signInCloud(assistantId, {
+      gatewayBaseUrl,
+      clientId: CLOUD_OAUTH_CLIENT_ID,
+    });
+    const baseUrl = assistant?.runtimeUrl || CLOUD_GATEWAY_BASE_URL;
+    return { kind: 'cloud', baseUrl, token: stored.token };
+  }
+
+  throw new MissingTokenError(missingTokenMessage(authProfile));
+}
+
+// ── Fixtures ────────────────────────────────────────────────────────
+
+function makeLocalAssistant(
+  overrides: Partial<AssistantDescriptor> = {},
+): AssistantDescriptor {
+  return {
+    assistantId: 'local-1',
+    cloud: 'local',
+    runtimeUrl: 'http://127.0.0.1:7831',
+    daemonPort: 7821,
+    isActive: true,
+    authProfile: 'local-pair',
+    ...overrides,
+  };
+}
+
+function makeCloudAssistant(
+  overrides: Partial<AssistantDescriptor> = {},
+): AssistantDescriptor {
+  return {
+    assistantId: 'cloud-1',
+    cloud: 'vellum',
+    runtimeUrl: 'https://rt.vellum.cloud',
+    daemonPort: undefined,
+    isActive: false,
+    authProfile: 'cloud-oauth',
+    ...overrides,
+  };
+}
+
+function makeStoredLocalToken(overrides: Partial<StoredLocalToken> = {}): StoredLocalToken {
+  return {
+    token: 'local-cap-token-abc',
+    expiresAt: Date.now() + 3600_000,
+    guardianId: 'guardian-local-1',
+    assistantPort: 7831,
+    ...overrides,
+  };
+}
+
+function makeStoredCloudToken(overrides: Partial<StoredCloudToken> = {}): StoredCloudToken {
+  return {
+    token: 'cloud-jwt-xyz',
+    expiresAt: Date.now() + 3600_000,
+    guardianId: 'guardian-cloud-1',
+    ...overrides,
+  };
+}
+
+function makeDeps(overrides: Partial<PreflightDeps> = {}): PreflightDeps {
+  return {
+    bootstrapLocalToken: async () => {
+      throw new Error('bootstrapLocalToken not configured');
+    },
+    signInCloud: async () => {
+      throw new Error('signInCloud not configured');
+    },
+    refreshCloudToken: async () => null,
+    getStoredCloudToken: async () => null,
+    getRelayPort: async () => 7830,
+    ...overrides,
+  };
+}
+
+// ── Tests ───────────────────────────────────────────────────────────
+
+describe('connectPreflight — local-pair topology', () => {
+  test('interactive: auto-bootstraps local token when missing', async () => {
+    const assistant = makeLocalAssistant();
+    const mode: RelayMode = {
+      kind: 'self-hosted',
+      baseUrl: 'http://127.0.0.1:7821',
+      token: null,
+    };
+    const bootstrapped = makeStoredLocalToken({ token: 'fresh-local-token', assistantPort: 9999 });
+    let calledWith: string | null | undefined;
+    const deps = makeDeps({
+      bootstrapLocalToken: async (id) => {
+        calledWith = id;
+        return bootstrapped;
+      },
+    });
+
+    const result = await connectPreflight(
+      assistant,
+      'local-pair',
+      mode,
+      { interactive: true },
+      deps,
+    );
+
+    expect(calledWith).toBe('local-1');
+    expect(result.kind).toBe('self-hosted');
+    expect(result.token).toBe('fresh-local-token');
+    expect(result.baseUrl).toBe('http://127.0.0.1:9999');
+  });
+
+  test('interactive: uses daemon port when bootstrap has no assistantPort', async () => {
+    const assistant = makeLocalAssistant({ daemonPort: 8888 });
+    const mode: RelayMode = {
+      kind: 'self-hosted',
+      baseUrl: 'http://127.0.0.1:8888',
+      token: null,
+    };
+    const bootstrapped = makeStoredLocalToken({
+      token: 'fresh-token',
+      assistantPort: undefined,
+    });
+    const deps = makeDeps({
+      bootstrapLocalToken: async () => bootstrapped,
+    });
+
+    const result = await connectPreflight(
+      assistant,
+      'local-pair',
+      mode,
+      { interactive: true },
+      deps,
+    );
+
+    expect(result.baseUrl).toBe('http://127.0.0.1:8888');
+    expect(result.token).toBe('fresh-token');
+  });
+
+  test('non-interactive: throws MissingTokenError when token is missing', async () => {
+    const assistant = makeLocalAssistant();
+    const mode: RelayMode = {
+      kind: 'self-hosted',
+      baseUrl: 'http://127.0.0.1:7821',
+      token: null,
+    };
+    const deps = makeDeps();
+
+    try {
+      await connectPreflight(
+        assistant,
+        'local-pair',
+        mode,
+        { interactive: false },
+        deps,
+      );
+      expect.unreachable('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(MissingTokenError);
+      expect((err as Error).message).toContain('Pair');
+    }
+  });
+
+  test('skips preflight when valid local token already exists', async () => {
+    const assistant = makeLocalAssistant();
+    const mode: RelayMode = {
+      kind: 'self-hosted',
+      baseUrl: 'http://127.0.0.1:7821',
+      token: 'existing-token',
+    };
+    let bootstrapCalled = false;
+    const deps = makeDeps({
+      bootstrapLocalToken: async () => {
+        bootstrapCalled = true;
+        return makeStoredLocalToken();
+      },
+    });
+
+    const result = await connectPreflight(
+      assistant,
+      'local-pair',
+      mode,
+      { interactive: true },
+      deps,
+    );
+
+    expect(bootstrapCalled).toBe(false);
+    expect(result.token).toBe('existing-token');
+  });
+});
+
+describe('connectPreflight — cloud-oauth topology', () => {
+  test('interactive: auto-signs-in when token is missing', async () => {
+    const assistant = makeCloudAssistant();
+    const mode: RelayMode = {
+      kind: 'cloud',
+      baseUrl: 'https://rt.vellum.cloud',
+      token: null,
+    };
+    const signedIn = makeStoredCloudToken({ token: 'fresh-cloud-jwt' });
+    let signInCalledWith: { assistantId: string; gatewayBaseUrl: string } | null = null;
+    const deps = makeDeps({
+      signInCloud: async (id, config) => {
+        signInCalledWith = { assistantId: id, gatewayBaseUrl: config.gatewayBaseUrl };
+        return signedIn;
+      },
+    });
+
+    const result = await connectPreflight(
+      assistant,
+      'cloud-oauth',
+      mode,
+      { interactive: true },
+      deps,
+    );
+
+    expect(signInCalledWith).not.toBeNull();
+    expect(signInCalledWith!.assistantId).toBe('cloud-1');
+    expect(signInCalledWith!.gatewayBaseUrl).toBe('https://rt.vellum.cloud');
+    expect(result.kind).toBe('cloud');
+    expect(result.token).toBe('fresh-cloud-jwt');
+    expect(result.baseUrl).toBe('https://rt.vellum.cloud');
+  });
+
+  test('interactive: auto-signs-in when token is stale', async () => {
+    const assistant = makeCloudAssistant();
+    // Mode has a token, but the stored token is stale (about to expire)
+    const mode: RelayMode = {
+      kind: 'cloud',
+      baseUrl: 'https://rt.vellum.cloud',
+      token: 'stale-token',
+    };
+    const staleToken = makeStoredCloudToken({
+      token: 'stale-token',
+      // Expires in 30 seconds — within the 60-second stale window
+      expiresAt: Date.now() + 30_000,
+    });
+    const freshToken = makeStoredCloudToken({ token: 'refreshed-cloud-jwt' });
+    const deps = makeDeps({
+      getStoredCloudToken: async () => staleToken,
+      signInCloud: async () => freshToken,
+    });
+
+    const result = await connectPreflight(
+      assistant,
+      'cloud-oauth',
+      mode,
+      { interactive: true },
+      deps,
+    );
+
+    expect(result.token).toBe('refreshed-cloud-jwt');
+  });
+
+  test('non-interactive: succeeds when refresh returns a fresh token', async () => {
+    const assistant = makeCloudAssistant();
+    const mode: RelayMode = {
+      kind: 'cloud',
+      baseUrl: 'https://rt.vellum.cloud',
+      token: null,
+    };
+    const refreshed = makeStoredCloudToken({ token: 'refreshed-jwt' });
+    let refreshCalledWith: { assistantId: string; gatewayBaseUrl: string } | null = null;
+    const deps = makeDeps({
+      refreshCloudToken: async (id, config) => {
+        refreshCalledWith = { assistantId: id, gatewayBaseUrl: config.gatewayBaseUrl };
+        return refreshed;
+      },
+    });
+
+    const result = await connectPreflight(
+      assistant,
+      'cloud-oauth',
+      mode,
+      { interactive: false },
+      deps,
+    );
+
+    expect(refreshCalledWith).not.toBeNull();
+    expect(refreshCalledWith!.assistantId).toBe('cloud-1');
+    expect(result.token).toBe('refreshed-jwt');
+    expect(result.baseUrl).toBe('https://rt.vellum.cloud');
+  });
+
+  test('non-interactive: throws MissingTokenError when refresh returns null', async () => {
+    const assistant = makeCloudAssistant();
+    const mode: RelayMode = {
+      kind: 'cloud',
+      baseUrl: 'https://rt.vellum.cloud',
+      token: null,
+    };
+    const deps = makeDeps({
+      refreshCloudToken: async () => null,
+    });
+
+    try {
+      await connectPreflight(
+        assistant,
+        'cloud-oauth',
+        mode,
+        { interactive: false },
+        deps,
+      );
+      expect.unreachable('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(MissingTokenError);
+      expect((err as Error).message).toContain('Sign in');
+    }
+  });
+
+  test('skips preflight when valid cloud token exists and is not stale', async () => {
+    const assistant = makeCloudAssistant();
+    const mode: RelayMode = {
+      kind: 'cloud',
+      baseUrl: 'https://rt.vellum.cloud',
+      token: 'existing-jwt',
+    };
+    const freshToken = makeStoredCloudToken({
+      token: 'existing-jwt',
+      // Expires in 2 hours — well outside the stale window
+      expiresAt: Date.now() + 7200_000,
+    });
+    let signInCalled = false;
+    let refreshCalled = false;
+    const deps = makeDeps({
+      getStoredCloudToken: async () => freshToken,
+      signInCloud: async () => {
+        signInCalled = true;
+        return makeStoredCloudToken();
+      },
+      refreshCloudToken: async () => {
+        refreshCalled = true;
+        return null;
+      },
+    });
+
+    const result = await connectPreflight(
+      assistant,
+      'cloud-oauth',
+      mode,
+      { interactive: true },
+      deps,
+    );
+
+    expect(signInCalled).toBe(false);
+    expect(refreshCalled).toBe(false);
+    expect(result.token).toBe('existing-jwt');
+  });
+
+  test('non-interactive: uses runtimeUrl from assistant for refresh', async () => {
+    const assistant = makeCloudAssistant({
+      runtimeUrl: 'https://custom-gateway.vellum.cloud',
+    });
+    const mode: RelayMode = {
+      kind: 'cloud',
+      baseUrl: 'https://custom-gateway.vellum.cloud',
+      token: null,
+    };
+    const refreshed = makeStoredCloudToken({ token: 'refreshed-jwt' });
+    let refreshCalledWith: { gatewayBaseUrl: string } | null = null;
+    const deps = makeDeps({
+      refreshCloudToken: async (_id, config) => {
+        refreshCalledWith = { gatewayBaseUrl: config.gatewayBaseUrl };
+        return refreshed;
+      },
+    });
+
+    const result = await connectPreflight(
+      assistant,
+      'cloud-oauth',
+      mode,
+      { interactive: false },
+      deps,
+    );
+
+    expect(refreshCalledWith!.gatewayBaseUrl).toBe('https://custom-gateway.vellum.cloud');
+    expect(result.baseUrl).toBe('https://custom-gateway.vellum.cloud');
+  });
+});
+
+describe('connectPreflight — edge cases', () => {
+  test('unsupported profile throws MissingTokenError', async () => {
+    const assistant: AssistantDescriptor = {
+      assistantId: 'unsupported-1',
+      cloud: 'future-topology',
+      runtimeUrl: '',
+      daemonPort: undefined,
+      isActive: false,
+      authProfile: 'unsupported',
+    };
+    const mode: RelayMode = {
+      kind: 'self-hosted',
+      baseUrl: 'http://127.0.0.1:7830',
+      token: null,
+    };
+    const deps = makeDeps();
+
+    try {
+      await connectPreflight(
+        assistant,
+        'unsupported',
+        mode,
+        { interactive: true },
+        deps,
+      );
+      expect.unreachable('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(MissingTokenError);
+      expect((err as Error).message).toContain('unsupported topology');
+    }
+  });
+
+  test('null assistant throws MissingTokenError for cloud profile', async () => {
+    const mode: RelayMode = {
+      kind: 'cloud',
+      baseUrl: CLOUD_GATEWAY_BASE_URL,
+      token: null,
+    };
+    const deps = makeDeps();
+
+    try {
+      await connectPreflight(
+        null,
+        'cloud-oauth',
+        mode,
+        { interactive: true },
+        deps,
+      );
+      expect.unreachable('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(MissingTokenError);
+      expect((err as Error).message).toContain('Select an assistant');
+    }
+  });
+
+  test('null profile throws MissingTokenError', async () => {
+    const mode: RelayMode = {
+      kind: 'self-hosted',
+      baseUrl: 'http://127.0.0.1:7830',
+      token: null,
+    };
+    const deps = makeDeps();
+
+    try {
+      await connectPreflight(null, null, mode, { interactive: true }, deps);
+      expect.unreachable('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(MissingTokenError);
+      expect((err as Error).message).toContain('Select an assistant');
+    }
+  });
+
+  test('cloud interactive falls back to default gateway when no runtimeUrl', async () => {
+    const assistant = makeCloudAssistant({ runtimeUrl: '' });
+    const mode: RelayMode = {
+      kind: 'cloud',
+      baseUrl: CLOUD_GATEWAY_BASE_URL,
+      token: null,
+    };
+    const signedIn = makeStoredCloudToken({ token: 'fallback-jwt' });
+    let signInCalledWith: { gatewayBaseUrl: string } | null = null;
+    const deps = makeDeps({
+      signInCloud: async (_id, config) => {
+        signInCalledWith = { gatewayBaseUrl: config.gatewayBaseUrl };
+        return signedIn;
+      },
+    });
+
+    const result = await connectPreflight(
+      assistant,
+      'cloud-oauth',
+      mode,
+      { interactive: true },
+      deps,
+    );
+
+    expect(signInCalledWith!.gatewayBaseUrl).toBe(CLOUD_GATEWAY_BASE_URL);
+    expect(result.baseUrl).toBe(CLOUD_GATEWAY_BASE_URL);
+    expect(result.token).toBe('fallback-jwt');
+  });
+});

--- a/clients/chrome-extension/background/__tests__/worker-connect-preflight.test.ts
+++ b/clients/chrome-extension/background/__tests__/worker-connect-preflight.test.ts
@@ -18,7 +18,9 @@
  *   - Cloud interactive: auto-signs-in when token is missing/stale.
  *   - Cloud non-interactive: attempts refresh, succeeds if provider
  *     session is live.
- *   - Cloud non-interactive: fails when refresh also fails.
+ *   - Cloud non-interactive: fails when refresh also fails (no token).
+ *   - Cloud non-interactive: falls back to stale-but-valid token when
+ *     refresh fails (token present but within staleness window).
  *   - Preflight is a no-op when valid token already exists.
  */
 
@@ -128,6 +130,12 @@ async function connectPreflight(
       if (refreshed) {
         const baseUrl = assistant?.runtimeUrl || CLOUD_GATEWAY_BASE_URL;
         return { kind: 'cloud', baseUrl, token: refreshed.token };
+      }
+      // If the token is stale but still technically valid, fall back to
+      // the existing mode rather than discarding a usable token. The
+      // onReconnect hook will handle actual expiry later.
+      if (mode.token) {
+        return mode;
       }
       throw new MissingTokenError(missingTokenMessage('cloud-oauth'));
     }
@@ -437,6 +445,45 @@ describe('connectPreflight — cloud-oauth topology', () => {
       expect(err).toBeInstanceOf(MissingTokenError);
       expect((err as Error).message).toContain('Sign in');
     }
+  });
+
+  test('non-interactive: falls back to stale-but-valid token when refresh fails', async () => {
+    const assistant = makeCloudAssistant();
+    // Mode has a token — stale but still technically valid
+    const mode: RelayMode = {
+      kind: 'cloud',
+      baseUrl: 'https://rt.vellum.cloud',
+      token: 'stale-but-valid-jwt',
+    };
+    const staleToken = makeStoredCloudToken({
+      token: 'stale-but-valid-jwt',
+      // Expires in 50 seconds — within the 60-second stale window
+      expiresAt: Date.now() + 50_000,
+    });
+    let refreshCalled = false;
+    const deps = makeDeps({
+      getStoredCloudToken: async () => staleToken,
+      // Refresh fails (e.g. provider session expired)
+      refreshCloudToken: async () => {
+        refreshCalled = true;
+        return null;
+      },
+    });
+
+    const result = await connectPreflight(
+      assistant,
+      'cloud-oauth',
+      mode,
+      { interactive: false },
+      deps,
+    );
+
+    // Should have attempted refresh
+    expect(refreshCalled).toBe(true);
+    // Should fall back to the original mode with the stale-but-valid token
+    expect(result).toBe(mode);
+    expect(result.token).toBe('stale-but-valid-jwt');
+    expect(result.baseUrl).toBe('https://rt.vellum.cloud');
   });
 
   test('skips preflight when valid cloud token exists and is not stale', async () => {

--- a/clients/chrome-extension/background/worker.ts
+++ b/clients/chrome-extension/background/worker.ts
@@ -826,8 +826,12 @@ interface ConnectOptions {
  *     `signInCloud(...)` and rebuilds the mode.
  *   - If the token is missing/stale and `interactive=false`, attempts
  *     `refreshCloudToken(...)` first. If the non-interactive refresh
- *     succeeds, rebuilds the mode with the fresh token. Otherwise
- *     throws a {@link MissingTokenError}.
+ *     succeeds, rebuilds the mode with the fresh token. If the refresh
+ *     fails but the original mode still carries a token (stale but not
+ *     yet expired), the existing mode is returned as-is so the
+ *     `onReconnect` hook can handle actual expiry later. Only when
+ *     both the refresh fails and no token exists does it throw a
+ *     {@link MissingTokenError}.
  *
  * Returns the (possibly refreshed) {@link RelayMode} ready for socket
  * open.
@@ -884,6 +888,12 @@ async function connectPreflight(
       if (refreshed) {
         const baseUrl = assistant?.runtimeUrl || CLOUD_GATEWAY_BASE_URL;
         return { kind: 'cloud', baseUrl, token: refreshed.token };
+      }
+      // If the token is stale but still technically valid, fall back to
+      // the existing mode rather than discarding a usable token. The
+      // onReconnect hook will handle actual expiry later.
+      if (mode.token) {
+        return mode;
       }
       throw new MissingTokenError(missingTokenMessage('cloud-oauth'));
     }

--- a/clients/chrome-extension/background/worker.ts
+++ b/clients/chrome-extension/background/worker.ts
@@ -1157,14 +1157,17 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponseFn) => {
           try {
             await connect({ interactive: true });
           } catch (err) {
-            if (err instanceof MissingTokenError) {
-              shouldConnect = false;
-              console.warn(
-                `[vellum-relay] Assistant switch left disconnected: ${err.message}`,
-              );
-            } else {
-              throw err;
-            }
+            // The assistant selection was already persisted and the old
+            // relay disconnected, so the switch itself succeeded regardless
+            // of whether the reconnect worked. MissingTokenError means no
+            // credentials at all; other errors (e.g. "cloud sign-in
+            // cancelled" when the user closes the OAuth window) are
+            // transient. In both cases, log and continue — the user can
+            // manually reconnect via the Connect button.
+            shouldConnect = false;
+            console.warn(
+              `[vellum-relay] Assistant switch left disconnected: ${err instanceof Error ? err.message : String(err)}`,
+            );
           }
         }
 

--- a/clients/chrome-extension/background/worker.ts
+++ b/clients/chrome-extension/background/worker.ts
@@ -26,6 +26,7 @@ import {
   getStoredToken as getStoredCloudToken,
   getStoredTokenRaw as getStoredCloudTokenRaw,
   validateCloudToken,
+  isCloudTokenStale,
   CLOUD_AUTH_FAILURE_CLOSE_CODES,
   LEGACY_CLOUD_STORAGE_KEY,
   type CloudAuthConfig,
@@ -782,7 +783,126 @@ function missingTokenMessage(profile: AssistantAuthProfile | null): string {
   return 'Select an assistant before connecting';
 }
 
-async function connect(): Promise<void> {
+// ── Connect options ────────────────────────────────────────────────
+//
+// Threading an explicit `interactive` flag through the connect flow
+// lets the worker decide whether missing/stale credentials should
+// trigger an interactive sign-in/pair flow or produce an immediate
+// error. User-initiated Connect passes `interactive: true`; non-user-
+// initiated paths (auto-connect on bootstrap, reconnect) pass `false`.
+
+/**
+ * Options bag threaded through {@link connect} to control whether
+ * missing credentials trigger an interactive auth bootstrap.
+ *
+ * - `interactive: true` — the worker will auto-bootstrap auth when
+ *   credentials are missing or stale. For `local-pair` this runs
+ *   `bootstrapLocalToken`; for `cloud-oauth` this runs `signInCloud`.
+ * - `interactive: false` — the worker will attempt a non-interactive
+ *   refresh for cloud tokens but will NOT launch an interactive flow.
+ *   Missing credentials produce a {@link MissingTokenError}.
+ */
+interface ConnectOptions {
+  interactive: boolean;
+}
+
+/**
+ * Resolve credentials for the selected assistant before the socket
+ * opens. This is the single authority for whether auth is satisfied —
+ * the popup no longer needs to pre-check pairing/sign-in state.
+ *
+ * For `local-pair`:
+ *   - If the assistant-scoped local token is present and unexpired,
+ *     the existing relay mode is returned as-is.
+ *   - If the token is missing/expired and `interactive=true`, runs
+ *     `bootstrapLocalToken({ assistantId })` and rebuilds the mode.
+ *   - If the token is missing/expired and `interactive=false`, throws
+ *     a {@link MissingTokenError}.
+ *
+ * For `cloud-oauth`:
+ *   - If the stored cloud token is present and not stale, the existing
+ *     relay mode is returned as-is.
+ *   - If the token is missing/stale and `interactive=true`, runs
+ *     `signInCloud(...)` and rebuilds the mode.
+ *   - If the token is missing/stale and `interactive=false`, attempts
+ *     `refreshCloudToken(...)` first. If the non-interactive refresh
+ *     succeeds, rebuilds the mode with the fresh token. Otherwise
+ *     throws a {@link MissingTokenError}.
+ *
+ * Returns the (possibly refreshed) {@link RelayMode} ready for socket
+ * open.
+ */
+async function connectPreflight(
+  assistant: AssistantDescriptor | null,
+  authProfile: AssistantAuthProfile | null,
+  mode: RelayMode,
+  options: ConnectOptions,
+): Promise<RelayMode> {
+  // Token already present — nothing to do.
+  if (mode.token) {
+    // For cloud mode, check staleness: a token that's about to expire
+    // should be proactively refreshed even when it's technically present.
+    if (mode.kind === 'cloud' && assistant) {
+      const stored = await getStoredCloudToken(assistant.assistantId);
+      if (!isCloudTokenStale(stored)) {
+        return mode;
+      }
+      // Token is stale — fall through to the refresh/sign-in logic below.
+    } else {
+      return mode;
+    }
+  }
+
+  if (authProfile === 'local-pair') {
+    if (!options.interactive) {
+      throw new MissingTokenError(missingTokenMessage('local-pair'));
+    }
+    // Interactive: auto-bootstrap the local capability token.
+    const assistantId = assistant?.assistantId ?? null;
+    const stored = await bootstrapLocalToken(assistantId);
+    const port = stored.assistantPort ?? assistant?.daemonPort ?? (await getRelayPort());
+    return {
+      kind: 'self-hosted',
+      baseUrl: `http://127.0.0.1:${port}`,
+      token: stored.token,
+    };
+  }
+
+  if (authProfile === 'cloud-oauth') {
+    const assistantId = assistant?.assistantId ?? null;
+    if (!assistantId) {
+      throw new MissingTokenError(missingTokenMessage(null));
+    }
+
+    if (!options.interactive) {
+      // Non-interactive: attempt a silent refresh first.
+      const gatewayBaseUrl = assistant?.runtimeUrl || CLOUD_GATEWAY_BASE_URL;
+      const refreshed = await refreshCloudToken(assistantId, {
+        gatewayBaseUrl,
+        clientId: CLOUD_OAUTH_CLIENT_ID,
+      });
+      if (refreshed) {
+        const baseUrl = assistant?.runtimeUrl || CLOUD_GATEWAY_BASE_URL;
+        return { kind: 'cloud', baseUrl, token: refreshed.token };
+      }
+      throw new MissingTokenError(missingTokenMessage('cloud-oauth'));
+    }
+
+    // Interactive: launch the full OAuth sign-in flow.
+    const gatewayBaseUrl = assistant?.runtimeUrl || CLOUD_GATEWAY_BASE_URL;
+    const stored = await signInCloud(assistantId, {
+      gatewayBaseUrl,
+      clientId: CLOUD_OAUTH_CLIENT_ID,
+    });
+    const baseUrl = assistant?.runtimeUrl || CLOUD_GATEWAY_BASE_URL;
+    return { kind: 'cloud', baseUrl, token: stored.token };
+  }
+
+  // Unsupported or no assistant selected — preflight can't help.
+  throw new MissingTokenError(missingTokenMessage(authProfile));
+}
+
+async function connect(options: ConnectOptions = { interactive: false }): Promise<void> {
   if (relayConnection && relayConnection.isOpen()) return;
   // Defensive: a fresh connect() always starts the 1006 refresh
   // budget from scratch. The counter is normally reset from onOpen,
@@ -812,12 +932,12 @@ async function connect(): Promise<void> {
     throw new MissingTokenError(msg);
   }
 
-  const mode = await buildRelayModeForAssistant(selected);
-  if (!mode.token) {
-    const msg = missingTokenMessage(authProfile);
-    console.warn(`[vellum-relay] ${msg}`);
-    throw new MissingTokenError(msg);
-  }
+  const rawMode = await buildRelayModeForAssistant(selected);
+  // Run the preflight to resolve/bootstrap credentials. When
+  // interactive=true the preflight auto-pairs or auto-signs-in;
+  // when interactive=false it either refreshes non-interactively or
+  // throws MissingTokenError.
+  const mode = await connectPreflight(selected, authProfile, rawMode, options);
   // Tear down any stale instance before constructing a new one. This
   // keeps the close/reconnect lifecycle simple — one RelayConnection
   // per live socket, no hidden state carried across mode switches.
@@ -875,7 +995,10 @@ async function handleServerMessage(raw: string): Promise<void> {
 chrome.runtime.onMessage.addListener((message, _sender, sendResponseFn) => {
   if (message.type === 'connect') {
     shouldConnect = true;
-    connect()
+    // User-initiated Connect is interactive: the worker will auto-
+    // bootstrap missing auth (pair for local, sign-in for cloud)
+    // rather than requiring the popup to pre-check credentials.
+    connect({ interactive: true })
       .then(() => sendResponseFn({ ok: true }))
       .catch((err) => {
         // Reset shouldConnect so a subsequent storage change or
@@ -1019,9 +1142,10 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponseFn) => {
         if (shouldConnect && relayConnection) {
           disconnect();
           // Attempt a reconnect to the newly selected assistant.
+          // Interactive since the user is actively switching.
           // Errors are non-fatal — the user can manually reconnect.
           try {
-            await connect();
+            await connect({ interactive: true });
           } catch (err) {
             if (err instanceof MissingTokenError) {
               shouldConnect = false;
@@ -1056,7 +1180,10 @@ async function bootstrap(): Promise<void> {
   if (autoConnect !== true) return;
   shouldConnect = true;
   try {
-    await connect();
+    // Non-interactive: bootstrap should not pop up auth UIs. If
+    // credentials are missing the user will see disconnected state
+    // in the popup and can trigger an interactive connect.
+    await connect({ interactive: false });
   } catch (err) {
     // A missing token at auto-connect time is not a hard failure —
     // the user will see the disconnected state in the popup and can

--- a/clients/chrome-extension/background/worker.ts
+++ b/clients/chrome-extension/background/worker.ts
@@ -912,7 +912,26 @@ async function connectPreflight(
   throw new MissingTokenError(missingTokenMessage(authProfile));
 }
 
+// Serialization lock: if a connect is already in progress, subsequent
+// callers await the existing attempt rather than launching a concurrent
+// preflight. This prevents duplicate auth/pair flows when multiple
+// connect calls arrive before the first socket opens (e.g., repeated
+// user action or overlapping message paths).
+let connectInFlight: Promise<void> | null = null;
+
 async function connect(options: ConnectOptions = { interactive: false }): Promise<void> {
+  if (connectInFlight) {
+    return connectInFlight;
+  }
+  connectInFlight = doConnect(options);
+  try {
+    await connectInFlight;
+  } finally {
+    connectInFlight = null;
+  }
+}
+
+async function doConnect(options: ConnectOptions): Promise<void> {
   if (relayConnection && relayConnection.isOpen()) return;
   // Defensive: a fresh connect() always starts the 1006 refresh
   // budget from scratch. The counter is normally reset from onOpen,


### PR DESCRIPTION
## Summary
- Introduce ConnectOptions with interactive flag threaded through the connect flow
- Add connectPreflight helper that resolves auth for selected assistant before socket open
- Add worker tests for local/cloud interactive and non-interactive connect paths

Part of plan: one-click-connect-pause-autoconnect.md (PR 1 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24782" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
