### PR TITLE
Clean up native-primary assumptions and document service-first STT architecture

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -584,15 +584,16 @@ All guardian decisions for voice access requests flow through:
 
 ### Speech-to-Text (STT) Boundaries
 
-Audio-to-text conversion occurs in three distinct runtime boundaries, each with its own provider model and adapter layer. There is no global STT provider switch — each boundary resolves its provider independently based on its runtime context and available credentials.
+Audio-to-text conversion occurs in four distinct runtime boundaries, each with its own provider model and adapter layer. The `services.stt` config block controls provider selection for the daemon's STT service; other boundaries resolve providers independently based on their runtime context.
 
 **Boundary overview:**
 
-| Boundary             | Runtime                               | Provider (current)                  | Adapter module                                                                                     | Caller                                                  |
-| -------------------- | ------------------------------------- | ----------------------------------- | -------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
-| **Telephony-native** | Twilio ConversationRelay              | Deepgram or Google (config-driven)  | `src/calls/stt-profile.ts`                                                                         | `src/calls/twilio-routes.ts`                            |
-| **Daemon batch**     | Daemon process (REST API to provider) | OpenAI Whisper                      | `src/stt/daemon-batch-transcriber.ts`                                                              | `src/runtime/routes/inbound-stages/transcribe-audio.ts` |
-| **Client-native**    | macOS / iOS on-device                 | Apple Speech (`SFSpeechRecognizer`) | `clients/macos/.../SpeechRecognizerAdapter.swift`, `clients/ios/.../SpeechRecognizerAdapter.swift` | `VoiceInputManager` (macOS), `InputBarView` (iOS)       |
+| Boundary                     | Runtime                               | Provider (current)                           | Adapter module                                                                                     | Caller                                                                                               |
+| ---------------------------- | ------------------------------------- | -------------------------------------------- | -------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| **Telephony-native**         | Twilio ConversationRelay              | Deepgram or Google (config-driven)           | `src/calls/stt-profile.ts`                                                                         | `src/calls/twilio-routes.ts`                                                                         |
+| **Daemon batch**             | Daemon process (REST API to provider) | OpenAI Whisper                               | `src/stt/daemon-batch-transcriber.ts`                                                              | `src/runtime/routes/inbound-stages/transcribe-audio.ts`                                              |
+| **Client service-first**     | macOS / iOS via gateway → daemon      | Configured STT provider (via `services.stt`) | `src/runtime/routes/stt-routes.ts`, `clients/shared/Network/STTClient.swift`                       | `VoiceInputManager` (macOS dictation), `InputBarView` (iOS), `OpenAIVoiceService` (macOS voice mode) |
+| **Client-native (fallback)** | macOS / iOS on-device                 | Apple Speech (`SFSpeechRecognizer`)          | `clients/macos/.../SpeechRecognizerAdapter.swift`, `clients/ios/.../SpeechRecognizerAdapter.swift` | Fallback when STT service is unconfigured or fails                                                   |
 
 **Telephony-native boundary:**
 
