### PR TITLE
Media-Processing STT Service Refactor

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -202,7 +202,6 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "workspace/provider-commit-message-generator.ts", // commit message generation provider key lookup
       "config/bundled-skills/image-studio/tools/media-generate-image.ts", // image generation tool API key lookup
       "config/bundled-skills/media-processing/tools/analyze-keyframes.ts", // keyframe analysis tool API key lookup
-      "config/bundled-skills/media-processing/tools/extract-keyframes.ts", // keyframe extraction tool API key lookup
       "providers/registry.ts", // provider registry API key lookup for initialization
       "providers/provider-availability.ts", // provider availability API key check
       "media/app-icon-generator.ts", // app icon generation API key lookup

--- a/assistant/src/config/bundled-skills/media-processing/SKILL.md
+++ b/assistant/src/config/bundled-skills/media-processing/SKILL.md
@@ -45,8 +45,7 @@ Parameters:
 - `section_config` - Path to a JSON file with manual section boundaries.
 - `detect_dead_time` - Whether to detect and skip dead time (default: false). Dead-time detection can be too aggressive for continuous action video like sports - it may incorrectly skip live play. Enable only for content with clear idle periods (e.g., lectures, surveillance footage).
 - `short_edge` - Short edge resolution for downscaled frames in pixels (default: 480).
-- `include_audio` - Whether to extract and transcribe audio for each segment (default: false). When enabled, each segment's audio is transcribed and stored alongside visual frames.
-- `transcription_mode` - Transcription backend: `'api'` (OpenAI Whisper cloud) or `'local'` (whisper.cpp on-device). Default: `'local'`. The `'api'` mode requires an OpenAI API key configured in settings.
+- `include_audio` - Whether to extract and transcribe audio for each segment (default: false). When enabled, each segment's audio is transcribed using the configured STT service and stored alongside visual frames.
 
 ### analyze_keyframes
 
@@ -121,7 +120,7 @@ Tracks estimated API costs during pipeline execution.
 
 ## Audio + Vision Multimodal Analysis
 
-When `include_audio` is enabled on `extract_keyframes`, the pipeline transcribes each segment's audio track and attaches the transcript to the segment data. During the Map phase (`analyze_keyframes`), Gemini receives both the visual frames and the audio transcript for each segment, enabling multimodal analysis that combines what is seen with what is said.
+When `include_audio` is enabled on `extract_keyframes`, the pipeline transcribes each segment's audio track using the configured STT service and attaches the transcript to the segment data. During the Map phase (`analyze_keyframes`), Gemini receives both the visual frames and the audio transcript for each segment, enabling multimodal analysis that combines what is seen with what is said.
 
 This is useful for:
 
@@ -130,12 +129,7 @@ This is useful for:
 - **Meetings and interviews**: Pair facial expressions and gestures with spoken dialogue.
 - **Tutorials and demos**: Link on-screen actions with verbal instructions.
 
-Transcription modes:
-
-- **`local`** (default): Uses whisper.cpp for on-device transcription. Requires `whisper-cpp` to be installed (`brew install whisper-cpp`). No API costs, but slower.
-- **`api`**: Uses the OpenAI Whisper API for cloud-based transcription. Faster and more accurate, but requires an OpenAI API key and incurs per-minute costs.
-
-The audio transcription degrades gracefully - if transcription fails for a segment (missing tools, no audio track, API errors), the segment proceeds with visual-only analysis.
+Audio transcription uses the STT service configured in assistant settings. If no STT service is configured or transcription fails for a segment (no audio track, service errors), the segment gracefully degrades to visual-only analysis.
 
 ## Best Practices
 

