### PR TITLE
fix(macos): call scrollCoordinator.endStabilization() alongside scrollState

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
@@ -255,7 +255,7 @@ extension MessageListView {
         let intents = scrollCoordinator.handle(.containerWidthChanged)
         executeCoordinatorIntents(intents)
         resizeScrollTask?.cancel()
-        resizeScrollTask = Task { @MainActor [scrollState] in
+        resizeScrollTask = Task { @MainActor [scrollState, scrollCoordinator] in
             scrollState.beginStabilization(.resize)
             defer {
                 if !Task.isCancelled { resizeScrollTask = nil }
@@ -263,9 +263,11 @@ extension MessageListView {
             try? await Task.sleep(nanoseconds: 100_000_000)
             guard !Task.isCancelled else {
                 scrollState.endStabilization()
+                scrollCoordinator.endStabilization()
                 return
             }
                 scrollState.endStabilization()
+                scrollCoordinator.endStabilization()
                 if scrollState.mode.allowsAutoScroll && anchorMessageId == nil {
                     // Use mode.allowsAutoScroll (covers both .initialLoad and
                     // .followingBottom) instead of isFollowingBottom (which

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -168,6 +168,13 @@ struct MessageListView: View {
                 executeCoordinatorIntents(intents)
                 // Keep scrollState in sync as runtime executor.
                 scrollState.handleManualExpansionInteraction()
+                // Mirror scrollState's internal 200ms expansion timeout on the
+                // coordinator. Without this, the coordinator would stick in
+                // .stabilizing until another event forced a mode transition.
+                Task { @MainActor [scrollCoordinator] in
+                    try? await Task.sleep(nanoseconds: 200_000_000)
+                    scrollCoordinator.endStabilization()
+                }
             })
             .onScrollPhaseChange { oldPhase, newPhase in
                 let coordinatorPhase = ScrollCoordinator.Phase.from(newPhase)

--- a/clients/macos/vellum-assistantTests/MessageListScrollStateTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListScrollStateTests.swift
@@ -650,6 +650,36 @@ final class MessageListScrollStateTests: XCTestCase {
                      "Pending anchor should be cleared after resolution")
     }
 
+    /// Verifies that the container-width resize path keeps both state
+    /// machines in lockstep: both exit stabilization together once the
+    /// view-layer resize task calls `endStabilization()` on each.
+    func testCoordinatorAndScrollStateExitStabilizationTogetherOnResize() {
+        let coordinator = ScrollCoordinator()
+
+        // Enter free-browsing on both (what a user scrolled-up during
+        // streaming looks like).
+        _ = coordinator.handle(.manualBrowseIntent)
+        state.transition(to: .freeBrowsing)
+
+        // Width change: coordinator enters .stabilizing(.resize).
+        _ = coordinator.handle(.containerWidthChanged)
+        XCTAssertTrue(coordinator.isSuppressed,
+                      "Coordinator should enter stabilization on width change in free-browsing")
+
+        // View layer independently begins stabilization on scrollState.
+        state.beginStabilization(.resize)
+        XCTAssertTrue(state.isSuppressed)
+
+        // End both (what the view's resize task does after the 100ms sleep).
+        state.endStabilization()
+        coordinator.endStabilization()
+
+        XCTAssertFalse(coordinator.isSuppressed,
+                       "Coordinator must exit stabilization when the view-layer ends it")
+        XCTAssertFalse(state.isSuppressed)
+        XCTAssertEqual(coordinator.mode, .freeBrowsing)
+    }
+
     /// Verifies that the coordinator and scrollState both reset on
     /// conversation switch.
     func testCoordinatorResetOnConversationSwitch() {


### PR DESCRIPTION
Addresses Devin feedback on #24407. scrollState.endStabilization() was called at stabilization-end but scrollCoordinator.endStabilization() was missing — production never called it, so the coordinator got stuck in .stabilizing. Pair the calls so both state machines stay in lockstep.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25077" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
