### PR TITLE
feat(settings): add ElevenLabs Voice ID input field to TTS settings

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -2936,6 +2936,18 @@ public final class SettingsStore: ObservableObject {
         return task
     }
 
+    func setElevenLabsVoiceId(_ voiceId: String) {
+        Task {
+            let trimmed = voiceId.trimmingCharacters(in: .whitespacesAndNewlines)
+            let success = await settingsClient.patchConfig([
+                "services": ["tts": ["providers": ["elevenlabs": ["voiceId": trimmed]]]]
+            ])
+            if !success {
+                log.error("Failed to patch config for ElevenLabs voice ID")
+            }
+        }
+    }
+
     /// Schedules a delayed refresh of provider routing sources, giving the
     /// daemon time to re-initialize providers after a key change.
     private func scheduleRoutingSourceRefresh() {

--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -33,6 +33,7 @@ struct VoiceSettingsView: View {
     @AppStorage("ttsProvider") private var ttsProviderRaw: String = TTSProviderOption.elevenlabs.rawValue
 
     @State private var elevenLabsKeyText: String = ""
+    @State private var elevenLabsVoiceId: String = ""
     @State private var ttsSetupExpanded: Bool = false
     /// Whether an ElevenLabs API key is stored (fetched per-component).
     @State private var elevenLabsHasKey = false
@@ -388,6 +389,22 @@ struct VoiceSettingsView: View {
                         elevenLabsKeyText = ""
                         ttsSetupExpanded = false
                     }
+                }
+
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    VTextField(
+                        "Voice ID",
+                        placeholder: "ElevenLabs Voice ID (optional)",
+                        text: $elevenLabsVoiceId,
+                        onSubmit: {
+                            store.setElevenLabsVoiceId(elevenLabsVoiceId)
+                        },
+                        maxWidth: 400
+                    )
+
+                    Text("Leave blank to use the default voice. Find voice IDs at elevenlabs.io/voice-library.")
+                        .font(VFont.labelDefault)
+                        .foregroundStyle(VColor.contentTertiary)
                 }
             } else if ttsSetupExpanded {
                 VStack(alignment: .leading, spacing: VSpacing.sm) {


### PR DESCRIPTION
## Summary
- Add Voice ID text field to ElevenLabs provider config section (visible when connected)
- Add setElevenLabsVoiceId method to SettingsStore for config patch persistence
- Voice ID saved to services.tts.providers.elevenlabs.voiceId on Enter

Part of plan: tts-setup-flow-unification.md (PR 1 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24950" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
