### PR TITLE
fix: use en-US locale for isRecognizerAvailable check in macOS adapter

### DIFF
--- a/clients/macos/vellum-assistant/Features/Voice/SpeechRecognizerAdapter.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/SpeechRecognizerAdapter.swift
@@ -44,7 +44,7 @@ final class AppleSpeechRecognizerAdapter: SpeechRecognizerAdapter {
     }
 
     var isRecognizerAvailable: Bool {
-        guard let recognizer = SFSpeechRecognizer() else { return false }
+        guard let recognizer = SFSpeechRecognizer(locale: Locale(identifier: "en-US")) else { return false }
         return recognizer.isAvailable
     }
 }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for initial-stt-unification.md.

**Gap:** isRecognizerAvailable checks default locale instead of en-US
**What was expected:** Locale-consistent availability check
**What was found:** Used default locale instead of en-US
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24864" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
