### PR TITLE
feat(settings): unify TTS provider setup flow for ElevenLabs and Fish Audio

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -2960,8 +2960,9 @@ public final class SettingsStore: ObservableObject {
     }
 
     func setElevenLabsVoiceId(_ voiceId: String) {
+        let trimmed = voiceId.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
         Task {
-            let trimmed = voiceId.trimmingCharacters(in: .whitespacesAndNewlines)
             let success = await settingsClient.patchConfig([
                 "services": ["tts": ["providers": ["elevenlabs": ["voiceId": trimmed]]]]
             ])
@@ -2972,8 +2973,9 @@ public final class SettingsStore: ObservableObject {
     }
 
     func setFishAudioReferenceId(_ referenceId: String) {
+        let trimmed = referenceId.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
         Task {
-            let trimmed = referenceId.trimmingCharacters(in: .whitespacesAndNewlines)
             let success = await settingsClient.patchConfig([
                 "services": ["tts": ["providers": ["fish-audio": ["referenceId": trimmed]]]]
             ])

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -2936,6 +2936,18 @@ public final class SettingsStore: ObservableObject {
         return task
     }
 
+    func setElevenLabsVoiceId(_ voiceId: String) {
+        Task {
+            let trimmed = voiceId.trimmingCharacters(in: .whitespacesAndNewlines)
+            let success = await settingsClient.patchConfig([
+                "services": ["tts": ["providers": ["elevenlabs": ["voiceId": trimmed]]]]
+            ])
+            if !success {
+                log.error("Failed to patch config for ElevenLabs voice ID")
+            }
+        }
+    }
+
     /// Schedules a delayed refresh of provider routing sources, giving the
     /// daemon time to re-initialize providers after a key change.
     private func scheduleRoutingSourceRefresh() {

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -892,6 +892,29 @@ public final class SettingsStore: ObservableObject {
         }
     }
 
+    func saveFishAudioKey(_ raw: String, onSuccess: (() -> Void)? = nil) {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        APIKeyManager.setCredential(trimmed, service: "fish-audio", field: "api_key")
+        removeDeletionTombstone(type: "credential", name: "fish-audio:api_key")
+        Task {
+            let result = await APIKeyManager.setCredential(trimmed, service: "fish-audio", field: "api_key")
+            if result.success {
+                onSuccess?()
+            } else if let error = result.error {
+                log.error("Failed to sync Fish Audio key to daemon: \(error, privacy: .public)")
+            }
+        }
+    }
+
+    func clearFishAudioKey() {
+        APIKeyManager.deleteCredential(service: "fish-audio", field: "api_key")
+        Task {
+            let deleted = await APIKeyManager.deleteCredential(service: "fish-audio", field: "api_key")
+            if !deleted { addDeletionTombstone(type: "credential", name: "fish-audio:api_key") }
+        }
+    }
+
     func clearAPIKeyForProvider(_ provider: String) {
         APIKeyManager.deleteKey(for: provider)
         scheduleRoutingSourceRefresh()

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -2971,6 +2971,18 @@ public final class SettingsStore: ObservableObject {
         }
     }
 
+    func setFishAudioReferenceId(_ referenceId: String) {
+        Task {
+            let trimmed = referenceId.trimmingCharacters(in: .whitespacesAndNewlines)
+            let success = await settingsClient.patchConfig([
+                "services": ["tts": ["providers": ["fish-audio": ["referenceId": trimmed]]]]
+            ])
+            if !success {
+                log.error("Failed to patch config for Fish Audio reference ID")
+            }
+        }
+    }
+
     /// Schedules a delayed refresh of provider routing sources, giving the
     /// daemon time to re-initialize providers after a key change.
     private func scheduleRoutingSourceRefresh() {

--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -37,6 +37,12 @@ struct VoiceSettingsView: View {
     @State private var ttsSetupExpanded: Bool = false
     /// Whether an ElevenLabs API key is stored (fetched per-component).
     @State private var elevenLabsHasKey = false
+
+    @State private var fishAudioKeyText: String = ""
+    @State private var fishAudioSetupExpanded: Bool = false
+    @State private var fishAudioHasKey = false
+    @State private var fishAudioReferenceId: String = ""
+
     @State private var isRecordingCustomKey: Bool = false
     @State private var recordingMonitors: [Any] = []
     @State private var modifierHoldTimer: Timer? = nil
@@ -75,6 +81,7 @@ struct VoiceSettingsView: View {
         }
         .onAppear {
             elevenLabsHasKey = APIKeyManager.getKey(for: "elevenlabs") != nil
+            fishAudioHasKey = APIKeyManager.getCredential(service: "fish-audio", field: "api_key") != nil
         }
         .onChange(of: conversationTimeoutSeconds) {
             VoiceModeManager.conversationTimeoutOverride = conversationTimeoutSeconds
@@ -448,35 +455,70 @@ struct VoiceSettingsView: View {
     // MARK: - Fish Audio Provider Config
 
     private var fishAudioProviderConfig: some View {
-        VStack(alignment: .leading, spacing: VSpacing.md) {
-            VStack(alignment: .leading, spacing: VSpacing.xs) {
-                Text("1. Create a Fish Audio account at fish.audio")
-                    .font(VFont.bodyMediumDefault)
-                    .foregroundStyle(VColor.contentSecondary)
-                Text("2. Generate an API key from your Fish Audio dashboard")
-                    .font(VFont.bodyMediumDefault)
-                    .foregroundStyle(VColor.contentSecondary)
-                Text("3. Choose or create a voice and copy its reference ID")
-                    .font(VFont.bodyMediumDefault)
-                    .foregroundStyle(VColor.contentSecondary)
-                Text("4. Run the setup commands in your terminal:")
-                    .font(VFont.bodyMediumDefault)
-                    .foregroundStyle(VColor.contentSecondary)
-            }
+        Group {
+            if fishAudioHasKey {
+                VStack(alignment: .leading, spacing: VSpacing.md) {
+                    HStack(spacing: VSpacing.sm) {
+                        VButton(label: "Connected", leftIcon: VIcon.circleCheck.rawValue, style: .primary) {}
+                        VButton(label: "Disconnect", style: .danger) {
+                            store.clearFishAudioKey()
+                            fishAudioHasKey = false
+                            fishAudioKeyText = ""
+                            fishAudioSetupExpanded = false
+                        }
+                    }
 
-            Text("assistant credentials set --service fish-audio --field api_key YOUR_KEY\nassistant config set services.tts.providers.fish-audio.referenceId YOUR_VOICE_ID")
-                .font(.system(size: 12, design: .monospaced))
-                .foregroundStyle(VColor.contentSecondary)
-                .padding(VSpacing.md)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .background(
-                    RoundedRectangle(cornerRadius: VRadius.md)
-                        .fill(VColor.surfaceBase)
-                )
-                .textSelection(.enabled)
+                    VStack(alignment: .leading, spacing: VSpacing.xs) {
+                        VTextField(
+                            "Voice Reference ID",
+                            placeholder: "Fish Audio voice reference ID (optional)",
+                            text: $fishAudioReferenceId,
+                            onSubmit: {
+                                store.setFishAudioReferenceId(fishAudioReferenceId)
+                            },
+                            maxWidth: 400
+                        )
 
-            VButton(label: "Visit Fish Audio", rightIcon: VIcon.arrowUpRight.rawValue, style: .outlined) {
-                NSWorkspace.shared.open(URL(string: "https://fish.audio")!)
+                        Text("Find voice IDs at fish.audio. Leave blank if you've already configured one via the CLI.")
+                            .font(VFont.labelDefault)
+                            .foregroundStyle(VColor.contentTertiary)
+                    }
+                }
+            } else if fishAudioSetupExpanded {
+                VStack(alignment: .leading, spacing: VSpacing.sm) {
+                    VTextField(
+                        "Fish Audio API Key",
+                        placeholder: "Your Fish Audio API key",
+                        text: $fishAudioKeyText,
+                        isSecure: true,
+                        maxWidth: 400
+                    )
+
+                    HStack(spacing: VSpacing.xs) {
+                        VIconView(.lock, size: 10)
+                            .foregroundStyle(VColor.contentTertiary)
+                        Text("Your API key is stored securely in the macOS Keychain.")
+                            .font(VFont.labelDefault)
+                            .foregroundStyle(VColor.contentTertiary)
+                    }
+
+                    HStack(spacing: VSpacing.sm) {
+                        VButton(label: "Connect", style: .outlined, isDisabled: fishAudioKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty) {
+                            store.saveFishAudioKey(fishAudioKeyText)
+                            fishAudioHasKey = true
+                            fishAudioKeyText = ""
+                            fishAudioSetupExpanded = false
+                        }
+                        VButton(label: "Cancel", style: .outlined) {
+                            fishAudioSetupExpanded = false
+                            fishAudioKeyText = ""
+                        }
+                    }
+                }
+            } else {
+                VButton(label: "Set Up", style: .outlined) {
+                    fishAudioSetupExpanded = true
+                }
             }
         }
     }

--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -33,6 +33,7 @@ struct VoiceSettingsView: View {
     @AppStorage("ttsProvider") private var ttsProviderRaw: String = TTSProviderOption.elevenlabs.rawValue
 
     @State private var elevenLabsKeyText: String = ""
+    @State private var elevenLabsVoiceId: String = ""
     @State private var ttsSetupExpanded: Bool = false
     /// Whether an ElevenLabs API key is stored (fetched per-component).
     @State private var elevenLabsHasKey = false
@@ -388,6 +389,22 @@ struct VoiceSettingsView: View {
                         elevenLabsKeyText = ""
                         ttsSetupExpanded = false
                     }
+                }
+
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    VTextField(
+                        "Voice ID",
+                        placeholder: "ElevenLabs Voice ID (optional)",
+                        text: $elevenLabsVoiceId,
+                        onSubmit: {
+                            store.setElevenLabsVoiceId(elevenLabsVoiceId)
+                        },
+                        maxWidth: 400
+                    )
+
+                    Text("Leave blank to use the default voice. Find voice IDs at elevenlabs.io/voice-library.")
+                        .font(VFont.labelDefault)
+                        .foregroundStyle(VColor.contentTertiary)
                 }
             } else if ttsSetupExpanded {
                 VStack(alignment: .leading, spacing: VSpacing.sm) {


### PR DESCRIPTION
## Summary
Unify the setup experience for ElevenLabs and Fish Audio TTS providers so both follow the same pattern: Set Up → API Key → Connect → Voice ID. Previously ElevenLabs had an inline API key form while Fish Audio showed terminal commands.

## Self-review result
GAPS FOUND — 1 gap fixed across 1 fix PR (empty-string guard for voice ID config setters)

## PRs merged into feature branch
- #24950: feat(settings): add ElevenLabs Voice ID input field to TTS settings
- #24947: feat(settings): add Fish Audio API key save/clear using credential type
- #24956: feat(settings): unify Fish Audio setup UI with ElevenLabs pattern and add Reference ID field

### Fix PRs
- #24961: fix: guard against empty-string submission in voice ID config setters

Part of plan: tts-setup-flow-unification.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24962" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
