### PR TITLE
Add `stt-service`-gated STT configuration card to Voice tab

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -146,6 +146,8 @@ struct SettingsPanel: View {
     private static let embeddingProviderFeatureFlagKey = "settings-embedding-provider"
     private static let emailChannelFeatureFlagKey = "email-channel"
     private static let soundsFeatureFlagKey = "sounds"
+    private static let sttServiceFeatureFlagKey = "stt-service"
+    @State private var isSttServiceEnabled: Bool = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -203,6 +205,7 @@ struct SettingsPanel: View {
             isBillingEnabled = MacOSClientFeatureFlagManager.shared.isEnabled(Self.billingFeatureFlagKey)
             isSoundsEnabled = assistantFeatureFlagStore.isEnabled(Self.soundsFeatureFlagKey)
             isSchedulesEnabled = assistantFeatureFlagStore.isEnabled(Self.schedulesFeatureFlagKey)
+            isSttServiceEnabled = assistantFeatureFlagStore.isEnabled(Self.sttServiceFeatureFlagKey)
             // The init already consumed pendingSettingsTab into selectedTab.
             // Clear the store value so it doesn't leak into future navigations.
             if store.pendingSettingsTab != nil {
@@ -266,6 +269,8 @@ struct SettingsPanel: View {
                     if !enabled && selectedTab == .schedules {
                         selectedTab = .general
                     }
+                } else if key == Self.sttServiceFeatureFlagKey {
+                    isSttServiceEnabled = enabled
                 }
             }
         }
@@ -414,7 +419,7 @@ struct SettingsPanel: View {
                 onEnableIntegration: onEnableIntegration
             )
         case .voice:
-            VoiceSettingsView(store: store)
+            VoiceSettingsView(store: store, isSttServiceEnabled: isSttServiceEnabled)
         case .sounds:
             SettingsSoundsTab()
         case .permissionsAndPrivacy:
@@ -660,6 +665,9 @@ struct SettingsPanel: View {
                 if let schedulesFlag = flags.first(where: { $0.key == Self.schedulesFeatureFlagKey }) {
                     isSchedulesEnabled = schedulesFlag.enabled
                 }
+                if let sttServiceFlag = flags.first(where: { $0.key == Self.sttServiceFeatureFlagKey }) {
+                    isSttServiceEnabled = sttServiceFlag.enabled
+                }
                 consumeDeferredDeepLinkIfVisible()
                 return
             } catch {
@@ -685,6 +693,9 @@ struct SettingsPanel: View {
         }
         if let schedulesEnabled = resolved[Self.schedulesFeatureFlagKey] {
             isSchedulesEnabled = schedulesEnabled
+        }
+        if let sttServiceEnabled = resolved[Self.sttServiceFeatureFlagKey] {
+            isSttServiceEnabled = sttServiceEnabled
         }
         consumeDeferredDeepLinkIfVisible()
     }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -2957,10 +2957,10 @@ public final class SettingsStore: ObservableObject {
     func saveSTTOpenAIKey(_ raw: String, onSuccess: (() -> Void)? = nil) {
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
-        APIKeyManager.setKey(trimmed, for: "openai-stt")
-        removeDeletionTombstone(type: "api_key", name: "openai-stt")
+        APIKeyManager.setKey(trimmed, for: "openai")
+        removeDeletionTombstone(type: "api_key", name: "openai")
         Task {
-            let result = await APIKeyManager.setKey(trimmed, for: "openai-stt")
+            let result = await APIKeyManager.setKey(trimmed, for: "openai")
             if result.success {
                 onSuccess?()
             } else if let error = result.error {
@@ -2971,10 +2971,10 @@ public final class SettingsStore: ObservableObject {
 
     /// Removes the stored OpenAI API key for the STT service.
     func clearSTTOpenAIKey() {
-        APIKeyManager.deleteKey(for: "openai-stt")
+        APIKeyManager.deleteKey(for: "openai")
         Task {
-            let deleted = await APIKeyManager.deleteKey(for: "openai-stt")
-            if !deleted { addDeletionTombstone(type: "api_key", name: "openai-stt") }
+            let deleted = await APIKeyManager.deleteKey(for: "openai")
+            if !deleted { addDeletionTombstone(type: "api_key", name: "openai") }
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -2936,6 +2936,48 @@ public final class SettingsStore: ObservableObject {
         return task
     }
 
+    /// Persists the selected STT provider to the daemon config so
+    /// transcription routes through the correct backend. The canonical
+    /// config path is `services.stt.provider`.
+    @discardableResult
+    func setSTTProvider(_ provider: String) -> Task<Bool, Never> {
+        let task = Task {
+            let success = await settingsClient.patchConfig([
+                "services": ["stt": ["provider": provider]]
+            ])
+            if !success {
+                log.error("Failed to patch config for STT provider")
+            }
+            return success
+        }
+        return task
+    }
+
+    /// Saves an OpenAI API key for the STT service to the credential store.
+    func saveSTTOpenAIKey(_ raw: String, onSuccess: (() -> Void)? = nil) {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        APIKeyManager.setKey(trimmed, for: "openai-stt")
+        removeDeletionTombstone(type: "api_key", name: "openai-stt")
+        Task {
+            let result = await APIKeyManager.setKey(trimmed, for: "openai-stt")
+            if result.success {
+                onSuccess?()
+            } else if let error = result.error {
+                log.error("Failed to sync OpenAI STT key to daemon: \(error, privacy: .public)")
+            }
+        }
+    }
+
+    /// Removes the stored OpenAI API key for the STT service.
+    func clearSTTOpenAIKey() {
+        APIKeyManager.deleteKey(for: "openai-stt")
+        Task {
+            let deleted = await APIKeyManager.deleteKey(for: "openai-stt")
+            if !deleted { addDeletionTombstone(type: "api_key", name: "openai-stt") }
+        }
+    }
+
     /// Schedules a delayed refresh of provider routing sources, giving the
     /// daemon time to re-initialize providers after a key change.
     private func scheduleRoutingSourceRefresh() {
@@ -3364,6 +3406,15 @@ public final class SettingsStore: ObservableObject {
            let tts = services["tts"] as? [String: Any],
            let ttsProvider = tts["provider"] as? String {
             UserDefaults.standard.set(ttsProvider, forKey: "ttsProvider")
+        }
+
+        // Sync the global STT provider from the daemon config so the client
+        // stays aligned after restart or reconnection. The canonical path
+        // is services.stt.provider.
+        if let services = config["services"] as? [String: Any],
+           let stt = services["stt"] as? [String: Any],
+           let sttProvider = stt["provider"] as? String {
+            UserDefaults.standard.set(sttProvider, forKey: "sttProvider")
         }
 
         Self.applyHostBrowserCdpInspectConfig(config, into: self)

--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -107,7 +107,7 @@ struct VoiceSettingsView: View {
         }
         .onAppear {
             elevenLabsHasKey = APIKeyManager.getKey(for: "elevenlabs") != nil
-            sttOpenAIHasKey = APIKeyManager.getKey(for: "openai-stt") != nil
+            sttOpenAIHasKey = APIKeyManager.getKey(for: "openai") != nil
         }
         .onChange(of: conversationTimeoutSeconds) {
             VoiceModeManager.conversationTimeoutOverride = conversationTimeoutSeconds

--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -23,14 +23,34 @@ private enum TTSProviderOption: String, CaseIterable {
     }
 }
 
+/// STT provider options for the speech-to-text service card.
+private enum STTProviderOption: String, CaseIterable {
+    case openaiWhisper = "openai-whisper"
+
+    var displayName: String {
+        switch self {
+        case .openaiWhisper: return "OpenAI Whisper"
+        }
+    }
+
+    var subtitle: String {
+        switch self {
+        case .openaiWhisper:
+            return "High-accuracy speech-to-text transcription. Requires an OpenAI API key."
+        }
+    }
+}
+
 /// Voice settings tab — configure push-to-talk activation key,
-/// conversation timeout, and text-to-speech provider.
+/// conversation timeout, text-to-speech provider, and speech-to-text provider.
 struct VoiceSettingsView: View {
     @ObservedObject var store: SettingsStore
+    var isSttServiceEnabled: Bool = false
 
     @AppStorage("activationKey") private var activationKey: String = "fn"
     @AppStorage("voiceConversationTimeoutSeconds") private var conversationTimeoutSeconds: Int = 30
     @AppStorage("ttsProvider") private var ttsProviderRaw: String = TTSProviderOption.elevenlabs.rawValue
+    @AppStorage("sttProvider") private var sttProviderRaw: String = STTProviderOption.openaiWhisper.rawValue
 
     @State private var elevenLabsKeyText: String = ""
     @State private var ttsSetupExpanded: Bool = false
@@ -40,8 +60,18 @@ struct VoiceSettingsView: View {
     @State private var recordingMonitors: [Any] = []
     @State private var modifierHoldTimer: Timer? = nil
 
+    // STT-specific state
+    @State private var sttOpenAIKeyText: String = ""
+    @State private var sttSetupExpanded: Bool = false
+    /// Whether an OpenAI API key is stored for STT (fetched per-component).
+    @State private var sttOpenAIHasKey = false
+
     private var ttsProvider: TTSProviderOption {
         TTSProviderOption(rawValue: ttsProviderRaw) ?? .elevenlabs
+    }
+
+    private var sttProvider: STTProviderOption {
+        STTProviderOption(rawValue: sttProviderRaw) ?? .openaiWhisper
     }
 
     private var currentActivator: PTTActivator {
@@ -68,12 +98,16 @@ struct VoiceSettingsView: View {
             pttCard
             conversationTimeoutCard
             ttsProviderCard
+            if isSttServiceEnabled {
+                sttProviderCard
+            }
         }
         .onDisappear {
             stopRecordingCustomKey()
         }
         .onAppear {
             elevenLabsHasKey = APIKeyManager.getKey(for: "elevenlabs") != nil
+            sttOpenAIHasKey = APIKeyManager.getKey(for: "openai-stt") != nil
         }
         .onChange(of: conversationTimeoutSeconds) {
             VoiceModeManager.conversationTimeoutOverride = conversationTimeoutSeconds
@@ -460,6 +494,95 @@ struct VoiceSettingsView: View {
 
             VButton(label: "Visit Fish Audio", rightIcon: VIcon.arrowUpRight.rawValue, style: .outlined) {
                 NSWorkspace.shared.open(URL(string: "https://fish.audio")!)
+            }
+        }
+    }
+
+    // MARK: - STT Provider Card
+
+    private var sttProviderCard: some View {
+        SettingsCard(title: "Speech-to-Text", subtitle: "Choose an STT provider for audio transcription. The selected provider is used globally across all transcription features.") {
+            VStack(alignment: .leading, spacing: VSpacing.md) {
+                // Provider selector
+                VStack(alignment: .leading, spacing: VSpacing.sm) {
+                    Text("Provider:")
+                        .font(VFont.bodySmallDefault)
+                        .foregroundStyle(VColor.contentSecondary)
+
+                    HStack(spacing: VSpacing.sm) {
+                        ForEach(STTProviderOption.allCases, id: \.rawValue) { provider in
+                            let isSelected = sttProvider == provider
+                            providerOption(label: provider.displayName, isSelected: isSelected) {
+                                sttProviderRaw = provider.rawValue
+                                store.setSTTProvider(provider.rawValue)
+                            }
+                        }
+                    }
+                }
+
+                // Provider-specific subtitle
+                Text(sttProvider.subtitle)
+                    .font(VFont.bodySmallDefault)
+                    .foregroundStyle(VColor.contentTertiary)
+
+                // Provider-specific configuration
+                switch sttProvider {
+                case .openaiWhisper:
+                    openaiWhisperProviderConfig
+                }
+            }
+        }
+    }
+
+    // MARK: - OpenAI Whisper Provider Config
+
+    private var openaiWhisperProviderConfig: some View {
+        Group {
+            if sttOpenAIHasKey {
+                HStack(spacing: VSpacing.sm) {
+                    VButton(label: "Connected", leftIcon: VIcon.circleCheck.rawValue, style: .primary) {}
+                    VButton(label: "Disconnect", style: .danger) {
+                        store.clearSTTOpenAIKey()
+                        sttOpenAIHasKey = false
+                        sttOpenAIKeyText = ""
+                        sttSetupExpanded = false
+                    }
+                }
+            } else if sttSetupExpanded {
+                VStack(alignment: .leading, spacing: VSpacing.sm) {
+                    VTextField(
+                        "OpenAI API Key",
+                        placeholder: "Your OpenAI API key",
+                        text: $sttOpenAIKeyText,
+                        isSecure: true,
+                        maxWidth: 400
+                    )
+
+                    HStack(spacing: VSpacing.xs) {
+                        VIconView(.lock, size: 10)
+                            .foregroundStyle(VColor.contentTertiary)
+                        Text("Your API key is stored securely in the macOS Keychain.")
+                            .font(VFont.labelDefault)
+                            .foregroundStyle(VColor.contentTertiary)
+                    }
+
+                    HStack(spacing: VSpacing.sm) {
+                        VButton(label: "Connect", style: .outlined, isDisabled: sttOpenAIKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty) {
+                            store.saveSTTOpenAIKey(sttOpenAIKeyText)
+                            sttOpenAIHasKey = true
+                            sttOpenAIKeyText = ""
+                            sttSetupExpanded = false
+                        }
+                        VButton(label: "Cancel", style: .outlined) {
+                            sttSetupExpanded = false
+                            sttOpenAIKeyText = ""
+                        }
+                    }
+                }
+            } else {
+                VButton(label: "Set Up", style: .outlined) {
+                    sttSetupExpanded = true
+                }
             }
         }
     }

--- a/clients/macos/vellum-assistantTests/SettingsStoreVoiceServiceTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsStoreVoiceServiceTests.swift
@@ -1,0 +1,203 @@
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+/// Verifies that `SettingsStore` emits the expected config patch payloads
+/// for the `services.stt` namespace and correctly loads STT provider config
+/// from daemon config responses.
+@MainActor
+final class SettingsStoreVoiceServiceTests: XCTestCase {
+
+    private var mockSettingsClient: MockSettingsClient!
+    private var store: SettingsStore!
+
+    override func setUp() {
+        super.setUp()
+        mockSettingsClient = MockSettingsClient()
+        mockSettingsClient.patchConfigResponse = true
+        store = SettingsStore(settingsClient: mockSettingsClient)
+    }
+
+    override func tearDown() {
+        store = nil
+        mockSettingsClient = nil
+        super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    /// Returns the most recent `services.stt` patch payload captured
+    /// by the mock client, or `nil` if no such patch has been emitted.
+    private func lastSTTPatch() -> [String: Any]? {
+        for payload in mockSettingsClient.patchConfigCalls.reversed() {
+            if let services = payload["services"] as? [String: Any],
+               let stt = services["stt"] as? [String: Any] {
+                return stt
+            }
+        }
+        return nil
+    }
+
+    /// Returns the most recent `services.tts` patch payload captured
+    /// by the mock client, or `nil` if no such patch has been emitted.
+    private func lastTTSPatch() -> [String: Any]? {
+        for payload in mockSettingsClient.patchConfigCalls.reversed() {
+            if let services = payload["services"] as? [String: Any],
+               let tts = services["tts"] as? [String: Any] {
+                return tts
+            }
+        }
+        return nil
+    }
+
+    /// Waits for the background `Task` started by a store helper to flush
+    /// its patch into the mock client.
+    private func waitForPatchCount(_ expected: Int, timeout: TimeInterval = 2.0) {
+        let predicate = NSPredicate { _, _ in
+            self.mockSettingsClient.patchConfigCalls.count >= expected
+        }
+        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: nil)
+        wait(for: [expectation], timeout: timeout)
+    }
+
+    // MARK: - setSTTProvider
+
+    func testSetSTTProviderEmitsExpectedPatch() {
+        store.setSTTProvider("openai-whisper")
+
+        waitForPatchCount(1)
+
+        let patch = lastSTTPatch()
+        XCTAssertNotNil(patch, "expected a services.stt patch payload")
+        XCTAssertEqual(patch?["provider"] as? String, "openai-whisper")
+    }
+
+    func testSetSTTProviderDoesNotEmitTTSPatch() {
+        store.setSTTProvider("openai-whisper")
+
+        waitForPatchCount(1)
+
+        let ttsPatch = lastTTSPatch()
+        XCTAssertNil(ttsPatch, "setSTTProvider must not emit a TTS patch")
+    }
+
+    func testSetTTSProviderDoesNotEmitSTTPatch() {
+        store.setTTSProvider("elevenlabs")
+
+        waitForPatchCount(1)
+
+        let sttPatch = lastSTTPatch()
+        XCTAssertNil(sttPatch, "setTTSProvider must not emit an STT patch")
+    }
+
+    // MARK: - applyDaemonConfig STT loading
+
+    func testApplyDaemonConfigSyncsSTTProvider() {
+        // Clear any existing value to confirm the config load writes it.
+        UserDefaults.standard.removeObject(forKey: "sttProvider")
+
+        let config: [String: Any] = [
+            "services": [
+                "stt": [
+                    "provider": "openai-whisper"
+                ]
+            ]
+        ]
+
+        // loadConfigFromDaemon calls applyDaemonConfig internally, but
+        // we can test the effect by setting up the mock response and calling load.
+        mockSettingsClient.fetchConfigResponse = config
+        let expectation = XCTestExpectation(description: "config loaded")
+        Task {
+            await store.loadConfigFromDaemon()
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 2.0)
+
+        XCTAssertEqual(
+            UserDefaults.standard.string(forKey: "sttProvider"),
+            "openai-whisper"
+        )
+    }
+
+    func testApplyDaemonConfigSyncsTTSProvider() {
+        // Verify TTS loading still works alongside STT.
+        UserDefaults.standard.removeObject(forKey: "ttsProvider")
+
+        let config: [String: Any] = [
+            "services": [
+                "tts": [
+                    "provider": "fish-audio"
+                ]
+            ]
+        ]
+
+        mockSettingsClient.fetchConfigResponse = config
+        let expectation = XCTestExpectation(description: "config loaded")
+        Task {
+            await store.loadConfigFromDaemon()
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 2.0)
+
+        XCTAssertEqual(
+            UserDefaults.standard.string(forKey: "ttsProvider"),
+            "fish-audio"
+        )
+    }
+
+    func testApplyDaemonConfigSyncsBothTTSAndSTT() {
+        UserDefaults.standard.removeObject(forKey: "ttsProvider")
+        UserDefaults.standard.removeObject(forKey: "sttProvider")
+
+        let config: [String: Any] = [
+            "services": [
+                "tts": [
+                    "provider": "elevenlabs"
+                ],
+                "stt": [
+                    "provider": "openai-whisper"
+                ]
+            ]
+        ]
+
+        mockSettingsClient.fetchConfigResponse = config
+        let expectation = XCTestExpectation(description: "config loaded")
+        Task {
+            await store.loadConfigFromDaemon()
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 2.0)
+
+        XCTAssertEqual(UserDefaults.standard.string(forKey: "ttsProvider"), "elevenlabs")
+        XCTAssertEqual(UserDefaults.standard.string(forKey: "sttProvider"), "openai-whisper")
+    }
+
+    func testApplyDaemonConfigDoesNotOverwriteSTTWhenMissing() {
+        // Pre-seed a value and verify it is not cleared when the
+        // daemon config does not include an stt section.
+        UserDefaults.standard.set("openai-whisper", forKey: "sttProvider")
+
+        let config: [String: Any] = [
+            "services": [
+                "tts": [
+                    "provider": "elevenlabs"
+                ]
+            ]
+        ]
+
+        mockSettingsClient.fetchConfigResponse = config
+        let expectation = XCTestExpectation(description: "config loaded")
+        Task {
+            await store.loadConfigFromDaemon()
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 2.0)
+
+        XCTAssertEqual(
+            UserDefaults.standard.string(forKey: "sttProvider"),
+            "openai-whisper",
+            "STT provider must not be cleared when the daemon config omits stt"
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `stt-service` feature flag gating to SettingsPanel
- Adds STT service card to VoiceSettingsView with OpenAI Whisper provider selection
- Adds SettingsStore STT helpers mirroring TTS patterns for config loading/patching
- Adds tests for STT config loading and patch payload behavior

Part of plan: stt-service-product-unification.md (PR 6 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24944" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
