### PR TITLE
fix(macos): persistent keyboard binding for mark-as-unread ⌘⇧U

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -103,6 +103,7 @@ extension AppDelegate {
         registerCmdKMonitor()
         registerNewChatMonitor()
         registerCurrentConversationMonitor()
+        registerMarkConversationUnreadMonitor()
         registerPopOutMonitor()
 
         globalHotkeyObserver = Publishers.Merge4(
@@ -122,6 +123,7 @@ extension AppDelegate {
             self?.registerSidebarToggleMonitor()
             self?.registerNewChatMonitor()
             self?.registerCurrentConversationMonitor()
+            self?.registerMarkConversationUnreadMonitor()
             self?.registerPopOutMonitor()
             self?.updateNewChatMenuItemShortcut()
             self?.updateCurrentConversationMenuItemShortcut()
@@ -214,6 +216,10 @@ extension AppDelegate {
         if let monitor = currentConversationLocalMonitor {
             NSEvent.removeMonitor(monitor)
             currentConversationLocalMonitor = nil
+        }
+        if let monitor = markConversationUnreadLocalMonitor {
+            NSEvent.removeMonitor(monitor)
+            markConversationUnreadLocalMonitor = nil
         }
         if let monitor = navLocalMonitor {
             NSEvent.removeMonitor(monitor)
@@ -312,6 +318,38 @@ extension AppDelegate {
             return nil
         }
         currentConversationLocalMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown, handler: handler)
+    }
+
+    /// Registers a local event monitor to mark the active conversation as unread
+    /// when the configured shortcut (default: Cmd+Shift+U) is pressed. The shortcut
+    /// is read dynamically from UserDefaults so it can be reconfigured without
+    /// restarting. Using a persistent local monitor keeps the shortcut active
+    /// regardless of whether the SwiftUI-managed File menu has been opened.
+    func registerMarkConversationUnreadMonitor() {
+        if let existing = markConversationUnreadLocalMonitor {
+            NSEvent.removeMonitor(existing)
+            markConversationUnreadLocalMonitor = nil
+        }
+
+        let shortcut = UserDefaults.standard.string(forKey: "markConversationUnreadShortcut") ?? "cmd+shift+u"
+        guard !shortcut.isEmpty else { return }
+
+        let (targetModifiers, targetKey) = ShortcutHelper.parseShortcut(shortcut)
+
+        let handler: (NSEvent) -> NSEvent? = { [weak self] event in
+            guard self?.isBootstrapping != true,
+                  self?.mainWindow?.isVisible == true else { return event }
+            let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask).subtracting(.numericPad)
+            guard mods == targetModifiers,
+                  event.charactersIgnoringModifiers?.lowercased() == targetKey.lowercased() else {
+                return event
+            }
+            Task { @MainActor in
+                self?.markCurrentConversationUnread()
+            }
+            return nil
+        }
+        markConversationUnreadLocalMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown, handler: handler)
     }
 
     /// Registers Cmd+K as a local shortcut to open the command palette.

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -65,6 +65,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     var cmdKLocalMonitor: Any?
     var cmdNLocalMonitor: Any?
     var currentConversationLocalMonitor: Any?
+    var markConversationUnreadLocalMonitor: Any?
     var newChatMenuItem: NSMenuItem?
     var currentConversationMenuItem: NSMenuItem?
     var markConversationUnreadMenuItem: NSMenuItem?


### PR DESCRIPTION
## Summary

Addresses Codex feedback on #25044: the ⌘⇧U mark-as-unread shortcut was only bound via the `NSMenuItem` injected in `FileMenuPatchDelegate.menuWillOpen`, so the key equivalent was only active after the user had opened the File menu in the current UI lifecycle. Because the File menu is SwiftUI-managed and rebuilt, the binding could disappear again, making the shortcut intermittently non-functional.

## Fix

Adds a persistent local `NSEvent` keyDown monitor for the configured mark-as-unread shortcut (default ⌘⇧U), mirroring the pattern used by the other configurable shortcuts (`registerNewChatMonitor`, `registerCurrentConversationMonitor`, `registerPopOutMonitor`, etc.). The monitor:

- Reads the shortcut dynamically from `UserDefaults` so it stays in sync with Settings changes (already wired into the `globalHotkeyObserver` publisher sink).
- Calls the existing `markCurrentConversationUnread()` action so menu item and keyboard path share one implementation.
- Gates on `mainWindow?.isVisible` and only consumes the event when the shortcut matches (pass-through otherwise).
- Is torn down in `tearDownQuickInputMonitors()` alongside the other local monitors.

The `NSMenuItem` stays in place for File-menu discoverability; key handling no longer depends on whether the menu has been opened.

## Files

- `clients/macos/vellum-assistant/App/AppDelegate.swift` — add `markConversationUnreadLocalMonitor` storage.
- `clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift` — new `registerMarkConversationUnreadMonitor()`, wire into `setupHotKey()`, observer sink, and teardown.

## Test plan
- [x] `./build.sh` — macOS Swift build succeeds.
- [ ] Manual: fresh launch, do not open File menu, press ⌘⇧U on an active conversation — it should mark unread.
- [ ] Manual: change shortcut in Settings → Appearance, confirm monitor re-registers with new binding.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25081" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
