### PR TITLE
feat(ci): dynamically inject CWS extension ID from GitHub variable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1366,12 +1366,6 @@ jobs:
             meta/browser-extension/chrome-extension-allowlist.json > tmp.json \
             && mv tmp.json meta/browser-extension/chrome-extension-allowlist.json
 
-      - name: Build extension ID CSV for compiled binaries
-        working-directory: .
-        run: |
-          IDS_CSV=$(jq -r '.allowedExtensionIds | join(",")' meta/browser-extension/chrome-extension-allowlist.json)
-          echo "CHROME_EXTENSION_IDS_CSV=$IDS_CSV" >> "$GITHUB_ENV"
-
       - name: Select Xcode 26.2
         run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
 
@@ -1748,12 +1742,6 @@ jobs:
             '.allowedExtensionIds += [$id]' \
             meta/browser-extension/chrome-extension-allowlist.json > tmp.json \
             && mv tmp.json meta/browser-extension/chrome-extension-allowlist.json
-
-      - name: Build extension ID CSV for compiled binaries
-        working-directory: .
-        run: |
-          IDS_CSV=$(jq -r '.allowedExtensionIds | join(",")' meta/browser-extension/chrome-extension-allowlist.json)
-          echo "CHROME_EXTENSION_IDS_CSV=$IDS_CSV" >> "$GITHUB_ENV"
 
       - name: Select Xcode 26.2
         run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1354,8 +1354,18 @@ jobs:
       DMG_PATH: build/vellum-assistant.dmg
       KEYCHAIN_NAME: build.keychain
       KEYCHAIN_PASSWORD: temporary-ci-password
+      CHROME_EXTENSION_IDS_CSV: ${{ vars.CWS_EXTENSION_ID != '' && format('ccfbbgpdcnnfnnnodmkjkcpnbkmbjecp,{0}', vars.CWS_EXTENSION_ID) || 'ccfbbgpdcnnfnnnodmkjkcpnbkmbjecp' }}
     steps:
       - uses: actions/checkout@v6
+
+      - name: Inject CWS extension ID into allowlist
+        if: vars.CWS_EXTENSION_ID != ''
+        working-directory: .
+        run: |
+          jq --arg id "${{ vars.CWS_EXTENSION_ID }}" \
+            '.allowedExtensionIds += [$id]' \
+            meta/browser-extension/chrome-extension-allowlist.json > tmp.json \
+            && mv tmp.json meta/browser-extension/chrome-extension-allowlist.json
 
       - name: Select Xcode 26.2
         run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
@@ -1722,8 +1732,18 @@ jobs:
       DMG_PATH: build/vellum-assistant-x64.dmg
       KEYCHAIN_NAME: build-x64.keychain
       KEYCHAIN_PASSWORD: temporary-ci-password
+      CHROME_EXTENSION_IDS_CSV: ${{ vars.CWS_EXTENSION_ID != '' && format('ccfbbgpdcnnfnnnodmkjkcpnbkmbjecp,{0}', vars.CWS_EXTENSION_ID) || 'ccfbbgpdcnnfnnnodmkjkcpnbkmbjecp' }}
     steps:
       - uses: actions/checkout@v6
+
+      - name: Inject CWS extension ID into allowlist
+        if: vars.CWS_EXTENSION_ID != ''
+        working-directory: .
+        run: |
+          jq --arg id "${{ vars.CWS_EXTENSION_ID }}" \
+            '.allowedExtensionIds += [$id]' \
+            meta/browser-extension/chrome-extension-allowlist.json > tmp.json \
+            && mv tmp.json meta/browser-extension/chrome-extension-allowlist.json
 
       - name: Select Xcode 26.2
         run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1354,7 +1354,6 @@ jobs:
       DMG_PATH: build/vellum-assistant.dmg
       KEYCHAIN_NAME: build.keychain
       KEYCHAIN_PASSWORD: temporary-ci-password
