### PR TITLE
Add `services.stt` schema with `your-own` OpenAI Whisper defaults

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -58,6 +58,7 @@ import { invalidateConfigCache, loadConfig } from "../config/loader.js";
 import {
   AssistantConfigSchema,
   DEFAULT_ELEVENLABS_VOICE_ID,
+  SttServiceSchema,
   TtsServiceSchema,
 } from "../config/schema.js";
 import type { AssistantConfig } from "../config/types.js";
@@ -1140,6 +1141,80 @@ describe("AssistantConfigSchema", () => {
 
     // Any other string should be rejected
     const invalid2 = TtsServiceSchema.safeParse({ mode: "self-hosted" });
+    expect(invalid2.success).toBe(false);
+  });
+
+  // ── services.stt config ──────────────────────────────────────────────
+
+  test("applies services.stt defaults when not specified", () => {
+    const result = AssistantConfigSchema.parse({});
+    expect(result.services.stt.mode).toBe("your-own");
+    expect(result.services.stt.provider).toBe("openai-whisper");
+    expect(result.services.stt.providers["openai-whisper"].model).toBe(
+      "whisper-1",
+    );
+    expect(result.services.stt.providers["openai-whisper"].language).toBe("");
+  });
+
+  test("accepts valid services.stt provider override", () => {
+    const result = AssistantConfigSchema.parse({
+      services: { stt: { provider: "openai-whisper" } },
+    });
+    expect(result.services.stt.provider).toBe("openai-whisper");
+    expect(result.services.stt.mode).toBe("your-own");
+  });
+
+  test("accepts valid services.stt.providers.openai-whisper overrides", () => {
+    const result = AssistantConfigSchema.parse({
+      services: {
+        stt: {
+          providers: {
+            "openai-whisper": { model: "whisper-2", language: "en" },
+          },
+        },
+      },
+    });
+    expect(result.services.stt.providers["openai-whisper"].model).toBe(
+      "whisper-2",
+    );
+    expect(result.services.stt.providers["openai-whisper"].language).toBe("en");
+  });
+
+  test("rejects services.stt.mode = managed", () => {
+    const result = AssistantConfigSchema.safeParse({
+      services: { stt: { mode: "managed" } },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const msgs = result.error.issues.map((i) => i.message);
+      expect(
+        msgs.some((m) => m.includes("your-own") || m.includes("managed")),
+      ).toBe(true);
+    }
+  });
+
+  test("rejects invalid services.stt.provider", () => {
+    const result = AssistantConfigSchema.safeParse({
+      services: { stt: { provider: "azure-speech" } },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const msgs = result.error.issues.map((i) => i.message);
+      expect(msgs.some((m) => m.includes("services.stt.provider"))).toBe(true);
+    }
+  });
+
+  test("services.stt.mode only accepts your-own as literal", () => {
+    // Explicit your-own should work
+    const valid = SttServiceSchema.safeParse({ mode: "your-own" });
+    expect(valid.success).toBe(true);
+
+    // managed should be rejected
+    const invalid = SttServiceSchema.safeParse({ mode: "managed" });
+    expect(invalid.success).toBe(false);
+
+    // Any other string should be rejected
+    const invalid2 = SttServiceSchema.safeParse({ mode: "self-hosted" });
     expect(invalid2.success).toBe(false);
   });
 

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -192,6 +192,17 @@ export {
   SkillsInstallConfigSchema,
   SkillsLoadConfigSchema,
 } from "./schemas/skills.js";
+export type {
+  SttOpenAiWhisperProviderConfig,
+  SttProviders,
+  SttService,
+} from "./schemas/stt.js";
+export {
+  SttOpenAiWhisperProviderConfigSchema,
+  SttProvidersSchema,
+  SttServiceSchema,
+  VALID_STT_PROVIDERS,
+} from "./schemas/stt.js";
 export type { RateLimitConfig, TimeoutConfig } from "./schemas/timeouts.js";
 export {
   RateLimitConfigSchema,

--- a/assistant/src/config/schemas/services.ts
+++ b/assistant/src/config/schemas/services.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 
+import { SttServiceSchema } from "./stt.js";
 import { TtsServiceSchema } from "./tts.js";
 
 export const ServiceModeSchema = z.enum(["managed", "your-own"]);
@@ -86,6 +87,7 @@ export const ServicesSchema = z.object({
   "web-search": WebSearchServiceSchema.default(
     WebSearchServiceSchema.parse({}),
   ),
+  stt: SttServiceSchema.default(SttServiceSchema.parse({})),
   tts: TtsServiceSchema.default(TtsServiceSchema.parse({})),
   "google-oauth": GoogleOAuthServiceSchema.default(
     GoogleOAuthServiceSchema.parse({}),

--- a/assistant/src/config/schemas/stt.ts
+++ b/assistant/src/config/schemas/stt.ts
@@ -1,0 +1,76 @@
+import { z } from "zod";
+
+/**
+ * Valid STT provider identifiers. New providers append here and register
+ * an adapter.
+ */
+export const VALID_STT_PROVIDERS = ["openai-whisper"] as const;
+
+/**
+ * Per-provider config schemas nested under `services.stt.providers.<id>`.
+ *
+ * Each provider's schema is the full provider-specific config (model,
+ * language, tuning params, etc.). New providers add sibling schemas
+ * without restructuring.
+ */
+export const SttOpenAiWhisperProviderConfigSchema = z
+  .object({
+    model: z
+      .string({
+        error: "services.stt.providers.openai-whisper.model must be a string",
+      })
+      .default("whisper-1")
+      .describe("OpenAI Whisper model ID for speech-to-text"),
+    language: z
+      .string({
+        error:
+          "services.stt.providers.openai-whisper.language must be a string",
+      })
+      .default("")
+      .describe(
+        "ISO-639-1 language hint for transcription (leave empty for auto-detect)",
+      ),
+  })
+  .describe("OpenAI Whisper provider configuration under services.stt");
+
+export type SttOpenAiWhisperProviderConfig = z.infer<
+  typeof SttOpenAiWhisperProviderConfigSchema
+>;
+
+export const SttProvidersSchema = z.object({
+  "openai-whisper": SttOpenAiWhisperProviderConfigSchema.default(
+    SttOpenAiWhisperProviderConfigSchema.parse({}),
+  ),
+});
+export type SttProviders = z.infer<typeof SttProvidersSchema>;
+
+/**
+ * Canonical STT service configuration.
+ *
+ * `mode` is locked to `"your-own"` -- managed STT is not supported.
+ * Attempting to set `mode: "managed"` will fail schema validation.
+ */
+export const SttServiceSchema = z
+  .object({
+    mode: z
+      .literal("your-own", {
+        error:
+          'services.stt.mode must be "your-own" -- managed STT is not supported',
+      })
+      .default("your-own" as const)
+      .describe(
+        'STT service mode -- only "your-own" is supported (managed STT is not available)',
+      ),
+    provider: z
+      .enum(VALID_STT_PROVIDERS, {
+        error: `services.stt.provider must be one of: ${VALID_STT_PROVIDERS.join(", ")}`,
+      })
+      .default("openai-whisper")
+      .describe("Active STT provider used for speech-to-text transcription"),
+    providers: SttProvidersSchema.default(SttProvidersSchema.parse({})),
+  })
+  .describe(
+    "Speech-to-text service configuration -- provider selection and per-provider settings",
+  );
+
+export type SttService = z.infer<typeof SttServiceSchema>;


### PR DESCRIPTION
## Summary
- Adds canonical `services.stt` Zod schema mirroring TTS service conventions
- Wires STT config into ServicesSchema with OpenAI Whisper as default provider
- Adds schema validation tests for defaults, provider overrides, and rejection cases

Part of plan: stt-service-product-unification.md (PR 1 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24941" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
