### PR TITLE
refactor(identity-intro-cache): hash guardian persona file instead of USER.md

### DIFF
--- a/assistant/src/__tests__/identity-intro-cache.test.ts
+++ b/assistant/src/__tests__/identity-intro-cache.test.ts
@@ -2,7 +2,8 @@
  * Unit tests for the identity intro cache (identity-intro-cache.ts).
  *
  * Validates TTL-based expiration, content-hash-based invalidation when
- * workspace identity files change, and round-trip get/set behavior.
+ * workspace identity files or the guardian persona content change, and
+ * round-trip get/set behavior.
  */
 
 import { afterEach, describe, expect, mock, test } from "bun:test";
@@ -44,6 +45,14 @@ mock.module("node:fs", () => ({
   },
 }));
 
+// Mocked guardian persona — mutable so tests can change it and verify cache
+// invalidation based on the per-user persona file content.
+let guardianPersonaContent: string | null = null;
+
+mock.module("../prompts/persona-resolver.js", () => ({
+  resolveGuardianPersona: () => guardianPersonaContent,
+}));
+
 // ---------------------------------------------------------------------------
 // Imports (after mocks)
 // ---------------------------------------------------------------------------
@@ -63,6 +72,7 @@ afterEach(() => {
   for (const key of Object.keys(workspaceFiles)) {
     delete workspaceFiles[key];
   }
+  guardianPersonaContent = null;
 });
 
 // ---------------------------------------------------------------------------
@@ -77,7 +87,7 @@ describe("identity intro cache", () => {
   test("round-trip: set then get returns cached text", () => {
     workspaceFiles["IDENTITY.md"] = "- **Name:** Atlas";
     workspaceFiles["SOUL.md"] = "Be playful.";
-    workspaceFiles["USER.md"] = "The user likes coffee.";
+    guardianPersonaContent = "The user likes coffee.";
 
     setCachedIntro("Hey, I'm Atlas.");
     const cached = getCachedIntro();
@@ -131,24 +141,24 @@ describe("identity intro cache", () => {
     expect(getCachedIntro()).toBeNull();
   });
 
-  test("busts cache when USER.md changes", () => {
-    workspaceFiles["USER.md"] = "Likes coffee.";
+  test("busts cache when guardian persona content changes", () => {
+    guardianPersonaContent = "Likes coffee.";
     setCachedIntro("Good morning!");
 
-    // Change USER.md
-    workspaceFiles["USER.md"] = "Likes tea.";
+    // Change guardian persona (e.g. user edited users/<slug>.md)
+    guardianPersonaContent = "Likes tea.";
 
     expect(getCachedIntro()).toBeNull();
   });
 
-  test("cache survives when files are unchanged", () => {
+  test("cache remains valid when guardian persona is unchanged", () => {
     workspaceFiles["IDENTITY.md"] = "- **Name:** Atlas";
     workspaceFiles["SOUL.md"] = "Be chill.";
-    workspaceFiles["USER.md"] = "Likes sunsets.";
+    guardianPersonaContent = "Likes sunsets.";
 
     setCachedIntro("Atlas here.");
 
-    // Read twice — both should return the cached value
+    // Read twice with the same guardian persona — both should return the cached value
     expect(getCachedIntro()?.text).toBe("Atlas here.");
     expect(getCachedIntro()?.text).toBe("Atlas here.");
   });
@@ -156,12 +166,32 @@ describe("identity intro cache", () => {
   test("computeIdentityContentHash is deterministic", () => {
     workspaceFiles["IDENTITY.md"] = "test";
     workspaceFiles["SOUL.md"] = "test2";
-    workspaceFiles["USER.md"] = "test3";
+    guardianPersonaContent = "test3";
 
     const hash1 = computeIdentityContentHash();
     const hash2 = computeIdentityContentHash();
     expect(hash1).toBe(hash2);
     expect(hash1).toMatch(/^[a-f0-9]{64}$/); // SHA-256 hex
+  });
+
+  test("computeIdentityContentHash changes when guardian persona changes", () => {
+    workspaceFiles["IDENTITY.md"] = "- **Name:** Atlas";
+    workspaceFiles["SOUL.md"] = "Be playful.";
+    guardianPersonaContent = "Likes coffee.";
+    const hash1 = computeIdentityContentHash();
+
+    guardianPersonaContent = "Likes tea.";
+    const hash2 = computeIdentityContentHash();
+
+    expect(hash1).not.toBe(hash2);
+  });
+
+  test("computeIdentityContentHash handles null guardian persona", () => {
+    workspaceFiles["IDENTITY.md"] = "- **Name:** Atlas";
+    guardianPersonaContent = null;
+
+    const hash = computeIdentityContentHash();
+    expect(hash).toMatch(/^[a-f0-9]{64}$/);
   });
 
   test("computeIdentityContentHash changes when file content changes", () => {

--- a/assistant/src/runtime/routes/identity-intro-cache.ts
+++ b/assistant/src/runtime/routes/identity-intro-cache.ts
@@ -4,7 +4,8 @@
  * The intro (a short identity tagline) is generated via the
  * /v1/btw endpoint and displayed on the Identity panel. To avoid redundant LLM
  * calls, we cache the result for 4 hours with content-hash-based invalidation:
- * when USER.md, IDENTITY.md, or SOUL.md change, the cache is busted.
+ * when IDENTITY.md, SOUL.md, or the guardian's per-user persona file change,
+ * the cache is busted.
  *
  * Storage uses the existing `memory_checkpoints` table (simple key-value store).
  */
@@ -16,6 +17,7 @@ import {
   getMemoryCheckpoint,
   setMemoryCheckpoint,
 } from "../../memory/checkpoints.js";
+import { resolveGuardianPersona } from "../../prompts/persona-resolver.js";
 import { getWorkspacePromptPath } from "../../util/platform.js";
 
 // ---------------------------------------------------------------------------
@@ -29,7 +31,7 @@ const CHECKPOINT_KEY_HASH = "identity:intro:content_hash";
 const CHECKPOINT_KEY_TIMESTAMP = "identity:intro:cached_at";
 
 /** Workspace files whose content influences the identity intro. */
-const IDENTITY_FILES = ["USER.md", "IDENTITY.md", "SOUL.md"] as const;
+const IDENTITY_FILES = ["IDENTITY.md", "SOUL.md"] as const;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -48,7 +50,9 @@ function readWorkspaceFile(name: string): string {
 
 /** Compute a SHA-256 hex hash of the concatenated identity file contents. */
 export function computeIdentityContentHash(): string {
-  const combined = IDENTITY_FILES.map(readWorkspaceFile).join("\n---\n");
+  const staticFiles = IDENTITY_FILES.map(readWorkspaceFile).join("\n---\n");
+  const guardianPersona = resolveGuardianPersona() ?? "";
+  const combined = staticFiles + "\n---\n" + guardianPersona;
   return createHash("sha256").update(combined).digest("hex");
 }
 


### PR DESCRIPTION
## Summary
- Drop `USER.md` from the static `IDENTITY_FILES` list.
- Append the guardian persona content (`resolveGuardianPersona()`) to the hashed string so cache invalidates when the per-user persona changes.

Part of plan: drop-user-md.md (PR 5 of 17)