### PR TITLE
fix(backup): restore integrity, credentials cleanup, list respects offsite.enabled

### DIFF
--- a/assistant/src/backup/__tests__/restore.test.ts
+++ b/assistant/src/backup/__tests__/restore.test.ts
@@ -2,8 +2,20 @@
  * Tests for restoreFromSnapshot and verifySnapshot.
  *
  * The destructive bits of restore (commitImport — overwrites files,
- * resets the DB, etc.) are stubbed via the `commitImpl` injection
- * parameter so these tests never touch the live workspace.
+ * clears the workspace, runs per-file backup-before-overwrite) are stubbed
+ * via the `commitImpl` injection parameter so these tests never touch the
+ * live workspace.
+ *
+ * Note: `commitImport` itself does NOT reset the SQLite singleton or
+ * invalidate caches — those are the caller's responsibility. The HTTP and
+ * CLI restore handlers wrap this module with the appropriate `resetDb()` /
+ * `invalidateConfigCache()` / `clearTrustCache()` calls; the tests for that
+ * recovery sequence live in `backup-routes.test.ts` and `backup.test.ts`.
+ *
+ * Credentials are intentionally excluded from backups, so `restoreFromSnapshot`
+ * has no credential-related surface area — bundles that happen to include
+ * `credentials/*` entries (e.g. from older migration exports) are ignored
+ * here and never surfaced to the caller.
  */
 
 import { randomBytes } from "node:crypto";
