### PR TITLE
feat(bootstrap): route first-run onboarding writes to users/<slug>.md via placeholder

### DIFF
--- a/assistant/src/__tests__/onboarding-template-contract.test.ts
+++ b/assistant/src/__tests__/onboarding-template-contract.test.ts
@@ -49,10 +49,10 @@ describe("onboarding template contracts", () => {
       expect(lower).toContain("declined");
     });
 
-    test("instructs saving to IDENTITY.md, USER.md, and SOUL.md via file_edit", () => {
+    test("instructs saving to IDENTITY.md, SOUL.md, and user persona file via file_edit", () => {
       expect(bootstrap).toContain("IDENTITY.md");
-      expect(bootstrap).toContain("USER.md");
       expect(bootstrap).toContain("SOUL.md");
+      expect(bootstrap).toContain("{{USER_PERSONA_FILE}}");
       expect(bootstrap).toContain("file_edit");
     });
 

--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -276,6 +276,47 @@ describe("buildSystemPrompt", () => {
     expect(basePrompt(result)).toBe("");
   });
 
+  describe("BOOTSTRAP.md user persona placeholder", () => {
+    test("substitutes {{USER_PERSONA_FILE}} with users/<slug>.md when userSlug is provided", () => {
+      writeFileSync(
+        join(TEST_DIR, "BOOTSTRAP.md"),
+        "# First run\n\nSave facts to users/{{USER_PERSONA_FILE}} immediately.",
+      );
+      const result = buildSystemPrompt({ userSlug: "alice" });
+      expect(result).toContain("users/alice.md");
+      expect(result).not.toContain("{{USER_PERSONA_FILE}}");
+    });
+
+    test("falls back to users/default.md when userSlug is omitted", () => {
+      writeFileSync(
+        join(TEST_DIR, "BOOTSTRAP.md"),
+        "# First run\n\nSave facts to users/{{USER_PERSONA_FILE}} immediately.",
+      );
+      const result = buildSystemPrompt();
+      expect(result).toContain("users/default.md");
+      expect(result).not.toContain("{{USER_PERSONA_FILE}}");
+    });
+
+    test("substitutes the unmodified bundled BOOTSTRAP.md template", () => {
+      // Copy the real bundled BOOTSTRAP.md into the test workspace so we
+      // verify substitution against the actual template the daemon ships.
+      const bundled = readFileSync(
+        join(
+          import.meta.dirname,
+          "..",
+          "prompts",
+          "templates",
+          "BOOTSTRAP.md",
+        ),
+        "utf-8",
+      );
+      writeFileSync(join(TEST_DIR, "BOOTSTRAP.md"), bundled);
+      const result = buildSystemPrompt({ userSlug: "alice" });
+      expect(result).toContain("users/alice.md");
+      expect(result).not.toContain("{{USER_PERSONA_FILE}}");
+    });
+  });
+
   describe("app-builder tool ownership guidance", () => {
     test("iteration guidance does not mention app_update for HTML changes", () => {
       const result = buildSystemPrompt();

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -280,10 +280,15 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
   if (options?.channelPersona) dynamicParts.push(options.channelPersona);
   if (user && !userIsTemplate && !options?.userPersona) dynamicParts.push(user);
   if (includeBootstrap) {
+    const userSlug = options?.userSlug ?? "default";
+    const bootstrapWithSlug = bootstrap.replaceAll(
+      "{{USER_PERSONA_FILE}}",
+      `${userSlug}.md`,
+    );
     dynamicParts.push(
       "# First-Run Ritual\n\n" +
         "BOOTSTRAP.md is present — this is your first conversation. Follow its instructions.\n\n" +
-        bootstrap,
+        bootstrapWithSlug,
     );
   }
   if (updates) {

--- a/assistant/src/prompts/templates/BOOTSTRAP.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP.md
@@ -16,7 +16,7 @@ This is your first conversation. This document gives you goals and constraints �
 
 5. **Offer the next level** — once you know something, offer a capability it enables. Not as a reward — as a natural relationship step.
 
-6. **Write everything immediately** — every fact learned gets saved to USER.md the same turn. Style observations go to SOUL.md. No batching.
+6. **Write everything immediately** — every fact learned gets saved to users/{{USER_PERSONA_FILE}} the same turn. Style observations go to SOUL.md. No batching.
 
 7. **Clean up** — delete BOOTSTRAP.md and BOOTSTRAP-REFERENCE.md at the end of this conversation, regardless of how far you got. One-shot.
 
@@ -37,15 +37,15 @@ This is your first conversation. This document gives you goals and constraints �
 
 ## Technical Contract (what must be prescribed)
 
-**Files to create/update:** IDENTITY.md, SOUL.md, USER.md
+**Files to create/update:** IDENTITY.md, SOUL.md, users/{{USER_PERSONA_FILE}}
 
 **File format:** preserve existing field structure:
 - IDENTITY.md: Name, Emoji, Nature, Personality, Role
-- USER.md: Preferred name, Pronouns, Locale, Work role, Goals, Hobbies/fun, Daily tools
+- users/{{USER_PERSONA_FILE}}: Preferred name, Pronouns, Locale, Work role, Goals, Hobbies/fun, Daily tools
 
 Use `file_edit` immediately, silently, never mention file names or tool names to the user.
 
-The contents of IDENTITY.md, SOUL.md, and USER.md are already in your system prompt — use the exact text you see there for `old_string` in `file_edit`.
+The contents of IDENTITY.md, SOUL.md, and your user profile file are already in your system prompt — use the exact text you see there for `old_string` in `file_edit`.
 
 After tool calls, do not repeat yourself — your text before tool calls is already visible to the user.
 
@@ -90,7 +90,7 @@ If an `onboarding` JSON context is present in this conversation, the user alread
 - `tools` array -> know which integration offers to surface first, infer work profile
 - `tasks` array -> know what "prove value fast" means for this person
 - `tone` string -> calibrate warmth/formality
-- `userName` / `assistantName` -> write to IDENTITY.md and USER.md immediately, skip name exchange
+- `userName` / `assistantName` -> write to IDENTITY.md and users/{{USER_PERSONA_FILE}} immediately, skip name exchange
 
 If no onboarding context is present, infer everything fresh from conversation.
 


### PR DESCRIPTION
## Summary
- Replace literal `USER.md` references in BOOTSTRAP.md with `users/{{USER_PERSONA_FILE}}` placeholder.
- Substitute the placeholder with `${options.userSlug}.md` in `system-prompt.ts` at the moment bootstrap is appended.
- Additive only — USER.md fallback read stays for now; removal lands in PR 11.

Part of plan: drop-user-md.md (PR 6 of 17)