### PR TITLE
feat(backup): add /v1/backups HTTP endpoints

### DIFF
--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -438,6 +438,12 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: "migrations/import-preflight", scopes: ["settings.write"] },
   { endpoint: "migrations/import", scopes: ["settings.write"] },
 
+  // Backups
+  { endpoint: "backups", scopes: ["settings.read"] },
+  { endpoint: "backups/create", scopes: ["settings.write"] },
+  { endpoint: "backups/restore", scopes: ["settings.write"] },
+  { endpoint: "backups/verify", scopes: ["settings.read"] },
+
   // Settings (voice, avatar, client settings)
   { endpoint: "settings/voice", scopes: ["settings.write"] },
   { endpoint: "settings/avatar/generate", scopes: ["settings.write"] },

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -121,6 +121,7 @@ import { approvalRouteDefinitions } from "./routes/approval-routes.js";
 import { attachmentRouteDefinitions } from "./routes/attachment-routes.js";
 import { handleGetAudio } from "./routes/audio-routes.js";
 import { avatarRouteDefinitions } from "./routes/avatar-routes.js";
+import { backupRouteDefinitions } from "./routes/backup-routes.js";
 import { brainGraphRouteDefinitions } from "./routes/brain-graph-routes.js";
 import { handleBrowserExtensionPair } from "./routes/browser-extension-pair-routes.js";
 import { btwRouteDefinitions } from "./routes/btw-routes.js";
