### PR TITLE
Remove media-processing transcription_mode input and document configured STT service

### DIFF
--- a/assistant/src/config/bundled-skills/media-processing/SKILL.md
+++ b/assistant/src/config/bundled-skills/media-processing/SKILL.md
@@ -45,8 +45,7 @@ Parameters:
 - `section_config` - Path to a JSON file with manual section boundaries.
 - `detect_dead_time` - Whether to detect and skip dead time (default: false). Dead-time detection can be too aggressive for continuous action video like sports - it may incorrectly skip live play. Enable only for content with clear idle periods (e.g., lectures, surveillance footage).
 - `short_edge` - Short edge resolution for downscaled frames in pixels (default: 480).
-- `include_audio` - Whether to extract and transcribe audio for each segment (default: false). When enabled, each segment's audio is transcribed and stored alongside visual frames.
-- `transcription_mode` - Transcription backend: `'api'` (OpenAI Whisper cloud) or `'local'` (whisper.cpp on-device). Default: `'local'`. The `'api'` mode requires an OpenAI API key configured in settings.
+- `include_audio` - Whether to extract and transcribe audio for each segment (default: false). When enabled, each segment's audio is transcribed using the configured STT service and stored alongside visual frames.
 
 ### analyze_keyframes
 
@@ -121,7 +120,7 @@ Tracks estimated API costs during pipeline execution.
 
 ## Audio + Vision Multimodal Analysis
 
-When `include_audio` is enabled on `extract_keyframes`, the pipeline transcribes each segment's audio track and attaches the transcript to the segment data. During the Map phase (`analyze_keyframes`), Gemini receives both the visual frames and the audio transcript for each segment, enabling multimodal analysis that combines what is seen with what is said.
+When `include_audio` is enabled on `extract_keyframes`, the pipeline transcribes each segment's audio track using the configured STT service and attaches the transcript to the segment data. During the Map phase (`analyze_keyframes`), Gemini receives both the visual frames and the audio transcript for each segment, enabling multimodal analysis that combines what is seen with what is said.
 
 This is useful for:
 
@@ -130,12 +129,7 @@ This is useful for:
 - **Meetings and interviews**: Pair facial expressions and gestures with spoken dialogue.
 - **Tutorials and demos**: Link on-screen actions with verbal instructions.
 
-Transcription modes:
-
-- **`local`** (default): Uses whisper.cpp for on-device transcription. Requires `whisper-cpp` to be installed (`brew install whisper-cpp`). No API costs, but slower.
-- **`api`**: Uses the OpenAI Whisper API for cloud-based transcription. Faster and more accurate, but requires an OpenAI API key and incurs per-minute costs.
-
-The audio transcription degrades gracefully - if transcription fails for a segment (missing tools, no audio track, API errors), the segment proceeds with visual-only analysis.
+Audio transcription uses the STT service configured in assistant settings. If no STT service is configured or transcription fails for a segment (no audio track, service errors), the segment gracefully degrades to visual-only analysis.
 
 ## Best Practices
 

--- a/assistant/src/config/bundled-skills/media-processing/TOOLS.json
+++ b/assistant/src/config/bundled-skills/media-processing/TOOLS.json
@@ -99,12 +99,7 @@
           },
           "include_audio": {
             "type": "boolean",
-            "description": "Whether to extract and transcribe audio for each segment. Default: false."
-          },
-          "transcription_mode": {
-            "type": "string",
-            "enum": ["api", "local"],
-            "description": "Transcription backend: 'api' (OpenAI Whisper cloud) or 'local' (whisper.cpp). Default: 'local'."
+            "description": "Whether to extract and transcribe audio for each segment using the configured STT service. Default: false."
           },
           "activity": {
             "type": "string",


### PR DESCRIPTION
## Summary
- Remove transcription_mode from TOOLS.json input schema
- Rewrite SKILL.md to describe configured STT provider behavior
- Remove all api/local and whisper.cpp references from docs

Part of plan: media-processing-stt-service-refactor.md (PR 2 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24980" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
