### PR TITLE
fix(test): drop USER.md assertion from dynamic-skill-workflow-prompt test

### DIFF
--- a/assistant/src/__tests__/dynamic-skill-workflow-prompt.test.ts
+++ b/assistant/src/__tests__/dynamic-skill-workflow-prompt.test.ts
@@ -83,15 +83,13 @@ describe("Dynamic Skill Authoring Workflow moved to tool descriptions", () => {
     expect(result).not.toContain("**test-skill**");
   });
 
-  test("prompt is additive with IDENTITY/SOUL/USER files", () => {
+  test("prompt is additive with IDENTITY/SOUL files", () => {
     writeFileSync(join(TEST_DIR, "IDENTITY.md"), "Identity here");
     writeFileSync(join(TEST_DIR, "SOUL.md"), "Soul here");
-    writeFileSync(join(TEST_DIR, "USER.md"), "User here");
 
     const result = buildSystemPrompt();
     expect(result).toContain("Identity here");
     expect(result).toContain("Soul here");
-    expect(result).toContain("User here");
   });
 
   test("browser skill activation hints no longer appear in system prompt", () => {


### PR DESCRIPTION
## Summary

- \`PROMPT_FILES\` was narrowed to \`['SOUL.md', 'IDENTITY.md']\` in ce1b3172d, so USER.md content is no longer included in the system prompt.
- The \`dynamic-skill-workflow-prompt.test.ts\` \"prompt is additive\" test was still seeding USER.md and asserting its content appears in the built prompt, which broke the Test job on main.
- Drop the USER.md write and assertion; keep the IDENTITY/SOUL coverage.

## Original prompt

--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24292023452/job/70930863819
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24857" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
