### PR TITLE
chore(permissions): rewrite removal-history comments per AGENTS.md

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -1552,10 +1552,9 @@ describe("Permission Checker", () => {
     });
 
     // ── guardian persona file (users/<slug>.md) ──────────────────
-    // The drop-user-md migration replaces the legacy workspace USER.md
-    // with a per-user persona file at `users/<guardian-slug>.md`. The
-    // dynamic guardian-persona default rules are now the sole auto-allow
-    // entry for the per-user profile file.
+    // The per-user persona file lives at `users/<guardian-slug>.md`.
+    // Dynamic guardian-persona default rules auto-allow reads and
+    // edits of this file.
 
     test("file_edit of guardian users/<slug>.md is auto-allowed", async () => {
       const guardianPath = join(checkerTestDir, "users", "alice.md");

--- a/assistant/src/permissions/defaults.ts
+++ b/assistant/src/permissions/defaults.ts
@@ -152,8 +152,7 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
   // Guardian persona file — the contact-store-resolved `users/<slug>.md`
   // for the current guardian. Once the workspace has a guardian contact,
   // their per-user persona file should be readable/editable without a
-  // prompt. This is the sole auto-allow entry for the per-user profile
-  // file (the legacy workspace `USER.md` was removed).
+  // prompt.
   //
   // Resolved dynamically at template-build time (rather than hardcoded
   // like WORKSPACE_PROMPT_FILES) because the slug depends on the


### PR DESCRIPTION
Addresses Devin feedback on #24868. Two comments narrated USER.md removal, which AGENTS.md explicitly forbids. Rewritten in present tense, describing current invariants only.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25072" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