-      CHROME_EXTENSION_IDS_CSV: ${{ vars.CWS_EXTENSION_ID != '' && format('ccfbbgpdcnnfnnnodmkjkcpnbkmbjecp,{0}', vars.CWS_EXTENSION_ID) || 'ccfbbgpdcnnfnnnodmkjkcpnbkmbjecp' }}
     steps:
       - uses: actions/checkout@v6
 
@@ -1366,6 +1365,12 @@ jobs:
             '.allowedExtensionIds += [$id]' \
             meta/browser-extension/chrome-extension-allowlist.json > tmp.json \
             && mv tmp.json meta/browser-extension/chrome-extension-allowlist.json
+
+      - name: Build extension ID CSV for compiled binaries
+        working-directory: .
+        run: |
+          IDS_CSV=$(jq -r '.allowedExtensionIds | join(",")' meta/browser-extension/chrome-extension-allowlist.json)
+          echo "CHROME_EXTENSION_IDS_CSV=$IDS_CSV" >> "$GITHUB_ENV"
 
       - name: Select Xcode 26.2
         run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
@@ -1732,7 +1737,6 @@ jobs:
       DMG_PATH: build/vellum-assistant-x64.dmg
       KEYCHAIN_NAME: build-x64.keychain
       KEYCHAIN_PASSWORD: temporary-ci-password
-      CHROME_EXTENSION_IDS_CSV: ${{ vars.CWS_EXTENSION_ID != '' && format('ccfbbgpdcnnfnnnodmkjkcpnbkmbjecp,{0}', vars.CWS_EXTENSION_ID) || 'ccfbbgpdcnnfnnnodmkjkcpnbkmbjecp' }}
     steps:
       - uses: actions/checkout@v6
 
@@ -1744,6 +1748,12 @@ jobs:
             '.allowedExtensionIds += [$id]' \
             meta/browser-extension/chrome-extension-allowlist.json > tmp.json \
             && mv tmp.json meta/browser-extension/chrome-extension-allowlist.json
+
+      - name: Build extension ID CSV for compiled binaries
+        working-directory: .
+        run: |
+          IDS_CSV=$(jq -r '.allowedExtensionIds | join(",")' meta/browser-extension/chrome-extension-allowlist.json)
+          echo "CHROME_EXTENSION_IDS_CSV=$IDS_CSV" >> "$GITHUB_ENV"
 
       - name: Select Xcode 26.2
         run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer

--- a/meta/browser-extension/chrome-extension-allowlist.json
+++ b/meta/browser-extension/chrome-extension-allowlist.json
@@ -1,7 +1,6 @@
 {
   "version": 1,
   "allowedExtensionIds": [
-    "ccfbbgpdcnnfnnnodmkjkcpnbkmbjecp",
-    "TODO_REPLACE_WITH_CWS_PRODUCTION_EXTENSION_ID"
+    "ccfbbgpdcnnfnnnodmkjkcpnbkmbjecp"
   ]
 }


### PR DESCRIPTION
## Summary
- Remove hardcoded placeholder CWS extension ID from allowlist JSON (revert to dev ID only)
- Add `Inject CWS extension ID into allowlist` step to both macOS build jobs that uses `jq` to append `vars.CWS_EXTENSION_ID` to the allowlist at build time
- Set `CHROME_EXTENSION_IDS_CSV` env var on both macOS builds so compiled Bun binaries (native host, daemon, CLI) also have the CWS ID baked in
- Both injection paths are no-ops when `CWS_EXTENSION_ID` is not set

## Original prompt
Update the CWS extension ID injection to be dynamic: revert the placeholder from the allowlist JSON (keep only the dev ID), and add a step to release.yml that injects vars.CWS_EXTENSION_ID into the allowlist JSON before the macOS builds. This way the CWS ID is managed entirely through GitHub configuration, no hardcoded placeholder needed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24875" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
