### PR TITLE
assistant+gateway: document and validate one-step twilio stt cutover readiness

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -595,15 +595,35 @@ Audio-to-text conversion occurs in four distinct runtime boundaries, each with i
 | **Client service-first**     | macOS / iOS via gateway → daemon      | Configured STT provider (via `services.stt`) | `src/runtime/routes/stt-routes.ts`, `clients/shared/Network/STTClient.swift`                       | `VoiceInputManager` (macOS dictation), `InputBarView` (iOS), `OpenAIVoiceService` (macOS voice mode) |
 | **Client-native (fallback)** | macOS / iOS on-device                 | Apple Speech (`SFSpeechRecognizer`)          | `clients/macos/.../SpeechRecognizerAdapter.swift`, `clients/ios/.../SpeechRecognizerAdapter.swift` | Fallback when STT service is unconfigured or fails                                                   |
 
-**Telephony-native boundary:**
+**Telephony-native boundary (current production path):**
 
 STT runs inside the telephony platform (Twilio ConversationRelay). The daemon does not receive raw audio — it receives transcribed text from the relay. Provider selection is config-driven (`calls.voice.transcriptionProvider`, `calls.voice.speechModel`).
 
 - `resolveTelephonySttProfile()` in `src/calls/stt-profile.ts` maps config values to a provider-agnostic `TelephonySttProfile` with provider-specific defaults (Deepgram defaults to `"nova-3"`; Google leaves the model undefined).
 - `buildTwilioRelaySpeechConfig()` in `src/calls/twilio-relay-speech-config.ts` serializes the profile into Twilio ConversationRelay TwiML attributes.
 - `twilio-routes.ts` calls both at call setup time.
+- Guard tests in `__tests__/twilio-routes-twiml.test.ts` ("ConversationRelay STT attribute guardrails") and `__tests__/twilio-routes.test.ts` ("ConversationRelay STT integration guardrails") assert that TwiML always emits `<ConversationRelay>` with `transcriptionProvider` sourced from `calls.voice` config.
 
 To add a new telephony STT provider: add a branch in `resolveEffectiveSpeechModel()` for the provider's default model behavior, then ensure `buildTwilioRelaySpeechConfig` passes the provider name through to the TwiML.
+
+**Prepared dark path — `services.stt` telephony cutover:**
+
+A parallel set of modules is fully wired but **not** connected to the production call setup path. These form the activation seam for a future cutover from ConversationRelay-native STT to `services.stt`-driven telephony STT via the Twilio Media Streams protocol:
+
+| Module                                                                      | Purpose                                                                       | Status       |
+| --------------------------------------------------------------------------- | ----------------------------------------------------------------------------- | ------------ |
+| `src/providers/speech-to-text/provider-catalog.ts`                          | Provider catalog with `telephonyMode` metadata per entry                      | Ready (PR 5) |
+| `src/providers/speech-to-text/resolve.ts` (`resolveTelephonySttCapability`) | Validates whether `services.stt` provider is telephony-eligible               | Ready (PR 5) |
+| `src/calls/stt-profile.ts` (`evaluateServicesSttReadiness`)                 | Preflight helper — checks config + catalog + credentials without side effects | Ready (PR 6) |
+| `src/calls/media-stream-parser.ts`                                          | Twilio Media Streams protocol parser                                          | Ready (PR 2) |
+| `src/calls/media-turn-detector.ts`                                          | Energy-based VAD turn detector for raw audio                                  | Ready (PR 2) |
+| `src/calls/media-stream-stt-session.ts`                                     | STT session that transcribes audio turns via `services.stt`                   | Ready (PR 2) |
+| `src/calls/call-transport.ts`                                               | Transport interface decoupling CallController from wire protocol              | Ready (PR 1) |
+| `src/calls/media-stream-output.ts`                                          | Output adapter for sending TTS audio back via Media Streams                   | Ready (PR 3) |
+| `src/calls/media-stream-server.ts`                                          | WebSocket server binding media-stream lifecycle to call sessions              | Ready (PR 3) |
+| `gateway/src/http/routes/twilio-media-websocket.ts`                         | Gateway WebSocket proxy for Media Streams frames (inactive)                   | Ready (PR 4) |
+
+**Activation seam:** The single change needed to activate this path is in `twilio-routes.ts` — switch the TwiML element from `<ConversationRelay>` to `<Connect><Stream>` and route the WebSocket URL to the media-stream server instead of the relay server. See the cutover runbook in `docs/internal-reference.md` for the exact steps.
 
 **Daemon batch boundary:**
 
