### PR TITLE
test(macos): remove redundant ThinkingBlockView smoke test

### DIFF
--- a/clients/macos/vellum-assistantTests/ThinkingBlockViewTests.swift
+++ b/clients/macos/vellum-assistantTests/ThinkingBlockViewTests.swift
@@ -36,23 +36,6 @@ final class ThinkingBlockViewTests: XCTestCase {
         window.contentViewController = nil
     }
 
-    /// Smoke test that `ThinkingBlockView` renders end-to-end against the
-    /// store-backed expansion without crashing, with the store injected via
-    /// the environment so the view reads the toggled state.
-    func testThinkingBlockBodyEvaluatesWithStoreInjection() {
-        let store = ThinkingBlockExpansionStore()
-        store.toggle("test-key")
-
-        let view = ThinkingBlockView(
-            content: "thinking content",
-            isStreaming: false,
-            expansionKey: "test-key"
-        )
-        .environment(\.thinkingBlockExpansionStore, store)
-
-        hostAndDriveLifecycle(view)
-    }
-
     /// Regression test for expanded thinking blocks going blank at the end of
     /// an active turn. When `MessageListContentView` tears down and rebuilds
     /// the wrapped subtree as `isActiveTurn` flips true → false, a freshly


### PR DESCRIPTION
Addresses Devin feedback on #24734. The smoke test `testThinkingBlockBodyEvaluatesWithStoreInjection` is now fully subsumed by `testThinkingBlockExpandedOnAppearSeedsSegmentCache` (added in #25056), which hosts the view, injects a toggled store into the environment, and additionally asserts `.onAppear` segment-cache seeding. Devin flagged that the smoke test toggled a store but never injected it — #25056 fixed that injection but the smoke variant now provides no coverage beyond the regression test. Deleting rather than renaming.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25070" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
