### PR TITLE
feat(skills): include audit data in skills.sh detail endpoint

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -6841,6 +6841,32 @@ paths:
                             type: string
                           installs:
                             type: number
+                          audit:
+                            type: object
+                            propertyNames:
+                              type: string
+                            additionalProperties:
+                              type: object
+                              properties:
+                                risk:
+                                  type: string
+                                  enum:
+                                    - safe
+                                    - low
+                                    - medium
+                                    - high
+                                    - critical
+                                    - unknown
+                                alerts:
+                                  type: number
+                                score:
+                                  type: number
+                                analyzedAt:
+                                  type: string
+                              required:
+                                - risk
+                                - analyzedAt
+                              additionalProperties: false
                         required:
                           - id
                           - name

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -549,6 +549,21 @@ export async function getSkill(
       sourceRepo: slim.sourceRepo,
       installs: slim.installs,
     };
+    // Enrich with audit data (non-fatal on failure)
+    try {
+      const source = resolveSkillSource(slim.slug);
+      const sourceRepo = `${source.owner}/${source.repo}`;
+      const skillSlug = source.skillSlug;
+      const audits = await fetchSkillAudits(sourceRepo, [skillSlug]);
+      if (audits[skillSlug]) {
+        (detail as { audit?: SkillAuditData }).audit = audits[skillSlug];
+      }
+    } catch (err) {
+      log.warn(
+        { err, skillId },
+        "Failed to enrich skillssh skill detail with audit data",
+      );
+    }
     return { skill: detail };
   }
 

--- a/assistant/src/daemon/message-types/skills.ts
+++ b/assistant/src/daemon/message-types/skills.ts
@@ -184,6 +184,7 @@ interface SkillsshSkillDetail extends SkillDetailBase {
   slug: string;
   sourceRepo: string;
   installs: number;
+  audit?: Record<string, PartnerAudit>;
 }
 
 interface CustomSkillDetail extends SkillDetailBase {

--- a/assistant/src/runtime/routes/skills-routes.ts
+++ b/assistant/src/runtime/routes/skills-routes.ts
@@ -124,6 +124,7 @@ const skillDetailSchema = z.discriminatedUnion("origin", [
     slug: z.string(),
     sourceRepo: z.string(),
     installs: z.number(),
+    audit: z.record(z.string(), partnerAuditSchema).optional(),
   }),
   z.object({ ...slimSkillBase, origin: z.literal("custom") }),
 ]);


### PR DESCRIPTION
## Summary
- Add `audit?: Record<string, PartnerAudit>` to `SkillsshSkillDetail` type
- Fetch audit data via `fetchSkillAudits` in the detail handler (non-fatal on failure)
- Update Zod detail schema and regenerate OpenAPI spec

Part of plan: enrich-skill-search-metadata.md (PR 3 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25024" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
