### PR TITLE
fix(macos): convert UUID to String for tool call cache key

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -664,7 +664,7 @@ private struct StepDetailRow: View {
     private var cachedColoredResult: AttributedString? {
         guard let result = toolCall.result, !result.isEmpty else { return nil }
         let key = Self.coloredOutputCacheKey(
-            toolCallID: toolCall.id,
+            toolCallID: toolCall.id.uuidString,
             resultCount: result.utf8.count,
             isError: toolCall.isError
         )


### PR DESCRIPTION
## Summary
- Fixes Swift compile error `cannot convert value of type 'UUID' to expected argument type 'String'` in `AssistantProgressView.swift:667` that broke both the `macOS Build` and `macOS Tests` jobs on `main`.
- Convert `toolCall.id` to `.uuidString` when building the `StepDetailRow` colored-output cache key. The helper signature added in #25048 takes `toolCallID: String`, but `ToolCallData.id` is a `UUID`.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24318539241