### PR TITLE
fix: remove dead STT fields from VoiceQualityProfile

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -1122,7 +1122,6 @@ describe("resolveVoiceQualityProfile", () => {
     const config = AssistantConfigSchema.parse({});
     const profile = resolveVoiceQualityProfile(config);
     expect(profile.ttsProvider).toBe("ElevenLabs");
-    expect(profile.transcriptionProvider).toBe("Deepgram");
   });
 
   test("uses shared elevenlabs.voiceId for voice", () => {
@@ -1152,44 +1151,6 @@ describe("resolveVoiceQualityProfile", () => {
     });
     const profile = resolveVoiceQualityProfile(config);
     expect(profile.voice).toBe("abc123-turbo_v2_5-0.9_0.8_0.9");
-  });
-
-  test("Deepgram defaults speechModel to nova-3 via STT profile adapter", () => {
-    const config = AssistantConfigSchema.parse({});
-    const profile = resolveVoiceQualityProfile(config);
-    expect(profile.transcriptionProvider).toBe("Deepgram");
-    expect(profile.speechModel).toBe("nova-3");
-  });
-
-  test("Google leaves speechModel undefined via STT profile adapter", () => {
-    const config = AssistantConfigSchema.parse({
-      calls: { voice: { transcriptionProvider: "Google" } },
-    });
-    const profile = resolveVoiceQualityProfile(config);
-    expect(profile.transcriptionProvider).toBe("Google");
-    expect(profile.speechModel).toBeUndefined();
-  });
-
-  test("Google strips legacy nova-3 default via STT profile adapter", () => {
-    const config = AssistantConfigSchema.parse({
-      calls: {
-        voice: { transcriptionProvider: "Google", speechModel: "nova-3" },
-      },
-    });
-    const profile = resolveVoiceQualityProfile(config);
-    expect(profile.transcriptionProvider).toBe("Google");
-    expect(profile.speechModel).toBeUndefined();
-  });
-
-  test("Google preserves explicit telephony model via STT profile adapter", () => {
-    const config = AssistantConfigSchema.parse({
-      calls: {
-        voice: { transcriptionProvider: "Google", speechModel: "telephony" },
-      },
-    });
-    const profile = resolveVoiceQualityProfile(config);
-    expect(profile.transcriptionProvider).toBe("Google");
-    expect(profile.speechModel).toBe("telephony");
   });
 });
 

--- a/assistant/src/__tests__/voice-quality.test.ts
+++ b/assistant/src/__tests__/voice-quality.test.ts
@@ -6,7 +6,6 @@ mock.module("../config/loader.js", () => ({
   loadConfig: () => mockConfig,
 }));
 
-import { resolveTelephonySttProfile } from "../calls/stt-profile.js";
 import {
   buildElevenLabsVoiceSpec,
   resolveVoiceQualityProfile,
@@ -62,55 +61,6 @@ describe("buildElevenLabsVoiceSpec", () => {
   });
 });
 
