### PR TITLE
test(backup): save/restore VELLUM_BACKUP_KEY_PATH env var in paths tests

### DIFF
--- a/assistant/src/backup/__tests__/paths.test.ts
+++ b/assistant/src/backup/__tests__/paths.test.ts
@@ -118,8 +118,14 @@ describe("resolveOffsiteDestinations", () => {
 });
 
 describe("getBackupKeyPath", () => {
+  const ORIGINAL_KEY_PATH = process.env.VELLUM_BACKUP_KEY_PATH;
+
   afterEach(() => {
-    delete process.env.VELLUM_BACKUP_KEY_PATH;
+    if (ORIGINAL_KEY_PATH === undefined) {
+      delete process.env.VELLUM_BACKUP_KEY_PATH;
+    } else {
+      process.env.VELLUM_BACKUP_KEY_PATH = ORIGINAL_KEY_PATH;
+    }
   });
 
   test("ends with /protected/backup.key when env var is unset", () => {


### PR DESCRIPTION
Addresses Devin feedback on #24913. Test's afterEach unconditionally deleted VELLUM_BACKUP_KEY_PATH; if the test runner has it set, that would silently destroy it. Mirror the VELLUM_BACKUP_DIR save/restore pattern used elsewhere in the same file.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25071" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
