### PR TITLE
Chrome popup: one-click Connect flow with user-facing Pause control

### DIFF
--- a/clients/chrome-extension/popup/popup-state.test.ts
+++ b/clients/chrome-extension/popup/popup-state.test.ts
@@ -5,6 +5,8 @@
  *   - deriveSelectorDisplay: hidden for 0/1 assistants, visible for 2+
  *   - assistantLabel: readable label derivation
  *   - shouldShowLocalSection / shouldShowCloudSection: auth-profile gating
+ *   - deriveCtaState: CTA label/enablement for each connection phase
+ *   - deriveStatusDisplay: status dot class and text for each phase
  */
 
 import { describe, test, expect } from 'bun:test';
@@ -14,6 +16,9 @@ import {
   assistantLabel,
   shouldShowLocalSection,
   shouldShowCloudSection,
+  deriveCtaState,
+  deriveStatusDisplay,
+  type ConnectionPhase,
 } from './popup-state.js';
 
 import type { AssistantDescriptor } from '../background/native-host-assistants.js';
@@ -146,5 +151,104 @@ describe('shouldShowCloudSection', () => {
 
   test('returns false for null profile', () => {
     expect(shouldShowCloudSection(null)).toBe(false);
+  });
+});
+
+// ── deriveCtaState ─────────────────────────────────────────────────
+
+describe('deriveCtaState', () => {
+  test('disconnected: Connect enabled, Pause disabled', () => {
+    const state = deriveCtaState('disconnected');
+    expect(state.connectLabel).toBe('Connect');
+    expect(state.connectEnabled).toBe(true);
+    expect(state.pauseLabel).toBe('Pause');
+    expect(state.pauseEnabled).toBe(false);
+  });
+
+  test('connecting: shows Connecting\u2026 label, both buttons disabled', () => {
+    const state = deriveCtaState('connecting');
+    expect(state.connectLabel).toBe('Connecting\u2026');
+    expect(state.connectEnabled).toBe(false);
+    expect(state.pauseLabel).toBe('Pause');
+    expect(state.pauseEnabled).toBe(false);
+  });
+
+  test('connected: Connect disabled, Pause enabled', () => {
+    const state = deriveCtaState('connected');
+    expect(state.connectLabel).toBe('Connect');
+    expect(state.connectEnabled).toBe(false);
+    expect(state.pauseLabel).toBe('Pause');
+    expect(state.pauseEnabled).toBe(true);
+  });
+
+  test('paused: Connect enabled, Pause disabled (same as disconnected)', () => {
+    const state = deriveCtaState('paused');
+    expect(state.connectLabel).toBe('Connect');
+    expect(state.connectEnabled).toBe(true);
+    expect(state.pauseLabel).toBe('Pause');
+    expect(state.pauseEnabled).toBe(false);
+  });
+
+  test('all phases produce consistent label/enablement pairs', () => {
+    const phases: ConnectionPhase[] = ['disconnected', 'connecting', 'connected', 'paused'];
+    for (const phase of phases) {
+      const state = deriveCtaState(phase);
+      // Pause should only be enabled when connected
+      expect(state.pauseEnabled).toBe(phase === 'connected');
+      // Connect should be disabled only when connecting or connected
+      expect(state.connectEnabled).toBe(phase !== 'connecting' && phase !== 'connected');
+    }
+  });
+});
+
+// ── deriveStatusDisplay ────────────────────────────────────────────
+
+describe('deriveStatusDisplay', () => {
+  test('disconnected: red dot, Not connected', () => {
+    const status = deriveStatusDisplay('disconnected');
+    expect(status.dotClass).toBe('disconnected');
+    expect(status.text).toBe('Not connected');
+  });
+
+  test('connecting: red dot, Connecting\u2026', () => {
+    const status = deriveStatusDisplay('connecting');
+    expect(status.dotClass).toBe('disconnected');
+    expect(status.text).toBe('Connecting\u2026');
+  });
+
+  test('connected: green dot, Connected to relay server', () => {
+    const status = deriveStatusDisplay('connected');
+    expect(status.dotClass).toBe('connected');
+    expect(status.text).toBe('Connected to relay server');
+  });
+
+  test('paused: amber dot, Paused', () => {
+    const status = deriveStatusDisplay('paused');
+    expect(status.dotClass).toBe('paused');
+    expect(status.text).toBe('Paused');
+  });
+
+  test('display transitions: disconnected -> connecting -> connected -> paused -> disconnected', () => {
+    const transitions: ConnectionPhase[] = [
+      'disconnected',
+      'connecting',
+      'connected',
+      'paused',
+      'disconnected',
+    ];
+    const expectedDots = ['disconnected', 'disconnected', 'connected', 'paused', 'disconnected'];
+    const expectedTexts = [
+      'Not connected',
+      'Connecting\u2026',
+      'Connected to relay server',
+      'Paused',
+      'Not connected',
+    ];
+
+    for (let i = 0; i < transitions.length; i++) {
+      const status = deriveStatusDisplay(transitions[i]!);
+      expect(status.dotClass).toBe(expectedDots[i]);
+      expect(status.text).toBe(expectedTexts[i]);
+    }
   });
 });

