### PR TITLE
fix: restrict formatCdpSendDiagnostics to transport errors only

### DIFF
--- a/assistant/src/tools/browser/browser-execution.ts
+++ b/assistant/src/tools/browser/browser-execution.ts
@@ -340,6 +340,7 @@ function formatCdpSendDiagnostics(
   if (
     err instanceof CdpError &&
     browserMode !== "auto" &&
+    err.code === "transport_error" &&
     err.attemptDiagnostics
   ) {
     return formatModeSelectionFailure(browserMode, err);


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for browser-mode-fallback-diagnostics.md.

**Gap:** formatCdpSendDiagnostics catches all CdpErrors with attemptDiagnostics, but should only format transport-level errors as mode-selection failures.
**What was expected:** Only transport errors trigger remediation formatting.
**What was found:** Any CdpError with attemptDiagnostics in pinned mode would be misclassified.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25021" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
