### PR TITLE
Chrome extension: one-click connect, pause, and auto-connect

### DIFF
--- a/clients/chrome-extension/README.md
+++ b/clients/chrome-extension/README.md
@@ -6,7 +6,7 @@ Core pieces:
 - `background/worker.ts`: service worker (relay lifecycle, pairing, CDP dispatch)
 - `background/assistant-auth-profile.ts`: lockfile topology to auth profile mapping
 - `background/native-host-assistants.ts`: native messaging client for assistant catalog
-- `popup/`: popup UI (assistant selector, auth panels, Connect/Disconnect)
+- `popup/`: popup UI (assistant selector, one-click Connect, Pause, troubleshooting auth controls)
 - `popup/popup-state.ts`: pure view-state helpers for the assistant selector
 - `native-host/`: native messaging helper (`com.vellum.daemon`) for self-hosted pairing and assistant discovery
 - `build.sh`: bundles extension assets into `dist/`
@@ -36,12 +36,50 @@ Then in Chrome:
 3. Click **Load unpacked**
 4. Select `clients/chrome-extension/dist`
 
-## How It Works — Assistant-Centric Model
+## How It Works — One-Click Connect
 
 The extension discovers available assistants from the lockfile via the native
 messaging helper (`com.vellum.daemon`). The lockfile lists every assistant
 configured on the machine, along with its hosting topology (`cloud` field),
 runtime URL, and local assistant port.
+
+### First-Time Connect (One Click)
+
+1. The user opens the popup and clicks **Connect**.
+2. The worker resolves the selected assistant's auth profile from the
+   lockfile topology, then auto-bootstraps credentials under the hood:
+   - **Local assistants** (`local-pair`): The worker spawns the native
+     messaging helper, which POSTs to the assistant's
+     `/v1/browser-extension-pair` endpoint and returns a scoped capability
+     token. No manual "Pair" step is needed.
+   - **Cloud assistants** (`cloud-oauth`): The worker launches a
+     `chrome.identity.launchWebAuthFlow` against the cloud gateway to
+     obtain an OAuth token. No manual "Sign in" step is needed.
+3. Once credentials are obtained, the relay WebSocket opens automatically.
+
+The entire flow is a single user action — click **Connect**.
+
+### Auto-Connect On Reopen
+
+After a successful first connect, the extension sets a persistent
+`autoConnect` flag. On subsequent browser launches (or service-worker
+restarts), the worker reads this flag and automatically reconnects using
+the stored credentials — no user interaction required.
+
+If stored credentials have expired or are missing at auto-connect time,
+the extension falls back to the disconnected state silently. The user
+can click **Connect** again to re-bootstrap credentials interactively.
+
+### Pause Semantics
+
+**Pause** is the user-facing stop action. It:
+- Tears down the active relay WebSocket.
+- Clears the `autoConnect` flag so the extension does **not** reconnect
+  on the next browser launch.
+- Preserves stored credentials so the next **Connect** is instant (no
+  re-pair or re-sign-in needed unless the token has expired).
+
+Pause replaces the previous "Disconnect" terminology.
 
 ### Assistant Discovery And Selection
 
@@ -59,9 +97,10 @@ runtime URL, and local assistant port.
 ### Topology-To-Auth Mapping
 
 Each assistant's `cloud` field in the lockfile determines which auth flow
-the extension uses. The mapping is in `assistant-auth-profile.ts`:
+the worker bootstraps automatically on Connect. The mapping is in
+`assistant-auth-profile.ts`:
 
-| `cloud` value | Auth profile | Auth flow |
+| `cloud` value | Auth profile | Auth bootstrapped on Connect |
 |---|---|---|
 | `local` | `local-pair` | Native messaging pair (capability token) |
 | `apple-container` | `local-pair` | Native messaging pair (capability token) |
@@ -69,22 +108,27 @@ the extension uses. The mapping is in `assistant-auth-profile.ts`:
 | `platform` | `cloud-oauth` | Chrome identity OAuth flow |
 | *(anything else)* | `unsupported` | Error: update the extension |
 
-- **`local-pair`**: The popup shows the **Local** auth section with a
-  "Pair with local assistant" button. Pairing spawns the native messaging
-  helper, which POSTs to the assistant's `/v1/browser-extension-pair`
-  endpoint and returns a scoped capability token. Connect targets the
-  local assistant at `ws://127.0.0.1:<port>/v1/browser-relay`.
+- **`local-pair`**: The worker auto-pairs via native messaging on Connect.
+  The relay targets the local assistant at
+  `ws://127.0.0.1:<port>/v1/browser-relay`.
 
-- **`cloud-oauth`**: The popup shows the **Cloud** auth section with a
-  "Sign in with Vellum (cloud)" button. Sign-in runs a
-  `chrome.identity.launchWebAuthFlow` against the cloud gateway. Connect
-  targets the cloud gateway at `wss://<runtimeUrl>/v1/browser-relay`.
+- **`cloud-oauth`**: The worker auto-signs in via Chrome identity on Connect.
+  The relay targets the cloud gateway at
+  `wss://<runtimeUrl>/v1/browser-relay`.
 
 - **`unsupported`**: An error message instructs the user to update the
   extension. No auth panel is shown.
 
 Auth tokens are stored per-assistant under scoped storage keys so
 switching between assistants does not require re-authentication.
+
+### Manual Recovery (Troubleshooting)
+
+The popup includes a collapsible **Troubleshooting** section with manual
+"Re-pair with local assistant" and "Re-sign in with Vellum (cloud)"
+buttons. These are **not** required for the normal connect flow — they
+exist for edge cases where the automatic bootstrap fails (e.g. expired
+tokens, native host issues, OAuth configuration problems).
 
 ## Native Messaging Host Setup (If Pairing Fails)
 
@@ -177,15 +221,15 @@ of the extension. Update the extension to the latest version.
 
 ### Per-assistant auth mismatch
 
-Each assistant requires its own auth token scoped to its topology:
+Each assistant requires its own auth token scoped to its topology. The
+worker auto-bootstraps the correct token type on Connect, so switching
+between assistants with different topologies is handled transparently.
 
-- A `local` assistant requires a **local pair** token (click "Pair with
-  local assistant").
-- A `vellum`/`platform` assistant requires a **cloud sign-in** token
-  (click "Sign in with Vellum (cloud)").
-
-Switching between assistants with different topologies may require completing
-the appropriate auth flow for the newly selected assistant before connecting.
+If automatic bootstrap fails, use the Troubleshooting controls:
+- A `local` assistant can be manually re-paired via "Re-pair with local
+  assistant".
+- A `vellum`/`platform` assistant can be manually re-signed-in via
+  "Re-sign in with Vellum (cloud)".
 
 ### Common error messages
 
@@ -196,9 +240,9 @@ the appropriate auth flow for the newly selected assistant before connecting.
 - `assistant pair request failed with HTTP 401`
   - The pair endpoint rejected `extensionOrigin`. Verify your extension ID is in `meta/browser-extension/chrome-extension-allowlist.json`, then restart the assistant so it reloads allowlist config.
 - `Sign in with Vellum (cloud) before connecting`
-  - The selected assistant uses cloud-oauth but no cloud token is stored. Click "Sign in with Vellum (cloud)" first.
+  - The selected assistant uses cloud-oauth and the automatic sign-in failed. Use the "Re-sign in with Vellum (cloud)" troubleshooting button, then click Connect again.
 - `Pair the Vellum assistant (self-hosted) before connecting`
-  - The selected assistant uses local-pair but no capability token is stored. Click "Pair with local assistant" first.
+  - The selected assistant uses local-pair and the automatic pairing failed. Use the "Re-pair with local assistant" troubleshooting button, then click Connect again.
 - `Select an assistant before connecting`
   - No assistant is selected. The lockfile may be empty or the native messaging helper is unreachable.
 - `failed to reach assistant at http://127.0.0.1:<port>/v1/browser-extension-pair`

--- a/clients/chrome-extension/README.md
+++ b/clients/chrome-extension/README.md
@@ -239,10 +239,10 @@ If automatic bootstrap fails, use the Troubleshooting controls:
   - Chrome could not launch Node for a `dist/index.js` host path. Use a wrapper script with an absolute Node path in the manifest `path`.
 - `assistant pair request failed with HTTP 401`
   - The pair endpoint rejected `extensionOrigin`. Verify your extension ID is in `meta/browser-extension/chrome-extension-allowlist.json`, then restart the assistant so it reloads allowlist config.
-- `Sign in with Vellum (cloud) before connecting`
-  - The selected assistant uses cloud-oauth and the automatic sign-in failed. Use the "Re-sign in with Vellum (cloud)" troubleshooting button, then click Connect again.
-- `Pair the Vellum assistant (self-hosted) before connecting`
-  - The selected assistant uses local-pair and the automatic pairing failed. Use the "Re-pair with local assistant" troubleshooting button, then click Connect again.
+- `Automatic cloud sign-in failed — use 'Re-sign in' in Troubleshooting, then try Connect again`
+  - The selected assistant uses cloud-oauth and the automatic sign-in failed. Use the "Re-sign in" button in the Troubleshooting section of the popup, then click Connect again.
+- `Automatic local pairing failed — use 'Re-pair' in Troubleshooting, then try Connect again`
+  - The selected assistant uses local-pair and the automatic pairing failed. Use the "Re-pair" button in the Troubleshooting section of the popup, then click Connect again.
 - `Select an assistant before connecting`
   - No assistant is selected. The lockfile may be empty or the native messaging helper is unreachable.
 - `failed to reach assistant at http://127.0.0.1:<port>/v1/browser-extension-pair`

--- a/clients/chrome-extension/background/__tests__/cloud-reconnect-decision.test.ts
+++ b/clients/chrome-extension/background/__tests__/cloud-reconnect-decision.test.ts
@@ -114,7 +114,7 @@ describe('decideCloudReconnectAction', () => {
       expect(action.error).toContain(
         `after ${CLOUD_REFRESH_ATTEMPT_CAP} token refresh attempts`,
       );
-      expect(action.error).toContain('sign in');
+      expect(action.error).toContain('Re-sign in');
     }
   });
 

