### PR TITLE
Chrome extension docs: document one-click connect, pause, and reopen auto-connect

### DIFF
--- a/clients/chrome-extension/README.md
+++ b/clients/chrome-extension/README.md
@@ -6,7 +6,7 @@ Core pieces:
 - `background/worker.ts`: service worker (relay lifecycle, pairing, CDP dispatch)
 - `background/assistant-auth-profile.ts`: lockfile topology to auth profile mapping
 - `background/native-host-assistants.ts`: native messaging client for assistant catalog
-- `popup/`: popup UI (assistant selector, auth panels, Connect/Disconnect)
+- `popup/`: popup UI (assistant selector, one-click Connect, Pause, troubleshooting auth controls)
 - `popup/popup-state.ts`: pure view-state helpers for the assistant selector
 - `native-host/`: native messaging helper (`com.vellum.daemon`) for self-hosted pairing and assistant discovery
 - `build.sh`: bundles extension assets into `dist/`
@@ -36,12 +36,50 @@ Then in Chrome:
 3. Click **Load unpacked**
 4. Select `clients/chrome-extension/dist`
 
-## How It Works — Assistant-Centric Model
+## How It Works — One-Click Connect
 
 The extension discovers available assistants from the lockfile via the native
 messaging helper (`com.vellum.daemon`). The lockfile lists every assistant
 configured on the machine, along with its hosting topology (`cloud` field),
 runtime URL, and local assistant port.
+
+### First-Time Connect (One Click)
+
+1. The user opens the popup and clicks **Connect**.
+2. The worker resolves the selected assistant's auth profile from the
+   lockfile topology, then auto-bootstraps credentials under the hood:
+   - **Local assistants** (`local-pair`): The worker spawns the native
+     messaging helper, which POSTs to the assistant's
+     `/v1/browser-extension-pair` endpoint and returns a scoped capability
+     token. No manual "Pair" step is needed.
+   - **Cloud assistants** (`cloud-oauth`): The worker launches a
+     `chrome.identity.launchWebAuthFlow` against the cloud gateway to
+     obtain an OAuth token. No manual "Sign in" step is needed.
+3. Once credentials are obtained, the relay WebSocket opens automatically.
+
+The entire flow is a single user action — click **Connect**.
+
+### Auto-Connect On Reopen
+
+After a successful first connect, the extension sets a persistent
+`autoConnect` flag. On subsequent browser launches (or service-worker
+restarts), the worker reads this flag and automatically reconnects using
+the stored credentials — no user interaction required.
+
+If stored credentials have expired or are missing at auto-connect time,
+the extension falls back to the disconnected state silently. The user
+can click **Connect** again to re-bootstrap credentials interactively.
+
+### Pause Semantics
+
+**Pause** is the user-facing stop action. It:
+- Tears down the active relay WebSocket.
+- Clears the `autoConnect` flag so the extension does **not** reconnect
+  on the next browser launch.
+- Preserves stored credentials so the next **Connect** is instant (no
+  re-pair or re-sign-in needed unless the token has expired).
+
+Pause replaces the previous "Disconnect" terminology.
 
 ### Assistant Discovery And Selection
 
@@ -59,9 +97,10 @@ runtime URL, and local assistant port.
 ### Topology-To-Auth Mapping
 
 Each assistant's `cloud` field in the lockfile determines which auth flow
-the extension uses. The mapping is in `assistant-auth-profile.ts`:
+the worker bootstraps automatically on Connect. The mapping is in
+`assistant-auth-profile.ts`:
 
-| `cloud` value | Auth profile | Auth flow |
+| `cloud` value | Auth profile | Auth bootstrapped on Connect |
 |---|---|---|
 | `local` | `local-pair` | Native messaging pair (capability token) |
 | `apple-container` | `local-pair` | Native messaging pair (capability token) |
@@ -69,22 +108,27 @@ the extension uses. The mapping is in `assistant-auth-profile.ts`:
 | `platform` | `cloud-oauth` | Chrome identity OAuth flow |
 | *(anything else)* | `unsupported` | Error: update the extension |
 
-- **`local-pair`**: The popup shows the **Local** auth section with a
-  "Pair with local assistant" button. Pairing spawns the native messaging
-  helper, which POSTs to the assistant's `/v1/browser-extension-pair`
-  endpoint and returns a scoped capability token. Connect targets the
-  local assistant at `ws://127.0.0.1:<port>/v1/browser-relay`.
+- **`local-pair`**: The worker auto-pairs via native messaging on Connect.
+  The relay targets the local assistant at
+  `ws://127.0.0.1:<port>/v1/browser-relay`.
 
-- **`cloud-oauth`**: The popup shows the **Cloud** auth section with a
-  "Sign in with Vellum (cloud)" button. Sign-in runs a
-  `chrome.identity.launchWebAuthFlow` against the cloud gateway. Connect
-  targets the cloud gateway at `wss://<runtimeUrl>/v1/browser-relay`.
+- **`cloud-oauth`**: The worker auto-signs in via Chrome identity on Connect.
+  The relay targets the cloud gateway at
+  `wss://<runtimeUrl>/v1/browser-relay`.
 
 - **`unsupported`**: An error message instructs the user to update the
   extension. No auth panel is shown.
 
 Auth tokens are stored per-assistant under scoped storage keys so
 switching between assistants does not require re-authentication.
