### PR TITLE
Add runtime STT transcribe API backed by `services.stt`

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -7377,6 +7377,38 @@ paths:
       responses:
         "200":
           description: Successful response
+  /v1/stt/transcribe:
+    post:
+      operationId: stt_transcribe_post
+      summary: Transcribe audio to text
+      description:
+        Transcribe base64-encoded audio to text using the configured STT provider. Provider selection is resolved
+        globally via config.
+      tags:
+        - stt
+      responses:
+        "200":
+          description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                audioBase64:
+                  type: string
+                  description: Base64-encoded audio data to transcribe
+                mimeType:
+                  type: string
+                  description: MIME type of the audio data (must start with "audio/", e.g. "audio/wav", "audio/ogg")
+                source:
+                  description: Optional source identifier for analytics (e.g. 'dictation', 'voice-mode')
+                  type: string
+              required:
+                - audioBase64
+                - mimeType
+              additionalProperties: false
   /v1/subagents/{id}:
     get:
       operationId: subagents_by_id_get

--- a/assistant/src/runtime/auth/__tests__/route-policy.test.ts
+++ b/assistant/src/runtime/auth/__tests__/route-policy.test.ts
@@ -182,4 +182,44 @@ describe("enforcePolicy", () => {
     expect(policy).toBeDefined();
     expect(policy!.requiredScopes).toContain("chat.read");
   });
+
+  // -- STT transcribe policy ------------------------------------------------
+
+  test("stt/transcribe is registered as a protected endpoint", () => {
+    authDisabled = false;
+    const policy = getPolicy("stt/transcribe");
+    expect(policy).toBeDefined();
+  });
+
+  test("stt/transcribe requires chat.write scope", () => {
+    authDisabled = false;
+    const policy = getPolicy("stt/transcribe");
+    expect(policy).toBeDefined();
+    expect(policy!.requiredScopes).toContain("chat.write");
+  });
+
+  test("stt/transcribe allows actor, svc_gateway, svc_daemon, and local principals", () => {
+    authDisabled = false;
+    const policy = getPolicy("stt/transcribe");
+    expect(policy).toBeDefined();
+    expect(policy!.allowedPrincipalTypes).toContain("actor");
+    expect(policy!.allowedPrincipalTypes).toContain("svc_gateway");
+    expect(policy!.allowedPrincipalTypes).toContain("svc_daemon");
+    expect(policy!.allowedPrincipalTypes).toContain("local");
+  });
+
+  test("stt/transcribe denies actor without chat.write scope", () => {
+    authDisabled = false;
+    const ctx = buildTestContext({ scopes: ["chat.read"] });
+    const result = enforcePolicy("stt/transcribe", ctx);
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe(403);
+  });
+
+  test("stt/transcribe allows actor with chat.write scope", () => {
+    authDisabled = false;
+    const ctx = buildTestContext({ scopes: ["chat.write"] });
+    const result = enforcePolicy("stt/transcribe", ctx);
+    expect(result).toBeNull();
+  });
 });

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -465,6 +465,9 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   // Dictation
   { endpoint: "dictation", scopes: ["chat.write"] },
 
+  // Speech-to-text
+  { endpoint: "stt/transcribe", scopes: ["chat.write"] },
+
   // OAuth / integrations
   { endpoint: "oauth/start", scopes: ["settings.write"] },
   { endpoint: "integrations/oauth/start", scopes: ["settings.write"] }, // legacy alias

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -199,6 +199,7 @@ import { scheduleRouteDefinitions } from "./routes/schedule-routes.js";
 import { secretRouteDefinitions } from "./routes/secret-routes.js";
 import { settingsRouteDefinitions } from "./routes/settings-routes.js";
 import { skillRouteDefinitions } from "./routes/skills-routes.js";
