### PR TITLE
feat(vbundle): translate legacy USER.md in imported bundles to users/<slug>.md

### DIFF
--- a/assistant/src/__tests__/persona-resolver.test.ts
+++ b/assistant/src/__tests__/persona-resolver.test.ts
@@ -62,6 +62,7 @@ mock.module("../contacts/contact-store.js", () => ({
 // implementations.
 import {
   ensureGuardianPersonaFile,
+  isGuardianPersonaCustomized,
   resolveGuardianPersonaPath,
 } from "../prompts/persona-resolver.js";
 
@@ -144,5 +145,55 @@ describe("ensureGuardianPersonaFile", () => {
 
     const content = readFileSync(filePath, "utf-8");
     expect(content).toBe(existingContent);
+  });
+});
+
+// ── isGuardianPersonaCustomized ────────────────────────────────────
+
+describe("isGuardianPersonaCustomized", () => {
+  test("returns false when the file does not exist", () => {
+    const filePath = join(mockWorkspaceDir, "users", "nobody.md");
+    expect(isGuardianPersonaCustomized(filePath)).toBe(false);
+  });
+
+  test("returns false for the bare scaffold template (no user edits)", () => {
+    const slug = "sidd.md";
+    const filePath = join(mockWorkspaceDir, "users", slug);
+
+    // ensureGuardianPersonaFile writes the canonical template — the
+    // exact bytes that "not customized" accepts.
+    ensureGuardianPersonaFile(slug);
+
+    expect(isGuardianPersonaCustomized(filePath)).toBe(false);
+  });
+
+  test("returns false when the file contains only comment lines", () => {
+    const slug = "sidd.md";
+    const dir = join(mockWorkspaceDir, "users");
+    const filePath = join(dir, slug);
+
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      filePath,
+      "_ only comments here\n_ nothing meaningful\n",
+      "utf-8",
+    );
+
+    expect(isGuardianPersonaCustomized(filePath)).toBe(false);
+  });
+
+  test("returns true when the file has user-authored content", () => {
+    const slug = "sidd.md";
+    const dir = join(mockWorkspaceDir, "users");
+    const filePath = join(dir, slug);
+
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      filePath,
+      "# My profile\n\n- Preferred name/reference: Real User\n",
+      "utf-8",
+    );
+
+    expect(isGuardianPersonaCustomized(filePath)).toBe(true);
   });
 });

--- a/assistant/src/prompts/persona-resolver.ts
+++ b/assistant/src/prompts/persona-resolver.ts
@@ -259,3 +259,34 @@ export function ensureGuardianPersonaFile(slug: string): void {
   writeFileSync(filePath, GUARDIAN_PERSONA_TEMPLATE, "utf-8");
   log.debug({ path: filePath }, "Wrote guardian persona scaffold");
 }
+
+/**
+ * Return `true` when the persona file at `filePath` has been edited by
+ * the user (its stripped content differs from the bare scaffold
+ * template). Returns `false` when the file is missing, unreadable,
+ * empty after stripping, or byte-identical to the template after
+ * stripping comment lines.
+ *
+ * Used by the vbundle importer to decide whether a legacy
+ * `prompts/USER.md` entry may safely overwrite `users/<slug>.md`.
+ */
+export function isGuardianPersonaCustomized(filePath: string): boolean {
+  if (!existsSync(filePath)) return false;
+
+  let content: string;
+  try {
+    content = readFileSync(filePath, "utf-8");
+  } catch (err) {
+    log.warn(
+      { err, path: filePath },
+      "Failed to read persona file while checking customization",
+    );
+    return false;
+  }
+
+  const stripped = stripCommentLines(content);
+  if (stripped.length === 0) return false;
+
+  const templateStripped = stripCommentLines(GUARDIAN_PERSONA_TEMPLATE);
+  return stripped !== templateStripped;
+}

