### PR TITLE
fix: deduplicate BrowserMode type, refactor inline mode handling, merge AGENTS.md paragraphs

### DIFF
--- a/assistant/src/runtime/AGENTS.md
+++ b/assistant/src/runtime/AGENTS.md
@@ -115,9 +115,7 @@ All CDP-backed browser tools (`browser_navigate`, `browser_snapshot`, `browser_s
 
 **Auto-mode fallback logging**: In auto mode, fallback transitions are logged at `warn` level with structured metadata including the full candidate sequence and per-candidate failure reasons. This ensures fallback events are always observable in production logs.
 
-**Test coverage:** Regression tests for `browser_mode` wiring live in `__tests__/headless-browser-mode.test.ts`. Unit tests for pinned candidate construction and failover live in `tools/browser/cdp-client/__tests__/factory.test.ts`.
-
-**Test coverage:** E2E regression tests for this precedence order live in `__tests__/host-browser-e2e-cloud.test.ts` (extension path) and `__tests__/conversation-routes-disk-view.test.ts` (macOS fallback path). Unit tests for candidate list construction and failover live in `tools/browser/cdp-client/__tests__/factory.test.ts`.
+**Test coverage:** Regression tests for `browser_mode` wiring live in `__tests__/headless-browser-mode.test.ts`. E2E regression tests for backend precedence live in `__tests__/host-browser-e2e-cloud.test.ts` (extension path) and `__tests__/conversation-routes-disk-view.test.ts` (macOS fallback path). Unit tests for pinned candidate construction and failover live in `tools/browser/cdp-client/__tests__/factory.test.ts`.
 
 ### Channel approvals (Telegram, Slack)
 

--- a/assistant/src/tools/browser/browser-execution.ts
+++ b/assistant/src/tools/browser/browser-execution.ts
@@ -422,12 +422,8 @@ export async function executeBrowserNavigate(
     return { content: "Error: operation was cancelled", isError: true };
   }
 
-  const modeResult = parseBrowserMode(input);
-  if (!modeResult.ok) {
-    return { content: modeResult.error, isError: true };
-  }
-  const browserMode = modeResult.mode;
-
+  // Pre-flight URL validation runs before CDP acquisition so we fail
+  // fast on obviously invalid URLs without opening a browser session.
   const parsedUrl = parseUrl(input.url);
   if (!parsedUrl) {
     return {
@@ -466,18 +462,10 @@ export async function executeBrowserNavigate(
     }
   }
 
-  let cdp;
-  try {
-    cdp = getCdpClient(context, { mode: browserMode });
-  } catch (err) {
-    if (err instanceof CdpError && browserMode !== "auto") {
-      return {
-        content: formatModeSelectionFailure(browserMode, err),
-        isError: true,
-      };
-    }
-    throw err;
-  }
+  // URL validation passed — acquire the CDP client.
+  const acquired = acquireCdpClientWithMode(input, context);
+  if (acquired.errorResult) return acquired.errorResult;
+  const { cdp, browserMode } = acquired;
 
   // Screencast + handoff are Playwright-backed and only meaningful
   // for the local sacrificial-profile path. On the extension path the
@@ -847,24 +835,9 @@ export async function executeBrowserSnapshot(
   _input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  const modeResult = parseBrowserMode(_input);
-  if (!modeResult.ok) {
-    return { content: modeResult.error, isError: true };
-  }
-  const browserMode = modeResult.mode;
-
-  let cdp;
-  try {
-    cdp = getCdpClient(context, { mode: browserMode });
-  } catch (err) {
-    if (err instanceof CdpError && browserMode !== "auto") {
-      return {
-        content: formatModeSelectionFailure(browserMode, err),
-        isError: true,
-      };
-    }
-    throw err;
-  }
+  const acquired = acquireCdpClientWithMode(_input, context);
+  if (acquired.errorResult) return acquired.errorResult;
+  const { cdp, browserMode } = acquired;
 
   try {
     const currentUrl = await getCurrentUrl(cdp, context.signal);
@@ -914,25 +887,10 @@ export async function executeBrowserScreenshot(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  const modeResult = parseBrowserMode(input);
-  if (!modeResult.ok) {
-    return { content: modeResult.error, isError: true };
-  }
-  const browserMode = modeResult.mode;
+  const acquired = acquireCdpClientWithMode(input, context);
+  if (acquired.errorResult) return acquired.errorResult;
+  const { cdp, browserMode } = acquired;
   const fullPage = input.full_page === true;
-
-  let cdp;
-  try {
-    cdp = getCdpClient(context, { mode: browserMode });
-  } catch (err) {
-    if (err instanceof CdpError && browserMode !== "auto") {
-      return {
-        content: formatModeSelectionFailure(browserMode, err),
-        isError: true,
-      };
-    }
-    throw err;
-  }
 
   try {
     const buffer = await captureScreenshotJpeg(

--- a/assistant/src/tools/browser/browser-mode.ts
+++ b/assistant/src/tools/browser/browser-mode.ts
@@ -12,8 +12,10 @@
  *   - `playwright`   -> `local`
  */
 
-/** Canonical browser mode values. */
-export type BrowserMode = "auto" | "extension" | "cdp-inspect" | "local";
+import type { BrowserMode } from "./cdp-client/types.js";
+
+/** Canonical browser mode values. Re-exported from cdp-client/types. */
+export type { BrowserMode } from "./cdp-client/types.js";
 
 /** All accepted values (canonical + aliases). */
 const ALIAS_MAP: Record<string, BrowserMode> = {


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for browser-mode-fallback-diagnostics.md.

**Gap A:** Deduplicate BrowserMode type — single canonical definition in cdp-client/types.ts, re-exported from browser-mode.ts
**Gap B:** Refactor executeBrowserNavigate/Snapshot/Screenshot to use acquireCdpClientWithMode (navigate preserves pre-flight URL validation before CDP acquisition)
**Gap C:** Merge duplicate Test coverage paragraphs in runtime AGENTS.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25015" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
