### PR TITLE
fix(macos): short-circuit typing indicator TimelineView when reduce-motion is on

### DIFF
--- a/clients/shared/Features/Chat/TypingIndicatorView.swift
+++ b/clients/shared/Features/Chat/TypingIndicatorView.swift
@@ -12,19 +12,14 @@ public struct TypingIndicatorView: View {
     public init() {}
 
     public var body: some View {
-        TimelineView(.periodic(from: .now, by: tickInterval)) { context in
-            let activeIndex = reduceMotion ? -1 : animationPhase(at: context.date)
-
-            HStack(spacing: dotSpacing) {
-                ForEach(0..<3, id: \.self) { index in
-                    Circle()
-                        .fill(VColor.contentTertiary)
-                        .frame(width: dotSize, height: dotSize)
-                        .scaleEffect(reduceMotion ? 1.0 : (activeIndex == index ? 1.0 : 0.6))
-                        .opacity(reduceMotion ? 0.7 : (activeIndex == index ? 1.0 : 0.45))
+        Group {
+            if reduceMotion {
+                staticDots
+            } else {
+                TimelineView(.periodic(from: .now, by: tickInterval)) { context in
+                    animatedDots(activeIndex: animationPhase(at: context.date))
                 }
             }
-            .frame(width: intrinsicDotsWidth, height: dotSize, alignment: .center)
         }
         .padding(.horizontal, VSpacing.md)
         .padding(.vertical, VSpacing.sm)
@@ -35,6 +30,31 @@ public struct TypingIndicatorView: View {
         .fixedSize()
         .accessibilityElement(children: .ignore)
         .accessibilityLabel("Assistant is thinking")
+    }
+
+    private var staticDots: some View {
+        HStack(spacing: dotSpacing) {
+            ForEach(0..<3, id: \.self) { _ in
+                Circle()
+                    .fill(VColor.contentTertiary)
+                    .frame(width: dotSize, height: dotSize)
+                    .opacity(0.7)
+            }
+        }
+        .frame(width: intrinsicDotsWidth, height: dotSize, alignment: .center)
+    }
+
+    private func animatedDots(activeIndex: Int) -> some View {
+        HStack(spacing: dotSpacing) {
+            ForEach(0..<3, id: \.self) { index in
+                Circle()
+                    .fill(VColor.contentTertiary)
+                    .frame(width: dotSize, height: dotSize)
+                    .scaleEffect(activeIndex == index ? 1.0 : 0.6)
+                    .opacity(activeIndex == index ? 1.0 : 0.45)
+            }
+        }
+        .frame(width: intrinsicDotsWidth, height: dotSize, alignment: .center)
     }
 
     private var intrinsicDotsWidth: CGFloat {


### PR DESCRIPTION
Addresses Codex feedback on #24627. Under accessibilityReduceMotion, TimelineView(.periodic) still wakes every 180ms even though the output is static. Render a plain HStack in that branch to avoid unnecessary view invalidation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25051" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
