### PR TITLE
fix(macos): remove unused appIcon local in AppsGridView.appCard

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
@@ -141,7 +141,6 @@ struct AppsGridView: View {
 
     private func appCard(_ app: AppListManager.AppItem) -> some View {
         let isHovered = hoveredAppId == app.id
-        let appIcon = resolvedIcon(for: app)
         let rawPreview = app.previewBase64 ?? previewCache[app.id]
         let preview = rawPreview?.isEmpty == true ? nil : rawPreview
 


### PR DESCRIPTION
## Summary
- Drop the unused `let appIcon = resolvedIcon(for: app)` in `AppsGridView.appCard(_:)` that Swift 6 flagged with a `#no-usage` warning during debug builds.
- `resolvedIcon(for:)` is pure (see line 520), so removing the binding is a no-op behaviorally.

## Original prompt
```
--yolo --skip-ci Fix: ~v/clients/macos (main) ❯❯❯ VELLUM_NO_WATCH=1 ./build.sh run
VELLUM_ENVIRONMENT=local
Building (debug)...
[1/1] Planning build
Building for debugging...
/Users/sidd/vocify/vellum-assistant/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift:144:13: warning: initialization of immutable value 'appIcon' was never used; consider replacing with assignment to '_' or removing it [#no-usage]
142 |     private func appCard(_ app: AppListManager.AppItem) -> some View {
143 |         let isHovered = hoveredAppId == app.id
144 |         let appIcon = resolvedIcon(for: app)
    |             \`- warning: initialization of immutable value 'appIcon' was never used; consider replacing with assignment to '_' or removing it [#no-usage]
145 |         let rawPreview = app.previewBase64 ?? previewCache[app.id]
146 |         let preview = rawPreview?.isEmpty == true ? nil : rawPreview
```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24894" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