@@ -649,7 +669,8 @@ These differences are intentional — the adapters were designed for their respe
 
 **Cross-boundary notes:**
 
-- The `services.stt` config block controls provider selection for both the daemon batch boundary and the client service-first boundary (they share `resolveBatchTranscriber()`). Telephony STT is configured separately via `calls.voice.transcriptionProvider`.
+- The `services.stt` config block controls provider selection for both the daemon batch boundary and the client service-first boundary (they share `resolveBatchTranscriber()`). Telephony STT is configured separately via `calls.voice.transcriptionProvider`. A prepared (but inactive) dark path exists to unify telephony STT under `services.stt` — see "Prepared dark path" above and the cutover runbook in `docs/internal-reference.md`.
+- `evaluateServicesSttReadiness()` in `src/calls/stt-profile.ts` can validate cutover prerequisites without affecting active calls.
 - Terminology: "STT" and "transcription" refer to the same operation (converting audio to text). "Speech recognition" is used in client-native contexts where Apple's Speech framework terminology is canonical. All three terms map to the same conceptual operation.
 
 ### Update Bulletin System

--- a/assistant/src/__tests__/twilio-routes-twiml.test.ts
+++ b/assistant/src/__tests__/twilio-routes-twiml.test.ts
@@ -431,3 +431,111 @@ describe("generateTwiML with voice quality profile", () => {
     expect(twiml).not.toContain("hints=\"O'Brien");
   });
 });
+
+// ── ConversationRelay STT guardrail tests ─────────────────────────────
+// These tests assert that production TwiML continues to emit
+// ConversationRelay-native STT attributes sourced from
+// calls.voice.transcriptionProvider (not from services.stt). They serve
+// as regression guardrails for the future cutover — if a change
+// inadvertently switches the STT source, these tests will fail.
+
+describe("ConversationRelay STT attribute guardrails", () => {
+  const callSessionId = "guardrail-session-1";
+  const relayUrl = "wss://test.example.com/v1/calls/relay";
+
+  test("TwiML contains <ConversationRelay> element with transcriptionProvider attribute", () => {
+    const twiml = generateTwiML(
+      callSessionId,
+      relayUrl,
+      null,
+      {
+        language: "en-US",
+        ttsProvider: "Google",
+        voice: "Google.en-US-Journey-O",
+      },
+      speechConfigFor("Deepgram", undefined, "low"),
+    );
+
+    // Must use ConversationRelay (not <Stream> or media-stream)
+    expect(twiml).toContain("<ConversationRelay");
+    expect(twiml).not.toContain("<Stream");
+    // transcriptionProvider is a ConversationRelay-native attribute
+    expect(twiml).toContain('transcriptionProvider="Deepgram"');
+  });
+
+  test("Deepgram default: TwiML emits transcriptionProvider=Deepgram and speechModel=nova-3", () => {
+    const twiml = generateTwiML(
+      callSessionId,
+      relayUrl,
+      null,
+      { language: "en-US", ttsProvider: "ElevenLabs", voice: "voice1" },
+      speechConfigFor("Deepgram", undefined, "low"),
+    );
+
+    expect(twiml).toContain('transcriptionProvider="Deepgram"');
+    expect(twiml).toContain('speechModel="nova-3"');
+  });
+
+  test("Google default: TwiML emits transcriptionProvider=Google with no speechModel", () => {
+    const twiml = generateTwiML(
+      callSessionId,
+      relayUrl,
+      null,
+      { language: "en-US", ttsProvider: "ElevenLabs", voice: "voice1" },
+      speechConfigFor("Google", undefined, "low"),
+    );
+
+    expect(twiml).toContain('transcriptionProvider="Google"');
+    expect(twiml).not.toContain("speechModel=");
+  });
+
+  test("STT attributes are sourced from resolveTelephonySttProfile (calls.voice config), not services.stt", () => {
+    // This test verifies the data flow: calls.voice.transcriptionProvider
+    // -> resolveTelephonySttProfile -> buildTwilioRelaySpeechConfig -> TwiML.
+    // The services.stt provider (openai-whisper) must NOT appear in TwiML.
+    const sttProfile = resolveTelephonySttProfile({
+      transcriptionProvider: "Deepgram",
+      speechModel: undefined,
+    });
+    const speechConfig = buildTwilioRelaySpeechConfig(
+      sttProfile,
+      "low",
+      undefined,
+    );
+
+    const twiml = generateTwiML(
+      callSessionId,
+      relayUrl,
+      null,
+      { language: "en-US", ttsProvider: "ElevenLabs", voice: "voice1" },
+      speechConfig,
+    );
+
+    // The TwiML must contain the calls.voice provider, not services.stt
+    expect(twiml).toContain('transcriptionProvider="Deepgram"');
+    expect(twiml).not.toContain("openai-whisper");
+    expect(twiml).not.toContain("openai");
+  });
+
+  test("ConversationRelay element contains all required STT-related attributes", () => {
+    const twiml = generateTwiML(
+      callSessionId,
+      relayUrl,
+      null,
+      {
+        language: "en-US",
+        ttsProvider: "Google",
+        voice: "Google.en-US-Journey-O",
+      },
+      speechConfigFor("Deepgram", "nova-3", "medium", "Alice,Bob"),
+    );
+
+    // All STT-related attributes that ConversationRelay supports
+    expect(twiml).toContain('transcriptionProvider="Deepgram"');
+    expect(twiml).toContain('speechModel="nova-3"');
+    expect(twiml).toContain('interruptSensitivity="medium"');
+    expect(twiml).toContain('hints="Alice,Bob"');
+    expect(twiml).toContain('interruptible="true"');
+    expect(twiml).toContain('dtmfDetection="true"');
+  });
+});

