### PR TITLE
CDP factory: avoid silent cdp-inspect takeover when extension transport is expected

### DIFF
--- a/assistant/src/tools/browser/cdp-client/__tests__/factory.test.ts
+++ b/assistant/src/tools/browser/cdp-client/__tests__/factory.test.ts
@@ -541,7 +541,7 @@ describe("getCdpClient", () => {
     expect(createExtensionCdpClientMock).toHaveBeenCalledTimes(1);
   });
 
-  test("context with transportInterface set routes normally to local backend when no proxy", async () => {
+  test("context with transportInterface=macos routes to desktop-auto cdp-inspect when no proxy", async () => {
     const ctx = makeContext({
       conversationId: "macos-local",
       transportInterface: "macos",
@@ -549,10 +549,12 @@ describe("getCdpClient", () => {
 
     const client = getCdpClient(ctx);
 
-    expect(client.kind).toBe("local");
+    // desktopAuto.enabled is true by default and no proxy is provisioned,
+    // so cdp-inspect is the first candidate (desktop-auto path).
+    expect(client.kind).toBe("cdp-inspect");
     expect(client.conversationId).toBe("macos-local");
-    await client.send("Runtime.evaluate");
-    expect(createLocalCdpClientMock).toHaveBeenCalledTimes(1);
+    await client.send("Page.navigate");
+    expect(createCdpInspectClientMock).toHaveBeenCalledTimes(1);
   });
 
   test("context with transportInterface set routes to cdp-inspect when enabled", async () => {
@@ -1003,6 +1005,55 @@ describe("desktop-auto cdp-inspect (macOS)", () => {
     expect(candidates[2].kind).toBe("local");
   });
 
+  test("macOS turn with proxy unavailable skips desktop-auto cdp-inspect (extension intent)", () => {
+    const fakeProxy = makeUnavailableProxy();
+    const ctx = makeContext({
+      conversationId: "macos-proxy-unavailable-no-inspect",
+      hostBrowserProxy: fakeProxy,
+      transportInterface: "macos",
+    });
+
+    const candidates = buildCandidateList(ctx);
+
+    // Should only include local -- cdp-inspect is suppressed because extension
+    // transport is expected (proxy exists) but temporarily unavailable.
+    expect(candidates.length).toBe(1);
+    expect(candidates[0].kind).toBe("local");
+  });
+
+  test("macOS turn with no proxy still includes desktop-auto cdp-inspect", () => {
+    const ctx = makeContext({
+      conversationId: "macos-no-proxy-inspect-allowed",
+      transportInterface: "macos",
+    });
+
+    const candidates = buildCandidateList(ctx);
+
+    // No proxy provisioned => cdp-inspect remains available as fallback
+    expect(candidates.length).toBe(2);
+    expect(candidates[0].kind).toBe("cdp-inspect");
+    expect(candidates[0].reason).toContain("desktopAuto");
+    expect(candidates[1].kind).toBe("local");
+  });
+
+  test("macOS turn with extension available still includes cdp-inspect as fallback", () => {
+    const fakeProxy = makeAvailableProxy();
+    const ctx = makeContext({
+      conversationId: "macos-ext-available-inspect-fallback",
+      hostBrowserProxy: fakeProxy,
+      transportInterface: "macos",
+    });
+
+    const candidates = buildCandidateList(ctx);
+
+    // Extension is available => extension + cdp-inspect (desktop-auto) + local
+    expect(candidates.length).toBe(3);
+    expect(candidates[0].kind).toBe("extension");
+    expect(candidates[1].kind).toBe("cdp-inspect");
+    expect(candidates[1].reason).toContain("desktopAuto");
+    expect(candidates[2].kind).toBe("local");
+  });
+
   test("macOS turn does NOT include cdp-inspect when desktopAuto.enabled is false", () => {
     desktopAutoConfig = { enabled: false, cooldownMs: 30_000 };
     const ctx = makeContext({
@@ -1136,6 +1187,28 @@ describe("desktop-auto cdp-inspect (macOS)", () => {
     const candidates = buildCandidateList(ctx2);
     expect(candidates.length).toBe(1);
     expect(candidates[0].kind).toBe("local");
+  });
+
+  test("macOS turn with proxy unavailable routes to local without trying cdp-inspect", async () => {
+    const fakeProxy = makeUnavailableProxy();
+    const ctx = makeContext({
+      conversationId: "macos-proxy-unavail-route",
+      hostBrowserProxy: fakeProxy,
+      transportInterface: "macos",
+    });
+
+    const client = getCdpClient(ctx);
+
+    // Should go straight to local -- no cdp-inspect candidate inserted
+    expect(client.kind).toBe("local");
+    const result = await client.send<{ ok: boolean; via: string }>(
+      "Page.navigate",
+    );
+    expect(result).toEqual({ ok: true, via: "local" });
+    expect(createCdpInspectClientMock).not.toHaveBeenCalled();
+    expect(createExtensionCdpClientMock).not.toHaveBeenCalled();
+    expect(createLocalCdpClientMock).toHaveBeenCalledTimes(1);
+    client.dispose();
   });
 
   test("explicit config cdp-inspect failure does NOT record desktop-auto cooldown", async () => {

--- a/assistant/src/tools/browser/cdp-client/factory.ts
+++ b/assistant/src/tools/browser/cdp-client/factory.ts
@@ -208,38 +208,52 @@ export function buildCandidateList(context: ToolContext): BackendCandidate[] {
     context.transportInterface === "macos" &&
     cdpInspectConfig.desktopAuto.enabled
   ) {
-    // macOS desktop-auto: include cdp-inspect as a candidate unless the
-    // cooldown from a recent failure is still active.
-    const { cooldownMs } = cdpInspectConfig.desktopAuto;
-    if (isDesktopAutoCooldownActive(cooldownMs)) {
+    // macOS desktop-auto: include cdp-inspect as a candidate unless:
+    // (a) the hostBrowserProxy exists but is temporarily unavailable
+    //     (extension transport expected but transiently disconnected --
+    //     inserting cdp-inspect here would cause a silent takeover), or
+    // (b) the cooldown from a recent failure is still active.
+    //
+    // When no hostBrowserProxy is present at all (extension not
+    // provisioned for this conversation), cdp-inspect remains available
+    // as a fallback per the desktop-auto contract.
+    if (hostBrowserProxy && !hostBrowserProxy.isAvailable()) {
       log.debug(
-        {
-          conversationId,
-          cooldownMs,
-          cooldownSince: _desktopAutoCooldownSince,
-        },
-        "CDP factory: desktop-auto cdp-inspect skipped (cooldown active)",
+        { conversationId },
+        "CDP factory: desktop-auto cdp-inspect skipped (extension transport expected but temporarily unavailable)",
       );
     } else {
-      candidates.push({
-        kind: "cdp-inspect",
-        reason: "desktopAuto: macOS turn, cdp-inspect auto-attempted",
-        create() {
-          const client = createCdpInspectClient(conversationId, {
-            host: cdpInspectConfig.host,
-            port: cdpInspectConfig.port,
-            discoveryTimeoutMs: cdpInspectConfig.probeTimeoutMs,
-            wsConnectTimeoutMs: cdpInspectConfig.probeTimeoutMs,
-          });
-          const backend = createCdpInspectBackend({
-            isAvailable: () => true,
-            sendCdp: (command, signal) =>
-              dispatchThroughClient(client, command, signal),
-            dispose: () => client.dispose(),
-          });
-          return { client, backend };
-        },
-      });
+      const { cooldownMs } = cdpInspectConfig.desktopAuto;
+      if (isDesktopAutoCooldownActive(cooldownMs)) {
+        log.debug(
+          {
+            conversationId,
+            cooldownMs,
+            cooldownSince: _desktopAutoCooldownSince,
+          },
+          "CDP factory: desktop-auto cdp-inspect skipped (cooldown active)",
+        );
+      } else {
+        candidates.push({
+          kind: "cdp-inspect",
+          reason: "desktopAuto: macOS turn, cdp-inspect auto-attempted",
+          create() {
+            const client = createCdpInspectClient(conversationId, {
+              host: cdpInspectConfig.host,
+              port: cdpInspectConfig.port,
+              discoveryTimeoutMs: cdpInspectConfig.probeTimeoutMs,
+              wsConnectTimeoutMs: cdpInspectConfig.probeTimeoutMs,
+            });
+            const backend = createCdpInspectBackend({
+              isAvailable: () => true,
+              sendCdp: (command, signal) =>
+                dispatchThroughClient(client, command, signal),
+              dispose: () => client.dispose(),
+            });
+            return { client, backend };
+          },
+        });
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- Refine buildCandidateList to skip cdp-inspect fallback when hostBrowserProxy exists but is temporarily unavailable
- Preserve cdp-inspect availability for explicit non-extension scenarios (no proxy provisioned)
- Add test coverage for macOS routing with proxy unavailable, no proxy, and extension available paths

Part of plan: seamless-browser-extension-ux.md (PR 4 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24808" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
