### PR TITLE
Remove stray merge conflict marker from VoiceSettingsView.swift

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -557,7 +557,6 @@ struct VoiceSettingsView: View {
         }
     }
 
-<<<<<<< HEAD
     // MARK: - Generic Provider Config (Fallback)
 
     /// Generic setup panel for providers added to the registry that do not


### PR DESCRIPTION
## Summary
- Removes a leftover `<<<<<<< HEAD` merge conflict marker on line 560 of `VoiceSettingsView.swift` that was causing a Swift build error

## Original prompt
Fix this build error:

/Users/noaflaherty/Repos/vellum-ai/vellum-assistant/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift:560:13: error: expected '(' in argument list of function declaration
558 |     }
559 |
560 | <<<<<<< HEAD
    |             `- error: expected '(' in argument list of function declaration
561 |     // MARK: - Generic Provider Config (Fallback)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24982" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
