### PR TITLE
fix(macos): auto-kill sibling processes instead of refusing to launch

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -1462,17 +1462,25 @@ if [ "$CMD" = "run" ]; then
 
     if [ -n "$other_vellum" ]; then
         echo ""
-        echo "ERROR: Another process from this project (bundle ID $BUNDLE_ID) is already running:"
+        echo "Killing sibling process(es) from this project (bundle ID $BUNDLE_ID):"
         echo "$other_vellum" | sed 's/^/  /'
-        echo ""
-        echo "It shares the lockfile, identity cache, and UserDefaults with"
-        echo "the bundle you're about to launch, and will race against it on"
-        echo "every write. Refusing to launch a duplicate."
-        echo ""
-        echo "Kill the existing process(es) and re-run:"
-        echo "$other_vellum" | awk '{print "  kill " $1}'
-        echo ""
-        exit 1
+        echo "$other_vellum" | awk '{print $1}' | xargs kill 2>/dev/null || true
+        # Give them a moment to exit
+        for i in {1..20}; do
+            still_running=false
+            while IFS= read -r pid_line; do
+                sib_pid=${pid_line%% *}
+                kill -0 "$sib_pid" 2>/dev/null && still_running=true && break
+            done <<< "$other_vellum"
+            $still_running || break
+            sleep 0.1
+        done
+        # Force-kill any stragglers
+        if $still_running; then
+            echo "Force-killing remaining sibling process(es)..."
+            echo "$other_vellum" | awk '{print $1}' | xargs kill -9 2>/dev/null || true
+            sleep 0.3
+        fi
     fi
 
     # Refresh /Applications/$BUNDLE_DISPLAY_NAME.app from the freshly-built


### PR DESCRIPTION
## Summary
- Replace the hard error when a duplicate bundle-ID process is detected with automatic cleanup
- Sends SIGTERM first, waits up to 2 seconds, then falls back to SIGKILL for any stragglers
- Removes the manual `kill` instructions that were printed to the user
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24928" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
