### PR TITLE
chore(settings-routes): drop USER.md from workspace files listing

### DIFF
--- a/assistant/src/runtime/routes/settings-routes.test.ts
+++ b/assistant/src/runtime/routes/settings-routes.test.ts
@@ -74,19 +74,19 @@ describe("GET /workspace-files", () => {
     resetContactTables();
   });
 
-  test("with no guardian: returns the static legacy entries only", async () => {
+  test("with no guardian: returns the static entries only", async () => {
     const res = await handler(makeCtx("workspace-files"));
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
       files: Array<{ path: string; name: string; exists: boolean }>;
     };
     const paths = body.files.map((f) => f.path);
-    expect(paths).toEqual(["IDENTITY.md", "SOUL.md", "USER.md", "skills/"]);
+    expect(paths).toEqual(["IDENTITY.md", "SOUL.md", "skills/"]);
     // No guardian → no users/*.md entry.
     expect(paths.find((p) => p.startsWith("users/"))).toBeUndefined();
   });
 
-  test("with a guardian: includes users/<slug>.md alongside legacy USER.md", async () => {
+  test("with a guardian: includes users/<slug>.md", async () => {
     createGuardianBinding({
       channel: "telegram",
       guardianExternalUserId: "Alice",
@@ -102,8 +102,9 @@ describe("GET /workspace-files", () => {
     };
     const paths = body.files.map((f) => f.path);
 
-    // Legacy USER.md entry is still present.
-    expect(paths).toContain("USER.md");
+    // USER.md has been removed — the guardian per-user persona is the sole
+    // user-profile entry.
+    expect(paths).not.toContain("USER.md");
     // Guardian per-user persona is appended.
     expect(paths).toContain("users/alice.md");
 

--- a/assistant/src/runtime/routes/settings-routes.ts
+++ b/assistant/src/runtime/routes/settings-routes.ts
@@ -318,17 +318,13 @@ async function handleOAuthConnectStart(body: {
 /**
  * Build the list of workspace files exposed via the workspace-files endpoint.
  *
- * Returns the static identity/soul/user files plus the guardian's resolved
- * per-user persona file at `users/<slug>.md` when a guardian exists. Callers
- * should invoke this per-request instead of caching, since the guardian can
- * change over the lifetime of the daemon.
- *
- * `USER.md` remains in the list as a legacy transitional entry; a later
- * change will remove it once all readers have migrated to the per-user
- * persona path.
+ * Returns the static identity/soul files and skills directory plus the
+ * guardian's resolved per-user persona file at `users/<slug>.md` when a
+ * guardian exists. Callers should invoke this per-request instead of
+ * caching, since the guardian can change over the lifetime of the daemon.
  */
 function getWorkspaceFiles(): string[] {
-  const files = ["IDENTITY.md", "SOUL.md", "USER.md", "skills/"];
+  const files = ["IDENTITY.md", "SOUL.md", "skills/"];
   const guardianPath = resolveGuardianPersonaPath();
   if (guardianPath) {
     files.push(`users/${basename(guardianPath)}`);


### PR DESCRIPTION
## Summary
- Remove `USER.md` from the dynamic `getWorkspaceFiles()` listing; the guardian's `users/<slug>.md` is the sole user-profile entry.

Part of plan: drop-user-md.md (PR 15 of 17)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24867" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
