### PR TITLE
fix: update Swift codegen for new version and audit fields

### DIFF
--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -4042,6 +4042,21 @@ public struct SkillsListResponse: Codable, Sendable {
     }
 }
 
+/// Security audit result from a partner analysis provider.
+public struct PartnerAudit: Codable, Sendable, Equatable {
+    public let risk: String
+    public let alerts: Int?
+    public let score: Double?
+    public let analyzedAt: String
+
+    public init(risk: String, alerts: Int? = nil, score: Double? = nil, analyzedAt: String) {
+        self.risk = risk
+        self.alerts = alerts
+        self.score = score
+        self.analyzedAt = analyzedAt
+    }
+}
+
 public struct SkillsListResponseSkill: Codable, Sendable {
     public let id: String
     public let name: String
@@ -4058,10 +4073,12 @@ public struct SkillsListResponseSkill: Codable, Sendable {
     public let stars: Int?
     public let reports: Int?
     public let publishedAt: String?
+    public let version: String?
     // Skillssh-only:
     public let sourceRepo: String?
+    public let audit: [String: PartnerAudit]?
 
-    public init(id: String, name: String, description: String, emoji: String? = nil, kind: String, origin: String, status: String, slug: String? = nil, installs: Int? = nil, author: String? = nil, stars: Int? = nil, reports: Int? = nil, publishedAt: String? = nil, sourceRepo: String? = nil) {
+    public init(id: String, name: String, description: String, emoji: String? = nil, kind: String, origin: String, status: String, slug: String? = nil, installs: Int? = nil, author: String? = nil, stars: Int? = nil, reports: Int? = nil, publishedAt: String? = nil, version: String? = nil, sourceRepo: String? = nil, audit: [String: PartnerAudit]? = nil) {
         self.id = id
         self.name = name
         self.description = description
@@ -4075,7 +4092,9 @@ public struct SkillsListResponseSkill: Codable, Sendable {
         self.stars = stars
         self.reports = reports
         self.publishedAt = publishedAt
+        self.version = version
         self.sourceRepo = sourceRepo
+        self.audit = audit
     }
 }
 
@@ -4135,6 +4154,7 @@ public struct SkillDetailHTTPResponse: Codable, Sendable {
     public let publishedAt: String?
     // Skillssh-only:
     public let sourceRepo: String?
+    public let audit: [String: PartnerAudit]?
     // Clawhub detail enrichment fields:
     public let owner: ClawhubDetailOwner?
     public let stats: ClawhubDetailStats?
@@ -4142,7 +4162,7 @@ public struct SkillDetailHTTPResponse: Codable, Sendable {
     public let createdAt: Int?
     public let updatedAt: Int?
 
-    public init(id: String, name: String, description: String, emoji: String? = nil, kind: String, origin: String, status: String, slug: String? = nil, installs: Int? = nil, author: String? = nil, stars: Int? = nil, reports: Int? = nil, publishedAt: String? = nil, sourceRepo: String? = nil, owner: ClawhubDetailOwner? = nil, stats: ClawhubDetailStats? = nil, latestVersion: ClawhubDetailVersion? = nil, createdAt: Int? = nil, updatedAt: Int? = nil) {
+    public init(id: String, name: String, description: String, emoji: String? = nil, kind: String, origin: String, status: String, slug: String? = nil, installs: Int? = nil, author: String? = nil, stars: Int? = nil, reports: Int? = nil, publishedAt: String? = nil, sourceRepo: String? = nil, audit: [String: PartnerAudit]? = nil, owner: ClawhubDetailOwner? = nil, stats: ClawhubDetailStats? = nil, latestVersion: ClawhubDetailVersion? = nil, createdAt: Int? = nil, updatedAt: Int? = nil) {
         self.id = id
         self.name = name
         self.description = description
@@ -4157,6 +4177,7 @@ public struct SkillDetailHTTPResponse: Codable, Sendable {
         self.reports = reports
         self.publishedAt = publishedAt
         self.sourceRepo = sourceRepo
+        self.audit = audit
         self.owner = owner
         self.stats = stats
         self.latestVersion = latestVersion

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -967,7 +967,7 @@ extension SkillsListResponseSkill: Identifiable {}
 extension SkillsListResponseSkill {
     /// Returns a copy with a different `status`, preserving all other fields including `id`.
     public func withStatus(_ newStatus: String) -> Self {
-        Self(id: id, name: name, description: description, emoji: emoji, kind: kind, origin: origin, status: newStatus, slug: slug, installs: installs, author: author, stars: stars, reports: reports, publishedAt: publishedAt, sourceRepo: sourceRepo)
+        Self(id: id, name: name, description: description, emoji: emoji, kind: kind, origin: origin, status: newStatus, slug: slug, installs: installs, author: author, stars: stars, reports: reports, publishedAt: publishedAt, version: version, sourceRepo: sourceRepo, audit: audit)
     }
 
     /// Whether the skill is available from the catalog but not yet installed.
@@ -1081,6 +1081,7 @@ public struct ClawhubOriginMeta: Codable, Sendable, Equatable {
     public let installs: Int
     public let reports: Int
     public let publishedAt: String?
+    public let version: String?
 }
 
 /// Origin-specific metadata for a skill sourced from Skills.sh.
@@ -1088,6 +1089,7 @@ public struct SkillsshOriginMeta: Codable, Sendable, Equatable {
     public let slug: String
     public let sourceRepo: String
     public let installs: Int
+    public let audit: [String: PartnerAudit]?
 }
 
 /// Discriminated union over the `origin` field of a skill.
@@ -1110,13 +1112,15 @@ extension SkillsListResponseSkill {
                 stars: stars ?? 0,
                 installs: installs ?? 0,
                 reports: reports ?? 0,
-                publishedAt: publishedAt
+                publishedAt: publishedAt,
+                version: version
             ))
         case "skillssh":
             return .skillssh(SkillsshOriginMeta(
                 slug: slug ?? id,
                 sourceRepo: sourceRepo ?? "",
-                installs: installs ?? 0
+                installs: installs ?? 0,
+                audit: audit
             ))
         case "vellum":
             return .vellum
@@ -1137,13 +1141,15 @@ extension SkillDetailHTTPResponse {
                 stars: stars ?? 0,
                 installs: installs ?? 0,
                 reports: reports ?? 0,
-                publishedAt: publishedAt
+                publishedAt: publishedAt,
+                version: latestVersion?.version
             ))
         case "skillssh":
             return .skillssh(SkillsshOriginMeta(
                 slug: slug ?? id,
                 sourceRepo: sourceRepo ?? "",
-                installs: installs ?? 0
+                installs: installs ?? 0,
+                audit: audit
             ))
         case "vellum":
             return .vellum


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for enrich-skill-search-metadata.md.

**Gap:** Swift codegen not updated for new fields
**What was expected:** Swift types should include version and audit fields
**What was found:** OpenAPI spec was updated but Swift types were not regenerated

### Changes
- Added `PartnerAudit` struct to `GeneratedAPITypes.swift` modeling the security audit result from partner analysis providers (risk, alerts, score, analyzedAt)
- Added `version: String?` field to `SkillsListResponseSkill` (clawhub-only)
- Added `audit: [String: PartnerAudit]?` field to both `SkillsListResponseSkill` and `SkillDetailHTTPResponse` (skillssh-only)
- Updated `withStatus()` in `MessageTypes.swift` to pass through the new fields
- Updated `ClawhubOriginMeta` to include `version` and `SkillsshOriginMeta` to include `audit`
- Updated `originMeta` computed properties on both `SkillsListResponseSkill` and `SkillDetailHTTPResponse` to propagate the new fields
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25033" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
