### PR TITLE
refactor(skills): extract SkillFileProvider interface from vellum catalog file preview

### DIFF
--- a/assistant/src/__tests__/catalog-files.test.ts
+++ b/assistant/src/__tests__/catalog-files.test.ts
@@ -45,6 +45,7 @@ let mockRepoSkillsDir: string | undefined = undefined;
 
 mock.module("../skills/catalog-cache.js", () => ({
   getCatalog: async () => mockCatalog,
+  getCachedCatalogSync: () => mockCatalog,
 }));
 
 mock.module("../skills/catalog-install.js", () => ({
@@ -72,6 +73,8 @@ mock.module("../config/env.js", () => ({
 // ---------------------------------------------------------------------------
 
 import {
+  catalogSkillToSlim,
+  createVellumCatalogProvider,
   readCatalogSkillFileContent,
   readCatalogSkillFiles,
   sanitizeRelativePath,
@@ -858,5 +861,140 @@ describe("readCatalogSkillFileContent (platform mode)", () => {
     installFetchForbidden();
     expect(await readCatalogSkillFileContent("unknown", "SKILL.md")).toBeNull();
     expect(fetchCalls.length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// catalogSkillToSlim
+// ---------------------------------------------------------------------------
+
+describe("catalogSkillToSlim", () => {
+  test("maps CatalogSkill to SlimSkillResponse with vellum origin", () => {
+    const cs: CatalogSkill = {
+      id: "test-skill",
+      name: "test-skill",
+      description: "A test skill",
+      emoji: "🧪",
+    };
+    const slim = catalogSkillToSlim(cs);
+    expect(slim.id).toBe("test-skill");
+    expect(slim.name).toBe("test-skill");
+    expect(slim.description).toBe("A test skill");
+    expect(slim.emoji).toBe("🧪");
+    expect(slim.kind).toBe("catalog");
+    expect(slim.origin).toBe("vellum");
+    expect(slim.status).toBe("available");
+  });
+
+  test("uses display-name from metadata when available", () => {
+    const cs: CatalogSkill = {
+      id: "test-skill",
+      name: "test-skill",
+      description: "A test skill",
+      metadata: { vellum: { "display-name": "Pretty Name" } },
+    };
+    const slim = catalogSkillToSlim(cs);
+    expect(slim.name).toBe("Pretty Name");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createVellumCatalogProvider
+// ---------------------------------------------------------------------------
+
+describe("createVellumCatalogProvider", () => {
+  test("canHandle returns true when skill is in the cached catalog", () => {
+    mockCatalog = [skill("my-skill"), skill("other-skill")];
+    const provider = createVellumCatalogProvider();
+    expect(provider.canHandle("my-skill")).toBe(true);
+    expect(provider.canHandle("other-skill")).toBe(true);
+  });
+
+  test("canHandle returns false when skill is NOT in the cached catalog", () => {
+    mockCatalog = [skill("my-skill")];
+    const provider = createVellumCatalogProvider();
+    expect(provider.canHandle("unknown-skill")).toBe(false);
+  });
+
+  test("canHandle returns false when catalog cache is empty", () => {
+    mockCatalog = [];
+    const provider = createVellumCatalogProvider();
+    expect(provider.canHandle("any-skill")).toBe(false);
+  });
+
+  test("listFiles delegates to readCatalogSkillFiles", async () => {
+    const root = makeTempSkillsDir();
+    writeSkill(root, "my-skill", {
+      "SKILL.md": "# hello",
+      "tools/run.sh": "#!/bin/sh\necho hi\n",
+    });
+    mockRepoSkillsDir = root;
+    mockCatalog = [skill("my-skill")];
+    installFetchForbidden();
+
+    const provider = createVellumCatalogProvider();
+    const entries = await provider.listFiles("my-skill");
+    expect(entries).not.toBeNull();
+    const paths = entries!.map((e) => e.path).sort();
+    expect(paths).toEqual(["SKILL.md", "tools/run.sh"]);
+  });
+
+  test("listFiles returns null for unknown skill", async () => {
+    mockCatalog = [];
+    installFetchForbidden();
+
+    const provider = createVellumCatalogProvider();
+    expect(await provider.listFiles("unknown")).toBeNull();
+  });
+
+  test("readFileContent delegates to readCatalogSkillFileContent", async () => {
+    const root = makeTempSkillsDir();
+    writeSkill(root, "my-skill", { "SKILL.md": "# hello world\n" });
+    mockRepoSkillsDir = root;
+    mockCatalog = [skill("my-skill")];
+    installFetchForbidden();
+
+    const provider = createVellumCatalogProvider();
+    const entry = await provider.readFileContent("my-skill", "SKILL.md");
+    expect(entry).not.toBeNull();
+    expect(entry!.content).toBe("# hello world\n");
+    expect(entry!.path).toBe("SKILL.md");
+  });
+
+  test("readFileContent returns null for unknown skill", async () => {
+    mockCatalog = [];
+    installFetchForbidden();
+
+    const provider = createVellumCatalogProvider();
+    expect(await provider.readFileContent("unknown", "SKILL.md")).toBeNull();
+  });
+
+  test("toSlimSkill returns SlimSkillResponse for catalog skill", async () => {
+    mockCatalog = [
+      {
+        id: "my-skill",
+        name: "my-skill",
+        description: "A skill",
+        emoji: "🔧",
+        metadata: { vellum: { "display-name": "My Skill" } },
+      },
+    ];
+
+    const provider = createVellumCatalogProvider();
+    const slim = await provider.toSlimSkill("my-skill");
+    expect(slim).not.toBeNull();
+    expect(slim!.id).toBe("my-skill");
+    expect(slim!.name).toBe("My Skill");
+    expect(slim!.description).toBe("A skill");
+    expect(slim!.kind).toBe("catalog");
+    expect(slim!.origin).toBe("vellum");
+    expect(slim!.status).toBe("available");
+  });
+
+  test("toSlimSkill returns null for unknown skill", async () => {
+    mockCatalog = [];
+
+    const provider = createVellumCatalogProvider();
+    expect(await provider.toSlimSkill("unknown")).toBeNull();
   });
 });

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -37,6 +37,7 @@ import {
 } from "../../runtime/routes/workspace-utils.js";
 import { getCatalog } from "../../skills/catalog-cache.js";
 import {
+  catalogSkillToSlim,
   hasHiddenOrSkippedSegment,
   readCatalogSkillFileContent,
   readCatalogSkillFiles,
@@ -563,25 +564,6 @@ function readDirRecursive(dir: string, rootDir: string): SkillFileEntry[] {
     }
   }
   return entries;
-}
-
-/**
- * Map a `CatalogSkill` (from the Vellum platform API) to a `SlimSkillResponse`
- * shaped for the "available catalog skill" case. Shared between
- * `listSkillsWithCatalog` (merging catalog entries into the installed list)
- * and `getSkillFiles` (catalog fallback for preview listings). Keeping the
- * mapping in one place avoids divergence between the list and detail paths.
- */
-function catalogSkillToSlim(cs: CatalogSkill): SlimSkillResponse {
-  return {
-    id: cs.id,
-    name: cs.metadata?.vellum?.["display-name"] ?? cs.name,
-    description: cs.description,
-    emoji: cs.emoji,
-    kind: "catalog",
-    origin: "vellum",
-    status: "available",
-  };
 }
 
 /**

--- a/assistant/src/skills/catalog-files.ts
+++ b/assistant/src/skills/catalog-files.ts
@@ -29,14 +29,16 @@ import {
 import { basename, join, posix, sep } from "node:path";
 
 import { getPlatformBaseUrl } from "../config/env.js";
+import type { SlimSkillResponse } from "../daemon/message-types/skills.js";
 import {
   isTextMimeType as isTextMime,
   MAX_INLINE_TEXT_SIZE,
 } from "../runtime/routes/workspace-utils.js";
 import { getLogger } from "../util/logger.js";
 import { readPlatformToken } from "../util/platform.js";
-import { getCatalog } from "./catalog-cache.js";
-import { getRepoSkillsDir } from "./catalog-install.js";
+import { getCachedCatalogSync, getCatalog } from "./catalog-cache.js";
+import { type CatalogSkill, getRepoSkillsDir } from "./catalog-install.js";
+import type { SkillFileProvider } from "./skill-file-provider.js";
 
 const log = getLogger("catalog-files");
 
@@ -488,5 +490,65 @@ export async function readCatalogSkillFileContent(
     mimeType: response.mime_type,
     isBinary: response.is_binary,
     content: response.content,
+  };
+}
+
+// ─── Catalog-to-slim conversion ──────────────────────────────────────────────
+
+/**
+ * Map a `CatalogSkill` (from the Vellum platform API) to a `SlimSkillResponse`
+ * shaped for the "available catalog skill" case. Shared between
+ * `listSkillsWithCatalog` (merging catalog entries into the installed list),
+ * `getSkillFiles` (catalog fallback for preview listings), and the
+ * `VellumCatalogProvider`. Keeping the mapping in one place avoids divergence
+ * between the list and detail paths.
+ *
+ * Extracted here (rather than in `daemon/handlers/skills.ts`) to avoid a
+ * circular import — catalog-files depends on `catalog-cache.ts`, which would
+ * otherwise be reachable via the handler module.
+ */
+export function catalogSkillToSlim(cs: CatalogSkill): SlimSkillResponse {
+  return {
+    id: cs.id,
+    name: cs.metadata?.vellum?.["display-name"] ?? cs.name,
+    description: cs.description,
+    emoji: cs.emoji,
+    kind: "catalog",
+    origin: "vellum",
+    status: "available",
+  };
+}
+
+// ─── Vellum Catalog Provider ─────────────────────────────────────────────────
+
+/**
+ * Create a `SkillFileProvider` that wraps the existing catalog-files functions
+ * for the Vellum first-party catalog. This is the first provider implementation
+ * in the unified file-preview chain.
+ */
+export function createVellumCatalogProvider(): SkillFileProvider {
+  return {
+    canHandle(skillId: string): boolean {
+      const cached = getCachedCatalogSync();
+      return cached.some((s) => s.id === skillId);
+    },
+
+    listFiles(skillId: string): Promise<SkillFileEntry[] | null> {
+      return readCatalogSkillFiles(skillId);
+    },
+
+    readFileContent(
+      skillId: string,
+      sanitizedPath: string,
+    ): Promise<SkillFileEntry | null> {
+      return readCatalogSkillFileContent(skillId, sanitizedPath);
+    },
+
+    async toSlimSkill(skillId: string): Promise<SlimSkillResponse | null> {
+      const catalog = await getCatalog();
+      const cs = catalog.find((s) => s.id === skillId);
+      if (!cs) return null;
+      return catalogSkillToSlim(cs);
+    },
   };
 }

--- a/assistant/src/skills/skill-file-provider.ts
+++ b/assistant/src/skills/skill-file-provider.ts
@@ -1,0 +1,40 @@
+import type { SlimSkillResponse } from "../daemon/message-types/skills.js";
+import type { SkillFileEntry } from "./catalog-files.js";
+
+/**
+ * A file provider can resolve file listings and single-file content for
+ * skills that are NOT installed locally. Each origin (vellum catalog,
+ * skills.sh, clawhub) implements this interface.
+ */
+export interface SkillFileProvider {
+  /**
+   * Return true if this provider can handle the given skill id.
+   * Called synchronously — must not perform I/O.
+   */
+  canHandle(skillId: string): boolean;
+
+  /**
+   * List all files in the skill directory. Returns entries with
+   * `content: null` (content is fetched on demand via `readFileContent`).
+   * Returns `null` if the skill doesn't exist in this provider.
+   */
+  listFiles(skillId: string): Promise<SkillFileEntry[] | null>;
+
+  /**
+   * Read a single file's content. `relativePath` has already been
+   * sanitized by the caller (sanitizeRelativePath + hasHiddenOrSkippedSegment).
+   * Returns `null` if the file doesn't exist.
+   */
+  readFileContent(
+    skillId: string,
+    sanitizedPath: string,
+  ): Promise<SkillFileEntry | null>;
+
+  /**
+   * Synthesize a SlimSkillResponse for an uninstalled skill in this
+   * provider. Used by getSkill/getSkillFiles when the skill isn't in
+   * the local catalog. Returns `null` if the provider can't produce
+   * metadata for this skill.
+   */
+  toSlimSkill(skillId: string): Promise<SlimSkillResponse | null>;
+}


### PR DESCRIPTION
## Summary
- Define SkillFileProvider interface with canHandle, listFiles, readFileContent, toSlimSkill methods
- Wrap existing vellum catalog file preview functions as the first provider implementation
- Extract catalogSkillToSlim helper to catalog-files.ts to avoid circular imports

Part of plan: skillssh-file-preview.md (PR 1 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24785" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
