### PR TITLE
Add filter query params and category counts to skills list endpoint

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -6386,7 +6386,9 @@ paths:
     get:
       operationId: skills_get
       summary: List all skills
-      description: Return all installed skills. Pass ?include=catalog to also include available catalog skills.
+      description:
+        "Return all installed skills. Pass ?include=catalog to also include available catalog skills. Supports
+        optional filter params: origin, kind, q, category."
       tags:
         - skills
       responses:
@@ -6589,6 +6591,16 @@ paths:
                             - origin
                           additionalProperties: false
                     description: Skill objects
+                  categoryCounts:
+                    description: Count of skills per category (before category filter is applied)
+                    type: object
+                    propertyNames:
+                      type: string
+                    additionalProperties:
+                      type: number
+                  totalCount:
+                    description: Total number of skills matching non-category filters
+                    type: number
                 required:
                   - skills
                 additionalProperties: false
@@ -6601,6 +6613,30 @@ paths:
             enum:
               - catalog
           description: Optional inclusion flag. Use 'catalog' to merge available Vellum catalog skills into the response.
+        - name: origin
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Filter by skill origin (e.g. 'vellum', 'clawhub', 'skillssh', 'custom').
+        - name: kind
+          in: query
+          required: false
+          schema:
+            type: string
+          description: "Filter by kind: 'installed' (includes bundled), 'available', or pass through as skill.kind."
+        - name: q
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Text search across skill name, description, id, and origin label.
+        - name: category
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Filter by inferred category (e.g. 'communication', 'productivity').
     post:
       operationId: skills_post
       summary: Create skill

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -467,6 +467,134 @@ export async function listSkillsWithCatalog(
   return merged;
 }
 
