### PR TITLE
feat(skills): use SkillFileProvider chain for all-origin uninstalled skill preview

### DIFF
--- a/assistant/src/__tests__/skills-file-content-endpoint.test.ts
+++ b/assistant/src/__tests__/skills-file-content-endpoint.test.ts
@@ -6,17 +6,17 @@
  *   - Installed skill, traversal path → 400 "Invalid path".
  *   - Installed skill, missing file → 404 "File not found".
  *   - Installed skill with missing on-disk directory → 404 "Skill directory
- *     missing" without consulting the catalog fallback.
- *   - Uninstalled catalog skill → delegates to `readCatalogSkillFileContent`
- *     and returns its payload; null result → 404.
+ *     missing" without consulting the provider chain fallback.
+ *   - Uninstalled vellum catalog skill → vellum provider returns content.
+ *   - Uninstalled skills.sh skill → skills.sh provider returns content.
+ *   - Uninstalled clawhub skill → clawhub provider returns content.
  *   - Skill not found anywhere → 404.
  *   - Hidden / SKIP_DIRS path segments → rejected with 400 before touching
- *     either the installed-skill disk read or the catalog fallback.
+ *     either the installed-skill disk read or the provider chain fallback.
  *
  * The test exercises the daemon handler directly — route wiring is a thin
- * pass-through to this function. The catalog-files module is mocked so the
- * handler's wiring is exercised in isolation; the helper's own dev-mode /
- * platform-mode behavior is covered in `catalog-files.test.ts`.
+ * pass-through to this function. The provider modules are mocked so the
+ * handler's wiring is exercised in isolation.
  */
 
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
@@ -25,8 +25,9 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { SkillSummary } from "../config/skills.js";
+import type { SlimSkillResponse } from "../daemon/message-types/skills.js";
 import type { SkillFileEntry } from "../skills/catalog-files.js";
-import type { CatalogSkill } from "../skills/catalog-install.js";
+import type { SkillFileProvider } from "../skills/skill-file-provider.js";
 
 // ---------------------------------------------------------------------------
 // Mocks — must be declared before importing the module under test
@@ -56,19 +57,39 @@ let mockResolvedSkills: Array<{
   summary: SkillSummary;
   state: "enabled" | "disabled";
 }> = [];
