### PR TITLE
chore: GA managed-google-oauth feature flag

### DIFF
--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -154,14 +154,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "managed-google-oauth",
-      "scope": "assistant",
-      "key": "managed-google-oauth",
-      "label": "Managed Google OAuth",
-      "description": "Show the Google OAuth service card in Models & Services settings",
-      "defaultEnabled": true
-    },
-    {
       "id": "settings-embedding-provider",
       "scope": "assistant",
       "key": "settings-embedding-provider",


### PR DESCRIPTION
## Summary
- Remove the `managed-google-oauth` feature flag from the registry — it was already `defaultEnabled: true` and had no consumers in code (the Google OAuth provider never set a `featureFlag` field in seed data)