### PR TITLE
feat(backup): add local snapshot writer with retention

### DIFF
--- a/assistant/src/backup/__tests__/list-snapshots.test.ts
+++ b/assistant/src/backup/__tests__/list-snapshots.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Tests for `listSnapshotsInDir`. All tests run against a freshly-minted
+ * temp directory to avoid touching the real `~/.vellum/` tree.
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { listSnapshotsInDir } from "../list-snapshots.js";
+
+describe("listSnapshotsInDir", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "vellum-list-snapshots-"));
+  });
+
+  afterEach(() => {
+    try {
+      rmSync(root, { recursive: true, force: true });
+    } catch {
+      // best-effort
+    }
+  });
+
+  test("empty directory returns []", async () => {
+    const result = await listSnapshotsInDir(root);
+    expect(result).toEqual([]);
+  });
+
+  test("missing directory returns [] and does not throw", async () => {
+    const missing = join(root, "does-not-exist");
+    const result = await listSnapshotsInDir(missing);
+    expect(result).toEqual([]);
+  });
+
+  test("returns three backup files newest-first", async () => {
+    const names = [
+      "backup-20260411-100000.vbundle",
+      "backup-20260411-120000.vbundle",
+      "backup-20260411-110000.vbundle",
+    ];
+    for (const name of names) {
+      writeFileSync(join(root, name), `payload ${name}`);
+    }
+
+    const result = await listSnapshotsInDir(root);
+    expect(result.map((e) => e.filename)).toEqual([
+      "backup-20260411-120000.vbundle",
+      "backup-20260411-110000.vbundle",
+      "backup-20260411-100000.vbundle",
+    ]);
+    // Each entry has the right size and the parsed UTC timestamp.
+    expect(result[0].sizeBytes).toBe(
+      Buffer.byteLength("payload backup-20260411-120000.vbundle"),
+    );
+    expect(result[0].createdAt.toISOString()).toBe("2026-04-11T12:00:00.000Z");
+    expect(result[0].path).toBe(join(root, "backup-20260411-120000.vbundle"));
+  });
+
+  test("non-backup files are filtered out", async () => {
+    writeFileSync(join(root, "backup-20260411-120000.vbundle"), "real");
+    writeFileSync(join(root, "README.md"), "not a backup");
+    writeFileSync(join(root, "backup-20260411.vbundle"), "wrong shape");
+    writeFileSync(join(root, ".DS_Store"), "junk");
+
+    const result = await listSnapshotsInDir(root);
+    expect(result).toHaveLength(1);
+    expect(result[0].filename).toBe("backup-20260411-120000.vbundle");
+  });
+
+  test("mixed .vbundle and .vbundle.enc files set encrypted flag correctly", async () => {
+    writeFileSync(join(root, "backup-20260411-100000.vbundle"), "plain");
+    writeFileSync(join(root, "backup-20260411-110000.vbundle.enc"), "ciphered");
+
+    const result = await listSnapshotsInDir(root);
+    // Newest first.
+    expect(result.map((e) => e.filename)).toEqual([
+      "backup-20260411-110000.vbundle.enc",
+      "backup-20260411-100000.vbundle",
+    ]);
+    expect(result[0].encrypted).toBe(true);
+    expect(result[1].encrypted).toBe(false);
+  });
+});

