### PR TITLE
fix: address review gaps in TTS/STT settings redesign

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -116,6 +116,12 @@ struct VoiceSettingsView: View {
             ttsSaveError = nil
             ttsProviderHasKey = ttsCredentialExists(for: draftTTSProvider)
         }
+        .onChange(of: draftSTTProvider) { _, _ in
+            // Clear stale fields when STT provider changes
+            sttApiKeyText = ""
+            sttSaveError = nil
+            sttProviderHasKey = APIKeyManager.getKey(for: "openai") != nil
+        }
         .onChange(of: conversationTimeoutSeconds) {
             VoiceModeManager.conversationTimeoutOverride = conversationTimeoutSeconds
         }
@@ -492,22 +498,19 @@ struct VoiceSettingsView: View {
                 store.saveElevenLabsKey(trimmedKey, onSuccess: {
                     ttsApiKeyText = ""
                     ttsProviderHasKey = true
-                    ttsSaving = false
                 })
             case "fish-audio":
                 store.saveFishAudioKey(trimmedKey, onSuccess: {
                     ttsApiKeyText = ""
                     ttsProviderHasKey = true
-                    ttsSaving = false
                 })
             default:
-                // For unknown providers, just clear and finish
+                // For unknown providers, just clear the field
                 ttsApiKeyText = ""
-                ttsSaving = false
             }
-        } else {
-            ttsSaving = false
         }
+
+        ttsSaving = false
 
         // Update baseline for change detection
         initialTTSProvider = draftTTSProvider
@@ -563,6 +566,11 @@ struct VoiceSettingsView: View {
                         }
                     )
                 }
+
+                // Provider-specific subtitle
+                Text("High-accuracy speech-to-text transcription. Requires an OpenAI API key.")
+                    .font(VFont.bodySmallDefault)
+                    .foregroundStyle(VColor.contentTertiary)
 
                 // API key field
                 VTextField(


### PR DESCRIPTION
## Summary
- Fix ttsSaving stuck on daemon sync failure by setting it unconditionally
- Add STT provider subtitle for visual consistency with TTS card
- Add onChange(of: draftSTTProvider) handler to clear stale state on provider switch

Fixes gaps identified during plan review for tts-stt-ui-redesign.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25000" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
