### PR TITLE
Replace iOS hardcoded TTS provider enum with shared registry

### DIFF
--- a/clients/ios/Tests/TTSProviderRegistryIOSTests.swift
+++ b/clients/ios/Tests/TTSProviderRegistryIOSTests.swift
@@ -1,0 +1,86 @@
+#if canImport(UIKit)
+import XCTest
+
+@testable import VellumAssistantShared
+
+/// Tests verifying that the iOS TTS provider selector works correctly
+/// with the shared ``TTSProviderRegistry``.
+final class TTSProviderRegistryIOSTests: XCTestCase {
+
+    // MARK: - Registry Loading
+
+    func testRegistryLoadsNonEmptyProviderList() {
+        let registry = loadTTSProviderRegistry()
+        XCTAssertFalse(registry.providers.isEmpty, "Registry should contain at least one provider")
+    }
+
+    func testRegistryContainsElevenLabs() {
+        let registry = loadTTSProviderRegistry()
+        let entry = registry.provider(withId: "elevenlabs")
+        XCTAssertNotNil(entry, "Registry should contain an 'elevenlabs' provider")
+        XCTAssertEqual(entry?.displayName, "ElevenLabs")
+    }
+
+    // MARK: - Provider Lookup and Fallback
+
+    func testProviderLookupReturnsMatchingEntry() {
+        let registry = loadTTSProviderRegistry()
+        for provider in registry.providers {
+            let found = registry.provider(withId: provider.id)
+            XCTAssertNotNil(found, "Lookup should find provider with id '\(provider.id)'")
+            XCTAssertEqual(found?.id, provider.id)
+        }
+    }
+
+    func testProviderLookupReturnsNilForUnknownId() {
+        let registry = loadTTSProviderRegistry()
+        let result = registry.provider(withId: "nonexistent-provider-id")
+        XCTAssertNil(result, "Lookup should return nil for unknown provider IDs")
+    }
+
+    func testFallbackToFirstProviderForUnknownPersistedValue() {
+        let registry = loadTTSProviderRegistry()
+        // Simulate the fallback logic used in VoiceSettingsSection:
+        // registry.provider(withId: raw) ?? registry.providers.first
+        let unknownRaw = "deleted-provider"
+        let resolved = registry.provider(withId: unknownRaw) ?? registry.providers.first
+        XCTAssertNotNil(resolved, "Fallback should resolve to the first registry provider")
+        XCTAssertEqual(resolved?.id, registry.providers.first?.id)
+    }
+
+    // MARK: - API Key Provider Derivation
+
+    func testAPIKeyProvidersFilteredBySetupMode() {
+        let registry = loadTTSProviderRegistry()
+        let apiKeyProviders = registry.providers.filter { $0.setupMode == .apiKey }
+        // At minimum, ElevenLabs has setupMode == .apiKey in the catalog
+        XCTAssertFalse(apiKeyProviders.isEmpty, "At least one provider should have apiKey setup mode")
+        XCTAssertTrue(
+            apiKeyProviders.contains { $0.id == "elevenlabs" },
+            "ElevenLabs should have apiKey setup mode"
+        )
+    }
+
+    func testCLIProvidersExcludedFromAPIKeyList() {
+        let registry = loadTTSProviderRegistry()
+        let cliProviders = registry.providers.filter { $0.setupMode == .cli }
+        let apiKeyProviders = registry.providers.filter { $0.setupMode == .apiKey }
+        // CLI providers should not appear in the api-key filtered list
+        for cliProvider in cliProviders {
+            XCTAssertFalse(
+                apiKeyProviders.contains { $0.id == cliProvider.id },
+                "CLI provider '\(cliProvider.id)' should not appear in apiKey-filtered list"
+            )
+        }
+    }
+
+    // MARK: - Default Provider Selection
+
+    func testDefaultProviderIdMatchesRegistryEntry() {
+        let registry = loadTTSProviderRegistry()
+        let defaultId = "elevenlabs" // matches the @AppStorage default in VoiceSettingsSection
+        let entry = registry.provider(withId: defaultId)
+        XCTAssertNotNil(entry, "Default provider ID '\(defaultId)' should exist in the registry")
+    }
+}
+#endif

--- a/clients/ios/Views/Settings/ModelsServicesSection.swift
+++ b/clients/ios/Views/Settings/ModelsServicesSection.swift
@@ -3,6 +3,10 @@ import SwiftUI
 import VellumAssistantShared
 
 /// Settings section for managing API keys and the active LLM model.