+import { sttRouteDefinitions } from "./routes/stt-routes.js";
 import { subagentRouteDefinitions } from "./routes/subagents-routes.js";
 import { surfaceActionRouteDefinitions } from "./routes/surface-action-routes.js";
 import { surfaceContentRouteDefinitions } from "./routes/surface-content-routes.js";
@@ -1380,6 +1381,7 @@ export class RuntimeHttpServer {
           : undefined,
       }),
       ...ttsRouteDefinitions(),
+      ...sttRouteDefinitions(),
 
       // Conversation list and seen signal — kept inline because they
       // depend on multiple cross-cutting stores that aren't grouped

--- a/assistant/src/runtime/routes/__tests__/stt-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/stt-routes.test.ts
@@ -1,0 +1,406 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Module mocks — must appear before any imports of the modules under test
+// ---------------------------------------------------------------------------
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// -- Transcriber mock -------------------------------------------------------
+
+import type { BatchTranscriber } from "../../../stt/types.js";
+import { SttError } from "../../../stt/types.js";
+
+let mockTranscriber: BatchTranscriber | null = null;
+let mockResolveError: Error | null = null;
+
+mock.module("../../../providers/speech-to-text/resolve.js", () => ({
+  resolveBatchTranscriber: async () => {
+    if (mockResolveError) throw mockResolveError;
+    return mockTranscriber;
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Import under test — after mocks
+// ---------------------------------------------------------------------------
+
+import type { RouteContext } from "../../http-router.js";
+import { sttRouteDefinitions } from "../stt-routes.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function getTranscribeHandler() {
+  const routes = sttRouteDefinitions();
+  return routes[0].handler;
+}
+
+function makeRouteContext(body: unknown): RouteContext {
+  const url = new URL("http://localhost/v1/stt/transcribe");
+  return {
+    req: new Request(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: typeof body === "string" ? body : JSON.stringify(body),
+    }),
+    url,
+    server: {} as RouteContext["server"],
+    authContext: {
+      subject: "test-user",
+      principalType: "local",
+      assistantId: "self",
+      scopeProfile: "local_v1",
+      scopes: new Set(["local.all" as const]),
+      policyEpoch: 0,
+    },
+    params: {},
+  } as unknown as RouteContext;
+}
+
+function makeInvalidJsonContext(): RouteContext {
+  const url = new URL("http://localhost/v1/stt/transcribe");
+  return {
+    req: new Request(url, {
+      method: "POST",
+      body: "not-json",
+    }),
+    url,
+    server: {} as RouteContext["server"],
+    authContext: {
+      subject: "test-user",
+      principalType: "local",
+      assistantId: "self",
+      scopeProfile: "local_v1",
+      scopes: new Set(["local.all" as const]),
+      policyEpoch: 0,
+    },
+    params: {},
+  } as unknown as RouteContext;
+}
+
+async function readErrorBody(
+  response: Response,
+): Promise<{ error: { code: string; message: string } }> {
+  return response.json();
+}
+
+/** Encode a string to base64 to simulate valid audio data. */
+function toBase64(data: string): string {
+  return Buffer.from(data).toString("base64");
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+const fakeTranscriber: BatchTranscriber = {
+  providerId: "openai-whisper",
+  boundaryId: "daemon-batch",
+  transcribe: async () => ({ text: "hello world" }),
+};
+
+beforeEach(() => {
+  mockTranscriber = fakeTranscriber;
+  mockResolveError = null;
+});
+
+afterEach(() => {
+  // Reset to defaults
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("stt-routes", () => {
+  // -- Route metadata -------------------------------------------------------
+
+  test("exports a route definition for stt/transcribe", () => {
+    const routes = sttRouteDefinitions();
+    expect(routes).toHaveLength(1);
+    expect(routes[0].endpoint).toBe("stt/transcribe");
+    expect(routes[0].method).toBe("POST");
+    expect(routes[0].policyKey).toBe("stt/transcribe");
+  });
+
+  // -- Success path ---------------------------------------------------------
+
+  test("returns transcribed text with provider and boundary ids", async () => {
+    const handler = getTranscribeHandler();
+    const res = await handler(
+      makeRouteContext({
+        audioBase64: toBase64("fake-audio-data"),
+        mimeType: "audio/wav",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      text: string;
+      providerId: string;
+      boundaryId: string;
+    };
+    expect(body.text).toBe("hello world");
+    expect(body.providerId).toBe("openai-whisper");
+    expect(body.boundaryId).toBe("daemon-batch");
+  });
+
+  test("accepts optional source parameter", async () => {
+    const handler = getTranscribeHandler();
+    const res = await handler(
+      makeRouteContext({
+        audioBase64: toBase64("fake-audio-data"),
+        mimeType: "audio/wav",
+        source: "dictation",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+  });
+
+  // -- Malformed body -------------------------------------------------------
+
+  test("returns 400 for invalid JSON body", async () => {
+    const handler = getTranscribeHandler();
+    const res = await handler(makeInvalidJsonContext());
+
+    expect(res.status).toBe(400);
+    const body = await readErrorBody(res);
+    expect(body.error.code).toBe("BAD_REQUEST");
+    expect(body.error.message).toContain("Invalid JSON");
+  });
+
+  test("returns 400 when audioBase64 is missing", async () => {
+    const handler = getTranscribeHandler();
+    const res = await handler(makeRouteContext({ mimeType: "audio/wav" }));
+
+    expect(res.status).toBe(400);
+    const body = await readErrorBody(res);
+    expect(body.error.code).toBe("BAD_REQUEST");
+    expect(body.error.message).toContain("audioBase64");
+  });
+
+  test("returns 400 when audioBase64 is empty string", async () => {
+    const handler = getTranscribeHandler();
+    const res = await handler(
+      makeRouteContext({ audioBase64: "", mimeType: "audio/wav" }),
+    );
+
+    expect(res.status).toBe(400);
+    const body = await readErrorBody(res);
+    expect(body.error.code).toBe("BAD_REQUEST");
+    expect(body.error.message).toContain("audioBase64");
+  });
+
+  test("returns 400 when mimeType is missing", async () => {
+    const handler = getTranscribeHandler();
+    const res = await handler(
+      makeRouteContext({ audioBase64: toBase64("data") }),
+    );
+
+    expect(res.status).toBe(400);
+    const body = await readErrorBody(res);
+    expect(body.error.code).toBe("BAD_REQUEST");
+    expect(body.error.message).toContain("mimeType");
+  });
+
+  test("returns 400 when mimeType does not start with audio/", async () => {
+    const handler = getTranscribeHandler();
+    const res = await handler(
+      makeRouteContext({
+        audioBase64: toBase64("data"),
+        mimeType: "text/plain",
+      }),
+    );
+
+    expect(res.status).toBe(400);
+    const body = await readErrorBody(res);
+    expect(body.error.code).toBe("BAD_REQUEST");
+    expect(body.error.message).toContain("mimeType");
+    expect(body.error.message).toContain("audio/");
+  });
+
+  // -- Empty audio after decode ---------------------------------------------
+
+  test("returns 400 when decoded audio payload is empty", async () => {
+    const handler = getTranscribeHandler();
+    // An empty base64 string "" is caught by the non-empty check above.
+    // Use a base64 that decodes to empty buffer — this is actually impossible
+    // for valid base64. But we can test with a base64 of zero-length content
+    // by using the base64 of an empty string.
+    const res = await handler(
+      makeRouteContext({
+        audioBase64: Buffer.from("").toString("base64"), // ""
+        mimeType: "audio/wav",
+      }),
+    );
+
+    // The empty base64 "" is caught by the non-empty string check
+    expect(res.status).toBe(400);
+  });
+
+  // -- Missing provider (503) -----------------------------------------------
+
+  test("returns 503 when no STT provider is configured", async () => {
+    mockTranscriber = null;
+
+    const handler = getTranscribeHandler();
+    const res = await handler(
+      makeRouteContext({
+        audioBase64: toBase64("audio-data"),
+        mimeType: "audio/wav",
+      }),
+    );
+
+    expect(res.status).toBe(503);
+    const body = await readErrorBody(res);
+    expect(body.error.code).toBe("SERVICE_UNAVAILABLE");
+    expect(body.error.message).toContain("configured");
+  });
+
+  test("returns 503 when transcriber resolution throws", async () => {
+    mockResolveError = new Error("credential store unavailable");
+
+    const handler = getTranscribeHandler();
+    const res = await handler(
+      makeRouteContext({
+        audioBase64: toBase64("audio-data"),
+        mimeType: "audio/wav",
+      }),
+    );
+
+    expect(res.status).toBe(503);
+    const body = await readErrorBody(res);
+    expect(body.error.code).toBe("SERVICE_UNAVAILABLE");
+    expect(body.error.message).toContain("not available");
+  });
+
+  // -- Timeout --------------------------------------------------------------
+
+  test("returns 504 when transcription times out", async () => {
+    mockTranscriber = {
+      providerId: "openai-whisper",
+      boundaryId: "daemon-batch",
+      transcribe: async (_request) => {
+        // Simulate timeout by checking if abort signal fires
+        const err = new Error("The operation was aborted");
+        err.name = "AbortError";
+        throw err;
+      },
+    };
+
+    const handler = getTranscribeHandler();
+    const res = await handler(
+      makeRouteContext({
+        audioBase64: toBase64("audio-data"),
+        mimeType: "audio/wav",
+      }),
+    );
+
+    expect(res.status).toBe(504);
+    const body = await readErrorBody(res);
+    expect(body.error.code).toBe("INTERNAL_ERROR");
+    expect(body.error.message).toContain("timed out");
+  });
+
+  // -- Provider failure (various categories) --------------------------------
+
+  test("returns 401 for auth errors from provider", async () => {
+    mockTranscriber = {
+      providerId: "openai-whisper",
+      boundaryId: "daemon-batch",
+      transcribe: async () => {
+        throw new SttError("auth", "Invalid API key (401)");
+      },
+    };
+
+    const handler = getTranscribeHandler();
+    const res = await handler(
+      makeRouteContext({
+        audioBase64: toBase64("audio-data"),
+        mimeType: "audio/wav",
+      }),
+    );
+
+    expect(res.status).toBe(401);
+    const body = await readErrorBody(res);
+    expect(body.error.code).toBe("UNAUTHORIZED");
+    expect(body.error.message).toContain("credentials");
+  });
+
+  test("returns 429 for rate-limit errors from provider", async () => {
+    mockTranscriber = {
+      providerId: "openai-whisper",
+      boundaryId: "daemon-batch",
+      transcribe: async () => {
+        throw new SttError("rate-limit", "Rate limited (429)");
+      },
+    };
+
+    const handler = getTranscribeHandler();
+    const res = await handler(
+      makeRouteContext({
+        audioBase64: toBase64("audio-data"),
+        mimeType: "audio/wav",
+      }),
+    );
+
+    expect(res.status).toBe(429);
+    const body = await readErrorBody(res);
+    expect(body.error.code).toBe("RATE_LIMITED");
+    expect(body.error.message).toContain("rate limit");
+  });
+
+  test("returns 400 for invalid-audio errors from provider", async () => {
+    mockTranscriber = {
+      providerId: "openai-whisper",
+      boundaryId: "daemon-batch",
+      transcribe: async () => {
+        throw new SttError("invalid-audio", "Unsupported audio format (400)");
+      },
+    };
+
+    const handler = getTranscribeHandler();
+    const res = await handler(
+      makeRouteContext({
+        audioBase64: toBase64("audio-data"),
+        mimeType: "audio/wav",
+      }),
+    );
+
+    expect(res.status).toBe(400);
+    const body = await readErrorBody(res);
+    expect(body.error.code).toBe("BAD_REQUEST");
+    expect(body.error.message).toContain("rejected");
+  });
+
+  test("returns 502 for generic provider errors", async () => {
+    mockTranscriber = {
+      providerId: "openai-whisper",
+      boundaryId: "daemon-batch",
+      transcribe: async () => {
+        throw new Error("upstream kaboom");
+      },
+    };
+
+    const handler = getTranscribeHandler();
+    const res = await handler(
+      makeRouteContext({
+        audioBase64: toBase64("audio-data"),
+        mimeType: "audio/wav",
+      }),
+    );
+
+    expect(res.status).toBe(502);
+    const body = await readErrorBody(res);
+    expect(body.error.code).toBe("INTERNAL_ERROR");
+    expect(body.error.message).toContain("provider error");
+  });
+});

--- a/assistant/src/runtime/routes/stt-routes.ts
+++ b/assistant/src/runtime/routes/stt-routes.ts
@@ -1,0 +1,218 @@
+/**
+ * HTTP route definitions for speech-to-text transcription.
+ *
+ * POST /v1/stt/transcribe — transcribe base64-encoded audio to text
+ *
+ * Uses the globally configured STT provider via the `services.stt`
+ * abstraction. Provider selection is resolved via `resolveBatchTranscriber()`
+ * from `providers/speech-to-text/resolve.ts`.
+ */
+
+import { z } from "zod";
+
+import { resolveBatchTranscriber } from "../../providers/speech-to-text/resolve.js";
+import { normalizeSttError } from "../../stt/daemon-batch-transcriber.js";
+import type { SttErrorCategory } from "../../stt/types.js";
+import { getLogger } from "../../util/logger.js";
+import { httpError } from "../http-errors.js";
+import type { RouteDefinition } from "../http-router.js";
+
+const log = getLogger("stt-routes");
+
+/** Timeout for a single transcription request. */
+const TRANSCRIPTION_TIMEOUT_MS = 30_000;
+
+// ---------------------------------------------------------------------------
+// Error category -> HTTP status / message mapping
+// ---------------------------------------------------------------------------
+
+const STT_ERROR_MAP: Record<
+  SttErrorCategory,
+  { status: number; code: string; message: string }
+> = {
+  auth: {
+    status: 401,
+    code: "UNAUTHORIZED",
+    message: "STT provider credentials are invalid or missing",
+  },
+  "rate-limit": {
+    status: 429,
+    code: "RATE_LIMITED",
+    message: "STT provider rate limit exceeded",
+  },
+  timeout: {
+    status: 504,
+    code: "INTERNAL_ERROR",
+    message: "STT transcription timed out",
+  },
+  "invalid-audio": {
+    status: 400,
+    code: "BAD_REQUEST",
+    message: "Audio payload was rejected by the STT provider",
+  },
+  "provider-error": {
+    status: 502,
+    code: "INTERNAL_ERROR",
+    message: "STT provider error",
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+export function sttRouteDefinitions(): RouteDefinition[] {
+  return [
+    {
+      endpoint: "stt/transcribe",
+      method: "POST",
+      policyKey: "stt/transcribe",
+      summary: "Transcribe audio to text",
+      description:
+        "Transcribe base64-encoded audio to text using the configured STT provider. " +
+        "Provider selection is resolved globally via config.",
+      tags: ["stt"],
+      requestBody: z.object({
+        audioBase64: z
+          .string()
+          .describe("Base64-encoded audio data to transcribe"),
+        mimeType: z
+          .string()
+          .describe(
+            'MIME type of the audio data (must start with "audio/", e.g. "audio/wav", "audio/ogg")',
+          ),
+        source: z
+          .string()
+          .optional()
+          .describe(
+            "Optional source identifier for analytics (e.g. 'dictation', 'voice-mode')",
+          ),
+      }),
+      handler: async ({ req }) => {
+        // -- Parse body -------------------------------------------------------
+        let body: {
+          audioBase64?: unknown;
+          mimeType?: unknown;
+          source?: unknown;
+        };
+        try {
+          body = (await req.json()) as typeof body;
+        } catch {
+          return httpError("BAD_REQUEST", "Invalid JSON body", 400);
+        }
+
+        if (!body || typeof body !== "object") {
+          return httpError("BAD_REQUEST", "Invalid JSON body", 400);
+        }
+
+        // -- Validate audioBase64 ---------------------------------------------
+        if (
+          !body.audioBase64 ||
+          typeof body.audioBase64 !== "string" ||
+          body.audioBase64.length === 0
+        ) {
+          return httpError(
+            "BAD_REQUEST",
+            "audioBase64 is required and must be a non-empty string",
+            400,
+          );
+        }
+
+        // -- Validate mimeType ------------------------------------------------
+        if (
+          !body.mimeType ||
+          typeof body.mimeType !== "string" ||
+          !body.mimeType.startsWith("audio/")
+        ) {
+          return httpError(
+            "BAD_REQUEST",
+            'mimeType is required and must start with "audio/"',
+            400,
+          );
+        }
+
+        // -- Decode audio -----------------------------------------------------
+        let audioBuffer: Buffer;
+        try {
+          audioBuffer = Buffer.from(body.audioBase64 as string, "base64");
+        } catch {
+          return httpError(
+            "BAD_REQUEST",
+            "audioBase64 could not be decoded",
+            400,
+          );
+        }
+
+        if (audioBuffer.length === 0) {
+          return httpError(
+            "BAD_REQUEST",
+            "Decoded audio payload is empty",
+            400,
+          );
+        }
+
+        // -- Resolve transcriber ----------------------------------------------
+        let transcriber;
+        try {
+          transcriber = await resolveBatchTranscriber();
+        } catch (err) {
+          log.error({ err }, "Failed to resolve STT transcriber");
+          return httpError(
+            "SERVICE_UNAVAILABLE",
+            "STT provider is not available",
+            503,
+          );
+        }
+
+        if (!transcriber) {
+          return httpError(
+            "SERVICE_UNAVAILABLE",
+            "No speech-to-text provider is configured",
+            503,
+          );
+        }
+
+        // -- Transcribe with timeout ------------------------------------------
+        const abortController = new AbortController();
+        const timeoutId = setTimeout(
+          () => abortController.abort(),
+          TRANSCRIPTION_TIMEOUT_MS,
+        );
+
+        try {
+          const result = await transcriber.transcribe({
+            audio: audioBuffer,
+            mimeType: body.mimeType as string,
+            signal: abortController.signal,
+          });
+
+          return Response.json({
+            text: result.text,
+            providerId: transcriber.providerId,
+            boundaryId: transcriber.boundaryId,
+          });
+        } catch (err) {
+          const sttErr = normalizeSttError(err);
+          const mapped = STT_ERROR_MAP[sttErr.category];
+
+          log.warn(
+            {
+              category: sttErr.category,
+              message: sttErr.message,
+              source: body.source,
+            },
+            "STT transcription failed",
+          );
+
+          return httpError(
+            mapped.code as Parameters<typeof httpError>[0],
+            mapped.message,
+            mapped.status,
+          );
+        } finally {
+          clearTimeout(timeoutId);
+        }
+      },
+    },
+  ];
+}


### PR DESCRIPTION
## Summary
- Adds POST /v1/stt/transcribe route that accepts audioBase64+mimeType, resolves configured STT provider, and returns transcribed text
- Includes strict input validation, normalized error handling, and route policy protection with chat.write scope
- Adds comprehensive route-level and policy tests

Part of plan: service-first-stt-dictation-streaming.md (PR 1 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24986" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
