### PR TITLE
Add 'Mark Conversation as Unread' keyboard shortcut

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -72,6 +72,12 @@ extension UserDefaults {
         }
         return string(forKey: "currentConversationShortcut") ?? ""
     }
+    @objc dynamic var markConversationUnreadShortcut: String {
+        if UserDefaults.standard.object(forKey: "markConversationUnreadShortcut") == nil {
+            return "cmd+shift+u"
+        }
+        return string(forKey: "markConversationUnreadShortcut") ?? ""
+    }
     @objc dynamic var popOutShortcut: String {
         if UserDefaults.standard.object(forKey: "popOutShortcut") == nil {
             return "cmd+p"
@@ -107,6 +113,7 @@ extension AppDelegate {
         )
         .merge(with: UserDefaults.standard.publisher(for: \.newChatShortcut).map { _ in () })
         .merge(with: UserDefaults.standard.publisher(for: \.currentConversationShortcut).map { _ in () })
+        .merge(with: UserDefaults.standard.publisher(for: \.markConversationUnreadShortcut).map { _ in () })
         .merge(with: UserDefaults.standard.publisher(for: \.popOutShortcut).map { _ in () })
         .debounce(for: .milliseconds(100), scheduler: RunLoop.main)
         .sink { [weak self] _ in
@@ -118,6 +125,7 @@ extension AppDelegate {
             self?.registerPopOutMonitor()
             self?.updateNewChatMenuItemShortcut()
             self?.updateCurrentConversationMenuItemShortcut()
+            self?.updateMarkConversationUnreadMenuItemShortcut()
         }
     }
 

--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -91,9 +91,23 @@ final class FileMenuPatchDelegate: NSObject, NSMenuDelegate {
         currentItem.tag = Self.injectedTag
         menu.insertItem(currentItem, at: 1)
 
+        let markUnreadShortcut = UserDefaults.standard.string(forKey: "markConversationUnreadShortcut") ?? "cmd+shift+u"
+        let markUnreadItem: NSMenuItem
+        if markUnreadShortcut.isEmpty {
+            markUnreadItem = NSMenuItem(title: "Mark Conversation as Unread", action: #selector(AppDelegate.markCurrentConversationUnread), keyEquivalent: "")
+        } else {
+            let (muModifiers, muKey) = ShortcutHelper.parseShortcut(markUnreadShortcut)
+            markUnreadItem = NSMenuItem(title: "Mark Conversation as Unread", action: #selector(AppDelegate.markCurrentConversationUnread), keyEquivalent: muKey)
+            markUnreadItem.keyEquivalentModifierMask = muModifiers
+        }
+        markUnreadItem.target = appDelegate
+        markUnreadItem.tag = Self.injectedTag
+        menu.insertItem(markUnreadItem, at: 2)
+        appDelegate.markConversationUnreadMenuItem = markUnreadItem
+
         let separator = NSMenuItem.separator()
         separator.tag = Self.injectedTag
-        menu.insertItem(separator, at: 2)
+        menu.insertItem(separator, at: 3)
     }
 }
 
@@ -196,6 +210,7 @@ extension AppDelegate {
 
         updateNewChatMenuItemShortcut()
         updateCurrentConversationMenuItemShortcut()
+        updateMarkConversationUnreadMenuItemShortcut()
     }
 
     /// Updates the File > New Conversation menu item's key equivalent to match
@@ -230,12 +245,34 @@ extension AppDelegate {
         item.keyEquivalentModifierMask = modifiers
     }
 
+    /// Updates the File > Mark Conversation as Unread menu item's key equivalent
+    /// to match the current `markConversationUnreadShortcut` preference.
+    func updateMarkConversationUnreadMenuItemShortcut() {
+        guard let item = markConversationUnreadMenuItem else { return }
+        let shortcut = UserDefaults.standard.string(forKey: "markConversationUnreadShortcut") ?? "cmd+shift+u"
+        guard !shortcut.isEmpty else {
+            item.keyEquivalent = ""
+            item.keyEquivalentModifierMask = []
+            return
+        }
+        let (modifiers, key) = ShortcutHelper.parseShortcut(shortcut)
+        item.keyEquivalent = key
+        item.keyEquivalentModifierMask = modifiers
+    }
+
     // MARK: - Menu Item Validation
 
     @objc func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
         guard let action = menuItem.action else { return true }
         if action == #selector(markAllConversationsSeen) {
             return (mainWindow?.conversationManager.unseenVisibleConversationCount ?? 0) > 0
+        }
+        if action == #selector(markCurrentConversationUnread) {
+            guard let conversationManager = mainWindow?.conversationManager,
+                  let activeId = conversationManager.selectionStore.activeConversationId,
+                  let idx = conversationManager.listStore.conversations.firstIndex(where: { $0.id == activeId })
+            else { return false }
+            return conversationManager.listStore.canMarkConversationUnread(conversationId: activeId, at: idx)
         }
         return true
     }
@@ -528,6 +565,13 @@ extension AppDelegate {
             mainWindow?.windowState.selection = nil
         }
         UserDefaults.standard.set(false, forKey: "sidebarExpanded")
