### PR TITLE
fix: add reconnecting phase to popup ConnectionPhase for proper status display

### DIFF
--- a/clients/chrome-extension/popup/popup-state.test.ts
+++ b/clients/chrome-extension/popup/popup-state.test.ts
@@ -206,14 +206,24 @@ describe('deriveCtaState', () => {
     expect(state.pauseEnabled).toBe(false);
   });
 
+  test('reconnecting: shows Reconnecting\u2026 label, both buttons disabled', () => {
+    const state = deriveCtaState('reconnecting');
+    expect(state.connectLabel).toBe('Reconnecting\u2026');
+    expect(state.connectEnabled).toBe(false);
+    expect(state.pauseLabel).toBe('Pause');
+    expect(state.pauseEnabled).toBe(false);
+  });
+
   test('all phases produce consistent label/enablement pairs', () => {
-    const phases: ConnectionPhase[] = ['disconnected', 'connecting', 'connected', 'paused'];
+    const phases: ConnectionPhase[] = ['disconnected', 'connecting', 'reconnecting', 'connected', 'paused'];
     for (const phase of phases) {
       const state = deriveCtaState(phase);
       // Pause should only be enabled when connected
       expect(state.pauseEnabled).toBe(phase === 'connected');
-      // Connect should be disabled only when connecting or connected
-      expect(state.connectEnabled).toBe(phase !== 'connecting' && phase !== 'connected');
+      // Connect should be disabled when connecting, reconnecting, or connected
+      expect(state.connectEnabled).toBe(
+        phase !== 'connecting' && phase !== 'reconnecting' && phase !== 'connected',
+      );
     }
   });
 });
@@ -233,6 +243,12 @@ describe('deriveStatusDisplay', () => {
     expect(status.text).toBe('Connecting\u2026');
   });
 
