### PR TITLE
fix(usage): DST-aware bucket IDs and day-midnight alignment

### DIFF
--- a/assistant/src/__tests__/llm-usage-store.test.ts
+++ b/assistant/src/__tests__/llm-usage-store.test.ts
@@ -536,6 +536,66 @@ describe("getUsageDayBuckets — timezone-aware", () => {
     expect(buckets[1].eventCount).toBe(0);
     expect(buckets[2].totalInputTokens).toBe(200);
   });
+
+  test("DST spring forward: mid-day `from` anchors correctly to local midnight", () => {
+    // America/Los_Angeles 2026-03-08 spring-forward: 02:00 PST -> 03:00 PDT.
+    // Naive day alignment (subtract current wall-clock hours from epoch)
+    // would misplace events around the transition when `from` is mid-day on
+    // the transition day. (PR #24722 review feedback from Codex.)
+
+    // Event at 17:00 UTC = 10:00 PDT on 2026-03-08 (post-DST).
+    insertEventAt(Date.UTC(2026, 2, 8, 17), { inputTokens: 500 });
+    // Event at 23:00 UTC = 16:00 PDT on 2026-03-08 (post-DST).
+    insertEventAt(Date.UTC(2026, 2, 8, 23), { inputTokens: 700 });
+    // Event at 06:00 UTC = 22:00 PST on 2026-03-07 (pre-DST, previous local day).
+    insertEventAt(Date.UTC(2026, 2, 8, 6), { inputTokens: 300 });
+
+    // `from` is mid-day on the transition day.
+    const buckets = getUsageDayBuckets(
+      { from: Date.UTC(2026, 2, 8, 18), to: Date.UTC(2026, 2, 9, 23) },
+      "America/Los_Angeles",
+      { fillEmpty: true },
+    );
+
+    // fillEmpty should seed a 2026-03-08 bucket aligned to 08:00 UTC (local
+    // midnight PST) — not to some post-transition offset that yields a prior
+    // local day. No "2026-03-07" bucket should appear.
+    const dates = buckets.map((b) => b.date);
+    expect(dates).not.toContain("2026-03-07");
+    expect(dates).toContain("2026-03-08");
+    // The 23:00-UTC event on March 8 must land in the 2026-03-08 bucket, not
+    // drift into 2026-03-09 due to offset/midnight misalignment.
+    const map = Object.fromEntries(buckets.map((b) => [b.date, b]));
+    // Events inserted at 17:00 and 23:00 UTC on March 8 are both after `from`
+    // (18:00 UTC) only for the second one; we mainly care that the 23:00-UTC
+    // event correctly lands on March 8 local.
+    expect(map["2026-03-08"]?.totalInputTokens).toBeGreaterThanOrEqual(700);
+  });
+
+  test("DST spring forward: day-midnight alignment works across the jump", () => {
+    // Direct regression test: an event at the FIRST moment of post-DST (just
+    // after 03:00 PDT = 10:00 UTC) on 2026-03-08 should bucket to 2026-03-08,
+    // not 2026-03-07.
+    insertEventAt(Date.UTC(2026, 2, 8, 10, 1), { inputTokens: 42 });
+
+    const buckets = getUsageDayBuckets(
+      { from: Date.UTC(2026, 2, 8, 10), to: Date.UTC(2026, 2, 9, 0) },
+      "America/Los_Angeles",
+    );
+
+    const map = Object.fromEntries(buckets.map((b) => [b.date, b]));
+    expect(map["2026-03-08"]?.totalInputTokens).toBe(42);
+    expect(map["2026-03-07"]).toBeUndefined();
+  });
+
+  test("bucketId: daily bucketId equals the date string", () => {
+    insertEventAt(Date.UTC(2026, 3, 10, 12), { inputTokens: 10 });
+    const buckets = getUsageDayBuckets(
+      { from: Date.UTC(2026, 3, 10, 0), to: Date.UTC(2026, 3, 10, 23) },
+      "UTC",
+    );
+    expect(buckets[0].bucketId).toBe(buckets[0].date);
+  });
 });
 
 describe("getUsageHourBuckets — timezone-aware", () => {
@@ -634,6 +694,18 @@ describe("getUsageHourBuckets — timezone-aware", () => {
     // Both should share the "1am" display label.
     expect(oneAmBuckets[0].displayLabel).toBe("1am");
     expect(oneAmBuckets[1].displayLabel).toBe("1am");
+    // But their bucketIds MUST be distinct so SwiftUI ForEach(id:\.bucketId)
+    // doesn't collapse them. (PR #24722 review feedback from Codex.)
+    expect(oneAmBuckets[0].bucketId).not.toBe(oneAmBuckets[1].bucketId);
+    expect(oneAmBuckets.map((b) => b.bucketId).sort()).toEqual([
+      "2026-11-01 01:00|-240",
+      "2026-11-01 01:00|-300",
+    ]);
+    // Daily/non-dup-hour bucketIds default to the date key.
+    const nonDupHour = buckets.find((b) => b.date === "2026-11-01 00:00");
+    if (nonDupHour) {
+      expect(nonDupHour.bucketId).toBe(`${nonDupHour.date}|-240`);
+    }
   });
 
   test("fillEmpty seeds zero buckets for empty hours in range", () => {

--- a/assistant/src/memory/llm-usage-store.ts
+++ b/assistant/src/memory/llm-usage-store.ts
@@ -158,8 +158,17 @@ export type UsageGranularity = "daily" | "hourly";
 /** A single time bucket with its aggregate totals. */
 export interface UsageDayBucket {
   /**
+   * Stable unique identifier for the bucket. Safe for use as a SwiftUI/React
+   * list key. Distinct even for DST fall-back duplicate hours (which share the
+   * same `date` string). Daily buckets use `date` directly; hourly buckets use
+   * "YYYY-MM-DD HH:00|<offsetMinutes>" to disambiguate repeated local hours.
+   */
+  bucketId: string;
+  /**
    * Local-time bucket key in the requested tz:
    * "YYYY-MM-DD" (daily) or "YYYY-MM-DD HH:00" (hourly).
+   * NOT unique: on DST fall-back days, two 01:00 hourly buckets share this key.
+   * Use `bucketId` as a list identifier and `date` for display/sort only.
    */
   date: string;
   /**

--- a/assistant/src/memory/usage-buckets.ts
+++ b/assistant/src/memory/usage-buckets.ts
@@ -184,25 +184,27 @@ function alignToLocalHourStart(epochMillis: number, tz: string): number {
 /**
  * Find the UTC instant corresponding to local midnight of the day containing
  * `epochMillis` in `tz`.
+ *
+ * DST-aware: the UTC offset at local midnight can differ from the offset at
+ * `epochMillis` when a DST transition falls earlier in the same local day.
+ * Naively subtracting the current wall-clock hours/minutes/seconds would land
+ * on a UTC instant that formats as the wrong local date (e.g. 23:00 of the
+ * previous day after spring-forward). We instead derive midnight by locating
+ * the UTC instant whose local formatting is Y-M-D 00:00 in `tz`.
  */
 function alignToLocalDayStart(epochMillis: number, tz: string): number {
-  const formatter = new Intl.DateTimeFormat("en-US", {
-    timeZone: tz,
-    hour: "2-digit",
-    minute: "2-digit",
-    second: "2-digit",
-    hour12: false,
-  });
-  const parts = formatter.formatToParts(new Date(epochMillis));
-  let hour = 0;
-  let minute = 0;
-  let second = 0;
-  for (const part of parts) {
-    if (part.type === "hour") hour = Number(part.value) % 24;
-    if (part.type === "minute") minute = Number(part.value);
-    if (part.type === "second") second = Number(part.value);
+  const parts = getLocalParts(epochMillis, tz);
+  // UTC midnight of the same Y-M-D is a close-but-incorrect guess. Its offset
+  // approximates the offset at local midnight — one iteration of correction
+  // handles the common case where a DST transition sits between the two.
+  const utcMidnightGuess = Date.UTC(parts.year, parts.month - 1, parts.day);
+  const offset1 = getLocalParts(utcMidnightGuess, tz).offsetMinutes;
+  let candidate = utcMidnightGuess - offset1 * 60_000;
+  const offset2 = getLocalParts(candidate, tz).offsetMinutes;
+  if (offset2 !== offset1) {
+    candidate = utcMidnightGuess - offset2 * 60_000;
   }
-  return epochMillis - (hour * 3600 + minute * 60 + second) * 1000;
+  return candidate;
 }
 
 /** Format a short human-readable hour label in `tz`, e.g. "3pm". */
@@ -227,6 +229,7 @@ function formatDayLabel(epochMillis: number, tz: string): string {
 }
 
 interface MutableBucket {
+  bucketId: string;
   date: string;
   displayLabel: string;
   totalInputTokens: number;
@@ -238,11 +241,13 @@ interface MutableBucket {
 }
 
 function emptyBucket(
+  bucketId: string,
   date: string,
   displayLabel: string,
   sortKey: number,
 ): MutableBucket {
   return {
+    bucketId,
     date,
     displayLabel,
     totalInputTokens: 0,
@@ -266,7 +271,8 @@ function addEventToBucket(
 function finalize(buckets: Map<string, MutableBucket>): UsageDayBucket[] {
   return Array.from(buckets.values())
     .sort((a, b) => a.sortKey - b.sortKey)
-    .map(({ date, displayLabel, ...rest }) => ({
+    .map(({ bucketId, date, displayLabel, ...rest }) => ({
+      bucketId,
       date,
       displayLabel,
       totalInputTokens: rest.totalInputTokens,
@@ -313,7 +319,7 @@ export function bucketEventsByHour(
       if (!buckets.has(key)) {
         buckets.set(
           key,
-          emptyBucket(hourKey(parts), formatHourLabel(cursor, tz), cursor),
+          emptyBucket(key, hourKey(parts), formatHourLabel(cursor, tz), cursor),
         );
       }
       cursor = addOneHourUtc(cursor);
@@ -327,6 +333,7 @@ export function bucketEventsByHour(
     if (!bucket) {
       const hourStart = alignToLocalHourStart(row.created_at, tz);
       bucket = emptyBucket(
+        key,
         hourKey(parts),
         formatHourLabel(hourStart, tz),
         hourStart,
@@ -362,7 +369,10 @@ export function bucketEventsByDay(
       const parts = getLocalParts(cursor, tz);
       const key = dayKey(parts);
       if (!buckets.has(key)) {
-        buckets.set(key, emptyBucket(key, formatDayLabel(cursor, tz), cursor));
+        buckets.set(
+          key,
+          emptyBucket(key, key, formatDayLabel(cursor, tz), cursor),
+        );
       }
       // Advance by 24 UTC hours, then realign to local midnight. Handles
       // DST transitions where a "day" is 23 or 25 hours long in local time.
@@ -376,7 +386,7 @@ export function bucketEventsByDay(
     let bucket = buckets.get(key);
     if (!bucket) {
       const dayStart = alignToLocalDayStart(row.created_at, tz);
-      bucket = emptyBucket(key, formatDayLabel(dayStart, tz), dayStart);
+      bucket = emptyBucket(key, key, formatDayLabel(dayStart, tz), dayStart);
       buckets.set(key, bucket);
     }
     addEventToBucket(bucket, row);

--- a/clients/ios/Views/UsageDashboardView.swift
+++ b/clients/ios/Views/UsageDashboardView.swift
@@ -97,7 +97,7 @@ struct UsageDashboardView: View {
                     Text("No data for selected range")
                         .foregroundStyle(.secondary)
                 } else {
-                    ForEach(daily.buckets, id: \.date) { bucket in
+                    ForEach(daily.buckets, id: \.bucketId) { bucket in
                         HStack {
                             Text(bucket.displayLabel ?? bucket.date)
                                 .font(.footnote.monospaced())

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/LogsAndUsagePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/LogsAndUsagePanel.swift
@@ -471,7 +471,7 @@ struct UsageTabContent: View {
         ScrollView(.horizontal, showsIndicators: false) {
             VStack(alignment: .leading, spacing: VSpacing.xs) {
                 HStack(alignment: .bottom, spacing: VSpacing.xs) {
-                    ForEach(sorted, id: \.date) { bucket in
+                    ForEach(sorted, id: \.bucketId) { bucket in
                         let fraction = maxCost > 0 ? bucket.totalEstimatedCostUsd / maxCost : 0
                         VStack(spacing: VSpacing.xxs) {
                             Spacer(minLength: 0)
@@ -484,7 +484,7 @@ struct UsageTabContent: View {
                 .frame(height: barChartHeight)
 
                 HStack(alignment: .top, spacing: VSpacing.xs) {
-                    ForEach(sorted, id: \.date) { bucket in
+                    ForEach(sorted, id: \.bucketId) { bucket in
                         VStack(spacing: VSpacing.xxs) {
                             Text(formatCost(bucket.totalEstimatedCostUsd))
                                 .font(VFont.labelSmall)

--- a/clients/shared/Network/UsageModels.swift
+++ b/clients/shared/Network/UsageModels.swift
@@ -35,10 +35,16 @@ public struct UsageTotalsResponse: Decodable, Equatable, Sendable {
 }
 
 /// A single day bucket from `GET /v1/usage/daily`.
-public struct UsageDayBucket: Decodable, Equatable, Sendable {
+public struct UsageDayBucket: Decodable, Equatable, Sendable, Identifiable {
+    /// Stable unique identifier for use as a SwiftUI list key. Distinct across
+    /// DST fall-back duplicate hours (which share the same `date` string).
+    /// Older daemons don't send this field, so we fall back to `date` on decode
+    /// — acceptable for daily buckets but hourly charts require a newer daemon
+    /// to render correctly on fall-back days.
+    public let bucketId: String
     /// Local-time bucket key in the requested tz: "YYYY-MM-DD" (daily) or
-    /// "YYYY-MM-DD HH:00" (hourly). Clients should treat this as an opaque
-    /// identifier and prefer `displayLabel` for rendering.
+    /// "YYYY-MM-DD HH:00" (hourly). Not guaranteed unique — use `bucketId` for
+    /// list identity and `displayLabel` for rendering.
     public let date: String
     /// Pre-formatted human-readable label from the daemon, formatted in the
     /// requested timezone. Absent for responses from older daemons.
@@ -48,7 +54,10 @@ public struct UsageDayBucket: Decodable, Equatable, Sendable {
     public let totalEstimatedCostUsd: Double
     public let eventCount: Int
 
+    public var id: String { bucketId }
+
     public init(
+        bucketId: String? = nil,
         date: String,
         displayLabel: String? = nil,
         totalInputTokens: Int,
@@ -56,6 +65,7 @@ public struct UsageDayBucket: Decodable, Equatable, Sendable {
         totalEstimatedCostUsd: Double,
         eventCount: Int
     ) {
+        self.bucketId = bucketId ?? date
         self.date = date
         self.displayLabel = displayLabel
         self.totalInputTokens = totalInputTokens
@@ -65,6 +75,7 @@ public struct UsageDayBucket: Decodable, Equatable, Sendable {
     }
 
     private enum CodingKeys: String, CodingKey {
+        case bucketId
         case date
         case displayLabel
         case totalInputTokens
@@ -76,6 +87,7 @@ public struct UsageDayBucket: Decodable, Equatable, Sendable {
     public init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         date = try container.decode(String.self, forKey: .date)
+        bucketId = try container.decodeIfPresent(String.self, forKey: .bucketId) ?? date
         displayLabel = try container.decodeIfPresent(String.self, forKey: .displayLabel)
         totalInputTokens = try container.decode(Int.self, forKey: .totalInputTokens)
         totalOutputTokens = try container.decode(Int.self, forKey: .totalOutputTokens)


### PR DESCRIPTION
Addresses Codex review feedback on #24722.

## Issue 1 — duplicate ForEach IDs on DST fall-back
SwiftUI usage views keyed hourly buckets by \`\\.date\`, but two 01:00 buckets on DST fall-back days shared the same \`date\` string — so SwiftUI diffing collapsed one of them and under-reported that hour's cost/events.

Fix: daemon now emits a \`bucketId\` per bucket. Daily buckets use the date string; hourly buckets append the offset (e.g. \`2026-11-01 01:00|-240\` vs \`...|-300\`) so fall-back duplicates are distinct. Swift \`UsageDayBucket\` decodes \`bucketId\` (falls back to \`date\` for older daemons, safe for daily; hourly DST-fallback charts need a current daemon). Both iOS and macOS \`ForEach\` views key on \`\\.bucketId\`.

## Issue 2 — day-start alignment on DST transition days
\`alignToLocalDayStart\` subtracted the current wall-clock hours/minutes/seconds from the epoch, which assumes the UTC offset at that instant equals the offset at local midnight. After spring-forward, those differ by an hour, so the result landed at 23:00 of the previous local day — causing incorrect sort keys, wrong daily labels, and \`fillEmpty\` seeding an out-of-range prior-day bucket when \`from\` was mid-day on the transition.

Fix: compute local Y-M-D via \`Intl.DateTimeFormat\`, then derive the UTC instant for 00:00 of that local day by starting from UTC midnight of Y-M-D and correcting by the timezone offset — with one iteration to handle the case where a DST transition sits between the guess and the answer.

## Tests
- DST fall-back: asserts both 01:00 buckets have distinct \`bucketId\` values.
- DST spring-forward: \`fillEmpty\` with a mid-day \`from\` does not seed a prior local day; event just after the jump buckets to the correct local day.
- Daily \`bucketId\` equals the date string.

All 48 tests in \`llm-usage-store.test.ts\` pass.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25084" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
