### PR TITLE
fix(unicode): species-safe array clone in sanitizeSurrogates

### DIFF
--- a/assistant/src/util/unicode.ts
+++ b/assistant/src/util/unicode.ts
@@ -148,7 +148,7 @@ export function stripOrphanedSurrogatesDeep<T>(input: T): DeepSanitizeResult<T> 
       for (let i = 0; i < value.length; i++) {
         const result = walk(value[i]);
         if (result.changed && next === null) {
-          next = value.slice(0, i);
+          next = Array.prototype.slice.call(value, 0, i) as unknown[];
         }
         if (next !== null) {
           next.push(result.value);


### PR DESCRIPTION
Addresses Codex P2 on #25053. `value.slice(0, i)` honors `Symbol.species`, so an Array subclass that overrides species could return a non-Array whose `push` is missing/incompatible — causing a runtime throw on the subsequent `next.push(...)`. Switch to `Array.prototype.slice.call(value, 0, i)` to force a plain Array while preserving the laziness optimization.

The object path already uses a plain `{}` literal, which does not go through `Symbol.species`, so no change is needed there.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25091" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
