### PR TITLE
fix: preserve stale-but-valid local token when silent bootstrap fails

### DIFF
--- a/clients/chrome-extension/background/worker.ts
+++ b/clients/chrome-extension/background/worker.ts
@@ -604,14 +604,13 @@ async function buildRelayModeForAssistant(
         local = await bootstrapLocalToken(assistant.assistantId);
       } catch (err) {
         // Non-recoverable native-host failures (missing host, forbidden
-        // origin, pair endpoint failure) — fall through to the
-        // token-less error path below so the caller surfaces an
-        // actionable error.
+        // origin, pair endpoint failure) — leave the original `local`
+        // value unchanged so a stale-but-not-expired token can still be
+        // used. If the original was already null, nothing changes.
         const detail = err instanceof Error ? err.message : String(err);
         console.warn(
           `[vellum-relay] Silent local token refresh failed: ${detail}`,
         );
-        local = null;
       }
     }
 
@@ -886,11 +885,12 @@ function createRelayConnection(
         try {
           local = await bootstrapLocalToken(selectedId);
         } catch (err) {
+          // Leave original `local` value unchanged so a stale-but-not-expired
+          // token can still be used on reconnect.
           const detail = err instanceof Error ? err.message : String(err);
           console.warn(
             `[vellum-relay] Silent local token refresh on reconnect failed: ${detail}`,
           );
-          local = null;
         }
       }
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for seamless-browser-extension-ux.md.

**Gap:** Silent bootstrap catch block discards stale-but-valid token
**What was expected:** Stale token preserved on bootstrap failure
**What was found:** catch block sets local = null, losing usable token
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24828" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
