### PR TITLE
Introduce shared STT client and WAV encoding helpers for Apple clients

### DIFF
--- a/clients/shared/Network/STTClient.swift
+++ b/clients/shared/Network/STTClient.swift
@@ -1,0 +1,108 @@
+import Foundation
+import os
+
+private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "STTClient")
+
+/// Result of an STT transcription request. Callers use pattern matching to
+/// deterministically trigger native fallback when the service is unavailable
+/// or unconfigured.
+public enum STTResult: Sendable, Equatable {
+    /// Transcription succeeded — `text` contains the recognized speech.
+    case success(text: String)
+    /// STT service is not configured on the assistant (HTTP 503).
+    case notConfigured
+    /// STT service is temporarily unavailable (HTTP 5xx other than 503).
+    case serviceUnavailable
+    /// Generic error with optional status code and description.
+    case error(statusCode: Int?, message: String)
+}
+
+/// Client for speech-to-text transcription routed through the gateway.
+public protocol STTClientProtocol: Sendable {
+    /// Transcribe an audio payload via the assistant's configured STT service.
+    ///
+    /// - Parameters:
+    ///   - audioData: WAV-encoded audio data.
+    ///   - contentType: MIME type of the audio payload (default `"audio/wav"`).
+    /// - Returns: A typed ``STTResult`` that callers can match on to decide
+    ///   whether to fall back to native recognition.
+    func transcribe(audioData: Data, contentType: String) async -> STTResult
+}
+
+extension STTClientProtocol {
+    /// Convenience overload that defaults `contentType` to `"audio/wav"`.
+    public func transcribe(audioData: Data) async -> STTResult {
+        await transcribe(audioData: audioData, contentType: "audio/wav")
+    }
+}
+
+/// Gateway-backed implementation of ``STTClientProtocol``.
+public struct STTClient: STTClientProtocol {
+    nonisolated public init() {}
+
+    /// Timeout for the STT HTTP request. Kept moderate — transcription may take
+    /// a few seconds depending on audio length and provider latency, but we
+    /// don't want to block the user indefinitely.
+    static let requestTimeout: TimeInterval = 15
+
+    public func transcribe(audioData: Data, contentType: String = "audio/wav") async -> STTResult {
+        let start = CFAbsoluteTimeGetCurrent()
+        do {
+            let response = try await GatewayHTTPClient.post(
+                path: "assistants/{assistantId}/stt/transcribe",
+                body: audioData,
+                contentType: contentType,
+                timeout: Self.requestTimeout
+            )
+            let elapsed = CFAbsoluteTimeGetCurrent() - start
+            return Self.mapResponse(response, elapsed: elapsed)
+        } catch {
+            let elapsed = CFAbsoluteTimeGetCurrent() - start
+            log.error("STT request error after \(String(format: "%.1f", elapsed))s: \(error.localizedDescription)")
+            return .error(statusCode: nil, message: error.localizedDescription)
+        }
+    }
+
+    // MARK: - Response Mapping
+
+    /// Maps an HTTP response to a typed ``STTResult``.
+    ///
+    /// Internal visibility so tests can verify mapping without making network calls.
+    static func mapResponse(_ response: GatewayHTTPClient.Response, elapsed: TimeInterval = 0) -> STTResult {
+        switch response.statusCode {
+        case 200:
+            return decodeSuccess(response.data, elapsed: elapsed)
+        case 400:
+            let body = String(data: response.data, encoding: .utf8) ?? "unknown"
+            log.warning("STT bad request (400) after \(String(format: "%.1f", elapsed))s: \(body)")
+            return .error(statusCode: 400, message: "Bad request: \(body)")
+        case 503:
+            log.info("STT service not configured (503) after \(String(format: "%.1f", elapsed))s")
+            return .notConfigured
+        default:
+            if (500..<600).contains(response.statusCode) {
+                let body = String(data: response.data, encoding: .utf8) ?? "unknown"
+                log.warning("STT service unavailable (\(response.statusCode)) after \(String(format: "%.1f", elapsed))s: \(body)")
+                return .serviceUnavailable
+            }
+            let body = String(data: response.data, encoding: .utf8) ?? "unknown"
+            log.warning("STT unexpected status (\(response.statusCode)) after \(String(format: "%.1f", elapsed))s: \(body)")
+            return .error(statusCode: response.statusCode, message: "STT failed (HTTP \(response.statusCode))")
+        }
+    }
+
+    /// Decodes the 200 response body. Expects a JSON object with a `text` field.
+    private static func decodeSuccess(_ data: Data, elapsed: TimeInterval) -> STTResult {
+        struct TranscribeResponse: Decodable {
+            let text: String
+        }
+        do {
+            let decoded = try JSONDecoder().decode(TranscribeResponse.self, from: data)
+            log.info("STT transcription succeeded after \(String(format: "%.1f", elapsed))s (\(decoded.text.count) chars)")
+            return .success(text: decoded.text)
+        } catch {
+            log.warning("STT response decode failed after \(String(format: "%.1f", elapsed))s: \(error.localizedDescription)")
+            return .error(statusCode: 200, message: "Failed to decode STT response")
+        }
+    }
+}

