### PR TITLE
fix: use sourceRepo directly for skillssh audit enrichment in detail handler

### DIFF
--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -551,9 +551,8 @@ export async function getSkill(
     };
     // Enrich with audit data (non-fatal on failure)
     try {
-      const source = resolveSkillSource(slim.slug);
-      const sourceRepo = `${source.owner}/${source.repo}`;
-      const skillSlug = source.skillSlug;
+      const sourceRepo = slim.sourceRepo;
+      const skillSlug = slim.slug.split("/").pop() ?? slim.slug;
       const audits = await fetchSkillAudits(sourceRepo, [skillSlug]);
       if (audits[skillSlug]) {
         (detail as { audit?: SkillAuditData }).audit = audits[skillSlug];


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for enrich-skill-search-metadata.md.

**Gap:** Audit enrichment silently fails for installed skillssh skills
**What was expected:** Detail handler should fetch audit data for installed skills.sh skills
**What was found:** resolveSkillSource(slim.slug) throws for bare slugs from install-meta
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25029" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