--- a/assistant/src/__tests__/twilio-routes.test.ts
+++ b/assistant/src/__tests__/twilio-routes.test.ts
@@ -1029,6 +1029,46 @@ describe("twilio webhook routes", () => {
     });
   });
 
+  // ── ConversationRelay STT integration guardrails ────────────────────
+  // These tests assert at the handler level that the voice webhook TwiML
+  // always uses ConversationRelay with STT attributes from
+  // calls.voice.transcriptionProvider — the current production path.
+
+  describe("ConversationRelay STT integration guardrails", () => {
+    test("outbound voice webhook TwiML uses ConversationRelay with transcriptionProvider from config", async () => {
+      const session = createTestSession("conv-stt-guard-1", "CA_stt_guard_1");
+      const req = makeVoiceRequest(session.id, { CallSid: "CA_stt_guard_1" });
+
+      const res = await handleVoiceWebhook(req);
+      expect(res.status).toBe(200);
+
+      const twiml = await res.text();
+      // Must use ConversationRelay (not <Stream> / media-stream)
+      expect(twiml).toContain("<ConversationRelay");
+      expect(twiml).not.toContain("<Stream");
+      // STT attributes must come from calls.voice config (Deepgram default)
+      expect(twiml).toContain('transcriptionProvider="Deepgram"');
+      // services.stt provider must NOT appear in TwiML
+      expect(twiml).not.toContain("openai-whisper");
+    });
+
+    test("inbound voice webhook TwiML uses ConversationRelay with transcriptionProvider from config", async () => {
+      const req = makeInboundVoiceRequest({
+        CallSid: "CA_stt_guard_inbound_1",
+        From: "+14155551234",
+        To: "+15550001111",
+      });
+
+      const res = await handleVoiceWebhook(req);
+      expect(res.status).toBe(200);
+
+      const twiml = await res.text();
+      expect(twiml).toContain("<ConversationRelay");
+      expect(twiml).toContain('transcriptionProvider="Deepgram"');
+      expect(twiml).not.toContain("<Stream");
+    });
+  });
+
   describe("Twilio control-plane credential and number operations", () => {
     test("setting credentials stores them and returns success", async () => {
       mockRawConfigStore = {};

--- a/assistant/src/calls/stt-profile.ts
+++ b/assistant/src/calls/stt-profile.ts
@@ -11,9 +11,27 @@
  *   API uses its own default). Treats the legacy Deepgram default `"nova-3"`
  *   as unset — upgraded workspaces may still have it persisted from prior
  *   defaults before provider was switched.
+ *
+ * ## Cutover readiness
+ *
+ * {@link evaluateServicesSttReadiness} is a pure preflight check that
+ * validates whether the `services.stt` provider (the future telephony STT
+ * path) is configured and telephony-eligible. It does **not** alter the
+ * active call setup — production calls continue to use the ConversationRelay
+ * native STT path driven by `calls.voice.transcriptionProvider`.
+ *
+ * The cutover activation seam is a single future change in
+ * `twilio-routes.ts`: replace the call to `resolveTelephonySttProfile()`
+ * with a resolver that reads from `services.stt` instead of
+ * `calls.voice.transcriptionProvider`. See the cutover runbook in
+ * `docs/internal-reference.md` for the full step-by-step plan.
  */
 
 import type { CallsVoiceConfig } from "../config/schemas/calls.js";
+import {
+  resolveTelephonySttCapability,
+  type TelephonySttCapability,
+} from "../providers/speech-to-text/resolve.js";
 
 /**
  * Provider-agnostic representation of the telephony STT configuration.
@@ -71,4 +89,68 @@ function resolveEffectiveSpeechModel(
   }
 
   return rawSpeechModel;
+}
+
+// ── Cutover readiness preflight ─────────────────────────────────────
+
+/**
+ * Outcome of the services.stt telephony readiness check.
+ *
+ * - `ready` — the configured `services.stt` provider is telephony-eligible
+ *   and credentials are present. A future cutover can proceed.
+ * - `not-ready` — one or more prerequisites are unmet. The `reasons` array
+ *   contains human-readable diagnostics.
+ */
+export type ServicesSttReadiness =
+  | {
+      status: "ready";
+      capability: TelephonySttCapability & { status: "supported" };
+    }
+  | {
+      status: "not-ready";
+      reasons: string[];
+      capability: TelephonySttCapability;
+    };
+
+/**
+ * Evaluate whether the `services.stt` provider is ready for a future
+ * telephony cutover.
+ *
+ * This is a **read-only preflight check** — it inspects configuration,
+ * the provider catalog, and credential availability without creating live
+ * connections or modifying call setup behavior. Production calls continue
+ * on the ConversationRelay native STT path regardless of this result.
+ *
+ * Intended callers:
+ * - Integration tests that assert cutover preconditions.
+ * - Future admin/diagnostic endpoints that surface readiness status.
+ * - The cutover PR itself, to gate activation on a passing preflight.
+ */
+export async function evaluateServicesSttReadiness(): Promise<ServicesSttReadiness> {
+  const capability = await resolveTelephonySttCapability();
+
+  if (capability.status === "supported") {
+    return { status: "ready", capability };
+  }
+
+  const reasons: string[] = [];
+  switch (capability.status) {
+    case "unconfigured":
+      reasons.push(
+        `services.stt provider is not in the provider catalog: ${capability.reason}`,
+      );
+      break;
+    case "unsupported":
+      reasons.push(
+        `services.stt provider "${capability.providerId}" does not support telephony: ${capability.reason}`,
+      );
+      break;
+    case "missing-credentials":
+      reasons.push(
+        `services.stt provider "${capability.providerId}" is telephony-eligible but missing credentials for "${capability.credentialProvider}": ${capability.reason}`,
+      );
+      break;
+  }
+
+  return { status: "not-ready", reasons, capability };
 }

--- a/assistant/src/calls/twilio-relay-speech-config.ts
+++ b/assistant/src/calls/twilio-relay-speech-config.ts
@@ -6,6 +6,12 @@
  * for the Twilio ConversationRelay TwiML element. Route code should call
  * {@link buildTwilioRelaySpeechConfig} rather than composing STT attributes
  * inline.
+ *
+ * **Cutover note:** This module is part of the current ConversationRelay
+ * production path. When the telephony STT cutover to `services.stt` is
+ * activated, this module will no longer be needed — the media-stream STT
+ * session resolves provider config server-side. Retain for rollback until
+ * the cutover is confirmed stable.
  */
 
 import type { TelephonySttProfile } from "./stt-profile.js";

--- a/assistant/src/config/bundled-skills/phone-calls/references/CONFIG.md
+++ b/assistant/src/config/bundled-skills/phone-calls/references/CONFIG.md
@@ -18,6 +18,8 @@ All call-related settings can be managed via `assistant config`:
 | `services.tts.provider`                     | Active TTS provider for speech synthesis. Must be a provider ID from the catalog (e.g. `elevenlabs`, `fish-audio`). New providers can be added via the catalog without code changes to call routing.                                      | `elevenlabs`                                                                                             |
 | `services.tts.providers.<id>.*`             | Provider-specific settings block. Each catalog provider has its own settings namespace under `services.tts.providers.<id>`. See voice settings in the desktop/iOS app or run `assistant config list` for available settings per provider. | _(per-provider defaults)_                                                                                |
 
+**Note on STT configuration:** Telephony STT is currently driven by `calls.voice.transcriptionProvider` (Deepgram or Google) via ConversationRelay's built-in transcription. The `services.stt` config block controls STT for non-telephony paths (dictation, voice mode, batch transcription). A future migration will unify telephony STT under `services.stt` — see `docs/internal-reference.md` for the cutover plan.
+
 ## Adjusting settings
 
 ```bash

--- a/docs/internal-reference.md
+++ b/docs/internal-reference.md
@@ -24,6 +24,12 @@ Detailed reference documentation for the Vellum Assistant platform. For an overv
 - [**Development Workflow**](#development-workflow)
   - [Claude Code Workflow](#claude-code-workflow)
   - [Release Management](#release-management)
+- [**Telephony STT Cutover Runbook**](#telephony-stt-cutover-runbook)
+  - [Background](#background)
+  - [Prerequisites](#prerequisites-1)
+  - [Cutover Steps](#cutover-steps)
+  - [Rollback Plan](#rollback-plan)
+  - [Verification](#verification)
 
 ## Getting Started
 
@@ -619,3 +625,78 @@ The macOS app uses [Sparkle](https://sparkle-project.org/) for automatic updates
 #### First-time installation
 
 New users download the latest DMG from the [releases page](https://github.com/vellum-ai/vellum-assistant/releases/latest), open it, and drag the app to their Applications folder. All subsequent updates are handled automatically by Sparkle.
+
+---
+
+## Telephony STT Cutover Runbook
+
+This runbook documents the exact steps to migrate telephony STT from ConversationRelay-native transcription (`calls.voice.transcriptionProvider`) to `services.stt`-driven transcription via Twilio Media Streams. All preparation work is complete (PRs 1-6 of the `twilio-services-stt-provider-unification` plan). This section exists so the cutover can be executed in a single focused follow-up PR.
+
+### Background
+
+**Current production path:** Voice calls use the Twilio ConversationRelay element in TwiML. STT is handled natively by ConversationRelay using Deepgram or Google, configured via `calls.voice.transcriptionProvider`. The daemon receives transcribed text from the relay — it never sees raw audio.
+
+**Prepared dark path:** A complete alternative path exists using Twilio Media Streams. Raw audio flows from Twilio through the gateway's media-stream WebSocket proxy to the assistant's media-stream server, which uses `services.stt` for transcription. All modules are wired, tested, and registered — but no production TwiML points to them.
+
+### Prerequisites
+
+Before executing the cutover, verify all prerequisites pass:
+
+1. **`services.stt` provider must be telephony-eligible.** Run `evaluateServicesSttReadiness()` from `assistant/src/calls/stt-profile.ts` — it must return `status: "ready"`. This validates that the configured provider is in the catalog with a compatible `telephonyMode` and has valid credentials.
+
+2. **Provider catalog must include a `realtime-ws` telephony provider.** The current catalog only has `openai-whisper` with `telephonyMode: "batch-only"`. A realtime-capable provider entry must be added to `assistant/src/providers/speech-to-text/provider-catalog.ts` before cutover.
+
+3. **Gateway media-stream proxy route must be deployed.** The route in `gateway/src/http/routes/twilio-media-websocket.ts` must be live on the gateway that serves the public ingress URL.
+
+4. **ConversationRelay STT guardrail tests must be updated.** The tests in `__tests__/twilio-routes-twiml.test.ts` and `__tests__/twilio-routes.test.ts` that assert `<ConversationRelay>` and `transcriptionProvider="Deepgram"` must be updated in the cutover PR to assert the new `<Stream>` element and media-stream URL instead.
+
+### Cutover Steps
+
+Execute these changes in a single PR:
+
+1. **Switch TwiML element in `twilio-routes.ts`:**
+   - Replace the `<ConversationRelay>` element in `generateTwiML()` with a `<Connect><Stream>` element.
+   - Point the Stream URL to the media-stream server endpoint (`/v1/calls/media-stream`) instead of the relay server (`/v1/calls/relay`).
+   - Remove ConversationRelay-specific attributes (`transcriptionProvider`, `speechModel`, `interruptSensitivity`, `hints`, `ttsProvider`, `voice`, `welcomeGreeting`) and replace with Stream-appropriate attributes.
+
+2. **Update `buildVoiceWebhookTwiml()` in `twilio-routes.ts`:**
+   - Replace the call to `resolveTelephonySttProfile(cfg.calls.voice)` with a call to `resolveTelephonySttCapability()` or equivalent resolver that reads from `services.stt`.
+   - Remove the `buildTwilioRelaySpeechConfig()` call (no longer needed — STT config is resolved server-side in the media-stream STT session).
+
+3. **Migrate config keys:**
+   - Add a workspace migration that copies `calls.voice.transcriptionProvider` and `calls.voice.speechModel` values to the equivalent `services.stt` settings (if not already configured).
+   - Mark `calls.voice.transcriptionProvider` and `calls.voice.speechModel` as deprecated in the config schema (keep them readable for rollback).
+
+4. **Update guardrail tests:**
+   - Update `__tests__/twilio-routes-twiml.test.ts` ConversationRelay guardrails to assert `<Stream>` instead.
+   - Update `__tests__/twilio-routes.test.ts` integration guardrails to verify TwiML uses media-stream URL.
+
+5. **Remove legacy code (deferred):**
+   - `calls.voice.transcriptionProvider` and `calls.voice.speechModel` config keys can be removed in a follow-up cleanup PR after the cutover is stable.
+   - `twilio-relay-speech-config.ts` and the ConversationRelay-specific code path in `stt-profile.ts` can be removed once rollback is no longer needed.
+
+### Rollback Plan
+
+If the cutover introduces regressions, revert to the ConversationRelay path:
+
+1. **Revert the TwiML change:** Restore `<ConversationRelay>` element in `generateTwiML()` with the original attributes. The ConversationRelay relay server (`relay-server.ts`) is still registered and will resume handling calls.
+
+2. **Revert the STT resolution:** Restore the `resolveTelephonySttProfile(cfg.calls.voice)` call in `buildVoiceWebhookTwiml()`.
+
+3. **Config keys are preserved:** Since `calls.voice.transcriptionProvider` and `calls.voice.speechModel` are deprecated but not removed, they still contain valid values for the rollback path.
+
+4. **No data migration needed for rollback:** The workspace migration (step 3 in cutover) copies values forward — it does not delete the originals. Both config paths remain readable.
+
+The rollback is a single-commit revert of the cutover PR. No user data is lost and no config migration is needed.
+
+### Verification
+
+After cutover, verify:
+
+- [ ] Outbound calls connect and produce audible speech.
+- [ ] Inbound calls are answered with transcription working.
+- [ ] STT provider shown in call logs matches the `services.stt` provider.
+- [ ] `evaluateServicesSttReadiness()` returns `status: "ready"`.
+- [ ] No `<ConversationRelay>` elements appear in TwiML responses.
+- [ ] The media-stream WebSocket connection appears in gateway logs.
+- [ ] Existing `calls.voice.transcriptionProvider` config value is still readable (for rollback).

--- a/gateway/ARCHITECTURE.md
+++ b/gateway/ARCHITECTURE.md
@@ -1094,4 +1094,12 @@ The voice webhook in `twilio-routes.ts` calls `resolveVoiceQualityProfile()` for
 
 For full details on the catalog-driven TTS architecture, provider catalog, call strategy abstraction, and the provider-add checklist, see the [TTS Provider Abstraction](../assistant/ARCHITECTURE.md#tts-provider-abstraction-servicestts) section in the assistant architecture docs.
 
+### Telephony STT: Current Production Path vs Prepared Dark Path
+
+**Current production path (ConversationRelay-native STT):** All production calls use the Twilio ConversationRelay element in the voice webhook TwiML. STT is handled natively by ConversationRelay using providers configured via `calls.voice.transcriptionProvider` (Deepgram or Google). The daemon never receives raw audio in this path — it receives transcribed text from the relay.
+
+**Prepared dark path (services.stt via Media Streams):** A fully wired but inactive path exists for future cutover to `services.stt`-driven telephony STT via Twilio Media Streams. The gateway has a Media Streams WebSocket proxy route (`twilio-media-websocket.ts`) that can forward raw audio frames to the assistant's media-stream server. This route is registered but not referenced by any production TwiML — no calls will reach it until the voice webhook TwiML is updated.
+
+**Activation seam:** The cutover requires a single TwiML change in the assistant's `twilio-routes.ts` — switching from `<ConversationRelay>` to `<Connect><Stream>` with the media-stream URL. The gateway's media-stream proxy route is already registered and will begin receiving traffic once TwiML points to it. See the cutover runbook in `docs/internal-reference.md` for the complete step-by-step plan.
+
 ---


### PR DESCRIPTION
## Summary
- Add STT preflight helper and cutover readiness validation
- Add tests asserting current TwiML emits ConversationRelay STT attributes
- Document cutover/rollback runbook and architecture separation

Part of plan: twilio-services-stt-provider-unification.md (PR 6 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25043" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
