### PR TITLE
fix(macos): stabilize thinking block expansion key during streaming

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
@@ -410,7 +410,7 @@ extension ChatBubble {
                     .filter { !$0.isEmpty }
                     .joined(separator: "\n")
                 if !joined.isEmpty {
-                    textBubble(for: joined)
+                    textBubble(for: joined, textGroupIndex: indices.first ?? 0)
                 }
                 // Render deferred tool call images from the preceding tool group,
                 // so descriptive text appears before the screenshot it introduces.

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
@@ -15,11 +15,16 @@ extension ChatBubble {
     /// the transformation entirely at the presentation layer — no changes to
     /// the message data model or streaming pipeline.
     @ViewBuilder
-    func textBubble(for segmentText: String) -> some View {
+    func textBubble(for segmentText: String, textGroupIndex: Int? = nil) -> some View {
         if !isUser,
            containsInlineThinkingTag(segmentText),
            MacOSClientFeatureFlagManager.shared.isEnabled("show-thinking-blocks") {
             let chunks = parseInlineThinkingTags(segmentText)
+            // Use a stable key prefix that doesn't change as segmentText grows
+            // during streaming. The previous hash-based key caused thinking
+            // blocks to collapse on every text flush because hashValue changed.
+            let keyPrefix = textGroupIndex.map { "\(message.id.uuidString)-txt\($0)" }
+                ?? "\(message.id.uuidString)-txt\(segmentText.hashValue)"
             VStack(alignment: .leading, spacing: VSpacing.sm) {
                 ForEach(Array(chunks.enumerated()), id: \.offset) { offset, chunk in
                     switch chunk {
@@ -32,7 +37,7 @@ extension ChatBubble {
                         ThinkingBlockView(
                             content: body,
                             isStreaming: message.isStreaming,
-                            expansionKey: "\(message.id.uuidString)-txt\(segmentText.hashValue)-\(offset)",
+                            expansionKey: "\(keyPrefix)-\(offset)",
                             typographyGeneration: typographyGeneration
                         )
                     }


### PR DESCRIPTION
## Summary
- The expansion key for inline `<thinking>` blocks in `textBubble(for:)` included `segmentText.hashValue`, which changed on every streaming text flush (~100ms), causing the `ThinkingBlockExpansionStore` lookup to fail and the block to collapse repeatedly
- Replace the hash-based key with a stable `textGroupIndex` parameter passed from the interleaved content caller, using the text group's first segment index which is constant during streaming

## Original prompt
it