### PR TITLE
feat: inject time_since_last_message into turn context for long gaps

### DIFF
--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -1391,6 +1391,61 @@ describe("buildUnifiedTurnContextBlock", () => {
     expect(text).toContain("contact_notes: Prefers short replies");
     expect(text).toContain("contact_interaction_count: 42");
   });
+
+  test("time_since_last_message: emitted right after current_time when provided", () => {
+    const options: UnifiedTurnContextOptions = {
+      timestamp: "2026-04-02T12:00:00Z",
+      interfaceName: "macos",
+      timeSinceLastMessage: "2d ago",
+    };
+
+    const text = buildUnifiedTurnContextBlock(options);
+    const lines = text.split("\n");
+    expect(lines[0]).toBe("<turn_context>");
+    expect(lines[1]).toBe("current_time: 2026-04-02T12:00:00Z");
+    expect(lines[2]).toBe("time_since_last_message: 2d ago");
+    expect(lines[3]).toBe("interface: macos");
+    expect(lines[4]).toBe("</turn_context>");
+  });
+
+  test("time_since_last_message: omitted when null", () => {
+    const options: UnifiedTurnContextOptions = {
+      timestamp: "2026-04-02T12:00:00Z",
+      interfaceName: "macos",
+      timeSinceLastMessage: null,
+    };
+
+    const text = buildUnifiedTurnContextBlock(options);
+    expect(text).not.toContain("time_since_last_message");
+  });
+
+  test("time_since_last_message: omitted when field absent (backward-compat)", () => {
+    const options: UnifiedTurnContextOptions = {
+      timestamp: "2026-04-02T12:00:00Z",
+      interfaceName: "macos",
+    };
+
+    const text = buildUnifiedTurnContextBlock(options);
+    expect(text).not.toContain("time_since_last_message");
+  });
+
+  test("time_since_last_message: works on non-guardian path", () => {
+    const options: UnifiedTurnContextOptions = {
+      timestamp: "2026-04-02T12:00:00Z",
+      interfaceName: "telegram",
+      channelName: "telegram",
+      timeSinceLastMessage: "yesterday",
+      actorContext: {
+        sourceChannel: "telegram",
+        canonicalActorIdentity: "user-1",
+        trustClass: "trusted_contact",
+      },
+    };
+
+    const text = buildUnifiedTurnContextBlock(options);
+    expect(text).toContain("time_since_last_message: yesterday");
+    expect(text).toContain("canonical_actor_identity: user-1");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -41,6 +41,8 @@ import {
   getConversation,
   getConversationOriginChannel,
   getConversationOriginInterface,
+  getLastUserTimestampBefore,
+  getMessageById,
   provenanceFromTrustContext,
   updateConversationContextWindow,
   updateConversationTitle,
@@ -64,6 +66,7 @@ import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { getSubagentManager } from "../subagent/index.js";
 import type { UsageActor } from "../usage/actors.js";
 import { getLogger } from "../util/logger.js";
+import { timeAgo } from "../util/time.js";
 import { truncate } from "../util/truncate.js";
 import { getWorkspaceGitService } from "../workspace/git-service.js";
 import { commitTurnChanges } from "../workspace/turn-commit.js";
@@ -773,14 +776,35 @@ export async function runAgentLoopImpl(
     const isGuardian =
       resolvedInboundActorContext?.trustClass === "guardian" ||
       !resolvedInboundActorContext;
+
+    // Surface long gaps between user messages so the model can acknowledge
+    // the absence naturally. Gated at >12h to avoid noisy injection during
+    // normal back-and-forth turns.
+    const TWELVE_HOURS_MS = 12 * 60 * 60 * 1000;
+    let timeSinceLastMessage: string | null = null;
+    const currentUserMessage = getMessageById(userMessageId);
+    if (currentUserMessage) {
+      const prevUserTs = getLastUserTimestampBefore(
+        ctx.conversationId,
+        currentUserMessage.createdAt,
+      );
+      if (
+        prevUserTs > 0 &&
+        currentUserMessage.createdAt - prevUserTs > TWELVE_HOURS_MS
+      ) {
+        timeSinceLastMessage = timeAgo(prevUserTs);
+      }
+    }
+
     const unifiedTurnContextStr = buildUnifiedTurnContextBlock(
       isGuardian
-        ? { timestamp, interfaceName, channelName }
+        ? { timestamp, interfaceName, channelName, timeSinceLastMessage }
         : {
             timestamp,
             interfaceName,
             channelName,
             actorContext: resolvedInboundActorContext,
+            timeSinceLastMessage,
           },
     );
 

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -876,6 +876,12 @@ export interface UnifiedTurnContextOptions {
   interfaceName?: string;
   channelName?: string;
   actorContext?: InboundActorContext | null;
+  /**
+   * Human-readable duration since the previous user message (e.g. "14h ago",
+   * "yesterday", "3d ago"). Only populated when the gap exceeds 12 hours so
+   * the model can acknowledge long absences; otherwise omitted.
+   */
+  timeSinceLastMessage?: string | null;
 }
 
 /**
@@ -908,6 +914,9 @@ export function buildUnifiedTurnContextBlock(
 
   const lines: string[] = ["<turn_context>"];
   lines.push(`current_time: ${options.timestamp}`);
+  if (options.timeSinceLastMessage) {
+    lines.push(`time_since_last_message: ${options.timeSinceLastMessage}`);
+  }
   if (options.interfaceName) {
     lines.push(`interface: ${options.interfaceName}`);
   }

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -1062,6 +1062,27 @@ export function getLastAssistantTimestampBefore(
   return row?.createdAt ?? 0;
 }
 
+export function getLastUserTimestampBefore(
+  conversationId: string,
+  beforeTimestamp: number,
+): number {
+  const db = getDb();
+  const row = db
+    .select({ createdAt: messages.createdAt })
+    .from(messages)
+    .where(
+      and(
+        eq(messages.conversationId, conversationId),
+        eq(messages.role, "user"),
+        lt(messages.createdAt, beforeTimestamp),
+      ),
+    )
+    .orderBy(desc(messages.createdAt))
+    .limit(1)
+    .get();
+  return row?.createdAt ?? 0;
+}
+
 /** Fetch a single message by ID, optionally scoped to a specific conversation. */
 export function getMessageById(
   messageId: string,


### PR DESCRIPTION
## Summary
- Add \`getLastUserTimestampBefore\` DB query (mirrors existing \`getLastAssistantTimestampBefore\`) to find the prior user message timestamp in a conversation.
- In the agent loop, compute the gap between the current and previous user message; if >12h, pass \`timeAgo(prevTs)\` as \`timeSinceLastMessage\` to \`buildUnifiedTurnContextBlock\`.
- Emit \`time_since_last_message: <value>\` on the line after \`current_time:\` in the \`<turn_context>\` block when populated; omitted otherwise (backward-compat).

## Original prompt
it