@@ -287,7 +299,6 @@ describe("restoreFromSnapshot", () => {
     // Public result is shaped correctly.
     expect(result.manifest.manifest_sha256).toBe(manifest.manifest_sha256);
     expect(result.restoredFiles).toBe(2);
-    expect(result.credentials).toEqual([]);
   });
 
   test("encrypted round-trip: decrypts then commits, and cleans up the temp file", async () => {
@@ -352,7 +363,10 @@ describe("restoreFromSnapshot", () => {
     expect(after.length).toBe(before.length);
   });
 
-  test("includeCredentials: surfaces credential entries to the caller", async () => {
+  test("credentials in a bundle are ignored and not surfaced to the caller", async () => {
+    // Older bundles (or a shared vbundle format) may include `credentials/*`
+    // entries. Backup restore explicitly drops them — credentials live in
+    // the OS keychain / CES and are not part of the backup round trip.
     const { archive, manifest } = buildVBundle({
       files: [
         {
@@ -363,10 +377,6 @@ describe("restoreFromSnapshot", () => {
           path: "credentials/openai_api_key",
           data: new TextEncoder().encode("sk-test-1234"),
         },
-        {
-          path: "credentials/anthropic_api_key",
-          data: new TextEncoder().encode("sk-ant-test-5678"),
-        },
       ],
     });
 
@@ -376,47 +386,13 @@ describe("restoreFromSnapshot", () => {
     const { commitImpl } = makeStubCommitImpl();
     const result = await restoreFromSnapshot(path, {
       pathResolver: NULL_RESOLVER,
-      includeCredentials: true,
       commitImpl,
     });
 
+    // The restore result must not expose a `credentials` field — the public
+    // type only has `manifest` and `restoredFiles`.
     expect(result.manifest.manifest_sha256).toBe(manifest.manifest_sha256);
-    // Credentials are extracted via extractCredentialsFromBundle, which
-    // returns one entry per credentials/* file. Order is not guaranteed,
-    // so we sort before comparing.
-    const sorted = [...result.credentials].sort((a, b) =>
-      a.account.localeCompare(b.account),
-    );
-    expect(sorted).toEqual([
-      { account: "anthropic_api_key", value: "sk-ant-test-5678" },
-      { account: "openai_api_key", value: "sk-test-1234" },
-    ]);
-  });
-
-  test("includeCredentials defaults to false", async () => {
-    const { archive } = buildVBundle({
-      files: [
-        {
-          path: "workspace/notes/hello.txt",
-          data: new TextEncoder().encode("hello"),
-        },
-        {
-          path: "credentials/secret_key",
-          data: new TextEncoder().encode("super-secret"),
-        },
-      ],
-    });
-
-    const path = join(TEST_DIR, "with-creds.vbundle");
-    writeFileSync(path, archive);
-
-    const { commitImpl } = makeStubCommitImpl();
-    const result = await restoreFromSnapshot(path, {
-      pathResolver: NULL_RESOLVER,
-      commitImpl,
-    });
-
-    expect(result.credentials).toEqual([]);
+    expect("credentials" in result).toBe(false);
   });
 
   test("validation failure: throws with the validation error message", async () => {

--- a/assistant/src/backup/restore.ts
+++ b/assistant/src/backup/restore.ts
@@ -17,9 +17,25 @@
  *
  * Restore is intentionally a thin wrapper around the existing
  * `commitImport` flow in `runtime/migrations/vbundle-importer.ts`. That
- * function owns the destructive bits (backup-before-overwrite, atomic
- * write semantics, post-write integrity checks). This module just adds
- * snapshot-format detection and decrypted-temp-file lifecycle management.
+ * function handles bundle validation, workspace clearing, per-file
+ * backup-before-overwrite, and writing files to disk.
+ *
+ * IMPORTANT: `commitImport` does NOT reset the live SQLite handle, invalidate
+ * cached config, or clear the trust cache. Callers are responsible for:
+ *   1. Calling `resetDb()` BEFORE invoking `restoreFromSnapshot` so the
+ *      running daemon's DB singleton is closed before the file is overwritten
+ *      (otherwise the daemon keeps a handle to the old inode and subsequent
+ *      writes can corrupt the restored state).
+ *   2. Calling `invalidateConfigCache()` and `clearTrustCache()` AFTER a
+ *      successful restore so the daemon re-reads the restored `config.json`
+ *      and `trust.json` instead of serving stale in-process caches.
+ *   3. Considering a daemon restart as the simplest, most reliable recovery
+ *      path — a CLI caller should refuse to restore against a live daemon
+ *      unless explicitly forced.
+ *
+ * Credentials are intentionally excluded from backups — they live in the OS
+ * keychain / CES and are not restored by this path. Users re-authenticate
+ * integrations after a restore.
  */
 
 import { randomUUID } from "node:crypto";
@@ -28,10 +44,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import type { PathResolver } from "../runtime/migrations/vbundle-import-analyzer.js";
-import {
-  commitImport,
-  extractCredentialsFromBundle,
-} from "../runtime/migrations/vbundle-importer.js";
+import { commitImport } from "../runtime/migrations/vbundle-importer.js";
 import type { ManifestType } from "../runtime/migrations/vbundle-validator.js";
 import { validateVBundle } from "../runtime/migrations/vbundle-validator.js";
 import { decryptFile } from "./stream-crypt.js";
@@ -51,12 +64,6 @@ export type CommitImpl = typeof commitImport;
 export interface RestoreOptions {
   /** AES-256 decryption key. Required for `.vbundle.enc` snapshots. */
   key?: Buffer;
-  /**
-   * Whether to extract credential entries from the bundle and return them
-   * to the caller. Defaults to `false` — credentials are handled by a
-   * separate import path and intentionally excluded from a normal restore.
-   */
-  includeCredentials?: boolean;
   /**
    * Resolver that maps archive paths (e.g. `workspace/config.json`) to
    * absolute disk paths. Required by the underlying `commitImport` flow.
@@ -80,11 +87,6 @@ export interface RestoreResult {
   manifest: ManifestType;
   /** Number of files written (or skipped) by the underlying commit. */
   restoredFiles: number;
-  /**
-   * Credential entries extracted from the bundle when
-   * `includeCredentials` was set. Empty array otherwise.
-   */
-  credentials: Array<{ account: string; value: string }>;
 }
 
 export interface VerifyOptions {
@@ -179,7 +181,6 @@ export async function restoreFromSnapshot(
 ): Promise<RestoreResult> {
   const {
     key,
-    includeCredentials = false,
     pathResolver,
     workspaceDir,
     commitImpl = commitImport,
@@ -201,13 +202,6 @@ export async function restoreFromSnapshot(
         .join("; ");
       throw new Error(`Snapshot failed validation: ${summary}`);
     }
-
-    // Extract credentials before commitImport runs — commitImport skips
-    // credential entries by design (they live behind the secure store API),
-    // so we read them out of the parsed entry map first.
-    const credentials = includeCredentials
-      ? extractCredentialsFromBundle(validation.entries, validation.manifest)
-      : [];
 
     const commitResult = commitImpl({
       archiveData: fileData,
@@ -238,7 +232,6 @@ export async function restoreFromSnapshot(
     return {
       manifest: commitResult.report.manifest,
       restoredFiles: commitResult.report.summary.total_files,
-      credentials,
     };
   } finally {
     await safeUnlink(tmpPath);

--- a/assistant/src/cli/commands/__tests__/backup.test.ts
+++ b/assistant/src/cli/commands/__tests__/backup.test.ts
@@ -75,7 +75,6 @@ let mockRestoreResult: {
     manifest_sha256: string;
   };
   restoredFiles: number;
-  credentials: Array<{ account: string; value: string }>;
 } = {
   manifest: {
     schema_version: "1.0.0",
@@ -85,7 +84,6 @@ let mockRestoreResult: {
     manifest_sha256: "abc",
   },
   restoredFiles: 42,
-  credentials: [],
 };
 
 /** Result returned by the stubbed `createSnapshotNow`. */
@@ -125,6 +123,17 @@ let mockCreateSnapshotResult: {
 /** Whether `createSnapshotNow` should throw concurrency error. */
 let mockCreateShouldThrow: Error | null = null;
 
+/** Whether the stubbed `isDaemonRunning` should report the assistant as alive. */
+let mockDaemonRunning = false;
+
+/** Sequence of recovery calls so tests can assert ordering. */
+const recoveryCallOrder: string[] = [];
+
+/** Number of times each recovery helper was invoked. */
+let mockResetDbCalls = 0;
+let mockInvalidateConfigCacheCalls = 0;
+let mockClearTrustCacheCalls = 0;
+
 /** Log calls captured by the mocked logger. */
 let mockLogInfo: string[] = [];
 let mockLogError: string[] = [];
@@ -158,6 +167,28 @@ mock.module("../../../config/loader.js", () => ({
   getConfig: () => ({
     backup: getComputedBackupConfig(),
   }),
+  invalidateConfigCache: () => {
+    mockInvalidateConfigCacheCalls += 1;
+    recoveryCallOrder.push("invalidateConfigCache");
+  },
+}));
+
+mock.module("../../../daemon/daemon-control.js", () => ({
+  isDaemonRunning: () => mockDaemonRunning,
+}));
+
+mock.module("../../../memory/db-connection.js", () => ({
+  resetDb: () => {
+    mockResetDbCalls += 1;
+    recoveryCallOrder.push("resetDb");
+  },
+}));
+
+mock.module("../../../permissions/trust-store.js", () => ({
+  clearCache: () => {
+    mockClearTrustCacheCalls += 1;
+    recoveryCallOrder.push("clearTrustCache");
+  },
 }));
 
 mock.module("../../../memory/checkpoints.js", () => ({
@@ -196,7 +227,10 @@ mock.module("../../../backup/backup-key.js", () => ({
 
 mock.module("../../../backup/restore.js", () => ({
   verifySnapshot: async () => mockVerifyResult,
-  restoreFromSnapshot: async () => mockRestoreResult,
+  restoreFromSnapshot: async () => {
+    recoveryCallOrder.push("restoreFromSnapshot");
+    return mockRestoreResult;
+  },
 }));
 
 mock.module("../../../backup/backup-worker.js", () => ({
@@ -311,6 +345,11 @@ beforeEach(() => {
   mockLogInfo = [];
   mockLogError = [];
   mockCreateShouldThrow = null;
+  mockDaemonRunning = false;
+  mockResetDbCalls = 0;
+  mockInvalidateConfigCacheCalls = 0;
+  mockClearTrustCacheCalls = 0;
+  recoveryCallOrder.length = 0;
   process.exitCode = 0;
   mockVerifyResult = { valid: true };
   mockRestoreResult = {
@@ -322,7 +361,6 @@ beforeEach(() => {
       manifest_sha256: "abc",
     },
     restoredFiles: 42,
-    credentials: [],
   };
   mockCreateSnapshotResult = {
     local: {
@@ -929,6 +967,78 @@ describe("handleRestore", () => {
     expect(mockLogInfo.some((m) => m.includes("newest.vbundle"))).toBe(
       true,
     );
+  });
+
+  test("refuses to run while the assistant is running (no --force)", async () => {
+    // Safety gate: the CLI must refuse to restore against a live assistant
+    // unless --force is passed. Restoring under a running assistant is
+    // dangerous — the open SQLite handle, cached config, and cached trust
+    // rules all contradict the on-disk state after the bundle is written.
+    mockDaemonRunning = true;
+
+    await handleRestore({
+      path: "/tmp/local/backup-20260411-093000.vbundle",
+      yes: true,
+    });
+
+    expect(process.exitCode).toBe(1);
+    expect(
+      mockLogError.some((m) =>
+        m.toLowerCase().includes("assistant is running"),
+      ),
+    ).toBe(true);
+    // restoreFromSnapshot must not have been called — the safety gate
+    // bails before reaching the recovery sequence.
+    expect(mockResetDbCalls).toBe(0);
+    expect(recoveryCallOrder).toEqual([]);
+  });
+
+  test("--force overrides the daemon-running refusal and still runs recovery sequence", async () => {
+    mockDaemonRunning = true;
+
+    await handleRestore({
+      path: "/tmp/local/backup-20260411-093000.vbundle",
+      yes: true,
+      force: true,
+    });
+
+    expect(process.exitCode).toBe(0);
+    // Recovery sequence must still run even with --force — the flag only
+    // overrides the running-assistant refusal, not the DB reset or cache
+    // invalidation.
+    expect(mockResetDbCalls).toBe(1);
+    expect(mockInvalidateConfigCacheCalls).toBe(1);
+    expect(mockClearTrustCacheCalls).toBe(1);
+    expect(recoveryCallOrder).toEqual([
+      "resetDb",
+      "restoreFromSnapshot",
+      "invalidateConfigCache",
+      "clearTrustCache",
+    ]);
+  });
+
+  test("successful restore runs resetDb, restore, then cache invalidation in order", async () => {
+    // Regression test for the restore-corrupts-daemon-state gap. The CLI
+    // handler must mirror the HTTP handler's recovery sequence so an
+    // in-process CLI invocation leaves the shared runtime in a consistent
+    // state.
+    mockDaemonRunning = false;
+
+    await handleRestore({
+      path: "/tmp/local/backup-20260411-093000.vbundle",
+      yes: true,
+    });
+
+    expect(process.exitCode).toBe(0);
+    expect(mockResetDbCalls).toBe(1);
+    expect(mockInvalidateConfigCacheCalls).toBe(1);
+    expect(mockClearTrustCacheCalls).toBe(1);
+    expect(recoveryCallOrder).toEqual([
+      "resetDb",
+      "restoreFromSnapshot",
+      "invalidateConfigCache",
+      "clearTrustCache",
+    ]);
   });
 });
 

--- a/assistant/src/cli/commands/backup.ts
+++ b/assistant/src/cli/commands/backup.ts
@@ -26,12 +26,16 @@ import {
 import { restoreFromSnapshot, verifySnapshot } from "../../backup/restore.js";
 import {
   getConfig,
+  invalidateConfigCache,
   loadRawConfig,
   saveRawConfig,
   setNestedValue,
 } from "../../config/loader.js";
 import type { BackupDestination } from "../../config/schema.js";
+import { isDaemonRunning } from "../../daemon/daemon-control.js";
 import { getMemoryCheckpoint } from "../../memory/checkpoints.js";
+import { resetDb } from "../../memory/db-connection.js";
+import { clearCache as clearTrustCache } from "../../permissions/trust-store.js";
 import { DefaultPathResolver } from "../../runtime/migrations/vbundle-import-analyzer.js";
 import {
   getWorkspaceDir,
@@ -523,6 +527,7 @@ export interface RestoreOptions {
   path?: string;
   latest?: boolean;
   yes?: boolean;
+  force?: boolean;
 }
 
 export async function handleRestore(opts: RestoreOptions): Promise<void> {
@@ -537,6 +542,20 @@ export async function handleRestore(opts: RestoreOptions): Promise<void> {
   if (opts.path && opts.latest) {
     log.error(
       "Cannot combine --path and --latest. Drop one.",
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  // Safety gate: a restore while the assistant is running is dangerous.
+  // The assistant holds an open SQLite handle (referencing the old inode on
+  // Unix), a cached config, and cached trust rules. Overwriting the files
+  // under a running process corrupts state. Refuse unless `--force` says the
+  // caller knows what they're doing.
+  if (!opts.force && isDaemonRunning()) {
+    log.error(
+      "Assistant is running — stop it first with 'vellum sleep' before restoring " +
+        "(safe restore requires an idle assistant). Pass --force to override.",
     );
     process.exitCode = 1;
     return;
@@ -586,11 +605,26 @@ export async function handleRestore(opts: RestoreOptions): Promise<void> {
     const workspaceDir = getWorkspaceDir();
     const hooksDir = getWorkspaceHooksDir();
     const pathResolver = new DefaultPathResolver(workspaceDir, hooksDir);
+
+    // Close the SQLite singleton before the bundle is written. If the
+    // assistant process was running in-process (tests, `--force`) the
+    // singleton may still reference the old file; resetting closes the
+    // handle so the restored DB file is picked up cleanly on the next
+    // getDb() call.
+    resetDb();
+
     const result = await restoreFromSnapshot(snapshotPath, {
       key,
       pathResolver,
       workspaceDir,
     });
+
+    // Invalidate in-process caches so the restored settings.json and
+    // trust.json take effect (matches the HTTP handler's recovery sequence
+    // and the migration importer).
+    invalidateConfigCache();
+    clearTrustCache();
+
     log.info(`Restored from ${snapshotPath}`);
     log.info(`  source: ${result.manifest.source ?? "unknown"}`);
     log.info(`  schema_version: ${result.manifest.schema_version}`);
@@ -653,10 +687,12 @@ export function registerBackupCommand(program: Command): void {
     "after",
     `
 Backups capture a snapshot of the assistant workspace (config, conversations,
-trust rules, hooks, the SQLite database, and optionally credentials) as a
-.vbundle file. The automated worker runs on a configurable interval and writes
-to a local pool under ~/.vellum/backups/local/, optionally mirroring each
-snapshot to one or more offsite destinations (iCloud Drive by default).
+trust rules, hooks, the SQLite database) as a .vbundle file. Credentials are
+NOT included — they live in the OS keychain / CES and users re-authenticate
+integrations after a restore. The automated worker runs on a configurable
+interval and writes to a local pool under ~/.vellum/backups/local/, optionally
+mirroring each snapshot to one or more offsite destinations (iCloud Drive by
+default).
 
 Offsite destinations can be per-destination encrypted (AES-256-GCM) or
 plaintext — plaintext only makes sense when the user owns physical access to
@@ -904,6 +940,10 @@ Examples:
       "Restore the newest local snapshot (offsite files are not considered)",
     )
     .option("--yes", "Skip the confirmation prompt")
+    .option(
+      "--force",
+      "Restore even when the assistant is running (unsafe — only use if you know what you're doing)",
+    )
     .addHelpText(
       "after",
       `
@@ -916,6 +956,11 @@ Prompts for confirmation unless --yes is passed.
 --latest selects the newest local snapshot only. Offsite files may not exist
 on a new machine after a workspace migration, so --latest refuses to dig into
 them on purpose.
+
+Safety: refuses to run while the assistant is running, because the live
+SQLite handle and cached config/trust rules can corrupt the restored state.
+Stop the assistant first with 'vellum sleep'. Pass --force to override (only
+use this if you understand the risk).
 
 Examples:
   $ vellum backup restore --latest --yes

--- a/assistant/src/runtime/routes/__tests__/backup-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/backup-routes.test.ts
@@ -46,12 +46,30 @@ mock.module("../../../util/logger.js", () => ({
     }),
 }));
 
+// -- listSnapshotsInDir spy ------------------------------------------------
+// Wraps the real implementation so tests can assert on which directories
+// were enumerated. Needed to verify handleBackupList skips offsite
+// enumeration when backup.offsite.enabled is false.
+
+const listSnapshotsCallLog: string[] = [];
+const { listSnapshotsInDir: realListSnapshotsInDir } = await import(
+  "../../../backup/list-snapshots.js"
+);
+mock.module("../../../backup/list-snapshots.js", () => ({
+  listSnapshotsInDir: async (dir: string) => {
+    listSnapshotsCallLog.push(dir);
+    return realListSnapshotsInDir(dir);
+  },
+}));
+
 // -- Config mock -----------------------------------------------------------
 // Built in `beforeEach` from BackupConfigSchema defaults, with overrides
 // applied per test via `setMockBackupConfig`.
 
 let mockBackupConfig: BackupConfig = BackupConfigSchema.parse({});
 let mockWorkspaceDir = "/tmp/mock-workspace-unused";
+
+let mockInvalidateConfigCacheCalls = 0;
 
 mock.module("../../../config/loader.js", () => ({
   getConfig: () => ({
@@ -60,6 +78,34 @@ mock.module("../../../config/loader.js", () => ({
     // the full AssistantConfig. Cast through `unknown` so the partial shape is
     // accepted without pulling in the full config schema.
   }),
+  invalidateConfigCache: () => {
+    mockInvalidateConfigCacheCalls += 1;
+    recoveryCallOrder.push("invalidateConfigCache");
+  },
+}));
+
+// -- DB + trust-cache mocks ------------------------------------------------
+// handleBackupRestore must call `resetDb()` BEFORE `restoreFromSnapshot` and
+// `invalidateConfigCache()` + `clearTrustCache()` AFTER (matching the
+// migration importer). Tests record the call sequence via
+// `recoveryCallOrder` and assert on the relative ordering.
+
+let mockResetDbCalls = 0;
+let mockClearTrustCacheCalls = 0;
+const recoveryCallOrder: string[] = [];
+
+mock.module("../../../memory/db-connection.js", () => ({
+  resetDb: () => {
+    mockResetDbCalls += 1;
+    recoveryCallOrder.push("resetDb");
+  },
+}));
+
+mock.module("../../../permissions/trust-store.js", () => ({
+  clearCache: () => {
+    mockClearTrustCacheCalls += 1;
+    recoveryCallOrder.push("clearTrustCache");
+  },
 }));
 
 // -- Platform paths mock ---------------------------------------------------
@@ -129,7 +175,6 @@ mock.module("../../../backup/backup-worker.js", () => ({
 interface RestoreCall {
   path: string;
   hasKey: boolean;
-  includeCredentials: boolean | undefined;
   workspaceDir: string | undefined;
 }
 interface VerifyCall {
@@ -147,7 +192,6 @@ let mockRestoreResult: RestoreResult = {
     manifest_sha256: "0".repeat(64),
   } as unknown as RestoreResult["manifest"],
   restoredFiles: 0,
-  credentials: [],
 };
 let mockRestoreError: Error | null = null;
 let mockVerifyResult: VerifyResult = { valid: true };
@@ -157,14 +201,13 @@ mock.module("../../../backup/restore.js", () => ({
     path: string,
     opts: {
       key?: Buffer;
-      includeCredentials?: boolean;
       workspaceDir?: string;
     },
   ) => {
+    recoveryCallOrder.push("restoreFromSnapshot");
     lastRestoreArgs = {
       path,
       hasKey: opts.key != null,
-      includeCredentials: opts.includeCredentials,
       workspaceDir: opts.workspaceDir,
     };
     if (mockRestoreError) throw mockRestoreError;
@@ -250,9 +293,13 @@ beforeEach(() => {
       manifest_sha256: "0".repeat(64),
     } as unknown as RestoreResult["manifest"],
     restoredFiles: 0,
-    credentials: [],
   };
   mockVerifyResult = { valid: true };
+  mockResetDbCalls = 0;
+  mockInvalidateConfigCacheCalls = 0;
+  mockClearTrustCacheCalls = 0;
+  recoveryCallOrder.length = 0;
+  listSnapshotsCallLog.length = 0;
 });
 
 afterEach(() => {
@@ -422,6 +469,57 @@ describe("handleBackupList", () => {
     const res = await handleBackupList(new Request("http://localhost/v1/backups"));
     const body = (await res.json()) as { nextRunAt: string | null };
     expect(body.nextRunAt).toBeNull();
+  });
+
+  test("offsite.enabled=false returns offsite:[] and offsiteEnabled:false without probing destinations", async () => {
+    // Regression test: when the user disables offsite backups, the HTTP
+    // handler must mirror the worker's behavior and return an empty offsite
+    // list without enumerating any destinations. Previously the handler
+    // would still probe each configured destination, causing the macOS UI
+    // to render offsite cards even after offsite was turned off.
+    //
+    // Even with destinations present in config, `offsite.enabled=false`
+    // should short-circuit the enumeration loop.
+    const configuredDestDir = join(ROOT, "offsite-still-configured");
+    mkdirSync(configuredDestDir, { recursive: true });
+    mockBackupConfig = makeConfig({
+      localDirectory: LOCAL_DIR,
+      offsite: {
+        enabled: false,
+        destinations: [
+          { path: configuredDestDir, encrypt: true },
+        ],
+      },
+    });
+
+    const res = await handleBackupList(
+      new Request("http://localhost/v1/backups"),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      local: SnapshotEntry[];
+      offsite: unknown[];
+      offsiteEnabled: boolean;
+    };
+    expect(body.offsite).toEqual([]);
+    expect(body.offsiteEnabled).toBe(false);
+    // listSnapshotsInDir should only have been called for the local dir —
+    // never for any offsite destination.
+    expect(listSnapshotsCallLog).toEqual([LOCAL_DIR]);
+  });
+
+  test("offsite.enabled=true returns offsiteEnabled:true", async () => {
+    mockBackupConfig = makeConfig({
+      localDirectory: LOCAL_DIR,
+      offsite: { enabled: true, destinations: [] },
+    });
+
+    const res = await handleBackupList(
+      new Request("http://localhost/v1/backups"),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { offsiteEnabled: boolean };
+    expect(body.offsiteEnabled).toBe(true);
   });
 });
 
@@ -629,7 +727,13 @@ describe("handleBackupRestore", () => {
     expect(lastRestoreArgs).toBeNull();
   });
 
-  test("includeCredentials flag is forwarded to restoreFromSnapshot", async () => {
+  test("successful restore runs the full recovery sequence in order", async () => {
+    // Regression test for the restore-corrupts-daemon-state gap:
+    // handleBackupRestore must call resetDb() BEFORE restoreFromSnapshot
+    // (so the live SQLite handle is closed before the file is overwritten)
+    // and invalidateConfigCache() + clearTrustCache() AFTER (so the daemon
+    // re-reads the restored config/trust rules). The migration importer
+    // already does this — the backup handler must match.
     const snapshotPath = writeBackupFile(
       LOCAL_DIR,
       "backup-20260411-100000.vbundle",
@@ -640,10 +744,67 @@ describe("handleBackupRestore", () => {
     });
 
     const res = await handleBackupRestore(
-      jsonRequest("POST", { path: snapshotPath, includeCredentials: true }),
+      jsonRequest("POST", { path: snapshotPath }),
     );
     expect(res.status).toBe(200);
-    expect(lastRestoreArgs!.includeCredentials).toBe(true);
+    expect(mockResetDbCalls).toBe(1);
+    expect(mockInvalidateConfigCacheCalls).toBe(1);
+    expect(mockClearTrustCacheCalls).toBe(1);
+    expect(recoveryCallOrder).toEqual([
+      "resetDb",
+      "restoreFromSnapshot",
+      "invalidateConfigCache",
+      "clearTrustCache",
+    ]);
+  });
+
+  test("restore failure still closes the DB singleton before throwing", async () => {
+    // Even on failure, resetDb must have been called — we don't want the
+    // daemon to keep writing through an open handle to a file that's been
+    // partially overwritten by a failed commit.
+    const snapshotPath = writeBackupFile(
+      LOCAL_DIR,
+      "backup-20260411-100000.vbundle",
+    );
+    mockBackupConfig = makeConfig({
+      localDirectory: LOCAL_DIR,
+      offsite: { enabled: true, destinations: [] },
+    });
+    mockRestoreError = new Error("simulated restore failure");
+
+    const res = await handleBackupRestore(
+      jsonRequest("POST", { path: snapshotPath }),
+    );
+    expect(res.status).toBe(500);
+    expect(mockResetDbCalls).toBe(1);
+    // Caches should NOT be invalidated on failure — the in-process caches
+    // still reflect the pre-restore state on disk (the bundle write failed
+    // so there's nothing new to re-read).
+    expect(mockInvalidateConfigCacheCalls).toBe(0);
+    expect(mockClearTrustCacheCalls).toBe(0);
+  });
+
+  test("response no longer exposes credentialsIncluded", async () => {
+    // The dead credentials plumbing has been removed from the backup surface.
+    // Credentials intentionally live in the OS keychain / CES and are not
+    // part of the backup round trip.
+    const snapshotPath = writeBackupFile(
+      LOCAL_DIR,
+      "backup-20260411-100000.vbundle",
+    );
+    mockBackupConfig = makeConfig({
+      localDirectory: LOCAL_DIR,
+      offsite: { enabled: true, destinations: [] },
+    });
+
+    const res = await handleBackupRestore(
+      jsonRequest("POST", { path: snapshotPath }),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect("credentialsIncluded" in body).toBe(false);
+    expect(body.manifest).toBeDefined();
+    expect(body.restoredFiles).toBeDefined();
   });
 
   test("missing path field returns 400", async () => {

--- a/assistant/src/runtime/routes/backup-routes.ts
+++ b/assistant/src/runtime/routes/backup-routes.ts
@@ -41,9 +41,11 @@ import {
   resolveOffsiteDestinations,
 } from "../../backup/paths.js";
 import { restoreFromSnapshot, verifySnapshot } from "../../backup/restore.js";
-import { getConfig } from "../../config/loader.js";
+import { getConfig, invalidateConfigCache } from "../../config/loader.js";
 import type { BackupDestination } from "../../config/schema.js";
 import { getMemoryCheckpoint } from "../../memory/checkpoints.js";
+import { resetDb } from "../../memory/db-connection.js";
+import { clearCache as clearTrustCache } from "../../permissions/trust-store.js";
 import { getLogger } from "../../util/logger.js";
 import {
   getWorkspaceDir,
@@ -187,6 +189,11 @@ async function loadKeyIfEncrypted(
 /**
  * Shape returned by {@link handleBackupList}. Exported so client code (and
  * the test suite) can type the JSON response without re-deriving it.
+ *
+ * `offsiteEnabled` distinguishes "offsite disabled" (user turned it off — the
+ * UI should hide or gray out offsite cards) from "offsite enabled but no
+ * destinations configured" (the `offsite` array is empty but the UI should
+ * still prompt the user to add one).
  */
 export interface BackupListResponse {
   local: SnapshotEntry[];
@@ -195,6 +202,7 @@ export interface BackupListResponse {
     snapshots: SnapshotEntry[];
     reachable: boolean;
   }>;
+  offsiteEnabled: boolean;
   nextRunAt: string | null;
 }
 
@@ -204,6 +212,12 @@ export interface BackupListResponse {
  * reflects whether `dirname(destination.path)` exists on disk right now (the
  * same probe the offsite writer uses), so clients can distinguish "empty
  * destination" from "unavailable destination" without a second round trip.
+ *
+ * When `backup.offsite.enabled` is `false`, the offsite array is returned
+ * empty without probing any destinations — mirroring the worker's runtime
+ * logic so the UI never renders offsite cards after the user has disabled
+ * offsite backups. Clients should gate offsite UI on `offsiteEnabled` rather
+ * than `offsite.length`.
  */
 export async function handleBackupList(_req: Request): Promise<Response> {
   try {
@@ -211,21 +225,24 @@ export async function handleBackupList(_req: Request): Promise<Response> {
     const localDir = getLocalBackupsDir(config.backup.localDirectory);
     const local = await listSnapshotsInDir(localDir);
 
+    const offsiteEnabled = config.backup.offsite.enabled;
     const offsite: BackupListResponse["offsite"] = [];
-    for (const destination of resolveOffsiteDestinations(
-      config.backup.offsite.destinations,
-    )) {
-      let reachable = false;
-      try {
-        await fs.stat(dirname(destination.path));
-        reachable = true;
-      } catch {
-        reachable = false;
+    if (offsiteEnabled) {
+      for (const destination of resolveOffsiteDestinations(
+        config.backup.offsite.destinations,
+      )) {
+        let reachable = false;
+        try {
+          await fs.stat(dirname(destination.path));
+          reachable = true;
+        } catch {
+          reachable = false;
+        }
+        const snapshots = reachable
+          ? await listSnapshotsInDir(destination.path)
+          : [];
+        offsite.push({ destination, snapshots, reachable });
       }
-      const snapshots = reachable
-        ? await listSnapshotsInDir(destination.path)
-        : [];
-      offsite.push({ destination, snapshots, reachable });
     }
 
     let nextRunAt: string | null = null;
@@ -240,7 +257,12 @@ export async function handleBackupList(_req: Request): Promise<Response> {
       }
     }
 
-    const body: BackupListResponse = { local, offsite, nextRunAt };
+    const body: BackupListResponse = {
+      local,
+      offsite,
+      offsiteEnabled,
+      nextRunAt,
+    };
     return Response.json(body);
   } catch (err) {
     log.error({ err }, "Failed to list backups");
@@ -290,7 +312,6 @@ export async function handleBackupCreate(_req: Request): Promise<Response> {
 
 interface RestoreRequestBody {
   path: unknown;
-  includeCredentials?: unknown;
 }
 
 /**
@@ -298,9 +319,18 @@ interface RestoreRequestBody {
  * `commitImport` flow backs up existing files before overwriting, but callers
  * should still treat this as an irreversible "replace the workspace" operation.
  *
- * `includeCredentials` defaults to `false`; when true, credential entries from
- * the bundle are returned to the caller alongside the manifest summary so they
- * can be re-persisted via the separate credential-import path.
+ * Recovery sequence (mirroring `handleMigrationImport`):
+ *   1. `resetDb()` is called BEFORE the restore so the live SQLite singleton
+ *      closes its handle before `assistant.db` is overwritten. Without this,
+ *      the daemon would keep a reference to the old inode and subsequent
+ *      writes could silently corrupt the restored state.
+ *   2. `invalidateConfigCache()` and `clearTrustCache()` are called AFTER a
+ *      successful restore so the daemon re-reads the restored `config.json`
+ *      and `trust.json` from disk instead of serving stale in-process caches.
+ *
+ * Credentials are intentionally excluded from backups — they live in the OS
+ * keychain / CES and are not restored by this path. Users re-authenticate
+ * integrations after a restore.
  */
 export async function handleBackupRestore(req: Request): Promise<Response> {
   let body: RestoreRequestBody;
@@ -326,17 +356,25 @@ export async function handleBackupRestore(req: Request): Promise<Response> {
       getWorkspaceDir(),
       getWorkspaceHooksDir(),
     );
+
+    // Close the live SQLite connection before overwriting assistant.db on disk.
+    // The singleton will be lazily reopened on the next getDb() call.
+    resetDb();
+
     const result = await restoreFromSnapshot(snapshotPath, {
       key: keyResult.key ?? undefined,
-      includeCredentials: body.includeCredentials === true,
       pathResolver,
       workspaceDir: getWorkspaceDir(),
     });
 
+    // Invalidate in-process caches so the restored settings.json and trust.json
+    // take effect without requiring a daemon restart.
+    invalidateConfigCache();
+    clearTrustCache();
+
     return Response.json({
       manifest: result.manifest,
       restoredFiles: result.restoredFiles,
-      credentialsIncluded: result.credentials.length,
     });
   } catch (err) {
     log.error({ err, snapshotPath }, "Snapshot restore failed");
@@ -407,7 +445,7 @@ export function backupRouteDefinitions(): RouteDefinition[] {
       method: "GET",
       summary: "List backup snapshots",
       description:
-        "Lists local and offsite backup snapshots. Each offsite destination includes a `reachable` flag reflecting whether the backing volume is currently available.",
+        "Lists local and offsite backup snapshots. Each offsite destination includes a `reachable` flag reflecting whether the backing volume is currently available. When `backup.offsite.enabled` is false the `offsite` array is empty and `offsiteEnabled` is false — clients should gate offsite UI on `offsiteEnabled` rather than `offsite.length`.",
       tags: ["backups"],
       responseBody: z.object({
         local: z.array(z.unknown()),
@@ -418,6 +456,7 @@ export function backupRouteDefinitions(): RouteDefinition[] {
             reachable: z.boolean(),
           }),
         ),
+        offsiteEnabled: z.boolean(),
         nextRunAt: z.string().nullable(),
       }),
       handler: async ({ req }) => handleBackupList(req),
@@ -441,23 +480,16 @@ export function backupRouteDefinitions(): RouteDefinition[] {
       method: "POST",
       summary: "Restore from a backup snapshot",
       description:
-        "Restores a snapshot into the workspace. Destructive: the underlying commit flow backs up existing files before overwriting.",
+        "Restores a snapshot into the workspace. Destructive: the underlying commit flow backs up existing files before overwriting. The daemon closes the live SQLite handle before writing and invalidates its config/trust caches afterwards. Credentials are NOT included — users re-authenticate integrations after a restore.",
       tags: ["backups"],
       requestBody: z.object({
         path: z
           .string()
           .describe("Absolute path to the snapshot file to restore"),
-        includeCredentials: z
-          .boolean()
-          .optional()
-          .describe(
-            "Whether to extract credential entries from the bundle (default false)",
-          ),
       }),
       responseBody: z.object({
         manifest: z.object({}).passthrough(),
         restoredFiles: z.number(),
-        credentialsIncluded: z.number(),
       }),
       handler: async ({ req }) => handleBackupRestore(req),
     },

--- a/clients/macos/vellum-assistant/Features/Settings/AssistantBackupsSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantBackupsSection.swift
@@ -34,6 +34,7 @@ struct AssistantBackupsSection: View {
     @State private var autoBackupsIntervalHours: Int = 6
     @State private var localSnapshots: [AutoBackupEntry] = []
     @State private var offsiteGroups: [OffsiteGroup] = []
+    @State private var offsiteEnabled: Bool = true
     @State private var nextRunAt: Date? = nil
     @State private var isLoadingAutoBackups: Bool = false
     @State private var showingManageDestinationsSheet: Bool = false
@@ -190,15 +191,21 @@ struct AssistantBackupsSection: View {
                     localSnapshotsCard
                 }
 
-                ForEach(offsiteGroups) { group in
-                    offsiteGroupCard(group)
-                }
-
-                HStack {
-                    VButton(label: "Manage destinations…", style: .outlined) {
-                        showingManageDestinationsSheet = true
+                if offsiteEnabled {
+                    ForEach(offsiteGroups) { group in
+                        offsiteGroupCard(group)
                     }
-                    Spacer()
+
+                    HStack {
+                        VButton(label: "Manage destinations…", style: .outlined) {
+                            showingManageDestinationsSheet = true
+                        }
+                        Spacer()
+                    }
+                } else {
+                    Text("Offsite backups are disabled.")
+                        .font(VFont.labelDefault)
+                        .foregroundStyle(VColor.contentTertiary)
                 }
             }
         }
@@ -679,6 +686,7 @@ struct AssistantBackupsSection: View {
 
             localSnapshots = decoded.local
             offsiteGroups = decoded.offsite
+            offsiteEnabled = decoded.offsiteEnabled
             nextRunAt = decoded.nextRunAt
 
             // Pull `backup.enabled` / `backup.intervalHours` from the daemon
@@ -944,10 +952,34 @@ struct BackupDestinationDTO: Decodable, Equatable, Identifiable {
 
 /// Shape of the `GET /v1/backups` response, decoded with an ISO8601 strategy
 /// so `createdAt` and `nextRunAt` arrive as `Date` values.
+///
+/// `offsiteEnabled` distinguishes "offsite disabled" (user turned it off — UI
+/// should hide offsite cards) from "offsite enabled but no destinations
+/// configured" (`offsite` is empty but the UI should prompt to add one).
+/// Older daemons that predate this field default `offsiteEnabled` to `true`
+/// on decode so the UI keeps rendering offsite cards the way it used to.
 struct BackupListResponseDTO: Decodable {
     let local: [AutoBackupEntry]
     let offsite: [OffsiteGroup]
+    let offsiteEnabled: Bool
     let nextRunAt: Date?
+
+    private enum CodingKeys: String, CodingKey {
+        case local
+        case offsite
+        case offsiteEnabled
+        case nextRunAt
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        local = try container.decode([AutoBackupEntry].self, forKey: .local)
+        offsite = try container.decode([OffsiteGroup].self, forKey: .offsite)
+        // Default to `true` for pre-offsiteEnabled daemons so the UI keeps
+        // rendering offsite cards instead of silently hiding them.
+        offsiteEnabled = try container.decodeIfPresent(Bool.self, forKey: .offsiteEnabled) ?? true
+        nextRunAt = try container.decodeIfPresent(Date.self, forKey: .nextRunAt)
+    }
 }
 
 // MARK: - Manage Destinations Sheet


### PR DESCRIPTION
## Summary
Fixes three gaps identified during self-review of the backup-restore-system plan:

1. **Restore corrupts daemon state** — handleBackupRestore and CLI handleRestore now call resetDb() before commitImport and invalidateConfigCache() + clearTrustCache() after, matching handleMigrationImport. CLI also refuses to run against a live daemon without --force.
2. **Dead credentials plumbing** — the plan explicitly excludes credentials from backups, but the code had an includeCredentials field that was never wired on the export side. Removed all dead plumbing.
3. **offsite.enabled ignored** — handleBackupList now returns offsite: [] when offsite is disabled, mirroring the worker's behavior. Added offsiteEnabled flag to the response.

Plus: fixed stale docstrings in restore.ts/restore.test.ts that had misled callers into thinking commitImport handled DB reset.