### PR TITLE
Resolve daemon batch STT transcribers from `services.stt`

### DIFF
--- a/assistant/src/providers/speech-to-text/__tests__/resolve.test.ts
+++ b/assistant/src/providers/speech-to-text/__tests__/resolve.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before any subject imports
+// ---------------------------------------------------------------------------
+
+// -- Logger mock ----------------------------------------------------------
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// -- Config mock ----------------------------------------------------------
+
+let mockConfig: Record<string, unknown> = {};
+
+mock.module("../../../config/loader.js", () => ({
+  getConfig: () => mockConfig,
+  loadConfig: () => mockConfig,
+}));
+
+// -- Credential mock ------------------------------------------------------
+
+let mockProviderKeys: Record<string, string | undefined> = {};
+
+mock.module("../../../security/secure-keys.js", () => ({
+  getProviderKeyAsync: async (provider: string) =>
+    mockProviderKeys[provider] ?? undefined,
+  getSecureKeyAsync: async () => null,
+  getSecureKey: () => null,
+}));
+
+mock.module("../../../security/credential-key.js", () => ({
+  credentialKey: (...args: string[]) => args.join("/"),
+}));
+
+// ---------------------------------------------------------------------------
+// Subject import (after mocks)
+// ---------------------------------------------------------------------------
+
+import { resolveBatchTranscriber } from "../resolve.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildConfig(overrides: {
+  provider?: string;
+}): Record<string, unknown> {
+  return {
+    services: {
+      stt: {
+        mode: "your-own",
+        provider: overrides.provider ?? "openai-whisper",
+        providers: {
+          "openai-whisper": { model: "whisper-1", language: "" },
+        },
+      },
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("resolveBatchTranscriber", () => {
+  beforeEach(() => {
+    mockConfig = buildConfig({});
+    mockProviderKeys = {};
+  });
+
+  test("returns a BatchTranscriber when openai-whisper is configured and credentials are available", async () => {
+    mockProviderKeys["openai"] = "sk-test-key";
+    mockConfig = buildConfig({ provider: "openai-whisper" });
+
+    const transcriber = await resolveBatchTranscriber();
+
+    expect(transcriber).not.toBeNull();
+    expect(transcriber!.providerId).toBe("openai-whisper");
+    expect(transcriber!.boundaryId).toBe("daemon-batch");
+  });
+
+  test("returns null when credentials are missing for the configured provider", async () => {
+    mockProviderKeys = {}; // no keys at all
+    mockConfig = buildConfig({ provider: "openai-whisper" });
+
+    const transcriber = await resolveBatchTranscriber();
+
+    expect(transcriber).toBeNull();
+  });
+
+  test("returns null when configured provider is unsupported for daemon-batch", async () => {
+    // Force an unknown provider past the type system to simulate a future
+    // provider that hasn't been wired into the daemon-batch boundary yet.
+    mockProviderKeys["deepgram"] = "dg-test-key";
+    mockConfig = buildConfig({ provider: "deepgram" as string });
+
+    const transcriber = await resolveBatchTranscriber();
+
+    expect(transcriber).toBeNull();
+  });
+
+  test("uses config-driven provider selection, not hardcoded OpenAI", async () => {
+    // Verify the resolver reads from config rather than always using "openai".
+    // If the config says openai-whisper, we expect credential lookup for "openai".
+    mockProviderKeys["openai"] = "sk-config-driven";
+    mockConfig = buildConfig({ provider: "openai-whisper" });
+
+    const transcriber = await resolveBatchTranscriber();
+
+    expect(transcriber).not.toBeNull();
+    expect(transcriber!.providerId).toBe("openai-whisper");
+  });
+
+  test("resolved transcriber has stable provider identity", async () => {
+    mockProviderKeys["openai"] = "sk-identity-test";
+    mockConfig = buildConfig({ provider: "openai-whisper" });
+
+    const transcriber = await resolveBatchTranscriber();
+
+    // The providerId must remain "openai-whisper" for downstream identity checks.
+    expect(transcriber!.providerId).toBe("openai-whisper");
+    expect(transcriber!.boundaryId).toBe("daemon-batch");
+  });
+});

--- a/assistant/src/providers/speech-to-text/resolve.ts
+++ b/assistant/src/providers/speech-to-text/resolve.ts
@@ -1,16 +1,57 @@
+import { getConfig } from "../../config/loader.js";
 import { getProviderKeyAsync } from "../../security/secure-keys.js";
 import { createDaemonBatchTranscriber } from "../../stt/daemon-batch-transcriber.js";
-import type { BatchTranscriber } from "../../stt/types.js";
+import type { BatchTranscriber, SttProviderId } from "../../stt/types.js";
+
+// ---------------------------------------------------------------------------
+// Provider-to-credential mapping
+// ---------------------------------------------------------------------------
+
+/**
+ * Map an STT provider identifier to the credential provider name used by
+ * `getProviderKeyAsync`. New STT providers that share credentials with an
+ * existing credential provider (e.g. a future Deepgram provider would map
+ * to `"deepgram"`) add an entry here.
+ *
+ * Typed as `Record<SttProviderId, string>` to ensure compile-time
+ * completeness: adding a new variant to `SttProviderId` without a
+ * corresponding entry here is a type error.
+ */
+const STT_PROVIDER_CREDENTIAL_MAP: Record<SttProviderId, string> = {
+  "openai-whisper": "openai",
+};
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
 
 /**
  * Resolve a `BatchTranscriber` for daemon-hosted batch transcription.
  *
- * Credential lookup is centralized here (an authorized secure-keys importer)
- * so callers don't need to import secure-keys directly.
+ * Reads `services.stt.provider` from the assistant config to determine which
+ * STT provider to use, then looks up the corresponding credential. Credential
+ * lookup is centralized here (an authorized secure-keys importer) so callers
+ * don't need to import secure-keys directly.
  *
- * Returns `null` when no STT credentials are configured.
+ * Returns `null` when:
+ * - The configured provider is not supported by the daemon-batch boundary.
+ * - No credentials are configured for the resolved provider.
  */
 export async function resolveBatchTranscriber(): Promise<BatchTranscriber | null> {
-  const apiKey = await getProviderKeyAsync("openai");
+  const config = getConfig();
+  const provider = config.services.stt.provider;
+
+  // Resolve the credential provider name for the configured STT provider.
+  // Cast to `string` for the lookup so that unknown providers (which can
+  // arrive at runtime despite the schema validation) produce `undefined`
+  // instead of a type error. This keeps the runtime guard meaningful.
+  const credentialProvider = STT_PROVIDER_CREDENTIAL_MAP[
+    provider as SttProviderId
+  ] as string | undefined;
+  if (!credentialProvider) {
+    return null;
+  }
+
+  const apiKey = await getProviderKeyAsync(credentialProvider);
   return createDaemonBatchTranscriber(apiKey);
 }


### PR DESCRIPTION
## Summary
- Refactors batch STT resolver to read from `services.stt` config instead of hardcoded OpenAI logic
- Centralizes provider selection with explicit unsupported provider handling
- Adds resolver tests for config-driven resolution, missing credentials, and unknown providers

Part of plan: stt-service-product-unification.md (PR 2 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24943" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
