### PR TITLE
fix: deduplicate update bulletin content blocks across version bumps

### DIFF
--- a/assistant/src/__tests__/update-bulletin-format.test.ts
+++ b/assistant/src/__tests__/update-bulletin-format.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import {
   appendReleaseBlock,
   extractReleaseIds,
+  filterNewContentBlocks,
   hasReleaseBlock,
   releaseMarker,
 } from "../prompts/update-bulletin-format.js";
@@ -80,6 +81,64 @@ describe("appendReleaseBlock", () => {
 
     // Double newline separates the blocks when there was no trailing newline
     expect(result).toContain("First.\n\n<!-- vellum-update-release:1.1.0 -->");
+  });
+});
+
+describe("filterNewContentBlocks", () => {
+  const blockA = [
+    "<!-- vellum-update-release:entry-a -->",
+    "## Entry A",
+    "Content for A.",
+    "<!-- /vellum-update-release:entry-a -->",
+  ].join("\n");
+
+  const blockB = [
+    "<!-- vellum-update-release:entry-b -->",
+    "## Entry B",
+    "Content for B.",
+    "<!-- /vellum-update-release:entry-b -->",
+  ].join("\n");
+
+  const blockC = [
+    "<!-- vellum-update-release:entry-c -->",
+    "## Entry C",
+    "Content for C.",
+    "<!-- /vellum-update-release:entry-c -->",
+  ].join("\n");
+
+  test("returns body unchanged when no block structure exists", () => {
+    const body = "## What's New\n\nPlain text notes.\n";
+    expect(filterNewContentBlocks(body, "anything")).toBe(body);
+  });
+
+  test("returns all blocks when none are present in existing content", () => {
+    const body = `${blockA}\n\n${blockB}`;
+    const result = filterNewContentBlocks(body, "no markers here");
+    expect(result).toContain("entry-a");
+    expect(result).toContain("entry-b");
+  });
+
+  test("returns empty string when all blocks are already present", () => {
+    const body = `${blockA}\n\n${blockB}`;
+    const existing = `<!-- vellum-update-release:0.9.0 -->\n${blockA}\n\n${blockB}\n`;
+    expect(filterNewContentBlocks(body, existing)).toBe("");
+  });
+
+  test("returns only new blocks when some are already present", () => {
+    const body = `${blockA}\n\n${blockB}\n\n${blockC}`;
+    const existing = `<!-- vellum-update-release:0.9.0 -->\n${blockA}\n\n${blockB}\n`;
+
+    const result = filterNewContentBlocks(body, existing);
+    expect(result).toContain("entry-c");
+    expect(result).toContain("Content for C.");
+    expect(result).not.toContain("entry-a");
+    expect(result).not.toContain("entry-b");
+  });
+
+  test("handles single-block template", () => {
+    const result = filterNewContentBlocks(blockA, "no markers");
+    expect(result).toContain("entry-a");
+    expect(result).toContain("Content for A.");
   });
 });
 

--- a/assistant/src/__tests__/update-bulletin.test.ts
+++ b/assistant/src/__tests__/update-bulletin.test.ts
@@ -239,6 +239,109 @@ describe("syncUpdateBulletinOnStartup", () => {
     expect(existsSync(workspacePath)).toBe(false);
   });
 