--- a/assistant/src/backup/__tests__/local-writer.test.ts
+++ b/assistant/src/backup/__tests__/local-writer.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Tests for `writeLocalSnapshot` and `pruneLocalSnapshots`. All tests run
+ * against a temp directory to keep the real `~/.vellum/` tree untouched.
+ */
+
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { listSnapshotsInDir } from "../list-snapshots.js";
+import { pruneLocalSnapshots, writeLocalSnapshot } from "../local-writer.js";
+
+describe("writeLocalSnapshot", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "vellum-local-writer-"));
+  });
+
+  afterEach(() => {
+    try {
+      rmSync(root, { recursive: true, force: true });
+    } catch {
+      // best-effort
+    }
+  });
+
+  test("creates the target directory if missing and moves the temp file to the final name", async () => {
+    const tempPath = join(root, "stage.vbundle.tmp");
+    const payload = "fake bundle bytes";
+    writeFileSync(tempPath, payload);
+
+    // Nest one level so the writer must mkdir -p.
+    const localDir = join(root, "backups", "local");
+    const now = new Date("2026-04-11T15:30:45Z");
+
+    const entry = await writeLocalSnapshot(tempPath, localDir, now);
+
+    expect(entry.filename).toBe("backup-20260411-153045.vbundle");
+    expect(entry.path).toBe(join(localDir, "backup-20260411-153045.vbundle"));
+    expect(entry.encrypted).toBe(false);
+    expect(entry.createdAt).toBe(now);
+    expect(entry.sizeBytes).toBe(Buffer.byteLength(payload));
+
+    // Final file exists with the original payload.
+    expect(existsSync(entry.path)).toBe(true);
+    expect(readFileSync(entry.path, "utf8")).toBe(payload);
+    // Source temp file is gone (rename or copy+unlink, both clean up).
+    expect(existsSync(tempPath)).toBe(false);
+  });
+
+  test("returned SnapshotEntry has the correct filename, size, and timestamp", async () => {
+    const tempPath = join(root, "stage.tmp");
+    const payload = Buffer.alloc(1234, 0xab);
+    writeFileSync(tempPath, payload);
+
+    const localDir = join(root, "local");
+    const now = new Date("2026-01-02T03:04:05Z");
+    const entry = await writeLocalSnapshot(tempPath, localDir, now);
+
+    expect(entry.filename).toBe("backup-20260102-030405.vbundle");
+    expect(entry.sizeBytes).toBe(1234);
+    expect(entry.createdAt.toISOString()).toBe("2026-01-02T03:04:05.000Z");
+    // listSnapshotsInDir should round-trip the same entry.
+    const listed = await listSnapshotsInDir(localDir);
+    expect(listed).toHaveLength(1);
+    expect(listed[0].filename).toBe(entry.filename);
+    expect(listed[0].sizeBytes).toBe(entry.sizeBytes);
+    expect(listed[0].createdAt.toISOString()).toBe(
+      entry.createdAt.toISOString(),
+    );
+  });
+});
+
+describe("pruneLocalSnapshots", () => {
+  let root: string;
+  let localDir: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "vellum-prune-local-"));
+    localDir = join(root, "local");
+  });
+
+  afterEach(() => {
+    try {
+      rmSync(root, { recursive: true, force: true });
+    } catch {
+      // best-effort
+    }
+  });
+
+  /** Helper: drop N timestamped backup files into `localDir`. */
+  async function seed(count: number): Promise<string[]> {
+    await import("node:fs/promises").then((fsp) =>
+      fsp.mkdir(localDir, { recursive: true, mode: 0o700 }),
+    );
+    const names: string[] = [];
+    for (let i = 0; i < count; i++) {
+      // Use ascending hours so file index N is the Nth-oldest, with the
+      // last seeded entry being the newest.
+      const hour = i.toString().padStart(2, "0");
+      const name = `backup-20260411-${hour}0000.vbundle`;
+      writeFileSync(join(localDir, name), `payload ${i}`);
+      names.push(name);
+    }
+    return names;
+  }
+
+  test("with 7 existing + retention 3 keeps the 3 newest and deletes 4", async () => {
+    const seeded = await seed(7);
+    const expectedKept = seeded.slice(-3).reverse(); // newest-first
+    const expectedDeleted = seeded.slice(0, 4).reverse(); // newest-first within deletes
+
+    const result = await pruneLocalSnapshots(localDir, 3);
+
+    expect(result.kept.map((e) => e.filename)).toEqual(expectedKept);
+    expect(result.deleted.map((e) => e.filename)).toEqual(expectedDeleted);
+
+    // Filesystem matches.
+    const remaining = await listSnapshotsInDir(localDir);
+    expect(remaining.map((e) => e.filename)).toEqual(expectedKept);
+    for (const name of expectedDeleted) {
+      expect(existsSync(join(localDir, name))).toBe(false);
+    }
+  });
+
+  test("retention >= count keeps everything", async () => {
+    const seeded = await seed(3);
+    const result = await pruneLocalSnapshots(localDir, 10);
+    expect(result.deleted).toEqual([]);
+    expect(result.kept.map((e) => e.filename)).toEqual(
+      seeded.slice().reverse(),
+    );
+    // All files still on disk.
+    const remaining = await listSnapshotsInDir(localDir);
+    expect(remaining).toHaveLength(3);
+  });
+
+  test("retention === count keeps everything (boundary)", async () => {
+    await seed(3);
+    const result = await pruneLocalSnapshots(localDir, 3);
+    expect(result.deleted).toEqual([]);
+    expect(result.kept).toHaveLength(3);
+  });
+
+  test("retention 0 deletes everything (defensive — config schema rejects 0)", async () => {
+    const seeded = await seed(4);
+    const result = await pruneLocalSnapshots(localDir, 0);
+    expect(result.kept).toEqual([]);
+    expect(result.deleted).toHaveLength(4);
+    for (const name of seeded) {
+      expect(existsSync(join(localDir, name))).toBe(false);
+    }
+    const remaining = await listSnapshotsInDir(localDir);
+    expect(remaining).toEqual([]);
+  });
+
+  test("missing directory returns empty kept/deleted", async () => {
+    const result = await pruneLocalSnapshots(join(root, "nope"), 3);
+    expect(result.kept).toEqual([]);
+    expect(result.deleted).toEqual([]);
+  });
+});

