### PR TITLE
fix: use separate lastKeepaliveAt field in ChromeExtensionRegistry to avoid routing interference

### DIFF
--- a/assistant/src/__tests__/host-browser-ws-events-e2e.test.ts
+++ b/assistant/src/__tests__/host-browser-ws-events-e2e.test.ts
@@ -299,8 +299,8 @@ describe("host_browser WS event + invalidation e2e", () => {
     await mockExt.waitForConnection();
     await waitForRegistryEntry(guardianId);
 
-    // Grab the initial lastActiveAt timestamp so we can verify it
-    // was bumped by the keepalive.
+    // Grab the initial timestamps so we can verify that keepalive
+    // bumps lastKeepaliveAt but NOT lastActiveAt (routing field).
     const connBefore = getChromeExtensionRegistry().get(guardianId)!;
     const lastActiveBefore = connBefore.lastActiveAt;
 
@@ -313,14 +313,17 @@ describe("host_browser WS event + invalidation e2e", () => {
     // runtime should silently ignore (lenient validation).
     mockExt.sendRaw(JSON.stringify({ type: "keepalive", ts: Date.now() }));
 
-    // Wait for the touch to propagate.
+    // Wait for the touch to propagate — touch() updates
+    // lastKeepaliveAt (not lastActiveAt) to avoid routing interference.
     await waitFor(() => {
       const conn = getChromeExtensionRegistry().get(guardianId);
-      return conn !== undefined && conn.lastActiveAt > lastActiveBefore;
+      return conn !== undefined && (conn.lastKeepaliveAt ?? 0) > 0;
     });
 
     const connAfter = getChromeExtensionRegistry().get(guardianId)!;
-    expect(connAfter.lastActiveAt).toBeGreaterThan(lastActiveBefore);
+    expect(connAfter.lastKeepaliveAt).toBeGreaterThan(0);
+    // lastActiveAt must remain unchanged — keepalives must not affect routing.
+    expect(connAfter.lastActiveAt).toBe(lastActiveBefore);
 
     // Verify the socket is still alive by sending a normal host_browser_event
     // frame after the keepalive — if the socket had been torn down, this

--- a/assistant/src/runtime/chrome-extension-registry.ts
+++ b/assistant/src/runtime/chrome-extension-registry.ts
@@ -20,8 +20,10 @@
  *   - When a caller does not pin a specific instance, the registry picks
  *     the "most recently active" instance for the guardian (highest
  *     `lastActiveAt` timestamp). `lastActiveAt` is bumped on register and
- *     on every successful `send()`, which is a good enough stand-in for
- *     WebSocket heartbeats under the current load profile.
+ *     on every successful `send()` — but NOT by keepalive pings. Keepalive
+ *     frames update a separate `lastKeepaliveAt` field that is used only
+ *     for liveness checks, preventing idle instances from stealing the
+ *     routing default via periodic keepalive traffic.
  *   - When no `clientInstanceId` is present on the handshake (older
  *     extension builds, dev bypass paths), we synthesize a placeholder
  *     `legacy:<connectionId>` key. The send/lookup path treats it the
@@ -65,8 +67,20 @@ export interface ChromeExtensionConnection {
    * connection — updated on register and on each successful `send()`.
    * Used by the default-send routing path to pick the "most recently
    * active" instance when the caller does not pin a specific one.
+   *
+   * Crucially, this is NOT updated by keepalive pings — those update
+   * `lastKeepaliveAt` instead. This separation prevents idle instances
+   * from stealing the routing default via periodic keepalive traffic.
    */
   lastActiveAt: number;
+  /**
+   * Wall-clock timestamp (ms) of the most recent keepalive ping
+   * received on this connection. Updated exclusively by `touch()`
+   * (i.e. keepalive frames). Does NOT affect routing — used only for
+   * liveness checks (e.g. a future stale-connection sweep can evict
+   * connections whose `lastKeepaliveAt` is too far in the past).
+   */
+  lastKeepaliveAt?: number;
   /**
    * Monotonic registration sequence number assigned by the registry
    * on each `register()` call. Used as a tuple-secondary tiebreaker
@@ -199,18 +213,21 @@ export class ChromeExtensionRegistry {
   }
 
   /**
-   * Update the `lastActiveAt` timestamp for the connection identified by
-   * `connectionId`, without changing routing semantics or registration
+   * Update the `lastKeepaliveAt` timestamp for the connection identified
+   * by `connectionId`, without changing routing semantics or registration
    * state. Used by keepalive frames to signal that the extension is still
-   * alive and reachable. No-op if no connection with the given id is
-   * currently registered (e.g. after a race between disconnect and a
-   * trailing keepalive frame).
+   * alive and reachable. Deliberately does NOT update `lastActiveAt` — that
+   * field is reserved for actual CDP traffic (register, send) so that idle
+   * instances cannot steal the routing default via periodic keepalive pings.
+   *
+   * No-op if no connection with the given id is currently registered
+   * (e.g. after a race between disconnect and a trailing keepalive frame).
    */
   touch(connectionId: string): void {
     for (const instances of this.byGuardian.values()) {
       for (const conn of instances.values()) {
         if (conn.id === connectionId) {
-          conn.lastActiveAt = Date.now();
+          conn.lastKeepaliveAt = Date.now();
           return;
         }
       }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for seamless-browser-extension-ux.md.

**Gap:** touch() bumps lastActiveAt, can misroute in multi-instance setups
**What was expected:** touch() should update activity without affecting routing
**What was found:** touch() updates lastActiveAt which is used for routing selection
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24829" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