-let mockCatalog: CatalogSkill[] = [];
-// Ordered log of `readCatalogSkillFileContent` invocations so individual
-// tests can assert that the catalog-fallback helper was (or was not)
-// consulted. Mirrors the `catalogFilesCalls` array pattern used in
-// `skills-files-catalog-fallback.test.ts` for `readCatalogSkillFiles`.
-const catalogFileContentCalls: Array<{ skillId: string; path: string }> = [];
-// Per-test override for the catalog fallback helper. When set, the
-// `catalog-files.js` mock's `readCatalogSkillFileContent` delegates to
-// this function, letting tests return canned payloads without touching
-// disk or the network.
-let mockCatalogFileContentResponder:
-  | ((skillId: string, path: string) => Promise<SkillFileEntry | null>)
-  | null = null;
+
+// Per-provider mock state
+let mockVellumProvider: SkillFileProvider;
+let mockSkillsshProvider: SkillFileProvider;
+let mockClawhubProvider: SkillFileProvider;
+
+// Track provider calls
+const providerReadCalls: Array<{
+  provider: string;
+  skillId: string;
+  path: string;
+}> = [];
+
+function makeNoopProvider(name: string): SkillFileProvider {
+  return {
+    canHandle(): boolean {
+      return false;
+    },
+    async listFiles(): Promise<SkillFileEntry[] | null> {
+      return null;
+    },
+    async readFileContent(
+      skillId: string,
+      path: string,
+    ): Promise<SkillFileEntry | null> {
+      providerReadCalls.push({ provider: name, skillId, path });
+      return null;
+    },
+    async toSlimSkill(): Promise<SlimSkillResponse | null> {
+      return null;
+    },
+  };
+}
 
 mock.module("../config/skills.js", () => ({
   loadSkillCatalog: () => mockResolvedSkills.map((r) => r.summary),
@@ -91,22 +112,11 @@ mock.module("../config/assistant-feature-flags.js", () => ({
 }));
 
 mock.module("../skills/catalog-cache.js", () => ({
-  getCatalog: async () => mockCatalog,
+  getCatalog: async () => [],
 }));
 
-// The `catalog-files.js` mock replaces `readCatalogSkillFileContent` with
-// a spy wrapper that logs invocations and delegates to a per-test
-// responder. Other exports (`sanitizeRelativePath`,
-// `hasHiddenOrSkippedSegment`, `SKIP_DIRS`, `readCatalogSkillFiles`) are
-// re-implemented inline from the production module so the handler's
-// path-validation code still runs against equivalent logic without
-// recursing back through the mocked module.
-//
-// The spy gives the new "installed skill directory missing" regression
-// test a way to assert that the catalog fallback helper is NOT consulted
-// when `findSkillById` resolves a ghost install — mirroring the
-// `catalogFilesCalls.length === 0` assertion in
-// `skills-files-catalog-fallback.test.ts`.
+// The `catalog-files.js` mock — provides path validation functions inline
+// and delegates provider creation to mock state.
 const INLINE_SKIP_DIRS = new Set(["node_modules", "__pycache__", ".git"]);
 
 function inlineSanitizeRelativePath(rawPath: string): string | null {
@@ -119,7 +129,6 @@ function inlineSanitizeRelativePath(rawPath: string): string | null {
     candidate = candidate.slice(2);
   }
   if (candidate.length === 0) return null;
-  // posix.normalize without the node import: collapse segments manually.
   const segments: string[] = [];
   for (const seg of candidate.split("/")) {
     if (seg === "" || seg === ".") continue;
@@ -150,15 +159,21 @@ mock.module("../skills/catalog-files.js", () => ({
   SKIP_DIRS: INLINE_SKIP_DIRS,
   sanitizeRelativePath: inlineSanitizeRelativePath,
   hasHiddenOrSkippedSegment: inlineHasHiddenOrSkippedSegment,
+  catalogSkillToSlim: () => ({}),
+  createVellumCatalogProvider: () => mockVellumProvider,
   readCatalogSkillFiles: async () => null,
-  readCatalogSkillFileContent: async (skillId: string, path: string) => {
-    catalogFileContentCalls.push({ skillId, path });
-    if (mockCatalogFileContentResponder) {
-      return mockCatalogFileContentResponder(skillId, path);
-    }
-    return null;
-  },
+  readCatalogSkillFileContent: async () => null,
 }));
+
+mock.module("../skills/skillssh-files.js", () => ({
+  createSkillsShProvider: () => mockSkillsshProvider,
+}));
+
+mock.module("../skills/clawhub-files.js", () => ({
+  createClawhubProvider: () => mockClawhubProvider,
+}));
+
+mock.module("../skills/skill-file-provider.js", () => ({}));
 
 mock.module("../skills/catalog-install.js", () => ({
   installSkillLocally: async () => {},
@@ -298,10 +313,6 @@ function installedSkill(id: string, directoryPath: string) {
   };
 }
 
-function catalogSkill(id: string): CatalogSkill {
-  return { id, name: id, description: id };
-}
-
 // ---------------------------------------------------------------------------
 // Setup / teardown
 // ---------------------------------------------------------------------------
@@ -309,10 +320,11 @@ function catalogSkill(id: string): CatalogSkill {
 beforeEach(() => {
   originalFetch = globalThis.fetch;
   mockResolvedSkills = [];
-  mockCatalog = [];
   mockPlatformBaseUrl = "https://platform.test";
-  catalogFileContentCalls.length = 0;
-  mockCatalogFileContentResponder = null;
+  providerReadCalls.length = 0;
+  mockVellumProvider = makeNoopProvider("vellum");
+  mockSkillsshProvider = makeNoopProvider("skillssh");
+  mockClawhubProvider = makeNoopProvider("clawhub");
 });
 
 afterEach(() => {
@@ -412,31 +424,27 @@ describe("getSkillFileContent — installed skill", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Catalog fallback — helper invocation
+// Provider chain fallback — uninstalled skill content
 // ---------------------------------------------------------------------------
-//
-// The daemon handler delegates to `readCatalogSkillFileContent` for any
-// skill id that is not resolved locally but is present in the platform
-// catalog. The helper's own dev-mode / platform-mode behavior is covered
-// in detail in `catalog-files.test.ts`; these tests assert the handler
-// wiring: the helper is invoked with the sanitized path, and the
-// helper's result is returned on the response shape.
 
-describe("getSkillFileContent — uninstalled catalog skill", () => {
-  test("delegates to readCatalogSkillFileContent and returns the helper payload", async () => {
-    // Skill is NOT in the installed catalog, but IS in the platform catalog.
+describe("getSkillFileContent — uninstalled skill (provider chain)", () => {
+  test("delegates to vellum provider and returns the payload", async () => {
     mockResolvedSkills = [];
-    mockCatalog = [catalogSkill("remote-skill")];
     installFetchForbidden();
 
-    mockCatalogFileContentResponder = async (_skillId, path) => ({
-      path,
-      name: "SKILL.md",
-      size: 14,
-      mimeType: "text/markdown",
-      isBinary: false,
-      content: "# hello world\n",
-    });
+    mockVellumProvider = {
+      canHandle: () => true,
+      listFiles: async () => null,
+      readFileContent: async (_skillId, path) => ({
+        path,
+        name: "SKILL.md",
+        size: 14,
+        mimeType: "text/markdown",
+        isBinary: false,
+        content: "# hello world\n",
+      }),
+      toSlimSkill: async () => null,
+    };
 
     const result = await getSkillFileContent(
       "remote-skill",
@@ -451,33 +459,86 @@ describe("getSkillFileContent — uninstalled catalog skill", () => {
     expect(result.mimeType).toBe("text/markdown");
     expect(result.isBinary).toBe(false);
     expect(result.content).toBe("# hello world\n");
-
-    expect(catalogFileContentCalls).toEqual([
-      { skillId: "remote-skill", path: "SKILL.md" },
-    ]);
   });
 
-  test("returns 404 when readCatalogSkillFileContent resolves to null", async () => {
-    // Catalog helper returns null for a missing or unreadable file —
-    // daemon handler translates that to 404 "File not found".
+  test("returns 404 when all providers return null", async () => {
     mockResolvedSkills = [];
-    mockCatalog = [catalogSkill("remote-skill")];
     installFetchForbidden();
 
-    mockCatalogFileContentResponder = async () => null;
+    // All providers return canHandle=false (default noop)
 
     const result = await getSkillFileContent(
-      "remote-skill",
-      "missing.md",
+      "ghost-skill",
+      "SKILL.md",
       dummyCtx,
     );
     expect("error" in result).toBe(true);
     if (!("error" in result)) return;
     expect(result.status).toBe(404);
-    expect(result.error).toBe("File not found");
-    expect(catalogFileContentCalls).toEqual([
-      { skillId: "remote-skill", path: "missing.md" },
-    ]);
+    expect(result.error).toBe("Skill not found");
+  });
+
+  test("skills.sh content fallback", async () => {
+    mockResolvedSkills = [];
+    installFetchForbidden();
+
+    // Vellum doesn't handle
+    mockVellumProvider = makeNoopProvider("vellum");
+
+    // skills.sh handles and returns content
+    mockSkillsshProvider = {
+      canHandle: (id: string) => id.split("/").length >= 3,
+      listFiles: async () => null,
+      readFileContent: async (_skillId, path) => ({
+        path,
+        name: "SKILL.md",
+        size: 20,
+        mimeType: "text/markdown",
+        isBinary: false,
+        content: "# skillssh content\n",
+      }),
+      toSlimSkill: async () => null,
+    };
+
+    const result = await getSkillFileContent(
+      "owner/repo/my-skill",
+      "SKILL.md",
+      dummyCtx,
+    );
+    expect("error" in result).toBe(false);
+    if ("error" in result) return;
+    expect(result.content).toBe("# skillssh content\n");
+    expect(result.path).toBe("SKILL.md");
+  });
+
+  test("clawhub content fallback", async () => {
+    mockResolvedSkills = [];
+    installFetchForbidden();
+
+    // Vellum and skills.sh don't handle
+    mockVellumProvider = makeNoopProvider("vellum");
+    mockSkillsshProvider = makeNoopProvider("skillssh");
+
+    // Clawhub handles and returns content
+    mockClawhubProvider = {
+      canHandle: () => true,
+      listFiles: async () => null,
+      readFileContent: async (_skillId, path) => ({
+        path,
+        name: "SKILL.md",
+        size: 22,
+        mimeType: "text/markdown",
+        isBinary: false,
+        content: "# clawhub content yo\n",
+      }),
+      toSlimSkill: async () => null,
+    };
+
+    const result = await getSkillFileContent("cool-tool", "SKILL.md", dummyCtx);
+    expect("error" in result).toBe(false);
+    if ("error" in result) return;
+    expect(result.content).toBe("# clawhub content yo\n");
+    expect(result.path).toBe("SKILL.md");
   });
 });
 
@@ -486,9 +547,8 @@ describe("getSkillFileContent — uninstalled catalog skill", () => {
 // ---------------------------------------------------------------------------
 
 describe("getSkillFileContent — skill not found", () => {
-  test("returns 404 when the skill is neither installed nor in the catalog", async () => {
+  test("returns 404 when the skill is neither installed nor handled by any provider", async () => {
     mockResolvedSkills = [];
-    mockCatalog = [];
     installFetchForbidden();
 
     const result = await getSkillFileContent(
@@ -506,38 +566,30 @@ describe("getSkillFileContent — skill not found", () => {
 // ---------------------------------------------------------------------------
 // Installed skill with missing directory (ghost install)
 // ---------------------------------------------------------------------------
-//
-// When `findSkillById` resolves a skill as installed but the on-disk
-// directory has disappeared (corrupted install, mid-delete race,
-// external unmount), the handler must return a distinct 404 "Skill
-// directory missing" instead of falling through to the catalog path.
-// Falling through would flip the content response to a catalog payload
-// even though `listSkillsWithCatalog` still classifies the same id as
-// `kind: "installed"`, breaking the `isInstalled` contract between the
-// listing and content responses. Mirrors the same fix on
-// `getSkillFiles` verified by
-// `skills-files-catalog-fallback.test.ts`.
 
 describe("getSkillFileContent — installed skill with missing directory", () => {
-  test("returns 404 without consulting the catalog when the installed dir is gone", async () => {
+  test("returns 404 without consulting providers when the installed dir is gone", async () => {
     mockResolvedSkills = [
       installedSkill(
         "ghost-installed",
         "/tmp/definitely-does-not-exist-" + Date.now(),
       ),
     ];
-    // Even if the same id is present in the catalog, the handler must NOT
-    // fall through. Prime both the catalog and a responder that would
-    // return a successful payload to prove the short-circuit is active.
-    mockCatalog = [catalogSkill("ghost-installed")];
-    mockCatalogFileContentResponder = async () => ({
-      path: "SKILL.md",
-      name: "SKILL.md",
-      size: 10,
-      mimeType: "text/markdown",
-      isBinary: false,
-      content: "# from catalog\n",
-    });
+    // Even if a provider would return content, the handler must NOT
+    // fall through.
+    mockVellumProvider = {
+      canHandle: () => true,
+      listFiles: async () => null,
+      readFileContent: async () => ({
+        path: "SKILL.md",
+        name: "SKILL.md",
+        size: 10,
+        mimeType: "text/markdown",
+        isBinary: false,
+        content: "# from provider\n",
+      }),
+      toSlimSkill: async () => null,
+    };
     installFetchForbidden();
 
     const result = await getSkillFileContent(
@@ -551,27 +603,17 @@ describe("getSkillFileContent — installed skill with missing directory", () =>
     expect(result.status).toBe(404);
     expect(result.error).toContain("ghost-installed");
     expect(result.error).toContain("directory missing");
-    // Catalog fallback must not have been consulted.
-    expect(catalogFileContentCalls).toEqual([]);
+    // Provider chain must not have been consulted.
+    expect(providerReadCalls).toEqual([]);
   });
 });
 
 // ---------------------------------------------------------------------------
 // Hidden / SKIP_DIRS path rejection
 // ---------------------------------------------------------------------------
-//
-// The daemon handler rejects paths containing dotfile segments (`.env`,
-// `.git/`) or SKIP_DIRS segments (`node_modules`, `__pycache__`) with a
-// 400 "Invalid path" BEFORE any disk read or network round-trip, matching
-// the file-listing endpoint that hides these entries. This applies
-// regardless of whether the skill is installed locally or only available
-// via the catalog.
 
 describe("getSkillFileContent — hidden / SKIP_DIRS rejection", () => {
   test("rejects dotfile reads from an installed skill with 400 Invalid path", async () => {
-    // Set up an installed skill where a real `.env` file exists on disk.
-    // Without the hidden-segment rejection, the handler would happily
-    // read its content because sanitizeRelativePath accepts `.env`.
     const skillDir = makeTempSkillDir("leaky-skill");
     writeFile(skillDir, "SKILL.md", "# ok\n");
     writeFile(skillDir, ".env", "SECRET=abc\n");
@@ -585,37 +627,33 @@ describe("getSkillFileContent — hidden / SKIP_DIRS rejection", () => {
     expect(result.error).toBe("Invalid path");
   });
 
-  test("rejects dotfile reads for an uninstalled catalog skill before any catalog read", async () => {
-    // Same dotfile attack, but the skill id is NOT installed — only
-    // present in the Vellum catalog. The rejection must run in the daemon
-    // handler BEFORE the catalog fallback, so the catalog helper should
-    // never be consulted. We prime the responder with content that WOULD
-    // succeed to prove that even though the fallback path would return a
-    // payload, the daemon short-circuits first.
+  test("rejects dotfile reads for an uninstalled skill before any provider read", async () => {
     mockResolvedSkills = []; // not installed
-    mockCatalog = [catalogSkill("catalog-leaky")];
     installFetchForbidden();
-    mockCatalogFileContentResponder = async () => ({
-      path: ".env",
-      name: ".env",
-      size: 12,
-      mimeType: "text/plain",
-      isBinary: false,
-      content: "SECRET=xyz\n",
-    });
+    mockVellumProvider = {
+      canHandle: () => true,
+      listFiles: async () => null,
+      readFileContent: async () => ({
+        path: ".env",
+        name: ".env",
+        size: 12,
+        mimeType: "text/plain",
+        isBinary: false,
+        content: "SECRET=xyz\n",
+      }),
+      toSlimSkill: async () => null,
+    };
 
     const result = await getSkillFileContent("catalog-leaky", ".env", dummyCtx);
     expect("error" in result).toBe(true);
     if (!("error" in result)) return;
     expect(result.status).toBe(400);
     expect(result.error).toBe("Invalid path");
-    // The hidden-segment check must run before the catalog helper.
-    expect(catalogFileContentCalls).toEqual([]);
+    // The hidden-segment check must run before the provider chain.
+    expect(providerReadCalls).toEqual([]);
   });
 
   test("rejects paths whose parent directory is a dotfile segment", async () => {
-    // `.git/config` and `docs/.hidden/file.md` both contain hidden
-    // segments even though the leaf isn't a dotfile.
     const skillDir = makeTempSkillDir("my-skill");
     writeFile(skillDir, "SKILL.md", "# ok\n");
     mockResolvedSkills = [installedSkill("my-skill", skillDir)];
@@ -650,8 +688,6 @@ describe("getSkillFileContent — hidden / SKIP_DIRS rejection", () => {
   });
 
   test("regular SKILL.md still reads successfully (sanity)", async () => {
-    // Guards against collateral damage from the hidden/SKIP_DIRS filter:
-    // a normal, non-hidden path must continue to work unchanged.
     const skillDir = makeTempSkillDir("healthy-skill");
     writeFile(skillDir, "SKILL.md", "# hello\n");
     mockResolvedSkills = [installedSkill("healthy-skill", skillDir)];

--- a/assistant/src/__tests__/skills-files-catalog-fallback.test.ts
+++ b/assistant/src/__tests__/skills-files-catalog-fallback.test.ts
@@ -1,21 +1,24 @@
 /**
- * Tests for `getSkillFiles` catalog fallback.
+ * Tests for `getSkillFiles` provider chain fallback.
  *
  * When a skill id isn't resolvable via `findSkillById` (i.e. not installed
  * locally, not bundled, not a managed skill), `getSkillFiles` falls back to
- * the Vellum catalog via `readCatalogSkillFiles`. Catalog fallback entries
- * carry `content: null` because the catalog-files helper defers content
- * fetching to a follow-up per-file endpoint. When a skill IS resolved by
+ * the provider chain (vellum catalog → skills.sh → clawhub). Each provider
+ * is tried in order until one returns data. When a skill IS resolved by
  * `findSkillById` but its on-disk directory is missing, `getSkillFiles`
- * returns a 404 without falling through to the catalog so the listing and
- * detail responses agree on `isInstalled`.
+ * returns a 404 without falling through to the provider chain so the
+ * listing and detail responses agree on `isInstalled`.
  *
  * Coverage:
  *   - Uninstalled catalog skill: returns `{ skill: catalog/vellum/available, files }` with `content: null` for every entry.
- *   - Neither installed nor in catalog: returns 404.
+ *   - Neither installed nor handled by any provider: returns 404.
  *   - Installed skill: preserves the disk-read behavior with inline `content`.
- *   - Installed skill with missing directory: returns 404 without consulting the catalog.
+ *   - Installed skill with missing directory: returns 404 without consulting providers.
  *   - `catalogSkillToSlim` mapping: `metadata.vellum["display-name"]` wins over `cs.name`.
+ *   - skills.sh-shaped ID not in vellum catalog returns files from skills.sh provider.
+ *   - clawhub-shaped ID not in vellum catalog returns files from clawhub provider.
+ *   - ID that no provider handles returns 404.
+ *   - Provider priority: vellum provider is tried before skills.sh/clawhub.
  */
 
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
@@ -24,8 +27,9 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { SkillSummary } from "../config/skills.js";
+import type { SlimSkillResponse } from "../daemon/message-types/skills.js";
 import type { SkillFileEntry } from "../skills/catalog-files.js";
-import type { CatalogSkill } from "../skills/catalog-install.js";
+import type { SkillFileProvider } from "../skills/skill-file-provider.js";
 
 // ---------------------------------------------------------------------------
 // Mock state — mutated by individual tests via reset helpers below
@@ -37,9 +41,45 @@ type ResolvedSkillEntry = {
 };
 
 let mockResolvedStates: ResolvedSkillEntry[] = [];
-let mockCatalog: CatalogSkill[] = [];
-let mockCatalogFiles: SkillFileEntry[] | null = null;
-const catalogFilesCalls: string[] = [];
+
+// Per-provider mock state
+let mockVellumProvider: SkillFileProvider;
+let mockSkillsshProvider: SkillFileProvider;
+let mockClawhubProvider: SkillFileProvider;
+
+// Track which providers were consulted
+const providerCalls: Array<{
+  provider: string;
+  method: string;
+  skillId: string;
+}> = [];
+
+function makeNoopProvider(name: string): SkillFileProvider {
+  return {
+    canHandle(_skillId: string): boolean {
+      return false;
+    },
+    async listFiles(skillId: string): Promise<SkillFileEntry[] | null> {
+      providerCalls.push({ provider: name, method: "listFiles", skillId });
+      return null;
+    },
+    async readFileContent(
+      skillId: string,
+      _path: string,
+    ): Promise<SkillFileEntry | null> {
+      providerCalls.push({
+        provider: name,
+        method: "readFileContent",
+        skillId,
+      });
+      return null;
+    },
+    async toSlimSkill(skillId: string): Promise<SlimSkillResponse | null> {
+      providerCalls.push({ provider: name, method: "toSlimSkill", skillId });
+      return null;
+    },
+  };
+}
 
 // ---------------------------------------------------------------------------
 // Module mocks — must be declared before importing the module under test
@@ -77,15 +117,28 @@ mock.module("../skills/install-meta.js", () => ({
 }));
 
 mock.module("../skills/catalog-cache.js", () => ({
-  getCatalog: async () => mockCatalog,
+  getCatalog: async () => [],
 }));
 
 mock.module("../skills/catalog-files.js", () => ({
-  readCatalogSkillFiles: async (skillId: string) => {
-    catalogFilesCalls.push(skillId);
-    return mockCatalogFiles;
-  },
+  catalogSkillToSlim: () => ({}),
+  createVellumCatalogProvider: () => mockVellumProvider,
+  hasHiddenOrSkippedSegment: () => false,
+  readCatalogSkillFiles: async () => null,
+  readCatalogSkillFileContent: async () => null,
+  sanitizeRelativePath: (p: string) => p,
+  SKIP_DIRS: new Set(["node_modules", "__pycache__", ".git"]),
 }));
+
+mock.module("../skills/skillssh-files.js", () => ({
+  createSkillsShProvider: () => mockSkillsshProvider,
+}));
+
+mock.module("../skills/clawhub-files.js", () => ({
+  createClawhubProvider: () => mockClawhubProvider,
+}));
+
+mock.module("../skills/skill-file-provider.js", () => ({}));
 
 mock.module("../skills/catalog-install.js", () => ({
   installSkillLocally: async () => {},
@@ -194,25 +247,17 @@ function makeSummary(overrides: Partial<SkillSummary>): SkillSummary {
 // Tests
 // ---------------------------------------------------------------------------
 
-describe("getSkillFiles — catalog fallback", () => {
+describe("getSkillFiles — provider chain fallback", () => {
   beforeEach(() => {
     mockResolvedStates = [];
-    mockCatalog = [];
-    mockCatalogFiles = null;
-    catalogFilesCalls.length = 0;
+    providerCalls.length = 0;
+    mockVellumProvider = makeNoopProvider("vellum");
+    mockSkillsshProvider = makeNoopProvider("skillssh");
+    mockClawhubProvider = makeNoopProvider("clawhub");
   });
 
-  test("returns catalog skill with files (content: null) when skill is uninstalled but present in catalog", async () => {
-    mockCatalog = [
-      {
-        id: "acme-seo",
-        name: "acme-seo",
-        description: "SEO helper",
-        emoji: "\u{1F50D}",
-        metadata: { vellum: { "display-name": "Acme SEO" } },
-      },
-    ];
-    mockCatalogFiles = [
+  test("returns catalog skill with files (content: null) when skill is uninstalled but present in vellum catalog", async () => {
+    const mockFiles: SkillFileEntry[] = [
       {
         path: "SKILL.md",
         name: "SKILL.md",
@@ -230,6 +275,21 @@ describe("getSkillFiles — catalog fallback", () => {
         content: null,
       },
     ];
+
+    mockVellumProvider = {
+      canHandle: () => true,
+      listFiles: async () => mockFiles,
+      readFileContent: async () => null,
+      toSlimSkill: async () => ({
+        id: "acme-seo",
+        name: "Acme SEO",
+        description: "SEO helper",
+        emoji: "\u{1F50D}",
+        kind: "catalog",
+        origin: "vellum",
+        status: "available",
+      }),
+    };
 
     const result = await getSkillFiles("acme-seo", dummyCtx);
 
@@ -249,20 +309,17 @@ describe("getSkillFiles — catalog fallback", () => {
     for (const entry of result.files) {
       expect(entry.content).toBeNull();
     }
-    // Files should be sorted by path via localeCompare (not codepoint) —
-    // so "assets/logo.png" sorts before "SKILL.md" under default collation.
+    // Files should be sorted by path via localeCompare
     expect(result.files.map((f) => f.path)).toEqual(
       [...result.files.map((f) => f.path)].sort((a, b) => a.localeCompare(b)),
     );
     expect(new Set(result.files.map((f) => f.path))).toEqual(
       new Set(["SKILL.md", "assets/logo.png"]),
     );
-    expect(catalogFilesCalls).toEqual(["acme-seo"]);
   });
 
-  test("returns 404 when skill is neither installed nor in the catalog", async () => {
+  test("returns 404 when skill is neither installed nor handled by any provider", async () => {
     mockResolvedStates = [];
-    mockCatalog = [];
 
     const result = await getSkillFiles("ghost-skill", dummyCtx);
 
@@ -270,18 +327,15 @@ describe("getSkillFiles — catalog fallback", () => {
     if (!("error" in result)) return;
     expect(result.status).toBe(404);
     expect(result.error).toContain("ghost-skill");
-    expect(catalogFilesCalls).toEqual([]);
   });
 
-  test("returns 404 when skill is in catalog but readCatalogSkillFiles returns null", async () => {
-    mockCatalog = [
-      {
-        id: "broken-skill",
-        name: "broken-skill",
-        description: "",
-      },
-    ];
-    mockCatalogFiles = null;
+  test("returns 404 when vellum provider canHandle returns true but listFiles returns null", async () => {
+    mockVellumProvider = {
+      canHandle: () => true,
+      listFiles: async () => null,
+      readFileContent: async () => null,
+      toSlimSkill: async () => null,
+    };
 
     const result = await getSkillFiles("broken-skill", dummyCtx);
 
@@ -291,7 +345,7 @@ describe("getSkillFiles — catalog fallback", () => {
     expect(result.error).toContain("broken-skill");
   });
 
-  test("installed skill returns inline disk content (no catalog call)", async () => {
+  test("installed skill returns inline disk content (no provider fallback)", async () => {
     // Create a real temp directory for the installed-skill path to read.
     const workspaceRoot = mkdtempSync(
       join(tmpdir(), "vellum-skill-files-test-"),
@@ -327,9 +381,6 @@ describe("getSkillFiles — catalog fallback", () => {
       expect("error" in result).toBe(false);
       if ("error" in result) return;
 
-      // Catalog fallback should NOT have been consulted for an installed skill.
-      expect(catalogFilesCalls).toEqual([]);
-
       expect(result.files).toHaveLength(2);
       const skillMd = result.files.find((f) => f.path === "SKILL.md");
       const notes = result.files.find((f) => f.path === "notes.txt");
@@ -349,14 +400,7 @@ describe("getSkillFiles — catalog fallback", () => {
     }
   });
 
-  test("returns 404 without catalog fallback when installed skill directory is missing on disk", async () => {
-    // `findSkillById` resolves the skill (resolver lists it as installed)
-    // but the on-disk directoryPath does not exist — simulates a corrupted
-    // install, mid-delete race, or external unmount. The handler must
-    // return 404 so the listing response (`kind: "installed"`) and the
-    // detail response stay consistent; falling through to the catalog
-    // would flip the detail to `kind: "catalog"` and break the
-    // client-side `isInstalled` contract.
+  test("returns 404 without provider fallback when installed skill directory is missing on disk", async () => {
     mockResolvedStates = [
       {
         summary: makeSummary({
@@ -370,26 +414,30 @@ describe("getSkillFiles — catalog fallback", () => {
         state: "enabled",
       },
     ];
-    // Even if the same id is present in the catalog, the handler must NOT
-    // fall through — return 404 instead to avoid masking the missing
-    // install directory with a catalog response.
-    mockCatalog = [
-      {
+    // Even if a provider would handle this id, the handler must NOT
+    // fall through — return 404 instead.
+    mockVellumProvider = {
+      canHandle: () => true,
+      listFiles: async () => [
+        {
+          path: "SKILL.md",
+          name: "SKILL.md",
+          size: 10,
+          mimeType: "",
+          isBinary: false,
+          content: null,
+        },
+      ],
+      readFileContent: async () => null,
+      toSlimSkill: async () => ({
         id: "ghost-installed",
-        name: "ghost-installed",
-        description: "Also present in catalog",
-      },
-    ];
-    mockCatalogFiles = [
-      {
-        path: "SKILL.md",
-        name: "SKILL.md",
-        size: 10,
-        mimeType: "",
-        isBinary: false,
-        content: null,
-      },
-    ];
+        name: "Ghost",
+        description: "",
+        kind: "catalog",
+        origin: "vellum",
+        status: "available",
+      }),
+    };
 
     const result = await getSkillFiles("ghost-installed", dummyCtx);
 
@@ -398,19 +446,22 @@ describe("getSkillFiles — catalog fallback", () => {
     expect(result.status).toBe(404);
     expect(result.error).toContain("ghost-installed");
     expect(result.error).toContain("directory missing");
-    // Catalog fallback must not have been consulted.
-    expect(catalogFilesCalls).toEqual([]);
   });
 
   test("catalogSkillToSlim falls back to cs.name when metadata.vellum.display-name is absent", async () => {
-    mockCatalog = [
-      {
+    mockVellumProvider = {
+      canHandle: () => true,
+      listFiles: async () => [],
+      readFileContent: async () => null,
+      toSlimSkill: async () => ({
         id: "plain-skill",
         name: "plain-skill",
         description: "Minimal",
-      },
-    ];
-    mockCatalogFiles = [];
+        kind: "catalog",
+        origin: "vellum",
+        status: "available",
+      }),
+    };
 
     const result = await getSkillFiles("plain-skill", dummyCtx);
 
@@ -423,21 +474,228 @@ describe("getSkillFiles — catalog fallback", () => {
   });
 
   test("catalogSkillToSlim prefers metadata.vellum.display-name over cs.name", async () => {
-    mockCatalog = [
-      {
+    mockVellumProvider = {
+      canHandle: () => true,
+      listFiles: async () => [],
+      readFileContent: async () => null,
+      toSlimSkill: async () => ({
         id: "fancy-skill",
-        name: "raw-fancy-name",
+        name: "Pretty Fancy Name",
         description: "",
-        metadata: { vellum: { "display-name": "Pretty Fancy Name" } },
-      },
-    ];
-    mockCatalogFiles = [];
+        kind: "catalog",
+        origin: "vellum",
+        status: "available",
+      }),
+    };
 
     const result = await getSkillFiles("fancy-skill", dummyCtx);
 
     expect("error" in result).toBe(false);
     if ("error" in result) return;
     expect(result.skill.name).toBe("Pretty Fancy Name");
+  });
+
+  test("skills.sh-shaped ID not in vellum catalog returns files from skills.sh provider", async () => {
+    // Vellum provider doesn't handle this ID
+    mockVellumProvider = {
+      canHandle: () => false,
+      listFiles: async () => null,
+      readFileContent: async () => null,
+      toSlimSkill: async () => null,
+    };
+
+    const skillsshFiles: SkillFileEntry[] = [
+      {
+        path: "SKILL.md",
+        name: "SKILL.md",
+        size: 100,
+        mimeType: "",
+        isBinary: false,
+        content: null,
+      },
+    ];
+    mockSkillsshProvider = {
+      canHandle: (id: string) => id.split("/").length >= 3,
+      listFiles: async () => skillsshFiles,
+      readFileContent: async () => null,
+      toSlimSkill: async (id: string) => ({
+        id,
+        name: "my-skill",
+        description: "",
+        kind: "catalog",
+        origin: "skillssh",
+        status: "available",
+        slug: id,
+        sourceRepo: "owner/repo",
+        installs: 0,
+      }),
+    };
+
+    const result = await getSkillFiles("owner/repo/my-skill", dummyCtx);
+
+    expect("error" in result).toBe(false);
+    if ("error" in result) return;
+    expect(result.skill.origin).toBe("skillssh");
+    expect(result.files).toHaveLength(1);
+    expect(result.files[0].path).toBe("SKILL.md");
+  });
+
+  test("clawhub-shaped ID not in vellum catalog returns files from clawhub provider", async () => {
+    // Vellum and skills.sh providers don't handle this ID
+    mockVellumProvider = {
+      canHandle: () => false,
+      listFiles: async () => null,
+      readFileContent: async () => null,
+      toSlimSkill: async () => null,
+    };
+    mockSkillsshProvider = {
+      canHandle: () => false,
+      listFiles: async () => null,
+      readFileContent: async () => null,
+      toSlimSkill: async () => null,
+    };
+
+    const clawhubFiles: SkillFileEntry[] = [
+      {
+        path: "SKILL.md",
+        name: "SKILL.md",
+        size: 200,
+        mimeType: "",
+        isBinary: false,
+        content: null,
+      },
+      {
+        path: "lib/utils.js",
+        name: "utils.js",
+        size: 500,
+        mimeType: "",
+        isBinary: false,
+        content: null,
+      },
+    ];
+    mockClawhubProvider = {
+      canHandle: () => true,
+      listFiles: async () => clawhubFiles,
+      readFileContent: async () => null,
+      toSlimSkill: async () => ({
+        id: "cool-tool",
+        name: "Cool Tool",
+        description: "A clawhub skill",
+        kind: "catalog",
+        origin: "clawhub",
+        status: "available",
+        slug: "cool-tool",
+        author: "someone",
+        stars: 5,
+        installs: 10,
+        reports: 0,
+      }),
+    };
+
+    const result = await getSkillFiles("cool-tool", dummyCtx);
+
+    expect("error" in result).toBe(false);
+    if ("error" in result) return;
+    expect(result.skill.origin).toBe("clawhub");
+    expect(result.files).toHaveLength(2);
+  });
+
+  test("ID that no provider handles returns 404", async () => {
+    // All providers return canHandle=false
+    mockVellumProvider = makeNoopProvider("vellum");
+    mockSkillsshProvider = makeNoopProvider("skillssh");
+    mockClawhubProvider = makeNoopProvider("clawhub");
+
+    const result = await getSkillFiles("unknown-origin-skill", dummyCtx);
+
+    expect("error" in result).toBe(true);
+    if (!("error" in result)) return;
+    expect(result.status).toBe(404);
+  });
+
+  test("provider priority — vellum provider is tried before skills.sh and clawhub", async () => {
+    // All three providers claim to handle this ID, but vellum should win
+    const vellumListFilesCalls: string[] = [];
+    const skillsshListFilesCalls: string[] = [];
+    const clawhubListFilesCalls: string[] = [];
+
+    mockVellumProvider = {
+      canHandle: () => true,
+      listFiles: async (skillId: string) => {
+        vellumListFilesCalls.push(skillId);
+        return [
+          {
+            path: "SKILL.md",
+            name: "SKILL.md",
+            size: 10,
+            mimeType: "",
+            isBinary: false,
+            content: null,
+          },
+        ];
+      },
+      readFileContent: async () => null,
+      toSlimSkill: async () => ({
+        id: "contested-skill",
+        name: "Vellum Contested",
+        description: "",
+        kind: "catalog",
+        origin: "vellum",
+        status: "available",
+      }),
+    };
+    mockSkillsshProvider = {
+      canHandle: () => true,
+      listFiles: async (skillId: string) => {
+        skillsshListFilesCalls.push(skillId);
+        return [];
+      },
+      readFileContent: async () => null,
+      toSlimSkill: async () => ({
+        id: "contested-skill",
+        name: "Skillssh Contested",
+        description: "",
+        kind: "catalog",
+        origin: "skillssh",
+        status: "available",
+        slug: "contested-skill",
+        sourceRepo: "",
+        installs: 0,
+      }),
+    };
+    mockClawhubProvider = {
+      canHandle: () => true,
+      listFiles: async (skillId: string) => {
+        clawhubListFilesCalls.push(skillId);
+        return [];
+      },
+      readFileContent: async () => null,
+      toSlimSkill: async () => ({
+        id: "contested-skill",
+        name: "Clawhub Contested",
+        description: "",
+        kind: "catalog",
+        origin: "clawhub",
+        status: "available",
+        slug: "contested-skill",
+        author: "",
+        stars: 0,
+        installs: 0,
+        reports: 0,
+      }),
+    };
+
+    const result = await getSkillFiles("contested-skill", dummyCtx);
+
+    expect("error" in result).toBe(false);
+    if ("error" in result) return;
+    // Vellum provider should have been used
+    expect(result.skill.origin).toBe("vellum");
+    expect(result.skill.name).toBe("Vellum Contested");
+    // Vellum was called, but skills.sh and clawhub were NOT called
+    expect(vellumListFilesCalls).toEqual(["contested-skill"]);
+    expect(skillsshListFilesCalls).toEqual([]);
+    expect(clawhubListFilesCalls).toEqual([]);
   });
 });
 

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -38,9 +38,8 @@ import {
 import { getCatalog } from "../../skills/catalog-cache.js";
 import {
   catalogSkillToSlim,
+  createVellumCatalogProvider,
   hasHiddenOrSkippedSegment,
-  readCatalogSkillFileContent,
-  readCatalogSkillFiles,
   sanitizeRelativePath,
   type SkillFileEntry,
   SKIP_DIRS,
@@ -59,6 +58,7 @@ import {
   clawhubSearch,
   clawhubUpdate,
 } from "../../skills/clawhub.js";
+import { createClawhubProvider } from "../../skills/clawhub-files.js";
 import {
   readInstallMeta,
   type SkillInstallMeta,
@@ -69,6 +69,8 @@ import {
   removeSkillsIndexEntry,
   validateManagedSkillId,
 } from "../../skills/managed-store.js";
+import type { SkillFileProvider } from "../../skills/skill-file-provider.js";
+import { createSkillsShProvider } from "../../skills/skillssh-files.js";
 import {
   installExternalSkill,
   resolveSkillSource,
@@ -99,6 +101,44 @@ export interface SkillOperationContext {
   setSuppressConfigReload(value: boolean): void;
   updateConfigFingerprint(): void;
   broadcast: HandlerContext["broadcast"];
+}
+
+// ─── Provider chain for uninstalled skill file preview ───────────────────────
+// Ordered by priority: vellum first (most common and cheapest to check),
+// then skills.sh, then clawhub.
+
+const fileProviders: SkillFileProvider[] = [
+  createVellumCatalogProvider(),
+  createSkillsShProvider(),
+  createClawhubProvider(),
+];
+
+async function resolveSkillFiles(skillId: string): Promise<{
+  skill: SlimSkillResponse;
+  files: SkillFileEntry[];
+} | null> {
+  for (const provider of fileProviders) {
+    if (!provider.canHandle(skillId)) continue;
+    const files = await provider.listFiles(skillId);
+    if (files === null) continue;
+    const skill = await provider.toSlimSkill(skillId);
+    if (skill === null) continue;
+    files.sort((a, b) => a.path.localeCompare(b.path));
+    return { skill, files };
+  }
+  return null;
+}
+
+async function resolveSkillFileContent(
+  skillId: string,
+  sanitizedPath: string,
+): Promise<SkillFileEntry | null> {
+  for (const provider of fileProviders) {
+    if (!provider.canHandle(skillId)) continue;
+    const result = await provider.readFileContent(skillId, sanitizedPath);
+    if (result !== null) return result;
+  }
+  return null;
 }
 
 // ─── Frontmatter parsing ─────────────────────────────────────────────────────
@@ -421,6 +461,14 @@ export async function getSkill(
 ): Promise<{ skill: SkillDetailResponse } | { error: string; status: number }> {
   const found = findSkillById(skillId);
   if (!found) {
+    // Fallback: skill is not installed. Try all file providers.
+    for (const provider of fileProviders) {
+      if (!provider.canHandle(skillId)) continue;
+      const slim = await provider.toSlimSkill(skillId);
+      if (slim) {
+        return { skill: slim as SkillDetailResponse };
+      }
+    }
     return { error: `Skill "${skillId}" not found`, status: 404 };
   }
 
@@ -567,16 +615,15 @@ function readDirRecursive(dir: string, rootDir: string): SkillFileEntry[] {
 }
 
 /**
- * Read a single file's content from an installed or catalog skill.
+ * Read a single file's content from an installed or uninstalled skill.
  *
  * Installed-skill path (eager): reads the file directly from the skill's
  * on-disk directory. Applies lexical containment, symlink rejection, and
  * realpath containment checks for defense in depth.
  *
- * Catalog fallback: when the skill id is not backed by a local directory
- * (e.g. an uninstalled Vellum catalog skill), delegates to
- * `readCatalogSkillFileContent`, which handles both the dev-mode repo
- * checkout path and the platform preview API path internally.
+ * Provider chain fallback: when the skill id is not backed by a local
+ * directory, iterates the `fileProviders` chain (vellum catalog,
+ * skills.sh, clawhub) until one returns content.
  */
 export async function getSkillFileContent(
   skillId: string,
@@ -683,32 +730,19 @@ export async function getSkillFileContent(
     };
   }
 
-  // Catalog fallback: skill is not installed locally. Try the catalog
-  // preview helper, which handles both dev-mode repo checkouts and the
-  // platform preview API.
-  let catalog: Awaited<ReturnType<typeof getCatalog>> = [];
-  try {
-    catalog = await getCatalog();
-  } catch {
-    catalog = [];
+  // Fallback: skill is not installed. Try all file providers.
+  const result = await resolveSkillFileContent(skillId, sanitized);
+  if (result) {
+    return {
+      path: result.path,
+      name: result.name,
+      size: result.size,
+      mimeType: result.mimeType,
+      isBinary: result.isBinary,
+      content: result.content,
+    };
   }
-  const inCatalog = catalog.some((s) => s.id === skillId);
-  if (!inCatalog) {
-    return { error: "Skill not found", status: 404 };
-  }
-
-  const result = await readCatalogSkillFileContent(skillId, sanitized);
-  if (!result) {
-    return { error: "File not found", status: 404 };
-  }
-  return {
-    path: result.path,
-    name: result.name,
-    size: result.size,
-    mimeType: result.mimeType,
-    isBinary: result.isBinary,
-    content: result.content,
-  };
+  return { error: "Skill not found", status: 404 };
 }
 
 export async function getSkillFiles(
@@ -740,31 +774,10 @@ export async function getSkillFiles(
     };
   }
 
-  // Fallback: skill is not installed. Try the Vellum catalog — this covers
-  // previewing files for an uninstalled catalog skill without touching the
-  // install flow.
-  let catalog: CatalogSkill[];
-  try {
-    catalog = await getCatalog();
-  } catch {
-    return { error: `Skill "${skillId}" not found`, status: 404 };
-  }
-  const cs = catalog.find((c) => c.id === skillId);
-  if (!cs) {
-    return { error: `Skill "${skillId}" not found`, status: 404 };
-  }
-
-  const files = await readCatalogSkillFiles(skillId);
-  if (files === null) {
-    return {
-      error: `Skill files unavailable for "${skillId}"`,
-      status: 404,
-    };
-  }
-
-  const skill = catalogSkillToSlim(cs);
-  files.sort((a, b) => a.path.localeCompare(b.path));
-  return { skill, files };
+  // Fallback: skill is not installed. Try all file providers.
+  const resolved = await resolveSkillFiles(skillId);
+  if (resolved) return resolved;
+  return { error: `Skill "${skillId}" not found`, status: 404 };
 }
 
 export function enableSkill(


### PR DESCRIPTION
## Summary
- Replace hard-coded vellum-only catalog fallback with a provider chain (vellum → skills.sh → clawhub)
- Wire getSkillFiles, getSkillFileContent, and getSkill to use the unified provider chain
- Handler code is now origin-agnostic — new origins only need a new provider module

Part of plan: skillssh-file-preview.md (PR 4 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24790" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
