### PR TITLE
fix(browser-relay): make host-browser callback failures explicit

### DIFF
--- a/assistant/src/daemon/host-browser-proxy.ts
+++ b/assistant/src/daemon/host-browser-proxy.ts
@@ -77,7 +77,8 @@ export class HostBrowserProxy {
           "Host browser proxy request timed out",
         );
         resolve({
-          content: "Host browser proxy timed out waiting for client response",
+          content:
+            "Host browser proxy timed out waiting for extension response (check browser-relay connectivity and /v1/host-browser-result callback failures such as 404/401).",
           isError: true,
         });
       }, timeoutSec * 1000);

--- a/assistant/src/tools/browser/cdp-client/__tests__/extension-cdp-client.test.ts
+++ b/assistant/src/tools/browser/cdp-client/__tests__/extension-cdp-client.test.ts
@@ -185,6 +185,35 @@ describe("ExtensionCdpClient", () => {
     expect(err.underlying).toBeInstanceOf(Error);
   });
 
+  test("result.isError with non-JSON content throws CdpError('cdp_error')", async () => {
+    const { proxy } = fakeProxy(async () => ({
+      content:
+        "Host browser proxy timed out waiting for extension response (check callback failures).",
+      isError: true,
+    }));
+
+    const client = createExtensionCdpClient(proxy, "conv-6b");
+
+    let caught: unknown;
+    try {
+      await client.send("Runtime.evaluate", { expression: "document.title" });
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(CdpError);
+    const err = caught as CdpError;
+    expect(err.code).toBe("cdp_error");
+    expect(err.message).toContain(
+      "Host browser proxy timed out waiting for extension response",
+    );
+    expect(err.cdpMethod).toBe("Runtime.evaluate");
+    expect(err.cdpParams).toEqual({ expression: "document.title" });
+    expect(err.underlying).toBe(
+      "Host browser proxy timed out waiting for extension response (check callback failures).",
+    );
+  });
+
   test("result.content === 'Aborted' throws CdpError('aborted')", async () => {
     const { proxy, request } = fakeProxy(async () => ({
       content: "Aborted",

--- a/assistant/src/tools/browser/cdp-client/extension-cdp-client.ts
+++ b/assistant/src/tools/browser/cdp-client/extension-cdp-client.ts
@@ -74,6 +74,45 @@ export class ExtensionCdpClient implements ScopedCdpClient {
       });
     }
 
+    if (result.isError) {
+      let parsedError: unknown;
+      try {
+        parsedError = JSON.parse(result.content);
+      } catch {
+        // The host-browser dispatcher may surface plain-text errors
+        // (for example timeout/callback-delivery failures) instead
+        // of JSON-RPC envelopes. Treat these as CDP-level failures so
+        // the factory does not silently fail over to cdp-inspect/local
+        // and mask the extension path as the true failing hop.
+        throw new CdpError(
+          "cdp_error",
+          result.content.slice(0, 200) || `CDP error for ${method}`,
+          {
+            cdpMethod: method,
+            cdpParams: params,
+            underlying: result.content,
+          },
+        );
+      }
+
+      const msg =
+        (typeof parsedError === "object" &&
+          parsedError !== null &&
+          "message" in parsedError &&
+          typeof (parsedError as { message: unknown }).message === "string" &&
+          (parsedError as { message: string }).message) ||
+        `CDP error for ${method}`;
+      log.debug(
+        { method, params, parsedError },
+        "ExtensionCdpClient: CDP error",
+      );
+      throw new CdpError("cdp_error", msg, {
+        cdpMethod: method,
+        cdpParams: params,
+        underlying: parsedError,
+      });
+    }
+
     let parsed: unknown;
     try {
       parsed = JSON.parse(result.content);
@@ -87,22 +126,6 @@ export class ExtensionCdpClient implements ScopedCdpClient {
           underlying: err,
         },
       );
-    }
-
-    if (result.isError) {
-      const msg =
-        (typeof parsed === "object" &&
-          parsed !== null &&
-          "message" in parsed &&
-          typeof (parsed as { message: unknown }).message === "string" &&
-          (parsed as { message: string }).message) ||
-        `CDP error for ${method}`;
-      log.debug({ method, params, parsed }, "ExtensionCdpClient: CDP error");
-      throw new CdpError("cdp_error", msg, {
-        cdpMethod: method,
-        cdpParams: params,
-        underlying: parsed,
-      });
     }
 
     return parsed as T;

--- a/clients/chrome-extension/background/__tests__/worker-host-browser-result.test.ts
+++ b/clients/chrome-extension/background/__tests__/worker-host-browser-result.test.ts
@@ -205,8 +205,10 @@ describe('postHostBrowserResult — self-hosted mode', () => {
     );
   });
 
-  test('logs a warning when the daemon returns a non-2xx status', async () => {
-    fetchHandle.setNextResponse(new Response(null, { status: 503 }));
+  test('logs a warning with status/request context when the daemon returns non-2xx', async () => {
+    fetchHandle.setNextResponse(
+      new Response(JSON.stringify({ error: 'not found' }), { status: 404 }),
+    );
     const mode: RelayMode = {
       kind: 'self-hosted',
       baseUrl: 'http://127.0.0.1:9999',
@@ -217,7 +219,10 @@ describe('postHostBrowserResult — self-hosted mode', () => {
 
     expect(consoleSpy.warnings.length).toBeGreaterThanOrEqual(1);
     const flat = consoleSpy.warnings.flat().join(' ');
-    expect(flat).toContain('503');
+    expect(flat).toContain('host-browser-result POST failed');
+    expect(flat).toContain('404');
+    expect(flat).toContain('req-abc');
+    expect(flat).toContain('not found');
   });
 
   test('ignores the supplied connection in self-hosted mode', async () => {

--- a/clients/chrome-extension/background/__tests__/worker-host-browser-result.test.ts
+++ b/clients/chrome-extension/background/__tests__/worker-host-browser-result.test.ts
@@ -226,14 +226,13 @@ describe('postHostBrowserResult — self-hosted mode', () => {
     expect(warningCall).toBeDefined();
 
     const details = warningCall?.[1];
-    expect(details).toEqual(
-      expect.objectContaining({
-        status: 404,
-        requestId: 'req-abc',
-        url: 'http://127.0.0.1:9999/v1/host-browser-result',
-        responseBodySnippet: expect.stringContaining('not found'),
-      }),
-    );
+    expect(typeof details).toBe('object');
+    expect(details).not.toBeNull();
+    const payload = details as Record<string, unknown>;
+    expect(payload.status).toBe(404);
+    expect(payload.requestId).toBe('req-abc');
+    expect(payload.url).toBe('http://127.0.0.1:9999/v1/host-browser-result');
+    expect(String(payload.responseBodySnippet)).toContain('not found');
   });
 
   test('ignores the supplied connection in self-hosted mode', async () => {

--- a/clients/chrome-extension/background/__tests__/worker-host-browser-result.test.ts
+++ b/clients/chrome-extension/background/__tests__/worker-host-browser-result.test.ts
@@ -218,11 +218,22 @@ describe('postHostBrowserResult — self-hosted mode', () => {
     await postHostBrowserResult(mode, null, exampleResult);
 
     expect(consoleSpy.warnings.length).toBeGreaterThanOrEqual(1);
-    const flat = consoleSpy.warnings.flat().join(' ');
-    expect(flat).toContain('host-browser-result POST failed');
-    expect(flat).toContain('404');
-    expect(flat).toContain('req-abc');
-    expect(flat).toContain('not found');
+    const warningCall = consoleSpy.warnings.find(
+      (args) =>
+        typeof args[0] === 'string' &&
+        args[0].includes('host-browser-result POST failed'),
+    );
+    expect(warningCall).toBeDefined();
+
+    const details = warningCall?.[1];
+    expect(details).toEqual(
+      expect.objectContaining({
+        status: 404,
+        requestId: 'req-abc',
+        url: 'http://127.0.0.1:9999/v1/host-browser-result',
+        responseBodySnippet: expect.stringContaining('not found'),
+      }),
+    );
   });
 
   test('ignores the supplied connection in self-hosted mode', async () => {

--- a/clients/chrome-extension/background/relay-connection.ts
+++ b/clients/chrome-extension/background/relay-connection.ts
@@ -701,8 +701,20 @@ export async function postHostBrowserResult(
     body: JSON.stringify(result),
   });
   if (!resp.ok) {
+    let responseBodySnippet = '';
+    try {
+      responseBodySnippet = (await resp.text()).slice(0, 200);
+    } catch {
+      // Best-effort diagnostics only.
+    }
     console.warn(
-      `[vellum-relay] host-browser-result POST returned ${resp.status}`,
+      '[vellum-relay] host-browser-result POST failed',
+      {
+        status: resp.status,
+        requestId: result.requestId,
+        url,
+        responseBodySnippet: responseBodySnippet || undefined,
+      },
     );
   }
 }


### PR DESCRIPTION
## Summary
- Improve self-hosted extension callback logging when `POST /v1/host-browser-result` returns non-2xx by including status, request id, URL, and response snippet.
- Make host-browser proxy timeout messages explicitly point to extension callback delivery issues so failures are actionable.
- Classify non-JSON extension error payloads as `cdp_error` in `ExtensionCdpClient` so we do not silently fail over and mask the root cause.

## Original prompt
it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24946" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
