### PR TITLE
fix(backup): basename-based filename derivation + collision suffix regex

### DIFF
--- a/assistant/src/backup/__tests__/paths.test.ts
+++ b/assistant/src/backup/__tests__/paths.test.ts
@@ -275,4 +275,26 @@ describe("parseBackupTimestamp", () => {
   test("returns null for Feb 29 in a non-leap year", () => {
     expect(parseBackupTimestamp("backup-20260229-000000.vbundle")).toBeNull();
   });
+
+  test("accepts filenames with a hex collision suffix after milliseconds", () => {
+    const parsed = parseBackupTimestamp(
+      "backup-20260411-153045-123-abcdef.vbundle",
+    );
+    expect(parsed).not.toBeNull();
+    expect(parsed!.toISOString()).toBe("2026-04-11T15:30:45.123Z");
+  });
+
+  test("accepts encrypted filenames with a hex collision suffix", () => {
+    const parsed = parseBackupTimestamp(
+      "backup-20260411-153045-123-0a1b2c.vbundle.enc",
+    );
+    expect(parsed).not.toBeNull();
+    expect(parsed!.toISOString()).toBe("2026-04-11T15:30:45.123Z");
+  });
+
+  test("rejects non-hex collision suffixes", () => {
+    expect(
+      parseBackupTimestamp("backup-20260411-153045-123-XYZ123.vbundle"),
+    ).toBeNull();
+  });
 });

--- a/assistant/src/backup/local-writer.ts
+++ b/assistant/src/backup/local-writer.ts
@@ -13,7 +13,7 @@
 
 import { randomBytes } from "node:crypto";
 import { copyFile, mkdir, rename, stat, unlink } from "node:fs/promises";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 
 import { pruneDir, type SnapshotEntry } from "./list-snapshots.js";
 import { formatBackupFilename } from "./paths.js";
@@ -83,7 +83,7 @@ export async function writeLocalSnapshot(
 
   const baseFilename = formatBackupFilename(now, { encrypted: false });
   const destPath = await resolveUniqueDestPath(localDir, baseFilename);
-  const filename = destPath.slice(localDir.length + 1);
+  const filename = basename(destPath);
 
   try {
     await rename(tempVBundlePath, destPath);

--- a/assistant/src/backup/paths.ts
+++ b/assistant/src/backup/paths.ts
@@ -158,11 +158,13 @@ export function formatBackupFilename(
 }
 
 // Matches `backup-YYYYMMDD-HHMMSS` with an optional `-SSS` milliseconds
-// segment (legacy backups written before ms precision was added omit it),
-// followed by `.vbundle` or `.vbundle.enc`. Kept as a module-level constant so
-// repeated parsing doesn't rebuild the RegExp.
+// segment (legacy backups written before ms precision was added omit it) and
+// an optional `-<hex>` collision suffix that `writeLocalSnapshot` appends when
+// the canonical name is already taken. Followed by `.vbundle` or
+// `.vbundle.enc`. Kept as a module-level constant so repeated parsing doesn't
+// rebuild the RegExp.
 const BACKUP_FILENAME_RE =
-  /^backup-(\d{4})(\d{2})(\d{2})-(\d{2})(\d{2})(\d{2})(?:-(\d{3}))?\.vbundle(?:\.enc)?$/;
+  /^backup-(\d{4})(\d{2})(\d{2})-(\d{2})(\d{2})(\d{2})(?:-(\d{3})(?:-[0-9a-f]+)?)?\.vbundle(?:\.enc)?$/;
 
 /**
  * Inverse of `formatBackupFilename`. Parses a backup filename (with either


### PR DESCRIPTION
Addresses Codex feedback on #25078.

- **Bug 1 (P1)**: `writeLocalSnapshot` derived the returned filename via `destPath.slice(localDir.length + 1)`, which dropped the first character when `backup.localDirectory` ended with a trailing slash (schema-allowed). The returned metadata would then desync from the on-disk name, causing downstream listing/pruning/restore to miss the snapshot. Switched to `path.basename(destPath)` which is invariant to trailing slashes.
- **Bug 2 (P2)**: `BACKUP_FILENAME_RE` only matched `backup-...[-SSS].vbundle[.enc]`, so the collision-fallback names (`backup-...-SSS-<hex>.vbundle`) emitted by the new unique-path resolver were excluded from listing, retention, and restore. Extended the regex to accept an optional `-[0-9a-f]+` suffix after the milliseconds group, matching the 6-hex-char token `resolveUniqueDestPath` appends. Added parse tests for the collision-suffix form.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25093" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