@@ -615,9 +616,25 @@ The daemon transcribes audio attachments (e.g. voice messages from channel inbou
 
 To add a new daemon batch STT provider: add a new `SttProviderId` variant in `types.ts`, implement `BatchTranscriber` in a new adapter class alongside `WhisperBatchTranscriber`, and update the factory in `daemon-batch-transcriber.ts` to select the adapter based on configuration or credential availability.
 
-**Client-native boundary:**
+**Client service-first boundary:**
 
-On macOS and iOS, speech recognition runs on-device via Apple's Speech framework (`SFSpeechRecognizer`). The daemon never receives raw microphone audio from clients — it receives the final transcribed text. The `SpeechRecognizerAdapter` protocols on each platform abstract Apple Speech for **testability and dependency injection**, not for provider-agnostic pluggability. The two platform adapters have intentionally different API shapes reflecting their different UI integration patterns.
+All product-facing dictation and voice-streaming paths on macOS and iOS use a service-first STT strategy. Clients record audio, encode it to WAV via `AudioWavEncoder` (shared utility in `clients/shared/Utilities/AudioWavEncoder.swift`), and POST it through the gateway to the daemon's `POST /v1/stt/transcribe` endpoint via `STTClient` (`clients/shared/Network/STTClient.swift`). The daemon resolves the configured STT provider through `resolveBatchTranscriber()` and returns the transcribed text.
+
+- `STTClient` conforms to `STTClientProtocol` and returns a typed `STTResult` enum (`success`, `notConfigured`, `serviceUnavailable`, `error`). Callers pattern-match on the result to deterministically trigger native fallback.
+- The gateway proxies the request via assistant-scoped path rewriting: `/v1/assistants/:id/stt/transcribe` is rewritten to `/v1/stt/transcribe` on the daemon.
+- `stt-routes.ts` (`src/runtime/routes/stt-routes.ts`) defines the HTTP endpoint, validates the audio payload, and delegates to `resolveBatchTranscriber()`.
+
+Product-facing flows using service-first STT:
+
+| Flow                       | Client | Entry point                                                                                                                                                                                         |
+| -------------------------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Push-to-talk dictation** | macOS  | `VoiceInputManager.resolveTranscription()` — encodes accumulated PCM buffers to WAV, calls `sttClient.transcribe()`, falls back to native text on failure                                           |
+| **Input bar dictation**    | iOS    | `InputBarView.resolveTranscriptWithServiceFirst()` — encodes captured audio buffers to WAV, calls `sttClient.transcribe()`, falls back to native transcript on failure                              |
+| **Voice mode (streaming)** | macOS  | `OpenAIVoiceService.stopRecordingAndGetTranscription()` — encodes per-turn PCM to WAV, calls `sttClient.transcribe()` for turn-final transcript resolution, falls back to SFSpeechRecognizer result |
+
+**Client-native fallback boundary:**
+
+Apple-native on-device recognition via `SFSpeechRecognizer` serves two roles in all three product-facing flows above: (1) it provides low-latency partial transcriptions for real-time display during recording, and (2) it provides the fallback final transcription when the STT service is unconfigured (HTTP 503), temporarily unavailable (HTTP 5xx), or returns an empty result. The `SpeechRecognizerAdapter` protocols on each platform abstract Apple Speech for **testability and dependency injection**.
 
 - macOS: `SpeechRecognizerAdapter` protocol in `clients/macos/vellum-assistant/Features/Voice/SpeechRecognizerAdapter.swift` abstracts `SFSpeechRecognizer` static APIs and instance creation. `AppleSpeechRecognizerAdapter` is the production implementation. `OpenAIVoiceService` and `VoiceInputManager` consume the adapter via dependency injection. **Note:** The macOS protocol leaks Apple Speech types through its surface — `authorizationStatus()` returns `SFSpeechRecognizerAuthorizationStatus` and `makeRecognizer(locale:)` returns `SFSpeechRecognizer?` directly. This means callers depend on the Speech framework at compile time.
 - iOS: `SpeechRecognizerAdapter` protocol in `clients/ios/Services/SpeechRecognizerAdapter.swift` covers authorization, availability, and task construction. `AppleSpeechRecognizerAdapter` is the production implementation. `InputBarView` consumes the adapter. **Note:** The iOS protocol defines its own framework-agnostic types (`SpeechRecognizerAuthorizationStatus`, `SpeechRecognitionResult`) so callers never see `SFSpeechRecognizer` directly. However, `startRecognitionTask` still returns `SFSpeechAudioBufferRecognitionRequest` in its tuple, so full framework decoupling is not yet achieved.
@@ -628,11 +645,11 @@ Platform divergence summary:
 - **Recognizer exposure:** macOS exposes the raw `SFSpeechRecognizer?` via `makeRecognizer(locale:)`; iOS fully encapsulates recognizer construction inside `startRecognitionTask`.
 - **Concurrency model:** The iOS protocol is `@MainActor`-annotated; the macOS protocol is not.
 
-These differences are intentional — the adapters were designed for their respective platform integration needs, not for cross-platform uniformity. Adding a non-Apple STT provider (e.g., a third-party on-device engine) would require refactoring both protocols to remove Apple Speech types from their public surfaces and converging on a shared provider-agnostic interface. The current adapters are suitable for swapping in test doubles for Apple Speech, but not for swapping in an entirely different speech engine without protocol changes.
+These differences are intentional — the adapters were designed for their respective platform integration needs, not for cross-platform uniformity.
 
 **Cross-boundary notes:**
 
-- No global STT provider configuration exists. Each boundary resolves its provider independently. A future phase may introduce a unified config surface, but it is not part of the current architecture.
+- The `services.stt` config block controls provider selection for both the daemon batch boundary and the client service-first boundary (they share `resolveBatchTranscriber()`). Telephony STT is configured separately via `calls.voice.transcriptionProvider`.
 - Terminology: "STT" and "transcription" refer to the same operation (converting audio to text). "Speech recognition" is used in client-native contexts where Apple's Speech framework terminology is canonical. All three terms map to the same conceptual operation.
 
 ### Update Bulletin System

--- a/clients/ios/README.md
+++ b/clients/ios/README.md
@@ -20,7 +20,7 @@ After editing `project.yml`, regenerate the Xcode project by running `xcodegen g
 - Inline media embeds (images, YouTube, Vimeo, Loom videos)
 - Settings: integrations, trust rules, scheduled tasks, reminders (Connected mode)
 - Attachment support (photos, files)
-- Voice input via on-device speech recognition (`SpeechRecognizerAdapter`)
+- Voice input with service-first STT (gateway → configured provider) and Apple-native fallback (`SpeechRecognizerAdapter`)
 - Onboarding flow with adaptive steps based on connection mode
 - Export conversation as markdown (copy to clipboard or share sheet)
 - Siri Shortcuts integration — "Ask Vellum..." via AppIntents framework
@@ -166,9 +166,9 @@ The iOS app depends only on `VellumAssistantShared`. It must **not** import `Vel
 
 ## Speech Recognition (STT)
 
-Voice input uses the `SpeechRecognizerAdapter` protocol (`Services/SpeechRecognizerAdapter.swift`) to abstract on-device speech recognition. The protocol covers three phases: authorization, availability, and task construction. The production implementation (`AppleSpeechRecognizerAdapter`) delegates to Apple's `SFSpeechRecognizer`. `InputBarView` consumes the adapter via a stored property, enabling tests to substitute a mock without a live microphone or OS permission dialogs.
+Voice input uses a **service-first STT** strategy. When the user finishes recording, captured audio buffers are encoded to WAV via `AudioWavEncoder` (shared utility) and sent to the assistant's configured STT service through the gateway using `STTClient` (`clients/shared/Network/STTClient.swift`). If the STT service returns a successful transcription, that text is used. If the service is unconfigured (HTTP 503), unavailable, or returns an empty result, the native `SFSpeechRecognizer` transcript is used as fallback.
 
-To add a new on-device STT provider, implement `SpeechRecognizerAdapter` with the provider's SDK and inject it at the `InputBarView` call site.
+During recording, the `SpeechRecognizerAdapter` protocol (`Services/SpeechRecognizerAdapter.swift`) provides real-time partial transcriptions via Apple's on-device `SFSpeechRecognizer` for immediate display in the input bar. The production implementation (`AppleSpeechRecognizerAdapter`) delegates to `SFSpeechRecognizer`. `InputBarView` consumes both the adapter (for partials and fallback) and `STTClient` (for service-first resolution) via stored properties, enabling tests to substitute mocks without a live microphone or OS permission dialogs.
 
 ---
 

--- a/clients/macos/AGENTS.md
+++ b/clients/macos/AGENTS.md
@@ -121,9 +121,17 @@ A background screen-watching system that runs alongside the manual session loop:
 
 ### Voice Input
 
-`VoiceInputManager` — hold Fn (or Ctrl, configurable) for on-device speech recognition via `SFSpeechRecognizer`. Shows `VoiceTranscriptionWindow` during recording.
+`VoiceInputManager` — hold Fn (or Ctrl, configurable) for voice input. Shows `VoiceTranscriptionWindow` during recording. Uses a **service-first STT** strategy: captured audio is encoded to WAV and sent to the assistant's configured STT service via `STTClient` (shared client in `clients/shared/Network/STTClient.swift`). Apple-native `SFSpeechRecognizer` provides real-time partial transcriptions during recording and serves as the fallback when the STT service is unconfigured or fails.
 
-**STT adapter:** All speech recognition access goes through the `SpeechRecognizerAdapter` protocol (`Features/Voice/SpeechRecognizerAdapter.swift`), which abstracts `SFSpeechRecognizer` static APIs and instance creation. The production implementation is `AppleSpeechRecognizerAdapter`. Both `VoiceInputManager` and `OpenAIVoiceService` accept the adapter via init injection, enabling tests to substitute a mock without hardware or permission dependencies. To add a new on-device STT provider, implement `SpeechRecognizerAdapter` with the provider's SDK and inject it at the call site.
+**Service-first STT precedence (dictation mode):**
+1. Audio is recorded and accumulated as PCM buffers alongside a live `SFSpeechRecognizer` session for partial display.
+2. On recording end, buffers are encoded to WAV via `AudioWavEncoder` and sent to the STT service through the gateway.
+3. If the service returns a non-empty transcription, that text is used as the final result.
+4. If the service is unconfigured (503), unavailable, or returns empty text, the native `SFSpeechRecognizer` result is used as fallback.
+
+**Voice mode (streaming):** `OpenAIVoiceService` follows the same service-first pattern for turn-final transcript resolution. Per-turn PCM audio is encoded to WAV and sent to the STT service. The service result takes precedence; the live `SFSpeechRecognizer` transcript is used as fallback.
+
+**STT adapter:** The `SpeechRecognizerAdapter` protocol (`Features/Voice/SpeechRecognizerAdapter.swift`) abstracts `SFSpeechRecognizer` static APIs and instance creation for partial transcription and fallback. The production implementation is `AppleSpeechRecognizerAdapter`. Both `VoiceInputManager` and `OpenAIVoiceService` accept the adapter and `STTClient` via init injection, enabling tests to substitute mocks without hardware or permission dependencies.
 
 **Keyboard shortcut detection:** Uses defense-in-depth to distinguish voice activation from keyboard shortcuts (Control+C, Fn+arrow). Timer starts on key press, but recording only begins if no other keys are pressed during the 300ms hold period. Flag check (`otherKeyPressedDuringHold`) handles cases where apps consume keyDown events (e.g., Terminal).
 

--- a/gateway/ARCHITECTURE.md
+++ b/gateway/ARCHITECTURE.md
@@ -32,6 +32,25 @@ Internet
        +-- /webhooks/* --> BLOCKED (404, never forwarded to runtime)
 ```
 
+### STT Route Proxying (Assistant-Scoped Rewrite)
+
+Native clients (macOS, iOS) send speech-to-text transcription requests through the gateway to the daemon's STT service. Clients POST to the assistant-scoped path `/v1/assistants/:assistantId/stt/transcribe`, which the gateway's runtime proxy rewrites to the flat daemon path `/v1/stt/transcribe`. This follows the same assistant-scoped rewrite pattern used by other client-facing endpoints (feature flags, privacy config, etc.).
+
+The request carries base64-encoded WAV audio and a MIME type. The daemon resolves the configured STT provider via `resolveBatchTranscriber()` and returns the transcribed text. Clients use the response to implement a service-first strategy: the service transcription takes precedence when available, with Apple-native `SFSpeechRecognizer` as fallback when the service returns 503 (not configured) or fails.
+
+| Client path (gateway)               | Daemon path (after rewrite) | Method |
+| ----------------------------------- | --------------------------- | ------ |
+| `/v1/assistants/:id/stt/transcribe` | `/v1/stt/transcribe`        | POST   |
+
+**Key source files:**
+
+| File                                             | Purpose                                                                   |
+| ------------------------------------------------ | ------------------------------------------------------------------------- |
+| `gateway/src/http/routes/runtime-proxy.ts`       | Assistant-scoped path rewriting (`/v1/assistants/:id/...` → `/v1/...`)    |
+| `assistant/src/runtime/routes/stt-routes.ts`     | Daemon HTTP endpoint: validates audio, resolves transcriber, returns text |
+| `clients/shared/Network/STTClient.swift`         | Shared client: POSTs audio to the gateway, returns typed `STTResult`      |
+| `clients/shared/Utilities/AudioWavEncoder.swift` | WAV encoding utility for PCM audio buffers                                |
+
 ### Assistant Feature Flags API
 
 The gateway exposes a REST API for reading and mutating assistant feature flags. Assistant feature flags are assistant-scoped, declaration-driven booleans that can gate any assistant behavior. Skill availability is one consumer, but not a required coupling (see [`assistant/ARCHITECTURE.md`](../assistant/ARCHITECTURE.md) for resolver and skill enforcement details).


### PR DESCRIPTION
## Summary
- Updates architecture docs to reflect service-first STT precedence across macOS/iOS dictation paths
- Documents STT route proxying in gateway architecture
- Removes stale language implying native Apple recognition as the primary transcription path

Part of plan: service-first-stt-dictation-streaming.md (PR 7 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25001" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
