### PR TITLE
Use provider catalog for voice settings tool provider validation and copy

### DIFF
--- a/assistant/src/__tests__/voice-config-update.test.ts
+++ b/assistant/src/__tests__/voice-config-update.test.ts
@@ -46,6 +46,7 @@ mock.module("../util/logger.js", () => ({
 import { run } from "../config/bundled-skills/settings/tools/voice-config-update.js";
 import { invalidateConfigCache } from "../config/loader.js";
 import type { ToolContext } from "../tools/types.js";
+import { listCatalogProviderIds } from "../tts/provider-catalog.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -309,5 +310,59 @@ describe("voice_config_update — validation", () => {
     );
     expect(result.isError).toBe(true);
     expect(result.content).toContain("Unknown setting");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: catalog-driven provider validation
+// ---------------------------------------------------------------------------
+
+describe("voice_config_update — catalog-driven provider validation", () => {
+  test("accepts every provider ID in the catalog", async () => {
+    const catalogIds = listCatalogProviderIds();
+    expect(catalogIds.length).toBeGreaterThanOrEqual(1);
+
+    for (const id of catalogIds) {
+      writeConfig({});
+      invalidateConfigCache();
+
+      const result = await run(
+        { setting: "tts_provider", value: id },
+        makeContext(),
+      );
+
+      expect(result.isError).toBe(false);
+      expect(result.content).toContain("updated to");
+    }
+  });
+
+  test("rejects provider IDs not in the catalog", async () => {
+    const bogusIds = ["nonexistent-provider", "google-tts", "amazon-polly", ""];
+
+    for (const id of bogusIds) {
+      writeConfig({});
+      invalidateConfigCache();
+
+      const result = await run(
+        { setting: "tts_provider", value: id },
+        makeContext(),
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("tts_provider must be one of");
+    }
+  });
+
+  test("error message lists all catalog provider IDs", async () => {
+    const catalogIds = listCatalogProviderIds();
+    const result = await run(
+      { setting: "tts_provider", value: "bogus" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(true);
+    for (const id of catalogIds) {
+      expect(result.content).toContain(id);
+    }
   });
 });

--- a/assistant/src/config/bundled-skills/settings/TOOLS.json
+++ b/assistant/src/config/bundled-skills/settings/TOOLS.json
@@ -3,7 +3,7 @@
   "tools": [
     {
       "name": "voice_config_update",
-      "description": "Update a voice configuration setting. Use tts_provider to switch the global TTS provider (elevenlabs or fish-audio). Use tts_voice_id to set the ElevenLabs voice ID, fish_audio_reference_id for Fish Audio voice reference. Changes persist to services.tts config and take effect immediately.",
+      "description": "Update a voice configuration setting. Use tts_provider to switch the global TTS provider (valid providers are defined by the provider catalog). Use tts_voice_id to set the ElevenLabs voice ID, fish_audio_reference_id for Fish Audio voice reference. Changes persist to services.tts config and take effect immediately.",
       "category": "system",
       "risk": "low",
       "input_schema": {
@@ -18,10 +18,10 @@
               "tts_provider",
               "tts_voice_id"
             ],
-            "description": "The voice setting to change. tts_provider selects the global TTS provider used for all speech features. tts_voice_id sets the ElevenLabs voice. fish_audio_reference_id sets the Fish Audio voice reference."
+            "description": "The voice setting to change. tts_provider selects the global TTS provider from the provider catalog. tts_voice_id sets the ElevenLabs voice. fish_audio_reference_id sets the Fish Audio voice reference."
           },
           "value": {
-            "description": "The new value for the setting. For tts_provider: 'elevenlabs' or 'fish-audio'. For tts_voice_id: an alphanumeric ElevenLabs voice ID. For fish_audio_reference_id: a Fish Audio voice reference ID. For conversation_timeout: seconds (5, 10, 15, 30, or 60). For activation_key: key identifier string."
+            "description": "The new value for the setting. For tts_provider: a valid provider ID from the provider catalog. For tts_voice_id: an alphanumeric ElevenLabs voice ID. For fish_audio_reference_id: a Fish Audio voice reference ID. For conversation_timeout: seconds (5, 10, 15, 30, or 60). For activation_key: key identifier string."
           },
           "activity": {
             "type": "string",

--- a/assistant/src/config/bundled-skills/settings/tools/voice-config-update.ts
+++ b/assistant/src/config/bundled-skills/settings/tools/voice-config-update.ts
@@ -5,12 +5,12 @@ import {
   setNestedValue,
 } from "../../../../config/loader.js";
 import { VALID_CONVERSATION_TIMEOUTS } from "../../../../config/schemas/elevenlabs.js";
-import { VALID_TTS_PROVIDERS } from "../../../../config/schemas/tts.js";
 import { normalizeActivationKey } from "../../../../daemon/handlers/config-voice.js";
 import type {
   ToolContext,
   ToolExecutionResult,
 } from "../../../../tools/types.js";
+import { listCatalogProviderIds } from "../../../../tts/provider-catalog.js";
 
 /**
  * Valid voice config settings and their UserDefaults key mappings.
@@ -108,11 +108,11 @@ function validateSetting(
       return { ok: true, coerced: trimmed };
     }
     case "tts_provider": {
-      const valid: readonly string[] = VALID_TTS_PROVIDERS;
-      if (typeof value !== "string" || !valid.includes(value.trim())) {
+      const catalogIds = listCatalogProviderIds();
+      if (typeof value !== "string" || !catalogIds.includes(value.trim())) {
         return {
           ok: false,
-          error: `tts_provider must be one of: ${valid.join(", ")}`,
+          error: `tts_provider must be one of: ${catalogIds.join(", ")}`,
         };
       }
       return { ok: true, coerced: value.trim() };


### PR DESCRIPTION
## Summary
- Replaces hardcoded provider-value checks with catalog-derived provider IDs
- Updates TOOLS.json descriptions for catalog-driven provider selection
- Keeps canonical config write paths unchanged
- Extends tests to verify catalog-driven validation

Part of plan: tts-provider-onboarding-unification.md (PR 7 of 11)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24949" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