--- a/clients/chrome-extension/popup/popup-state.ts
+++ b/clients/chrome-extension/popup/popup-state.ts
@@ -1,10 +1,16 @@
 /**
- * Pure view-state helpers for the popup assistant selector.
+ * Pure view-state helpers for the popup UI.
  *
- * These functions derive display state from the assistant catalog and
- * selection data returned by the worker's `assistants-get` message.
- * They are deliberately side-effect-free so they can be unit tested
- * without a Chrome runtime environment.
+ * These functions derive display state from the assistant catalog,
+ * selection data, and connection phase. They are deliberately
+ * side-effect-free so they can be unit tested without a Chrome runtime
+ * environment.
+ *
+ * The popup exposes two primary actions:
+ *   - **Connect** — the only first-step CTA. The worker handles auth
+ *     bootstrap (pairing/sign-in) automatically when `interactive=true`.
+ *   - **Pause** — user-facing stop action that halts the relay but
+ *     preserves credentials so reconnect is instant.
  */
 
 import type { AssistantDescriptor } from '../background/native-host-assistants.js';
@@ -111,4 +117,101 @@ export function shouldShowCloudSection(
   authProfile: AssistantAuthProfile | null,
 ): boolean {
   return authProfile === 'cloud-oauth';
+}
+
+// ── Connection phase & CTA helpers ──────────────────────────────────
+
+/**
+ * The popup's connection lifecycle phase. Drives the primary/secondary
+ * button labels, enablement, and status indicator.
+ *
+ * - `disconnected` — idle, no active relay connection.
+ * - `connecting`   — connect in progress (waiting for socket open).
+ * - `connected`    — relay WebSocket is open and active.
+ * - `paused`       — user explicitly paused; credentials are preserved
+ *                    so reconnect is instant.
+ */
+export type ConnectionPhase = 'disconnected' | 'connecting' | 'connected' | 'paused';
+
+/**
+ * Derived view state for the popup's primary and secondary action buttons.
+ */
+export interface CtaState {
+  /** Label for the primary action button. */
+  connectLabel: string;
+  /** Whether the primary Connect button is enabled. */
+  connectEnabled: boolean;
+  /** Label for the secondary action button. */
+  pauseLabel: string;
+  /** Whether the secondary Pause button is enabled. */
+  pauseEnabled: boolean;
+}
+
+/**
+ * Derive the CTA button labels and enablement from the connection phase.
+ *
+ * | Phase        | Connect       | Pause         |
+ * |--------------|---------------|---------------|
+ * | disconnected | Connect (on)  | Pause (off)   |
+ * | connecting   | Connecting... (off) | Pause (off) |
+ * | connected    | Connect (off) | Pause (on)    |
+ * | paused       | Connect (on)  | Pause (off)   |
+ */
+export function deriveCtaState(phase: ConnectionPhase): CtaState {
+  switch (phase) {
+    case 'disconnected':
+      return {
+        connectLabel: 'Connect',
+        connectEnabled: true,
+        pauseLabel: 'Pause',
+        pauseEnabled: false,
+      };
+    case 'connecting':
+      return {
+        connectLabel: 'Connecting\u2026',
+        connectEnabled: false,
+        pauseLabel: 'Pause',
+        pauseEnabled: false,
+      };
+    case 'connected':
+      return {
+        connectLabel: 'Connect',
+        connectEnabled: false,
+        pauseLabel: 'Pause',
+        pauseEnabled: true,
+      };
+    case 'paused':
+      return {
+        connectLabel: 'Connect',
+        connectEnabled: true,
+        pauseLabel: 'Pause',
+        pauseEnabled: false,
+      };
+  }
+}
+
+/**
+ * Derived view state for the status indicator (dot + text).
+ */
+export interface StatusDisplay {
+  /** CSS class for the status dot (`connected`, `paused`, `disconnected`). */
+  dotClass: string;
+  /** User-facing status text. */
+  text: string;
+}
+
+/**
+ * Derive the status dot class and text from the connection phase.
+ */
+export function deriveStatusDisplay(phase: ConnectionPhase): StatusDisplay {
+  switch (phase) {
+    case 'disconnected':
+      return { dotClass: 'disconnected', text: 'Not connected' };
+    case 'connecting':
+      return { dotClass: 'disconnected', text: 'Connecting\u2026' };
+    case 'connected':
+      return { dotClass: 'connected', text: 'Connected to relay server' };
+    case 'paused':
+      return { dotClass: 'paused', text: 'Paused' };
+  }
 }

