### PR TITLE
fix(macos): add button a11y traits to Usage breakdown row (addresses #24728 and #24730)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/LogsAndUsagePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/LogsAndUsagePanel.swift
@@ -649,6 +649,10 @@ struct UsageTabContent: View {
                 .pointerCursor { hovering in
                     hoveredConversationGroupId = hovering ? target : nil
                 }
+                .accessibilityAddTraits(.isButton)
+                .accessibilityAction {
+                    onSelectConversation(target)
+                }
         } else {
             row
         }


### PR DESCRIPTION
Addresses Codex feedback on #24728 and Devin feedback on #24730. Interactive breakdown rows were using .onTapGesture without button semantics — VoiceOver/keyboard users couldn't reach them. Adds .accessibilityAddTraits(.isButton) and .accessibilityAction to the interactive branch.