--- a/clients/chrome-extension/background/__tests__/worker-autoconnect.test.ts
+++ b/clients/chrome-extension/background/__tests__/worker-autoconnect.test.ts
@@ -234,7 +234,7 @@ describe('autoConnect lifecycle — connect sets sticky flag', () => {
 
     const response = await handleConnectFailing(
       state,
-      new MissingTokenError('Sign in with Vellum (cloud) before connecting'),
+      new MissingTokenError("Automatic cloud sign-in failed \u2014 use 'Re-sign in' in Troubleshooting, then try Connect again"),
     );
 
     expect(response.ok).toBe(false);
@@ -349,7 +349,7 @@ describe('failed auto-connect — no reconnect loop', () => {
     const state = createWorkerState({ currentAuthProfile: 'local-pair' });
     await state.storage.set({ [AUTO_CONNECT_KEY]: true });
 
-    const errorMessage = 'Pair the Vellum assistant (self-hosted) before connecting';
+    const errorMessage = "Automatic local pairing failed \u2014 use 'Re-pair' in Troubleshooting, then try Connect again";
     await simulateBootstrap(state, async () => {
       throw new MissingTokenError(errorMessage);
     });
@@ -370,7 +370,7 @@ describe('failed auto-connect — no reconnect loop', () => {
     const state = createWorkerState({ currentAuthProfile: 'cloud-oauth' });
     await state.storage.set({ [AUTO_CONNECT_KEY]: true });
 
-    const errorMessage = 'Sign in with Vellum (cloud) before connecting';
+    const errorMessage = "Automatic cloud sign-in failed \u2014 use 'Re-sign in' in Troubleshooting, then try Connect again";
     await simulateBootstrap(state, async () => {
       throw new MissingTokenError(errorMessage);
     });

--- a/clients/chrome-extension/background/__tests__/worker-autoconnect.test.ts
+++ b/clients/chrome-extension/background/__tests__/worker-autoconnect.test.ts
@@ -1,0 +1,489 @@
+/**
+ * Tests for the worker's auto-connect lifecycle and pause semantics.
+ *
+ * Coverage:
+ *   - User-initiated connect sets autoConnect=true (sticky).
+ *   - Pause sets autoConnect=false and tears down the relay.
+ *   - Disconnect (backward-compatible alias) behaves identically to pause.
+ *   - Bootstrap auto-connects when autoConnect=true, skips when false.
+ *   - Failed auto-connect does not flip the extension into a reconnect
+ *     loop — it persists an actionable auth error exactly once per
+ *     failure chain.
+ *   - Reopen behavior after prior successful setup.
+ *
+ * Since the worker module is side-effectful (registers listeners, calls
+ * bootstrap), these tests exercise the key state transitions by
+ * replicating the message-handler logic under test in isolation — the
+ * same approach used by `worker-connect-preflight.test.ts` and
+ * `worker-selected-assistant-connect.test.ts`.
+ */
+
+import { describe, test, expect, beforeEach } from 'bun:test';
+
+// ── Fake chrome.storage.local ───────────────────────────────────────
+
+interface FakeStorage {
+  data: Record<string, unknown>;
+  get(key: string | string[]): Promise<Record<string, unknown>>;
+  set(items: Record<string, unknown>): Promise<void>;
+  remove(key: string | string[]): Promise<void>;
+}
+
+function createFakeStorage(): FakeStorage {
+  const data: Record<string, unknown> = {};
+  return {
+    data,
+    async get(key) {
+      const keys = Array.isArray(key) ? key : [key];
+      const result: Record<string, unknown> = {};
+      for (const k of keys) {
+        if (k in data) result[k] = data[k];
+      }
+      return result;
+    },
+    async set(items) {
+      Object.assign(data, items);
+    },
+    async remove(key) {
+      const keys = Array.isArray(key) ? key : [key];
+      for (const k of keys) delete data[k];
+    },
+  };
+}
+
+// ── Storage key constants (mirror worker.ts) ────────────────────────
+
+const AUTO_CONNECT_KEY = 'autoConnect';
+const RELAY_AUTH_ERROR_KEY = 'vellum.relayAuthError';
+
+// ── Minimal RelayConnection fake ────────────────────────────────────
+
+interface FakeRelayConnection {
+  started: boolean;
+  closed: boolean;
+  closeCode: number | null;
+  closeReason: string | null;
+  isOpen(): boolean;
+  start(): void;
+  close(code: number, reason: string): void;
+}
+
+function createFakeRelayConnection(opts?: { open?: boolean }): FakeRelayConnection {
+  let open = opts?.open ?? false;
+  return {
+    started: false,
+    closed: false,
+    closeCode: null,
+    closeReason: null,
+    isOpen() {
+      return open && !this.closed;
+    },
+    start() {
+      this.started = true;
+      open = true;
+    },
+    close(code, reason) {
+      this.closed = true;
+      this.closeCode = code;
+      this.closeReason = reason;
+      open = false;
+    },
+  };
+}
+
+// ── Isolated state machine mirroring worker.ts logic ────────────────
+//
+// This replicates the state transitions from the worker's message
+// listener and bootstrap function so we can test them without loading
+// the full side-effectful service worker module.
+
+interface WorkerState {
+  shouldConnect: boolean;
+  relayConnection: FakeRelayConnection | null;
+  currentAuthProfile: 'local-pair' | 'cloud-oauth' | 'unsupported' | null;
+  storage: FakeStorage;
+}
+
+function createWorkerState(overrides?: Partial<WorkerState>): WorkerState {
+  return {
+    shouldConnect: false,
+    relayConnection: null,
+    currentAuthProfile: null,
+    storage: createFakeStorage(),
+    ...overrides,
+  };
+}
+
+class MissingTokenError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'MissingTokenError';
+  }
+}
+
+interface RelayAuthError {
+  message: string;
+  mode: 'cloud' | 'self-hosted';
+  at: number;
+}
+
+/**
+ * Simulate the connect message handler's success path.
+ * Sets shouldConnect, calls connect (simulated as setting up a relay),
+ * and on success persists autoConnect=true.
+ */
+async function handleConnect(state: WorkerState): Promise<{ ok: boolean; error?: string }> {
+  state.shouldConnect = true;
+  try {
+    // Simulate a successful connect: create and start a relay connection.
+    const relay = createFakeRelayConnection();
+    relay.start();
+    state.relayConnection = relay;
+    // Successful user-initiated connect — make auto-connect sticky.
+    await state.storage.set({ [AUTO_CONNECT_KEY]: true });
+    return { ok: true };
+  } catch (err) {
+    state.shouldConnect = false;
+    const errorMessage = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: errorMessage };
+  }
+}
+
+/**
+ * Simulate a failed connect attempt (e.g. missing token).
+ */
+async function handleConnectFailing(
+  state: WorkerState,
+  error: Error,
+): Promise<{ ok: boolean; error?: string }> {
+  state.shouldConnect = true;
+  // Connect fails
+  state.shouldConnect = false;
+  const errorMessage = error.message;
+  return { ok: false, error: errorMessage };
+}
+
+/**
+ * Simulate the pause/disconnect message handler.
+ * Both `pause` and `disconnect` actions clear autoConnect and tear
+ * down the relay.
+ */
+async function handlePause(state: WorkerState): Promise<{ ok: boolean }> {
+  state.shouldConnect = false;
+  await state.storage.set({ [AUTO_CONNECT_KEY]: false });
+  if (state.relayConnection) {
+    state.relayConnection.close(1000, 'User paused');
+    state.relayConnection = null;
+  }
+  return { ok: true };
+}
+
+/**
+ * Simulate the bootstrap function. Reads autoConnect from storage;
+ * when true, attempts a non-interactive connect.
+ *
+ * @param connectFn - Injectable connect simulation. Returns void on
+ *   success, throws on failure.
+ */
+async function simulateBootstrap(
+  state: WorkerState,
+  connectFn: () => Promise<void>,
+): Promise<void> {
+  const result = await state.storage.get(AUTO_CONNECT_KEY);
+  if (result[AUTO_CONNECT_KEY] !== true) return;
+
+  state.shouldConnect = true;
+  try {
+    await connectFn();
+  } catch (err) {
+    state.shouldConnect = false;
+    const detail = err instanceof Error ? err.message : String(err);
+    const mode: 'cloud' | 'self-hosted' =
+      state.currentAuthProfile === 'cloud-oauth' ? 'cloud' : 'self-hosted';
+
+    // Persist auth error exactly once for popup display.
+    await state.storage.set({
+      [RELAY_AUTH_ERROR_KEY]: {
+        message: detail,
+        mode,
+        at: Date.now(),
+      } satisfies RelayAuthError,
+    });
+  }
+}
+
+// ── Tests ───────────────────────────────────────────────────────────
+
+describe('autoConnect lifecycle — connect sets sticky flag', () => {
+  test('successful user-initiated connect sets autoConnect=true', async () => {
+    const state = createWorkerState();
+
+    const response = await handleConnect(state);
+
+    expect(response.ok).toBe(true);
+    expect(state.shouldConnect).toBe(true);
+    expect(state.relayConnection).not.toBeNull();
+    expect(state.relayConnection!.isOpen()).toBe(true);
+
+    const stored = await state.storage.get(AUTO_CONNECT_KEY);
+    expect(stored[AUTO_CONNECT_KEY]).toBe(true);
+  });
+
+  test('failed connect does not set autoConnect=true', async () => {
+    const state = createWorkerState();
+
+    const response = await handleConnectFailing(
+      state,
+      new MissingTokenError('Sign in with Vellum (cloud) before connecting'),
+    );
+
+    expect(response.ok).toBe(false);
+    expect(state.shouldConnect).toBe(false);
+
+    const stored = await state.storage.get(AUTO_CONNECT_KEY);
+    expect(stored[AUTO_CONNECT_KEY]).toBeUndefined();
+  });
+});
+
+describe('pause semantics — clears autoConnect and tears down relay', () => {
+  test('pause sets autoConnect=false and closes relay', async () => {
+    const state = createWorkerState();
+
+    // First connect successfully
+    await handleConnect(state);
+    expect(state.relayConnection!.isOpen()).toBe(true);
+
+    const preCheck = await state.storage.get(AUTO_CONNECT_KEY);
+    expect(preCheck[AUTO_CONNECT_KEY]).toBe(true);
+
+    // Now pause
+    const response = await handlePause(state);
+
+    expect(response.ok).toBe(true);
+    expect(state.shouldConnect).toBe(false);
+    expect(state.relayConnection).toBeNull();
+
+    const postCheck = await state.storage.get(AUTO_CONNECT_KEY);
+    expect(postCheck[AUTO_CONNECT_KEY]).toBe(false);
+  });
+
+  test('pause is idempotent when already disconnected', async () => {
+    const state = createWorkerState();
+
+    // No active connection
+    const response = await handlePause(state);
+
+    expect(response.ok).toBe(true);
+    expect(state.shouldConnect).toBe(false);
+
+    const stored = await state.storage.get(AUTO_CONNECT_KEY);
+    expect(stored[AUTO_CONNECT_KEY]).toBe(false);
+  });
+
+  test('disconnect (backward-compatible alias) behaves identically to pause', async () => {
+    const state = createWorkerState();
+
+    // Connect first
+    await handleConnect(state);
+
+    // "disconnect" performs the same transitions as "pause"
+    const response = await handlePause(state); // same handler
+
+    expect(response.ok).toBe(true);
+    expect(state.shouldConnect).toBe(false);
+    expect(state.relayConnection).toBeNull();
+
+    const stored = await state.storage.get(AUTO_CONNECT_KEY);
+    expect(stored[AUTO_CONNECT_KEY]).toBe(false);
+  });
+});
+
+describe('bootstrap — auto-connect on service worker startup', () => {
+  test('bootstrap auto-connects when autoConnect=true', async () => {
+    const state = createWorkerState();
+    await state.storage.set({ [AUTO_CONNECT_KEY]: true });
+
+    let connectCalled = false;
+    await simulateBootstrap(state, async () => {
+      connectCalled = true;
+      // Simulate successful connect
+      const relay = createFakeRelayConnection();
+      relay.start();
+      state.relayConnection = relay;
+    });
+
+    expect(connectCalled).toBe(true);
+    expect(state.shouldConnect).toBe(true);
+    expect(state.relayConnection).not.toBeNull();
+  });
+
+  test('bootstrap skips when autoConnect=false', async () => {
+    const state = createWorkerState();
+    await state.storage.set({ [AUTO_CONNECT_KEY]: false });
+
+    let connectCalled = false;
+    await simulateBootstrap(state, async () => {
+      connectCalled = true;
+    });
+
+    expect(connectCalled).toBe(false);
+    expect(state.shouldConnect).toBe(false);
+  });
+
+  test('bootstrap skips when autoConnect is not set', async () => {
+    const state = createWorkerState();
+    // Storage is empty — no autoConnect key at all
+
+    let connectCalled = false;
+    await simulateBootstrap(state, async () => {
+      connectCalled = true;
+    });
+
+    expect(connectCalled).toBe(false);
+    expect(state.shouldConnect).toBe(false);
+  });
+});
+
+describe('failed auto-connect — no reconnect loop', () => {
+  test('failed auto-connect resets shouldConnect and persists error once', async () => {
+    const state = createWorkerState({ currentAuthProfile: 'local-pair' });
+    await state.storage.set({ [AUTO_CONNECT_KEY]: true });
+
+    const errorMessage = 'Pair the Vellum assistant (self-hosted) before connecting';
+    await simulateBootstrap(state, async () => {
+      throw new MissingTokenError(errorMessage);
+    });
+
+    // shouldConnect must be reset so the worker does not retry
+    expect(state.shouldConnect).toBe(false);
+
+    // Auth error should be persisted exactly once for popup display
+    const errorResult = await state.storage.get(RELAY_AUTH_ERROR_KEY);
+    const persisted = errorResult[RELAY_AUTH_ERROR_KEY] as RelayAuthError;
+    expect(persisted).toBeDefined();
+    expect(persisted.message).toBe(errorMessage);
+    expect(persisted.mode).toBe('self-hosted');
+    expect(typeof persisted.at).toBe('number');
+  });
+
+  test('failed auto-connect for cloud mode persists cloud error', async () => {
+    const state = createWorkerState({ currentAuthProfile: 'cloud-oauth' });
+    await state.storage.set({ [AUTO_CONNECT_KEY]: true });
+
+    const errorMessage = 'Sign in with Vellum (cloud) before connecting';
+    await simulateBootstrap(state, async () => {
+      throw new MissingTokenError(errorMessage);
+    });
+
+    expect(state.shouldConnect).toBe(false);
+
+    const errorResult = await state.storage.get(RELAY_AUTH_ERROR_KEY);
+    const persisted = errorResult[RELAY_AUTH_ERROR_KEY] as RelayAuthError;
+    expect(persisted.mode).toBe('cloud');
+    expect(persisted.message).toBe(errorMessage);
+  });
+
+  test('non-token auto-connect failure also persists error and stops', async () => {
+    const state = createWorkerState({ currentAuthProfile: 'local-pair' });
+    await state.storage.set({ [AUTO_CONNECT_KEY]: true });
+
+    const errorMessage = 'Native host not installed';
+    await simulateBootstrap(state, async () => {
+      throw new Error(errorMessage);
+    });
+
+    expect(state.shouldConnect).toBe(false);
+
+    const errorResult = await state.storage.get(RELAY_AUTH_ERROR_KEY);
+    const persisted = errorResult[RELAY_AUTH_ERROR_KEY] as RelayAuthError;
+    expect(persisted.message).toBe(errorMessage);
+  });
+});
+
+describe('reopen behavior — full lifecycle', () => {
+  test('connect -> close browser -> reopen resumes auto-connect', async () => {
+    const state = createWorkerState();
+
+    // Step 1: User connects successfully
+    await handleConnect(state);
+    const afterConnect = await state.storage.get(AUTO_CONNECT_KEY);
+    expect(afterConnect[AUTO_CONNECT_KEY]).toBe(true);
+
+    // Step 2: Simulate browser close (relay torn down, worker dies).
+    // The storage flag survives because chrome.storage.local is
+    // persisted across service-worker restarts.
+
+    // Step 3: Simulate reopen — fresh worker state but storage persists
+    const freshState = createWorkerState({
+      storage: state.storage, // same persistent storage
+    });
+
+    let bootstrapConnectCalled = false;
+    await simulateBootstrap(freshState, async () => {
+      bootstrapConnectCalled = true;
+      const relay = createFakeRelayConnection();
+      relay.start();
+      freshState.relayConnection = relay;
+    });
+
+    expect(bootstrapConnectCalled).toBe(true);
+    expect(freshState.shouldConnect).toBe(true);
+    expect(freshState.relayConnection!.isOpen()).toBe(true);
+  });
+
+  test('connect -> pause -> close browser -> reopen does NOT auto-connect', async () => {
+    const state = createWorkerState();
+
+    // Step 1: User connects
+    await handleConnect(state);
+    // Step 2: User pauses
+    await handlePause(state);
+
+    const afterPause = await state.storage.get(AUTO_CONNECT_KEY);
+    expect(afterPause[AUTO_CONNECT_KEY]).toBe(false);
+
+    // Step 3: Simulate reopen — fresh worker state, same storage
+    const freshState = createWorkerState({
+      storage: state.storage,
+    });
+
+    let bootstrapConnectCalled = false;
+    await simulateBootstrap(freshState, async () => {
+      bootstrapConnectCalled = true;
+    });
+
+    expect(bootstrapConnectCalled).toBe(false);
+    expect(freshState.shouldConnect).toBe(false);
+    expect(freshState.relayConnection).toBeNull();
+  });
+
+  test('connect -> pause -> reconnect -> reopen resumes auto-connect', async () => {
+    const state = createWorkerState();
+
+    // Step 1: Connect
+    await handleConnect(state);
+    // Step 2: Pause
+    await handlePause(state);
+    // Step 3: Reconnect
+    await handleConnect(state);
+
+    const afterReconnect = await state.storage.get(AUTO_CONNECT_KEY);
+    expect(afterReconnect[AUTO_CONNECT_KEY]).toBe(true);
+
+    // Step 4: Simulate reopen
+    const freshState = createWorkerState({
+      storage: state.storage,
+    });
+
+    let bootstrapConnectCalled = false;
+    await simulateBootstrap(freshState, async () => {
+      bootstrapConnectCalled = true;
+      const relay = createFakeRelayConnection();
+      relay.start();
+      freshState.relayConnection = relay;
+    });
+
+    expect(bootstrapConnectCalled).toBe(true);
+    expect(freshState.shouldConnect).toBe(true);
+  });
+});

--- a/clients/chrome-extension/background/__tests__/worker-connect-preflight.test.ts
+++ b/clients/chrome-extension/background/__tests__/worker-connect-preflight.test.ts
@@ -1,0 +1,659 @@
+/**
+ * Tests for the worker's connect preflight logic.
+ *
+ * The preflight resolves credentials for the selected assistant before
+ * the relay socket opens. When `interactive=true`, missing credentials
+ * trigger an auto-bootstrap (pair for local, sign-in for cloud). When
+ * `interactive=false`, only non-interactive refresh is attempted for
+ * cloud; missing credentials produce an error.
+ *
+ * Since the worker module is side-effectful (registers listeners, calls
+ * bootstrap), these tests exercise the preflight logic by replicating
+ * the key functions under test in isolation — the same approach used by
+ * `worker-selected-assistant-connect.test.ts`.
+ *
+ * Coverage:
+ *   - Local interactive: auto-pairs when token is missing.
+ *   - Local non-interactive: fails when token is missing.
+ *   - Cloud interactive: auto-signs-in when token is missing/stale.
+ *   - Cloud non-interactive: attempts refresh, succeeds if provider
+ *     session is live.
+ *   - Cloud non-interactive: fails when refresh also fails (no token).
+ *   - Cloud non-interactive: falls back to stale-but-valid token when
+ *     refresh fails (token present but within staleness window).
+ *   - Preflight is a no-op when valid token already exists.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+
+import { resolveAuthProfile, type AssistantAuthProfile } from '../assistant-auth-profile.js';
+import type { AssistantDescriptor } from '../native-host-assistants.js';
+import { isCloudTokenStale, type StoredCloudToken } from '../cloud-auth.js';
+import type { StoredLocalToken } from '../self-hosted-auth.js';
+
+// ── Types mirroring worker.ts internals ─────────────────────────────
+
+type RelayMode =
+  | { kind: 'self-hosted'; baseUrl: string; token: string | null }
+  | { kind: 'cloud'; baseUrl: string; token: string | null };
+
+interface ConnectOptions {
+  interactive: boolean;
+}
+
+class MissingTokenError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'MissingTokenError';
+  }
+}
+
+function missingTokenMessage(profile: AssistantAuthProfile | null): string {
+  if (profile === 'cloud-oauth') {
+    return 'Sign in with Vellum (cloud) before connecting';
+  }
+  if (profile === 'local-pair') {
+    return 'Pair the Vellum assistant (self-hosted) before connecting';
+  }
+  if (profile === 'unsupported') {
+    return 'This assistant uses an unsupported topology. Please update the Vellum extension.';
+  }
+  return 'Select an assistant before connecting';
+}
+
+// ── Controllable fakes ──────────────────────────────────────────────
+
+/**
+ * Fake implementations for the auth functions the preflight calls.
+ * Tests configure these per-case to control the preflight's behavior.
+ */
+interface PreflightDeps {
+  bootstrapLocalToken: (assistantId: string | null) => Promise<StoredLocalToken>;
+  signInCloud: (assistantId: string, config: { gatewayBaseUrl: string; clientId: string }) => Promise<StoredCloudToken>;
+  refreshCloudToken: (assistantId: string, config: { gatewayBaseUrl: string; clientId: string }) => Promise<StoredCloudToken | null>;
+  getStoredCloudToken: (assistantId: string) => Promise<StoredCloudToken | null>;
+  getRelayPort: () => Promise<number>;
+}
+
+const CLOUD_GATEWAY_BASE_URL = 'https://api.vellum.ai';
+const CLOUD_OAUTH_CLIENT_ID = 'vellum-chrome-extension';
+
+/**
+ * Standalone preflight implementation that mirrors the worker's
+ * `connectPreflight` function but accepts injectable deps so tests
+ * can control the auth function outcomes without mocking globals.
+ */
+async function connectPreflight(
+  assistant: AssistantDescriptor | null,
+  authProfile: AssistantAuthProfile | null,
+  mode: RelayMode,
+  options: ConnectOptions,
+  deps: PreflightDeps,
+): Promise<RelayMode> {
+  if (mode.token) {
+    if (mode.kind === 'cloud' && assistant) {
+      const stored = await deps.getStoredCloudToken(assistant.assistantId);
+      if (!isCloudTokenStale(stored)) {
+        return mode;
+      }
+    } else {
+      return mode;
+    }
+  }
+
+  if (authProfile === 'local-pair') {
+    if (!options.interactive) {
+      throw new MissingTokenError(missingTokenMessage('local-pair'));
+    }
+    const assistantId = assistant?.assistantId ?? null;
+    const stored = await deps.bootstrapLocalToken(assistantId);
+    const port = stored.assistantPort ?? assistant?.daemonPort ?? (await deps.getRelayPort());
+    return {
+      kind: 'self-hosted',
+      baseUrl: `http://127.0.0.1:${port}`,
+      token: stored.token,
+    };
+  }
+
+  if (authProfile === 'cloud-oauth') {
+    const assistantId = assistant?.assistantId ?? null;
+    if (!assistantId) {
+      throw new MissingTokenError(missingTokenMessage(null));
+    }
+
+    if (!options.interactive) {
+      const gatewayBaseUrl = assistant?.runtimeUrl || CLOUD_GATEWAY_BASE_URL;
+      const refreshed = await deps.refreshCloudToken(assistantId, {
+        gatewayBaseUrl,
+        clientId: CLOUD_OAUTH_CLIENT_ID,
+      });
+      if (refreshed) {
+        const baseUrl = assistant?.runtimeUrl || CLOUD_GATEWAY_BASE_URL;
+        return { kind: 'cloud', baseUrl, token: refreshed.token };
+      }
+      // If the token is stale but still technically valid, fall back to
+      // the existing mode rather than discarding a usable token. The
+      // onReconnect hook will handle actual expiry later.
+      if (mode.token) {
+        return mode;
+      }
+      throw new MissingTokenError(missingTokenMessage('cloud-oauth'));
+    }
+
+    const gatewayBaseUrl = assistant?.runtimeUrl || CLOUD_GATEWAY_BASE_URL;
+    const stored = await deps.signInCloud(assistantId, {
+      gatewayBaseUrl,
+      clientId: CLOUD_OAUTH_CLIENT_ID,
+    });
+    const baseUrl = assistant?.runtimeUrl || CLOUD_GATEWAY_BASE_URL;
+    return { kind: 'cloud', baseUrl, token: stored.token };
+  }
+
+  throw new MissingTokenError(missingTokenMessage(authProfile));
+}
+
+// ── Fixtures ────────────────────────────────────────────────────────
+
+function makeLocalAssistant(
+  overrides: Partial<AssistantDescriptor> = {},
+): AssistantDescriptor {
+  return {
+    assistantId: 'local-1',
+    cloud: 'local',
+    runtimeUrl: 'http://127.0.0.1:7831',
+    daemonPort: 7821,
+    isActive: true,
+    authProfile: 'local-pair',
+    ...overrides,
+  };
+}
+
+function makeCloudAssistant(
+  overrides: Partial<AssistantDescriptor> = {},
+): AssistantDescriptor {
+  return {
+    assistantId: 'cloud-1',
+    cloud: 'vellum',
+    runtimeUrl: 'https://rt.vellum.cloud',
+    daemonPort: undefined,
+    isActive: false,
+    authProfile: 'cloud-oauth',
+    ...overrides,
+  };
+}
+
+function makeStoredLocalToken(overrides: Partial<StoredLocalToken> = {}): StoredLocalToken {
+  return {
+    token: 'local-cap-token-abc',
+    expiresAt: Date.now() + 3600_000,
+    guardianId: 'guardian-local-1',
+    assistantPort: 7831,
+    ...overrides,
+  };
+}
+
+function makeStoredCloudToken(overrides: Partial<StoredCloudToken> = {}): StoredCloudToken {
+  return {
+    token: 'cloud-jwt-xyz',
+    expiresAt: Date.now() + 3600_000,
+    guardianId: 'guardian-cloud-1',
+    ...overrides,
+  };
+}
+
+function makeDeps(overrides: Partial<PreflightDeps> = {}): PreflightDeps {
+  return {
+    bootstrapLocalToken: async () => {
+      throw new Error('bootstrapLocalToken not configured');
+    },
+    signInCloud: async () => {
+      throw new Error('signInCloud not configured');
+    },
+    refreshCloudToken: async () => null,
+    getStoredCloudToken: async () => null,
+    getRelayPort: async () => 7830,
+    ...overrides,
+  };
+}
+
+// ── Tests ───────────────────────────────────────────────────────────
+
+describe('connectPreflight — local-pair topology', () => {
+  test('interactive: auto-bootstraps local token when missing', async () => {
+    const assistant = makeLocalAssistant();
+    const mode: RelayMode = {
+      kind: 'self-hosted',
+      baseUrl: 'http://127.0.0.1:7821',
+      token: null,
+    };
+    const bootstrapped = makeStoredLocalToken({ token: 'fresh-local-token', assistantPort: 9999 });
+    let calledWith: string | null | undefined;
+    const deps = makeDeps({
+      bootstrapLocalToken: async (id) => {
+        calledWith = id;
+        return bootstrapped;
+      },
+    });
+
+    const result = await connectPreflight(
+      assistant,
+      'local-pair',
+      mode,
+      { interactive: true },
+      deps,
+    );
+
+    expect(calledWith).toBe('local-1');
+    expect(result.kind).toBe('self-hosted');
+    expect(result.token).toBe('fresh-local-token');
+    expect(result.baseUrl).toBe('http://127.0.0.1:9999');
+  });
+
+  test('interactive: uses daemon port when bootstrap has no assistantPort', async () => {
+    const assistant = makeLocalAssistant({ daemonPort: 8888 });
+    const mode: RelayMode = {
+      kind: 'self-hosted',
+      baseUrl: 'http://127.0.0.1:8888',
+      token: null,
+    };
+    const bootstrapped = makeStoredLocalToken({
+      token: 'fresh-token',
+      assistantPort: undefined,
+    });
+    const deps = makeDeps({
+      bootstrapLocalToken: async () => bootstrapped,
+    });
+
+    const result = await connectPreflight(
+      assistant,
+      'local-pair',
+      mode,
+      { interactive: true },
+      deps,
+    );
+
+    expect(result.baseUrl).toBe('http://127.0.0.1:8888');
+    expect(result.token).toBe('fresh-token');
+  });
+
+  test('non-interactive: throws MissingTokenError when token is missing', async () => {
+    const assistant = makeLocalAssistant();
+    const mode: RelayMode = {
+      kind: 'self-hosted',
+      baseUrl: 'http://127.0.0.1:7821',
+      token: null,
+    };
+    const deps = makeDeps();
+
+    try {
+      await connectPreflight(
+        assistant,
+        'local-pair',
+        mode,
+        { interactive: false },
+        deps,
+      );
+      expect.unreachable('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(MissingTokenError);
+      expect((err as Error).message).toContain('Pair');
+    }
+  });
+
+  test('skips preflight when valid local token already exists', async () => {
+    const assistant = makeLocalAssistant();
+    const mode: RelayMode = {
+      kind: 'self-hosted',
+      baseUrl: 'http://127.0.0.1:7821',
+      token: 'existing-token',
+    };
+    let bootstrapCalled = false;
+    const deps = makeDeps({
+      bootstrapLocalToken: async () => {
+        bootstrapCalled = true;
+        return makeStoredLocalToken();
+      },
+    });
+
+    const result = await connectPreflight(
+      assistant,
+      'local-pair',
+      mode,
+      { interactive: true },
+      deps,
+    );
+
+    expect(bootstrapCalled).toBe(false);
+    expect(result.token).toBe('existing-token');
+  });
+});
+
+describe('connectPreflight — cloud-oauth topology', () => {
+  test('interactive: auto-signs-in when token is missing', async () => {
+    const assistant = makeCloudAssistant();
+    const mode: RelayMode = {
+      kind: 'cloud',
+      baseUrl: 'https://rt.vellum.cloud',
+      token: null,
+    };
+    const signedIn = makeStoredCloudToken({ token: 'fresh-cloud-jwt' });
+    let signInCalledWith: { assistantId: string; gatewayBaseUrl: string } | null = null;
+    const deps = makeDeps({
+      signInCloud: async (id, config) => {
+        signInCalledWith = { assistantId: id, gatewayBaseUrl: config.gatewayBaseUrl };
+        return signedIn;
+      },
+    });
+
+    const result = await connectPreflight(
+      assistant,
+      'cloud-oauth',
+      mode,
+      { interactive: true },
+      deps,
+    );
+
+    expect(signInCalledWith).not.toBeNull();
+    expect(signInCalledWith!.assistantId).toBe('cloud-1');
+    expect(signInCalledWith!.gatewayBaseUrl).toBe('https://rt.vellum.cloud');
+    expect(result.kind).toBe('cloud');
+    expect(result.token).toBe('fresh-cloud-jwt');
+    expect(result.baseUrl).toBe('https://rt.vellum.cloud');
+  });
+
+  test('interactive: auto-signs-in when token is stale', async () => {
+    const assistant = makeCloudAssistant();
+    // Mode has a token, but the stored token is stale (about to expire)
+    const mode: RelayMode = {
+      kind: 'cloud',
+      baseUrl: 'https://rt.vellum.cloud',
+      token: 'stale-token',
+    };
+    const staleToken = makeStoredCloudToken({
+      token: 'stale-token',
+      // Expires in 30 seconds — within the 60-second stale window
+      expiresAt: Date.now() + 30_000,
+    });
+    const freshToken = makeStoredCloudToken({ token: 'refreshed-cloud-jwt' });
+    const deps = makeDeps({
+      getStoredCloudToken: async () => staleToken,
+      signInCloud: async () => freshToken,
+    });
+
+    const result = await connectPreflight(
+      assistant,
+      'cloud-oauth',
+      mode,
+      { interactive: true },
+      deps,
+    );
+
+    expect(result.token).toBe('refreshed-cloud-jwt');
+  });
+
+  test('non-interactive: succeeds when refresh returns a fresh token', async () => {
+    const assistant = makeCloudAssistant();
+    const mode: RelayMode = {
+      kind: 'cloud',
+      baseUrl: 'https://rt.vellum.cloud',
+      token: null,
+    };
+    const refreshed = makeStoredCloudToken({ token: 'refreshed-jwt' });
+    let refreshCalledWith: { assistantId: string; gatewayBaseUrl: string } | null = null;
+    const deps = makeDeps({
+      refreshCloudToken: async (id, config) => {
+        refreshCalledWith = { assistantId: id, gatewayBaseUrl: config.gatewayBaseUrl };
+        return refreshed;
+      },
+    });
+
+    const result = await connectPreflight(
+      assistant,
+      'cloud-oauth',
+      mode,
+      { interactive: false },
+      deps,
+    );
+
+    expect(refreshCalledWith).not.toBeNull();
+    expect(refreshCalledWith!.assistantId).toBe('cloud-1');
+    expect(result.token).toBe('refreshed-jwt');
+    expect(result.baseUrl).toBe('https://rt.vellum.cloud');
+  });
+
+  test('non-interactive: throws MissingTokenError when refresh returns null', async () => {
+    const assistant = makeCloudAssistant();
+    const mode: RelayMode = {
+      kind: 'cloud',
+      baseUrl: 'https://rt.vellum.cloud',
+      token: null,
+    };
+    const deps = makeDeps({
+      refreshCloudToken: async () => null,
+    });
+
+    try {
+      await connectPreflight(
+        assistant,
+        'cloud-oauth',
+        mode,
+        { interactive: false },
+        deps,
+      );
+      expect.unreachable('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(MissingTokenError);
+      expect((err as Error).message).toContain('Sign in');
+    }
+  });
+
+  test('non-interactive: falls back to stale-but-valid token when refresh fails', async () => {
+    const assistant = makeCloudAssistant();
+    // Mode has a token — stale but still technically valid
+    const mode: RelayMode = {
+      kind: 'cloud',
+      baseUrl: 'https://rt.vellum.cloud',
+      token: 'stale-but-valid-jwt',
+    };
+    const staleToken = makeStoredCloudToken({
+      token: 'stale-but-valid-jwt',
+      // Expires in 50 seconds — within the 60-second stale window
+      expiresAt: Date.now() + 50_000,
+    });
+    let refreshCalled = false;
+    const deps = makeDeps({
+      getStoredCloudToken: async () => staleToken,
+      // Refresh fails (e.g. provider session expired)
+      refreshCloudToken: async () => {
+        refreshCalled = true;
+        return null;
+      },
+    });
+
+    const result = await connectPreflight(
+      assistant,
+      'cloud-oauth',
+      mode,
+      { interactive: false },
+      deps,
+    );
+
+    // Should have attempted refresh
+    expect(refreshCalled).toBe(true);
+    // Should fall back to the original mode with the stale-but-valid token
+    expect(result).toBe(mode);
+    expect(result.token).toBe('stale-but-valid-jwt');
+    expect(result.baseUrl).toBe('https://rt.vellum.cloud');
+  });
+
+  test('skips preflight when valid cloud token exists and is not stale', async () => {
+    const assistant = makeCloudAssistant();
+    const mode: RelayMode = {
+      kind: 'cloud',
+      baseUrl: 'https://rt.vellum.cloud',
+      token: 'existing-jwt',
+    };
+    const freshToken = makeStoredCloudToken({
+      token: 'existing-jwt',
+      // Expires in 2 hours — well outside the stale window
+      expiresAt: Date.now() + 7200_000,
+    });
+    let signInCalled = false;
+    let refreshCalled = false;
+    const deps = makeDeps({
+      getStoredCloudToken: async () => freshToken,
+      signInCloud: async () => {
+        signInCalled = true;
+        return makeStoredCloudToken();
+      },
+      refreshCloudToken: async () => {
+        refreshCalled = true;
+        return null;
+      },
+    });
+
+    const result = await connectPreflight(
+      assistant,
+      'cloud-oauth',
+      mode,
+      { interactive: true },
+      deps,
+    );
+
+    expect(signInCalled).toBe(false);
+    expect(refreshCalled).toBe(false);
+    expect(result.token).toBe('existing-jwt');
+  });
+
+  test('non-interactive: uses runtimeUrl from assistant for refresh', async () => {
+    const assistant = makeCloudAssistant({
+      runtimeUrl: 'https://custom-gateway.vellum.cloud',
+    });
+    const mode: RelayMode = {
+      kind: 'cloud',
+      baseUrl: 'https://custom-gateway.vellum.cloud',
+      token: null,
+    };
+    const refreshed = makeStoredCloudToken({ token: 'refreshed-jwt' });
+    let refreshCalledWith: { gatewayBaseUrl: string } | null = null;
+    const deps = makeDeps({
+      refreshCloudToken: async (_id, config) => {
+        refreshCalledWith = { gatewayBaseUrl: config.gatewayBaseUrl };
+        return refreshed;
+      },
+    });
+
+    const result = await connectPreflight(
+      assistant,
+      'cloud-oauth',
+      mode,
+      { interactive: false },
+      deps,
+    );
+
+    expect(refreshCalledWith!.gatewayBaseUrl).toBe('https://custom-gateway.vellum.cloud');
+    expect(result.baseUrl).toBe('https://custom-gateway.vellum.cloud');
+  });
+});
+
+describe('connectPreflight — edge cases', () => {
+  test('unsupported profile throws MissingTokenError', async () => {
+    const assistant: AssistantDescriptor = {
+      assistantId: 'unsupported-1',
+      cloud: 'future-topology',
+      runtimeUrl: '',
+      daemonPort: undefined,
+      isActive: false,
+      authProfile: 'unsupported',
+    };
+    const mode: RelayMode = {
+      kind: 'self-hosted',
+      baseUrl: 'http://127.0.0.1:7830',
+      token: null,
+    };
+    const deps = makeDeps();
+
+    try {
+      await connectPreflight(
+        assistant,
+        'unsupported',
+        mode,
+        { interactive: true },
+        deps,
+      );
+      expect.unreachable('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(MissingTokenError);
+      expect((err as Error).message).toContain('unsupported topology');
+    }
+  });
+
+  test('null assistant throws MissingTokenError for cloud profile', async () => {
+    const mode: RelayMode = {
+      kind: 'cloud',
+      baseUrl: CLOUD_GATEWAY_BASE_URL,
+      token: null,
+    };
+    const deps = makeDeps();
+
+    try {
+      await connectPreflight(
+        null,
+        'cloud-oauth',
+        mode,
+        { interactive: true },
+        deps,
+      );
+      expect.unreachable('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(MissingTokenError);
+      expect((err as Error).message).toContain('Select an assistant');
+    }
+  });
+
+  test('null profile throws MissingTokenError', async () => {
+    const mode: RelayMode = {
+      kind: 'self-hosted',
+      baseUrl: 'http://127.0.0.1:7830',
+      token: null,
+    };
+    const deps = makeDeps();
+
+    try {
+      await connectPreflight(null, null, mode, { interactive: true }, deps);
+      expect.unreachable('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(MissingTokenError);
+      expect((err as Error).message).toContain('Select an assistant');
+    }
+  });
+
+  test('cloud interactive falls back to default gateway when no runtimeUrl', async () => {
+    const assistant = makeCloudAssistant({ runtimeUrl: '' });
+    const mode: RelayMode = {
+      kind: 'cloud',
+      baseUrl: CLOUD_GATEWAY_BASE_URL,
+      token: null,
+    };
+    const signedIn = makeStoredCloudToken({ token: 'fallback-jwt' });
+    let signInCalledWith: { gatewayBaseUrl: string } | null = null;
+    const deps = makeDeps({
+      signInCloud: async (_id, config) => {
+        signInCalledWith = { gatewayBaseUrl: config.gatewayBaseUrl };
+        return signedIn;
+      },
+    });
+
+    const result = await connectPreflight(
+      assistant,
+      'cloud-oauth',
+      mode,
+      { interactive: true },
+      deps,
+    );
+
+    expect(signInCalledWith!.gatewayBaseUrl).toBe(CLOUD_GATEWAY_BASE_URL);
+    expect(result.baseUrl).toBe(CLOUD_GATEWAY_BASE_URL);
+    expect(result.token).toBe('fallback-jwt');
+  });
+});

--- a/clients/chrome-extension/background/__tests__/worker-connect-preflight.test.ts
+++ b/clients/chrome-extension/background/__tests__/worker-connect-preflight.test.ts
@@ -50,10 +50,10 @@ class MissingTokenError extends Error {
 
 function missingTokenMessage(profile: AssistantAuthProfile | null): string {
   if (profile === 'cloud-oauth') {
-    return 'Sign in with Vellum (cloud) before connecting';
+    return "Automatic cloud sign-in failed \u2014 use 'Re-sign in' in Troubleshooting, then try Connect again";
   }
   if (profile === 'local-pair') {
-    return 'Pair the Vellum assistant (self-hosted) before connecting';
+    return "Automatic local pairing failed \u2014 use 'Re-pair' in Troubleshooting, then try Connect again";
   }
   if (profile === 'unsupported') {
     return 'This assistant uses an unsupported topology. Please update the Vellum extension.';
@@ -296,7 +296,7 @@ describe('connectPreflight — local-pair topology', () => {
       expect.unreachable('should have thrown');
     } catch (err) {
       expect(err).toBeInstanceOf(MissingTokenError);
-      expect((err as Error).message).toContain('Pair');
+      expect((err as Error).message).toContain('Re-pair');
     }
   });
 
@@ -443,7 +443,7 @@ describe('connectPreflight — cloud-oauth topology', () => {
       expect.unreachable('should have thrown');
     } catch (err) {
       expect(err).toBeInstanceOf(MissingTokenError);
-      expect((err as Error).message).toContain('Sign in');
+      expect((err as Error).message).toContain('Re-sign in');
     }
   });
 

--- a/clients/chrome-extension/background/__tests__/worker-connect-preflight.test.ts
+++ b/clients/chrome-extension/background/__tests__/worker-connect-preflight.test.ts
@@ -24,7 +24,7 @@
  *   - Preflight is a no-op when valid token already exists.
  */
 
-import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { describe, test, expect } from 'bun:test';
 
 import { resolveAuthProfile, type AssistantAuthProfile } from '../assistant-auth-profile.js';
 import type { AssistantDescriptor } from '../native-host-assistants.js';

--- a/clients/chrome-extension/background/__tests__/worker-selected-assistant-connect.test.ts
+++ b/clients/chrome-extension/background/__tests__/worker-selected-assistant-connect.test.ts
@@ -219,10 +219,10 @@ describe('missing token error messages', () => {
   // testing without importing the side-effectful module.
   function missingTokenMessage(profile: AssistantAuthProfile | null): string {
     if (profile === 'cloud-oauth') {
-      return 'Sign in with Vellum (cloud) before connecting';
+      return "Automatic cloud sign-in failed \u2014 use 'Re-sign in' in Troubleshooting, then try Connect again";
     }
     if (profile === 'local-pair') {
-      return 'Pair the Vellum assistant (self-hosted) before connecting';
+      return "Automatic local pairing failed \u2014 use 'Re-pair' in Troubleshooting, then try Connect again";
     }
     if (profile === 'unsupported') {
       return 'This assistant uses an unsupported topology. Please update the Vellum extension.';
@@ -231,11 +231,11 @@ describe('missing token error messages', () => {
   }
 
   test('cloud-oauth produces cloud sign-in prompt', () => {
-    expect(missingTokenMessage('cloud-oauth')).toContain('Sign in');
+    expect(missingTokenMessage('cloud-oauth')).toContain('Re-sign in');
   });
 
   test('local-pair produces pair prompt', () => {
-    expect(missingTokenMessage('local-pair')).toContain('Pair');
+    expect(missingTokenMessage('local-pair')).toContain('Re-pair');
   });
 
   test('unsupported produces update prompt', () => {

--- a/clients/chrome-extension/background/cloud-reconnect-decision.ts
+++ b/clients/chrome-extension/background/cloud-reconnect-decision.ts
@@ -77,7 +77,7 @@ export function decideCloudReconnectAction(
       kind: 'abort',
       error:
         `Cloud relay kept closing with abnormal closure (code 1006) after ${CLOUD_REFRESH_ATTEMPT_CAP} ` +
-        'token refresh attempts. Please sign in with Vellum (cloud) again from the extension popup to reconnect.',
+        "token refresh attempts. Use 'Re-sign in' in Troubleshooting, then try Connect again.",
     };
   }
 

--- a/clients/chrome-extension/background/worker.ts
+++ b/clients/chrome-extension/background/worker.ts
@@ -2,7 +2,7 @@
  * Chrome MV3 service worker — browser-relay bridge.
  *
  * Connects to either
- *   - the local daemon's browser-relay endpoint
+ *   - the local assistant's browser-relay endpoint
  *     (`ws://127.0.0.1:<relayPort>/v1/browser-relay`), or
  *   - the cloud gateway's browser-relay endpoint
  *     (`wss://<cloud-gateway>/v1/browser-relay`)
@@ -12,11 +12,24 @@
  * vocabulary — the choice is strictly about where the socket points and
  * which token is presented on the handshake.
  *
+ * The worker owns the full connect lifecycle:
+ *   - **One-click Connect**: When the popup sends `connect` with
+ *     `interactive=true`, the worker auto-bootstraps credentials
+ *     (local pair or cloud OAuth) before opening the socket. The user
+ *     never needs to manually pair or sign in.
+ *   - **Auto-connect on reopen**: After a successful connect, the
+ *     `autoConnect` storage flag is set. On service-worker startup
+ *     the `bootstrap()` function reads this flag and reconnects
+ *     non-interactively using stored credentials.
+ *   - **Pause**: The `pause` message clears the `autoConnect` flag
+ *     and tears down the socket. Credentials are preserved so the
+ *     next Connect is instant.
+ *
  * Once connected, the worker routes incoming server messages:
  *   - `host_browser_request` / `host_browser_cancel` envelopes are
  *     dispatched to the CDP proxy dispatcher, which drives a
  *     `chrome.debugger` session and POSTs a result envelope back to
- *     the daemon's `/v1/host-browser-result` endpoint.
+ *     the assistant's `/v1/host-browser-result` endpoint.
  *   - Every other payload is logged and discarded.
  */
 
@@ -273,7 +286,7 @@ let shouldConnect = false;
 // `host_browser_request` / `host_browser_cancel` envelopes arriving on
 // the relay WebSocket are routed into the CDP proxy dispatcher, which
 // drives a chrome.debugger session and POSTs a result envelope back to
-// the daemon's `/v1/host-browser-result` endpoint.
+// the assistant's `/v1/host-browser-result` endpoint.
 
 async function resolveHostBrowserTarget(
   cdpSessionId: string | undefined,
@@ -315,7 +328,7 @@ async function resolveHostBrowserTarget(
  * When no relay connection exists yet (e.g. a stale result arriving
  * after `disconnect()`), we fall back per the current auth profile:
  *
- *   - `local-pair`: POST directly to the local daemon using live
+ *   - `local-pair`: POST directly to the local assistant using live
  *     creds resolved from storage.
  *   - `cloud-oauth`: warn and drop the envelope. POSTing to localhost
  *     in cloud mode would always fail, and we have no WebSocket to
@@ -341,7 +354,7 @@ async function dispatchHostBrowserResult(
     return;
   }
 
-  // Self-hosted fallback: POST directly to the local daemon using the
+  // Self-hosted fallback: POST directly to the local assistant using the
   // capability token from the native-messaging pair flow. If no paired
   // token is available the result is dropped. When no assistant is
   // selected, fall back to the legacy unscoped token key.
@@ -772,10 +785,11 @@ function createRelayConnection(
 
 /**
  * Thrown by `connect()` when the selected assistant's auth profile
- * has no usable token yet, or when the topology is unsupported.
- * Callers (e.g. the popup connect handler) surface the message
- * verbatim to the user so they can take action — signing in to cloud,
- * re-pairing the local daemon, or updating the extension.
+ * has no usable token and the interactive bootstrap also failed, or
+ * when the topology is unsupported. Callers (e.g. the popup connect
+ * handler) surface the message verbatim so the user can take action
+ * via the Troubleshooting controls (re-pair or re-sign-in) or by
+ * updating the extension.
  */
 class MissingTokenError extends Error {
   constructor(message: string) {

--- a/clients/chrome-extension/background/worker.ts
+++ b/clients/chrome-extension/background/worker.ts
@@ -950,17 +950,26 @@ async function connectPreflight(
 // preflight. This prevents duplicate auth/pair flows when multiple
 // connect calls arrive before the first socket opens (e.g., repeated
 // user action or overlapping message paths).
+//
+// Exception: an interactive connect (user-initiated) always supersedes a
+// non-interactive one (bootstrap). If the in-flight connect is
+// non-interactive and the new caller is interactive, we discard the
+// in-flight promise and start a fresh interactive connect so the user
+// gets the interactive auth flow they expect.
 let connectInFlight: Promise<void> | null = null;
+let connectInFlightInteractive = false;
 
 async function connect(options: ConnectOptions = { interactive: false }): Promise<void> {
-  if (connectInFlight) {
+  if (connectInFlight && (connectInFlightInteractive || !options.interactive)) {
     return connectInFlight;
   }
+  connectInFlightInteractive = !!options.interactive;
   connectInFlight = doConnect(options);
   try {
     await connectInFlight;
   } finally {
     connectInFlight = null;
+    connectInFlightInteractive = false;
   }
 }
 

--- a/clients/chrome-extension/background/worker.ts
+++ b/clients/chrome-extension/background/worker.ts
@@ -119,6 +119,12 @@ async function getOrCreateClientInstanceId(): Promise<string> {
   return fresh;
 }
 
+// Storage key that controls auto-connect on service-worker startup.
+// Set to `true` after a successful user-initiated connect, cleared to
+// `false` by the `pause` action so the extension stays quiet until
+// the user explicitly reconnects.
+const AUTO_CONNECT_KEY = 'autoConnect';
+
 // Storage key used to surface the most recent auth-related relay error
 // to the popup. The popup reads this on open and shows it next to the
 // cloud sign-in button. Cleared on a successful connect so stale errors
@@ -144,6 +150,19 @@ async function clearRelayAuthError(): Promise<void> {
     await chrome.storage.local.remove(RELAY_AUTH_ERROR_KEY);
   } catch (err) {
     console.warn('[vellum-relay] Failed to clear relay auth error', err);
+  }
+}
+
+/**
+ * Persist the auto-connect flag. Called after a successful user-initiated
+ * connect so the next service-worker startup (e.g. browser reopen)
+ * automatically reconnects.
+ */
+async function setAutoConnect(enabled: boolean): Promise<void> {
+  try {
+    await chrome.storage.local.set({ [AUTO_CONNECT_KEY]: enabled });
+  } catch (err) {
+    console.warn('[vellum-relay] Failed to persist autoConnect flag', err);
   }
 }
 
@@ -1028,22 +1047,48 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponseFn) => {
     // bootstrap missing auth (pair for local, sign-in for cloud)
     // rather than requiring the popup to pre-check credentials.
     connect({ interactive: true })
-      .then(() => sendResponseFn({ ok: true }))
-      .catch((err) => {
+      .then(async () => {
+        // Guard: skip if the user paused/disconnected while the connect
+        // was in-flight — their pause intent takes precedence.
+        if (shouldConnect) {
+          await setAutoConnect(true);
+        }
+        sendResponseFn({ ok: true });
+      })
+      .catch(async (err) => {
         // Reset shouldConnect so a subsequent storage change or
         // bootstrap doesn't silently retry a doomed connect. The user
         // will press Connect again after signing in / pairing.
         shouldConnect = false;
+        // Undo the popup's eager autoConnect write — a failed connect
+        // must not leave the flag set, otherwise the next bootstrap
+        // would retry a doomed connect.
+        await setAutoConnect(false);
         const errorMessage = err instanceof Error ? err.message : String(err);
         sendResponseFn({ ok: false, error: errorMessage });
       });
     return true; // async
   }
-  if (message.type === 'disconnect') {
+  // `pause` is the canonical user-level stop action: it clears the
+  // sticky auto-connect flag so the extension does not reconnect on
+  // the next startup, then tears down the relay connection.
+  // `disconnect` is kept as a backward-compatible alias during rollout
+  // — both actions perform identical state transitions.
+  if (message.type === 'pause' || message.type === 'disconnect') {
     shouldConnect = false;
-    disconnect();
-    sendResponseFn({ ok: true });
-    return false;
+    // Await the storage write so MV3 can't terminate the worker before
+    // the autoConnect flag is persisted to false.
+    setAutoConnect(false)
+      .then(() => {
+        disconnect();
+        sendResponseFn({ ok: true });
+      })
+      .catch(() => {
+        // Even if the storage write fails, still disconnect and respond.
+        disconnect();
+        sendResponseFn({ ok: true });
+      });
+    return true; // async
   }
   if (message.type === 'get_status') {
     sendResponseFn({
@@ -1207,31 +1252,43 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponseFn) => {
 });
 
 // Auto-connect on service worker start if previously connected.
+// Only fires when the sticky `autoConnect` flag is `true` (set by a
+// prior successful user-initiated Connect). Bootstrap uses a non-
+// interactive connect so it never pops up auth UIs — if credentials
+// are missing the user will see the disconnected state in the popup
+// and can trigger an interactive connect manually.
 async function bootstrap(): Promise<void> {
-  const { autoConnect } = await chrome.storage.local.get('autoConnect');
-  if (autoConnect !== true) return;
+  const result = await chrome.storage.local.get(AUTO_CONNECT_KEY);
+  if (result[AUTO_CONNECT_KEY] !== true) return;
   shouldConnect = true;
   try {
-    // Non-interactive: bootstrap should not pop up auth UIs. If
-    // credentials are missing the user will see disconnected state
-    // in the popup and can trigger an interactive connect.
     await connect({ interactive: false });
   } catch (err) {
     // A missing token at auto-connect time is not a hard failure —
     // the user will see the disconnected state in the popup and can
-    // sign in / pair to try again. Log and move on.
+    // sign in / pair to try again. Persist the error detail exactly
+    // once so the popup can surface it, then stop retrying.
+    shouldConnect = false;
     if (err instanceof MissingTokenError) {
-      shouldConnect = false;
       console.warn(`[vellum-relay] Skipping auto-connect: ${err.message}`);
+      void setRelayAuthError({
+        message: err.message,
+        mode: currentAuthProfile === 'cloud-oauth' ? 'cloud' : 'self-hosted',
+        at: Date.now(),
+      });
       return;
     }
     // Non-token errors (e.g. native host not installed) are not
     // recoverable at auto-connect time. Reset state and log so the
     // popup shows disconnected rather than crashing the worker with
     // an unhandled rejection.
-    shouldConnect = false;
     const detail = err instanceof Error ? err.message : String(err);
     console.warn(`[vellum-relay] Auto-connect failed: ${detail}`);
+    void setRelayAuthError({
+      message: detail,
+      mode: currentAuthProfile === 'cloud-oauth' ? 'cloud' : 'self-hosted',
+      at: Date.now(),
+    });
   }
 }
 

--- a/clients/chrome-extension/background/worker.ts
+++ b/clients/chrome-extension/background/worker.ts
@@ -694,7 +694,7 @@ async function cloudReconnectHook(
   return {
     kind: 'abort',
     error:
-      `${reason}. Please sign in with Vellum (cloud) again from the extension popup to reconnect.`,
+      `${reason}. Use 'Re-sign in' in Troubleshooting, then try Connect again.`,
   };
 }
 
@@ -777,7 +777,7 @@ function createRelayConnection(
       return {
         kind: 'abort',
         error:
-          'Self-hosted relay token missing or expired. Pair the Vellum assistant again from the extension popup.',
+          "Self-hosted relay token missing or expired. Use 'Re-pair' in Troubleshooting, then try Connect again.",
       };
     },
   });
@@ -804,10 +804,10 @@ class MissingTokenError extends Error {
  */
 function missingTokenMessage(profile: AssistantAuthProfile | null): string {
   if (profile === 'cloud-oauth') {
-    return 'Sign in with Vellum (cloud) before connecting';
+    return "Automatic cloud sign-in failed \u2014 use 'Re-sign in' in Troubleshooting, then try Connect again";
   }
   if (profile === 'local-pair') {
-    return 'Pair the Vellum assistant (self-hosted) before connecting';
+    return "Automatic local pairing failed \u2014 use 'Re-pair' in Troubleshooting, then try Connect again";
   }
   if (profile === 'unsupported') {
     return 'This assistant uses an unsupported topology. Please update the Vellum extension.';

--- a/clients/chrome-extension/background/worker.ts
+++ b/clients/chrome-extension/background/worker.ts
@@ -26,6 +26,7 @@ import {
   getStoredToken as getStoredCloudToken,
   getStoredTokenRaw as getStoredCloudTokenRaw,
   validateCloudToken,
+  isCloudTokenStale,
   CLOUD_AUTH_FAILURE_CLOSE_CODES,
   LEGACY_CLOUD_STORAGE_KEY,
   type CloudAuthConfig,
@@ -782,7 +783,155 @@ function missingTokenMessage(profile: AssistantAuthProfile | null): string {
   return 'Select an assistant before connecting';
 }
 
-async function connect(): Promise<void> {
+// ── Connect options ────────────────────────────────────────────────
+//
+// Threading an explicit `interactive` flag through the connect flow
+// lets the worker decide whether missing/stale credentials should
+// trigger an interactive sign-in/pair flow or produce an immediate
+// error. User-initiated Connect passes `interactive: true`; non-user-
+// initiated paths (auto-connect on bootstrap, reconnect) pass `false`.
+
+/**
+ * Options bag threaded through {@link connect} to control whether
+ * missing credentials trigger an interactive auth bootstrap.
+ *
+ * - `interactive: true` — the worker will auto-bootstrap auth when
+ *   credentials are missing or stale. For `local-pair` this runs
+ *   `bootstrapLocalToken`; for `cloud-oauth` this runs `signInCloud`.
+ * - `interactive: false` — the worker will attempt a non-interactive
+ *   refresh for cloud tokens but will NOT launch an interactive flow.
+ *   Missing credentials produce a {@link MissingTokenError}.
+ */
+interface ConnectOptions {
+  interactive: boolean;
+}
+
+/**
+ * Resolve credentials for the selected assistant before the socket
+ * opens. This is the single authority for whether auth is satisfied —
+ * the popup no longer needs to pre-check pairing/sign-in state.
+ *
+ * For `local-pair`:
+ *   - If the assistant-scoped local token is present and unexpired,
+ *     the existing relay mode is returned as-is.
+ *   - If the token is missing/expired and `interactive=true`, runs
+ *     `bootstrapLocalToken({ assistantId })` and rebuilds the mode.
+ *   - If the token is missing/expired and `interactive=false`, throws
+ *     a {@link MissingTokenError}.
+ *
+ * For `cloud-oauth`:
+ *   - If the stored cloud token is present and not stale, the existing
+ *     relay mode is returned as-is.
+ *   - If the token is missing/stale and `interactive=true`, runs
+ *     `signInCloud(...)` and rebuilds the mode.
+ *   - If the token is missing/stale and `interactive=false`, attempts
+ *     `refreshCloudToken(...)` first. If the non-interactive refresh
+ *     succeeds, rebuilds the mode with the fresh token. If the refresh
+ *     fails but the original mode still carries a token (stale but not
+ *     yet expired), the existing mode is returned as-is so the
+ *     `onReconnect` hook can handle actual expiry later. Only when
+ *     both the refresh fails and no token exists does it throw a
+ *     {@link MissingTokenError}.
+ *
+ * Returns the (possibly refreshed) {@link RelayMode} ready for socket
+ * open.
+ */
+async function connectPreflight(
+  assistant: AssistantDescriptor | null,
+  authProfile: AssistantAuthProfile | null,
+  mode: RelayMode,
+  options: ConnectOptions,
+): Promise<RelayMode> {
+  // Token already present — nothing to do.
+  if (mode.token) {
+    // For cloud mode, check staleness: a token that's about to expire
+    // should be proactively refreshed even when it's technically present.
+    if (mode.kind === 'cloud' && assistant) {
+      const stored = await getStoredCloudToken(assistant.assistantId);
+      if (!isCloudTokenStale(stored)) {
+        return mode;
+      }
+      // Token is stale — fall through to the refresh/sign-in logic below.
+    } else {
+      return mode;
+    }
+  }
+
+  if (authProfile === 'local-pair') {
+    if (!options.interactive) {
+      throw new MissingTokenError(missingTokenMessage('local-pair'));
+    }
+    // Interactive: auto-bootstrap the local capability token.
+    const assistantId = assistant?.assistantId ?? null;
+    const stored = await bootstrapLocalToken(assistantId);
+    const port = stored.assistantPort ?? assistant?.daemonPort ?? (await getRelayPort());
+    return {
+      kind: 'self-hosted',
+      baseUrl: `http://127.0.0.1:${port}`,
+      token: stored.token,
+    };
+  }
+
+  if (authProfile === 'cloud-oauth') {
+    const assistantId = assistant?.assistantId ?? null;
+    if (!assistantId) {
+      throw new MissingTokenError(missingTokenMessage(null));
+    }
+
+    if (!options.interactive) {
+      // Non-interactive: attempt a silent refresh first.
+      const gatewayBaseUrl = assistant?.runtimeUrl || CLOUD_GATEWAY_BASE_URL;
+      const refreshed = await refreshCloudToken(assistantId, {
+        gatewayBaseUrl,
+        clientId: CLOUD_OAUTH_CLIENT_ID,
+      });
+      if (refreshed) {
+        const baseUrl = assistant?.runtimeUrl || CLOUD_GATEWAY_BASE_URL;
+        return { kind: 'cloud', baseUrl, token: refreshed.token };
+      }
+      // If the token is stale but still technically valid, fall back to
+      // the existing mode rather than discarding a usable token. The
+      // onReconnect hook will handle actual expiry later.
+      if (mode.token) {
+        return mode;
+      }
+      throw new MissingTokenError(missingTokenMessage('cloud-oauth'));
+    }
+
+    // Interactive: launch the full OAuth sign-in flow.
+    const gatewayBaseUrl = assistant?.runtimeUrl || CLOUD_GATEWAY_BASE_URL;
+    const stored = await signInCloud(assistantId, {
+      gatewayBaseUrl,
+      clientId: CLOUD_OAUTH_CLIENT_ID,
+    });
+    const baseUrl = assistant?.runtimeUrl || CLOUD_GATEWAY_BASE_URL;
+    return { kind: 'cloud', baseUrl, token: stored.token };
+  }
+
+  // Unsupported or no assistant selected — preflight can't help.
+  throw new MissingTokenError(missingTokenMessage(authProfile));
+}
+
+// Serialization lock: if a connect is already in progress, subsequent
+// callers await the existing attempt rather than launching a concurrent
+// preflight. This prevents duplicate auth/pair flows when multiple
+// connect calls arrive before the first socket opens (e.g., repeated
+// user action or overlapping message paths).
+let connectInFlight: Promise<void> | null = null;
+
+async function connect(options: ConnectOptions = { interactive: false }): Promise<void> {
+  if (connectInFlight) {
+    return connectInFlight;
+  }
+  connectInFlight = doConnect(options);
+  try {
+    await connectInFlight;
+  } finally {
+    connectInFlight = null;
+  }
+}
+
+async function doConnect(options: ConnectOptions): Promise<void> {
   if (relayConnection && relayConnection.isOpen()) return;
   // Defensive: a fresh connect() always starts the 1006 refresh
   // budget from scratch. The counter is normally reset from onOpen,
@@ -812,12 +961,12 @@ async function connect(): Promise<void> {
     throw new MissingTokenError(msg);
   }
 
-  const mode = await buildRelayModeForAssistant(selected);
-  if (!mode.token) {
-    const msg = missingTokenMessage(authProfile);
-    console.warn(`[vellum-relay] ${msg}`);
-    throw new MissingTokenError(msg);
-  }
+  const rawMode = await buildRelayModeForAssistant(selected);
+  // Run the preflight to resolve/bootstrap credentials. When
+  // interactive=true the preflight auto-pairs or auto-signs-in;
+  // when interactive=false it either refreshes non-interactively or
+  // throws MissingTokenError.
+  const mode = await connectPreflight(selected, authProfile, rawMode, options);
   // Tear down any stale instance before constructing a new one. This
   // keeps the close/reconnect lifecycle simple — one RelayConnection
   // per live socket, no hidden state carried across mode switches.
@@ -875,7 +1024,10 @@ async function handleServerMessage(raw: string): Promise<void> {
 chrome.runtime.onMessage.addListener((message, _sender, sendResponseFn) => {
   if (message.type === 'connect') {
     shouldConnect = true;
-    connect()
+    // User-initiated Connect is interactive: the worker will auto-
+    // bootstrap missing auth (pair for local, sign-in for cloud)
+    // rather than requiring the popup to pre-check credentials.
+    connect({ interactive: true })
       .then(() => sendResponseFn({ ok: true }))
       .catch((err) => {
         // Reset shouldConnect so a subsequent storage change or
@@ -1019,18 +1171,22 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponseFn) => {
         if (shouldConnect && relayConnection) {
           disconnect();
           // Attempt a reconnect to the newly selected assistant.
+          // Interactive since the user is actively switching.
           // Errors are non-fatal — the user can manually reconnect.
           try {
-            await connect();
+            await connect({ interactive: true });
           } catch (err) {
-            if (err instanceof MissingTokenError) {
-              shouldConnect = false;
-              console.warn(
-                `[vellum-relay] Assistant switch left disconnected: ${err.message}`,
-              );
-            } else {
-              throw err;
-            }
+            // The assistant selection was already persisted and the old
+            // relay disconnected, so the switch itself succeeded regardless
+            // of whether the reconnect worked. MissingTokenError means no
+            // credentials at all; other errors (e.g. "cloud sign-in
+            // cancelled" when the user closes the OAuth window) are
+            // transient. In both cases, log and continue — the user can
+            // manually reconnect via the Connect button.
+            shouldConnect = false;
+            console.warn(
+              `[vellum-relay] Assistant switch left disconnected: ${err instanceof Error ? err.message : String(err)}`,
+            );
           }
         }
 
@@ -1056,7 +1212,10 @@ async function bootstrap(): Promise<void> {
   if (autoConnect !== true) return;
   shouldConnect = true;
   try {
-    await connect();
+    // Non-interactive: bootstrap should not pop up auth UIs. If
+    // credentials are missing the user will see disconnected state
+    // in the popup and can trigger an interactive connect.
+    await connect({ interactive: false });
   } catch (err) {
     // A missing token at auto-connect time is not a hard failure —
     // the user will see the disconnected state in the popup and can

--- a/clients/chrome-extension/native-host/README.md
+++ b/clients/chrome-extension/native-host/README.md
@@ -9,7 +9,11 @@ serves two purposes:
    assistant selector dropdown.
 2. **Self-hosted pairing** (`request_token`): bootstraps a scoped
    capability token for the local-assistant transport without shipping a
-   long-lived secret in the extension package.
+   long-lived secret in the extension package. In the normal one-click
+   Connect flow, the extension's service worker invokes this
+   automatically — users never need to trigger pairing manually. The
+   `request_token` message also serves as a recovery mechanism when
+   the popup's Troubleshooting "Re-pair" button is used.
 
 The macOS installer bundles this helper into the Mac `.app` under
 `Contents/MacOS/vellum-chrome-native-host` via `clients/macos/build.sh`
@@ -96,6 +100,12 @@ a `request_token` frame, the helper pairs against the specified
 assistant's port rather than the default.
 
 #### Self-hosted pairing (`request_token`)
+
+During normal operation, the extension's service worker sends this message
+automatically as part of the one-click Connect flow when the selected
+assistant uses the `local-pair` auth profile. Users do not interact with
+this message directly. It is also invoked when the user clicks the
+"Re-pair with local assistant" troubleshooting button in the popup.
 
 The extension sends:
 

--- a/clients/chrome-extension/popup/popup-state.test.ts
+++ b/clients/chrome-extension/popup/popup-state.test.ts
@@ -5,6 +5,8 @@
  *   - deriveSelectorDisplay: hidden for 0/1 assistants, visible for 2+
  *   - assistantLabel: readable label derivation
  *   - shouldShowLocalSection / shouldShowCloudSection: auth-profile gating
+ *   - deriveCtaState: CTA label/enablement for each connection phase
+ *   - deriveStatusDisplay: status dot class and text for each phase
  */
 
 import { describe, test, expect } from 'bun:test';
@@ -14,6 +16,9 @@ import {
   assistantLabel,
   shouldShowLocalSection,
   shouldShowCloudSection,
+  deriveCtaState,
+  deriveStatusDisplay,
+  type ConnectionPhase,
 } from './popup-state.js';
 
 import type { AssistantDescriptor } from '../background/native-host-assistants.js';
@@ -146,5 +151,104 @@ describe('shouldShowCloudSection', () => {
 
   test('returns false for null profile', () => {
     expect(shouldShowCloudSection(null)).toBe(false);
+  });
+});
+
+// ── deriveCtaState ─────────────────────────────────────────────────
+
+describe('deriveCtaState', () => {
+  test('disconnected: Connect enabled, Pause disabled', () => {
+    const state = deriveCtaState('disconnected');
+    expect(state.connectLabel).toBe('Connect');
+    expect(state.connectEnabled).toBe(true);
+    expect(state.pauseLabel).toBe('Pause');
+    expect(state.pauseEnabled).toBe(false);
+  });
+
+  test('connecting: shows Connecting\u2026 label, both buttons disabled', () => {
+    const state = deriveCtaState('connecting');
+    expect(state.connectLabel).toBe('Connecting\u2026');
+    expect(state.connectEnabled).toBe(false);
+    expect(state.pauseLabel).toBe('Pause');
+    expect(state.pauseEnabled).toBe(false);
+  });
+
+  test('connected: Connect disabled, Pause enabled', () => {
+    const state = deriveCtaState('connected');
+    expect(state.connectLabel).toBe('Connect');
+    expect(state.connectEnabled).toBe(false);
+    expect(state.pauseLabel).toBe('Pause');
+    expect(state.pauseEnabled).toBe(true);
+  });
+
+  test('paused: Connect enabled, Pause disabled (same as disconnected)', () => {
+    const state = deriveCtaState('paused');
+    expect(state.connectLabel).toBe('Connect');
+    expect(state.connectEnabled).toBe(true);
+    expect(state.pauseLabel).toBe('Pause');
+    expect(state.pauseEnabled).toBe(false);
+  });
+
+  test('all phases produce consistent label/enablement pairs', () => {
+    const phases: ConnectionPhase[] = ['disconnected', 'connecting', 'connected', 'paused'];
+    for (const phase of phases) {
+      const state = deriveCtaState(phase);
+      // Pause should only be enabled when connected
+      expect(state.pauseEnabled).toBe(phase === 'connected');
+      // Connect should be disabled only when connecting or connected
+      expect(state.connectEnabled).toBe(phase !== 'connecting' && phase !== 'connected');
+    }
+  });
+});
+
+// ── deriveStatusDisplay ────────────────────────────────────────────
+
+describe('deriveStatusDisplay', () => {
+  test('disconnected: red dot, Not connected', () => {
+    const status = deriveStatusDisplay('disconnected');
+    expect(status.dotClass).toBe('disconnected');
+    expect(status.text).toBe('Not connected');
+  });
+
+  test('connecting: red dot, Connecting\u2026', () => {
+    const status = deriveStatusDisplay('connecting');
+    expect(status.dotClass).toBe('disconnected');
+    expect(status.text).toBe('Connecting\u2026');
+  });
+
+  test('connected: green dot, Connected to relay server', () => {
+    const status = deriveStatusDisplay('connected');
+    expect(status.dotClass).toBe('connected');
+    expect(status.text).toBe('Connected to relay server');
+  });
+
+  test('paused: amber dot, Paused', () => {
+    const status = deriveStatusDisplay('paused');
+    expect(status.dotClass).toBe('paused');
+    expect(status.text).toBe('Paused');
+  });
+
+  test('display transitions: disconnected -> connecting -> connected -> paused -> disconnected', () => {
+    const transitions: ConnectionPhase[] = [
+      'disconnected',
+      'connecting',
+      'connected',
+      'paused',
+      'disconnected',
+    ];
+    const expectedDots = ['disconnected', 'disconnected', 'connected', 'paused', 'disconnected'];
+    const expectedTexts = [
+      'Not connected',
+      'Connecting\u2026',
+      'Connected to relay server',
+      'Paused',
+      'Not connected',
+    ];
+
+    for (let i = 0; i < transitions.length; i++) {
+      const status = deriveStatusDisplay(transitions[i]!);
+      expect(status.dotClass).toBe(expectedDots[i]);
+      expect(status.text).toBe(expectedTexts[i]);
+    }
   });
 });

--- a/clients/chrome-extension/popup/popup-state.ts
+++ b/clients/chrome-extension/popup/popup-state.ts
@@ -1,10 +1,16 @@
 /**
- * Pure view-state helpers for the popup assistant selector.
+ * Pure view-state helpers for the popup UI.
  *
- * These functions derive display state from the assistant catalog and
- * selection data returned by the worker's `assistants-get` message.
- * They are deliberately side-effect-free so they can be unit tested
- * without a Chrome runtime environment.
+ * These functions derive display state from the assistant catalog,
+ * selection data, and connection phase. They are deliberately
+ * side-effect-free so they can be unit tested without a Chrome runtime
+ * environment.
+ *
+ * The popup exposes two primary actions:
+ *   - **Connect** — the only first-step CTA. The worker handles auth
+ *     bootstrap (pairing/sign-in) automatically when `interactive=true`.
+ *   - **Pause** — user-facing stop action that halts the relay but
+ *     preserves credentials so reconnect is instant.
  */
 
 import type { AssistantDescriptor } from '../background/native-host-assistants.js';
@@ -111,4 +117,101 @@ export function shouldShowCloudSection(
   authProfile: AssistantAuthProfile | null,
 ): boolean {
   return authProfile === 'cloud-oauth';
+}
+
+// ── Connection phase & CTA helpers ──────────────────────────────────
+
+/**
+ * The popup's connection lifecycle phase. Drives the primary/secondary
+ * button labels, enablement, and status indicator.
+ *
+ * - `disconnected` — idle, no active relay connection.
+ * - `connecting`   — connect in progress (waiting for socket open).
+ * - `connected`    — relay WebSocket is open and active.
+ * - `paused`       — user explicitly paused; credentials are preserved
+ *                    so reconnect is instant.
+ */
+export type ConnectionPhase = 'disconnected' | 'connecting' | 'connected' | 'paused';
+
+/**
+ * Derived view state for the popup's primary and secondary action buttons.
+ */
+export interface CtaState {
+  /** Label for the primary action button. */
+  connectLabel: string;
+  /** Whether the primary Connect button is enabled. */
+  connectEnabled: boolean;
+  /** Label for the secondary action button. */
+  pauseLabel: string;
+  /** Whether the secondary Pause button is enabled. */
+  pauseEnabled: boolean;
+}
+
+/**
+ * Derive the CTA button labels and enablement from the connection phase.
+ *
+ * | Phase        | Connect       | Pause         |
+ * |--------------|---------------|---------------|
+ * | disconnected | Connect (on)  | Pause (off)   |
+ * | connecting   | Connecting... (off) | Pause (off) |
+ * | connected    | Connect (off) | Pause (on)    |
+ * | paused       | Connect (on)  | Pause (off)   |
+ */
+export function deriveCtaState(phase: ConnectionPhase): CtaState {
+  switch (phase) {
+    case 'disconnected':
+      return {
+        connectLabel: 'Connect',
+        connectEnabled: true,
+        pauseLabel: 'Pause',
+        pauseEnabled: false,
+      };
+    case 'connecting':
+      return {
+        connectLabel: 'Connecting\u2026',
+        connectEnabled: false,
+        pauseLabel: 'Pause',
+        pauseEnabled: false,
+      };
+    case 'connected':
+      return {
+        connectLabel: 'Connect',
+        connectEnabled: false,
+        pauseLabel: 'Pause',
+        pauseEnabled: true,
+      };
+    case 'paused':
+      return {
+        connectLabel: 'Connect',
+        connectEnabled: true,
+        pauseLabel: 'Pause',
+        pauseEnabled: false,
+      };
+  }
+}
+
+/**
+ * Derived view state for the status indicator (dot + text).
+ */
+export interface StatusDisplay {
+  /** CSS class for the status dot (`connected`, `paused`, `disconnected`). */
+  dotClass: string;
+  /** User-facing status text. */
+  text: string;
+}
+
+/**
+ * Derive the status dot class and text from the connection phase.
+ */
+export function deriveStatusDisplay(phase: ConnectionPhase): StatusDisplay {
+  switch (phase) {
+    case 'disconnected':
+      return { dotClass: 'disconnected', text: 'Not connected' };
+    case 'connecting':
+      return { dotClass: 'disconnected', text: 'Connecting\u2026' };
+    case 'connected':
+      return { dotClass: 'connected', text: 'Connected to relay server' };
+    case 'paused':
+      return { dotClass: 'paused', text: 'Paused' };
+  }
 }

--- a/clients/chrome-extension/popup/popup.html
+++ b/clients/chrome-extension/popup/popup.html
@@ -37,6 +37,7 @@
       transition: background 0.2s;
     }
     .status-dot.connected { background: #22c55e; }
+    .status-dot.paused { background: #f59e0b; }
     .status-dot.disconnected { background: #ef4444; }
 
     .status-text {
@@ -88,11 +89,11 @@
     }
     #btn-connect:hover:not(:disabled) { background: #4f46e5; }
 
-    #btn-disconnect {
+    #btn-pause {
       background: #f3f4f6;
       color: #374151;
     }
-    #btn-disconnect:hover:not(:disabled) { background: #e5e7eb; }
+    #btn-pause:hover:not(:disabled) { background: #e5e7eb; }
 
     .divider {
       height: 1px;
@@ -200,22 +201,20 @@
 
   <div class="btn-row">
     <button id="btn-connect">Connect</button>
-    <button id="btn-disconnect" disabled>Disconnect</button>
+    <button id="btn-pause" disabled>Pause</button>
   </div>
 
   <p class="hint">Relay port defaults to 7830.</p>
 
-  <div class="divider"></div>
+  <div class="divider" id="troubleshooting-divider"></div>
 
-  <p class="section-label">Local</p>
-  <p class="local-status" id="local-status">Not paired</p>
-  <button id="btn-pair-local" type="button">Pair with local assistant</button>
+  <p class="section-label" id="troubleshooting-label">Troubleshooting</p>
 
-  <div class="divider"></div>
+  <p class="local-status" id="local-status" style="display:none">Not paired</p>
+  <button id="btn-pair-local" type="button" style="display:none">Re-pair with local assistant</button>
 
-  <p class="section-label">Cloud</p>
-  <p class="cloud-status" id="cloud-status">Not signed in</p>
-  <button id="btn-cloud-signin" type="button">Sign in with Vellum (cloud)</button>
+  <p class="cloud-status" id="cloud-status" style="display:none">Not signed in</p>
+  <button id="btn-cloud-signin" type="button" style="display:none">Re-sign in with Vellum (cloud)</button>
 
   <script type="module" src="popup.js"></script>
 </body>

--- a/clients/chrome-extension/popup/popup.ts
+++ b/clients/chrome-extension/popup/popup.ts
@@ -264,18 +264,16 @@ function getPort(): number {
 
 btnConnect.addEventListener('click', async () => {
   const port = getPort();
-  const storageUpdate: Record<string, unknown> = { autoConnect: true };
 
   errorText.style.display = 'none';
   setPhase('connecting');
 
   try {
     if (portInput.value.trim()) {
-      storageUpdate.relayPort = port;
+      await chrome.storage.local.set({ relayPort: port });
     } else {
       await chrome.storage.local.remove('relayPort');
     }
-    await chrome.storage.local.set(storageUpdate);
   } catch (err) {
     showError(err instanceof Error ? err.message : String(err));
     setPhase('disconnected');
@@ -308,7 +306,6 @@ btnConnect.addEventListener('click', async () => {
 // preserved so the next Connect is instant.
 
 btnPause.addEventListener('click', () => {
-  chrome.storage.local.set({ autoConnect: false });
   chrome.runtime.sendMessage({ type: 'pause' }, () => {
     setPhase('paused');
   });

--- a/clients/chrome-extension/popup/popup.ts
+++ b/clients/chrome-extension/popup/popup.ts
@@ -5,10 +5,9 @@
  * one click even when the user hasn't previously paired or signed in.
  * The worker handles auth bootstrap automatically when `interactive=true`.
  *
- * The secondary action is **Pause**, which halts the relay but preserves
- * credentials for instant reconnect. Under the hood this sends the
- * existing `disconnect` message to the worker; once PR 2 lands it will
- * migrate to the dedicated `pause` message.
+ * The secondary action is **Pause**, which halts the relay and clears the
+ * auto-connect flag so the extension stays quiet until the user explicitly
+ * reconnects. Credentials are preserved for instant reconnect.
  *
  * Manual recovery controls (local re-pair and cloud re-sign-in) are
  * available under a Troubleshooting section, but are not required for
@@ -307,14 +306,13 @@ btnConnect.addEventListener('click', async () => {
 
 // ── Pause (secondary action) ────────────────────────────────────────
 //
-// Sends the existing disconnect/stop message to the worker while
-// presenting the action as "Pause" in the UI. Credentials are
-// preserved so reconnect is instant. Once PR 2 lands, this will
-// migrate to the dedicated `pause` message.
+// Sends the `pause` message to the worker, which tears down the relay
+// WebSocket and clears the `autoConnect` flag. Credentials are
+// preserved so the next Connect is instant.
 
 btnPause.addEventListener('click', () => {
   chrome.storage.local.set({ autoConnect: false });
-  chrome.runtime.sendMessage({ type: 'disconnect' }, () => {
+  chrome.runtime.sendMessage({ type: 'pause' }, () => {
     setPhase('paused');
   });
 });

--- a/clients/chrome-extension/popup/popup.ts
+++ b/clients/chrome-extension/popup/popup.ts
@@ -1,6 +1,19 @@
 /**
  * Popup UI for the Vellum browser-relay extension.
  *
+ * The popup exposes a single primary CTA — **Connect** — that works in
+ * one click even when the user hasn't previously paired or signed in.
+ * The worker handles auth bootstrap automatically when `interactive=true`.
+ *
+ * The secondary action is **Pause**, which halts the relay but preserves
+ * credentials for instant reconnect. Under the hood this sends the
+ * existing `disconnect` message to the worker; once PR 2 lands it will
+ * migrate to the dedicated `pause` message.
+ *
+ * Manual recovery controls (local re-pair and cloud re-sign-in) are
+ * available under a Troubleshooting section, but are not required for
+ * the normal connect flow.
+ *
  * On open the popup loads the assistant catalog from the worker via the
  * `assistants-get` message. When exactly one assistant exists it is
  * auto-selected and no selector dropdown is shown. When multiple
@@ -10,20 +23,6 @@
  * worker, which persists the selection and returns the resolved
  * descriptor + auth profile. The popup then refreshes the local/cloud
  * auth status panels to match the newly selected assistant.
- *
- * Self-hosted pairing is governed by the "Pair local assistant" button,
- * which spawns the native messaging helper and persists a capability
- * token (see self-hosted-auth.ts). Connect then reads that stored
- * capability token directly. If the user hasn't paired yet we surface
- * an inline error pointing them at the Pair button.
- *
- * Also exposes a "Sign in with Vellum (cloud)" button. The actual OAuth
- * flow runs in the background service worker (see worker.ts) — the popup
- * only sends a message asking the worker to start it. This avoids the
- * MV3 popup teardown race where closing the popup mid-auth would kill
- * the awaited launchWebAuthFlow promise before the token was persisted.
- * Cloud sign-in and self-hosted Pair coexist — they represent the two
- * possible relay transports.
  */
 
 import { getStoredToken, type StoredCloudToken } from '../background/cloud-auth.js';
@@ -37,6 +36,9 @@ import {
   deriveSelectorDisplay,
   shouldShowLocalSection,
   shouldShowCloudSection,
+  deriveCtaState,
+  deriveStatusDisplay,
+  type ConnectionPhase,
   type AssistantsGetResponse,
   type AssistantSelectResponse,
 } from './popup-state.js';
@@ -47,7 +49,7 @@ const DEFAULT_RELAY_PORT = 7830;
 
 const portInput = document.getElementById('port-input') as HTMLInputElement;
 const btnConnect = document.getElementById('btn-connect') as HTMLButtonElement;
-const btnDisconnect = document.getElementById('btn-disconnect') as HTMLButtonElement;
+const btnPause = document.getElementById('btn-pause') as HTMLButtonElement;
 const statusDot = document.getElementById('status-dot') as HTMLDivElement;
 const statusText = document.getElementById('status-text') as HTMLParagraphElement;
 const errorText = document.getElementById('error-text') as HTMLParagraphElement;
@@ -55,6 +57,13 @@ const btnCloudSignIn = document.getElementById('btn-cloud-signin') as HTMLButton
 const cloudStatus = document.getElementById('cloud-status') as HTMLParagraphElement;
 const btnPairLocal = document.getElementById('btn-pair-local') as HTMLButtonElement;
 const localStatus = document.getElementById('local-status') as HTMLParagraphElement;
+
+const troubleshootingDivider = document.getElementById(
+  'troubleshooting-divider',
+) as HTMLDivElement;
+const troubleshootingLabel = document.getElementById(
+  'troubleshooting-label',
+) as HTMLParagraphElement;
 
 const assistantSelectorGroup = document.getElementById(
   'assistant-selector-group',
@@ -71,15 +80,30 @@ const assistantSelect = document.getElementById(
 let currentAuthProfile: AssistantAuthProfile | null = null;
 let currentAssistantId: string | null = null;
 
-// ── Connection state helpers ────────────────────────────────────────
+// ── Connection phase management ─────────────────────────────────────
 
-function setConnected(connected: boolean): void {
-  statusDot.className = `status-dot ${connected ? 'connected' : 'disconnected'}`;
-  statusText.textContent = connected ? 'Connected to relay server' : 'Not connected';
-  btnConnect.disabled = connected;
-  btnDisconnect.disabled = !connected;
-  portInput.disabled = connected;
-  if (connected) {
+let currentPhase: ConnectionPhase = 'disconnected';
+
+/**
+ * Apply a connection phase to the UI. Derives button labels/enablement
+ * and status indicator from the pure helpers in popup-state.ts.
+ */
+function setPhase(phase: ConnectionPhase): void {
+  currentPhase = phase;
+
+  const cta = deriveCtaState(phase);
+  btnConnect.textContent = cta.connectLabel;
+  btnConnect.disabled = !cta.connectEnabled;
+  btnPause.textContent = cta.pauseLabel;
+  btnPause.disabled = !cta.pauseEnabled;
+
+  const status = deriveStatusDisplay(phase);
+  statusDot.className = `status-dot ${status.dotClass}`;
+  statusText.textContent = status.text;
+
+  portInput.disabled = phase === 'connected' || phase === 'connecting';
+
+  if (phase === 'connected') {
     errorText.style.display = 'none';
   }
 }
@@ -132,61 +156,26 @@ function renderAssistantSelector(
 }
 
 /**
- * Update the visibility of the Local and Cloud auth sections based on
- * the selected assistant's auth profile.
+ * Update the visibility of the Local and Cloud troubleshooting controls
+ * based on the selected assistant's auth profile.
  */
 function updateAuthSections(authProfile: AssistantAuthProfile | null): void {
   currentAuthProfile = authProfile;
 
-  // Find the section containers by walking from the section-label elements.
-  // The Local section = section-label "Local" + local-status + btn-pair-local + preceding divider.
-  // The Cloud section = section-label "Cloud" + cloud-status + btn-cloud-signin + preceding divider.
-  //
-  // We use a simpler approach: show/hide the local and cloud elements
-  // individually based on the auth profile.
-
   const showLocal = shouldShowLocalSection(authProfile);
   const showCloud = shouldShowCloudSection(authProfile);
 
-  // Walk DOM to find the divider before each section label.
-  const sectionLabels = document.querySelectorAll('.section-label');
+  // Toggle Local troubleshooting elements visibility.
+  localStatus.style.display = showLocal ? '' : 'none';
+  btnPairLocal.style.display = showLocal ? '' : 'none';
 
-  // Find the local section's divider (the one before "Local")
-  // and the cloud section's divider (the one before "Cloud")
-  let localDividerEl: Element | null = null;
-  let cloudDividerEl: Element | null = null;
-  let localLabelEl: Element | null = null;
-  let cloudLabelEl: Element | null = null;
+  // Toggle Cloud troubleshooting elements visibility.
+  cloudStatus.style.display = showCloud ? '' : 'none';
+  btnCloudSignIn.style.display = showCloud ? '' : 'none';
 
-  for (const label of sectionLabels) {
-    if (label.textContent?.trim() === 'Local') localLabelEl = label;
-    if (label.textContent?.trim() === 'Cloud') cloudLabelEl = label;
-  }
-
-  // The divider immediately before the Local label
-  if (localLabelEl?.previousElementSibling?.classList.contains('divider')) {
-    localDividerEl = localLabelEl.previousElementSibling;
-  }
-  // The divider immediately before the Cloud label
-  if (cloudLabelEl?.previousElementSibling?.classList.contains('divider')) {
-    cloudDividerEl = cloudLabelEl.previousElementSibling;
-  }
-
-  // Toggle Local section visibility
-  const localElements = [localDividerEl, localLabelEl, localStatus, btnPairLocal];
-  for (const el of localElements) {
-    if (el instanceof HTMLElement) {
-      el.style.display = showLocal ? '' : 'none';
-    }
-  }
-
-  // Toggle Cloud section visibility
-  const cloudElements = [cloudDividerEl, cloudLabelEl, cloudStatus, btnCloudSignIn];
-  for (const el of cloudElements) {
-    if (el instanceof HTMLElement) {
-      el.style.display = showCloud ? '' : 'none';
-    }
-  }
+  // Hide the Troubleshooting divider and heading when no controls are shown.
+  troubleshootingDivider.style.display = showLocal || showCloud ? '' : 'none';
+  troubleshootingLabel.style.display = showLocal || showCloud ? '' : 'none';
 }
 
 /**
@@ -259,7 +248,7 @@ chrome.storage.local.get(['relayPort']).then((result) => {
 // Query current status from service worker
 chrome.runtime.sendMessage({ type: 'get_status' }, (response: { connected: boolean }) => {
   if (chrome.runtime.lastError) return;
-  setConnected(response?.connected ?? false);
+  setPhase(response?.connected ? 'connected' : 'disconnected');
 });
 
 function getPort(): number {
@@ -271,41 +260,36 @@ function getPort(): number {
   return DEFAULT_RELAY_PORT;
 }
 
+// ── Connect (primary CTA) ───────────────────────────────────────────
+//
+// No local precheck — the worker handles auth bootstrap (pairing/sign-in)
+// automatically when interactive=true. Users can connect in one click
+// even when not previously paired or signed in.
+
 btnConnect.addEventListener('click', async () => {
   const port = getPort();
   const storageUpdate: Record<string, unknown> = { autoConnect: true };
 
   errorText.style.display = 'none';
+  setPhase('connecting');
 
-  // Check whether pairing is required based on the selected assistant's
-  // auth profile. In cloud mode the worker uses the stored cloud token
-  // (vellum.cloudAuthToken) directly, so the popup must NOT try to hit
-  // localhost — a cloud-only user may not have a local assistant running.
-  if (currentAuthProfile === 'local-pair') {
-    if (!currentAssistantId) {
-      showError('No assistant selected — please select an assistant first.');
-      return;
+  try {
+    if (portInput.value.trim()) {
+      storageUpdate.relayPort = port;
+    } else {
+      await chrome.storage.local.remove('relayPort');
     }
-    const pairedToken = await getStoredLocalToken(currentAssistantId);
-    if (!pairedToken) {
-      showError(
-        'Local assistant is not paired yet — click "Pair with local assistant" below before connecting.',
-      );
-      return;
-    }
+    await chrome.storage.local.set(storageUpdate);
+  } catch (err) {
+    showError(err instanceof Error ? err.message : String(err));
+    setPhase('disconnected');
+    return;
   }
-
-  if (portInput.value.trim()) {
-    storageUpdate.relayPort = port;
-  } else {
-    await chrome.storage.local.remove('relayPort');
-  }
-  await chrome.storage.local.set(storageUpdate);
 
   chrome.runtime.sendMessage({ type: 'connect' }, (response: { ok: boolean; error?: string }) => {
     if (chrome.runtime.lastError || !response?.ok) {
       showError(response?.error ?? chrome.runtime.lastError?.message ?? 'Unknown error');
-      btnConnect.disabled = false;
+      setPhase('disconnected');
       return;
     }
     // Poll briefly for open state
@@ -314,21 +298,28 @@ btnConnect.addEventListener('click', async () => {
       chrome.runtime.sendMessage({ type: 'get_status' }, (r: { connected: boolean }) => {
         if (r?.connected || ++attempts > 10) {
           clearInterval(poll);
-          setConnected(r?.connected ?? false);
+          setPhase(r?.connected ? 'connected' : 'disconnected');
         }
       });
     }, 300);
   });
 });
 
-btnDisconnect.addEventListener('click', () => {
+// ── Pause (secondary action) ────────────────────────────────────────
+//
+// Sends the existing disconnect/stop message to the worker while
+// presenting the action as "Pause" in the UI. Credentials are
+// preserved so reconnect is instant. Once PR 2 lands, this will
+// migrate to the dedicated `pause` message.
+
+btnPause.addEventListener('click', () => {
   chrome.storage.local.set({ autoConnect: false });
   chrome.runtime.sendMessage({ type: 'disconnect' }, () => {
-    setConnected(false);
+    setPhase('paused');
   });
 });
 
-// ── Self-hosted native-messaging pairing ────────────────────────────
+// ── Self-hosted native-messaging pairing (troubleshooting) ──────────
 //
 // Pairing runs the local native messaging helper (com.vellum.daemon),
 // which POSTs the extension's origin to the assistant's
@@ -336,6 +327,9 @@ btnDisconnect.addEventListener('click', () => {
 // The token is persisted in chrome.storage.local under
 // `vellum.localCapabilityToken` and is used directly by the
 // self-hosted relay WebSocket connection.
+//
+// This is a manual recovery control — normal connect handles pairing
+// automatically via the worker's interactive bootstrap.
 
 function setLocalStatus(text: string, state: 'neutral' | 'paired' | 'error'): void {
   localStatus.textContent = text;
@@ -395,7 +389,7 @@ function requestLocalPair(): Promise<LocalPairResponse> {
 
 btnPairLocal.addEventListener('click', async () => {
   btnPairLocal.disabled = true;
-  setLocalStatus('Pairing…', 'neutral');
+  setLocalStatus('Pairing\u2026', 'neutral');
   // Delegate to the service worker so the native-messaging bootstrap
   // survives the popup teardown race — see the `self-hosted-pair`
   // handler in worker.ts, and the matching cloud-auth-sign-in pattern.
@@ -410,10 +404,13 @@ btnPairLocal.addEventListener('click', async () => {
 
 refreshLocalStatus();
 
-// ── Cloud sign-in ───────────────────────────────────────────────────
+// ── Cloud sign-in (troubleshooting) ─────────────────────────────────
 //
 // The token is persisted and consumed by the background worker when
 // opening cloud relay WebSocket connections.
+//
+// This is a manual recovery control — normal connect handles cloud
+// sign-in automatically via the worker's interactive bootstrap.
 
 function setCloudStatus(text: string, signedIn: boolean): void {
   cloudStatus.textContent = text;
@@ -473,7 +470,7 @@ function requestCloudSignIn(): Promise<CloudSignInResponse> {
 
 btnCloudSignIn.addEventListener('click', async () => {
   btnCloudSignIn.disabled = true;
-  setCloudStatus('Signing in…', false);
+  setCloudStatus('Signing in\u2026', false);
   errorText.style.display = 'none';
   // Clear any stale auth-error the worker persisted during a failed
   // reconnect — the user is explicitly retrying sign-in now.

--- a/clients/chrome-extension/popup/popup.ts
+++ b/clients/chrome-extension/popup/popup.ts
@@ -81,14 +81,11 @@ let currentAssistantId: string | null = null;
 
 // ── Connection phase management ─────────────────────────────────────
 
-let currentPhase: ConnectionPhase = 'disconnected';
-
 /**
  * Apply a connection phase to the UI. Derives button labels/enablement
  * and status indicator from the pure helpers in popup-state.ts.
  */
 function setPhase(phase: ConnectionPhase): void {
-  currentPhase = phase;
 
   const cta = deriveCtaState(phase);
   btnConnect.textContent = cta.connectLabel;


### PR DESCRIPTION
## Summary
Simplifies the Chrome extension UX so users perform a single Connect action while the worker handles pairing/sign-in automatically. Replaces user-facing Disconnect with Pause semantics, and ensures the extension auto-connects on reopen after successful initial setup.

## Self-review result
GAPS FOUND — 5 gaps fixed across 5 fix PRs (round 1). Re-review passed clean.

## PRs merged into feature branch
- #24782: Chrome worker: make Connect interactive and auto-bootstrap assistant auth
- #24788: Chrome worker: formalize Pause action and reliable auto-connect lifecycle
- #24789: Chrome popup: one-click Connect flow with user-facing Pause control
- #24794: Chrome extension docs: document one-click connect, pause, and reopen auto-connect

### Fix PRs
- #24801: fix: update error messages to reference troubleshooting controls
- #24799: fix: remove popup's eager autoConnect writes, let worker own the flag
- #24800: fix: allow interactive connect to supersede in-flight non-interactive connect
- #24797: fix: remove unused currentPhase variable from popup.ts
- #24798: fix: remove unused beforeEach/afterEach imports from connect preflight tests

Part of plan: one-click-connect-pause-autoconnect.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24802" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
