### PR TITLE
feat(browser): add browser_mode input schema and normalization helper

### DIFF
--- a/assistant/src/__tests__/browser-skill-endstate.test.ts
+++ b/assistant/src/__tests__/browser-skill-endstate.test.ts
@@ -128,6 +128,24 @@ describe("browser skill migration end-state", () => {
     }
   });
 
+  test("every browser tool schema exposes an optional browser_mode property", async () => {
+    const path = await import("node:path");
+    const fs = await import("node:fs");
+    const toolsPath = path.resolve(
+      import.meta.dirname,
+      "../config/bundled-skills/browser/TOOLS.json",
+    );
+    const manifest = JSON.parse(fs.readFileSync(toolsPath, "utf-8"));
+    for (const tool of manifest.tools) {
+      const props = tool.input_schema?.properties ?? {};
+      expect(props.browser_mode).toBeDefined();
+      expect(props.browser_mode.type).toBe("string");
+      // browser_mode must NOT be required
+      const required: string[] = tool.input_schema?.required ?? [];
+      expect(required).not.toContain("browser_mode");
+    }
+  });
+
   // ── 3. Permission defaults align with PR 08/09 ────────────────────
 
   test("skill_load has default allow rule", () => {

--- a/assistant/src/config/bundled-skills/browser/SKILL.md
+++ b/assistant/src/config/bundled-skills/browser/SKILL.md
@@ -34,6 +34,26 @@ Use this skill to browse the web. After loading this skill, the following browse
 
 This browser runs **full Chromium with JavaScript enabled**. It can handle SPAs, React/Vue/Angular apps, dynamic content, date pickers, booking systems, reservation flows, and any JavaScript-heavy interactive site. Never tell the user you "can't handle interactive JavaScript" - you can.
 
+## Browser Mode
+
+Every browser tool accepts an optional `browser_mode` parameter that controls which backend executes the command:
+
+| Value | Backend | Description |
+|---|---|---|
+| `auto` | Automatic | Default. The assistant picks the best available backend based on context (extension > cdp-inspect > local). |
+| `extension` | Chrome extension | Routes through the user's Chrome browser via the extension debugger. |
+| `cdp-inspect` | CDP inspect | Connects to an already-running Chrome instance via the DevTools protocol. Alias: `cdp-debugger`. |
+| `local` | Playwright | Drives a dedicated Playwright-managed Chromium instance. Alias: `playwright`. |
+
+**When to use `auto`**: Prefer `auto` (or omit `browser_mode` entirely) unless you have a specific reason to pin. The automatic backend selection handles extension availability, fallback, and session reuse.
+
+**When to pin a mode**: Pin explicitly when:
+- The user requests interaction with their own browser (use `extension` or `cdp-inspect`).
+- A tool only works on a specific backend (e.g. `browser_wait_for_download` requires `local`).
+- You want to avoid fallback behavior for diagnostic clarity.
+
+**Unsupported mode errors**: Some tools restrict which modes they support. For example, `browser_wait_for_download` only supports `auto` and `local` because file downloads require the Playwright backend. Passing an unsupported mode returns a clear error with the accepted alternatives.
+
 ## Typical Workflow
 
 1. `browser_attach` to establish the debugger session (extension path; optional on other backends)

--- a/assistant/src/config/bundled-skills/browser/TOOLS.json
+++ b/assistant/src/config/bundled-skills/browser/TOOLS.json
@@ -17,6 +17,10 @@
             "type": "boolean",
             "description": "If true, allows navigation to localhost/private-network hosts. Disabled by default for SSRF safety."
           },
+          "browser_mode": {
+            "type": "string",
+            "description": "Override backend selection. Values: auto (default), extension, cdp-inspect (alias: cdp-debugger), local (alias: playwright). Omit or use auto to let the assistant choose."
+          },
           "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
@@ -35,6 +39,10 @@
       "input_schema": {
         "type": "object",
         "properties": {
+          "browser_mode": {
+            "type": "string",
+            "description": "Override backend selection. Values: auto (default), extension, cdp-inspect (alias: cdp-debugger), local (alias: playwright). Omit or use auto to let the assistant choose."
+          },
           "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
@@ -55,6 +63,10 @@
           "full_page": {
             "type": "boolean",
             "description": "Capture the full scrollable page instead of just the viewport."
+          },
+          "browser_mode": {
+            "type": "string",
+            "description": "Override backend selection. Values: auto (default), extension, cdp-inspect (alias: cdp-debugger), local (alias: playwright). Omit or use auto to let the assistant choose."
           },
           "activity": {
             "type": "string",
@@ -77,6 +89,10 @@
             "type": "boolean",
             "description": "If true, close all browser pages and the browser context. Default: false (close only the current conversation page)."
           },
+          "browser_mode": {
+            "type": "string",
+            "description": "Override backend selection. Values: auto (default), extension, cdp-inspect (alias: cdp-debugger), local (alias: playwright). Omit or use auto to let the assistant choose."
+          },
           "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
@@ -94,6 +110,10 @@
       "input_schema": {
         "type": "object",
         "properties": {
+          "browser_mode": {
+            "type": "string",
+            "description": "Override backend selection. Values: auto (default), extension, cdp-inspect (alias: cdp-debugger), local (alias: playwright). Omit or use auto to let the assistant choose."
+          },
           "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
@@ -111,6 +131,10 @@
       "input_schema": {
         "type": "object",
         "properties": {
+          "browser_mode": {
+            "type": "string",
+            "description": "Override backend selection. Values: auto (default), extension, cdp-inspect (alias: cdp-debugger), local (alias: playwright). Omit or use auto to let the assistant choose."
+          },
           "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
@@ -135,6 +159,10 @@
           "selector": {
             "type": "string",
             "description": "A CSS selector to target. Used as fallback when element_id is not available."
+          },
+          "browser_mode": {
+            "type": "string",
+            "description": "Override backend selection. Values: auto (default), extension, cdp-inspect (alias: cdp-debugger), local (alias: playwright). Omit or use auto to let the assistant choose."
           },
           "activity": {
             "type": "string",
@@ -173,6 +201,10 @@
             "type": "boolean",
             "description": "If true, press Enter after typing the text."
           },
+          "browser_mode": {
+            "type": "string",
+            "description": "Override backend selection. Values: auto (default), extension, cdp-inspect (alias: cdp-debugger), local (alias: playwright). Omit or use auto to let the assistant choose."
+          },
           "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
@@ -202,6 +234,10 @@
           "selector": {
             "type": "string",
             "description": "Optional CSS selector to target."
+          },
+          "browser_mode": {
+            "type": "string",
+            "description": "Override backend selection. Values: auto (default), extension, cdp-inspect (alias: cdp-debugger), local (alias: playwright). Omit or use auto to let the assistant choose."
           },
           "activity": {
             "type": "string",
@@ -237,6 +273,10 @@
           "selector": {
             "type": "string",
             "description": "Optional CSS selector of element to scroll within."
+          },
+          "browser_mode": {
+            "type": "string",
+            "description": "Override backend selection. Values: auto (default), extension, cdp-inspect (alias: cdp-debugger), local (alias: playwright). Omit or use auto to let the assistant choose."
           },
           "activity": {
             "type": "string",
@@ -276,6 +316,10 @@
             "type": "number",
             "description": "The zero-based index of the <option> to select."
           },
+          "browser_mode": {
+            "type": "string",
+            "description": "Override backend selection. Values: auto (default), extension, cdp-inspect (alias: cdp-debugger), local (alias: playwright). Omit or use auto to let the assistant choose."
+          },
           "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
@@ -300,6 +344,10 @@
           "selector": {
             "type": "string",
             "description": "A CSS selector to target. Used as fallback when element_id is not available."
+          },
+          "browser_mode": {
+            "type": "string",
+            "description": "Override backend selection. Values: auto (default), extension, cdp-inspect (alias: cdp-debugger), local (alias: playwright). Omit or use auto to let the assistant choose."
           },
           "activity": {
             "type": "string",
@@ -334,6 +382,10 @@
             "type": "number",
             "description": "Maximum wait time in milliseconds (default and max: 30000)."
           },
+          "browser_mode": {
+            "type": "string",
+            "description": "Override backend selection. Values: auto (default), extension, cdp-inspect (alias: cdp-debugger), local (alias: playwright). Omit or use auto to let the assistant choose."
+          },
           "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
@@ -355,6 +407,10 @@
             "type": "boolean",
             "description": "If true, include a list of links found on the page (up to 200)."
           },
+          "browser_mode": {
+            "type": "string",
+            "description": "Override backend selection. Values: auto (default), extension, cdp-inspect (alias: cdp-debugger), local (alias: playwright). Omit or use auto to let the assistant choose."
+          },
           "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
@@ -375,6 +431,10 @@
           "timeout": {
             "type": "number",
             "description": "Maximum wait time in milliseconds (default: 30000, max: 120000)."
+          },
+          "browser_mode": {
+            "type": "string",
+            "description": "Override backend selection. Values: auto (default), extension, cdp-inspect (alias: cdp-debugger), local (alias: playwright). Omit or use auto to let the assistant choose."
           },
           "activity": {
             "type": "string",
@@ -412,6 +472,10 @@
           "press_enter": {
             "type": "boolean",
             "description": "Press Enter after filling"
+          },
+          "browser_mode": {
+            "type": "string",
+            "description": "Override backend selection. Values: auto (default), extension, cdp-inspect (alias: cdp-debugger), local (alias: playwright). Omit or use auto to let the assistant choose."
           },
           "activity": {
             "type": "string",

--- a/assistant/src/config/bundled-skills/browser/tools/browser-wait-for-download.ts
+++ b/assistant/src/config/bundled-skills/browser/tools/browser-wait-for-download.ts
@@ -1,4 +1,5 @@
 import { browserManager } from "../../../../tools/browser/browser-manager.js";
+import { normalizeBrowserMode } from "../../../../tools/browser/browser-mode.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -8,6 +9,22 @@ export async function run(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
+  // Validate browser_mode: only auto/local are supported for downloads.
+  const modeResult = normalizeBrowserMode(input.browser_mode);
+  if ("error" in modeResult) {
+    return { content: `Error: ${modeResult.error}`, isError: true };
+  }
+  const { mode } = modeResult;
+  if (mode !== "auto" && mode !== "local") {
+    return {
+      content:
+        `Error: browser_wait_for_download does not support browser_mode "${mode}". ` +
+        `File downloads require the local Playwright backend. ` +
+        `Use browser_mode "auto" or "local" instead.`,
+      isError: true,
+    };
+  }
+
   const timeout =
     typeof input.timeout === "number"
       ? Math.min(Math.max(input.timeout, 1000), 120_000)

--- a/assistant/src/tools/browser/__tests__/browser-mode.test.ts
+++ b/assistant/src/tools/browser/__tests__/browser-mode.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from "bun:test";
+
+import type { BrowserMode } from "../browser-mode.js";
+import { normalizeBrowserMode } from "../browser-mode.js";
+
+describe("normalizeBrowserMode", () => {
+  // ── Defaults ──────────────────────────────────────────────────────────
+
+  test("undefined defaults to auto", () => {
+    const result = normalizeBrowserMode(undefined);
+    expect(result).toEqual({ mode: "auto" });
+  });
+
+  test("null defaults to auto", () => {
+    const result = normalizeBrowserMode(null);
+    expect(result).toEqual({ mode: "auto" });
+  });
+
+  test("empty string defaults to auto", () => {
+    const result = normalizeBrowserMode("");
+    expect(result).toEqual({ mode: "auto" });
+  });
+
+  // ── Canonical values ──────────────────────────────────────────────────
+
+  const canonicalValues: BrowserMode[] = [
+    "auto",
+    "extension",
+    "cdp-inspect",
+    "local",
+  ];
+
+  for (const value of canonicalValues) {
+    test(`canonical value "${value}" normalizes to itself`, () => {
+      const result = normalizeBrowserMode(value);
+      expect(result).toEqual({ mode: value });
+    });
+  }
+
+  // ── Aliases ───────────────────────────────────────────────────────────
+
+  test('alias "cdp-debugger" normalizes to "cdp-inspect"', () => {
+    const result = normalizeBrowserMode("cdp-debugger");
+    expect(result).toEqual({ mode: "cdp-inspect" });
+  });
+
+  test('alias "playwright" normalizes to "local"', () => {
+    const result = normalizeBrowserMode("playwright");
+    expect(result).toEqual({ mode: "local" });
+  });
+
+  // ── Case insensitivity ────────────────────────────────────────────────
+
+  test("uppercase input is normalized", () => {
+    const result = normalizeBrowserMode("AUTO");
+    expect(result).toEqual({ mode: "auto" });
+  });
+
+  test("mixed-case alias is normalized", () => {
+    const result = normalizeBrowserMode("Playwright");
+    expect(result).toEqual({ mode: "local" });
+  });
+
+  test("mixed-case cdp-debugger alias is normalized", () => {
+    const result = normalizeBrowserMode("CDP-Debugger");
+    expect(result).toEqual({ mode: "cdp-inspect" });
+  });
+
+  // ── Whitespace trimming ───────────────────────────────────────────────
+
+  test("leading/trailing whitespace is trimmed", () => {
+    const result = normalizeBrowserMode("  local  ");
+    expect(result).toEqual({ mode: "local" });
+  });
+
+  // ── Invalid values ────────────────────────────────────────────────────
+
+  test("unknown string returns error with accepted values", () => {
+    const result = normalizeBrowserMode("headless");
+    expect("error" in result).toBe(true);
+    if ("error" in result) {
+      expect(result.error).toContain('Invalid browser_mode "headless"');
+      expect(result.error).toContain("Accepted values:");
+      expect(result.error).toContain("auto");
+      expect(result.error).toContain("extension");
+      expect(result.error).toContain("cdp-inspect");
+      expect(result.error).toContain("cdp-debugger");
+      expect(result.error).toContain("local");
+      expect(result.error).toContain("playwright");
+      expect(result.error).toContain("Aliases:");
+      expect(result.error).toContain("cdp-debugger->cdp-inspect");
+      expect(result.error).toContain("playwright->local");
+    }
+  });
+
+  test("non-string input returns error", () => {
+    const result = normalizeBrowserMode(42);
+    expect("error" in result).toBe(true);
+    if ("error" in result) {
+      expect(result.error).toContain('Invalid browser_mode "42"');
+    }
+  });
+
+  test("boolean input returns error", () => {
+    const result = normalizeBrowserMode(true);
+    expect("error" in result).toBe(true);
+    if ("error" in result) {
+      expect(result.error).toContain('Invalid browser_mode "true"');
+    }
+  });
+
+  // ── Error message determinism ─────────────────────────────────────────
+
+  test("error message is deterministic across calls", () => {
+    const r1 = normalizeBrowserMode("bogus");
+    const r2 = normalizeBrowserMode("bogus");
+    expect(r1).toEqual(r2);
+  });
+});

--- a/assistant/src/tools/browser/browser-mode.ts
+++ b/assistant/src/tools/browser/browser-mode.ts
@@ -1,0 +1,89 @@
+/**
+ * Normalization helper for the `browser_mode` tool input parameter.
+ *
+ * Canonical values map directly to {@link CdpClientKind}:
+ *   - `auto`        -- let the factory pick the best backend (default)
+ *   - `extension`   -- force the Chrome extension transport
+ *   - `cdp-inspect` -- force the CDP inspect/debugger transport
+ *   - `local`       -- force the Playwright-managed local browser
+ *
+ * Aliases are accepted and normalized to their canonical form:
+ *   - `cdp-debugger` -> `cdp-inspect`
+ *   - `playwright`   -> `local`
+ */
+
+/** Canonical browser mode values. */
+export type BrowserMode = "auto" | "extension" | "cdp-inspect" | "local";
+
+/** All accepted values (canonical + aliases). */
+const ALIAS_MAP: Record<string, BrowserMode> = {
+  auto: "auto",
+  extension: "extension",
+  "cdp-inspect": "cdp-inspect",
+  "cdp-debugger": "cdp-inspect",
+  local: "local",
+  playwright: "local",
+};
+
+/** Ordered list of accepted values for error messages. */
+const ACCEPTED_VALUES = Object.keys(ALIAS_MAP);
+
+/**
+ * Human-readable alias mapping for error messages.
+ * Only includes entries where the alias differs from the canonical value.
+ */
+const ALIAS_DISPLAY: Record<string, string> = {
+  "cdp-debugger": "cdp-inspect",
+  playwright: "local",
+};
+
+export interface NormalizeBrowserModeResult {
+  /** The normalized canonical mode. */
+  mode: BrowserMode;
+}
+
+export interface NormalizeBrowserModeError {
+  /** Deterministic error message describing the invalid value. */
+  error: string;
+}
+
+/**
+ * Normalize a raw `browser_mode` input value to a canonical {@link BrowserMode}.
+ *
+ * - `undefined` / `null` / empty string -> `{ mode: "auto" }`
+ * - Valid canonical value or alias       -> `{ mode: <canonical> }`
+ * - Invalid value                        -> `{ error: "..." }` with accepted list and alias mapping
+ */
+export function normalizeBrowserMode(
+  raw: unknown,
+): NormalizeBrowserModeResult | NormalizeBrowserModeError {
+  if (raw === undefined || raw === null || raw === "") {
+    return { mode: "auto" };
+  }
+
+  if (typeof raw !== "string") {
+    return buildError(String(raw));
+  }
+
+  const lower = raw.toLowerCase().trim();
+  const canonical = ALIAS_MAP[lower];
+
+  if (canonical !== undefined) {
+    return { mode: canonical };
+  }
+
+  return buildError(raw);
+}
+
+function buildError(value: string): NormalizeBrowserModeError {
+  const aliasHints = Object.entries(ALIAS_DISPLAY)
+    .map(([alias, canonical]) => `${alias}->${canonical}`)
+    .join(", ");
+
+  return {
+    error:
+      `Invalid browser_mode "${value}". ` +
+      `Accepted values: ${ACCEPTED_VALUES.join(", ")}. ` +
+      `Aliases: ${aliasHints}.`,
+  };
+}


### PR DESCRIPTION
## Summary
- Add optional browser_mode parameter to all browser tool schemas in TOOLS.json
- Create normalization helper with canonical values and aliases (cdp-debugger→cdp-inspect, playwright→local)
- Update browser-wait-for-download to validate browser_mode and reject non-local modes

Part of plan: browser-mode-fallback-diagnostics.md (PR 1 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24996" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
