### PR TITLE
Chrome popup: default to minimal status, auto-recovery messaging, and hidden troubleshooting controls

### DIFF
--- a/clients/chrome-extension/popup/popup-state.test.ts
+++ b/clients/chrome-extension/popup/popup-state.test.ts
@@ -7,6 +7,10 @@
  *   - shouldShowLocalSection / shouldShowCloudSection: auth-profile gating
  *   - deriveCtaState: CTA label/enablement for each connection phase
  *   - deriveStatusDisplay: status dot class and text for each phase
+ *   - healthToPhase: mapping from ConnectionHealthState to ConnectionPhase
+ *   - deriveHealthStatusDisplay: health-aware status display with detail
+ *   - shouldExpandTroubleshooting: troubleshoot section auto-expand rules
+ *   - hasTroubleshootingControls: whether auth controls exist for profile
  */
 
 import { describe, test, expect } from 'bun:test';
@@ -18,7 +22,13 @@ import {
   shouldShowCloudSection,
   deriveCtaState,
   deriveStatusDisplay,
+  healthToPhase,
+  deriveHealthStatusDisplay,
+  shouldExpandTroubleshooting,
+  hasTroubleshootingControls,
   type ConnectionPhase,
+  type ConnectionHealthState,
+  type ConnectionHealthDetail,
 } from './popup-state.js';
 
 import type { AssistantDescriptor } from '../background/native-host-assistants.js';
@@ -46,6 +56,13 @@ const cloudAssistant = makeDescriptor({
   authProfile: 'cloud-oauth',
 });
 const secondLocal = makeDescriptor({ assistantId: 'second-local' });
+
+function makeDetail(overrides?: Partial<ConnectionHealthDetail>): ConnectionHealthDetail {
+  return {
+    lastChangeAt: Date.now(),
+    ...overrides,
+  };
+}
 
 // ── deriveSelectorDisplay ──────────────────────────────────────────
 
