### PR TITLE
feat(settings): add Fish Audio API key save/clear using credential type

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -892,6 +892,29 @@ public final class SettingsStore: ObservableObject {
         }
     }
 
+    func saveFishAudioKey(_ raw: String, onSuccess: (() -> Void)? = nil) {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        APIKeyManager.setCredential(trimmed, service: "fish-audio", field: "api_key")
+        removeDeletionTombstone(type: "credential", name: "fish-audio:api_key")
+        Task {
+            let result = await APIKeyManager.setCredential(trimmed, service: "fish-audio", field: "api_key")
+            if result.success {
+                onSuccess?()
+            } else if let error = result.error {
+                log.error("Failed to sync Fish Audio key to daemon: \(error, privacy: .public)")
+            }
+        }
+    }
+
+    func clearFishAudioKey() {
+        APIKeyManager.deleteCredential(service: "fish-audio", field: "api_key")
+        Task {
+            let deleted = await APIKeyManager.deleteCredential(service: "fish-audio", field: "api_key")
+            if !deleted { addDeletionTombstone(type: "credential", name: "fish-audio:api_key") }
+        }
+    }
+
     func clearAPIKeyForProvider(_ provider: String) {
         APIKeyManager.deleteKey(for: provider)
         scheduleRoutingSourceRefresh()


### PR DESCRIPTION
## Summary
- Add saveFishAudioKey method using APIKeyManager.setCredential to store at credential/fish-audio/api_key
- Add clearFishAudioKey method using APIKeyManager.deleteCredential
- Both methods follow the same error handling and tombstone patterns as ElevenLabs

Part of plan: tts-setup-flow-unification.md (PR 2 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24947" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
