### PR TITLE
Rename and reorder Docker/Local hosting options in onboarding

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -221,6 +221,7 @@ struct APIKeyStepView: View {
     private func iconForMode(_ mode: OnboardingState.HostingMode) -> VIcon {
         switch mode {
         case .vellumCloud: return .cloud
+        case .local where localDockerEnabled && !appleContainerEnabled: return .package
         case .local: return .laptop
         case .docker: return .package
         case .oldLocal: return .laptop

--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -13,9 +13,9 @@ enum OnboardingHostingModeResolver {
             // and bare-host local as separate fallback options.
             modes.append(contentsOf: [.docker, .oldLocal])
         } else if localDockerEnabled {
-            // Keep "Local" as the default choice and expose the legacy
-            // non-Docker hatch explicitly as an escape hatch.
-            modes.append(.oldLocal)
+            // Show bare-metal local before Docker (experimental).
+            let localIndex = modes.firstIndex(of: .local)!
+            modes.insert(.oldLocal, at: localIndex)
         }
         if userHostedEnabled {
             modes.append(contentsOf: [.aws, .gcp, .customHardware])
@@ -25,14 +25,24 @@ enum OnboardingHostingModeResolver {
 
     static func displayName(
         for mode: OnboardingState.HostingMode,
+        localDockerEnabled: Bool,
         appleContainerEnabled: Bool
     ) -> String {
-        guard appleContainerEnabled else { return mode.displayName }
-        switch mode {
-        case .docker: return "Docker Local"
-        case .oldLocal: return "Host Local"
-        default: return mode.displayName
+        if appleContainerEnabled {
+            switch mode {
+            case .docker: return "Docker Local"
+            case .oldLocal: return "Host Local"
+            default: return mode.displayName
+            }
         }
+        if localDockerEnabled {
+            switch mode {
+            case .local: return "Docker (Experimental)"
+            case .oldLocal: return "Local (Bare Metal)"
+            default: return mode.displayName
+            }
+        }
+        return mode.displayName
     }
 
     static func subtitle(
@@ -44,7 +54,10 @@ enum OnboardingHostingModeResolver {
             return "Native macOS sandbox. Your machine, your data, fully isolated."
         }
         if localDockerEnabled && mode == .local {
-            return OnboardingState.HostingMode.docker.subtitle
+            return "Runs locally in a Docker container for added isolation."
+        }
+        if localDockerEnabled && mode == .oldLocal {
+            return "Runs directly on your Mac. No containers, no extra setup."
         }
         return mode.subtitle
     }
@@ -189,6 +202,7 @@ struct APIKeyStepView: View {
                 )
                 let title = OnboardingHostingModeResolver.displayName(
                     for: mode,
+                    localDockerEnabled: localDockerEnabled,
                     appleContainerEnabled: appleContainerEnabled
                 )
                 let requiresAccount = mode == .vellumCloud && !isAuthenticated

--- a/clients/macos/vellum-assistantTests/OnboardingHostingModeResolverTests.swift
+++ b/clients/macos/vellum-assistantTests/OnboardingHostingModeResolverTests.swift
@@ -12,7 +12,7 @@ final class OnboardingHostingModeResolverTests: XCTestCase {
             appleContainerEnabled: false
         )
 
-        XCTAssertEqual(modes, [.vellumCloud, .local, .oldLocal])
+        XCTAssertEqual(modes, [.vellumCloud, .oldLocal, .local])
     }
 
     func testAvailableHostingModesAddsUserHostedOptionsWithoutDockerCard() {
@@ -50,22 +50,36 @@ final class OnboardingHostingModeResolverTests: XCTestCase {
 
     func testDisplayNameShowsDockerLocalWhenAppleContainerEnabled() {
         XCTAssertEqual(
-            OnboardingHostingModeResolver.displayName(for: .docker, appleContainerEnabled: true),
+            OnboardingHostingModeResolver.displayName(for: .docker, localDockerEnabled: false, appleContainerEnabled: true),
             "Docker Local"
         )
     }
 
     func testDisplayNameShowsHostLocalWhenAppleContainerEnabled() {
         XCTAssertEqual(
-            OnboardingHostingModeResolver.displayName(for: .oldLocal, appleContainerEnabled: true),
+            OnboardingHostingModeResolver.displayName(for: .oldLocal, localDockerEnabled: false, appleContainerEnabled: true),
             "Host Local"
         )
     }
 
     func testDisplayNameUsesDefaultWhenAppleContainerDisabled() {
         XCTAssertEqual(
-            OnboardingHostingModeResolver.displayName(for: .docker, appleContainerEnabled: false),
+            OnboardingHostingModeResolver.displayName(for: .docker, localDockerEnabled: false, appleContainerEnabled: false),
             OnboardingState.HostingMode.docker.displayName
+        )
+    }
+
+    func testDisplayNameShowsDockerExperimentalWhenLocalDockerEnabled() {
+        XCTAssertEqual(
+            OnboardingHostingModeResolver.displayName(for: .local, localDockerEnabled: true, appleContainerEnabled: false),
+            "Docker (Experimental)"
+        )
+    }
+
+    func testDisplayNameShowsLocalBareMetalWhenLocalDockerEnabled() {
+        XCTAssertEqual(
+            OnboardingHostingModeResolver.displayName(for: .oldLocal, localDockerEnabled: true, appleContainerEnabled: false),
+            "Local (Bare Metal)"
         )
     }
 
@@ -78,7 +92,18 @@ final class OnboardingHostingModeResolverTests: XCTestCase {
                 localDockerEnabled: true,
                 appleContainerEnabled: false
             ),
-            OnboardingState.HostingMode.docker.subtitle
+            "Runs locally in a Docker container for added isolation."
+        )
+    }
+
+    func testOldLocalSubtitleUsesBareMetalCopyWhenDockerEnabled() {
+        XCTAssertEqual(
+            OnboardingHostingModeResolver.subtitle(
+                for: .oldLocal,
+                localDockerEnabled: true,
+                appleContainerEnabled: false
+            ),
+            "Runs directly on your Mac. No containers, no extra setup."
         )
     }
 


### PR DESCRIPTION
## Summary
- Swap the order of the local hosting options when `localDockerEnabled` is true: "Local (Bare Metal)" now appears before "Docker (Experimental)"
- Rename "Local" → "Docker (Experimental)" and "Old Local" → "Local (Bare Metal)" in the Docker-enabled onboarding flow
- Update subtexts: bare metal says "Runs directly on your Mac. No containers, no extra setup." and Docker says "Runs locally in a Docker container for added isolation."

## Original prompt
In the macOS onboarding hosting step, when both "Old Local" and "Local" are displayed (localDockerEnabled=true, appleContainerEnabled=false):
1. Swap the order of the two
2. Change "Local" to say "Docker (Experimental)"
3. Change "Old Local" to say "Local (Bare Metal)"
4. Update the subtext of each

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24783" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
