### PR TITLE
Introduce iOS speech recognizer adapter and migrate InputBar voice input

### DIFF
--- a/clients/ios/Services/SpeechRecognizerAdapter.swift
+++ b/clients/ios/Services/SpeechRecognizerAdapter.swift
@@ -1,0 +1,127 @@
+#if canImport(UIKit)
+import Foundation
+import Speech
+import AVFoundation
+
+// MARK: - Authorization Status
+
+/// Unified authorization status for speech recognition, abstracting the platform-specific
+/// `SFSpeechRecognizerAuthorizationStatus` so consumers and tests don't depend on the Speech framework.
+enum SpeechRecognizerAuthorizationStatus {
+    case authorized
+    case denied
+    case restricted
+    case notDetermined
+}
+
+// MARK: - Recognition Result
+
+/// A simplified speech recognition result delivered by the adapter, decoupling callers
+/// from `SFSpeechRecognitionResult`.
+struct SpeechRecognitionResult {
+    /// The best transcription string for the current recognition pass.
+    let transcription: String
+    /// True when the recognizer has finalized the result and no further updates will arrive.
+    let isFinal: Bool
+}
+
+// MARK: - Protocol
+
+/// Abstraction boundary for on-device speech recognition on iOS.
+///
+/// The protocol covers the three operational phases callers care about:
+/// 1. **Authorization** -- request and query permission to use speech recognition.
+/// 2. **Availability** -- check whether a recognizer is available for the current locale.
+/// 3. **Task construction** -- start a recognition task that delivers results via a callback.
+///
+/// Injecting this protocol instead of calling `SFSpeechRecognizer` directly lets the
+/// `InputBarView` voice-input path be tested without a live microphone or OS permission dialogs.
+@MainActor
+protocol SpeechRecognizerAdapter {
+    /// Request speech recognition authorization from the user.
+    /// Returns the resulting authorization status.
+    func requestAuthorization() async -> SpeechRecognizerAuthorizationStatus
+
+    /// Whether a speech recognizer is currently available for the device locale.
+    var isAvailable: Bool { get }
+
+    /// Start a recognition task that consumes audio buffers appended to the returned request.
+    ///
+    /// - Parameter resultHandler: Called on the main queue with each partial or final result,
+    ///   or with an error if recognition fails. The handler receives `(result, error)`.
+    /// - Returns: A tuple of the audio buffer request (callers append `AVAudioPCMBuffer` to it)
+    ///   and a cancellation closure that tears down the recognition task.
+    /// - Throws: If a recognizer cannot be constructed for the current locale.
+    func startRecognitionTask(
+        resultHandler: @escaping (SpeechRecognitionResult?, Error?) -> Void
+    ) throws -> (request: SFSpeechAudioBufferRecognitionRequest, cancel: () -> Void)
+}
+
+// MARK: - Apple Implementation
+
+/// Production implementation backed by `SFSpeechRecognizer`.
+@MainActor
+final class AppleSpeechRecognizerAdapter: SpeechRecognizerAdapter {
+
+    func requestAuthorization() async -> SpeechRecognizerAuthorizationStatus {
+        await withCheckedContinuation { continuation in
+            SFSpeechRecognizer.requestAuthorization { status in
+                let mapped: SpeechRecognizerAuthorizationStatus
+                switch status {
+                case .authorized:    mapped = .authorized
+                case .denied:        mapped = .denied
+                case .restricted:    mapped = .restricted
+                case .notDetermined: mapped = .notDetermined
+                @unknown default:    mapped = .denied
+                }
+                continuation.resume(returning: mapped)
+            }
+        }
+    }
+
+    var isAvailable: Bool {
+        guard let recognizer = SFSpeechRecognizer() else { return false }
+        return recognizer.isAvailable
+    }
+
+    func startRecognitionTask(
+        resultHandler: @escaping (SpeechRecognitionResult?, Error?) -> Void
+    ) throws -> (request: SFSpeechAudioBufferRecognitionRequest, cancel: () -> Void) {
+        guard let recognizer = SFSpeechRecognizer(), recognizer.isAvailable else {
+            throw SpeechRecognizerAdapterError.recognizerUnavailable
+        }
+
+        let request = SFSpeechAudioBufferRecognitionRequest()
+        request.shouldReportPartialResults = true
+
+        let task = recognizer.recognitionTask(with: request) { sfResult, error in
+            DispatchQueue.main.async {
+                let mapped: SpeechRecognitionResult? = sfResult.map {
+                    SpeechRecognitionResult(
+                        transcription: $0.bestTranscription.formattedString,
+                        isFinal: $0.isFinal
+                    )
+                }
+                resultHandler(mapped, error)
+            }
+        }
+
+        let cancel: () -> Void = { task.cancel() }
+        return (request: request, cancel: cancel)
+    }
+}
+
+// MARK: - Errors
+
+enum SpeechRecognizerAdapterError: LocalizedError {
+    case recognizerUnavailable
+
+    var errorDescription: String? {
+        switch self {
+        case .recognizerUnavailable:
+            return "Speech recognizer is not available on this device."
+        }
+    }
+}
+
+#endif

