### PR TITLE
feat(backup): add AES-256-GCM streaming encrypt/decrypt

### DIFF
--- a/assistant/src/backup/__tests__/stream-crypt.test.ts
+++ b/assistant/src/backup/__tests__/stream-crypt.test.ts
@@ -1,0 +1,191 @@
+import { randomBytes } from "node:crypto";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { open } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  decryptFile,
+  ENCRYPTED_HEADER_SIZE,
+  encryptFile,
+  GCM_TAG_SIZE,
+  verifyEncryptedFile,
+} from "../stream-crypt.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+let TEST_DIR: string;
+
+beforeEach(() => {
+  TEST_DIR = join(
+    tmpdir(),
+    `vellum-stream-crypt-test-${randomBytes(6).toString("hex")}`,
+  );
+  mkdirSync(TEST_DIR, { recursive: true });
+});
+
+afterEach(() => {
+  try {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  } catch {
+    // best-effort
+  }
+});
+
+function makeKey(seed: number): Buffer {
+  const buf = Buffer.alloc(32);
+  for (let i = 0; i < 32; i++) {
+    buf[i] = (seed + i) & 0xff;
+  }
+  return buf;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("stream-crypt", () => {
+  test("round-trips a 1 KB random file", async () => {
+    const key = randomBytes(32);
+    const plaintext = randomBytes(1024);
+    const plainPath = join(TEST_DIR, "plain.bin");
+    const encPath = join(TEST_DIR, "enc.bin");
+    const roundTripPath = join(TEST_DIR, "roundtrip.bin");
+
+    writeFileSync(plainPath, plaintext);
+    await encryptFile(plainPath, encPath, key);
+    await decryptFile(encPath, roundTripPath, key);
+
+    const result = readFileSync(roundTripPath);
+    expect(result.equals(plaintext)).toBe(true);
+
+    // Encrypted file has the IV + tag overhead
+    const encBytes = readFileSync(encPath);
+    expect(encBytes.length).toBe(
+      plaintext.length + ENCRYPTED_HEADER_SIZE + GCM_TAG_SIZE,
+    );
+  });
+
+  test("round-trips a 10 MB file (streaming across chunk boundaries)", async () => {
+    const key = randomBytes(32);
+    const size = 10 * 1024 * 1024;
+    const plaintext = randomBytes(size);
+    const plainPath = join(TEST_DIR, "plain.bin");
+    const encPath = join(TEST_DIR, "enc.bin");
+    const roundTripPath = join(TEST_DIR, "roundtrip.bin");
+
+    writeFileSync(plainPath, plaintext);
+    await encryptFile(plainPath, encPath, key);
+    await decryptFile(encPath, roundTripPath, key);
+
+    const result = readFileSync(roundTripPath);
+    expect(result.length).toBe(size);
+    expect(result.equals(plaintext)).toBe(true);
+  });
+
+  test("auth tag verification: flipping a byte in the ciphertext causes decrypt to throw", async () => {
+    const key = randomBytes(32);
+    const plaintext = randomBytes(2048);
+    const plainPath = join(TEST_DIR, "plain.bin");
+    const encPath = join(TEST_DIR, "enc.bin");
+    const outPath = join(TEST_DIR, "out.bin");
+
+    writeFileSync(plainPath, plaintext);
+    await encryptFile(plainPath, encPath, key);
+
+    // Flip one byte somewhere in the middle of the ciphertext body
+    // (not in the IV header or the trailing auth tag).
+    const ciphertextByteOffset =
+      ENCRYPTED_HEADER_SIZE + Math.floor(plaintext.length / 2);
+    const fh = await open(encPath, "r+");
+    try {
+      const one = Buffer.alloc(1);
+      await fh.read(one, 0, 1, ciphertextByteOffset);
+      one[0] = one[0] ^ 0xff;
+      await fh.write(one, 0, 1, ciphertextByteOffset);
+    } finally {
+      await fh.close();
+    }
+
+    await expect(decryptFile(encPath, outPath, key)).rejects.toThrow();
+  });
+
+  test("decrypting with the wrong key throws", async () => {
+    const keyA = makeKey(1);
+    const keyB = makeKey(99);
+    const plaintext = randomBytes(4096);
+    const plainPath = join(TEST_DIR, "plain.bin");
+    const encPath = join(TEST_DIR, "enc.bin");
+    const outPath = join(TEST_DIR, "out.bin");
+
+    writeFileSync(plainPath, plaintext);
+    await encryptFile(plainPath, encPath, keyA);
+
+    await expect(decryptFile(encPath, outPath, keyB)).rejects.toThrow();
+  });
+
+  test("passing a 16-byte key throws the typed error", async () => {
+    const badKey = randomBytes(16);
+    const plainPath = join(TEST_DIR, "plain.bin");
+    const encPath = join(TEST_DIR, "enc.bin");
+
+    writeFileSync(plainPath, Buffer.from("hello world", "utf-8"));
+
+    await expect(encryptFile(plainPath, encPath, badKey)).rejects.toThrow(
+      "Backup encryption key must be 32 bytes",
+    );
+  });
+
+  test("IV uniqueness: encrypting the same file twice yields different outputs", async () => {
+    const key = randomBytes(32);
+    const plaintext = randomBytes(4096);
+    const plainPath = join(TEST_DIR, "plain.bin");
+    const encPathA = join(TEST_DIR, "enc-a.bin");
+    const encPathB = join(TEST_DIR, "enc-b.bin");
+
+    writeFileSync(plainPath, plaintext);
+    await encryptFile(plainPath, encPathA, key);
+    await encryptFile(plainPath, encPathB, key);
+
+    const a = readFileSync(encPathA);
+    const b = readFileSync(encPathB);
+
+    expect(a.equals(b)).toBe(false);
+    // The first 12 bytes are the IV — they must differ with overwhelming
+    // probability (collision chance is 1/2^96 for random 12-byte IVs).
+    expect(
+      a.subarray(0, ENCRYPTED_HEADER_SIZE).equals(
+        b.subarray(0, ENCRYPTED_HEADER_SIZE),
+      ),
+    ).toBe(false);
+  });
+
+  test("verifyEncryptedFile returns true for a valid bundle and false for a tampered one", async () => {
+    const key = randomBytes(32);
+    const plaintext = randomBytes(1024);
+    const plainPath = join(TEST_DIR, "plain.bin");
+    const encPath = join(TEST_DIR, "enc.bin");
+
+    writeFileSync(plainPath, plaintext);
+    await encryptFile(plainPath, encPath, key);
+
+    expect(await verifyEncryptedFile(encPath, key)).toBe(true);
+
+    // Tamper the ciphertext and re-verify
+    const fh = await open(encPath, "r+");
+    try {
+      const flipOffset = ENCRYPTED_HEADER_SIZE + 10;
+      const one = Buffer.alloc(1);
+      await fh.read(one, 0, 1, flipOffset);
+      one[0] = one[0] ^ 0x01;
+      await fh.write(one, 0, 1, flipOffset);
+    } finally {
+      await fh.close();
+    }
+
+    expect(await verifyEncryptedFile(encPath, key)).toBe(false);
+  });
+});

--- a/assistant/src/backup/stream-crypt.ts
+++ b/assistant/src/backup/stream-crypt.ts
@@ -1,0 +1,216 @@
+/**
+ * Streaming AES-256-GCM file encryption/decryption for backup bundles.
+ *
+ * The on-disk format is:
+ *
+ *   [12-byte IV][ciphertext...][16-byte GCM auth tag]
+ *
+ * Both encrypt and decrypt use Node streams so peak memory stays bounded
+ * regardless of input size. This is important for backup archives which may
+ * run to many gigabytes on larger workspaces.
+ *
+ * The key must be exactly 32 bytes (AES-256). The IV is randomly generated
+ * per call, which is required for GCM semantic security — never reuse an
+ * IV with the same key.
+ */
+
+import {
+  createCipheriv,
+  createDecipheriv,
+  randomBytes,
+} from "node:crypto";
+import {
+  createReadStream,
+  createWriteStream,
+} from "node:fs";
+import { open, rename, stat, unlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Size of the AES-GCM initialization vector prefix, in bytes. */
+export const ENCRYPTED_HEADER_SIZE = 12;
+
+/** Size of the AES-GCM authentication tag suffix, in bytes. */
+export const GCM_TAG_SIZE = 16;
+
+const ALGORITHM = "aes-256-gcm";
+const KEY_LENGTH = 32;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function assertKey(key: Buffer): void {
+  if (key.length !== KEY_LENGTH) {
+    throw new Error("Backup encryption key must be 32 bytes");
+  }
+}
+
+async function safeUnlink(path: string): Promise<void> {
+  try {
+    await unlink(path);
+  } catch {
+    // best-effort cleanup — swallow ENOENT and other errors
+  }
+}
+
+function tempPath(outputPath: string): string {
+  return `${outputPath}.tmp.${process.pid}.${randomBytes(4).toString("hex")}`;
+}
+
+// ---------------------------------------------------------------------------
+// Encrypt
+// ---------------------------------------------------------------------------
+
+/**
+ * Stream-encrypt `inputPath` to `outputPath` using AES-256-GCM.
+ *
+ * Produces `[IV (12 bytes)][ciphertext][auth tag (16 bytes)]` in the output.
+ * Writes to a temp file and atomically renames on success; unlinks the temp
+ * file on any error so failed writes don't leave partial bundles behind.
+ */
+export async function encryptFile(
+  inputPath: string,
+  outputPath: string,
+  key: Buffer,
+): Promise<void> {
+  assertKey(key);
+
+  const iv = randomBytes(ENCRYPTED_HEADER_SIZE);
+  const cipher = createCipheriv(ALGORITHM, key, iv);
+
+  const tmp = tempPath(outputPath);
+  const writeStream = createWriteStream(tmp);
+
+  try {
+    // Write IV first so decrypt can read it without knowing the ciphertext size.
+    await new Promise<void>((resolve, reject) => {
+      writeStream.write(iv, (err) => (err ? reject(err) : resolve()));
+    });
+
+    // Stream plaintext through the cipher into the output.
+    const readStream = createReadStream(inputPath);
+    await pipeline(readStream, cipher, writeStream, { end: false });
+
+    // Append the auth tag after the ciphertext body.
+    const tag = cipher.getAuthTag();
+    await new Promise<void>((resolve, reject) => {
+      writeStream.write(tag, (err) => (err ? reject(err) : resolve()));
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      writeStream.end((err?: Error | null) => (err ? reject(err) : resolve()));
+    });
+
+    await rename(tmp, outputPath);
+  } catch (err) {
+    // Make sure the write stream is closed before we try to unlink the temp file.
+    writeStream.destroy();
+    await safeUnlink(tmp);
+    throw err;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Decrypt
+// ---------------------------------------------------------------------------
+
+/**
+ * Stream-decrypt `inputPath` to `outputPath`. Expects the on-disk format
+ * produced by `encryptFile`: `[IV][ciphertext][auth tag]`.
+ *
+ * Reads the IV and auth tag via positional reads, then streams only the
+ * ciphertext body through the decipher. Atomic tmp + rename semantics.
+ */
+export async function decryptFile(
+  inputPath: string,
+  outputPath: string,
+  key: Buffer,
+): Promise<void> {
+  assertKey(key);
+
+  const info = await stat(inputPath);
+  const totalSize = info.size;
+  const minSize = ENCRYPTED_HEADER_SIZE + GCM_TAG_SIZE;
+  if (totalSize < minSize) {
+    throw new Error(
+      `Encrypted file is too small: ${totalSize} bytes (need at least ${minSize})`,
+    );
+  }
+
+  // Read IV (first 12 bytes) and auth tag (last 16 bytes) via positional reads.
+  const iv = Buffer.alloc(ENCRYPTED_HEADER_SIZE);
+  const tag = Buffer.alloc(GCM_TAG_SIZE);
+  const fh = await open(inputPath, "r");
+  try {
+    await fh.read(iv, 0, ENCRYPTED_HEADER_SIZE, 0);
+    await fh.read(tag, 0, GCM_TAG_SIZE, totalSize - GCM_TAG_SIZE);
+  } finally {
+    await fh.close();
+  }
+
+  const decipher = createDecipheriv(ALGORITHM, key, iv);
+  decipher.setAuthTag(tag);
+
+  const ciphertextStart = ENCRYPTED_HEADER_SIZE;
+  const ciphertextEnd = totalSize - GCM_TAG_SIZE - 1; // createReadStream end is inclusive
+  const hasCiphertext = ciphertextEnd >= ciphertextStart;
+
+  const tmp = tempPath(outputPath);
+  const writeStream = createWriteStream(tmp);
+
+  try {
+    const ciphertextStream = hasCiphertext
+      ? createReadStream(inputPath, {
+          start: ciphertextStart,
+          end: ciphertextEnd,
+        })
+      : Readable.from([]);
+
+    // pipeline consumes the ciphertext, pushes it through the decipher, and
+    // calls decipher.final() at the end — which is where auth tag verification
+    // happens. A bad tag surfaces here as a thrown error.
+    await pipeline(ciphertextStream, decipher, writeStream);
+
+    await rename(tmp, outputPath);
+  } catch (err) {
+    writeStream.destroy();
+    await safeUnlink(tmp);
+    throw err;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Verify
+// ---------------------------------------------------------------------------
+
+/**
+ * Verify that `path` is a valid AES-256-GCM encrypted bundle for `key` by
+ * running a full decrypt into a throwaway temp file. Returns `true` if the
+ * decrypt succeeds (auth tag matches, IV readable, etc.), `false` otherwise.
+ *
+ * Always cleans up the temp file, even on failure.
+ */
+export async function verifyEncryptedFile(
+  path: string,
+  key: Buffer,
+): Promise<boolean> {
+  const scratch = join(
+    tmpdir(),
+    `vellum-backup-verify-${process.pid}-${randomBytes(6).toString("hex")}`,
+  );
+  try {
+    await decryptFile(path, scratch, key);
+    return true;
+  } catch {
+    return false;
+  } finally {
+    await safeUnlink(scratch);
+  }
+}


### PR DESCRIPTION
## Summary
- Add streaming encrypt/decrypt helpers for backup bundles
- Uses AES-256-GCM with random 12-byte IV and 16-byte auth tag
- Streaming I/O keeps peak memory bounded regardless of file size

Part of plan: backup-restore-system.md (PR 3 of 12)