### PR TITLE
Runtime browser-relay: accept keepalive frames and update extension activity

### DIFF
--- a/assistant/src/__tests__/fixtures/mock-chrome-extension.ts
+++ b/assistant/src/__tests__/fixtures/mock-chrome-extension.ts
@@ -124,6 +124,12 @@ export interface MockChromeExtension {
    * command.
    */
   sendSessionInvalidated(event: { targetId?: string; reason?: string }): void;
+  /**
+   * Send an arbitrary pre-serialized JSON string over the active
+   * WebSocket. Used by tests that need to send frame types not covered
+   * by the fixture's typed helpers (e.g. keepalive frames).
+   */
+  sendRaw(json: string): void;
 }
 
 // ── Defaults ────────────────────────────────────────────────────────
@@ -370,6 +376,11 @@ export function createMockChromeExtension(
           ...(event.reason !== undefined ? { reason: event.reason } : {}),
         }),
       );
+    },
+    sendRaw(json: string) {
+      const sock = ws;
+      if (!sock || sock.readyState !== WebSocket.OPEN) return;
+      sock.send(json);
     },
   };
 }

--- a/assistant/src/__tests__/host-browser-ws-events-e2e.test.ts
+++ b/assistant/src/__tests__/host-browser-ws-events-e2e.test.ts
@@ -284,6 +284,106 @@ describe("host_browser WS event + invalidation e2e", () => {
     await mockExt.stop();
   });
 
+  test("keepalive frames are accepted without closing the socket or producing warnings", async () => {
+    const guardianId = `guardian-${crypto.randomUUID()}`;
+    const { token } = mintHostBrowserCapability(guardianId);
+
+    const { createMockChromeExtension } =
+      await import("./fixtures/mock-chrome-extension.js");
+    const mockExt = createMockChromeExtension({
+      runtimeBaseUrl,
+      token,
+      resultTransport: "ws",
+    });
+    await mockExt.start();
+    await mockExt.waitForConnection();
+    await waitForRegistryEntry(guardianId);
+
+    // Grab the initial lastActiveAt timestamp so we can verify it
+    // was bumped by the keepalive.
+    const connBefore = getChromeExtensionRegistry().get(guardianId)!;
+    const lastActiveBefore = connBefore.lastActiveAt;
+
+    // Small delay to ensure Date.now() advances at least 1ms.
+    await new Promise((r) => setTimeout(r, 15));
+
+    // Send a keepalive frame (the extension sends these periodically
+    // to prevent the runtime from considering the connection stale).
+    // The frame may contain extra keys (e.g. timestamp) that the
+    // runtime should silently ignore (lenient validation).
+    mockExt.sendRaw(JSON.stringify({ type: "keepalive", ts: Date.now() }));
+
+    // Wait for the touch to propagate.
+    await waitFor(() => {
+      const conn = getChromeExtensionRegistry().get(guardianId);
+      return conn !== undefined && conn.lastActiveAt > lastActiveBefore;
+    });
+
+    const connAfter = getChromeExtensionRegistry().get(guardianId)!;
+    expect(connAfter.lastActiveAt).toBeGreaterThan(lastActiveBefore);
+
+    // Verify the socket is still alive by sending a normal host_browser_event
+    // frame after the keepalive — if the socket had been torn down, this
+    // would never arrive.
+    const observed: ForwardedCdpEvent[] = [];
+    const unsubscribe = onCdpEvent((event) => observed.push(event));
+
+    mockExt.sendHostBrowserEvent({ method: "Page.loadEventFired" });
+    await waitFor(() => observed.length === 1);
+    expect(observed[0].method).toBe("Page.loadEventFired");
+
+    unsubscribe();
+    await mockExt.stop();
+  });
+
+  test("normal host_browser flows still pass after keepalive traffic", async () => {
+    const guardianId = `guardian-${crypto.randomUUID()}`;
+    const { token } = mintHostBrowserCapability(guardianId);
+
+    const { createMockChromeExtension } =
+      await import("./fixtures/mock-chrome-extension.js");
+    const mockExt = createMockChromeExtension({
+      runtimeBaseUrl,
+      token,
+      resultTransport: "ws",
+    });
+    await mockExt.start();
+    await mockExt.waitForConnection();
+    await waitForRegistryEntry(guardianId);
+
+    // Simulate a burst of keepalive frames (as would happen during an
+    // idle period with the extension's alarm-based keepalive ticker).
+    for (let i = 0; i < 5; i++) {
+      mockExt.sendRaw(JSON.stringify({ type: "keepalive" }));
+    }
+
+    // Small delay to let all keepalive frames process.
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Now send a host_browser_event and verify it still fans out
+    // correctly — proving keepalive traffic does not interfere with
+    // normal message processing.
+    const observed: ForwardedCdpEvent[] = [];
+    const unsubscribe = onCdpEvent((event) => observed.push(event));
+
+    mockExt.sendHostBrowserEvent({
+      method: "Network.requestWillBeSent",
+      params: { requestId: "req-42", url: "https://example.com/api" },
+      cdpSessionId: "session-xyz",
+    });
+
+    await waitFor(() => observed.length === 1);
+    expect(observed[0].method).toBe("Network.requestWillBeSent");
+    expect(observed[0].params).toEqual({
+      requestId: "req-42",
+      url: "https://example.com/api",
+    });
+    expect(observed[0].cdpSessionId).toBe("session-xyz");
+
+    unsubscribe();
+    await mockExt.stop();
+  });
+
   test("malformed host_browser_event frames are dropped without tearing down the socket", async () => {
     const guardianId = `guardian-${crypto.randomUUID()}`;
     const { token } = mintHostBrowserCapability(guardianId);

--- a/assistant/src/runtime/chrome-extension-registry.ts
+++ b/assistant/src/runtime/chrome-extension-registry.ts
@@ -199,6 +199,25 @@ export class ChromeExtensionRegistry {
   }
 
   /**
+   * Update the `lastActiveAt` timestamp for the connection identified by
+   * `connectionId`, without changing routing semantics or registration
+   * state. Used by keepalive frames to signal that the extension is still
+   * alive and reachable. No-op if no connection with the given id is
+   * currently registered (e.g. after a race between disconnect and a
+   * trailing keepalive frame).
+   */
+  touch(connectionId: string): void {
+    for (const instances of this.byGuardian.values()) {
+      for (const conn of instances.values()) {
+        if (conn.id === connectionId) {
+          conn.lastActiveAt = Date.now();
+          return;
+        }
+      }
+    }
+  }
+
+  /**
    * Return the default "active" connection for a guardian — the
    * instance with the most recent `lastActiveAt` timestamp. Ties on
    * `lastActiveAt` (common when two sibling instances register or

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -520,6 +520,14 @@ export class RuntimeHttpServer {
                 }
                 return;
               }
+              case "keepalive": {
+                // Extension keepalive frames refresh the connection's
+                // activity timestamp without producing log noise or
+                // altering routing semantics. Unknown extra keys on
+                // the frame are silently ignored (lenient validation).
+                getChromeExtensionRegistry().touch(data.connectionId);
+                return;
+              }
               default: {
                 log.debug(
                   { connectionId: data.connectionId, type: frame.type },


### PR DESCRIPTION
## Summary
- Add touch() method to ChromeExtensionRegistry to update lastActiveAt on keepalive
- Handle keepalive frame type in browser-relay WebSocket message handler without warnings
- Extend e2e tests to verify keepalive acceptance and normal flow continuity

Part of plan: seamless-browser-extension-ux.md (PR 2 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24804" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
