### PR TITLE
Replace split voice/read-aloud settings with a single global TTS provider setting

### DIFF
--- a/assistant/src/__tests__/voice-config-update.test.ts
+++ b/assistant/src/__tests__/voice-config-update.test.ts
@@ -1,0 +1,311 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mocks — declared before imports that depend on platform/logger
+// ---------------------------------------------------------------------------
+
+const WORKSPACE_DIR = process.env.VELLUM_WORKSPACE_DIR!;
+const CONFIG_PATH = join(WORKSPACE_DIR, "config.json");
+
+function ensureTestDir(): void {
+  const dirs = [
+    WORKSPACE_DIR,
+    join(WORKSPACE_DIR, "data"),
+    join(WORKSPACE_DIR, "data", "memory"),
+    join(WORKSPACE_DIR, "data", "memory", "knowledge"),
+    join(WORKSPACE_DIR, "data", "logs"),
+  ];
+  for (const dir of dirs) {
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  }
+}
+
+function makeLoggerStub(): Record<string, unknown> {
+  const stub: Record<string, unknown> = {};
+  for (const m of [
+    "info",
+    "warn",
+    "error",
+    "debug",
+    "trace",
+    "fatal",
+    "silent",
+    "child",
+  ]) {
+    stub[m] = m === "child" ? () => makeLoggerStub() : () => {};
+  }
+  return stub;
+}
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () => makeLoggerStub(),
+}));
+
+import { run } from "../config/bundled-skills/settings/tools/voice-config-update.js";
+import { invalidateConfigCache } from "../config/loader.js";
+import type { ToolContext } from "../tools/types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function writeConfig(obj: unknown): void {
+  writeFileSync(CONFIG_PATH, JSON.stringify(obj));
+}
+
+function readConfig(): Record<string, unknown> {
+  return JSON.parse(readFileSync(CONFIG_PATH, "utf8"));
+}
+
+function makeContext(overrides?: Partial<ToolContext>): ToolContext {
+  return {
+    conversationId: "test-conv",
+    turnId: "test-turn",
+    sendToClient: overrides?.sendToClient ?? (() => {}),
+    ...overrides,
+  } as ToolContext;
+}
+
+// ---------------------------------------------------------------------------
+// Setup / Teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  ensureTestDir();
+  writeConfig({});
+  invalidateConfigCache();
+});
+
+afterEach(() => {
+  try {
+    writeConfig({});
+    invalidateConfigCache();
+  } catch {
+    // best-effort cleanup
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Tests: tts_provider persists to canonical and legacy paths
+// ---------------------------------------------------------------------------
+
+describe("voice_config_update — tts_provider", () => {
+  test("persists tts_provider to canonical services.tts.provider", async () => {
+    writeConfig({});
+    invalidateConfigCache();
+
+    const result = await run(
+      { setting: "tts_provider", value: "fish-audio" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    const config = readConfig();
+    expect((config.services as any)?.tts?.provider).toBe("fish-audio");
+  });
+
+  test("persists tts_provider to legacy calls.voice.ttsProvider", async () => {
+    writeConfig({});
+    invalidateConfigCache();
+
+    const result = await run(
+      { setting: "tts_provider", value: "fish-audio" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    const config = readConfig();
+    expect((config.calls as any)?.voice?.ttsProvider).toBe("fish-audio");
+  });
+
+  test("rejects invalid tts_provider", async () => {
+    const result = await run(
+      { setting: "tts_provider", value: "invalid-provider" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("tts_provider must be one of");
+  });
+
+  test("broadcasts ttsProvider to client", async () => {
+    const messages: any[] = [];
+    const ctx = makeContext({
+      sendToClient: (msg: any) => messages.push(msg),
+    });
+
+    await run({ setting: "tts_provider", value: "elevenlabs" }, ctx);
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0].key).toBe("ttsProvider");
+    expect(messages[0].value).toBe("elevenlabs");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: tts_voice_id persists to canonical and legacy paths
+// ---------------------------------------------------------------------------
+
+describe("voice_config_update — tts_voice_id", () => {
+  test("persists to canonical services.tts.providers.elevenlabs.voiceId", async () => {
+    writeConfig({});
+    invalidateConfigCache();
+
+    const result = await run(
+      { setting: "tts_voice_id", value: "abc123" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    const config = readConfig();
+    expect((config.services as any)?.tts?.providers?.elevenlabs?.voiceId).toBe(
+      "abc123",
+    );
+  });
+
+  test("persists to legacy elevenlabs.voiceId", async () => {
+    writeConfig({});
+    invalidateConfigCache();
+
+    const result = await run(
+      { setting: "tts_voice_id", value: "abc123" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    const config = readConfig();
+    expect((config.elevenlabs as any)?.voiceId).toBe("abc123");
+  });
+
+  test("rejects non-alphanumeric voice ID", async () => {
+    const result = await run(
+      { setting: "tts_voice_id", value: "abc-123!" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("alphanumeric");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: fish_audio_reference_id persists to canonical and legacy paths
+// ---------------------------------------------------------------------------
+
+describe("voice_config_update — fish_audio_reference_id", () => {
+  test("persists to canonical services.tts.providers.fish-audio.referenceId", async () => {
+    writeConfig({});
+    invalidateConfigCache();
+
+    const result = await run(
+      { setting: "fish_audio_reference_id", value: "voice-ref-123" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    const config = readConfig();
+    expect(
+      (config.services as any)?.tts?.providers?.["fish-audio"]?.referenceId,
+    ).toBe("voice-ref-123");
+  });
+
+  test("persists to legacy fishAudio.referenceId", async () => {
+    writeConfig({});
+    invalidateConfigCache();
+
+    const result = await run(
+      { setting: "fish_audio_reference_id", value: "voice-ref-123" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    const config = readConfig();
+    expect((config.fishAudio as any)?.referenceId).toBe("voice-ref-123");
+  });
+
+  test("rejects empty reference ID", async () => {
+    const result = await run(
+      { setting: "fish_audio_reference_id", value: "" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("non-empty string");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: conversation_timeout persists to canonical and legacy paths
+// ---------------------------------------------------------------------------
+
+describe("voice_config_update — conversation_timeout", () => {
+  test("persists to canonical services.tts.providers.elevenlabs.conversationTimeoutSeconds", async () => {
+    writeConfig({});
+    invalidateConfigCache();
+
+    const result = await run(
+      { setting: "conversation_timeout", value: 15 },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    const config = readConfig();
+    expect(
+      (config.services as any)?.tts?.providers?.elevenlabs
+        ?.conversationTimeoutSeconds,
+    ).toBe(15);
+  });
+
+  test("persists to legacy elevenlabs.conversationTimeoutSeconds", async () => {
+    writeConfig({});
+    invalidateConfigCache();
+
+    const result = await run(
+      { setting: "conversation_timeout", value: 15 },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    const config = readConfig();
+    expect((config.elevenlabs as any)?.conversationTimeoutSeconds).toBe(15);
+  });
+
+  test("rejects invalid timeout", async () => {
+    const result = await run(
+      { setting: "conversation_timeout", value: 42 },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("conversation_timeout must be one of");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: validation edge cases
+// ---------------------------------------------------------------------------
+
+describe("voice_config_update — validation", () => {
+  test("missing setting returns error", async () => {
+    const result = await run({ value: "test" }, makeContext());
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("setting");
+  });
+
+  test("missing value returns error", async () => {
+    const result = await run({ setting: "tts_provider" }, makeContext());
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("value");
+  });
+
+  test("unknown setting returns error", async () => {
+    const result = await run(
+      { setting: "unknown_setting", value: "test" },
+      makeContext(),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("Unknown setting");
+  });
+});

--- a/assistant/src/config/bundled-skills/settings/TOOLS.json
+++ b/assistant/src/config/bundled-skills/settings/TOOLS.json
@@ -3,7 +3,7 @@
   "tools": [
     {
       "name": "voice_config_update",
-      "description": "Update a voice configuration setting (TTS provider, TTS voice ID, Fish Audio reference ID, PTT activation key, conversation timeout). Changes take effect immediately.",
+      "description": "Update a voice configuration setting. Use tts_provider to switch the global TTS provider (elevenlabs or fish-audio). Use tts_voice_id to set the ElevenLabs voice ID, fish_audio_reference_id for Fish Audio voice reference. Changes persist to services.tts config and take effect immediately.",
       "category": "system",
       "risk": "low",
       "input_schema": {
@@ -18,10 +18,10 @@
               "tts_provider",
               "tts_voice_id"
             ],
-            "description": "The voice setting to change"
+            "description": "The voice setting to change. tts_provider selects the global TTS provider used for all speech features. tts_voice_id sets the ElevenLabs voice. fish_audio_reference_id sets the Fish Audio voice reference."
           },
           "value": {
-            "description": "The new value for the setting (type depends on setting)"
+            "description": "The new value for the setting. For tts_provider: 'elevenlabs' or 'fish-audio'. For tts_voice_id: an alphanumeric ElevenLabs voice ID. For fish_audio_reference_id: a Fish Audio voice reference ID. For conversation_timeout: seconds (5, 10, 15, 30, or 60). For activation_key: key identifier string."
           },
           "activity": {
             "type": "string",

--- a/assistant/src/config/bundled-skills/settings/tools/voice-config-update.ts
+++ b/assistant/src/config/bundled-skills/settings/tools/voice-config-update.ts
@@ -5,6 +5,7 @@ import {
   setNestedValue,
 } from "../../../../config/loader.js";
 import { VALID_CONVERSATION_TIMEOUTS } from "../../../../config/schemas/elevenlabs.js";
+import { VALID_TTS_PROVIDERS } from "../../../../config/schemas/tts.js";
 import { normalizeActivationKey } from "../../../../daemon/handlers/config-voice.js";
 import type {
   ToolContext,
@@ -13,6 +14,11 @@ import type {
 
 /**
  * Valid voice config settings and their UserDefaults key mappings.
+ *
+ * Canonical config paths (services.tts.*) are the source of truth.
+ * Legacy aliases (tts_voice_id, fish_audio_reference_id) write to both
+ * canonical and legacy config paths during the migration window. These
+ * aliases will be removed in PR 10.
  */
 const VOICE_SETTINGS = {
   activation_key: {
@@ -23,8 +29,8 @@ const VOICE_SETTINGS = {
     userDefaultsKey: "voiceConversationTimeoutSeconds",
     type: "number" as const,
   },
-  tts_voice_id: { userDefaultsKey: "ttsVoiceId", type: "string" as const },
   tts_provider: { userDefaultsKey: "ttsProvider", type: "string" as const },
+  tts_voice_id: { userDefaultsKey: "ttsVoiceId", type: "string" as const },
   fish_audio_reference_id: {
     userDefaultsKey: "fishAudioReferenceId",
     type: "string" as const,
@@ -40,8 +46,8 @@ const VALID_TIMEOUTS: readonly number[] = VALID_CONVERSATION_TIMEOUTS;
 const FRIENDLY_NAMES: Record<VoiceSettingName, string> = {
   activation_key: "PTT activation key",
   conversation_timeout: "Conversation timeout",
-  tts_voice_id: "ElevenLabs voice",
   tts_provider: "TTS provider",
+  tts_voice_id: "ElevenLabs voice",
   fish_audio_reference_id: "Fish Audio voice",
 };
 
@@ -105,7 +111,7 @@ function validateSetting(
       return { ok: true, coerced: trimmed };
     }
     case "tts_provider": {
-      const valid = ["elevenlabs", "fish-audio"];
+      const valid: readonly string[] = VALID_TTS_PROVIDERS;
       if (typeof value !== "string" || !valid.includes(value.trim())) {
         return {
           ok: false,
@@ -170,19 +176,40 @@ export async function run(
     });
   }
 
-  // For tts_voice_id, also persist to the config file (elevenlabs.voiceId)
-  // so phone calls and other consumers pick it up.
+  // Persist to canonical config paths under services.tts.*
+  // Also write to legacy paths as temporary adapters until PR 10.
+  const raw = loadRawConfig();
+
+  if (setting === "tts_provider") {
+    // Canonical path
+    setNestedValue(raw, "services.tts.provider", validation.coerced);
+    // Legacy alias (temporary — removed in PR 10)
+    setNestedValue(raw, "calls.voice.ttsProvider", validation.coerced);
+    saveRawConfig(raw);
+    invalidateConfigCache();
+  }
+
   if (setting === "tts_voice_id") {
-    const raw = loadRawConfig();
+    // Canonical path
+    setNestedValue(
+      raw,
+      "services.tts.providers.elevenlabs.voiceId",
+      validation.coerced,
+    );
+    // Legacy alias (temporary — removed in PR 10)
     setNestedValue(raw, "elevenlabs.voiceId", validation.coerced);
     saveRawConfig(raw);
     invalidateConfigCache();
   }
 
-  // For conversation_timeout, persist to the config file
-  // (elevenlabs.conversationTimeoutSeconds).
   if (setting === "conversation_timeout") {
-    const raw = loadRawConfig();
+    // Canonical path
+    setNestedValue(
+      raw,
+      "services.tts.providers.elevenlabs.conversationTimeoutSeconds",
+      validation.coerced,
+    );
+    // Legacy alias (temporary — removed in PR 10)
     setNestedValue(
       raw,
       "elevenlabs.conversationTimeoutSeconds",
@@ -192,17 +219,14 @@ export async function run(
     invalidateConfigCache();
   }
 
-  // For tts_provider, persist to config file (calls.voice.ttsProvider).
-  if (setting === "tts_provider") {
-    const raw = loadRawConfig();
-    setNestedValue(raw, "calls.voice.ttsProvider", validation.coerced);
-    saveRawConfig(raw);
-    invalidateConfigCache();
-  }
-
-  // For fish_audio_reference_id, persist to config file (fishAudio.referenceId).
   if (setting === "fish_audio_reference_id") {
-    const raw = loadRawConfig();
+    // Canonical path
+    setNestedValue(
+      raw,
+      "services.tts.providers.fish-audio.referenceId",
+      validation.coerced,
+    );
+    // Legacy alias (temporary — removed in PR 10)
     setNestedValue(raw, "fishAudio.referenceId", validation.coerced);
     saveRawConfig(raw);
     invalidateConfigCache();

--- a/assistant/src/daemon/tool-side-effects.ts
+++ b/assistant/src/daemon/tool-side-effects.ts
@@ -215,7 +215,9 @@ registerHook(
     const SETTING_TO_KEY: Record<string, string> = {
       activation_key: "pttActivationKey",
       tts_voice_id: "ttsVoiceId",
+      tts_provider: "ttsProvider",
       conversation_timeout: "voiceConversationTimeoutSeconds",
+      fish_audio_reference_id: "fishAudioReferenceId",
     };
     const key = SETTING_TO_KEY[setting];
     if (!key) return;
@@ -227,6 +229,13 @@ registerHook(
     if (setting === "conversation_timeout") {
       coerced = typeof raw === "number" ? raw : Number(raw);
     } else if (setting === "tts_voice_id" && typeof raw === "string") {
+      coerced = raw.trim();
+    } else if (
+      setting === "fish_audio_reference_id" &&
+      typeof raw === "string"
+    ) {
+      coerced = raw.trim();
+    } else if (setting === "tts_provider" && typeof raw === "string") {
       coerced = raw.trim();
     }
     broadcastToAllClients?.({

--- a/clients/ios/Views/Settings/VoiceSettingsSection.swift
+++ b/clients/ios/Views/Settings/VoiceSettingsSection.swift
@@ -2,17 +2,27 @@
 import SwiftUI
 import VellumAssistantShared
 
-/// TTS provider options surfaced in Voice settings.
-/// The system provider uses iOS AVSpeechSynthesizer; ElevenLabs uses the
-/// ElevenLabs REST API (requires an API key stored in the keychain under "elevenlabs").
+/// TTS provider options for the unified global provider selector.
+/// The selected provider is used for all speech features — voice conversations
+/// and read-aloud. Provider-specific configuration (API keys, voice IDs)
+/// is managed through the assistant's settings tools.
 enum TTSProvider: String, CaseIterable {
-    case system = "system"
-    case elevenLabs = "elevenlabs"
+    case elevenlabs = "elevenlabs"
+    case fishAudio = "fish-audio"
 
     var displayName: String {
         switch self {
-        case .system: return "System (Apple)"
-        case .elevenLabs: return "ElevenLabs"
+        case .elevenlabs: return "ElevenLabs"
+        case .fishAudio: return "Fish Audio"
+        }
+    }
+
+    var footerText: String {
+        switch self {
+        case .elevenlabs:
+            return "ElevenLabs provides high-quality voice synthesis. Requires an API key — configure via the assistant's voice settings on your Mac."
+        case .fishAudio:
+            return "Fish Audio provides natural-sounding voice synthesis with custom voice cloning. Requires an API key and voice reference ID — configure via the assistant's voice settings on your Mac."
         }
     }
 }
@@ -31,11 +41,11 @@ struct VoiceSettingsSection: View {
     /// Range 5 – 60 s.
     @AppStorage(UserDefaultsKeys.voiceListeningTimeout) private var listeningTimeout: Double = 30.0
 
-    /// TTS provider used when the assistant speaks a response.
-    @AppStorage(UserDefaultsKeys.voiceTTSProvider) private var ttsProviderRaw: String = TTSProvider.system.rawValue
+    /// Global TTS provider used for all speech features.
+    @AppStorage(UserDefaultsKeys.voiceTTSProvider) private var ttsProviderRaw: String = TTSProvider.elevenlabs.rawValue
 
     private var ttsProvider: TTSProvider {
-        TTSProvider(rawValue: ttsProviderRaw) ?? .system
+        TTSProvider(rawValue: ttsProviderRaw) ?? .elevenlabs
     }
 
     var body: some View {
@@ -92,71 +102,11 @@ struct VoiceSettingsSection: View {
             } header: {
                 Text("Text-to-Speech")
             } footer: {
-                Group {
-                    if ttsProvider == .elevenLabs {
-                        Text("ElevenLabs requires an API key. Get yours at elevenlabs.io — this is the same provider used by voice mode on macOS.")
-                    } else {
-                        Text("System uses Apple's built-in AVSpeechSynthesizer. No API key required.")
-                    }
-                }
-            }
-
-            // ElevenLabs API key entry (shown only when ElevenLabs is selected)
-            if ttsProvider == .elevenLabs {
-                ElevenLabsKeySection()
+                Text(ttsProvider.footerText)
             }
         }
         .navigationTitle("Voice")
         .navigationBarTitleDisplayMode(.inline)
-    }
-}
-
-// MARK: - ElevenLabs Key Section
-
-/// Inline key management for ElevenLabs — shown when ElevenLabs TTS is selected.
-private struct ElevenLabsKeySection: View {
-    @State private var keyText: String = ""
-    @State private var isSaved = false
-    @State private var hasExistingKey = false
-
-    var body: some View {
-        Section {
-            if hasExistingKey {
-                HStack {
-                    VIconView(.circleCheck, size: 16)
-                        .foregroundStyle(.green)
-                    Text("API key saved")
-                    Spacer()
-                    Button("Remove", role: .destructive) {
-                        _ = APIKeyManager.shared.deleteAPIKey(provider: "elevenlabs")
-                        hasExistingKey = false
-                        keyText = ""
-                    }
-                    .font(.caption)
-                }
-            } else {
-                SecureField("ElevenLabs API Key", text: $keyText)
-                    .textContentType(.password)
-                    .autocapitalization(.none)
-                    .disableAutocorrection(true)
-
-                Button("Save") {
-                    let trimmed = keyText.trimmingCharacters(in: .whitespacesAndNewlines)
-                    guard !trimmed.isEmpty else { return }
-                    _ = APIKeyManager.shared.setAPIKey(trimmed, provider: "elevenlabs")
-                    hasExistingKey = true
-                    keyText = ""
-                }
-                .disabled(keyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-            }
-        } header: {
-            Text("ElevenLabs API Key")
-        } footer: {
-            Text("Your key is stored securely in the iOS Keychain and never sent to Vellum servers.")
-        }
-        .onAppear {
-            hasExistingKey = APIKeyManager.shared.getAPIKey(provider: "elevenlabs") != nil
-        }
     }
 }
 #endif

--- a/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
@@ -302,6 +302,11 @@ extension AppDelegate {
                     if msg.key == "activationKey" {
                         NotificationCenter.default.post(name: .activationKeyChanged, object: nil)
                     }
+                    // Notify observers when the global TTS provider changes so
+                    // voice mode and other consumers can pick up the new provider.
+                    if msg.key == "ttsProvider" {
+                        NotificationCenter.default.post(name: .configChanged, object: nil)
+                    }
                 case .identityChanged(let msg):
                     NotificationCenter.default.post(
                         name: .identityChanged,

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -2906,6 +2906,23 @@ public final class SettingsStore: ObservableObject {
         return task
     }
 
+    /// Persists the selected TTS provider to the daemon config so synthesis
+    /// routes through the correct backend. The canonical config path is
+    /// `services.tts.provider`.
+    @discardableResult
+    func setTTSProvider(_ provider: String) -> Task<Bool, Never> {
+        let task = Task {
+            let success = await settingsClient.patchConfig([
+                "services": ["tts": ["provider": provider]]
+            ])
+            if !success {
+                log.error("Failed to patch config for TTS provider")
+            }
+            return success
+        }
+        return task
+    }
+
     /// Schedules a delayed refresh of provider routing sources, giving the
     /// daemon time to re-initialize providers after a key change.
     private func scheduleRoutingSourceRefresh() {

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -3327,6 +3327,15 @@ public final class SettingsStore: ObservableObject {
             self.webSearchProvider = provider
         }
 
+        // Sync the global TTS provider from the daemon config so the client
+        // stays aligned after restart or reconnection. The canonical path
+        // is services.tts.provider.
+        if let services = config["services"] as? [String: Any],
+           let tts = services["tts"] as? [String: Any],
+           let ttsProvider = tts["provider"] as? String {
+            UserDefaults.standard.set(ttsProvider, forKey: "ttsProvider")
+        }
+
         Self.applyHostBrowserCdpInspectConfig(config, into: self)
 
         loadServiceModes(config: config)

--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -322,6 +322,7 @@ struct VoiceSettingsView: View {
                             let isSelected = ttsProvider == provider
                             providerOption(label: provider.displayName, isSelected: isSelected) {
                                 ttsProviderRaw = provider.rawValue
+                                store.setTTSProvider(provider.rawValue)
                             }
                         }
                     }

--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -1,13 +1,36 @@
 import SwiftUI
 import VellumAssistantShared
 
+/// TTS provider options for the unified global provider selector.
+private enum TTSProviderOption: String, CaseIterable {
+    case elevenlabs = "elevenlabs"
+    case fishAudio = "fish-audio"
+
+    var displayName: String {
+        switch self {
+        case .elevenlabs: return "ElevenLabs"
+        case .fishAudio: return "Fish Audio"
+        }
+    }
+
+    var subtitle: String {
+        switch self {
+        case .elevenlabs:
+            return "High-quality voice synthesis for conversations and read-aloud. Requires an ElevenLabs API key."
+        case .fishAudio:
+            return "Natural-sounding voice synthesis with custom voice cloning. Requires a Fish Audio API key and voice reference ID."
+        }
+    }
+}
+
 /// Voice settings tab — configure push-to-talk activation key,
-/// conversation timeout, and text-to-speech.
+/// conversation timeout, and text-to-speech provider.
 struct VoiceSettingsView: View {
     @ObservedObject var store: SettingsStore
 
     @AppStorage("activationKey") private var activationKey: String = "fn"
     @AppStorage("voiceConversationTimeoutSeconds") private var conversationTimeoutSeconds: Int = 30
+    @AppStorage("ttsProvider") private var ttsProviderRaw: String = TTSProviderOption.elevenlabs.rawValue
 
     @State private var elevenLabsKeyText: String = ""
     @State private var ttsSetupExpanded: Bool = false
@@ -16,6 +39,10 @@ struct VoiceSettingsView: View {
     @State private var isRecordingCustomKey: Bool = false
     @State private var recordingMonitors: [Any] = []
     @State private var modifierHoldTimer: Timer? = nil
+
+    private var ttsProvider: TTSProviderOption {
+        TTSProviderOption(rawValue: ttsProviderRaw) ?? .elevenlabs
+    }
 
     private var currentActivator: PTTActivator {
         // Read activationKey to establish SwiftUI dependency tracking —
@@ -40,15 +67,12 @@ struct VoiceSettingsView: View {
         VStack(alignment: .leading, spacing: VSpacing.lg) {
             pttCard
             conversationTimeoutCard
-            ttsCard
-            readAloudCard
+            ttsProviderCard
         }
         .onDisappear {
             stopRecordingCustomKey()
         }
         .onAppear {
-            // ElevenLabs key is still saved locally (not yet synced to daemon),
-            // so use the sync check until 22a-3 migrates saveElevenLabsKey.
             elevenLabsHasKey = APIKeyManager.getKey(for: "elevenlabs") != nil
         }
         .onChange(of: conversationTimeoutSeconds) {
@@ -282,10 +306,78 @@ struct VoiceSettingsView: View {
         (label: "60 seconds", value: 60),
     ]
 
-    // MARK: - Voice Conversation TTS Card
+    // MARK: - Unified TTS Provider Card
 
-    private var ttsCard: some View {
-        SettingsCard(title: "Text-to-Speech", subtitle: "ElevenLabs provides high-quality voice responses during voice conversations. An API key is required.") {
+    private var ttsProviderCard: some View {
+        SettingsCard(title: "Text-to-Speech", subtitle: "Choose a TTS provider for voice conversations and read-aloud. The selected provider is used globally across all speech features.") {
+            VStack(alignment: .leading, spacing: VSpacing.md) {
+                // Provider selector
+                VStack(alignment: .leading, spacing: VSpacing.sm) {
+                    Text("Provider:")
+                        .font(VFont.bodySmallDefault)
+                        .foregroundStyle(VColor.contentSecondary)
+
+                    HStack(spacing: VSpacing.sm) {
+                        ForEach(TTSProviderOption.allCases, id: \.rawValue) { provider in
+                            let isSelected = ttsProvider == provider
+                            providerOption(label: provider.displayName, isSelected: isSelected) {
+                                ttsProviderRaw = provider.rawValue
+                            }
+                        }
+                    }
+                }
+
+                // Provider-specific subtitle
+                Text(ttsProvider.subtitle)
+                    .font(VFont.bodySmallDefault)
+                    .foregroundStyle(VColor.contentTertiary)
+
+                // Provider-specific configuration
+                switch ttsProvider {
+                case .elevenlabs:
+                    elevenLabsProviderConfig
+                case .fishAudio:
+                    fishAudioProviderConfig
+                }
+            }
+        }
+    }
+
+    private func providerOption(label: String, isSelected: Bool, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            HStack(spacing: VSpacing.sm) {
+                Circle()
+                    .fill(isSelected ? VColor.primaryBase : Color.clear)
+                    .frame(width: 10, height: 10)
+                    .overlay(
+                        Circle()
+                            .strokeBorder(isSelected ? VColor.primaryBase : VColor.borderHover, lineWidth: 1.5)
+                    )
+
+                Text(label)
+                    .font(VFont.bodyMediumLighter)
+                    .foregroundStyle(VColor.contentDefault)
+            }
+            .padding(.horizontal, VSpacing.md)
+            .padding(.vertical, VSpacing.sm)
+            .background(
+                RoundedRectangle(cornerRadius: VRadius.lg)
+                    .fill(isSelected ? VColor.surfaceActive : Color.clear)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: VRadius.lg)
+                    .strokeBorder(VColor.borderBase, lineWidth: 1)
+            )
+            .contentShape(RoundedRectangle(cornerRadius: VRadius.lg))
+        }
+        .buttonStyle(.plain)
+        .pointerCursor()
+    }
+
+    // MARK: - ElevenLabs Provider Config
+
+    private var elevenLabsProviderConfig: some View {
+        Group {
             if elevenLabsHasKey {
                 HStack(spacing: VSpacing.sm) {
                     VButton(label: "Connected", leftIcon: VIcon.circleCheck.rawValue, style: .primary) {}
@@ -335,40 +427,38 @@ struct VoiceSettingsView: View {
         }
     }
 
-    // MARK: - Read Aloud Card
+    // MARK: - Fish Audio Provider Config
 
-    private var readAloudCard: some View {
-        SettingsCard(title: "Read Aloud", subtitle: "Fish Audio powers natural-sounding read-aloud for any assistant message. Requires a Fish Audio account with an API key and a voice reference ID.") {
-            VStack(alignment: .leading, spacing: VSpacing.md) {
-                VStack(alignment: .leading, spacing: VSpacing.xs) {
-                    Text("1. Create a Fish Audio account at fish.audio")
-                        .font(VFont.bodyMediumDefault)
-                        .foregroundStyle(VColor.contentSecondary)
-                    Text("2. Generate an API key from your Fish Audio dashboard")
-                        .font(VFont.bodyMediumDefault)
-                        .foregroundStyle(VColor.contentSecondary)
-                    Text("3. Choose or create a voice and copy its reference ID")
-                        .font(VFont.bodyMediumDefault)
-                        .foregroundStyle(VColor.contentSecondary)
-                    Text("4. Run the setup commands in your terminal:")
-                        .font(VFont.bodyMediumDefault)
-                        .foregroundStyle(VColor.contentSecondary)
-                }
-
-                Text("assistant credentials set --service fish-audio --field api_key YOUR_KEY\nassistant config set fishAudio.referenceId YOUR_VOICE_ID")
-                    .font(.system(size: 12, design: .monospaced))
+    private var fishAudioProviderConfig: some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                Text("1. Create a Fish Audio account at fish.audio")
+                    .font(VFont.bodyMediumDefault)
                     .foregroundStyle(VColor.contentSecondary)
-                    .padding(VSpacing.md)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .background(
-                        RoundedRectangle(cornerRadius: VRadius.md)
-                            .fill(VColor.surfaceBase)
-                    )
-                    .textSelection(.enabled)
+                Text("2. Generate an API key from your Fish Audio dashboard")
+                    .font(VFont.bodyMediumDefault)
+                    .foregroundStyle(VColor.contentSecondary)
+                Text("3. Choose or create a voice and copy its reference ID")
+                    .font(VFont.bodyMediumDefault)
+                    .foregroundStyle(VColor.contentSecondary)
+                Text("4. Run the setup commands in your terminal:")
+                    .font(VFont.bodyMediumDefault)
+                    .foregroundStyle(VColor.contentSecondary)
+            }
 
-                VButton(label: "Visit Fish Audio", rightIcon: VIcon.arrowUpRight.rawValue, style: .outlined) {
-                    NSWorkspace.shared.open(URL(string: "https://fish.audio")!)
-                }
+            Text("assistant credentials set --service fish-audio --field api_key YOUR_KEY\nassistant config set services.tts.providers.fish-audio.referenceId YOUR_VOICE_ID")
+                .font(.system(size: 12, design: .monospaced))
+                .foregroundStyle(VColor.contentSecondary)
+                .padding(VSpacing.md)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(
+                    RoundedRectangle(cornerRadius: VRadius.md)
+                        .fill(VColor.surfaceBase)
+                )
+                .textSelection(.enabled)
+
+            VButton(label: "Visit Fish Audio", rightIcon: VIcon.arrowUpRight.rawValue, style: .outlined) {
+                NSWorkspace.shared.open(URL(string: "https://fish.audio")!)
             }
         }
     }


### PR DESCRIPTION
## Summary
- Replaces separate ElevenLabs/Fish Audio settings with unified global provider selector
- Extends voice-config-update tool to support canonical services.tts config paths
- Updates TOOLS.json, tool-side-effects, and client settings for new keys
- Updates iOS voice settings to match unified model

Part of plan: product-tts-provider-abstraction.md (PR 9 of 11)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24796" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
