### PR TITLE
fix: allow colon in FileCredentialStorage filenames for credential keys

### DIFF
--- a/clients/macos/vellum-assistant/Security/FileCredentialStorage.swift
+++ b/clients/macos/vellum-assistant/Security/FileCredentialStorage.swift
@@ -21,10 +21,10 @@ struct FileCredentialStorage: CredentialStorage {
 
     /// Returns the file URL for a given credential account name.
     /// The account name is sanitized to a safe filename by replacing
-    /// characters that are not alphanumerics, hyphens, or underscores.
+    /// characters that are not alphanumerics, hyphens, underscores, or colons.
     private func fileURL(for account: String) -> URL {
         let safeName = account.replacingOccurrences(
-            of: "[^a-zA-Z0-9_\\-]",
+            of: "[^a-zA-Z0-9_\\-:]",
             with: "_",
             options: .regularExpression
         )


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for apikeymgr-credential-type.md.

**Gap:** FileCredentialStorage filename collision for credential account keys
**What was expected:** Distinct (service, field) credential pairs must map to distinct storage files
**What was found:** The colon in account keys like `vellum_credential_fish_audio:api_key` was sanitized to underscore by fileURL(for:), causing potential filename collisions
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24939" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
