### PR TITLE
fix: update BatchTranscriber JSDoc to reflect raw error propagation contract

### DIFF
--- a/assistant/src/stt/types.ts
+++ b/assistant/src/stt/types.ts
@@ -87,8 +87,11 @@ export class SttError extends Error {
  * Daemon-hosted batch transcriber contract.
  *
  * Implementations accept a buffer of audio data and return a transcription
- * result. Errors are thrown as `SttError` instances with a normalized category
- * so callers can handle failures uniformly across providers.
+ * result. Errors propagate as raw provider errors (not wrapped in
+ * {@link SttError}) so that callers relying on specific error identities
+ * (e.g. `AbortError` for cancellation) continue to work. Callers that need
+ * normalized error categories should wrap calls with `normalizeSttError()`
+ * from `daemon-batch-transcriber.ts`.
  */
 export interface BatchTranscriber {
   /** Which provider backs this transcriber. */
@@ -98,7 +101,10 @@ export interface BatchTranscriber {
 
   /**
    * Transcribe a chunk of audio.
-   * @throws {SttError} on any transcription failure.
+   *
+   * Rejects with the raw provider error on failure. Use
+   * `normalizeSttError()` to convert to an {@link SttError} with a
+   * structured {@link SttErrorCategory}.
    */
   transcribe(request: SttTranscribeRequest): Promise<SttTranscribeResult>;
 }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for initial-stt-unification.md.

**Gap:** BatchTranscriber JSDoc @throws {SttError} mismatch
**What was expected:** Accurate error contract documentation
**What was found:** JSDoc claimed errors are thrown as SttError but implementation propagates raw errors
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24859" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
