### PR TITLE
Docs: codify seamless extension lifecycle, recovery expectations, and validation steps

### DIFF
--- a/clients/chrome-extension/README.md
+++ b/clients/chrome-extension/README.md
@@ -36,12 +36,18 @@ Then in Chrome:
 3. Click **Load unpacked**
 4. Select `clients/chrome-extension/dist`
 
-## How It Works — One-Click Connect
+## How It Works — Install Once, Connect Once, Forget It
 
 The extension discovers available assistants from the lockfile via the native
 messaging helper (`com.vellum.daemon`). The lockfile lists every assistant
 configured on the machine, along with its hosting topology (`cloud` field),
 runtime URL, and local assistant port.
+
+After the first successful Connect, the extension maintains a long-lived
+background connection and recovers automatically from transient interruptions
+(browser restarts, network drops, service-worker suspension, token rotation).
+Users should **not** need to touch Pair, Sign-in, or Connect again under
+normal operation.
 
 ### First-Time Connect (One Click)
 
@@ -59,6 +65,39 @@ runtime URL, and local assistant port.
 
 The entire flow is a single user action — click **Connect**.
 
+### Long-Lived Background Behavior
+
+After a successful first connect, the extension runs as a long-lived
+background service. The relay WebSocket stays open and the service worker
+sends periodic keepalive frames (every 20 seconds) to prevent Chrome's
+MV3 idle-suspension timeout (~30 seconds). The assistant runtime
+acknowledges keepalives by touching the connection's activity timestamp
+in the `ChromeExtensionRegistry`.
+
+The extension handles the following interruptions automatically:
+
+| Interruption | Recovery |
+|---|---|
+| **Service-worker restart** (Chrome MV3 teardown/relaunch) | Auto-reconnect via persisted `autoConnect` flag and stored credentials. |
+| **Transient network drop** (cable unplugged, Wi-Fi blip) | Exponential-backoff reconnect (1 s base, 30 s cap). |
+| **Token expiry** (local capability token or cloud JWT) | Silent non-interactive token refresh via native messaging (local) or OAuth refresh (cloud) before the next reconnect attempt. |
+| **Assistant restart** | WebSocket close triggers reconnect; the extension re-establishes the relay against the new runtime instance. |
+| **Browser close and reopen** | The `autoConnect` flag persists across browser sessions, so the worker auto-connects on startup. |
+
+Users should **not** re-pair, re-sign-in, or re-click Connect for any of
+these cases. The popup's health indicator shows the current state
+(`Connected`, `Reconnecting automatically...`, `Paused`, or
+`Action required`) so users can verify recovery is happening without
+taking action.
+
+### When User Action IS Required
+
+The extension enters `auth_required` only when non-interactive token
+refresh is impossible (e.g. the cloud OAuth refresh token itself has
+expired, or the native messaging host is uninstalled). In this state the
+popup's Troubleshooting section expands automatically and prompts the
+user to re-pair (local) or re-sign-in (cloud), then click **Connect**.
+
 ### Auto-Connect On Reopen
 
 After a successful first connect, the extension sets a persistent
@@ -66,9 +105,10 @@ After a successful first connect, the extension sets a persistent
 restarts), the worker reads this flag and automatically reconnects using
 the stored credentials — no user interaction required.
 
-If stored credentials have expired or are missing at auto-connect time,
-the extension falls back to the disconnected state silently. The user
-can click **Connect** again to re-bootstrap credentials interactively.
+If stored credentials have expired or are missing at auto-connect time
+and silent refresh also fails, the extension transitions to
+`auth_required`. The user can click **Connect** to re-bootstrap
+credentials interactively.
 
 ### Pause Semantics
 
@@ -79,7 +119,9 @@ can click **Connect** again to re-bootstrap credentials interactively.
 - Preserves stored credentials so the next **Connect** is instant (no
   re-pair or re-sign-in needed unless the token has expired).
 
-Pause replaces the previous "Disconnect" terminology.
+Pause replaces the previous "Disconnect" terminology. It is the only
+action that intentionally stops the extension — all other disconnects
+trigger automatic recovery.
 
 ### Assistant Discovery And Selection
 
