### PR TITLE
chore(config-watcher): remove obsolete USER.md handler

### DIFF
--- a/assistant/src/__tests__/config-watcher.test.ts
+++ b/assistant/src/__tests__/config-watcher.test.ts
@@ -157,14 +157,6 @@ describe("ConfigWatcher workspace file handlers", () => {
     expect(evictCallCount).toBe(1);
   });
 
-  test("USER.md change triggers onConversationEvict", async () => {
-    watcher.start(onConversationEvict);
-    simulateFileChange(WORKSPACE_DIR, "USER.md");
-
-    await new Promise((r) => setTimeout(r, 300));
-    expect(evictCallCount).toBe(1);
-  });
-
   test("UPDATES.md change triggers onConversationEvict", async () => {
     watcher.start(onConversationEvict);
     simulateFileChange(WORKSPACE_DIR, "UPDATES.md");

--- a/assistant/src/daemon/config-watcher.ts
+++ b/assistant/src/daemon/config-watcher.ts
@@ -172,7 +172,6 @@ export class ConfigWatcher {
         onConversationEvict();
         onIdentityChanged?.();
       },
-      "USER.md": () => onConversationEvict(),
       "UPDATES.md": () => onConversationEvict(),
     };
 


### PR DESCRIPTION
## Summary
- Drop the `"USER.md"` entry from `workspaceHandlers`; the users/ watcher added in PR 7 is now the canonical hot-reload mechanism.
- Remove the corresponding hot-reload test case.

Part of plan: drop-user-md.md (PR 13 of 17)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24866" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
