### PR TITLE
Enable Deepgram end-to-end in services.stt runtime and schema

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -1153,6 +1153,7 @@ describe("AssistantConfigSchema", () => {
     expect(result.services.stt.mode).toBe("your-own");
     expect(result.services.stt.provider).toBe("openai-whisper");
     expect(result.services.stt.providers["openai-whisper"]).toEqual({});
+    expect(result.services.stt.providers.deepgram).toEqual({});
   });
 
   test("accepts valid services.stt provider override", () => {
@@ -1198,6 +1199,32 @@ describe("AssistantConfigSchema", () => {
       const msgs = result.error.issues.map((i) => i.message);
       expect(msgs.some((m) => m.includes("services.stt.provider"))).toBe(true);
     }
+  });
+
+  test("accepts deepgram as services.stt.provider", () => {
+    const result = AssistantConfigSchema.parse({
+      services: { stt: { provider: "deepgram" } },
+    });
+    expect(result.services.stt.provider).toBe("deepgram");
+    expect(result.services.stt.mode).toBe("your-own");
+  });
+
+  test("accepts valid services.stt.providers.deepgram overrides", () => {
+    const result = AssistantConfigSchema.parse({
+      services: {
+        stt: {
+          providers: {
+            deepgram: {},
+          },
+        },
+      },
+    });
+    expect(result.services.stt.providers.deepgram).toEqual({});
+  });
+
+  test("deepgram provider default is openai-whisper (not deepgram)", () => {
+    const result = AssistantConfigSchema.parse({});
+    expect(result.services.stt.provider).toBe("openai-whisper");
   });
 
   test("services.stt.mode only accepts your-own as literal", () => {

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -193,11 +193,13 @@ export {
   SkillsLoadConfigSchema,
 } from "./schemas/skills.js";
 export type {
+  SttDeepgramProviderConfig,
   SttOpenAiWhisperProviderConfig,
   SttProviders,
   SttService,
 } from "./schemas/stt.js";
 export {
+  SttDeepgramProviderConfigSchema,
   SttOpenAiWhisperProviderConfigSchema,
   SttProvidersSchema,
   SttServiceSchema,

--- a/assistant/src/config/schemas/stt.ts
+++ b/assistant/src/config/schemas/stt.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
  * Valid STT provider identifiers. New providers append here and register
  * an adapter.
  */
-export const VALID_STT_PROVIDERS = ["openai-whisper"] as const;
+export const VALID_STT_PROVIDERS = ["openai-whisper", "deepgram"] as const;
 
 /**
  * Per-provider config schemas nested under `services.stt.providers.<id>`.
@@ -24,9 +24,27 @@ export type SttOpenAiWhisperProviderConfig = z.infer<
   typeof SttOpenAiWhisperProviderConfigSchema
 >;
 
+/**
+ * Deepgram provider configuration under `services.stt.providers.deepgram`.
+ *
+ * Provider-specific tuning params (model, language, smart formatting)
+ * can be added here as the adapter evolves. For now the schema is empty
+ * so that adding the provider to config.json is friction-free.
+ */
+export const SttDeepgramProviderConfigSchema = z
+  .object({})
+  .describe("Deepgram provider configuration under services.stt");
+
+export type SttDeepgramProviderConfig = z.infer<
+  typeof SttDeepgramProviderConfigSchema
+>;
+
 export const SttProvidersSchema = z.object({
   "openai-whisper": SttOpenAiWhisperProviderConfigSchema.default(
     SttOpenAiWhisperProviderConfigSchema.parse({}),
+  ),
+  deepgram: SttDeepgramProviderConfigSchema.default(
+    SttDeepgramProviderConfigSchema.parse({}),
   ),
 });
 export type SttProviders = z.infer<typeof SttProvidersSchema>;

--- a/assistant/src/providers/provider-secret-catalog.ts
+++ b/assistant/src/providers/provider-secret-catalog.ts
@@ -2,11 +2,13 @@
  * Canonical source for API-key-addressable providers.
  *
  * This module composes the full set of providers that store API keys in
- * secure storage (the `api_key` secret type) from two sources:
+ * secure storage (the `api_key` secret type) from three sources:
  *
  * 1. **LLM / search providers** -- statically declared here because they
  *    have no separate catalog module yet.
- * 2. **TTS catalog providers** -- dynamically derived from the canonical
+ * 2. **STT providers** -- statically declared here because no STT
+ *    provider-catalog module exists yet.
+ * 3. **TTS catalog providers** -- dynamically derived from the canonical
  *    TTS provider catalog by selecting entries whose secret requirements
  *    use the bare-name (non-credential) storage convention.
  *
@@ -39,6 +41,21 @@ const LLM_AND_SEARCH_API_KEY_PROVIDERS = [
   "brave",
   "perplexity",
 ] as const;
+
+// ---------------------------------------------------------------------------
+// Static STT providers
+// ---------------------------------------------------------------------------
+
+/**
+ * STT providers that store API keys under their bare provider name in the
+ * secure credential store (e.g. `deepgram`).
+ *
+ * Declared statically because no STT provider-catalog module exists yet.
+ * Providers whose credential key collides with an LLM provider (e.g.
+ * `openai-whisper` uses the `openai` key which is already in the LLM
+ * list) are intentionally omitted to avoid duplicates.
+ */
+const STT_API_KEY_PROVIDERS = ["deepgram"] as const;
 
 // ---------------------------------------------------------------------------
 // TTS catalog-derived providers
@@ -93,5 +110,6 @@ function catalogApiKeyProviderIds(): string[] {
  */
 export const API_KEY_PROVIDERS: readonly string[] = [
   ...LLM_AND_SEARCH_API_KEY_PROVIDERS,
+  ...STT_API_KEY_PROVIDERS,
   ...catalogApiKeyProviderIds(),
 ] as const;

--- a/assistant/src/providers/speech-to-text/__tests__/resolve.test.ts
+++ b/assistant/src/providers/speech-to-text/__tests__/resolve.test.ts
@@ -57,6 +57,7 @@ function buildConfig(overrides: {
         provider: overrides.provider ?? "openai-whisper",
         providers: {
           "openai-whisper": {},
+          deepgram: {},
         },
       },
     },
@@ -96,8 +97,8 @@ describe("resolveBatchTranscriber", () => {
   test("returns null when configured provider is unsupported for daemon-batch", async () => {
     // Force an unknown provider past the type system to simulate a future
     // provider that hasn't been wired into the daemon-batch boundary yet.
-    mockProviderKeys["deepgram"] = "dg-test-key";
-    mockConfig = buildConfig({ provider: "deepgram" as string });
+    mockProviderKeys["some-provider"] = "key";
+    mockConfig = buildConfig({ provider: "unknown-provider" as string });
 
     const transcriber = await resolveBatchTranscriber();
 
@@ -124,6 +125,50 @@ describe("resolveBatchTranscriber", () => {
 
     // The providerId must remain "openai-whisper" for downstream identity checks.
     expect(transcriber!.providerId).toBe("openai-whisper");
+    expect(transcriber!.boundaryId).toBe("daemon-batch");
+  });
+
+  // -------------------------------------------------------------------------
+  // Deepgram provider resolution
+  // -------------------------------------------------------------------------
+
+  test("returns a BatchTranscriber when deepgram is configured and credentials are available", async () => {
+    mockProviderKeys["deepgram"] = "dg-test-key";
+    mockConfig = buildConfig({ provider: "deepgram" });
+
+    const transcriber = await resolveBatchTranscriber();
+
+    expect(transcriber).not.toBeNull();
+    expect(transcriber!.providerId).toBe("deepgram");
+    expect(transcriber!.boundaryId).toBe("daemon-batch");
+  });
+
+  test("returns null when deepgram is configured but no credentials exist", async () => {
+    mockProviderKeys = {}; // no keys
+    mockConfig = buildConfig({ provider: "deepgram" });
+
+    const transcriber = await resolveBatchTranscriber();
+
+    expect(transcriber).toBeNull();
+  });
+
+  test("deepgram uses 'deepgram' credential key, not 'openai'", async () => {
+    // Only openai key is set — deepgram should NOT resolve
+    mockProviderKeys["openai"] = "sk-test-key";
+    mockConfig = buildConfig({ provider: "deepgram" });
+
+    const transcriber = await resolveBatchTranscriber();
+
+    expect(transcriber).toBeNull();
+  });
+
+  test("resolved deepgram transcriber has stable provider identity", async () => {
+    mockProviderKeys["deepgram"] = "dg-identity-test";
+    mockConfig = buildConfig({ provider: "deepgram" });
+
+    const transcriber = await resolveBatchTranscriber();
+
+    expect(transcriber!.providerId).toBe("deepgram");
     expect(transcriber!.boundaryId).toBe("daemon-batch");
   });
 });

--- a/assistant/src/providers/speech-to-text/resolve.ts
+++ b/assistant/src/providers/speech-to-text/resolve.ts
@@ -10,8 +10,7 @@ import type { BatchTranscriber, SttProviderId } from "../../stt/types.js";
 /**
  * Map an STT provider identifier to the credential provider name used by
  * `getProviderKeyAsync`. New STT providers that share credentials with an
- * existing credential provider (e.g. a future Deepgram provider would map
- * to `"deepgram"`) add an entry here.
+ * existing credential provider add an entry here.
  *
  * Typed as `Record<SttProviderId, string>` to ensure compile-time
  * completeness: adding a new variant to `SttProviderId` without a
@@ -19,6 +18,7 @@ import type { BatchTranscriber, SttProviderId } from "../../stt/types.js";
  */
 const STT_PROVIDER_CREDENTIAL_MAP: Record<SttProviderId, string> = {
   "openai-whisper": "openai",
+  deepgram: "deepgram",
 };
 
 // ---------------------------------------------------------------------------
@@ -53,5 +53,5 @@ export async function resolveBatchTranscriber(): Promise<BatchTranscriber | null
   }
 
   const apiKey = await getProviderKeyAsync(credentialProvider);
-  return createDaemonBatchTranscriber(apiKey);
+  return createDaemonBatchTranscriber(apiKey, provider as SttProviderId);
 }

--- a/assistant/src/stt/__tests__/daemon-batch-transcriber.test.ts
+++ b/assistant/src/stt/__tests__/daemon-batch-transcriber.test.ts
@@ -6,15 +6,28 @@ import { SttError } from "../types.js";
 // Module mocks — must precede dynamic imports
 // ---------------------------------------------------------------------------
 
-let mockTranscribeResult: { text: string } = { text: "" };
-let mockTranscribeError: Error | null = null;
+let mockWhisperTranscribeResult: { text: string } = { text: "" };
+let mockWhisperTranscribeError: Error | null = null;
 
 mock.module("../../providers/speech-to-text/openai-whisper.js", () => ({
   OpenAIWhisperProvider: class MockWhisperProvider {
     constructor(_apiKey: string) {}
     async transcribe(_audio: Buffer, _mimeType: string, _signal?: AbortSignal) {
-      if (mockTranscribeError) throw mockTranscribeError;
-      return mockTranscribeResult;
+      if (mockWhisperTranscribeError) throw mockWhisperTranscribeError;
+      return mockWhisperTranscribeResult;
+    }
+  },
+}));
+
+let mockDeepgramTranscribeResult: { text: string } = { text: "" };
+let mockDeepgramTranscribeError: Error | null = null;
+
+mock.module("../../providers/speech-to-text/deepgram.js", () => ({
+  DeepgramProvider: class MockDeepgramProvider {
+    constructor(_apiKey: string) {}
+    async transcribe(_audio: Buffer, _mimeType: string, _signal?: AbortSignal) {
+      if (mockDeepgramTranscribeError) throw mockDeepgramTranscribeError;
+      return mockDeepgramTranscribeResult;
     }
   },
 }));
@@ -29,8 +42,10 @@ const { createDaemonBatchTranscriber, normalizeSttError } =
 
 describe("createDaemonBatchTranscriber", () => {
   beforeEach(() => {
-    mockTranscribeResult = { text: "" };
-    mockTranscribeError = null;
+    mockWhisperTranscribeResult = { text: "" };
+    mockWhisperTranscribeError = null;
+    mockDeepgramTranscribeResult = { text: "" };
+    mockDeepgramTranscribeError = null;
   });
 
   // -------------------------------------------------------------------------
@@ -48,10 +63,10 @@ describe("createDaemonBatchTranscriber", () => {
   });
 
   // -------------------------------------------------------------------------
-  // Provider identity
+  // Provider identity — Whisper (default)
   // -------------------------------------------------------------------------
 
-  test("reports providerId as openai-whisper", () => {
+  test("reports providerId as openai-whisper by default", () => {
     const transcriber = createDaemonBatchTranscriber("sk-test-key");
     expect(transcriber!.providerId).toBe("openai-whisper");
   });
@@ -62,11 +77,11 @@ describe("createDaemonBatchTranscriber", () => {
   });
 
   // -------------------------------------------------------------------------
-  // Successful transcription
+  // Successful transcription — Whisper
   // -------------------------------------------------------------------------
 
-  test("delegates transcription to the underlying provider", async () => {
-    mockTranscribeResult = { text: "Hello from Whisper" };
+  test("delegates transcription to the Whisper provider", async () => {
+    mockWhisperTranscribeResult = { text: "Hello from Whisper" };
 
     const transcriber = createDaemonBatchTranscriber("sk-test-key");
     const result = await transcriber!.transcribe({
@@ -87,7 +102,7 @@ describe("createDaemonBatchTranscriber", () => {
       "The operation was aborted",
       "AbortError",
     );
-    mockTranscribeError = original;
+    mockWhisperTranscribeError = original;
 
     const transcriber = createDaemonBatchTranscriber("sk-test-key");
 
@@ -105,7 +120,7 @@ describe("createDaemonBatchTranscriber", () => {
 
   test("propagates generic errors unchanged", async () => {
     const original = new Error("Something went wrong");
-    mockTranscribeError = original;
+    mockWhisperTranscribeError = original;
 
     const transcriber = createDaemonBatchTranscriber("sk-test-key");
 
@@ -118,6 +133,67 @@ describe("createDaemonBatchTranscriber", () => {
     } catch (err) {
       expect(err).toBe(original);
     }
+  });
+
+  // -------------------------------------------------------------------------
+  // Provider identity — Deepgram
+  // -------------------------------------------------------------------------
+
+  test("reports providerId as deepgram when created with deepgram", () => {
+    const transcriber = createDaemonBatchTranscriber("dg-test-key", "deepgram");
+    expect(transcriber).not.toBeNull();
+    expect(transcriber!.providerId).toBe("deepgram");
+  });
+
+  test("reports boundaryId as daemon-batch for deepgram", () => {
+    const transcriber = createDaemonBatchTranscriber("dg-test-key", "deepgram");
+    expect(transcriber!.boundaryId).toBe("daemon-batch");
+  });
+
+  // -------------------------------------------------------------------------
+  // Successful transcription — Deepgram
+  // -------------------------------------------------------------------------
+
+  test("delegates transcription to the Deepgram provider", async () => {
+    mockDeepgramTranscribeResult = { text: "Hello from Deepgram" };
+
+    const transcriber = createDaemonBatchTranscriber("dg-test-key", "deepgram");
+    const result = await transcriber!.transcribe({
+      audio: Buffer.from("fake-audio"),
+      mimeType: "audio/ogg",
+    });
+
+    expect(result).toEqual({ text: "Hello from Deepgram" });
+  });
+
+  // -------------------------------------------------------------------------
+  // Error propagation — Deepgram
+  // -------------------------------------------------------------------------
+
+  test("propagates Deepgram errors unchanged", async () => {
+    const original = new Error("Deepgram API error (401): Invalid credentials");
+    mockDeepgramTranscribeError = original;
+
+    const transcriber = createDaemonBatchTranscriber("dg-test-key", "deepgram");
+
+    try {
+      await transcriber!.transcribe({
+        audio: Buffer.from("audio"),
+        mimeType: "audio/wav",
+      });
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBe(original);
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Null on missing key — Deepgram
+  // -------------------------------------------------------------------------
+
+  test("returns null for deepgram when no API key is provided", () => {
+    expect(createDaemonBatchTranscriber(null, "deepgram")).toBeNull();
+    expect(createDaemonBatchTranscriber(undefined, "deepgram")).toBeNull();
   });
 });
 
@@ -184,5 +260,23 @@ describe("normalizeSttError", () => {
     const result = normalizeSttError(original);
     expect(result).toBe(original);
     expect(result.category).toBe("auth");
+  });
+
+  // Deepgram error normalization (same categories apply)
+
+  test("normalizes Deepgram 401 errors to auth category", () => {
+    const result = normalizeSttError(
+      new Error("Deepgram API error (401): Invalid credentials"),
+    );
+    expect(result).toBeInstanceOf(SttError);
+    expect(result.category).toBe("auth");
+  });
+
+  test("normalizes Deepgram 429 errors to rate-limit category", () => {
+    const result = normalizeSttError(
+      new Error("Deepgram API error (429): Rate limited"),
+    );
+    expect(result).toBeInstanceOf(SttError);
+    expect(result.category).toBe("rate-limit");
   });
 });

--- a/assistant/src/stt/daemon-batch-transcriber.ts
+++ b/assistant/src/stt/daemon-batch-transcriber.ts
@@ -6,13 +6,14 @@
  * be configured. Callers use this instead of constructing provider classes
  * directly.
  *
- * Currently the only daemon-batch provider is OpenAI Whisper. As new providers
- * are added, this module can select the appropriate adapter based on
- * configuration or feature flags.
+ * Supported daemon-batch providers:
+ * - OpenAI Whisper (`openai-whisper`)
+ * - Deepgram (`deepgram`)
  */
 
 import type {
   BatchTranscriber,
+  SttProviderId,
   SttTranscribeRequest,
   SttTranscribeResult,
 } from "./types.js";
@@ -49,6 +50,38 @@ class WhisperBatchTranscriber implements BatchTranscriber {
     const { OpenAIWhisperProvider } =
       await import("../providers/speech-to-text/openai-whisper.js");
     const provider = new OpenAIWhisperProvider(this.apiKey);
+
+    return provider.transcribe(request.audio, request.mimeType, request.signal);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Deepgram adapter — implements BatchTranscriber on top of the Deepgram
+// prerecorded-audio provider.
+// ---------------------------------------------------------------------------
+
+/**
+ * Wraps `DeepgramProvider` behind the `BatchTranscriber` contract.
+ *
+ * Same error-propagation semantics as WhisperBatchTranscriber: raw provider
+ * errors pass through unchanged.
+ */
+class DeepgramBatchTranscriber implements BatchTranscriber {
+  readonly providerId = "deepgram" as const;
+  readonly boundaryId = "daemon-batch" as const;
+
+  private readonly apiKey: string;
+
+  constructor(apiKey: string) {
+    this.apiKey = apiKey;
+  }
+
+  async transcribe(
+    request: SttTranscribeRequest,
+  ): Promise<SttTranscribeResult> {
+    const { DeepgramProvider } =
+      await import("../providers/speech-to-text/deepgram.js");
+    const provider = new DeepgramProvider(this.apiKey);
 
     return provider.transcribe(request.audio, request.mimeType, request.signal);
   }
@@ -99,16 +132,29 @@ export function normalizeSttError(err: unknown): SttError {
 /**
  * Create a `BatchTranscriber` for the daemon-batch boundary.
  *
- * Callers provide the API key (obtained via the authorized secure-keys
- * importer in `providers/speech-to-text/resolve.ts`) so that this module
- * doesn't need to import secure-keys directly.
+ * Callers provide the API key and provider ID (obtained via the authorized
+ * secure-keys importer in `providers/speech-to-text/resolve.ts`) so that
+ * this module doesn't need to import secure-keys directly.
  *
  * Returns `null` when `apiKey` is falsy, signalling to the caller that
  * batch transcription is unavailable.
  */
 export function createDaemonBatchTranscriber(
   apiKey: string | null | undefined,
+  providerId: SttProviderId = "openai-whisper",
 ): BatchTranscriber | null {
   if (!apiKey) return null;
-  return new WhisperBatchTranscriber(apiKey);
+
+  switch (providerId) {
+    case "openai-whisper":
+      return new WhisperBatchTranscriber(apiKey);
+    case "deepgram":
+      return new DeepgramBatchTranscriber(apiKey);
+    default: {
+      // Exhaustive check — compile error if a new SttProviderId is added
+      // without a corresponding case here.
+      const _exhaustive: never = providerId;
+      return null;
+    }
+  }
 }

--- a/assistant/src/stt/types.ts
+++ b/assistant/src/stt/types.ts
@@ -15,7 +15,7 @@
  * Canonical provider identifiers for daemon-hosted batch STT backends.
  * Extend this union as new providers are integrated.
  */
-export type SttProviderId = "openai-whisper";
+export type SttProviderId = "openai-whisper" | "deepgram";
 
 // ---------------------------------------------------------------------------
 // Boundary identifier


### PR DESCRIPTION
## Summary
- Extends STT types, runtime resolver, and config schema to support deepgram as a first-class provider
- Refactors daemon batch transcriber from Whisper-only to provider-aware construction
- Adds deepgram to provider secret catalog for CLI key management
- Updates tests for resolve, daemon transcriber, and config schema

Part of plan: deepgram-first-class-services-stt.md (PR 2 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25046" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
