### PR TITLE
fix: only subtract summaryOffset when summary is injected, not child-owned

### DIFF
--- a/assistant/src/__tests__/context-window-manager.test.ts
+++ b/assistant/src/__tests__/context-window-manager.test.ts
@@ -1052,4 +1052,92 @@ describe("ContextWindowManager", () => {
       normalResult.compactedMessages,
     );
   });
+
+  test("subtracts summaryOffset only when summary at index 0 was injected from parent", async () => {
+    const provider = createProvider(() => ({
+      content: [{ type: "text", text: "## Goals\n- new child summary" }],
+      model: "mock-model",
+      usage: { inputTokens: 75, outputTokens: 20 },
+      stopReason: "end_turn",
+    }));
+    const manager = new ContextWindowManager({
+      provider,
+      systemPrompt: "system prompt",
+      config: makeConfig({
+        maxInputTokens: 320,
+        targetBudgetRatio: 0.58,
+      }),
+    });
+    const long = "k".repeat(220);
+    // Parent-injected summary at index 0, plus 2 injected non-persisted
+    // messages, plus 3 child-persisted messages. nonPersistedPrefixCount
+    // includes the summary (set by injectInheritedContext).
+    const history: Message[] = [
+      createContextSummaryMessage("parent summary"),
+      message("user", `injected-u ${long}`),
+      message("assistant", `injected-a ${long}`),
+      message("user", `persisted-u1 ${long}`),
+      message("assistant", `persisted-a1 ${long}`),
+      message("user", `persisted-u2 ${long}`),
+    ];
+    manager.nonPersistedPrefixCount = 3;
+    manager.summaryIsInjected = true;
+
+    const result = await manager.maybeCompact(history, undefined, {
+      force: true,
+    });
+    expect(result.compacted).toBe(true);
+    // 4 messages compacted (2 injected + 2 child-persisted), but only the
+    // 2 child-persisted ones count as DB-persisted.
+    expect(result.compactedMessages).toBe(4);
+    expect(result.compactedPersistedMessages).toBe(2);
+    // Flag clears and prefix drains (both injected messages + summary slot).
+    expect(manager.summaryIsInjected).toBe(false);
+    expect(manager.nonPersistedPrefixCount).toBe(0);
+  });
+
+  test("does not subtract summaryOffset when summary at index 0 is child-owned from prior compaction", async () => {
+    const provider = createProvider(() => ({
+      content: [{ type: "text", text: "## Goals\n- next child summary" }],
+      model: "mock-model",
+      usage: { inputTokens: 75, outputTokens: 20 },
+      stopReason: "end_turn",
+    }));
+    const manager = new ContextWindowManager({
+      provider,
+      systemPrompt: "system prompt",
+      config: makeConfig({
+        maxInputTokens: 320,
+        targetBudgetRatio: 0.58,
+      }),
+    });
+    const long = "k".repeat(220);
+    // Post-first-compaction state: child-owned summary at index 0, 2
+    // still-injected messages that survived the first compaction's keep
+    // region, 3 child-persisted messages. nonPersistedPrefixCount reflects
+    // only the 2 remaining injected messages — the summary slot was already
+    // consumed when the flag-gated decrement ran on the prior compaction.
+    const history: Message[] = [
+      createContextSummaryMessage("prior child summary"),
+      message("user", `injected-u ${long}`),
+      message("assistant", `injected-a ${long}`),
+      message("user", `persisted-u1 ${long}`),
+      message("assistant", `persisted-a1 ${long}`),
+      message("user", `persisted-u2 ${long}`),
+    ];
+    manager.nonPersistedPrefixCount = 2;
+    manager.summaryIsInjected = false;
+
+    const result = await manager.maybeCompact(history, undefined, {
+      force: true,
+    });
+    expect(result.compacted).toBe(true);
+    expect(result.compactedMessages).toBe(4);
+    // Regression guard: without the flag gate, the subtraction from the
+    // #24353 fix would double-apply here (nonPersistedPrefixCount - 1),
+    // undercounting injectedInCompactable and inflating
+    // compactedPersistedMessages by 1 (to 3).
+    expect(result.compactedPersistedMessages).toBe(2);
+    expect(manager.nonPersistedPrefixCount).toBe(0);
+  });
 });

