### PR TITLE
fix(macos): gate endStabilization on mode + track expansion timeout task

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
@@ -251,7 +251,12 @@ extension MessageListView {
             return
         }
         scrollState.lastHandledChatColumnWidth = trackedWidth
-        // Route through coordinator for policy decision.
+        // Route through coordinator for policy decision. Snapshot whether
+        // the coordinator opened a new resize stabilization window so we
+        // only pair an endStabilization() call when there's a window to
+        // end — otherwise we'd decrement an unrelated stabilization cycle
+        // (e.g. an active expansion window the user is still inspecting).
+        let didOpenCoordinatorStabilization = scrollCoordinator.wouldOpenResizeStabilization
         let intents = scrollCoordinator.handle(.containerWidthChanged)
         executeCoordinatorIntents(intents)
         resizeScrollTask?.cancel()
@@ -263,11 +268,15 @@ extension MessageListView {
             try? await Task.sleep(nanoseconds: 100_000_000)
             guard !Task.isCancelled else {
                 scrollState.endStabilization()
-                scrollCoordinator.endStabilization()
+                if didOpenCoordinatorStabilization {
+                    scrollCoordinator.endStabilization()
+                }
                 return
             }
                 scrollState.endStabilization()
-                scrollCoordinator.endStabilization()
+                if didOpenCoordinatorStabilization {
+                    scrollCoordinator.endStabilization()
+                }
                 if scrollState.mode.allowsAutoScroll && anchorMessageId == nil {
                     // Use mode.allowsAutoScroll (covers both .initialLoad and
                     // .followingBottom) instead of isFollowingBottom (which

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -164,17 +164,12 @@ struct MessageListView: View {
             .environment(\.filePreviewExpansionStore, filePreviewExpansionStore)
             .environment(\.suppressAutoScroll, { [self] in
                 os_signpost(.event, log: PerfSignposts.log, name: "scrollSuppressionChanged", "on reason=manualExpansionDetach")
+                // Coordinator owns the 200ms expansion timeout internally
+                // (generation-tracked, cancellable) — no view-layer Task needed.
                 let intents = scrollCoordinator.handle(.manualExpansion)
                 executeCoordinatorIntents(intents)
                 // Keep scrollState in sync as runtime executor.
                 scrollState.handleManualExpansionInteraction()
-                // Mirror scrollState's internal 200ms expansion timeout on the
-                // coordinator. Without this, the coordinator would stick in
-                // .stabilizing until another event forced a mode transition.
-                Task { @MainActor [scrollCoordinator] in
-                    try? await Task.sleep(nanoseconds: 200_000_000)
-                    scrollCoordinator.endStabilization()
-                }
             })
             .onScrollPhaseChange { oldPhase, newPhase in
                 let coordinatorPhase = ScrollCoordinator.Phase.from(newPhase)

--- a/clients/macos/vellum-assistant/Features/Chat/ScrollCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ScrollCoordinator.swift
@@ -192,6 +192,17 @@ final class ScrollCoordinator {
     /// Tracks overlapping stabilization windows.
     private var activeStabilizationCount: Int = 0
 
+    /// Timeout task for expansion stabilization — auto-ends after 200ms.
+    /// Owned by the coordinator (not the view layer) so stale tasks from
+    /// an earlier stabilization cycle can't decrement the wrong window.
+    private var expansionTimeoutTask: Task<Void, Never>?
+
+    /// Monotonically increasing counter, bumped when leaving the
+    /// `.stabilizing` mode. Expansion timeout tasks capture the current
+    /// generation before sleeping; stale tasks bail out if the generation
+    /// no longer matches. Mirrors `MessageListScrollState`.
+    private var stabilizationGeneration: UInt64 = 0
+
     /// Timestamp of the last user-initiated pin (CTA tap). Used to suppress
     /// stale momentum from the pre-CTA scroll gesture.
     private var lastUserInitiatedPinTime: Date?
@@ -403,6 +414,21 @@ final class ScrollCoordinator {
         return intents
     }
 
+    /// Whether `handle(.containerWidthChanged)` would open a new resize
+    /// stabilization window in the current mode. Callers use this to
+    /// decide whether to pair an `endStabilization()` call after their
+    /// view-layer resize task completes. Skipping the pairing in modes
+    /// that don't open a window avoids decrementing an unrelated
+    /// stabilization cycle (e.g. an active expansion window).
+    var wouldOpenResizeStabilization: Bool {
+        switch mode {
+        case .freeBrowsing, .stabilizing:
+            return true
+        case .initialLoad, .followingBottom, .programmaticScroll:
+            return false
+        }
+    }
+
     // MARK: - User-Initiated Pin (CTA tap)
 
     /// Handles a user-initiated scroll-to-bottom (e.g. tapping the CTA).
@@ -445,9 +471,13 @@ final class ScrollCoordinator {
         switch oldMode {
         case .stabilizing:
             if case .stabilizing = newMode {
-                // Staying in stabilizing — preserve window count.
+                // Staying in stabilizing — preserve window count and
+                // generation so cancelled tasks from the old reason can
+                // still balance the count.
             } else {
+                stabilizationGeneration &+= 1
                 activeStabilizationCount = 0
+                cancelStabilizationTasks()
             }
         default:
             break
@@ -470,6 +500,9 @@ final class ScrollCoordinator {
             if activeReason == reason {
                 // Same-reason re-entry — increment count but don't re-transition.
                 activeStabilizationCount += 1
+                if reason == .expansion {
+                    scheduleExpansionTimeout()
+                }
                 return
             }
         case .programmaticScroll:
@@ -478,6 +511,10 @@ final class ScrollCoordinator {
 
         activeStabilizationCount += 1
         transition(to: .stabilizing(previousMode: previousMode, reason: reason))
+
+        if reason == .expansion {
+            scheduleExpansionTimeout()
+        }
     }
 
     /// Ends one stabilization window. Only restores the previous mode
@@ -491,6 +528,30 @@ final class ScrollCoordinator {
             transition(to: .followingBottom)
         case .freeBrowsing:
             transition(to: .freeBrowsing)
+        }
+    }
+
+    private func cancelStabilizationTasks() {
+        expansionTimeoutTask?.cancel()
+        expansionTimeoutTask = nil
+    }
+
+    private func scheduleExpansionTimeout() {
+        expansionTimeoutTask?.cancel()
+        let capturedGeneration = stabilizationGeneration
+        expansionTimeoutTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: 200_000_000)
+            guard let self else { return }
+            if Task.isCancelled {
+                // Cancelled within the same cycle (e.g. cross-reason
+                // transition): balance the count so the superseding
+                // reason's endStabilization() can reach zero. If a new
+                // cycle started (generation changed), a stale task must
+                // NOT call endStabilization — it would decrement the
+                // wrong window.
+                guard capturedGeneration == self.stabilizationGeneration else { return }
+            }
+            self.endStabilization()
         }
     }
 
@@ -513,6 +574,8 @@ final class ScrollCoordinator {
         phase = .idle
         isAtBottom = false
         activeStabilizationCount = 0
+        stabilizationGeneration &+= 1
+        cancelStabilizationTasks()
         lastUserInitiatedPinTime = nil
         pendingAnchor = nil
     }


### PR DESCRIPTION
## Summary

Addresses two P2 races Codex identified on #25077.

**Race 1 — unconditional `endStabilization()` on width change.** `handleContainerWidthChanged` always called `scrollCoordinator.endStabilization()` after the 100ms resize sleep, but the coordinator only opens a stabilization window in `.freeBrowsing` / `.stabilizing`. In `.followingBottom`, `.initialLoad`, or `.programmaticScroll` the end call is a no-op (guard returns), but the intent was unclear and fragile. Now the view snapshots `scrollCoordinator.wouldOpenResizeStabilization` before calling `.handle(.containerWidthChanged)` and only pairs `endStabilization()` when a window actually opened.

**Race 2 — untracked expansion timeout `Task`.** The `suppressAutoScroll` callback in `MessageListView.swift` scheduled a bare `Task.sleep(200ms)` that unconditionally called `coordinator.endStabilization()`. Stale tasks from an earlier stabilization cycle could fire during a later cycle and decrement `activeStabilizationCount` for the wrong window.

Fix: move the expansion timeout into `ScrollCoordinator` itself, mirroring `MessageListScrollState.scheduleExpansionTimeout()`:

- `expansionTimeoutTask` — cancelled on cross-reason transition, reset, and leaving stabilizing.
- `stabilizationGeneration` — bumped when leaving `.stabilizing`. Timeout tasks capture the current generation before sleeping; cancelled tasks bail out if the generation changed (stale), and only balance the count if it didn't (same-cycle cross-reason transition).
- Same-reason expansion re-entry now resets the timer and increments count, matching scrollState's semantics.

View layer no longer owns an expansion Task — the coordinator manages it internally.

## Test plan

- [ ] Manually expand tool details while streaming → coordinator stays in `.stabilizing(.expansion)` for 200ms then exits to `.freeBrowsing`.
- [ ] Resize during streaming (no user scroll-up) → mode is `.followingBottom`, no stabilization window, re-pins to bottom.
- [ ] Resize while user has an active expansion → expansion timer not clobbered by resize end call.
- [ ] Rapid expand → resize → conversation switch → no stale task fires against the new cycle.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25100" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
