### PR TITLE
test(contacts-write): lock in PR #24878 regression guards

### DIFF
--- a/assistant/src/__tests__/contacts-write.test.ts
+++ b/assistant/src/__tests__/contacts-write.test.ts
@@ -19,8 +19,16 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
-import { createGuardianBinding } from "../contacts/contacts-write.js";
+import {
+  createGuardianBinding,
+  upsertContactChannel,
+} from "../contacts/contacts-write.js";
 import { getSqlite, initializeDb } from "../memory/db.js";
+import {
+  clearAllRules,
+  clearCache as clearTrustCache,
+  getAllRules,
+} from "../permissions/trust-store.js";
 
 initializeDb();
 
@@ -100,5 +108,83 @@ describe("createGuardianBinding seeds users/<slug>.md", () => {
 
     const afterContent = readFileSync(expectedPath, "utf-8");
     expect(afterContent).toBe(customContent);
+  });
+});
+
+// These two tests lock in invariants from the drop-user-md plan fix PR
+// #24878. They guard against two specific regressions that have already
+// happened once:
+//
+//  1. Seeding `users/<slug>.md` from `upsertContactChannel` fires the
+//     users/ directory watcher on every inbound message from a new
+//     contact and evicts live conversations. Seeding must be restricted
+//     to the guardian-creation path.
+//
+//  2. Without `clearTrustCache()` in `createGuardianBinding`, the
+//     dynamic `default:allow-file_*-guardian-persona` rules from
+//     `permissions/defaults.ts` are never backfilled for guardians
+//     created at runtime, so the model prompts on its first
+//     `file_edit users/<slug>.md`.
+describe("drop-user-md regression guards (PR #24878)", () => {
+  beforeEach(() => {
+    resetContactTables();
+    clearAllRules();
+    clearTrustCache();
+  });
+
+  test("upsertContactChannel does NOT seed users/<slug>.md for non-guardian contacts", () => {
+    // upsertContact assigns a userFile slug to every contact (including
+    // non-guardians) via generateUserFileSlug when no principalId/sibling
+    // match is found. If upsertContactChannel ever re-adds the
+    // `ensureGuardianPersonaFile(contact.userFile)` call that PR #24878
+    // removed, this test will start seeing the file on disk and fail.
+    const result = upsertContactChannel({
+      sourceChannel: "telegram",
+      externalUserId: "Bob",
+      externalChatId: "chat-bob",
+      displayName: "Bob",
+      role: "contact",
+      status: "active",
+    });
+
+    expect(result).not.toBeNull();
+    // Confirm the contact was actually persisted with a userFile slug —
+    // otherwise the assertion below would pass trivially.
+    expect(result?.contact.userFile).toBeTruthy();
+
+    const slug = result!.contact.userFile!;
+    const personaPath = userFilePath(slug);
+    expect(existsSync(personaPath)).toBe(false);
+  });
+
+  test("createGuardianBinding backfills the guardian-persona auto-allow rule via clearTrustCache", () => {
+    // Warm the trust cache BEFORE a guardian exists so the initial
+    // loadFromDisk → backfillDefaults → getDefaultRuleTemplates round
+    // sees no guardian and emits no guardian-persona rule.
+    const beforeRules = getAllRules();
+    const guardianRuleBefore = beforeRules.find(
+      (r) => r.id === "default:allow-file_edit-guardian-persona",
+    );
+    expect(guardianRuleBefore).toBeUndefined();
+
+    createGuardianBinding({
+      channel: "telegram",
+      guardianExternalUserId: "Carol",
+      guardianDeliveryChatId: "chat-carol",
+      guardianPrincipalId: "principal-carol",
+      verifiedVia: "challenge",
+    });
+
+    // After createGuardianBinding, clearTrustCache() should have been
+    // invoked, so the next getAllRules() call re-runs loadFromDisk and
+    // backfills the dynamic guardian-persona rule pointing at the
+    // newly-resolved users/<slug>.md.
+    const afterRules = getAllRules();
+    const guardianRuleAfter = afterRules.find(
+      (r) => r.id === "default:allow-file_edit-guardian-persona",
+    );
+    expect(guardianRuleAfter).toBeDefined();
+    expect(guardianRuleAfter?.decision).toBe("allow");
+    expect(guardianRuleAfter?.pattern).toContain("users/carol.md");
   });
 });


### PR DESCRIPTION
## Summary
- Add two regression tests to `contacts-write.test.ts` that lock in the two invariants fixed by PR #24878.
- Test 1 asserts `upsertContactChannel` does NOT write `users/<slug>.md` for non-guardian contacts (guards the inbound-message eviction cascade regression).
- Test 2 asserts `createGuardianBinding` invalidates the trust cache so the dynamic `default:allow-file_edit-guardian-persona` auto-allow rule is backfilled (guards the runtime-guardian approval-prompt regression).

## Context
PR #24878 fixed two bugs from the `drop-user-md` plan:

1. **Inbound-message eviction cascade.** `upsertContactChannel` was calling `ensureGuardianPersonaFile(contact.userFile)` on every new contact (Slack, phone, email, etc), which fired the `users/` directory watcher added in PR #24845 and evicted live conversations on every inbound message from a new contact. The fix restricted seeding to the guardian-creation path.
2. **Trust cache never invalidated.** The dynamic `default:allow-file_{read,write,edit}-guardian-persona` rule from `permissions/defaults.ts` (PR #24849) is only backfilled during `trust-store.loadFromDisk()`. Runtime guardian creation paths (self-heal, first-message-seeds-guardian) did not invalidate the cache, so the rule was never backfilled for those guardians and the model had to approve its first `file_edit` on `users/<slug>.md`.

Neither invariant had test coverage. Future contributors could re-add the non-guardian seeding call ("it seems consistent") or remove the `clearTrustCache` call ("this looks like dead code") without CI catching it. This PR adds narrow regression locks for both.

## Original prompt
> ok let's /do #4

Where #4 was:
> Regression test for \`upsertContactChannel\` not seeding. This is the one worth the effort. PR #24878 fixed a real production bug — every inbound message from a new contact was firing the users/ watcher and evicting live conversations. The fix was a one-line deletion, and nothing in the test suite prevents someone from reintroducing it in a future PR that "just adds back the helper call because it seems consistent." A single test case is maybe ten lines and locks in the invariant that was learned the hard way. While in there, add a second case that asserts \`clearTrustCache\` is called when \`createGuardianBinding\` runs, since that's the other half of the same fix and has the same risk profile.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24879" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
