### PR TITLE
fix(auth): downgrade migrations/validate scope from settings.write to settings.read

### DIFF
--- a/assistant/src/__tests__/migration-export-http.test.ts
+++ b/assistant/src/__tests__/migration-export-http.test.ts
@@ -508,7 +508,7 @@ describe("route policy registration", () => {
     const policy = getPolicy("migrations/validate");
 
     expect(policy).toBeDefined();
-    expect(policy?.requiredScopes).toContain("settings.write");
+    expect(policy?.requiredScopes).toContain("settings.read");
   });
 });
 
@@ -531,15 +531,15 @@ describe("auth policy shape", () => {
     expect(policy!.allowedPrincipalTypes).toHaveLength(4);
   });
 
-  test("export policy matches validate policy shape", async () => {
+  test("export policy differs from validate policy on scopes (validate is read-only)", async () => {
     const { getPolicy } = await import("../runtime/auth/route-policy.js");
     const exportPolicy = getPolicy("migrations/export");
     const validatePolicy = getPolicy("migrations/validate");
 
-    // Both migration endpoints should have the same auth requirements
-    expect(exportPolicy!.requiredScopes).toEqual(
-      validatePolicy!.requiredScopes,
-    );
+    // validate is read-only so requires settings.read; export requires settings.write
+    expect(exportPolicy!.requiredScopes).toEqual(["settings.write"]);
+    expect(validatePolicy!.requiredScopes).toEqual(["settings.read"]);
+    // Both share the same principal types
     expect(exportPolicy!.allowedPrincipalTypes).toEqual(
       validatePolicy!.allowedPrincipalTypes,
     );

--- a/assistant/src/__tests__/migration-import-commit-http.test.ts
+++ b/assistant/src/__tests__/migration-import-commit-http.test.ts
@@ -988,22 +988,24 @@ describe("route policy registration", () => {
     expect(policy?.allowedPrincipalTypes).toContain("local");
   });
 
-  test("import policy matches other migration endpoint policies", async () => {
+  test("import policy matches export/preflight but differs from validate on scopes", async () => {
     const { getPolicy } = await import("../runtime/auth/route-policy.js");
     const importPolicy = getPolicy("migrations/import");
     const validatePolicy = getPolicy("migrations/validate");
     const exportPolicy = getPolicy("migrations/export");
     const preflightPolicy = getPolicy("migrations/import-preflight");
 
-    expect(importPolicy!.requiredScopes).toEqual(
-      validatePolicy!.requiredScopes,
-    );
-    expect(importPolicy!.allowedPrincipalTypes).toEqual(
-      validatePolicy!.allowedPrincipalTypes,
-    );
+    // import, export, and preflight all require settings.write
     expect(importPolicy!.requiredScopes).toEqual(exportPolicy!.requiredScopes);
     expect(importPolicy!.requiredScopes).toEqual(
       preflightPolicy!.requiredScopes,
+    );
+    expect(importPolicy!.requiredScopes).toEqual(["settings.write"]);
+    // validate is read-only so requires settings.read
+    expect(validatePolicy!.requiredScopes).toEqual(["settings.read"]);
+    // all share the same principal types
+    expect(importPolicy!.allowedPrincipalTypes).toEqual(
+      validatePolicy!.allowedPrincipalTypes,
     );
   });
 });

--- a/assistant/src/__tests__/migration-import-preflight-http.test.ts
+++ b/assistant/src/__tests__/migration-import-preflight-http.test.ts
@@ -720,20 +720,21 @@ describe("route policy registration", () => {
     expect(policy?.allowedPrincipalTypes).toContain("local");
   });
 
-  test("import-preflight policy matches validate/export policy shape", async () => {
+  test("import-preflight policy matches export but differs from validate on scopes", async () => {
     const { getPolicy } = await import("../runtime/auth/route-policy.js");
     const preflightPolicy = getPolicy("migrations/import-preflight");
     const validatePolicy = getPolicy("migrations/validate");
     const exportPolicy = getPolicy("migrations/export");
 
-    expect(preflightPolicy!.requiredScopes).toEqual(
-      validatePolicy!.requiredScopes,
-    );
-    expect(preflightPolicy!.allowedPrincipalTypes).toEqual(
-      validatePolicy!.allowedPrincipalTypes,
-    );
+    // preflight and export both require settings.write
     expect(preflightPolicy!.requiredScopes).toEqual(
       exportPolicy!.requiredScopes,
+    );
+    // validate is read-only so requires settings.read
+    expect(validatePolicy!.requiredScopes).toEqual(["settings.read"]);
+    // all share the same principal types
+    expect(preflightPolicy!.allowedPrincipalTypes).toEqual(
+      validatePolicy!.allowedPrincipalTypes,
     );
   });
 });

--- a/assistant/src/__tests__/migration-validate-http.test.ts
+++ b/assistant/src/__tests__/migration-validate-http.test.ts
@@ -638,13 +638,13 @@ describe("handleMigrationValidate", () => {
 // ---------------------------------------------------------------------------
 
 describe("route policy registration", () => {
-  test("migrations/validate policy requires settings.write scope", async () => {
+  test("migrations/validate policy requires settings.read scope", async () => {
     // Import route-policy to verify the registration exists
     const { getPolicy } = await import("../runtime/auth/route-policy.js");
     const policy = getPolicy("migrations/validate");
 
     expect(policy).toBeDefined();
-    expect(policy?.requiredScopes).toContain("settings.write");
+    expect(policy?.requiredScopes).toContain("settings.read");
     expect(policy?.allowedPrincipalTypes).toContain("actor");
     expect(policy?.allowedPrincipalTypes).toContain("svc_gateway");
     expect(policy?.allowedPrincipalTypes).toContain("local");

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -433,7 +433,7 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: "channels/delivery-ack", scopes: ["internal.write"] },
 
   // Migrations
-  { endpoint: "migrations/validate", scopes: ["settings.write"] },
+  { endpoint: "migrations/validate", scopes: ["settings.read"] },
   { endpoint: "migrations/export", scopes: ["settings.write"] },
   { endpoint: "migrations/import-preflight", scopes: ["settings.write"] },
   { endpoint: "migrations/import", scopes: ["settings.write"] },


### PR DESCRIPTION
## Summary
- Downgrade migrations/validate route scope from settings.write to settings.read to match its read-only behavior
- Update test assertions across 4 test files to expect settings.read scope for validate
- Aligns with backups/verify which already uses settings.read

Part of plan: validate-scope-fix.md (PR 1 of 1)