### PR TITLE
fix: allow interactive connect to supersede in-flight non-interactive connect

### DIFF
--- a/clients/chrome-extension/background/worker.ts
+++ b/clients/chrome-extension/background/worker.ts
@@ -950,17 +950,26 @@ async function connectPreflight(
 // preflight. This prevents duplicate auth/pair flows when multiple
 // connect calls arrive before the first socket opens (e.g., repeated
 // user action or overlapping message paths).
+//
+// Exception: an interactive connect (user-initiated) always supersedes a
+// non-interactive one (bootstrap). If the in-flight connect is
+// non-interactive and the new caller is interactive, we discard the
+// in-flight promise and start a fresh interactive connect so the user
+// gets the interactive auth flow they expect.
 let connectInFlight: Promise<void> | null = null;
+let connectInFlightInteractive = false;
 
 async function connect(options: ConnectOptions = { interactive: false }): Promise<void> {
-  if (connectInFlight) {
+  if (connectInFlight && (connectInFlightInteractive || !options.interactive)) {
     return connectInFlight;
   }
+  connectInFlightInteractive = !!options.interactive;
   connectInFlight = doConnect(options);
   try {
     await connectInFlight;
   } finally {
     connectInFlight = null;
+    connectInFlightInteractive = false;
   }
 }
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for one-click-connect-pause-autoconnect.md.

**Gap:** connectInFlight serialization lock discards the second caller's interactive flag
**What was expected:** Interactive connect should always launch interactive auth flow
**What was found:** Non-interactive in-flight connect blocked interactive caller
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24800" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
