### PR TITLE
fix(backup): reject normalized-invalid dates in parseBackupTimestamp

### DIFF
--- a/assistant/src/backup/__tests__/paths.test.ts
+++ b/assistant/src/backup/__tests__/paths.test.ts
@@ -180,4 +180,27 @@ describe("parseBackupTimestamp", () => {
   test("returns null for a filename with the wrong extension", () => {
     expect(parseBackupTimestamp("backup-20260411-153045.tar.gz")).toBeNull();
   });
+
+  test("returns null for out-of-range calendar dates (Feb 31)", () => {
+    // `new Date("2026-02-31T...")` silently normalizes to March 3. Without a
+    // round-trip check this would misorder retention.
+    expect(parseBackupTimestamp("backup-20260231-000000.vbundle")).toBeNull();
+  });
+
+  test("returns null for other normalized-invalid dates", () => {
+    // Month 13, day 32, hour 24, April 31 all normalize silently.
+    expect(parseBackupTimestamp("backup-20261301-000000.vbundle")).toBeNull();
+    expect(parseBackupTimestamp("backup-20260132-000000.vbundle")).toBeNull();
+    expect(parseBackupTimestamp("backup-20260431-000000.vbundle")).toBeNull();
+  });
+
+  test("accepts Feb 29 in a leap year", () => {
+    const parsed = parseBackupTimestamp("backup-20240229-120000.vbundle");
+    expect(parsed).not.toBeNull();
+    expect(parsed!.toISOString()).toBe("2024-02-29T12:00:00.000Z");
+  });
+
+  test("returns null for Feb 29 in a non-leap year", () => {
+    expect(parseBackupTimestamp("backup-20260229-000000.vbundle")).toBeNull();
+  });
 });

--- a/assistant/src/backup/paths.ts
+++ b/assistant/src/backup/paths.ts
@@ -119,5 +119,18 @@ export function parseBackupTimestamp(filename: string): Date | null {
   const iso = `${year}-${month}-${day}T${hour}:${minute}:${second}.000Z`;
   const date = new Date(iso);
   if (Number.isNaN(date.getTime())) return null;
+  // `new Date()` silently normalizes out-of-range calendar values (e.g. Feb 31
+  // → March 3). Verify round-trip so malformed filenames can't be accepted and
+  // reordered in retention/restore flows.
+  if (
+    date.getUTCFullYear() !== Number(year) ||
+    date.getUTCMonth() !== Number(month) - 1 ||
+    date.getUTCDate() !== Number(day) ||
+    date.getUTCHours() !== Number(hour) ||
+    date.getUTCMinutes() !== Number(minute) ||
+    date.getUTCSeconds() !== Number(second)
+  ) {
+    return null;
+  }
   return date;
 }


### PR DESCRIPTION
Addresses Codex P2 feedback on #24881. new Date() silently normalizes invalid calendar dates (Feb 31 → March 3), so malformed backup filenames could misorder retention. Verify round-trip component match; return null on mismatch.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25062" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
