### PR TITLE
feat(backup): use VELLUM_BACKUP_DIR override in paths.ts and snapshot-lock.ts

### DIFF
--- a/assistant/src/backup/__tests__/paths.test.ts
+++ b/assistant/src/backup/__tests__/paths.test.ts
@@ -1,13 +1,15 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 
 import {
   formatBackupFilename,
   getBackupKeyPath,
+  getBackupRootDir,
   getDefaultOffsiteBackupsDir,
   getLocalBackupsDir,
   parseBackupTimestamp,
   resolveOffsiteDestinations,
 } from "../paths.js";
+import { getSnapshotLockPath } from "../snapshot-lock.js";
 
 describe("getLocalBackupsDir", () => {
   test("returns a path containing /backups/local when no override is given", () => {
@@ -22,6 +24,60 @@ describe("getLocalBackupsDir", () => {
   test("treats null override as absent", () => {
     const dir = getLocalBackupsDir(null);
     expect(dir).toContain("/backups/local");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// VELLUM_BACKUP_DIR env var override
+// ---------------------------------------------------------------------------
+
+describe("VELLUM_BACKUP_DIR override", () => {
+  const ORIGINAL = process.env.VELLUM_BACKUP_DIR;
+
+  afterEach(() => {
+    if (ORIGINAL === undefined) {
+      delete process.env.VELLUM_BACKUP_DIR;
+    } else {
+      process.env.VELLUM_BACKUP_DIR = ORIGINAL;
+    }
+  });
+
+  test("getBackupRootDir() uses VELLUM_BACKUP_DIR when set", () => {
+    process.env.VELLUM_BACKUP_DIR = "/workspace/.backups";
+    expect(getBackupRootDir()).toBe("/workspace/.backups");
+  });
+
+  test("getBackupRootDir() falls back to ~/.vellum/backups when unset", () => {
+    delete process.env.VELLUM_BACKUP_DIR;
+    const dir = getBackupRootDir();
+    expect(dir).toMatch(/\/\.vellum\/backups$/);
+  });
+
+  test("getLocalBackupsDir() resolves under VELLUM_BACKUP_DIR", () => {
+    process.env.VELLUM_BACKUP_DIR = "/workspace/.backups";
+    expect(getLocalBackupsDir()).toBe("/workspace/.backups/local");
+  });
+
+  test("getLocalBackupsDir() falls back to default when env var is unset", () => {
+    delete process.env.VELLUM_BACKUP_DIR;
+    expect(getLocalBackupsDir()).toMatch(/\/\.vellum\/backups\/local$/);
+  });
+
+  test("config override still takes precedence over VELLUM_BACKUP_DIR", () => {
+    process.env.VELLUM_BACKUP_DIR = "/workspace/.backups";
+    expect(getLocalBackupsDir("/custom/dir")).toBe("/custom/dir");
+  });
+
+  test("getSnapshotLockPath() resolves under VELLUM_BACKUP_DIR", () => {
+    process.env.VELLUM_BACKUP_DIR = "/workspace/.backups";
+    expect(getSnapshotLockPath()).toBe("/workspace/.backups/.snapshot.lock");
+  });
+
+  test("getSnapshotLockPath() falls back to default when env var is unset", () => {
+    delete process.env.VELLUM_BACKUP_DIR;
+    expect(getSnapshotLockPath()).toMatch(
+      /\/\.vellum\/backups\/\.snapshot\.lock$/,
+    );
   });
 });
 

--- a/assistant/src/backup/paths.ts
+++ b/assistant/src/backup/paths.ts
@@ -1,6 +1,7 @@
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 
+import { getBackupDirOverride } from "../config/env-registry.js";
 import type { BackupDestination } from "../config/schema.js";
 import { getProtectedDir } from "../util/platform.js";
 
@@ -16,12 +17,21 @@ function vellumRootFromProtected(): string {
 }
 
 /**
+ * Returns the backup root directory. Respects the `VELLUM_BACKUP_DIR`
+ * environment variable override (used in containerized deployments where
+ * backups must be on a persistent volume); falls back to `~/.vellum/backups`.
+ */
+export function getBackupRootDir(): string {
+  return getBackupDirOverride() ?? join(vellumRootFromProtected(), "backups");
+}
+
+/**
  * Returns the directory for local (on-device) backups. By default this lives
  * under `~/.vellum/backups/local`; callers can pass an explicit override from
  * config to place backups elsewhere on disk.
  */
 export function getLocalBackupsDir(override?: string | null): string {
-  return override ?? join(vellumRootFromProtected(), "backups", "local");
+  return override ?? join(getBackupRootDir(), "local");
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add `getBackupRootDir()` helper that respects `VELLUM_BACKUP_DIR` env var
- Update `getLocalBackupsDir()` to use the new helper for path resolution
- Snapshot lock path automatically picks up the override via `getLocalBackupsDir()`
- Add tests for env var override behavior

Part of plan: docker-backup-paths.md (PR 3 of 7)