### PR TITLE
feat(chrome-ext): show setup guidance when native host is unavailable

### DIFF
--- a/clients/chrome-extension/popup/popup-state.test.ts
+++ b/clients/chrome-extension/popup/popup-state.test.ts
@@ -18,6 +18,7 @@ import {
   shouldShowCloudSection,
   deriveCtaState,
   deriveStatusDisplay,
+  deriveSetupMessage,
   type ConnectionPhase,
 } from './popup-state.js';
 
@@ -189,14 +190,24 @@ describe('deriveCtaState', () => {
     expect(state.pauseEnabled).toBe(false);
   });
 
+  test('no-native-host: both buttons disabled', () => {
+    const state = deriveCtaState('no-native-host');
+    expect(state.connectLabel).toBe('Connect');
+    expect(state.connectEnabled).toBe(false);
+    expect(state.pauseLabel).toBe('Pause');
+    expect(state.pauseEnabled).toBe(false);
+  });
+
   test('all phases produce consistent label/enablement pairs', () => {
-    const phases: ConnectionPhase[] = ['disconnected', 'connecting', 'connected', 'paused'];
+    const phases: ConnectionPhase[] = ['disconnected', 'connecting', 'connected', 'paused', 'no-native-host'];
     for (const phase of phases) {
       const state = deriveCtaState(phase);
       // Pause should only be enabled when connected
       expect(state.pauseEnabled).toBe(phase === 'connected');
-      // Connect should be disabled only when connecting or connected
-      expect(state.connectEnabled).toBe(phase !== 'connecting' && phase !== 'connected');
+      // Connect should be disabled when connecting, connected, or no-native-host
+      expect(state.connectEnabled).toBe(
+        phase !== 'connecting' && phase !== 'connected' && phase !== 'no-native-host',
+      );
     }
   });
 });
@@ -228,6 +239,12 @@ describe('deriveStatusDisplay', () => {
     expect(status.text).toBe('Paused');
   });
 
+  test('no-native-host: red dot, Desktop app required', () => {
+    const status = deriveStatusDisplay('no-native-host');
+    expect(status.dotClass).toBe('disconnected');
+    expect(status.text).toBe('Desktop app required');
+  });
+
   test('display transitions: disconnected -> connecting -> connected -> paused -> disconnected', () => {
     const transitions: ConnectionPhase[] = [
       'disconnected',
@@ -249,6 +266,39 @@ describe('deriveStatusDisplay', () => {
       const status = deriveStatusDisplay(transitions[i]!);
       expect(status.dotClass).toBe(expectedDots[i]);
       expect(status.text).toBe(expectedTexts[i]);
+    }
+  });
+});
+
+// ── deriveSetupMessage ─────────────────────────────────────────────
+
+describe('deriveSetupMessage', () => {
+  test('returns setup guidance for no-native-host phase', () => {
+    const msg = deriveSetupMessage('no-native-host');
+    expect(msg).toBeString();
+    expect(msg).toContain('desktop app');
+  });
+
+  test('returns null for disconnected phase', () => {
+    expect(deriveSetupMessage('disconnected')).toBeNull();
+  });
+
+  test('returns null for connecting phase', () => {
+    expect(deriveSetupMessage('connecting')).toBeNull();
+  });
+
+  test('returns null for connected phase', () => {
+    expect(deriveSetupMessage('connected')).toBeNull();
+  });
+
+  test('returns null for paused phase', () => {
+    expect(deriveSetupMessage('paused')).toBeNull();
+  });
+
+  test('all non-no-native-host phases return null', () => {
+    const normalPhases: ConnectionPhase[] = ['disconnected', 'connecting', 'connected', 'paused'];
+    for (const phase of normalPhases) {
+      expect(deriveSetupMessage(phase)).toBeNull();
     }
   });
 });

