### PR TITLE
Adopt TTS-style data-driven STT settings UI with Deepgram support

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -591,7 +591,7 @@ Audio-to-text conversion occurs in four distinct runtime boundaries, each with i
 | Boundary                     | Runtime                               | Provider (current)                           | Adapter module                                                                                     | Caller                                                                                               |
 | ---------------------------- | ------------------------------------- | -------------------------------------------- | -------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
 | **Telephony-native**         | Twilio ConversationRelay              | Deepgram or Google (config-driven)           | `src/calls/stt-profile.ts`                                                                         | `src/calls/twilio-routes.ts`                                                                         |
-| **Daemon batch**             | Daemon process (REST API to provider) | OpenAI Whisper                               | `src/stt/daemon-batch-transcriber.ts`                                                              | `src/runtime/routes/inbound-stages/transcribe-audio.ts`                                              |
+| **Daemon batch**             | Daemon process (REST API to provider) | Configured STT provider (via `services.stt`) | `src/stt/daemon-batch-transcriber.ts`                                                              | `src/runtime/routes/inbound-stages/transcribe-audio.ts`                                              |
 | **Client service-first**     | macOS / iOS via gateway → daemon      | Configured STT provider (via `services.stt`) | `src/runtime/routes/stt-routes.ts`, `clients/shared/Network/STTClient.swift`                       | `VoiceInputManager` (macOS dictation), `InputBarView` (iOS), `OpenAIVoiceService` (macOS voice mode) |
 | **Client-native (fallback)** | macOS / iOS on-device                 | Apple Speech (`SFSpeechRecognizer`)          | `clients/macos/.../SpeechRecognizerAdapter.swift`, `clients/ios/.../SpeechRecognizerAdapter.swift` | Fallback when STT service is unconfigured or fails                                                   |
 
