### PR TITLE
fix: update error messages to reference troubleshooting controls instead of manual pre-steps

### DIFF
--- a/clients/chrome-extension/README.md
+++ b/clients/chrome-extension/README.md
@@ -239,10 +239,10 @@ If automatic bootstrap fails, use the Troubleshooting controls:
   - Chrome could not launch Node for a `dist/index.js` host path. Use a wrapper script with an absolute Node path in the manifest `path`.
 - `assistant pair request failed with HTTP 401`
   - The pair endpoint rejected `extensionOrigin`. Verify your extension ID is in `meta/browser-extension/chrome-extension-allowlist.json`, then restart the assistant so it reloads allowlist config.
-- `Sign in with Vellum (cloud) before connecting`
-  - The selected assistant uses cloud-oauth and the automatic sign-in failed. Use the "Re-sign in with Vellum (cloud)" troubleshooting button, then click Connect again.
-- `Pair the Vellum assistant (self-hosted) before connecting`
-  - The selected assistant uses local-pair and the automatic pairing failed. Use the "Re-pair with local assistant" troubleshooting button, then click Connect again.
+- `Automatic cloud sign-in failed — use 'Re-sign in' in Troubleshooting, then try Connect again`
+  - The selected assistant uses cloud-oauth and the automatic sign-in failed. Use the "Re-sign in" button in the Troubleshooting section of the popup, then click Connect again.
+- `Automatic local pairing failed — use 'Re-pair' in Troubleshooting, then try Connect again`
+  - The selected assistant uses local-pair and the automatic pairing failed. Use the "Re-pair" button in the Troubleshooting section of the popup, then click Connect again.
 - `Select an assistant before connecting`
   - No assistant is selected. The lockfile may be empty or the native messaging helper is unreachable.
 - `failed to reach assistant at http://127.0.0.1:<port>/v1/browser-extension-pair`

--- a/clients/chrome-extension/background/__tests__/cloud-reconnect-decision.test.ts
+++ b/clients/chrome-extension/background/__tests__/cloud-reconnect-decision.test.ts
@@ -114,7 +114,7 @@ describe('decideCloudReconnectAction', () => {
       expect(action.error).toContain(
         `after ${CLOUD_REFRESH_ATTEMPT_CAP} token refresh attempts`,
       );
-      expect(action.error).toContain('sign in');
+      expect(action.error).toContain('Re-sign in');
     }
   });
 

