### PR TITLE
fix(macos): include content fingerprint in tool-output cache key

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -665,7 +665,7 @@ private struct StepDetailRow: View {
         guard let result = toolCall.result, !result.isEmpty else { return nil }
         let key = Self.coloredOutputCacheKey(
             toolCallID: toolCall.id.uuidString,
-            resultCount: result.utf8.count,
+            result: result,
             isError: toolCall.isError
         )
         if let cached = Self.coloredOutputCache.object(forKey: key) {
@@ -953,10 +953,18 @@ private struct StepDetailRow: View {
 
     private static func coloredOutputCacheKey(
         toolCallID: String,
-        resultCount: Int,
+        result: String,
         isError: Bool
     ) -> NSString {
-        return "\(toolCallID)|\(resultCount)|\(isError ? "err" : "ok")" as NSString
+        // Cheap content fingerprint: length + prefix + suffix + per-process hash.
+        // Ensures the key changes when `result` is overwritten in place with
+        // different text of the same byte count (replay / correction / rehydration
+        // paths all mutate toolCalls[...].result).
+        let count = result.utf8.count
+        let prefix = result.prefix(16)
+        let suffix = result.suffix(16)
+        let hash = result.hashValue
+        return "\(toolCallID)|\(count)|\(isError ? "err" : "ok")|\(prefix)|\(suffix)|\(hash)" as NSString
     }
 
     private func coloredOutput(_ result: String, isError: Bool) -> AttributedString {


### PR DESCRIPTION
## Summary

Addresses Codex P2 review feedback on #25048: the `"<toolCallID>|<resultCount>|..."` cache key could return stale rendered output when a tool call's `result` was overwritten in place with different text of the same byte count (replay / correction / rehydration paths all mutate `toolCalls[...].result`).

Extended the cache key with a cheap content fingerprint (prefix[0..<16] + suffix[-16..] + Swift `hashValue`) so the key changes for same-length overwrites. The prefix/suffix + length fields are deterministic across runs; `hashValue` is per-process randomized but that is fine for an in-process NSCache.

## Files

- `clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift`

## Test plan

- [ ] Build macOS client and verify tool output renders correctly on first completion.
- [ ] Trigger a replay / rehydration of a completed tool call and confirm the updated text is shown (not a stale cached render).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25092" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