--- a/clients/chrome-extension/popup/popup.html
+++ b/clients/chrome-extension/popup/popup.html
@@ -206,7 +206,7 @@
 
   <p class="hint">Relay port defaults to 7830.</p>
 
-  <div class="divider"></div>
+  <div class="divider" id="troubleshooting-divider"></div>
 
   <p class="section-label" id="troubleshooting-label">Troubleshooting</p>
 

--- a/clients/chrome-extension/popup/popup.html
+++ b/clients/chrome-extension/popup/popup.html
@@ -37,6 +37,7 @@
       transition: background 0.2s;
     }
     .status-dot.connected { background: #22c55e; }
+    .status-dot.paused { background: #f59e0b; }
     .status-dot.disconnected { background: #ef4444; }
 
     .status-text {
@@ -88,11 +89,11 @@
     }
     #btn-connect:hover:not(:disabled) { background: #4f46e5; }
 
-    #btn-disconnect {
+    #btn-pause {
       background: #f3f4f6;
       color: #374151;
     }
-    #btn-disconnect:hover:not(:disabled) { background: #e5e7eb; }
+    #btn-pause:hover:not(:disabled) { background: #e5e7eb; }
 
     .divider {
       height: 1px;
@@ -200,22 +201,20 @@
 
   <div class="btn-row">
     <button id="btn-connect">Connect</button>
-    <button id="btn-disconnect" disabled>Disconnect</button>
+    <button id="btn-pause" disabled>Pause</button>
   </div>
 
   <p class="hint">Relay port defaults to 7830.</p>
 
   <div class="divider"></div>
 
-  <p class="section-label">Local</p>
-  <p class="local-status" id="local-status">Not paired</p>
-  <button id="btn-pair-local" type="button">Pair with local assistant</button>
+  <p class="section-label">Troubleshooting</p>
 
-  <div class="divider"></div>
+  <p class="local-status" id="local-status" style="display:none">Not paired</p>
+  <button id="btn-pair-local" type="button" style="display:none">Re-pair with local assistant</button>
 
-  <p class="section-label">Cloud</p>
-  <p class="cloud-status" id="cloud-status">Not signed in</p>
-  <button id="btn-cloud-signin" type="button">Sign in with Vellum (cloud)</button>
+  <p class="cloud-status" id="cloud-status" style="display:none">Not signed in</p>
+  <button id="btn-cloud-signin" type="button" style="display:none">Re-sign in with Vellum (cloud)</button>
 
   <script type="module" src="popup.js"></script>
 </body>

--- a/clients/chrome-extension/popup/popup.html
+++ b/clients/chrome-extension/popup/popup.html
@@ -208,7 +208,7 @@
 
   <div class="divider"></div>
 
-  <p class="section-label">Troubleshooting</p>
+  <p class="section-label" id="troubleshooting-label">Troubleshooting</p>
 
   <p class="local-status" id="local-status" style="display:none">Not paired</p>
   <button id="btn-pair-local" type="button" style="display:none">Re-pair with local assistant</button>

--- a/clients/chrome-extension/popup/popup.ts
+++ b/clients/chrome-extension/popup/popup.ts
@@ -1,6 +1,19 @@
 /**
  * Popup UI for the Vellum browser-relay extension.
  *
+ * The popup exposes a single primary CTA — **Connect** — that works in
+ * one click even when the user hasn't previously paired or signed in.
+ * The worker handles auth bootstrap automatically when `interactive=true`.
+ *
+ * The secondary action is **Pause**, which halts the relay but preserves
+ * credentials for instant reconnect. Under the hood this sends the
+ * existing `disconnect` message to the worker; once PR 2 lands it will
+ * migrate to the dedicated `pause` message.
+ *
+ * Manual recovery controls (local re-pair and cloud re-sign-in) are
+ * available under a Troubleshooting section, but are not required for
+ * the normal connect flow.
+ *
  * On open the popup loads the assistant catalog from the worker via the
  * `assistants-get` message. When exactly one assistant exists it is
  * auto-selected and no selector dropdown is shown. When multiple
@@ -10,20 +23,6 @@
  * worker, which persists the selection and returns the resolved
  * descriptor + auth profile. The popup then refreshes the local/cloud
  * auth status panels to match the newly selected assistant.
- *
- * Self-hosted pairing is governed by the "Pair local assistant" button,
- * which spawns the native messaging helper and persists a capability
- * token (see self-hosted-auth.ts). Connect then reads that stored
- * capability token directly. If the user hasn't paired yet we surface
- * an inline error pointing them at the Pair button.
- *
- * Also exposes a "Sign in with Vellum (cloud)" button. The actual OAuth
- * flow runs in the background service worker (see worker.ts) — the popup
- * only sends a message asking the worker to start it. This avoids the
- * MV3 popup teardown race where closing the popup mid-auth would kill
- * the awaited launchWebAuthFlow promise before the token was persisted.
- * Cloud sign-in and self-hosted Pair coexist — they represent the two
- * possible relay transports.
  */
 
 import { getStoredToken, type StoredCloudToken } from '../background/cloud-auth.js';
@@ -37,6 +36,9 @@ import {
   deriveSelectorDisplay,
   shouldShowLocalSection,
   shouldShowCloudSection,
+  deriveCtaState,
+  deriveStatusDisplay,
+  type ConnectionPhase,
   type AssistantsGetResponse,
   type AssistantSelectResponse,
 } from './popup-state.js';
@@ -47,7 +49,7 @@ const DEFAULT_RELAY_PORT = 7830;
 
 const portInput = document.getElementById('port-input') as HTMLInputElement;
 const btnConnect = document.getElementById('btn-connect') as HTMLButtonElement;
-const btnDisconnect = document.getElementById('btn-disconnect') as HTMLButtonElement;
+const btnPause = document.getElementById('btn-pause') as HTMLButtonElement;
 const statusDot = document.getElementById('status-dot') as HTMLDivElement;
 const statusText = document.getElementById('status-text') as HTMLParagraphElement;
 const errorText = document.getElementById('error-text') as HTMLParagraphElement;
@@ -71,15 +73,30 @@ const assistantSelect = document.getElementById(
 let currentAuthProfile: AssistantAuthProfile | null = null;
 let currentAssistantId: string | null = null;
 
-// ── Connection state helpers ────────────────────────────────────────
+// ── Connection phase management ─────────────────────────────────────
 
-function setConnected(connected: boolean): void {
-  statusDot.className = `status-dot ${connected ? 'connected' : 'disconnected'}`;
-  statusText.textContent = connected ? 'Connected to relay server' : 'Not connected';
-  btnConnect.disabled = connected;
-  btnDisconnect.disabled = !connected;
-  portInput.disabled = connected;
-  if (connected) {
+let currentPhase: ConnectionPhase = 'disconnected';
+
+/**
+ * Apply a connection phase to the UI. Derives button labels/enablement
+ * and status indicator from the pure helpers in popup-state.ts.
+ */
+function setPhase(phase: ConnectionPhase): void {
+  currentPhase = phase;
+
+  const cta = deriveCtaState(phase);
+  btnConnect.textContent = cta.connectLabel;
+  btnConnect.disabled = !cta.connectEnabled;
+  btnPause.textContent = cta.pauseLabel;
+  btnPause.disabled = !cta.pauseEnabled;
+
+  const status = deriveStatusDisplay(phase);
+  statusDot.className = `status-dot ${status.dotClass}`;
+  statusText.textContent = status.text;
+
+  portInput.disabled = phase === 'connected' || phase === 'connecting';
+
+  if (phase === 'connected') {
     errorText.style.display = 'none';
   }
 }
@@ -132,61 +149,22 @@ function renderAssistantSelector(
 }
 
 /**
- * Update the visibility of the Local and Cloud auth sections based on
- * the selected assistant's auth profile.
+ * Update the visibility of the Local and Cloud troubleshooting controls
+ * based on the selected assistant's auth profile.
  */
 function updateAuthSections(authProfile: AssistantAuthProfile | null): void {
   currentAuthProfile = authProfile;
 
-  // Find the section containers by walking from the section-label elements.
-  // The Local section = section-label "Local" + local-status + btn-pair-local + preceding divider.
-  // The Cloud section = section-label "Cloud" + cloud-status + btn-cloud-signin + preceding divider.
-  //
-  // We use a simpler approach: show/hide the local and cloud elements
-  // individually based on the auth profile.
-
   const showLocal = shouldShowLocalSection(authProfile);
   const showCloud = shouldShowCloudSection(authProfile);
 
-  // Walk DOM to find the divider before each section label.
-  const sectionLabels = document.querySelectorAll('.section-label');
+  // Toggle Local troubleshooting elements visibility.
+  localStatus.style.display = showLocal ? '' : 'none';
+  btnPairLocal.style.display = showLocal ? '' : 'none';
 
-  // Find the local section's divider (the one before "Local")
-  // and the cloud section's divider (the one before "Cloud")
-  let localDividerEl: Element | null = null;
-  let cloudDividerEl: Element | null = null;
-  let localLabelEl: Element | null = null;
-  let cloudLabelEl: Element | null = null;
-
-  for (const label of sectionLabels) {
-    if (label.textContent?.trim() === 'Local') localLabelEl = label;
-    if (label.textContent?.trim() === 'Cloud') cloudLabelEl = label;
-  }
-
-  // The divider immediately before the Local label
-  if (localLabelEl?.previousElementSibling?.classList.contains('divider')) {
-    localDividerEl = localLabelEl.previousElementSibling;
-  }
-  // The divider immediately before the Cloud label
-  if (cloudLabelEl?.previousElementSibling?.classList.contains('divider')) {
-    cloudDividerEl = cloudLabelEl.previousElementSibling;
-  }
-
-  // Toggle Local section visibility
-  const localElements = [localDividerEl, localLabelEl, localStatus, btnPairLocal];
-  for (const el of localElements) {
-    if (el instanceof HTMLElement) {
-      el.style.display = showLocal ? '' : 'none';
-    }
-  }
-
-  // Toggle Cloud section visibility
-  const cloudElements = [cloudDividerEl, cloudLabelEl, cloudStatus, btnCloudSignIn];
-  for (const el of cloudElements) {
-    if (el instanceof HTMLElement) {
-      el.style.display = showCloud ? '' : 'none';
-    }
-  }
+  // Toggle Cloud troubleshooting elements visibility.
+  cloudStatus.style.display = showCloud ? '' : 'none';
+  btnCloudSignIn.style.display = showCloud ? '' : 'none';
 }
 
 /**
@@ -259,7 +237,7 @@ chrome.storage.local.get(['relayPort']).then((result) => {
 // Query current status from service worker
 chrome.runtime.sendMessage({ type: 'get_status' }, (response: { connected: boolean }) => {
   if (chrome.runtime.lastError) return;
-  setConnected(response?.connected ?? false);
+  setPhase(response?.connected ? 'connected' : 'disconnected');
 });
 
 function getPort(): number {
@@ -271,29 +249,18 @@ function getPort(): number {
   return DEFAULT_RELAY_PORT;
 }
 
+// ── Connect (primary CTA) ───────────────────────────────────────────
+//
+// No local precheck — the worker handles auth bootstrap (pairing/sign-in)
+// automatically when interactive=true. Users can connect in one click
+// even when not previously paired or signed in.
+
 btnConnect.addEventListener('click', async () => {
   const port = getPort();
   const storageUpdate: Record<string, unknown> = { autoConnect: true };
 
   errorText.style.display = 'none';
-
-  // Check whether pairing is required based on the selected assistant's
-  // auth profile. In cloud mode the worker uses the stored cloud token
-  // (vellum.cloudAuthToken) directly, so the popup must NOT try to hit
-  // localhost — a cloud-only user may not have a local assistant running.
-  if (currentAuthProfile === 'local-pair') {
-    if (!currentAssistantId) {
-      showError('No assistant selected — please select an assistant first.');
-      return;
-    }
-    const pairedToken = await getStoredLocalToken(currentAssistantId);
-    if (!pairedToken) {
-      showError(
-        'Local assistant is not paired yet — click "Pair with local assistant" below before connecting.',
-      );
-      return;
-    }
-  }
+  setPhase('connecting');
 
   if (portInput.value.trim()) {
     storageUpdate.relayPort = port;
@@ -305,7 +272,7 @@ btnConnect.addEventListener('click', async () => {
   chrome.runtime.sendMessage({ type: 'connect' }, (response: { ok: boolean; error?: string }) => {
     if (chrome.runtime.lastError || !response?.ok) {
       showError(response?.error ?? chrome.runtime.lastError?.message ?? 'Unknown error');
-      btnConnect.disabled = false;
+      setPhase('disconnected');
       return;
     }
     // Poll briefly for open state
@@ -314,21 +281,28 @@ btnConnect.addEventListener('click', async () => {
       chrome.runtime.sendMessage({ type: 'get_status' }, (r: { connected: boolean }) => {
         if (r?.connected || ++attempts > 10) {
           clearInterval(poll);
-          setConnected(r?.connected ?? false);
+          setPhase(r?.connected ? 'connected' : 'disconnected');
         }
       });
     }, 300);
   });
 });
 
-btnDisconnect.addEventListener('click', () => {
+// ── Pause (secondary action) ────────────────────────────────────────
+//
+// Sends the existing disconnect/stop message to the worker while
+// presenting the action as "Pause" in the UI. Credentials are
+// preserved so reconnect is instant. Once PR 2 lands, this will
+// migrate to the dedicated `pause` message.
+
+btnPause.addEventListener('click', () => {
   chrome.storage.local.set({ autoConnect: false });
   chrome.runtime.sendMessage({ type: 'disconnect' }, () => {
-    setConnected(false);
+    setPhase('paused');
   });
 });
 
-// ── Self-hosted native-messaging pairing ────────────────────────────
+// ── Self-hosted native-messaging pairing (troubleshooting) ──────────
 //
 // Pairing runs the local native messaging helper (com.vellum.daemon),
 // which POSTs the extension's origin to the assistant's
@@ -336,6 +310,9 @@ btnDisconnect.addEventListener('click', () => {
 // The token is persisted in chrome.storage.local under
 // `vellum.localCapabilityToken` and is used directly by the
 // self-hosted relay WebSocket connection.
+//
+// This is a manual recovery control — normal connect handles pairing
+// automatically via the worker's interactive bootstrap.
 
 function setLocalStatus(text: string, state: 'neutral' | 'paired' | 'error'): void {
   localStatus.textContent = text;
@@ -395,7 +372,7 @@ function requestLocalPair(): Promise<LocalPairResponse> {
 
 btnPairLocal.addEventListener('click', async () => {
   btnPairLocal.disabled = true;
-  setLocalStatus('Pairing…', 'neutral');
+  setLocalStatus('Pairing\u2026', 'neutral');
   // Delegate to the service worker so the native-messaging bootstrap
   // survives the popup teardown race — see the `self-hosted-pair`
   // handler in worker.ts, and the matching cloud-auth-sign-in pattern.
@@ -410,10 +387,13 @@ btnPairLocal.addEventListener('click', async () => {
 
 refreshLocalStatus();
 
-// ── Cloud sign-in ───────────────────────────────────────────────────
+// ── Cloud sign-in (troubleshooting) ─────────────────────────────────
 //
 // The token is persisted and consumed by the background worker when
 // opening cloud relay WebSocket connections.
+//
+// This is a manual recovery control — normal connect handles cloud
+// sign-in automatically via the worker's interactive bootstrap.
 
 function setCloudStatus(text: string, signedIn: boolean): void {
   cloudStatus.textContent = text;
@@ -473,7 +453,7 @@ function requestCloudSignIn(): Promise<CloudSignInResponse> {
 
 btnCloudSignIn.addEventListener('click', async () => {
   btnCloudSignIn.disabled = true;
-  setCloudStatus('Signing in…', false);
+  setCloudStatus('Signing in\u2026', false);
   errorText.style.display = 'none';
   // Clear any stale auth-error the worker persisted during a failed
   // reconnect — the user is explicitly retrying sign-in now.

--- a/clients/chrome-extension/popup/popup.ts
+++ b/clients/chrome-extension/popup/popup.ts
@@ -58,6 +58,9 @@ const cloudStatus = document.getElementById('cloud-status') as HTMLParagraphElem
 const btnPairLocal = document.getElementById('btn-pair-local') as HTMLButtonElement;
 const localStatus = document.getElementById('local-status') as HTMLParagraphElement;
 
+const troubleshootingDivider = document.getElementById(
+  'troubleshooting-divider',
+) as HTMLDivElement;
 const troubleshootingLabel = document.getElementById(
   'troubleshooting-label',
 ) as HTMLParagraphElement;
@@ -170,7 +173,8 @@ function updateAuthSections(authProfile: AssistantAuthProfile | null): void {
   cloudStatus.style.display = showCloud ? '' : 'none';
   btnCloudSignIn.style.display = showCloud ? '' : 'none';
 
-  // Hide the Troubleshooting heading when no controls are shown.
+  // Hide the Troubleshooting divider and heading when no controls are shown.
+  troubleshootingDivider.style.display = showLocal || showCloud ? '' : 'none';
   troubleshootingLabel.style.display = showLocal || showCloud ? '' : 'none';
 }
 

--- a/clients/chrome-extension/popup/popup.ts
+++ b/clients/chrome-extension/popup/popup.ts
@@ -58,6 +58,10 @@ const cloudStatus = document.getElementById('cloud-status') as HTMLParagraphElem
 const btnPairLocal = document.getElementById('btn-pair-local') as HTMLButtonElement;
 const localStatus = document.getElementById('local-status') as HTMLParagraphElement;
 
+const troubleshootingLabel = document.getElementById(
+  'troubleshooting-label',
+) as HTMLParagraphElement;
+
 const assistantSelectorGroup = document.getElementById(
   'assistant-selector-group',
 ) as HTMLDivElement;
@@ -165,6 +169,9 @@ function updateAuthSections(authProfile: AssistantAuthProfile | null): void {
   // Toggle Cloud troubleshooting elements visibility.
   cloudStatus.style.display = showCloud ? '' : 'none';
   btnCloudSignIn.style.display = showCloud ? '' : 'none';
+
+  // Hide the Troubleshooting heading when no controls are shown.
+  troubleshootingLabel.style.display = showLocal || showCloud ? '' : 'none';
 }
 
 /**
@@ -262,12 +269,18 @@ btnConnect.addEventListener('click', async () => {
   errorText.style.display = 'none';
   setPhase('connecting');
 
-  if (portInput.value.trim()) {
-    storageUpdate.relayPort = port;
-  } else {
-    await chrome.storage.local.remove('relayPort');
+  try {
+    if (portInput.value.trim()) {
+      storageUpdate.relayPort = port;
+    } else {
+      await chrome.storage.local.remove('relayPort');
+    }
+    await chrome.storage.local.set(storageUpdate);
+  } catch (err) {
+    showError(err instanceof Error ? err.message : String(err));
+    setPhase('disconnected');
+    return;
   }
-  await chrome.storage.local.set(storageUpdate);
 
   chrome.runtime.sendMessage({ type: 'connect' }, (response: { ok: boolean; error?: string }) => {
     if (chrome.runtime.lastError || !response?.ok) {


### PR DESCRIPTION
## Summary
- Make Connect the only primary CTA, remove pre-pairing gate
- Change Disconnect label to Pause in popup UI
- Always send connect with interactive=true so worker handles bootstrap
- Add popup-state.ts helpers and tests for CTA copy/enablement transitions

Part of plan: one-click-connect-pause-autoconnect.md (PR 3 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24789" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
