### PR TITLE
Redesign TTS & STT settings to use dropdown + Save pattern

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -10,15 +10,7 @@ private enum STTProviderOption: String, CaseIterable {
         case .openaiWhisper: return "OpenAI Whisper"
         }
     }
-
-    var subtitle: String {
-        switch self {
-        case .openaiWhisper:
-            return "High-accuracy speech-to-text transcription. Requires an OpenAI API key."
-        }
-    }
 }
-
 
 /// Voice settings tab — configure push-to-talk activation key,
 /// conversation timeout, text-to-speech provider, and speech-to-text provider.
@@ -464,37 +456,6 @@ struct VoiceSettingsView: View {
             // Generic providers do not have a voice ID field
             EmptyView()
         }
-    }
-
-    private func providerOption(label: String, isSelected: Bool, action: @escaping () -> Void) -> some View {
-        Button(action: action) {
-            HStack(spacing: VSpacing.sm) {
-                Circle()
-                    .fill(isSelected ? VColor.primaryBase : Color.clear)
-                    .frame(width: 10, height: 10)
-                    .overlay(
-                        Circle()
-                            .strokeBorder(isSelected ? VColor.primaryBase : VColor.borderHover, lineWidth: 1.5)
-                    )
-
-                Text(label)
-                    .font(VFont.bodyMediumLighter)
-                    .foregroundStyle(VColor.contentDefault)
-            }
-            .padding(.horizontal, VSpacing.md)
-            .padding(.vertical, VSpacing.sm)
-            .background(
-                RoundedRectangle(cornerRadius: VRadius.lg)
-                    .fill(isSelected ? VColor.surfaceActive : Color.clear)
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: VRadius.lg)
-                    .strokeBorder(VColor.borderBase, lineWidth: 1)
-            )
-            .contentShape(RoundedRectangle(cornerRadius: VRadius.lg))
-        }
-        .buttonStyle(.plain)
-        .pointerCursor()
     }
 
     // MARK: - TTS Save / Helpers

--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -477,17 +477,17 @@ struct VoiceSettingsView: View {
             ttsProviderRaw = draftTTSProvider
         }
 
-        // Persist voice ID for the selected provider
+        // Always persist voice ID for the selected provider, even when
+        // empty — sending an empty string clears a previously set voice
+        // ID and reverts to the provider's default voice.
         let trimmedVoiceId = ttsVoiceIdText.trimmingCharacters(in: .whitespacesAndNewlines)
-        if !trimmedVoiceId.isEmpty {
-            switch draftTTSProvider {
-            case "elevenlabs":
-                store.setElevenLabsVoiceId(trimmedVoiceId)
-            case "fish-audio":
-                store.setFishAudioReferenceId(trimmedVoiceId)
-            default:
-                break
-            }
+        switch draftTTSProvider {
+        case "elevenlabs":
+            store.setElevenLabsVoiceId(trimmedVoiceId)
+        case "fish-audio":
+            store.setFishAudioReferenceId(trimmedVoiceId)
+        default:
+            break
         }
 
         // Persist API key if entered. Clear the field and update hasKey

--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -490,23 +490,20 @@ struct VoiceSettingsView: View {
             }
         }
 
-        // Persist API key if entered
+        // Persist API key if entered. Clear the field and update hasKey
+        // optimistically so the UI reflects the save immediately; the
+        // async daemon sync validates the key in the background.
         let trimmedKey = ttsApiKeyText.trimmingCharacters(in: .whitespacesAndNewlines)
         if !trimmedKey.isEmpty {
+            ttsApiKeyText = ""
+            ttsProviderHasKey = true
             switch draftTTSProvider {
             case "elevenlabs":
-                store.saveElevenLabsKey(trimmedKey, onSuccess: {
-                    ttsApiKeyText = ""
-                    ttsProviderHasKey = true
-                })
+                store.saveElevenLabsKey(trimmedKey)
             case "fish-audio":
-                store.saveFishAudioKey(trimmedKey, onSuccess: {
-                    ttsApiKeyText = ""
-                    ttsProviderHasKey = true
-                })
+                store.saveFishAudioKey(trimmedKey)
             default:
-                // For unknown providers, just clear the field
-                ttsApiKeyText = ""
+                break
             }
         }
 
