### PR TITLE
fix(backup): include milliseconds in snapshot filename

### DIFF
--- a/assistant/src/backup/__tests__/backup-worker.test.ts
+++ b/assistant/src/backup/__tests__/backup-worker.test.ts
@@ -226,7 +226,7 @@ describe("runBackupTick — gating", () => {
     expect(streamStub.calls).toHaveLength(1);
     expect(checkpoints.store["backup:last_run_at"]).toBe(String(now.getTime()));
     // Local snapshot file was created
-    expect(result!.local.path).toContain("backup-20260411-100000.vbundle");
+    expect(result!.local.path).toContain("backup-20260411-100000-000.vbundle");
     expect(existsSync(result!.local.path)).toBe(true);
     expect(result!.offsite).toEqual([]);
   });
@@ -317,7 +317,7 @@ describe("runBackupTick — offsite destinations", () => {
     expect(result!.offsite).toHaveLength(1);
     expect(result!.offsite[0].entry).not.toBeNull();
     expect(result!.offsite[0].entry!.filename).toBe(
-      "backup-20260411-120000.vbundle",
+      "backup-20260411-120000-000.vbundle",
     );
     expect(result!.offsite[0].entry!.encrypted).toBe(false);
     expect(existsSync(result!.offsite[0].entry!.path)).toBe(true);
@@ -357,7 +357,7 @@ describe("runBackupTick — offsite destinations", () => {
     expect(result!.offsite).toHaveLength(1);
     expect(result!.offsite[0].entry).not.toBeNull();
     expect(result!.offsite[0].entry!.filename).toBe(
-      "backup-20260411-130000.vbundle.enc",
+      "backup-20260411-130000-000.vbundle.enc",
     );
     expect(result!.offsite[0].entry!.encrypted).toBe(true);
     expect(existsSync(result!.offsite[0].entry!.path)).toBe(true);
@@ -751,8 +751,8 @@ describe("retention across successive ticks", () => {
       .sort();
     expect(localFiles).toHaveLength(2);
     expect(localFiles).toEqual([
-      "backup-20260411-120000.vbundle",
-      "backup-20260411-140000.vbundle",
+      "backup-20260411-120000-000.vbundle",
+      "backup-20260411-140000-000.vbundle",
     ]);
 
     const offsiteFiles = readdirSync(offsiteDir)
@@ -760,8 +760,8 @@ describe("retention across successive ticks", () => {
       .sort();
     expect(offsiteFiles).toHaveLength(2);
     expect(offsiteFiles).toEqual([
-      "backup-20260411-120000.vbundle",
-      "backup-20260411-140000.vbundle",
+      "backup-20260411-120000-000.vbundle",
+      "backup-20260411-140000-000.vbundle",
     ]);
   });
 });

--- a/assistant/src/backup/__tests__/local-writer.test.ts
+++ b/assistant/src/backup/__tests__/local-writer.test.ts
@@ -43,8 +43,10 @@ describe("writeLocalSnapshot", () => {
 
     const entry = await writeLocalSnapshot(tempPath, localDir, now);
 
-    expect(entry.filename).toBe("backup-20260411-153045.vbundle");
-    expect(entry.path).toBe(join(localDir, "backup-20260411-153045.vbundle"));
+    expect(entry.filename).toBe("backup-20260411-153045-000.vbundle");
+    expect(entry.path).toBe(
+      join(localDir, "backup-20260411-153045-000.vbundle"),
+    );
     expect(entry.encrypted).toBe(false);
     expect(entry.createdAt).toBe(now);
     expect(entry.sizeBytes).toBe(Buffer.byteLength(payload));
@@ -56,6 +58,52 @@ describe("writeLocalSnapshot", () => {
     expect(existsSync(tempPath)).toBe(false);
   });
 
+  test("two backups started in the same UTC second produce distinct filenames", async () => {
+    const tempA = join(root, "stage-a.tmp");
+    const tempB = join(root, "stage-b.tmp");
+    writeFileSync(tempA, "payload-a");
+    writeFileSync(tempB, "payload-b");
+
+    const localDir = join(root, "same-second");
+    // Same second, different milliseconds — should produce distinct names.
+    const nowA = new Date("2026-04-11T15:30:45.100Z");
+    const nowB = new Date("2026-04-11T15:30:45.900Z");
+
+    const entryA = await writeLocalSnapshot(tempA, localDir, nowA);
+    const entryB = await writeLocalSnapshot(tempB, localDir, nowB);
+
+    expect(entryA.filename).not.toBe(entryB.filename);
+    expect(existsSync(entryA.path)).toBe(true);
+    expect(existsSync(entryB.path)).toBe(true);
+    // Neither file was overwritten: the bytes match what was staged.
+    expect(readFileSync(entryA.path, "utf8")).toBe("payload-a");
+    expect(readFileSync(entryB.path, "utf8")).toBe("payload-b");
+  });
+
+  test("same-millisecond collision falls back to a random-suffixed filename", async () => {
+    const tempA = join(root, "stage-a.tmp");
+    const tempB = join(root, "stage-b.tmp");
+    writeFileSync(tempA, "payload-a");
+    writeFileSync(tempB, "payload-b");
+
+    const localDir = join(root, "identical-ms");
+    // Identical timestamp down to the millisecond — the stat probe should
+    // detect the existing destination and pick a different suffix for the
+    // second write instead of silently overwriting.
+    const now = new Date("2026-04-11T15:30:45.123Z");
+
+    const entryA = await writeLocalSnapshot(tempA, localDir, now);
+    const entryB = await writeLocalSnapshot(tempB, localDir, now);
+
+    expect(entryA.filename).toBe("backup-20260411-153045-123.vbundle");
+    expect(entryB.filename).not.toBe(entryA.filename);
+    expect(entryB.filename).toMatch(
+      /^backup-20260411-153045-123-[0-9a-f]{6}\.vbundle$/,
+    );
+    expect(readFileSync(entryA.path, "utf8")).toBe("payload-a");
+    expect(readFileSync(entryB.path, "utf8")).toBe("payload-b");
+  });
+
   test("returned SnapshotEntry has the correct filename, size, and timestamp", async () => {
     const tempPath = join(root, "stage.tmp");
     const payload = Buffer.alloc(1234, 0xab);
@@ -65,7 +113,7 @@ describe("writeLocalSnapshot", () => {
     const now = new Date("2026-01-02T03:04:05Z");
     const entry = await writeLocalSnapshot(tempPath, localDir, now);
 
-    expect(entry.filename).toBe("backup-20260102-030405.vbundle");
+    expect(entry.filename).toBe("backup-20260102-030405-000.vbundle");
     expect(entry.sizeBytes).toBe(1234);
     expect(entry.createdAt.toISOString()).toBe("2026-01-02T03:04:05.000Z");
     // listSnapshotsInDir should round-trip the same entry.

--- a/assistant/src/backup/__tests__/offsite-writer.test.ts
+++ b/assistant/src/backup/__tests__/offsite-writer.test.ts
@@ -108,11 +108,11 @@ describe("writeOffsiteSnapshotToOne", () => {
     expect(result.error).toBeUndefined();
     expect(result.skipped).toBeUndefined();
     expect(result.entry).not.toBeNull();
-    expect(result.entry!.filename).toBe("backup-20260411-153045.vbundle.enc");
+    expect(result.entry!.filename).toBe("backup-20260411-153045-000.vbundle.enc");
     expect(result.entry!.encrypted).toBe(true);
     expect(result.entry!.createdAt).toBe(NOW);
     expect(result.entry!.path).toBe(
-      join(destination.path, "backup-20260411-153045.vbundle.enc"),
+      join(destination.path, "backup-20260411-153045-000.vbundle.enc"),
     );
     expect(existsSync(result.entry!.path)).toBe(true);
 
@@ -145,7 +145,7 @@ describe("writeOffsiteSnapshotToOne", () => {
     expect(result.error).toBeUndefined();
     expect(result.skipped).toBeUndefined();
     expect(result.entry).not.toBeNull();
-    expect(result.entry!.filename).toBe("backup-20260411-153045.vbundle");
+    expect(result.entry!.filename).toBe("backup-20260411-153045-000.vbundle");
     expect(result.entry!.encrypted).toBe(false);
     expect(result.entry!.sizeBytes).toBe(plaintext.length);
 
@@ -226,7 +226,7 @@ describe("writeOffsiteSnapshotToAll", () => {
     // Encrypted destination
     expect(results[0].destination).toEqual(destinations[0]);
     expect(results[0].entry).not.toBeNull();
-    expect(results[0].entry!.filename).toBe("backup-20260411-153045.vbundle.enc");
+    expect(results[0].entry!.filename).toBe("backup-20260411-153045-000.vbundle.enc");
     expect(results[0].entry!.encrypted).toBe(true);
     expect(results[0].skipped).toBeUndefined();
     expect(results[0].error).toBeUndefined();
@@ -234,7 +234,7 @@ describe("writeOffsiteSnapshotToAll", () => {
     // Plaintext destination
     expect(results[1].destination).toEqual(destinations[1]);
     expect(results[1].entry).not.toBeNull();
-    expect(results[1].entry!.filename).toBe("backup-20260411-153045.vbundle");
+    expect(results[1].entry!.filename).toBe("backup-20260411-153045-000.vbundle");
     expect(results[1].entry!.encrypted).toBe(false);
     expect(results[1].skipped).toBeUndefined();
     expect(results[1].error).toBeUndefined();

--- a/assistant/src/backup/__tests__/paths.test.ts
+++ b/assistant/src/backup/__tests__/paths.test.ts
@@ -134,36 +134,58 @@ describe("getBackupKeyPath", () => {
 });
 
 describe("formatBackupFilename", () => {
-  const fixture = new Date("2026-04-11T15:30:45Z");
+  const fixture = new Date("2026-04-11T15:30:45.000Z");
 
   test("formats a plaintext backup filename", () => {
     expect(formatBackupFilename(fixture, { encrypted: false })).toBe(
-      "backup-20260411-153045.vbundle",
+      "backup-20260411-153045-000.vbundle",
     );
   });
 
   test("formats an encrypted backup filename", () => {
     expect(formatBackupFilename(fixture, { encrypted: true })).toBe(
-      "backup-20260411-153045.vbundle.enc",
+      "backup-20260411-153045-000.vbundle.enc",
     );
   });
 
   test("zero-pads single-digit UTC components", () => {
-    const early = new Date("2026-01-02T03:04:05Z");
+    const early = new Date("2026-01-02T03:04:05.007Z");
     expect(formatBackupFilename(early, { encrypted: false })).toBe(
-      "backup-20260102-030405.vbundle",
+      "backup-20260102-030405-007.vbundle",
+    );
+  });
+
+  test("includes milliseconds so same-second backups get distinct filenames", () => {
+    const a = new Date("2026-04-11T15:30:45.001Z");
+    const b = new Date("2026-04-11T15:30:45.002Z");
+    expect(formatBackupFilename(a, { encrypted: false })).not.toBe(
+      formatBackupFilename(b, { encrypted: false }),
     );
   });
 });
 
 describe("parseBackupTimestamp", () => {
-  test("round-trips a plaintext backup filename", () => {
+  test("round-trips a plaintext backup filename with milliseconds", () => {
+    const parsed = parseBackupTimestamp("backup-20260411-153045-123.vbundle");
+    expect(parsed).not.toBeNull();
+    expect(parsed!.toISOString()).toBe("2026-04-11T15:30:45.123Z");
+  });
+
+  test("round-trips an encrypted backup filename with milliseconds", () => {
+    const parsed = parseBackupTimestamp(
+      "backup-20260411-153045-123.vbundle.enc",
+    );
+    expect(parsed).not.toBeNull();
+    expect(parsed!.toISOString()).toBe("2026-04-11T15:30:45.123Z");
+  });
+
+  test("accepts legacy filenames without the milliseconds segment (treated as .000)", () => {
     const parsed = parseBackupTimestamp("backup-20260411-153045.vbundle");
     expect(parsed).not.toBeNull();
     expect(parsed!.toISOString()).toBe("2026-04-11T15:30:45.000Z");
   });
 
-  test("round-trips an encrypted backup filename", () => {
+  test("accepts legacy encrypted filenames without the milliseconds segment", () => {
     const parsed = parseBackupTimestamp("backup-20260411-153045.vbundle.enc");
     expect(parsed).not.toBeNull();
     expect(parsed!.toISOString()).toBe("2026-04-11T15:30:45.000Z");

--- a/assistant/src/backup/local-writer.ts
+++ b/assistant/src/backup/local-writer.ts
@@ -11,6 +11,7 @@
  * tmp directories without monkey-patching path helpers.
  */
 
+import { randomBytes } from "node:crypto";
 import { copyFile, mkdir, rename, stat, unlink } from "node:fs/promises";
 import { join } from "node:path";
 
@@ -18,13 +19,55 @@ import { pruneDir, type SnapshotEntry } from "./list-snapshots.js";
 import { formatBackupFilename } from "./paths.js";
 
 /**
+ * Resolve a destination path that does not already exist on disk. Milliseconds
+ * in the filename already make same-second collisions effectively impossible
+ * from normal operation, but two backups fired in the same millisecond (or a
+ * leftover file from a previous run) would still collide. Fall back to a
+ * random suffix so the write never silently overwrites an existing file.
+ */
+async function resolveUniqueDestPath(
+  localDir: string,
+  filename: string,
+): Promise<string> {
+  const primary = join(localDir, filename);
+  try {
+    await stat(primary);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return primary;
+    throw err;
+  }
+  // Path occupied — insert a short random token before the extension. Loop in
+  // case the collision itself repeats, though 6 hex chars gives 16M values.
+  const extIdx = filename.indexOf(".vbundle");
+  const base = filename.slice(0, extIdx);
+  const ext = filename.slice(extIdx);
+  for (let attempt = 0; attempt < 5; attempt++) {
+    const token = randomBytes(3).toString("hex");
+    const candidate = join(localDir, `${base}-${token}${ext}`);
+    try {
+      await stat(candidate);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return candidate;
+      throw err;
+    }
+  }
+  throw new Error(
+    `Unable to find a unique backup filename under ${localDir} for ${filename}`,
+  );
+}
+
+/**
  * Move a freshly-built `.vbundle` temp file into the local backup directory
  * under its canonical timestamped name.
  *
  * - Creates `localDir` (recursively, mode `0o700`) if it does not yet exist.
- * - Renames the temp file to `<localDir>/backup-YYYYMMDD-HHMMSS.vbundle`.
+ * - Renames the temp file to `<localDir>/backup-YYYYMMDD-HHMMSS-SSS.vbundle`.
  *   On EXDEV (cross-device move, e.g. when the temp dir is on a different
  *   filesystem than the backup directory) it falls back to copy + unlink.
+ * - If the canonical filename is already taken on disk (two backups in the
+ *   same millisecond, or a leftover from a prior crash), a short random
+ *   suffix is appended so the rename never silently overwrites an existing
+ *   snapshot.
  * - Returns a `SnapshotEntry` describing the final on-disk file.
  *
  * The caller is expected to pass the same `now` it used when staging the
@@ -38,8 +81,9 @@ export async function writeLocalSnapshot(
 ): Promise<SnapshotEntry> {
   await mkdir(localDir, { recursive: true, mode: 0o700 });
 
-  const filename = formatBackupFilename(now, { encrypted: false });
-  const destPath = join(localDir, filename);
+  const baseFilename = formatBackupFilename(now, { encrypted: false });
+  const destPath = await resolveUniqueDestPath(localDir, baseFilename);
+  const filename = destPath.slice(localDir.length + 1);
 
   try {
     await rename(tempVBundlePath, destPath);

--- a/assistant/src/backup/paths.ts
+++ b/assistant/src/backup/paths.ts
@@ -82,9 +82,11 @@ export function getBackupKeyPath(): string {
 /**
  * Formats a backup filename from a date. Encrypted backups get a `.vbundle.enc`
  * suffix; plaintext backups get `.vbundle`. Timestamp components are in UTC to
- * avoid timezone-induced filename collisions across devices.
+ * avoid timezone-induced filename collisions across devices. Milliseconds are
+ * included so two backups started in the same UTC second produce distinct
+ * filenames rather than silently overwriting each other.
  *
- * Example: `backup-20260411-153045.vbundle`
+ * Example: `backup-20260411-153045-123.vbundle`
  */
 export function formatBackupFilename(
   date: Date,
@@ -96,27 +98,32 @@ export function formatBackupFilename(
   const hour = date.getUTCHours().toString().padStart(2, "0");
   const minute = date.getUTCMinutes().toString().padStart(2, "0");
   const second = date.getUTCSeconds().toString().padStart(2, "0");
+  const millis = date.getUTCMilliseconds().toString().padStart(3, "0");
   const ext = encrypted ? ".vbundle.enc" : ".vbundle";
-  return `backup-${year}${month}${day}-${hour}${minute}${second}${ext}`;
+  return `backup-${year}${month}${day}-${hour}${minute}${second}-${millis}${ext}`;
 }
 
-// Matches `backup-YYYYMMDD-HHMMSS` optionally followed by `.vbundle` or
-// `.vbundle.enc`. Kept as a module-level constant so repeated parsing doesn't
-// rebuild the RegExp.
+// Matches `backup-YYYYMMDD-HHMMSS` with an optional `-SSS` milliseconds
+// segment (legacy backups written before ms precision was added omit it),
+// followed by `.vbundle` or `.vbundle.enc`. Kept as a module-level constant so
+// repeated parsing doesn't rebuild the RegExp.
 const BACKUP_FILENAME_RE =
-  /^backup-(\d{4})(\d{2})(\d{2})-(\d{2})(\d{2})(\d{2})\.vbundle(?:\.enc)?$/;
+  /^backup-(\d{4})(\d{2})(\d{2})-(\d{2})(\d{2})(\d{2})(?:-(\d{3}))?\.vbundle(?:\.enc)?$/;
 
 /**
  * Inverse of `formatBackupFilename`. Parses a backup filename (with either
  * `.vbundle` or `.vbundle.enc` suffix) and returns the encoded UTC timestamp.
- * Returns `null` when the filename doesn't match the expected pattern, when a
- * component is out of range, or when the parsed date is invalid.
+ * Accepts legacy filenames without the `-SSS` milliseconds segment (treated
+ * as `.000`). Returns `null` when the filename doesn't match the expected
+ * pattern, when a component is out of range, or when the parsed date is
+ * invalid.
  */
 export function parseBackupTimestamp(filename: string): Date | null {
   const match = BACKUP_FILENAME_RE.exec(filename);
   if (!match) return null;
-  const [, year, month, day, hour, minute, second] = match;
-  const iso = `${year}-${month}-${day}T${hour}:${minute}:${second}.000Z`;
+  const [, year, month, day, hour, minute, second, millis] = match;
+  const ms = millis ?? "000";
+  const iso = `${year}-${month}-${day}T${hour}:${minute}:${second}.${ms}Z`;
   const date = new Date(iso);
   if (Number.isNaN(date.getTime())) return null;
   // `new Date()` silently normalizes out-of-range calendar values (e.g. Feb 31
@@ -128,7 +135,8 @@ export function parseBackupTimestamp(filename: string): Date | null {
     date.getUTCDate() !== Number(day) ||
     date.getUTCHours() !== Number(hour) ||
     date.getUTCMinutes() !== Number(minute) ||
-    date.getUTCSeconds() !== Number(second)
+    date.getUTCSeconds() !== Number(second) ||
+    date.getUTCMilliseconds() !== Number(ms)
   ) {
     return null;
   }


### PR DESCRIPTION
Addresses Codex P1 feedback on #24885. Second-level timestamps in snapshot filenames meant two backups started in the same UTC second would silently overwrite each other — data-loss risk. Include milliseconds in the name; parser accepts legacy format without for backward compatibility.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25078" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