+    }
+
+    @objc public func markCurrentConversationUnread() {
+        guard let conversationManager = mainWindow?.conversationManager,
+              let activeId = conversationManager.selectionStore.activeConversationId
+        else { return }
+        conversationManager.markConversationUnread(conversationId: activeId)
     }
 
     @objc func activateChatSearch() {

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -67,6 +67,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     var currentConversationLocalMonitor: Any?
     var newChatMenuItem: NSMenuItem?
     var currentConversationMenuItem: NSMenuItem?
+    var markConversationUnreadMenuItem: NSMenuItem?
     var fileMenuPatchDelegate: FileMenuPatchDelegate?
     var navLocalMonitor: Any?
     var zoomLocalMonitor: Any?

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
@@ -13,6 +13,7 @@ struct SettingsAppearanceTab: View {
     @State private var isRecordingSidebarToggle = false
     @State private var isRecordingNewChat = false
     @State private var isRecordingCurrentConversation = false
+    @State private var isRecordingMarkConversationUnread = false
     @State private var isRecordingPopOut = false
     @State private var isRecordingVoiceInput = false
     @State private var shortcutMonitor: Any?
@@ -328,6 +329,39 @@ struct SettingsAppearanceTab: View {
 
                 SettingsDivider()
 
+                // Mark conversation as unread (configurable)
+                HStack {
+                    Text("Mark conversation as unread")
+                        .font(VFont.bodyMediumLighter)
+                        .foregroundStyle(VColor.contentSecondary)
+                    Spacer()
+                    if isRecordingMarkConversationUnread, let display = recordingDisplayString, !display.isEmpty {
+                        VShortcutTag(display)
+                    } else {
+                        VShortcutTag(ShortcutHelper.displayString(for: store.markConversationUnreadShortcut))
+                    }
+
+                    if isRecordingMarkConversationUnread {
+                        VButton(label: "Press shortcut...", style: .outlined) {
+                            stopRecording()
+                        }
+                    } else {
+                        HStack(spacing: VSpacing.sm) {
+                            VButton(label: "Change", style: .outlined) {
+                                startRecordingMarkConversationUnread()
+                            }
+                            if !store.markConversationUnreadShortcut.isEmpty {
+                                VButton(label: "Remove", style: .outlined) {
+                                    store.markConversationUnreadShortcut = ""
+                                }
+                            }
+                        }
+                    }
+                }
+                .padding(.vertical, VSpacing.md)
+
+                SettingsDivider()
+
                 // Toggle sidebar (configurable)
                 HStack {
                     Text("Toggle sidebar")
@@ -610,6 +644,13 @@ struct SettingsAppearanceTab: View {
         isRecordingCurrentConversation = true
     }
 
+    private func startRecordingMarkConversationUnread() {
+        startRecordingShortcut { shortcut, _ in
+            store.markConversationUnreadShortcut = shortcut
+        }
+        isRecordingMarkConversationUnread = true
+    }
+
     private func startRecordingPopOut() {
         startRecordingShortcut { shortcut, _ in
             store.popOutShortcut = shortcut
@@ -663,6 +704,7 @@ struct SettingsAppearanceTab: View {
         isRecordingSidebarToggle = false
         isRecordingNewChat = false
         isRecordingCurrentConversation = false
+        isRecordingMarkConversationUnread = false
         isRecordingPopOut = false
         recordingDisplayString = nil
         if let monitor = shortcutMonitor {

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -75,6 +75,7 @@ public final class SettingsStore: ObservableObject {
     @Published var sidebarToggleShortcut: String
     @Published var newChatShortcut: String
     @Published var currentConversationShortcut: String
+    @Published var markConversationUnreadShortcut: String
     @Published var popOutShortcut: String
     @Published var cmdEnterToSend: Bool
 
@@ -465,6 +466,11 @@ public final class SettingsStore: ObservableObject {
         } else {
             self.currentConversationShortcut = UserDefaults.standard.string(forKey: "currentConversationShortcut") ?? ""
         }
+        if UserDefaults.standard.object(forKey: "markConversationUnreadShortcut") == nil {
+            self.markConversationUnreadShortcut = "cmd+shift+u"
+        } else {
+            self.markConversationUnreadShortcut = UserDefaults.standard.string(forKey: "markConversationUnreadShortcut") ?? ""
+        }
         if UserDefaults.standard.object(forKey: "popOutShortcut") == nil {
             self.popOutShortcut = "cmd+p"
         } else {
@@ -556,6 +562,11 @@ public final class SettingsStore: ObservableObject {
         $currentConversationShortcut
             .dropFirst()
             .sink { value in UserDefaults.standard.set(value, forKey: "currentConversationShortcut") }
+            .store(in: &cancellables)
+
+        $markConversationUnreadShortcut
+            .dropFirst()
+            .sink { value in UserDefaults.standard.set(value, forKey: "markConversationUnreadShortcut") }
             .store(in: &cancellables)
 
         $popOutShortcut


### PR DESCRIPTION
## Summary
- Adds a configurable keyboard shortcut that marks the currently active conversation as unread (default `cmd+shift+u`, matches macOS Mail.app).
- Wires a new File > Mark Conversation as Unread menu item through `FileMenuPatchDelegate`, reusing the existing `ConversationManager.markConversationUnread` action and its rollback/signal plumbing.
- Adds a matching row in Settings > General > Keyboard Shortcuts so users can rebind (per `clients/macos/AGENTS.md`); `validateMenuItem` disables the menu item when there is no active conversation that satisfies `canMarkConversationUnread`.

## Original prompt
Add a keyboard shortcut to mark the current vellum assistant conversation as unread in the desktop app.