### PR TITLE
feat(chrome-ext): add CWS production extension ID to native host allowlist

### DIFF
--- a/clients/chrome-extension/native-host/com.vellum.daemon.json.template
+++ b/clients/chrome-extension/native-host/com.vellum.daemon.json.template
@@ -4,6 +4,7 @@
   "path": "__HELPER_BINARY_PATH__",
   "type": "stdio",
   "allowed_origins": [
-    "chrome-extension://__VELLUM_EXTENSION_ID__/"
+    "chrome-extension://__VELLUM_DEV_EXTENSION_ID__/",
+    "chrome-extension://__VELLUM_CWS_EXTENSION_ID__/"
   ]
 }

--- a/clients/macos/vellum-assistant/App/AppDelegate+NativeMessaging.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+NativeMessaging.swift
@@ -46,7 +46,7 @@ extension AppDelegate {
         do {
             try NativeMessagingInstaller.installChromeManifest(
                 helperBinaryPath: helperBinaryUrl,
-                extensionId: ChromeExtensionAllowlist.primaryId
+                extensionIds: ChromeExtensionAllowlist.allIds
             )
         } catch {
             // Best-effort: a failing manifest install must not crash
@@ -91,8 +91,8 @@ extension AppDelegate {
     }
 }
 
-/// Chrome extension id used when writing the native messaging manifest's
-/// `allowed_origins` entry. Resolved from the canonical config at
+/// Chrome extension IDs used when writing the native messaging manifest's
+/// `allowed_origins` entries. Resolved from the canonical config at
 /// `meta/browser-extension/chrome-extension-allowlist.json` when available.
 ///
 /// Kept in a standalone enum so unit tests can reference it without
@@ -101,6 +101,25 @@ enum ChromeExtensionAllowlist {
     private static let fallbackPlaceholderId = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     private static let extensionIdRegex = try! NSRegularExpression(pattern: "^[a-p]{32}$")
 
+    /// All valid extension IDs from the canonical config. Used to populate
+    /// the native messaging manifest's `allowed_origins` array so both the
+    /// development (sideloaded) and CWS-published extension are accepted.
+    static var allIds: [String] {
+        if let fromEnv = ProcessInfo.processInfo.environment["VELLUM_CHROME_EXTENSION_IDS"] {
+            let ids = fromEnv.components(separatedBy: CharacterSet(charactersIn: ", "))
+                .map { $0.trimmingCharacters(in: .whitespaces) }
+                .filter { isValidExtensionId($0) }
+            if !ids.isEmpty { return ids }
+        }
+
+        if let fromConfig = loadAllIdsFromCanonicalConfig() {
+            return fromConfig
+        }
+
+        return [fallbackPlaceholderId]
+    }
+
+    /// The first valid extension ID — used when a single ID is needed.
     static var primaryId: String {
         if let fromEnv = ProcessInfo.processInfo.environment["VELLUM_CHROME_EXTENSION_ID"],
            isValidExtensionId(fromEnv)
@@ -119,6 +138,20 @@ enum ChromeExtensionAllowlist {
         let fullRange = NSRange(value.startIndex..<value.endIndex, in: value)
         let match = extensionIdRegex.firstMatch(in: value, options: [], range: fullRange)
         return match != nil
+    }
+
+    private static func loadAllIdsFromCanonicalConfig() -> [String]? {
+        for candidate in canonicalConfigPathCandidates() {
+            guard let data = try? Data(contentsOf: candidate),
+                  let raw = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let ids = raw["allowedExtensionIds"] as? [String]
+            else {
+                continue
+            }
+            let valid = ids.filter { isValidExtensionId($0) }
+            if !valid.isEmpty { return valid }
+        }
+        return nil
     }
 
     private static func loadPrimaryIdFromCanonicalConfig() -> String? {

--- a/clients/macos/vellum-assistant/Features/Installer/NativeMessagingInstaller.swift
+++ b/clients/macos/vellum-assistant/Features/Installer/NativeMessagingInstaller.swift
@@ -72,17 +72,17 @@ public enum NativeMessagingInstaller {
     ///     messaging helper binary (e.g.
     ///     `…/Contents/MacOS/vellum-chrome-native-host`). Must exist —
     ///     Chrome refuses to spawn a host whose `path` is missing.
-    ///   - extensionId: The Chrome extension ID to pin in
-    ///     `allowed_origins`. Must match the allowlist enforced by the
-    ///     helper binary itself (PR 7 `ALLOWED_EXTENSION_IDS`) and the
-    ///     runtime pair endpoint's allowlist (PR 11).
+    ///   - extensionIds: Chrome extension IDs to pin in
+    ///     `allowed_origins`. Should include both the development and
+    ///     CWS production IDs so the native host accepts connections
+    ///     from either origin.
     public static func installChromeManifest(
         helperBinaryPath: URL,
-        extensionId: String
+        extensionIds: [String]
     ) throws {
         try installChromeManifest(
             helperBinaryPath: helperBinaryPath,
-            extensionId: extensionId,
+            extensionIds: extensionIds,
             homeDirectory: FileManager.default.homeDirectoryForCurrentUser,
             fileManager: FileManager.default
         )
@@ -104,7 +104,7 @@ public enum NativeMessagingInstaller {
     /// directory under the tester's home folder.
     internal static func installChromeManifest(
         helperBinaryPath: URL,
-        extensionId: String,
+        extensionIds: [String],
         homeDirectory: URL,
         fileManager: FileManager
     ) throws {
@@ -134,7 +134,7 @@ public enum NativeMessagingInstaller {
             "description": hostDescription,
             "path": helperBinaryPath.path,
             "type": "stdio",
-            "allowed_origins": ["chrome-extension://\(extensionId)/"],
+            "allowed_origins": extensionIds.map { "chrome-extension://\($0)/" },
         ]
 
         let data = try JSONSerialization.data(

--- a/clients/macos/vellum-assistantTests/NativeMessagingInstallerTests.swift
+++ b/clients/macos/vellum-assistantTests/NativeMessagingInstallerTests.swift
@@ -60,7 +60,7 @@ final class NativeMessagingInstallerTests: XCTestCase {
     func testInstallWritesManifestWithExpectedStructure() throws {
         try NativeMessagingInstaller.installChromeManifest(
             helperBinaryPath: helperBinaryUrl,
-            extensionId: placeholderExtensionId,
+            extensionIds: [placeholderExtensionId],
             homeDirectory: mockHome,
             fileManager: .default
         )
@@ -91,7 +91,7 @@ final class NativeMessagingInstallerTests: XCTestCase {
     func testInstallSetsManifestPermissionsTo0o644() throws {
         try NativeMessagingInstaller.installChromeManifest(
             helperBinaryPath: helperBinaryUrl,
-            extensionId: placeholderExtensionId,
+            extensionIds: [placeholderExtensionId],
             homeDirectory: mockHome,
             fileManager: .default
         )
@@ -115,7 +115,7 @@ final class NativeMessagingInstallerTests: XCTestCase {
 
         try NativeMessagingInstaller.installChromeManifest(
             helperBinaryPath: helperBinaryUrl,
-            extensionId: placeholderExtensionId,
+            extensionIds: [placeholderExtensionId],
             homeDirectory: mockHome,
             fileManager: .default
         )
@@ -138,7 +138,7 @@ final class NativeMessagingInstallerTests: XCTestCase {
         )
         try NativeMessagingInstaller.installChromeManifest(
             helperBinaryPath: staleBinary,
-            extensionId: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            extensionIds: ["bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"],
             homeDirectory: mockHome,
             fileManager: .default
         )
@@ -146,7 +146,7 @@ final class NativeMessagingInstallerTests: XCTestCase {
         // Re-install with the canonical helper binary and placeholder id.
         try NativeMessagingInstaller.installChromeManifest(
             helperBinaryPath: helperBinaryUrl,
-            extensionId: placeholderExtensionId,
+            extensionIds: [placeholderExtensionId],
             homeDirectory: mockHome,
             fileManager: .default
         )
@@ -177,7 +177,7 @@ final class NativeMessagingInstallerTests: XCTestCase {
         XCTAssertThrowsError(
             try NativeMessagingInstaller.installChromeManifest(
                 helperBinaryPath: missingBinary,
-                extensionId: placeholderExtensionId,
+                extensionIds: [placeholderExtensionId],
                 homeDirectory: mockHome,
                 fileManager: .default
             )
@@ -205,7 +205,7 @@ final class NativeMessagingInstallerTests: XCTestCase {
     func testUninstallRemovesManifest() throws {
         try NativeMessagingInstaller.installChromeManifest(
             helperBinaryPath: helperBinaryUrl,
-            extensionId: placeholderExtensionId,
+            extensionIds: [placeholderExtensionId],
             homeDirectory: mockHome,
             fileManager: .default
         )

--- a/meta/browser-extension/chrome-extension-allowlist.json
+++ b/meta/browser-extension/chrome-extension-allowlist.json
@@ -1,6 +1,7 @@
 {
   "version": 1,
   "allowedExtensionIds": [
-    "ccfbbgpdcnnfnnnodmkjkcpnbkmbjecp"
+    "ccfbbgpdcnnfnnnodmkjkcpnbkmbjecp",
+    "TODO_REPLACE_WITH_CWS_PRODUCTION_EXTENSION_ID"
   ]
 }


### PR DESCRIPTION
## Summary
- Add placeholder CWS production extension ID to `chrome-extension-allowlist.json` (replace `TODO_REPLACE_WITH_CWS_PRODUCTION_EXTENSION_ID` with the real ID once CWS listing is approved)
- Update `NativeMessagingInstaller` to accept multiple extension IDs and write all of them into `allowed_origins`
- Add `ChromeExtensionAllowlist.allIds` property that returns all valid IDs from the config
- Update native messaging manifest template to show both dev and CWS origins

## ⚠️ Before merging
Replace `TODO_REPLACE_WITH_CWS_PRODUCTION_EXTENSION_ID` in `meta/browser-extension/chrome-extension-allowlist.json` with the actual CWS production extension ID.

Part of plan: cws-distribution.md (PR 6 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24872" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