--- a/assistant/src/runtime/migrations/__tests__/vbundle-legacy-user-md.test.ts
+++ b/assistant/src/runtime/migrations/__tests__/vbundle-legacy-user-md.test.ts
@@ -1,0 +1,361 @@
+/**
+ * Tests for legacy `prompts/USER.md` translation during vbundle import.
+ *
+ * Covers:
+ * - `DefaultPathResolver` translates `prompts/USER.md` to the current
+ *   guardian's `users/<slug>.md` path when a guardian exists.
+ * - Missing guardian → resolver returns null (commit skips with warn).
+ * - Full commit round-trip: legacy bundle writes content into
+ *   `users/<slug>.md` on a fresh workspace.
+ * - Missing guardian: commit skips the legacy entry with a warning
+ *   instead of crashing.
+ * - Already-customized `users/<slug>.md` is NOT overwritten.
+ * - Pristine scaffold `users/<slug>.md` (template only) IS overwritten.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { buildVBundle } from "../vbundle-builder.js";
+import {
+  analyzeImport,
+  DefaultPathResolver,
+} from "../vbundle-import-analyzer.js";
+import { commitImport } from "../vbundle-importer.js";
+
+// ---------------------------------------------------------------------------
+// Shared fixture: per-test workspace under VELLUM_WORKSPACE_DIR.
+// ---------------------------------------------------------------------------
+
+const WORKSPACE_ROOT = process.env.VELLUM_WORKSPACE_DIR!;
+const USERS_DIR = join(WORKSPACE_ROOT, "users");
+
+const LEGACY_USER_MD_CONTENT = `# User Profile
+
+- Preferred name/reference: Captain Legacy
+- Pronouns: they/them
+- Work role: Archivist
+- Hobbies/fun: Unearthing old bundles
+`;
+
+/**
+ * Bare scaffold template matching `GUARDIAN_PERSONA_TEMPLATE` in
+ * `persona-resolver.ts`. Duplicated here intentionally so the test
+ * pins the exact bytes that count as "not customized".
+ */
+const PRISTINE_SCAFFOLD = `_ Lines starting with _ are comments - they won't appear in the system prompt
+
+# User Profile
+
+Store details about your user here. Edit freely - build this over time as you learn about them. Don't be pushy about seeking details, but when you learn something, write it down. More context makes you more useful.
+
+- Preferred name/reference:
+- Pronouns:
+- Locale:
+- Work role:
+- Goals:
+- Hobbies/fun:
+- Daily tools:
+`;
+
+/**
+ * Customized guardian persona file — has user-authored content past the
+ * bare scaffold. Must survive an import unchanged.
+ */
+const CUSTOMIZED_PERSONA = `_ Lines starting with _ are comments - they won't appear in the system prompt
+
+# User Profile
+
+- Preferred name/reference: Real User
+- Pronouns: she/her
+- Locale: en-US
+- Work role: Staff Engineer
+- Goals: Ship drop-user-md
+- Hobbies/fun: Reading papers
+- Daily tools: Terminal, Vellum
+`;
+
+function cleanWorkspace() {
+  try {
+    rmSync(USERS_DIR, { recursive: true, force: true });
+  } catch {
+    /* best effort */
+  }
+  mkdirSync(USERS_DIR, { recursive: true });
+}
+
+beforeEach(() => {
+  cleanWorkspace();
+});
+
+afterEach(() => {
+  cleanWorkspace();
+});
+
+// ---------------------------------------------------------------------------
+// DefaultPathResolver — USER.md translation
+// ---------------------------------------------------------------------------
+
+describe("DefaultPathResolver prompts/USER.md translation", () => {
+  test("rewrites prompts/USER.md to the guardian's users/<slug>.md", () => {
+    const guardianPath = join(USERS_DIR, "captain.md");
+    const resolver = new DefaultPathResolver(
+      WORKSPACE_ROOT,
+      undefined,
+      () => guardianPath,
+    );
+
+    expect(resolver.resolve("prompts/USER.md")).toBe(guardianPath);
+  });
+
+  test("returns null when no guardian exists", () => {
+    const resolver = new DefaultPathResolver(
+      WORKSPACE_ROOT,
+      undefined,
+      () => null,
+    );
+
+    expect(resolver.resolve("prompts/USER.md")).toBeNull();
+  });
+
+  test("rejects guardian paths outside the workspace (traversal guard)", () => {
+    // Stubbed resolver returns a path outside the workspace — the
+    // analyzer resolver must reject it to prevent writing outside
+    // the workspace root.
+    const resolver = new DefaultPathResolver(
+      WORKSPACE_ROOT,
+      undefined,
+      () => "/etc/passwd",
+    );
+
+    expect(resolver.resolve("prompts/USER.md")).toBeNull();
+  });
+
+  test("still resolves other prompt files (IDENTITY.md) to workspace root", () => {
+    const resolver = new DefaultPathResolver(
+      WORKSPACE_ROOT,
+      undefined,
+      () => join(USERS_DIR, "captain.md"),
+    );
+
+    expect(resolver.resolve("prompts/IDENTITY.md")).toBe(
+      join(WORKSPACE_ROOT, "IDENTITY.md"),
+    );
+    expect(resolver.resolve("prompts/SOUL.md")).toBe(
+      join(WORKSPACE_ROOT, "SOUL.md"),
+    );
+    expect(resolver.resolve("prompts/UPDATES.md")).toBe(
+      join(WORKSPACE_ROOT, "UPDATES.md"),
+    );
+  });
+
+  test("skips unknown prompt filenames regardless of guardian state", () => {
+    const resolver = new DefaultPathResolver(
+      WORKSPACE_ROOT,
+      undefined,
+      () => join(USERS_DIR, "captain.md"),
+    );
+
+    expect(resolver.resolve("prompts/SECRET.md")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// analyzeImport — surfaces the translated destination for preflight
+// ---------------------------------------------------------------------------
+
+describe("analyzeImport for legacy prompts/USER.md", () => {
+  test("reports a `create` action on a fresh users/<slug>.md", () => {
+    const guardianPath = join(USERS_DIR, "captain.md");
+    const resolver = new DefaultPathResolver(
+      WORKSPACE_ROOT,
+      undefined,
+      () => guardianPath,
+    );
+
+    const { archive, manifest } = buildVBundle({
+      files: [
+        {
+          path: "prompts/USER.md",
+          data: new TextEncoder().encode(LEGACY_USER_MD_CONTENT),
+        },
+      ],
+    });
+    expect(archive.length).toBeGreaterThan(0);
+
+    const report = analyzeImport({ manifest, pathResolver: resolver });
+
+    expect(report.can_import).toBe(true);
+    expect(report.files).toHaveLength(1);
+    expect(report.files[0].path).toBe("prompts/USER.md");
+    expect(report.files[0].action).toBe("create");
+  });
+
+  test("reports a conflict when no guardian is resolvable", () => {
+    const resolver = new DefaultPathResolver(
+      WORKSPACE_ROOT,
+      undefined,
+      () => null,
+    );
+
+    const { manifest } = buildVBundle({
+      files: [
+        {
+          path: "prompts/USER.md",
+          data: new TextEncoder().encode(LEGACY_USER_MD_CONTENT),
+        },
+      ],
+    });
+
+    const report = analyzeImport({ manifest, pathResolver: resolver });
+
+    // UNKNOWN_ARCHIVE_PATH is the analyzer's conflict code for entries
+    // whose resolver returned null.
+    expect(report.conflicts.some((c) => c.code === "UNKNOWN_ARCHIVE_PATH")).toBe(
+      true,
+    );
+    expect(report.files[0].action).toBe("skip");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// commitImport — end-to-end legacy USER.md import
+// ---------------------------------------------------------------------------
+
+describe("commitImport for legacy prompts/USER.md", () => {
+  test("writes legacy USER.md content into users/<slug>.md", () => {
+    const slug = "captain.md";
+    const guardianPath = join(USERS_DIR, slug);
+    const resolver = new DefaultPathResolver(
+      WORKSPACE_ROOT,
+      undefined,
+      () => guardianPath,
+    );
+
+    const { archive } = buildVBundle({
+      files: [
+        {
+          path: "prompts/USER.md",
+          data: new TextEncoder().encode(LEGACY_USER_MD_CONTENT),
+        },
+      ],
+    });
+
+    const result = commitImport({ archiveData: archive, pathResolver: resolver });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.report.success).toBe(true);
+      expect(result.report.summary.files_created).toBe(1);
+      expect(result.report.summary.files_skipped).toBe(0);
+    }
+
+    expect(existsSync(guardianPath)).toBe(true);
+    expect(readFileSync(guardianPath, "utf-8")).toBe(LEGACY_USER_MD_CONTENT);
+  });
+
+  test("overwrites a pristine scaffold users/<slug>.md", () => {
+    const slug = "captain.md";
+    const guardianPath = join(USERS_DIR, slug);
+    writeFileSync(guardianPath, PRISTINE_SCAFFOLD, "utf-8");
+
+    const resolver = new DefaultPathResolver(
+      WORKSPACE_ROOT,
+      undefined,
+      () => guardianPath,
+    );
+
+    const { archive } = buildVBundle({
+      files: [
+        {
+          path: "prompts/USER.md",
+          data: new TextEncoder().encode(LEGACY_USER_MD_CONTENT),
+        },
+      ],
+    });
+
+    const result = commitImport({ archiveData: archive, pathResolver: resolver });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.report.summary.files_overwritten).toBe(1);
+      expect(result.report.summary.files_skipped).toBe(0);
+    }
+    expect(readFileSync(guardianPath, "utf-8")).toBe(LEGACY_USER_MD_CONTENT);
+  });
+
+  test("skips with a warning when no guardian exists (no crash)", () => {
+    const resolver = new DefaultPathResolver(
+      WORKSPACE_ROOT,
+      undefined,
+      () => null,
+    );
+
+    const { archive } = buildVBundle({
+      files: [
+        {
+          path: "prompts/USER.md",
+          data: new TextEncoder().encode(LEGACY_USER_MD_CONTENT),
+        },
+      ],
+    });
+
+    const result = commitImport({ archiveData: archive, pathResolver: resolver });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.report.summary.files_skipped).toBe(1);
+      expect(result.report.summary.files_created).toBe(0);
+      expect(
+        result.report.warnings.some((w) => w.includes("prompts/USER.md")),
+      ).toBe(true);
+    }
+
+    // No stray file was written anywhere in users/.
+    expect(existsSync(join(USERS_DIR, "USER.md"))).toBe(false);
+  });
+
+  test("does NOT overwrite a customized users/<slug>.md", () => {
+    const slug = "captain.md";
+    const guardianPath = join(USERS_DIR, slug);
+    writeFileSync(guardianPath, CUSTOMIZED_PERSONA, "utf-8");
+
+    const resolver = new DefaultPathResolver(
+      WORKSPACE_ROOT,
+      undefined,
+      () => guardianPath,
+    );
+
+    const { archive } = buildVBundle({
+      files: [
+        {
+          path: "prompts/USER.md",
+          data: new TextEncoder().encode(LEGACY_USER_MD_CONTENT),
+        },
+      ],
+    });
+
+    const result = commitImport({ archiveData: archive, pathResolver: resolver });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.report.summary.files_skipped).toBe(1);
+      expect(result.report.summary.files_overwritten).toBe(0);
+      expect(
+        result.report.warnings.some((w) =>
+          w.includes("guardian persona"),
+        ),
+      ).toBe(true);
+    }
+
+    // Existing customized content is preserved byte-for-byte.
+    expect(readFileSync(guardianPath, "utf-8")).toBe(CUSTOMIZED_PERSONA);
+  });
+});

--- a/assistant/src/runtime/migrations/vbundle-import-analyzer.ts
+++ b/assistant/src/runtime/migrations/vbundle-import-analyzer.ts
@@ -17,15 +17,28 @@ import { createHash } from "node:crypto";
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { join, resolve } from "node:path";
 
+import { resolveGuardianPersonaPath } from "../../prompts/persona-resolver.js";
+import { getLogger } from "../../util/logger.js";
 import type { ManifestType } from "./vbundle-validator.js";
 
-/** Only these prompt filenames are accepted during import. */
+const log = getLogger("vbundle-import-analyzer");
+
+/**
+ * Only these prompt filenames are accepted during import.
+ *
+ * `USER.md` is retained for backward compatibility with legacy bundles —
+ * on import, its content is translated to `users/<slug>.md` at the
+ * current guardian's location (see `DefaultPathResolver.resolve`).
+ */
 const ALLOWED_PROMPT_FILENAMES = new Set([
   "IDENTITY.md",
   "SOUL.md",
   "USER.md",
   "UPDATES.md",
 ]);
+
+/** Archive path for the legacy guardian user persona file. */
+const LEGACY_USER_MD_ARCHIVE_PATH = "prompts/USER.md";
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -87,9 +100,19 @@ export interface PathResolver {
 }
 
 export class DefaultPathResolver implements PathResolver {
+  /**
+   * @param workspaceDir  absolute path to the workspace directory.
+   * @param hooksDir      absolute path to the hooks directory.
+   * @param guardianPersonaPathResolver  function that returns the
+   *   current guardian's persona path (`users/<slug>.md`) or `null`
+   *   when no guardian exists. Defaults to the production
+   *   `resolveGuardianPersonaPath` helper; tests inject a stub so they
+   *   don't need to mock the contact store.
+   */
   constructor(
     private workspaceDir?: string,
     private hooksDir?: string,
+    private guardianPersonaPathResolver: () => string | null = resolveGuardianPersonaPath,
   ) {}
 
   resolve(archivePath: string): string | null {
@@ -139,6 +162,38 @@ export class DefaultPathResolver implements PathResolver {
       if (!ALLOWED_PROMPT_FILENAMES.has(filename)) {
         return null;
       }
+
+      // Legacy USER.md translation: rewrite the destination to the
+      // current guardian's per-user persona file `users/<slug>.md`.
+      // Guardian-less workspaces return null → importer skips with a
+      // warning (see vbundle-importer.ts). This lookup runs against
+      // whatever DB state is live at the time of resolve — typically
+      // the pre-import workspace, which is the common upgrade case.
+      if (archivePath === LEGACY_USER_MD_ARCHIVE_PATH) {
+        const guardianPath = this.guardianPersonaPathResolver();
+        if (!guardianPath) {
+          log.warn(
+            { path: archivePath },
+            "Legacy prompts/USER.md has no guardian target — will be skipped on import",
+          );
+          return null;
+        }
+        // Containment check: guardian path must live under the workspace.
+        const wsRoot = resolve(this.workspaceDir);
+        const guardianResolved = resolve(guardianPath);
+        if (
+          guardianResolved !== wsRoot &&
+          !guardianResolved.startsWith(wsRoot + "/")
+        ) {
+          log.warn(
+            { path: archivePath, guardianPath },
+            "Guardian persona path falls outside workspace — refusing to write",
+          );
+          return null;
+        }
+        return guardianResolved;
+      }
+
       const resolved = resolve(this.workspaceDir, filename);
       const wsRoot = resolve(this.workspaceDir);
       if (resolved !== wsRoot && !resolved.startsWith(wsRoot + "/")) {

--- a/assistant/src/runtime/migrations/vbundle-importer.ts
+++ b/assistant/src/runtime/migrations/vbundle-importer.ts
@@ -25,9 +25,16 @@ import {
 import { dirname, join } from "node:path";
 
 import { sanitizeConfigForTransfer } from "../../config/sanitize-for-transfer.js";
+import { isGuardianPersonaCustomized } from "../../prompts/persona-resolver.js";
+import { getLogger } from "../../util/logger.js";
 import type { PathResolver } from "./vbundle-import-analyzer.js";
 import type { ManifestType, VBundleTarEntry } from "./vbundle-validator.js";
 import { validateVBundle } from "./vbundle-validator.js";
+
+const log = getLogger("vbundle-importer");
+
+/** Archive path for the legacy guardian user persona file. */
+const LEGACY_USER_MD_ARCHIVE_PATH = "prompts/USER.md";
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -267,6 +274,33 @@ export function commitImport(options: ImportCommitOptions): ImportCommitResult {
       warnings.push(
         `Skipped "${fileEntry.path}": declared in manifest but not found in archive`,
       );
+      continue;
+    }
+
+    // Legacy guardian persona (prompts/USER.md) is translated to the
+    // current guardian's users/<slug>.md by DefaultPathResolver. If
+    // that target already holds user-authored content, skip rather
+    // than clobber — the user has curated their persona since the
+    // bundle was exported.
+    if (
+      fileEntry.path === LEGACY_USER_MD_ARCHIVE_PATH &&
+      isGuardianPersonaCustomized(diskPath)
+    ) {
+      log.warn(
+        { archivePath: fileEntry.path, diskPath },
+        "Skipping legacy prompts/USER.md import: guardian persona is already customized",
+      );
+      warnings.push(
+        `Skipped "${fileEntry.path}": guardian persona at "${diskPath}" is already customized`,
+      );
+      importedFiles.push({
+        path: fileEntry.path,
+        disk_path: diskPath,
+        action: "skipped",
+        size: fileEntry.size,
+        sha256: fileEntry.sha256,
+        backup_path: null,
+      });
       continue;
     }
 


### PR DESCRIPTION
## Summary
- Legacy `.vbundle` archives that ship `prompts/USER.md` now land their content at `users/<slug>.md` on import.
- Guardian lookup uses `resolveGuardianPersonaPath`; no guardian → warn and skip.
- Customized `users/<slug>.md` is never overwritten by an import.

Part of plan: drop-user-md.md (PR 10 of 17)