### PR TITLE
fix: Chrome extension test type errors and missed error message migration

### DIFF
--- a/clients/chrome-extension/background/relay-connection.ts
+++ b/clients/chrome-extension/background/relay-connection.ts
@@ -451,7 +451,7 @@ export class RelayConnection {
             kind: 'abort',
             error:
               `Relay token refresh failed: ${message}. ` +
-              `Sign in with Vellum again from the extension popup to reconnect.`,
+              `Use 'Re-sign in' in Troubleshooting, then try Connect again.`,
           };
         }
       }

--- a/clients/chrome-extension/types/bun-test-shim.d.ts
+++ b/clients/chrome-extension/types/bun-test-shim.d.ts
@@ -41,7 +41,9 @@ declare module 'bun:test' {
 
   interface Matchers<R> {
     toBe(expected: unknown): R;
+    toBeDefined(): R;
     toEqual(expected: unknown): R;
+    toBeInstanceOf(expected: Function): R;
     toBeNull(): R;
     toBeUndefined(): R;
     toBeGreaterThanOrEqual(expected: number): R;
@@ -54,5 +56,10 @@ declare module 'bun:test' {
     toThrow(expected?: string | RegExp | Error): R;
   }
 
-  export function expect<T>(actual: T): Matchers<void>;
+  interface ExpectFunction {
+    <T>(actual: T): Matchers<void>;
+    unreachable(message?: string): never;
+  }
+
+  export const expect: ExpectFunction;
 }


### PR DESCRIPTION
## Summary
- Add `toBeDefined`, `toBeInstanceOf`, and `expect.unreachable` to the bun-test shim so test files type-check correctly
- Update relay-connection.ts error message to reference Troubleshooting controls (missed in #24801)

Addresses late review feedback on #24802 and fixes the extension build.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24807" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
