### PR TITLE
fix(ios): update TTS provider test to match catalog-driven CLI setup mode

### DIFF
--- a/clients/ios/Tests/TTSProviderRegistryIOSTests.swift
+++ b/clients/ios/Tests/TTSProviderRegistryIOSTests.swift
@@ -48,16 +48,14 @@ final class TTSProviderRegistryIOSTests: XCTestCase {
         XCTAssertEqual(resolved?.id, registry.providers.first?.id)
     }
 
-    // MARK: - API Key Provider Derivation
+    // MARK: - Setup Mode Filtering
 
-    func testAPIKeyProvidersFilteredBySetupMode() {
+    func testProvidersFilteredBySetupMode() {
         let registry = loadTTSProviderRegistry()
-        let apiKeyProviders = registry.providers.filter { $0.setupMode == .apiKey }
-        // At minimum, ElevenLabs has setupMode == .apiKey in the catalog
-        XCTAssertFalse(apiKeyProviders.isEmpty, "At least one provider should have apiKey setup mode")
+        let cliProviders = registry.providers.filter { $0.setupMode == .cli }
         XCTAssertTrue(
-            apiKeyProviders.contains { $0.id == "elevenlabs" },
-            "ElevenLabs should have apiKey setup mode"
+            cliProviders.contains { $0.id == "elevenlabs" },
+            "ElevenLabs should have CLI setup mode"
         )
     }
 


### PR DESCRIPTION
## Summary
- ElevenLabs was intentionally switched from `apiKey` to `cli` setupMode in f33aa75eb (catalog-driven TTS onboarding), but `TTSProviderRegistryIOSTests` still asserted the old behavior, failing CI.
- Rewrite `testAPIKeyProvidersFilteredBySetupMode` as `testProvidersFilteredBySetupMode` to verify ElevenLabs appears in the CLI-filtered set, matching the canonical `meta/tts-provider-catalog.json`.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24318539257/job/71000389482
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25079" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
