### PR TITLE
Redesign Chrome extension popup with dark theme and improved UX

### DIFF
--- a/clients/chrome-extension/popup/popup.html
+++ b/clients/chrome-extension/popup/popup.html
@@ -237,9 +237,6 @@
       font-weight: 500;
       color: var(--text-1);
       line-height: 1.35;
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
     }
 
     /* ── Status badge ────────────────────────────────────────────── */

--- a/clients/chrome-extension/popup/popup.html
+++ b/clients/chrome-extension/popup/popup.html
@@ -3,137 +3,113 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Browser Connection</title>
+  <title>Vellum Relay</title>
   <style>
     * { box-sizing: border-box; margin: 0; padding: 0; }
 
+    :root {
+      --bg: #0d1017;
+      --surface: #141820;
+      --surface-2: #1a1f2b;
+      --border: rgba(255, 255, 255, 0.07);
+      --border-hover: rgba(255, 255, 255, 0.12);
+      --text-1: #e4e7ed;
+      --text-2: #8990a0;
+      --text-3: #4e5568;
+      --green: #4ade80;
+      --green-soft: rgba(74, 222, 128, 0.08);
+      --green-border: rgba(74, 222, 128, 0.2);
+      --amber: #fbbf24;
+      --amber-soft: rgba(251, 191, 36, 0.08);
+      --amber-border: rgba(251, 191, 36, 0.2);
+      --red: #fb7185;
+      --red-soft: rgba(251, 113, 133, 0.08);
+      --red-border: rgba(251, 113, 133, 0.2);
+      --accent: #818cf8;
+    }
+
     body {
       font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-      font-size: 14px;
-      color: #1a1a1a;
-      background: #fff;
+      font-size: 13px;
+      color: var(--text-1);
+      background: linear-gradient(180deg, #10131b 0%, var(--bg) 100%);
       width: 300px;
       padding: 16px;
+      -webkit-font-smoothing: antialiased;
     }
+
+    /* Subtle grain overlay */
+    body::after {
+      content: "";
+      position: fixed;
+      inset: 0;
+      opacity: 0.018;
+      pointer-events: none;
+      background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.65' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+      background-size: 200px 200px;
+    }
+
+    /* ── Header ──────────────────────────────────────────────────── */
 
     header {
       display: flex;
       align-items: center;
       gap: 8px;
-      margin-bottom: 12px;
+      margin-bottom: 14px;
+    }
+
+    .logo-mark {
+      width: 18px;
+      height: 18px;
+      flex-shrink: 0;
+      color: var(--text-2);
     }
 
     header h1 {
-      font-size: 15px;
-      font-weight: 600;
-    }
-
-    .status-card {
-      background: #f8fafc;
-      border: 1px solid #e5e7eb;
-      border-radius: 10px;
-      padding: 10px;
-      margin-bottom: 12px;
-    }
-
-    .status-row {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      gap: 8px;
-      margin-bottom: 8px;
-    }
-
-    .status-left {
-      display: flex;
-      align-items: center;
-      gap: 8px;
-      min-width: 0;
-    }
-
-    .status-dot {
-      width: 10px;
-      height: 10px;
-      border-radius: 50%;
-      background: #ccc;
-      flex-shrink: 0;
-      transition: background 0.2s;
-    }
-    .status-dot.connected { background: #22c55e; }
-    .status-dot.paused { background: #f59e0b; }
-    .status-dot.disconnected { background: #ef4444; }
-
-    .status-badge {
-      font-size: 12px;
-      font-weight: 600;
-      color: #1f2937;
-      background: #e5e7eb;
-      border-radius: 999px;
-      padding: 2px 8px;
-      flex-shrink: 0;
-    }
-    .status-badge.connected { background: #dcfce7; color: #166534; }
-    .status-badge.paused { background: #fef3c7; color: #92400e; }
-    .status-badge.disconnected { background: #fee2e2; color: #991b1b; }
-
-    .status-text {
-      font-size: 12px;
-      color: #4b5563;
-      line-height: 1.45;
-    }
-
-    label {
-      display: block;
-      font-size: 12px;
-      font-weight: 500;
-      color: #444;
-      margin-bottom: 4px;
-    }
-
-    input[type="text"] {
-      width: 100%;
-      border: 1px solid #d1d5db;
-      border-radius: 6px;
-      padding: 7px 10px;
       font-size: 13px;
-      outline: none;
-      transition: border-color 0.15s;
-      margin-bottom: 12px;
+      font-weight: 600;
+      color: var(--text-2);
+      letter-spacing: 0.01em;
     }
-    input:focus { border-color: #6366f1; }
+
+    /* ── Toggle row ──────────────────────────────────────────────── */
 
     .toggle-row {
       display: flex;
       align-items: center;
       justify-content: space-between;
-      border: 1px solid #e5e7eb;
-      border-radius: 10px;
-      padding: 10px;
-      margin-bottom: 12px;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 12px 14px;
+      margin-bottom: 10px;
+      transition: border-color 0.2s;
     }
 
     .toggle-copy {
       display: flex;
       flex-direction: column;
-      gap: 3px;
+      gap: 2px;
     }
 
     .toggle-title {
       font-size: 13px;
       font-weight: 600;
-      color: #111827;
+      color: var(--text-1);
     }
 
     .toggle-hint {
-      font-size: 12px;
-      color: #6b7280;
-      line-height: 1.4;
+      font-size: 11px;
+      color: var(--text-3);
+      line-height: 1.35;
     }
+
+    /* ── Switch ──────────────────────────────────────────────────── */
 
     .switch {
       position: relative;
-      width: 44px;
-      height: 26px;
+      width: 40px;
+      height: 22px;
       flex-shrink: 0;
     }
 
@@ -147,27 +123,27 @@
     .switch-slider {
       position: absolute;
       inset: 0;
-      background: #d1d5db;
+      background: var(--text-3);
       border-radius: 999px;
-      transition: background 0.2s;
+      transition: background 0.25s cubic-bezier(0.4, 0, 0.2, 1);
       cursor: pointer;
     }
 
     .switch-slider::before {
       content: "";
       position: absolute;
-      left: 3px;
-      top: 3px;
-      width: 20px;
-      height: 20px;
+      left: 2px;
+      top: 2px;
+      width: 18px;
+      height: 18px;
       border-radius: 50%;
       background: #fff;
-      transition: transform 0.2s;
-      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+      transition: transform 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.35);
     }
 
     .switch input:checked + .switch-slider {
-      background: #4f46e5;
+      background: var(--green);
     }
 
     .switch input:checked + .switch-slider::before {
@@ -176,105 +152,260 @@
 
     .switch input:disabled + .switch-slider {
       cursor: default;
-      opacity: 0.55;
+      opacity: 0.35;
     }
 
-    button {
-      width: 100%;
-      padding: 8px 0;
-      border: none;
-      border-radius: 6px;
+    /* ── Status card ─────────────────────────────────────────────── */
+
+    .status-card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 14px 16px;
+      margin-bottom: 10px;
+      transition: border-color 0.4s ease, box-shadow 0.4s ease;
+    }
+
+    .status-card:has(.status-dot.connected) {
+      border-color: var(--green-border);
+      box-shadow: 0 0 20px -6px rgba(74, 222, 128, 0.1);
+    }
+
+    .status-card:has(.status-dot.paused) {
+      border-color: var(--amber-border);
+    }
+
+    .status-card:has(.status-dot.disconnected) {
+      border-color: var(--red-border);
+    }
+
+    .status-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 10px;
+    }
+
+    .status-left {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      min-width: 0;
+    }
+
+    /* ── Status dot — the living indicator ────────────────────────── */
+
+    .status-dot {
+      width: 10px;
+      height: 10px;
+      border-radius: 50%;
+      background: var(--text-3);
+      flex-shrink: 0;
+      position: relative;
+      transition: background 0.3s, box-shadow 0.3s;
+    }
+
+    .status-dot.connected {
+      background: var(--green);
+      box-shadow: 0 0 8px rgba(74, 222, 128, 0.5);
+      animation: alive-pulse 2.5s ease-in-out infinite;
+    }
+
+    .status-dot.paused {
+      background: var(--amber);
+      box-shadow: 0 0 6px rgba(251, 191, 36, 0.3);
+    }
+
+    .status-dot.disconnected {
+      background: var(--red);
+      box-shadow: 0 0 6px rgba(251, 113, 133, 0.35);
+    }
+
+    @keyframes alive-pulse {
+      0%, 100% {
+        box-shadow: 0 0 8px rgba(74, 222, 128, 0.5),
+                    0 0 0 0 rgba(74, 222, 128, 0.3);
+      }
+      50% {
+        box-shadow: 0 0 8px rgba(74, 222, 128, 0.5),
+                    0 0 0 5px rgba(74, 222, 128, 0);
+      }
+    }
+
+    .status-text {
       font-size: 13px;
       font-weight: 500;
-      cursor: pointer;
-      transition: opacity 0.15s;
-    }
-    button:disabled { opacity: 0.5; cursor: default; }
-
-    .divider {
-      height: 1px;
-      background: #e5e7eb;
-      margin: 16px 0 14px 0;
+      color: var(--text-1);
+      line-height: 1.35;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
 
-    #btn-cloud-signin {
-      width: 100%;
-      background: #111827;
-      color: #fff;
-      margin-bottom: 8px;
-    }
-    #btn-cloud-signin:hover:not(:disabled) { background: #1f2937; }
+    /* ── Status badge ────────────────────────────────────────────── */
 
-    #btn-pair-local {
-      width: 100%;
-      background: #0f766e;
-      color: #fff;
-      margin-bottom: 8px;
-    }
-    #btn-pair-local:hover:not(:disabled) { background: #115e59; }
-
-    .cloud-status {
-      font-size: 12px;
-      color: #4b5563;
-      margin-bottom: 4px;
-      word-break: break-all;
-    }
-    .cloud-status.signed-in { color: #0f766e; }
-
-    .local-status {
-      font-size: 12px;
-      color: #4b5563;
-      margin-bottom: 4px;
-      word-break: break-all;
-    }
-    .local-status.paired { color: #0f766e; }
-    .local-status.error { color: #ef4444; }
-
-    .assistant-selector-group {
-      margin-bottom: 14px;
+    .status-badge {
+      font-size: 10px;
+      font-weight: 600;
+      border-radius: 5px;
+      padding: 3px 7px;
+      flex-shrink: 0;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      transition: all 0.3s;
+      background: rgba(255, 255, 255, 0.06);
+      color: var(--text-3);
     }
 
-    select {
-      width: 100%;
-      border: 1px solid #d1d5db;
-      border-radius: 6px;
-      padding: 7px 10px;
-      font-size: 13px;
-      outline: none;
-      transition: border-color 0.15s;
-      background: #fff;
-      color: #1a1a1a;
-      cursor: pointer;
+    .status-badge.connected {
+      background: var(--green-soft);
+      color: var(--green);
     }
-    select:focus { border-color: #6366f1; }
 
-    .hint {
-      font-size: 11px;
-      color: #9ca3af;
-      margin-top: 6px;
-      line-height: 1.5;
+    .status-badge.paused {
+      background: var(--amber-soft);
+      color: var(--amber);
     }
+
+    .status-badge.disconnected {
+      background: var(--red-soft);
+      color: var(--red);
+    }
+
+    /* ── Error & setup alerts ────────────────────────────────────── */
 
     .error-text {
       font-size: 12px;
-      color: #ef4444;
-      margin-bottom: 8px;
-    }
-
-    .setup-message {
-      font-size: 12px;
-      color: #92400e;
-      background: #fef3c7;
-      border: 1px solid #fde68a;
-      border-radius: 6px;
-      padding: 8px 10px;
+      color: var(--red);
+      background: var(--red-soft);
+      border: 1px solid var(--red-border);
+      border-radius: 8px;
+      padding: 10px 12px;
       margin-bottom: 10px;
       line-height: 1.45;
     }
 
-    .advanced-setting {
-      margin-top: 10px;
+    .setup-message {
+      font-size: 12px;
+      color: var(--amber);
+      background: var(--amber-soft);
+      border: 1px solid var(--amber-border);
+      border-radius: 8px;
+      padding: 10px 12px;
       margin-bottom: 10px;
+      line-height: 1.45;
+    }
+
+    /* ── Assistant selector ──────────────────────────────────────── */
+
+    .assistant-selector-group {
+      margin-bottom: 10px;
+    }
+
+    .assistant-selector-group > label {
+      font-size: 10px;
+      font-weight: 600;
+      color: var(--text-3);
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      margin-bottom: 6px;
+    }
+
+    select {
+      width: 100%;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 8px 28px 8px 10px;
+      font-size: 13px;
+      color: var(--text-1);
+      outline: none;
+      cursor: pointer;
+      transition: border-color 0.2s;
+      -webkit-appearance: none;
+      appearance: none;
+      background-image: url("data:image/svg+xml,%3Csvg width='10' height='6' viewBox='0 0 10 6' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1 1L5 5L9 1' stroke='%234e5568' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+      background-repeat: no-repeat;
+      background-position: right 10px center;
+    }
+
+    select:focus { border-color: var(--accent); }
+
+    /* ── Base label ──────────────────────────────────────────────── */
+
+    label {
+      display: block;
+      font-size: 10px;
+      font-weight: 600;
+      color: var(--text-3);
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      margin-bottom: 4px;
+    }
+
+    /* ── Divider ─────────────────────────────────────────────────── */
+
+    .divider {
+      height: 1px;
+      background: var(--border);
+      margin: 14px 0 4px;
+    }
+
+    /* ── Advanced / Troubleshoot ──────────────────────────────────── */
+
+    #troubleshoot-section {
+      margin-top: 0;
+    }
+
+    #troubleshoot-section[hidden] {
+      display: none;
+    }
+
+    .troubleshoot-toggle {
+      display: flex;
+      align-items: center;
+      gap: 5px;
+      background: none;
+      border: none;
+      padding: 8px 0;
+      margin-bottom: 0;
+      cursor: pointer;
+      font-size: 10px;
+      font-weight: 600;
+      color: var(--text-3);
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      width: auto;
+      flex: none;
+      transition: color 0.15s;
+    }
+
+    .troubleshoot-toggle:hover { color: var(--text-2); }
+
+    .troubleshoot-toggle .chevron {
+      display: inline-block;
+      font-size: 8px;
+      transition: transform 0.2s ease;
+      color: inherit;
+    }
+
+    .troubleshoot-toggle[aria-expanded="true"] .chevron {
+      transform: rotate(90deg);
+    }
+
+    #troubleshoot-body {
+      overflow: hidden;
+    }
+
+    #troubleshoot-body[hidden] {
+      display: none;
+    }
+
+    /* ── Advanced settings ────────────────────────────────────────── */
+
+    .advanced-setting {
+      margin-top: 6px;
+      margin-bottom: 14px;
     }
 
     .advanced-setting label {
@@ -285,56 +416,107 @@
       margin-bottom: 0;
     }
 
-    /* ── Advanced collapsible area ────────────────────────────────── */
-
-    #troubleshoot-section {
-      margin-top: 16px;
+    input[type="text"] {
+      width: 100%;
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 8px 10px;
+      font-size: 13px;
+      font-family: "SF Mono", Menlo, Monaco, Consolas, monospace;
+      color: var(--text-1);
+      outline: none;
+      transition: border-color 0.2s;
+      margin-bottom: 12px;
     }
 
-    #troubleshoot-section[hidden] {
-      display: none;
-    }
+    input[type="text"]:focus { border-color: var(--accent); }
 
-    .troubleshoot-toggle {
-      display: flex;
-      align-items: center;
-      gap: 4px;
-      background: none;
-      border: none;
-      padding: 0;
-      margin-bottom: 10px;
-      cursor: pointer;
-      font-size: 11px;
-      font-weight: 600;
-      color: #6b7280;
-      text-transform: uppercase;
-      letter-spacing: 0.04em;
-      flex: none;
-      width: auto;
-    }
-    .troubleshoot-toggle:hover { color: #374151; }
-
-    .troubleshoot-toggle .chevron {
-      display: inline-block;
+    .hint {
       font-size: 10px;
-      transition: transform 0.15s;
-    }
-    .troubleshoot-toggle[aria-expanded="true"] .chevron {
-      transform: rotate(90deg);
+      color: var(--text-3);
+      margin-top: 5px;
+      line-height: 1.4;
     }
 
-    #troubleshoot-body {
-      overflow: hidden;
+    /* ── Buttons ──────────────────────────────────────────────────── */
+
+    button {
+      width: 100%;
+      padding: 9px 12px;
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      font-size: 12px;
+      font-weight: 500;
+      cursor: pointer;
+      transition: all 0.15s ease;
+      background: var(--surface-2);
+      color: var(--text-1);
     }
-    #troubleshoot-body[hidden] {
-      display: none;
+
+    button:hover:not(:disabled) {
+      background: var(--surface);
+      border-color: var(--border-hover);
+    }
+
+    button:active:not(:disabled) {
+      transform: scale(0.98);
+    }
+
+    button:disabled {
+      opacity: 0.35;
+      cursor: default;
+    }
+
+    #btn-pair-local {
+      margin-bottom: 8px;
+    }
+
+    #btn-cloud-signin {
+      margin-bottom: 8px;
+    }
+
+    /* ── Local / Cloud status text ────────────────────────────────── */
+
+    .local-status,
+    .cloud-status {
+      font-size: 11px;
+      color: var(--text-3);
+      margin-bottom: 6px;
+      word-break: break-all;
+      font-family: "SF Mono", Menlo, Monaco, Consolas, monospace;
+      line-height: 1.5;
+    }
+
+    .local-status.paired,
+    .cloud-status.signed-in {
+      color: var(--green);
+    }
+
+    .local-status.error {
+      color: var(--red);
     }
   </style>
 </head>
 <body>
   <header>
+    <svg class="logo-mark" viewBox="0 0 18 18" fill="none" aria-hidden="true">
+      <path d="M9 1.5L16.5 9L9 16.5L1.5 9L9 1.5Z" stroke="currentColor" stroke-width="1.2" stroke-linejoin="round"/>
+      <path d="M9 5.5L12.5 9L9 12.5L5.5 9L9 5.5Z" fill="currentColor" opacity="0.3"/>
+    </svg>
     <h1>Vellum Relay</h1>
   </header>
+
+  <div class="toggle-row">
+    <div class="toggle-copy">
+      <p class="toggle-title">Connection</p>
+      <p class="toggle-hint" id="connection-toggle-hint">Turn on to connect.</p>
+    </div>
+    <label class="switch" for="connection-toggle">
+      <input type="checkbox" id="connection-toggle" aria-label="Toggle connection" />
+      <span class="switch-slider"></span>
+    </label>
+  </div>
 
   <div class="status-card" role="status" aria-live="polite">
     <div class="status-row">
@@ -353,17 +535,6 @@
   <div class="assistant-selector-group" id="assistant-selector-group" style="display:none">
     <label for="assistant-select">Assistant</label>
     <select id="assistant-select"></select>
-  </div>
-
-  <div class="toggle-row">
-    <div class="toggle-copy">
-      <p class="toggle-title">Connection</p>
-      <p class="toggle-hint" id="connection-toggle-hint">Turn on to connect.</p>
-    </div>
-    <label class="switch" for="connection-toggle">
-      <input type="checkbox" id="connection-toggle" aria-label="Toggle connection" />
-      <span class="switch-slider"></span>
-    </label>
   </div>
 
   <!-- Advanced section: collapsed by default, auto-expanded for auth_required/error -->


### PR DESCRIPTION
## Summary
- Redesign the Chrome extension popup from a generic white form to a dark, professional control panel with CSS custom properties, animated status indicators, and state-aware card borders (green/amber/red glow via `:has()`)
- Reorder layout: connection toggle now comes before status card, putting the primary action first
- Add SVG logo mark, monospace font for technical values (port, guardian IDs), subtle grain texture, and refined micro-interactions (cubic-bezier easing, press-scale on buttons)

All 16 element IDs and CSS class patterns preserved — `popup.ts` requires zero changes.

## Original prompt
it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25027" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
