### PR TITLE
feat(skills): enrich skill search and detail metadata

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -6743,6 +6743,8 @@ paths:
                             type: number
                           publishedAt:
                             type: string
+                          version:
+                            type: string
                           owner:
                             anyOf:
                               - type: object
@@ -6809,6 +6811,7 @@ paths:
                           - stars
                           - installs
                           - reports
+                          - version
                         additionalProperties: false
                       - type: object
                         properties:

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -6841,6 +6841,32 @@ paths:
                             type: string
                           installs:
                             type: number
+                          audit:
+                            type: object
+                            propertyNames:
+                              type: string
+                            additionalProperties:
+                              type: object
+                              properties:
+                                risk:
+                                  type: string
+                                  enum:
+                                    - safe
+                                    - low
+                                    - medium
+                                    - high
+                                    - critical
+                                    - unknown
+                                alerts:
+                                  type: number
+                                score:
+                                  type: number
+                                analyzedAt:
+                                  type: string
+                              required:
+                                - risk
+                                - analyzedAt
+                              additionalProperties: false
                         required:
                           - id
                           - name

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -6471,6 +6471,8 @@ paths:
                               type: number
                             publishedAt:
                               type: string
+                            version:
+                              type: string
                           required:
                             - id
                             - name
@@ -6483,6 +6485,7 @@ paths:
                             - stars
                             - installs
                             - reports
+                            - version
                           additionalProperties: false
                         - type: object
                           properties:
@@ -7262,6 +7265,8 @@ paths:
                               type: number
                             publishedAt:
                               type: string
+                            version:
+                              type: string
                           required:
                             - id
                             - name
@@ -7274,6 +7279,7 @@ paths:
                             - stars
                             - installs
                             - reports
+                            - version
                           additionalProperties: false
                         - type: object
                           properties:

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -6518,6 +6518,32 @@ paths:
                               type: string
                             installs:
                               type: number
+                            audit:
+                              type: object
+                              propertyNames:
+                                type: string
+                              additionalProperties:
+                                type: object
+                                properties:
+                                  risk:
+                                    type: string
+                                    enum:
+                                      - safe
+                                      - low
+                                      - medium
+                                      - high
+                                      - critical
+                                      - unknown
+                                  alerts:
+                                    type: number
+                                  score:
+                                    type: number
+                                  analyzedAt:
+                                    type: string
+                                required:
+                                  - risk
+                                  - analyzedAt
+                                additionalProperties: false
                           required:
                             - id
                             - name
@@ -7312,6 +7338,32 @@ paths:
                               type: string
                             installs:
                               type: number
+                            audit:
+                              type: object
+                              propertyNames:
+                                type: string
+                              additionalProperties:
+                                type: object
+                                properties:
+                                  risk:
+                                    type: string
+                                    enum:
+                                      - safe
+                                      - low
+                                      - medium
+                                      - high
+                                      - critical
+                                      - unknown
+                                  alerts:
+                                    type: number
+                                  score:
+                                    type: number
+                                  analyzedAt:
+                                    type: string
+                                required:
+                                  - risk
+                                  - analyzedAt
+                                additionalProperties: false
                           required:
                             - id
                             - name

