### PR TITLE
Clean up runtime routes type-only imports

### DIFF
--- a/assistant/src/runtime/routes/app-management-routes.ts
+++ b/assistant/src/runtime/routes/app-management-routes.ts
@@ -23,6 +23,7 @@ import { z } from "zod";
 import { packageApp } from "../../bundler/app-bundler.js";
 import { compileApp } from "../../bundler/app-compiler.js";
 import { scanBundle } from "../../bundler/bundle-scanner.js";
+import type { SignatureJson } from "../../bundler/bundle-signer.js";
 import { verifyBundleSignature } from "../../bundler/signature-verifier.js";
 import { compareSemver } from "../../daemon/handlers/shared.js";
 import { defaultGallery } from "../../gallery/default-gallery.js";
@@ -583,16 +584,15 @@ export function appManagementRouteDefinitions(): RouteDefinition[] {
               return httpError("BAD_REQUEST", "payload is not valid JSON", 400);
             }
 
-            const signatureJson: import("../../bundler/bundle-signer.js").SignatureJson =
-              {
-                algorithm: "ed25519",
-                signer: {
-                  key_id: body.keyId,
-                  display_name: "HTTP Signer",
-                },
-                content_hashes: contentHashes,
-                signature: body.signature,
-              };
+            const signatureJson: SignatureJson = {
+              algorithm: "ed25519",
+              signer: {
+                key_id: body.keyId,
+                display_name: "HTTP Signer",
+              },
+              content_hashes: contentHashes,
+              signature: body.signature,
+            };
             return Response.json({ signed: true, signatureJson });
           }
 

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -23,6 +23,7 @@ import {
 } from "../../channels/types.js";
 import { isHttpAuthDisabled } from "../../config/env.js";
 import { getConfig } from "../../config/loader.js";
+import type { Conversation } from "../../daemon/conversation.js";
 import {
   buildModelInfoEvent,
   formatCompactResult,
@@ -109,7 +110,7 @@ const SUGGESTION_CACHE_MAX = 100;
 function collectCanonicalGuardianRequestHintIds(
   conversationId: string,
   sourceChannel: string,
-  conversation: import("../../daemon/conversation.js").Conversation,
+  conversation: Conversation,
 ): string[] {
   const requests = listPendingRequestsByConversationScope(
     conversationId,
@@ -174,7 +175,7 @@ async function tryConsumeCanonicalGuardianReply(params: {
     data: string;
     filePath?: string;
   }>;
-  conversation: import("../../daemon/conversation.js").Conversation;
+  conversation: Conversation;
   onEvent: (msg: ServerMessage) => void;
   approvalConversationGenerator?: ApprovalConversationGenerator;
   /** Verified actor identity from actor-token middleware. */
@@ -969,7 +970,7 @@ function mergeConsecutiveAssistantMessages(messages: MessageRow[]): {
 function makeHubPublisher(
   deps: SendMessageDeps,
   conversationId: string,
-  conversation: import("../../daemon/conversation.js").Conversation,
+  conversation: Conversation,
 ): (msg: ServerMessage) => void {
   let hubChain: Promise<void> = Promise.resolve();
   return (msg: ServerMessage) => {
@@ -1090,7 +1091,7 @@ function makeHubPublisher(
  */
 function registerHostProxyPendingInteraction(
   msg: ServerMessage,
-  conversation: import("../../daemon/conversation.js").Conversation,
+  conversation: Conversation,
   conversationId: string,
 ): string | undefined {
   if (msg.type === "host_bash_request") {
@@ -1151,7 +1152,7 @@ function registerHostProxyPendingInteraction(
  * for interfaces that don't statically support host_browser (e.g. macOS).
  */
 function resolveHostBrowserSender(
-  conversation: import("../../daemon/conversation.js").Conversation,
+  conversation: Conversation,
   conversationId: string,
   authContext: AuthContext,
   onEvent: (msg: ServerMessage) => void,

--- a/assistant/src/runtime/routes/settings-routes.ts
+++ b/assistant/src/runtime/routes/settings-routes.ts
@@ -37,6 +37,7 @@ import {
   generateScopeOptions,
 } from "../../permissions/checker.js";
 import { resolveGuardianPersonaPath } from "../../prompts/persona-resolver.js";
+import type { ToolDefinition } from "../../providers/types.js";
 import { getSecureKeyAsync } from "../../security/secure-keys.js";
 import { parseToolManifestFile } from "../../skills/tool-manifest.js";
 import {
@@ -405,7 +406,7 @@ function handleToolNamesList(): Response {
   const schemas: Record<string, SchemaShape> = {};
 
   // Collect raw definitions from the registry so we can transform them.
-  const rawDefs: import("../../providers/types.js").ToolDefinition[] = [];
+  const rawDefs: ToolDefinition[] = [];
   for (const tool of tools) {
     try {
       rawDefs.push(tool.getDefinition());


### PR DESCRIPTION
## Summary
- replace inline `import("...").Type` annotations with explicit `import type` in `conversation-routes`, `settings-routes`, and `app-management-routes`
- keep behavior unchanged while making type usage clearer and avoiding confusion with runtime dynamic imports
- sweep the runtime routes layer for the same pattern and leave only the true runtime dynamic import in route tests

## Original prompt
/do this and any other similar cleanup