--- a/clients/chrome-extension/popup/popup-state.ts
+++ b/clients/chrome-extension/popup/popup-state.ts
@@ -125,13 +125,15 @@ export function shouldShowCloudSection(
  * The popup's connection lifecycle phase. Drives the primary/secondary
  * button labels, enablement, and status indicator.
  *
- * - `disconnected` — idle, no active relay connection.
- * - `connecting`   — connect in progress (waiting for socket open).
- * - `connected`    — relay WebSocket is open and active.
- * - `paused`       — user explicitly paused; credentials are preserved
- *                    so reconnect is instant.
+ * - `disconnected`    — idle, no active relay connection.
+ * - `connecting`      — connect in progress (waiting for socket open).
+ * - `connected`       — relay WebSocket is open and active.
+ * - `paused`          — user explicitly paused; credentials are preserved
+ *                       so reconnect is instant.
+ * - `no-native-host`  — native messaging host is not installed; the user
+ *                       needs to install the Vellum desktop app first.
  */
-export type ConnectionPhase = 'disconnected' | 'connecting' | 'connected' | 'paused';
+export type ConnectionPhase = 'disconnected' | 'connecting' | 'connected' | 'paused' | 'no-native-host';
 
 /**
  * Derived view state for the popup's primary and secondary action buttons.
@@ -150,12 +152,13 @@ export interface CtaState {
 /**
  * Derive the CTA button labels and enablement from the connection phase.
  *
- * | Phase        | Connect       | Pause         |
- * |--------------|---------------|---------------|
- * | disconnected | Connect (on)  | Pause (off)   |
- * | connecting   | Connecting... (off) | Pause (off) |
- * | connected    | Connect (off) | Pause (on)    |
- * | paused       | Connect (on)  | Pause (off)   |
+ * | Phase           | Connect              | Pause         |
+ * |-----------------|----------------------|---------------|
+ * | disconnected    | Connect (on)         | Pause (off)   |
+ * | connecting      | Connecting... (off)  | Pause (off)   |
+ * | connected       | Connect (off)        | Pause (on)    |
+ * | paused          | Connect (on)         | Pause (off)   |
+ * | no-native-host  | Connect (off)        | Pause (off)   |
  */
 export function deriveCtaState(phase: ConnectionPhase): CtaState {
   switch (phase) {
@@ -187,6 +190,13 @@ export function deriveCtaState(phase: ConnectionPhase): CtaState {
         pauseLabel: 'Pause',
         pauseEnabled: false,
       };
+    case 'no-native-host':
+      return {
+        connectLabel: 'Connect',
+        connectEnabled: false,
+        pauseLabel: 'Pause',
+        pauseEnabled: false,
+      };
   }
 }
 
@@ -213,5 +223,23 @@ export function deriveStatusDisplay(phase: ConnectionPhase): StatusDisplay {
       return { dotClass: 'connected', text: 'Connected to relay server' };
     case 'paused':
       return { dotClass: 'paused', text: 'Paused' };
+    case 'no-native-host':
+      return { dotClass: 'disconnected', text: 'Desktop app required' };
   }
+}
+
+/**
+ * Derive a user-facing setup message for phases that require
+ * external action (e.g. installing the desktop app).
+ *
+ * Returns `null` when no setup guidance is needed.
+ */
+export function deriveSetupMessage(phase: ConnectionPhase): string | null {
+  if (phase === 'no-native-host') {
+    return (
+      'Install the Vellum desktop app to connect. ' +
+      'The browser extension requires the desktop app to communicate with your local assistant.'
+    );
+  }
+  return null;
 }

--- a/clients/chrome-extension/popup/popup.html
+++ b/clients/chrome-extension/popup/popup.html
@@ -173,6 +173,17 @@
       color: #ef4444;
       margin-bottom: 8px;
     }
+
+    .setup-message {
+      font-size: 12px;
+      color: #92400e;
+      background: #fef3c7;
+      border: 1px solid #fde68a;
+      border-radius: 6px;
+      padding: 8px 10px;
+      margin-bottom: 10px;
+      line-height: 1.45;
+    }
   </style>
 </head>
 <body>
@@ -184,6 +195,8 @@
   <p class="status-text" id="status-text">Not connected</p>
 
   <p class="error-text" id="error-text" style="display:none"></p>
+
+  <p id="setup-message" class="setup-message" style="display:none"></p>
 
   <div class="assistant-selector-group" id="assistant-selector-group" style="display:none">
     <label for="assistant-select">Assistant</label>

