### PR TITLE
feat(chrome-ext): add protocol version to native messaging handshake

### DIFF
--- a/clients/chrome-extension/background/__tests__/self-hosted-auth.test.ts
+++ b/clients/chrome-extension/background/__tests__/self-hosted-auth.test.ts
@@ -272,6 +272,49 @@ describe('bootstrapLocalToken', () => {
     expect(result.guardianId).toBe('g-legacy');
   });
 
+  test('persists protocolVersion when the helper frame includes it', async () => {
+    const expiresAtIso = new Date(Date.now() + 60_000).toISOString();
+
+    fakeRuntime.onConnect = (port) => {
+      queueMicrotask(() => {
+        port.emitMessage({
+          type: 'token_response',
+          token: 'pv-token',
+          expiresAt: expiresAtIso,
+          guardianId: 'g-pv',
+          protocolVersion: 1,
+        });
+      });
+    };
+
+    const result = await bootstrapLocalToken(ASSISTANT_A);
+    expect(result.protocolVersion).toBe(1);
+
+    // And the stored value must round-trip through getStoredLocalToken.
+    const loaded = await getStoredLocalToken(ASSISTANT_A);
+    expect(loaded).not.toBeNull();
+    expect(loaded!.protocolVersion).toBe(1);
+  });
+
+  test('treats missing protocolVersion as null for backward compatibility', async () => {
+    const expiresAtIso = new Date(Date.now() + 60_000).toISOString();
+
+    fakeRuntime.onConnect = (port) => {
+      queueMicrotask(() => {
+        // Simulate an older native host that does not include protocolVersion
+        port.emitMessage({
+          type: 'token_response',
+          token: 'legacy-pv-token',
+          expiresAt: expiresAtIso,
+          guardianId: 'g-legacy-pv',
+        });
+      });
+    };
+
+    const result = await bootstrapLocalToken(ASSISTANT_A);
+    expect(result.protocolVersion).toBeNull();
+  });
+
   test('drops malformed assistantPort from the helper frame', async () => {
     const expiresAtIso = new Date(Date.now() + 60_000).toISOString();
 

--- a/clients/chrome-extension/background/__tests__/worker-assistant-catalog.test.ts
+++ b/clients/chrome-extension/background/__tests__/worker-assistant-catalog.test.ts
@@ -207,6 +207,7 @@ describe('listAssistants', () => {
           type: 'assistants_response',
           assistants: [entry1, entry2],
           activeAssistantId: 'a-1',
+          protocolVersion: 1,
         });
       });
     };
@@ -215,6 +216,7 @@ describe('listAssistants', () => {
 
     expect(catalog.assistants.length).toBe(2);
     expect(catalog.activeAssistantId).toBe('a-1');
+    expect(catalog.protocolVersion).toBe(1);
 
     // First assistant: local with daemon port
     expect(catalog.assistants[0]!.assistantId).toBe('a-1');
@@ -240,6 +242,7 @@ describe('listAssistants', () => {
           type: 'assistants_response',
           assistants: [],
           activeAssistantId: null,
+          protocolVersion: 1,
         });
       });
     };
