### PR TITLE
fix: STTClient sends JSON with base64-encoded audio to match server contract

### DIFF
--- a/clients/shared/Network/STTClient.swift
+++ b/clients/shared/Network/STTClient.swift
@@ -48,10 +48,10 @@ public struct STTClient: STTClientProtocol {
     public func transcribe(audioData: Data, contentType: String = "audio/wav") async -> STTResult {
         let start = CFAbsoluteTimeGetCurrent()
         do {
+            let json = Self.buildRequestBody(audioData: audioData, contentType: contentType)
             let response = try await GatewayHTTPClient.post(
                 path: "assistants/{assistantId}/stt/transcribe",
-                body: audioData,
-                contentType: contentType,
+                json: json,
                 timeout: Self.requestTimeout
             )
             let elapsed = CFAbsoluteTimeGetCurrent() - start
@@ -61,6 +61,19 @@ public struct STTClient: STTClientProtocol {
             log.error("STT request error after \(String(format: "%.1f", elapsed))s: \(error.localizedDescription)")
             return .error(statusCode: nil, message: error.localizedDescription)
         }
+    }
+
+    // MARK: - Request Body Construction
+
+    /// Builds the JSON request body for the STT transcribe endpoint.
+    ///
+    /// The server expects a JSON object with `audioBase64` (base64-encoded audio)
+    /// and `mimeType` (MIME type string). Internal visibility for testability.
+    static func buildRequestBody(audioData: Data, contentType: String) -> [String: Any] {
+        return [
+            "audioBase64": audioData.base64EncodedString(),
+            "mimeType": contentType,
+        ]
     }
 
     // MARK: - Response Mapping

--- a/clients/shared/Tests/STTClientTests.swift
+++ b/clients/shared/Tests/STTClientTests.swift
@@ -145,4 +145,44 @@ final class STTClientTests: XCTestCase {
             XCTFail("Expected .error, got \(result)")
         }
     }
+
+    // MARK: - Request Body Format
+
+    func testBuildRequestBodyContainsBase64EncodedAudio() {
+        let audioData = Data([0x52, 0x49, 0x46, 0x46]) // "RIFF" header bytes
+        let body = STTClient.buildRequestBody(audioData: audioData, contentType: "audio/wav")
+
+        let audioBase64 = body["audioBase64"] as? String
+        XCTAssertNotNil(audioBase64, "Body must contain audioBase64 string")
+        XCTAssertEqual(audioBase64, audioData.base64EncodedString())
+    }
+
+    func testBuildRequestBodyContainsMimeType() {
+        let audioData = Data([0x01, 0x02])
+        let body = STTClient.buildRequestBody(audioData: audioData, contentType: "audio/ogg")
+
+        let mimeType = body["mimeType"] as? String
+        XCTAssertEqual(mimeType, "audio/ogg")
+    }
+
+    func testBuildRequestBodyHasExactlyTwoKeys() {
+        let audioData = Data([0x01])
+        let body = STTClient.buildRequestBody(audioData: audioData, contentType: "audio/wav")
+
+        XCTAssertEqual(body.count, 2, "Request body should have exactly audioBase64 and mimeType keys")
+        XCTAssertNotNil(body["audioBase64"])
+        XCTAssertNotNil(body["mimeType"])
+    }
+
+    func testBuildRequestBodyIsValidJSON() throws {
+        let audioData = "Hello audio".data(using: .utf8)!
+        let body = STTClient.buildRequestBody(audioData: audioData, contentType: "audio/wav")
+
+        // Verify the dictionary can be serialized to valid JSON
+        let jsonData = try JSONSerialization.data(withJSONObject: body)
+        let decoded = try JSONSerialization.jsonObject(with: jsonData) as? [String: Any]
+        XCTAssertNotNil(decoded)
+        XCTAssertEqual(decoded?["audioBase64"] as? String, audioData.base64EncodedString())
+        XCTAssertEqual(decoded?["mimeType"] as? String, "audio/wav")
+    }
 }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for service-first-stt-dictation-streaming.md.

**Gap:** STT payload format mismatch
**What was expected:** Client sends JSON with audioBase64 and mimeType fields
**What was found:** Client was sending raw WAV bytes with Content-Type: audio/wav
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25008" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
