### PR TITLE
fix(chrome-ext): remove unused extension permissions

### DIFF
--- a/clients/chrome-extension/manifest.json
+++ b/clients/chrome-extension/manifest.json
@@ -6,12 +6,9 @@
   "description": "Bridges the Vellum assistant to your live browser session via Chrome DevTools Protocol (CDP) through chrome.debugger.",
 
   "permissions": [
-    "activeTab",
-    "cookies",
     "debugger",
     "identity",
     "nativeMessaging",
-    "scripting",
     "storage",
     "tabs"
   ],


### PR DESCRIPTION
## Summary
- Chrome Web Store rejected the extension for requesting the `scripting` permission without using it
- Audited all permissions and found `cookies` and `activeTab` are also unused — `cookies` has zero API calls, and `activeTab` is fully redundant with the `<all_urls>` host permission
- Removed all three, keeping only the five that are actively used: `debugger`, `identity`, `nativeMessaging`, `storage`, `tabs`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25107" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
