### PR TITLE
chore(drop-user-md): clean up stale USER.md references in comments, tests, and macOS client

### DIFF
--- a/assistant/src/__tests__/conversation-init.benchmark.test.ts
+++ b/assistant/src/__tests__/conversation-init.benchmark.test.ts
@@ -44,7 +44,6 @@ writeFileSync(
   "# Test Identity\nYou are a test assistant.",
 );
 writeFileSync(join(testDir, "SOUL.md"), "# Test Soul\nBe helpful.");
-writeFileSync(join(testDir, "USER.md"), "# Test User\nName: Benchmark Runner");
 
 // Create real skill directories so projectSkillTools can load them from the catalog
 const testSkillIds = ["bench-skill-a", "bench-skill-b", "bench-skill-c"];

--- a/assistant/src/__tests__/platform.test.ts
+++ b/assistant/src/__tests__/platform.test.ts
@@ -119,6 +119,5 @@ describe("workspace path primitives", () => {
     expect(getWorkspaceHooksDir()).toBe(join(ws, "hooks"));
     expect(getWorkspacePromptPath("IDENTITY.md")).toBe(join(ws, "IDENTITY.md"));
     expect(getWorkspacePromptPath("SOUL.md")).toBe(join(ws, "SOUL.md"));
-    expect(getWorkspacePromptPath("USER.md")).toBe(join(ws, "USER.md"));
   });
 });

--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -44,7 +44,7 @@ mock.module("../daemon/identity-helpers.js", () => ({
   getAssistantName: () => mockAssistantName,
 }));
 
-// ── User-reference mock (isolate from real USER.md) ──────────────────
+// ── User-reference mock (isolate from real guardian persona) ────────
 
 let mockUserReference = "my human";
 // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -4156,7 +4156,7 @@ describe("relay-server", () => {
 
   // ── resolveGuardianLabel resolution priority ─────────────────────────
 
