### PR TITLE
feat(config): add backup config schema (disabled by default)

### DIFF
--- a/assistant/src/config/__tests__/backup-schema.test.ts
+++ b/assistant/src/config/__tests__/backup-schema.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  BackupConfigSchema,
+  BackupDestinationSchema,
+  BackupOffsiteConfigSchema,
+} from "../schemas/backup.js";
+
+describe("BackupConfigSchema", () => {
+  test("empty object parses to full defaults (disabled, sensible intervals, iCloud default)", () => {
+    const parsed = BackupConfigSchema.parse({});
+    expect(parsed).toEqual({
+      enabled: false,
+      intervalHours: 6,
+      retention: 7,
+      offsite: { enabled: true, destinations: null },
+      localDirectory: null,
+    });
+  });
+
+  test("rejects intervalHours: 0 (must be >= 1)", () => {
+    const result = BackupConfigSchema.safeParse({ intervalHours: 0 });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects intervalHours above max 168", () => {
+    const result = BackupConfigSchema.safeParse({ intervalHours: 169 });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects retention: 0 (must be >= 1)", () => {
+    const result = BackupConfigSchema.safeParse({ retention: 0 });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects retention above max 100", () => {
+    const result = BackupConfigSchema.safeParse({ retention: 101 });
+    expect(result.success).toBe(false);
+  });
+
+  test("valid custom values round-trip", () => {
+    const input = {
+      enabled: true,
+      intervalHours: 12,
+      retention: 30,
+      offsite: {
+        enabled: false,
+        destinations: [{ path: "/mnt/backups", encrypt: true }],
+      },
+      localDirectory: "/var/backups/vellum",
+    };
+    const parsed = BackupConfigSchema.parse(input);
+    expect(parsed).toEqual(input);
+  });
+
+  test("offsite.destinations with only path defaults encrypt to true", () => {
+    const parsed = BackupConfigSchema.parse({
+      offsite: {
+        destinations: [{ path: "/tmp/a" }, { path: "/tmp/b" }],
+      },
+    });
+    expect(parsed.offsite.destinations).toEqual([
+      { path: "/tmp/a", encrypt: true },
+      { path: "/tmp/b", encrypt: true },
+    ]);
+  });
+
+  test("offsite.destinations honors explicit encrypt: false (plaintext allowed)", () => {
+    const parsed = BackupConfigSchema.parse({
+      offsite: {
+        destinations: [{ path: "/tmp/a", encrypt: false }],
+      },
+    });
+    expect(parsed.offsite.destinations).toEqual([
+      { path: "/tmp/a", encrypt: false },
+    ]);
+  });
+
+  test("offsite.destinations allows mixed encryption across destinations", () => {
+    const parsed = BackupConfigSchema.parse({
+      offsite: {
+        destinations: [
+          { path: "/tmp/a", encrypt: true },
+          { path: "/tmp/b", encrypt: false },
+        ],
+      },
+    });
+    expect(parsed.offsite.destinations).toEqual([
+      { path: "/tmp/a", encrypt: true },
+      { path: "/tmp/b", encrypt: false },
+    ]);
+  });
+
+  test("offsite.destinations: [] parses as an explicit empty array (distinct from null)", () => {
+    const parsed = BackupConfigSchema.parse({
+      offsite: { destinations: [] },
+    });
+    expect(parsed.offsite.destinations).toEqual([]);
+    // Distinct from null (the iCloud-default sentinel).
+    expect(parsed.offsite.destinations).not.toBe(null);
+  });
+
+  test("partial config with only enabled: true fills in defaults", () => {
+    const parsed = BackupConfigSchema.parse({ enabled: true });
+    expect(parsed).toEqual({
+      enabled: true,
+      intervalHours: 6,
+      retention: 7,
+      offsite: { enabled: true, destinations: null },
+      localDirectory: null,
+    });
+  });
+});
+
+describe("BackupDestinationSchema", () => {
+  test("defaults encrypt to true when omitted", () => {
+    const parsed = BackupDestinationSchema.parse({ path: "/tmp/x" });
+    expect(parsed).toEqual({ path: "/tmp/x", encrypt: true });
+  });
+
+  test("requires path", () => {
+    const result = BackupDestinationSchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("BackupOffsiteConfigSchema", () => {
+  test("empty object defaults to enabled=true, destinations=null", () => {
+    expect(BackupOffsiteConfigSchema.parse({})).toEqual({
+      enabled: true,
+      destinations: null,
+    });
+  });
+});

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -10,6 +10,8 @@ export {
 } from "../permissions/permission-mode.js";
 export type { AcpAgentConfig, AcpConfig } from "./acp-schema.js";
 export { AcpAgentConfigSchema, AcpConfigSchema } from "./acp-schema.js";
+export type { BackupConfig, BackupDestination } from "./schemas/backup.js";
+export { BackupConfigSchema } from "./schemas/backup.js";
 export type {
   CallerIdentityConfig,
   CallsConfig,
@@ -213,6 +215,7 @@ export { WorkspaceGitConfigSchema } from "./schemas/workspace-git.js";
 
 // Imports for AssistantConfigSchema composition
 import { AcpConfigSchema } from "./acp-schema.js";
+import { BackupConfigSchema } from "./schemas/backup.js";
 import { CallsConfigSchema } from "./schemas/calls.js";
 import {
   SlackConfigSchema,
@@ -300,6 +303,7 @@ export const AssistantConfigSchema = z
       HostBrowserConfigSchema.parse({}),
     ),
     journal: JournalConfigSchema.default(JournalConfigSchema.parse({})),
+    backup: BackupConfigSchema.default(BackupConfigSchema.parse({})),
     mcp: McpConfigSchema.default(McpConfigSchema.parse({})),
     acp: AcpConfigSchema.default(AcpConfigSchema.parse({})),
     skills: SkillsConfigSchema.default(SkillsConfigSchema.parse({})),

--- a/assistant/src/config/schemas/backup.ts
+++ b/assistant/src/config/schemas/backup.ts
@@ -1,0 +1,72 @@
+import { z } from "zod";
+
+export const BackupDestinationSchema = z
+  .object({
+    path: z
+      .string({ error: "backup.offsite.destinations[].path must be a string" })
+      .describe("Absolute path to the offsite destination directory"),
+    encrypt: z
+      .boolean({
+        error: "backup.offsite.destinations[].encrypt must be a boolean",
+      })
+      .default(true)
+      .describe(
+        "Encrypt backups written to this destination. Defaults to true; set to false only for destinations where the user trusts physical control (e.g. an external SSD).",
+      ),
+  })
+  .describe("A single offsite backup destination");
+
+export type BackupDestination = z.infer<typeof BackupDestinationSchema>;
+
+export const BackupOffsiteConfigSchema = z
+  .object({
+    enabled: z
+      .boolean({ error: "backup.offsite.enabled must be a boolean" })
+      .default(true)
+      .describe("Whether offsite backup is enabled"),
+    destinations: z
+      .array(BackupDestinationSchema)
+      .nullable()
+      .default(null)
+      .describe(
+        "Offsite destinations. null means use the default iCloud Drive destination with encryption on; an explicit array (including []) overrides the default.",
+      ),
+  })
+  .describe("Offsite backup configuration");
+
+export type BackupOffsiteConfig = z.infer<typeof BackupOffsiteConfigSchema>;
+
+export const BackupConfigSchema = z
+  .object({
+    enabled: z
+      .boolean({ error: "backup.enabled must be a boolean" })
+      .default(false)
+      .describe("Whether automated backups are enabled"),
+    intervalHours: z
+      .number({ error: "backup.intervalHours must be a number" })
+      .int("backup.intervalHours must be an integer")
+      .min(1, "backup.intervalHours must be >= 1")
+      .max(168, "backup.intervalHours must be <= 168")
+      .default(6)
+      .describe("Interval between automated backups, in hours"),
+    retention: z
+      .number({ error: "backup.retention must be a number" })
+      .int("backup.retention must be an integer")
+      .min(1, "backup.retention must be >= 1")
+      .max(100, "backup.retention must be <= 100")
+      .default(7)
+      .describe("Number of recent backups to retain"),
+    offsite: BackupOffsiteConfigSchema.default(
+      BackupOffsiteConfigSchema.parse({}),
+    ),
+    localDirectory: z
+      .string({ error: "backup.localDirectory must be a string" })
+      .nullable()
+      .default(null)
+      .describe(
+        "Directory for local backup snapshots. null means use the default workspace-adjacent location.",
+      ),
+  })
+  .describe("Automated backup configuration");
+
+export type BackupConfig = z.infer<typeof BackupConfigSchema>;


### PR DESCRIPTION
## Summary
- Add BackupConfigSchema, BackupOffsiteConfigSchema, BackupDestinationSchema
- Wire into AssistantConfigSchema; defaults to disabled
- Schema supports per-destination encryption override

Part of plan: backup-restore-system.md (PR 1 of 12)