### PR TITLE
fix(btw-sidechain): thread userSlug into buildSystemPrompt to avoid default fallback

### DIFF
--- a/assistant/src/__tests__/btw-routes.test.ts
+++ b/assistant/src/__tests__/btw-routes.test.ts
@@ -62,9 +62,15 @@ mock.module("../prompts/system-prompt.js", () => ({
 }));
 
 mock.module("../prompts/persona-resolver.js", () => ({
+  resolvePersonaContext: () => ({
+    userPersona: null,
+    userSlug: null,
+    channelPersona: null,
+  }),
   resolveGuardianPersona: () => null,
   resolveChannelPersona: () => null,
   resolveUserPersona: () => null,
+  resolveUserSlug: () => null,
 }));
 
 // ---------------------------------------------------------------------------
@@ -313,6 +319,7 @@ describe("POST /v1/btw", () => {
       channelPersona: null,
       excludeBootstrap: true,
       userPersona: null,
+      userSlug: null,
     });
 
     // Options: tool_choice must be "none"

--- a/assistant/src/runtime/btw-sidechain.ts
+++ b/assistant/src/runtime/btw-sidechain.ts
@@ -35,6 +35,7 @@ export interface RunBtwSidechainParams {
   onEvent?: (event: ProviderEvent) => void;
   userPersona?: string | null;
   channelPersona?: string | null;
+  userSlug?: string | null;
 }
 
 export interface RunBtwSidechainResult {
@@ -70,6 +71,7 @@ export async function runBtwSidechain(
           excludeBootstrap: true,
           userPersona: params.userPersona,
           channelPersona: params.channelPersona,
+          userSlug: params.userSlug,
         }));
 
   const { signal: timeoutSignal, cleanup } = createTimeout(

--- a/assistant/src/runtime/routes/btw-routes.ts
+++ b/assistant/src/runtime/routes/btw-routes.ts
@@ -19,10 +19,7 @@ import { z } from "zod";
 import { getConfig } from "../../config/loader.js";
 import { readNowScratchpad } from "../../daemon/conversation-runtime-assembly.js";
 import { getConversationByKey } from "../../memory/conversation-key-store.js";
-import {
-  resolveChannelPersona,
-  resolveGuardianPersona,
-} from "../../prompts/persona-resolver.js";
+import { resolvePersonaContext } from "../../prompts/persona-resolver.js";
 import { getLogger } from "../../util/logger.js";
 import { getWorkspacePromptPath } from "../../util/platform.js";
 import type { AuthContext } from "../auth/types.js";
@@ -168,14 +165,19 @@ async function handleBtw(
         try {
           const isIntroRequest = conversationKey === IDENTITY_INTRO_KEY;
           const isGreeting = conversationKey === GREETING_KEY;
-          const userPersona = resolveGuardianPersona();
-          const channelPersona = resolveChannelPersona(undefined);
+          // Resolve guardian persona context (undefined trustContext triggers
+          // the guardian lookup path in persona-resolver). Thread userSlug
+          // through so buildSystemPrompt's BOOTSTRAP.md placeholder never
+          // falls back to "default.md" if excludeBootstrap is ever flipped.
+          const { userPersona, userSlug, channelPersona } =
+            resolvePersonaContext(undefined, undefined);
           const result = await runBtwSidechain({
             content: effectiveContent,
             conversation,
             signal: req.signal,
             userPersona,
             channelPersona,
+            userSlug,
             ...(isGreeting
               ? { modelIntent: getConfig().ui.greetingModelIntent }
               : {}),


### PR DESCRIPTION
## Summary
Post-plan fix from the drop-user-md review:
- `btw-sidechain.ts` calls `buildSystemPrompt` with `userPersona` but not `userSlug`. Today this is masked by `excludeBootstrap: true`, but if that flag ever flips, BTW prompts would silently reference `users/default.md` instead of the guardian's real persona file.
- Thread `userSlug` through defensively via `resolvePersonaContext`.

Fixes one gap identified during drop-user-md plan review.