### PR TITLE
fix(test): tolerate TODO_* placeholders in chrome extension allowlist guard

### DIFF
--- a/assistant/src/__tests__/extension-id-sync-guard.test.ts
+++ b/assistant/src/__tests__/extension-id-sync-guard.test.ts
@@ -23,6 +23,7 @@ const CANONICAL_CONFIG_REL_PATH =
 const CANONICAL_CONFIG_ABS_PATH = join(repoRoot, CANONICAL_CONFIG_REL_PATH);
 
 const EXTENSION_ID_REGEX = /^[a-p]{32}$/;
+const PLACEHOLDER_ID_REGEX = /^TODO_[A-Z0-9_]+$/;
 
 type AllowlistConfig = {
   version: number;
@@ -48,19 +49,32 @@ function parseCanonicalConfig(): AllowlistConfig {
   }
 
   const seen = new Set<string>();
+  const validIds: string[] = [];
   for (const id of parsed.allowedExtensionIds) {
-    if (typeof id !== "string" || !EXTENSION_ID_REGEX.test(id)) {
+    if (typeof id !== "string") {
       throw new Error(`Invalid canonical extension id: ${String(id)}`);
     }
     if (seen.has(id)) {
       throw new Error(`Duplicate canonical extension id: ${id}`);
     }
     seen.add(id);
+
+    if (EXTENSION_ID_REGEX.test(id)) {
+      validIds.push(id);
+    } else if (!PLACEHOLDER_ID_REGEX.test(id)) {
+      throw new Error(`Invalid canonical extension id: ${id}`);
+    }
+  }
+
+  if (validIds.length === 0) {
+    throw new Error(
+      "Invalid canonical config: allowedExtensionIds must contain at least one real extension id",
+    );
   }
 
   return {
     version: parsed.version as number,
-    allowedExtensionIds: parsed.allowedExtensionIds as string[],
+    allowedExtensionIds: validIds,
   };
 }
 


### PR DESCRIPTION
## Summary
- PR #24872 added a `TODO_REPLACE_WITH_CWS_PRODUCTION_EXTENSION_ID` slot to `meta/browser-extension/chrome-extension-allowlist.json`, breaking mainline CI in `extension-id-sync-guard.test.ts` which rejects any entry not matching the `[a-p]{32}` extension-id regex.
- Align the guard with the runtime (`browser-extension-pair-routes.ts`) and Swift (`ChromeExtensionAllowlist`) loaders, both of which already filter invalid ids gracefully. The test now accepts entries matching `^TODO_[A-Z0-9_]+$` as explicit placeholders (still rejecting garbage), requires at least one real id, and mirrors/concrete-id checks only run against the real ids.
- Minimal fix scoped to the failing job only (https://github.com/vellum-ai/vellum-assistant/actions/runs/24292775855/job/70932756780).

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24292775855/job/70932756780