### PR TITLE
feat(skills): add skills.sh SkillFileProvider backed by GitHub Contents API

### DIFF
--- a/assistant/src/__tests__/skillssh-files.test.ts
+++ b/assistant/src/__tests__/skillssh-files.test.ts
@@ -1,0 +1,446 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import {
+  clearDirPathCache,
+  createSkillsShProvider,
+} from "../skills/skillssh-files.js";
+
+// ─── Fetch mock helpers ──────────────────────────────────────────────────────
+
+const originalFetch = globalThis.fetch;
+
+let mockFetchImpl: (url: string | URL | Request) => Promise<Response>;
+
+beforeEach(() => {
+  clearDirPathCache();
+  mockFetchImpl = () =>
+    Promise.resolve(new Response("not mocked", { status: 500 }));
+  globalThis.fetch = mock((input: string | URL | Request) =>
+    mockFetchImpl(typeof input === "string" ? input : input.toString()),
+  ) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+// ─── canHandle ──────────────────────────────────────────────────────────────
+
+describe("canHandle", () => {
+  const provider = createSkillsShProvider();
+
+  test("returns true for owner/repo/skill format", () => {
+    expect(provider.canHandle("owner/repo/skill")).toBe(true);
+  });
+
+  test("returns true for deeply nested slug", () => {
+    expect(provider.canHandle("owner/repo/skill/extra")).toBe(true);
+  });
+
+  test("returns false for simple slug", () => {
+    expect(provider.canHandle("simple-slug")).toBe(false);
+  });
+
+  test("returns false for owner/repo format (only 2 segments)", () => {
+    expect(provider.canHandle("owner/repo")).toBe(false);
+  });
+});
+
+// ─── listFiles ──────────────────────────────────────────────────────────────
+
+describe("listFiles", () => {
+  test("returns entries via conventional path", async () => {
+    const provider = createSkillsShProvider();
+
+    mockFetchImpl = (url: string | URL | Request) => {
+      const urlStr = url.toString();
+
+      // Probe for conventional path — returns directory listing
+      if (urlStr.includes("/contents/skills/my-skill")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify([
+              {
+                name: "SKILL.md",
+                type: "file",
+                download_url: "https://raw.example.com/SKILL.md",
+              },
+              {
+                name: "tools.ts",
+                type: "file",
+                download_url: "https://raw.example.com/tools.ts",
+              },
+            ]),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        );
+      }
+
+      return Promise.resolve(new Response("not found", { status: 404 }));
+    };
+
+    const entries = await provider.listFiles("owner/repo/my-skill");
+    expect(entries).not.toBeNull();
+    expect(entries!.length).toBe(2);
+    expect(entries![0]!.path).toBe("SKILL.md");
+    expect(entries![0]!.content).toBeNull();
+    expect(entries![1]!.path).toBe("tools.ts");
+    expect(entries![1]!.content).toBeNull();
+  });
+
+  test("returns entries via tree-search fallback", async () => {
+    const provider = createSkillsShProvider();
+
+    mockFetchImpl = (url: string | URL | Request) => {
+      const urlStr = url.toString();
+
+      // Conventional path returns 404
+      if (
+        urlStr.includes("/contents/skills/csv") &&
+        !urlStr.includes("examples")
+      ) {
+        return Promise.resolve(new Response("Not Found", { status: 404 }));
+      }
+
+      // Tree search finds it at a non-standard path
+      if (urlStr.includes("/git/trees/")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              tree: [
+                { path: "examples/skills/csv/SKILL.md", type: "blob" },
+                { path: "examples/skills/csv/filter.sh", type: "blob" },
+              ],
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        );
+      }
+
+      // Contents API for the discovered path
+      if (urlStr.includes("/contents/examples/skills/csv")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify([
+              {
+                name: "SKILL.md",
+                type: "file",
+                download_url: "https://raw.example.com/SKILL.md",
+              },
+              {
+                name: "filter.sh",
+                type: "file",
+                download_url: "https://raw.example.com/filter.sh",
+              },
+            ]),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        );
+      }
+
+      return Promise.resolve(new Response("not found", { status: 404 }));
+    };
+
+    const entries = await provider.listFiles("vercel-labs/bash-tool/csv");
+    expect(entries).not.toBeNull();
+    expect(entries!.length).toBe(2);
+    expect(entries!.some((e) => e.path === "SKILL.md")).toBe(true);
+    expect(entries!.some((e) => e.path === "filter.sh")).toBe(true);
+  });
+
+  test("returns null on GitHub API error", async () => {
+    const provider = createSkillsShProvider();
+
+    mockFetchImpl = () =>
+      Promise.resolve(new Response("Internal Server Error", { status: 500 }));
+
+    const entries = await provider.listFiles("owner/repo/my-skill");
+    expect(entries).toBeNull();
+  });
+
+  test("returns null for malformed skill id", async () => {
+    const provider = createSkillsShProvider();
+    const entries = await provider.listFiles("simple-slug");
+    expect(entries).toBeNull();
+  });
+
+  test("skips hidden files and SKIP_DIRS", async () => {
+    const provider = createSkillsShProvider();
+
+    mockFetchImpl = (url: string | URL | Request) => {
+      const urlStr = url.toString();
+
+      if (urlStr.includes("/contents/skills/my-skill")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify([
+              {
+                name: "SKILL.md",
+                type: "file",
+                download_url: "https://raw.example.com/SKILL.md",
+              },
+              {
+                name: ".env",
+                type: "file",
+                download_url: "https://raw.example.com/.env",
+              },
+              {
+                name: "node_modules",
+                type: "dir",
+                download_url: null,
+              },
+              {
+                name: ".git",
+                type: "dir",
+                download_url: null,
+              },
+            ]),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        );
+      }
+
+      return Promise.resolve(new Response("not found", { status: 404 }));
+    };
+
+    const entries = await provider.listFiles("owner/repo/my-skill");
+    expect(entries).not.toBeNull();
+    expect(entries!.length).toBe(1);
+    expect(entries![0]!.path).toBe("SKILL.md");
+  });
+});
+
+// ─── readFileContent ────────────────────────────────────────────────────────
+
+describe("readFileContent", () => {
+  test("returns text content inline", async () => {
+    const provider = createSkillsShProvider();
+
+    mockFetchImpl = (url: string | URL | Request) => {
+      const urlStr = url.toString();
+
+      // Probe for conventional path — returns 200 for dir probe
+      if (
+        urlStr.includes("/contents/skills/my-skill") &&
+        !urlStr.includes("SKILL.md")
+      ) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify([
+              {
+                name: "SKILL.md",
+                type: "file",
+                download_url: "https://raw.example.com/SKILL.md",
+              },
+            ]),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        );
+      }
+
+      // Individual file fetch via Contents API
+      if (urlStr.includes("/contents/skills/my-skill/SKILL.md")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              name: "SKILL.md",
+              type: "file",
+              size: 42,
+              download_url: "https://raw.example.com/SKILL.md",
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        );
+      }
+
+      // File content download
+      if (urlStr.includes("raw.example.com/SKILL.md")) {
+        return Promise.resolve(
+          new Response("# My Skill\nDescription here", { status: 200 }),
+        );
+      }
+
+      return Promise.resolve(new Response("not found", { status: 404 }));
+    };
+
+    const entry = await provider.readFileContent(
+      "owner/repo/my-skill",
+      "SKILL.md",
+    );
+    expect(entry).not.toBeNull();
+    expect(entry!.path).toBe("SKILL.md");
+    expect(entry!.name).toBe("SKILL.md");
+    expect(entry!.isBinary).toBe(false);
+    expect(entry!.content).toBe("# My Skill\nDescription here");
+  });
+
+  test("returns null for binary files", async () => {
+    const provider = createSkillsShProvider();
+
+    mockFetchImpl = (url: string | URL | Request) => {
+      const urlStr = url.toString();
+
+      // Probe for conventional path
+      if (
+        urlStr.includes("/contents/skills/my-skill") &&
+        !urlStr.includes("logo.png")
+      ) {
+        return Promise.resolve(
+          new Response(JSON.stringify([]), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+      }
+
+      // Individual file fetch
+      if (urlStr.includes("/contents/skills/my-skill/logo.png")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              name: "logo.png",
+              type: "file",
+              size: 1024,
+              download_url: "https://raw.example.com/logo.png",
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        );
+      }
+
+      return Promise.resolve(new Response("not found", { status: 404 }));
+    };
+
+    const entry = await provider.readFileContent(
+      "owner/repo/my-skill",
+      "logo.png",
+    );
+    expect(entry).not.toBeNull();
+    expect(entry!.isBinary).toBe(true);
+    expect(entry!.content).toBeNull();
+  });
+
+  test("returns null when file does not exist", async () => {
+    const provider = createSkillsShProvider();
+
+    mockFetchImpl = (url: string | URL | Request) => {
+      const urlStr = url.toString();
+
+      // Probe for conventional path
+      if (
+        urlStr.includes("/contents/skills/my-skill") &&
+        !urlStr.includes("nonexistent.md")
+      ) {
+        return Promise.resolve(
+          new Response(JSON.stringify([]), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+      }
+
+      // File not found
+      if (urlStr.includes("/contents/skills/my-skill/nonexistent.md")) {
+        return Promise.resolve(new Response("Not Found", { status: 404 }));
+      }
+
+      return Promise.resolve(new Response("not found", { status: 404 }));
+    };
+
+    const entry = await provider.readFileContent(
+      "owner/repo/my-skill",
+      "nonexistent.md",
+    );
+    expect(entry).toBeNull();
+  });
+
+  test("returns null for hidden/skipped paths", async () => {
+    const provider = createSkillsShProvider();
+
+    const entry1 = await provider.readFileContent(
+      "owner/repo/my-skill",
+      ".env",
+    );
+    expect(entry1).toBeNull();
+
+    const entry2 = await provider.readFileContent(
+      "owner/repo/my-skill",
+      "node_modules/pkg/index.js",
+    );
+    expect(entry2).toBeNull();
+  });
+});
+
+// ─── toSlimSkill ────────────────────────────────────────────────────────────
+
+describe("toSlimSkill", () => {
+  const provider = createSkillsShProvider();
+
+  test("returns valid SkillsshSlimSkill for well-formed slug", async () => {
+    const slim = await provider.toSlimSkill("owner/repo/my-skill");
+    expect(slim).not.toBeNull();
+    expect(slim!.id).toBe("owner/repo/my-skill");
+    expect(slim!.name).toBe("my-skill");
+    expect(slim!.kind).toBe("catalog");
+    expect(slim!.status).toBe("available");
+    expect(slim!.origin).toBe("skillssh");
+    expect((slim as any).slug).toBe("owner/repo/my-skill");
+    expect((slim as any).sourceRepo).toBe("owner/repo");
+    expect((slim as any).installs).toBe(0);
+  });
+
+  test("returns null for malformed slug", async () => {
+    const slim = await provider.toSlimSkill("bad-slug");
+    expect(slim).toBeNull();
+  });
+});
+
+// ─── Cache behavior ─────────────────────────────────────────────────────────
+
+describe("cache", () => {
+  test("cache hit avoids re-probing GitHub", async () => {
+    const provider = createSkillsShProvider();
+    const fetchedUrls: string[] = [];
+
+    mockFetchImpl = (url: string | URL | Request) => {
+      const urlStr = url.toString();
+      fetchedUrls.push(urlStr);
+
+      // Both the dir probe and the listing hit the same Contents API URL.
+      // Return a valid directory listing for both.
+      if (urlStr.includes("/contents/skills/my-skill")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify([
+              {
+                name: "SKILL.md",
+                type: "file",
+                download_url: "https://raw.example.com/SKILL.md",
+              },
+            ]),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        );
+      }
+
+      return Promise.resolve(new Response("not found", { status: 404 }));
+    };
+
+    // First call: resolveSkillDir probes + listGitHubDir lists = 2 fetches
+    const entries1 = await provider.listFiles("owner/repo/my-skill");
+    expect(entries1).not.toBeNull();
+    const contentsCallsAfterFirst = fetchedUrls.filter((u) =>
+      u.includes("/contents/skills/my-skill"),
+    ).length;
+    expect(contentsCallsAfterFirst).toBe(2); // 1 probe + 1 listing
+
+    // Second call: resolveSkillDir uses cache + listGitHubDir lists = 1 fetch
+    const entries2 = await provider.listFiles("owner/repo/my-skill");
+    expect(entries2).not.toBeNull();
+    const contentsCallsAfterSecond = fetchedUrls.filter((u) =>
+      u.includes("/contents/skills/my-skill"),
+    ).length;
+    // Only 1 additional call (the listing), not 2. The probe is cached.
+    expect(contentsCallsAfterSecond).toBe(3); // 2 from first + 1 listing from second
+  });
+});

