### PR TITLE
fix(backup): don't treat transient empty lock as stale

### DIFF
--- a/assistant/src/backup/__tests__/snapshot-lock.test.ts
+++ b/assistant/src/backup/__tests__/snapshot-lock.test.ts
@@ -143,30 +143,35 @@ describe("acquireSnapshotLock — stale locks", () => {
     expect(existsSync(LOCK)).toBe(false);
   });
 
-  test("unparseable lock file: acquire takes it over", async () => {
-    // A lock file that contains garbage (no digits) has no recoverable
-    // holder PID — treat it as stale and take over.
+  test("unparseable lock file: acquire refuses takeover and surfaces conflict", async () => {
+    // A lock file with no parseable PID is indistinguishable from an
+    // in-progress partial write by a live holder (both read back as
+    // `null`). We conservatively refuse takeover in both cases — we
+    // only ever take over a lock whose holder PID is readable AND
+    // confirmed not running. Garbage files require manual cleanup; the
+    // alternative (silently unlinking) is what introduced the TOCTOU
+    // race flagged on PR #24896.
     writeFileSync(LOCK, "not a pid at all\n", { mode: 0o600 });
 
-    const release = await acquireSnapshotLock(LOCK);
-    try {
-      expect(existsSync(LOCK)).toBe(true);
-    } finally {
-      await release();
-    }
-    expect(existsSync(LOCK)).toBe(false);
+    await expect(acquireSnapshotLock(LOCK)).rejects.toThrow(
+      /^snapshot in progress/,
+    );
+    expect(existsSync(LOCK)).toBe(true);
   });
 
-  test("empty lock file: acquire takes it over", async () => {
+  test("empty lock file: acquire refuses takeover and preserves the file", async () => {
+    // An empty lock file is ambiguous: it could be debris from a dead
+    // writer, or it could belong to a *live* holder that just won
+    // `O_EXCL` but has not yet flushed its PID. Taking it over would
+    // allow a second process to acquire and run concurrently — the
+    // exact TOCTOU race this module exists to prevent. The correct
+    // behavior is to surface a conflict and leave the file alone.
     writeFileSync(LOCK, "", { mode: 0o600 });
 
-    const release = await acquireSnapshotLock(LOCK);
-    try {
-      expect(existsSync(LOCK)).toBe(true);
-    } finally {
-      await release();
-    }
-    expect(existsSync(LOCK)).toBe(false);
+    await expect(acquireSnapshotLock(LOCK)).rejects.toThrow(
+      /^snapshot in progress/,
+    );
+    expect(existsSync(LOCK)).toBe(true);
   });
 });
 
@@ -295,25 +300,34 @@ describe("acquireSnapshotLock — TOCTOU mutual exclusion", () => {
     }
   });
 
-  test("zero-length lock file from partial write is handled without corruption", async () => {
-    // Simulates the "partial write" window: another process has created
-    // the lock via O_EXCL but has not yet written the payload. The inspector
-    // sees an empty file. After retrying, the file is still empty (the
-    // hypothetical writer crashed between open and write). We treat it as
-    // stale and take it over via rename-aside.
+  test("zero-length lock file from partial write is NOT taken over", async () => {
+    // Regression test for the TOCTOU race flagged on PR #24896.
+    //
+    // Window: process A has just succeeded at `openSync(O_EXCL)` but has
+    // not yet flushed `<pid> <timestamp>` to the file. Process B opens
+    // the file and sees zero bytes. If B takes over, it unlinks / renames
+    // A's lock and acquires its own — now both A and B believe they own
+    // the lock and both snapshots run concurrently (WAL corruption, path
+    // clobber, racing retention pruner).
+    //
+    // The fix bounds how many times we re-read an empty file and refuses
+    // takeover if it is still empty after the retry budget is exhausted.
+    // We simulate the live-holder case here by leaving the file empty
+    // throughout the acquire attempt — acquire must throw "snapshot in
+    // progress" and must NOT touch the existing file.
     writeFileSync(LOCK, "", { mode: 0o600 });
     expect(statSync(LOCK).size).toBe(0);
+    const inodeBefore = statSync(LOCK).ino;
 
-    const release = await acquireSnapshotLock(LOCK);
-    try {
-      expect(existsSync(LOCK)).toBe(true);
-      // Must contain our PID after takeover, not be empty.
-      const { readFileSync } = await import("node:fs");
-      const contents = readFileSync(LOCK, "utf-8");
-      expect(contents).toMatch(new RegExp(`^${process.pid} `));
-    } finally {
-      await release();
-    }
+    await expect(acquireSnapshotLock(LOCK)).rejects.toThrow(
+      /^snapshot in progress/,
+    );
+
+    // The original empty file must still exist and must not have been
+    // replaced — if the inode changed, something unlinked/recreated it.
+    expect(existsSync(LOCK)).toBe(true);
+    expect(statSync(LOCK).ino).toBe(inodeBefore);
+    expect(statSync(LOCK).size).toBe(0);
   });
 
   test("rename-aside sideband file is cleaned up after takeover", async () => {

--- a/assistant/src/backup/snapshot-lock.ts
+++ b/assistant/src/backup/snapshot-lock.ts
@@ -56,12 +56,23 @@ const MAX_ACQUIRE_ITERATIONS = 8;
 const ACQUIRE_RETRY_DELAY_MS = 10;
 
 /**
- * Extra delay when we see an empty lock file (suggesting another process
- * is mid-write between `openSync(O_EXCL)` succeeding and `writeSync(payload)`
- * completing). 20ms is plenty of time for the writer to finish a
- * fixed-size `<pid> <timestamp>` payload.
+ * Per-attempt delay when we see an empty lock file (suggesting another
+ * process is mid-write between `openSync(O_EXCL)` succeeding and
+ * `writeSync(payload)` completing). 50ms is comfortably longer than the
+ * write-and-close of a ~30-byte payload even on a loaded host.
  */
-const EMPTY_FILE_RETRY_DELAY_MS = 20;
+const EMPTY_FILE_RETRY_DELAY_MS = 50;
+
+/**
+ * Maximum number of times we re-read an empty lock file before giving up
+ * and treating it as contended. Three retries at 50ms each bound the wait
+ * at ~150ms — long enough to ride out every realistic partial-write
+ * window, short enough that genuine contention surfaces quickly. We must
+ * not unlink an empty file: it could belong to a live holder that has
+ * just won `O_EXCL` but not yet flushed its PID, and unlinking it would
+ * let a second process re-acquire and run concurrently.
+ */
+const EMPTY_FILE_MAX_RETRIES = 3;
 
 /**
  * Returns the canonical path to the snapshot lock file. The lock lives one
@@ -212,9 +223,15 @@ function readLockHolderPid(lockPath: string): number | null {
  *
  * There is a tiny window between `openSync(O_EXCL)` succeeding and
  * `writeSync(payload)` completing where another reader could observe a
- * zero-byte lock file. If we see an empty file on inspection, we sleep
- * briefly and re-read — if it's still empty, we treat it as stale and
- * proceed with the rename-aside takeover.
+ * zero-byte lock file. An empty file is ambiguous: it might be a dead
+ * writer's debris, OR it might belong to a *live* holder that has just
+ * won `O_EXCL` and not yet flushed the PID. We re-read up to
+ * `EMPTY_FILE_MAX_RETRIES` times with a short delay; only a lock file
+ * with a parseable PID whose owner is not running is ever taken over.
+ * If the file is still unreadable after the retry budget, we surface a
+ * conflict — unlinking it would race the live-holder case and risk
+ * letting two snapshots run concurrently (the exact corruption scenario
+ * this lock exists to prevent).
  *
  * ## Bounded retry
  *
@@ -259,13 +276,30 @@ export async function acquireSnapshotLock(
 
     // Partial-write window: the file exists but has no parseable PID. This
     // can happen in the tiny window between `O_EXCL` create and the payload
-    // write, so we retry once after a short sleep.
-    if (holderPid == null) {
+    // write, so we retry a bounded number of times before deciding what to
+    // do with it.
+    for (
+      let retry = 0;
+      retry < EMPTY_FILE_MAX_RETRIES && holderPid == null;
+      retry += 1
+    ) {
       await sleep(EMPTY_FILE_RETRY_DELAY_MS);
       holderPid = readLockHolderPid(lockPath);
     }
 
-    if (holderPid != null && isProcessAlive(holderPid)) {
+    // If the file is still unreadable, a live holder may be mid-write.
+    // Unlinking would let a second acquirer succeed at `O_EXCL` while the
+    // first holder still believes it owns the lock — the TOCTOU double-
+    // acquire this module exists to prevent. Surface as a conflict and
+    // let the caller retry; we only ever take over a lock with a parseable
+    // PID that points at a non-running process.
+    if (holderPid == null) {
+      throw new Error(
+        "snapshot in progress (lock holder unidentified; possible partial write)",
+      );
+    }
+
+    if (isProcessAlive(holderPid)) {
       throw new Error(
         `snapshot in progress (locked by pid ${holderPid})`,
       );


### PR DESCRIPTION
## Summary

Addresses Codex feedback on #24896. `readLockHolderPid()` returns \`null\` not only for dead-writer debris but also for the *live* window between \`openSync(O_EXCL)\` succeeding and \`writeSync(payload)\` completing. The previous code retried once at 20ms and then fell through to stale-takeover — so a second acquirer could rename-aside a live holder's lock and both processes would believe they owned it (the exact double-snapshot scenario this lock exists to prevent).

## Fix

- Retry budget for empty/unreadable lock files raised to 3 × 50ms (~150ms total), comfortably longer than any realistic flush window.
- If the file is still unreadable after retries, throw \`snapshot in progress (lock holder unidentified; possible partial write)\` instead of taking over. Callers already match on the \`snapshot in progress\` prefix (HTTP 409 mapping in \`backup-routes.ts\`).
- Stale-takeover now fires only when the PID is parseable AND its owner is not running.

## Tests

- Updated existing empty-file and unparseable-file tests — the old assertions that these got unlinked-and-reacquired are exactly the behavior Codex flagged.
- New regression test verifies that an empty lock file is preserved (same inode) through an acquire attempt, proving a racing acquirer can no longer destroy a live holder's lock.

## Human attention

Concurrency primitive — see the new stale-detection branch in \`snapshot-lock.ts\` and the retry bound constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25083" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
