### PR TITLE
fix: use credential path for ElevenLabs API key

### DIFF
--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -26,7 +26,6 @@ export const API_KEY_PROVIDERS = [
   "fireworks",
   "openrouter",
   "brave",
-  "elevenlabs",
   "perplexity",
 ] as const;
 

--- a/assistant/src/tts/providers/elevenlabs-provider.ts
+++ b/assistant/src/tts/providers/elevenlabs-provider.ts
@@ -3,13 +3,14 @@
  *
  * Wraps the ElevenLabs REST text-to-speech API (`/v1/text-to-speech/:voiceId`)
  * behind the uniform {@link TtsProvider} interface. Reads the API key from the
- * secure credential store and the voice configuration
+ * secure credential store (`elevenlabs/api_key`) and the voice configuration
  * from `services.tts.providers.elevenlabs` config section.
  */
 
 import { getConfig } from "../../config/loader.js";
 import { DEFAULT_ELEVENLABS_VOICE_ID } from "../../config/schemas/elevenlabs.js";
 import type { TtsElevenLabsProviderConfig } from "../../config/schemas/tts.js";
+import { credentialKey } from "../../security/credential-key.js";
 import { getSecureKeyAsync } from "../../security/secure-keys.js";
 import { getLogger } from "../../util/logger.js";
 import type {
@@ -113,12 +114,14 @@ export function createElevenLabsProvider(): TtsProvider {
     async synthesize(
       request: TtsSynthesisRequest,
     ): Promise<TtsSynthesisResult> {
-      const apiKey = await getSecureKeyAsync("elevenlabs");
+      const apiKey = await getSecureKeyAsync(
+        credentialKey("elevenlabs", "api_key"),
+      );
       if (!apiKey) {
         throw new ElevenLabsTtsError(
           "ELEVENLABS_TTS_NO_API_KEY",
           "ElevenLabs API key not configured. " +
-            "Add it in Settings → Voice or via: vellum keys set elevenlabs <key>",
+            "Add it in Settings → Voice or via: assistant credentials set --service elevenlabs --field api_key <key>",
         );
       }
 

--- a/clients/macos/vellum-assistant/App/APIKeyManager.swift
+++ b/clients/macos/vellum-assistant/App/APIKeyManager.swift
@@ -37,7 +37,6 @@ enum APIKeyManager {
     static let allSyncableProviders = [
         "anthropic",
         "brave",
-        "elevenlabs",
         "fireworks",
         "gemini",
         "openai",
@@ -63,7 +62,32 @@ enum APIKeyManager {
         for provider in allSyncableProviders {
             migrateProviderFromUserDefaults(provider)
         }
-        migrateProviderFromUserDefaults("elevenlabs")
+        migrateElevenLabsToCredential()
+    }
+
+    /// Migrate ElevenLabs key from api_key storage to credential storage.
+    /// Handles keys stored in UserDefaults or FileCredentialStorage under the
+    /// old `vellum_provider_elevenlabs` account.
+    private static func migrateElevenLabsToCredential() {
+        let oldAccount = udPrefix + "elevenlabs"
+        let newAccount = credentialPrefix + "elevenlabs:api_key"
+
+        // First migrate from UserDefaults if present
+        if let udValue = UserDefaults.standard.string(forKey: oldAccount), !udValue.isEmpty {
+            if storage.get(account: newAccount) == nil {
+                guard storage.set(account: newAccount, value: udValue) else { return }
+            }
+            UserDefaults.standard.removeObject(forKey: oldAccount)
+            _ = storage.delete(account: oldAccount)
+            return
+        }
+
+        // Then migrate from old FileCredentialStorage format
+        if let oldValue = storage.get(account: oldAccount),
+           storage.get(account: newAccount) == nil {
+            guard storage.set(account: newAccount, value: oldValue) else { return }
+        }
+        _ = storage.delete(account: oldAccount)
     }
 
     /// Migrate a single provider's key from UserDefaults to credential storage.

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -872,10 +872,10 @@ public final class SettingsStore: ObservableObject {
     func saveElevenLabsKey(_ raw: String, onSuccess: (() -> Void)? = nil) {
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
-        APIKeyManager.setKey(trimmed, for: "elevenlabs")
-        removeDeletionTombstone(type: "api_key", name: "elevenlabs")
+        APIKeyManager.setCredential(trimmed, service: "elevenlabs", field: "api_key")
+        removeDeletionTombstone(type: "credential", name: "elevenlabs:api_key")
         Task {
-            let result = await APIKeyManager.setKey(trimmed, for: "elevenlabs")
+            let result = await APIKeyManager.setCredential(trimmed, service: "elevenlabs", field: "api_key")
             if result.success {
                 onSuccess?()
             } else if let error = result.error {
@@ -885,10 +885,10 @@ public final class SettingsStore: ObservableObject {
     }
 
     func clearElevenLabsKey() {
-        APIKeyManager.deleteKey(for: "elevenlabs")
+        APIKeyManager.deleteCredential(service: "elevenlabs", field: "api_key")
         Task {
-            let deleted = await APIKeyManager.deleteKey(for: "elevenlabs")
-            if !deleted { addDeletionTombstone(type: "api_key", name: "elevenlabs") }
+            let deleted = await APIKeyManager.deleteCredential(service: "elevenlabs", field: "api_key")
+            if !deleted { addDeletionTombstone(type: "credential", name: "elevenlabs:api_key") }
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -73,7 +73,7 @@ struct VoiceSettingsView: View {
             stopRecordingCustomKey()
         }
         .onAppear {
-            elevenLabsHasKey = APIKeyManager.getKey(for: "elevenlabs") != nil
+            elevenLabsHasKey = APIKeyManager.getCredential(service: "elevenlabs", field: "api_key") != nil
         }
         .onChange(of: conversationTimeoutSeconds) {
             VoiceModeManager.conversationTimeoutOverride = conversationTimeoutSeconds


### PR DESCRIPTION
## Summary
- Revert the ElevenLabs workaround from #24827 now that APIKeyManager supports credentials (#24942)
- Remove `elevenlabs` from `API_KEY_PROVIDERS` on the server and switch the provider back to reading from `credentialKey("elevenlabs", "api_key")`
- Update macOS client `SettingsStore` and `VoiceSettingsView` to use credential methods (`setCredential`/`getCredential`/`deleteCredential`) for ElevenLabs keys
- Add one-time migration from old `vellum_provider_elevenlabs` storage format to new `vellum_credential_elevenlabs:api_key` format
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24953" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
