### PR TITLE
refactor(system-prompt): drop USER.md from PROMPT_FILES, fallback push, and ensurePromptFiles seed

### DIFF
--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -79,7 +79,7 @@ const {
 } = await import("../prompts/system-prompt.js");
 
 /**
- * Extract just the workspace-file content (IDENTITY.md, SOUL.md, USER.md,
+ * Extract just the workspace-file content (IDENTITY.md, SOUL.md,
  * BOOTSTRAP.md) from the full system prompt, stripping all static
  * instruction sections, configuration, and skills catalog.
  *
@@ -123,6 +123,7 @@ describe("buildSystemPrompt", () => {
       "BOOTSTRAP.md",
       "UPDATES.md",
       "skills",
+      "users",
     ]) {
       const p = join(TEST_DIR, name);
       if (existsSync(p)) rmSync(p, { recursive: true, force: true });
@@ -249,31 +250,39 @@ describe("buildSystemPrompt", () => {
     expect(result).not.toContain("incident-response");
   });
 
-  test("appends USER.md after base prompt", () => {
-    writeFileSync(join(TEST_DIR, "IDENTITY.md"), "Base prompt");
-    writeFileSync(join(TEST_DIR, "USER.md"), "# User\n\nName: Alice");
-    const result = buildSystemPrompt();
-    expect(basePrompt(result)).toBe("Base prompt\n\n# User\n\nName: Alice");
-  });
-
-  test("appends USER.md after IDENTITY + SOUL", () => {
+  test("builds prompt without error when USER.md does not exist on disk", () => {
+    // Persona content now flows through options.userPersona (resolved via
+    // resolveGuardianPersona upstream). buildSystemPrompt must never read
+    // USER.md from disk — verify it returns a well-formed prompt when the
+    // file is absent.
     writeFileSync(join(TEST_DIR, "IDENTITY.md"), "Identity");
     writeFileSync(join(TEST_DIR, "SOUL.md"), "Soul");
-    writeFileSync(join(TEST_DIR, "USER.md"), "User info");
     const result = buildSystemPrompt();
-    expect(basePrompt(result)).toBe("Identity\n\nSoul\n\nUser info");
+    expect(basePrompt(result)).toBe("Identity\n\nSoul");
   });
 
-  test("USER.md alone becomes the prompt", () => {
-    writeFileSync(join(TEST_DIR, "USER.md"), "Just user");
+  test("does not read USER.md content from disk even when the file is present", () => {
+    // USER.md has been removed from PROMPT_FILES and the fallback read
+    // path. A stale file on disk must not leak into the prompt.
+    writeFileSync(join(TEST_DIR, "IDENTITY.md"), "Identity");
+    writeFileSync(
+      join(TEST_DIR, "USER.md"),
+      "stale user content that should be ignored",
+    );
     const result = buildSystemPrompt();
-    expect(basePrompt(result)).toBe("Just user");
+    expect(result).not.toContain("stale user content");
+    expect(basePrompt(result)).toBe("Identity");
   });
 
-  test("ignores empty USER.md", () => {
-    writeFileSync(join(TEST_DIR, "USER.md"), "  \n  ");
-    const result = buildSystemPrompt();
-    expect(basePrompt(result)).toBe("");
+  test("uses options.userPersona instead of USER.md", () => {
+    writeFileSync(join(TEST_DIR, "IDENTITY.md"), "Identity");
+    writeFileSync(join(TEST_DIR, "SOUL.md"), "Soul");
+    const result = buildSystemPrompt({
+      userPersona: "# User persona\n\nName: Alice",
+    });
+    expect(basePrompt(result)).toBe(
+      "Identity\n\nSoul\n\n# User persona\n\nName: Alice",
+    );
   });
 
   describe("BOOTSTRAP.md user persona placeholder", () => {
@@ -582,22 +591,43 @@ describe("ensurePromptFiles", () => {
       "SOUL.md",
       "USER.md",
       "BOOTSTRAP.md",
+      "BOOTSTRAP-REFERENCE.md",
+      "HEARTBEAT.md",
       "conversations",
+      "users",
     ]) {
       const p = join(TEST_DIR, name);
       if (existsSync(p)) rmSync(p, { recursive: true, force: true });
     }
   });
 
-  test("creates all 3 files from templates when none exist", () => {
+  test("creates SOUL.md and IDENTITY.md from templates when none exist", () => {
     ensurePromptFiles();
 
-    for (const file of ["SOUL.md", "IDENTITY.md", "USER.md"]) {
+    for (const file of ["SOUL.md", "IDENTITY.md"]) {
       const dest = join(TEST_DIR, file);
       expect(existsSync(dest)).toBe(true);
       const content = readFileSync(dest, "utf-8");
       expect(content.length).toBeGreaterThan(0);
     }
+  });
+
+  test("does not seed USER.md", () => {
+    // USER.md is no longer part of the seeded prompt files — persona
+    // content lives in users/<slug>.md and is resolved via the guardian
+    // persona path.
+    ensurePromptFiles();
+
+    expect(existsSync(join(TEST_DIR, "USER.md"))).toBe(false);
+  });
+
+  test("seeds users/default.md persona template", () => {
+    ensurePromptFiles();
+
+    const defaultPersonaPath = join(TEST_DIR, "users", "default.md");
+    expect(existsSync(defaultPersonaPath)).toBe(true);
+    const content = readFileSync(defaultPersonaPath, "utf-8");
+    expect(content.length).toBeGreaterThan(0);
   });
 
   test("does not overwrite existing files", () => {
@@ -609,9 +639,8 @@ describe("ensurePromptFiles", () => {
     const content = readFileSync(join(TEST_DIR, "IDENTITY.md"), "utf-8");
     expect(content).toBe(customContent);
 
-    // Other files should be created
+    // The other seeded file should be created
     expect(existsSync(join(TEST_DIR, "SOUL.md"))).toBe(true);
-    expect(existsSync(join(TEST_DIR, "USER.md"))).toBe(true);
   });
 
   test("handles missing template gracefully (warn, no crash)", () => {
@@ -636,7 +665,6 @@ describe("ensurePromptFiles", () => {
     // BOOTSTRAP.md was deleted by the user.
     writeFileSync(join(TEST_DIR, "IDENTITY.md"), "My identity");
     writeFileSync(join(TEST_DIR, "SOUL.md"), "My soul");
-    writeFileSync(join(TEST_DIR, "USER.md"), "My user");
 
     ensurePromptFiles();
 
@@ -658,7 +686,6 @@ describe("ensurePromptFiles", () => {
     // Simulate a non-first-run workspace: core files + BOOTSTRAP.md still present
     writeFileSync(join(TEST_DIR, "IDENTITY.md"), "My identity");
     writeFileSync(join(TEST_DIR, "SOUL.md"), "My soul");
-    writeFileSync(join(TEST_DIR, "USER.md"), "My user");
     writeFileSync(join(TEST_DIR, "BOOTSTRAP.md"), "# Stale bootstrap");
 
     // Create a conversations directory with at least one entry

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -25,7 +25,7 @@ export { SYSTEM_PROMPT_CACHE_BOUNDARY };
 
 const log = getLogger("system-prompt");
 
-const PROMPT_FILES = ["SOUL.md", "IDENTITY.md", "USER.md"] as const;
+const PROMPT_FILES = ["SOUL.md", "IDENTITY.md"] as const;
 
 /**
  * Copy template prompt files into the data directory if they don't already exist.
@@ -190,7 +190,7 @@ export function ensurePromptFiles(): void {
  *
  * Composition:
  *   1. Base prompt: IDENTITY.md + SOUL.md (guaranteed to exist after ensurePromptFiles)
- *   2. Append USER.md (user profile)
+ *   2. Append the resolved user persona from users/<slug>.md (via options.userPersona)
  *   3. If BOOTSTRAP.md exists, append first-run ritual instructions
  */
 export interface BuildSystemPromptOptions {
@@ -215,7 +215,7 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
   // ── Static instruction sections (stable across turns) ──
   // These sections are deterministic within a process lifetime.  They form
   // the first cache block so they remain cached even when workspace files
-  // (IDENTITY.md, SOUL.md, USER.md, etc.) are edited between turns.
+  // (IDENTITY.md, SOUL.md, users/<slug>.md, etc.) are edited between turns.
   const staticParts: string[] = [];
   const customPrefix = readCustomSystemPromptPrefix();
   if (customPrefix) staticParts.push(customPrefix);
@@ -242,13 +242,11 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
 
   const soulPath = getWorkspacePromptPath("SOUL.md");
   const identityPath = getWorkspacePromptPath("IDENTITY.md");
-  const userPath = getWorkspacePromptPath("USER.md");
   const bootstrapPath = getWorkspacePromptPath("BOOTSTRAP.md");
   const updatesPath = getWorkspacePromptPath("UPDATES.md");
 
   const soul = readPromptFile(soulPath);
   const identity = readPromptFile(identityPath);
-  const user = readPromptFile(userPath);
   const bootstrap = readPromptFile(bootstrapPath);
   const updates = readPromptFile(updatesPath);
 
@@ -262,7 +260,6 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
   // source and skip them — SOUL.md provides sufficient personality defaults
   // until onboarding completes.
   const identityIsTemplate = isTemplateContent(identity, "IDENTITY.md");
-  const userIsTemplate = isTemplateContent(user, "USER.md");
 
   if (identity && !identityIsTemplate) {
     // Strip placeholder lines (e.g. "- **Name:** _(not yet chosen)_") so
@@ -278,7 +275,6 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
   if (soul) dynamicParts.push(soul);
   if (options?.userPersona) dynamicParts.push(options.userPersona);
   if (options?.channelPersona) dynamicParts.push(options.channelPersona);
-  if (user && !userIsTemplate && !options?.userPersona) dynamicParts.push(user);
   if (includeBootstrap) {
     const userSlug = options?.userSlug ?? "default";
     const bootstrapWithSlug = bootstrap.replaceAll(
@@ -495,7 +491,7 @@ function readPromptFile(path: string): string | null {
 }
 
 /**
- * Reads the core identity/personality prompt files (SOUL.md, IDENTITY.md, USER.md)
+ * Reads the core identity/personality prompt files (SOUL.md, IDENTITY.md)
  * and concatenates whichever exist. Returns null if none are present.
  *
  * This is useful for injecting identity context into subsystems (e.g. memory
@@ -509,10 +505,9 @@ export function buildCoreIdentityContext(opts?: {
     const content = readPromptFile(getWorkspacePromptPath(file));
     if (!content) continue;
     // SOUL.md is always included — it provides personality defaults even
-    // before onboarding completes.  Only skip IDENTITY.md and USER.md when
-    // they are still unmodified templates (matching buildSystemPrompt).
+    // before onboarding completes.  Only skip IDENTITY.md when it is still
+    // an unmodified template (matching buildSystemPrompt).
     if (file !== "SOUL.md" && isTemplateContent(content, file)) continue;
-    if (file === "USER.md" && opts?.userPersona) continue;
     parts.push(content);
   }
   if (opts?.userPersona) parts.push(opts.userPersona);


### PR DESCRIPTION
## Summary
- Remove USER.md from `PROMPT_FILES`, the `userPath`/`user`/`userIsTemplate` read path, the fallback push into `dynamicParts`, and the `buildCoreIdentityContext` special case.
- Stop seeding `USER.md` in `ensurePromptFiles()` — only SOUL.md, IDENTITY.md, and users/default.md are seeded going forward.
- Persona content still reaches the prompt via `options.userPersona` (already wired by PR 2 and resolved via `resolveGuardianPersona`).

Part of plan: drop-user-md.md (PR 11 of 17)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24854" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
