### PR TITLE
Use explicit provider call strategy for Twilio voice profile resolution

### DIFF
--- a/assistant/src/__tests__/voice-quality.test.ts
+++ b/assistant/src/__tests__/voice-quality.test.ts
@@ -29,42 +29,37 @@ mock.module("../config/loader.js", () => ({
   loadConfig: () => mockConfig,
 }));
 
-// -- TTS registry setup ---------------------------------------------------
+// -- Call strategy voice-spec registry setup --------------------------------
 
 import {
-  _resetTtsProviderRegistry,
-  registerTtsProvider,
-} from "../tts/provider-registry.js";
-import type { TtsProvider } from "../tts/types.js";
+  _resetNativeTwilioVoiceSpecRegistry,
+  registerNativeTwilioVoiceSpec,
+} from "../calls/tts-call-strategy.js";
 
-function registerTestProviders(): void {
-  _resetTtsProviderRegistry();
+function registerTestVoiceSpecs(): void {
+  _resetNativeTwilioVoiceSpecRegistry();
 
-  // ElevenLabs: native provider (no streaming)
-  const elevenlabs: TtsProvider = {
-    id: "elevenlabs",
-    capabilities: { supportsStreaming: false, supportedFormats: ["mp3"] },
-    async synthesize() {
-      return { audio: Buffer.from(""), contentType: "audio/mpeg" };
+  // Register the ElevenLabs native Twilio voice-spec builder (mirrors
+  // the production registration in register-builtins.ts).
+  registerNativeTwilioVoiceSpec("elevenlabs", {
+    twilioProviderName: "ElevenLabs",
+    buildVoiceSpec: (providerConfig) => {
+      const cfg = providerConfig as {
+        voiceId?: string;
+        voiceModelId?: string;
+        speed?: number;
+        stability?: number;
+        similarityBoost?: number;
+      };
+      return buildElevenLabsVoiceSpec({
+        voiceId: cfg.voiceId ?? "",
+        voiceModelId: cfg.voiceModelId,
+        speed: cfg.speed,
+        stability: cfg.stability,
+        similarityBoost: cfg.similarityBoost,
+      });
     },
-  };
-  registerTtsProvider(elevenlabs);
-
-  // Fish Audio: synthesized provider (streaming)
-  const fishAudio: TtsProvider = {
-    id: "fish-audio",
-    capabilities: {
-      supportsStreaming: true,
-      supportedFormats: ["mp3", "wav", "opus"],
-    },
-    async synthesize() {
-      return { audio: Buffer.from(""), contentType: "audio/mpeg" };
-    },
-    async synthesizeStream(_req, _onChunk) {
-      return { audio: Buffer.from(""), contentType: "audio/mpeg" };
-    },
-  };
-  registerTtsProvider(fishAudio);
+  });
 }
 
 // -- Import subjects after mocks ------------------------------------------
@@ -130,12 +125,12 @@ describe("buildElevenLabsVoiceSpec", () => {
 
 describe("resolveVoiceQualityProfile", () => {
   beforeEach(() => {
-    registerTestProviders();
+    registerTestVoiceSpecs();
   });
 
-  // -- Native provider path (ElevenLabs) ----------------------------------
+  // -- Explicit strategy: native-twilio (ElevenLabs) ----------------------
 
-  test("returns ElevenLabs ttsProvider for native provider", () => {
+  test("uses catalog callMode to select native-twilio path for ElevenLabs", () => {
     mockConfig = {
       calls: {
         voice: {
@@ -157,7 +152,7 @@ describe("resolveVoiceQualityProfile", () => {
     expect(profile.ttsProvider).toBe("ElevenLabs");
   });
 
-  test("voice ID comes from services.tts.providers.elevenlabs.voiceId", () => {
+  test("voice spec comes from registered NativeTwilioVoiceSpec builder", () => {
     mockConfig = {
       calls: {
         voice: {
@@ -201,7 +196,7 @@ describe("resolveVoiceQualityProfile", () => {
     expect(profile.language).toBe("es-MX");
   });
 
-  test("builds voice spec with model and tuning params", () => {
+  test("builds voice spec with model and tuning params via builder", () => {
     mockConfig = {
       calls: {
         voice: {
@@ -319,9 +314,9 @@ describe("resolveVoiceQualityProfile", () => {
     expect(profile.hints).toEqual(["Vellum", "Nova", "AI assistant"]);
   });
 
-  // -- Synthesized provider path (Fish Audio) -----------------------------
+  // -- Explicit strategy: synthesized-play (Fish Audio) -------------------
 
-  test("returns Google placeholder ttsProvider for synthesized provider (Fish Audio)", () => {
+  test("uses catalog callMode to select synthesized-play path for Fish Audio", () => {
     mockConfig = {
       calls: {
         voice: {
@@ -393,5 +388,117 @@ describe("resolveVoiceQualityProfile", () => {
     // Should resolve to fish-audio from canonical config
     expect(profile.ttsProvider).toBe("Google");
     expect(profile.voice).toBe("");
+  });
+
+  // -- Strategy-based behavior (explicit call strategy) -------------------
+
+  test("strategy selects path from catalog callMode, not supportsStreaming", () => {
+    // The catalog declares fish-audio as synthesized-play via callMode,
+    // regardless of its supportsStreaming capability. This test verifies
+    // call-path selection is driven by explicit catalog metadata.
+    mockConfig = {
+      calls: {
+        voice: {
+          language: "en-US",
+          transcriptionProvider: "Deepgram",
+        },
+      },
+      services: {
+        tts: {
+          provider: "fish-audio",
+          providers: {
+            elevenlabs: { voiceId: DEFAULT_ELEVENLABS_VOICE_ID },
+            "fish-audio": { referenceId: "ref-abc" },
+          },
+        },
+      },
+    };
+    const profile = resolveVoiceQualityProfile();
+    expect(profile.ttsProvider).toBe("Google");
+    expect(profile.voice).toBe("");
+  });
+
+  test("native-twilio strategy delegates voice-spec to registered builder", () => {
+    // The catalog declares elevenlabs as native-twilio. The voice spec
+    // is built by the registered NativeTwilioVoiceSpec builder, not by
+    // hardcoded branching in resolveVoiceQualityProfile.
+    mockConfig = {
+      calls: {
+        voice: {
+          language: "en-US",
+          transcriptionProvider: "Deepgram",
+        },
+      },
+      services: {
+        tts: {
+          provider: "elevenlabs",
+          providers: {
+            elevenlabs: {
+              voiceId: "test-voice",
+              voiceModelId: "model-x",
+              speed: 1.1,
+              stability: 0.6,
+              similarityBoost: 0.8,
+            },
+            "fish-audio": { referenceId: "" },
+          },
+        },
+      },
+    };
+    const profile = resolveVoiceQualityProfile();
+    expect(profile.ttsProvider).toBe("ElevenLabs");
+    expect(profile.voice).toBe("test-voice-model-x-1.1_0.6_0.8");
+  });
+
+  test("falls back to ElevenLabs config when voice-spec builder is not registered", () => {
+    // Clear the voice-spec registry to simulate missing builder.
+    _resetNativeTwilioVoiceSpecRegistry();
+
+    mockConfig = {
+      calls: {
+        voice: {
+          language: "en-US",
+          transcriptionProvider: "Deepgram",
+        },
+      },
+      services: {
+        tts: {
+          provider: "elevenlabs",
+          providers: {
+            elevenlabs: { voiceId: "some-voice" },
+            "fish-audio": { referenceId: "" },
+          },
+        },
+      },
+    };
+    const profile = resolveVoiceQualityProfile();
+    // Falls back to reading from the elevenlabs config block directly.
+    expect(profile.ttsProvider).toBe("ElevenLabs");
+    expect(profile.voice).toBe("some-voice");
+  });
+
+  test("falls back to default voice ID when no config or builder available", () => {
+    // Clear the voice-spec registry and omit elevenlabs config.
+    _resetNativeTwilioVoiceSpecRegistry();
+
+    mockConfig = {
+      calls: {
+        voice: {
+          language: "en-US",
+          transcriptionProvider: "Deepgram",
+        },
+      },
+      services: {
+        tts: {
+          provider: "elevenlabs",
+          providers: {
+            "fish-audio": { referenceId: "" },
+          },
+        },
+      },
+    };
+    const profile = resolveVoiceQualityProfile();
+    expect(profile.ttsProvider).toBe("ElevenLabs");
+    expect(profile.voice).toBe(DEFAULT_ELEVENLABS_VOICE_ID);
   });
 });

--- a/assistant/src/calls/tts-call-strategy.ts
+++ b/assistant/src/calls/tts-call-strategy.ts
@@ -1,0 +1,161 @@
+/**
+ * Explicit call-path strategy for TTS providers.
+ *
+ * Determines how a TTS provider integrates with the Twilio
+ * ConversationRelay call path by reading the provider's `callMode` from
+ * the canonical catalog rather than inferring behavior from runtime
+ * capabilities like `supportsStreaming`.
+ *
+ * Two strategies exist:
+ *
+ * - **native-twilio** -- Twilio handles TTS natively via
+ *   ConversationRelay. The profile needs a real `ttsProvider` name
+ *   (e.g. `"ElevenLabs"`) and a provider-specific voice spec string.
+ *   New native providers plug in by registering a
+ *   {@link NativeTwilioVoiceSpecBuilder} -- no edits to the core call
+ *   routing logic required.
+ *
+ * - **synthesized-play** -- The assistant synthesises audio and streams
+ *   chunks to Twilio via `play` messages. The profile uses a
+ *   placeholder TTS provider (`"Google"`) and an empty voice string
+ *   because Twilio never drives TTS itself on this path.
+ *
+ * @module
+ */
+
+import type { AssistantConfig } from "../config/types.js";
+import { getCatalogProvider } from "../tts/provider-catalog.js";
+import { resolveTtsConfig } from "../tts/tts-config-resolver.js";
+import type { TtsCallMode, TtsProviderId } from "../tts/types.js";
+
+// ---------------------------------------------------------------------------
+// Native Twilio voice-spec builder registry
+// ---------------------------------------------------------------------------
+
+/**
+ * Builds the provider-specific voice spec string for a native Twilio
+ * provider.
+ *
+ * The returned string is used as the `voice` attribute in the
+ * ConversationRelay TwiML element. Its format is provider-specific --
+ * e.g. ElevenLabs uses `voiceId-modelId-speed_stability_similarity`.
+ *
+ * @param providerConfig - Provider-specific config block from
+ *   `services.tts.providers.<id>`.
+ * @returns The voice spec string for the ConversationRelay `voice`
+ *   attribute, or an empty string if the provider has no voice to
+ *   specify.
+ */
+export type NativeTwilioVoiceSpecBuilder = (
+  providerConfig: Record<string, unknown>,
+) => string;
+
+/**
+ * Metadata returned by a native Twilio voice-spec builder registration.
+ */
+export interface NativeTwilioVoiceSpec {
+  /** The Twilio `ttsProvider` attribute value (e.g. `"ElevenLabs"`). */
+  readonly twilioProviderName: string;
+
+  /** Builds the `voice` attribute string from provider config. */
+  readonly buildVoiceSpec: NativeTwilioVoiceSpecBuilder;
+}
+
+/** Internal registry keyed by provider ID. */
+const nativeVoiceSpecRegistry = new Map<TtsProviderId, NativeTwilioVoiceSpec>();
+
+/**
+ * Register a native Twilio voice-spec builder for a provider.
+ *
+ * Called at startup alongside provider adapter registration. This is
+ * the extension point that allows new native Twilio providers to be
+ * added without modifying core call routing logic.
+ *
+ * @throws if a builder for the same provider ID is already registered.
+ */
+export function registerNativeTwilioVoiceSpec(
+  providerId: TtsProviderId,
+  spec: NativeTwilioVoiceSpec,
+): void {
+  if (nativeVoiceSpecRegistry.has(providerId)) {
+    throw new Error(
+      `Native Twilio voice spec for "${providerId}" is already registered. ` +
+        "Duplicate registrations are not allowed.",
+    );
+  }
+  nativeVoiceSpecRegistry.set(providerId, spec);
+}
+
+/**
+ * Look up a registered native Twilio voice-spec builder.
+ *
+ * @throws if no builder has been registered for the given provider.
+ */
+export function getNativeTwilioVoiceSpec(
+  providerId: TtsProviderId,
+): NativeTwilioVoiceSpec {
+  const spec = nativeVoiceSpecRegistry.get(providerId);
+  if (!spec) {
+    const known = [...nativeVoiceSpecRegistry.keys()];
+    const knownList =
+      known.length > 0 ? ` Registered: ${known.join(", ")}` : "";
+    throw new Error(
+      `No native Twilio voice spec registered for "${providerId}".${knownList}`,
+    );
+  }
+  return spec;
+}
+
+// ---------------------------------------------------------------------------
+// Strategy resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolved call strategy for the active TTS provider.
+ */
+export interface TtsCallStrategy {
+  /** The provider ID from the catalog. */
+  readonly providerId: TtsProviderId;
+
+  /** How this provider integrates with the telephony call path. */
+  readonly callMode: TtsCallMode;
+}
+
+/**
+ * Resolve the call strategy for the currently configured TTS provider.
+ *
+ * Reads the active provider from config via {@link resolveTtsConfig},
+ * then looks up the provider's `callMode` in the catalog.
+ *
+ * Falls back to `native-twilio` with `"elevenlabs"` when the config
+ * or catalog is unavailable (e.g. test mocks, pre-migration configs).
+ */
+export function resolveCallStrategy(config: AssistantConfig): TtsCallStrategy {
+  try {
+    const resolved = resolveTtsConfig(config);
+    const catalogEntry = getCatalogProvider(resolved.provider);
+    return {
+      providerId: catalogEntry.id,
+      callMode: catalogEntry.callMode,
+    };
+  } catch {
+    // Config or catalog not available -- default to native ElevenLabs path.
+    return {
+      providerId: "elevenlabs",
+      callMode: "native-twilio",
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Clear all registered native Twilio voice spec builders.
+ *
+ * **Test-only** -- must not be called in production code.
+ */
+export function _resetNativeTwilioVoiceSpecRegistry(): void {
+  nativeVoiceSpecRegistry.clear();
+}

--- a/assistant/src/calls/voice-quality.ts
+++ b/assistant/src/calls/voice-quality.ts
@@ -1,7 +1,10 @@
 import { loadConfig } from "../config/loader.js";
 import { DEFAULT_ELEVENLABS_VOICE_ID } from "../config/schemas/elevenlabs.js";
-import { getTtsProvider } from "../tts/provider-registry.js";
 import { resolveTtsConfig } from "../tts/tts-config-resolver.js";
+import {
+  getNativeTwilioVoiceSpec,
+  resolveCallStrategy,
+} from "./tts-call-strategy.js";
 
 export interface VoiceQualityProfile {
   language: string;
@@ -46,14 +49,22 @@ export function buildElevenLabsVoiceSpec(config: {
 /**
  * Resolve the effective voice quality profile from config.
  *
- * Uses the global TTS provider abstraction to determine which provider is
- * active. Providers that declare streaming support (e.g. Fish Audio) use
- * the synthesized-play path — ConversationRelay needs a valid TTS provider
- * in TwiML, so we set `ttsProvider` to `"Google"` as a placeholder and
- * leave `voice` empty since actual audio is delivered via `play` messages.
+ * Uses the explicit call strategy from the TTS provider catalog to
+ * determine the call path. The catalog's `callMode` field
+ * (`"native-twilio"` vs `"synthesized-play"`) drives the decision
+ * rather than inferring behavior from runtime `supportsStreaming`
+ * capability.
  *
- * For native providers (e.g. ElevenLabs), `ttsProvider` and `voice` are
- * populated from config so Twilio handles TTS natively.
+ * For **synthesized-play** providers (e.g. Fish Audio),
+ * ConversationRelay needs a valid TTS provider in TwiML, so we set
+ * `ttsProvider` to `"Google"` as a placeholder and leave `voice` empty
+ * since actual audio is delivered via `play` messages.
+ *
+ * For **native-twilio** providers (e.g. ElevenLabs), `ttsProvider` and
+ * `voice` are populated via the provider's registered
+ * {@link NativeTwilioVoiceSpec} builder so Twilio handles TTS natively.
+ * New native providers plug in by registering a voice-spec builder --
+ * no edits to this module required.
  *
  * NOTE: STT provider and speech model are intentionally NOT part of this
  * profile. STT resolution is handled once in the voice webhook route
@@ -66,29 +77,44 @@ export function resolveVoiceQualityProfile(
   const cfg = config ?? loadConfig();
   const voice = cfg.calls.voice;
 
-  // Resolve the active TTS provider through the global abstraction.
-  // When the config lacks the `services.tts` block (e.g. test mocks or
-  // pre-migration configs) or the provider registry has not been initialised,
-  // we fall back to the native ElevenLabs profile.
-  let usesSynthesizedPath = false;
-  try {
-    const resolved = resolveTtsConfig(cfg);
-    const provider = getTtsProvider(resolved.provider);
-    usesSynthesizedPath = provider.capabilities.supportsStreaming;
-  } catch {
-    // Config or provider not available — default to native (ElevenLabs) path.
+  // Resolve the call strategy from catalog metadata.
+  // Falls back to native ElevenLabs when config/catalog is unavailable.
+  const strategy = resolveCallStrategy(cfg);
+
+  let ttsProvider: string;
+  let voiceSpec: string;
+
+  if (strategy.callMode === "synthesized-play") {
+    // Synthesized providers stream audio via `play` messages.
+    // Twilio still needs a valid ttsProvider in TwiML, so use a
+    // placeholder and leave voice empty.
+    ttsProvider = "Google";
+    voiceSpec = "";
+  } else {
+    // Native providers: delegate voice-spec building to the
+    // provider's registered builder.
+    try {
+      const spec = getNativeTwilioVoiceSpec(strategy.providerId);
+      ttsProvider = spec.twilioProviderName;
+
+      const resolved = resolveTtsConfig(cfg);
+      voiceSpec = spec.buildVoiceSpec(resolved.providerConfig);
+    } catch {
+      // Voice-spec builder not registered or config unavailable --
+      // fall back to ElevenLabs using the config's elevenlabs block.
+      ttsProvider = "ElevenLabs";
+      voiceSpec = buildElevenLabsVoiceSpec(
+        cfg.services?.tts?.providers?.elevenlabs ?? {
+          voiceId: DEFAULT_ELEVENLABS_VOICE_ID,
+        },
+      );
+    }
   }
 
   return {
     language: voice.language,
-    ttsProvider: usesSynthesizedPath ? "Google" : "ElevenLabs",
-    voice: usesSynthesizedPath
-      ? ""
-      : buildElevenLabsVoiceSpec(
-          cfg.services?.tts?.providers?.elevenlabs ?? {
-            voiceId: DEFAULT_ELEVENLABS_VOICE_ID,
-          },
-        ),
+    ttsProvider,
+    voice: voiceSpec,
     interruptSensitivity: voice.interruptSensitivity ?? "low",
     hints: voice.hints ?? [],
   };

--- a/assistant/src/tts/providers/register-builtins.ts
+++ b/assistant/src/tts/providers/register-builtins.ts
@@ -8,14 +8,59 @@
  * causes a clear startup-time error so that new catalog providers cannot be
  * added without also wiring an adapter factory.
  *
+ * Also registers native Twilio voice-spec builders for providers whose
+ * catalog `callMode` is `"native-twilio"`. These builders are consumed by
+ * the call strategy abstraction in `tts-call-strategy.ts`.
+ *
  * This module is the single entry point for built-in registration — new
  * providers should be added to the catalog and the factory map so they are
  * available from first request.
  */
 
-import { listCatalogProviderIds } from "../provider-catalog.js";
+import {
+  _resetNativeTwilioVoiceSpecRegistry,
+  type NativeTwilioVoiceSpec,
+  registerNativeTwilioVoiceSpec,
+} from "../../calls/tts-call-strategy.js";
+import { buildElevenLabsVoiceSpec } from "../../calls/voice-quality.js";
+import {
+  getCatalogProvider,
+  listCatalogProviderIds,
+} from "../provider-catalog.js";
 import { registerTtsProvider } from "../provider-registry.js";
+import type { TtsProviderId } from "../types.js";
 import { providerFactories } from "./index.js";
+
+// ---------------------------------------------------------------------------
+// Native Twilio voice-spec builders
+// ---------------------------------------------------------------------------
+
+/**
+ * Maps provider IDs with `callMode: "native-twilio"` to their Twilio
+ * voice-spec builder metadata.
+ *
+ * When onboarding a new native Twilio provider, add an entry here.
+ * Synthesized-play providers do not need an entry — they use a
+ * placeholder TTS provider and empty voice string.
+ */
+const nativeVoiceSpecs = new Map<TtsProviderId, NativeTwilioVoiceSpec>([
+  [
+    "elevenlabs",
+    {
+      twilioProviderName: "ElevenLabs",
+      buildVoiceSpec: (providerConfig) =>
+        buildElevenLabsVoiceSpec(
+          providerConfig as {
+            voiceId: string;
+            voiceModelId?: string;
+            speed?: number;
+            stability?: number;
+            similarityBoost?: number;
+          },
+        ),
+    },
+  ],
+]);
 
 let registered = false;
 
@@ -24,11 +69,14 @@ let registered = false;
  *
  * Iterates every provider ID declared in the canonical catalog and creates
  * an adapter via the corresponding factory in {@link providerFactories}.
+ * For providers whose catalog `callMode` is `"native-twilio"`, also
+ * registers the corresponding native Twilio voice-spec builder.
  *
  * Safe to call multiple times — subsequent calls are no-ops. This prevents
  * double-registration when the daemon restarts hot-module paths.
  *
  * @throws if any catalog provider ID has no corresponding adapter factory.
+ * @throws if a native-twilio provider has no corresponding voice-spec entry.
  */
 export function registerBuiltinTtsProviders(): void {
   if (registered) return;
@@ -36,6 +84,7 @@ export function registerBuiltinTtsProviders(): void {
   const catalogIds = listCatalogProviderIds();
 
   for (const id of catalogIds) {
+    // Register the TTS provider adapter.
     const factory = providerFactories.get(id);
     if (!factory) {
       throw new Error(
@@ -44,6 +93,19 @@ export function registerBuiltinTtsProviders(): void {
       );
     }
     registerTtsProvider(factory());
+
+    // Register the native Twilio voice-spec builder when applicable.
+    const catalogEntry = getCatalogProvider(id);
+    if (catalogEntry.callMode === "native-twilio") {
+      const voiceSpec = nativeVoiceSpecs.get(id);
+      if (!voiceSpec) {
+        throw new Error(
+          `TTS provider "${id}" has callMode "native-twilio" but no native ` +
+            `voice-spec builder. Add an entry in register-builtins.ts nativeVoiceSpecs.`,
+        );
+      }
+      registerNativeTwilioVoiceSpec(id, voiceSpec);
+    }
   }
 
   registered = true;
@@ -57,8 +119,12 @@ export function registerBuiltinTtsProviders(): void {
  * Reset the registration guard so {@link registerBuiltinTtsProviders} can
  * re-register providers after a test clears the global registry.
  *
+ * Also clears the native Twilio voice-spec registry to avoid
+ * duplicate-registration errors on subsequent calls.
+ *
  * **Test-only** — must not be called in production code.
  */
 export function _resetBuiltinRegistration(): void {
   registered = false;
+  _resetNativeTwilioVoiceSpecRegistry();
 }


### PR DESCRIPTION
## Summary
- Creates tts-call-strategy.ts resolving call behavior from catalog metadata
- Refactors resolveVoiceQualityProfile to consume explicit strategy
- Adds extension point for provider-specific native Twilio voice-spec builders
- Updates tests to verify strategy behavior and preserve TwiML expectations

Part of plan: tts-provider-onboarding-unification.md (PR 5 of 11)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24955" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
