### PR TITLE
feat(browser): support pinned backend mode and structured fallback diagnostics

### DIFF
--- a/assistant/src/tools/browser/cdp-client/__tests__/factory.test.ts
+++ b/assistant/src/tools/browser/cdp-client/__tests__/factory.test.ts
@@ -72,6 +72,12 @@ const createCdpInspectClientMock = mock(
 let cdpInspectEnabled = false;
 let desktopAutoConfig = { enabled: true, cooldownMs: 30_000 };
 
+/**
+ * Captured log calls for verifying fallback log payloads.
+ */
+const logWarnCalls: Array<{ args: unknown[] }> = [];
+const logDebugCalls: Array<{ args: unknown[] }> = [];
+
 mock.module("../extension-cdp-client.js", () => ({
   createExtensionCdpClient: createExtensionCdpClientMock,
 }));
@@ -94,6 +100,18 @@ mock.module("../../../../config/loader.js", () => ({
     },
   }),
 }));
+mock.module("../../../../util/logger.js", () => ({
+  getLogger: () => ({
+    debug: (...args: unknown[]) => {
+      logDebugCalls.push({ args });
+    },
+    warn: (...args: unknown[]) => {
+      logWarnCalls.push({ args });
+    },
+    info: () => {},
+    error: () => {},
+  }),
+}));
 
 // Import under test AFTER mock.module calls so that the factory's
 // top-level imports resolve to our fakes.
