### PR TITLE
fix(macos): use local timezone in LLM Context Inspector timestamps

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageInspectorSummaryFormatters.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageInspectorSummaryFormatters.swift
@@ -162,9 +162,18 @@ enum MessageInspectorSummaryFormatters {
         return "\(visible) +\(cleanedNames.count - maxVisible) more"
     }
 
+    private static let createdAtFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = .autoupdatingCurrent
+        f.dateStyle = .medium
+        f.timeStyle = .medium
+        return f
+    }()
+
     static func formattedCreatedAt(_ epochMs: Int) -> String {
-        Date(timeIntervalSince1970: TimeInterval(epochMs) / 1000.0)
-            .formatted(date: .abbreviated, time: .standard)
+        let date = Date(timeIntervalSince1970: TimeInterval(epochMs) / 1000.0)
+        createdAtFormatter.timeZone = ChatTimestampTimeZone.resolve()
+        return createdAtFormatter.string(from: date)
     }
 
     static func isProviderOnlySummary(_ summary: LLMCallSummary) -> Bool {

--- a/clients/macos/vellum-assistant/Features/Chat/MessageInspectorView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageInspectorView.swift
@@ -555,14 +555,32 @@ struct MessageInspectorView: View {
         .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
     }
 
+    private static let timeOnlyFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = .autoupdatingCurrent
+        f.dateStyle = .none
+        f.timeStyle = .medium
+        return f
+    }()
+
+    private static let dateTimeFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = .autoupdatingCurrent
+        f.dateStyle = .medium
+        f.timeStyle = .medium
+        return f
+    }()
+
     private func formattedTimestamp(_ epochMs: Int) -> String {
-        Date(timeIntervalSince1970: TimeInterval(epochMs) / 1000.0)
-            .formatted(date: .omitted, time: .standard)
+        let date = Date(timeIntervalSince1970: TimeInterval(epochMs) / 1000.0)
+        Self.timeOnlyFormatter.timeZone = ChatTimestampTimeZone.resolve()
+        return Self.timeOnlyFormatter.string(from: date)
     }
 
     private func formattedDateTime(_ epochMs: Int) -> String {
-        Date(timeIntervalSince1970: TimeInterval(epochMs) / 1000.0)
-            .formatted(date: .abbreviated, time: .standard)
+        let date = Date(timeIntervalSince1970: TimeInterval(epochMs) / 1000.0)
+        Self.dateTimeFormatter.timeZone = ChatTimestampTimeZone.resolve()
+        return Self.dateTimeFormatter.string(from: date)
     }
 }
 


### PR DESCRIPTION
## Summary
- LLM Context Inspector timestamps were showing UTC instead of the user's local timezone
- Switched from `Date.formatted(date:time:)` to `DateFormatter` with explicit `ChatTimestampTimeZone.resolve()`, matching the established pattern used by chat dividers, bubble overflow menus, and memory detail sheets
- Affects both the sidebar call list timestamps and the detail panel header

## Original prompt
These timestamps should be in the user's timezone, not UTC