### PR TITLE
refactor(heartbeat): check guardian persona file instead of USER.md for onboarding state

### DIFF
--- a/assistant/src/__tests__/heartbeat-service.test.ts
+++ b/assistant/src/__tests__/heartbeat-service.test.ts
@@ -23,6 +23,39 @@ mock.module("../config/loader.js", () => ({
   invalidateConfigCache: () => {},
 }));
 
+// ── Guardian persona mock ─────────────────────────────────────────
+//
+// `heartbeat-service.isShallowProfile` reads the guardian persona via
+// `resolveGuardianPersona()` and compares against the exported
+// `GUARDIAN_PERSONA_TEMPLATE` scaffold. We mock the module so each
+// test can seed whatever persona content it needs; the scaffold text
+// below is kept byte-identical to the real template in
+// `persona-resolver.ts` so the "scaffold-only" path triggers a match.
+const GUARDIAN_PERSONA_TEMPLATE = `_ Lines starting with _ are comments - they won't appear in the system prompt
+
+# User Profile
+
+Store details about your user here. Edit freely - build this over time as you learn about them. Don't be pushy about seeking details, but when you learn something, write it down. More context makes you more useful.
+
+- Preferred name/reference:
+- Pronouns:
+- Locale:
+- Work role:
+- Goals:
+- Hobbies/fun:
+- Daily tools:
+`;
+
+// `resolveGuardianPersona` returns already-stripped + trimmed content
+// (or null for missing/empty files). Tests mutate this variable to
+// drive `isShallowProfile`.
+let mockGuardianPersona: string | null = null;
+
+mock.module("../prompts/persona-resolver.js", () => ({
+  GUARDIAN_PERSONA_TEMPLATE,
+  resolveGuardianPersona: () => mockGuardianPersona,
+}));
+
 // Mock conversation store
 const createdConversations: Array<{ title: string; conversationType: string }> =
   [];
@@ -85,7 +118,13 @@ const IDENTITY_TEMPLATE = readFileSync(
   join(templatesDir, "IDENTITY.md"),
   "utf-8",
 );
