### PR TITLE
fix(backup): close SQLite singleton before restoreFromSnapshot commits

### DIFF
--- a/assistant/src/backup/__tests__/restore.test.ts
+++ b/assistant/src/backup/__tests__/restore.test.ts
@@ -274,11 +274,19 @@ describe("restoreFromSnapshot", () => {
   test("plaintext round-trip: passes the validated bundle through to commitImpl", async () => {
     const { path, manifest } = writeTinyPlaintextBundle("plain.vbundle");
     const { commitImpl, calls } = makeStubCommitImpl();
+    let resetDbCalls = 0;
 
     const result = await restoreFromSnapshot(path, {
       pathResolver: NULL_RESOLVER,
       commitImpl,
+      resetDbImpl: () => {
+        resetDbCalls += 1;
+      },
     });
+
+    // resetDbImpl must run exactly once before the commit step, so the
+    // live SQLite singleton is closed before assistant.db is overwritten.
+    expect(resetDbCalls).toBe(1);
 
     expect(calls.length).toBe(1);
     const passed = calls[0].options;
@@ -411,6 +419,48 @@ describe("restoreFromSnapshot", () => {
 
     // commitImpl must NOT have been called when validation fails.
     expect(calls.length).toBe(0);
+  });
+
+  test("resetDbImpl runs before commitImpl and is skipped when validation fails", async () => {
+    // Happy path: resetDb must be called, and must be called BEFORE the
+    // commit step so the SQLite handle is released before assistant.db is
+    // overwritten on disk.
+    const { path } = writeTinyPlaintextBundle("plain.vbundle");
+    const order: string[] = [];
+    const { commitImpl } = makeStubCommitImpl();
+    const instrumentedCommit = (opts: ImportCommitOptions) => {
+      order.push("commit");
+      return commitImpl(opts);
+    };
+
+    await restoreFromSnapshot(path, {
+      pathResolver: NULL_RESOLVER,
+      commitImpl: instrumentedCommit,
+      resetDbImpl: () => {
+        order.push("reset");
+      },
+    });
+
+    expect(order).toEqual(["reset", "commit"]);
+
+    // Failure path: when validation fails, resetDb must NOT be invoked —
+    // there's no reason to close the DB singleton if we're not going to
+    // overwrite anything on disk.
+    const garbagePath = join(TEST_DIR, "garbage-for-reset.vbundle");
+    writeFileSync(garbagePath, Buffer.from("not a real bundle"));
+    let resetCallsOnInvalid = 0;
+
+    await expect(
+      restoreFromSnapshot(garbagePath, {
+        pathResolver: NULL_RESOLVER,
+        commitImpl,
+        resetDbImpl: () => {
+          resetCallsOnInvalid += 1;
+        },
+      }),
+    ).rejects.toThrow(/Snapshot failed validation/);
+
+    expect(resetCallsOnInvalid).toBe(0);
   });
 
   test("commit returning a write_failed result is surfaced as an error", async () => {

--- a/assistant/src/backup/restore.ts
+++ b/assistant/src/backup/restore.ts
@@ -20,16 +20,19 @@
  * function handles bundle validation, workspace clearing, per-file
  * backup-before-overwrite, and writing files to disk.
  *
- * IMPORTANT: `commitImport` does NOT reset the live SQLite handle, invalidate
- * cached config, or clear the trust cache. Callers are responsible for:
- *   1. Calling `resetDb()` BEFORE invoking `restoreFromSnapshot` so the
- *      running daemon's DB singleton is closed before the file is overwritten
- *      (otherwise the daemon keeps a handle to the old inode and subsequent
- *      writes can corrupt the restored state).
- *   2. Calling `invalidateConfigCache()` and `clearTrustCache()` AFTER a
+ * `restoreFromSnapshot` closes the live SQLite singleton via `resetDb()`
+ * immediately before the commit step so the daemon's DB handle is released
+ * before `assistant.db` is overwritten on disk. This mirrors the pattern in
+ * `handleMigrationImport` and ensures both the HTTP restore path and any
+ * in-process CLI caller get the reset for free. Tests can inject a fake via
+ * `opts.resetDbImpl`.
+ *
+ * `commitImport` does NOT invalidate cached config or clear the trust cache.
+ * Callers are responsible for:
+ *   1. Calling `invalidateConfigCache()` and `clearTrustCache()` AFTER a
  *      successful restore so the daemon re-reads the restored `config.json`
  *      and `trust.json` instead of serving stale in-process caches.
- *   3. Considering a daemon restart as the simplest, most reliable recovery
+ *   2. Considering a daemon restart as the simplest, most reliable recovery
  *      path — a CLI caller should refuse to restore against a live daemon
  *      unless explicitly forced.
  *
@@ -43,6 +46,7 @@ import { readFile, unlink } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import { resetDb } from "../memory/db-connection.js";
 import type { PathResolver } from "../runtime/migrations/vbundle-import-analyzer.js";
 import { commitImport } from "../runtime/migrations/vbundle-importer.js";
 import type { ManifestType } from "../runtime/migrations/vbundle-validator.js";
@@ -80,6 +84,13 @@ export interface RestoreOptions {
    * fake to avoid mutating disk; production callers should leave this unset.
    */
   commitImpl?: CommitImpl;
+  /**
+   * Optional override for the DB-reset hook. Invoked immediately before
+   * `commitImpl` so the live SQLite singleton is closed before
+   * `assistant.db` is overwritten. Tests inject a spy; production callers
+   * should leave this unset so the real `resetDb` is used.
+   */
+  resetDbImpl?: () => void;
 }
 
 export interface RestoreResult {
@@ -184,6 +195,7 @@ export async function restoreFromSnapshot(
     pathResolver,
     workspaceDir,
     commitImpl = commitImport,
+    resetDbImpl = resetDb,
   } = opts;
 
   let tmpPath: string | null = null;
@@ -202,6 +214,13 @@ export async function restoreFromSnapshot(
         .join("; ");
       throw new Error(`Snapshot failed validation: ${summary}`);
     }
+
+    // Close the live SQLite singleton before overwriting assistant.db on
+    // disk — otherwise the daemon keeps a handle to the old inode and
+    // subsequent writes can corrupt the restored state. Mirrors the
+    // pattern in `handleMigrationImport`. The singleton will be lazily
+    // reopened on the next getDb() call.
+    resetDbImpl();
 
     const commitResult = commitImpl({
       archiveData: fileData,

--- a/assistant/src/runtime/routes/backup-routes.ts
+++ b/assistant/src/runtime/routes/backup-routes.ts
@@ -44,7 +44,6 @@ import { restoreFromSnapshot, verifySnapshot } from "../../backup/restore.js";
 import { getConfig, invalidateConfigCache } from "../../config/loader.js";
 import type { BackupDestination } from "../../config/schema.js";
 import { getMemoryCheckpoint } from "../../memory/checkpoints.js";
-import { resetDb } from "../../memory/db-connection.js";
 import { clearCache as clearTrustCache } from "../../permissions/trust-store.js";
 import { getLogger } from "../../util/logger.js";
 import {
@@ -322,10 +321,11 @@ interface RestoreRequestBody {
  * should still treat this as an irreversible "replace the workspace" operation.
  *
  * Recovery sequence (mirroring `handleMigrationImport`):
- *   1. `resetDb()` is called BEFORE the restore so the live SQLite singleton
- *      closes its handle before `assistant.db` is overwritten. Without this,
- *      the daemon would keep a reference to the old inode and subsequent
- *      writes could silently corrupt the restored state.
+ *   1. `restoreFromSnapshot` internally calls `resetDb()` BEFORE the commit
+ *      step so the live SQLite singleton closes its handle before
+ *      `assistant.db` is overwritten. Without this, the daemon would keep a
+ *      reference to the old inode and subsequent writes could silently
+ *      corrupt the restored state.
  *   2. `invalidateConfigCache()` and `clearTrustCache()` are called AFTER a
  *      successful restore so the daemon re-reads the restored `config.json`
  *      and `trust.json` from disk instead of serving stale in-process caches.
@@ -359,9 +359,10 @@ export async function handleBackupRestore(req: Request): Promise<Response> {
       getWorkspaceHooksDir(),
     );
 
-    // Close the live SQLite connection before overwriting assistant.db on disk.
-    // The singleton will be lazily reopened on the next getDb() call.
-    resetDb();
+    // `restoreFromSnapshot` internally calls `resetDb()` before the commit
+    // step so the live SQLite connection is closed before assistant.db is
+    // overwritten. The singleton will be lazily reopened on the next getDb()
+    // call, after the restored file is in place.
 
     const result = await restoreFromSnapshot(snapshotPath, {
       key: keyResult.key ?? undefined,


### PR DESCRIPTION
Addresses Codex P1 feedback on #24886. restoreFromSnapshot committed the import directly without closing the active SQLite singleton, unlike handleMigrationImport. In a running daemon this risks locked DB artifacts or stale cached state. Mirror the migration pattern.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25067" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