--- a/assistant/src/backup/list-snapshots.ts
+++ b/assistant/src/backup/list-snapshots.ts
@@ -1,0 +1,85 @@
+/**
+ * Helpers for listing on-disk backup snapshots.
+ *
+ * A "snapshot" here is any file inside a backup destination directory whose
+ * name matches the canonical `backup-YYYYMMDD-HHMMSS.vbundle[.enc]` pattern
+ * defined in `./paths.ts`. Anything else (READMEs, dotfiles, partial writes)
+ * is silently ignored so callers can scan a destination without worrying
+ * about non-snapshot clutter.
+ *
+ * The list helper is intentionally pure: it takes an explicit directory and
+ * touches no global state, which makes both production code and tests cheap
+ * to drive against tmp directories.
+ */
+
+import { readdir, stat } from "node:fs/promises";
+import { join } from "node:path";
+
+import { parseBackupTimestamp } from "./paths.js";
+
+/**
+ * Metadata about a single backup snapshot file. The `path` is the absolute
+ * path on disk; `createdAt` is parsed from the filename (UTC) rather than
+ * read from filesystem mtime so that copies/restores preserve their original
+ * snapshot identity.
+ */
+export interface SnapshotEntry {
+  path: string;
+  filename: string;
+  createdAt: Date;
+  sizeBytes: number;
+  encrypted: boolean;
+}
+
+/**
+ * Lists all backup snapshots in a directory, newest-first.
+ *
+ * Returns `[]` when the directory does not exist -- this is a normal case
+ * for fresh installs where no backup has been written yet, so callers do
+ * not need to special-case ENOENT.
+ *
+ * Files that don't match the canonical backup filename pattern are
+ * filtered out. Encrypted snapshots (`.vbundle.enc`) and plaintext
+ * snapshots (`.vbundle`) are both returned, distinguished by the
+ * `encrypted` flag on each entry.
+ */
+export async function listSnapshotsInDir(
+  dir: string,
+): Promise<SnapshotEntry[]> {
+  let names: string[];
+  try {
+    names = await readdir(dir);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw err;
+  }
+
+  const entries: SnapshotEntry[] = [];
+  for (const name of names) {
+    const createdAt = parseBackupTimestamp(name);
+    if (createdAt == null) continue;
+    const fullPath = join(dir, name);
+    let stats;
+    try {
+      stats = await stat(fullPath);
+    } catch (err) {
+      // Race: a file we just listed may have been removed (e.g. by a
+      // concurrent prune). Skip it rather than failing the whole listing.
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") continue;
+      throw err;
+    }
+    if (!stats.isFile()) continue;
+    entries.push({
+      path: fullPath,
+      filename: name,
+      createdAt,
+      sizeBytes: stats.size,
+      encrypted: name.endsWith(".vbundle.enc"),
+    });
+  }
+
+  // Newest-first by parsed snapshot timestamp. Stable across filesystems
+  // since we don't depend on inode/mtime ordering from `readdir`.
+  entries.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+  return entries;
+}

