### PR TITLE
fix(personas): read guardian name/pronouns strictly from guardian file, no default.md fallback

### DIFF
--- a/assistant/src/__tests__/persona-resolver.test.ts
+++ b/assistant/src/__tests__/persona-resolver.test.ts
@@ -63,7 +63,9 @@ mock.module("../contacts/contact-store.js", () => ({
 import {
   ensureGuardianPersonaFile,
   isGuardianPersonaCustomized,
+  resolveGuardianPersona,
   resolveGuardianPersonaPath,
+  resolveGuardianPersonaStrict,
 } from "../prompts/persona-resolver.js";
 
 // ── Temp workspace scaffold ───────────────────────────────────────
@@ -145,6 +147,56 @@ describe("ensureGuardianPersonaFile", () => {
 
     const content = readFileSync(filePath, "utf-8");
     expect(content).toBe(existingContent);
+  });
+});
+
+// ── resolveGuardianPersonaStrict ───────────────────────────────────
+
+describe("resolveGuardianPersonaStrict", () => {
+  test("returns null when no guardian contact exists", () => {
+    mockVellumGuardian = null;
+    mockAnyGuardian = null;
+
+    expect(resolveGuardianPersonaStrict()).toBeNull();
+  });
+
+  test("returns null when the guardian's own file is missing, even if default.md exists", () => {
+    mockVellumGuardian = {
+      contact: { userFile: "sidd.md" },
+      channel: {},
+    };
+
+    // default.md is populated but sidd.md is not on disk.
+    const usersDir = join(mockWorkspaceDir, "users");
+    mkdirSync(usersDir, { recursive: true });
+    writeFileSync(
+      join(usersDir, "default.md"),
+      "- Preferred name/reference: DefaultName\n",
+      "utf-8",
+    );
+
+    // Strict variant must not leak default.md content.
+    expect(resolveGuardianPersonaStrict()).toBeNull();
+    // Sanity: the non-strict variant DOES fall back to default.md, which
+    // is the documented divergence these tests pin down.
+    expect(resolveGuardianPersona()).toContain("DefaultName");
+  });
+
+  test("returns guardian file content when present", () => {
+    mockVellumGuardian = {
+      contact: { userFile: "sidd.md" },
+      channel: {},
+    };
+
+    const usersDir = join(mockWorkspaceDir, "users");
+    mkdirSync(usersDir, { recursive: true });
+    writeFileSync(
+      join(usersDir, "sidd.md"),
+      "- Preferred name/reference: Sidd\n",
+      "utf-8",
+    );
+
+    expect(resolveGuardianPersonaStrict()).toContain("Sidd");
   });
 });
 

--- a/assistant/src/__tests__/user-reference.test.ts
+++ b/assistant/src/__tests__/user-reference.test.ts
@@ -1,20 +1,22 @@
 /**
  * Tests for user-reference resolvers. After the drop-user-md migration,
  * `readPreferredNameFromUserMd` and `resolveUserPronouns` source their
- * content from `resolveGuardianPersona()` instead of the legacy
- * workspace-root `USER.md`. We mock the persona-resolver module directly
- * so tests can drive the input content without touching disk.
+ * content from the guardian's per-user persona file via
+ * `resolveGuardianPersonaStrict()` (no `default.md` fallback). We mock
+ * the persona-resolver module directly so tests can drive the input
+ * content without touching disk.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 // Mutable state the tests control — represents the value returned by
-// `resolveGuardianPersona()` (comment-stripped string, or null when no
-// guardian / empty file).
+// `resolveGuardianPersonaStrict()` (comment-stripped string, or null
+// when no guardian / empty / missing guardian-specific file).
 let mockGuardianPersona: string | null = null;
 
 mock.module("../prompts/persona-resolver.js", () => ({
   resolveGuardianPersona: () => mockGuardianPersona,
+  resolveGuardianPersonaStrict: () => mockGuardianPersona,
 }));
 
 // Import after mocks are in place so the module under test binds to

--- a/assistant/src/prompts/persona-resolver.ts
+++ b/assistant/src/prompts/persona-resolver.ts
@@ -237,6 +237,27 @@ export function resolveGuardianPersona(): string | null {
 }
 
 /**
+ * Resolve the guardian's user persona strictly from their own
+ * `users/<slug>.md` file, with NO fallback to `users/default.md`.
+ *
+ * Returns `null` when no guardian contact is resolvable, the
+ * guardian's userFile is unset, or the file is missing / empty.
+ *
+ * Used by callers that derive guardian-specific attributes (name,
+ * pronouns) where `default.md` content would incorrectly override an
+ * intentional caller-supplied fallback such as `Contact.displayName`.
+ * System-prompt callers that want the default.md fallback should
+ * continue to use `resolveGuardianPersona`.
+ */
+export function resolveGuardianPersonaStrict(): string | null {
+  const filename = resolveUserFilename(undefined);
+  if (!filename) return null;
+  const filePath = join(getWorkspaceDir(), "users", filename);
+  if (!existsSync(filePath)) return null;
+  return readPersonaFile(filePath);
+}
+
+/**
  * Write the guardian persona template scaffold to `users/<userFile>`
  * when the file does not yet exist. No-op when the file already
  * exists (safe against clobbering user edits).

--- a/assistant/src/prompts/user-reference.ts
+++ b/assistant/src/prompts/user-reference.ts
@@ -1,4 +1,4 @@
-import { resolveGuardianPersona } from "./persona-resolver.js";
+import { resolveGuardianPersonaStrict } from "./persona-resolver.js";
 
 export const DEFAULT_USER_REFERENCE = "my human";
 export const DECLINED_BY_USER_SENTINEL = "declined_by_user";
@@ -12,7 +12,7 @@ export const DECLINED_BY_USER_SENTINEL = "declined_by_user";
  * itself is blank.
  */
 function readPreferredNameFromUserMd(): string | null {
-  const content = resolveGuardianPersona();
+  const content = resolveGuardianPersonaStrict();
   if (content != null) {
     const match = content.match(/Preferred name\/reference:[ \t]*(.*)/);
     if (match && match[1].trim()) {
@@ -49,7 +49,7 @@ export function resolveUserReference(): string {
  * in the file.
  */
 export function resolveUserPronouns(): string | null {
-  const content = resolveGuardianPersona();
+  const content = resolveGuardianPersonaStrict();
   if (content == null) return null;
 
   const snapshotIdx = content.indexOf("## Onboarding Snapshot");


### PR DESCRIPTION
Addresses Codex feedback on #24843. resolveGuardianPersona falls back to users/default.md when the guardian's file is missing, which leaked default.md's content into resolveGuardianName/Pronouns — overriding the intended Contact.displayName fallback. Add a strict variant for those call sites.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25075" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
