### PR TITLE
fix: remove unconsumed model/language fields from STT provider config schema

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -1150,10 +1150,7 @@ describe("AssistantConfigSchema", () => {
     const result = AssistantConfigSchema.parse({});
     expect(result.services.stt.mode).toBe("your-own");
     expect(result.services.stt.provider).toBe("openai-whisper");
-    expect(result.services.stt.providers["openai-whisper"].model).toBe(
-      "whisper-1",
-    );
-    expect(result.services.stt.providers["openai-whisper"].language).toBe("");
+    expect(result.services.stt.providers["openai-whisper"]).toEqual({});
   });
 
   test("accepts valid services.stt provider override", () => {
@@ -1169,15 +1166,12 @@ describe("AssistantConfigSchema", () => {
       services: {
         stt: {
           providers: {
-            "openai-whisper": { model: "whisper-2", language: "en" },
+            "openai-whisper": {},
           },
         },
       },
     });
-    expect(result.services.stt.providers["openai-whisper"].model).toBe(
-      "whisper-2",
-    );
-    expect(result.services.stt.providers["openai-whisper"].language).toBe("en");
+    expect(result.services.stt.providers["openai-whisper"]).toEqual({});
   });
 
   test("rejects services.stt.mode = managed", () => {

--- a/assistant/src/config/schemas/stt.ts
+++ b/assistant/src/config/schemas/stt.ts
@@ -9,28 +9,16 @@ export const VALID_STT_PROVIDERS = ["openai-whisper"] as const;
 /**
  * Per-provider config schemas nested under `services.stt.providers.<id>`.
  *
- * Each provider's schema is the full provider-specific config (model,
- * language, tuning params, etc.). New providers add sibling schemas
- * without restructuring.
+ * Each provider's schema is the full provider-specific config (tuning
+ * params, etc.). New providers add sibling schemas without restructuring.
+ *
+ * NOTE: `model` and `language` were intentionally removed — the runtime
+ * hardcodes `"whisper-1"` and auto-detect, so exposing config fields for
+ * them was misleading (values were silently ignored). Re-add them here
+ * once the provider adapter actually consumes them.
  */
 export const SttOpenAiWhisperProviderConfigSchema = z
-  .object({
-    model: z
-      .string({
-        error: "services.stt.providers.openai-whisper.model must be a string",
-      })
-      .default("whisper-1")
-      .describe("OpenAI Whisper model ID for speech-to-text"),
-    language: z
-      .string({
-        error:
-          "services.stt.providers.openai-whisper.language must be a string",
-      })
-      .default("")
-      .describe(
-        "ISO-639-1 language hint for transcription (leave empty for auto-detect)",
-      ),
-  })
+  .object({})
   .describe("OpenAI Whisper provider configuration under services.stt");
 
 export type SttOpenAiWhisperProviderConfig = z.infer<

--- a/assistant/src/providers/speech-to-text/__tests__/resolve.test.ts
+++ b/assistant/src/providers/speech-to-text/__tests__/resolve.test.ts
@@ -56,7 +56,7 @@ function buildConfig(overrides: {
         mode: "your-own",
         provider: overrides.provider ?? "openai-whisper",
         providers: {
-          "openai-whisper": { model: "whisper-1", language: "" },
+          "openai-whisper": {},
         },
       },
     },


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for stt-service-product-unification.md.

**Gap:** STT provider config model and language fields defined but never consumed
**What was expected:** Schema fields should be consumed or not exist
**What was found:** model and language are defined but silently ignored at runtime
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24966" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