-const USER_TEMPLATE = readFileSync(join(templatesDir, "USER.md"), "utf-8");
+
+// Stripped/trimmed form of the guardian persona scaffold — mirrors
+// the transformation applied by `resolveGuardianPersona` (which runs
+// `stripCommentLines` internally). Used to simulate a freshly-seeded,
+// never-edited persona file.
+const { stripCommentLines } = await import("../util/strip-comment-lines.js");
+const SCAFFOLD_PERSONA = stripCommentLines(GUARDIAN_PERSONA_TEMPLATE).trim();
 
 describe("HeartbeatService", () => {
   let processMessageCalls: Array<{
@@ -99,7 +138,6 @@ describe("HeartbeatService", () => {
     // Clean up workspace files between tests so file-existence tests don't leak
     rmSync(join(testWorkspaceDir, "HEARTBEAT.md"), { force: true });
     rmSync(join(testWorkspaceDir, "IDENTITY.md"), { force: true });
-    rmSync(join(testWorkspaceDir, "USER.md"), { force: true });
     rmSync(join(testWorkspaceDir, ".reengagement-ts"), { force: true });
   });
 
@@ -108,6 +146,7 @@ describe("HeartbeatService", () => {
     alerterCalls = [];
     createdConversations.length = 0;
     conversationIdCounter = 0;
+    mockGuardianPersona = null;
 
     mockConfig = {
       heartbeat: {
@@ -494,9 +533,23 @@ describe("HeartbeatService", () => {
   });
 
   describe("isShallowProfile", () => {
-    test("returns true when both IDENTITY.md and USER.md are unmodified templates", () => {
+    test("returns true when IDENTITY.md is template and guardian persona is missing", () => {
       writeFileSync(join(testWorkspaceDir, "IDENTITY.md"), IDENTITY_TEMPLATE);
-      writeFileSync(join(testWorkspaceDir, "USER.md"), USER_TEMPLATE);
+      mockGuardianPersona = null;
+
+      expect(isShallowProfile()).toBe(true);
+    });
+
+    test("returns true when IDENTITY.md is template and guardian persona has only scaffold fields", () => {
+      writeFileSync(join(testWorkspaceDir, "IDENTITY.md"), IDENTITY_TEMPLATE);
+      mockGuardianPersona = SCAFFOLD_PERSONA;
+
+      expect(isShallowProfile()).toBe(true);
+    });
+
+    test("returns true when IDENTITY.md is template and guardian persona is empty string", () => {
+      writeFileSync(join(testWorkspaceDir, "IDENTITY.md"), IDENTITY_TEMPLATE);
+      mockGuardianPersona = "";
 
       expect(isShallowProfile()).toBe(true);
     });
@@ -506,22 +559,22 @@ describe("HeartbeatService", () => {
         join(testWorkspaceDir, "IDENTITY.md"),
         "# IDENTITY.md\n\n- **Name:** Jarvis\n",
       );
-      writeFileSync(join(testWorkspaceDir, "USER.md"), USER_TEMPLATE);
+      mockGuardianPersona = SCAFFOLD_PERSONA;
 
       expect(isShallowProfile()).toBe(false);
     });
 
-    test("returns false when USER.md has been customized", () => {
+    test("returns false when guardian persona has real content", () => {
       writeFileSync(join(testWorkspaceDir, "IDENTITY.md"), IDENTITY_TEMPLATE);
-      writeFileSync(
-        join(testWorkspaceDir, "USER.md"),
-        "# USER.md\n\n- Preferred name/reference: Alice\n",
-      );
+      mockGuardianPersona =
+        "# User Profile\n\n- Preferred name/reference: Alice\n- Work role: designer";
 
       expect(isShallowProfile()).toBe(false);
     });
 
-    test("returns false when neither file exists", () => {
+    test("returns false when IDENTITY.md does not exist", () => {
+      mockGuardianPersona = null;
+
       expect(isShallowProfile()).toBe(false);
     });
   });
@@ -529,7 +582,7 @@ describe("HeartbeatService", () => {
   describe("relationship-depth prompt injection", () => {
     test("includes <relationship-depth> when profile is shallow", () => {
       writeFileSync(join(testWorkspaceDir, "IDENTITY.md"), IDENTITY_TEMPLATE);
-      writeFileSync(join(testWorkspaceDir, "USER.md"), USER_TEMPLATE);
+      mockGuardianPersona = SCAFFOLD_PERSONA;
 
       const service = createService();
       const { prompt, includedReengagement } =
@@ -545,7 +598,7 @@ describe("HeartbeatService", () => {
         join(testWorkspaceDir, "IDENTITY.md"),
         "# IDENTITY.md\n\n- **Name:** Jarvis\n",
       );
-      writeFileSync(join(testWorkspaceDir, "USER.md"), USER_TEMPLATE);
+      mockGuardianPersona = SCAFFOLD_PERSONA;
 
       const service = createService();
       const { prompt, includedReengagement } =
@@ -557,7 +610,7 @@ describe("HeartbeatService", () => {
 
     test("omits <relationship-depth> when cooldown has not elapsed", () => {
       writeFileSync(join(testWorkspaceDir, "IDENTITY.md"), IDENTITY_TEMPLATE);
-      writeFileSync(join(testWorkspaceDir, "USER.md"), USER_TEMPLATE);
+      mockGuardianPersona = SCAFFOLD_PERSONA;
       // Write a recent timestamp to simulate cooldown not elapsed
       writeFileSync(
         join(testWorkspaceDir, ".reengagement-ts"),
@@ -574,7 +627,7 @@ describe("HeartbeatService", () => {
 
     test("includes <relationship-depth> when cooldown has elapsed", () => {
       writeFileSync(join(testWorkspaceDir, "IDENTITY.md"), IDENTITY_TEMPLATE);
-      writeFileSync(join(testWorkspaceDir, "USER.md"), USER_TEMPLATE);
+      mockGuardianPersona = SCAFFOLD_PERSONA;
       // Write a timestamp from 19 hours ago
       const nineteenHoursAgo = Date.now() - 19 * 60 * 60 * 1000;
       writeFileSync(
@@ -592,7 +645,7 @@ describe("HeartbeatService", () => {
 
     test("does not record timestamp when processMessage fails", async () => {
       writeFileSync(join(testWorkspaceDir, "IDENTITY.md"), IDENTITY_TEMPLATE);
-      writeFileSync(join(testWorkspaceDir, "USER.md"), USER_TEMPLATE);
+      mockGuardianPersona = SCAFFOLD_PERSONA;
 
       const service = createService({
         processMessage: async () => {
@@ -609,7 +662,7 @@ describe("HeartbeatService", () => {
 
     test("records timestamp after successful delivery", async () => {
       writeFileSync(join(testWorkspaceDir, "IDENTITY.md"), IDENTITY_TEMPLATE);
-      writeFileSync(join(testWorkspaceDir, "USER.md"), USER_TEMPLATE);
+      mockGuardianPersona = SCAFFOLD_PERSONA;
 
       const service = createService();
       await service.runOnce();

--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -5,6 +5,10 @@ import { getConfig } from "../config/loader.js";
 import type { Speed } from "../config/schemas/inference.js";
 import type { HeartbeatAlert } from "../daemon/message-protocol.js";
 import { bootstrapConversation } from "../memory/conversation-bootstrap.js";
+import {
+  GUARDIAN_PERSONA_TEMPLATE,
+  resolveGuardianPersona,
+} from "../prompts/persona-resolver.js";
 import { isTemplateContent } from "../prompts/system-prompt.js";
 import { readTextFileSync } from "../util/fs.js";
 import { getLogger } from "../util/logger.js";
@@ -23,19 +27,27 @@ const DEFAULT_CHECKLIST = `- Check in with yourself. Read NOW.md. Is it still ac
 const REENGAGEMENT_COOLDOWN_MS = 18 * 60 * 60 * 1000; // 18 hours
 const HEARTBEAT_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
 
+// Stripped-comment form of the guardian persona scaffold. Computed
+// once at module load because stripping comment lines is deterministic
+// and the template itself is a compile-time constant.
+const GUARDIAN_PERSONA_SCAFFOLD_STRIPPED = stripCommentLines(
+  GUARDIAN_PERSONA_TEMPLATE,
+).trim();
+
 /** @internal Exported for testing. */
 export function isShallowProfile(): boolean {
   try {
     const identityPath = getWorkspacePromptPath("IDENTITY.md");
-    const userPath = getWorkspacePromptPath("USER.md");
     const rawIdentity = readTextFileSync(identityPath);
-    const rawUser = readTextFileSync(userPath);
     const identity = rawIdentity != null ? stripCommentLines(rawIdentity) : null;
-    const user = rawUser != null ? stripCommentLines(rawUser) : null;
-    return (
-      isTemplateContent(identity, "IDENTITY.md") &&
-      isTemplateContent(user, "USER.md")
-    );
+    // `resolveGuardianPersona` returns already-stripped, trimmed content
+    // (or null for missing/empty files).
+    const user = resolveGuardianPersona();
+    const userIsEmpty =
+      user == null ||
+      user.length === 0 ||
+      user === GUARDIAN_PERSONA_SCAFFOLD_STRIPPED;
+    return isTemplateContent(identity, "IDENTITY.md") && userIsEmpty;
   } catch {
     return false;
   }

--- a/assistant/src/prompts/persona-resolver.ts
+++ b/assistant/src/prompts/persona-resolver.ts
@@ -26,8 +26,9 @@ const log = getLogger("persona-resolver");
 // Scaffold written to `users/<slug>.md` when a guardian is resolved
 // but no per-user persona file yet exists. Kept in sync with the
 // legacy workspace USER.md template so that upgrading users preserve
-// the same editable shape.
-const GUARDIAN_PERSONA_TEMPLATE = `_ Lines starting with _ are comments - they won't appear in the system prompt
+// the same editable shape. Exported so consumers can detect the
+// unmodified scaffold (e.g. heartbeat's `isShallowProfile`).
+export const GUARDIAN_PERSONA_TEMPLATE = `_ Lines starting with _ are comments - they won't appear in the system prompt
 
 # User Profile
 


### PR DESCRIPTION
## Summary
- `isShallowProfile` now sources the user-profile content from `resolveGuardianPersona()` instead of reading the legacy workspace-root `USER.md`.
- Shallow detection compares against the persona-template scaffold from PR 1.
- Tests updated to seed the guardian persona path.

Part of plan: drop-user-md.md (PR 4 of 17)