### PR TITLE
Seamless browser extension background UX

### DIFF
--- a/assistant/src/__tests__/fixtures/mock-chrome-extension.ts
+++ b/assistant/src/__tests__/fixtures/mock-chrome-extension.ts
@@ -124,6 +124,12 @@ export interface MockChromeExtension {
    * command.
    */
   sendSessionInvalidated(event: { targetId?: string; reason?: string }): void;
+  /**
+   * Send an arbitrary pre-serialized JSON string over the active
+   * WebSocket. Used by tests that need to send frame types not covered
+   * by the fixture's typed helpers (e.g. keepalive frames).
+   */
+  sendRaw(json: string): void;
 }
 
 // ── Defaults ────────────────────────────────────────────────────────
@@ -370,6 +376,11 @@ export function createMockChromeExtension(
           ...(event.reason !== undefined ? { reason: event.reason } : {}),
         }),
       );
+    },
+    sendRaw(json: string) {
+      const sock = ws;
+      if (!sock || sock.readyState !== WebSocket.OPEN) return;
+      sock.send(json);
     },
   };
 }

--- a/assistant/src/__tests__/host-browser-ws-events-e2e.test.ts
+++ b/assistant/src/__tests__/host-browser-ws-events-e2e.test.ts
@@ -299,8 +299,8 @@ describe("host_browser WS event + invalidation e2e", () => {
     await mockExt.waitForConnection();
     await waitForRegistryEntry(guardianId);
 
-    // Grab the initial lastActiveAt timestamp so we can verify it
-    // was bumped by the keepalive.
+    // Grab the initial timestamps so we can verify that keepalive
+    // bumps lastKeepaliveAt but NOT lastActiveAt (routing field).
     const connBefore = getChromeExtensionRegistry().get(guardianId)!;
     const lastActiveBefore = connBefore.lastActiveAt;
 
@@ -313,14 +313,17 @@ describe("host_browser WS event + invalidation e2e", () => {
     // runtime should silently ignore (lenient validation).
     mockExt.sendRaw(JSON.stringify({ type: "keepalive", ts: Date.now() }));
 
-    // Wait for the touch to propagate.
+    // Wait for the touch to propagate — touch() updates
+    // lastKeepaliveAt (not lastActiveAt) to avoid routing interference.
     await waitFor(() => {
       const conn = getChromeExtensionRegistry().get(guardianId);
-      return conn !== undefined && conn.lastActiveAt > lastActiveBefore;
+      return conn !== undefined && (conn.lastKeepaliveAt ?? 0) > 0;
     });
 
     const connAfter = getChromeExtensionRegistry().get(guardianId)!;
-    expect(connAfter.lastActiveAt).toBeGreaterThan(lastActiveBefore);
+    expect(connAfter.lastKeepaliveAt).toBeGreaterThan(0);
+    // lastActiveAt must remain unchanged — keepalives must not affect routing.
+    expect(connAfter.lastActiveAt).toBe(lastActiveBefore);
 
     // Verify the socket is still alive by sending a normal host_browser_event
     // frame after the keepalive — if the socket had been torn down, this

--- a/assistant/src/__tests__/host-browser-ws-events-e2e.test.ts
+++ b/assistant/src/__tests__/host-browser-ws-events-e2e.test.ts
@@ -284,6 +284,106 @@ describe("host_browser WS event + invalidation e2e", () => {
     await mockExt.stop();
   });
 
+  test("keepalive frames are accepted without closing the socket or producing warnings", async () => {
+    const guardianId = `guardian-${crypto.randomUUID()}`;
+    const { token } = mintHostBrowserCapability(guardianId);
+
+    const { createMockChromeExtension } =
+      await import("./fixtures/mock-chrome-extension.js");
+    const mockExt = createMockChromeExtension({
+      runtimeBaseUrl,
+      token,
+      resultTransport: "ws",
+    });
+    await mockExt.start();
+    await mockExt.waitForConnection();
+    await waitForRegistryEntry(guardianId);
+
+    // Grab the initial lastActiveAt timestamp so we can verify it
+    // was bumped by the keepalive.
+    const connBefore = getChromeExtensionRegistry().get(guardianId)!;
+    const lastActiveBefore = connBefore.lastActiveAt;
+
+    // Small delay to ensure Date.now() advances at least 1ms.
+    await new Promise((r) => setTimeout(r, 15));
+
+    // Send a keepalive frame (the extension sends these periodically
+    // to prevent the runtime from considering the connection stale).
+    // The frame may contain extra keys (e.g. timestamp) that the
+    // runtime should silently ignore (lenient validation).
+    mockExt.sendRaw(JSON.stringify({ type: "keepalive", ts: Date.now() }));
+
+    // Wait for the touch to propagate.
+    await waitFor(() => {
+      const conn = getChromeExtensionRegistry().get(guardianId);
+      return conn !== undefined && conn.lastActiveAt > lastActiveBefore;
+    });
+
+    const connAfter = getChromeExtensionRegistry().get(guardianId)!;
+    expect(connAfter.lastActiveAt).toBeGreaterThan(lastActiveBefore);
+
+    // Verify the socket is still alive by sending a normal host_browser_event
+    // frame after the keepalive — if the socket had been torn down, this
+    // would never arrive.
+    const observed: ForwardedCdpEvent[] = [];
+    const unsubscribe = onCdpEvent((event) => observed.push(event));
+
+    mockExt.sendHostBrowserEvent({ method: "Page.loadEventFired" });
+    await waitFor(() => observed.length === 1);
+    expect(observed[0].method).toBe("Page.loadEventFired");
+
+    unsubscribe();
+    await mockExt.stop();
+  });
+
+  test("normal host_browser flows still pass after keepalive traffic", async () => {
+    const guardianId = `guardian-${crypto.randomUUID()}`;
+    const { token } = mintHostBrowserCapability(guardianId);
+
+    const { createMockChromeExtension } =
+      await import("./fixtures/mock-chrome-extension.js");
+    const mockExt = createMockChromeExtension({
+      runtimeBaseUrl,
+      token,
+      resultTransport: "ws",
+    });
+    await mockExt.start();
+    await mockExt.waitForConnection();
+    await waitForRegistryEntry(guardianId);
+
+    // Simulate a burst of keepalive frames (as would happen during an
+    // idle period with the extension's alarm-based keepalive ticker).
+    for (let i = 0; i < 5; i++) {
+      mockExt.sendRaw(JSON.stringify({ type: "keepalive" }));
+    }
+
+    // Small delay to let all keepalive frames process.
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Now send a host_browser_event and verify it still fans out
+    // correctly — proving keepalive traffic does not interfere with
+    // normal message processing.
+    const observed: ForwardedCdpEvent[] = [];
+    const unsubscribe = onCdpEvent((event) => observed.push(event));
+
+    mockExt.sendHostBrowserEvent({
+      method: "Network.requestWillBeSent",
+      params: { requestId: "req-42", url: "https://example.com/api" },
+      cdpSessionId: "session-xyz",
+    });
+
+    await waitFor(() => observed.length === 1);
+    expect(observed[0].method).toBe("Network.requestWillBeSent");
+    expect(observed[0].params).toEqual({
+      requestId: "req-42",
+      url: "https://example.com/api",
+    });
+    expect(observed[0].cdpSessionId).toBe("session-xyz");
+
+    unsubscribe();
+    await mockExt.stop();
+  });
+
   test("malformed host_browser_event frames are dropped without tearing down the socket", async () => {
     const guardianId = `guardian-${crypto.randomUUID()}`;
     const { token } = mintHostBrowserCapability(guardianId);

--- a/assistant/src/runtime/chrome-extension-registry.ts
+++ b/assistant/src/runtime/chrome-extension-registry.ts
@@ -199,6 +199,25 @@ export class ChromeExtensionRegistry {
   }
 
   /**
+   * Update the `lastActiveAt` timestamp for the connection identified by
+   * `connectionId`, without changing routing semantics or registration
+   * state. Used by keepalive frames to signal that the extension is still
+   * alive and reachable. No-op if no connection with the given id is
+   * currently registered (e.g. after a race between disconnect and a
+   * trailing keepalive frame).
+   */
+  touch(connectionId: string): void {
+    for (const instances of this.byGuardian.values()) {
+      for (const conn of instances.values()) {
+        if (conn.id === connectionId) {
+          conn.lastActiveAt = Date.now();
+          return;
+        }
+      }
+    }
+  }
+
+  /**
    * Return the default "active" connection for a guardian — the
    * instance with the most recent `lastActiveAt` timestamp. Ties on
    * `lastActiveAt` (common when two sibling instances register or

--- a/assistant/src/runtime/chrome-extension-registry.ts
+++ b/assistant/src/runtime/chrome-extension-registry.ts
@@ -20,8 +20,10 @@
  *   - When a caller does not pin a specific instance, the registry picks
  *     the "most recently active" instance for the guardian (highest
  *     `lastActiveAt` timestamp). `lastActiveAt` is bumped on register and
- *     on every successful `send()`, which is a good enough stand-in for
- *     WebSocket heartbeats under the current load profile.
+ *     on every successful `send()` — but NOT by keepalive pings. Keepalive
+ *     frames update a separate `lastKeepaliveAt` field that is used only
+ *     for liveness checks, preventing idle instances from stealing the
+ *     routing default via periodic keepalive traffic.
  *   - When no `clientInstanceId` is present on the handshake (older
  *     extension builds, dev bypass paths), we synthesize a placeholder
  *     `legacy:<connectionId>` key. The send/lookup path treats it the
@@ -65,8 +67,20 @@ export interface ChromeExtensionConnection {
    * connection — updated on register and on each successful `send()`.
    * Used by the default-send routing path to pick the "most recently
    * active" instance when the caller does not pin a specific one.
+   *
+   * Crucially, this is NOT updated by keepalive pings — those update
+   * `lastKeepaliveAt` instead. This separation prevents idle instances
+   * from stealing the routing default via periodic keepalive traffic.
    */
   lastActiveAt: number;
+  /**
+   * Wall-clock timestamp (ms) of the most recent keepalive ping
+   * received on this connection. Updated exclusively by `touch()`
+   * (i.e. keepalive frames). Does NOT affect routing — used only for
+   * liveness checks (e.g. a future stale-connection sweep can evict
+   * connections whose `lastKeepaliveAt` is too far in the past).
+   */
+  lastKeepaliveAt?: number;
   /**
    * Monotonic registration sequence number assigned by the registry
    * on each `register()` call. Used as a tuple-secondary tiebreaker
@@ -199,18 +213,21 @@ export class ChromeExtensionRegistry {
   }
 
   /**
-   * Update the `lastActiveAt` timestamp for the connection identified by
-   * `connectionId`, without changing routing semantics or registration
+   * Update the `lastKeepaliveAt` timestamp for the connection identified
+   * by `connectionId`, without changing routing semantics or registration
    * state. Used by keepalive frames to signal that the extension is still
-   * alive and reachable. No-op if no connection with the given id is
-   * currently registered (e.g. after a race between disconnect and a
-   * trailing keepalive frame).
+   * alive and reachable. Deliberately does NOT update `lastActiveAt` — that
+   * field is reserved for actual CDP traffic (register, send) so that idle
+   * instances cannot steal the routing default via periodic keepalive pings.
+   *
+   * No-op if no connection with the given id is currently registered
+   * (e.g. after a race between disconnect and a trailing keepalive frame).
    */
   touch(connectionId: string): void {
     for (const instances of this.byGuardian.values()) {
       for (const conn of instances.values()) {
         if (conn.id === connectionId) {
-          conn.lastActiveAt = Date.now();
+          conn.lastKeepaliveAt = Date.now();
           return;
         }
       }

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -520,6 +520,14 @@ export class RuntimeHttpServer {
                 }
                 return;
               }
+              case "keepalive": {
+                // Extension keepalive frames refresh the connection's
+                // activity timestamp without producing log noise or
+                // altering routing semantics. Unknown extra keys on
+                // the frame are silently ignored (lenient validation).
+                getChromeExtensionRegistry().touch(data.connectionId);
+                return;
+              }
               default: {
                 log.debug(
                   { connectionId: data.connectionId, type: frame.type },

--- a/assistant/src/tools/browser/cdp-client/__tests__/factory.test.ts
+++ b/assistant/src/tools/browser/cdp-client/__tests__/factory.test.ts
@@ -541,7 +541,7 @@ describe("getCdpClient", () => {
     expect(createExtensionCdpClientMock).toHaveBeenCalledTimes(1);
   });
 
-  test("context with transportInterface set routes normally to local backend when no proxy", async () => {
+  test("context with transportInterface=macos routes to desktop-auto cdp-inspect when no proxy", async () => {
     const ctx = makeContext({
       conversationId: "macos-local",
       transportInterface: "macos",
@@ -549,10 +549,12 @@ describe("getCdpClient", () => {
 
     const client = getCdpClient(ctx);
 
-    expect(client.kind).toBe("local");
+    // desktopAuto.enabled is true by default and no proxy is provisioned,
+    // so cdp-inspect is the first candidate (desktop-auto path).
+    expect(client.kind).toBe("cdp-inspect");
     expect(client.conversationId).toBe("macos-local");
-    await client.send("Runtime.evaluate");
-    expect(createLocalCdpClientMock).toHaveBeenCalledTimes(1);
+    await client.send("Page.navigate");
+    expect(createCdpInspectClientMock).toHaveBeenCalledTimes(1);
   });
 
   test("context with transportInterface set routes to cdp-inspect when enabled", async () => {
@@ -1003,6 +1005,55 @@ describe("desktop-auto cdp-inspect (macOS)", () => {
     expect(candidates[2].kind).toBe("local");
   });
 
+  test("macOS turn with proxy unavailable skips desktop-auto cdp-inspect (extension intent)", () => {
+    const fakeProxy = makeUnavailableProxy();
+    const ctx = makeContext({
+      conversationId: "macos-proxy-unavailable-no-inspect",
+      hostBrowserProxy: fakeProxy,
+      transportInterface: "macos",
+    });
+
+    const candidates = buildCandidateList(ctx);
+
+    // Should only include local -- cdp-inspect is suppressed because extension
+    // transport is expected (proxy exists) but temporarily unavailable.
+    expect(candidates.length).toBe(1);
+    expect(candidates[0].kind).toBe("local");
+  });
+
+  test("macOS turn with no proxy still includes desktop-auto cdp-inspect", () => {
+    const ctx = makeContext({
+      conversationId: "macos-no-proxy-inspect-allowed",
+      transportInterface: "macos",
+    });
+
+    const candidates = buildCandidateList(ctx);
+
+    // No proxy provisioned => cdp-inspect remains available as fallback
+    expect(candidates.length).toBe(2);
+    expect(candidates[0].kind).toBe("cdp-inspect");
+    expect(candidates[0].reason).toContain("desktopAuto");
+    expect(candidates[1].kind).toBe("local");
+  });
+
+  test("macOS turn with extension available still includes cdp-inspect as fallback", () => {
+    const fakeProxy = makeAvailableProxy();
+    const ctx = makeContext({
+      conversationId: "macos-ext-available-inspect-fallback",
+      hostBrowserProxy: fakeProxy,
+      transportInterface: "macos",
+    });
+
+    const candidates = buildCandidateList(ctx);
+
+    // Extension is available => extension + cdp-inspect (desktop-auto) + local
+    expect(candidates.length).toBe(3);
+    expect(candidates[0].kind).toBe("extension");
+    expect(candidates[1].kind).toBe("cdp-inspect");
+    expect(candidates[1].reason).toContain("desktopAuto");
+    expect(candidates[2].kind).toBe("local");
+  });
+
   test("macOS turn does NOT include cdp-inspect when desktopAuto.enabled is false", () => {
     desktopAutoConfig = { enabled: false, cooldownMs: 30_000 };
     const ctx = makeContext({
@@ -1136,6 +1187,28 @@ describe("desktop-auto cdp-inspect (macOS)", () => {
     const candidates = buildCandidateList(ctx2);
     expect(candidates.length).toBe(1);
     expect(candidates[0].kind).toBe("local");
+  });
+
+  test("macOS turn with proxy unavailable routes to local without trying cdp-inspect", async () => {
+    const fakeProxy = makeUnavailableProxy();
+    const ctx = makeContext({
+      conversationId: "macos-proxy-unavail-route",
+      hostBrowserProxy: fakeProxy,
+      transportInterface: "macos",
+    });
+
+    const client = getCdpClient(ctx);
+
+    // Should go straight to local -- no cdp-inspect candidate inserted
+    expect(client.kind).toBe("local");
+    const result = await client.send<{ ok: boolean; via: string }>(
+      "Page.navigate",
+    );
+    expect(result).toEqual({ ok: true, via: "local" });
+    expect(createCdpInspectClientMock).not.toHaveBeenCalled();
+    expect(createExtensionCdpClientMock).not.toHaveBeenCalled();
+    expect(createLocalCdpClientMock).toHaveBeenCalledTimes(1);
+    client.dispose();
   });
 
   test("explicit config cdp-inspect failure does NOT record desktop-auto cooldown", async () => {

--- a/assistant/src/tools/browser/cdp-client/factory.ts
+++ b/assistant/src/tools/browser/cdp-client/factory.ts
@@ -208,38 +208,52 @@ export function buildCandidateList(context: ToolContext): BackendCandidate[] {
     context.transportInterface === "macos" &&
     cdpInspectConfig.desktopAuto.enabled
   ) {
-    // macOS desktop-auto: include cdp-inspect as a candidate unless the
-    // cooldown from a recent failure is still active.
-    const { cooldownMs } = cdpInspectConfig.desktopAuto;
-    if (isDesktopAutoCooldownActive(cooldownMs)) {
+    // macOS desktop-auto: include cdp-inspect as a candidate unless:
+    // (a) the hostBrowserProxy exists but is temporarily unavailable
+    //     (extension transport expected but transiently disconnected --
+    //     inserting cdp-inspect here would cause a silent takeover), or
+    // (b) the cooldown from a recent failure is still active.
+    //
+    // When no hostBrowserProxy is present at all (extension not
+    // provisioned for this conversation), cdp-inspect remains available
+    // as a fallback per the desktop-auto contract.
+    if (hostBrowserProxy && !hostBrowserProxy.isAvailable()) {
       log.debug(
-        {
-          conversationId,
-          cooldownMs,
-          cooldownSince: _desktopAutoCooldownSince,
-        },
-        "CDP factory: desktop-auto cdp-inspect skipped (cooldown active)",
+        { conversationId },
+        "CDP factory: desktop-auto cdp-inspect skipped (extension transport expected but temporarily unavailable)",
       );
     } else {
-      candidates.push({
-        kind: "cdp-inspect",
-        reason: "desktopAuto: macOS turn, cdp-inspect auto-attempted",
-        create() {
-          const client = createCdpInspectClient(conversationId, {
-            host: cdpInspectConfig.host,
-            port: cdpInspectConfig.port,
-            discoveryTimeoutMs: cdpInspectConfig.probeTimeoutMs,
-            wsConnectTimeoutMs: cdpInspectConfig.probeTimeoutMs,
-          });
-          const backend = createCdpInspectBackend({
-            isAvailable: () => true,
-            sendCdp: (command, signal) =>
-              dispatchThroughClient(client, command, signal),
-            dispose: () => client.dispose(),
-          });
-          return { client, backend };
-        },
-      });
+      const { cooldownMs } = cdpInspectConfig.desktopAuto;
+      if (isDesktopAutoCooldownActive(cooldownMs)) {
+        log.debug(
+          {
+            conversationId,
+            cooldownMs,
+            cooldownSince: _desktopAutoCooldownSince,
+          },
+          "CDP factory: desktop-auto cdp-inspect skipped (cooldown active)",
+        );
+      } else {
+        candidates.push({
+          kind: "cdp-inspect",
+          reason: "desktopAuto: macOS turn, cdp-inspect auto-attempted",
+          create() {
+            const client = createCdpInspectClient(conversationId, {
+              host: cdpInspectConfig.host,
+              port: cdpInspectConfig.port,
+              discoveryTimeoutMs: cdpInspectConfig.probeTimeoutMs,
+              wsConnectTimeoutMs: cdpInspectConfig.probeTimeoutMs,
+            });
+            const backend = createCdpInspectBackend({
+              isAvailable: () => true,
+              sendCdp: (command, signal) =>
+                dispatchThroughClient(client, command, signal),
+              dispose: () => client.dispose(),
+            });
+            return { client, backend };
+          },
+        });
+      }
     }
   }
 

--- a/clients/chrome-extension/README.md
+++ b/clients/chrome-extension/README.md
@@ -36,12 +36,18 @@ Then in Chrome:
 3. Click **Load unpacked**
 4. Select `clients/chrome-extension/dist`
 
-## How It Works — One-Click Connect
+## How It Works — Install Once, Connect Once, Forget It
 
 The extension discovers available assistants from the lockfile via the native
 messaging helper (`com.vellum.daemon`). The lockfile lists every assistant
 configured on the machine, along with its hosting topology (`cloud` field),
 runtime URL, and local assistant port.
+
+After the first successful Connect, the extension maintains a long-lived
+background connection and recovers automatically from transient interruptions
+(browser restarts, network drops, service-worker suspension, token rotation).
+Users should **not** need to touch Pair, Sign-in, or Connect again under
+normal operation.
 
 ### First-Time Connect (One Click)
 
@@ -59,6 +65,39 @@ runtime URL, and local assistant port.
 
 The entire flow is a single user action — click **Connect**.
 
+### Long-Lived Background Behavior
+
+After a successful first connect, the extension runs as a long-lived
+background service. The relay WebSocket stays open and the service worker
+sends periodic keepalive frames (every 20 seconds) to prevent Chrome's
+MV3 idle-suspension timeout (~30 seconds). The assistant runtime
+acknowledges keepalives by touching the connection's activity timestamp
+in the `ChromeExtensionRegistry`.
+
+The extension handles the following interruptions automatically:
+
+| Interruption | Recovery |
+|---|---|
+| **Service-worker restart** (Chrome MV3 teardown/relaunch) | Auto-reconnect via persisted `autoConnect` flag and stored credentials. |
+| **Transient network drop** (cable unplugged, Wi-Fi blip) | Exponential-backoff reconnect (1 s base, 30 s cap). |
+| **Token expiry** (local capability token or cloud JWT) | Silent non-interactive token refresh via native messaging (local) or OAuth refresh (cloud) before the next reconnect attempt. |
+| **Assistant restart** | WebSocket close triggers reconnect; the extension re-establishes the relay against the new runtime instance. |
+| **Browser close and reopen** | The `autoConnect` flag persists across browser sessions, so the worker auto-connects on startup. |
+
+Users should **not** re-pair, re-sign-in, or re-click Connect for any of
+these cases. The popup's health indicator shows the current state
+(`Connected`, `Reconnecting automatically...`, `Paused`, or
+`Action required`) so users can verify recovery is happening without
+taking action.
+
+### When User Action IS Required
+
+The extension enters `auth_required` only when non-interactive token
+refresh is impossible (e.g. the cloud OAuth refresh token itself has
+expired, or the native messaging host is uninstalled). In this state the
+popup's Troubleshooting section expands automatically and prompts the
+user to re-pair (local) or re-sign-in (cloud), then click **Connect**.
+
 ### Auto-Connect On Reopen
 
 After a successful first connect, the extension sets a persistent
@@ -66,9 +105,10 @@ After a successful first connect, the extension sets a persistent
 restarts), the worker reads this flag and automatically reconnects using
 the stored credentials — no user interaction required.
 
-If stored credentials have expired or are missing at auto-connect time,
-the extension falls back to the disconnected state silently. The user
-can click **Connect** again to re-bootstrap credentials interactively.
+If stored credentials have expired or are missing at auto-connect time
+and silent refresh also fails, the extension transitions to
+`auth_required`. The user can click **Connect** to re-bootstrap
+credentials interactively.
 
 ### Pause Semantics
 
@@ -79,7 +119,9 @@ can click **Connect** again to re-bootstrap credentials interactively.
 - Preserves stored credentials so the next **Connect** is instant (no
   re-pair or re-sign-in needed unless the token has expired).
 
-Pause replaces the previous "Disconnect" terminology.
+Pause replaces the previous "Disconnect" terminology. It is the only
+action that intentionally stops the extension — all other disconnects
+trigger automatic recovery.
 
 ### Assistant Discovery And Selection
 
@@ -127,8 +169,89 @@ switching between assistants does not require re-authentication.
 The popup includes a collapsible **Troubleshooting** section with manual
 "Re-pair with local assistant" and "Re-sign in with Vellum (cloud)"
 buttons. These are **not** required for the normal connect flow — they
-exist for edge cases where the automatic bootstrap fails (e.g. expired
-tokens, native host issues, OAuth configuration problems).
+exist for edge cases where automatic recovery is impossible.
+
+**When to use Troubleshooting controls:**
+- The popup shows `Action required` with an `auth_required` health state.
+- The Troubleshooting section expanded automatically (it stays collapsed
+  during `connected`, `reconnecting`, `connecting`, and `paused` states).
+
+**When NOT to use Troubleshooting controls:**
+- The popup shows `Reconnecting automatically...` — the extension is
+  already recovering and will reconnect on its own.
+- The popup shows `Connected` — everything is working.
+- The popup shows `Paused` — click **Connect** (not Troubleshoot) to
+  resume.
+
+Transient disconnects (network drops, service-worker restarts, assistant
+restarts) are handled silently with exponential-backoff reconnect and
+automatic token refresh. Touching the Troubleshooting controls during a
+transient interruption is unnecessary and may interfere with the
+automatic recovery path.
+
+### Connection Health States
+
+The worker maintains a structured health state machine surfaced to the
+popup via `get_status`. The six states drive the popup's status indicator,
+button enablement, and Troubleshooting section visibility:
+
+| State | Popup display | Auto-reconnect? | User action needed? |
+|---|---|---|---|
+| `connected` | Green dot, "Connected" | n/a | No |
+| `connecting` | Gray dot, "Connecting..." | n/a | No |
+| `reconnecting` | Yellow dot, "Reconnecting automatically..." | Yes | No |
+| `paused` | Yellow dot, "Paused" | No | Click Connect to resume |
+| `auth_required` | Gray dot, "Action required: ..." | No | Re-pair / Re-sign-in, then Connect |
+| `error` | Gray dot, "Error: ..." | No | Check Troubleshooting section |
+
+The `reconnecting` state means the extension detected an unexpected
+disconnect and is actively recovering — the user should wait. Only
+`auth_required` and `error` warrant manual intervention.
+
+## End-to-End Validation (QA Playbook)
+
+Use this checklist to verify the "install once, connect once, forget it"
+contract from a clean state.
+
+### Setup
+1. Build and load the extension (see [Build And Load](#build-and-load-the-extension)).
+2. Start at least one local assistant (or have a cloud-managed assistant configured).
+3. Verify the native messaging host is installed (macOS app installs it automatically).
+
+### Happy path
+1. Open the extension popup.
+2. Click **Connect**. Verify the status transitions: `Connecting...` then `Connected`.
+3. Close Chrome completely. Reopen Chrome.
+4. Open the extension popup. Verify the status shows `Connected` (auto-reconnect from `autoConnect` flag).
+5. Open the service worker console (`chrome://extensions` > Service worker link). Verify keepalive frames are logged every ~20 seconds.
+
+### Automatic recovery — network drop
+1. While connected, disable your network adapter (Wi-Fi off, cable out).
+2. Open the popup. Verify the status shows `Reconnecting automatically...`.
+3. Re-enable the network adapter.
+4. Verify the status returns to `Connected` within ~30 seconds (backoff cap).
+
+### Automatic recovery — assistant restart
+1. While connected, stop the assistant process.
+2. Verify the popup shows `Reconnecting automatically...`.
+3. Restart the assistant.
+4. Verify the popup returns to `Connected`.
+
+### Automatic recovery — token refresh
+1. While connected, manually expire or delete the stored token in `chrome.storage.local`.
+2. On the next reconnect cycle, the extension should silently re-bootstrap the token (local pair via native messaging, or cloud via OAuth refresh).
+3. Verify the popup returns to `Connected` without manual intervention.
+
+### Pause and resume
+1. While connected, click **Pause**. Verify the status shows `Paused`.
+2. Close and reopen Chrome. Verify the popup still shows `Paused` (autoConnect cleared).
+3. Click **Connect**. Verify the status returns to `Connected`.
+
+### Auth failure (manual recovery required)
+1. Uninstall the native messaging host (or revoke the cloud OAuth token entirely).
+2. Force a reconnect (restart Chrome or stop/start the assistant).
+3. Verify the popup shows `Action required` and the Troubleshooting section expands automatically.
+4. Reinstall the native host (or re-sign-in), then click **Connect**. Verify recovery.
 
 ## Native Messaging Host Setup (If Pairing Fails)
 

--- a/clients/chrome-extension/background/__tests__/relay-connection.test.ts
+++ b/clients/chrome-extension/background/__tests__/relay-connection.test.ts
@@ -11,6 +11,7 @@ import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
 
 import {
   RelayConnection,
+  KEEPALIVE_INTERVAL_MS,
   type RelayMode,
   type RelayReconnectContext,
   type RelayReconnectDecision,
@@ -953,6 +954,307 @@ describe('RelayConnection', () => {
       // ws.readyState is still CONNECTING (0).
       conn.send('too-early');
       expect(instances[0].sent).toEqual([]);
+    });
+  });
+
+  describe('keepalive', () => {
+    /**
+     * These tests intercept setInterval/clearInterval to verify keepalive
+     * timer lifecycle without waiting for real 20-second intervals.
+     */
+
+    /** Tracks setInterval calls for deterministic keepalive testing. */
+    interface IntervalRecord {
+      id: number;
+      callback: () => void;
+      ms: number;
+      cleared: boolean;
+    }
+
+    let intervalRecords: IntervalRecord[];
+    let nextIntervalId: number;
+    let origSetInterval: typeof setInterval;
+    let origClearInterval: typeof clearInterval;
+
+    function installFakeIntervals(): void {
+      intervalRecords = [];
+      nextIntervalId = 9000;
+      origSetInterval = globalThis.setInterval;
+      origClearInterval = globalThis.clearInterval;
+
+      (globalThis as unknown as { setInterval: typeof setInterval }).setInterval = ((
+        cb: () => void,
+        ms: number,
+      ) => {
+        const id = nextIntervalId++;
+        intervalRecords.push({ id, callback: cb, ms, cleared: false });
+        return id as unknown as ReturnType<typeof setInterval>;
+      }) as typeof setInterval;
+
+      (globalThis as unknown as { clearInterval: typeof clearInterval }).clearInterval = ((
+        id: ReturnType<typeof clearInterval>,
+      ) => {
+        const record = intervalRecords.find((r) => r.id === (id as unknown as number));
+        if (record) record.cleared = true;
+      }) as typeof clearInterval;
+    }
+
+    function restoreFakeIntervals(): void {
+      globalThis.setInterval = origSetInterval;
+      globalThis.clearInterval = origClearInterval;
+    }
+
+    /** Fire the callback of all active (non-cleared) interval records. */
+    function tickActiveIntervals(): void {
+      for (const record of intervalRecords) {
+        if (!record.cleared) record.callback();
+      }
+    }
+
+    /** Return all non-cleared interval records. */
+    function activeIntervals(): IntervalRecord[] {
+      return intervalRecords.filter((r) => !r.cleared);
+    }
+
+    test('sends keepalive frames only while the socket is OPEN', () => {
+      installFakeIntervals();
+      try {
+        const cbs = makeCallbacks();
+        const conn = makeConn(
+          { kind: 'self-hosted', baseUrl: 'http://127.0.0.1:7830', token: 't' },
+          cbs,
+        );
+
+        conn.start();
+
+        // While CONNECTING — no interval should have been created.
+        expect(activeIntervals().length).toBe(0);
+        expect(instances[0].sent.length).toBe(0);
+
+        // Open the socket — keepalive timer should now be active.
+        openSocket(instances[0]);
+        expect(activeIntervals().length).toBe(1);
+        expect(activeIntervals()[0].ms).toBe(KEEPALIVE_INTERVAL_MS);
+
+        // Simulate the interval firing — should send a keepalive frame.
+        tickActiveIntervals();
+
+        expect(instances[0].sent.length).toBe(1);
+        const frame = JSON.parse(instances[0].sent[0]);
+        expect(frame.type).toBe('keepalive');
+        expect(typeof frame.sentAt).toBe('number');
+        expect(frame.sentAt).toBeGreaterThan(0);
+
+        conn.close();
+      } finally {
+        restoreFakeIntervals();
+      }
+    });
+
+    test('keepalive does not send when socket readyState is not OPEN', () => {
+      installFakeIntervals();
+      try {
+        const cbs = makeCallbacks();
+        const conn = makeConn(
+          { kind: 'self-hosted', baseUrl: 'http://127.0.0.1:7830', token: 't' },
+          cbs,
+        );
+
+        conn.start();
+        openSocket(instances[0]);
+        expect(activeIntervals().length).toBe(1);
+
+        // Simulate the socket transitioning to CLOSING before the
+        // interval fires (race condition edge case).
+        instances[0].readyState = 2; // CLOSING
+
+        tickActiveIntervals();
+        // No frame should have been sent because readyState is not OPEN.
+        expect(instances[0].sent.length).toBe(0);
+
+        conn.close();
+      } finally {
+        restoreFakeIntervals();
+      }
+    });
+
+    test('keepalives stop immediately after close()', () => {
+      installFakeIntervals();
+      try {
+        const cbs = makeCallbacks();
+        const conn = makeConn(
+          { kind: 'self-hosted', baseUrl: 'http://127.0.0.1:7830', token: 't' },
+          cbs,
+        );
+
+        conn.start();
+        openSocket(instances[0]);
+        expect(activeIntervals().length).toBe(1);
+
+        conn.close();
+
+        // The interval should have been cleared.
+        expect(activeIntervals().length).toBe(0);
+        expect(intervalRecords[0].cleared).toBe(true);
+
+        // Simulate firing the interval callback after clear — should
+        // be a no-op (belt-and-suspenders: even if the cleared callback
+        // somehow fires, readyState check prevents sending).
+        tickActiveIntervals();
+        expect(instances[0].sent.length).toBe(0);
+      } finally {
+        restoreFakeIntervals();
+      }
+    });
+
+    test('keepalives stop immediately after setMode()', () => {
+      installFakeIntervals();
+      try {
+        const cbs = makeCallbacks();
+        const conn = makeConn(
+          { kind: 'self-hosted', baseUrl: 'http://127.0.0.1:7830', token: 't' },
+          cbs,
+        );
+
+        conn.start();
+        openSocket(instances[0]);
+        expect(activeIntervals().length).toBe(1);
+        const firstIntervalId = intervalRecords[0].id;
+
+        // Switch modes — keepalive for the old socket should stop.
+        conn.setMode({
+          kind: 'cloud',
+          baseUrl: 'https://api.vellum.ai',
+          token: 'cloud-jwt',
+        });
+
+        // The first interval should be cleared.
+        expect(intervalRecords.find((r) => r.id === firstIntervalId)!.cleared).toBe(true);
+
+        // The new socket is still CONNECTING, so no new interval yet.
+        expect(activeIntervals().length).toBe(0);
+
+        // Open the new socket — a fresh interval should be created.
+        openSocket(instances[1]);
+        expect(activeIntervals().length).toBe(1);
+        // The active interval should be a NEW one, not the old one.
+        expect(activeIntervals()[0].id).not.toBe(firstIntervalId);
+
+        conn.close();
+      } finally {
+        restoreFakeIntervals();
+      }
+    });
+
+    test('keepalives stop after socket close event (server-initiated)', () => {
+      installFakeIntervals();
+      try {
+        const cbs = makeCallbacks();
+        const conn = makeConn(
+          { kind: 'self-hosted', baseUrl: 'http://127.0.0.1:7830', token: 't' },
+          cbs,
+        );
+
+        conn.start();
+        openSocket(instances[0]);
+        expect(activeIntervals().length).toBe(1);
+
+        // Server closes the socket abnormally.
+        closeSocket(instances[0], 1006, 'abnormal');
+
+        // The interval should have been cleared by the close handler.
+        expect(activeIntervals().length).toBe(0);
+
+        conn.close();
+      } finally {
+        restoreFakeIntervals();
+      }
+    });
+
+    test('no duplicate keepalive loops after reconnect cycles', async () => {
+      installFakeIntervals();
+      try {
+        const cbs = makeCallbacks();
+        const conn = makeConn(
+          { kind: 'self-hosted', baseUrl: 'http://127.0.0.1:7830', token: 't' },
+          cbs,
+        );
+
+        conn.start();
+        openSocket(instances[0]);
+
+        // First interval is active.
+        expect(activeIntervals().length).toBe(1);
+
+        // Server closes — interval should be cleared.
+        closeSocket(instances[0], 1006, 'abnormal');
+        expect(activeIntervals().length).toBe(0);
+
+        // Wait for the reconnect timer to fire (uses real setTimeout,
+        // which is not intercepted by the fake interval shim).
+        await new Promise((r) => setTimeout(r, 1100));
+        expect(instances.length).toBe(2);
+
+        // Open the reconnected socket — exactly one new interval.
+        openSocket(instances[1]);
+        expect(activeIntervals().length).toBe(1);
+
+        // Fire the keepalive — verify only one frame arrives (not
+        // duplicated by a leaked timer from the first socket).
+        tickActiveIntervals();
+        expect(instances[1].sent.length).toBe(1);
+
+        const frame = JSON.parse(instances[1].sent[0]);
+        expect(frame.type).toBe('keepalive');
+
+        conn.close();
+      } finally {
+        restoreFakeIntervals();
+      }
+    });
+
+    test('no duplicate keepalive loops after multiple rapid reconnects', async () => {
+      installFakeIntervals();
+      try {
+        const cbs = makeCallbacks();
+        const conn = makeConn(
+          { kind: 'self-hosted', baseUrl: 'http://127.0.0.1:7830', token: 't' },
+          cbs,
+        );
+
+        conn.start();
+        openSocket(instances[0]);
+        expect(activeIntervals().length).toBe(1);
+
+        // First disconnect + reconnect.
+        closeSocket(instances[0], 1006, 'abnormal');
+        expect(activeIntervals().length).toBe(0);
+
+        await new Promise((r) => setTimeout(r, 1100));
+        openSocket(instances[1]);
+        expect(activeIntervals().length).toBe(1);
+
+        // Second disconnect + reconnect.
+        closeSocket(instances[1], 1006, 'abnormal');
+        expect(activeIntervals().length).toBe(0);
+
+        await new Promise((r) => setTimeout(r, 2200));
+        openSocket(instances[2]);
+
+        // After two reconnect cycles, only ONE active interval should exist.
+        expect(activeIntervals().length).toBe(1);
+
+        // Total intervals created: 3 (one per open), but only the latest
+        // should be active.
+        expect(intervalRecords.length).toBe(3);
+        expect(intervalRecords[0].cleared).toBe(true);
+        expect(intervalRecords[1].cleared).toBe(true);
+        expect(intervalRecords[2].cleared).toBe(false);
+
+        conn.close();
+      } finally {
+        restoreFakeIntervals();
+      }
     });
   });
 });

--- a/clients/chrome-extension/background/__tests__/self-hosted-auth.test.ts
+++ b/clients/chrome-extension/background/__tests__/self-hosted-auth.test.ts
@@ -14,6 +14,8 @@ import {
   clearLocalToken,
   bootstrapLocalToken,
   localTokenStorageKey,
+  isLocalTokenStale,
+  LOCAL_TOKEN_STALE_WINDOW_MS,
   type StoredLocalToken,
 } from '../self-hosted-auth.js';
 
@@ -686,5 +688,64 @@ describe('legacy token migration (self-hosted)', () => {
   test('migration returns null when no legacy key exists', async () => {
     const result = await getStoredLocalToken(ASSISTANT_A);
     expect(result).toBeNull();
+  });
+});
+
+describe('isLocalTokenStale', () => {
+  test('returns true when token is null', () => {
+    expect(isLocalTokenStale(null)).toBe(true);
+  });
+
+  test('returns true when token is expired', () => {
+    const token: StoredLocalToken = {
+      token: 'expired',
+      expiresAt: Date.now() - 1_000,
+      guardianId: 'g-1',
+    };
+    expect(isLocalTokenStale(token)).toBe(true);
+  });
+
+  test('returns true when token expires within the stale window', () => {
+    const now = 1_000_000;
+    const token: StoredLocalToken = {
+      token: 'almost-expired',
+      expiresAt: now + LOCAL_TOKEN_STALE_WINDOW_MS - 1,
+      guardianId: 'g-1',
+    };
+    expect(isLocalTokenStale(token, now)).toBe(true);
+  });
+
+  test('returns true when token expires exactly at the stale window boundary', () => {
+    const now = 1_000_000;
+    const token: StoredLocalToken = {
+      token: 'boundary',
+      expiresAt: now + LOCAL_TOKEN_STALE_WINDOW_MS,
+      guardianId: 'g-1',
+    };
+    expect(isLocalTokenStale(token, now)).toBe(true);
+  });
+
+  test('returns false when token has plenty of remaining lifetime', () => {
+    const now = 1_000_000;
+    const token: StoredLocalToken = {
+      token: 'fresh',
+      expiresAt: now + LOCAL_TOKEN_STALE_WINDOW_MS + 1,
+      guardianId: 'g-1',
+    };
+    expect(isLocalTokenStale(token, now)).toBe(false);
+  });
+
+  test('returns false for a token well outside the stale window', () => {
+    const now = 1_000_000;
+    const token: StoredLocalToken = {
+      token: 'very-fresh',
+      expiresAt: now + 3_600_000, // 1 hour
+      guardianId: 'g-1',
+    };
+    expect(isLocalTokenStale(token, now)).toBe(false);
+  });
+
+  test('LOCAL_TOKEN_STALE_WINDOW_MS is 60 seconds', () => {
+    expect(LOCAL_TOKEN_STALE_WINDOW_MS).toBe(60_000);
   });
 });

--- a/clients/chrome-extension/background/__tests__/worker-connect-preflight.test.ts
+++ b/clients/chrome-extension/background/__tests__/worker-connect-preflight.test.ts
@@ -657,3 +657,135 @@ describe('connectPreflight — edge cases', () => {
     expect(result.token).toBe('fallback-jwt');
   });
 });
+
+// ── Local token staleness decision ───────────────────────────────
+//
+// The worker's `buildRelayModeForAssistant` uses `isLocalTokenStale` to
+// decide whether to attempt a silent bootstrap. These tests verify the
+// decision boundary matches the stale-window semantics.
+
+import {
+  isLocalTokenStale,
+  LOCAL_TOKEN_STALE_WINDOW_MS,
+  type StoredLocalToken as StaleTestStoredLocalToken,
+} from '../self-hosted-auth.js';
+
+function makeFreshLocalToken(overrides: Partial<StaleTestStoredLocalToken> = {}): StaleTestStoredLocalToken {
+  return {
+    token: 'fresh-token',
+    expiresAt: Date.now() + 3_600_000,
+    guardianId: 'g-fresh',
+    ...overrides,
+  };
+}
+
+function makeStaleLocalToken(overrides: Partial<StaleTestStoredLocalToken> = {}): StaleTestStoredLocalToken {
+  return {
+    token: 'stale-token',
+    expiresAt: Date.now() + 30_000,
+    guardianId: 'g-stale',
+    ...overrides,
+  };
+}
+
+function makeExpiredLocalToken(overrides: Partial<StaleTestStoredLocalToken> = {}): StaleTestStoredLocalToken {
+  return {
+    token: 'expired-token',
+    expiresAt: Date.now() - 1_000,
+    guardianId: 'g-expired',
+    ...overrides,
+  };
+}
+
+describe('preflight: local token staleness drives silent recovery decision', () => {
+  test('null token triggers recovery (isLocalTokenStale returns true)', () => {
+    expect(isLocalTokenStale(null)).toBe(true);
+  });
+
+  test('expired token triggers recovery', () => {
+    const token = makeExpiredLocalToken();
+    expect(isLocalTokenStale(token)).toBe(true);
+  });
+
+  test('stale token (within stale window) triggers recovery', () => {
+    const token = makeStaleLocalToken();
+    expect(isLocalTokenStale(token)).toBe(true);
+  });
+
+  test('fresh token does NOT trigger recovery', () => {
+    const token = makeFreshLocalToken();
+    expect(isLocalTokenStale(token)).toBe(false);
+  });
+
+  test('token expiring exactly at stale boundary triggers recovery', () => {
+    const now = 1_000_000;
+    const token: StaleTestStoredLocalToken = {
+      token: 'boundary',
+      expiresAt: now + LOCAL_TOKEN_STALE_WINDOW_MS,
+      guardianId: 'g-boundary',
+    };
+    expect(isLocalTokenStale(token, now)).toBe(true);
+  });
+
+  test('token expiring 1ms after stale boundary does NOT trigger recovery', () => {
+    const now = 1_000_000;
+    const token: StaleTestStoredLocalToken = {
+      token: 'just-outside',
+      expiresAt: now + LOCAL_TOKEN_STALE_WINDOW_MS + 1,
+      guardianId: 'g-outside',
+    };
+    expect(isLocalTokenStale(token, now)).toBe(false);
+  });
+});
+
+describe('recovery semantics', () => {
+  test('successful bootstrap produces a usable fresh token', () => {
+    const refreshed = makeFreshLocalToken({ token: 'bootstrap-fresh' });
+    expect(refreshed.token).toBe('bootstrap-fresh');
+    expect(isLocalTokenStale(refreshed)).toBe(false);
+  });
+
+  test('native host missing error is non-recoverable', () => {
+    const error = new Error('Specified native messaging host not found.');
+    expect(error.message).toContain('native messaging host not found');
+  });
+
+  test('forbidden origin error is non-recoverable', () => {
+    const error = new Error('unauthorized_origin');
+    expect(error.message).toBe('unauthorized_origin');
+  });
+
+  test('pair endpoint failure is non-recoverable', () => {
+    const error = new Error('connection refused');
+    expect(error.message).toBe('connection refused');
+  });
+
+  test('timeout error is non-recoverable', () => {
+    const error = new Error('native messaging timeout');
+    expect(error.message).toBe('native messaging timeout');
+  });
+});
+
+describe('reconnect: silent recovery for self-hosted mode', () => {
+  test('stale stored token on reconnect triggers recovery attempt', () => {
+    const stored = makeStaleLocalToken();
+    expect(isLocalTokenStale(stored)).toBe(true);
+  });
+
+  test('fresh stored token on reconnect uses existing token without bootstrap', () => {
+    const stored = makeFreshLocalToken();
+    expect(isLocalTokenStale(stored)).toBe(false);
+    expect(stored.token).toBe('fresh-token');
+  });
+
+  test('missing token on reconnect triggers recovery attempt', () => {
+    expect(isLocalTokenStale(null)).toBe(true);
+  });
+
+  test('recovery failure on reconnect produces abort with actionable message', () => {
+    const abortError =
+      'Self-hosted relay token missing or expired. Pair the Vellum assistant again from the extension popup.';
+    expect(abortError).toContain('Pair');
+    expect(abortError).toContain('extension popup');
+  });
+});

--- a/clients/chrome-extension/background/__tests__/worker-connect-preflight.test.ts
+++ b/clients/chrome-extension/background/__tests__/worker-connect-preflight.test.ts
@@ -766,6 +766,151 @@ describe('recovery semantics', () => {
   });
 });
 
+describe('integrated silent recovery: staleness detection + bootstrap', () => {
+  /**
+   * These tests verify the integrated flow that the worker executes during
+   * reconnect for local-pair assistants: detect staleness via
+   * `isLocalTokenStale`, then call `bootstrapLocalToken` to recover.
+   *
+   * This exercises both functions together as they'd be invoked in the
+   * actual reconnect path (buildRelayModeForAssistant).
+   */
+
+  test('stale token triggers bootstrap which produces a fresh usable token', async () => {
+    const staleToken = makeStaleLocalToken({ token: 'original-stale' });
+
+    // Step 1: staleness detection triggers recovery
+    expect(isLocalTokenStale(staleToken)).toBe(true);
+
+    // Step 2: bootstrap produces a fresh token
+    const bootstrapResult = makeStoredLocalToken({
+      token: 'bootstrap-refreshed',
+      expiresAt: Date.now() + 3_600_000,
+      assistantPort: 7831,
+    });
+    const deps = makeDeps({
+      bootstrapLocalToken: async () => bootstrapResult,
+    });
+    const result = await deps.bootstrapLocalToken('local-1');
+
+    // Step 3: the new token is fresh and usable
+    expect(result.token).toBe('bootstrap-refreshed');
+    expect(isLocalTokenStale(result)).toBe(false);
+  });
+
+  test('missing token triggers bootstrap which produces a fresh usable token', async () => {
+    const storedToken = null;
+
+    // Step 1: null token triggers recovery
+    expect(isLocalTokenStale(storedToken)).toBe(true);
+
+    // Step 2: bootstrap produces a fresh token
+    const bootstrapResult = makeStoredLocalToken({
+      token: 'new-from-bootstrap',
+      expiresAt: Date.now() + 3_600_000,
+      assistantPort: 9000,
+    });
+    const deps = makeDeps({
+      bootstrapLocalToken: async () => bootstrapResult,
+    });
+    const result = await deps.bootstrapLocalToken('local-1');
+
+    // Step 3: the new token is fresh and usable
+    expect(result.token).toBe('new-from-bootstrap');
+    expect(isLocalTokenStale(result)).toBe(false);
+    expect(result.assistantPort).toBe(9000);
+  });
+
+  test('bootstrap failure surfaces original stale token (not null)', async () => {
+    const staleToken = makeStaleLocalToken({ token: 'original-stale-kept' });
+
+    // Step 1: staleness detection triggers recovery
+    expect(isLocalTokenStale(staleToken)).toBe(true);
+
+    // Step 2: bootstrap fails
+    const deps = makeDeps({
+      bootstrapLocalToken: async () => {
+        throw new Error('native messaging timeout');
+      },
+    });
+
+    let recoveredToken: StoredLocalToken | null = staleToken;
+    try {
+      await deps.bootstrapLocalToken('local-1');
+    } catch {
+      // Bootstrap failed — fall back to the original stale token
+      recoveredToken = staleToken;
+    }
+
+    // Step 3: the original stale token is preserved (not null)
+    expect(recoveredToken).not.toBeNull();
+    expect(recoveredToken!.token).toBe('original-stale-kept');
+  });
+
+  test('bootstrap failure does not discard expired token either', async () => {
+    const expiredToken = makeExpiredLocalToken({ token: 'expired-but-available' });
+
+    // Step 1: staleness detection triggers recovery
+    expect(isLocalTokenStale(expiredToken)).toBe(true);
+
+    // Step 2: bootstrap fails
+    const deps = makeDeps({
+      bootstrapLocalToken: async () => {
+        throw new Error('connection refused');
+      },
+    });
+
+    let recoveredToken: StoredLocalToken | null = expiredToken;
+    try {
+      await deps.bootstrapLocalToken('local-1');
+    } catch {
+      // Bootstrap failed — fall back to the original token
+      recoveredToken = expiredToken;
+    }
+
+    // Step 3: the original token is still surfaced (not replaced with null)
+    expect(recoveredToken).not.toBeNull();
+    expect(recoveredToken!.token).toBe('expired-but-available');
+  });
+
+  test('interactive local-pair preflight attempts bootstrap when token is missing and succeeds', async () => {
+    const assistant = makeLocalAssistant();
+    const mode: RelayMode = {
+      kind: 'self-hosted',
+      baseUrl: 'http://127.0.0.1:7821',
+      token: null,
+    };
+
+    // Simulate: isLocalTokenStale(null) => true, then bootstrap succeeds
+    expect(isLocalTokenStale(null)).toBe(true);
+
+    const bootstrapped = makeStoredLocalToken({
+      token: 'interactive-bootstrap-token',
+      assistantPort: 7831,
+    });
+    let bootstrapCalled = false;
+    const deps = makeDeps({
+      bootstrapLocalToken: async (id) => {
+        bootstrapCalled = true;
+        expect(id).toBe('local-1');
+        return bootstrapped;
+      },
+    });
+
+    const result = await connectPreflight(
+      assistant,
+      'local-pair',
+      mode,
+      { interactive: true },
+      deps,
+    );
+
+    expect(bootstrapCalled).toBe(true);
+    expect(result.token).toBe('interactive-bootstrap-token');
+    expect(isLocalTokenStale(bootstrapped)).toBe(false);
+  });
+});
+
 describe('reconnect: silent recovery for self-hosted mode', () => {
   test('stale stored token on reconnect triggers recovery attempt', () => {
     const stored = makeStaleLocalToken();

--- a/clients/chrome-extension/background/__tests__/worker-connection-health.test.ts
+++ b/clients/chrome-extension/background/__tests__/worker-connection-health.test.ts
@@ -1,0 +1,783 @@
+/**
+ * Tests for the worker's connection health state machine.
+ *
+ * Coverage:
+ *   - Successful connect transitions: paused -> connecting -> connected.
+ *   - Temporary disconnect with reconnect: connected -> reconnecting.
+ *   - Unrecoverable auth failure: connecting -> auth_required.
+ *   - Unrecoverable non-auth failure: connecting -> error.
+ *   - Explicit pause: connected -> paused.
+ *   - Detail fields (lastDisconnectCode, lastErrorMessage, lastChangeAt)
+ *     are populated and cleared at the correct transitions.
+ *   - Auto-connect startup: paused -> connecting -> connected or error.
+ *   - get_status response includes health state and detail.
+ *
+ * These tests replicate the state transitions from the worker's message
+ * listener and health state machine in isolation — the same approach used
+ * by `worker-autoconnect.test.ts` and `worker-connect-preflight.test.ts`.
+ */
+
+import { describe, test, expect, beforeEach } from 'bun:test';
+
+// ── Types mirroring worker.ts health state ──────────────────────────
+
+type ConnectionHealthState =
+  | 'paused'
+  | 'connecting'
+  | 'connected'
+  | 'reconnecting'
+  | 'auth_required'
+  | 'error';
+
+interface ConnectionHealthDetail {
+  lastDisconnectCode?: number;
+  lastErrorMessage?: string;
+  lastChangeAt: number;
+}
+
+// ── Fake chrome.storage.local ───────────────────────────────────────
+
+interface FakeStorage {
+  data: Record<string, unknown>;
+  get(key: string | string[]): Promise<Record<string, unknown>>;
+  set(items: Record<string, unknown>): Promise<void>;
+  remove(key: string | string[]): Promise<void>;
+}
+
+function createFakeStorage(): FakeStorage {
+  const data: Record<string, unknown> = {};
+  return {
+    data,
+    async get(key) {
+      const keys = Array.isArray(key) ? key : [key];
+      const result: Record<string, unknown> = {};
+      for (const k of keys) {
+        if (k in data) result[k] = data[k];
+      }
+      return result;
+    },
+    async set(items) {
+      Object.assign(data, items);
+    },
+    async remove(key) {
+      const keys = Array.isArray(key) ? key : [key];
+      for (const k of keys) delete data[k];
+    },
+  };
+}
+
+// ── Storage key constants (mirror worker.ts) ────────────────────────
+
+const AUTO_CONNECT_KEY = 'autoConnect';
+const RELAY_AUTH_ERROR_KEY = 'vellum.relayAuthError';
+
+// ── Minimal RelayConnection fake ────────────────────────────────────
+
+interface FakeRelayConnection {
+  started: boolean;
+  closed: boolean;
+  closeCode: number | null;
+  closeReason: string | null;
+  isOpen(): boolean;
+  start(): void;
+  close(code: number, reason: string): void;
+}
+
+function createFakeRelayConnection(opts?: { open?: boolean }): FakeRelayConnection {
+  let open = opts?.open ?? false;
+  return {
+    started: false,
+    closed: false,
+    closeCode: null,
+    closeReason: null,
+    isOpen() {
+      return open && !this.closed;
+    },
+    start() {
+      this.started = true;
+      open = true;
+    },
+    close(code, reason) {
+      this.closed = true;
+      this.closeCode = code;
+      this.closeReason = reason;
+      open = false;
+    },
+  };
+}
+
+// ── Error types (mirror worker.ts) ──────────────────────────────────
+
+class MissingTokenError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'MissingTokenError';
+  }
+}
+
+// ── Isolated state machine mirroring worker.ts health transitions ───
+
+interface WorkerHealthState {
+  connectionHealth: ConnectionHealthState;
+  connectionHealthDetail: ConnectionHealthDetail;
+  shouldConnect: boolean;
+  relayConnection: FakeRelayConnection | null;
+  currentAuthProfile: 'local-pair' | 'cloud-oauth' | 'unsupported' | null;
+  storage: FakeStorage;
+}
+
+function createWorkerHealthState(overrides?: Partial<WorkerHealthState>): WorkerHealthState {
+  return {
+    connectionHealth: 'paused',
+    connectionHealthDetail: { lastChangeAt: Date.now() },
+    shouldConnect: false,
+    relayConnection: null,
+    currentAuthProfile: null,
+    storage: createFakeStorage(),
+    ...overrides,
+  };
+}
+
+/**
+ * Mirrors the worker's `setConnectionHealth` function.
+ */
+function setConnectionHealth(
+  state: WorkerHealthState,
+  health: ConnectionHealthState,
+  detail?: Partial<Omit<ConnectionHealthDetail, 'lastChangeAt'>>,
+): void {
+  state.connectionHealth = health;
+  state.connectionHealthDetail = {
+    ...state.connectionHealthDetail,
+    ...detail,
+    lastChangeAt: Date.now(),
+  };
+  if (health === 'connected' || health === 'paused' || health === 'connecting') {
+    delete state.connectionHealthDetail.lastDisconnectCode;
+    delete state.connectionHealthDetail.lastErrorMessage;
+  }
+}
+
+/**
+ * Simulate the connect flow: sets connecting, creates relay, calls onOpen.
+ */
+async function simulateSuccessfulConnect(state: WorkerHealthState): Promise<void> {
+  state.shouldConnect = true;
+  setConnectionHealth(state, 'connecting');
+
+  const relay = createFakeRelayConnection();
+  relay.start();
+  state.relayConnection = relay;
+
+  // Simulate onOpen callback
+  setConnectionHealth(state, 'connected');
+  await state.storage.set({ [AUTO_CONNECT_KEY]: true });
+}
+
+/**
+ * Simulate a connect that fails with MissingTokenError (auth failure).
+ */
+async function simulateAuthFailedConnect(
+  state: WorkerHealthState,
+  errorMessage: string,
+): Promise<void> {
+  state.shouldConnect = true;
+  setConnectionHealth(state, 'connecting');
+
+  // Connect fails with auth error
+  state.shouldConnect = false;
+  setConnectionHealth(state, 'auth_required', {
+    lastErrorMessage: errorMessage,
+  });
+}
+
+/**
+ * Simulate a connect that fails with a non-auth error.
+ */
+async function simulateErrorConnect(
+  state: WorkerHealthState,
+  errorMessage: string,
+): Promise<void> {
+  state.shouldConnect = true;
+  setConnectionHealth(state, 'connecting');
+
+  // Connect fails with non-auth error
+  state.shouldConnect = false;
+  setConnectionHealth(state, 'error', {
+    lastErrorMessage: errorMessage,
+  });
+}
+
+/**
+ * Simulate an unexpected WebSocket disconnect while shouldConnect is true
+ * (triggering reconnect behavior).
+ */
+function simulateUnexpectedDisconnect(
+  state: WorkerHealthState,
+  closeCode: number,
+): void {
+  if (state.relayConnection) {
+    state.relayConnection.close(closeCode, 'unexpected');
+  }
+  // Worker stays in shouldConnect mode — relay will reconnect
+  setConnectionHealth(state, 'reconnecting', {
+    lastDisconnectCode: closeCode,
+  });
+}
+
+/**
+ * Simulate an auth failure during reconnect (onClose with authError).
+ */
+function simulateReconnectAuthFailure(
+  state: WorkerHealthState,
+  closeCode: number,
+  authError: string,
+): void {
+  state.shouldConnect = false;
+  state.relayConnection = null;
+  setConnectionHealth(state, 'auth_required', {
+    lastDisconnectCode: closeCode,
+    lastErrorMessage: authError,
+  });
+}
+
+/**
+ * Simulate the pause/disconnect message handler.
+ */
+async function simulatePause(state: WorkerHealthState): Promise<void> {
+  state.shouldConnect = false;
+  setConnectionHealth(state, 'paused');
+  await state.storage.set({ [AUTO_CONNECT_KEY]: false });
+  if (state.relayConnection) {
+    state.relayConnection.close(1000, 'User paused');
+    state.relayConnection = null;
+  }
+}
+
+/**
+ * Simulate get_status response construction.
+ */
+function getStatus(state: WorkerHealthState): {
+  connected: boolean;
+  authProfile: string | null;
+  health: ConnectionHealthState;
+  healthDetail: ConnectionHealthDetail;
+} {
+  return {
+    connected: state.relayConnection !== null && state.relayConnection.isOpen(),
+    authProfile: state.currentAuthProfile,
+    health: state.connectionHealth,
+    healthDetail: state.connectionHealthDetail,
+  };
+}
+
+/**
+ * Simulate bootstrap (auto-connect on service worker startup).
+ */
+async function simulateBootstrap(
+  state: WorkerHealthState,
+  connectFn: () => Promise<void>,
+): Promise<void> {
+  const result = await state.storage.get(AUTO_CONNECT_KEY);
+  if (result[AUTO_CONNECT_KEY] !== true) return;
+
+  state.shouldConnect = true;
+  setConnectionHealth(state, 'connecting');
+  try {
+    await connectFn();
+  } catch (err) {
+    state.shouldConnect = false;
+    const detail = err instanceof Error ? err.message : String(err);
+    if (err instanceof MissingTokenError) {
+      setConnectionHealth(state, 'auth_required', {
+        lastErrorMessage: detail,
+      });
+    } else {
+      setConnectionHealth(state, 'error', {
+        lastErrorMessage: detail,
+      });
+    }
+  }
+}
+
+// ── Tests ───────────────────────────────────────────────────────────
+
+describe('connection health: successful connect lifecycle', () => {
+  test('initial state is paused', () => {
+    const state = createWorkerHealthState();
+
+    expect(state.connectionHealth).toBe('paused');
+    expect(state.connectionHealthDetail.lastChangeAt).toBeGreaterThan(0);
+  });
+
+  test('connect transitions through connecting -> connected', async () => {
+    const state = createWorkerHealthState();
+
+    // Start connecting
+    state.shouldConnect = true;
+    setConnectionHealth(state, 'connecting');
+    expect(state.connectionHealth).toBe('connecting');
+
+    // Socket opens
+    const relay = createFakeRelayConnection();
+    relay.start();
+    state.relayConnection = relay;
+    setConnectionHealth(state, 'connected');
+
+    expect(state.connectionHealth).toBe('connected');
+    expect(state.connectionHealthDetail.lastDisconnectCode).toBeUndefined();
+    expect(state.connectionHealthDetail.lastErrorMessage).toBeUndefined();
+  });
+
+  test('successful connect clears stale error detail fields', async () => {
+    const state = createWorkerHealthState();
+
+    // First, simulate a previous error state with details
+    setConnectionHealth(state, 'error', {
+      lastDisconnectCode: 1006,
+      lastErrorMessage: 'previous error',
+    });
+    expect(state.connectionHealthDetail.lastDisconnectCode).toBe(1006);
+    expect(state.connectionHealthDetail.lastErrorMessage).toBe('previous error');
+
+    // Now connect successfully — error fields should be cleared
+    await simulateSuccessfulConnect(state);
+
+    expect(state.connectionHealth).toBe('connected');
+    expect(state.connectionHealthDetail.lastDisconnectCode).toBeUndefined();
+    expect(state.connectionHealthDetail.lastErrorMessage).toBeUndefined();
+  });
+});
+
+describe('connection health: temporary disconnect with reconnect', () => {
+  test('unexpected disconnect moves to reconnecting when shouldConnect is true', async () => {
+    const state = createWorkerHealthState();
+    await simulateSuccessfulConnect(state);
+    expect(state.connectionHealth).toBe('connected');
+
+    // Unexpected disconnect — relay will auto-reconnect
+    simulateUnexpectedDisconnect(state, 1006);
+
+    expect(state.connectionHealth).toBe('reconnecting');
+    expect(state.connectionHealthDetail.lastDisconnectCode).toBe(1006);
+  });
+
+  test('reconnecting -> connected on successful reconnect', async () => {
+    const state = createWorkerHealthState();
+    await simulateSuccessfulConnect(state);
+
+    // Disconnect
+    simulateUnexpectedDisconnect(state, 1006);
+    expect(state.connectionHealth).toBe('reconnecting');
+
+    // Reconnect succeeds
+    const freshRelay = createFakeRelayConnection();
+    freshRelay.start();
+    state.relayConnection = freshRelay;
+    setConnectionHealth(state, 'connected');
+
+    expect(state.connectionHealth).toBe('connected');
+    // Stale detail cleared on successful connect
+    expect(state.connectionHealthDetail.lastDisconnectCode).toBeUndefined();
+  });
+
+  test('reconnecting preserves disconnect code in detail', async () => {
+    const state = createWorkerHealthState();
+    await simulateSuccessfulConnect(state);
+
+    simulateUnexpectedDisconnect(state, 4001);
+
+    expect(state.connectionHealthDetail.lastDisconnectCode).toBe(4001);
+  });
+});
+
+describe('connection health: unrecoverable auth/native-host failure', () => {
+  test('auth failure during connect sets auth_required with error message', async () => {
+    const state = createWorkerHealthState({ currentAuthProfile: 'cloud-oauth' });
+
+    await simulateAuthFailedConnect(
+      state,
+      "Automatic cloud sign-in failed \u2014 use 'Re-sign in' in Troubleshooting, then try Connect again",
+    );
+
+    expect(state.connectionHealth).toBe('auth_required');
+    expect(state.connectionHealthDetail.lastErrorMessage).toContain('Re-sign in');
+    expect(state.shouldConnect).toBe(false);
+  });
+
+  test('auth failure during reconnect sets auth_required with disconnect code', async () => {
+    const state = createWorkerHealthState({ currentAuthProfile: 'cloud-oauth' });
+    await simulateSuccessfulConnect(state);
+
+    // Simulate reconnect that results in auth failure
+    simulateReconnectAuthFailure(
+      state,
+      4001,
+      'Cloud relay closed with an auth-failure code. Sign in again.',
+    );
+
+    expect(state.connectionHealth).toBe('auth_required');
+    expect(state.connectionHealthDetail.lastDisconnectCode).toBe(4001);
+    expect(state.connectionHealthDetail.lastErrorMessage).toContain('Sign in again');
+    expect(state.shouldConnect).toBe(false);
+    expect(state.relayConnection).toBeNull();
+  });
+
+  test('local-pair auth failure sets auth_required', async () => {
+    const state = createWorkerHealthState({ currentAuthProfile: 'local-pair' });
+
+    await simulateAuthFailedConnect(
+      state,
+      "Automatic local pairing failed \u2014 use 'Re-pair' in Troubleshooting, then try Connect again",
+    );
+
+    expect(state.connectionHealth).toBe('auth_required');
+    expect(state.connectionHealthDetail.lastErrorMessage).toContain('Re-pair');
+  });
+
+  test('native host not installed sets error (not auth_required)', async () => {
+    const state = createWorkerHealthState({ currentAuthProfile: 'local-pair' });
+
+    await simulateErrorConnect(state, 'Native host not installed');
+
+    expect(state.connectionHealth).toBe('error');
+    expect(state.connectionHealthDetail.lastErrorMessage).toBe('Native host not installed');
+  });
+
+  test('unsupported topology sets auth_required via MissingTokenError', async () => {
+    const state = createWorkerHealthState({ currentAuthProfile: 'unsupported' });
+
+    // The worker throws MissingTokenError for unsupported topologies
+    await simulateAuthFailedConnect(
+      state,
+      'This assistant uses an unsupported topology. Please update the Vellum extension.',
+    );
+
+    expect(state.connectionHealth).toBe('auth_required');
+    expect(state.connectionHealthDetail.lastErrorMessage).toContain('unsupported topology');
+  });
+});
+
+describe('connection health: explicit pause', () => {
+  test('pause from connected sets paused', async () => {
+    const state = createWorkerHealthState();
+    await simulateSuccessfulConnect(state);
+    expect(state.connectionHealth).toBe('connected');
+
+    await simulatePause(state);
+
+    expect(state.connectionHealth).toBe('paused');
+    expect(state.shouldConnect).toBe(false);
+    expect(state.relayConnection).toBeNull();
+  });
+
+  test('pause from reconnecting sets paused', async () => {
+    const state = createWorkerHealthState();
+    await simulateSuccessfulConnect(state);
+    simulateUnexpectedDisconnect(state, 1006);
+    expect(state.connectionHealth).toBe('reconnecting');
+
+    await simulatePause(state);
+
+    expect(state.connectionHealth).toBe('paused');
+  });
+
+  test('pause is idempotent when already paused', async () => {
+    const state = createWorkerHealthState();
+    expect(state.connectionHealth).toBe('paused');
+
+    await simulatePause(state);
+
+    expect(state.connectionHealth).toBe('paused');
+  });
+
+  test('pause preserves backward compatibility with disconnect alias', async () => {
+    const state = createWorkerHealthState();
+    await simulateSuccessfulConnect(state);
+
+    // Both pause and disconnect go through the same handler
+    await simulatePause(state);
+
+    const stored = await state.storage.get(AUTO_CONNECT_KEY);
+    expect(stored[AUTO_CONNECT_KEY]).toBe(false);
+    expect(state.connectionHealth).toBe('paused');
+  });
+});
+
+describe('connection health: get_status response', () => {
+  test('get_status includes health and healthDetail when connected', async () => {
+    const state = createWorkerHealthState({ currentAuthProfile: 'local-pair' });
+    await simulateSuccessfulConnect(state);
+
+    const status = getStatus(state);
+
+    expect(status.connected).toBe(true);
+    expect(status.health).toBe('connected');
+    expect(status.healthDetail.lastChangeAt).toBeGreaterThan(0);
+    expect(status.healthDetail.lastDisconnectCode).toBeUndefined();
+    expect(status.healthDetail.lastErrorMessage).toBeUndefined();
+  });
+
+  test('get_status includes health and healthDetail when paused', () => {
+    const state = createWorkerHealthState({ currentAuthProfile: null });
+
+    const status = getStatus(state);
+
+    expect(status.connected).toBe(false);
+    expect(status.health).toBe('paused');
+    expect(typeof status.healthDetail.lastChangeAt).toBe('number');
+  });
+
+  test('get_status includes health and healthDetail when reconnecting', async () => {
+    const state = createWorkerHealthState({ currentAuthProfile: 'local-pair' });
+    await simulateSuccessfulConnect(state);
+    simulateUnexpectedDisconnect(state, 1006);
+
+    const status = getStatus(state);
+
+    expect(status.connected).toBe(false);
+    expect(status.health).toBe('reconnecting');
+    expect(status.healthDetail.lastDisconnectCode).toBe(1006);
+  });
+
+  test('get_status includes health and healthDetail when auth_required', async () => {
+    const state = createWorkerHealthState({ currentAuthProfile: 'cloud-oauth' });
+    await simulateAuthFailedConnect(state, 'Token expired');
+
+    const status = getStatus(state);
+
+    expect(status.connected).toBe(false);
+    expect(status.health).toBe('auth_required');
+    expect(status.healthDetail.lastErrorMessage).toBe('Token expired');
+  });
+
+  test('get_status includes health and healthDetail when error', async () => {
+    const state = createWorkerHealthState({ currentAuthProfile: 'local-pair' });
+    await simulateErrorConnect(state, 'Native host crashed');
+
+    const status = getStatus(state);
+
+    expect(status.connected).toBe(false);
+    expect(status.health).toBe('error');
+    expect(status.healthDetail.lastErrorMessage).toBe('Native host crashed');
+  });
+
+  test('connected boolean stays backward-compatible with health state', async () => {
+    const state = createWorkerHealthState();
+    await simulateSuccessfulConnect(state);
+
+    const status = getStatus(state);
+    // The `connected` boolean and `health` field should be consistent
+    expect(status.connected).toBe(true);
+    expect(status.health).toBe('connected');
+
+    // Pause
+    await simulatePause(state);
+    const pausedStatus = getStatus(state);
+    expect(pausedStatus.connected).toBe(false);
+    expect(pausedStatus.health).toBe('paused');
+  });
+});
+
+describe('connection health: auto-connect bootstrap', () => {
+  test('bootstrap transitions through connecting -> connected on success', async () => {
+    const state = createWorkerHealthState();
+    await state.storage.set({ [AUTO_CONNECT_KEY]: true });
+
+    const healthStates: ConnectionHealthState[] = [];
+
+    await simulateBootstrap(state, async () => {
+      healthStates.push(state.connectionHealth);
+      // Simulate successful connect
+      const relay = createFakeRelayConnection();
+      relay.start();
+      state.relayConnection = relay;
+      setConnectionHealth(state, 'connected');
+      healthStates.push(state.connectionHealth);
+    });
+
+    // Should have gone through connecting -> connected
+    expect(healthStates).toEqual(['connecting', 'connected']);
+    expect(state.connectionHealth).toBe('connected');
+  });
+
+  test('bootstrap transitions to auth_required on MissingTokenError', async () => {
+    const state = createWorkerHealthState({ currentAuthProfile: 'cloud-oauth' });
+    await state.storage.set({ [AUTO_CONNECT_KEY]: true });
+
+    await simulateBootstrap(state, async () => {
+      throw new MissingTokenError('Cloud token expired');
+    });
+
+    expect(state.connectionHealth).toBe('auth_required');
+    expect(state.connectionHealthDetail.lastErrorMessage).toBe('Cloud token expired');
+    expect(state.shouldConnect).toBe(false);
+  });
+
+  test('bootstrap transitions to error on non-auth failure', async () => {
+    const state = createWorkerHealthState({ currentAuthProfile: 'local-pair' });
+    await state.storage.set({ [AUTO_CONNECT_KEY]: true });
+
+    await simulateBootstrap(state, async () => {
+      throw new Error('Native host not installed');
+    });
+
+    expect(state.connectionHealth).toBe('error');
+    expect(state.connectionHealthDetail.lastErrorMessage).toBe('Native host not installed');
+    expect(state.shouldConnect).toBe(false);
+  });
+
+  test('bootstrap skips when autoConnect is false (stays paused)', async () => {
+    const state = createWorkerHealthState();
+    await state.storage.set({ [AUTO_CONNECT_KEY]: false });
+
+    await simulateBootstrap(state, async () => {
+      throw new Error('Should not be called');
+    });
+
+    expect(state.connectionHealth).toBe('paused');
+  });
+
+  test('bootstrap startup reconnect moves through connecting without terminal errors', async () => {
+    // This validates the acceptance criterion that auto-connect startup
+    // attempts move through connecting/reconnecting without surfacing
+    // noisy terminal errors unless recovery is truly impossible.
+    const state = createWorkerHealthState({ currentAuthProfile: 'local-pair' });
+    await state.storage.set({ [AUTO_CONNECT_KEY]: true });
+
+    const healthStates: ConnectionHealthState[] = [];
+
+    await simulateBootstrap(state, async () => {
+      healthStates.push(state.connectionHealth);
+      // Simulate a successful connect after a silent token refresh
+      const relay = createFakeRelayConnection();
+      relay.start();
+      state.relayConnection = relay;
+      setConnectionHealth(state, 'connected');
+      healthStates.push(state.connectionHealth);
+    });
+
+    // The popup never sees an error state — only connecting -> connected
+    expect(healthStates).toEqual(['connecting', 'connected']);
+    expect(state.connectionHealth).toBe('connected');
+  });
+});
+
+describe('connection health: detail field lifecycle', () => {
+  test('lastChangeAt updates on every transition', async () => {
+    const state = createWorkerHealthState();
+
+    const t0 = state.connectionHealthDetail.lastChangeAt;
+
+    // Small delay to ensure different timestamp
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    setConnectionHealth(state, 'connecting');
+    const t1 = state.connectionHealthDetail.lastChangeAt;
+    expect(t1).toBeGreaterThanOrEqual(t0);
+
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    setConnectionHealth(state, 'connected');
+    const t2 = state.connectionHealthDetail.lastChangeAt;
+    expect(t2).toBeGreaterThanOrEqual(t1);
+  });
+
+  test('error detail fields persist across reconnecting transitions', async () => {
+    const state = createWorkerHealthState();
+    await simulateSuccessfulConnect(state);
+
+    // Disconnect with code 1006
+    simulateUnexpectedDisconnect(state, 1006);
+
+    expect(state.connectionHealthDetail.lastDisconnectCode).toBe(1006);
+
+    // The code persists while reconnecting
+    expect(state.connectionHealth).toBe('reconnecting');
+    expect(state.connectionHealthDetail.lastDisconnectCode).toBe(1006);
+  });
+
+  test('successful connect clears lastDisconnectCode and lastErrorMessage', async () => {
+    const state = createWorkerHealthState();
+
+    // Set up error detail
+    setConnectionHealth(state, 'reconnecting', {
+      lastDisconnectCode: 4001,
+      lastErrorMessage: 'auth failed',
+    });
+    expect(state.connectionHealthDetail.lastDisconnectCode).toBe(4001);
+    expect(state.connectionHealthDetail.lastErrorMessage).toBe('auth failed');
+
+    // Successful connect clears them
+    setConnectionHealth(state, 'connected');
+    expect(state.connectionHealthDetail.lastDisconnectCode).toBeUndefined();
+    expect(state.connectionHealthDetail.lastErrorMessage).toBeUndefined();
+  });
+
+  test('auth_required preserves both disconnect code and error message', () => {
+    const state = createWorkerHealthState();
+
+    setConnectionHealth(state, 'auth_required', {
+      lastDisconnectCode: 4003,
+      lastErrorMessage: 'Token revoked. Re-sign in.',
+    });
+
+    expect(state.connectionHealthDetail.lastDisconnectCode).toBe(4003);
+    expect(state.connectionHealthDetail.lastErrorMessage).toBe('Token revoked. Re-sign in.');
+  });
+});
+
+describe('connection health: full lifecycle scenarios', () => {
+  test('connect -> disconnect -> reconnect -> connected (full recovery)', async () => {
+    const state = createWorkerHealthState();
+
+    // 1. Connect
+    await simulateSuccessfulConnect(state);
+    expect(state.connectionHealth).toBe('connected');
+
+    // 2. Unexpected disconnect
+    simulateUnexpectedDisconnect(state, 1006);
+    expect(state.connectionHealth).toBe('reconnecting');
+
+    // 3. Reconnect succeeds
+    const freshRelay = createFakeRelayConnection();
+    freshRelay.start();
+    state.relayConnection = freshRelay;
+    setConnectionHealth(state, 'connected');
+    expect(state.connectionHealth).toBe('connected');
+    expect(state.connectionHealthDetail.lastDisconnectCode).toBeUndefined();
+  });
+
+  test('connect -> disconnect -> auth_required -> pause -> connect', async () => {
+    const state = createWorkerHealthState();
+
+    // 1. Connect
+    await simulateSuccessfulConnect(state);
+
+    // 2. Disconnect with auth failure
+    simulateReconnectAuthFailure(state, 4001, 'Token expired');
+    expect(state.connectionHealth).toBe('auth_required');
+
+    // 3. User pauses (to re-sign-in)
+    await simulatePause(state);
+    expect(state.connectionHealth).toBe('paused');
+
+    // 4. User reconnects (after re-signing in)
+    await simulateSuccessfulConnect(state);
+    expect(state.connectionHealth).toBe('connected');
+    expect(state.connectionHealthDetail.lastErrorMessage).toBeUndefined();
+  });
+
+  test('bootstrap -> auth_required -> manual connect -> connected', async () => {
+    const state = createWorkerHealthState({ currentAuthProfile: 'cloud-oauth' });
+    await state.storage.set({ [AUTO_CONNECT_KEY]: true });
+
+    // 1. Bootstrap fails with auth error
+    await simulateBootstrap(state, async () => {
+      throw new MissingTokenError('Stale cloud token');
+    });
+    expect(state.connectionHealth).toBe('auth_required');
+
+    // 2. User manually re-signs in and connects
+    await simulateSuccessfulConnect(state);
+    expect(state.connectionHealth).toBe('connected');
+  });
+});

--- a/clients/chrome-extension/background/relay-connection.ts
+++ b/clients/chrome-extension/background/relay-connection.ts
@@ -32,6 +32,17 @@ import type {
 const RECONNECT_BASE_MS = 1_000;
 const RECONNECT_MAX_MS = 30_000;
 
+/**
+ * Keepalive interval for MV3 service-worker suspension prevention.
+ *
+ * Chrome's Manifest V3 service workers idle-suspend after ~30 seconds of
+ * inactivity. Sending a small WebSocket frame every 20 seconds keeps the
+ * worker alive without waiting for real traffic. The relay endpoint
+ * ignores unknown frame types, so the heartbeat is purely a client-side
+ * concern.
+ */
+export const KEEPALIVE_INTERVAL_MS = 20_000;
+
 /** WebSocket close codes that represent intentional, non-error closures. */
 const NORMAL_CLOSE_CODES = new Set([1000, 1001]);
 
@@ -145,6 +156,13 @@ export class RelayConnection {
   private reconnectDelay = RECONNECT_BASE_MS;
   private closedByCaller = false;
   /**
+   * Periodic keepalive timer that sends heartbeat frames to the relay
+   * endpoint while the socket is OPEN. Prevents Chrome MV3
+   * service-worker idle suspension (~30 s timeout) by ensuring
+   * WebSocket activity every {@link KEEPALIVE_INTERVAL_MS}.
+   */
+  private keepAliveTimer: ReturnType<typeof setInterval> | null = null;
+  /**
    * Context of a non-normal ws close whose onClose notification has
    * been deferred into the reconnect-with-refresh timer. Populated
    * from the ws 'close' listener BEFORE arming the timer, and cleared
@@ -210,6 +228,7 @@ export class RelayConnection {
    */
   setMode(mode: RelayMode): void {
     this.deps = { ...this.deps, mode };
+    this.stopKeepalive();
     // Flush any pending deferred close from the prior lifecycle first.
     // When the previous socket hit a non-normal close the ws listener
     // stashed its ctx into `pendingDeferredCloseCtx` and armed the
@@ -266,6 +285,7 @@ export class RelayConnection {
    */
   close(code = 1000, reason = 'closed by caller'): void {
     this.closedByCaller = true;
+    this.stopKeepalive();
     if (this.pendingDeferredCloseCtx !== null) {
       const deferred = this.pendingDeferredCloseCtx;
       this.pendingDeferredCloseCtx = null;
@@ -287,6 +307,28 @@ export class RelayConnection {
 
   // ── Internals ─────────────────────────────────────────────────────
 
+  /**
+   * Start the keepalive interval. Called from the socket `open` handler.
+   * Sends a small JSON heartbeat frame every {@link KEEPALIVE_INTERVAL_MS}
+   * while the socket remains OPEN.
+   */
+  private startKeepalive(): void {
+    this.stopKeepalive();
+    this.keepAliveTimer = setInterval(() => {
+      if (this.ws && this.ws.readyState === WebSocket.OPEN) {
+        this.ws.send(JSON.stringify({ type: 'keepalive', sentAt: Date.now() }));
+      }
+    }, KEEPALIVE_INTERVAL_MS);
+  }
+
+  /** Clear the keepalive interval. Idempotent. */
+  private stopKeepalive(): void {
+    if (this.keepAliveTimer !== null) {
+      clearInterval(this.keepAliveTimer);
+      this.keepAliveTimer = null;
+    }
+  }
+
   private connect(): void {
     if (this.ws && (this.ws.readyState === WebSocket.OPEN || this.ws.readyState === WebSocket.CONNECTING)) {
       return;
@@ -305,6 +347,7 @@ export class RelayConnection {
     ws.addEventListener('open', () => {
       if (this.ws !== ws) return; // stale event from a superseded socket
       this.reconnectDelay = RECONNECT_BASE_MS;
+      this.startKeepalive();
       this.deps.onOpen();
     });
 
@@ -315,6 +358,7 @@ export class RelayConnection {
 
     ws.addEventListener('close', (event: CloseEvent) => {
       if (this.ws !== ws) return; // stale event from a superseded socket
+      this.stopKeepalive();
       const code = event.code;
       const reason = event.reason;
       this.ws = null;

--- a/clients/chrome-extension/background/self-hosted-auth.ts
+++ b/clients/chrome-extension/background/self-hosted-auth.ts
@@ -50,6 +50,27 @@ const NATIVE_HOST_NAME = 'com.vellum.daemon';
 const DEFAULT_BOOTSTRAP_TIMEOUT_MS = 5_000;
 
 /**
+ * Window (ms) before `expiresAt` inside which we treat the stored local token
+ * as "stale" and proactively re-bootstrap it. 60 seconds mirrors the cloud
+ * token stale semantics — gives enough headroom that an in-flight reconnect
+ * doesn't race the runtime's own expiry check.
+ */
+export const LOCAL_TOKEN_STALE_WINDOW_MS = 60_000;
+
+/**
+ * Return `true` when the stored local token is expired or within
+ * {@link LOCAL_TOKEN_STALE_WINDOW_MS} of expiring. `null`/missing tokens
+ * also count as stale so callers can treat them uniformly.
+ */
+export function isLocalTokenStale(
+  token: StoredLocalToken | null,
+  now: number = Date.now(),
+): boolean {
+  if (!token) return true;
+  return token.expiresAt - now <= LOCAL_TOKEN_STALE_WINDOW_MS;
+}
+
+/**
  * The legacy unscoped storage key used before assistant-scoped keys were
  * introduced. Existing users may have a token stored under this key from
  * a previous version of the extension. The migration helpers below

--- a/clients/chrome-extension/background/worker.ts
+++ b/clients/chrome-extension/background/worker.ts
@@ -265,6 +265,77 @@ async function getAssistantCatalogAndSelection(): Promise<{
   return { assistants: catalog.assistants, selected, authProfile };
 }
 
+// ── Connection health state ──────────────────────────────────────────
+//
+// Explicit state machine for the relay connection lifecycle. The popup
+// consumes this via `get_status` instead of inferring state from the
+// `connected` boolean and ad-hoc error fields.
+//
+// States:
+//   - `paused`       — user explicitly paused; autoConnect is false.
+//   - `connecting`    — initial connect attempt in progress.
+//   - `connected`     — relay WebSocket is OPEN.
+//   - `reconnecting`  — socket dropped unexpectedly; reconnect in progress.
+//   - `auth_required` — credentials are missing/expired and non-interactive
+//                       refresh failed. User must sign in / re-pair.
+//   - `error`         — unrecoverable non-auth error (e.g. native host
+//                       not installed, unsupported topology).
+
+/**
+ * Structured connection health state exposed to the popup via
+ * `get_status`. Transitions are driven by the connect, reconnect,
+ * close, and pause actions in the worker.
+ */
+export type ConnectionHealthState =
+  | 'paused'
+  | 'connecting'
+  | 'connected'
+  | 'reconnecting'
+  | 'auth_required'
+  | 'error';
+
+/**
+ * Detail fields attached to the current health state. Populated on
+ * disconnect / error transitions and cleared on successful connect.
+ */
+export interface ConnectionHealthDetail {
+  /** WebSocket close code from the last unexpected disconnect. */
+  lastDisconnectCode?: number;
+  /** Human-readable error message from the last failure. */
+  lastErrorMessage?: string;
+  /** Epoch ms of the most recent health state change. */
+  lastChangeAt: number;
+}
+
+let connectionHealth: ConnectionHealthState = 'paused';
+let connectionHealthDetail: ConnectionHealthDetail = {
+  lastChangeAt: Date.now(),
+};
+
+/**
+ * Transition the connection health state. Every transition updates
+ * `lastChangeAt`. Additional detail fields (disconnect code, error
+ * message) are set by the caller via the optional `detail` argument.
+ */
+function setConnectionHealth(
+  state: ConnectionHealthState,
+  detail?: Partial<Omit<ConnectionHealthDetail, 'lastChangeAt'>>,
+): void {
+  connectionHealth = state;
+  connectionHealthDetail = {
+    ...connectionHealthDetail,
+    ...detail,
+    lastChangeAt: Date.now(),
+  };
+  // Clear stale error fields when entering a non-error state so
+  // previous `lastErrorMessage` / `lastDisconnectCode` values don't
+  // bleed into unrelated transitions (e.g. auth_required → paused).
+  if (state === 'connected' || state === 'paused' || state === 'connecting') {
+    delete connectionHealthDetail.lastDisconnectCode;
+    delete connectionHealthDetail.lastErrorMessage;
+  }
+}
+
 // ── Connection state ───────────────────────────────────────────────
 //
 // The connect path is driven entirely by the selected assistant's auth
@@ -734,6 +805,7 @@ function createRelayConnection(
     clientInstanceId,
     onOpen: () => {
       console.log(`[vellum-relay] Connected (${mode.kind})`);
+      setConnectionHealth('connected');
       // A successful connect means any persisted auth-error is stale
       // — clear it so the popup stops showing the sign-in prompt.
       void clearRelayAuthError();
@@ -762,6 +834,10 @@ function createRelayConnection(
         // after re-signing in.
         console.warn(`[vellum-relay] Auth refresh impossible: ${authError}`);
         shouldConnect = false;
+        setConnectionHealth('auth_required', {
+          lastDisconnectCode: code,
+          lastErrorMessage: authError,
+        });
         void setRelayAuthError({
           message: authError,
           mode: currentAuthProfile === 'cloud-oauth' ? 'cloud' : 'self-hosted',
@@ -771,6 +847,12 @@ function createRelayConnection(
         // connect() starts from a clean slate instead of trying to
         // reuse a connection we've already marked dead.
         relayConnection = null;
+      } else if (shouldConnect) {
+        // Unexpected disconnect but we intend to stay connected —
+        // the RelayConnection will attempt to reconnect automatically.
+        setConnectionHealth('reconnecting', {
+          lastDisconnectCode: code,
+        });
       }
     },
     onReconnect: async (ctx) => {
@@ -1016,6 +1098,7 @@ async function connect(options: ConnectOptions = { interactive: false }): Promis
 
 async function doConnect(options: ConnectOptions): Promise<void> {
   if (relayConnection && relayConnection.isOpen()) return;
+  setConnectionHealth('connecting');
   // Defensive: a fresh connect() always starts the 1006 refresh
   // budget from scratch. The counter is normally reset from onOpen,
   // but if a previous session exhausted the cap (so onOpen never
@@ -1129,6 +1212,17 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponseFn) => {
         // would retry a doomed connect.
         await setAutoConnect(false);
         const errorMessage = err instanceof Error ? err.message : String(err);
+        // Classify the failure: auth-related errors (MissingTokenError)
+        // surface as `auth_required`; everything else is a generic `error`.
+        if (err instanceof MissingTokenError) {
+          setConnectionHealth('auth_required', {
+            lastErrorMessage: errorMessage,
+          });
+        } else {
+          setConnectionHealth('error', {
+            lastErrorMessage: errorMessage,
+          });
+        }
         sendResponseFn({ ok: false, error: errorMessage });
       });
     return true; // async
@@ -1140,6 +1234,7 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponseFn) => {
   // — both actions perform identical state transitions.
   if (message.type === 'pause' || message.type === 'disconnect') {
     shouldConnect = false;
+    setConnectionHealth('paused');
     // Await the storage write so MV3 can't terminate the worker before
     // the autoConnect flag is persisted to false.
     setAutoConnect(false)
@@ -1158,6 +1253,8 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponseFn) => {
     sendResponseFn({
       connected: relayConnection !== null && relayConnection.isOpen(),
       authProfile: currentAuthProfile,
+      health: connectionHealth,
+      healthDetail: connectionHealthDetail,
     });
     return false;
   }
@@ -1293,9 +1390,22 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponseFn) => {
             // transient. In both cases, log and continue — the user can
             // manually reconnect via the Connect button.
             shouldConnect = false;
+            const errorMessage =
+              err instanceof Error ? err.message : String(err);
             console.warn(
-              `[vellum-relay] Assistant switch left disconnected: ${err instanceof Error ? err.message : String(err)}`,
+              `[vellum-relay] Assistant switch left disconnected: ${errorMessage}`,
             );
+            // Transition health so the popup reflects the actual state
+            // instead of remaining stuck at 'connecting'.
+            if (err instanceof MissingTokenError) {
+              setConnectionHealth('auth_required', {
+                lastErrorMessage: errorMessage,
+              });
+            } else {
+              setConnectionHealth('error', {
+                lastErrorMessage: errorMessage,
+              });
+            }
           }
         }
 
@@ -1335,6 +1445,9 @@ async function bootstrap(): Promise<void> {
     shouldConnect = false;
     if (err instanceof MissingTokenError) {
       console.warn(`[vellum-relay] Skipping auto-connect: ${err.message}`);
+      setConnectionHealth('auth_required', {
+        lastErrorMessage: err.message,
+      });
       void setRelayAuthError({
         message: err.message,
         mode: currentAuthProfile === 'cloud-oauth' ? 'cloud' : 'self-hosted',
@@ -1348,6 +1461,9 @@ async function bootstrap(): Promise<void> {
     // an unhandled rejection.
     const detail = err instanceof Error ? err.message : String(err);
     console.warn(`[vellum-relay] Auto-connect failed: ${detail}`);
+    setConnectionHealth('error', {
+      lastErrorMessage: detail,
+    });
     void setRelayAuthError({
       message: detail,
       mode: currentAuthProfile === 'cloud-oauth' ? 'cloud' : 'self-hosted',

--- a/clients/chrome-extension/background/worker.ts
+++ b/clients/chrome-extension/background/worker.ts
@@ -61,6 +61,7 @@ import {
   bootstrapLocalToken,
   getStoredLocalToken,
   validateLocalToken,
+  isLocalTokenStale,
   LEGACY_LOCAL_STORAGE_KEY,
   type StoredLocalToken,
 } from './self-hosted-auth.js';
@@ -520,7 +521,29 @@ async function buildRelayModeForAssistant(
   });
 
   if (profile === 'local-pair') {
-    const local = await getStoredLocalToken(assistant.assistantId);
+    let local = await getStoredLocalToken(assistant.assistantId);
+
+    // Silent token recovery: when the stored token is missing, expired,
+    // or stale (within the stale window), attempt a non-interactive
+    // bootstrap before surfacing a missing-token error. This lets
+    // returning local users with expired/stale pair tokens auto-recover
+    // without a manual re-pair click in startup/reconnect flows.
+    if (isLocalTokenStale(local)) {
+      try {
+        local = await bootstrapLocalToken(assistant.assistantId);
+      } catch (err) {
+        // Non-recoverable native-host failures (missing host, forbidden
+        // origin, pair endpoint failure) — fall through to the
+        // token-less error path below so the caller surfaces an
+        // actionable error.
+        const detail = err instanceof Error ? err.message : String(err);
+        console.warn(
+          `[vellum-relay] Silent local token refresh failed: ${detail}`,
+        );
+        local = null;
+      }
+    }
+
     if (local) {
       const port = local.assistantPort ?? assistant.daemonPort ?? (await getRelayPort());
       return {
@@ -768,9 +791,27 @@ function createRelayConnection(
         return cloudReconnectHook(ctx);
       }
       const selectedId = await loadSelectedAssistantId();
-      const local = selectedId
+      let local = selectedId
         ? await getStoredLocalToken(selectedId)
         : await getLegacyLocalToken();
+
+      // Silent token recovery on reconnect: when the stored local token
+      // is stale/expired/missing, attempt a non-interactive bootstrap
+      // before aborting. This mirrors the preflight recovery in
+      // buildRelayModeForAssistant and lets auto-reconnect paths
+      // silently refresh tokens without user interaction.
+      if (isLocalTokenStale(local) && selectedId) {
+        try {
+          local = await bootstrapLocalToken(selectedId);
+        } catch (err) {
+          const detail = err instanceof Error ? err.message : String(err);
+          console.warn(
+            `[vellum-relay] Silent local token refresh on reconnect failed: ${detail}`,
+          );
+          local = null;
+        }
+      }
+
       if (local?.token) {
         return { kind: 'refreshed', token: local.token };
       }

--- a/clients/chrome-extension/background/worker.ts
+++ b/clients/chrome-extension/background/worker.ts
@@ -604,14 +604,13 @@ async function buildRelayModeForAssistant(
         local = await bootstrapLocalToken(assistant.assistantId);
       } catch (err) {
         // Non-recoverable native-host failures (missing host, forbidden
-        // origin, pair endpoint failure) — fall through to the
-        // token-less error path below so the caller surfaces an
-        // actionable error.
+        // origin, pair endpoint failure) — leave the original `local`
+        // value unchanged so a stale-but-not-expired token can still be
+        // used. If the original was already null, nothing changes.
         const detail = err instanceof Error ? err.message : String(err);
         console.warn(
           `[vellum-relay] Silent local token refresh failed: ${detail}`,
         );
-        local = null;
       }
     }
 
@@ -886,11 +885,12 @@ function createRelayConnection(
         try {
           local = await bootstrapLocalToken(selectedId);
         } catch (err) {
+          // Leave original `local` value unchanged so a stale-but-not-expired
+          // token can still be used on reconnect.
           const detail = err instanceof Error ? err.message : String(err);
           console.warn(
             `[vellum-relay] Silent local token refresh on reconnect failed: ${detail}`,
           );
-          local = null;
         }
       }
 

--- a/clients/chrome-extension/manifest.json
+++ b/clients/chrome-extension/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": 3,
   "name": "Vellum Assistant Browser Relay",
   "version": "1.0.0",
+  "minimum_chrome_version": "116",
   "description": "Bridges the Vellum assistant to your live browser session via Chrome DevTools Protocol (CDP) through chrome.debugger.",
 
   "permissions": [

--- a/clients/chrome-extension/native-host/README.md
+++ b/clients/chrome-extension/native-host/README.md
@@ -9,11 +9,37 @@ serves two purposes:
    assistant selector dropdown.
 2. **Self-hosted pairing** (`request_token`): bootstraps a scoped
    capability token for the local-assistant transport without shipping a
-   long-lived secret in the extension package. In the normal one-click
-   Connect flow, the extension's service worker invokes this
-   automatically — users never need to trigger pairing manually. The
-   `request_token` message also serves as a recovery mechanism when
-   the popup's Troubleshooting "Re-pair" button is used.
+   long-lived secret in the extension package.
+
+### Automatic maintenance path (normal operation)
+
+In the shipped seamless-extension architecture, native pairing is an
+**automatic maintenance operation** — not a user-initiated step. The
+extension's service worker invokes `request_token` silently in two
+scenarios:
+
+- **First connect**: When the user clicks Connect for the first time, the
+  worker auto-bootstraps the local capability token via native messaging
+  as part of the one-click flow. No separate "Pair" action is needed.
+- **Silent token refresh**: When a stored token is expired or stale (at
+  connect time, reconnect time, or auto-connect on browser reopen), the
+  worker attempts a non-interactive `bootstrapLocalToken()` call that
+  re-invokes the native helper under the hood. If the assistant is
+  reachable, the token is refreshed silently and the relay reconnects
+  without user involvement.
+
+### Manual invocation (diagnostics only)
+
+The popup's Troubleshooting section includes a "Re-pair with local
+assistant" button that also invokes `request_token`. This is reserved for
+cases where automatic recovery has failed — e.g. the native messaging
+host was uninstalled, the assistant was unreachable during all automatic
+refresh attempts, or the pair endpoint rejected the extension origin. The
+popup only surfaces this control when the health state is `auth_required`
+or `error`; during normal `connected` or `reconnecting` states the
+Troubleshooting section stays collapsed.
+
+### Bundling
 
 The macOS installer bundles this helper into the Mac `.app` under
 `Contents/MacOS/vellum-chrome-native-host` via `clients/macos/build.sh`

--- a/clients/chrome-extension/popup/popup-state.test.ts
+++ b/clients/chrome-extension/popup/popup-state.test.ts
@@ -206,14 +206,24 @@ describe('deriveCtaState', () => {
     expect(state.pauseEnabled).toBe(false);
   });
 
+  test('reconnecting: shows Reconnecting\u2026 label, both buttons disabled', () => {
+    const state = deriveCtaState('reconnecting');
+    expect(state.connectLabel).toBe('Reconnecting\u2026');
+    expect(state.connectEnabled).toBe(false);
+    expect(state.pauseLabel).toBe('Pause');
+    expect(state.pauseEnabled).toBe(false);
+  });
+
   test('all phases produce consistent label/enablement pairs', () => {
-    const phases: ConnectionPhase[] = ['disconnected', 'connecting', 'connected', 'paused'];
+    const phases: ConnectionPhase[] = ['disconnected', 'connecting', 'reconnecting', 'connected', 'paused'];
     for (const phase of phases) {
       const state = deriveCtaState(phase);
       // Pause should only be enabled when connected
       expect(state.pauseEnabled).toBe(phase === 'connected');
-      // Connect should be disabled only when connecting or connected
-      expect(state.connectEnabled).toBe(phase !== 'connecting' && phase !== 'connected');
+      // Connect should be disabled when connecting, reconnecting, or connected
+      expect(state.connectEnabled).toBe(
+        phase !== 'connecting' && phase !== 'reconnecting' && phase !== 'connected',
+      );
     }
   });
 });
@@ -233,6 +243,12 @@ describe('deriveStatusDisplay', () => {
     expect(status.text).toBe('Connecting\u2026');
   });
 
+  test('reconnecting: amber dot, Reconnecting automatically\u2026', () => {
+    const status = deriveStatusDisplay('reconnecting');
+    expect(status.dotClass).toBe('paused');
+    expect(status.text).toBe('Reconnecting automatically\u2026');
+  });
+
   test('connected: green dot, Connected to relay server', () => {
     const status = deriveStatusDisplay('connected');
     expect(status.dotClass).toBe('connected');
@@ -245,18 +261,22 @@ describe('deriveStatusDisplay', () => {
     expect(status.text).toBe('Paused');
   });
 
-  test('display transitions: disconnected -> connecting -> connected -> paused -> disconnected', () => {
+  test('display transitions: disconnected -> connecting -> connected -> reconnecting -> connected -> paused -> disconnected', () => {
     const transitions: ConnectionPhase[] = [
       'disconnected',
       'connecting',
       'connected',
+      'reconnecting',
+      'connected',
       'paused',
       'disconnected',
     ];
-    const expectedDots = ['disconnected', 'disconnected', 'connected', 'paused', 'disconnected'];
+    const expectedDots = ['disconnected', 'disconnected', 'connected', 'paused', 'connected', 'paused', 'disconnected'];
     const expectedTexts = [
       'Not connected',
       'Connecting\u2026',
+      'Connected to relay server',
+      'Reconnecting automatically\u2026',
       'Connected to relay server',
       'Paused',
       'Not connected',
@@ -281,8 +301,8 @@ describe('healthToPhase', () => {
     expect(healthToPhase('connecting')).toBe('connecting');
   });
 
-  test('reconnecting health maps to connecting phase', () => {
-    expect(healthToPhase('reconnecting')).toBe('connecting');
+  test('reconnecting health maps to reconnecting phase', () => {
+    expect(healthToPhase('reconnecting')).toBe('reconnecting');
   });
 
   test('paused health maps to paused phase', () => {
@@ -301,7 +321,7 @@ describe('healthToPhase', () => {
     const healthStates: ConnectionHealthState[] = [
       'paused', 'connecting', 'connected', 'reconnecting', 'auth_required', 'error',
     ];
-    const validPhases = new Set<ConnectionPhase>(['disconnected', 'connecting', 'connected', 'paused']);
+    const validPhases = new Set<ConnectionPhase>(['disconnected', 'connecting', 'reconnecting', 'connected', 'paused']);
 
     for (const health of healthStates) {
       const phase = healthToPhase(health);
@@ -316,9 +336,11 @@ describe('healthToPhase', () => {
     expect(cta.pauseEnabled).toBe(false);
   });
 
-  test('CTA enablement via healthToPhase: reconnecting disables both', () => {
+  test('CTA enablement via healthToPhase: reconnecting disables both buttons', () => {
     const phase = healthToPhase('reconnecting');
+    expect(phase).toBe('reconnecting');
     const cta = deriveCtaState(phase);
+    expect(cta.connectLabel).toBe('Reconnecting\u2026');
     expect(cta.connectEnabled).toBe(false);
     expect(cta.pauseEnabled).toBe(false);
   });

--- a/clients/chrome-extension/popup/popup-state.test.ts
+++ b/clients/chrome-extension/popup/popup-state.test.ts
@@ -7,6 +7,10 @@
  *   - shouldShowLocalSection / shouldShowCloudSection: auth-profile gating
  *   - deriveCtaState: CTA label/enablement for each connection phase
  *   - deriveStatusDisplay: status dot class and text for each phase
+ *   - healthToPhase: mapping from ConnectionHealthState to ConnectionPhase
+ *   - deriveHealthStatusDisplay: health-aware status display with detail
+ *   - shouldExpandTroubleshooting: troubleshoot section auto-expand rules
+ *   - hasTroubleshootingControls: whether auth controls exist for profile
  */
 
 import { describe, test, expect } from 'bun:test';
@@ -18,7 +22,13 @@ import {
   shouldShowCloudSection,
   deriveCtaState,
   deriveStatusDisplay,
+  healthToPhase,
+  deriveHealthStatusDisplay,
+  shouldExpandTroubleshooting,
+  hasTroubleshootingControls,
   type ConnectionPhase,
+  type ConnectionHealthState,
+  type ConnectionHealthDetail,
 } from './popup-state.js';
 
 import type { AssistantDescriptor } from '../background/native-host-assistants.js';
@@ -46,6 +56,13 @@ const cloudAssistant = makeDescriptor({
   authProfile: 'cloud-oauth',
 });
 const secondLocal = makeDescriptor({ assistantId: 'second-local' });
+
+function makeDetail(overrides?: Partial<ConnectionHealthDetail>): ConnectionHealthDetail {
+  return {
+    lastChangeAt: Date.now(),
+    ...overrides,
+  };
+}
 
 // ── deriveSelectorDisplay ──────────────────────────────────────────
 
@@ -250,5 +267,302 @@ describe('deriveStatusDisplay', () => {
       expect(status.dotClass).toBe(expectedDots[i]);
       expect(status.text).toBe(expectedTexts[i]);
     }
+  });
+});
+
+// ── healthToPhase ──────────────────────────────────────────────────
+
+describe('healthToPhase', () => {
+  test('connected health maps to connected phase', () => {
+    expect(healthToPhase('connected')).toBe('connected');
+  });
+
+  test('connecting health maps to connecting phase', () => {
+    expect(healthToPhase('connecting')).toBe('connecting');
+  });
+
+  test('reconnecting health maps to connecting phase', () => {
+    expect(healthToPhase('reconnecting')).toBe('connecting');
+  });
+
+  test('paused health maps to paused phase', () => {
+    expect(healthToPhase('paused')).toBe('paused');
+  });
+
+  test('auth_required health maps to disconnected phase', () => {
+    expect(healthToPhase('auth_required')).toBe('disconnected');
+  });
+
+  test('error health maps to disconnected phase', () => {
+    expect(healthToPhase('error')).toBe('disconnected');
+  });
+
+  test('all health states map to valid phases', () => {
+    const healthStates: ConnectionHealthState[] = [
+      'paused', 'connecting', 'connected', 'reconnecting', 'auth_required', 'error',
+    ];
+    const validPhases = new Set<ConnectionPhase>(['disconnected', 'connecting', 'connected', 'paused']);
+
+    for (const health of healthStates) {
+      const phase = healthToPhase(health);
+      expect(validPhases.has(phase)).toBe(true);
+    }
+  });
+
+  test('CTA enablement via healthToPhase: auth_required allows Connect', () => {
+    const phase = healthToPhase('auth_required');
+    const cta = deriveCtaState(phase);
+    expect(cta.connectEnabled).toBe(true);
+    expect(cta.pauseEnabled).toBe(false);
+  });
+
+  test('CTA enablement via healthToPhase: reconnecting disables both', () => {
+    const phase = healthToPhase('reconnecting');
+    const cta = deriveCtaState(phase);
+    expect(cta.connectEnabled).toBe(false);
+    expect(cta.pauseEnabled).toBe(false);
+  });
+
+  test('CTA enablement via healthToPhase: error allows Connect', () => {
+    const phase = healthToPhase('error');
+    const cta = deriveCtaState(phase);
+    expect(cta.connectEnabled).toBe(true);
+    expect(cta.pauseEnabled).toBe(false);
+  });
+});
+
+// ── deriveHealthStatusDisplay ──────────────────────────────────────
+
+describe('deriveHealthStatusDisplay', () => {
+  test('connected: green dot, Connected', () => {
+    const status = deriveHealthStatusDisplay('connected');
+    expect(status.dotClass).toBe('connected');
+    expect(status.text).toBe('Connected');
+  });
+
+  test('connecting: red dot, Connecting\u2026', () => {
+    const status = deriveHealthStatusDisplay('connecting');
+    expect(status.dotClass).toBe('disconnected');
+    expect(status.text).toBe('Connecting\u2026');
+  });
+
+  test('reconnecting: amber dot, Reconnecting automatically\u2026', () => {
+    const status = deriveHealthStatusDisplay('reconnecting');
+    expect(status.dotClass).toBe('paused');
+    expect(status.text).toBe('Reconnecting automatically\u2026');
+  });
+
+  test('paused: amber dot, Paused', () => {
+    const status = deriveHealthStatusDisplay('paused');
+    expect(status.dotClass).toBe('paused');
+    expect(status.text).toBe('Paused');
+  });
+
+  test('auth_required without detail: generic action required text', () => {
+    const status = deriveHealthStatusDisplay('auth_required');
+    expect(status.dotClass).toBe('disconnected');
+    expect(status.text).toContain('Action required');
+  });
+
+  test('auth_required with error message: includes message in text', () => {
+    const detail = makeDetail({ lastErrorMessage: 'Cloud token expired' });
+    const status = deriveHealthStatusDisplay('auth_required', detail);
+    expect(status.dotClass).toBe('disconnected');
+    expect(status.text).toContain('Action required');
+    expect(status.text).toContain('Cloud token expired');
+  });
+
+  test('error without detail: generic error text', () => {
+    const status = deriveHealthStatusDisplay('error');
+    expect(status.dotClass).toBe('disconnected');
+    expect(status.text).toBe('Connection error');
+  });
+
+  test('error with error message: includes message in text', () => {
+    const detail = makeDetail({ lastErrorMessage: 'Native host not installed' });
+    const status = deriveHealthStatusDisplay('error', detail);
+    expect(status.dotClass).toBe('disconnected');
+    expect(status.text).toContain('Error');
+    expect(status.text).toContain('Native host not installed');
+  });
+
+  test('reconnecting with disconnect code: still shows friendly message', () => {
+    const detail = makeDetail({ lastDisconnectCode: 1006 });
+    const status = deriveHealthStatusDisplay('reconnecting', detail);
+    expect(status.dotClass).toBe('paused');
+    expect(status.text).toBe('Reconnecting automatically\u2026');
+  });
+
+  test('all health states produce valid dot classes', () => {
+    const healthStates: ConnectionHealthState[] = [
+      'paused', 'connecting', 'connected', 'reconnecting', 'auth_required', 'error',
+    ];
+    const validDots = new Set(['connected', 'paused', 'disconnected']);
+
+    for (const health of healthStates) {
+      const status = deriveHealthStatusDisplay(health);
+      expect(validDots.has(status.dotClass)).toBe(true);
+    }
+  });
+
+  test('all health states produce non-empty status text', () => {
+    const healthStates: ConnectionHealthState[] = [
+      'paused', 'connecting', 'connected', 'reconnecting', 'auth_required', 'error',
+    ];
+
+    for (const health of healthStates) {
+      const status = deriveHealthStatusDisplay(health);
+      expect(status.text.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+// ── shouldExpandTroubleshooting ────────────────────────────────────
+
+describe('shouldExpandTroubleshooting', () => {
+  test('expands for auth_required', () => {
+    expect(shouldExpandTroubleshooting('auth_required')).toBe(true);
+  });
+
+  test('expands for error', () => {
+    expect(shouldExpandTroubleshooting('error')).toBe(true);
+  });
+
+  test('collapses for connected', () => {
+    expect(shouldExpandTroubleshooting('connected')).toBe(false);
+  });
+
+  test('collapses for connecting', () => {
+    expect(shouldExpandTroubleshooting('connecting')).toBe(false);
+  });
+
+  test('collapses for reconnecting', () => {
+    expect(shouldExpandTroubleshooting('reconnecting')).toBe(false);
+  });
+
+  test('collapses for paused', () => {
+    expect(shouldExpandTroubleshooting('paused')).toBe(false);
+  });
+
+  test('happy path states never expand troubleshooting', () => {
+    const happyStates: ConnectionHealthState[] = ['connected', 'connecting', 'reconnecting', 'paused'];
+    for (const state of happyStates) {
+      expect(shouldExpandTroubleshooting(state)).toBe(false);
+    }
+  });
+
+  test('action-required states always expand troubleshooting', () => {
+    const actionStates: ConnectionHealthState[] = ['auth_required', 'error'];
+    for (const state of actionStates) {
+      expect(shouldExpandTroubleshooting(state)).toBe(true);
+    }
+  });
+});
+
+// ── hasTroubleshootingControls ─────────────────────────────────────
+
+describe('hasTroubleshootingControls', () => {
+  test('returns true for local-pair', () => {
+    expect(hasTroubleshootingControls('local-pair')).toBe(true);
+  });
+
+  test('returns true for cloud-oauth', () => {
+    expect(hasTroubleshootingControls('cloud-oauth')).toBe(true);
+  });
+
+  test('returns false for unsupported', () => {
+    expect(hasTroubleshootingControls('unsupported')).toBe(false);
+  });
+
+  test('returns false for null', () => {
+    expect(hasTroubleshootingControls(null)).toBe(false);
+  });
+});
+
+// ── Integrated state derivation scenarios ──────────────────────────
+
+describe('integrated health-to-display scenarios', () => {
+  test('typical user happy path: paused -> connecting -> connected', () => {
+    // User opens popup when paused.
+    let status = deriveHealthStatusDisplay('paused');
+    expect(status.text).toBe('Paused');
+    expect(shouldExpandTroubleshooting('paused')).toBe(false);
+
+    // User clicks Connect.
+    status = deriveHealthStatusDisplay('connecting');
+    expect(status.text).toBe('Connecting\u2026');
+    expect(shouldExpandTroubleshooting('connecting')).toBe(false);
+
+    // Connection established.
+    status = deriveHealthStatusDisplay('connected');
+    expect(status.text).toBe('Connected');
+    expect(shouldExpandTroubleshooting('connected')).toBe(false);
+  });
+
+  test('transient disconnect and auto-recovery', () => {
+    // Connected, then disconnects.
+    let status = deriveHealthStatusDisplay('connected');
+    expect(status.text).toBe('Connected');
+
+    // Auto-reconnecting.
+    status = deriveHealthStatusDisplay('reconnecting');
+    expect(status.text).toBe('Reconnecting automatically\u2026');
+    expect(status.dotClass).toBe('paused');
+    expect(shouldExpandTroubleshooting('reconnecting')).toBe(false);
+
+    // Reconnect succeeds.
+    status = deriveHealthStatusDisplay('connected');
+    expect(status.text).toBe('Connected');
+  });
+
+  test('auth failure surfaces action required with expanded troubleshoot', () => {
+    const detail = makeDetail({
+      lastErrorMessage: "Automatic cloud sign-in failed",
+    });
+
+    const status = deriveHealthStatusDisplay('auth_required', detail);
+    expect(status.dotClass).toBe('disconnected');
+    expect(status.text).toContain('Action required');
+    expect(status.text).toContain('Automatic cloud sign-in failed');
+
+    // Troubleshoot should auto-expand.
+    expect(shouldExpandTroubleshooting('auth_required')).toBe(true);
+
+    // Connect button should be enabled for retry.
+    const phase = healthToPhase('auth_required');
+    const cta = deriveCtaState(phase);
+    expect(cta.connectEnabled).toBe(true);
+  });
+
+  test('native host error surfaces error with expanded troubleshoot', () => {
+    const detail = makeDetail({
+      lastErrorMessage: 'Native host not installed',
+    });
+
+    const status = deriveHealthStatusDisplay('error', detail);
+    expect(status.dotClass).toBe('disconnected');
+    expect(status.text).toContain('Error');
+    expect(status.text).toContain('Native host not installed');
+
+    expect(shouldExpandTroubleshooting('error')).toBe(true);
+  });
+
+  test('single-assistant install: no selector, controls hidden when not needed', () => {
+    // Single assistant: selector hidden.
+    const selectorDisplay = deriveSelectorDisplay([localAssistant], localAssistant);
+    expect(selectorDisplay.kind).toBe('hidden');
+
+    // Connected state: troubleshoot collapsed.
+    expect(shouldExpandTroubleshooting('connected')).toBe(false);
+  });
+
+  test('multi-assistant install: selector visible, controls preserved', () => {
+    const selectorDisplay = deriveSelectorDisplay(
+      [localAssistant, cloudAssistant],
+      localAssistant,
+    );
+    expect(selectorDisplay.kind).toBe('visible');
+    if (selectorDisplay.kind !== 'visible') throw new Error('unreachable');
+    expect(selectorDisplay.options.length).toBe(2);
   });
 });

--- a/clients/chrome-extension/popup/popup-state.ts
+++ b/clients/chrome-extension/popup/popup-state.ts
@@ -1,20 +1,50 @@
 /**
  * Pure view-state helpers for the popup UI.
  *
- * These functions derive display state from the assistant catalog,
- * selection data, and connection phase. They are deliberately
- * side-effect-free so they can be unit tested without a Chrome runtime
- * environment.
+ * These functions derive display state from the worker's structured
+ * connection health contract, the assistant catalog, and selection
+ * data. They are deliberately side-effect-free so they can be unit
+ * tested without a Chrome runtime environment.
  *
- * The popup exposes two primary actions:
- *   - **Connect** — the only first-step CTA. The worker handles auth
- *     bootstrap (pairing/sign-in) automatically when `interactive=true`.
- *   - **Pause** — user-facing stop action that halts the relay but
- *     preserves credentials so reconnect is instant.
+ * The popup shows concise primary states to the user:
+ *   - **Connected** — background relay active.
+ *   - **Reconnecting automatically** — transient disconnect, recovery
+ *     in progress.
+ *   - **Paused** — user explicitly paused; credentials preserved.
+ *   - **Action required** — auth/host error requiring manual recovery.
+ *
+ * Primary controls remain **Connect** and **Pause**. Manual recovery
+ * actions (Pair / Sign-in) live in a collapsible Troubleshoot area
+ * that is hidden by default unless the health state is `auth_required`
+ * or `error`.
  */
 
 import type { AssistantDescriptor } from '../background/native-host-assistants.js';
 import type { AssistantAuthProfile } from '../background/assistant-auth-profile.js';
+
+// ── Health state types (mirrored from worker.ts) ───────────────────
+
+/**
+ * The structured connection health state published by the worker via
+ * `get_status`. This is the canonical source of truth for the popup's
+ * display state.
+ */
+export type ConnectionHealthState =
+  | 'paused'
+  | 'connecting'
+  | 'connected'
+  | 'reconnecting'
+  | 'auth_required'
+  | 'error';
+
+/**
+ * Detail fields attached to the current health state from the worker.
+ */
+export interface ConnectionHealthDetail {
+  lastDisconnectCode?: number;
+  lastErrorMessage?: string;
+  lastChangeAt: number;
+}
 
 // ── Types ──────────────────────────────────────────────────────────
 
@@ -39,6 +69,16 @@ export interface AssistantSelectResponse {
   selected?: AssistantDescriptor | null;
   authProfile?: AssistantAuthProfile | null;
   error?: string;
+}
+
+/**
+ * Response shape from the worker's `get_status` message.
+ */
+export interface GetStatusResponse {
+  connected: boolean;
+  authProfile: AssistantAuthProfile | null;
+  health: ConnectionHealthState;
+  healthDetail: ConnectionHealthDetail;
 }
 
 /**
@@ -214,4 +254,113 @@ export function deriveStatusDisplay(phase: ConnectionPhase): StatusDisplay {
     case 'paused':
       return { dotClass: 'paused', text: 'Paused' };
   }
+}
+
+// ── Health-aware state mapping ──────────────────────────────────────
+//
+// These functions consume the worker's structured ConnectionHealthState
+// to produce the popup's concise user-facing display. They replace the
+// older boolean-based `connected` field with deterministic mapping from
+// the six-state health enum.
+
+/**
+ * Map the worker's health state to the popup's connection phase.
+ *
+ * The popup phase is a simplified view of the health state:
+ *   - `connected` and `reconnecting` both map to phases that keep
+ *     the user informed without requiring action.
+ *   - `auth_required` and `error` map to `disconnected` since the
+ *     user may need to take action.
+ *   - `paused` and `connecting` map directly.
+ */
+export function healthToPhase(health: ConnectionHealthState): ConnectionPhase {
+  switch (health) {
+    case 'connected':
+      return 'connected';
+    case 'connecting':
+      return 'connecting';
+    case 'reconnecting':
+      return 'connecting';
+    case 'paused':
+      return 'paused';
+    case 'auth_required':
+      return 'disconnected';
+    case 'error':
+      return 'disconnected';
+  }
+}
+
+/**
+ * Derive a concise, user-facing status display from the worker's
+ * health state and detail. This produces friendlier messages than the
+ * phase-based `deriveStatusDisplay` for health states that have no
+ * direct phase equivalent (reconnecting, auth_required, error).
+ *
+ * | Health state   | Dot class     | Status text                              |
+ * |----------------|---------------|------------------------------------------|
+ * | connected      | connected     | Connected                                |
+ * | connecting     | disconnected  | Connecting...                            |
+ * | reconnecting   | paused        | Reconnecting automatically...            |
+ * | paused         | paused        | Paused                                   |
+ * | auth_required  | disconnected  | Action required (+ detail if available)  |
+ * | error          | disconnected  | Error (+ detail if available)            |
+ */
+export function deriveHealthStatusDisplay(
+  health: ConnectionHealthState,
+  detail?: ConnectionHealthDetail,
+): StatusDisplay {
+  switch (health) {
+    case 'connected':
+      return { dotClass: 'connected', text: 'Connected' };
+    case 'connecting':
+      return { dotClass: 'disconnected', text: 'Connecting\u2026' };
+    case 'reconnecting':
+      return { dotClass: 'paused', text: 'Reconnecting automatically\u2026' };
+    case 'paused':
+      return { dotClass: 'paused', text: 'Paused' };
+    case 'auth_required':
+      return {
+        dotClass: 'disconnected',
+        text: detail?.lastErrorMessage
+          ? `Action required: ${detail.lastErrorMessage}`
+          : 'Action required \u2014 sign in or re-pair to continue',
+      };
+    case 'error':
+      return {
+        dotClass: 'disconnected',
+        text: detail?.lastErrorMessage
+          ? `Error: ${detail.lastErrorMessage}`
+          : 'Connection error',
+      };
+  }
+}
+
+// ── Troubleshooting visibility ──────────────────────────────────────
+
+/**
+ * Whether the Troubleshoot section should be expanded (visible) by
+ * default based on the current health state.
+ *
+ * The section is expanded when the health state requires user action:
+ *   - `auth_required` — credentials expired/missing, user must
+ *     re-pair or re-sign-in.
+ *   - `error` — unrecoverable error, manual recovery may help.
+ *
+ * For all other states (`connected`, `connecting`, `reconnecting`,
+ * `paused`) the section is collapsed so typical users see only the
+ * concise primary status without implementation details.
+ */
+export function shouldExpandTroubleshooting(health: ConnectionHealthState): boolean {
+  return health === 'auth_required' || health === 'error';
+}
+
+/**
+ * Whether troubleshooting auth controls are relevant given the auth
+ * profile. When the profile is null or unsupported, there are no
+ * auth controls to show regardless of health state.
+ */
+export function hasTroubleshootingControls(
+  authProfile: AssistantAuthProfile | null,
+): boolean {
+  return authProfile === 'local-pair' || authProfile === 'cloud-oauth';
 }

--- a/clients/chrome-extension/popup/popup-state.ts
+++ b/clients/chrome-extension/popup/popup-state.ts
@@ -165,13 +165,14 @@ export function shouldShowCloudSection(
  * The popup's connection lifecycle phase. Drives the primary/secondary
  * button labels, enablement, and status indicator.
  *
- * - `disconnected` — idle, no active relay connection.
- * - `connecting`   — connect in progress (waiting for socket open).
- * - `connected`    — relay WebSocket is open and active.
- * - `paused`       — user explicitly paused; credentials are preserved
- *                    so reconnect is instant.
+ * - `disconnected`  — idle, no active relay connection.
+ * - `connecting`    — connect in progress (waiting for socket open).
+ * - `reconnecting`  — transient disconnect, automatic recovery in progress.
+ * - `connected`     — relay WebSocket is open and active.
+ * - `paused`        — user explicitly paused; credentials are preserved
+ *                     so reconnect is instant.
  */
-export type ConnectionPhase = 'disconnected' | 'connecting' | 'connected' | 'paused';
+export type ConnectionPhase = 'disconnected' | 'connecting' | 'reconnecting' | 'connected' | 'paused';
 
 /**
  * Derived view state for the popup's primary and secondary action buttons.
@@ -194,6 +195,7 @@ export interface CtaState {
  * |--------------|---------------|---------------|
  * | disconnected | Connect (on)  | Pause (off)   |
  * | connecting   | Connecting... (off) | Pause (off) |
+ * | reconnecting | Reconnecting... (off) | Pause (off) |
  * | connected    | Connect (off) | Pause (on)    |
  * | paused       | Connect (on)  | Pause (off)   |
  */
@@ -209,6 +211,13 @@ export function deriveCtaState(phase: ConnectionPhase): CtaState {
     case 'connecting':
       return {
         connectLabel: 'Connecting\u2026',
+        connectEnabled: false,
+        pauseLabel: 'Pause',
+        pauseEnabled: false,
+      };
+    case 'reconnecting':
+      return {
+        connectLabel: 'Reconnecting\u2026',
         connectEnabled: false,
         pauseLabel: 'Pause',
         pauseEnabled: false,
@@ -249,6 +258,8 @@ export function deriveStatusDisplay(phase: ConnectionPhase): StatusDisplay {
       return { dotClass: 'disconnected', text: 'Not connected' };
     case 'connecting':
       return { dotClass: 'disconnected', text: 'Connecting\u2026' };
+    case 'reconnecting':
+      return { dotClass: 'paused', text: 'Reconnecting automatically\u2026' };
     case 'connected':
       return { dotClass: 'connected', text: 'Connected to relay server' };
     case 'paused':
@@ -267,11 +278,11 @@ export function deriveStatusDisplay(phase: ConnectionPhase): StatusDisplay {
  * Map the worker's health state to the popup's connection phase.
  *
  * The popup phase is a simplified view of the health state:
- *   - `connected` and `reconnecting` both map to phases that keep
- *     the user informed without requiring action.
+ *   - `connected`, `reconnecting`, and `connecting` map directly to
+ *     their respective phases.
  *   - `auth_required` and `error` map to `disconnected` since the
  *     user may need to take action.
- *   - `paused` and `connecting` map directly.
+ *   - `paused` maps directly.
  */
 export function healthToPhase(health: ConnectionHealthState): ConnectionPhase {
   switch (health) {
@@ -280,7 +291,7 @@ export function healthToPhase(health: ConnectionHealthState): ConnectionPhase {
     case 'connecting':
       return 'connecting';
     case 'reconnecting':
-      return 'connecting';
+      return 'reconnecting';
     case 'paused':
       return 'paused';
     case 'auth_required':

--- a/clients/chrome-extension/popup/popup.html
+++ b/clients/chrome-extension/popup/popup.html
@@ -173,6 +173,50 @@
       color: #ef4444;
       margin-bottom: 8px;
     }
+
+    /* ── Troubleshoot collapsible area ────────────────────────────── */
+
+    #troubleshoot-section {
+      margin-top: 16px;
+    }
+
+    #troubleshoot-section[hidden] {
+      display: none;
+    }
+
+    .troubleshoot-toggle {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+      background: none;
+      border: none;
+      padding: 0;
+      margin-bottom: 10px;
+      cursor: pointer;
+      font-size: 11px;
+      font-weight: 600;
+      color: #6b7280;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      flex: none;
+    }
+    .troubleshoot-toggle:hover { color: #374151; }
+
+    .troubleshoot-toggle .chevron {
+      display: inline-block;
+      font-size: 10px;
+      transition: transform 0.15s;
+    }
+    .troubleshoot-toggle[aria-expanded="true"] .chevron {
+      transform: rotate(90deg);
+    }
+
+    #troubleshoot-body {
+      overflow: hidden;
+    }
+    #troubleshoot-body[hidden] {
+      display: none;
+    }
   </style>
 </head>
 <body>
@@ -206,15 +250,29 @@
 
   <p class="hint">Relay port defaults to 7830.</p>
 
-  <div class="divider" id="troubleshooting-divider"></div>
+  <!-- Troubleshoot section: collapsed by default, auto-expanded for auth_required/error -->
+  <div id="troubleshoot-section" hidden>
+    <div class="divider"></div>
 
-  <p class="section-label" id="troubleshooting-label">Troubleshooting</p>
+    <button
+      type="button"
+      class="troubleshoot-toggle"
+      id="troubleshoot-toggle"
+      aria-expanded="false"
+      aria-controls="troubleshoot-body"
+    >
+      <span class="chevron">&#9654;</span>
+      Troubleshoot
+    </button>
 
-  <p class="local-status" id="local-status" style="display:none">Not paired</p>
-  <button id="btn-pair-local" type="button" style="display:none">Re-pair with local assistant</button>
+    <div id="troubleshoot-body" hidden>
+      <p class="local-status" id="local-status" style="display:none">Not paired</p>
+      <button id="btn-pair-local" type="button" style="display:none">Re-pair with local assistant</button>
 
-  <p class="cloud-status" id="cloud-status" style="display:none">Not signed in</p>
-  <button id="btn-cloud-signin" type="button" style="display:none">Re-sign in with Vellum (cloud)</button>
+      <p class="cloud-status" id="cloud-status" style="display:none">Not signed in</p>
+      <button id="btn-cloud-signin" type="button" style="display:none">Re-sign in with Vellum (cloud)</button>
+    </div>
+  </div>
 
   <script type="module" src="popup.js"></script>
 </body>

--- a/clients/chrome-extension/popup/popup.ts
+++ b/clients/chrome-extension/popup/popup.ts
@@ -375,14 +375,14 @@ btnConnect.addEventListener('click', async () => {
     }
   } catch (err) {
     showError(err instanceof Error ? err.message : String(err));
-    setPhase('disconnected');
+    applyHealthState('error');
     return;
   }
 
   chrome.runtime.sendMessage({ type: 'connect' }, (response: { ok: boolean; error?: string }) => {
     if (chrome.runtime.lastError || !response?.ok) {
       showError(response?.error ?? chrome.runtime.lastError?.message ?? 'Unknown error');
-      setPhase('disconnected');
+      applyHealthState('error');
       return;
     }
     // Poll briefly for health state convergence.

--- a/clients/chrome-extension/popup/popup.ts
+++ b/clients/chrome-extension/popup/popup.ts
@@ -1,17 +1,19 @@
 /**
  * Popup UI for the Vellum browser-relay extension.
  *
- * The popup exposes a single primary CTA — **Connect** — that works in
- * one click even when the user hasn't previously paired or signed in.
- * The worker handles auth bootstrap automatically when `interactive=true`.
+ * The popup renders a concise primary status derived from the worker's
+ * structured connection health state:
+ *   - **Connected** — relay active, everything working.
+ *   - **Reconnecting automatically** — transient disconnect, auto-recovery
+ *     in progress. No user action needed.
+ *   - **Paused** — user explicitly paused the relay.
+ *   - **Action required** — auth or host error requiring manual recovery.
  *
- * The secondary action is **Pause**, which halts the relay and clears the
- * auto-connect flag so the extension stays quiet until the user explicitly
- * reconnects. Credentials are preserved for instant reconnect.
- *
- * Manual recovery controls (local re-pair and cloud re-sign-in) are
- * available under a Troubleshooting section, but are not required for
- * the normal connect flow.
+ * Primary controls are **Connect** and **Pause**. Manual recovery
+ * controls (local re-pair and cloud re-sign-in) live in a collapsible
+ * Troubleshoot section that is hidden by default. The section auto-
+ * expands when the health state is `auth_required` or `error`, making
+ * break-glass recovery accessible without cluttering the happy path.
  *
  * On open the popup loads the assistant catalog from the worker via the
  * `assistants-get` message. When exactly one assistant exists it is
@@ -36,8 +38,14 @@ import {
   shouldShowLocalSection,
   shouldShowCloudSection,
   deriveCtaState,
-  deriveStatusDisplay,
+  deriveHealthStatusDisplay,
+  healthToPhase,
+  shouldExpandTroubleshooting,
+  hasTroubleshootingControls,
+  type ConnectionHealthState,
+  type ConnectionHealthDetail,
   type ConnectionPhase,
+  type GetStatusResponse,
   type AssistantsGetResponse,
   type AssistantSelectResponse,
 } from './popup-state.js';
@@ -57,12 +65,15 @@ const cloudStatus = document.getElementById('cloud-status') as HTMLParagraphElem
 const btnPairLocal = document.getElementById('btn-pair-local') as HTMLButtonElement;
 const localStatus = document.getElementById('local-status') as HTMLParagraphElement;
 
-const troubleshootingDivider = document.getElementById(
-  'troubleshooting-divider',
+const troubleshootSection = document.getElementById(
+  'troubleshoot-section',
 ) as HTMLDivElement;
-const troubleshootingLabel = document.getElementById(
-  'troubleshooting-label',
-) as HTMLParagraphElement;
+const troubleshootToggle = document.getElementById(
+  'troubleshoot-toggle',
+) as HTMLButtonElement;
+const troubleshootBody = document.getElementById(
+  'troubleshoot-body',
+) as HTMLDivElement;
 
 const assistantSelectorGroup = document.getElementById(
   'assistant-selector-group',
@@ -79,35 +90,69 @@ const assistantSelect = document.getElementById(
 let currentAuthProfile: AssistantAuthProfile | null = null;
 let currentAssistantId: string | null = null;
 
+// ── Current health state ────────────────────────────────────────────
+//
+// Tracks the latest health state from the worker so the troubleshoot
+// section can react to state changes.
+
+let currentHealthState: ConnectionHealthState = 'paused';
+
 // ── Connection phase management ─────────────────────────────────────
 
 /**
- * Apply a connection phase to the UI. Derives button labels/enablement
- * and status indicator from the pure helpers in popup-state.ts.
+ * Apply the worker's health state to the full popup UI. Derives button
+ * labels/enablement, status indicator, and troubleshooting section
+ * visibility from the pure helpers in popup-state.ts.
  */
-function setPhase(phase: ConnectionPhase): void {
+function applyHealthState(
+  health: ConnectionHealthState,
+  detail?: ConnectionHealthDetail,
+): void {
+  currentHealthState = health;
 
+  // Derive phase for CTA button states.
+  const phase = healthToPhase(health);
   const cta = deriveCtaState(phase);
   btnConnect.textContent = cta.connectLabel;
   btnConnect.disabled = !cta.connectEnabled;
   btnPause.textContent = cta.pauseLabel;
   btnPause.disabled = !cta.pauseEnabled;
 
-  const status = deriveStatusDisplay(phase);
+  // Derive health-aware status display (richer than phase-based).
+  const status = deriveHealthStatusDisplay(health, detail);
   statusDot.className = `status-dot ${status.dotClass}`;
   statusText.textContent = status.text;
 
   portInput.disabled = phase === 'connected' || phase === 'connecting';
 
-  if (phase === 'connected') {
+  if (health === 'connected') {
     errorText.style.display = 'none';
   }
+
+  // Update troubleshooting section visibility and expansion.
+  updateTroubleshootSection(health);
+}
+
+/**
+ * Backward-compatible wrapper: apply a connection phase to the UI
+ * when only phase information is available (e.g. during the
+ * connecting -> polling -> connected flow initiated by the popup).
+ */
+function setPhase(phase: ConnectionPhase): void {
+  // Map phase back to a health state for the unified path.
+  const healthMap: Record<ConnectionPhase, ConnectionHealthState> = {
+    connected: 'connected',
+    connecting: 'connecting',
+    disconnected: 'paused',
+    paused: 'paused',
+  };
+  applyHealthState(healthMap[phase]);
 }
 
 /**
  * Render an inline error message without touching any other UI.
  *
- * Use this for generic popup errors — e.g. cloud OAuth failures,
+ * Use this for generic popup errors -- e.g. cloud OAuth failures,
  * refresh exceptions, or generic service-worker messages.
  */
 function showErrorText(msg: string): void {
@@ -118,6 +163,54 @@ function showErrorText(msg: string): void {
 function showError(msg: string): void {
   showErrorText(msg);
 }
+
+// ── Troubleshoot section ────────────────────────────────────────────
+
+/**
+ * Update the troubleshoot section visibility and expansion state.
+ *
+ * The section is shown when there are auth controls to display
+ * (local-pair or cloud-oauth). It auto-expands when the health
+ * state is `auth_required` or `error` so the user can access
+ * recovery controls.
+ */
+function updateTroubleshootSection(health: ConnectionHealthState): void {
+  const hasControls = hasTroubleshootingControls(currentAuthProfile);
+
+  if (!hasControls) {
+    troubleshootSection.hidden = true;
+    return;
+  }
+
+  troubleshootSection.hidden = false;
+
+  // Auto-expand when action is required, auto-collapse on recovery.
+  if (shouldExpandTroubleshooting(health)) {
+    expandTroubleshoot();
+  } else if (health === 'connected') {
+    collapseTroubleshoot();
+  }
+}
+
+function expandTroubleshoot(): void {
+  troubleshootBody.hidden = false;
+  troubleshootToggle.setAttribute('aria-expanded', 'true');
+}
+
+function collapseTroubleshoot(): void {
+  troubleshootBody.hidden = true;
+  troubleshootToggle.setAttribute('aria-expanded', 'false');
+}
+
+// Toggle on click.
+troubleshootToggle.addEventListener('click', () => {
+  const expanded = troubleshootToggle.getAttribute('aria-expanded') === 'true';
+  if (expanded) {
+    collapseTroubleshoot();
+  } else {
+    expandTroubleshoot();
+  }
+});
 
 // ── Assistant selector ──────────────────────────────────────────────
 
@@ -169,9 +262,8 @@ function updateAuthSections(authProfile: AssistantAuthProfile | null): void {
   cloudStatus.style.display = showCloud ? '' : 'none';
   btnCloudSignIn.style.display = showCloud ? '' : 'none';
 
-  // Hide the Troubleshooting divider and heading when no controls are shown.
-  troubleshootingDivider.style.display = showLocal || showCloud ? '' : 'none';
-  troubleshootingLabel.style.display = showLocal || showCloud ? '' : 'none';
+  // Update troubleshoot section with current health state.
+  updateTroubleshootSection(currentHealthState);
 }
 
 /**
@@ -241,10 +333,17 @@ chrome.storage.local.get(['relayPort']).then((result) => {
   }
 });
 
-// Query current status from service worker
-chrome.runtime.sendMessage({ type: 'get_status' }, (response: { connected: boolean }) => {
+// Query current health state from service worker.
+chrome.runtime.sendMessage({ type: 'get_status' }, (response: GetStatusResponse) => {
   if (chrome.runtime.lastError) return;
-  setPhase(response?.connected ? 'connected' : 'disconnected');
+
+  // Use the structured health state if available, fall back to boolean.
+  if (response?.health) {
+    applyHealthState(response.health, response.healthDetail);
+  } else {
+    // Backward compatibility: older workers may not expose health.
+    setPhase(response?.connected ? 'connected' : 'disconnected');
+  }
 });
 
 function getPort(): number {
@@ -258,7 +357,7 @@ function getPort(): number {
 
 // ── Connect (primary CTA) ───────────────────────────────────────────
 //
-// No local precheck — the worker handles auth bootstrap (pairing/sign-in)
+// No local precheck -- the worker handles auth bootstrap (pairing/sign-in)
 // automatically when interactive=true. Users can connect in one click
 // even when not previously paired or signed in.
 
@@ -286,13 +385,29 @@ btnConnect.addEventListener('click', async () => {
       setPhase('disconnected');
       return;
     }
-    // Poll briefly for open state
+    // Poll briefly for health state convergence.
     let attempts = 0;
     const poll = setInterval(() => {
-      chrome.runtime.sendMessage({ type: 'get_status' }, (r: { connected: boolean }) => {
-        if (r?.connected || ++attempts > 10) {
+      chrome.runtime.sendMessage({ type: 'get_status' }, (r: GetStatusResponse) => {
+        if (chrome.runtime.lastError) {
+          if (++attempts > 10) {
+            clearInterval(poll);
+            // Fall back to a recoverable state so the user can retry.
+            applyHealthState('paused');
+          }
+          return;
+        }
+
+        const health = r?.health ?? (r?.connected ? 'connected' : 'connecting');
+        if (health === 'connected' || health === 'error' || health === 'auth_required') {
           clearInterval(poll);
-          setPhase(r?.connected ? 'connected' : 'disconnected');
+          applyHealthState(health as ConnectionHealthState, r?.healthDetail);
+        } else if (++attempts > 10) {
+          clearInterval(poll);
+          // Polling exhausted without reaching a terminal health state.
+          // Fall back to paused so the Connect button re-enables and
+          // the user can retry instead of being stuck on "Connecting...".
+          applyHealthState('paused');
         }
       });
     }, 300);
@@ -307,7 +422,7 @@ btnConnect.addEventListener('click', async () => {
 
 btnPause.addEventListener('click', () => {
   chrome.runtime.sendMessage({ type: 'pause' }, () => {
-    setPhase('paused');
+    applyHealthState('paused');
   });
 });
 
@@ -320,7 +435,7 @@ btnPause.addEventListener('click', () => {
 // `vellum.localCapabilityToken` and is used directly by the
 // self-hosted relay WebSocket connection.
 //
-// This is a manual recovery control — normal connect handles pairing
+// This is a manual recovery control -- normal connect handles pairing
 // automatically via the worker's interactive bootstrap.
 
 function setLocalStatus(text: string, state: 'neutral' | 'paired' | 'error'): void {
@@ -383,7 +498,7 @@ btnPairLocal.addEventListener('click', async () => {
   btnPairLocal.disabled = true;
   setLocalStatus('Pairing\u2026', 'neutral');
   // Delegate to the service worker so the native-messaging bootstrap
-  // survives the popup teardown race — see the `self-hosted-pair`
+  // survives the popup teardown race -- see the `self-hosted-pair`
   // handler in worker.ts, and the matching cloud-auth-sign-in pattern.
   const response = await requestLocalPair();
   if (response.ok && response.token) {
@@ -401,7 +516,7 @@ refreshLocalStatus();
 // The token is persisted and consumed by the background worker when
 // opening cloud relay WebSocket connections.
 //
-// This is a manual recovery control — normal connect handles cloud
+// This is a manual recovery control -- normal connect handles cloud
 // sign-in automatically via the worker's interactive bootstrap.
 
 function setCloudStatus(text: string, signedIn: boolean): void {
@@ -465,9 +580,9 @@ btnCloudSignIn.addEventListener('click', async () => {
   setCloudStatus('Signing in\u2026', false);
   errorText.style.display = 'none';
   // Clear any stale auth-error the worker persisted during a failed
-  // reconnect — the user is explicitly retrying sign-in now.
+  // reconnect -- the user is explicitly retrying sign-in now.
   await chrome.storage.local.remove('vellum.relayAuthError');
-  // Delegate to the service worker — see header comment for the rationale.
+  // Delegate to the service worker -- see header comment for the rationale.
   const response = await requestCloudSignIn();
   if (response.ok && response.token) {
     setCloudStatus(`Signed in as guardian:${response.token.guardianId}`, true);

--- a/docs/browser-use-architecture-phase2.md
+++ b/docs/browser-use-architecture-phase2.md
@@ -25,7 +25,7 @@ Phase 2 ships:
    - **Cloud**: WSS to the gateway's `/v1/browser-relay` endpoint, using
      a guardian-bound JWT minted via WorkOS-backed
      `chrome.identity.launchWebAuthFlow`.
-   - **Self-hosted**: WS to the local daemon's `/v1/browser-relay`
+   - **Self-hosted**: WS to the local assistant's `/v1/browser-relay`
      endpoint on `127.0.0.1`, using a scoped capability token bootstrapped
      via Chrome Native Messaging.
 3. A new `chrome-extension` interface in `INTERFACE_IDS` that routes
@@ -34,6 +34,28 @@ Phase 2 ships:
 4. A per-capability `supportsHostProxy(id, capability)` so the
    chrome-extension interface can advertise `host_browser` without
    implying that bash / file / CU proxies are also available.
+5. **Relay keepalive**: The extension sends periodic JSON heartbeat
+   frames (`{ type: "keepalive", sentAt: <epoch_ms> }`) every 20 seconds
+   to prevent Chrome MV3 service-worker idle suspension (~30 s timeout).
+   The runtime acknowledges by touching the connection's activity
+   timestamp in the `ChromeExtensionRegistry`.
+6. **Silent token maintenance**: On connect, reconnect, and auto-connect,
+   the worker transparently re-bootstraps expired/stale local tokens via
+   native messaging and refreshes cloud JWTs via non-interactive OAuth —
+   no user interaction required unless refresh itself fails.
+7. **Extension-first CDP routing**: The CDP client factory always prefers
+   the extension transport when it is provisioned. When the extension
+   proxy exists but is temporarily unavailable (mid-reconnect), the
+   factory intentionally skips `cdp-inspect` to prevent silent backend
+   drift. `cdp-inspect` enters the candidate list when no extension proxy
+   exists at all (macOS desktop-auto path) or when explicitly enabled in
+   config (`hostBrowser.cdpInspect.enabled`), but it is not used as a
+   fallback during transient extension disconnects.
+8. **Structured connection health**: The worker maintains a six-state
+   health machine (`paused`, `connecting`, `connected`, `reconnecting`,
+   `auth_required`, `error`) surfaced to the popup via `get_status`.
+   The popup renders concise status text and auto-expands the
+   Troubleshooting section only when user action is genuinely needed.
 
 `browser-execution.ts` drives the live navigation surface through a
 per-invocation `BrowserSessionManager` obtained via `getCdpClient()`
@@ -49,18 +71,30 @@ registry/proxy code path on the runtime side. Only the transport layer
 and the handshake differ.
 
 ```
- ┌───────────────────────┐
- │  Chrome extension     │
- │  (service worker)     │
- │                       │
- │  host-browser-dispatcher
- │   + cdp-proxy         │
- │   + relay-connection  │
- └──────────┬────────────┘
+ ┌─────────────────────────────────┐
+ │  Chrome extension               │
+ │  (MV3 service worker)           │
+ │                                 │
+ │  host-browser-dispatcher        │
+ │   + cdp-proxy                   │
+ │   + relay-connection            │
+ │     (keepalive 20s interval)    │
+ │     (reconnect 1s–30s backoff)  │
+ │     (silent token refresh)      │
+ │                                 │
+ │  ConnectionHealthState:         │
+ │   paused | connecting |         │
+ │   connected | reconnecting |    │
+ │   auth_required | error         │
+ │        │                        │
+ │        ▼                        │
+ │  popup (get_status)             │
+ └──────────┬──────────────────────┘
             │ WS (self-hosted)     WSS (cloud)
+            │  + keepalive frames  │
             │                      │
             ▼                      ▼
-    127.0.0.1:<port>         api.vellum.ai
+    127.0.0.1:<port>         <gateway>
     /v1/browser-relay        /v1/browser-relay
             │                      │
             └──────────┬───────────┘
@@ -71,7 +105,8 @@ and the handshake differ.
           │  http-server.ts open/close │
           │        │                   │
           │        ▼                   │
-         │  ChromeExtensionRegistry   │  (guardianId, clientInstanceId → ws)
+          │  ChromeExtensionRegistry   │  (guardianId, clientInstanceId → ws)
+          │   .touch() on keepalive    │
           │        │                   │
           │        ▼                   │
           │  HostBrowserProxy          │
@@ -99,30 +134,47 @@ the runtime runs on infrastructure managed by Vellum.
 
 Handshake:
 
-1. The user clicks "Sign in with Vellum (cloud)" in the extension
-   popup.
+1. The user clicks **Connect** in the extension popup. For cloud
+   assistants, the worker auto-bootstraps credentials as part of the
+   one-click flow — no separate "Sign in" step is needed.
 2. The service worker (not the popup) runs
    `chrome.identity.launchWebAuthFlow` against the gateway's WorkOS
    OIDC endpoint. Running it in the service worker keeps the awaited
    promise alive if the popup closes mid-flow.
 3. On success, the gateway returns a guardian-bound JWT and the
-   extension persists it via `cloud-auth.ts::getStoredToken`.
-4. The extension opens `wss://api.vellum.ai/v1/browser-relay` with the
-   JWT on the `token=...` query parameter.
+   extension persists it per-assistant via scoped storage keys.
+4. The extension opens `wss://<gateway>/v1/browser-relay` with the
+   JWT on the `token=...` query parameter and a `clientInstanceId`
+   for multi-install disambiguation.
 5. The gateway verifies the JWT, extracts the guardian id, and forwards
    the upgrade to the assistant runtime. The runtime registers the
-   connection under that guardian id in the `ChromeExtensionRegistry`.
+   connection under `(guardianId, clientInstanceId)` in the
+   `ChromeExtensionRegistry`.
+
+Token lifecycle:
+
+- The worker proactively refreshes stale cloud JWTs before they expire,
+  both at connect time (`connectPreflight`) and on reconnect
+  (`cloudReconnectHook`).
+- A non-interactive OAuth refresh is attempted first. If it succeeds the
+  relay reconnects silently.
+- If non-interactive refresh is impossible (refresh token expired, OAuth
+  configuration changed), the reconnect loop aborts and the popup enters
+  `auth_required` state. The user must re-sign-in via the Troubleshooting
+  controls, then click **Connect**.
 
 ## Self-hosted transport
 
 The self-hosted transport is used by users who run the assistant
 locally on their own machine (the default desktop experience). The
-extension talks directly to the local daemon over loopback.
+extension talks directly to the local assistant over loopback.
 
 Handshake:
 
-1. The user clicks "Pair with Vellum (self-hosted)" in the extension
-   popup.
+1. The user clicks **Connect** in the extension popup. For local
+   assistants, the worker auto-bootstraps the capability token via
+   native messaging as part of the one-click flow — no separate "Pair"
+   step is needed.
 2. The service worker calls
    `chrome.runtime.connectNative("com.vellum.daemon")`, which spawns
    `clients/chrome-extension/native-host/` (a tiny CLI helper bundled
@@ -136,13 +188,26 @@ Handshake:
    c. POSTs to `http://127.0.0.1:<port>/v1/browser-extension-pair` to
       mint a scoped capability token bound to the caller's guardian.
    d. Writes a `token_response` frame to stdout and exits.
-4. The extension persists the token and opens
-   `ws://127.0.0.1:<port>/v1/browser-relay` with the token on the
-   `token=...` query parameter.
-5. The daemon verifies the token via
-   `verifyHostBrowserCapability`, registers the connection in the
-   `ChromeExtensionRegistry`, and starts routing `host_browser_request`
-   frames to it.
+4. The extension persists the token per-assistant under scoped storage
+   keys and opens `ws://127.0.0.1:<port>/v1/browser-relay` with the
+   token on the `token=...` query parameter and a `clientInstanceId`
+   for multi-install disambiguation.
+5. The assistant verifies the token via
+   `verifyHostBrowserCapability`, registers the connection under
+   `(guardianId, clientInstanceId)` in the `ChromeExtensionRegistry`,
+   and starts routing `host_browser_request` frames to it.
+
+Token lifecycle:
+
+- The worker silently re-bootstraps local tokens when they are expired
+  or stale, both at connect time (`buildRelayModeForAssistant`) and on
+  reconnect (`onReconnect` hook in `createRelayConnection`). The native
+  messaging helper is re-spawned to mint a fresh token — no user
+  interaction required.
+- If the native host is unreachable or the pair endpoint rejects the
+  request, the reconnect loop aborts and the popup enters
+  `auth_required` state. The user must re-pair via the Troubleshooting
+  controls, then click **Connect**.
 
 `/v1/browser-extension-pair` is loopback-only and refuses requests
 from any non-private peer. The capability token is HMAC-SHA256 signed
@@ -180,16 +245,31 @@ The new modules that implement Phase 2:
   hands results to the worker for relay-aware delivery (WS first, HTTP
   fallback in self-hosted mode).
 - **`clients/chrome-extension/background/relay-connection.ts`** —
-  WebSocket relay with heartbeat, reconnect-with-token-refresh, and
-  mode-aware bearer injection.
+  Long-lived WebSocket relay with keepalive heartbeat (20 s interval to
+  prevent MV3 idle suspension), exponential-backoff reconnect (1 s base,
+  30 s cap), structured reconnect-with-refresh lifecycle (token rotation
+  before each reconnect attempt), and mode-aware bearer injection. The
+  `onReconnect` hook supports three outcomes: `keep` (reuse token),
+  `refreshed` (swap in a new token), or `abort` (stop reconnecting and
+  surface auth error to popup).
+- **`clients/chrome-extension/background/cloud-reconnect-decision.ts`** —
+  Pure decision function for cloud reconnect strategy. Distinguishes
+  auth-failure closes (4001/4002/4003/1008) from transient 1006 closes
+  and manages a refresh-attempt budget to avoid silently hammering the
+  gateway. Covered by direct unit tests.
 - **`clients/chrome-extension/native-host/`** — Native messaging helper
-  binary that bootstraps the self-hosted capability token.
+  binary that bootstraps the self-hosted capability token. Invoked
+  automatically by the service worker during connect, reconnect, and
+  auto-connect flows; manual invocation via the popup's Troubleshooting
+  controls is reserved for diagnostics when automatic recovery fails.
 
 Runtime wiring:
 
 - `http-server.ts` open/close handlers for `/v1/browser-relay` register
   the connection in `ChromeExtensionRegistry` on open and unregister on
-  close.
+  close. The inbound frame handler dispatches `keepalive` frames to
+  `registry.touch(connectionId)` to refresh the connection's activity
+  timestamp without log noise.
 - `conversation-routes.ts` turn-start wires a registry-routed
   `hostBrowserSenderOverride` onto the `Conversation` so
   `host_browser_request` frames go to the extension WebSocket instead of
@@ -202,6 +282,23 @@ Runtime wiring:
   only for `host_browser`; macOS returns `true` for all four (bash,
   file, cu, browser).
 
+Extension-side health wiring:
+
+- The worker maintains a `ConnectionHealthState` enum (`paused`,
+  `connecting`, `connected`, `reconnecting`, `auth_required`, `error`)
+  with detail fields (last disconnect code, last error message,
+  timestamp).
+- Health transitions are driven by connect/open/close/pause actions.
+  The `onClose` callback transitions to `reconnecting` on unexpected
+  disconnects and to `auth_required` when the reconnect hook aborts.
+- The popup reads health via the `get_status` message and maps it to
+  concise display states via `popup-state.ts` helpers
+  (`deriveHealthStatusDisplay`, `shouldExpandTroubleshooting`,
+  `healthToPhase`).
+- The Troubleshooting section auto-expands only when health is
+  `auth_required` or `error` — during `connected`, `reconnecting`, and
+  `paused` it stays collapsed to avoid distracting users.
+
 ## Open follow-ups
 
 - Production extension allowlist: the native messaging helper, the
@@ -212,6 +309,37 @@ Runtime wiring:
   if any of the three drifts out of sync, so updating the placeholder
   to the production id must touch all three files plus the test
   constant in lockstep.
+
+## Steady-state contract
+
+After the first successful Connect, the extension operates as a
+background service with no further user interaction required:
+
+1. **Install once**: Load the extension, ensure the native messaging host
+   is installed (the macOS app does this automatically).
+2. **Connect once**: Click Connect in the popup. The worker
+   auto-bootstraps credentials (local pair token or cloud JWT) as part
+   of the single-click flow.
+3. **Forget it**: The extension maintains the relay indefinitely.
+   Keepalive frames prevent MV3 idle suspension. Exponential-backoff
+   reconnect handles transient drops. Silent token refresh re-bootstraps
+   credentials when they expire. The `autoConnect` flag persists across
+   browser sessions so reopening Chrome automatically reconnects.
+
+Users should only interact with the extension again when:
+
+- They want to **Pause** (intentionally disconnect and disable
+  auto-reconnect).
+- The popup shows **Action required** (`auth_required` or `error` health
+  state), meaning automatic recovery has been exhausted.
+
+The `cdp-inspect` backend is **not** a fallback for transient extension
+interruptions. The CDP client factory intentionally skips cdp-inspect
+when the extension proxy exists but is temporarily unavailable, giving
+the extension's automatic recovery time to restore the connection.
+`cdp-inspect` is an advanced, opt-in backend for users who cannot install
+the extension or who need broad session-level CDP access; see
+[Browser Use — `cdp-inspect` Backend](./browser-use-cdp-inspect-backend.md).
 
 ## Known UX considerations
 
@@ -253,4 +381,7 @@ Alternatives considered:
   and avoids the per-tab debugger infobar entirely. It is implemented
   and opt-in via `hostBrowser.cdpInspect.enabled`; see
   [Browser Use — `cdp-inspect` Backend](./browser-use-cdp-inspect-backend.md)
-  for setup, security trade-offs, and troubleshooting.
+  for setup, security trade-offs, and troubleshooting. Note: the
+  `cdp-inspect` backend does **not** activate as a fallback during
+  transient extension disconnects — the extension-first routing logic
+  in the CDP client factory prevents silent backend drift.

--- a/docs/browser-use-cdp-inspect-backend.md
+++ b/docs/browser-use-cdp-inspect-backend.md
@@ -6,6 +6,16 @@ already-running Chrome instance via the DevTools JSON protocol
 that the Chrome extension transport shows, at the cost of broader
 session-level access.
 
+**This is an explicit, advanced backend.** The Chrome extension is the
+default and preferred transport for browser use. The extension maintains a
+long-lived background connection with automatic reconnect and silent token
+refresh, so users never need to fall back to `cdp-inspect` during transient
+extension interruptions. The assistant's CDP client factory enforces this:
+when the extension transport is provisioned for a conversation but
+temporarily unavailable (e.g. mid-reconnect), `cdp-inspect` is
+intentionally skipped in the desktop-auto candidate list to prevent silent
+takeover.
+
 ## Backend comparison
 
 | | **Extension** | **cdp-inspect** | **Local** |
@@ -15,13 +25,14 @@ session-level access.
 | Debugger infobar | Yes (per tab) | No | No (dedicated profile) |
 | Tab scope | Single active tab | Any open tab | Dedicated browser |
 | Auth/session access | Active tab only | All tabs, all cookies | Isolated profile |
-| Selection priority | 1st (highest) | 2nd (when enabled) | 3rd (default) |
+| Selection priority | 1st (highest) | 2nd (when explicitly enabled) | 3rd (default) |
 
 ## When to use this backend
 
 **Prefer the Chrome extension.** It provides the best security boundary
 (single-tab scope, visible debugger infobar, chrome.debugger permission
-model) and requires no special Chrome launch flags.
+model), requires no special Chrome launch flags, and handles all lifecycle
+management automatically (keepalive, reconnect, token refresh).
 
 Use `cdp-inspect` only when:
 
@@ -31,6 +42,27 @@ Use `cdp-inspect` only when:
   that `chrome.debugger.attach` displays.
 - You are running in a headless/CI environment where a user-profile
   Chrome is already running with `--remote-debugging-port`.
+- You are intentionally opting into broad session-level access for
+  advanced debugging or automation workflows.
+
+## Relationship to extension transport
+
+The CDP client factory (`cdp-client/factory.ts`) builds an ordered
+candidate list for each browser tool invocation:
+
+1. **Extension** — always first when the extension proxy is connected.
+2. **cdp-inspect** — included only when *explicitly enabled* in config,
+   OR via the macOS desktop-auto path when no extension proxy exists
+   for the conversation. When the extension proxy exists but is
+   temporarily unavailable (reconnecting), cdp-inspect is deliberately
+   **excluded** to prevent silent backend drift during transient
+   extension disconnects.
+3. **Local** (Playwright) — default fallback.
+
+This means `cdp-inspect` does not silently "take over" when the extension
+has a brief interruption. The extension's automatic recovery (keepalive +
+exponential-backoff reconnect + silent token refresh) is given time to
+restore the connection before any fallback is considered.
 
 ## Security considerations
 


### PR DESCRIPTION
## Summary
Hardens the Chrome extension + assistant runtime path so extension transport remains stable in the background, recovers automatically, and does not silently drift to less-preferred backends during transient extension disconnects. End state: one successful connect, then automatic continuity.

## Self-review result
GAPS FOUND — 4 gaps fixed across 4 fix PRs

## PRs merged into feature branch
- #24806: Chrome extension: keep browser-relay WebSocket alive across MV3 idle windows
- #24804: Runtime browser-relay: accept keepalive frames and update extension activity
- #24805: Chrome worker: auto-refresh local pair token during non-interactive reconnect paths
- #24808: CDP factory: avoid silent cdp-inspect takeover when extension transport is expected
- #24811: Chrome worker: publish structured relay health state for user-facing UX
- #24813: Chrome popup: default to minimal status, auto-recovery messaging, hidden troubleshooting
- #24819: Docs: codify seamless extension lifecycle, recovery expectations, and validation steps

### Fix PRs
- #24828: fix: preserve stale-but-valid local token when silent bootstrap fails
- #24829: fix: use separate lastKeepaliveAt field in ChromeExtensionRegistry
- #24830: test: add integrated silent recovery tests for local-pair preflight
- #24832: fix: add reconnecting phase to popup ConnectionPhase

Part of plan: seamless-browser-extension-ux.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24833" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
