### PR TITLE
feat(skills): include batched audit data in skills.sh search results

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -6515,6 +6515,32 @@ paths:
                               type: string
                             installs:
                               type: number
+                            audit:
+                              type: object
+                              propertyNames:
+                                type: string
+                              additionalProperties:
+                                type: object
+                                properties:
+                                  risk:
+                                    type: string
+                                    enum:
+                                      - safe
+                                      - low
+                                      - medium
+                                      - high
+                                      - critical
+                                      - unknown
+                                  alerts:
+                                    type: number
+                                  score:
+                                    type: number
+                                  analyzedAt:
+                                    type: string
+                                required:
+                                  - risk
+                                  - analyzedAt
+                                additionalProperties: false
                           required:
                             - id
                             - name
@@ -7306,6 +7332,32 @@ paths:
                               type: string
                             installs:
                               type: number
+                            audit:
+                              type: object
+                              propertyNames:
+                                type: string
+                              additionalProperties:
+                                type: object
+                                properties:
+                                  risk:
+                                    type: string
+                                    enum:
+                                      - safe
+                                      - low
+                                      - medium
+                                      - high
+                                      - critical
+                                      - unknown
+                                  alerts:
+                                    type: number
+                                  score:
+                                    type: number
+                                  analyzedAt:
+                                    type: string
+                                required:
+                                  - risk
+                                  - analyzedAt
+                                additionalProperties: false
                           required:
                             - id
                             - name

--- a/assistant/src/__tests__/search-skills-unified.test.ts
+++ b/assistant/src/__tests__/search-skills-unified.test.ts
@@ -43,6 +43,20 @@ const mockSkillsshSearch = mock(
     }>
   > => [],
 );
+const mockFetchSkillAudits = mock(
+  async (
+    _source: string,
+    _skillSlugs: string[],
+  ): Promise<
+    Record<
+      string,
+      Record<
+        string,
+        { risk: string; alerts?: number; score?: number; analyzedAt: string }
+      >
+    >
+  > => ({}),
+);
 
 // ---------------------------------------------------------------------------
 // Mock modules — before importing module under test
