### PR TITLE
Route channel audio transcription messaging and behavior through `services.stt`

### DIFF
--- a/assistant/src/runtime/routes/inbound-stages/transcribe-audio.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/transcribe-audio.test.ts
@@ -156,7 +156,7 @@ describe("tryTranscribeAudioAttachments", () => {
     expect(result).toEqual({ status: "no_audio" });
   });
 
-  test("no API key returns no_provider with helpful reason string", async () => {
+  test("no provider returns no_provider with service-agnostic reason", async () => {
     const audio = makeAudioAttachment("a1");
     mockAttachments = [audio];
     mockTranscriber = null; // No transcriber resolved
@@ -164,9 +164,10 @@ describe("tryTranscribeAudioAttachments", () => {
     const result = await tryTranscribeAudioAttachments(["a1"]);
 
     expect(result.status).toBe("no_provider");
-    expect((result as { reason: string }).reason).toContain(
-      "No OpenAI API key configured",
-    );
+    const reason = (result as { reason: string }).reason;
+    expect(reason).toContain("speech-to-text");
+    expect(reason).toContain("voice message transcription");
+    expect(reason).not.toContain("OpenAI");
   });
 
   test("API failure returns error with reason", async () => {

--- a/assistant/src/runtime/routes/inbound-stages/transcribe-audio.ts
+++ b/assistant/src/runtime/routes/inbound-stages/transcribe-audio.ts
@@ -62,7 +62,7 @@ export async function tryTranscribeAudioAttachments(
       return {
         status: "no_provider",
         reason:
-          "No OpenAI API key configured. Set one up to enable voice message transcription.",
+          "No speech-to-text provider configured. Add an API key for your STT service to enable voice message transcription.",
       };
     }
 


### PR DESCRIPTION
## Summary
- Updates no_provider messaging to use STT service terminology instead of hardcoded OpenAI references
- Preserves existing channel-voice-transcription feature gate and non-blocking behavior
- Updates tests to assert provider-agnostic messaging

Part of plan: stt-service-product-unification.md (PR 3 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24957" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
