### PR TITLE
fix(macos): inject FilePreviewExpansionStore at MessageListView level

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -115,6 +115,10 @@ struct MessageListView: View {
     /// destruction that happens when `state.isActiveTurn` flips at the
     /// start/end of an active turn. See `ThinkingBlockExpansionStore.swift`.
     @State var thinkingBlockExpansionStore = ThinkingBlockExpansionStore()
+    /// Tracks expand/collapse state for file preview cards in this list.
+    /// Owned here (same level as `thinkingBlockExpansionStore`) so the state
+    /// survives view-tree destruction. See `FilePreviewExpansionStore.swift`.
+    @State var filePreviewExpansionStore = FilePreviewExpansionStore()
 
     // MARK: - Body
 
@@ -157,6 +161,7 @@ struct MessageListView: View {
             .defaultScrollAnchor(.bottom, for: .initialOffset)
             .scrollPosition($scrollPosition)
             .environment(\.thinkingBlockExpansionStore, thinkingBlockExpansionStore)
+            .environment(\.filePreviewExpansionStore, filePreviewExpansionStore)
             .environment(\.suppressAutoScroll, { [self] in
                 os_signpost(.event, log: PerfSignposts.log, name: "scrollSuppressionChanged", "on reason=manualExpansionDetach")
                 let intents = scrollCoordinator.handle(.manualExpansion)


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for inline-file-preview.md.

**Gap:** FilePreviewExpansionStore not injected at MessageListView level
**What was expected:** Store should be scoped per-conversation via explicit environment injection
**What was found:** Store fell through to process-wide static singleton
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24921" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