--- a/assistant/src/context/window-manager.ts
+++ b/assistant/src/context/window-manager.ts
@@ -112,6 +112,16 @@ export class ContextWindowManager {
    */
   nonPersistedPrefixCount = 0;
   /**
+   * True when the message at index 0 is a context summary that was inherited
+   * from a parent fork (i.e. injected as part of the non-persisted prefix),
+   * rather than produced by this conversation's own compaction. The parent
+   * summary sits at index 0 but is excluded from `compactableMessages` by
+   * `summaryOffset`, so its slot in `nonPersistedPrefixCount` must be
+   * accounted for separately. Cleared after the first compaction replaces
+   * the parent summary with a child-owned one.
+   */
+  summaryIsInjected = false;
+  /**
    * Cached resolved system prompt. Lazily populated on first access via the
    * `systemPrompt` getter and cleared after each compaction pass so the next
    * pass picks up any prompt changes.
@@ -314,8 +324,15 @@ export class ContextWindowManager {
       };
     }
 
+    // When the summary at index 0 was injected from a parent fork, it
+    // contributes 1 to `nonPersistedPrefixCount` but is excluded from
+    // `compactableMessages` by `summaryOffset`; subtract it here so the
+    // remaining injected count lines up with compactableMessages. A summary
+    // produced by this conversation's own prior compaction is not part of
+    // `nonPersistedPrefixCount` (already decremented), so no subtraction.
+    const injectedSummaryOffset = this.summaryIsInjected ? summaryOffset : 0;
     const injectedInCompactable = Math.min(
-      Math.max(0, this.nonPersistedPrefixCount - summaryOffset),
+      Math.max(0, this.nonPersistedPrefixCount - injectedSummaryOffset),
       compactableMessages.length,
     );
     const compactedPersistedMessages =
@@ -465,11 +482,16 @@ export class ContextWindowManager {
         toolTokenBudget: this.toolTokenBudget,
       },
     );
-    // Consume the injected prefix messages that were compacted away.
+    // Consume the injected prefix messages that were compacted away. When the
+    // parent-injected summary was replaced by a freshly produced child summary,
+    // also consume its slot (it was excluded from injectedInCompactable via
+    // injectedSummaryOffset) and clear the flag so subsequent compactions treat
+    // the summary at index 0 as child-owned.
     this.nonPersistedPrefixCount = Math.max(
       0,
-      this.nonPersistedPrefixCount - injectedInCompactable,
+      this.nonPersistedPrefixCount - injectedInCompactable - injectedSummaryOffset,
     );
+    this.summaryIsInjected = false;
 
     log.info(
       {

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -28,6 +28,7 @@ import type { Speed } from "../config/schemas/inference.js";
 import {
   ContextWindowManager,
   type ContextWindowResult,
+  getSummaryFromContextMessage,
 } from "../context/window-manager.js";
 import type { CesClient } from "../credential-execution/client.js";
 import { EventBus } from "../events/bus.js";
@@ -652,6 +653,8 @@ export class Conversation {
     }
     this.messages = [...messages];
     this.contextWindowManager.nonPersistedPrefixCount = messages.length;
+    this.contextWindowManager.summaryIsInjected =
+      getSummaryFromContextMessage(messages[0]) != null;
   }
 
   /**


### PR DESCRIPTION
Addresses Devin feedback on #24353. Tracks whether a summary at index 0 was injected from the parent fork; gates the summaryOffset subtraction on that flag so child-owned compactions don't get double-decremented.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25063" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
