### PR TITLE
gateway+assistant: add twilio media-stream websocket ingress plumbing (inactive)

### DIFF
--- a/assistant/src/__tests__/gateway-only-enforcement.test.ts
+++ b/assistant/src/__tests__/gateway-only-enforcement.test.ts
@@ -455,6 +455,86 @@ describe("gateway-only ingress enforcement", () => {
     });
   });
 
+  // ── Media-stream WebSocket upgrade ─────────────────────────────────
+
+  describe("media-stream WebSocket upgrade", () => {
+    test("blocks non-private-network origin", async () => {
+      // The peer address (127.0.0.1) passes the private network check,
+      // but the external Origin header triggers the secondary defense-in-depth block.
+      const res = await fetch(
+        `http://127.0.0.1:${port}/v1/calls/media-stream?callSessionId=sess-123`,
+        {
+          headers: {
+            Upgrade: "websocket",
+            Connection: "Upgrade",
+            Origin: "https://external.example.com",
+            "Sec-WebSocket-Key": "dGhlIHNhbXBsZSBub25jZQ==",
+            "Sec-WebSocket-Version": "13",
+          },
+        },
+      );
+      expect(res.status).toBe(403);
+      const body = (await res.json()) as {
+        error: { code: string; message: string };
+      };
+      expect(body.error.code).toBe("FORBIDDEN");
+      expect(body.error.message).toContain(
+        "Direct media-stream access disabled",
+      );
+    });
+
+    test("allows request with no origin header (private network peer)", async () => {
+      // Without an origin header, isPrivateNetworkOrigin returns true.
+      // The peer address (127.0.0.1) passes the private network peer check.
+      const res = await fetch(
+        `http://127.0.0.1:${port}/v1/calls/media-stream?callSessionId=sess-123`,
+        {
+          headers: {
+            Upgrade: "websocket",
+            Connection: "Upgrade",
+            "Sec-WebSocket-Key": "dGhlIHNhbXBsZSBub25jZQ==",
+            "Sec-WebSocket-Version": "13",
+          },
+        },
+      );
+      // Should NOT be 403 — WebSocket upgrade may or may not succeed
+      // depending on test environment, but the gateway guard should pass.
+      expect(res.status).not.toBe(403);
+    });
+
+    test("allows localhost origin from loopback peer", async () => {
+      const res = await fetch(
+        `http://127.0.0.1:${port}/v1/calls/media-stream?callSessionId=sess-123`,
+        {
+          headers: {
+            Upgrade: "websocket",
+            Connection: "Upgrade",
+            Origin: "http://127.0.0.1:3000",
+            "Sec-WebSocket-Key": "dGhlIHNhbXBsZSBub25jZQ==",
+            "Sec-WebSocket-Version": "13",
+          },
+        },
+      );
+      // Should NOT be 403
+      expect(res.status).not.toBe(403);
+    });
+
+    test("returns 400 when callSessionId is missing", async () => {
+      const res = await fetch(
+        `http://127.0.0.1:${port}/v1/calls/media-stream`,
+        {
+          headers: {
+            Upgrade: "websocket",
+            Connection: "Upgrade",
+            "Sec-WebSocket-Key": "dGhlIHNhbXBsZSBub25jZQ==",
+            "Sec-WebSocket-Version": "13",
+          },
+        },
+      );
+      expect(res.status).toBe(400);
+    });
+  });
+
   // ── isPrivateAddress unit tests ─────────────────────────────────────
 
   describe("isPrivateAddress", () => {

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -780,6 +780,15 @@ export class RuntimeHttpServer {
       return this.handleRelayUpgrade(req, server);
     }
 
+    // WebSocket upgrade for Twilio Media Streams — same private-network
+    // restrictions as relay upgrades.
+    if (
+      path.startsWith("/v1/calls/media-stream") &&
+      req.headers.get("upgrade")?.toLowerCase() === "websocket"
+    ) {
+      return this.handleMediaStreamUpgrade(req, server);
+    }
+
     // Twilio webhook endpoints — before auth check because Twilio
     // webhook POSTs don't include bearer tokens.
     const twilioResponse = await this.handleTwilioWebhook(req, path);
@@ -1061,6 +1070,33 @@ export class RuntimeHttpServer {
     if (!callSessionId) {
       return new Response("Missing callSessionId", { status: 400 });
     }
+    const upgraded = server.upgrade(req, { data: { callSessionId } });
+    if (!upgraded) {
+      return new Response("WebSocket upgrade failed", { status: 500 });
+    }
+    // Bun's WebSocket upgrade consumes the request — no Response is sent.
+    return undefined!;
+  }
+
+  private handleMediaStreamUpgrade(
+    req: Request,
+    server: ReturnType<typeof Bun.serve>,
+  ): Response {
+    if (!isPrivateNetworkPeer(server, req) || !isPrivateNetworkOrigin(req)) {
+      return httpError(
+        "FORBIDDEN",
+        "Direct media-stream access disabled — only private network peers allowed",
+        403,
+      );
+    }
+
+    const wsUrl = new URL(req.url);
+    const callSessionId = wsUrl.searchParams.get("callSessionId");
+    if (!callSessionId) {
+      return new Response("Missing callSessionId", { status: 400 });
+    }
+    // Media-stream connections use the same data shape as relay for now.
+    // The callSessionId links the stream to the active call session.
     const upgraded = server.upgrade(req, { data: { callSessionId } });
     if (!upgraded) {
       return new Response("WebSocket upgrade failed", { status: 500 });

--- a/gateway/src/__tests__/schema.test.ts
+++ b/gateway/src/__tests__/schema.test.ts
@@ -61,6 +61,7 @@ describe("/schema route", () => {
     expect(body.paths["/webhooks/twilio/status"]).toBeDefined();
     expect(body.paths["/webhooks/twilio/connect-action"]).toBeDefined();
     expect(body.paths["/webhooks/twilio/relay"]).toBeDefined();
+    expect(body.paths["/webhooks/twilio/media-stream"]).toBeDefined();
     expect(body.paths["/webhooks/oauth/callback"]).toBeDefined();
     expect(body.paths["/v1/integrations/telegram/config"]).toBeDefined();
     expect(body.paths["/v1/integrations/telegram/commands"]).toBeDefined();

--- a/gateway/src/__tests__/twilio-media-websocket.test.ts
+++ b/gateway/src/__tests__/twilio-media-websocket.test.ts
@@ -1,0 +1,525 @@
+import { describe, test, expect, mock, beforeEach, afterAll } from "bun:test";
+import type { GatewayConfig } from "../config.js";
+import { initSigningKey, mintToken } from "../auth/token-service.js";
+import { CURRENT_POLICY_EPOCH } from "../auth/policy.js";
+import {
+  createTwilioMediaWebsocketHandler,
+  getMediaStreamWebsocketHandlers,
+} from "../http/routes/twilio-media-websocket.js";
+
+// ---------------------------------------------------------------------------
+// Auth setup — initialize signing key so JWT minting/validation works
+// ---------------------------------------------------------------------------
+
+const TEST_SIGNING_KEY = Buffer.from("test-signing-key-at-least-32-bytes-long");
+initSigningKey(TEST_SIGNING_KEY);
+
+/** Mint a valid edge JWT (aud=vellum-gateway) for test requests. */
+function mintEdgeToken(): string {
+  return mintToken({
+    aud: "vellum-gateway",
+    sub: "svc:gateway:self",
+    scope_profile: "gateway_service_v1",
+    policy_epoch: CURRENT_POLICY_EPOCH,
+    ttlSeconds: 300,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Preserve WebSocket readyState constants so mocking the constructor
+// does not clobber the static values the source code compares against.
+// ---------------------------------------------------------------------------
+const WS_CONNECTING = WebSocket.CONNECTING; // 0
+const WS_OPEN = WebSocket.OPEN; // 1
+const WS_CLOSED = WebSocket.CLOSED; // 3
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
+  const merged: GatewayConfig = {
+    assistantRuntimeBaseUrl: "http://localhost:7821",
+    routingEntries: [],
+    defaultAssistantId: undefined,
+    unmappedPolicy: "reject",
+    port: 7830,
+    runtimeProxyEnabled: false,
+    runtimeProxyRequireAuth: true,
+    shutdownDrainMs: 5000,
+    runtimeTimeoutMs: 30000,
+    runtimeMaxRetries: 2,
+    runtimeInitialBackoffMs: 500,
+    maxWebhookPayloadBytes: 1048576,
+    logFile: { dir: undefined, retentionDays: 30 },
+    maxAttachmentBytes: {
+      telegram: 50 * 1024 * 1024,
+      slack: 100 * 1024 * 1024,
+      whatsapp: 16 * 1024 * 1024,
+      default: 50 * 1024 * 1024,
+    },
+    maxAttachmentConcurrency: 3,
+    gatewayInternalBaseUrl: "http://127.0.0.1:7830",
+    trustProxy: false,
+    ...overrides,
+  };
+  return merged;
+}
+
+/**
+ * Lightweight fake that mimics a Bun ServerWebSocket for the media-stream handler.
+ * Tracks sent messages, close calls, and exposes `.data` for handler use.
+ */
+function createFakeDownstreamWs(data: Record<string, unknown> = {}) {
+  const sent: (string | Uint8Array)[] = [];
+  const closes: { code: number; reason: string }[] = [];
+  return {
+    data,
+    sent,
+    closes,
+    send: mock((msg: string | Uint8Array) => {
+      sent.push(msg);
+    }),
+    close: mock((code?: number, reason?: string) => {
+      closes.push({ code: code ?? 1000, reason: reason ?? "" });
+    }),
+  };
+}
+
+/**
+ * Minimal fake WebSocket that stores addEventListener listeners so tests
+ * can fire events synchronously, and tracks send / close calls.
+ */
+function createFakeUpstreamWs() {
+  const listeners: Record<string, ((...args: unknown[]) => void)[]> = {};
+  const sent: unknown[] = [];
+  const closes: { code?: number; reason?: string }[] = [];
+  return {
+    readyState: WS_CONNECTING as number,
+    sent,
+    closes,
+    listeners,
+    addEventListener: mock(
+      (event: string, cb: (...args: unknown[]) => void) => {
+        (listeners[event] ??= []).push(cb);
+      },
+    ),
+    send: mock((msg: unknown) => {
+      sent.push(msg);
+    }),
+    close: mock((code?: number, reason?: string) => {
+      closes.push({ code, reason });
+    }),
+    /** Simulate firing an event on this fake socket. */
+    emit(event: string, detail: unknown = {}) {
+      for (const cb of listeners[event] ?? []) {
+        cb(detail);
+      }
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Upgrade handler tests
+// ---------------------------------------------------------------------------
+
+describe("createTwilioMediaWebsocketHandler", () => {
+  const TEST_TOKEN = mintEdgeToken();
+
+  test("returns 400 when callSessionId is missing", () => {
+    const handler = createTwilioMediaWebsocketHandler(makeConfig());
+    const req = new Request("http://localhost:7830/ws/twilio/media-stream");
+    const fakeServer = {
+      upgrade: mock(() => true),
+    } as unknown as import("bun").Server<any>;
+    const res = handler(req, fakeServer);
+
+    expect(res).toBeInstanceOf(Response);
+    expect(res!.status).toBe(400);
+    expect(fakeServer.upgrade).not.toHaveBeenCalled();
+  });
+
+  test("calls server.upgrade with callSessionId and config on valid request with query token", () => {
+    const config = makeConfig({});
+    const handler = createTwilioMediaWebsocketHandler(config);
+    const req = new Request(
+      `http://localhost:7830/ws/twilio/media-stream?callSessionId=sess-42&token=${TEST_TOKEN}`,
+    );
+    const fakeServer = {
+      upgrade: mock(() => true),
+    } as unknown as import("bun").Server<any>;
+    const res = handler(req, fakeServer);
+
+    expect(res).toBeUndefined();
+    expect(fakeServer.upgrade).toHaveBeenCalledTimes(1);
+
+    const call = (fakeServer.upgrade as ReturnType<typeof mock>).mock
+      .calls[0] as unknown[];
+    // First arg is the request, second is { data: ... }
+    expect(call[0]).toBe(req);
+    const upgradeData = (
+      call[1] as {
+        data: {
+          wsType: string;
+          callSessionId: string;
+          assistantRuntimeBaseUrl: string;
+        };
+      }
+    ).data;
+    expect(upgradeData.wsType).toBe("twilio-media-stream");
+    expect(upgradeData.callSessionId).toBe("sess-42");
+    expect(upgradeData.assistantRuntimeBaseUrl).toBe(
+      config.assistantRuntimeBaseUrl,
+    );
+  });
+
+  test("calls server.upgrade when Authorization header provides valid token", () => {
+    const config = makeConfig({});
+    const handler = createTwilioMediaWebsocketHandler(config);
+    const req = new Request(
+      "http://localhost:7830/ws/twilio/media-stream?callSessionId=sess-42",
+      { headers: { authorization: `Bearer ${TEST_TOKEN}` } },
+    );
+    const fakeServer = {
+      upgrade: mock(() => true),
+    } as unknown as import("bun").Server<any>;
+    const res = handler(req, fakeServer);
+
+    expect(res).toBeUndefined();
+    expect(fakeServer.upgrade).toHaveBeenCalledTimes(1);
+  });
+
+  test("returns 500 when server.upgrade fails", () => {
+    const config = makeConfig({});
+    const handler = createTwilioMediaWebsocketHandler(config);
+    const req = new Request(
+      `http://localhost:7830/ws/twilio/media-stream?callSessionId=sess-1&token=${TEST_TOKEN}`,
+    );
+    const fakeServer = {
+      upgrade: mock(() => false),
+    } as unknown as import("bun").Server<any>;
+    const res = handler(req, fakeServer);
+
+    expect(res).toBeInstanceOf(Response);
+    expect(res!.status).toBe(500);
+  });
+
+  // --- Auth tests ---
+
+  test("returns 401 when no token provided and bypass is off", () => {
+    const handler = createTwilioMediaWebsocketHandler(makeConfig());
+    const req = new Request(
+      "http://localhost:7830/ws/twilio/media-stream?callSessionId=sess-1",
+    );
+    const fakeServer = {
+      upgrade: mock(() => true),
+    } as unknown as import("bun").Server<any>;
+    const res = handler(req, fakeServer);
+
+    expect(res).toBeInstanceOf(Response);
+    expect(res!.status).toBe(401);
+    expect(fakeServer.upgrade).not.toHaveBeenCalled();
+  });
+
+  test("returns 401 when token is missing from request", () => {
+    const config = makeConfig({});
+    const handler = createTwilioMediaWebsocketHandler(config);
+    const req = new Request(
+      "http://localhost:7830/ws/twilio/media-stream?callSessionId=sess-1",
+    );
+    const fakeServer = {
+      upgrade: mock(() => true),
+    } as unknown as import("bun").Server<any>;
+    const res = handler(req, fakeServer);
+
+    expect(res).toBeInstanceOf(Response);
+    expect(res!.status).toBe(401);
+    expect(fakeServer.upgrade).not.toHaveBeenCalled();
+  });
+
+  test("returns 401 when token is wrong", () => {
+    const config = makeConfig({});
+    const handler = createTwilioMediaWebsocketHandler(config);
+    const req = new Request(
+      "http://localhost:7830/ws/twilio/media-stream?callSessionId=sess-1&token=wrong-token",
+    );
+    const fakeServer = {
+      upgrade: mock(() => true),
+    } as unknown as import("bun").Server<any>;
+    const res = handler(req, fakeServer);
+
+    expect(res).toBeInstanceOf(Response);
+    expect(res!.status).toBe(401);
+    expect(fakeServer.upgrade).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// WebSocket handler tests
+// ---------------------------------------------------------------------------
+
+describe("getMediaStreamWebsocketHandlers", () => {
+  const OriginalWebSocket = globalThis.WebSocket;
+  let fakeUpstream: ReturnType<typeof createFakeUpstreamWs>;
+  let handlers: ReturnType<typeof getMediaStreamWebsocketHandlers>;
+
+  beforeEach(() => {
+    fakeUpstream = createFakeUpstreamWs();
+    // Replace global WebSocket constructor so `open` handler creates our fake.
+    // Copy static readyState constants so the source code's comparisons
+    // against WebSocket.OPEN / WebSocket.CONNECTING work correctly.
+    const MockWS = mock(() => fakeUpstream);
+    Object.assign(MockWS, {
+      CONNECTING: WS_CONNECTING,
+      OPEN: WS_OPEN,
+      CLOSING: 2,
+      CLOSED: WS_CLOSED,
+    });
+    globalThis.WebSocket = MockWS as unknown as typeof WebSocket;
+    handlers = getMediaStreamWebsocketHandlers();
+  });
+
+  // Restore after each file-level describe to avoid leaking
+  afterAll(() => {
+    globalThis.WebSocket = OriginalWebSocket;
+  });
+
+  // --- open handler ---------------------------------------------------------
+
+  test("open initializes pendingMessages buffer", () => {
+    const ws = createFakeDownstreamWs({
+      wsType: "twilio-media-stream",
+      callSessionId: "sess-1",
+      assistantRuntimeBaseUrl: "http://localhost:7821",
+    });
+    handlers.open(ws as never);
+
+    expect(ws.data.pendingMessages).toEqual([]);
+  });
+
+  test("open creates upstream WebSocket to correct URL", () => {
+    const ws = createFakeDownstreamWs({
+      wsType: "twilio-media-stream",
+      callSessionId: "s&id=1",
+      assistantRuntimeBaseUrl: "http://runtime:8000",
+    });
+    handlers.open(ws as never);
+
+    const ctorCall = (
+      globalThis.WebSocket as unknown as ReturnType<typeof mock>
+    ).mock.calls[0] as unknown[];
+    const url = ctorCall[0] as string;
+    // The URL includes a service JWT token parameter for runtime auth
+    expect(url).toStartWith(
+      "ws://runtime:8000/v1/calls/media-stream?callSessionId=s%26id%3D1&token=",
+    );
+  });
+
+  // --- message buffering before upstream open --------------------------------
+
+  test("buffers downstream messages while upstream is CONNECTING", () => {
+    const ws = createFakeDownstreamWs({
+      wsType: "twilio-media-stream",
+      callSessionId: "sess-1",
+      assistantRuntimeBaseUrl: "http://localhost:7821",
+    });
+    handlers.open(ws as never);
+
+    // Upstream is still CONNECTING
+    fakeUpstream.readyState = WS_CONNECTING;
+
+    handlers.message(ws as never, "msg-1");
+    handlers.message(ws as never, "msg-2");
+
+    expect(ws.data.pendingMessages).toEqual(["msg-1", "msg-2"]);
+    expect(fakeUpstream.sent).toHaveLength(0);
+  });
+
+  test("flushes buffered messages on upstream open", () => {
+    const ws = createFakeDownstreamWs({
+      wsType: "twilio-media-stream",
+      callSessionId: "sess-1",
+      assistantRuntimeBaseUrl: "http://localhost:7821",
+    });
+    handlers.open(ws as never);
+
+    // Buffer a couple of messages while CONNECTING
+    handlers.message(ws as never, "msg-a");
+    handlers.message(ws as never, "msg-b");
+
+    // Simulate upstream open event
+    fakeUpstream.readyState = WS_OPEN;
+    fakeUpstream.emit("open");
+
+    // Buffered messages should have been flushed to upstream
+    expect(fakeUpstream.sent).toEqual(["msg-a", "msg-b"]);
+    // Buffer should be cleared
+    expect(ws.data.pendingMessages).toBeUndefined();
+  });
+
+  test("forwards downstream messages directly when upstream is OPEN", () => {
+    const ws = createFakeDownstreamWs({
+      wsType: "twilio-media-stream",
+      callSessionId: "sess-1",
+      assistantRuntimeBaseUrl: "http://localhost:7821",
+    });
+    handlers.open(ws as never);
+
+    // Mark upstream as OPEN
+    fakeUpstream.readyState = WS_OPEN;
+    fakeUpstream.emit("open");
+
+    handlers.message(ws as never, "direct-msg");
+
+    expect(fakeUpstream.sent).toContain("direct-msg");
+  });
+
+  // --- buffer overflow -------------------------------------------------------
+
+  test("closes downstream with 1008 on buffer overflow", () => {
+    const ws = createFakeDownstreamWs({
+      wsType: "twilio-media-stream",
+      callSessionId: "sess-1",
+      assistantRuntimeBaseUrl: "http://localhost:7821",
+    });
+    handlers.open(ws as never);
+
+    // Fill the buffer to capacity (MAX_PENDING_MESSAGES = 100)
+    for (let i = 0; i < 100; i++) {
+      handlers.message(ws as never, `msg-${i}`);
+    }
+
+    // One more should trigger overflow
+    handlers.message(ws as never, "overflow");
+
+    expect(ws.closes).toHaveLength(1);
+    expect(ws.closes[0].code).toBe(1008);
+    expect(ws.closes[0].reason).toBe("Buffer overflow");
+  });
+
+  // --- downstream close while upstream is CONNECTING -------------------------
+
+  test("downstream close while upstream is CONNECTING closes upstream and clears buffer", () => {
+    const ws = createFakeDownstreamWs({
+      wsType: "twilio-media-stream",
+      callSessionId: "sess-1",
+      assistantRuntimeBaseUrl: "http://localhost:7821",
+    });
+    handlers.open(ws as never);
+
+    // Buffer some messages
+    handlers.message(ws as never, "pending-1");
+
+    // Downstream closes before upstream opens
+    fakeUpstream.readyState = WS_CONNECTING;
+    handlers.close(ws as never, 1000, "client gone");
+
+    // Buffer should be cleared
+    expect(ws.data.pendingMessages).toBeUndefined();
+    // Upstream should be closed
+    expect(fakeUpstream.closes).toHaveLength(1);
+    expect(fakeUpstream.closes[0].code).toBe(1000);
+    expect(fakeUpstream.closes[0].reason).toBe("client gone");
+  });
+
+  // --- upstream close propagation --------------------------------------------
+
+  test("upstream close event propagates to downstream close", () => {
+    const ws = createFakeDownstreamWs({
+      wsType: "twilio-media-stream",
+      callSessionId: "sess-1",
+      assistantRuntimeBaseUrl: "http://localhost:7821",
+    });
+    handlers.open(ws as never);
+
+    fakeUpstream.emit("close", { code: 1001, reason: "going away" });
+
+    expect(ws.closes).toHaveLength(1);
+    expect(ws.closes[0].code).toBe(1001);
+    expect(ws.closes[0].reason).toBe("going away");
+  });
+
+  // --- upstream error propagation --------------------------------------------
+
+  test("upstream error event closes downstream with 1011", () => {
+    const ws = createFakeDownstreamWs({
+      wsType: "twilio-media-stream",
+      callSessionId: "sess-1",
+      assistantRuntimeBaseUrl: "http://localhost:7821",
+    });
+    handlers.open(ws as never);
+
+    fakeUpstream.emit("error", new Event("error"));
+
+    expect(ws.closes).toHaveLength(1);
+    expect(ws.closes[0].code).toBe(1011);
+    expect(ws.closes[0].reason).toBe("Upstream error");
+  });
+
+  // --- upstream message forwarding -------------------------------------------
+
+  test("upstream message is forwarded to downstream (string)", () => {
+    const ws = createFakeDownstreamWs({
+      wsType: "twilio-media-stream",
+      callSessionId: "sess-1",
+      assistantRuntimeBaseUrl: "http://localhost:7821",
+    });
+    handlers.open(ws as never);
+
+    fakeUpstream.emit("message", { data: "hello from runtime" });
+
+    expect(ws.sent).toHaveLength(1);
+    expect(ws.sent[0]).toBe("hello from runtime");
+  });
+
+  test("upstream binary message is forwarded to downstream as Uint8Array", () => {
+    const ws = createFakeDownstreamWs({
+      wsType: "twilio-media-stream",
+      callSessionId: "sess-1",
+      assistantRuntimeBaseUrl: "http://localhost:7821",
+    });
+    handlers.open(ws as never);
+
+    const buf = new ArrayBuffer(4);
+    fakeUpstream.emit("message", { data: buf });
+
+    expect(ws.sent).toHaveLength(1);
+    expect(ws.sent[0]).toBeInstanceOf(Uint8Array);
+  });
+
+  // --- downstream close with OPEN upstream -----------------------------------
+
+  test("downstream close with OPEN upstream closes upstream", () => {
+    const ws = createFakeDownstreamWs({
+      wsType: "twilio-media-stream",
+      callSessionId: "sess-1",
+      assistantRuntimeBaseUrl: "http://localhost:7821",
+    });
+    handlers.open(ws as never);
+
+    fakeUpstream.readyState = WS_OPEN;
+
+    handlers.close(ws as never, 1000, "normal");
+
+    expect(fakeUpstream.closes).toHaveLength(1);
+    expect(fakeUpstream.closes[0].code).toBe(1000);
+    expect(fakeUpstream.closes[0].reason).toBe("normal");
+  });
+
+  // --- downstream close with already-closed upstream -------------------------
+
+  test("downstream close does not call upstream.close when upstream is already CLOSED", () => {
+    const ws = createFakeDownstreamWs({
+      wsType: "twilio-media-stream",
+      callSessionId: "sess-1",
+      assistantRuntimeBaseUrl: "http://localhost:7821",
+    });
+    handlers.open(ws as never);
+
+    fakeUpstream.readyState = WS_CLOSED;
+
+    handlers.close(ws as never, 1000, "done");
+
+    expect(fakeUpstream.closes).toHaveLength(0);
+  });
+});

--- a/gateway/src/http/routes/twilio-media-websocket.ts
+++ b/gateway/src/http/routes/twilio-media-websocket.ts
@@ -1,0 +1,225 @@
+import {
+  validateEdgeToken,
+  mintServiceToken,
+} from "../../auth/token-exchange.js";
+import type { GatewayConfig } from "../../config.js";
+import type { ConfigFileCache } from "../../config-file-cache.js";
+import { getLogger } from "../../logger.js";
+
+const log = getLogger("twilio-media-ws");
+
+// Cap buffered messages to prevent unbounded memory growth if upstream stalls
+const MAX_PENDING_MESSAGES = 100;
+
+type MediaStreamSocketData = {
+  wsType: "twilio-media-stream";
+  callSessionId: string;
+  assistantRuntimeBaseUrl: string;
+  upstream?: WebSocket;
+  pendingMessages?: (string | ArrayBuffer | Uint8Array)[];
+};
+
+export type { MediaStreamSocketData };
+
+/**
+ * Create a WebSocket upgrade handler that proxies Twilio Media Stream
+ * frames between Twilio and the runtime's /v1/calls/media-stream endpoint.
+ *
+ * Uses the same edge-token auth model as the relay websocket upgrades.
+ */
+export function createTwilioMediaWebsocketHandler(
+  config: GatewayConfig,
+  caches?: { configFile?: ConfigFileCache },
+) {
+  return function handleUpgrade(
+    req: Request,
+    server: import("bun").Server<unknown>,
+  ): Response | undefined {
+    const url = new URL(req.url);
+    const callSessionId = url.searchParams.get("callSessionId");
+
+    if (!callSessionId) {
+      log.warn("Media stream WS upgrade without callSessionId");
+      return new Response("Missing callSessionId", { status: 400 });
+    }
+
+    // Authenticate before upgrading. Twilio passes the token as a query
+    // parameter since WebSocket upgrades don't support arbitrary headers.
+    const isBypassed =
+      process.env.APP_VERSION === "0.0.0-dev" &&
+      (caches?.configFile?.getBoolean("telegram", "deliverAuthBypass") ??
+        false);
+    const authResponse = checkMediaStreamAuth(req, url, isBypassed);
+    if (authResponse) return authResponse;
+
+    const upgraded = server.upgrade(req, {
+      data: {
+        wsType: "twilio-media-stream",
+        callSessionId,
+        assistantRuntimeBaseUrl: config.assistantRuntimeBaseUrl,
+      } satisfies MediaStreamSocketData,
+    });
+
+    if (!upgraded) {
+      return new Response("WebSocket upgrade failed", { status: 500 });
+    }
+
+    // Return undefined to indicate upgrade was handled
+    return undefined;
+  };
+}
+
+/**
+ * Validate the media-stream WebSocket upgrade request using JWT edge tokens.
+ *
+ * Accepts a JWT via:
+ *   1. `Authorization: Bearer <token>` header (standard clients)
+ *   2. `token` query parameter (Twilio media streams -- no custom headers)
+ *
+ * Fail-closed: rejects all unauthenticated requests unless the deliver auth
+ * bypass flag is set (local-dev only escape hatch).
+ */
+function checkMediaStreamAuth(
+  req: Request,
+  url: URL,
+  isBypassed: boolean,
+): Response | null {
+  // Local-dev bypass: allow unauthenticated access when deliverAuthBypass is set
+  if (isBypassed) {
+    return null;
+  }
+
+  // Try Authorization header first, then fall back to query param
+  const authHeader = req.headers.get("authorization");
+  const queryToken = url.searchParams.get("token");
+  const rawToken = authHeader
+    ? authHeader.toLowerCase().startsWith("bearer ")
+      ? authHeader.slice(7)
+      : null
+    : queryToken;
+
+  if (!rawToken) {
+    log.warn("Media stream WS: no token provided");
+    return new Response("Unauthorized", { status: 401 });
+  }
+
+  const result = validateEdgeToken(rawToken);
+  if (!result.ok) {
+    log.warn(
+      { reason: result.reason },
+      "Media stream WS: authentication failed",
+    );
+    return new Response("Unauthorized", { status: 401 });
+  }
+
+  return null;
+}
+
+/**
+ * WebSocket handler config for Bun.serve() that proxies media-stream
+ * frames to the runtime.
+ */
+export function getMediaStreamWebsocketHandlers() {
+  return {
+    open(ws: import("bun").ServerWebSocket<MediaStreamSocketData>) {
+      const { callSessionId, assistantRuntimeBaseUrl } = ws.data;
+
+      // Initialize message buffer for frames arriving before upstream connects
+      ws.data.pendingMessages = [];
+
+      // Build upstream URL to runtime with JWT service token for auth
+      const runtimeBase = assistantRuntimeBaseUrl.replace(/^http/, "ws");
+      const serviceToken = mintServiceToken();
+      const upstreamUrl = `${runtimeBase}/v1/calls/media-stream?callSessionId=${encodeURIComponent(callSessionId)}&token=${encodeURIComponent(serviceToken)}`;
+
+      const logSafeUpstreamUrl = `${runtimeBase}/v1/calls/media-stream?callSessionId=${encodeURIComponent(callSessionId)}&token=<redacted>`;
+      log.info(
+        { callSessionId, upstreamUrl: logSafeUpstreamUrl },
+        "Opening upstream media-stream WS to runtime",
+      );
+
+      const upstream = new WebSocket(upstreamUrl);
+      ws.data.upstream = upstream;
+
+      upstream.addEventListener("open", () => {
+        log.info({ callSessionId }, "Upstream media-stream WS connected");
+        // Flush any buffered messages
+        const pending = ws.data.pendingMessages;
+        if (pending) {
+          for (const msg of pending) {
+            upstream.send(msg);
+          }
+          ws.data.pendingMessages = undefined;
+        }
+      });
+
+      upstream.addEventListener("message", (event) => {
+        // Forward runtime -> Twilio
+        const data =
+          typeof event.data === "string"
+            ? event.data
+            : new Uint8Array(event.data as ArrayBuffer);
+        ws.send(data);
+      });
+
+      upstream.addEventListener("close", (event) => {
+        log.info(
+          { callSessionId, code: event.code },
+          "Upstream media-stream WS closed",
+        );
+        ws.close(event.code, event.reason);
+      });
+
+      upstream.addEventListener("error", (event) => {
+        log.error(
+          { callSessionId, error: event },
+          "Upstream media-stream WS error",
+        );
+        ws.close(1011, "Upstream error");
+      });
+    },
+
+    message(
+      ws: import("bun").ServerWebSocket<MediaStreamSocketData>,
+      message: string | ArrayBuffer | Uint8Array,
+    ) {
+      // Forward Twilio -> runtime
+      const upstream = ws.data.upstream;
+      if (upstream && upstream.readyState === WebSocket.OPEN) {
+        upstream.send(message);
+      } else if (ws.data.pendingMessages) {
+        // Buffer messages until upstream connects
+        if (ws.data.pendingMessages.length >= MAX_PENDING_MESSAGES) {
+          log.warn(
+            { callSessionId: ws.data.callSessionId },
+            "Media stream pending message buffer overflow — closing connection",
+          );
+          ws.close(1008, "Buffer overflow");
+          return;
+        }
+        ws.data.pendingMessages.push(message);
+      }
+    },
+
+    close(
+      ws: import("bun").ServerWebSocket<MediaStreamSocketData>,
+      code: number,
+      reason: string,
+    ) {
+      const { callSessionId, upstream } = ws.data;
+      log.info(
+        { callSessionId, code, reason },
+        "Twilio media-stream WS closed",
+      );
+      // Clear pending buffer so no messages are flushed after close
+      ws.data.pendingMessages = undefined;
+      if (
+        upstream &&
+        (upstream.readyState === WebSocket.OPEN ||
+          upstream.readyState === WebSocket.CONNECTING)
+      ) {
+        upstream.close(code, reason);
+      }
+    },
+  };
+}

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -34,6 +34,11 @@ import {
   createTwilioRelayWebsocketHandler,
   getRelayWebsocketHandlers,
 } from "./http/routes/twilio-relay-websocket.js";
+import {
+  createTwilioMediaWebsocketHandler,
+  getMediaStreamWebsocketHandlers,
+  type MediaStreamSocketData,
+} from "./http/routes/twilio-media-websocket.js";
 import { createWhatsAppWebhookHandler } from "./http/routes/whatsapp-webhook.js";
 import { createWhatsAppDeliverHandler } from "./http/routes/whatsapp-deliver.js";
 import { createEmailWebhookHandler } from "./http/routes/email-webhook.js";
@@ -163,6 +168,14 @@ function isBrowserRelaySocketData(
   );
 }
 
+function isMediaStreamSocketData(data: unknown): data is MediaStreamSocketData {
+  return (
+    !!data &&
+    typeof data === "object" &&
+    (data as { wsType?: unknown }).wsType === "twilio-media-stream"
+  );
+}
+
 function getClientIp(
   req: Request,
   server: ReturnType<typeof Bun.serve>,
@@ -237,8 +250,12 @@ async function main() {
   const handleTwilioRelayWs = createTwilioRelayWebsocketHandler(config, {
     configFile: configFileCache,
   });
+  const handleTwilioMediaWs = createTwilioMediaWebsocketHandler(config, {
+    configFile: configFileCache,
+  });
   const handleBrowserRelayWs = createBrowserRelayWebsocketHandler(config);
   const twilioRelayWebsocketHandlers = getRelayWebsocketHandlers();
+  const twilioMediaStreamWebsocketHandlers = getMediaStreamWebsocketHandlers();
   const browserRelayWebsocketHandlers = getBrowserRelayWebsocketHandlers();
   const { handler: handleWhatsAppWebhook, dedupCache: whatsappDedupCache } =
     createWhatsAppWebhookHandler(config, {
@@ -1046,6 +1063,10 @@ async function main() {
           browserRelayWebsocketHandlers.open(ws as never);
           return;
         }
+        if (isMediaStreamSocketData(ws.data)) {
+          twilioMediaStreamWebsocketHandlers.open(ws as never);
+          return;
+        }
         twilioRelayWebsocketHandlers.open(ws as never);
       },
       message(ws, message) {
@@ -1053,11 +1074,19 @@ async function main() {
           browserRelayWebsocketHandlers.message(ws as never, message);
           return;
         }
+        if (isMediaStreamSocketData(ws.data)) {
+          twilioMediaStreamWebsocketHandlers.message(ws as never, message);
+          return;
+        }
         twilioRelayWebsocketHandlers.message(ws as never, message);
       },
       close(ws, code, reason) {
         if (isBrowserRelaySocketData(ws.data)) {
           browserRelayWebsocketHandlers.close(ws as never, code, reason);
+          return;
+        }
+        if (isMediaStreamSocketData(ws.data)) {
+          twilioMediaStreamWebsocketHandlers.close(ws as never, code, reason);
           return;
         }
         twilioRelayWebsocketHandlers.close(ws as never, code, reason);
@@ -1178,6 +1207,12 @@ async function main() {
       // a Response, so these can't go through the route table.
       if (url.pathname === "/webhooks/twilio/relay") {
         const upgradeResult = handleTwilioRelayWs(req, server);
+        if (upgradeResult !== undefined) return upgradeResult;
+        return undefined as unknown as Response;
+      }
+
+      if (url.pathname === "/webhooks/twilio/media-stream") {
+        const upgradeResult = handleTwilioMediaWs(req, server);
         if (upgradeResult !== undefined) return upgradeResult;
         return undefined as unknown as Response;
       }

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -822,6 +822,54 @@ export function buildSchema(): Record<string, unknown> {
           },
         },
       },
+      "/webhooks/twilio/media-stream": {
+        get: {
+          summary: "Twilio Media Stream WebSocket",
+          description:
+            "Accepts a WebSocket upgrade from Twilio Media Streams and bidirectionally proxies frames to the assistant runtime's /v1/calls/media-stream endpoint. Requires a callSessionId query parameter.",
+          operationId: "twilioMediaStreamWebsocket",
+          parameters: [
+            {
+              name: "callSessionId",
+              in: "query",
+              required: true,
+              schema: { type: "string" },
+              description:
+                "Call session identifier used to correlate the WebSocket connection with the runtime media-stream session.",
+            },
+          ],
+          responses: {
+            "101": {
+              description:
+                "WebSocket upgrade successful — bidirectional media-stream frame proxying begins.",
+            },
+            "400": {
+              description: "Missing callSessionId query parameter",
+              content: {
+                "text/plain": {
+                  schema: { type: "string" },
+                },
+              },
+            },
+            "401": {
+              description: "Unauthorized — missing or invalid token",
+              content: {
+                "text/plain": {
+                  schema: { type: "string" },
+                },
+              },
+            },
+            "500": {
+              description: "WebSocket upgrade failed",
+              content: {
+                "text/plain": {
+                  schema: { type: "string" },
+                },
+              },
+            },
+          },
+        },
+      },
       "/webhooks/oauth/callback": {
         get: {
           summary: "OAuth2 callback",


### PR DESCRIPTION
## Summary
- Add gateway websocket ingress route for Twilio media-stream with edge-token auth
- Proxy media-stream route to runtime with service-token auth
- Register runtime websocket upgrade handling with private-network restrictions

Part of plan: twilio-services-stt-provider-unification.md (PR 3 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25036" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