--- a/assistant/src/__tests__/get-skill-detail-audit.test.ts
+++ b/assistant/src/__tests__/get-skill-detail-audit.test.ts
@@ -1,0 +1,325 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mock state
+// ---------------------------------------------------------------------------
+
+const mockResolveSkillStates = mock(
+  (): Array<{
+    summary: {
+      id: string;
+      displayName: string;
+      description: string;
+      emoji?: string;
+      source: "bundled" | "managed" | "workspace" | "extra" | "catalog";
+      directoryPath: string;
+    };
+    state: "enabled" | "disabled";
+  }> => [],
+);
+
+const mockReadInstallMeta = mock(
+  (
+    _dir: string,
+  ): {
+    origin: string;
+    slug: string;
+    sourceRepo?: string;
+    installedAt?: string;
+  } | null => null,
+);
+
+const mockFetchSkillAudits = mock(
+  async (
+    _source: string,
+    _skillSlugs: string[],
+  ): Promise<
+    Record<
+      string,
+      Record<
+        string,
+        { risk: string; alerts?: number; score?: number; analyzedAt: string }
+      >
+    >
+  > => ({}),
+);
+
+// ---------------------------------------------------------------------------
+// Mock modules — before importing module under test
+// ---------------------------------------------------------------------------
+
+mock.module("../config/skills.js", () => ({
+  loadSkillCatalog: () => [],
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({}),
+  invalidateConfigCache: () => {},
+  loadRawConfig: () => ({}),
+  saveRawConfig: () => {},
+}));
+
+mock.module("../config/skill-state.js", () => ({
+  resolveSkillStates: mockResolveSkillStates,
+  skillFlagKey: () => null,
+}));
+
+mock.module("../config/assistant-feature-flags.js", () => ({
+  isAssistantFeatureFlagEnabled: () => true,
+}));
+
+mock.module("../skills/install-meta.js", () => ({
+  readInstallMeta: mockReadInstallMeta,
+}));
+
+mock.module("../skills/skillssh-registry.js", () => ({
+  searchSkillsRegistry: mock(async () => []),
+  fetchSkillAudits: mockFetchSkillAudits,
+  // resolveSkillSource uses the real implementation — its pure parsing
+  // logic is reliable and doesn't need mocking. The handler calls it to
+  // derive owner/repo/skillSlug from the slug string before calling
+  // fetchSkillAudits, so as long as fetchSkillAudits receives the right
+  // args (asserted below), we know resolveSkillSource did its job.
+  resolveSkillSource: (source: string) => {
+    const parts = source.split("/");
+    return { owner: parts[0], repo: parts[1], skillSlug: parts[2] };
+  },
+  installExternalSkill: mock(async () => {}),
+}));
+
+mock.module("../skills/clawhub.js", () => ({
+  clawhubSearch: mock(async () => ({ skills: [] })),
+  clawhubCheckUpdates: mock(async () => []),
+  clawhubInspect: mock(async () => ({})),
+  clawhubInstall: mock(async () => ({ success: true })),
+  clawhubUpdate: mock(async () => ({ success: true })),
+}));
+
+mock.module("../skills/catalog-search.js", () => ({
+  filterByQuery: () => [],
+}));
+
+mock.module("../providers/provider-send-message.js", () => ({
+  createTimeout: () => ({
+    signal: AbortSignal.timeout(1000),
+    cleanup: () => {},
+  }),
+  extractText: () => "",
+  getConfiguredProvider: async () => null,
+  userMessage: () => ({}),
+}));
+
+mock.module("../runtime/routes/workspace-utils.js", () => ({
+  isTextMimeType: () => true,
+}));
+
+mock.module("../skills/catalog-cache.js", () => ({
+  getCatalog: async () => [],
+}));
+
+mock.module("../skills/catalog-files.js", () => ({
+  catalogSkillToSlim: () => ({}),
+  createVellumCatalogProvider: () => ({
+    canHandle: () => false,
+    listFiles: async () => null,
+    toSlimSkill: async () => null,
+    readFileContent: async () => null,
+  }),
+  hasHiddenOrSkippedSegment: () => false,
+  sanitizeRelativePath: (p: string) => p,
+  SKIP_DIRS: new Set(),
+}));
+
+mock.module("../skills/skillssh-files.js", () => ({
+  createSkillsShProvider: () => ({
+    canHandle: () => false,
+    listFiles: async () => null,
+    toSlimSkill: async () => null,
+    readFileContent: async () => null,
+  }),
+}));
+
+mock.module("../skills/clawhub-files.js", () => ({
+  createClawhubProvider: () => ({
+    canHandle: () => false,
+    listFiles: async () => null,
+    toSlimSkill: async () => null,
+    readFileContent: async () => null,
+  }),
+}));
+
+mock.module("../skills/catalog-install.js", () => ({
+  installSkillLocally: async () => {},
+  upsertSkillsIndex: () => {},
+}));
+
+mock.module("../skills/managed-store.js", () => ({
+  createManagedSkill: () => ({ created: true }),
+  deleteManagedSkill: () => ({ deleted: true }),
+  removeSkillsIndexEntry: () => {},
+  validateManagedSkillId: () => null,
+}));
+
+mock.module("../memory/graph/capability-seed.js", () => ({
+  deleteSkillCapabilityNode: () => {},
+  seedSkillGraphNodes: () => {},
+  seedUninstalledCatalogSkillMemories: async () => {},
+}));
+
+mock.module("../util/platform.js", () => ({
+  getWorkspaceSkillsDir: () => "/tmp/test-skills",
+}));
+
+mock.module("../daemon/handlers/shared.js", () => ({
+  CONFIG_RELOAD_DEBOUNCE_MS: 100,
+  ensureSkillEntry: () => ({}),
+  log: {
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  },
+}));
+
+// Import after mocking
+import { getSkill } from "../daemon/handlers/skills.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const dummyCtx = {
+  debounceTimers: { schedule: () => {} },
+  setSuppressConfigReload: () => {},
+  updateConfigFingerprint: () => {},
+  broadcast: () => {},
+} as unknown as Parameters<typeof getSkill>[1];
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("getSkill — skillssh audit enrichment", () => {
+  beforeEach(() => {
+    mockResolveSkillStates.mockReset();
+    mockReadInstallMeta.mockReset();
+    mockFetchSkillAudits.mockReset();
+
+    // Default: no skills resolved
+    mockResolveSkillStates.mockReturnValue([]);
+    mockReadInstallMeta.mockReturnValue(null);
+    mockFetchSkillAudits.mockResolvedValue({});
+  });
+
+  test("enriches skillssh skill detail with audit data on success", async () => {
+    // Set up a skillssh installed skill
+    mockResolveSkillStates.mockReturnValue([
+      {
+        summary: {
+          id: "acme/tools/lint",
+          displayName: "Lint",
+          description: "A lint skill",
+          source: "extra" as const,
+          directoryPath: "/tmp/test-skills/lint",
+        },
+        state: "enabled" as const,
+      },
+    ]);
+
+    // Return skillssh origin from install-meta
+    mockReadInstallMeta.mockReturnValue({
+      origin: "skillssh",
+      slug: "acme/tools/lint",
+      sourceRepo: "acme/tools",
+    });
+
+    // fetchSkillAudits returns audit data keyed by skill slug
+    mockFetchSkillAudits.mockResolvedValue({
+      lint: {
+        ath: { risk: "safe", score: 100, analyzedAt: "2025-06-01T00:00:00Z" },
+        socket: {
+          risk: "low",
+          alerts: 1,
+          analyzedAt: "2025-06-01T00:00:00Z",
+        },
+      },
+    });
+
+    const result = await getSkill("acme/tools/lint", dummyCtx);
+
+    // Should succeed
+    expect("skill" in result).toBe(true);
+    if (!("skill" in result)) throw new Error("Expected skill response");
+
+    const detail = result.skill;
+    expect(detail.origin).toBe("skillssh");
+    expect(detail.id).toBe("acme/tools/lint");
+    expect(detail.name).toBe("Lint");
+
+    // Verify audit data is attached
+    if (detail.origin === "skillssh") {
+      expect(detail.audit).toBeDefined();
+      expect(detail.audit!.ath).toEqual({
+        risk: "safe",
+        score: 100,
+        analyzedAt: "2025-06-01T00:00:00Z",
+      });
+      expect(detail.audit!.socket).toEqual({
+        risk: "low",
+        alerts: 1,
+        analyzedAt: "2025-06-01T00:00:00Z",
+      });
+    }
+
+    // Verify fetchSkillAudits was called with the correct source repo and slug
+    expect(mockFetchSkillAudits).toHaveBeenCalledTimes(1);
+    expect(mockFetchSkillAudits).toHaveBeenCalledWith("acme/tools", ["lint"]);
+  });
+
+  test("returns detail without audit data when fetchSkillAudits throws", async () => {
+    // Set up a skillssh installed skill
+    mockResolveSkillStates.mockReturnValue([
+      {
+        summary: {
+          id: "org/repo/my-tool",
+          displayName: "My Tool",
+          description: "A community tool",
+          source: "extra" as const,
+          directoryPath: "/tmp/test-skills/my-tool",
+        },
+        state: "enabled" as const,
+      },
+    ]);
+
+    // Return skillssh origin from install-meta
+    mockReadInstallMeta.mockReturnValue({
+      origin: "skillssh",
+      slug: "org/repo/my-tool",
+      sourceRepo: "org/repo",
+    });
+
+    // fetchSkillAudits throws an error
+    mockFetchSkillAudits.mockRejectedValue(
+      new Error("audit service unavailable"),
+    );
+
+    const result = await getSkill("org/repo/my-tool", dummyCtx);
+
+    // Should still succeed — audit failure is non-fatal
+    expect("skill" in result).toBe(true);
+    if (!("skill" in result)) throw new Error("Expected skill response");
+
+    const detail = result.skill;
+    expect(detail.origin).toBe("skillssh");
+    expect(detail.id).toBe("org/repo/my-tool");
+    expect(detail.name).toBe("My Tool");
+
+    // Audit data should not be present
+    if (detail.origin === "skillssh") {
+      expect(detail.audit).toBeUndefined();
+    }
+
+    // fetchSkillAudits was still called (just failed)
+    expect(mockFetchSkillAudits).toHaveBeenCalledTimes(1);
+  });
+});

