### PR TITLE
fix: return untrimmed service text from OpenAIVoiceService for consistency

### DIFF
--- a/clients/macos/vellum-assistant/Features/Voice/OpenAIVoiceService.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/OpenAIVoiceService.swift
@@ -390,7 +390,7 @@ final class OpenAIVoiceService: VoiceServiceProtocol {
                 return nil
             }
             log.info("STT service: transcription succeeded (\(trimmed.count) chars)")
-            return trimmed
+            return text
         case .notConfigured:
             log.info("STT service: not configured, falling back to local recognizer")
             return nil


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for service-first-stt-dictation-streaming.md.

**Gap:** Inconsistent text trimming across STT flows
**What was expected:** All flows handle service text consistently
**What was found:** OpenAIVoiceService returned trimmed text while other flows returned untrimmed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25009" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
