### PR TITLE
fix(macos): skip Chrome NMH install when Gatekeeper rejects the bundled helper

### DIFF
--- a/clients/macos/vellum-assistant/Features/Installer/NativeMessagingInstaller.swift
+++ b/clients/macos/vellum-assistant/Features/Installer/NativeMessagingInstaller.swift
@@ -84,7 +84,8 @@ public enum NativeMessagingInstaller {
             helperBinaryPath: helperBinaryPath,
             extensionIds: extensionIds,
             homeDirectory: FileManager.default.homeDirectoryForCurrentUser,
-            fileManager: FileManager.default
+            fileManager: FileManager.default,
+            gatekeeperAssessment: Self.runGatekeeperAssessment(at:)
         )
     }
 
@@ -106,10 +107,25 @@ public enum NativeMessagingInstaller {
         helperBinaryPath: URL,
         extensionIds: [String],
         homeDirectory: URL,
-        fileManager: FileManager
+        fileManager: FileManager,
+        gatekeeperAssessment: (String) -> Bool = { _ in true }
     ) throws {
         guard fileManager.fileExists(atPath: helperBinaryPath.path) else {
             throw InstallError.helperBinaryMissing(helperBinaryPath)
+        }
+
+        // Chrome refuses to launch a native messaging host that
+        // Gatekeeper rejects, so installing a manifest that points at a
+        // rejected helper leaves the extension permanently unable to
+        // connect — and worse, clobbers any working manually-installed
+        // manifest on every app launch. Skip the install in that case
+        // and let the developer fall back to the manual setup documented
+        // in clients/chrome-extension/README.md.
+        guard gatekeeperAssessment(helperBinaryPath.path) else {
+            log.warning(
+                "Skipping Chrome native messaging manifest install: bundled helper at \(helperBinaryPath.path, privacy: .public) is not accepted by Gatekeeper (expected for local dev builds with a self-signed helper). Follow the manual setup in clients/chrome-extension/README.md to install the extension bridge."
+            )
+            return
         }
 
         let targetDir = manifestDirectory(under: homeDirectory)
@@ -178,5 +194,24 @@ public enum NativeMessagingInstaller {
             .appendingPathComponent("Google", isDirectory: true)
             .appendingPathComponent("Chrome", isDirectory: true)
             .appendingPathComponent("NativeMessagingHosts", isDirectory: true)
+    }
+
+    /// Runs `spctl -a -vv <path>` and returns `true` when Gatekeeper
+    /// accepts the binary. Local dev builds ship a self-signed helper
+    /// that fails this check; notarized release builds pass.
+    private static func runGatekeeperAssessment(at path: String) -> Bool {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/sbin/spctl")
+        process.arguments = ["-a", "-vv", path]
+        let sink = Pipe()
+        process.standardOutput = sink
+        process.standardError = sink
+        do {
+            try process.run()
+            process.waitUntilExit()
+            return process.terminationStatus == 0
+        } catch {
+            return false
+        }
     }
 }

--- a/clients/macos/vellum-assistantTests/NativeMessagingInstallerTests.swift
+++ b/clients/macos/vellum-assistantTests/NativeMessagingInstallerTests.swift
@@ -200,6 +200,67 @@ final class NativeMessagingInstallerTests: XCTestCase {
         )
     }
 
+    // MARK: - Gatekeeper
+
+    func testInstallSkipsWhenGatekeeperRejectsHelper() throws {
+        try NativeMessagingInstaller.installChromeManifest(
+            helperBinaryPath: helperBinaryUrl,
+            extensionIds: [placeholderExtensionId],
+            homeDirectory: mockHome,
+            fileManager: .default,
+            gatekeeperAssessment: { _ in false }
+        )
+
+        let manifestUrl = NativeMessagingInstaller
+            .manifestDirectory(under: mockHome)
+            .appendingPathComponent("com.vellum.daemon.json")
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: manifestUrl.path),
+            "manifest must not be written when Gatekeeper rejects the helper"
+        )
+    }
+
+    func testInstallPreservesExistingManifestWhenGatekeeperRejectsHelper() throws {
+        // First install a working manifest (e.g. from a prior manual
+        // setup pointing at a sh-wrapper that Gatekeeper trusts).
+        try NativeMessagingInstaller.installChromeManifest(
+            helperBinaryPath: helperBinaryUrl,
+            extensionIds: [placeholderExtensionId],
+            homeDirectory: mockHome,
+            fileManager: .default,
+            gatekeeperAssessment: { _ in true }
+        )
+
+        let manifestUrl = NativeMessagingInstaller
+            .manifestDirectory(under: mockHome)
+            .appendingPathComponent("com.vellum.daemon.json")
+        let originalData = try Data(contentsOf: manifestUrl)
+
+        // A later install whose bundled helper is Gatekeeper-rejected
+        // (e.g. a local dev build of the macOS app on top of a manual
+        // install) must not clobber the working manifest.
+        let rejectedBinary = tempDir.appendingPathComponent("rejected-binary")
+        FileManager.default.createFile(
+            atPath: rejectedBinary.path,
+            contents: Data("#!/bin/sh\nexit 0\n".utf8),
+            attributes: [.posixPermissions: NSNumber(value: 0o755)]
+        )
+        try NativeMessagingInstaller.installChromeManifest(
+            helperBinaryPath: rejectedBinary,
+            extensionIds: ["bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"],
+            homeDirectory: mockHome,
+            fileManager: .default,
+            gatekeeperAssessment: { _ in false }
+        )
+
+        let afterData = try Data(contentsOf: manifestUrl)
+        XCTAssertEqual(
+            originalData,
+            afterData,
+            "existing manifest must be left untouched when Gatekeeper rejects the new helper"
+        )
+    }
+
     // MARK: - uninstall
 
     func testUninstallRemovesManifest() throws {


### PR DESCRIPTION
## Summary
- On local dev builds, \`Velissa.app\` ships a self-signed \`vellum-chrome-native-host\` helper that Gatekeeper rejects (\`spctl -a -vv\` returns \`rejected, origin=Vellum Dev (Self-Signed)\`). Chrome then refuses to launch the helper, so the extension popup shows "Desktop app required / NEEDS APP" even with an assistant running — and worse, every app launch overwrote any working manually-installed manifest pointing at a trusted sh-wrapper.
- \`NativeMessagingInstaller.installChromeManifest\` now runs \`spctl -a -vv\` on the bundled helper and skips the install (logging a warning that points to \`clients/chrome-extension/README.md\`) when Gatekeeper rejects it. Notarized release builds pass the check and get the existing auto-install behavior.
- Gatekeeper assessment is injected as a closure for testability; added two tests — one asserting no manifest is written on rejection, and one asserting an existing working manifest is preserved (the key user-facing regression fix).

## Original prompt
Prevent Velissa.app's Chrome native-messaging-host installer from clobbering a working manifest with a pointer to a Gatekeeper-rejected helper binary. Perform a Gatekeeper assessment (\`spctl -a\`) on the bundled helper before writing; if assessment fails, skip the manifest write entirely and log a warning. This preserves any existing manual install for dev builds while keeping auto-install intact for notarized release builds. Scope: only \`clients/macos/vellum-assistant/Features/Installer/NativeMessagingInstaller.swift\` and its test.