### PR TITLE
fix(migrations,test): inline 017 template snapshot and move settings-routes test to discoverable location

### DIFF
--- a/assistant/src/__tests__/settings-routes.test.ts
+++ b/assistant/src/__tests__/settings-routes.test.ts
@@ -10,16 +10,16 @@ import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-mock.module("../../util/logger.js", () => ({
+mock.module("../util/logger.js", () => ({
   getLogger: () =>
     new Proxy({} as Record<string, unknown>, {
       get: () => () => {},
     }),
 }));
 
-import { createGuardianBinding } from "../../contacts/contacts-write.js";
-import { getSqlite, initializeDb } from "../../memory/db.js";
-import { settingsRouteDefinitions } from "./settings-routes.js";
+import { createGuardianBinding } from "../contacts/contacts-write.js";
+import { getSqlite, initializeDb } from "../memory/db.js";
+import { settingsRouteDefinitions } from "../runtime/routes/settings-routes.js";
 
 initializeDb();
 

--- a/assistant/src/workspace/migrations/017-seed-persona-dirs.ts
+++ b/assistant/src/workspace/migrations/017-seed-persona-dirs.ts
@@ -13,9 +13,71 @@ import { desc, eq } from "drizzle-orm";
 import { generateUserFileSlug } from "../../contacts/contact-store.js";
 import { getDb } from "../../memory/db.js";
 import { contacts } from "../../memory/schema/contacts.js";
-import { isTemplateContent } from "../../prompts/system-prompt.js";
-import { stripCommentLines } from "../../util/strip-comment-lines.js";
 import type { WorkspaceMigration } from "./types.js";
+
+// ── Inlined helpers ───────────────────────────────────────────────
+//
+// Per migrations/AGENTS.md, migrations must be self-contained. The
+// helpers below are duplicated inline (rather than imported from
+// `util/strip-comment-lines.js` or `prompts/system-prompt.js`) so this
+// migration does not regress if those modules change — or, in the case
+// of the legacy `templates/USER.md` template file, disappear entirely.
+// Migration 031-drop-user-md deletes that template file, and previously
+// this migration's unmodified-template check silently started copying
+// bare scaffolds once the template was gone.
+
+/**
+ * Strip lines starting with `_` (comment convention for prompt .md files)
+ * and collapse any resulting consecutive blank lines. Copied from
+ * `util/strip-comment-lines.ts` to keep this migration self-contained.
+ */
+function stripCommentLines(content: string): string {
+  const normalized = content.replace(/\r\n/g, "\n");
+  let openFenceChar: string | null = null;
+  const filtered = normalized.split("\n").filter((line) => {
+    const fenceMatch = line.match(/^ {0,3}(`{3,}|~{3,})/);
+    if (fenceMatch) {
+      const char = fenceMatch[1][0];
+      if (!openFenceChar) {
+        openFenceChar = char;
+      } else if (char === openFenceChar) {
+        openFenceChar = null;
+      }
+    }
+    if (openFenceChar) return true;
+    return !line.trimStart().startsWith("_");
+  });
+  return filtered
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+/**
+ * Frozen snapshot of the legacy `templates/USER.md` contents that
+ * shipped at the time this migration was authored. Used to detect
+ * unmodified template installs so we don't copy a useless scaffold
+ * into `users/<slug>.md`. The template file itself is deleted by
+ * migration 031, so we cannot read it from disk here.
+ */
+const LEGACY_USER_MD_TEMPLATE = `_ Lines starting with _ are comments - they won't appear in the system prompt
+
+# USER.md
+
+Store details about your user here. Edit freely - build this over time as you learn about them. Don't be pushy about seeking details, but when you learn something, write it down. More context makes you more useful.
+
+- Preferred name/reference:
+- Pronouns:
+- Locale:
+- Work role:
+- Goals:
+- Hobbies/fun:
+- Daily tools:
+`;
+
+const LEGACY_USER_MD_TEMPLATE_STRIPPED = stripCommentLines(
+  LEGACY_USER_MD_TEMPLATE,
+);
 
 export const seedPersonaDirsMigration: WorkspaceMigration = {
   id: "017-seed-persona-dirs",
@@ -55,8 +117,10 @@ export const seedPersonaDirsMigration: WorkspaceMigration = {
     const content = stripCommentLines(rawContent);
     if (!content) return;
 
-    // Skip if the content is the unmodified template
-    if (isTemplateContent(content, "USER.md")) return;
+    // Skip if the content is the unmodified legacy template. We compare
+    // against an inlined snapshot rather than reading the bundled
+    // template from disk, since migration 031 deletes that template file.
+    if (content === LEGACY_USER_MD_TEMPLATE_STRIPPED) return;
 
     // Determine destination filename based on guardian contact
     let destFilename = "guardian.md";


### PR DESCRIPTION
## Summary
Two post-plan fixes from the drop-user-md review:

1. **Migration 017 template check**: `017-seed-persona-dirs.ts` relied on `isTemplateContent(content, 'USER.md')`, which reads `assistant/src/prompts/templates/USER.md` — a file deleted by migration 031 (drop-user-md). Inline the legacy template snapshot directly in 017 to make it self-contained, per the migrations AGENTS.md rule.

2. **CI test discovery**: The new `settings-routes.test.ts` (PR 9 from drop-user-md) was placed in `src/runtime/routes/`, outside the `src/__tests__/` tree that `scripts/test.sh` discovers. Move it so CI runs it.

Fixes gaps identified during drop-user-md plan review.