### PR TITLE
fix(macos): progress card shouldAutoExpand uses allComplete, not phase-match

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ProgressCardPresentationModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ProgressCardPresentationModel.swift
@@ -226,8 +226,14 @@ struct ProgressCardPresentationModel: Equatable {
         )
 
         // --- Auto-expand ---
-        let isCompleteOrDenied = phase == .complete || phase == .denied
-        let shouldAutoExpand = (isCompleteOrDenied && expandCompletedStepsFlag) || hasPendingConfirmation
+        // Matches the original AssistantProgressView logic: auto-expand fires when all
+        // tools are complete, or when incomplete tools were denied/timed out. Phase-based
+        // checks are narrower — .processing and .toolsCompleteThinking both imply
+        // allComplete=true but are excluded by a `phase == .complete` match, which
+        // silently dropped auto-expand for those states.
+        let isComplete = hasTools && resolvedAllComplete
+        let isDenied = hasDeniedToolCalls && hasTools && !resolvedAllComplete
+        let shouldAutoExpand = ((isComplete || isDenied) && expandCompletedStepsFlag) || hasPendingConfirmation
 
         return ProgressCardPresentationModel(
             allComplete: resolvedAllComplete,

--- a/clients/macos/vellum-assistantTests/ProgressCardPresentationModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ProgressCardPresentationModelTests.swift
@@ -556,6 +556,42 @@ struct ProgressCardPresentationModelTests {
         #expect(!model.shouldAutoExpand)
     }
 
+    @Test
+    func autoExpandWhenProcessingPhaseAndFlagEnabled() {
+        // allComplete=true + isProcessing=true resolves to .processing phase, but
+        // auto-expand should still fire because tools are all complete.
+        let tc = Self.makeToolCall(
+            index: 1, isComplete: true,
+            completedAt: Date(timeIntervalSince1970: 1001)
+        )
+        let model = ProgressCardPresentationModel.build(
+            toolCalls: [tc],
+            decidedConfirmations: [],
+            context: Self.streamingContext(isProcessing: true),
+            expandCompletedStepsFlag: true
+        )
+        #expect(model.phase == .processing)
+        #expect(model.shouldAutoExpand)
+    }
+
+    @Test
+    func autoExpandWhenToolsCompleteThinkingPhaseAndFlagEnabled() {
+        // allComplete=true + isStreaming=true + hasText=false resolves to
+        // .toolsCompleteThinking phase, but auto-expand should still fire.
+        let tc = Self.makeToolCall(
+            index: 1, isComplete: true,
+            completedAt: Date(timeIntervalSince1970: 1001)
+        )
+        let model = ProgressCardPresentationModel.build(
+            toolCalls: [tc],
+            decidedConfirmations: [],
+            context: Self.streamingContext(isStreaming: true, hasText: false),
+            expandCompletedStepsFlag: true
+        )
+        #expect(model.phase == .toolsCompleteThinking)
+        #expect(model.shouldAutoExpand)
+    }
+
     // MARK: - Equatable
 
     @Test


### PR DESCRIPTION
Addresses Devin feedback on #24381. Phase-based check was narrower than the original data-based allComplete condition, causing .processing and .toolsCompleteThinking to silently drop auto-expand. Restore the allComplete condition.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25069" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
