### PR TITLE
feat(personas): add resolveGuardianPersonaPath and ensureGuardianPersonaFile helpers

### DIFF
--- a/assistant/src/__tests__/persona-resolver.test.ts
+++ b/assistant/src/__tests__/persona-resolver.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Tests for persona-resolver helpers used by the drop-user-md migration:
+ * `resolveGuardianPersonaPath` and `ensureGuardianPersonaFile`.
+ *
+ * The module under test reads/writes files under `getWorkspaceDir()`,
+ * so these tests stub `util/platform.js` to point at an ephemeral temp
+ * directory and stub `contacts/contact-store.js` to control which
+ * guardian (if any) is returned by the resolver.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+// ── Mock state ────────────────────────────────────────────────────
+
+let mockWorkspaceDir: string = "";
+let mockVellumGuardian:
+  | {
+      contact: { userFile: string | null };
+      channel: Record<string, unknown>;
+    }
+  | null = null;
+let mockAnyGuardian:
+  | {
+      contact: { userFile: string | null };
+      channels: Record<string, unknown>[];
+    }
+  | null = null;
+
+// ── Mock modules (must precede imports from the module under test) ──
+
+mock.module("../util/platform.js", () => ({
+  getWorkspaceDir: () => mockWorkspaceDir,
+}));
+
+mock.module("../contacts/contact-store.js", () => ({
+  findContactByChannelExternalId: () => null,
+  findGuardianForChannel: (channelType: string) =>
+    channelType === "vellum" ? mockVellumGuardian : null,
+  listGuardianChannels: () => mockAnyGuardian,
+}));
+
+// Import AFTER mocks so the module under test binds to the stubbed
+// implementations.
+import {
+  ensureGuardianPersonaFile,
+  resolveGuardianPersonaPath,
+} from "../prompts/persona-resolver.js";
+
+// ── Temp workspace scaffold ───────────────────────────────────────
+
+let testRoot: string;
+
+beforeAll(() => {
+  testRoot = mkdtempSync(join(tmpdir(), "persona-resolver-test-"));
+});
+
+afterAll(() => {
+  rmSync(testRoot, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  // Fresh workspace per test, so filesystem state doesn't leak.
+  mockWorkspaceDir = mkdtempSync(join(testRoot, "ws-"));
+  mockVellumGuardian = null;
+  mockAnyGuardian = null;
+});
+
+afterEach(() => {
+  rmSync(mockWorkspaceDir, { recursive: true, force: true });
+});
+
+// ── resolveGuardianPersonaPath ─────────────────────────────────────
+
+describe("resolveGuardianPersonaPath", () => {
+  test("returns null when no guardian exists", () => {
+    mockVellumGuardian = null;
+    mockAnyGuardian = null;
+
+    expect(resolveGuardianPersonaPath()).toBeNull();
+  });
+
+  test("returns absolute path when guardian has userFile set", () => {
+    mockVellumGuardian = {
+      contact: { userFile: "sidd.md" },
+      channel: {},
+    };
+
+    const result = resolveGuardianPersonaPath();
+    expect(result).toBe(join(mockWorkspaceDir, "users", "sidd.md"));
+  });
+});
+
+// ── ensureGuardianPersonaFile ──────────────────────────────────────
+
+describe("ensureGuardianPersonaFile", () => {
+  test("writes the template when the file is missing", () => {
+    const slug = "sidd.md";
+    const filePath = join(mockWorkspaceDir, "users", slug);
+
+    expect(existsSync(filePath)).toBe(false);
+
+    ensureGuardianPersonaFile(slug);
+
+    expect(existsSync(filePath)).toBe(true);
+    const content = readFileSync(filePath, "utf-8");
+    expect(content).toContain("# User Profile");
+    expect(content).toContain("Preferred name/reference:");
+    expect(content).toContain("Daily tools:");
+    // Sanity check the comment-line prefix survives verbatim.
+    expect(content.startsWith("_ Lines starting with _ are comments")).toBe(
+      true,
+    );
+  });
+
+  test("is a no-op when the file already exists (does not clobber)", () => {
+    const slug = "sidd.md";
+    const dir = join(mockWorkspaceDir, "users");
+    const filePath = join(dir, slug);
+    const existingContent = "# Existing user notes\n\n- Likes sparkling water\n";
+
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(filePath, existingContent, "utf-8");
+
+    ensureGuardianPersonaFile(slug);
+
+    const content = readFileSync(filePath, "utf-8");
+    expect(content).toBe(existingContent);
+  });
+});

--- a/assistant/src/prompts/persona-resolver.ts
+++ b/assistant/src/prompts/persona-resolver.ts
@@ -1,5 +1,10 @@
-import { existsSync, readFileSync } from "node:fs";
-import { basename, join } from "node:path";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { basename, dirname, join } from "node:path";
 
 import {
   findContactByChannelExternalId,
@@ -15,6 +20,27 @@ import { getWorkspaceDir } from "../util/platform.js";
 import { stripCommentLines } from "../util/strip-comment-lines.js";
 
 const log = getLogger("persona-resolver");
+
+// ── Guardian persona template ─────────────────────────────────────
+//
+// Scaffold written to `users/<slug>.md` when a guardian is resolved
+// but no per-user persona file yet exists. Kept in sync with the
+// legacy workspace USER.md template so that upgrading users preserve
+// the same editable shape.
+const GUARDIAN_PERSONA_TEMPLATE = `_ Lines starting with _ are comments - they won't appear in the system prompt
+
+# User Profile
+
+Store details about your user here. Edit freely - build this over time as you learn about them. Don't be pushy about seeking details, but when you learn something, write it down. More context makes you more useful.
+
+- Preferred name/reference:
+- Pronouns:
+- Locale:
+- Work role:
+- Goals:
+- Hobbies/fun:
+- Daily tools:
+`;
 
 // ── Types ──────────────────────────────────────────────────────────
 
@@ -96,6 +122,22 @@ function resolveUserFilename(
   }
 
   return null;
+}
+
+/**
+ * Resolve the absolute on-disk path to the guardian's per-user persona
+ * file (e.g. `<workspace>/users/sidd.md`). Returns `null` when no
+ * guardian is resolvable (no guardian contact, or its `userFile` is
+ * unusable / fails basename validation).
+ *
+ * This does not check whether the file exists — it only resolves the
+ * path. Callers use it alongside `ensureGuardianPersonaFile` to open
+ * or scaffold the file.
+ */
+export function resolveGuardianPersonaPath(): string | null {
+  const filename = resolveUserFilename(undefined);
+  if (!filename) return null;
+  return join(getWorkspaceDir(), "users", filename);
 }
 
 /**
@@ -191,4 +233,29 @@ export function resolvePersonaContext(
  */
 export function resolveGuardianPersona(): string | null {
   return resolveUserPersona(undefined);
+}
+
+/**
+ * Write the guardian persona template scaffold to `users/<slug>.md`
+ * when the file does not yet exist. No-op when the file already
+ * exists (safe against clobbering user edits).
+ *
+ * Rejects slugs that fail basename validation (path traversal guard).
+ * Creates the parent `users/` directory if missing.
+ */
+export function ensureGuardianPersonaFile(slug: string): void {
+  if (basename(slug) !== slug || slug === ".." || slug === ".") {
+    log.warn(
+      { slug },
+      "Guardian persona slug contains path traversal; refusing to write",
+    );
+    return;
+  }
+
+  const filePath = join(getWorkspaceDir(), "users", slug);
+  if (existsSync(filePath)) return;
+
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(filePath, GUARDIAN_PERSONA_TEMPLATE, "utf-8");
+  log.debug({ path: filePath }, "Wrote guardian persona scaffold");
 }


### PR DESCRIPTION
## Summary
- Add `resolveGuardianPersonaPath()` returning the absolute path to the guardian's persona file, or `null` when no guardian is resolved.
- Add `ensureGuardianPersonaFile(slug)` that writes a template scaffold to `users/<slug>.md` only when missing; idempotent and safe against clobber.
- Infrastructure only — no callers yet; downstream PRs in the drop-user-md plan consume these helpers.

Part of plan: drop-user-md.md (PR 1 of 17)