### PR TITLE
Introduce macOS speech recognizer adapter abstraction for voice services

### DIFF
--- a/clients/macos/vellum-assistant/Features/Voice/OpenAIVoiceService.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/OpenAIVoiceService.swift
@@ -36,6 +36,11 @@ final class OpenAIVoiceService: VoiceServiceProtocol {
     var speakingAmplitude: Float = 0
     var livePartialText: String = ""
 
+    // MARK: - Speech Recognizer Adapter
+
+    /// Injected adapter wrapping SFSpeechRecognizer static APIs and instance creation.
+    @ObservationIgnored let speechRecognizerAdapter: any SpeechRecognizerAdapter
+
     // MARK: - Recording State
 
     @ObservationIgnored private let engineController = AudioEngineController(label: "com.vellum.audioEngine.voiceService")
@@ -94,7 +99,9 @@ final class OpenAIVoiceService: VoiceServiceProtocol {
             ?? Self.defaultVoiceId
     }
 
-    nonisolated init() {}
+    nonisolated init(speechRecognizerAdapter: any SpeechRecognizerAdapter = AppleSpeechRecognizerAdapter()) {
+        self.speechRecognizerAdapter = speechRecognizerAdapter
+    }
 
     // MARK: - API Keys
 
@@ -104,21 +111,19 @@ final class OpenAIVoiceService: VoiceServiceProtocol {
     // MARK: - Speech Recognition Authorization
 
     /// Check if speech recognition is authorized. Returns true if authorized.
-    nonisolated static func isSpeechRecognitionAuthorized() -> Bool {
-        SFSpeechRecognizer.authorizationStatus() == .authorized
+    nonisolated func isSpeechRecognitionAuthorized() -> Bool {
+        speechRecognizerAdapter.authorizationStatus() == .authorized
     }
 
     /// Request speech recognition authorization if not yet determined.
-    nonisolated static func requestSpeechRecognitionAuthorization(completion: @escaping (Bool) -> Void) {
-        let status = SFSpeechRecognizer.authorizationStatus()
+    nonisolated func requestSpeechRecognitionAuthorization(completion: @escaping (Bool) -> Void) {
+        let status = speechRecognizerAdapter.authorizationStatus()
         switch status {
         case .authorized:
             completion(true)
         case .notDetermined:
-            SFSpeechRecognizer.requestAuthorization { newStatus in
-                DispatchQueue.main.async {
-                    completion(newStatus == .authorized)
-                }
+            speechRecognizerAdapter.requestAuthorization { newStatus in
+                completion(newStatus == .authorized)
             }
         default:
             completion(false)
@@ -156,7 +161,7 @@ final class OpenAIVoiceService: VoiceServiceProtocol {
         // release delays that make isAvailable return false on the second turn.
         // Recreate if transiently unavailable (e.g. after sleep/wake or heavy use).
         if speechRecognizer == nil || speechRecognizer?.isAvailable != true {
-            speechRecognizer = SFSpeechRecognizer(locale: Locale(identifier: "en-US"))
+            speechRecognizer = speechRecognizerAdapter.makeRecognizer(locale: Locale(identifier: "en-US"))
         }
         guard let recognizer = speechRecognizer, recognizer.isAvailable else {
             log.error("SFSpeechRecognizer not available")

--- a/clients/macos/vellum-assistant/Features/Voice/SpeechRecognizerAdapter.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/SpeechRecognizerAdapter.swift
@@ -1,0 +1,39 @@
+import Foundation
+import Speech
+
+/// Abstraction over `SFSpeechRecognizer` static APIs and instance creation.
+///
+/// The production implementation (`AppleSpeechRecognizerAdapter`) delegates to
+/// the real Speech framework. Tests can substitute a mock to avoid hardware and
+/// permission dependencies.
+protocol SpeechRecognizerAdapter: AnyObject, Sendable {
+    /// Returns the current authorization status for speech recognition.
+    func authorizationStatus() -> SFSpeechRecognizerAuthorizationStatus
+
+    /// Requests speech recognition authorization from the user.
+    /// The completion handler is called on the main queue with the granted status.
+    func requestAuthorization(completion: @escaping @Sendable (SFSpeechRecognizerAuthorizationStatus) -> Void)
+
+    /// Creates a new `SFSpeechRecognizer` for the given locale, or returns nil
+    /// if the locale is not supported.
+    func makeRecognizer(locale: Locale) -> SFSpeechRecognizer?
+}
+
+/// Default adapter backed by the real Apple Speech framework.
+final class AppleSpeechRecognizerAdapter: SpeechRecognizerAdapter {
+    func authorizationStatus() -> SFSpeechRecognizerAuthorizationStatus {
+        SFSpeechRecognizer.authorizationStatus()
+    }
+
+    func requestAuthorization(completion: @escaping @Sendable (SFSpeechRecognizerAuthorizationStatus) -> Void) {
+        SFSpeechRecognizer.requestAuthorization { status in
+            DispatchQueue.main.async {
+                completion(status)
+            }
+        }
+    }
+
+    func makeRecognizer(locale: Locale) -> SFSpeechRecognizer? {
+        SFSpeechRecognizer(locale: locale)
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
@@ -84,10 +84,10 @@ final class VoiceModeManager: ObservableObject {
         guard state == .off else { return }
         wasAutoDeactivated = false
 
-        guard OpenAIVoiceService.isSpeechRecognitionAuthorized() else {
+        guard openAIVoiceService?.isSpeechRecognitionAuthorized() == true else {
             log.error("Voice mode: speech recognition not authorized")
             awaitingAuthorization = true
-            OpenAIVoiceService.requestSpeechRecognitionAuthorization { [weak self] authorized in
+            openAIVoiceService?.requestSpeechRecognitionAuthorization { [weak self] authorized in
                 guard let self, self.awaitingAuthorization else { return }
                 self.awaitingAuthorization = false
                 if authorized {


### PR DESCRIPTION
## Summary
- Add `SpeechRecognizerAdapter` protocol wrapping `SFSpeechRecognizer` authorization and session creation
- Refactor `OpenAIVoiceService` to use injected adapter instead of direct static API calls
- Update `VoiceModeManager` to call authorization methods through adapter on `OpenAIVoiceService` instance

Part of plan: initial-stt-unification.md (PR 5 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24826" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
