### PR TITLE
fix(backup): bootstrap iCloud default path by creating intermediate dirs under a known ancestor

### DIFF
--- a/assistant/src/backup/__tests__/offsite-writer.test.ts
+++ b/assistant/src/backup/__tests__/offsite-writer.test.ts
@@ -6,6 +6,7 @@
 
 import { randomBytes } from "node:crypto";
 import {
+  chmodSync,
   existsSync,
   mkdirSync,
   mkdtempSync,
@@ -155,6 +156,129 @@ describe("writeOffsiteSnapshotToOne", () => {
 
     // No stray .tmp sibling left behind.
     expect(existsSync(`${result.entry!.path}.tmp`)).toBe(false);
+  });
+
+  test("bootstraps intermediate directories under the iCloud Drive safe ancestor on first run", async () => {
+    // Redirect HOME so `getICloudDriveRoot()` resolves inside our temp ROOT.
+    // This is the key regression: on first install only the iCloud Drive root
+    // exists; `VellumAssistant/backups/` needs to be created by the writer.
+    const ORIGINAL_HOME = process.env.HOME;
+    process.env.HOME = ROOT;
+    try {
+      const iCloudRoot = join(
+        ROOT,
+        "Library",
+        "Mobile Documents",
+        "com~apple~CloudDocs",
+      );
+      mkdirSync(iCloudRoot, { recursive: true });
+      // Destination is two levels below the safe ancestor — neither of the
+      // intermediate dirs exists yet.
+      const destinationPath = join(iCloudRoot, "VellumAssistant", "backups");
+      expect(existsSync(destinationPath)).toBe(false);
+
+      const plaintext = randomBytes(512);
+      const localSnapshotPath = seedLocalSnapshot(plaintext);
+      const destination: BackupDestination = {
+        path: destinationPath,
+        encrypt: true,
+      };
+      const key = randomBytes(32);
+
+      const result = await writeOffsiteSnapshotToOne(
+        localSnapshotPath,
+        destination,
+        key,
+        NOW,
+      );
+
+      expect(result.skipped).toBeUndefined();
+      expect(result.error).toBeUndefined();
+      expect(result.entry).not.toBeNull();
+      expect(existsSync(destinationPath)).toBe(true);
+      expect(existsSync(result.entry!.path)).toBe(true);
+    } finally {
+      if (ORIGINAL_HOME === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = ORIGINAL_HOME;
+      }
+    }
+  });
+
+  test("iCloud default path is still skipped when the iCloud Drive root is missing", async () => {
+    // Same shape as the previous test, but we do NOT create the iCloud Drive
+    // root — simulates iCloud Drive disabled. The destination must stay
+    // skipped rather than bootstrapping the tree under an arbitrary location.
+    const ORIGINAL_HOME = process.env.HOME;
+    process.env.HOME = ROOT;
+    try {
+      const iCloudRoot = join(
+        ROOT,
+        "Library",
+        "Mobile Documents",
+        "com~apple~CloudDocs",
+      );
+      expect(existsSync(iCloudRoot)).toBe(false);
+
+      const destinationPath = join(iCloudRoot, "VellumAssistant", "backups");
+      const localSnapshotPath = seedLocalSnapshot("payload");
+      const destination: BackupDestination = {
+        path: destinationPath,
+        encrypt: true,
+      };
+
+      const result = await writeOffsiteSnapshotToOne(
+        localSnapshotPath,
+        destination,
+        randomBytes(32),
+        NOW,
+      );
+
+      expect(result.skipped).toBe("parent-missing");
+      expect(result.entry).toBeNull();
+      expect(result.error).toBeUndefined();
+      expect(existsSync(destinationPath)).toBe(false);
+      // Critical: no intermediate directories were materialized.
+      expect(existsSync(join(iCloudRoot, "VellumAssistant"))).toBe(false);
+    } finally {
+      if (ORIGINAL_HOME === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = ORIGINAL_HOME;
+      }
+    }
+  });
+
+  test("permissions error on mkdir is surfaced as result.error rather than thrown", async () => {
+    // Root directory exists but is not writable, so `mkdir -p destination` fails
+    // with EACCES. The writer must catch it and surface via `error` to keep
+    // a broken destination from poisoning the others.
+    const readOnlyParent = subPath("read-only");
+    mkdirSync(readOnlyParent, { recursive: true });
+    chmodSync(readOnlyParent, 0o500); // r-x only: stat works, mkdir fails
+    try {
+      const destination: BackupDestination = {
+        path: join(readOnlyParent, "backups"),
+        encrypt: false,
+      };
+      const localSnapshotPath = seedLocalSnapshot("payload");
+
+      const result = await writeOffsiteSnapshotToOne(
+        localSnapshotPath,
+        destination,
+        null,
+        NOW,
+      );
+
+      expect(result.entry).toBeNull();
+      expect(result.skipped).toBeUndefined();
+      expect(result.error).toBeDefined();
+      expect(result.error).toMatch(/EACCES|permission/i);
+    } finally {
+      // Restore writable perms so the afterEach rmSync can clean up.
+      chmodSync(readOnlyParent, 0o700);
+    }
   });
 
   test("encrypt=true with key=null returns an error (caught internally, not thrown)", async () => {

--- a/assistant/src/backup/__tests__/paths.test.ts
+++ b/assistant/src/backup/__tests__/paths.test.ts
@@ -1,10 +1,14 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
 import { afterEach, describe, expect, test } from "bun:test";
 
 import {
+  deriveSafeAncestor,
   formatBackupFilename,
   getBackupKeyPath,
   getBackupRootDir,
   getDefaultOffsiteBackupsDir,
+  getICloudDriveRoot,
   getLocalBackupsDir,
   parseBackupTimestamp,
   resolveOffsiteDestinations,
@@ -78,6 +82,46 @@ describe("VELLUM_BACKUP_DIR override", () => {
     expect(getSnapshotLockPath()).toMatch(
       /\/\.vellum\/backups\/\.snapshot\.lock$/,
     );
+  });
+});
+
+describe("deriveSafeAncestor", () => {
+  test("iCloud Drive subtree anchors on the iCloud Drive root", () => {
+    const iCloudRoot = getICloudDriveRoot();
+    expect(deriveSafeAncestor(join(iCloudRoot, "VellumAssistant", "backups")))
+      .toBe(iCloudRoot);
+    // The default offsite path specifically — this is the regression the
+    // feature exists to fix.
+    expect(deriveSafeAncestor(getDefaultOffsiteBackupsDir())).toBe(iCloudRoot);
+  });
+
+  test("the iCloud Drive root itself is its own safe ancestor", () => {
+    const iCloudRoot = getICloudDriveRoot();
+    expect(deriveSafeAncestor(iCloudRoot)).toBe(iCloudRoot);
+  });
+
+  test("paths under /Volumes/<name> anchor on the volume root", () => {
+    expect(deriveSafeAncestor("/Volumes/MyExtSSD/vellum/backups")).toBe(
+      "/Volumes/MyExtSSD",
+    );
+    expect(deriveSafeAncestor("/Volumes/MyExtSSD")).toBe("/Volumes/MyExtSSD");
+  });
+
+  test("arbitrary user paths fall back to the immediate parent", () => {
+    // Preserves the pre-fix conservative behavior where we only mkdir the
+    // leaf directory and require its parent to exist — we have no reliable
+    // mount signal for arbitrary paths.
+    expect(deriveSafeAncestor("/tmp/some/where/backups")).toBe(
+      "/tmp/some/where",
+    );
+    expect(
+      deriveSafeAncestor(join(homedir(), "Documents", "vellum-backups")),
+    ).toBe(join(homedir(), "Documents"));
+  });
+
+  test("bare /Volumes (no volume name) falls back to dirname", () => {
+    // `/Volumes` itself is not a volume mount; treat it like any other path.
+    expect(deriveSafeAncestor("/Volumes")).toBe("/");
   });
 });
 

--- a/assistant/src/backup/offsite-writer.ts
+++ b/assistant/src/backup/offsite-writer.ts
@@ -21,14 +21,14 @@
  */
 
 import { copyFile, mkdir, rename, stat } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import { join } from "node:path";
 
 import type { BackupDestination } from "../config/schema.js";
 import {
   pruneDir,
   type SnapshotEntry,
 } from "./list-snapshots.js";
-import { formatBackupFilename } from "./paths.js";
+import { deriveSafeAncestor, formatBackupFilename } from "./paths.js";
 import { encryptFile } from "./stream-crypt.js";
 
 /**
@@ -36,9 +36,13 @@ import { encryptFile } from "./stream-crypt.js";
  *
  * Exactly one of `entry`, `skipped`, or `error` is meaningful:
  * - `entry` non-null → the write succeeded.
- * - `skipped: "parent-missing"` → the destination's parent directory does
- *   not exist (e.g. iCloud Drive not enabled, external volume unplugged).
- *   Not an error — the write is simply deferred until the volume is back.
+ * - `skipped: "parent-missing"` → the destination's safe ancestor does not
+ *   exist (e.g. iCloud Drive not enabled, external volume unplugged). Not an
+ *   error — the write is simply deferred until the volume is back. The
+ *   ancestor is derived by `deriveSafeAncestor`: for iCloud Drive or
+ *   `/Volumes/<name>/...` paths it is a well-known mount root, which lets us
+ *   bootstrap intermediate directories on first run; for arbitrary
+ *   user-configured paths it falls back to the immediate parent.
  * - `error` set → an unexpected failure while writing. Surfaced as a string
  *   so callers can log without serializing an `Error` object.
  *
@@ -56,11 +60,14 @@ export interface OffsiteWriteResult {
  * Write a local snapshot to a single offsite destination.
  *
  * Behavior:
- * - If `dirname(destination.path)` does not exist → returns
- *   `{ destination, entry: null, skipped: "parent-missing" }`. The offsite
- *   volume is (temporarily) unavailable; the caller should not treat this
- *   as an error.
- * - Otherwise `mkdir -p` the destination directory (mode `0o700`).
+ * - If the destination's safe ancestor (see `deriveSafeAncestor`) does not
+ *   exist → returns `{ destination, entry: null, skipped: "parent-missing" }`.
+ *   The offsite volume is (temporarily) unavailable; the caller should not
+ *   treat this as an error.
+ * - Otherwise `mkdir -p` the destination directory (mode `0o700`). This
+ *   bootstraps any intermediate directories between the safe ancestor and
+ *   the destination (e.g. creating `VellumAssistant/backups/` under iCloud
+ *   Drive on first run).
  * - If `destination.encrypt === true`, stream-encrypts via `encryptFile`
  *   with the provided `key` and writes `.vbundle.enc`. A missing `key`
  *   here is a programmer error, but per the plan we still catch it rather
@@ -78,11 +85,15 @@ export async function writeOffsiteSnapshotToOne(
   now: Date,
 ): Promise<OffsiteWriteResult> {
   try {
-    // Parent-missing probe: if the parent directory of `destination.path`
+    // Ancestor-missing probe: if the destination's derived "safe ancestor"
     // does not exist we treat the destination as temporarily unavailable
-    // rather than auto-creating a deep tree we have no reason to own.
+    // rather than auto-creating a deep tree we have no reason to own. The
+    // ancestor is a well-known mount root (iCloud Drive, /Volumes/<name>)
+    // for recognized path shapes, or the immediate parent otherwise. That
+    // way an unplugged external drive still skips cleanly while the default
+    // iCloud destination can bootstrap its intermediate folders on first run.
     try {
-      await stat(dirname(destination.path));
+      await stat(deriveSafeAncestor(destination.path));
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code === "ENOENT") {
         return { destination, entry: null, skipped: "parent-missing" };

--- a/assistant/src/backup/paths.ts
+++ b/assistant/src/backup/paths.ts
@@ -38,19 +38,73 @@ export function getLocalBackupsDir(override?: string | null): string {
 }
 
 /**
+ * Returns the iCloud Drive root on macOS. This is the "safe ancestor" we use
+ * for bootstrapping the default offsite path: if this directory exists iCloud
+ * Drive is enabled and we can safely `mkdir -p` the `VellumAssistant/backups`
+ * subtree below it.
+ *
+ * Reads `process.env.HOME` at call time before falling back to `homedir()`.
+ * `homedir()` is snapshot at process start on some platforms, so consulting
+ * `$HOME` on each call keeps this function honest under tests that redirect
+ * the home directory mid-process.
+ */
+export function getICloudDriveRoot(): string {
+  const home = process.env.HOME ?? homedir();
+  return join(
+    home,
+    "Library",
+    "Mobile Documents",
+    "com~apple~CloudDocs",
+  );
+}
+
+/**
  * Returns the default offsite backups directory — the iCloud Drive path under
  * the VellumAssistant namespace. Used when no explicit offsite destinations
  * are configured.
  */
 export function getDefaultOffsiteBackupsDir(): string {
-  return join(
-    homedir(),
-    "Library",
-    "Mobile Documents",
-    "com~apple~CloudDocs",
-    "VellumAssistant",
-    "backups",
-  );
+  return join(getICloudDriveRoot(), "VellumAssistant", "backups");
+}
+
+/**
+ * Derive the "safe ancestor" for an offsite destination — a directory that
+ * must already exist on disk before we are willing to create intermediate
+ * directories under it. If the ancestor exists we `mkdir -p destinationPath`;
+ * if it is missing we skip the destination (treating it as a transient
+ * unavailability like an unplugged drive or disabled iCloud Drive).
+ *
+ * Derivation rules:
+ *   - iCloud Drive subtrees (`~/Library/Mobile Documents/com~apple~CloudDocs/...`)
+ *     anchor on the iCloud Drive root. This lets the default destination
+ *     (`.../VellumAssistant/backups`) bootstrap on first run without the user
+ *     having to pre-create the `VellumAssistant` folder.
+ *   - `/Volumes/<name>/...` paths anchor on `/Volumes/<name>`, the macOS
+ *     volume mount point. An unmounted drive has no entry in `/Volumes`, so
+ *     its destination is correctly skipped rather than bootstrapped on the
+ *     root filesystem.
+ *   - Everything else falls back to `dirname(destinationPath)` — the original
+ *     conservative behavior, preserved for arbitrary user-configured paths
+ *     where we have no reliable mount signal.
+ */
+export function deriveSafeAncestor(destinationPath: string): string {
+  const iCloudRoot = getICloudDriveRoot();
+  if (
+    destinationPath === iCloudRoot ||
+    destinationPath.startsWith(`${iCloudRoot}/`)
+  ) {
+    return iCloudRoot;
+  }
+  const volumesPrefix = "/Volumes/";
+  if (destinationPath.startsWith(volumesPrefix)) {
+    const rest = destinationPath.slice(volumesPrefix.length);
+    const slash = rest.indexOf("/");
+    const volumeName = slash === -1 ? rest : rest.slice(0, slash);
+    if (volumeName.length > 0) {
+      return `${volumesPrefix}${volumeName}`;
+    }
+  }
+  return dirname(destinationPath);
 }
 
 /**


### PR DESCRIPTION
## Summary

Addresses Codex feedback on #24887: the offsite preflight check used
`dirname(destination.path)` as the existence probe, which meant the default
iCloud destination (`.../com~apple~CloudDocs/VellumAssistant/backups`) stayed
permanently `skipped: "parent-missing"` on fresh installs — the
`VellumAssistant` folder doesn't exist yet on first run, so no offsite
snapshot was ever written until the user manually created the tree.

This PR introduces a per-destination **safe ancestor** concept: each
destination derives an ancestor directory that must already exist before the
writer is willing to `mkdir -p` the full destination path.

- iCloud Drive subtrees (`~/Library/Mobile Documents/com~apple~CloudDocs/...`)
  anchor on the iCloud Drive root. If iCloud Drive is enabled the writer now
  bootstraps `VellumAssistant/backups/` on first run; if iCloud Drive is
  disabled the destination still skips cleanly.
- `/Volumes/<name>/...` paths anchor on the volume mount root. An unmounted
  external disk has no `/Volumes/<name>` entry, so it is still skipped
  rather than writing into the root filesystem.
- Arbitrary user-configured paths fall back to the original conservative
  behavior (`dirname(path)` must exist) — we have no reliable mount signal
  so we don't auto-create arbitrary trees.

## Files modified

- `assistant/src/backup/paths.ts` — added `getICloudDriveRoot()` and
  `deriveSafeAncestor()`; refactored `getDefaultOffsiteBackupsDir()` to
  reuse the new iCloud root helper. `getICloudDriveRoot()` reads
  `process.env.HOME` before falling back to `os.homedir()` so test redirects
  actually take effect.
- `assistant/src/backup/offsite-writer.ts` — replaced the
  `stat(dirname(destination.path))` probe with
  `stat(deriveSafeAncestor(destination.path))`; updated doc comments.
- `assistant/src/backup/__tests__/paths.test.ts` — unit tests for the
  derivation rules (iCloud subtrees, `/Volumes/<name>`, fallback to
  `dirname`).
- `assistant/src/backup/__tests__/offsite-writer.test.ts` — added three
  integration tests: bootstrap succeeds when iCloud Drive root exists,
  bootstrap is skipped when iCloud Drive root is missing (no intermediate
  dirs materialized), and mkdir permission failures surface as
  `result.error` rather than throwing.

## Test plan

- [x] `bun test src/backup/__tests__/` — 133 tests pass
- [x] `bunx tsc --noEmit` — clean
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25085" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
