### PR TITLE
fix(test): route contacts-write trust-store writes to test workspace

### DIFF
--- a/assistant/src/__tests__/contacts-write.test.ts
+++ b/assistant/src/__tests__/contacts-write.test.ts
@@ -12,6 +12,16 @@ import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+// Route trust-store file writes at the test workspace's protected dir
+// instead of the real ~/.vellum/protected/trust.json. Must be set before
+// importing ../permissions/trust-store.js so getGatewaySecurityDir() picks
+// up the override at module load time. Matches the pattern in
+// checker.test.ts, trust-store.test.ts, etc.
+process.env.GATEWAY_SECURITY_DIR = join(
+  process.env.VELLUM_WORKSPACE_DIR!,
+  "protected",
+);
+
 mock.module("../util/logger.js", () => ({
   getLogger: () =>
     new Proxy({} as Record<string, unknown>, {


### PR DESCRIPTION
## Summary
- Set `GATEWAY_SECURITY_DIR` to the per-test workspace's `protected/` dir before importing `../permissions/trust-store.js` in `contacts-write.test.ts`.
- Prevents the regression-guard tests added in PR #24879 from clobbering the developer's real `~/.vellum/protected/trust.json`.

## Context

PR #24879 added a regression test that imports `clearAllRules` and `getAllRules` from `../permissions/trust-store.js` and calls them in `beforeEach`/test bodies. Both functions write to disk via `fileClearAllRules` → `saveToDisk` (see `trust-store.ts:597-609`). The file path is resolved from `getGatewaySecurityDir()`, which falls back to `~/.vellum/protected` when `GATEWAY_SECURITY_DIR` is unset.

Because PR #24879 did not set the env var before the import, running `bun test src/__tests__/contacts-write.test.ts` was writing to the developer's real `~/.vellum/protected/trust.json`. After the test runs, the file contains stale `default:allow-file_{read,write,edit}-guardian-persona` rules pointing at `/private/var/folders/.../vellum-test-workspace-XXX/users/carol.md` — a temp directory that no longer exists. This breaks permission matching on the real assistant: every `file_edit users/<slug>.md` would prompt for approval because the auto-allow rule points at a dead path.

Verified the blast radius on my machine:
- Before the fix: `trust.json` mtime updated after each test run, and stale guardian-persona entries with `vellum-test-workspace-XXX` paths appeared.
- After the fix: `trust.json` mtime unchanged across test runs (4 pass, 0 fail).

This follows the same `GATEWAY_SECURITY_DIR` override pattern used by every other trust-store-touching test file (`checker.test.ts:27-30`, `trust-store.test.ts`, `inline-skill-load-permissions.test.ts`, `ephemeral-permissions.test.ts`, `starter-bundle.test.ts`, `config-watcher-feature-flags.test.ts`).

## Follow-up suggestion
The `test-preload.ts` module could set `GATEWAY_SECURITY_DIR = join(testDir, "protected")` unconditionally so individual test files don't need to remember this. That would prevent the same class of bug for any future test that imports trust-store. Out of scope for this fix.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24884" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
