### PR TITLE
refactor(prompts): read guardian name/pronouns from users/<slug>.md via persona-resolver

### DIFF
--- a/assistant/src/__tests__/user-reference.test.ts
+++ b/assistant/src/__tests__/user-reference.test.ts
@@ -1,27 +1,24 @@
-import * as realFs from "node:fs";
-import { join } from "node:path";
+/**
+ * Tests for user-reference resolvers. After the drop-user-md migration,
+ * `readPreferredNameFromUserMd` and `resolveUserPronouns` source their
+ * content from `resolveGuardianPersona()` instead of the legacy
+ * workspace-root `USER.md`. We mock the persona-resolver module directly
+ * so tests can drive the input content without touching disk.
+ */
+
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-const TEST_DIR = process.env.VELLUM_WORKSPACE_DIR!;
+// Mutable state the tests control — represents the value returned by
+// `resolveGuardianPersona()` (comment-stripped string, or null when no
+// guardian / empty file).
+let mockGuardianPersona: string | null = null;
 
-// Mutable state the tests control
-let mockFileExists = false;
-let mockFileContent = "";
-
-mock.module("node:fs", () => ({
-  ...realFs,
-  existsSync: (path: string) => {
-    if (path === join(TEST_DIR, "USER.md")) return mockFileExists;
-    return false;
-  },
-  readFileSync: (path: string, _encoding: string) => {
-    if (path === join(TEST_DIR, "USER.md") && mockFileExists)
-      return mockFileContent;
-    throw new Error(`ENOENT: no such file: ${path}`);
-  },
+mock.module("../prompts/persona-resolver.js", () => ({
+  resolveGuardianPersona: () => mockGuardianPersona,
 }));
 
-// Import after mocks are in place
+// Import after mocks are in place so the module under test binds to
+// the stubbed implementation.
 const {
   resolveUserReference,
   resolveUserPronouns,
@@ -31,18 +28,16 @@ const {
 
 describe("resolveUserReference", () => {
   beforeEach(() => {
-    mockFileExists = false;
-    mockFileContent = "";
+    mockGuardianPersona = null;
   });
 
-  test('returns "my human" when USER.md does not exist', () => {
-    mockFileExists = false;
+  test('returns "my human" when no guardian persona exists', () => {
+    mockGuardianPersona = null;
     expect(resolveUserReference()).toBe("my human");
   });
 
   test('returns "my human" when preferred name field is empty', () => {
-    mockFileExists = true;
-    mockFileContent = [
+    mockGuardianPersona = [
       "## Onboarding Snapshot",
       "",
       "- Preferred name/reference:",
@@ -53,8 +48,7 @@ describe("resolveUserReference", () => {
   });
 
   test("returns the configured name when it is set", () => {
-    mockFileExists = true;
-    mockFileContent = [
+    mockGuardianPersona = [
       "## Onboarding Snapshot",
       "",
       "- Preferred name/reference: John",
@@ -65,27 +59,24 @@ describe("resolveUserReference", () => {
   });
 
   test("trims whitespace around the configured name", () => {
-    mockFileExists = true;
-    mockFileContent = "- Preferred name/reference:   Alice   \n";
+    mockGuardianPersona = "- Preferred name/reference:   Alice   \n";
     expect(resolveUserReference()).toBe("Alice");
   });
 });
 
 describe("resolveUserPronouns", () => {
   beforeEach(() => {
-    mockFileExists = false;
-    mockFileContent = "";
+    mockGuardianPersona = null;
   });
 
-  test("returns null when USER.md does not exist", () => {
-    mockFileExists = false;
+  test("returns null when no guardian persona exists", () => {
+    mockGuardianPersona = null;
     expect(resolveUserPronouns()).toBeNull();
   });
 
-  test("returns pronouns from flat USER.md (no Onboarding Snapshot)", () => {
-    mockFileExists = true;
-    mockFileContent = [
-      "# USER.md",
+  test("returns pronouns from flat persona file (no Onboarding Snapshot)", () => {
+    mockGuardianPersona = [
+      "# User Profile",
       "",
       "- Preferred name/reference: Alice",
       "- Pronouns: she/her",
@@ -95,9 +86,8 @@ describe("resolveUserPronouns", () => {
   });
 
   test("returns null when pronouns field is empty in flat format", () => {
-    mockFileExists = true;
-    mockFileContent = [
-      "# USER.md",
+    mockGuardianPersona = [
+      "# User Profile",
       "",
       "- Preferred name/reference: Alice",
       "- Pronouns:",
@@ -107,8 +97,7 @@ describe("resolveUserPronouns", () => {
   });
 
   test("returns pronouns from legacy Onboarding Snapshot section", () => {
-    mockFileExists = true;
-    mockFileContent = [
+    mockGuardianPersona = [
       "## Onboarding Snapshot",
       "",
       "- Pronouns: they/them",
@@ -117,8 +106,7 @@ describe("resolveUserPronouns", () => {
   });
 
   test("prefers pronouns above Onboarding Snapshot over inside it", () => {
-    mockFileExists = true;
-    mockFileContent = [
+    mockGuardianPersona = [
       "Pronouns: he/him",
       "",
       "## Onboarding Snapshot",
@@ -129,8 +117,7 @@ describe("resolveUserPronouns", () => {
   });
 
   test("returns null for declined_by_user", () => {
-    mockFileExists = true;
-    mockFileContent = [
+    mockGuardianPersona = [
       "- Preferred name/reference: Alice",
       "- Pronouns: declined_by_user",
     ].join("\n");
@@ -138,8 +125,7 @@ describe("resolveUserPronouns", () => {
   });
 
   test("strips inferred: prefix", () => {
-    mockFileExists = true;
-    mockFileContent = [
+    mockGuardianPersona = [
       "- Preferred name/reference: Alice",
       "- Pronouns: inferred: she/her",
     ].join("\n");
@@ -149,13 +135,11 @@ describe("resolveUserPronouns", () => {
 
 describe("resolveGuardianName", () => {
   beforeEach(() => {
-    mockFileExists = false;
-    mockFileContent = "";
+    mockGuardianPersona = null;
   });
 
-  test("returns USER.md name when present, ignoring guardianDisplayName", () => {
-    mockFileExists = true;
-    mockFileContent = [
+  test("returns persona name when present, ignoring guardianDisplayName", () => {
+    mockGuardianPersona = [
       "## Onboarding Snapshot",
       "",
       "- Preferred name/reference: John",
@@ -163,9 +147,8 @@ describe("resolveGuardianName", () => {
     expect(resolveGuardianName("Jane")).toBe("John");
   });
 
-  test('returns "my human" when USER.md explicitly sets name to default value', () => {
-    mockFileExists = true;
-    mockFileContent = [
+  test('returns "my human" when persona explicitly sets name to default value', () => {
+    mockGuardianPersona = [
       "## Onboarding Snapshot",
       "",
       "- Preferred name/reference: my human",
@@ -174,20 +157,20 @@ describe("resolveGuardianName", () => {
     expect(resolveGuardianName("Jane")).toBe("my human");
   });
 
-  test("falls back to guardianDisplayName when USER.md is empty", () => {
-    mockFileExists = false;
+  test("falls back to guardianDisplayName when persona is empty", () => {
+    mockGuardianPersona = null;
     expect(resolveGuardianName("Jane")).toBe("Jane");
   });
 
   test("falls back to DEFAULT_USER_REFERENCE when both are empty", () => {
-    mockFileExists = false;
+    mockGuardianPersona = null;
     expect(resolveGuardianName()).toBe(DEFAULT_USER_REFERENCE);
     expect(resolveGuardianName(null)).toBe(DEFAULT_USER_REFERENCE);
     expect(resolveGuardianName("")).toBe(DEFAULT_USER_REFERENCE);
   });
 
   test("trims whitespace on guardianDisplayName fallback", () => {
-    mockFileExists = false;
+    mockGuardianPersona = null;
     expect(resolveGuardianName("  Jane  ")).toBe("Jane");
   });
 });

--- a/assistant/src/prompts/user-reference.ts
+++ b/assistant/src/prompts/user-reference.ts
@@ -1,16 +1,18 @@
-import { readTextFileSync } from "../util/fs.js";
-import { getWorkspacePromptPath } from "../util/platform.js";
+import { resolveGuardianPersona } from "./persona-resolver.js";
 
 export const DEFAULT_USER_REFERENCE = "my human";
 export const DECLINED_BY_USER_SENTINEL = "declined_by_user";
 
 /**
- * Read the raw "Preferred name/reference:" value from USER.md.
- * Returns the trimmed value when present, or `null` when the file
- * is missing, unreadable, or the field is empty.
+ * Read the raw "Preferred name/reference:" value from the guardian's
+ * per-user persona file (`users/<slug>.md`).
+ *
+ * Returns the trimmed value when present, or `null` when no guardian
+ * is resolvable, the persona file is missing / empty, or the field
+ * itself is blank.
  */
 function readPreferredNameFromUserMd(): string | null {
-  const content = readTextFileSync(getWorkspacePromptPath("USER.md"));
+  const content = resolveGuardianPersona();
   if (content != null) {
     const match = content.match(/Preferred name\/reference:[ \t]*(.*)/);
     if (match && match[1].trim()) {
@@ -24,9 +26,9 @@ function readPreferredNameFromUserMd(): string | null {
  * Resolve the name/reference the assistant uses when referring to
  * the human it represents in external communications.
  *
- * Reads the "Preferred name/reference:" field from USER.md.
- * Falls back to "my human" when the file is missing, unreadable,
- * or the field is empty.
+ * Reads the "Preferred name/reference:" field from the guardian's
+ * persona file. Falls back to "my human" when the file is missing,
+ * unreadable, or the field is empty.
  */
 export function resolveUserReference(): string {
   const preferredName = readPreferredNameFromUserMd();
@@ -37,9 +39,9 @@ export function resolveUserReference(): string {
 }
 
 /**
- * Resolve the user's pronouns from USER.md.  Returns `null` when the
- * file is missing, the field is empty, or the value is a sentinel like
- * `declined_by_user`.
+ * Resolve the user's pronouns from the guardian's per-user persona file.
+ * Returns `null` when no guardian is resolvable, the file is missing,
+ * the field is empty, or the value is a sentinel like `declined_by_user`.
  *
  * When a legacy `## Onboarding Snapshot` section exists, a `Pronouns:`
  * line *above* that section takes priority (explicit post-onboarding edit).
@@ -47,7 +49,7 @@ export function resolveUserReference(): string {
  * in the file.
  */
 export function resolveUserPronouns(): string | null {
-  const content = readTextFileSync(getWorkspacePromptPath("USER.md"));
+  const content = resolveGuardianPersona();
   if (content == null) return null;
 
   const snapshotIdx = content.indexOf("## Onboarding Snapshot");
@@ -82,10 +84,11 @@ function cleanPronounValue(raw: string): string | null {
  * Resolve the guardian's display name.
  *
  * Priority:
- *   1. USER.md "Preferred name/reference:" — the user-editable, actively
- *      maintained source of truth.
- *   2. guardianDisplayName (fallback for when USER.md is missing or empty,
- *      e.g. pre-onboarding). Callers pass in Contact.displayName.
+ *   1. Guardian persona file "Preferred name/reference:" — the
+ *      user-editable, actively maintained source of truth.
+ *   2. guardianDisplayName (fallback for when the persona file is
+ *      missing or empty, e.g. pre-onboarding). Callers pass in
+ *      Contact.displayName.
  *   3. DEFAULT_USER_REFERENCE ("my human").
  */
 export function resolveGuardianName(


### PR DESCRIPTION
## Summary
- Rewrite `readPreferredNameFromUserMd` and `resolveUserPronouns` to source content from `resolveGuardianPersona()` instead of the legacy workspace-root `USER.md`.
- `resolveUserReference`, `resolveGuardianName` are unchanged callers — they transparently pick up the new source.
- Tests rewritten to seed the guardian persona path.

Part of plan: drop-user-md.md (PR 3 of 17)