### PR TITLE
fix: remove popup's eager autoConnect writes, let worker own the flag

### DIFF
--- a/clients/chrome-extension/popup/popup.ts
+++ b/clients/chrome-extension/popup/popup.ts
@@ -267,18 +267,16 @@ function getPort(): number {
 
 btnConnect.addEventListener('click', async () => {
   const port = getPort();
-  const storageUpdate: Record<string, unknown> = { autoConnect: true };
 
   errorText.style.display = 'none';
   setPhase('connecting');
 
   try {
     if (portInput.value.trim()) {
-      storageUpdate.relayPort = port;
+      await chrome.storage.local.set({ relayPort: port });
     } else {
       await chrome.storage.local.remove('relayPort');
     }
-    await chrome.storage.local.set(storageUpdate);
   } catch (err) {
     showError(err instanceof Error ? err.message : String(err));
     setPhase('disconnected');
@@ -311,7 +309,6 @@ btnConnect.addEventListener('click', async () => {
 // preserved so the next Connect is instant.
 
 btnPause.addEventListener('click', () => {
-  chrome.storage.local.set({ autoConnect: false });
   chrome.runtime.sendMessage({ type: 'pause' }, () => {
     setPhase('paused');
   });


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for one-click-connect-pause-autoconnect.md.

**Gap:** Popup eagerly writes autoConnect=true before worker confirms success
**What was expected:** autoConnect should only be true after successful connect
**What was found:** Popup wrote autoConnect: true before sending connect message
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24799" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