@@ -127,8 +169,89 @@ switching between assistants does not require re-authentication.
 The popup includes a collapsible **Troubleshooting** section with manual
 "Re-pair with local assistant" and "Re-sign in with Vellum (cloud)"
 buttons. These are **not** required for the normal connect flow — they
-exist for edge cases where the automatic bootstrap fails (e.g. expired
-tokens, native host issues, OAuth configuration problems).
+exist for edge cases where automatic recovery is impossible.
+
+**When to use Troubleshooting controls:**
+- The popup shows `Action required` with an `auth_required` health state.
+- The Troubleshooting section expanded automatically (it stays collapsed
+  during `connected`, `reconnecting`, `connecting`, and `paused` states).
+
+**When NOT to use Troubleshooting controls:**
+- The popup shows `Reconnecting automatically...` — the extension is
+  already recovering and will reconnect on its own.
+- The popup shows `Connected` — everything is working.
+- The popup shows `Paused` — click **Connect** (not Troubleshoot) to
+  resume.
+
+Transient disconnects (network drops, service-worker restarts, assistant
+restarts) are handled silently with exponential-backoff reconnect and
+automatic token refresh. Touching the Troubleshooting controls during a
+transient interruption is unnecessary and may interfere with the
+automatic recovery path.
+
+### Connection Health States
+
+The worker maintains a structured health state machine surfaced to the
+popup via `get_status`. The six states drive the popup's status indicator,
+button enablement, and Troubleshooting section visibility:
+
+| State | Popup display | Auto-reconnect? | User action needed? |
+|---|---|---|---|
+| `connected` | Green dot, "Connected" | n/a | No |
+| `connecting` | Gray dot, "Connecting..." | n/a | No |
+| `reconnecting` | Yellow dot, "Reconnecting automatically..." | Yes | No |
+| `paused` | Yellow dot, "Paused" | No | Click Connect to resume |
+| `auth_required` | Gray dot, "Action required: ..." | No | Re-pair / Re-sign-in, then Connect |
+| `error` | Gray dot, "Error: ..." | No | Check Troubleshooting section |
+
+The `reconnecting` state means the extension detected an unexpected
+disconnect and is actively recovering — the user should wait. Only
+`auth_required` and `error` warrant manual intervention.
+
+## End-to-End Validation (QA Playbook)
+
+Use this checklist to verify the "install once, connect once, forget it"
+contract from a clean state.
+
+### Setup
+1. Build and load the extension (see [Build And Load](#build-and-load-the-extension)).
+2. Start at least one local assistant (or have a cloud-managed assistant configured).
+3. Verify the native messaging host is installed (macOS app installs it automatically).
+
+### Happy path
+1. Open the extension popup.
+2. Click **Connect**. Verify the status transitions: `Connecting...` then `Connected`.
+3. Close Chrome completely. Reopen Chrome.
+4. Open the extension popup. Verify the status shows `Connected` (auto-reconnect from `autoConnect` flag).
+5. Open the service worker console (`chrome://extensions` > Service worker link). Verify keepalive frames are logged every ~20 seconds.
+
+### Automatic recovery — network drop
+1. While connected, disable your network adapter (Wi-Fi off, cable out).
+2. Open the popup. Verify the status shows `Reconnecting automatically...`.
+3. Re-enable the network adapter.
+4. Verify the status returns to `Connected` within ~30 seconds (backoff cap).
+
+### Automatic recovery — assistant restart
+1. While connected, stop the assistant process.
+2. Verify the popup shows `Reconnecting automatically...`.
+3. Restart the assistant.
+4. Verify the popup returns to `Connected`.
+
+### Automatic recovery — token refresh
+1. While connected, manually expire or delete the stored token in `chrome.storage.local`.
+2. On the next reconnect cycle, the extension should silently re-bootstrap the token (local pair via native messaging, or cloud via OAuth refresh).
+3. Verify the popup returns to `Connected` without manual intervention.
+
+### Pause and resume
+1. While connected, click **Pause**. Verify the status shows `Paused`.
+2. Close and reopen Chrome. Verify the popup still shows `Paused` (autoConnect cleared).
+3. Click **Connect**. Verify the status returns to `Connected`.
+
+### Auth failure (manual recovery required)
+1. Uninstall the native messaging host (or revoke the cloud OAuth token entirely).
+2. Force a reconnect (restart Chrome or stop/start the assistant).
+3. Verify the popup shows `Action required` and the Troubleshooting section expands automatically.
+4. Reinstall the native host (or re-sign-in), then click **Connect**. Verify recovery.
 
 ## Native Messaging Host Setup (If Pairing Fails)
 

--- a/clients/chrome-extension/native-host/README.md
+++ b/clients/chrome-extension/native-host/README.md
@@ -9,11 +9,37 @@ serves two purposes:
    assistant selector dropdown.
 2. **Self-hosted pairing** (`request_token`): bootstraps a scoped
    capability token for the local-assistant transport without shipping a
-   long-lived secret in the extension package. In the normal one-click
-   Connect flow, the extension's service worker invokes this
-   automatically — users never need to trigger pairing manually. The
-   `request_token` message also serves as a recovery mechanism when
-   the popup's Troubleshooting "Re-pair" button is used.
+   long-lived secret in the extension package.
+
+### Automatic maintenance path (normal operation)
+
+In the shipped seamless-extension architecture, native pairing is an
+**automatic maintenance operation** — not a user-initiated step. The
+extension's service worker invokes `request_token` silently in two
+scenarios:
+
+- **First connect**: When the user clicks Connect for the first time, the
+  worker auto-bootstraps the local capability token via native messaging
+  as part of the one-click flow. No separate "Pair" action is needed.
+- **Silent token refresh**: When a stored token is expired or stale (at
+  connect time, reconnect time, or auto-connect on browser reopen), the
+  worker attempts a non-interactive `bootstrapLocalToken()` call that
+  re-invokes the native helper under the hood. If the assistant is
+  reachable, the token is refreshed silently and the relay reconnects
+  without user involvement.
+
+### Manual invocation (diagnostics only)
+
+The popup's Troubleshooting section includes a "Re-pair with local
+assistant" button that also invokes `request_token`. This is reserved for
+cases where automatic recovery has failed — e.g. the native messaging
+host was uninstalled, the assistant was unreachable during all automatic
+refresh attempts, or the pair endpoint rejected the extension origin. The
+popup only surfaces this control when the health state is `auth_required`
+or `error`; during normal `connected` or `reconnecting` states the
+Troubleshooting section stays collapsed.
+
+### Bundling
 
 The macOS installer bundles this helper into the Mac `.app` under
 `Contents/MacOS/vellum-chrome-native-host` via `clients/macos/build.sh`

--- a/docs/browser-use-architecture-phase2.md
+++ b/docs/browser-use-architecture-phase2.md
@@ -47,9 +47,10 @@ Phase 2 ships:
    the extension transport when it is provisioned. When the extension
    proxy exists but is temporarily unavailable (mid-reconnect), the
    factory intentionally skips `cdp-inspect` to prevent silent backend
-   drift; only when no extension proxy exists at all does `cdp-inspect`
-   enter the candidate list (via the macOS desktop-auto path or explicit
-   config enablement).
+   drift. `cdp-inspect` enters the candidate list when no extension proxy
+   exists at all (macOS desktop-auto path) or when explicitly enabled in
+   config (`hostBrowser.cdpInspect.enabled`), but it is not used as a
+   fallback during transient extension disconnects.
 8. **Structured connection health**: The worker maintains a six-state
    health machine (`paused`, `connecting`, `connected`, `reconnecting`,
    `auth_required`, `error`) surfaced to the popup via `get_status`.

--- a/docs/browser-use-architecture-phase2.md
+++ b/docs/browser-use-architecture-phase2.md
@@ -25,7 +25,7 @@ Phase 2 ships:
    - **Cloud**: WSS to the gateway's `/v1/browser-relay` endpoint, using
      a guardian-bound JWT minted via WorkOS-backed
      `chrome.identity.launchWebAuthFlow`.
-   - **Self-hosted**: WS to the local daemon's `/v1/browser-relay`
+   - **Self-hosted**: WS to the local assistant's `/v1/browser-relay`
      endpoint on `127.0.0.1`, using a scoped capability token bootstrapped
      via Chrome Native Messaging.
 3. A new `chrome-extension` interface in `INTERFACE_IDS` that routes
@@ -34,6 +34,27 @@ Phase 2 ships:
 4. A per-capability `supportsHostProxy(id, capability)` so the
    chrome-extension interface can advertise `host_browser` without
    implying that bash / file / CU proxies are also available.
+5. **Relay keepalive**: The extension sends periodic JSON heartbeat
+   frames (`{ type: "keepalive", sentAt: <epoch_ms> }`) every 20 seconds
+   to prevent Chrome MV3 service-worker idle suspension (~30 s timeout).
+   The runtime acknowledges by touching the connection's activity
+   timestamp in the `ChromeExtensionRegistry`.
+6. **Silent token maintenance**: On connect, reconnect, and auto-connect,
+   the worker transparently re-bootstraps expired/stale local tokens via
+   native messaging and refreshes cloud JWTs via non-interactive OAuth —
+   no user interaction required unless refresh itself fails.
+7. **Extension-first CDP routing**: The CDP client factory always prefers
+   the extension transport when it is provisioned. When the extension
+   proxy exists but is temporarily unavailable (mid-reconnect), the
+   factory intentionally skips `cdp-inspect` to prevent silent backend
+   drift; only when no extension proxy exists at all does `cdp-inspect`
+   enter the candidate list (via the macOS desktop-auto path or explicit
+   config enablement).
+8. **Structured connection health**: The worker maintains a six-state
+   health machine (`paused`, `connecting`, `connected`, `reconnecting`,
+   `auth_required`, `error`) surfaced to the popup via `get_status`.
+   The popup renders concise status text and auto-expands the
+   Troubleshooting section only when user action is genuinely needed.
 
 `browser-execution.ts` drives the live navigation surface through a
 per-invocation `BrowserSessionManager` obtained via `getCdpClient()`
@@ -49,18 +70,30 @@ registry/proxy code path on the runtime side. Only the transport layer
 and the handshake differ.
 
 ```
- ┌───────────────────────┐
- │  Chrome extension     │
- │  (service worker)     │
- │                       │
- │  host-browser-dispatcher
- │   + cdp-proxy         │
- │   + relay-connection  │
- └──────────┬────────────┘
+ ┌─────────────────────────────────┐
+ │  Chrome extension               │
+ │  (MV3 service worker)           │
+ │                                 │
+ │  host-browser-dispatcher        │
+ │   + cdp-proxy                   │
+ │   + relay-connection            │
+ │     (keepalive 20s interval)    │
+ │     (reconnect 1s–30s backoff)  │
+ │     (silent token refresh)      │
+ │                                 │
+ │  ConnectionHealthState:         │
+ │   paused | connecting |         │
+ │   connected | reconnecting |    │
+ │   auth_required | error         │
+ │        │                        │
+ │        ▼                        │
+ │  popup (get_status)             │
+ └──────────┬──────────────────────┘
             │ WS (self-hosted)     WSS (cloud)
+            │  + keepalive frames  │
             │                      │
             ▼                      ▼
-    127.0.0.1:<port>         api.vellum.ai
+    127.0.0.1:<port>         <gateway>
     /v1/browser-relay        /v1/browser-relay
             │                      │
             └──────────┬───────────┘
@@ -71,7 +104,8 @@ and the handshake differ.
           │  http-server.ts open/close │
           │        │                   │
           │        ▼                   │
-         │  ChromeExtensionRegistry   │  (guardianId, clientInstanceId → ws)
+          │  ChromeExtensionRegistry   │  (guardianId, clientInstanceId → ws)
+          │   .touch() on keepalive    │
           │        │                   │
           │        ▼                   │
           │  HostBrowserProxy          │
@@ -99,30 +133,47 @@ the runtime runs on infrastructure managed by Vellum.
 
 Handshake:
 
-1. The user clicks "Sign in with Vellum (cloud)" in the extension
-   popup.
+1. The user clicks **Connect** in the extension popup. For cloud
+   assistants, the worker auto-bootstraps credentials as part of the
+   one-click flow — no separate "Sign in" step is needed.
 2. The service worker (not the popup) runs
    `chrome.identity.launchWebAuthFlow` against the gateway's WorkOS
    OIDC endpoint. Running it in the service worker keeps the awaited
    promise alive if the popup closes mid-flow.
 3. On success, the gateway returns a guardian-bound JWT and the
-   extension persists it via `cloud-auth.ts::getStoredToken`.
-4. The extension opens `wss://api.vellum.ai/v1/browser-relay` with the
-   JWT on the `token=...` query parameter.
+   extension persists it per-assistant via scoped storage keys.
+4. The extension opens `wss://<gateway>/v1/browser-relay` with the
+   JWT on the `token=...` query parameter and a `clientInstanceId`
+   for multi-install disambiguation.
 5. The gateway verifies the JWT, extracts the guardian id, and forwards
    the upgrade to the assistant runtime. The runtime registers the
-   connection under that guardian id in the `ChromeExtensionRegistry`.
+   connection under `(guardianId, clientInstanceId)` in the
+   `ChromeExtensionRegistry`.
+
+Token lifecycle:
+
+- The worker proactively refreshes stale cloud JWTs before they expire,
+  both at connect time (`connectPreflight`) and on reconnect
+  (`cloudReconnectHook`).
+- A non-interactive OAuth refresh is attempted first. If it succeeds the
+  relay reconnects silently.
+- If non-interactive refresh is impossible (refresh token expired, OAuth
+  configuration changed), the reconnect loop aborts and the popup enters
+  `auth_required` state. The user must re-sign-in via the Troubleshooting
+  controls, then click **Connect**.
 
 ## Self-hosted transport
 
 The self-hosted transport is used by users who run the assistant
 locally on their own machine (the default desktop experience). The
-extension talks directly to the local daemon over loopback.
+extension talks directly to the local assistant over loopback.
 
 Handshake:
 
-1. The user clicks "Pair with Vellum (self-hosted)" in the extension
-   popup.
+1. The user clicks **Connect** in the extension popup. For local
+   assistants, the worker auto-bootstraps the capability token via
+   native messaging as part of the one-click flow — no separate "Pair"
+   step is needed.
 2. The service worker calls
    `chrome.runtime.connectNative("com.vellum.daemon")`, which spawns
    `clients/chrome-extension/native-host/` (a tiny CLI helper bundled
@@ -136,13 +187,26 @@ Handshake:
    c. POSTs to `http://127.0.0.1:<port>/v1/browser-extension-pair` to
       mint a scoped capability token bound to the caller's guardian.
    d. Writes a `token_response` frame to stdout and exits.
-4. The extension persists the token and opens
-   `ws://127.0.0.1:<port>/v1/browser-relay` with the token on the
-   `token=...` query parameter.
-5. The daemon verifies the token via
-   `verifyHostBrowserCapability`, registers the connection in the
-   `ChromeExtensionRegistry`, and starts routing `host_browser_request`
-   frames to it.
+4. The extension persists the token per-assistant under scoped storage
+   keys and opens `ws://127.0.0.1:<port>/v1/browser-relay` with the
+   token on the `token=...` query parameter and a `clientInstanceId`
+   for multi-install disambiguation.
+5. The assistant verifies the token via
+   `verifyHostBrowserCapability`, registers the connection under
+   `(guardianId, clientInstanceId)` in the `ChromeExtensionRegistry`,
+   and starts routing `host_browser_request` frames to it.
+
+Token lifecycle:
+
+- The worker silently re-bootstraps local tokens when they are expired
+  or stale, both at connect time (`buildRelayModeForAssistant`) and on
+  reconnect (`onReconnect` hook in `createRelayConnection`). The native
+  messaging helper is re-spawned to mint a fresh token — no user
+  interaction required.
+- If the native host is unreachable or the pair endpoint rejects the
+  request, the reconnect loop aborts and the popup enters
+  `auth_required` state. The user must re-pair via the Troubleshooting
+  controls, then click **Connect**.
 
 `/v1/browser-extension-pair` is loopback-only and refuses requests
 from any non-private peer. The capability token is HMAC-SHA256 signed
@@ -180,16 +244,31 @@ The new modules that implement Phase 2:
   hands results to the worker for relay-aware delivery (WS first, HTTP
   fallback in self-hosted mode).
 - **`clients/chrome-extension/background/relay-connection.ts`** —
-  WebSocket relay with heartbeat, reconnect-with-token-refresh, and
-  mode-aware bearer injection.
+  Long-lived WebSocket relay with keepalive heartbeat (20 s interval to
+  prevent MV3 idle suspension), exponential-backoff reconnect (1 s base,
+  30 s cap), structured reconnect-with-refresh lifecycle (token rotation
+  before each reconnect attempt), and mode-aware bearer injection. The
+  `onReconnect` hook supports three outcomes: `keep` (reuse token),
+  `refreshed` (swap in a new token), or `abort` (stop reconnecting and
+  surface auth error to popup).
+- **`clients/chrome-extension/background/cloud-reconnect-decision.ts`** —
+  Pure decision function for cloud reconnect strategy. Distinguishes
+  auth-failure closes (4001/4002/4003/1008) from transient 1006 closes
+  and manages a refresh-attempt budget to avoid silently hammering the
+  gateway. Covered by direct unit tests.
 - **`clients/chrome-extension/native-host/`** — Native messaging helper
-  binary that bootstraps the self-hosted capability token.
+  binary that bootstraps the self-hosted capability token. Invoked
+  automatically by the service worker during connect, reconnect, and
+  auto-connect flows; manual invocation via the popup's Troubleshooting
+  controls is reserved for diagnostics when automatic recovery fails.
 
 Runtime wiring:
 
 - `http-server.ts` open/close handlers for `/v1/browser-relay` register
   the connection in `ChromeExtensionRegistry` on open and unregister on
-  close.
+  close. The inbound frame handler dispatches `keepalive` frames to
+  `registry.touch(connectionId)` to refresh the connection's activity
+  timestamp without log noise.
 - `conversation-routes.ts` turn-start wires a registry-routed
   `hostBrowserSenderOverride` onto the `Conversation` so
   `host_browser_request` frames go to the extension WebSocket instead of
@@ -202,6 +281,23 @@ Runtime wiring:
   only for `host_browser`; macOS returns `true` for all four (bash,
   file, cu, browser).
 
+Extension-side health wiring:
+
+- The worker maintains a `ConnectionHealthState` enum (`paused`,
+  `connecting`, `connected`, `reconnecting`, `auth_required`, `error`)
+  with detail fields (last disconnect code, last error message,
+  timestamp).
+- Health transitions are driven by connect/open/close/pause actions.
+  The `onClose` callback transitions to `reconnecting` on unexpected
+  disconnects and to `auth_required` when the reconnect hook aborts.
+- The popup reads health via the `get_status` message and maps it to
+  concise display states via `popup-state.ts` helpers
+  (`deriveHealthStatusDisplay`, `shouldExpandTroubleshooting`,
+  `healthToPhase`).
+- The Troubleshooting section auto-expands only when health is
+  `auth_required` or `error` — during `connected`, `reconnecting`, and
+  `paused` it stays collapsed to avoid distracting users.
+
 ## Open follow-ups
 
 - Production extension allowlist: the native messaging helper, the
@@ -212,6 +308,37 @@ Runtime wiring:
   if any of the three drifts out of sync, so updating the placeholder
   to the production id must touch all three files plus the test
   constant in lockstep.
+
+## Steady-state contract
+
+After the first successful Connect, the extension operates as a
+background service with no further user interaction required:
+
+1. **Install once**: Load the extension, ensure the native messaging host
+   is installed (the macOS app does this automatically).
+2. **Connect once**: Click Connect in the popup. The worker
+   auto-bootstraps credentials (local pair token or cloud JWT) as part
+   of the single-click flow.
+3. **Forget it**: The extension maintains the relay indefinitely.
+   Keepalive frames prevent MV3 idle suspension. Exponential-backoff
+   reconnect handles transient drops. Silent token refresh re-bootstraps
+   credentials when they expire. The `autoConnect` flag persists across
+   browser sessions so reopening Chrome automatically reconnects.
+
+Users should only interact with the extension again when:
+
+- They want to **Pause** (intentionally disconnect and disable
+  auto-reconnect).
+- The popup shows **Action required** (`auth_required` or `error` health
+  state), meaning automatic recovery has been exhausted.
+
+The `cdp-inspect` backend is **not** a fallback for transient extension
+interruptions. The CDP client factory intentionally skips cdp-inspect
+when the extension proxy exists but is temporarily unavailable, giving
+the extension's automatic recovery time to restore the connection.
+`cdp-inspect` is an advanced, opt-in backend for users who cannot install
+the extension or who need broad session-level CDP access; see
+[Browser Use — `cdp-inspect` Backend](./browser-use-cdp-inspect-backend.md).
 
 ## Known UX considerations
 
@@ -253,4 +380,7 @@ Alternatives considered:
   and avoids the per-tab debugger infobar entirely. It is implemented
   and opt-in via `hostBrowser.cdpInspect.enabled`; see
   [Browser Use — `cdp-inspect` Backend](./browser-use-cdp-inspect-backend.md)
-  for setup, security trade-offs, and troubleshooting.
+  for setup, security trade-offs, and troubleshooting. Note: the
+  `cdp-inspect` backend does **not** activate as a fallback during
+  transient extension disconnects — the extension-first routing logic
+  in the CDP client factory prevents silent backend drift.

--- a/docs/browser-use-cdp-inspect-backend.md
+++ b/docs/browser-use-cdp-inspect-backend.md
@@ -6,6 +6,16 @@ already-running Chrome instance via the DevTools JSON protocol
 that the Chrome extension transport shows, at the cost of broader
 session-level access.
 
+**This is an explicit, advanced backend.** The Chrome extension is the
+default and preferred transport for browser use. The extension maintains a
+long-lived background connection with automatic reconnect and silent token
+refresh, so users never need to fall back to `cdp-inspect` during transient
+extension interruptions. The assistant's CDP client factory enforces this:
+when the extension transport is provisioned for a conversation but
+temporarily unavailable (e.g. mid-reconnect), `cdp-inspect` is
+intentionally skipped in the desktop-auto candidate list to prevent silent
+takeover.
+
 ## Backend comparison
 
 | | **Extension** | **cdp-inspect** | **Local** |
@@ -15,13 +25,14 @@ session-level access.
 | Debugger infobar | Yes (per tab) | No | No (dedicated profile) |
 | Tab scope | Single active tab | Any open tab | Dedicated browser |
 | Auth/session access | Active tab only | All tabs, all cookies | Isolated profile |
-| Selection priority | 1st (highest) | 2nd (when enabled) | 3rd (default) |
+| Selection priority | 1st (highest) | 2nd (when explicitly enabled) | 3rd (default) |
 
 ## When to use this backend
 
 **Prefer the Chrome extension.** It provides the best security boundary
 (single-tab scope, visible debugger infobar, chrome.debugger permission
-model) and requires no special Chrome launch flags.
+model), requires no special Chrome launch flags, and handles all lifecycle
+management automatically (keepalive, reconnect, token refresh).
 
 Use `cdp-inspect` only when:
 
@@ -31,6 +42,27 @@ Use `cdp-inspect` only when:
   that `chrome.debugger.attach` displays.
 - You are running in a headless/CI environment where a user-profile
   Chrome is already running with `--remote-debugging-port`.
+- You are intentionally opting into broad session-level access for
+  advanced debugging or automation workflows.
+
+## Relationship to extension transport
+
+The CDP client factory (`cdp-client/factory.ts`) builds an ordered
+candidate list for each browser tool invocation:
+
+1. **Extension** — always first when the extension proxy is connected.
+2. **cdp-inspect** — included only when *explicitly enabled* in config,
+   OR via the macOS desktop-auto path when no extension proxy exists
+   for the conversation. When the extension proxy exists but is
+   temporarily unavailable (reconnecting), cdp-inspect is deliberately
+   **excluded** to prevent silent backend drift during transient
+   extension disconnects.
+3. **Local** (Playwright) — default fallback.
+
+This means `cdp-inspect` does not silently "take over" when the extension
+has a brief interruption. The extension's automatic recovery (keepalive +
+exponential-backoff reconnect + silent token refresh) is given time to
+restore the connection before any fallback is considered.
 
 ## Security considerations
 


### PR DESCRIPTION
## Summary
- Update extension README to describe long-lived background behavior and auto-reconnect
- Clarify native pairing as automatic maintenance path in native-host README
- Reflect extension-first routing and cdp-inspect as explicit/advanced path in browser backend docs
- Refresh Phase 2 architecture doc with keepalive, health state, and popup changes

Part of plan: seamless-browser-extension-ux.md (PR 7 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24819" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
