### PR TITLE
fix(backup): verifyEncryptedFile shouldn't need scratch disk

### DIFF
--- a/assistant/src/backup/__tests__/stream-crypt.test.ts
+++ b/assistant/src/backup/__tests__/stream-crypt.test.ts
@@ -188,4 +188,41 @@ describe("stream-crypt", () => {
 
     expect(await verifyEncryptedFile(encPath, key)).toBe(false);
   });
+
+  test("verifyEncryptedFile returns true for a valid bundle even when tmpdir is unwritable", async () => {
+    const key = randomBytes(32);
+    const plaintext = randomBytes(2048);
+    const plainPath = join(TEST_DIR, "plain.bin");
+    const encPath = join(TEST_DIR, "enc.bin");
+
+    writeFileSync(plainPath, plaintext);
+    await encryptFile(plainPath, encPath, key);
+
+    // Point tmpdir at a path that cannot be written to. The implementation
+    // must authenticate the bundle without writing any scratch file — a full
+    // or read-only /tmp must not block restore for healthy backups.
+    const originalTmpdir = process.env.TMPDIR;
+    const originalTmp = process.env.TMP;
+    const originalTemp = process.env.TEMP;
+    process.env.TMPDIR = "/dev/null/does-not-exist";
+    process.env.TMP = "/dev/null/does-not-exist";
+    process.env.TEMP = "/dev/null/does-not-exist";
+    try {
+      expect(await verifyEncryptedFile(encPath, key)).toBe(true);
+    } finally {
+      if (originalTmpdir === undefined) delete process.env.TMPDIR;
+      else process.env.TMPDIR = originalTmpdir;
+      if (originalTmp === undefined) delete process.env.TMP;
+      else process.env.TMP = originalTmp;
+      if (originalTemp === undefined) delete process.env.TEMP;
+      else process.env.TEMP = originalTemp;
+    }
+  });
+
+  test("verifyEncryptedFile rethrows filesystem errors (e.g. ENOENT) instead of masking them as tamper", async () => {
+    const key = randomBytes(32);
+    const missingPath = join(TEST_DIR, "does-not-exist.bin");
+
+    await expect(verifyEncryptedFile(missingPath, key)).rejects.toThrow();
+  });
 });

--- a/assistant/src/backup/stream-crypt.ts
+++ b/assistant/src/backup/stream-crypt.ts
@@ -24,9 +24,7 @@ import {
   createWriteStream,
 } from "node:fs";
 import { open, rename, stat, unlink } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { Readable } from "node:stream";
+import { Readable, Writable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 
 // ---------------------------------------------------------------------------
@@ -191,26 +189,75 @@ export async function decryptFile(
 // ---------------------------------------------------------------------------
 
 /**
- * Verify that `path` is a valid AES-256-GCM encrypted bundle for `key` by
- * running a full decrypt into a throwaway temp file. Returns `true` if the
- * decrypt succeeds (auth tag matches, IV readable, etc.), `false` otherwise.
+ * Verify that `path` is a valid AES-256-GCM encrypted bundle for `key`.
  *
- * Always cleans up the temp file, even on failure.
+ * Streams the ciphertext through the decipher into a null sink and relies on
+ * `decipher.final()` to either succeed (tag matches) or throw (tamper / wrong
+ * key). No scratch file is written, so a full or read-only tmpdir cannot
+ * cause a healthy backup to be reported as invalid.
+ *
+ * Returns `true` if the bundle authenticates, `false` on a cryptographic
+ * failure (bad auth tag, wrong key, truncated/short input). Filesystem errors
+ * on the *source* file (ENOENT, EACCES, EIO, …) are rethrown so callers can
+ * distinguish tamper from transient I/O.
  */
 export async function verifyEncryptedFile(
   path: string,
   key: Buffer,
 ): Promise<boolean> {
-  const scratch = join(
-    tmpdir(),
-    `vellum-backup-verify-${process.pid}-${randomBytes(6).toString("hex")}`,
-  );
-  try {
-    await decryptFile(path, scratch, key);
-    return true;
-  } catch {
+  assertKey(key);
+
+  const info = await stat(path);
+  const totalSize = info.size;
+  const minSize = ENCRYPTED_HEADER_SIZE + GCM_TAG_SIZE;
+  if (totalSize < minSize) {
+    // Too short to contain an IV + tag — not a valid bundle.
     return false;
-  } finally {
-    await safeUnlink(scratch);
   }
+
+  const iv = Buffer.alloc(ENCRYPTED_HEADER_SIZE);
+  const tag = Buffer.alloc(GCM_TAG_SIZE);
+  const fh = await open(path, "r");
+  try {
+    await fh.read(iv, 0, ENCRYPTED_HEADER_SIZE, 0);
+    await fh.read(tag, 0, GCM_TAG_SIZE, totalSize - GCM_TAG_SIZE);
+  } finally {
+    await fh.close();
+  }
+
+  const decipher = createDecipheriv(ALGORITHM, key, iv);
+  decipher.setAuthTag(tag);
+
+  const ciphertextStart = ENCRYPTED_HEADER_SIZE;
+  const ciphertextEnd = totalSize - GCM_TAG_SIZE - 1;
+  const hasCiphertext = ciphertextEnd >= ciphertextStart;
+  const ciphertextStream = hasCiphertext
+    ? createReadStream(path, { start: ciphertextStart, end: ciphertextEnd })
+    : Readable.from([]);
+
+  // Discard-only sink — verification never touches scratch disk.
+  const nullSink = new Writable({
+    write(_chunk, _encoding, cb) {
+      cb();
+    },
+  });
+
+  try {
+    await pipeline(ciphertextStream, decipher, nullSink);
+    return true;
+  } catch (err) {
+    if (isFilesystemError(err)) {
+      throw err;
+    }
+    return false;
+  }
+}
+
+// Node errno exceptions surface as uppercase `E`-prefixed codes (ENOENT,
+// EACCES, ENOSPC, EIO, EROFS, …). Crypto errors use `ERR_*` codes or no code
+// at all, so the regex rules them out.
+function isFilesystemError(err: unknown): boolean {
+  if (!err || typeof err !== "object") return false;
+  const code = (err as { code?: unknown }).code;
+  return typeof code === "string" && /^E[A-Z]+$/.test(code);
 }


### PR DESCRIPTION
Addresses Codex P1 feedback on #24883. verifyEncryptedFile wrote a full decryption to tmpdir and swallowed all errors as "invalid", so a full or read-only /tmp would block restore for healthy backups. Stream through a null sink and let decipher.final() report tamper.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25066" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
