### PR TITLE
feat(backup): add periodic backup worker

### DIFF
--- a/assistant/src/backup/__tests__/backup-worker.test.ts
+++ b/assistant/src/backup/__tests__/backup-worker.test.ts
@@ -1,0 +1,652 @@
+/**
+ * Tests for the periodic backup worker. Drives `runBackupTick` and
+ * `createSnapshotNow` directly with fake dependencies so the whole pipeline
+ * runs against a temp directory with an in-memory checkpoint store and
+ * no real database.
+ *
+ * `streamExportVBundle` is stubbed to write a tiny byte blob to a temp
+ * file — the worker never validates bundle contents, it just hands the
+ * path to `writeLocalSnapshot` which renames it into place.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { unlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+import type { BackupConfig, BackupDestination } from "../../config/schema.js";
+import { BackupConfigSchema } from "../../config/schema.js";
+import type { StreamExportVBundleResult } from "../../runtime/migrations/vbundle-builder.js";
+import type { BackupDeps } from "../backup-worker.js";
+import {
+  createSnapshotNow,
+  runBackupTick,
+} from "../backup-worker.js";
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+let ROOT: string;
+
+beforeEach(() => {
+  ROOT = mkdtempSync(join(tmpdir(), "vellum-backup-worker-"));
+});
+
+afterEach(() => {
+  try {
+    rmSync(ROOT, { recursive: true, force: true });
+  } catch {
+    // best-effort
+  }
+});
+
+/** Build a valid BackupConfig with overrides. Starts from schema defaults. */
+function makeConfig(overrides?: {
+  enabled?: boolean;
+  intervalHours?: number;
+  retention?: number;
+  localDirectory?: string | null;
+  offsite?: {
+    enabled?: boolean;
+    destinations?: BackupDestination[] | null;
+  };
+}): BackupConfig {
+  const base = BackupConfigSchema.parse({});
+  return {
+    ...base,
+    enabled: overrides?.enabled ?? base.enabled,
+    intervalHours: overrides?.intervalHours ?? base.intervalHours,
+    retention: overrides?.retention ?? base.retention,
+    localDirectory: overrides?.localDirectory ?? base.localDirectory,
+    offsite: {
+      enabled: overrides?.offsite?.enabled ?? base.offsite.enabled,
+      destinations:
+        overrides?.offsite?.destinations === undefined
+          ? base.offsite.destinations
+          : overrides.offsite.destinations,
+    },
+  };
+}
+
+/**
+ * Build an in-memory checkpoint store. Returns fake getters/setters and a
+ * plain object so tests can inspect or preload entries.
+ */
+function makeCheckpointStore(initial: Record<string, string> = {}) {
+  const store: Record<string, string> = { ...initial };
+  return {
+    store,
+    get: (key: string): string | null => store[key] ?? null,
+    set: (key: string, value: string): void => {
+      store[key] = value;
+    },
+  };
+}
+
+/**
+ * Build a stub `streamExportVBundle` that writes a tiny payload to a fresh
+ * temp file on every call. The worker only cares that `tempPath` exists and
+ * can be renamed — the bundle content is never introspected.
+ */
+function makeStreamExportStub(): {
+  fn: BackupDeps["streamExportVBundle"];
+  calls: Array<Parameters<NonNullable<BackupDeps["streamExportVBundle"]>>[0]>;
+} {
+  const calls: Array<
+    Parameters<NonNullable<BackupDeps["streamExportVBundle"]>>[0]
+  > = [];
+  let counter = 0;
+  const fn: BackupDeps["streamExportVBundle"] = async (opts) => {
+    calls.push(opts);
+    // Deliberately do NOT fire opts.checkpoint?.() here — the real checkpoint
+    // callback opens a fresh DB handle at `getDbPath()` which does not exist
+    // in the test environment. Tests don't care about the WAL side-effect;
+    // they just need the stub to return a valid temp bundle path.
+    counter += 1;
+    const tempPath = join(ROOT, `stub-bundle-${counter}.tmp`);
+    await writeFile(tempPath, `fake bundle ${counter}`);
+    const result: StreamExportVBundleResult = {
+      tempPath,
+      size: 16,
+      manifest: {
+        schema_version: "1.0",
+        created_at: new Date().toISOString(),
+        source: "test",
+        description: "test stub",
+        files: [],
+        manifest_sha256: "0".repeat(64),
+      },
+      cleanup: async () => {
+        try {
+          await unlink(tempPath);
+        } catch {
+          // best-effort
+        }
+      },
+    };
+    return result;
+  };
+  return { fn, calls };
+}
+
+// ---------------------------------------------------------------------------
+// runBackupTick — gating
+// ---------------------------------------------------------------------------
+
+describe("runBackupTick — gating", () => {
+  test("returns null when config.enabled is false", async () => {
+    const checkpoints = makeCheckpointStore();
+    const streamStub = makeStreamExportStub();
+    const config = makeConfig({ enabled: false });
+    const localDir = join(ROOT, "local");
+
+    const result = await runBackupTick(config, new Date(), {
+      streamExportVBundle: streamStub.fn,
+      getMemoryCheckpoint: checkpoints.get,
+      setMemoryCheckpoint: checkpoints.set,
+      workspaceDir: ROOT,
+      localDir,
+    });
+
+    expect(result).toBeNull();
+    expect(streamStub.calls).toHaveLength(0);
+    expect(Object.keys(checkpoints.store)).toHaveLength(0);
+    expect(existsSync(localDir)).toBe(false);
+  });
+
+  test("returns null when last_run_at is within the interval window", async () => {
+    const now = new Date("2026-04-11T10:00:00Z");
+    const oneHourAgoMs = now.getTime() - 1 * 3600 * 1000;
+    const checkpoints = makeCheckpointStore({
+      "backup:last_run_at": String(oneHourAgoMs),
+    });
+    const streamStub = makeStreamExportStub();
+    const config = makeConfig({ enabled: true, intervalHours: 6 });
+    const localDir = join(ROOT, "local");
+
+    const result = await runBackupTick(config, now, {
+      streamExportVBundle: streamStub.fn,
+      getMemoryCheckpoint: checkpoints.get,
+      setMemoryCheckpoint: checkpoints.set,
+      workspaceDir: ROOT,
+      localDir,
+      // Explicit plaintext to avoid touching the key file
+      trustPath: join(ROOT, "trust.json"),
+      hooksDir: join(ROOT, "hooks"),
+    });
+
+    expect(result).toBeNull();
+    expect(streamStub.calls).toHaveLength(0);
+    // Checkpoint unchanged
+    expect(checkpoints.store["backup:last_run_at"]).toBe(String(oneHourAgoMs));
+  });
+
+  test("runs when last_run_at is older than the interval", async () => {
+    const now = new Date("2026-04-11T10:00:00Z");
+    const sevenHoursAgoMs = now.getTime() - 7 * 3600 * 1000;
+    const checkpoints = makeCheckpointStore({
+      "backup:last_run_at": String(sevenHoursAgoMs),
+    });
+    const streamStub = makeStreamExportStub();
+    const config = makeConfig({
+      enabled: true,
+      intervalHours: 6,
+      offsite: { enabled: false, destinations: null },
+    });
+    const localDir = join(ROOT, "local");
+
+    const result = await runBackupTick(config, now, {
+      streamExportVBundle: streamStub.fn,
+      getMemoryCheckpoint: checkpoints.get,
+      setMemoryCheckpoint: checkpoints.set,
+      workspaceDir: ROOT,
+      localDir,
+    });
+
+    expect(result).not.toBeNull();
+    expect(streamStub.calls).toHaveLength(1);
+    expect(checkpoints.store["backup:last_run_at"]).toBe(String(now.getTime()));
+    // Local snapshot file was created
+    expect(result!.local.path).toContain("backup-20260411-100000.vbundle");
+    expect(existsSync(result!.local.path)).toBe(true);
+    expect(result!.offsite).toEqual([]);
+  });
+
+  test("runs when last_run_at checkpoint is missing (first-ever run)", async () => {
+    const now = new Date("2026-04-11T10:00:00Z");
+    const checkpoints = makeCheckpointStore();
+    const streamStub = makeStreamExportStub();
+    const config = makeConfig({
+      enabled: true,
+      offsite: { enabled: false, destinations: null },
+    });
+    const localDir = join(ROOT, "local");
+
+    const result = await runBackupTick(config, now, {
+      streamExportVBundle: streamStub.fn,
+      getMemoryCheckpoint: checkpoints.get,
+      setMemoryCheckpoint: checkpoints.set,
+      workspaceDir: ROOT,
+      localDir,
+    });
+
+    expect(result).not.toBeNull();
+    expect(checkpoints.store["backup:last_run_at"]).toBe(String(now.getTime()));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runBackupTick — offsite destinations
+// ---------------------------------------------------------------------------
+
+describe("runBackupTick — offsite destinations", () => {
+  test("config.offsite.enabled === false: offsite is empty and key is not loaded", async () => {
+    const checkpoints = makeCheckpointStore();
+    const streamStub = makeStreamExportStub();
+    const ensureKey = mock(async () => Buffer.alloc(32, 1));
+    const config = makeConfig({
+      enabled: true,
+      offsite: { enabled: false, destinations: null },
+    });
+    const localDir = join(ROOT, "local");
+
+    const result = await runBackupTick(config, new Date(), {
+      streamExportVBundle: streamStub.fn,
+      getMemoryCheckpoint: checkpoints.get,
+      setMemoryCheckpoint: checkpoints.set,
+      ensureBackupKey: ensureKey,
+      workspaceDir: ROOT,
+      localDir,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!.offsite).toEqual([]);
+    expect(ensureKey).not.toHaveBeenCalled();
+  });
+
+  test("single plaintext destination: key is not loaded, file has .vbundle extension", async () => {
+    const checkpoints = makeCheckpointStore();
+    const streamStub = makeStreamExportStub();
+    const ensureKey = mock(async () => Buffer.alloc(32, 1));
+    const offsiteDir = join(ROOT, "offsite", "plain");
+    // Parent must exist — writer probes for parent before mkdir of dest.
+    mkdirSync(join(ROOT, "offsite"), { recursive: true });
+    const config = makeConfig({
+      enabled: true,
+      offsite: {
+        enabled: true,
+        destinations: [{ path: offsiteDir, encrypt: false }],
+      },
+    });
+    const localDir = join(ROOT, "local");
+    const now = new Date("2026-04-11T12:00:00Z");
+
+    const result = await runBackupTick(config, now, {
+      streamExportVBundle: streamStub.fn,
+      getMemoryCheckpoint: checkpoints.get,
+      setMemoryCheckpoint: checkpoints.set,
+      ensureBackupKey: ensureKey,
+      workspaceDir: ROOT,
+      localDir,
+    });
+
+    expect(result).not.toBeNull();
+    expect(ensureKey).not.toHaveBeenCalled();
+    expect(result!.offsite).toHaveLength(1);
+    expect(result!.offsite[0].entry).not.toBeNull();
+    expect(result!.offsite[0].entry!.filename).toBe(
+      "backup-20260411-120000.vbundle",
+    );
+    expect(result!.offsite[0].entry!.encrypted).toBe(false);
+    expect(existsSync(result!.offsite[0].entry!.path)).toBe(true);
+  });
+
+  test("single encrypted destination: key is loaded, file has .vbundle.enc extension", async () => {
+    const checkpoints = makeCheckpointStore();
+    const streamStub = makeStreamExportStub();
+    const ensureKey = mock(async () => Buffer.alloc(32, 0xab));
+    const offsiteDir = join(ROOT, "offsite", "enc");
+    mkdirSync(join(ROOT, "offsite"), { recursive: true });
+    const keyPath = join(ROOT, "backup.key");
+    const config = makeConfig({
+      enabled: true,
+      offsite: {
+        enabled: true,
+        destinations: [{ path: offsiteDir, encrypt: true }],
+      },
+    });
+    const localDir = join(ROOT, "local");
+    const now = new Date("2026-04-11T13:00:00Z");
+
+    const result = await runBackupTick(config, now, {
+      streamExportVBundle: streamStub.fn,
+      getMemoryCheckpoint: checkpoints.get,
+      setMemoryCheckpoint: checkpoints.set,
+      ensureBackupKey: ensureKey,
+      backupKeyPath: keyPath,
+      workspaceDir: ROOT,
+      localDir,
+    });
+
+    expect(result).not.toBeNull();
+    expect(ensureKey).toHaveBeenCalledTimes(1);
+    expect(ensureKey).toHaveBeenCalledWith(keyPath);
+    expect(result!.offsite).toHaveLength(1);
+    expect(result!.offsite[0].entry).not.toBeNull();
+    expect(result!.offsite[0].entry!.filename).toBe(
+      "backup-20260411-130000.vbundle.enc",
+    );
+    expect(result!.offsite[0].entry!.encrypted).toBe(true);
+    expect(existsSync(result!.offsite[0].entry!.path)).toBe(true);
+  });
+
+  test("mixed destinations: key is loaded once (because A needs it), both files written", async () => {
+    const checkpoints = makeCheckpointStore();
+    const streamStub = makeStreamExportStub();
+    const ensureKey = mock(async () => Buffer.alloc(32, 0xcd));
+    const encDir = join(ROOT, "offsite", "enc");
+    const plainDir = join(ROOT, "offsite", "plain");
+    mkdirSync(join(ROOT, "offsite"), { recursive: true });
+    const config = makeConfig({
+      enabled: true,
+      offsite: {
+        enabled: true,
+        destinations: [
+          { path: encDir, encrypt: true },
+          { path: plainDir, encrypt: false },
+        ],
+      },
+    });
+    const localDir = join(ROOT, "local");
+
+    const result = await runBackupTick(config, new Date(), {
+      streamExportVBundle: streamStub.fn,
+      getMemoryCheckpoint: checkpoints.get,
+      setMemoryCheckpoint: checkpoints.set,
+      ensureBackupKey: ensureKey,
+      workspaceDir: ROOT,
+      localDir,
+    });
+
+    expect(result).not.toBeNull();
+    expect(ensureKey).toHaveBeenCalledTimes(1);
+    expect(result!.offsite).toHaveLength(2);
+    expect(result!.offsite[0].entry).not.toBeNull();
+    expect(result!.offsite[0].entry!.encrypted).toBe(true);
+    expect(result!.offsite[1].entry).not.toBeNull();
+    expect(result!.offsite[1].entry!.encrypted).toBe(false);
+  });
+
+  test("mixed reachability: one ok + one parent-missing skip, local succeeds, checkpoint updated", async () => {
+    const checkpoints = makeCheckpointStore();
+    const streamStub = makeStreamExportStub();
+    const reachableDir = join(ROOT, "offsite", "reachable");
+    // Nested parent-missing: the parent directory is /nope/deeper which is
+    // unreachable because /nope itself does not exist.
+    const unreachableDir = join(ROOT, "nope", "deeper", "backups");
+    mkdirSync(join(ROOT, "offsite"), { recursive: true });
+    const config = makeConfig({
+      enabled: true,
+      offsite: {
+        enabled: true,
+        destinations: [
+          { path: reachableDir, encrypt: false },
+          { path: unreachableDir, encrypt: false },
+        ],
+      },
+    });
+    const localDir = join(ROOT, "local");
+    const now = new Date("2026-04-11T14:00:00Z");
+
+    const result = await runBackupTick(config, now, {
+      streamExportVBundle: streamStub.fn,
+      getMemoryCheckpoint: checkpoints.get,
+      setMemoryCheckpoint: checkpoints.set,
+      workspaceDir: ROOT,
+      localDir,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!.offsite).toHaveLength(2);
+    expect(result!.offsite[0].entry).not.toBeNull();
+    expect(result!.offsite[1].entry).toBeNull();
+    expect(result!.offsite[1].skipped).toBe("parent-missing");
+    // Local still succeeded
+    expect(existsSync(result!.local.path)).toBe(true);
+    // Checkpoint updated because performBackup returned successfully
+    expect(checkpoints.store["backup:last_run_at"]).toBe(String(now.getTime()));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runBackupTick — error propagation
+// ---------------------------------------------------------------------------
+
+describe("runBackupTick — error propagation", () => {
+  test("throws when streamExportVBundle throws and leaves checkpoint untouched", async () => {
+    const checkpoints = makeCheckpointStore();
+    const throwingStream: BackupDeps["streamExportVBundle"] = async () => {
+      throw new Error("boom");
+    };
+    const config = makeConfig({
+      enabled: true,
+      offsite: { enabled: false, destinations: null },
+    });
+    const localDir = join(ROOT, "local");
+
+    await expect(
+      runBackupTick(config, new Date(), {
+        streamExportVBundle: throwingStream,
+        getMemoryCheckpoint: checkpoints.get,
+        setMemoryCheckpoint: checkpoints.set,
+        workspaceDir: ROOT,
+        localDir,
+      }),
+    ).rejects.toThrow("boom");
+    expect(checkpoints.store["backup:last_run_at"]).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createSnapshotNow — manual trigger
+// ---------------------------------------------------------------------------
+
+describe("createSnapshotNow", () => {
+  test("bypasses enabled check (snapshot created even when enabled is false)", async () => {
+    const checkpoints = makeCheckpointStore();
+    const streamStub = makeStreamExportStub();
+    const config = makeConfig({
+      enabled: false,
+      offsite: { enabled: false, destinations: null },
+    });
+    const localDir = join(ROOT, "local");
+
+    const result = await createSnapshotNow(config, new Date(), {
+      streamExportVBundle: streamStub.fn,
+      getMemoryCheckpoint: checkpoints.get,
+      setMemoryCheckpoint: checkpoints.set,
+      workspaceDir: ROOT,
+      localDir,
+    });
+
+    expect(result).not.toBeNull();
+    expect(streamStub.calls).toHaveLength(1);
+    // Manual runs do NOT update the automatic cadence checkpoint
+    expect(checkpoints.store["backup:last_run_at"]).toBeUndefined();
+  });
+
+  test("bypasses interval check even when a recent run was recorded", async () => {
+    const now = new Date("2026-04-11T10:00:00Z");
+    const checkpoints = makeCheckpointStore({
+      "backup:last_run_at": String(now.getTime() - 60_000),
+    });
+    const streamStub = makeStreamExportStub();
+    const config = makeConfig({
+      enabled: true,
+      intervalHours: 6,
+      offsite: { enabled: false, destinations: null },
+    });
+    const localDir = join(ROOT, "local");
+
+    const result = await createSnapshotNow(config, now, {
+      streamExportVBundle: streamStub.fn,
+      getMemoryCheckpoint: checkpoints.get,
+      setMemoryCheckpoint: checkpoints.set,
+      workspaceDir: ROOT,
+      localDir,
+    });
+
+    expect(result).not.toBeNull();
+    expect(streamStub.calls).toHaveLength(1);
+    // The pre-existing checkpoint is preserved — manual runs do not touch it.
+    expect(checkpoints.store["backup:last_run_at"]).toBe(
+      String(now.getTime() - 60_000),
+    );
+  });
+
+  test("two concurrent calls: second throws 'snapshot in progress'", async () => {
+    const checkpoints = makeCheckpointStore();
+    // Stub that holds the first caller indefinitely until we release it,
+    // giving the test a clean window to observe the mutex from a second call.
+    let release: () => void = () => {};
+    const holdPromise = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let callCount = 0;
+    const holdingStream: BackupDeps["streamExportVBundle"] = async (_opts) => {
+      callCount += 1;
+      if (callCount === 1) {
+        await holdPromise;
+      }
+      const tempPath = join(ROOT, `hold-${callCount}.tmp`);
+      writeFileSync(tempPath, "payload");
+      return {
+        tempPath,
+        size: 7,
+        manifest: {
+          schema_version: "1.0",
+          created_at: new Date().toISOString(),
+          files: [],
+          manifest_sha256: "0".repeat(64),
+        },
+        cleanup: async () => {
+          try {
+            await unlink(tempPath);
+          } catch {
+            // best-effort
+          }
+        },
+      };
+    };
+    const config = makeConfig({
+      enabled: true,
+      offsite: { enabled: false, destinations: null },
+    });
+    const localDir = join(ROOT, "local");
+
+    // Start the first call — it will park inside `streamExportVBundle`
+    // waiting on holdPromise.
+    const first = createSnapshotNow(config, new Date(), {
+      streamExportVBundle: holdingStream,
+      getMemoryCheckpoint: checkpoints.get,
+      setMemoryCheckpoint: checkpoints.set,
+      workspaceDir: ROOT,
+      localDir,
+    });
+
+    // Yield once so the first call has a chance to enter the mutex + the
+    // stream stub before we kick off the second call.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    await expect(
+      createSnapshotNow(config, new Date(), {
+        streamExportVBundle: holdingStream,
+        getMemoryCheckpoint: checkpoints.get,
+        setMemoryCheckpoint: checkpoints.set,
+        workspaceDir: ROOT,
+        localDir,
+      }),
+    ).rejects.toThrow("snapshot in progress");
+
+    release();
+    await first;
+    // Only the first call should have been executed by the stub.
+    expect(callCount).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Retention — integration across multiple ticks
+// ---------------------------------------------------------------------------
+
+describe("retention across successive ticks", () => {
+  test("three ticks past the interval with retention=2 leaves 2 local + 2 offsite", async () => {
+    const checkpoints = makeCheckpointStore();
+    const streamStub = makeStreamExportStub();
+    const offsiteDir = join(ROOT, "offsite", "plain");
+    mkdirSync(join(ROOT, "offsite"), { recursive: true });
+    const config = makeConfig({
+      enabled: true,
+      intervalHours: 1,
+      retention: 2,
+      offsite: {
+        enabled: true,
+        destinations: [{ path: offsiteDir, encrypt: false }],
+      },
+    });
+    const localDir = join(ROOT, "local");
+
+    // Three successive runs, each 2 hours apart (past the 1-hour interval).
+    const t1 = new Date("2026-04-11T10:00:00Z");
+    const t2 = new Date("2026-04-11T12:00:00Z");
+    const t3 = new Date("2026-04-11T14:00:00Z");
+
+    for (const t of [t1, t2, t3]) {
+      const result = await runBackupTick(config, t, {
+        streamExportVBundle: streamStub.fn,
+        getMemoryCheckpoint: checkpoints.get,
+        setMemoryCheckpoint: checkpoints.set,
+        workspaceDir: ROOT,
+        localDir,
+      });
+      expect(result).not.toBeNull();
+    }
+
+    // After three runs with retention=2, only the two newest survive in
+    // both local and offsite pools.
+    const localFiles = readdirSync(localDir)
+      .filter((f) => f.startsWith("backup-"))
+      .sort();
+    expect(localFiles).toHaveLength(2);
+    expect(localFiles).toEqual([
+      "backup-20260411-120000.vbundle",
+      "backup-20260411-140000.vbundle",
+    ]);
+
+    const offsiteFiles = readdirSync(offsiteDir)
+      .filter((f) => f.startsWith("backup-"))
+      .sort();
+    expect(offsiteFiles).toHaveLength(2);
+    expect(offsiteFiles).toEqual([
+      "backup-20260411-120000.vbundle",
+      "backup-20260411-140000.vbundle",
+    ]);
+  });
+});

--- a/assistant/src/backup/backup-worker.ts
+++ b/assistant/src/backup/backup-worker.ts
@@ -1,0 +1,392 @@
+/**
+ * Periodic backup worker.
+ *
+ * Drives the backup pipeline on a 5-minute tick interval. On each tick it
+ * checks whether `config.enabled` is true and whether enough time has passed
+ * since the last successful run; if so, it builds a workspace vbundle,
+ * writes it to the local backup directory, mirrors it to every configured
+ * offsite destination, applies retention to each pool, and records the run
+ * timestamp in the memory checkpoint store.
+ *
+ * The public surface is intentionally split into three layers:
+ *
+ * - `startBackupWorker` — installs the `setInterval` and returns a handle
+ *   with `stop()` and `runOnce()`. Must never throw during startup (daemon
+ *   startup philosophy); any failure during setup falls back to a no-op
+ *   handle and logs the error.
+ * - `runBackupTick` — the pure tick body. Gates on `enabled` + interval +
+ *   mutex, then delegates to `performBackup`. Propagates errors so callers
+ *   (tests, the interval wrapper) can observe failures.
+ * - `createSnapshotNow` — manual-trigger variant. Bypasses the enabled and
+ *   interval checks, but still honors the concurrency mutex (so a manual
+ *   trigger will reject with "snapshot in progress" if one is in flight).
+ *
+ * Everything that touches real daemon state (DB, workspace, filesystem) is
+ * injected through the `BackupDeps` shape so tests can drive the whole
+ * surface against temp directories with tiny fake bundles.
+ */
+
+import { join } from "node:path";
+import { Database } from "bun:sqlite";
+
+import { getConfig } from "../config/loader.js";
+import type { BackupConfig } from "../config/schema.js";
+import {
+  getMemoryCheckpoint as realGetMemoryCheckpoint,
+  setMemoryCheckpoint as realSetMemoryCheckpoint,
+} from "../memory/checkpoints.js";
+import type { StreamExportVBundleResult } from "../runtime/migrations/vbundle-builder.js";
+import { streamExportVBundle as realStreamExportVBundle } from "../runtime/migrations/vbundle-builder.js";
+import { getLogger } from "../util/logger.js";
+import {
+  getDbPath,
+  getProtectedDir,
+  getWorkspaceDir,
+  getWorkspaceHooksDir,
+} from "../util/platform.js";
+import { ensureBackupKey as realEnsureBackupKey } from "./backup-key.js";
+import type { SnapshotEntry } from "./list-snapshots.js";
+import {
+  pruneLocalSnapshots,
+  writeLocalSnapshot,
+} from "./local-writer.js";
+import type { OffsiteWriteResult } from "./offsite-writer.js";
+import {
+  pruneOffsiteSnapshotsInAll,
+  writeOffsiteSnapshotToAll,
+} from "./offsite-writer.js";
+import {
+  getBackupKeyPath,
+  getLocalBackupsDir,
+  resolveOffsiteDestinations,
+} from "./paths.js";
+
+const log = getLogger("backup-worker");
+
+/** Memory checkpoint key for the last successful backup run timestamp. */
+const LAST_RUN_CHECKPOINT_KEY = "backup:last_run_at";
+
+/** Default tick interval — fires every 5 minutes, gated by interval check. */
+const TICK_INTERVAL_MS = 5 * 60 * 1000;
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * Result of a single backup run. `offsite` is an array with one entry per
+ * destination so callers can inspect per-destination success / skip / error
+ * status — a single missing offsite volume does not poison the whole run.
+ */
+export interface BackupRunResult {
+  local: SnapshotEntry;
+  offsite: OffsiteWriteResult[];
+  durationMs: number;
+}
+
+/**
+ * Opaque handle returned by `startBackupWorker`. Callers drive the worker
+ * exclusively through this handle; the underlying timer and mutex state are
+ * module-scoped implementation details.
+ */
+export interface BackupWorkerHandle {
+  stop(): void;
+  runOnce(): Promise<BackupRunResult | null>;
+}
+
+/**
+ * Dependency injection bag for `runBackupTick` / `createSnapshotNow`.
+ *
+ * In production the defaults wire up the real DB, workspace, and memory
+ * checkpoint store. Tests inject fakes so they can drive the worker
+ * against temp directories with in-memory checkpoint state.
+ */
+export interface BackupDeps {
+  streamExportVBundle?: (
+    options: Parameters<typeof realStreamExportVBundle>[0],
+  ) => Promise<StreamExportVBundleResult>;
+  getMemoryCheckpoint?: (key: string) => string | null;
+  setMemoryCheckpoint?: (key: string, value: string) => void;
+  ensureBackupKey?: (path: string) => Promise<Buffer>;
+  /** Override for the workspace directory (tests). */
+  workspaceDir?: string;
+  /** Override for the local backup directory (tests). */
+  localDir?: string;
+  /** Override for the trust.json path (tests). */
+  trustPath?: string;
+  /** Override for the hooks directory (tests). */
+  hooksDir?: string;
+  /** Override for the backup key file path (tests). */
+  backupKeyPath?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Concurrency mutex (module-scoped)
+// ---------------------------------------------------------------------------
+
+/**
+ * In-memory mutex flag. Both the scheduled tick and the manual trigger share
+ * this flag so that:
+ * - A scheduled tick that fires while a manual run is in flight skips silently.
+ * - A manual run that starts while a scheduled tick is running throws so the
+ *   user can decide how to react (retry, wait, surface the conflict).
+ *
+ * The mutex is deliberately module-scoped rather than tied to the handle
+ * returned by `startBackupWorker` — the daemon may start the worker once at
+ * boot and also call `createSnapshotNow` from other code paths, and both must
+ * see the same concurrency state.
+ */
+let snapshotInProgress = false;
+
+// ---------------------------------------------------------------------------
+// Core pipeline body
+// ---------------------------------------------------------------------------
+
+/**
+ * The shared body that both `runBackupTick` and `createSnapshotNow` call
+ * after their gating checks pass. Does not touch the mutex — callers are
+ * responsible for acquiring it.
+ *
+ * Pipeline:
+ *   1. Resolve offsite destinations (iCloud default if config did not
+ *      specify an explicit array).
+ *   2. Load the backup key only if at least one destination needs it.
+ *      Plaintext-only setups never touch the key file.
+ *   3. Stream the workspace into a temp .vbundle file, passing a WAL
+ *      checkpoint callback so the exported DB has every committed row.
+ *   4. Move the temp file into the local backup directory (rename).
+ *      After this point the temp file no longer exists, so we must not
+ *      call the `cleanup()` callback on success.
+ *   5. Mirror the local file to every offsite destination (sequential).
+ *   6. Apply retention to the local pool and every offsite pool.
+ */
+async function performBackup(
+  config: BackupConfig,
+  now: Date,
+  deps: BackupDeps,
+): Promise<BackupRunResult> {
+  const streamExport = deps.streamExportVBundle ?? realStreamExportVBundle;
+  const ensureKey = deps.ensureBackupKey ?? realEnsureBackupKey;
+  const workspaceDir = deps.workspaceDir ?? getWorkspaceDir();
+  const localDir = deps.localDir ?? getLocalBackupsDir(config.localDirectory);
+  const trustPath =
+    deps.trustPath ?? join(getProtectedDir(), "trust.json");
+  const hooksDir = deps.hooksDir ?? getWorkspaceHooksDir();
+  const backupKeyPath = deps.backupKeyPath ?? getBackupKeyPath();
+
+  const startTimestamp = Date.now();
+
+  const destinations = config.offsite.enabled
+    ? resolveOffsiteDestinations(config.offsite.destinations)
+    : [];
+  const needsKey = destinations.some((d) => d.encrypt);
+  const key: Buffer | null = needsKey ? await ensureKey(backupKeyPath) : null;
+
+  // Build the vbundle into a temp file. Pass a WAL checkpoint callback that
+  // mirrors the pattern in `handleMigrationExport`: open a fresh Database
+  // handle, run PRAGMA wal_checkpoint(TRUNCATE), close it. Any failure is
+  // best-effort — the export still proceeds with whatever is on disk.
+  const result = await streamExport({
+    workspaceDir,
+    trustPath,
+    hooksDir,
+    source: "backup-worker",
+    description: "Automated backup snapshot",
+    checkpoint: () => {
+      const dbPath = getDbPath();
+      try {
+        const db = new Database(dbPath);
+        try {
+          db.exec("PRAGMA wal_checkpoint(TRUNCATE)");
+        } finally {
+          db.close();
+        }
+      } catch (err) {
+        log.warn(
+          { err },
+          "WAL checkpoint failed — proceeding with backup without checkpoint",
+        );
+      }
+    },
+  });
+
+  const { tempPath, cleanup } = result;
+
+  // `writeLocalSnapshot` moves (renames) the temp file to its final
+  // location. On success the temp file no longer exists, so we MUST NOT
+  // call `cleanup()` afterwards — it would try to unlink a missing path.
+  // On failure we still need to unlink the temp file to avoid leaks.
+  let localResult: SnapshotEntry;
+  try {
+    localResult = await writeLocalSnapshot(tempPath, localDir, now);
+  } catch (err) {
+    try {
+      await cleanup();
+    } catch {
+      // best-effort
+    }
+    throw err;
+  }
+
+  const offsiteResults = await writeOffsiteSnapshotToAll(
+    localResult.path,
+    destinations,
+    key,
+    now,
+  );
+
+  // Apply retention to both pools. Retention is per-destination so a
+  // missing offsite volume doesn't skew the local pool's retention count.
+  await pruneLocalSnapshots(localDir, config.retention);
+  await pruneOffsiteSnapshotsInAll(destinations, config.retention);
+
+  log.info(
+    {
+      localPath: localResult.path,
+      offsite: offsiteResults.map((r) => ({
+        path: r.destination.path,
+        status: r.entry ? "ok" : r.skipped ? "skipped" : "error",
+        reason: r.skipped ?? r.error,
+      })),
+    },
+    "Backup snapshot complete",
+  );
+
+  return {
+    local: localResult,
+    offsite: offsiteResults,
+    durationMs: Date.now() - startTimestamp,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Public entry points
+// ---------------------------------------------------------------------------
+
+/**
+ * Pure tick body for the scheduled backup worker. Runs the enabled + interval
+ * gates, acquires the mutex, delegates to `performBackup`, and records the
+ * last-run timestamp on success. Returns `null` if any gate rejects the run.
+ *
+ * Errors from `performBackup` propagate — the `setInterval` caller wraps this
+ * in a try/catch that logs and swallows, so daemon startup and steady-state
+ * ticks never crash the process.
+ */
+export async function runBackupTick(
+  config: BackupConfig,
+  now: Date,
+  deps: BackupDeps = {},
+): Promise<BackupRunResult | null> {
+  if (config.enabled !== true) return null;
+
+  const getCheckpoint = deps.getMemoryCheckpoint ?? realGetMemoryCheckpoint;
+  const setCheckpoint = deps.setMemoryCheckpoint ?? realSetMemoryCheckpoint;
+
+  const lastRunRaw = getCheckpoint(LAST_RUN_CHECKPOINT_KEY);
+  if (lastRunRaw != null) {
+    const lastRunMs = Number.parseInt(lastRunRaw, 10);
+    if (!Number.isNaN(lastRunMs)) {
+      const intervalMs = config.intervalHours * 3600 * 1000;
+      if (now.getTime() - lastRunMs < intervalMs) {
+        return null;
+      }
+    }
+  }
+
+  // A manual snapshot in flight wins — the scheduled tick silently defers
+  // and will reconsider on the next interval.
+  if (snapshotInProgress) return null;
+  snapshotInProgress = true;
+  try {
+    const result = await performBackup(config, now, deps);
+    setCheckpoint(LAST_RUN_CHECKPOINT_KEY, String(now.getTime()));
+    return result;
+  } finally {
+    snapshotInProgress = false;
+  }
+}
+
+/**
+ * Manual-trigger variant of the backup pipeline. Bypasses the `enabled` and
+ * interval checks so users can force a snapshot regardless of schedule, but
+ * still honors the concurrency mutex — a second concurrent caller throws
+ * with "snapshot in progress".
+ *
+ * Does NOT update the last-run checkpoint on success: manual snapshots are
+ * an escape hatch and should not reset the automatic cadence.
+ */
+export async function createSnapshotNow(
+  config: BackupConfig,
+  now: Date,
+  deps: BackupDeps = {},
+): Promise<BackupRunResult> {
+  if (snapshotInProgress) {
+    throw new Error("snapshot in progress");
+  }
+  snapshotInProgress = true;
+  try {
+    return await performBackup(config, now, deps);
+  } finally {
+    snapshotInProgress = false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Scheduler
+// ---------------------------------------------------------------------------
+
+/**
+ * A no-op handle used when `startBackupWorker` fails to install its timer.
+ * Returning a live handle even on failure lets callers follow the normal
+ * `.stop()` cleanup path unconditionally.
+ */
+const NOOP_HANDLE: BackupWorkerHandle = {
+  stop: () => {},
+  runOnce: async () => null,
+};
+
+/**
+ * Install the periodic backup worker.
+ *
+ * Schedules a `setInterval` tick every 5 minutes and returns a handle with
+ * `stop()` and `runOnce()`. `runOnce()` invokes the tick body synchronously
+ * (bypassing the interval) so callers can drive a backup from code without
+ * waiting up to 5 minutes for the next tick.
+ *
+ * Daemon startup philosophy: this function must never throw. Any unexpected
+ * error during setup logs and returns a no-op handle so the caller's startup
+ * sequence proceeds unperturbed.
+ */
+export function startBackupWorker(): BackupWorkerHandle {
+  try {
+    const timer = setInterval(() => {
+      void (async () => {
+        try {
+          const config = getConfig();
+          await runBackupTick(config.backup, new Date());
+        } catch (err) {
+          log.warn({ err }, "Backup worker tick failed");
+        }
+      })();
+    }, TICK_INTERVAL_MS);
+
+    // Non-blocking: the process may exit even if the timer is still armed.
+    (timer as NodeJS.Timeout).unref?.();
+
+    let stopped = false;
+    return {
+      stop(): void {
+        if (stopped) return;
+        stopped = true;
+        clearInterval(timer);
+      },
+      async runOnce(): Promise<BackupRunResult | null> {
+        const config = getConfig();
+        return runBackupTick(config.backup, new Date());
+      },
+    };
+  } catch (err) {
+    log.warn({ err }, "Failed to start backup worker — continuing without it");
+    return NOOP_HANDLE;
+  }
+}


### PR DESCRIPTION
## Summary
- Add backup-worker with 5-min tick loop, 6h default cadence
- runBackupTick gates on enabled + interval; createSnapshotNow bypasses both
- In-memory mutex prevents concurrent snapshots
- Dependency injection for testability
- Key is only loaded when at least one destination has encrypt: true

Part of plan: backup-restore-system.md (PR 8 of 12)