--- a/assistant/src/__tests__/search-skills-unified.test.ts
+++ b/assistant/src/__tests__/search-skills-unified.test.ts
@@ -43,6 +43,20 @@ const mockSkillsshSearch = mock(
     }>
   > => [],
 );
+const mockFetchSkillAudits = mock(
+  async (
+    _source: string,
+    _skillSlugs: string[],
+  ): Promise<
+    Record<
+      string,
+      Record<
+        string,
+        { risk: string; alerts?: number; score?: number; analyzedAt: string }
+      >
+    >
+  > => ({}),
+);
 
 // ---------------------------------------------------------------------------
 // Mock modules — before importing module under test
@@ -79,6 +93,7 @@ mock.module("../skills/clawhub.js", () => ({
 
 mock.module("../skills/skillssh-registry.js", () => ({
   searchSkillsRegistry: mockSkillsshSearch,
+  fetchSkillAudits: mockFetchSkillAudits,
 }));
 
 // Stub install-meta (needed by the new origin derivation logic)
@@ -166,11 +181,13 @@ describe("searchSkills (unified)", () => {
     mockCatalogSkills.mockReset();
     mockClawhubSearch.mockReset();
     mockSkillsshSearch.mockReset();
+    mockFetchSkillAudits.mockReset();
 
     // Defaults: empty results
     mockCatalogSkills.mockReturnValue([]);
     mockClawhubSearch.mockResolvedValue({ skills: [] });
     mockSkillsshSearch.mockResolvedValue([]);
+    mockFetchSkillAudits.mockResolvedValue({});
   });
 
   test("returns results from all three registries", async () => {
@@ -422,6 +439,102 @@ describe("searchSkills (unified)", () => {
       expect(skill.slug).toBe("org/repo/test-skill");
       expect(skill.sourceRepo).toBe("org/repo");
       expect(skill.installs).toBe(99);
+    }
+  });
+
+  test("attaches audit data to skills.sh results on success", async () => {
+    mockCatalogSkills.mockReturnValue([]);
+    mockClawhubSearch.mockResolvedValue({ skills: [] });
+    mockSkillsshSearch.mockResolvedValue([
+      {
+        id: "acme/tools/lint",
+        skillId: "lint",
+        name: "Lint",
+        installs: 10,
+        source: "acme/tools",
+      },
+      {
+        id: "acme/tools/format",
+        skillId: "format",
+        name: "Format",
+        installs: 20,
+        source: "acme/tools",
+      },
+    ]);
+    mockFetchSkillAudits.mockResolvedValue({
+      lint: {
+        ath: { risk: "safe", score: 100, analyzedAt: "2025-01-01T00:00:00Z" },
+      },
+      format: {
+        socket: {
+          risk: "low",
+          alerts: 2,
+          analyzedAt: "2025-01-02T00:00:00Z",
+        },
+      },
+    });
+
+    const result = await searchSkills("lint", dummyCtx);
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error("Expected success");
+
+    expect(result.skills).toHaveLength(2);
+
+    const lintSkill = result.skills.find((s) => s.id === "acme/tools/lint")!;
+    expect(lintSkill.origin).toBe("skillssh");
+    if (lintSkill.origin === "skillssh") {
+      expect(lintSkill.audit).toBeDefined();
+      expect(lintSkill.audit!.ath).toEqual({
+        risk: "safe",
+        score: 100,
+        analyzedAt: "2025-01-01T00:00:00Z",
+      });
+    }
+
+    const formatSkill = result.skills.find(
+      (s) => s.id === "acme/tools/format",
+    )!;
+    expect(formatSkill.origin).toBe("skillssh");
+    if (formatSkill.origin === "skillssh") {
+      expect(formatSkill.audit).toBeDefined();
+      expect(formatSkill.audit!.socket).toEqual({
+        risk: "low",
+        alerts: 2,
+        analyzedAt: "2025-01-02T00:00:00Z",
+      });
+    }
+
+    // Verify fetchSkillAudits was called with grouped source/slugs
+    expect(mockFetchSkillAudits).toHaveBeenCalledTimes(1);
+    expect(mockFetchSkillAudits).toHaveBeenCalledWith("acme/tools", [
+      "lint",
+      "format",
+    ]);
+  });
+
+  test("search succeeds when fetchSkillAudits throws", async () => {
+    mockCatalogSkills.mockReturnValue([]);
+    mockClawhubSearch.mockResolvedValue({ skills: [] });
+    mockSkillsshSearch.mockResolvedValue([
+      {
+        id: "org/repo/my-skill",
+        skillId: "my-skill",
+        name: "My Skill",
+        installs: 5,
+        source: "org/repo",
+      },
+    ]);
+    mockFetchSkillAudits.mockRejectedValue(new Error("audit service down"));
+
+    const result = await searchSkills("my-skill", dummyCtx);
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error("Expected success");
+
+    expect(result.skills).toHaveLength(1);
+    const skill = result.skills[0]!;
+    expect(skill.origin).toBe("skillssh");
+    if (skill.origin === "skillssh") {
+      expect(skill.audit).toBeUndefined();
     }
   });
 });

--- a/assistant/src/__tests__/search-skills-unified.test.ts
+++ b/assistant/src/__tests__/search-skills-unified.test.ts
@@ -221,6 +221,11 @@ describe("searchSkills (unified)", () => {
     expect(result.skills[1]!.id).toBe("deploy");
     expect(result.skills[1]!.origin).toBe("clawhub");
     expect(result.skills[1]!.kind).toBe("catalog");
+    // Verify version is mapped through from clawhub search results
+    const clawhubSkill = result.skills[1]!;
+    if (clawhubSkill.origin === "clawhub") {
+      expect(clawhubSkill.version).toBe("1.0.0");
+    }
     expect(result.skills[2]!.id).toBe("vercel-labs/skills/react-best");
     expect(result.skills[2]!.origin).toBe("skillssh");
     expect(result.skills[2]!.kind).toBe("catalog");

--- a/assistant/src/__tests__/skills-files-catalog-fallback.test.ts
+++ b/assistant/src/__tests__/skills-files-catalog-fallback.test.ts
@@ -617,6 +617,7 @@ describe("getSkillFiles — provider chain fallback", () => {
         stars: 5,
         installs: 10,
         reports: 0,
+        version: "",
       }),
     };
 
@@ -710,6 +711,7 @@ describe("getSkillFiles — provider chain fallback", () => {
         stars: 0,
         installs: 0,
         reports: 0,
+        version: "",
       }),
     };
 

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -488,6 +488,22 @@ export async function getSkill(
       // Commit to this provider — don't fall through to subsequent providers.
       const slim = await provider.toSlimSkill(skillId);
       if (slim) {
+        // Enrich uninstalled skills.sh skills with audit data (non-fatal)
+        if (slim.origin === "skillssh") {
+          try {
+            const sourceRepo = slim.sourceRepo;
+            const skillSlug = slim.slug.split("/").pop() ?? slim.slug;
+            const audits = await fetchSkillAudits(sourceRepo, [skillSlug]);
+            if (audits[skillSlug]) {
+              (slim as { audit?: SkillAuditData }).audit = audits[skillSlug];
+            }
+          } catch (err) {
+            log.warn(
+              { err, skillId },
+              "Failed to enrich uninstalled skillssh skill with audit data",
+            );
+          }
+        }
         return { skill: slim as SkillDetailResponse };
       }
       return { error: `Skill "${skillId}" not found`, status: 404 };

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -72,9 +72,11 @@ import {
 import type { SkillFileProvider } from "../../skills/skill-file-provider.js";
 import { createSkillsShProvider } from "../../skills/skillssh-files.js";
 import {
+  fetchSkillAudits,
   installExternalSkill,
   resolveSkillSource,
   searchSkillsRegistry,
+  type SkillAuditData,
 } from "../../skills/skillssh-registry.js";
 import { getWorkspaceSkillsDir } from "../../util/platform.js";
 import type {
@@ -1214,6 +1216,50 @@ export async function searchSkills(
         sourceRepo: r.source,
         installs: r.installs,
       }));
+
+      // Batch-fetch audit data for skills.sh results, grouped by source repo.
+      try {
+        if (skillsshResult.value.length > 0) {
+          const sourceToSlugs = new Map<string, string[]>();
+          for (const r of skillsshResult.value) {
+            const slugs = sourceToSlugs.get(r.source) ?? [];
+            slugs.push(r.skillId);
+            sourceToSlugs.set(r.source, slugs);
+          }
+
+          const auditResults = await Promise.allSettled(
+            [...sourceToSlugs.entries()].map(([source, slugs]) =>
+              fetchSkillAudits(source, slugs).then((audits) => ({
+                source,
+                audits,
+              })),
+            ),
+          );
+
+          // Build a lookup map keyed by full skill ID (e.g. "owner/repo/skill-name")
+          const auditMap = new Map<string, SkillAuditData>();
+          for (const result of auditResults) {
+            if (result.status !== "fulfilled") continue;
+            const { source, audits } = result.value;
+            for (const [skillSlug, auditData] of Object.entries(audits)) {
+              auditMap.set(`${source}/${skillSlug}`, auditData);
+            }
+          }
+
+          // Enrich each skills.sh skill with audit data
+          skillsshSkills = skillsshSkills.map((skill) => {
+            if (skill.origin !== "skillssh") return skill;
+            const audit = auditMap.get(skill.id);
+            if (!audit) return skill;
+            return { ...skill, audit };
+          });
+        }
+      } catch (err) {
+        log.warn(
+          { err },
+          "Audit fetch failed for skills.sh results, continuing without audit data",
+        );
+      }
     } else {
       log.warn(
         { err: skillsshResult.reason },

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -551,9 +551,8 @@ export async function getSkill(
     };
     // Enrich with audit data (non-fatal on failure)
     try {
-      const source = resolveSkillSource(slim.slug);
-      const sourceRepo = `${source.owner}/${source.repo}`;
-      const skillSlug = source.skillSlug;
+      const sourceRepo = slim.sourceRepo;
+      const skillSlug = slim.slug.split("/").pop() ?? slim.slug;
       const audits = await fetchSkillAudits(sourceRepo, [skillSlug]);
       if (audits[skillSlug]) {
         (detail as { audit?: SkillAuditData }).audit = audits[skillSlug];

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -549,6 +549,21 @@ export async function getSkill(
       sourceRepo: slim.sourceRepo,
       installs: slim.installs,
     };
+    // Enrich with audit data (non-fatal on failure)
+    try {
+      const source = resolveSkillSource(slim.slug);
+      const sourceRepo = `${source.owner}/${source.repo}`;
+      const skillSlug = source.skillSlug;
+      const audits = await fetchSkillAudits(sourceRepo, [skillSlug]);
+      if (audits[skillSlug]) {
+        (detail as { audit?: SkillAuditData }).audit = audits[skillSlug];
+      }
+    } catch (err) {
+      log.warn(
+        { err, skillId },
+        "Failed to enrich skillssh skill detail with audit data",
+      );
+    }
     return { skill: detail };
   }
 

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -385,6 +385,7 @@ function toSlimSkillResponse(
         stars: 0,
         installs: 0,
         reports: 0,
+        version: "",
       };
     }
     case "skillssh": {
@@ -1191,6 +1192,7 @@ export async function searchSkills(
         publishedAt: s.createdAt
           ? new Date(s.createdAt * 1000).toISOString()
           : undefined,
+        version: s.version,
       }));
     } else {
       log.warn(

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -515,6 +515,7 @@ export async function getSkill(
       installs: slim.installs,
       reports: slim.reports,
       publishedAt: slim.publishedAt,
+      version: slim.version,
     };
     try {
       const inspectResult = await clawhubInspect(slim.slug);

--- a/assistant/src/daemon/message-types/skills.ts
+++ b/assistant/src/daemon/message-types/skills.ts
@@ -98,6 +98,7 @@ interface ClawhubSlimSkill extends SlimSkillBase {
   installs: number;
   reports: number;
   publishedAt?: string;
+  version: string;
 }
 
 interface SkillsshSlimSkill extends SlimSkillBase {

--- a/assistant/src/daemon/message-types/skills.ts
+++ b/assistant/src/daemon/message-types/skills.ts
@@ -1,5 +1,10 @@
 // Skill management types.
 
+import type { PartnerAudit } from "../../skills/skillssh-registry.js";
+
+// Re-export so consumers can access the audit types from this module.
+export type { PartnerAudit } from "../../skills/skillssh-registry.js";
+
 // === Client → Server ===
 
 export interface SkillsListRequest {
@@ -106,6 +111,7 @@ interface SkillsshSlimSkill extends SlimSkillBase {
   slug: string;
   sourceRepo: string;
   installs: number;
+  audit?: Record<string, PartnerAudit>;
 }
 
 interface CustomSlimSkill extends SlimSkillBase {

--- a/assistant/src/daemon/message-types/skills.ts
+++ b/assistant/src/daemon/message-types/skills.ts
@@ -166,6 +166,7 @@ interface ClawhubSkillDetail extends SkillDetailBase {
   installs: number;
   reports: number;
   publishedAt?: string;
+  version: string;
   // Enrichment fields (from clawhubInspect):
   owner?: { handle: string; displayName: string; image?: string } | null;
   stats?: {

--- a/assistant/src/daemon/message-types/skills.ts
+++ b/assistant/src/daemon/message-types/skills.ts
@@ -184,6 +184,7 @@ interface SkillsshSkillDetail extends SkillDetailBase {
   slug: string;
   sourceRepo: string;
   installs: number;
+  audit?: Record<string, PartnerAudit>;
 }
 
 interface CustomSkillDetail extends SkillDetailBase {

--- a/assistant/src/runtime/routes/skills-routes.ts
+++ b/assistant/src/runtime/routes/skills-routes.ts
@@ -40,6 +40,13 @@ export interface SkillRouteDeps {
   getSkillContext: () => SkillOperationContext;
 }
 
+const partnerAuditSchema = z.object({
+  risk: z.enum(["safe", "low", "medium", "high", "critical", "unknown"]),
+  alerts: z.number().optional(),
+  score: z.number().optional(),
+  analyzedAt: z.string(),
+});
+
 const slimSkillBase = {
   id: z.string(),
   name: z.string(),
@@ -68,6 +75,7 @@ const slimSkillSchema = z.discriminatedUnion("origin", [
     slug: z.string(),
     sourceRepo: z.string(),
     installs: z.number(),
+    audit: z.record(z.string(), partnerAuditSchema).optional(),
   }),
   z.object({ ...slimSkillBase, origin: z.literal("custom") }),
 ]);

--- a/assistant/src/runtime/routes/skills-routes.ts
+++ b/assistant/src/runtime/routes/skills-routes.ts
@@ -91,6 +91,7 @@ const skillDetailSchema = z.discriminatedUnion("origin", [
     installs: z.number(),
     reports: z.number(),
     publishedAt: z.string().optional(),
+    version: z.string(),
     owner: z
       .object({
         handle: z.string(),

--- a/assistant/src/runtime/routes/skills-routes.ts
+++ b/assistant/src/runtime/routes/skills-routes.ts
@@ -124,6 +124,7 @@ const skillDetailSchema = z.discriminatedUnion("origin", [
     slug: z.string(),
     sourceRepo: z.string(),
     installs: z.number(),
+    audit: z.record(z.string(), partnerAuditSchema).optional(),
   }),
   z.object({ ...slimSkillBase, origin: z.literal("custom") }),
 ]);

--- a/assistant/src/runtime/routes/skills-routes.ts
+++ b/assistant/src/runtime/routes/skills-routes.ts
@@ -60,6 +60,7 @@ const slimSkillSchema = z.discriminatedUnion("origin", [
     installs: z.number(),
     reports: z.number(),
     publishedAt: z.string().optional(),
+    version: z.string(),
   }),
   z.object({
     ...slimSkillBase,

--- a/assistant/src/skills/clawhub-files.ts
+++ b/assistant/src/skills/clawhub-files.ts
@@ -206,6 +206,7 @@ export function createClawhubProvider(): SkillFileProvider {
         publishedAt: data.updatedAt
           ? new Date(data.updatedAt).toISOString()
           : undefined,
+        version: data.latestVersion?.version ?? "",
       };
     },
   };

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -4042,6 +4042,21 @@ public struct SkillsListResponse: Codable, Sendable {
     }
 }
 
+/// Security audit result from a partner analysis provider.
+public struct PartnerAudit: Codable, Sendable, Equatable {
+    public let risk: String
+    public let alerts: Int?
+    public let score: Double?
+    public let analyzedAt: String
+
+    public init(risk: String, alerts: Int? = nil, score: Double? = nil, analyzedAt: String) {
+        self.risk = risk
+        self.alerts = alerts
+        self.score = score
+        self.analyzedAt = analyzedAt
+    }
+}
+
 public struct SkillsListResponseSkill: Codable, Sendable {
     public let id: String
     public let name: String
@@ -4058,10 +4073,12 @@ public struct SkillsListResponseSkill: Codable, Sendable {
     public let stars: Int?
     public let reports: Int?
     public let publishedAt: String?
+    public let version: String?
     // Skillssh-only:
     public let sourceRepo: String?
+    public let audit: [String: PartnerAudit]?
 
-    public init(id: String, name: String, description: String, emoji: String? = nil, kind: String, origin: String, status: String, slug: String? = nil, installs: Int? = nil, author: String? = nil, stars: Int? = nil, reports: Int? = nil, publishedAt: String? = nil, sourceRepo: String? = nil) {
+    public init(id: String, name: String, description: String, emoji: String? = nil, kind: String, origin: String, status: String, slug: String? = nil, installs: Int? = nil, author: String? = nil, stars: Int? = nil, reports: Int? = nil, publishedAt: String? = nil, version: String? = nil, sourceRepo: String? = nil, audit: [String: PartnerAudit]? = nil) {
         self.id = id
         self.name = name
         self.description = description
@@ -4075,7 +4092,9 @@ public struct SkillsListResponseSkill: Codable, Sendable {
         self.stars = stars
         self.reports = reports
         self.publishedAt = publishedAt
+        self.version = version
         self.sourceRepo = sourceRepo
+        self.audit = audit
     }
 }
 
@@ -4135,6 +4154,7 @@ public struct SkillDetailHTTPResponse: Codable, Sendable {
     public let publishedAt: String?
     // Skillssh-only:
     public let sourceRepo: String?
+    public let audit: [String: PartnerAudit]?
     // Clawhub detail enrichment fields:
     public let owner: ClawhubDetailOwner?
     public let stats: ClawhubDetailStats?
@@ -4142,7 +4162,7 @@ public struct SkillDetailHTTPResponse: Codable, Sendable {
     public let createdAt: Int?
     public let updatedAt: Int?
 
-    public init(id: String, name: String, description: String, emoji: String? = nil, kind: String, origin: String, status: String, slug: String? = nil, installs: Int? = nil, author: String? = nil, stars: Int? = nil, reports: Int? = nil, publishedAt: String? = nil, sourceRepo: String? = nil, owner: ClawhubDetailOwner? = nil, stats: ClawhubDetailStats? = nil, latestVersion: ClawhubDetailVersion? = nil, createdAt: Int? = nil, updatedAt: Int? = nil) {
+    public init(id: String, name: String, description: String, emoji: String? = nil, kind: String, origin: String, status: String, slug: String? = nil, installs: Int? = nil, author: String? = nil, stars: Int? = nil, reports: Int? = nil, publishedAt: String? = nil, sourceRepo: String? = nil, audit: [String: PartnerAudit]? = nil, owner: ClawhubDetailOwner? = nil, stats: ClawhubDetailStats? = nil, latestVersion: ClawhubDetailVersion? = nil, createdAt: Int? = nil, updatedAt: Int? = nil) {
         self.id = id
         self.name = name
         self.description = description
@@ -4157,6 +4177,7 @@ public struct SkillDetailHTTPResponse: Codable, Sendable {
         self.reports = reports
         self.publishedAt = publishedAt
         self.sourceRepo = sourceRepo
+        self.audit = audit
         self.owner = owner
         self.stats = stats
         self.latestVersion = latestVersion

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -967,7 +967,7 @@ extension SkillsListResponseSkill: Identifiable {}
 extension SkillsListResponseSkill {
     /// Returns a copy with a different `status`, preserving all other fields including `id`.
     public func withStatus(_ newStatus: String) -> Self {
-        Self(id: id, name: name, description: description, emoji: emoji, kind: kind, origin: origin, status: newStatus, slug: slug, installs: installs, author: author, stars: stars, reports: reports, publishedAt: publishedAt, sourceRepo: sourceRepo)
+        Self(id: id, name: name, description: description, emoji: emoji, kind: kind, origin: origin, status: newStatus, slug: slug, installs: installs, author: author, stars: stars, reports: reports, publishedAt: publishedAt, version: version, sourceRepo: sourceRepo, audit: audit)
     }
 
     /// Whether the skill is available from the catalog but not yet installed.
@@ -1081,6 +1081,7 @@ public struct ClawhubOriginMeta: Codable, Sendable, Equatable {
     public let installs: Int
     public let reports: Int
     public let publishedAt: String?
+    public let version: String?
 }
 
 /// Origin-specific metadata for a skill sourced from Skills.sh.
@@ -1088,6 +1089,7 @@ public struct SkillsshOriginMeta: Codable, Sendable, Equatable {
     public let slug: String
     public let sourceRepo: String
     public let installs: Int
+    public let audit: [String: PartnerAudit]?
 }
 
 /// Discriminated union over the `origin` field of a skill.
@@ -1110,13 +1112,15 @@ extension SkillsListResponseSkill {
                 stars: stars ?? 0,
                 installs: installs ?? 0,
                 reports: reports ?? 0,
-                publishedAt: publishedAt
+                publishedAt: publishedAt,
+                version: version
             ))
         case "skillssh":
             return .skillssh(SkillsshOriginMeta(
                 slug: slug ?? id,
                 sourceRepo: sourceRepo ?? "",
-                installs: installs ?? 0
+                installs: installs ?? 0,
+                audit: audit
             ))
         case "vellum":
             return .vellum
@@ -1137,13 +1141,15 @@ extension SkillDetailHTTPResponse {
                 stars: stars ?? 0,
                 installs: installs ?? 0,
                 reports: reports ?? 0,
-                publishedAt: publishedAt
+                publishedAt: publishedAt,
+                version: latestVersion?.version
             ))
         case "skillssh":
             return .skillssh(SkillsshOriginMeta(
                 slug: slug ?? id,
                 sourceRepo: sourceRepo ?? "",
-                installs: installs ?? 0
+                installs: installs ?? 0,
+                audit: audit
             ))
         case "vellum":
             return .vellum


### PR DESCRIPTION
## Summary
Extends `SlimSkillResponse` and `SkillDetailResponse` to surface all available metadata from clawhub and skills.sh APIs without n+1 lookups on search, and with enrichment on detail views.

## Self-review result
PASS — 4 gaps found and fixed across 4 fix PRs

## PRs merged into feature branch
- #25016: feat(skills): include version in clawhub search results
- #25017: feat(skills): include batched audit data in skills.sh search results
- #25024: feat(skills): include audit data in skills.sh detail endpoint

### Fix PRs
- #25029: fix: use sourceRepo directly for skillssh audit enrichment in detail handler
- #25030: fix: add version to ClawhubSkillDetail and skillDetailSchema
- #25033: fix: update Swift codegen for new version and audit fields
- #25032: test: add tests for skillssh detail handler audit enrichment

Part of plan: enrich-skill-search-metadata.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25034" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
