### PR TITLE
feat(backup): start backup worker on daemon boot

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -1,5 +1,7 @@
 import { config as dotenvConfig } from "dotenv";
 
+import type { BackupWorkerHandle } from "../backup/backup-worker.js";
+import { startBackupWorker } from "../backup/backup-worker.js";
 import { setPointerMessageProcessor } from "../calls/call-pointer-messages.js";
 import { reconcileCallsOnStartup } from "../calls/call-recovery.js";
 import { setRelayBroadcast } from "../calls/relay-server.js";
@@ -638,12 +640,13 @@ export async function runDaemon(): Promise<void> {
     await server.start();
     log.info("Daemon startup: DaemonServer started");
 
-    // Mutable refs for Qdrant and memory worker so background init can assign
-    // them and the shutdown handler always sees the latest value.
+    // Mutable refs for Qdrant, memory worker, and backup worker so background
+    // init can assign them and the shutdown handler always sees the latest value.
     const bgRefs: {
       qdrantManager: QdrantManager | null;
       memoryWorker: { stop(): void } | null;
-    } = { qdrantManager: null, memoryWorker: null };
+      backupWorker: BackupWorkerHandle | null;
+    } = { qdrantManager: null, memoryWorker: null, backupWorker: null };
 
     // Initialize Qdrant vector store and memory worker in the background so the
     // RuntimeHttpServer can start accepting requests without waiting for Qdrant.
@@ -725,6 +728,16 @@ export async function runDaemon(): Promise<void> {
 
       log.info("Daemon startup: starting memory worker");
       bgRefs.memoryWorker = startMemoryJobsWorker();
+
+      log.info("Daemon startup: starting backup worker");
+      try {
+        bgRefs.backupWorker = startBackupWorker();
+      } catch (err) {
+        log.warn(
+          { err },
+          "Backup worker failed to start — continuing without backups",
+        );
+      }
 
       // Seed capability graph nodes (new memory graph system)
       try {
@@ -1369,6 +1382,7 @@ export async function runDaemon(): Promise<void> {
       runtimeHttp,
       scheduler,
       getMemoryWorker: () => bgRefs.memoryWorker,
+      getBackupWorker: () => bgRefs.backupWorker,
       getQdrantManager: () => bgRefs.qdrantManager,
       mcpManager,
       telemetryReporter,

--- a/assistant/src/daemon/shutdown-handlers.ts
+++ b/assistant/src/daemon/shutdown-handlers.ts
@@ -1,5 +1,6 @@
 import * as Sentry from "@sentry/node";
 
+import type { BackupWorkerHandle } from "../backup/backup-worker.js";
 import type { FilingService } from "../filing/filing-service.js";
 import type { HeartbeatService } from "../heartbeat/heartbeat-service.js";
 import type { HookManager } from "../hooks/manager.js";
@@ -25,6 +26,7 @@ export interface ShutdownDeps {
   runtimeHttp: RuntimeHttpServer | null;
   scheduler: { stop(): void };
   getMemoryWorker: () => { stop(): void } | null;
+  getBackupWorker: () => BackupWorkerHandle | null;
   getQdrantManager: () => QdrantManager | null;
   mcpManager: McpServerManager | null;
   telemetryReporter: { stop(): Promise<void> } | null;
@@ -112,6 +114,7 @@ export function installShutdownHandlers(deps: ShutdownDeps): void {
     cleanupShellOutputTempFiles();
     deps.scheduler.stop();
     deps.getMemoryWorker()?.stop();
+    deps.getBackupWorker()?.stop();
 
     if (deps.mcpManager) {
       try {


### PR DESCRIPTION
## Summary
- Wire startBackupWorker() into daemon lifecycle next to memory worker
- Wrapped in try/catch to honor daemon-never-throws startup rule
- Shutdown hook stops the backup worker

Part of plan: backup-restore-system.md (PR 9 of 12)