### PR TITLE
fix(macos): make TTSClientProtocol Sendable to silence Swift 6 warning

### DIFF
--- a/clients/shared/Network/TTSClient.swift
+++ b/clients/shared/Network/TTSClient.swift
@@ -18,7 +18,7 @@ public enum TTSResult: Sendable {
 }
 
 /// Client for text-to-speech synthesis routed through the gateway.
-public protocol TTSClientProtocol {
+public protocol TTSClientProtocol: Sendable {
     /// Synthesize a specific message's text to audio.
     func synthesize(messageId: String, conversationId: String?) async -> TTSResult
 


### PR DESCRIPTION
## Summary

- `OpenAIVoiceService.init` is `nonisolated` but the class is `@MainActor`, so assigning to the actor-isolated `ttsClient` property from the init emitted a Swift 6 warning (main actor-isolated property cannot be mutated from a nonisolated context).
- `SpeechRecognizerAdapter` sitting next to it is already `Sendable`, which is why that assignment was fine. `TTSClientProtocol` was not.
- Adding `Sendable` conformance to `TTSClientProtocol` is safe: the sole conformer, `TTSClient`, is a struct with zero stored properties, so it's trivially `Sendable`.

## Original prompt

Fix: /Users/sidd/vocify/vellum-assistant/clients/macos/vellum-assistant/Features/Voice/OpenAIVoiceService.swift:96:14: warning: main actor-isolated property 'ttsClient' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode