### PR TITLE
docs: replace USER.md references with users/<slug>.md across docs and skill files

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -989,7 +989,7 @@ if tr '\0' '\n' < "$STAGED_ALL_FILE" | grep -q 'assistant/src/prompts/system-pro
     echo ""
     echo "  • IDENTITY.md    — Name, nature, personality, emoji, role"
     echo "  • SOUL.md        — Core principles, personality, quirks, boundaries"
-    echo "  • USER.md        — User profile and preferences"
+    echo "  • users/<slug>.md — User profile and preferences (per-user persona file)"
     echo "  • LOOKS.md       — Avatar appearance and outfit"
     echo "  • BOOTSTRAP.md   — First-run onboarding ritual instructions"
     echo "  • skills/        — Skill-specific instructions (SKILL.md per skill)"

--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -7,7 +7,7 @@ This document owns assistant-runtime architecture details. The repo-level archit
 - Transport metadata arrives via `conversation_create.transport` (HTTP) or `/channels/inbound` (`channelId`, optional `hints`, optional `uxBrief`).
 - Telegram webhook ingress injects deterministic channel-safe transport metadata (`hints` + `uxBrief`) so non-dashboard channels defer dashboard-only UI tasks cleanly.
 - `OnboardingPlaybookManager` resolves `<channel>_onboarding.md`, checks `onboarding/playbooks/registry.json`, and applies per-channel first-time fast-path onboarding.
-- `OnboardingOrchestrator` derives onboarding-mode guidance (post-hatch sequence, USER.md capture) from playbook + transport context.
+- `OnboardingOrchestrator` derives onboarding-mode guidance (post-hatch sequence, `users/<slug>.md` persona capture) from playbook + transport context.
 - Conversation runtime assembly injects both `<channel_onboarding_playbook>` and `<onboarding_mode>` context before provider calls, then strips both from persisted conversation history.
 - Permission setup remains user-initiated and hatch + first-conversation flows avoid proactive permission asks.
 

--- a/assistant/src/config/bundled-skills/messaging/SKILL.md
+++ b/assistant/src/config/bundled-skills/messaging/SKILL.md
@@ -17,7 +17,7 @@ You are a unified messaging assistant with access to multiple platforms (Gmail, 
 
 ## External Identity
 
-When composing messages on behalf of your user to external recipients, refer to yourself as an "assistant" (not "AI assistant"). Use your user's name and pronouns from USER.md. Don't volunteer that you are an AI unless directly asked.
+When composing messages on behalf of your user to external recipients, refer to yourself as an "assistant" (not "AI assistant"). Use your user's name and pronouns from their user persona file (`users/<slug>.md`). Don't volunteer that you are an AI unless directly asked.
 
 For Email management (archive, label, triage, declutter), load the **gmail** or **outlook** skill. For email sequences, load the **sequences** skill.
 

--- a/assistant/src/config/bundled-skills/phone-calls/SKILL.md
+++ b/assistant/src/config/bundled-skills/phone-calls/SKILL.md
@@ -21,7 +21,7 @@ You are helping the user set up and manage phone calls via Twilio. This skill co
 
 ## External Identity
 
-When speaking on behalf of your user during calls, refer to yourself as an "assistant" (not "AI assistant"). Use your user's name and pronouns from USER.md. Don't volunteer that you are an AI unless directly asked.
+When speaking on behalf of your user during calls, refer to yourself as an "assistant" (not "AI assistant"). Use your user's name and pronouns from their user persona file (`users/<slug>.md`). Don't volunteer that you are an AI unless directly asked.
 
 # Overview
 

--- a/skills/email-setup/SKILL.md
+++ b/skills/email-setup/SKILL.md
@@ -33,7 +33,7 @@ Create a new inbox through the CLI:
 assistant email inbox create --username <your-username>
 ```
 
-For `<your-username>`, use your assistant name (lowercased, alphanumeric only). Check your identity from `IDENTITY.md` or `USER.md` to determine your name. If you don't have a name yet, ask the user what username they'd like for your email.
+For `<your-username>`, use your assistant name (lowercased, alphanumeric only). Check your identity from `IDENTITY.md` or your user persona file (`users/<slug>.md`) to determine your name. If you don't have a name yet, ask the user what username they'd like for your email.
 
 Use the returned `inbox.address` (or `inbox.id` if `address` is empty) as the created email address.
 
@@ -50,7 +50,7 @@ Confirm the created inbox appears in `health.inboxes`.
 After the inbox is created and visible in status:
 
 1. Tell the user your new email address.
-2. Store a note in your memory or `USER.md` that your email has been provisioned so you remember it in future conversations.
+2. Store a note in your memory or the user persona file (`users/<slug>.md`) that your email has been provisioned so you remember it in future conversations.
 
 ## Rules
 


### PR DESCRIPTION
## Summary
- Update ARCHITECTURE.md, bundled/first-party skill descriptions, and .githooks/pre-commit help text to reference `users/<slug>.md` instead of the legacy `USER.md`.
- Prose-only changes; no code paths affected.

Part of plan: drop-user-md.md (PR 16 of 17)