@@ -79,6 +93,7 @@ mock.module("../skills/clawhub.js", () => ({
 
 mock.module("../skills/skillssh-registry.js", () => ({
   searchSkillsRegistry: mockSkillsshSearch,
+  fetchSkillAudits: mockFetchSkillAudits,
 }));
 
 // Stub install-meta (needed by the new origin derivation logic)
@@ -166,11 +181,13 @@ describe("searchSkills (unified)", () => {
     mockCatalogSkills.mockReset();
     mockClawhubSearch.mockReset();
     mockSkillsshSearch.mockReset();
+    mockFetchSkillAudits.mockReset();
 
     // Defaults: empty results
     mockCatalogSkills.mockReturnValue([]);
     mockClawhubSearch.mockResolvedValue({ skills: [] });
     mockSkillsshSearch.mockResolvedValue([]);
+    mockFetchSkillAudits.mockResolvedValue({});
   });
 
   test("returns results from all three registries", async () => {
@@ -417,6 +434,102 @@ describe("searchSkills (unified)", () => {
       expect(skill.slug).toBe("org/repo/test-skill");
       expect(skill.sourceRepo).toBe("org/repo");
       expect(skill.installs).toBe(99);
+    }
+  });
+
+  test("attaches audit data to skills.sh results on success", async () => {
+    mockCatalogSkills.mockReturnValue([]);
+    mockClawhubSearch.mockResolvedValue({ skills: [] });
+    mockSkillsshSearch.mockResolvedValue([
+      {
+        id: "acme/tools/lint",
+        skillId: "lint",
+        name: "Lint",
+        installs: 10,
+        source: "acme/tools",
+      },
+      {
+        id: "acme/tools/format",
+        skillId: "format",
+        name: "Format",
+        installs: 20,
+        source: "acme/tools",
+      },
+    ]);
+    mockFetchSkillAudits.mockResolvedValue({
+      lint: {
+        ath: { risk: "safe", score: 100, analyzedAt: "2025-01-01T00:00:00Z" },
+      },
+      format: {
+        socket: {
+          risk: "low",
+          alerts: 2,
+          analyzedAt: "2025-01-02T00:00:00Z",
+        },
+      },
+    });
+
+    const result = await searchSkills("lint", dummyCtx);
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error("Expected success");
+
+    expect(result.skills).toHaveLength(2);
+
+    const lintSkill = result.skills.find((s) => s.id === "acme/tools/lint")!;
+    expect(lintSkill.origin).toBe("skillssh");
+    if (lintSkill.origin === "skillssh") {
+      expect(lintSkill.audit).toBeDefined();
+      expect(lintSkill.audit!.ath).toEqual({
+        risk: "safe",
+        score: 100,
+        analyzedAt: "2025-01-01T00:00:00Z",
+      });
+    }
+
+    const formatSkill = result.skills.find(
+      (s) => s.id === "acme/tools/format",
+    )!;
+    expect(formatSkill.origin).toBe("skillssh");
+    if (formatSkill.origin === "skillssh") {
+      expect(formatSkill.audit).toBeDefined();
+      expect(formatSkill.audit!.socket).toEqual({
+        risk: "low",
+        alerts: 2,
+        analyzedAt: "2025-01-02T00:00:00Z",
+      });
+    }
+
+    // Verify fetchSkillAudits was called with grouped source/slugs
+    expect(mockFetchSkillAudits).toHaveBeenCalledTimes(1);
+    expect(mockFetchSkillAudits).toHaveBeenCalledWith("acme/tools", [
+      "lint",
+      "format",
+    ]);
+  });
+
+  test("search succeeds when fetchSkillAudits throws", async () => {
+    mockCatalogSkills.mockReturnValue([]);
+    mockClawhubSearch.mockResolvedValue({ skills: [] });
+    mockSkillsshSearch.mockResolvedValue([
+      {
+        id: "org/repo/my-skill",
+        skillId: "my-skill",
+        name: "My Skill",
+        installs: 5,
+        source: "org/repo",
+      },
+    ]);
+    mockFetchSkillAudits.mockRejectedValue(new Error("audit service down"));
+
+    const result = await searchSkills("my-skill", dummyCtx);
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error("Expected success");
+
+    expect(result.skills).toHaveLength(1);
+    const skill = result.skills[0]!;
+    expect(skill.origin).toBe("skillssh");
+    if (skill.origin === "skillssh") {
+      expect(skill.audit).toBeUndefined();
     }
   });
 });

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -72,9 +72,11 @@ import {
 import type { SkillFileProvider } from "../../skills/skill-file-provider.js";
 import { createSkillsShProvider } from "../../skills/skillssh-files.js";
 import {
+  fetchSkillAudits,
   installExternalSkill,
   resolveSkillSource,
   searchSkillsRegistry,
+  type SkillAuditData,
 } from "../../skills/skillssh-registry.js";
 import { getWorkspaceSkillsDir } from "../../util/platform.js";
 import type {
@@ -1212,6 +1214,50 @@ export async function searchSkills(
         sourceRepo: r.source,
         installs: r.installs,
       }));
+
+      // Batch-fetch audit data for skills.sh results, grouped by source repo.
+      try {
+        if (skillsshResult.value.length > 0) {
+          const sourceToSlugs = new Map<string, string[]>();
+          for (const r of skillsshResult.value) {
+            const slugs = sourceToSlugs.get(r.source) ?? [];
+            slugs.push(r.skillId);
+            sourceToSlugs.set(r.source, slugs);
+          }
+
+          const auditResults = await Promise.allSettled(
+            [...sourceToSlugs.entries()].map(([source, slugs]) =>
+              fetchSkillAudits(source, slugs).then((audits) => ({
+                source,
+                audits,
+              })),
+            ),
+          );
+
+          // Build a lookup map keyed by full skill ID (e.g. "owner/repo/skill-name")
+          const auditMap = new Map<string, SkillAuditData>();
+          for (const result of auditResults) {
+            if (result.status !== "fulfilled") continue;
+            const { source, audits } = result.value;
+            for (const [skillSlug, auditData] of Object.entries(audits)) {
+              auditMap.set(`${source}/${skillSlug}`, auditData);
+            }
+          }
+
+          // Enrich each skills.sh skill with audit data
+          skillsshSkills = skillsshSkills.map((skill) => {
+            if (skill.origin !== "skillssh") return skill;
+            const audit = auditMap.get(skill.id);
+            if (!audit) return skill;
+            return { ...skill, audit };
+          });
+        }
+      } catch (err) {
+        log.warn(
+          { err },
+          "Audit fetch failed for skills.sh results, continuing without audit data",
+        );
+      }
     } else {
       log.warn(
         { err: skillsshResult.reason },

--- a/assistant/src/daemon/message-types/skills.ts
+++ b/assistant/src/daemon/message-types/skills.ts
@@ -1,5 +1,10 @@
 // Skill management types.
 
+import type { PartnerAudit } from "../../skills/skillssh-registry.js";
+
+// Re-export so consumers can access the audit types from this module.
+export type { PartnerAudit } from "../../skills/skillssh-registry.js";
+
 // === Client → Server ===
 
 export interface SkillsListRequest {
@@ -105,6 +110,7 @@ interface SkillsshSlimSkill extends SlimSkillBase {
   slug: string;
   sourceRepo: string;
   installs: number;
+  audit?: Record<string, PartnerAudit>;
 }
 
 interface CustomSlimSkill extends SlimSkillBase {

--- a/assistant/src/runtime/routes/skills-routes.ts
+++ b/assistant/src/runtime/routes/skills-routes.ts
@@ -40,6 +40,13 @@ export interface SkillRouteDeps {
   getSkillContext: () => SkillOperationContext;
 }
 
+const partnerAuditSchema = z.object({
+  risk: z.enum(["safe", "low", "medium", "high", "critical", "unknown"]),
+  alerts: z.number().optional(),
+  score: z.number().optional(),
+  analyzedAt: z.string(),
+});
+
 const slimSkillBase = {
   id: z.string(),
   name: z.string(),
@@ -67,6 +74,7 @@ const slimSkillSchema = z.discriminatedUnion("origin", [
     slug: z.string(),
     sourceRepo: z.string(),
     installs: z.number(),
+    audit: z.record(z.string(), partnerAuditSchema).optional(),
   }),
   z.object({ ...slimSkillBase, origin: z.literal("custom") }),
 ]);


### PR DESCRIPTION
## Summary
- Add `audit?: Record<string, PartnerAudit>` field to `SkillsshSlimSkill` type
- Fetch audit data in batches by source repo during search (non-fatal on failure)
- Update Zod schema and add tests for audit data flow

Part of plan: enrich-skill-search-metadata.md (PR 2 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25017" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