+// ─── Filtered skill listing ──────────────────────────────────────────────────
+
+export interface SkillListFilter {
+  origin?: string;
+  kind?: string;
+  q?: string;
+  category?: string;
+}
+
+/** Human-readable labels matching Swift's `sourceLabel`. */
+export function originDisplayLabel(origin: string): string {
+  switch (origin) {
+    case "vellum":
+      return "Vellum";
+    case "clawhub":
+      return "Clawhub";
+    case "skillssh":
+      return "skills.sh";
+    case "custom":
+      return "Custom";
+    default:
+      return origin;
+  }
+}
+
+/** Check if a skill's origin matches a text query (matching Swift logic). */
+export function originMatchesQuery(origin: string, query: string): boolean {
+  const label = originDisplayLabel(origin).toLowerCase();
+  if (label.includes(query)) return true;
+  // "community" umbrella matches clawhub and skillssh
+  if (
+    (origin === "clawhub" || origin === "skillssh") &&
+    "community".includes(query)
+  ) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * List skills with filtering, category counts, and sorting.
+ * Calls listSkillsWithCatalog for the full merged list, then applies filters.
+ */
+export async function listSkillsFiltered(
+  filter: SkillListFilter,
+  ctx: SkillOperationContext,
+): Promise<{
+  skills: SlimSkillResponse[];
+  categoryCounts: Record<string, number>;
+  totalCount: number;
+}> {
+  let skills = await listSkillsWithCatalog(ctx);
+
+  // Apply origin filter
+  if (filter.origin) {
+    skills = skills.filter((s) => s.origin === filter.origin);
+  }
+
+  // Apply kind/status filter
+  if (filter.kind) {
+    switch (filter.kind) {
+      case "installed":
+        skills = skills.filter(
+          (s) => s.kind === "installed" || s.kind === "bundled",
+        );
+        break;
+      case "available":
+        skills = skills.filter((s) => s.status === "available");
+        break;
+      default:
+        skills = skills.filter((s) => s.kind === filter.kind);
+        break;
+    }
+  }
+
+  // Apply text search
+  if (filter.q) {
+    const query = filter.q.trim().toLowerCase();
+    if (query) {
+      skills = skills.filter((s) => {
+        if (s.name.toLowerCase().includes(query)) return true;
+        if (s.description.toLowerCase().includes(query)) return true;
+        if (s.id.toLowerCase().includes(query)) return true;
+        if (originMatchesQuery(s.origin, query)) return true;
+        return false;
+      });
+    }
+  }
+
+  // Compute category counts BEFORE applying the category filter
+  const categoryCounts: Record<string, number> = {};
+  for (const s of skills) {
+    const cat = inferCategory(s.name, s.description);
+    categoryCounts[cat] = (categoryCounts[cat] ?? 0) + 1;
+  }
+  const totalCount = skills.length;
+
+  // Apply category filter
+  if (filter.category) {
+    skills = skills.filter(
+      (s) => inferCategory(s.name, s.description) === filter.category,
+    );
+  }
+
+  // Sort: installed first, community origins before core within installed,
+  // then alphabetical by name (matching Swift sorting logic)
+  skills.sort((a, b) => {
+    // Installed (bundled + installed) before catalog (available)
+    const aInstalled = a.kind === "installed" || a.kind === "bundled" ? 0 : 1;
+    const bInstalled = b.kind === "installed" || b.kind === "bundled" ? 0 : 1;
+    if (aInstalled !== bInstalled) return aInstalled - bInstalled;
+
+    // Within installed, community origins (clawhub, skillssh) before core (vellum)
+    if (aInstalled === 0 && bInstalled === 0) {
+      const aCommunity =
+        a.origin === "clawhub" || a.origin === "skillssh" ? 0 : 1;
+      const bCommunity =
+        b.origin === "clawhub" || b.origin === "skillssh" ? 0 : 1;
+      if (aCommunity !== bCommunity) return aCommunity - bCommunity;
+    }
+
+    // Alphabetical by name
+    return a.name.localeCompare(b.name);
+  });
+
+  return { skills, categoryCounts, totalCount };
+}
+
 /** Look up a single skill by ID from the resolved catalog, returning its SlimSkillResponse. */
 function findSkillById(
   skillId: string,

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -474,6 +474,7 @@ export interface SkillListFilter {
   kind?: string;
   q?: string;
   category?: string;
+  includeCatalog?: boolean;
 }
 
 /** Human-readable labels matching Swift's `sourceLabel`. */
@@ -518,7 +519,10 @@ export async function listSkillsFiltered(
   categoryCounts: Record<string, number>;
   totalCount: number;
 }> {
-  let skills = await listSkillsWithCatalog(ctx);
+  let skills =
+    filter.includeCatalog !== false
+      ? await listSkillsWithCatalog(ctx)
+      : listSkills(ctx);
 
   // Apply origin filter
   if (filter.origin) {

--- a/assistant/src/daemon/message-types/skills.ts
+++ b/assistant/src/daemon/message-types/skills.ts
@@ -129,6 +129,13 @@ export interface SkillsListResponse {
   skills: SlimSkillResponse[];
 }
 
+export interface SkillsListFilteredResponse {
+  type: "skills_list_response";
+  skills: SlimSkillResponse[];
+  categoryCounts: Record<string, number>;
+  totalCount: number;
+}
+
 export interface SkillStateChanged {
   type: "skills_state_changed";
   name: string;

--- a/assistant/src/runtime/routes/skills-routes.ts
+++ b/assistant/src/runtime/routes/skills-routes.ts
@@ -203,6 +203,7 @@ export function skillRouteDefinitions(deps: SkillRouteDeps): RouteDefinition[] {
               ...(kind ? { kind } : {}),
               ...(q ? { q } : {}),
               ...(category ? { category } : {}),
+              includeCatalog: include === "catalog",
             },
             ctx(),
           );

--- a/assistant/src/runtime/routes/skills-routes.ts
+++ b/assistant/src/runtime/routes/skills-routes.ts
@@ -24,7 +24,7 @@ import {
   inspectSkill,
   installSkill,
   listSkills,
-  listSkillsWithCatalog,
+  listSkillsFiltered,
   searchSkills,
   uninstallSkill,
   updateSkill,
@@ -140,7 +140,7 @@ export function skillRouteDefinitions(deps: SkillRouteDeps): RouteDefinition[] {
       policyKey: "skills",
       summary: "List all skills",
       description:
-        "Return all installed skills. Pass ?include=catalog to also include available catalog skills.",
+        "Return all installed skills. Pass ?include=catalog to also include available catalog skills. Supports optional filter params: origin, kind, q, category.",
       tags: ["skills"],
       queryParams: [
         {
@@ -149,16 +149,72 @@ export function skillRouteDefinitions(deps: SkillRouteDeps): RouteDefinition[] {
           description:
             "Optional inclusion flag. Use 'catalog' to merge available Vellum catalog skills into the response.",
         },
+        {
+          name: "origin",
+          schema: { type: "string" },
+          description:
+            "Filter by skill origin (e.g. 'vellum', 'clawhub', 'skillssh', 'custom').",
+        },
+        {
+          name: "kind",
+          schema: { type: "string" },
+          description:
+            "Filter by kind: 'installed' (includes bundled), 'available', or pass through as skill.kind.",
+        },
+        {
+          name: "q",
+          schema: { type: "string" },
+          description:
+            "Text search across skill name, description, id, and origin label.",
+        },
+        {
+          name: "category",
+          schema: { type: "string" },
+          description:
+            "Filter by inferred category (e.g. 'communication', 'productivity').",
+        },
       ],
       responseBody: z.object({
         skills: z.array(slimSkillSchema).describe("Skill objects"),
+        categoryCounts: z
+          .record(z.string(), z.number())
+          .optional()
+          .describe(
+            "Count of skills per category (before category filter is applied)",
+          ),
+        totalCount: z
+          .number()
+          .optional()
+          .describe("Total number of skills matching non-category filters"),
       }),
       handler: async ({ url }) => {
         const include = url.searchParams.get("include");
-        const skills =
-          include === "catalog"
-            ? await listSkillsWithCatalog(ctx())
-            : listSkills(ctx());
+        const origin = url.searchParams.get("origin");
+        const kind = url.searchParams.get("kind");
+        const q = url.searchParams.get("q");
+        const category = url.searchParams.get("category");
+
+        const hasFilter = !!(origin || kind || q || category);
+
+        if (hasFilter || include === "catalog") {
+          const result = await listSkillsFiltered(
+            {
+              ...(origin ? { origin } : {}),
+              ...(kind ? { kind } : {}),
+              ...(q ? { q } : {}),
+              ...(category ? { category } : {}),
+            },
+            ctx(),
+          );
+          return Response.json({
+            skills: result.skills,
+            categoryCounts: result.categoryCounts,
+            totalCount: result.totalCount,
+          });
+        }
+
+        // No filter params and include !== catalog: preserve existing behavior
+        const skills = listSkills(ctx());
         return Response.json({ skills });
       },
     },


### PR DESCRIPTION
## Summary
- Add origin, kind, q, and category query params to GET /v1/skills
- Return categoryCounts and totalCount in filtered responses
- Add listSkillsFiltered function with origin/status/text/category filtering
- Preserve existing behavior when no filter params are provided

Part of plan: server-side-skill-filtering.md (PR 2 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25108" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
