### PR TITLE
fix(test): plug incomplete tool-usage-store mocks that flaked deterministic-verification-control-plane

### DIFF
--- a/assistant/src/__tests__/platform-bash-auto-approve.test.ts
+++ b/assistant/src/__tests__/platform-bash-auto-approve.test.ts
@@ -99,8 +99,12 @@ mock.module("../permissions/checker.js", () => ({
     scopeOptionsOverride ?? [{ label: "/tmp", scope: "/tmp" }],
 }));
 
+// Mock every export so downstream test files that dynamically import modules
+// with a static `from "../memory/tool-usage-store.js"` still see all symbols.
 mock.module("../memory/tool-usage-store.js", () => ({
   recordToolInvocation: () => {},
+  getRecentInvocations: () => [],
+  rotateToolInvocations: () => 0,
 }));
 
 mock.module("../tools/registry.js", () => ({

--- a/assistant/src/__tests__/secret-scanner-executor.test.ts
+++ b/assistant/src/__tests__/secret-scanner-executor.test.ts
@@ -56,10 +56,14 @@ mock.module("../permissions/checker.js", () => ({
   generateScopeOptions: () => [],
 }));
 
+// Mock every export so downstream test files that dynamically import modules
+// with a static `from "../memory/tool-usage-store.js"` still see all symbols.
 mock.module("../memory/tool-usage-store.js", () => ({
   recordToolInvocation: (inv: unknown) => {
     recordedInvocations.push(inv);
   },
+  getRecentInvocations: () => [],
+  rotateToolInvocations: () => 0,
 }));
 
 mock.module("../tools/registry.js", () => ({

--- a/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
+++ b/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
@@ -72,8 +72,12 @@ mock.module("../permissions/checker.js", () => ({
   generateScopeOptions: () => [{ label: "/tmp", scope: "/tmp" }],
 }));
 
+// Mock every export so downstream test files that dynamically import modules
+// with a static `from "../memory/tool-usage-store.js"` still see all symbols.
 mock.module("../memory/tool-usage-store.js", () => ({
   recordToolInvocation: () => {},
+  getRecentInvocations: () => [],
+  rotateToolInvocations: () => 0,
 }));
 
 mock.module("../tools/registry.js", () => ({

--- a/assistant/src/__tests__/tool-executor-shell-integration.test.ts
+++ b/assistant/src/__tests__/tool-executor-shell-integration.test.ts
@@ -92,8 +92,12 @@ mock.module("../permissions/trust-store.js", () => ({
 }));
 
 // ── Tool usage store ──
+// Mock every export so downstream test files that dynamically import modules
+// with a static `from "../memory/tool-usage-store.js"` still see all symbols.
 mock.module("../memory/tool-usage-store.js", () => ({
   recordToolInvocation: () => {},
+  getRecentInvocations: () => [],
+  rotateToolInvocations: () => 0,
 }));
 
 // ── Path policy ──

--- a/assistant/src/__tests__/tool-executor.test.ts
+++ b/assistant/src/__tests__/tool-executor.test.ts
@@ -129,8 +129,12 @@ mock.module("../permissions/checker.js", () => ({
     scopeOptionsOverride ?? [{ label: "/tmp", scope: "/tmp" }],
 }));
 
+// Mock every export so downstream test files that dynamically import modules
+// with a static `from "../memory/tool-usage-store.js"` still see all symbols.
 mock.module("../memory/tool-usage-store.js", () => ({
   recordToolInvocation: () => {},
+  getRecentInvocations: () => [],
+  rotateToolInvocations: () => 0,
 }));
 
 mock.module("../tools/registry.js", () => ({

--- a/assistant/src/__tests__/verification-control-plane-policy.test.ts
+++ b/assistant/src/__tests__/verification-control-plane-policy.test.ts
@@ -73,8 +73,12 @@ mock.module("../permissions/checker.js", () => ({
   generateScopeOptions: () => [],
 }));
 
+// Mock every export so downstream test files that dynamically import modules
+// with a static `from "../memory/tool-usage-store.js"` still see all symbols.
 mock.module("../memory/tool-usage-store.js", () => ({
   recordToolInvocation: () => {},
+  getRecentInvocations: () => [],
+  rotateToolInvocations: () => 0,
 }));
 
 mock.module("../tools/registry.js", () => ({


### PR DESCRIPTION
## Summary
- Six test files mock `../memory/tool-usage-store.js` but only stub `recordToolInvocation`, dropping `getRecentInvocations` and `rotateToolInvocations` from the module shape.
- Bun's \`mock.module\` persists across test files, so when any of those ran before \`deterministic-verification-control-plane.test.ts\`, its dynamic \`import(\"../runtime/routes/inbound-message-handler.js\")\` transitively pulled \`cli/program.ts → audit.ts\`, which statically imports \`getRecentInvocations\` — producing a \`SyntaxError: Export named 'getRecentInvocations' not found\` between tests. Reproducible with \`bun test --randomize\` on seeds 3, 5, 7, 8.
- Added the missing exports (\`getRecentInvocations: () => []\`, \`rotateToolInvocations: () => 0\`) to all six incomplete mocks. Verified each polluter+target pairing is green, and 20 back-to-back runs of the deterministic test plus 8 randomized seeds across the trio all pass.

## Original prompt
The test at deterministic-verification-control-plane.test.ts is flaky. Can you fix it?
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24893" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
