### PR TITLE
fix: use catalog callMode in resolveCallTtsProvider instead of supportsStreaming

### DIFF
--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -537,10 +537,10 @@ export class CallController {
     runSignal: AbortSignal,
   ): Promise<string> {
     // Resolve the active TTS provider through the global abstraction.
-    // Providers that declare streaming support use the synthesized-play
-    // path (buffer text, synthesize via provider API, stream audio chunks
-    // to Twilio via play-URL). Native providers stream text tokens to
-    // the relay for Twilio's built-in TTS.
+    // The catalog's callMode determines the call path: synthesized-play
+    // providers buffer text, synthesize via provider API, and stream
+    // audio chunks to Twilio via play-URL. Native-twilio providers
+    // stream text tokens to the relay for Twilio's built-in TTS.
     const { provider, useSynthesizedPath, audioFormat } =
       resolveCallTtsProvider();
 
@@ -738,7 +738,7 @@ export class CallController {
       } else {
         // Fallback: buffer-oriented synthesis for providers that don't
         // implement streaming (shouldn't normally reach here since
-        // useSynthesizedPath is gated on supportsStreaming).
+        // useSynthesizedPath is gated on catalog callMode).
         const result = await provider.synthesize({
           text,
           useCase: "phone-call",

--- a/assistant/src/calls/call-speech-output.ts
+++ b/assistant/src/calls/call-speech-output.ts
@@ -6,10 +6,10 @@
  * abstraction used by the call controller so that configured synthesized
  * providers (e.g. Fish Audio) are respected for all spoken output.
  *
- * Two output paths:
- * - **Native**: Provider does not support streaming — text is sent via
+ * Two output paths (determined by the catalog's `callMode`):
+ * - **Native**: `callMode: "native-twilio"` — text is sent via
  *   `sendTextToken()` for Twilio's built-in TTS engine.
- * - **Synthesized**: Provider supports streaming — text is synthesized
+ * - **Synthesized**: `callMode: "synthesized-play"` — text is synthesized
  *   via the provider API, streamed through the audio store, and played
  *   via `sendPlayUrl()`.
  */

--- a/assistant/src/calls/resolve-call-tts-provider.ts
+++ b/assistant/src/calls/resolve-call-tts-provider.ts
@@ -11,6 +11,7 @@ import { loadConfig } from "../config/loader.js";
 import { getTtsProvider } from "../tts/provider-registry.js";
 import { resolveTtsConfig } from "../tts/tts-config-resolver.js";
 import type { TtsProvider } from "../tts/types.js";
+import { resolveCallStrategy } from "./tts-call-strategy.js";
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -21,10 +22,10 @@ export interface ResolvedCallTts {
   provider: TtsProvider | null;
 
   /**
-   * True when the provider supports streaming and audio should be
-   * synthesized via the provider API and streamed through the audio store.
-   * False when text tokens are sent directly to the relay for Twilio's
-   * built-in TTS engine.
+   * True when the catalog's `callMode` is `"synthesized-play"` -- audio
+   * is synthesized via the provider API and streamed through the audio
+   * store. False when `callMode` is `"native-twilio"` -- text tokens are
+   * sent directly to the relay for Twilio's built-in TTS engine.
    */
   useSynthesizedPath: boolean;
 
@@ -39,15 +40,17 @@ export interface ResolvedCallTts {
 /**
  * Resolve the active TTS provider via the global provider abstraction.
  *
- * Providers that declare streaming support are treated as "synthesized"
- * providers -- their audio is streamed through the audio store and played
- * via `sendPlayUrl`. Providers without streaming support are "native"
- * providers -- text tokens are streamed directly to the relay for Twilio's
- * built-in TTS.
+ * The native-vs-synthesized decision is driven by the catalog's
+ * `callMode` field via {@link resolveCallStrategy} -- the same single
+ * decision path used by `voice-quality.ts`. Providers with
+ * `callMode: "synthesized-play"` have their audio streamed through the
+ * audio store and played via `sendPlayUrl`. Providers with
+ * `callMode: "native-twilio"` stream text tokens directly to the relay
+ * for Twilio's built-in TTS.
  *
- * Falls back to the native (non-streaming) path with `mp3` format when
- * the config is missing a `services.tts` block or the provider is not
- * registered (e.g. unit tests or early startup).
+ * Falls back to the native path with `mp3` format when the config is
+ * missing a `services.tts` block or the provider is not registered
+ * (e.g. unit tests or early startup).
  */
 export function resolveCallTtsProvider(): ResolvedCallTts {
   try {
@@ -55,9 +58,10 @@ export function resolveCallTtsProvider(): ResolvedCallTts {
     const resolved = resolveTtsConfig(config);
     const provider = getTtsProvider(resolved.provider);
 
-    // Providers with streaming support synthesize audio themselves; others
-    // rely on the relay's native (Twilio-managed) TTS engine.
-    const useSynthesizedPath = provider.capabilities.supportsStreaming;
+    // Use the catalog's callMode to decide the call path -- the same
+    // decision path used by voice-quality.ts via resolveCallStrategy().
+    const strategy = resolveCallStrategy(config);
+    const useSynthesizedPath = strategy.callMode === "synthesized-play";
 
     // Read the user-configured audio format from the resolved provider
     // config so the streaming store entry's content-type matches the
@@ -74,7 +78,7 @@ export function resolveCallTtsProvider(): ResolvedCallTts {
   } catch {
     // Config missing `services.tts` block or provider not registered
     // (e.g. unit tests or early startup) -- fall back to the native
-    // (non-streaming) path where the provider object is not used.
+    // path where the provider object is not used.
     return { provider: null, useSynthesizedPath: false, audioFormat: "mp3" };
   }
 }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for tts-provider-onboarding-unification.md.

**Gap:** resolveCallTtsProvider uses supportsStreaming instead of catalog callMode
**What was expected:** Single decision path for native-vs-synthesized using catalog callMode
**What was found:** Two parallel decision paths that could diverge for future providers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24974" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
