### PR TITLE
fix(macos): prevent STT card from destructively deleting shared OpenAI key

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -2969,15 +2969,6 @@ public final class SettingsStore: ObservableObject {
         }
     }
 
-    /// Removes the stored OpenAI API key for the STT service.
-    func clearSTTOpenAIKey() {
-        APIKeyManager.deleteKey(for: "openai")
-        Task {
-            let deleted = await APIKeyManager.deleteKey(for: "openai")
-            if !deleted { addDeletionTombstone(type: "api_key", name: "openai") }
-        }
-    }
-
     /// Schedules a delayed refresh of provider routing sources, giving the
     /// daemon time to re-initialize providers after a key change.
     private func scheduleRoutingSourceRefresh() {

--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -539,14 +539,18 @@ struct VoiceSettingsView: View {
     private var openaiWhisperProviderConfig: some View {
         Group {
             if sttOpenAIHasKey {
-                HStack(spacing: VSpacing.sm) {
-                    VButton(label: "Connected", leftIcon: VIcon.circleCheck.rawValue, style: .primary) {}
-                    VButton(label: "Disconnect", style: .danger) {
-                        store.clearSTTOpenAIKey()
-                        sttOpenAIHasKey = false
-                        sttOpenAIKeyText = ""
-                        sttSetupExpanded = false
-                    }
+                // The OpenAI key is shared with the inference provider.
+                // Show a read-only "Connected" indicator without a
+                // "Disconnect" button — deleting the shared credential
+                // from the STT card would break inference.
+                VButton(label: "Connected", leftIcon: VIcon.circleCheck.rawValue, style: .primary) {}
+
+                HStack(spacing: VSpacing.xs) {
+                    VIconView(.info, size: 10)
+                        .foregroundStyle(VColor.contentTertiary)
+                    Text("Using your OpenAI API key from inference settings.")
+                        .font(VFont.labelDefault)
+                        .foregroundStyle(VColor.contentTertiary)
                 }
             } else if sttSetupExpanded {
                 VStack(alignment: .leading, spacing: VSpacing.sm) {
@@ -561,7 +565,7 @@ struct VoiceSettingsView: View {
                     HStack(spacing: VSpacing.xs) {
                         VIconView(.lock, size: 10)
                             .foregroundStyle(VColor.contentTertiary)
-                        Text("Your API key is stored securely in the macOS Keychain.")
+                        Text("Your API key is stored securely in the macOS Keychain and shared with inference.")
                             .font(VFont.labelDefault)
                             .foregroundStyle(VColor.contentTertiary)
                     }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for stt-service-product-unification.md.

**Gap:** clearSTTOpenAIKey() destructively deletes the shared OpenAI inference API key
**What was expected:** STT card should not delete shared credentials
**What was found:** clearSTTOpenAIKey() and saveSTTOpenAIKey() both operate on the shared 'openai' key slot

### Changes

- **VoiceSettingsView.swift**: When an OpenAI key exists, the STT card now shows a read-only 'Connected' indicator with an info message ('Using your OpenAI API key from inference settings.') instead of showing a 'Disconnect' button that would delete the shared credential. The key entry flow is only shown when no key exists yet.
- **SettingsStore.swift**: Removed `clearSTTOpenAIKey()` entirely since deleting the shared `openai` credential from the STT card is never safe (it would also break inference). Kept `saveSTTOpenAIKey()` for the case where no OpenAI key exists yet.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24965" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
