### PR TITLE
Show specific community source in skill pills and hide counts while searching

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -192,10 +192,12 @@ struct AgentPanelContent: View {
                 withAnimation(VAnimation.fast) { skillsManager.selectedCategory = category }
             }
         ) {
-            let count = category.map { skillsManager.categoryCounts[$0, default: 0] } ?? skillsManager.searchFilteredCount
-            Text("\(count)")
-                .font(VFont.labelDefault)
-                .foregroundStyle(VColor.contentTertiary)
+            if !skillsManager.isSearching {
+                let count = category.map { skillsManager.categoryCounts[$0, default: 0] } ?? skillsManager.searchFilteredCount
+                Text("\(count)")
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentTertiary)
+            }
         }
         .accessibilityLabel("\(label) filter")
         .accessibilityAddTraits(skillsManager.selectedCategory == category ? .isSelected : [])

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
@@ -261,14 +261,14 @@ final class SkillsManager {
                     $0.name.lowercased().contains(query) ||
                     $0.description.lowercased().contains(query) ||
                     $0.id.lowercased().contains(query) ||
-                    Self.sourceLabel($0.origin).lowercased().contains(query)
+                    Self.originMatchesQuery($0.origin, query: query)
                 }
             } else {
                 searchFiltered = baseSkills.filter {
                     $0.name.lowercased().contains(query) ||
                     $0.description.lowercased().contains(query) ||
                     $0.id.lowercased().contains(query) ||
-                    Self.sourceLabel($0.origin).lowercased().contains(query)
+                    Self.originMatchesQuery($0.origin, query: query)
                 }
             }
         } else {
@@ -316,6 +316,15 @@ final class SkillsManager {
         default:
             return origin.replacingOccurrences(of: "-", with: " ").capitalized
         }
+    }
+
+    /// Whether a search query matches any searchable term for a skill origin.
+    /// Includes both the display label (e.g. "Clawhub") and the umbrella
+    /// category "community" so users can still search for community skills.
+    static func originMatchesQuery(_ origin: String, query: String) -> Bool {
+        if sourceLabel(origin).lowercased().contains(query) { return true }
+        if (origin == "clawhub" || origin == "skillssh") && "community".contains(query) { return true }
+        return false
     }
 
     // MARK: - Debounced Search

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
@@ -308,9 +308,9 @@ final class SkillsManager {
         case "vellum":
             return "Vellum"
         case "clawhub":
-            return "Community"
+            return "Clawhub"
         case "skillssh":
-            return "Community"
+            return "skills.sh"
         case "custom":
             return "Custom"
         default:

--- a/clients/shared/DesignSystem/Core/Feedback/VSkillTypePill.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VSkillTypePill.swift
@@ -4,14 +4,16 @@ import SwiftUI
 public struct VSkillTypePill: View {
     public enum SkillType {
         case vellum
-        case community
+        case clawhub
+        case skillssh
         case custom
         case other(label: String, icon: String, foreground: Color, background: Color)
 
         var label: String {
             switch self {
             case .vellum: return "Vellum"
-            case .community: return "Community"
+            case .clawhub: return "Clawhub"
+            case .skillssh: return "skills.sh"
             case .custom: return "Custom"
             case .other(let label, _, _, _): return label
             }
@@ -20,7 +22,7 @@ public struct VSkillTypePill: View {
         var vIcon: VIcon {
             switch self {
             case .vellum: return .package
-            case .community: return .globe
+            case .clawhub, .skillssh: return .globe
             case .custom: return .user
             case .other(_, let icon, _, _): return .resolve(icon)
             }
@@ -29,7 +31,7 @@ public struct VSkillTypePill: View {
         var foregroundColor: Color {
             switch self {
             case .vellum: return VColor.primaryBase
-            case .community: return VColor.funTeal
+            case .clawhub, .skillssh: return VColor.funTeal
             case .custom: return VColor.funPurple
             case .other(_, _, let fg, _): return fg
             }
@@ -38,7 +40,7 @@ public struct VSkillTypePill: View {
         var backgroundColor: Color {
             switch self {
             case .vellum: return VColor.primaryBase.opacity(0.12)
-            case .community: return VColor.funTeal.opacity(0.12)
+            case .clawhub, .skillssh: return VColor.funTeal.opacity(0.12)
             case .custom: return VColor.funPurple.opacity(0.12)
             case .other(_, _, _, let bg): return bg
             }
@@ -56,8 +58,10 @@ public struct VSkillTypePill: View {
         switch origin {
         case "vellum":
             self.type = .vellum
-        case "clawhub", "skillssh":
-            self.type = .community
+        case "clawhub":
+            self.type = .clawhub
+        case "skillssh":
+            self.type = .skillssh
         case "custom":
             self.type = .custom
         default:

--- a/clients/shared/DesignSystem/Gallery/Sections/FeedbackGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/FeedbackGallerySection.swift
@@ -458,7 +458,8 @@ struct FeedbackGallerySection: View {
                 VCard {
                     HStack(spacing: VSpacing.lg) {
                         VSkillTypePill(type: .vellum)
-                        VSkillTypePill(type: .community)
+                        VSkillTypePill(type: .clawhub)
+                        VSkillTypePill(type: .skillssh)
                         VSkillTypePill(type: .custom)
                     }
                 }


### PR DESCRIPTION
## Summary
- Replace the generic "Community" pill badge on skills with specific source labels ("Clawhub" or "skills.sh") so users can see which community registry a skill comes from
- Hide category sidebar counts while search results are loading, instead of showing misleading 0s
- Update the `sourceLabel` helper and gallery preview to match

## Original prompt
1. The numbers to the right of each skill category (All, Automation, etc.) should be absent while results are loading (whereas currently they misleadingly show 0)
2. We should show which community the skill is from (Clawhub or skills.sh) whereas currently we just have a "Community" tag
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25013" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