--- a/clients/ios/Tests/InputBarVoiceInputTests.swift
+++ b/clients/ios/Tests/InputBarVoiceInputTests.swift
@@ -1,0 +1,211 @@
+#if canImport(UIKit)
+import XCTest
+import Speech
+@testable import VellumAssistantShared
+@testable import vellum_assistant_ios
+
+/// Tests for the InputBarView voice input path exercised through the SpeechRecognizerAdapter
+/// abstraction. Uses a mock adapter to verify authorization, availability, and transcript
+/// application without requiring a live microphone or OS permission dialogs.
+@MainActor
+final class InputBarVoiceInputTests: XCTestCase {
+
+    // MARK: - Mock Adapter
+
+    /// A controllable mock of `SpeechRecognizerAdapter` for testing InputBarView's voice-input
+    /// branches without hitting the real SFSpeechRecognizer or microphone hardware.
+    private final class MockSpeechRecognizerAdapter: SpeechRecognizerAdapter {
+        var authorizationStatus: SpeechRecognizerAuthorizationStatus = .authorized
+        var available: Bool = true
+        var shouldThrowOnStart: Bool = false
+
+        /// The result handler captured from the most recent `startRecognitionTask` call.
+        /// Tests invoke this to simulate the recognizer delivering results.
+        var capturedResultHandler: ((SpeechRecognitionResult?, Error?) -> Void)?
+
+        /// Tracks how many times `startRecognitionTask` was called.
+        var startCallCount = 0
+
+        /// The most recently created request, if any.
+        var lastRequest: SFSpeechAudioBufferRecognitionRequest?
+
+        func requestAuthorization() async -> SpeechRecognizerAuthorizationStatus {
+            return authorizationStatus
+        }
+
+        var isAvailable: Bool { available }
+
+        func startRecognitionTask(
+            resultHandler: @escaping (SpeechRecognitionResult?, Error?) -> Void
+        ) throws -> (request: SFSpeechAudioBufferRecognitionRequest, cancel: () -> Void) {
+            if shouldThrowOnStart {
+                throw SpeechRecognizerAdapterError.recognizerUnavailable
+            }
+            startCallCount += 1
+            capturedResultHandler = resultHandler
+            let request = SFSpeechAudioBufferRecognitionRequest()
+            lastRequest = request
+            return (request: request, cancel: { [weak self] in self?.capturedResultHandler = nil })
+        }
+    }
+
+    // MARK: - Authorization Denied
+
+    func testAuthorizationDeniedReturnsCorrectStatus() async {
+        let adapter = MockSpeechRecognizerAdapter()
+        adapter.authorizationStatus = .denied
+
+        let status = await adapter.requestAuthorization()
+        XCTAssertEqual(status, .denied, "Adapter should return denied status when configured as denied")
+    }
+
+    func testAuthorizationDeniedDoesNotStartRecognition() async {
+        let adapter = MockSpeechRecognizerAdapter()
+        adapter.authorizationStatus = .denied
+
+        let status = await adapter.requestAuthorization()
+        XCTAssertNotEqual(status, .authorized)
+        // Verify no recognition task was started
+        XCTAssertEqual(adapter.startCallCount, 0, "Recognition task should not start when authorization is denied")
+    }
+
+    func testAuthorizationRestrictedReturnsCorrectStatus() async {
+        let adapter = MockSpeechRecognizerAdapter()
+        adapter.authorizationStatus = .restricted
+
+        let status = await adapter.requestAuthorization()
+        XCTAssertEqual(status, .restricted)
+    }
+
+    // MARK: - Recognizer Unavailable
+
+    func testRecognizerUnavailableReportsNotAvailable() {
+        let adapter = MockSpeechRecognizerAdapter()
+        adapter.available = false
+
+        XCTAssertFalse(adapter.isAvailable, "Adapter should report unavailable when configured as unavailable")
+    }
+
+    func testStartRecognitionTaskThrowsWhenConfigured() {
+        let adapter = MockSpeechRecognizerAdapter()
+        adapter.shouldThrowOnStart = true
+
+        XCTAssertThrowsError(try adapter.startRecognitionTask { _, _ in }) { error in
+            XCTAssertTrue(
+                error is SpeechRecognizerAdapterError,
+                "Error should be SpeechRecognizerAdapterError, got \(type(of: error))"
+            )
+        }
+    }
+
+    func testRecognizerUnavailableDoesNotCaptureHandler() {
+        let adapter = MockSpeechRecognizerAdapter()
+        adapter.shouldThrowOnStart = true
+
+        _ = try? adapter.startRecognitionTask { _, _ in }
+        XCTAssertNil(adapter.capturedResultHandler, "No result handler should be captured when start throws")
+        XCTAssertEqual(adapter.startCallCount, 0, "Start call count should remain 0 when start throws")
+    }
+
+    // MARK: - Successful Final Transcript
+
+    func testSuccessfulFinalTranscriptDelivered() throws {
+        let adapter = MockSpeechRecognizerAdapter()
+
+        var receivedTranscription: String?
+        var receivedIsFinal: Bool?
+
+        let (_, _) = try adapter.startRecognitionTask { result, error in
+            receivedTranscription = result?.transcription
+            receivedIsFinal = result?.isFinal
+        }
+
+        XCTAssertEqual(adapter.startCallCount, 1)
+
+        // Simulate the recognizer delivering a final result
+        let finalResult = SpeechRecognitionResult(transcription: "Hello world", isFinal: true)
+        adapter.capturedResultHandler?(finalResult, nil)
+
+        XCTAssertEqual(receivedTranscription, "Hello world")
+        XCTAssertEqual(receivedIsFinal, true)
+    }
+
+    func testPartialTranscriptDeliveredBeforeFinal() throws {
+        let adapter = MockSpeechRecognizerAdapter()
+
+        var transcriptions: [String] = []
+        var finalFlags: [Bool] = []
+
+        let (_, _) = try adapter.startRecognitionTask { result, error in
+            if let result = result {
+                transcriptions.append(result.transcription)
+                finalFlags.append(result.isFinal)
+            }
+        }
+
+        // Simulate partial result
+        adapter.capturedResultHandler?(
+            SpeechRecognitionResult(transcription: "Hello", isFinal: false),
+            nil
+        )
+
+        // Simulate final result
+        adapter.capturedResultHandler?(
+            SpeechRecognitionResult(transcription: "Hello world", isFinal: true),
+            nil
+        )
+
+        XCTAssertEqual(transcriptions, ["Hello", "Hello world"])
+        XCTAssertEqual(finalFlags, [false, true])
+    }
+
+    func testCancelClosureClearsHandler() throws {
+        let adapter = MockSpeechRecognizerAdapter()
+
+        let (_, cancel) = try adapter.startRecognitionTask { _, _ in }
+        XCTAssertNotNil(adapter.capturedResultHandler)
+
+        cancel()
+        XCTAssertNil(adapter.capturedResultHandler, "Cancel should clear the captured result handler")
+    }
+
+    func testRecognitionErrorDelivered() throws {
+        let adapter = MockSpeechRecognizerAdapter()
+
+        var receivedError: Error?
+
+        let (_, _) = try adapter.startRecognitionTask { result, error in
+            receivedError = error
+        }
+
+        let testError = NSError(domain: "kAFAssistantErrorDomain", code: 1110, userInfo: nil)
+        adapter.capturedResultHandler?(nil, testError)
+
+        XCTAssertNotNil(receivedError)
+        XCTAssertEqual((receivedError as? NSError)?.code, 1110)
+    }
+
+    // MARK: - Adapter Protocol Contract
+
+    func testAdapterRequestIsReturned() throws {
+        let adapter = MockSpeechRecognizerAdapter()
+
+        let (request, _) = try adapter.startRecognitionTask { _, _ in }
+        // The mock creates the request; in production AppleSpeechRecognizerAdapter also sets
+        // shouldReportPartialResults = true. Verify the request object is valid.
+        XCTAssertNotNil(request, "Adapter should return a valid audio buffer request")
+    }
+
+    func testMultipleStartCallsIncrementCount() throws {
+        let adapter = MockSpeechRecognizerAdapter()
+
+        let (_, cancel1) = try adapter.startRecognitionTask { _, _ in }
+        cancel1()
+        let (_, cancel2) = try adapter.startRecognitionTask { _, _ in }
+        cancel2()
+
+        XCTAssertEqual(adapter.startCallCount, 2)
+    }
+}
+
+#endif

