### PR TITLE
fix(backup): close ensureBackupKey race and stop treating all stat errors as missing

### DIFF
--- a/assistant/src/backup/__tests__/backup-key.test.ts
+++ b/assistant/src/backup/__tests__/backup-key.test.ts
@@ -7,13 +7,22 @@
 import {
   mkdirSync,
   mkdtempSync,
+  readdirSync,
   rmSync,
   statSync,
   writeFileSync,
 } from "node:fs";
+import * as fsPromises from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { basename, join } from "node:path";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  spyOn,
+  test,
+} from "bun:test";
 
 import { ensureBackupKey, readBackupKey } from "../backup-key.js";
 
@@ -75,10 +84,48 @@ describe("backup-key", () => {
       );
     });
 
-    test("does not leave a .tmp file behind after a successful write", async () => {
+    test("does not leave any .tmp file behind after a successful write", async () => {
       await ensureBackupKey(keyPath);
-      const tmpPath = `${keyPath}.tmp.${process.pid}`;
-      expect(() => statSync(tmpPath)).toThrow();
+      const parent = join(root, "backup");
+      const base = basename(keyPath);
+      const entries = readdirSync(parent);
+      const tmpEntries = entries.filter((e) => e.startsWith(`${base}.tmp.`));
+      expect(tmpEntries).toEqual([]);
+    });
+
+    test("two concurrent callers converge on the same persisted bytes", async () => {
+      // Race two ensureBackupKey calls. Exactly one caller's bytes win
+      // the rename; the other caller must re-read the file and return
+      // those same bytes rather than the key it generated locally.
+      const [a, b] = await Promise.all([
+        ensureBackupKey(keyPath),
+        ensureBackupKey(keyPath),
+      ]);
+      expect(Buffer.compare(a, b)).toBe(0);
+      const onDisk = statSync(keyPath);
+      expect(onDisk.size).toBe(32);
+    });
+
+    test("propagates non-ENOENT stat errors instead of treating them as missing", async () => {
+      // Simulate flaky storage (EIO / ESTALE). If pathExists swallowed
+      // these, the key file would appear "missing" and be silently
+      // regenerated, rotating away bytes used to encrypt existing data.
+      const statSpy = spyOn(fsPromises, "stat").mockImplementation(
+        async () => {
+          const err = new Error("simulated EIO") as NodeJS.ErrnoException;
+          err.code = "EIO";
+          throw err;
+        },
+      );
+      try {
+        await expect(ensureBackupKey(keyPath)).rejects.toThrow(
+          /simulated EIO/,
+        );
+        // And the key file must NOT have been created as a side effect.
+        expect(() => statSync(keyPath)).toThrow();
+      } finally {
+        statSpy.mockRestore();
+      }
     });
   });
 

--- a/assistant/src/backup/backup-key.ts
+++ b/assistant/src/backup/backup-key.ts
@@ -12,12 +12,21 @@
  *
  * On-disk invariants:
  * - Parent directory is created with mode `0o700`.
- * - Key file is written atomically (temp + rename) with mode `0o600`.
+ * - Key file is written atomically (temp + `link`) with mode `0o600`, so
+ *   concurrent callers converge on the first winner's bytes.
  * - Key file is exactly 32 bytes; any other size is treated as corruption.
  */
 
 import { randomBytes } from "node:crypto";
-import { chmod, mkdir, readFile, rename, stat, writeFile } from "node:fs/promises";
+import {
+  chmod,
+  link,
+  mkdir,
+  readFile,
+  stat,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
 import { dirname } from "node:path";
 
 /** Required length of the backup key file, in bytes. */
@@ -25,13 +34,20 @@ const BACKUP_KEY_LENGTH = 32;
 
 /**
  * Check whether a filesystem path exists without throwing.
+ *
+ * Only `ENOENT` is treated as "missing". Any other errno (EIO, ESTALE,
+ * EACCES, ...) is rethrown — we must not silently treat a transient I/O
+ * failure as "file is absent" because that can cause an existing backup
+ * key to be rotated away under the caller's feet, breaking decryption of
+ * data encrypted with the prior key.
  */
 async function pathExists(path: string): Promise<boolean> {
   try {
     await stat(path);
     return true;
-  } catch {
-    return false;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code === "ENOENT") return false;
+    throw err;
   }
 }
 
