### PR TITLE
fix(macos): ⌘⇧U falls through when mark-unread is unavailable

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -344,6 +344,9 @@ extension AppDelegate {
                   event.charactersIgnoringModifiers?.lowercased() == targetKey.lowercased() else {
                 return event
             }
+            guard self?.canMarkCurrentConversationUnread() == true else {
+                return event
+            }
             Task { @MainActor in
                 self?.markCurrentConversationUnread()
             }

--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -268,13 +268,21 @@ extension AppDelegate {
             return (mainWindow?.conversationManager.unseenVisibleConversationCount ?? 0) > 0
         }
         if action == #selector(markCurrentConversationUnread) {
-            guard let conversationManager = mainWindow?.conversationManager,
-                  let activeId = conversationManager.selectionStore.activeConversationId,
-                  let idx = conversationManager.listStore.conversations.firstIndex(where: { $0.id == activeId })
-            else { return false }
-            return conversationManager.listStore.canMarkConversationUnread(conversationId: activeId, at: idx)
+            return canMarkCurrentConversationUnread()
         }
         return true
+    }
+
+    /// Returns whether the mark-as-unread action is currently executable.
+    /// Shared by `validateMenuItem(_:)` and the keyboard-shortcut monitor so
+    /// both gates stay in sync and the shortcut falls through to the responder
+    /// chain when the action cannot run.
+    func canMarkCurrentConversationUnread() -> Bool {
+        guard let conversationManager = mainWindow?.conversationManager,
+              let activeId = conversationManager.selectionStore.activeConversationId,
+              let idx = conversationManager.listStore.conversations.firstIndex(where: { $0.id == activeId })
+        else { return false }
+        return conversationManager.listStore.canMarkConversationUnread(conversationId: activeId, at: idx)
     }
 
     /// Builds the status item tooltip, appending PTT key info when enabled.


### PR DESCRIPTION
## Summary

Addresses Codex P2 feedback on #25081: the persistent `NSEvent` local monitor for the mark-as-unread shortcut was returning \`nil\` (consuming the event) whenever the shortcut matched, even when \`markCurrentConversationUnread()\` would be a no-op (no active conversation, ineligible conversation, settings panel focused). That swallowed ⌘⇧U in states where \`validateMenuItem(_:)\` would have disabled the menu-key-equivalent and let the event fall through.

## Fix

- Extracted the menu-item validation predicate into \`AppDelegate.canMarkCurrentConversationUnread()\` so \`validateMenuItem(_:)\` and the keyboard monitor share one gate.
- Before consuming the key event in \`registerMarkConversationUnreadMonitor()\`, check \`canMarkCurrentConversationUnread()\`; if false, return the event so the normal responder chain handles it.
- Persistent-binding fix from #25081 is preserved: the monitor still fires whenever the shortcut matches AND the action is executable.

## Files

- \`clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift\` — extract \`canMarkCurrentConversationUnread()\` helper, use in \`validateMenuItem\`.
- \`clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift\` — gate event consumption on the new predicate.

## Test plan
- [ ] Manual: with an eligible conversation selected, ⌘⇧U marks unread.
- [ ] Manual: with settings panel focused / no active conversation, ⌘⇧U falls through to system beep / other responders instead of being silently swallowed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25094" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