--- a/clients/ios/Views/InputBarView.swift
+++ b/clients/ios/Views/InputBarView.swift
@@ -23,6 +23,10 @@ struct InputBarView: View {
     var onVoiceResult: ((String) -> Void)?
     var viewModel: ChatViewModel
 
+    /// Speech recognizer adapter — defaults to the Apple implementation backed by SFSpeechRecognizer.
+    /// Inject a mock for testing.
+    var speechRecognizer: any SpeechRecognizerAdapter = AppleSpeechRecognizerAdapter()
+
     @State private var isRecording = false
     /// True after the audio engine and tap have been torn down (set by finishRecordingForAutoStop
     /// and stopRecording). Prevents double-stop when the auto-stop path and the isFinal callback
@@ -35,7 +39,9 @@ struct InputBarView: View {
     /// the user has not typed anything in the interim.
     @State private var isAutoStopPending = false
     @State private var textAtAutoStop: String = ""
-    @State private var recognitionTask: SFSpeechRecognitionTask?
+    /// Cancellation closure returned by the adapter's startRecognitionTask — tears down the
+    /// recognition task without requiring a direct SFSpeechRecognitionTask reference.
+    @State private var cancelRecognitionTask: (() -> Void)?
     @State private var recognitionRequest: SFSpeechAudioBufferRecognitionRequest?
     @State private var audioEngine = AVAudioEngine()
     @State private var showPhotosPicker = false
@@ -116,7 +122,7 @@ struct InputBarView: View {
     }
 
     private var voiceOrbState: VoiceOrbState {
-        // The SFSpeechRecognizer pipeline only has listening and idle states in
+        // The speech recognizer pipeline only has listening and idle states in
         // this simplified implementation; thinking/processing is not separately
         // observable here, so we reflect the recording flag directly.
         isRecording ? .listening : .idle
@@ -290,17 +296,16 @@ struct InputBarView: View {
                 }
                 return
             }
-            // Request speech recognition access
-            SFSpeechRecognizer.requestAuthorization { status in
-                DispatchQueue.main.async {
-                    guard status == .authorized else {
-                        log.warning("Speech recognition not authorized: \(String(describing: status))")
-                        isVoiceOrbExpanded = false
-                        viewModel.errorText = "Speech recognition not authorized — enable it in Settings > Privacy > Speech Recognition."
-                        return
-                    }
-                    beginRecording()
+            // Request speech recognition access via the adapter
+            Task { @MainActor in
+                let status = await speechRecognizer.requestAuthorization()
+                guard status == .authorized else {
+                    log.warning("Speech recognition not authorized: \(String(describing: status))")
+                    isVoiceOrbExpanded = false
+                    viewModel.errorText = "Speech recognition not authorized — enable it in Settings > Privacy > Speech Recognition."
+                    return
                 }
+                beginRecording()
             }
         }
     }
@@ -313,7 +318,7 @@ struct InputBarView: View {
             return
         }
 
-        guard let recognizer = SFSpeechRecognizer(), recognizer.isAvailable else {
+        guard speechRecognizer.isAvailable else {
             log.error("Speech recognizer not available")
             isVoiceOrbExpanded = false
             viewModel.errorText = "Voice input is not available on this device."
@@ -331,9 +336,48 @@ struct InputBarView: View {
             return
         }
 
-        let request = SFSpeechAudioBufferRecognitionRequest()
-        request.shouldReportPartialResults = true
+        // Start the recognition task via the adapter. The adapter returns the audio buffer
+        // request (for appending mic samples) and a cancellation closure.
+        let taskResult: (request: SFSpeechAudioBufferRecognitionRequest, cancel: () -> Void)
+        do {
+            taskResult = try speechRecognizer.startRecognitionTask { result, error in
+                if let result = result {
+                    let transcribed = result.transcription
+                    if result.isFinal {
+                        log.info("Voice transcription final: \(transcribed, privacy: .public)")
+                        // Only apply the final transcription if the user has not typed anything
+                        // since auto-stop. When isAutoStopPending is true the voice orb has already
+                        // collapsed and the text field is visible, so the user may have started
+                        // editing; we respect their input by skipping the overwrite in that case.
+                        if !isAutoStopPending || text == textAtAutoStop {
+                            text = transcribed
+                            onVoiceResult?(transcribed)
+                        }
+                        stopRecording()
+                        isVoiceOrbExpanded = false
+                    }
+                }
+                if let error = error {
+                    // Code 1110 is "no speech detected" — not an error worth logging at error level
+                    let nsError = error as NSError
+                    if nsError.code != 1110 {
+                        log.error("Recognition error: \(error.localizedDescription)")
+                    }
+                    stopRecording()
+                    isVoiceOrbExpanded = false
+                }
+            }
+        } catch {
+            log.error("Failed to start recognition task: \(error.localizedDescription)")
+            isVoiceOrbExpanded = false
+            viewModel.errorText = "Voice input is not available on this device."
+            try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+            return
+        }
+
+        let request = taskResult.request
         recognitionRequest = request
+        cancelRecognitionTask = taskResult.cancel
 
         let inputNode = audioEngine.inputNode
         let recordingFormat = inputNode.outputFormat(forBus: 0)
@@ -342,6 +386,8 @@ struct InputBarView: View {
             log.error("No audio input channels available")
             isVoiceOrbExpanded = false
             viewModel.errorText = "No microphone input available."
+            try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+            cleanupRecognition()
             return
         }
 
@@ -396,36 +442,6 @@ struct InputBarView: View {
             try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
             cleanupRecognition()
             return
-        }
-
-        recognitionTask = recognizer.recognitionTask(with: request) { result, error in
-            DispatchQueue.main.async {
-                if let result = result {
-                    let transcribed = result.bestTranscription.formattedString
-                    if result.isFinal {
-                        log.info("Voice transcription final: \(transcribed, privacy: .public)")
-                        // Only apply the final transcription if the user has not typed anything
-                        // since auto-stop. When isAutoStopPending is true the voice orb has already
-                        // collapsed and the text field is visible, so the user may have started
-                        // editing; we respect their input by skipping the overwrite in that case.
-                        if !isAutoStopPending || text == textAtAutoStop {
-                            text = transcribed
-                            onVoiceResult?(transcribed)
-                        }
-                        stopRecording()
-                        isVoiceOrbExpanded = false
-                    }
-                }
-                if let error = error {
-                    // Code 1110 is "no speech detected" — not an error worth logging at error level
-                    let nsError = error as NSError
-                    if nsError.code != 1110 {
-                        log.error("Recognition error: \(error.localizedDescription)")
-                    }
-                    stopRecording()
-                    isVoiceOrbExpanded = false
-                }
-            }
         }
 
         do {
@@ -533,8 +549,8 @@ struct InputBarView: View {
 
     private func cleanupRecognition() {
         recognitionRequest = nil
-        recognitionTask?.cancel()
-        recognitionTask = nil
+        cancelRecognitionTask?()
+        cancelRecognitionTask = nil
     }
 }
 

--- a/clients/ios/project.yml
+++ b/clients/ios/project.yml
@@ -13,6 +13,7 @@ targets:
     platform: iOS
     sources:
       - path: App
+      - path: Services
       - path: Views
       - path: Resources
         buildPhase: resources


### PR DESCRIPTION
## Summary
- Add iOS SpeechRecognizerAdapter protocol with Apple implementation wrapping SFSpeechRecognizer
- Refactor InputBarView to use injected adapter instead of direct recognizer calls
- Add tests covering authorization denied, recognizer unavailable, and successful transcript paths

Part of plan: initial-stt-unification.md (PR 7 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24825" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