@@ -62,8 +78,21 @@ export async function readBackupKey(keyPath: string): Promise<Buffer | null> {
  * - If the file exists, it is read and validated. A wrong-size file throws,
  *   so a corrupt key is never silently replaced.
  * - Otherwise, the parent directory is created (mode `0o700`), a fresh
- *   32-byte random key is generated, written atomically (`.tmp` + rename),
- *   and returned.
+ *   32-byte random key is generated, written to a unique tmp file, and
+ *   atomically published to `keyPath` via `link()`.
+ *
+ * Concurrency: callers that race here must all converge on the same bytes
+ * — otherwise one caller encrypts data with bytes that will never be
+ * persisted and can never be decrypted.
+ *
+ * We use the canonical Unix atomic-create idiom: write full contents to
+ * a per-call tmp file, then `link(tmp, keyPath)`. `link` fails with
+ * `EEXIST` if `keyPath` already exists, which makes exactly one racing
+ * caller the winner; the rest read the winner's bytes. `rename(2)` by
+ * contrast overwrites the destination and is not race-safe here — two
+ * renames can leave either caller's bytes on disk regardless of who
+ * generated them, so a lost caller would return bytes that don't match
+ * what's persisted. `link` avoids that entirely.
  */
 export async function ensureBackupKey(keyPath: string): Promise<Buffer> {
   const existing = await readBackupKey(keyPath);
@@ -73,15 +102,36 @@ export async function ensureBackupKey(keyPath: string): Promise<Buffer> {
   await mkdir(parent, { recursive: true, mode: 0o700 });
 
   const key = randomBytes(BACKUP_KEY_LENGTH);
-  // Use pid suffix to prevent cross-process collisions while ensuring
-  // same-process retries overwrite a stale temp file rather than
-  // orphaning it on failure. Mirrors the pattern used in
-  // `security/encrypted-store.ts`.
-  const tmpPath = `${keyPath}.tmp.${process.pid}`;
-  await writeFile(tmpPath, key, { mode: 0o600 });
-  // Some platforms / umasks ignore the `mode` option on writeFile, so
-  // enforce 0o600 explicitly before the rename.
-  await chmod(tmpPath, 0o600);
-  await rename(tmpPath, keyPath);
-  return key;
+  const tmpPath = `${keyPath}.tmp.${process.pid}.${randomBytes(8).toString("hex")}`;
+  try {
+    // `wx` fails if tmpPath somehow exists (stale orphan or collision) so
+    // we never silently overwrite another writer's in-flight tmp file.
+    await writeFile(tmpPath, key, { flag: "wx", mode: 0o600 });
+    // Some platforms / umasks ignore the `mode` option on writeFile, so
+    // enforce 0o600 explicitly before publishing.
+    await chmod(tmpPath, 0o600);
+    try {
+      // Atomic publish: only one racing caller's link() succeeds.
+      await link(tmpPath, keyPath);
+      return key;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException)?.code !== "EEXIST") throw err;
+      // Another caller won the race. Return their bytes, not ours.
+      const winner = await readBackupKey(keyPath);
+      if (!winner) {
+        throw new Error(
+          `link() reported EEXIST but ${keyPath} is unreadable`,
+        );
+      }
+      return winner;
+    }
+  } finally {
+    // Remove our tmp file whether we won (tmp is a hard link to keyPath,
+    // safe to unlink), lost, or errored. Best-effort.
+    try {
+      await unlink(tmpPath);
+    } catch {
+      // ignore
+    }
+  }
 }


### PR DESCRIPTION
Addresses Codex P1 + P2 feedback on #24882. Check-then-write had no O_EXCL guard (concurrent callers could generate different keys); pathExists swallowed EIO/ESTALE and could silently rotate the key. Use atomic link() publish with wx tmp write, and ENOENT-only semantics in pathExists.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25068" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