+
+### Manual Recovery (Troubleshooting)
+
+The popup includes a collapsible **Troubleshooting** section with manual
+"Re-pair with local assistant" and "Re-sign in with Vellum (cloud)"
+buttons. These are **not** required for the normal connect flow — they
+exist for edge cases where the automatic bootstrap fails (e.g. expired
+tokens, native host issues, OAuth configuration problems).
 
 ## Native Messaging Host Setup (If Pairing Fails)
 
@@ -177,15 +221,15 @@ of the extension. Update the extension to the latest version.
 
 ### Per-assistant auth mismatch
 
-Each assistant requires its own auth token scoped to its topology:
+Each assistant requires its own auth token scoped to its topology. The
+worker auto-bootstraps the correct token type on Connect, so switching
+between assistants with different topologies is handled transparently.
 
-- A `local` assistant requires a **local pair** token (click "Pair with
-  local assistant").
-- A `vellum`/`platform` assistant requires a **cloud sign-in** token
-  (click "Sign in with Vellum (cloud)").
-
-Switching between assistants with different topologies may require completing
-the appropriate auth flow for the newly selected assistant before connecting.
+If automatic bootstrap fails, use the Troubleshooting controls:
+- A `local` assistant can be manually re-paired via "Re-pair with local
+  assistant".
+- A `vellum`/`platform` assistant can be manually re-signed-in via
+  "Re-sign in with Vellum (cloud)".
 
 ### Common error messages
 
@@ -196,9 +240,9 @@ the appropriate auth flow for the newly selected assistant before connecting.
 - `assistant pair request failed with HTTP 401`
   - The pair endpoint rejected `extensionOrigin`. Verify your extension ID is in `meta/browser-extension/chrome-extension-allowlist.json`, then restart the assistant so it reloads allowlist config.
 - `Sign in with Vellum (cloud) before connecting`
-  - The selected assistant uses cloud-oauth but no cloud token is stored. Click "Sign in with Vellum (cloud)" first.
+  - The selected assistant uses cloud-oauth and the automatic sign-in failed. Use the "Re-sign in with Vellum (cloud)" troubleshooting button, then click Connect again.
 - `Pair the Vellum assistant (self-hosted) before connecting`
-  - The selected assistant uses local-pair but no capability token is stored. Click "Pair with local assistant" first.
+  - The selected assistant uses local-pair and the automatic pairing failed. Use the "Re-pair with local assistant" troubleshooting button, then click Connect again.
 - `Select an assistant before connecting`
   - No assistant is selected. The lockfile may be empty or the native messaging helper is unreachable.
 - `failed to reach assistant at http://127.0.0.1:<port>/v1/browser-extension-pair`

--- a/clients/chrome-extension/background/worker.ts
+++ b/clients/chrome-extension/background/worker.ts
@@ -2,7 +2,7 @@
  * Chrome MV3 service worker — browser-relay bridge.
  *
  * Connects to either
- *   - the local daemon's browser-relay endpoint
+ *   - the local assistant's browser-relay endpoint
  *     (`ws://127.0.0.1:<relayPort>/v1/browser-relay`), or
  *   - the cloud gateway's browser-relay endpoint
  *     (`wss://<cloud-gateway>/v1/browser-relay`)
@@ -12,11 +12,24 @@
  * vocabulary — the choice is strictly about where the socket points and
  * which token is presented on the handshake.
  *
+ * The worker owns the full connect lifecycle:
+ *   - **One-click Connect**: When the popup sends `connect` with
+ *     `interactive=true`, the worker auto-bootstraps credentials
+ *     (local pair or cloud OAuth) before opening the socket. The user
+ *     never needs to manually pair or sign in.
+ *   - **Auto-connect on reopen**: After a successful connect, the
+ *     `autoConnect` storage flag is set. On service-worker startup
+ *     the `bootstrap()` function reads this flag and reconnects
+ *     non-interactively using stored credentials.
+ *   - **Pause**: The `pause` message clears the `autoConnect` flag
+ *     and tears down the socket. Credentials are preserved so the
+ *     next Connect is instant.
+ *
  * Once connected, the worker routes incoming server messages:
  *   - `host_browser_request` / `host_browser_cancel` envelopes are
  *     dispatched to the CDP proxy dispatcher, which drives a
  *     `chrome.debugger` session and POSTs a result envelope back to
- *     the daemon's `/v1/host-browser-result` endpoint.
+ *     the assistant's `/v1/host-browser-result` endpoint.
  *   - Every other payload is logged and discarded.
  */
 
@@ -273,7 +286,7 @@ let shouldConnect = false;
 // `host_browser_request` / `host_browser_cancel` envelopes arriving on
 // the relay WebSocket are routed into the CDP proxy dispatcher, which
 // drives a chrome.debugger session and POSTs a result envelope back to
-// the daemon's `/v1/host-browser-result` endpoint.
+// the assistant's `/v1/host-browser-result` endpoint.
 
 async function resolveHostBrowserTarget(
   cdpSessionId: string | undefined,
@@ -315,7 +328,7 @@ async function resolveHostBrowserTarget(
  * When no relay connection exists yet (e.g. a stale result arriving
  * after `disconnect()`), we fall back per the current auth profile:
  *
- *   - `local-pair`: POST directly to the local daemon using live
+ *   - `local-pair`: POST directly to the local assistant using live
  *     creds resolved from storage.
  *   - `cloud-oauth`: warn and drop the envelope. POSTing to localhost
  *     in cloud mode would always fail, and we have no WebSocket to
@@ -341,7 +354,7 @@ async function dispatchHostBrowserResult(
     return;
   }
 
-  // Self-hosted fallback: POST directly to the local daemon using the
+  // Self-hosted fallback: POST directly to the local assistant using the
   // capability token from the native-messaging pair flow. If no paired
   // token is available the result is dropped. When no assistant is
   // selected, fall back to the legacy unscoped token key.
@@ -772,10 +785,11 @@ function createRelayConnection(
 
 /**
  * Thrown by `connect()` when the selected assistant's auth profile
- * has no usable token yet, or when the topology is unsupported.
- * Callers (e.g. the popup connect handler) surface the message
- * verbatim to the user so they can take action — signing in to cloud,
- * re-pairing the local daemon, or updating the extension.
+ * has no usable token and the interactive bootstrap also failed, or
+ * when the topology is unsupported. Callers (e.g. the popup connect
+ * handler) surface the message verbatim so the user can take action
+ * via the Troubleshooting controls (re-pair or re-sign-in) or by
+ * updating the extension.
  */
 class MissingTokenError extends Error {
   constructor(message: string) {

--- a/clients/chrome-extension/native-host/README.md
+++ b/clients/chrome-extension/native-host/README.md
@@ -9,7 +9,11 @@ serves two purposes:
    assistant selector dropdown.
 2. **Self-hosted pairing** (`request_token`): bootstraps a scoped
    capability token for the local-assistant transport without shipping a
-   long-lived secret in the extension package.
+   long-lived secret in the extension package. In the normal one-click
+   Connect flow, the extension's service worker invokes this
+   automatically — users never need to trigger pairing manually. The
+   `request_token` message also serves as a recovery mechanism when
+   the popup's Troubleshooting "Re-pair" button is used.
 
 The macOS installer bundles this helper into the Mac `.app` under
 `Contents/MacOS/vellum-chrome-native-host` via `clients/macos/build.sh`
@@ -96,6 +100,12 @@ a `request_token` frame, the helper pairs against the specified
 assistant's port rather than the default.
 
 #### Self-hosted pairing (`request_token`)
+
+During normal operation, the extension's service worker sends this message
+automatically as part of the one-click Connect flow when the selected
+assistant uses the `local-pair` auth profile. Users do not interact with
+this message directly. It is also invoked when the user clicks the
+"Re-pair with local assistant" troubleshooting button in the popup.
 
 The extension sends:
 

--- a/clients/chrome-extension/popup/popup.ts
+++ b/clients/chrome-extension/popup/popup.ts
@@ -5,10 +5,9 @@
  * one click even when the user hasn't previously paired or signed in.
  * The worker handles auth bootstrap automatically when `interactive=true`.
  *
- * The secondary action is **Pause**, which halts the relay but preserves
- * credentials for instant reconnect. Under the hood this sends the
- * existing `disconnect` message to the worker; once PR 2 lands it will
- * migrate to the dedicated `pause` message.
+ * The secondary action is **Pause**, which halts the relay and clears the
+ * auto-connect flag so the extension stays quiet until the user explicitly
+ * reconnects. Credentials are preserved for instant reconnect.
  *
  * Manual recovery controls (local re-pair and cloud re-sign-in) are
  * available under a Troubleshooting section, but are not required for
@@ -307,14 +306,13 @@ btnConnect.addEventListener('click', async () => {
 
 // ── Pause (secondary action) ────────────────────────────────────────
 //
-// Sends the existing disconnect/stop message to the worker while
-// presenting the action as "Pause" in the UI. Credentials are
-// preserved so reconnect is instant. Once PR 2 lands, this will
-// migrate to the dedicated `pause` message.
+// Sends the `pause` message to the worker, which tears down the relay
+// WebSocket and clears the `autoConnect` flag. Credentials are
+// preserved so the next Connect is instant.
 
 btnPause.addEventListener('click', () => {
   chrome.storage.local.set({ autoConnect: false });
-  chrome.runtime.sendMessage({ type: 'disconnect' }, () => {
+  chrome.runtime.sendMessage({ type: 'pause' }, () => {
     setPhase('paused');
   });
 });


### PR DESCRIPTION
## Summary
- Update extension and native-host READMEs to describe one-click connect, auto-connect, and pause
- Remove stale pair-then-connect comments from worker.ts and popup.ts
- Verify no user-facing strings require manual pairing before connect
- Migrate popup pause action from `disconnect` to `pause` message type

Part of plan: one-click-connect-pause-autoconnect.md (PR 4 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24794" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
