### PR TITLE
fix(usage): stable hourly bucket sort by bucketId

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/LogsAndUsagePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/LogsAndUsagePanel.swift
@@ -464,7 +464,7 @@ struct UsageTabContent: View {
 
     @ViewBuilder
     private func trendBarChart(_ buckets: [UsageDayBucket], isHourly: Bool) -> some View {
-        let sorted = buckets.sorted { $0.date < $1.date }
+        let sorted = buckets.sorted { $0.bucketId < $1.bucketId }
         let maxCost = buckets.map(\.totalEstimatedCostUsd).max() ?? 1.0
         let barWidth = isHourly ? hourlyBarWidth : maxBarWidth
 


### PR DESCRIPTION
## Summary
- Sort hourly usage buckets in the macOS Logs & Usage panel by `bucketId` instead of `date`.
- On DST fall-back days, two `01:00` buckets share the same `date` string; Swift's sort is not stable, so their chart position could swap run-to-run.
- `bucketId` (from PR #25084) includes the UTC-offset suffix for hourly buckets (e.g. `2026-11-01 01:00|-240` vs `|-300`), so lexicographic ordering is deterministic.
- Daily buckets are unaffected: `bucketId == date` for daily granularity.

## Notes
- Only one sort site exists in Swift (`LogsAndUsagePanel.swift:467`). iOS `UsageDashboardView` iterates buckets as returned by the daemon (which sorts by `sortKey`) and doesn't resort.
- `UsageDayBucket.bucketId` is always non-nil on the Swift side: the decoder falls back to `date` when the field is absent (older daemon), matching the pattern established in #25084.

## Test plan
- [ ] Verify charts on a DST fall-back day show two distinct `01:00` bars in deterministic order.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25096" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