@@ -101,6 +119,7 @@ const {
   getCdpClient,
   buildCandidateList,
   buildChainedClient,
+  buildPinnedCandidateList,
   _resetDesktopAutoCooldown,
   _getDesktopAutoCooldownSince,
   recordDesktopAutoCooldown,
@@ -150,6 +169,8 @@ describe("getCdpClient", () => {
     cdpInspectEnabled = false;
     desktopAutoConfig = { enabled: true, cooldownMs: 30_000 };
     _resetDesktopAutoCooldown();
+    logWarnCalls.length = 0;
+    logDebugCalls.length = 0;
   });
 
   // ── Candidate selection (kind reported before first send) ────────────
@@ -306,6 +327,34 @@ describe("getCdpClient", () => {
     expect(createLocalCdpClientMock).toHaveBeenCalledWith("another-convo");
     expect(createExtensionCdpClientMock).not.toHaveBeenCalled();
     expect(createCdpInspectClientMock).not.toHaveBeenCalled();
+  });
+
+  // ── Backwards compatibility: omitted mode behaves as auto ───────────
+
+  test("getCdpClient without options behaves identically to auto mode", async () => {
+    const fakeProxy = makeAvailableProxy();
+    const ctx = makeContext({
+      conversationId: "no-opts",
+      hostBrowserProxy: fakeProxy,
+    });
+
+    const client = getCdpClient(ctx);
+    expect(client.kind).toBe("extension");
+    const result = await client.send<{ ok: boolean; via: string }>(
+      "Page.navigate",
+    );
+    expect(result).toEqual({ ok: true, via: "extension" });
+  });
+
+  test("getCdpClient with explicit auto mode behaves identically to omitted mode", async () => {
+    const ctx = makeContext({ conversationId: "explicit-auto" });
+
+    const client = getCdpClient(ctx, { mode: "auto" });
+    expect(client.kind).toBe("local");
+    const result = await client.send<{ ok: boolean; via: string }>(
+      "Runtime.evaluate",
+    );
+    expect(result).toEqual({ ok: true, via: "local" });
   });
 
   // ── send() forwarding ────────────────────────────────────────────────
@@ -659,6 +708,8 @@ describe("buildChainedClient failover", () => {
     cdpInspectEnabled = false;
     desktopAutoConfig = { enabled: true, cooldownMs: 30_000 };
     _resetDesktopAutoCooldown();
+    logWarnCalls.length = 0;
+    logDebugCalls.length = 0;
   });
 
   test("fails over from extension to local on transport_error", async () => {
@@ -970,6 +1021,8 @@ describe("desktop-auto cdp-inspect (macOS)", () => {
     cdpInspectEnabled = false;
     desktopAutoConfig = { enabled: true, cooldownMs: 30_000 };
     _resetDesktopAutoCooldown();
+    logWarnCalls.length = 0;
+    logDebugCalls.length = 0;
   });
 
   // ── buildCandidateList with desktopAuto ─────────────────────────────
@@ -1263,5 +1316,678 @@ describe("desktop-auto cdp-inspect (macOS)", () => {
     _resetDesktopAutoCooldown();
     expect(isDesktopAutoCooldownActive(30_000)).toBe(false);
     expect(_getDesktopAutoCooldownSince()).toBe(0);
+  });
+});
+
+// ── Pinned-mode tests ────────────────────────────────────────────────────
+
+describe("pinned-mode selection", () => {
+  beforeEach(() => {
+    createExtensionCdpClientMock.mockClear();
+    createLocalCdpClientMock.mockClear();
+    createCdpInspectClientMock.mockClear();
+    lastExtensionClient = undefined;
+    lastLocalClient = undefined;
+    lastCdpInspectClient = undefined;
+    cdpInspectEnabled = false;
+    desktopAutoConfig = { enabled: true, cooldownMs: 30_000 };
+    _resetDesktopAutoCooldown();
+    logWarnCalls.length = 0;
+    logDebugCalls.length = 0;
+  });
+
+  // ── Pinned extension ────────────────────────────────────────────────
+
+  test("pinned extension mode routes to extension when proxy is available", async () => {
+    const fakeProxy = makeAvailableProxy();
+    const ctx = makeContext({
+      conversationId: "pinned-ext",
+      hostBrowserProxy: fakeProxy,
+    });
+
+    const client = getCdpClient(ctx, { mode: "extension" });
+    expect(client.kind).toBe("extension");
+
+    const result = await client.send<{ ok: boolean; via: string }>(
+      "Page.navigate",
+    );
+    expect(result).toEqual({ ok: true, via: "extension" });
+    expect(createExtensionCdpClientMock).toHaveBeenCalledTimes(1);
+    expect(createLocalCdpClientMock).not.toHaveBeenCalled();
+    expect(createCdpInspectClientMock).not.toHaveBeenCalled();
+  });
+
+  test("pinned extension mode throws when no proxy is provisioned", () => {
+    const ctx = makeContext({ conversationId: "pinned-ext-no-proxy" });
+
+    expect(() => getCdpClient(ctx, { mode: "extension" })).toThrow(CdpError);
+
+    try {
+      getCdpClient(ctx, { mode: "extension" });
+    } catch (err) {
+      expect(err).toBeInstanceOf(CdpError);
+      const cdpErr = err as CdpError;
+      expect(cdpErr.code).toBe("transport_error");
+      expect(cdpErr.message).toContain('Pinned mode "extension" unavailable');
+      expect(cdpErr.message).toContain("no host browser proxy provisioned");
+      expect(cdpErr.attemptDiagnostics).toBeDefined();
+      expect(cdpErr.attemptDiagnostics).toHaveLength(1);
+      expect(cdpErr.attemptDiagnostics![0].candidateKind).toBe("extension");
+      expect(cdpErr.attemptDiagnostics![0].stage).toBe("candidate_selection");
+    }
+  });
+
+  test("pinned extension mode throws when proxy is present but unavailable", () => {
+    const fakeProxy = makeUnavailableProxy();
+    const ctx = makeContext({
+      conversationId: "pinned-ext-unavail",
+      hostBrowserProxy: fakeProxy,
+    });
+
+    expect(() => getCdpClient(ctx, { mode: "extension" })).toThrow(CdpError);
+
+    try {
+      getCdpClient(ctx, { mode: "extension" });
+    } catch (err) {
+      const cdpErr = err as CdpError;
+      expect(cdpErr.code).toBe("transport_error");
+      expect(cdpErr.message).toContain("not connected");
+      expect(cdpErr.attemptDiagnostics![0].stage).toBe("candidate_selection");
+    }
+  });
+
+  test("pinned extension mode does NOT fall back to local on transport error", async () => {
+    const fakeProxy = makeAvailableProxy();
+
+    // Make extension fail with transport_error
+    createExtensionCdpClientMock.mockImplementationOnce(
+      (_proxy: HostBrowserProxy, conversationId: string) => {
+        const c = makeFakeExtensionClient(conversationId);
+        c.send = mock(async () => {
+          throw new CdpError("transport_error", "WS disconnected");
+        });
+        lastExtensionClient = c;
+        return c;
+      },
+    );
+
+    const ctx = makeContext({
+      conversationId: "pinned-ext-no-fallback",
+      hostBrowserProxy: fakeProxy,
+    });
+
+    const client = getCdpClient(ctx, { mode: "extension" });
+
+    await expect(client.send("Page.navigate")).rejects.toMatchObject({
+      code: "transport_error",
+      message: "WS disconnected",
+    });
+
+    // Local and cdp-inspect should NOT have been tried
+    expect(createLocalCdpClientMock).not.toHaveBeenCalled();
+    expect(createCdpInspectClientMock).not.toHaveBeenCalled();
+  });
+
+  // ── Pinned cdp-inspect ──────────────────────────────────────────────
+
+  test("pinned cdp-inspect mode routes to cdp-inspect", async () => {
+    const ctx = makeContext({ conversationId: "pinned-inspect" });
+
+    const client = getCdpClient(ctx, { mode: "cdp-inspect" });
+    expect(client.kind).toBe("cdp-inspect");
+
+    const result = await client.send<{ ok: boolean; via: string }>(
+      "Page.navigate",
+    );
+    expect(result).toEqual({ ok: true, via: "cdp-inspect" });
+    expect(createCdpInspectClientMock).toHaveBeenCalledTimes(1);
+    expect(createExtensionCdpClientMock).not.toHaveBeenCalled();
+    expect(createLocalCdpClientMock).not.toHaveBeenCalled();
+  });
+
+  test("pinned cdp-inspect mode does NOT fall back to local on transport error", async () => {
+    createCdpInspectClientMock.mockImplementationOnce(
+      (conversationId: string) => {
+        const c = makeFakeCdpInspectClient(conversationId);
+        c.send = mock(async () => {
+          throw new CdpError("transport_error", "Connection refused");
+        });
+        lastCdpInspectClient = c;
+        return c;
+      },
+    );
+
+    const ctx = makeContext({ conversationId: "pinned-inspect-no-fb" });
+    const client = getCdpClient(ctx, { mode: "cdp-inspect" });
+
+    await expect(client.send("Page.navigate")).rejects.toMatchObject({
+      code: "transport_error",
+      message: "Connection refused",
+    });
+
+    expect(createLocalCdpClientMock).not.toHaveBeenCalled();
+    expect(createExtensionCdpClientMock).not.toHaveBeenCalled();
+  });
+
+  test("pinned cdp-inspect uses config host/port", async () => {
+    const ctx = makeContext({ conversationId: "pinned-inspect-cfg" });
+
+    const client = getCdpClient(ctx, { mode: "cdp-inspect" });
+    await client.send("Page.navigate");
+
+    expect(createCdpInspectClientMock).toHaveBeenCalledWith(
+      "pinned-inspect-cfg",
+      {
+        host: "localhost",
+        port: 9222,
+        discoveryTimeoutMs: 500,
+      },
+    );
+  });
+
+  // ── Pinned local ────────────────────────────────────────────────────
+
+  test("pinned local mode routes to local", async () => {
+    const fakeProxy = makeAvailableProxy();
+    const ctx = makeContext({
+      conversationId: "pinned-local",
+      hostBrowserProxy: fakeProxy,
+    });
+
+    // Even with proxy available, pinned local should skip extension
+    const client = getCdpClient(ctx, { mode: "local" });
+    expect(client.kind).toBe("local");
+
+    const result = await client.send<{ ok: boolean; via: string }>(
+      "Runtime.evaluate",
+    );
+    expect(result).toEqual({ ok: true, via: "local" });
+    expect(createLocalCdpClientMock).toHaveBeenCalledTimes(1);
+    expect(createExtensionCdpClientMock).not.toHaveBeenCalled();
+    expect(createCdpInspectClientMock).not.toHaveBeenCalled();
+  });
+
+  test("pinned local mode does NOT fall back on transport error", async () => {
+    createLocalCdpClientMock.mockImplementationOnce(
+      (conversationId: string) => {
+        const c = makeFakeLocalClient(conversationId);
+        c.send = mock(async () => {
+          throw new CdpError("transport_error", "Playwright crashed");
+        });
+        lastLocalClient = c;
+        return c;
+      },
+    );
+
+    const ctx = makeContext({ conversationId: "pinned-local-no-fb" });
+    const client = getCdpClient(ctx, { mode: "local" });
+
+    await expect(client.send("Page.navigate")).rejects.toMatchObject({
+      code: "transport_error",
+      message: "Playwright crashed",
+    });
+
+    expect(createExtensionCdpClientMock).not.toHaveBeenCalled();
+    expect(createCdpInspectClientMock).not.toHaveBeenCalled();
+  });
+});
+
+// ── buildPinnedCandidateList tests ───────────────────────────────────────
+
+describe("buildPinnedCandidateList", () => {
+  beforeEach(() => {
+    createExtensionCdpClientMock.mockClear();
+    createLocalCdpClientMock.mockClear();
+    createCdpInspectClientMock.mockClear();
+    lastExtensionClient = undefined;
+    lastLocalClient = undefined;
+    lastCdpInspectClient = undefined;
+    cdpInspectEnabled = false;
+    desktopAutoConfig = { enabled: true, cooldownMs: 30_000 };
+    _resetDesktopAutoCooldown();
+  });
+
+  test("extension mode produces single extension candidate", () => {
+    const fakeProxy = makeAvailableProxy();
+    const ctx = makeContext({
+      conversationId: "bpl-ext",
+      hostBrowserProxy: fakeProxy,
+    });
+
+    const candidates = buildPinnedCandidateList(ctx, "extension");
+
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].kind).toBe("extension");
+    expect(candidates[0].reason).toBe("pinned mode: extension");
+  });
+
+  test("cdp-inspect mode produces single cdp-inspect candidate", () => {
+    const ctx = makeContext({ conversationId: "bpl-inspect" });
+
+    const candidates = buildPinnedCandidateList(ctx, "cdp-inspect");
+
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].kind).toBe("cdp-inspect");
+    expect(candidates[0].reason).toBe("pinned mode: cdp-inspect");
+  });
+
+  test("local mode produces single local candidate", () => {
+    const ctx = makeContext({ conversationId: "bpl-local" });
+
+    const candidates = buildPinnedCandidateList(ctx, "local");
+
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].kind).toBe("local");
+    expect(candidates[0].reason).toBe("pinned mode: local");
+  });
+
+  test("extension mode throws with diagnostics when proxy absent", () => {
+    const ctx = makeContext({ conversationId: "bpl-ext-absent" });
+
+    try {
+      buildPinnedCandidateList(ctx, "extension");
+      expect(true).toBe(false); // should not reach
+    } catch (err) {
+      expect(err).toBeInstanceOf(CdpError);
+      const cdpErr = err as CdpError;
+      expect(cdpErr.code).toBe("transport_error");
+      expect(cdpErr.attemptDiagnostics).toHaveLength(1);
+      expect(cdpErr.attemptDiagnostics![0]).toMatchObject({
+        candidateKind: "extension",
+        inclusionReason: "pinned mode: extension",
+        stage: "candidate_selection",
+        errorCode: "transport_error",
+      });
+    }
+  });
+});
+
+// ── Attempt diagnostics & fallback log tests ─────────────────────────────
+
+describe("attempt diagnostics", () => {
+  beforeEach(() => {
+    createExtensionCdpClientMock.mockClear();
+    createLocalCdpClientMock.mockClear();
+    createCdpInspectClientMock.mockClear();
+    lastExtensionClient = undefined;
+    lastLocalClient = undefined;
+    lastCdpInspectClient = undefined;
+    cdpInspectEnabled = false;
+    desktopAutoConfig = { enabled: true, cooldownMs: 30_000 };
+    _resetDesktopAutoCooldown();
+    logWarnCalls.length = 0;
+    logDebugCalls.length = 0;
+  });
+
+  test("exhausted candidates error includes full attempt diagnostics", async () => {
+    cdpInspectEnabled = true;
+    const fakeProxy = makeAvailableProxy();
+
+    // Make extension fail
+    createExtensionCdpClientMock.mockImplementationOnce(
+      (_proxy: HostBrowserProxy, conversationId: string) => {
+        const c = makeFakeExtensionClient(conversationId);
+        c.send = mock(async () => {
+          throw new CdpError("transport_error", "ext disconnected");
+        });
+        lastExtensionClient = c;
+        return c;
+      },
+    );
+
+    // Make cdp-inspect fail
+    createCdpInspectClientMock.mockImplementationOnce(
+      (conversationId: string) => {
+        const c = makeFakeCdpInspectClient(conversationId);
+        c.send = mock(async () => {
+          throw new CdpError("transport_error", "inspect refused");
+        });
+        lastCdpInspectClient = c;
+        return c;
+      },
+    );
+
+    // Make local fail too
+    createLocalCdpClientMock.mockImplementationOnce(
+      (conversationId: string) => {
+        const c = makeFakeLocalClient(conversationId);
+        c.send = mock(async () => {
+          throw new CdpError("transport_error", "playwright dead");
+        });
+        lastLocalClient = c;
+        return c;
+      },
+    );
+
+    const ctx = makeContext({
+      conversationId: "diag-all-fail",
+      hostBrowserProxy: fakeProxy,
+    });
+
+    const client = getCdpClient(ctx);
+
+    try {
+      await client.send("Page.navigate");
+      expect(true).toBe(false); // should not reach
+    } catch (err) {
+      expect(err).toBeInstanceOf(CdpError);
+      const cdpErr = err as CdpError;
+      expect(cdpErr.code).toBe("transport_error");
+      expect(cdpErr.attemptDiagnostics).toBeDefined();
+      expect(cdpErr.attemptDiagnostics).toHaveLength(3);
+
+      // First attempt: extension
+      expect(cdpErr.attemptDiagnostics![0]).toMatchObject({
+        candidateKind: "extension",
+        stage: "send",
+        errorCode: "transport_error",
+        errorMessage: expect.stringContaining("ext disconnected"),
+      });
+
+      // Second attempt: cdp-inspect
+      expect(cdpErr.attemptDiagnostics![1]).toMatchObject({
+        candidateKind: "cdp-inspect",
+        stage: "send",
+        errorCode: "transport_error",
+        errorMessage: expect.stringContaining("inspect refused"),
+      });
+
+      // Third attempt: local
+      expect(cdpErr.attemptDiagnostics![2]).toMatchObject({
+        candidateKind: "local",
+        stage: "send",
+        errorCode: "transport_error",
+        errorMessage: expect.stringContaining("playwright dead"),
+      });
+    }
+  });
+
+  test("successful fallback still records diagnostics for failed candidates", async () => {
+    const fakeProxy = makeAvailableProxy();
+
+    // Make extension fail
+    createExtensionCdpClientMock.mockImplementationOnce(
+      (_proxy: HostBrowserProxy, conversationId: string) => {
+        const c = makeFakeExtensionClient(conversationId);
+        c.send = mock(async () => {
+          throw new CdpError("transport_error", "ext down");
+        });
+        lastExtensionClient = c;
+        return c;
+      },
+    );
+
+    const ctx = makeContext({
+      conversationId: "diag-partial",
+      hostBrowserProxy: fakeProxy,
+    });
+
+    const client = getCdpClient(ctx);
+    const result = await client.send<{ ok: boolean; via: string }>(
+      "Page.navigate",
+    );
+    expect(result).toEqual({ ok: true, via: "local" });
+
+    // The fallback log should have been emitted with attempt data
+    const fallbackLogs = logWarnCalls.filter(
+      (c) =>
+        typeof c.args[1] === "string" &&
+        c.args[1].includes("auto-mode fallback"),
+    );
+    expect(fallbackLogs.length).toBeGreaterThan(0);
+  });
+
+  test("auto-mode fallback log includes candidate sequence and failure reasons", async () => {
+    cdpInspectEnabled = true;
+    const fakeProxy = makeAvailableProxy();
+
+    // Make extension fail
+    createExtensionCdpClientMock.mockImplementationOnce(
+      (_proxy: HostBrowserProxy, conversationId: string) => {
+        const c = makeFakeExtensionClient(conversationId);
+        c.send = mock(async () => {
+          throw new CdpError("transport_error", "WS closed");
+        });
+        lastExtensionClient = c;
+        return c;
+      },
+    );
+
+    // Make cdp-inspect fail
+    createCdpInspectClientMock.mockImplementationOnce(
+      (conversationId: string) => {
+        const c = makeFakeCdpInspectClient(conversationId);
+        c.send = mock(async () => {
+          throw new CdpError("transport_error", "no debugger");
+        });
+        lastCdpInspectClient = c;
+        return c;
+      },
+    );
+
+    const ctx = makeContext({
+      conversationId: "diag-log-shape",
+      hostBrowserProxy: fakeProxy,
+    });
+
+    const client = getCdpClient(ctx);
+    await client.send<{ ok: boolean; via: string }>("Page.navigate");
+
+    // Check that a warn-level log was emitted for the completed fallback
+    const completedLogs = logWarnCalls.filter(
+      (c) =>
+        typeof c.args[1] === "string" &&
+        c.args[1].includes("fallback completed"),
+    );
+    expect(completedLogs.length).toBe(1);
+
+    // Verify the log payload contains the expected structure
+    const payload = completedLogs[0].args[0] as Record<string, unknown>;
+    expect(payload.conversationId).toBe("diag-log-shape");
+    expect(payload.stickyCandidate).toBe("local");
+    expect(Array.isArray(payload.attemptSequence)).toBe(true);
+    const seq = payload.attemptSequence as Array<Record<string, unknown>>;
+    expect(seq.length).toBe(3); // extension, cdp-inspect, local
+    expect(seq[0].kind).toBe("extension");
+    expect(seq[0].errorCode).toBe("transport_error");
+    expect(seq[1].kind).toBe("cdp-inspect");
+    expect(seq[1].errorCode).toBe("transport_error");
+    expect(seq[2].kind).toBe("local");
+    expect(seq[2].stage).toBe("success");
+  });
+
+  test("pinned mode transport error includes attempt diagnostics on the thrown error", async () => {
+    createCdpInspectClientMock.mockImplementationOnce(
+      (conversationId: string) => {
+        const c = makeFakeCdpInspectClient(conversationId);
+        c.send = mock(async () => {
+          throw new CdpError("transport_error", "Connection refused");
+        });
+        lastCdpInspectClient = c;
+        return c;
+      },
+    );
+
+    const ctx = makeContext({ conversationId: "pinned-diag" });
+    const client = getCdpClient(ctx, { mode: "cdp-inspect" });
+
+    try {
+      await client.send("Page.navigate");
+      expect(true).toBe(false); // should not reach
+    } catch (err) {
+      expect(err).toBeInstanceOf(CdpError);
+      const cdpErr = err as CdpError;
+      expect(cdpErr.attemptDiagnostics).toBeDefined();
+      expect(cdpErr.attemptDiagnostics).toHaveLength(1);
+      expect(cdpErr.attemptDiagnostics![0]).toMatchObject({
+        candidateKind: "cdp-inspect",
+        inclusionReason: "pinned mode: cdp-inspect",
+        stage: "send",
+        errorCode: "transport_error",
+      });
+    }
+  });
+
+  test("construction failure is recorded in attempt diagnostics", async () => {
+    // Make the cdp-inspect client's create() throw
+    createCdpInspectClientMock.mockImplementationOnce(() => {
+      throw new Error("Config missing");
+    });
+
+    cdpInspectEnabled = true;
+    const ctx = makeContext({ conversationId: "diag-construction" });
+    const client = getCdpClient(ctx);
+
+    // cdp-inspect construction fails, falls back to local
+    const result = await client.send<{ ok: boolean; via: string }>(
+      "Page.navigate",
+    );
+    expect(result).toEqual({ ok: true, via: "local" });
+  });
+
+  test("cdp_error on single-candidate list includes diagnostics", async () => {
+    createLocalCdpClientMock.mockImplementationOnce(
+      (conversationId: string) => {
+        const c = makeFakeLocalClient(conversationId);
+        c.send = mock(async () => {
+          throw new CdpError("cdp_error", "Protocol error -32000");
+        });
+        lastLocalClient = c;
+        return c;
+      },
+    );
+
+    const ctx = makeContext({ conversationId: "diag-cdp-err" });
+    const client = getCdpClient(ctx);
+
+    try {
+      await client.send("Page.navigate");
+      expect(true).toBe(false);
+    } catch (err) {
+      const cdpErr = err as CdpError;
+      expect(cdpErr.code).toBe("cdp_error");
+      expect(cdpErr.attemptDiagnostics).toBeDefined();
+      expect(cdpErr.attemptDiagnostics).toHaveLength(1);
+      expect(cdpErr.attemptDiagnostics![0]).toMatchObject({
+        candidateKind: "local",
+        stage: "send",
+        errorCode: "cdp_error",
+      });
+    }
+  });
+});
+
+// ── No-fallback guarantees for pinned modes ──────────────────────────────
+
+describe("no-fallback guarantees", () => {
+  beforeEach(() => {
+    createExtensionCdpClientMock.mockClear();
+    createLocalCdpClientMock.mockClear();
+    createCdpInspectClientMock.mockClear();
+    lastExtensionClient = undefined;
+    lastLocalClient = undefined;
+    lastCdpInspectClient = undefined;
+    cdpInspectEnabled = false;
+    desktopAutoConfig = { enabled: true, cooldownMs: 30_000 };
+    _resetDesktopAutoCooldown();
+    logWarnCalls.length = 0;
+  });
+
+  test("pinned extension: only one candidate is ever constructed", async () => {
+    const fakeProxy = makeAvailableProxy();
+
+    // Make extension fail
+    createExtensionCdpClientMock.mockImplementationOnce(
+      (_proxy: HostBrowserProxy, conversationId: string) => {
+        const c = makeFakeExtensionClient(conversationId);
+        c.send = mock(async () => {
+          throw new CdpError("transport_error", "failed");
+        });
+        lastExtensionClient = c;
+        return c;
+      },
+    );
+
+    const ctx = makeContext({
+      conversationId: "nofb-ext",
+      hostBrowserProxy: fakeProxy,
+    });
+    const client = getCdpClient(ctx, { mode: "extension" });
+
+    await expect(client.send("Page.navigate")).rejects.toThrow();
+
+    expect(createExtensionCdpClientMock).toHaveBeenCalledTimes(1);
+    expect(createCdpInspectClientMock).not.toHaveBeenCalled();
+    expect(createLocalCdpClientMock).not.toHaveBeenCalled();
+  });
+
+  test("pinned cdp-inspect: only one candidate is ever constructed", async () => {
+    createCdpInspectClientMock.mockImplementationOnce(
+      (conversationId: string) => {
+        const c = makeFakeCdpInspectClient(conversationId);
+        c.send = mock(async () => {
+          throw new CdpError("transport_error", "failed");
+        });
+        lastCdpInspectClient = c;
+        return c;
+      },
+    );
+
+    const ctx = makeContext({ conversationId: "nofb-inspect" });
+    const client = getCdpClient(ctx, { mode: "cdp-inspect" });
+
+    await expect(client.send("Page.navigate")).rejects.toThrow();
+
+    expect(createCdpInspectClientMock).toHaveBeenCalledTimes(1);
+    expect(createExtensionCdpClientMock).not.toHaveBeenCalled();
+    expect(createLocalCdpClientMock).not.toHaveBeenCalled();
+  });
+
+  test("pinned local: only one candidate is ever constructed", async () => {
+    createLocalCdpClientMock.mockImplementationOnce(
+      (conversationId: string) => {
+        const c = makeFakeLocalClient(conversationId);
+        c.send = mock(async () => {
+          throw new CdpError("transport_error", "failed");
+        });
+        lastLocalClient = c;
+        return c;
+      },
+    );
+
+    const ctx = makeContext({ conversationId: "nofb-local" });
+    const client = getCdpClient(ctx, { mode: "local" });
+
+    await expect(client.send("Page.navigate")).rejects.toThrow();
+
+    expect(createLocalCdpClientMock).toHaveBeenCalledTimes(1);
+    expect(createExtensionCdpClientMock).not.toHaveBeenCalled();
+    expect(createCdpInspectClientMock).not.toHaveBeenCalled();
+  });
+
+  test("pinned modes do not emit auto-mode fallback logs", async () => {
+    createLocalCdpClientMock.mockImplementationOnce(
+      (conversationId: string) => {
+        const c = makeFakeLocalClient(conversationId);
+        c.send = mock(async () => {
+          throw new CdpError("transport_error", "failed");
+        });
+        lastLocalClient = c;
+        return c;
+      },
+    );
+
+    const ctx = makeContext({ conversationId: "nofb-no-log" });
+    const client = getCdpClient(ctx, { mode: "local" });
+
+    await expect(client.send("Page.navigate")).rejects.toThrow();
+
+    // No warn-level fallback logs should have been emitted
+    const fallbackLogs = logWarnCalls.filter(
+      (c) =>
+        typeof c.args[1] === "string" &&
+        c.args[1].includes("auto-mode fallback"),
+    );
+    expect(fallbackLogs.length).toBe(0);
   });
 });

