### PR TITLE
chore(permissions): remove USER.md from workspace prompt files allowlist

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -1484,14 +1484,6 @@ describe("Permission Checker", () => {
       expect(result.matchedRule!.id).toBe("default:allow-file_edit-identity");
     });
 
-    test("file_read of workspace USER.md is auto-allowed", async () => {
-      const userPath = join(checkerTestDir, "USER.md");
-      const result = await check("file_read", { path: userPath }, "/tmp");
-      expect(result.decision).toBe("allow");
-      expect(result.matchedRule).toBeDefined();
-      expect(result.matchedRule!.id).toBe("default:allow-file_read-user");
-    });
-
     test("file_write of workspace SOUL.md is auto-allowed", async () => {
       const soulPath = join(checkerTestDir, "SOUL.md");
       const result = await check("file_write", { path: soulPath }, "/tmp");
@@ -1543,8 +1535,8 @@ describe("Permission Checker", () => {
     // ── guardian persona file (users/<slug>.md) ──────────────────
     // The drop-user-md migration replaces the legacy workspace USER.md
     // with a per-user persona file at `users/<guardian-slug>.md`. The
-    // dynamic guardian-persona default rules make first-run onboarding
-    // and day-to-day persona edits frictionless.
+    // dynamic guardian-persona default rules are now the sole auto-allow
+    // entry for the per-user profile file.
 
     test("file_edit of guardian users/<slug>.md is auto-allowed", async () => {
       const guardianPath = join(checkerTestDir, "users", "alice.md");

--- a/assistant/src/permissions/defaults.ts
+++ b/assistant/src/permissions/defaults.ts
@@ -119,7 +119,6 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
   const workspaceDir = getWorkspaceDir().replaceAll("\\", "/");
   const WORKSPACE_PROMPT_FILES = [
     "IDENTITY.md",
-    "USER.md",
     "SOUL.md",
     "BOOTSTRAP.md",
     "UPDATES.md",
@@ -143,13 +142,15 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
   // Guardian persona file — the contact-store-resolved `users/<slug>.md`
   // for the current guardian. Once the workspace has a guardian contact,
   // their per-user persona file should be readable/editable without a
-  // prompt, the same way the legacy workspace USER.md is.
+  // prompt. This is the sole auto-allow entry for the per-user profile
+  // file (the legacy workspace `USER.md` was removed).
   //
-  // This is resolved dynamically at template-build time (rather than
-  // hardcoded like WORKSPACE_PROMPT_FILES) because the slug depends on
-  // the installed guardian. The try/catch protects against early-boot
-  // paths where the DB may not yet be initialized — in that case the
-  // legacy workspace USER.md rules still cover onboarding.
+  // Resolved dynamically at template-build time (rather than hardcoded
+  // like WORKSPACE_PROMPT_FILES) because the slug depends on the
+  // installed guardian. The try/catch protects against early-boot paths
+  // where the DB may not yet be initialized — in that case no guardian
+  // persona rules are emitted and the agent will be prompted on first
+  // edit until the guardian contact is created.
   let guardianPersonaRules: DefaultRuleTemplate[] = [];
   try {
     const guardianPath = resolveGuardianPersonaPath();
@@ -165,7 +166,8 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
       }));
     }
   } catch {
-    // Guardian may not exist yet; the workspace prompt rules still cover USER.md during onboarding.
+    // Guardian may not exist yet; rules will be emitted on the next
+    // template build once the guardian contact is created.
   }
 
   const bootstrapDeleteRule: DefaultRuleTemplate = {


### PR DESCRIPTION
## Summary
- Drop `USER.md` from `WORKSPACE_PROMPT_FILES`; the guardian-persona dynamic rule (PR 8) is the sole auto-allow entry for the per-user profile file.

Part of plan: drop-user-md.md (PR 14 of 17)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24868" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
