### PR TITLE
Fix registry-routed host_browser pending interaction registration

### DIFF
--- a/assistant/src/__tests__/conversation-routes-disk-view.test.ts
+++ b/assistant/src/__tests__/conversation-routes-disk-view.test.ts
@@ -21,6 +21,12 @@ import {
 import { getDb, initializeDb } from "../memory/db.js";
 import { AssistantEventHub } from "../runtime/assistant-event-hub.js";
 import type { AuthContext } from "../runtime/auth/types.js";
+import {
+  __resetChromeExtensionRegistryForTests,
+  getChromeExtensionRegistry,
+  type ChromeExtensionConnection,
+} from "../runtime/chrome-extension-registry.js";
+import * as pendingInteractions from "../runtime/pending-interactions.js";
 import { handleSendMessage } from "../runtime/routes/conversation-routes.js";
 
 const testDir = process.env.VELLUM_WORKSPACE_DIR!;
@@ -329,6 +335,8 @@ beforeEach(() => {
   resetTables();
   resetConversationsDir();
   conversationInstances.clear();
+  pendingInteractions.clear();
+  __resetChromeExtensionRegistryForTests();
 });
 
 // ── macOS browser backend fallback regression ─────────────────────────
@@ -473,6 +481,123 @@ describe("macOS browser backend fallback (no extension, no cdp-inspect)", () => 
     expect(assistantLine?.role).toBe("assistant");
     expect(assistantLine?.metadata?.userMessageInterface).toBe("macos");
     expect(assistantLine?.metadata?.assistantMessageInterface).toBe("macos");
+  });
+});
+
+describe("chrome-extension host_browser pending registration", () => {
+  test("registers pending interaction before registry-routed host_browser send", async () => {
+    const guardianId = `guardian-${crypto.randomUUID()}`;
+    let pendingRegisteredAtSend: boolean | undefined;
+    let observedRequestId: string | undefined;
+
+    const connection: ChromeExtensionConnection = {
+      id: `conn-${crypto.randomUUID()}`,
+      guardianId,
+      ws: {
+        send(payload: string) {
+          const frame = JSON.parse(payload) as {
+            type?: string;
+            requestId?: string;
+          };
+          if (
+            frame.type === "host_browser_request" &&
+            typeof frame.requestId === "string"
+          ) {
+            observedRequestId = frame.requestId;
+            pendingRegisteredAtSend =
+              pendingInteractions.get(frame.requestId)?.kind === "host_browser";
+          }
+        },
+        close() {},
+      } as unknown as ChromeExtensionConnection["ws"],
+      connectedAt: Date.now(),
+      lastActiveAt: Date.now(),
+    };
+    getChromeExtensionRegistry().register(connection);
+
+    const actorAuthContext: AuthContext = {
+      ...authContext,
+      subject: `actor:self:${guardianId}`,
+      principalType: "actor",
+      scopeProfile: "actor_client_v1",
+      actorPrincipalId: guardianId,
+    };
+
+    const conversationKey = `chrome-ext-pending-${crypto.randomUUID()}`;
+    const response = await handleSendMessage(
+      new Request("http://localhost/v1/messages", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          conversationKey,
+          content: "Trigger host browser request via registry sender.",
+          sourceChannel: "vellum",
+          interface: "chrome-extension",
+        }),
+      }),
+      {
+        sendMessageDeps: {
+          getOrCreateConversation: async (conversationId: string) => {
+            const conversation = createFakeConversation(
+              conversationId,
+            ) as unknown as {
+              hostBrowserProxy?: {
+                request: (
+                  input: { cdpMethod: string; timeout_seconds?: number },
+                  conversationId: string,
+                ) => Promise<{ content: string; isError: boolean }>;
+              };
+              processing: boolean;
+              abortController: AbortController | null;
+              currentRequestId?: string;
+              runAgentLoop: (
+                content: string,
+                userMessageId: string,
+                onEvent: (msg: Record<string, unknown>) => void,
+              ) => Promise<void>;
+              conversationId: string;
+            };
+
+            conversation.runAgentLoop = async function (
+              _content: string,
+              _userMessageId: string,
+              _onEvent: (msg: Record<string, unknown>) => void,
+            ): Promise<void> {
+              if (!this.hostBrowserProxy) {
+                throw new Error(
+                  "Expected hostBrowserProxy to be provisioned for chrome-extension turn",
+                );
+              }
+              await this.hostBrowserProxy.request(
+                {
+                  cdpMethod: "Browser.getVersion",
+                  // Keep the test fast while still allowing assertion at send time.
+                  timeout_seconds: 0.05,
+                },
+                this.conversationId,
+              );
+              this.processing = false;
+              this.abortController = null;
+              this.currentRequestId = undefined;
+            };
+
+            conversationInstances.set(
+              conversationId,
+              conversation as unknown as Conversation,
+            );
+            return conversation as unknown as Conversation;
+          },
+          assistantEventHub: new AssistantEventHub(),
+          resolveAttachments: () => [],
+        },
+      },
+      actorAuthContext,
+    );
+
+    expect(response.status).toBe(202);
+    const registered = await waitFor(() => pendingRegisteredAtSend, 1000);
+    expect(observedRequestId).toBeDefined();
+    expect(registered).toBe(true);
   });
 });
 

