### PR TITLE
test(conversation-queue): mock new conversation-crud exports

### DIFF
--- a/assistant/src/__tests__/conversation-queue.test.ts
+++ b/assistant/src/__tests__/conversation-queue.test.ts
@@ -164,6 +164,8 @@ mock.module("../memory/conversation-crud.js", () => ({
   },
   updateConversationUsage: () => {},
   updateConversationTitle: () => {},
+  getMessageById: () => null,
+  getLastUserTimestampBefore: () => 0,
 }));
 
 mock.module("../memory/conversation-queries.js", () => ({


### PR DESCRIPTION
## Summary
- Adds `getMessageById` and `getLastUserTimestampBefore` to the `conversation-crud` mock in `conversation-queue.test.ts`.
- These were introduced in #25018 and called unconditionally inside `runAgentLoopImpl`; without the mocks they were `undefined` and threw before `agentLoop.run()`, causing all `waitForPendingRun` waits to time out (11 failing tests on main).

## Original prompt
`--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24315135825/job/70991423854`
