### PR TITLE
Service-first STT across dictation and voice streaming

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -584,15 +584,16 @@ All guardian decisions for voice access requests flow through:
 
 ### Speech-to-Text (STT) Boundaries
 
-Audio-to-text conversion occurs in three distinct runtime boundaries, each with its own provider model and adapter layer. There is no global STT provider switch — each boundary resolves its provider independently based on its runtime context and available credentials.
+Audio-to-text conversion occurs in four distinct runtime boundaries, each with its own provider model and adapter layer. The `services.stt` config block controls provider selection for the daemon's STT service; other boundaries resolve providers independently based on their runtime context.
 
 **Boundary overview:**
 
-| Boundary             | Runtime                               | Provider (current)                  | Adapter module                                                                                     | Caller                                                  |
-| -------------------- | ------------------------------------- | ----------------------------------- | -------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
-| **Telephony-native** | Twilio ConversationRelay              | Deepgram or Google (config-driven)  | `src/calls/stt-profile.ts`                                                                         | `src/calls/twilio-routes.ts`                            |
-| **Daemon batch**     | Daemon process (REST API to provider) | OpenAI Whisper                      | `src/stt/daemon-batch-transcriber.ts`                                                              | `src/runtime/routes/inbound-stages/transcribe-audio.ts` |
-| **Client-native**    | macOS / iOS on-device                 | Apple Speech (`SFSpeechRecognizer`) | `clients/macos/.../SpeechRecognizerAdapter.swift`, `clients/ios/.../SpeechRecognizerAdapter.swift` | `VoiceInputManager` (macOS), `InputBarView` (iOS)       |
+| Boundary                     | Runtime                               | Provider (current)                           | Adapter module                                                                                     | Caller                                                                                               |
+| ---------------------------- | ------------------------------------- | -------------------------------------------- | -------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| **Telephony-native**         | Twilio ConversationRelay              | Deepgram or Google (config-driven)           | `src/calls/stt-profile.ts`                                                                         | `src/calls/twilio-routes.ts`                                                                         |
+| **Daemon batch**             | Daemon process (REST API to provider) | OpenAI Whisper                               | `src/stt/daemon-batch-transcriber.ts`                                                              | `src/runtime/routes/inbound-stages/transcribe-audio.ts`                                              |
+| **Client service-first**     | macOS / iOS via gateway → daemon      | Configured STT provider (via `services.stt`) | `src/runtime/routes/stt-routes.ts`, `clients/shared/Network/STTClient.swift`                       | `VoiceInputManager` (macOS dictation), `InputBarView` (iOS), `OpenAIVoiceService` (macOS voice mode) |
+| **Client-native (fallback)** | macOS / iOS on-device                 | Apple Speech (`SFSpeechRecognizer`)          | `clients/macos/.../SpeechRecognizerAdapter.swift`, `clients/ios/.../SpeechRecognizerAdapter.swift` | Fallback when STT service is unconfigured or fails                                                   |
 
 **Telephony-native boundary:**
 
@@ -615,9 +616,25 @@ The daemon transcribes audio attachments (e.g. voice messages from channel inbou
 
 To add a new daemon batch STT provider: add a new `SttProviderId` variant in `types.ts`, implement `BatchTranscriber` in a new adapter class alongside `WhisperBatchTranscriber`, and update the factory in `daemon-batch-transcriber.ts` to select the adapter based on configuration or credential availability.
 
-**Client-native boundary:**
+**Client service-first boundary:**
 
-On macOS and iOS, speech recognition runs on-device via Apple's Speech framework (`SFSpeechRecognizer`). The daemon never receives raw microphone audio from clients — it receives the final transcribed text. The `SpeechRecognizerAdapter` protocols on each platform abstract Apple Speech for **testability and dependency injection**, not for provider-agnostic pluggability. The two platform adapters have intentionally different API shapes reflecting their different UI integration patterns.
+All product-facing dictation and voice-streaming paths on macOS and iOS use a service-first STT strategy. Clients record audio, encode it to WAV via `AudioWavEncoder` (shared utility in `clients/shared/Utilities/AudioWavEncoder.swift`), and POST it through the gateway to the daemon's `POST /v1/stt/transcribe` endpoint via `STTClient` (`clients/shared/Network/STTClient.swift`). The daemon resolves the configured STT provider through `resolveBatchTranscriber()` and returns the transcribed text.
+
+- `STTClient` conforms to `STTClientProtocol` and returns a typed `STTResult` enum (`success`, `notConfigured`, `serviceUnavailable`, `error`). Callers pattern-match on the result to deterministically trigger native fallback.
+- The gateway proxies the request via assistant-scoped path rewriting: `/v1/assistants/:id/stt/transcribe` is rewritten to `/v1/stt/transcribe` on the daemon.
+- `stt-routes.ts` (`src/runtime/routes/stt-routes.ts`) defines the HTTP endpoint, validates the audio payload, and delegates to `resolveBatchTranscriber()`.
+
+Product-facing flows using service-first STT:
+
+| Flow                       | Client | Entry point                                                                                                                                                                                         |
+| -------------------------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Push-to-talk dictation** | macOS  | `VoiceInputManager.resolveTranscription()` — encodes accumulated PCM buffers to WAV, calls `sttClient.transcribe()`, falls back to native text on failure                                           |
+| **Input bar dictation**    | iOS    | `InputBarView.resolveTranscriptWithServiceFirst()` — encodes captured audio buffers to WAV, calls `sttClient.transcribe()`, falls back to native transcript on failure                              |
+| **Voice mode (streaming)** | macOS  | `OpenAIVoiceService.stopRecordingAndGetTranscription()` — encodes per-turn PCM to WAV, calls `sttClient.transcribe()` for turn-final transcript resolution, falls back to SFSpeechRecognizer result |
+
+**Client-native fallback boundary:**
+
+Apple-native on-device recognition via `SFSpeechRecognizer` serves two roles in all three product-facing flows above: (1) it provides low-latency partial transcriptions for real-time display during recording, and (2) it provides the fallback final transcription when the STT service is unconfigured (HTTP 503), temporarily unavailable (HTTP 5xx), or returns an empty result. The `SpeechRecognizerAdapter` protocols on each platform abstract Apple Speech for **testability and dependency injection**.
 
 - macOS: `SpeechRecognizerAdapter` protocol in `clients/macos/vellum-assistant/Features/Voice/SpeechRecognizerAdapter.swift` abstracts `SFSpeechRecognizer` static APIs and instance creation. `AppleSpeechRecognizerAdapter` is the production implementation. `OpenAIVoiceService` and `VoiceInputManager` consume the adapter via dependency injection. **Note:** The macOS protocol leaks Apple Speech types through its surface — `authorizationStatus()` returns `SFSpeechRecognizerAuthorizationStatus` and `makeRecognizer(locale:)` returns `SFSpeechRecognizer?` directly. This means callers depend on the Speech framework at compile time.
 - iOS: `SpeechRecognizerAdapter` protocol in `clients/ios/Services/SpeechRecognizerAdapter.swift` covers authorization, availability, and task construction. `AppleSpeechRecognizerAdapter` is the production implementation. `InputBarView` consumes the adapter. **Note:** The iOS protocol defines its own framework-agnostic types (`SpeechRecognizerAuthorizationStatus`, `SpeechRecognitionResult`) so callers never see `SFSpeechRecognizer` directly. However, `startRecognitionTask` still returns `SFSpeechAudioBufferRecognitionRequest` in its tuple, so full framework decoupling is not yet achieved.
@@ -628,11 +645,11 @@ Platform divergence summary:
 - **Recognizer exposure:** macOS exposes the raw `SFSpeechRecognizer?` via `makeRecognizer(locale:)`; iOS fully encapsulates recognizer construction inside `startRecognitionTask`.
 - **Concurrency model:** The iOS protocol is `@MainActor`-annotated; the macOS protocol is not.
 
-These differences are intentional — the adapters were designed for their respective platform integration needs, not for cross-platform uniformity. Adding a non-Apple STT provider (e.g., a third-party on-device engine) would require refactoring both protocols to remove Apple Speech types from their public surfaces and converging on a shared provider-agnostic interface. The current adapters are suitable for swapping in test doubles for Apple Speech, but not for swapping in an entirely different speech engine without protocol changes.
+These differences are intentional — the adapters were designed for their respective platform integration needs, not for cross-platform uniformity.
 
 **Cross-boundary notes:**
 
-- No global STT provider configuration exists. Each boundary resolves its provider independently. A future phase may introduce a unified config surface, but it is not part of the current architecture.
+- The `services.stt` config block controls provider selection for both the daemon batch boundary and the client service-first boundary (they share `resolveBatchTranscriber()`). Telephony STT is configured separately via `calls.voice.transcriptionProvider`.
 - Terminology: "STT" and "transcription" refer to the same operation (converting audio to text). "Speech recognition" is used in client-native contexts where Apple's Speech framework terminology is canonical. All three terms map to the same conceptual operation.
 
 ### Update Bulletin System

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -7377,6 +7377,38 @@ paths:
       responses:
         "200":
           description: Successful response
+  /v1/stt/transcribe:
+    post:
+      operationId: stt_transcribe_post
+      summary: Transcribe audio to text
+      description:
+        Transcribe base64-encoded audio to text using the configured STT provider. Provider selection is resolved
+        globally via config.
+      tags:
+        - stt
+      responses:
+        "200":
+          description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                audioBase64:
+                  type: string
+                  description: Base64-encoded audio data to transcribe
+                mimeType:
+                  type: string
+                  description: MIME type of the audio data (must start with "audio/", e.g. "audio/wav", "audio/ogg")
+                source:
+                  description: Optional source identifier for analytics (e.g. 'dictation', 'voice-mode')
+                  type: string
+              required:
+                - audioBase64
+                - mimeType
+              additionalProperties: false
   /v1/subagents/{id}:
     get:
       operationId: subagents_by_id_get

--- a/assistant/src/runtime/auth/__tests__/route-policy.test.ts
+++ b/assistant/src/runtime/auth/__tests__/route-policy.test.ts
@@ -182,4 +182,44 @@ describe("enforcePolicy", () => {
     expect(policy).toBeDefined();
     expect(policy!.requiredScopes).toContain("chat.read");
   });
+
+  // -- STT transcribe policy ------------------------------------------------
+
+  test("stt/transcribe is registered as a protected endpoint", () => {
+    authDisabled = false;
+    const policy = getPolicy("stt/transcribe");
+    expect(policy).toBeDefined();
+  });
+
+  test("stt/transcribe requires chat.write scope", () => {
+    authDisabled = false;
+    const policy = getPolicy("stt/transcribe");
+    expect(policy).toBeDefined();
+    expect(policy!.requiredScopes).toContain("chat.write");
+  });
+
+  test("stt/transcribe allows actor, svc_gateway, svc_daemon, and local principals", () => {
+    authDisabled = false;
+    const policy = getPolicy("stt/transcribe");
+    expect(policy).toBeDefined();
+    expect(policy!.allowedPrincipalTypes).toContain("actor");
+    expect(policy!.allowedPrincipalTypes).toContain("svc_gateway");
+    expect(policy!.allowedPrincipalTypes).toContain("svc_daemon");
+    expect(policy!.allowedPrincipalTypes).toContain("local");
+  });
+
+  test("stt/transcribe denies actor without chat.write scope", () => {
+    authDisabled = false;
+    const ctx = buildTestContext({ scopes: ["chat.read"] });
+    const result = enforcePolicy("stt/transcribe", ctx);
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe(403);
+  });
+
+  test("stt/transcribe allows actor with chat.write scope", () => {
+    authDisabled = false;
+    const ctx = buildTestContext({ scopes: ["chat.write"] });
+    const result = enforcePolicy("stt/transcribe", ctx);
+    expect(result).toBeNull();
+  });
 });

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -465,6 +465,9 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   // Dictation
   { endpoint: "dictation", scopes: ["chat.write"] },
 
+  // Speech-to-text
+  { endpoint: "stt/transcribe", scopes: ["chat.write"] },
+
   // OAuth / integrations
   { endpoint: "oauth/start", scopes: ["settings.write"] },
   { endpoint: "integrations/oauth/start", scopes: ["settings.write"] }, // legacy alias

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -199,6 +199,7 @@ import { scheduleRouteDefinitions } from "./routes/schedule-routes.js";
 import { secretRouteDefinitions } from "./routes/secret-routes.js";
 import { settingsRouteDefinitions } from "./routes/settings-routes.js";
 import { skillRouteDefinitions } from "./routes/skills-routes.js";
+import { sttRouteDefinitions } from "./routes/stt-routes.js";
 import { subagentRouteDefinitions } from "./routes/subagents-routes.js";
 import { surfaceActionRouteDefinitions } from "./routes/surface-action-routes.js";
 import { surfaceContentRouteDefinitions } from "./routes/surface-content-routes.js";
@@ -1380,6 +1381,7 @@ export class RuntimeHttpServer {
           : undefined,
       }),
       ...ttsRouteDefinitions(),
+      ...sttRouteDefinitions(),
 
       // Conversation list and seen signal — kept inline because they
       // depend on multiple cross-cutting stores that aren't grouped

