### PR TITLE
fix: improve skill detail view loading and error states

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillDetailView.swift
@@ -289,24 +289,26 @@ struct SkillDetailView: View {
     @ViewBuilder
     private var skillDetailFileBrowser: some View {
         if skillsManager.isLoadingSkillFiles {
-            VEmptyState(
-                title: "Loading files...",
-                icon: VIcon.fileText.rawValue
-            )
+            VStack(spacing: VSpacing.lg) {
+                VEmptyState(
+                    title: "Loading files...",
+                    icon: VIcon.fileText.rawValue
+                )
+                ProgressView()
+                    .controlSize(.small)
+            }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .overlay { ProgressView().controlSize(.small) }
-        } else if let error = skillsManager.skillFilesError {
+        } else if skillsManager.skillFilesError != nil {
             VStack(spacing: VSpacing.md) {
                 VEmptyState(
                     title: "Failed to load files",
-                    subtitle: error,
                     icon: VIcon.circleAlert.rawValue
                 )
                 retryButton(label: "Retry") {
                     skillsManager.fetchSkillFiles(skillId: skill.id)
                 }
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .frame(maxWidth: .infinity)
         } else {
             VFileBrowser(
                 rootNodes: browserNodes,


### PR DESCRIPTION
## Summary
- Remove redundant error subtitle ("Failed to load skill files") that duplicated the title ("Failed to load files")
- Move retry button closer to error message by removing maxHeight: .infinity from the error state container
- Fix spinner overlap with file icon by moving ProgressView from an overlay to a VStack sibling below the empty state

## Original prompt
UI improvements to the skills details page. Three fixes needed:

1. **Remove redundant error text**: When files fail to load, it shows both "Failed to load files" and "Failed to load skill files" - remove the redundant one so only one error message is shown.

2. **Move Retry button up**: The "Retry" button is positioned far below the error message with too much empty space. Move it up so it's closer to/right below the error message.

3. **Fix spinner overlap**: During the loading state ("Loading files..."), the spinner overlaps with the file icon. Fix the positioning so they don't overlap.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25028" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