--- a/assistant/src/__tests__/conversation-routes-disk-view.test.ts
+++ b/assistant/src/__tests__/conversation-routes-disk-view.test.ts
@@ -23,8 +23,8 @@ import { AssistantEventHub } from "../runtime/assistant-event-hub.js";
 import type { AuthContext } from "../runtime/auth/types.js";
 import {
   __resetChromeExtensionRegistryForTests,
-  getChromeExtensionRegistry,
   type ChromeExtensionConnection,
+  getChromeExtensionRegistry,
 } from "../runtime/chrome-extension-registry.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 import { handleSendMessage } from "../runtime/routes/conversation-routes.js";

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1050,30 +1050,8 @@ function makeHubPublisher(
         conversationId,
         kind: "secret",
       });
-    } else if (msg.type === "host_bash_request") {
-      pendingInteractions.register(msg.requestId, {
-        conversation,
-        conversationId,
-        kind: "host_bash",
-      });
-    } else if (msg.type === "host_browser_request") {
-      pendingInteractions.register(msg.requestId, {
-        conversation,
-        conversationId,
-        kind: "host_browser",
-      });
-    } else if (msg.type === "host_file_request") {
-      pendingInteractions.register(msg.requestId, {
-        conversation,
-        conversationId,
-        kind: "host_file",
-      });
-    } else if (msg.type === "host_cu_request") {
-      pendingInteractions.register(msg.requestId, {
-        conversation,
-        conversationId,
-        kind: "host_cu",
-      });
+    } else {
+      registerHostProxyPendingInteraction(msg, conversation, conversationId);
     }
 
     // ServerMessage is a large union; conversationId exists on most but not all variants.
@@ -1103,6 +1081,54 @@ function makeHubPublisher(
 }
 
 /**
+ * Register pending interactions for host proxy request envelopes so
+ * standalone result endpoints can resolve by requestId.
+ *
+ * Returns the registered requestId when a host proxy request was registered.
+ * Callers that route through non-hub transports (e.g. registry-routed
+ * host_browser sends) can use this to clean up the registration if send fails.
+ */
+function registerHostProxyPendingInteraction(
+  msg: ServerMessage,
+  conversation: import("../../daemon/conversation.js").Conversation,
+  conversationId: string,
+): string | undefined {
+  if (msg.type === "host_bash_request") {
+    pendingInteractions.register(msg.requestId, {
+      conversation,
+      conversationId,
+      kind: "host_bash",
+    });
+    return msg.requestId;
+  }
+  if (msg.type === "host_browser_request") {
+    pendingInteractions.register(msg.requestId, {
+      conversation,
+      conversationId,
+      kind: "host_browser",
+    });
+    return msg.requestId;
+  }
+  if (msg.type === "host_file_request") {
+    pendingInteractions.register(msg.requestId, {
+      conversation,
+      conversationId,
+      kind: "host_file",
+    });
+    return msg.requestId;
+  }
+  if (msg.type === "host_cu_request") {
+    pendingInteractions.register(msg.requestId, {
+      conversation,
+      conversationId,
+      kind: "host_cu",
+    });
+    return msg.requestId;
+  }
+  return undefined;
+}
+
+/**
  * Resolve the host_browser sender function for a conversation turn.
  *
  * When the guardian has an active extension connection in the
@@ -1126,6 +1152,7 @@ function makeHubPublisher(
  */
 function resolveHostBrowserSender(
   conversation: import("../../daemon/conversation.js").Conversation,
+  conversationId: string,
   authContext: AuthContext,
   onEvent: (msg: ServerMessage) => void,
   sourceInterface: InterfaceId,
@@ -1151,16 +1178,23 @@ function resolveHostBrowserSender(
   // the conversation's bound guardian identity rather than a stale
   // authContext.actorPrincipalId.
   const registrySender = (msg: ServerMessage): void => {
+    const requestId = registerHostProxyPendingInteraction(
+      msg,
+      conversation,
+      conversationId,
+    );
     const gid =
       conversation.trustContext?.guardianPrincipalId ??
       authContext.actorPrincipalId;
     if (!gid) {
+      if (requestId) pendingInteractions.resolve(requestId);
       throw new Error(
         "host_browser send skipped: no guardianId on AuthContext",
       );
     }
     const ok = getChromeExtensionRegistry().send(gid, msg);
     if (!ok) {
+      if (requestId) pendingInteractions.resolve(requestId);
       throw new Error(
         `host_browser send failed: no active connection for guardian ${gid}`,
       );
@@ -1405,6 +1439,7 @@ export async function handleSendMessage(
   const { sender: browserProxySendToClient, isRegistryRouted } =
     resolveHostBrowserSender(
       conversation,
+      mapping.conversationId,
       authContext,
       onEvent,
       sourceInterface,
@@ -1931,10 +1966,7 @@ export async function handleSendMessage(
         onEvent({ type: "assistant_text_delta", text: responseText });
         onEvent({ type: "message_complete", conversationId });
       } catch (err) {
-        log.error(
-          { err, conversationId },
-          "Compact command failed",
-        );
+        log.error({ err, conversationId }, "Compact command failed");
         onEvent({
           type: "conversation_error",
           conversationId,


### PR DESCRIPTION
## Summary
- register host-proxy pending interactions through a shared helper and use it for both hub-published events and registry-routed host_browser sends
- clean up newly-registered pending interactions when the registry sender fails so requestIds are not left stale
- add a regression test proving chrome-extension registry transport has a pending host_browser interaction registered before send time

## Original prompt
the fix
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24978" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
