### PR TITLE
fix: always persist TTS voice ID on save, even when empty

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -477,17 +477,17 @@ struct VoiceSettingsView: View {
             ttsProviderRaw = draftTTSProvider
         }
 
-        // Persist voice ID for the selected provider
+        // Always persist voice ID for the selected provider, even when
+        // empty — sending an empty string clears a previously set voice
+        // ID and reverts to the provider's default voice.
         let trimmedVoiceId = ttsVoiceIdText.trimmingCharacters(in: .whitespacesAndNewlines)
-        if !trimmedVoiceId.isEmpty {
-            switch draftTTSProvider {
-            case "elevenlabs":
-                store.setElevenLabsVoiceId(trimmedVoiceId)
-            case "fish-audio":
-                store.setFishAudioReferenceId(trimmedVoiceId)
-            default:
-                break
-            }
+        switch draftTTSProvider {
+        case "elevenlabs":
+            store.setElevenLabsVoiceId(trimmedVoiceId)
+        case "fish-audio":
+            store.setFishAudioReferenceId(trimmedVoiceId)
+        default:
+            break
         }
 
         // Persist API key if entered. Clear the field and update hasKey


### PR DESCRIPTION
## Summary
- Remove the `!trimmedVoiceId.isEmpty` guard in `saveTTS()` so that saving with a blank voice ID field sends an empty string to the daemon config
- This allows users to clear a previously-set custom voice/reference ID and revert to the provider's default voice
- Addresses review feedback: https://github.com/vellum-ai/vellum-assistant/pull/25002#discussion_r3070022447
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25006" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