-// ── resolveTelephonySttProfile (adapter unit tests) ─────────────────
-
-describe("resolveTelephonySttProfile", () => {
-  test("Deepgram defaults speechModel to nova-3 when unset", () => {
-    const profile = resolveTelephonySttProfile({
-      transcriptionProvider: "Deepgram",
-      speechModel: undefined,
-    });
-    expect(profile.provider).toBe("Deepgram");
-    expect(profile.speechModel).toBe("nova-3");
-  });
-
-  test("Deepgram preserves explicitly set speechModel", () => {
-    const profile = resolveTelephonySttProfile({
-      transcriptionProvider: "Deepgram",
-      speechModel: "nova-2-phonecall",
-    });
-    expect(profile.provider).toBe("Deepgram");
-    expect(profile.speechModel).toBe("nova-2-phonecall");
-  });
-
-  test("Google leaves speechModel undefined when unset", () => {
-    const profile = resolveTelephonySttProfile({
-      transcriptionProvider: "Google",
-      speechModel: undefined,
-    });
-    expect(profile.provider).toBe("Google");
-    expect(profile.speechModel).toBeUndefined();
-  });
-
-  test("Google treats legacy Deepgram default nova-3 as unset", () => {
-    const profile = resolveTelephonySttProfile({
-      transcriptionProvider: "Google",
-      speechModel: "nova-3",
-    });
-    expect(profile.provider).toBe("Google");
-    expect(profile.speechModel).toBeUndefined();
-  });
-
-  test("Google preserves explicitly set non-legacy speechModel", () => {
-    const profile = resolveTelephonySttProfile({
-      transcriptionProvider: "Google",
-      speechModel: "telephony",
-    });
-    expect(profile.provider).toBe("Google");
-    expect(profile.speechModel).toBe("telephony");
-  });
-});
-
 // ── resolveVoiceQualityProfile ──────────────────────────────────────
 
 describe("resolveVoiceQualityProfile", () => {
@@ -154,7 +104,6 @@ describe("resolveVoiceQualityProfile", () => {
     };
     const profile = resolveVoiceQualityProfile();
     expect(profile.language).toBe("es-MX");
-    expect(profile.transcriptionProvider).toBe("Google");
   });
 
   test("builds voice spec with model and tuning params", () => {
@@ -233,67 +182,5 @@ describe("resolveVoiceQualityProfile", () => {
     };
     const profile = resolveVoiceQualityProfile();
     expect(profile.hints).toEqual(["Vellum", "Nova", "AI assistant"]);
-  });
-
-  test("delegates STT resolution to adapter — Deepgram defaults to nova-3", () => {
-    mockConfig = {
-      elevenlabs: { voiceId: "abc" },
-      calls: {
-        voice: {
-          language: "en-US",
-          transcriptionProvider: "Deepgram",
-        },
-      },
-    };
-    const profile = resolveVoiceQualityProfile();
-    expect(profile.transcriptionProvider).toBe("Deepgram");
-    expect(profile.speechModel).toBe("nova-3");
-  });
-
-  test("delegates STT resolution to adapter — Google leaves speechModel undefined", () => {
-    mockConfig = {
-      elevenlabs: { voiceId: "abc" },
-      calls: {
-        voice: {
-          language: "en-US",
-          transcriptionProvider: "Google",
-        },
-      },
-    };
-    const profile = resolveVoiceQualityProfile();
-    expect(profile.transcriptionProvider).toBe("Google");
-    expect(profile.speechModel).toBeUndefined();
-  });
-
-  test("delegates STT resolution to adapter — Google strips legacy nova-3", () => {
-    mockConfig = {
-      elevenlabs: { voiceId: "abc" },
-      calls: {
-        voice: {
-          language: "en-US",
-          transcriptionProvider: "Google",
-          speechModel: "nova-3",
-        },
-      },
-    };
-    const profile = resolveVoiceQualityProfile();
-    expect(profile.transcriptionProvider).toBe("Google");
-    expect(profile.speechModel).toBeUndefined();
-  });
-
-  test("delegates STT resolution to adapter — Google preserves explicit model", () => {
-    mockConfig = {
-      elevenlabs: { voiceId: "abc" },
-      calls: {
-        voice: {
-          language: "en-US",
-          transcriptionProvider: "Google",
-          speechModel: "telephony",
-        },
-      },
-    };
-    const profile = resolveVoiceQualityProfile();
-    expect(profile.transcriptionProvider).toBe("Google");
-    expect(profile.speechModel).toBe("telephony");
   });
 });

--- a/assistant/src/calls/voice-quality.ts
+++ b/assistant/src/calls/voice-quality.ts
@@ -1,10 +1,7 @@
 import { loadConfig } from "../config/loader.js";
-import { resolveTelephonySttProfile } from "./stt-profile.js";
 
 export interface VoiceQualityProfile {
   language: string;
-  transcriptionProvider: string;
-  speechModel?: string;
   ttsProvider: string;
   voice: string;
   interruptSensitivity: string;
@@ -46,10 +43,6 @@ export function buildElevenLabsVoiceSpec(config: {
 /**
  * Resolve the effective voice quality profile from config.
  *
- * STT provider and speech model selection is delegated to the telephony
- * STT profile adapter (`stt-profile.ts`), which centralizes all
- * provider-specific fallback logic.
- *
  * Supports ElevenLabs (default) and Fish Audio TTS providers.
  * When Fish Audio is selected, `ttsProvider` is set to `"Google"` as a
  * placeholder — ConversationRelay requires a valid provider in TwiML, but
@@ -58,6 +51,11 @@ export function buildElevenLabsVoiceSpec(config: {
  *
  * For ElevenLabs, the voice ID comes from the shared `elevenlabs.voiceId`
  * config (defaults to Amelia — ZF6FPAbjXT4488VcRRnw).
+ *
+ * NOTE: STT provider and speech model are intentionally NOT part of this
+ * profile. STT resolution is handled once in the voice webhook route
+ * (`twilio-routes.ts`) via `resolveTelephonySttProfile()` to maintain a
+ * single point of ownership.
  */
 export function resolveVoiceQualityProfile(
   config?: ReturnType<typeof loadConfig>,
@@ -66,11 +64,8 @@ export function resolveVoiceQualityProfile(
   const voice = cfg.calls.voice;
   const configuredTts = voice.ttsProvider ?? "elevenlabs";
   const fishAudio = configuredTts === "fish-audio";
-  const sttProfile = resolveTelephonySttProfile(voice);
   return {
     language: voice.language,
-    transcriptionProvider: sttProfile.provider,
-    speechModel: sttProfile.speechModel,
     ttsProvider: fishAudio ? "Google" : "ElevenLabs",
     voice: fishAudio ? "" : buildElevenLabsVoiceSpec(cfg.elevenlabs),
     interruptSensitivity: voice.interruptSensitivity ?? "low",


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for initial-stt-unification.md.

**Gap:** Dead STT fields on VoiceQualityProfile + double resolveTelephonySttProfile call
**What was expected:** Single STT resolution point
**What was found:** STT resolved twice, profile fields unused
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24865" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
