### PR TITLE
feat(client): add credential type support to APIKeyManager

### DIFF
--- a/clients/macos/vellum-assistant/App/APIKeyManager.swift
+++ b/clients/macos/vellum-assistant/App/APIKeyManager.swift
@@ -193,18 +193,18 @@ enum APIKeyManager {
 
     /// Sync local read for a credential (FileCredentialStorage).
     static func getCredential(service: String, field: String) -> String? {
-        storage.get(account: credentialPrefix + service + "_" + field)
+        storage.get(account: credentialPrefix + service + ":" + field)
     }
 
     /// Sync local write for a credential (FileCredentialStorage).
     static func setCredential(_ value: String, service: String, field: String) {
-        _ = storage.set(account: credentialPrefix + service + "_" + field, value: value)
+        _ = storage.set(account: credentialPrefix + service + ":" + field, value: value)
         notifyKeyDidChange()
     }
 
     /// Sync local delete for a credential (FileCredentialStorage).
     static func deleteCredential(service: String, field: String) {
-        _ = storage.delete(account: credentialPrefix + service + "_" + field)
+        _ = storage.delete(account: credentialPrefix + service + ":" + field)
         notifyKeyDidChange()
     }
 

--- a/clients/macos/vellum-assistant/App/APIKeyManager.swift
+++ b/clients/macos/vellum-assistant/App/APIKeyManager.swift
@@ -187,6 +187,96 @@ enum APIKeyManager {
         }
     }
 
+    // MARK: - Credential access (service:field secrets)
+
+    private static let credentialPrefix = "vellum_credential_"
+
+    /// Sync local read for a credential (FileCredentialStorage).
+    static func getCredential(service: String, field: String) -> String? {
+        storage.get(account: credentialPrefix + service + "_" + field)
+    }
+
+    /// Sync local write for a credential (FileCredentialStorage).
+    static func setCredential(_ value: String, service: String, field: String) {
+        _ = storage.set(account: credentialPrefix + service + "_" + field, value: value)
+        notifyKeyDidChange()
+    }
+
+    /// Sync local delete for a credential (FileCredentialStorage).
+    static func deleteCredential(service: String, field: String) {
+        _ = storage.delete(account: credentialPrefix + service + "_" + field)
+        notifyKeyDidChange()
+    }
+
+    /// Calls `secrets/read` with credential type and returns existence + masked value.
+    private static func readCredentialSecret(service: String, field: String) async -> SecretReadResult {
+        do {
+            let body: [String: Any] = ["type": "credential", "name": "\(service):\(field)"]
+            let response = try await GatewayHTTPClient.post(
+                path: "assistants/{assistantId}/secrets/read", json: body, timeout: 5
+            )
+            guard response.isSuccess,
+                  let json = try? JSONSerialization.jsonObject(with: response.data) as? [String: Any],
+                  let found = json["found"] as? Bool else {
+                return SecretReadResult(found: false, masked: nil)
+            }
+            let masked = json["masked"] as? String
+            return SecretReadResult(found: found, masked: masked)
+        } catch {
+            apiKeyLog.error("readCredentialSecret(\(service, privacy: .public):\(field, privacy: .public)) failed: \(error.localizedDescription, privacy: .public)")
+            return SecretReadResult(found: false, masked: nil)
+        }
+    }
+
+    /// Check whether the assistant's secret store has a credential.
+    static func hasCredential(service: String, field: String) async -> Bool {
+        await readCredentialSecret(service: service, field: field).found
+    }
+
+    /// Read a masked credential from the assistant's secret store.
+    static func maskedCredential(service: String, field: String) async -> String? {
+        let result = await readCredentialSecret(service: service, field: field)
+        guard result.found, let masked = result.masked, !masked.isEmpty else { return nil }
+        return masked
+    }
+
+    /// Write a credential to the daemon's secret store via the gateway API.
+    static func setCredential(_ value: String, service: String, field: String) async -> SetKeyResult {
+        do {
+            let body: [String: Any] = ["type": "credential", "name": "\(service):\(field)", "value": value]
+            let response = try await GatewayHTTPClient.post(
+                path: "assistants/{assistantId}/secrets", json: body, timeout: 5
+            )
+            if response.isSuccess {
+                return SetKeyResult(success: true, error: nil, isTransient: false)
+            }
+            let isServerError = response.statusCode >= 500
+            if let parsed = try? JSONSerialization.jsonObject(with: response.data) as? [String: Any],
+               let errorMsg = parsed["error"] as? String {
+                return SetKeyResult(success: false, error: errorMsg, isTransient: isServerError)
+            }
+            return SetKeyResult(success: false, error: "Failed to save credential (HTTP \(response.statusCode)).", isTransient: isServerError)
+        } catch {
+            apiKeyLog.error("setCredential(\(service, privacy: .public):\(field, privacy: .public)) async failed: \(error.localizedDescription, privacy: .public)")
+            return SetKeyResult(success: false, error: "Could not reach assistant. Please check that it is running.", isTransient: true)
+        }
+    }
+
+    /// Delete a credential from the daemon's secret store via the gateway API.
+    @discardableResult
+    static func deleteCredential(service: String, field: String) async -> Bool {
+        do {
+            let body: [String: Any] = ["type": "credential", "name": "\(service):\(field)"]
+            let response = try await GatewayHTTPClient.delete(
+                path: "assistants/{assistantId}/secrets", json: body, timeout: 5
+            )
+            return response.isSuccess
+        } catch {
+            apiKeyLog.error("deleteCredential(\(service, privacy: .public):\(field, privacy: .public)) async failed: \(error.localizedDescription, privacy: .public)")
+            return false
+        }
+    }
+
     private static func notifyKeyDidChange() {
         NotificationCenter.default.post(name: .apiKeyManagerDidChange, object: nil)
     }


### PR DESCRIPTION
## Summary
- Add sync local methods (get/set/delete) for credential-type secrets with distinct storage prefix
- Add async gateway methods (has/masked/set/delete) using credential type and service:field naming
- Mirror existing api_key method patterns for consistency

Part of plan: apikeymgr-credential-type.md (PR 1 of 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24933" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
