### PR TITLE
fix(backup): cross-process snapshot lock

### DIFF
--- a/assistant/src/backup/__tests__/backup-worker.test.ts
+++ b/assistant/src/backup/__tests__/backup-worker.test.ts
@@ -162,6 +162,7 @@ describe("runBackupTick — gating", () => {
       setMemoryCheckpoint: checkpoints.set,
       workspaceDir: ROOT,
       localDir,
+      snapshotLockPath: join(ROOT, ".snapshot.lock"),
     });
 
     expect(result).toBeNull();
@@ -186,6 +187,7 @@ describe("runBackupTick — gating", () => {
       setMemoryCheckpoint: checkpoints.set,
       workspaceDir: ROOT,
       localDir,
+      snapshotLockPath: join(ROOT, ".snapshot.lock"),
       // Explicit plaintext to avoid touching the key file
       trustPath: join(ROOT, "trust.json"),
       hooksDir: join(ROOT, "hooks"),
@@ -217,6 +219,7 @@ describe("runBackupTick — gating", () => {
       setMemoryCheckpoint: checkpoints.set,
       workspaceDir: ROOT,
       localDir,
+      snapshotLockPath: join(ROOT, ".snapshot.lock"),
     });
 
     expect(result).not.toBeNull();
@@ -244,6 +247,7 @@ describe("runBackupTick — gating", () => {
       setMemoryCheckpoint: checkpoints.set,
       workspaceDir: ROOT,
       localDir,
+      snapshotLockPath: join(ROOT, ".snapshot.lock"),
     });
 
     expect(result).not.toBeNull();
@@ -273,6 +277,7 @@ describe("runBackupTick — offsite destinations", () => {
       ensureBackupKey: ensureKey,
       workspaceDir: ROOT,
       localDir,
+      snapshotLockPath: join(ROOT, ".snapshot.lock"),
     });
 
     expect(result).not.toBeNull();
@@ -304,6 +309,7 @@ describe("runBackupTick — offsite destinations", () => {
       ensureBackupKey: ensureKey,
       workspaceDir: ROOT,
       localDir,
+      snapshotLockPath: join(ROOT, ".snapshot.lock"),
     });
 
     expect(result).not.toBeNull();
@@ -342,6 +348,7 @@ describe("runBackupTick — offsite destinations", () => {
       backupKeyPath: keyPath,
       workspaceDir: ROOT,
       localDir,
+      snapshotLockPath: join(ROOT, ".snapshot.lock"),
     });
 
     expect(result).not.toBeNull();
@@ -382,6 +389,7 @@ describe("runBackupTick — offsite destinations", () => {
       ensureBackupKey: ensureKey,
       workspaceDir: ROOT,
       localDir,
+      snapshotLockPath: join(ROOT, ".snapshot.lock"),
     });
 
     expect(result).not.toBeNull();
@@ -420,6 +428,7 @@ describe("runBackupTick — offsite destinations", () => {
       setMemoryCheckpoint: checkpoints.set,
       workspaceDir: ROOT,
       localDir,
+      snapshotLockPath: join(ROOT, ".snapshot.lock"),
     });
 
     expect(result).not.toBeNull();
@@ -457,6 +466,7 @@ describe("runBackupTick — error propagation", () => {
         setMemoryCheckpoint: checkpoints.set,
         workspaceDir: ROOT,
         localDir,
+        snapshotLockPath: join(ROOT, ".snapshot.lock"),
       }),
     ).rejects.toThrow("boom");
     expect(checkpoints.store["backup:last_run_at"]).toBeUndefined();
@@ -483,6 +493,7 @@ describe("createSnapshotNow", () => {
       setMemoryCheckpoint: checkpoints.set,
       workspaceDir: ROOT,
       localDir,
+      snapshotLockPath: join(ROOT, ".snapshot.lock"),
     });
 
     expect(result).not.toBeNull();
@@ -510,6 +521,7 @@ describe("createSnapshotNow", () => {
       setMemoryCheckpoint: checkpoints.set,
       workspaceDir: ROOT,
       localDir,
+      snapshotLockPath: join(ROOT, ".snapshot.lock"),
     });
 
     expect(result).not.toBeNull();
@@ -568,6 +580,7 @@ describe("createSnapshotNow", () => {
       setMemoryCheckpoint: checkpoints.set,
       workspaceDir: ROOT,
       localDir,
+      snapshotLockPath: join(ROOT, ".snapshot.lock"),
     });
 
     // Yield once so the first call has a chance to enter the mutex + the
@@ -582,6 +595,7 @@ describe("createSnapshotNow", () => {
         setMemoryCheckpoint: checkpoints.set,
         workspaceDir: ROOT,
         localDir,
+        snapshotLockPath: join(ROOT, ".snapshot.lock"),
       }),
     ).rejects.toThrow("snapshot in progress");
 
