### PR TITLE
fix(macos): avoid O(n) hashing of tool output for NSCache key

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -663,7 +663,11 @@ private struct StepDetailRow: View {
     /// Render-time memoization that stays off SwiftUI-owned state.
     private var cachedColoredResult: AttributedString? {
         guard let result = toolCall.result, !result.isEmpty else { return nil }
-        let key = Self.coloredOutputCacheKey(for: result, isError: toolCall.isError)
+        let key = Self.coloredOutputCacheKey(
+            toolCallID: toolCall.id,
+            resultCount: result.utf8.count,
+            isError: toolCall.isError
+        )
         if let cached = Self.coloredOutputCache.object(forKey: key) {
             return cached.value
         }
@@ -947,12 +951,12 @@ private struct StepDetailRow: View {
 
     // MARK: - Helpers
 
-    private static func coloredOutputCacheKey(for result: String, isError: Bool) -> NSString {
-        var hasher = Hasher()
-        hasher.combine(result)
-        hasher.combine(result.utf8.count)
-        hasher.combine(isError)
-        return "output:\(result.utf8.count):\(hasher.finalize())" as NSString
+    private static func coloredOutputCacheKey(
+        toolCallID: String,
+        resultCount: Int,
+        isError: Bool
+    ) -> NSString {
+        return "\(toolCallID)|\(resultCount)|\(isError ? "err" : "ok")" as NSString
     }
 
     private func coloredOutput(_ result: String, isError: Bool) -> AttributedString {


### PR DESCRIPTION
Addresses Codex feedback on #24336 — cache key now derives from toolCall.id + result.count + error flag instead of hashing the full result string every render.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25048" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
