### PR TITLE
Drive TTS schema provider IDs and resolver lookup from provider catalog

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -59,9 +59,11 @@ import {
   AssistantConfigSchema,
   DEFAULT_ELEVENLABS_VOICE_ID,
   TtsServiceSchema,
+  VALID_TTS_SERVICE_PROVIDERS,
 } from "../config/schema.js";
 import type { AssistantConfig } from "../config/types.js";
 import { _setStorePath } from "../security/encrypted-store.js";
+import { listCatalogProviderIds } from "../tts/provider-catalog.js";
 import { resolveTtsConfig } from "../tts/tts-config-resolver.js";
 
 // ---------------------------------------------------------------------------
@@ -1448,6 +1450,108 @@ describe("resolveTtsConfig", () => {
     const resolved = resolveTtsConfig(config);
     expect(resolved.provider).toBe("aws-polly");
     expect(resolved.providerConfig).toEqual({});
+  });
+
+  test("unknown provider resolution is deterministic across repeated calls", () => {
+    const config = structuredClone(
+      AssistantConfigSchema.parse({}),
+    ) as AssistantConfig;
+    (config.services.tts as { provider: string }).provider = "nonexistent";
+    const first = resolveTtsConfig(config);
+    const second = resolveTtsConfig(config);
+    expect(first).toEqual(second);
+    expect(first.providerConfig).toEqual({});
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: TTS provider catalog integration
+// ---------------------------------------------------------------------------
+
+describe("TTS provider catalog integration", () => {
+  test("VALID_TTS_SERVICE_PROVIDERS matches catalog provider IDs", () => {
+    const catalogIds = listCatalogProviderIds();
+    expect([...VALID_TTS_SERVICE_PROVIDERS]).toEqual(catalogIds);
+  });
+
+  test("schema accepts all catalog provider IDs as services.tts.provider", () => {
+    for (const providerId of listCatalogProviderIds()) {
+      const result = AssistantConfigSchema.safeParse({
+        services: { tts: { provider: providerId } },
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.services.tts.provider).toBe(providerId);
+      }
+    }
+  });
+
+  test("TtsProvidersSchema has a key for every catalog provider", () => {
+    const parsed = AssistantConfigSchema.parse({});
+    const providerKeys = Object.keys(parsed.services.tts.providers);
+    for (const providerId of listCatalogProviderIds()) {
+      expect(providerKeys).toContain(providerId);
+    }
+  });
+
+  test("resolveTtsConfig returns correct defaults for each catalog provider", () => {
+    for (const providerId of listCatalogProviderIds()) {
+      const config = AssistantConfigSchema.parse({
+        services: { tts: { provider: providerId } },
+      });
+      const resolved = resolveTtsConfig(config);
+      expect(resolved.provider).toBe(providerId);
+      // Every catalog provider should resolve to a non-empty config object
+      expect(Object.keys(resolved.providerConfig).length).toBeGreaterThan(0);
+    }
+  });
+
+  test("resolveTtsConfig returns overridden values for elevenlabs", () => {
+    const config = AssistantConfigSchema.parse({
+      services: {
+        tts: {
+          provider: "elevenlabs",
+          providers: {
+            elevenlabs: { voiceId: "override-voice", speed: 0.7 },
+          },
+        },
+      },
+    });
+    const resolved = resolveTtsConfig(config);
+    expect(resolved.provider).toBe("elevenlabs");
+    expect(resolved.providerConfig).toMatchObject({
+      voiceId: "override-voice",
+      speed: 0.7,
+      // Defaults still present for unset fields
+      stability: 0.5,
+      similarityBoost: 0.75,
+    });
+  });
+
+  test("resolveTtsConfig returns overridden values for fish-audio", () => {
+    const config = AssistantConfigSchema.parse({
+      services: {
+        tts: {
+          provider: "fish-audio",
+          providers: {
+            "fish-audio": {
+              referenceId: "override-ref",
+              format: "opus",
+              speed: 1.5,
+            },
+          },
+        },
+      },
+    });
+    const resolved = resolveTtsConfig(config);
+    expect(resolved.provider).toBe("fish-audio");
+    expect(resolved.providerConfig).toMatchObject({
+      referenceId: "override-ref",
+      format: "opus",
+      speed: 1.5,
+      // Defaults for unset fields
+      chunkLength: 200,
+    });
   });
 });
 

--- a/assistant/src/config/schemas/tts.ts
+++ b/assistant/src/config/schemas/tts.ts
@@ -1,15 +1,20 @@
 import { z } from "zod";
 
+import { listCatalogProviderIds } from "../../tts/provider-catalog.js";
+import type { TtsProviderId } from "../../tts/types.js";
 import {
   DEFAULT_ELEVENLABS_VOICE_ID,
   VALID_CONVERSATION_TIMEOUTS,
 } from "./elevenlabs.js";
 
 /**
- * Valid TTS provider identifiers — must stay in sync with TtsProviderId union
- * in `../../tts/types.ts`. New providers append here and register an adapter.
+ * Valid TTS provider identifiers derived from the canonical provider catalog.
+ *
+ * Adding a new TTS provider starts in `provider-catalog.ts` — the IDs flow
+ * here automatically.
  */
-export const VALID_TTS_PROVIDERS = ["elevenlabs", "fish-audio"] as const;
+export const VALID_TTS_PROVIDERS: readonly [string, ...string[]] =
+  listCatalogProviderIds() as [TtsProviderId, ...TtsProviderId[]];
 
 /**
  * Per-provider config schemas nested under `services.tts.providers.<id>`.
@@ -148,6 +153,24 @@ export const TtsProvidersSchema = z.object({
   ),
 });
 export type TtsProviders = z.infer<typeof TtsProvidersSchema>;
+
+// ---------------------------------------------------------------------------
+// Catalog-completeness guard
+// ---------------------------------------------------------------------------
+// Ensures every provider in the catalog has a corresponding key in
+// TtsProvidersSchema. If a new provider is added to the catalog without a
+// schema entry, this fires at module-load time so the oversight is caught
+// immediately rather than at runtime when a user selects the provider.
+// ---------------------------------------------------------------------------
+const schemaKeys = new Set(Object.keys(TtsProvidersSchema.shape));
+for (const id of VALID_TTS_PROVIDERS) {
+  if (!schemaKeys.has(id)) {
+    throw new Error(
+      `TTS provider "${id}" exists in the catalog but has no schema entry ` +
+        `in TtsProvidersSchema. Add a "services.tts.providers.${id}" schema.`,
+    );
+  }
+}
 
 /**
  * Canonical TTS service configuration.

--- a/assistant/src/tts/tts-config-resolver.ts
+++ b/assistant/src/tts/tts-config-resolver.ts
@@ -58,24 +58,21 @@ export function resolveTtsConfig(config: AssistantConfig): ResolvedTtsConfig {
 /**
  * Build the provider-specific config object from the canonical
  * `services.tts.providers.<id>` block.
+ *
+ * Uses a generic lookup against the providers map — no provider-specific
+ * branching. Unknown providers (not in the catalog / schema) receive an
+ * empty config; their adapters are responsible for validating required fields.
  */
 function resolveProviderConfig(
   config: AssistantConfig,
   provider: TtsProviderId,
 ): Record<string, unknown> {
-  const ttsProviders = config.services.tts.providers;
+  const ttsProviders = config.services.tts.providers as Record<string, unknown>;
 
-  if (provider === "elevenlabs") {
-    return { ...ttsProviders.elevenlabs } as unknown as Record<string, unknown>;
+  const providerBlock = ttsProviders[provider];
+  if (providerBlock != null && typeof providerBlock === "object") {
+    return { ...providerBlock } as Record<string, unknown>;
   }
 
-  if (provider === "fish-audio") {
-    return {
-      ...ttsProviders["fish-audio"],
-    } as unknown as Record<string, unknown>;
-  }
-
-  // Unknown provider — return empty config. Provider adapters should
-  // validate their own required fields.
   return {};
 }


### PR DESCRIPTION
## Summary
- Replaces hardcoded VALID_TTS_PROVIDERS with catalog-derived provider IDs
- Adds catalog-completeness guard asserting all catalog providers have schema entries
- Removes provider-specific branching in resolveProviderConfig
- Extends config-schema tests for defaults, overrides, and unknown providers

Part of plan: tts-provider-onboarding-unification.md (PR 2 of 11)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24936" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
