### PR TITLE
fix(contacts): tighten migration 220 GLOB to avoid misclassifying dated persona filenames

### DIFF
--- a/assistant/src/__tests__/contact-store-user-file.test.ts
+++ b/assistant/src/__tests__/contact-store-user-file.test.ts
@@ -297,6 +297,66 @@ describe("migrateNormalizeUserFileByPrincipal", () => {
     expect(rows[0]?.user_file).toBe("alone.md");
   });
 
+  test("does not classify dated-slug filenames as auto-incremented", () => {
+    // A display name containing a 4-digit year (e.g. "Alex 2024") produces
+    // `alex-2024.md`. The auto-increment suffix only ever appends 1–3 digits
+    // (starting at 2), so `alex-2024.md` must be treated as a normal filename
+    // and not deprioritized in favor of an older sibling.
+    const now = Date.now();
+    insertContact({
+      id: "c1",
+      displayName: "Alex 2024",
+      role: "guardian",
+      principalId: "principal-dated",
+      userFile: "alex-2024.md",
+      createdAt: now,
+    });
+    insertContact({
+      id: "c2",
+      displayName: "Alex",
+      role: "guardian",
+      principalId: "principal-dated",
+      userFile: "alex.md",
+      createdAt: now - 1000,
+    });
+
+    migrateNormalizeUserFileByPrincipal(getDb());
+
+    const rows = fetchUserFilesByPrincipal("principal-dated");
+    // Neither candidate looks auto-incremented, so tiebreaker is oldest
+    // created_at — c2 (`alex.md`) wins. Crucially, `alex-2024.md` was NOT
+    // classified as auto-incremented and penalized.
+    expect(rows.map((r) => r.user_file).sort()).toEqual(["alex.md", "alex.md"]);
+  });
+
+  test("classifies only 1-3 digit tails as auto-incremented", () => {
+    // `-2.md` is auto-increment; `-1999.md` (year) is not.
+    const now = Date.now();
+    insertContact({
+      id: "c1",
+      displayName: "Bob 1999",
+      role: "guardian",
+      principalId: "principal-mixed",
+      userFile: "bob-1999.md",
+      createdAt: now - 2000,
+    });
+    insertContact({
+      id: "c2",
+      displayName: "Bob",
+      role: "guardian",
+      principalId: "principal-mixed",
+      userFile: "bob-2.md",
+      createdAt: now - 1000,
+    });
+
+    migrateNormalizeUserFileByPrincipal(getDb());
+
+    const rows = fetchUserFilesByPrincipal("principal-mixed");
+    // `bob-1999.md` is non-auto-incremented, `bob-2.md` is auto-incremented;
+    // the former wins regardless of age.
+    for (const row of rows) expect(row.user_file).toBe("bob-1999.md");
+  });
+
   test("is idempotent", () => {
     const now = Date.now();
     insertContact({

--- a/assistant/src/memory/migrations/220-normalize-user-file-by-principal.ts
+++ b/assistant/src/memory/migrations/220-normalize-user-file-by-principal.ts
@@ -26,7 +26,11 @@ export function downNormalizeUserFileByPrincipal(_database: DrizzleDb): void {
  * This migration picks one canonical `user_file` per principal and updates
  * every sibling row to match. Selection heuristic:
  *
- *   1. Prefer values that do NOT look auto-incremented (no `-<digit>.md` tail).
+ *   1. Prefer values that do NOT look auto-incremented. Auto-increment tails
+ *      are `-<N>.md` where N is 1–3 digits (matches `generateUserFileSlug`'s
+ *      counter). Matching is anchored to the end of the filename so a slug
+ *      that happens to contain a numeric segment (e.g. `alex-2024.md` — a
+ *      display name with a year) is NOT classified as auto-incremented.
  *   2. Among those, prefer the oldest contact row (earliest `created_at`).
  *   3. Ties broken by `id` for determinism.
  *
@@ -83,7 +87,12 @@ export function migrateNormalizeUserFileByPrincipal(
           SELECT user_file FROM contacts
           WHERE principal_id = ? AND user_file IS NOT NULL
           ORDER BY
-            CASE WHEN user_file GLOB '*-[0-9]*.md' THEN 1 ELSE 0 END,
+            CASE
+              WHEN user_file GLOB '*-[0-9].md'
+                OR user_file GLOB '*-[0-9][0-9].md'
+                OR user_file GLOB '*-[0-9][0-9][0-9].md'
+              THEN 1 ELSE 0
+            END,
             created_at ASC,
             id ASC
           LIMIT 1


### PR DESCRIPTION
Addresses Codex feedback on #24723. The canonical-selection GLOB matched any user_file with -<digit> anywhere, so e.g. alex-2024.md would be deprioritized as if it were an auto-increment suffix. Tighten the pattern to only match -<digits>.md at the end.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25061" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
