### PR TITLE
fix(daemon): reset taskRunId per-turn and reapply trust on conversation reuse

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -249,6 +249,8 @@ export interface AgentLoopConversationContext {
   currentTurnChannelCapabilities?: ChannelCapabilities;
   commandIntent?: { type: string; payload?: string; languageCode?: string };
   trustContext?: TrustContext;
+  /** Task-run scope for the current turn. Cleared at turn end so queued/drained turns don't inherit it. */
+  taskRunId?: string;
   assistantId?: string;
   voiceCallControlPrompt?: string;
   transportHints?: string[];
@@ -2053,6 +2055,10 @@ export async function runAgentLoopImpl(
     // Channel command intents (e.g. Telegram /start) are single-turn metadata.
     // Clear at turn end so they never leak into subsequent unrelated messages.
     ctx.commandIntent = undefined;
+    // taskRunId scopes ephemeral task-run permissions to a single turn. Clear
+    // before drainQueue so queued/drained turns on a reused conversation can't
+    // inherit stale in-task-run scope from the turn that just finished.
+    ctx.taskRunId = undefined;
 
     // Consolidation deferred to compaction: keeping assistant + tool_result
     // messages unconsolidated preserves the exact message structure sent to

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -998,6 +998,13 @@ export class DaemonServer {
       if (!conversation.isProcessing()) {
         this.applyTransportMetadata(conversation, options);
       }
+      // Reapply trust context to reused in-memory conversations so callers
+      // that pass a fresh trustContext (e.g. schedule run-now) don't silently
+      // inherit the prior turn's guardian scope. The new-conversation branch
+      // already applies this via storedOptions; mirror it for reuse.
+      if (options?.trustContext !== undefined) {
+        conversation.setTrustContext(options.trustContext);
+      }
       this.evictor.touch(conversationId);
     }
     return conversation;


### PR DESCRIPTION
Addresses Codex P1 + Devin feedback on #24343.

- Clear `conversation.taskRunId` in `runAgentLoop`'s cleanup (before `drainQueue` fires) so queued/drained turns on a reused conversation can't inherit stale in-task-run scope from the turn that just finished. Covers both queue-drain and `/v1/messages` paths that reuse in-memory conversations without re-entering `prepareConversationForMessage`.
- In `getOrCreateConversation`'s reuse branch, call `conversation.setTrustContext(options.trustContext)` when the caller passes one. Previously only the new-conversation branch applied trustContext from stored options, so reused conversations silently inherited the prior turn's guardian scope.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25065" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
