### PR TITLE
feat(settings-routes): include guardian users/<slug>.md in workspace files listing

### DIFF
--- a/assistant/src/runtime/routes/settings-routes.test.ts
+++ b/assistant/src/runtime/routes/settings-routes.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Tests for the `workspace-files` list/read endpoints in settings-routes.
+ *
+ * Focus: the list now includes the guardian's per-user persona file
+ * (`users/<slug>.md`) whenever a guardian exists, and the read endpoint
+ * accepts paths under `users/`.
+ */
+
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import { createGuardianBinding } from "../../contacts/contacts-write.js";
+import { getSqlite, initializeDb } from "../../memory/db.js";
+import { settingsRouteDefinitions } from "./settings-routes.js";
+
+initializeDb();
+
+const testWorkspaceDir = process.env.VELLUM_WORKSPACE_DIR!;
+
+function resetContactTables(): void {
+  const sqlite = getSqlite();
+  sqlite.run("DELETE FROM contact_channels");
+  sqlite.run("DELETE FROM contacts");
+}
+
+// ---------------------------------------------------------------------------
+// RouteContext helpers (mirrors workspace-routes.test.ts)
+// ---------------------------------------------------------------------------
+
+function makeCtx(
+  endpoint: string,
+  searchParams: Record<string, string> = {},
+) {
+  const url = new URL(`http://localhost/v1/${endpoint}`);
+  for (const [k, v] of Object.entries(searchParams)) {
+    url.searchParams.set(k, v);
+  }
+  return {
+    url,
+    req: new Request(url),
+    server: {} as ReturnType<typeof Bun.serve>,
+    authContext: {} as never,
+    params: {},
+  };
+}
+
+function getHandler(endpoint: string, method: string) {
+  const routes = settingsRouteDefinitions();
+  const route = routes.find(
+    (r) => r.endpoint === endpoint && r.method === method,
+  );
+  if (!route) {
+    throw new Error(`No route found for ${method} ${endpoint}`);
+  }
+  return route.handler;
+}
+
+// ---------------------------------------------------------------------------
+// GET /workspace-files
+// ---------------------------------------------------------------------------
+
+describe("GET /workspace-files", () => {
+  const handler = getHandler("workspace-files", "GET");
+
+  beforeEach(() => {
+    resetContactTables();
+  });
+
+  test("with no guardian: returns the static legacy entries only", async () => {
+    const res = await handler(makeCtx("workspace-files"));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      files: Array<{ path: string; name: string; exists: boolean }>;
+    };
+    const paths = body.files.map((f) => f.path);
+    expect(paths).toEqual(["IDENTITY.md", "SOUL.md", "USER.md", "skills/"]);
+    // No guardian → no users/*.md entry.
+    expect(paths.find((p) => p.startsWith("users/"))).toBeUndefined();
+  });
+
+  test("with a guardian: includes users/<slug>.md alongside legacy USER.md", async () => {
+    createGuardianBinding({
+      channel: "telegram",
+      guardianExternalUserId: "Alice",
+      guardianDeliveryChatId: "chat-alice",
+      guardianPrincipalId: "principal-alice",
+      verifiedVia: "challenge",
+    });
+
+    const res = await handler(makeCtx("workspace-files"));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      files: Array<{ path: string; name: string; exists: boolean }>;
+    };
+    const paths = body.files.map((f) => f.path);
+
+    // Legacy USER.md entry is still present.
+    expect(paths).toContain("USER.md");
+    // Guardian per-user persona is appended.
+    expect(paths).toContain("users/alice.md");
+
+    // The guardian entry reports `exists: true` because PR 2 seeds the
+    // template scaffold when the binding is created.
+    const guardianEntry = body.files.find((f) => f.path === "users/alice.md");
+    expect(guardianEntry).toBeDefined();
+    expect(guardianEntry!.exists).toBe(true);
+  });
+
+  test("reflects guardian changes on a subsequent request (not cached)", async () => {
+    // Initially no guardian.
+    let res = await handler(makeCtx("workspace-files"));
+    let body = (await res.json()) as {
+      files: Array<{ path: string }>;
+    };
+    expect(body.files.map((f) => f.path)).not.toContain("users/alice.md");
+
+    // Create a guardian mid-session.
+    createGuardianBinding({
+      channel: "telegram",
+      guardianExternalUserId: "Alice",
+      guardianDeliveryChatId: "chat-alice",
+      guardianPrincipalId: "principal-alice",
+      verifiedVia: "challenge",
+    });
+
+    // The next request must reflect the new guardian — we do not want a
+    // stale module-level cache here.
+    res = await handler(makeCtx("workspace-files"));
+    body = (await res.json()) as {
+      files: Array<{ path: string }>;
+    };
+    expect(body.files.map((f) => f.path)).toContain("users/alice.md");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /workspace-files/read
+// ---------------------------------------------------------------------------
+
+describe("GET /workspace-files/read", () => {
+  const handler = getHandler("workspace-files/read", "GET");
+
+  beforeEach(() => {
+    resetContactTables();
+  });
+
+  test("reads a guardian users/<slug>.md file", async () => {
+    createGuardianBinding({
+      channel: "telegram",
+      guardianExternalUserId: "Alice",
+      guardianDeliveryChatId: "chat-alice",
+      guardianPrincipalId: "principal-alice",
+      verifiedVia: "challenge",
+    });
+
+    const personaPath = join(testWorkspaceDir, "users", "alice.md");
+    // PR 2 seeds the template scaffold; overwrite with something recognizable
+    // so the test asserts on exact content rather than scaffold boilerplate.
+    expect(existsSync(personaPath)).toBe(true);
+    writeFileSync(
+      personaPath,
+      "# Alice\n\n- Preferred name/reference: Alice\n",
+      "utf-8",
+    );
+
+    const res = await handler(
+      makeCtx("workspace-files/read", { path: "users/alice.md" }),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { path: string; content: string };
+    expect(body.path).toBe("users/alice.md");
+    expect(body.content).toBe(readFileSync(personaPath, "utf-8"));
+    expect(body.content).toContain("Preferred name/reference: Alice");
+  });
+
+  test("rejects path traversal attempts via users/", async () => {
+    const res = await handler(
+      makeCtx("workspace-files/read", {
+        path: "users/../../etc/passwd",
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  test("returns 404 for a non-existent users/<slug>.md", async () => {
+    const res = await handler(
+      makeCtx("workspace-files/read", { path: "users/nobody.md" }),
+    );
+    expect(res.status).toBe(404);
+  });
+});

--- a/assistant/src/runtime/routes/settings-routes.ts
+++ b/assistant/src/runtime/routes/settings-routes.ts
@@ -8,7 +8,7 @@
  */
 
 import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 
 import { z } from "zod";
 
@@ -36,6 +36,7 @@ import {
   generateAllowlistOptions,
   generateScopeOptions,
 } from "../../permissions/checker.js";
+import { resolveGuardianPersonaPath } from "../../prompts/persona-resolver.js";
 import { getSecureKeyAsync } from "../../security/secure-keys.js";
 import { parseToolManifestFile } from "../../skills/tool-manifest.js";
 import {
@@ -314,11 +315,30 @@ async function handleOAuthConnectStart(body: {
 // Workspace files (list/read)
 // ---------------------------------------------------------------------------
 
-const WORKSPACE_FILES = ["IDENTITY.md", "SOUL.md", "USER.md", "skills/"];
+/**
+ * Build the list of workspace files exposed via the workspace-files endpoint.
+ *
+ * Returns the static identity/soul/user files plus the guardian's resolved
+ * per-user persona file at `users/<slug>.md` when a guardian exists. Callers
+ * should invoke this per-request instead of caching, since the guardian can
+ * change over the lifetime of the daemon.
+ *
+ * `USER.md` remains in the list as a legacy transitional entry; a later
+ * change will remove it once all readers have migrated to the per-user
+ * persona path.
+ */
+function getWorkspaceFiles(): string[] {
+  const files = ["IDENTITY.md", "SOUL.md", "USER.md", "skills/"];
+  const guardianPath = resolveGuardianPersonaPath();
+  if (guardianPath) {
+    files.push(`users/${basename(guardianPath)}`);
+  }
+  return files;
+}
 
 function handleWorkspaceFilesList(): Response {
   const base = getWorkspaceDir();
-  const files = WORKSPACE_FILES.map((name) => ({
+  const files = getWorkspaceFiles().map((name) => ({
     path: name,
     name,
     exists: pathExists(join(base, name)),


### PR DESCRIPTION
## Summary
- Convert `WORKSPACE_FILES` to a dynamic `getWorkspaceFiles()` that appends the guardian's resolved `users/<slug>.md`.
- `handleWorkspaceFileRead` now accepts paths under `users/`.
- Legacy `USER.md` listing remains until PR 15 removes it.

Part of plan: drop-user-md.md (PR 9 of 17)