### PR TITLE
fix: use explicit little-endian PCM encoding in all audio capture paths

### DIFF
--- a/clients/ios/Views/InputBarView.swift
+++ b/clients/ios/Views/InputBarView.swift
@@ -426,7 +426,7 @@ struct InputBarView: View {
                             let int16Buffer = rawBuffer.bindMemory(to: Int16.self)
                             for i in 0..<frameCount {
                                 let clamped = max(-1.0, min(1.0, floatData[0][i]))
-                                int16Buffer[i] = Int16(clamped * Float(Int16.max))
+                                int16Buffer[i] = Int16(clamped * Float(Int16.max)).littleEndian
                             }
                         }
                         Task { @MainActor in

--- a/clients/macos/vellum-assistant/Features/Voice/OpenAIVoiceService.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/OpenAIVoiceService.swift
@@ -248,8 +248,8 @@ final class OpenAIVoiceService: VoiceServiceProtocol {
             var pcmChunk = Data(capacity: frameCount * MemoryLayout<Int16>.size)
             for i in 0..<frameCount {
                 let clamped = max(-1.0, min(1.0, floatData[0][i]))
-                var sample = Int16(clamped * Float(Int16.max))
-                withUnsafeBytes(of: &sample) { pcmChunk.append(contentsOf: $0) }
+                let sample = Int16(clamped * Float(Int16.max))
+                withUnsafeBytes(of: sample.littleEndian) { pcmChunk.append(contentsOf: $0) }
             }
 
             // Compute RMS for amplitude display and silence detection


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for service-first-stt-dictation-streaming.md.

**Gap:** PCM encoding endianness inconsistency
**What was expected:** All audio capture paths use explicit little-endian as WAV requires
**What was found:** OpenAIVoiceService and InputBarView used native byte order
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25005" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
