### PR TITLE
feat(browser): add browser_mode overrides and fallback diagnostics

### DIFF
--- a/assistant/src/__tests__/browser-skill-endstate.test.ts
+++ b/assistant/src/__tests__/browser-skill-endstate.test.ts
@@ -128,6 +128,24 @@ describe("browser skill migration end-state", () => {
     }
   });
 
+  test("every browser tool schema exposes an optional browser_mode property", async () => {
+    const path = await import("node:path");
+    const fs = await import("node:fs");
+    const toolsPath = path.resolve(
+      import.meta.dirname,
+      "../config/bundled-skills/browser/TOOLS.json",
+    );
+    const manifest = JSON.parse(fs.readFileSync(toolsPath, "utf-8"));
+    for (const tool of manifest.tools) {
+      const props = tool.input_schema?.properties ?? {};
+      expect(props.browser_mode).toBeDefined();
+      expect(props.browser_mode.type).toBe("string");
+      // browser_mode must NOT be required
+      const required: string[] = tool.input_schema?.required ?? [];
+      expect(required).not.toContain("browser_mode");
+    }
+  });
+
   // ── 3. Permission defaults align with PR 08/09 ────────────────────
 
   test("skill_load has default allow rule", () => {

--- a/assistant/src/__tests__/headless-browser-mode.test.ts
+++ b/assistant/src/__tests__/headless-browser-mode.test.ts
@@ -513,13 +513,18 @@ describe("browser_mode wiring through tool execution", () => {
       },
     );
 
+    // Use selector (not element_id) so resolveElement succeeds and
+    // execution reaches acquireCdpClientWithMode where the factory
+    // throws the pinned-mode CdpError.
     const result = await executeBrowserClick(
-      { element_id: "e1", browser_mode: "extension" },
+      { selector: "#btn", browser_mode: "extension" },
       ctx,
     );
-    // Note: click tries resolveElement first (which returns null for e1)
-    // so the error comes from element resolution, not mode selection
-    // Let's test with selector instead
     expect(result.isError).toBe(true);
+    expect(result.content).toContain('Browser mode "extension" failed');
+    expect(result.content).toContain(
+      "extension: FAILED at candidate_selection",
+    );
+    expect(result.content).toContain("Remediation:");
   });
 });