+  it("only appends new content blocks on version bump with extended template", () => {
+    // Workspace already has entries A and B from a prior release
+    const oldContent = [
+      "<!-- vellum-update-release:0.9.0 -->",
+      "<!-- vellum-update-release:entry-a -->",
+      "## Entry A",
+      "Content for A.",
+      "<!-- /vellum-update-release:entry-a -->",
+      "",
+      "<!-- vellum-update-release:entry-b -->",
+      "## Entry B",
+      "Content for B.",
+      "<!-- /vellum-update-release:entry-b -->",
+      "",
+    ].join("\n");
+    writeFileSync(workspacePath, oldContent, "utf-8");
+
+    // Template now has A, B, C — C is the only new entry
+    const extendedTemplate = [
+      "<!-- vellum-update-release:entry-a -->",
+      "## Entry A",
+      "Content for A.",
+      "<!-- /vellum-update-release:entry-a -->",
+      "",
+      "<!-- vellum-update-release:entry-b -->",
+      "## Entry B",
+      "Content for B.",
+      "<!-- /vellum-update-release:entry-b -->",
+      "",
+      "<!-- vellum-update-release:entry-c -->",
+      "## Entry C",
+      "New content for C.",
+      "<!-- /vellum-update-release:entry-c -->",
+      "",
+    ].join("\n");
+    writeFileSync(
+      join(tempTemplateDir, "UPDATES.md"),
+      extendedTemplate,
+      "utf-8",
+    );
+
+    syncUpdateBulletinOnStartup();
+
+    const content = readFileSync(workspacePath, "utf-8");
+
+    // New release block should be present
+    expect(content).toContain("<!-- vellum-update-release:1.0.0 -->");
+
+    // Entry C should appear
+    expect(content).toContain("entry-c");
+    expect(content).toContain("New content for C.");
+
+    // Entries A and B should NOT be duplicated
+    const countA = (
+      content.match(/<!-- vellum-update-release:entry-a -->/g) || []
+    ).length;
+    const countB = (
+      content.match(/<!-- vellum-update-release:entry-b -->/g) || []
+    ).length;
+    expect(countA).toBe(1);
+    expect(countB).toBe(1);
+  });
+
+  it("skips append when all template content blocks already exist in workspace", () => {
+    // Workspace already has entries A and B from a prior release
+    const oldContent = [
+      "<!-- vellum-update-release:0.9.0 -->",
+      "<!-- vellum-update-release:entry-a -->",
+      "## Entry A",
+      "<!-- /vellum-update-release:entry-a -->",
+      "",
+      "<!-- vellum-update-release:entry-b -->",
+      "## Entry B",
+      "<!-- /vellum-update-release:entry-b -->",
+      "",
+    ].join("\n");
+    writeFileSync(workspacePath, oldContent, "utf-8");
+
+    // Template has the same A and B — nothing new
+    const sameTemplate = [
+      "<!-- vellum-update-release:entry-a -->",
+      "## Entry A",
+      "<!-- /vellum-update-release:entry-a -->",
+      "",
+      "<!-- vellum-update-release:entry-b -->",
+      "## Entry B",
+      "<!-- /vellum-update-release:entry-b -->",
+      "",
+    ].join("\n");
+    writeFileSync(
+      join(tempTemplateDir, "UPDATES.md"),
+      sameTemplate,
+      "utf-8",
+    );
+
+    syncUpdateBulletinOnStartup();
+
+    const content = readFileSync(workspacePath, "utf-8");
+
+    // No 1.0.0 block should be added — all content already present
+    expect(content).not.toContain("<!-- vellum-update-release:1.0.0 -->");
+  });
+
   it("preserves existing file when atomic write fails", () => {
     const originalContent =
       "<!-- vellum-update-release:0.9.0 -->\nOriginal content.\n";

--- a/assistant/src/prompts/update-bulletin-format.ts
+++ b/assistant/src/prompts/update-bulletin-format.ts
@@ -42,18 +42,35 @@ export function appendReleaseBlock(
 }
 
 /**
- * Extracts content-level markers (non-version feature markers) from the
- * template body. These are markers like `schedule-reminder-unification`
- * that identify the _content_ rather than the release version.
+ * Filters template content to only include content blocks whose opening
+ * markers are not already present in the existing workspace content.
+ *
+ * Each content block is delimited by opening/closing marker pairs:
+ *   <!-- vellum-update-release:id --> ... <!-- /vellum-update-release:id -->
+ *
+ * If the template has no block structure (no matched open/close pairs),
+ * returns the original body unchanged for backward compatibility.
+ * Returns empty string when all blocks are already present.
  */
-export function extractContentMarkers(body: string): string[] {
-  const ids: string[] = [];
-  const regex = /<!-- vellum-update-release:(.+?) -->/g;
+export function filterNewContentBlocks(
+  body: string,
+  existing: string,
+): string {
+  const blockRegex =
+    /(<!-- vellum-update-release:(.+?) -->[\s\S]*?<!-- \/vellum-update-release:\2 -->)/g;
+  const blocks: Array<{ full: string; id: string }> = [];
   let match: RegExpExecArray | null;
-  while ((match = regex.exec(body)) !== null) {
-    ids.push(match[1]);
+  while ((match = blockRegex.exec(body)) !== null) {
+    blocks.push({ full: match[1], id: match[2] });
   }
-  return ids;
+
+  if (blocks.length === 0) return body;
+
+  const newBlocks = blocks.filter((b) => !hasReleaseBlock(existing, b.id));
+
+  if (newBlocks.length === 0) return "";
+
+  return newBlocks.map((b) => b.full).join("\n\n");
 }
 
 /** Extracts all version strings from release markers found in `content`. */

--- a/assistant/src/prompts/update-bulletin.ts
+++ b/assistant/src/prompts/update-bulletin.ts
@@ -13,9 +13,8 @@ import { stripCommentLines } from "../util/strip-comment-lines.js";
 import { APP_VERSION } from "../version.js";
 import {
   appendReleaseBlock,
-  extractContentMarkers,
+  filterNewContentBlocks,
   hasReleaseBlock,
-  releaseMarker,
 } from "./update-bulletin-format.js";
 import {
   addActiveRelease,
@@ -105,19 +104,15 @@ export function syncUpdateBulletinOnStartup(): void {
   } else {
     const existing = readFileSync(workspacePath, "utf-8");
     if (!hasReleaseBlock(existing, currentReleaseId)) {
-      // Guard: skip if the template's content markers already exist in the
-      // workspace file. This prevents the same update notes from being
-      // appended on every version bump when the template isn't cleared.
-      const contentMarkers = extractContentMarkers(templateContent);
-      const allContentAlreadyPresent =
-        contentMarkers.length > 0 &&
-        contentMarkers.every((m) => existing.includes(releaseMarker(m)));
-
-      if (!allContentAlreadyPresent) {
+      const contentToAppend = filterNewContentBlocks(
+        templateContent,
+        existing,
+      );
+      if (contentToAppend.length > 0) {
         const updated = appendReleaseBlock(
           existing,
           currentReleaseId,
-          templateContent,
+          contentToAppend,
         );
         atomicWriteFileSync(workspacePath, updated);
       }


### PR DESCRIPTION
## Summary

- Replace all-or-nothing content dedup guard with `filterNewContentBlocks()` that parses template into marker-delimited blocks and only appends truly new ones
- Remove dead `extractContentMarkers` function (only consumer was the replaced guard)
- Add unit tests for the new filter function and integration tests covering the version-bump duplication scenario

## Original prompt

Fix UPDATES.md duplicating content blocks when the template extends across version bumps