### PR TITLE
Document unified STT boundary architecture and provider extension model

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -582,6 +582,53 @@ All guardian decisions for voice access requests flow through:
 | `src/runtime/actor-trust-resolver.ts`          | `resolveActorTrust` — caller trust classification                                      |
 | `src/memory/canonical-guardian-store.ts`       | Canonical request persistence and CAS resolution                                       |
 
+### Speech-to-Text (STT) Boundaries
+
+Audio-to-text conversion occurs in three distinct runtime boundaries, each with its own provider model and adapter layer. There is no global STT provider switch — each boundary resolves its provider independently based on its runtime context and available credentials.
+
+**Boundary overview:**
+
+| Boundary             | Runtime                               | Provider (current)                  | Adapter module                                                                                     | Caller                                                  |
+| -------------------- | ------------------------------------- | ----------------------------------- | -------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
+| **Telephony-native** | Twilio ConversationRelay              | Deepgram or Google (config-driven)  | `src/calls/stt-profile.ts`                                                                         | `src/calls/twilio-routes.ts`                            |
+| **Daemon batch**     | Daemon process (REST API to provider) | OpenAI Whisper                      | `src/stt/daemon-batch-transcriber.ts`                                                              | `src/runtime/routes/inbound-stages/transcribe-audio.ts` |
+| **Client-native**    | macOS / iOS on-device                 | Apple Speech (`SFSpeechRecognizer`) | `clients/macos/.../SpeechRecognizerAdapter.swift`, `clients/ios/.../SpeechRecognizerAdapter.swift` | `VoiceInputManager` (macOS), `InputBarView` (iOS)       |
+
+**Telephony-native boundary:**
+
+STT runs inside the telephony platform (Twilio ConversationRelay). The daemon does not receive raw audio — it receives transcribed text from the relay. Provider selection is config-driven (`calls.voice.transcriptionProvider`, `calls.voice.speechModel`).
+
+- `resolveTelephonySttProfile()` in `src/calls/stt-profile.ts` maps config values to a provider-agnostic `TelephonySttProfile` with provider-specific defaults (Deepgram defaults to `"nova-3"`; Google leaves the model undefined).
+- `buildTwilioRelaySpeechConfig()` in `src/calls/twilio-relay-speech-config.ts` serializes the profile into Twilio ConversationRelay TwiML attributes.
+- `twilio-routes.ts` calls both at call setup time.
+
+To add a new telephony STT provider: add a branch in `resolveEffectiveSpeechModel()` for the provider's default model behavior, then ensure `buildTwilioRelaySpeechConfig` passes the provider name through to the TwiML.
+
+**Daemon batch boundary:**
+
+The daemon transcribes audio attachments (e.g. voice messages from channel inbound) by calling a provider's REST API directly.
+
+- `src/stt/types.ts` defines provider-agnostic domain types: `BatchTranscriber` interface, `SttTranscribeRequest`, `SttTranscribeResult`, `SttError` with normalized categories (`auth`, `rate-limit`, `timeout`, `invalid-audio`, `provider-error`), and `SttProviderId` / `SttBoundaryId` discriminants.
+- `createDaemonBatchTranscriber()` in `src/stt/daemon-batch-transcriber.ts` is the factory that returns a `BatchTranscriber` backed by OpenAI Whisper (or `null` when no API key is available). `normalizeSttError()` maps raw provider errors to `SttError` categories.
+- `resolveBatchTranscriber()` in `src/providers/speech-to-text/resolve.ts` is the credential-aware entry point — it reads the OpenAI key from the secure key store and delegates to the factory.
+- `tryTranscribeAudioAttachments()` in `src/runtime/routes/inbound-stages/transcribe-audio.ts` is the callsite that uses the facade for channel audio attachment transcription.
+
+To add a new daemon batch STT provider: add a new `SttProviderId` variant in `types.ts`, implement `BatchTranscriber` in a new adapter class alongside `WhisperBatchTranscriber`, and update the factory in `daemon-batch-transcriber.ts` to select the adapter based on configuration or credential availability.
+
+**Client-native boundary:**
+
+On macOS and iOS, speech recognition runs on-device via Apple's Speech framework (`SFSpeechRecognizer`). The daemon never receives raw microphone audio from clients — it receives the final transcribed text.
+
+- macOS: `SpeechRecognizerAdapter` protocol in `clients/macos/vellum-assistant/Features/Voice/SpeechRecognizerAdapter.swift` abstracts `SFSpeechRecognizer` static APIs and instance creation. `AppleSpeechRecognizerAdapter` is the production implementation. `OpenAIVoiceService` and `VoiceInputManager` consume the adapter via dependency injection.
+- iOS: `SpeechRecognizerAdapter` protocol in `clients/ios/Services/SpeechRecognizerAdapter.swift` covers authorization, availability, and task construction. `AppleSpeechRecognizerAdapter` is the production implementation. `InputBarView` consumes the adapter.
+
+To add a new client-native STT provider: implement the `SpeechRecognizerAdapter` protocol with the new provider's SDK, then inject the new adapter at the call site (the protocol is already injected via init parameters on both platforms).
+
+**Cross-boundary notes:**
+
+- No global STT provider configuration exists. Each boundary resolves its provider independently. A future phase may introduce a unified config surface, but it is not part of the current architecture.
+- Terminology: "STT" and "transcription" refer to the same operation (converting audio to text). "Speech recognition" is used in client-native contexts where Apple's Speech framework terminology is canonical. All three terms map to the same conceptual operation.
+
 ### Update Bulletin System
 
 Release-driven update notification system that surfaces release notes to the assistant via the system prompt.

