### PR TITLE
feat(macos): add FilePreviewExpansionStore for inline file preview cards

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/FilePreviewExpansionStore.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/FilePreviewExpansionStore.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+/// Persists the expand/collapse state of file preview cards across view
+/// destruction and recreation. Lifting the state into this store, owned at the
+/// `MessageListView` level (above the wrapper), lets expansion survive
+/// tree changes that would destroy `@State` in descendant views.
+///
+/// Only accessed from SwiftUI view bodies, which are implicitly
+/// main-actor-isolated, so the mutations are safe in practice. The class
+/// is not annotated `@MainActor` because `EnvironmentKey.defaultValue`
+/// is a nonisolated protocol requirement and main-actor-isolated default
+/// values violate Swift 6 isolation checking.
+@Observable
+final class FilePreviewExpansionStore: @unchecked Sendable {
+    private var expandedKeys: Set<String> = []
+
+    func isExpanded(_ key: String) -> Bool {
+        expandedKeys.contains(key)
+    }
+
+    func toggle(_ key: String) {
+        if expandedKeys.contains(key) {
+            expandedKeys.remove(key)
+        } else {
+            expandedKeys.insert(key)
+        }
+    }
+}
+
+private struct FilePreviewExpansionStoreKey: EnvironmentKey {
+    static let defaultValue = FilePreviewExpansionStore()
+}
+
+extension EnvironmentValues {
+    var filePreviewExpansionStore: FilePreviewExpansionStore {
+        get { self[FilePreviewExpansionStoreKey.self] }
+        set { self[FilePreviewExpansionStoreKey.self] = newValue }
+    }
+}


### PR DESCRIPTION
## Summary
- Add FilePreviewExpansionStore mirroring ThinkingBlockExpansionStore pattern
- Provides environment-injected expansion state for inline file preview cards
- Expansion state survives view-tree destruction via @Observable + EnvironmentKey

Part of plan: inline-file-preview.md (PR 1 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24917" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
