### PR TITLE
test: mock getMessageById and getLastUserTimestampBefore in remaining conversation tests

### DIFF
--- a/assistant/src/__tests__/conversation-abort-tool-results.test.ts
+++ b/assistant/src/__tests__/conversation-abort-tool-results.test.ts
@@ -112,6 +112,8 @@ mock.module("../memory/conversation-crud.js", () => ({
   },
   updateConversationUsage: () => {},
   updateConversationTitle: () => {},
+  getMessageById: () => null,
+  getLastUserTimestampBefore: () => 0,
 }));
 
 mock.module("../memory/conversation-queries.js", () => ({

--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -137,6 +137,8 @@ mock.module("../memory/conversation-crud.js", () => ({
   updateConversationContextWindow: () => {},
   updateConversationTitle: () => {},
   getConversationOriginChannel: () => null,
+  getMessageById: () => null,
+  getLastUserTimestampBefore: () => 0,
 }));
 
 const syncMessageToDiskMock = mock(() => {});

--- a/assistant/src/__tests__/conversation-pre-run-repair.test.ts
+++ b/assistant/src/__tests__/conversation-pre-run-repair.test.ts
@@ -101,6 +101,8 @@ mock.module("../memory/conversation-crud.js", () => ({
   addMessage: () => ({ id: "new-msg" }),
   updateConversationUsage: () => {},
   updateConversationTitle: () => {},
+  getMessageById: () => null,
+  getLastUserTimestampBefore: () => 0,
 }));
 
 mock.module("../memory/conversation-queries.js", () => ({

--- a/assistant/src/__tests__/conversation-provider-retry-repair.test.ts
+++ b/assistant/src/__tests__/conversation-provider-retry-repair.test.ts
@@ -167,6 +167,8 @@ mock.module("../memory/conversation-crud.js", () => ({
   getConversationOriginChannel: () => null,
   getConversationOriginInterface: () => null,
   provenanceFromTrustContext: () => ({}),
+  getMessageById: () => null,
+  getLastUserTimestampBefore: () => 0,
 }));
 
 mock.module("../memory/conversation-queries.js", () => ({

--- a/assistant/src/__tests__/conversation-slash-queue.test.ts
+++ b/assistant/src/__tests__/conversation-slash-queue.test.ts
@@ -113,6 +113,8 @@ mock.module("../memory/conversation-crud.js", () => ({
   },
   updateConversationUsage: () => {},
   updateConversationTitle: () => {},
+  getMessageById: () => null,
+  getLastUserTimestampBefore: () => 0,
 }));
 
 mock.module("../memory/conversation-queries.js", () => ({

--- a/assistant/src/__tests__/conversation-slash-unknown.test.ts
+++ b/assistant/src/__tests__/conversation-slash-unknown.test.ts
@@ -120,6 +120,8 @@ mock.module("../memory/conversation-crud.js", () => ({
   },
   updateConversationUsage: () => {},
   updateConversationTitle: () => {},
+  getMessageById: () => null,
+  getLastUserTimestampBefore: () => 0,
 }));
 
 mock.module("../memory/conversation-queries.js", () => ({

--- a/assistant/src/__tests__/conversation-workspace-injection.test.ts
+++ b/assistant/src/__tests__/conversation-workspace-injection.test.ts
@@ -125,6 +125,8 @@ mock.module("../memory/conversation-crud.js", () => ({
   updateConversationContextWindow: () => {},
   deleteMessageById: () => ({ segmentIds: [], deletedSummaryIds: [] }),
   deleteLastExchange: () => 0,
+  getMessageById: () => null,
+  getLastUserTimestampBefore: () => 0,
 }));
 
 mock.module("../memory/conversation-queries.js", () => ({

--- a/assistant/src/__tests__/conversation-workspace-tool-tracking.test.ts
+++ b/assistant/src/__tests__/conversation-workspace-tool-tracking.test.ts
@@ -122,6 +122,8 @@ mock.module("../memory/conversation-crud.js", () => ({
   updateConversationContextWindow: () => {},
   deleteMessageById: () => ({ segmentIds: [], deletedSummaryIds: [] }),
   deleteLastExchange: () => 0,
+  getMessageById: () => null,
+  getLastUserTimestampBefore: () => 0,
 }));
 
 mock.module("../memory/conversation-queries.js", () => ({


### PR DESCRIPTION
## Summary
- Adds \`getMessageById\` and \`getLastUserTimestampBefore\` mocks to 8 conversation test files that mock \`conversation-crud\` but were missing these exports introduced in #25018.
- #25023 fixed this for \`conversation-queue.test.ts\`; this PR fixes the same root-cause failure in the other 8 tests that were still red on main.
- Without these mocks, the unconditional calls in \`runAgentLoopImpl\` (and \`syncMessageToDisk\`) hit real DB queries against tables that don't exist in the test environment, causing \`SQLiteError: no such table: messages\`.

## Original prompt
\`--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24315303809/job/70991869195\`