### PR TITLE
fix: remove stale whisper-cpp reference from spawn.ts PATH comment

### DIFF
--- a/assistant/src/util/spawn.ts
+++ b/assistant/src/util/spawn.ts
@@ -22,7 +22,7 @@ export function spawnWithTimeout(
   timeoutMs: number,
 ): Promise<{ exitCode: number; stdout: string; stderr: string }> {
   return new Promise((resolve, reject) => {
-    // Augment PATH so Homebrew-installed tools (ffmpeg, ffprobe, whisper-cpp)
+    // Augment PATH so Homebrew-installed tools (ffmpeg, ffprobe)
     // are found even when the daemon runs as a bundled binary with minimal PATH.
     const proc = Bun.spawn(cmd, {
       stdout: "pipe",


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for media-processing-stt-service-refactor.md.

**Gap:** Stale whisper-cpp reference in spawn.ts PATH comment
**What was expected:** After removing local whisper-cpp support, all references should be cleaned up
**What was found:** Comment in spawn.ts still mentioned whisper-cpp as a Homebrew PATH tool
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24992" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
