### PR TITLE
feat(backup): add backup key read/generate helper

### DIFF
--- a/assistant/src/backup/__tests__/backup-key.test.ts
+++ b/assistant/src/backup/__tests__/backup-key.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Tests for the backup key read/generate helpers. All tests run against a
+ * temp directory and explicitly pass the key path -- nothing touches the
+ * real `~/.vellum/` tree or depends on daemon startup state.
+ */
+
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { ensureBackupKey, readBackupKey } from "../backup-key.js";
+
+describe("backup-key", () => {
+  let root: string;
+  let keyPath: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "vellum-backup-key-"));
+    // Nest the key file one level down so we can verify that the
+    // parent directory is created on demand with the expected mode.
+    keyPath = join(root, "backup", "backup.key");
+  });
+
+  afterEach(() => {
+    try {
+      rmSync(root, { recursive: true, force: true });
+    } catch {
+      // best-effort
+    }
+  });
+
+  describe("ensureBackupKey", () => {
+    test("first call generates a fresh 32-byte key and writes it with mode 0600", async () => {
+      const key = await ensureBackupKey(keyPath);
+
+      expect(key).toBeInstanceOf(Buffer);
+      expect(key.length).toBe(32);
+
+      const fileMode = statSync(keyPath).mode & 0o777;
+      expect(fileMode).toBe(0o600);
+    });
+
+    test("creates the parent directory with mode 0700 when missing", async () => {
+      await ensureBackupKey(keyPath);
+
+      const parent = join(root, "backup");
+      const dirMode = statSync(parent).mode & 0o777;
+      // On some platforms umask can strip bits further, but it must
+      // never be more permissive than 0o700.
+      expect(dirMode & ~0o700).toBe(0);
+      expect(dirMode & 0o700).toBe(0o700);
+    });
+
+    test("second call returns the same bytes persisted on the first call", async () => {
+      const first = await ensureBackupKey(keyPath);
+      const second = await ensureBackupKey(keyPath);
+      expect(Buffer.compare(first, second)).toBe(0);
+    });
+
+    test("throws when an existing key file has the wrong size", async () => {
+      mkdirSync(join(root, "backup"), { recursive: true, mode: 0o700 });
+      // 16 bytes is half the expected length -- simulate a truncated or
+      // otherwise corrupt key file.
+      writeFileSync(keyPath, Buffer.alloc(16, 0xaa), { mode: 0o600 });
+
+      await expect(ensureBackupKey(keyPath)).rejects.toThrow(
+        /invalid length 16/,
+      );
+    });
+
+    test("does not leave a .tmp file behind after a successful write", async () => {
+      await ensureBackupKey(keyPath);
+      const tmpPath = `${keyPath}.tmp.${process.pid}`;
+      expect(() => statSync(tmpPath)).toThrow();
+    });
+  });
+
+  describe("readBackupKey", () => {
+    test("returns null when the key file is missing", async () => {
+      const result = await readBackupKey(keyPath);
+      expect(result).toBeNull();
+    });
+
+    test("returns the same bytes that ensureBackupKey wrote", async () => {
+      const generated = await ensureBackupKey(keyPath);
+      const read = await readBackupKey(keyPath);
+      expect(read).not.toBeNull();
+      expect(Buffer.compare(read!, generated)).toBe(0);
+    });
+
+    test("throws when the existing key file has the wrong size", async () => {
+      mkdirSync(join(root, "backup"), { recursive: true, mode: 0o700 });
+      writeFileSync(keyPath, Buffer.alloc(8, 0xff), { mode: 0o600 });
+
+      await expect(readBackupKey(keyPath)).rejects.toThrow(/invalid length 8/);
+    });
+  });
+});

--- a/assistant/src/backup/backup-key.ts
+++ b/assistant/src/backup/backup-key.ts
@@ -1,0 +1,87 @@
+/**
+ * Backup key management.
+ *
+ * The backup key is a 32-byte random secret used to authenticate / encrypt
+ * workspace backups. It is generated once per install and persisted to disk
+ * so subsequent backup/restore operations reuse the same key.
+ *
+ * This module is intentionally pure: callers pass the full `keyPath` rather
+ * than resolving a default location. That keeps the helpers trivially
+ * testable against temp directories and avoids any coupling to daemon
+ * startup, workspace layout, or global path helpers.
+ *
+ * On-disk invariants:
+ * - Parent directory is created with mode `0o700`.
+ * - Key file is written atomically (temp + rename) with mode `0o600`.
+ * - Key file is exactly 32 bytes; any other size is treated as corruption.
+ */
+
+import { randomBytes } from "node:crypto";
+import { chmod, mkdir, readFile, rename, stat, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+
+/** Required length of the backup key file, in bytes. */
+const BACKUP_KEY_LENGTH = 32;
+
+/**
+ * Check whether a filesystem path exists without throwing.
+ */
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Read the backup key from disk if it exists.
+ *
+ * Returns the raw 32-byte buffer, or `null` if the file is missing. Intended
+ * for read-only callers (e.g. restore paths) that should not create a new
+ * key as a side effect.
+ *
+ * Throws if the file exists but is not exactly 32 bytes -- callers should
+ * treat that as a corruption signal rather than silently regenerating.
+ */
+export async function readBackupKey(keyPath: string): Promise<Buffer | null> {
+  if (!(await pathExists(keyPath))) return null;
+  const buf = await readFile(keyPath);
+  if (buf.length !== BACKUP_KEY_LENGTH) {
+    throw new Error(
+      `Backup key at ${keyPath} has invalid length ${buf.length} (expected ${BACKUP_KEY_LENGTH})`,
+    );
+  }
+  return buf;
+}
+
+/**
+ * Ensure a backup key exists at `keyPath`, returning its bytes.
+ *
+ * - If the file exists, it is read and validated. A wrong-size file throws,
+ *   so a corrupt key is never silently replaced.
+ * - Otherwise, the parent directory is created (mode `0o700`), a fresh
+ *   32-byte random key is generated, written atomically (`.tmp` + rename),
+ *   and returned.
+ */
+export async function ensureBackupKey(keyPath: string): Promise<Buffer> {
+  const existing = await readBackupKey(keyPath);
+  if (existing) return existing;
+
+  const parent = dirname(keyPath);
+  await mkdir(parent, { recursive: true, mode: 0o700 });
+
+  const key = randomBytes(BACKUP_KEY_LENGTH);
+  // Use pid suffix to prevent cross-process collisions while ensuring
+  // same-process retries overwrite a stale temp file rather than
+  // orphaning it on failure. Mirrors the pattern used in
+  // `security/encrypted-store.ts`.
+  const tmpPath = `${keyPath}.tmp.${process.pid}`;
+  await writeFile(tmpPath, key, { mode: 0o600 });
+  // Some platforms / umasks ignore the `mode` option on writeFile, so
+  // enforce 0o600 explicitly before the rename.
+  await chmod(tmpPath, 0o600);
+  await rename(tmpPath, keyPath);
+  return key;
+}


### PR DESCRIPTION
## Summary
- Add ensureBackupKey and readBackupKey helpers
- Key file at configurable path with 0o600 permissions
- Atomic write (tmp + rename) and parent dir creation

Part of plan: backup-restore-system.md (PR 4 of 12)