### PR TITLE
fix(macos): ScrollCoordinator locking tests now exercise the stabilizing path

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ScrollCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ScrollCoordinator.swift
@@ -383,13 +383,21 @@ final class ScrollCoordinator {
     private func handleContainerWidthChanged() -> [OutputIntent] {
         var intents: [OutputIntent] = []
 
-        if mode.allowsAutoScroll {
+        switch mode {
+        case .initialLoad, .followingBottom:
             // Re-pin to bottom after resize with a recovery window.
             intents.append(.startRecoveryWindow)
             intents.append(.scrollToBottom(animated: false))
-        } else if case .freeBrowsing = mode {
+        case .freeBrowsing:
             // Stabilize during resize to maintain reading position.
             beginStabilization(.resize)
+        case .stabilizing:
+            // Already stabilizing — restart the resize window so overlapping
+            // resize events don't get dropped. Mirrors MessageListView+Lifecycle
+            // which unconditionally calls beginStabilization(.resize).
+            beginStabilization(.resize)
+        case .programmaticScroll:
+            break
         }
 
         return intents

--- a/clients/macos/vellum-assistantTests/ScrollCoordinatorTests.swift
+++ b/clients/macos/vellum-assistantTests/ScrollCoordinatorTests.swift
@@ -433,24 +433,39 @@ final class ScrollCoordinatorTests: XCTestCase {
                        "Should exit stabilization after all windows complete")
     }
 
-    func testStabilizationPreservesFollowingBottom() {
-        // Use sendingChanged to enter followingBottom, then manual expansion
-        // to trigger stabilization. Resize in followingBottom mode does NOT
-        // stabilize — it re-pins directly to bottom.
+    func testExpansionFromFollowingBottomDetachesBeforeStabilizing() {
+        // Manual expansion detaches to freeBrowsing before stabilizing — so
+        // the pre-stabilization mode captured is freeBrowsing, not followingBottom.
         coordinator.handle(.sendingChanged(isSending: true))
         XCTAssertTrue(coordinator.isFollowingBottom)
 
-        // Manual expansion detaches to freeBrowsing and then stabilizes.
         coordinator.handle(.manualExpansion)
         XCTAssertTrue(coordinator.isSuppressed)
-        // After expansion, the pre-stabilization mode is freeBrowsing
-        // (expansion detaches first), not followingBottom.
         XCTAssertFalse(coordinator.isFollowingBottom,
                        "Manual expansion detaches from following-bottom before stabilizing")
 
         coordinator.endStabilization()
         XCTAssertEqual(coordinator.mode, .freeBrowsing,
                        "Should restore freeBrowsing after expansion stabilization")
+    }
+
+    func testContainerWidthChangedInStabilizingRestartsWindow() {
+        // Enter stabilizing via free-browsing + resize.
+        coordinator.handle(.manualBrowseIntent)
+        coordinator.handle(.containerWidthChanged)
+        XCTAssertTrue(coordinator.isSuppressed)
+
+        // A second resize while already stabilizing should add another window
+        // rather than silently dropping the event.
+        coordinator.handle(.containerWidthChanged)
+        XCTAssertTrue(coordinator.isSuppressed)
+
+        coordinator.endStabilization()
+        XCTAssertTrue(coordinator.isSuppressed,
+                      "Overlapping resize should keep stabilization active")
+
+        coordinator.endStabilization()
+        XCTAssertFalse(coordinator.isSuppressed)
     }
 
     func testResizeInFollowingBottomRepinsDirectly() {


### PR DESCRIPTION
Addresses Devin feedback on #24389. Three stabilization-locking tests never entered the stabilizing mode — handleContainerWidthChanged re-pinned from followingBottom. Drive tests via manualBrowseIntent first, and re-enter stabilization in handleContainerWidthChanged for .stabilizing mode to match MessageListView+Lifecycle.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25074" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
