### PR TITLE
fix(permissions): escape minimatch metacharacters in guardian-persona auto-allow path

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -1615,6 +1615,50 @@ describe("Permission Checker", () => {
       );
       expect(guardianRules).toHaveLength(0);
     });
+
+    test("glob metacharacters in guardian path are escaped and match only the literal file", async () => {
+      // A legacy/imported contact whose userFile contains glob metacharacters
+      // must not broaden the auto-allow rule into a wildcard match.
+      const weirdDir = join(checkerTestDir, "users");
+      const guardianPath = join(weirdDir, "weird[slug]*.md");
+      const siblingPath = join(weirdDir, "weirdX.md");
+      mockGuardianPersonaPath = guardianPath;
+
+      const templates = getDefaultRuleTemplates();
+      const guardianRules = templates.filter((t) =>
+        t.id.endsWith("-guardian-persona"),
+      );
+      expect(guardianRules).toHaveLength(3);
+      for (const rule of guardianRules) {
+        // Pattern must contain escaped metacharacters, not bare wildcards.
+        expect(rule.pattern).not.toBe(`${rule.tool}:${guardianPath}`);
+        expect(rule.pattern).toContain("\\[");
+        expect(rule.pattern).toContain("\\]");
+        expect(rule.pattern).toContain("\\*");
+      }
+
+      // Literal guardian path is auto-allowed.
+      const literal = await check(
+        "file_edit",
+        { path: guardianPath },
+        "/tmp",
+      );
+      expect(literal.decision).toBe("allow");
+      expect(literal.matchedRule?.id).toBe(
+        "default:allow-file_edit-guardian-persona",
+      );
+
+      // A sibling file that would match if `*` / `[...]` were treated as
+      // wildcards must NOT match the dynamic guardian-persona rule.
+      const sibling = await check(
+        "file_edit",
+        { path: siblingPath },
+        "/tmp",
+      );
+      expect(sibling.matchedRule?.id).not.toBe(
+        "default:allow-file_edit-guardian-persona",
+      );
+    });
   });
 
   // ── generateAllowlistOptions ───────────────────────────────────

--- a/assistant/src/permissions/defaults.ts
+++ b/assistant/src/permissions/defaults.ts
@@ -16,6 +16,16 @@ export interface DefaultRuleTemplate {
   allowHighRisk?: boolean;
 }
 
+/**
+ * Escape minimatch metacharacters so a literal path is matched literally when
+ * interpolated into a rule pattern. Without this, characters like `*`, `?`,
+ * `[`, `]`, `{`, `}` in a filename would be treated as wildcards and broaden
+ * the resulting allow rule beyond the intended file.
+ */
+function escapeMinimatchPath(p: string): string {
+  return p.replace(/[?*[\]{}()!|\\]/g, "\\$&");
+}
+
 const HOST_FILE_TOOLS = [
   "host_file_read",
   "host_file_write",
@@ -156,10 +166,11 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
     const guardianPath = resolveGuardianPersonaPath();
     if (guardianPath) {
       const posixPath = guardianPath.replaceAll("\\", "/");
+      const escapedPath = escapeMinimatchPath(posixPath);
       guardianPersonaRules = WORKSPACE_FILE_TOOLS.map((tool) => ({
         id: `default:allow-${tool}-guardian-persona`,
         tool,
-        pattern: `${tool}:${posixPath}`,
+        pattern: `${tool}:${escapedPath}`,
         scope: "everywhere",
         decision: "allow" as const,
         priority: 100,


### PR DESCRIPTION
Addresses Codex feedback on #24849. Minimatch metacharacters (*, ?, [, ], {, }) in userFile would be treated as wildcards, broadening the default allow. Escape them before interpolation and add a defensive test.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25058" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
