### PR TITLE
Refactor Twilio route STT serialization to consume call STT profile adapter

### DIFF
--- a/assistant/src/__tests__/deterministic-verification-control-plane.test.ts
+++ b/assistant/src/__tests__/deterministic-verification-control-plane.test.ts
@@ -31,6 +31,7 @@ mock.module("../config/env.js", () => ({
 // Imports (after mocks)
 // ---------------------------------------------------------------------------
 
+import type { TwilioRelaySpeechConfig } from "../calls/twilio-relay-speech-config.js";
 import { generateTwiML } from "../calls/twilio-routes.js";
 import { initializeDb } from "../memory/db-init.js";
 import {
@@ -100,9 +101,14 @@ describe("Channel verification reply templates", () => {
 describe("TwiML parameter propagation", () => {
   const defaultProfile = {
     language: "en-US",
-    transcriptionProvider: "deepgram",
     ttsProvider: "google",
     voice: "en-US-Standard-A",
+  };
+
+  const defaultSpeechConfig: TwilioRelaySpeechConfig = {
+    transcriptionProvider: "deepgram",
+    speechModel: undefined,
+    hints: undefined,
     interruptSensitivity: "low",
   };
 
@@ -112,6 +118,7 @@ describe("TwiML parameter propagation", () => {
       "wss://example.com/v1/calls/relay",
       null,
       defaultProfile,
+      defaultSpeechConfig,
       undefined,
       { verificationSessionId: "gv-session-456" },
     );
@@ -126,6 +133,7 @@ describe("TwiML parameter propagation", () => {
       "wss://example.com/v1/calls/relay",
       null,
       defaultProfile,
+      defaultSpeechConfig,
     );
     expect(twiml).not.toContain("<Parameter");
   });
@@ -136,6 +144,7 @@ describe("TwiML parameter propagation", () => {
       "wss://example.com/v1/calls/relay",
       null,
       defaultProfile,
+      defaultSpeechConfig,
       "token123",
       undefined,
     );

--- a/assistant/src/__tests__/twilio-routes-twiml.test.ts
+++ b/assistant/src/__tests__/twilio-routes-twiml.test.ts
@@ -1,9 +1,11 @@
 /**
- * Unit tests for TwiML generation with voice quality profiles.
+ * Unit tests for TwiML generation with voice quality profiles and the
+ * Twilio ConversationRelay speech config helper.
  *
  * Tests that generateTwiML correctly uses profile values for
- * ttsProvider, voice, language, transcriptionProvider,
- * and interruptSensitivity.
+ * ttsProvider, voice, and language, and that STT attributes
+ * (transcriptionProvider, speechModel, interruptSensitivity, hints)
+ * are driven by the TwilioRelaySpeechConfig helper.
  */
 import { describe, expect, mock, test } from "bun:test";
 
@@ -14,7 +16,79 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
+import { resolveTelephonySttProfile } from "../calls/stt-profile.js";
+import { buildTwilioRelaySpeechConfig } from "../calls/twilio-relay-speech-config.js";
 import { generateTwiML } from "../calls/twilio-routes.js";
+
+// ── Helper to build speech config from raw provider settings ─────────
+
+function speechConfigFor(
+  transcriptionProvider: string,
+  speechModel: string | undefined,
+  interruptSensitivity: string,
+  hints?: string,
+) {
+  const sttProfile = resolveTelephonySttProfile({
+    transcriptionProvider,
+    speechModel,
+  });
+  return buildTwilioRelaySpeechConfig(sttProfile, interruptSensitivity, hints);
+}
+
+// ── buildTwilioRelaySpeechConfig unit tests ──────────────────────────
+
+describe("buildTwilioRelaySpeechConfig", () => {
+  test("Deepgram: provider and default speechModel are set", () => {
+    const config = speechConfigFor("Deepgram", undefined, "low");
+    expect(config.transcriptionProvider).toBe("Deepgram");
+    expect(config.speechModel).toBe("nova-3");
+    expect(config.interruptSensitivity).toBe("low");
+    expect(config.hints).toBeUndefined();
+  });
+
+  test("Deepgram: explicit speechModel is preserved", () => {
+    const config = speechConfigFor("Deepgram", "nova-2-phonecall", "medium");
+    expect(config.transcriptionProvider).toBe("Deepgram");
+    expect(config.speechModel).toBe("nova-2-phonecall");
+    expect(config.interruptSensitivity).toBe("medium");
+  });
+
+  test("Google: speechModel is undefined when unset", () => {
+    const config = speechConfigFor("Google", undefined, "low");
+    expect(config.transcriptionProvider).toBe("Google");
+    expect(config.speechModel).toBeUndefined();
+  });
+
+  test("Google: legacy Deepgram default nova-3 is stripped", () => {
+    const config = speechConfigFor("Google", "nova-3", "low");
+    expect(config.transcriptionProvider).toBe("Google");
+    expect(config.speechModel).toBeUndefined();
+  });
+
+  test("Google: explicit non-legacy speechModel is preserved", () => {
+    const config = speechConfigFor("Google", "telephony", "high");
+    expect(config.transcriptionProvider).toBe("Google");
+    expect(config.speechModel).toBe("telephony");
+    expect(config.interruptSensitivity).toBe("high");
+  });
+
+  test("hints included when non-empty", () => {
+    const config = speechConfigFor("Deepgram", undefined, "low", "Alice,Bob");
+    expect(config.hints).toBe("Alice,Bob");
+  });
+
+  test("hints undefined when empty string", () => {
+    const config = speechConfigFor("Deepgram", undefined, "low", "");
+    expect(config.hints).toBeUndefined();
+  });
+
+  test("hints undefined when not provided", () => {
+    const config = speechConfigFor("Deepgram", undefined, "low");
+    expect(config.hints).toBeUndefined();
+  });
+});
+
+// ── generateTwiML with speech config ─────────────────────────────────
 
 describe("generateTwiML with voice quality profile", () => {
   const callSessionId = "test-session-123";
@@ -22,13 +96,17 @@ describe("generateTwiML with voice quality profile", () => {
   const welcomeGreeting = "Hello, how can I help?";
 
   test('TwiML includes ttsProvider="Google" when profile specifies Google', () => {
-    const twiml = generateTwiML(callSessionId, relayUrl, welcomeGreeting, {
-      language: "en-US",
-      transcriptionProvider: "Deepgram",
-      ttsProvider: "Google",
-      voice: "Google.en-US-Journey-O",
-      interruptSensitivity: "low",
-    });
+    const twiml = generateTwiML(
+      callSessionId,
+      relayUrl,
+      welcomeGreeting,
+      {
+        language: "en-US",
+        ttsProvider: "Google",
+        voice: "Google.en-US-Journey-O",
+      },
+      speechConfigFor("Deepgram", undefined, "low"),
+    );
 
     expect(twiml).toContain('ttsProvider="Google"');
     expect(twiml).toContain('voice="Google.en-US-Journey-O"');
@@ -37,124 +115,216 @@ describe("generateTwiML with voice quality profile", () => {
   });
 
   test('TwiML includes ttsProvider="ElevenLabs" when profile specifies ElevenLabs', () => {
-    const twiml = generateTwiML(callSessionId, relayUrl, welcomeGreeting, {
-      language: "en-US",
-      transcriptionProvider: "Deepgram",
-      ttsProvider: "ElevenLabs",
-      voice: "voice123-turbo_v2_5-1_0.5_0.75",
-      interruptSensitivity: "low",
-    });
+    const twiml = generateTwiML(
+      callSessionId,
+      relayUrl,
+      welcomeGreeting,
+      {
+        language: "en-US",
+        ttsProvider: "ElevenLabs",
+        voice: "voice123-turbo_v2_5-1_0.5_0.75",
+      },
+      speechConfigFor("Deepgram", undefined, "low"),
+    );
 
     expect(twiml).toContain('ttsProvider="ElevenLabs"');
     expect(twiml).toContain('voice="voice123-turbo_v2_5-1_0.5_0.75"');
   });
 
   test("voice attribute reflects configured Google voice", () => {
-    const twiml = generateTwiML(callSessionId, relayUrl, welcomeGreeting, {
-      language: "en-US",
-      transcriptionProvider: "Deepgram",
-      ttsProvider: "Google",
-      voice: "Google.en-US-Journey-O",
-      interruptSensitivity: "low",
-    });
+    const twiml = generateTwiML(
+      callSessionId,
+      relayUrl,
+      welcomeGreeting,
+      {
+        language: "en-US",
+        ttsProvider: "Google",
+        voice: "Google.en-US-Journey-O",
+      },
+      speechConfigFor("Deepgram", undefined, "low"),
+    );
 
     expect(twiml).toContain('voice="Google.en-US-Journey-O"');
   });
 
   test("voice attribute reflects configured ElevenLabs voice", () => {
-    const twiml = generateTwiML(callSessionId, relayUrl, welcomeGreeting, {
-      language: "en-US",
-      transcriptionProvider: "Deepgram",
-      ttsProvider: "ElevenLabs",
-      voice: "abc123-turbo_v2_5-1_0.5_0.75",
-      interruptSensitivity: "low",
-    });
+    const twiml = generateTwiML(
+      callSessionId,
+      relayUrl,
+      welcomeGreeting,
+      {
+        language: "en-US",
+        ttsProvider: "ElevenLabs",
+        voice: "abc123-turbo_v2_5-1_0.5_0.75",
+      },
+      speechConfigFor("Deepgram", undefined, "low"),
+    );
 
     expect(twiml).toContain('voice="abc123-turbo_v2_5-1_0.5_0.75"');
   });
 
   test("language attribute reflects configured language", () => {
-    const twiml = generateTwiML(callSessionId, relayUrl, welcomeGreeting, {
-      language: "es-MX",
-      transcriptionProvider: "Google",
-      ttsProvider: "Google",
-      voice: "Google.es-MX-Standard-A",
-      interruptSensitivity: "low",
-    });
+    const twiml = generateTwiML(
+      callSessionId,
+      relayUrl,
+      welcomeGreeting,
+      {
+        language: "es-MX",
+        ttsProvider: "Google",
+        voice: "Google.es-MX-Standard-A",
+      },
+      speechConfigFor("Google", undefined, "low"),
+    );
 
     expect(twiml).toContain('language="es-MX"');
   });
 
-  test("transcriptionProvider reflects configured value", () => {
-    const twiml = generateTwiML(callSessionId, relayUrl, welcomeGreeting, {
-      language: "en-US",
-      transcriptionProvider: "Google",
-      ttsProvider: "Google",
-      voice: "Google.en-US-Journey-O",
-      interruptSensitivity: "low",
-    });
+  test("transcriptionProvider reflects Deepgram via speech config", () => {
+    const twiml = generateTwiML(
+      callSessionId,
+      relayUrl,
+      welcomeGreeting,
+      {
+        language: "en-US",
+        ttsProvider: "ElevenLabs",
+        voice: "voice123",
+      },
+      speechConfigFor("Deepgram", undefined, "low"),
+    );
+
+    expect(twiml).toContain('transcriptionProvider="Deepgram"');
+    expect(twiml).toContain('speechModel="nova-3"');
+  });
+
+  test("transcriptionProvider reflects Google via speech config", () => {
+    const twiml = generateTwiML(
+      callSessionId,
+      relayUrl,
+      welcomeGreeting,
+      {
+        language: "en-US",
+        ttsProvider: "ElevenLabs",
+        voice: "voice123",
+      },
+      speechConfigFor("Google", undefined, "low"),
+    );
 
     expect(twiml).toContain('transcriptionProvider="Google"');
+    expect(twiml).not.toContain("speechModel=");
+  });
+
+  test("Google with explicit telephony model includes speechModel", () => {
+    const twiml = generateTwiML(
+      callSessionId,
+      relayUrl,
+      welcomeGreeting,
+      {
+        language: "en-US",
+        ttsProvider: "ElevenLabs",
+        voice: "voice123",
+      },
+      speechConfigFor("Google", "telephony", "low"),
+    );
+
+    expect(twiml).toContain('transcriptionProvider="Google"');
+    expect(twiml).toContain('speechModel="telephony"');
+  });
+
+  test("Deepgram with explicit model preserves it", () => {
+    const twiml = generateTwiML(
+      callSessionId,
+      relayUrl,
+      welcomeGreeting,
+      {
+        language: "en-US",
+        ttsProvider: "ElevenLabs",
+        voice: "voice123",
+      },
+      speechConfigFor("Deepgram", "nova-2-phonecall", "low"),
+    );
+
+    expect(twiml).toContain('transcriptionProvider="Deepgram"');
+    expect(twiml).toContain('speechModel="nova-2-phonecall"');
   });
 
   test("TwiML properly escapes XML characters in profile values", () => {
-    const twiml = generateTwiML(callSessionId, relayUrl, welcomeGreeting, {
-      language: "en-US",
-      transcriptionProvider: "Deepgram",
-      ttsProvider: "Google",
-      voice: 'voice<>&"test',
-      interruptSensitivity: "low",
-    });
+    const twiml = generateTwiML(
+      callSessionId,
+      relayUrl,
+      welcomeGreeting,
+      {
+        language: "en-US",
+        ttsProvider: "Google",
+        voice: 'voice<>&"test',
+      },
+      speechConfigFor("Deepgram", undefined, "low"),
+    );
 
     expect(twiml).toContain('voice="voice&lt;&gt;&amp;&quot;test"');
     expect(twiml).not.toContain('voice="voice<>&"test"');
   });
 
   test("TwiML includes callSessionId in relay URL", () => {
-    const twiml = generateTwiML(callSessionId, relayUrl, welcomeGreeting, {
-      language: "en-US",
-      transcriptionProvider: "Deepgram",
-      ttsProvider: "Google",
-      voice: "Google.en-US-Journey-O",
-      interruptSensitivity: "low",
-    });
+    const twiml = generateTwiML(
+      callSessionId,
+      relayUrl,
+      welcomeGreeting,
+      {
+        language: "en-US",
+        ttsProvider: "Google",
+        voice: "Google.en-US-Journey-O",
+      },
+      speechConfigFor("Deepgram", undefined, "low"),
+    );
 
     expect(twiml).toContain(`callSessionId=${callSessionId}`);
   });
 
   test("TwiML includes interruptible and dtmfDetection attributes", () => {
-    const twiml = generateTwiML(callSessionId, relayUrl, welcomeGreeting, {
-      language: "en-US",
-      transcriptionProvider: "Deepgram",
-      ttsProvider: "Google",
-      voice: "Google.en-US-Journey-O",
-      interruptSensitivity: "low",
-    });
+    const twiml = generateTwiML(
+      callSessionId,
+      relayUrl,
+      welcomeGreeting,
+      {
+        language: "en-US",
+        ttsProvider: "Google",
+        voice: "Google.en-US-Journey-O",
+      },
+      speechConfigFor("Deepgram", undefined, "low"),
+    );
 
     expect(twiml).toContain('interruptible="true"');
     expect(twiml).toContain('dtmfDetection="true"');
   });
 
   test("TwiML omits welcomeGreeting attribute when not provided", () => {
-    const twiml = generateTwiML(callSessionId, relayUrl, null, {
-      language: "en-US",
-      transcriptionProvider: "Deepgram",
-      ttsProvider: "Google",
-      voice: "Google.en-US-Journey-O",
-      interruptSensitivity: "low",
-    });
+    const twiml = generateTwiML(
+      callSessionId,
+      relayUrl,
+      null,
+      {
+        language: "en-US",
+        ttsProvider: "Google",
+        voice: "Google.en-US-Journey-O",
+      },
+      speechConfigFor("Deepgram", undefined, "low"),
+    );
 
     expect(twiml).not.toContain("welcomeGreeting=");
   });
 
-  test('TwiML includes interruptSensitivity="low" when profile has low', () => {
-    const twiml = generateTwiML(callSessionId, relayUrl, welcomeGreeting, {
-      language: "en-US",
-      transcriptionProvider: "Deepgram",
-      ttsProvider: "Google",
-      voice: "Google.en-US-Journey-O",
-      interruptSensitivity: "low",
-    });
+  test('TwiML includes interruptSensitivity="low" from speech config', () => {
+    const twiml = generateTwiML(
+      callSessionId,
+      relayUrl,
+      welcomeGreeting,
+      {
+        language: "en-US",
+        ttsProvider: "Google",
+        voice: "Google.en-US-Journey-O",
+      },
+      speechConfigFor("Deepgram", undefined, "low"),
+    );
 
     expect(twiml).toContain('interruptSensitivity="low"');
   });
@@ -166,81 +336,72 @@ describe("generateTwiML with voice quality profile", () => {
       welcomeGreeting,
       {
         language: "en-US",
-        transcriptionProvider: "Deepgram",
         ttsProvider: "Google",
         voice: "Google.en-US-Journey-O",
-        interruptSensitivity: "medium",
       },
+      speechConfigFor("Deepgram", undefined, "medium"),
     );
 
     expect(twimlMedium).toContain('interruptSensitivity="medium"');
 
-    const twimlHigh = generateTwiML(callSessionId, relayUrl, welcomeGreeting, {
-      language: "en-US",
-      transcriptionProvider: "Deepgram",
-      ttsProvider: "Google",
-      voice: "Google.en-US-Journey-O",
-      interruptSensitivity: "high",
-    });
+    const twimlHigh = generateTwiML(
+      callSessionId,
+      relayUrl,
+      welcomeGreeting,
+      {
+        language: "en-US",
+        ttsProvider: "Google",
+        voice: "Google.en-US-Journey-O",
+      },
+      speechConfigFor("Deepgram", undefined, "high"),
+    );
 
     expect(twimlHigh).toContain('interruptSensitivity="high"');
   });
 
-  test("hints attribute present when hints string is non-empty", () => {
+  test("hints attribute present when speech config includes hints", () => {
     const twiml = generateTwiML(
       callSessionId,
       relayUrl,
       welcomeGreeting,
       {
         language: "en-US",
-        transcriptionProvider: "Deepgram",
         ttsProvider: "ElevenLabs",
         voice: "voice123",
-        interruptSensitivity: "low",
       },
-      undefined,
-      undefined,
-      "Alice,Bob,Vellum",
+      speechConfigFor("Deepgram", undefined, "low", "Alice,Bob,Vellum"),
     );
 
     expect(twiml).toContain('hints="Alice,Bob,Vellum"');
   });
 
-  test("hints attribute omitted when hints string is empty", () => {
+  test("hints attribute omitted when speech config has no hints", () => {
     const twiml = generateTwiML(
       callSessionId,
       relayUrl,
       welcomeGreeting,
       {
         language: "en-US",
-        transcriptionProvider: "Deepgram",
         ttsProvider: "ElevenLabs",
         voice: "voice123",
-        interruptSensitivity: "low",
       },
-      undefined,
-      undefined,
-      "",
+      speechConfigFor("Deepgram", undefined, "low"),
     );
 
     expect(twiml).not.toContain("hints=");
   });
 
-  test("hints attribute omitted when hints parameter is undefined", () => {
+  test("hints attribute omitted when speech config hints is empty", () => {
     const twiml = generateTwiML(
       callSessionId,
       relayUrl,
       welcomeGreeting,
       {
         language: "en-US",
-        transcriptionProvider: "Deepgram",
         ttsProvider: "ElevenLabs",
         voice: "voice123",
-        interruptSensitivity: "low",
       },
-      undefined,
-      undefined,
-      undefined,
+      speechConfigFor("Deepgram", undefined, "low", ""),
     );
 
     expect(twiml).not.toContain("hints=");
@@ -253,14 +414,15 @@ describe("generateTwiML with voice quality profile", () => {
       welcomeGreeting,
       {
         language: "en-US",
-        transcriptionProvider: "Deepgram",
         ttsProvider: "ElevenLabs",
         voice: "voice123",
-        interruptSensitivity: "low",
       },
-      undefined,
-      undefined,
-      'O\'Brien,Smith & Jones,"Dr. Lee"',
+      speechConfigFor(
+        "Deepgram",
+        undefined,
+        "low",
+        'O\'Brien,Smith & Jones,"Dr. Lee"',
+      ),
     );
 
     expect(twiml).toContain(

--- a/assistant/src/__tests__/twilio-routes-twiml.test.ts
+++ b/assistant/src/__tests__/twilio-routes-twiml.test.ts
@@ -23,7 +23,7 @@ import { generateTwiML } from "../calls/twilio-routes.js";
 // ── Helper to build speech config from raw provider settings ─────────
 
 function speechConfigFor(
-  transcriptionProvider: string,
+  transcriptionProvider: "Deepgram" | "Google",
   speechModel: string | undefined,
   interruptSensitivity: string,
   hints?: string,

--- a/assistant/src/calls/twilio-relay-speech-config.ts
+++ b/assistant/src/calls/twilio-relay-speech-config.ts
@@ -1,0 +1,49 @@
+/**
+ * Maps a normalized telephony STT profile into Twilio ConversationRelay
+ * speech attributes.
+ *
+ * This module is the single place where STT profile data is serialized
+ * for the Twilio ConversationRelay TwiML element. Route code should call
+ * {@link buildTwilioRelaySpeechConfig} rather than composing STT attributes
+ * inline.
+ */
+
+import type { TelephonySttProfile } from "./stt-profile.js";
+
+/**
+ * Twilio ConversationRelay speech-to-text attributes.
+ *
+ * All values are pre-formatted strings ready for direct insertion into
+ * TwiML XML attribute values (XML escaping is the caller's responsibility).
+ */
+export interface TwilioRelaySpeechConfig {
+  /** STT provider name (e.g. "Deepgram", "Google"). */
+  transcriptionProvider: string;
+  /** ASR model identifier, or undefined when the provider default should be used. */
+  speechModel: string | undefined;
+  /** Comma-separated vocabulary hints for the STT provider, or undefined when no hints are available. */
+  hints: string | undefined;
+  /** How aggressively the provider detects the start of caller speech. */
+  interruptSensitivity: string;
+}
+
+/**
+ * Build the Twilio ConversationRelay speech config from a normalized
+ * STT profile and contextual call data.
+ *
+ * @param sttProfile - Provider-agnostic STT profile from {@link resolveTelephonySttProfile}.
+ * @param interruptSensitivity - Interrupt sensitivity level from the voice quality profile.
+ * @param hints - Resolved hints string from {@link resolveCallHints}, or undefined/empty.
+ */
+export function buildTwilioRelaySpeechConfig(
+  sttProfile: TelephonySttProfile,
+  interruptSensitivity: string,
+  hints: string | undefined,
+): TwilioRelaySpeechConfig {
+  return {
+    transcriptionProvider: sttProfile.provider,
+    speechModel: sttProfile.speechModel,
+    hints: hints && hints.length > 0 ? hints : undefined,
+    interruptSensitivity,
+  };
+}

--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -27,6 +27,11 @@ import {
   updateCallSession,
 } from "./call-store.js";
 import { resolveCallHints } from "./stt-hints.js";
+import { resolveTelephonySttProfile } from "./stt-profile.js";
+import {
+  buildTwilioRelaySpeechConfig,
+  type TwilioRelaySpeechConfig,
+} from "./twilio-relay-speech-config.js";
 import type { CallStatus } from "./types.js";
 import { resolveVoiceQualityProfile } from "./voice-quality.js";
 
@@ -49,15 +54,12 @@ export function generateTwiML(
   welcomeGreeting: string | null,
   profile: {
     language: string;
-    transcriptionProvider: string;
-    speechModel?: string;
     ttsProvider: string;
     voice: string;
-    interruptSensitivity: string;
   },
+  speechConfig: TwilioRelaySpeechConfig,
   relayToken?: string,
   customParameters?: Record<string, string>,
-  hints?: string,
 ): string {
   const greetingAttr =
     welcomeGreeting && welcomeGreeting.trim().length > 0
@@ -95,11 +97,11 @@ export function generateTwiML(
 ${greetingAttr}
       voice="${escapeXml(profile.voice)}"
       language="${escapeXml(profile.language)}"
-      transcriptionProvider="${escapeXml(profile.transcriptionProvider)}"${profile.speechModel ? `\n      speechModel="${escapeXml(profile.speechModel)}"` : ""}
+      transcriptionProvider="${escapeXml(speechConfig.transcriptionProvider)}"${speechConfig.speechModel ? `\n      speechModel="${escapeXml(speechConfig.speechModel)}"` : ""}
       ttsProvider="${escapeXml(profile.ttsProvider)}"
       interruptible="true"
       dtmfDetection="true"
-      interruptSensitivity="${escapeXml(profile.interruptSensitivity)}"${hints ? `\n      hints="${escapeXml(hints)}"` : ""}
+      interruptSensitivity="${escapeXml(speechConfig.interruptSensitivity)}"${speechConfig.hints ? `\n      hints="${escapeXml(speechConfig.hints)}"` : ""}
     ${relayClose}
   </Connect>
 </Response>`;
@@ -253,16 +255,26 @@ function buildVoiceWebhookTwiml(
   } | null,
   verificationSessionId?: string | null,
 ): Response {
-  const profile = resolveVoiceQualityProfile(loadConfig());
+  const cfg = loadConfig();
+  const profile = resolveVoiceQualityProfile(cfg);
 
   const hints = resolveCallHints(sessionContext, profile.hints);
+
+  // Build STT attributes via the serialization helper so that route code
+  // never mixes STT config resolution with XML attribute composition.
+  const sttProfile = resolveTelephonySttProfile(cfg.calls.voice);
+  const speechConfig = buildTwilioRelaySpeechConfig(
+    sttProfile,
+    profile.interruptSensitivity,
+    hints || undefined,
+  );
 
   log.info(
     { callSessionId, ttsProvider: profile.ttsProvider, voice: profile.voice },
     "Voice quality profile resolved",
   );
 
-  const relayUrl = getTwilioRelayUrl(loadConfig());
+  const relayUrl = getTwilioRelayUrl(cfg);
   const welcomeGreeting = buildWelcomeGreeting(sessionContext?.task ?? null);
 
   const relayToken = mintEdgeRelayToken();
@@ -278,9 +290,9 @@ function buildVoiceWebhookTwiml(
     relayUrl,
     welcomeGreeting,
     profile,
+    speechConfig,
     relayToken,
     customParameters,
-    hints || undefined,
   );
 
   log.info({ callSessionId }, "Returning ConversationRelay TwiML");


### PR DESCRIPTION
## Summary
- Create twilio-relay-speech-config helper mapping STT profile to Twilio ConversationRelay attributes
- Refactor twilio-routes to use serialization helper instead of inline STT/TwiML composition
- Preserve byte-for-byte TwiML equivalence for existing configs

Part of plan: initial-stt-unification.md (PR 4 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24840" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