--- a/assistant/src/backup/local-writer.ts
+++ b/assistant/src/backup/local-writer.ts
@@ -1,0 +1,104 @@
+/**
+ * Local snapshot writer + retention pruner.
+ *
+ * The "local" destination is the on-device backup directory (typically under
+ * `~/.vellum/backups/local`). It always stores plaintext `.vbundle` files --
+ * the encrypted variant is reserved for offsite destinations where the user
+ * cannot rely on filesystem-level access controls.
+ *
+ * Both helpers operate on an explicit directory path so callers can pick the
+ * right destination from config and so tests can drive everything against
+ * tmp directories without monkey-patching path helpers.
+ */
+
+import { copyFile, mkdir, rename, stat, unlink } from "node:fs/promises";
+import { join } from "node:path";
+
+import {
+  listSnapshotsInDir,
+  type SnapshotEntry,
+} from "./list-snapshots.js";
+import { formatBackupFilename } from "./paths.js";
+
+/**
+ * Move a freshly-built `.vbundle` temp file into the local backup directory
+ * under its canonical timestamped name.
+ *
+ * - Creates `localDir` (recursively, mode `0o700`) if it does not yet exist.
+ * - Renames the temp file to `<localDir>/backup-YYYYMMDD-HHMMSS.vbundle`.
+ *   On EXDEV (cross-device move, e.g. when the temp dir is on a different
+ *   filesystem than the backup directory) it falls back to copy + unlink.
+ * - Returns a `SnapshotEntry` describing the final on-disk file.
+ *
+ * The caller is expected to pass the same `now` it used when staging the
+ * bundle so that the filename, the entry's `createdAt`, and any external
+ * record stay in sync.
+ */
+export async function writeLocalSnapshot(
+  tempVBundlePath: string,
+  localDir: string,
+  now: Date,
+): Promise<SnapshotEntry> {
+  await mkdir(localDir, { recursive: true, mode: 0o700 });
+
+  const filename = formatBackupFilename(now, { encrypted: false });
+  const destPath = join(localDir, filename);
+
+  try {
+    await rename(tempVBundlePath, destPath);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "EXDEV") throw err;
+    // Cross-device fallback: copy then remove the source so callers don't
+    // leak the temp file. We deliberately use copyFile (not a stream pipe)
+    // because the bundle has already been fully written to disk by the
+    // staging step -- there's nothing to stream.
+    await copyFile(tempVBundlePath, destPath);
+    await unlink(tempVBundlePath);
+  }
+
+  const stats = await stat(destPath);
+  return {
+    path: destPath,
+    filename,
+    createdAt: now,
+    sizeBytes: stats.size,
+    encrypted: false,
+  };
+}
+
+/**
+ * Apply retention policy to the local backup directory.
+ *
+ * Lists snapshots newest-first, keeps the first `retention` entries, and
+ * `unlink`s the rest. Returns a `{ kept, deleted }` split so callers can
+ * log/report what happened without re-listing the directory.
+ *
+ * Edge cases:
+ * - Missing directory: returns `{ kept: [], deleted: [] }` (the listing
+ *   helper already swallows ENOENT).
+ * - `retention >= snapshots.length`: nothing is deleted; everything is kept.
+ * - `retention === 0`: every snapshot is deleted. The config schema rejects
+ *   `retention: 0` (min is 1), so this branch only fires when callers
+ *   explicitly opt into a wipe; treat it as a defensive guarantee.
+ */
+export async function pruneLocalSnapshots(
+  localDir: string,
+  retention: number,
+): Promise<{ kept: SnapshotEntry[]; deleted: SnapshotEntry[] }> {
+  const snapshots = await listSnapshotsInDir(localDir);
+  const kept = snapshots.slice(0, retention);
+  const deleted = snapshots.slice(retention);
+
+  for (const entry of deleted) {
+    try {
+      await unlink(entry.path);
+    } catch (err) {
+      // Tolerate races with concurrent prunes / external deletions: a
+      // file we just stat'd may have been removed before we could unlink.
+      // Anything else (EACCES, EBUSY, ...) should still propagate.
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+    }
+  }
+
+  return { kept, deleted };
+}


### PR DESCRIPTION
## Summary
- Add listSnapshotsInDir + writeLocalSnapshot + pruneLocalSnapshots helpers
- Retention logic keeps newest N, deletes the rest
- Standalone modules; no callers yet

Part of plan: backup-restore-system.md (PR 5 of 12)