### PR TITLE
refactor(macos): drop hardcoded USER.md in IdentityData.swift

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
@@ -810,7 +810,10 @@ struct ConstellationView: View {
 
     private var groups: [CategoryGroup] {
         let fileItems = existingFiles.enumerated().map { idx, node in
-            let path: String? = node.label.hasSuffix(".md") ? node.path : nil
+            // Detect files by the backend-provided path, not the display
+            // label — labels are user-facing strings (e.g. "User Profile")
+            // that no longer necessarily match the filename.
+            let path: String? = node.path.hasSuffix(".md") ? node.path : nil
             return OrbitItem(
                 id: "workspace-\(idx)", label: node.label, icon: SkillCategory.knowledge.icon,
                 emoji: nil, color: SkillCategory.knowledge.color, filePath: path,

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityData.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityData.swift
@@ -382,22 +382,85 @@ struct WorkspaceFileNode: Identifiable {
     let path: String
     let exists: Bool
 
-    /// Check file existence via the gateway workspace tree API.
+    /// Legacy user-persona filename, retained only as a fallback label for
+    /// installs that pre-date the guardian's `users/<slug>.md` path. The
+    /// primary source of truth is the server-returned `GET /workspace-files`
+    /// list; this constant is never used as a hardcoded match filter against
+    /// the response.
+    private static let legacyUserPersonaFilename = "USER.md"
+
+    /// Static nodes used as a last-resort fallback when the gateway is
+    /// unreachable. Mirrors the server's static entries in `settings-routes.ts`
+    /// (minus the guardian's dynamic `users/<slug>.md`, which we obviously
+    /// can't resolve client-side).
+    private static let fallbackNodes: [WorkspaceFileNode] = [
+        WorkspaceFileNode(label: "IDENTITY.md", path: "IDENTITY.md", exists: false),
+        WorkspaceFileNode(label: "SOUL.md", path: "SOUL.md", exists: false),
+        WorkspaceFileNode(label: "User Profile", path: legacyUserPersonaFilename, exists: false),
+        WorkspaceFileNode(label: "skills/", path: "skills", exists: false),
+    ]
+
+    /// Fetch the well-known workspace files from the gateway.
+    ///
+    /// Uses `GET /workspace-files`, which the daemon builds dynamically:
+    /// it includes the static identity/soul/skills entries plus the
+    /// guardian's resolved per-user persona file at `users/<slug>.md`
+    /// (and still includes the legacy `USER.md` during the transition).
+    /// The client does not hardcode which user-persona file to look for —
+    /// it renders whatever the server returns, preferring any `users/*.md`
+    /// entry over the legacy `USER.md` so fresh installs show a single
+    /// "User Profile" node.
     static func scanAsync() async -> [WorkspaceFileNode] {
-        guard let tree = await WorkspaceClient().fetchWorkspaceTree(path: "", showHidden: false) else {
-            return [
-                WorkspaceFileNode(label: "IDENTITY.md", path: "IDENTITY.md", exists: false),
-                WorkspaceFileNode(label: "SOUL.md", path: "SOUL.md", exists: false),
-                WorkspaceFileNode(label: "USER.md", path: "USER.md", exists: false),
-                WorkspaceFileNode(label: "skills/", path: "skills", exists: false),
-            ]
+        guard let response = await WorkspaceClient().fetchWorkspaceFilesList() else {
+            return fallbackNodes
         }
-        let names = Set(tree.entries.map { $0.name })
-        return [
-            WorkspaceFileNode(label: "IDENTITY.md", path: "IDENTITY.md", exists: names.contains("IDENTITY.md")),
-            WorkspaceFileNode(label: "SOUL.md", path: "SOUL.md", exists: names.contains("SOUL.md")),
-            WorkspaceFileNode(label: "USER.md", path: "USER.md", exists: names.contains("USER.md")),
-            WorkspaceFileNode(label: "skills/", path: "skills", exists: names.contains("skills")),
-        ]
+        return buildNodes(from: response.files)
+    }
+
+    /// Pure transformation from the server's `workspace-files` response to
+    /// the nodes rendered by the identity panel. Factored out for easier
+    /// reasoning and future unit testing — contains no I/O.
+    static func buildNodes(from entries: [WorkspaceFilesListEntry]) -> [WorkspaceFileNode] {
+        // When the server returns a guardian-resolved `users/<slug>.md`, we
+        // suppress the legacy `USER.md` entry so the panel renders a single
+        // user-persona node instead of two competing ones.
+        let hasGuardianUserPersona = entries.contains { isGuardianUserPersonaPath($0.path) }
+
+        var nodes: [WorkspaceFileNode] = []
+        for entry in entries {
+            if hasGuardianUserPersona && entry.path == legacyUserPersonaFilename {
+                continue
+            }
+            nodes.append(
+                WorkspaceFileNode(
+                    label: displayLabel(for: entry),
+                    path: entry.path,
+                    exists: entry.exists
+                )
+            )
+        }
+        return nodes
+    }
+
+    /// True when `path` points at the guardian-owned per-user persona file
+    /// (any markdown file directly under `users/`). The client does not care
+    /// which slug the guardian chose — the server decides and we render it.
+    private static func isGuardianUserPersonaPath(_ path: String) -> Bool {
+        guard path.hasPrefix("users/") else { return false }
+        let remainder = path.dropFirst("users/".count)
+        return !remainder.isEmpty
+            && !remainder.contains("/")
+            && remainder.hasSuffix(".md")
+    }
+
+    /// Maps a server entry to a user-facing label. User-persona files — both
+    /// the guardian's `users/<slug>.md` and the legacy `USER.md` — are shown
+    /// as "User Profile" so the UI doesn't surface a slug or legacy filename.
+    /// All other entries render their server-provided name verbatim.
+    private static func displayLabel(for entry: WorkspaceFilesListEntry) -> String {
+        if isGuardianUserPersonaPath(entry.path) || entry.path == legacyUserPersonaFilename {
+            return "User Profile"
+        }
+        return entry.name
     }
 }

--- a/clients/shared/Network/NetworkResponseTypes.swift
+++ b/clients/shared/Network/NetworkResponseTypes.swift
@@ -85,3 +85,23 @@ public struct WorkspaceFileResponse: Codable, Sendable {
         self.isBinary = isBinary
     }
 }
+
+// MARK: - Workspace files list (distinct from tree)
+
+/// A single entry in the `GET /workspace-files` response.
+///
+/// This endpoint is distinct from the workspace tree API: it returns a flat,
+/// server-curated list of the well-known workspace files the UI cares about
+/// (`IDENTITY.md`, `SOUL.md`, the user persona file, `skills/`), including
+/// dynamic entries such as the guardian's per-user persona path at
+/// `users/<slug>.md`.
+public struct WorkspaceFilesListEntry: Codable, Sendable {
+    public let path: String
+    public let name: String
+    public let exists: Bool
+}
+
+/// Response shape from `GET /workspace-files`.
+public struct WorkspaceFilesListResponse: Codable, Sendable {
+    public let files: [WorkspaceFilesListEntry]
+}

--- a/clients/shared/Network/WorkspaceClient.swift
+++ b/clients/shared/Network/WorkspaceClient.swift
@@ -7,6 +7,7 @@ private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "Works
 public protocol WorkspaceClientProtocol {
     func fetchWorkspaceTree(path: String, showHidden: Bool) async -> WorkspaceTreeResponse?
     func fetchWorkspaceFile(path: String, showHidden: Bool) async -> WorkspaceFileResponse?
+    func fetchWorkspaceFilesList() async -> WorkspaceFilesListResponse?
     func deleteWorkspaceItem(path: String) async -> Bool
     func writeWorkspaceFile(path: String, content: Data) async -> Bool
     func createWorkspaceDirectory(path: String) async -> Bool
@@ -48,6 +49,23 @@ public struct WorkspaceClient: WorkspaceClientProtocol {
         }
         guard let data = response?.data else { return nil }
         return try? JSONDecoder().decode(WorkspaceFileResponse.self, from: data)
+    }
+
+    /// Fetches the server-curated list of well-known workspace files via
+    /// `GET /workspace-files`. Unlike ``fetchWorkspaceTree``, this endpoint
+    /// returns a flat list that the daemon builds dynamically — including
+    /// the guardian's per-user persona file at `users/<slug>.md` when
+    /// present — so the UI doesn't need to hardcode which files to look for.
+    public func fetchWorkspaceFilesList() async -> WorkspaceFilesListResponse? {
+        let response = try? await GatewayHTTPClient.get(
+            path: "assistants/{assistantId}/workspace-files", timeout: 10
+        )
+        if let statusCode = response?.statusCode, !(200..<300).contains(statusCode) {
+            log.error("Fetch workspace files list failed (HTTP \(statusCode))")
+            return nil
+        }
+        guard let data = response?.data else { return nil }
+        return try? JSONDecoder().decode(WorkspaceFilesListResponse.self, from: data)
     }
 
     public func deleteWorkspaceItem(path: String) async -> Bool {


### PR DESCRIPTION
## Summary
- Identity panel now surfaces whichever user-profile file the backend returns from `GET /workspace-files`, preferring the guardian's `users/<slug>.md` when present.
- Legacy `USER.md` still renders if only that entry exists, for graceful transition.

Part of plan: drop-user-md.md (PR 17 of 17)