### PR TITLE
Drop preprocess transcription_mode/openaiApiKey plumbing for media-processing

### DIFF
--- a/assistant/src/config/bundled-skills/media-processing/__tests__/extract-keyframes.test.ts
+++ b/assistant/src/config/bundled-skills/media-processing/__tests__/extract-keyframes.test.ts
@@ -1,0 +1,181 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { PreprocessManifest } from "../services/preprocess.js";
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before the subject import
+// ---------------------------------------------------------------------------
+
+let lastPreprocessOptions: Record<string, unknown> | undefined;
+let mockManifest: PreprocessManifest;
+let mockPreprocessError: Error | null = null;
+
+mock.module("../services/preprocess.js", () => ({
+  preprocessForAsset: async (
+    _assetId: string,
+    options: Record<string, unknown>,
+  ) => {
+    lastPreprocessOptions = options;
+    if (mockPreprocessError) throw mockPreprocessError;
+    return mockManifest;
+  },
+}));
+
+mock.module("../../../../memory/media-store.js", () => ({
+  getMediaAssetById: () => ({ filePath: "/tmp/videos/test.mp4" }),
+  getKeyframesForAsset: () => [{ id: "kf-1" }, { id: "kf-2" }, { id: "kf-3" }],
+}));
+
+// ---------------------------------------------------------------------------
+// Subject import (after mocks)
+// ---------------------------------------------------------------------------
+
+import { run } from "../tools/extract-keyframes.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeManifest(
+  overrides: Partial<PreprocessManifest> = {},
+): PreprocessManifest {
+  return {
+    assetId: "asset-1",
+    videoPath: "/tmp/videos/test.mp4",
+    durationSeconds: 60,
+    segments: [
+      {
+        id: "seg-001",
+        startSeconds: 0,
+        endSeconds: 15,
+        framePaths: ["/tmp/frame-1.jpg"],
+        frameTimestamps: [0],
+      },
+    ],
+    deadTimeRanges: [],
+    subjectRegistry: { groups: [] },
+    sectionBoundaries: [],
+    config: {
+      intervalSeconds: 1,
+      segmentDuration: 15,
+      deadTimeThreshold: 0.02,
+      shortEdge: 480,
+    },
+    ...overrides,
+  };
+}
+
+function makeContext() {
+  return {
+    workingDir: "/tmp",
+    conversationId: "conv-1",
+    trustClass: "guardian" as const,
+    onOutput: () => {},
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("extract_keyframes tool", () => {
+  beforeEach(() => {
+    lastPreprocessOptions = undefined;
+    mockPreprocessError = null;
+    mockManifest = makeManifest();
+  });
+
+  test("returns error when asset_id is missing", async () => {
+    const result = await run({}, makeContext());
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toBe("asset_id is required.");
+  });
+
+  test("passes include_audio through to preprocessForAsset", async () => {
+    await run({ asset_id: "asset-1", include_audio: true }, makeContext());
+
+    expect(lastPreprocessOptions?.includeAudio).toBe(true);
+  });
+
+  test("defaults include_audio to false when not provided", async () => {
+    await run({ asset_id: "asset-1" }, makeContext());
+
+    expect(lastPreprocessOptions?.includeAudio).toBe(false);
+  });
+
+  test("maps all numeric option fields from tool input", async () => {
+    await run(
+      {
+        asset_id: "asset-1",
+        interval_seconds: 2,
+        segment_duration: 30,
+        dead_time_threshold: 0.05,
+        short_edge: 720,
+      },
+      makeContext(),
+    );
+
+    expect(lastPreprocessOptions?.intervalSeconds).toBe(2);
+    expect(lastPreprocessOptions?.segmentDuration).toBe(30);
+    expect(lastPreprocessOptions?.deadTimeThreshold).toBe(0.05);
+    expect(lastPreprocessOptions?.shortEdge).toBe(720);
+  });
+
+  test("passes detect_dead_time and section_config through", async () => {
+    await run(
+      {
+        asset_id: "asset-1",
+        detect_dead_time: true,
+        section_config: "/tmp/sections.json",
+      },
+      makeContext(),
+    );
+
+    expect(lastPreprocessOptions?.detectDeadTime).toBe(true);
+    expect(lastPreprocessOptions?.sectionConfigPath).toBe("/tmp/sections.json");
+  });
+
+  test("does not pass transcriptionMode or openaiApiKey", async () => {
+    await run(
+      {
+        asset_id: "asset-1",
+        include_audio: true,
+        transcription_mode: "api",
+      },
+      makeContext(),
+    );
+
+    expect(lastPreprocessOptions).toBeDefined();
+    expect("transcriptionMode" in lastPreprocessOptions!).toBe(false);
+    expect("openaiApiKey" in lastPreprocessOptions!).toBe(false);
+  });
+
+  test("returns successful result with manifest summary", async () => {
+    const result = await run({ asset_id: "asset-1" }, makeContext());
+
+    expect(result.isError).toBe(false);
+    const parsed = JSON.parse(result.content);
+    expect(parsed.assetId).toBe("asset-1");
+    expect(parsed.segmentCount).toBe(1);
+    expect(parsed.keyframeCount).toBe(3);
+  });
+
+  test("returns error content for known preprocess failures", async () => {
+    mockPreprocessError = new Error("Media asset not found: asset-bad");
+
+    const result = await run({ asset_id: "asset-bad" }, makeContext());
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toBe("Media asset not found: asset-bad");
+  });
+
+  test("wraps unknown errors in generic message", async () => {
+    mockPreprocessError = new Error("Something unexpected");
+
+    const result = await run({ asset_id: "asset-1" }, makeContext());
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toBe("Preprocess failed: Something unexpected");
+  });
+});

--- a/assistant/src/config/bundled-skills/media-processing/__tests__/preprocess-audio.test.ts
+++ b/assistant/src/config/bundled-skills/media-processing/__tests__/preprocess-audio.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before the subject import
+// ---------------------------------------------------------------------------
+
+let mockTranscribeResult: string = "";
+
+mock.module("../services/audio-transcribe.js", () => ({
+  transcribeSegmentAudio: async () => mockTranscribeResult,
+}));
+
+let spawnExitCode = 0;
+
+mock.module("../../../../util/spawn.js", () => ({
+  spawnWithTimeout: async () => ({
+    exitCode: spawnExitCode,
+    stdout: "",
+    stderr: "",
+  }),
+  FFMPEG_PALETTE_TIMEOUT_MS: 10_000,
+  FFMPEG_PREPROCESS_TIMEOUT_MS: 60_000,
+}));
+
+mock.module("../../../../memory/media-store.js", () => ({
+  getMediaAssetById: (id: string) => ({
+    id,
+    mediaType: "video",
+    filePath: "/tmp/videos/test.mp4",
+    durationSeconds: 30,
+  }),
+  getProcessingStagesForAsset: () => [],
+  createProcessingStage: () => ({ id: "stage-1" }),
+  updateProcessingStage: () => {},
+  deleteKeyframesForAsset: () => {},
+  insertKeyframesBatch: () => {},
+}));
+
+// Mock fs — readdir must return frame filenames to produce segments with frames
+let mockReaddirFiles: string[] = ["frame-000001.jpg", "frame-000002.jpg"];
+
+mock.module("node:fs/promises", () => ({
+  mkdir: async () => {},
+  readdir: async () => mockReaddirFiles,
+  readFile: async () => "[]",
+  rename: async () => {},
+  rm: async () => {},
+  writeFile: async () => {},
+}));
+
+mock.module("../../../../util/silently.js", () => ({
+  silentlyWithLog: async () => {},
+}));
+
+// ---------------------------------------------------------------------------
+// Subject import (after mocks)
+// ---------------------------------------------------------------------------
+
+import { preprocessForAsset } from "../services/preprocess.js";
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("preprocessForAsset — audio transcript enrichment", () => {
+  beforeEach(() => {
+    mockTranscribeResult = "";
+    spawnExitCode = 0;
+    mockReaddirFiles = ["frame-000001.jpg", "frame-000002.jpg"];
+  });
+
+  test("attaches transcript to segments when transcription returns text", async () => {
+    mockTranscribeResult = "Hello world, this is a transcript.";
+
+    const manifest = await preprocessForAsset("asset-1", {
+      includeAudio: true,
+      segmentDuration: 30,
+    });
+
+    expect(manifest.segments.length).toBeGreaterThan(0);
+    for (const seg of manifest.segments) {
+      expect(seg.transcript).toBe("Hello world, this is a transcript.");
+    }
+  });
+
+  test("omits transcript field when transcription returns empty string", async () => {
+    mockTranscribeResult = "";
+
+    const manifest = await preprocessForAsset("asset-1", {
+      includeAudio: true,
+      segmentDuration: 30,
+    });
+
+    expect(manifest.segments.length).toBeGreaterThan(0);
+    for (const seg of manifest.segments) {
+      expect(seg.transcript).toBeUndefined();
+    }
+  });
+
+  test("does not set transcript when includeAudio is false", async () => {
+    mockTranscribeResult = "Should not appear";
+
+    const manifest = await preprocessForAsset("asset-1", {
+      includeAudio: false,
+      segmentDuration: 30,
+    });
+
+    expect(manifest.segments.length).toBeGreaterThan(0);
+    for (const seg of manifest.segments) {
+      expect(seg.transcript).toBeUndefined();
+    }
+  });
+
+  test("does not set transcript when includeAudio is omitted", async () => {
+    mockTranscribeResult = "Should not appear";
+
+    const manifest = await preprocessForAsset("asset-1", {
+      segmentDuration: 30,
+    });
+
+    expect(manifest.segments.length).toBeGreaterThan(0);
+    for (const seg of manifest.segments) {
+      expect(seg.transcript).toBeUndefined();
+    }
+  });
+
+  test("does not throw when transcription returns empty for all segments", async () => {
+    mockTranscribeResult = "";
+
+    const manifest = await preprocessForAsset("asset-1", {
+      includeAudio: true,
+      segmentDuration: 15,
+    });
+
+    // Should complete successfully with segments but no transcripts
+    expect(manifest.segments.length).toBeGreaterThan(0);
+    expect(manifest.segments.every((s) => s.transcript === undefined)).toBe(
+      true,
+    );
+  });
+});

--- a/assistant/src/config/bundled-skills/media-processing/services/preprocess.ts
+++ b/assistant/src/config/bundled-skills/media-processing/services/preprocess.ts
@@ -92,8 +92,6 @@ export interface PreprocessOptions {
   detectDeadTime?: boolean;
   shortEdge?: number;
   includeAudio?: boolean;
-  transcriptionMode?: "api" | "local";
-  openaiApiKey?: string;
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/config/bundled-skills/media-processing/tools/extract-keyframes.ts
+++ b/assistant/src/config/bundled-skills/media-processing/tools/extract-keyframes.ts
@@ -4,7 +4,6 @@ import {
   getKeyframesForAsset,
   getMediaAssetById,
 } from "../../../../memory/media-store.js";
-import { getProviderKeyAsync } from "../../../../security/secure-keys.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -26,13 +25,6 @@ export async function run(
   }
 
   const includeAudio = Boolean(input.include_audio);
-  const transcriptionMode =
-    (input.transcription_mode as "api" | "local") || undefined;
-
-  let openaiApiKey: string | undefined;
-  if (includeAudio && (!transcriptionMode || transcriptionMode === "api")) {
-    openaiApiKey = await getProviderKeyAsync("openai");
-  }
 
   const options: PreprocessOptions = {
     intervalSeconds: (input.interval_seconds as number) || undefined,
@@ -45,8 +37,6 @@ export async function run(
         : undefined,
     shortEdge: (input.short_edge as number) || undefined,
     includeAudio,
-    transcriptionMode,
-    openaiApiKey,
   };
 
   try {


### PR DESCRIPTION
## Summary
- Remove transcriptionMode and openaiApiKey from PreprocessOptions interface
- Remove getProviderKeyAsync import and transcription_mode reading from extract-keyframes
- Add tests for extract-keyframes option mapping and preprocess audio transcript enrichment

Part of plan: media-processing-stt-service-refactor.md (PR 3 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24983" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
