### PR TITLE
fix: clarify browser_wait_for_download schema modes and add missing fallback warn logs

### DIFF
--- a/assistant/src/config/bundled-skills/browser/TOOLS.json
+++ b/assistant/src/config/bundled-skills/browser/TOOLS.json
@@ -434,7 +434,7 @@
           },
           "browser_mode": {
             "type": "string",
-            "description": "Override backend selection. Values: auto (default), extension, cdp-inspect (alias: cdp-debugger), local (alias: playwright). Omit or use auto to let the assistant choose."
+            "description": "Override backend selection. Only auto (default) and local (alias: playwright) are supported for this tool — file downloads require the local Playwright backend. Other modes (extension, cdp-inspect) are not supported and will be rejected."
           },
           "activity": {
             "type": "string",

--- a/assistant/src/tools/browser/cdp-client/factory.ts
+++ b/assistant/src/tools/browser/cdp-client/factory.ts
@@ -600,6 +600,24 @@ async function sendWithFailover<T>(
         errorMessage,
       });
       maybeRecordDesktopAutoCooldown(candidate);
+
+      // Emit production-visible fallback log in auto mode
+      if (mode === "auto" && i < candidates.length - 1) {
+        log.warn(
+          {
+            conversationId,
+            failedCandidate: candidate.kind,
+            nextCandidate: candidates[i + 1].kind,
+            attemptedSoFar: diagnostics.map((d) => ({
+              kind: d.candidateKind,
+              stage: d.stage,
+              errorCode: d.errorCode,
+              errorMessage: d.errorMessage,
+            })),
+          },
+          "CDP factory: auto-mode fallback triggered",
+        );
+      }
       continue;
     }
 
@@ -634,6 +652,24 @@ async function sendWithFailover<T>(
         discoveryCode: extractDiscoveryCode(err),
       });
       maybeRecordDesktopAutoCooldown(candidate);
+
+      // Emit production-visible fallback log in auto mode
+      if (mode === "auto" && i < candidates.length - 1) {
+        log.warn(
+          {
+            conversationId,
+            failedCandidate: candidate.kind,
+            nextCandidate: candidates[i + 1].kind,
+            attemptedSoFar: diagnostics.map((d) => ({
+              kind: d.candidateKind,
+              stage: d.stage,
+              errorCode: d.errorCode,
+              errorMessage: d.errorMessage,
+            })),
+          },
+          "CDP factory: auto-mode fallback triggered",
+        );
+      }
       continue;
     }
 


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for browser-mode-fallback-diagnostics.md.

**Gap A:** Update browser_wait_for_download schema to only advertise auto/local modes
**Gap B:** Add warn-level fallback logs in construction-failure and send-throw paths
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25012" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
