### PR TITLE
fix(ces-contracts): install shared packages during macOS build so zod resolves

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -327,8 +327,15 @@ build_binaries() {
     command -v bun &>/dev/null || { echo "ERROR: bun is required but not found"; exit 1; }
 
     # Pre-install dependencies once per source directory so parallel builds
-    # don't race on the same node_modules.
+    # don't race on the same node_modules. Shared packages under packages/ must
+    # be installed first: assistant/ et al. reference them via file: and import
+    # their TypeScript source directly, so the packages need their own
+    # node_modules for transitive deps (e.g. zod) to resolve during tsc/bun build.
     echo "Installing dependencies..."
+    for pkg_dir in "$SCRIPT_DIR"/../../packages/*/; do
+        [ -f "${pkg_dir}package.json" ] || continue
+        (cd "$pkg_dir" && bun install --frozen-lockfile 2>/dev/null || bun install)
+    done
     (cd "$ASSISTANT_SRC_DIR" && bun install --frozen-lockfile 2>/dev/null || bun install)
     (cd "$CLI_SRC_DIR" && bun install --frozen-lockfile 2>/dev/null || bun install)
     (cd "$GATEWAY_SRC_DIR" && bun install --frozen-lockfile 2>/dev/null || bun install)

--- a/packages/ces-contracts/bun.lock
+++ b/packages/ces-contracts/bun.lock
@@ -5,22 +5,24 @@
     "": {
       "name": "@vellumai/ces-contracts",
       "dependencies": {
-        "zod": "^4.3.6",
+        "zod": "4.3.6",
       },
       "devDependencies": {
-        "@types/bun": "^1.2.4",
-        "typescript": "^5.7.3",
+        "@types/bun": "1.2.4",
+        "typescript": "5.7.3",
       },
     },
   },
   "packages": {
-    "@types/bun": ["@types/bun@1.3.10", "", { "dependencies": { "bun-types": "1.3.10" } }, "sha512-0+rlrUrOrTSskibryHbvQkDOWRJwJZqZlxrUs1u4oOoTln8+WIXBPmAuCF35SWB2z4Zl3E84Nl/D0P7803nigQ=="],
+    "@types/bun": ["@types/bun@1.2.4", "", { "dependencies": { "bun-types": "1.2.4" } }, "sha512-QtuV5OMR8/rdKJs213iwXDpfVvnskPXY/S0ZiFbsTjQZycuqPbMW8Gf/XhLfwE5njW8sxI2WjISURXPlHypMFA=="],
 
     "@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
 
-    "bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
+    "@types/ws": ["@types/ws@8.5.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-bd/YFLW+URhBzMXurx7lWByOu+xzU9+kb3RboOteXYDfW+tr+JZa99OyNmPINEGB/ahzKrEuc8rcv4gnpJmxTw=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "bun-types": ["bun-types@1.2.4", "", { "dependencies": { "@types/node": "*", "@types/ws": "~8.5.10" } }, "sha512-nDPymR207ZZEoWD4AavvEaa/KZe/qlrbMSchqpQwovPZCKc7pwMoENjEtHgMKaAjJhy+x6vfqSBA1QU3bJgs0Q=="],
+
+    "typescript": ["typescript@5.7.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw=="],
 
     "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 

--- a/packages/ces-contracts/package.json
+++ b/packages/ces-contracts/package.json
@@ -16,10 +16,10 @@
     "test": "bun test src/"
   },
   "dependencies": {
-    "zod": "^4.3.6"
+    "zod": "4.3.6"
   },
   "devDependencies": {
-    "@types/bun": "^1.2.4",
-    "typescript": "^5.7.3"
+    "@types/bun": "1.2.4",
+    "typescript": "5.7.3"
   }
 }


### PR DESCRIPTION
## Summary

Fresh clones failed to typecheck/package the daemon because `packages/ces-contracts` was never `bun install`ed during the macOS build path. `assistant/` depends on it via `file:../packages/ces-contracts`, but bun symlinks the referenced `src/` back to the original path instead of copying, and does not install the package's transitive deps under the consumer's `node_modules`. As a result `tsc` (and `bun build`) walking up from `packages/ces-contracts/src/\*.ts` could not resolve `zod`.

CI workflows and `setup.sh` already ran `bun install` in `packages/*/`; only `clients/macos/build.sh` was missing the step. Added a preflight loop that installs every `packages/*/` before the assistant/cli/gateway installs.

Also pinned exact versions in `packages/ces-contracts/package.json` (`zod`, `@types/bun`, `typescript`) per repo policy (`bunfig.toml` has `exact = true`).

## Test plan
- [x] Reproduced the failure: clean `assistant/node_modules` + `packages/ces-contracts/node_modules`, `bun install` in `assistant/`, `bunx tsc --noEmit` → "Cannot find module 'zod'" from ces-contracts.
- [x] With fix (`bun install` in packages/ces-contracts first), `bunx tsc --noEmit` passes cleanly in `assistant/`, `cli/`, `gateway/`.
- [x] Pre-existing unrelated `contracts.test.ts` type errors remain on main and are out of scope.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25102" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