--- a/assistant/src/config/bundled-skills/media-processing/TOOLS.json
+++ b/assistant/src/config/bundled-skills/media-processing/TOOLS.json
@@ -99,12 +99,7 @@
           },
           "include_audio": {
             "type": "boolean",
-            "description": "Whether to extract and transcribe audio for each segment. Default: false."
-          },
-          "transcription_mode": {
-            "type": "string",
-            "enum": ["api", "local"],
-            "description": "Transcription backend: 'api' (OpenAI Whisper cloud) or 'local' (whisper.cpp). Default: 'local'."
+            "description": "Whether to extract and transcribe audio for each segment using the configured STT service. Default: false."
           },
           "activity": {
             "type": "string",

--- a/assistant/src/config/bundled-skills/media-processing/__tests__/audio-transcribe.test.ts
+++ b/assistant/src/config/bundled-skills/media-processing/__tests__/audio-transcribe.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { BatchTranscriber } from "../../../../stt/types.js";
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before the subject import
+// ---------------------------------------------------------------------------
+
+let mockTranscriber: BatchTranscriber | null = null;
+
+mock.module("../../../../providers/speech-to-text/resolve.js", () => ({
+  resolveBatchTranscriber: async () => mockTranscriber,
+}));
+
+let spawnResult: { exitCode: number; stdout: string; stderr: string } = {
+  exitCode: 0,
+  stdout: "",
+  stderr: "",
+};
+
+mock.module("../../../../util/spawn.js", () => ({
+  spawnWithTimeout: async () => spawnResult,
+}));
+
+let mockFileContents: Buffer = Buffer.alloc(0);
+
+mock.module("node:fs/promises", () => ({
+  readFile: async () => mockFileContents,
+  unlink: async () => {},
+}));
+
+// ---------------------------------------------------------------------------
+// Subject import (after mocks)
+// ---------------------------------------------------------------------------
+
+import { transcribeSegmentAudio } from "../services/audio-transcribe.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeMockTranscriber(text: string): BatchTranscriber {
+  return {
+    providerId: "openai-whisper",
+    boundaryId: "daemon-batch",
+    transcribe: async () => ({ text }),
+  };
+}
+
+function makeFailingTranscriber(error: Error): BatchTranscriber {
+  return {
+    providerId: "openai-whisper",
+    boundaryId: "daemon-batch",
+    transcribe: async () => {
+      throw error;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("transcribeSegmentAudio", () => {
+  beforeEach(() => {
+    mockTranscriber = null;
+    spawnResult = { exitCode: 0, stdout: "", stderr: "" };
+    mockFileContents = Buffer.from("fake-wav-data");
+  });
+
+  test("returns transcript text on successful transcription", async () => {
+    mockTranscriber = makeMockTranscriber("Hello, this is a test transcript.");
+
+    const result = await transcribeSegmentAudio("/tmp/video.mp4", 10, 15);
+
+    expect(result).toBe("Hello, this is a test transcript.");
+  });
+
+  test("returns empty string when no STT provider is configured", async () => {
+    mockTranscriber = null;
+
+    const result = await transcribeSegmentAudio("/tmp/video.mp4", 0, 30);
+
+    expect(result).toBe("");
+  });
+
+  test("returns empty string when ffmpeg extraction fails", async () => {
+    mockTranscriber = makeMockTranscriber("should not reach here");
+    spawnResult = {
+      exitCode: 1,
+      stdout: "",
+      stderr: "ffmpeg: error extracting audio",
+    };
+
+    const result = await transcribeSegmentAudio("/tmp/video.mp4", 5, 10);
+
+    expect(result).toBe("");
+  });
+
+  test("returns empty string when provider throws an error", async () => {
+    mockTranscriber = makeFailingTranscriber(
+      new Error("Provider API rate limited"),
+    );
+
+    const result = await transcribeSegmentAudio("/tmp/video.mp4", 0, 20);
+
+    expect(result).toBe("");
+  });
+
+  test("trims whitespace from transcript result", async () => {
+    mockTranscriber = makeMockTranscriber("  trimmed text  ");
+
+    const result = await transcribeSegmentAudio("/tmp/video.mp4", 0, 10);
+
+    expect(result).toBe("trimmed text");
+  });
+
+  test("returns empty string when provider returns empty text", async () => {
+    mockTranscriber = makeMockTranscriber("");
+
+    const result = await transcribeSegmentAudio("/tmp/video.mp4", 0, 10);
+
+    expect(result).toBe("");
+  });
+});

--- a/assistant/src/config/bundled-skills/media-processing/__tests__/extract-keyframes.test.ts
+++ b/assistant/src/config/bundled-skills/media-processing/__tests__/extract-keyframes.test.ts
@@ -1,0 +1,181 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { PreprocessManifest } from "../services/preprocess.js";
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before the subject import
+// ---------------------------------------------------------------------------
+
+let lastPreprocessOptions: Record<string, unknown> | undefined;
+let mockManifest: PreprocessManifest;
+let mockPreprocessError: Error | null = null;
+
+mock.module("../services/preprocess.js", () => ({
+  preprocessForAsset: async (
+    _assetId: string,
+    options: Record<string, unknown>,
+  ) => {
+    lastPreprocessOptions = options;
+    if (mockPreprocessError) throw mockPreprocessError;
+    return mockManifest;
+  },
+}));
+
+mock.module("../../../../memory/media-store.js", () => ({
+  getMediaAssetById: () => ({ filePath: "/tmp/videos/test.mp4" }),
+  getKeyframesForAsset: () => [{ id: "kf-1" }, { id: "kf-2" }, { id: "kf-3" }],
+}));
+
+// ---------------------------------------------------------------------------
+// Subject import (after mocks)
+// ---------------------------------------------------------------------------
+
+import { run } from "../tools/extract-keyframes.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeManifest(
+  overrides: Partial<PreprocessManifest> = {},
+): PreprocessManifest {
+  return {
+    assetId: "asset-1",
+    videoPath: "/tmp/videos/test.mp4",
+    durationSeconds: 60,
+    segments: [
+      {
+        id: "seg-001",
+        startSeconds: 0,
+        endSeconds: 15,
+        framePaths: ["/tmp/frame-1.jpg"],
+        frameTimestamps: [0],
+      },
+    ],
+    deadTimeRanges: [],
+    subjectRegistry: { groups: [] },
+    sectionBoundaries: [],
+    config: {
+      intervalSeconds: 1,
+      segmentDuration: 15,
+      deadTimeThreshold: 0.02,
+      shortEdge: 480,
+    },
+    ...overrides,
+  };
+}
+
+function makeContext() {
+  return {
+    workingDir: "/tmp",
+    conversationId: "conv-1",
+    trustClass: "guardian" as const,
+    onOutput: () => {},
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("extract_keyframes tool", () => {
+  beforeEach(() => {
+    lastPreprocessOptions = undefined;
+    mockPreprocessError = null;
+    mockManifest = makeManifest();
+  });
+
+  test("returns error when asset_id is missing", async () => {
+    const result = await run({}, makeContext());
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toBe("asset_id is required.");
+  });
+
+  test("passes include_audio through to preprocessForAsset", async () => {
+    await run({ asset_id: "asset-1", include_audio: true }, makeContext());
+
+    expect(lastPreprocessOptions?.includeAudio).toBe(true);
+  });
+
+  test("defaults include_audio to false when not provided", async () => {
+    await run({ asset_id: "asset-1" }, makeContext());
+
+    expect(lastPreprocessOptions?.includeAudio).toBe(false);
+  });
+
+  test("maps all numeric option fields from tool input", async () => {
+    await run(
+      {
+        asset_id: "asset-1",
+        interval_seconds: 2,
+        segment_duration: 30,
+        dead_time_threshold: 0.05,
+        short_edge: 720,
+      },
+      makeContext(),
+    );
+
+    expect(lastPreprocessOptions?.intervalSeconds).toBe(2);
+    expect(lastPreprocessOptions?.segmentDuration).toBe(30);
+    expect(lastPreprocessOptions?.deadTimeThreshold).toBe(0.05);
+    expect(lastPreprocessOptions?.shortEdge).toBe(720);
+  });
+
+  test("passes detect_dead_time and section_config through", async () => {
+    await run(
+      {
+        asset_id: "asset-1",
+        detect_dead_time: true,
+        section_config: "/tmp/sections.json",
+      },
+      makeContext(),
+    );
+
+    expect(lastPreprocessOptions?.detectDeadTime).toBe(true);
+    expect(lastPreprocessOptions?.sectionConfigPath).toBe("/tmp/sections.json");
+  });
+
+  test("does not pass transcriptionMode or openaiApiKey", async () => {
+    await run(
+      {
+        asset_id: "asset-1",
+        include_audio: true,
+        transcription_mode: "api",
+      },
+      makeContext(),
+    );
+
+    expect(lastPreprocessOptions).toBeDefined();
+    expect("transcriptionMode" in lastPreprocessOptions!).toBe(false);
+    expect("openaiApiKey" in lastPreprocessOptions!).toBe(false);
+  });
+
+  test("returns successful result with manifest summary", async () => {
+    const result = await run({ asset_id: "asset-1" }, makeContext());
+
+    expect(result.isError).toBe(false);
+    const parsed = JSON.parse(result.content);
+    expect(parsed.assetId).toBe("asset-1");
+    expect(parsed.segmentCount).toBe(1);
+    expect(parsed.keyframeCount).toBe(3);
+  });
+
+  test("returns error content for known preprocess failures", async () => {
+    mockPreprocessError = new Error("Media asset not found: asset-bad");
+
+    const result = await run({ asset_id: "asset-bad" }, makeContext());
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toBe("Media asset not found: asset-bad");
+  });
+
+  test("wraps unknown errors in generic message", async () => {
+    mockPreprocessError = new Error("Something unexpected");
+
+    const result = await run({ asset_id: "asset-1" }, makeContext());
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toBe("Preprocess failed: Something unexpected");
+  });
+});

--- a/assistant/src/config/bundled-skills/media-processing/__tests__/preprocess-audio.test.ts
+++ b/assistant/src/config/bundled-skills/media-processing/__tests__/preprocess-audio.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before the subject import
+// ---------------------------------------------------------------------------
+
+let mockTranscribeResult: string = "";
+
+mock.module("../services/audio-transcribe.js", () => ({
+  transcribeSegmentAudio: async () => mockTranscribeResult,
+}));
+
+let spawnExitCode = 0;
+
+mock.module("../../../../util/spawn.js", () => ({
+  spawnWithTimeout: async () => ({
+    exitCode: spawnExitCode,
+    stdout: "",
+    stderr: "",
+  }),
+  FFMPEG_PALETTE_TIMEOUT_MS: 10_000,
+  FFMPEG_PREPROCESS_TIMEOUT_MS: 60_000,
+}));
+
+mock.module("../../../../memory/media-store.js", () => ({
+  getMediaAssetById: (id: string) => ({
+    id,
+    mediaType: "video",
+    filePath: "/tmp/videos/test.mp4",
+    durationSeconds: 30,
+  }),
+  getProcessingStagesForAsset: () => [],
+  createProcessingStage: () => ({ id: "stage-1" }),
+  updateProcessingStage: () => {},
+  deleteKeyframesForAsset: () => {},
+  insertKeyframesBatch: () => {},
+}));
+
+// Mock fs — readdir must return frame filenames to produce segments with frames
+let mockReaddirFiles: string[] = ["frame-000001.jpg", "frame-000002.jpg"];
+
+mock.module("node:fs/promises", () => ({
+  mkdir: async () => {},
+  readdir: async () => mockReaddirFiles,
+  readFile: async () => "[]",
+  rename: async () => {},
+  rm: async () => {},
+  writeFile: async () => {},
+}));
+
+mock.module("../../../../util/silently.js", () => ({
+  silentlyWithLog: async () => {},
+}));
+
+// ---------------------------------------------------------------------------
+// Subject import (after mocks)
+// ---------------------------------------------------------------------------
+
+import { preprocessForAsset } from "../services/preprocess.js";
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("preprocessForAsset — audio transcript enrichment", () => {
+  beforeEach(() => {
+    mockTranscribeResult = "";
+    spawnExitCode = 0;
+    mockReaddirFiles = ["frame-000001.jpg", "frame-000002.jpg"];
+  });
+
+  test("attaches transcript to segments when transcription returns text", async () => {
+    mockTranscribeResult = "Hello world, this is a transcript.";
+
+    const manifest = await preprocessForAsset("asset-1", {
+      includeAudio: true,
+      segmentDuration: 30,
+    });
+
+    expect(manifest.segments.length).toBeGreaterThan(0);
+    for (const seg of manifest.segments) {
+      expect(seg.transcript).toBe("Hello world, this is a transcript.");
+    }
+  });
+
+  test("omits transcript field when transcription returns empty string", async () => {
+    mockTranscribeResult = "";
+
+    const manifest = await preprocessForAsset("asset-1", {
+      includeAudio: true,
+      segmentDuration: 30,
+    });
+
+    expect(manifest.segments.length).toBeGreaterThan(0);
+    for (const seg of manifest.segments) {
+      expect(seg.transcript).toBeUndefined();
+    }
+  });
+
+  test("does not set transcript when includeAudio is false", async () => {
+    mockTranscribeResult = "Should not appear";
+
+    const manifest = await preprocessForAsset("asset-1", {
+      includeAudio: false,
+      segmentDuration: 30,
+    });
+
+    expect(manifest.segments.length).toBeGreaterThan(0);
+    for (const seg of manifest.segments) {
+      expect(seg.transcript).toBeUndefined();
+    }
+  });
+
+  test("does not set transcript when includeAudio is omitted", async () => {
+    mockTranscribeResult = "Should not appear";
+
+    const manifest = await preprocessForAsset("asset-1", {
+      segmentDuration: 30,
+    });
+
+    expect(manifest.segments.length).toBeGreaterThan(0);
+    for (const seg of manifest.segments) {
+      expect(seg.transcript).toBeUndefined();
+    }
+  });
+
+  test("does not throw when transcription returns empty for all segments", async () => {
+    mockTranscribeResult = "";
+
+    const manifest = await preprocessForAsset("asset-1", {
+      includeAudio: true,
+      segmentDuration: 15,
+    });
+
+    // Should complete successfully with segments but no transcripts
+    expect(manifest.segments.length).toBeGreaterThan(0);
+    expect(manifest.segments.every((s) => s.transcript === undefined)).toBe(
+      true,
+    );
+  });
+});

--- a/assistant/src/config/bundled-skills/media-processing/services/audio-transcribe.ts
+++ b/assistant/src/config/bundled-skills/media-processing/services/audio-transcribe.ts
@@ -1,34 +1,43 @@
 /**
  * Per-segment audio transcription for the video processing pipeline.
- * Extracts audio for a time range and transcribes it via OpenAI Whisper API
- * or local whisper.cpp, returning the transcript text.
+ * Extracts audio for a time range and transcribes it via the configured
+ * STT service (resolved through `resolveBatchTranscriber`), returning the
+ * transcript text.
  */
 
 import { randomUUID } from "node:crypto";
-import { access, readFile, unlink } from "node:fs/promises";
+import { readFile, unlink } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import { resolveBatchTranscriber } from "../../../../providers/speech-to-text/resolve.js";
 import { spawnWithTimeout } from "../../../../util/spawn.js";
 
 const FFMPEG_TIMEOUT_MS = 60_000;
-const API_REQUEST_TIMEOUT_MS = 120_000;
-const LOCAL_CHUNK_TIMEOUT_MS = 120_000;
+const STT_REQUEST_TIMEOUT_MS = 120_000;
 
 /**
  * Transcribe the audio from a specific time range of a video file.
  * Returns the transcript text, or empty string on failure (graceful degradation).
+ *
+ * Uses the daemon's configured STT service via `resolveBatchTranscriber()`.
+ * Returns empty string when no provider is configured, the provider call
+ * fails, or ffmpeg extraction fails — this preserves preprocess resilience.
  */
 export async function transcribeSegmentAudio(
   videoPath: string,
   startSeconds: number,
   durationSeconds: number,
-  mode: "api" | "local",
-  options?: { apiKey?: string },
 ): Promise<string> {
   const tmpWav = join(tmpdir(), `vellum-seg-audio-${randomUUID()}.wav`);
 
   try {
+    // Resolve the configured STT provider — return empty if none available
+    const transcriber = await resolveBatchTranscriber();
+    if (!transcriber) {
+      return "";
+    }
+
     // Extract audio for the time range as 16kHz mono WAV
     const extractResult = await spawnWithTimeout(
       [
@@ -56,10 +65,15 @@ export async function transcribeSegmentAudio(
       return "";
     }
 
-    if (mode === "api") {
-      return await transcribeViaApi(tmpWav, options?.apiKey);
-    }
-    return await transcribeViaLocal(tmpWav);
+    // Send extracted WAV through the provider-agnostic transcriber
+    const audioBuffer = await readFile(tmpWav);
+    const result = await transcriber.transcribe({
+      audio: audioBuffer,
+      mimeType: "audio/wav",
+      signal: AbortSignal.timeout(STT_REQUEST_TIMEOUT_MS),
+    });
+
+    return result.text?.trim() ?? "";
   } catch {
     return "";
   } finally {
@@ -69,80 +83,4 @@ export async function transcribeSegmentAudio(
       /* ignore */
     }
   }
-}
-
-async function transcribeViaApi(
-  audioPath: string,
-  apiKey?: string,
-): Promise<string> {
-  if (!apiKey) return "";
-
-  const audioData = await readFile(audioPath);
-  const formData = new FormData();
-  formData.append(
-    "file",
-    new Blob([audioData], { type: "audio/wav" }),
-    "audio.wav",
-  );
-  formData.append("model", "whisper-1");
-
-  const response = await fetch(
-    "https://api.openai.com/v1/audio/transcriptions",
-    {
-      method: "POST",
-      headers: { Authorization: `Bearer ${apiKey}` },
-      body: formData,
-      signal: AbortSignal.timeout(API_REQUEST_TIMEOUT_MS),
-    },
-  );
-
-  if (!response.ok) return "";
-
-  const result = (await response.json()) as { text?: string };
-  return result.text?.trim() ?? "";
-}
-
-async function transcribeViaLocal(audioPath: string): Promise<string> {
-  // Check if whisper-cpp is available
-  const whichResult = await spawnWithTimeout(["which", "whisper-cpp"], 5_000);
-  if (whichResult.exitCode !== 0) return "";
-
-  // Resolve model path
-  const modelPath = await resolveWhisperModel();
-  if (!modelPath) return "";
-
-  const result = await spawnWithTimeout(
-    ["whisper-cpp", "-m", modelPath, "-f", audioPath, "--no-timestamps"],
-    LOCAL_CHUNK_TIMEOUT_MS,
-  );
-
-  if (result.exitCode !== 0) return "";
-
-  return result.stdout
-    .split("\n")
-    .map((l) => l.trim())
-    .filter((l) => l.length > 0)
-    .join(" ")
-    .trim();
-}
-
-async function resolveWhisperModel(): Promise<string | null> {
-  const homeDir = process.env.HOME ?? "/tmp";
-  const candidates = [
-    join(homeDir, ".vellum", "models", "ggml-base.en.bin"),
-    join(homeDir, ".vellum", "models", "ggml-base.bin"),
-    "/usr/local/share/whisper-cpp/models/ggml-base.en.bin",
-    "/opt/homebrew/share/whisper-cpp/models/ggml-base.en.bin",
-  ];
-
-  for (const p of candidates) {
-    try {
-      await access(p);
-      return p;
-    } catch {
-      /* next */
-    }
-  }
-
-  return null;
 }

--- a/assistant/src/config/bundled-skills/media-processing/services/audio-transcribe.ts
+++ b/assistant/src/config/bundled-skills/media-processing/services/audio-transcribe.ts
@@ -11,6 +11,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { resolveBatchTranscriber } from "../../../../providers/speech-to-text/resolve.js";
+import type { BatchTranscriber } from "../../../../stt/types.js";
 import { spawnWithTimeout } from "../../../../util/spawn.js";
 
 const FFMPEG_TIMEOUT_MS = 60_000;
@@ -20,7 +21,10 @@ const STT_REQUEST_TIMEOUT_MS = 120_000;
  * Transcribe the audio from a specific time range of a video file.
  * Returns the transcript text, or empty string on failure (graceful degradation).
  *
- * Uses the daemon's configured STT service via `resolveBatchTranscriber()`.
+ * Accepts an optional pre-resolved `BatchTranscriber` to avoid repeated
+ * credential lookups when transcribing multiple segments in a loop. When
+ * omitted, resolves the transcriber on demand via `resolveBatchTranscriber()`.
+ *
  * Returns empty string when no provider is configured, the provider call
  * fails, or ffmpeg extraction fails — this preserves preprocess resilience.
  */
@@ -28,13 +32,14 @@ export async function transcribeSegmentAudio(
   videoPath: string,
   startSeconds: number,
   durationSeconds: number,
+  transcriber?: BatchTranscriber | null,
 ): Promise<string> {
   const tmpWav = join(tmpdir(), `vellum-seg-audio-${randomUUID()}.wav`);
 
   try {
-    // Resolve the configured STT provider — return empty if none available
-    const transcriber = await resolveBatchTranscriber();
-    if (!transcriber) {
+    // Use the provided transcriber or resolve on demand
+    const resolved = transcriber ?? (await resolveBatchTranscriber());
+    if (!resolved) {
       return "";
     }
 
@@ -67,7 +72,7 @@ export async function transcribeSegmentAudio(
 
     // Send extracted WAV through the provider-agnostic transcriber
     const audioBuffer = await readFile(tmpWav);
-    const result = await transcriber.transcribe({
+    const result = await resolved.transcribe({
       audio: audioBuffer,
       mimeType: "audio/wav",
       signal: AbortSignal.timeout(STT_REQUEST_TIMEOUT_MS),

--- a/assistant/src/config/bundled-skills/media-processing/services/audio-transcribe.ts
+++ b/assistant/src/config/bundled-skills/media-processing/services/audio-transcribe.ts
@@ -37,8 +37,10 @@ export async function transcribeSegmentAudio(
   const tmpWav = join(tmpdir(), `vellum-seg-audio-${randomUUID()}.wav`);
 
   try {
-    // Use the provided transcriber or resolve on demand
-    const resolved = transcriber ?? (await resolveBatchTranscriber());
+    // Use the provided transcriber or resolve on demand.
+    // null = "already resolved, no provider"; only re-resolve when undefined (not passed).
+    const resolved =
+      transcriber === undefined ? await resolveBatchTranscriber() : transcriber;
     if (!resolved) {
       return "";
     }

--- a/assistant/src/config/bundled-skills/media-processing/services/preprocess.ts
+++ b/assistant/src/config/bundled-skills/media-processing/services/preprocess.ts
@@ -18,6 +18,7 @@ import {
   type ProcessingStage,
   updateProcessingStage,
 } from "../../../../memory/media-store.js";
+import { resolveBatchTranscriber } from "../../../../providers/speech-to-text/resolve.js";
 import { silentlyWithLog } from "../../../../util/silently.js";
 import {
   FFMPEG_PALETTE_TIMEOUT_MS,
@@ -451,6 +452,12 @@ export async function preprocessForAsset(
     const segments: Segment[] = [];
     const allFramePaths: string[] = [];
 
+    // Resolve the STT transcriber once for all segments to avoid repeated
+    // credential lookups in the per-segment loop.
+    const transcriber = options.includeAudio
+      ? await resolveBatchTranscriber()
+      : null;
+
     const scaleFilter = `scale='if(gt(iw,ih),-1,${config.shortEdge})':'if(gt(iw,ih),${config.shortEdge},-1)'`;
 
     for (let i = 0; i < rawSegments.length; i++) {
@@ -527,6 +534,7 @@ export async function preprocessForAsset(
           asset.filePath,
           seg.startSeconds,
           seg.endSeconds - seg.startSeconds,
+          transcriber,
         );
         if (transcript) {
           segment.transcript = transcript;

--- a/assistant/src/config/bundled-skills/media-processing/services/preprocess.ts
+++ b/assistant/src/config/bundled-skills/media-processing/services/preprocess.ts
@@ -92,8 +92,6 @@ export interface PreprocessOptions {
   detectDeadTime?: boolean;
   shortEdge?: number;
   includeAudio?: boolean;
-  transcriptionMode?: "api" | "local";
-  openaiApiKey?: string;
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/config/bundled-skills/media-processing/services/preprocess.ts
+++ b/assistant/src/config/bundled-skills/media-processing/services/preprocess.ts
@@ -529,8 +529,6 @@ export async function preprocessForAsset(
           asset.filePath,
           seg.startSeconds,
           seg.endSeconds - seg.startSeconds,
-          options.transcriptionMode ?? "local",
-          { apiKey: options.openaiApiKey },
         );
         if (transcript) {
           segment.transcript = transcript;

--- a/assistant/src/config/bundled-skills/media-processing/tools/extract-keyframes.ts
+++ b/assistant/src/config/bundled-skills/media-processing/tools/extract-keyframes.ts
@@ -4,7 +4,6 @@ import {
   getKeyframesForAsset,
   getMediaAssetById,
 } from "../../../../memory/media-store.js";
-import { getProviderKeyAsync } from "../../../../security/secure-keys.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -26,13 +25,6 @@ export async function run(
   }
 
   const includeAudio = Boolean(input.include_audio);
-  const transcriptionMode =
-    (input.transcription_mode as "api" | "local") || undefined;
-
-  let openaiApiKey: string | undefined;
-  if (includeAudio && (!transcriptionMode || transcriptionMode === "api")) {
-    openaiApiKey = await getProviderKeyAsync("openai");
-  }
 
   const options: PreprocessOptions = {
     intervalSeconds: (input.interval_seconds as number) || undefined,
@@ -45,8 +37,6 @@ export async function run(
         : undefined,
     shortEdge: (input.short_edge as number) || undefined,
     includeAudio,
-    transcriptionMode,
-    openaiApiKey,
   };
 
   try {

--- a/assistant/src/util/spawn.ts
+++ b/assistant/src/util/spawn.ts
@@ -22,7 +22,7 @@ export function spawnWithTimeout(
   timeoutMs: number,
 ): Promise<{ exitCode: number; stdout: string; stderr: string }> {
   return new Promise((resolve, reject) => {
-    // Augment PATH so Homebrew-installed tools (ffmpeg, ffprobe, whisper-cpp)
+    // Augment PATH so Homebrew-installed tools (ffmpeg, ffprobe)
     // are found even when the daemon runs as a bundled binary with minimal PATH.
     const proc = Bun.spawn(cmd, {
       stdout: "pipe",


### PR DESCRIPTION
## Summary
Route media-processing segment transcription through the canonical `resolveBatchTranscriber()` STT service abstraction, removing local whisper.cpp support and direct OpenAI key plumbing. Eliminates `api|local` mode branching from media-processing entirely.

## Self-review result
GAPS FOUND — 1 gap fixed across 1 fix PR (stale whisper-cpp comment in spawn.ts)

## PRs merged into feature branch
- #24981: Route media-processing segment transcription through configured STT service
- #24980: Remove media-processing transcription_mode input and document configured STT service
- #24983: Drop preprocess transcription_mode/openaiApiKey plumbing for media-processing
- #24984: Remove obsolete secure-keys allowlist exception for media-processing extract_keyframes

### Fix PRs
- #24992: fix: remove stale whisper-cpp reference from spawn.ts PATH comment

Part of plan: media-processing-stt-service-refactor.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24998" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