@@ -623,13 +620,13 @@ struct VoiceSettingsView: View {
             sttProviderRaw = draftSTTProvider
         }
 
-        // Persist API key if provided
+        // Persist API key if provided. Clear the field and update hasKey
+        // optimistically so the UI reflects the save immediately.
         let trimmedKey = sttApiKeyText.trimmingCharacters(in: .whitespacesAndNewlines)
         if !trimmedKey.isEmpty {
-            store.saveSTTOpenAIKey(trimmedKey) {
-                sttProviderHasKey = true
-                sttApiKeyText = ""
-            }
+            sttApiKeyText = ""
+            sttProviderHasKey = true
+            store.saveSTTOpenAIKey(trimmedKey)
         }
 
         initialSTTProvider = draftSTTProvider

--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -116,6 +116,12 @@ struct VoiceSettingsView: View {
             ttsSaveError = nil
             ttsProviderHasKey = ttsCredentialExists(for: draftTTSProvider)
         }
+        .onChange(of: draftSTTProvider) { _, _ in
+            // Clear stale fields when STT provider changes
+            sttApiKeyText = ""
+            sttSaveError = nil
+            sttProviderHasKey = APIKeyManager.getKey(for: "openai") != nil
+        }
         .onChange(of: conversationTimeoutSeconds) {
             VoiceModeManager.conversationTimeoutOverride = conversationTimeoutSeconds
         }
@@ -492,22 +498,19 @@ struct VoiceSettingsView: View {
                 store.saveElevenLabsKey(trimmedKey, onSuccess: {
                     ttsApiKeyText = ""
                     ttsProviderHasKey = true
-                    ttsSaving = false
                 })
             case "fish-audio":
                 store.saveFishAudioKey(trimmedKey, onSuccess: {
                     ttsApiKeyText = ""
                     ttsProviderHasKey = true
-                    ttsSaving = false
                 })
             default:
-                // For unknown providers, just clear and finish
+                // For unknown providers, just clear the field
                 ttsApiKeyText = ""
-                ttsSaving = false
             }
-        } else {
-            ttsSaving = false
         }
+
+        ttsSaving = false
 
         // Update baseline for change detection
         initialTTSProvider = draftTTSProvider
@@ -563,6 +566,11 @@ struct VoiceSettingsView: View {
                         }
                     )
                 }