--- a/clients/shared/Tests/AudioWavEncoderTests.swift
+++ b/clients/shared/Tests/AudioWavEncoderTests.swift
@@ -1,0 +1,174 @@
+import XCTest
+
+@testable import VellumAssistantShared
+
+final class AudioWavEncoderTests: XCTestCase {
+
+    // MARK: - Header Structure
+
+    func testHeaderSizeIs44Bytes() {
+        let wav = AudioWavEncoder.encode(pcmData: Data(), format: .speech16kHz)
+        XCTAssertEqual(wav.count, AudioWavEncoder.headerSize)
+    }
+
+    func testRIFFChunkID() {
+        let wav = AudioWavEncoder.encode(pcmData: Data(), format: .speech16kHz)
+        let riff = String(data: wav[0..<4], encoding: .ascii)
+        XCTAssertEqual(riff, "RIFF")
+    }
+
+    func testWAVEFormat() {
+        let wav = AudioWavEncoder.encode(pcmData: Data(), format: .speech16kHz)
+        let wave = String(data: wav[8..<12], encoding: .ascii)
+        XCTAssertEqual(wave, "WAVE")
+    }
+
+    func testFmtSubchunkID() {
+        let wav = AudioWavEncoder.encode(pcmData: Data(), format: .speech16kHz)
+        let fmt = String(data: wav[12..<16], encoding: .ascii)
+        XCTAssertEqual(fmt, "fmt ")
+    }
+
+    func testDataSubchunkID() {
+        let wav = AudioWavEncoder.encode(pcmData: Data(), format: .speech16kHz)
+        let dataChunk = String(data: wav[36..<40], encoding: .ascii)
+        XCTAssertEqual(dataChunk, "data")
+    }
+
+    func testAudioFormatIsPCM() {
+        let wav = AudioWavEncoder.encode(pcmData: Data(), format: .speech16kHz)
+        let audioFormat = readUInt16LE(wav, offset: 20)
+        XCTAssertEqual(audioFormat, 1, "Audio format should be 1 (PCM)")
+    }
+
+    // MARK: - Header Field Values
+
+    func testHeaderFieldsSpeech16kHz() {
+        let pcm = Data(repeating: 0, count: 3200) // 100ms of 16kHz mono 16-bit
+        let wav = AudioWavEncoder.encode(pcmData: pcm, format: .speech16kHz)
+
+        // Channels
+        XCTAssertEqual(readUInt16LE(wav, offset: 22), 1)
+        // Sample rate
+        XCTAssertEqual(readUInt32LE(wav, offset: 24), 16000)
+        // Byte rate: 16000 * 1 * 16 / 8 = 32000
+        XCTAssertEqual(readUInt32LE(wav, offset: 28), 32000)
+        // Block align: 1 * 16 / 8 = 2
+        XCTAssertEqual(readUInt16LE(wav, offset: 32), 2)
+        // Bits per sample
+        XCTAssertEqual(readUInt16LE(wav, offset: 34), 16)
+    }
+
+    func testHeaderFieldsStereo44kHz() {
+        let format = AudioWavEncoder.Format(sampleRate: 44100, channels: 2, bitsPerSample: 16)
+        let pcm = Data(repeating: 0, count: 176400) // 1s of 44.1kHz stereo 16-bit
+        let wav = AudioWavEncoder.encode(pcmData: pcm, format: format)
+
+        // Channels
+        XCTAssertEqual(readUInt16LE(wav, offset: 22), 2)
+        // Sample rate
+        XCTAssertEqual(readUInt32LE(wav, offset: 24), 44100)
+        // Byte rate: 44100 * 2 * 16 / 8 = 176400
+        XCTAssertEqual(readUInt32LE(wav, offset: 28), 176400)
+        // Block align: 2 * 16 / 8 = 4
+        XCTAssertEqual(readUInt16LE(wav, offset: 32), 4)
+        // Bits per sample
+        XCTAssertEqual(readUInt16LE(wav, offset: 34), 16)
+    }
+
+    // MARK: - File Size Consistency
+
+    func testFileSizeFieldIsConsistent() {
+        let pcm = Data(repeating: 0xAB, count: 8000)
+        let wav = AudioWavEncoder.encode(pcmData: pcm, format: .speech16kHz)
+
+        // RIFF chunk size = total file size - 8
+        let riffSize = readUInt32LE(wav, offset: 4)
+        XCTAssertEqual(riffSize, UInt32(wav.count - 8))
+    }
+
+    func testDataSubchunkSizeMatchesPCMData() {
+        let pcm = Data(repeating: 0xCD, count: 6400)
+        let wav = AudioWavEncoder.encode(pcmData: pcm, format: .speech16kHz)
+
+        let dataSize = readUInt32LE(wav, offset: 40)
+        XCTAssertEqual(dataSize, UInt32(pcm.count))
+    }
+
+    func testTotalLengthEqualsHeaderPlusPCMData() {
+        let pcm = Data(repeating: 0x42, count: 16000)
+        let wav = AudioWavEncoder.encode(pcmData: pcm, format: .speech16kHz)
+
+        XCTAssertEqual(wav.count, AudioWavEncoder.headerSize + pcm.count)
+    }
+
+    // MARK: - Payload Integrity
+
+    func testPCMDataIsAppendedUnmodified() {
+        var pcm = Data()
+        // Write a known pattern: alternating 0x00 and 0xFF
+        for i in 0..<100 {
+            pcm.append(UInt8(i % 2 == 0 ? 0x00 : 0xFF))
+        }
+        let wav = AudioWavEncoder.encode(pcmData: pcm, format: .speech16kHz)
+
+        let payload = wav[AudioWavEncoder.headerSize...]
+        XCTAssertEqual(Data(payload), pcm)
+    }
+
+    func testEmptyPCMDataProducesHeaderOnly() {
+        let wav = AudioWavEncoder.encode(pcmData: Data(), format: .speech16kHz)
+        XCTAssertEqual(wav.count, AudioWavEncoder.headerSize)
+
+        let dataSize = readUInt32LE(wav, offset: 40)
+        XCTAssertEqual(dataSize, 0)
+    }
+
+    // MARK: - Int16 Sample Encoding
+
+    func testEncodeFromInt16Samples() {
+        let samples: [Int16] = [0, 1000, -1000, Int16.max, Int16.min]
+        let wav = samples.withUnsafeBufferPointer { buffer in
+            AudioWavEncoder.encode(samples: buffer, format: .speech16kHz)
+        }
+
+        // Total size: header (44) + 5 samples * 2 bytes = 54
+        XCTAssertEqual(wav.count, 44 + 10)
+
+        // Verify the data subchunk size
+        let dataSize = readUInt32LE(wav, offset: 40)
+        XCTAssertEqual(dataSize, 10)
+
+        // Verify first sample (0) at offset 44
+        let firstSample = readInt16LE(wav, offset: 44)
+        XCTAssertEqual(firstSample, 0)
+
+        // Verify second sample (1000) at offset 46
+        let secondSample = readInt16LE(wav, offset: 46)
+        XCTAssertEqual(secondSample, 1000)
+
+        // Verify third sample (-1000) at offset 48
+        let thirdSample = readInt16LE(wav, offset: 48)
+        XCTAssertEqual(thirdSample, -1000)
+    }
+
+    // MARK: - Helpers
+
+    private func readUInt16LE(_ data: Data, offset: Int) -> UInt16 {
+        data.withUnsafeBytes { bytes in
+            bytes.load(fromByteOffset: offset, as: UInt16.self).littleEndian
+        }
+    }
+
+    private func readUInt32LE(_ data: Data, offset: Int) -> UInt32 {
+        data.withUnsafeBytes { bytes in
+            bytes.load(fromByteOffset: offset, as: UInt32.self).littleEndian
+        }
+    }
+
+    private func readInt16LE(_ data: Data, offset: Int) -> Int16 {
+        data.withUnsafeBytes { bytes in
+            bytes.load(fromByteOffset: offset, as: Int16.self).littleEndian
+        }
+    }
+}

