### PR TITLE
assistant: add media-stream call server and transport adapter behind inactive path

### DIFF
--- a/assistant/src/__tests__/media-stream-output.test.ts
+++ b/assistant/src/__tests__/media-stream-output.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+}));
+
+import { MediaStreamOutput } from "../calls/media-stream-output.js";
+
+// ---------------------------------------------------------------------------
+// Mock WebSocket
+// ---------------------------------------------------------------------------
+
+function createMockWs() {
+  const sent: string[] = [];
+  let closed = false;
+  let closeCode: number | undefined;
+  let closeReason: string | undefined;
+
+  return {
+    ws: {
+      send(data: string) {
+        if (closed) throw new Error("WebSocket is closed");
+        sent.push(data);
+      },
+      close(code?: number, reason?: string) {
+        closed = true;
+        closeCode = code;
+        closeReason = reason;
+      },
+    } as unknown as import("bun").ServerWebSocket<unknown>,
+    get sent() {
+      return sent;
+    },
+    get closed() {
+      return closed;
+    },
+    get closeCode() {
+      return closeCode;
+    },
+    get closeReason() {
+      return closeReason;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("MediaStreamOutput", () => {
+  describe("CallTransport interface", () => {
+    test("sendTextToken is a no-op", () => {
+      const { ws, sent } = createMockWs();
+      const output = new MediaStreamOutput(ws, "stream-1");
+      output.sendTextToken("hello", false);
+      output.sendTextToken("world", true);
+      expect(sent).toHaveLength(0);
+    });
+
+    test("sendPlayUrl is a no-op", () => {
+      const { ws, sent } = createMockWs();
+      const output = new MediaStreamOutput(ws, "stream-1");
+      output.sendPlayUrl("https://example.com/audio.mp3");
+      expect(sent).toHaveLength(0);
+    });
+
+    test("endSession closes the WebSocket with code 1000", () => {
+      const mock = createMockWs();
+      const output = new MediaStreamOutput(mock.ws, "stream-1");
+      output.endSession("test-reason");
+      expect(mock.closed).toBe(true);
+      expect(mock.closeCode).toBe(1000);
+      expect(mock.closeReason).toBe("test-reason");
+    });
+
+    test("endSession uses default reason when none provided", () => {
+      const mock = createMockWs();
+      const output = new MediaStreamOutput(mock.ws, "stream-1");
+      output.endSession();
+      expect(mock.closed).toBe(true);
+      expect(mock.closeReason).toBe("session-ended");
+    });
+
+    test("endSession is idempotent", () => {
+      const mock = createMockWs();
+      const output = new MediaStreamOutput(mock.ws, "stream-1");
+      output.endSession("first");
+      // Second call should not throw (ws.close would throw on already-closed)
+      output.endSession("second");
+      expect(mock.closed).toBe(true);
+    });
+
+    test("getConnectionState returns 'connected' initially", () => {
+      const { ws } = createMockWs();
+      const output = new MediaStreamOutput(ws, "stream-1");
+      expect(output.getConnectionState()).toBe("connected");
+    });
+
+    test("getConnectionState returns 'closed' after endSession", () => {
+      const mock = createMockWs();
+      const output = new MediaStreamOutput(mock.ws, "stream-1");
+      output.endSession();
+      expect(output.getConnectionState()).toBe("closed");
+    });
+  });
+
+  describe("sendAudioPayload", () => {
+    test("sends a media command with the base64 payload", () => {
+      const { ws, sent } = createMockWs();
+      const output = new MediaStreamOutput(ws, "MZ-stream-1");
+      output.sendAudioPayload("dGVzdA==");
+
+      expect(sent).toHaveLength(1);
+      const parsed = JSON.parse(sent[0]);
+      expect(parsed).toEqual({
+        event: "media",
+        streamSid: "MZ-stream-1",
+        media: { payload: "dGVzdA==" },
+      });
+    });
+
+    test("does not send when closed", () => {
+      const { ws, sent } = createMockWs();
+      const output = new MediaStreamOutput(ws, "MZ-stream-1");
+      output.endSession();
+      output.sendAudioPayload("dGVzdA==");
+      // Only the close would have happened, no media sent
+      expect(sent).toHaveLength(0);
+    });
+  });
+
+  describe("sendMark", () => {
+    test("sends a mark command with the given name", () => {
+      const { ws, sent } = createMockWs();
+      const output = new MediaStreamOutput(ws, "MZ-stream-1");
+      output.sendMark("end-of-turn");
+
+      expect(sent).toHaveLength(1);
+      const parsed = JSON.parse(sent[0]);
+      expect(parsed).toEqual({
+        event: "mark",
+        streamSid: "MZ-stream-1",
+        mark: { name: "end-of-turn" },
+      });
+    });
+
+    test("does not send when closed", () => {
+      const { ws, sent } = createMockWs();
+      const output = new MediaStreamOutput(ws, "MZ-stream-1");
+      output.endSession();
+      output.sendMark("end-of-turn");
+      expect(sent).toHaveLength(0);
+    });
+  });
+
+  describe("clearAudio", () => {
+    test("sends a clear command", () => {
+      const { ws, sent } = createMockWs();
+      const output = new MediaStreamOutput(ws, "MZ-stream-1");
+      output.clearAudio();
+
+      expect(sent).toHaveLength(1);
+      const parsed = JSON.parse(sent[0]);
+      expect(parsed).toEqual({
+        event: "clear",
+        streamSid: "MZ-stream-1",
+      });
+    });
+
+    test("does not send when closed", () => {
+      const { ws, sent } = createMockWs();
+      const output = new MediaStreamOutput(ws, "MZ-stream-1");
+      output.endSession();
+      output.clearAudio();
+      expect(sent).toHaveLength(0);
+    });
+  });
+
+  describe("setStreamSid / getStreamSid", () => {
+    test("updates the stream SID used in subsequent commands", () => {
+      const { ws, sent } = createMockWs();
+      const output = new MediaStreamOutput(ws, "old-sid");
+      expect(output.getStreamSid()).toBe("old-sid");
+
+      output.setStreamSid("new-sid");
+      expect(output.getStreamSid()).toBe("new-sid");
+
+      output.sendAudioPayload("dGVzdA==");
+      const parsed = JSON.parse(sent[0]);
+      expect(parsed.streamSid).toBe("new-sid");
+    });
+  });
+
+  describe("markClosed", () => {
+    test("transitions to closed state without sending a close frame", () => {
+      const mock = createMockWs();
+      const output = new MediaStreamOutput(mock.ws, "stream-1");
+      output.markClosed();
+      expect(output.getConnectionState()).toBe("closed");
+      expect(mock.closed).toBe(false); // WebSocket not actually closed
+      output.sendAudioPayload("dGVzdA=="); // Should be suppressed
+      expect(mock.sent).toHaveLength(0);
+    });
+  });
+
+  describe("error resilience", () => {
+    test("sendAudioPayload handles ws.send throwing", () => {
+      const ws = {
+        send() {
+          throw new Error("send failed");
+        },
+        close() {},
+      } as unknown as import("bun").ServerWebSocket<unknown>;
+
+      const output = new MediaStreamOutput(ws, "stream-1");
+      // Should not throw
+      expect(() => output.sendAudioPayload("dGVzdA==")).not.toThrow();
+    });
+
+    test("endSession handles ws.close throwing", () => {
+      const ws = {
+        send() {},
+        close() {
+          throw new Error("close failed");
+        },
+      } as unknown as import("bun").ServerWebSocket<unknown>;
+
+      const output = new MediaStreamOutput(ws, "stream-1");
+      // Should not throw
+      expect(() => output.endSession()).not.toThrow();
+    });
+  });
+});

--- a/assistant/src/__tests__/media-stream-server-integration.test.ts
+++ b/assistant/src/__tests__/media-stream-server-integration.test.ts
@@ -1,0 +1,517 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  mock,
+  test,
+} from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Module mocks — declared before imports of the module under test.
+// ---------------------------------------------------------------------------
+
+// Mock the STT resolve module (used by MediaStreamSttSession)
+mock.module("../providers/speech-to-text/resolve.js", () => ({
+  resolveTelephonySttCapability: jest.fn(),
+  resolveBatchTranscriber: jest.fn(),
+}));
+
+// Mock the logger to suppress output during tests
+mock.module("../util/logger.js", () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+}));
+
+// Mock the call store — lightweight in-memory stubs
+const mockSessions = new Map<string, Record<string, unknown>>();
+const mockEvents: Array<{
+  callSessionId: string;
+  eventType: string;
+  data: unknown;
+}> = [];
+
+mock.module("../calls/call-store.js", () => ({
+  getCallSession: jest.fn((id: string) => mockSessions.get(id) ?? null),
+  updateCallSession: jest.fn((id: string, updates: Record<string, unknown>) => {
+    const session = mockSessions.get(id);
+    if (session) {
+      Object.assign(session, updates);
+    }
+  }),
+  recordCallEvent: jest.fn(
+    (callSessionId: string, eventType: string, data: unknown) => {
+      mockEvents.push({ callSessionId, eventType, data });
+    },
+  ),
+  createCallSession: jest.fn(),
+  getCallSessionByCallSid: jest.fn(),
+  getActiveCallSessionForConversation: jest.fn(),
+  createPendingQuestion: jest.fn(),
+  expirePendingQuestions: jest.fn(),
+  getPendingQuestion: jest.fn(),
+  answerPendingQuestion: jest.fn(),
+}));
+
+// Mock the call state machine
+mock.module("../calls/call-state-machine.js", () => ({
+  isTerminalState: jest.fn(
+    (status: string) =>
+      status === "completed" || status === "failed" || status === "cancelled",
+  ),
+}));
+
+// Mock the call state (controller registry)
+const mockControllers = new Map<string, unknown>();
+mock.module("../calls/call-state.js", () => ({
+  registerCallController: jest.fn(
+    (callSessionId: string, controller: unknown) => {
+      mockControllers.set(callSessionId, controller);
+    },
+  ),
+  unregisterCallController: jest.fn((callSessionId: string) => {
+    mockControllers.delete(callSessionId);
+  }),
+  getCallController: jest.fn((callSessionId: string) =>
+    mockControllers.get(callSessionId),
+  ),
+  fireCallTranscriptNotifier: jest.fn(),
+  fireCallQuestionNotifier: jest.fn(),
+  fireCallCompletionNotifier: jest.fn(),
+  registerCallQuestionNotifier: jest.fn(),
+  unregisterCallQuestionNotifier: jest.fn(),
+  registerCallTranscriptNotifier: jest.fn(),
+  unregisterCallTranscriptNotifier: jest.fn(),
+  registerCallCompletionNotifier: jest.fn(),
+  unregisterCallCompletionNotifier: jest.fn(),
+}));
+
+// Mock the finalize-call module
+mock.module("../calls/finalize-call.js", () => ({
+  finalizeCall: jest.fn(),
+}));
+
+// Mock the call pointer messages
+mock.module("../calls/call-pointer-messages.js", () => ({
+  addPointerMessage: jest.fn(async () => {}),
+  formatDuration: jest.fn((ms: number) => `${Math.round(ms / 1000)}s`),
+}));
+
+// Mock the CallController to avoid pulling in the full conversation pipeline
+const mockStartInitialGreeting = jest.fn(async () => {});
+const mockHandleCallerUtterance = jest.fn(async () => {});
+const mockHandleInterrupt = jest.fn();
+const mockDestroy = jest.fn();
+
+mock.module("../calls/call-controller.js", () => ({
+  CallController: jest.fn().mockImplementation(() => ({
+    startInitialGreeting: mockStartInitialGreeting,
+    handleCallerUtterance: mockHandleCallerUtterance,
+    handleInterrupt: mockHandleInterrupt,
+    destroy: mockDestroy,
+    setTrustContext: jest.fn(),
+    markNextCallerTurnAsOpeningAck: jest.fn(),
+    getPendingConsultationQuestionId: jest.fn(),
+    handleUserAnswer: jest.fn(),
+    handleUserInstruction: jest.fn(),
+  })),
+}));
+
+// Mock the assistant scope
+mock.module("../runtime/assistant-scope.js", () => ({
+  DAEMON_INTERNAL_ASSISTANT_ID: "self",
+}));
+
+// ---------------------------------------------------------------------------
+// Now import the module under test.
+// ---------------------------------------------------------------------------
+
+import { registerCallController } from "../calls/call-state.js";
+import { recordCallEvent, updateCallSession } from "../calls/call-store.js";
+import { finalizeCall } from "../calls/finalize-call.js";
+import {
+  activeMediaStreamSessions,
+  MediaStreamCallSession,
+} from "../calls/media-stream-server.js";
+
+// ---------------------------------------------------------------------------
+// Mock WebSocket factory
+// ---------------------------------------------------------------------------
+
+function createMockWs() {
+  const sent: string[] = [];
+  let closed = false;
+  let closeCode: number | undefined;
+  let closeReason: string | undefined;
+
+  return {
+    ws: {
+      send(data: string) {
+        if (closed) throw new Error("WebSocket is closed");
+        sent.push(data);
+      },
+      close(code?: number, reason?: string) {
+        closed = true;
+        closeCode = code;
+        closeReason = reason;
+      },
+    } as unknown as import("bun").ServerWebSocket<unknown>,
+    get sent() {
+      return sent;
+    },
+    get closed() {
+      return closed;
+    },
+    get closeCode() {
+      return closeCode;
+    },
+    get closeReason() {
+      return closeReason;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Fixture factories
+// ---------------------------------------------------------------------------
+
+function makeStartMessage(overrides?: {
+  callSid?: string;
+  streamSid?: string;
+}): string {
+  return JSON.stringify({
+    event: "start",
+    sequenceNumber: "1",
+    streamSid: overrides?.streamSid ?? "MZ00000000000000000000000000000000",
+    start: {
+      accountSid: "AC00000000000000000000000000000000",
+      streamSid: overrides?.streamSid ?? "MZ00000000000000000000000000000000",
+      callSid: overrides?.callSid ?? "CA00000000000000000000000000000000",
+      tracks: ["inbound"],
+      customParameters: {},
+      mediaFormat: {
+        encoding: "audio/x-mulaw",
+        sampleRate: 8000,
+        channels: 1,
+      },
+    },
+  });
+}
+
+function makeMediaMessage(payload: string, chunk: string = "1"): string {
+  return JSON.stringify({
+    event: "media",
+    sequenceNumber: "2",
+    streamSid: "MZ00000000000000000000000000000000",
+    media: {
+      track: "inbound",
+      chunk,
+      timestamp: "100",
+      payload,
+    },
+  });
+}
+
+function makeStopMessage(): string {
+  return JSON.stringify({
+    event: "stop",
+    sequenceNumber: "99",
+    streamSid: "MZ00000000000000000000000000000000",
+    stop: {
+      accountSid: "AC00000000000000000000000000000000",
+      callSid: "CA00000000000000000000000000000000",
+    },
+  });
+}
+
+function makeMarkMessage(name: string): string {
+  return JSON.stringify({
+    event: "mark",
+    sequenceNumber: "50",
+    streamSid: "MZ00000000000000000000000000000000",
+    mark: { name },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  mockSessions.clear();
+  mockEvents.length = 0;
+  mockControllers.clear();
+  activeMediaStreamSessions.clear();
+  mockStartInitialGreeting.mockClear();
+  mockHandleCallerUtterance.mockClear();
+  mockHandleInterrupt.mockClear();
+  mockDestroy.mockClear();
+  (registerCallController as jest.Mock).mockClear();
+  (recordCallEvent as jest.Mock).mockClear();
+  (updateCallSession as jest.Mock).mockClear();
+  (finalizeCall as jest.Mock).mockClear();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+  activeMediaStreamSessions.clear();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("MediaStreamCallSession", () => {
+  test("creates a session and exposes output adapter", () => {
+    const { ws } = createMockWs();
+    const session = new MediaStreamCallSession(ws, "call-1");
+    expect(session.callSessionId).toBe("call-1");
+    expect(session.getOutput()).toBeDefined();
+    expect(session.getOutput().getConnectionState()).toBe("connected");
+  });
+
+  describe("start event handling", () => {
+    test("start event registers a controller and records call_connected", () => {
+      const mock = createMockWs();
+      // Set up a call session in the mock store
+      mockSessions.set("call-1", {
+        id: "call-1",
+        conversationId: "conv-1",
+        status: "initiated",
+        task: "Test task",
+        startedAt: null,
+        toNumber: "+15551234567",
+      });
+
+      const session = new MediaStreamCallSession(mock.ws, "call-1");
+      session.handleMessage(makeStartMessage());
+
+      // Controller should have been registered
+      expect(registerCallController).toHaveBeenCalledWith(
+        "call-1",
+        expect.anything(),
+      );
+
+      // call_connected event should have been recorded
+      expect(recordCallEvent).toHaveBeenCalledWith(
+        "call-1",
+        "call_connected",
+        expect.objectContaining({
+          callSid: "CA00000000000000000000000000000000",
+          transport: "media-stream",
+        }),
+      );
+
+      // Call session should have been updated
+      expect(updateCallSession).toHaveBeenCalledWith(
+        "call-1",
+        expect.objectContaining({
+          providerCallSid: "CA00000000000000000000000000000000",
+          status: "in_progress",
+        }),
+      );
+
+      // Initial greeting should have been fired
+      expect(mockStartInitialGreeting).toHaveBeenCalled();
+    });
+
+    test("start event updates streamSid on the output adapter", () => {
+      const mock = createMockWs();
+      mockSessions.set("call-1", {
+        id: "call-1",
+        conversationId: "conv-1",
+        status: "initiated",
+        task: null,
+        startedAt: null,
+        toNumber: "+15551234567",
+      });
+
+      const session = new MediaStreamCallSession(mock.ws, "call-1");
+      session.handleMessage(makeStartMessage({ streamSid: "MZ-custom-sid" }));
+
+      expect(session.getOutput().getStreamSid()).toBe("MZ-custom-sid");
+    });
+  });
+
+  describe("transport close handling", () => {
+    test("normal close (1000) marks session as completed", () => {
+      const mock = createMockWs();
+      mockSessions.set("call-1", {
+        id: "call-1",
+        conversationId: "conv-1",
+        status: "in_progress",
+        startedAt: Date.now() - 60000,
+        toNumber: "+15551234567",
+      });
+
+      const session = new MediaStreamCallSession(mock.ws, "call-1");
+      session.handleTransportClosed(1000, "normal-close");
+
+      expect(updateCallSession).toHaveBeenCalledWith(
+        "call-1",
+        expect.objectContaining({ status: "completed" }),
+      );
+      expect(finalizeCall).toHaveBeenCalledWith("call-1", "conv-1");
+    });
+
+    test("abnormal close marks session as failed", () => {
+      const mock = createMockWs();
+      mockSessions.set("call-1", {
+        id: "call-1",
+        conversationId: "conv-1",
+        status: "in_progress",
+        startedAt: Date.now() - 60000,
+        toNumber: "+15551234567",
+      });
+
+      const session = new MediaStreamCallSession(mock.ws, "call-1");
+      session.handleTransportClosed(1006, "abnormal-close");
+
+      expect(updateCallSession).toHaveBeenCalledWith(
+        "call-1",
+        expect.objectContaining({
+          status: "failed",
+          lastError: expect.stringContaining("abnormal-close"),
+        }),
+      );
+      expect(finalizeCall).toHaveBeenCalledWith("call-1", "conv-1");
+    });
+
+    test("close on already-terminal session is a no-op", () => {
+      const mock = createMockWs();
+      mockSessions.set("call-1", {
+        id: "call-1",
+        conversationId: "conv-1",
+        status: "completed",
+        toNumber: "+15551234567",
+      });
+
+      const session = new MediaStreamCallSession(mock.ws, "call-1");
+      session.handleTransportClosed(1000);
+
+      // updateCallSession should NOT have been called because session
+      // was already terminal
+      expect(updateCallSession).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("destroy", () => {
+    test("destroys the controller and marks output as closed", () => {
+      const mock = createMockWs();
+      mockSessions.set("call-1", {
+        id: "call-1",
+        conversationId: "conv-1",
+        status: "initiated",
+        task: null,
+        startedAt: null,
+        toNumber: "+15551234567",
+      });
+
+      const session = new MediaStreamCallSession(mock.ws, "call-1");
+      // Trigger start to create a controller
+      session.handleMessage(makeStartMessage());
+
+      session.destroy();
+      expect(mockDestroy).toHaveBeenCalled();
+      expect(session.getOutput().getConnectionState()).toBe("closed");
+    });
+
+    test("destroy is idempotent", () => {
+      const mock = createMockWs();
+      const session = new MediaStreamCallSession(mock.ws, "call-1");
+      session.destroy();
+      session.destroy(); // Should not throw
+    });
+
+    test("messages after destroy are dropped", () => {
+      const mock = createMockWs();
+      const session = new MediaStreamCallSession(mock.ws, "call-1");
+      session.destroy();
+
+      // Should not throw or create side effects
+      session.handleMessage(makeStartMessage());
+      expect(registerCallController).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("media event forwarding", () => {
+    test("media events are forwarded to the STT session without errors", () => {
+      const mock = createMockWs();
+      mockSessions.set("call-1", {
+        id: "call-1",
+        conversationId: "conv-1",
+        status: "initiated",
+        task: null,
+        startedAt: null,
+        toNumber: "+15551234567",
+      });
+
+      const session = new MediaStreamCallSession(mock.ws, "call-1");
+      session.handleMessage(makeStartMessage());
+
+      // Send media frames — should not throw
+      const payload = Buffer.from("test-audio").toString("base64");
+      session.handleMessage(makeMediaMessage(payload, "1"));
+      session.handleMessage(makeMediaMessage(payload, "2"));
+      session.handleMessage(makeMediaMessage(payload, "3"));
+    });
+
+    test("mark events are forwarded without errors", () => {
+      const mock = createMockWs();
+      const session = new MediaStreamCallSession(mock.ws, "call-1");
+
+      // Mark events should be silently handled
+      session.handleMessage(makeMarkMessage("end-of-turn"));
+    });
+
+    test("stop events are forwarded to the STT session", () => {
+      const mock = createMockWs();
+      mockSessions.set("call-1", {
+        id: "call-1",
+        conversationId: "conv-1",
+        status: "initiated",
+        task: null,
+        startedAt: null,
+        toNumber: "+15551234567",
+      });
+
+      const session = new MediaStreamCallSession(mock.ws, "call-1");
+      session.handleMessage(makeStartMessage());
+      session.handleMessage(makeStopMessage());
+
+      // Stop is informational; the session continues until WebSocket closes
+    });
+  });
+
+  describe("malformed messages", () => {
+    test("invalid JSON is dropped silently", () => {
+      const mock = createMockWs();
+      const session = new MediaStreamCallSession(mock.ws, "call-1");
+      // Should not throw
+      session.handleMessage("not json {{{");
+    });
+
+    test("unknown event types are dropped silently", () => {
+      const mock = createMockWs();
+      const session = new MediaStreamCallSession(mock.ws, "call-1");
+      session.handleMessage(JSON.stringify({ event: "unknown_type" }));
+    });
+  });
+});
+
+describe("activeMediaStreamSessions registry", () => {
+  test("sessions can be added and retrieved", () => {
+    const mock = createMockWs();
+    const session = new MediaStreamCallSession(mock.ws, "call-1");
+    activeMediaStreamSessions.set("call-1", session);
+    expect(activeMediaStreamSessions.get("call-1")).toBe(session);
+    activeMediaStreamSessions.delete("call-1");
+    expect(activeMediaStreamSessions.get("call-1")).toBeUndefined();
+  });
+});

--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -38,6 +38,7 @@ import {
   getPendingQuestion,
   updateCallSession,
 } from "./call-store.js";
+import { activeMediaStreamSessions } from "./media-stream-server.js";
 import { activeRelayConnections } from "./relay-server.js";
 import { getTwilioConfig } from "./twilio-config.js";
 import { TwilioConversationRelayProvider } from "./twilio-provider.js";
@@ -677,6 +678,14 @@ export async function cancelCall(
     relayConnection.endSession(reason);
     relayConnection.destroy();
     activeRelayConnections.delete(callSessionId);
+  }
+
+  // End the media-stream session if active
+  const mediaStreamSession = activeMediaStreamSessions.get(callSessionId);
+  if (mediaStreamSession) {
+    mediaStreamSession.getOutput().endSession(reason);
+    mediaStreamSession.destroy();
+    activeMediaStreamSessions.delete(callSessionId);
   }
 
   // Clean up controller

--- a/assistant/src/calls/media-stream-output.ts
+++ b/assistant/src/calls/media-stream-output.ts
@@ -1,0 +1,216 @@
+/**
+ * Output adapter for media-stream call egress.
+ *
+ * Implements the {@link CallTransport} interface so the call controller
+ * can send synthesized audio and lifecycle signals through a Twilio Media
+ * Stream WebSocket connection.
+ *
+ * Unlike the ConversationRelay transport which sends text tokens for
+ * Twilio's built-in TTS, the media-stream transport operates on raw
+ * audio frames:
+ *
+ * - `sendTextToken()` — For the media-stream path, text tokens are
+ *   a no-op placeholder. In a fully-wired media-stream stack the
+ *   controller would synthesize audio and call `sendAudioPayload()`
+ *   instead. The no-op keeps the transport contract satisfied while
+ *   the media-stream path is dark.
+ *
+ * - `sendPlayUrl()` — Similarly a no-op in the current dark path.
+ *   A fully-wired stack would fetch the audio from the URL and stream
+ *   it as media frames.
+ *
+ * - `endSession()` — Closes the underlying WebSocket, which triggers
+ *   Twilio to tear down the media stream and (eventually) the call.
+ *
+ * - `sendAudioPayload()` — Sends a base64-encoded audio frame to
+ *   Twilio for playback on the caller's channel.
+ *
+ * - `sendMark()` — Inserts a named mark into the outbound audio
+ *   pipeline. Twilio will echo it back as a `mark` event once the
+ *   caller reaches that point in playback.
+ *
+ * - `clearAudio()` — Clears any queued outbound audio (barge-in).
+ *
+ * This module is integration-neutral and not wired to any production
+ * call setup path. It exists behind a dark path for testing only.
+ */
+
+import type { ServerWebSocket } from "bun";
+
+import { getLogger } from "../util/logger.js";
+import type { CallTransport } from "./call-transport.js";
+import type {
+  MediaStreamClearCommand,
+  MediaStreamSendMarkCommand,
+  MediaStreamSendMediaCommand,
+} from "./media-stream-protocol.js";
+
+const log = getLogger("media-stream-output");
+
+// ---------------------------------------------------------------------------
+// Connection state
+// ---------------------------------------------------------------------------
+
+export type MediaStreamOutputState = "connected" | "closed";
+
+// ---------------------------------------------------------------------------
+// Output adapter
+// ---------------------------------------------------------------------------
+
+export class MediaStreamOutput implements CallTransport {
+  private streamSid: string;
+  private ws: ServerWebSocket<unknown>;
+  private state: MediaStreamOutputState = "connected";
+
+  constructor(ws: ServerWebSocket<unknown>, streamSid: string) {
+    this.ws = ws;
+    this.streamSid = streamSid;
+  }
+
+  // ── CallTransport interface ─────────────────────────────────────────
+
+  /**
+   * No-op for the media-stream dark path. In a fully-wired stack, text
+   * would be synthesized to audio frames and sent via `sendAudioPayload()`.
+   */
+  sendTextToken(_token: string, _last: boolean): void {
+    // Intentional no-op: media-stream transport does not support
+    // text-to-TTS passthrough. The controller's synthesized-play
+    // codepath should be used instead.
+  }
+
+  /**
+   * No-op for the media-stream dark path. In a fully-wired stack, the
+   * audio at the URL would be fetched, transcoded, and streamed as
+   * media frames.
+   */
+  sendPlayUrl(_url: string): void {
+    // Intentional no-op: media-stream transport does not support
+    // play-URL passthrough.
+  }
+
+  /**
+   * Signal the transport to end the call session by closing the
+   * WebSocket. Twilio tears down the media stream when the socket
+   * closes.
+   */
+  endSession(reason?: string): void {
+    if (this.state === "closed") return;
+    this.state = "closed";
+
+    log.info(
+      { streamSid: this.streamSid, reason },
+      "Media stream output ending session",
+    );
+
+    try {
+      this.ws.close(1000, reason ?? "session-ended");
+    } catch (err) {
+      log.warn(
+        { err, streamSid: this.streamSid },
+        "Failed to close media-stream WebSocket",
+      );
+    }
+  }
+
+  /**
+   * Return the current connection-level state. The controller uses this
+   * to suppress silence nudges during guardian wait states.
+   */
+  getConnectionState(): string {
+    return this.state;
+  }
+
+  // ── Media-stream specific methods ───────────────────────────────────
+
+  /**
+   * Send a base64-encoded audio frame to Twilio for playback.
+   */
+  sendAudioPayload(base64Payload: string): void {
+    if (this.state === "closed") return;
+
+    const command: MediaStreamSendMediaCommand = {
+      event: "media",
+      streamSid: this.streamSid,
+      media: {
+        payload: base64Payload,
+      },
+    };
+
+    try {
+      this.ws.send(JSON.stringify(command));
+    } catch (err) {
+      log.error(
+        { err, streamSid: this.streamSid },
+        "Failed to send audio payload",
+      );
+    }
+  }
+
+  /**
+   * Insert a named mark into the outbound audio stream. Twilio echoes
+   * back a `mark` event when the caller reaches this point in playback.
+   */
+  sendMark(name: string): void {
+    if (this.state === "closed") return;
+
+    const command: MediaStreamSendMarkCommand = {
+      event: "mark",
+      streamSid: this.streamSid,
+      mark: { name },
+    };
+
+    try {
+      this.ws.send(JSON.stringify(command));
+    } catch (err) {
+      log.error(
+        { err, streamSid: this.streamSid },
+        "Failed to send mark command",
+      );
+    }
+  }
+
+  /**
+   * Clear any queued outbound audio. Useful for barge-in scenarios
+   * where the caller interrupts the assistant.
+   */
+  clearAudio(): void {
+    if (this.state === "closed") return;
+
+    const command: MediaStreamClearCommand = {
+      event: "clear",
+      streamSid: this.streamSid,
+    };
+
+    try {
+      this.ws.send(JSON.stringify(command));
+    } catch (err) {
+      log.error(
+        { err, streamSid: this.streamSid },
+        "Failed to send clear command",
+      );
+    }
+  }
+
+  /**
+   * Update the stream SID (e.g. after receiving the `start` event).
+   */
+  setStreamSid(streamSid: string): void {
+    this.streamSid = streamSid;
+  }
+
+  /**
+   * Get the current stream SID.
+   */
+  getStreamSid(): string {
+    return this.streamSid;
+  }
+
+  /**
+   * Mark the output as closed without sending a close frame.
+   * Used when the WebSocket is already closed by the remote side.
+   */
+  markClosed(): void {
+    this.state = "closed";
+  }
+}

--- a/assistant/src/calls/media-stream-server.ts
+++ b/assistant/src/calls/media-stream-server.ts
@@ -32,6 +32,7 @@
 
 import type { ServerWebSocket } from "bun";
 
+import { revokeScopedApprovalGrantsForContext } from "../memory/scoped-approval-grants.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { getLogger } from "../util/logger.js";
 import { CallController } from "./call-controller.js";
@@ -213,6 +214,24 @@ export class MediaStreamCallSession {
           );
         });
       }
+    }
+
+    // Revoke any scoped approval grants bound to this call session.
+    // Revoke by both callSessionId and conversationId because the
+    // guardian-approval-interception minting path sets callSessionId: null
+    // but always sets conversationId.
+    try {
+      revokeScopedApprovalGrantsForContext({
+        callSessionId: this.callSessionId,
+      });
+      revokeScopedApprovalGrantsForContext({
+        conversationId: session.conversationId,
+      });
+    } catch (err) {
+      log.warn(
+        { err, callSessionId: this.callSessionId },
+        "Failed to revoke scoped grants on media-stream transport close",
+      );
     }
 
     finalizeCall(this.callSessionId, session.conversationId);

--- a/assistant/src/calls/media-stream-server.ts
+++ b/assistant/src/calls/media-stream-server.ts
@@ -1,0 +1,382 @@
+/**
+ * Media-stream call server: binds WebSocket lifecycle to call-session
+ * lifecycle and wires STT session callbacks to controller entry points.
+ *
+ * Each active media-stream call has a single `MediaStreamCallSession`
+ * instance that:
+ *
+ * 1. Owns a {@link MediaStreamSttSession} for ingesting raw audio and
+ *    producing transcripts.
+ * 2. Owns a {@link MediaStreamOutput} for sending synthesized audio
+ *    and lifecycle signals back to Twilio.
+ * 3. Creates and registers a {@link CallController} to process
+ *    transcripts through the conversation pipeline.
+ *
+ * The server is registered on `/v1/calls/media-stream` but is **not**
+ * reachable from production TwiML — the Twilio voice webhook and
+ * relay setup router continue to use ConversationRelay exclusively.
+ * This module exists as a dark path for integration testing only.
+ *
+ * Lifecycle:
+ * - WebSocket `open` -> extract callSessionId from upgrade params,
+ *   create `MediaStreamCallSession`.
+ * - Media stream `start` event -> capture streamSid/callSid, wire
+ *   output adapter, create controller.
+ * - Media stream `media` events -> forwarded to STT session for
+ *   turn detection and transcription.
+ * - STT `onTranscriptFinal` -> routed to controller's
+ *   `handleCallerUtterance()`.
+ * - STT `onSpeechStart` -> (future) barge-in detection.
+ * - Media stream `stop` event / WebSocket close -> finalize call.
+ */
+
+import type { ServerWebSocket } from "bun";
+
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
+import { getLogger } from "../util/logger.js";
+import { CallController } from "./call-controller.js";
+import { addPointerMessage, formatDuration } from "./call-pointer-messages.js";
+import {
+  fireCallTranscriptNotifier,
+  registerCallController,
+  unregisterCallController,
+} from "./call-state.js";
+import { isTerminalState } from "./call-state-machine.js";
+import {
+  getCallSession,
+  recordCallEvent,
+  updateCallSession,
+} from "./call-store.js";
+import { finalizeCall } from "./finalize-call.js";
+import { MediaStreamOutput } from "./media-stream-output.js";
+import { parseMediaStreamFrame } from "./media-stream-parser.js";
+import {
+  MediaStreamSttSession,
+  type MediaStreamSttSessionCallbacks,
+  type MediaStreamSttSessionConfig,
+} from "./media-stream-stt-session.js";
+
+const log = getLogger("media-stream-server");
+
+// ---------------------------------------------------------------------------
+// Active sessions registry (keyed by callSessionId)
+// ---------------------------------------------------------------------------
+
+/**
+ * Active media-stream call sessions keyed by callSessionId.
+ *
+ * Exported for use in `call-domain.ts` (cancel call cleanup) and for
+ * test assertions. Not intended for general consumption.
+ */
+export const activeMediaStreamSessions = new Map<
+  string,
+  MediaStreamCallSession
+>();
+
+// ---------------------------------------------------------------------------
+// Session
+// ---------------------------------------------------------------------------
+
+export class MediaStreamCallSession {
+  readonly callSessionId: string;
+  private output: MediaStreamOutput;
+  private sttSession: MediaStreamSttSession;
+  private controller: CallController | null = null;
+  private streamSid: string | null = null;
+  private callSid: string | null = null;
+  private disposed = false;
+
+  constructor(
+    ws: ServerWebSocket<unknown>,
+    callSessionId: string,
+    sttConfig?: MediaStreamSttSessionConfig,
+  ) {
+    this.callSessionId = callSessionId;
+
+    // Create output adapter with a placeholder streamSid — it will be
+    // set when the `start` event arrives.
+    this.output = new MediaStreamOutput(ws, "");
+
+    // Create STT session with callbacks wired to the controller.
+    const callbacks: MediaStreamSttSessionCallbacks = {
+      onSpeechStart: () => this.handleSpeechStart(),
+      onTranscriptFinal: (text, durationMs) =>
+        this.handleTranscriptFinal(text, durationMs),
+      onDtmf: (digit) => this.handleDtmf(digit),
+      onStop: () => this.handleStreamStop(),
+      onError: (category, message) => this.handleSttError(category, message),
+    };
+
+    this.sttSession = new MediaStreamSttSession(sttConfig ?? {}, callbacks);
+
+    log.info({ callSessionId }, "Media stream call session created");
+  }
+
+  /**
+   * Get the output adapter (for test assertions).
+   */
+  getOutput(): MediaStreamOutput {
+    return this.output;
+  }
+
+  /**
+   * Get the controller (for test assertions).
+   */
+  getController(): CallController | null {
+    return this.controller;
+  }
+
+  /**
+   * Feed a raw WebSocket message into the session.
+   *
+   * The message is parsed to intercept `start` events (for session
+   * bootstrapping) before being forwarded to the STT session for
+   * audio processing.
+   */
+  handleMessage(raw: string): void {
+    if (this.disposed) return;
+
+    // Intercept `start` to bootstrap the session before forwarding.
+    const parseResult = parseMediaStreamFrame(raw);
+    if (parseResult.ok && parseResult.event.event === "start") {
+      this.handleStart(parseResult.event);
+    }
+
+    // Always forward to the STT session (it handles all event types).
+    this.sttSession.handleMessage(raw);
+  }
+
+  /**
+   * Handle WebSocket close. Finalizes the call session if not already
+   * in a terminal state.
+   */
+  handleTransportClosed(code?: number, reason?: string): void {
+    if (this.disposed) return;
+
+    const session = getCallSession(this.callSessionId);
+    if (!session) return;
+    if (isTerminalState(session.status)) return;
+
+    const isNormalClose = code === 1000;
+    if (isNormalClose) {
+      updateCallSession(this.callSessionId, {
+        status: "completed",
+        endedAt: Date.now(),
+      });
+      recordCallEvent(this.callSessionId, "call_ended", {
+        reason: reason || "media_stream_closed",
+        closeCode: code,
+      });
+
+      if (session.initiatedFromConversationId) {
+        const durationMs = session.startedAt
+          ? Date.now() - session.startedAt
+          : 0;
+        addPointerMessage(
+          session.initiatedFromConversationId,
+          "completed",
+          session.toNumber,
+          {
+            duration: durationMs > 0 ? formatDuration(durationMs) : undefined,
+          },
+        ).catch((err) => {
+          log.warn(
+            { conversationId: session.initiatedFromConversationId, err },
+            "Skipping pointer write — origin conversation may no longer exist",
+          );
+        });
+      }
+    } else {
+      const detail =
+        reason ||
+        (code ? `media_stream_closed_${code}` : "media_stream_closed_abnormal");
+      updateCallSession(this.callSessionId, {
+        status: "failed",
+        endedAt: Date.now(),
+        lastError: `Media stream WebSocket closed unexpectedly: ${detail}`,
+      });
+      recordCallEvent(this.callSessionId, "call_failed", {
+        reason: detail,
+        closeCode: code,
+      });
+
+      if (session.initiatedFromConversationId) {
+        addPointerMessage(
+          session.initiatedFromConversationId,
+          "failed",
+          session.toNumber,
+          { reason: detail },
+        ).catch((err) => {
+          log.warn(
+            { conversationId: session.initiatedFromConversationId, err },
+            "Skipping pointer write — origin conversation may no longer exist",
+          );
+        });
+      }
+    }
+
+    finalizeCall(this.callSessionId, session.conversationId);
+  }
+
+  /**
+   * Dispose of the session, cleaning up all resources.
+   */
+  destroy(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+
+    this.sttSession.dispose();
+
+    if (this.controller) {
+      this.controller.destroy();
+      unregisterCallController(this.callSessionId);
+      this.controller = null;
+    }
+
+    this.output.markClosed();
+
+    log.info(
+      { callSessionId: this.callSessionId },
+      "Media stream call session destroyed",
+    );
+  }
+
+  // ── Internal: media-stream event handlers ─────────────────────────
+
+  private handleStart(
+    event: import("./media-stream-protocol.js").MediaStreamStartEvent,
+  ): void {
+    this.streamSid = event.streamSid;
+    this.callSid = event.start.callSid;
+
+    // Update the output adapter with the real streamSid.
+    this.output.setStreamSid(event.streamSid);
+
+    // Update the call session with the provider call SID.
+    const session = getCallSession(this.callSessionId);
+    if (session) {
+      const updates: Parameters<typeof updateCallSession>[1] = {
+        providerCallSid: event.start.callSid,
+      };
+      if (
+        !isTerminalState(session.status) &&
+        session.status !== "in_progress" &&
+        session.status !== "waiting_on_user"
+      ) {
+        updates.status = "in_progress";
+        if (!session.startedAt) updates.startedAt = Date.now();
+      }
+      updateCallSession(this.callSessionId, updates);
+    }
+
+    recordCallEvent(this.callSessionId, "call_connected", {
+      callSid: event.start.callSid,
+      streamSid: event.streamSid,
+      encoding: event.start.mediaFormat.encoding,
+      sampleRate: event.start.mediaFormat.sampleRate,
+      transport: "media-stream",
+    });
+
+    // Create the call controller bound to the media-stream output.
+    this.controller = new CallController(
+      this.callSessionId,
+      this.output,
+      session?.task ?? null,
+      {
+        assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
+      },
+    );
+    registerCallController(this.callSessionId, this.controller);
+
+    log.info(
+      {
+        callSessionId: this.callSessionId,
+        streamSid: this.streamSid,
+        callSid: this.callSid,
+      },
+      "Media stream session started — controller registered",
+    );
+
+    // Fire the initial greeting.
+    this.controller.startInitialGreeting().catch((err) => {
+      log.error(
+        { err, callSessionId: this.callSessionId },
+        "Failed to start initial greeting on media-stream session",
+      );
+    });
+  }
+
+  // ── STT callbacks ─────────────────────────────────────────────────
+
+  private handleSpeechStart(): void {
+    // Future: barge-in detection — clear queued outbound audio when
+    // the caller starts speaking.
+    if (this.output && this.controller) {
+      this.output.clearAudio();
+    }
+  }
+
+  private handleTranscriptFinal(text: string, _durationMs: number): void {
+    if (!text.trim()) return;
+    if (!this.controller) {
+      log.warn(
+        { callSessionId: this.callSessionId },
+        "Transcript received but no controller — dropping",
+      );
+      return;
+    }
+
+    const session = getCallSession(this.callSessionId);
+    if (session) {
+      fireCallTranscriptNotifier(
+        session.conversationId,
+        this.callSessionId,
+        "caller",
+        text,
+      );
+    }
+
+    recordCallEvent(this.callSessionId, "caller_spoke", {
+      transcript: text,
+      transport: "media-stream",
+    });
+
+    // Route to the controller for conversation-backed response.
+    this.controller.handleCallerUtterance(text).catch((err) => {
+      log.error(
+        { err, callSessionId: this.callSessionId },
+        "Controller failed to handle caller utterance",
+      );
+    });
+  }
+
+  private handleDtmf(digit: string): void {
+    log.info(
+      { callSessionId: this.callSessionId, digit },
+      "DTMF digit received on media-stream",
+    );
+    recordCallEvent(this.callSessionId, "caller_spoke", {
+      dtmfDigit: digit,
+      transport: "media-stream",
+    });
+  }
+
+  private handleStreamStop(): void {
+    log.info(
+      { callSessionId: this.callSessionId },
+      "Media stream stop event received",
+    );
+    // The WebSocket close handler will finalize the call session.
+  }
+
+  private handleSttError(category: string, message: string): void {
+    log.error(
+      { callSessionId: this.callSessionId, category, message },
+      "STT error on media-stream session",
+    );
+    recordCallEvent(this.callSessionId, "call_failed", {
+      reason: `STT error: ${category} — ${message}`,
+      transport: "media-stream",
+    });
+  }
+}

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -295,6 +295,9 @@ interface BrowserRelayWebSocketData {
 interface MediaStreamWebSocketData {
   wsType: "media-stream";
   callSessionId: string;
+  /** Bound at open time so the close handler tears down the exact session
+   *  that owns *this* socket, avoiding races with reconnects. */
+  session?: MediaStreamCallSession;
 }
 
 export class RuntimeHttpServer {
@@ -428,6 +431,10 @@ export class RuntimeHttpServer {
               msData.callSessionId,
             );
             activeMediaStreamSessions.set(msData.callSessionId, session);
+            // Bind the session instance to the websocket so the close
+            // handler tears down *this* session, not a replacement that
+            // a reconnect may have inserted under the same callSessionId.
+            msData.session = session;
             return;
           }
           const callSessionId = (data as RelayWebSocketData).callSessionId;
@@ -571,10 +578,7 @@ export class RuntimeHttpServer {
           }
           if ("wsType" in data && data.wsType === "media-stream") {
             const msData = data as MediaStreamWebSocketData;
-            const msSession = activeMediaStreamSessions.get(
-              msData.callSessionId,
-            );
-            msSession?.handleMessage(raw);
+            msData.session?.handleMessage(raw);
             return;
           }
           const callSessionId = (data as RelayWebSocketData).callSessionId;
@@ -604,12 +608,22 @@ export class RuntimeHttpServer {
               },
               "Media-stream WebSocket closed",
             );
-            const msSession = activeMediaStreamSessions.get(
-              msData.callSessionId,
-            );
-            msSession?.handleTransportClosed(code, reason?.toString());
-            msSession?.destroy();
-            activeMediaStreamSessions.delete(msData.callSessionId);
+            // Use the session bound at open time so we tear down the
+            // exact session that owns *this* socket, not a replacement
+            // that a reconnect may have inserted under the same key.
+            const msSession = msData.session;
+            if (msSession) {
+              msSession.handleTransportClosed(code, reason?.toString());
+              msSession.destroy();
+              // Only delete from the map if *our* session is still the
+              // registered one — a reconnect may have already replaced it.
+              if (
+                activeMediaStreamSessions.get(msData.callSessionId) ===
+                msSession
+              ) {
+                activeMediaStreamSessions.delete(msData.callSessionId);
+              }
+            }
             return;
           }
           const callSessionId = (data as RelayWebSocketData).callSessionId;

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -21,6 +21,10 @@ import {
   startGuardianActionSweep,
   stopGuardianActionSweep,
 } from "../calls/guardian-action-sweep.js";
+import {
+  activeMediaStreamSessions,
+  MediaStreamCallSession,
+} from "../calls/media-stream-server.js";
 import type { RelayWebSocketData } from "../calls/relay-server.js";
 import {
   activeRelayConnections,
@@ -283,6 +287,16 @@ interface BrowserRelayWebSocketData {
   clientInstanceId?: string;
 }
 
+/**
+ * WebSocket data attached to `/v1/calls/media-stream` connections.
+ * The `wsType` discriminator routes frames to the media-stream call
+ * session instead of the ConversationRelay or browser-relay handlers.
+ */
+interface MediaStreamWebSocketData {
+  wsType: "media-stream";
+  callSessionId: string;
+}
+
 export class RuntimeHttpServer {
   private server: ReturnType<typeof Bun.serve> | null = null;
   private port: number;
@@ -373,7 +387,10 @@ export class RuntimeHttpServer {
   }
 
   async start(): Promise<void> {
-    type AllWebSocketData = RelayWebSocketData | BrowserRelayWebSocketData;
+    type AllWebSocketData =
+      | RelayWebSocketData
+      | BrowserRelayWebSocketData
+      | MediaStreamWebSocketData;
     this.server = Bun.serve<AllWebSocketData>({
       port: this.port,
       hostname: this.hostname,
@@ -398,6 +415,19 @@ export class RuntimeHttpServer {
                 lastActiveAt: now,
               });
             }
+            return;
+          }
+          if ("wsType" in data && data.wsType === "media-stream") {
+            const msData = data as MediaStreamWebSocketData;
+            log.info(
+              { callSessionId: msData.callSessionId },
+              "Media-stream WebSocket opened",
+            );
+            const session = new MediaStreamCallSession(
+              ws,
+              msData.callSessionId,
+            );
+            activeMediaStreamSessions.set(msData.callSessionId, session);
             return;
           }
           const callSessionId = (data as RelayWebSocketData).callSessionId;
@@ -539,6 +569,14 @@ export class RuntimeHttpServer {
               }
             }
           }
+          if ("wsType" in data && data.wsType === "media-stream") {
+            const msData = data as MediaStreamWebSocketData;
+            const msSession = activeMediaStreamSessions.get(
+              msData.callSessionId,
+            );
+            msSession?.handleMessage(raw);
+            return;
+          }
           const callSessionId = (data as RelayWebSocketData).callSessionId;
           if (callSessionId) {
             const connection = activeRelayConnections.get(callSessionId);
@@ -554,6 +592,24 @@ export class RuntimeHttpServer {
             // undefined, or when it was superseded by a newer registration
             // for the same guardian).
             getChromeExtensionRegistry().unregister(data.connectionId);
+            return;
+          }
+          if ("wsType" in data && data.wsType === "media-stream") {
+            const msData = data as MediaStreamWebSocketData;
+            log.info(
+              {
+                callSessionId: msData.callSessionId,
+                code,
+                reason: reason?.toString(),
+              },
+              "Media-stream WebSocket closed",
+            );
+            const msSession = activeMediaStreamSessions.get(
+              msData.callSessionId,
+            );
+            msSession?.handleTransportClosed(code, reason?.toString());
+            msSession?.destroy();
+            activeMediaStreamSessions.delete(msData.callSessionId);
             return;
           }
           const callSessionId = (data as RelayWebSocketData).callSessionId;
@@ -1095,9 +1151,14 @@ export class RuntimeHttpServer {
     if (!callSessionId) {
       return new Response("Missing callSessionId", { status: 400 });
     }
-    // Media-stream connections use the same data shape as relay for now.
-    // The callSessionId links the stream to the active call session.
-    const upgraded = server.upgrade(req, { data: { callSessionId } });
+    // Media-stream connections use a distinct wsType so the open/message/close
+    // handlers route them to MediaStreamCallSession instead of RelayConnection.
+    const upgraded = server.upgrade(req, {
+      data: {
+        wsType: "media-stream",
+        callSessionId,
+      } satisfies MediaStreamWebSocketData,
+    });
     if (!upgraded) {
       return new Response("WebSocket upgrade failed", { status: 500 });
     }


### PR DESCRIPTION
## Summary
- Implement media-stream output adapter for synthesized audio frames and mark events
- Implement media-stream-server binding websocket lifecycle to call-session lifecycle
- Register on /v1/calls/media-stream while keeping it unreachable from production TwiML

Part of plan: twilio-services-stt-provider-unification.md (PR 5 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25039" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