@@ -1691,6 +1692,7 @@ export class RuntimeHttpServer {
       ...eventsRouteDefinitions(),
       ...traceEventRouteDefinitions(),
       ...migrationRouteDefinitions(),
+      ...backupRouteDefinitions(),
 
       // User-defined routes under /x/* — must be LAST so built-in routes
       // always take priority.

--- a/assistant/src/runtime/routes/__tests__/backup-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/backup-routes.test.ts
@@ -1,0 +1,775 @@
+/**
+ * Unit tests for the /v1/backups HTTP route handlers.
+ *
+ * These tests drive the handler functions directly (bypassing the router)
+ * so they exercise the handler logic — input validation, path containment,
+ * key-loading, and error mapping — without needing a live HTTP server.
+ *
+ * Module-level mocks replace the real `config/loader`, `memory/checkpoints`,
+ * `backup/backup-worker`, `backup/restore`, and `backup/backup-key` modules
+ * with test doubles. Each test shapes the doubles through the `setMockXxx`
+ * helpers in the setup/teardown block.
+ */
+
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+import type { BackupRunResult } from "../../../backup/backup-worker.js";
+import type { SnapshotEntry } from "../../../backup/list-snapshots.js";
+import type { RestoreResult, VerifyResult } from "../../../backup/restore.js";
+import type { BackupConfig } from "../../../config/schema.js";
+import { BackupConfigSchema } from "../../../config/schema.js";
+
+// ---------------------------------------------------------------------------
+// Module mocks — must appear before any imports of the module under test
+// ---------------------------------------------------------------------------
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// -- Config mock -----------------------------------------------------------
+// Built in `beforeEach` from BackupConfigSchema defaults, with overrides
+// applied per test via `setMockBackupConfig`.
+
+let mockBackupConfig: BackupConfig = BackupConfigSchema.parse({});
+let mockWorkspaceDir = "/tmp/mock-workspace-unused";
+
+mock.module("../../../config/loader.js", () => ({
+  getConfig: () => ({
+    backup: mockBackupConfig,
+    // The handlers only touch `.backup`, but getConfig() is typed as returning
+    // the full AssistantConfig. Cast through `unknown` so the partial shape is
+    // accepted without pulling in the full config schema.
+  }),
+}));
+
+// -- Platform paths mock ---------------------------------------------------
+// `getWorkspaceDir` / `getWorkspaceHooksDir` are used inside the restore
+// handler to build a DefaultPathResolver. Return test-friendly paths so
+// restore tests don't pollute the real workspace.
+
+mock.module("../../../util/platform.js", () => ({
+  getWorkspaceDir: () => mockWorkspaceDir,
+  getWorkspaceHooksDir: () => join(mockWorkspaceDir, "hooks"),
+  // Passed through when tests need the protected dir (e.g. via paths.ts).
+  getProtectedDir: () => join(mockWorkspaceDir, "protected"),
+  getDbPath: () => join(mockWorkspaceDir, "data", "db", "assistant.db"),
+}));
+
+// -- Memory checkpoint mock ------------------------------------------------
+
+const mockCheckpointStore: Record<string, string | null> = {};
+
+mock.module("../../../memory/checkpoints.js", () => ({
+  getMemoryCheckpoint: (key: string) => mockCheckpointStore[key] ?? null,
+  setMemoryCheckpoint: (key: string, value: string) => {
+    mockCheckpointStore[key] = value;
+  },
+}));
+
+// -- Backup key mock -------------------------------------------------------
+// Tests override this via `setMockBackupKey` / `setMockBackupKeyMissing`.
+// The mock also records how many times the key was read so tests can assert
+// "key file was never touched" for plaintext-only code paths.
+
+let mockBackupKey: Buffer | null = Buffer.alloc(32, 0xaa);
+let mockReadBackupKeyCalls = 0;
+
+mock.module("../../../backup/backup-key.js", () => ({
+  readBackupKey: async (_path: string) => {
+    mockReadBackupKeyCalls += 1;
+    return mockBackupKey;
+  },
+  ensureBackupKey: async (_path: string) => mockBackupKey ?? Buffer.alloc(32),
+}));
+
+// -- Backup worker mock ----------------------------------------------------
+// `createSnapshotNow` is replaced so tests can control success / 409
+// behavior without touching the real export pipeline.
+
+let mockCreateSnapshotResult: BackupRunResult | null = null;
+let mockCreateSnapshotError: Error | null = null;
+let mockCreateSnapshotCalls = 0;
+
+mock.module("../../../backup/backup-worker.js", () => ({
+  createSnapshotNow: async (_config: BackupConfig, _now: Date) => {
+    mockCreateSnapshotCalls += 1;
+    if (mockCreateSnapshotError) throw mockCreateSnapshotError;
+    if (mockCreateSnapshotResult == null) {
+      throw new Error("Test forgot to set mockCreateSnapshotResult");
+    }
+    return mockCreateSnapshotResult;
+  },
+}));
+
+// -- Restore module mock ---------------------------------------------------
+// Both `restoreFromSnapshot` and `verifySnapshot` are replaced. Tests
+// inspect `lastRestoreArgs` / `lastVerifyArgs` to assert the handler
+// forwarded the correct key and options.
+
+interface RestoreCall {
+  path: string;
+  hasKey: boolean;
+  includeCredentials: boolean | undefined;
+  workspaceDir: string | undefined;
+}
+interface VerifyCall {
+  path: string;
+  hasKey: boolean;
+}
+
+let lastRestoreArgs: RestoreCall | null = null;
+let lastVerifyArgs: VerifyCall | null = null;
+let mockRestoreResult: RestoreResult = {
+  manifest: {
+    schema_version: "1.0",
+    created_at: "2026-04-11T10:00:00.000Z",
+    files: [],
+    manifest_sha256: "0".repeat(64),
+  } as unknown as RestoreResult["manifest"],
+  restoredFiles: 0,
+  credentials: [],
+};
+let mockRestoreError: Error | null = null;
+let mockVerifyResult: VerifyResult = { valid: true };
+
+mock.module("../../../backup/restore.js", () => ({
+  restoreFromSnapshot: async (
+    path: string,
+    opts: {
+      key?: Buffer;
+      includeCredentials?: boolean;
+      workspaceDir?: string;
+    },
+  ) => {
+    lastRestoreArgs = {
+      path,
+      hasKey: opts.key != null,
+      includeCredentials: opts.includeCredentials,
+      workspaceDir: opts.workspaceDir,
+    };
+    if (mockRestoreError) throw mockRestoreError;
+    return mockRestoreResult;
+  },
+  verifySnapshot: async (path: string, opts: { key?: Buffer }) => {
+    lastVerifyArgs = { path, hasKey: opts.key != null };
+    return mockVerifyResult;
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Import under test — after mocks
+// ---------------------------------------------------------------------------
+
+import {
+  backupRouteDefinitions,
+  handleBackupCreate,
+  handleBackupList,
+  handleBackupRestore,
+  handleBackupVerify,
+} from "../backup-routes.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let ROOT: string;
+let LOCAL_DIR: string;
+
+/** Build a valid BackupConfig with overrides applied via spread. */
+function makeConfig(overrides: Partial<BackupConfig> = {}): BackupConfig {
+  const base = BackupConfigSchema.parse({});
+  return { ...base, ...overrides };
+}
+
+/** Write a backup-shaped file to disk so `listSnapshotsInDir` picks it up. */
+function writeBackupFile(
+  dir: string,
+  filename: string,
+  payload: string = "fake-bundle",
+): string {
+  mkdirSync(dir, { recursive: true });
+  const fullPath = join(dir, filename);
+  writeFileSync(fullPath, payload);
+  return fullPath;
+}
+
+function jsonRequest(method: string, body: unknown): Request {
+  return new Request("http://localhost/v1/backups", {
+    method,
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  ROOT = mkdtempSync(join(tmpdir(), "vellum-backup-routes-"));
+  LOCAL_DIR = join(ROOT, "local");
+  // Reset mocks to defaults
+  mockBackupConfig = makeConfig({ localDirectory: LOCAL_DIR });
+  mockWorkspaceDir = join(ROOT, "workspace");
+  for (const key of Object.keys(mockCheckpointStore)) {
+    delete mockCheckpointStore[key];
+  }
+  mockBackupKey = Buffer.alloc(32, 0xaa);
+  mockReadBackupKeyCalls = 0;
+  mockCreateSnapshotResult = null;
+  mockCreateSnapshotError = null;
+  mockCreateSnapshotCalls = 0;
+  lastRestoreArgs = null;
+  lastVerifyArgs = null;
+  mockRestoreError = null;
+  mockRestoreResult = {
+    manifest: {
+      schema_version: "1.0",
+      created_at: "2026-04-11T10:00:00.000Z",
+      files: [],
+      manifest_sha256: "0".repeat(64),
+    } as unknown as RestoreResult["manifest"],
+    restoredFiles: 0,
+    credentials: [],
+  };
+  mockVerifyResult = { valid: true };
+});
+
+afterEach(() => {
+  try {
+    rmSync(ROOT, { recursive: true, force: true });
+  } catch {
+    // best-effort
+  }
+});
+
+// ---------------------------------------------------------------------------
+// handleBackupList
+// ---------------------------------------------------------------------------
+
+describe("handleBackupList", () => {
+  test("empty workspace: returns empty local array and one unreachable iCloud default", async () => {
+    // Use default offsite destinations (null) so the iCloud default kicks in.
+    mockBackupConfig = makeConfig({
+      localDirectory: LOCAL_DIR,
+      offsite: {
+        enabled: true,
+        destinations: null,
+      },
+    });
+
+    const res = await handleBackupList(new Request("http://localhost/v1/backups"));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      local: SnapshotEntry[];
+      offsite: Array<{
+        destination: { path: string; encrypt: boolean };
+        snapshots: SnapshotEntry[];
+        reachable: boolean;
+      }>;
+      nextRunAt: string | null;
+    };
+    expect(body.local).toEqual([]);
+    // iCloud default is present as a single destination. Whether it's
+    // reachable depends on whether the CI agent has iCloud Drive enabled —
+    // we only assert its presence and shape, not `reachable`.
+    expect(body.offsite).toHaveLength(1);
+    expect(body.offsite[0].destination.encrypt).toBe(true);
+    expect(body.offsite[0].snapshots).toEqual([]);
+    expect(typeof body.offsite[0].reachable).toBe("boolean");
+    expect(body.nextRunAt).toBeNull();
+  });
+
+  test("two local files: returned newest-first", async () => {
+    writeBackupFile(LOCAL_DIR, "backup-20260411-100000.vbundle");
+    writeBackupFile(LOCAL_DIR, "backup-20260411-120000.vbundle");
+    mockBackupConfig = makeConfig({
+      localDirectory: LOCAL_DIR,
+      offsite: { enabled: true, destinations: [] },
+    });
+
+    const res = await handleBackupList(new Request("http://localhost/v1/backups"));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      local: SnapshotEntry[];
+      offsite: Array<unknown>;
+    };
+    expect(body.local).toHaveLength(2);
+    expect(body.local[0].filename).toBe("backup-20260411-120000.vbundle");
+    expect(body.local[1].filename).toBe("backup-20260411-100000.vbundle");
+    expect(body.offsite).toEqual([]);
+  });
+
+  test("two offsite destinations: reachable + unreachable reflected per-entry", async () => {
+    const reachableDir = join(ROOT, "offsite-reachable");
+    const unreachableDir = join(ROOT, "nope", "deeper", "backups");
+    mkdirSync(reachableDir, { recursive: true });
+    // Put a snapshot in the reachable one so the `snapshots` array is populated.
+    writeBackupFile(reachableDir, "backup-20260411-100000.vbundle");
+
+    mockBackupConfig = makeConfig({
+      localDirectory: LOCAL_DIR,
+      offsite: {
+        enabled: true,
+        destinations: [
+          { path: reachableDir, encrypt: false },
+          { path: unreachableDir, encrypt: true },
+        ],
+      },
+    });
+
+    const res = await handleBackupList(new Request("http://localhost/v1/backups"));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      offsite: Array<{
+        destination: { path: string; encrypt: boolean };
+        snapshots: SnapshotEntry[];
+        reachable: boolean;
+      }>;
+    };
+    expect(body.offsite).toHaveLength(2);
+    expect(body.offsite[0].destination.path).toBe(reachableDir);
+    expect(body.offsite[0].reachable).toBe(true);
+    expect(body.offsite[0].snapshots).toHaveLength(1);
+    expect(body.offsite[0].snapshots[0].filename).toBe(
+      "backup-20260411-100000.vbundle",
+    );
+    expect(body.offsite[1].destination.path).toBe(unreachableDir);
+    expect(body.offsite[1].reachable).toBe(false);
+    expect(body.offsite[1].snapshots).toEqual([]);
+  });
+
+  test("encrypted files in a reachable offsite dir return with encrypted: true", async () => {
+    const encryptedDir = join(ROOT, "offsite-enc");
+    mkdirSync(encryptedDir, { recursive: true });
+    writeBackupFile(encryptedDir, "backup-20260411-100000.vbundle.enc");
+    writeBackupFile(encryptedDir, "backup-20260411-120000.vbundle.enc");
+
+    mockBackupConfig = makeConfig({
+      localDirectory: LOCAL_DIR,
+      offsite: {
+        enabled: true,
+        destinations: [{ path: encryptedDir, encrypt: true }],
+      },
+    });
+
+    const res = await handleBackupList(new Request("http://localhost/v1/backups"));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      offsite: Array<{
+        snapshots: SnapshotEntry[];
+        reachable: boolean;
+      }>;
+    };
+    expect(body.offsite).toHaveLength(1);
+    expect(body.offsite[0].reachable).toBe(true);
+    expect(body.offsite[0].snapshots).toHaveLength(2);
+    // Newest-first
+    expect(body.offsite[0].snapshots[0].filename).toBe(
+      "backup-20260411-120000.vbundle.enc",
+    );
+    expect(body.offsite[0].snapshots[0].encrypted).toBe(true);
+    expect(body.offsite[0].snapshots[1].encrypted).toBe(true);
+  });
+
+  test("nextRunAt is computed from checkpoint + intervalHours when enabled", async () => {
+    const lastRunMs = Date.parse("2026-04-11T10:00:00Z");
+    mockCheckpointStore["backup:last_run_at"] = String(lastRunMs);
+    mockBackupConfig = makeConfig({
+      enabled: true,
+      intervalHours: 6,
+      localDirectory: LOCAL_DIR,
+      offsite: { enabled: true, destinations: [] },
+    });
+
+    const res = await handleBackupList(new Request("http://localhost/v1/backups"));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { nextRunAt: string | null };
+    // 6 hours after 10:00 UTC is 16:00 UTC
+    expect(body.nextRunAt).toBe("2026-04-11T16:00:00.000Z");
+  });
+
+  test("nextRunAt is null when backup is disabled", async () => {
+    mockCheckpointStore["backup:last_run_at"] = String(
+      Date.parse("2026-04-11T10:00:00Z"),
+    );
+    mockBackupConfig = makeConfig({
+      enabled: false,
+      localDirectory: LOCAL_DIR,
+      offsite: { enabled: true, destinations: [] },
+    });
+
+    const res = await handleBackupList(new Request("http://localhost/v1/backups"));
+    const body = (await res.json()) as { nextRunAt: string | null };
+    expect(body.nextRunAt).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleBackupCreate
+// ---------------------------------------------------------------------------
+
+describe("handleBackupCreate", () => {
+  const fakeRunResult: BackupRunResult = {
+    local: {
+      path: "/tmp/fake/backup-20260411-100000.vbundle",
+      filename: "backup-20260411-100000.vbundle",
+      createdAt: new Date("2026-04-11T10:00:00Z"),
+      sizeBytes: 100,
+      encrypted: false,
+    },
+    offsite: [],
+    durationMs: 42,
+  };
+
+  test("manual create bypasses enabled flag and succeeds with disabled config", async () => {
+    mockBackupConfig = makeConfig({
+      enabled: false,
+      localDirectory: LOCAL_DIR,
+      offsite: { enabled: false, destinations: null },
+    });
+    mockCreateSnapshotResult = fakeRunResult;
+
+    const res = await handleBackupCreate(
+      new Request("http://localhost/v1/backups/create", { method: "POST" }),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as BackupRunResult;
+    expect(body.durationMs).toBe(42);
+    expect(body.offsite).toEqual([]);
+    expect(mockCreateSnapshotCalls).toBe(1);
+  });
+
+  test("plaintext-only destinations do not create backup.key file", async () => {
+    const plaintextDir = join(ROOT, "offsite-plain");
+    mkdirSync(plaintextDir, { recursive: true });
+    mockBackupConfig = makeConfig({
+      enabled: true,
+      localDirectory: LOCAL_DIR,
+      offsite: {
+        enabled: true,
+        destinations: [{ path: plaintextDir, encrypt: false }],
+      },
+    });
+    mockCreateSnapshotResult = fakeRunResult;
+
+    // The mocked createSnapshotNow never touches the key file. We assert:
+    // (a) the HTTP layer itself did not try to load readBackupKey, and
+    // (b) no backup.key file exists under the protected dir (which is under
+    //     our ROOT per the platform mock).
+    mockReadBackupKeyCalls = 0;
+    const res = await handleBackupCreate(
+      new Request("http://localhost/v1/backups/create", { method: "POST" }),
+    );
+    expect(res.status).toBe(200);
+    expect(mockReadBackupKeyCalls).toBe(0);
+    // ROOT is a fresh temp dir — no protected/backup.key was ever written.
+    const keyFileExists = await import("node:fs").then((m) =>
+      m.existsSync(join(ROOT, "workspace", "protected", "backup.key")),
+    );
+    expect(keyFileExists).toBe(false);
+  });
+
+  test("concurrent call returns 409 when mock raises 'snapshot in progress'", async () => {
+    mockBackupConfig = makeConfig({ localDirectory: LOCAL_DIR });
+    mockCreateSnapshotError = new Error("snapshot in progress");
+
+    const res = await handleBackupCreate(
+      new Request("http://localhost/v1/backups/create", { method: "POST" }),
+    );
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("CONFLICT");
+  });
+
+  test("other errors are surfaced as 500", async () => {
+    mockCreateSnapshotError = new Error("disk full");
+    const res = await handleBackupCreate(
+      new Request("http://localhost/v1/backups/create", { method: "POST" }),
+    );
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: { code: string; message: string } };
+    expect(body.error.code).toBe("INTERNAL_ERROR");
+    expect(body.error.message).toBe("disk full");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleBackupRestore
+// ---------------------------------------------------------------------------
+
+describe("handleBackupRestore", () => {
+  test("rejects path outside the allowed directories with 400", async () => {
+    const outsidePath = join(ROOT, "elsewhere", "backup-20260411-100000.vbundle");
+    mkdirSync(join(ROOT, "elsewhere"), { recursive: true });
+    writeFileSync(outsidePath, "payload");
+    mockBackupConfig = makeConfig({
+      localDirectory: LOCAL_DIR,
+      offsite: { enabled: true, destinations: [] },
+    });
+
+    const res = await handleBackupRestore(
+      jsonRequest("POST", { path: outsidePath }),
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: { code: string; message: string } };
+    expect(body.error.code).toBe("BAD_REQUEST");
+    expect(body.error.message).toMatch(/outside/i);
+    expect(lastRestoreArgs).toBeNull();
+  });
+
+  test("rejects symlink that escapes the allowed directories", async () => {
+    // Create a valid-looking symlink inside LOCAL_DIR that points to a file
+    // outside. realpath() follows the symlink, so containment check fails.
+    const outsideTarget = join(ROOT, "evil-target.vbundle");
+    writeFileSync(outsideTarget, "payload");
+    mkdirSync(LOCAL_DIR, { recursive: true });
+    const symlinkPath = join(LOCAL_DIR, "backup-20260411-100000.vbundle");
+    symlinkSync(outsideTarget, symlinkPath);
+    mockBackupConfig = makeConfig({
+      localDirectory: LOCAL_DIR,
+      offsite: { enabled: true, destinations: [] },
+    });
+
+    const res = await handleBackupRestore(
+      jsonRequest("POST", { path: symlinkPath }),
+    );
+    expect(res.status).toBe(400);
+    expect(lastRestoreArgs).toBeNull();
+  });
+
+  test("plaintext .vbundle inside local dir is restored without loading key", async () => {
+    const snapshotPath = writeBackupFile(
+      LOCAL_DIR,
+      "backup-20260411-100000.vbundle",
+    );
+    mockBackupConfig = makeConfig({
+      localDirectory: LOCAL_DIR,
+      offsite: { enabled: true, destinations: [] },
+    });
+    mockReadBackupKeyCalls = 0;
+
+    const res = await handleBackupRestore(
+      jsonRequest("POST", { path: snapshotPath }),
+    );
+    expect(res.status).toBe(200);
+    expect(mockReadBackupKeyCalls).toBe(0);
+    expect(lastRestoreArgs).not.toBeNull();
+    expect(lastRestoreArgs!.hasKey).toBe(false);
+    // restoreFromSnapshot should be called with the realpath'd snapshot path.
+    // On macOS, `/var/...` resolves to `/private/var/...`, so compare against
+    // the realpath of the input rather than the raw string.
+    const expectedRealpath = await (
+      await import("node:fs/promises")
+    ).realpath(snapshotPath);
+    expect(lastRestoreArgs!.path).toBe(expectedRealpath);
+  });
+
+  test("encrypted .vbundle.enc inside local dir loads key and restores", async () => {
+    const snapshotPath = writeBackupFile(
+      LOCAL_DIR,
+      "backup-20260411-100000.vbundle.enc",
+    );
+    mockBackupConfig = makeConfig({
+      localDirectory: LOCAL_DIR,
+      offsite: { enabled: true, destinations: [] },
+    });
+    mockBackupKey = Buffer.alloc(32, 0xbb);
+    mockReadBackupKeyCalls = 0;
+
+    const res = await handleBackupRestore(
+      jsonRequest("POST", { path: snapshotPath }),
+    );
+    expect(res.status).toBe(200);
+    expect(mockReadBackupKeyCalls).toBe(1);
+    expect(lastRestoreArgs).not.toBeNull();
+    expect(lastRestoreArgs!.hasKey).toBe(true);
+  });
+
+  test("encrypted bundle with missing backup.key returns a clear 400", async () => {
+    const snapshotPath = writeBackupFile(
+      LOCAL_DIR,
+      "backup-20260411-100000.vbundle.enc",
+    );
+    mockBackupConfig = makeConfig({
+      localDirectory: LOCAL_DIR,
+      offsite: { enabled: true, destinations: [] },
+    });
+    mockBackupKey = null; // readBackupKey returns null when the file is missing
+
+    const res = await handleBackupRestore(
+      jsonRequest("POST", { path: snapshotPath }),
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: { code: string; message: string } };
+    expect(body.error.code).toBe("BAD_REQUEST");
+    expect(body.error.message).toMatch(/backup.key is missing/);
+    // restoreFromSnapshot must NOT have been called — we bail before handing
+    // the path to the restore helper.
+    expect(lastRestoreArgs).toBeNull();
+  });
+
+  test("includeCredentials flag is forwarded to restoreFromSnapshot", async () => {
+    const snapshotPath = writeBackupFile(
+      LOCAL_DIR,
+      "backup-20260411-100000.vbundle",
+    );
+    mockBackupConfig = makeConfig({
+      localDirectory: LOCAL_DIR,
+      offsite: { enabled: true, destinations: [] },
+    });
+
+    const res = await handleBackupRestore(
+      jsonRequest("POST", { path: snapshotPath, includeCredentials: true }),
+    );
+    expect(res.status).toBe(200);
+    expect(lastRestoreArgs!.includeCredentials).toBe(true);
+  });
+
+  test("missing path field returns 400", async () => {
+    const res = await handleBackupRestore(jsonRequest("POST", {}));
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: { code: string; message: string } };
+    expect(body.error.code).toBe("BAD_REQUEST");
+  });
+
+  test("malformed JSON body returns 400", async () => {
+    const req = new Request("http://localhost/v1/backups/restore", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{not-json",
+    });
+    const res = await handleBackupRestore(req);
+    expect(res.status).toBe(400);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleBackupVerify
+// ---------------------------------------------------------------------------
+
+describe("handleBackupVerify", () => {
+  test("corrupted bundle returns { valid: false }", async () => {
+    const snapshotPath = writeBackupFile(
+      LOCAL_DIR,
+      "backup-20260411-100000.vbundle",
+      "not-a-real-bundle",
+    );
+    mockBackupConfig = makeConfig({
+      localDirectory: LOCAL_DIR,
+      offsite: { enabled: true, destinations: [] },
+    });
+    mockVerifyResult = { valid: false, error: "bad checksum" };
+
+    const res = await handleBackupVerify(
+      jsonRequest("POST", { path: snapshotPath }),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as VerifyResult;
+    expect(body.valid).toBe(false);
+    expect(body.error).toBe("bad checksum");
+    expect(lastVerifyArgs!.hasKey).toBe(false);
+  });
+
+  test("valid plaintext bundle returns { valid: true } without loading key", async () => {
+    const snapshotPath = writeBackupFile(
+      LOCAL_DIR,
+      "backup-20260411-100000.vbundle",
+    );
+    mockBackupConfig = makeConfig({
+      localDirectory: LOCAL_DIR,
+      offsite: { enabled: true, destinations: [] },
+    });
+    mockReadBackupKeyCalls = 0;
+    mockVerifyResult = {
+      valid: true,
+      manifest: {
+        schema_version: "1.0",
+        created_at: "2026-04-11T10:00:00.000Z",
+        files: [],
+        manifest_sha256: "0".repeat(64),
+      } as unknown as VerifyResult["manifest"],
+    };
+
+    const res = await handleBackupVerify(
+      jsonRequest("POST", { path: snapshotPath }),
+    );
+    expect(res.status).toBe(200);
+    expect(mockReadBackupKeyCalls).toBe(0);
+    const body = (await res.json()) as VerifyResult;
+    expect(body.valid).toBe(true);
+  });
+
+  test("encrypted bundle with key loads key and forwards to verifySnapshot", async () => {
+    const snapshotPath = writeBackupFile(
+      LOCAL_DIR,
+      "backup-20260411-100000.vbundle.enc",
+    );
+    mockBackupConfig = makeConfig({
+      localDirectory: LOCAL_DIR,
+      offsite: { enabled: true, destinations: [] },
+    });
+    mockBackupKey = Buffer.alloc(32, 0xcc);
+    mockReadBackupKeyCalls = 0;
+
+    const res = await handleBackupVerify(
+      jsonRequest("POST", { path: snapshotPath }),
+    );
+    expect(res.status).toBe(200);
+    expect(mockReadBackupKeyCalls).toBe(1);
+    expect(lastVerifyArgs!.hasKey).toBe(true);
+  });
+
+  test("path outside allowed directories returns 400", async () => {
+    const outsidePath = join(ROOT, "elsewhere", "backup-20260411-100000.vbundle");
+    mkdirSync(join(ROOT, "elsewhere"), { recursive: true });
+    writeFileSync(outsidePath, "payload");
+    mockBackupConfig = makeConfig({
+      localDirectory: LOCAL_DIR,
+      offsite: { enabled: true, destinations: [] },
+    });
+
+    const res = await handleBackupVerify(
+      jsonRequest("POST", { path: outsidePath }),
+    );
+    expect(res.status).toBe(400);
+    expect(lastVerifyArgs).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// backupRouteDefinitions
+// ---------------------------------------------------------------------------
+
+describe("backupRouteDefinitions", () => {
+  test("registers four routes with the expected endpoint+method pairs", () => {
+    const defs = backupRouteDefinitions();
+    const pairs = defs.map((d) => `${d.method} ${d.endpoint}`).sort();
+    expect(pairs).toEqual([
+      "GET backups",
+      "POST backups/create",
+      "POST backups/restore",
+      "POST backups/verify",
+    ]);
+  });
+});

--- a/assistant/src/runtime/routes/backup-routes.ts
+++ b/assistant/src/runtime/routes/backup-routes.ts
@@ -1,0 +1,484 @@
+/**
+ * Route handlers for the backup/restore endpoints.
+ *
+ * GET  /v1/backups             — list local + offsite snapshots
+ * POST /v1/backups/create      — manual snapshot trigger (bypasses schedule gates)
+ * POST /v1/backups/restore     — restore a snapshot into the workspace
+ * POST /v1/backups/verify      — verify a snapshot without restoring
+ *
+ * The list endpoint reports a per-destination `reachable` flag so callers can
+ * render offsite status (e.g. iCloud Drive enabled / external volume mounted)
+ * without probing each path themselves.
+ *
+ * Restore and verify accept a `path` pointing at a concrete snapshot file. The
+ * path must resolve (via `realpath`) to somewhere inside the configured local
+ * or offsite backup directories — this prevents a caller from coaxing the
+ * daemon into restoring an arbitrary file via a symlink escape.
+ *
+ * The backup decryption key is only loaded when the target file is a
+ * `.vbundle.enc` (encrypted) bundle. Plaintext `.vbundle` files never touch
+ * the key material, which means plaintext-only installs never create the
+ * key file as a side effect of list/restore/verify.
+ */
+
+import { promises as fs } from "node:fs";
+import { dirname, sep } from "node:path";
+
+import { z } from "zod";
+
+import { readBackupKey } from "../../backup/backup-key.js";
+import {
+  type BackupRunResult,
+  createSnapshotNow,
+} from "../../backup/backup-worker.js";
+import {
+  listSnapshotsInDir,
+  type SnapshotEntry,
+} from "../../backup/list-snapshots.js";
+import {
+  getBackupKeyPath,
+  getLocalBackupsDir,
+  resolveOffsiteDestinations,
+} from "../../backup/paths.js";
+import { restoreFromSnapshot, verifySnapshot } from "../../backup/restore.js";
+import { getConfig } from "../../config/loader.js";
+import type { BackupDestination } from "../../config/schema.js";
+import { getMemoryCheckpoint } from "../../memory/checkpoints.js";
+import { getLogger } from "../../util/logger.js";
+import {
+  getWorkspaceDir,
+  getWorkspaceHooksDir,
+} from "../../util/platform.js";
+import { httpError } from "../http-errors.js";
+import type { RouteDefinition } from "../http-router.js";
+import { DefaultPathResolver } from "../migrations/vbundle-import-analyzer.js";
+
+const log = getLogger("backup-routes");
+
+/** Memory checkpoint key for the last successful backup run (milliseconds). */
+const LAST_RUN_CHECKPOINT_KEY = "backup:last_run_at";
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve an absolute path via `realpath`, following symlinks. Returns `null`
+ * when the path does not exist or any component is missing. Callers that need
+ * to distinguish missing-file from other errors should check separately.
+ */
+async function safeRealpath(path: string): Promise<string | null> {
+  try {
+    return await fs.realpath(path);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Check whether `candidate` is contained inside `root`. Containment is
+ * inclusive of `root` itself (so `root === candidate` is accepted) and uses
+ * the platform path separator so a root of `/a` doesn't accidentally match
+ * `/a-evil/`. Callers must pass already-realpath'd inputs.
+ */
+function isInside(candidate: string, root: string): boolean {
+  if (candidate === root) return true;
+  return candidate.startsWith(root + sep);
+}
+
+/**
+ * Build the list of absolute directories a restore/verify target is allowed
+ * to live inside. Includes the local backups directory plus every configured
+ * offsite destination (after resolving the null → iCloud default).
+ */
+function computeAllowedRoots(): string[] {
+  const config = getConfig();
+  const roots: string[] = [getLocalBackupsDir(config.backup.localDirectory)];
+  for (const dest of resolveOffsiteDestinations(
+    config.backup.offsite.destinations,
+  )) {
+    roots.push(dest.path);
+  }
+  return roots;
+}
+
+/**
+ * Resolve a caller-supplied snapshot path against the allowed roots. Returns
+ * the realpath'd candidate on success, or an `Response` error envelope if the
+ * path is missing, outside every root, or a symlink that escapes.
+ *
+ * Symlink handling: we realpath both the candidate and every root, then
+ * compare. A symlink inside an allowed root pointing at `/etc/passwd` would
+ * be caught here because `realpath(candidate)` returns `/etc/passwd` which
+ * is not inside any allowed root.
+ */
+async function validateSnapshotPath(
+  rawPath: unknown,
+): Promise<{ path: string } | { error: Response }> {
+  if (typeof rawPath !== "string" || rawPath.length === 0) {
+    return {
+      error: httpError(
+        "BAD_REQUEST",
+        "Request body must include a non-empty `path` field",
+        400,
+      ),
+    };
+  }
+
+  const realCandidate = await safeRealpath(rawPath);
+  if (realCandidate == null) {
+    return {
+      error: httpError(
+        "BAD_REQUEST",
+        `Snapshot path does not exist: ${rawPath}`,
+        400,
+      ),
+    };
+  }
+
+  const allowedRoots = computeAllowedRoots();
+  for (const root of allowedRoots) {
+    const realRoot = await safeRealpath(root);
+    if (realRoot == null) continue;
+    if (isInside(realCandidate, realRoot)) {
+      return { path: realCandidate };
+    }
+  }
+
+  return {
+    error: httpError(
+      "BAD_REQUEST",
+      "Snapshot path is outside the configured backup directories",
+      400,
+    ),
+  };
+}
+
+/**
+ * Load the backup decryption key iff the target snapshot is encrypted. Returns
+ * `{ key: null }` for plaintext bundles without touching the filesystem.
+ * Returns `{ error }` with a clear 400 envelope when an encrypted bundle is
+ * supplied but no key file exists (an unrecoverable user-facing state that
+ * should not silently 500).
+ */
+async function loadKeyIfEncrypted(
+  snapshotPath: string,
+): Promise<{ key: Buffer | null } | { error: Response }> {
+  if (!snapshotPath.endsWith(".vbundle.enc")) {
+    return { key: null };
+  }
+  const key = await readBackupKey(getBackupKeyPath());
+  if (key == null) {
+    return {
+      error: httpError(
+        "BAD_REQUEST",
+        "Encrypted snapshot requires a backup key, but backup.key is missing",
+        400,
+      ),
+    };
+  }
+  return { key };
+}
+
+// ---------------------------------------------------------------------------
+// GET /v1/backups
+// ---------------------------------------------------------------------------
+
+/**
+ * Shape returned by {@link handleBackupList}. Exported so client code (and
+ * the test suite) can type the JSON response without re-deriving it.
+ */
+export interface BackupListResponse {
+  local: SnapshotEntry[];
+  offsite: Array<{
+    destination: BackupDestination;
+    snapshots: SnapshotEntry[];
+    reachable: boolean;
+  }>;
+  nextRunAt: string | null;
+}
+
+/**
+ * List all known backup snapshots — local and every configured offsite
+ * destination — along with scheduling metadata. Per-destination `reachable`
+ * reflects whether `dirname(destination.path)` exists on disk right now (the
+ * same probe the offsite writer uses), so clients can distinguish "empty
+ * destination" from "unavailable destination" without a second round trip.
+ */
+export async function handleBackupList(_req: Request): Promise<Response> {
+  try {
+    const config = getConfig();
+    const localDir = getLocalBackupsDir(config.backup.localDirectory);
+    const local = await listSnapshotsInDir(localDir);
+
+    const offsite: BackupListResponse["offsite"] = [];
+    for (const destination of resolveOffsiteDestinations(
+      config.backup.offsite.destinations,
+    )) {
+      let reachable = false;
+      try {
+        await fs.stat(dirname(destination.path));
+        reachable = true;
+      } catch {
+        reachable = false;
+      }
+      const snapshots = reachable
+        ? await listSnapshotsInDir(destination.path)
+        : [];
+      offsite.push({ destination, snapshots, reachable });
+    }
+
+    let nextRunAt: string | null = null;
+    if (config.backup.enabled) {
+      const lastRunRaw = getMemoryCheckpoint(LAST_RUN_CHECKPOINT_KEY);
+      if (lastRunRaw != null) {
+        const lastRunMs = Number.parseInt(lastRunRaw, 10);
+        if (!Number.isNaN(lastRunMs)) {
+          const intervalMs = config.backup.intervalHours * 3600 * 1000;
+          nextRunAt = new Date(lastRunMs + intervalMs).toISOString();
+        }
+      }
+    }
+
+    const body: BackupListResponse = { local, offsite, nextRunAt };
+    return Response.json(body);
+  } catch (err) {
+    log.error({ err }, "Failed to list backups");
+    return httpError(
+      "INTERNAL_ERROR",
+      err instanceof Error ? err.message : "Failed to list backups",
+      500,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// POST /v1/backups/create
+// ---------------------------------------------------------------------------
+
+/**
+ * Trigger a manual backup snapshot immediately. This bypasses both the
+ * `backup.enabled` flag and the interval gate, but still honors the
+ * snapshot-in-progress mutex: a concurrent caller receives a 409.
+ *
+ * On success, returns the full `BackupRunResult` so the client can render
+ * per-destination outcomes without re-listing.
+ */
+export async function handleBackupCreate(_req: Request): Promise<Response> {
+  try {
+    const config = getConfig();
+    const result: BackupRunResult = await createSnapshotNow(
+      config.backup,
+      new Date(),
+    );
+    return Response.json(result);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    // Map the mutex rejection to 409 so clients can distinguish "try again
+    // later" from a real failure.
+    if (message === "snapshot in progress") {
+      return httpError("CONFLICT", "A snapshot is already in progress", 409);
+    }
+    log.error({ err }, "Manual backup snapshot failed");
+    return httpError("INTERNAL_ERROR", message, 500);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// POST /v1/backups/restore
+// ---------------------------------------------------------------------------
+
+interface RestoreRequestBody {
+  path: unknown;
+  includeCredentials?: unknown;
+}
+
+/**
+ * Restore a snapshot into the live workspace. Destructive: the underlying
+ * `commitImport` flow backs up existing files before overwriting, but callers
+ * should still treat this as an irreversible "replace the workspace" operation.
+ *
+ * `includeCredentials` defaults to `false`; when true, credential entries from
+ * the bundle are returned to the caller alongside the manifest summary so they
+ * can be re-persisted via the separate credential-import path.
+ */
+export async function handleBackupRestore(req: Request): Promise<Response> {
+  let body: RestoreRequestBody;
+  try {
+    body = (await req.json()) as RestoreRequestBody;
+  } catch {
+    return httpError(
+      "BAD_REQUEST",
+      "Request body must be valid JSON with a `path` field",
+      400,
+    );
+  }
+
+  const validated = await validateSnapshotPath(body.path);
+  if ("error" in validated) return validated.error;
+  const snapshotPath = validated.path;
+
+  const keyResult = await loadKeyIfEncrypted(snapshotPath);
+  if ("error" in keyResult) return keyResult.error;
+
+  try {
+    const pathResolver = new DefaultPathResolver(
+      getWorkspaceDir(),
+      getWorkspaceHooksDir(),
+    );
+    const result = await restoreFromSnapshot(snapshotPath, {
+      key: keyResult.key ?? undefined,
+      includeCredentials: body.includeCredentials === true,
+      pathResolver,
+      workspaceDir: getWorkspaceDir(),
+    });
+
+    return Response.json({
+      manifest: result.manifest,
+      restoredFiles: result.restoredFiles,
+      credentialsIncluded: result.credentials.length,
+    });
+  } catch (err) {
+    log.error({ err, snapshotPath }, "Snapshot restore failed");
+    return httpError(
+      "INTERNAL_ERROR",
+      err instanceof Error ? err.message : "Snapshot restore failed",
+      500,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// POST /v1/backups/verify
+// ---------------------------------------------------------------------------
+
+interface VerifyRequestBody {
+  path: unknown;
+}
+
+/**
+ * Verify a snapshot (decrypts if needed, runs `validateVBundle`) without
+ * touching the workspace. Does not throw on validation or decryption failure
+ * — those surface as `{ valid: false, error: ... }` so callers can render a
+ * uniform status for each snapshot in a list.
+ */
+export async function handleBackupVerify(req: Request): Promise<Response> {
+  let body: VerifyRequestBody;
+  try {
+    body = (await req.json()) as VerifyRequestBody;
+  } catch {
+    return httpError(
+      "BAD_REQUEST",
+      "Request body must be valid JSON with a `path` field",
+      400,
+    );
+  }
+
+  const validated = await validateSnapshotPath(body.path);
+  if ("error" in validated) return validated.error;
+  const snapshotPath = validated.path;
+
+  const keyResult = await loadKeyIfEncrypted(snapshotPath);
+  if ("error" in keyResult) return keyResult.error;
+
+  try {
+    const result = await verifySnapshot(snapshotPath, {
+      key: keyResult.key ?? undefined,
+    });
+    return Response.json(result);
+  } catch (err) {
+    log.error({ err, snapshotPath }, "Snapshot verification failed");
+    return httpError(
+      "INTERNAL_ERROR",
+      err instanceof Error ? err.message : "Snapshot verification failed",
+      500,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+export function backupRouteDefinitions(): RouteDefinition[] {
+  return [
+    {
+      endpoint: "backups",
+      method: "GET",
+      summary: "List backup snapshots",
+      description:
+        "Lists local and offsite backup snapshots. Each offsite destination includes a `reachable` flag reflecting whether the backing volume is currently available.",
+      tags: ["backups"],
+      responseBody: z.object({
+        local: z.array(z.unknown()),
+        offsite: z.array(
+          z.object({
+            destination: z.object({}).passthrough(),
+            snapshots: z.array(z.unknown()),
+            reachable: z.boolean(),
+          }),
+        ),
+        nextRunAt: z.string().nullable(),
+      }),
+      handler: async ({ req }) => handleBackupList(req),
+    },
+    {
+      endpoint: "backups/create",
+      method: "POST",
+      summary: "Create a backup snapshot immediately",
+      description:
+        "Trigger a manual snapshot. Bypasses the enabled and interval gates, but honors the in-progress mutex — a concurrent caller receives 409.",
+      tags: ["backups"],
+      responseBody: z.object({
+        local: z.object({}).passthrough(),
+        offsite: z.array(z.unknown()),
+        durationMs: z.number(),
+      }),
+      handler: async ({ req }) => handleBackupCreate(req),
+    },
+    {
+      endpoint: "backups/restore",
+      method: "POST",
+      summary: "Restore from a backup snapshot",
+      description:
+        "Restores a snapshot into the workspace. Destructive: the underlying commit flow backs up existing files before overwriting.",
+      tags: ["backups"],
+      requestBody: z.object({
+        path: z
+          .string()
+          .describe("Absolute path to the snapshot file to restore"),
+        includeCredentials: z
+          .boolean()
+          .optional()
+          .describe(
+            "Whether to extract credential entries from the bundle (default false)",
+          ),
+      }),
+      responseBody: z.object({
+        manifest: z.object({}).passthrough(),
+        restoredFiles: z.number(),
+        credentialsIncluded: z.number(),
+      }),
+      handler: async ({ req }) => handleBackupRestore(req),
+    },
+    {
+      endpoint: "backups/verify",
+      method: "POST",
+      summary: "Verify a backup snapshot",
+      description:
+        "Validates a snapshot without restoring. Decrypts encrypted bundles to a temp file, runs the vbundle validator, and returns a pass/fail status.",
+      tags: ["backups"],
+      requestBody: z.object({
+        path: z
+          .string()
+          .describe("Absolute path to the snapshot file to verify"),
+      }),
+      responseBody: z.object({
+        valid: z.boolean(),
+        manifest: z.object({}).passthrough().optional(),
+        error: z.string().optional(),
+      }),
+      handler: async ({ req }) => handleBackupVerify(req),
+    },
+  ];
+}


### PR DESCRIPTION
## Summary
- Add GET /v1/backups (list), POST /v1/backups/create, /restore, /verify
- Per-destination offsite status with reachable flag in the list response
- Path validation via realpath prevents symlink escapes
- Key is only loaded when restoring/verifying .vbundle.enc files

Part of plan: backup-restore-system.md (PR 10 of 12)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24890" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
