### PR TITLE
Add workspace migration to explicitly persist services.stt provider settings

### DIFF
--- a/assistant/src/__tests__/workspace-migration-033-stt-service-explicit-config.test.ts
+++ b/assistant/src/__tests__/workspace-migration-033-stt-service-explicit-config.test.ts
@@ -1,0 +1,531 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { sttServiceExplicitConfigMigration } from "../workspace/migrations/033-stt-service-explicit-config.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let workspaceDir: string;
+
+function freshWorkspace(): void {
+  workspaceDir = join(
+    tmpdir(),
+    `vellum-migration-033-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(workspaceDir, { recursive: true });
+}
+
+function writeConfig(data: Record<string, unknown>): void {
+  writeFileSync(
+    join(workspaceDir, "config.json"),
+    JSON.stringify(data, null, 2) + "\n",
+  );
+}
+
+function readConfig(): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(workspaceDir, "config.json"), "utf-8"));
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  freshWorkspace();
+});
+
+afterEach(() => {
+  if (existsSync(workspaceDir)) {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("033-stt-service-explicit-config migration", () => {
+  test("has correct migration id", () => {
+    expect(sttServiceExplicitConfigMigration.id).toBe(
+      "033-stt-service-explicit-config",
+    );
+  });
+
+  // ─── Fresh config backfill ─────────────────────────────────────────────
+
+  test("backfills full services.stt block on config with no services key", () => {
+    writeConfig({ maxTokens: 64000 });
+
+    sttServiceExplicitConfigMigration.run(workspaceDir);
+
+    const config = readConfig();
+    const services = config.services as Record<string, unknown>;
+    const stt = services.stt as Record<string, unknown>;
+
+    expect(stt.mode).toBe("your-own");
+    expect(stt.provider).toBe("openai-whisper");
+    expect(stt.providers).toEqual({
+      "openai-whisper": {},
+      deepgram: {},
+    });
+
+    // Other config keys preserved
+    expect(config.maxTokens).toBe(64000);
+  });
+
+  test("backfills services.stt when services exists but has no stt key", () => {
+    writeConfig({
+      services: {
+        inference: { mode: "your-own", provider: "anthropic" },
+      },
+    });
+
+    sttServiceExplicitConfigMigration.run(workspaceDir);
+
+    const config = readConfig();
+    const services = config.services as Record<string, unknown>;
+    const stt = services.stt as Record<string, unknown>;
+
+    expect(stt.mode).toBe("your-own");
+    expect(stt.provider).toBe("openai-whisper");
+    expect(stt.providers).toEqual({
+      "openai-whisper": {},
+      deepgram: {},
+    });
+
+    // Existing services preserved
+    const inference = services.inference as Record<string, unknown>;
+    expect(inference.provider).toBe("anthropic");
+  });
+
+  test("backfills on empty config object", () => {
+    writeConfig({});
+
+    sttServiceExplicitConfigMigration.run(workspaceDir);
+
+    const config = readConfig();
+    const services = config.services as Record<string, unknown>;
+    const stt = services.stt as Record<string, unknown>;
+
+    expect(stt.mode).toBe("your-own");
+    expect(stt.provider).toBe("openai-whisper");
+    expect(stt.providers).toEqual({
+      "openai-whisper": {},
+      deepgram: {},
+    });
+  });
+
+  // ─── Partial STT object completion ────────────────────────────────────
+
+  test("fills in missing mode when stt has provider and providers", () => {
+    writeConfig({
+      services: {
+        stt: {
+          provider: "deepgram",
+          providers: { "openai-whisper": {}, deepgram: {} },
+        },
+      },
+    });
+
+    sttServiceExplicitConfigMigration.run(workspaceDir);
+
+    const config = readConfig();
+    const stt = (config.services as Record<string, unknown>).stt as Record<
+      string,
+      unknown
+    >;
+
+    expect(stt.mode).toBe("your-own");
+    expect(stt.provider).toBe("deepgram");
+  });
+
+  test("fills in missing provider when stt has mode and providers", () => {
+    writeConfig({
+      services: {
+        stt: {
+          mode: "your-own",
+          providers: { "openai-whisper": {}, deepgram: {} },
+        },
+      },
+    });
+
+    sttServiceExplicitConfigMigration.run(workspaceDir);
+
+    const config = readConfig();
+    const stt = (config.services as Record<string, unknown>).stt as Record<
+      string,
+      unknown
+    >;
+
+    expect(stt.provider).toBe("openai-whisper");
+    expect(stt.mode).toBe("your-own");
+  });
+
+  test("fills in missing providers entries when stt has mode and provider", () => {
+    writeConfig({
+      services: {
+        stt: {
+          mode: "your-own",
+          provider: "deepgram",
+        },
+      },
+    });
+
+    sttServiceExplicitConfigMigration.run(workspaceDir);
+
+    const config = readConfig();
+    const stt = (config.services as Record<string, unknown>).stt as Record<
+      string,
+      unknown
+    >;
+    const providers = stt.providers as Record<string, unknown>;
+
+    expect(providers["openai-whisper"]).toEqual({});
+    expect(providers.deepgram).toEqual({});
+  });
+
+  test("fills in missing deepgram entry when only openai-whisper exists in providers", () => {
+    writeConfig({
+      services: {
+        stt: {
+          mode: "your-own",
+          provider: "openai-whisper",
+          providers: { "openai-whisper": {} },
+        },
+      },
+    });
+
+    sttServiceExplicitConfigMigration.run(workspaceDir);
+
+    const config = readConfig();
+    const stt = (config.services as Record<string, unknown>).stt as Record<
+      string,
+      unknown
+    >;
+    const providers = stt.providers as Record<string, unknown>;
+
+    expect(providers["openai-whisper"]).toEqual({});
+    expect(providers.deepgram).toEqual({});
+  });
+
+  // ─── Preservation of explicit user provider overrides ─────────────────
+
+  test("preserves explicit user-defined provider value", () => {
+    writeConfig({
+      services: {
+        stt: {
+          mode: "your-own",
+          provider: "deepgram",
+          providers: { "openai-whisper": {}, deepgram: {} },
+        },
+      },
+    });
+
+    sttServiceExplicitConfigMigration.run(workspaceDir);
+
+    const config = readConfig();
+    const stt = (config.services as Record<string, unknown>).stt as Record<
+      string,
+      unknown
+    >;
+
+    expect(stt.provider).toBe("deepgram");
+  });
+
+  test("preserves existing provider-specific config values", () => {
+    writeConfig({
+      services: {
+        stt: {
+          mode: "your-own",
+          provider: "deepgram",
+          providers: {
+            "openai-whisper": { customSetting: "preserved" },
+            deepgram: { model: "nova-3" },
+          },
+        },
+      },
+    });
+
+    sttServiceExplicitConfigMigration.run(workspaceDir);
+
+    const config = readConfig();
+    const stt = (config.services as Record<string, unknown>).stt as Record<
+      string,
+      unknown
+    >;
+    const providers = stt.providers as Record<string, unknown>;
+    const whisper = providers["openai-whisper"] as Record<string, unknown>;
+    const deepgram = providers.deepgram as Record<string, unknown>;
+
+    expect(whisper.customSetting).toBe("preserved");
+    expect(deepgram.model).toBe("nova-3");
+  });
+
+  test("does not clobber explicit mode value", () => {
+    writeConfig({
+      services: {
+        stt: {
+          mode: "your-own",
+        },
+      },
+    });
+
+    sttServiceExplicitConfigMigration.run(workspaceDir);
+
+    const config = readConfig();
+    const stt = (config.services as Record<string, unknown>).stt as Record<
+      string,
+      unknown
+    >;
+    expect(stt.mode).toBe("your-own");
+  });
+
+  test("preserves other services keys", () => {
+    writeConfig({
+      services: {
+        inference: { mode: "your-own", provider: "anthropic" },
+        tts: { mode: "your-own", provider: "elevenlabs" },
+      },
+    });
+
+    sttServiceExplicitConfigMigration.run(workspaceDir);
+
+    const config = readConfig();
+    const services = config.services as Record<string, Record<string, unknown>>;
+
+    expect(services.inference.provider).toBe("anthropic");
+    expect(services.tts.provider).toBe("elevenlabs");
+    expect(services.stt).toBeDefined();
+  });
+
+  // ─── Malformed config no-op ───────────────────────────────────────────
+
+  test("no-op when config.json does not exist", () => {
+    sttServiceExplicitConfigMigration.run(workspaceDir);
+    expect(existsSync(join(workspaceDir, "config.json"))).toBe(false);
+  });
+
+  test("no-op when config.json contains invalid JSON", () => {
+    writeFileSync(join(workspaceDir, "config.json"), "not-valid-json");
+
+    sttServiceExplicitConfigMigration.run(workspaceDir);
+
+    expect(readFileSync(join(workspaceDir, "config.json"), "utf-8")).toBe(
+      "not-valid-json",
+    );
+  });
+
+  test("no-op when config.json contains a JSON array", () => {
+    writeFileSync(join(workspaceDir, "config.json"), JSON.stringify([1, 2, 3]));
+
+    sttServiceExplicitConfigMigration.run(workspaceDir);
+
+    const raw = JSON.parse(
+      readFileSync(join(workspaceDir, "config.json"), "utf-8"),
+    );
+    expect(raw).toEqual([1, 2, 3]);
+  });
+
+  test("no-op when config.json contains a JSON string", () => {
+    writeFileSync(
+      join(workspaceDir, "config.json"),
+      JSON.stringify("just a string"),
+    );
+
+    sttServiceExplicitConfigMigration.run(workspaceDir);
+
+    const raw = JSON.parse(
+      readFileSync(join(workspaceDir, "config.json"), "utf-8"),
+    );
+    expect(raw).toBe("just a string");
+  });
+
+  test("recovers when services.stt is a non-object value", () => {
+    writeConfig({
+      services: {
+        stt: "invalid",
+      },
+    });
+
+    sttServiceExplicitConfigMigration.run(workspaceDir);
+
+    const config = readConfig();
+    const stt = (config.services as Record<string, unknown>).stt as Record<
+      string,
+      unknown
+    >;
+
+    // ensureObj replaces the non-object with a fresh object and backfills
+    expect(stt.mode).toBe("your-own");
+    expect(stt.provider).toBe("openai-whisper");
+  });
+
+  test("recovers when services is a non-object value", () => {
+    writeConfig({
+      services: 42,
+    });
+
+    sttServiceExplicitConfigMigration.run(workspaceDir);
+
+    const config = readConfig();
+    const services = config.services as Record<string, unknown>;
+    const stt = services.stt as Record<string, unknown>;
+
+    expect(stt.mode).toBe("your-own");
+    expect(stt.provider).toBe("openai-whisper");
+  });
+
+  // ─── Second-run idempotency ───────────────────────────────────────────
+
+  test("second run produces identical output (fresh backfill)", () => {
+    writeConfig({ maxTokens: 64000 });
+
+    sttServiceExplicitConfigMigration.run(workspaceDir);
+    const afterFirst = readConfig();
+
+    sttServiceExplicitConfigMigration.run(workspaceDir);
+    const afterSecond = readConfig();
+
+    expect(afterSecond).toEqual(afterFirst);
+  });
+
+  test("second run produces identical output (already complete config)", () => {
+    writeConfig({
+      services: {
+        stt: {
+          mode: "your-own",
+          provider: "deepgram",
+          providers: {
+            "openai-whisper": {},
+            deepgram: { model: "nova-3" },
+          },
+        },
+      },
+    });
+
+    sttServiceExplicitConfigMigration.run(workspaceDir);
+    const afterFirst = readConfig();
+
+    sttServiceExplicitConfigMigration.run(workspaceDir);
+    const afterSecond = readConfig();
+
+    expect(afterSecond).toEqual(afterFirst);
+  });
+
+  test("does not write file when nothing changed (fully populated config)", () => {
+    const original = {
+      services: {
+        stt: {
+          mode: "your-own",
+          provider: "openai-whisper",
+          providers: {
+            "openai-whisper": {},
+            deepgram: {},
+          },
+        },
+      },
+    };
+    writeConfig(original);
+
+    // Capture the file's mtime before migration
+    const before = readFileSync(join(workspaceDir, "config.json"), "utf-8");
+
+    sttServiceExplicitConfigMigration.run(workspaceDir);
+
+    const after = readFileSync(join(workspaceDir, "config.json"), "utf-8");
+    // Content should be byte-identical since nothing changed
+    expect(after).toBe(before);
+  });
+
+  // ─── down() ───────────────────────────────────────────────────────────
+
+  describe("down()", () => {
+    test("removes services.stt block", () => {
+      writeConfig({
+        services: {
+          inference: { mode: "your-own", provider: "anthropic" },
+          stt: {
+            mode: "your-own",
+            provider: "openai-whisper",
+            providers: { "openai-whisper": {}, deepgram: {} },
+          },
+        },
+      });
+
+      sttServiceExplicitConfigMigration.down(workspaceDir);
+
+      const config = readConfig();
+      const services = config.services as Record<string, unknown>;
+      expect(services.stt).toBeUndefined();
+      // Other services preserved
+      expect(services.inference).toBeDefined();
+    });
+
+    test("no-op when config.json does not exist", () => {
+      sttServiceExplicitConfigMigration.down(workspaceDir);
+      // Should not throw
+    });
+
+    test("no-op when config has no services key", () => {
+      writeConfig({ maxTokens: 64000 });
+
+      sttServiceExplicitConfigMigration.down(workspaceDir);
+
+      const config = readConfig();
+      expect(config.maxTokens).toBe(64000);
+    });
+
+    test("no-op when services.stt does not exist", () => {
+      writeConfig({
+        services: {
+          inference: { mode: "your-own", provider: "anthropic" },
+        },
+      });
+
+      sttServiceExplicitConfigMigration.down(workspaceDir);
+
+      const config = readConfig();
+      const services = config.services as Record<string, unknown>;
+      expect(services.inference).toBeDefined();
+    });
+
+    test("idempotent: calling down() twice is safe", () => {
+      writeConfig({
+        services: {
+          stt: {
+            mode: "your-own",
+            provider: "openai-whisper",
+            providers: { "openai-whisper": {}, deepgram: {} },
+          },
+        },
+      });
+
+      sttServiceExplicitConfigMigration.down(workspaceDir);
+      sttServiceExplicitConfigMigration.down(workspaceDir);
+
+      const config = readConfig();
+      const services = config.services as Record<string, unknown>;
+      expect(services.stt).toBeUndefined();
+    });
+
+    test("gracefully handles malformed JSON", () => {
+      writeFileSync(join(workspaceDir, "config.json"), "bad-json");
+
+      sttServiceExplicitConfigMigration.down(workspaceDir);
+
+      expect(readFileSync(join(workspaceDir, "config.json"), "utf-8")).toBe(
+        "bad-json",
+      );
+    });
+  });
+});

--- a/assistant/src/workspace/migrations/033-stt-service-explicit-config.ts
+++ b/assistant/src/workspace/migrations/033-stt-service-explicit-config.ts
@@ -1,0 +1,118 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { WorkspaceMigration } from "./types.js";
+
+/**
+ * Materialize explicit `services.stt` configuration on disk.
+ *
+ * Prior to this migration the STT block was only populated at runtime via
+ * Zod `.default()` values in the schema. This meant existing workspaces had
+ * no `services.stt` in their `config.json` at all, making it invisible
+ * to users and tooling that inspects config on disk.
+ *
+ * This migration writes a canonical `services.stt` block when missing or
+ * partial, backfilling:
+ *
+ *   - `services.stt.mode`      -> `"your-own"`
+ *   - `services.stt.provider`  -> `"openai-whisper"`
+ *   - `services.stt.providers` -> `{ "openai-whisper": {}, "deepgram": {} }`
+ *
+ * It never clobbers user-defined STT values — only fills in what is missing.
+ *
+ * Idempotent: re-running the migration on an already-migrated config
+ * produces no changes.
+ */
+export const sttServiceExplicitConfigMigration: WorkspaceMigration = {
+  id: "033-stt-service-explicit-config",
+  description:
+    "Materialize explicit services.stt provider settings on disk (mode, provider, providers)",
+  run(workspaceDir: string): void {
+    const configPath = join(workspaceDir, "config.json");
+    if (!existsSync(configPath)) return;
+
+    let config: Record<string, unknown>;
+    try {
+      const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+      if (!raw || typeof raw !== "object" || Array.isArray(raw)) return;
+      config = raw as Record<string, unknown>;
+    } catch {
+      return; // Malformed JSON — skip
+    }
+
+    // Ensure services.stt exists as an object
+    const services = ensureObj(config, "services");
+    const stt = ensureObj(services, "stt");
+
+    let changed = false;
+
+    // Backfill mode
+    if (!("mode" in stt)) {
+      stt.mode = "your-own";
+      changed = true;
+    }
+
+    // Backfill provider
+    if (!("provider" in stt)) {
+      stt.provider = "openai-whisper";
+      changed = true;
+    }
+
+    // Backfill providers map and its entries
+    const providers = ensureObj(stt, "providers");
+    if (!("openai-whisper" in providers)) {
+      providers["openai-whisper"] = {};
+      changed = true;
+    }
+    if (!("deepgram" in providers)) {
+      providers.deepgram = {};
+      changed = true;
+    }
+
+    // Only write when something actually changed
+    if (changed) {
+      writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+    }
+  },
+  down(workspaceDir: string): void {
+    const configPath = join(workspaceDir, "config.json");
+    if (!existsSync(configPath)) return;
+
+    let config: Record<string, unknown>;
+    try {
+      const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+      if (!raw || typeof raw !== "object" || Array.isArray(raw)) return;
+      config = raw as Record<string, unknown>;
+    } catch {
+      return;
+    }
+
+    // Remove services.stt entirely.
+    const services = config.services;
+    if (services && typeof services === "object" && !Array.isArray(services)) {
+      const servicesObj = services as Record<string, unknown>;
+      delete servicesObj.stt;
+    }
+
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Helpers (self-contained per migration AGENTS.md)
+// ---------------------------------------------------------------------------
+
+function ensureObj(
+  parent: Record<string, unknown>,
+  key: string,
+): Record<string, unknown> {
+  if (
+    !(key in parent) ||
+    parent[key] == null ||
+    typeof parent[key] !== "object" ||
+    Array.isArray(parent[key])
+  ) {
+    parent[key] = {};
+  }
+  return parent[key] as Record<string, unknown>;
+}

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -30,6 +30,7 @@ import { seedPkbAutoinjectMigration } from "./030-seed-pkb-autoinject.js";
 import { dropUserMdMigration } from "./031-drop-user-md.js";
 import { llmLogRetentionZeroToNullMigration } from "./031-llm-log-retention-zero-to-null.js";
 import { ttsProviderUnificationMigration } from "./032-tts-provider-unification.js";
+import { sttServiceExplicitConfigMigration } from "./033-stt-service-explicit-config.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -71,4 +72,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   llmLogRetentionZeroToNullMigration,
   ttsProviderUnificationMigration,
   dropUserMdMigration,
+  sttServiceExplicitConfigMigration,
 ];


### PR DESCRIPTION
## Summary
- Adds workspace migration 033 to materialize explicit services.stt config on disk
- Backfills mode, provider, and providers block when missing/partial without clobbering existing values
- Idempotent and handles malformed configs safely
- Comprehensive test coverage for backfill, completion, preservation, malformed configs, and idempotency

Part of plan: deepgram-first-class-services-stt.md (PR 3 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25080" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
