### PR TITLE
feat(contacts): seed per-user persona file when guardian is created

### DIFF
--- a/assistant/src/__tests__/contacts-write.test.ts
+++ b/assistant/src/__tests__/contacts-write.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Tests for `contacts-write.ts` — specifically the side-effect that
+ * seeds `users/<slug>.md` whenever a contact's `userFile` is persisted.
+ *
+ * These tests use the real DB (via `initializeDb()`) and the real
+ * `ensureGuardianPersonaFile` helper. The test preload sets
+ * `VELLUM_WORKSPACE_DIR` to a per-file temp directory, so all filesystem
+ * writes land under that temp dir and are cleaned up automatically.
+ */
+
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import { createGuardianBinding } from "../contacts/contacts-write.js";
+import { getSqlite, initializeDb } from "../memory/db.js";
+
+initializeDb();
+
+function resetContactTables(): void {
+  const sqlite = getSqlite();
+  sqlite.run("DELETE FROM contact_channels");
+  sqlite.run("DELETE FROM contacts");
+}
+
+function workspaceDir(): string {
+  const dir = process.env.VELLUM_WORKSPACE_DIR;
+  if (!dir) {
+    throw new Error(
+      "VELLUM_WORKSPACE_DIR should be set by the test preload — aborting",
+    );
+  }
+  return dir;
+}
+
+function userFilePath(slug: string): string {
+  return join(workspaceDir(), "users", slug);
+}
+
+describe("createGuardianBinding seeds users/<slug>.md", () => {
+  beforeEach(() => {
+    resetContactTables();
+  });
+
+  test("writes the persona template scaffold on first creation", () => {
+    createGuardianBinding({
+      channel: "telegram",
+      guardianExternalUserId: "Sidd",
+      guardianDeliveryChatId: "chat-sidd",
+      guardianPrincipalId: "principal-sidd",
+      verifiedVia: "challenge",
+    });
+
+    const expectedPath = userFilePath("sidd.md");
+    expect(existsSync(expectedPath)).toBe(true);
+
+    const content = readFileSync(expectedPath, "utf-8");
+    expect(content).toContain("# User Profile");
+    expect(content).toContain("Preferred name/reference:");
+    expect(content).toContain("Daily tools:");
+    // Template comment-line prefix survives verbatim.
+    expect(content.startsWith("_ Lines starting with _ are comments")).toBe(
+      true,
+    );
+  });
+
+  test("does not clobber a pre-existing customized users/<slug>.md", () => {
+    // First creation seeds the scaffold.
+    createGuardianBinding({
+      channel: "telegram",
+      guardianExternalUserId: "Alice",
+      guardianDeliveryChatId: "chat-alice",
+      guardianPrincipalId: "principal-alice",
+      verifiedVia: "challenge",
+    });
+
+    const expectedPath = userFilePath("alice.md");
+    expect(existsSync(expectedPath)).toBe(true);
+
+    // User customizes the file manually.
+    const customContent = "# Alice's Profile\n\n- Loves kayaking\n";
+    writeFileSync(expectedPath, customContent, "utf-8");
+
+    // Re-running createGuardianBinding (idempotent re-verification) must
+    // not overwrite the user's edits.
+    createGuardianBinding({
+      channel: "telegram",
+      guardianExternalUserId: "Alice",
+      guardianDeliveryChatId: "chat-alice",
+      guardianPrincipalId: "principal-alice",
+      verifiedVia: "challenge",
+    });
+
+    const afterContent = readFileSync(expectedPath, "utf-8");
+    expect(afterContent).toBe(customContent);
+  });
+});

--- a/assistant/src/contacts/contacts-write.ts
+++ b/assistant/src/contacts/contacts-write.ts
@@ -8,6 +8,7 @@
 
 import type { ChannelId } from "../channels/types.js";
 import type { GuardianBinding } from "../memory/channel-verification-sessions.js";
+import { ensureGuardianPersonaFile } from "../prompts/persona-resolver.js";
 import { canonicalizeInboundIdentity } from "../util/canonicalize-identity.js";
 import { getLogger } from "../util/logger.js";
 import { emitContactChange } from "./contact-events.js";
@@ -76,7 +77,7 @@ export function createGuardianBinding(params: {
     parseDisplayNameFromMetadata(params.metadataJson) ??
     params.guardianExternalUserId;
 
-  upsertContact({
+  const contact = upsertContact({
     displayName,
     role: "guardian",
     notes: "guardian",
@@ -93,6 +94,13 @@ export function createGuardianBinding(params: {
       },
     ],
   });
+
+  // Seed the per-user persona file so downstream readers (journaling,
+  // persona resolution) can rely on `users/<slug>.md` existing on disk.
+  // Idempotent: pre-existing customized files are preserved.
+  if (contact.userFile) {
+    ensureGuardianPersonaFile(contact.userFile);
+  }
 
   const now = Date.now();
   const result: GuardianBinding = {
@@ -185,7 +193,7 @@ export function upsertContactChannel(params: {
       ) ?? params.externalUserId)
     : null;
 
-  upsertContact({
+  const contact = upsertContact({
     id: params.contactId,
     displayName,
     role: params.role,
@@ -209,6 +217,13 @@ export function upsertContactChannel(params: {
     // existing channel identity to the invite's target contact.
     reassignConflictingChannels: !!params.contactId,
   });
+
+  // Seed the per-user persona file so downstream readers (journaling,
+  // persona resolution) can rely on `users/<slug>.md` existing on disk.
+  // Idempotent: pre-existing customized files are preserved.
+  if (contact.userFile) {
+    ensureGuardianPersonaFile(contact.userFile);
+  }
 
   const contactResult = findContactChannel({
     channelType: params.sourceChannel,


### PR DESCRIPTION
## Summary
- Call `ensureGuardianPersonaFile(slug)` immediately after writing `contacts.userFile` in `createGuardianBinding` and `upsertContact`.
- Ensures every guardian-bound install has a populated `users/<slug>.md` on disk before any downstream reader needs it.
- Idempotent: existing customized files are preserved.

Part of plan: drop-user-md.md (PR 2 of 17)