+///
+/// TTS-related API key providers are derived from the shared
+/// ``TTSProviderRegistry`` so that new providers with `apiKey` setup
+/// mode are surfaced automatically without code changes.
 struct ModelsServicesSection: View {
     @EnvironmentObject var clientProvider: ClientProvider
     @State private var currentModel: String?
@@ -10,11 +14,22 @@ struct ModelsServicesSection: View {
     @State private var selectedProvider: APIKeyProvider?
     @State private var loading = false
 
-    /// The two API key providers currently supported by `APIKeyManager`.
-    private let providers: [APIKeyProvider] = [
-        APIKeyProvider(id: "anthropic", displayName: "Claude (Anthropic)"),
-        APIKeyProvider(id: "elevenlabs", displayName: "ElevenLabs"),
-    ]
+    /// API key providers shown in the settings list.
+    ///
+    /// Static entries (e.g. Claude/Anthropic) are listed first, followed
+    /// by TTS providers whose ``TTSProviderSetupMode`` is `.apiKey` —
+    /// pulled from the shared registry so new providers appear without
+    /// adding enum cases.
+    private let providers: [APIKeyProvider] = {
+        var list: [APIKeyProvider] = [
+            APIKeyProvider(id: "anthropic", displayName: "Claude (Anthropic)"),
+        ]
+        let registry = loadTTSProviderRegistry()
+        for entry in registry.providers where entry.setupMode == .apiKey {
+            list.append(APIKeyProvider(id: entry.id, displayName: entry.displayName))
+        }
+        return list
+    }()
 
     var body: some View {
         Form {

--- a/clients/ios/Views/Settings/VoiceSettingsSection.swift
+++ b/clients/ios/Views/Settings/VoiceSettingsSection.swift
@@ -2,33 +2,12 @@
 import SwiftUI
 import VellumAssistantShared
 
-/// TTS provider options for the unified global provider selector.
-/// The selected provider is used for all speech features — voice conversations
-/// and read-aloud. Provider-specific configuration (API keys, voice IDs)
-/// is managed through the assistant's settings tools.
-enum TTSProvider: String, CaseIterable {
-    case elevenlabs = "elevenlabs"
-    case fishAudio = "fish-audio"
-
-    var displayName: String {
-        switch self {
-        case .elevenlabs: return "ElevenLabs"
-        case .fishAudio: return "Fish Audio"
-        }
-    }
-
-    var footerText: String {
-        switch self {
-        case .elevenlabs:
-            return "ElevenLabs provides high-quality voice synthesis. Requires an API key — configure via the assistant's voice settings on your Mac."
-        case .fishAudio:
-            return "Fish Audio provides natural-sounding voice synthesis with custom voice cloning. Requires an API key and voice reference ID — configure via the assistant's voice settings on your Mac."
-        }
-    }
-}
-
 /// Voice mode settings — listening timeout, TTS provider, and silence detection
 /// threshold. These mirror the equivalent options available on macOS.
+///
+/// The TTS provider picker is registry-driven: providers are loaded from
+/// the shared ``TTSProviderRegistry`` so that new providers can be surfaced
+/// without adding new enum cases in iOS settings code.
 struct VoiceSettingsSection: View {
     /// Seconds of silence that trigger end-of-speech detection. iOS SFSpeechRecognizer
     /// does not have a built-in silence threshold API, so this value controls how long
@@ -41,11 +20,18 @@ struct VoiceSettingsSection: View {
     /// Range 5 – 60 s.
     @AppStorage(UserDefaultsKeys.voiceListeningTimeout) private var listeningTimeout: Double = 30.0
 
-    /// Global TTS provider used for all speech features.
-    @AppStorage(UserDefaultsKeys.voiceTTSProvider) private var ttsProviderRaw: String = TTSProvider.elevenlabs.rawValue
+    /// Global TTS provider used for all speech features. Persisted as the
+    /// provider's string identifier (e.g. `"elevenlabs"`, `"fish-audio"`).
+    @AppStorage(UserDefaultsKeys.voiceTTSProvider) private var ttsProviderRaw: String = "elevenlabs"
 
-    private var ttsProvider: TTSProvider {
-        TTSProvider(rawValue: ttsProviderRaw) ?? .elevenlabs
+    /// Registry loaded once from the bundled catalog JSON.
+    private let registry = loadTTSProviderRegistry()
+
+    /// Resolved catalog entry for the currently selected provider.
+    /// Falls back to the first provider in the registry if the persisted
+    /// value does not match any known entry.
+    private var selectedProvider: TTSProviderCatalogEntry? {
+        registry.provider(withId: ttsProviderRaw) ?? registry.providers.first
     }
 
     var body: some View {
@@ -94,15 +80,17 @@ struct VoiceSettingsSection: View {
 
             Section {
                 Picker("TTS Provider", selection: $ttsProviderRaw) {
-                    ForEach(TTSProvider.allCases, id: \.rawValue) { provider in
-                        Text(provider.displayName).tag(provider.rawValue)
+                    ForEach(registry.providers, id: \.id) { provider in
+                        Text(provider.displayName).tag(provider.id)
                     }
                 }
                 .pickerStyle(.navigationLink)
             } header: {
                 Text("Text-to-Speech")
             } footer: {
-                Text(ttsProvider.footerText)
+                if let provider = selectedProvider {
+                    Text(provider.subtitle)
+                }
             }
         }
         .navigationTitle("Voice")


### PR DESCRIPTION
## Summary
- Replaces hardcoded iOS TTSProvider enum with registry-backed provider model
- Updates models/services provider list to use shared metadata
- Keeps TTS network routing unchanged
- Ensures UI selection still writes voiceTTSProvider defaults

Part of plan: tts-provider-onboarding-unification.md (PR 10 of 11)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24951" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
