### PR TITLE
Drop legacy TTS config/schema paths and require services.tts only

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -669,7 +669,6 @@ describe("AssistantConfigSchema", () => {
       voice: {
         language: "en-US",
         transcriptionProvider: "Deepgram",
-        ttsProvider: "elevenlabs",
         hints: [],
         interruptSensitivity: "low",
       },
@@ -780,28 +779,6 @@ describe("AssistantConfigSchema", () => {
     expect(result.calls.voice.transcriptionProvider).toBe("Deepgram");
   });
 
-  test("elevenlabs tuning params have correct defaults", () => {
-    const result = AssistantConfigSchema.parse({});
-    expect(result.elevenlabs.voiceModelId).toBe("");
-    expect(result.elevenlabs.speed).toBe(1.0);
-    expect(result.elevenlabs.stability).toBe(0.5);
-    expect(result.elevenlabs.similarityBoost).toBe(0.75);
-  });
-
-  test("rejects elevenlabs.speed below 0.7", () => {
-    const result = AssistantConfigSchema.safeParse({
-      elevenlabs: { speed: 0.5 },
-    });
-    expect(result.success).toBe(false);
-  });
-
-  test("rejects elevenlabs.speed above 1.2", () => {
-    const result = AssistantConfigSchema.safeParse({
-      elevenlabs: { speed: 1.5 },
-    });
-    expect(result.success).toBe(false);
-  });
-
   test("accepts valid calls.voice overrides", () => {
     const result = AssistantConfigSchema.parse({
       calls: {
@@ -810,16 +787,9 @@ describe("AssistantConfigSchema", () => {
           transcriptionProvider: "Google",
         },
       },
-      elevenlabs: {
-        stability: 0.8,
-      },
     });
     expect(result.calls.voice.language).toBe("es-ES");
     expect(result.calls.voice.transcriptionProvider).toBe("Google");
-    expect(result.elevenlabs.stability).toBe(0.8);
-    // Defaults preserved for unset fields
-    expect(result.elevenlabs.voiceModelId).toBe("");
-    expect(result.elevenlabs.similarityBoost).toBe(0.75);
   });
 
   test("rejects invalid calls.voice.transcriptionProvider", () => {
@@ -833,13 +803,6 @@ describe("AssistantConfigSchema", () => {
         msgs.some((m) => m.includes("calls.voice.transcriptionProvider")),
       ).toBe(true);
     }
-  });
-
-  test("rejects elevenlabs.stability out of range", () => {
-    const result = AssistantConfigSchema.safeParse({
-      elevenlabs: { stability: 1.5 },
-    });
-    expect(result.success).toBe(false);
   });
 
   test("accepts optional calls.model", () => {
@@ -1141,9 +1104,13 @@ describe("resolveVoiceQualityProfile", () => {
     expect(profile.transcriptionProvider).toBe("Deepgram");
   });
 
-  test("uses shared elevenlabs.voiceId for voice", () => {
+  test("uses services.tts.providers.elevenlabs.voiceId for voice", () => {
     const config = AssistantConfigSchema.parse({
-      elevenlabs: { voiceId: "test-voice-id" },
+      services: {
+        tts: {
+          providers: { elevenlabs: { voiceId: "test-voice-id" } },
+        },
+      },
     });
     const profile = resolveVoiceQualityProfile(config);
     expect(profile.ttsProvider).toBe("ElevenLabs");
@@ -1156,14 +1123,20 @@ describe("resolveVoiceQualityProfile", () => {
     expect(profile.voice).toBe(DEFAULT_ELEVENLABS_VOICE_ID);
   });
 
-  test("applies voice tuning params from elevenlabs config", () => {
+  test("applies voice tuning params from services.tts.providers.elevenlabs config", () => {
     const config = AssistantConfigSchema.parse({
-      elevenlabs: {
-        voiceId: "abc123",
-        voiceModelId: "turbo_v2_5",
-        speed: 0.9,
-        stability: 0.8,
-        similarityBoost: 0.9,
+      services: {
+        tts: {
+          providers: {
+            elevenlabs: {
+              voiceId: "abc123",
+              voiceModelId: "turbo_v2_5",
+              speed: 0.9,
+              stability: 0.8,
+              similarityBoost: 0.9,
+            },
+          },
+        },
       },
     });
     const profile = resolveVoiceQualityProfile(config);
@@ -1211,9 +1184,15 @@ describe("buildElevenLabsVoiceSpec", () => {
 
   test("default config uses a bare voiceId when no model override is set", () => {
     const config = AssistantConfigSchema.parse({
-      elevenlabs: { voiceId: "test" },
+      services: {
+        tts: {
+          providers: { elevenlabs: { voiceId: "test" } },
+        },
+      },
     });
-    const spec = buildElevenLabsVoiceSpec(config.elevenlabs);
+    const spec = buildElevenLabsVoiceSpec(
+      config.services.tts.providers.elevenlabs,
+    );
     expect(spec).toBe("test");
   });
 });
@@ -1268,88 +1247,41 @@ describe("resolveTtsConfig", () => {
     });
   });
 
-  test("falls back to legacy elevenlabs config when voiceId differs", () => {
+  test("uses canonical elevenlabs config exclusively (no legacy fallback)", () => {
     const config = AssistantConfigSchema.parse({
-      elevenlabs: { voiceId: "legacy-voice", speed: 0.9 },
+      services: {
+        tts: {
+          providers: {
+            elevenlabs: { voiceId: "canonical-voice", speed: 0.9 },
+          },
+        },
+      },
     });
     const resolved = resolveTtsConfig(config);
     expect(resolved.provider).toBe("elevenlabs");
     expect(resolved.providerConfig).toMatchObject({
-      voiceId: "legacy-voice",
+      voiceId: "canonical-voice",
       speed: 0.9,
     });
   });
 
-  test("falls back to legacy fishAudio config when referenceId differs", () => {
-    const config = AssistantConfigSchema.parse({
-      services: { tts: { provider: "fish-audio" } },
-      fishAudio: { referenceId: "legacy-ref", format: "wav" },
-    });
-    const resolved = resolveTtsConfig(config);
-    expect(resolved.provider).toBe("fish-audio");
-    expect(resolved.providerConfig).toMatchObject({
-      referenceId: "legacy-ref",
-      format: "wav",
-    });
-  });
-
-  test("canonical config takes precedence when both are same", () => {
+  test("uses canonical fish-audio config exclusively (no legacy fallback)", () => {
     const config = AssistantConfigSchema.parse({
       services: {
         tts: {
-          provider: "elevenlabs",
+          provider: "fish-audio",
           providers: {
-            elevenlabs: {
-              voiceId: DEFAULT_ELEVENLABS_VOICE_ID,
-              stability: 0.8,
-            },
+            "fish-audio": { referenceId: "canonical-ref", format: "wav" },
           },
         },
       },
-      elevenlabs: {
-        voiceId: DEFAULT_ELEVENLABS_VOICE_ID,
-        stability: 0.5,
-      },
-    });
-    const resolved = resolveTtsConfig(config);
-    // Both have same voiceId, so canonical is returned
-    expect(resolved.providerConfig).toMatchObject({
-      voiceId: DEFAULT_ELEVENLABS_VOICE_ID,
-      stability: 0.8,
-    });
-  });
-
-  test("falls back to legacy calls.voice.ttsProvider when canonical is default", () => {
-    // Simulates a workspace where migration 032 hasn't run yet: the user
-    // configured fish-audio via the legacy key, but the canonical
-    // services.tts.provider is still the schema default ("elevenlabs").
-    const config = AssistantConfigSchema.parse({
-      calls: { voice: { ttsProvider: "fish-audio" } },
-      fishAudio: { referenceId: "legacy-fish-ref" },
     });
     const resolved = resolveTtsConfig(config);
     expect(resolved.provider).toBe("fish-audio");
     expect(resolved.providerConfig).toMatchObject({
-      referenceId: "legacy-fish-ref",
+      referenceId: "canonical-ref",
+      format: "wav",
     });
-  });
-
-  test("canonical provider takes precedence over legacy when explicitly set", () => {
-    // User has explicitly set services.tts.provider to "elevenlabs" — even
-    // though calls.voice.ttsProvider says "fish-audio", the canonical value
-    // is not just a schema default so it should win.
-    const config = AssistantConfigSchema.parse({
-      services: { tts: { provider: "elevenlabs" } },
-      calls: { voice: { ttsProvider: "fish-audio" } },
-    });
-    const resolved = resolveTtsConfig(config);
-    // Both canonical and legacy provider are populated, but the canonical
-    // value matches the default. Since we can't distinguish "explicitly set
-    // to elevenlabs" from "schema-defaulted to elevenlabs" via Zod, the
-    // legacy provider wins here. This is the safe-side behaviour: once
-    // migration 032 runs it will copy the legacy value into canonical,
-    // making them agree.
-    expect(resolved.provider).toBe("fish-audio");
   });
 
   test("returns empty config for unknown provider", () => {
@@ -1451,16 +1383,16 @@ describe("032-tts-provider-unification migration", () => {
     expect(providers["fish-audio"].format).toBe("wav");
   });
 
-  test("preserves legacy fields during migration", async () => {
+  test("removes legacy fields after migration", async () => {
     writeMigConfig({
-      calls: { voice: { ttsProvider: "elevenlabs" } },
+      calls: { voice: { ttsProvider: "elevenlabs", language: "en-US" } },
       elevenlabs: { voiceId: "my-voice" },
     });
     const { ttsProviderUnificationMigration } =
       await import("../workspace/migrations/032-tts-provider-unification.js");
     await ttsProviderUnificationMigration.run(migrationDir);
     const result = readMigConfig();
-    // Legacy keys still present
+    // Legacy keys removed
     expect(
       (
         (result.calls as Record<string, unknown>).voice as Record<
@@ -1468,10 +1400,17 @@ describe("032-tts-provider-unification migration", () => {
           unknown
         >
       ).ttsProvider,
-    ).toBe("elevenlabs");
-    expect((result.elevenlabs as Record<string, unknown>).voiceId).toBe(
-      "my-voice",
-    );
+    ).toBeUndefined();
+    expect(result.elevenlabs).toBeUndefined();
+    // Other voice fields preserved
+    expect(
+      (
+        (result.calls as Record<string, unknown>).voice as Record<
+          string,
+          unknown
+        >
+      ).language,
+    ).toBe("en-US");
   });
 
   test("is idempotent — repeated runs produce no changes", async () => {
@@ -1528,6 +1467,8 @@ describe("032-tts-provider-unification migration", () => {
     // Canonical voiceId preserved, legacy speed backfilled
     expect(providers.elevenlabs.voiceId).toBe("canonical-voice");
     expect(providers.elevenlabs.speed).toBe(0.8);
+    // Legacy top-level key removed
+    expect(result.elevenlabs).toBeUndefined();
   });
 
   test("skips config without any legacy TTS fields", async () => {
@@ -1764,6 +1705,9 @@ describe("loadConfig with schema validation", () => {
     expect(config.calls.safety.denyCategories).toEqual([]);
     expect(config.calls.voice.language).toBe("en-US");
     expect(config.calls.voice.transcriptionProvider).toBe("Deepgram");
+    expect(
+      (config.calls.voice as Record<string, unknown>).ttsProvider,
+    ).toBeUndefined();
     expect(config.calls.model).toBeUndefined();
     expect(config.calls.callerIdentity).toEqual({
       allowPerCallOverride: true,

--- a/assistant/src/__tests__/twilio-routes.test.ts
+++ b/assistant/src/__tests__/twilio-routes.test.ts
@@ -112,6 +112,29 @@ const mockConfigObj = {
       elevenlabs: {},
     },
   },
+  services: {
+    tts: {
+      mode: "your-own" as const,
+      provider: "elevenlabs" as const,
+      providers: {
+        elevenlabs: {
+          voiceId: DEFAULT_ELEVENLABS_VOICE_ID,
+          voiceModelId: "",
+          speed: 1.0,
+          stability: 0.5,
+          similarityBoost: 0.75,
+          conversationTimeoutSeconds: 30,
+        },
+        "fish-audio": {
+          referenceId: "",
+          chunkLength: 200,
+          format: "mp3" as const,
+          latency: "normal" as const,
+          speed: 1.0,
+        },
+      },
+    },
+  },
 };
 
 mock.module("../config/loader.js", () => ({

--- a/assistant/src/__tests__/voice-config-update.test.ts
+++ b/assistant/src/__tests__/voice-config-update.test.ts
@@ -88,7 +88,7 @@ afterEach(() => {
 });
 
 // ---------------------------------------------------------------------------
-// Tests: tts_provider persists to canonical and legacy paths
+// Tests: tts_provider persists to canonical path only
 // ---------------------------------------------------------------------------
 
 describe("voice_config_update — tts_provider", () => {
@@ -106,7 +106,7 @@ describe("voice_config_update — tts_provider", () => {
     expect((config.services as any)?.tts?.provider).toBe("fish-audio");
   });
 
-  test("persists tts_provider to legacy calls.voice.ttsProvider", async () => {
+  test("does not write to legacy calls.voice.ttsProvider", async () => {
     writeConfig({});
     invalidateConfigCache();
 
@@ -117,7 +117,7 @@ describe("voice_config_update — tts_provider", () => {
 
     expect(result.isError).toBe(false);
     const config = readConfig();
-    expect((config.calls as any)?.voice?.ttsProvider).toBe("fish-audio");
+    expect((config.calls as any)?.voice?.ttsProvider).toBeUndefined();
   });
 
   test("rejects invalid tts_provider", async () => {
@@ -145,7 +145,7 @@ describe("voice_config_update — tts_provider", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Tests: tts_voice_id persists to canonical and legacy paths
+// Tests: tts_voice_id persists to canonical path only
 // ---------------------------------------------------------------------------
 
 describe("voice_config_update — tts_voice_id", () => {
@@ -165,7 +165,7 @@ describe("voice_config_update — tts_voice_id", () => {
     );
   });
 
-  test("persists to legacy elevenlabs.voiceId", async () => {
+  test("does not write to legacy elevenlabs.voiceId", async () => {
     writeConfig({});
     invalidateConfigCache();
 
@@ -176,7 +176,7 @@ describe("voice_config_update — tts_voice_id", () => {
 
     expect(result.isError).toBe(false);
     const config = readConfig();
-    expect((config.elevenlabs as any)?.voiceId).toBe("abc123");
+    expect((config.elevenlabs as any)?.voiceId).toBeUndefined();
   });
 
   test("rejects non-alphanumeric voice ID", async () => {
@@ -191,7 +191,7 @@ describe("voice_config_update — tts_voice_id", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Tests: fish_audio_reference_id persists to canonical and legacy paths
+// Tests: fish_audio_reference_id persists to canonical path only
 // ---------------------------------------------------------------------------
 
 describe("voice_config_update — fish_audio_reference_id", () => {
@@ -211,7 +211,7 @@ describe("voice_config_update — fish_audio_reference_id", () => {
     ).toBe("voice-ref-123");
   });
 
-  test("persists to legacy fishAudio.referenceId", async () => {
+  test("does not write to legacy fishAudio.referenceId", async () => {
     writeConfig({});
     invalidateConfigCache();
 
@@ -222,7 +222,7 @@ describe("voice_config_update — fish_audio_reference_id", () => {
 
     expect(result.isError).toBe(false);
     const config = readConfig();
-    expect((config.fishAudio as any)?.referenceId).toBe("voice-ref-123");
+    expect((config.fishAudio as any)?.referenceId).toBeUndefined();
   });
 
   test("rejects empty reference ID", async () => {
@@ -237,7 +237,7 @@ describe("voice_config_update — fish_audio_reference_id", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Tests: conversation_timeout persists to canonical and legacy paths
+// Tests: conversation_timeout persists to canonical path only
 // ---------------------------------------------------------------------------
 
 describe("voice_config_update — conversation_timeout", () => {
@@ -258,7 +258,7 @@ describe("voice_config_update — conversation_timeout", () => {
     ).toBe(15);
   });
 
-  test("persists to legacy elevenlabs.conversationTimeoutSeconds", async () => {
+  test("does not write to legacy elevenlabs.conversationTimeoutSeconds", async () => {
     writeConfig({});
     invalidateConfigCache();
 
@@ -269,7 +269,9 @@ describe("voice_config_update — conversation_timeout", () => {
 
     expect(result.isError).toBe(false);
     const config = readConfig();
-    expect((config.elevenlabs as any)?.conversationTimeoutSeconds).toBe(15);
+    expect(
+      (config.elevenlabs as any)?.conversationTimeoutSeconds,
+    ).toBeUndefined();
   });
 
   test("rejects invalid timeout", async () => {

--- a/assistant/src/__tests__/voice-quality.test.ts
+++ b/assistant/src/__tests__/voice-quality.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-// ── Logger mock ──────────────────────────────────────────────────────
+// -- Logger mock ----------------------------------------------------------
 
 mock.module("../util/logger.js", () => ({
   getLogger: () =>
@@ -9,7 +9,7 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
-// ── Credential mock (prevents real key lookups) ──────────────────────
+// -- Credential mock (prevents real key lookups) --------------------------
 
 mock.module("../security/secure-keys.js", () => ({
   getSecureKeyAsync: async () => null,
@@ -20,7 +20,7 @@ mock.module("../security/credential-key.js", () => ({
   credentialKey: (...args: string[]) => args.join("/"),
 }));
 
-// ── Config mock ──────────────────────────────────────────────────────
+// -- Config mock ----------------------------------------------------------
 
 let mockConfig: Record<string, unknown> = {};
 
@@ -29,7 +29,7 @@ mock.module("../config/loader.js", () => ({
   loadConfig: () => mockConfig,
 }));
 
-// ── TTS registry setup ───────────────────────────────────────────────
+// -- TTS registry setup ---------------------------------------------------
 
 import {
   _resetTtsProviderRegistry,
@@ -67,7 +67,7 @@ function registerTestProviders(): void {
   registerTtsProvider(fishAudio);
 }
 
-// ── Import subjects after mocks ──────────────────────────────────────
+// -- Import subjects after mocks ------------------------------------------
 
 import {
   buildElevenLabsVoiceSpec,
@@ -75,7 +75,7 @@ import {
 } from "../calls/voice-quality.js";
 import { DEFAULT_ELEVENLABS_VOICE_ID } from "../config/schemas/elevenlabs.js";
 
-// ── Tests ────────────────────────────────────────────────────────────
+// -- Tests ----------------------------------------------------------------
 
 describe("buildElevenLabsVoiceSpec", () => {
   test("returns bare voiceId when no model is set", () => {
@@ -131,11 +131,10 @@ describe("resolveVoiceQualityProfile", () => {
     registerTestProviders();
   });
 
-  // ── Native provider path (ElevenLabs) ─────────────────────────────
+  // -- Native provider path (ElevenLabs) ----------------------------------
 
   test("returns ElevenLabs ttsProvider for native provider", () => {
     mockConfig = {
-      elevenlabs: { voiceId: DEFAULT_ELEVENLABS_VOICE_ID },
       calls: {
         voice: {
           language: "en-US",
@@ -156,9 +155,8 @@ describe("resolveVoiceQualityProfile", () => {
     expect(profile.ttsProvider).toBe("ElevenLabs");
   });
 
-  test("voice ID comes from elevenlabs.voiceId for native provider", () => {
+  test("voice ID comes from services.tts.providers.elevenlabs.voiceId", () => {
     mockConfig = {
-      elevenlabs: { voiceId: "custom-voice-123" },
       calls: {
         voice: {
           language: "en-US",
@@ -181,7 +179,6 @@ describe("resolveVoiceQualityProfile", () => {
 
   test("uses language from calls.voice config", () => {
     mockConfig = {
-      elevenlabs: { voiceId: "abc" },
       calls: {
         voice: {
           language: "es-MX",
@@ -205,13 +202,6 @@ describe("resolveVoiceQualityProfile", () => {
 
   test("builds voice spec with model and tuning params", () => {
     mockConfig = {
-      elevenlabs: {
-        voiceId: "voice1",
-        voiceModelId: "turbo_v2_5",
-        speed: 0.9,
-        stability: 0.8,
-        similarityBoost: 0.9,
-      },
       calls: {
         voice: {
           language: "en-US",
@@ -222,7 +212,13 @@ describe("resolveVoiceQualityProfile", () => {
         tts: {
           provider: "elevenlabs",
           providers: {
-            elevenlabs: { voiceId: "voice1" },
+            elevenlabs: {
+              voiceId: "voice1",
+              voiceModelId: "turbo_v2_5",
+              speed: 0.9,
+              stability: 0.8,
+              similarityBoost: 0.9,
+            },
             "fish-audio": { referenceId: "" },
           },
         },
@@ -234,7 +230,6 @@ describe("resolveVoiceQualityProfile", () => {
 
   test("interruptSensitivity defaults to 'low' when not configured", () => {
     mockConfig = {
-      elevenlabs: { voiceId: "abc" },
       calls: {
         voice: {
           language: "en-US",
@@ -257,7 +252,6 @@ describe("resolveVoiceQualityProfile", () => {
 
   test("interruptSensitivity reflects configured value", () => {
     mockConfig = {
-      elevenlabs: { voiceId: "abc" },
       calls: {
         voice: {
           language: "en-US",
@@ -281,7 +275,6 @@ describe("resolveVoiceQualityProfile", () => {
 
   test("hints defaults to empty array when not configured", () => {
     mockConfig = {
-      elevenlabs: { voiceId: "abc" },
       calls: {
         voice: {
           language: "en-US",
@@ -304,7 +297,6 @@ describe("resolveVoiceQualityProfile", () => {
 
   test("hints reflects configured values", () => {
     mockConfig = {
-      elevenlabs: { voiceId: "abc" },
       calls: {
         voice: {
           language: "en-US",
@@ -326,17 +318,14 @@ describe("resolveVoiceQualityProfile", () => {
     expect(profile.hints).toEqual(["Vellum", "Nova", "AI assistant"]);
   });
 
-  // ── Synthesized provider path (Fish Audio) ────────────────────────
+  // -- Synthesized provider path (Fish Audio) -----------------------------
 
   test("returns Google placeholder ttsProvider for synthesized provider (Fish Audio)", () => {
     mockConfig = {
-      elevenlabs: { voiceId: DEFAULT_ELEVENLABS_VOICE_ID },
-      fishAudio: { referenceId: "ref-123" },
       calls: {
         voice: {
           language: "en-US",
           transcriptionProvider: "Deepgram",
-          ttsProvider: "fish-audio",
         },
       },
       services: {
@@ -356,13 +345,10 @@ describe("resolveVoiceQualityProfile", () => {
 
   test("preserves transcription and language settings for synthesized providers", () => {
     mockConfig = {
-      elevenlabs: { voiceId: DEFAULT_ELEVENLABS_VOICE_ID },
-      fishAudio: { referenceId: "ref-123" },
       calls: {
         voice: {
           language: "ja-JP",
           transcriptionProvider: "Google",
-          ttsProvider: "fish-audio",
           speechModel: "nova-3",
         },
       },
@@ -383,22 +369,19 @@ describe("resolveVoiceQualityProfile", () => {
     expect(profile.speechModel).toBeUndefined();
   });
 
-  // ── Legacy fallback (calls.voice.ttsProvider disagrees with services.tts.provider) ──
+  // -- Canonical-only behavior (no legacy fallback) -----------------------
 
-  test("falls back to legacy calls.voice.ttsProvider when services.tts.provider is still default", () => {
+  test("reads provider exclusively from services.tts.provider", () => {
     mockConfig = {
-      elevenlabs: { voiceId: DEFAULT_ELEVENLABS_VOICE_ID },
-      fishAudio: { referenceId: "ref-abc" },
       calls: {
         voice: {
           language: "en-US",
           transcriptionProvider: "Deepgram",
-          ttsProvider: "fish-audio", // legacy key set to fish-audio
         },
       },
       services: {
         tts: {
-          provider: "elevenlabs", // canonical still at default
+          provider: "fish-audio",
           providers: {
             elevenlabs: { voiceId: DEFAULT_ELEVENLABS_VOICE_ID },
             "fish-audio": { referenceId: "ref-abc" },
@@ -407,7 +390,7 @@ describe("resolveVoiceQualityProfile", () => {
       },
     };
     const profile = resolveVoiceQualityProfile();
-    // Should resolve to fish-audio (legacy override)
+    // Should resolve to fish-audio from canonical config
     expect(profile.ttsProvider).toBe("Google");
     expect(profile.voice).toBe("");
   });

--- a/assistant/src/calls/voice-quality.ts
+++ b/assistant/src/calls/voice-quality.ts
@@ -1,4 +1,5 @@
 import { loadConfig } from "../config/loader.js";
+import { DEFAULT_ELEVENLABS_VOICE_ID } from "../config/schemas/elevenlabs.js";
 import { getTtsProvider } from "../tts/provider-registry.js";
 import { resolveTtsConfig } from "../tts/tts-config-resolver.js";
 
@@ -91,7 +92,11 @@ export function resolveVoiceQualityProfile(
     ttsProvider: usesSynthesizedPath ? "Google" : "ElevenLabs",
     voice: usesSynthesizedPath
       ? ""
-      : buildElevenLabsVoiceSpec(cfg.services.tts.providers.elevenlabs),
+      : buildElevenLabsVoiceSpec(
+          cfg.services?.tts?.providers?.elevenlabs ?? {
+            voiceId: DEFAULT_ELEVENLABS_VOICE_ID,
+          },
+        ),
     interruptSensitivity: voice.interruptSensitivity ?? "low",
     hints: voice.hints ?? [],
   };

--- a/assistant/src/calls/voice-quality.ts
+++ b/assistant/src/calls/voice-quality.ts
@@ -89,7 +89,9 @@ export function resolveVoiceQualityProfile(
     transcriptionProvider: voice.transcriptionProvider,
     speechModel: effectiveSpeechModel,
     ttsProvider: usesSynthesizedPath ? "Google" : "ElevenLabs",
-    voice: usesSynthesizedPath ? "" : buildElevenLabsVoiceSpec(cfg.elevenlabs),
+    voice: usesSynthesizedPath
+      ? ""
+      : buildElevenLabsVoiceSpec(cfg.services.tts.providers.elevenlabs),
     interruptSensitivity: voice.interruptSensitivity ?? "low",
     hints: voice.hints ?? [],
   };

--- a/assistant/src/config/bundled-skills/settings/tools/voice-config-update.ts
+++ b/assistant/src/config/bundled-skills/settings/tools/voice-config-update.ts
@@ -15,10 +15,7 @@ import type {
 /**
  * Valid voice config settings and their UserDefaults key mappings.
  *
- * Canonical config paths (services.tts.*) are the source of truth.
- * Legacy aliases (tts_voice_id, fish_audio_reference_id) write to both
- * canonical and legacy config paths during the migration window. These
- * aliases will be removed in PR 10.
+ * All config paths are canonical (`services.tts.*`).
  */
 const VOICE_SETTINGS = {
   activation_key: {
@@ -177,42 +174,28 @@ export async function run(
   }
 
   // Persist to canonical config paths under services.tts.*
-  // Also write to legacy paths as temporary adapters until PR 10.
   const raw = loadRawConfig();
 
   if (setting === "tts_provider") {
-    // Canonical path
     setNestedValue(raw, "services.tts.provider", validation.coerced);
-    // Legacy alias (temporary — removed in PR 10)
-    setNestedValue(raw, "calls.voice.ttsProvider", validation.coerced);
     saveRawConfig(raw);
     invalidateConfigCache();
   }
 
   if (setting === "tts_voice_id") {
-    // Canonical path
     setNestedValue(
       raw,
       "services.tts.providers.elevenlabs.voiceId",
       validation.coerced,
     );
-    // Legacy alias (temporary — removed in PR 10)
-    setNestedValue(raw, "elevenlabs.voiceId", validation.coerced);
     saveRawConfig(raw);
     invalidateConfigCache();
   }
 
   if (setting === "conversation_timeout") {
-    // Canonical path
     setNestedValue(
       raw,
       "services.tts.providers.elevenlabs.conversationTimeoutSeconds",
-      validation.coerced,
-    );
-    // Legacy alias (temporary — removed in PR 10)
-    setNestedValue(
-      raw,
-      "elevenlabs.conversationTimeoutSeconds",
       validation.coerced,
     );
     saveRawConfig(raw);
@@ -220,14 +203,11 @@ export async function run(
   }
 
   if (setting === "fish_audio_reference_id") {
-    // Canonical path
     setNestedValue(
       raw,
       "services.tts.providers.fish-audio.referenceId",
       validation.coerced,
     );
-    // Legacy alias (temporary — removed in PR 10)
-    setNestedValue(raw, "fishAudio.referenceId", validation.coerced);
     saveRawConfig(raw);
     invalidateConfigCache();
   }

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -39,14 +39,10 @@ export {
   TwilioConfigSchema,
   WhatsAppConfigSchema,
 } from "./schemas/channels.js";
-export type { ElevenLabsConfig } from "./schemas/elevenlabs.js";
 export {
   DEFAULT_ELEVENLABS_VOICE_ID,
-  ElevenLabsConfigSchema,
   VALID_CONVERSATION_TIMEOUTS,
 } from "./schemas/elevenlabs.js";
-export type { FishAudioConfig } from "./schemas/fish-audio.js";
-export { FishAudioConfigSchema } from "./schemas/fish-audio.js";
 export type { HeartbeatConfig } from "./schemas/heartbeat.js";
 export { HeartbeatConfigSchema } from "./schemas/heartbeat.js";
 export type {
@@ -222,9 +218,7 @@ import {
   TwilioConfigSchema,
   WhatsAppConfigSchema,
 } from "./schemas/channels.js";
-import { ElevenLabsConfigSchema } from "./schemas/elevenlabs.js";
 import { FilingConfigSchema } from "./schemas/filing.js";
-import { FishAudioConfigSchema } from "./schemas/fish-audio.js";
 import { HeartbeatConfigSchema } from "./schemas/heartbeat.js";
 import { HostBrowserConfigSchema } from "./schemas/host-browser.js";
 import {
@@ -312,10 +306,6 @@ export const AssistantConfigSchema = z
     ),
     twilio: TwilioConfigSchema.default(TwilioConfigSchema.parse({})),
     calls: CallsConfigSchema.default(CallsConfigSchema.parse({})),
-    elevenlabs: ElevenLabsConfigSchema.default(
-      ElevenLabsConfigSchema.parse({}),
-    ),
-    fishAudio: FishAudioConfigSchema.default(FishAudioConfigSchema.parse({})),
     whatsapp: WhatsAppConfigSchema.default(WhatsAppConfigSchema.parse({})),
     telegram: TelegramConfigSchema.default(TelegramConfigSchema.parse({})),
     slack: SlackConfigSchema.default(SlackConfigSchema.parse({})),

--- a/assistant/src/config/schemas/calls.ts
+++ b/assistant/src/config/schemas/calls.ts
@@ -6,7 +6,6 @@ export const VALID_CALLER_IDENTITY_MODES = [
   "user_number",
 ] as const;
 const VALID_CALL_TRANSCRIPTION_PROVIDERS = ["Deepgram", "Google"] as const;
-export const VALID_TTS_PROVIDERS = ["elevenlabs", "fish-audio"] as const;
 
 export const CallsDisclosureConfigSchema = z
   .object({
@@ -64,16 +63,8 @@ export const CallsVoiceConfigSchema = z
       .describe(
         "ASR model to use for speech recognition (e.g. nova-3, nova-2-phonecall for Deepgram; telephony, long for Google)",
       ),
-    ttsProvider: z
-      .enum(VALID_TTS_PROVIDERS, {
-        error: `calls.voice.ttsProvider must be one of: ${VALID_TTS_PROVIDERS.join(", ")}`,
-      })
-      .default("elevenlabs")
-      .describe("Text-to-speech provider for phone calls"),
     hints: z
-      .array(
-        z.string({ error: "calls.voice.hints values must be strings" }),
-      )
+      .array(z.string({ error: "calls.voice.hints values must be strings" }))
       .default([])
       .describe(
         "Static vocabulary hints for speech recognition — proper nouns, domain terms, and other words the STT provider should prioritize",

--- a/assistant/src/tts/__tests__/provider-adapters.test.ts
+++ b/assistant/src/tts/__tests__/provider-adapters.test.ts
@@ -32,8 +32,14 @@ let mockFishAudioConfig = {
 
 mock.module("../../config/loader.js", () => ({
   getConfig: () => ({
-    elevenlabs: mockElevenLabsConfig,
-    fishAudio: mockFishAudioConfig,
+    services: {
+      tts: {
+        providers: {
+          elevenlabs: mockElevenLabsConfig,
+          "fish-audio": mockFishAudioConfig,
+        },
+      },
+    },
   }),
 }));
 

--- a/assistant/src/tts/providers/elevenlabs-provider.ts
+++ b/assistant/src/tts/providers/elevenlabs-provider.ts
@@ -4,12 +4,12 @@
  * Wraps the ElevenLabs REST text-to-speech API (`/v1/text-to-speech/:voiceId`)
  * behind the uniform {@link TtsProvider} interface. Reads the API key from the
  * secure credential store (`elevenlabs/api_key`) and the voice configuration
- * from the workspace `elevenlabs` config section.
+ * from `services.tts.providers.elevenlabs` config section.
  */
 
 import { getConfig } from "../../config/loader.js";
-import type { ElevenLabsConfig } from "../../config/schemas/elevenlabs.js";
 import { DEFAULT_ELEVENLABS_VOICE_ID } from "../../config/schemas/elevenlabs.js";
+import type { TtsElevenLabsProviderConfig } from "../../config/schemas/tts.js";
 import { credentialKey } from "../../security/credential-key.js";
 import { getSecureKeyAsync } from "../../security/secure-keys.js";
 import { getLogger } from "../../util/logger.js";
@@ -77,7 +77,7 @@ const FORMAT_CONTENT_TYPE: Record<string, string> = {
  */
 function resolveVoiceId(
   request: TtsSynthesisRequest,
-  config: ElevenLabsConfig,
+  config: TtsElevenLabsProviderConfig,
 ): string {
   const voiceId =
     request.voiceId?.trim() || config.voiceId || DEFAULT_ELEVENLABS_VOICE_ID;
@@ -125,7 +125,7 @@ export function createElevenLabsProvider(): TtsProvider {
         );
       }
 
-      const config = getConfig().elevenlabs;
+      const config = getConfig().services.tts.providers.elevenlabs;
       const voiceId = resolveVoiceId(request, config);
       const outputFormat = resolveOutputFormat(request);
 

--- a/assistant/src/tts/providers/fish-audio-provider.ts
+++ b/assistant/src/tts/providers/fish-audio-provider.ts
@@ -5,14 +5,14 @@
  * uniform {@link TtsProvider} interface, preserving its streaming chunk
  * callbacks for real-time call playback.
  *
- * Config comes from the workspace `fishAudio` section. The API key is read
+ * Config comes from `services.tts.providers['fish-audio']`. The API key is read
  * from the secure credential store (`fish-audio/api_key`) by the underlying
  * client.
  */
 
 import { synthesizeWithFishAudio } from "../../calls/fish-audio-client.js";
 import { getConfig } from "../../config/loader.js";
-import type { FishAudioConfig } from "../../config/schemas/fish-audio.js";
+import type { TtsFishAudioProviderConfig } from "../../config/schemas/tts.js";
 import { getLogger } from "../../util/logger.js";
 import type {
   TtsProvider,
@@ -59,7 +59,7 @@ const FORMAT_CONTENT_TYPE: Record<string, string> = {
  */
 function resolveReferenceId(
   request: TtsSynthesisRequest,
-  config: FishAudioConfig,
+  config: TtsFishAudioProviderConfig,
 ): string {
   const referenceId = request.voiceId?.trim() || config.referenceId;
   if (!referenceId) {
@@ -89,11 +89,11 @@ export function createFishAudioProvider(): TtsProvider {
     async synthesize(
       request: TtsSynthesisRequest,
     ): Promise<TtsSynthesisResult> {
-      const config = getConfig().fishAudio;
+      const config = getConfig().services.tts.providers["fish-audio"];
       const referenceId = resolveReferenceId(request, config);
 
       // Build an effective config with the resolved reference ID
-      const effectiveConfig: FishAudioConfig = {
+      const effectiveConfig: TtsFishAudioProviderConfig = {
         ...config,
         referenceId,
       };
@@ -128,10 +128,10 @@ export function createFishAudioProvider(): TtsProvider {
       request: TtsSynthesisRequest,
       onChunk: (chunk: Uint8Array) => void,
     ): Promise<TtsSynthesisResult> {
-      const config = getConfig().fishAudio;
+      const config = getConfig().services.tts.providers["fish-audio"];
       const referenceId = resolveReferenceId(request, config);
 
-      const effectiveConfig: FishAudioConfig = {
+      const effectiveConfig: TtsFishAudioProviderConfig = {
         ...config,
         referenceId,
       };

--- a/assistant/src/tts/tts-config-resolver.ts
+++ b/assistant/src/tts/tts-config-resolver.ts
@@ -2,20 +2,11 @@
  * Resolves the effective TTS provider and provider-specific configuration
  * from the canonical `services.tts` config block.
  *
- * During the migration window the resolver also falls back to legacy config
- * keys:
- * - Provider selection: `calls.voice.ttsProvider` is consulted when the
- *   canonical `services.tts.provider` is still the schema default and the
- *   legacy key has a different value (i.e. migration 032 has not run yet).
- * - Provider-specific config: `elevenlabs.*` / `fishAudio.*` are consulted
- *   when the canonical `services.tts.providers.*` block only contains
- *   schema defaults.
- *
- * These temporary fallbacks will be removed once all workspaces have been
- * migrated and the legacy keys are deleted.
+ * All legacy fallback logic has been removed. The resolver reads only
+ * from `services.tts.provider` and `services.tts.providers.<id>`.
+ * Migration 032 ensures all workspaces have canonical fields materialised.
  */
 
-import { DEFAULT_ELEVENLABS_VOICE_ID } from "../config/schemas/elevenlabs.js";
 import type { AssistantConfig } from "../config/types.js";
 import type { TtsProviderId } from "./types.js";
 
@@ -46,33 +37,13 @@ const DEFAULT_TTS_PROVIDER: TtsProviderId = "elevenlabs";
  * Resolve the effective TTS provider and its configuration from the
  * assistant config.
  *
- * Resolution:
- * - Provider is read from `services.tts.provider` (always populated by Zod
- *   defaults; migration 032 copies legacy `calls.voice.ttsProvider`). When
- *   the canonical provider is still the schema default and
- *   `calls.voice.ttsProvider` has a different value — meaning migration has
- *   not run yet — the legacy provider is preferred.
- * - Provider-specific config is read from `services.tts.providers.<id>`,
- *   falling back to legacy top-level keys (`elevenlabs.*`, `fishAudio.*`)
- *   when the canonical block only has schema defaults.
+ * Reads exclusively from `services.tts.provider` and
+ * `services.tts.providers.<id>`. No legacy fallback logic.
  */
 export function resolveTtsConfig(config: AssistantConfig): ResolvedTtsConfig {
   const ttsService = config.services.tts;
 
-  // Start with the canonical provider (always populated by Zod defaults).
-  let provider: TtsProviderId = ttsService.provider ?? DEFAULT_TTS_PROVIDER;
-
-  // If the canonical provider is still the schema default, check whether
-  // the legacy `calls.voice.ttsProvider` disagrees — this means migration
-  // 032 hasn't run yet and we should honour the user's legacy selection.
-  const legacyProvider = config.calls?.voice?.ttsProvider;
-  if (
-    provider === DEFAULT_TTS_PROVIDER &&
-    legacyProvider &&
-    legacyProvider !== provider
-  ) {
-    provider = legacyProvider as TtsProviderId;
-  }
+  const provider: TtsProviderId = ttsService.provider ?? DEFAULT_TTS_PROVIDER;
 
   // Resolve provider-specific config from the canonical providers map.
   const providerConfig = resolveProviderConfig(config, provider);
@@ -85,10 +56,8 @@ export function resolveTtsConfig(config: AssistantConfig): ResolvedTtsConfig {
 // ---------------------------------------------------------------------------
 
 /**
- * Build the provider-specific config object. Prefers the canonical
- * `services.tts.providers.<id>` block. Falls back to legacy top-level
- * keys (`elevenlabs.*`, `fishAudio.*`) when the canonical block only
- * contains schema defaults (i.e. migration hasn't run or wrote defaults).
+ * Build the provider-specific config object from the canonical
+ * `services.tts.providers.<id>` block.
  */
 function resolveProviderConfig(
   config: AssistantConfig,
@@ -97,34 +66,13 @@ function resolveProviderConfig(
   const ttsProviders = config.services.tts.providers;
 
   if (provider === "elevenlabs") {
-    const canonical = ttsProviders.elevenlabs;
-    // If the legacy top-level elevenlabs config has a voiceId that differs
-    // from the schema default, the user customised legacy settings before
-    // migration.  Prefer those legacy values (temporary compat).
-    const legacy = config.elevenlabs;
-    if (
-      legacy &&
-      legacy.voiceId !== DEFAULT_ELEVENLABS_VOICE_ID &&
-      legacy.voiceId !== canonical.voiceId
-    ) {
-      return { ...legacy } as unknown as Record<string, unknown>;
-    }
-    return { ...canonical } as unknown as Record<string, unknown>;
+    return { ...ttsProviders.elevenlabs } as unknown as Record<string, unknown>;
   }
 
   if (provider === "fish-audio") {
-    const canonical = ttsProviders["fish-audio"];
-    // Fall back to legacy fishAudio only when it has been explicitly
-    // customised (non-empty referenceId that differs from canonical).
-    const legacy = config.fishAudio;
-    if (
-      legacy &&
-      legacy.referenceId !== "" &&
-      legacy.referenceId !== canonical.referenceId
-    ) {
-      return { ...legacy } as unknown as Record<string, unknown>;
-    }
-    return { ...canonical } as unknown as Record<string, unknown>;
+    return {
+      ...ttsProviders["fish-audio"],
+    } as unknown as Record<string, unknown>;
   }
 
   // Unknown provider — return empty config. Provider adapters should

--- a/assistant/src/tts/tts-config-resolver.ts
+++ b/assistant/src/tts/tts-config-resolver.ts
@@ -2,9 +2,9 @@
  * Resolves the effective TTS provider and provider-specific configuration
  * from the canonical `services.tts` config block.
  *
- * All legacy fallback logic has been removed. The resolver reads only
- * from `services.tts.provider` and `services.tts.providers.<id>`.
- * Migration 032 ensures all workspaces have canonical fields materialised.
+ * Reads exclusively from `services.tts.provider` and
+ * `services.tts.providers.<id>`. Migration 032 ensures all workspaces
+ * have canonical fields materialised.
  */
 
 import type { AssistantConfig } from "../config/types.js";

--- a/assistant/src/workspace/migrations/032-tts-provider-unification.ts
+++ b/assistant/src/workspace/migrations/032-tts-provider-unification.ts
@@ -5,7 +5,7 @@ import type { WorkspaceMigration } from "./types.js";
 
 /**
  * Backfill `services.tts.provider` and `services.tts.providers.*` from
- * legacy config keys when missing.
+ * legacy config keys, then remove the legacy keys.
  *
  * Legacy keys consulted:
  *  - `calls.voice.ttsProvider`  -> `services.tts.provider`
@@ -16,8 +16,8 @@ import type { WorkspaceMigration } from "./types.js";
  * provider. Provider-specific values are copied from the legacy top-level
  * sections into their canonical `services.tts.providers.*` locations.
  *
- * Legacy fields are preserved during the transition — later PRs will
- * remove them once all callsites read from `services.tts`.
+ * After copying, legacy fields are removed so no compatibility shim is
+ * required in the runtime resolver.
  *
  * Idempotent: re-running the migration on an already-migrated config
  * produces no changes.
@@ -25,7 +25,7 @@ import type { WorkspaceMigration } from "./types.js";
 export const ttsProviderUnificationMigration: WorkspaceMigration = {
   id: "032-tts-provider-unification",
   description:
-    "Backfill services.tts.provider and services.tts.providers.* from legacy TTS config keys",
+    "Backfill services.tts.provider and services.tts.providers.* from legacy TTS config keys, then remove legacy keys",
   run(workspaceDir: string): void {
     const configPath = join(workspaceDir, "config.json");
     if (!existsSync(configPath)) return;
@@ -85,6 +85,13 @@ export const ttsProviderUnificationMigration: WorkspaceMigration = {
       }
     }
 
+    // Clean up legacy fields — canonical paths are now fully materialised.
+    // Remove calls.voice.ttsProvider (but preserve the rest of calls.voice)
+    removeLegacyTtsProvider(config);
+    // Remove top-level elevenlabs and fishAudio sections
+    delete config.elevenlabs;
+    delete config.fishAudio;
+
     writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
   },
   down(workspaceDir: string): void {
@@ -143,6 +150,19 @@ function resolveLegacyProvider(config: Record<string, unknown>): string | null {
 
   const provider = voiceObj.ttsProvider;
   return typeof provider === "string" ? provider : null;
+}
+
+/** Remove calls.voice.ttsProvider from config while preserving other voice fields. */
+function removeLegacyTtsProvider(config: Record<string, unknown>): void {
+  const calls = config.calls;
+  if (!calls || typeof calls !== "object" || Array.isArray(calls)) return;
+  const callsObj = calls as Record<string, unknown>;
+
+  const voice = callsObj.voice;
+  if (!voice || typeof voice !== "object" || Array.isArray(voice)) return;
+  const voiceObj = voice as Record<string, unknown>;
+
+  delete voiceObj.ttsProvider;
 }
 
 /** Extract legacy ElevenLabs config from top-level elevenlabs object. */

--- a/assistant/src/workspace/migrations/032-tts-provider-unification.ts
+++ b/assistant/src/workspace/migrations/032-tts-provider-unification.ts
@@ -107,12 +107,52 @@ export const ttsProviderUnificationMigration: WorkspaceMigration = {
       return;
     }
 
-    // Remove services.tts block added by this migration.
-    // We only remove the tts key from services — other service keys are
-    // unrelated.
+    // Restore legacy keys from canonical services.tts before removing it.
     const services = config.services;
     if (services && typeof services === "object" && !Array.isArray(services)) {
-      delete (services as Record<string, unknown>).tts;
+      const servicesObj = services as Record<string, unknown>;
+      const tts = servicesObj.tts;
+      if (tts && typeof tts === "object" && !Array.isArray(tts)) {
+        const ttsObj = tts as Record<string, unknown>;
+
+        // Restore calls.voice.ttsProvider from services.tts.provider
+        const provider = ttsObj.provider;
+        if (typeof provider === "string") {
+          const calls = ensureObj(config, "calls");
+          const voice = ensureObj(calls, "voice");
+          voice.ttsProvider = provider;
+        }
+
+        // Restore top-level elevenlabs and fishAudio from providers map
+        const providers = ttsObj.providers;
+        if (
+          providers &&
+          typeof providers === "object" &&
+          !Array.isArray(providers)
+        ) {
+          const providersObj = providers as Record<string, unknown>;
+
+          const elConfig = providersObj.elevenlabs;
+          if (
+            elConfig &&
+            typeof elConfig === "object" &&
+            !Array.isArray(elConfig)
+          ) {
+            config.elevenlabs = { ...(elConfig as Record<string, unknown>) };
+          }
+
+          const faConfig = providersObj["fish-audio"];
+          if (
+            faConfig &&
+            typeof faConfig === "object" &&
+            !Array.isArray(faConfig)
+          ) {
+            config.fishAudio = { ...(faConfig as Record<string, unknown>) };
+          }
+        }
+      }
+
+      delete servicesObj.tts;
     }
 
     writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");


### PR DESCRIPTION
## Summary
- Removes legacy fallback logic from tts-config-resolver (canonical-only)
- Removes deprecated TTS fields from calls schema and top-level provider schemas
- Removes temporary legacy aliases from settings tooling and broadcasts
- Updates tests to verify legacy keys no longer drive behavior

Part of plan: product-tts-provider-abstraction.md (PR 10 of 11)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24810" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
