### PR TITLE
feat(macos): replace file chips with inline preview cards in chat

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -746,7 +746,15 @@ struct ChatBubble: View, Equatable {
                 if !partitioned.files.isEmpty {
                     VStack(alignment: .leading, spacing: VSpacing.xs) {
                         ForEach(partitioned.files) { attachment in
-                            fileAttachmentChip(attachment)
+                            if attachment.isTextPreviewable {
+                                InlineFilePreviewView(
+                                    attachment: attachment,
+                                    isUser: isUser,
+                                    messageId: message.id
+                                )
+                            } else {
+                                fileAttachmentChip(attachment)
+                            }
                         }
                     }
                 }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
@@ -440,7 +440,15 @@ extension ChatBubble {
                 lazyAttachmentId: attachment.data.isEmpty && !attachment.id.isEmpty ? attachment.id : nil
             )
         }) { attachment in
-            fileAttachmentChip(attachment)
+            if attachment.isTextPreviewable {
+                InlineFilePreviewView(
+                    attachment: attachment,
+                    isUser: isUser,
+                    messageId: message.id
+                )
+            } else {
+                fileAttachmentChip(attachment)
+            }
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
@@ -508,7 +508,15 @@ extension ChatBubble {
         if !partitioned.files.isEmpty {
             VStack(alignment: .leading, spacing: VSpacing.xs) {
                 ForEach(partitioned.files) { attachment in
-                    fileAttachmentChip(attachment)
+                    if attachment.isTextPreviewable {
+                        InlineFilePreviewView(
+                            attachment: attachment,
+                            isUser: isUser,
+                            messageId: message.id
+                        )
+                    } else {
+                        fileAttachmentChip(attachment)
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Replace fileAttachmentChip with InlineFilePreviewView for text-previewable files
- Wire into ChatBubble, ChatBubbleInterleavedContent, and ChatBubbleAttachmentContent
- Non-text files (PDF, ZIP, images) continue using the existing chip

Part of plan: inline-file-preview.md (PR 4 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24920" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