@@ -610,11 +610,11 @@ To add a new telephony STT provider: add a branch in `resolveEffectiveSpeechMode
 The daemon transcribes audio attachments (e.g. voice messages from channel inbound) by calling a provider's REST API directly.
 
 - `src/stt/types.ts` defines provider-agnostic domain types: `BatchTranscriber` interface, `SttTranscribeRequest`, `SttTranscribeResult`, `SttError` with normalized categories (`auth`, `rate-limit`, `timeout`, `invalid-audio`, `provider-error`), and `SttProviderId` / `SttBoundaryId` discriminants.
-- `createDaemonBatchTranscriber()` in `src/stt/daemon-batch-transcriber.ts` is the factory that returns a `BatchTranscriber` backed by OpenAI Whisper (or `null` when no API key is available). `normalizeSttError()` maps raw provider errors to `SttError` categories.
-- `resolveBatchTranscriber()` in `src/providers/speech-to-text/resolve.ts` is the credential-aware entry point — it reads the OpenAI key from the secure key store and delegates to the factory.
+- `createDaemonBatchTranscriber()` in `src/stt/daemon-batch-transcriber.ts` is the factory that returns a `BatchTranscriber` backed by the configured STT provider (OpenAI Whisper or Deepgram, selected via `services.stt.provider`). Returns `null` when no API key is available for the selected provider. `normalizeSttError()` maps raw provider errors to `SttError` categories.
+- `resolveBatchTranscriber()` in `src/providers/speech-to-text/resolve.ts` is the credential-aware entry point — it reads the configured provider from `services.stt`, resolves the corresponding API key from the secure key store, and delegates to the factory.
 - `tryTranscribeAudioAttachments()` in `src/runtime/routes/inbound-stages/transcribe-audio.ts` is the callsite that uses the facade for channel audio attachment transcription.
 
-To add a new daemon batch STT provider: add a new `SttProviderId` variant in `types.ts`, implement `BatchTranscriber` in a new adapter class alongside `WhisperBatchTranscriber`, and update the factory in `daemon-batch-transcriber.ts` to select the adapter based on configuration or credential availability.
+To add a new daemon batch STT provider: add a new `SttProviderId` variant in `types.ts`, implement `BatchTranscriber` in a new adapter class alongside `WhisperBatchTranscriber` and `DeepgramBatchTranscriber`, update the factory in `daemon-batch-transcriber.ts` to select the adapter based on configuration, and add the provider to `meta/stt-provider-catalog.json` so clients can display it in settings.
 
 **Client service-first boundary:**
 
@@ -649,7 +649,7 @@ These differences are intentional — the adapters were designed for their respe
 
 **Cross-boundary notes:**
 
-- The `services.stt` config block controls provider selection for both the daemon batch boundary and the client service-first boundary (they share `resolveBatchTranscriber()`). Telephony STT is configured separately via `calls.voice.transcriptionProvider`.
+- The `services.stt` config block controls provider selection for both the daemon batch boundary and the client service-first boundary (they share `resolveBatchTranscriber()`). Supported providers include OpenAI Whisper (`openai-whisper`) and Deepgram (`deepgram`). Telephony STT is configured independently via `calls.voice.transcriptionProvider` and is completely uncoupled from `services.stt` — changing one does not affect the other.
 - Terminology: "STT" and "transcription" refer to the same operation (converting audio to text). "Speech recognition" is used in client-native contexts where Apple's Speech framework terminology is canonical. All three terms map to the same conceptual operation.
 
 ### Update Bulletin System

--- a/assistant/src/config/bundled-skills/transcribe/SKILL.md
+++ b/assistant/src/config/bundled-skills/transcribe/SKILL.md
@@ -8,7 +8,7 @@ metadata:
     display-name: "Transcribe"
 ---
 
-Transcribe audio and video files using the configured speech-to-text provider (e.g. OpenAI Whisper).
+Transcribe audio and video files using the configured speech-to-text provider. Supports multiple STT providers including OpenAI Whisper and Deepgram — the active provider is selected in Settings under Speech-to-Text (`services.stt`).
 
 ## Usage Notes
 
@@ -17,3 +17,4 @@ Transcribe audio and video files using the configured speech-to-text provider (e
 - For video files, audio is automatically extracted via ffmpeg before transcription.
 - Large files are automatically split into chunks for processing.
 - If no STT provider credentials are configured, the tool will return an error with setup instructions.
+- The STT provider used here (`services.stt`) is independent of the telephony transcription provider (`calls.voice.transcriptionProvider`), which is configured separately for phone call STT.

--- a/assistant/src/config/bundled-skills/transcribe/tools/transcribe-media.ts
+++ b/assistant/src/config/bundled-skills/transcribe/tools/transcribe-media.ts
@@ -231,7 +231,7 @@ export async function run(
   if (!transcriber) {
     return {
       content:
-        "No speech-to-text provider is configured. Set up an STT provider (e.g. OpenAI API key) in your assistant settings to enable transcription.",
+        "No speech-to-text provider is configured. Set up an STT provider (e.g. OpenAI Whisper or Deepgram) in your assistant settings to enable transcription.",
       isError: true,
     };
   }

--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -562,7 +562,16 @@ struct VoiceSettingsView: View {
                     onSave: { saveSTT() },
                     savingLabel: "Saving...",
                     onReset: {
-                        store.clearSTTKey(sttProviderId: draftSTTProvider)
+                        // Only delete the API key when it belongs exclusively
+                        // to this STT provider. When the resolved credential
+                        // provider is shared with another service (e.g.
+                        // openai-whisper → openai) we skip the deletion to
+                        // avoid breaking inference or other OpenAI features.
+                        let entry = sttRegistry.provider(withId: draftSTTProvider)
+                        let isSharedKey = entry.map { $0.apiKeyProviderName != $0.id } ?? false
+                        if !isSharedKey {
+                            store.clearSTTKey(sttProviderId: draftSTTProvider)
+                        }
                         sttProviderHasKey = false
                         sttApiKeyText = ""
                     },

--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -1,17 +1,6 @@
 import SwiftUI
 import VellumAssistantShared
 
-/// STT provider options for the speech-to-text service card.
-private enum STTProviderOption: String, CaseIterable {
-    case openaiWhisper = "openai-whisper"
-
-    var displayName: String {
-        switch self {
-        case .openaiWhisper: return "OpenAI Whisper"
-        }
-    }
-}
-
 /// Voice settings tab — configure push-to-talk activation key,
 /// conversation timeout, text-to-speech provider, and speech-to-text provider.
 struct VoiceSettingsView: View {
@@ -21,7 +10,7 @@ struct VoiceSettingsView: View {
     @AppStorage("activationKey") private var activationKey: String = "fn"
     @AppStorage("voiceConversationTimeoutSeconds") private var conversationTimeoutSeconds: Int = 30
     @AppStorage("ttsProvider") private var ttsProviderRaw: String = "elevenlabs"
-    @AppStorage("sttProvider") private var sttProviderRaw: String = STTProviderOption.openaiWhisper.rawValue
+    @AppStorage("sttProvider") private var sttProviderRaw: String = "openai-whisper"
 
     // TTS draft-based state (mirrors Inference card pattern)
     /// Uncommitted provider selection — only persisted on Save.
@@ -58,13 +47,23 @@ struct VoiceSettingsView: View {
     @State private var sttSaveError: String? = nil
 
     /// The shared TTS provider registry loaded from the bundled catalog.
-    private let registry = loadTTSProviderRegistry()
+    private let ttsRegistry = loadTTSProviderRegistry()
 
-    /// The currently selected provider entry from the registry, based on
+    /// The shared STT provider registry loaded from the bundled catalog.
+    private let sttRegistry = loadSTTProviderRegistry()
+
+    /// The currently selected TTS provider entry from the registry, based on
     /// the draft selection. Falls back to the first provider in the registry
     /// if the value does not match any known entry (matching iOS behavior).
-    private var selectedProvider: TTSProviderCatalogEntry? {
-        registry.provider(withId: draftTTSProvider) ?? registry.providers.first
+    private var selectedTTSProvider: TTSProviderCatalogEntry? {
+        ttsRegistry.provider(withId: draftTTSProvider) ?? ttsRegistry.providers.first
+    }
+
+    /// The currently selected STT provider entry from the registry, based on
+    /// the draft selection. Falls back to the first provider in the registry
+    /// if the value does not match any known entry.
+    private var selectedSTTProvider: STTProviderCatalogEntry? {
+        sttRegistry.provider(withId: draftSTTProvider) ?? sttRegistry.providers.first
     }
 
     private var currentActivator: PTTActivator {
@@ -374,7 +373,7 @@ struct VoiceSettingsView: View {
                     VDropdown(
                         placeholder: "Select a provider\u{2026}",
                         selection: $draftTTSProvider,
-                        options: registry.providers.map { entry in
+                        options: ttsRegistry.providers.map { entry in
                             (label: entry.displayName, value: entry.id)
                         }
                     )
@@ -413,7 +412,7 @@ struct VoiceSettingsView: View {
             return "Enter your API key"
         }()
         return VTextField(
-            "\(selectedProvider?.displayName ?? "Provider") API Key",
+            "\(selectedTTSProvider?.displayName ?? "Provider") API Key",
             placeholder: placeholder,
             text: $ttsApiKeyText,
             isSecure: true,
@@ -429,7 +428,7 @@ struct VoiceSettingsView: View {
         if draftTTSProvider == "elevenlabs" || draftTTSProvider == "fish-audio" {
             VTextField(
                 "Voice ID",
-                placeholder: "\(selectedProvider?.displayName ?? "Provider") Voice ID (optional)",
+                placeholder: "\(selectedTTSProvider?.displayName ?? "Provider") Voice ID (optional)",
                 text: $ttsVoiceIdText
             )
         }
@@ -528,7 +527,7 @@ struct VoiceSettingsView: View {
     private var sttProviderCard: some View {
         SettingsCard(title: "Speech-to-Text", subtitle: "Choose an STT provider for audio transcription. The selected provider is used globally across all transcription features.") {
             VStack(alignment: .leading, spacing: VSpacing.md) {
-                // Provider dropdown selector
+                // Provider dropdown — data-driven from the shared STT registry
                 VStack(alignment: .leading, spacing: VSpacing.sm) {
                     Text("Provider")
                         .font(VFont.labelDefault)
@@ -536,49 +535,60 @@ struct VoiceSettingsView: View {
                     VDropdown(
                         placeholder: "Select a provider\u{2026}",
                         selection: $draftSTTProvider,
-                        options: STTProviderOption.allCases.map { provider in
-                            (label: provider.displayName, value: provider.rawValue)
+                        options: sttRegistry.providers.map { entry in
+                            (label: entry.displayName, value: entry.id)
                         }
                     )
                 }
 
-                // API key field
-                VTextField(
-                    "OpenAI API Key",
-                    placeholder: sttProviderHasKey ? "\u{2022}\u{2022}\u{2022}\u{2022}\u{2022}\u{2022}\u{2022}\u{2022}\u{2022}\u{2022}\u{2022}\u{2022}" : "Your OpenAI API key",
-                    text: $sttApiKeyText,
-                    isSecure: true,
-                    errorMessage: sttSaveError,
-                    maxWidth: 400
-                )
+                // API key field — label and placeholder adapt to the selected provider
+                sttApiKeyField
 
-                // Informational note about shared key
-                if sttProviderHasKey {
-                    HStack(alignment: .top, spacing: VSpacing.xs) {
+                // Provider-specific setup hint
+                if let hint = selectedSTTProvider?.setupHint, !hint.isEmpty {
+                    HStack(spacing: VSpacing.xs) {
                         VIconView(.info, size: 10)
                             .foregroundStyle(VColor.contentTertiary)
-                        Text("The OpenAI key is shared with inference. Use inference settings to manage it.")
-                            .font(VFont.labelDefault)
-                            .foregroundStyle(VColor.contentTertiary)
-                    }
-                } else {
-                    HStack(spacing: VSpacing.xs) {
-                        VIconView(.lock, size: 10)
-                            .foregroundStyle(VColor.contentTertiary)
-                        Text("This API key is shared with inference settings.")
+                        Text(hint)
                             .font(VFont.labelDefault)
                             .foregroundStyle(VColor.contentTertiary)
                     }
                 }
 
-                // Save action — no Reset for STT since the key is shared with inference
+                // Save + Reset actions
                 ServiceCardActions(
                     hasChanges: sttHasChanges,
                     isSaving: sttSaving,
-                    onSave: { saveSTT() }
+                    onSave: { saveSTT() },
+                    savingLabel: "Saving...",
+                    onReset: {
+                        store.clearSTTKey(sttProviderId: draftSTTProvider)
+                        sttProviderHasKey = false
+                        sttApiKeyText = ""
+                    },
+                    showReset: sttProviderHasKey
                 )
             }
         }
+    }
+
+    // MARK: - STT API Key Field
+
+    private var sttApiKeyField: some View {
+        let placeholder: String = {
+            if sttProviderHasKey {
+                return "\u{2022}\u{2022}\u{2022}\u{2022}\u{2022}\u{2022}\u{2022}\u{2022}\u{2022}\u{2022}\u{2022}\u{2022}\u{2022}\u{2022}\u{2022}\u{2022}"
+            }
+            return "Enter your API key"
+        }()
+        return VTextField(
+            "\(selectedSTTProvider?.displayName ?? "Provider") API Key",
+            placeholder: placeholder,
+            text: $sttApiKeyText,
+            isSecure: true,
+            errorMessage: sttSaveError
+        )
+        .disabled(sttSaving)
     }
 
     // MARK: - STT Save

--- a/clients/macos/vellum-assistantTests/SettingsStoreVoiceServiceTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsStoreVoiceServiceTests.swift
@@ -256,4 +256,58 @@ final class SettingsStoreVoiceServiceTests: XCTestCase {
         let keyName = SettingsStore.sttApiKeyProviderName(for: "unknown-provider")
         XCTAssertEqual(keyName, "unknown-provider")
     }
+
+    // MARK: - Deepgram provider patching roundtrip
+
+    func testSetSTTProviderDeepgramDoesNotEmitTTSPatch() {
+        store.setSTTProvider("deepgram")
+
+        waitForPatchCount(1)
+
+        let ttsPatch = lastTTSPatch()
+        XCTAssertNil(ttsPatch, "setSTTProvider(deepgram) must not emit a TTS patch")
+    }
+
+    func testApplyDaemonConfigSyncsDeepgramWithExistingOpenAISTT() {
+        // Start with openai-whisper persisted, then receive deepgram from the daemon
+        UserDefaults.standard.set("openai-whisper", forKey: "sttProvider")
+
+        let config: [String: Any] = [
+            "services": [
+                "stt": [
+                    "provider": "deepgram"
+                ]
+            ]
+        ]
+
+        mockSettingsClient.fetchConfigResponse = config
+        let expectation = XCTestExpectation(description: "config loaded")
+        Task {
+            await store.loadConfigFromDaemon()
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 2.0)
+
+        XCTAssertEqual(
+            UserDefaults.standard.string(forKey: "sttProvider"),
+            "deepgram",
+            "Daemon config should overwrite the persisted STT provider"
+        )
+    }
+
+    func testSequentialSTTProviderPatchesEmitCorrectProviders() {
+        // Patch openai-whisper then deepgram — both should produce distinct payloads
+        store.setSTTProvider("openai-whisper")
+        waitForPatchCount(1)
+
+        store.setSTTProvider("deepgram")
+        waitForPatchCount(2)
+
+        let patch = lastSTTPatch()
+        XCTAssertEqual(
+            patch?["provider"] as? String,
+            "deepgram",
+            "Most recent STT patch should reflect the deepgram provider"
+        )
+    }
 }


### PR DESCRIPTION
## Summary
- Replaces static STT enum with registry-driven provider options matching TTS pattern
- Updates STT card copy and key flows to be provider-aware (no longer OpenAI-only)
- Updates transcribe skill copy and ARCHITECTURE.md for multi-provider STT
- Adds tests for Deepgram provider patching path

Part of plan: deepgram-first-class-services-stt.md (PR 6 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25082" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
