### PR TITLE
fix(macos): revalidate PIDs before SIGKILL in sibling cleanup

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -1475,10 +1475,18 @@ if [ "$CMD" = "run" ]; then
             $still_running || break
             sleep 0.1
         done
-        # Force-kill any stragglers
+        # Force-kill any stragglers — recompute which PIDs are actually
+        # still alive to avoid SIGKILLing a reused PID.
         if $still_running; then
             echo "Force-killing remaining sibling process(es)..."
-            echo "$other_vellum" | awk '{print $1}' | xargs kill -9 2>/dev/null || true
+            survivors=""
+            while IFS= read -r pid_line; do
+                sib_pid=${pid_line%% *}
+                kill -0 "$sib_pid" 2>/dev/null && survivors="${survivors}${sib_pid} "
+            done <<< "$other_vellum"
+            if [ -n "$survivors" ]; then
+                echo "$survivors" | xargs kill -9 2>/dev/null || true
+            fi
             sleep 0.3
         fi
     fi

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -1475,15 +1475,25 @@ if [ "$CMD" = "run" ]; then
             $still_running || break
             sleep 0.1
         done
-        # Force-kill any stragglers — recompute which PIDs are actually
-        # still alive to avoid SIGKILLing a reused PID.
+        # Force-kill any stragglers — re-read ps and re-match the bundle
+        # ID so we never SIGKILL a PID that was reused by an unrelated
+        # process since the original snapshot.
         if $still_running; then
             echo "Force-killing remaining sibling process(es)..."
             survivors=""
-            while IFS= read -r pid_line; do
-                sib_pid=${pid_line%% *}
-                kill -0 "$sib_pid" 2>/dev/null && survivors="${survivors}${sib_pid} "
-            done <<< "$other_vellum"
+            while IFS= read -r line; do
+                pid=${line%% *}
+                exe_path=${line#* }
+                case "$exe_path" in
+                    */Contents/MacOS/*) ;;
+                    *) continue ;;
+                esac
+                bundle_root=${exe_path%/Contents/MacOS/*}
+                other_id=$(plutil -extract CFBundleIdentifier raw "$bundle_root/Contents/Info.plist" 2>/dev/null || true)
+                [ "$other_id" = "$BUNDLE_ID" ] || continue
+                [ "$exe_path" != "$bundle_root/Contents/MacOS/$BUNDLE_DISPLAY_NAME" ] || continue
+                survivors+="$pid "
+            done < <(ps -ax -o pid=,comm=)
             if [ -n "$survivors" ]; then
                 echo "$survivors" | xargs kill -9 2>/dev/null || true
             fi


### PR DESCRIPTION
## Summary
- Recompute which sibling PIDs are still alive before sending SIGKILL, instead of blasting the original snapshot
- Prevents the theoretical risk of SIGKILLing an unrelated process if a PID was reused during the 2-second grace period

## Original prompt
it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24929" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