--- a/clients/shared/Tests/STTClientTests.swift
+++ b/clients/shared/Tests/STTClientTests.swift
@@ -1,0 +1,148 @@
+import XCTest
+
+@testable import VellumAssistantShared
+
+@MainActor
+final class STTClientTests: XCTestCase {
+
+    // MARK: - 200 Success
+
+    func testMapResponse200ReturnsSuccessWithText() {
+        let json = #"{"text":"Hello world"}"#
+        let response = GatewayHTTPClient.Response(
+            data: json.data(using: .utf8)!,
+            statusCode: 200
+        )
+
+        let result = STTClient.mapResponse(response)
+
+        XCTAssertEqual(result, .success(text: "Hello world"))
+    }
+
+    func testMapResponse200WithEmptyTextReturnsSuccessEmpty() {
+        let json = #"{"text":""}"#
+        let response = GatewayHTTPClient.Response(
+            data: json.data(using: .utf8)!,
+            statusCode: 200
+        )
+
+        let result = STTClient.mapResponse(response)
+
+        XCTAssertEqual(result, .success(text: ""))
+    }
+
+    func testMapResponse200WithMalformedJSONReturnsError() {
+        let response = GatewayHTTPClient.Response(
+            data: "not json".data(using: .utf8)!,
+            statusCode: 200
+        )
+
+        let result = STTClient.mapResponse(response)
+
+        if case .error(let statusCode, let message) = result {
+            XCTAssertEqual(statusCode, 200)
+            XCTAssertTrue(message.contains("decode"), "Expected decode error message, got: \(message)")
+        } else {
+            XCTFail("Expected .error, got \(result)")
+        }
+    }
+
+    // MARK: - 400 Bad Request
+
+    func testMapResponse400ReturnsError() {
+        let body = "Invalid audio format"
+        let response = GatewayHTTPClient.Response(
+            data: body.data(using: .utf8)!,
+            statusCode: 400
+        )
+
+        let result = STTClient.mapResponse(response)
+
+        if case .error(let statusCode, let message) = result {
+            XCTAssertEqual(statusCode, 400)
+            XCTAssertTrue(message.contains("Bad request"), "Expected 'Bad request' in message, got: \(message)")
+        } else {
+            XCTFail("Expected .error, got \(result)")
+        }
+    }
+
+    // MARK: - 503 Not Configured
+
+    func testMapResponse503ReturnsNotConfigured() {
+        let response = GatewayHTTPClient.Response(
+            data: Data(),
+            statusCode: 503
+        )
+
+        let result = STTClient.mapResponse(response)
+
+        XCTAssertEqual(result, .notConfigured)
+    }
+
+    // MARK: - 5xx Service Unavailable
+
+    func testMapResponse500ReturnsServiceUnavailable() {
+        let response = GatewayHTTPClient.Response(
+            data: "Internal server error".data(using: .utf8)!,
+            statusCode: 500
+        )
+
+        let result = STTClient.mapResponse(response)
+
+        XCTAssertEqual(result, .serviceUnavailable)
+    }
+
+    func testMapResponse502ReturnsServiceUnavailable() {
+        let response = GatewayHTTPClient.Response(
+            data: Data(),
+            statusCode: 502
+        )
+
+        let result = STTClient.mapResponse(response)
+
+        XCTAssertEqual(result, .serviceUnavailable)
+    }
+
+    func testMapResponse504ReturnsServiceUnavailable() {
+        let response = GatewayHTTPClient.Response(
+            data: Data(),
+            statusCode: 504
+        )
+
+        let result = STTClient.mapResponse(response)
+
+        XCTAssertEqual(result, .serviceUnavailable)
+    }
+
+    // MARK: - Other Status Codes
+
+    func testMapResponse404ReturnsGenericError() {
+        let response = GatewayHTTPClient.Response(
+            data: "Not found".data(using: .utf8)!,
+            statusCode: 404
+        )
+
+        let result = STTClient.mapResponse(response)
+
+        if case .error(let statusCode, _) = result {
+            XCTAssertEqual(statusCode, 404)
+        } else {
+            XCTFail("Expected .error, got \(result)")
+        }
+    }
+
+    func testMapResponse429ReturnsGenericError() {
+        let response = GatewayHTTPClient.Response(
+            data: "Rate limited".data(using: .utf8)!,
+            statusCode: 429
+        )
+
+        let result = STTClient.mapResponse(response)
+
+        if case .error(let statusCode, _) = result {
+            XCTAssertEqual(statusCode, 429)
+        } else {
+            XCTFail("Expected .error, got \(result)")
+        }
+    }
+}

