### PR TITLE
Add canonical TTS provider catalog module and invariants

### DIFF
--- a/assistant/src/tts/__tests__/provider-catalog.test.ts
+++ b/assistant/src/tts/__tests__/provider-catalog.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  getCatalogProvider,
+  listCatalogProviderIds,
+  listCatalogProviders,
+} from "../provider-catalog.js";
+
+// ---------------------------------------------------------------------------
+// Catalog invariants
+// ---------------------------------------------------------------------------
+
+describe("TTS provider catalog", () => {
+  const entries = listCatalogProviders();
+  const ids = listCatalogProviderIds();
+
+  // -- Uniqueness -----------------------------------------------------------
+
+  test("all provider IDs are unique", () => {
+    const seen = new Set<string>();
+    for (const entry of entries) {
+      expect(seen.has(entry.id)).toBe(false);
+      seen.add(entry.id);
+    }
+  });
+
+  // -- Required fields ------------------------------------------------------
+
+  test("every entry has a non-empty id", () => {
+    for (const entry of entries) {
+      expect(entry.id.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("every entry has a non-empty displayName", () => {
+    for (const entry of entries) {
+      expect(entry.displayName.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("every entry has a valid callMode", () => {
+    const validModes = new Set(["native-twilio", "synthesized-play"]);
+    for (const entry of entries) {
+      expect(validModes.has(entry.callMode)).toBe(true);
+    }
+  });
+
+  test("every entry has a capabilities object with supportedFormats", () => {
+    for (const entry of entries) {
+      expect(entry.capabilities).toBeDefined();
+      expect(Array.isArray(entry.capabilities.supportedFormats)).toBe(true);
+      expect(entry.capabilities.supportedFormats.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("every entry has at least one secret requirement", () => {
+    for (const entry of entries) {
+      expect(entry.secretRequirements.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("every secret requirement has non-empty fields", () => {
+    for (const entry of entries) {
+      for (const secret of entry.secretRequirements) {
+        expect(secret.credentialStoreKey.length).toBeGreaterThan(0);
+        expect(secret.displayName.length).toBeGreaterThan(0);
+        expect(secret.setCommand.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  // -- Lookup helpers -------------------------------------------------------
+
+  test("listCatalogProviderIds returns IDs matching listCatalogProviders", () => {
+    expect(ids).toEqual(entries.map((e) => e.id));
+  });
+
+  test("getCatalogProvider returns the correct entry for each known ID", () => {
+    for (const entry of entries) {
+      const resolved = getCatalogProvider(entry.id);
+      expect(resolved).toBe(entry);
+    }
+  });
+
+  test("getCatalogProvider throws for unknown provider ID", () => {
+    expect(() => getCatalogProvider("nonexistent-provider")).toThrow(
+      /Unknown TTS provider "nonexistent-provider"/,
+    );
+  });
+
+  test("getCatalogProvider error message includes known provider IDs", () => {
+    try {
+      getCatalogProvider("nonexistent-provider");
+      throw new Error("Expected getCatalogProvider to throw");
+    } catch (err) {
+      const msg = (err as Error).message;
+      for (const id of ids) {
+        expect(msg).toContain(id);
+      }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Provider-specific assertions
+// ---------------------------------------------------------------------------
+
+describe("ElevenLabs catalog entry", () => {
+  const entry = getCatalogProvider("elevenlabs");
+
+  test("uses native-twilio call mode", () => {
+    expect(entry.callMode).toBe("native-twilio");
+  });
+
+  test("does not support streaming", () => {
+    expect(entry.capabilities.supportsStreaming).toBe(false);
+  });
+
+  test("supports mp3 format", () => {
+    expect(entry.capabilities.supportedFormats).toContain("mp3");
+  });
+
+  test("requires an API key stored under 'elevenlabs'", () => {
+    const apiKeySecret = entry.secretRequirements.find(
+      (s) => s.credentialStoreKey === "elevenlabs",
+    );
+    expect(apiKeySecret).toBeDefined();
+    expect(apiKeySecret!.displayName).toContain("ElevenLabs");
+  });
+});
+
+describe("Fish Audio catalog entry", () => {
+  const entry = getCatalogProvider("fish-audio");
+
+  test("uses synthesized-play call mode", () => {
+    expect(entry.callMode).toBe("synthesized-play");
+  });
+
+  test("supports streaming", () => {
+    expect(entry.capabilities.supportsStreaming).toBe(true);
+  });
+
+  test("supports mp3, wav, and opus formats", () => {
+    expect(entry.capabilities.supportedFormats).toContain("mp3");
+    expect(entry.capabilities.supportedFormats).toContain("wav");
+    expect(entry.capabilities.supportedFormats).toContain("opus");
+  });
+
+  test("requires an API key stored under 'credential/fish-audio/api_key'", () => {
+    const apiKeySecret = entry.secretRequirements.find(
+      (s) => s.credentialStoreKey === "credential/fish-audio/api_key",
+    );
+    expect(apiKeySecret).toBeDefined();
+    expect(apiKeySecret!.displayName).toContain("Fish Audio");
+  });
+});

--- a/assistant/src/tts/provider-catalog.ts
+++ b/assistant/src/tts/provider-catalog.ts
@@ -1,0 +1,167 @@
+/**
+ * Canonical TTS provider catalog.
+ *
+ * This module is the **single source of truth** for provider IDs and
+ * provider-level metadata on the assistant side. Every TTS provider that
+ * the system knows about is declared here — downstream modules query the
+ * catalog via {@link getCatalogProvider}, {@link listCatalogProviders}, or
+ * {@link listCatalogProviderIds} instead of hardcoding provider IDs.
+ *
+ * Adding a new TTS provider starts here: create a new
+ * {@link TtsProviderCatalogEntry} and append it to {@link CATALOG}.
+ */
+
+import type { TtsCallMode, TtsProviderId } from "./types.js";
+
+export type { TtsCallMode } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Catalog entry model
+// ---------------------------------------------------------------------------
+
+/**
+ * Metadata about a secret (API key / credential) required by a provider.
+ */
+export interface TtsProviderSecretRequirement {
+  /**
+   * The key used to retrieve this secret from the secure credential store.
+   *
+   * For simple keys this is a bare name (e.g. `"elevenlabs"`).
+   * For namespaced keys this follows the `credential/{service}/{field}`
+   * convention (e.g. `"credential/fish-audio/api_key"`).
+   */
+  credentialStoreKey: string;
+
+  /** Human-readable label shown in settings UI and error messages. */
+  displayName: string;
+
+  /**
+   * CLI command the user can run to store this secret.
+   *
+   * Shown in error messages when the key is missing.
+   */
+  setCommand: string;
+}
+
+/**
+ * Provider-level capabilities metadata surfaced by the catalog.
+ *
+ * These describe static, provider-wide traits — they do not change based
+ * on runtime configuration or per-request parameters.
+ */
+export interface TtsProviderCatalogCapabilities {
+  /** Whether the provider supports chunk-level streaming synthesis. */
+  supportsStreaming: boolean;
+
+  /** Audio formats the provider can produce (e.g. `["mp3"]`). */
+  supportedFormats: string[];
+}
+
+/**
+ * A single entry in the TTS provider catalog.
+ *
+ * Captures everything the system needs to know about a provider at a
+ * metadata level — identity, display name, telephony call mode,
+ * capabilities, and secret requirements.
+ */
+export interface TtsProviderCatalogEntry {
+  /** Unique provider identifier matching {@link TtsProviderId}. */
+  id: TtsProviderId;
+
+  /** Human-readable name for display in settings UI and logs. */
+  displayName: string;
+
+  /** How this provider integrates with the telephony call path. */
+  callMode: TtsCallMode;
+
+  /** Static provider-level capabilities. */
+  capabilities: TtsProviderCatalogCapabilities;
+
+  /** Secrets the provider requires to function. */
+  secretRequirements: TtsProviderSecretRequirement[];
+}
+
+// ---------------------------------------------------------------------------
+// Catalog data
+// ---------------------------------------------------------------------------
+
+/**
+ * The authoritative list of TTS providers.
+ *
+ * Order is significant only for display purposes (e.g. settings dropdowns).
+ */
+const CATALOG: readonly TtsProviderCatalogEntry[] = [
+  {
+    id: "elevenlabs",
+    displayName: "ElevenLabs",
+    callMode: "native-twilio",
+    capabilities: {
+      supportsStreaming: false,
+      supportedFormats: ["mp3"],
+    },
+    secretRequirements: [
+      {
+        credentialStoreKey: "elevenlabs",
+        displayName: "ElevenLabs API Key",
+        setCommand: "vellum keys set elevenlabs <key>",
+      },
+    ],
+  },
+  {
+    id: "fish-audio",
+    displayName: "Fish Audio",
+    callMode: "synthesized-play",
+    capabilities: {
+      supportsStreaming: true,
+      supportedFormats: ["mp3", "wav", "opus"],
+    },
+    secretRequirements: [
+      {
+        credentialStoreKey: "credential/fish-audio/api_key",
+        displayName: "Fish Audio API Key",
+        setCommand:
+          "assistant credentials set --service fish-audio --field api_key <key>",
+      },
+    ],
+  },
+] as const;
+
+/** Index for O(1) lookup by provider ID. */
+const catalogById = new Map<TtsProviderId, TtsProviderCatalogEntry>(
+  CATALOG.map((entry) => [entry.id, entry]),
+);
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * List all catalog providers in display order.
+ */
+export function listCatalogProviders(): readonly TtsProviderCatalogEntry[] {
+  return CATALOG;
+}
+
+/**
+ * List all known provider IDs in display order.
+ */
+export function listCatalogProviderIds(): TtsProviderId[] {
+  return CATALOG.map((entry) => entry.id);
+}
+
+/**
+ * Look up a catalog entry by provider ID.
+ *
+ * @throws if the ID is not in the catalog.
+ */
+export function getCatalogProvider(id: TtsProviderId): TtsProviderCatalogEntry {
+  const entry = catalogById.get(id);
+  if (!entry) {
+    const known = listCatalogProviderIds();
+    throw new Error(
+      `Unknown TTS provider "${id}" is not in the catalog. ` +
+        `Known providers: ${known.join(", ")}`,
+    );
+  }
+  return entry;
+}

--- a/assistant/src/tts/provider-catalog.ts
+++ b/assistant/src/tts/provider-catalog.ts
@@ -30,17 +30,17 @@ export interface TtsProviderSecretRequirement {
    * For namespaced keys this follows the `credential/{service}/{field}`
    * convention (e.g. `"credential/fish-audio/api_key"`).
    */
-  credentialStoreKey: string;
+  readonly credentialStoreKey: string;
 
   /** Human-readable label shown in settings UI and error messages. */
-  displayName: string;
+  readonly displayName: string;
 
   /**
    * CLI command the user can run to store this secret.
    *
    * Shown in error messages when the key is missing.
    */
-  setCommand: string;
+  readonly setCommand: string;
 }
 
 /**
@@ -51,10 +51,10 @@ export interface TtsProviderSecretRequirement {
  */
 export interface TtsProviderCatalogCapabilities {
   /** Whether the provider supports chunk-level streaming synthesis. */
-  supportsStreaming: boolean;
+  readonly supportsStreaming: boolean;
 
   /** Audio formats the provider can produce (e.g. `["mp3"]`). */
-  supportedFormats: string[];
+  readonly supportedFormats: readonly string[];
 }
 
 /**
@@ -66,19 +66,19 @@ export interface TtsProviderCatalogCapabilities {
  */
 export interface TtsProviderCatalogEntry {
   /** Unique provider identifier matching {@link TtsProviderId}. */
-  id: TtsProviderId;
+  readonly id: TtsProviderId;
 
   /** Human-readable name for display in settings UI and logs. */
-  displayName: string;
+  readonly displayName: string;
 
   /** How this provider integrates with the telephony call path. */
-  callMode: TtsCallMode;
+  readonly callMode: TtsCallMode;
 
   /** Static provider-level capabilities. */
-  capabilities: TtsProviderCatalogCapabilities;
+  readonly capabilities: Readonly<TtsProviderCatalogCapabilities>;
 
   /** Secrets the provider requires to function. */
-  secretRequirements: TtsProviderSecretRequirement[];
+  readonly secretRequirements: readonly Readonly<TtsProviderSecretRequirement>[];
 }
 
 // ---------------------------------------------------------------------------
@@ -103,7 +103,7 @@ const CATALOG: readonly TtsProviderCatalogEntry[] = [
       {
         credentialStoreKey: "elevenlabs",
         displayName: "ElevenLabs API Key",
-        setCommand: "vellum keys set elevenlabs <key>",
+        setCommand: "assistant keys set elevenlabs <key>",
       },
     ],
   },

--- a/assistant/src/tts/types.ts
+++ b/assistant/src/tts/types.ts
@@ -19,6 +19,24 @@
 export type TtsProviderId = "elevenlabs" | "fish-audio" | (string & {});
 
 // ---------------------------------------------------------------------------
+// Call-mode discriminator
+// ---------------------------------------------------------------------------
+
+/**
+ * Describes how a TTS provider integrates with the telephony call path.
+ *
+ * - `native-twilio`    — Twilio handles TTS natively via ConversationRelay;
+ *                         text tokens are forwarded to the relay and Twilio
+ *                         synthesises audio using the provider's built-in
+ *                         integration.
+ * - `synthesized-play` — The assistant synthesises audio via the provider's
+ *                         HTTP API and streams chunks to Twilio via `play`
+ *                         messages. Used when the provider is not natively
+ *                         supported by Twilio.
+ */
+export type TtsCallMode = "native-twilio" | "synthesized-play";
+
+// ---------------------------------------------------------------------------
 // Use-case discriminator
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Creates provider-catalog.ts as the single source of truth for TTS provider metadata
- Adds catalog entries for elevenlabs and fish-audio with call-mode and secret metadata
- Exports helper APIs (listCatalogProviders, getCatalogProvider, listCatalogProviderIds)
- Adds TtsCallMode type to types.ts for downstream reuse
- Adds comprehensive unit tests for catalog invariants

Part of plan: tts-provider-onboarding-unification.md (PR 1 of 11)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24934" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