--- a/assistant/src/skills/skillssh-files.ts
+++ b/assistant/src/skills/skillssh-files.ts
@@ -1,0 +1,395 @@
+/**
+ * skillssh-files — SkillFileProvider for skills.sh (GitHub-hosted) skills.
+ *
+ * Lists files and reads individual file content via the GitHub Contents API
+ * and Tree API, without downloading or installing the skill locally.
+ *
+ * Path resolution (conventional `skills/<slug>/` with tree-search fallback)
+ * mirrors the logic in `fetchSkillFromGitHub` from `skillssh-registry.ts`,
+ * but only collects metadata (no file content on listing) and fetches
+ * content on demand for individual files.
+ */
+
+import { basename } from "node:path";
+
+import type { SlimSkillResponse } from "../daemon/message-types/skills.js";
+import {
+  isTextMimeType as isTextMime,
+  MAX_INLINE_TEXT_SIZE,
+} from "../runtime/routes/workspace-utils.js";
+import { getLogger } from "../util/logger.js";
+import type { SkillFileEntry } from "./catalog-files.js";
+import {
+  hasHiddenOrSkippedSegment,
+  sanitizeRelativePath,
+  SKIP_DIRS,
+} from "./catalog-files.js";
+import type { SkillFileProvider } from "./skill-file-provider.js";
+import type { GitHubContentsEntry } from "./skillssh-registry.js";
+import {
+  findSkillDirInTree,
+  githubHeaders,
+  resolveSkillSource,
+} from "./skillssh-registry.js";
+
+const log = getLogger("skillssh-files");
+
+// ─── Path resolution cache ──────────────────────────────────────────────────
+
+interface CacheEntry {
+  dirPath: string;
+  expiresAt: number;
+}
+
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+/**
+ * In-memory cache for resolved skill directory paths. Keyed by
+ * `${owner}/${repo}/${skillSlug}` so repeated requests don't re-probe the
+ * GitHub Contents/Tree APIs.
+ */
+const dirPathCache = new Map<string, CacheEntry>();
+
+function cacheKey(owner: string, repo: string, skillSlug: string): string {
+  return `${owner}/${repo}/${skillSlug}`;
+}
+
+function getCachedDirPath(
+  owner: string,
+  repo: string,
+  skillSlug: string,
+): string | null {
+  const key = cacheKey(owner, repo, skillSlug);
+  const entry = dirPathCache.get(key);
+  if (!entry) return null;
+  if (Date.now() > entry.expiresAt) {
+    dirPathCache.delete(key);
+    return null;
+  }
+  return entry.dirPath;
+}
+
+function setCachedDirPath(
+  owner: string,
+  repo: string,
+  skillSlug: string,
+  dirPath: string,
+): void {
+  const key = cacheKey(owner, repo, skillSlug);
+  dirPathCache.set(key, { dirPath, expiresAt: Date.now() + CACHE_TTL_MS });
+}
+
+// Exported for testing only
+export function clearDirPathCache(): void {
+  dirPathCache.clear();
+}
+
+// ─── Binary classification ──────────────────────────────────────────────────
+
+/**
+ * Classify a file as binary from its name alone. Mirrors the
+ * `classifyByName` pattern in `catalog-files.ts`.
+ */
+function classifyByName(name: string): boolean {
+  const mime = Bun.file(name).type;
+  return !isTextMime(mime, name);
+}
+
+// ─── Skill directory resolution ─────────────────────────────────────────────
+
+/**
+ * Resolve the directory path for a skill in a GitHub repo. Tries the
+ * conventional `skills/<slug>/` path first, falls back to tree search.
+ * Returns null if the skill cannot be located.
+ */
+async function resolveSkillDir(
+  owner: string,
+  repo: string,
+  skillSlug: string,
+  ref?: string,
+): Promise<string | null> {
+  // Check cache first
+  const cached = getCachedDirPath(owner, repo, skillSlug);
+  if (cached !== null) return cached;
+
+  const headers = githubHeaders();
+  const conventionalPath = `skills/${encodeURIComponent(skillSlug)}`;
+
+  const probeUrl = `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/contents/${conventionalPath}${ref ? `?ref=${encodeURIComponent(ref)}` : ""}`;
+
+  const probeResponse = await fetch(probeUrl, {
+    headers,
+    signal: AbortSignal.timeout(15_000),
+  });
+
+  if (probeResponse.ok) {
+    setCachedDirPath(owner, repo, skillSlug, conventionalPath);
+    return conventionalPath;
+  }
+
+  if (probeResponse.status === 404) {
+    // Fall back to tree search
+    const treeRef = ref ?? "HEAD";
+    const foundPath = await findSkillDirInTree(
+      owner,
+      repo,
+      skillSlug,
+      treeRef,
+      headers,
+    );
+    if (foundPath) {
+      setCachedDirPath(owner, repo, skillSlug, foundPath);
+      return foundPath;
+    }
+    return null;
+  }
+
+  // Non-404 error — log and return null
+  log.warn(
+    { status: probeResponse.status, owner, repo, skillSlug },
+    "GitHub Contents API returned non-2xx during skill dir probe",
+  );
+  return null;
+}
+
+// ─── Recursive directory listing ────────────────────────────────────────────
+
+/**
+ * Recursively list files in a GitHub directory via the Contents API.
+ * Collects `SkillFileEntry` objects with `content: null`. Skips hidden
+ * files, `node_modules`, `__pycache__`, `.git` (same filtering as
+ * `walkSkillDir` in `catalog-files.ts`).
+ */
+async function listGitHubDir(
+  owner: string,
+  repo: string,
+  dirPath: string,
+  prefix: string,
+  ref: string | undefined,
+  headers: Record<string, string>,
+): Promise<SkillFileEntry[]> {
+  let apiUrl = `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/contents/${dirPath}`;
+  if (ref) {
+    apiUrl += `?ref=${encodeURIComponent(ref)}`;
+  }
+
+  const response = await fetch(apiUrl, {
+    headers,
+    signal: AbortSignal.timeout(15_000),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `GitHub Contents API error: HTTP ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const entries = (await response.json()) as GitHubContentsEntry[];
+  if (!Array.isArray(entries)) return [];
+
+  const result: SkillFileEntry[] = [];
+
+  for (const entry of entries) {
+    // Skip hidden files/dirs (same as walkSkillDir)
+    if (entry.name.startsWith(".")) continue;
+
+    const relativePath = prefix ? `${prefix}/${entry.name}` : entry.name;
+
+    if (entry.type === "dir") {
+      // Skip well-known heavyweight directories
+      if (SKIP_DIRS.has(entry.name)) continue;
+
+      const subEntries = await listGitHubDir(
+        owner,
+        repo,
+        `${dirPath}/${entry.name}`,
+        relativePath,
+        ref,
+        headers,
+      );
+      result.push(...subEntries);
+      continue;
+    }
+
+    if (entry.type !== "file") continue;
+
+    result.push({
+      path: relativePath,
+      name: basename(relativePath),
+      size: 0, // GitHub Contents API directory listings don't include size
+      mimeType: "",
+      isBinary: classifyByName(entry.name),
+      content: null,
+    });
+  }
+
+  return result;
+}
+
+// ─── Provider implementation ────────────────────────────────────────────────
+
+export function createSkillsShProvider(): SkillFileProvider {
+  return {
+    canHandle(skillId: string): boolean {
+      return skillId.split("/").length >= 3;
+    },
+
+    async listFiles(skillId: string): Promise<SkillFileEntry[] | null> {
+      let source;
+      try {
+        source = resolveSkillSource(skillId);
+      } catch {
+        return null;
+      }
+
+      try {
+        const dirPath = await resolveSkillDir(
+          source.owner,
+          source.repo,
+          source.skillSlug,
+          source.ref,
+        );
+        if (!dirPath) return null;
+
+        const headers = githubHeaders();
+        const entries = await listGitHubDir(
+          source.owner,
+          source.repo,
+          dirPath,
+          "",
+          source.ref,
+          headers,
+        );
+        entries.sort((a, b) => a.path.localeCompare(b.path));
+        return entries;
+      } catch (err) {
+        log.warn({ err, skillId }, "Failed to list files for skills.sh skill");
+        return null;
+      }
+    },
+
+    async readFileContent(
+      skillId: string,
+      sanitizedPath: string,
+    ): Promise<SkillFileEntry | null> {
+      // Re-validate the path even though the caller should have sanitized
+      const safe = sanitizeRelativePath(sanitizedPath);
+      if (!safe) return null;
+      if (hasHiddenOrSkippedSegment(safe)) return null;
+
+      let source;
+      try {
+        source = resolveSkillSource(skillId);
+      } catch {
+        return null;
+      }
+
+      try {
+        const dirPath = await resolveSkillDir(
+          source.owner,
+          source.repo,
+          source.skillSlug,
+          source.ref,
+        );
+        if (!dirPath) return null;
+
+        const headers = githubHeaders();
+        const filePath = `${dirPath}/${safe}`;
+
+        // Fetch the file entry via GitHub Contents API
+        let apiUrl = `https://api.github.com/repos/${encodeURIComponent(source.owner)}/${encodeURIComponent(source.repo)}/contents/${filePath}`;
+        if (source.ref) {
+          apiUrl += `?ref=${encodeURIComponent(source.ref)}`;
+        }
+
+        const response = await fetch(apiUrl, {
+          headers,
+          signal: AbortSignal.timeout(15_000),
+        });
+
+        if (!response.ok) return null;
+
+        const entry = (await response.json()) as GitHubContentsEntry & {
+          size?: number;
+        };
+
+        // Ensure it's a file, not a directory
+        if (entry.type !== "file") return null;
+
+        const name = basename(safe);
+        const isBinary = classifyByName(name);
+
+        // Return null content for binary files
+        if (isBinary) {
+          return {
+            path: safe,
+            name,
+            size: entry.size ?? 0,
+            mimeType: "",
+            isBinary: true,
+            content: null,
+          };
+        }
+
+        // For text files, check size and fetch content
+        const size = entry.size ?? 0;
+        if (size > MAX_INLINE_TEXT_SIZE) {
+          return {
+            path: safe,
+            name,
+            size,
+            mimeType: "",
+            isBinary: false,
+            content: null,
+          };
+        }
+
+        // Fetch the actual file content via download_url
+        if (!entry.download_url) return null;
+
+        const contentResponse = await fetch(entry.download_url, {
+          headers,
+          signal: AbortSignal.timeout(10_000),
+        });
+
+        if (!contentResponse.ok) return null;
+
+        const content = await contentResponse.text();
+
+        return {
+          path: safe,
+          name,
+          size: content.length,
+          mimeType: "",
+          isBinary: false,
+          content,
+        };
+      } catch (err) {
+        log.warn(
+          { err, skillId, path: sanitizedPath },
+          "Failed to read file content for skills.sh skill",
+        );
+        return null;
+      }
+    },
+
+    async toSlimSkill(skillId: string): Promise<SlimSkillResponse | null> {
+      try {
+        const source = resolveSkillSource(skillId);
+        return {
+          id: skillId,
+          name: source.skillSlug,
+          description: "",
+          kind: "catalog",
+          status: "available",
+          origin: "skillssh",
+          slug: skillId,
+          sourceRepo: `${source.owner}/${source.repo}`,
+          installs: 0,
+        };
+      } catch {
+        return null;
+      }
+    },
+  };
+}

