### PR TITLE
Product-Facing STT Service Unification

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -58,6 +58,7 @@ import { invalidateConfigCache, loadConfig } from "../config/loader.js";
 import {
   AssistantConfigSchema,
   DEFAULT_ELEVENLABS_VOICE_ID,
+  SttServiceSchema,
   TtsServiceSchema,
 } from "../config/schema.js";
 import type { AssistantConfig } from "../config/types.js";
@@ -1140,6 +1141,80 @@ describe("AssistantConfigSchema", () => {
 
     // Any other string should be rejected
     const invalid2 = TtsServiceSchema.safeParse({ mode: "self-hosted" });
+    expect(invalid2.success).toBe(false);
+  });
+
+  // ── services.stt config ──────────────────────────────────────────────
+
+  test("applies services.stt defaults when not specified", () => {
+    const result = AssistantConfigSchema.parse({});
+    expect(result.services.stt.mode).toBe("your-own");
+    expect(result.services.stt.provider).toBe("openai-whisper");
+    expect(result.services.stt.providers["openai-whisper"].model).toBe(
+      "whisper-1",
+    );
+    expect(result.services.stt.providers["openai-whisper"].language).toBe("");
+  });
+
+  test("accepts valid services.stt provider override", () => {
+    const result = AssistantConfigSchema.parse({
+      services: { stt: { provider: "openai-whisper" } },
+    });
+    expect(result.services.stt.provider).toBe("openai-whisper");
+    expect(result.services.stt.mode).toBe("your-own");
+  });
+
+  test("accepts valid services.stt.providers.openai-whisper overrides", () => {
+    const result = AssistantConfigSchema.parse({
+      services: {
+        stt: {
+          providers: {
+            "openai-whisper": { model: "whisper-2", language: "en" },
+          },
+        },
+      },
+    });
+    expect(result.services.stt.providers["openai-whisper"].model).toBe(
+      "whisper-2",
+    );
+    expect(result.services.stt.providers["openai-whisper"].language).toBe("en");
+  });
+
+  test("rejects services.stt.mode = managed", () => {
+    const result = AssistantConfigSchema.safeParse({
+      services: { stt: { mode: "managed" } },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const msgs = result.error.issues.map((i) => i.message);
+      expect(
+        msgs.some((m) => m.includes("your-own") || m.includes("managed")),
+      ).toBe(true);
+    }
+  });
+
+  test("rejects invalid services.stt.provider", () => {
+    const result = AssistantConfigSchema.safeParse({
+      services: { stt: { provider: "azure-speech" } },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const msgs = result.error.issues.map((i) => i.message);
+      expect(msgs.some((m) => m.includes("services.stt.provider"))).toBe(true);
+    }
+  });
+
+  test("services.stt.mode only accepts your-own as literal", () => {
+    // Explicit your-own should work
+    const valid = SttServiceSchema.safeParse({ mode: "your-own" });
+    expect(valid.success).toBe(true);
+
+    // managed should be rejected
+    const invalid = SttServiceSchema.safeParse({ mode: "managed" });
+    expect(invalid.success).toBe(false);
+
+    // Any other string should be rejected
+    const invalid2 = SttServiceSchema.safeParse({ mode: "self-hosted" });
     expect(invalid2.success).toBe(false);
   });
 

--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -1150,10 +1150,7 @@ describe("AssistantConfigSchema", () => {
     const result = AssistantConfigSchema.parse({});
     expect(result.services.stt.mode).toBe("your-own");
     expect(result.services.stt.provider).toBe("openai-whisper");
-    expect(result.services.stt.providers["openai-whisper"].model).toBe(
-      "whisper-1",
-    );
-    expect(result.services.stt.providers["openai-whisper"].language).toBe("");
+    expect(result.services.stt.providers["openai-whisper"]).toEqual({});
   });
 
   test("accepts valid services.stt provider override", () => {
@@ -1169,15 +1166,12 @@ describe("AssistantConfigSchema", () => {
       services: {
         stt: {
           providers: {
-            "openai-whisper": { model: "whisper-2", language: "en" },
+            "openai-whisper": {},
           },
         },
       },
     });
-    expect(result.services.stt.providers["openai-whisper"].model).toBe(
-      "whisper-2",
-    );
-    expect(result.services.stt.providers["openai-whisper"].language).toBe("en");
+    expect(result.services.stt.providers["openai-whisper"]).toEqual({});
   });
 
   test("rejects services.stt.mode = managed", () => {

--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -200,7 +200,6 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "oauth/oauth-store.ts", // OAuth provider disconnect (delete stored tokens)
       "oauth/manual-token-connection.ts", // manual-token provider backfill (credential store existence check)
       "workspace/provider-commit-message-generator.ts", // commit message generation provider key lookup
-      "config/bundled-skills/transcribe/tools/transcribe-media.ts", // transcription tool API key lookup
       "config/bundled-skills/image-studio/tools/media-generate-image.ts", // image generation tool API key lookup
       "config/bundled-skills/media-processing/tools/analyze-keyframes.ts", // keyframe analysis tool API key lookup
       "config/bundled-skills/media-processing/tools/extract-keyframes.ts", // keyframe extraction tool API key lookup

--- a/assistant/src/config/bundled-skills/transcribe/SKILL.md
+++ b/assistant/src/config/bundled-skills/transcribe/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: transcribe
-description: Transcribe audio and video files using Whisper
+description: Transcribe audio and video files using the configured speech-to-text provider
 compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "🎙️"
@@ -8,22 +8,12 @@ metadata:
     display-name: "Transcribe"
 ---
 
-Transcribe audio and video files using OpenAI's Whisper model - either via the cloud API or locally via whisper.cpp.
-
-## Choosing a Mode
-
-Before transcribing, **ask the user which mode they prefer** if they haven't specified:
-
-1. **`api`** - Uses the OpenAI Whisper API. Fast, accurate, no setup needed. Requires an OpenAI API key (check if one is already configured). Audio is sent to OpenAI's servers. Costs ~$0.006/min.
-2. **`local`** - Uses whisper.cpp installed via Homebrew. Free, private, runs entirely on-device. Requires a one-time `brew install whisper-cpp`. Slightly slower but no data leaves the machine.
-
-If the user says "cloud", "API", or "online" → use `api`.
-If the user says "local", "offline", "private", or "on-device" → use `local`.
+Transcribe audio and video files using the configured speech-to-text provider (e.g. OpenAI Whisper).
 
 ## Usage Notes
 
 - The tool accepts a `file_path` (absolute path to a local audio or video file) to transcribe.
 - Supported formats: any video (mp4, mov, etc.) or audio (mp3, wav, m4a, etc.) file.
 - For video files, audio is automatically extracted via ffmpeg before transcription.
-- The API mode has a 25MB per-request limit - large files are automatically split into chunks.
-- Local mode requires whisper.cpp (`brew install whisper-cpp`). The model is downloaded automatically on first use.
+- Large files are automatically split into chunks for processing.
+- If no STT provider credentials are configured, the tool will return an error with setup instructions.

--- a/assistant/src/config/bundled-skills/transcribe/TOOLS.json
+++ b/assistant/src/config/bundled-skills/transcribe/TOOLS.json
@@ -3,7 +3,7 @@
   "tools": [
     {
       "name": "transcribe_media",
-      "description": "Transcribe an audio or video file using Whisper. Provide a file_path to the media file. Set mode to 'api' (OpenAI cloud) or 'local' (whisper.cpp on-device). Ask the user which mode they prefer before calling.",
+      "description": "Transcribe an audio or video file using the configured speech-to-text provider. Provide a file_path to the media file.",
       "category": "transcribe",
       "risk": "low",
       "input_schema": {
@@ -13,17 +13,12 @@
             "type": "string",
             "description": "Absolute path to a local audio or video file to transcribe"
           },
-          "mode": {
-            "type": "string",
-            "enum": ["api", "local"],
-            "description": "Transcription backend: 'api' for OpenAI Whisper API (cloud), 'local' for whisper.cpp (on-device)"
-          },
           "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
-        "required": ["mode", "file_path"]
+        "required": ["file_path"]
       },
       "executor": "tools/transcribe-media.ts",
       "execution_target": "host"

--- a/assistant/src/config/bundled-skills/transcribe/tools/transcribe-media.test.ts
+++ b/assistant/src/config/bundled-skills/transcribe/tools/transcribe-media.test.ts
@@ -1,0 +1,256 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { BatchTranscriber } from "../../../../stt/types.js";
+import type { ToolContext } from "../../../../tools/types.js";
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before the subject import
+// ---------------------------------------------------------------------------
+
+mock.module("../../../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+let mockTranscriber: BatchTranscriber | null = null;
+
+mock.module("../../../../providers/speech-to-text/resolve.js", () => ({
+  resolveBatchTranscriber: async () => mockTranscriber,
+}));
+
+// Track calls to spawnWithTimeout so we can simulate ffmpeg/ffprobe results.
+let spawnResults: Record<
+  string,
+  { exitCode: number; stdout: string; stderr: string }
+> = {};
+
+mock.module("../../../../util/spawn.js", () => ({
+  FFMPEG_TRANSCODE_TIMEOUT_MS: 60_000,
+  FFPROBE_TIMEOUT_MS: 10_000,
+  spawnWithTimeout: async (args: string[]) => {
+    const cmd = args[0];
+    if (cmd === "ffprobe" && spawnResults["ffprobe"]) {
+      return spawnResults["ffprobe"];
+    }
+    if (cmd === "ffmpeg" && spawnResults["ffmpeg"]) {
+      return spawnResults["ffmpeg"];
+    }
+    return { exitCode: 0, stdout: "", stderr: "" };
+  },
+}));
+
+// Mock file access and reading
+let accessiblePaths: Set<string> = new Set();
+let mockFileContents: Record<string, Buffer> = {};
+
+mock.module("node:fs/promises", () => ({
+  access: async (p: string) => {
+    if (!accessiblePaths.has(p)) throw new Error(`ENOENT: no such file: ${p}`);
+  },
+  readFile: async (p: string) => {
+    return mockFileContents[p] ?? Buffer.alloc(0);
+  },
+  unlink: async () => {},
+  mkdir: async () => {},
+  readdir: async (dir: string) => {
+    // Return chunk files if any were set up
+    const chunks = Object.keys(mockFileContents).filter(
+      (k) => k.startsWith(dir) && k.includes("chunk-"),
+    );
+    return chunks.map((k) => k.split("/").pop()!);
+  },
+}));
+
+mock.module("../../../../util/silently.js", () => ({
+  silentlyWithLog: async () => {},
+}));
+
+// ---------------------------------------------------------------------------
+// Subject import (after mocks)
+// ---------------------------------------------------------------------------
+
+import { run } from "./transcribe-media.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeContext(overrides?: Partial<ToolContext>): ToolContext {
+  return {
+    workingDir: "/tmp",
+    conversationId: "test-conv",
+    trustClass: "guardian",
+    ...overrides,
+  };
+}
+
+function makeMockTranscriber(
+  results: Array<{ text: string }>,
+): BatchTranscriber {
+  let callIndex = 0;
+  return {
+    providerId: "openai-whisper",
+    boundaryId: "daemon-batch",
+    transcribe: async () => {
+      const result = results[callIndex] ?? { text: "" };
+      callIndex++;
+      return result;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("transcribe_media tool", () => {
+  beforeEach(() => {
+    mockTranscriber = null;
+    spawnResults = {};
+    accessiblePaths = new Set();
+    mockFileContents = {};
+  });
+
+  describe("no provider configured", () => {
+    test("returns error when no STT provider is available", async () => {
+      mockTranscriber = null;
+
+      const result = await run({ file_path: "/tmp/test.mp3" }, makeContext());
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain(
+        "No speech-to-text provider is configured",
+      );
+    });
+  });
+
+  describe("input validation", () => {
+    test("returns error when file_path is missing", async () => {
+      mockTranscriber = makeMockTranscriber([{ text: "hello" }]);
+
+      const result = await run({}, makeContext());
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("Provide a file_path");
+    });
+
+    test("returns error when file does not exist", async () => {
+      mockTranscriber = makeMockTranscriber([{ text: "hello" }]);
+
+      const result = await run(
+        { file_path: "/tmp/nonexistent.mp3" },
+        makeContext(),
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("File not found");
+    });
+
+    test("returns error for unsupported file type", async () => {
+      mockTranscriber = makeMockTranscriber([{ text: "hello" }]);
+      accessiblePaths.add("/tmp/test.xyz");
+
+      const result = await run({ file_path: "/tmp/test.xyz" }, makeContext());
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("Unsupported file type");
+    });
+  });
+
+  describe("successful transcription", () => {
+    test("transcribes audio file via configured STT provider", async () => {
+      mockTranscriber = makeMockTranscriber([
+        { text: "Hello world, this is a test." },
+      ]);
+      accessiblePaths.add("/tmp/test.mp3");
+
+      // Mock ffmpeg conversion success — toWav will produce a tmp wav file
+      spawnResults["ffmpeg"] = {
+        exitCode: 0,
+        stdout: "",
+        stderr: "",
+      };
+      // Mock ffprobe for duration check
+      spawnResults["ffprobe"] = {
+        exitCode: 0,
+        stdout: "60.0\n",
+        stderr: "",
+      };
+
+      const result = await run({ file_path: "/tmp/test.mp3" }, makeContext());
+
+      expect(result.isError).toBe(false);
+      expect(result.content).toBe("Hello world, this is a test.");
+    });
+
+    test("returns no-speech message when transcription is empty", async () => {
+      mockTranscriber = makeMockTranscriber([{ text: "" }]);
+      accessiblePaths.add("/tmp/silence.wav");
+
+      spawnResults["ffmpeg"] = { exitCode: 0, stdout: "", stderr: "" };
+      spawnResults["ffprobe"] = {
+        exitCode: 0,
+        stdout: "10.0\n",
+        stderr: "",
+      };
+
+      const result = await run(
+        { file_path: "/tmp/silence.wav" },
+        makeContext(),
+      );
+
+      expect(result.isError).toBe(false);
+      expect(result.content).toContain("No speech detected");
+    });
+  });
+
+  describe("error handling", () => {
+    test("returns error when ffmpeg conversion fails", async () => {
+      mockTranscriber = makeMockTranscriber([{ text: "hello" }]);
+      accessiblePaths.add("/tmp/test.mp3");
+
+      spawnResults["ffmpeg"] = {
+        exitCode: 1,
+        stdout: "",
+        stderr: "ffmpeg error: unsupported codec",
+      };
+
+      const result = await run({ file_path: "/tmp/test.mp3" }, makeContext());
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("Transcription failed");
+      expect(result.content).toContain("ffmpeg failed");
+    });
+  });
+
+  describe("legacy mode parameter rejection", () => {
+    test("rejects calls that pass the legacy mode parameter", async () => {
+      mockTranscriber = makeMockTranscriber([{ text: "transcribed text" }]);
+      accessiblePaths.add("/tmp/test.wav");
+
+      const result = await run(
+        { file_path: "/tmp/test.wav", mode: "local" },
+        makeContext(),
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain(
+        "`mode` parameter is no longer supported",
+      );
+    });
+
+    test("rejects mode parameter regardless of value", async () => {
+      mockTranscriber = makeMockTranscriber([{ text: "transcribed text" }]);
+
+      const result = await run(
+        { file_path: "/tmp/test.wav", mode: "cloud" },
+        makeContext(),
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("configured speech-to-text service");
+    });
+  });
+});

--- a/assistant/src/config/bundled-skills/transcribe/tools/transcribe-media.ts
+++ b/assistant/src/config/bundled-skills/transcribe/tools/transcribe-media.ts
@@ -37,8 +37,8 @@ const AUDIO_EXTENSIONS = new Set([
   ".wma",
 ]);
 
-/** Max file size for a single Whisper API request (25MB). */
-const WHISPER_API_MAX_BYTES = 25 * 1024 * 1024;
+/** Max file size for a single STT chunk request (25MB). */
+const STT_CHUNK_MAX_BYTES = 25 * 1024 * 1024;
 
 /** Duration per chunk when splitting for large files (10 minutes - stays well under 25MB as WAV). */
 const CHUNK_DURATION_SECS = 600;
@@ -163,7 +163,7 @@ async function transcribeWithProvider(
   const fileSize = Bun.file(audioPath).size;
 
   // If small enough, send directly
-  if (fileSize <= WHISPER_API_MAX_BYTES) {
+  if (fileSize <= STT_CHUNK_MAX_BYTES) {
     const audioBuffer = await readFile(audioPath);
     const result = await transcriber.transcribe({
       audio: audioBuffer,

--- a/assistant/src/config/bundled-skills/transcribe/tools/transcribe-media.ts
+++ b/assistant/src/config/bundled-skills/transcribe/tools/transcribe-media.ts
@@ -1,17 +1,10 @@
 import { randomUUID } from "node:crypto";
-import {
-  access,
-  mkdir,
-  readdir,
-  readFile,
-  unlink,
-  writeFile,
-} from "node:fs/promises";
+import { access, mkdir, readdir, readFile, unlink } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { extname, join } from "node:path";
 
-import { OpenAIWhisperProvider } from "../../../../providers/speech-to-text/openai-whisper.js";
-import { getProviderKeyAsync } from "../../../../security/secure-keys.js";
+import { resolveBatchTranscriber } from "../../../../providers/speech-to-text/resolve.js";
+import type { BatchTranscriber } from "../../../../stt/types.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -44,17 +37,14 @@ const AUDIO_EXTENSIONS = new Set([
   ".wma",
 ]);
 
-/** Max file size for a single OpenAI Whisper API request (25MB). */
+/** Max file size for a single Whisper API request (25MB). */
 const WHISPER_API_MAX_BYTES = 25 * 1024 * 1024;
 
-/** Duration per chunk when splitting for the API (10 minutes - stays well under 25MB as WAV). */
-const API_CHUNK_DURATION_SECS = 600;
+/** Duration per chunk when splitting for large files (10 minutes - stays well under 25MB as WAV). */
+const CHUNK_DURATION_SECS = 600;
 
-/** Timeout for a single Whisper API request. */
-const API_REQUEST_TIMEOUT_MS = 300_000;
-
-/** Timeout for a single whisper.cpp chunk transcription. */
-const LOCAL_CHUNK_TIMEOUT_MS = 600_000;
+/** Timeout for a single STT transcription request. */
+const STT_REQUEST_TIMEOUT_MS = 300_000;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -161,34 +151,30 @@ async function toWav(inputPath: string, isVideo: boolean): Promise<string> {
 }
 
 // ---------------------------------------------------------------------------
-// API mode - OpenAI Whisper API
+// Transcription via resolved STT provider
 // ---------------------------------------------------------------------------
 
-async function transcribeViaApi(
+async function transcribeWithProvider(
   audioPath: string,
-  apiKey: string,
+  transcriber: BatchTranscriber,
   context: ToolContext,
 ): Promise<string> {
-  const provider = new OpenAIWhisperProvider(apiKey);
   const duration = await getAudioDuration(audioPath);
   const fileSize = Bun.file(audioPath).size;
 
   // If small enough, send directly
   if (fileSize <= WHISPER_API_MAX_BYTES) {
     const audioBuffer = await readFile(audioPath);
-    const result = await provider.transcribe(
-      audioBuffer,
-      "audio/wav",
-      AbortSignal.timeout(API_REQUEST_TIMEOUT_MS),
-    );
+    const result = await transcriber.transcribe({
+      audio: audioBuffer,
+      mimeType: "audio/wav",
+      signal: AbortSignal.timeout(STT_REQUEST_TIMEOUT_MS),
+    });
     return result.text;
   }
 
   // Split into chunks for large files
-  const chunkDir = join(
-    tmpdir(),
-    `vellum-transcribe-api-chunks-${randomUUID()}`,
-  );
+  const chunkDir = join(tmpdir(), `vellum-transcribe-chunks-${randomUUID()}`);
   await mkdir(chunkDir, { recursive: true });
 
   try {
@@ -197,22 +183,18 @@ async function transcribeViaApi(
         duration / 60,
       )}min) - splitting into chunks...\n`,
     );
-    const chunks = await splitAudio(
-      audioPath,
-      chunkDir,
-      API_CHUNK_DURATION_SECS,
-    );
+    const chunks = await splitAudio(audioPath, chunkDir, CHUNK_DURATION_SECS);
     const parts: string[] = [];
 
     for (let i = 0; i < chunks.length; i++) {
       if (context.signal?.aborted) throw new Error("Cancelled");
       context.onOutput?.(`  Transcribing chunk ${i + 1}/${chunks.length}...\n`);
       const audioBuffer = await readFile(chunks[i]);
-      const result = await provider.transcribe(
-        audioBuffer,
-        "audio/wav",
-        AbortSignal.timeout(API_REQUEST_TIMEOUT_MS),
-      );
+      const result = await transcriber.transcribe({
+        audio: audioBuffer,
+        mimeType: "audio/wav",
+        signal: AbortSignal.timeout(STT_REQUEST_TIMEOUT_MS),
+      });
       if (result.text) parts.push(result.text);
     }
 
@@ -227,131 +209,6 @@ async function transcribeViaApi(
 }
 
 // ---------------------------------------------------------------------------
-// Local mode - whisper.cpp
-// ---------------------------------------------------------------------------
-
-async function transcribeViaLocal(
-  audioPath: string,
-  context: ToolContext,
-): Promise<string> {
-  // Check if whisper-cpp is installed
-  const whichResult = await spawnWithTimeout(["which", "whisper-cpp"], 5_000);
-  if (whichResult.exitCode !== 0) {
-    throw new Error(
-      "whisper-cpp is not installed. Install it with: brew install whisper-cpp",
-    );
-  }
-
-  // Resolve model path - use the base model, download if needed
-  const modelPath = await resolveWhisperModel(context);
-
-  const duration = await getAudioDuration(audioPath);
-
-  if (duration > 0 && duration <= 1800) {
-    // Under 30 minutes - transcribe directly (whisper.cpp handles long files well)
-    context.onOutput?.(
-      `Transcribing ${Math.round(duration / 60)}min of audio locally...\n`,
-    );
-    return await whisperCppRun(audioPath, modelPath);
-  }
-
-  // Very long files - split into 10-minute chunks to show progress
-  const chunkDir = join(
-    tmpdir(),
-    `vellum-transcribe-local-chunks-${randomUUID()}`,
-  );
-  await mkdir(chunkDir, { recursive: true });
-
-  try {
-    context.onOutput?.(
-      `Large file (${Math.round(
-        duration / 60,
-      )}min) - splitting into chunks...\n`,
-    );
-    const chunks = await splitAudio(audioPath, chunkDir, 600);
-    const parts: string[] = [];
-
-    for (let i = 0; i < chunks.length; i++) {
-      if (context.signal?.aborted) throw new Error("Cancelled");
-      context.onOutput?.(`  Transcribing chunk ${i + 1}/${chunks.length}...\n`);
-      const text = await whisperCppRun(chunks[i], modelPath);
-      if (text) parts.push(text);
-    }
-
-    return parts.join(" ");
-  } finally {
-    const { rm } = await import("node:fs/promises");
-    await silentlyWithLog(
-      rm(chunkDir, { recursive: true, force: true }),
-      "transcribe chunk cleanup",
-    );
-  }
-}
-
-async function resolveWhisperModel(context: ToolContext): Promise<string> {
-  // Check common locations for the base model
-  const homeDir = process.env.HOME ?? "/tmp";
-  const candidates = [
-    join(homeDir, ".vellum", "models", "ggml-base.en.bin"),
-    join(homeDir, ".vellum", "models", "ggml-base.bin"),
-    "/usr/local/share/whisper-cpp/models/ggml-base.en.bin",
-    "/opt/homebrew/share/whisper-cpp/models/ggml-base.en.bin",
-  ];
-
-  for (const p of candidates) {
-    try {
-      await access(p);
-      return p;
-    } catch {
-      /* next */
-    }
-  }
-
-  // Download the base.en model (~140MB)
-  const modelDir = join(homeDir, ".vellum", "models");
-  await mkdir(modelDir, { recursive: true });
-  const modelPath = join(modelDir, "ggml-base.en.bin");
-  const modelUrl =
-    "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.en.bin";
-
-  context.onOutput?.("Downloading Whisper base.en model (~140MB)...\n");
-
-  const response = await fetch(modelUrl);
-  if (!response.ok) {
-    throw new Error(`Failed to download model: ${response.status}`);
-  }
-
-  const data = Buffer.from(await response.arrayBuffer());
-  await writeFile(modelPath, data);
-  context.onOutput?.("Model downloaded.\n");
-
-  return modelPath;
-}
-
-async function whisperCppRun(
-  audioPath: string,
-  modelPath: string,
-): Promise<string> {
-  const result = await spawnWithTimeout(
-    ["whisper-cpp", "-m", modelPath, "-f", audioPath, "--no-timestamps"],
-    LOCAL_CHUNK_TIMEOUT_MS,
-  );
-
-  if (result.exitCode !== 0) {
-    throw new Error(`whisper-cpp failed: ${result.stderr.slice(0, 300)}`);
-  }
-
-  // whisper-cpp outputs transcription to stderr with some logging, and
-  // the actual text lines to stdout. Clean up whitespace.
-  return result.stdout
-    .split("\n")
-    .map((l) => l.trim())
-    .filter((l) => l.length > 0)
-    .join(" ")
-    .trim();
-}
-
-// ---------------------------------------------------------------------------
 // Main entry point
 // ---------------------------------------------------------------------------
 
@@ -359,26 +216,24 @@ export async function run(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  const mode = input.mode as "api" | "local";
-  if (!mode || (mode !== "api" && mode !== "local")) {
+  // Reject legacy callers that pass the now-removed `mode` parameter to avoid
+  // silently routing audio through a different provider than expected.
+  if ("mode" in input) {
     return {
       content:
-        "Please specify mode: 'api' (OpenAI cloud) or 'local' (whisper.cpp on-device). Ask the user which they prefer.",
+        "The `mode` parameter is no longer supported. Transcription now uses the configured speech-to-text service.",
       isError: true,
     };
   }
 
-  // Validate API key for api mode
-  let openaiKey: string | undefined;
-  if (mode === "api") {
-    openaiKey = await getProviderKeyAsync("openai");
-    if (!openaiKey) {
-      return {
-        content:
-          'No OpenAI API key configured. Set your OpenAI API key to use cloud transcription, or use mode "local" for on-device transcription with whisper.cpp.',
-        isError: true,
-      };
-    }
+  // Resolve the configured STT provider
+  const transcriber = await resolveBatchTranscriber();
+  if (!transcriber) {
+    return {
+      content:
+        "No speech-to-text provider is configured. Set up an STT provider (e.g. OpenAI API key) in your assistant settings to enable transcription.",
+      isError: true,
+    };
   }
 
   const source = await resolveSource(input);
@@ -391,12 +246,7 @@ export async function run(
     // Convert to WAV
     wavPath = await toWav(inputPath, isVideo);
 
-    let text: string;
-    if (mode === "api") {
-      text = await transcribeViaApi(wavPath, openaiKey!, context);
-    } else {
-      text = await transcribeViaLocal(wavPath, context);
-    }
+    const text = await transcribeWithProvider(wavPath, transcriber, context);
 
     if (!text.trim()) {
       return { content: "No speech detected in the audio.", isError: false };

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -192,6 +192,17 @@ export {
   SkillsInstallConfigSchema,
   SkillsLoadConfigSchema,
 } from "./schemas/skills.js";
+export type {
+  SttOpenAiWhisperProviderConfig,
+  SttProviders,
+  SttService,
+} from "./schemas/stt.js";
+export {
+  SttOpenAiWhisperProviderConfigSchema,
+  SttProvidersSchema,
+  SttServiceSchema,
+  VALID_STT_PROVIDERS,
+} from "./schemas/stt.js";
 export type { RateLimitConfig, TimeoutConfig } from "./schemas/timeouts.js";
 export {
   RateLimitConfigSchema,

--- a/assistant/src/config/schemas/services.ts
+++ b/assistant/src/config/schemas/services.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 
+import { SttServiceSchema } from "./stt.js";
 import { TtsServiceSchema } from "./tts.js";
 
 export const ServiceModeSchema = z.enum(["managed", "your-own"]);
@@ -86,6 +87,7 @@ export const ServicesSchema = z.object({
   "web-search": WebSearchServiceSchema.default(
     WebSearchServiceSchema.parse({}),
   ),
+  stt: SttServiceSchema.default(SttServiceSchema.parse({})),
   tts: TtsServiceSchema.default(TtsServiceSchema.parse({})),
   "google-oauth": GoogleOAuthServiceSchema.default(
     GoogleOAuthServiceSchema.parse({}),

--- a/assistant/src/config/schemas/stt.ts
+++ b/assistant/src/config/schemas/stt.ts
@@ -9,28 +9,16 @@ export const VALID_STT_PROVIDERS = ["openai-whisper"] as const;
 /**
  * Per-provider config schemas nested under `services.stt.providers.<id>`.
  *
- * Each provider's schema is the full provider-specific config (model,
- * language, tuning params, etc.). New providers add sibling schemas
- * without restructuring.
+ * Each provider's schema is the full provider-specific config (tuning
+ * params, etc.). New providers add sibling schemas without restructuring.
+ *
+ * NOTE: `model` and `language` were intentionally removed — the runtime
+ * hardcodes `"whisper-1"` and auto-detect, so exposing config fields for
+ * them was misleading (values were silently ignored). Re-add them here
+ * once the provider adapter actually consumes them.
  */
 export const SttOpenAiWhisperProviderConfigSchema = z
-  .object({
-    model: z
-      .string({
-        error: "services.stt.providers.openai-whisper.model must be a string",
-      })
-      .default("whisper-1")
-      .describe("OpenAI Whisper model ID for speech-to-text"),
-    language: z
-      .string({
-        error:
-          "services.stt.providers.openai-whisper.language must be a string",
-      })
-      .default("")
-      .describe(
-        "ISO-639-1 language hint for transcription (leave empty for auto-detect)",
-      ),
-  })
+  .object({})
   .describe("OpenAI Whisper provider configuration under services.stt");
 
 export type SttOpenAiWhisperProviderConfig = z.infer<

--- a/assistant/src/config/schemas/stt.ts
+++ b/assistant/src/config/schemas/stt.ts
@@ -12,10 +12,9 @@ export const VALID_STT_PROVIDERS = ["openai-whisper"] as const;
  * Each provider's schema is the full provider-specific config (tuning
  * params, etc.). New providers add sibling schemas without restructuring.
  *
- * NOTE: `model` and `language` were intentionally removed — the runtime
- * hardcodes `"whisper-1"` and auto-detect, so exposing config fields for
- * them was misleading (values were silently ignored). Re-add them here
- * once the provider adapter actually consumes them.
+ * The provider config is an empty object. Per-provider tuning params
+ * (e.g., model, language) can be added here once the provider adapter
+ * consumes them at runtime.
  */
 export const SttOpenAiWhisperProviderConfigSchema = z
   .object({})

--- a/assistant/src/config/schemas/stt.ts
+++ b/assistant/src/config/schemas/stt.ts
@@ -1,0 +1,76 @@
+import { z } from "zod";
+
+/**
+ * Valid STT provider identifiers. New providers append here and register
+ * an adapter.
+ */
+export const VALID_STT_PROVIDERS = ["openai-whisper"] as const;
+
+/**
+ * Per-provider config schemas nested under `services.stt.providers.<id>`.
+ *
+ * Each provider's schema is the full provider-specific config (model,
+ * language, tuning params, etc.). New providers add sibling schemas
+ * without restructuring.
+ */
+export const SttOpenAiWhisperProviderConfigSchema = z
+  .object({
+    model: z
+      .string({
+        error: "services.stt.providers.openai-whisper.model must be a string",
+      })
+      .default("whisper-1")
+      .describe("OpenAI Whisper model ID for speech-to-text"),
+    language: z
+      .string({
+        error:
+          "services.stt.providers.openai-whisper.language must be a string",
+      })
+      .default("")
+      .describe(
+        "ISO-639-1 language hint for transcription (leave empty for auto-detect)",
+      ),
+  })
+  .describe("OpenAI Whisper provider configuration under services.stt");
+
+export type SttOpenAiWhisperProviderConfig = z.infer<
+  typeof SttOpenAiWhisperProviderConfigSchema
+>;
+
+export const SttProvidersSchema = z.object({
+  "openai-whisper": SttOpenAiWhisperProviderConfigSchema.default(
+    SttOpenAiWhisperProviderConfigSchema.parse({}),
+  ),
+});
+export type SttProviders = z.infer<typeof SttProvidersSchema>;
+
+/**
+ * Canonical STT service configuration.
+ *
+ * `mode` is locked to `"your-own"` -- managed STT is not supported.
+ * Attempting to set `mode: "managed"` will fail schema validation.
+ */
+export const SttServiceSchema = z
+  .object({
+    mode: z
+      .literal("your-own", {
+        error:
+          'services.stt.mode must be "your-own" -- managed STT is not supported',
+      })
+      .default("your-own" as const)
+      .describe(
+        'STT service mode -- only "your-own" is supported (managed STT is not available)',
+      ),
+    provider: z
+      .enum(VALID_STT_PROVIDERS, {
+        error: `services.stt.provider must be one of: ${VALID_STT_PROVIDERS.join(", ")}`,
+      })
+      .default("openai-whisper")
+      .describe("Active STT provider used for speech-to-text transcription"),
+    providers: SttProvidersSchema.default(SttProvidersSchema.parse({})),
+  })
+  .describe(
+    "Speech-to-text service configuration -- provider selection and per-provider settings",
+  );
+
+export type SttService = z.infer<typeof SttServiceSchema>;

--- a/assistant/src/providers/speech-to-text/__tests__/resolve.test.ts
+++ b/assistant/src/providers/speech-to-text/__tests__/resolve.test.ts
@@ -56,7 +56,7 @@ function buildConfig(overrides: {
         mode: "your-own",
         provider: overrides.provider ?? "openai-whisper",
         providers: {
-          "openai-whisper": { model: "whisper-1", language: "" },
+          "openai-whisper": {},
         },
       },
     },

--- a/assistant/src/providers/speech-to-text/__tests__/resolve.test.ts
+++ b/assistant/src/providers/speech-to-text/__tests__/resolve.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before any subject imports
+// ---------------------------------------------------------------------------
+
+// -- Logger mock ----------------------------------------------------------
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// -- Config mock ----------------------------------------------------------
+
+let mockConfig: Record<string, unknown> = {};
+
+mock.module("../../../config/loader.js", () => ({
+  getConfig: () => mockConfig,
+  loadConfig: () => mockConfig,
+}));
+
+// -- Credential mock ------------------------------------------------------
+
+let mockProviderKeys: Record<string, string | undefined> = {};
+
+mock.module("../../../security/secure-keys.js", () => ({
+  getProviderKeyAsync: async (provider: string) =>
+    mockProviderKeys[provider] ?? undefined,
+  getSecureKeyAsync: async () => null,
+  getSecureKey: () => null,
+}));
+
+mock.module("../../../security/credential-key.js", () => ({
+  credentialKey: (...args: string[]) => args.join("/"),
+}));
+
+// ---------------------------------------------------------------------------
+// Subject import (after mocks)
+// ---------------------------------------------------------------------------
+
+import { resolveBatchTranscriber } from "../resolve.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildConfig(overrides: {
+  provider?: string;
+}): Record<string, unknown> {
+  return {
+    services: {
+      stt: {
+        mode: "your-own",
+        provider: overrides.provider ?? "openai-whisper",
+        providers: {
+          "openai-whisper": { model: "whisper-1", language: "" },
+        },
+      },
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("resolveBatchTranscriber", () => {
+  beforeEach(() => {
+    mockConfig = buildConfig({});
+    mockProviderKeys = {};
+  });
+
+  test("returns a BatchTranscriber when openai-whisper is configured and credentials are available", async () => {
+    mockProviderKeys["openai"] = "sk-test-key";
+    mockConfig = buildConfig({ provider: "openai-whisper" });
+
+    const transcriber = await resolveBatchTranscriber();
+
+    expect(transcriber).not.toBeNull();
+    expect(transcriber!.providerId).toBe("openai-whisper");
+    expect(transcriber!.boundaryId).toBe("daemon-batch");
+  });
+
+  test("returns null when credentials are missing for the configured provider", async () => {
+    mockProviderKeys = {}; // no keys at all
+    mockConfig = buildConfig({ provider: "openai-whisper" });
+
+    const transcriber = await resolveBatchTranscriber();
+
+    expect(transcriber).toBeNull();
+  });
+
+  test("returns null when configured provider is unsupported for daemon-batch", async () => {
+    // Force an unknown provider past the type system to simulate a future
+    // provider that hasn't been wired into the daemon-batch boundary yet.
+    mockProviderKeys["deepgram"] = "dg-test-key";
+    mockConfig = buildConfig({ provider: "deepgram" as string });
+
+    const transcriber = await resolveBatchTranscriber();
+
+    expect(transcriber).toBeNull();
+  });
+
+  test("uses config-driven provider selection, not hardcoded OpenAI", async () => {
+    // Verify the resolver reads from config rather than always using "openai".
+    // If the config says openai-whisper, we expect credential lookup for "openai".
+    mockProviderKeys["openai"] = "sk-config-driven";
+    mockConfig = buildConfig({ provider: "openai-whisper" });
+
+    const transcriber = await resolveBatchTranscriber();
+
+    expect(transcriber).not.toBeNull();
+    expect(transcriber!.providerId).toBe("openai-whisper");
+  });
+
+  test("resolved transcriber has stable provider identity", async () => {
+    mockProviderKeys["openai"] = "sk-identity-test";
+    mockConfig = buildConfig({ provider: "openai-whisper" });
+
+    const transcriber = await resolveBatchTranscriber();
+
+    // The providerId must remain "openai-whisper" for downstream identity checks.
+    expect(transcriber!.providerId).toBe("openai-whisper");
+    expect(transcriber!.boundaryId).toBe("daemon-batch");
+  });
+});

--- a/assistant/src/providers/speech-to-text/resolve.ts
+++ b/assistant/src/providers/speech-to-text/resolve.ts
@@ -1,16 +1,57 @@
+import { getConfig } from "../../config/loader.js";
 import { getProviderKeyAsync } from "../../security/secure-keys.js";
 import { createDaemonBatchTranscriber } from "../../stt/daemon-batch-transcriber.js";
-import type { BatchTranscriber } from "../../stt/types.js";
+import type { BatchTranscriber, SttProviderId } from "../../stt/types.js";
+
+// ---------------------------------------------------------------------------
+// Provider-to-credential mapping
+// ---------------------------------------------------------------------------
+
+/**
+ * Map an STT provider identifier to the credential provider name used by
+ * `getProviderKeyAsync`. New STT providers that share credentials with an
+ * existing credential provider (e.g. a future Deepgram provider would map
+ * to `"deepgram"`) add an entry here.
+ *
+ * Typed as `Record<SttProviderId, string>` to ensure compile-time
+ * completeness: adding a new variant to `SttProviderId` without a
+ * corresponding entry here is a type error.
+ */
+const STT_PROVIDER_CREDENTIAL_MAP: Record<SttProviderId, string> = {
+  "openai-whisper": "openai",
+};
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
 
 /**
  * Resolve a `BatchTranscriber` for daemon-hosted batch transcription.
  *
- * Credential lookup is centralized here (an authorized secure-keys importer)
- * so callers don't need to import secure-keys directly.
+ * Reads `services.stt.provider` from the assistant config to determine which
+ * STT provider to use, then looks up the corresponding credential. Credential
+ * lookup is centralized here (an authorized secure-keys importer) so callers
+ * don't need to import secure-keys directly.
  *
- * Returns `null` when no STT credentials are configured.
+ * Returns `null` when:
+ * - The configured provider is not supported by the daemon-batch boundary.
+ * - No credentials are configured for the resolved provider.
  */
 export async function resolveBatchTranscriber(): Promise<BatchTranscriber | null> {
-  const apiKey = await getProviderKeyAsync("openai");
+  const config = getConfig();
+  const provider = config.services.stt.provider;
+
+  // Resolve the credential provider name for the configured STT provider.
+  // Cast to `string` for the lookup so that unknown providers (which can
+  // arrive at runtime despite the schema validation) produce `undefined`
+  // instead of a type error. This keeps the runtime guard meaningful.
+  const credentialProvider = STT_PROVIDER_CREDENTIAL_MAP[
+    provider as SttProviderId
+  ] as string | undefined;
+  if (!credentialProvider) {
+    return null;
+  }
+
+  const apiKey = await getProviderKeyAsync(credentialProvider);
   return createDaemonBatchTranscriber(apiKey);
 }

--- a/assistant/src/runtime/routes/inbound-stages/transcribe-audio.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/transcribe-audio.test.ts
@@ -156,7 +156,7 @@ describe("tryTranscribeAudioAttachments", () => {
     expect(result).toEqual({ status: "no_audio" });
   });
 
-  test("no API key returns no_provider with helpful reason string", async () => {
+  test("no provider returns no_provider with service-agnostic reason", async () => {
     const audio = makeAudioAttachment("a1");
     mockAttachments = [audio];
     mockTranscriber = null; // No transcriber resolved
@@ -164,9 +164,10 @@ describe("tryTranscribeAudioAttachments", () => {
     const result = await tryTranscribeAudioAttachments(["a1"]);
 
     expect(result.status).toBe("no_provider");
-    expect((result as { reason: string }).reason).toContain(
-      "No OpenAI API key configured",
-    );
+    const reason = (result as { reason: string }).reason;
+    expect(reason).toContain("speech-to-text");
+    expect(reason).toContain("voice message transcription");
+    expect(reason).not.toContain("OpenAI");
   });
 
   test("API failure returns error with reason", async () => {

--- a/assistant/src/runtime/routes/inbound-stages/transcribe-audio.ts
+++ b/assistant/src/runtime/routes/inbound-stages/transcribe-audio.ts
@@ -62,7 +62,7 @@ export async function tryTranscribeAudioAttachments(
       return {
         status: "no_provider",
         reason:
-          "No OpenAI API key configured. Set one up to enable voice message transcription.",
+          "No speech-to-text provider configured. Add an API key for your STT service to enable voice message transcription.",
       };
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -146,6 +146,8 @@ struct SettingsPanel: View {
     private static let embeddingProviderFeatureFlagKey = "settings-embedding-provider"
     private static let emailChannelFeatureFlagKey = "email-channel"
     private static let soundsFeatureFlagKey = "sounds"
+    private static let sttServiceFeatureFlagKey = "stt-service"
+    @State private var isSttServiceEnabled: Bool = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -203,6 +205,7 @@ struct SettingsPanel: View {
             isBillingEnabled = MacOSClientFeatureFlagManager.shared.isEnabled(Self.billingFeatureFlagKey)
             isSoundsEnabled = assistantFeatureFlagStore.isEnabled(Self.soundsFeatureFlagKey)
             isSchedulesEnabled = assistantFeatureFlagStore.isEnabled(Self.schedulesFeatureFlagKey)
+            isSttServiceEnabled = assistantFeatureFlagStore.isEnabled(Self.sttServiceFeatureFlagKey)
             // The init already consumed pendingSettingsTab into selectedTab.
             // Clear the store value so it doesn't leak into future navigations.
             if store.pendingSettingsTab != nil {
@@ -266,6 +269,8 @@ struct SettingsPanel: View {
                     if !enabled && selectedTab == .schedules {
                         selectedTab = .general
                     }
+                } else if key == Self.sttServiceFeatureFlagKey {
+                    isSttServiceEnabled = enabled
                 }
             }
         }
@@ -414,7 +419,7 @@ struct SettingsPanel: View {
                 onEnableIntegration: onEnableIntegration
             )
         case .voice:
-            VoiceSettingsView(store: store)
+            VoiceSettingsView(store: store, isSttServiceEnabled: isSttServiceEnabled)
         case .sounds:
             SettingsSoundsTab()
         case .permissionsAndPrivacy:
@@ -660,6 +665,9 @@ struct SettingsPanel: View {
                 if let schedulesFlag = flags.first(where: { $0.key == Self.schedulesFeatureFlagKey }) {
                     isSchedulesEnabled = schedulesFlag.enabled
                 }
+                if let sttServiceFlag = flags.first(where: { $0.key == Self.sttServiceFeatureFlagKey }) {
+                    isSttServiceEnabled = sttServiceFlag.enabled
+                }
                 consumeDeferredDeepLinkIfVisible()
                 return
             } catch {
@@ -685,6 +693,9 @@ struct SettingsPanel: View {
         }
         if let schedulesEnabled = resolved[Self.schedulesFeatureFlagKey] {
             isSchedulesEnabled = schedulesEnabled
+        }
+        if let sttServiceEnabled = resolved[Self.sttServiceFeatureFlagKey] {
+            isSttServiceEnabled = sttServiceEnabled
         }
         consumeDeferredDeepLinkIfVisible()
     }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -2936,6 +2936,48 @@ public final class SettingsStore: ObservableObject {
         return task
     }
 
+    /// Persists the selected STT provider to the daemon config so
+    /// transcription routes through the correct backend. The canonical
+    /// config path is `services.stt.provider`.
+    @discardableResult
+    func setSTTProvider(_ provider: String) -> Task<Bool, Never> {
+        let task = Task {
+            let success = await settingsClient.patchConfig([
+                "services": ["stt": ["provider": provider]]
+            ])
+            if !success {
+                log.error("Failed to patch config for STT provider")
+            }
+            return success
+        }
+        return task
+    }
+
+    /// Saves an OpenAI API key for the STT service to the credential store.
+    func saveSTTOpenAIKey(_ raw: String, onSuccess: (() -> Void)? = nil) {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        APIKeyManager.setKey(trimmed, for: "openai")
+        removeDeletionTombstone(type: "api_key", name: "openai")
+        Task {
+            let result = await APIKeyManager.setKey(trimmed, for: "openai")
+            if result.success {
+                onSuccess?()
+            } else if let error = result.error {
+                log.error("Failed to sync OpenAI STT key to daemon: \(error, privacy: .public)")
+            }
+        }
+    }
+
+    /// Removes the stored OpenAI API key for the STT service.
+    func clearSTTOpenAIKey() {
+        APIKeyManager.deleteKey(for: "openai")
+        Task {
+            let deleted = await APIKeyManager.deleteKey(for: "openai")
+            if !deleted { addDeletionTombstone(type: "api_key", name: "openai") }
+        }
+    }
+
     /// Schedules a delayed refresh of provider routing sources, giving the
     /// daemon time to re-initialize providers after a key change.
     private func scheduleRoutingSourceRefresh() {
@@ -3364,6 +3406,15 @@ public final class SettingsStore: ObservableObject {
            let tts = services["tts"] as? [String: Any],
            let ttsProvider = tts["provider"] as? String {
             UserDefaults.standard.set(ttsProvider, forKey: "ttsProvider")
+        }
+
+        // Sync the global STT provider from the daemon config so the client
+        // stays aligned after restart or reconnection. The canonical path
+        // is services.stt.provider.
+        if let services = config["services"] as? [String: Any],
+           let stt = services["stt"] as? [String: Any],
+           let sttProvider = stt["provider"] as? String {
+            UserDefaults.standard.set(sttProvider, forKey: "sttProvider")
         }
 
         Self.applyHostBrowserCdpInspectConfig(config, into: self)

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -2969,15 +2969,6 @@ public final class SettingsStore: ObservableObject {
         }
     }
 
-    /// Removes the stored OpenAI API key for the STT service.
-    func clearSTTOpenAIKey() {
-        APIKeyManager.deleteKey(for: "openai")
-        Task {
-            let deleted = await APIKeyManager.deleteKey(for: "openai")
-            if !deleted { addDeletionTombstone(type: "api_key", name: "openai") }
-        }
-    }
-
     /// Schedules a delayed refresh of provider routing sources, giving the
     /// daemon time to re-initialize providers after a key change.
     private func scheduleRoutingSourceRefresh() {

--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -539,14 +539,18 @@ struct VoiceSettingsView: View {
     private var openaiWhisperProviderConfig: some View {
         Group {
             if sttOpenAIHasKey {
-                HStack(spacing: VSpacing.sm) {
-                    VButton(label: "Connected", leftIcon: VIcon.circleCheck.rawValue, style: .primary) {}
-                    VButton(label: "Disconnect", style: .danger) {
-                        store.clearSTTOpenAIKey()
-                        sttOpenAIHasKey = false
-                        sttOpenAIKeyText = ""
-                        sttSetupExpanded = false
-                    }
+                // The OpenAI key is shared with the inference provider.
+                // Show a read-only "Connected" indicator without a
+                // "Disconnect" button — deleting the shared credential
+                // from the STT card would break inference.
+                VButton(label: "Connected", leftIcon: VIcon.circleCheck.rawValue, style: .primary) {}
+
+                HStack(spacing: VSpacing.xs) {
+                    VIconView(.info, size: 10)
+                        .foregroundStyle(VColor.contentTertiary)
+                    Text("Using your OpenAI API key from inference settings.")
+                        .font(VFont.labelDefault)
+                        .foregroundStyle(VColor.contentTertiary)
                 }
             } else if sttSetupExpanded {
                 VStack(alignment: .leading, spacing: VSpacing.sm) {
@@ -561,7 +565,7 @@ struct VoiceSettingsView: View {
                     HStack(spacing: VSpacing.xs) {
                         VIconView(.lock, size: 10)
                             .foregroundStyle(VColor.contentTertiary)
-                        Text("Your API key is stored securely in the macOS Keychain.")
+                        Text("Your API key is stored securely in the macOS Keychain and shared with inference.")
                             .font(VFont.labelDefault)
                             .foregroundStyle(VColor.contentTertiary)
                     }

--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -23,14 +23,34 @@ private enum TTSProviderOption: String, CaseIterable {
     }
 }
 
+/// STT provider options for the speech-to-text service card.
+private enum STTProviderOption: String, CaseIterable {
+    case openaiWhisper = "openai-whisper"
+
+    var displayName: String {
+        switch self {
+        case .openaiWhisper: return "OpenAI Whisper"
+        }
+    }
+
+    var subtitle: String {
+        switch self {
+        case .openaiWhisper:
+            return "High-accuracy speech-to-text transcription. Requires an OpenAI API key."
+        }
+    }
+}
+
 /// Voice settings tab — configure push-to-talk activation key,
-/// conversation timeout, and text-to-speech provider.
+/// conversation timeout, text-to-speech provider, and speech-to-text provider.
 struct VoiceSettingsView: View {
     @ObservedObject var store: SettingsStore
+    var isSttServiceEnabled: Bool = false
 
     @AppStorage("activationKey") private var activationKey: String = "fn"
     @AppStorage("voiceConversationTimeoutSeconds") private var conversationTimeoutSeconds: Int = 30
     @AppStorage("ttsProvider") private var ttsProviderRaw: String = TTSProviderOption.elevenlabs.rawValue
+    @AppStorage("sttProvider") private var sttProviderRaw: String = STTProviderOption.openaiWhisper.rawValue
 
     @State private var elevenLabsKeyText: String = ""
     @State private var ttsSetupExpanded: Bool = false
@@ -40,8 +60,18 @@ struct VoiceSettingsView: View {
     @State private var recordingMonitors: [Any] = []
     @State private var modifierHoldTimer: Timer? = nil
 
+    // STT-specific state
+    @State private var sttOpenAIKeyText: String = ""
+    @State private var sttSetupExpanded: Bool = false
+    /// Whether an OpenAI API key is stored for STT (fetched per-component).
+    @State private var sttOpenAIHasKey = false
+
     private var ttsProvider: TTSProviderOption {
         TTSProviderOption(rawValue: ttsProviderRaw) ?? .elevenlabs
+    }
+
+    private var sttProvider: STTProviderOption {
+        STTProviderOption(rawValue: sttProviderRaw) ?? .openaiWhisper
     }
 
     private var currentActivator: PTTActivator {
@@ -68,12 +98,16 @@ struct VoiceSettingsView: View {
             pttCard
             conversationTimeoutCard
             ttsProviderCard
+            if isSttServiceEnabled {
+                sttProviderCard
+            }
         }
         .onDisappear {
             stopRecordingCustomKey()
         }
         .onAppear {
             elevenLabsHasKey = APIKeyManager.getKey(for: "elevenlabs") != nil
+            sttOpenAIHasKey = APIKeyManager.getKey(for: "openai") != nil
         }
         .onChange(of: conversationTimeoutSeconds) {
             VoiceModeManager.conversationTimeoutOverride = conversationTimeoutSeconds
@@ -460,6 +494,95 @@ struct VoiceSettingsView: View {
 
             VButton(label: "Visit Fish Audio", rightIcon: VIcon.arrowUpRight.rawValue, style: .outlined) {
                 NSWorkspace.shared.open(URL(string: "https://fish.audio")!)
+            }
+        }
+    }
+
+    // MARK: - STT Provider Card
+
+    private var sttProviderCard: some View {
+        SettingsCard(title: "Speech-to-Text", subtitle: "Choose an STT provider for audio transcription. The selected provider is used globally across all transcription features.") {
+            VStack(alignment: .leading, spacing: VSpacing.md) {
+                // Provider selector
+                VStack(alignment: .leading, spacing: VSpacing.sm) {
+                    Text("Provider:")
+                        .font(VFont.bodySmallDefault)
+                        .foregroundStyle(VColor.contentSecondary)
+
+                    HStack(spacing: VSpacing.sm) {
+                        ForEach(STTProviderOption.allCases, id: \.rawValue) { provider in
+                            let isSelected = sttProvider == provider
+                            providerOption(label: provider.displayName, isSelected: isSelected) {
+                                sttProviderRaw = provider.rawValue
+                                store.setSTTProvider(provider.rawValue)
+                            }
+                        }
+                    }
+                }
+
+                // Provider-specific subtitle
+                Text(sttProvider.subtitle)
+                    .font(VFont.bodySmallDefault)
+                    .foregroundStyle(VColor.contentTertiary)
+
+                // Provider-specific configuration
+                switch sttProvider {
+                case .openaiWhisper:
+                    openaiWhisperProviderConfig
+                }
+            }
+        }
+    }
+
+    // MARK: - OpenAI Whisper Provider Config
+
+    private var openaiWhisperProviderConfig: some View {
+        Group {
+            if sttOpenAIHasKey {
+                HStack(spacing: VSpacing.sm) {
+                    VButton(label: "Connected", leftIcon: VIcon.circleCheck.rawValue, style: .primary) {}
+                    VButton(label: "Disconnect", style: .danger) {
+                        store.clearSTTOpenAIKey()
+                        sttOpenAIHasKey = false
+                        sttOpenAIKeyText = ""
+                        sttSetupExpanded = false
+                    }
+                }
+            } else if sttSetupExpanded {
+                VStack(alignment: .leading, spacing: VSpacing.sm) {
+                    VTextField(
+                        "OpenAI API Key",
+                        placeholder: "Your OpenAI API key",
+                        text: $sttOpenAIKeyText,
+                        isSecure: true,
+                        maxWidth: 400
+                    )
+
+                    HStack(spacing: VSpacing.xs) {
+                        VIconView(.lock, size: 10)
+                            .foregroundStyle(VColor.contentTertiary)
+                        Text("Your API key is stored securely in the macOS Keychain.")
+                            .font(VFont.labelDefault)
+                            .foregroundStyle(VColor.contentTertiary)
+                    }
+
+                    HStack(spacing: VSpacing.sm) {
+                        VButton(label: "Connect", style: .outlined, isDisabled: sttOpenAIKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty) {
+                            store.saveSTTOpenAIKey(sttOpenAIKeyText)
+                            sttOpenAIHasKey = true
+                            sttOpenAIKeyText = ""
+                            sttSetupExpanded = false
+                        }
+                        VButton(label: "Cancel", style: .outlined) {
+                            sttSetupExpanded = false
+                            sttOpenAIKeyText = ""
+                        }
+                    }
+                }
+            } else {
+                VButton(label: "Set Up", style: .outlined) {
+                    sttSetupExpanded = true
+                }
             }
         }
     }

--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -115,7 +115,7 @@ struct VoiceSettingsView: View {
         .onAppear {
             elevenLabsHasKey = APIKeyManager.getCredential(service: "elevenlabs", field: "api_key") != nil
             fishAudioHasKey = APIKeyManager.getCredential(service: "fish-audio", field: "api_key") != nil
-            sttOpenAIHasKey = APIKeyManager.getCredential(service: "openai", field: "api_key") != nil
+            sttOpenAIHasKey = APIKeyManager.getKey(for: "openai") != nil
         }
         .onChange(of: conversationTimeoutSeconds) {
             VoiceModeManager.conversationTimeoutOverride = conversationTimeoutSeconds

--- a/clients/macos/vellum-assistantTests/SettingsStoreVoiceServiceTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsStoreVoiceServiceTests.swift
@@ -1,0 +1,203 @@
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+/// Verifies that `SettingsStore` emits the expected config patch payloads
+/// for the `services.stt` namespace and correctly loads STT provider config
+/// from daemon config responses.
+@MainActor
+final class SettingsStoreVoiceServiceTests: XCTestCase {
+
+    private var mockSettingsClient: MockSettingsClient!
+    private var store: SettingsStore!
+
+    override func setUp() {
+        super.setUp()
+        mockSettingsClient = MockSettingsClient()
+        mockSettingsClient.patchConfigResponse = true
+        store = SettingsStore(settingsClient: mockSettingsClient)
+    }
+
+    override func tearDown() {
+        store = nil
+        mockSettingsClient = nil
+        super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    /// Returns the most recent `services.stt` patch payload captured
+    /// by the mock client, or `nil` if no such patch has been emitted.
+    private func lastSTTPatch() -> [String: Any]? {
+        for payload in mockSettingsClient.patchConfigCalls.reversed() {
+            if let services = payload["services"] as? [String: Any],
+               let stt = services["stt"] as? [String: Any] {
+                return stt
+            }
+        }
+        return nil
+    }
+
+    /// Returns the most recent `services.tts` patch payload captured
+    /// by the mock client, or `nil` if no such patch has been emitted.
+    private func lastTTSPatch() -> [String: Any]? {
+        for payload in mockSettingsClient.patchConfigCalls.reversed() {
+            if let services = payload["services"] as? [String: Any],
+               let tts = services["tts"] as? [String: Any] {
+                return tts
+            }
+        }
+        return nil
+    }
+
+    /// Waits for the background `Task` started by a store helper to flush
+    /// its patch into the mock client.
+    private func waitForPatchCount(_ expected: Int, timeout: TimeInterval = 2.0) {
+        let predicate = NSPredicate { _, _ in
+            self.mockSettingsClient.patchConfigCalls.count >= expected
+        }
+        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: nil)
+        wait(for: [expectation], timeout: timeout)
+    }
+
+    // MARK: - setSTTProvider
+
+    func testSetSTTProviderEmitsExpectedPatch() {
+        store.setSTTProvider("openai-whisper")
+
+        waitForPatchCount(1)
+
+        let patch = lastSTTPatch()
+        XCTAssertNotNil(patch, "expected a services.stt patch payload")
+        XCTAssertEqual(patch?["provider"] as? String, "openai-whisper")
+    }
+
+    func testSetSTTProviderDoesNotEmitTTSPatch() {
+        store.setSTTProvider("openai-whisper")
+
+        waitForPatchCount(1)
+
+        let ttsPatch = lastTTSPatch()
+        XCTAssertNil(ttsPatch, "setSTTProvider must not emit a TTS patch")
+    }
+
+    func testSetTTSProviderDoesNotEmitSTTPatch() {
+        store.setTTSProvider("elevenlabs")
+
+        waitForPatchCount(1)
+
+        let sttPatch = lastSTTPatch()
+        XCTAssertNil(sttPatch, "setTTSProvider must not emit an STT patch")
+    }
+
+    // MARK: - applyDaemonConfig STT loading
+
+    func testApplyDaemonConfigSyncsSTTProvider() {
+        // Clear any existing value to confirm the config load writes it.
+        UserDefaults.standard.removeObject(forKey: "sttProvider")
+
+        let config: [String: Any] = [
+            "services": [
+                "stt": [
+                    "provider": "openai-whisper"
+                ]
+            ]
+        ]
+
+        // loadConfigFromDaemon calls applyDaemonConfig internally, but
+        // we can test the effect by setting up the mock response and calling load.
+        mockSettingsClient.fetchConfigResponse = config
+        let expectation = XCTestExpectation(description: "config loaded")
+        Task {
+            await store.loadConfigFromDaemon()
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 2.0)
+
+        XCTAssertEqual(
+            UserDefaults.standard.string(forKey: "sttProvider"),
+            "openai-whisper"
+        )
+    }
+
+    func testApplyDaemonConfigSyncsTTSProvider() {
+        // Verify TTS loading still works alongside STT.
+        UserDefaults.standard.removeObject(forKey: "ttsProvider")
+
+        let config: [String: Any] = [
+            "services": [
+                "tts": [
+                    "provider": "fish-audio"
+                ]
+            ]
+        ]
+
+        mockSettingsClient.fetchConfigResponse = config
+        let expectation = XCTestExpectation(description: "config loaded")
+        Task {
+            await store.loadConfigFromDaemon()
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 2.0)
+
+        XCTAssertEqual(
+            UserDefaults.standard.string(forKey: "ttsProvider"),
+            "fish-audio"
+        )
+    }
+
+    func testApplyDaemonConfigSyncsBothTTSAndSTT() {
+        UserDefaults.standard.removeObject(forKey: "ttsProvider")
+        UserDefaults.standard.removeObject(forKey: "sttProvider")
+
+        let config: [String: Any] = [
+            "services": [
+                "tts": [
+                    "provider": "elevenlabs"
+                ],
+                "stt": [
+                    "provider": "openai-whisper"
+                ]
+            ]
+        ]
+
+        mockSettingsClient.fetchConfigResponse = config
+        let expectation = XCTestExpectation(description: "config loaded")
+        Task {
+            await store.loadConfigFromDaemon()
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 2.0)
+
+        XCTAssertEqual(UserDefaults.standard.string(forKey: "ttsProvider"), "elevenlabs")
+        XCTAssertEqual(UserDefaults.standard.string(forKey: "sttProvider"), "openai-whisper")
+    }
+
+    func testApplyDaemonConfigDoesNotOverwriteSTTWhenMissing() {
+        // Pre-seed a value and verify it is not cleared when the
+        // daemon config does not include an stt section.
+        UserDefaults.standard.set("openai-whisper", forKey: "sttProvider")
+
+        let config: [String: Any] = [
+            "services": [
+                "tts": [
+                    "provider": "elevenlabs"
+                ]
+            ]
+        ]
+
+        mockSettingsClient.fetchConfigResponse = config
+        let expectation = XCTestExpectation(description: "config loaded")
+        Task {
+            await store.loadConfigFromDaemon()
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 2.0)
+
+        XCTAssertEqual(
+            UserDefaults.standard.string(forKey: "sttProvider"),
+            "openai-whisper",
+            "STT provider must not be cleared when the daemon config omits stt"
+        )
+    }
+}

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -314,19 +314,19 @@
       "defaultEnabled": false
     },
     {
-      "id": "fork-from-message",
-      "scope": "macos",
-      "key": "fork-from-message",
-      "label": "Fork from Message",
-      "description": "Show the Fork from here option in message overflow menus",
-      "defaultEnabled": false
-    },
-    {
       "id": "managed-x-oauth-integration",
       "scope": "assistant",
       "key": "managed-x-oauth-integration",
       "label": "Managed X/Twitter OAuth",
       "description": "Enable platform-managed X/Twitter OAuth integration in Models & Services settings",
+      "defaultEnabled": false
+    },
+    {
+      "id": "stt-service",
+      "scope": "assistant",
+      "key": "stt-service",
+      "label": "Voice STT Service",
+      "description": "Enable Voice settings STT service configuration UI for selecting and configuring speech-to-text providers",
       "defaultEnabled": false
     }
   ]


### PR DESCRIPTION
## Summary
Introduces a canonical `services.stt` configuration surface (mirroring `services.tts`), routes channel voice/audio auto-transcription and the bundled `transcribe` skill through one shared daemon STT abstraction, and adds Voice-tab configuration UI on macOS behind the `stt-service` feature flag with `your-own` mode only and OpenAI Whisper as the initial provider.

## Self-review result
PASS — 3 gaps found and fixed across 4 fix PRs (shared key deletion, unconsumed schema fields, Whisper-specific naming, comment style)

## PRs merged into feature branch
- #24941: Add `services.stt` schema with `your-own` OpenAI Whisper defaults
- #24940: Register `stt-service` assistant feature flag
- #24943: Resolve daemon batch STT transcribers from `services.stt`
- #24944: Add `stt-service`-gated STT configuration card to Voice tab
- #24957: Route channel audio transcription through `services.stt`
- #24958: Use configured STT service for `transcribe_media` and remove local mode

### Fix PRs
- #24964: Rename Whisper-specific constant to provider-agnostic name
- #24965: Prevent STT card from destructively deleting shared OpenAI key
- #24966: Remove unconsumed model/language fields from STT provider config schema
- #24968: Rewrite STT schema comment to describe current state only

Part of plan: stt-service-product-unification.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24969" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
