### PR TITLE
fix: add version to ClawhubSkillDetail and skillDetailSchema

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -6743,6 +6743,8 @@ paths:
                             type: number
                           publishedAt:
                             type: string
+                          version:
+                            type: string
                           owner:
                             anyOf:
                               - type: object
@@ -6809,6 +6811,7 @@ paths:
                           - stars
                           - installs
                           - reports
+                          - version
                         additionalProperties: false
                       - type: object
                         properties:

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -515,6 +515,7 @@ export async function getSkill(
       installs: slim.installs,
       reports: slim.reports,
       publishedAt: slim.publishedAt,
+      version: slim.version,
     };
     try {
       const inspectResult = await clawhubInspect(slim.slug);

--- a/assistant/src/daemon/message-types/skills.ts
+++ b/assistant/src/daemon/message-types/skills.ts
@@ -166,6 +166,7 @@ interface ClawhubSkillDetail extends SkillDetailBase {
   installs: number;
   reports: number;
   publishedAt?: string;
+  version: string;
   // Enrichment fields (from clawhubInspect):
   owner?: { handle: string; displayName: string; image?: string } | null;
   stats?: {

--- a/assistant/src/runtime/routes/skills-routes.ts
+++ b/assistant/src/runtime/routes/skills-routes.ts
@@ -91,6 +91,7 @@ const skillDetailSchema = z.discriminatedUnion("origin", [
     installs: z.number(),
     reports: z.number(),
     publishedAt: z.string().optional(),
+    version: z.string(),
     owner: z
       .object({
         handle: z.string(),


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for enrich-skill-search-metadata.md.

**Gap:** ClawhubSkillDetail missing version
**What was expected:** Detail type and schema should include version for clawhub skills
**What was found:** ClawhubSkillDetail and skillDetailSchema lacked version, causing divergence from runtime response
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25030" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
