### PR TITLE
Split Community filter into Clawhub and skills.sh filters

### DIFF
--- a/clients/ios/Views/Intelligence/SkillDetailView.swift
+++ b/clients/ios/Views/Intelligence/SkillDetailView.swift
@@ -293,8 +293,8 @@ struct SkillDetailView: View {
     private func originLabel(_ origin: String) -> String {
         switch origin {
         case "vellum": return "Core"
-        case "clawhub": return "Community"
-        case "skillssh": return "Community"
+        case "clawhub": return "Clawhub"
+        case "skillssh": return "skills.sh"
         case "custom": return "Created"
         default: return origin.capitalized
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -167,7 +167,7 @@ struct AgentPanelContent: View {
             VDropdown(
                 options: SkillFilter.allCases.map { VDropdownOption(label: $0.rawValue, value: $0, icon: $0.icon) },
                 selection: $skillsManager.skillFilter,
-                maxWidth: 130
+                maxWidth: 140
             )
         }
     }
@@ -214,7 +214,8 @@ struct AgentPanelContent: View {
         case .installed: return "No Skills Installed"
         case .available: return "No Skills Available"
         case .vellum: return "No Vellum Skills"
-        case .community: return "No Community Skills"
+        case .clawhub: return "No Clawhub Skills"
+        case .skillssh: return "No skills.sh Skills"
         case .custom: return "No Custom Skills"
         }
     }
@@ -228,7 +229,8 @@ struct AgentPanelContent: View {
         case .installed: return "Ask your assistant in chat to search for and install new skills."
         case .available: return "All available skills have been installed."
         case .vellum: return "No bundled Vellum skills found."
-        case .community: return "No Community skills found. Try installing some from the catalog."
+        case .clawhub: return "No Clawhub skills found. Try searching the catalog."
+        case .skillssh: return "No skills.sh skills found. Try searching the catalog."
         case .custom: return "Create a custom skill by describing what you want in chat."
         }
     }
@@ -242,7 +244,8 @@ struct AgentPanelContent: View {
         case .installed: return VIcon.zap.rawValue
         case .available: return VIcon.circleCheck.rawValue
         case .vellum: return VIcon.package.rawValue
-        case .community: return VIcon.globe.rawValue
+        case .clawhub: return VIcon.globe.rawValue
+        case .skillssh: return VIcon.terminal.rawValue
         case .custom: return VIcon.user.rawValue
         }
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
@@ -8,7 +8,8 @@ enum SkillFilter: String, CaseIterable {
     case installed = "Installed"
     case available = "Available"
     case vellum = "Vellum"
-    case community = "Community"
+    case clawhub = "Clawhub"
+    case skillssh = "skills.sh"
     case custom = "Custom"
 
     var icon: VIcon {
@@ -17,13 +18,14 @@ enum SkillFilter: String, CaseIterable {
         case .installed: return .circleCheck
         case .available: return .arrowDownToLine
         case .vellum: return .package
-        case .community: return .globe
+        case .clawhub: return .globe
+        case .skillssh: return .terminal
         case .custom: return .user
         }
     }
 
     static var statusFilters: [SkillFilter] { [.all, .installed, .available] }
-    static var sourceFilters: [SkillFilter] { [.vellum, .community, .custom] }
+    static var sourceFilters: [SkillFilter] { [.vellum, .clawhub, .skillssh, .custom] }
 }
 
 @MainActor
@@ -239,8 +241,10 @@ final class SkillsManager {
             baseSkills = skills.filter { $0.isAvailable }
         case .vellum:
             baseSkills = skills.filter { $0.origin == "vellum" }
-        case .community:
-            baseSkills = skills.filter { $0.origin == "clawhub" || $0.origin == "skillssh" }
+        case .clawhub:
+            baseSkills = skills.filter { $0.origin == "clawhub" }
+        case .skillssh:
+            baseSkills = skills.filter { $0.origin == "skillssh" }
         case .custom:
             baseSkills = skills.filter { $0.origin == "custom" }
         }
@@ -320,7 +324,7 @@ final class SkillsManager {
 
     /// Whether a search query matches any searchable term for a skill origin.
     /// Includes both the display label (e.g. "Clawhub") and the umbrella
-    /// category "community" so users can still search for community skills.
+    /// term "community" so users can still discover community skills by searching.
     static func originMatchesQuery(_ origin: String, query: String) -> Bool {
         if sourceLabel(origin).lowercased().contains(query) { return true }
         if (origin == "clawhub" || origin == "skillssh") && "community".contains(query) { return true }

--- a/clients/shared/DesignSystem/Core/Feedback/VSkillTypePill.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VSkillTypePill.swift
@@ -22,7 +22,8 @@ public struct VSkillTypePill: View {
         var vIcon: VIcon {
             switch self {
             case .vellum: return .package
-            case .clawhub, .skillssh: return .globe
+            case .clawhub: return .globe
+            case .skillssh: return .terminal
             case .custom: return .user
             case .other(_, let icon, _, _): return .resolve(icon)
             }


### PR DESCRIPTION
## Summary
Replace the single "Community" filter in the skills manager dropdown with two distinct filters — "Clawhub" and "skills.sh" — so users can filter skill searches to a specific community source.

## Self-review result
PASS — 1 gap found and fixed (VSkillTypePill icon inconsistency)

## PRs merged into feature branch
- #25086: Split Community filter into Clawhub and skills.sh filters
  
### Fix PRs
- #25089: fix: Use terminal icon for skills.sh in VSkillTypePill

## Changes
- `SkillFilter` enum: replaced `.community` with `.clawhub` and `.skillssh`
- Filter logic: each new filter independently filters by its specific origin
- Empty states: distinct title, subtitle, and icon for each new filter
- VSkillTypePill: `.skillssh` now uses `.terminal` icon (matching the filter)
- iOS SkillDetailView: origin labels updated from "Community" to "Clawhub"/"skills.sh"
- Search: "community" preserved as a search synonym for backward compatibility
- VDropdown maxWidth increased from 130 to 140

Part of plan: split-community-filter.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25090" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
