### PR TITLE
fix(macos): rename ComposerPopupState.none to .inactive (keeps rawValue="none")

### DIFF
--- a/clients/macos/vellum-assistant/Logging/ChatDiagnosticsStore.swift
+++ b/clients/macos/vellum-assistant/Logging/ChatDiagnosticsStore.swift
@@ -62,7 +62,7 @@ enum ChatDiagnosticEventKind: String, Codable, Sendable {
 enum ComposerPopupState: String, Codable, Sendable {
     case slash
     case emoji
-    case none
+    case inactive = "none"
 }
 
 /// Content-safe scroll intent source.

--- a/clients/macos/vellum-assistantTests/ChatDiagnosticsStoreTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatDiagnosticsStoreTests.swift
@@ -563,7 +563,7 @@ struct ChatDiagnosticsStoreTests {
             viewportHeight: 800.0,
             source: .chatView,
             expandedProgressCardCount: 1,
-            composerPopupState: ComposerPopupState.none,
+            composerPopupState: ComposerPopupState.inactive,
             scrollIntentSource: .anchor
         )
 
@@ -583,7 +583,7 @@ struct ChatDiagnosticsStoreTests {
         let decoded = try decoder.decode(ChatTranscriptSnapshot.self, from: data)
         #expect(decoded.source == .chatView)
         #expect(decoded.expandedProgressCardCount == 1)
-        #expect(decoded.composerPopupState == ComposerPopupState.none)
+        #expect(decoded.composerPopupState == ComposerPopupState.inactive)
         #expect(decoded.scrollIntentSource == .anchor)
     }
 
@@ -623,7 +623,7 @@ struct ChatDiagnosticsStoreTests {
             source: .scrollCoordinator,
             interaction: .anchorJump,
             expandedProgressCardCount: 0,
-            composerPopupState: ComposerPopupState.none,
+            composerPopupState: ComposerPopupState.inactive,
             scrollIntentSource: .anchor
         ))
 
@@ -632,7 +632,7 @@ struct ChatDiagnosticsStoreTests {
         #expect(recorded?.source == .scrollCoordinator)
         #expect(recorded?.interaction == .anchorJump)
         #expect(recorded?.expandedProgressCardCount == 0)
-        #expect(recorded?.composerPopupState == ComposerPopupState.none)
+        #expect(recorded?.composerPopupState == ComposerPopupState.inactive)
         #expect(recorded?.scrollIntentSource == .anchor)
     }
 
@@ -691,7 +691,7 @@ struct ChatDiagnosticsStoreTests {
     func composerPopupStateRawValuesAreStable() {
         #expect(ComposerPopupState.slash.rawValue == "slash")
         #expect(ComposerPopupState.emoji.rawValue == "emoji")
-        #expect(ComposerPopupState.none.rawValue == "none")
+        #expect(ComposerPopupState.inactive.rawValue == "none")
     }
 
     @Test


### PR DESCRIPTION
Addresses Devin feedback on #24379. Naming footgun: .none on an optional enum silently resolves to Optional.none. Rename to .inactive while preserving rawValue for JSONL compatibility.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25050" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