@@ -250,5 +267,302 @@ describe('deriveStatusDisplay', () => {
       expect(status.dotClass).toBe(expectedDots[i]);
       expect(status.text).toBe(expectedTexts[i]);
     }
+  });
+});
+
+// ── healthToPhase ──────────────────────────────────────────────────
+
+describe('healthToPhase', () => {
+  test('connected health maps to connected phase', () => {
+    expect(healthToPhase('connected')).toBe('connected');
+  });
+
+  test('connecting health maps to connecting phase', () => {
+    expect(healthToPhase('connecting')).toBe('connecting');
+  });
+
+  test('reconnecting health maps to connecting phase', () => {
+    expect(healthToPhase('reconnecting')).toBe('connecting');
+  });
+
+  test('paused health maps to paused phase', () => {
+    expect(healthToPhase('paused')).toBe('paused');
+  });
+
+  test('auth_required health maps to disconnected phase', () => {
+    expect(healthToPhase('auth_required')).toBe('disconnected');
+  });
+
+  test('error health maps to disconnected phase', () => {
+    expect(healthToPhase('error')).toBe('disconnected');
+  });
+
+  test('all health states map to valid phases', () => {
+    const healthStates: ConnectionHealthState[] = [
+      'paused', 'connecting', 'connected', 'reconnecting', 'auth_required', 'error',
+    ];
+    const validPhases = new Set<ConnectionPhase>(['disconnected', 'connecting', 'connected', 'paused']);
+
+    for (const health of healthStates) {
+      const phase = healthToPhase(health);
+      expect(validPhases.has(phase)).toBe(true);
+    }
+  });
+
+  test('CTA enablement via healthToPhase: auth_required allows Connect', () => {
+    const phase = healthToPhase('auth_required');
+    const cta = deriveCtaState(phase);
+    expect(cta.connectEnabled).toBe(true);
+    expect(cta.pauseEnabled).toBe(false);
+  });
+
+  test('CTA enablement via healthToPhase: reconnecting disables both', () => {
+    const phase = healthToPhase('reconnecting');
+    const cta = deriveCtaState(phase);
+    expect(cta.connectEnabled).toBe(false);
+    expect(cta.pauseEnabled).toBe(false);
+  });
+
+  test('CTA enablement via healthToPhase: error allows Connect', () => {
+    const phase = healthToPhase('error');
+    const cta = deriveCtaState(phase);
+    expect(cta.connectEnabled).toBe(true);
+    expect(cta.pauseEnabled).toBe(false);
+  });
+});
+
+// ── deriveHealthStatusDisplay ──────────────────────────────────────
+
+describe('deriveHealthStatusDisplay', () => {
+  test('connected: green dot, Connected', () => {
+    const status = deriveHealthStatusDisplay('connected');
+    expect(status.dotClass).toBe('connected');
+    expect(status.text).toBe('Connected');
+  });
+
+  test('connecting: red dot, Connecting\u2026', () => {
+    const status = deriveHealthStatusDisplay('connecting');
+    expect(status.dotClass).toBe('disconnected');
+    expect(status.text).toBe('Connecting\u2026');
+  });
+
+  test('reconnecting: amber dot, Reconnecting automatically\u2026', () => {
+    const status = deriveHealthStatusDisplay('reconnecting');
+    expect(status.dotClass).toBe('paused');
+    expect(status.text).toBe('Reconnecting automatically\u2026');
+  });
+
+  test('paused: amber dot, Paused', () => {
+    const status = deriveHealthStatusDisplay('paused');
+    expect(status.dotClass).toBe('paused');
+    expect(status.text).toBe('Paused');
+  });
+
+  test('auth_required without detail: generic action required text', () => {
+    const status = deriveHealthStatusDisplay('auth_required');
+    expect(status.dotClass).toBe('disconnected');
+    expect(status.text).toContain('Action required');
+  });
+
+  test('auth_required with error message: includes message in text', () => {
+    const detail = makeDetail({ lastErrorMessage: 'Cloud token expired' });
+    const status = deriveHealthStatusDisplay('auth_required', detail);
+    expect(status.dotClass).toBe('disconnected');
+    expect(status.text).toContain('Action required');
+    expect(status.text).toContain('Cloud token expired');
+  });
+
+  test('error without detail: generic error text', () => {
+    const status = deriveHealthStatusDisplay('error');
+    expect(status.dotClass).toBe('disconnected');
+    expect(status.text).toBe('Connection error');
+  });
+
+  test('error with error message: includes message in text', () => {
+    const detail = makeDetail({ lastErrorMessage: 'Native host not installed' });
+    const status = deriveHealthStatusDisplay('error', detail);
+    expect(status.dotClass).toBe('disconnected');
+    expect(status.text).toContain('Error');
+    expect(status.text).toContain('Native host not installed');
+  });
+
+  test('reconnecting with disconnect code: still shows friendly message', () => {
+    const detail = makeDetail({ lastDisconnectCode: 1006 });
+    const status = deriveHealthStatusDisplay('reconnecting', detail);
+    expect(status.dotClass).toBe('paused');
+    expect(status.text).toBe('Reconnecting automatically\u2026');
+  });
+
+  test('all health states produce valid dot classes', () => {
+    const healthStates: ConnectionHealthState[] = [
+      'paused', 'connecting', 'connected', 'reconnecting', 'auth_required', 'error',
+    ];
+    const validDots = new Set(['connected', 'paused', 'disconnected']);
+
+    for (const health of healthStates) {
+      const status = deriveHealthStatusDisplay(health);
+      expect(validDots.has(status.dotClass)).toBe(true);
+    }
+  });
+
+  test('all health states produce non-empty status text', () => {
+    const healthStates: ConnectionHealthState[] = [
+      'paused', 'connecting', 'connected', 'reconnecting', 'auth_required', 'error',
+    ];
+
+    for (const health of healthStates) {
+      const status = deriveHealthStatusDisplay(health);
+      expect(status.text.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+// ── shouldExpandTroubleshooting ────────────────────────────────────
+
+describe('shouldExpandTroubleshooting', () => {
+  test('expands for auth_required', () => {
+    expect(shouldExpandTroubleshooting('auth_required')).toBe(true);
+  });
+
+  test('expands for error', () => {
+    expect(shouldExpandTroubleshooting('error')).toBe(true);
+  });
+
+  test('collapses for connected', () => {
+    expect(shouldExpandTroubleshooting('connected')).toBe(false);
+  });
+
+  test('collapses for connecting', () => {
+    expect(shouldExpandTroubleshooting('connecting')).toBe(false);
+  });
+
+  test('collapses for reconnecting', () => {
+    expect(shouldExpandTroubleshooting('reconnecting')).toBe(false);
+  });
+
+  test('collapses for paused', () => {
+    expect(shouldExpandTroubleshooting('paused')).toBe(false);
+  });
+
+  test('happy path states never expand troubleshooting', () => {
+    const happyStates: ConnectionHealthState[] = ['connected', 'connecting', 'reconnecting', 'paused'];
+    for (const state of happyStates) {
+      expect(shouldExpandTroubleshooting(state)).toBe(false);
+    }
+  });
+
+  test('action-required states always expand troubleshooting', () => {
+    const actionStates: ConnectionHealthState[] = ['auth_required', 'error'];
+    for (const state of actionStates) {
+      expect(shouldExpandTroubleshooting(state)).toBe(true);
+    }
+  });
+});
+
+// ── hasTroubleshootingControls ─────────────────────────────────────
+
+describe('hasTroubleshootingControls', () => {
+  test('returns true for local-pair', () => {
+    expect(hasTroubleshootingControls('local-pair')).toBe(true);
+  });
+
+  test('returns true for cloud-oauth', () => {
+    expect(hasTroubleshootingControls('cloud-oauth')).toBe(true);
+  });
+
+  test('returns false for unsupported', () => {
+    expect(hasTroubleshootingControls('unsupported')).toBe(false);
+  });
+
+  test('returns false for null', () => {
+    expect(hasTroubleshootingControls(null)).toBe(false);
+  });
+});
+
+// ── Integrated state derivation scenarios ──────────────────────────
+
+describe('integrated health-to-display scenarios', () => {
+  test('typical user happy path: paused -> connecting -> connected', () => {
+    // User opens popup when paused.
+    let status = deriveHealthStatusDisplay('paused');
+    expect(status.text).toBe('Paused');
+    expect(shouldExpandTroubleshooting('paused')).toBe(false);
+
+    // User clicks Connect.
+    status = deriveHealthStatusDisplay('connecting');
+    expect(status.text).toBe('Connecting\u2026');
+    expect(shouldExpandTroubleshooting('connecting')).toBe(false);
+
+    // Connection established.
+    status = deriveHealthStatusDisplay('connected');
+    expect(status.text).toBe('Connected');
+    expect(shouldExpandTroubleshooting('connected')).toBe(false);
+  });
+
+  test('transient disconnect and auto-recovery', () => {
+    // Connected, then disconnects.
+    let status = deriveHealthStatusDisplay('connected');
+    expect(status.text).toBe('Connected');
+
+    // Auto-reconnecting.
+    status = deriveHealthStatusDisplay('reconnecting');
+    expect(status.text).toBe('Reconnecting automatically\u2026');
+    expect(status.dotClass).toBe('paused');
+    expect(shouldExpandTroubleshooting('reconnecting')).toBe(false);
+
+    // Reconnect succeeds.
+    status = deriveHealthStatusDisplay('connected');
+    expect(status.text).toBe('Connected');
+  });
+
+  test('auth failure surfaces action required with expanded troubleshoot', () => {
+    const detail = makeDetail({
+      lastErrorMessage: "Automatic cloud sign-in failed",
+    });
+
+    const status = deriveHealthStatusDisplay('auth_required', detail);
+    expect(status.dotClass).toBe('disconnected');
+    expect(status.text).toContain('Action required');
+    expect(status.text).toContain('Automatic cloud sign-in failed');
+
+    // Troubleshoot should auto-expand.
+    expect(shouldExpandTroubleshooting('auth_required')).toBe(true);
+
+    // Connect button should be enabled for retry.
+    const phase = healthToPhase('auth_required');
+    const cta = deriveCtaState(phase);
+    expect(cta.connectEnabled).toBe(true);
+  });
+
+  test('native host error surfaces error with expanded troubleshoot', () => {
+    const detail = makeDetail({
+      lastErrorMessage: 'Native host not installed',
+    });
+
+    const status = deriveHealthStatusDisplay('error', detail);
+    expect(status.dotClass).toBe('disconnected');
+    expect(status.text).toContain('Error');
+    expect(status.text).toContain('Native host not installed');
+
+    expect(shouldExpandTroubleshooting('error')).toBe(true);
+  });
+
+  test('single-assistant install: no selector, controls hidden when not needed', () => {
+    // Single assistant: selector hidden.
+    const selectorDisplay = deriveSelectorDisplay([localAssistant], localAssistant);
+    expect(selectorDisplay.kind).toBe('hidden');
+
+    // Connected state: troubleshoot collapsed.
+    expect(shouldExpandTroubleshooting('connected')).toBe(false);
+  });
+
+  test('multi-assistant install: selector visible, controls preserved', () => {
+    const selectorDisplay = deriveSelectorDisplay(
+      [localAssistant, cloudAssistant],
+      localAssistant,
+    );
+    expect(selectorDisplay.kind).toBe('visible');
+    if (selectorDisplay.kind !== 'visible') throw new Error('unreachable');
+    expect(selectorDisplay.options.length).toBe(2);
   });
 });

--- a/clients/chrome-extension/popup/popup-state.ts
+++ b/clients/chrome-extension/popup/popup-state.ts
@@ -1,20 +1,50 @@
 /**
  * Pure view-state helpers for the popup UI.
  *
- * These functions derive display state from the assistant catalog,
- * selection data, and connection phase. They are deliberately
- * side-effect-free so they can be unit tested without a Chrome runtime
- * environment.
+ * These functions derive display state from the worker's structured
+ * connection health contract, the assistant catalog, and selection
+ * data. They are deliberately side-effect-free so they can be unit
+ * tested without a Chrome runtime environment.
  *
- * The popup exposes two primary actions:
- *   - **Connect** — the only first-step CTA. The worker handles auth
- *     bootstrap (pairing/sign-in) automatically when `interactive=true`.
- *   - **Pause** — user-facing stop action that halts the relay but
- *     preserves credentials so reconnect is instant.
+ * The popup shows concise primary states to the user:
+ *   - **Connected** — background relay active.
+ *   - **Reconnecting automatically** — transient disconnect, recovery
+ *     in progress.
+ *   - **Paused** — user explicitly paused; credentials preserved.
+ *   - **Action required** — auth/host error requiring manual recovery.
+ *
+ * Primary controls remain **Connect** and **Pause**. Manual recovery
+ * actions (Pair / Sign-in) live in a collapsible Troubleshoot area
+ * that is hidden by default unless the health state is `auth_required`
+ * or `error`.
  */
 
 import type { AssistantDescriptor } from '../background/native-host-assistants.js';
 import type { AssistantAuthProfile } from '../background/assistant-auth-profile.js';
+
+// ── Health state types (mirrored from worker.ts) ───────────────────
+
+/**
+ * The structured connection health state published by the worker via
+ * `get_status`. This is the canonical source of truth for the popup's
+ * display state.
+ */
+export type ConnectionHealthState =
+  | 'paused'
+  | 'connecting'
+  | 'connected'
+  | 'reconnecting'
+  | 'auth_required'
+  | 'error';
+
+/**
+ * Detail fields attached to the current health state from the worker.
+ */
+export interface ConnectionHealthDetail {
+  lastDisconnectCode?: number;
+  lastErrorMessage?: string;
+  lastChangeAt: number;
+}
 
 // ── Types ──────────────────────────────────────────────────────────
 
@@ -39,6 +69,16 @@ export interface AssistantSelectResponse {
   selected?: AssistantDescriptor | null;
   authProfile?: AssistantAuthProfile | null;
   error?: string;
+}
+
+/**
+ * Response shape from the worker's `get_status` message.
+ */
+export interface GetStatusResponse {
+  connected: boolean;
+  authProfile: AssistantAuthProfile | null;
+  health: ConnectionHealthState;
+  healthDetail: ConnectionHealthDetail;
 }
 
 /**
@@ -214,4 +254,113 @@ export function deriveStatusDisplay(phase: ConnectionPhase): StatusDisplay {
     case 'paused':
       return { dotClass: 'paused', text: 'Paused' };
   }
+}
+
+// ── Health-aware state mapping ──────────────────────────────────────
+//
+// These functions consume the worker's structured ConnectionHealthState
+// to produce the popup's concise user-facing display. They replace the
+// older boolean-based `connected` field with deterministic mapping from
+// the six-state health enum.
+
+/**
+ * Map the worker's health state to the popup's connection phase.
+ *
+ * The popup phase is a simplified view of the health state:
+ *   - `connected` and `reconnecting` both map to phases that keep
+ *     the user informed without requiring action.
+ *   - `auth_required` and `error` map to `disconnected` since the
+ *     user may need to take action.
+ *   - `paused` and `connecting` map directly.
+ */
+export function healthToPhase(health: ConnectionHealthState): ConnectionPhase {
+  switch (health) {
+    case 'connected':
+      return 'connected';
+    case 'connecting':
+      return 'connecting';
+    case 'reconnecting':
+      return 'connecting';
+    case 'paused':
+      return 'paused';
+    case 'auth_required':
+      return 'disconnected';
+    case 'error':
+      return 'disconnected';
+  }
+}
+
+/**
+ * Derive a concise, user-facing status display from the worker's
+ * health state and detail. This produces friendlier messages than the
+ * phase-based `deriveStatusDisplay` for health states that have no
+ * direct phase equivalent (reconnecting, auth_required, error).
+ *
+ * | Health state   | Dot class     | Status text                              |
+ * |----------------|---------------|------------------------------------------|
+ * | connected      | connected     | Connected                                |
+ * | connecting     | disconnected  | Connecting...                            |
+ * | reconnecting   | paused        | Reconnecting automatically...            |
+ * | paused         | paused        | Paused                                   |
+ * | auth_required  | disconnected  | Action required (+ detail if available)  |
+ * | error          | disconnected  | Error (+ detail if available)            |
+ */
+export function deriveHealthStatusDisplay(
+  health: ConnectionHealthState,
+  detail?: ConnectionHealthDetail,
+): StatusDisplay {
+  switch (health) {
+    case 'connected':
+      return { dotClass: 'connected', text: 'Connected' };
+    case 'connecting':
+      return { dotClass: 'disconnected', text: 'Connecting\u2026' };
+    case 'reconnecting':
+      return { dotClass: 'paused', text: 'Reconnecting automatically\u2026' };
+    case 'paused':
+      return { dotClass: 'paused', text: 'Paused' };
+    case 'auth_required':
+      return {
+        dotClass: 'disconnected',
+        text: detail?.lastErrorMessage
+          ? `Action required: ${detail.lastErrorMessage}`
+          : 'Action required \u2014 sign in or re-pair to continue',
+      };
+    case 'error':
+      return {
+        dotClass: 'disconnected',
+        text: detail?.lastErrorMessage
+          ? `Error: ${detail.lastErrorMessage}`
+          : 'Connection error',
+      };
+  }
+}
+
+// ── Troubleshooting visibility ──────────────────────────────────────
+
+/**
+ * Whether the Troubleshoot section should be expanded (visible) by
+ * default based on the current health state.
+ *
+ * The section is expanded when the health state requires user action:
+ *   - `auth_required` — credentials expired/missing, user must
+ *     re-pair or re-sign-in.
+ *   - `error` — unrecoverable error, manual recovery may help.
+ *
+ * For all other states (`connected`, `connecting`, `reconnecting`,
+ * `paused`) the section is collapsed so typical users see only the
+ * concise primary status without implementation details.
+ */
+export function shouldExpandTroubleshooting(health: ConnectionHealthState): boolean {
+  return health === 'auth_required' || health === 'error';
+}
+
+/**
+ * Whether troubleshooting auth controls are relevant given the auth
+ * profile. When the profile is null or unsupported, there are no
+ * auth controls to show regardless of health state.
+ */
+export function hasTroubleshootingControls(
+  authProfile: AssistantAuthProfile | null,
+): boolean {
+  return authProfile === 'local-pair' || authProfile === 'cloud-oauth';
 }

--- a/clients/chrome-extension/popup/popup.html
+++ b/clients/chrome-extension/popup/popup.html
@@ -173,6 +173,50 @@
       color: #ef4444;
       margin-bottom: 8px;
     }
+
+    /* ── Troubleshoot collapsible area ────────────────────────────── */
+
+    #troubleshoot-section {
+      margin-top: 16px;
+    }
+
+    #troubleshoot-section[hidden] {
+      display: none;
+    }
+
+    .troubleshoot-toggle {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+      background: none;
+      border: none;
+      padding: 0;
+      margin-bottom: 10px;
+      cursor: pointer;
+      font-size: 11px;
+      font-weight: 600;
+      color: #6b7280;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      flex: none;
+    }
+    .troubleshoot-toggle:hover { color: #374151; }
+
+    .troubleshoot-toggle .chevron {
+      display: inline-block;
+      font-size: 10px;
+      transition: transform 0.15s;
+    }
+    .troubleshoot-toggle[aria-expanded="true"] .chevron {
+      transform: rotate(90deg);
+    }
+
+    #troubleshoot-body {
+      overflow: hidden;
+    }
+    #troubleshoot-body[hidden] {
+      display: none;
+    }
   </style>
 </head>
 <body>
@@ -206,15 +250,29 @@
 
   <p class="hint">Relay port defaults to 7830.</p>
 
-  <div class="divider" id="troubleshooting-divider"></div>
+  <!-- Troubleshoot section: collapsed by default, auto-expanded for auth_required/error -->
+  <div id="troubleshoot-section" hidden>
+    <div class="divider"></div>
 
-  <p class="section-label" id="troubleshooting-label">Troubleshooting</p>
+    <button
+      type="button"
+      class="troubleshoot-toggle"
+      id="troubleshoot-toggle"
+      aria-expanded="false"
+      aria-controls="troubleshoot-body"
+    >
+      <span class="chevron">&#9654;</span>
+      Troubleshoot
+    </button>
 
-  <p class="local-status" id="local-status" style="display:none">Not paired</p>
-  <button id="btn-pair-local" type="button" style="display:none">Re-pair with local assistant</button>
+    <div id="troubleshoot-body" hidden>
+      <p class="local-status" id="local-status" style="display:none">Not paired</p>
+      <button id="btn-pair-local" type="button" style="display:none">Re-pair with local assistant</button>
 
-  <p class="cloud-status" id="cloud-status" style="display:none">Not signed in</p>
-  <button id="btn-cloud-signin" type="button" style="display:none">Re-sign in with Vellum (cloud)</button>
+      <p class="cloud-status" id="cloud-status" style="display:none">Not signed in</p>
+      <button id="btn-cloud-signin" type="button" style="display:none">Re-sign in with Vellum (cloud)</button>
+    </div>
+  </div>
 
   <script type="module" src="popup.js"></script>
 </body>

--- a/clients/chrome-extension/popup/popup.ts
+++ b/clients/chrome-extension/popup/popup.ts
@@ -1,17 +1,19 @@
 /**
  * Popup UI for the Vellum browser-relay extension.
  *
- * The popup exposes a single primary CTA — **Connect** — that works in
- * one click even when the user hasn't previously paired or signed in.
- * The worker handles auth bootstrap automatically when `interactive=true`.
+ * The popup renders a concise primary status derived from the worker's
+ * structured connection health state:
+ *   - **Connected** — relay active, everything working.
+ *   - **Reconnecting automatically** — transient disconnect, auto-recovery
+ *     in progress. No user action needed.
+ *   - **Paused** — user explicitly paused the relay.
+ *   - **Action required** — auth or host error requiring manual recovery.
  *
- * The secondary action is **Pause**, which halts the relay and clears the
- * auto-connect flag so the extension stays quiet until the user explicitly
- * reconnects. Credentials are preserved for instant reconnect.
- *
- * Manual recovery controls (local re-pair and cloud re-sign-in) are
- * available under a Troubleshooting section, but are not required for
- * the normal connect flow.
+ * Primary controls are **Connect** and **Pause**. Manual recovery
+ * controls (local re-pair and cloud re-sign-in) live in a collapsible
+ * Troubleshoot section that is hidden by default. The section auto-
+ * expands when the health state is `auth_required` or `error`, making
+ * break-glass recovery accessible without cluttering the happy path.
  *
  * On open the popup loads the assistant catalog from the worker via the
  * `assistants-get` message. When exactly one assistant exists it is
@@ -36,8 +38,14 @@ import {
   shouldShowLocalSection,
   shouldShowCloudSection,
   deriveCtaState,
-  deriveStatusDisplay,
+  deriveHealthStatusDisplay,
+  healthToPhase,
+  shouldExpandTroubleshooting,
+  hasTroubleshootingControls,
+  type ConnectionHealthState,
+  type ConnectionHealthDetail,
   type ConnectionPhase,
+  type GetStatusResponse,
   type AssistantsGetResponse,
   type AssistantSelectResponse,
 } from './popup-state.js';
@@ -57,12 +65,15 @@ const cloudStatus = document.getElementById('cloud-status') as HTMLParagraphElem
 const btnPairLocal = document.getElementById('btn-pair-local') as HTMLButtonElement;
 const localStatus = document.getElementById('local-status') as HTMLParagraphElement;
 
-const troubleshootingDivider = document.getElementById(
-  'troubleshooting-divider',
+const troubleshootSection = document.getElementById(
+  'troubleshoot-section',
 ) as HTMLDivElement;
-const troubleshootingLabel = document.getElementById(
-  'troubleshooting-label',
-) as HTMLParagraphElement;
+const troubleshootToggle = document.getElementById(
+  'troubleshoot-toggle',
+) as HTMLButtonElement;
+const troubleshootBody = document.getElementById(
+  'troubleshoot-body',
+) as HTMLDivElement;
 
 const assistantSelectorGroup = document.getElementById(
   'assistant-selector-group',
@@ -79,35 +90,69 @@ const assistantSelect = document.getElementById(
 let currentAuthProfile: AssistantAuthProfile | null = null;
 let currentAssistantId: string | null = null;
 
+// ── Current health state ────────────────────────────────────────────
+//
+// Tracks the latest health state from the worker so the troubleshoot
+// section can react to state changes.
+
+let currentHealthState: ConnectionHealthState = 'paused';
+
 // ── Connection phase management ─────────────────────────────────────
 
 /**
- * Apply a connection phase to the UI. Derives button labels/enablement
- * and status indicator from the pure helpers in popup-state.ts.
+ * Apply the worker's health state to the full popup UI. Derives button
+ * labels/enablement, status indicator, and troubleshooting section
+ * visibility from the pure helpers in popup-state.ts.
  */
-function setPhase(phase: ConnectionPhase): void {
+function applyHealthState(
+  health: ConnectionHealthState,
+  detail?: ConnectionHealthDetail,
+): void {
+  currentHealthState = health;
 
+  // Derive phase for CTA button states.
+  const phase = healthToPhase(health);
   const cta = deriveCtaState(phase);
   btnConnect.textContent = cta.connectLabel;
   btnConnect.disabled = !cta.connectEnabled;
   btnPause.textContent = cta.pauseLabel;
   btnPause.disabled = !cta.pauseEnabled;
 
-  const status = deriveStatusDisplay(phase);
+  // Derive health-aware status display (richer than phase-based).
+  const status = deriveHealthStatusDisplay(health, detail);
   statusDot.className = `status-dot ${status.dotClass}`;
   statusText.textContent = status.text;
 
   portInput.disabled = phase === 'connected' || phase === 'connecting';
 
-  if (phase === 'connected') {
+  if (health === 'connected') {
     errorText.style.display = 'none';
   }
+
+  // Update troubleshooting section visibility and expansion.
+  updateTroubleshootSection(health);
+}
+
+/**
+ * Backward-compatible wrapper: apply a connection phase to the UI
+ * when only phase information is available (e.g. during the
+ * connecting -> polling -> connected flow initiated by the popup).
+ */
+function setPhase(phase: ConnectionPhase): void {
+  // Map phase back to a health state for the unified path.
+  const healthMap: Record<ConnectionPhase, ConnectionHealthState> = {
+    connected: 'connected',
+    connecting: 'connecting',
+    disconnected: 'paused',
+    paused: 'paused',
+  };
+  applyHealthState(healthMap[phase]);
 }
 
 /**
  * Render an inline error message without touching any other UI.
  *
- * Use this for generic popup errors — e.g. cloud OAuth failures,
+ * Use this for generic popup errors -- e.g. cloud OAuth failures,
  * refresh exceptions, or generic service-worker messages.
  */
 function showErrorText(msg: string): void {
@@ -118,6 +163,52 @@ function showErrorText(msg: string): void {
 function showError(msg: string): void {
   showErrorText(msg);
 }
+
+// ── Troubleshoot section ────────────────────────────────────────────
+
+/**
+ * Update the troubleshoot section visibility and expansion state.
+ *
+ * The section is shown when there are auth controls to display
+ * (local-pair or cloud-oauth). It auto-expands when the health
+ * state is `auth_required` or `error` so the user can access
+ * recovery controls.
+ */
+function updateTroubleshootSection(health: ConnectionHealthState): void {
+  const hasControls = hasTroubleshootingControls(currentAuthProfile);
+
+  if (!hasControls) {
+    troubleshootSection.hidden = true;
+    return;
+  }
+
+  troubleshootSection.hidden = false;
+
+  // Auto-expand when action is required.
+  if (shouldExpandTroubleshooting(health)) {
+    expandTroubleshoot();
+  }
+}
+
+function expandTroubleshoot(): void {
+  troubleshootBody.hidden = false;
+  troubleshootToggle.setAttribute('aria-expanded', 'true');
+}
+
+function collapseTroubleshoot(): void {
+  troubleshootBody.hidden = true;
+  troubleshootToggle.setAttribute('aria-expanded', 'false');
+}
+
+// Toggle on click.
+troubleshootToggle.addEventListener('click', () => {
+  const expanded = troubleshootToggle.getAttribute('aria-expanded') === 'true';
+  if (expanded) {
+    collapseTroubleshoot();
+  } else {
+    expandTroubleshoot();
+  }
+});
 
 // ── Assistant selector ──────────────────────────────────────────────
 
@@ -169,9 +260,8 @@ function updateAuthSections(authProfile: AssistantAuthProfile | null): void {
   cloudStatus.style.display = showCloud ? '' : 'none';
   btnCloudSignIn.style.display = showCloud ? '' : 'none';
 
-  // Hide the Troubleshooting divider and heading when no controls are shown.
-  troubleshootingDivider.style.display = showLocal || showCloud ? '' : 'none';
-  troubleshootingLabel.style.display = showLocal || showCloud ? '' : 'none';
+  // Update troubleshoot section with current health state.
+  updateTroubleshootSection(currentHealthState);
 }
 
 /**
@@ -241,10 +331,17 @@ chrome.storage.local.get(['relayPort']).then((result) => {
   }
 });
 
-// Query current status from service worker
-chrome.runtime.sendMessage({ type: 'get_status' }, (response: { connected: boolean }) => {
+// Query current health state from service worker.
+chrome.runtime.sendMessage({ type: 'get_status' }, (response: GetStatusResponse) => {
   if (chrome.runtime.lastError) return;
-  setPhase(response?.connected ? 'connected' : 'disconnected');
+
+  // Use the structured health state if available, fall back to boolean.
+  if (response?.health) {
+    applyHealthState(response.health, response.healthDetail);
+  } else {
+    // Backward compatibility: older workers may not expose health.
+    setPhase(response?.connected ? 'connected' : 'disconnected');
+  }
 });
 
 function getPort(): number {
@@ -258,7 +355,7 @@ function getPort(): number {
 
 // ── Connect (primary CTA) ───────────────────────────────────────────
 //
-// No local precheck — the worker handles auth bootstrap (pairing/sign-in)
+// No local precheck -- the worker handles auth bootstrap (pairing/sign-in)
 // automatically when interactive=true. Users can connect in one click
 // even when not previously paired or signed in.
 
@@ -286,13 +383,19 @@ btnConnect.addEventListener('click', async () => {
       setPhase('disconnected');
       return;
     }
-    // Poll briefly for open state
+    // Poll briefly for health state convergence.
     let attempts = 0;
     const poll = setInterval(() => {
-      chrome.runtime.sendMessage({ type: 'get_status' }, (r: { connected: boolean }) => {
-        if (r?.connected || ++attempts > 10) {
+      chrome.runtime.sendMessage({ type: 'get_status' }, (r: GetStatusResponse) => {
+        if (chrome.runtime.lastError) {
+          if (++attempts > 10) clearInterval(poll);
+          return;
+        }
+
+        const health = r?.health ?? (r?.connected ? 'connected' : 'connecting');
+        if (health === 'connected' || health === 'error' || health === 'auth_required' || ++attempts > 10) {
           clearInterval(poll);
-          setPhase(r?.connected ? 'connected' : 'disconnected');
+          applyHealthState(health as ConnectionHealthState, r?.healthDetail);
         }
       });
     }, 300);
@@ -307,7 +410,7 @@ btnConnect.addEventListener('click', async () => {
 
 btnPause.addEventListener('click', () => {
   chrome.runtime.sendMessage({ type: 'pause' }, () => {
-    setPhase('paused');
+    applyHealthState('paused');
   });
 });
 
@@ -320,7 +423,7 @@ btnPause.addEventListener('click', () => {
 // `vellum.localCapabilityToken` and is used directly by the
 // self-hosted relay WebSocket connection.
 //
-// This is a manual recovery control — normal connect handles pairing
+// This is a manual recovery control -- normal connect handles pairing
 // automatically via the worker's interactive bootstrap.
 
 function setLocalStatus(text: string, state: 'neutral' | 'paired' | 'error'): void {
@@ -383,7 +486,7 @@ btnPairLocal.addEventListener('click', async () => {
   btnPairLocal.disabled = true;
   setLocalStatus('Pairing\u2026', 'neutral');
   // Delegate to the service worker so the native-messaging bootstrap
-  // survives the popup teardown race — see the `self-hosted-pair`
+  // survives the popup teardown race -- see the `self-hosted-pair`
   // handler in worker.ts, and the matching cloud-auth-sign-in pattern.
   const response = await requestLocalPair();
   if (response.ok && response.token) {
@@ -401,7 +504,7 @@ refreshLocalStatus();
 // The token is persisted and consumed by the background worker when
 // opening cloud relay WebSocket connections.
 //
-// This is a manual recovery control — normal connect handles cloud
+// This is a manual recovery control -- normal connect handles cloud
 // sign-in automatically via the worker's interactive bootstrap.
 
 function setCloudStatus(text: string, signedIn: boolean): void {
@@ -465,9 +568,9 @@ btnCloudSignIn.addEventListener('click', async () => {
   setCloudStatus('Signing in\u2026', false);
   errorText.style.display = 'none';
   // Clear any stale auth-error the worker persisted during a failed
-  // reconnect — the user is explicitly retrying sign-in now.
+  // reconnect -- the user is explicitly retrying sign-in now.
   await chrome.storage.local.remove('vellum.relayAuthError');
-  // Delegate to the service worker — see header comment for the rationale.
+  // Delegate to the service worker -- see header comment for the rationale.
   const response = await requestCloudSignIn();
   if (response.ok && response.token) {
     setCloudStatus(`Signed in as guardian:${response.token.guardianId}`, true);

--- a/clients/chrome-extension/popup/popup.ts
+++ b/clients/chrome-extension/popup/popup.ts
@@ -388,14 +388,24 @@ btnConnect.addEventListener('click', async () => {
     const poll = setInterval(() => {
       chrome.runtime.sendMessage({ type: 'get_status' }, (r: GetStatusResponse) => {
         if (chrome.runtime.lastError) {
-          if (++attempts > 10) clearInterval(poll);
+          if (++attempts > 10) {
+            clearInterval(poll);
+            // Fall back to a recoverable state so the user can retry.
+            applyHealthState('paused');
+          }
           return;
         }
 
         const health = r?.health ?? (r?.connected ? 'connected' : 'connecting');
-        if (health === 'connected' || health === 'error' || health === 'auth_required' || ++attempts > 10) {
+        if (health === 'connected' || health === 'error' || health === 'auth_required') {
           clearInterval(poll);
           applyHealthState(health as ConnectionHealthState, r?.healthDetail);
+        } else if (++attempts > 10) {
+          clearInterval(poll);
+          // Polling exhausted without reaching a terminal health state.
+          // Fall back to paused so the Connect button re-enables and
+          // the user can retry instead of being stuck on "Connecting...".
+          applyHealthState('paused');
         }
       });
     }, 300);

--- a/clients/chrome-extension/popup/popup.ts
+++ b/clients/chrome-extension/popup/popup.ts
@@ -184,9 +184,11 @@ function updateTroubleshootSection(health: ConnectionHealthState): void {
 
   troubleshootSection.hidden = false;
 
-  // Auto-expand when action is required.
+  // Auto-expand when action is required, auto-collapse on recovery.
   if (shouldExpandTroubleshooting(health)) {
     expandTroubleshoot();
+  } else if (health === 'connected') {
+    collapseTroubleshoot();
   }
 }
 


### PR DESCRIPTION
## Summary
- Update popup rendering to consume worker health contract with concise primary states
- Move manual Pair/Sign-in into collapsed Troubleshoot area, only visible for auth_required/error states
- Preserve single-assistant no-selector UX and multi-assistant selector behavior
- Expand popup-state.ts tests for new state mapping and visibility rules

Part of plan: seamless-browser-extension-ux.md (PR 6 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24813" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