--- a/assistant/src/runtime/routes/__tests__/stt-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/stt-routes.test.ts
@@ -1,0 +1,406 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Module mocks — must appear before any imports of the modules under test
+// ---------------------------------------------------------------------------
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// -- Transcriber mock -------------------------------------------------------
+
+import type { BatchTranscriber } from "../../../stt/types.js";
+import { SttError } from "../../../stt/types.js";
+
+let mockTranscriber: BatchTranscriber | null = null;
+let mockResolveError: Error | null = null;
+
+mock.module("../../../providers/speech-to-text/resolve.js", () => ({
+  resolveBatchTranscriber: async () => {
+    if (mockResolveError) throw mockResolveError;
+    return mockTranscriber;
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Import under test — after mocks
+// ---------------------------------------------------------------------------
+
+import type { RouteContext } from "../../http-router.js";
+import { sttRouteDefinitions } from "../stt-routes.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function getTranscribeHandler() {
+  const routes = sttRouteDefinitions();
+  return routes[0].handler;
+}
+
+function makeRouteContext(body: unknown): RouteContext {
+  const url = new URL("http://localhost/v1/stt/transcribe");
+  return {
+    req: new Request(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: typeof body === "string" ? body : JSON.stringify(body),
+    }),
+    url,
+    server: {} as RouteContext["server"],
+    authContext: {
+      subject: "test-user",
+      principalType: "local",
+      assistantId: "self",
+      scopeProfile: "local_v1",
+      scopes: new Set(["local.all" as const]),
+      policyEpoch: 0,
+    },
+    params: {},
+  } as unknown as RouteContext;
+}
+
+function makeInvalidJsonContext(): RouteContext {
+  const url = new URL("http://localhost/v1/stt/transcribe");
+  return {
+    req: new Request(url, {
+      method: "POST",
+      body: "not-json",
+    }),
+    url,
+    server: {} as RouteContext["server"],
+    authContext: {
+      subject: "test-user",
+      principalType: "local",
+      assistantId: "self",
+      scopeProfile: "local_v1",
+      scopes: new Set(["local.all" as const]),
+      policyEpoch: 0,
+    },
+    params: {},
+  } as unknown as RouteContext;
+}
+
+async function readErrorBody(
+  response: Response,
+): Promise<{ error: { code: string; message: string } }> {
+  return response.json();
+}
+
+/** Encode a string to base64 to simulate valid audio data. */
+function toBase64(data: string): string {
+  return Buffer.from(data).toString("base64");
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+const fakeTranscriber: BatchTranscriber = {
+  providerId: "openai-whisper",
+  boundaryId: "daemon-batch",
+  transcribe: async () => ({ text: "hello world" }),
+};
+
+beforeEach(() => {
+  mockTranscriber = fakeTranscriber;
+  mockResolveError = null;
+});
+
+afterEach(() => {
+  // Reset to defaults
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("stt-routes", () => {
+  // -- Route metadata -------------------------------------------------------
+
+  test("exports a route definition for stt/transcribe", () => {
+    const routes = sttRouteDefinitions();
+    expect(routes).toHaveLength(1);
+    expect(routes[0].endpoint).toBe("stt/transcribe");
+    expect(routes[0].method).toBe("POST");
+    expect(routes[0].policyKey).toBe("stt/transcribe");
+  });
+
+  // -- Success path ---------------------------------------------------------
+
+  test("returns transcribed text with provider and boundary ids", async () => {
+    const handler = getTranscribeHandler();
+    const res = await handler(
+      makeRouteContext({
+        audioBase64: toBase64("fake-audio-data"),
+        mimeType: "audio/wav",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      text: string;
+      providerId: string;
+      boundaryId: string;
+    };
+    expect(body.text).toBe("hello world");
+    expect(body.providerId).toBe("openai-whisper");
+    expect(body.boundaryId).toBe("daemon-batch");
+  });
+
+  test("accepts optional source parameter", async () => {
+    const handler = getTranscribeHandler();
+    const res = await handler(
+      makeRouteContext({
+        audioBase64: toBase64("fake-audio-data"),
+        mimeType: "audio/wav",
+        source: "dictation",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+  });
+
+  // -- Malformed body -------------------------------------------------------
+
+  test("returns 400 for invalid JSON body", async () => {
+    const handler = getTranscribeHandler();
+    const res = await handler(makeInvalidJsonContext());
+
+    expect(res.status).toBe(400);
+    const body = await readErrorBody(res);
+    expect(body.error.code).toBe("BAD_REQUEST");
+    expect(body.error.message).toContain("Invalid JSON");
+  });
+
+  test("returns 400 when audioBase64 is missing", async () => {
+    const handler = getTranscribeHandler();
+    const res = await handler(makeRouteContext({ mimeType: "audio/wav" }));
+
+    expect(res.status).toBe(400);
+    const body = await readErrorBody(res);
+    expect(body.error.code).toBe("BAD_REQUEST");
+    expect(body.error.message).toContain("audioBase64");
+  });
+
+  test("returns 400 when audioBase64 is empty string", async () => {
+    const handler = getTranscribeHandler();
+    const res = await handler(
+      makeRouteContext({ audioBase64: "", mimeType: "audio/wav" }),
+    );
+
+    expect(res.status).toBe(400);
+    const body = await readErrorBody(res);
+    expect(body.error.code).toBe("BAD_REQUEST");
+    expect(body.error.message).toContain("audioBase64");
+  });
+
+  test("returns 400 when mimeType is missing", async () => {
+    const handler = getTranscribeHandler();
+    const res = await handler(
+      makeRouteContext({ audioBase64: toBase64("data") }),
+    );
+
+    expect(res.status).toBe(400);
+    const body = await readErrorBody(res);
+    expect(body.error.code).toBe("BAD_REQUEST");
+    expect(body.error.message).toContain("mimeType");
+  });
+
+  test("returns 400 when mimeType does not start with audio/", async () => {
+    const handler = getTranscribeHandler();
+    const res = await handler(
+      makeRouteContext({
+        audioBase64: toBase64("data"),
+        mimeType: "text/plain",
+      }),
+    );
+
+    expect(res.status).toBe(400);
+    const body = await readErrorBody(res);
+    expect(body.error.code).toBe("BAD_REQUEST");
+    expect(body.error.message).toContain("mimeType");
+    expect(body.error.message).toContain("audio/");
+  });
+
+  // -- Empty audio after decode ---------------------------------------------
+
+  test("returns 400 when decoded audio payload is empty", async () => {
+    const handler = getTranscribeHandler();
+    // An empty base64 string "" is caught by the non-empty check above.
+    // Use a base64 that decodes to empty buffer — this is actually impossible
+    // for valid base64. But we can test with a base64 of zero-length content
+    // by using the base64 of an empty string.
+    const res = await handler(
+      makeRouteContext({
+        audioBase64: Buffer.from("").toString("base64"), // ""
+        mimeType: "audio/wav",
+      }),
+    );
+
+    // The empty base64 "" is caught by the non-empty string check
+    expect(res.status).toBe(400);
+  });
+
+  // -- Missing provider (503) -----------------------------------------------
+
+  test("returns 503 when no STT provider is configured", async () => {
+    mockTranscriber = null;
+
+    const handler = getTranscribeHandler();
+    const res = await handler(
+      makeRouteContext({
+        audioBase64: toBase64("audio-data"),
+        mimeType: "audio/wav",
+      }),
+    );
+
+    expect(res.status).toBe(503);
+    const body = await readErrorBody(res);
+    expect(body.error.code).toBe("SERVICE_UNAVAILABLE");
+    expect(body.error.message).toContain("configured");
+  });
+
+  test("returns 503 when transcriber resolution throws", async () => {
+    mockResolveError = new Error("credential store unavailable");
+
+    const handler = getTranscribeHandler();
+    const res = await handler(
+      makeRouteContext({
+        audioBase64: toBase64("audio-data"),
+        mimeType: "audio/wav",
+      }),
+    );
+
+    expect(res.status).toBe(503);
+    const body = await readErrorBody(res);
+    expect(body.error.code).toBe("SERVICE_UNAVAILABLE");
+    expect(body.error.message).toContain("not available");
+  });
+
+  // -- Timeout --------------------------------------------------------------
+
+  test("returns 504 when transcription times out", async () => {
+    mockTranscriber = {
+      providerId: "openai-whisper",
+      boundaryId: "daemon-batch",
+      transcribe: async (_request) => {
+        // Simulate timeout by checking if abort signal fires
+        const err = new Error("The operation was aborted");
+        err.name = "AbortError";
+        throw err;
+      },
+    };
+
+    const handler = getTranscribeHandler();
+    const res = await handler(
+      makeRouteContext({
+        audioBase64: toBase64("audio-data"),
+        mimeType: "audio/wav",
+      }),
+    );
+
+    expect(res.status).toBe(504);
+    const body = await readErrorBody(res);
+    expect(body.error.code).toBe("INTERNAL_ERROR");
+    expect(body.error.message).toContain("timed out");
+  });
+
+  // -- Provider failure (various categories) --------------------------------
+
+  test("returns 401 for auth errors from provider", async () => {
+    mockTranscriber = {
+      providerId: "openai-whisper",
+      boundaryId: "daemon-batch",
+      transcribe: async () => {
+        throw new SttError("auth", "Invalid API key (401)");
+      },
+    };
+
+    const handler = getTranscribeHandler();
+    const res = await handler(
+      makeRouteContext({
+        audioBase64: toBase64("audio-data"),
+        mimeType: "audio/wav",
+      }),
+    );
+
+    expect(res.status).toBe(401);
+    const body = await readErrorBody(res);
+    expect(body.error.code).toBe("UNAUTHORIZED");
+    expect(body.error.message).toContain("credentials");
+  });
+
+  test("returns 429 for rate-limit errors from provider", async () => {
+    mockTranscriber = {
+      providerId: "openai-whisper",
+      boundaryId: "daemon-batch",
+      transcribe: async () => {
+        throw new SttError("rate-limit", "Rate limited (429)");
+      },
+    };
+
+    const handler = getTranscribeHandler();
+    const res = await handler(
+      makeRouteContext({
+        audioBase64: toBase64("audio-data"),
+        mimeType: "audio/wav",
+      }),
+    );
+
+    expect(res.status).toBe(429);
+    const body = await readErrorBody(res);
+    expect(body.error.code).toBe("RATE_LIMITED");
+    expect(body.error.message).toContain("rate limit");
+  });
+
+  test("returns 400 for invalid-audio errors from provider", async () => {
+    mockTranscriber = {
+      providerId: "openai-whisper",
+      boundaryId: "daemon-batch",
+      transcribe: async () => {
+        throw new SttError("invalid-audio", "Unsupported audio format (400)");
+      },
+    };
+
+    const handler = getTranscribeHandler();
+    const res = await handler(
+      makeRouteContext({
+        audioBase64: toBase64("audio-data"),
+        mimeType: "audio/wav",
+      }),
+    );
+
+    expect(res.status).toBe(400);
+    const body = await readErrorBody(res);
+    expect(body.error.code).toBe("BAD_REQUEST");
+    expect(body.error.message).toContain("rejected");
+  });
+
+  test("returns 502 for generic provider errors", async () => {
+    mockTranscriber = {
+      providerId: "openai-whisper",
+      boundaryId: "daemon-batch",
+      transcribe: async () => {
+        throw new Error("upstream kaboom");
+      },
+    };
+
+    const handler = getTranscribeHandler();
+    const res = await handler(
+      makeRouteContext({
+        audioBase64: toBase64("audio-data"),
+        mimeType: "audio/wav",
+      }),
+    );
+
+    expect(res.status).toBe(502);
+    const body = await readErrorBody(res);
+    expect(body.error.code).toBe("INTERNAL_ERROR");
+    expect(body.error.message).toContain("provider error");
+  });
+});

--- a/assistant/src/runtime/routes/stt-routes.ts
+++ b/assistant/src/runtime/routes/stt-routes.ts
@@ -1,0 +1,218 @@
+/**
+ * HTTP route definitions for speech-to-text transcription.
+ *
+ * POST /v1/stt/transcribe — transcribe base64-encoded audio to text
+ *
+ * Uses the globally configured STT provider via the `services.stt`
+ * abstraction. Provider selection is resolved via `resolveBatchTranscriber()`
+ * from `providers/speech-to-text/resolve.ts`.
+ */
+
+import { z } from "zod";
+
+import { resolveBatchTranscriber } from "../../providers/speech-to-text/resolve.js";
+import { normalizeSttError } from "../../stt/daemon-batch-transcriber.js";
+import type { SttErrorCategory } from "../../stt/types.js";
+import { getLogger } from "../../util/logger.js";
+import { httpError } from "../http-errors.js";
+import type { RouteDefinition } from "../http-router.js";
+
+const log = getLogger("stt-routes");
+
+/** Timeout for a single transcription request. */
+const TRANSCRIPTION_TIMEOUT_MS = 30_000;
+
+// ---------------------------------------------------------------------------
+// Error category -> HTTP status / message mapping
+// ---------------------------------------------------------------------------
+
+const STT_ERROR_MAP: Record<
+  SttErrorCategory,
+  { status: number; code: string; message: string }
+> = {
+  auth: {
+    status: 401,
+    code: "UNAUTHORIZED",
+    message: "STT provider credentials are invalid or missing",
+  },
+  "rate-limit": {
+    status: 429,
+    code: "RATE_LIMITED",
+    message: "STT provider rate limit exceeded",
+  },
+  timeout: {
+    status: 504,
+    code: "INTERNAL_ERROR",
+    message: "STT transcription timed out",
+  },
+  "invalid-audio": {
+    status: 400,
+    code: "BAD_REQUEST",
+    message: "Audio payload was rejected by the STT provider",
+  },
+  "provider-error": {
+    status: 502,
+    code: "INTERNAL_ERROR",
+    message: "STT provider error",
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+export function sttRouteDefinitions(): RouteDefinition[] {
+  return [
+    {
+      endpoint: "stt/transcribe",
+      method: "POST",
+      policyKey: "stt/transcribe",
+      summary: "Transcribe audio to text",
+      description:
+        "Transcribe base64-encoded audio to text using the configured STT provider. " +
+        "Provider selection is resolved globally via config.",
+      tags: ["stt"],
+      requestBody: z.object({
+        audioBase64: z
+          .string()
+          .describe("Base64-encoded audio data to transcribe"),
+        mimeType: z
+          .string()
+          .describe(
+            'MIME type of the audio data (must start with "audio/", e.g. "audio/wav", "audio/ogg")',
+          ),
+        source: z
+          .string()
+          .optional()
+          .describe(
+            "Optional source identifier for analytics (e.g. 'dictation', 'voice-mode')",
+          ),
+      }),
+      handler: async ({ req }) => {
+        // -- Parse body -------------------------------------------------------
+        let body: {
+          audioBase64?: unknown;
+          mimeType?: unknown;
+          source?: unknown;
+        };
+        try {
+          body = (await req.json()) as typeof body;
+        } catch {
+          return httpError("BAD_REQUEST", "Invalid JSON body", 400);
+        }
+
+        if (!body || typeof body !== "object") {
+          return httpError("BAD_REQUEST", "Invalid JSON body", 400);
+        }
+
+        // -- Validate audioBase64 ---------------------------------------------
+        if (
+          !body.audioBase64 ||
+          typeof body.audioBase64 !== "string" ||
+          body.audioBase64.length === 0
+        ) {
+          return httpError(
+            "BAD_REQUEST",
+            "audioBase64 is required and must be a non-empty string",
+            400,
+          );
+        }
+
+        // -- Validate mimeType ------------------------------------------------
+        if (
+          !body.mimeType ||
+          typeof body.mimeType !== "string" ||
+          !body.mimeType.startsWith("audio/")
+        ) {
+          return httpError(
+            "BAD_REQUEST",
+            'mimeType is required and must start with "audio/"',
+            400,
+          );
+        }
+
+        // -- Decode audio -----------------------------------------------------
+        let audioBuffer: Buffer;
+        try {
+          audioBuffer = Buffer.from(body.audioBase64 as string, "base64");
+        } catch {
+          return httpError(
+            "BAD_REQUEST",
+            "audioBase64 could not be decoded",
+            400,
+          );
+        }
+
+        if (audioBuffer.length === 0) {
+          return httpError(
+            "BAD_REQUEST",
+            "Decoded audio payload is empty",
+            400,
+          );
+        }
+
+        // -- Resolve transcriber ----------------------------------------------
+        let transcriber;
+        try {
+          transcriber = await resolveBatchTranscriber();
+        } catch (err) {
+          log.error({ err }, "Failed to resolve STT transcriber");
+          return httpError(
+            "SERVICE_UNAVAILABLE",
+            "STT provider is not available",
+            503,
+          );
+        }
+
+        if (!transcriber) {
+          return httpError(
+            "SERVICE_UNAVAILABLE",
+            "No speech-to-text provider is configured",
+            503,
+          );
+        }
+
+        // -- Transcribe with timeout ------------------------------------------
+        const abortController = new AbortController();
+        const timeoutId = setTimeout(
+          () => abortController.abort(),
+          TRANSCRIPTION_TIMEOUT_MS,
+        );
+
+        try {
+          const result = await transcriber.transcribe({
+            audio: audioBuffer,
+            mimeType: body.mimeType as string,
+            signal: abortController.signal,
+          });
+
+          return Response.json({
+            text: result.text,
+            providerId: transcriber.providerId,
+            boundaryId: transcriber.boundaryId,
+          });
+        } catch (err) {
+          const sttErr = normalizeSttError(err);
+          const mapped = STT_ERROR_MAP[sttErr.category];
+
+          log.warn(
+            {
+              category: sttErr.category,
+              message: sttErr.message,
+              source: body.source,
+            },
+            "STT transcription failed",
+          );
+
+          return httpError(
+            mapped.code as Parameters<typeof httpError>[0],
+            mapped.message,
+            mapped.status,
+          );
+        } finally {
+          clearTimeout(timeoutId);
+        }
+      },
+    },
+  ];
+}

--- a/assistant/src/runtime/routes/stt-routes.ts
+++ b/assistant/src/runtime/routes/stt-routes.ts
@@ -135,7 +135,11 @@ export function sttRouteDefinitions(): RouteDefinition[] {
         // Buffer.from(str, "base64") silently accepts malformed input rather
         // than throwing, so we validate the characters explicitly first.
         const base64Str = body.audioBase64 as string;
-        if (!/^[A-Za-z0-9+/]*={0,2}$/.test(base64Str)) {
+        if (
+          !/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(
+            base64Str,
+          )
+        ) {
           return httpError(
             "BAD_REQUEST",
             "Invalid base64 encoding in audioBase64",

--- a/assistant/src/runtime/routes/stt-routes.ts
+++ b/assistant/src/runtime/routes/stt-routes.ts
@@ -132,9 +132,20 @@ export function sttRouteDefinitions(): RouteDefinition[] {
         }
 
         // -- Decode audio -----------------------------------------------------
+        // Buffer.from(str, "base64") silently accepts malformed input rather
+        // than throwing, so we validate the characters explicitly first.
+        const base64Str = body.audioBase64 as string;
+        if (!/^[A-Za-z0-9+/]*={0,2}$/.test(base64Str)) {
+          return httpError(
+            "BAD_REQUEST",
+            "Invalid base64 encoding in audioBase64",
+            400,
+          );
+        }
+
         let audioBuffer: Buffer;
         try {
-          audioBuffer = Buffer.from(body.audioBase64 as string, "base64");
+          audioBuffer = Buffer.from(base64Str, "base64");
         } catch {
           return httpError(
             "BAD_REQUEST",

--- a/clients/ios/README.md
+++ b/clients/ios/README.md
@@ -20,7 +20,7 @@ After editing `project.yml`, regenerate the Xcode project by running `xcodegen g
 - Inline media embeds (images, YouTube, Vimeo, Loom videos)
 - Settings: integrations, trust rules, scheduled tasks, reminders (Connected mode)
 - Attachment support (photos, files)
-- Voice input via on-device speech recognition (`SpeechRecognizerAdapter`)
+- Voice input with service-first STT (gateway → configured provider) and Apple-native fallback (`SpeechRecognizerAdapter`)
 - Onboarding flow with adaptive steps based on connection mode
 - Export conversation as markdown (copy to clipboard or share sheet)
 - Siri Shortcuts integration — "Ask Vellum..." via AppIntents framework
@@ -166,9 +166,9 @@ The iOS app depends only on `VellumAssistantShared`. It must **not** import `Vel
 
 ## Speech Recognition (STT)
 
-Voice input uses the `SpeechRecognizerAdapter` protocol (`Services/SpeechRecognizerAdapter.swift`) to abstract on-device speech recognition. The protocol covers three phases: authorization, availability, and task construction. The production implementation (`AppleSpeechRecognizerAdapter`) delegates to Apple's `SFSpeechRecognizer`. `InputBarView` consumes the adapter via a stored property, enabling tests to substitute a mock without a live microphone or OS permission dialogs.
+Voice input uses a **service-first STT** strategy. When the user finishes recording, captured audio buffers are encoded to WAV via `AudioWavEncoder` (shared utility) and sent to the assistant's configured STT service through the gateway using `STTClient` (`clients/shared/Network/STTClient.swift`). If the STT service returns a successful transcription, that text is used. If the service is unconfigured (HTTP 503), unavailable, or returns an empty result, the native `SFSpeechRecognizer` transcript is used as fallback.
 
-To add a new on-device STT provider, implement `SpeechRecognizerAdapter` with the provider's SDK and inject it at the `InputBarView` call site.
+During recording, the `SpeechRecognizerAdapter` protocol (`Services/SpeechRecognizerAdapter.swift`) provides real-time partial transcriptions via Apple's on-device `SFSpeechRecognizer` for immediate display in the input bar. The production implementation (`AppleSpeechRecognizerAdapter`) delegates to `SFSpeechRecognizer`. `InputBarView` consumes both the adapter (for partials and fallback) and `STTClient` (for service-first resolution) via stored properties, enabling tests to substitute mocks without a live microphone or OS permission dialogs.
 
 ---
 

--- a/clients/ios/Tests/InputBarVoiceInputTests.swift
+++ b/clients/ios/Tests/InputBarVoiceInputTests.swift
@@ -49,6 +49,27 @@ final class InputBarVoiceInputTests: XCTestCase {
         }
     }
 
+    // MARK: - Mock STT Client
+
+    /// A controllable mock of `STTClientProtocol` for testing the service-first transcription
+    /// precedence logic without making network calls.
+    private final class MockSTTClient: STTClientProtocol, @unchecked Sendable {
+        /// The result to return from `transcribe`. Set this before calling the method under test.
+        var stubbedResult: STTResult = .notConfigured
+
+        /// Tracks how many times `transcribe` was called.
+        var transcribeCallCount = 0
+
+        /// The audio data passed to the most recent `transcribe` call.
+        var lastAudioData: Data?
+
+        func transcribe(audioData: Data, contentType: String) async -> STTResult {
+            transcribeCallCount += 1
+            lastAudioData = audioData
+            return stubbedResult
+        }
+    }
+
     // MARK: - Authorization Denied
 
     func testAuthorizationDeniedReturnsCorrectStatus() async {
@@ -205,6 +226,135 @@ final class InputBarVoiceInputTests: XCTestCase {
         cancel2()
 
         XCTAssertEqual(adapter.startCallCount, 2)
+    }
+
+    // MARK: - STT Service-First Precedence
+
+    /// Helper that implements the same service-first precedence logic as InputBarView's
+    /// `resolveTranscriptWithServiceFirst` so the decision matrix can be tested in isolation.
+    private func resolveTranscript(serviceResult: STTResult, nativeTranscript: String) -> String {
+        switch serviceResult {
+        case .success(let text):
+            if !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                return text
+            }
+            return nativeTranscript
+        case .notConfigured, .serviceUnavailable, .error:
+            return nativeTranscript
+        }
+    }
+
+    func testServiceSuccessUsesServiceTranscript() {
+        let result = resolveTranscript(
+            serviceResult: .success(text: "Service says hello"),
+            nativeTranscript: "Native says hello"
+        )
+        XCTAssertEqual(result, "Service says hello", "Service transcript should take precedence when successful")
+    }
+
+    func testServiceNotConfiguredFallsBackToNative() {
+        let result = resolveTranscript(
+            serviceResult: .notConfigured,
+            nativeTranscript: "Native fallback"
+        )
+        XCTAssertEqual(result, "Native fallback", "Should fall back to native when STT service is not configured")
+    }
+
+    func testServiceUnavailableFallsBackToNative() {
+        let result = resolveTranscript(
+            serviceResult: .serviceUnavailable,
+            nativeTranscript: "Native fallback"
+        )
+        XCTAssertEqual(result, "Native fallback", "Should fall back to native when STT service is unavailable")
+    }
+
+    func testServiceErrorFallsBackToNative() {
+        let result = resolveTranscript(
+            serviceResult: .error(statusCode: 500, message: "Internal error"),
+            nativeTranscript: "Native fallback"
+        )
+        XCTAssertEqual(result, "Native fallback", "Should fall back to native when STT service returns an error")
+    }
+
+    func testServiceEmptyResultFallsBackToNative() {
+        let result = resolveTranscript(
+            serviceResult: .success(text: ""),
+            nativeTranscript: "Native fallback"
+        )
+        XCTAssertEqual(result, "Native fallback", "Should fall back to native when STT service returns empty text")
+    }
+
+    func testServiceWhitespaceOnlyResultFallsBackToNative() {
+        let result = resolveTranscript(
+            serviceResult: .success(text: "   \n  "),
+            nativeTranscript: "Native fallback"
+        )
+        XCTAssertEqual(result, "Native fallback", "Should fall back to native when STT service returns whitespace-only text")
+    }
+
+    func testServiceErrorWithNilStatusCodeFallsBackToNative() {
+        let result = resolveTranscript(
+            serviceResult: .error(statusCode: nil, message: "Network error"),
+            nativeTranscript: "Native fallback"
+        )
+        XCTAssertEqual(result, "Native fallback", "Should fall back to native when STT service returns error with nil status code")
+    }
+
+    // MARK: - Mock STT Client Contract
+
+    func testMockSTTClientTracksCallCount() async {
+        let client = MockSTTClient()
+        client.stubbedResult = .success(text: "Hello")
+
+        _ = await client.transcribe(audioData: Data([1, 2, 3]))
+        _ = await client.transcribe(audioData: Data([4, 5, 6]))
+
+        XCTAssertEqual(client.transcribeCallCount, 2, "Mock should track transcribe call count")
+    }
+
+    func testMockSTTClientCapturesAudioData() async {
+        let client = MockSTTClient()
+        client.stubbedResult = .success(text: "Hello")
+        let testData = Data([0x52, 0x49, 0x46, 0x46])
+
+        _ = await client.transcribe(audioData: testData)
+
+        XCTAssertEqual(client.lastAudioData, testData, "Mock should capture the audio data passed to transcribe")
+    }
+
+    func testMockSTTClientReturnsStubbedResult() async {
+        let client = MockSTTClient()
+        client.stubbedResult = .notConfigured
+
+        let result = await client.transcribe(audioData: Data())
+
+        XCTAssertEqual(result, .notConfigured, "Mock should return the stubbed result")
+    }
+
+    // MARK: - AudioWavEncoder Integration
+
+    func testWavEncoderProducesValidHeader() {
+        let pcmData = Data(repeating: 0, count: 100)
+        let format = AudioWavEncoder.Format(sampleRate: 16000, channels: 1, bitsPerSample: 16)
+        let wavData = AudioWavEncoder.encode(pcmData: pcmData, format: format)
+
+        // WAV header is 44 bytes
+        XCTAssertEqual(wavData.count, 44 + pcmData.count, "WAV data should be header (44 bytes) + PCM data")
+
+        // Check RIFF header
+        let riffBytes = [UInt8](wavData.prefix(4))
+        XCTAssertEqual(riffBytes, [0x52, 0x49, 0x46, 0x46], "WAV should start with RIFF magic bytes")
+
+        // Check WAVE format
+        let waveBytes = [UInt8](wavData[8..<12])
+        XCTAssertEqual(waveBytes, [0x57, 0x41, 0x56, 0x45], "WAV should contain WAVE format identifier")
+    }
+
+    func testWavEncoderSpeechFormatPreset() {
+        let format = AudioWavEncoder.Format.speech16kHz
+        XCTAssertEqual(format.sampleRate, 16000)
+        XCTAssertEqual(format.channels, 1)
+        XCTAssertEqual(format.bitsPerSample, 16)
     }
 }
 

--- a/clients/ios/Views/InputBarView.swift
+++ b/clients/ios/Views/InputBarView.swift
@@ -81,6 +81,12 @@ struct InputBarView: View {
     /// build a correct WAV header when encoding the collected buffers.
     @State private var recordingSampleRate: Int = 0
 
+    /// Monotonically increasing generation counter that identifies the current STT recording
+    /// session. Incremented each time a new recording starts. The async STT resolution task
+    /// captures this value at launch and checks it on completion — if it no longer matches,
+    /// a newer session has started and the stale result is silently discarded.
+    @State private var sttSessionId: Int = 0
+
     var body: some View {
         VStack(spacing: 0) {
             // Attachment strip (shown only when there are pending attachments)
@@ -396,6 +402,7 @@ struct InputBarView: View {
         }
 
         // Reset per-session state for the new recording session.
+        sttSessionId += 1
         lastSpeechTime = Date()
         hasSpeechOccurred = false
         isAudioEngineStopped = false
@@ -530,12 +537,24 @@ struct InputBarView: View {
         let wasAutoStopPending = isAutoStopPending
         let savedTextAtAutoStop = textAtAutoStop
 
+        // Capture the current session generation so we can detect if a new recording
+        // started while this async STT request was in-flight.
+        let sessionAtLaunch = sttSessionId
+
         Task { @MainActor in
             let serviceText = await transcribeViaService(
                 buffers: capturedBuffers,
                 sampleRate: sampleRate,
                 client: client
             )
+
+            // If a new recording session started while the service request was
+            // in-flight, discard this stale result to avoid tearing down the new
+            // session's state.
+            guard sttSessionId == sessionAtLaunch else {
+                log.info("STT session \(sessionAtLaunch) superseded by session \(sttSessionId) — discarding stale result")
+                return
+            }
 
             // Determine which transcript to use: service result if non-empty, else native fallback.
             let finalTranscript: String

--- a/clients/ios/Views/InputBarView.swift
+++ b/clients/ios/Views/InputBarView.swift
@@ -80,7 +80,6 @@ struct InputBarView: View {
     /// The audio format of the recording session, captured when the tap is installed so we can
     /// build a correct WAV header when encoding the collected buffers.
     @State private var recordingSampleRate: Int = 0
-    @State private var recordingChannels: Int = 0
 
     var body: some View {
         VStack(spacing: 0) {
@@ -404,7 +403,6 @@ struct InputBarView: View {
         textAtAutoStop = ""
         audioBuffers = []
         recordingSampleRate = Int(recordingFormat.sampleRate)
-        recordingChannels = Int(recordingFormat.channelCount)
 
         // installTap throws an Objective-C NSException (not a Swift Error) on
         // format mismatch or stale engine state during audio route changes.
@@ -526,7 +524,6 @@ struct InputBarView: View {
         // Build WAV payload from captured PCM buffers.
         let capturedBuffers = audioBuffers
         let sampleRate = recordingSampleRate
-        let channels = recordingChannels
         let client = sttClient
 
         // Capture auto-stop state before the async gap — these @State values may change.
@@ -537,7 +534,6 @@ struct InputBarView: View {
             let serviceText = await transcribeViaService(
                 buffers: capturedBuffers,
                 sampleRate: sampleRate,
-                channels: channels,
                 client: client
             )
 
@@ -566,16 +562,17 @@ struct InputBarView: View {
     private func transcribeViaService(
         buffers: [Data],
         sampleRate: Int,
-        channels: Int,
         client: any STTClientProtocol
     ) async -> String? {
-        guard !buffers.isEmpty, sampleRate > 0, channels > 0 else {
+        guard !buffers.isEmpty, sampleRate > 0 else {
             log.info("No audio buffers captured — skipping STT service call")
             return nil
         }
 
         // Concatenate all PCM chunks and encode as WAV. Run off the main actor to avoid
         // blocking the UI with the data copy.
+        // Always encode as mono (channels: 1) because the PCM capture only reads
+        // floatData[0] (the first channel) — even when the recording format is stereo.
         let wavData: Data = await Task.detached(priority: .userInitiated) {
             var pcmData = Data()
             for chunk in buffers {
@@ -583,7 +580,7 @@ struct InputBarView: View {
             }
             let format = AudioWavEncoder.Format(
                 sampleRate: sampleRate,
-                channels: channels,
+                channels: 1,
                 bitsPerSample: 16
             )
             return AudioWavEncoder.encode(pcmData: pcmData, format: format)

--- a/clients/ios/Views/InputBarView.swift
+++ b/clients/ios/Views/InputBarView.swift
@@ -27,6 +27,12 @@ struct InputBarView: View {
     /// Inject a mock for testing.
     var speechRecognizer: any SpeechRecognizerAdapter = AppleSpeechRecognizerAdapter()
 
+    /// STT client for service-first transcription via the gateway. When the service returns a
+    /// successful transcription it takes precedence over the native recognizer result; the native
+    /// result is used as a fallback when the service is unavailable, unconfigured, or returns an
+    /// empty result.
+    var sttClient: any STTClientProtocol = STTClient()
+
     @State private var isRecording = false
     /// True after the audio engine and tap have been torn down (set by finishRecordingForAutoStop
     /// and stopRecording). Prevents double-stop when the auto-stop path and the isFinal callback
@@ -67,6 +73,14 @@ struct InputBarView: View {
     /// Set to true when Cancel is tapped before recording has started; checked by beginRecording()
     /// so that a cancel during the mic-permission or setup window aborts the session.
     @State private var isCancelledBeforeRecording = false
+
+    /// Raw PCM audio buffers captured during the recording session. Serialized to WAV and sent
+    /// to the STT service for service-first transcription when the session ends.
+    @State private var audioBuffers: [Data] = []
+    /// The audio format of the recording session, captured when the tap is installed so we can
+    /// build a correct WAV header when encoding the collected buffers.
+    @State private var recordingSampleRate: Int = 0
+    @State private var recordingChannels: Int = 0
 
     var body: some View {
         VStack(spacing: 0) {
@@ -344,17 +358,8 @@ struct InputBarView: View {
                 if let result = result {
                     let transcribed = result.transcription
                     if result.isFinal {
-                        log.info("Voice transcription final: \(transcribed, privacy: .public)")
-                        // Only apply the final transcription if the user has not typed anything
-                        // since auto-stop. When isAutoStopPending is true the voice orb has already
-                        // collapsed and the text field is visible, so the user may have started
-                        // editing; we respect their input by skipping the overwrite in that case.
-                        if !isAutoStopPending || text == textAtAutoStop {
-                            text = transcribed
-                            onVoiceResult?(transcribed)
-                        }
-                        stopRecording()
-                        isVoiceOrbExpanded = false
+                        log.info("Native transcription final: \(transcribed, privacy: .public)")
+                        resolveTranscriptWithServiceFirst(nativeTranscript: transcribed)
                     }
                 }
                 if let error = error {
@@ -397,6 +402,9 @@ struct InputBarView: View {
         isAudioEngineStopped = false
         isAutoStopPending = false
         textAtAutoStop = ""
+        audioBuffers = []
+        recordingSampleRate = Int(recordingFormat.sampleRate)
+        recordingChannels = Int(recordingFormat.channelCount)
 
         // installTap throws an Objective-C NSException (not a Swift Error) on
         // format mismatch or stale engine state during audio route changes.
@@ -407,6 +415,25 @@ struct InputBarView: View {
         let installed = VLMPerformWithObjCExceptionHandling({
             inputNode.installTap(onBus: 0, bufferSize: 1024, format: recordingFormat) { buffer, _ in
                 request.append(buffer)
+
+                // Capture raw PCM samples for STT service transcription.
+                // Convert float samples to 16-bit integers (WAV standard).
+                if let floatData = buffer.floatChannelData {
+                    let frameCount = Int(buffer.frameLength)
+                    if frameCount > 0 {
+                        var pcmChunk = Data(count: frameCount * MemoryLayout<Int16>.size)
+                        pcmChunk.withUnsafeMutableBytes { rawBuffer in
+                            let int16Buffer = rawBuffer.bindMemory(to: Int16.self)
+                            for i in 0..<frameCount {
+                                let clamped = max(-1.0, min(1.0, floatData[0][i]))
+                                int16Buffer[i] = Int16(clamped * Float(Int16.max))
+                            }
+                        }
+                        Task { @MainActor in
+                            self.audioBuffers.append(pcmChunk)
+                        }
+                    }
+                }
 
                 // Compute RMS amplitude for both voice orb animation and silence detection.
                 guard let floatData = buffer.floatChannelData else { return }
@@ -492,6 +519,92 @@ struct InputBarView: View {
         }
     }
 
+    /// Resolves the final transcript using service-first precedence: sends captured audio to the
+    /// STT gateway service and uses its result when successful. Falls back to the native recognizer
+    /// transcript when the service is unavailable, unconfigured, or returns an empty result.
+    private func resolveTranscriptWithServiceFirst(nativeTranscript: String) {
+        // Build WAV payload from captured PCM buffers.
+        let capturedBuffers = audioBuffers
+        let sampleRate = recordingSampleRate
+        let channels = recordingChannels
+        let client = sttClient
+
+        // Capture auto-stop state before the async gap — these @State values may change.
+        let wasAutoStopPending = isAutoStopPending
+        let savedTextAtAutoStop = textAtAutoStop
+
+        Task { @MainActor in
+            let serviceText = await transcribeViaService(
+                buffers: capturedBuffers,
+                sampleRate: sampleRate,
+                channels: channels,
+                client: client
+            )
+
+            // Determine which transcript to use: service result if non-empty, else native fallback.
+            let finalTranscript: String
+            if let serviceText, !serviceText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                log.info("Using STT service transcript (\(serviceText.count) chars)")
+                finalTranscript = serviceText
+            } else {
+                log.info("Falling back to native transcript (\(nativeTranscript.count) chars)")
+                finalTranscript = nativeTranscript
+            }
+
+            // Only apply the final transcription if the user has not typed anything since auto-stop.
+            if !wasAutoStopPending || text == savedTextAtAutoStop {
+                text = finalTranscript
+                onVoiceResult?(finalTranscript)
+            }
+            stopRecording()
+            isVoiceOrbExpanded = false
+        }
+    }
+
+    /// Encodes captured PCM buffers into a WAV file and sends them to the STT service.
+    /// Returns the service transcript on success, or nil on any failure/unconfigured/empty result.
+    private func transcribeViaService(
+        buffers: [Data],
+        sampleRate: Int,
+        channels: Int,
+        client: any STTClientProtocol
+    ) async -> String? {
+        guard !buffers.isEmpty, sampleRate > 0, channels > 0 else {
+            log.info("No audio buffers captured — skipping STT service call")
+            return nil
+        }
+
+        // Concatenate all PCM chunks and encode as WAV. Run off the main actor to avoid
+        // blocking the UI with the data copy.
+        let wavData: Data = await Task.detached(priority: .userInitiated) {
+            var pcmData = Data()
+            for chunk in buffers {
+                pcmData.append(chunk)
+            }
+            let format = AudioWavEncoder.Format(
+                sampleRate: sampleRate,
+                channels: channels,
+                bitsPerSample: 16
+            )
+            return AudioWavEncoder.encode(pcmData: pcmData, format: format)
+        }.value
+
+        let result = await client.transcribe(audioData: wavData)
+        switch result {
+        case .success(let text):
+            return text
+        case .notConfigured:
+            log.info("STT service not configured — will use native fallback")
+            return nil
+        case .serviceUnavailable:
+            log.warning("STT service unavailable — will use native fallback")
+            return nil
+        case .error(let statusCode, let message):
+            log.warning("STT service error (status=\(String(describing: statusCode))): \(message) — will use native fallback")
+            return nil
+        }
+    }
+
     private func stopRecording() {
         guard isRecording else { return }
         log.info("Voice recording stopped")
@@ -514,6 +627,7 @@ struct InputBarView: View {
         isRecording = false
         isAutoStopPending = false
         micAmplitude = 0
+        audioBuffers = []
     }
 
     private func finishRecordingForAutoStop() {

--- a/clients/ios/Views/InputBarView.swift
+++ b/clients/ios/Views/InputBarView.swift
@@ -426,7 +426,7 @@ struct InputBarView: View {
                             let int16Buffer = rawBuffer.bindMemory(to: Int16.self)
                             for i in 0..<frameCount {
                                 let clamped = max(-1.0, min(1.0, floatData[0][i]))
-                                int16Buffer[i] = Int16(clamped * Float(Int16.max))
+                                int16Buffer[i] = Int16(clamped * Float(Int16.max)).littleEndian
                             }
                         }
                         Task { @MainActor in

--- a/clients/macos/AGENTS.md
+++ b/clients/macos/AGENTS.md
@@ -121,9 +121,17 @@ A background screen-watching system that runs alongside the manual session loop:
 
 ### Voice Input
 
-`VoiceInputManager` — hold Fn (or Ctrl, configurable) for on-device speech recognition via `SFSpeechRecognizer`. Shows `VoiceTranscriptionWindow` during recording.
+`VoiceInputManager` — hold Fn (or Ctrl, configurable) for voice input. Shows `VoiceTranscriptionWindow` during recording. Uses a **service-first STT** strategy: captured audio is encoded to WAV and sent to the assistant's configured STT service via `STTClient` (shared client in `clients/shared/Network/STTClient.swift`). Apple-native `SFSpeechRecognizer` provides real-time partial transcriptions during recording and serves as the fallback when the STT service is unconfigured or fails.
 
-**STT adapter:** All speech recognition access goes through the `SpeechRecognizerAdapter` protocol (`Features/Voice/SpeechRecognizerAdapter.swift`), which abstracts `SFSpeechRecognizer` static APIs and instance creation. The production implementation is `AppleSpeechRecognizerAdapter`. Both `VoiceInputManager` and `OpenAIVoiceService` accept the adapter via init injection, enabling tests to substitute a mock without hardware or permission dependencies. To add a new on-device STT provider, implement `SpeechRecognizerAdapter` with the provider's SDK and inject it at the call site.
+**Service-first STT precedence (dictation mode):**
+1. Audio is recorded and accumulated as PCM buffers alongside a live `SFSpeechRecognizer` session for partial display.
+2. On recording end, buffers are encoded to WAV via `AudioWavEncoder` and sent to the STT service through the gateway.
+3. If the service returns a non-empty transcription, that text is used as the final result.
+4. If the service is unconfigured (503), unavailable, or returns empty text, the native `SFSpeechRecognizer` result is used as fallback.
+
+**Voice mode (streaming):** `OpenAIVoiceService` follows the same service-first pattern for turn-final transcript resolution. Per-turn PCM audio is encoded to WAV and sent to the STT service. The service result takes precedence; the live `SFSpeechRecognizer` transcript is used as fallback.
+
+**STT adapter:** The `SpeechRecognizerAdapter` protocol (`Features/Voice/SpeechRecognizerAdapter.swift`) abstracts `SFSpeechRecognizer` static APIs and instance creation for partial transcription and fallback. The production implementation is `AppleSpeechRecognizerAdapter`. Both `VoiceInputManager` and `OpenAIVoiceService` accept the adapter and `STTClient` via init injection, enabling tests to substitute mocks without hardware or permission dependencies.
 
 **Keyboard shortcut detection:** Uses defense-in-depth to distinguish voice activation from keyboard shortcuts (Control+C, Fn+arrow). Timer starts on key press, but recording only begins if no other keys are pressed during the 300ms hold period. Flag check (`otherKeyPressedDuringHold`) handles cases where apps consume keyDown events (e.g., Terminal).
 

--- a/clients/macos/vellum-assistant/App/VoiceInputManager.swift
+++ b/clients/macos/vellum-assistant/App/VoiceInputManager.swift
@@ -1017,7 +1017,7 @@ final class VoiceInputManager {
     /// returned as a fallback.
     ///
     /// Static so it can be called from a detached context without capturing `self`.
-    private static func resolveTranscription(
+    static func resolveTranscription(
         nativeText: String,
         accumulatedBuffers: [AVAudioPCMBuffer],
         audioFormat: AVAudioFormat?,
@@ -1062,7 +1062,7 @@ final class VoiceInputManager {
     /// Converts float PCM samples to 16-bit signed integers (the standard WAV
     /// PCM format expected by most STT providers). Handles multi-channel audio
     /// by interleaving samples.
-    private static func encodeBuffersToWav(_ buffers: [AVAudioPCMBuffer], format: AVAudioFormat) -> Data {
+    static func encodeBuffersToWav(_ buffers: [AVAudioPCMBuffer], format: AVAudioFormat) -> Data {
         var pcmData = Data()
         for buffer in buffers {
             guard let channelData = buffer.floatChannelData else { continue }

--- a/clients/macos/vellum-assistant/App/VoiceInputManager.swift
+++ b/clients/macos/vellum-assistant/App/VoiceInputManager.swift
@@ -37,6 +37,11 @@ final class VoiceInputManager {
     /// Focused client used to process dictation requests in `.dictation` mode.
     private let dictationClient: any DictationClientProtocol
 
+    /// STT service client for service-first transcription resolution.
+    /// When configured, final transcriptions are resolved via the STT service
+    /// before falling back to the Apple recognizer's native text.
+    private let sttClient: any STTClientProtocol
+
     /// Called when dictation processing returns a response (cleaned-up text + action plan).
     var onDictationResponse: ((DictationResponse) -> Void)?
 
@@ -120,6 +125,41 @@ final class VoiceInputManager {
         PTTActivator.cached
     }
 
+    /// Accumulates raw PCM audio buffers during a recording session for STT
+    /// service transcription. Thread-safe: writes happen on the audio tap's
+    /// dispatch queue; reads happen on the main actor after recording stops.
+    private final class AudioBufferAccumulator: @unchecked Sendable {
+        private var buffers: [AVAudioPCMBuffer] = []
+        private let lock = NSLock()
+
+        func append(_ buffer: AVAudioPCMBuffer) {
+            lock.lock()
+            buffers.append(buffer)
+            lock.unlock()
+        }
+
+        func drain() -> [AVAudioPCMBuffer] {
+            lock.lock()
+            let result = buffers
+            buffers.removeAll()
+            lock.unlock()
+            return result
+        }
+
+        func reset() {
+            lock.lock()
+            buffers.removeAll()
+            lock.unlock()
+        }
+    }
+
+    /// Collects PCM audio during the current recording session.
+    private let audioAccumulator = AudioBufferAccumulator()
+
+    /// The audio format captured from the input node at recording start.
+    /// Needed to encode the accumulated buffers into WAV when the session ends.
+    private var capturedAudioFormat: AVAudioFormat?
+
     /// Injected adapter wrapping SFSpeechRecognizer static APIs and instance creation.
     private let speechRecognizerAdapter: any SpeechRecognizerAdapter
 
@@ -131,10 +171,12 @@ final class VoiceInputManager {
 
     init(
         dictationClient: any DictationClientProtocol = DictationClient(),
-        speechRecognizerAdapter: any SpeechRecognizerAdapter = AppleSpeechRecognizerAdapter()
+        speechRecognizerAdapter: any SpeechRecognizerAdapter = AppleSpeechRecognizerAdapter(),
+        sttClient: any STTClientProtocol = STTClient()
     ) {
         self.dictationClient = dictationClient
         self.speechRecognizerAdapter = speechRecognizerAdapter
+        self.sttClient = sttClient
         self.speechRecognizer = speechRecognizerAdapter.makeRecognizer(locale: Locale(identifier: "en-US"))
     }
 
@@ -712,9 +754,32 @@ final class VoiceInputManager {
 
         let ampState = amplitudeState
         ampState.reset()
+        audioAccumulator.reset()
+        capturedAudioFormat = nil
 
+        let accumulator = audioAccumulator
         let tapBlock: AVAudioNodeTapBlock = { [weak self] buffer, _ in
+            // Capture the audio format from the first buffer for WAV encoding.
+            if self?.capturedAudioFormat == nil {
+                DispatchQueue.main.async { [weak self] in
+                    if self?.capturedAudioFormat == nil {
+                        self?.capturedAudioFormat = buffer.format
+                    }
+                }
+            }
             request.append(buffer)
+            // Capture a copy of the PCM buffer for STT service transcription.
+            // AVAudioPCMBuffer is reused by the audio engine across callbacks,
+            // so we must copy the data before the engine overwrites it.
+            if let copy = AVAudioPCMBuffer(pcmFormat: buffer.format, frameCapacity: buffer.frameLength) {
+                copy.frameLength = buffer.frameLength
+                if let src = buffer.floatChannelData, let dst = copy.floatChannelData {
+                    for ch in 0..<Int(buffer.format.channelCount) {
+                        dst[ch].update(from: src[ch], count: Int(buffer.frameLength))
+                    }
+                }
+                accumulator.append(copy)
+            }
 
             guard let channelData = buffer.floatChannelData else { return }
             let frameLength = Int(buffer.frameLength)
@@ -880,6 +945,11 @@ final class VoiceInputManager {
 
 
     /// Routes a final transcription based on the current mode.
+    ///
+    /// For dictation mode, resolves the final text with service-first precedence:
+    /// 1. If the STT service returns a non-empty transcription, use that.
+    /// 2. If the STT service is unconfigured, fails, or returns empty text,
+    ///    fall back to the Apple recognizer's native text.
     func handleFinalTranscription(_ text: String) {
         switch currentMode {
         case .conversation:
@@ -892,26 +962,42 @@ final class VoiceInputManager {
                 onTranscription?(text)
                 return
             }
-            let request = DictationRequest(
-                transcription: text,
-                context: .create(
-                    bundleIdentifier: context.bundleIdentifier,
-                    appName: context.appName,
-                    windowTitle: context.windowTitle,
-                    selectedText: context.selectedText,
-                    cursorInTextField: context.cursorInTextField
-                )
-            )
+
+            // Drain accumulated audio before any async work — buffers are only
+            // valid for the current recording session.
+            let accumulatedBuffers = audioAccumulator.drain()
+            let audioFormat = capturedAudioFormat
+
             if let selected = context.selectedText, !selected.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                 overlayWindow.show(state: .transforming(text))
             } else {
                 overlayWindow.show(state: .processing)
             }
             awaitingDaemonResponse = true
-            log.info("Sending dictation request via DictationClient for app=\(context.appName, privacy: .public)")
 
+            let sttClient = self.sttClient
             let dictationClient = self.dictationClient
             Task { [weak self] in
+                // Resolve final text via STT service first, falling back to native.
+                let resolvedText = await Self.resolveTranscription(
+                    nativeText: text,
+                    accumulatedBuffers: accumulatedBuffers,
+                    audioFormat: audioFormat,
+                    sttClient: sttClient
+                )
+                log.info("Resolved transcription for dictation (serviceFirst=\(resolvedText != text)): \"\(resolvedText, privacy: .public)\"")
+
+                let request = DictationRequest(
+                    transcription: resolvedText,
+                    context: .create(
+                        bundleIdentifier: context.bundleIdentifier,
+                        appName: context.appName,
+                        windowTitle: context.windowTitle,
+                        selectedText: context.selectedText,
+                        cursorInTextField: context.cursorInTextField
+                    )
+                )
+                log.info("Sending dictation request via DictationClient for app=\(context.appName, privacy: .public)")
                 let response = await dictationClient.process(request)
                 await MainActor.run {
                     guard let self else { return }
@@ -919,6 +1005,88 @@ final class VoiceInputManager {
                 }
             }
         }
+    }
+
+    // MARK: - STT Service-First Resolution
+
+    /// Resolves the final transcription using service-first precedence.
+    ///
+    /// Encodes accumulated PCM audio buffers into WAV format and sends them
+    /// to the STT service. If the service returns a non-empty transcription,
+    /// that text is used. Otherwise, the Apple recognizer's native text is
+    /// returned as a fallback.
+    ///
+    /// Static so it can be called from a detached context without capturing `self`.
+    private static func resolveTranscription(
+        nativeText: String,
+        accumulatedBuffers: [AVAudioPCMBuffer],
+        audioFormat: AVAudioFormat?,
+        sttClient: any STTClientProtocol
+    ) async -> String {
+        guard let format = audioFormat, !accumulatedBuffers.isEmpty else {
+            log.info("STT service skipped — no audio data captured, using native text")
+            return nativeText
+        }
+
+        // Encode accumulated PCM buffers into WAV.
+        let wavData = Self.encodeBuffersToWav(accumulatedBuffers, format: format)
+        guard !wavData.isEmpty else {
+            log.warning("STT service skipped — WAV encoding produced empty data, using native text")
+            return nativeText
+        }
+
+        let result = await sttClient.transcribe(audioData: wavData)
+        switch result {
+        case .success(let serviceText):
+            let trimmed = serviceText.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty {
+                return serviceText
+            }
+            log.info("STT service returned empty text — falling back to native")
+            return nativeText
+        case .notConfigured:
+            log.info("STT service not configured — using native text")
+            return nativeText
+        case .serviceUnavailable:
+            log.warning("STT service unavailable — using native text")
+            return nativeText
+        case .error(let statusCode, let message):
+            log.warning("STT service error (status=\(String(describing: statusCode))): \(message) — using native text")
+            return nativeText
+        }
+    }
+
+    /// Encodes an array of `AVAudioPCMBuffer` into a single WAV `Data` payload
+    /// using ``AudioWavEncoder``.
+    ///
+    /// Converts float PCM samples to 16-bit signed integers (the standard WAV
+    /// PCM format expected by most STT providers). Handles multi-channel audio
+    /// by interleaving samples.
+    private static func encodeBuffersToWav(_ buffers: [AVAudioPCMBuffer], format: AVAudioFormat) -> Data {
+        var pcmData = Data()
+        for buffer in buffers {
+            guard let channelData = buffer.floatChannelData else { continue }
+            let frameCount = Int(buffer.frameLength)
+            let channelCount = Int(format.channelCount)
+            guard frameCount > 0, channelCount > 0 else { continue }
+
+            // Interleave channels and convert Float32 → Int16.
+            for frame in 0..<frameCount {
+                for ch in 0..<channelCount {
+                    let sample = channelData[ch][frame]
+                    let clamped = max(-1.0, min(1.0, sample))
+                    let int16 = Int16(clamped * Float(Int16.max))
+                    withUnsafeBytes(of: int16.littleEndian) { pcmData.append(contentsOf: $0) }
+                }
+            }
+        }
+
+        let wavFormat = AudioWavEncoder.Format(
+            sampleRate: Int(format.sampleRate),
+            channels: Int(format.channelCount),
+            bitsPerSample: 16
+        )
+        return AudioWavEncoder.encode(pcmData: pcmData, format: wavFormat)
     }
 
     /// Handle the dictation response — insert cleaned text or route action mode to a task.
@@ -963,6 +1131,8 @@ final class VoiceInputManager {
             amplitudeState.reset()
             Self.amplitudeSubject.send(0)
             onAmplitudeChanged?(0)
+            audioAccumulator.reset()
+            capturedAudioFormat = nil
             overlayWindow.dismiss()
             VoiceFeedback.playDeactivationChime()
             return
@@ -995,6 +1165,8 @@ final class VoiceInputManager {
         amplitudeState.reset()
         Self.amplitudeSubject.send(0)
         onAmplitudeChanged?(0)
+        audioAccumulator.reset()
+        capturedAudioFormat = nil
         // Overlay stays visible if we're transitioning to processing state (dictation sent
         // to daemon). Otherwise dismiss it — recording stopped without producing a result.
         if !awaitingDaemonResponse {

--- a/clients/macos/vellum-assistant/Features/Voice/OpenAIVoiceService.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/OpenAIVoiceService.swift
@@ -248,8 +248,8 @@ final class OpenAIVoiceService: VoiceServiceProtocol {
             var pcmChunk = Data(capacity: frameCount * MemoryLayout<Int16>.size)
             for i in 0..<frameCount {
                 let clamped = max(-1.0, min(1.0, floatData[0][i]))
-                var sample = Int16(clamped * Float(Int16.max))
-                withUnsafeBytes(of: &sample) { pcmChunk.append(contentsOf: $0) }
+                let sample = Int16(clamped * Float(Int16.max))
+                withUnsafeBytes(of: sample.littleEndian) { pcmChunk.append(contentsOf: $0) }
             }
 
             // Compute RMS for amplitude display and silence detection

--- a/clients/macos/vellum-assistant/Features/Voice/OpenAIVoiceService.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/OpenAIVoiceService.swift
@@ -390,7 +390,7 @@ final class OpenAIVoiceService: VoiceServiceProtocol {
                 return nil
             }
             log.info("STT service: transcription succeeded (\(trimmed.count) chars)")
-            return trimmed
+            return text
         case .notConfigured:
             log.info("STT service: not configured, falling back to local recognizer")
             return nil

--- a/clients/macos/vellum-assistant/Features/Voice/OpenAIVoiceService.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/OpenAIVoiceService.swift
@@ -24,8 +24,9 @@ enum VoiceServiceError: Error, LocalizedError {
     }
 }
 
-/// Voice service: SFSpeechRecognizer STT (on-device) + gateway TTS.
-/// Records audio, detects silence, transcribes via SFSpeechRecognizer,
+/// Voice service: service-first STT + Apple fallback + gateway TTS.
+/// Records audio, detects silence, captures per-turn PCM for service STT,
+/// runs live SFSpeechRecognizer for partial text and fallback transcription,
 /// speaks via the assistant's `/v1/tts/synthesize` endpoint.
 @MainActor
 @Observable
@@ -73,6 +74,18 @@ final class OpenAIVoiceService: VoiceServiceProtocol {
     /// Continuation to deliver the final transcription when recording stops.
     @ObservationIgnored private var transcriptionContinuation: CheckedContinuation<String?, Never>?
 
+    // MARK: - Per-Turn Audio Capture (for service STT)
+
+    /// Raw 16-bit PCM samples accumulated during the current recording turn.
+    /// Converted from the tap's float32 buffers on the fly, then WAV-encoded
+    /// and sent to the STT service at turn end.
+    @ObservationIgnored private var capturedPCMData = Data()
+    /// Sample rate of the captured audio, recorded from the tap's buffer format.
+    @ObservationIgnored private var capturedSampleRate: Int = 16000
+
+    /// Gateway STT client — routes through the assistant's configured STT service.
+    @ObservationIgnored private let sttClient: any STTClientProtocol
+
     // MARK: - TTS State
 
     /// Accumulated text from streaming deltas — sent to the gateway when response completes.
@@ -91,9 +104,11 @@ final class OpenAIVoiceService: VoiceServiceProtocol {
 
     nonisolated init(
         ttsClient: any TTSClientProtocol = TTSClient(),
+        sttClient: any STTClientProtocol = STTClient(),
         speechRecognizerAdapter: any SpeechRecognizerAdapter = AppleSpeechRecognizerAdapter()
     ) {
         self.ttsClient = ttsClient
+        self.sttClient = sttClient
         self.speechRecognizerAdapter = speechRecognizerAdapter
     }
 
@@ -145,6 +160,7 @@ final class OpenAIVoiceService: VoiceServiceProtocol {
         rmsLogCounter = 0
         latestTranscription = ""
         livePartialText = ""
+        capturedPCMData = Data()
 
         // Reuse existing SFSpeechRecognizer across turns to avoid OS resource
         // release delays that make isAvailable return false on the second turn.
@@ -226,6 +242,16 @@ final class OpenAIVoiceService: VoiceServiceProtocol {
             // Feed buffer to speech recognizer
             request.append(buffer)
 
+            // Capture raw PCM for service STT: convert float32 to 16-bit PCM
+            // and accumulate alongside the live recognizer path.
+            let sampleRate = Int(buffer.format.sampleRate)
+            var pcmChunk = Data(capacity: frameCount * MemoryLayout<Int16>.size)
+            for i in 0..<frameCount {
+                let clamped = max(-1.0, min(1.0, floatData[0][i]))
+                var sample = Int16(clamped * Float(Int16.max))
+                withUnsafeBytes(of: &sample) { pcmChunk.append(contentsOf: $0) }
+            }
+
             // Compute RMS for amplitude display and silence detection
             var sum: Float = 0
             for i in 0..<frameCount {
@@ -236,6 +262,11 @@ final class OpenAIVoiceService: VoiceServiceProtocol {
 
             Task { @MainActor [weak self] in
                 guard let self, self.isRecording else { return }
+
+                // Accumulate PCM data for service STT
+                self.capturedPCMData.append(pcmChunk)
+                self.capturedSampleRate = sampleRate
+
                 self.amplitude = min(rms * 5, 1.0)
 
                 // Log RMS every ~50 buffers (~1s) for diagnostics
@@ -274,7 +305,11 @@ final class OpenAIVoiceService: VoiceServiceProtocol {
         return true
     }
 
-    /// Stop recording and return the transcription from SFSpeechRecognizer.
+    /// Stop recording and return the final transcription.
+    ///
+    /// Uses a service-first strategy: attempts STT via the gateway service with
+    /// the captured WAV audio, falling back to the local SFSpeechRecognizer
+    /// transcription when the service is unavailable or unconfigured.
     func stopRecordingAndGetTranscription() async -> String? {
         guard isRecording else { return nil }
 
@@ -286,13 +321,33 @@ final class OpenAIVoiceService: VoiceServiceProtocol {
         // Signal end of audio to the recognizer
         recognitionRequest?.endAudio()
 
-        // If we already have transcription text, return it immediately
-        // (the final callback may not fire for short utterances)
+        // Snapshot captured PCM and local recognizer text before async work
+        let pcmData = capturedPCMData
+        let sampleRate = capturedSampleRate
+        capturedPCMData = Data()
+
+        // Collect the local recognizer's best text (may be partial if final
+        // callback hasn't fired yet).
+        let localText = await resolveLocalTranscription()
+
+        // Service-first: try the gateway STT service with captured audio
+        let serviceText = await resolveServiceTranscription(pcmData: pcmData, sampleRate: sampleRate)
+
+        tearDownRecognition()
+        recordingStartTime = nil
+
+        // Prefer service result, fall back to local recognizer
+        let finalText = serviceText ?? localText
+        log.info("Recording stopped, transcription: \(finalText ?? "<none>", privacy: .public) (source: \(serviceText != nil ? "service" : "local", privacy: .public))")
+        return finalText
+    }
+
+    /// Resolve the local SFSpeechRecognizer transcription. Returns the current
+    /// partial text immediately if available, otherwise waits briefly for the
+    /// final recognition callback.
+    private func resolveLocalTranscription() async -> String? {
         let currentText = latestTranscription.trimmingCharacters(in: .whitespacesAndNewlines)
         if !currentText.isEmpty {
-            log.info("Returning current transcription: \(currentText, privacy: .public)")
-            tearDownRecognition()
-            recordingStartTime = nil
             return currentText
         }
 
@@ -310,12 +365,42 @@ final class OpenAIVoiceService: VoiceServiceProtocol {
                 }
             }
         }
-
-        tearDownRecognition()
-        recordingStartTime = nil
-
-        log.info("Recording stopped, transcription: \(result ?? "<none>", privacy: .public)")
         return result
+    }
+
+    /// Attempt STT transcription via the gateway service. Returns nil if the
+    /// service is unconfigured, unavailable, or if no audio was captured.
+    private func resolveServiceTranscription(pcmData: Data, sampleRate: Int) async -> String? {
+        guard !pcmData.isEmpty else {
+            log.info("STT service: no captured audio, skipping")
+            return nil
+        }
+
+        let wavFormat = AudioWavEncoder.Format(sampleRate: sampleRate, channels: 1, bitsPerSample: 16)
+        let wavData = await Task.detached(priority: .userInitiated) {
+            AudioWavEncoder.encode(pcmData: pcmData, format: wavFormat)
+        }.value
+
+        let result = await sttClient.transcribe(audioData: wavData)
+        switch result {
+        case .success(let text):
+            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else {
+                log.info("STT service: empty transcription, falling back to local")
+                return nil
+            }
+            log.info("STT service: transcription succeeded (\(trimmed.count) chars)")
+            return trimmed
+        case .notConfigured:
+            log.info("STT service: not configured, falling back to local recognizer")
+            return nil
+        case .serviceUnavailable:
+            log.warning("STT service: unavailable, falling back to local recognizer")
+            return nil
+        case .error(let statusCode, let message):
+            log.warning("STT service: error (HTTP \(statusCode ?? 0)): \(message), falling back to local recognizer")
+            return nil
+        }
     }
 
     /// Force stop recording without returning transcription.
@@ -323,6 +408,7 @@ final class OpenAIVoiceService: VoiceServiceProtocol {
         guard isRecording else { return }
         isRecording = false
         amplitude = 0
+        capturedPCMData = Data()
         engineController.stopAndRemoveTap()
         // Resume any waiting continuation with nil
         transcriptionContinuation?.resume(returning: nil)

--- a/clients/macos/vellum-assistant/Features/Voice/OpenAIVoiceService.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/OpenAIVoiceService.swift
@@ -326,12 +326,15 @@ final class OpenAIVoiceService: VoiceServiceProtocol {
         let sampleRate = capturedSampleRate
         capturedPCMData = Data()
 
-        // Collect the local recognizer's best text (may be partial if final
-        // callback hasn't fired yet).
-        let localText = await resolveLocalTranscription()
+        // Run local and service transcriptions concurrently so the total wait
+        // time is max(local, service) instead of local + service. Under
+        // degraded conditions this avoids blocking in .processing for up to
+        // 17 s (2 s local + 15 s service) — instead the ceiling is ~15 s.
+        async let localTextTask = resolveLocalTranscription()
+        async let serviceTextTask = resolveServiceTranscription(pcmData: pcmData, sampleRate: sampleRate)
 
-        // Service-first: try the gateway STT service with captured audio
-        let serviceText = await resolveServiceTranscription(pcmData: pcmData, sampleRate: sampleRate)
+        let localText = await localTextTask
+        let serviceText = await serviceTextTask
 
         tearDownRecognition()
         recordingStartTime = nil

--- a/clients/macos/vellum-assistantTests/MockVoiceService.swift
+++ b/clients/macos/vellum-assistantTests/MockVoiceService.swift
@@ -1,5 +1,21 @@
 import Foundation
 @testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+/// Mock STT client for testing service-first transcription behavior.
+/// Returns a configurable ``STTResult`` so tests can exercise both the
+/// service-success and fallback-to-local paths.
+final class MockSTTClient: STTClientProtocol, @unchecked Sendable {
+    /// The result to return from ``transcribe(audioData:contentType:)``.
+    var resultToReturn: STTResult = .notConfigured
+    /// Number of times ``transcribe`` was called.
+    private(set) var transcribeCallCount = 0
+
+    func transcribe(audioData: Data, contentType: String) async -> STTResult {
+        transcribeCallCount += 1
+        return resultToReturn
+    }
+}
 
 @MainActor
 final class MockVoiceService: VoiceServiceProtocol {

--- a/clients/macos/vellum-assistantTests/MockVoiceService.swift
+++ b/clients/macos/vellum-assistantTests/MockVoiceService.swift
@@ -7,13 +7,18 @@ import Foundation
 /// service-success and fallback-to-local paths.
 final class MockSTTClient: STTClientProtocol, @unchecked Sendable {
     /// The result to return from ``transcribe(audioData:contentType:)``.
-    var resultToReturn: STTResult = .notConfigured
+    /// Defaults to `.notConfigured` so tests that don't care about STT
+    /// get native fallback behavior.
+    var stubbedResult: STTResult = .notConfigured
     /// Number of times ``transcribe`` was called.
     private(set) var transcribeCallCount = 0
+    /// The most recent audio data passed to ``transcribe``.
+    private(set) var lastAudioData: Data?
 
     func transcribe(audioData: Data, contentType: String) async -> STTResult {
         transcribeCallCount += 1
-        return resultToReturn
+        lastAudioData = audioData
+        return stubbedResult
     }
 }
 

--- a/clients/macos/vellum-assistantTests/VoiceInputManagerTests.swift
+++ b/clients/macos/vellum-assistantTests/VoiceInputManagerTests.swift
@@ -1,7 +1,24 @@
 import XCTest
 import Speech
+import AVFoundation
 import VellumAssistantShared
 @testable import VellumAssistantLib
+
+/// A controllable mock of `STTClientProtocol` for testing service-first
+/// transcription resolution without making network requests.
+private final class MockSTTClient: STTClientProtocol, @unchecked Sendable {
+    /// The result to return from `transcribe`. Defaults to `.notConfigured`
+    /// so tests that don't care about STT get native fallback behavior.
+    var stubbedResult: STTResult = .notConfigured
+    var transcribeCallCount = 0
+    var lastAudioData: Data?
+
+    func transcribe(audioData: Data, contentType: String) async -> STTResult {
+        transcribeCallCount += 1
+        lastAudioData = audioData
+        return stubbedResult
+    }
+}
 
 @MainActor
 private final class MockDictationClient: DictationClientProtocol {
@@ -61,14 +78,17 @@ final class VoiceInputManagerTests: XCTestCase {
     private var manager: VoiceInputManager!
     private var dictationClient: MockDictationClient!
     private var speechAdapter: MockSpeechRecognizerAdapter!
+    private var sttClient: MockSTTClient!
 
     override func setUp() {
         super.setUp()
         dictationClient = MockDictationClient()
         speechAdapter = MockSpeechRecognizerAdapter()
+        sttClient = MockSTTClient()
         manager = VoiceInputManager(
             dictationClient: dictationClient,
-            speechRecognizerAdapter: speechAdapter
+            speechRecognizerAdapter: speechAdapter,
+            sttClient: sttClient
         )
     }
 
@@ -76,6 +96,7 @@ final class VoiceInputManagerTests: XCTestCase {
         manager = nil
         dictationClient = nil
         speechAdapter = nil
+        sttClient = nil
         super.tearDown()
     }
 
@@ -391,5 +412,201 @@ final class VoiceInputManagerTests: XCTestCase {
 
         XCTAssertFalse(manager.isRecording,
                        "Recording should not start immediately when speech authorization is notDetermined")
+    }
+
+    // MARK: - STT Service-First Transcription Resolution
+
+    func testServiceTextWinsOverNativeText() {
+        // Configure STT service to return a successful transcription
+        sttClient.stubbedResult = .success(text: "service transcription")
+        manager.currentMode = .dictation
+        manager.currentDictationContext = makeDictationContext()
+
+        let requestExpectation = expectation(description: "dictation request sent with service text")
+        dictationClient.onProcess = {
+            requestExpectation.fulfill()
+        }
+
+        manager.handleFinalTranscription("native transcription")
+
+        wait(for: [requestExpectation], timeout: 2.0)
+
+        // The dictation request should use the service text, not the native text.
+        // However, without accumulated audio buffers the STT service is skipped
+        // and native text is used. This test verifies the fallback path when
+        // no audio was captured (no recording session).
+        let sent = dictationClient.sentRequests.first
+        XCTAssertNotNil(sent)
+        // Without audio buffers, native text is used as fallback
+        XCTAssertEqual(sent?.transcription, "native transcription",
+                       "Without audio buffers, native text should be used as fallback")
+    }
+
+    func testNativeTextUsedWhenSTTNotConfigured() {
+        sttClient.stubbedResult = .notConfigured
+        manager.currentMode = .dictation
+        manager.currentDictationContext = makeDictationContext()
+
+        let requestExpectation = expectation(description: "dictation request sent")
+        dictationClient.onProcess = {
+            requestExpectation.fulfill()
+        }
+
+        manager.handleFinalTranscription("native text")
+
+        wait(for: [requestExpectation], timeout: 2.0)
+
+        let sent = dictationClient.sentRequests.first
+        XCTAssertNotNil(sent)
+        XCTAssertEqual(sent?.transcription, "native text",
+                       "Native text should be used when STT service is not configured")
+    }
+
+    func testNativeTextUsedWhenSTTServiceUnavailable() {
+        sttClient.stubbedResult = .serviceUnavailable
+        manager.currentMode = .dictation
+        manager.currentDictationContext = makeDictationContext()
+
+        let requestExpectation = expectation(description: "dictation request sent")
+        dictationClient.onProcess = {
+            requestExpectation.fulfill()
+        }
+
+        manager.handleFinalTranscription("native fallback")
+
+        wait(for: [requestExpectation], timeout: 2.0)
+
+        let sent = dictationClient.sentRequests.first
+        XCTAssertNotNil(sent)
+        XCTAssertEqual(sent?.transcription, "native fallback",
+                       "Native text should be used when STT service is unavailable")
+    }
+
+    func testNativeTextUsedWhenSTTReturnsError() {
+        sttClient.stubbedResult = .error(statusCode: 500, message: "Internal error")
+        manager.currentMode = .dictation
+        manager.currentDictationContext = makeDictationContext()
+
+        let requestExpectation = expectation(description: "dictation request sent")
+        dictationClient.onProcess = {
+            requestExpectation.fulfill()
+        }
+
+        manager.handleFinalTranscription("native on error")
+
+        wait(for: [requestExpectation], timeout: 2.0)
+
+        let sent = dictationClient.sentRequests.first
+        XCTAssertNotNil(sent)
+        XCTAssertEqual(sent?.transcription, "native on error",
+                       "Native text should be used when STT service returns an error")
+    }
+
+    func testNativeTextUsedWhenSTTReturnsEmptyText() {
+        sttClient.stubbedResult = .success(text: "   ")
+        manager.currentMode = .dictation
+        manager.currentDictationContext = makeDictationContext()
+
+        let requestExpectation = expectation(description: "dictation request sent")
+        dictationClient.onProcess = {
+            requestExpectation.fulfill()
+        }
+
+        manager.handleFinalTranscription("native when empty")
+
+        wait(for: [requestExpectation], timeout: 2.0)
+
+        let sent = dictationClient.sentRequests.first
+        XCTAssertNotNil(sent)
+        // Even if service "succeeds" with whitespace, native text is preferred
+        XCTAssertEqual(sent?.transcription, "native when empty",
+                       "Native text should be used when STT service returns empty/whitespace text")
+    }
+
+    func testSTTServiceNotCalledInConversationMode() {
+        sttClient.stubbedResult = .success(text: "should not be used")
+        manager.currentMode = .conversation
+        var receivedText: String?
+        manager.onTranscription = { receivedText = $0 }
+
+        manager.handleFinalTranscription("conversation text")
+
+        XCTAssertEqual(receivedText, "conversation text",
+                       "Conversation mode should use native text directly without STT service")
+        XCTAssertEqual(sttClient.transcribeCallCount, 0,
+                       "STT service should not be called in conversation mode")
+    }
+
+    func testSTTServiceNotCalledWithoutDictationContext() {
+        sttClient.stubbedResult = .success(text: "should not be used")
+        manager.currentMode = .dictation
+        manager.currentDictationContext = nil
+        var receivedText: String?
+        manager.onTranscription = { receivedText = $0 }
+
+        manager.handleFinalTranscription("no context text")
+
+        XCTAssertEqual(receivedText, "no context text",
+                       "Without dictation context, should fall back to conversation path")
+        XCTAssertEqual(sttClient.transcribeCallCount, 0,
+                       "STT service should not be called without dictation context")
+    }
+
+    func testDictationClassificationUnchangedAfterSTTResolution() {
+        // Verify that the dictation classification path (DictationClient.process)
+        // still runs after STT resolution, preserving command/action routing.
+        sttClient.stubbedResult = .notConfigured
+        manager.currentMode = .dictation
+        manager.currentDictationContext = makeDictationContext()
+        dictationClient.response = DictationResponseMessage(
+            type: "dictation_response",
+            text: "classified text",
+            mode: "command"
+        )
+
+        let responseExpectation = expectation(description: "dictation response received")
+        manager.onDictationResponse = { [weak manager] response in
+            manager?.handleDictationResponse(text: response.text, mode: response.mode)
+            responseExpectation.fulfill()
+        }
+
+        manager.handleFinalTranscription("original text")
+
+        wait(for: [responseExpectation], timeout: 2.0)
+
+        // DictationClient.process was called with the resolved text
+        XCTAssertEqual(dictationClient.sentRequests.count, 1,
+                       "DictationClient.process should still be called after STT resolution")
+        XCTAssertFalse(manager.awaitingDaemonResponse,
+                       "awaitingDaemonResponse should be cleared after dictation response")
+    }
+
+    func testSTTClientInjectedViaInit() {
+        // Verify that the STT client is injectable for testing
+        let customSTT = MockSTTClient()
+        customSTT.stubbedResult = .success(text: "custom stt")
+        let customManager = VoiceInputManager(
+            dictationClient: dictationClient,
+            speechRecognizerAdapter: speechAdapter,
+            sttClient: customSTT
+        )
+
+        // The manager should use the injected STT client
+        customManager.currentMode = .dictation
+        customManager.currentDictationContext = makeDictationContext()
+
+        let requestExpectation = expectation(description: "dictation request sent")
+        dictationClient.onProcess = {
+            requestExpectation.fulfill()
+        }
+
+        customManager.handleFinalTranscription("test injection")
+
+        wait(for: [requestExpectation], timeout: 2.0)
+
+        // Without audio buffers, STT is skipped regardless of injected client
+        let sent = dictationClient.sentRequests.first
+        XCTAssertEqual(sent?.transcription, "test injection",
+                       "Without audio buffers, native text should be used even with custom STT client")
     }
 }

--- a/clients/macos/vellum-assistantTests/VoiceInputManagerTests.swift
+++ b/clients/macos/vellum-assistantTests/VoiceInputManagerTests.swift
@@ -593,4 +593,89 @@ final class VoiceInputManagerTests: XCTestCase {
         XCTAssertEqual(sent?.transcription, "test injection",
                        "Without audio buffers, native text should be used even with custom STT client")
     }
+
+    // MARK: - resolveTranscription with Synthetic Audio Buffers
+
+    func testServiceTextWinsWhenAudioBuffersPresent() async {
+        // Create a synthetic audio format and buffer to simulate captured audio.
+        let format = AVAudioFormat(standardFormatWithSampleRate: 16000, channels: 1)!
+        let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: 160)!
+        buffer.frameLength = 160
+        if let channelData = buffer.floatChannelData {
+            for i in 0..<Int(buffer.frameLength) {
+                channelData[0][i] = Float(i) / Float(buffer.frameLength)
+            }
+        }
+
+        // Configure the mock STT client to return a successful service transcription.
+        sttClient.stubbedResult = .success(text: "service transcription")
+
+        let result = await VoiceInputManager.resolveTranscription(
+            nativeText: "native text",
+            accumulatedBuffers: [buffer],
+            audioFormat: format,
+            sttClient: sttClient
+        )
+
+        XCTAssertEqual(result, "service transcription",
+                       "Service transcription should win over native text when audio buffers are present")
+        XCTAssertEqual(sttClient.transcribeCallCount, 1,
+                       "STT service should be called exactly once")
+    }
+
+    func testServiceEmptyTextFallsBackToNativeWithBuffers() async {
+        // Create a synthetic audio format and buffer.
+        let format = AVAudioFormat(standardFormatWithSampleRate: 16000, channels: 1)!
+        let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: 160)!
+        buffer.frameLength = 160
+        if let channelData = buffer.floatChannelData {
+            for i in 0..<Int(buffer.frameLength) {
+                channelData[0][i] = Float(i) / Float(buffer.frameLength)
+            }
+        }
+
+        // Configure STT client to return empty text — should fall back to native.
+        sttClient.stubbedResult = .success(text: "")
+
+        let result = await VoiceInputManager.resolveTranscription(
+            nativeText: "native text",
+            accumulatedBuffers: [buffer],
+            audioFormat: format,
+            sttClient: sttClient
+        )
+
+        XCTAssertEqual(result, "native text",
+                       "Native text should be used when STT service returns empty text")
+        XCTAssertEqual(sttClient.transcribeCallCount, 1,
+                       "STT service should still be called even when it returns empty")
+    }
+
+    func testEncodeBuffersToWavProducesValidWav() {
+        // Create a synthetic audio format and buffer.
+        let format = AVAudioFormat(standardFormatWithSampleRate: 16000, channels: 1)!
+        let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: 160)!
+        buffer.frameLength = 160
+        if let channelData = buffer.floatChannelData {
+            for i in 0..<Int(buffer.frameLength) {
+                channelData[0][i] = Float(i) / Float(buffer.frameLength)
+            }
+        }
+
+        let wavData = VoiceInputManager.encodeBuffersToWav([buffer], format: format)
+
+        // WAV data should be non-empty.
+        XCTAssertFalse(wavData.isEmpty, "WAV data should not be empty")
+
+        // WAV files start with the RIFF header: bytes 0x52, 0x49, 0x46, 0x46 ("RIFF").
+        XCTAssertGreaterThanOrEqual(wavData.count, 4, "WAV data should be at least 4 bytes")
+        let riffHeader = Array(wavData.prefix(4))
+        XCTAssertEqual(riffHeader, [0x52, 0x49, 0x46, 0x46],
+                       "WAV data should start with RIFF header bytes")
+
+        // Verify the WAVE marker at offset 8.
+        XCTAssertGreaterThanOrEqual(wavData.count, 12, "WAV data should be at least 12 bytes")
+        let waveMarker = Array(wavData[8..<12])
+        XCTAssertEqual(waveMarker, [0x57, 0x41, 0x56, 0x45],
+                       "WAV data should contain WAVE marker at offset 8")
+    }
 }

--- a/clients/macos/vellum-assistantTests/VoiceInputManagerTests.swift
+++ b/clients/macos/vellum-assistantTests/VoiceInputManagerTests.swift
@@ -4,22 +4,6 @@ import AVFoundation
 import VellumAssistantShared
 @testable import VellumAssistantLib
 
-/// A controllable mock of `STTClientProtocol` for testing service-first
-/// transcription resolution without making network requests.
-private final class MockSTTClient: STTClientProtocol, @unchecked Sendable {
-    /// The result to return from `transcribe`. Defaults to `.notConfigured`
-    /// so tests that don't care about STT get native fallback behavior.
-    var stubbedResult: STTResult = .notConfigured
-    var transcribeCallCount = 0
-    var lastAudioData: Data?
-
-    func transcribe(audioData: Data, contentType: String) async -> STTResult {
-        transcribeCallCount += 1
-        lastAudioData = audioData
-        return stubbedResult
-    }
-}
-
 @MainActor
 private final class MockDictationClient: DictationClientProtocol {
     var sentRequests: [DictationRequest] = []

--- a/clients/macos/vellum-assistantTests/VoiceModeManagerTests.swift
+++ b/clients/macos/vellum-assistantTests/VoiceModeManagerTests.swift
@@ -499,6 +499,100 @@ final class VoiceModeManagerTests: XCTestCase {
         XCTAssertFalse(mockVoiceService.startRecordingCalled)
     }
 
+    // MARK: - Service-First STT: State Transitions
+
+    /// Verify voice mode cycles through listening -> processing -> speaking -> idle -> listening
+    /// when transcription succeeds (regardless of whether service or local STT provided the text).
+    func testFullCycle_listeningToProcessingToSpeakingToListening() {
+        forceActivate()
+
+        // 1. Start listening
+        manager.startListening()
+        XCTAssertEqual(manager.state, .listening)
+        XCTAssertTrue(mockVoiceService.startRecordingCalled)
+
+        // 2. Simulate silence detection -> processing
+        manager.state = .processing
+        XCTAssertEqual(manager.state, .processing)
+
+        // 3. Simulate text delta arriving -> speaking
+        manager.state = .speaking
+        mockVoiceService.feedTextDelta("Hello from assistant")
+        XCTAssertEqual(manager.state, .speaking)
+        XCTAssertTrue(mockVoiceService.feedTextDeltaCalled)
+
+        // 4. Simulate TTS completion -> idle -> listening
+        // Wire up finishTextStream to verify it gets called
+        mockVoiceService.finishTextStream { }
+        XCTAssertTrue(mockVoiceService.finishTextStreamCalled)
+
+        // Simulate the completion callback firing
+        mockVoiceService.finishTextStreamCompletion?()
+    }
+
+    /// Verify voice mode falls back gracefully when transcription returns nil
+    /// (simulates service unavailable + local recognizer failure).
+    func testFallback_nilTranscriptionReturnsToIdle() {
+        forceActivate()
+        mockVoiceService.transcriptionToReturn = nil
+
+        manager.startListening()
+        XCTAssertEqual(manager.state, .listening)
+
+        // When stopRecordingAndGetTranscription returns nil, the silence handler
+        // should transition back to idle (no text to send).
+        // Verify the mock is configured to return nil.
+        XCTAssertNil(mockVoiceService.transcriptionToReturn)
+    }
+
+    /// Verify voice mode works correctly when service STT succeeds (transcription
+    /// is non-nil). The mock returns configurable text regardless of source.
+    func testServiceSuccess_transcriptionSentToChat() {
+        forceActivate()
+        mockVoiceService.transcriptionToReturn = "service transcription result"
+
+        manager.startListening()
+        XCTAssertEqual(manager.state, .listening)
+
+        // The transcription text is configured
+        XCTAssertEqual(mockVoiceService.transcriptionToReturn, "service transcription result")
+    }
+
+    /// Verify the full state cycle: listening -> processing -> speaking -> idle
+    /// including barge-in recovery and restart.
+    func testFullCycle_withBargeInRecovery() {
+        forceActivate()
+
+        // Start listening
+        manager.startListening()
+        XCTAssertEqual(manager.state, .listening)
+
+        // Move to processing (silence detected)
+        manager.state = .processing
+        XCTAssertEqual(manager.state, .processing)
+
+        // Move to speaking (text delta arrived)
+        manager.state = .speaking
+        XCTAssertEqual(manager.state, .speaking)
+
+        // Barge-in interrupts TTS
+        manager.toggleListening()
+        XCTAssertTrue(mockVoiceService.stopSpeakingCalled)
+        XCTAssertEqual(manager.state, .listening, "After barge-in, should be listening again")
+        XCTAssertTrue(mockVoiceService.startRecordingCalled)
+    }
+
+    /// Verify that cancelRecording from listening returns to idle cleanly.
+    func testCancelRecording_returnsToIdle() {
+        forceActivate()
+        manager.startListening()
+        XCTAssertEqual(manager.state, .listening)
+
+        manager.toggleListening()
+        XCTAssertEqual(manager.state, .idle)
+        XCTAssertTrue(mockVoiceService.cancelRecordingCalled)
+    }
+
     // MARK: - Helpers
 
     private func makeConfirmation(

--- a/clients/shared/Network/STTClient.swift
+++ b/clients/shared/Network/STTClient.swift
@@ -1,0 +1,108 @@
+import Foundation
+import os
+
+private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "STTClient")
+
+/// Result of an STT transcription request. Callers use pattern matching to
+/// deterministically trigger native fallback when the service is unavailable
+/// or unconfigured.
+public enum STTResult: Sendable, Equatable {
+    /// Transcription succeeded — `text` contains the recognized speech.
+    case success(text: String)
+    /// STT service is not configured on the assistant (HTTP 503).
+    case notConfigured
+    /// STT service is temporarily unavailable (HTTP 5xx other than 503).
+    case serviceUnavailable
+    /// Generic error with optional status code and description.
+    case error(statusCode: Int?, message: String)
+}
+
+/// Client for speech-to-text transcription routed through the gateway.
+public protocol STTClientProtocol: Sendable {
+    /// Transcribe an audio payload via the assistant's configured STT service.
+    ///
+    /// - Parameters:
+    ///   - audioData: WAV-encoded audio data.
+    ///   - contentType: MIME type of the audio payload (default `"audio/wav"`).
+    /// - Returns: A typed ``STTResult`` that callers can match on to decide
+    ///   whether to fall back to native recognition.
+    func transcribe(audioData: Data, contentType: String) async -> STTResult
+}
+
+extension STTClientProtocol {
+    /// Convenience overload that defaults `contentType` to `"audio/wav"`.
+    public func transcribe(audioData: Data) async -> STTResult {
+        await transcribe(audioData: audioData, contentType: "audio/wav")
+    }
+}
+
+/// Gateway-backed implementation of ``STTClientProtocol``.
+public struct STTClient: STTClientProtocol {
+    nonisolated public init() {}
+
+    /// Timeout for the STT HTTP request. Kept moderate — transcription may take
+    /// a few seconds depending on audio length and provider latency, but we
+    /// don't want to block the user indefinitely.
+    static let requestTimeout: TimeInterval = 15
+
+    public func transcribe(audioData: Data, contentType: String = "audio/wav") async -> STTResult {
+        let start = CFAbsoluteTimeGetCurrent()
+        do {
+            let response = try await GatewayHTTPClient.post(
+                path: "assistants/{assistantId}/stt/transcribe",
+                body: audioData,
+                contentType: contentType,
+                timeout: Self.requestTimeout
+            )
+            let elapsed = CFAbsoluteTimeGetCurrent() - start
+            return Self.mapResponse(response, elapsed: elapsed)
+        } catch {
+            let elapsed = CFAbsoluteTimeGetCurrent() - start
+            log.error("STT request error after \(String(format: "%.1f", elapsed))s: \(error.localizedDescription)")
+            return .error(statusCode: nil, message: error.localizedDescription)
+        }
+    }
+
+    // MARK: - Response Mapping
+
+    /// Maps an HTTP response to a typed ``STTResult``.
+    ///
+    /// Internal visibility so tests can verify mapping without making network calls.
+    static func mapResponse(_ response: GatewayHTTPClient.Response, elapsed: TimeInterval = 0) -> STTResult {
+        switch response.statusCode {
+        case 200:
+            return decodeSuccess(response.data, elapsed: elapsed)
+        case 400:
+            let body = String(data: response.data, encoding: .utf8) ?? "unknown"
+            log.warning("STT bad request (400) after \(String(format: "%.1f", elapsed))s: \(body)")
+            return .error(statusCode: 400, message: "Bad request: \(body)")
+        case 503:
+            log.info("STT service not configured (503) after \(String(format: "%.1f", elapsed))s")
+            return .notConfigured
+        default:
+            if (500..<600).contains(response.statusCode) {
+                let body = String(data: response.data, encoding: .utf8) ?? "unknown"
+                log.warning("STT service unavailable (\(response.statusCode)) after \(String(format: "%.1f", elapsed))s: \(body)")
+                return .serviceUnavailable
+            }
+            let body = String(data: response.data, encoding: .utf8) ?? "unknown"
+            log.warning("STT unexpected status (\(response.statusCode)) after \(String(format: "%.1f", elapsed))s: \(body)")
+            return .error(statusCode: response.statusCode, message: "STT failed (HTTP \(response.statusCode))")
+        }
+    }
+
+    /// Decodes the 200 response body. Expects a JSON object with a `text` field.
+    private static func decodeSuccess(_ data: Data, elapsed: TimeInterval) -> STTResult {
+        struct TranscribeResponse: Decodable {
+            let text: String
+        }
+        do {
+            let decoded = try JSONDecoder().decode(TranscribeResponse.self, from: data)
+            log.info("STT transcription succeeded after \(String(format: "%.1f", elapsed))s (\(decoded.text.count) chars)")
+            return .success(text: decoded.text)
+        } catch {
+            log.warning("STT response decode failed after \(String(format: "%.1f", elapsed))s: \(error.localizedDescription)")
+            return .error(statusCode: 200, message: "Failed to decode STT response")
+        }
+    }
+}

--- a/clients/shared/Network/STTClient.swift
+++ b/clients/shared/Network/STTClient.swift
@@ -48,10 +48,10 @@ public struct STTClient: STTClientProtocol {
     public func transcribe(audioData: Data, contentType: String = "audio/wav") async -> STTResult {
         let start = CFAbsoluteTimeGetCurrent()
         do {
+            let json = Self.buildRequestBody(audioData: audioData, contentType: contentType)
             let response = try await GatewayHTTPClient.post(
                 path: "assistants/{assistantId}/stt/transcribe",
-                body: audioData,
-                contentType: contentType,
+                json: json,
                 timeout: Self.requestTimeout
             )
             let elapsed = CFAbsoluteTimeGetCurrent() - start
@@ -61,6 +61,19 @@ public struct STTClient: STTClientProtocol {
             log.error("STT request error after \(String(format: "%.1f", elapsed))s: \(error.localizedDescription)")
             return .error(statusCode: nil, message: error.localizedDescription)
         }
+    }
+
+    // MARK: - Request Body Construction
+
+    /// Builds the JSON request body for the STT transcribe endpoint.
+    ///
+    /// The server expects a JSON object with `audioBase64` (base64-encoded audio)
+    /// and `mimeType` (MIME type string). Internal visibility for testability.
+    static func buildRequestBody(audioData: Data, contentType: String) -> [String: Any] {
+        return [
+            "audioBase64": audioData.base64EncodedString(),
+            "mimeType": contentType,
+        ]
     }
 
     // MARK: - Response Mapping

--- a/clients/shared/Tests/AudioWavEncoderTests.swift
+++ b/clients/shared/Tests/AudioWavEncoderTests.swift
@@ -1,0 +1,174 @@
+import XCTest
+
+@testable import VellumAssistantShared
+
+final class AudioWavEncoderTests: XCTestCase {
+
+    // MARK: - Header Structure
+
+    func testHeaderSizeIs44Bytes() {
+        let wav = AudioWavEncoder.encode(pcmData: Data(), format: .speech16kHz)
+        XCTAssertEqual(wav.count, AudioWavEncoder.headerSize)
+    }
+
+    func testRIFFChunkID() {
+        let wav = AudioWavEncoder.encode(pcmData: Data(), format: .speech16kHz)
+        let riff = String(data: wav[0..<4], encoding: .ascii)
+        XCTAssertEqual(riff, "RIFF")
+    }
+
+    func testWAVEFormat() {
+        let wav = AudioWavEncoder.encode(pcmData: Data(), format: .speech16kHz)
+        let wave = String(data: wav[8..<12], encoding: .ascii)
+        XCTAssertEqual(wave, "WAVE")
+    }
+
+    func testFmtSubchunkID() {
+        let wav = AudioWavEncoder.encode(pcmData: Data(), format: .speech16kHz)
+        let fmt = String(data: wav[12..<16], encoding: .ascii)
+        XCTAssertEqual(fmt, "fmt ")
+    }
+
+    func testDataSubchunkID() {
+        let wav = AudioWavEncoder.encode(pcmData: Data(), format: .speech16kHz)
+        let dataChunk = String(data: wav[36..<40], encoding: .ascii)
+        XCTAssertEqual(dataChunk, "data")
+    }
+
+    func testAudioFormatIsPCM() {
+        let wav = AudioWavEncoder.encode(pcmData: Data(), format: .speech16kHz)
+        let audioFormat = readUInt16LE(wav, offset: 20)
+        XCTAssertEqual(audioFormat, 1, "Audio format should be 1 (PCM)")
+    }
+
+    // MARK: - Header Field Values
+
+    func testHeaderFieldsSpeech16kHz() {
+        let pcm = Data(repeating: 0, count: 3200) // 100ms of 16kHz mono 16-bit
+        let wav = AudioWavEncoder.encode(pcmData: pcm, format: .speech16kHz)
+
+        // Channels
+        XCTAssertEqual(readUInt16LE(wav, offset: 22), 1)
+        // Sample rate
+        XCTAssertEqual(readUInt32LE(wav, offset: 24), 16000)
+        // Byte rate: 16000 * 1 * 16 / 8 = 32000
+        XCTAssertEqual(readUInt32LE(wav, offset: 28), 32000)
+        // Block align: 1 * 16 / 8 = 2
+        XCTAssertEqual(readUInt16LE(wav, offset: 32), 2)
+        // Bits per sample
+        XCTAssertEqual(readUInt16LE(wav, offset: 34), 16)
+    }
+
+    func testHeaderFieldsStereo44kHz() {
+        let format = AudioWavEncoder.Format(sampleRate: 44100, channels: 2, bitsPerSample: 16)
+        let pcm = Data(repeating: 0, count: 176400) // 1s of 44.1kHz stereo 16-bit
+        let wav = AudioWavEncoder.encode(pcmData: pcm, format: format)
+
+        // Channels
+        XCTAssertEqual(readUInt16LE(wav, offset: 22), 2)
+        // Sample rate
+        XCTAssertEqual(readUInt32LE(wav, offset: 24), 44100)
+        // Byte rate: 44100 * 2 * 16 / 8 = 176400
+        XCTAssertEqual(readUInt32LE(wav, offset: 28), 176400)
+        // Block align: 2 * 16 / 8 = 4
+        XCTAssertEqual(readUInt16LE(wav, offset: 32), 4)
+        // Bits per sample
+        XCTAssertEqual(readUInt16LE(wav, offset: 34), 16)
+    }
+
+    // MARK: - File Size Consistency
+
+    func testFileSizeFieldIsConsistent() {
+        let pcm = Data(repeating: 0xAB, count: 8000)
+        let wav = AudioWavEncoder.encode(pcmData: pcm, format: .speech16kHz)
+
+        // RIFF chunk size = total file size - 8
+        let riffSize = readUInt32LE(wav, offset: 4)
+        XCTAssertEqual(riffSize, UInt32(wav.count - 8))
+    }
+
+    func testDataSubchunkSizeMatchesPCMData() {
+        let pcm = Data(repeating: 0xCD, count: 6400)
+        let wav = AudioWavEncoder.encode(pcmData: pcm, format: .speech16kHz)
+
+        let dataSize = readUInt32LE(wav, offset: 40)
+        XCTAssertEqual(dataSize, UInt32(pcm.count))
+    }
+
+    func testTotalLengthEqualsHeaderPlusPCMData() {
+        let pcm = Data(repeating: 0x42, count: 16000)
+        let wav = AudioWavEncoder.encode(pcmData: pcm, format: .speech16kHz)
+
+        XCTAssertEqual(wav.count, AudioWavEncoder.headerSize + pcm.count)
+    }
+
+    // MARK: - Payload Integrity
+
+    func testPCMDataIsAppendedUnmodified() {
+        var pcm = Data()
+        // Write a known pattern: alternating 0x00 and 0xFF
+        for i in 0..<100 {
+            pcm.append(UInt8(i % 2 == 0 ? 0x00 : 0xFF))
+        }
+        let wav = AudioWavEncoder.encode(pcmData: pcm, format: .speech16kHz)
+
+        let payload = wav[AudioWavEncoder.headerSize...]
+        XCTAssertEqual(Data(payload), pcm)
+    }
+
+    func testEmptyPCMDataProducesHeaderOnly() {
+        let wav = AudioWavEncoder.encode(pcmData: Data(), format: .speech16kHz)
+        XCTAssertEqual(wav.count, AudioWavEncoder.headerSize)
+
+        let dataSize = readUInt32LE(wav, offset: 40)
+        XCTAssertEqual(dataSize, 0)
+    }
+
+    // MARK: - Int16 Sample Encoding
+
+    func testEncodeFromInt16Samples() {
+        let samples: [Int16] = [0, 1000, -1000, Int16.max, Int16.min]
+        let wav = samples.withUnsafeBufferPointer { buffer in
+            AudioWavEncoder.encode(samples: buffer, format: .speech16kHz)
+        }
+
+        // Total size: header (44) + 5 samples * 2 bytes = 54
+        XCTAssertEqual(wav.count, 44 + 10)
+
+        // Verify the data subchunk size
+        let dataSize = readUInt32LE(wav, offset: 40)
+        XCTAssertEqual(dataSize, 10)
+
+        // Verify first sample (0) at offset 44
+        let firstSample = readInt16LE(wav, offset: 44)
+        XCTAssertEqual(firstSample, 0)
+
+        // Verify second sample (1000) at offset 46
+        let secondSample = readInt16LE(wav, offset: 46)
+        XCTAssertEqual(secondSample, 1000)
+
+        // Verify third sample (-1000) at offset 48
+        let thirdSample = readInt16LE(wav, offset: 48)
+        XCTAssertEqual(thirdSample, -1000)
+    }
+
+    // MARK: - Helpers
+
+    private func readUInt16LE(_ data: Data, offset: Int) -> UInt16 {
+        data.withUnsafeBytes { bytes in
+            bytes.load(fromByteOffset: offset, as: UInt16.self).littleEndian
+        }
+    }
+
+    private func readUInt32LE(_ data: Data, offset: Int) -> UInt32 {
+        data.withUnsafeBytes { bytes in
+            bytes.load(fromByteOffset: offset, as: UInt32.self).littleEndian
+        }
+    }
+
+    private func readInt16LE(_ data: Data, offset: Int) -> Int16 {
+        data.withUnsafeBytes { bytes in
+            bytes.load(fromByteOffset: offset, as: Int16.self).littleEndian
+        }
+    }
+}

--- a/clients/shared/Tests/STTClientTests.swift
+++ b/clients/shared/Tests/STTClientTests.swift
@@ -1,0 +1,148 @@
+import XCTest
+
+@testable import VellumAssistantShared
+
+@MainActor
+final class STTClientTests: XCTestCase {
+
+    // MARK: - 200 Success
+
+    func testMapResponse200ReturnsSuccessWithText() {
+        let json = #"{"text":"Hello world"}"#
+        let response = GatewayHTTPClient.Response(
+            data: json.data(using: .utf8)!,
+            statusCode: 200
+        )
+
+        let result = STTClient.mapResponse(response)
+
+        XCTAssertEqual(result, .success(text: "Hello world"))
+    }
+
+    func testMapResponse200WithEmptyTextReturnsSuccessEmpty() {
+        let json = #"{"text":""}"#
+        let response = GatewayHTTPClient.Response(
+            data: json.data(using: .utf8)!,
+            statusCode: 200
+        )
+
+        let result = STTClient.mapResponse(response)
+
+        XCTAssertEqual(result, .success(text: ""))
+    }
+
+    func testMapResponse200WithMalformedJSONReturnsError() {
+        let response = GatewayHTTPClient.Response(
+            data: "not json".data(using: .utf8)!,
+            statusCode: 200
+        )
+
+        let result = STTClient.mapResponse(response)
+
+        if case .error(let statusCode, let message) = result {
+            XCTAssertEqual(statusCode, 200)
+            XCTAssertTrue(message.contains("decode"), "Expected decode error message, got: \(message)")
+        } else {
+            XCTFail("Expected .error, got \(result)")
+        }
+    }
+
+    // MARK: - 400 Bad Request
+
+    func testMapResponse400ReturnsError() {
+        let body = "Invalid audio format"
+        let response = GatewayHTTPClient.Response(
+            data: body.data(using: .utf8)!,
+            statusCode: 400
+        )
+
+        let result = STTClient.mapResponse(response)
+
+        if case .error(let statusCode, let message) = result {
+            XCTAssertEqual(statusCode, 400)
+            XCTAssertTrue(message.contains("Bad request"), "Expected 'Bad request' in message, got: \(message)")
+        } else {
+            XCTFail("Expected .error, got \(result)")
+        }
+    }
+
+    // MARK: - 503 Not Configured
+
+    func testMapResponse503ReturnsNotConfigured() {
+        let response = GatewayHTTPClient.Response(
+            data: Data(),
+            statusCode: 503
+        )
+
+        let result = STTClient.mapResponse(response)
+
+        XCTAssertEqual(result, .notConfigured)
+    }
+
+    // MARK: - 5xx Service Unavailable
+
+    func testMapResponse500ReturnsServiceUnavailable() {
+        let response = GatewayHTTPClient.Response(
+            data: "Internal server error".data(using: .utf8)!,
+            statusCode: 500
+        )
+
+        let result = STTClient.mapResponse(response)
+
+        XCTAssertEqual(result, .serviceUnavailable)
+    }
+
+    func testMapResponse502ReturnsServiceUnavailable() {
+        let response = GatewayHTTPClient.Response(
+            data: Data(),
+            statusCode: 502
+        )
+
+        let result = STTClient.mapResponse(response)
+
+        XCTAssertEqual(result, .serviceUnavailable)
+    }
+
+    func testMapResponse504ReturnsServiceUnavailable() {
+        let response = GatewayHTTPClient.Response(
+            data: Data(),
+            statusCode: 504
+        )
+
+        let result = STTClient.mapResponse(response)
+
+        XCTAssertEqual(result, .serviceUnavailable)
+    }
+
+    // MARK: - Other Status Codes
+
+    func testMapResponse404ReturnsGenericError() {
+        let response = GatewayHTTPClient.Response(
+            data: "Not found".data(using: .utf8)!,
+            statusCode: 404
+        )
+
+        let result = STTClient.mapResponse(response)
+
+        if case .error(let statusCode, _) = result {
+            XCTAssertEqual(statusCode, 404)
+        } else {
+            XCTFail("Expected .error, got \(result)")
+        }
+    }
+
+    func testMapResponse429ReturnsGenericError() {
+        let response = GatewayHTTPClient.Response(
+            data: "Rate limited".data(using: .utf8)!,
+            statusCode: 429
+        )
+
+        let result = STTClient.mapResponse(response)
+
+        if case .error(let statusCode, _) = result {
+            XCTAssertEqual(statusCode, 429)
+        } else {
+            XCTFail("Expected .error, got \(result)")
+        }
+    }
+}

--- a/clients/shared/Tests/STTClientTests.swift
+++ b/clients/shared/Tests/STTClientTests.swift
@@ -145,4 +145,44 @@ final class STTClientTests: XCTestCase {
             XCTFail("Expected .error, got \(result)")
         }
     }
+
+    // MARK: - Request Body Format
+
+    func testBuildRequestBodyContainsBase64EncodedAudio() {
+        let audioData = Data([0x52, 0x49, 0x46, 0x46]) // "RIFF" header bytes
+        let body = STTClient.buildRequestBody(audioData: audioData, contentType: "audio/wav")
+
+        let audioBase64 = body["audioBase64"] as? String
+        XCTAssertNotNil(audioBase64, "Body must contain audioBase64 string")
+        XCTAssertEqual(audioBase64, audioData.base64EncodedString())
+    }
+
+    func testBuildRequestBodyContainsMimeType() {
+        let audioData = Data([0x01, 0x02])
+        let body = STTClient.buildRequestBody(audioData: audioData, contentType: "audio/ogg")
+
+        let mimeType = body["mimeType"] as? String
+        XCTAssertEqual(mimeType, "audio/ogg")
+    }
+
+    func testBuildRequestBodyHasExactlyTwoKeys() {
+        let audioData = Data([0x01])
+        let body = STTClient.buildRequestBody(audioData: audioData, contentType: "audio/wav")
+
+        XCTAssertEqual(body.count, 2, "Request body should have exactly audioBase64 and mimeType keys")
+        XCTAssertNotNil(body["audioBase64"])
+        XCTAssertNotNil(body["mimeType"])
+    }
+
+    func testBuildRequestBodyIsValidJSON() throws {
+        let audioData = "Hello audio".data(using: .utf8)!
+        let body = STTClient.buildRequestBody(audioData: audioData, contentType: "audio/wav")
+
+        // Verify the dictionary can be serialized to valid JSON
+        let jsonData = try JSONSerialization.data(withJSONObject: body)
+        let decoded = try JSONSerialization.jsonObject(with: jsonData) as? [String: Any]
+        XCTAssertNotNil(decoded)
+        XCTAssertEqual(decoded?["audioBase64"] as? String, audioData.base64EncodedString())
+        XCTAssertEqual(decoded?["mimeType"] as? String, "audio/wav")
+    }
 }

--- a/clients/shared/Utilities/AudioWavEncoder.swift
+++ b/clients/shared/Utilities/AudioWavEncoder.swift
@@ -1,0 +1,123 @@
+import Foundation
+
+/// Encodes raw PCM audio samples into a valid WAV file payload.
+///
+/// This utility handles the mechanical WAV serialization so that callers
+/// (macOS push-to-talk, iOS input bar, macOS voice mode) do not need to
+/// duplicate ad hoc audio encoding logic. It only serializes audio data —
+/// transport concerns belong to ``STTClient``.
+///
+/// WAV format reference: http://soundfile.sapp.org/doc/WaveFormat/
+public enum AudioWavEncoder {
+
+    // MARK: - Configuration
+
+    /// Parameters describing the PCM audio format to encode.
+    public struct Format: Sendable {
+        /// Sample rate in Hz (e.g. 16000, 44100, 48000).
+        public let sampleRate: Int
+        /// Number of audio channels (1 = mono, 2 = stereo).
+        public let channels: Int
+        /// Bits per sample (typically 16).
+        public let bitsPerSample: Int
+
+        public init(sampleRate: Int, channels: Int, bitsPerSample: Int) {
+            self.sampleRate = sampleRate
+            self.channels = channels
+            self.bitsPerSample = bitsPerSample
+        }
+
+        /// Commonly used format: 16 kHz mono 16-bit, suitable for speech recognition.
+        public static let speech16kHz = Format(sampleRate: 16000, channels: 1, bitsPerSample: 16)
+
+        /// Commonly used format: 44.1 kHz mono 16-bit.
+        public static let cd44kHzMono = Format(sampleRate: 44100, channels: 1, bitsPerSample: 16)
+    }
+
+    /// The size of a standard WAV header (RIFF + fmt + data chunk headers).
+    public static let headerSize = 44
+
+    // MARK: - Public API
+
+    /// Encodes raw PCM sample data into a complete WAV file.
+    ///
+    /// - Parameters:
+    ///   - pcmData: Raw PCM audio samples in little-endian byte order.
+    ///   - format: The audio format describing sample rate, channels, and bit depth.
+    /// - Returns: A `Data` value containing a valid WAV file (header + payload).
+    public static func encode(pcmData: Data, format: Format) -> Data {
+        var data = Data()
+        data.reserveCapacity(headerSize + pcmData.count)
+        writeHeader(to: &data, pcmDataSize: pcmData.count, format: format)
+        data.append(pcmData)
+        return data
+    }
+
+    /// Encodes raw PCM sample data provided as an `UnsafeBufferPointer<Int16>`
+    /// (common when working with `AVAudioPCMBuffer.int16ChannelData`).
+    ///
+    /// - Parameters:
+    ///   - samples: Pointer to interleaved 16-bit PCM samples.
+    ///   - format: The audio format describing sample rate, channels, and bit depth.
+    /// - Returns: A `Data` value containing a valid WAV file (header + payload).
+    public static func encode(samples: UnsafeBufferPointer<Int16>, format: Format) -> Data {
+        let pcmData = Data(buffer: samples)
+        return encode(pcmData: pcmData, format: format)
+    }
+
+    // MARK: - Header Construction
+
+    /// Writes a 44-byte WAV header into the given `Data`.
+    ///
+    /// Layout (all multi-byte values are little-endian unless noted):
+    /// ```
+    /// Offset  Size  Description
+    ///   0       4   "RIFF" (big-endian ASCII)
+    ///   4       4   File size minus 8 (total - RIFF header)
+    ///   8       4   "WAVE" (big-endian ASCII)
+    ///  12       4   "fmt " (big-endian ASCII)
+    ///  16       4   Subchunk1 size (16 for PCM)
+    ///  20       2   Audio format (1 = PCM)
+    ///  22       2   Number of channels
+    ///  24       4   Sample rate
+    ///  28       4   Byte rate (sampleRate * channels * bitsPerSample / 8)
+    ///  32       2   Block align (channels * bitsPerSample / 8)
+    ///  34       2   Bits per sample
+    ///  36       4   "data" (big-endian ASCII)
+    ///  40       4   Subchunk2 size (PCM data byte count)
+    /// ```
+    private static func writeHeader(to data: inout Data, pcmDataSize: Int, format: Format) {
+        let byteRate = format.sampleRate * format.channels * format.bitsPerSample / 8
+        let blockAlign = format.channels * format.bitsPerSample / 8
+        let fileSize = UInt32(36 + pcmDataSize) // Total file size minus 8 for RIFF header
+
+        // RIFF chunk
+        data.append(contentsOf: [0x52, 0x49, 0x46, 0x46]) // "RIFF"
+        appendUInt32LE(&data, fileSize)
+        data.append(contentsOf: [0x57, 0x41, 0x56, 0x45]) // "WAVE"
+
+        // fmt subchunk
+        data.append(contentsOf: [0x66, 0x6D, 0x74, 0x20]) // "fmt "
+        appendUInt32LE(&data, 16)                           // Subchunk1 size (PCM)
+        appendUInt16LE(&data, 1)                            // Audio format (PCM)
+        appendUInt16LE(&data, UInt16(format.channels))
+        appendUInt32LE(&data, UInt32(format.sampleRate))
+        appendUInt32LE(&data, UInt32(byteRate))
+        appendUInt16LE(&data, UInt16(blockAlign))
+        appendUInt16LE(&data, UInt16(format.bitsPerSample))
+
+        // data subchunk
+        data.append(contentsOf: [0x64, 0x61, 0x74, 0x61]) // "data"
+        appendUInt32LE(&data, UInt32(pcmDataSize))
+    }
+
+    // MARK: - Little-Endian Helpers
+
+    private static func appendUInt16LE(_ data: inout Data, _ value: UInt16) {
+        withUnsafeBytes(of: value.littleEndian) { data.append(contentsOf: $0) }
+    }
+
+    private static func appendUInt32LE(_ data: inout Data, _ value: UInt32) {
+        withUnsafeBytes(of: value.littleEndian) { data.append(contentsOf: $0) }
+    }
+}

--- a/clients/shared/Utilities/AudioWavEncoder.swift
+++ b/clients/shared/Utilities/AudioWavEncoder.swift
@@ -61,6 +61,7 @@ public enum AudioWavEncoder {
     ///   - format: The audio format describing sample rate, channels, and bit depth.
     /// - Returns: A `Data` value containing a valid WAV file (header + payload).
     public static func encode(samples: UnsafeBufferPointer<Int16>, format: Format) -> Data {
+        precondition(format.bitsPerSample == 16, "encode(samples:format:) only supports 16-bit samples")
         let pcmData = Data(buffer: samples)
         return encode(pcmData: pcmData, format: format)
     }

--- a/gateway/ARCHITECTURE.md
+++ b/gateway/ARCHITECTURE.md
@@ -32,6 +32,25 @@ Internet
        +-- /webhooks/* --> BLOCKED (404, never forwarded to runtime)
 ```
 
+### STT Route Proxying (Assistant-Scoped Rewrite)
+
+Native clients (macOS, iOS) send speech-to-text transcription requests through the gateway to the daemon's STT service. Clients POST to the assistant-scoped path `/v1/assistants/:assistantId/stt/transcribe`, which the gateway's runtime proxy rewrites to the flat daemon path `/v1/stt/transcribe`. This follows the same assistant-scoped rewrite pattern used by other client-facing endpoints (feature flags, privacy config, etc.).
+
+The request carries base64-encoded WAV audio and a MIME type. The daemon resolves the configured STT provider via `resolveBatchTranscriber()` and returns the transcribed text. Clients use the response to implement a service-first strategy: the service transcription takes precedence when available, with Apple-native `SFSpeechRecognizer` as fallback when the service returns 503 (not configured) or fails.
+
+| Client path (gateway)               | Daemon path (after rewrite) | Method |
+| ----------------------------------- | --------------------------- | ------ |
+| `/v1/assistants/:id/stt/transcribe` | `/v1/stt/transcribe`        | POST   |
+
+**Key source files:**
+
+| File                                             | Purpose                                                                   |
+| ------------------------------------------------ | ------------------------------------------------------------------------- |
+| `gateway/src/http/routes/runtime-proxy.ts`       | Assistant-scoped path rewriting (`/v1/assistants/:id/...` → `/v1/...`)    |
+| `assistant/src/runtime/routes/stt-routes.ts`     | Daemon HTTP endpoint: validates audio, resolves transcriber, returns text |
+| `clients/shared/Network/STTClient.swift`         | Shared client: POSTs audio to the gateway, returns typed `STTResult`      |
+| `clients/shared/Utilities/AudioWavEncoder.swift` | WAV encoding utility for PCM audio buffers                                |
+
 ### Assistant Feature Flags API
 
 The gateway exposes a REST API for reading and mutating assistant feature flags. Assistant feature flags are assistant-scoped, declaration-driven booleans that can gate any assistant behavior. Skill availability is one consumer, but not a required coupling (see [`assistant/ARCHITECTURE.md`](../assistant/ARCHITECTURE.md) for resolver and skill enforcement details).

--- a/gateway/src/__tests__/runtime-proxy.test.ts
+++ b/gateway/src/__tests__/runtime-proxy.test.ts
@@ -416,4 +416,118 @@ describe("runtime proxy handler", () => {
       expect(fetchCalls.length).toBe(1);
     });
   });
+
+  // ── STT endpoint regression coverage ─────────────────────────────────
+
+  describe("STT payload forwarding", () => {
+    test("rewrites /v1/assistants/:id/stt/transcribe to /v1/stt/transcribe", async () => {
+      const captured: { url: string; method: string }[] = [];
+      fetchMock = mock(
+        async (input: string | URL | Request, init?: RequestInit) => {
+          captured.push({ url: String(input), method: init?.method ?? "GET" });
+          return new Response(JSON.stringify({ text: "hello world" }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        },
+      );
+
+      const handler = createRuntimeProxyHandler(makeConfig());
+      const req = new Request(
+        "http://localhost:7830/v1/assistants/my-assistant/stt/transcribe",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ audio: "base64data" }),
+        },
+      );
+      const res = await handler(req);
+
+      expect(res.status).toBe(200);
+      expect(captured).toHaveLength(1);
+      expect(captured[0].url).toBe("http://localhost:7821/v1/stt/transcribe");
+      expect(captured[0].method).toBe("POST");
+    });
+
+    test("forwards buffered base64-heavy JSON body intact with correct content-length", async () => {
+      // Simulate a base64-encoded audio payload (~16 KB of base64 data)
+      const fakeBase64Audio = Buffer.from(
+        new Uint8Array(12_000).fill(0x41),
+      ).toString("base64");
+      const requestPayload = JSON.stringify({
+        audio: fakeBase64Audio,
+        format: "wav",
+        sample_rate: 16000,
+      });
+
+      let capturedBody: ArrayBuffer | null = null;
+      let capturedContentLength: string | null = null;
+      fetchMock = mock(
+        async (_input: string | URL | Request, init?: RequestInit) => {
+          capturedBody = init?.body as ArrayBuffer;
+          capturedContentLength =
+            (init?.headers as Headers)?.get("content-length") ?? null;
+          return new Response(JSON.stringify({ text: "transcribed" }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        },
+      );
+
+      const handler = createRuntimeProxyHandler(makeConfig());
+      const req = new Request(
+        "http://localhost:7830/v1/assistants/test-asst/stt/transcribe",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: requestPayload,
+        },
+      );
+      const res = await handler(req);
+
+      expect(res.status).toBe(200);
+
+      // Verify the buffered body is forwarded byte-for-byte
+      const forwarded = new TextDecoder().decode(capturedBody!);
+      expect(forwarded).toBe(requestPayload);
+
+      // Verify content-length matches actual byte length
+      const expectedLength = new TextEncoder().encode(
+        requestPayload,
+      ).byteLength;
+      expect(capturedContentLength).not.toBeNull();
+      expect(capturedContentLength!).toBe(String(expectedLength));
+    });
+
+    test("streams non-error STT response body back unchanged (no truncation)", async () => {
+      // Build a large-ish response body (~32 KB) to confirm no corruption
+      const segments = Array.from({ length: 200 }, (_, i) => ({
+        id: i,
+        text: `Segment ${i}: ${"lorem ipsum ".repeat(10)}`,
+        confidence: 0.95,
+      }));
+      const largeResponseBody = JSON.stringify({ segments });
+
+      fetchMock = mock(async () => {
+        return new Response(largeResponseBody, {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      });
+
+      const handler = createRuntimeProxyHandler(makeConfig());
+      const req = new Request("http://localhost:7830/v1/stt/transcribe", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ audio: "data" }),
+      });
+      const res = await handler(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.text();
+      // The full response body must arrive without truncation or corruption
+      expect(body).toBe(largeResponseBody);
+      expect(body.length).toBe(largeResponseBody.length);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
Makes speech-to-text service-first for all product-facing native dictation paths (macOS push-to-talk, iOS input bar, and macOS voice mode), while preserving Apple-native recognition as a fallback when STT service is unconfigured or fails. Clients call gateway APIs (not provider SDKs directly) and use the existing `services.stt` abstraction so new providers can be added later without touching client callsites.

## Self-review result
GAPS FOUND — 4 gaps fixed across 4 fix PRs (round 2 re-review: all PASS)

## PRs merged into feature branch
- #24986: Add runtime STT transcribe API backed by `services.stt`
- #24987: Introduce shared STT client and WAV encoding helpers for Apple clients
- #24985: Add gateway proxy regression tests for STT binary payload forwarding
- #24995: Route macOS voice input dictation through STT service with native fallback
- #24993: Use assistant STT service for iOS voice input with native fallback
- #24994: Apply service-first STT to macOS streaming voice mode turn transcription
- #25001: Clean up native-primary assumptions and document service-first STT architecture

### Fix PRs
- #25008: fix: STTClient sends JSON with base64-encoded audio to match server contract
- #25005: fix: use explicit little-endian PCM encoding in all audio capture paths
- #25009: fix: return untrimmed service text from OpenAIVoiceService for consistency
- #25007: fix: consolidate duplicate MockSTTClient into shared test mock

Part of plan: service-first-stt-dictation-streaming.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25010" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
