### PR TITLE
fix(contacts): wrap ensureGuardianPersonaFile in try/catch in createGuardianBinding

### DIFF
--- a/assistant/src/contacts/contacts-write.ts
+++ b/assistant/src/contacts/contacts-write.ts
@@ -105,7 +105,17 @@ export function createGuardianBinding(params: {
   // `users/` directory watcher would fire on every new contact and
   // evict live conversations.
   if (contact.userFile) {
-    ensureGuardianPersonaFile(contact.userFile);
+    // Tolerate filesystem failures (read-only or full workspace) so a
+    // disk error doesn't leave the DB commit orphaned. The persona file
+    // can be reseeded later; failing the binding here would be worse.
+    try {
+      ensureGuardianPersonaFile(contact.userFile);
+    } catch (err) {
+      log.warn(
+        { err, userFile: contact.userFile },
+        "failed to seed guardian persona file; continuing",
+      );
+    }
     // Invalidate the trust rule cache so the dynamic guardian-persona
     // auto-allow rules from `permissions/defaults.ts` are backfilled on
     // the next `getRules()` call. Without this, guardians created at


### PR DESCRIPTION
Addresses Codex feedback on #24842. ensureGuardianPersonaFile does sync fs writes; a read-only or full workspace throws AFTER the DB commit, leaving partially-applied state. Log and continue on fs failure so the binding succeeds.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25054" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