--- a/clients/chrome-extension/popup/popup.ts
+++ b/clients/chrome-extension/popup/popup.ts
@@ -197,7 +197,15 @@ function updateAuthSections(authProfile: AssistantAuthProfile | null): void {
 function isNativeHostUnavailable(error: string | undefined): boolean {
   if (!error) return false;
   const lower = error.toLowerCase();
-  return lower.includes('native messaging') || lower.includes('native host');
+  // Match only Chrome's specific host-not-installed error messages:
+  //   "Specified native messaging host not found."
+  //   "Access to the specified native messaging host is forbidden."
+  // Recoverable errors like timeouts, generic helper errors, and
+  // disconnect-before-response must NOT trigger the no-native-host phase.
+  return (
+    (lower.includes('native messaging host') && lower.includes('not found')) ||
+    (lower.includes('native messaging host') && lower.includes('forbidden'))
+  );
 }
 
 function loadAssistantCatalog(): void {

--- a/clients/chrome-extension/popup/popup.ts
+++ b/clients/chrome-extension/popup/popup.ts
@@ -37,6 +37,7 @@ import {
   shouldShowCloudSection,
   deriveCtaState,
   deriveStatusDisplay,
+  deriveSetupMessage,
   type ConnectionPhase,
   type AssistantsGetResponse,
   type AssistantSelectResponse,
@@ -52,6 +53,7 @@ const btnPause = document.getElementById('btn-pause') as HTMLButtonElement;
 const statusDot = document.getElementById('status-dot') as HTMLDivElement;
 const statusText = document.getElementById('status-text') as HTMLParagraphElement;
 const errorText = document.getElementById('error-text') as HTMLParagraphElement;
+const setupMessage = document.getElementById('setup-message') as HTMLParagraphElement;
 const btnCloudSignIn = document.getElementById('btn-cloud-signin') as HTMLButtonElement;
 const cloudStatus = document.getElementById('cloud-status') as HTMLParagraphElement;
 const btnPairLocal = document.getElementById('btn-pair-local') as HTMLButtonElement;
@@ -82,6 +84,19 @@ let currentAssistantId: string | null = null;
 // ── Connection phase management ─────────────────────────────────────
 
 /**
+ * Show or hide the setup-message element based on the current phase.
+ */
+function setSetupMessage(phase: ConnectionPhase): void {
+  const msg = deriveSetupMessage(phase);
+  if (msg) {
+    setupMessage.textContent = msg;
+    setupMessage.style.display = 'block';
+  } else {
+    setupMessage.style.display = 'none';
+  }
+}
+
+/**
  * Apply a connection phase to the UI. Derives button labels/enablement
  * and status indicator from the pure helpers in popup-state.ts.
  */
@@ -98,6 +113,8 @@ function setPhase(phase: ConnectionPhase): void {
   statusText.textContent = status.text;
 
   portInput.disabled = phase === 'connected' || phase === 'connecting';
+
+  setSetupMessage(phase);
 
   if (phase === 'connected') {
     errorText.style.display = 'none';
@@ -177,10 +194,22 @@ function updateAuthSections(authProfile: AssistantAuthProfile | null): void {
 /**
  * Load the assistant catalog from the worker and render the selector.
  */
+function isNativeHostUnavailable(error: string | undefined): boolean {
+  if (!error) return false;
+  const lower = error.toLowerCase();
+  return lower.includes('native messaging') || lower.includes('native host');
+}
+
 function loadAssistantCatalog(): void {
   chrome.runtime.sendMessage({ type: 'assistants-get' }, (response: AssistantsGetResponse) => {
     if (chrome.runtime.lastError || !response?.ok) {
       const errMsg = response?.error ?? chrome.runtime.lastError?.message ?? 'Failed to load assistants';
+
+      if (isNativeHostUnavailable(errMsg)) {
+        setPhase('no-native-host');
+        return;
+      }
+
       showError(errMsg);
       return;
     }


### PR DESCRIPTION
## Summary
- Add 'no-native-host' connection phase with user-friendly setup message
- Detect native messaging errors in popup and show install guidance
- Connect button disabled when native host is missing
- Tests cover new phase derivations

Part of plan: cws-distribution.md (PR 3 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24823" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