--- a/assistant/src/tools/browser/cdp-client/errors.ts
+++ b/assistant/src/tools/browser/cdp-client/errors.ts
@@ -1,3 +1,5 @@
+import type { AttemptDiagnostic } from "./types.js";
+
 export type CdpErrorCode =
   | "cdp_error" // JSON-RPC error returned by CDP
   | "transport_error" // underlying transport failed (socket closed, timeout)
@@ -15,6 +17,17 @@ export class CdpError extends Error {
   readonly cdpParams?: Record<string, unknown>;
   readonly underlying?: unknown;
 
+  /**
+   * Structured attempt diagnostics from the factory's failover walk.
+   * Present when the error is thrown by the factory after walking one
+   * or more candidates. Each entry describes a single candidate
+   * attempt with the kind, stage, and failure reason.
+   *
+   * Higher layers (e.g. tool-response formatting) can use this to
+   * render detailed failure information with remediation hints.
+   */
+  readonly attemptDiagnostics?: readonly AttemptDiagnostic[];
+
   constructor(
     code: CdpErrorCode,
     message: string,
@@ -22,6 +35,7 @@ export class CdpError extends Error {
       cdpMethod?: string;
       cdpParams?: Record<string, unknown>;
       underlying?: unknown;
+      attemptDiagnostics?: readonly AttemptDiagnostic[];
     },
   ) {
     super(message);
@@ -30,5 +44,6 @@ export class CdpError extends Error {
     this.cdpMethod = details?.cdpMethod;
     this.cdpParams = details?.cdpParams;
     this.underlying = details?.underlying;
+    this.attemptDiagnostics = details?.attemptDiagnostics;
   }
 }

--- a/assistant/src/tools/browser/cdp-client/factory.ts
+++ b/assistant/src/tools/browser/cdp-client/factory.ts
@@ -15,7 +15,9 @@ import { CdpError } from "./errors.js";
 import { createExtensionCdpClient } from "./extension-cdp-client.js";
 import { createLocalCdpClient } from "./local-cdp-client.js";
 import type {
+  AttemptDiagnostic,
   BackendCandidate,
+  BrowserMode,
   CdpClient,
   CdpClientKind,
   ScopedCdpClient,
@@ -83,6 +85,20 @@ export function _getDesktopAutoCooldownSince(): number {
 // ---------------------------------------------------------------------------
 
 /**
+ * Options for {@link getCdpClient}. All fields are optional — omitting
+ * them preserves the existing auto-mode behavior.
+ */
+export interface GetCdpClientOptions {
+  /**
+   * Backend mode preference. When omitted or `"auto"`, the factory
+   * uses the existing priority-ordered fallback chain. When set to a
+   * specific backend kind, the factory pins to that single backend
+   * and disables failover.
+   */
+  mode?: BrowserMode;
+}
+
+/**
  * Select the appropriate CdpClient implementation for a tool
  * invocation based on the ToolContext and config. Three backends are
  * considered in priority order:
@@ -100,6 +116,13 @@ export function _getDesktopAutoCooldownSince(): number {
  *     top-level `enabled` flag is false.
  *  3. **Local** -- Default. Drives Playwright's CDPSession against
  *     the sacrificial-profile browser managed by browserManager.
+ *
+ * When `options.mode` is set to a specific backend kind, the factory
+ * builds exactly one candidate and disables failover. If the pinned
+ * backend is unavailable (e.g. pinned `extension` without an
+ * available host browser proxy), the factory throws a typed
+ * `CdpError` with `transport_error` code and a diagnostic indicating
+ * the precondition that was not met.
  *
  * The factory builds an ordered candidate list and returns a
  * {@link ScopedCdpClient} with per-invocation failover semantics:
@@ -123,22 +146,139 @@ export function _getDesktopAutoCooldownSince(): number {
  * client does NOT dispose the underlying HostBrowserProxy -- that is
  * owned by the conversation.
  */
-export function getCdpClient(context: ToolContext): ScopedCdpClient {
-  const candidates = buildCandidateList(context);
+export function getCdpClient(
+  context: ToolContext,
+  options?: GetCdpClientOptions,
+): ScopedCdpClient {
+  const mode: BrowserMode = options?.mode ?? "auto";
+  const candidates =
+    mode === "auto"
+      ? buildCandidateList(context)
+      : buildPinnedCandidateList(context, mode);
 
   log.debug(
     {
       conversationId: context.conversationId,
+      mode,
       candidates: candidates.map((c) => ({ kind: c.kind, reason: c.reason })),
     },
     "CDP factory: built candidate list",
   );
 
-  return buildChainedClient(context.conversationId, candidates);
+  return buildChainedClient(context.conversationId, candidates, mode);
 }
 
 // ---------------------------------------------------------------------------
-// Candidate list construction
+// Pinned candidate list construction
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a single-element candidate list for a pinned backend mode.
+ * Throws a typed `CdpError` with structured diagnostics when the
+ * requested backend's preconditions are not met.
+ *
+ * Exported for testing.
+ */
+export function buildPinnedCandidateList(
+  context: ToolContext,
+  mode: Exclude<BrowserMode, "auto">,
+): BackendCandidate[] {
+  const { conversationId, hostBrowserProxy } = context;
+
+  switch (mode) {
+    case "extension": {
+      if (!hostBrowserProxy || !hostBrowserProxy.isAvailable()) {
+        const reason = !hostBrowserProxy
+          ? "no host browser proxy provisioned for this conversation"
+          : "host browser proxy exists but is not connected";
+        throw new CdpError(
+          "transport_error",
+          `Pinned mode "extension" unavailable: ${reason}`,
+          {
+            attemptDiagnostics: [
+              {
+                candidateKind: "extension",
+                inclusionReason: `pinned mode: extension`,
+                stage: "candidate_selection",
+                errorCode: "transport_error",
+                errorMessage: reason,
+              },
+            ],
+          },
+        );
+      }
+      return [
+        {
+          kind: "extension",
+          reason: "pinned mode: extension",
+          create() {
+            const client = createExtensionCdpClient(
+              hostBrowserProxy,
+              conversationId,
+            );
+            const backend = createExtensionBackend({
+              isAvailable: () => true,
+              sendCdp: (command, signal) =>
+                dispatchThroughClient(client, command, signal),
+              dispose: () => client.dispose(),
+            });
+            return { client, backend };
+          },
+        },
+      ];
+    }
+    case "cdp-inspect": {
+      const cdpInspectConfig = getConfig().hostBrowser.cdpInspect;
+      return [
+        {
+          kind: "cdp-inspect",
+          reason: "pinned mode: cdp-inspect",
+          create() {
+            const client = createCdpInspectClient(conversationId, {
+              host: cdpInspectConfig.host,
+              port: cdpInspectConfig.port,
+              discoveryTimeoutMs: cdpInspectConfig.probeTimeoutMs,
+            });
+            const backend = createCdpInspectBackend({
+              isAvailable: () => true,
+              sendCdp: (command, signal) =>
+                dispatchThroughClient(client, command, signal),
+              dispose: () => client.dispose(),
+            });
+            return { client, backend };
+          },
+        },
+      ];
+    }
+    case "local": {
+      return [
+        {
+          kind: "local",
+          reason: "pinned mode: local",
+          create() {
+            const client = createLocalCdpClient(conversationId);
+            const backend = createLocalBackend({
+              isAvailable: () => true,
+              sendCdp: (command, signal) =>
+                dispatchThroughClient(client, command, signal),
+              dispose: () => client.dispose(),
+            });
+            return { client, backend };
+          },
+        },
+      ];
+    }
+    default: {
+      // Exhaustive check — if new modes are added, TypeScript will
+      // flag this as an error.
+      const _exhaustive: never = mode;
+      throw new Error(`Unknown pinned mode: ${_exhaustive}`);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Candidate list construction (auto mode)
 // ---------------------------------------------------------------------------
 
 /**
@@ -290,6 +430,7 @@ export function buildCandidateList(context: ToolContext): BackendCandidate[] {
 export function buildChainedClient(
   conversationId: string,
   candidates: BackendCandidate[],
+  mode: BrowserMode = "auto",
 ): ScopedCdpClient {
   if (candidates.length === 0) {
     throw new Error("CDP factory: no backend candidates available");
@@ -364,6 +505,7 @@ export function buildChainedClient(
         },
         () => disposed,
         conversationId,
+        mode,
       );
     },
 
@@ -389,6 +531,12 @@ export function buildChainedClient(
  * When a desktop-auto cdp-inspect candidate fails with a transport
  * error, the factory records a cooldown so subsequent calls skip the
  * probe until the window expires.
+ *
+ * In auto mode, each attempted candidate is recorded as an
+ * {@link AttemptDiagnostic}. When fallback occurs, a production-visible
+ * log is emitted with the full candidate sequence and per-candidate
+ * failure reasons. If all candidates are exhausted, the diagnostics
+ * are attached to the thrown {@link CdpError}.
  */
 async function sendWithFailover<T>(
   candidates: BackendCandidate[],
@@ -403,8 +551,10 @@ async function sendWithFailover<T>(
   }) => void,
   isDisposed: () => boolean,
   conversationId: string,
+  mode: BrowserMode,
 ): Promise<T> {
   let lastError: CdpError | undefined;
+  const diagnostics: AttemptDiagnostic[] = [];
 
   for (let i = 0; i < candidates.length; i++) {
     const candidate = candidates[i];
@@ -432,15 +582,23 @@ async function sendWithFailover<T>(
     } catch (err) {
       // Backend construction failed -- treat as transport error and
       // try the next candidate.
+      const errorMessage = `Backend ${candidate.kind} construction failed: ${err instanceof Error ? err.message : String(err)}`;
       log.debug(
         { conversationId, candidateKind: candidate.kind, err },
         "CDP factory: candidate construction failed, trying next",
       );
-      lastError = new CdpError(
-        "transport_error",
-        `Backend ${candidate.kind} construction failed: ${err instanceof Error ? err.message : String(err)}`,
-        { cdpMethod: method, cdpParams: params, underlying: err },
-      );
+      lastError = new CdpError("transport_error", errorMessage, {
+        cdpMethod: method,
+        cdpParams: params,
+        underlying: err,
+      });
+      diagnostics.push({
+        candidateKind: candidate.kind,
+        inclusionReason: candidate.reason,
+        stage: "construction",
+        errorCode: "transport_error",
+        errorMessage,
+      });
       maybeRecordDesktopAutoCooldown(candidate);
       continue;
     }
@@ -456,16 +614,25 @@ async function sendWithFailover<T>(
     } catch (err) {
       // Manager-level errors (unknown session, no available backend)
       // are transport-level problems -- try the next candidate.
+      const errorMessage = `Backend ${candidate.kind} send threw: ${err instanceof Error ? err.message : String(err)}`;
       log.debug(
         { conversationId, candidateKind: candidate.kind, err },
         "CDP factory: candidate send threw, trying next",
       );
       manager.disposeAll();
-      lastError = new CdpError(
-        "transport_error",
-        `Backend ${candidate.kind} send threw: ${err instanceof Error ? err.message : String(err)}`,
-        { cdpMethod: method, cdpParams: params, underlying: err },
-      );
+      lastError = new CdpError("transport_error", errorMessage, {
+        cdpMethod: method,
+        cdpParams: params,
+        underlying: err,
+      });
+      diagnostics.push({
+        candidateKind: candidate.kind,
+        inclusionReason: candidate.reason,
+        stage: "send",
+        errorCode: "transport_error",
+        errorMessage,
+        discoveryCode: extractDiscoveryCode(err),
+      });
       maybeRecordDesktopAutoCooldown(candidate);
       continue;
     }
@@ -487,16 +654,79 @@ async function sendWithFailover<T>(
         );
         manager.disposeAll();
         lastError = cdpError;
+        diagnostics.push({
+          candidateKind: candidate.kind,
+          inclusionReason: candidate.reason,
+          stage: "send",
+          errorCode: cdpError.code,
+          errorMessage: cdpError.message,
+          discoveryCode: extractDiscoveryCode(cdpError.underlying),
+        });
         maybeRecordDesktopAutoCooldown(candidate);
+
+        // Emit production-visible fallback log in auto mode
+        if (mode === "auto") {
+          log.warn(
+            {
+              conversationId,
+              failedCandidate: candidate.kind,
+              nextCandidate: candidates[i + 1].kind,
+              attemptedSoFar: diagnostics.map((d) => ({
+                kind: d.candidateKind,
+                stage: d.stage,
+                errorCode: d.errorCode,
+                errorMessage: d.errorMessage,
+              })),
+            },
+            "CDP factory: auto-mode fallback triggered",
+          );
+        }
         continue;
       }
 
       // Either a CDP protocol error or we've exhausted candidates --
-      // propagate the error as-is.
-      throw cdpError;
+      // propagate the error as-is, attaching diagnostics.
+      diagnostics.push({
+        candidateKind: candidate.kind,
+        inclusionReason: candidate.reason,
+        stage: "send",
+        errorCode: cdpError.code,
+        errorMessage: cdpError.message,
+        discoveryCode: extractDiscoveryCode(cdpError.underlying),
+      });
+      throw new CdpError(cdpError.code, cdpError.message, {
+        cdpMethod: cdpError.cdpMethod,
+        cdpParams: cdpError.cdpParams,
+        underlying: cdpError.underlying,
+        attemptDiagnostics: diagnostics.length > 0 ? diagnostics : undefined,
+      });
     }
 
     // Success! Establish this backend as the sticky choice.
+    diagnostics.push({
+      candidateKind: candidate.kind,
+      inclusionReason: candidate.reason,
+      stage: "success",
+    });
+
+    // If there were prior failed candidates in auto mode, log the
+    // full sequence for observability.
+    if (mode === "auto" && diagnostics.length > 1) {
+      log.warn(
+        {
+          conversationId,
+          stickyCandidate: candidate.kind,
+          attemptSequence: diagnostics.map((d) => ({
+            kind: d.candidateKind,
+            stage: d.stage,
+            errorCode: d.errorCode,
+            errorMessage: d.errorMessage,
+          })),
+        },
+        "CDP factory: auto-mode fallback completed, backend established after retries",
+      );
+    }
+
     log.debug(
       { conversationId, candidateKind: candidate.kind, method },
       "CDP factory: candidate succeeded, backend is now sticky",
@@ -505,14 +735,20 @@ async function sendWithFailover<T>(
     return envelope.result as T;
   }
 
-  // All candidates exhausted -- throw the last transport error.
-  throw (
-    lastError ??
-    new CdpError("transport_error", "All backend candidates exhausted", {
-      cdpMethod: method,
-      cdpParams: params,
-    })
-  );
+  // All candidates exhausted -- throw the last transport error with
+  // full attempt diagnostics attached.
+  throw lastError
+    ? new CdpError(lastError.code, lastError.message, {
+        cdpMethod: lastError.cdpMethod,
+        cdpParams: lastError.cdpParams,
+        underlying: lastError.underlying,
+        attemptDiagnostics: diagnostics.length > 0 ? diagnostics : undefined,
+      })
+    : new CdpError("transport_error", "All backend candidates exhausted", {
+        cdpMethod: method,
+        cdpParams: params,
+        attemptDiagnostics: diagnostics.length > 0 ? diagnostics : undefined,
+      });
 }
 
 /**
@@ -622,4 +858,21 @@ function unwrapResult<T>(
     throw extractCdpError(envelope, method, params);
   }
   return envelope.result as T;
+}
+
+/**
+ * Attempt to extract a discovery-level error code from an underlying
+ * error. Some CdpInspectClient errors embed a discovery code (e.g.
+ * "ECONNREFUSED", "DISCOVERY_TIMEOUT") that is useful for diagnostics.
+ */
+function extractDiscoveryCode(underlying: unknown): string | undefined {
+  if (underlying == null) return undefined;
+  if (typeof underlying === "object" && "code" in underlying) {
+    const code = (underlying as Record<string, unknown>).code;
+    if (typeof code === "string") return code;
+  }
+  if (underlying instanceof Error && "cause" in underlying) {
+    return extractDiscoveryCode(underlying.cause);
+  }
+  return undefined;
 }

--- a/assistant/src/tools/browser/cdp-client/index.ts
+++ b/assistant/src/tools/browser/cdp-client/index.ts
@@ -12,11 +12,16 @@ export {
 export {
   buildCandidateList,
   buildChainedClient,
+  buildPinnedCandidateList,
   getCdpClient,
+  type GetCdpClientOptions,
 } from "./factory.js";
 export { createLocalCdpClient, LocalCdpClient } from "./local-cdp-client.js";
 export type {
+  AttemptDiagnostic,
+  AttemptStage,
   BackendCandidate,
+  BrowserMode,
   CdpClient,
   CdpClientKind,
   ScopedCdpClient,

--- a/assistant/src/tools/browser/cdp-client/types.ts
+++ b/assistant/src/tools/browser/cdp-client/types.ts
@@ -42,6 +42,51 @@ export interface CdpClient {
 export type CdpClientKind = "local" | "extension" | "cdp-inspect";
 
 /**
+ * Backend mode preference for the CDP factory. Controls which
+ * transport is selected:
+ *
+ *  - `"auto"` — default, existing priority-ordered fallback
+ *    (extension → cdp-inspect → local).
+ *  - `"extension"` — pin to the chrome-extension backend. Fails
+ *    immediately if the host browser proxy is unavailable.
+ *  - `"cdp-inspect"` — pin to the cdp-inspect backend. Fails
+ *    immediately if cdp-inspect cannot connect.
+ *  - `"local"` — pin to the local Playwright backend. No fallback.
+ */
+export type BrowserMode = "auto" | "extension" | "cdp-inspect" | "local";
+
+/**
+ * Stage at which a candidate attempt ended. Used in
+ * {@link AttemptDiagnostic} to indicate how far the attempt progressed.
+ */
+export type AttemptStage =
+  | "candidate_selection" // failed before construction (precondition not met)
+  | "construction" // create() threw
+  | "send" // manager.send() threw or returned an error envelope
+  | "success"; // command completed successfully
+
+/**
+ * Structured diagnostic for a single candidate attempt during the
+ * factory's failover walk. Collected into an array and attached to
+ * thrown {@link CdpError} instances so higher layers can render
+ * detailed failure information in user-facing tool errors.
+ */
+export interface AttemptDiagnostic {
+  /** Which backend kind was attempted. */
+  readonly candidateKind: CdpClientKind;
+  /** Why this candidate was included (from {@link BackendCandidate.reason}). */
+  readonly inclusionReason: string;
+  /** How far the attempt progressed before it ended. */
+  readonly stage: AttemptStage;
+  /** Error code from the CdpError, if the attempt failed. */
+  readonly errorCode?: string;
+  /** Error message from the CdpError, if the attempt failed. */
+  readonly errorMessage?: string;
+  /** Discovery-level error code extracted from the underlying error, if any. */
+  readonly discoveryCode?: string;
+}
+
+/**
  * Concrete CdpClient instance returned by the factory. Carries the
  * backend `kind` for transport-aware branches in tool code.
  */


### PR DESCRIPTION
## Summary
- Extend CDP factory to accept optional backend preference (auto/extension/cdp-inspect/local)
- Add structured attempt diagnostics tracking candidate kind, failure reasons, and discovery codes
- Emit production-visible logs on auto-mode fallback with full candidate sequence

Part of plan: browser-mode-fallback-diagnostics.md (PR 2 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24999" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
