### PR TITLE
perf(daemon): lazy-allocate containers in surrogate sanitizer to avoid per-request GC churn

### DIFF
--- a/assistant/src/__tests__/unicode.test.ts
+++ b/assistant/src/__tests__/unicode.test.ts
@@ -195,6 +195,55 @@ describe("stripOrphanedSurrogatesDeep", () => {
     expect(result.fixedStringCount).toBe(2);
   });
 
+  test("preserves reference identity of every clean container in a nested tree", () => {
+    // The happy path must not allocate shadow arrays/objects — this runs on
+    // every outbound Anthropic request, so GC churn adds up. Verify that the
+    // top-level object AND every nested container is returned by reference.
+    const innerArr = ["a", "b", EMOJI];
+    const innerObj = { x: 1, y: "ok", z: innerArr };
+    const input = {
+      a: "hello",
+      b: innerObj,
+      c: [innerObj, "clean", EMOJI],
+    };
+    const result = stripOrphanedSurrogatesDeep(input);
+    expect(result.changed).toBe(false);
+    expect(result.value).toBe(input);
+    expect(result.value.b).toBe(innerObj);
+    expect(result.value.b.z).toBe(innerArr);
+    expect(result.value.c).toBe(input.c);
+    expect(result.value.c[0]).toBe(innerObj);
+  });
+
+  test("clean siblings alongside a dirty child reuse original references where possible", () => {
+    // When one branch changes, only the containers on the path from root to
+    // the change should be reallocated — untouched sibling subtrees must keep
+    // their original reference.
+    const cleanBranch = { deep: { list: ["a", "b"] } };
+    const input = {
+      clean: cleanBranch,
+      dirty: { value: `bad${HIGH}` },
+    };
+    const result = stripOrphanedSurrogatesDeep(input);
+    expect(result.changed).toBe(true);
+    expect(result.value).not.toBe(input);
+    expect(result.value.clean).toBe(cleanBranch);
+    expect(result.value.clean.deep).toBe(cleanBranch.deep);
+    expect(result.value.clean.deep.list).toBe(cleanBranch.deep.list);
+    expect(result.value.dirty).not.toBe(input.dirty);
+    expect(result.value.dirty.value).toBe(`bad${REPLACEMENT}`);
+  });
+
+  test("array with a dirty tail preserves clean leading element references", () => {
+    const cleanItem = { k: "v" };
+    const input = [cleanItem, `bad${HIGH}`];
+    const result = stripOrphanedSurrogatesDeep(input);
+    expect(result.changed).toBe(true);
+    expect(result.value).not.toBe(input);
+    expect(result.value[0]).toBe(cleanItem);
+    expect(result.value[1]).toBe(`bad${REPLACEMENT}`);
+  });
+
   test("rewritten output can be JSON-stringified end-to-end", () => {
     // This is the exact shape of the bug: a payload with an orphaned high
     // surrogate buried in a tool_result content string. After sanitization,

--- a/assistant/src/util/unicode.ts
+++ b/assistant/src/util/unicode.ts
@@ -144,14 +144,19 @@ export function stripOrphanedSurrogatesDeep<T>(input: T): DeepSanitizeResult<T> 
     }
 
     if (Array.isArray(value)) {
-      let arrChanged = false;
-      const next: unknown[] = new Array(value.length);
+      let next: unknown[] | null = null;
       for (let i = 0; i < value.length; i++) {
         const result = walk(value[i]);
-        next[i] = result.value;
-        if (result.changed) arrChanged = true;
+        if (result.changed && next === null) {
+          next = value.slice(0, i);
+        }
+        if (next !== null) {
+          next.push(result.value);
+        }
       }
-      return arrChanged ? { value: next, changed: true } : { value, changed: false };
+      return next !== null
+        ? { value: next, changed: true }
+        : { value, changed: false };
     }
 
     if (value != null && typeof value === "object") {
@@ -159,14 +164,26 @@ export function stripOrphanedSurrogatesDeep<T>(input: T): DeepSanitizeResult<T> 
       if (proto !== Object.prototype && proto !== null) {
         return { value, changed: false };
       }
-      let objChanged = false;
-      const next: Record<string, unknown> = {};
-      for (const key of Object.keys(value as Record<string, unknown>)) {
-        const result = walk((value as Record<string, unknown>)[key]);
-        next[key] = result.value;
-        if (result.changed) objChanged = true;
+      const source = value as Record<string, unknown>;
+      const keys = Object.keys(source);
+      let next: Record<string, unknown> | null = null;
+      for (let i = 0; i < keys.length; i++) {
+        const key = keys[i]!;
+        const result = walk(source[key]);
+        if (result.changed && next === null) {
+          next = {};
+          for (let j = 0; j < i; j++) {
+            const priorKey = keys[j]!;
+            next[priorKey] = source[priorKey];
+          }
+        }
+        if (next !== null) {
+          next[key] = result.value;
+        }
       }
-      return objChanged ? { value: next, changed: true } : { value, changed: false };
+      return next !== null
+        ? { value: next, changed: true }
+        : { value, changed: false };
     }
 
     return { value, changed: false };


### PR DESCRIPTION
Addresses Codex feedback on #24691. The sanitizer runs on every outbound Anthropic request; clean payloads were still paying allocation+GC cost for shadow containers. Defer allocation until the first changed child so the happy path is reference-preserving.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25053" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
