### PR TITLE
fix: guard against empty-string submission in voice ID config setters

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -2960,8 +2960,9 @@ public final class SettingsStore: ObservableObject {
     }
 
     func setElevenLabsVoiceId(_ voiceId: String) {
+        let trimmed = voiceId.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
         Task {
-            let trimmed = voiceId.trimmingCharacters(in: .whitespacesAndNewlines)
             let success = await settingsClient.patchConfig([
                 "services": ["tts": ["providers": ["elevenlabs": ["voiceId": trimmed]]]]
             ])
@@ -2972,8 +2973,9 @@ public final class SettingsStore: ObservableObject {
     }
 
     func setFishAudioReferenceId(_ referenceId: String) {
+        let trimmed = referenceId.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
         Task {
-            let trimmed = referenceId.trimmingCharacters(in: .whitespacesAndNewlines)
             let success = await settingsClient.patchConfig([
                 "services": ["tts": ["providers": ["fish-audio": ["referenceId": trimmed]]]]
             ])


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for tts-setup-flow-unification.md.

**Gap:** Guard against empty-string submission in voice ID / reference ID config setters
**What was expected:** Pressing Enter on an empty voice ID field should be a no-op
**What was found:** setElevenLabsVoiceId and setFishAudioReferenceId patch config even when trimmed value is empty, which for Fish Audio overwrites a configured referenceId with empty string and breaks TTS
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24961" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