+  test('reconnecting: amber dot, Reconnecting automatically\u2026', () => {
+    const status = deriveStatusDisplay('reconnecting');
+    expect(status.dotClass).toBe('paused');
+    expect(status.text).toBe('Reconnecting automatically\u2026');
+  });
+
   test('connected: green dot, Connected to relay server', () => {
     const status = deriveStatusDisplay('connected');
     expect(status.dotClass).toBe('connected');
@@ -245,18 +261,22 @@ describe('deriveStatusDisplay', () => {
     expect(status.text).toBe('Paused');
   });
 
-  test('display transitions: disconnected -> connecting -> connected -> paused -> disconnected', () => {
+  test('display transitions: disconnected -> connecting -> connected -> reconnecting -> connected -> paused -> disconnected', () => {
     const transitions: ConnectionPhase[] = [
       'disconnected',
       'connecting',
       'connected',
+      'reconnecting',
+      'connected',
       'paused',
       'disconnected',
     ];
-    const expectedDots = ['disconnected', 'disconnected', 'connected', 'paused', 'disconnected'];
+    const expectedDots = ['disconnected', 'disconnected', 'connected', 'paused', 'connected', 'paused', 'disconnected'];
     const expectedTexts = [
       'Not connected',
       'Connecting\u2026',
+      'Connected to relay server',
+      'Reconnecting automatically\u2026',
       'Connected to relay server',
       'Paused',
       'Not connected',
@@ -281,8 +301,8 @@ describe('healthToPhase', () => {
     expect(healthToPhase('connecting')).toBe('connecting');
   });
 
-  test('reconnecting health maps to connecting phase', () => {
-    expect(healthToPhase('reconnecting')).toBe('connecting');
+  test('reconnecting health maps to reconnecting phase', () => {
+    expect(healthToPhase('reconnecting')).toBe('reconnecting');
   });
 
   test('paused health maps to paused phase', () => {
@@ -301,7 +321,7 @@ describe('healthToPhase', () => {
     const healthStates: ConnectionHealthState[] = [
       'paused', 'connecting', 'connected', 'reconnecting', 'auth_required', 'error',
     ];
-    const validPhases = new Set<ConnectionPhase>(['disconnected', 'connecting', 'connected', 'paused']);
+    const validPhases = new Set<ConnectionPhase>(['disconnected', 'connecting', 'reconnecting', 'connected', 'paused']);
 
     for (const health of healthStates) {
       const phase = healthToPhase(health);
@@ -316,9 +336,11 @@ describe('healthToPhase', () => {
     expect(cta.pauseEnabled).toBe(false);
   });
 
-  test('CTA enablement via healthToPhase: reconnecting disables both', () => {
+  test('CTA enablement via healthToPhase: reconnecting disables both buttons', () => {
     const phase = healthToPhase('reconnecting');
+    expect(phase).toBe('reconnecting');
     const cta = deriveCtaState(phase);
+    expect(cta.connectLabel).toBe('Reconnecting\u2026');
     expect(cta.connectEnabled).toBe(false);
     expect(cta.pauseEnabled).toBe(false);
   });

--- a/clients/chrome-extension/popup/popup-state.ts
+++ b/clients/chrome-extension/popup/popup-state.ts
@@ -165,13 +165,14 @@ export function shouldShowCloudSection(
  * The popup's connection lifecycle phase. Drives the primary/secondary
  * button labels, enablement, and status indicator.
  *
- * - `disconnected` — idle, no active relay connection.
- * - `connecting`   — connect in progress (waiting for socket open).
- * - `connected`    — relay WebSocket is open and active.
- * - `paused`       — user explicitly paused; credentials are preserved
- *                    so reconnect is instant.
+ * - `disconnected`  — idle, no active relay connection.
+ * - `connecting`    — connect in progress (waiting for socket open).
+ * - `reconnecting`  — transient disconnect, automatic recovery in progress.
+ * - `connected`     — relay WebSocket is open and active.
+ * - `paused`        — user explicitly paused; credentials are preserved
+ *                     so reconnect is instant.
  */
-export type ConnectionPhase = 'disconnected' | 'connecting' | 'connected' | 'paused';
+export type ConnectionPhase = 'disconnected' | 'connecting' | 'reconnecting' | 'connected' | 'paused';
 
 /**
  * Derived view state for the popup's primary and secondary action buttons.
@@ -194,6 +195,7 @@ export interface CtaState {
  * |--------------|---------------|---------------|
  * | disconnected | Connect (on)  | Pause (off)   |
  * | connecting   | Connecting... (off) | Pause (off) |
+ * | reconnecting | Reconnecting... (off) | Pause (off) |
  * | connected    | Connect (off) | Pause (on)    |
  * | paused       | Connect (on)  | Pause (off)   |
  */
@@ -209,6 +211,13 @@ export function deriveCtaState(phase: ConnectionPhase): CtaState {
     case 'connecting':
       return {
         connectLabel: 'Connecting\u2026',
+        connectEnabled: false,
+        pauseLabel: 'Pause',
+        pauseEnabled: false,
+      };
+    case 'reconnecting':
+      return {
+        connectLabel: 'Reconnecting\u2026',
         connectEnabled: false,
         pauseLabel: 'Pause',
         pauseEnabled: false,
@@ -249,6 +258,8 @@ export function deriveStatusDisplay(phase: ConnectionPhase): StatusDisplay {
       return { dotClass: 'disconnected', text: 'Not connected' };
     case 'connecting':
       return { dotClass: 'disconnected', text: 'Connecting\u2026' };
+    case 'reconnecting':
+      return { dotClass: 'paused', text: 'Reconnecting automatically\u2026' };
     case 'connected':
       return { dotClass: 'connected', text: 'Connected to relay server' };
     case 'paused':
@@ -267,11 +278,11 @@ export function deriveStatusDisplay(phase: ConnectionPhase): StatusDisplay {
  * Map the worker's health state to the popup's connection phase.
  *
  * The popup phase is a simplified view of the health state:
- *   - `connected` and `reconnecting` both map to phases that keep
- *     the user informed without requiring action.
+ *   - `connected`, `reconnecting`, and `connecting` map directly to
+ *     their respective phases.
  *   - `auth_required` and `error` map to `disconnected` since the
  *     user may need to take action.
- *   - `paused` and `connecting` map directly.
+ *   - `paused` maps directly.
  */
 export function healthToPhase(health: ConnectionHealthState): ConnectionPhase {
   switch (health) {
@@ -280,7 +291,7 @@ export function healthToPhase(health: ConnectionHealthState): ConnectionPhase {
     case 'connecting':
       return 'connecting';
     case 'reconnecting':
-      return 'connecting';
+      return 'reconnecting';
     case 'paused':
       return 'paused';
     case 'auth_required':


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for seamless-browser-extension-ux.md.

**Gap:** Popup ConnectionPhase lacks reconnecting value
**What was expected:** Popup shows 'Reconnecting automatically...' for reconnecting state
**What was found:** healthToPhase maps reconnecting to connecting, showing wrong status
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24832" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
