### PR TITLE
fix(ios): resolve duplicate WorkspaceFilesListResponse type

### DIFF
--- a/assistant/src/runtime/routes/settings-routes.ts
+++ b/assistant/src/runtime/routes/settings-routes.ts
@@ -343,7 +343,7 @@ function handleWorkspaceFilesList(): Response {
     name,
     exists: pathExists(join(base, name)),
   }));
-  return Response.json({ files });
+  return Response.json({ type: "workspace_files_list_response", files });
 }
 
 function handleWorkspaceFileRead(requestedPath: string): Response {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityData.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityData.swift
@@ -420,7 +420,7 @@ struct WorkspaceFileNode: Identifiable {
     /// Pure transformation from the server's `workspace-files` response to
     /// the nodes rendered by the identity panel. Factored out for easier
     /// reasoning and future unit testing — contains no I/O.
-    static func buildNodes(from entries: [WorkspaceFilesListEntry]) -> [WorkspaceFileNode] {
+    static func buildNodes(from entries: [WorkspaceFilesListResponseFile]) -> [WorkspaceFileNode] {
         // When the server returns a guardian-resolved `users/<slug>.md`, we
         // suppress the legacy `USER.md` entry so the panel renders a single
         // user-persona node instead of two competing ones.
@@ -457,7 +457,7 @@ struct WorkspaceFileNode: Identifiable {
     /// the guardian's `users/<slug>.md` and the legacy `USER.md` — are shown
     /// as "User Profile" so the UI doesn't surface a slug or legacy filename.
     /// All other entries render their server-provided name verbatim.
-    private static func displayLabel(for entry: WorkspaceFilesListEntry) -> String {
+    private static func displayLabel(for entry: WorkspaceFilesListResponseFile) -> String {
         if isGuardianUserPersonaPath(entry.path) || entry.path == legacyUserPersonaFilename {
             return "User Profile"
         }

--- a/clients/shared/Network/NetworkResponseTypes.swift
+++ b/clients/shared/Network/NetworkResponseTypes.swift
@@ -85,23 +85,3 @@ public struct WorkspaceFileResponse: Codable, Sendable {
         self.isBinary = isBinary
     }
 }
-
-// MARK: - Workspace files list (distinct from tree)
-
-/// A single entry in the `GET /workspace-files` response.
-///
-/// This endpoint is distinct from the workspace tree API: it returns a flat,
-/// server-curated list of the well-known workspace files the UI cares about
-/// (`IDENTITY.md`, `SOUL.md`, the user persona file, `skills/`), including
-/// dynamic entries such as the guardian's per-user persona path at
-/// `users/<slug>.md`.
-public struct WorkspaceFilesListEntry: Codable, Sendable {
-    public let path: String
-    public let name: String
-    public let exists: Bool
-}
-
-/// Response shape from `GET /workspace-files`.
-public struct WorkspaceFilesListResponse: Codable, Sendable {
-    public let files: [WorkspaceFilesListEntry]
-}


### PR DESCRIPTION
## Summary
- Drop manual \`WorkspaceFilesListResponse\`/\`WorkspaceFilesListEntry\` in \`clients/shared/Network/NetworkResponseTypes.swift\`; they collided with the generated types in \`Generated/GeneratedAPITypes.swift\` and broke the iOS build (#24856).
- Update \`IdentityData.swift\` to use the generated \`WorkspaceFilesListResponseFile\`.
- Include \`type: \"workspace_files_list_response\"\` in the \`GET /workspace-files\` HTTP response so JSON decoding into the generated Swift type (which has a required \`type\` field) succeeds.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24292072138/job/70930988597