### PR TITLE
fix: update stale settings.write comment to settings.read in migration-validate-http.test.ts

### DIFF
--- a/assistant/src/__tests__/migration-validate-http.test.ts
+++ b/assistant/src/__tests__/migration-validate-http.test.ts
@@ -5,7 +5,7 @@
  * - Success: valid .vbundle archive returns is_valid: true with manifest
  * - Validation failures: invalid gzip, missing entries, bad manifest, checksum mismatches
  * - Request errors: empty body, invalid multipart
- * - Auth: route policy enforcement (settings.write scope required)
+ * - Auth: route policy enforcement (settings.read scope required)
  * - Integration: existing routes are unaffected by the new endpoint
  */
 import { createHash } from "node:crypto";


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for validate-scope-fix.md.

**Gap:** Stale file header comment in migration-validate-http.test.ts
**What was expected:** All references to settings.write for the validate endpoint should be updated to settings.read
**What was found:** Line 8 still said settings.write in the doc comment