### PR TITLE
feat(skills): include version in clawhub search results

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -6471,6 +6471,8 @@ paths:
                               type: number
                             publishedAt:
                               type: string
+                            version:
+                              type: string
                           required:
                             - id
                             - name
@@ -6483,6 +6485,7 @@ paths:
                             - stars
                             - installs
                             - reports
+                            - version
                           additionalProperties: false
                         - type: object
                           properties:
@@ -7262,6 +7265,8 @@ paths:
                               type: number
                             publishedAt:
                               type: string
+                            version:
+                              type: string
                           required:
                             - id
                             - name
@@ -7274,6 +7279,7 @@ paths:
                             - stars
                             - installs
                             - reports
+                            - version
                           additionalProperties: false
                         - type: object
                           properties:

--- a/assistant/src/__tests__/search-skills-unified.test.ts
+++ b/assistant/src/__tests__/search-skills-unified.test.ts
@@ -221,6 +221,11 @@ describe("searchSkills (unified)", () => {
     expect(result.skills[1]!.id).toBe("deploy");
     expect(result.skills[1]!.origin).toBe("clawhub");
     expect(result.skills[1]!.kind).toBe("catalog");
+    // Verify version is mapped through from clawhub search results
+    const clawhubSkill = result.skills[1]!;
+    if (clawhubSkill.origin === "clawhub") {
+      expect(clawhubSkill.version).toBe("1.0.0");
+    }
     expect(result.skills[2]!.id).toBe("vercel-labs/skills/react-best");
     expect(result.skills[2]!.origin).toBe("skillssh");
     expect(result.skills[2]!.kind).toBe("catalog");

--- a/assistant/src/__tests__/skills-files-catalog-fallback.test.ts
+++ b/assistant/src/__tests__/skills-files-catalog-fallback.test.ts
@@ -617,6 +617,7 @@ describe("getSkillFiles — provider chain fallback", () => {
         stars: 5,
         installs: 10,
         reports: 0,
+        version: "",
       }),
     };
 
@@ -710,6 +711,7 @@ describe("getSkillFiles — provider chain fallback", () => {
         stars: 0,
         installs: 0,
         reports: 0,
+        version: "",
       }),
     };
 

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -385,6 +385,7 @@ function toSlimSkillResponse(
         stars: 0,
         installs: 0,
         reports: 0,
+        version: "",
       };
     }
     case "skillssh": {
@@ -1191,6 +1192,7 @@ export async function searchSkills(
         publishedAt: s.createdAt
           ? new Date(s.createdAt * 1000).toISOString()
           : undefined,
+        version: s.version,
       }));
     } else {
       log.warn(

--- a/assistant/src/daemon/message-types/skills.ts
+++ b/assistant/src/daemon/message-types/skills.ts
@@ -98,6 +98,7 @@ interface ClawhubSlimSkill extends SlimSkillBase {
   installs: number;
   reports: number;
   publishedAt?: string;
+  version: string;
 }
 
 interface SkillsshSlimSkill extends SlimSkillBase {

--- a/assistant/src/runtime/routes/skills-routes.ts
+++ b/assistant/src/runtime/routes/skills-routes.ts
@@ -60,6 +60,7 @@ const slimSkillSchema = z.discriminatedUnion("origin", [
     installs: z.number(),
     reports: z.number(),
     publishedAt: z.string().optional(),
+    version: z.string(),
   }),
   z.object({
     ...slimSkillBase,

--- a/assistant/src/skills/clawhub-files.ts
+++ b/assistant/src/skills/clawhub-files.ts
@@ -206,6 +206,7 @@ export function createClawhubProvider(): SkillFileProvider {
         publishedAt: data.updatedAt
           ? new Date(data.updatedAt).toISOString()
           : undefined,
+        version: data.latestVersion?.version ?? "",
       };
     },
   };


### PR DESCRIPTION
## Summary
- Add `version: string` field to `ClawhubSlimSkill` type
- Map `version` from clawhub search API response and inspect data
- Update Zod schema and tests

Part of plan: enrich-skill-search-metadata.md (PR 1 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25016" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
