### PR TITLE
feat(backup): add restore-from-snapshot helper

### DIFF
--- a/assistant/src/backup/__tests__/restore.test.ts
+++ b/assistant/src/backup/__tests__/restore.test.ts
@@ -1,0 +1,472 @@
+/**
+ * Tests for restoreFromSnapshot and verifySnapshot.
+ *
+ * The destructive bits of restore (commitImport — overwrites files,
+ * resets the DB, etc.) are stubbed via the `commitImpl` injection
+ * parameter so these tests never touch the live workspace.
+ */
+
+import { randomBytes } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { open } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { buildVBundle } from "../../runtime/migrations/vbundle-builder.js";
+import type { PathResolver } from "../../runtime/migrations/vbundle-import-analyzer.js";
+import type {
+  ImportCommitOptions,
+  ImportCommitResult,
+} from "../../runtime/migrations/vbundle-importer.js";
+import type { ManifestType } from "../../runtime/migrations/vbundle-validator.js";
+import { restoreFromSnapshot, verifySnapshot } from "../restore.js";
+import { ENCRYPTED_HEADER_SIZE, encryptFile } from "../stream-crypt.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+let TEST_DIR: string;
+
+beforeEach(() => {
+  TEST_DIR = join(
+    tmpdir(),
+    `vellum-restore-test-${randomBytes(6).toString("hex")}`,
+  );
+  mkdirSync(TEST_DIR, { recursive: true });
+});
+
+afterEach(() => {
+  try {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  } catch {
+    // best-effort
+  }
+});
+
+/**
+ * A null PathResolver — the stubbed commitImpl never calls it, so we just
+ * need a value of the right shape for the type-checker.
+ */
+const NULL_RESOLVER: PathResolver = {
+  resolve() {
+    return null;
+  },
+};
+
+/**
+ * Build a tiny in-memory plaintext .vbundle and write it to a path. Returns
+ * the file path along with the manifest the builder embedded so tests can
+ * compare against it.
+ */
+function writeTinyPlaintextBundle(
+  fileName: string,
+): { path: string; manifest: ManifestType } {
+  const { archive, manifest } = buildVBundle({
+    files: [
+      {
+        path: "workspace/notes/hello.txt",
+        data: new TextEncoder().encode("hello world"),
+      },
+      {
+        path: "workspace/notes/about.txt",
+        data: new TextEncoder().encode("a tiny bundle for tests"),
+      },
+    ],
+    source: "restore-test",
+    description: "tiny bundle for restore.test.ts",
+  });
+
+  const path = join(TEST_DIR, fileName);
+  writeFileSync(path, archive);
+  return { path, manifest };
+}
+
+/**
+ * Capture the arguments passed to commitImport without performing any
+ * destructive work. Records the call and returns a synthetic success
+ * report so the caller can introspect what the wrapper passed in.
+ */
+interface RecordedCall {
+  options: ImportCommitOptions;
+}
+
+function makeStubCommitImpl(): {
+  commitImpl: (options: ImportCommitOptions) => ImportCommitResult;
+  calls: RecordedCall[];
+} {
+  const calls: RecordedCall[] = [];
+  const commitImpl = (options: ImportCommitOptions): ImportCommitResult => {
+    calls.push({ options });
+    const manifest =
+      options.preValidatedManifest ??
+      ({
+        schema_version: "1.0",
+        created_at: new Date().toISOString(),
+        files: [],
+        manifest_sha256: "stub",
+      } satisfies ManifestType);
+    return {
+      ok: true,
+      report: {
+        success: true,
+        summary: {
+          total_files: manifest.files.length,
+          files_created: manifest.files.length,
+          files_overwritten: 0,
+          files_skipped: 0,
+          backups_created: 0,
+        },
+        files: [],
+        manifest,
+        warnings: [],
+      },
+    };
+  };
+  return { commitImpl, calls };
+}
+
+/** Throwing stub used to verify temp-file cleanup on commit failure. */
+function makeThrowingCommitImpl(): (
+  options: ImportCommitOptions,
+) => ImportCommitResult {
+  return () => {
+    throw new Error("simulated commit failure");
+  };
+}
+
+/**
+ * Snapshot the OS temp directory so tests can later verify that nothing
+ * matching `vellum-restore-*.vbundle` was left behind. Restricting the
+ * search to that prefix avoids racing with unrelated processes.
+ */
+function listRestoreTempArtifacts(): string[] {
+  return readdirSync(tmpdir()).filter((name) =>
+    name.startsWith("vellum-restore-"),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("verifySnapshot", () => {
+  test("plaintext: returns valid:true and the manifest for a well-formed bundle", async () => {
+    const { path, manifest } = writeTinyPlaintextBundle("plain.vbundle");
+
+    const result = await verifySnapshot(path, {});
+
+    expect(result.valid).toBe(true);
+    expect(result.manifest).toBeDefined();
+    expect(result.error).toBeUndefined();
+    expect(result.manifest?.manifest_sha256).toBe(manifest.manifest_sha256);
+    expect(result.manifest?.files.length).toBe(2);
+  });
+
+  test("encrypted: returns valid:true after decrypting first", async () => {
+    const { path: plainPath } = writeTinyPlaintextBundle("plain.vbundle");
+    const encPath = join(TEST_DIR, "plain.vbundle.enc");
+    const key = randomBytes(32);
+    await encryptFile(plainPath, encPath, key);
+
+    const before = listRestoreTempArtifacts();
+    const result = await verifySnapshot(encPath, { key });
+    const after = listRestoreTempArtifacts();
+
+    expect(result.valid).toBe(true);
+    expect(result.manifest).toBeDefined();
+    // The decrypted temp file must be cleaned up after verification.
+    expect(after.length).toBe(before.length);
+  });
+
+  test("encrypted with no key throws the typed error", async () => {
+    const { path: plainPath } = writeTinyPlaintextBundle("plain.vbundle");
+    const encPath = join(TEST_DIR, "plain.vbundle.enc");
+    const key = randomBytes(32);
+    await encryptFile(plainPath, encPath, key);
+
+    await expect(verifySnapshot(encPath, {})).rejects.toThrow(
+      "Encrypted snapshot requires a decryption key",
+    );
+  });
+
+  test("corrupt ciphertext: returns valid:false with the decrypt error", async () => {
+    const { path: plainPath } = writeTinyPlaintextBundle("plain.vbundle");
+    const encPath = join(TEST_DIR, "plain.vbundle.enc");
+    const key = randomBytes(32);
+    await encryptFile(plainPath, encPath, key);
+
+    // Flip a byte inside the ciphertext body — auth tag verification fails.
+    const flipOffset = ENCRYPTED_HEADER_SIZE + 4;
+    const fh = await open(encPath, "r+");
+    try {
+      const one = Buffer.alloc(1);
+      await fh.read(one, 0, 1, flipOffset);
+      one[0] = one[0] ^ 0xff;
+      await fh.write(one, 0, 1, flipOffset);
+    } finally {
+      await fh.close();
+    }
+
+    const before = listRestoreTempArtifacts();
+    const result = await verifySnapshot(encPath, { key });
+    const after = listRestoreTempArtifacts();
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(result.manifest).toBeUndefined();
+    // Even on failure, the decrypted temp file must be cleaned up.
+    expect(after.length).toBe(before.length);
+  });
+
+  test("corrupt manifest: returns valid:false with the validation error", async () => {
+    // Build a valid bundle, then re-encrypt with the manifest tampered.
+    // We tamper at the plaintext bundle level so encryption succeeds but
+    // validateVBundle catches the bad manifest.
+    const { archive } = buildVBundle({
+      files: [
+        {
+          path: "workspace/notes/hello.txt",
+          data: new TextEncoder().encode("hello"),
+        },
+      ],
+    });
+
+    // Flip a few bytes in the middle of the gzipped archive — this almost
+    // always corrupts the gzip stream itself or the embedded manifest JSON,
+    // both of which are validation failures (NOT decryption failures).
+    const tampered = Buffer.from(archive);
+    const tamperOffset = Math.floor(tampered.length / 2);
+    tampered[tamperOffset] = tampered[tamperOffset] ^ 0xff;
+    tampered[tamperOffset + 1] = tampered[tamperOffset + 1] ^ 0xff;
+
+    const path = join(TEST_DIR, "corrupt.vbundle");
+    writeFileSync(path, tampered);
+
+    const result = await verifySnapshot(path, {});
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(result.manifest).toBeUndefined();
+  });
+});
+
+describe("restoreFromSnapshot", () => {
+  test("plaintext round-trip: passes the validated bundle through to commitImpl", async () => {
+    const { path, manifest } = writeTinyPlaintextBundle("plain.vbundle");
+    const { commitImpl, calls } = makeStubCommitImpl();
+
+    const result = await restoreFromSnapshot(path, {
+      pathResolver: NULL_RESOLVER,
+      commitImpl,
+    });
+
+    expect(calls.length).toBe(1);
+    const passed = calls[0].options;
+    // The wrapper should pass the pre-validated manifest + entries so
+    // commitImport doesn't re-validate.
+    expect(passed.preValidatedManifest?.manifest_sha256).toBe(
+      manifest.manifest_sha256,
+    );
+    expect(passed.preValidatedEntries).toBeDefined();
+    expect(passed.preValidatedEntries?.has("manifest.json")).toBe(true);
+    expect(
+      passed.preValidatedEntries?.has("workspace/notes/hello.txt"),
+    ).toBe(true);
+    // archiveData must be the actual bundle bytes.
+    expect(passed.archiveData).toBeInstanceOf(Uint8Array);
+    expect(passed.archiveData.length).toBeGreaterThan(0);
+
+    // Public result is shaped correctly.
+    expect(result.manifest.manifest_sha256).toBe(manifest.manifest_sha256);
+    expect(result.restoredFiles).toBe(2);
+    expect(result.credentials).toEqual([]);
+  });
+
+  test("encrypted round-trip: decrypts then commits, and cleans up the temp file", async () => {
+    const { path: plainPath, manifest } =
+      writeTinyPlaintextBundle("plain.vbundle");
+    const encPath = join(TEST_DIR, "plain.vbundle.enc");
+    const key = randomBytes(32);
+    await encryptFile(plainPath, encPath, key);
+
+    const { commitImpl, calls } = makeStubCommitImpl();
+
+    const before = listRestoreTempArtifacts();
+    const result = await restoreFromSnapshot(encPath, {
+      key,
+      pathResolver: NULL_RESOLVER,
+      commitImpl,
+    });
+    const after = listRestoreTempArtifacts();
+
+    expect(calls.length).toBe(1);
+    expect(result.manifest.manifest_sha256).toBe(manifest.manifest_sha256);
+    expect(result.restoredFiles).toBe(2);
+
+    // Decrypted temp file must be cleaned up after the call.
+    expect(after.length).toBe(before.length);
+  });
+
+  test("encrypted with no key throws the typed error", async () => {
+    const { path: plainPath } = writeTinyPlaintextBundle("plain.vbundle");
+    const encPath = join(TEST_DIR, "plain.vbundle.enc");
+    const key = randomBytes(32);
+    await encryptFile(plainPath, encPath, key);
+
+    const { commitImpl, calls } = makeStubCommitImpl();
+
+    await expect(
+      restoreFromSnapshot(encPath, {
+        pathResolver: NULL_RESOLVER,
+        commitImpl,
+      }),
+    ).rejects.toThrow("Encrypted snapshot requires a decryption key");
+
+    expect(calls.length).toBe(0);
+  });
+
+  test("temp decrypted file is cleaned up after a commit failure", async () => {
+    const { path: plainPath } = writeTinyPlaintextBundle("plain.vbundle");
+    const encPath = join(TEST_DIR, "plain.vbundle.enc");
+    const key = randomBytes(32);
+    await encryptFile(plainPath, encPath, key);
+
+    const before = listRestoreTempArtifacts();
+    await expect(
+      restoreFromSnapshot(encPath, {
+        key,
+        pathResolver: NULL_RESOLVER,
+        commitImpl: makeThrowingCommitImpl(),
+      }),
+    ).rejects.toThrow("simulated commit failure");
+    const after = listRestoreTempArtifacts();
+
+    expect(after.length).toBe(before.length);
+  });
+
+  test("includeCredentials: surfaces credential entries to the caller", async () => {
+    const { archive, manifest } = buildVBundle({
+      files: [
+        {
+          path: "workspace/notes/hello.txt",
+          data: new TextEncoder().encode("hello"),
+        },
+        {
+          path: "credentials/openai_api_key",
+          data: new TextEncoder().encode("sk-test-1234"),
+        },
+        {
+          path: "credentials/anthropic_api_key",
+          data: new TextEncoder().encode("sk-ant-test-5678"),
+        },
+      ],
+    });
+
+    const path = join(TEST_DIR, "with-creds.vbundle");
+    writeFileSync(path, archive);
+
+    const { commitImpl } = makeStubCommitImpl();
+    const result = await restoreFromSnapshot(path, {
+      pathResolver: NULL_RESOLVER,
+      includeCredentials: true,
+      commitImpl,
+    });
+
+    expect(result.manifest.manifest_sha256).toBe(manifest.manifest_sha256);
+    // Credentials are extracted via extractCredentialsFromBundle, which
+    // returns one entry per credentials/* file. Order is not guaranteed,
+    // so we sort before comparing.
+    const sorted = [...result.credentials].sort((a, b) =>
+      a.account.localeCompare(b.account),
+    );
+    expect(sorted).toEqual([
+      { account: "anthropic_api_key", value: "sk-ant-test-5678" },
+      { account: "openai_api_key", value: "sk-test-1234" },
+    ]);
+  });
+
+  test("includeCredentials defaults to false", async () => {
+    const { archive } = buildVBundle({
+      files: [
+        {
+          path: "workspace/notes/hello.txt",
+          data: new TextEncoder().encode("hello"),
+        },
+        {
+          path: "credentials/secret_key",
+          data: new TextEncoder().encode("super-secret"),
+        },
+      ],
+    });
+
+    const path = join(TEST_DIR, "with-creds.vbundle");
+    writeFileSync(path, archive);
+
+    const { commitImpl } = makeStubCommitImpl();
+    const result = await restoreFromSnapshot(path, {
+      pathResolver: NULL_RESOLVER,
+      commitImpl,
+    });
+
+    expect(result.credentials).toEqual([]);
+  });
+
+  test("validation failure: throws with the validation error message", async () => {
+    // Write garbage to a .vbundle path — gzip decompression will fail.
+    const path = join(TEST_DIR, "garbage.vbundle");
+    writeFileSync(path, Buffer.from("not a real bundle"));
+
+    const { commitImpl, calls } = makeStubCommitImpl();
+
+    await expect(
+      restoreFromSnapshot(path, {
+        pathResolver: NULL_RESOLVER,
+        commitImpl,
+      }),
+    ).rejects.toThrow(/Snapshot failed validation/);
+
+    // commitImpl must NOT have been called when validation fails.
+    expect(calls.length).toBe(0);
+  });
+
+  test("commit returning a write_failed result is surfaced as an error", async () => {
+    const { path } = writeTinyPlaintextBundle("plain.vbundle");
+
+    // Stub that simulates a write failure (the importer returns this for
+    // disk errors like permission denied or partial bundle writes).
+    const failingCommit = (
+      _opts: ImportCommitOptions,
+    ): ImportCommitResult => ({
+      ok: false,
+      reason: "write_failed",
+      message: "disk full",
+    });
+
+    await expect(
+      restoreFromSnapshot(path, {
+        pathResolver: NULL_RESOLVER,
+        commitImpl: failingCommit,
+      }),
+    ).rejects.toThrow(/disk full/);
+  });
+});
+
+describe("snapshot path detection", () => {
+  test("plaintext path that doesn't exist surfaces an I/O error from verify", async () => {
+    const path = join(TEST_DIR, "missing.vbundle");
+    expect(existsSync(path)).toBe(false);
+
+    const result = await verifySnapshot(path, {});
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+});

--- a/assistant/src/backup/restore.ts
+++ b/assistant/src/backup/restore.ts
@@ -1,0 +1,310 @@
+/**
+ * High-level helpers for restoring and verifying backup snapshots produced
+ * by the backup pipeline.
+ *
+ * A snapshot is one of:
+ *   - A plaintext `.vbundle` file (gzipped tar — see `vbundle-builder.ts`).
+ *   - An encrypted `.vbundle.enc` file produced by `stream-crypt.encryptFile`.
+ *
+ * The encryption status is detected purely from the file extension:
+ *   - `.vbundle.enc` → encrypted (decryption key required)
+ *   - `.vbundle`     → plaintext
+ *
+ * For encrypted snapshots, this module decrypts to a temporary file under the
+ * OS temp directory, runs validation, and then either commits the import or
+ * just reports validation status. The temp file is always cleaned up — on
+ * success and on failure — via a `try { ... } finally { unlink }` block.
+ *
+ * Restore is intentionally a thin wrapper around the existing
+ * `commitImport` flow in `runtime/migrations/vbundle-importer.ts`. That
+ * function owns the destructive bits (backup-before-overwrite, atomic
+ * write semantics, post-write integrity checks). This module just adds
+ * snapshot-format detection and decrypted-temp-file lifecycle management.
+ */
+
+import { randomUUID } from "node:crypto";
+import { readFile, unlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type { PathResolver } from "../runtime/migrations/vbundle-import-analyzer.js";
+import {
+  commitImport,
+  extractCredentialsFromBundle,
+} from "../runtime/migrations/vbundle-importer.js";
+import type { ManifestType } from "../runtime/migrations/vbundle-validator.js";
+import { validateVBundle } from "../runtime/migrations/vbundle-validator.js";
+import { decryptFile } from "./stream-crypt.js";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * Optional injection point for the underlying commit function. Tests pass a
+ * fake here to avoid running the destructive `commitImport` flow against the
+ * live workspace. Production callers should leave this unset so the real
+ * importer is used.
+ */
+export type CommitImpl = typeof commitImport;
+
+export interface RestoreOptions {
+  /** AES-256 decryption key. Required for `.vbundle.enc` snapshots. */
+  key?: Buffer;
+  /**
+   * Whether to extract credential entries from the bundle and return them
+   * to the caller. Defaults to `false` — credentials are handled by a
+   * separate import path and intentionally excluded from a normal restore.
+   */
+  includeCredentials?: boolean;
+  /**
+   * Resolver that maps archive paths (e.g. `workspace/config.json`) to
+   * absolute disk paths. Required by the underlying `commitImport` flow.
+   */
+  pathResolver: PathResolver;
+  /**
+   * Absolute path to the workspace directory. When set and the bundle
+   * contains `workspace/` entries, `commitImport` clears the workspace
+   * before writing to ensure an exact-match restore.
+   */
+  workspaceDir?: string;
+  /**
+   * Optional override for the underlying commit function. Tests inject a
+   * fake to avoid mutating disk; production callers should leave this unset.
+   */
+  commitImpl?: CommitImpl;
+}
+
+export interface RestoreResult {
+  /** Manifest from the bundle that was restored. */
+  manifest: ManifestType;
+  /** Number of files written (or skipped) by the underlying commit. */
+  restoredFiles: number;
+  /**
+   * Credential entries extracted from the bundle when
+   * `includeCredentials` was set. Empty array otherwise.
+   */
+  credentials: Array<{ account: string; value: string }>;
+}
+
+export interface VerifyOptions {
+  /** AES-256 decryption key. Required for `.vbundle.enc` snapshots. */
+  key?: Buffer;
+}
+
+export interface VerifyResult {
+  /** True iff the bundle decrypts (when applicable) and validates. */
+  valid: boolean;
+  /** Manifest from the bundle when `valid` is true. */
+  manifest?: ManifestType;
+  /**
+   * Human-readable error message when `valid` is false. Populated for
+   * validation failures, decryption failures, and missing-file errors.
+   * Always undefined when `valid` is true.
+   */
+  error?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/** Returns true if the snapshot path indicates an encrypted bundle. */
+function isEncryptedSnapshot(snapshotPath: string): boolean {
+  return snapshotPath.endsWith(".vbundle.enc");
+}
+
+/** Build a unique temp path for a decrypted bundle. */
+function makeDecryptedTempPath(): string {
+  return join(tmpdir(), `vellum-restore-${randomUUID()}.vbundle`);
+}
+
+/**
+ * Resolve `snapshotPath` to a path that holds plaintext `.vbundle` bytes.
+ *
+ * For plaintext snapshots, this just returns `{ path: snapshotPath }`. For
+ * encrypted snapshots, it decrypts to a fresh temp file and returns
+ * `{ path: tmpPath, tmpPath }` so the caller can clean up afterwards.
+ *
+ * Throws when an encrypted bundle has no key, when `decryptFile` fails
+ * (bad key, tampered ciphertext, truncated file), or on any I/O error.
+ */
+async function materializePlaintext(
+  snapshotPath: string,
+  key: Buffer | undefined,
+): Promise<{ path: string; tmpPath: string | null }> {
+  if (!isEncryptedSnapshot(snapshotPath)) {
+    return { path: snapshotPath, tmpPath: null };
+  }
+
+  if (!key) {
+    throw new Error("Encrypted snapshot requires a decryption key");
+  }
+
+  const tmpPath = makeDecryptedTempPath();
+  await decryptFile(snapshotPath, tmpPath, key);
+  return { path: tmpPath, tmpPath };
+}
+
+/** Best-effort temp file cleanup — swallows ENOENT and other errors. */
+async function safeUnlink(path: string | null): Promise<void> {
+  if (!path) return;
+  try {
+    await unlink(path);
+  } catch {
+    // Best-effort — temp file may already be gone.
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Restore a backup snapshot into the workspace.
+ *
+ * Auto-detects encryption from the file extension. Encrypted snapshots
+ * (`.vbundle.enc`) decrypt to a temp file under `tmpdir()` before
+ * validation; the temp file is unlinked in a `finally` block so it never
+ * lingers, even on validation or commit failure.
+ *
+ * The actual restore is delegated to `commitImport`, which owns the
+ * backup-before-overwrite, workspace-clearing, and integrity-check logic.
+ * Tests can pass `opts.commitImpl` to substitute a fake without mutating
+ * the live workspace.
+ */
+export async function restoreFromSnapshot(
+  snapshotPath: string,
+  opts: RestoreOptions,
+): Promise<RestoreResult> {
+  const {
+    key,
+    includeCredentials = false,
+    pathResolver,
+    workspaceDir,
+    commitImpl = commitImport,
+  } = opts;
+
+  let tmpPath: string | null = null;
+  try {
+    const materialized = await materializePlaintext(snapshotPath, key);
+    tmpPath = materialized.tmpPath;
+
+    // Read plaintext bytes for validation + commit. validateVBundle takes
+    // raw bytes (Uint8Array) — file paths are not part of its API.
+    const fileData = await readFile(materialized.path);
+
+    const validation = validateVBundle(fileData);
+    if (!validation.is_valid || !validation.manifest || !validation.entries) {
+      const summary = validation.errors
+        .map((e) => `${e.code}: ${e.message}`)
+        .join("; ");
+      throw new Error(`Snapshot failed validation: ${summary}`);
+    }
+
+    // Extract credentials before commitImport runs — commitImport skips
+    // credential entries by design (they live behind the secure store API),
+    // so we read them out of the parsed entry map first.
+    const credentials = includeCredentials
+      ? extractCredentialsFromBundle(validation.entries, validation.manifest)
+      : [];
+
+    const commitResult = commitImpl({
+      archiveData: fileData,
+      pathResolver,
+      preValidatedManifest: validation.manifest,
+      preValidatedEntries: validation.entries,
+      workspaceDir,
+    });
+
+    if (!commitResult.ok) {
+      // Surface a single error message regardless of which discriminated
+      // branch failed — callers in the backup CLI just want a message.
+      let message: string;
+      switch (commitResult.reason) {
+        case "validation_failed":
+          message = commitResult.errors
+            .map((e) => `${e.code}: ${e.message}`)
+            .join("; ");
+          break;
+        case "extraction_failed":
+        case "write_failed":
+          message = commitResult.message;
+          break;
+      }
+      throw new Error(`Snapshot restore failed: ${message}`);
+    }
+
+    return {
+      manifest: commitResult.report.manifest,
+      restoredFiles: commitResult.report.summary.total_files,
+      credentials,
+    };
+  } finally {
+    await safeUnlink(tmpPath);
+  }
+}
+
+/**
+ * Verify a backup snapshot without restoring it.
+ *
+ * Auto-detects encryption from the file extension and decrypts to a temp
+ * file when needed (cleaned up in a `finally` block). Runs the same
+ * `validateVBundle` checks the importer would run, but never touches the
+ * workspace.
+ *
+ * Does NOT throw on validation or decryption failure — those are returned
+ * as `{ valid: false, error: ... }`. Only the missing-key precondition
+ * for encrypted bundles throws, since that is a programmer error.
+ */
+export async function verifySnapshot(
+  snapshotPath: string,
+  opts: VerifyOptions,
+): Promise<VerifyResult> {
+  const { key } = opts;
+
+  // Encrypted bundles must have a key — this is a precondition error,
+  // not a validation failure, so we throw rather than return.
+  if (isEncryptedSnapshot(snapshotPath) && !key) {
+    throw new Error("Encrypted snapshot requires a decryption key");
+  }
+
+  let tmpPath: string | null = null;
+  try {
+    let plaintextPath: string;
+    try {
+      const materialized = await materializePlaintext(snapshotPath, key);
+      tmpPath = materialized.tmpPath;
+      plaintextPath = materialized.path;
+    } catch (err) {
+      // Decryption / I/O failure — surface as a soft error so verification
+      // callers (e.g. snapshot list health checks) get a uniform shape.
+      return {
+        valid: false,
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+
+    let fileData: Uint8Array;
+    try {
+      fileData = await readFile(plaintextPath);
+    } catch (err) {
+      return {
+        valid: false,
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+
+    const validation = validateVBundle(fileData);
+    if (!validation.is_valid || !validation.manifest) {
+      const summary = validation.errors
+        .map((e) => `${e.code}: ${e.message}`)
+        .join("; ");
+      return { valid: false, error: summary };
+    }
+
+    return { valid: true, manifest: validation.manifest };
+  } finally {
+    await safeUnlink(tmpPath);
+  }
+}


### PR DESCRIPTION
## Summary
- Add restoreFromSnapshot and verifySnapshot helpers
- Auto-detects encryption by file extension, decrypts before validate+commit
- Temp files always cleaned up, even on error

Part of plan: backup-restore-system.md (PR 7 of 12)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24886" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
