### PR TITLE
Add Deepgram prerecorded-audio STT adapter with unit coverage

### DIFF
--- a/assistant/src/providers/speech-to-text/deepgram.test.ts
+++ b/assistant/src/providers/speech-to-text/deepgram.test.ts
@@ -324,7 +324,9 @@ describe("DeepgramProvider", () => {
     await provider.transcribe(audioData, "audio/wav");
 
     // Deepgram accepts raw bytes — verify we're not wrapping in FormData
-    expect(capturedBody).toBeInstanceOf(Buffer);
-    expect(Buffer.compare(capturedBody as Buffer, audioData)).toBe(0);
+    expect(capturedBody).toBeInstanceOf(Uint8Array);
+    expect(
+      Buffer.compare(Buffer.from(capturedBody as Uint8Array), audioData),
+    ).toBe(0);
   });
 });

--- a/assistant/src/providers/speech-to-text/deepgram.test.ts
+++ b/assistant/src/providers/speech-to-text/deepgram.test.ts
@@ -1,0 +1,330 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { DeepgramProvider } from "./deepgram.js";
+
+const TEST_API_KEY = "dg-test-key-for-unit-tests";
+
+/** Helper: build a Deepgram-shaped JSON response body. */
+function deepgramResponse(transcript: string): string {
+  return JSON.stringify({
+    results: {
+      channels: [{ alternatives: [{ transcript }] }],
+    },
+  });
+}
+
+describe("DeepgramProvider", () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  // -----------------------------------------------------------------------
+  // Success path
+  // -----------------------------------------------------------------------
+
+  test("successful transcription returns trimmed text", async () => {
+    globalThis.fetch = (async (
+      _url: string | URL | Request,
+      _init?: RequestInit,
+    ) => {
+      return new Response(deepgramResponse("  Hello from Deepgram!  "), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    const provider = new DeepgramProvider(TEST_API_KEY);
+    const result = await provider.transcribe(
+      Buffer.from("fake-audio"),
+      "audio/wav",
+    );
+
+    expect(result).toEqual({ text: "Hello from Deepgram!" });
+  });
+
+  // -----------------------------------------------------------------------
+  // Empty transcript
+  // -----------------------------------------------------------------------
+
+  test("returns empty text when transcript is empty string", async () => {
+    globalThis.fetch = (async () => {
+      return new Response(deepgramResponse(""), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+
+    const provider = new DeepgramProvider(TEST_API_KEY);
+    const result = await provider.transcribe(
+      Buffer.from("silence"),
+      "audio/wav",
+    );
+
+    expect(result).toEqual({ text: "" });
+  });
+
+  // -----------------------------------------------------------------------
+  // Malformed response fallback
+  // -----------------------------------------------------------------------
+
+  test("returns empty text when response has no results property", async () => {
+    globalThis.fetch = (async () => {
+      return new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+
+    const provider = new DeepgramProvider(TEST_API_KEY);
+    const result = await provider.transcribe(Buffer.from("audio"), "audio/wav");
+
+    expect(result).toEqual({ text: "" });
+  });
+
+  test("returns empty text when channels array is empty", async () => {
+    globalThis.fetch = (async () => {
+      return new Response(JSON.stringify({ results: { channels: [] } }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+
+    const provider = new DeepgramProvider(TEST_API_KEY);
+    const result = await provider.transcribe(Buffer.from("audio"), "audio/wav");
+
+    expect(result).toEqual({ text: "" });
+  });
+
+  test("returns empty text when alternatives array is empty", async () => {
+    globalThis.fetch = (async () => {
+      return new Response(
+        JSON.stringify({ results: { channels: [{ alternatives: [] }] } }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    }) as unknown as typeof fetch;
+
+    const provider = new DeepgramProvider(TEST_API_KEY);
+    const result = await provider.transcribe(Buffer.from("audio"), "audio/wav");
+
+    expect(result).toEqual({ text: "" });
+  });
+
+  test("returns empty text when transcript field is missing", async () => {
+    globalThis.fetch = (async () => {
+      return new Response(
+        JSON.stringify({
+          results: { channels: [{ alternatives: [{ confidence: 0.95 }] }] },
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    }) as unknown as typeof fetch;
+
+    const provider = new DeepgramProvider(TEST_API_KEY);
+    const result = await provider.transcribe(Buffer.from("audio"), "audio/wav");
+
+    expect(result).toEqual({ text: "" });
+  });
+
+  // -----------------------------------------------------------------------
+  // Non-2xx error propagation
+  // -----------------------------------------------------------------------
+
+  test("API error throws with status and partial body", async () => {
+    const errorBody = JSON.stringify({
+      err_code: "INVALID_AUTH",
+      err_msg: "Invalid credentials",
+    });
+
+    globalThis.fetch = (async (
+      _url: string | URL | Request,
+      _init?: RequestInit,
+    ) => {
+      return new Response(errorBody, {
+        status: 401,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    const provider = new DeepgramProvider(TEST_API_KEY);
+
+    await expect(
+      provider.transcribe(Buffer.from("fake-audio"), "audio/wav"),
+    ).rejects.toThrow("Deepgram API error (401)");
+  });
+
+  test("error body is truncated to 300 characters", async () => {
+    const longBody = "x".repeat(500);
+
+    globalThis.fetch = (async () => {
+      return new Response(longBody, { status: 500 });
+    }) as unknown as typeof fetch;
+
+    const provider = new DeepgramProvider(TEST_API_KEY);
+
+    try {
+      await provider.transcribe(Buffer.from("audio"), "audio/wav");
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      const msg = (err as Error).message;
+      expect(msg).toContain("Deepgram API error (500)");
+      // The body portion should be at most 300 chars
+      const bodyPart = msg.replace("Deepgram API error (500): ", "");
+      expect(bodyPart.length).toBeLessThanOrEqual(300);
+    }
+  });
+
+  // -----------------------------------------------------------------------
+  // Request URL / query construction
+  // -----------------------------------------------------------------------
+
+  test("sends correct URL with default query params (model, smart_format)", async () => {
+    let capturedUrl: string | undefined;
+    let capturedHeaders: Record<string, string> | undefined;
+    let capturedContentType: string | undefined;
+
+    globalThis.fetch = (async (
+      url: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      capturedUrl = String(url);
+      const headers = init?.headers as Record<string, string> | undefined;
+      capturedHeaders = headers;
+      capturedContentType = headers?.["Content-Type"];
+
+      return new Response(deepgramResponse("ok"), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    const provider = new DeepgramProvider(TEST_API_KEY);
+    await provider.transcribe(Buffer.from("fake-audio"), "audio/ogg");
+
+    // URL shape
+    expect(capturedUrl).toContain("https://api.deepgram.com/v1/listen");
+    const url = new URL(capturedUrl!);
+    expect(url.searchParams.get("model")).toBe("nova-2");
+    expect(url.searchParams.get("smart_format")).toBe("true");
+    expect(url.searchParams.has("language")).toBe(false);
+
+    // Auth header uses Token scheme
+    expect(capturedHeaders?.Authorization).toBe(`Token ${TEST_API_KEY}`);
+
+    // Content-Type matches the input MIME
+    expect(capturedContentType).toBe("audio/ogg");
+  });
+
+  test("includes language param when specified", async () => {
+    let capturedUrl: string | undefined;
+
+    globalThis.fetch = (async (url: string | URL | Request) => {
+      capturedUrl = String(url);
+      return new Response(deepgramResponse("hola"), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    const provider = new DeepgramProvider(TEST_API_KEY, { language: "es" });
+    await provider.transcribe(Buffer.from("audio"), "audio/wav");
+
+    const url = new URL(capturedUrl!);
+    expect(url.searchParams.get("language")).toBe("es");
+  });
+
+  test("uses custom model when specified", async () => {
+    let capturedUrl: string | undefined;
+
+    globalThis.fetch = (async (url: string | URL | Request) => {
+      capturedUrl = String(url);
+      return new Response(deepgramResponse("text"), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    const provider = new DeepgramProvider(TEST_API_KEY, {
+      model: "nova-2-medical",
+    });
+    await provider.transcribe(Buffer.from("audio"), "audio/wav");
+
+    const url = new URL(capturedUrl!);
+    expect(url.searchParams.get("model")).toBe("nova-2-medical");
+  });
+
+  test("omits smart_format when smartFormatting is false", async () => {
+    let capturedUrl: string | undefined;
+
+    globalThis.fetch = (async (url: string | URL | Request) => {
+      capturedUrl = String(url);
+      return new Response(deepgramResponse("text"), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    const provider = new DeepgramProvider(TEST_API_KEY, {
+      smartFormatting: false,
+    });
+    await provider.transcribe(Buffer.from("audio"), "audio/wav");
+
+    const url = new URL(capturedUrl!);
+    expect(url.searchParams.has("smart_format")).toBe(false);
+  });
+
+  test("uses custom base URL when specified", async () => {
+    let capturedUrl: string | undefined;
+
+    globalThis.fetch = (async (url: string | URL | Request) => {
+      capturedUrl = String(url);
+      return new Response(deepgramResponse("text"), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    const provider = new DeepgramProvider(TEST_API_KEY, {
+      baseUrl: "https://custom-deepgram.example.com/",
+    });
+    await provider.transcribe(Buffer.from("audio"), "audio/wav");
+
+    expect(capturedUrl).toContain(
+      "https://custom-deepgram.example.com/v1/listen",
+    );
+  });
+
+  test("sends raw audio bytes as request body (not FormData)", async () => {
+    let capturedBody: BodyInit | undefined;
+
+    globalThis.fetch = (async (
+      _url: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      capturedBody = init?.body as BodyInit;
+      return new Response(deepgramResponse("text"), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    const audioData = Buffer.from("raw-audio-bytes");
+    const provider = new DeepgramProvider(TEST_API_KEY);
+    await provider.transcribe(audioData, "audio/wav");
+
+    // Deepgram accepts raw bytes — verify we're not wrapping in FormData
+    expect(capturedBody).toBeInstanceOf(Buffer);
+    expect(Buffer.compare(capturedBody as Buffer, audioData)).toBe(0);
+  });
+});

--- a/assistant/src/providers/speech-to-text/deepgram.ts
+++ b/assistant/src/providers/speech-to-text/deepgram.ts
@@ -1,0 +1,115 @@
+import type { SttTranscribeResult } from "../../stt/types.js";
+
+const DEFAULT_BASE_URL = "https://api.deepgram.com";
+const DEFAULT_MODEL = "nova-2";
+const DEFAULT_TIMEOUT_MS = 60_000;
+
+// ---------------------------------------------------------------------------
+// Options
+// ---------------------------------------------------------------------------
+
+export interface DeepgramProviderOptions {
+  /** Deepgram model to use (default: "nova-2"). */
+  model?: string;
+  /** BCP-47 language code (e.g. "en", "es"). Omitted by default (auto-detect). */
+  language?: string;
+  /** Enable Deepgram smart formatting (punctuation, numerals, etc.). Default: true. */
+  smartFormatting?: boolean;
+  /** Override the Deepgram API base URL (useful for proxies or on-prem). */
+  baseUrl?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
+/**
+ * Deepgram prerecorded-audio STT provider.
+ *
+ * Posts raw audio bytes to Deepgram's `/v1/listen` endpoint and returns
+ * a normalised `{ text }` result compatible with the daemon batch
+ * transcription boundary.
+ */
+export class DeepgramProvider {
+  private readonly apiKey: string;
+  private readonly model: string;
+  private readonly language: string | undefined;
+  private readonly smartFormatting: boolean;
+  private readonly baseUrl: string;
+
+  constructor(apiKey: string, options: DeepgramProviderOptions = {}) {
+    this.apiKey = apiKey;
+    this.model = options.model ?? DEFAULT_MODEL;
+    this.language = options.language;
+    this.smartFormatting = options.smartFormatting ?? true;
+    this.baseUrl = (options.baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, "");
+  }
+
+  async transcribe(
+    audio: Buffer,
+    mimeType: string,
+    signal?: AbortSignal,
+  ): Promise<SttTranscribeResult> {
+    const url = this.buildRequestUrl();
+    const effectiveSignal = signal ?? AbortSignal.timeout(DEFAULT_TIMEOUT_MS);
+
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Token ${this.apiKey}`,
+        "Content-Type": mimeType,
+      },
+      body: audio,
+      signal: effectiveSignal,
+    });
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => "");
+      throw new Error(
+        `Deepgram API error (${response.status}): ${body.slice(0, 300)}`,
+      );
+    }
+
+    const result = (await response.json()) as DeepgramResponse;
+    const transcript =
+      result?.results?.channels?.[0]?.alternatives?.[0]?.transcript;
+
+    return { text: typeof transcript === "string" ? transcript.trim() : "" };
+  }
+
+  // -------------------------------------------------------------------------
+  // Internals
+  // -------------------------------------------------------------------------
+
+  private buildRequestUrl(): string {
+    const params = new URLSearchParams();
+    params.set("model", this.model);
+    if (this.language) {
+      params.set("language", this.language);
+    }
+    if (this.smartFormatting) {
+      params.set("smart_format", "true");
+    }
+    return `${this.baseUrl}/v1/listen?${params.toString()}`;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Response shape (subset relevant to transcript extraction)
+// ---------------------------------------------------------------------------
+
+interface DeepgramAlternative {
+  transcript?: string;
+}
+
+interface DeepgramChannel {
+  alternatives?: DeepgramAlternative[];
+}
+
+interface DeepgramResults {
+  channels?: DeepgramChannel[];
+}
+
+interface DeepgramResponse {
+  results?: DeepgramResults;
+}

--- a/assistant/src/providers/speech-to-text/deepgram.ts
+++ b/assistant/src/providers/speech-to-text/deepgram.ts
@@ -59,7 +59,7 @@ export class DeepgramProvider {
         Authorization: `Token ${this.apiKey}`,
         "Content-Type": mimeType,
       },
-      body: audio,
+      body: new Uint8Array(audio),
       signal: effectiveSignal,
     });
 


### PR DESCRIPTION
## Summary
- Adds a standalone Deepgram STT provider class that posts audio bytes to /v1/listen and returns normalized transcript text
- Includes configurable options (model, language, smart formatting, base URL override)
- Comprehensive unit tests covering success, empty transcript, malformed response, and error paths

Part of plan: deepgram-first-class-services-stt.md (PR 1 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25042" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
