### PR TITLE
Simplify TTS/STT settings card UI

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -380,13 +380,6 @@ struct VoiceSettingsView: View {
                     )
                 }
 
-                // Provider-specific subtitle from registry metadata
-                if let provider = selectedProvider {
-                    Text(provider.subtitle)
-                        .font(VFont.bodySmallDefault)
-                        .foregroundStyle(VColor.contentTertiary)
-                }
-
                 // Unified API key field
                 ttsApiKeyField
 
@@ -433,34 +426,12 @@ struct VoiceSettingsView: View {
 
     @ViewBuilder
     private var ttsVoiceIdField: some View {
-        switch draftTTSProvider {
-        case "elevenlabs":
-            VStack(alignment: .leading, spacing: VSpacing.xs) {
-                VTextField(
-                    "Voice ID",
-                    placeholder: "ElevenLabs Voice ID (optional)",
-                    text: $ttsVoiceIdText
-                )
-
-                Text("Leave blank to use the default voice.")
-                    .font(VFont.labelDefault)
-                    .foregroundStyle(VColor.contentTertiary)
-            }
-        case "fish-audio":
-            VStack(alignment: .leading, spacing: VSpacing.xs) {
-                VTextField(
-                    "Voice Reference ID",
-                    placeholder: "Fish Audio voice reference ID (optional)",
-                    text: $ttsVoiceIdText
-                )
-
-                Text("Leave blank to use the default voice.")
-                    .font(VFont.labelDefault)
-                    .foregroundStyle(VColor.contentTertiary)
-            }
-        default:
-            // Generic providers do not have a voice ID field
-            EmptyView()
+        if draftTTSProvider == "elevenlabs" || draftTTSProvider == "fish-audio" {
+            VTextField(
+                "Voice ID",
+                placeholder: "\(selectedProvider?.displayName ?? "Provider") Voice ID (optional)",
+                text: $ttsVoiceIdText
+            )
         }
     }
 
@@ -563,11 +534,6 @@ struct VoiceSettingsView: View {
                         }
                     )
                 }
-
-                // Provider-specific subtitle
-                Text("High-accuracy speech-to-text transcription. Requires an OpenAI API key.")
-                    .font(VFont.bodySmallDefault)
-                    .foregroundStyle(VColor.contentTertiary)
 
                 // API key field
                 VTextField(


### PR DESCRIPTION
## Summary
- Remove per-provider subtitle text from TTS card — the card-level subtitle already explains purpose
- Unify Voice ID field: single "Voice ID" label for all providers, provider-specific placeholder, remove "Leave blank to use the default voice" helper text
- Remove STT per-provider description text for visual consistency with Inference card pattern

## Original prompt
Simplify TTS/STT settings UI to reduce visual complexity and match the Inference card's density: provider dropdown, fields, buttons with no interstitial descriptions or helper text.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25011" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
