### PR TITLE
fix: remove unused beforeEach/afterEach imports from connect preflight tests

### DIFF
--- a/clients/chrome-extension/background/__tests__/worker-connect-preflight.test.ts
+++ b/clients/chrome-extension/background/__tests__/worker-connect-preflight.test.ts
@@ -24,7 +24,7 @@
  *   - Preflight is a no-op when valid token already exists.
  */
 
-import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { describe, test, expect } from 'bun:test';
 
 import { resolveAuthProfile, type AssistantAuthProfile } from '../assistant-auth-profile.js';
 import type { AssistantDescriptor } from '../native-host-assistants.js';


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for one-click-connect-pause-autoconnect.md.

**Gap:** Unused imports in test file
**What was expected:** Clean imports
**What was found:** beforeEach and afterEach imported but never used
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24798" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
