### PR TITLE
assistant: add provider-catalog-driven telephony stt capability resolver

### DIFF
--- a/assistant/src/providers/speech-to-text/__tests__/resolve.test.ts
+++ b/assistant/src/providers/speech-to-text/__tests__/resolve.test.ts
@@ -41,7 +41,10 @@ mock.module("../../../security/credential-key.js", () => ({
 // Subject import (after mocks)
 // ---------------------------------------------------------------------------
 
-import { resolveBatchTranscriber } from "../resolve.js";
+import {
+  resolveBatchTranscriber,
+  resolveTelephonySttCapability,
+} from "../resolve.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -64,7 +67,7 @@ function buildConfig(overrides: {
 }
 
 // ---------------------------------------------------------------------------
-// Tests
+// Tests — resolveBatchTranscriber
 // ---------------------------------------------------------------------------
 
 describe("resolveBatchTranscriber", () => {
@@ -125,5 +128,78 @@ describe("resolveBatchTranscriber", () => {
     // The providerId must remain "openai-whisper" for downstream identity checks.
     expect(transcriber!.providerId).toBe("openai-whisper");
     expect(transcriber!.boundaryId).toBe("daemon-batch");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — resolveTelephonySttCapability
+// ---------------------------------------------------------------------------
+
+describe("resolveTelephonySttCapability", () => {
+  beforeEach(() => {
+    mockConfig = buildConfig({});
+    mockProviderKeys = {};
+  });
+
+  test("returns 'supported' when provider is telephony-eligible and credentials exist", async () => {
+    mockProviderKeys["openai"] = "sk-telephony-test";
+    mockConfig = buildConfig({ provider: "openai-whisper" });
+
+    const result = await resolveTelephonySttCapability();
+
+    expect(result.status).toBe("supported");
+    if (result.status === "supported") {
+      expect(result.providerId).toBe("openai-whisper");
+      // openai-whisper is batch-only, so telephonyMode should reflect that
+      expect(result.telephonyMode).toBe("batch-only");
+    }
+  });
+
+  test("returns 'unconfigured' when provider is not in the catalog", async () => {
+    mockProviderKeys["unknown-provider"] = "key-doesnt-matter";
+    mockConfig = buildConfig({ provider: "unknown-provider" as string });
+
+    const result = await resolveTelephonySttCapability();
+
+    expect(result.status).toBe("unconfigured");
+    if (result.status === "unconfigured") {
+      expect(result.reason).toContain("unknown-provider");
+      expect(result.reason).toContain("not in the provider catalog");
+    }
+  });
+
+  test("returns 'missing-credentials' when provider is eligible but has no API key", async () => {
+    mockProviderKeys = {}; // no keys
+    mockConfig = buildConfig({ provider: "openai-whisper" });
+
+    const result = await resolveTelephonySttCapability();
+
+    expect(result.status).toBe("missing-credentials");
+    if (result.status === "missing-credentials") {
+      expect(result.providerId).toBe("openai-whisper");
+      expect(result.credentialProvider).toBe("openai");
+      expect(result.reason).toContain("openai");
+    }
+  });
+
+  test("uses config-driven provider, not a hardcoded default", async () => {
+    // Use a provider that IS in the catalog to verify config is read
+    mockProviderKeys["openai"] = "sk-config-test";
+    mockConfig = buildConfig({ provider: "openai-whisper" });
+
+    const result = await resolveTelephonySttCapability();
+
+    expect(result.status).toBe("supported");
+    if (result.status === "supported") {
+      expect(result.providerId).toBe("openai-whisper");
+    }
+  });
+
+  test("returns 'unconfigured' for empty-string provider", async () => {
+    mockConfig = buildConfig({ provider: "" as string });
+
+    const result = await resolveTelephonySttCapability();
+
+    expect(result.status).toBe("unconfigured");
   });
 });

--- a/assistant/src/providers/speech-to-text/provider-catalog.ts
+++ b/assistant/src/providers/speech-to-text/provider-catalog.ts
@@ -1,0 +1,123 @@
+/**
+ * STT provider catalog — single source of truth for provider metadata.
+ *
+ * Every STT provider is described by a {@link SttProviderEntry} that
+ * captures its canonical ID, the credential-provider name used to look up
+ * API keys, supported runtime boundaries, and telephony support mode.
+ *
+ * All other modules that need provider metadata (resolve.ts,
+ * daemon-batch-transcriber.ts, future telephony adapters) read from this
+ * catalog rather than maintaining their own hardcoded maps.
+ */
+
+import type {
+  SttBoundaryId,
+  SttProviderId,
+  TelephonySttMode,
+} from "../../stt/types.js";
+
+// ---------------------------------------------------------------------------
+// Catalog entry
+// ---------------------------------------------------------------------------
+
+/**
+ * Metadata for a single STT provider.
+ */
+export interface SttProviderEntry {
+  /** Canonical provider identifier (must match an {@link SttProviderId} variant). */
+  readonly id: SttProviderId;
+
+  /**
+   * Name of the credential provider used by `getProviderKeyAsync` to
+   * retrieve the API key. Multiple STT providers may share a credential
+   * provider (e.g. a future "openai-realtime" provider would also map to
+   * `"openai"`).
+   */
+  readonly credentialProvider: string;
+
+  /**
+   * Set of runtime boundaries this provider supports. A provider may
+   * support more than one boundary (e.g. both `daemon-batch` and a future
+   * `realtime-ws` boundary).
+   */
+  readonly supportedBoundaries: ReadonlySet<SttBoundaryId>;
+
+  /**
+   * Telephony support mode — describes whether and how the provider can
+   * participate in real-time call ingestion via `services.stt`.
+   */
+  readonly telephonyMode: TelephonySttMode;
+}
+
+// ---------------------------------------------------------------------------
+// Catalog data
+// ---------------------------------------------------------------------------
+
+/**
+ * Provider catalog entries, keyed by provider ID.
+ *
+ * To add a new STT provider:
+ * 1. Add a new variant to `SttProviderId` in `stt/types.ts`.
+ * 2. Add an entry here with the credential mapping and boundary support.
+ * 3. Wire up the adapter in `daemon-batch-transcriber.ts` (and/or a
+ *    future realtime adapter) for the boundaries the provider supports.
+ */
+const CATALOG: ReadonlyMap<SttProviderId, SttProviderEntry> = new Map<
+  SttProviderId,
+  SttProviderEntry
+>([
+  [
+    "openai-whisper",
+    {
+      id: "openai-whisper",
+      credentialProvider: "openai",
+      supportedBoundaries: new Set<SttBoundaryId>(["daemon-batch"]),
+      telephonyMode: "batch-only",
+    },
+  ],
+]);
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Look up a provider entry by its canonical ID.
+ *
+ * Returns `undefined` when the ID is not present in the catalog (e.g. an
+ * unknown runtime value that passed schema validation).
+ */
+export function getProviderEntry(
+  id: SttProviderId,
+): SttProviderEntry | undefined {
+  return CATALOG.get(id);
+}
+
+/**
+ * Return all catalog entries in deterministic (insertion) order.
+ */
+export function listProviderEntries(): readonly SttProviderEntry[] {
+  return [...CATALOG.values()];
+}
+
+/**
+ * Look up the credential-provider name for a given STT provider.
+ *
+ * Convenience wrapper around `getProviderEntry` for callers that only need
+ * the credential mapping. Returns `undefined` when the provider is unknown.
+ */
+export function getCredentialProvider(id: SttProviderId): string | undefined {
+  return CATALOG.get(id)?.credentialProvider;
+}
+
+/**
+ * Check whether a provider supports a specific runtime boundary.
+ *
+ * Returns `false` for unknown provider IDs.
+ */
+export function supportsBoundary(
+  id: SttProviderId,
+  boundary: SttBoundaryId,
+): boolean {
+  return CATALOG.get(id)?.supportedBoundaries.has(boundary) ?? false;
+}

--- a/assistant/src/providers/speech-to-text/resolve.ts
+++ b/assistant/src/providers/speech-to-text/resolve.ts
@@ -2,56 +2,133 @@ import { getConfig } from "../../config/loader.js";
 import { getProviderKeyAsync } from "../../security/secure-keys.js";
 import { createDaemonBatchTranscriber } from "../../stt/daemon-batch-transcriber.js";
 import type { BatchTranscriber, SttProviderId } from "../../stt/types.js";
+import {
+  getCredentialProvider,
+  getProviderEntry,
+  supportsBoundary,
+} from "./provider-catalog.js";
 
 // ---------------------------------------------------------------------------
-// Provider-to-credential mapping
-// ---------------------------------------------------------------------------
-
-/**
- * Map an STT provider identifier to the credential provider name used by
- * `getProviderKeyAsync`. New STT providers that share credentials with an
- * existing credential provider (e.g. a future Deepgram provider would map
- * to `"deepgram"`) add an entry here.
- *
- * Typed as `Record<SttProviderId, string>` to ensure compile-time
- * completeness: adding a new variant to `SttProviderId` without a
- * corresponding entry here is a type error.
- */
-const STT_PROVIDER_CREDENTIAL_MAP: Record<SttProviderId, string> = {
-  "openai-whisper": "openai",
-};
-
-// ---------------------------------------------------------------------------
-// Public API
+// Batch transcriber resolver (existing public API — unchanged contract)
 // ---------------------------------------------------------------------------
 
 /**
  * Resolve a `BatchTranscriber` for daemon-hosted batch transcription.
  *
  * Reads `services.stt.provider` from the assistant config to determine which
- * STT provider to use, then looks up the corresponding credential. Credential
- * lookup is centralized here (an authorized secure-keys importer) so callers
- * don't need to import secure-keys directly.
+ * STT provider to use, then looks up the corresponding credential via the
+ * provider catalog. Credential lookup is centralized here (an authorized
+ * secure-keys importer) so callers don't need to import secure-keys directly.
  *
  * Returns `null` when:
- * - The configured provider is not supported by the daemon-batch boundary.
+ * - The configured provider is not in the catalog.
+ * - The configured provider doesn't support the `daemon-batch` boundary.
  * - No credentials are configured for the resolved provider.
  */
 export async function resolveBatchTranscriber(): Promise<BatchTranscriber | null> {
   const config = getConfig();
   const provider = config.services.stt.provider;
 
-  // Resolve the credential provider name for the configured STT provider.
-  // Cast to `string` for the lookup so that unknown providers (which can
-  // arrive at runtime despite the schema validation) produce `undefined`
-  // instead of a type error. This keeps the runtime guard meaningful.
-  const credentialProvider = STT_PROVIDER_CREDENTIAL_MAP[
-    provider as SttProviderId
-  ] as string | undefined;
-  if (!credentialProvider) {
+  // Look up credential provider via the catalog.
+  const credentialProviderName = getCredentialProvider(
+    provider as SttProviderId,
+  );
+  if (!credentialProviderName) {
     return null;
   }
 
-  const apiKey = await getProviderKeyAsync(credentialProvider);
+  // Verify the provider supports the daemon-batch boundary.
+  if (!supportsBoundary(provider as SttProviderId, "daemon-batch")) {
+    return null;
+  }
+
+  const apiKey = await getProviderKeyAsync(credentialProviderName);
   return createDaemonBatchTranscriber(apiKey);
+}
+
+// ---------------------------------------------------------------------------
+// Telephony capability resolver
+// ---------------------------------------------------------------------------
+
+/**
+ * Result of resolving whether the configured `services.stt` provider is
+ * eligible for telephony call ingestion.
+ */
+export type TelephonySttCapability =
+  | {
+      /** The configured provider supports telephony. */
+      status: "supported";
+      providerId: SttProviderId;
+      /** How the provider participates in real-time call ingestion. */
+      telephonyMode: "realtime-ws" | "batch-only";
+    }
+  | {
+      /** The configured provider does not support telephony. */
+      status: "unsupported";
+      providerId: SttProviderId;
+      reason: string;
+    }
+  | {
+      /** The configured provider is unknown or not in the catalog. */
+      status: "unconfigured";
+      reason: string;
+    }
+  | {
+      /** The provider is eligible but missing credentials. */
+      status: "missing-credentials";
+      providerId: SttProviderId;
+      credentialProvider: string;
+      reason: string;
+    };
+
+/**
+ * Validate whether the configured `services.stt` provider is eligible for
+ * future real-time telephony call ingestion.
+ *
+ * This resolver does **not** create a live transcriber — it only validates
+ * that the configuration, catalog entry, and credentials are all in order.
+ * The actual wiring is deferred to a future media-stream call adapter PR.
+ *
+ * Callers can branch on the discriminated `status` field:
+ * - `"supported"` — the provider is telephony-eligible and credentials exist.
+ * - `"unsupported"` — the provider exists but has `telephonyMode: "none"`.
+ * - `"unconfigured"` — the provider is unknown or missing from the catalog.
+ * - `"missing-credentials"` — the provider is eligible but has no API key.
+ */
+export async function resolveTelephonySttCapability(): Promise<TelephonySttCapability> {
+  const config = getConfig();
+  const provider = config.services.stt.provider;
+
+  const entry = getProviderEntry(provider as SttProviderId);
+  if (!entry) {
+    return {
+      status: "unconfigured",
+      reason: `STT provider "${provider}" is not in the provider catalog`,
+    };
+  }
+
+  if (entry.telephonyMode === "none") {
+    return {
+      status: "unsupported",
+      providerId: entry.id,
+      reason: `STT provider "${entry.id}" does not support telephony`,
+    };
+  }
+
+  // Provider is telephony-eligible — verify credentials exist.
+  const apiKey = await getProviderKeyAsync(entry.credentialProvider);
+  if (!apiKey) {
+    return {
+      status: "missing-credentials",
+      providerId: entry.id,
+      credentialProvider: entry.credentialProvider,
+      reason: `No API key configured for credential provider "${entry.credentialProvider}"`,
+    };
+  }
+
+  return {
+    status: "supported",
+    providerId: entry.id,
+    telephonyMode: entry.telephonyMode,
+  };
 }

--- a/assistant/src/stt/types.ts
+++ b/assistant/src/stt/types.ts
@@ -17,6 +17,22 @@
  */
 export type SttProviderId = "openai-whisper";
 
+/**
+ * Telephony-specific STT support mode.
+ *
+ * Describes how a provider can participate in real-time telephony call
+ * ingestion when wired through `services.stt` (as opposed to the
+ * ConversationRelay-native STT path in `calls.voice.transcriptionProvider`).
+ *
+ * - `"realtime-ws"` — provider offers a WebSocket streaming endpoint suitable
+ *   for low-latency telephony audio. Future PRs will wire this into the
+ *   media-stream call adapter.
+ * - `"batch-only"` — provider supports only REST batch transcription; not
+ *   suitable for real-time telephony.
+ * - `"none"` — provider has no telephony support.
+ */
+export type TelephonySttMode = "realtime-ws" | "batch-only" | "none";
+
 // ---------------------------------------------------------------------------
 // Boundary identifier
 // ---------------------------------------------------------------------------
@@ -27,6 +43,28 @@ export type SttProviderId = "openai-whisper";
  *   call to the provider (e.g. OpenAI Whisper).
  */
 export type SttBoundaryId = "daemon-batch";
+
+// ---------------------------------------------------------------------------
+// Call-context hints
+// ---------------------------------------------------------------------------
+
+/**
+ * Optional metadata hints that a caller can supply when the transcription
+ * originates from a phone-call context. These are advisory — providers may
+ * ignore hints they do not support.
+ *
+ * This type is intentionally separate from the batch request so that
+ * call-context awareness can be added incrementally without changing the
+ * shape for non-call callers.
+ */
+export interface SttCallContextHints {
+  /** BCP-47 language code for the expected speech (e.g. "en-US"). */
+  language?: string;
+  /** Static vocabulary hints (proper nouns, domain terms) the ASR should prioritize. */
+  vocabularyHints?: string[];
+  /** Short natural-language prompt to bias the transcription model. */
+  prompt?: string;
+}
 
 // ---------------------------------------------------------------------------
 // Request / result
@@ -40,6 +78,12 @@ export interface SttTranscribeRequest {
   mimeType: string;
   /** Optional abort signal for cancellation / timeout. */
   signal?: AbortSignal;
+  /**
+   * Optional call-context hints. Present when the transcription request
+   * originates from a telephony call. Providers may use these to improve
+   * recognition accuracy.
+   */
+  callContext?: SttCallContextHints;
 }
 
 /** Successful transcription output. */


### PR DESCRIPTION
## Summary
- Introduce centralized STT provider catalog as single source of truth for provider metadata
- Add telephony-facing STT capability resolver with full validation
- Extend STT request typing for optional call-context hints

Part of plan: twilio-services-stt-provider-unification.md (PR 1 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25035" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
