### PR TITLE
fix(contacts): migration 220 matches unbounded counter suffixes

### DIFF
--- a/assistant/src/__tests__/contact-store-user-file.test.ts
+++ b/assistant/src/__tests__/contact-store-user-file.test.ts
@@ -329,7 +329,7 @@ describe("migrateNormalizeUserFileByPrincipal", () => {
     expect(rows.map((r) => r.user_file).sort()).toEqual(["alex.md", "alex.md"]);
   });
 
-  test("classifies only 1-3 digit tails as auto-incremented", () => {
+  test("excludes year-like 4-digit tails from the auto-increment class", () => {
     // `-2.md` is auto-increment; `-1999.md` (year) is not.
     const now = Date.now();
     insertContact({
@@ -355,6 +355,68 @@ describe("migrateNormalizeUserFileByPrincipal", () => {
     // `bob-1999.md` is non-auto-incremented, `bob-2.md` is auto-incremented;
     // the former wins regardless of age.
     for (const row of rows) expect(row.user_file).toBe("bob-1999.md");
+  });
+
+  test("classifies 4+ digit counter tails as auto-incremented", () => {
+    // `generateUserFileSlug` has an unbounded `for (let i = 2; ; i++)` loop,
+    // so a dense slug space can produce 4+ digit counters like `-1000.md`.
+    // Those must still be recognized as auto-increments so siblings are
+    // normalized to the clean base, not to the counter value.
+    const now = Date.now();
+    insertContact({
+      id: "c1",
+      displayName: "Carol",
+      role: "guardian",
+      principalId: "principal-big",
+      userFile: "carol-1000.md",
+      createdAt: now - 2000,
+    });
+    insertContact({
+      id: "c2",
+      displayName: "Carol",
+      role: "guardian",
+      principalId: "principal-big",
+      userFile: "carol.md",
+      createdAt: now,
+    });
+
+    migrateNormalizeUserFileByPrincipal(getDb());
+
+    const rows = fetchUserFilesByPrincipal("principal-big");
+    // Despite `carol-1000.md` being older, it's auto-incremented, so
+    // `carol.md` wins as canonical.
+    for (const row of rows) expect(row.user_file).toBe("carol.md");
+  });
+
+  test("excludes full date-shaped tails from the auto-increment class", () => {
+    // `alex-2025-04-13.md` ends with `-13.md` (which otherwise looks like a
+    // small counter), but the preceding `-2025-04` marks the whole tail as a
+    // date. Must NOT be classified as auto-incremented.
+    const now = Date.now();
+    insertContact({
+      id: "c1",
+      displayName: "Alex 2025 04 13",
+      role: "guardian",
+      principalId: "principal-datefull",
+      userFile: "alex-2025-04-13.md",
+      createdAt: now - 2000,
+    });
+    insertContact({
+      id: "c2",
+      displayName: "Alex",
+      role: "guardian",
+      principalId: "principal-datefull",
+      userFile: "alex-2.md",
+      createdAt: now - 1000,
+    });
+
+    migrateNormalizeUserFileByPrincipal(getDb());
+
+    const rows = fetchUserFilesByPrincipal("principal-datefull");
+    // `alex-2.md` is auto-incremented; `alex-2025-04-13.md` is a date-shaped
+    // slug and wins as canonical.
+    for (const row of rows)
+      expect(row.user_file).toBe("alex-2025-04-13.md");
   });
 
   test("is idempotent", () => {

--- a/assistant/src/memory/migrations/220-normalize-user-file-by-principal.ts
+++ b/assistant/src/memory/migrations/220-normalize-user-file-by-principal.ts
@@ -11,6 +11,31 @@ export function downNormalizeUserFileByPrincipal(_database: DrizzleDb): void {
 }
 
 /**
+ * Heuristic: does `userFile` look like an auto-incremented persona slug?
+ *
+ * `generateUserFileSlug` appends `-<N>.md` where N is any positive integer
+ * (the loop is unbounded, so a very dense principal space could reach 4+
+ * digits). Matching is anchored to the end so a slug that happens to contain
+ * digits earlier (e.g. `alex-2024.md` for display name "Alex 2024") is not
+ * affected.
+ *
+ * The final-integer suffix also matches year-like or date-like names
+ * (`-2025.md`, `-2025-04-13.md` via the trailing `-13.md`). Those must NOT
+ * be classified as auto-increments, so we exclude any filename that ends
+ * with a date-shaped tail: `-YYYY.md`, `-YYYY-MM.md`, or `-YYYY-MM-DD.md`
+ * where YYYY is a 4-digit year starting with 19, 20, or 21. A counter that
+ * happens to fall in that range (e.g. `-1999.md`) is indistinguishable from
+ * a year by filename alone, so we conservatively treat it as non-auto.
+ */
+const DATE_LIKE_SUFFIX = /-(19|20|21)\d{2}(-\d{1,2}){0,2}\.md$/;
+const INTEGER_SUFFIX = /-\d+\.md$/;
+
+export function isAutoIncrementedUserFile(userFile: string): boolean {
+  if (DATE_LIKE_SUFFIX.test(userFile)) return false;
+  return INTEGER_SUFFIX.test(userFile);
+}
+
+/**
  * Normalize `contacts.user_file` across contact rows that share the same
  * `principal_id`.
  *
@@ -26,11 +51,8 @@ export function downNormalizeUserFileByPrincipal(_database: DrizzleDb): void {
  * This migration picks one canonical `user_file` per principal and updates
  * every sibling row to match. Selection heuristic:
  *
- *   1. Prefer values that do NOT look auto-incremented. Auto-increment tails
- *      are `-<N>.md` where N is 1–3 digits (matches `generateUserFileSlug`'s
- *      counter). Matching is anchored to the end of the filename so a slug
- *      that happens to contain a numeric segment (e.g. `alex-2024.md` — a
- *      display name with a year) is NOT classified as auto-incremented.
+ *   1. Prefer values that do NOT look auto-incremented (see
+ *      `isAutoIncrementedUserFile`).
  *   2. Among those, prefer the oldest contact row (earliest `created_at`).
  *   3. Ties broken by `id` for determinism.
  *
@@ -82,20 +104,14 @@ export function migrateNormalizeUserFileByPrincipal(
           )
           .all() as Array<{ principal_id: string }>;
 
-        const selectCanonical = raw.prepare(
+        // Fetch all non-null candidates and rank in JS. The auto-increment
+        // classification is a regex that SQLite's GLOB can't express cleanly
+        // (unbounded digit count, date-pattern exclusion), and keeping the
+        // logic in one place avoids SQL/JS drift.
+        const selectCandidates = raw.prepare(
           /*sql*/ `
-          SELECT user_file FROM contacts
+          SELECT user_file, created_at, id FROM contacts
           WHERE principal_id = ? AND user_file IS NOT NULL
-          ORDER BY
-            CASE
-              WHEN user_file GLOB '*-[0-9].md'
-                OR user_file GLOB '*-[0-9][0-9].md'
-                OR user_file GLOB '*-[0-9][0-9][0-9].md'
-              THEN 1 ELSE 0
-            END,
-            created_at ASC,
-            id ASC
-          LIMIT 1
           `,
         );
 
@@ -109,15 +125,28 @@ export function migrateNormalizeUserFileByPrincipal(
         );
 
         for (const { principal_id } of principals) {
-          const canonical = selectCanonical.get(principal_id) as {
+          const candidates = selectCandidates.all(principal_id) as Array<{
             user_file: string;
-          } | null;
-          if (!canonical?.user_file) continue;
+            created_at: number;
+            id: string;
+          }>;
+          if (candidates.length === 0) continue;
+
+          candidates.sort((a, b) => {
+            const aAuto = isAutoIncrementedUserFile(a.user_file) ? 1 : 0;
+            const bAuto = isAutoIncrementedUserFile(b.user_file) ? 1 : 0;
+            if (aAuto !== bAuto) return aAuto - bAuto;
+            if (a.created_at !== b.created_at)
+              return a.created_at - b.created_at;
+            return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+          });
+
+          const canonical = candidates[0]!.user_file;
           updateSiblings.run(
-            canonical.user_file,
+            canonical,
             Date.now(),
             principal_id,
-            canonical.user_file,
+            canonical,
           );
         }
 


### PR DESCRIPTION
## Summary

Addresses Codex's P2 feedback on #25061. `generateUserFileSlug` has an unbounded `for (let i = 2; ; i++)` loop, so it can emit 4+ digit counters (`alex-1000.md`, etc.). The previous SQL GLOB only covered 1–3 digit tails, so those counter values bypassed the auto-increment classification and could be mis-ranked as canonical — recreating the bug migration 220 is meant to fix.

## Changes

- Replaced the SQL-side GLOB with JS-side ranking in \`migrateNormalizeUserFileByPrincipal\`. Candidates are fetched and sorted in memory using \`isAutoIncrementedUserFile\`.
- New classifier: \`-<digits>.md$\` matches any positive integer suffix, but date-shaped tails (\`-YYYY.md\`, \`-YYYY-MM.md\`, \`-YYYY-MM-DD.md\` with YYYY starting 19/20/21) are excluded so year-bearing display names like "Alex 2024" are still treated as non-auto.
- Tests added for the 4+ digit counter case (\`carol-1000.md\`) and full date suffixes (\`alex-2025-04-13.md\`).

## Test plan

- [x] \`bun test assistant/src/__tests__/contact-store-user-file.test.ts\` — 15 pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25097" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
