### PR TITLE
fix(vbundle): unblock preflight for legacy bundles in guardian-less workspaces

### DIFF
--- a/assistant/src/runtime/migrations/__tests__/vbundle-legacy-user-md.test.ts
+++ b/assistant/src/runtime/migrations/__tests__/vbundle-legacy-user-md.test.ts
@@ -198,7 +198,7 @@ describe("analyzeImport for legacy prompts/USER.md", () => {
     expect(report.files[0].action).toBe("create");
   });
 
-  test("reports a conflict when no guardian is resolvable", () => {
+  test("non-blocking skip when no guardian is resolvable (can_import stays true)", () => {
     const resolver = new DefaultPathResolver(
       WORKSPACE_ROOT,
       undefined,
@@ -216,11 +216,10 @@ describe("analyzeImport for legacy prompts/USER.md", () => {
 
     const report = analyzeImport({ manifest, pathResolver: resolver });
 
-    // UNKNOWN_ARCHIVE_PATH is the analyzer's conflict code for entries
-    // whose resolver returned null.
-    expect(report.conflicts.some((c) => c.code === "UNKNOWN_ARCHIVE_PATH")).toBe(
-      true,
-    );
+    // Guardian-less workspaces must not block preflight — the commit-time
+    // path warns and skips, so preflight mirrors that behavior.
+    expect(report.can_import).toBe(true);
+    expect(report.conflicts).toHaveLength(0);
     expect(report.files[0].action).toBe("skip");
   });
 });

--- a/assistant/src/runtime/migrations/vbundle-import-analyzer.ts
+++ b/assistant/src/runtime/migrations/vbundle-import-analyzer.ts
@@ -265,6 +265,27 @@ export function analyzeImport(
     }
 
     if (!diskPath) {
+      // Legacy `prompts/USER.md` in a guardian-less workspace has no
+      // destination to translate to. The commit-time path skips this
+      // entry with a warning rather than failing, so preflight mirrors
+      // that: emit a non-blocking skip so `can_import` stays true and
+      // upgrade paths proceed. No conflict is registered.
+      if (fileEntry.path === LEGACY_USER_MD_ARCHIVE_PATH) {
+        log.warn(
+          { path: fileEntry.path },
+          "Legacy prompts/USER.md has no guardian target — will be skipped on import",
+        );
+        files.push({
+          path: fileEntry.path,
+          action: "skip",
+          bundle_size: fileEntry.size,
+          bundle_sha256: fileEntry.sha256,
+          current_size: null,
+          current_sha256: null,
+        });
+        continue;
+      }
+
       // Unknown archive path — would have nowhere to write
       conflicts.push({
         code: "UNKNOWN_ARCHIVE_PATH",


### PR DESCRIPTION
Addresses Codex P1 feedback on #24852. The analyzer was emitting UNKNOWN_ARCHIVE_PATH for legacy prompts/USER.md when no guardian was resolvable, which blocked preflight even though the commit-time path skipped with a warning. Align preflight with commit-time behavior so upgrade paths proceed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25059" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
