### PR TITLE
fix: remove unused currentPhase variable from popup.ts

### DIFF
--- a/clients/chrome-extension/popup/popup.ts
+++ b/clients/chrome-extension/popup/popup.ts
@@ -81,14 +81,11 @@ let currentAssistantId: string | null = null;
 
 // ── Connection phase management ─────────────────────────────────────
 
-let currentPhase: ConnectionPhase = 'disconnected';
-
 /**
  * Apply a connection phase to the UI. Derives button labels/enablement
  * and status indicator from the pure helpers in popup-state.ts.
  */
 function setPhase(phase: ConnectionPhase): void {
-  currentPhase = phase;
 
   const cta = deriveCtaState(phase);
   btnConnect.textContent = cta.connectLabel;


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for one-click-connect-pause-autoconnect.md.

**Gap:** currentPhase variable written but never read
**What was expected:** No dead code
**What was found:** currentPhase set in setPhase() but never consumed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24797" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