@@ -247,6 +250,7 @@ describe('listAssistants', () => {
     const catalog = await listAssistants();
     expect(catalog.assistants.length).toBe(0);
     expect(catalog.activeAssistantId).toBeNull();
+    expect(catalog.protocolVersion).toBe(1);
   });
 
   test('filters out malformed entries from the response', async () => {
@@ -325,6 +329,24 @@ describe('listAssistants', () => {
     expect(catalog.activeAssistantId).toBe('orphan');
   });
 
+  test('treats missing protocolVersion as null for backward compatibility', async () => {
+    fakeRuntime.onConnect = (port) => {
+      queueMicrotask(() => {
+        // Simulate an older native host that does not include protocolVersion
+        port.emitMessage({
+          type: 'assistants_response',
+          assistants: [makeAssistantEntry({ assistantId: 'legacy' })],
+          activeAssistantId: 'legacy',
+          // No protocolVersion field
+        });
+      });
+    };
+
+    const catalog = await listAssistants();
+    expect(catalog.protocolVersion).toBeNull();
+    expect(catalog.assistants.length).toBe(1);
+  });
+
   test('resolves unsupported cloud values to unsupported auth profile', async () => {
     fakeRuntime.onConnect = (port) => {
       queueMicrotask(() => {
@@ -397,6 +419,7 @@ describe('resolveSelectedAssistant', () => {
     const result = await testResolveSelectedAssistant({
       assistants: [],
       activeAssistantId: null,
+      protocolVersion: null,
     });
     expect(result).toBeNull();
   });
@@ -406,6 +429,7 @@ describe('resolveSelectedAssistant', () => {
     const result = await testResolveSelectedAssistant({
       assistants: [single],
       activeAssistantId: 'solo',
+      protocolVersion: 1,
     });
     expect(result).toEqual(single);
     expect(fakeStorage.data[SELECTED_ASSISTANT_ID_KEY]).toBe('solo');
@@ -417,6 +441,7 @@ describe('resolveSelectedAssistant', () => {
     const result = await testResolveSelectedAssistant({
       assistants: [a1, a2],
       activeAssistantId: null,
+      protocolVersion: 1,
     });
     expect(result).toEqual(a1);
     expect(fakeStorage.data[SELECTED_ASSISTANT_ID_KEY]).toBe('first');
@@ -429,6 +454,7 @@ describe('resolveSelectedAssistant', () => {
     const result = await testResolveSelectedAssistant({
       assistants: [a1, a2],
       activeAssistantId: null,
+      protocolVersion: 1,
     });
     expect(result).toEqual(a2);
     // Storage was not overwritten
@@ -442,6 +468,7 @@ describe('resolveSelectedAssistant', () => {
     const result = await testResolveSelectedAssistant({
       assistants: [a1, a2],
       activeAssistantId: null,
+      protocolVersion: 1,
     });
     expect(result).toEqual(a1);
     // Storage was updated to the new default
@@ -455,6 +482,7 @@ describe('resolveSelectedAssistant', () => {
     const result = await testResolveSelectedAssistant({
       assistants: [a1, a2],
       activeAssistantId: null,
+      protocolVersion: 1,
     });
     expect(result).toEqual(a1);
     expect(fakeStorage.data[SELECTED_ASSISTANT_ID_KEY]).toBe('first');
@@ -467,6 +495,7 @@ describe('resolveSelectedAssistant', () => {
     const result = await testResolveSelectedAssistant({
       assistants: [a1, a2],
       activeAssistantId: null,
+      protocolVersion: 1,
     });
     expect(result).toEqual(a1);
     expect(fakeStorage.data[SELECTED_ASSISTANT_ID_KEY]).toBe('first');

--- a/clients/chrome-extension/background/native-host-assistants.ts
+++ b/clients/chrome-extension/background/native-host-assistants.ts
@@ -42,6 +42,12 @@ export interface AssistantDescriptor {
 export interface AssistantCatalog {
   assistants: AssistantDescriptor[];
   activeAssistantId: string | null;
+  /**
+   * Protocol version reported by the native host. `null` when the native
+   * host predates protocol versioning (backward-compatible — treat as
+   * "version unknown, assume compatible").
+   */
+  protocolVersion: number | null;
 }
 
 export interface ListAssistantsOptions {
@@ -139,6 +145,7 @@ export async function listAssistants(
         type?: unknown;
         assistants?: unknown;
         activeAssistantId?: unknown;
+        protocolVersion?: unknown;
         message?: unknown;
       };
 
@@ -153,10 +160,14 @@ export async function listAssistants(
             ? frame.activeAssistantId
             : null;
 
+        const protocolVersion =
+          typeof frame.protocolVersion === 'number' ? frame.protocolVersion : null;
+
         finish(() =>
           resolve({
             assistants,
             activeAssistantId,
+            protocolVersion,
           }),
         );
         return;

--- a/clients/chrome-extension/background/self-hosted-auth.ts
+++ b/clients/chrome-extension/background/self-hosted-auth.ts
@@ -43,6 +43,13 @@ export interface StoredLocalToken {
    * native helpers that predate PR 3 of the browser-remediation plan.
    */
   assistantPort?: number;
+  /**
+   * Protocol version reported by the native host. `null` when the native
+   * host predates protocol versioning (backward-compatible — treat as
+   * "version unknown, assume compatible"). Optional so existing stored
+   * tokens without this field remain valid.
+   */
+  protocolVersion?: number | null;
 }
 
 const STORAGE_KEY_PREFIX = 'vellum.localCapabilityToken';
@@ -255,6 +262,7 @@ export async function bootstrapLocalToken(
         expiresAt?: unknown;
         guardianId?: unknown;
         assistantPort?: unknown;
+        protocolVersion?: unknown;
         message?: unknown;
       };
 
@@ -285,11 +293,18 @@ export async function bootstrapLocalToken(
         ) {
           assistantPort = rawPort;
         }
+        // Forward/back-compat: accept missing protocolVersion. Older
+        // native helpers that predate protocol versioning don't emit
+        // this field; treat as null (version unknown, assume compatible).
+        const protocolVersion =
+          typeof frame.protocolVersion === 'number' ? frame.protocolVersion : null;
+
         const stored: StoredLocalToken = {
           token: frame.token,
           expiresAt,
           guardianId: frame.guardianId,
           ...(assistantPort !== undefined ? { assistantPort } : {}),
+          protocolVersion,
         };
 
         // Mark settled + tear down the port SYNCHRONOUSLY so a racing

--- a/clients/chrome-extension/native-host/src/__tests__/index.test.ts
+++ b/clients/chrome-extension/native-host/src/__tests__/index.test.ts
@@ -285,9 +285,12 @@ describe("native host — subprocess regression coverage", () => {
 
     // Exactly one error frame on stdout — never a token_response.
     expect(result.frames).toHaveLength(1);
-    const frame = result.frames[0] as { type?: unknown; message?: unknown };
+    const frame = result.frames[0] as { type?: unknown; message?: unknown; protocolVersion?: unknown };
     expect(frame.type).toBe("error");
     expect(frame.message).toBe("unauthorized_origin");
+    // Error frames must include the protocol version so the extension
+    // can detect incompatible native host versions even on error paths.
+    expect(frame.protocolVersion).toBe(1);
 
     // The critical invariant: the helper must NOT have POSTed anything
     // to /v1/browser-extension-pair. If the unauthorized branch falls
@@ -320,11 +323,13 @@ describe("native host — subprocess regression coverage", () => {
       token?: unknown;
       expiresAt?: unknown;
       guardianId?: unknown;
+      protocolVersion?: unknown;
     };
     expect(frame.type).toBe("token_response");
     expect(frame.token).toBe("tok-1");
     expect(frame.expiresAt).toBe("2026-12-31T00:00:00Z");
     expect(frame.guardianId).toBe("g-1");
+    expect(frame.protocolVersion).toBe(1);
 
     // The helper should have made exactly one POST to the pair
     // endpoint, carrying the extension origin we passed on argv.
@@ -390,10 +395,11 @@ describe("native host — subprocess regression coverage", () => {
 
     expect(result.exitCode).not.toBe(0);
     expect(result.frames).toHaveLength(1);
-    const frame = result.frames[0] as { type?: unknown; message?: unknown };
+    const frame = result.frames[0] as { type?: unknown; message?: unknown; protocolVersion?: unknown };
     expect(frame.type).toBe("error");
     expect(typeof frame.message).toBe("string");
     expect(frame.message).toMatch(/guardianId/);
+    expect(frame.protocolVersion).toBe(1);
   });
 });
 
@@ -476,10 +482,12 @@ describe("native host — list_assistants response framing", () => {
         isActive: boolean;
       }>;
       activeAssistantId: string | null;
+      protocolVersion: number;
     };
 
     expect(frame.type).toBe("assistants_response");
     expect(frame.activeAssistantId).toBe("local-one");
+    expect(frame.protocolVersion).toBe(1);
     expect(frame.assistants).toHaveLength(2);
 
     expect(frame.assistants[0]!.assistantId).toBe("local-one");
@@ -509,10 +517,12 @@ describe("native host — list_assistants response framing", () => {
       type: string;
       assistants: unknown[];
       activeAssistantId: unknown;
+      protocolVersion: unknown;
     };
     expect(frame.type).toBe("assistants_response");
     expect(frame.assistants).toEqual([]);
     expect(frame.activeAssistantId).toBeNull();
+    expect(frame.protocolVersion).toBe(1);
   });
 });
 
@@ -612,10 +622,12 @@ describe("native host — assistant-scoped token request", () => {
       type: string;
       token: string;
       assistantPort: number;
+      protocolVersion: number;
     };
     expect(frame.type).toBe("token_response");
     expect(frame.token).toBe("tok-b");
     expect(frame.assistantPort).toBe(srvB.port);
+    expect(frame.protocolVersion).toBe(1);
 
     // srvB should have received the pair request, not srvA.
     expect(srvB.requests).toHaveLength(1);

--- a/clients/chrome-extension/native-host/src/index.ts
+++ b/clients/chrome-extension/native-host/src/index.ts
@@ -151,6 +151,14 @@ const RUNTIME_PORT_FILE = join(homedir(), ".vellum", "runtime-port");
 export const NATIVE_HOST_MARKER_HEADER = "x-vellum-native-host";
 export const NATIVE_HOST_MARKER_VALUE = "1";
 
+/**
+ * Protocol version for the native messaging handshake. Increment this when
+ * making breaking changes to the message format. The extension uses this to
+ * detect incompatible native host versions and show an "update your desktop
+ * app" message.
+ */
+export const PROTOCOL_VERSION = 1;
+
 interface TokenResponse {
   token: string;
   expiresAt: string;
@@ -312,7 +320,7 @@ function writeFrameAndExitAsync(
  */
 function fail(message: string, code = 1): never {
   process.stderr.write(`vellum-chrome-native-host: ${message}\n`);
-  writeErrorFrameAndExit({ type: "error", message }, code);
+  writeErrorFrameAndExit({ type: "error", message, protocolVersion: PROTOCOL_VERSION }, code);
 }
 
 /**
@@ -474,6 +482,7 @@ async function main(): Promise<void> {
                 type: "assistants_response",
                 assistants: inventory.assistants,
                 activeAssistantId: inventory.activeAssistantId,
+                protocolVersion: PROTOCOL_VERSION,
               },
               0,
             );
@@ -500,6 +509,7 @@ async function main(): Promise<void> {
                 expiresAt,
                 guardianId,
                 assistantPort,
+                protocolVersion: PROTOCOL_VERSION,
               },
               0,
             );

--- a/clients/chrome-extension/native-host/src/index.ts
+++ b/clients/chrome-extension/native-host/src/index.ts
@@ -428,7 +428,7 @@ async function main(): Promise<void> {
       `vellum-chrome-native-host: unauthorized_origin (got ${extensionOrigin ?? "<none>"})\n`,
     );
     writeErrorFrameAndExit(
-      { type: "error", message: "unauthorized_origin" },
+      { type: "error", message: "unauthorized_origin", protocolVersion: PROTOCOL_VERSION },
       1,
     );
     // Defense-in-depth: even though writeErrorFrameAndExit calls


### PR DESCRIPTION
## Summary
- Add PROTOCOL_VERSION constant to native host, included in all response frames
- Parse protocolVersion in extension-side AssistantCatalog and bootstrapLocalToken
- Backward compatible: treats missing protocolVersion as null (assume compatible)
- Update tests for both native host and extension-side protocol version parsing

Part of plan: cws-distribution.md (PR 2 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24818" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
