### PR TITLE
Extract shared call TTS provider resolution helper

### DIFF
--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -223,6 +223,7 @@ import {
   updateCallSession,
 } from "../calls/call-store.js";
 import type { RelayConnection } from "../calls/relay-server.js";
+import { resolveCallTtsProvider } from "../calls/resolve-call-tts-provider.js";
 import {
   getCanonicalGuardianRequest,
   getPendingCanonicalRequestByCallSessionId,
@@ -2495,5 +2496,45 @@ describe("call-controller", () => {
     expect(controller.getState()).toBe("idle");
 
     controller.destroy();
+  });
+
+  // ── Shared TTS provider resolution ──────────────────────────────────
+
+  describe("resolveCallTtsProvider (shared helper)", () => {
+    test("returns native path with elevenlabs (non-streaming provider)", () => {
+      // Default config has provider: "elevenlabs" which is registered as
+      // non-streaming in registerTestTtsProviders()
+      const result = resolveCallTtsProvider();
+      expect(result.provider).not.toBeNull();
+      expect(result.provider!.id).toBe("elevenlabs");
+      expect(result.useSynthesizedPath).toBe(false);
+      expect(result.audioFormat).toBe("mp3");
+    });
+
+    test("returns fallback when provider registry is empty", () => {
+      _resetTtsProviderRegistry();
+      const result = resolveCallTtsProvider();
+      expect(result.provider).toBeNull();
+      expect(result.useSynthesizedPath).toBe(false);
+      expect(result.audioFormat).toBe("mp3");
+    });
+
+    test("call controller LLM path uses shared resolution (native provider sends text tokens)", async () => {
+      // With the default elevenlabs provider (non-streaming), the call
+      // controller should send text tokens directly to the relay (native path).
+      mockStartVoiceTurn.mockImplementation(
+        createMockVoiceTurn(["Hello", " caller"]),
+      );
+      const { relay, controller } = setupController();
+
+      await controller.handleCallerUtterance("Hi");
+
+      // Native path: text tokens should be sent, no play URLs
+      const nonEmptyTokens = relay.sentTokens.filter((t) => t.token.length > 0);
+      expect(nonEmptyTokens.length).toBeGreaterThan(0);
+      expect(relay.sentPlayUrls.length).toBe(0);
+
+      controller.destroy();
+    });
   });
 });

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -23,8 +23,6 @@ import { revokeScopedApprovalGrantsForContext } from "../memory/scoped-approval-
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { mintDaemonDeliveryToken } from "../runtime/auth/token-service.js";
 import { computeToolApprovalDigest } from "../security/tool-approval-digest.js";
-import { getTtsProvider } from "../tts/provider-registry.js";
-import { resolveTtsConfig } from "../tts/tts-config-resolver.js";
 import type { TtsProvider } from "../tts/types.js";
 import { getLogger } from "../util/logger.js";
 import { createStreamingEntry } from "./audio-store.js";
@@ -51,6 +49,7 @@ import { finalizeCall } from "./finalize-call.js";
 import { sendGuardianExpiryNotices } from "./guardian-action-sweep.js";
 import { dispatchGuardianQuestion } from "./guardian-dispatch.js";
 import type { RelayConnection } from "./relay-server.js";
