### PR TITLE
fix: consolidate duplicate MockSTTClient into shared test mock

### DIFF
--- a/clients/macos/vellum-assistantTests/MockVoiceService.swift
+++ b/clients/macos/vellum-assistantTests/MockVoiceService.swift
@@ -7,13 +7,18 @@ import Foundation
 /// service-success and fallback-to-local paths.
 final class MockSTTClient: STTClientProtocol, @unchecked Sendable {
     /// The result to return from ``transcribe(audioData:contentType:)``.
-    var resultToReturn: STTResult = .notConfigured
+    /// Defaults to `.notConfigured` so tests that don't care about STT
+    /// get native fallback behavior.
+    var stubbedResult: STTResult = .notConfigured
     /// Number of times ``transcribe`` was called.
     private(set) var transcribeCallCount = 0
+    /// The most recent audio data passed to ``transcribe``.
+    private(set) var lastAudioData: Data?
 
     func transcribe(audioData: Data, contentType: String) async -> STTResult {
         transcribeCallCount += 1
-        return resultToReturn
+        lastAudioData = audioData
+        return stubbedResult
     }
 }
 

--- a/clients/macos/vellum-assistantTests/VoiceInputManagerTests.swift
+++ b/clients/macos/vellum-assistantTests/VoiceInputManagerTests.swift
@@ -4,22 +4,6 @@ import AVFoundation
 import VellumAssistantShared
 @testable import VellumAssistantLib
 
-/// A controllable mock of `STTClientProtocol` for testing service-first
-/// transcription resolution without making network requests.
-private final class MockSTTClient: STTClientProtocol, @unchecked Sendable {
-    /// The result to return from `transcribe`. Defaults to `.notConfigured`
-    /// so tests that don't care about STT get native fallback behavior.
-    var stubbedResult: STTResult = .notConfigured
-    var transcribeCallCount = 0
-    var lastAudioData: Data?
-
-    func transcribe(audioData: Data, contentType: String) async -> STTResult {
-        transcribeCallCount += 1
-        lastAudioData = audioData
-        return stubbedResult
-    }
-}
-
 @MainActor
 private final class MockDictationClient: DictationClientProtocol {
     var sentRequests: [DictationRequest] = []


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for service-first-stt-dictation-streaming.md.

**Gap:** Duplicate MockSTTClient in macOS test target
**What was expected:** Single shared mock with consistent API
**What was found:** Two divergent MockSTTClient implementations in different test files
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25007" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