--- a/clients/ios/README.md
+++ b/clients/ios/README.md
@@ -20,7 +20,7 @@ After editing `project.yml`, regenerate the Xcode project by running `xcodegen g
 - Inline media embeds (images, YouTube, Vimeo, Loom videos)
 - Settings: integrations, trust rules, scheduled tasks, reminders (Connected mode)
 - Attachment support (photos, files)
-- Voice input via `SFSpeechRecognizer`
+- Voice input via on-device speech recognition (`SpeechRecognizerAdapter`)
 - Onboarding flow with adaptive steps based on connection mode
 - Export conversation as markdown (copy to clipboard or share sheet)
 - Siri Shortcuts integration — "Ask Vellum..." via AppIntents framework
@@ -161,6 +161,14 @@ swift test --filter VellumAssistantSharedTests
 ## Dependencies
 
 The iOS app depends only on `VellumAssistantShared`. It must **not** import `VellumAssistantLib`, which links macOS-only frameworks (AppKit, ScreenCaptureKit, etc.).
+
+---
+
+## Speech Recognition (STT)
+
+Voice input uses the `SpeechRecognizerAdapter` protocol (`Services/SpeechRecognizerAdapter.swift`) to abstract on-device speech recognition. The protocol covers three phases: authorization, availability, and task construction. The production implementation (`AppleSpeechRecognizerAdapter`) delegates to Apple's `SFSpeechRecognizer`. `InputBarView` consumes the adapter via a stored property, enabling tests to substitute a mock without a live microphone or OS permission dialogs.
+
+To add a new on-device STT provider, implement `SpeechRecognizerAdapter` with the provider's SDK and inject it at the `InputBarView` call site.
 
 ---
 

--- a/clients/macos/AGENTS.md
+++ b/clients/macos/AGENTS.md
@@ -118,7 +118,9 @@ A background screen-watching system that runs alongside the manual session loop:
 
 ### Voice Input
 
-`VoiceInputManager` — hold Fn (or Ctrl, configurable) for speech-to-text via `SFSpeechRecognizer`. Shows `VoiceTranscriptionWindow` during recording.
+`VoiceInputManager` — hold Fn (or Ctrl, configurable) for on-device speech recognition via `SFSpeechRecognizer`. Shows `VoiceTranscriptionWindow` during recording.
+
+**STT adapter:** All speech recognition access goes through the `SpeechRecognizerAdapter` protocol (`Features/Voice/SpeechRecognizerAdapter.swift`), which abstracts `SFSpeechRecognizer` static APIs and instance creation. The production implementation is `AppleSpeechRecognizerAdapter`. Both `VoiceInputManager` and `OpenAIVoiceService` accept the adapter via init injection, enabling tests to substitute a mock without hardware or permission dependencies. To add a new on-device STT provider, implement `SpeechRecognizerAdapter` with the provider's SDK and inject it at the call site.
 
 **Keyboard shortcut detection:** Uses defense-in-depth to distinguish voice activation from keyboard shortcuts (Control+C, Fn+arrow). Timer starts on key press, but recording only begins if no other keys are pressed during the 300ms hold period. Flag check (`otherKeyPressedDuringHold`) handles cases where apps consume keyDown events (e.g., Terminal).
 


### PR DESCRIPTION
## Summary
- Document the three STT boundaries: telephony-native, daemon batch, and client-native
- Add provider extension points for each boundary
- Clarify that no global STT provider config exists yet

Part of plan: initial-stt-unification.md (PR 8 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24851" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
