### PR TITLE
feat(assistant): add daily SQLite VACUUM and PRAGMA optimize

### DIFF
--- a/assistant/src/daemon/shutdown-handlers.ts
+++ b/assistant/src/daemon/shutdown-handlers.ts
@@ -126,9 +126,15 @@ export function installShutdownHandlers(deps: ShutdownDeps): void {
 
     await deps.getQdrantManager()?.stop();
 
-    // Checkpoint WAL and close SQLite so no writes are lost on exit.
-    // Checkpoint and close are in separate try blocks so that close()
-    // always runs even if checkpointing throws (e.g. SQLITE_BUSY).
+    // Optimize query planner statistics before closing so they persist for
+    // the next session. Checkpoint WAL and close SQLite so no writes are
+    // lost on exit. Each step is in its own try block so later steps still
+    // run if an earlier one throws (e.g. SQLITE_BUSY).
+    try {
+      getSqlite().exec("PRAGMA optimize");
+    } catch (err) {
+      log.warn({ err }, "PRAGMA optimize at shutdown failed (non-fatal)");
+    }
     try {
       getSqlite().exec("PRAGMA wal_checkpoint(TRUNCATE)");
     } catch (err) {

--- a/assistant/src/memory/db-maintenance.ts
+++ b/assistant/src/memory/db-maintenance.ts
@@ -1,0 +1,108 @@
+import { statSync } from "node:fs";
+
+import { getLogger } from "../util/logger.js";
+import { getDbPath } from "../util/platform.js";
+import { getMemoryCheckpoint, setMemoryCheckpoint } from "./checkpoints.js";
+import { getSqlite } from "./db-connection.js";
+
+const log = getLogger("db-maintenance");
+
+const DB_MAINTENANCE_CHECKPOINT_KEY = "db_maintenance:last_run";
+const DB_MAINTENANCE_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+interface DbStats {
+  pageSizeBytes: number;
+  pageCount: number;
+  freelistCount: number;
+  fileSizeBytes: number | null;
+}
+
+function getDbStats(): DbStats {
+  const sqlite = getSqlite();
+  const pageSizeBytes = (
+    sqlite.query("PRAGMA page_size").get() as { page_size: number }
+  ).page_size;
+  const pageCount = (
+    sqlite.query("PRAGMA page_count").get() as { page_count: number }
+  ).page_count;
+  const freelistCount = (
+    sqlite.query("PRAGMA freelist_count").get() as { freelist_count: number }
+  ).freelist_count;
+  let fileSizeBytes: number | null = null;
+  try {
+    fileSizeBytes = statSync(getDbPath()).size;
+  } catch {
+    /* non-fatal */
+  }
+  return { pageSizeBytes, pageCount, freelistCount, fileSizeBytes };
+}
+
+export function runDbMaintenance(): void {
+  const before = getDbStats();
+  const freelistPct =
+    before.pageCount > 0
+      ? ((before.freelistCount / before.pageCount) * 100).toFixed(1)
+      : "0";
+
+  log.info(
+    {
+      pageCount: before.pageCount,
+      freelistCount: before.freelistCount,
+      freelistPct,
+      fileSizeBytes: before.fileSizeBytes,
+    },
+    "Starting database maintenance",
+  );
+
+  try {
+    getSqlite().exec("VACUUM");
+  } catch (err) {
+    log.warn({ err }, "VACUUM failed (non-fatal)");
+    try {
+      getSqlite().exec("PRAGMA optimize");
+    } catch (optErr) {
+      log.warn({ err: optErr }, "PRAGMA optimize failed (non-fatal)");
+    }
+    return;
+  }
+
+  try {
+    getSqlite().exec("PRAGMA optimize");
+  } catch (err) {
+    log.warn({ err }, "PRAGMA optimize failed (non-fatal)");
+  }
+
+  const after = getDbStats();
+  const reclaimedPages = before.pageCount - after.pageCount;
+  const reclaimedBytes =
+    before.fileSizeBytes != null && after.fileSizeBytes != null
+      ? before.fileSizeBytes - after.fileSizeBytes
+      : null;
+
+  log.info(
+    {
+      beforePageCount: before.pageCount,
+      afterPageCount: after.pageCount,
+      reclaimedPages,
+      reclaimedBytes,
+      afterFileSizeBytes: after.fileSizeBytes,
+    },
+    "Database maintenance complete",
+  );
+}
+
+export function maybeRunDbMaintenance(nowMs = Date.now()): void {
+  const lastRun = parseInt(
+    getMemoryCheckpoint(DB_MAINTENANCE_CHECKPOINT_KEY) ?? "0",
+    10,
+  );
+  if (nowMs - lastRun < DB_MAINTENANCE_INTERVAL_MS) return;
+
+  try {
+    runDbMaintenance();
+  } catch (err) {
+    log.error({ err }, "Database maintenance failed unexpectedly");
+  }
+  // Always set checkpoint — even on failure — to avoid retry-hammering every tick.
+  setMemoryCheckpoint(DB_MAINTENANCE_CHECKPOINT_KEY, String(nowMs));
+}

--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -6,6 +6,7 @@ export {
   resetDb,
 } from "./db-connection.js";
 export { initializeDb } from "./db-init.js";
+export { maybeRunDbMaintenance, runDbMaintenance } from "./db-maintenance.js";
 export {
   rawAll,
   rawAllFrom,

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -2,6 +2,7 @@ import { getConfig } from "../config/loader.js";
 import type { AssistantConfig } from "../config/types.js";
 import { getLogger } from "../util/logger.js";
 import { getMemoryCheckpoint, setMemoryCheckpoint } from "./checkpoints.js";
+import { maybeRunDbMaintenance } from "./db-maintenance.js";
 import {
   getLastScheduledCleanupEnqueueMs,
   markScheduledCleanupEnqueued,
@@ -165,6 +166,7 @@ export async function runMemoryJobsOnce(
       maybeEnqueueScheduledCleanupJobs(config);
     }
     maybeEnqueueGraphMaintenanceJobs();
+    maybeRunDbMaintenance();
     return 0;
   }
 
@@ -261,6 +263,7 @@ export async function runMemoryJobsOnce(
     maybeEnqueueScheduledCleanupJobs(config);
   }
   maybeEnqueueGraphMaintenanceJobs();
+  maybeRunDbMaintenance();
   return processed;
 }
 


### PR DESCRIPTION
## Summary
- Add `db-maintenance.ts` with checkpoint-gated daily VACUUM + PRAGMA optimize, logging before/after stats (page counts, freelist, file size, reclaimed bytes)
- Wire into the memory-jobs worker tick loop (same pattern as graph maintenance)
- Add PRAGMA optimize at shutdown before WAL checkpoint

## Original prompt
Add periodic VACUUM to prevent DB bloat — affects all users