--- a/assistant/src/skills/skillssh-registry.ts
+++ b/assistant/src/skills/skillssh-registry.ts
@@ -189,14 +189,14 @@ export function resolveSkillSource(source: string): ResolvedSkillSource {
 
 // ─── GitHub fetch ───────────────────────────────────────────────────────────
 
-interface GitHubContentsEntry {
+export interface GitHubContentsEntry {
   name: string;
   type: "file" | "dir";
   download_url: string | null;
 }
 
 /** Build common headers for GitHub API requests (User-Agent + optional auth). */
-function githubHeaders(): Record<string, string> {
+export function githubHeaders(): Record<string, string> {
   const headers: Record<string, string> = {
     Accept: "application/vnd.github.v3+json",
     "User-Agent": "vellum-assistant",
@@ -208,7 +208,7 @@ function githubHeaders(): Record<string, string> {
   return headers;
 }
 
-interface GitHubTreeEntry {
+export interface GitHubTreeEntry {
   path: string;
   type: "blob" | "tree";
 }
@@ -217,7 +217,7 @@ interface GitHubTreeEntry {
  * Search the repo tree for a directory containing `<slug>/SKILL.md`.
  * Returns the directory path (e.g. "examples/skills-tool/skills/csv") or null.
  */
-async function findSkillDirInTree(
+export async function findSkillDirInTree(
   owner: string,
   repo: string,
   skillSlug: string,


### PR DESCRIPTION
## Summary
- Implement SkillFileProvider for skills.sh origin backed by GitHub Contents API
- Support file listing and on-demand content fetching without installing the skill
- Include in-memory caching for resolved skill directory paths

Part of plan: skillssh-file-preview.md (PR 2 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24786" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
