### PR TITLE
fix: rename Whisper-specific constant to provider-agnostic name

### DIFF
--- a/assistant/src/config/bundled-skills/transcribe/tools/transcribe-media.ts
+++ b/assistant/src/config/bundled-skills/transcribe/tools/transcribe-media.ts
@@ -37,8 +37,8 @@ const AUDIO_EXTENSIONS = new Set([
   ".wma",
 ]);
 
-/** Max file size for a single Whisper API request (25MB). */
-const WHISPER_API_MAX_BYTES = 25 * 1024 * 1024;
+/** Max file size for a single STT chunk request (25MB). */
+const STT_CHUNK_MAX_BYTES = 25 * 1024 * 1024;
 
 /** Duration per chunk when splitting for large files (10 minutes - stays well under 25MB as WAV). */
 const CHUNK_DURATION_SECS = 600;
@@ -163,7 +163,7 @@ async function transcribeWithProvider(
   const fileSize = Bun.file(audioPath).size;
 
   // If small enough, send directly
-  if (fileSize <= WHISPER_API_MAX_BYTES) {
+  if (fileSize <= STT_CHUNK_MAX_BYTES) {
     const audioBuffer = await readFile(audioPath);
     const result = await transcriber.transcribe({
       audio: audioBuffer,


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for stt-service-product-unification.md.

**Gap:** Whisper-specific constant in provider-agnostic code path
**What was expected:** Provider-agnostic naming
**What was found:** WHISPER_API_MAX_BYTES used in generic transcribeWithProvider()
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24964" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
