### PR TITLE
fix: add fallback to macOS selectedProvider matching iOS behavior

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -22,8 +22,10 @@ struct VoiceSettingsView: View {
     private let registry = loadTTSProviderRegistry()
 
     /// The currently selected provider entry from the registry.
+    /// Falls back to the first provider in the registry if the persisted
+    /// value does not match any known entry (matching iOS behavior).
     private var selectedProvider: TTSProviderCatalogEntry? {
-        registry.provider(withId: ttsProviderRaw)
+        registry.provider(withId: ttsProviderRaw) ?? registry.providers.first
     }
 
     private var currentActivator: PTTActivator {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for tts-provider-onboarding-unification.md.

**Gap:** macOS selectedProvider lacks fallback
**What was expected:** Consistent fallback behavior when persisted provider ID is unknown
**What was found:** macOS returns nil while iOS falls back to first provider
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24975" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