+
+                // Provider-specific subtitle
+                Text("High-accuracy speech-to-text transcription. Requires an OpenAI API key.")
+                    .font(VFont.bodySmallDefault)
+                    .foregroundStyle(VColor.contentTertiary)
 
                 // API key field
                 VTextField(

--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -31,16 +31,21 @@ struct VoiceSettingsView: View {
     @AppStorage("ttsProvider") private var ttsProviderRaw: String = "elevenlabs"
     @AppStorage("sttProvider") private var sttProviderRaw: String = STTProviderOption.openaiWhisper.rawValue
 
-    @State private var elevenLabsKeyText: String = ""
-    @State private var elevenLabsVoiceId: String = ""
-    @State private var ttsSetupExpanded: Bool = false
-    /// Whether an ElevenLabs API key is stored (fetched per-component).
-    @State private var elevenLabsHasKey = false
-
-    @State private var fishAudioKeyText: String = ""
-    @State private var fishAudioSetupExpanded: Bool = false
-    @State private var fishAudioHasKey = false
-    @State private var fishAudioReferenceId: String = ""
+    // TTS draft-based state (mirrors Inference card pattern)
+    /// Uncommitted provider selection — only persisted on Save.
+    @State private var draftTTSProvider: String = "elevenlabs"
+    /// API key input field text.
+    @State private var ttsApiKeyText: String = ""
+    /// Voice ID / reference ID input text.
+    @State private var ttsVoiceIdText: String = ""
+    /// Baseline provider for change detection.
+    @State private var initialTTSProvider: String = "elevenlabs"
+    /// Whether the current TTS provider has a stored API key.
+    @State private var ttsProviderHasKey: Bool = false
+    /// Save-in-progress indicator.
+    @State private var ttsSaving: Bool = false
+    /// Error message from key save.
+    @State private var ttsSaveError: String? = nil
 
     @State private var isRecordingCustomKey: Bool = false
     @State private var recordingMonitors: [Any] = []
@@ -55,11 +60,11 @@ struct VoiceSettingsView: View {
     /// The shared TTS provider registry loaded from the bundled catalog.
     private let registry = loadTTSProviderRegistry()
 
-    /// The currently selected provider entry from the registry.
-    /// Falls back to the first provider in the registry if the persisted
-    /// value does not match any known entry (matching iOS behavior).
+    /// The currently selected provider entry from the registry, based on
+    /// the draft selection. Falls back to the first provider in the registry
+    /// if the value does not match any known entry (matching iOS behavior).
     private var selectedProvider: TTSProviderCatalogEntry? {
-        registry.provider(withId: ttsProviderRaw) ?? registry.providers.first
+        registry.provider(withId: draftTTSProvider) ?? registry.providers.first
     }
 
     private var sttProvider: STTProviderOption {
@@ -98,9 +103,20 @@ struct VoiceSettingsView: View {
             stopRecordingCustomKey()
         }
         .onAppear {
-            elevenLabsHasKey = APIKeyManager.getCredential(service: "elevenlabs", field: "api_key") != nil
-            fishAudioHasKey = APIKeyManager.getCredential(service: "fish-audio", field: "api_key") != nil
+            // Initialize TTS draft state from persisted values
+            draftTTSProvider = ttsProviderRaw
+            initialTTSProvider = ttsProviderRaw
+            ttsProviderHasKey = ttsCredentialExists(for: ttsProviderRaw)
+
+            // STT key check
             sttOpenAIHasKey = APIKeyManager.getKey(for: "openai") != nil
+        }
+        .onChange(of: draftTTSProvider) { _, _ in
+            // Clear API key and voice ID fields when provider changes
+            ttsApiKeyText = ""
+            ttsVoiceIdText = ""
+            ttsSaveError = nil
+            ttsProviderHasKey = ttsCredentialExists(for: draftTTSProvider)
         }
         .onChange(of: conversationTimeoutSeconds) {
             VoiceModeManager.conversationTimeoutOverride = conversationTimeoutSeconds
@@ -335,24 +351,29 @@ struct VoiceSettingsView: View {
 
     // MARK: - Unified TTS Provider Card
 
+    /// Whether the user has made changes worth saving in the TTS card.
+    private var ttsHasChanges: Bool {
+        let providerChanged = draftTTSProvider != initialTTSProvider
+        let hasNewKey = !ttsApiKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        let hasVoiceId = !ttsVoiceIdText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        return providerChanged || hasNewKey || hasVoiceId
+    }
+
     private var ttsProviderCard: some View {
         SettingsCard(title: "Text-to-Speech", subtitle: "Choose a TTS provider for voice conversations and read-aloud. The selected provider is used globally across all speech features.") {
             VStack(alignment: .leading, spacing: VSpacing.md) {
-                // Provider selector — data-driven from the shared registry
+                // Provider dropdown — data-driven from the shared registry
                 VStack(alignment: .leading, spacing: VSpacing.sm) {
-                    Text("Provider:")
-                        .font(VFont.bodySmallDefault)
+                    Text("Provider")
+                        .font(VFont.labelDefault)
                         .foregroundStyle(VColor.contentSecondary)
-
-                    HStack(spacing: VSpacing.sm) {
-                        ForEach(registry.providers, id: \.id) { entry in
-                            let isSelected = ttsProviderRaw == entry.id
-                            providerOption(label: entry.displayName, isSelected: isSelected) {
-                                ttsProviderRaw = entry.id
-                                store.setTTSProvider(entry.id)
-                            }
+                    VDropdown(
+                        placeholder: "Select a provider\u{2026}",
+                        selection: $draftTTSProvider,
+                        options: registry.providers.map { entry in
+                            (label: entry.displayName, value: entry.id)
                         }
-                    }
+                    )
                 }
 
                 // Provider-specific subtitle from registry metadata
@@ -362,27 +383,80 @@ struct VoiceSettingsView: View {
                         .foregroundStyle(VColor.contentTertiary)
                 }
 
-                // Provider-specific configuration panels.
-                // Existing providers retain their bespoke setup UX;
-                // new registry providers get a generic fallback panel.
-                providerConfigPanel
+                // Unified API key field
+                ttsApiKeyField
+
+                // Voice ID / Reference ID field (provider-specific)
+                ttsVoiceIdField
+
+                // Save + Reset actions
+                ServiceCardActions(
+                    hasChanges: ttsHasChanges,
+                    isSaving: ttsSaving,
+                    onSave: { saveTTS() },
+                    savingLabel: "Saving...",
+                    onReset: {
+                        clearTTSCredential(for: draftTTSProvider)
+                        ttsProviderHasKey = false
+                        ttsApiKeyText = ""
+                    },
+                    showReset: ttsProviderHasKey
+                )
             }
         }
     }
 
-    /// Routes to bespoke setup panels for known providers, or a generic
-    /// fallback for providers added to the registry without custom UI.
-    @ViewBuilder
-    private var providerConfigPanel: some View {
-        switch ttsProviderRaw {
-        case "elevenlabs":
-            elevenLabsProviderConfig
-        case "fish-audio":
-            fishAudioProviderConfig
-        default:
-            if let provider = selectedProvider {
-                genericProviderConfig(for: provider)
+    // MARK: - TTS API Key Field
+
+    private var ttsApiKeyField: some View {
+        let placeholder: String = {
+            if ttsProviderHasKey {
+                return "\u{2022}\u{2022}\u{2022}\u{2022}\u{2022}\u{2022}\u{2022}\u{2022}\u{2022}\u{2022}\u{2022}\u{2022}\u{2022}\u{2022}\u{2022}\u{2022}"
             }
+            return "Enter your API key"
+        }()
+        return VTextField(
+            "\(selectedProvider?.displayName ?? "Provider") API Key",
+            placeholder: placeholder,
+            text: $ttsApiKeyText,
+            isSecure: true,
+            errorMessage: ttsSaveError
+        )
+        .disabled(ttsSaving)
+    }
+
+    // MARK: - TTS Voice ID Field
+
+    @ViewBuilder
+    private var ttsVoiceIdField: some View {
+        switch draftTTSProvider {
+        case "elevenlabs":
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                VTextField(
+                    "Voice ID",
+                    placeholder: "ElevenLabs Voice ID (optional)",
+                    text: $ttsVoiceIdText
+                )
+
+                Text("Leave blank to use the default voice.")
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentTertiary)
+            }
+        case "fish-audio":
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                VTextField(
+                    "Voice Reference ID",
+                    placeholder: "Fish Audio voice reference ID (optional)",
+                    text: $ttsVoiceIdText
+                )
+
+                Text("Leave blank to use the default voice.")
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentTertiary)
+            }
+        default:
+            // Generic providers do not have a voice ID field
+            EmptyView()
         }
     }
 
@@ -417,180 +491,83 @@ struct VoiceSettingsView: View {
         .pointerCursor()
     }
 
-    // MARK: - ElevenLabs Provider Config
+    // MARK: - TTS Save / Helpers
 
-    private var elevenLabsProviderConfig: some View {
-        Group {
-            if elevenLabsHasKey {
-                HStack(spacing: VSpacing.sm) {
-                    VButton(label: "Connected", leftIcon: VIcon.circleCheck.rawValue, style: .primary) {}
-                    VButton(label: "Disconnect", style: .danger) {
-                        store.clearElevenLabsKey()
-                        elevenLabsHasKey = false
-                        elevenLabsKeyText = ""
-                        ttsSetupExpanded = false
-                    }
-                }
+    /// Persists the TTS provider, API key, and voice ID atomically.
+    private func saveTTS() {
+        ttsSaving = true
+        ttsSaveError = nil
 
-                VStack(alignment: .leading, spacing: VSpacing.xs) {
-                    VTextField(
-                        "Voice ID",
-                        placeholder: "ElevenLabs Voice ID (optional)",
-                        text: $elevenLabsVoiceId,
-                        onSubmit: {
-                            store.setElevenLabsVoiceId(elevenLabsVoiceId)
-                        },
-                        maxWidth: 400
-                    )
+        // Persist provider if changed
+        if draftTTSProvider != ttsProviderRaw {
+            store.setTTSProvider(draftTTSProvider)
+            ttsProviderRaw = draftTTSProvider
+        }
 
-                    Text("Leave blank to use the default voice. Find voice IDs at elevenlabs.io/voice-library.")
-                        .font(VFont.labelDefault)
-                        .foregroundStyle(VColor.contentTertiary)
-                }
-            } else if ttsSetupExpanded {
-                VStack(alignment: .leading, spacing: VSpacing.sm) {
-                    VTextField(
-                        "ElevenLabs API Key",
-                        placeholder: "Your ElevenLabs API key",
-                        text: $elevenLabsKeyText,
-                        isSecure: true,
-                        maxWidth: 400
-                    )
-
-                    HStack(spacing: VSpacing.xs) {
-                        VIconView(.lock, size: 10)
-                            .foregroundStyle(VColor.contentTertiary)
-                        Text("Your API key is stored securely in the macOS Keychain.")
-                            .font(VFont.labelDefault)
-                            .foregroundStyle(VColor.contentTertiary)
-                    }
-
-                    HStack(spacing: VSpacing.sm) {
-                        VButton(label: "Connect", style: .outlined, isDisabled: elevenLabsKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty) {
-                            store.saveElevenLabsKey(elevenLabsKeyText)
-                            elevenLabsHasKey = true
-                            elevenLabsKeyText = ""
-                            ttsSetupExpanded = false
-                        }
-                        VButton(label: "Cancel", style: .outlined) {
-                            ttsSetupExpanded = false
-                            elevenLabsKeyText = ""
-                        }
-                    }
-                }
-            } else {
-                VButton(label: "Set Up", style: .outlined) {
-                    ttsSetupExpanded = true
-                }
+        // Persist voice ID for the selected provider
+        let trimmedVoiceId = ttsVoiceIdText.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmedVoiceId.isEmpty {
+            switch draftTTSProvider {
+            case "elevenlabs":
+                store.setElevenLabsVoiceId(trimmedVoiceId)
+            case "fish-audio":
+                store.setFishAudioReferenceId(trimmedVoiceId)
+            default:
+                break
             }
+        }
+
+        // Persist API key if entered
+        let trimmedKey = ttsApiKeyText.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmedKey.isEmpty {
+            switch draftTTSProvider {
+            case "elevenlabs":
+                store.saveElevenLabsKey(trimmedKey, onSuccess: {
+                    ttsApiKeyText = ""
+                    ttsProviderHasKey = true
+                    ttsSaving = false
+                })
+            case "fish-audio":
+                store.saveFishAudioKey(trimmedKey, onSuccess: {
+                    ttsApiKeyText = ""
+                    ttsProviderHasKey = true
+                    ttsSaving = false
+                })
+            default:
+                // For unknown providers, just clear and finish
+                ttsApiKeyText = ""
+                ttsSaving = false
+            }
+        } else {
+            ttsSaving = false
+        }
+
+        // Update baseline for change detection
+        initialTTSProvider = draftTTSProvider
+        ttsVoiceIdText = ""
+    }
+
+    /// Checks whether a TTS credential exists for the given provider.
+    private func ttsCredentialExists(for provider: String) -> Bool {
+        switch provider {
+        case "elevenlabs":
+            return APIKeyManager.getCredential(service: "elevenlabs", field: "api_key") != nil
+        case "fish-audio":
+            return APIKeyManager.getCredential(service: "fish-audio", field: "api_key") != nil
+        default:
+            return false
         }
     }
 
-    // MARK: - Fish Audio Provider Config
-
-    private var fishAudioProviderConfig: some View {
-        Group {
-            if fishAudioHasKey {
-                VStack(alignment: .leading, spacing: VSpacing.md) {
-                    HStack(spacing: VSpacing.sm) {
-                        VButton(label: "Connected", leftIcon: VIcon.circleCheck.rawValue, style: .primary) {}
-                        VButton(label: "Disconnect", style: .danger) {
-                            store.clearFishAudioKey()
-                            fishAudioHasKey = false
-                            fishAudioKeyText = ""
-                            fishAudioSetupExpanded = false
-                        }
-                    }
-
-                    VStack(alignment: .leading, spacing: VSpacing.xs) {
-                        VTextField(
-                            "Voice Reference ID",
-                            placeholder: "Fish Audio voice reference ID (optional)",
-                            text: $fishAudioReferenceId,
-                            onSubmit: {
-                                store.setFishAudioReferenceId(fishAudioReferenceId)
-                            },
-                            maxWidth: 400
-                        )
-
-                        Text("Find voice IDs at fish.audio. Leave blank if you've already configured one via the CLI.")
-                            .font(VFont.labelDefault)
-                            .foregroundStyle(VColor.contentTertiary)
-                    }
-                }
-            } else if fishAudioSetupExpanded {
-                VStack(alignment: .leading, spacing: VSpacing.sm) {
-                    VTextField(
-                        "Fish Audio API Key",
-                        placeholder: "Your Fish Audio API key",
-                        text: $fishAudioKeyText,
-                        isSecure: true,
-                        maxWidth: 400
-                    )
-
-                    HStack(spacing: VSpacing.xs) {
-                        VIconView(.lock, size: 10)
-                            .foregroundStyle(VColor.contentTertiary)
-                        Text("Your API key is stored securely in the macOS Keychain.")
-                            .font(VFont.labelDefault)
-                            .foregroundStyle(VColor.contentTertiary)
-                    }
-
-                    HStack(spacing: VSpacing.sm) {
-                        VButton(label: "Connect", style: .outlined, isDisabled: fishAudioKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty) {
-                            store.saveFishAudioKey(fishAudioKeyText)
-                            fishAudioHasKey = true
-                            fishAudioKeyText = ""
-                            fishAudioSetupExpanded = false
-                        }
-                        VButton(label: "Cancel", style: .outlined) {
-                            fishAudioSetupExpanded = false
-                            fishAudioKeyText = ""
-                        }
-                    }
-                }
-            } else {
-                VButton(label: "Set Up", style: .outlined) {
-                    fishAudioSetupExpanded = true
-                }
-            }
-        }
-    }
-
-    // MARK: - Generic Provider Config (Fallback)
-
-    /// Generic setup panel for providers added to the registry that do not
-    /// have bespoke UI. Shows the setup hint from the catalog metadata and
-    /// renders either an inline API key field or CLI instructions depending
-    /// on the provider's `setupMode`.
-    private func genericProviderConfig(for entry: TTSProviderCatalogEntry) -> some View {
-        VStack(alignment: .leading, spacing: VSpacing.md) {
-            Text(entry.setupHint)
-                .font(VFont.bodyMediumDefault)
-                .foregroundStyle(VColor.contentSecondary)
-
-            switch entry.setupMode {
-            case .apiKey:
-                Text("Configure this provider via the CLI:")
-                    .font(VFont.bodySmallDefault)
-                    .foregroundStyle(VColor.contentTertiary)
-
-                Text("assistant keys set \(entry.id) YOUR_KEY")
-                    .font(.system(size: 12, design: .monospaced))
-                    .foregroundStyle(VColor.contentSecondary)
-                    .padding(VSpacing.md)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .background(
-                        RoundedRectangle(cornerRadius: VRadius.md)
-                            .fill(VColor.surfaceBase)
-                    )
-                    .textSelection(.enabled)
-
-            case .cli:
-                Text("Follow your provider's documentation to complete setup via the CLI.")
-                    .font(VFont.bodySmallDefault)
-                    .foregroundStyle(VColor.contentTertiary)
-            }
+    /// Clears the stored TTS credential for the given provider.
+    private func clearTTSCredential(for provider: String) {
+        switch provider {
+        case "elevenlabs":
+            store.clearElevenLabsKey()
+        case "fish-audio":
+            store.clearFishAudioKey()
+        default:
+            break
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -51,11 +51,19 @@ struct VoiceSettingsView: View {
     @State private var recordingMonitors: [Any] = []
     @State private var modifierHoldTimer: Timer? = nil
 
-    // STT-specific state
-    @State private var sttOpenAIKeyText: String = ""
-    @State private var sttSetupExpanded: Bool = false
-    /// Whether an OpenAI API key is stored for STT (fetched per-component).
-    @State private var sttOpenAIHasKey = false
+    // STT draft-based state
+    /// Uncommitted provider selection — persisted only on Save.
+    @State private var draftSTTProvider: String = "openai-whisper"
+    /// API key input text (replaces the old Connect/Set Up flow).
+    @State private var sttApiKeyText: String = ""
+    /// Baseline provider for change detection — set on appear and after save.
+    @State private var initialSTTProvider: String = "openai-whisper"
+    /// Whether the current STT provider already has a stored API key.
+    @State private var sttProviderHasKey: Bool = false
+    /// Save-in-progress indicator.
+    @State private var sttSaving: Bool = false
+    /// Error message from key validation / save.
+    @State private var sttSaveError: String? = nil
 
     /// The shared TTS provider registry loaded from the bundled catalog.
     private let registry = loadTTSProviderRegistry()
@@ -65,10 +73,6 @@ struct VoiceSettingsView: View {
     /// if the value does not match any known entry (matching iOS behavior).
     private var selectedProvider: TTSProviderCatalogEntry? {
         registry.provider(withId: draftTTSProvider) ?? registry.providers.first
-    }
-
-    private var sttProvider: STTProviderOption {
-        STTProviderOption(rawValue: sttProviderRaw) ?? .openaiWhisper
     }
 
     private var currentActivator: PTTActivator {
@@ -108,8 +112,10 @@ struct VoiceSettingsView: View {
             initialTTSProvider = ttsProviderRaw
             ttsProviderHasKey = ttsCredentialExists(for: ttsProviderRaw)
 
-            // STT key check
-            sttOpenAIHasKey = APIKeyManager.getKey(for: "openai") != nil
+            // Initialize STT draft state from persisted values
+            draftSTTProvider = sttProviderRaw
+            initialSTTProvider = sttProviderRaw
+            sttProviderHasKey = APIKeyManager.getKey(for: "openai") != nil
         }
         .onChange(of: draftTTSProvider) { _, _ in
             // Clear API key and voice ID fields when provider changes
@@ -573,94 +579,91 @@ struct VoiceSettingsView: View {
 
     // MARK: - STT Provider Card
 
+    /// True when the user has made changes worth saving in the STT card.
+    private var sttHasChanges: Bool {
+        let providerChanged = draftSTTProvider != initialSTTProvider
+        let hasNewKey = !sttApiKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        return providerChanged || hasNewKey
+    }
+
     private var sttProviderCard: some View {
         SettingsCard(title: "Speech-to-Text", subtitle: "Choose an STT provider for audio transcription. The selected provider is used globally across all transcription features.") {
             VStack(alignment: .leading, spacing: VSpacing.md) {
-                // Provider selector
+                // Provider dropdown selector
                 VStack(alignment: .leading, spacing: VSpacing.sm) {
-                    Text("Provider:")
-                        .font(VFont.bodySmallDefault)
+                    Text("Provider")
+                        .font(VFont.labelDefault)
                         .foregroundStyle(VColor.contentSecondary)
-
-                    HStack(spacing: VSpacing.sm) {
-                        ForEach(STTProviderOption.allCases, id: \.rawValue) { provider in
-                            let isSelected = sttProvider == provider
-                            providerOption(label: provider.displayName, isSelected: isSelected) {
-                                sttProviderRaw = provider.rawValue
-                                store.setSTTProvider(provider.rawValue)
-                            }
+                    VDropdown(
+                        placeholder: "Select a provider\u{2026}",
+                        selection: $draftSTTProvider,
+                        options: STTProviderOption.allCases.map { provider in
+                            (label: provider.displayName, value: provider.rawValue)
                         }
+                    )
+                }
+
+                // API key field
+                VTextField(
+                    "OpenAI API Key",
+                    placeholder: sttProviderHasKey ? "\u{2022}\u{2022}\u{2022}\u{2022}\u{2022}\u{2022}\u{2022}\u{2022}\u{2022}\u{2022}\u{2022}\u{2022}" : "Your OpenAI API key",
+                    text: $sttApiKeyText,
+                    isSecure: true,
+                    errorMessage: sttSaveError,
+                    maxWidth: 400
+                )
+
+                // Informational note about shared key
+                if sttProviderHasKey {
+                    HStack(alignment: .top, spacing: VSpacing.xs) {
+                        VIconView(.info, size: 10)
+                            .foregroundStyle(VColor.contentTertiary)
+                        Text("The OpenAI key is shared with inference. Use inference settings to manage it.")
+                            .font(VFont.labelDefault)
+                            .foregroundStyle(VColor.contentTertiary)
+                    }
+                } else {
+                    HStack(spacing: VSpacing.xs) {
+                        VIconView(.lock, size: 10)
+                            .foregroundStyle(VColor.contentTertiary)
+                        Text("This API key is shared with inference settings.")
+                            .font(VFont.labelDefault)
+                            .foregroundStyle(VColor.contentTertiary)
                     }
                 }
 
-                // Provider-specific subtitle
-                Text(sttProvider.subtitle)
-                    .font(VFont.bodySmallDefault)
-                    .foregroundStyle(VColor.contentTertiary)
-
-                // Provider-specific configuration
-                switch sttProvider {
-                case .openaiWhisper:
-                    openaiWhisperProviderConfig
-                }
+                // Save action — no Reset for STT since the key is shared with inference
+                ServiceCardActions(
+                    hasChanges: sttHasChanges,
+                    isSaving: sttSaving,
+                    onSave: { saveSTT() }
+                )
             }
         }
     }
 
-    // MARK: - OpenAI Whisper Provider Config
+    // MARK: - STT Save
 
-    private var openaiWhisperProviderConfig: some View {
-        Group {
-            if sttOpenAIHasKey {
-                // The OpenAI key is shared with the inference provider.
-                // Show a read-only "Connected" indicator without a
-                // "Disconnect" button — deleting the shared credential
-                // from the STT card would break inference.
-                VButton(label: "Connected", leftIcon: VIcon.circleCheck.rawValue, style: .primary) {}
+    private func saveSTT() {
+        sttSaving = true
+        sttSaveError = nil
 
-                HStack(spacing: VSpacing.xs) {
-                    VIconView(.info, size: 10)
-                        .foregroundStyle(VColor.contentTertiary)
-                    Text("Using your OpenAI API key from inference settings.")
-                        .font(VFont.labelDefault)
-                        .foregroundStyle(VColor.contentTertiary)
-                }
-            } else if sttSetupExpanded {
-                VStack(alignment: .leading, spacing: VSpacing.sm) {
-                    VTextField(
-                        "OpenAI API Key",
-                        placeholder: "Your OpenAI API key",
-                        text: $sttOpenAIKeyText,
-                        isSecure: true,
-                        maxWidth: 400
-                    )
+        // Persist provider change if needed
+        if draftSTTProvider != sttProviderRaw {
+            store.setSTTProvider(draftSTTProvider)
+            sttProviderRaw = draftSTTProvider
+        }
 
-                    HStack(spacing: VSpacing.xs) {
-                        VIconView(.lock, size: 10)
-                            .foregroundStyle(VColor.contentTertiary)
-                        Text("Your API key is stored securely in the macOS Keychain and shared with inference.")
-                            .font(VFont.labelDefault)
-                            .foregroundStyle(VColor.contentTertiary)
-                    }
-
-                    HStack(spacing: VSpacing.sm) {
-                        VButton(label: "Connect", style: .outlined, isDisabled: sttOpenAIKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty) {
-                            store.saveSTTOpenAIKey(sttOpenAIKeyText)
-                            sttOpenAIHasKey = true
-                            sttOpenAIKeyText = ""
-                            sttSetupExpanded = false
-                        }
-                        VButton(label: "Cancel", style: .outlined) {
-                            sttSetupExpanded = false
-                            sttOpenAIKeyText = ""
-                        }
-                    }
-                }
-            } else {
-                VButton(label: "Set Up", style: .outlined) {
-                    sttSetupExpanded = true
-                }
+        // Persist API key if provided
+        let trimmedKey = sttApiKeyText.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmedKey.isEmpty {
+            store.saveSTTOpenAIKey(trimmedKey) {
+                sttProviderHasKey = true
+                sttApiKeyText = ""
             }
         }
+
+        initialSTTProvider = draftSTTProvider
+        sttSaving = false
     }
 }


### PR DESCRIPTION
## Summary
Redesign the macOS Text-to-Speech and Speech-to-Text settings cards to use the same dropdown + text field + Save button pattern as the Inference "Your Own" tab, replacing the old radio-button + Connect/Disconnect flow. Creates a consistent settings UX across all service cards.

## Self-review result
GAPS FOUND — 3 gaps fixed in 1 fix PR (ttsSaving stuck on failure, STT subtitle missing, missing onChange handler)

## PRs merged into feature branch
- #24990: Redesign TTS settings card to use dropdown + text field + Save pattern
- #24989: Redesign STT settings card to use dropdown + text field + Save pattern
- #24997: Remove unused radio button code and STTProviderOption enum from voice settings

### Fix PRs
- #25000: fix: address review gaps in TTS/STT settings redesign

Part of plan: tts-stt-ui-redesign.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25002" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
