### PR TITLE
fix(prompts): broaden isFirstRun to cover workspaces with users/ or existing conversations

### DIFF
--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -682,6 +682,21 @@ describe("ensurePromptFiles", () => {
     expect(existsSync(bootstrapPath)).toBe(false);
   });
 
+  test("does not treat a workspace with populated users/ as a first run", () => {
+    // Upgraded workspaces may have dropped USER.md but still carry a
+    // populated users/ directory.  Presence of users/<slug>.md signals an
+    // existing install, so BOOTSTRAP.md must not be re-seeded even when
+    // SOUL.md and IDENTITY.md are absent (they will be freshly seeded from
+    // templates, but onboarding should not re-trigger).
+    mkdirSync(join(TEST_DIR, "users"), { recursive: true });
+    writeFileSync(join(TEST_DIR, "users", "sidd.md"), "# Sidd persona");
+
+    ensurePromptFiles();
+
+    const bootstrapPath = join(TEST_DIR, "BOOTSTRAP.md");
+    expect(existsSync(bootstrapPath)).toBe(false);
+  });
+
   test("auto-deletes stale BOOTSTRAP.md when prior conversations exist", () => {
     // Simulate a non-first-run workspace: core files + BOOTSTRAP.md still present
     writeFileSync(join(TEST_DIR, "IDENTITY.md"), "My identity");
@@ -698,15 +713,18 @@ describe("ensurePromptFiles", () => {
     expect(existsSync(join(TEST_DIR, "BOOTSTRAP.md"))).toBe(false);
   });
 
-  test("keeps BOOTSTRAP.md on first run even if conversations dir exists", () => {
-    // First run: no core files exist, BOOTSTRAP.md should be created and kept
+  test("does not seed BOOTSTRAP.md when conversations exist even if core files are missing", () => {
+    // An upgraded workspace might have dropped SOUL.md/IDENTITY.md (they
+    // will be re-seeded from templates) but still carries prior
+    // conversations.  Existing conversation history signals a non-fresh
+    // install, so onboarding must not re-trigger.
     const convDir = join(TEST_DIR, "conversations");
     mkdirSync(convDir, { recursive: true });
     writeFileSync(join(convDir, "conv-001.json"), "{}");
 
     ensurePromptFiles();
 
-    expect(existsSync(join(TEST_DIR, "BOOTSTRAP.md"))).toBe(true);
+    expect(existsSync(join(TEST_DIR, "BOOTSTRAP.md"))).toBe(false);
   });
 
   test("keeps BOOTSTRAP.md when no conversations exist yet", () => {

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -27,6 +27,26 @@ const log = getLogger("system-prompt");
 
 const PROMPT_FILES = ["SOUL.md", "IDENTITY.md"] as const;
 
+function hasPopulatedUsersDir(): boolean {
+  try {
+    const usersDir = join(getWorkspaceDir(), "users");
+    if (!existsSync(usersDir)) return false;
+    return readdirSync(usersDir).length > 0;
+  } catch {
+    return false;
+  }
+}
+
+function hasExistingConversations(): boolean {
+  try {
+    const convDir = getConversationsDir();
+    if (!existsSync(convDir)) return false;
+    return readdirSync(convDir).length > 0;
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Copy template prompt files into the data directory if they don't already exist.
  * Called once during daemon startup so users always have discoverable files to edit.
@@ -43,10 +63,16 @@ export function ensurePromptFiles(): void {
     "templates",
   );
 
-  // Track whether this is a fresh workspace (no core prompt files exist yet).
-  const isFirstRun = PROMPT_FILES.every(
-    (file) => !existsSync(getWorkspacePromptPath(file)),
-  );
+  // Track whether this is a fresh workspace.  A workspace counts as fresh
+  // only when none of these signals are present: core prompt files, a
+  // populated `users/` directory, or existing conversations.  Upgraded
+  // workspaces that dropped USER.md but still carry personas or history
+  // would otherwise be mistaken for fresh installs and re-trigger
+  // onboarding.
+  const isFirstRun =
+    PROMPT_FILES.every((file) => !existsSync(getWorkspacePromptPath(file))) &&
+    !hasPopulatedUsersDir() &&
+    !hasExistingConversations();
 
   for (const file of PROMPT_FILES) {
     const dest = getWorkspacePromptPath(file);


### PR DESCRIPTION
Addresses Codex feedback on #24854. After dropping USER.md from PROMPT_FILES, isFirstRun only checked SOUL.md and IDENTITY.md — an upgraded workspace missing those two but with populated users/ would be mistaken for fresh. Broaden the check.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25060" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
