### PR TITLE
fix(backup): fall back to homedir() when HOME is empty string

### DIFF
--- a/assistant/src/backup/paths.ts
+++ b/assistant/src/backup/paths.ts
@@ -1,5 +1,5 @@
 import { homedir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, isAbsolute, join } from "node:path";
 
 import {
   getBackupDirOverride,
@@ -46,16 +46,27 @@ export function getLocalBackupsDir(override?: string | null): string {
  * Reads `process.env.HOME` at call time before falling back to `homedir()`.
  * `homedir()` is snapshot at process start on some platforms, so consulting
  * `$HOME` on each call keeps this function honest under tests that redirect
- * the home directory mid-process.
+ * the home directory mid-process. Uses `||` (not `??`) so an empty-string
+ * `HOME` — legal in some sandboxed envs — also falls back to `homedir()`
+ * rather than producing a relative `Library/...` path. Asserts the result is
+ * absolute so callers downstream (`deriveSafeAncestor`, the offsite writer)
+ * never see a relative path regardless of how the home lookup resolved.
  */
 export function getICloudDriveRoot(): string {
-  const home = process.env.HOME ?? homedir();
-  return join(
+  const home = process.env.HOME || homedir();
+  const root = join(
     home,
     "Library",
     "Mobile Documents",
     "com~apple~CloudDocs",
   );
+  if (!isAbsolute(root)) {
+    throw new Error(
+      `getICloudDriveRoot resolved to a relative path: ${root}. ` +
+        `HOME and homedir() both returned empty or relative values.`,
+    );
+  }
+  return root;
 }
 
 /**

--- a/gateway/src/db/connection.ts
+++ b/gateway/src/db/connection.ts
@@ -16,7 +16,7 @@ let db: Database | null = null;
  */
 function getLegacyRootDir(): string {
   return join(
-    process.env.BASE_DATA_DIR?.trim() || (process.env.HOME ?? homedir()),
+    process.env.BASE_DATA_DIR?.trim() || process.env.HOME || homedir(),
     ".vellum",
   );
 }


### PR DESCRIPTION
## Summary

Addresses Codex P2 feedback on #25085.

`getICloudDriveRoot()` used `process.env.HOME ?? homedir()`, which only falls back on \`undefined\`/\`null\` but not on an empty string. If \`HOME\` is present but empty (rare but legal in some sandboxed envs), the default iCloud destination and \`deriveSafeAncestor()\` would silently become relative paths (\`Library/...\`), causing \`writeOffsiteSnapshotToOne()\` to either skip incorrectly or write backups under the current working directory.

- Switch to \`process.env.HOME || homedir()\` so empty strings also trigger the \`homedir()\` fallback.
- Belt-and-suspenders: assert \`isAbsolute(root)\` and throw if not, so a relative path can never sneak downstream into \`deriveSafeAncestor\` or the offsite writer.
- Apply the same \`||\` fix to the deprecated \`getLegacyRootDir()\` in \`gateway/src/db/connection.ts\` (other occurrence of the same pattern).

## Files

- \`assistant/src/backup/paths.ts\` — \`??\` → \`||\`, absolute-path assertion, updated docstring.
- \`gateway/src/db/connection.ts\` — \`??\` → \`||\` on the legacy HOME fallback.

## Test plan

- [x] Code inspection — logic equivalent except when HOME is \`""\`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25099" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
