### PR TITLE
Hide raw principal ID on Guardian contact card

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
@@ -179,7 +179,7 @@ struct ContactsContainerView: View {
                     // Title row: display name + badge + interaction count
                     VStack(alignment: .leading, spacing: VSpacing.xs) {
                         HStack(spacing: VSpacing.sm) {
-                            Text("\(contact.displayName) (You)")
+                            Text(contact.displayName.hasPrefix("vellum-principal-") ? "You" : "\(contact.displayName) (You)")
                                 .font(VFont.titleSmall)
                                 .foregroundStyle(VColor.contentDefault)
                             ContactTypeBadge(role: "guardian")
@@ -251,14 +251,14 @@ struct ContactsContainerView: View {
         .contentMargins(0)
         .id(contact.id)
         .onAppear {
-            guardianEditedName = contact.displayName
+            guardianEditedName = contact.displayName.hasPrefix("vellum-principal-") ? "" : contact.displayName
             guardianEditedNotes = contact.notes ?? ""
         }
         .onChange(of: contact) { _, newContact in
             // Don't reset fields while a save is in flight — the reload
             // triggers this with stale data before the API response propagates.
             guard !guardianIsSaving else { return }
-            guardianEditedName = newContact.displayName
+            guardianEditedName = newContact.displayName.hasPrefix("vellum-principal-") ? "" : newContact.displayName
             guardianEditedNotes = newContact.notes ?? ""
         }
     }

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
@@ -218,7 +218,7 @@ struct ContactsContainerView: View {
                         VButton(
                             label: "Save",
                             style: .primary,
-                            isDisabled: guardianIsSaving || guardianEditedName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                            isDisabled: guardianIsSaving || (guardianEditedName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !contact.displayName.hasPrefix("vellum-principal-"))
                         ) {
                             Task { await saveGuardianEdits(contact: contact) }
                         }
@@ -266,7 +266,8 @@ struct ContactsContainerView: View {
     /// Persists guardian name/notes edits via the contacts API.
     private func saveGuardianEdits(contact: ContactPayload) async {
         let trimmedName = guardianEditedName.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmedName.isEmpty else { return }
+        // When the name field is empty (e.g. guardian with raw principal ID), preserve the existing displayName
+        let nameToSave = trimmedName.isEmpty ? contact.displayName : trimmedName
         let trimmedNotes = guardianEditedNotes.trimmingCharacters(in: .whitespacesAndNewlines)
 
         guardianIsSaving = true
@@ -274,10 +275,10 @@ struct ContactsContainerView: View {
         do {
             if let updated = try await contactClient.updateContact(
                 contactId: contact.id,
-                displayName: trimmedName,
+                displayName: nameToSave,
                 notes: trimmedNotes.isEmpty ? nil : trimmedNotes
             ) {
-                guardianEditedName = updated.displayName
+                guardianEditedName = updated.displayName.hasPrefix("vellum-principal-") ? "" : updated.displayName
                 guardianEditedNotes = updated.notes ?? ""
                 viewModel.loadContacts()
                 showToast?("Contact saved", .success)


### PR DESCRIPTION
## Summary
- When the guardian's `displayName` is a raw principal ID (e.g. `vellum-principal-...`), the contact detail header now shows just "You" instead of the gibberish ID
- The Name text field also shows empty with the "Your name" placeholder instead of the raw ID, so the user can type their actual name
- The sidebar already hard-codes "You" so no change needed there

## Original prompt
Help me do a quick improvement to the Guardian card on the Contacts tab in the macos client. We shouldn't show `vellum-principal...` because this is gibberish to the user. We should just show the guardian's name, if known, otherwise fall back to "You"
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25022" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
