### PR TITLE
Improve Chrome extension popup usability

### DIFF
--- a/clients/chrome-extension/background/__tests__/worker-autoconnect.test.ts
+++ b/clients/chrome-extension/background/__tests__/worker-autoconnect.test.ts
@@ -234,7 +234,7 @@ describe('autoConnect lifecycle — connect sets sticky flag', () => {
 
     const response = await handleConnectFailing(
       state,
-      new MissingTokenError("Automatic cloud sign-in failed \u2014 use 'Re-sign in' in Troubleshooting, then try Connect again"),
+      new MissingTokenError("Automatic cloud sign-in failed \u2014 use 'Re-sign in' in Advanced, then turn Connection on again"),
     );
 
     expect(response.ok).toBe(false);
@@ -349,7 +349,7 @@ describe('failed auto-connect — no reconnect loop', () => {
     const state = createWorkerState({ currentAuthProfile: 'local-pair' });
     await state.storage.set({ [AUTO_CONNECT_KEY]: true });
 
-    const errorMessage = "Automatic local pairing failed \u2014 use 'Re-pair' in Troubleshooting, then try Connect again";
+    const errorMessage = "Automatic local pairing failed \u2014 use 'Re-pair' in Advanced, then turn Connection on again";
     await simulateBootstrap(state, async () => {
       throw new MissingTokenError(errorMessage);
     });
@@ -370,7 +370,7 @@ describe('failed auto-connect — no reconnect loop', () => {
     const state = createWorkerState({ currentAuthProfile: 'cloud-oauth' });
     await state.storage.set({ [AUTO_CONNECT_KEY]: true });
 
-    const errorMessage = "Automatic cloud sign-in failed \u2014 use 'Re-sign in' in Troubleshooting, then try Connect again";
+    const errorMessage = "Automatic cloud sign-in failed \u2014 use 'Re-sign in' in Advanced, then turn Connection on again";
     await simulateBootstrap(state, async () => {
       throw new MissingTokenError(errorMessage);
     });

--- a/clients/chrome-extension/background/__tests__/worker-connect-preflight.test.ts
+++ b/clients/chrome-extension/background/__tests__/worker-connect-preflight.test.ts
@@ -50,10 +50,10 @@ class MissingTokenError extends Error {
 
 function missingTokenMessage(profile: AssistantAuthProfile | null): string {
   if (profile === 'cloud-oauth') {
-    return "Automatic cloud sign-in failed \u2014 use 'Re-sign in' in Troubleshooting, then try Connect again";
+    return "Automatic cloud sign-in failed \u2014 use 'Re-sign in' in Advanced, then turn Connection on again";
   }
   if (profile === 'local-pair') {
-    return "Automatic local pairing failed \u2014 use 'Re-pair' in Troubleshooting, then try Connect again";
+    return "Automatic local pairing failed \u2014 use 'Re-pair' in Advanced, then turn Connection on again";
   }
   if (profile === 'unsupported') {
     return 'This assistant uses an unsupported topology. Please update the Vellum extension.';

--- a/clients/chrome-extension/background/__tests__/worker-connection-health.test.ts
+++ b/clients/chrome-extension/background/__tests__/worker-connection-health.test.ts
@@ -397,7 +397,7 @@ describe('connection health: unrecoverable auth/native-host failure', () => {
 
     await simulateAuthFailedConnect(
       state,
-      "Automatic cloud sign-in failed \u2014 use 'Re-sign in' in Troubleshooting, then try Connect again",
+      "Automatic cloud sign-in failed \u2014 use 'Re-sign in' in Advanced, then turn Connection on again",
     );
 
     expect(state.connectionHealth).toBe('auth_required');
@@ -428,7 +428,7 @@ describe('connection health: unrecoverable auth/native-host failure', () => {
 
     await simulateAuthFailedConnect(
       state,
-      "Automatic local pairing failed \u2014 use 'Re-pair' in Troubleshooting, then try Connect again",
+      "Automatic local pairing failed \u2014 use 'Re-pair' in Advanced, then turn Connection on again",
     );
 
     expect(state.connectionHealth).toBe('auth_required');

--- a/clients/chrome-extension/background/__tests__/worker-selected-assistant-connect.test.ts
+++ b/clients/chrome-extension/background/__tests__/worker-selected-assistant-connect.test.ts
@@ -121,10 +121,10 @@ describe('missing token error messages', () => {
   // testing without importing the side-effectful module.
   function missingTokenMessage(profile: AssistantAuthProfile | null): string {
     if (profile === 'cloud-oauth') {
-      return "Automatic cloud sign-in failed \u2014 use 'Re-sign in' in Troubleshooting, then try Connect again";
+      return "Automatic cloud sign-in failed \u2014 use 'Re-sign in' in Advanced, then turn Connection on again";
     }
     if (profile === 'local-pair') {
-      return "Automatic local pairing failed \u2014 use 'Re-pair' in Troubleshooting, then try Connect again";
+      return "Automatic local pairing failed \u2014 use 'Re-pair' in Advanced, then turn Connection on again";
     }
     if (profile === 'unsupported') {
       return 'This assistant uses an unsupported topology. Please update the Vellum extension.';

--- a/clients/chrome-extension/background/cloud-reconnect-decision.ts
+++ b/clients/chrome-extension/background/cloud-reconnect-decision.ts
@@ -77,7 +77,7 @@ export function decideCloudReconnectAction(
       kind: 'abort',
       error:
         `Cloud relay kept closing with abnormal closure (code 1006) after ${CLOUD_REFRESH_ATTEMPT_CAP} ` +
-        "token refresh attempts. Use 'Re-sign in' in Troubleshooting, then try Connect again.",
+        "token refresh attempts. Use 'Re-sign in' in Advanced, then turn Connection on again.",
     };
   }
 

--- a/clients/chrome-extension/background/relay-connection.ts
+++ b/clients/chrome-extension/background/relay-connection.ts
@@ -495,7 +495,7 @@ export class RelayConnection {
             kind: 'abort',
             error:
               `Relay token refresh failed: ${message}. ` +
-              `Use 'Re-sign in' in Troubleshooting, then try Connect again.`,
+              `Use 'Re-sign in' in Advanced, then turn Connection on again.`,
           };
         }
       }

--- a/clients/chrome-extension/background/worker.ts
+++ b/clients/chrome-extension/background/worker.ts
@@ -787,7 +787,7 @@ async function cloudReconnectHook(
   return {
     kind: 'abort',
     error:
-      `${reason}. Use 'Re-sign in' in Troubleshooting, then try Connect again.`,
+      `${reason}. Use 'Re-sign in' in Advanced, then turn Connection on again.`,
   };
 }
 
@@ -900,7 +900,7 @@ function createRelayConnection(
       return {
         kind: 'abort',
         error:
-          "Self-hosted relay token missing or expired. Use 'Re-pair' in Troubleshooting, then try Connect again.",
+          "Self-hosted relay token missing or expired. Use 'Re-pair' in Advanced, then turn Connection on again.",
       };
     },
   });
@@ -927,10 +927,10 @@ class MissingTokenError extends Error {
  */
 function missingTokenMessage(profile: AssistantAuthProfile | null): string {
   if (profile === 'cloud-oauth') {
-    return "Automatic cloud sign-in failed \u2014 use 'Re-sign in' in Troubleshooting, then try Connect again";
+    return "Automatic cloud sign-in failed \u2014 use 'Re-sign in' in Advanced, then turn Connection on again";
   }
   if (profile === 'local-pair') {
-    return "Automatic local pairing failed \u2014 use 'Re-pair' in Troubleshooting, then try Connect again";
+    return "Automatic local pairing failed \u2014 use 'Re-pair' in Advanced, then turn Connection on again";
   }
   if (profile === 'unsupported') {
     return 'This assistant uses an unsupported topology. Please update the Vellum extension.';

--- a/clients/chrome-extension/popup/popup.html
+++ b/clients/chrome-extension/popup/popup.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Vellum Relay</title>
+  <title>Browser Connection</title>
   <style>
     * { box-sizing: border-box; margin: 0; padding: 0; }
 
@@ -20,12 +20,35 @@
       display: flex;
       align-items: center;
       gap: 8px;
-      margin-bottom: 16px;
+      margin-bottom: 12px;
     }
 
     header h1 {
       font-size: 15px;
       font-weight: 600;
+    }
+
+    .status-card {
+      background: #f8fafc;
+      border: 1px solid #e5e7eb;
+      border-radius: 10px;
+      padding: 10px;
+      margin-bottom: 12px;
+    }
+
+    .status-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 8px;
+      margin-bottom: 8px;
+    }
+
+    .status-left {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      min-width: 0;
     }
 
     .status-dot {
@@ -40,10 +63,23 @@
     .status-dot.paused { background: #f59e0b; }
     .status-dot.disconnected { background: #ef4444; }
 
+    .status-badge {
+      font-size: 12px;
+      font-weight: 600;
+      color: #1f2937;
+      background: #e5e7eb;
+      border-radius: 999px;
+      padding: 2px 8px;
+      flex-shrink: 0;
+    }
+    .status-badge.connected { background: #dcfce7; color: #166534; }
+    .status-badge.paused { background: #fef3c7; color: #92400e; }
+    .status-badge.disconnected { background: #fee2e2; color: #991b1b; }
+
     .status-text {
       font-size: 12px;
-      color: #666;
-      margin-bottom: 14px;
+      color: #4b5563;
+      line-height: 1.45;
     }
 
     label {
@@ -66,13 +102,85 @@
     }
     input:focus { border-color: #6366f1; }
 
-    .btn-row {
+    .toggle-row {
       display: flex;
-      gap: 8px;
+      align-items: center;
+      justify-content: space-between;
+      border: 1px solid #e5e7eb;
+      border-radius: 10px;
+      padding: 10px;
+      margin-bottom: 12px;
+    }
+
+    .toggle-copy {
+      display: flex;
+      flex-direction: column;
+      gap: 3px;
+    }
+
+    .toggle-title {
+      font-size: 13px;
+      font-weight: 600;
+      color: #111827;
+    }
+
+    .toggle-hint {
+      font-size: 12px;
+      color: #6b7280;
+      line-height: 1.4;
+    }
+
+    .switch {
+      position: relative;
+      width: 44px;
+      height: 26px;
+      flex-shrink: 0;
+    }
+
+    .switch input {
+      opacity: 0;
+      width: 0;
+      height: 0;
+      position: absolute;
+    }
+
+    .switch-slider {
+      position: absolute;
+      inset: 0;
+      background: #d1d5db;
+      border-radius: 999px;
+      transition: background 0.2s;
+      cursor: pointer;
+    }
+
+    .switch-slider::before {
+      content: "";
+      position: absolute;
+      left: 3px;
+      top: 3px;
+      width: 20px;
+      height: 20px;
+      border-radius: 50%;
+      background: #fff;
+      transition: transform 0.2s;
+      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+    }
+
+    .switch input:checked + .switch-slider {
+      background: #4f46e5;
+    }
+
+    .switch input:checked + .switch-slider::before {
+      transform: translateX(18px);
+    }
+
+    .switch input:disabled + .switch-slider {
+      cursor: default;
+      opacity: 0.55;
     }
 
     button {
-      flex: 1;
+      width: 100%;
       padding: 8px 0;
       border: none;
       border-radius: 6px;
@@ -83,31 +191,10 @@
     }
     button:disabled { opacity: 0.5; cursor: default; }
 
-    #btn-connect {
-      background: #6366f1;
-      color: #fff;
-    }
-    #btn-connect:hover:not(:disabled) { background: #4f46e5; }
-
-    #btn-pause {
-      background: #f3f4f6;
-      color: #374151;
-    }
-    #btn-pause:hover:not(:disabled) { background: #e5e7eb; }
-
     .divider {
       height: 1px;
       background: #e5e7eb;
       margin: 16px 0 14px 0;
-    }
-
-    .section-label {
-      font-size: 11px;
-      font-weight: 600;
-      color: #6b7280;
-      text-transform: uppercase;
-      letter-spacing: 0.04em;
-      margin-bottom: 8px;
     }
 
     #btn-cloud-signin {
@@ -164,7 +251,7 @@
     .hint {
       font-size: 11px;
       color: #9ca3af;
-      margin-top: 10px;
+      margin-top: 6px;
       line-height: 1.5;
     }
 
@@ -185,7 +272,20 @@
       line-height: 1.45;
     }
 
-    /* ── Troubleshoot collapsible area ────────────────────────────── */
+    .advanced-setting {
+      margin-top: 10px;
+      margin-bottom: 10px;
+    }
+
+    .advanced-setting label {
+      margin-bottom: 6px;
+    }
+
+    .advanced-setting input {
+      margin-bottom: 0;
+    }
+
+    /* ── Advanced collapsible area ────────────────────────────────── */
 
     #troubleshoot-section {
       margin-top: 16px;
@@ -210,6 +310,7 @@
       text-transform: uppercase;
       letter-spacing: 0.04em;
       flex: none;
+      width: auto;
     }
     .troubleshoot-toggle:hover { color: #374151; }
 
@@ -232,11 +333,18 @@
 </head>
 <body>
   <header>
-    <div class="status-dot disconnected" id="status-dot"></div>
     <h1>Vellum Relay</h1>
   </header>
 
-  <p class="status-text" id="status-text">Not connected</p>
+  <div class="status-card" role="status" aria-live="polite">
+    <div class="status-row">
+      <div class="status-left">
+        <div class="status-dot disconnected" id="status-dot"></div>
+        <p class="status-text" id="status-text">Not connected</p>
+      </div>
+      <span class="status-badge disconnected" id="status-badge">Offline</span>
+    </div>
+  </div>
 
   <p class="error-text" id="error-text" style="display:none"></p>
 
@@ -247,23 +355,18 @@
     <select id="assistant-select"></select>
   </div>
 
-  <label for="port-input">Relay port</label>
-  <input
-    type="text"
-    id="port-input"
-    placeholder="7830"
-    autocomplete="off"
-    spellcheck="false"
-  />
-
-  <div class="btn-row">
-    <button id="btn-connect">Connect</button>
-    <button id="btn-pause" disabled>Pause</button>
+  <div class="toggle-row">
+    <div class="toggle-copy">
+      <p class="toggle-title">Connection</p>
+      <p class="toggle-hint" id="connection-toggle-hint">Turn on to connect.</p>
+    </div>
+    <label class="switch" for="connection-toggle">
+      <input type="checkbox" id="connection-toggle" aria-label="Toggle connection" />
+      <span class="switch-slider"></span>
+    </label>
   </div>
 
-  <p class="hint">Relay port defaults to 7830.</p>
-
-  <!-- Troubleshoot section: collapsed by default, auto-expanded for auth_required/error -->
+  <!-- Advanced section: collapsed by default, auto-expanded for auth_required/error -->
   <div id="troubleshoot-section" hidden>
     <div class="divider"></div>
 
@@ -275,10 +378,22 @@
       aria-controls="troubleshoot-body"
     >
       <span class="chevron">&#9654;</span>
-      Troubleshoot
+      Advanced
     </button>
 
     <div id="troubleshoot-body" hidden>
+      <div class="advanced-setting">
+        <label for="port-input">Connection port</label>
+        <input
+          type="text"
+          id="port-input"
+          placeholder="7830"
+          autocomplete="off"
+          spellcheck="false"
+        />
+        <p class="hint">Only change this if support asks you to.</p>
+      </div>
+
       <p class="local-status" id="local-status" style="display:none">Not paired</p>
       <button id="btn-pair-local" type="button" style="display:none">Re-pair with local assistant</button>
 

--- a/clients/chrome-extension/popup/popup.ts
+++ b/clients/chrome-extension/popup/popup.ts
@@ -9,11 +9,12 @@
  *   - **Paused** — user explicitly paused the relay.
  *   - **Action required** — auth or host error requiring manual recovery.
  *
- * Primary controls are **Connect** and **Pause**. Manual recovery
- * controls (local re-pair and cloud re-sign-in) live in a collapsible
- * Troubleshoot section that is hidden by default. The section auto-
- * expands when the health state is `auth_required` or `error`, making
- * break-glass recovery accessible without cluttering the happy path.
+ * Primary control is a single **Connection** toggle. Manual recovery
+ * controls (local re-pair and cloud re-sign-in) plus the support port
+ * override live in a collapsible **Advanced** section that is hidden
+ * by default. The section auto-expands when the health state is
+ * `auth_required` or `error`, making recovery accessible without
+ * cluttering the happy path.
  *
  * On open the popup loads the assistant catalog from the worker via the
  * `assistants-get` message. When exactly one assistant exists it is
@@ -37,7 +38,6 @@ import {
   deriveSelectorDisplay,
   shouldShowLocalSection,
   shouldShowCloudSection,
-  deriveCtaState,
   deriveSetupMessage,
   deriveHealthStatusDisplay,
   healthToPhase,
@@ -56,10 +56,13 @@ const DEFAULT_RELAY_PORT = 7830;
 // ── DOM references ──────────────────────────────────────────────────
 
 const portInput = document.getElementById('port-input') as HTMLInputElement;
-const btnConnect = document.getElementById('btn-connect') as HTMLButtonElement;
-const btnPause = document.getElementById('btn-pause') as HTMLButtonElement;
+const connectionToggle = document.getElementById('connection-toggle') as HTMLInputElement;
+const connectionToggleHint = document.getElementById(
+  'connection-toggle-hint',
+) as HTMLParagraphElement;
 const statusDot = document.getElementById('status-dot') as HTMLDivElement;
 const statusText = document.getElementById('status-text') as HTMLParagraphElement;
+const statusBadge = document.getElementById('status-badge') as HTMLSpanElement;
 const errorText = document.getElementById('error-text') as HTMLParagraphElement;
 const setupMessage = document.getElementById('setup-message') as HTMLParagraphElement;
 const btnCloudSignIn = document.getElementById('btn-cloud-signin') as HTMLButtonElement;
@@ -114,10 +117,48 @@ function setSetupMessage(phase: ConnectionPhase): void {
   }
 }
 
+function statusBadgeDisplay(health: ConnectionHealthState): {
+  text: string;
+  className: 'connected' | 'paused' | 'disconnected';
+} {
+  switch (health) {
+    case 'connected':
+      return { text: 'Online', className: 'connected' };
+    case 'connecting':
+      return { text: 'Starting', className: 'paused' };
+    case 'reconnecting':
+      return { text: 'Recovering', className: 'paused' };
+    case 'paused':
+      return { text: 'Paused', className: 'paused' };
+    case 'auth_required':
+      return { text: 'Needs action', className: 'disconnected' };
+    case 'error':
+      return { text: 'Issue detected', className: 'disconnected' };
+  }
+}
+
+function connectionHint(phase: ConnectionPhase): string {
+  switch (phase) {
+    case 'connected':
+      return 'On and ready.';
+    case 'connecting':
+      return 'Starting connection...';
+    case 'reconnecting':
+      return 'Recovering automatically...';
+    case 'paused':
+    case 'disconnected':
+      return 'Turn on to connect.';
+    case 'no-native-host':
+      return 'Install the desktop app first.';
+  }
+}
+
+function isToggleCheckedForPhase(phase: ConnectionPhase): boolean {
+  return phase === 'connecting' || phase === 'reconnecting' || phase === 'connected';
+}
+
 /**
- * Apply the worker's health state to the full popup UI. Derives button
- * labels/enablement, status indicator, and troubleshooting section
- * visibility from the pure helpers in popup-state.ts.
+ * Apply the worker's health state to the full popup UI.
  */
 function applyHealthState(
   health: ConnectionHealthState,
@@ -125,20 +166,20 @@ function applyHealthState(
 ): void {
   currentHealthState = health;
 
-  // Derive phase for CTA button states.
   const phase = healthToPhase(health);
-  const cta = deriveCtaState(phase);
-  btnConnect.textContent = cta.connectLabel;
-  btnConnect.disabled = !cta.connectEnabled;
-  btnPause.textContent = cta.pauseLabel;
-  btnPause.disabled = !cta.pauseEnabled;
+  connectionToggle.checked = isToggleCheckedForPhase(phase);
+  connectionToggle.disabled = phase === 'connecting' || phase === 'reconnecting';
+  connectionToggleHint.textContent = connectionHint(phase);
 
   // Derive health-aware status display (richer than phase-based).
   const status = deriveHealthStatusDisplay(health, detail);
   statusDot.className = `status-dot ${status.dotClass}`;
   statusText.textContent = status.text;
+  const badge = statusBadgeDisplay(health);
+  statusBadge.textContent = badge.text;
+  statusBadge.className = `status-badge ${badge.className}`;
 
-  portInput.disabled = phase === 'connected' || phase === 'connecting';
+  portInput.disabled = phase === 'connecting' || phase === 'reconnecting';
 
   setSetupMessage(phase);
 
@@ -156,14 +197,28 @@ function applyHealthState(
  * connecting -> polling -> connected flow initiated by the popup).
  */
 function setPhase(phase: ConnectionPhase): void {
+  if (phase === 'no-native-host') {
+    currentHealthState = 'error';
+    connectionToggle.checked = false;
+    connectionToggle.disabled = true;
+    connectionToggleHint.textContent = connectionHint('no-native-host');
+    statusDot.className = 'status-dot disconnected';
+    statusText.textContent = 'Desktop app required';
+    statusBadge.textContent = 'Needs app';
+    statusBadge.className = 'status-badge disconnected';
+    portInput.disabled = false;
+    setSetupMessage('no-native-host');
+    updateTroubleshootSection('error');
+    return;
+  }
+
   // Map phase back to a health state for the unified path.
-  const healthMap: Record<ConnectionPhase, ConnectionHealthState> = {
+  const healthMap: Record<Exclude<ConnectionPhase, 'no-native-host'>, ConnectionHealthState> = {
     connected: 'connected',
     connecting: 'connecting',
     reconnecting: 'reconnecting',
     disconnected: 'paused',
     paused: 'paused',
-    'no-native-host': 'error',
   };
   applyHealthState(healthMap[phase]);
 }
@@ -183,30 +238,23 @@ function showError(msg: string): void {
   showErrorText(msg);
 }
 
-// ── Troubleshoot section ────────────────────────────────────────────
+// ── Advanced section ─────────────────────────────────────────────────
 
 /**
- * Update the troubleshoot section visibility and expansion state.
+ * Update the Advanced section visibility and expansion state.
  *
- * The section is shown when there are auth controls to display
- * (local-pair or cloud-oauth). It auto-expands when the health
- * state is `auth_required` or `error` so the user can access
- * recovery controls.
+ * The section is always shown because it contains support settings.
+ * It auto-expands when the health state is `auth_required` or `error`
+ * so users can access recovery controls.
  */
 function updateTroubleshootSection(health: ConnectionHealthState): void {
   const hasControls = hasTroubleshootingControls(currentAuthProfile);
-
-  if (!hasControls) {
-    troubleshootSection.hidden = true;
-    return;
-  }
-
   troubleshootSection.hidden = false;
 
   // Auto-expand when action is required, auto-collapse on recovery.
   if (shouldExpandTroubleshooting(health)) {
     expandTroubleshoot();
-  } else if (health === 'connected') {
+  } else if (health === 'connected' || !hasControls) {
     collapseTroubleshoot();
   }
 }
@@ -393,13 +441,13 @@ function getPort(): number {
   return DEFAULT_RELAY_PORT;
 }
 
-// ── Connect (primary CTA) ───────────────────────────────────────────
+// ── Connection toggle ────────────────────────────────────────────────
 //
 // No local precheck -- the worker handles auth bootstrap (pairing/sign-in)
 // automatically when interactive=true. Users can connect in one click
 // even when not previously paired or signed in.
 
-btnConnect.addEventListener('click', async () => {
+async function requestConnect(): Promise<void> {
   const port = getPort();
 
   errorText.style.display = 'none';
@@ -417,51 +465,64 @@ btnConnect.addEventListener('click', async () => {
     return;
   }
 
-  chrome.runtime.sendMessage({ type: 'connect' }, (response: { ok: boolean; error?: string }) => {
-    if (chrome.runtime.lastError || !response?.ok) {
-      showError(response?.error ?? chrome.runtime.lastError?.message ?? 'Unknown error');
-      applyHealthState('error');
-      return;
-    }
-    // Poll briefly for health state convergence.
-    let attempts = 0;
-    const poll = setInterval(() => {
-      chrome.runtime.sendMessage({ type: 'get_status' }, (r: GetStatusResponse) => {
-        if (chrome.runtime.lastError) {
-          if (++attempts > 10) {
-            clearInterval(poll);
-            // Fall back to a recoverable state so the user can retry.
-            applyHealthState('paused');
+  await new Promise<void>((resolve) => {
+    chrome.runtime.sendMessage({ type: 'connect' }, (response: { ok: boolean; error?: string }) => {
+      if (chrome.runtime.lastError || !response?.ok) {
+        showError(response?.error ?? chrome.runtime.lastError?.message ?? 'Unknown error');
+        applyHealthState('error');
+        resolve();
+        return;
+      }
+      // Poll briefly for health state convergence.
+      let attempts = 0;
+      const poll = setInterval(() => {
+        chrome.runtime.sendMessage({ type: 'get_status' }, (r: GetStatusResponse) => {
+          if (chrome.runtime.lastError) {
+            if (++attempts > 10) {
+              clearInterval(poll);
+              // Fall back to a recoverable state so the user can retry.
+              applyHealthState('paused');
+              resolve();
+            }
+            return;
           }
-          return;
-        }
 
-        const health = r?.health ?? (r?.connected ? 'connected' : 'connecting');
-        if (health === 'connected' || health === 'error' || health === 'auth_required') {
-          clearInterval(poll);
-          applyHealthState(health as ConnectionHealthState, r?.healthDetail);
-        } else if (++attempts > 10) {
-          clearInterval(poll);
-          // Polling exhausted without reaching a terminal health state.
-          // Fall back to paused so the Connect button re-enables and
-          // the user can retry instead of being stuck on "Connecting...".
-          applyHealthState('paused');
-        }
-      });
-    }, 300);
+          const health = r?.health ?? (r?.connected ? 'connected' : 'connecting');
+          if (health === 'connected' || health === 'error' || health === 'auth_required') {
+            clearInterval(poll);
+            applyHealthState(health as ConnectionHealthState, r?.healthDetail);
+            resolve();
+          } else if (++attempts > 10) {
+            clearInterval(poll);
+            // Polling exhausted without reaching a terminal health state.
+            // Fall back to paused so users can retry instead of staying stuck.
+            applyHealthState('paused');
+            resolve();
+          }
+        });
+      }, 300);
+    });
   });
-});
+}
 
-// ── Pause (secondary action) ────────────────────────────────────────
+// ── Pause ────────────────────────────────────────────────────────────
 //
 // Sends the `pause` message to the worker, which tears down the relay
 // WebSocket and clears the `autoConnect` flag. Credentials are
 // preserved so the next Connect is instant.
 
-btnPause.addEventListener('click', () => {
+function requestPause(): void {
   chrome.runtime.sendMessage({ type: 'pause' }, () => {
     applyHealthState('paused');
   });
+}
+
+connectionToggle.addEventListener('change', async () => {
+  if (connectionToggle.checked) {
+    await requestConnect();
+    return;
+  }
+  requestPause();
 });
 
 // ── Self-hosted native-messaging pairing (troubleshooting) ──────────


### PR DESCRIPTION
## Summary
- Reworked the popup to use a clearer status card and a single Connection toggle, and moved the port override into the collapsed Advanced section.
- Removed the top-level relay port controls and default-port helper copy from the main flow to reduce technical friction for non-technical users.
- Updated background recovery messaging and matching tests so runtime guidance references Advanced and turning Connection on again.

## Original prompt
 these improvements
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25019" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
