### PR TITLE
fix: rewrite STT schema comment to describe current state only

### DIFF
--- a/assistant/src/config/schemas/stt.ts
+++ b/assistant/src/config/schemas/stt.ts
@@ -12,10 +12,9 @@ export const VALID_STT_PROVIDERS = ["openai-whisper"] as const;
  * Each provider's schema is the full provider-specific config (tuning
  * params, etc.). New providers add sibling schemas without restructuring.
  *
- * NOTE: `model` and `language` were intentionally removed — the runtime
- * hardcodes `"whisper-1"` and auto-detect, so exposing config fields for
- * them was misleading (values were silently ignored). Re-add them here
- * once the provider adapter actually consumes them.
+ * The provider config is an empty object. Per-provider tuning params
+ * (e.g., model, language) can be added here once the provider adapter
+ * consumes them at runtime.
  */
 export const SttOpenAiWhisperProviderConfigSchema = z
   .object({})


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for stt-service-product-unification.md.

**Gap:** Comment uses historical narration about removed fields, violating AGENTS.md convention
**Fix:** Rewrote to describe current state and forward-looking extensibility

Part of plan: stt-service-product-unification.md (fix PR)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24968" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
