### PR TITLE
Introduce telephony STT profile adapter for call configuration

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -43,6 +43,7 @@ mock.module("../util/logger.js", () => ({
   getLogger: () => makeLoggerStub(),
 }));
 
+import { resolveTelephonySttProfile } from "../calls/stt-profile.js";
 import {
   buildElevenLabsVoiceSpec,
   resolveVoiceQualityProfile,
@@ -1151,6 +1152,102 @@ describe("resolveVoiceQualityProfile", () => {
     });
     const profile = resolveVoiceQualityProfile(config);
     expect(profile.voice).toBe("abc123-turbo_v2_5-0.9_0.8_0.9");
+  });
+
+  test("Deepgram defaults speechModel to nova-3 via STT profile adapter", () => {
+    const config = AssistantConfigSchema.parse({});
+    const profile = resolveVoiceQualityProfile(config);
+    expect(profile.transcriptionProvider).toBe("Deepgram");
+    expect(profile.speechModel).toBe("nova-3");
+  });
+
+  test("Google leaves speechModel undefined via STT profile adapter", () => {
+    const config = AssistantConfigSchema.parse({
+      calls: { voice: { transcriptionProvider: "Google" } },
+    });
+    const profile = resolveVoiceQualityProfile(config);
+    expect(profile.transcriptionProvider).toBe("Google");
+    expect(profile.speechModel).toBeUndefined();
+  });
+
+  test("Google strips legacy nova-3 default via STT profile adapter", () => {
+    const config = AssistantConfigSchema.parse({
+      calls: {
+        voice: { transcriptionProvider: "Google", speechModel: "nova-3" },
+      },
+    });
+    const profile = resolveVoiceQualityProfile(config);
+    expect(profile.transcriptionProvider).toBe("Google");
+    expect(profile.speechModel).toBeUndefined();
+  });
+
+  test("Google preserves explicit telephony model via STT profile adapter", () => {
+    const config = AssistantConfigSchema.parse({
+      calls: {
+        voice: { transcriptionProvider: "Google", speechModel: "telephony" },
+      },
+    });
+    const profile = resolveVoiceQualityProfile(config);
+    expect(profile.transcriptionProvider).toBe("Google");
+    expect(profile.speechModel).toBe("telephony");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: resolveTelephonySttProfile (adapter + parsed config integration)
+// ---------------------------------------------------------------------------
+
+describe("resolveTelephonySttProfile with parsed config", () => {
+  test("Deepgram defaults produce provider Deepgram with nova-3", () => {
+    const config = AssistantConfigSchema.parse({});
+    const stt = resolveTelephonySttProfile(config.calls.voice);
+    expect(stt.provider).toBe("Deepgram");
+    expect(stt.speechModel).toBe("nova-3");
+  });
+
+  test("Google provider with no speechModel yields undefined speechModel", () => {
+    const config = AssistantConfigSchema.parse({
+      calls: { voice: { transcriptionProvider: "Google" } },
+    });
+    const stt = resolveTelephonySttProfile(config.calls.voice);
+    expect(stt.provider).toBe("Google");
+    expect(stt.speechModel).toBeUndefined();
+  });
+
+  test("Google provider with legacy nova-3 yields undefined speechModel", () => {
+    const config = AssistantConfigSchema.parse({
+      calls: {
+        voice: { transcriptionProvider: "Google", speechModel: "nova-3" },
+      },
+    });
+    const stt = resolveTelephonySttProfile(config.calls.voice);
+    expect(stt.provider).toBe("Google");
+    expect(stt.speechModel).toBeUndefined();
+  });
+
+  test("Google provider with explicit long model preserves it", () => {
+    const config = AssistantConfigSchema.parse({
+      calls: {
+        voice: { transcriptionProvider: "Google", speechModel: "long" },
+      },
+    });
+    const stt = resolveTelephonySttProfile(config.calls.voice);
+    expect(stt.provider).toBe("Google");
+    expect(stt.speechModel).toBe("long");
+  });
+
+  test("Deepgram with explicit speech model preserves it", () => {
+    const config = AssistantConfigSchema.parse({
+      calls: {
+        voice: {
+          transcriptionProvider: "Deepgram",
+          speechModel: "nova-2-phonecall",
+        },
+      },
+    });
+    const stt = resolveTelephonySttProfile(config.calls.voice);
+    expect(stt.provider).toBe("Deepgram");
+    expect(stt.speechModel).toBe("nova-2-phonecall");
   });
 });
 

--- a/assistant/src/__tests__/voice-quality.test.ts
+++ b/assistant/src/__tests__/voice-quality.test.ts
@@ -6,6 +6,7 @@ mock.module("../config/loader.js", () => ({
   loadConfig: () => mockConfig,
 }));
 
+import { resolveTelephonySttProfile } from "../calls/stt-profile.js";
 import {
   buildElevenLabsVoiceSpec,
   resolveVoiceQualityProfile,
@@ -60,6 +61,57 @@ describe("buildElevenLabsVoiceSpec", () => {
     expect(buildElevenLabsVoiceSpec({ voiceId: "  abc123  " })).toBe("abc123");
   });
 });
+
+// ── resolveTelephonySttProfile (adapter unit tests) ─────────────────
+
+describe("resolveTelephonySttProfile", () => {
+  test("Deepgram defaults speechModel to nova-3 when unset", () => {
+    const profile = resolveTelephonySttProfile({
+      transcriptionProvider: "Deepgram",
+      speechModel: undefined,
+    });
+    expect(profile.provider).toBe("Deepgram");
+    expect(profile.speechModel).toBe("nova-3");
+  });
+
+  test("Deepgram preserves explicitly set speechModel", () => {
+    const profile = resolveTelephonySttProfile({
+      transcriptionProvider: "Deepgram",
+      speechModel: "nova-2-phonecall",
+    });
+    expect(profile.provider).toBe("Deepgram");
+    expect(profile.speechModel).toBe("nova-2-phonecall");
+  });
+
+  test("Google leaves speechModel undefined when unset", () => {
+    const profile = resolveTelephonySttProfile({
+      transcriptionProvider: "Google",
+      speechModel: undefined,
+    });
+    expect(profile.provider).toBe("Google");
+    expect(profile.speechModel).toBeUndefined();
+  });
+
+  test("Google treats legacy Deepgram default nova-3 as unset", () => {
+    const profile = resolveTelephonySttProfile({
+      transcriptionProvider: "Google",
+      speechModel: "nova-3",
+    });
+    expect(profile.provider).toBe("Google");
+    expect(profile.speechModel).toBeUndefined();
+  });
+
+  test("Google preserves explicitly set non-legacy speechModel", () => {
+    const profile = resolveTelephonySttProfile({
+      transcriptionProvider: "Google",
+      speechModel: "telephony",
+    });
+    expect(profile.provider).toBe("Google");
+    expect(profile.speechModel).toBe("telephony");
+  });
+});
+
+// ── resolveVoiceQualityProfile ──────────────────────────────────────
 
 describe("resolveVoiceQualityProfile", () => {
   test("always returns ElevenLabs ttsProvider", () => {
@@ -181,5 +233,67 @@ describe("resolveVoiceQualityProfile", () => {
     };
     const profile = resolveVoiceQualityProfile();
     expect(profile.hints).toEqual(["Vellum", "Nova", "AI assistant"]);
+  });
+
+  test("delegates STT resolution to adapter — Deepgram defaults to nova-3", () => {
+    mockConfig = {
+      elevenlabs: { voiceId: "abc" },
+      calls: {
+        voice: {
+          language: "en-US",
+          transcriptionProvider: "Deepgram",
+        },
+      },
+    };
+    const profile = resolveVoiceQualityProfile();
+    expect(profile.transcriptionProvider).toBe("Deepgram");
+    expect(profile.speechModel).toBe("nova-3");
+  });
+
+  test("delegates STT resolution to adapter — Google leaves speechModel undefined", () => {
+    mockConfig = {
+      elevenlabs: { voiceId: "abc" },
+      calls: {
+        voice: {
+          language: "en-US",
+          transcriptionProvider: "Google",
+        },
+      },
+    };
+    const profile = resolveVoiceQualityProfile();
+    expect(profile.transcriptionProvider).toBe("Google");
+    expect(profile.speechModel).toBeUndefined();
+  });
+
+  test("delegates STT resolution to adapter — Google strips legacy nova-3", () => {
+    mockConfig = {
+      elevenlabs: { voiceId: "abc" },
+      calls: {
+        voice: {
+          language: "en-US",
+          transcriptionProvider: "Google",
+          speechModel: "nova-3",
+        },
+      },
+    };
+    const profile = resolveVoiceQualityProfile();
+    expect(profile.transcriptionProvider).toBe("Google");
+    expect(profile.speechModel).toBeUndefined();
+  });
+
+  test("delegates STT resolution to adapter — Google preserves explicit model", () => {
+    mockConfig = {
+      elevenlabs: { voiceId: "abc" },
+      calls: {
+        voice: {
+          language: "en-US",
+          transcriptionProvider: "Google",
+          speechModel: "telephony",
+        },
+      },
+    };
+    const profile = resolveVoiceQualityProfile();
+    expect(profile.transcriptionProvider).toBe("Google");
+    expect(profile.speechModel).toBe("telephony");
   });
 });

--- a/assistant/src/calls/stt-profile.ts
+++ b/assistant/src/calls/stt-profile.ts
@@ -1,0 +1,74 @@
+/**
+ * Telephony STT profile adapter.
+ *
+ * Centralizes the mapping from config-level STT settings
+ * (`calls.voice.transcriptionProvider`, `calls.voice.speechModel`) to a
+ * normalized profile object consumed by call infrastructure.
+ *
+ * Provider-specific semantics:
+ * - **Deepgram**: defaults speechModel to `"nova-3"` when unset.
+ * - **Google**: leaves speechModel undefined when unset (Google's Cloud Speech
+ *   API uses its own default). Treats the legacy Deepgram default `"nova-3"`
+ *   as unset — upgraded workspaces may still have it persisted from prior
+ *   defaults before provider was switched.
+ */
+
+import type { CallsVoiceConfig } from "../config/schemas/calls.js";
+
+/**
+ * Provider-agnostic representation of the telephony STT configuration.
+ */
+export interface TelephonySttProfile {
+  /** STT provider name as expected by the telephony platform (e.g. "Deepgram", "Google"). */
+  provider: string;
+  /** ASR model identifier, or undefined to let the provider use its default. */
+  speechModel: string | undefined;
+}
+
+const DEEPGRAM_DEFAULT_SPEECH_MODEL = "nova-3";
+
+/**
+ * Resolve a normalized telephony STT profile from the calls voice config.
+ *
+ * This is the single source of truth for STT provider selection in the
+ * telephony call path. All call-related code should read STT details from
+ * the returned profile rather than branching on provider inline.
+ */
+export function resolveTelephonySttProfile(
+  voiceConfig: Pick<CallsVoiceConfig, "transcriptionProvider" | "speechModel">,
+): TelephonySttProfile {
+  const provider = voiceConfig.transcriptionProvider;
+  const rawSpeechModel = voiceConfig.speechModel;
+
+  return {
+    provider,
+    speechModel: resolveEffectiveSpeechModel(provider, rawSpeechModel),
+  };
+}
+
+/**
+ * Determine the effective speech model for the given provider.
+ *
+ * - Deepgram: fall back to "nova-3" when the model is not explicitly set.
+ * - Google: treat the legacy Deepgram default ("nova-3") as unset so that
+ *   workspaces that were previously configured for Deepgram and later
+ *   switched to Google don't inadvertently send a Deepgram model name.
+ */
+function resolveEffectiveSpeechModel(
+  provider: string,
+  rawSpeechModel: string | undefined,
+): string | undefined {
+  const isGoogle = provider === "Google";
+
+  if (rawSpeechModel == null) {
+    return isGoogle ? undefined : DEEPGRAM_DEFAULT_SPEECH_MODEL;
+  }
+
+  // Legacy migration: if the persisted model is the Deepgram default but
+  // the provider has been switched to Google, treat it as unset.
+  if (rawSpeechModel === DEEPGRAM_DEFAULT_SPEECH_MODEL && isGoogle) {
+    return undefined;
+  }
+
+  return rawSpeechModel;
+}

--- a/assistant/src/calls/voice-quality.ts
+++ b/assistant/src/calls/voice-quality.ts
@@ -1,4 +1,5 @@
 import { loadConfig } from "../config/loader.js";
+import { resolveTelephonySttProfile } from "./stt-profile.js";
 
 export interface VoiceQualityProfile {
   language: string;
@@ -45,6 +46,10 @@ export function buildElevenLabsVoiceSpec(config: {
 /**
  * Resolve the effective voice quality profile from config.
  *
+ * STT provider and speech model selection is delegated to the telephony
+ * STT profile adapter (`stt-profile.ts`), which centralizes all
+ * provider-specific fallback logic.
+ *
  * Supports ElevenLabs (default) and Fish Audio TTS providers.
  * When Fish Audio is selected, `ttsProvider` is set to `"Google"` as a
  * placeholder — ConversationRelay requires a valid provider in TwiML, but
@@ -61,20 +66,11 @@ export function resolveVoiceQualityProfile(
   const voice = cfg.calls.voice;
   const configuredTts = voice.ttsProvider ?? "elevenlabs";
   const fishAudio = configuredTts === "fish-audio";
-  const isGoogle = voice.transcriptionProvider === "Google";
-  // Treat the legacy Deepgram default ("nova-3") as unset when provider is
-  // Google — upgraded workspaces may still have it persisted from prior defaults.
-  const effectiveSpeechModel =
-    voice.speechModel == null ||
-    (voice.speechModel === "nova-3" && isGoogle)
-      ? isGoogle
-        ? undefined
-        : "nova-3"
-      : voice.speechModel;
+  const sttProfile = resolveTelephonySttProfile(voice);
   return {
     language: voice.language,
-    transcriptionProvider: voice.transcriptionProvider,
-    speechModel: effectiveSpeechModel,
+    transcriptionProvider: sttProfile.provider,
+    speechModel: sttProfile.speechModel,
     ttsProvider: fishAudio ? "Google" : "ElevenLabs",
     voice: fishAudio ? "" : buildElevenLabsVoiceSpec(cfg.elevenlabs),
     interruptSensitivity: voice.interruptSensitivity ?? "low",


### PR DESCRIPTION
## Summary
- Add centralized telephony STT profile adapter mapping provider and speech model config
- Refactor voice-quality to use profile adapter instead of inline provider branching
- Preserve Deepgram/Google defaults and fallback semantics

Part of plan: initial-stt-unification.md (PR 3 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24821" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