+import { resolveCallTtsProvider } from "./resolve-call-tts-provider.js";
 import type { PromptSpeakerContext } from "./speaker-identification.js";
 import { sanitizeForTts } from "./tts-text-sanitizer.js";
 import {
@@ -528,46 +527,6 @@ export class CallController {
   }
 
   /**
-   * Resolve the active TTS provider via the global provider abstraction.
-   *
-   * Providers that declare streaming support are treated as "synthesized"
-   * providers — their audio is streamed through the audio store and played
-   * via `sendPlayUrl`. Providers without streaming support are "native"
-   * providers — text tokens are streamed directly to the relay for Twilio's
-   * built-in TTS.
-   */
-  private resolveCallTtsProvider(): {
-    provider: TtsProvider | null;
-    useSynthesizedPath: boolean;
-    audioFormat: "mp3" | "wav" | "opus";
-  } {
-    try {
-      const config = loadConfig();
-      const resolved = resolveTtsConfig(config);
-      const provider = getTtsProvider(resolved.provider);
-      // Providers with streaming support synthesize audio themselves; others
-      // rely on the relay's native (Twilio-managed) TTS engine.
-      const useSynthesizedPath = provider.capabilities.supportsStreaming;
-      // Read the user-configured audio format from the resolved provider
-      // config so the streaming store entry's content-type matches the
-      // actual audio bytes the provider produces.
-      const configuredFormat = (resolved.providerConfig as { format?: string })
-        .format;
-      const audioFormat = (
-        configuredFormat && ["mp3", "wav", "opus"].includes(configuredFormat)
-          ? configuredFormat
-          : "mp3"
-      ) as "mp3" | "wav" | "opus";
-      return { provider, useSynthesizedPath, audioFormat };
-    } catch {
-      // Config missing `services.tts` block or provider not registered
-      // (e.g. unit tests or early startup) — fall back to the native
-      // (non-streaming) path where the provider object is not used.
-      return { provider: null, useSynthesizedPath: false, audioFormat: "mp3" };
-    }
-  }
-
-  /**
    * Stream TTS tokens from the conversation pipeline, buffering to strip
    * control markers before they reach the relay. Returns the full
    * accumulated response text for post-turn marker detection.
@@ -583,7 +542,7 @@ export class CallController {
     // to Twilio via play-URL). Native providers stream text tokens to
     // the relay for Twilio's built-in TTS.
     const { provider, useSynthesizedPath, audioFormat } =
-      this.resolveCallTtsProvider();
+      resolveCallTtsProvider();
 
     // Buffer incoming tokens so we can strip control markers ([ASK_GUARDIAN:...], [END_CALL])
     // before they reach TTS. We hold text whenever an unmatched '[' appears, since it

--- a/assistant/src/calls/call-speech-output.ts
+++ b/assistant/src/calls/call-speech-output.ts
@@ -16,51 +16,13 @@
 
 import { loadConfig } from "../config/loader.js";
 import { getPublicBaseUrl } from "../inbound/public-ingress-urls.js";
-import { getTtsProvider } from "../tts/provider-registry.js";
-import { resolveTtsConfig } from "../tts/tts-config-resolver.js";
 import type { TtsProvider } from "../tts/types.js";
 import { getLogger } from "../util/logger.js";
 import { createStreamingEntry } from "./audio-store.js";
 import type { RelayConnection } from "./relay-server.js";
+import { resolveCallTtsProvider } from "./resolve-call-tts-provider.js";
 
 const log = getLogger("call-speech-output");
-
-// ---------------------------------------------------------------------------
-// Provider resolution (shared logic with call-controller)
-// ---------------------------------------------------------------------------
-
-interface ResolvedCallTts {
-  provider: TtsProvider | null;
-  useSynthesizedPath: boolean;
-  audioFormat: "mp3" | "wav" | "opus";
-}
-
-/**
- * Resolve the active TTS provider via the global provider abstraction.
- *
- * Mirrors the resolution logic in CallController.resolveCallTtsProvider()
- * so deterministic prompts use the same provider path as LLM-generated
- * speech.
- */
-function resolveCallTtsProvider(): ResolvedCallTts {
-  try {
-    const config = loadConfig();
-    const resolved = resolveTtsConfig(config);
-    const provider = getTtsProvider(resolved.provider);
-    const useSynthesizedPath = provider.capabilities.supportsStreaming;
-    const configuredFormat = (resolved.providerConfig as { format?: string })
-      .format;
-    const audioFormat = (
-      configuredFormat && ["mp3", "wav", "opus"].includes(configuredFormat)
-        ? configuredFormat
-        : "mp3"
-    ) as "mp3" | "wav" | "opus";
-    return { provider, useSynthesizedPath, audioFormat };
-  } catch {
-    // Config missing or provider not registered — fall back to native path.
-    return { provider: null, useSynthesizedPath: false, audioFormat: "mp3" };
-  }
-}
 
 // ---------------------------------------------------------------------------
 // Public API

--- a/assistant/src/calls/resolve-call-tts-provider.ts
+++ b/assistant/src/calls/resolve-call-tts-provider.ts
@@ -1,0 +1,80 @@
+/**
+ * Shared call TTS provider resolution.
+ *
+ * Both the call controller (LLM turn speech) and deterministic system
+ * prompts (verification codes, guardian wait updates, timeout copy) use
+ * this helper so that provider selection, format fallback, and the
+ * native-vs-synthesized strategy decision stay in one implementation.
+ */
+
+import { loadConfig } from "../config/loader.js";
+import { getTtsProvider } from "../tts/provider-registry.js";
+import { resolveTtsConfig } from "../tts/tts-config-resolver.js";
+import type { TtsProvider } from "../tts/types.js";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface ResolvedCallTts {
+  /** The resolved TTS provider, or null when config/registry is unavailable. */
+  provider: TtsProvider | null;
+
+  /**
+   * True when the provider supports streaming and audio should be
+   * synthesized via the provider API and streamed through the audio store.
+   * False when text tokens are sent directly to the relay for Twilio's
+   * built-in TTS engine.
+   */
+  useSynthesizedPath: boolean;
+
+  /** Audio format to use for synthesized audio. */
+  audioFormat: "mp3" | "wav" | "opus";
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the active TTS provider via the global provider abstraction.
+ *
+ * Providers that declare streaming support are treated as "synthesized"
+ * providers -- their audio is streamed through the audio store and played
+ * via `sendPlayUrl`. Providers without streaming support are "native"
+ * providers -- text tokens are streamed directly to the relay for Twilio's
+ * built-in TTS.
+ *
+ * Falls back to the native (non-streaming) path with `mp3` format when
+ * the config is missing a `services.tts` block or the provider is not
+ * registered (e.g. unit tests or early startup).
+ */
+export function resolveCallTtsProvider(): ResolvedCallTts {
+  try {
+    const config = loadConfig();
+    const resolved = resolveTtsConfig(config);
+    const provider = getTtsProvider(resolved.provider);
+
+    // Providers with streaming support synthesize audio themselves; others
+    // rely on the relay's native (Twilio-managed) TTS engine.
+    const useSynthesizedPath = provider.capabilities.supportsStreaming;
+
+    // Read the user-configured audio format from the resolved provider
+    // config so the streaming store entry's content-type matches the
+    // actual audio bytes the provider produces.
+    const configuredFormat = (resolved.providerConfig as { format?: string })
+      .format;
+    const audioFormat = (
+      configuredFormat && ["mp3", "wav", "opus"].includes(configuredFormat)
+        ? configuredFormat
+        : "mp3"
+    ) as "mp3" | "wav" | "opus";
+
+    return { provider, useSynthesizedPath, audioFormat };
+  } catch {
+    // Config missing `services.tts` block or provider not registered
+    // (e.g. unit tests or early startup) -- fall back to the native
+    // (non-streaming) path where the provider object is not used.
+    return { provider: null, useSynthesizedPath: false, audioFormat: "mp3" };
+  }
+}


### PR DESCRIPTION
## Summary
- Extracts duplicated provider-resolution logic into resolve-call-tts-provider.ts
- Both call controller and system-prompt speech paths consume the shared helper
- Preserves existing fallback semantics for missing config/provider registration
- Adds/adjusts tests for identical resolution behavior across call sites

Part of plan: tts-provider-onboarding-unification.md (PR 6 of 11)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24963" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
