### PR TITLE
Add assistant STT contracts and daemon batch transcription facade

### DIFF
--- a/assistant/src/providers/speech-to-text/resolve.ts
+++ b/assistant/src/providers/speech-to-text/resolve.ts
@@ -1,18 +1,19 @@
-import { resolveDaemonBatchTranscriber } from "../../stt/daemon-batch-transcriber.js";
+import { getProviderKeyAsync } from "../../security/secure-keys.js";
+import { createDaemonBatchTranscriber } from "../../stt/daemon-batch-transcriber.js";
 import type { SpeechToTextProvider } from "./types.js";
 
 /**
  * Resolve a `SpeechToTextProvider` for daemon-hosted batch transcription.
  *
  * Delegates to the daemon batch transcriber facade so that the provider
- * construction and credential lookup are centralized. The returned object
- * satisfies the existing `SpeechToTextProvider` interface so that all
- * current callsites continue working without changes.
+ * construction is centralized. Credential lookup stays here (an authorized
+ * secure-keys importer) and the API key is passed through.
  *
  * Returns `null` when no STT credentials are configured.
  */
 export async function resolveSpeechToTextProvider(): Promise<SpeechToTextProvider | null> {
-  const transcriber = await resolveDaemonBatchTranscriber();
+  const apiKey = await getProviderKeyAsync("openai");
+  const transcriber = createDaemonBatchTranscriber(apiKey);
   if (!transcriber) return null;
 
   // Adapt the BatchTranscriber interface to the legacy SpeechToTextProvider

--- a/assistant/src/providers/speech-to-text/resolve.ts
+++ b/assistant/src/providers/speech-to-text/resolve.ts
@@ -1,9 +1,25 @@
-import { getProviderKeyAsync } from "../../security/secure-keys.js";
-import { OpenAIWhisperProvider } from "./openai-whisper.js";
+import { resolveDaemonBatchTranscriber } from "../../stt/daemon-batch-transcriber.js";
 import type { SpeechToTextProvider } from "./types.js";
 
+/**
+ * Resolve a `SpeechToTextProvider` for daemon-hosted batch transcription.
+ *
+ * Delegates to the daemon batch transcriber facade so that the provider
+ * construction and credential lookup are centralized. The returned object
+ * satisfies the existing `SpeechToTextProvider` interface so that all
+ * current callsites continue working without changes.
+ *
+ * Returns `null` when no STT credentials are configured.
+ */
 export async function resolveSpeechToTextProvider(): Promise<SpeechToTextProvider | null> {
-  const apiKey = await getProviderKeyAsync("openai");
-  if (!apiKey) return null;
-  return new OpenAIWhisperProvider(apiKey);
+  const transcriber = await resolveDaemonBatchTranscriber();
+  if (!transcriber) return null;
+
+  // Adapt the BatchTranscriber interface to the legacy SpeechToTextProvider
+  // contract expected by existing callers.
+  return {
+    async transcribe(audio: Buffer, mimeType: string, signal?: AbortSignal) {
+      return transcriber.transcribe({ audio, mimeType, signal });
+    },
+  };
 }

--- a/assistant/src/stt/__tests__/daemon-batch-transcriber.test.ts
+++ b/assistant/src/stt/__tests__/daemon-batch-transcriber.test.ts
@@ -1,0 +1,249 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { SttError } from "../types.js";
+
+// ---------------------------------------------------------------------------
+// Module mocks — must precede dynamic imports
+// ---------------------------------------------------------------------------
+
+let mockOpenAIKey: string | undefined;
+
+mock.module("../../security/secure-keys.js", () => ({
+  getProviderKeyAsync: async (provider: string) =>
+    provider === "openai" ? mockOpenAIKey : undefined,
+}));
+
+let mockTranscribeResult: { text: string } = { text: "" };
+let mockTranscribeError: Error | null = null;
+
+mock.module("../../providers/speech-to-text/openai-whisper.js", () => ({
+  OpenAIWhisperProvider: class MockWhisperProvider {
+    constructor(_apiKey: string) {}
+    async transcribe(_audio: Buffer, _mimeType: string, _signal?: AbortSignal) {
+      if (mockTranscribeError) throw mockTranscribeError;
+      return mockTranscribeResult;
+    }
+  },
+}));
+
+// Dynamic import so mocks are active when the module loads.
+const { resolveDaemonBatchTranscriber } =
+  await import("../daemon-batch-transcriber.js");
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("resolveDaemonBatchTranscriber", () => {
+  beforeEach(() => {
+    mockOpenAIKey = undefined;
+    mockTranscribeResult = { text: "" };
+    mockTranscribeError = null;
+  });
+
+  // -------------------------------------------------------------------------
+  // Credential resolution
+  // -------------------------------------------------------------------------
+
+  test("returns null when no OpenAI key is configured", async () => {
+    mockOpenAIKey = undefined;
+    const transcriber = await resolveDaemonBatchTranscriber();
+    expect(transcriber).toBeNull();
+  });
+
+  test("returns a BatchTranscriber when OpenAI key is present", async () => {
+    mockOpenAIKey = "sk-test-key";
+    const transcriber = await resolveDaemonBatchTranscriber();
+    expect(transcriber).not.toBeNull();
+  });
+
+  // -------------------------------------------------------------------------
+  // Provider identity
+  // -------------------------------------------------------------------------
+
+  test("reports providerId as openai-whisper", async () => {
+    mockOpenAIKey = "sk-test-key";
+    const transcriber = await resolveDaemonBatchTranscriber();
+    expect(transcriber!.providerId).toBe("openai-whisper");
+  });
+
+  test("reports boundaryId as daemon-batch", async () => {
+    mockOpenAIKey = "sk-test-key";
+    const transcriber = await resolveDaemonBatchTranscriber();
+    expect(transcriber!.boundaryId).toBe("daemon-batch");
+  });
+
+  // -------------------------------------------------------------------------
+  // Successful transcription
+  // -------------------------------------------------------------------------
+
+  test("delegates transcription to the underlying provider", async () => {
+    mockOpenAIKey = "sk-test-key";
+    mockTranscribeResult = { text: "Hello from Whisper" };
+
+    const transcriber = await resolveDaemonBatchTranscriber();
+    const result = await transcriber!.transcribe({
+      audio: Buffer.from("fake-audio"),
+      mimeType: "audio/ogg",
+    });
+
+    expect(result).toEqual({ text: "Hello from Whisper" });
+  });
+
+  // -------------------------------------------------------------------------
+  // Normalized error mapping
+  // -------------------------------------------------------------------------
+
+  test("normalizes AbortError to timeout category", async () => {
+    mockOpenAIKey = "sk-test-key";
+    mockTranscribeError = new DOMException(
+      "The operation was aborted",
+      "AbortError",
+    );
+
+    const transcriber = await resolveDaemonBatchTranscriber();
+
+    try {
+      await transcriber!.transcribe({
+        audio: Buffer.from("audio"),
+        mimeType: "audio/wav",
+      });
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(SttError);
+      expect((err as SttError).category).toBe("timeout");
+    }
+  });
+
+  test("normalizes 401 errors to auth category", async () => {
+    mockOpenAIKey = "sk-test-key";
+    mockTranscribeError = new Error("Whisper API error (401): Unauthorized");
+
+    const transcriber = await resolveDaemonBatchTranscriber();
+
+    try {
+      await transcriber!.transcribe({
+        audio: Buffer.from("audio"),
+        mimeType: "audio/wav",
+      });
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(SttError);
+      expect((err as SttError).category).toBe("auth");
+    }
+  });
+
+  test("normalizes 403 errors to auth category", async () => {
+    mockOpenAIKey = "sk-test-key";
+    mockTranscribeError = new Error("Whisper API error (403): Forbidden");
+
+    const transcriber = await resolveDaemonBatchTranscriber();
+
+    try {
+      await transcriber!.transcribe({
+        audio: Buffer.from("audio"),
+        mimeType: "audio/wav",
+      });
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(SttError);
+      expect((err as SttError).category).toBe("auth");
+    }
+  });
+
+  test("normalizes 429 errors to rate-limit category", async () => {
+    mockOpenAIKey = "sk-test-key";
+    mockTranscribeError = new Error(
+      "Whisper API error (429): Too Many Requests",
+    );
+
+    const transcriber = await resolveDaemonBatchTranscriber();
+
+    try {
+      await transcriber!.transcribe({
+        audio: Buffer.from("audio"),
+        mimeType: "audio/wav",
+      });
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(SttError);
+      expect((err as SttError).category).toBe("rate-limit");
+    }
+  });
+
+  test("normalizes rate limit text to rate-limit category", async () => {
+    mockOpenAIKey = "sk-test-key";
+    mockTranscribeError = new Error("Request rate-limited by provider");
+
+    const transcriber = await resolveDaemonBatchTranscriber();
+
+    try {
+      await transcriber!.transcribe({
+        audio: Buffer.from("audio"),
+        mimeType: "audio/wav",
+      });
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(SttError);
+      expect((err as SttError).category).toBe("rate-limit");
+    }
+  });
+
+  test("normalizes 400 audio errors to invalid-audio category", async () => {
+    mockOpenAIKey = "sk-test-key";
+    mockTranscribeError = new Error(
+      "Whisper API error (400): Invalid audio format",
+    );
+
+    const transcriber = await resolveDaemonBatchTranscriber();
+
+    try {
+      await transcriber!.transcribe({
+        audio: Buffer.from("audio"),
+        mimeType: "audio/wav",
+      });
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(SttError);
+      expect((err as SttError).category).toBe("invalid-audio");
+    }
+  });
+
+  test("normalizes unknown errors to provider-error category", async () => {
+    mockOpenAIKey = "sk-test-key";
+    mockTranscribeError = new Error("Something went wrong");
+
+    const transcriber = await resolveDaemonBatchTranscriber();
+
+    try {
+      await transcriber!.transcribe({
+        audio: Buffer.from("audio"),
+        mimeType: "audio/wav",
+      });
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(SttError);
+      expect((err as SttError).category).toBe("provider-error");
+    }
+  });
+
+  test("passes through SttError instances without re-wrapping", async () => {
+    mockOpenAIKey = "sk-test-key";
+    const original = new SttError("auth", "Custom auth failure");
+    mockTranscribeError = original;
+
+    const transcriber = await resolveDaemonBatchTranscriber();
+
+    try {
+      await transcriber!.transcribe({
+        audio: Buffer.from("audio"),
+        mimeType: "audio/wav",
+      });
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBe(original);
+      expect((err as SttError).category).toBe("auth");
+      expect((err as SttError).message).toBe("Custom auth failure");
+    }
+  });
+});

--- a/assistant/src/stt/__tests__/daemon-batch-transcriber.test.ts
+++ b/assistant/src/stt/__tests__/daemon-batch-transcriber.test.ts
@@ -6,13 +6,6 @@ import { SttError } from "../types.js";
 // Module mocks — must precede dynamic imports
 // ---------------------------------------------------------------------------
 
-let mockOpenAIKey: string | undefined;
-
-mock.module("../../security/secure-keys.js", () => ({
-  getProviderKeyAsync: async (provider: string) =>
-    provider === "openai" ? mockOpenAIKey : undefined,
-}));
-
 let mockTranscribeResult: { text: string } = { text: "" };
 let mockTranscribeError: Error | null = null;
 
@@ -27,16 +20,15 @@ mock.module("../../providers/speech-to-text/openai-whisper.js", () => ({
 }));
 
 // Dynamic import so mocks are active when the module loads.
-const { resolveDaemonBatchTranscriber } =
+const { createDaemonBatchTranscriber } =
   await import("../daemon-batch-transcriber.js");
 
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
-describe("resolveDaemonBatchTranscriber", () => {
+describe("createDaemonBatchTranscriber", () => {
   beforeEach(() => {
-    mockOpenAIKey = undefined;
     mockTranscribeResult = { text: "" };
     mockTranscribeError = null;
   });
@@ -45,15 +37,13 @@ describe("resolveDaemonBatchTranscriber", () => {
   // Credential resolution
   // -------------------------------------------------------------------------
 
-  test("returns null when no OpenAI key is configured", async () => {
-    mockOpenAIKey = undefined;
-    const transcriber = await resolveDaemonBatchTranscriber();
-    expect(transcriber).toBeNull();
+  test("returns null when no API key is provided", () => {
+    expect(createDaemonBatchTranscriber(null)).toBeNull();
+    expect(createDaemonBatchTranscriber(undefined)).toBeNull();
   });
 
-  test("returns a BatchTranscriber when OpenAI key is present", async () => {
-    mockOpenAIKey = "sk-test-key";
-    const transcriber = await resolveDaemonBatchTranscriber();
+  test("returns a BatchTranscriber when API key is present", () => {
+    const transcriber = createDaemonBatchTranscriber("sk-test-key");
     expect(transcriber).not.toBeNull();
   });
 
@@ -61,15 +51,13 @@ describe("resolveDaemonBatchTranscriber", () => {
   // Provider identity
   // -------------------------------------------------------------------------
 
-  test("reports providerId as openai-whisper", async () => {
-    mockOpenAIKey = "sk-test-key";
-    const transcriber = await resolveDaemonBatchTranscriber();
+  test("reports providerId as openai-whisper", () => {
+    const transcriber = createDaemonBatchTranscriber("sk-test-key");
     expect(transcriber!.providerId).toBe("openai-whisper");
   });
 
-  test("reports boundaryId as daemon-batch", async () => {
-    mockOpenAIKey = "sk-test-key";
-    const transcriber = await resolveDaemonBatchTranscriber();
+  test("reports boundaryId as daemon-batch", () => {
+    const transcriber = createDaemonBatchTranscriber("sk-test-key");
     expect(transcriber!.boundaryId).toBe("daemon-batch");
   });
 
@@ -78,10 +66,9 @@ describe("resolveDaemonBatchTranscriber", () => {
   // -------------------------------------------------------------------------
 
   test("delegates transcription to the underlying provider", async () => {
-    mockOpenAIKey = "sk-test-key";
     mockTranscribeResult = { text: "Hello from Whisper" };
 
-    const transcriber = await resolveDaemonBatchTranscriber();
+    const transcriber = createDaemonBatchTranscriber("sk-test-key");
     const result = await transcriber!.transcribe({
       audio: Buffer.from("fake-audio"),
       mimeType: "audio/ogg",
@@ -95,13 +82,12 @@ describe("resolveDaemonBatchTranscriber", () => {
   // -------------------------------------------------------------------------
 
   test("normalizes AbortError to timeout category", async () => {
-    mockOpenAIKey = "sk-test-key";
     mockTranscribeError = new DOMException(
       "The operation was aborted",
       "AbortError",
     );
 
-    const transcriber = await resolveDaemonBatchTranscriber();
+    const transcriber = createDaemonBatchTranscriber("sk-test-key");
 
     try {
       await transcriber!.transcribe({
@@ -116,10 +102,9 @@ describe("resolveDaemonBatchTranscriber", () => {
   });
 
   test("normalizes 401 errors to auth category", async () => {
-    mockOpenAIKey = "sk-test-key";
     mockTranscribeError = new Error("Whisper API error (401): Unauthorized");
 
-    const transcriber = await resolveDaemonBatchTranscriber();
+    const transcriber = createDaemonBatchTranscriber("sk-test-key");
 
     try {
       await transcriber!.transcribe({
@@ -134,10 +119,9 @@ describe("resolveDaemonBatchTranscriber", () => {
   });
 
   test("normalizes 403 errors to auth category", async () => {
-    mockOpenAIKey = "sk-test-key";
     mockTranscribeError = new Error("Whisper API error (403): Forbidden");
 
-    const transcriber = await resolveDaemonBatchTranscriber();
+    const transcriber = createDaemonBatchTranscriber("sk-test-key");
 
     try {
       await transcriber!.transcribe({
@@ -152,12 +136,11 @@ describe("resolveDaemonBatchTranscriber", () => {
   });
 
   test("normalizes 429 errors to rate-limit category", async () => {
-    mockOpenAIKey = "sk-test-key";
     mockTranscribeError = new Error(
       "Whisper API error (429): Too Many Requests",
     );
 
-    const transcriber = await resolveDaemonBatchTranscriber();
+    const transcriber = createDaemonBatchTranscriber("sk-test-key");
 
     try {
       await transcriber!.transcribe({
@@ -172,10 +155,9 @@ describe("resolveDaemonBatchTranscriber", () => {
   });
 
   test("normalizes rate limit text to rate-limit category", async () => {
-    mockOpenAIKey = "sk-test-key";
     mockTranscribeError = new Error("Request rate-limited by provider");
 
-    const transcriber = await resolveDaemonBatchTranscriber();
+    const transcriber = createDaemonBatchTranscriber("sk-test-key");
 
     try {
       await transcriber!.transcribe({
@@ -190,12 +172,11 @@ describe("resolveDaemonBatchTranscriber", () => {
   });
 
   test("normalizes 400 audio errors to invalid-audio category", async () => {
-    mockOpenAIKey = "sk-test-key";
     mockTranscribeError = new Error(
       "Whisper API error (400): Invalid audio format",
     );
 
-    const transcriber = await resolveDaemonBatchTranscriber();
+    const transcriber = createDaemonBatchTranscriber("sk-test-key");
 
     try {
       await transcriber!.transcribe({
@@ -210,10 +191,9 @@ describe("resolveDaemonBatchTranscriber", () => {
   });
 
   test("normalizes unknown errors to provider-error category", async () => {
-    mockOpenAIKey = "sk-test-key";
     mockTranscribeError = new Error("Something went wrong");
 
-    const transcriber = await resolveDaemonBatchTranscriber();
+    const transcriber = createDaemonBatchTranscriber("sk-test-key");
 
     try {
       await transcriber!.transcribe({
@@ -228,11 +208,10 @@ describe("resolveDaemonBatchTranscriber", () => {
   });
 
   test("passes through SttError instances without re-wrapping", async () => {
-    mockOpenAIKey = "sk-test-key";
     const original = new SttError("auth", "Custom auth failure");
     mockTranscribeError = original;
 
-    const transcriber = await resolveDaemonBatchTranscriber();
+    const transcriber = createDaemonBatchTranscriber("sk-test-key");
 
     try {
       await transcriber!.transcribe({

--- a/assistant/src/stt/__tests__/daemon-batch-transcriber.test.ts
+++ b/assistant/src/stt/__tests__/daemon-batch-transcriber.test.ts
@@ -20,7 +20,7 @@ mock.module("../../providers/speech-to-text/openai-whisper.js", () => ({
 }));
 
 // Dynamic import so mocks are active when the module loads.
-const { createDaemonBatchTranscriber } =
+const { createDaemonBatchTranscriber, normalizeSttError } =
   await import("../daemon-batch-transcriber.js");
 
 // ---------------------------------------------------------------------------
@@ -78,137 +78,15 @@ describe("createDaemonBatchTranscriber", () => {
   });
 
   // -------------------------------------------------------------------------
-  // Normalized error mapping
+  // Error propagation — raw provider errors pass through unchanged so that
+  // legacy callers (e.g. transcribe-audio.ts) can still detect AbortError.
   // -------------------------------------------------------------------------
 
-  test("normalizes AbortError to timeout category", async () => {
-    mockTranscribeError = new DOMException(
+  test("propagates AbortError unchanged", async () => {
+    const original = new DOMException(
       "The operation was aborted",
       "AbortError",
     );
-
-    const transcriber = createDaemonBatchTranscriber("sk-test-key");
-
-    try {
-      await transcriber!.transcribe({
-        audio: Buffer.from("audio"),
-        mimeType: "audio/wav",
-      });
-      expect.unreachable("should have thrown");
-    } catch (err) {
-      expect(err).toBeInstanceOf(SttError);
-      expect((err as SttError).category).toBe("timeout");
-    }
-  });
-
-  test("normalizes 401 errors to auth category", async () => {
-    mockTranscribeError = new Error("Whisper API error (401): Unauthorized");
-
-    const transcriber = createDaemonBatchTranscriber("sk-test-key");
-
-    try {
-      await transcriber!.transcribe({
-        audio: Buffer.from("audio"),
-        mimeType: "audio/wav",
-      });
-      expect.unreachable("should have thrown");
-    } catch (err) {
-      expect(err).toBeInstanceOf(SttError);
-      expect((err as SttError).category).toBe("auth");
-    }
-  });
-
-  test("normalizes 403 errors to auth category", async () => {
-    mockTranscribeError = new Error("Whisper API error (403): Forbidden");
-
-    const transcriber = createDaemonBatchTranscriber("sk-test-key");
-
-    try {
-      await transcriber!.transcribe({
-        audio: Buffer.from("audio"),
-        mimeType: "audio/wav",
-      });
-      expect.unreachable("should have thrown");
-    } catch (err) {
-      expect(err).toBeInstanceOf(SttError);
-      expect((err as SttError).category).toBe("auth");
-    }
-  });
-
-  test("normalizes 429 errors to rate-limit category", async () => {
-    mockTranscribeError = new Error(
-      "Whisper API error (429): Too Many Requests",
-    );
-
-    const transcriber = createDaemonBatchTranscriber("sk-test-key");
-
-    try {
-      await transcriber!.transcribe({
-        audio: Buffer.from("audio"),
-        mimeType: "audio/wav",
-      });
-      expect.unreachable("should have thrown");
-    } catch (err) {
-      expect(err).toBeInstanceOf(SttError);
-      expect((err as SttError).category).toBe("rate-limit");
-    }
-  });
-
-  test("normalizes rate limit text to rate-limit category", async () => {
-    mockTranscribeError = new Error("Request rate-limited by provider");
-
-    const transcriber = createDaemonBatchTranscriber("sk-test-key");
-
-    try {
-      await transcriber!.transcribe({
-        audio: Buffer.from("audio"),
-        mimeType: "audio/wav",
-      });
-      expect.unreachable("should have thrown");
-    } catch (err) {
-      expect(err).toBeInstanceOf(SttError);
-      expect((err as SttError).category).toBe("rate-limit");
-    }
-  });
-
-  test("normalizes 400 audio errors to invalid-audio category", async () => {
-    mockTranscribeError = new Error(
-      "Whisper API error (400): Invalid audio format",
-    );
-
-    const transcriber = createDaemonBatchTranscriber("sk-test-key");
-
-    try {
-      await transcriber!.transcribe({
-        audio: Buffer.from("audio"),
-        mimeType: "audio/wav",
-      });
-      expect.unreachable("should have thrown");
-    } catch (err) {
-      expect(err).toBeInstanceOf(SttError);
-      expect((err as SttError).category).toBe("invalid-audio");
-    }
-  });
-
-  test("normalizes unknown errors to provider-error category", async () => {
-    mockTranscribeError = new Error("Something went wrong");
-
-    const transcriber = createDaemonBatchTranscriber("sk-test-key");
-
-    try {
-      await transcriber!.transcribe({
-        audio: Buffer.from("audio"),
-        mimeType: "audio/wav",
-      });
-      expect.unreachable("should have thrown");
-    } catch (err) {
-      expect(err).toBeInstanceOf(SttError);
-      expect((err as SttError).category).toBe("provider-error");
-    }
-  });
-
-  test("passes through SttError instances without re-wrapping", async () => {
-    const original = new SttError("auth", "Custom auth failure");
     mockTranscribeError = original;
 
     const transcriber = createDaemonBatchTranscriber("sk-test-key");
@@ -221,8 +99,90 @@ describe("createDaemonBatchTranscriber", () => {
       expect.unreachable("should have thrown");
     } catch (err) {
       expect(err).toBe(original);
-      expect((err as SttError).category).toBe("auth");
-      expect((err as SttError).message).toBe("Custom auth failure");
+      expect((err as Error).name).toBe("AbortError");
     }
+  });
+
+  test("propagates generic errors unchanged", async () => {
+    const original = new Error("Something went wrong");
+    mockTranscribeError = original;
+
+    const transcriber = createDaemonBatchTranscriber("sk-test-key");
+
+    try {
+      await transcriber!.transcribe({
+        audio: Buffer.from("audio"),
+        mimeType: "audio/wav",
+      });
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBe(original);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// normalizeSttError — callers use this explicitly when they need categories
+// ---------------------------------------------------------------------------
+
+describe("normalizeSttError", () => {
+  test("normalizes AbortError to timeout category", () => {
+    const err = new DOMException("The operation was aborted", "AbortError");
+    const result = normalizeSttError(err);
+    expect(result).toBeInstanceOf(SttError);
+    expect(result.category).toBe("timeout");
+  });
+
+  test("normalizes 401 errors to auth category", () => {
+    const result = normalizeSttError(
+      new Error("Whisper API error (401): Unauthorized"),
+    );
+    expect(result).toBeInstanceOf(SttError);
+    expect(result.category).toBe("auth");
+  });
+
+  test("normalizes 403 errors to auth category", () => {
+    const result = normalizeSttError(
+      new Error("Whisper API error (403): Forbidden"),
+    );
+    expect(result).toBeInstanceOf(SttError);
+    expect(result.category).toBe("auth");
+  });
+
+  test("normalizes 429 errors to rate-limit category", () => {
+    const result = normalizeSttError(
+      new Error("Whisper API error (429): Too Many Requests"),
+    );
+    expect(result).toBeInstanceOf(SttError);
+    expect(result.category).toBe("rate-limit");
+  });
+
+  test("normalizes rate limit text to rate-limit category", () => {
+    const result = normalizeSttError(
+      new Error("Request rate-limited by provider"),
+    );
+    expect(result).toBeInstanceOf(SttError);
+    expect(result.category).toBe("rate-limit");
+  });
+
+  test("normalizes 400 audio errors to invalid-audio category", () => {
+    const result = normalizeSttError(
+      new Error("Whisper API error (400): Invalid audio format"),
+    );
+    expect(result).toBeInstanceOf(SttError);
+    expect(result.category).toBe("invalid-audio");
+  });
+
+  test("normalizes unknown errors to provider-error category", () => {
+    const result = normalizeSttError(new Error("Something went wrong"));
+    expect(result).toBeInstanceOf(SttError);
+    expect(result.category).toBe("provider-error");
+  });
+
+  test("passes through SttError instances without re-wrapping", () => {
+    const original = new SttError("auth", "Custom auth failure");
+    const result = normalizeSttError(original);
+    expect(result).toBe(original);
+    expect(result.category).toBe("auth");
   });
 });

--- a/assistant/src/stt/daemon-batch-transcriber.ts
+++ b/assistant/src/stt/daemon-batch-transcriber.ts
@@ -24,8 +24,12 @@ import { SttError } from "./types.js";
 // ---------------------------------------------------------------------------
 
 /**
- * Wraps `OpenAIWhisperProvider` behind the `BatchTranscriber` contract and
- * normalizes its errors into `SttError` categories.
+ * Wraps `OpenAIWhisperProvider` behind the `BatchTranscriber` contract.
+ *
+ * Raw provider errors propagate unchanged so that legacy callers (e.g.
+ * `transcribe-audio.ts`) can continue detecting `AbortError` by name.
+ * Callers that want normalized categories should wrap calls with
+ * {@link normalizeSttError}.
  */
 class WhisperBatchTranscriber implements BatchTranscriber {
   readonly providerId = "openai-whisper" as const;
@@ -46,15 +50,7 @@ class WhisperBatchTranscriber implements BatchTranscriber {
       await import("../providers/speech-to-text/openai-whisper.js");
     const provider = new OpenAIWhisperProvider(this.apiKey);
 
-    try {
-      return await provider.transcribe(
-        request.audio,
-        request.mimeType,
-        request.signal,
-      );
-    } catch (err: unknown) {
-      throw normalizeSttError(err);
-    }
+    return provider.transcribe(request.audio, request.mimeType, request.signal);
   }
 }
 
@@ -62,7 +58,13 @@ class WhisperBatchTranscriber implements BatchTranscriber {
 // Error normalization
 // ---------------------------------------------------------------------------
 
-function normalizeSttError(err: unknown): SttError {
+/**
+ * Map a raw provider error into an {@link SttError} with a normalized category.
+ *
+ * Callers that need structured error categories should wrap
+ * `BatchTranscriber.transcribe()` calls with this utility.
+ */
+export function normalizeSttError(err: unknown): SttError {
   if (err instanceof SttError) return err;
 
   const message = err instanceof Error ? err.message : String(err);

--- a/assistant/src/stt/daemon-batch-transcriber.ts
+++ b/assistant/src/stt/daemon-batch-transcriber.ts
@@ -1,0 +1,108 @@
+/**
+ * Daemon batch transcriber facade.
+ *
+ * Provides a single resolver that returns a `BatchTranscriber` implementation
+ * when provider credentials are available, or `null` when no STT backend can
+ * be configured. Callers use this instead of constructing provider classes
+ * directly.
+ *
+ * Currently the only daemon-batch provider is OpenAI Whisper. As new providers
+ * are added, this module can select the appropriate adapter based on
+ * configuration or feature flags.
+ */
+
+import { getProviderKeyAsync } from "../security/secure-keys.js";
+import type {
+  BatchTranscriber,
+  SttTranscribeRequest,
+  SttTranscribeResult,
+} from "./types.js";
+import { SttError } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// OpenAI Whisper adapter — implements BatchTranscriber on top of the existing
+// OpenAIWhisperProvider low-level class.
+// ---------------------------------------------------------------------------
+
+/**
+ * Wraps `OpenAIWhisperProvider` behind the `BatchTranscriber` contract and
+ * normalizes its errors into `SttError` categories.
+ */
+class WhisperBatchTranscriber implements BatchTranscriber {
+  readonly providerId = "openai-whisper" as const;
+  readonly boundaryId = "daemon-batch" as const;
+
+  private readonly apiKey: string;
+
+  constructor(apiKey: string) {
+    this.apiKey = apiKey;
+  }
+
+  async transcribe(
+    request: SttTranscribeRequest,
+  ): Promise<SttTranscribeResult> {
+    // Lazy-import so the module graph stays lightweight for callers that
+    // only need the resolver, not the provider.
+    const { OpenAIWhisperProvider } =
+      await import("../providers/speech-to-text/openai-whisper.js");
+    const provider = new OpenAIWhisperProvider(this.apiKey);
+
+    try {
+      return await provider.transcribe(
+        request.audio,
+        request.mimeType,
+        request.signal,
+      );
+    } catch (err: unknown) {
+      throw normalizeSttError(err);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Error normalization
+// ---------------------------------------------------------------------------
+
+function normalizeSttError(err: unknown): SttError {
+  if (err instanceof SttError) return err;
+
+  const message = err instanceof Error ? err.message : String(err);
+
+  // Abort / timeout
+  if (err instanceof Error && err.name === "AbortError") {
+    return new SttError("timeout", message);
+  }
+
+  // Auth (401 / 403)
+  if (/\b40[13]\b/.test(message)) {
+    return new SttError("auth", message);
+  }
+
+  // Rate limit (429)
+  if (/\b429\b/.test(message) || /rate.?limit/i.test(message)) {
+    return new SttError("rate-limit", message);
+  }
+
+  // Invalid audio (400 with recognisable hints)
+  if (/\b400\b/.test(message) && /audio|format|file/i.test(message)) {
+    return new SttError("invalid-audio", message);
+  }
+
+  return new SttError("provider-error", message);
+}
+
+// ---------------------------------------------------------------------------
+// Public resolver / factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve a `BatchTranscriber` for the daemon-batch boundary.
+ *
+ * Returns `null` when the required provider credentials are not configured,
+ * signalling to the caller that batch transcription is unavailable.
+ */
+export async function resolveDaemonBatchTranscriber(): Promise<BatchTranscriber | null> {
+  const apiKey = await getProviderKeyAsync("openai");
+  if (!apiKey) return null;
+  return new WhisperBatchTranscriber(apiKey);
+}

--- a/assistant/src/stt/daemon-batch-transcriber.ts
+++ b/assistant/src/stt/daemon-batch-transcriber.ts
@@ -11,7 +11,6 @@
  * configuration or feature flags.
  */
 
-import { getProviderKeyAsync } from "../security/secure-keys.js";
 import type {
   BatchTranscriber,
   SttTranscribeRequest,
@@ -96,13 +95,18 @@ function normalizeSttError(err: unknown): SttError {
 // ---------------------------------------------------------------------------
 
 /**
- * Resolve a `BatchTranscriber` for the daemon-batch boundary.
+ * Create a `BatchTranscriber` for the daemon-batch boundary.
  *
- * Returns `null` when the required provider credentials are not configured,
- * signalling to the caller that batch transcription is unavailable.
+ * Callers provide the API key (obtained via the authorized secure-keys
+ * importer in `providers/speech-to-text/resolve.ts`) so that this module
+ * doesn't need to import secure-keys directly.
+ *
+ * Returns `null` when `apiKey` is falsy, signalling to the caller that
+ * batch transcription is unavailable.
  */
-export async function resolveDaemonBatchTranscriber(): Promise<BatchTranscriber | null> {
-  const apiKey = await getProviderKeyAsync("openai");
+export function createDaemonBatchTranscriber(
+  apiKey: string | null | undefined,
+): BatchTranscriber | null {
   if (!apiKey) return null;
   return new WhisperBatchTranscriber(apiKey);
 }

--- a/assistant/src/stt/types.ts
+++ b/assistant/src/stt/types.ts
@@ -1,0 +1,104 @@
+/**
+ * Provider-agnostic speech-to-text domain types for daemon batch transcription.
+ *
+ * These types define the boundary between callers that need audio transcription
+ * and the concrete STT provider implementations. The goal is to let daemon
+ * callsites program against a single typed interface so that provider swaps are
+ * localized to the adapter layer.
+ */
+
+// ---------------------------------------------------------------------------
+// Provider identity
+// ---------------------------------------------------------------------------
+
+/**
+ * Canonical provider identifiers for daemon-hosted batch STT backends.
+ * Extend this union as new providers are integrated.
+ */
+export type SttProviderId = "openai-whisper";
+
+// ---------------------------------------------------------------------------
+// Boundary identifier
+// ---------------------------------------------------------------------------
+
+/**
+ * Runtime boundary through which STT is executed.
+ * - `daemon-batch` — transcription runs in the daemon process via a REST API
+ *   call to the provider (e.g. OpenAI Whisper).
+ */
+export type SttBoundaryId = "daemon-batch";
+
+// ---------------------------------------------------------------------------
+// Request / result
+// ---------------------------------------------------------------------------
+
+/** Input to a batch transcription call. */
+export interface SttTranscribeRequest {
+  /** Raw audio data (WAV, OGG, MP3, etc.). */
+  audio: Buffer;
+  /** MIME type of the audio data (e.g. "audio/ogg", "audio/wav"). */
+  mimeType: string;
+  /** Optional abort signal for cancellation / timeout. */
+  signal?: AbortSignal;
+}
+
+/** Successful transcription output. */
+export interface SttTranscribeResult {
+  /** The transcribed text, trimmed. Empty string for silence. */
+  text: string;
+}
+
+// ---------------------------------------------------------------------------
+// Normalized error categories
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalized error categories that callers can branch on without coupling to
+ * provider-specific error shapes or HTTP status codes.
+ */
+export type SttErrorCategory =
+  /** The provider rejected the request due to invalid or missing credentials. */
+  | "auth"
+  /** The provider rate-limited the request. */
+  | "rate-limit"
+  /** The request or response timed out. */
+  | "timeout"
+  /** The audio payload was rejected (unsupported format, too large, etc.). */
+  | "invalid-audio"
+  /** Any other provider-side or network failure. */
+  | "provider-error";
+
+/** A transcription error enriched with a normalized category. */
+export class SttError extends Error {
+  readonly category: SttErrorCategory;
+
+  constructor(category: SttErrorCategory, message: string) {
+    super(message);
+    this.name = "SttError";
+    this.category = category;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Batch transcriber interface
+// ---------------------------------------------------------------------------
+
+/**
+ * Daemon-hosted batch transcriber contract.
+ *
+ * Implementations accept a buffer of audio data and return a transcription
+ * result. Errors are thrown as `SttError` instances with a normalized category
+ * so callers can handle failures uniformly across providers.
+ */
+export interface BatchTranscriber {
+  /** Which provider backs this transcriber. */
+  readonly providerId: SttProviderId;
+  /** Which runtime boundary this transcriber operates in. */
+  readonly boundaryId: SttBoundaryId;
+
+  /**
+   * Transcribe a chunk of audio.
+   * @throws {SttError} on any transcription failure.
+   */
+  transcribe(request: SttTranscribeRequest): Promise<SttTranscribeResult>;
+}


### PR DESCRIPTION
## Summary
- Introduce provider-agnostic STT domain types for daemon batch transcription
- Add daemon batch transcriber facade with credential-based resolver
- Refactor speech-to-text provider resolution to delegate through the new facade

Part of plan: initial-stt-unification.md (PR 1 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24820" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
