### PR TITLE
Refactor macOS STT settings store to support provider-specific API keys

### DIFF
--- a/clients/macos/vellum-assistant/App/APIKeyManager.swift
+++ b/clients/macos/vellum-assistant/App/APIKeyManager.swift
@@ -46,16 +46,22 @@ enum APIKeyManager {
 
     /// Provider identifiers whose API keys are synced to the daemon as
     /// `type: "api_key"`. Combines the core provider list with any TTS
-    /// providers from the shared registry that use `api_key` setup mode,
-    /// so new registry entries are automatically included without code
-    /// changes here.
+    /// and STT providers from the shared registries that use `api_key`
+    /// setup mode, so new registry entries are automatically included
+    /// without code changes here.
     static let allSyncableProviders: [String] = {
         var ids = coreSyncableProviders
-        let registryApiKeyIds = loadTTSProviderRegistry().providers
+        let ttsApiKeyIds = loadTTSProviderRegistry().providers
             .filter { $0.setupMode == .apiKey }
             .map(\.id)
-        for id in registryApiKeyIds where !ids.contains(id) {
+        for id in ttsApiKeyIds where !ids.contains(id) {
             ids.append(id)
+        }
+        let sttApiKeyNames = loadSTTProviderRegistry().providers
+            .filter { $0.setupMode == .apiKey }
+            .map(\.apiKeyProviderName)
+        for name in sttApiKeyNames where !ids.contains(name) {
+            ids.append(name)
         }
         return ids
     }()

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -3000,20 +3000,53 @@ public final class SettingsStore: ObservableObject {
         return task
     }
 
-    /// Saves an OpenAI API key for the STT service to the credential store.
-    func saveSTTOpenAIKey(_ raw: String, onSuccess: (() -> Void)? = nil) {
+    /// Saves an API key for the given STT provider to the credential store.
+    /// The `sttProviderId` is the catalog identifier (e.g. `"openai-whisper"`,
+    /// `"deepgram"`); the method resolves the credential provider name from
+    /// the STT provider registry's `apiKeyProviderName` field so callers
+    /// don't need to know the mapping.
+    func saveSTTKey(_ raw: String, sttProviderId: String, onSuccess: (() -> Void)? = nil) {
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
-        APIKeyManager.setKey(trimmed, for: "openai")
-        removeDeletionTombstone(type: "api_key", name: "openai")
+        let keyProvider = Self.sttApiKeyProviderName(for: sttProviderId)
+        APIKeyManager.setKey(trimmed, for: keyProvider)
+        removeDeletionTombstone(type: "api_key", name: keyProvider)
         Task {
-            let result = await APIKeyManager.setKey(trimmed, for: "openai")
+            let result = await APIKeyManager.setKey(trimmed, for: keyProvider)
             if result.success {
                 onSuccess?()
             } else if let error = result.error {
-                log.error("Failed to sync OpenAI STT key to daemon: \(error, privacy: .public)")
+                log.error("Failed to sync STT key for \(sttProviderId, privacy: .public) to daemon: \(error, privacy: .public)")
             }
         }
+    }
+
+    /// Clears the API key for the given STT provider from both local and
+    /// daemon credential stores.
+    func clearSTTKey(sttProviderId: String) {
+        let keyProvider = Self.sttApiKeyProviderName(for: sttProviderId)
+        APIKeyManager.deleteKey(for: keyProvider)
+        Task {
+            let deleted = await APIKeyManager.deleteKey(for: keyProvider)
+            if !deleted { addDeletionTombstone(type: "api_key", name: keyProvider) }
+        }
+    }
+
+    /// Checks whether the daemon has an API key stored for the given STT
+    /// provider.
+    func hasSTTKey(sttProviderId: String) async -> Bool {
+        let keyProvider = Self.sttApiKeyProviderName(for: sttProviderId)
+        return await APIKeyManager.hasKey(for: keyProvider)
+    }
+
+    /// Resolves the `api_key` secret-catalog provider name for a given STT
+    /// provider identifier. Looks up the `apiKeyProviderName` from the STT
+    /// provider registry; falls back to the provider id itself when the
+    /// registry entry is not found.
+    static func sttApiKeyProviderName(for sttProviderId: String) -> String {
+        loadSTTProviderRegistry()
+            .provider(withId: sttProviderId)?
+            .apiKeyProviderName ?? sttProviderId
     }
 
     /// Schedules a delayed refresh of provider routing sources, giving the

--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -107,7 +107,7 @@ struct VoiceSettingsView: View {
             // Initialize STT draft state from persisted values
             draftSTTProvider = sttProviderRaw
             initialSTTProvider = sttProviderRaw
-            sttProviderHasKey = APIKeyManager.getKey(for: "openai") != nil
+            sttProviderHasKey = sttKeyExists(for: draftSTTProvider)
         }
         .onChange(of: draftTTSProvider) { _, _ in
             // Clear API key and voice ID fields when provider changes
@@ -120,7 +120,7 @@ struct VoiceSettingsView: View {
             // Clear stale fields when STT provider changes
             sttApiKeyText = ""
             sttSaveError = nil
-            sttProviderHasKey = APIKeyManager.getKey(for: "openai") != nil
+            sttProviderHasKey = sttKeyExists(for: draftSTTProvider)
         }
         .onChange(of: conversationTimeoutSeconds) {
             VoiceModeManager.conversationTimeoutOverride = conversationTimeoutSeconds
@@ -497,6 +497,13 @@ struct VoiceSettingsView: View {
         }
     }
 
+    /// Checks whether an API key exists for the given STT provider by
+    /// resolving the provider's `apiKeyProviderName` from the registry.
+    private func sttKeyExists(for sttProviderId: String) -> Bool {
+        let keyProvider = SettingsStore.sttApiKeyProviderName(for: sttProviderId)
+        return APIKeyManager.getKey(for: keyProvider) != nil
+    }
+
     /// Clears the stored TTS credential for the given provider.
     private func clearTTSCredential(for provider: String) {
         switch provider {
@@ -592,7 +599,7 @@ struct VoiceSettingsView: View {
         if !trimmedKey.isEmpty {
             sttApiKeyText = ""
             sttProviderHasKey = true
-            store.saveSTTOpenAIKey(trimmedKey)
+            store.saveSTTKey(trimmedKey, sttProviderId: draftSTTProvider)
         }
 
         initialSTTProvider = draftSTTProvider

--- a/clients/macos/vellum-assistantTests/SettingsStoreVoiceServiceTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsStoreVoiceServiceTests.swift
@@ -200,4 +200,60 @@ final class SettingsStoreVoiceServiceTests: XCTestCase {
             "STT provider must not be cleared when the daemon config omits stt"
         )
     }
+
+    // MARK: - setSTTProvider with Deepgram
+
+    func testSetSTTProviderDeepgramEmitsExpectedPatch() {
+        store.setSTTProvider("deepgram")
+
+        waitForPatchCount(1)
+
+        let patch = lastSTTPatch()
+        XCTAssertNotNil(patch, "expected a services.stt patch payload for deepgram")
+        XCTAssertEqual(patch?["provider"] as? String, "deepgram")
+    }
+
+    func testApplyDaemonConfigSyncsDeepgramSTTProvider() {
+        UserDefaults.standard.removeObject(forKey: "sttProvider")
+
+        let config: [String: Any] = [
+            "services": [
+                "stt": [
+                    "provider": "deepgram"
+                ]
+            ]
+        ]
+
+        mockSettingsClient.fetchConfigResponse = config
+        let expectation = XCTestExpectation(description: "config loaded")
+        Task {
+            await store.loadConfigFromDaemon()
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 2.0)
+
+        XCTAssertEqual(
+            UserDefaults.standard.string(forKey: "sttProvider"),
+            "deepgram"
+        )
+    }
+
+    // MARK: - sttApiKeyProviderName mapping
+
+    func testSTTApiKeyProviderNameResolvesOpenAIWhisperToOpenAI() {
+        // openai-whisper shares the "openai" API key
+        let keyName = SettingsStore.sttApiKeyProviderName(for: "openai-whisper")
+        XCTAssertEqual(keyName, "openai")
+    }
+
+    func testSTTApiKeyProviderNameResolvesDeepgramToDeepgram() {
+        let keyName = SettingsStore.sttApiKeyProviderName(for: "deepgram")
+        XCTAssertEqual(keyName, "deepgram")
+    }
+
+    func testSTTApiKeyProviderNameFallsBackToProviderIdForUnknown() {
+        // Unknown providers fall back to the provider id itself
+        let keyName = SettingsStore.sttApiKeyProviderName(for: "unknown-provider")
+        XCTAssertEqual(keyName, "unknown-provider")
+    }
 }

--- a/clients/shared/Utilities/STTProviderRegistry.swift
+++ b/clients/shared/Utilities/STTProviderRegistry.swift
@@ -32,6 +32,11 @@ public struct STTProviderCatalogEntry: Decodable {
     public let setupMode: STTProviderSetupMode
     /// Brief help text guiding the user through setup.
     public let setupHint: String
+    /// The credential provider name used when persisting the API key via
+    /// `APIKeyManager`. Maps the STT provider id to the `api_key` secret
+    /// name in the daemon's secret catalog. For example, `openai-whisper`
+    /// shares the `openai` API key while `deepgram` uses `deepgram`.
+    public let apiKeyProviderName: String
 }
 
 /// Top-level schema for `stt-provider-catalog.json`.
@@ -62,14 +67,16 @@ private let fallbackRegistry = STTProviderRegistry(
             displayName: "OpenAI Whisper",
             subtitle: "High-accuracy speech-to-text powered by OpenAI Whisper. Requires an OpenAI API key.",
             setupMode: .apiKey,
-            setupHint: "Enter your OpenAI API key to enable Whisper transcription."
+            setupHint: "Enter your OpenAI API key to enable Whisper transcription.",
+            apiKeyProviderName: "openai"
         ),
         STTProviderCatalogEntry(
             id: "deepgram",
             displayName: "Deepgram",
             subtitle: "Fast, real-time speech-to-text with streaming support. Requires a Deepgram API key.",
             setupMode: .apiKey,
-            setupHint: "Enter your Deepgram API key to enable speech-to-text."
+            setupHint: "Enter your Deepgram API key to enable speech-to-text.",
+            apiKeyProviderName: "deepgram"
         ),
     ]
 )

--- a/meta/stt-provider-catalog.json
+++ b/meta/stt-provider-catalog.json
@@ -6,14 +6,16 @@
       "displayName": "OpenAI Whisper",
       "subtitle": "High-accuracy speech-to-text powered by OpenAI Whisper. Requires an OpenAI API key.",
       "setupMode": "api-key",
-      "setupHint": "Enter your OpenAI API key to enable Whisper transcription."
+      "setupHint": "Enter your OpenAI API key to enable Whisper transcription.",
+      "apiKeyProviderName": "openai"
     },
     {
       "id": "deepgram",
       "displayName": "Deepgram",
       "subtitle": "Fast, real-time speech-to-text with streaming support. Requires a Deepgram API key.",
       "setupMode": "api-key",
-      "setupHint": "Enter your Deepgram API key to enable speech-to-text."
+      "setupHint": "Enter your Deepgram API key to enable speech-to-text.",
+      "apiKeyProviderName": "deepgram"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Updates APIKeyManager syncable list to include deepgram provider
- Replaces OpenAI-hardcoded STT save helpers with provider-parameterized methods
- Adds apiKeyProviderName field to STT provider catalog entry for credential mapping
- Adds/adjusts tests to validate provider-aware STT key save pathways

Part of plan: deepgram-first-class-services-stt.md (PR 5 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25047" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