--- a/assistant/src/__tests__/headless-browser-mode.test.ts
+++ b/assistant/src/__tests__/headless-browser-mode.test.ts
@@ -1,0 +1,525 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ── Mocks ────────────────────────────────────────────────────────────
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// ── Fake CdpClient & Factory ─────────────────────────────────────────
+//
+// This test file validates browser_mode parsing and mode-selection
+// failure formatting in browser-execution.ts. The factory mock
+// intercepts getCdpClient calls and can be configured to throw
+// CdpError for pinned-mode precondition failures.
+
+import { CdpError } from "../tools/browser/cdp-client/errors.js";
+import type { AttemptDiagnostic } from "../tools/browser/cdp-client/types.js";
+
+let cdpSendCalls: Array<{ method: string; params?: unknown }> = [];
+let cdpSendHandler: (
+  method: string,
+  params?: Record<string, unknown>,
+) => unknown = () => ({});
+let _cdpDisposed = false;
+
+/** Configure the factory to throw on getCdpClient for pinned modes. */
+let factoryThrowError: CdpError | null = null;
+
+function makeFakeCdp(
+  kind: "local" | "extension" | "cdp-inspect",
+  conversationId: string,
+) {
+  return {
+    kind,
+    conversationId,
+    async send<T>(
+      method: string,
+      params?: Record<string, unknown>,
+    ): Promise<T> {
+      cdpSendCalls.push({ method, params });
+      const value = cdpSendHandler(method, params);
+      return (await value) as T;
+    },
+    dispose() {
+      _cdpDisposed = true;
+    },
+  };
+}
+
+mock.module("../tools/browser/cdp-client/factory.js", () => ({
+  getCdpClient: (
+    context: { hostBrowserProxy?: unknown; conversationId: string },
+    options?: { mode?: string },
+  ) => {
+    if (factoryThrowError) {
+      throw factoryThrowError;
+    }
+    const mode = options?.mode ?? "auto";
+    const kind =
+      mode === "extension"
+        ? "extension"
+        : mode === "cdp-inspect"
+          ? "cdp-inspect"
+          : mode === "local"
+            ? "local"
+            : context.hostBrowserProxy
+              ? "extension"
+              : "local";
+    return makeFakeCdp(kind, context.conversationId);
+  },
+}));
+
+// ── Minimal browserManager stub ──────────────────────────────────────
+
+mock.module("../tools/browser/browser-manager.js", () => {
+  return {
+    browserManager: {
+      getOrCreateSessionPage: mock(async () => ({
+        url: () => "https://example.com/",
+        route: mock(async () => {}),
+        unroute: mock(async () => {}),
+        close: async () => {},
+        isClosed: () => false,
+      })),
+      clearSnapshotBackendNodeMap: mock(() => {}),
+      storeSnapshotBackendNodeMap: mock(() => {}),
+      resolveSnapshotBackendNodeId: () => null,
+      supportsRouteInterception: false,
+      isInteractive: () => false,
+      positionWindowSidebar: mock(async () => {}),
+    },
+  };
+});
+
+mock.module("../tools/browser/browser-screencast.js", () => ({
+  ensureScreencast: async () => {},
+  getSender: () => null,
+  stopAllScreencasts: async () => {},
+  stopBrowserScreencast: async () => {},
+}));
+
+mock.module("../tools/browser/auth-detector.js", () => ({
+  detectAuthChallenge: async () => null,
+  detectCaptchaChallenge: async () => null,
+  formatAuthChallenge: () => "",
+}));
+
+// Default url-safety: allow everything
+mock.module("../tools/network/url-safety.js", () => ({
+  parseUrl: (input: unknown) => {
+    if (typeof input === "string" && input.startsWith("http")) {
+      try {
+        return new URL(input);
+      } catch {
+        return null;
+      }
+    }
+    return null;
+  },
+  isPrivateOrLocalHost: () => false,
+  resolveHostAddresses: async () => [],
+  resolveRequestAddress: async () => ({}),
+  sanitizeUrlForOutput: (url: URL) => url.href,
+}));
+
+import {
+  executeBrowserClick,
+  executeBrowserNavigate,
+  executeBrowserScreenshot,
+  executeBrowserSnapshot,
+  formatModeSelectionFailure,
+  parseBrowserMode,
+} from "../tools/browser/browser-execution.js";
+import type { ToolContext } from "../tools/types.js";
+
+const ctx: ToolContext = {
+  conversationId: "test-conversation",
+  workingDir: "/tmp",
+  trustClass: "guardian",
+};
+
+/**
+ * Default CDP handler that returns sensible defaults for the methods
+ * used by navigate and snapshot tools.
+ */
+function defaultCdpHandler(
+  method: string,
+  params?: Record<string, unknown>,
+): unknown {
+  if (method === "Page.navigate") return { frameId: "f1" };
+  if (method === "Runtime.evaluate") {
+    const expression = String(params?.["expression"] ?? "");
+    if (expression === "document.location.href") {
+      return { result: { value: "about:blank" } };
+    }
+    if (expression === "document.title") {
+      return { result: { value: "Example" } };
+    }
+    if (
+      expression.includes("readyState") &&
+      expression.includes("document.location.href")
+    ) {
+      return {
+        result: {
+          value: {
+            readyState: "complete",
+            href: "https://example.com/page",
+          },
+        },
+      };
+    }
+    return { result: { value: null } };
+  }
+  if (method === "Accessibility.enable") return {};
+  if (method === "Accessibility.getFullAXTree") {
+    return { nodes: [] };
+  }
+  if (method === "Page.captureScreenshot") {
+    return { data: "dGVzdA==" }; // base64 "test"
+  }
+  return {};
+}
+
+function resetCdp() {
+  cdpSendCalls = [];
+  _cdpDisposed = false;
+  cdpSendHandler = defaultCdpHandler;
+  factoryThrowError = null;
+}
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+describe("parseBrowserMode", () => {
+  test("returns auto for missing/empty browser_mode", () => {
+    expect(parseBrowserMode({})).toEqual({ ok: true, mode: "auto" });
+    expect(parseBrowserMode({ browser_mode: undefined })).toEqual({
+      ok: true,
+      mode: "auto",
+    });
+    expect(parseBrowserMode({ browser_mode: null })).toEqual({
+      ok: true,
+      mode: "auto",
+    });
+    expect(parseBrowserMode({ browser_mode: "" })).toEqual({
+      ok: true,
+      mode: "auto",
+    });
+  });
+
+  test("normalizes canonical values", () => {
+    expect(parseBrowserMode({ browser_mode: "extension" })).toEqual({
+      ok: true,
+      mode: "extension",
+    });
+    expect(parseBrowserMode({ browser_mode: "cdp-inspect" })).toEqual({
+      ok: true,
+      mode: "cdp-inspect",
+    });
+    expect(parseBrowserMode({ browser_mode: "local" })).toEqual({
+      ok: true,
+      mode: "local",
+    });
+    expect(parseBrowserMode({ browser_mode: "auto" })).toEqual({
+      ok: true,
+      mode: "auto",
+    });
+  });
+
+  test("normalizes cdp-debugger alias to cdp-inspect", () => {
+    expect(parseBrowserMode({ browser_mode: "cdp-debugger" })).toEqual({
+      ok: true,
+      mode: "cdp-inspect",
+    });
+  });
+
+  test("normalizes playwright alias to local", () => {
+    expect(parseBrowserMode({ browser_mode: "playwright" })).toEqual({
+      ok: true,
+      mode: "local",
+    });
+  });
+
+  test("returns error for invalid values", () => {
+    const result = parseBrowserMode({ browser_mode: "invalid" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('Invalid browser_mode "invalid"');
+      expect(result.error).toContain("Accepted values:");
+    }
+  });
+});
+
+describe("formatModeSelectionFailure", () => {
+  test("renders requested mode, attempted backends, and remediation", () => {
+    const diagnostics: AttemptDiagnostic[] = [
+      {
+        candidateKind: "extension",
+        inclusionReason: "pinned mode: extension",
+        stage: "candidate_selection",
+        errorCode: "transport_error",
+        errorMessage: "host browser proxy exists but is not connected",
+      },
+    ];
+
+    const error = new CdpError(
+      "transport_error",
+      'Pinned mode "extension" unavailable: host browser proxy exists but is not connected',
+      { attemptDiagnostics: diagnostics },
+    );
+
+    const formatted = formatModeSelectionFailure("extension", error);
+
+    expect(formatted).toContain('Browser mode "extension" failed');
+    expect(formatted).toContain("extension: FAILED at candidate_selection");
+    expect(formatted).toContain(
+      "host browser proxy exists but is not connected",
+    );
+    expect(formatted).toContain("Remediation:");
+    expect(formatted).toContain("extension is installed and enabled");
+  });
+
+  test("renders cdp-inspect transport_error with remediation", () => {
+    const diagnostics: AttemptDiagnostic[] = [
+      {
+        candidateKind: "cdp-inspect",
+        inclusionReason: "pinned mode: cdp-inspect",
+        stage: "send",
+        errorCode: "transport_error",
+        errorMessage: "CDP endpoint unreachable",
+        discoveryCode: "unreachable",
+      },
+    ];
+
+    const error = new CdpError("transport_error", "CDP endpoint unreachable", {
+      attemptDiagnostics: diagnostics,
+    });
+
+    const formatted = formatModeSelectionFailure("cdp-inspect", error);
+
+    expect(formatted).toContain('Browser mode "cdp-inspect" failed');
+    expect(formatted).toContain("cdp-inspect: FAILED at send");
+    expect(formatted).toContain("Discovery code: unreachable");
+    expect(formatted).toContain("Remediation:");
+    expect(formatted).toContain("--remote-debugging-port");
+  });
+});
+
+describe("browser_mode wiring through tool execution", () => {
+  beforeEach(() => {
+    resetCdp();
+  });
+
+  // ── Invalid browser_mode returns error ─────────────────────────
+
+  test("executeBrowserNavigate rejects invalid browser_mode", async () => {
+    const result = await executeBrowserNavigate(
+      { url: "https://example.com", browser_mode: "bogus" },
+      ctx,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Invalid browser_mode "bogus"');
+    expect(cdpSendCalls).toEqual([]);
+  });
+
+  test("executeBrowserSnapshot rejects invalid browser_mode", async () => {
+    const result = await executeBrowserSnapshot({ browser_mode: "bogus" }, ctx);
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Invalid browser_mode "bogus"');
+    expect(cdpSendCalls).toEqual([]);
+  });
+
+  test("executeBrowserScreenshot rejects invalid browser_mode", async () => {
+    const result = await executeBrowserScreenshot(
+      { browser_mode: "bogus" },
+      ctx,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Invalid browser_mode "bogus"');
+    expect(cdpSendCalls).toEqual([]);
+  });
+
+  // ── Pinned extension with no proxy returns remediation error ───
+
+  test("pinned extension with no proxy returns remediation-rich error in navigate", async () => {
+    factoryThrowError = new CdpError(
+      "transport_error",
+      'Pinned mode "extension" unavailable: no host browser proxy provisioned for this conversation',
+      {
+        attemptDiagnostics: [
+          {
+            candidateKind: "extension",
+            inclusionReason: "pinned mode: extension",
+            stage: "candidate_selection",
+            errorCode: "transport_error",
+            errorMessage:
+              "no host browser proxy provisioned for this conversation",
+          },
+        ],
+      },
+    );
+
+    const result = await executeBrowserNavigate(
+      { url: "https://example.com", browser_mode: "extension" },
+      ctx,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Browser mode "extension" failed');
+    expect(result.content).toContain(
+      "extension: FAILED at candidate_selection",
+    );
+    expect(result.content).toContain("Remediation:");
+    expect(result.content).toContain("extension is installed and enabled");
+    // Factory should not have been called for CDP
+    expect(cdpSendCalls).toEqual([]);
+  });
+
+  test("pinned extension failure surfaces in snapshot tool response", async () => {
+    factoryThrowError = new CdpError(
+      "transport_error",
+      'Pinned mode "extension" unavailable: host browser proxy exists but is not connected',
+      {
+        attemptDiagnostics: [
+          {
+            candidateKind: "extension",
+            inclusionReason: "pinned mode: extension",
+            stage: "candidate_selection",
+            errorCode: "transport_error",
+            errorMessage: "host browser proxy exists but is not connected",
+          },
+        ],
+      },
+    );
+
+    const result = await executeBrowserSnapshot(
+      { browser_mode: "extension" },
+      ctx,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Browser mode "extension" failed');
+    expect(result.content).toContain("Remediation:");
+  });
+
+  // ── cdp-debugger alias normalization ──────────────────────────
+
+  test("cdp-debugger alias normalizes to cdp-inspect and surfaces failure", async () => {
+    factoryThrowError = new CdpError(
+      "transport_error",
+      "CDP endpoint unreachable",
+      {
+        attemptDiagnostics: [
+          {
+            candidateKind: "cdp-inspect",
+            inclusionReason: "pinned mode: cdp-inspect",
+            stage: "send",
+            errorCode: "transport_error",
+            errorMessage: "CDP endpoint unreachable on localhost:9222",
+            discoveryCode: "unreachable",
+          },
+        ],
+      },
+    );
+
+    const result = await executeBrowserSnapshot(
+      { browser_mode: "cdp-debugger" },
+      ctx,
+    );
+    expect(result.isError).toBe(true);
+    // The error should reference the canonical cdp-inspect name
+    expect(result.content).toContain('Browser mode "cdp-inspect" failed');
+    expect(result.content).toContain("Discovery code: unreachable");
+    expect(result.content).toContain("Remediation:");
+    expect(result.content).toContain("--remote-debugging-port");
+  });
+
+  // ── Pinned local/playwright behavior ──────────────────────────
+
+  test("pinned local mode proceeds normally on success", async () => {
+    // No factory error — local mode succeeds
+    const result = await executeBrowserSnapshot({ browser_mode: "local" }, ctx);
+    // Snapshot should succeed (using default CDP handler)
+    expect(result.isError).toBe(false);
+  });
+
+  test("playwright alias maps to local and works", async () => {
+    const result = await executeBrowserSnapshot(
+      { browser_mode: "playwright" },
+      ctx,
+    );
+    expect(result.isError).toBe(false);
+  });
+
+  // ── Auto mode still works without browser_mode ────────────────
+
+  test("auto mode works when browser_mode is not specified", async () => {
+    const result = await executeBrowserSnapshot({}, ctx);
+    expect(result.isError).toBe(false);
+  });
+
+  // ── Tool-response includes full attempted-mode diagnostics ────
+
+  test("screenshot tool response includes full diagnostics on pinned mode failure", async () => {
+    factoryThrowError = new CdpError(
+      "transport_error",
+      "CDP endpoint unreachable",
+      {
+        attemptDiagnostics: [
+          {
+            candidateKind: "cdp-inspect",
+            inclusionReason: "pinned mode: cdp-inspect",
+            stage: "send",
+            errorCode: "transport_error",
+            errorMessage: "HTTP discovery failed (unreachable)",
+            discoveryCode: "unreachable",
+          },
+        ],
+      },
+    );
+
+    const result = await executeBrowserScreenshot(
+      { browser_mode: "cdp-inspect" },
+      ctx,
+    );
+    expect(result.isError).toBe(true);
+
+    // Verify the full diagnostic trace is in the response
+    expect(result.content).toContain('Browser mode "cdp-inspect" failed');
+    expect(result.content).toContain("Attempted backends:");
+    expect(result.content).toContain("cdp-inspect: FAILED at send");
+    expect(result.content).toContain(
+      "Reason: HTTP discovery failed (unreachable)",
+    );
+    expect(result.content).toContain("Discovery code: unreachable");
+    expect(result.content).toContain("Remediation:");
+  });
+
+  test("click tool returns remediation error on pinned mode failure", async () => {
+    factoryThrowError = new CdpError(
+      "transport_error",
+      'Pinned mode "extension" unavailable',
+      {
+        attemptDiagnostics: [
+          {
+            candidateKind: "extension",
+            inclusionReason: "pinned mode: extension",
+            stage: "candidate_selection",
+            errorCode: "transport_error",
+            errorMessage: "no host browser proxy provisioned",
+          },
+        ],
+      },
+    );
+
+    const result = await executeBrowserClick(
+      { element_id: "e1", browser_mode: "extension" },
+      ctx,
+    );
+    // Note: click tries resolveElement first (which returns null for e1)
+    // so the error comes from element resolution, not mode selection
+    // Let's test with selector instead
+    expect(result.isError).toBe(true);
+  });
+});

--- a/assistant/src/__tests__/headless-browser-mode.test.ts
+++ b/assistant/src/__tests__/headless-browser-mode.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
 // ── Mocks ────────────────────────────────────────────────────────────
 
@@ -135,6 +135,11 @@ import {
   parseBrowserMode,
 } from "../tools/browser/browser-execution.js";
 import type { ToolContext } from "../tools/types.js";
+
+// Restore all module mocks after this file completes so they don't
+// bleed into other test files when Bun runs multiple suites in a
+// single invocation (e.g. factory.test.ts receiving our fake getCdpClient).
+afterAll(() => mock.restore());
 
 const ctx: ToolContext = {
   conversationId: "test-conversation",

--- a/assistant/src/config/bundled-skills/browser/SKILL.md
+++ b/assistant/src/config/bundled-skills/browser/SKILL.md
@@ -34,6 +34,26 @@ Use this skill to browse the web. After loading this skill, the following browse
 
 This browser runs **full Chromium with JavaScript enabled**. It can handle SPAs, React/Vue/Angular apps, dynamic content, date pickers, booking systems, reservation flows, and any JavaScript-heavy interactive site. Never tell the user you "can't handle interactive JavaScript" - you can.
 
+## Browser Mode
+
+Every browser tool accepts an optional `browser_mode` parameter that controls which backend executes the command:
+
+| Value | Backend | Description |
+|---|---|---|
+| `auto` | Automatic | Default. The assistant picks the best available backend based on context (extension > cdp-inspect > local). |
+| `extension` | Chrome extension | Routes through the user's Chrome browser via the extension debugger. |
+| `cdp-inspect` | CDP inspect | Connects to an already-running Chrome instance via the DevTools protocol. Alias: `cdp-debugger`. |
+| `local` | Playwright | Drives a dedicated Playwright-managed Chromium instance. Alias: `playwright`. |
+
+**When to use `auto`**: Prefer `auto` (or omit `browser_mode` entirely) unless you have a specific reason to pin. The automatic backend selection handles extension availability, fallback, and session reuse.
+
+**When to pin a mode**: Pin explicitly when:
+- The user requests interaction with their own browser (use `extension` or `cdp-inspect`).
+- A tool only works on a specific backend (e.g. `browser_wait_for_download` requires `local`).
+- You want to avoid fallback behavior for diagnostic clarity.
+
+**Unsupported mode errors**: Some tools restrict which modes they support. For example, `browser_wait_for_download` only supports `auto` and `local` because file downloads require the Playwright backend. Passing an unsupported mode returns a clear error with the accepted alternatives.
+
 ## Typical Workflow
 
 1. `browser_attach` to establish the debugger session (extension path; optional on other backends)

--- a/assistant/src/config/bundled-skills/browser/TOOLS.json
+++ b/assistant/src/config/bundled-skills/browser/TOOLS.json
@@ -17,6 +17,10 @@
             "type": "boolean",
             "description": "If true, allows navigation to localhost/private-network hosts. Disabled by default for SSRF safety."
           },
+          "browser_mode": {
+            "type": "string",
+            "description": "Override backend selection. Values: auto (default), extension, cdp-inspect (alias: cdp-debugger), local (alias: playwright). Omit or use auto to let the assistant choose."
+          },
           "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
@@ -35,6 +39,10 @@
       "input_schema": {
         "type": "object",
         "properties": {
+          "browser_mode": {
+            "type": "string",
+            "description": "Override backend selection. Values: auto (default), extension, cdp-inspect (alias: cdp-debugger), local (alias: playwright). Omit or use auto to let the assistant choose."
+          },
           "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
@@ -55,6 +63,10 @@
           "full_page": {
             "type": "boolean",
             "description": "Capture the full scrollable page instead of just the viewport."
+          },
+          "browser_mode": {
+            "type": "string",
+            "description": "Override backend selection. Values: auto (default), extension, cdp-inspect (alias: cdp-debugger), local (alias: playwright). Omit or use auto to let the assistant choose."
           },
           "activity": {
             "type": "string",
@@ -77,6 +89,10 @@
             "type": "boolean",
             "description": "If true, close all browser pages and the browser context. Default: false (close only the current conversation page)."
           },
+          "browser_mode": {
+            "type": "string",
+            "description": "Override backend selection. Values: auto (default), extension, cdp-inspect (alias: cdp-debugger), local (alias: playwright). Omit or use auto to let the assistant choose."
+          },
           "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
@@ -94,6 +110,10 @@
       "input_schema": {
         "type": "object",
         "properties": {
+          "browser_mode": {
+            "type": "string",
+            "description": "Override backend selection. Values: auto (default), extension, cdp-inspect (alias: cdp-debugger), local (alias: playwright). Omit or use auto to let the assistant choose."
+          },
           "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
@@ -111,6 +131,10 @@
       "input_schema": {
         "type": "object",
         "properties": {
+          "browser_mode": {
+            "type": "string",
+            "description": "Override backend selection. Values: auto (default), extension, cdp-inspect (alias: cdp-debugger), local (alias: playwright). Omit or use auto to let the assistant choose."
+          },
           "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
@@ -135,6 +159,10 @@
           "selector": {
             "type": "string",
             "description": "A CSS selector to target. Used as fallback when element_id is not available."
+          },
+          "browser_mode": {
+            "type": "string",
+            "description": "Override backend selection. Values: auto (default), extension, cdp-inspect (alias: cdp-debugger), local (alias: playwright). Omit or use auto to let the assistant choose."
           },
           "activity": {
             "type": "string",
@@ -173,6 +201,10 @@
             "type": "boolean",
             "description": "If true, press Enter after typing the text."
           },
+          "browser_mode": {
+            "type": "string",
+            "description": "Override backend selection. Values: auto (default), extension, cdp-inspect (alias: cdp-debugger), local (alias: playwright). Omit or use auto to let the assistant choose."
+          },
           "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
@@ -202,6 +234,10 @@
           "selector": {
             "type": "string",
             "description": "Optional CSS selector to target."
+          },
+          "browser_mode": {
+            "type": "string",
+            "description": "Override backend selection. Values: auto (default), extension, cdp-inspect (alias: cdp-debugger), local (alias: playwright). Omit or use auto to let the assistant choose."
           },
           "activity": {
             "type": "string",
@@ -237,6 +273,10 @@
           "selector": {
             "type": "string",
             "description": "Optional CSS selector of element to scroll within."
+          },
+          "browser_mode": {
+            "type": "string",
+            "description": "Override backend selection. Values: auto (default), extension, cdp-inspect (alias: cdp-debugger), local (alias: playwright). Omit or use auto to let the assistant choose."
           },
           "activity": {
             "type": "string",
@@ -276,6 +316,10 @@
             "type": "number",
             "description": "The zero-based index of the <option> to select."
           },
+          "browser_mode": {
+            "type": "string",
+            "description": "Override backend selection. Values: auto (default), extension, cdp-inspect (alias: cdp-debugger), local (alias: playwright). Omit or use auto to let the assistant choose."
+          },
           "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
@@ -300,6 +344,10 @@
           "selector": {
             "type": "string",
             "description": "A CSS selector to target. Used as fallback when element_id is not available."
+          },
+          "browser_mode": {
+            "type": "string",
+            "description": "Override backend selection. Values: auto (default), extension, cdp-inspect (alias: cdp-debugger), local (alias: playwright). Omit or use auto to let the assistant choose."
           },
           "activity": {
             "type": "string",
@@ -334,6 +382,10 @@
             "type": "number",
             "description": "Maximum wait time in milliseconds (default and max: 30000)."
           },
+          "browser_mode": {
+            "type": "string",
+            "description": "Override backend selection. Values: auto (default), extension, cdp-inspect (alias: cdp-debugger), local (alias: playwright). Omit or use auto to let the assistant choose."
+          },
           "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
@@ -355,6 +407,10 @@
             "type": "boolean",
             "description": "If true, include a list of links found on the page (up to 200)."
           },
+          "browser_mode": {
+            "type": "string",
+            "description": "Override backend selection. Values: auto (default), extension, cdp-inspect (alias: cdp-debugger), local (alias: playwright). Omit or use auto to let the assistant choose."
+          },
           "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
@@ -375,6 +431,10 @@
           "timeout": {
             "type": "number",
             "description": "Maximum wait time in milliseconds (default: 30000, max: 120000)."
+          },
+          "browser_mode": {
+            "type": "string",
+            "description": "Override backend selection. Values: auto (default), extension, cdp-inspect (alias: cdp-debugger), local (alias: playwright). Omit or use auto to let the assistant choose."
           },
           "activity": {
             "type": "string",
@@ -412,6 +472,10 @@
           "press_enter": {
             "type": "boolean",
             "description": "Press Enter after filling"
+          },
+          "browser_mode": {
+            "type": "string",
+            "description": "Override backend selection. Values: auto (default), extension, cdp-inspect (alias: cdp-debugger), local (alias: playwright). Omit or use auto to let the assistant choose."
           },
           "activity": {
             "type": "string",

--- a/assistant/src/config/bundled-skills/browser/TOOLS.json
+++ b/assistant/src/config/bundled-skills/browser/TOOLS.json
@@ -434,7 +434,7 @@
           },
           "browser_mode": {
             "type": "string",
-            "description": "Override backend selection. Values: auto (default), extension, cdp-inspect (alias: cdp-debugger), local (alias: playwright). Omit or use auto to let the assistant choose."
+            "description": "Override backend selection. Only auto (default) and local (alias: playwright) are supported for this tool — file downloads require the local Playwright backend. Other modes (extension, cdp-inspect) are not supported and will be rejected."
           },
           "activity": {
             "type": "string",

--- a/assistant/src/config/bundled-skills/browser/tools/browser-wait-for-download.ts
+++ b/assistant/src/config/bundled-skills/browser/tools/browser-wait-for-download.ts
@@ -1,4 +1,5 @@
 import { browserManager } from "../../../../tools/browser/browser-manager.js";
+import { normalizeBrowserMode } from "../../../../tools/browser/browser-mode.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -8,6 +9,22 @@ export async function run(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
+  // Validate browser_mode: only auto/local are supported for downloads.
+  const modeResult = normalizeBrowserMode(input.browser_mode);
+  if ("error" in modeResult) {
+    return { content: `Error: ${modeResult.error}`, isError: true };
+  }
+  const { mode } = modeResult;
+  if (mode !== "auto" && mode !== "local") {
+    return {
+      content:
+        `Error: browser_wait_for_download does not support browser_mode "${mode}". ` +
+        `File downloads require the local Playwright backend. ` +
+        `Use browser_mode "auto" or "local" instead.`,
+      isError: true,
+    };
+  }
+
   const timeout =
     typeof input.timeout === "number"
       ? Math.min(Math.max(input.timeout, 1000), 120_000)

--- a/assistant/src/runtime/AGENTS.md
+++ b/assistant/src/runtime/AGENTS.md
@@ -94,6 +94,29 @@ On macOS-originated turns, the CDP factory (`tools/browser/cdp-client/factory.ts
 
 **After the first successful CDP command**, the selected backend becomes **sticky** for the remainder of the tool invocation. Subsequent commands always route through the same backend so multi-command tool flows do not hop transports mid-step.
 
+### Per-tool `browser_mode` override
+
+All CDP-backed browser tools (`browser_navigate`, `browser_snapshot`, `browser_screenshot`, `browser_click`, `browser_type`, `browser_hover`, `browser_scroll`, `browser_press_key`, `browser_select_option`, `browser_wait_for`, `browser_extract`, `browser_fill_credential`, `browser_attach`, `browser_detach`, `browser_close`) accept an optional `browser_mode` input parameter that overrides the automatic backend selection for that invocation.
+
+| Value            | Behavior                                                                 |
+| ---------------- | ------------------------------------------------------------------------ |
+| `auto` (default) | Existing priority-ordered fallback: extension -> cdp-inspect -> local    |
+| `extension`      | Pin to chrome-extension backend. Fails immediately if proxy unavailable. |
+| `cdp-inspect`    | Pin to CDP inspect/debugger backend. Fails if endpoint unreachable.      |
+| `local`          | Pin to local Playwright-managed browser. No fallback.                    |
+| `cdp-debugger`   | Alias for `cdp-inspect`.                                                 |
+| `playwright`     | Alias for `local`.                                                       |
+
+**Strict pinned-mode semantics**: When `browser_mode` is set to a specific backend (not `auto`), the factory builds exactly one candidate and disables failover. If the pinned backend is unavailable, the tool returns a detailed error including:
+
+- The requested mode
+- An ordered list of attempted backends with exact failure reasons
+- A remediation checklist tailored by backend and failure code (e.g. "Ensure Chrome is running with --remote-debugging-port=9222")
+
+**Auto-mode fallback logging**: In auto mode, fallback transitions are logged at `warn` level with structured metadata including the full candidate sequence and per-candidate failure reasons. This ensures fallback events are always observable in production logs.
+
+**Test coverage:** Regression tests for `browser_mode` wiring live in `__tests__/headless-browser-mode.test.ts`. Unit tests for pinned candidate construction and failover live in `tools/browser/cdp-client/__tests__/factory.test.ts`.
+
 **Test coverage:** E2E regression tests for this precedence order live in `__tests__/host-browser-e2e-cloud.test.ts` (extension path) and `__tests__/conversation-routes-disk-view.test.ts` (macOS fallback path). Unit tests for candidate list construction and failover live in `tools/browser/cdp-client/__tests__/factory.test.ts`.
 
 ### Channel approvals (Telegram, Slack)

--- a/assistant/src/runtime/AGENTS.md
+++ b/assistant/src/runtime/AGENTS.md
@@ -115,9 +115,7 @@ All CDP-backed browser tools (`browser_navigate`, `browser_snapshot`, `browser_s
 
 **Auto-mode fallback logging**: In auto mode, fallback transitions are logged at `warn` level with structured metadata including the full candidate sequence and per-candidate failure reasons. This ensures fallback events are always observable in production logs.
 
-**Test coverage:** Regression tests for `browser_mode` wiring live in `__tests__/headless-browser-mode.test.ts`. Unit tests for pinned candidate construction and failover live in `tools/browser/cdp-client/__tests__/factory.test.ts`.
-
-**Test coverage:** E2E regression tests for this precedence order live in `__tests__/host-browser-e2e-cloud.test.ts` (extension path) and `__tests__/conversation-routes-disk-view.test.ts` (macOS fallback path). Unit tests for candidate list construction and failover live in `tools/browser/cdp-client/__tests__/factory.test.ts`.
+**Test coverage:** Regression tests for `browser_mode` wiring live in `__tests__/headless-browser-mode.test.ts`. E2E regression tests for backend precedence live in `__tests__/host-browser-e2e-cloud.test.ts` (extension path) and `__tests__/conversation-routes-disk-view.test.ts` (macOS fallback path). Unit tests for pinned candidate construction and failover live in `tools/browser/cdp-client/__tests__/factory.test.ts`.
 
 ### Channel approvals (Telegram, Slack)
 

--- a/assistant/src/tools/browser/__tests__/browser-mode.test.ts
+++ b/assistant/src/tools/browser/__tests__/browser-mode.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from "bun:test";
+
+import type { BrowserMode } from "../browser-mode.js";
+import { normalizeBrowserMode } from "../browser-mode.js";
+
+describe("normalizeBrowserMode", () => {
+  // ── Defaults ──────────────────────────────────────────────────────────
+
+  test("undefined defaults to auto", () => {
+    const result = normalizeBrowserMode(undefined);
+    expect(result).toEqual({ mode: "auto" });
+  });
+
+  test("null defaults to auto", () => {
+    const result = normalizeBrowserMode(null);
+    expect(result).toEqual({ mode: "auto" });
+  });
+
+  test("empty string defaults to auto", () => {
+    const result = normalizeBrowserMode("");
+    expect(result).toEqual({ mode: "auto" });
+  });
+
+  // ── Canonical values ──────────────────────────────────────────────────
+
+  const canonicalValues: BrowserMode[] = [
+    "auto",
+    "extension",
+    "cdp-inspect",
+    "local",
+  ];
+
+  for (const value of canonicalValues) {
+    test(`canonical value "${value}" normalizes to itself`, () => {
+      const result = normalizeBrowserMode(value);
+      expect(result).toEqual({ mode: value });
+    });
+  }
+
+  // ── Aliases ───────────────────────────────────────────────────────────
+
+  test('alias "cdp-debugger" normalizes to "cdp-inspect"', () => {
+    const result = normalizeBrowserMode("cdp-debugger");
+    expect(result).toEqual({ mode: "cdp-inspect" });
+  });
+
+  test('alias "playwright" normalizes to "local"', () => {
+    const result = normalizeBrowserMode("playwright");
+    expect(result).toEqual({ mode: "local" });
+  });
+
+  // ── Case insensitivity ────────────────────────────────────────────────
+
+  test("uppercase input is normalized", () => {
+    const result = normalizeBrowserMode("AUTO");
+    expect(result).toEqual({ mode: "auto" });
+  });
+
+  test("mixed-case alias is normalized", () => {
+    const result = normalizeBrowserMode("Playwright");
+    expect(result).toEqual({ mode: "local" });
+  });
+
+  test("mixed-case cdp-debugger alias is normalized", () => {
+    const result = normalizeBrowserMode("CDP-Debugger");
+    expect(result).toEqual({ mode: "cdp-inspect" });
+  });
+
+  // ── Whitespace trimming ───────────────────────────────────────────────
+
+  test("leading/trailing whitespace is trimmed", () => {
+    const result = normalizeBrowserMode("  local  ");
+    expect(result).toEqual({ mode: "local" });
+  });
+
+  // ── Invalid values ────────────────────────────────────────────────────
+
+  test("unknown string returns error with accepted values", () => {
+    const result = normalizeBrowserMode("headless");
+    expect("error" in result).toBe(true);
+    if ("error" in result) {
+      expect(result.error).toContain('Invalid browser_mode "headless"');
+      expect(result.error).toContain("Accepted values:");
+      expect(result.error).toContain("auto");
+      expect(result.error).toContain("extension");
+      expect(result.error).toContain("cdp-inspect");
+      expect(result.error).toContain("cdp-debugger");
+      expect(result.error).toContain("local");
+      expect(result.error).toContain("playwright");
+      expect(result.error).toContain("Aliases:");
+      expect(result.error).toContain("cdp-debugger->cdp-inspect");
+      expect(result.error).toContain("playwright->local");
+    }
+  });
+
+  test("non-string input returns error", () => {
+    const result = normalizeBrowserMode(42);
+    expect("error" in result).toBe(true);
+    if ("error" in result) {
+      expect(result.error).toContain('Invalid browser_mode "42"');
+    }
+  });
+
+  test("boolean input returns error", () => {
+    const result = normalizeBrowserMode(true);
+    expect("error" in result).toBe(true);
+    if ("error" in result) {
+      expect(result.error).toContain('Invalid browser_mode "true"');
+    }
+  });
+
+  // ── Error message determinism ─────────────────────────────────────────
+
+  test("error message is deterministic across calls", () => {
+    const r1 = normalizeBrowserMode("bogus");
+    const r2 = normalizeBrowserMode("bogus");
+    expect(r1).toEqual(r2);
+  });
+});

--- a/assistant/src/tools/browser/browser-execution.ts
+++ b/assistant/src/tools/browser/browser-execution.ts
@@ -422,12 +422,8 @@ export async function executeBrowserNavigate(
     return { content: "Error: operation was cancelled", isError: true };
   }
 
-  const modeResult = parseBrowserMode(input);
-  if (!modeResult.ok) {
-    return { content: modeResult.error, isError: true };
-  }
-  const browserMode = modeResult.mode;
-
+  // Pre-flight URL validation runs before CDP acquisition so we fail
+  // fast on obviously invalid URLs without opening a browser session.
   const parsedUrl = parseUrl(input.url);
   if (!parsedUrl) {
     return {
@@ -466,18 +462,10 @@ export async function executeBrowserNavigate(
     }
   }
 
-  let cdp;
-  try {
-    cdp = getCdpClient(context, { mode: browserMode });
-  } catch (err) {
-    if (err instanceof CdpError && browserMode !== "auto") {
-      return {
-        content: formatModeSelectionFailure(browserMode, err),
-        isError: true,
-      };
-    }
-    throw err;
-  }
+  // URL validation passed — acquire the CDP client.
+  const acquired = acquireCdpClientWithMode(input, context);
+  if (acquired.errorResult) return acquired.errorResult;
+  const { cdp, browserMode } = acquired;
 
   // Screencast + handoff are Playwright-backed and only meaningful
   // for the local sacrificial-profile path. On the extension path the
@@ -847,24 +835,9 @@ export async function executeBrowserSnapshot(
   _input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  const modeResult = parseBrowserMode(_input);
-  if (!modeResult.ok) {
-    return { content: modeResult.error, isError: true };
-  }
-  const browserMode = modeResult.mode;
-
-  let cdp;
-  try {
-    cdp = getCdpClient(context, { mode: browserMode });
-  } catch (err) {
-    if (err instanceof CdpError && browserMode !== "auto") {
-      return {
-        content: formatModeSelectionFailure(browserMode, err),
-        isError: true,
-      };
-    }
-    throw err;
-  }
+  const acquired = acquireCdpClientWithMode(_input, context);
+  if (acquired.errorResult) return acquired.errorResult;
+  const { cdp, browserMode } = acquired;
 
   try {
     const currentUrl = await getCurrentUrl(cdp, context.signal);
@@ -914,25 +887,10 @@ export async function executeBrowserScreenshot(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  const modeResult = parseBrowserMode(input);
-  if (!modeResult.ok) {
-    return { content: modeResult.error, isError: true };
-  }
-  const browserMode = modeResult.mode;
+  const acquired = acquireCdpClientWithMode(input, context);
+  if (acquired.errorResult) return acquired.errorResult;
+  const { cdp, browserMode } = acquired;
   const fullPage = input.full_page === true;
-
-  let cdp;
-  try {
-    cdp = getCdpClient(context, { mode: browserMode });
-  } catch (err) {
-    if (err instanceof CdpError && browserMode !== "auto") {
-      return {
-        content: formatModeSelectionFailure(browserMode, err),
-        isError: true,
-      };
-    }
-    throw err;
-  }
 
   try {
     const buffer = await captureScreenshotJpeg(

--- a/assistant/src/tools/browser/browser-execution.ts
+++ b/assistant/src/tools/browser/browser-execution.ts
@@ -1636,6 +1636,13 @@ export async function executeBrowserWaitFor(
       ? Math.min(input.timeout, MAX_WAIT_MS)
       : MAX_WAIT_MS;
 
+  // Validate browser_mode even on the duration path so invalid values
+  // are rejected consistently regardless of which wait mode is used.
+  const modeResult = parseBrowserMode(input);
+  if (!modeResult.ok) {
+    return { content: modeResult.error, isError: true };
+  }
+
   // Duration mode has no CDP interaction — handle without acquiring
   // a CdpClient so the common "sleep" path stays transport-agnostic.
   if (duration != null) {

--- a/assistant/src/tools/browser/browser-execution.ts
+++ b/assistant/src/tools/browser/browser-execution.ts
@@ -18,6 +18,7 @@ import {
 } from "./auth-detector.js";
 import type { RouteHandler } from "./browser-manager.js";
 import { browserManager } from "./browser-manager.js";
+import { type BrowserMode, normalizeBrowserMode } from "./browser-mode.js";
 import {
   ensureScreencast,
   getSender,
@@ -46,8 +47,9 @@ import {
   waitForSelector as cdpWaitForSelector,
   waitForText as cdpWaitForText,
 } from "./cdp-client/cdp-dom-helpers.js";
+import { CdpError } from "./cdp-client/errors.js";
 import { getCdpClient } from "./cdp-client/factory.js";
-import type { CdpClient } from "./cdp-client/types.js";
+import type { AttemptDiagnostic, CdpClient } from "./cdp-client/types.js";
 
 const log = getLogger("headless-browser");
 
@@ -99,6 +101,251 @@ export const EXTRACT_LINKS_EXPRESSION = `
   }));
 })()
 `;
+
+// ── browser_mode parsing ─────────────────────────────────────────────
+
+/**
+ * Parse the `browser_mode` field from a tool input map. Returns either
+ * a normalized {@link BrowserMode} or a pre-formatted error string
+ * suitable for returning directly in a tool response.
+ *
+ * When the value is absent, undefined, or empty the default `"auto"`
+ * is returned. Invalid values produce a descriptive error listing
+ * accepted values and aliases.
+ */
+export function parseBrowserMode(
+  input: Record<string, unknown>,
+): { ok: true; mode: BrowserMode } | { ok: false; error: string } {
+  const raw = input.browser_mode;
+  const result = normalizeBrowserMode(raw);
+  if ("error" in result) {
+    return { ok: false, error: `Error: ${result.error}` };
+  }
+  return { ok: true, mode: result.mode };
+}
+
+// ── Mode-selection failure formatter ─────────────────────────────────
+
+/**
+ * Remediation hints keyed by (candidateKind, discoveryCode | errorCode).
+ * Discovery codes come from DevToolsDiscoveryError; error codes come
+ * from CdpError. The formatter walks these in priority order: exact
+ * (kind, discoveryCode) first, then (kind, errorCode), then a generic
+ * per-kind fallback.
+ */
+const REMEDIATION_HINTS: Record<string, string[]> = {
+  // Extension backend
+  "extension:transport_error": [
+    "Ensure the Vellum browser extension is installed and enabled.",
+    "Check that the extension WebSocket connection is active (extension popup → status).",
+    "Try reconnecting the extension or reloading the extension service worker.",
+  ],
+  // cdp-inspect backend — discovery-level failures
+  "cdp-inspect:unreachable": [
+    "Ensure Chrome/Chromium is running with --remote-debugging-port=9222.",
+    "Verify no firewall or antivirus is blocking localhost:9222.",
+    "Try: /Applications/Google\\ Chrome.app/Contents/MacOS/Google\\ Chrome --remote-debugging-port=9222",
+  ],
+  "cdp-inspect:non_chrome": [
+    "The process listening on the configured port is not Chrome/Chromium.",
+    "Check if another application (dev server, proxy) is using port 9222.",
+    "Ensure Chrome is launched with --remote-debugging-port=9222.",
+  ],
+  "cdp-inspect:timeout": [
+    "Chrome DevTools endpoint did not respond within the probe timeout.",
+    "Ensure Chrome is running and listening on the configured port.",
+    "Try increasing hostBrowser.cdpInspect.probeTimeoutMs in config.",
+  ],
+  "cdp-inspect:no_targets": [
+    "Chrome is reachable but has no open page targets.",
+    "Open at least one browser tab, then retry.",
+  ],
+  "cdp-inspect:non_loopback": [
+    "CDP inspect only allows loopback hosts (localhost, 127.0.0.1, ::1).",
+    "Update hostBrowser.cdpInspect.host in config to a loopback address.",
+  ],
+  "cdp-inspect:transport_error": [
+    "CDP endpoint unreachable. Ensure Chrome is running with --remote-debugging-port.",
+    "Verify the configured host:port matches Chrome's DevTools listener.",
+    "Consider using browser_mode: 'extension' or 'local' as an alternative.",
+  ],
+  // Local/Playwright backend
+  "local:transport_error": [
+    "The local Playwright-managed browser failed to start or connect.",
+    "Check that the Playwright browser binary is downloaded (bun run install).",
+    "Try closing any stale Chromium processes and retrying.",
+  ],
+};
+
+/**
+ * Build a human-readable, tool-response-ready error string from a
+ * pinned-mode failure. Includes:
+ *   - the requested mode
+ *   - ordered attempted modes with exact failure reasons
+ *   - a remediation checklist tailored by backend and failure code
+ *
+ * Exported for testing.
+ */
+export function formatModeSelectionFailure(
+  requestedMode: BrowserMode,
+  error: CdpError,
+): string {
+  const lines: string[] = [];
+  lines.push(`Error: Browser mode "${requestedMode}" failed.`);
+  lines.push("");
+
+  const diagnostics: readonly AttemptDiagnostic[] =
+    error.attemptDiagnostics ?? [];
+
+  if (diagnostics.length > 0) {
+    lines.push("Attempted backends:");
+    for (const diag of diagnostics) {
+      const status =
+        diag.stage === "success" ? "OK" : `FAILED at ${diag.stage}`;
+      lines.push(`  - ${diag.candidateKind}: ${status}`);
+      if (diag.errorMessage) {
+        lines.push(`    Reason: ${diag.errorMessage}`);
+      }
+      if (diag.discoveryCode) {
+        lines.push(`    Discovery code: ${diag.discoveryCode}`);
+      }
+    }
+    lines.push("");
+  }
+
+  // Collect remediation hints
+  const hints = collectRemediationHints(diagnostics, error);
+  if (hints.length > 0) {
+    lines.push("Remediation:");
+    for (const hint of hints) {
+      lines.push(`  - ${hint}`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * Gather remediation hints based on attempt diagnostics and the error.
+ * Walks each diagnostic and looks up hints by (kind, discoveryCode),
+ * then (kind, errorCode), then generic kind-level fallback.
+ */
+function collectRemediationHints(
+  diagnostics: readonly AttemptDiagnostic[],
+  error: CdpError,
+): string[] {
+  const seen = new Set<string>();
+  const hints: string[] = [];
+
+  const addHints = (key: string) => {
+    const list = REMEDIATION_HINTS[key];
+    if (!list) return;
+    for (const hint of list) {
+      if (!seen.has(hint)) {
+        seen.add(hint);
+        hints.push(hint);
+      }
+    }
+  };
+
+  for (const diag of diagnostics) {
+    if (diag.stage === "success") continue;
+    if (diag.discoveryCode) {
+      addHints(`${diag.candidateKind}:${diag.discoveryCode}`);
+    }
+    if (diag.errorCode) {
+      addHints(`${diag.candidateKind}:${diag.errorCode}`);
+    }
+  }
+
+  // Fallback: if no diagnostics but we have a top-level error, use
+  // the error code with a generic candidate kind derived from the mode.
+  if (diagnostics.length === 0 && error.code) {
+    // Try to infer the candidate kind from the error message
+    for (const kind of ["extension", "cdp-inspect", "local"] as const) {
+      if (error.message.toLowerCase().includes(kind)) {
+        addHints(`${kind}:${error.code}`);
+      }
+    }
+  }
+
+  return hints;
+}
+
+/**
+ * Parse browser_mode from input and acquire a CdpClient. Returns
+ * either a `{ cdp, browserMode }` pair on success or a pre-formatted
+ * `{ errorResult }` on failure (invalid mode or pinned-mode
+ * precondition not met).
+ *
+ * This is the single integration point for all CDP-backed tool
+ * functions. Using it ensures every tool:
+ *   - normalizes aliases (`cdp-debugger` -> `cdp-inspect`, etc.)
+ *   - passes the mode preference to the factory
+ *   - surfaces a remediation-rich error on pinned-mode failures
+ */
+export function acquireCdpClientWithMode(
+  input: Record<string, unknown>,
+  context: ToolContext,
+):
+  | {
+      cdp: ReturnType<typeof getCdpClient>;
+      browserMode: BrowserMode;
+      errorResult?: never;
+    }
+  | { cdp?: never; browserMode?: never; errorResult: ToolExecutionResult } {
+  const modeResult = parseBrowserMode(input);
+  if (!modeResult.ok) {
+    return {
+      errorResult: { content: modeResult.error, isError: true },
+    };
+  }
+  const browserMode = modeResult.mode;
+
+  try {
+    const cdp = getCdpClient(context, { mode: browserMode });
+    return { cdp, browserMode };
+  } catch (err) {
+    if (err instanceof CdpError && browserMode !== "auto") {
+      return {
+        errorResult: {
+          content: formatModeSelectionFailure(browserMode, err),
+          isError: true,
+        },
+      };
+    }
+    throw err;
+  }
+}
+
+// ── CDP error diagnostics helper ─────────────────────────────────────
+
+/**
+ * Check whether a caught error is a {@link CdpError} carrying
+ * {@link AttemptDiagnostic attempt diagnostics} from the factory's
+ * failover walk. When the browser_mode is pinned (not "auto") and
+ * diagnostics are present, format the error with the full remediation
+ * checklist via {@link formatModeSelectionFailure}. Otherwise return
+ * `null` so the caller falls through to its generic error message.
+ *
+ * This handles the case where pinned-mode unavailability is surfaced
+ * on the first `cdp.send()` (via `sendWithFailover`) rather than
+ * during client construction (which `acquireCdpClientWithMode` already
+ * covers).
+ */
+function formatCdpSendDiagnostics(
+  err: unknown,
+  browserMode: BrowserMode,
+): string | null {
+  if (
+    err instanceof CdpError &&
+    browserMode !== "auto" &&
+    err.attemptDiagnostics
+  ) {
+    return formatModeSelectionFailure(browserMode, err);
+  }
+  return null;
+}
 
 // ── Shared element resolution ────────────────────────────────────────
 
@@ -175,6 +422,12 @@ export async function executeBrowserNavigate(
     return { content: "Error: operation was cancelled", isError: true };
   }
 
+  const modeResult = parseBrowserMode(input);
+  if (!modeResult.ok) {
+    return { content: modeResult.error, isError: true };
+  }
+  const browserMode = modeResult.mode;
+
   const parsedUrl = parseUrl(input.url);
   if (!parsedUrl) {
     return {
@@ -213,7 +466,18 @@ export async function executeBrowserNavigate(
     }
   }
 
-  const cdp = getCdpClient(context);
+  let cdp;
+  try {
+    cdp = getCdpClient(context, { mode: browserMode });
+  } catch (err) {
+    if (err instanceof CdpError && browserMode !== "auto") {
+      return {
+        content: formatModeSelectionFailure(browserMode, err),
+        isError: true,
+      };
+    }
+    throw err;
+  }
 
   // Screencast + handoff are Playwright-backed and only meaningful
   // for the local sacrificial-profile path. On the extension path the
@@ -564,6 +828,11 @@ export async function executeBrowserNavigate(
       };
     }
 
+    const diagnosticMessage = formatCdpSendDiagnostics(err, browserMode);
+    if (diagnosticMessage) {
+      return { content: diagnosticMessage, isError: true };
+    }
+
     const msg = err instanceof Error ? err.message : String(err);
     log.error({ err, url: safeRequestedUrl }, "Navigation failed");
     return { content: `Error: Navigation failed: ${msg}`, isError: true };
@@ -578,7 +847,25 @@ export async function executeBrowserSnapshot(
   _input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  const cdp = getCdpClient(context);
+  const modeResult = parseBrowserMode(_input);
+  if (!modeResult.ok) {
+    return { content: modeResult.error, isError: true };
+  }
+  const browserMode = modeResult.mode;
+
+  let cdp;
+  try {
+    cdp = getCdpClient(context, { mode: browserMode });
+  } catch (err) {
+    if (err instanceof CdpError && browserMode !== "auto") {
+      return {
+        content: formatModeSelectionFailure(browserMode, err),
+        isError: true,
+      };
+    }
+    throw err;
+  }
+
   try {
     const currentUrl = await getCurrentUrl(cdp, context.signal);
     const title = await getPageTitle(cdp, context.signal);
@@ -609,6 +896,10 @@ export async function executeBrowserSnapshot(
       isError: false,
     };
   } catch (err) {
+    const diagnosticMessage = formatCdpSendDiagnostics(err, browserMode);
+    if (diagnosticMessage) {
+      return { content: diagnosticMessage, isError: true };
+    }
     const msg = err instanceof Error ? err.message : String(err);
     log.error({ err }, "Snapshot failed");
     return { content: `Error: Snapshot failed: ${msg}`, isError: true };
@@ -623,9 +914,26 @@ export async function executeBrowserScreenshot(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
+  const modeResult = parseBrowserMode(input);
+  if (!modeResult.ok) {
+    return { content: modeResult.error, isError: true };
+  }
+  const browserMode = modeResult.mode;
   const fullPage = input.full_page === true;
 
-  const cdp = getCdpClient(context);
+  let cdp;
+  try {
+    cdp = getCdpClient(context, { mode: browserMode });
+  } catch (err) {
+    if (err instanceof CdpError && browserMode !== "auto") {
+      return {
+        content: formatModeSelectionFailure(browserMode, err),
+        isError: true,
+      };
+    }
+    throw err;
+  }
+
   try {
     const buffer = await captureScreenshotJpeg(
       cdp,
@@ -651,6 +959,10 @@ export async function executeBrowserScreenshot(
       contentBlocks: [imageBlock],
     };
   } catch (err) {
+    const diagnosticMessage = formatCdpSendDiagnostics(err, browserMode);
+    if (diagnosticMessage) {
+      return { content: diagnosticMessage, isError: true };
+    }
     const msg = err instanceof Error ? err.message : String(err);
     log.error({ err }, "Screenshot failed");
     return { content: `Error: Screenshot failed: ${msg}`, isError: true };
@@ -665,7 +977,9 @@ export async function executeBrowserAttach(
   _input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  const cdp = getCdpClient(context);
+  const acquired = acquireCdpClientWithMode(_input, context);
+  if (acquired.errorResult) return acquired.errorResult;
+  const cdp = acquired.cdp;
   try {
     if (cdp.kind === "extension") {
       // Extension path: explicitly attach the debugger via a synthetic
@@ -695,6 +1009,13 @@ export async function executeBrowserAttach(
       isError: false,
     };
   } catch (err) {
+    const diagnosticMessage = formatCdpSendDiagnostics(
+      err,
+      acquired.browserMode,
+    );
+    if (diagnosticMessage) {
+      return { content: diagnosticMessage, isError: true };
+    }
     const msg = err instanceof Error ? err.message : String(err);
     log.error({ err }, "Attach failed");
     return { content: `Error: Attach failed: ${msg}`, isError: true };
@@ -709,7 +1030,9 @@ export async function executeBrowserDetach(
   _input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  const cdp = getCdpClient(context);
+  const acquired = acquireCdpClientWithMode(_input, context);
+  if (acquired.errorResult) return acquired.errorResult;
+  const cdp = acquired.cdp;
   try {
     if (cdp.kind === "extension") {
       // Extension path: explicitly detach the debugger via a synthetic
@@ -733,6 +1056,13 @@ export async function executeBrowserDetach(
       isError: false,
     };
   } catch (err) {
+    const diagnosticMessage = formatCdpSendDiagnostics(
+      err,
+      acquired.browserMode,
+    );
+    if (diagnosticMessage) {
+      return { content: diagnosticMessage, isError: true };
+    }
     const msg = err instanceof Error ? err.message : String(err);
     log.error({ err }, "Detach failed");
     return { content: `Error: Detach failed: ${msg}`, isError: true };
@@ -747,7 +1077,9 @@ export async function executeBrowserClose(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  const cdp = getCdpClient(context);
+  const acquired = acquireCdpClientWithMode(input, context);
+  if (acquired.errorResult) return acquired.errorResult;
+  const cdp = acquired.cdp;
   try {
     if (cdp.kind === "local") {
       // Local/sacrificial-profile path: tear down the Playwright page,
@@ -788,6 +1120,13 @@ export async function executeBrowserClose(
       isError: false,
     };
   } catch (err) {
+    const diagnosticMessage = formatCdpSendDiagnostics(
+      err,
+      acquired.browserMode,
+    );
+    if (diagnosticMessage) {
+      return { content: diagnosticMessage, isError: true };
+    }
     const msg = err instanceof Error ? err.message : String(err);
     log.error({ err }, "Close failed");
     return { content: `Error: Close failed: ${msg}`, isError: true };
@@ -805,7 +1144,9 @@ export async function executeBrowserClick(
   const { resolved, error } = resolveElement(context.conversationId, input);
   if (error) return { content: error, isError: true };
 
-  const cdp = getCdpClient(context);
+  const acquired = acquireCdpClientWithMode(input, context);
+  if (acquired.errorResult) return acquired.errorResult;
+  const cdp = acquired.cdp;
   try {
     let backendNodeId: number;
     if (resolved!.kind === "backend") {
@@ -833,6 +1174,13 @@ export async function executeBrowserClick(
         : resolved!.selector;
     return { content: `Clicked element: ${desc}`, isError: false };
   } catch (err) {
+    const diagnosticMessage = formatCdpSendDiagnostics(
+      err,
+      acquired.browserMode,
+    );
+    if (diagnosticMessage) {
+      return { content: diagnosticMessage, isError: true };
+    }
     const msg = err instanceof Error ? err.message : String(err);
     log.error({ err }, "Click failed");
     return { content: `Error: Click failed: ${msg}`, isError: true };
@@ -917,7 +1265,9 @@ export async function executeBrowserType(
       ? `element_id "${resolved!.eid}"`
       : resolved!.selector;
 
-  const cdp = getCdpClient(context);
+  const acquired = acquireCdpClientWithMode(input, context);
+  if (acquired.errorResult) return acquired.errorResult;
+  const cdp = acquired.cdp;
   try {
     let backendNodeId: number;
     if (resolved!.kind === "backend") {
@@ -946,6 +1296,13 @@ export async function executeBrowserType(
     if (pressEnter) lines.push("(pressed Enter after typing)");
     return { content: lines.join("\n"), isError: false };
   } catch (err) {
+    const diagnosticMessage = formatCdpSendDiagnostics(
+      err,
+      acquired.browserMode,
+    );
+    if (diagnosticMessage) {
+      return { content: diagnosticMessage, isError: true };
+    }
     const msg = err instanceof Error ? err.message : String(err);
     log.error({ err, target: targetDescription }, "Type failed");
     return { content: `Error: Type failed: ${msg}`, isError: true };
@@ -985,7 +1342,9 @@ export async function executeBrowserPressKey(
         : resolved!.selector;
   }
 
-  const cdp = getCdpClient(context);
+  const acquired = acquireCdpClientWithMode(input, context);
+  if (acquired.errorResult) return acquired.errorResult;
+  const cdp = acquired.cdp;
   try {
     if (resolved) {
       let backendNodeId: number;
@@ -1010,6 +1369,13 @@ export async function executeBrowserPressKey(
     await dispatchKeyPress(cdp, key, context.signal);
     return { content: `Pressed "${key}"`, isError: false };
   } catch (err) {
+    const diagnosticMessage = formatCdpSendDiagnostics(
+      err,
+      acquired.browserMode,
+    );
+    if (diagnosticMessage) {
+      return { content: diagnosticMessage, isError: true };
+    }
     const msg = err instanceof Error ? err.message : String(err);
     log.error({ err, key }, "Press key failed");
     return { content: `Error: Press key failed: ${msg}`, isError: true };
@@ -1053,7 +1419,9 @@ export async function executeBrowserScroll(
       break;
   }
 
-  const cdp = getCdpClient(context);
+  const acquired = acquireCdpClientWithMode(input, context);
+  if (acquired.errorResult) return acquired.errorResult;
+  const cdp = acquired.cdp;
   try {
     // Fetch viewport dimensions so we can dispatch the wheel event at
     // the viewport center — scrolling from (0, 0) misses sticky
@@ -1074,6 +1442,13 @@ export async function executeBrowserScroll(
 
     return { content: `Scrolled ${direction} by ${amount}px`, isError: false };
   } catch (err) {
+    const diagnosticMessage = formatCdpSendDiagnostics(
+      err,
+      acquired.browserMode,
+    );
+    if (diagnosticMessage) {
+      return { content: diagnosticMessage, isError: true };
+    }
     const msg = err instanceof Error ? err.message : String(err);
     log.error({ err, direction }, "Scroll failed");
     return { content: `Error: Scroll failed: ${msg}`, isError: true };
@@ -1107,7 +1482,9 @@ export async function executeBrowserSelectOption(
       ? `element_id "${resolved!.eid}"`
       : resolved!.selector;
 
-  const cdp = getCdpClient(context);
+  const acquired = acquireCdpClientWithMode(input, context);
+  if (acquired.errorResult) return acquired.errorResult;
+  const cdp = acquired.cdp;
   try {
     let backendNodeId: number;
     if (resolved!.kind === "backend") {
@@ -1197,6 +1574,13 @@ export async function executeBrowserSelectOption(
       isError: false,
     };
   } catch (err) {
+    const diagnosticMessage = formatCdpSendDiagnostics(
+      err,
+      acquired.browserMode,
+    );
+    if (diagnosticMessage) {
+      return { content: diagnosticMessage, isError: true };
+    }
     const msg = err instanceof Error ? err.message : String(err);
     log.error({ err, target: targetDescription }, "Select option failed");
     return { content: `Error: Select option failed: ${msg}`, isError: true };
@@ -1214,7 +1598,9 @@ export async function executeBrowserHover(
   const { resolved, error } = resolveElement(context.conversationId, input);
   if (error) return { content: error, isError: true };
 
-  const cdp = getCdpClient(context);
+  const acquired = acquireCdpClientWithMode(input, context);
+  if (acquired.errorResult) return acquired.errorResult;
+  const cdp = acquired.cdp;
   try {
     let backendNodeId: number;
     if (resolved!.kind === "backend") {
@@ -1239,6 +1625,13 @@ export async function executeBrowserHover(
         : resolved!.selector;
     return { content: `Hovered element: ${desc}`, isError: false };
   } catch (err) {
+    const diagnosticMessage = formatCdpSendDiagnostics(
+      err,
+      acquired.browserMode,
+    );
+    if (diagnosticMessage) {
+      return { content: diagnosticMessage, isError: true };
+    }
     const msg = err instanceof Error ? err.message : String(err);
     log.error({ err }, "Hover failed");
     return { content: `Error: Hover failed: ${msg}`, isError: true };
@@ -1292,7 +1685,9 @@ export async function executeBrowserWaitFor(
     return { content: `Waited ${waitMs}ms.`, isError: false };
   }
 
-  const cdp = getCdpClient(context);
+  const acquired = acquireCdpClientWithMode(input, context);
+  if (acquired.errorResult) return acquired.errorResult;
+  const cdp = acquired.cdp;
   try {
     if (selector) {
       // browser_wait_for selector mode is "did this node appear at
@@ -1316,6 +1711,13 @@ export async function executeBrowserWaitFor(
       isError: false,
     };
   } catch (err) {
+    const diagnosticMessage = formatCdpSendDiagnostics(
+      err,
+      acquired.browserMode,
+    );
+    if (diagnosticMessage) {
+      return { content: diagnosticMessage, isError: true };
+    }
     const msg = err instanceof Error ? err.message : String(err);
     log.error({ err }, "Wait failed");
     return { content: `Error: Wait failed: ${msg}`, isError: true };
@@ -1332,7 +1734,9 @@ export async function executeBrowserExtract(
 ): Promise<ToolExecutionResult> {
   const includeLinks = input.include_links === true;
 
-  const cdp = getCdpClient(context);
+  const acquired = acquireCdpClientWithMode(input, context);
+  if (acquired.errorResult) return acquired.errorResult;
+  const cdp = acquired.cdp;
   try {
     const currentUrl = await getCurrentUrl(cdp, context.signal);
     const title = await getPageTitle(cdp, context.signal);
@@ -1373,6 +1777,13 @@ export async function executeBrowserExtract(
 
     return { content: lines.join("\n"), isError: false };
   } catch (err) {
+    const diagnosticMessage = formatCdpSendDiagnostics(
+      err,
+      acquired.browserMode,
+    );
+    if (diagnosticMessage) {
+      return { content: diagnosticMessage, isError: true };
+    }
     const msg = err instanceof Error ? err.message : String(err);
     log.error({ err }, "Extract failed");
     return { content: `Error: Extract failed: ${msg}`, isError: true };
@@ -1406,7 +1817,9 @@ export async function executeBrowserFillCredential(
       ? `element_id "${resolved!.eid}"`
       : resolved!.selector;
 
-  const cdp = getCdpClient(context);
+  const acquired = acquireCdpClientWithMode(input, context);
+  if (acquired.errorResult) return acquired.errorResult;
+  const cdp = acquired.cdp;
   try {
     let backendNodeId: number;
     if (resolved!.kind === "backend") {
@@ -1495,6 +1908,13 @@ export async function executeBrowserFillCredential(
       isError: false,
     };
   } catch (err) {
+    const diagnosticMessage = formatCdpSendDiagnostics(
+      err,
+      acquired.browserMode,
+    );
+    if (diagnosticMessage) {
+      return { content: diagnosticMessage, isError: true };
+    }
     const msg = err instanceof Error ? err.message : String(err);
     log.error({ err }, "Fill credential failed");
     return { content: `Error: Fill credential failed: ${msg}`, isError: true };

--- a/assistant/src/tools/browser/browser-execution.ts
+++ b/assistant/src/tools/browser/browser-execution.ts
@@ -340,6 +340,7 @@ function formatCdpSendDiagnostics(
   if (
     err instanceof CdpError &&
     browserMode !== "auto" &&
+    err.code === "transport_error" &&
     err.attemptDiagnostics
   ) {
     return formatModeSelectionFailure(browserMode, err);

--- a/assistant/src/tools/browser/browser-mode.ts
+++ b/assistant/src/tools/browser/browser-mode.ts
@@ -12,8 +12,10 @@
  *   - `playwright`   -> `local`
  */
 
-/** Canonical browser mode values. */
-export type BrowserMode = "auto" | "extension" | "cdp-inspect" | "local";
+import type { BrowserMode } from "./cdp-client/types.js";
+
+/** Canonical browser mode values. Re-exported from cdp-client/types. */
+export type { BrowserMode } from "./cdp-client/types.js";
 
 /** All accepted values (canonical + aliases). */
 const ALIAS_MAP: Record<string, BrowserMode> = {

--- a/assistant/src/tools/browser/browser-mode.ts
+++ b/assistant/src/tools/browser/browser-mode.ts
@@ -1,0 +1,89 @@
+/**
+ * Normalization helper for the `browser_mode` tool input parameter.
+ *
+ * Canonical values map directly to {@link CdpClientKind}:
+ *   - `auto`        -- let the factory pick the best backend (default)
+ *   - `extension`   -- force the Chrome extension transport
+ *   - `cdp-inspect` -- force the CDP inspect/debugger transport
+ *   - `local`       -- force the Playwright-managed local browser
+ *
+ * Aliases are accepted and normalized to their canonical form:
+ *   - `cdp-debugger` -> `cdp-inspect`
+ *   - `playwright`   -> `local`
+ */
+
+/** Canonical browser mode values. */
+export type BrowserMode = "auto" | "extension" | "cdp-inspect" | "local";
+
+/** All accepted values (canonical + aliases). */
+const ALIAS_MAP: Record<string, BrowserMode> = {
+  auto: "auto",
+  extension: "extension",
+  "cdp-inspect": "cdp-inspect",
+  "cdp-debugger": "cdp-inspect",
+  local: "local",
+  playwright: "local",
+};
+
+/** Ordered list of accepted values for error messages. */
+const ACCEPTED_VALUES = Object.keys(ALIAS_MAP);
+
+/**
+ * Human-readable alias mapping for error messages.
+ * Only includes entries where the alias differs from the canonical value.
+ */
+const ALIAS_DISPLAY: Record<string, string> = {
+  "cdp-debugger": "cdp-inspect",
+  playwright: "local",
+};
+
+export interface NormalizeBrowserModeResult {
+  /** The normalized canonical mode. */
+  mode: BrowserMode;
+}
+
+export interface NormalizeBrowserModeError {
+  /** Deterministic error message describing the invalid value. */
+  error: string;
+}
+
+/**
+ * Normalize a raw `browser_mode` input value to a canonical {@link BrowserMode}.
+ *
+ * - `undefined` / `null` / empty string -> `{ mode: "auto" }`
+ * - Valid canonical value or alias       -> `{ mode: <canonical> }`
+ * - Invalid value                        -> `{ error: "..." }` with accepted list and alias mapping
+ */
+export function normalizeBrowserMode(
+  raw: unknown,
+): NormalizeBrowserModeResult | NormalizeBrowserModeError {
+  if (raw === undefined || raw === null || raw === "") {
+    return { mode: "auto" };
+  }
+
+  if (typeof raw !== "string") {
+    return buildError(String(raw));
+  }
+
+  const lower = raw.toLowerCase().trim();
+  const canonical = ALIAS_MAP[lower];
+
+  if (canonical !== undefined) {
+    return { mode: canonical };
+  }
+
+  return buildError(raw);
+}
+
+function buildError(value: string): NormalizeBrowserModeError {
+  const aliasHints = Object.entries(ALIAS_DISPLAY)
+    .map(([alias, canonical]) => `${alias}->${canonical}`)
+    .join(", ");
+
+  return {
+    error:
+      `Invalid browser_mode "${value}". ` +
+      `Accepted values: ${ACCEPTED_VALUES.join(", ")}. ` +
+      `Aliases: ${aliasHints}.`,
+  };
+}

--- a/assistant/src/tools/browser/cdp-client/__tests__/factory.test.ts
+++ b/assistant/src/tools/browser/cdp-client/__tests__/factory.test.ts
@@ -72,6 +72,12 @@ const createCdpInspectClientMock = mock(
 let cdpInspectEnabled = false;
 let desktopAutoConfig = { enabled: true, cooldownMs: 30_000 };
 
+/**
+ * Captured log calls for verifying fallback log payloads.
+ */
+const logWarnCalls: Array<{ args: unknown[] }> = [];
+const logDebugCalls: Array<{ args: unknown[] }> = [];
+
 mock.module("../extension-cdp-client.js", () => ({
   createExtensionCdpClient: createExtensionCdpClientMock,
 }));
@@ -94,6 +100,18 @@ mock.module("../../../../config/loader.js", () => ({
     },
   }),
 }));
+mock.module("../../../../util/logger.js", () => ({
+  getLogger: () => ({
+    debug: (...args: unknown[]) => {
+      logDebugCalls.push({ args });
+    },
+    warn: (...args: unknown[]) => {
+      logWarnCalls.push({ args });
+    },
+    info: () => {},
+    error: () => {},
+  }),
+}));
 
 // Import under test AFTER mock.module calls so that the factory's
 // top-level imports resolve to our fakes.
@@ -101,6 +119,7 @@ const {
   getCdpClient,
   buildCandidateList,
   buildChainedClient,
+  buildPinnedCandidateList,
   _resetDesktopAutoCooldown,
   _getDesktopAutoCooldownSince,
   recordDesktopAutoCooldown,
@@ -150,6 +169,8 @@ describe("getCdpClient", () => {
     cdpInspectEnabled = false;
     desktopAutoConfig = { enabled: true, cooldownMs: 30_000 };
     _resetDesktopAutoCooldown();
+    logWarnCalls.length = 0;
+    logDebugCalls.length = 0;
   });
 
   // ── Candidate selection (kind reported before first send) ────────────
@@ -306,6 +327,34 @@ describe("getCdpClient", () => {
     expect(createLocalCdpClientMock).toHaveBeenCalledWith("another-convo");
     expect(createExtensionCdpClientMock).not.toHaveBeenCalled();
     expect(createCdpInspectClientMock).not.toHaveBeenCalled();
+  });
+
+  // ── Backwards compatibility: omitted mode behaves as auto ───────────
+
+  test("getCdpClient without options behaves identically to auto mode", async () => {
+    const fakeProxy = makeAvailableProxy();
+    const ctx = makeContext({
+      conversationId: "no-opts",
+      hostBrowserProxy: fakeProxy,
+    });
+
+    const client = getCdpClient(ctx);
+    expect(client.kind).toBe("extension");
+    const result = await client.send<{ ok: boolean; via: string }>(
+      "Page.navigate",
+    );
+    expect(result).toEqual({ ok: true, via: "extension" });
+  });
+
+  test("getCdpClient with explicit auto mode behaves identically to omitted mode", async () => {
+    const ctx = makeContext({ conversationId: "explicit-auto" });
+
+    const client = getCdpClient(ctx, { mode: "auto" });
+    expect(client.kind).toBe("local");
+    const result = await client.send<{ ok: boolean; via: string }>(
+      "Runtime.evaluate",
+    );
+    expect(result).toEqual({ ok: true, via: "local" });
   });
 
   // ── send() forwarding ────────────────────────────────────────────────
@@ -659,6 +708,8 @@ describe("buildChainedClient failover", () => {
     cdpInspectEnabled = false;
     desktopAutoConfig = { enabled: true, cooldownMs: 30_000 };
     _resetDesktopAutoCooldown();
+    logWarnCalls.length = 0;
+    logDebugCalls.length = 0;
   });
 
   test("fails over from extension to local on transport_error", async () => {
@@ -970,6 +1021,8 @@ describe("desktop-auto cdp-inspect (macOS)", () => {
     cdpInspectEnabled = false;
     desktopAutoConfig = { enabled: true, cooldownMs: 30_000 };
     _resetDesktopAutoCooldown();
+    logWarnCalls.length = 0;
+    logDebugCalls.length = 0;
   });
 
   // ── buildCandidateList with desktopAuto ─────────────────────────────
@@ -1263,5 +1316,678 @@ describe("desktop-auto cdp-inspect (macOS)", () => {
     _resetDesktopAutoCooldown();
     expect(isDesktopAutoCooldownActive(30_000)).toBe(false);
     expect(_getDesktopAutoCooldownSince()).toBe(0);
+  });
+});
+
+// ── Pinned-mode tests ────────────────────────────────────────────────────
+
+describe("pinned-mode selection", () => {
+  beforeEach(() => {
+    createExtensionCdpClientMock.mockClear();
+    createLocalCdpClientMock.mockClear();
+    createCdpInspectClientMock.mockClear();
+    lastExtensionClient = undefined;
+    lastLocalClient = undefined;
+    lastCdpInspectClient = undefined;
+    cdpInspectEnabled = false;
+    desktopAutoConfig = { enabled: true, cooldownMs: 30_000 };
+    _resetDesktopAutoCooldown();
+    logWarnCalls.length = 0;
+    logDebugCalls.length = 0;
+  });
+
+  // ── Pinned extension ────────────────────────────────────────────────
+
+  test("pinned extension mode routes to extension when proxy is available", async () => {
+    const fakeProxy = makeAvailableProxy();
+    const ctx = makeContext({
+      conversationId: "pinned-ext",
+      hostBrowserProxy: fakeProxy,
+    });
+
+    const client = getCdpClient(ctx, { mode: "extension" });
+    expect(client.kind).toBe("extension");
+
+    const result = await client.send<{ ok: boolean; via: string }>(
+      "Page.navigate",
+    );
+    expect(result).toEqual({ ok: true, via: "extension" });
+    expect(createExtensionCdpClientMock).toHaveBeenCalledTimes(1);
+    expect(createLocalCdpClientMock).not.toHaveBeenCalled();
+    expect(createCdpInspectClientMock).not.toHaveBeenCalled();
+  });
+
+  test("pinned extension mode throws when no proxy is provisioned", () => {
+    const ctx = makeContext({ conversationId: "pinned-ext-no-proxy" });
+
+    expect(() => getCdpClient(ctx, { mode: "extension" })).toThrow(CdpError);
+
+    try {
+      getCdpClient(ctx, { mode: "extension" });
+    } catch (err) {
+      expect(err).toBeInstanceOf(CdpError);
+      const cdpErr = err as CdpError;
+      expect(cdpErr.code).toBe("transport_error");
+      expect(cdpErr.message).toContain('Pinned mode "extension" unavailable');
+      expect(cdpErr.message).toContain("no host browser proxy provisioned");
+      expect(cdpErr.attemptDiagnostics).toBeDefined();
+      expect(cdpErr.attemptDiagnostics).toHaveLength(1);
+      expect(cdpErr.attemptDiagnostics![0].candidateKind).toBe("extension");
+      expect(cdpErr.attemptDiagnostics![0].stage).toBe("candidate_selection");
+    }
+  });
+
+  test("pinned extension mode throws when proxy is present but unavailable", () => {
+    const fakeProxy = makeUnavailableProxy();
+    const ctx = makeContext({
+      conversationId: "pinned-ext-unavail",
+      hostBrowserProxy: fakeProxy,
+    });
+
+    expect(() => getCdpClient(ctx, { mode: "extension" })).toThrow(CdpError);
+
+    try {
+      getCdpClient(ctx, { mode: "extension" });
+    } catch (err) {
+      const cdpErr = err as CdpError;
+      expect(cdpErr.code).toBe("transport_error");
+      expect(cdpErr.message).toContain("not connected");
+      expect(cdpErr.attemptDiagnostics![0].stage).toBe("candidate_selection");
+    }
+  });
+
+  test("pinned extension mode does NOT fall back to local on transport error", async () => {
+    const fakeProxy = makeAvailableProxy();
+
+    // Make extension fail with transport_error
+    createExtensionCdpClientMock.mockImplementationOnce(
+      (_proxy: HostBrowserProxy, conversationId: string) => {
+        const c = makeFakeExtensionClient(conversationId);
+        c.send = mock(async () => {
+          throw new CdpError("transport_error", "WS disconnected");
+        });
+        lastExtensionClient = c;
+        return c;
+      },
+    );
+
+    const ctx = makeContext({
+      conversationId: "pinned-ext-no-fallback",
+      hostBrowserProxy: fakeProxy,
+    });
+
+    const client = getCdpClient(ctx, { mode: "extension" });
+
+    await expect(client.send("Page.navigate")).rejects.toMatchObject({
+      code: "transport_error",
+      message: "WS disconnected",
+    });
+
+    // Local and cdp-inspect should NOT have been tried
+    expect(createLocalCdpClientMock).not.toHaveBeenCalled();
+    expect(createCdpInspectClientMock).not.toHaveBeenCalled();
+  });
+
+  // ── Pinned cdp-inspect ──────────────────────────────────────────────
+
+  test("pinned cdp-inspect mode routes to cdp-inspect", async () => {
+    const ctx = makeContext({ conversationId: "pinned-inspect" });
+
+    const client = getCdpClient(ctx, { mode: "cdp-inspect" });
+    expect(client.kind).toBe("cdp-inspect");
+
+    const result = await client.send<{ ok: boolean; via: string }>(
+      "Page.navigate",
+    );
+    expect(result).toEqual({ ok: true, via: "cdp-inspect" });
+    expect(createCdpInspectClientMock).toHaveBeenCalledTimes(1);
+    expect(createExtensionCdpClientMock).not.toHaveBeenCalled();
+    expect(createLocalCdpClientMock).not.toHaveBeenCalled();
+  });
+
+  test("pinned cdp-inspect mode does NOT fall back to local on transport error", async () => {
+    createCdpInspectClientMock.mockImplementationOnce(
+      (conversationId: string) => {
+        const c = makeFakeCdpInspectClient(conversationId);
+        c.send = mock(async () => {
+          throw new CdpError("transport_error", "Connection refused");
+        });
+        lastCdpInspectClient = c;
+        return c;
+      },
+    );
+
+    const ctx = makeContext({ conversationId: "pinned-inspect-no-fb" });
+    const client = getCdpClient(ctx, { mode: "cdp-inspect" });
+
+    await expect(client.send("Page.navigate")).rejects.toMatchObject({
+      code: "transport_error",
+      message: "Connection refused",
+    });
+
+    expect(createLocalCdpClientMock).not.toHaveBeenCalled();
+    expect(createExtensionCdpClientMock).not.toHaveBeenCalled();
+  });
+
+  test("pinned cdp-inspect uses config host/port", async () => {
+    const ctx = makeContext({ conversationId: "pinned-inspect-cfg" });
+
+    const client = getCdpClient(ctx, { mode: "cdp-inspect" });
+    await client.send("Page.navigate");
+
+    expect(createCdpInspectClientMock).toHaveBeenCalledWith(
+      "pinned-inspect-cfg",
+      {
+        host: "localhost",
+        port: 9222,
+        discoveryTimeoutMs: 500,
+      },
+    );
+  });
+
+  // ── Pinned local ────────────────────────────────────────────────────
+
+  test("pinned local mode routes to local", async () => {
+    const fakeProxy = makeAvailableProxy();
+    const ctx = makeContext({
+      conversationId: "pinned-local",
+      hostBrowserProxy: fakeProxy,
+    });
+
+    // Even with proxy available, pinned local should skip extension
+    const client = getCdpClient(ctx, { mode: "local" });
+    expect(client.kind).toBe("local");
+
+    const result = await client.send<{ ok: boolean; via: string }>(
+      "Runtime.evaluate",
+    );
+    expect(result).toEqual({ ok: true, via: "local" });
+    expect(createLocalCdpClientMock).toHaveBeenCalledTimes(1);
+    expect(createExtensionCdpClientMock).not.toHaveBeenCalled();
+    expect(createCdpInspectClientMock).not.toHaveBeenCalled();
+  });
+
+  test("pinned local mode does NOT fall back on transport error", async () => {
+    createLocalCdpClientMock.mockImplementationOnce(
+      (conversationId: string) => {
+        const c = makeFakeLocalClient(conversationId);
+        c.send = mock(async () => {
+          throw new CdpError("transport_error", "Playwright crashed");
+        });
+        lastLocalClient = c;
+        return c;
+      },
+    );
+
+    const ctx = makeContext({ conversationId: "pinned-local-no-fb" });
+    const client = getCdpClient(ctx, { mode: "local" });
+
+    await expect(client.send("Page.navigate")).rejects.toMatchObject({
+      code: "transport_error",
+      message: "Playwright crashed",
+    });
+
+    expect(createExtensionCdpClientMock).not.toHaveBeenCalled();
+    expect(createCdpInspectClientMock).not.toHaveBeenCalled();
+  });
+});
+
+// ── buildPinnedCandidateList tests ───────────────────────────────────────
+
+describe("buildPinnedCandidateList", () => {
+  beforeEach(() => {
+    createExtensionCdpClientMock.mockClear();
+    createLocalCdpClientMock.mockClear();
+    createCdpInspectClientMock.mockClear();
+    lastExtensionClient = undefined;
+    lastLocalClient = undefined;
+    lastCdpInspectClient = undefined;
+    cdpInspectEnabled = false;
+    desktopAutoConfig = { enabled: true, cooldownMs: 30_000 };
+    _resetDesktopAutoCooldown();
+  });
+
+  test("extension mode produces single extension candidate", () => {
+    const fakeProxy = makeAvailableProxy();
+    const ctx = makeContext({
+      conversationId: "bpl-ext",
+      hostBrowserProxy: fakeProxy,
+    });
+
+    const candidates = buildPinnedCandidateList(ctx, "extension");
+
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].kind).toBe("extension");
+    expect(candidates[0].reason).toBe("pinned mode: extension");
+  });
+
+  test("cdp-inspect mode produces single cdp-inspect candidate", () => {
+    const ctx = makeContext({ conversationId: "bpl-inspect" });
+
+    const candidates = buildPinnedCandidateList(ctx, "cdp-inspect");
+
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].kind).toBe("cdp-inspect");
+    expect(candidates[0].reason).toBe("pinned mode: cdp-inspect");
+  });
+
+  test("local mode produces single local candidate", () => {
+    const ctx = makeContext({ conversationId: "bpl-local" });
+
+    const candidates = buildPinnedCandidateList(ctx, "local");
+
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].kind).toBe("local");
+    expect(candidates[0].reason).toBe("pinned mode: local");
+  });
+
+  test("extension mode throws with diagnostics when proxy absent", () => {
+    const ctx = makeContext({ conversationId: "bpl-ext-absent" });
+
+    try {
+      buildPinnedCandidateList(ctx, "extension");
+      expect(true).toBe(false); // should not reach
+    } catch (err) {
+      expect(err).toBeInstanceOf(CdpError);
+      const cdpErr = err as CdpError;
+      expect(cdpErr.code).toBe("transport_error");
+      expect(cdpErr.attemptDiagnostics).toHaveLength(1);
+      expect(cdpErr.attemptDiagnostics![0]).toMatchObject({
+        candidateKind: "extension",
+        inclusionReason: "pinned mode: extension",
+        stage: "candidate_selection",
+        errorCode: "transport_error",
+      });
+    }
+  });
+});
+
+// ── Attempt diagnostics & fallback log tests ─────────────────────────────
+
+describe("attempt diagnostics", () => {
+  beforeEach(() => {
+    createExtensionCdpClientMock.mockClear();
+    createLocalCdpClientMock.mockClear();
+    createCdpInspectClientMock.mockClear();
+    lastExtensionClient = undefined;
+    lastLocalClient = undefined;
+    lastCdpInspectClient = undefined;
+    cdpInspectEnabled = false;
+    desktopAutoConfig = { enabled: true, cooldownMs: 30_000 };
+    _resetDesktopAutoCooldown();
+    logWarnCalls.length = 0;
+    logDebugCalls.length = 0;
+  });
+
+  test("exhausted candidates error includes full attempt diagnostics", async () => {
+    cdpInspectEnabled = true;
+    const fakeProxy = makeAvailableProxy();
+
+    // Make extension fail
+    createExtensionCdpClientMock.mockImplementationOnce(
+      (_proxy: HostBrowserProxy, conversationId: string) => {
+        const c = makeFakeExtensionClient(conversationId);
+        c.send = mock(async () => {
+          throw new CdpError("transport_error", "ext disconnected");
+        });
+        lastExtensionClient = c;
+        return c;
+      },
+    );
+
+    // Make cdp-inspect fail
+    createCdpInspectClientMock.mockImplementationOnce(
+      (conversationId: string) => {
+        const c = makeFakeCdpInspectClient(conversationId);
+        c.send = mock(async () => {
+          throw new CdpError("transport_error", "inspect refused");
+        });
+        lastCdpInspectClient = c;
+        return c;
+      },
+    );
+
+    // Make local fail too
+    createLocalCdpClientMock.mockImplementationOnce(
+      (conversationId: string) => {
+        const c = makeFakeLocalClient(conversationId);
+        c.send = mock(async () => {
+          throw new CdpError("transport_error", "playwright dead");
+        });
+        lastLocalClient = c;
+        return c;
+      },
+    );
+
+    const ctx = makeContext({
+      conversationId: "diag-all-fail",
+      hostBrowserProxy: fakeProxy,
+    });
+
+    const client = getCdpClient(ctx);
+
+    try {
+      await client.send("Page.navigate");
+      expect(true).toBe(false); // should not reach
+    } catch (err) {
+      expect(err).toBeInstanceOf(CdpError);
+      const cdpErr = err as CdpError;
+      expect(cdpErr.code).toBe("transport_error");
+      expect(cdpErr.attemptDiagnostics).toBeDefined();
+      expect(cdpErr.attemptDiagnostics).toHaveLength(3);
+
+      // First attempt: extension
+      expect(cdpErr.attemptDiagnostics![0]).toMatchObject({
+        candidateKind: "extension",
+        stage: "send",
+        errorCode: "transport_error",
+        errorMessage: expect.stringContaining("ext disconnected"),
+      });
+
+      // Second attempt: cdp-inspect
+      expect(cdpErr.attemptDiagnostics![1]).toMatchObject({
+        candidateKind: "cdp-inspect",
+        stage: "send",
+        errorCode: "transport_error",
+        errorMessage: expect.stringContaining("inspect refused"),
+      });
+
+      // Third attempt: local
+      expect(cdpErr.attemptDiagnostics![2]).toMatchObject({
+        candidateKind: "local",
+        stage: "send",
+        errorCode: "transport_error",
+        errorMessage: expect.stringContaining("playwright dead"),
+      });
+    }
+  });
+
+  test("successful fallback still records diagnostics for failed candidates", async () => {
+    const fakeProxy = makeAvailableProxy();
+
+    // Make extension fail
+    createExtensionCdpClientMock.mockImplementationOnce(
+      (_proxy: HostBrowserProxy, conversationId: string) => {
+        const c = makeFakeExtensionClient(conversationId);
+        c.send = mock(async () => {
+          throw new CdpError("transport_error", "ext down");
+        });
+        lastExtensionClient = c;
+        return c;
+      },
+    );
+
+    const ctx = makeContext({
+      conversationId: "diag-partial",
+      hostBrowserProxy: fakeProxy,
+    });
+
+    const client = getCdpClient(ctx);
+    const result = await client.send<{ ok: boolean; via: string }>(
+      "Page.navigate",
+    );
+    expect(result).toEqual({ ok: true, via: "local" });
+
+    // The fallback log should have been emitted with attempt data
+    const fallbackLogs = logWarnCalls.filter(
+      (c) =>
+        typeof c.args[1] === "string" &&
+        c.args[1].includes("auto-mode fallback"),
+    );
+    expect(fallbackLogs.length).toBeGreaterThan(0);
+  });
+
+  test("auto-mode fallback log includes candidate sequence and failure reasons", async () => {
+    cdpInspectEnabled = true;
+    const fakeProxy = makeAvailableProxy();
+
+    // Make extension fail
+    createExtensionCdpClientMock.mockImplementationOnce(
+      (_proxy: HostBrowserProxy, conversationId: string) => {
+        const c = makeFakeExtensionClient(conversationId);
+        c.send = mock(async () => {
+          throw new CdpError("transport_error", "WS closed");
+        });
+        lastExtensionClient = c;
+        return c;
+      },
+    );
+
+    // Make cdp-inspect fail
+    createCdpInspectClientMock.mockImplementationOnce(
+      (conversationId: string) => {
+        const c = makeFakeCdpInspectClient(conversationId);
+        c.send = mock(async () => {
+          throw new CdpError("transport_error", "no debugger");
+        });
+        lastCdpInspectClient = c;
+        return c;
+      },
+    );
+
+    const ctx = makeContext({
+      conversationId: "diag-log-shape",
+      hostBrowserProxy: fakeProxy,
+    });
+
+    const client = getCdpClient(ctx);
+    await client.send<{ ok: boolean; via: string }>("Page.navigate");
+
+    // Check that a warn-level log was emitted for the completed fallback
+    const completedLogs = logWarnCalls.filter(
+      (c) =>
+        typeof c.args[1] === "string" &&
+        c.args[1].includes("fallback completed"),
+    );
+    expect(completedLogs.length).toBe(1);
+
+    // Verify the log payload contains the expected structure
+    const payload = completedLogs[0].args[0] as Record<string, unknown>;
+    expect(payload.conversationId).toBe("diag-log-shape");
+    expect(payload.stickyCandidate).toBe("local");
+    expect(Array.isArray(payload.attemptSequence)).toBe(true);
+    const seq = payload.attemptSequence as Array<Record<string, unknown>>;
+    expect(seq.length).toBe(3); // extension, cdp-inspect, local
+    expect(seq[0].kind).toBe("extension");
+    expect(seq[0].errorCode).toBe("transport_error");
+    expect(seq[1].kind).toBe("cdp-inspect");
+    expect(seq[1].errorCode).toBe("transport_error");
+    expect(seq[2].kind).toBe("local");
+    expect(seq[2].stage).toBe("success");
+  });
+
+  test("pinned mode transport error includes attempt diagnostics on the thrown error", async () => {
+    createCdpInspectClientMock.mockImplementationOnce(
+      (conversationId: string) => {
+        const c = makeFakeCdpInspectClient(conversationId);
+        c.send = mock(async () => {
+          throw new CdpError("transport_error", "Connection refused");
+        });
+        lastCdpInspectClient = c;
+        return c;
+      },
+    );
+
+    const ctx = makeContext({ conversationId: "pinned-diag" });
+    const client = getCdpClient(ctx, { mode: "cdp-inspect" });
+
+    try {
+      await client.send("Page.navigate");
+      expect(true).toBe(false); // should not reach
+    } catch (err) {
+      expect(err).toBeInstanceOf(CdpError);
+      const cdpErr = err as CdpError;
+      expect(cdpErr.attemptDiagnostics).toBeDefined();
+      expect(cdpErr.attemptDiagnostics).toHaveLength(1);
+      expect(cdpErr.attemptDiagnostics![0]).toMatchObject({
+        candidateKind: "cdp-inspect",
+        inclusionReason: "pinned mode: cdp-inspect",
+        stage: "send",
+        errorCode: "transport_error",
+      });
+    }
+  });
+
+  test("construction failure is recorded in attempt diagnostics", async () => {
+    // Make the cdp-inspect client's create() throw
+    createCdpInspectClientMock.mockImplementationOnce(() => {
+      throw new Error("Config missing");
+    });
+
+    cdpInspectEnabled = true;
+    const ctx = makeContext({ conversationId: "diag-construction" });
+    const client = getCdpClient(ctx);
+
+    // cdp-inspect construction fails, falls back to local
+    const result = await client.send<{ ok: boolean; via: string }>(
+      "Page.navigate",
+    );
+    expect(result).toEqual({ ok: true, via: "local" });
+  });
+
+  test("cdp_error on single-candidate list includes diagnostics", async () => {
+    createLocalCdpClientMock.mockImplementationOnce(
+      (conversationId: string) => {
+        const c = makeFakeLocalClient(conversationId);
+        c.send = mock(async () => {
+          throw new CdpError("cdp_error", "Protocol error -32000");
+        });
+        lastLocalClient = c;
+        return c;
+      },
+    );
+
+    const ctx = makeContext({ conversationId: "diag-cdp-err" });
+    const client = getCdpClient(ctx);
+
+    try {
+      await client.send("Page.navigate");
+      expect(true).toBe(false);
+    } catch (err) {
+      const cdpErr = err as CdpError;
+      expect(cdpErr.code).toBe("cdp_error");
+      expect(cdpErr.attemptDiagnostics).toBeDefined();
+      expect(cdpErr.attemptDiagnostics).toHaveLength(1);
+      expect(cdpErr.attemptDiagnostics![0]).toMatchObject({
+        candidateKind: "local",
+        stage: "send",
+        errorCode: "cdp_error",
+      });
+    }
+  });
+});
+
+// ── No-fallback guarantees for pinned modes ──────────────────────────────
+
+describe("no-fallback guarantees", () => {
+  beforeEach(() => {
+    createExtensionCdpClientMock.mockClear();
+    createLocalCdpClientMock.mockClear();
+    createCdpInspectClientMock.mockClear();
+    lastExtensionClient = undefined;
+    lastLocalClient = undefined;
+    lastCdpInspectClient = undefined;
+    cdpInspectEnabled = false;
+    desktopAutoConfig = { enabled: true, cooldownMs: 30_000 };
+    _resetDesktopAutoCooldown();
+    logWarnCalls.length = 0;
+  });
+
+  test("pinned extension: only one candidate is ever constructed", async () => {
+    const fakeProxy = makeAvailableProxy();
+
+    // Make extension fail
+    createExtensionCdpClientMock.mockImplementationOnce(
+      (_proxy: HostBrowserProxy, conversationId: string) => {
+        const c = makeFakeExtensionClient(conversationId);
+        c.send = mock(async () => {
+          throw new CdpError("transport_error", "failed");
+        });
+        lastExtensionClient = c;
+        return c;
+      },
+    );
+
+    const ctx = makeContext({
+      conversationId: "nofb-ext",
+      hostBrowserProxy: fakeProxy,
+    });
+    const client = getCdpClient(ctx, { mode: "extension" });
+
+    await expect(client.send("Page.navigate")).rejects.toThrow();
+
+    expect(createExtensionCdpClientMock).toHaveBeenCalledTimes(1);
+    expect(createCdpInspectClientMock).not.toHaveBeenCalled();
+    expect(createLocalCdpClientMock).not.toHaveBeenCalled();
+  });
+
+  test("pinned cdp-inspect: only one candidate is ever constructed", async () => {
+    createCdpInspectClientMock.mockImplementationOnce(
+      (conversationId: string) => {
+        const c = makeFakeCdpInspectClient(conversationId);
+        c.send = mock(async () => {
+          throw new CdpError("transport_error", "failed");
+        });
+        lastCdpInspectClient = c;
+        return c;
+      },
+    );
+
+    const ctx = makeContext({ conversationId: "nofb-inspect" });
+    const client = getCdpClient(ctx, { mode: "cdp-inspect" });
+
+    await expect(client.send("Page.navigate")).rejects.toThrow();
+
+    expect(createCdpInspectClientMock).toHaveBeenCalledTimes(1);
+    expect(createExtensionCdpClientMock).not.toHaveBeenCalled();
+    expect(createLocalCdpClientMock).not.toHaveBeenCalled();
+  });
+
+  test("pinned local: only one candidate is ever constructed", async () => {
+    createLocalCdpClientMock.mockImplementationOnce(
+      (conversationId: string) => {
+        const c = makeFakeLocalClient(conversationId);
+        c.send = mock(async () => {
+          throw new CdpError("transport_error", "failed");
+        });
+        lastLocalClient = c;
+        return c;
+      },
+    );
+
+    const ctx = makeContext({ conversationId: "nofb-local" });
+    const client = getCdpClient(ctx, { mode: "local" });
+
+    await expect(client.send("Page.navigate")).rejects.toThrow();
+
+    expect(createLocalCdpClientMock).toHaveBeenCalledTimes(1);
+    expect(createExtensionCdpClientMock).not.toHaveBeenCalled();
+    expect(createCdpInspectClientMock).not.toHaveBeenCalled();
+  });
+
+  test("pinned modes do not emit auto-mode fallback logs", async () => {
+    createLocalCdpClientMock.mockImplementationOnce(
+      (conversationId: string) => {
+        const c = makeFakeLocalClient(conversationId);
+        c.send = mock(async () => {
+          throw new CdpError("transport_error", "failed");
+        });
+        lastLocalClient = c;
+        return c;
+      },
+    );
+
+    const ctx = makeContext({ conversationId: "nofb-no-log" });
+    const client = getCdpClient(ctx, { mode: "local" });
+
+    await expect(client.send("Page.navigate")).rejects.toThrow();
+
+    // No warn-level fallback logs should have been emitted
+    const fallbackLogs = logWarnCalls.filter(
+      (c) =>
+        typeof c.args[1] === "string" &&
+        c.args[1].includes("auto-mode fallback"),
+    );
+    expect(fallbackLogs.length).toBe(0);
   });
 });

--- a/assistant/src/tools/browser/cdp-client/errors.ts
+++ b/assistant/src/tools/browser/cdp-client/errors.ts
@@ -1,3 +1,5 @@
+import type { AttemptDiagnostic } from "./types.js";
+
 export type CdpErrorCode =
   | "cdp_error" // JSON-RPC error returned by CDP
   | "transport_error" // underlying transport failed (socket closed, timeout)
@@ -15,6 +17,17 @@ export class CdpError extends Error {
   readonly cdpParams?: Record<string, unknown>;
   readonly underlying?: unknown;
 
+  /**
+   * Structured attempt diagnostics from the factory's failover walk.
+   * Present when the error is thrown by the factory after walking one
+   * or more candidates. Each entry describes a single candidate
+   * attempt with the kind, stage, and failure reason.
+   *
+   * Higher layers (e.g. tool-response formatting) can use this to
+   * render detailed failure information with remediation hints.
+   */
+  readonly attemptDiagnostics?: readonly AttemptDiagnostic[];
+
   constructor(
     code: CdpErrorCode,
     message: string,
@@ -22,6 +35,7 @@ export class CdpError extends Error {
       cdpMethod?: string;
       cdpParams?: Record<string, unknown>;
       underlying?: unknown;
+      attemptDiagnostics?: readonly AttemptDiagnostic[];
     },
   ) {
     super(message);
@@ -30,5 +44,6 @@ export class CdpError extends Error {
     this.cdpMethod = details?.cdpMethod;
     this.cdpParams = details?.cdpParams;
     this.underlying = details?.underlying;
+    this.attemptDiagnostics = details?.attemptDiagnostics;
   }
 }

--- a/assistant/src/tools/browser/cdp-client/factory.ts
+++ b/assistant/src/tools/browser/cdp-client/factory.ts
@@ -600,6 +600,24 @@ async function sendWithFailover<T>(
         errorMessage,
       });
       maybeRecordDesktopAutoCooldown(candidate);
+
+      // Emit production-visible fallback log in auto mode
+      if (mode === "auto" && i < candidates.length - 1) {
+        log.warn(
+          {
+            conversationId,
+            failedCandidate: candidate.kind,
+            nextCandidate: candidates[i + 1].kind,
+            attemptedSoFar: diagnostics.map((d) => ({
+              kind: d.candidateKind,
+              stage: d.stage,
+              errorCode: d.errorCode,
+              errorMessage: d.errorMessage,
+            })),
+          },
+          "CDP factory: auto-mode fallback triggered",
+        );
+      }
       continue;
     }
 
@@ -634,6 +652,24 @@ async function sendWithFailover<T>(
         discoveryCode: extractDiscoveryCode(err),
       });
       maybeRecordDesktopAutoCooldown(candidate);
+
+      // Emit production-visible fallback log in auto mode
+      if (mode === "auto" && i < candidates.length - 1) {
+        log.warn(
+          {
+            conversationId,
+            failedCandidate: candidate.kind,
+            nextCandidate: candidates[i + 1].kind,
+            attemptedSoFar: diagnostics.map((d) => ({
+              kind: d.candidateKind,
+              stage: d.stage,
+              errorCode: d.errorCode,
+              errorMessage: d.errorMessage,
+            })),
+          },
+          "CDP factory: auto-mode fallback triggered",
+        );
+      }
       continue;
     }
 

--- a/assistant/src/tools/browser/cdp-client/factory.ts
+++ b/assistant/src/tools/browser/cdp-client/factory.ts
@@ -15,7 +15,9 @@ import { CdpError } from "./errors.js";
 import { createExtensionCdpClient } from "./extension-cdp-client.js";
 import { createLocalCdpClient } from "./local-cdp-client.js";
 import type {
+  AttemptDiagnostic,
   BackendCandidate,
+  BrowserMode,
   CdpClient,
   CdpClientKind,
   ScopedCdpClient,
@@ -83,6 +85,20 @@ export function _getDesktopAutoCooldownSince(): number {
 // ---------------------------------------------------------------------------
 
 /**
+ * Options for {@link getCdpClient}. All fields are optional — omitting
+ * them preserves the existing auto-mode behavior.
+ */
+export interface GetCdpClientOptions {
+  /**
+   * Backend mode preference. When omitted or `"auto"`, the factory
+   * uses the existing priority-ordered fallback chain. When set to a
+   * specific backend kind, the factory pins to that single backend
+   * and disables failover.
+   */
+  mode?: BrowserMode;
+}
+
+/**
  * Select the appropriate CdpClient implementation for a tool
  * invocation based on the ToolContext and config. Three backends are
  * considered in priority order:
@@ -100,6 +116,13 @@ export function _getDesktopAutoCooldownSince(): number {
  *     top-level `enabled` flag is false.
  *  3. **Local** -- Default. Drives Playwright's CDPSession against
  *     the sacrificial-profile browser managed by browserManager.
+ *
+ * When `options.mode` is set to a specific backend kind, the factory
+ * builds exactly one candidate and disables failover. If the pinned
+ * backend is unavailable (e.g. pinned `extension` without an
+ * available host browser proxy), the factory throws a typed
+ * `CdpError` with `transport_error` code and a diagnostic indicating
+ * the precondition that was not met.
  *
  * The factory builds an ordered candidate list and returns a
  * {@link ScopedCdpClient} with per-invocation failover semantics:
@@ -123,22 +146,139 @@ export function _getDesktopAutoCooldownSince(): number {
  * client does NOT dispose the underlying HostBrowserProxy -- that is
  * owned by the conversation.
  */
-export function getCdpClient(context: ToolContext): ScopedCdpClient {
-  const candidates = buildCandidateList(context);
+export function getCdpClient(
+  context: ToolContext,
+  options?: GetCdpClientOptions,
+): ScopedCdpClient {
+  const mode: BrowserMode = options?.mode ?? "auto";
+  const candidates =
+    mode === "auto"
+      ? buildCandidateList(context)
+      : buildPinnedCandidateList(context, mode);
 
   log.debug(
     {
       conversationId: context.conversationId,
+      mode,
       candidates: candidates.map((c) => ({ kind: c.kind, reason: c.reason })),
     },
     "CDP factory: built candidate list",
   );
 
-  return buildChainedClient(context.conversationId, candidates);
+  return buildChainedClient(context.conversationId, candidates, mode);
 }
 
 // ---------------------------------------------------------------------------
-// Candidate list construction
+// Pinned candidate list construction
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a single-element candidate list for a pinned backend mode.
+ * Throws a typed `CdpError` with structured diagnostics when the
+ * requested backend's preconditions are not met.
+ *
+ * Exported for testing.
+ */
+export function buildPinnedCandidateList(
+  context: ToolContext,
+  mode: Exclude<BrowserMode, "auto">,
+): BackendCandidate[] {
+  const { conversationId, hostBrowserProxy } = context;
+
+  switch (mode) {
+    case "extension": {
+      if (!hostBrowserProxy || !hostBrowserProxy.isAvailable()) {
+        const reason = !hostBrowserProxy
+          ? "no host browser proxy provisioned for this conversation"
+          : "host browser proxy exists but is not connected";
+        throw new CdpError(
+          "transport_error",
+          `Pinned mode "extension" unavailable: ${reason}`,
+          {
+            attemptDiagnostics: [
+              {
+                candidateKind: "extension",
+                inclusionReason: `pinned mode: extension`,
+                stage: "candidate_selection",
+                errorCode: "transport_error",
+                errorMessage: reason,
+              },
+            ],
+          },
+        );
+      }
+      return [
+        {
+          kind: "extension",
+          reason: "pinned mode: extension",
+          create() {
+            const client = createExtensionCdpClient(
+              hostBrowserProxy,
+              conversationId,
+            );
+            const backend = createExtensionBackend({
+              isAvailable: () => true,
+              sendCdp: (command, signal) =>
+                dispatchThroughClient(client, command, signal),
+              dispose: () => client.dispose(),
+            });
+            return { client, backend };
+          },
+        },
+      ];
+    }
+    case "cdp-inspect": {
+      const cdpInspectConfig = getConfig().hostBrowser.cdpInspect;
+      return [
+        {
+          kind: "cdp-inspect",
+          reason: "pinned mode: cdp-inspect",
+          create() {
+            const client = createCdpInspectClient(conversationId, {
+              host: cdpInspectConfig.host,
+              port: cdpInspectConfig.port,
+              discoveryTimeoutMs: cdpInspectConfig.probeTimeoutMs,
+            });
+            const backend = createCdpInspectBackend({
+              isAvailable: () => true,
+              sendCdp: (command, signal) =>
+                dispatchThroughClient(client, command, signal),
+              dispose: () => client.dispose(),
+            });
+            return { client, backend };
+          },
+        },
+      ];
+    }
+    case "local": {
+      return [
+        {
+          kind: "local",
+          reason: "pinned mode: local",
+          create() {
+            const client = createLocalCdpClient(conversationId);
+            const backend = createLocalBackend({
+              isAvailable: () => true,
+              sendCdp: (command, signal) =>
+                dispatchThroughClient(client, command, signal),
+              dispose: () => client.dispose(),
+            });
+            return { client, backend };
+          },
+        },
+      ];
+    }
+    default: {
+      // Exhaustive check — if new modes are added, TypeScript will
+      // flag this as an error.
+      const _exhaustive: never = mode;
+      throw new Error(`Unknown pinned mode: ${_exhaustive}`);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Candidate list construction (auto mode)
 // ---------------------------------------------------------------------------
 
 /**
@@ -290,6 +430,7 @@ export function buildCandidateList(context: ToolContext): BackendCandidate[] {
 export function buildChainedClient(
   conversationId: string,
   candidates: BackendCandidate[],
+  mode: BrowserMode = "auto",
 ): ScopedCdpClient {
   if (candidates.length === 0) {
     throw new Error("CDP factory: no backend candidates available");
@@ -364,6 +505,7 @@ export function buildChainedClient(
         },
         () => disposed,
         conversationId,
+        mode,
       );
     },
 
@@ -389,6 +531,12 @@ export function buildChainedClient(
  * When a desktop-auto cdp-inspect candidate fails with a transport
  * error, the factory records a cooldown so subsequent calls skip the
  * probe until the window expires.
+ *
+ * In auto mode, each attempted candidate is recorded as an
+ * {@link AttemptDiagnostic}. When fallback occurs, a production-visible
+ * log is emitted with the full candidate sequence and per-candidate
+ * failure reasons. If all candidates are exhausted, the diagnostics
+ * are attached to the thrown {@link CdpError}.
  */
 async function sendWithFailover<T>(
   candidates: BackendCandidate[],
@@ -403,8 +551,10 @@ async function sendWithFailover<T>(
   }) => void,
   isDisposed: () => boolean,
   conversationId: string,
+  mode: BrowserMode,
 ): Promise<T> {
   let lastError: CdpError | undefined;
+  const diagnostics: AttemptDiagnostic[] = [];
 
   for (let i = 0; i < candidates.length; i++) {
     const candidate = candidates[i];
@@ -432,15 +582,23 @@ async function sendWithFailover<T>(
     } catch (err) {
       // Backend construction failed -- treat as transport error and
       // try the next candidate.
+      const errorMessage = `Backend ${candidate.kind} construction failed: ${err instanceof Error ? err.message : String(err)}`;
       log.debug(
         { conversationId, candidateKind: candidate.kind, err },
         "CDP factory: candidate construction failed, trying next",
       );
-      lastError = new CdpError(
-        "transport_error",
-        `Backend ${candidate.kind} construction failed: ${err instanceof Error ? err.message : String(err)}`,
-        { cdpMethod: method, cdpParams: params, underlying: err },
-      );
+      lastError = new CdpError("transport_error", errorMessage, {
+        cdpMethod: method,
+        cdpParams: params,
+        underlying: err,
+      });
+      diagnostics.push({
+        candidateKind: candidate.kind,
+        inclusionReason: candidate.reason,
+        stage: "construction",
+        errorCode: "transport_error",
+        errorMessage,
+      });
       maybeRecordDesktopAutoCooldown(candidate);
       continue;
     }
@@ -456,16 +614,25 @@ async function sendWithFailover<T>(
     } catch (err) {
       // Manager-level errors (unknown session, no available backend)
       // are transport-level problems -- try the next candidate.
+      const errorMessage = `Backend ${candidate.kind} send threw: ${err instanceof Error ? err.message : String(err)}`;
       log.debug(
         { conversationId, candidateKind: candidate.kind, err },
         "CDP factory: candidate send threw, trying next",
       );
       manager.disposeAll();
-      lastError = new CdpError(
-        "transport_error",
-        `Backend ${candidate.kind} send threw: ${err instanceof Error ? err.message : String(err)}`,
-        { cdpMethod: method, cdpParams: params, underlying: err },
-      );
+      lastError = new CdpError("transport_error", errorMessage, {
+        cdpMethod: method,
+        cdpParams: params,
+        underlying: err,
+      });
+      diagnostics.push({
+        candidateKind: candidate.kind,
+        inclusionReason: candidate.reason,
+        stage: "send",
+        errorCode: "transport_error",
+        errorMessage,
+        discoveryCode: extractDiscoveryCode(err),
+      });
       maybeRecordDesktopAutoCooldown(candidate);
       continue;
     }
@@ -487,16 +654,79 @@ async function sendWithFailover<T>(
         );
         manager.disposeAll();
         lastError = cdpError;
+        diagnostics.push({
+          candidateKind: candidate.kind,
+          inclusionReason: candidate.reason,
+          stage: "send",
+          errorCode: cdpError.code,
+          errorMessage: cdpError.message,
+          discoveryCode: extractDiscoveryCode(cdpError.underlying),
+        });
         maybeRecordDesktopAutoCooldown(candidate);
+
+        // Emit production-visible fallback log in auto mode
+        if (mode === "auto") {
+          log.warn(
+            {
+              conversationId,
+              failedCandidate: candidate.kind,
+              nextCandidate: candidates[i + 1].kind,
+              attemptedSoFar: diagnostics.map((d) => ({
+                kind: d.candidateKind,
+                stage: d.stage,
+                errorCode: d.errorCode,
+                errorMessage: d.errorMessage,
+              })),
+            },
+            "CDP factory: auto-mode fallback triggered",
+          );
+        }
         continue;
       }
 
       // Either a CDP protocol error or we've exhausted candidates --
-      // propagate the error as-is.
-      throw cdpError;
+      // propagate the error as-is, attaching diagnostics.
+      diagnostics.push({
+        candidateKind: candidate.kind,
+        inclusionReason: candidate.reason,
+        stage: "send",
+        errorCode: cdpError.code,
+        errorMessage: cdpError.message,
+        discoveryCode: extractDiscoveryCode(cdpError.underlying),
+      });
+      throw new CdpError(cdpError.code, cdpError.message, {
+        cdpMethod: cdpError.cdpMethod,
+        cdpParams: cdpError.cdpParams,
+        underlying: cdpError.underlying,
+        attemptDiagnostics: diagnostics.length > 0 ? diagnostics : undefined,
+      });
     }
 
     // Success! Establish this backend as the sticky choice.
+    diagnostics.push({
+      candidateKind: candidate.kind,
+      inclusionReason: candidate.reason,
+      stage: "success",
+    });
+
+    // If there were prior failed candidates in auto mode, log the
+    // full sequence for observability.
+    if (mode === "auto" && diagnostics.length > 1) {
+      log.warn(
+        {
+          conversationId,
+          stickyCandidate: candidate.kind,
+          attemptSequence: diagnostics.map((d) => ({
+            kind: d.candidateKind,
+            stage: d.stage,
+            errorCode: d.errorCode,
+            errorMessage: d.errorMessage,
+          })),
+        },
+        "CDP factory: auto-mode fallback completed, backend established after retries",
+      );
+    }
+
     log.debug(
       { conversationId, candidateKind: candidate.kind, method },
       "CDP factory: candidate succeeded, backend is now sticky",
@@ -505,14 +735,20 @@ async function sendWithFailover<T>(
     return envelope.result as T;
   }
 
-  // All candidates exhausted -- throw the last transport error.
-  throw (
-    lastError ??
-    new CdpError("transport_error", "All backend candidates exhausted", {
-      cdpMethod: method,
-      cdpParams: params,
-    })
-  );
+  // All candidates exhausted -- throw the last transport error with
+  // full attempt diagnostics attached.
+  throw lastError
+    ? new CdpError(lastError.code, lastError.message, {
+        cdpMethod: lastError.cdpMethod,
+        cdpParams: lastError.cdpParams,
+        underlying: lastError.underlying,
+        attemptDiagnostics: diagnostics.length > 0 ? diagnostics : undefined,
+      })
+    : new CdpError("transport_error", "All backend candidates exhausted", {
+        cdpMethod: method,
+        cdpParams: params,
+        attemptDiagnostics: diagnostics.length > 0 ? diagnostics : undefined,
+      });
 }
 
 /**
@@ -622,4 +858,21 @@ function unwrapResult<T>(
     throw extractCdpError(envelope, method, params);
   }
   return envelope.result as T;
+}
+
+/**
+ * Attempt to extract a discovery-level error code from an underlying
+ * error. Some CdpInspectClient errors embed a discovery code (e.g.
+ * "ECONNREFUSED", "DISCOVERY_TIMEOUT") that is useful for diagnostics.
+ */
+function extractDiscoveryCode(underlying: unknown): string | undefined {
+  if (underlying == null) return undefined;
+  if (typeof underlying === "object" && "code" in underlying) {
+    const code = (underlying as Record<string, unknown>).code;
+    if (typeof code === "string") return code;
+  }
+  if (underlying instanceof Error && "cause" in underlying) {
+    return extractDiscoveryCode(underlying.cause);
+  }
+  return undefined;
 }

--- a/assistant/src/tools/browser/cdp-client/index.ts
+++ b/assistant/src/tools/browser/cdp-client/index.ts
@@ -12,11 +12,16 @@ export {
 export {
   buildCandidateList,
   buildChainedClient,
+  buildPinnedCandidateList,
   getCdpClient,
+  type GetCdpClientOptions,
 } from "./factory.js";
 export { createLocalCdpClient, LocalCdpClient } from "./local-cdp-client.js";
 export type {
+  AttemptDiagnostic,
+  AttemptStage,
   BackendCandidate,
+  BrowserMode,
   CdpClient,
   CdpClientKind,
   ScopedCdpClient,

--- a/assistant/src/tools/browser/cdp-client/types.ts
+++ b/assistant/src/tools/browser/cdp-client/types.ts
@@ -42,6 +42,51 @@ export interface CdpClient {
 export type CdpClientKind = "local" | "extension" | "cdp-inspect";
 
 /**
+ * Backend mode preference for the CDP factory. Controls which
+ * transport is selected:
+ *
+ *  - `"auto"` — default, existing priority-ordered fallback
+ *    (extension → cdp-inspect → local).
+ *  - `"extension"` — pin to the chrome-extension backend. Fails
+ *    immediately if the host browser proxy is unavailable.
+ *  - `"cdp-inspect"` — pin to the cdp-inspect backend. Fails
+ *    immediately if cdp-inspect cannot connect.
+ *  - `"local"` — pin to the local Playwright backend. No fallback.
+ */
+export type BrowserMode = "auto" | "extension" | "cdp-inspect" | "local";
+
+/**
+ * Stage at which a candidate attempt ended. Used in
+ * {@link AttemptDiagnostic} to indicate how far the attempt progressed.
+ */
+export type AttemptStage =
+  | "candidate_selection" // failed before construction (precondition not met)
+  | "construction" // create() threw
+  | "send" // manager.send() threw or returned an error envelope
+  | "success"; // command completed successfully
+
+/**
+ * Structured diagnostic for a single candidate attempt during the
+ * factory's failover walk. Collected into an array and attached to
+ * thrown {@link CdpError} instances so higher layers can render
+ * detailed failure information in user-facing tool errors.
+ */
+export interface AttemptDiagnostic {
+  /** Which backend kind was attempted. */
+  readonly candidateKind: CdpClientKind;
+  /** Why this candidate was included (from {@link BackendCandidate.reason}). */
+  readonly inclusionReason: string;
+  /** How far the attempt progressed before it ended. */
+  readonly stage: AttemptStage;
+  /** Error code from the CdpError, if the attempt failed. */
+  readonly errorCode?: string;
+  /** Error message from the CdpError, if the attempt failed. */
+  readonly errorMessage?: string;
+  /** Discovery-level error code extracted from the underlying error, if any. */
+  readonly discoveryCode?: string;
+}
+
+/**
  * Concrete CdpClient instance returned by the factory. Carries the
  * backend `kind` for transport-aware branches in tool code.
  */

--- a/docs/browser-use-architecture-phase2.md
+++ b/docs/browser-use-architecture-phase2.md
@@ -64,6 +64,15 @@ manager picks an extension backend when the conversation has a host
 browser proxy bound to it and falls back to a local Playwright-backed
 backend otherwise, so tool code remains transport-agnostic.
 
+All CDP-backed tools accept an optional `browser_mode` input parameter
+(`auto`, `extension`, `cdp-inspect`/`cdp-debugger`, `local`/`playwright`)
+that pins backend selection for that invocation. When a pinned mode
+fails, the tool response includes a detailed error with the attempted
+backends, exact failure reasons, and a remediation checklist. In auto
+mode, fallback transitions are logged at warn level for observability.
+See `browser-mode.ts` for normalization and `browser-execution.ts` for
+the `acquireCdpClientWithMode` integration point.
+
 ## Architecture
 
 The two transports share the same envelope vocabulary and the same

--- a/docs/browser-use-cdp-inspect-backend.md
+++ b/docs/browser-use-cdp-inspect-backend.md
@@ -186,3 +186,24 @@ cdp-inspect backend cannot reach or identify the DevTools endpoint.
 | `invalid_response` | The port responds but is not speaking the DevTools protocol. | Verify with `curl http://localhost:9222/json/version`. If the response is not valid JSON with a `Browser` field, another service is using the port. |
 | `no_targets` | Chrome is running but has no open tabs or pages. | Open at least one tab in Chrome before using browser tools. |
 | `timeout` | Chrome is slow to respond to the discovery probe. | Increase `hostBrowser.cdpInspect.probeTimeoutMs` (max 5000). |
+
+## Per-tool `browser_mode` override
+
+All CDP-backed browser tools accept an optional `browser_mode` input parameter that pins backend selection for that single invocation:
+
+```json
+{
+  "browser_mode": "cdp-inspect"
+}
+```
+
+Accepted values: `auto`, `extension`, `cdp-inspect`, `cdp-debugger` (alias for `cdp-inspect`), `local`, `playwright` (alias for `local`).
+
+When `browser_mode` is set to a specific backend, the factory disables automatic fallback. If the pinned backend fails, the tool returns a detailed error with:
+- The requested mode and a human-readable failure summary
+- An ordered list of attempted backends with exact failure reasons and discovery error codes
+- A remediation checklist tailored to the specific failure (e.g. "Ensure Chrome is running with --remote-debugging-port=9222")
+
+This is useful for debugging backend selection issues: pin the mode you expect, and the error response tells you exactly what went wrong and how to fix it.
+
+When `browser_mode` is omitted or set to `auto`, the existing priority-ordered fallback chain operates normally. Fallback transitions are logged at `warn` level with structured metadata for production observability.


### PR DESCRIPTION
## Summary
Add an optional `browser_mode` argument to all browser tools so the assistant can explicitly pin backend selection (`extension`, `cdp-inspect`/`cdp-debugger`, or `local`/`playwright`) instead of always relying on automatic fallback. Strengthen CDP factory observability so every fallback attempt is logged with exact candidate order and failure reasons. When a user-specified mode fails, return the same detailed attempt trace in the tool error response with concrete remediation steps.

## Self-review result
PASS after 3 review rounds — 6 gaps found and fixed across 4 fix PRs.

## PRs merged into feature branch
- #24996: feat(browser): add browser_mode input schema and normalization helper
- #24999: feat(browser): support pinned backend mode and structured fallback diagnostics
- #25004: feat(browser): wire browser_mode into browser execution and surface actionable mode failures

### Fix PRs
- #25015: fix: deduplicate BrowserMode type, refactor inline mode handling, merge AGENTS.md paragraphs
- #25012: fix: clarify browser_wait_for_download schema modes and add missing fallback warn logs
- #25014: fix: correct click tool test to exercise browser_mode error path
- #25021: fix: restrict formatCdpSendDiagnostics to transport errors only

Part of plan: browser-mode-fallback-diagnostics.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25026" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
