### PR TITLE
Register `stt-service` assistant feature flag

### DIFF
--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -314,19 +314,19 @@
       "defaultEnabled": false
     },
     {
-      "id": "fork-from-message",
-      "scope": "macos",
-      "key": "fork-from-message",
-      "label": "Fork from Message",
-      "description": "Show the Fork from here option in message overflow menus",
-      "defaultEnabled": false
-    },
-    {
       "id": "managed-x-oauth-integration",
       "scope": "assistant",
       "key": "managed-x-oauth-integration",
       "label": "Managed X/Twitter OAuth",
       "description": "Enable platform-managed X/Twitter OAuth integration in Models & Services settings",
+      "defaultEnabled": false
+    },
+    {
+      "id": "stt-service",
+      "scope": "assistant",
+      "key": "stt-service",
+      "label": "Voice STT Service",
+      "description": "Enable Voice settings STT service configuration UI for selecting and configuring speech-to-text providers",
       "defaultEnabled": false
     }
   ]


### PR DESCRIPTION
## Summary
- Adds `stt-service` assistant-scope feature flag to canonical registry
- Syncs bundled copies to assistant and gateway
- Removes duplicate `fork-from-message` registry entry (pre-existing)
- Default disabled; companion Terraform PR in `vellum-assistant-platform` required for rollout

**Merge-order prerequisite**: A companion PR must be opened in [`vellum-assistant-platform`](../vellum-assistant-platform) to provision the `stt-service` flag in Terraform/LaunchDarkly before this flag can be enabled in production. The CI Feature Flag Sync Check will fail on unrelated PRs if the flag is not provisioned on the platform side.

Part of plan: stt-service-product-unification.md (PR 5 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24940" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