--- a/clients/shared/Utilities/AudioWavEncoder.swift
+++ b/clients/shared/Utilities/AudioWavEncoder.swift
@@ -1,0 +1,123 @@
+import Foundation
+
+/// Encodes raw PCM audio samples into a valid WAV file payload.
+///
+/// This utility handles the mechanical WAV serialization so that callers
+/// (macOS push-to-talk, iOS input bar, macOS voice mode) do not need to
+/// duplicate ad hoc audio encoding logic. It only serializes audio data —
+/// transport concerns belong to ``STTClient``.
+///
+/// WAV format reference: http://soundfile.sapp.org/doc/WaveFormat/
+public enum AudioWavEncoder {
+
+    // MARK: - Configuration
+
+    /// Parameters describing the PCM audio format to encode.
+    public struct Format: Sendable {
+        /// Sample rate in Hz (e.g. 16000, 44100, 48000).
+        public let sampleRate: Int
+        /// Number of audio channels (1 = mono, 2 = stereo).
+        public let channels: Int
+        /// Bits per sample (typically 16).
+        public let bitsPerSample: Int
+
+        public init(sampleRate: Int, channels: Int, bitsPerSample: Int) {
+            self.sampleRate = sampleRate
+            self.channels = channels
+            self.bitsPerSample = bitsPerSample
+        }
+
+        /// Commonly used format: 16 kHz mono 16-bit, suitable for speech recognition.
+        public static let speech16kHz = Format(sampleRate: 16000, channels: 1, bitsPerSample: 16)
+
+        /// Commonly used format: 44.1 kHz mono 16-bit.
+        public static let cd44kHzMono = Format(sampleRate: 44100, channels: 1, bitsPerSample: 16)
+    }
+
+    /// The size of a standard WAV header (RIFF + fmt + data chunk headers).
+    public static let headerSize = 44
+
+    // MARK: - Public API
+
+    /// Encodes raw PCM sample data into a complete WAV file.
+    ///
+    /// - Parameters:
+    ///   - pcmData: Raw PCM audio samples in little-endian byte order.
+    ///   - format: The audio format describing sample rate, channels, and bit depth.
+    /// - Returns: A `Data` value containing a valid WAV file (header + payload).
+    public static func encode(pcmData: Data, format: Format) -> Data {
+        var data = Data()
+        data.reserveCapacity(headerSize + pcmData.count)
+        writeHeader(to: &data, pcmDataSize: pcmData.count, format: format)
+        data.append(pcmData)
+        return data
+    }
+
+    /// Encodes raw PCM sample data provided as an `UnsafeBufferPointer<Int16>`
+    /// (common when working with `AVAudioPCMBuffer.int16ChannelData`).
+    ///
+    /// - Parameters:
+    ///   - samples: Pointer to interleaved 16-bit PCM samples.
+    ///   - format: The audio format describing sample rate, channels, and bit depth.
+    /// - Returns: A `Data` value containing a valid WAV file (header + payload).
+    public static func encode(samples: UnsafeBufferPointer<Int16>, format: Format) -> Data {
+        let pcmData = Data(buffer: samples)
+        return encode(pcmData: pcmData, format: format)
+    }
+
+    // MARK: - Header Construction
+
+    /// Writes a 44-byte WAV header into the given `Data`.
+    ///
+    /// Layout (all multi-byte values are little-endian unless noted):
+    /// ```
+    /// Offset  Size  Description
+    ///   0       4   "RIFF" (big-endian ASCII)
+    ///   4       4   File size minus 8 (total - RIFF header)
+    ///   8       4   "WAVE" (big-endian ASCII)
+    ///  12       4   "fmt " (big-endian ASCII)
+    ///  16       4   Subchunk1 size (16 for PCM)
+    ///  20       2   Audio format (1 = PCM)
+    ///  22       2   Number of channels
+    ///  24       4   Sample rate
+    ///  28       4   Byte rate (sampleRate * channels * bitsPerSample / 8)
+    ///  32       2   Block align (channels * bitsPerSample / 8)
+    ///  34       2   Bits per sample
+    ///  36       4   "data" (big-endian ASCII)
+    ///  40       4   Subchunk2 size (PCM data byte count)
+    /// ```
+    private static func writeHeader(to data: inout Data, pcmDataSize: Int, format: Format) {
+        let byteRate = format.sampleRate * format.channels * format.bitsPerSample / 8
+        let blockAlign = format.channels * format.bitsPerSample / 8
+        let fileSize = UInt32(36 + pcmDataSize) // Total file size minus 8 for RIFF header
+
+        // RIFF chunk
+        data.append(contentsOf: [0x52, 0x49, 0x46, 0x46]) // "RIFF"
+        appendUInt32LE(&data, fileSize)
+        data.append(contentsOf: [0x57, 0x41, 0x56, 0x45]) // "WAVE"
+
+        // fmt subchunk
+        data.append(contentsOf: [0x66, 0x6D, 0x74, 0x20]) // "fmt "
+        appendUInt32LE(&data, 16)                           // Subchunk1 size (PCM)
+        appendUInt16LE(&data, 1)                            // Audio format (PCM)
+        appendUInt16LE(&data, UInt16(format.channels))
+        appendUInt32LE(&data, UInt32(format.sampleRate))
+        appendUInt32LE(&data, UInt32(byteRate))
+        appendUInt16LE(&data, UInt16(blockAlign))
+        appendUInt16LE(&data, UInt16(format.bitsPerSample))
+
+        // data subchunk
+        data.append(contentsOf: [0x64, 0x61, 0x74, 0x61]) // "data"
+        appendUInt32LE(&data, UInt32(pcmDataSize))
+    }
+
+    // MARK: - Little-Endian Helpers
+
+    private static func appendUInt16LE(_ data: inout Data, _ value: UInt16) {
+        withUnsafeBytes(of: value.littleEndian) { data.append(contentsOf: $0) }
+    }
+
+    private static func appendUInt32LE(_ data: inout Data, _ value: UInt32) {
+        withUnsafeBytes(of: value.littleEndian) { data.append(contentsOf: $0) }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds STTClientProtocol and STTClient for gateway STT API calls with typed result model for deterministic fallback handling
- Adds AudioWavEncoder utility for converting PCM audio to WAV format
- Includes unit tests for response mapping and WAV encoding correctness

Part of plan: service-first-stt-dictation-streaming.md (PR 2 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24987" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
