### PR TITLE
fix(macos): composer dismiss clears text + click selection closes popup

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerController.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerController.swift
@@ -272,6 +272,20 @@ final class ComposerController {
         }
     }
 
+    /// Closes the slash menu without requiring a specific keyboard action.
+    /// Used by click-based selection paths that bypass `handleSlashNavigation`.
+    func closeSlashMenu() {
+        showSlashMenu = false
+        slashSelectedIndex = 0
+    }
+
+    /// Closes the emoji menu without requiring a specific keyboard action.
+    /// Used by click-based selection paths that bypass `handleEmojiNavigation`.
+    func closeEmojiMenu() {
+        showEmojiMenu = false
+        emojiSelectedIndex = 0
+    }
+
     // MARK: - Emoji navigation
 
     /// Handles keyboard navigation within the emoji menu.

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerEmojiPicker.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerEmojiPicker.swift
@@ -16,6 +16,8 @@ extension ComposerView {
         let nsRange = NSRange(location: colonOffset, length: length)
 
         textReplacer.replaceText?(nsRange, entry.emoji)
+
+        composerController.closeEmojiMenu()
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerSlashCommands.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerSlashCommands.swift
@@ -67,6 +67,7 @@ extension ComposerView {
     }
 
     func selectSlashCommand(_ command: SlashCommand) {
+        composerController.closeSlashMenu()
         inputText = command.selectedInputText
         if command.shouldAutoSendOnSelect {
             onSend()

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -305,7 +305,11 @@ struct ComposerView: View, Equatable {
                     return false
                 },
                 onEscape: {
-                    if composerController.showSlashMenu { composerController.handleSlashNavigation(.dismiss); return true }
+                    if composerController.showSlashMenu {
+                        composerController.handleSlashNavigation(.dismiss)
+                        inputText = ""
+                        return true
+                    }
                     if composerController.showEmojiMenu { composerController.handleEmojiNavigation(.dismiss); return true }
                     return false
                 },

--- a/clients/macos/vellum-assistantTests/ComposerControllerTests.swift
+++ b/clients/macos/vellum-assistantTests/ComposerControllerTests.swift
@@ -648,6 +648,54 @@ final class ComposerControllerTests: XCTestCase {
         XCTAssertFalse(controller.showEmojiMenu)
     }
 
+    // MARK: - Explicit menu close (click selection path)
+
+    @MainActor
+    func testCloseSlashMenuClosesAndResetsIndex() {
+        let controller = makeController()
+        controller.textChanged("/")
+        controller.performMenuRefresh()
+        controller.handleSlashNavigation(.down)
+        XCTAssertTrue(controller.showSlashMenu)
+        XCTAssertEqual(controller.slashSelectedIndex, 1)
+
+        controller.closeSlashMenu()
+
+        XCTAssertFalse(controller.showSlashMenu, "closeSlashMenu should hide the slash popup")
+        XCTAssertEqual(controller.slashSelectedIndex, 0, "closeSlashMenu should reset selection")
+    }
+
+    @MainActor
+    func testCloseEmojiMenuClosesAndResetsIndex() {
+        let controller = makeController()
+        let text = ":thumbs"
+        controller.textChanged(text)
+        controller.cursorMoved(to: text.utf16.count)
+        controller.performMenuRefresh()
+        controller.handleEmojiNavigation(.down)
+        XCTAssertTrue(controller.showEmojiMenu)
+        XCTAssertEqual(controller.emojiSelectedIndex, 1)
+
+        controller.closeEmojiMenu()
+
+        XCTAssertFalse(controller.showEmojiMenu, "closeEmojiMenu should hide the emoji popup")
+        XCTAssertEqual(controller.emojiSelectedIndex, 0, "closeEmojiMenu should reset selection")
+    }
+
+    @MainActor
+    func testCloseEmojiMenuDoesNotSuppressReopen() {
+        let controller = makeController()
+        let text = ":thumbs"
+        controller.textChanged(text)
+        controller.cursorMoved(to: text.utf16.count)
+        controller.performMenuRefresh()
+
+        controller.closeEmojiMenu()
+
+        XCTAssertFalse(controller.suppressEmojiReopen,
+                       "Click-driven close should not suppress reopen — user may immediately retrigger")
+    }
+
     // MARK: - Menu refresh supersession
 
     @MainActor


### PR DESCRIPTION
Addresses Devin feedback on #24397. Escape on popup didn't clear /co input; click-based selectEmoji/selectSlashCommand bypassed the close logic in navigation methods. Clear inputText on dismiss and route click through the close path.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25073" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
