### PR TITLE
fix: Use terminal icon for skills.sh in VSkillTypePill

### DIFF
--- a/clients/shared/DesignSystem/Core/Feedback/VSkillTypePill.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VSkillTypePill.swift
@@ -22,7 +22,8 @@ public struct VSkillTypePill: View {
         var vIcon: VIcon {
             switch self {
             case .vellum: return .package
-            case .clawhub, .skillssh: return .globe
+            case .clawhub: return .globe
+            case .skillssh: return .terminal
             case .custom: return .user
             case .other(_, let icon, _, _): return .resolve(icon)
             }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for split-community-filter.md.

**Gap:** Icon mismatch between SkillFilter dropdown and VSkillTypePill for skills.sh
**What was expected:** The filter icon and the skill card pill icon for skills.sh should be visually consistent.
**What was found:** VSkillTypePill used globe for both clawhub and skillssh, but the new filter uses terminal for skillssh.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25089" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