-  test("guardian label: USER.md name takes precedence over Contact.displayName", async () => {
+  test("guardian label: guardian persona name takes precedence over Contact.displayName", async () => {
     mockUserReference = "Alice";
 
     // Create a guardian binding with a different displayName
@@ -4190,7 +4190,7 @@ describe("relay-server", () => {
 
     expect(relay.getConnectionState()).toBe("awaiting_name");
 
-    // The greeting should use the USER.md name ("Alice"), not Contact.displayName ("Bob")
+    // The greeting should use the guardian persona name ("Alice"), not Contact.displayName ("Bob")
     const textMessages = ws.sentMessages
       .map((raw) => JSON.parse(raw) as { type: string; token?: string })
       .filter((m) => m.type === "text");
@@ -4201,7 +4201,7 @@ describe("relay-server", () => {
     relay.destroy();
   });
 
-  test("guardian label: Contact.displayName used when USER.md is empty", async () => {
+  test("guardian label: Contact.displayName used when guardian persona name is empty", async () => {
     mockUserReference = "my human";
 
     // Create a guardian binding with a displayName
@@ -4245,7 +4245,7 @@ describe("relay-server", () => {
     relay.destroy();
   });
 
-  test("guardian label: DEFAULT_USER_REFERENCE used when both USER.md and Contact.displayName are empty", async () => {
+  test("guardian label: DEFAULT_USER_REFERENCE used when both guardian persona name and Contact.displayName are empty", async () => {
     mockUserReference = "my human";
 
     // No guardian binding — no Contact.displayName available

--- a/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
+++ b/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
@@ -621,11 +621,11 @@ describe("ToolExecutor lifecycle events", () => {
     expect(events.map((e) => e.type)).toEqual(["start", "executed"]);
   });
 
-  test("file_edit to USER.md emits permission_prompt under forcePromptSideEffects", async () => {
-    // Security invariant: editing USER.md in a private thread must always
-    // prompt, even when a trust rule would auto-allow.
+  test("file_edit to guardian persona emits permission_prompt under forcePromptSideEffects", async () => {
+    // Security invariant: editing the guardian persona file in a private
+    // thread must always prompt, even when a trust rule would auto-allow.
     checkerDecision = "allow";
-    checkerReason = "Matched trust rule: file_edit:*/USER.md";
+    checkerReason = "Matched trust rule: file_edit:*/users/*.md";
     checkerRisk = "low";
     promptDecision = "allow";
 
@@ -635,7 +635,7 @@ describe("ToolExecutor lifecycle events", () => {
     const result = await executor.execute(
       "file_edit",
       {
-        path: "/Users/sidd/.vellum/workspace/USER.md",
+        path: "/Users/sidd/.vellum/workspace/users/sidd.md",
         old_string: "old",
         new_string: "new",
       },

--- a/assistant/src/__tests__/tool-executor.test.ts
+++ b/assistant/src/__tests__/tool-executor.test.ts
@@ -1220,12 +1220,13 @@ describe("isSideEffectTool", () => {
   });
 });
 
-// Baseline: allow rules can auto-allow file_edit for USER.md today (no forced prompting).
-// The mock check() delegates to findHighestPriorityRule (via spy) so a regression
-// in trust-rule matching would cause this test to fail instead of being masked by
-// a blanket mock-allow.
-describe("ToolExecutor baseline: allow rule auto-allows file_edit USER.md", () => {
-  const userMdPath = "/Users/sidd/.vellum/workspace/USER.md";
+// Baseline: allow rules can auto-allow file_edit for the guardian persona
+// today (no forced prompting). The mock check() delegates to
+// findHighestPriorityRule (via spy) so a regression in trust-rule matching
+// would cause this test to fail instead of being masked by a blanket
+// mock-allow.
+describe("ToolExecutor baseline: allow rule auto-allows file_edit guardian persona", () => {
+  const guardianPersonaPath = "/Users/sidd/.vellum/workspace/users/sidd.md";
   let ruleSpy: ReturnType<typeof spyOn> | undefined;
 
   beforeEach(() => {
@@ -1239,18 +1240,19 @@ describe("ToolExecutor baseline: allow rule auto-allows file_edit USER.md", () =
       addRuleSpy = undefined;
     }
 
-    // Simulate a trust rule that allows file_edit on USER.md by stubbing
-    // findHighestPriorityRule. This mirrors the default allow rules that
-    // the trust-store creates for workspace prompt files.
+    // Simulate a trust rule that allows file_edit on the guardian's per-user
+    // persona file by stubbing findHighestPriorityRule. This mirrors the
+    // default allow rules that the trust-store creates for the guardian
+    // persona file (see permissions/defaults.ts).
     ruleSpy = spyOn(trustStore, "findHighestPriorityRule").mockImplementation(
       (tool: string, commands: string[], _scope: string) => {
         if (tool !== "file_edit") return null;
         for (const cmd of commands) {
-          if (cmd === `file_edit:${userMdPath}`) {
+          if (cmd === `file_edit:${guardianPersonaPath}`) {
             return {
-              id: "default:allow-file_edit-user",
+              id: "default:allow-file_edit-guardian-persona",
               tool: "file_edit",
-              pattern: `file_edit:${userMdPath}`,
+              pattern: `file_edit:${guardianPersonaPath}`,
               scope: "everywhere",
               decision: "allow" as const,
               priority: 100,
@@ -1294,11 +1296,11 @@ describe("ToolExecutor baseline: allow rule auto-allows file_edit USER.md", () =
     }
   });
 
-  test("file_edit to USER.md is auto-allowed via trust rule", async () => {
+  test("file_edit to guardian persona is auto-allowed via trust rule", async () => {
     const executor = new ToolExecutor(makePrompter());
     const result = await executor.execute(
       "file_edit",
-      { path: userMdPath, content: "hello" },
+      { path: guardianPersonaPath, content: "hello" },
       makeContext(),
     );
     expect(result.isError).toBe(false);
@@ -1310,7 +1312,7 @@ describe("ToolExecutor baseline: allow rule auto-allows file_edit USER.md", () =
     expect(ruleSpy).toHaveBeenCalled();
   });
 
-  test("file_edit to a non-USER.md path is NOT auto-allowed without a matching rule", async () => {
+  test("file_edit to a non-guardian-persona path is NOT auto-allowed without a matching rule", async () => {
     let promptCalled = false;
     const trackingPrompter = {
       prompt: async () => {
@@ -1530,22 +1532,23 @@ describe("ToolExecutor forcePromptSideEffects enforcement", () => {
     expect(promptCount).toBe(1);
   });
 
-  // ── USER.md security invariant (PR 31) ──────────
+  // ── Guardian persona security invariant (PR 31) ──────────
 
-  test("file_edit to USER.md forces prompt in private conversation even with matching trust rule", async () => {
-    // This is a key security invariant: USER.md contains the user's persistent
-    // memory. In a private conversation (forcePromptSideEffects=true), edits to it
-    // must always require explicit approval, even when a trust rule matches.
+  test("file_edit to guardian persona forces prompt in private conversation even with matching trust rule", async () => {
+    // This is a key security invariant: the guardian persona file contains
+    // the user's persistent memory. In a private conversation
+    // (forcePromptSideEffects=true), edits to it must always require explicit
+    // approval, even when a trust rule matches.
     checkResultOverride = {
       decision: "allow",
-      reason: "Matched trust rule: file_edit:*/USER.md",
+      reason: "Matched trust rule: file_edit:*/users/*.md",
     };
 
     const executor = new ToolExecutor(makeTrackingPrompter());
     const result = await executor.execute(
       "file_edit",
       {
-        path: "/Users/sidd/.vellum/workspace/USER.md",
+        path: "/Users/sidd/.vellum/workspace/users/sidd.md",
         old_string: "old pref",
         new_string: "new pref",
       },
@@ -1557,14 +1560,14 @@ describe("ToolExecutor forcePromptSideEffects enforcement", () => {
     expect(promptCalled).toBe(true);
   });
 
-  test("host_file_edit to USER.md forces prompt in private conversation", async () => {
+  test("host_file_edit to guardian persona forces prompt in private conversation", async () => {
     checkResultOverride = { decision: "allow", reason: "Matched trust rule" };
 
     const executor = new ToolExecutor(makeTrackingPrompter());
     const result = await executor.execute(
       "host_file_edit",
       {
-        path: "/Users/sidd/.vellum/workspace/USER.md",
+        path: "/Users/sidd/.vellum/workspace/users/sidd.md",
         old_string: "x",
         new_string: "y",
       },

--- a/assistant/src/__tests__/trusted-contact-approval-notifier.test.ts
+++ b/assistant/src/__tests__/trusted-contact-approval-notifier.test.ts
@@ -117,7 +117,7 @@ mock.module("../prompts/user-reference.js", () => ({
   ...realUserReference,
   resolveUserReference: () => "my human",
   resolveGuardianName: (guardianDisplayName?: string | null): string => {
-    // Mirror the real implementation: USER.md name > guardianDisplayName > default
+    // Mirror the real implementation: guardian persona name (from users/<slug>.md) > guardianDisplayName > default
     const userRef = "my human"; // In tests, resolveUserReference() returns this
     if (userRef !== "my human") return userRef;
     if (guardianDisplayName && guardianDisplayName.trim().length > 0) {

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -1660,8 +1660,9 @@ export class RelayConnection {
 
   /**
    * Resolve a human-readable guardian label for voice wait copy.
-   * Delegates to the shared resolveGuardianName() which checks USER.md
-   * first, then falls back to Contact.displayName, then DEFAULT_USER_REFERENCE.
+   * Delegates to the shared resolveGuardianName() which checks the
+   * guardian's per-user persona file (users/<slug>.md) first, then falls
+   * back to Contact.displayName, then DEFAULT_USER_REFERENCE.
    */
   private resolveGuardianLabel(): string {
     // Look up the guardian contact for a displayName fallback

--- a/assistant/src/memory/job-handlers/conversation-starters.ts
+++ b/assistant/src/memory/job-handlers/conversation-starters.ts
@@ -197,7 +197,7 @@ async function generateStarters(scopeId: string): Promise<GeneratedStarter[]> {
   })}`;
 
   // Truncate identity context to prevent oversized prompts when SOUL.md /
-  // IDENTITY.md / USER.md are large.
+  // IDENTITY.md / users/<slug>.md are large.
   const rawIdentityContext = buildCoreIdentityContext({
     userPersona: resolveGuardianPersona(),
   });

--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -61,9 +61,9 @@ const PROMPT_VERSION = "v4";
 /**
  * Maximum character budget for identity context injected into the notification
  * decision prompt. We truncate to prevent oversized prompts when SOUL.md /
- * IDENTITY.md / USER.md are large — exceeding the provider context window
- * would cause the LLM call to fail and silently degrade to deterministic
- * fallback for all notifications.
+ * IDENTITY.md / users/<slug>.md are large — exceeding the provider context
+ * window would cause the LLM call to fail and silently degrade to
+ * deterministic fallback for all notifications.
  */
 const MAX_IDENTITY_CONTEXT_CHARS = 2000;
 

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -323,7 +323,7 @@ export function getConversationsDir(): string {
   return join(getWorkspaceDir(), "conversations");
 }
 
-/** Returns the workspace path for a prompt file (e.g. IDENTITY.md, SOUL.md, USER.md). */
+/** Returns the workspace path for a prompt file (e.g. IDENTITY.md, SOUL.md). */
 export function getWorkspacePromptPath(file: string): string {
   return join(getWorkspaceDir(), file);
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityData.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityData.swift
@@ -382,13 +382,6 @@ struct WorkspaceFileNode: Identifiable {
     let path: String
     let exists: Bool
 
-    /// Legacy user-persona filename, retained only as a fallback label for
-    /// installs that pre-date the guardian's `users/<slug>.md` path. The
-    /// primary source of truth is the server-returned `GET /workspace-files`
-    /// list; this constant is never used as a hardcoded match filter against
-    /// the response.
-    private static let legacyUserPersonaFilename = "USER.md"
-
     /// Static nodes used as a last-resort fallback when the gateway is
     /// unreachable. Mirrors the server's static entries in `settings-routes.ts`
     /// (minus the guardian's dynamic `users/<slug>.md`, which we obviously
@@ -396,7 +389,6 @@ struct WorkspaceFileNode: Identifiable {
     private static let fallbackNodes: [WorkspaceFileNode] = [
         WorkspaceFileNode(label: "IDENTITY.md", path: "IDENTITY.md", exists: false),
         WorkspaceFileNode(label: "SOUL.md", path: "SOUL.md", exists: false),
-        WorkspaceFileNode(label: "User Profile", path: legacyUserPersonaFilename, exists: false),
         WorkspaceFileNode(label: "skills/", path: "skills", exists: false),
     ]
 
@@ -404,12 +396,9 @@ struct WorkspaceFileNode: Identifiable {
     ///
     /// Uses `GET /workspace-files`, which the daemon builds dynamically:
     /// it includes the static identity/soul/skills entries plus the
-    /// guardian's resolved per-user persona file at `users/<slug>.md`
-    /// (and still includes the legacy `USER.md` during the transition).
-    /// The client does not hardcode which user-persona file to look for —
-    /// it renders whatever the server returns, preferring any `users/*.md`
-    /// entry over the legacy `USER.md` so fresh installs show a single
-    /// "User Profile" node.
+    /// guardian's resolved per-user persona file at `users/<slug>.md`.
+    /// The client renders whatever the server returns — the guardian slug
+    /// is decided server-side and surfaced as a single "User Profile" node.
     static func scanAsync() async -> [WorkspaceFileNode] {
         guard let response = await WorkspaceClient().fetchWorkspaceFilesList() else {
             return fallbackNodes
@@ -421,16 +410,8 @@ struct WorkspaceFileNode: Identifiable {
     /// the nodes rendered by the identity panel. Factored out for easier
     /// reasoning and future unit testing — contains no I/O.
     static func buildNodes(from entries: [WorkspaceFilesListResponseFile]) -> [WorkspaceFileNode] {
-        // When the server returns a guardian-resolved `users/<slug>.md`, we
-        // suppress the legacy `USER.md` entry so the panel renders a single
-        // user-persona node instead of two competing ones.
-        let hasGuardianUserPersona = entries.contains { isGuardianUserPersonaPath($0.path) }
-
         var nodes: [WorkspaceFileNode] = []
         for entry in entries {
-            if hasGuardianUserPersona && entry.path == legacyUserPersonaFilename {
-                continue
-            }
             nodes.append(
                 WorkspaceFileNode(
                     label: displayLabel(for: entry),
@@ -453,12 +434,11 @@ struct WorkspaceFileNode: Identifiable {
             && remainder.hasSuffix(".md")
     }
 
-    /// Maps a server entry to a user-facing label. User-persona files — both
-    /// the guardian's `users/<slug>.md` and the legacy `USER.md` — are shown
-    /// as "User Profile" so the UI doesn't surface a slug or legacy filename.
-    /// All other entries render their server-provided name verbatim.
+    /// Maps a server entry to a user-facing label. The guardian's
+    /// `users/<slug>.md` is shown as "User Profile" so the UI doesn't surface
+    /// a slug. All other entries render their server-provided name verbatim.
     private static func displayLabel(for entry: WorkspaceFilesListResponseFile) -> String {
-        if isGuardianUserPersonaPath(entry.path) || entry.path == legacyUserPersonaFilename {
+        if isGuardianUserPersonaPath(entry.path) {
             return "User Profile"
         }
         return entry.name

--- a/skills/vellum-self-knowledge/SKILL.md
+++ b/skills/vellum-self-knowledge/SKILL.md
@@ -20,7 +20,7 @@ Vellum is a personal AI assistant platform that runs as a local service on the u
 
 ## Architecture at a Glance
 
-The assistant runs as an HTTP server. Conversations are managed by a coordinator that delegates to an AgentLoop, which sends messages to the configured LLM provider and executes tools. The system prompt is composed from workspace files (IDENTITY.md, SOUL.md, USER.md) plus dynamic context. Skills extend capabilities via lazy-loaded instruction sets.
+The assistant runs as an HTTP server. Conversations are managed by a coordinator that delegates to an AgentLoop, which sends messages to the configured LLM provider and executes tools. The system prompt is composed from workspace files (IDENTITY.md, SOUL.md, and the guardian's per-user persona at `users/<slug>.md`) plus dynamic context. Skills extend capabilities via lazy-loaded instruction sets.
 
 ## Configuration System
 


### PR DESCRIPTION
## Summary
Post-plan cleanup from the drop-user-md review:
- Update stale docstrings/comments in relay-server, decision-engine, conversation-starters, platform.
- Update vellum-self-knowledge SKILL.md.
- Rename stale test names/comments in relay-server.test.ts and trusted-contact-approval-notifier.test.ts.
- Delete dead `USER.md` fixture seed in conversation-init.benchmark.test.ts.
- Update tool-executor test paths to the real `users/<slug>.md` layout.
- Remove unreachable `legacyUserPersonaFilename` constant and suppression logic in IdentityData.swift (migration 031 deletes USER.md, settings-routes no longer returns it).

Fixes gaps identified during drop-user-md plan review.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24876" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
