### PR TITLE
fix: clear API key text optimistically in TTS/STT save methods

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -490,23 +490,20 @@ struct VoiceSettingsView: View {
             }
         }
 
-        // Persist API key if entered
+        // Persist API key if entered. Clear the field and update hasKey
+        // optimistically so the UI reflects the save immediately; the
+        // async daemon sync validates the key in the background.
         let trimmedKey = ttsApiKeyText.trimmingCharacters(in: .whitespacesAndNewlines)
         if !trimmedKey.isEmpty {
+            ttsApiKeyText = ""
+            ttsProviderHasKey = true
             switch draftTTSProvider {
             case "elevenlabs":
-                store.saveElevenLabsKey(trimmedKey, onSuccess: {
-                    ttsApiKeyText = ""
-                    ttsProviderHasKey = true
-                })
+                store.saveElevenLabsKey(trimmedKey)
             case "fish-audio":
-                store.saveFishAudioKey(trimmedKey, onSuccess: {
-                    ttsApiKeyText = ""
-                    ttsProviderHasKey = true
-                })
+                store.saveFishAudioKey(trimmedKey)
             default:
-                // For unknown providers, just clear the field
-                ttsApiKeyText = ""
+                break
             }
         }
 
@@ -623,13 +620,13 @@ struct VoiceSettingsView: View {
             sttProviderRaw = draftSTTProvider
         }
 
-        // Persist API key if provided
+        // Persist API key if provided. Clear the field and update hasKey
+        // optimistically so the UI reflects the save immediately.
         let trimmedKey = sttApiKeyText.trimmingCharacters(in: .whitespacesAndNewlines)
         if !trimmedKey.isEmpty {
-            store.saveSTTOpenAIKey(trimmedKey) {
-                sttProviderHasKey = true
-                sttApiKeyText = ""
-            }
+            sttApiKeyText = ""
+            sttProviderHasKey = true
+            store.saveSTTOpenAIKey(trimmedKey)
         }
 
         initialSTTProvider = draftSTTProvider


### PR DESCRIPTION
## Summary
- Clear ttsApiKeyText/sttApiKeyText and set providerHasKey optimistically (synchronously) in saveTTS()/saveSTT() so the UI updates immediately
- Previously, these were only cleared in the async onSuccess callback, causing ttsHasChanges to remain true after save (Save button re-enabled with stale state)
- Matches the old pre-refactor behavior where state was updated synchronously

Fixes integration review gap from tts-stt-ui-redesign.md plan.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25003" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
