### PR TITLE
feat(config-watcher): watch users/ directory for persona changes

### DIFF
--- a/assistant/src/__tests__/config-watcher.test.ts
+++ b/assistant/src/__tests__/config-watcher.test.ts
@@ -1,4 +1,5 @@
 import { mkdirSync } from "node:fs";
+import { join } from "node:path";
 import {
   afterEach,
   beforeAll,
@@ -272,6 +273,48 @@ describe("ConfigWatcher watcher lifecycle", () => {
     await new Promise((r) => setTimeout(r, 300));
     // Each file has its own debounce key, so both should fire
     expect(evictCallCount).toBe(2);
+  });
+});
+
+describe("ConfigWatcher users directory watcher", () => {
+  const USERS_DIR = join(WORKSPACE_DIR, "users");
+
+  test("editing users/<slug>.md triggers onConversationEvict", async () => {
+    watcher.start(onConversationEvict);
+    simulateFileChange(USERS_DIR, "alice.md");
+
+    await new Promise((r) => setTimeout(r, 300));
+    expect(evictCallCount).toBe(1);
+  });
+
+  test("non-.md files in users/ do NOT trigger eviction", async () => {
+    watcher.start(onConversationEvict);
+    simulateFileChange(USERS_DIR, "alice.json");
+    simulateFileChange(USERS_DIR, "notes.txt");
+    simulateFileChange(USERS_DIR, "README");
+
+    await new Promise((r) => setTimeout(r, 300));
+    expect(evictCallCount).toBe(0);
+  });
+
+  test("null filename in users/ does not trigger eviction", async () => {
+    watcher.start(onConversationEvict);
+    const usersWatcher = findWatcher(USERS_DIR);
+    expect(usersWatcher).toBeDefined();
+    usersWatcher!.callback("change", null);
+
+    await new Promise((r) => setTimeout(r, 300));
+    expect(evictCallCount).toBe(0);
+  });
+
+  test("multiple rapid changes to the same persona file are debounced", async () => {
+    watcher.start(onConversationEvict);
+    simulateFileChange(USERS_DIR, "bob.md");
+    simulateFileChange(USERS_DIR, "bob.md");
+    simulateFileChange(USERS_DIR, "bob.md");
+
+    await new Promise((r) => setTimeout(r, 300));
+    expect(evictCallCount).toBe(1);
   });
 });
 

--- a/assistant/src/daemon/config-watcher.ts
+++ b/assistant/src/daemon/config-watcher.ts
@@ -217,6 +217,7 @@ export class ConfigWatcher {
 
     this.startFeatureFlagsWatcher(onFeatureFlagsChanged);
     this.startSignalsWatcher();
+    this.startUsersWatcher(onConversationEvict);
     this.startSkillsWatchers(onConversationEvict);
   }
 
@@ -256,6 +257,37 @@ export class ConfigWatcher {
       log.warn(
         { err, dir: soundsDir },
         "Failed to watch sounds directory. Sound config changes will require a restart.",
+      );
+    }
+  }
+
+  private startUsersWatcher(onConversationEvict: () => void): void {
+    const usersDir = join(getWorkspaceDir(), "users");
+    try {
+      if (!existsSync(usersDir)) {
+        mkdirSync(usersDir, { recursive: true });
+      }
+    } catch {
+      // If we can't create it, watching will also fail — handled below.
+    }
+
+    try {
+      const watcher = watch(usersDir, (_eventType, filename) => {
+        if (!filename) return;
+        const file = String(filename);
+        if (!file.endsWith(".md")) return;
+        this.debounceTimers.schedule(`file:users/${file}`, () => {
+          log.info({ file }, "Users persona file changed, reloading");
+          onConversationEvict();
+        });
+      });
+      attachWatcherErrorHandler(watcher, usersDir);
+      this.watchers.push(watcher);
+      log.info({ dir: usersDir }, "Watching users directory for persona changes");
+    } catch (err) {
+      log.warn(
+        { err, dir: usersDir },
+        "Failed to watch users directory. Persona file changes will require a restart.",
       );
     }
   }


### PR DESCRIPTION
## Summary
- Add `startUsersWatcher` modeled on `startSoundsWatcher`, filtering for `.md` files and evicting conversations on change.
- Additive only — the legacy `USER.md` workspace-handler entry stays in place until downstream consumers migrate.

Part of plan: drop-user-md.md (PR 7 of 17)