@@ -589,6 +603,106 @@ describe("createSnapshotNow", () => {
     await first;
     // Only the first call should have been executed by the stub.
     expect(callCount).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cross-process lock (simulates a second process holding the lock)
+// ---------------------------------------------------------------------------
+
+describe("cross-process snapshot lock", () => {
+  test("after performBackup succeeds, the lock file no longer exists", async () => {
+    const checkpoints = makeCheckpointStore();
+    const streamStub = makeStreamExportStub();
+    const config = makeConfig({
+      enabled: true,
+      offsite: { enabled: false, destinations: null },
+    });
+    const localDir = join(ROOT, "local");
+    const lockPath = join(ROOT, ".snapshot.lock");
+
+    const result = await createSnapshotNow(config, new Date(), {
+      streamExportVBundle: streamStub.fn,
+      getMemoryCheckpoint: checkpoints.get,
+      setMemoryCheckpoint: checkpoints.set,
+      workspaceDir: ROOT,
+      localDir,
+      snapshotLockPath: lockPath,
+    });
+
+    expect(result).not.toBeNull();
+    // Lock file released on the finally path — must not linger on disk.
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  test("another process holds the lock: createSnapshotNow throws 'snapshot in progress'", async () => {
+    const checkpoints = makeCheckpointStore();
+    const streamStub = makeStreamExportStub();
+    const config = makeConfig({
+      enabled: true,
+      offsite: { enabled: false, destinations: null },
+    });
+    const localDir = join(ROOT, "local");
+    const lockPath = join(ROOT, ".snapshot.lock");
+
+    // Simulate a concurrent CLI invocation by writing a lock file with the
+    // CURRENT pid (which is definitely alive — it's us). Because the lock
+    // file pre-exists and the PID probes as alive, the in-process flag will
+    // pass (it's reset after the previous test) but the cross-process lock
+    // will reject with "snapshot in progress (locked by pid N)".
+    writeFileSync(lockPath, `${process.pid} ${Date.now()}\n`, { mode: 0o600 });
+
+    await expect(
+      createSnapshotNow(config, new Date(), {
+        streamExportVBundle: streamStub.fn,
+        getMemoryCheckpoint: checkpoints.get,
+        setMemoryCheckpoint: checkpoints.set,
+        workspaceDir: ROOT,
+        localDir,
+        snapshotLockPath: lockPath,
+      }),
+    ).rejects.toThrow(/snapshot in progress/);
+
+    // The stream stub must not have been invoked because acquisition failed
+    // before performBackup ran.
+    expect(streamStub.calls).toHaveLength(0);
+    // The pre-existing lock file is preserved — we did not own it, so we
+    // must not have removed it on the failed-acquisition path.
+    expect(existsSync(lockPath)).toBe(true);
+  });
+
+  test("runBackupTick defers silently when another process holds the lock", async () => {
+    const now = new Date("2026-04-11T10:00:00Z");
+    const checkpoints = makeCheckpointStore();
+    const streamStub = makeStreamExportStub();
+    const config = makeConfig({
+      enabled: true,
+      offsite: { enabled: false, destinations: null },
+    });
+    const localDir = join(ROOT, "local");
+    const lockPath = join(ROOT, ".snapshot.lock");
+
+    // Pre-seed the lock file with the live PID so the worker observes a
+    // conflict on its cross-process check.
+    writeFileSync(lockPath, `${process.pid} ${Date.now()}\n`, { mode: 0o600 });
+
+    const result = await runBackupTick(config, now, {
+      streamExportVBundle: streamStub.fn,
+      getMemoryCheckpoint: checkpoints.get,
+      setMemoryCheckpoint: checkpoints.set,
+      workspaceDir: ROOT,
+      localDir,
+      snapshotLockPath: lockPath,
+    });
+
+    // Scheduled tick defers silently on conflict rather than throwing — the
+    // next interval will retry.
+    expect(result).toBeNull();
+    expect(streamStub.calls).toHaveLength(0);
+    // Checkpoint must not advance when the tick defers.
+    expect(checkpoints.store["backup:last_run_at"]).toBeUndefined();
+    // Pre-existing lock file is preserved.
+    expect(existsSync(lockPath)).toBe(true);
   });
 });
 
@@ -625,6 +739,7 @@ describe("retention across successive ticks", () => {
         setMemoryCheckpoint: checkpoints.set,
         workspaceDir: ROOT,
         localDir,
+        snapshotLockPath: join(ROOT, ".snapshot.lock"),
       });
       expect(result).not.toBeNull();
     }

--- a/assistant/src/backup/__tests__/snapshot-lock.test.ts
+++ b/assistant/src/backup/__tests__/snapshot-lock.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Tests for the cross-process snapshot lock helper. Each test gets a fresh
+ * temp directory so runs never collide with the real `~/.vellum/backups`
+ * directory and so parallel test workers never see each other's lock files.
+ *
+ * The interesting corners covered here are:
+ *   - Acquire → release round-trip leaves the filesystem clean
+ *   - A second acquire against a held lock throws with the expected prefix
+ *   - A dead-PID lock file (simulated by writing a garbage PID that is not
+ *     alive on this host) is taken over transparently
+ *   - The release function is idempotent — calling it twice is a no-op
+ *   - The lock file is created with mode `0o600` so an unprivileged
+ *     peer on the same machine cannot read the holder PID
+ */
+
+import { existsSync, mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { acquireSnapshotLock } from "../snapshot-lock.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+let ROOT: string;
+let LOCK: string;
+
+beforeEach(() => {
+  ROOT = mkdtempSync(join(tmpdir(), "vellum-snapshot-lock-"));
+  LOCK = join(ROOT, ".snapshot.lock");
+});
+
+afterEach(() => {
+  try {
+    rmSync(ROOT, { recursive: true, force: true });
+  } catch {
+    // best-effort
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Happy path
+// ---------------------------------------------------------------------------
+
+describe("acquireSnapshotLock — happy path", () => {
+  test("acquire creates the lock file; release removes it", async () => {
+    expect(existsSync(LOCK)).toBe(false);
+
+    const release = await acquireSnapshotLock(LOCK);
+    expect(existsSync(LOCK)).toBe(true);
+
+    await release();
+    expect(existsSync(LOCK)).toBe(false);
+  });
+
+  test("lock file is created with mode 0o600", async () => {
+    const release = await acquireSnapshotLock(LOCK);
+    try {
+      const stats = statSync(LOCK);
+      // mask to permission bits only
+      expect(stats.mode & 0o777).toBe(0o600);
+    } finally {
+      await release();
+    }
+  });
+
+  test("acquire creates the parent directory if missing", async () => {
+    // Point the lock at a nested path whose parent does not exist yet so
+    // we exercise the mkdir-on-demand code path.
+    const nested = join(ROOT, "missing-parent", ".snapshot.lock");
+    expect(existsSync(join(ROOT, "missing-parent"))).toBe(false);
+
+    const release = await acquireSnapshotLock(nested);
+    try {
+      expect(existsSync(nested)).toBe(true);
+    } finally {
+      await release();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Conflict detection
+// ---------------------------------------------------------------------------
+
+describe("acquireSnapshotLock — conflicts", () => {
+  test("two acquires against a live holder: second throws 'snapshot in progress'", async () => {
+    const release = await acquireSnapshotLock(LOCK);
+    try {
+      await expect(acquireSnapshotLock(LOCK)).rejects.toThrow(
+        /snapshot in progress/,
+      );
+    } finally {
+      await release();
+    }
+  });
+
+  test("conflict error includes the holder PID", async () => {
+    const release = await acquireSnapshotLock(LOCK);
+    try {
+      await expect(acquireSnapshotLock(LOCK)).rejects.toThrow(
+        new RegExp(`snapshot in progress \\(locked by pid ${process.pid}\\)`),
+      );
+    } finally {
+      await release();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Stale-lock takeover
+// ---------------------------------------------------------------------------
+
+describe("acquireSnapshotLock — stale locks", () => {
+  test("dead PID: acquire takes over and creates a fresh lock", async () => {
+    // PID 2^31 - 1 is virtually guaranteed to be dead on any sane host —
+    // the platform PID_MAX is typically much smaller. Writing it as the
+    // lock holder simulates a crashed prior writer whose process has since
+    // exited without releasing.
+    const deadPid = 2_147_483_647;
+    writeFileSync(LOCK, `${deadPid} ${Date.now()}\n`, { mode: 0o600 });
+    expect(existsSync(LOCK)).toBe(true);
+
+    const release = await acquireSnapshotLock(LOCK);
+    try {
+      expect(existsSync(LOCK)).toBe(true);
+    } finally {
+      await release();
+    }
+    expect(existsSync(LOCK)).toBe(false);
+  });
+
+  test("unparseable lock file: acquire takes it over", async () => {
+    // A lock file that contains garbage (no digits) has no recoverable
+    // holder PID — treat it as stale and take over.
+    writeFileSync(LOCK, "not a pid at all\n", { mode: 0o600 });
+
+    const release = await acquireSnapshotLock(LOCK);
+    try {
+      expect(existsSync(LOCK)).toBe(true);
+    } finally {
+      await release();
+    }
+    expect(existsSync(LOCK)).toBe(false);
+  });
+
+  test("empty lock file: acquire takes it over", async () => {
+    writeFileSync(LOCK, "", { mode: 0o600 });
+
+    const release = await acquireSnapshotLock(LOCK);
+    try {
+      expect(existsSync(LOCK)).toBe(true);
+    } finally {
+      await release();
+    }
+    expect(existsSync(LOCK)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Release semantics
+// ---------------------------------------------------------------------------
+
+describe("acquireSnapshotLock — release", () => {
+  test("release is idempotent: calling twice is safe", async () => {
+    const release = await acquireSnapshotLock(LOCK);
+    await release();
+    // Second call must not throw, even though the file is already gone.
+    await release();
+    expect(existsSync(LOCK)).toBe(false);
+  });
+
+  test("release tolerates an externally-unlinked lock file", async () => {
+    const release = await acquireSnapshotLock(LOCK);
+    // Simulate another process (or a rogue admin) removing our lock file
+    // out from under us. Release must still return without throwing.
+    rmSync(LOCK, { force: true });
+    await release();
+  });
+
+  test("after release, the lock can be acquired again", async () => {
+    const release1 = await acquireSnapshotLock(LOCK);
+    await release1();
+
+    const release2 = await acquireSnapshotLock(LOCK);
+    try {
+      expect(existsSync(LOCK)).toBe(true);
+    } finally {
+      await release2();
+    }
+  });
+});

--- a/assistant/src/backup/backup-worker.ts
+++ b/assistant/src/backup/backup-worker.ts
@@ -60,6 +60,10 @@ import {
   getLocalBackupsDir,
   resolveOffsiteDestinations,
 } from "./paths.js";
+import {
+  acquireSnapshotLock,
+  getSnapshotLockPath,
+} from "./snapshot-lock.js";
 
 const log = getLogger("backup-worker");
 
@@ -118,23 +122,37 @@ export interface BackupDeps {
   hooksDir?: string;
   /** Override for the backup key file path (tests). */
   backupKeyPath?: string;
+  /**
+   * Override for the cross-process snapshot lock file path (tests). Defaults
+   * to `getSnapshotLockPath()` in production. Tests that drive multiple
+   * parallel runs against temp directories inject a path under their fixture
+   * root so they don't collide with each other or with the real daemon.
+   */
+  snapshotLockPath?: string;
 }
 
 // ---------------------------------------------------------------------------
-// Concurrency mutex (module-scoped)
+// Concurrency mutex (two layers)
 // ---------------------------------------------------------------------------
 
 /**
- * In-memory mutex flag. Both the scheduled tick and the manual trigger share
- * this flag so that:
+ * In-memory mutex flag — the first line of defense. Protects the current
+ * process from racing itself:
  * - A scheduled tick that fires while a manual run is in flight skips silently.
  * - A manual run that starts while a scheduled tick is running throws so the
  *   user can decide how to react (retry, wait, surface the conflict).
  *
- * The mutex is deliberately module-scoped rather than tied to the handle
+ * The in-process flag is module-scoped rather than tied to the handle
  * returned by `startBackupWorker` — the daemon may start the worker once at
  * boot and also call `createSnapshotNow` from other code paths, and both must
  * see the same concurrency state.
+ *
+ * Beyond the in-process flag, both entry points also acquire a cross-process
+ * file lock at `getSnapshotLockPath()` so a CLI `vellum backup create` run
+ * cannot race the daemon's periodic tick — they would otherwise hold
+ * independent copies of this module-scoped flag. See `./snapshot-lock.ts`.
+ * The in-process flag stays as a fast path so same-process conflicts skip
+ * the filesystem entirely.
  */
 let snapshotInProgress = false;
 
@@ -281,6 +299,7 @@ export async function runBackupTick(
 
   const getCheckpoint = deps.getMemoryCheckpoint ?? realGetMemoryCheckpoint;
   const setCheckpoint = deps.setMemoryCheckpoint ?? realSetMemoryCheckpoint;
+  const lockPath = deps.snapshotLockPath ?? getSnapshotLockPath();
 
   const lastRunRaw = getCheckpoint(LAST_RUN_CHECKPOINT_KEY);
   if (lastRunRaw != null) {
@@ -293,15 +312,38 @@ export async function runBackupTick(
     }
   }
 
-  // A manual snapshot in flight wins — the scheduled tick silently defers
-  // and will reconsider on the next interval.
+  // A manual snapshot in flight inside this process wins — the scheduled
+  // tick silently defers and will reconsider on the next interval.
   if (snapshotInProgress) return null;
   snapshotInProgress = true;
+
+  // Acquire the cross-process lock after the in-process fast path passes.
+  // If another process (a CLI `vellum backup create`, say) holds the lock,
+  // the scheduled tick defers silently — same semantics as when the
+  // in-process flag is set — so a concurrent CLI run does not spam warning
+  // logs on every 5-minute tick.
+  let release: (() => Promise<void>) | null = null;
+  try {
+    release = await acquireSnapshotLock(lockPath);
+  } catch (err) {
+    snapshotInProgress = false;
+    const message = err instanceof Error ? err.message : String(err);
+    if (message.startsWith("snapshot in progress")) {
+      return null;
+    }
+    throw err;
+  }
+
   try {
     const result = await performBackup(config, now, deps);
     setCheckpoint(LAST_RUN_CHECKPOINT_KEY, String(now.getTime()));
     return result;
   } finally {
+    try {
+      await release();
+    } catch {
+      // release is best-effort; logged internally
+    }
     snapshotInProgress = false;
   }
 }
@@ -320,13 +362,38 @@ export async function createSnapshotNow(
   now: Date,
   deps: BackupDeps = {},
 ): Promise<BackupRunResult> {
+  const lockPath = deps.snapshotLockPath ?? getSnapshotLockPath();
+
+  // Fast path: in-process flag. Catches same-process races without touching
+  // the filesystem. The thrown message matches the cross-process variant's
+  // prefix so downstream consumers (HTTP 409, CLI error output) can test for
+  // "snapshot in progress" uniformly.
   if (snapshotInProgress) {
     throw new Error("snapshot in progress");
   }
   snapshotInProgress = true;
+
+  // Cross-process lock: the source of truth when a CLI invocation and the
+  // daemon worker could both be alive. On conflict, acquireSnapshotLock
+  // throws "snapshot in progress (locked by pid N)". We reset the
+  // in-process flag before rethrowing so subsequent local attempts aren't
+  // permanently blocked by a failed acquisition.
+  let release: (() => Promise<void>) | null = null;
+  try {
+    release = await acquireSnapshotLock(lockPath);
+  } catch (err) {
+    snapshotInProgress = false;
+    throw err;
+  }
+
   try {
     return await performBackup(config, now, deps);
   } finally {
+    try {
+      await release();
+    } catch {
+      // release is best-effort; logged internally
+    }
     snapshotInProgress = false;
   }
 }

--- a/assistant/src/backup/snapshot-lock.ts
+++ b/assistant/src/backup/snapshot-lock.ts
@@ -1,0 +1,222 @@
+/**
+ * Cross-process snapshot mutex.
+ *
+ * The backup worker's in-process `snapshotInProgress` flag only protects one
+ * process from racing itself. A CLI `vellum backup create` run against a live
+ * daemon has its own independent copy of the flag, so both processes could
+ * drive the pipeline concurrently: two WAL checkpoints against the live DB,
+ * two renames into the same `backup-YYYYMMDD-HHMMSS.vbundle` path (the second
+ * silently clobbering the first), and two retention-pruner passes racing.
+ *
+ * This module provides a small cross-process lock backed by an atomic
+ * `O_CREAT | O_EXCL` file create under `~/.vellum/backups/.snapshot.lock`.
+ * The in-process flag is kept as a fast path; this lock is the source of
+ * truth whenever two processes could collide.
+ *
+ * The implementation mirrors the pattern in `daemon/daemon-control.ts`'s
+ * startup lock, with two refinements:
+ *   1. The lock file contains the holder's PID so we can detect stale locks
+ *      by probing liveness with `kill(pid, 0)` rather than a fixed timeout.
+ *   2. Acquisition returns a release function so callers can wire it into
+ *      a `try/finally` without plumbing a separate release import.
+ */
+
+import {
+  closeSync,
+  constants as fsConstants,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  unlinkSync,
+  writeSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+import { kill } from "node:process";
+
+import { getLogger } from "../util/logger.js";
+import { getLocalBackupsDir } from "./paths.js";
+
+const log = getLogger("snapshot-lock");
+
+/**
+ * Returns the canonical path to the snapshot lock file. The lock lives one
+ * level above the local backups directory so it stays in place even when the
+ * backup pool is wiped or rotated — e.g. at `~/.vellum/backups/.snapshot.lock`.
+ *
+ * Placing it one level up (rather than inside the `local/` subdir) also
+ * guarantees that pruning never touches the lock file and that the lock
+ * survives custom `localDirectory` overrides, since we always use the default
+ * parent directory for cross-process coordination.
+ */
+export function getSnapshotLockPath(): string {
+  return join(dirname(getLocalBackupsDir()), ".snapshot.lock");
+}
+
+/**
+ * Check whether a PID refers to a live process. Uses `kill(pid, 0)`, which
+ * does not send any signal — it just probes for existence and permission.
+ *
+ * Returns `false` for obviously invalid PIDs (<= 0) and for any error that
+ * indicates the process is gone. Returns `true` for ESRCH-negative results
+ * (meaning a process exists) and for EPERM (process exists but is owned by
+ * another user — still a live process, still should not be taken over).
+ */
+function isProcessAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    kill(pid, 0);
+    return true;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    // EPERM means the PID exists but we cannot signal it — treat as alive so
+    // we don't accidentally take over another user's lock.
+    if (code === "EPERM") return true;
+    return false;
+  }
+}
+
+/**
+ * Try to atomically create the lock file with mode `0o600` and the current
+ * PID as its contents. Returns `true` on success, `false` if the file
+ * already exists (EEXIST), and rethrows any other error.
+ */
+function tryAtomicCreateLock(lockPath: string): boolean {
+  let fd: number | null = null;
+  try {
+    fd = openSync(
+      lockPath,
+      fsConstants.O_CREAT | fsConstants.O_EXCL | fsConstants.O_WRONLY,
+      0o600,
+    );
+    // Payload: `<pid> <timestamp>` so future callers can diagnose stale locks
+    // and so humans inspecting the file can tell how long it has been held.
+    const payload = `${process.pid} ${Date.now()}\n`;
+    writeSync(fd, payload);
+    return true;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "EEXIST") return false;
+    throw err;
+  } finally {
+    if (fd != null) {
+      try {
+        closeSync(fd);
+      } catch {
+        // best-effort
+      }
+    }
+  }
+}
+
+/**
+ * Parse the lock file and extract the holder PID. Returns `null` if the file
+ * is missing, empty, or does not contain a valid positive integer.
+ */
+function readLockHolderPid(lockPath: string): number | null {
+  try {
+    const raw = readFileSync(lockPath, "utf-8").trim();
+    if (raw.length === 0) return null;
+    // The payload is `<pid> <timestamp>`, but be lenient about formats: any
+    // leading positive integer is treated as the PID.
+    const match = /^\d+/.exec(raw);
+    if (!match) return null;
+    const pid = Number.parseInt(match[0], 10);
+    if (!Number.isFinite(pid) || pid <= 0) return null;
+    return pid;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Attempt to acquire the cross-process snapshot lock.
+ *
+ * On success, returns an idempotent release function that unlinks the lock
+ * file. Callers must invoke it in a `finally` block.
+ *
+ * On conflict with a live holder, throws an error whose message STARTS WITH
+ * "snapshot in progress" so existing consumers that match on that prefix
+ * (HTTP 409 mapping, CLI error output) continue to work without change.
+ *
+ * Stale lock handling: if the holder PID is dead (or unparseable), the lock
+ * file is removed and acquisition is retried exactly once. We do not loop
+ * indefinitely — a second EEXIST after stale cleanup means a legitimate
+ * concurrent caller raced us into the newly freed slot, and we report the
+ * conflict rather than sit-spinning.
+ *
+ * The lock directory is created on demand so first-run scenarios (no
+ * `~/.vellum/backups` yet) work without a separate bootstrap step.
+ */
+export async function acquireSnapshotLock(
+  lockPath: string,
+): Promise<() => Promise<void>> {
+  // Ensure the parent directory exists. `mkdirSync({ recursive: true })` is
+  // idempotent — it will not fail if the directory already exists.
+  mkdirSync(dirname(lockPath), { recursive: true, mode: 0o700 });
+
+  const tryAcquire = (): boolean => tryAtomicCreateLock(lockPath);
+
+  if (tryAcquire()) {
+    return makeRelease(lockPath);
+  }
+
+  // Lock already exists — probe the holder. If it's a dead PID or the file
+  // is unreadable, take it over and try once more.
+  const holderPid = readLockHolderPid(lockPath);
+  if (holderPid != null && isProcessAlive(holderPid)) {
+    throw new Error(
+      `snapshot in progress (locked by pid ${holderPid})`,
+    );
+  }
+
+  // Stale lock — the holder PID is dead or the file is corrupt. Remove it
+  // and retry once. Any error on unlink (e.g. another process raced us to
+  // clean it up) is ignored; the retry will discover the real state.
+  log.info(
+    { lockPath, holderPid },
+    "Taking over stale snapshot lock",
+  );
+  try {
+    unlinkSync(lockPath);
+  } catch {
+    // best-effort
+  }
+
+  if (tryAcquire()) {
+    return makeRelease(lockPath);
+  }
+
+  // Someone legitimately raced us into the cleaned slot. Report as a
+  // conflict so the caller can retry.
+  const racePid = readLockHolderPid(lockPath);
+  if (racePid != null) {
+    throw new Error(
+      `snapshot in progress (locked by pid ${racePid})`,
+    );
+  }
+  throw new Error("snapshot in progress (lock contended)");
+}
+
+/**
+ * Build an idempotent release function for an acquired lock file. Calling
+ * the returned function twice is safe — the second unlink catches ENOENT
+ * and returns without error.
+ */
+function makeRelease(lockPath: string): () => Promise<void> {
+  let released = false;
+  return async () => {
+    if (released) return;
+    released = true;
+    try {
+      unlinkSync(lockPath);
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== "ENOENT") {
+        log.warn(
+          { err, lockPath },
+          "Failed to release snapshot lock (best-effort)",
+        );
+      }
+    }
+  };
+}

--- a/assistant/src/runtime/routes/backup-routes.ts
+++ b/assistant/src/runtime/routes/backup-routes.ts
@@ -275,8 +275,10 @@ export async function handleBackupCreate(_req: Request): Promise<Response> {
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     // Map the mutex rejection to 409 so clients can distinguish "try again
-    // later" from a real failure.
-    if (message === "snapshot in progress") {
+    // later" from a real failure. Matches both the in-process variant
+    // (`"snapshot in progress"`) and the cross-process file-lock variant
+    // (`"snapshot in progress (locked by pid N)"`).
+    if (message.startsWith("snapshot in progress")) {
       return httpError("CONFLICT", "A snapshot is already in progress", 409);
     }
     log.error({ err }, "Manual backup snapshot failed");


### PR DESCRIPTION
## Summary
Fixes a gap identified during plan review: the backup worker's in-memory mutex (snapshotInProgress) only prevents concurrent snapshots within a single process. A CLI 'vellum backup create' run against a live daemon can race with the daemon's periodic tick because the two processes have independent copies of the flag.

Added a cross-process lock file at ~/.vellum/backups/.snapshot.lock with stale-PID takeover. In-process flag is kept as a fast path; cross-process lock is the source of truth.