### PR TITLE
fix(daemon): apply trustContext only after isProcessing idle check

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -998,13 +998,11 @@ export class DaemonServer {
       if (!conversation.isProcessing()) {
         this.applyTransportMetadata(conversation, options);
       }
-      // Reapply trust context to reused in-memory conversations so callers
-      // that pass a fresh trustContext (e.g. schedule run-now) don't silently
-      // inherit the prior turn's guardian scope. The new-conversation branch
-      // already applies this via storedOptions; mirror it for reuse.
-      if (options?.trustContext !== undefined) {
-        conversation.setTrustContext(options.trustContext);
-      }
+      // Note: trustContext reapplication for reused conversations is handled
+      // in prepareConversationForMessage AFTER the isProcessing() idle check.
+      // Applying it here would race concurrent requests — a busy-rejected
+      // caller could still overwrite the in-flight turn's guardian scope,
+      // changing authorization mid-turn.
       this.evictor.touch(conversationId);
     }
     return conversation;


### PR DESCRIPTION
## Summary

Addresses Codex P1 feedback on #25065.

The reuse branch in `getOrCreateConversation` called `setTrustContext(options.trustContext)` before `prepareConversationForMessage` ran its `isProcessing()` idle check. A concurrent request with a fresh `trustContext` (e.g. scheduler-triggered send racing an active user turn) could be rejected as busy yet still overwrite the in-flight turn's guardian scope — changing authorization mid-turn.

## Fix

Option (a): remove the `setTrustContext` call from `getOrCreateConversation`'s reuse branch. `prepareConversationForMessage` already applies it after the `isProcessing()` idle check (assistant/src/daemon/server.ts:1091-1093), so reused conversations still get a fresh trustContext when a turn actually starts — but never when another turn is mid-flight.

The per-turn `taskRunId` reset in `conversation-agent-loop.ts` is preserved.

## Files

- assistant/src/daemon/server.ts

## Test plan

- [x] Type-check passes
- [ ] Verify no regressions in conversation trust/auth behavior

Closes codex feedback on #25065
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25095" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
