### PR TITLE
feat(chrome-ext): parameterize manifest version via VERSION env var

### DIFF
--- a/clients/chrome-extension/build.sh
+++ b/clients/chrome-extension/build.sh
@@ -11,6 +11,14 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DIST_DIR="$SCRIPT_DIR/dist"
 
+# Resolve extension version. The release workflow injects VERSION; local
+# dev builds fall back to the value in the source manifest.
+if [ -n "${VERSION:-}" ]; then
+  EXT_VERSION="$VERSION"
+else
+  EXT_VERSION=$(jq -r '.version' "$SCRIPT_DIR/manifest.json")
+fi
+
 echo "Building Vellum browser-relay extension…"
 
 # Type-check with tsc --noEmit before bundling so type errors fail fast
@@ -45,6 +53,12 @@ bun build \
 
 # Copy static assets
 cp "$SCRIPT_DIR/manifest.json" "$DIST_DIR/manifest.json"
+
+# Stamp the resolved version into the dist manifest.
+jq --arg v "$EXT_VERSION" '.version = $v' "$DIST_DIR/manifest.json" > "$DIST_DIR/manifest.json.tmp" \
+  && mv "$DIST_DIR/manifest.json.tmp" "$DIST_DIR/manifest.json"
+echo "  Extension version: $EXT_VERSION"
+
 cp "$SCRIPT_DIR/popup/popup.html" "$DIST_DIR/popup/popup.html"
 
 # Copy icons if they exist, otherwise create placeholder PNGs


### PR DESCRIPTION
## Summary
- Add VERSION env var support to build.sh for release workflow version stamping
- Falls back to manifest.json source version for local dev builds
- Mirrors existing jq version stamping pattern from release.yml

Part of plan: cws-distribution.md (PR 1 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24814" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
