### PR TITLE
feat(skills): unified file preview for all origins (vellum, skills.sh, clawhub)

### DIFF
--- a/assistant/src/__tests__/catalog-files.test.ts
+++ b/assistant/src/__tests__/catalog-files.test.ts
@@ -45,6 +45,7 @@ let mockRepoSkillsDir: string | undefined = undefined;
 
 mock.module("../skills/catalog-cache.js", () => ({
   getCatalog: async () => mockCatalog,
+  getCachedCatalogSync: () => mockCatalog,
 }));
 
 mock.module("../skills/catalog-install.js", () => ({
@@ -72,6 +73,8 @@ mock.module("../config/env.js", () => ({
 // ---------------------------------------------------------------------------
 
 import {
+  catalogSkillToSlim,
+  createVellumCatalogProvider,
   readCatalogSkillFileContent,
   readCatalogSkillFiles,
   sanitizeRelativePath,
@@ -858,5 +861,140 @@ describe("readCatalogSkillFileContent (platform mode)", () => {
     installFetchForbidden();
     expect(await readCatalogSkillFileContent("unknown", "SKILL.md")).toBeNull();
     expect(fetchCalls.length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// catalogSkillToSlim
+// ---------------------------------------------------------------------------
+
+describe("catalogSkillToSlim", () => {
+  test("maps CatalogSkill to SlimSkillResponse with vellum origin", () => {
+    const cs: CatalogSkill = {
+      id: "test-skill",
+      name: "test-skill",
+      description: "A test skill",
+      emoji: "🧪",
+    };
+    const slim = catalogSkillToSlim(cs);
+    expect(slim.id).toBe("test-skill");
+    expect(slim.name).toBe("test-skill");
+    expect(slim.description).toBe("A test skill");
+    expect(slim.emoji).toBe("🧪");
+    expect(slim.kind).toBe("catalog");
+    expect(slim.origin).toBe("vellum");
+    expect(slim.status).toBe("available");
+  });
+
+  test("uses display-name from metadata when available", () => {
+    const cs: CatalogSkill = {
+      id: "test-skill",
+      name: "test-skill",
+      description: "A test skill",
+      metadata: { vellum: { "display-name": "Pretty Name" } },
+    };
+    const slim = catalogSkillToSlim(cs);
+    expect(slim.name).toBe("Pretty Name");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createVellumCatalogProvider
+// ---------------------------------------------------------------------------
+
+describe("createVellumCatalogProvider", () => {
+  test("canHandle returns true when skill is in the cached catalog", () => {
+    mockCatalog = [skill("my-skill"), skill("other-skill")];
+    const provider = createVellumCatalogProvider();
+    expect(provider.canHandle("my-skill")).toBe(true);
+    expect(provider.canHandle("other-skill")).toBe(true);
+  });
+
+  test("canHandle returns false when skill is NOT in the cached catalog", () => {
+    mockCatalog = [skill("my-skill")];
+    const provider = createVellumCatalogProvider();
+    expect(provider.canHandle("unknown-skill")).toBe(false);
+  });
+
+  test("canHandle returns false when catalog cache is empty", () => {
+    mockCatalog = [];
+    const provider = createVellumCatalogProvider();
+    expect(provider.canHandle("any-skill")).toBe(false);
+  });
+
+  test("listFiles delegates to readCatalogSkillFiles", async () => {
+    const root = makeTempSkillsDir();
+    writeSkill(root, "my-skill", {
+      "SKILL.md": "# hello",
+      "tools/run.sh": "#!/bin/sh\necho hi\n",
+    });
+    mockRepoSkillsDir = root;
+    mockCatalog = [skill("my-skill")];
+    installFetchForbidden();
+
+    const provider = createVellumCatalogProvider();
+    const entries = await provider.listFiles("my-skill");
+    expect(entries).not.toBeNull();
+    const paths = entries!.map((e) => e.path).sort();
+    expect(paths).toEqual(["SKILL.md", "tools/run.sh"]);
+  });
+
+  test("listFiles returns null for unknown skill", async () => {
+    mockCatalog = [];
+    installFetchForbidden();
+
+    const provider = createVellumCatalogProvider();
+    expect(await provider.listFiles("unknown")).toBeNull();
+  });
+
+  test("readFileContent delegates to readCatalogSkillFileContent", async () => {
+    const root = makeTempSkillsDir();
+    writeSkill(root, "my-skill", { "SKILL.md": "# hello world\n" });
+    mockRepoSkillsDir = root;
+    mockCatalog = [skill("my-skill")];
+    installFetchForbidden();
+
+    const provider = createVellumCatalogProvider();
+    const entry = await provider.readFileContent("my-skill", "SKILL.md");
+    expect(entry).not.toBeNull();
+    expect(entry!.content).toBe("# hello world\n");
+    expect(entry!.path).toBe("SKILL.md");
+  });
+
+  test("readFileContent returns null for unknown skill", async () => {
+    mockCatalog = [];
+    installFetchForbidden();
+
+    const provider = createVellumCatalogProvider();
+    expect(await provider.readFileContent("unknown", "SKILL.md")).toBeNull();
+  });
+
+  test("toSlimSkill returns SlimSkillResponse for catalog skill", async () => {
+    mockCatalog = [
+      {
+        id: "my-skill",
+        name: "my-skill",
+        description: "A skill",
+        emoji: "🔧",
+        metadata: { vellum: { "display-name": "My Skill" } },
+      },
+    ];
+
+    const provider = createVellumCatalogProvider();
+    const slim = await provider.toSlimSkill("my-skill");
+    expect(slim).not.toBeNull();
+    expect(slim!.id).toBe("my-skill");
+    expect(slim!.name).toBe("My Skill");
+    expect(slim!.description).toBe("A skill");
+    expect(slim!.kind).toBe("catalog");
+    expect(slim!.origin).toBe("vellum");
+    expect(slim!.status).toBe("available");
+  });
+
+  test("toSlimSkill returns null for unknown skill", async () => {
+    mockCatalog = [];
+
+    const provider = createVellumCatalogProvider();
+    expect(await provider.toSlimSkill("unknown")).toBeNull();
   });
 });

--- a/assistant/src/__tests__/clawhub-files.test.ts
+++ b/assistant/src/__tests__/clawhub-files.test.ts
@@ -1,0 +1,328 @@
+/**
+ * Unit tests for `skills/clawhub-files.ts` — SkillFileProvider implementation
+ * for clawhub-origin skills.
+ *
+ * Covers:
+ *   - canHandle correctly distinguishes clawhub from skills.sh slugs
+ *   - listFiles maps inspect result files to SkillFileEntry[]
+ *   - listFiles returns null when inspect fails
+ *   - readFileContent returns cached SKILL.md content without extra CLI call
+ *   - readFileContent calls clawhubInspectFile for non-SKILL.md files
+ *   - toSlimSkill maps inspect metadata to ClawhubSlimSkill
+ *   - Cache hit avoids redundant inspect calls
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { ClawhubInspectResult } from "../skills/clawhub.js";
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before importing the module under test
+// ---------------------------------------------------------------------------
+
+// Suppress logger output
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+let mockInspectResult: { data?: ClawhubInspectResult; error?: string } = {};
+let inspectCallCount = 0;
+let mockInspectFileResult: string | null = null;
+let inspectFileCallCount = 0;
+let inspectFileCalls: Array<{ slug: string; filePath: string }> = [];
+
+mock.module("../skills/clawhub.js", () => ({
+  validateSlug: (slug: string): boolean => {
+    return /^[a-zA-Z0-9]([a-zA-Z0-9._-]*(\/[a-zA-Z0-9][a-zA-Z0-9._-]*)?)?$/.test(
+      slug,
+    );
+  },
+  clawhubInspect: async (
+    _slug: string,
+  ): Promise<{ data?: ClawhubInspectResult; error?: string }> => {
+    inspectCallCount++;
+    return mockInspectResult;
+  },
+  clawhubInspectFile: async (
+    slug: string,
+    filePath: string,
+  ): Promise<string | null> => {
+    inspectFileCallCount++;
+    inspectFileCalls.push({ slug, filePath });
+    return mockInspectFileResult;
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Imports (after mocks)
+// ---------------------------------------------------------------------------
+
+import { createClawhubProvider } from "../skills/clawhub-files.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// The inspect cache is module-scoped in clawhub-files.ts and persists across
+// tests. To avoid cross-test contamination, each test that calls async
+// provider methods uses a UNIQUE slug so cache entries never collide.
+let slugCounter = 0;
+function uniqueSlug(base = "test-skill"): string {
+  return `${base}-${++slugCounter}`;
+}
+
+function makeInspectData(
+  slug: string,
+  overrides?: Partial<ClawhubInspectResult>,
+): ClawhubInspectResult {
+  return {
+    skill: { slug, displayName: "Test Skill", summary: "A test skill" },
+    owner: { handle: "testauthor", displayName: "Test Author" },
+    stats: { stars: 42, installs: 100, downloads: 200, versions: 3 },
+    createdAt: 1700000000000,
+    updatedAt: 1700100000000,
+    latestVersion: { version: "1.0.0" },
+    files: [
+      { path: "SKILL.md", size: 512, contentType: "text/markdown" },
+      { path: "tools/helper.ts", size: 1024, contentType: "text/typescript" },
+      { path: "assets/icon.png", size: 2048, contentType: "image/png" },
+    ],
+    skillMdContent: "# Test Skill\n\nThis is the SKILL.md content.",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Reset mock state between tests (cache is handled via unique slugs)
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  mockInspectResult = {};
+  inspectCallCount = 0;
+  mockInspectFileResult = null;
+  inspectFileCallCount = 0;
+  inspectFileCalls = [];
+});
+
+// ---------------------------------------------------------------------------
+// canHandle
+// ---------------------------------------------------------------------------
+
+describe("canHandle", () => {
+  const provider = createClawhubProvider();
+
+  test("returns true for simple slug", () => {
+    expect(provider.canHandle("my-skill")).toBe(true);
+  });
+
+  test("returns true for namespaced slug (author/skill)", () => {
+    expect(provider.canHandle("author/my-skill")).toBe(true);
+  });
+
+  test("returns false for skills.sh slug (owner/repo/skill)", () => {
+    expect(provider.canHandle("a/b/c")).toBe(false);
+  });
+
+  test("returns false for deeply nested slug", () => {
+    expect(provider.canHandle("a/b/c/d")).toBe(false);
+  });
+
+  test("returns false for invalid slug", () => {
+    expect(provider.canHandle("")).toBe(false);
+  });
+
+  test("returns false for slug starting with dot", () => {
+    expect(provider.canHandle(".hidden")).toBe(false);
+  });
+
+  test("returns false for slug starting with hyphen", () => {
+    expect(provider.canHandle("-dashed")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listFiles
+// ---------------------------------------------------------------------------
+
+describe("listFiles", () => {
+  test("maps inspect result files to SkillFileEntry[]", async () => {
+    const provider = createClawhubProvider();
+    const slug = uniqueSlug("list-map");
+    mockInspectResult = { data: makeInspectData(slug) };
+
+    const entries = await provider.listFiles(slug);
+    expect(entries).not.toBeNull();
+    expect(entries!.length).toBe(3);
+
+    // Entries should be sorted by path
+    expect(entries![0].path).toBe("SKILL.md");
+    expect(entries![0].name).toBe("SKILL.md");
+    expect(entries![0].size).toBe(512);
+    expect(entries![0].isBinary).toBe(false);
+    expect(entries![0].content).toBeNull(); // content is null in listings
+
+    expect(entries![1].path).toBe("assets/icon.png");
+    expect(entries![1].isBinary).toBe(true);
+
+    expect(entries![2].path).toBe("tools/helper.ts");
+    expect(entries![2].isBinary).toBe(false);
+  });
+
+  test("returns null when inspect fails", async () => {
+    const provider = createClawhubProvider();
+    const slug = uniqueSlug("list-fail");
+    mockInspectResult = { error: "Skill not found" };
+
+    const entries = await provider.listFiles(slug);
+    expect(entries).toBeNull();
+  });
+
+  test("returns null when inspect returns no files", async () => {
+    const provider = createClawhubProvider();
+    const slug = uniqueSlug("list-nofiles");
+    mockInspectResult = { data: makeInspectData(slug, { files: null }) };
+
+    const entries = await provider.listFiles(slug);
+    expect(entries).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// readFileContent
+// ---------------------------------------------------------------------------
+
+describe("readFileContent", () => {
+  test("returns cached SKILL.md content without extra CLI call", async () => {
+    const provider = createClawhubProvider();
+    const slug = uniqueSlug("read-skillmd");
+    mockInspectResult = { data: makeInspectData(slug) };
+
+    // First call listFiles to populate the cache
+    await provider.listFiles(slug);
+    const initialCallCount = inspectCallCount;
+
+    // Now read SKILL.md — should use cached skillMdContent
+    const entry = await provider.readFileContent(slug, "SKILL.md");
+    expect(entry).not.toBeNull();
+    expect(entry!.path).toBe("SKILL.md");
+    expect(entry!.name).toBe("SKILL.md");
+    expect(entry!.content).toBe(
+      "# Test Skill\n\nThis is the SKILL.md content.",
+    );
+    expect(entry!.isBinary).toBe(false);
+    expect(entry!.mimeType).toBe("text/markdown");
+
+    // No additional inspect call and no inspectFile call
+    expect(inspectCallCount).toBe(initialCallCount);
+    expect(inspectFileCallCount).toBe(0);
+  });
+
+  test("calls clawhubInspectFile for non-SKILL.md files", async () => {
+    const provider = createClawhubProvider();
+    const slug = uniqueSlug("read-other");
+    mockInspectResult = { data: makeInspectData(slug) };
+    mockInspectFileResult = "export function helper() { return 42; }";
+
+    // Populate cache first
+    await provider.listFiles(slug);
+
+    const entry = await provider.readFileContent(slug, "tools/helper.ts");
+    expect(entry).not.toBeNull();
+    expect(entry!.path).toBe("tools/helper.ts");
+    expect(entry!.name).toBe("helper.ts");
+    expect(entry!.content).toBe("export function helper() { return 42; }");
+    expect(entry!.isBinary).toBe(false);
+
+    expect(inspectFileCallCount).toBe(1);
+    expect(inspectFileCalls[0].slug).toBe(slug);
+    expect(inspectFileCalls[0].filePath).toBe("tools/helper.ts");
+  });
+
+  test("returns null when clawhubInspectFile fails", async () => {
+    const provider = createClawhubProvider();
+    const slug = uniqueSlug("read-fail");
+    mockInspectResult = { data: makeInspectData(slug) };
+    mockInspectFileResult = null;
+
+    await provider.listFiles(slug);
+
+    const entry = await provider.readFileContent(slug, "tools/missing.ts");
+    expect(entry).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// toSlimSkill
+// ---------------------------------------------------------------------------
+
+describe("toSlimSkill", () => {
+  test("maps inspect metadata to ClawhubSlimSkill", async () => {
+    const provider = createClawhubProvider();
+    const slug = uniqueSlug("slim-map");
+    mockInspectResult = { data: makeInspectData(slug) };
+
+    const slim = await provider.toSlimSkill(slug);
+    expect(slim).not.toBeNull();
+    expect(slim!.id).toBe(slug);
+    expect(slim!.name).toBe("Test Skill");
+    expect(slim!.description).toBe("A test skill");
+    expect(slim!.kind).toBe("catalog");
+    expect(slim!.status).toBe("available");
+    expect(slim!.origin).toBe("clawhub");
+
+    // Clawhub-specific fields
+    const clawhub = slim as unknown as Record<string, unknown>;
+    expect(clawhub.slug).toBe(slug);
+    expect(clawhub.author).toBe("testauthor");
+    expect(clawhub.stars).toBe(42);
+    expect(clawhub.installs).toBe(100);
+    expect(clawhub.reports).toBe(0);
+  });
+
+  test("returns null when inspect fails", async () => {
+    const provider = createClawhubProvider();
+    const slug = uniqueSlug("slim-fail");
+    mockInspectResult = { error: "Not found" };
+
+    const slim = await provider.toSlimSkill(slug);
+    expect(slim).toBeNull();
+  });
+
+  test("handles missing owner gracefully", async () => {
+    const provider = createClawhubProvider();
+    const slug = uniqueSlug("slim-noowner");
+    mockInspectResult = { data: makeInspectData(slug, { owner: null }) };
+
+    const slim = await provider.toSlimSkill(slug);
+    expect(slim).not.toBeNull();
+    const clawhub = slim as unknown as Record<string, unknown>;
+    expect(clawhub.author).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cache behavior
+// ---------------------------------------------------------------------------
+
+describe("caching", () => {
+  test("cache hit avoids redundant inspect calls", async () => {
+    const provider = createClawhubProvider();
+    const slug = uniqueSlug("cache-test");
+    mockInspectResult = { data: makeInspectData(slug) };
+
+    // First call — should trigger inspect
+    await provider.listFiles(slug);
+    expect(inspectCallCount).toBe(1);
+
+    // Second call to toSlimSkill — should use cache
+    await provider.toSlimSkill(slug);
+    expect(inspectCallCount).toBe(1); // no additional call
+
+    // Third call to listFiles — still cached
+    await provider.listFiles(slug);
+    expect(inspectCallCount).toBe(1);
+  });
+});

--- a/assistant/src/__tests__/clawhub-files.test.ts
+++ b/assistant/src/__tests__/clawhub-files.test.ts
@@ -157,18 +157,20 @@ describe("listFiles", () => {
     expect(entries).not.toBeNull();
     expect(entries!.length).toBe(3);
 
-    // Entries should be sorted by path
-    expect(entries![0].path).toBe("SKILL.md");
-    expect(entries![0].name).toBe("SKILL.md");
-    expect(entries![0].size).toBe(512);
-    expect(entries![0].isBinary).toBe(false);
-    expect(entries![0].content).toBeNull(); // content is null in listings
+    // Entries should be sorted by path (localeCompare: lowercase before uppercase)
+    const paths = entries!.map((e) => e.path);
+    expect(paths).toEqual([...paths].sort((a, b) => a.localeCompare(b)));
 
-    expect(entries![1].path).toBe("assets/icon.png");
-    expect(entries![1].isBinary).toBe(true);
+    // Verify all entries are present with expected metadata
+    const byPath = Object.fromEntries(entries!.map((e) => [e.path, e]));
+    expect(byPath["SKILL.md"].name).toBe("SKILL.md");
+    expect(byPath["SKILL.md"].size).toBe(512);
+    expect(byPath["SKILL.md"].isBinary).toBe(false);
+    expect(byPath["SKILL.md"].content).toBeNull(); // content is null in listings
 
-    expect(entries![2].path).toBe("tools/helper.ts");
-    expect(entries![2].isBinary).toBe(false);
+    expect(byPath["assets/icon.png"].isBinary).toBe(true);
+
+    expect(byPath["tools/helper.ts"].isBinary).toBe(false);
   });
 
   test("returns null when inspect fails", async () => {
@@ -241,7 +243,7 @@ describe("readFileContent", () => {
     expect(inspectFileCalls[0].filePath).toBe("tools/helper.ts");
   });
 
-  test("returns null when clawhubInspectFile fails", async () => {
+  test("returns null when clawhubInspectFile fails for a text file", async () => {
     const provider = createClawhubProvider();
     const slug = uniqueSlug("read-fail");
     mockInspectResult = { data: makeInspectData(slug) };
@@ -251,6 +253,23 @@ describe("readFileContent", () => {
 
     const entry = await provider.readFileContent(slug, "tools/missing.ts");
     expect(entry).toBeNull();
+  });
+
+  test("returns SkillFileEntry with content: null for binary files", async () => {
+    const provider = createClawhubProvider();
+    const slug = uniqueSlug("read-binary");
+    mockInspectResult = { data: makeInspectData(slug) };
+    mockInspectFileResult = null; // clawhubInspectFile returns null for binaries
+
+    await provider.listFiles(slug);
+
+    const entry = await provider.readFileContent(slug, "assets/icon.png");
+    expect(entry).not.toBeNull();
+    expect(entry!.path).toBe("assets/icon.png");
+    expect(entry!.name).toBe("icon.png");
+    expect(entry!.isBinary).toBe(true);
+    expect(entry!.content).toBeNull();
+    expect(entry!.size).toBe(2048); // from the inspect data files array
   });
 });
 

--- a/assistant/src/__tests__/skills-file-content-endpoint.test.ts
+++ b/assistant/src/__tests__/skills-file-content-endpoint.test.ts
@@ -6,17 +6,17 @@
  *   - Installed skill, traversal path → 400 "Invalid path".
  *   - Installed skill, missing file → 404 "File not found".
  *   - Installed skill with missing on-disk directory → 404 "Skill directory
- *     missing" without consulting the catalog fallback.
- *   - Uninstalled catalog skill → delegates to `readCatalogSkillFileContent`
- *     and returns its payload; null result → 404.
+ *     missing" without consulting the provider chain fallback.
+ *   - Uninstalled vellum catalog skill → vellum provider returns content.
+ *   - Uninstalled skills.sh skill → skills.sh provider returns content.
+ *   - Uninstalled clawhub skill → clawhub provider returns content.
  *   - Skill not found anywhere → 404.
  *   - Hidden / SKIP_DIRS path segments → rejected with 400 before touching
- *     either the installed-skill disk read or the catalog fallback.
+ *     either the installed-skill disk read or the provider chain fallback.
  *
  * The test exercises the daemon handler directly — route wiring is a thin
- * pass-through to this function. The catalog-files module is mocked so the
- * handler's wiring is exercised in isolation; the helper's own dev-mode /
- * platform-mode behavior is covered in `catalog-files.test.ts`.
+ * pass-through to this function. The provider modules are mocked so the
+ * handler's wiring is exercised in isolation.
  */
 
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
@@ -25,8 +25,9 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { SkillSummary } from "../config/skills.js";
+import type { SlimSkillResponse } from "../daemon/message-types/skills.js";
 import type { SkillFileEntry } from "../skills/catalog-files.js";
-import type { CatalogSkill } from "../skills/catalog-install.js";
+import type { SkillFileProvider } from "../skills/skill-file-provider.js";
 
 // ---------------------------------------------------------------------------
 // Mocks — must be declared before importing the module under test
@@ -56,19 +57,39 @@ let mockResolvedSkills: Array<{
   summary: SkillSummary;
   state: "enabled" | "disabled";
 }> = [];
-let mockCatalog: CatalogSkill[] = [];
-// Ordered log of `readCatalogSkillFileContent` invocations so individual
-// tests can assert that the catalog-fallback helper was (or was not)
-// consulted. Mirrors the `catalogFilesCalls` array pattern used in
-// `skills-files-catalog-fallback.test.ts` for `readCatalogSkillFiles`.
-const catalogFileContentCalls: Array<{ skillId: string; path: string }> = [];
-// Per-test override for the catalog fallback helper. When set, the
-// `catalog-files.js` mock's `readCatalogSkillFileContent` delegates to
-// this function, letting tests return canned payloads without touching
-// disk or the network.
-let mockCatalogFileContentResponder:
-  | ((skillId: string, path: string) => Promise<SkillFileEntry | null>)
-  | null = null;
+
+// Per-provider mock state
+let mockVellumProvider: SkillFileProvider;
+let mockSkillsshProvider: SkillFileProvider;
+let mockClawhubProvider: SkillFileProvider;
+
+// Track provider calls
+const providerReadCalls: Array<{
+  provider: string;
+  skillId: string;
+  path: string;
+}> = [];
+
+function makeNoopProvider(name: string): SkillFileProvider {
+  return {
+    canHandle(): boolean {
+      return false;
+    },
+    async listFiles(): Promise<SkillFileEntry[] | null> {
+      return null;
+    },
+    async readFileContent(
+      skillId: string,
+      path: string,
+    ): Promise<SkillFileEntry | null> {
+      providerReadCalls.push({ provider: name, skillId, path });
+      return null;
+    },
+    async toSlimSkill(): Promise<SlimSkillResponse | null> {
+      return null;
+    },
+  };
+}
 
 mock.module("../config/skills.js", () => ({
   loadSkillCatalog: () => mockResolvedSkills.map((r) => r.summary),
@@ -91,22 +112,11 @@ mock.module("../config/assistant-feature-flags.js", () => ({
 }));
 
 mock.module("../skills/catalog-cache.js", () => ({
-  getCatalog: async () => mockCatalog,
+  getCatalog: async () => [],
 }));
 
-// The `catalog-files.js` mock replaces `readCatalogSkillFileContent` with
-// a spy wrapper that logs invocations and delegates to a per-test
-// responder. Other exports (`sanitizeRelativePath`,
-// `hasHiddenOrSkippedSegment`, `SKIP_DIRS`, `readCatalogSkillFiles`) are
-// re-implemented inline from the production module so the handler's
-// path-validation code still runs against equivalent logic without
-// recursing back through the mocked module.
-//
-// The spy gives the new "installed skill directory missing" regression
-// test a way to assert that the catalog fallback helper is NOT consulted
-// when `findSkillById` resolves a ghost install — mirroring the
-// `catalogFilesCalls.length === 0` assertion in
-// `skills-files-catalog-fallback.test.ts`.
+// The `catalog-files.js` mock — provides path validation functions inline
+// and delegates provider creation to mock state.
 const INLINE_SKIP_DIRS = new Set(["node_modules", "__pycache__", ".git"]);
 
 function inlineSanitizeRelativePath(rawPath: string): string | null {
@@ -119,7 +129,6 @@ function inlineSanitizeRelativePath(rawPath: string): string | null {
     candidate = candidate.slice(2);
   }
   if (candidate.length === 0) return null;
-  // posix.normalize without the node import: collapse segments manually.
   const segments: string[] = [];
   for (const seg of candidate.split("/")) {
     if (seg === "" || seg === ".") continue;
@@ -150,15 +159,21 @@ mock.module("../skills/catalog-files.js", () => ({
   SKIP_DIRS: INLINE_SKIP_DIRS,
   sanitizeRelativePath: inlineSanitizeRelativePath,
   hasHiddenOrSkippedSegment: inlineHasHiddenOrSkippedSegment,
+  catalogSkillToSlim: () => ({}),
+  createVellumCatalogProvider: () => mockVellumProvider,
   readCatalogSkillFiles: async () => null,
-  readCatalogSkillFileContent: async (skillId: string, path: string) => {
-    catalogFileContentCalls.push({ skillId, path });
-    if (mockCatalogFileContentResponder) {
-      return mockCatalogFileContentResponder(skillId, path);
-    }
-    return null;
-  },
+  readCatalogSkillFileContent: async () => null,
 }));
+
+mock.module("../skills/skillssh-files.js", () => ({
+  createSkillsShProvider: () => mockSkillsshProvider,
+}));
+
+mock.module("../skills/clawhub-files.js", () => ({
+  createClawhubProvider: () => mockClawhubProvider,
+}));
+
+mock.module("../skills/skill-file-provider.js", () => ({}));
 
 mock.module("../skills/catalog-install.js", () => ({
   installSkillLocally: async () => {},
@@ -298,10 +313,6 @@ function installedSkill(id: string, directoryPath: string) {
   };
 }
 
-function catalogSkill(id: string): CatalogSkill {
-  return { id, name: id, description: id };
-}
-
 // ---------------------------------------------------------------------------
 // Setup / teardown
 // ---------------------------------------------------------------------------
@@ -309,10 +320,11 @@ function catalogSkill(id: string): CatalogSkill {
 beforeEach(() => {
   originalFetch = globalThis.fetch;
   mockResolvedSkills = [];
-  mockCatalog = [];
   mockPlatformBaseUrl = "https://platform.test";
-  catalogFileContentCalls.length = 0;
-  mockCatalogFileContentResponder = null;
+  providerReadCalls.length = 0;
+  mockVellumProvider = makeNoopProvider("vellum");
+  mockSkillsshProvider = makeNoopProvider("skillssh");
+  mockClawhubProvider = makeNoopProvider("clawhub");
 });
 
 afterEach(() => {
@@ -412,31 +424,27 @@ describe("getSkillFileContent — installed skill", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Catalog fallback — helper invocation
+// Provider chain fallback — uninstalled skill content
 // ---------------------------------------------------------------------------
-//
-// The daemon handler delegates to `readCatalogSkillFileContent` for any
-// skill id that is not resolved locally but is present in the platform
-// catalog. The helper's own dev-mode / platform-mode behavior is covered
-// in detail in `catalog-files.test.ts`; these tests assert the handler
-// wiring: the helper is invoked with the sanitized path, and the
-// helper's result is returned on the response shape.
 
-describe("getSkillFileContent — uninstalled catalog skill", () => {
-  test("delegates to readCatalogSkillFileContent and returns the helper payload", async () => {
-    // Skill is NOT in the installed catalog, but IS in the platform catalog.
+describe("getSkillFileContent — uninstalled skill (provider chain)", () => {
+  test("delegates to vellum provider and returns the payload", async () => {
     mockResolvedSkills = [];
-    mockCatalog = [catalogSkill("remote-skill")];
     installFetchForbidden();
 
-    mockCatalogFileContentResponder = async (_skillId, path) => ({
-      path,
-      name: "SKILL.md",
-      size: 14,
-      mimeType: "text/markdown",
-      isBinary: false,
-      content: "# hello world\n",
-    });
+    mockVellumProvider = {
+      canHandle: () => true,
+      listFiles: async () => null,
+      readFileContent: async (_skillId, path) => ({
+        path,
+        name: "SKILL.md",
+        size: 14,
+        mimeType: "text/markdown",
+        isBinary: false,
+        content: "# hello world\n",
+      }),
+      toSlimSkill: async () => null,
+    };
 
     const result = await getSkillFileContent(
       "remote-skill",
@@ -451,33 +459,86 @@ describe("getSkillFileContent — uninstalled catalog skill", () => {
     expect(result.mimeType).toBe("text/markdown");
     expect(result.isBinary).toBe(false);
     expect(result.content).toBe("# hello world\n");
-
-    expect(catalogFileContentCalls).toEqual([
-      { skillId: "remote-skill", path: "SKILL.md" },
-    ]);
   });
 
-  test("returns 404 when readCatalogSkillFileContent resolves to null", async () => {
-    // Catalog helper returns null for a missing or unreadable file —
-    // daemon handler translates that to 404 "File not found".
+  test("returns 404 when all providers return null", async () => {
     mockResolvedSkills = [];
-    mockCatalog = [catalogSkill("remote-skill")];
     installFetchForbidden();
 
-    mockCatalogFileContentResponder = async () => null;
+    // All providers return canHandle=false (default noop)
 
     const result = await getSkillFileContent(
-      "remote-skill",
-      "missing.md",
+      "ghost-skill",
+      "SKILL.md",
       dummyCtx,
     );
     expect("error" in result).toBe(true);
     if (!("error" in result)) return;
     expect(result.status).toBe(404);
-    expect(result.error).toBe("File not found");
-    expect(catalogFileContentCalls).toEqual([
-      { skillId: "remote-skill", path: "missing.md" },
-    ]);
+    expect(result.error).toBe("Skill not found");
+  });
+
+  test("skills.sh content fallback", async () => {
+    mockResolvedSkills = [];
+    installFetchForbidden();
+
+    // Vellum doesn't handle
+    mockVellumProvider = makeNoopProvider("vellum");
+
+    // skills.sh handles and returns content
+    mockSkillsshProvider = {
+      canHandle: (id: string) => id.split("/").length >= 3,
+      listFiles: async () => null,
+      readFileContent: async (_skillId, path) => ({
+        path,
+        name: "SKILL.md",
+        size: 20,
+        mimeType: "text/markdown",
+        isBinary: false,
+        content: "# skillssh content\n",
+      }),
+      toSlimSkill: async () => null,
+    };
+
+    const result = await getSkillFileContent(
+      "owner/repo/my-skill",
+      "SKILL.md",
+      dummyCtx,
+    );
+    expect("error" in result).toBe(false);
+    if ("error" in result) return;
+    expect(result.content).toBe("# skillssh content\n");
+    expect(result.path).toBe("SKILL.md");
+  });
+
+  test("clawhub content fallback", async () => {
+    mockResolvedSkills = [];
+    installFetchForbidden();
+
+    // Vellum and skills.sh don't handle
+    mockVellumProvider = makeNoopProvider("vellum");
+    mockSkillsshProvider = makeNoopProvider("skillssh");
+
+    // Clawhub handles and returns content
+    mockClawhubProvider = {
+      canHandle: () => true,
+      listFiles: async () => null,
+      readFileContent: async (_skillId, path) => ({
+        path,
+        name: "SKILL.md",
+        size: 22,
+        mimeType: "text/markdown",
+        isBinary: false,
+        content: "# clawhub content yo\n",
+      }),
+      toSlimSkill: async () => null,
+    };
+
+    const result = await getSkillFileContent("cool-tool", "SKILL.md", dummyCtx);
+    expect("error" in result).toBe(false);
+    if ("error" in result) return;
+    expect(result.content).toBe("# clawhub content yo\n");
+    expect(result.path).toBe("SKILL.md");
   });
 });
 
@@ -486,9 +547,8 @@ describe("getSkillFileContent — uninstalled catalog skill", () => {
 // ---------------------------------------------------------------------------
 
 describe("getSkillFileContent — skill not found", () => {
-  test("returns 404 when the skill is neither installed nor in the catalog", async () => {
+  test("returns 404 when the skill is neither installed nor handled by any provider", async () => {
     mockResolvedSkills = [];
-    mockCatalog = [];
     installFetchForbidden();
 
     const result = await getSkillFileContent(
@@ -506,38 +566,30 @@ describe("getSkillFileContent — skill not found", () => {
 // ---------------------------------------------------------------------------
 // Installed skill with missing directory (ghost install)
 // ---------------------------------------------------------------------------
-//
-// When `findSkillById` resolves a skill as installed but the on-disk
-// directory has disappeared (corrupted install, mid-delete race,
-// external unmount), the handler must return a distinct 404 "Skill
-// directory missing" instead of falling through to the catalog path.
-// Falling through would flip the content response to a catalog payload
-// even though `listSkillsWithCatalog` still classifies the same id as
-// `kind: "installed"`, breaking the `isInstalled` contract between the
-// listing and content responses. Mirrors the same fix on
-// `getSkillFiles` verified by
-// `skills-files-catalog-fallback.test.ts`.
 
 describe("getSkillFileContent — installed skill with missing directory", () => {
-  test("returns 404 without consulting the catalog when the installed dir is gone", async () => {
+  test("returns 404 without consulting providers when the installed dir is gone", async () => {
     mockResolvedSkills = [
       installedSkill(
         "ghost-installed",
         "/tmp/definitely-does-not-exist-" + Date.now(),
       ),
     ];
-    // Even if the same id is present in the catalog, the handler must NOT
-    // fall through. Prime both the catalog and a responder that would
-    // return a successful payload to prove the short-circuit is active.
-    mockCatalog = [catalogSkill("ghost-installed")];
-    mockCatalogFileContentResponder = async () => ({
-      path: "SKILL.md",
-      name: "SKILL.md",
-      size: 10,
-      mimeType: "text/markdown",
-      isBinary: false,
-      content: "# from catalog\n",
-    });
+    // Even if a provider would return content, the handler must NOT
+    // fall through.
+    mockVellumProvider = {
+      canHandle: () => true,
+      listFiles: async () => null,
+      readFileContent: async () => ({
+        path: "SKILL.md",
+        name: "SKILL.md",
+        size: 10,
+        mimeType: "text/markdown",
+        isBinary: false,
+        content: "# from provider\n",
+      }),
+      toSlimSkill: async () => null,
+    };
     installFetchForbidden();
 
     const result = await getSkillFileContent(
@@ -551,27 +603,17 @@ describe("getSkillFileContent — installed skill with missing directory", () =>
     expect(result.status).toBe(404);
     expect(result.error).toContain("ghost-installed");
     expect(result.error).toContain("directory missing");
-    // Catalog fallback must not have been consulted.
-    expect(catalogFileContentCalls).toEqual([]);
+    // Provider chain must not have been consulted.
+    expect(providerReadCalls).toEqual([]);
   });
 });
 
 // ---------------------------------------------------------------------------
 // Hidden / SKIP_DIRS path rejection
 // ---------------------------------------------------------------------------
-//
-// The daemon handler rejects paths containing dotfile segments (`.env`,
-// `.git/`) or SKIP_DIRS segments (`node_modules`, `__pycache__`) with a
-// 400 "Invalid path" BEFORE any disk read or network round-trip, matching
-// the file-listing endpoint that hides these entries. This applies
-// regardless of whether the skill is installed locally or only available
-// via the catalog.
 
 describe("getSkillFileContent — hidden / SKIP_DIRS rejection", () => {
   test("rejects dotfile reads from an installed skill with 400 Invalid path", async () => {
-    // Set up an installed skill where a real `.env` file exists on disk.
-    // Without the hidden-segment rejection, the handler would happily
-    // read its content because sanitizeRelativePath accepts `.env`.
     const skillDir = makeTempSkillDir("leaky-skill");
     writeFile(skillDir, "SKILL.md", "# ok\n");
     writeFile(skillDir, ".env", "SECRET=abc\n");
@@ -585,37 +627,33 @@ describe("getSkillFileContent — hidden / SKIP_DIRS rejection", () => {
     expect(result.error).toBe("Invalid path");
   });
 
-  test("rejects dotfile reads for an uninstalled catalog skill before any catalog read", async () => {
-    // Same dotfile attack, but the skill id is NOT installed — only
-    // present in the Vellum catalog. The rejection must run in the daemon
-    // handler BEFORE the catalog fallback, so the catalog helper should
-    // never be consulted. We prime the responder with content that WOULD
-    // succeed to prove that even though the fallback path would return a
-    // payload, the daemon short-circuits first.
+  test("rejects dotfile reads for an uninstalled skill before any provider read", async () => {
     mockResolvedSkills = []; // not installed
-    mockCatalog = [catalogSkill("catalog-leaky")];
     installFetchForbidden();
-    mockCatalogFileContentResponder = async () => ({
-      path: ".env",
-      name: ".env",
-      size: 12,
-      mimeType: "text/plain",
-      isBinary: false,
-      content: "SECRET=xyz\n",
-    });
+    mockVellumProvider = {
+      canHandle: () => true,
+      listFiles: async () => null,
+      readFileContent: async () => ({
+        path: ".env",
+        name: ".env",
+        size: 12,
+        mimeType: "text/plain",
+        isBinary: false,
+        content: "SECRET=xyz\n",
+      }),
+      toSlimSkill: async () => null,
+    };
 
     const result = await getSkillFileContent("catalog-leaky", ".env", dummyCtx);
     expect("error" in result).toBe(true);
     if (!("error" in result)) return;
     expect(result.status).toBe(400);
     expect(result.error).toBe("Invalid path");
-    // The hidden-segment check must run before the catalog helper.
-    expect(catalogFileContentCalls).toEqual([]);
+    // The hidden-segment check must run before the provider chain.
+    expect(providerReadCalls).toEqual([]);
   });
 
   test("rejects paths whose parent directory is a dotfile segment", async () => {
-    // `.git/config` and `docs/.hidden/file.md` both contain hidden
-    // segments even though the leaf isn't a dotfile.
     const skillDir = makeTempSkillDir("my-skill");
     writeFile(skillDir, "SKILL.md", "# ok\n");
     mockResolvedSkills = [installedSkill("my-skill", skillDir)];
@@ -650,8 +688,6 @@ describe("getSkillFileContent — hidden / SKIP_DIRS rejection", () => {
   });
 
   test("regular SKILL.md still reads successfully (sanity)", async () => {
-    // Guards against collateral damage from the hidden/SKIP_DIRS filter:
-    // a normal, non-hidden path must continue to work unchanged.
     const skillDir = makeTempSkillDir("healthy-skill");
     writeFile(skillDir, "SKILL.md", "# hello\n");
     mockResolvedSkills = [installedSkill("healthy-skill", skillDir)];

--- a/assistant/src/__tests__/skills-file-content-endpoint.test.ts
+++ b/assistant/src/__tests__/skills-file-content-endpoint.test.ts
@@ -155,22 +155,44 @@ function inlineHasHiddenOrSkippedSegment(sanitized: string): boolean {
   return false;
 }
 
+// The provider factory functions are called once at module init and the
+// returned objects are captured in the `fileProviders` array. To allow
+// per-test mock reassignment, return proxy objects that delegate every
+// method call to the CURRENT value of the mutable mock variable.
 mock.module("../skills/catalog-files.js", () => ({
   SKIP_DIRS: INLINE_SKIP_DIRS,
   sanitizeRelativePath: inlineSanitizeRelativePath,
   hasHiddenOrSkippedSegment: inlineHasHiddenOrSkippedSegment,
   catalogSkillToSlim: () => ({}),
-  createVellumCatalogProvider: () => mockVellumProvider,
+  createVellumCatalogProvider: () => ({
+    canHandle: (id: string) => mockVellumProvider.canHandle(id),
+    listFiles: (id: string) => mockVellumProvider.listFiles(id),
+    readFileContent: (id: string, p: string) =>
+      mockVellumProvider.readFileContent(id, p),
+    toSlimSkill: (id: string) => mockVellumProvider.toSlimSkill(id),
+  }),
   readCatalogSkillFiles: async () => null,
   readCatalogSkillFileContent: async () => null,
 }));
 
 mock.module("../skills/skillssh-files.js", () => ({
-  createSkillsShProvider: () => mockSkillsshProvider,
+  createSkillsShProvider: () => ({
+    canHandle: (id: string) => mockSkillsshProvider.canHandle(id),
+    listFiles: (id: string) => mockSkillsshProvider.listFiles(id),
+    readFileContent: (id: string, p: string) =>
+      mockSkillsshProvider.readFileContent(id, p),
+    toSlimSkill: (id: string) => mockSkillsshProvider.toSlimSkill(id),
+  }),
 }));
 
 mock.module("../skills/clawhub-files.js", () => ({
-  createClawhubProvider: () => mockClawhubProvider,
+  createClawhubProvider: () => ({
+    canHandle: (id: string) => mockClawhubProvider.canHandle(id),
+    listFiles: (id: string) => mockClawhubProvider.listFiles(id),
+    readFileContent: (id: string, p: string) =>
+      mockClawhubProvider.readFileContent(id, p),
+    toSlimSkill: (id: string) => mockClawhubProvider.toSlimSkill(id),
+  }),
 }));
 
 mock.module("../skills/skill-file-provider.js", () => ({}));
@@ -259,7 +281,10 @@ mock.module("../daemon/handlers/shared.js", () => ({
 // ---------------------------------------------------------------------------
 
 import type { SkillOperationContext } from "../daemon/handlers/skills.js";
-import { getSkillFileContent } from "../daemon/handlers/skills.js";
+import {
+  _resetFileProvidersForTest,
+  getSkillFileContent,
+} from "../daemon/handlers/skills.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -325,6 +350,8 @@ beforeEach(() => {
   mockVellumProvider = makeNoopProvider("vellum");
   mockSkillsshProvider = makeNoopProvider("skillssh");
   mockClawhubProvider = makeNoopProvider("clawhub");
+  // Force provider chain re-creation from the (mocked) factory functions
+  _resetFileProvidersForTest();
 });
 
 afterEach(() => {
@@ -539,6 +566,74 @@ describe("getSkillFileContent — uninstalled skill (provider chain)", () => {
     if ("error" in result) return;
     expect(result.content).toBe("# clawhub content yo\n");
     expect(result.path).toBe("SKILL.md");
+  });
+
+  test("returns 'File not found' when provider canHandle returns true but readFileContent returns null", async () => {
+    mockResolvedSkills = [];
+    installFetchForbidden();
+
+    // Vellum provider claims this skill but returns null for the specific file
+    mockVellumProvider = {
+      canHandle: () => true,
+      listFiles: async () => null,
+      readFileContent: async () => null,
+      toSlimSkill: async () => null,
+    };
+
+    const result = await getSkillFileContent(
+      "known-skill",
+      "nonexistent.txt",
+      dummyCtx,
+    );
+    expect("error" in result).toBe(true);
+    if (!("error" in result)) return;
+    expect(result.status).toBe(404);
+    expect(result.error).toBe("File not found");
+  });
+
+  test("stop-on-first-match: does not try clawhub when vellum canHandle returns true", async () => {
+    mockResolvedSkills = [];
+    installFetchForbidden();
+
+    const clawhubReadCalls: string[] = [];
+
+    // Vellum provider claims the skill but returns null for file content
+    mockVellumProvider = {
+      canHandle: () => true,
+      listFiles: async () => null,
+      readFileContent: async () => null,
+      toSlimSkill: async () => null,
+    };
+
+    // Clawhub would return content if asked, but should NOT be consulted
+    mockClawhubProvider = {
+      canHandle: () => true,
+      listFiles: async () => null,
+      readFileContent: async (_skillId, path) => {
+        clawhubReadCalls.push(path);
+        return {
+          path,
+          name: "SKILL.md",
+          size: 10,
+          mimeType: "text/markdown",
+          isBinary: false,
+          content: "# from clawhub\n",
+        };
+      },
+      toSlimSkill: async () => null,
+    };
+
+    const result = await getSkillFileContent(
+      "simple-slug",
+      "SKILL.md",
+      dummyCtx,
+    );
+    // Should be "File not found" (vellum handled but returned null)
+    expect("error" in result).toBe(true);
+    if (!("error" in result)) return;
+    expect(result.error).toBe("File not found");
+    // Clawhub should NOT have been called
+    expect(clawhubReadCalls).toEqual([]);
   });
 });
 

--- a/assistant/src/__tests__/skills-files-catalog-fallback.test.ts
+++ b/assistant/src/__tests__/skills-files-catalog-fallback.test.ts
@@ -120,9 +120,19 @@ mock.module("../skills/catalog-cache.js", () => ({
   getCatalog: async () => [],
 }));
 
+// The provider factory functions are called once at module init and the
+// returned objects are captured in the `fileProviders` array. To allow
+// per-test mock reassignment, return proxy objects that delegate every
+// method call to the CURRENT value of the mutable mock variable.
 mock.module("../skills/catalog-files.js", () => ({
   catalogSkillToSlim: () => ({}),
-  createVellumCatalogProvider: () => mockVellumProvider,
+  createVellumCatalogProvider: () => ({
+    canHandle: (id: string) => mockVellumProvider.canHandle(id),
+    listFiles: (id: string) => mockVellumProvider.listFiles(id),
+    readFileContent: (id: string, p: string) =>
+      mockVellumProvider.readFileContent(id, p),
+    toSlimSkill: (id: string) => mockVellumProvider.toSlimSkill(id),
+  }),
   hasHiddenOrSkippedSegment: () => false,
   readCatalogSkillFiles: async () => null,
   readCatalogSkillFileContent: async () => null,
@@ -131,11 +141,23 @@ mock.module("../skills/catalog-files.js", () => ({
 }));
 
 mock.module("../skills/skillssh-files.js", () => ({
-  createSkillsShProvider: () => mockSkillsshProvider,
+  createSkillsShProvider: () => ({
+    canHandle: (id: string) => mockSkillsshProvider.canHandle(id),
+    listFiles: (id: string) => mockSkillsshProvider.listFiles(id),
+    readFileContent: (id: string, p: string) =>
+      mockSkillsshProvider.readFileContent(id, p),
+    toSlimSkill: (id: string) => mockSkillsshProvider.toSlimSkill(id),
+  }),
 }));
 
 mock.module("../skills/clawhub-files.js", () => ({
-  createClawhubProvider: () => mockClawhubProvider,
+  createClawhubProvider: () => ({
+    canHandle: (id: string) => mockClawhubProvider.canHandle(id),
+    listFiles: (id: string) => mockClawhubProvider.listFiles(id),
+    readFileContent: (id: string, p: string) =>
+      mockClawhubProvider.readFileContent(id, p),
+    toSlimSkill: (id: string) => mockClawhubProvider.toSlimSkill(id),
+  }),
 }));
 
 mock.module("../skills/skill-file-provider.js", () => ({}));
@@ -207,7 +229,10 @@ mock.module("../daemon/handlers/shared.js", () => ({
 // Import after mocks
 // ---------------------------------------------------------------------------
 
-import { getSkillFiles } from "../daemon/handlers/skills.js";
+import {
+  _resetFileProvidersForTest,
+  getSkillFiles,
+} from "../daemon/handlers/skills.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -254,6 +279,8 @@ describe("getSkillFiles — provider chain fallback", () => {
     mockVellumProvider = makeNoopProvider("vellum");
     mockSkillsshProvider = makeNoopProvider("skillssh");
     mockClawhubProvider = makeNoopProvider("clawhub");
+    // Force provider chain re-creation from the (mocked) factory functions
+    _resetFileProvidersForTest();
   });
 
   test("returns catalog skill with files (content: null) when skill is uninstalled but present in vellum catalog", async () => {
@@ -329,7 +356,7 @@ describe("getSkillFiles — provider chain fallback", () => {
     expect(result.error).toContain("ghost-skill");
   });
 
-  test("returns 404 when vellum provider canHandle returns true but listFiles returns null", async () => {
+  test("returns 404 with 'files unavailable' when vellum provider canHandle returns true but listFiles returns null", async () => {
     mockVellumProvider = {
       canHandle: () => true,
       listFiles: async () => null,
@@ -343,6 +370,7 @@ describe("getSkillFiles — provider chain fallback", () => {
     if (!("error" in result)) return;
     expect(result.status).toBe(404);
     expect(result.error).toContain("broken-skill");
+    expect(result.error).toContain("unavailable");
   });
 
   test("installed skill returns inline disk content (no provider fallback)", async () => {

--- a/assistant/src/__tests__/skills-files-catalog-fallback.test.ts
+++ b/assistant/src/__tests__/skills-files-catalog-fallback.test.ts
@@ -1,21 +1,24 @@
 /**
- * Tests for `getSkillFiles` catalog fallback.
+ * Tests for `getSkillFiles` provider chain fallback.
  *
  * When a skill id isn't resolvable via `findSkillById` (i.e. not installed
  * locally, not bundled, not a managed skill), `getSkillFiles` falls back to
- * the Vellum catalog via `readCatalogSkillFiles`. Catalog fallback entries
- * carry `content: null` because the catalog-files helper defers content
- * fetching to a follow-up per-file endpoint. When a skill IS resolved by
+ * the provider chain (vellum catalog → skills.sh → clawhub). Each provider
+ * is tried in order until one returns data. When a skill IS resolved by
  * `findSkillById` but its on-disk directory is missing, `getSkillFiles`
- * returns a 404 without falling through to the catalog so the listing and
- * detail responses agree on `isInstalled`.
+ * returns a 404 without falling through to the provider chain so the
+ * listing and detail responses agree on `isInstalled`.
  *
  * Coverage:
  *   - Uninstalled catalog skill: returns `{ skill: catalog/vellum/available, files }` with `content: null` for every entry.
- *   - Neither installed nor in catalog: returns 404.
+ *   - Neither installed nor handled by any provider: returns 404.
  *   - Installed skill: preserves the disk-read behavior with inline `content`.
- *   - Installed skill with missing directory: returns 404 without consulting the catalog.
+ *   - Installed skill with missing directory: returns 404 without consulting providers.
  *   - `catalogSkillToSlim` mapping: `metadata.vellum["display-name"]` wins over `cs.name`.
+ *   - skills.sh-shaped ID not in vellum catalog returns files from skills.sh provider.
+ *   - clawhub-shaped ID not in vellum catalog returns files from clawhub provider.
+ *   - ID that no provider handles returns 404.
+ *   - Provider priority: vellum provider is tried before skills.sh/clawhub.
  */
 
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
@@ -24,8 +27,9 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { SkillSummary } from "../config/skills.js";
+import type { SlimSkillResponse } from "../daemon/message-types/skills.js";
 import type { SkillFileEntry } from "../skills/catalog-files.js";
-import type { CatalogSkill } from "../skills/catalog-install.js";
+import type { SkillFileProvider } from "../skills/skill-file-provider.js";
 
 // ---------------------------------------------------------------------------
 // Mock state — mutated by individual tests via reset helpers below
@@ -37,9 +41,45 @@ type ResolvedSkillEntry = {
 };
 
 let mockResolvedStates: ResolvedSkillEntry[] = [];
-let mockCatalog: CatalogSkill[] = [];
-let mockCatalogFiles: SkillFileEntry[] | null = null;
-const catalogFilesCalls: string[] = [];
+
+// Per-provider mock state
+let mockVellumProvider: SkillFileProvider;
+let mockSkillsshProvider: SkillFileProvider;
+let mockClawhubProvider: SkillFileProvider;
+
+// Track which providers were consulted
+const providerCalls: Array<{
+  provider: string;
+  method: string;
+  skillId: string;
+}> = [];
+
+function makeNoopProvider(name: string): SkillFileProvider {
+  return {
+    canHandle(_skillId: string): boolean {
+      return false;
+    },
+    async listFiles(skillId: string): Promise<SkillFileEntry[] | null> {
+      providerCalls.push({ provider: name, method: "listFiles", skillId });
+      return null;
+    },
+    async readFileContent(
+      skillId: string,
+      _path: string,
+    ): Promise<SkillFileEntry | null> {
+      providerCalls.push({
+        provider: name,
+        method: "readFileContent",
+        skillId,
+      });
+      return null;
+    },
+    async toSlimSkill(skillId: string): Promise<SlimSkillResponse | null> {
+      providerCalls.push({ provider: name, method: "toSlimSkill", skillId });
+      return null;
+    },
+  };
+}
 
 // ---------------------------------------------------------------------------
 // Module mocks — must be declared before importing the module under test
@@ -77,15 +117,28 @@ mock.module("../skills/install-meta.js", () => ({
 }));
 
 mock.module("../skills/catalog-cache.js", () => ({
-  getCatalog: async () => mockCatalog,
+  getCatalog: async () => [],
 }));
 
 mock.module("../skills/catalog-files.js", () => ({
-  readCatalogSkillFiles: async (skillId: string) => {
-    catalogFilesCalls.push(skillId);
-    return mockCatalogFiles;
-  },
+  catalogSkillToSlim: () => ({}),
+  createVellumCatalogProvider: () => mockVellumProvider,
+  hasHiddenOrSkippedSegment: () => false,
+  readCatalogSkillFiles: async () => null,
+  readCatalogSkillFileContent: async () => null,
+  sanitizeRelativePath: (p: string) => p,
+  SKIP_DIRS: new Set(["node_modules", "__pycache__", ".git"]),
 }));
+
+mock.module("../skills/skillssh-files.js", () => ({
+  createSkillsShProvider: () => mockSkillsshProvider,
+}));
+
+mock.module("../skills/clawhub-files.js", () => ({
+  createClawhubProvider: () => mockClawhubProvider,
+}));
+
+mock.module("../skills/skill-file-provider.js", () => ({}));
 
 mock.module("../skills/catalog-install.js", () => ({
   installSkillLocally: async () => {},
@@ -194,25 +247,17 @@ function makeSummary(overrides: Partial<SkillSummary>): SkillSummary {
 // Tests
 // ---------------------------------------------------------------------------
 
-describe("getSkillFiles — catalog fallback", () => {
+describe("getSkillFiles — provider chain fallback", () => {
   beforeEach(() => {
     mockResolvedStates = [];
-    mockCatalog = [];
-    mockCatalogFiles = null;
-    catalogFilesCalls.length = 0;
+    providerCalls.length = 0;
+    mockVellumProvider = makeNoopProvider("vellum");
+    mockSkillsshProvider = makeNoopProvider("skillssh");
+    mockClawhubProvider = makeNoopProvider("clawhub");
   });
 
-  test("returns catalog skill with files (content: null) when skill is uninstalled but present in catalog", async () => {
-    mockCatalog = [
-      {
-        id: "acme-seo",
-        name: "acme-seo",
-        description: "SEO helper",
-        emoji: "\u{1F50D}",
-        metadata: { vellum: { "display-name": "Acme SEO" } },
-      },
-    ];
-    mockCatalogFiles = [
+  test("returns catalog skill with files (content: null) when skill is uninstalled but present in vellum catalog", async () => {
+    const mockFiles: SkillFileEntry[] = [
       {
         path: "SKILL.md",
         name: "SKILL.md",
@@ -230,6 +275,21 @@ describe("getSkillFiles — catalog fallback", () => {
         content: null,
       },
     ];
+
+    mockVellumProvider = {
+      canHandle: () => true,
+      listFiles: async () => mockFiles,
+      readFileContent: async () => null,
+      toSlimSkill: async () => ({
+        id: "acme-seo",
+        name: "Acme SEO",
+        description: "SEO helper",
+        emoji: "\u{1F50D}",
+        kind: "catalog",
+        origin: "vellum",
+        status: "available",
+      }),
+    };
 
     const result = await getSkillFiles("acme-seo", dummyCtx);
 
@@ -249,20 +309,17 @@ describe("getSkillFiles — catalog fallback", () => {
     for (const entry of result.files) {
       expect(entry.content).toBeNull();
     }
-    // Files should be sorted by path via localeCompare (not codepoint) —
-    // so "assets/logo.png" sorts before "SKILL.md" under default collation.
+    // Files should be sorted by path via localeCompare
     expect(result.files.map((f) => f.path)).toEqual(
       [...result.files.map((f) => f.path)].sort((a, b) => a.localeCompare(b)),
     );
     expect(new Set(result.files.map((f) => f.path))).toEqual(
       new Set(["SKILL.md", "assets/logo.png"]),
     );
-    expect(catalogFilesCalls).toEqual(["acme-seo"]);
   });
 
-  test("returns 404 when skill is neither installed nor in the catalog", async () => {
+  test("returns 404 when skill is neither installed nor handled by any provider", async () => {
     mockResolvedStates = [];
-    mockCatalog = [];
 
     const result = await getSkillFiles("ghost-skill", dummyCtx);
 
@@ -270,18 +327,15 @@ describe("getSkillFiles — catalog fallback", () => {
     if (!("error" in result)) return;
     expect(result.status).toBe(404);
     expect(result.error).toContain("ghost-skill");
-    expect(catalogFilesCalls).toEqual([]);
   });
 
-  test("returns 404 when skill is in catalog but readCatalogSkillFiles returns null", async () => {
-    mockCatalog = [
-      {
-        id: "broken-skill",
-        name: "broken-skill",
-        description: "",
-      },
-    ];
-    mockCatalogFiles = null;
+  test("returns 404 when vellum provider canHandle returns true but listFiles returns null", async () => {
+    mockVellumProvider = {
+      canHandle: () => true,
+      listFiles: async () => null,
+      readFileContent: async () => null,
+      toSlimSkill: async () => null,
+    };
 
     const result = await getSkillFiles("broken-skill", dummyCtx);
 
@@ -291,7 +345,7 @@ describe("getSkillFiles — catalog fallback", () => {
     expect(result.error).toContain("broken-skill");
   });
 
-  test("installed skill returns inline disk content (no catalog call)", async () => {
+  test("installed skill returns inline disk content (no provider fallback)", async () => {
     // Create a real temp directory for the installed-skill path to read.
     const workspaceRoot = mkdtempSync(
       join(tmpdir(), "vellum-skill-files-test-"),
@@ -327,9 +381,6 @@ describe("getSkillFiles — catalog fallback", () => {
       expect("error" in result).toBe(false);
       if ("error" in result) return;
 
-      // Catalog fallback should NOT have been consulted for an installed skill.
-      expect(catalogFilesCalls).toEqual([]);
-
       expect(result.files).toHaveLength(2);
       const skillMd = result.files.find((f) => f.path === "SKILL.md");
       const notes = result.files.find((f) => f.path === "notes.txt");
@@ -349,14 +400,7 @@ describe("getSkillFiles — catalog fallback", () => {
     }
   });
 
-  test("returns 404 without catalog fallback when installed skill directory is missing on disk", async () => {
-    // `findSkillById` resolves the skill (resolver lists it as installed)
-    // but the on-disk directoryPath does not exist — simulates a corrupted
-    // install, mid-delete race, or external unmount. The handler must
-    // return 404 so the listing response (`kind: "installed"`) and the
-    // detail response stay consistent; falling through to the catalog
-    // would flip the detail to `kind: "catalog"` and break the
-    // client-side `isInstalled` contract.
+  test("returns 404 without provider fallback when installed skill directory is missing on disk", async () => {
     mockResolvedStates = [
       {
         summary: makeSummary({
@@ -370,26 +414,30 @@ describe("getSkillFiles — catalog fallback", () => {
         state: "enabled",
       },
     ];
-    // Even if the same id is present in the catalog, the handler must NOT
-    // fall through — return 404 instead to avoid masking the missing
-    // install directory with a catalog response.
-    mockCatalog = [
-      {
+    // Even if a provider would handle this id, the handler must NOT
+    // fall through — return 404 instead.
+    mockVellumProvider = {
+      canHandle: () => true,
+      listFiles: async () => [
+        {
+          path: "SKILL.md",
+          name: "SKILL.md",
+          size: 10,
+          mimeType: "",
+          isBinary: false,
+          content: null,
+        },
+      ],
+      readFileContent: async () => null,
+      toSlimSkill: async () => ({
         id: "ghost-installed",
-        name: "ghost-installed",
-        description: "Also present in catalog",
-      },
-    ];
-    mockCatalogFiles = [
-      {
-        path: "SKILL.md",
-        name: "SKILL.md",
-        size: 10,
-        mimeType: "",
-        isBinary: false,
-        content: null,
-      },
-    ];
+        name: "Ghost",
+        description: "",
+        kind: "catalog",
+        origin: "vellum",
+        status: "available",
+      }),
+    };
 
     const result = await getSkillFiles("ghost-installed", dummyCtx);
 
@@ -398,19 +446,22 @@ describe("getSkillFiles — catalog fallback", () => {
     expect(result.status).toBe(404);
     expect(result.error).toContain("ghost-installed");
     expect(result.error).toContain("directory missing");
-    // Catalog fallback must not have been consulted.
-    expect(catalogFilesCalls).toEqual([]);
   });
 
   test("catalogSkillToSlim falls back to cs.name when metadata.vellum.display-name is absent", async () => {
-    mockCatalog = [
-      {
+    mockVellumProvider = {
+      canHandle: () => true,
+      listFiles: async () => [],
+      readFileContent: async () => null,
+      toSlimSkill: async () => ({
         id: "plain-skill",
         name: "plain-skill",
         description: "Minimal",
-      },
-    ];
-    mockCatalogFiles = [];
+        kind: "catalog",
+        origin: "vellum",
+        status: "available",
+      }),
+    };
 
     const result = await getSkillFiles("plain-skill", dummyCtx);
 
@@ -423,21 +474,228 @@ describe("getSkillFiles — catalog fallback", () => {
   });
 
   test("catalogSkillToSlim prefers metadata.vellum.display-name over cs.name", async () => {
-    mockCatalog = [
-      {
+    mockVellumProvider = {
+      canHandle: () => true,
+      listFiles: async () => [],
+      readFileContent: async () => null,
+      toSlimSkill: async () => ({
         id: "fancy-skill",
-        name: "raw-fancy-name",
+        name: "Pretty Fancy Name",
         description: "",
-        metadata: { vellum: { "display-name": "Pretty Fancy Name" } },
-      },
-    ];
-    mockCatalogFiles = [];
+        kind: "catalog",
+        origin: "vellum",
+        status: "available",
+      }),
+    };
 
     const result = await getSkillFiles("fancy-skill", dummyCtx);
 
     expect("error" in result).toBe(false);
     if ("error" in result) return;
     expect(result.skill.name).toBe("Pretty Fancy Name");
+  });
+
+  test("skills.sh-shaped ID not in vellum catalog returns files from skills.sh provider", async () => {
+    // Vellum provider doesn't handle this ID
+    mockVellumProvider = {
+      canHandle: () => false,
+      listFiles: async () => null,
+      readFileContent: async () => null,
+      toSlimSkill: async () => null,
+    };
+
+    const skillsshFiles: SkillFileEntry[] = [
+      {
+        path: "SKILL.md",
+        name: "SKILL.md",
+        size: 100,
+        mimeType: "",
+        isBinary: false,
+        content: null,
+      },
+    ];
+    mockSkillsshProvider = {
+      canHandle: (id: string) => id.split("/").length >= 3,
+      listFiles: async () => skillsshFiles,
+      readFileContent: async () => null,
+      toSlimSkill: async (id: string) => ({
+        id,
+        name: "my-skill",
+        description: "",
+        kind: "catalog",
+        origin: "skillssh",
+        status: "available",
+        slug: id,
+        sourceRepo: "owner/repo",
+        installs: 0,
+      }),
+    };
+
+    const result = await getSkillFiles("owner/repo/my-skill", dummyCtx);
+
+    expect("error" in result).toBe(false);
+    if ("error" in result) return;
+    expect(result.skill.origin).toBe("skillssh");
+    expect(result.files).toHaveLength(1);
+    expect(result.files[0].path).toBe("SKILL.md");
+  });
+
+  test("clawhub-shaped ID not in vellum catalog returns files from clawhub provider", async () => {
+    // Vellum and skills.sh providers don't handle this ID
+    mockVellumProvider = {
+      canHandle: () => false,
+      listFiles: async () => null,
+      readFileContent: async () => null,
+      toSlimSkill: async () => null,
+    };
+    mockSkillsshProvider = {
+      canHandle: () => false,
+      listFiles: async () => null,
+      readFileContent: async () => null,
+      toSlimSkill: async () => null,
+    };
+
+    const clawhubFiles: SkillFileEntry[] = [
+      {
+        path: "SKILL.md",
+        name: "SKILL.md",
+        size: 200,
+        mimeType: "",
+        isBinary: false,
+        content: null,
+      },
+      {
+        path: "lib/utils.js",
+        name: "utils.js",
+        size: 500,
+        mimeType: "",
+        isBinary: false,
+        content: null,
+      },
+    ];
+    mockClawhubProvider = {
+      canHandle: () => true,
+      listFiles: async () => clawhubFiles,
+      readFileContent: async () => null,
+      toSlimSkill: async () => ({
+        id: "cool-tool",
+        name: "Cool Tool",
+        description: "A clawhub skill",
+        kind: "catalog",
+        origin: "clawhub",
+        status: "available",
+        slug: "cool-tool",
+        author: "someone",
+        stars: 5,
+        installs: 10,
+        reports: 0,
+      }),
+    };
+
+    const result = await getSkillFiles("cool-tool", dummyCtx);
+
+    expect("error" in result).toBe(false);
+    if ("error" in result) return;
+    expect(result.skill.origin).toBe("clawhub");
+    expect(result.files).toHaveLength(2);
+  });
+
+  test("ID that no provider handles returns 404", async () => {
+    // All providers return canHandle=false
+    mockVellumProvider = makeNoopProvider("vellum");
+    mockSkillsshProvider = makeNoopProvider("skillssh");
+    mockClawhubProvider = makeNoopProvider("clawhub");
+
+    const result = await getSkillFiles("unknown-origin-skill", dummyCtx);
+
+    expect("error" in result).toBe(true);
+    if (!("error" in result)) return;
+    expect(result.status).toBe(404);
+  });
+
+  test("provider priority — vellum provider is tried before skills.sh and clawhub", async () => {
+    // All three providers claim to handle this ID, but vellum should win
+    const vellumListFilesCalls: string[] = [];
+    const skillsshListFilesCalls: string[] = [];
+    const clawhubListFilesCalls: string[] = [];
+
+    mockVellumProvider = {
+      canHandle: () => true,
+      listFiles: async (skillId: string) => {
+        vellumListFilesCalls.push(skillId);
+        return [
+          {
+            path: "SKILL.md",
+            name: "SKILL.md",
+            size: 10,
+            mimeType: "",
+            isBinary: false,
+            content: null,
+          },
+        ];
+      },
+      readFileContent: async () => null,
+      toSlimSkill: async () => ({
+        id: "contested-skill",
+        name: "Vellum Contested",
+        description: "",
+        kind: "catalog",
+        origin: "vellum",
+        status: "available",
+      }),
+    };
+    mockSkillsshProvider = {
+      canHandle: () => true,
+      listFiles: async (skillId: string) => {
+        skillsshListFilesCalls.push(skillId);
+        return [];
+      },
+      readFileContent: async () => null,
+      toSlimSkill: async () => ({
+        id: "contested-skill",
+        name: "Skillssh Contested",
+        description: "",
+        kind: "catalog",
+        origin: "skillssh",
+        status: "available",
+        slug: "contested-skill",
+        sourceRepo: "",
+        installs: 0,
+      }),
+    };
+    mockClawhubProvider = {
+      canHandle: () => true,
+      listFiles: async (skillId: string) => {
+        clawhubListFilesCalls.push(skillId);
+        return [];
+      },
+      readFileContent: async () => null,
+      toSlimSkill: async () => ({
+        id: "contested-skill",
+        name: "Clawhub Contested",
+        description: "",
+        kind: "catalog",
+        origin: "clawhub",
+        status: "available",
+        slug: "contested-skill",
+        author: "",
+        stars: 0,
+        installs: 0,
+        reports: 0,
+      }),
+    };
+
+    const result = await getSkillFiles("contested-skill", dummyCtx);
+
+    expect("error" in result).toBe(false);
+    if ("error" in result) return;
+    // Vellum provider should have been used
+    expect(result.skill.origin).toBe("vellum");
+    expect(result.skill.name).toBe("Vellum Contested");
+    // Vellum was called, but skills.sh and clawhub were NOT called
+    expect(vellumListFilesCalls).toEqual(["contested-skill"]);
+    expect(skillsshListFilesCalls).toEqual([]);
+    expect(clawhubListFilesCalls).toEqual([]);
   });
 });
 

--- a/assistant/src/__tests__/skillssh-files.test.ts
+++ b/assistant/src/__tests__/skillssh-files.test.ts
@@ -1,0 +1,446 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import {
+  clearDirPathCache,
+  createSkillsShProvider,
+} from "../skills/skillssh-files.js";
+
+// ─── Fetch mock helpers ──────────────────────────────────────────────────────
+
+const originalFetch = globalThis.fetch;
+
+let mockFetchImpl: (url: string | URL | Request) => Promise<Response>;
+
+beforeEach(() => {
+  clearDirPathCache();
+  mockFetchImpl = () =>
+    Promise.resolve(new Response("not mocked", { status: 500 }));
+  globalThis.fetch = mock((input: string | URL | Request) =>
+    mockFetchImpl(typeof input === "string" ? input : input.toString()),
+  ) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+// ─── canHandle ──────────────────────────────────────────────────────────────
+
+describe("canHandle", () => {
+  const provider = createSkillsShProvider();
+
+  test("returns true for owner/repo/skill format", () => {
+    expect(provider.canHandle("owner/repo/skill")).toBe(true);
+  });
+
+  test("returns true for deeply nested slug", () => {
+    expect(provider.canHandle("owner/repo/skill/extra")).toBe(true);
+  });
+
+  test("returns false for simple slug", () => {
+    expect(provider.canHandle("simple-slug")).toBe(false);
+  });
+
+  test("returns false for owner/repo format (only 2 segments)", () => {
+    expect(provider.canHandle("owner/repo")).toBe(false);
+  });
+});
+
+// ─── listFiles ──────────────────────────────────────────────────────────────
+
+describe("listFiles", () => {
+  test("returns entries via conventional path", async () => {
+    const provider = createSkillsShProvider();
+
+    mockFetchImpl = (url: string | URL | Request) => {
+      const urlStr = url.toString();
+
+      // Probe for conventional path — returns directory listing
+      if (urlStr.includes("/contents/skills/my-skill")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify([
+              {
+                name: "SKILL.md",
+                type: "file",
+                download_url: "https://raw.example.com/SKILL.md",
+              },
+              {
+                name: "tools.ts",
+                type: "file",
+                download_url: "https://raw.example.com/tools.ts",
+              },
+            ]),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        );
+      }
+
+      return Promise.resolve(new Response("not found", { status: 404 }));
+    };
+
+    const entries = await provider.listFiles("owner/repo/my-skill");
+    expect(entries).not.toBeNull();
+    expect(entries!.length).toBe(2);
+    expect(entries![0]!.path).toBe("SKILL.md");
+    expect(entries![0]!.content).toBeNull();
+    expect(entries![1]!.path).toBe("tools.ts");
+    expect(entries![1]!.content).toBeNull();
+  });
+
+  test("returns entries via tree-search fallback", async () => {
+    const provider = createSkillsShProvider();
+
+    mockFetchImpl = (url: string | URL | Request) => {
+      const urlStr = url.toString();
+
+      // Conventional path returns 404
+      if (
+        urlStr.includes("/contents/skills/csv") &&
+        !urlStr.includes("examples")
+      ) {
+        return Promise.resolve(new Response("Not Found", { status: 404 }));
+      }
+
+      // Tree search finds it at a non-standard path
+      if (urlStr.includes("/git/trees/")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              tree: [
+                { path: "examples/skills/csv/SKILL.md", type: "blob" },
+                { path: "examples/skills/csv/filter.sh", type: "blob" },
+              ],
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        );
+      }
+
+      // Contents API for the discovered path
+      if (urlStr.includes("/contents/examples/skills/csv")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify([
+              {
+                name: "SKILL.md",
+                type: "file",
+                download_url: "https://raw.example.com/SKILL.md",
+              },
+              {
+                name: "filter.sh",
+                type: "file",
+                download_url: "https://raw.example.com/filter.sh",
+              },
+            ]),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        );
+      }
+
+      return Promise.resolve(new Response("not found", { status: 404 }));
+    };
+
+    const entries = await provider.listFiles("vercel-labs/bash-tool/csv");
+    expect(entries).not.toBeNull();
+    expect(entries!.length).toBe(2);
+    expect(entries!.some((e) => e.path === "SKILL.md")).toBe(true);
+    expect(entries!.some((e) => e.path === "filter.sh")).toBe(true);
+  });
+
+  test("returns null on GitHub API error", async () => {
+    const provider = createSkillsShProvider();
+
+    mockFetchImpl = () =>
+      Promise.resolve(new Response("Internal Server Error", { status: 500 }));
+
+    const entries = await provider.listFiles("owner/repo/my-skill");
+    expect(entries).toBeNull();
+  });
+
+  test("returns null for malformed skill id", async () => {
+    const provider = createSkillsShProvider();
+    const entries = await provider.listFiles("simple-slug");
+    expect(entries).toBeNull();
+  });
+
+  test("skips hidden files and SKIP_DIRS", async () => {
+    const provider = createSkillsShProvider();
+
+    mockFetchImpl = (url: string | URL | Request) => {
+      const urlStr = url.toString();
+
+      if (urlStr.includes("/contents/skills/my-skill")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify([
+              {
+                name: "SKILL.md",
+                type: "file",
+                download_url: "https://raw.example.com/SKILL.md",
+              },
+              {
+                name: ".env",
+                type: "file",
+                download_url: "https://raw.example.com/.env",
+              },
+              {
+                name: "node_modules",
+                type: "dir",
+                download_url: null,
+              },
+              {
+                name: ".git",
+                type: "dir",
+                download_url: null,
+              },
+            ]),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        );
+      }
+
+      return Promise.resolve(new Response("not found", { status: 404 }));
+    };
+
+    const entries = await provider.listFiles("owner/repo/my-skill");
+    expect(entries).not.toBeNull();
+    expect(entries!.length).toBe(1);
+    expect(entries![0]!.path).toBe("SKILL.md");
+  });
+});
+
+// ─── readFileContent ────────────────────────────────────────────────────────
+
+describe("readFileContent", () => {
+  test("returns text content inline", async () => {
+    const provider = createSkillsShProvider();
+
+    mockFetchImpl = (url: string | URL | Request) => {
+      const urlStr = url.toString();
+
+      // Probe for conventional path — returns 200 for dir probe
+      if (
+        urlStr.includes("/contents/skills/my-skill") &&
+        !urlStr.includes("SKILL.md")
+      ) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify([
+              {
+                name: "SKILL.md",
+                type: "file",
+                download_url: "https://raw.example.com/SKILL.md",
+              },
+            ]),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        );
+      }
+
+      // Individual file fetch via Contents API
+      if (urlStr.includes("/contents/skills/my-skill/SKILL.md")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              name: "SKILL.md",
+              type: "file",
+              size: 42,
+              download_url: "https://raw.example.com/SKILL.md",
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        );
+      }
+
+      // File content download
+      if (urlStr.includes("raw.example.com/SKILL.md")) {
+        return Promise.resolve(
+          new Response("# My Skill\nDescription here", { status: 200 }),
+        );
+      }
+
+      return Promise.resolve(new Response("not found", { status: 404 }));
+    };
+
+    const entry = await provider.readFileContent(
+      "owner/repo/my-skill",
+      "SKILL.md",
+    );
+    expect(entry).not.toBeNull();
+    expect(entry!.path).toBe("SKILL.md");
+    expect(entry!.name).toBe("SKILL.md");
+    expect(entry!.isBinary).toBe(false);
+    expect(entry!.content).toBe("# My Skill\nDescription here");
+  });
+
+  test("returns null for binary files", async () => {
+    const provider = createSkillsShProvider();
+
+    mockFetchImpl = (url: string | URL | Request) => {
+      const urlStr = url.toString();
+
+      // Probe for conventional path
+      if (
+        urlStr.includes("/contents/skills/my-skill") &&
+        !urlStr.includes("logo.png")
+      ) {
+        return Promise.resolve(
+          new Response(JSON.stringify([]), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+      }
+
+      // Individual file fetch
+      if (urlStr.includes("/contents/skills/my-skill/logo.png")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              name: "logo.png",
+              type: "file",
+              size: 1024,
+              download_url: "https://raw.example.com/logo.png",
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        );
+      }
+
+      return Promise.resolve(new Response("not found", { status: 404 }));
+    };
+
+    const entry = await provider.readFileContent(
+      "owner/repo/my-skill",
+      "logo.png",
+    );
+    expect(entry).not.toBeNull();
+    expect(entry!.isBinary).toBe(true);
+    expect(entry!.content).toBeNull();
+  });
+
+  test("returns null when file does not exist", async () => {
+    const provider = createSkillsShProvider();
+
+    mockFetchImpl = (url: string | URL | Request) => {
+      const urlStr = url.toString();
+
+      // Probe for conventional path
+      if (
+        urlStr.includes("/contents/skills/my-skill") &&
+        !urlStr.includes("nonexistent.md")
+      ) {
+        return Promise.resolve(
+          new Response(JSON.stringify([]), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+      }
+
+      // File not found
+      if (urlStr.includes("/contents/skills/my-skill/nonexistent.md")) {
+        return Promise.resolve(new Response("Not Found", { status: 404 }));
+      }
+
+      return Promise.resolve(new Response("not found", { status: 404 }));
+    };
+
+    const entry = await provider.readFileContent(
+      "owner/repo/my-skill",
+      "nonexistent.md",
+    );
+    expect(entry).toBeNull();
+  });
+
+  test("returns null for hidden/skipped paths", async () => {
+    const provider = createSkillsShProvider();
+
+    const entry1 = await provider.readFileContent(
+      "owner/repo/my-skill",
+      ".env",
+    );
+    expect(entry1).toBeNull();
+
+    const entry2 = await provider.readFileContent(
+      "owner/repo/my-skill",
+      "node_modules/pkg/index.js",
+    );
+    expect(entry2).toBeNull();
+  });
+});
+
+// ─── toSlimSkill ────────────────────────────────────────────────────────────
+
+describe("toSlimSkill", () => {
+  const provider = createSkillsShProvider();
+
+  test("returns valid SkillsshSlimSkill for well-formed slug", async () => {
+    const slim = await provider.toSlimSkill("owner/repo/my-skill");
+    expect(slim).not.toBeNull();
+    expect(slim!.id).toBe("owner/repo/my-skill");
+    expect(slim!.name).toBe("my-skill");
+    expect(slim!.kind).toBe("catalog");
+    expect(slim!.status).toBe("available");
+    expect(slim!.origin).toBe("skillssh");
+    expect((slim as any).slug).toBe("owner/repo/my-skill");
+    expect((slim as any).sourceRepo).toBe("owner/repo");
+    expect((slim as any).installs).toBe(0);
+  });
+
+  test("returns null for malformed slug", async () => {
+    const slim = await provider.toSlimSkill("bad-slug");
+    expect(slim).toBeNull();
+  });
+});
+
+// ─── Cache behavior ─────────────────────────────────────────────────────────
+
+describe("cache", () => {
+  test("cache hit avoids re-probing GitHub", async () => {
+    const provider = createSkillsShProvider();
+    const fetchedUrls: string[] = [];
+
+    mockFetchImpl = (url: string | URL | Request) => {
+      const urlStr = url.toString();
+      fetchedUrls.push(urlStr);
+
+      // Both the dir probe and the listing hit the same Contents API URL.
+      // Return a valid directory listing for both.
+      if (urlStr.includes("/contents/skills/my-skill")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify([
+              {
+                name: "SKILL.md",
+                type: "file",
+                download_url: "https://raw.example.com/SKILL.md",
+              },
+            ]),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        );
+      }
+
+      return Promise.resolve(new Response("not found", { status: 404 }));
+    };
+
+    // First call: resolveSkillDir probes + listGitHubDir lists = 2 fetches
+    const entries1 = await provider.listFiles("owner/repo/my-skill");
+    expect(entries1).not.toBeNull();
+    const contentsCallsAfterFirst = fetchedUrls.filter((u) =>
+      u.includes("/contents/skills/my-skill"),
+    ).length;
+    expect(contentsCallsAfterFirst).toBe(2); // 1 probe + 1 listing
+
+    // Second call: resolveSkillDir uses cache + listGitHubDir lists = 1 fetch
+    const entries2 = await provider.listFiles("owner/repo/my-skill");
+    expect(entries2).not.toBeNull();
+    const contentsCallsAfterSecond = fetchedUrls.filter((u) =>
+      u.includes("/contents/skills/my-skill"),
+    ).length;
+    // Only 1 additional call (the listing), not 2. The probe is cached.
+    expect(contentsCallsAfterSecond).toBe(3); // 2 from first + 1 listing from second
+  });
+});

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -37,6 +37,7 @@ import {
 } from "../../runtime/routes/workspace-utils.js";
 import { getCatalog } from "../../skills/catalog-cache.js";
 import {
+  catalogSkillToSlim,
   hasHiddenOrSkippedSegment,
   readCatalogSkillFileContent,
   readCatalogSkillFiles,
@@ -563,25 +564,6 @@ function readDirRecursive(dir: string, rootDir: string): SkillFileEntry[] {
     }
   }
   return entries;
-}
-
-/**
- * Map a `CatalogSkill` (from the Vellum platform API) to a `SlimSkillResponse`
- * shaped for the "available catalog skill" case. Shared between
- * `listSkillsWithCatalog` (merging catalog entries into the installed list)
- * and `getSkillFiles` (catalog fallback for preview listings). Keeping the
- * mapping in one place avoids divergence between the list and detail paths.
- */
-function catalogSkillToSlim(cs: CatalogSkill): SlimSkillResponse {
-  return {
-    id: cs.id,
-    name: cs.metadata?.vellum?.["display-name"] ?? cs.name,
-    description: cs.description,
-    emoji: cs.emoji,
-    kind: "catalog",
-    origin: "vellum",
-    status: "available",
-  };
 }
 
 /**

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -106,39 +106,57 @@ export interface SkillOperationContext {
 // ─── Provider chain for uninstalled skill file preview ───────────────────────
 // Ordered by priority: vellum first (most common and cheapest to check),
 // then skills.sh, then clawhub.
+//
+// Lazy-initialized on first access so that mock modules (in tests) can
+// replace the factory functions before providers are constructed.
 
-const fileProviders: SkillFileProvider[] = [
-  createVellumCatalogProvider(),
-  createSkillsShProvider(),
-  createClawhubProvider(),
-];
+let _fileProviders: SkillFileProvider[] | null = null;
+
+function getFileProviders(): SkillFileProvider[] {
+  if (!_fileProviders) {
+    _fileProviders = [
+      createVellumCatalogProvider(),
+      createSkillsShProvider(),
+      createClawhubProvider(),
+    ];
+  }
+  return _fileProviders;
+}
+
+/** @internal Exported for test use only — forces re-creation of providers. */
+export function _resetFileProvidersForTest(): void {
+  _fileProviders = null;
+}
 
 async function resolveSkillFiles(skillId: string): Promise<{
-  skill: SlimSkillResponse;
-  files: SkillFileEntry[];
-} | null> {
-  for (const provider of fileProviders) {
+  handled: boolean;
+  skill: SlimSkillResponse | null;
+  files: SkillFileEntry[] | null;
+}> {
+  for (const provider of getFileProviders()) {
     if (!provider.canHandle(skillId)) continue;
+    // Commit to this provider — don't fall through to subsequent providers.
     const files = await provider.listFiles(skillId);
-    if (files === null) continue;
+    if (files === null) return { handled: true, skill: null, files: null };
     const skill = await provider.toSlimSkill(skillId);
-    if (skill === null) continue;
+    if (skill === null) return { handled: true, skill: null, files: null };
     files.sort((a, b) => a.path.localeCompare(b.path));
-    return { skill, files };
+    return { handled: true, skill, files };
   }
-  return null;
+  return { handled: false, skill: null, files: null };
 }
 
 async function resolveSkillFileContent(
   skillId: string,
   sanitizedPath: string,
-): Promise<SkillFileEntry | null> {
-  for (const provider of fileProviders) {
+): Promise<{ handled: boolean; result: SkillFileEntry | null }> {
+  for (const provider of getFileProviders()) {
     if (!provider.canHandle(skillId)) continue;
+    // Commit to this provider — don't fall through to subsequent providers.
     const result = await provider.readFileContent(skillId, sanitizedPath);
-    if (result !== null) return result;
+    return { handled: true, result };
   }
-  return null;
+  return { handled: false, result: null };
 }
 
 // ─── Frontmatter parsing ─────────────────────────────────────────────────────
@@ -462,12 +480,14 @@ export async function getSkill(
   const found = findSkillById(skillId);
   if (!found) {
     // Fallback: skill is not installed. Try all file providers.
-    for (const provider of fileProviders) {
+    for (const provider of getFileProviders()) {
       if (!provider.canHandle(skillId)) continue;
+      // Commit to this provider — don't fall through to subsequent providers.
       const slim = await provider.toSlimSkill(skillId);
       if (slim) {
         return { skill: slim as SkillDetailResponse };
       }
+      return { error: `Skill "${skillId}" not found`, status: 404 };
     }
     return { error: `Skill "${skillId}" not found`, status: 404 };
   }
@@ -622,7 +642,7 @@ function readDirRecursive(dir: string, rootDir: string): SkillFileEntry[] {
  * realpath containment checks for defense in depth.
  *
  * Provider chain fallback: when the skill id is not backed by a local
- * directory, iterates the `fileProviders` chain (vellum catalog,
+ * directory, iterates the file-provider chain (vellum catalog,
  * skills.sh, clawhub) until one returns content.
  */
 export async function getSkillFileContent(
@@ -731,8 +751,8 @@ export async function getSkillFileContent(
   }
 
   // Fallback: skill is not installed. Try all file providers.
-  const result = await resolveSkillFileContent(skillId, sanitized);
-  if (result) {
+  const { handled, result } = await resolveSkillFileContent(skillId, sanitized);
+  if (handled && result) {
     return {
       path: result.path,
       name: result.name,
@@ -741,6 +761,10 @@ export async function getSkillFileContent(
       isBinary: result.isBinary,
       content: result.content,
     };
+  }
+  if (handled) {
+    // A provider claimed this skill but the specific file wasn't found.
+    return { error: "File not found", status: 404 };
   }
   return { error: "Skill not found", status: 404 };
 }
@@ -776,7 +800,13 @@ export async function getSkillFiles(
 
   // Fallback: skill is not installed. Try all file providers.
   const resolved = await resolveSkillFiles(skillId);
-  if (resolved) return resolved;
+  if (resolved.handled && resolved.skill && resolved.files) {
+    return { skill: resolved.skill, files: resolved.files };
+  }
+  if (resolved.handled) {
+    // A provider claimed this skill but couldn't produce files/metadata.
+    return { error: `Skill files unavailable for "${skillId}"`, status: 404 };
+  }
   return { error: `Skill "${skillId}" not found`, status: 404 };
 }
 

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -38,9 +38,8 @@ import {
 import { getCatalog } from "../../skills/catalog-cache.js";
 import {
   catalogSkillToSlim,
+  createVellumCatalogProvider,
   hasHiddenOrSkippedSegment,
-  readCatalogSkillFileContent,
-  readCatalogSkillFiles,
   sanitizeRelativePath,
   type SkillFileEntry,
   SKIP_DIRS,
@@ -59,6 +58,7 @@ import {
   clawhubSearch,
   clawhubUpdate,
 } from "../../skills/clawhub.js";
+import { createClawhubProvider } from "../../skills/clawhub-files.js";
 import {
   readInstallMeta,
   type SkillInstallMeta,
@@ -69,6 +69,8 @@ import {
   removeSkillsIndexEntry,
   validateManagedSkillId,
 } from "../../skills/managed-store.js";
+import type { SkillFileProvider } from "../../skills/skill-file-provider.js";
+import { createSkillsShProvider } from "../../skills/skillssh-files.js";
 import {
   installExternalSkill,
   resolveSkillSource,
@@ -99,6 +101,44 @@ export interface SkillOperationContext {
   setSuppressConfigReload(value: boolean): void;
   updateConfigFingerprint(): void;
   broadcast: HandlerContext["broadcast"];
+}
+
+// ─── Provider chain for uninstalled skill file preview ───────────────────────
+// Ordered by priority: vellum first (most common and cheapest to check),
+// then skills.sh, then clawhub.
+
+const fileProviders: SkillFileProvider[] = [
+  createVellumCatalogProvider(),
+  createSkillsShProvider(),
+  createClawhubProvider(),
+];
+
+async function resolveSkillFiles(skillId: string): Promise<{
+  skill: SlimSkillResponse;
+  files: SkillFileEntry[];
+} | null> {
+  for (const provider of fileProviders) {
+    if (!provider.canHandle(skillId)) continue;
+    const files = await provider.listFiles(skillId);
+    if (files === null) continue;
+    const skill = await provider.toSlimSkill(skillId);
+    if (skill === null) continue;
+    files.sort((a, b) => a.path.localeCompare(b.path));
+    return { skill, files };
+  }
+  return null;
+}
+
+async function resolveSkillFileContent(
+  skillId: string,
+  sanitizedPath: string,
+): Promise<SkillFileEntry | null> {
+  for (const provider of fileProviders) {
+    if (!provider.canHandle(skillId)) continue;
+    const result = await provider.readFileContent(skillId, sanitizedPath);
+    if (result !== null) return result;
+  }
+  return null;
 }
 
 // ─── Frontmatter parsing ─────────────────────────────────────────────────────
@@ -421,6 +461,14 @@ export async function getSkill(
 ): Promise<{ skill: SkillDetailResponse } | { error: string; status: number }> {
   const found = findSkillById(skillId);
   if (!found) {
+    // Fallback: skill is not installed. Try all file providers.
+    for (const provider of fileProviders) {
+      if (!provider.canHandle(skillId)) continue;
+      const slim = await provider.toSlimSkill(skillId);
+      if (slim) {
+        return { skill: slim as SkillDetailResponse };
+      }
+    }
     return { error: `Skill "${skillId}" not found`, status: 404 };
   }
 
@@ -567,16 +615,15 @@ function readDirRecursive(dir: string, rootDir: string): SkillFileEntry[] {
 }
 
 /**
- * Read a single file's content from an installed or catalog skill.
+ * Read a single file's content from an installed or uninstalled skill.
  *
  * Installed-skill path (eager): reads the file directly from the skill's
  * on-disk directory. Applies lexical containment, symlink rejection, and
  * realpath containment checks for defense in depth.
  *
- * Catalog fallback: when the skill id is not backed by a local directory
- * (e.g. an uninstalled Vellum catalog skill), delegates to
- * `readCatalogSkillFileContent`, which handles both the dev-mode repo
- * checkout path and the platform preview API path internally.
+ * Provider chain fallback: when the skill id is not backed by a local
+ * directory, iterates the `fileProviders` chain (vellum catalog,
+ * skills.sh, clawhub) until one returns content.
  */
 export async function getSkillFileContent(
   skillId: string,
@@ -683,32 +730,19 @@ export async function getSkillFileContent(
     };
   }
 
-  // Catalog fallback: skill is not installed locally. Try the catalog
-  // preview helper, which handles both dev-mode repo checkouts and the
-  // platform preview API.
-  let catalog: Awaited<ReturnType<typeof getCatalog>> = [];
-  try {
-    catalog = await getCatalog();
-  } catch {
-    catalog = [];
+  // Fallback: skill is not installed. Try all file providers.
+  const result = await resolveSkillFileContent(skillId, sanitized);
+  if (result) {
+    return {
+      path: result.path,
+      name: result.name,
+      size: result.size,
+      mimeType: result.mimeType,
+      isBinary: result.isBinary,
+      content: result.content,
+    };
   }
-  const inCatalog = catalog.some((s) => s.id === skillId);
-  if (!inCatalog) {
-    return { error: "Skill not found", status: 404 };
-  }
-
-  const result = await readCatalogSkillFileContent(skillId, sanitized);
-  if (!result) {
-    return { error: "File not found", status: 404 };
-  }
-  return {
-    path: result.path,
-    name: result.name,
-    size: result.size,
-    mimeType: result.mimeType,
-    isBinary: result.isBinary,
-    content: result.content,
-  };
+  return { error: "Skill not found", status: 404 };
 }
 
 export async function getSkillFiles(
@@ -740,31 +774,10 @@ export async function getSkillFiles(
     };
   }
 
-  // Fallback: skill is not installed. Try the Vellum catalog — this covers
-  // previewing files for an uninstalled catalog skill without touching the
-  // install flow.
-  let catalog: CatalogSkill[];
-  try {
-    catalog = await getCatalog();
-  } catch {
-    return { error: `Skill "${skillId}" not found`, status: 404 };
-  }
-  const cs = catalog.find((c) => c.id === skillId);
-  if (!cs) {
-    return { error: `Skill "${skillId}" not found`, status: 404 };
-  }
-
-  const files = await readCatalogSkillFiles(skillId);
-  if (files === null) {
-    return {
-      error: `Skill files unavailable for "${skillId}"`,
-      status: 404,
-    };
-  }
-
-  const skill = catalogSkillToSlim(cs);
-  files.sort((a, b) => a.path.localeCompare(b.path));
-  return { skill, files };
+  // Fallback: skill is not installed. Try all file providers.
+  const resolved = await resolveSkillFiles(skillId);
+  if (resolved) return resolved;
+  return { error: `Skill "${skillId}" not found`, status: 404 };
 }
 
 export function enableSkill(

--- a/assistant/src/skills/catalog-files.ts
+++ b/assistant/src/skills/catalog-files.ts
@@ -29,14 +29,16 @@ import {
 import { basename, join, posix, sep } from "node:path";
 
 import { getPlatformBaseUrl } from "../config/env.js";
+import type { SlimSkillResponse } from "../daemon/message-types/skills.js";
 import {
   isTextMimeType as isTextMime,
   MAX_INLINE_TEXT_SIZE,
 } from "../runtime/routes/workspace-utils.js";
 import { getLogger } from "../util/logger.js";
 import { readPlatformToken } from "../util/platform.js";
-import { getCatalog } from "./catalog-cache.js";
-import { getRepoSkillsDir } from "./catalog-install.js";
+import { getCachedCatalogSync, getCatalog } from "./catalog-cache.js";
+import { type CatalogSkill, getRepoSkillsDir } from "./catalog-install.js";
+import type { SkillFileProvider } from "./skill-file-provider.js";
 
 const log = getLogger("catalog-files");
 
@@ -488,5 +490,65 @@ export async function readCatalogSkillFileContent(
     mimeType: response.mime_type,
     isBinary: response.is_binary,
     content: response.content,
+  };
+}
+
+// ─── Catalog-to-slim conversion ──────────────────────────────────────────────
+
+/**
+ * Map a `CatalogSkill` (from the Vellum platform API) to a `SlimSkillResponse`
+ * shaped for the "available catalog skill" case. Shared between
+ * `listSkillsWithCatalog` (merging catalog entries into the installed list),
+ * `getSkillFiles` (catalog fallback for preview listings), and the
+ * `VellumCatalogProvider`. Keeping the mapping in one place avoids divergence
+ * between the list and detail paths.
+ *
+ * Extracted here (rather than in `daemon/handlers/skills.ts`) to avoid a
+ * circular import — catalog-files depends on `catalog-cache.ts`, which would
+ * otherwise be reachable via the handler module.
+ */
+export function catalogSkillToSlim(cs: CatalogSkill): SlimSkillResponse {
+  return {
+    id: cs.id,
+    name: cs.metadata?.vellum?.["display-name"] ?? cs.name,
+    description: cs.description,
+    emoji: cs.emoji,
+    kind: "catalog",
+    origin: "vellum",
+    status: "available",
+  };
+}
+
+// ─── Vellum Catalog Provider ─────────────────────────────────────────────────
+
+/**
+ * Create a `SkillFileProvider` that wraps the existing catalog-files functions
+ * for the Vellum first-party catalog. This is the first provider implementation
+ * in the unified file-preview chain.
+ */
+export function createVellumCatalogProvider(): SkillFileProvider {
+  return {
+    canHandle(skillId: string): boolean {
+      const cached = getCachedCatalogSync();
+      return cached.some((s) => s.id === skillId);
+    },
+
+    listFiles(skillId: string): Promise<SkillFileEntry[] | null> {
+      return readCatalogSkillFiles(skillId);
+    },
+
+    readFileContent(
+      skillId: string,
+      sanitizedPath: string,
+    ): Promise<SkillFileEntry | null> {
+      return readCatalogSkillFileContent(skillId, sanitizedPath);
+    },
+
+    async toSlimSkill(skillId: string): Promise<SlimSkillResponse | null> {
+      const catalog = await getCatalog();
+      const cs = catalog.find((s) => s.id === skillId);
+      if (!cs) return null;
+      return catalogSkillToSlim(cs);
+    },
   };
 }

--- a/assistant/src/skills/clawhub-files.ts
+++ b/assistant/src/skills/clawhub-files.ts
@@ -147,14 +147,35 @@ export function createClawhubProvider(): SkillFileProvider {
         };
       }
 
+      const name = basename(sanitizedPath);
+      const isBinary = classifyBinary(name);
+
       // For non-SKILL.md files (or when SKILL.md isn't cached), run
       // a dedicated inspect call for the specific file.
       const content = await clawhubInspectFile(skillId, sanitizedPath);
-      if (content == null) return null;
 
-      const name = basename(sanitizedPath);
-      const isBinary = classifyBinary(name);
-      if (isBinary) return null; // binary content can't be returned inline
+      // Binary files: return metadata with content: null (matching the
+      // contract followed by vellum and skills.sh providers). clawhubInspectFile
+      // returns null for binary files, which is expected.
+      if (isBinary) {
+        // Look up file metadata from cached inspect result if available.
+        const inspectData =
+          getCached(skillId) ?? (await inspectCached(skillId));
+        const fileMeta = inspectData?.files?.find(
+          (f) => f.path === sanitizedPath,
+        );
+        return {
+          path: sanitizedPath,
+          name,
+          size: fileMeta?.size ?? 0,
+          mimeType: fileMeta?.contentType ?? Bun.file(name).type,
+          isBinary: true,
+          content: null,
+        };
+      }
+
+      // Text file but content fetch failed — file doesn't exist.
+      if (content == null) return null;
 
       return {
         path: sanitizedPath,

--- a/assistant/src/skills/clawhub-files.ts
+++ b/assistant/src/skills/clawhub-files.ts
@@ -1,0 +1,191 @@
+/**
+ * clawhub-files — SkillFileProvider implementation for clawhub-origin skills.
+ *
+ * Backed by the `clawhub inspect` CLI. The initial `clawhubInspect` call
+ * fetches file metadata *and* SKILL.md content in a single round trip.
+ * Results are cached in memory (5-minute TTL) so that subsequent calls to
+ * `listFiles`, `readFileContent`, and `toSlimSkill` for the same slug
+ * reuse the inspect data without re-running the CLI.
+ *
+ * For non-SKILL.md files, `readFileContent` delegates to `clawhubInspectFile`
+ * which runs a second CLI call for the specific file.
+ */
+
+import { basename } from "node:path";
+
+import type { SlimSkillResponse } from "../daemon/message-types/skills.js";
+import { isTextMimeType as isTextMime } from "../runtime/routes/workspace-utils.js";
+import { getLogger } from "../util/logger.js";
+import type { SkillFileEntry } from "./catalog-files.js";
+import {
+  clawhubInspect,
+  clawhubInspectFile,
+  type ClawhubInspectResult,
+  validateSlug,
+} from "./clawhub.js";
+import type { SkillFileProvider } from "./skill-file-provider.js";
+
+const log = getLogger("clawhub-files");
+
+// ─── Inspect cache ────────────────────────────────────────────────────────────
+
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+interface CacheEntry {
+  data: ClawhubInspectResult;
+  expiresAt: number;
+}
+
+const inspectCache = new Map<string, CacheEntry>();
+
+function getCached(slug: string): ClawhubInspectResult | null {
+  const entry = inspectCache.get(slug);
+  if (!entry) return null;
+  if (Date.now() > entry.expiresAt) {
+    inspectCache.delete(slug);
+    return null;
+  }
+  return entry.data;
+}
+
+function setCache(slug: string, data: ClawhubInspectResult): void {
+  inspectCache.set(slug, { data, expiresAt: Date.now() + CACHE_TTL_MS });
+}
+
+/**
+ * Run `clawhubInspect` with caching. Returns the inspect result or `null`.
+ */
+async function inspectCached(
+  slug: string,
+): Promise<ClawhubInspectResult | null> {
+  const cached = getCached(slug);
+  if (cached) return cached;
+
+  const result = await clawhubInspect(slug);
+  if (!result.data) {
+    log.warn({ slug, error: result.error }, "clawhub inspect failed");
+    return null;
+  }
+  setCache(slug, result.data);
+  return result.data;
+}
+
+// ─── Binary classification ───────────────────────────────────────────────────
+
+/**
+ * Classify a file as binary from its name and optional contentType field.
+ * If the contentType from the inspect result is present and recognised,
+ * prefer it; otherwise fall back to Bun's extension-based MIME detection
+ * (same strategy as `catalog-files.ts`).
+ */
+function classifyBinary(fileName: string, contentType?: string): boolean {
+  if (contentType) {
+    return !isTextMime(contentType, fileName);
+  }
+  const mime = Bun.file(fileName).type;
+  return !isTextMime(mime, fileName);
+}
+
+// ─── Provider factory ─────────────────────────────────────────────────────────
+
+/**
+ * Create a `SkillFileProvider` for clawhub-origin skills.
+ *
+ * `canHandle` returns `true` for slugs that pass clawhub's `validateSlug`
+ * regex AND do not look like a skills.sh slug (skills.sh slugs have three
+ * slash-separated segments: `owner/repo/skill`).
+ */
+export function createClawhubProvider(): SkillFileProvider {
+  return {
+    canHandle(skillId: string): boolean {
+      if (!validateSlug(skillId)) return false;
+      // skills.sh slugs have ≥ 3 segments (owner/repo/skill)
+      if (skillId.split("/").length >= 3) return false;
+      return true;
+    },
+
+    async listFiles(skillId: string): Promise<SkillFileEntry[] | null> {
+      const data = await inspectCached(skillId);
+      if (!data || !data.files) return null;
+
+      const entries: SkillFileEntry[] = data.files.map((f) => {
+        const name = basename(f.path);
+        const isBinary = classifyBinary(name, f.contentType);
+        return {
+          path: f.path,
+          name,
+          size: f.size,
+          mimeType: f.contentType ?? Bun.file(name).type,
+          isBinary,
+          content: null,
+        };
+      });
+      entries.sort((a, b) => a.path.localeCompare(b.path));
+      return entries;
+    },
+
+    async readFileContent(
+      skillId: string,
+      sanitizedPath: string,
+    ): Promise<SkillFileEntry | null> {
+      // If the requested path is SKILL.md and we have cached inspect data
+      // with skillMdContent, return it directly without a second CLI call.
+      const cached = getCached(skillId);
+      if (
+        cached &&
+        sanitizedPath === "SKILL.md" &&
+        cached.skillMdContent != null
+      ) {
+        const name = "SKILL.md";
+        return {
+          path: sanitizedPath,
+          name,
+          size: cached.skillMdContent.length,
+          mimeType: "text/markdown",
+          isBinary: false,
+          content: cached.skillMdContent,
+        };
+      }
+
+      // For non-SKILL.md files (or when SKILL.md isn't cached), run
+      // a dedicated inspect call for the specific file.
+      const content = await clawhubInspectFile(skillId, sanitizedPath);
+      if (content == null) return null;
+
+      const name = basename(sanitizedPath);
+      const isBinary = classifyBinary(name);
+      if (isBinary) return null; // binary content can't be returned inline
+
+      return {
+        path: sanitizedPath,
+        name,
+        size: content.length,
+        mimeType: Bun.file(name).type,
+        isBinary: false,
+        content,
+      };
+    },
+
+    async toSlimSkill(skillId: string): Promise<SlimSkillResponse | null> {
+      const data = await inspectCached(skillId);
+      if (!data) return null;
+
+      return {
+        id: data.skill.slug,
+        name: data.skill.displayName,
+        description: data.skill.summary,
+        kind: "catalog",
+        status: "available",
+        origin: "clawhub",
+        slug: data.skill.slug,
+        author: data.owner?.handle ?? "",
+        stars: data.stats?.stars ?? 0,
+        installs: data.stats?.installs ?? 0,
+        reports: 0,
+        publishedAt: data.updatedAt
+          ? new Date(data.updatedAt).toISOString()
+          : undefined,
+      };
+    },
+  };
+}

--- a/assistant/src/skills/clawhub.ts
+++ b/assistant/src/skills/clawhub.ts
@@ -23,7 +23,7 @@ function getClawhubProjectRoot(): string {
 }
 
 // Validate slug format (alphanumeric, hyphens, dots, underscores; optional namespace with single slash)
-function validateSlug(slug: string): boolean {
+export function validateSlug(slug: string): boolean {
   return /^[a-zA-Z0-9]([a-zA-Z0-9._-]*(\/[a-zA-Z0-9][a-zA-Z0-9._-]*)?)?$/.test(
     slug,
   );
@@ -472,6 +472,44 @@ export async function clawhubInspect(
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     return { error: message };
+  }
+}
+
+/**
+ * Fetch a single file's content from a published clawhub skill.
+ * Calls `npx clawhub inspect <slug> --json --file <filePath>` and returns
+ * the file content string, or `null` on failure.
+ */
+export async function clawhubInspectFile(
+  slug: string,
+  filePath: string,
+): Promise<string | null> {
+  if (!validateSlug(slug)) return null;
+
+  try {
+    const result = await runClawhub([
+      "inspect",
+      slug,
+      "--json",
+      "--file",
+      filePath,
+    ]);
+    if (result.exitCode !== 0) return null;
+
+    try {
+      const parsed = JSON.parse(result.stdout);
+      // The CLI returns the file content in one of these fields
+      const content =
+        parsed.skillMdContent ??
+        parsed.fileContents?.[filePath] ??
+        parsed.file?.content ??
+        null;
+      return typeof content === "string" ? content : null;
+    } catch {
+      return null;
+    }
+  } catch {
+    return null;
   }
 }
 

--- a/assistant/src/skills/skill-file-provider.ts
+++ b/assistant/src/skills/skill-file-provider.ts
@@ -1,0 +1,40 @@
+import type { SlimSkillResponse } from "../daemon/message-types/skills.js";
+import type { SkillFileEntry } from "./catalog-files.js";
+
+/**
+ * A file provider can resolve file listings and single-file content for
+ * skills that are NOT installed locally. Each origin (vellum catalog,
+ * skills.sh, clawhub) implements this interface.
+ */
+export interface SkillFileProvider {
+  /**
+   * Return true if this provider can handle the given skill id.
+   * Called synchronously — must not perform I/O.
+   */
+  canHandle(skillId: string): boolean;
+
+  /**
+   * List all files in the skill directory. Returns entries with
+   * `content: null` (content is fetched on demand via `readFileContent`).
+   * Returns `null` if the skill doesn't exist in this provider.
+   */
+  listFiles(skillId: string): Promise<SkillFileEntry[] | null>;
+
+  /**
+   * Read a single file's content. `relativePath` has already been
+   * sanitized by the caller (sanitizeRelativePath + hasHiddenOrSkippedSegment).
+   * Returns `null` if the file doesn't exist.
+   */
+  readFileContent(
+    skillId: string,
+    sanitizedPath: string,
+  ): Promise<SkillFileEntry | null>;
+
+  /**
+   * Synthesize a SlimSkillResponse for an uninstalled skill in this
+   * provider. Used by getSkill/getSkillFiles when the skill isn't in
+   * the local catalog. Returns `null` if the provider can't produce
+   * metadata for this skill.
+   */
+  toSlimSkill(skillId: string): Promise<SlimSkillResponse | null>;
+}

--- a/assistant/src/skills/skillssh-files.ts
+++ b/assistant/src/skills/skillssh-files.ts
@@ -1,0 +1,395 @@
+/**
+ * skillssh-files — SkillFileProvider for skills.sh (GitHub-hosted) skills.
+ *
+ * Lists files and reads individual file content via the GitHub Contents API
+ * and Tree API, without downloading or installing the skill locally.
+ *
+ * Path resolution (conventional `skills/<slug>/` with tree-search fallback)
+ * mirrors the logic in `fetchSkillFromGitHub` from `skillssh-registry.ts`,
+ * but only collects metadata (no file content on listing) and fetches
+ * content on demand for individual files.
+ */
+
+import { basename } from "node:path";
+
+import type { SlimSkillResponse } from "../daemon/message-types/skills.js";
+import {
+  isTextMimeType as isTextMime,
+  MAX_INLINE_TEXT_SIZE,
+} from "../runtime/routes/workspace-utils.js";
+import { getLogger } from "../util/logger.js";
+import type { SkillFileEntry } from "./catalog-files.js";
+import {
+  hasHiddenOrSkippedSegment,
+  sanitizeRelativePath,
+  SKIP_DIRS,
+} from "./catalog-files.js";
+import type { SkillFileProvider } from "./skill-file-provider.js";
+import type { GitHubContentsEntry } from "./skillssh-registry.js";
+import {
+  findSkillDirInTree,
+  githubHeaders,
+  resolveSkillSource,
+} from "./skillssh-registry.js";
+
+const log = getLogger("skillssh-files");
+
+// ─── Path resolution cache ──────────────────────────────────────────────────
+
+interface CacheEntry {
+  dirPath: string;
+  expiresAt: number;
+}
+
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+/**
+ * In-memory cache for resolved skill directory paths. Keyed by
+ * `${owner}/${repo}/${skillSlug}` so repeated requests don't re-probe the
+ * GitHub Contents/Tree APIs.
+ */
+const dirPathCache = new Map<string, CacheEntry>();
+
+function cacheKey(owner: string, repo: string, skillSlug: string): string {
+  return `${owner}/${repo}/${skillSlug}`;
+}
+
+function getCachedDirPath(
+  owner: string,
+  repo: string,
+  skillSlug: string,
+): string | null {
+  const key = cacheKey(owner, repo, skillSlug);
+  const entry = dirPathCache.get(key);
+  if (!entry) return null;
+  if (Date.now() > entry.expiresAt) {
+    dirPathCache.delete(key);
+    return null;
+  }
+  return entry.dirPath;
+}
+
+function setCachedDirPath(
+  owner: string,
+  repo: string,
+  skillSlug: string,
+  dirPath: string,
+): void {
+  const key = cacheKey(owner, repo, skillSlug);
+  dirPathCache.set(key, { dirPath, expiresAt: Date.now() + CACHE_TTL_MS });
+}
+
+// Exported for testing only
+export function clearDirPathCache(): void {
+  dirPathCache.clear();
+}
+
+// ─── Binary classification ──────────────────────────────────────────────────
+
+/**
+ * Classify a file as binary from its name alone. Mirrors the
+ * `classifyByName` pattern in `catalog-files.ts`.
+ */
+function classifyByName(name: string): boolean {
+  const mime = Bun.file(name).type;
+  return !isTextMime(mime, name);
+}
+
+// ─── Skill directory resolution ─────────────────────────────────────────────
+
+/**
+ * Resolve the directory path for a skill in a GitHub repo. Tries the
+ * conventional `skills/<slug>/` path first, falls back to tree search.
+ * Returns null if the skill cannot be located.
+ */
+async function resolveSkillDir(
+  owner: string,
+  repo: string,
+  skillSlug: string,
+  ref?: string,
+): Promise<string | null> {
+  // Check cache first
+  const cached = getCachedDirPath(owner, repo, skillSlug);
+  if (cached !== null) return cached;
+
+  const headers = githubHeaders();
+  const conventionalPath = `skills/${encodeURIComponent(skillSlug)}`;
+
+  const probeUrl = `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/contents/${conventionalPath}${ref ? `?ref=${encodeURIComponent(ref)}` : ""}`;
+
+  const probeResponse = await fetch(probeUrl, {
+    headers,
+    signal: AbortSignal.timeout(15_000),
+  });
+
+  if (probeResponse.ok) {
+    setCachedDirPath(owner, repo, skillSlug, conventionalPath);
+    return conventionalPath;
+  }
+
+  if (probeResponse.status === 404) {
+    // Fall back to tree search
+    const treeRef = ref ?? "HEAD";
+    const foundPath = await findSkillDirInTree(
+      owner,
+      repo,
+      skillSlug,
+      treeRef,
+      headers,
+    );
+    if (foundPath) {
+      setCachedDirPath(owner, repo, skillSlug, foundPath);
+      return foundPath;
+    }
+    return null;
+  }
+
+  // Non-404 error — log and return null
+  log.warn(
+    { status: probeResponse.status, owner, repo, skillSlug },
+    "GitHub Contents API returned non-2xx during skill dir probe",
+  );
+  return null;
+}
+
+// ─── Recursive directory listing ────────────────────────────────────────────
+
+/**
+ * Recursively list files in a GitHub directory via the Contents API.
+ * Collects `SkillFileEntry` objects with `content: null`. Skips hidden
+ * files, `node_modules`, `__pycache__`, `.git` (same filtering as
+ * `walkSkillDir` in `catalog-files.ts`).
+ */
+async function listGitHubDir(
+  owner: string,
+  repo: string,
+  dirPath: string,
+  prefix: string,
+  ref: string | undefined,
+  headers: Record<string, string>,
+): Promise<SkillFileEntry[]> {
+  let apiUrl = `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/contents/${dirPath}`;
+  if (ref) {
+    apiUrl += `?ref=${encodeURIComponent(ref)}`;
+  }
+
+  const response = await fetch(apiUrl, {
+    headers,
+    signal: AbortSignal.timeout(15_000),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `GitHub Contents API error: HTTP ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const entries = (await response.json()) as GitHubContentsEntry[];
+  if (!Array.isArray(entries)) return [];
+
+  const result: SkillFileEntry[] = [];
+
+  for (const entry of entries) {
+    // Skip hidden files/dirs (same as walkSkillDir)
+    if (entry.name.startsWith(".")) continue;
+
+    const relativePath = prefix ? `${prefix}/${entry.name}` : entry.name;
+
+    if (entry.type === "dir") {
+      // Skip well-known heavyweight directories
+      if (SKIP_DIRS.has(entry.name)) continue;
+
+      const subEntries = await listGitHubDir(
+        owner,
+        repo,
+        `${dirPath}/${entry.name}`,
+        relativePath,
+        ref,
+        headers,
+      );
+      result.push(...subEntries);
+      continue;
+    }
+
+    if (entry.type !== "file") continue;
+
+    result.push({
+      path: relativePath,
+      name: basename(relativePath),
+      size: 0, // GitHub Contents API directory listings don't include size
+      mimeType: "",
+      isBinary: classifyByName(entry.name),
+      content: null,
+    });
+  }
+
+  return result;
+}
+
+// ─── Provider implementation ────────────────────────────────────────────────
+
+export function createSkillsShProvider(): SkillFileProvider {
+  return {
+    canHandle(skillId: string): boolean {
+      return skillId.split("/").length >= 3;
+    },
+
+    async listFiles(skillId: string): Promise<SkillFileEntry[] | null> {
+      let source;
+      try {
+        source = resolveSkillSource(skillId);
+      } catch {
+        return null;
+      }
+
+      try {
+        const dirPath = await resolveSkillDir(
+          source.owner,
+          source.repo,
+          source.skillSlug,
+          source.ref,
+        );
+        if (!dirPath) return null;
+
+        const headers = githubHeaders();
+        const entries = await listGitHubDir(
+          source.owner,
+          source.repo,
+          dirPath,
+          "",
+          source.ref,
+          headers,
+        );
+        entries.sort((a, b) => a.path.localeCompare(b.path));
+        return entries;
+      } catch (err) {
+        log.warn({ err, skillId }, "Failed to list files for skills.sh skill");
+        return null;
+      }
+    },
+
+    async readFileContent(
+      skillId: string,
+      sanitizedPath: string,
+    ): Promise<SkillFileEntry | null> {
+      // Re-validate the path even though the caller should have sanitized
+      const safe = sanitizeRelativePath(sanitizedPath);
+      if (!safe) return null;
+      if (hasHiddenOrSkippedSegment(safe)) return null;
+
+      let source;
+      try {
+        source = resolveSkillSource(skillId);
+      } catch {
+        return null;
+      }
+
+      try {
+        const dirPath = await resolveSkillDir(
+          source.owner,
+          source.repo,
+          source.skillSlug,
+          source.ref,
+        );
+        if (!dirPath) return null;
+
+        const headers = githubHeaders();
+        const filePath = `${dirPath}/${safe}`;
+
+        // Fetch the file entry via GitHub Contents API
+        let apiUrl = `https://api.github.com/repos/${encodeURIComponent(source.owner)}/${encodeURIComponent(source.repo)}/contents/${filePath}`;
+        if (source.ref) {
+          apiUrl += `?ref=${encodeURIComponent(source.ref)}`;
+        }
+
+        const response = await fetch(apiUrl, {
+          headers,
+          signal: AbortSignal.timeout(15_000),
+        });
+
+        if (!response.ok) return null;
+
+        const entry = (await response.json()) as GitHubContentsEntry & {
+          size?: number;
+        };
+
+        // Ensure it's a file, not a directory
+        if (entry.type !== "file") return null;
+
+        const name = basename(safe);
+        const isBinary = classifyByName(name);
+
+        // Return null content for binary files
+        if (isBinary) {
+          return {
+            path: safe,
+            name,
+            size: entry.size ?? 0,
+            mimeType: "",
+            isBinary: true,
+            content: null,
+          };
+        }
+
+        // For text files, check size and fetch content
+        const size = entry.size ?? 0;
+        if (size > MAX_INLINE_TEXT_SIZE) {
+          return {
+            path: safe,
+            name,
+            size,
+            mimeType: "",
+            isBinary: false,
+            content: null,
+          };
+        }
+
+        // Fetch the actual file content via download_url
+        if (!entry.download_url) return null;
+
+        const contentResponse = await fetch(entry.download_url, {
+          headers,
+          signal: AbortSignal.timeout(10_000),
+        });
+
+        if (!contentResponse.ok) return null;
+
+        const content = await contentResponse.text();
+
+        return {
+          path: safe,
+          name,
+          size: content.length,
+          mimeType: "",
+          isBinary: false,
+          content,
+        };
+      } catch (err) {
+        log.warn(
+          { err, skillId, path: sanitizedPath },
+          "Failed to read file content for skills.sh skill",
+        );
+        return null;
+      }
+    },
+
+    async toSlimSkill(skillId: string): Promise<SlimSkillResponse | null> {
+      try {
+        const source = resolveSkillSource(skillId);
+        return {
+          id: skillId,
+          name: source.skillSlug,
+          description: "",
+          kind: "catalog",
+          status: "available",
+          origin: "skillssh",
+          slug: skillId,
+          sourceRepo: `${source.owner}/${source.repo}`,
+          installs: 0,
+        };
+      } catch {
+        return null;
+      }
+    },
+  };
+}

--- a/assistant/src/skills/skillssh-registry.ts
+++ b/assistant/src/skills/skillssh-registry.ts
@@ -189,14 +189,14 @@ export function resolveSkillSource(source: string): ResolvedSkillSource {
 
 // ─── GitHub fetch ───────────────────────────────────────────────────────────
 
-interface GitHubContentsEntry {
+export interface GitHubContentsEntry {
   name: string;
   type: "file" | "dir";
   download_url: string | null;
 }
 
 /** Build common headers for GitHub API requests (User-Agent + optional auth). */
-function githubHeaders(): Record<string, string> {
+export function githubHeaders(): Record<string, string> {
   const headers: Record<string, string> = {
     Accept: "application/vnd.github.v3+json",
     "User-Agent": "vellum-assistant",
@@ -208,7 +208,7 @@ function githubHeaders(): Record<string, string> {
   return headers;
 }
 
-interface GitHubTreeEntry {
+export interface GitHubTreeEntry {
   path: string;
   type: "blob" | "tree";
 }
@@ -217,7 +217,7 @@ interface GitHubTreeEntry {
  * Search the repo tree for a directory containing `<slug>/SKILL.md`.
  * Returns the directory path (e.g. "examples/skills-tool/skills/csv") or null.
  */
-async function findSkillDirInTree(
+export async function findSkillDirInTree(
   owner: string,
   repo: string,
   skillSlug: string,


### PR DESCRIPTION
## Summary
Enable clicking into uninstalled skills to preview their files for all three community/catalog origins (vellum, skills.sh, clawhub), with a unified `SkillFileProvider` abstraction that makes the file-preview system origin-agnostic.

Previously, `getSkillFiles` and `getSkillFileContent` only fell back to the vellum platform catalog when a skill wasn't installed locally. This PR introduces a provider chain that tries vellum → skills.sh → clawhub in order, so uninstalled skills from any origin can be browsed before installing.

## Changes
- **`SkillFileProvider` interface** — defines `canHandle`, `listFiles`, `readFileContent`, `toSlimSkill` methods
- **Vellum catalog provider** — wraps existing `readCatalogSkillFiles`/`readCatalogSkillFileContent` (no behavior change)
- **Skills.sh provider** — GitHub Contents API-backed file listing and on-demand content fetching with in-memory path resolution cache
- **Clawhub provider** — `clawhub inspect` CLI-backed file listing with `clawhubInspectFile` for arbitrary file content, SKILL.md content caching
- **Handler refactor** — `getSkillFiles`, `getSkillFileContent`, and `getSkill` now iterate a `fileProviders[]` array instead of hard-coding vellum-only fallback

No frontend changes needed — `SkillDetailView.swift` already handles preview generically based on `isInstalled`.

## PRs merged into feature branch
- #24785: refactor(skills): extract SkillFileProvider interface from vellum catalog file preview
- #24786: feat(skills): add skills.sh SkillFileProvider backed by GitHub Contents API
- #24787: feat(skills): add clawhub SkillFileProvider backed by clawhub inspect CLI
- #24790: feat(skills): use SkillFileProvider chain for all-origin uninstalled skill preview

Part of plan: skillssh-file-preview.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24791" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
