### PR TITLE
fix: bundle tts-provider-catalog.json in iOS app resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ dist
 assistant/src/config/feature-flag-registry.json
 gateway/src/feature-flag-registry.json
 
+# Copied from meta/ into iOS Resources/ at build time by clients/ios/build.sh
+clients/ios/Resources/tts-provider-catalog.json
+
 # misc
 worktrees/
 .worktrees/

--- a/clients/ios/build.sh
+++ b/clients/ios/build.sh
@@ -64,6 +64,7 @@ case "$CMD" in
     clean)
         echo "Cleaning..."
         rm -rf "$DIST_DIR" "$CLIENTS_DIR/.build"
+        rm -f "$SCRIPT_DIR/Resources/tts-provider-catalog.json"
         echo "Done."
         exit 0
         ;;
@@ -74,6 +75,17 @@ case "$CMD" in
         exit 1
         ;;
 esac
+
+# ── Bundle metadata into Resources/ ──────────────────────────────────
+# Copy build-time artifacts from meta/ into the Resources directory so
+# XcodeGen includes them in the app bundle.  The macOS build performs
+# the equivalent copy into Contents/Resources/ after compilation; iOS
+# needs the files present *before* xcodegen so they are listed as
+# bundle resources in the generated xcodeproj.
+TTS_PROVIDER_CATALOG="$SCRIPT_DIR/../../meta/tts-provider-catalog.json"
+if [ -f "$TTS_PROVIDER_CATALOG" ]; then
+    cp "$TTS_PROVIDER_CATALOG" "$SCRIPT_DIR/Resources/tts-provider-catalog.json"
+fi
 
 # ── Generate xcodeproj ────────────────────────────────────────────────
 # Always regenerate from project.yml so the xcodeproj is never stale.


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for tts-provider-onboarding-unification.md.

**Gap:** iOS build does not bundle tts-provider-catalog.json
**What was expected:** iOS should load TTS provider metadata from the bundled JSON artifact
**What was found:** iOS build.sh had no copy step, causing fallback to hardcoded defaults

## Changes
- Add a copy step in `clients/ios/build.sh` to copy `meta/tts-provider-catalog.json` into `clients/ios/Resources/` before XcodeGen runs, so the file is included as a bundle resource in the generated xcodeproj.
- Add the copied file to `.gitignore` since it is a build-time artifact (same pattern as `feature-flag-registry.json`).
- Clean up the copied artifact in the `clean` command.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24972" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
