### PR TITLE
feat(backup): add encrypted offsite snapshot writer with multi-destination support

### DIFF
--- a/assistant/src/backup/__tests__/offsite-writer.test.ts
+++ b/assistant/src/backup/__tests__/offsite-writer.test.ts
@@ -1,0 +1,517 @@
+/**
+ * Tests for `writeOffsiteSnapshotToOne`, `writeOffsiteSnapshotToAll`, and
+ * `pruneOffsiteSnapshotsInAll`. All tests run against a temp directory so
+ * the real `~/.vellum/` tree is never touched.
+ */
+
+import { randomBytes } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import type { BackupDestination } from "../../config/schema.js";
+import { listSnapshotsInDir } from "../list-snapshots.js";
+import {
+  pruneOffsiteSnapshotsInAll,
+  writeOffsiteSnapshotToAll,
+  writeOffsiteSnapshotToOne,
+} from "../offsite-writer.js";
+import { decryptFile } from "../stream-crypt.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+let ROOT: string;
+
+beforeEach(() => {
+  ROOT = mkdtempSync(join(tmpdir(), "vellum-offsite-writer-"));
+});
+
+afterEach(() => {
+  try {
+    rmSync(ROOT, { recursive: true, force: true });
+  } catch {
+    // best-effort
+  }
+});
+
+/** Write a fake local snapshot file and return its absolute path. */
+function seedLocalSnapshot(payload: Buffer | string): string {
+  const path = join(ROOT, "local.vbundle");
+  writeFileSync(path, payload);
+  return path;
+}
+
+/** Absolute path helper for tests that need to construct destinations. */
+function subPath(...segments: string[]): string {
+  return join(ROOT, ...segments);
+}
+
+// ---------------------------------------------------------------------------
+// writeOffsiteSnapshotToOne
+// ---------------------------------------------------------------------------
+
+describe("writeOffsiteSnapshotToOne", () => {
+  const NOW = new Date("2026-04-11T15:30:45Z");
+
+  test("returns skipped=parent-missing when the parent directory does not exist", async () => {
+    const localSnapshotPath = seedLocalSnapshot("payload");
+    // Parent "does/not/exist" is not created.
+    const destination: BackupDestination = {
+      path: subPath("does", "not", "exist", "backups"),
+      encrypt: true,
+    };
+    const key = randomBytes(32);
+
+    const result = await writeOffsiteSnapshotToOne(
+      localSnapshotPath,
+      destination,
+      key,
+      NOW,
+    );
+
+    expect(result.skipped).toBe("parent-missing");
+    expect(result.entry).toBeNull();
+    expect(result.error).toBeUndefined();
+    expect(result.destination).toEqual(destination);
+  });
+
+  test("encrypt=true writes a .vbundle.enc that round-trips through decryptFile", async () => {
+    const plaintext = randomBytes(2048);
+    const localSnapshotPath = seedLocalSnapshot(plaintext);
+
+    // Parent exists; destination directory itself does not yet.
+    const parent = subPath("icloud");
+    mkdirSync(parent, { recursive: true });
+    const destination: BackupDestination = {
+      path: join(parent, "backups"),
+      encrypt: true,
+    };
+    const key = randomBytes(32);
+
+    const result = await writeOffsiteSnapshotToOne(
+      localSnapshotPath,
+      destination,
+      key,
+      NOW,
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.skipped).toBeUndefined();
+    expect(result.entry).not.toBeNull();
+    expect(result.entry!.filename).toBe("backup-20260411-153045.vbundle.enc");
+    expect(result.entry!.encrypted).toBe(true);
+    expect(result.entry!.createdAt).toBe(NOW);
+    expect(result.entry!.path).toBe(
+      join(destination.path, "backup-20260411-153045.vbundle.enc"),
+    );
+    expect(existsSync(result.entry!.path)).toBe(true);
+
+    // Round-trip through decryptFile to confirm the ciphertext actually
+    // decrypts to the original bytes.
+    const roundTripPath = subPath("roundtrip.bin");
+    await decryptFile(result.entry!.path, roundTripPath, key);
+    const decoded = readFileSync(roundTripPath);
+    expect(decoded.equals(plaintext)).toBe(true);
+  });
+
+  test("encrypt=false writes a plaintext .vbundle that byte-equals the source", async () => {
+    const plaintext = randomBytes(4096);
+    const localSnapshotPath = seedLocalSnapshot(plaintext);
+
+    const parent = subPath("external-ssd");
+    mkdirSync(parent, { recursive: true });
+    const destination: BackupDestination = {
+      path: join(parent, "vellum-backups"),
+      encrypt: false,
+    };
+
+    const result = await writeOffsiteSnapshotToOne(
+      localSnapshotPath,
+      destination,
+      null, // no key needed for plaintext
+      NOW,
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.skipped).toBeUndefined();
+    expect(result.entry).not.toBeNull();
+    expect(result.entry!.filename).toBe("backup-20260411-153045.vbundle");
+    expect(result.entry!.encrypted).toBe(false);
+    expect(result.entry!.sizeBytes).toBe(plaintext.length);
+
+    // Byte-equal check against the source file.
+    const written = readFileSync(result.entry!.path);
+    expect(written.equals(plaintext)).toBe(true);
+
+    // No stray .tmp sibling left behind.
+    expect(existsSync(`${result.entry!.path}.tmp`)).toBe(false);
+  });
+
+  test("encrypt=true with key=null returns an error (caught internally, not thrown)", async () => {
+    const localSnapshotPath = seedLocalSnapshot("payload");
+
+    const parent = subPath("icloud");
+    mkdirSync(parent, { recursive: true });
+    const destination: BackupDestination = {
+      path: join(parent, "backups"),
+      encrypt: true,
+    };
+
+    const result = await writeOffsiteSnapshotToOne(
+      localSnapshotPath,
+      destination,
+      null, // missing key despite encrypt=true
+      NOW,
+    );
+
+    expect(result.entry).toBeNull();
+    expect(result.skipped).toBeUndefined();
+    expect(result.error).toBeDefined();
+    expect(result.error).toContain("encryption");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// writeOffsiteSnapshotToAll
+// ---------------------------------------------------------------------------
+
+describe("writeOffsiteSnapshotToAll", () => {
+  const NOW = new Date("2026-04-11T15:30:45Z");
+
+  test("empty destinations returns [] immediately", async () => {
+    const localSnapshotPath = seedLocalSnapshot("payload");
+    const result = await writeOffsiteSnapshotToAll(
+      localSnapshotPath,
+      [],
+      null,
+      NOW,
+    );
+    expect(result).toEqual([]);
+  });
+
+  test("multi-destination: encrypted + plaintext writes succeed with correct extensions", async () => {
+    const plaintext = randomBytes(1024);
+    const localSnapshotPath = seedLocalSnapshot(plaintext);
+
+    const parentA = subPath("icloud");
+    const parentB = subPath("external-ssd");
+    mkdirSync(parentA, { recursive: true });
+    mkdirSync(parentB, { recursive: true });
+
+    const destinations: BackupDestination[] = [
+      { path: join(parentA, "backups"), encrypt: true },
+      { path: join(parentB, "vellum-backups"), encrypt: false },
+    ];
+    const key = randomBytes(32);
+
+    const results = await writeOffsiteSnapshotToAll(
+      localSnapshotPath,
+      destinations,
+      key,
+      NOW,
+    );
+
+    expect(results).toHaveLength(2);
+
+    // Encrypted destination
+    expect(results[0].destination).toEqual(destinations[0]);
+    expect(results[0].entry).not.toBeNull();
+    expect(results[0].entry!.filename).toBe("backup-20260411-153045.vbundle.enc");
+    expect(results[0].entry!.encrypted).toBe(true);
+    expect(results[0].skipped).toBeUndefined();
+    expect(results[0].error).toBeUndefined();
+
+    // Plaintext destination
+    expect(results[1].destination).toEqual(destinations[1]);
+    expect(results[1].entry).not.toBeNull();
+    expect(results[1].entry!.filename).toBe("backup-20260411-153045.vbundle");
+    expect(results[1].entry!.encrypted).toBe(false);
+    expect(results[1].skipped).toBeUndefined();
+    expect(results[1].error).toBeUndefined();
+
+    // Plaintext copy is byte-equal to source.
+    expect(readFileSync(results[1].entry!.path).equals(plaintext)).toBe(true);
+  });
+
+  test("one destination with a missing parent is skipped while the other succeeds", async () => {
+    const localSnapshotPath = seedLocalSnapshot("payload");
+
+    const parentA = subPath("icloud");
+    mkdirSync(parentA, { recursive: true });
+
+    const destinations: BackupDestination[] = [
+      { path: join(parentA, "backups"), encrypt: false }, // OK
+      { path: subPath("missing", "mount", "backups"), encrypt: false }, // parent missing
+    ];
+
+    const results = await writeOffsiteSnapshotToAll(
+      localSnapshotPath,
+      destinations,
+      null,
+      NOW,
+    );
+
+    expect(results).toHaveLength(2);
+
+    // A succeeded.
+    expect(results[0].entry).not.toBeNull();
+    expect(results[0].skipped).toBeUndefined();
+    expect(results[0].error).toBeUndefined();
+    expect(existsSync(results[0].entry!.path)).toBe(true);
+
+    // B skipped (parent missing).
+    expect(results[1].entry).toBeNull();
+    expect(results[1].skipped).toBe("parent-missing");
+    expect(results[1].error).toBeUndefined();
+  });
+
+  test("one destination throwing (dest.path is a file) reports error while the other still succeeds", async () => {
+    const localSnapshotPath = seedLocalSnapshot("payload");
+
+    const parentA = subPath("icloud");
+    const parentB = subPath("broken");
+    mkdirSync(parentA, { recursive: true });
+    mkdirSync(parentB, { recursive: true });
+
+    // Force B's `destination.path` to be a file, which makes the mkdir +
+    // write paths throw (a file exists where the destination directory
+    // should be).
+    const brokenDestPath = join(parentB, "not-a-dir");
+    writeFileSync(brokenDestPath, "I am a file, not a directory");
+
+    const destinations: BackupDestination[] = [
+      { path: join(parentA, "backups"), encrypt: false },
+      { path: brokenDestPath, encrypt: false },
+    ];
+
+    const results = await writeOffsiteSnapshotToAll(
+      localSnapshotPath,
+      destinations,
+      null,
+      NOW,
+    );
+
+    expect(results).toHaveLength(2);
+
+    // A still succeeded.
+    expect(results[0].entry).not.toBeNull();
+    expect(results[0].error).toBeUndefined();
+
+    // B failed with an error (not a skip — its parent exists).
+    expect(results[1].entry).toBeNull();
+    expect(results[1].skipped).toBeUndefined();
+    expect(results[1].error).toBeDefined();
+  });
+
+  test("writes are sequential: after each iteration the corresponding destination has exactly one file", async () => {
+    // We verify order by having each destination's mtime reflect the order
+    // of writes. A simpler check: by the time writeOffsiteSnapshotToAll
+    // returns, both files exist; and each intermediate result is fully
+    // formed (not a promise-like stub). Sequential ordering is also enforced
+    // at compile time by the for...of + await structure.
+    const plaintext = randomBytes(256);
+    const localSnapshotPath = seedLocalSnapshot(plaintext);
+
+    const parents = [subPath("p0"), subPath("p1"), subPath("p2")];
+    for (const p of parents) mkdirSync(p, { recursive: true });
+    const destinations: BackupDestination[] = parents.map((p) => ({
+      path: join(p, "dst"),
+      encrypt: false,
+    }));
+
+    const results = await writeOffsiteSnapshotToAll(
+      localSnapshotPath,
+      destinations,
+      null,
+      new Date("2026-04-11T15:30:45Z"),
+    );
+
+    expect(results).toHaveLength(3);
+    // Ordering by destination.path matches the input, which is only
+    // guaranteed if we loop sequentially (Promise.all would also preserve
+    // order, but then interleaved destination failures could interact).
+    for (let i = 0; i < destinations.length; i++) {
+      expect(results[i].destination.path).toBe(destinations[i].path);
+      expect(results[i].entry).not.toBeNull();
+      const listed = await listSnapshotsInDir(destinations[i].path);
+      expect(listed).toHaveLength(1);
+    }
+  });
+
+  test("only plaintext destinations with key=null succeeds (no key required)", async () => {
+    const plaintext = randomBytes(512);
+    const localSnapshotPath = seedLocalSnapshot(plaintext);
+
+    const parentA = subPath("a");
+    const parentB = subPath("b");
+    mkdirSync(parentA, { recursive: true });
+    mkdirSync(parentB, { recursive: true });
+
+    const destinations: BackupDestination[] = [
+      { path: join(parentA, "dst"), encrypt: false },
+      { path: join(parentB, "dst"), encrypt: false },
+    ];
+
+    const results = await writeOffsiteSnapshotToAll(
+      localSnapshotPath,
+      destinations,
+      null,
+      new Date("2026-04-11T15:30:45Z"),
+    );
+
+    expect(results).toHaveLength(2);
+    for (const r of results) {
+      expect(r.entry).not.toBeNull();
+      expect(r.error).toBeUndefined();
+      expect(r.skipped).toBeUndefined();
+      expect(readFileSync(r.entry!.path).equals(plaintext)).toBe(true);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pruneOffsiteSnapshotsInAll
+// ---------------------------------------------------------------------------
+
+describe("pruneOffsiteSnapshotsInAll", () => {
+  /**
+   * Seed `count` timestamped backup files into `dir`. Ascending hours mean
+   * file index N is the Nth-oldest, so the last seeded file is the newest.
+   * Alternates `.vbundle` / `.vbundle.enc` when `mixed` is true.
+   */
+  function seed(
+    dir: string,
+    count: number,
+    mixed = false,
+  ): string[] {
+    mkdirSync(dir, { recursive: true });
+    const names: string[] = [];
+    for (let i = 0; i < count; i++) {
+      const hour = i.toString().padStart(2, "0");
+      const ext = mixed && i % 2 === 0 ? ".vbundle.enc" : ".vbundle";
+      const name = `backup-20260411-${hour}0000${ext}`;
+      writeFileSync(join(dir, name), `payload ${i}`);
+      names.push(name);
+    }
+    return names;
+  }
+
+  test("two destinations with 10 files each, retention 7: each keeps its own 7 newest", async () => {
+    const parentA = subPath("a");
+    const parentB = subPath("b");
+    mkdirSync(parentA, { recursive: true });
+    mkdirSync(parentB, { recursive: true });
+
+    const dirA = join(parentA, "dst");
+    const dirB = join(parentB, "dst");
+    const seededA = seed(dirA, 10);
+    const seededB = seed(dirB, 10);
+
+    const destinations: BackupDestination[] = [
+      { path: dirA, encrypt: false },
+      { path: dirB, encrypt: false },
+    ];
+
+    const results = await pruneOffsiteSnapshotsInAll(destinations, 7);
+
+    expect(results).toHaveLength(2);
+
+    // A: 7 newest kept, 3 oldest deleted.
+    expect(results[0].destination).toEqual(destinations[0]);
+    expect(results[0].kept).toHaveLength(7);
+    expect(results[0].deleted).toHaveLength(3);
+    expect(results[0].skipped).toBeUndefined();
+    // Filesystem matches.
+    const remainingA = await listSnapshotsInDir(dirA);
+    expect(remainingA).toHaveLength(7);
+    // Oldest three (indexes 0..2) are gone.
+    for (const name of seededA.slice(0, 3)) {
+      expect(existsSync(join(dirA, name))).toBe(false);
+    }
+
+    // B: same, independently of A.
+    expect(results[1].destination).toEqual(destinations[1]);
+    expect(results[1].kept).toHaveLength(7);
+    expect(results[1].deleted).toHaveLength(3);
+    expect(results[1].skipped).toBeUndefined();
+    const remainingB = await listSnapshotsInDir(dirB);
+    expect(remainingB).toHaveLength(7);
+    for (const name of seededB.slice(0, 3)) {
+      expect(existsSync(join(dirB, name))).toBe(false);
+    }
+  });
+
+  test("a destination with a missing parent returns skipped=true for that entry only", async () => {
+    const parentA = subPath("a");
+    mkdirSync(parentA, { recursive: true });
+    const dirA = join(parentA, "dst");
+    seed(dirA, 5);
+
+    const destinations: BackupDestination[] = [
+      { path: dirA, encrypt: false },
+      // Parent does not exist.
+      { path: subPath("missing", "mount", "dst"), encrypt: false },
+    ];
+
+    const results = await pruneOffsiteSnapshotsInAll(destinations, 3);
+
+    expect(results).toHaveLength(2);
+
+    // A pruned normally.
+    expect(results[0].skipped).toBeUndefined();
+    expect(results[0].kept).toHaveLength(3);
+    expect(results[0].deleted).toHaveLength(2);
+
+    // B is skipped — parent missing.
+    expect(results[1].skipped).toBe(true);
+    expect(results[1].kept).toEqual([]);
+    expect(results[1].deleted).toEqual([]);
+  });
+
+  test("mixed .vbundle and .vbundle.enc files in one directory are pruned as a single pool ordered by timestamp", async () => {
+    const parent = subPath("a");
+    mkdirSync(parent, { recursive: true });
+    const dir = join(parent, "dst");
+    // 10 files alternating .vbundle.enc (even indexes) and .vbundle (odd).
+    const seeded = seed(dir, 10, /* mixed */ true);
+
+    const destinations: BackupDestination[] = [
+      { path: dir, encrypt: true }, // encrypt flag is unrelated to prune logic
+    ];
+
+    const results = await pruneOffsiteSnapshotsInAll(destinations, 4);
+    expect(results).toHaveLength(1);
+
+    const { kept, deleted } = results[0];
+    // 4 newest kept, 6 oldest deleted — pool treats both extensions the same.
+    expect(kept).toHaveLength(4);
+    expect(deleted).toHaveLength(6);
+
+    // Newest four are indexes 6..9 (ascending hours, so 09,08,07,06 newest-first).
+    const expectedKeptNames = seeded.slice(-4).reverse();
+    expect(kept.map((e) => e.filename)).toEqual(expectedKeptNames);
+
+    // Deleted six are indexes 0..5, returned in the original newest-first
+    // sort from listSnapshotsInDir: 05, 04, 03, 02, 01, 00.
+    const expectedDeletedNames = seeded.slice(0, 6).reverse();
+    expect(deleted.map((e) => e.filename)).toEqual(expectedDeletedNames);
+
+    // Filesystem check: mixed extensions gone for indexes 0..5.
+    for (const name of expectedDeletedNames) {
+      expect(existsSync(join(dir, name))).toBe(false);
+    }
+    // Kept files still on disk.
+    const remaining = await listSnapshotsInDir(dir);
+    expect(remaining.map((e) => e.filename)).toEqual(expectedKeptNames);
+  });
+});

--- a/assistant/src/backup/list-snapshots.ts
+++ b/assistant/src/backup/list-snapshots.ts
@@ -12,8 +12,8 @@
  * to drive against tmp directories.
  */
 
-import { readdir, stat } from "node:fs/promises";
-import { join } from "node:path";
+import { readdir, stat, unlink } from "node:fs/promises";
+import { dirname, join } from "node:path";
 
 import { parseBackupTimestamp } from "./paths.js";
 
@@ -82,4 +82,66 @@ export async function listSnapshotsInDir(
   // since we don't depend on inode/mtime ordering from `readdir`.
   entries.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
   return entries;
+}
+
+/**
+ * Apply retention policy to a backup directory.
+ *
+ * Lists snapshots newest-first, keeps the first `retention` entries, and
+ * `unlink`s the rest. Returns a `{ kept, deleted }` split so callers can
+ * log/report what happened without re-listing the directory.
+ *
+ * The `skipped` flag distinguishes two missing-directory cases:
+ *
+ * - **Parent missing** (`skipped: true`): the parent of `dir` does not exist.
+ *   For offsite destinations this typically means the backing volume is not
+ *   available (e.g. iCloud Drive not enabled, external SSD unplugged). The
+ *   caller should treat the destination as temporarily unavailable rather
+ *   than silently creating it.
+ * - **`dir` missing, parent exists** (no `skipped` flag): the destination is
+ *   just empty. Returns `{ kept: [], deleted: [] }`. This is the normal
+ *   fresh-install case for local backups, where `writeLocalSnapshot` creates
+ *   the directory on demand.
+ *
+ * Treats both `.vbundle` and `.vbundle.enc` files as one pool ordered by
+ * parsed timestamp, so mixing plaintext and encrypted snapshots in the same
+ * directory retains the newest `retention` regardless of extension.
+ */
+export async function pruneDir(
+  dir: string,
+  retention: number,
+): Promise<{
+  kept: SnapshotEntry[];
+  deleted: SnapshotEntry[];
+  skipped?: boolean;
+}> {
+  // If the parent of `dir` does not exist, the destination is unreachable
+  // (e.g. iCloud Drive disabled, external volume unplugged). Signal the
+  // skipped state so callers can surface a useful error rather than treating
+  // an unavailable destination as an empty one.
+  try {
+    await stat(dirname(dir));
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return { kept: [], deleted: [], skipped: true };
+    }
+    throw err;
+  }
+
+  const snapshots = await listSnapshotsInDir(dir);
+  const kept = snapshots.slice(0, retention);
+  const deleted = snapshots.slice(retention);
+
+  for (const entry of deleted) {
+    try {
+      await unlink(entry.path);
+    } catch (err) {
+      // Tolerate races with concurrent prunes / external deletions: a file
+      // we just stat'd may have been removed before we could unlink.
+      // Anything else (EACCES, EBUSY, ...) should still propagate.
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+    }
+  }
+
+  return { kept, deleted };
 }

--- a/assistant/src/backup/local-writer.ts
+++ b/assistant/src/backup/local-writer.ts
@@ -14,10 +14,7 @@
 import { copyFile, mkdir, rename, stat, unlink } from "node:fs/promises";
 import { join } from "node:path";
 
-import {
-  listSnapshotsInDir,
-  type SnapshotEntry,
-} from "./list-snapshots.js";
+import { pruneDir, type SnapshotEntry } from "./list-snapshots.js";
 import { formatBackupFilename } from "./paths.js";
 
 /**
@@ -69,13 +66,15 @@ export async function writeLocalSnapshot(
 /**
  * Apply retention policy to the local backup directory.
  *
- * Lists snapshots newest-first, keeps the first `retention` entries, and
- * `unlink`s the rest. Returns a `{ kept, deleted }` split so callers can
- * log/report what happened without re-listing the directory.
+ * Thin wrapper around the shared `pruneDir` helper in `list-snapshots.ts`.
+ * Local backup directories live under `~/.vellum/backups/local` and are
+ * created on demand by `writeLocalSnapshot`, so the parent is effectively
+ * always present — we strip the `skipped` flag from the returned shape to
+ * match the original local-writer contract.
  *
  * Edge cases:
- * - Missing directory: returns `{ kept: [], deleted: [] }` (the listing
- *   helper already swallows ENOENT).
+ * - Missing directory: returns `{ kept: [], deleted: [] }` (inherited from
+ *   `pruneDir`, which defers to `listSnapshotsInDir`'s ENOENT handling).
  * - `retention >= snapshots.length`: nothing is deleted; everything is kept.
  * - `retention === 0`: every snapshot is deleted. The config schema rejects
  *   `retention: 0` (min is 1), so this branch only fires when callers
@@ -85,20 +84,6 @@ export async function pruneLocalSnapshots(
   localDir: string,
   retention: number,
 ): Promise<{ kept: SnapshotEntry[]; deleted: SnapshotEntry[] }> {
-  const snapshots = await listSnapshotsInDir(localDir);
-  const kept = snapshots.slice(0, retention);
-  const deleted = snapshots.slice(retention);
-
-  for (const entry of deleted) {
-    try {
-      await unlink(entry.path);
-    } catch (err) {
-      // Tolerate races with concurrent prunes / external deletions: a
-      // file we just stat'd may have been removed before we could unlink.
-      // Anything else (EACCES, EBUSY, ...) should still propagate.
-      if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
-    }
-  }
-
+  const { kept, deleted } = await pruneDir(localDir, retention);
   return { kept, deleted };
 }

--- a/assistant/src/backup/offsite-writer.ts
+++ b/assistant/src/backup/offsite-writer.ts
@@ -1,0 +1,211 @@
+/**
+ * Offsite snapshot writer with per-destination encryption.
+ *
+ * "Offsite" destinations are any location outside the local backup directory
+ * where the user wants a redundant copy of a just-written local snapshot.
+ * Canonical examples: iCloud Drive, an external SSD, a network share.
+ *
+ * Per-destination `encrypt` flag:
+ * - `encrypt: true`  → AES-256-GCM stream-encrypt into `.vbundle.enc`.
+ * - `encrypt: false` → plaintext copy into `.vbundle`. Intended for volumes
+ *   where the user controls physical access (e.g. an external SSD).
+ *
+ * Each destination is written independently and sequentially, so one bad
+ * destination cannot poison the others: a missing iCloud mount or a broken
+ * external drive surfaces as a per-destination `skipped` or `error` in the
+ * returned array while every other destination still gets its copy.
+ *
+ * The helpers are pure with respect to daemon state — they operate on an
+ * explicit `localSnapshotPath`, `destinations`, `key`, and `now` so tests can
+ * drive the whole surface against temp directories.
+ */
+
+import { copyFile, mkdir, rename, stat } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+import type { BackupDestination } from "../config/schema.js";
+import {
+  pruneDir,
+  type SnapshotEntry,
+} from "./list-snapshots.js";
+import { formatBackupFilename } from "./paths.js";
+import { encryptFile } from "./stream-crypt.js";
+
+/**
+ * Result of writing a single offsite destination.
+ *
+ * Exactly one of `entry`, `skipped`, or `error` is meaningful:
+ * - `entry` non-null → the write succeeded.
+ * - `skipped: "parent-missing"` → the destination's parent directory does
+ *   not exist (e.g. iCloud Drive not enabled, external volume unplugged).
+ *   Not an error — the write is simply deferred until the volume is back.
+ * - `error` set → an unexpected failure while writing. Surfaced as a string
+ *   so callers can log without serializing an `Error` object.
+ *
+ * `destination` always preserves the full config record (path + encrypt) so
+ * callers can correlate a result with the destination that produced it.
+ */
+export interface OffsiteWriteResult {
+  destination: BackupDestination;
+  entry: SnapshotEntry | null;
+  skipped?: "parent-missing";
+  error?: string;
+}
+
+/**
+ * Write a local snapshot to a single offsite destination.
+ *
+ * Behavior:
+ * - If `dirname(destination.path)` does not exist → returns
+ *   `{ destination, entry: null, skipped: "parent-missing" }`. The offsite
+ *   volume is (temporarily) unavailable; the caller should not treat this
+ *   as an error.
+ * - Otherwise `mkdir -p` the destination directory (mode `0o700`).
+ * - If `destination.encrypt === true`, stream-encrypts via `encryptFile`
+ *   with the provided `key` and writes `.vbundle.enc`. A missing `key`
+ *   here is a programmer error, but per the plan we still catch it rather
+ *   than throwing — a broken destination must never poison the others.
+ * - If `destination.encrypt === false`, copies the local snapshot into a
+ *   `.tmp` sibling and renames into place (atomic; cross-filesystem safe
+ *   because `copyFile` handles the copy itself).
+ *
+ * On any unexpected throw, returns `{ destination, entry: null, error: msg }`.
+ */
+export async function writeOffsiteSnapshotToOne(
+  localSnapshotPath: string,
+  destination: BackupDestination,
+  key: Buffer | null,
+  now: Date,
+): Promise<OffsiteWriteResult> {
+  try {
+    // Parent-missing probe: if the parent directory of `destination.path`
+    // does not exist we treat the destination as temporarily unavailable
+    // rather than auto-creating a deep tree we have no reason to own.
+    try {
+      await stat(dirname(destination.path));
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+        return { destination, entry: null, skipped: "parent-missing" };
+      }
+      throw err;
+    }
+
+    // `destination.path` itself may not exist yet — create it now that we
+    // know its parent is reachable.
+    await mkdir(destination.path, { recursive: true, mode: 0o700 });
+
+    const filename = formatBackupFilename(now, {
+      encrypted: destination.encrypt,
+    });
+    const outputPath = join(destination.path, filename);
+
+    if (destination.encrypt) {
+      // Programmer-contract: the caller must have ensured a key exists if any
+      // destination is encrypted. We still route this through the catch block
+      // so a single broken destination cannot poison the others.
+      if (key == null) {
+        throw new Error(
+          "Offsite destination requires encryption but no key was provided",
+        );
+      }
+      await encryptFile(localSnapshotPath, outputPath, key);
+    } else {
+      // Atomic plaintext copy: write into a sibling `.tmp` then rename into
+      // place. `copyFile` handles cross-filesystem copies, so we don't need
+      // the EXDEV fallback dance that `writeLocalSnapshot` uses for a
+      // same-device rename.
+      const tempPath = `${outputPath}.tmp`;
+      await copyFile(localSnapshotPath, tempPath);
+      await rename(tempPath, outputPath);
+    }
+
+    const stats = await stat(outputPath);
+    return {
+      destination,
+      entry: {
+        path: outputPath,
+        filename,
+        createdAt: now,
+        sizeBytes: stats.size,
+        encrypted: destination.encrypt,
+      },
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { destination, entry: null, error: message };
+  }
+}
+
+/**
+ * Write a local snapshot to every configured offsite destination, in order.
+ *
+ * Sequential by design: parallelizing wouldn't save meaningful wall-clock
+ * time (the dominant cost is filesystem IO on potentially-slow network
+ * volumes) and sequential writes make per-destination failures trivially
+ * observable. Empty array returns `[]` immediately without any stat/mkdir.
+ *
+ * Returns one `OffsiteWriteResult` per input destination, in the same order
+ * as `destinations`. Callers can `filter` the result to extract successes
+ * (`entry != null`), skips (`skipped === "parent-missing"`), or errors
+ * (`error != null`).
+ */
+export async function writeOffsiteSnapshotToAll(
+  localSnapshotPath: string,
+  destinations: BackupDestination[],
+  key: Buffer | null,
+  now: Date,
+): Promise<OffsiteWriteResult[]> {
+  if (destinations.length === 0) return [];
+
+  const results: OffsiteWriteResult[] = [];
+  for (const destination of destinations) {
+    const result = await writeOffsiteSnapshotToOne(
+      localSnapshotPath,
+      destination,
+      key,
+      now,
+    );
+    results.push(result);
+  }
+  return results;
+}
+
+/**
+ * Apply retention to every configured offsite destination.
+ *
+ * Retention is applied **per destination** — each keeps its own newest
+ * `retention` snapshots independently. A `skipped: true` result means the
+ * destination's parent directory is missing (e.g. iCloud Drive disabled);
+ * callers should treat this as a transient unavailability rather than an
+ * empty directory.
+ *
+ * Mixed `.vbundle` and `.vbundle.enc` files in a single destination are
+ * treated as one pool ordered by parsed timestamp, so retention still holds
+ * if a destination's `encrypt` flag changes over its lifetime.
+ */
+export async function pruneOffsiteSnapshotsInAll(
+  destinations: BackupDestination[],
+  retention: number,
+): Promise<
+  Array<{
+    destination: BackupDestination;
+    kept: SnapshotEntry[];
+    deleted: SnapshotEntry[];
+    skipped?: boolean;
+  }>
+> {
+  const results: Array<{
+    destination: BackupDestination;
+    kept: SnapshotEntry[];
+    deleted: SnapshotEntry[];
+    skipped?: boolean;
+  }> = [];
+  for (const destination of destinations) {
+    const { kept, deleted, skipped } = await pruneDir(
+      destination.path,
+      retention,
+    );
+    results.push({ destination, kept, deleted, skipped });
+  }
+  return results;
+}

--- a/assistant/src/backup/paths.ts
+++ b/assistant/src/backup/paths.ts
@@ -1,15 +1,8 @@
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 
+import type { BackupDestination } from "../config/schema.js";
 import { getProtectedDir } from "../util/platform.js";
-
-/**
- * Temporary local type until the backup config PR lands — matches the shape
- * of `BackupDestinationSchema` that will be exported from `../config/schema.js`.
- * A later PR will replace this with the real import so callers that depend on
- * both modules have a single source of truth.
- */
-type BackupDestinationLike = { path: string; encrypt: boolean };
 
 /**
  * Computes the root ~/.vellum directory without introducing a new export from
@@ -55,8 +48,8 @@ export function getDefaultOffsiteBackupsDir(): string {
  * unchanged so callers never need to null-check.
  */
 export function resolveOffsiteDestinations(
-  override?: BackupDestinationLike[] | null,
-): BackupDestinationLike[] {
+  override?: BackupDestination[] | null,
+): BackupDestination[] {
   if (override == null) {
     return [{ path: getDefaultOffsiteBackupsDir(), encrypt: true }];
   }


### PR DESCRIPTION
## Summary
- Add offsite-writer with per-destination encrypt flag (AES-256-GCM or plaintext)
- Sequential writes; per-destination failure isolation (skipped / error)
- Replace PR 2's BackupDestinationLike alias with real BackupDestination import
- Extract shared pruneDir helper used by local + offsite

Part of plan: backup-restore-system.md (PR 6 of 12)