### PR TITLE
fix: correct click tool test to exercise browser_mode error path

### DIFF
--- a/assistant/src/__tests__/headless-browser-mode.test.ts
+++ b/assistant/src/__tests__/headless-browser-mode.test.ts
@@ -513,13 +513,18 @@ describe("browser_mode wiring through tool execution", () => {
       },
     );
 
+    // Use selector (not element_id) so resolveElement succeeds and
+    // execution reaches acquireCdpClientWithMode where the factory
+    // throws the pinned-mode CdpError.
     const result = await executeBrowserClick(
-      { element_id: "e1", browser_mode: "extension" },
+      { selector: "#btn", browser_mode: "extension" },
       ctx,
     );
-    // Note: click tries resolveElement first (which returns null for e1)
-    // so the error comes from element resolution, not mode selection
-    // Let's test with selector instead
     expect(result.isError).toBe(true);
+    expect(result.content).toContain('Browser mode "extension" failed');
+    expect(result.content).toContain(
+      "extension: FAILED at candidate_selection",
+    );
+    expect(result.content).toContain("Remediation:");
   });
 });


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for browser-mode-fallback-diagnostics.md.

**Gap:** Click tool test was testing element resolution failure, not mode selection failure.
**What was expected:** Test should exercise the browser_mode remediation error path.
**What was found:** resolveElement returned early before acquireCdpClientWithMode was called.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25014" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