--- a/clients/chrome-extension/background/__tests__/worker-autoconnect.test.ts
+++ b/clients/chrome-extension/background/__tests__/worker-autoconnect.test.ts
@@ -234,7 +234,7 @@ describe('autoConnect lifecycle — connect sets sticky flag', () => {
 
     const response = await handleConnectFailing(
       state,
-      new MissingTokenError('Sign in with Vellum (cloud) before connecting'),
+      new MissingTokenError("Automatic cloud sign-in failed \u2014 use 'Re-sign in' in Troubleshooting, then try Connect again"),
     );
 
     expect(response.ok).toBe(false);
@@ -349,7 +349,7 @@ describe('failed auto-connect — no reconnect loop', () => {
     const state = createWorkerState({ currentAuthProfile: 'local-pair' });
     await state.storage.set({ [AUTO_CONNECT_KEY]: true });
 
-    const errorMessage = 'Pair the Vellum assistant (self-hosted) before connecting';
+    const errorMessage = "Automatic local pairing failed \u2014 use 'Re-pair' in Troubleshooting, then try Connect again";
     await simulateBootstrap(state, async () => {
       throw new MissingTokenError(errorMessage);
     });
@@ -370,7 +370,7 @@ describe('failed auto-connect — no reconnect loop', () => {
     const state = createWorkerState({ currentAuthProfile: 'cloud-oauth' });
     await state.storage.set({ [AUTO_CONNECT_KEY]: true });
 
-    const errorMessage = 'Sign in with Vellum (cloud) before connecting';
+    const errorMessage = "Automatic cloud sign-in failed \u2014 use 'Re-sign in' in Troubleshooting, then try Connect again";
     await simulateBootstrap(state, async () => {
       throw new MissingTokenError(errorMessage);
     });

--- a/clients/chrome-extension/background/__tests__/worker-connect-preflight.test.ts
+++ b/clients/chrome-extension/background/__tests__/worker-connect-preflight.test.ts
@@ -50,10 +50,10 @@ class MissingTokenError extends Error {
 
 function missingTokenMessage(profile: AssistantAuthProfile | null): string {
   if (profile === 'cloud-oauth') {
-    return 'Sign in with Vellum (cloud) before connecting';
+    return "Automatic cloud sign-in failed \u2014 use 'Re-sign in' in Troubleshooting, then try Connect again";
   }
   if (profile === 'local-pair') {
-    return 'Pair the Vellum assistant (self-hosted) before connecting';
+    return "Automatic local pairing failed \u2014 use 'Re-pair' in Troubleshooting, then try Connect again";
   }
   if (profile === 'unsupported') {
     return 'This assistant uses an unsupported topology. Please update the Vellum extension.';
@@ -296,7 +296,7 @@ describe('connectPreflight — local-pair topology', () => {
       expect.unreachable('should have thrown');
     } catch (err) {
       expect(err).toBeInstanceOf(MissingTokenError);
-      expect((err as Error).message).toContain('Pair');
+      expect((err as Error).message).toContain('Re-pair');
     }
   });
 
@@ -443,7 +443,7 @@ describe('connectPreflight — cloud-oauth topology', () => {
       expect.unreachable('should have thrown');
     } catch (err) {
       expect(err).toBeInstanceOf(MissingTokenError);
-      expect((err as Error).message).toContain('Sign in');
+      expect((err as Error).message).toContain('Re-sign in');
     }
   });
 

--- a/clients/chrome-extension/background/__tests__/worker-selected-assistant-connect.test.ts
+++ b/clients/chrome-extension/background/__tests__/worker-selected-assistant-connect.test.ts
@@ -219,10 +219,10 @@ describe('missing token error messages', () => {
   // testing without importing the side-effectful module.
   function missingTokenMessage(profile: AssistantAuthProfile | null): string {
     if (profile === 'cloud-oauth') {
-      return 'Sign in with Vellum (cloud) before connecting';
+      return "Automatic cloud sign-in failed \u2014 use 'Re-sign in' in Troubleshooting, then try Connect again";
     }
     if (profile === 'local-pair') {
-      return 'Pair the Vellum assistant (self-hosted) before connecting';
+      return "Automatic local pairing failed \u2014 use 'Re-pair' in Troubleshooting, then try Connect again";
     }
     if (profile === 'unsupported') {
       return 'This assistant uses an unsupported topology. Please update the Vellum extension.';
@@ -231,11 +231,11 @@ describe('missing token error messages', () => {
   }
 
   test('cloud-oauth produces cloud sign-in prompt', () => {
-    expect(missingTokenMessage('cloud-oauth')).toContain('Sign in');
+    expect(missingTokenMessage('cloud-oauth')).toContain('Re-sign in');
   });
 
   test('local-pair produces pair prompt', () => {
-    expect(missingTokenMessage('local-pair')).toContain('Pair');
+    expect(missingTokenMessage('local-pair')).toContain('Re-pair');
   });
 
   test('unsupported produces update prompt', () => {

--- a/clients/chrome-extension/background/cloud-reconnect-decision.ts
+++ b/clients/chrome-extension/background/cloud-reconnect-decision.ts
@@ -77,7 +77,7 @@ export function decideCloudReconnectAction(
       kind: 'abort',
       error:
         `Cloud relay kept closing with abnormal closure (code 1006) after ${CLOUD_REFRESH_ATTEMPT_CAP} ` +
-        'token refresh attempts. Please sign in with Vellum (cloud) again from the extension popup to reconnect.',
+        "token refresh attempts. Use 'Re-sign in' in Troubleshooting, then try Connect again.",
     };
   }
 

--- a/clients/chrome-extension/background/worker.ts
+++ b/clients/chrome-extension/background/worker.ts
@@ -694,7 +694,7 @@ async function cloudReconnectHook(
   return {
     kind: 'abort',
     error:
-      `${reason}. Please sign in with Vellum (cloud) again from the extension popup to reconnect.`,
+      `${reason}. Use 'Re-sign in' in Troubleshooting, then try Connect again.`,
   };
 }
 
@@ -777,7 +777,7 @@ function createRelayConnection(
       return {
         kind: 'abort',
         error:
-          'Self-hosted relay token missing or expired. Pair the Vellum assistant again from the extension popup.',
+          "Self-hosted relay token missing or expired. Use 'Re-pair' in Troubleshooting, then try Connect again.",
       };
     },
   });
@@ -804,10 +804,10 @@ class MissingTokenError extends Error {
  */
 function missingTokenMessage(profile: AssistantAuthProfile | null): string {
   if (profile === 'cloud-oauth') {
-    return 'Sign in with Vellum (cloud) before connecting';
+    return "Automatic cloud sign-in failed \u2014 use 'Re-sign in' in Troubleshooting, then try Connect again";
   }
   if (profile === 'local-pair') {
-    return 'Pair the Vellum assistant (self-hosted) before connecting';
+    return "Automatic local pairing failed \u2014 use 'Re-pair' in Troubleshooting, then try Connect again";
   }
   if (profile === 'unsupported') {
     return 'This assistant uses an unsupported topology. Please update the Vellum extension.';


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for one-click-connect-pause-autoconnect.md.

**Gap:** Error messages still use 'before connecting' phrasing
**What was expected:** Messages should not tell users to manually pair/sign-in as a prerequisite
**What was found:** missingTokenMessage and reconnect hook use 'before connecting' language
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24801" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
