### PR TITLE
Reconnect browser relay after local re-pair

### DIFF
--- a/clients/chrome-extension/background/worker.ts
+++ b/clients/chrome-extension/background/worker.ts
@@ -1313,7 +1313,22 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponseFn) => {
       ? Promise.resolve(assistantId)
       : loadSelectedAssistantId()
     )
-      .then((resolvedId) => bootstrapLocalToken(resolvedId))
+      .then(async (resolvedId) => {
+        const stored = await bootstrapLocalToken(resolvedId);
+
+        // If the relay is intended to be connected, rotate the live socket
+        // so the fresh paired token is applied immediately. Without this,
+        // a stale open socket (bound under a previous guardian/token) can
+        // remain in memory and keep failing host_browser routing until the
+        // user manually toggles Connection off/on.
+        if (shouldConnect || relayConnection) {
+          setConnectionHealth('reconnecting');
+          disconnect();
+          await connect({ interactive: false });
+        }
+
+        return stored;
+      })
       .then((stored: StoredLocalToken) => sendResponseFn({ ok: true, token: stored }))
       .catch((err) => sendResponseFn({ ok: false, error: err instanceof Error ? err.message : String(err) }));
     return true; // async


### PR DESCRIPTION
## Summary
- Reconnect the extension relay socket after a successful `self-hosted-pair` so the fresh capability token is applied immediately.
- Prevent stale open sockets from staying bound to old guardian/token context and causing repeated extension-mode browser tool failures.
- Set connection health to `reconnecting` while rotating the socket so the UI accurately reflects the transient transition.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25045" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
