### PR TITLE
fix(macos): stabilize skill detail navigation for search results

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -14,6 +14,7 @@ struct AgentPanelContent: View {
 
     @State private var skillsManager: SkillsManager
     @State private var selectedSkillId: String?
+    @State private var cachedSelectedSkill: SkillInfo?
     @State private var skillToDelete: SkillInfo?
     @AppStorage("skillsBannerDismissed") private var bannerDismissed = false
 
@@ -96,6 +97,7 @@ struct AgentPanelContent: View {
             onSkillsChanged?()
             if let selectedId = selectedSkillId,
                skillsManager.installingSkillId != selectedId,
+               cachedSelectedSkill == nil,
                !skillsManager.skills.contains(where: { $0.id == selectedId }) {
                 selectedSkillId = nil
             }
@@ -110,6 +112,7 @@ struct AgentPanelContent: View {
             // from the unfiltered `skills` list (and not mid-install).
             if let selectedId = selectedSkillId,
                skillsManager.installingSkillId != selectedId,
+               cachedSelectedSkill == nil,
                !skillsManager.skills.contains(where: { $0.id == selectedId }) {
                 selectedSkillId = nil
             }
@@ -120,6 +123,8 @@ struct AgentPanelContent: View {
                 onDelete: {
                     skillsManager.uninstallSkill(id: skill.id)
                     skillToDelete = nil
+                    cachedSelectedSkill = nil
+                    selectedSkillId = nil
                 },
                 onCancel: {
                     skillToDelete = nil
@@ -247,17 +252,22 @@ struct AgentPanelContent: View {
         // Fall back to the unfiltered `skills` list so a detail view that
         // would otherwise be hidden by the active filter (e.g. a just-
         // installed skill viewed under the `.available` filter) still
-        // renders. Pair with `.id(skill.id)` so SwiftUI creates a fresh
+        // renders. Finally fall back to the cached snapshot taken when
+        // the user clicked into the detail, so a transient search
+        // refresh doesn't dismiss the detail view.
+        // Pair with `.id(skill.id)` so SwiftUI creates a fresh
         // view instance when the selected skill changes.
         if let selectedId = selectedSkillId,
            let skill = skillsManager.filteredSkills.first(where: { $0.id == selectedId })
-            ?? skillsManager.skills.first(where: { $0.id == selectedId }) {
+            ?? skillsManager.skills.first(where: { $0.id == selectedId })
+            ?? cachedSelectedSkill {
             SkillDetailView(
                 skill: skill,
                 skillsManager: skillsManager,
                 onBack: {
                     withAnimation(VAnimation.standard) {
                         selectedSkillId = nil
+                        cachedSelectedSkill = nil
                     }
                 },
                 onDelete: { skill in
@@ -294,6 +304,7 @@ struct AgentPanelContent: View {
                                 skill: skill,
                                 onSelect: {
                                     withAnimation(VAnimation.fast) {
+                                        cachedSelectedSkill = skill
                                         selectedSkillId = skill.id
                                     }
                                 },
@@ -305,6 +316,7 @@ struct AgentPanelContent: View {
                                 skill: skill,
                                 onSelect: {
                                     withAnimation(VAnimation.fast) {
+                                        cachedSelectedSkill = skill
                                         selectedSkillId = skill.id
                                     }
                                 },

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
@@ -121,9 +121,15 @@ final class SkillsManager {
 
                 // Merge local skills with external search results (if any),
                 // deduplicating by skill id so local entries take precedence.
+                // The merge is kept active while `isSearching` so that skills
+                // from the previous search remain visible (e.g. when a user
+                // clicks into a search result's detail view while a re-search
+                // is in progress). `searchResults` is only cleared on query
+                // changes (via `cancelSearch`), so stale cross-query results
+                // are already handled.
                 let localSkills = self.skillsStore.skills
                 let mergedSkills: [SkillInfo]
-                if hasActiveQuery && !self.skillsStore.searchResults.isEmpty && !self.skillsStore.isSearching {
+                if hasActiveQuery && !self.skillsStore.searchResults.isEmpty {
                     let localIds = Set(localSkills.map(\.id))
                     let externalResults = self.skillsStore.searchResults.filter { !localIds.contains($0.id) }
                     mergedSkills = localSkills + externalResults

--- a/clients/shared/Network/GatewayHTTPClient.swift
+++ b/clients/shared/Network/GatewayHTTPClient.swift
@@ -637,6 +637,15 @@ public enum GatewayHTTPClient {
         return cs
     }()
 
+    /// URL-path character set that preserves already-encoded percent sequences.
+    /// `.urlPathAllowed` excludes `%`, which causes pre-encoded path components
+    /// (e.g. `%2F` for skill slugs containing `/`) to be double-encoded as `%252F`.
+    private static let urlPathPreservingEncoded: CharacterSet = {
+        var cs = CharacterSet.urlPathAllowed
+        cs.insert("%")
+        return cs
+    }()
+
     /// Returns `true` when the current connection targets a managed (cloud-hosted)
     /// assistant that routes through the platform proxy, `false` otherwise.
     ///
@@ -768,7 +777,7 @@ public enum GatewayHTTPClient {
             }
         }
 
-        let encodedPath = pathComponent.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? pathComponent
+        let encodedPath = pathComponent.addingPercentEncoding(withAllowedCharacters: Self.urlPathPreservingEncoded) ?? pathComponent
         let trailingSlash = encodedPath.hasSuffix("/") ? "" : "/"
         guard let url = URL(string: "\(connection.baseURL)/v1/\(encodedPath)\(trailingSlash)\(queryString)") else {
             throw ClientError.invalidURL

--- a/clients/shared/Network/SkillsClient.swift
+++ b/clients/shared/Network/SkillsClient.swift
@@ -291,8 +291,12 @@ public struct SkillsClient: SkillsClientProtocol {
                 return nil
             }
             return try JSONDecoder().decode(SkillDetailHTTPResponse.self, from: skillData)
+        } catch is CancellationError {
+            return nil
+        } catch let urlError as URLError where urlError.code == .cancelled {
+            return nil
         } catch {
-            log.error("fetchSkillDetail error: \(error.localizedDescription)")
+            log.error("fetchSkillDetail error: \(error, privacy: .public)")
             return nil
         }
     }
@@ -307,8 +311,12 @@ public struct SkillsClient: SkillsClientProtocol {
                 return nil
             }
             return try JSONDecoder().decode(SkillDetailFilesHTTPResponse.self, from: response.data)
+        } catch is CancellationError {
+            return nil
+        } catch let urlError as URLError where urlError.code == .cancelled {
+            return nil
         } catch {
-            log.error("fetchSkillFiles error: \(error.localizedDescription)")
+            log.error("fetchSkillFiles error: \(error, privacy: .public)")
             return nil
         }
     }
@@ -325,8 +333,12 @@ public struct SkillsClient: SkillsClientProtocol {
                 return nil
             }
             return try JSONDecoder().decode(SkillFileContentResponse.self, from: response.data)
+        } catch is CancellationError {
+            return nil
+        } catch let urlError as URLError where urlError.code == .cancelled {
+            return nil
         } catch {
-            log.error("fetchSkillFileContent error: \(error.localizedDescription)")
+            log.error("fetchSkillFileContent error: \(error, privacy: .public)")
             return nil
         }
     }


### PR DESCRIPTION
## Summary
- Fix double URL-encoding of skill slugs containing `/` (e.g. skills.sh `owner/repo/skill`) — `%2F` was re-encoded to `%252F` by `GatewayHTTPClient.constructURL()`
- Prevent task cancellation from showing as a user-facing error when `fetchSkillFiles` is called multiple times in quick succession
- Keep external search results in the merged skills list during re-search, and cache the selected skill object so the detail view isn't dismissed by transient search refreshes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24948" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
