### PR TITLE
refactor(stt): derive API-key provider names from STT provider catalog

### DIFF
--- a/assistant/src/providers/__tests__/provider-secret-catalog.test.ts
+++ b/assistant/src/providers/__tests__/provider-secret-catalog.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+
+import { API_KEY_PROVIDERS } from "../provider-secret-catalog.js";
+
+// ---------------------------------------------------------------------------
+// API_KEY_PROVIDERS derivation invariants
+// ---------------------------------------------------------------------------
+
+describe("API_KEY_PROVIDERS", () => {
+  test("includes deepgram (STT catalog-derived)", () => {
+    expect(API_KEY_PROVIDERS).toContain("deepgram");
+  });
+
+  test("includes openai exactly once (shared by LLM and STT)", () => {
+    const occurrences = API_KEY_PROVIDERS.filter((p) => p === "openai");
+    expect(occurrences.length).toBe(1);
+  });
+
+  test("contains no duplicate entries", () => {
+    const unique = new Set(API_KEY_PROVIDERS);
+    expect(API_KEY_PROVIDERS.length).toBe(unique.size);
+  });
+
+  test("is deterministic across calls", () => {
+    // Re-import would return the same module-level constant, but this
+    // validates that the composition does not introduce non-determinism.
+    const first = [...API_KEY_PROVIDERS];
+    const second = [...API_KEY_PROVIDERS];
+    expect(first).toEqual(second);
+  });
+
+  test("includes core LLM providers", () => {
+    expect(API_KEY_PROVIDERS).toContain("anthropic");
+    expect(API_KEY_PROVIDERS).toContain("openai");
+    expect(API_KEY_PROVIDERS).toContain("gemini");
+  });
+});

--- a/assistant/src/providers/provider-secret-catalog.ts
+++ b/assistant/src/providers/provider-secret-catalog.ts
@@ -6,8 +6,8 @@
  *
  * 1. **LLM / search providers** -- statically declared here because they
  *    have no separate catalog module yet.
- * 2. **STT providers** -- statically declared here because no STT
- *    provider-catalog module exists yet.
+ * 2. **STT providers** -- dynamically derived from the canonical STT
+ *    provider catalog by reading credential-provider names.
  * 3. **TTS catalog providers** -- dynamically derived from the canonical
  *    TTS provider catalog by selecting entries whose secret requirements
  *    use the bare-name (non-credential) storage convention.
@@ -18,6 +18,7 @@
  */
 
 import { listCatalogProviders } from "../tts/provider-catalog.js";
+import { listCredentialProviderNames as listSttCredentialProviderNames } from "./speech-to-text/provider-catalog.js";
 
 // ---------------------------------------------------------------------------
 // Static LLM / search providers
@@ -43,19 +44,20 @@ const LLM_AND_SEARCH_API_KEY_PROVIDERS = [
 ] as const;
 
 // ---------------------------------------------------------------------------
-// Static STT providers
+// STT catalog-derived providers
 // ---------------------------------------------------------------------------
 
 /**
- * STT providers that store API keys under their bare provider name in the
- * secure credential store (e.g. `deepgram`).
- *
- * Declared statically because no STT provider-catalog module exists yet.
- * Providers whose credential key collides with an LLM provider (e.g.
- * `openai-whisper` uses the `openai` key which is already in the LLM
- * list) are intentionally omitted to avoid duplicates.
+ * Derive the deduplicated set of STT credential-provider names from the
+ * canonical STT provider catalog, filtering out names that already appear
+ * in the LLM/search list to avoid duplicates (e.g. `openai-whisper` maps
+ * to `"openai"` which is already present in
+ * {@link LLM_AND_SEARCH_API_KEY_PROVIDERS}).
  */
-const STT_API_KEY_PROVIDERS = ["deepgram"] as const;
+function sttApiKeyProviderNames(): string[] {
+  const llmSet = new Set<string>(LLM_AND_SEARCH_API_KEY_PROVIDERS);
+  return listSttCredentialProviderNames().filter((name) => !llmSet.has(name));
+}
 
 // ---------------------------------------------------------------------------
 // TTS catalog-derived providers
@@ -103,13 +105,15 @@ function catalogApiKeyProviderIds(): string[] {
  * - Provider availability checks
  *
  * Adding a new TTS provider to the catalog with a bare-name secret
- * requirement automatically includes it here. Adding a new LLM or
- * search provider requires appending to
+ * requirement automatically includes it here. Adding a new STT
+ * provider to the STT catalog automatically includes it here (shared
+ * credential names like `openai` are deduplicated against the LLM
+ * list). Adding a new LLM or search provider requires appending to
  * {@link LLM_AND_SEARCH_API_KEY_PROVIDERS} until those domains get
  * their own catalog modules.
  */
 export const API_KEY_PROVIDERS: readonly string[] = [
   ...LLM_AND_SEARCH_API_KEY_PROVIDERS,
-  ...STT_API_KEY_PROVIDERS,
+  ...sttApiKeyProviderNames(),
   ...catalogApiKeyProviderIds(),
 ] as const;

--- a/assistant/src/providers/speech-to-text/__tests__/provider-catalog.test.ts
+++ b/assistant/src/providers/speech-to-text/__tests__/provider-catalog.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  getCredentialProvider,
+  getProviderEntry,
+  listCredentialProviderNames,
+  listProviderEntries,
+  listProviderIds,
+  supportsBoundary,
+} from "../provider-catalog.js";
+
+// ---------------------------------------------------------------------------
+// Catalog invariants
+// ---------------------------------------------------------------------------
+
+describe("STT provider catalog", () => {
+  // -----------------------------------------------------------------------
+  // Stable IDs
+  // -----------------------------------------------------------------------
+
+  test("listProviderIds returns all known provider IDs", () => {
+    const ids = listProviderIds();
+    expect(ids).toContain("openai-whisper");
+    expect(ids).toContain("deepgram");
+  });
+
+  test("listProviderIds returns IDs in deterministic insertion order", () => {
+    const first = listProviderIds();
+    const second = listProviderIds();
+    expect(first).toEqual(second);
+  });
+
+  test("every ID returned by listProviderIds has a catalog entry", () => {
+    for (const id of listProviderIds()) {
+      expect(getProviderEntry(id)).toBeDefined();
+    }
+  });
+
+  // -----------------------------------------------------------------------
+  // Credential provider names
+  // -----------------------------------------------------------------------
+
+  test("listCredentialProviderNames returns deduplicated names", () => {
+    const names = listCredentialProviderNames();
+    const unique = new Set(names);
+    expect(names.length).toBe(unique.size);
+  });
+
+  test("listCredentialProviderNames includes expected providers", () => {
+    const names = listCredentialProviderNames();
+    // openai-whisper maps to "openai", deepgram maps to "deepgram"
+    expect(names).toContain("openai");
+    expect(names).toContain("deepgram");
+  });
+
+  test("listCredentialProviderNames returns names in deterministic order", () => {
+    const first = listCredentialProviderNames();
+    const second = listCredentialProviderNames();
+    expect(first).toEqual(second);
+  });
+
+  // -----------------------------------------------------------------------
+  // Entry-level invariants
+  // -----------------------------------------------------------------------
+
+  test("every entry has a non-empty credentialProvider", () => {
+    for (const entry of listProviderEntries()) {
+      expect(entry.credentialProvider.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("every entry has at least one supported boundary", () => {
+    for (const entry of listProviderEntries()) {
+      expect(entry.supportedBoundaries.size).toBeGreaterThan(0);
+    }
+  });
+
+  test("every entry ID matches its catalog key", () => {
+    for (const id of listProviderIds()) {
+      const entry = getProviderEntry(id);
+      expect(entry?.id).toBe(id);
+    }
+  });
+
+  // -----------------------------------------------------------------------
+  // Boundary support
+  // -----------------------------------------------------------------------
+
+  test("supportsBoundary returns true for supported boundaries", () => {
+    expect(supportsBoundary("openai-whisper", "daemon-batch")).toBe(true);
+    expect(supportsBoundary("deepgram", "daemon-batch")).toBe(true);
+  });
+
+  test("supportsBoundary returns false for unknown provider IDs", () => {
+    // Cast to bypass type checking for the test
+    expect(supportsBoundary("nonexistent" as never, "daemon-batch")).toBe(
+      false,
+    );
+  });
+
+  // -----------------------------------------------------------------------
+  // Credential lookup
+  // -----------------------------------------------------------------------
+
+  test("getCredentialProvider returns correct mapping", () => {
+    expect(getCredentialProvider("openai-whisper")).toBe("openai");
+    expect(getCredentialProvider("deepgram")).toBe("deepgram");
+  });
+
+  test("getCredentialProvider returns undefined for unknown ID", () => {
+    expect(getCredentialProvider("nonexistent" as never)).toBeUndefined();
+  });
+});

--- a/assistant/src/providers/speech-to-text/provider-catalog.ts
+++ b/assistant/src/providers/speech-to-text/provider-catalog.ts
@@ -130,3 +130,31 @@ export function supportsBoundary(
 ): boolean {
   return CATALOG.get(id)?.supportedBoundaries.has(boundary) ?? false;
 }
+
+/**
+ * Return all canonical provider IDs in deterministic (insertion) order.
+ */
+export function listProviderIds(): readonly SttProviderId[] {
+  return [...CATALOG.keys()];
+}
+
+/**
+ * Return the deduplicated set of credential-provider names used by STT
+ * providers, in deterministic (first-seen) order.
+ *
+ * Multiple STT providers may share a single credential provider (e.g.
+ * `openai-whisper` and a future `openai-realtime` both map to `"openai"`).
+ * This helper deduplicates so that callers composing API-key provider
+ * lists do not produce duplicate entries.
+ */
+export function listCredentialProviderNames(): readonly string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const entry of CATALOG.values()) {
+    if (!seen.has(entry.credentialProvider)) {
+      seen.add(entry.credentialProvider);
+      result.push(entry.credentialProvider);
+    }
+  }
+  return result;
+}


### PR DESCRIPTION
## Summary
- Add helper exports to STT provider catalog (listProviderIds, listCredentialProviderNames)
- Derive STT API-key names from catalog in provider-secret-catalog instead of hardcoded list
- Add tests for catalog invariants and API_KEY_PROVIDERS derivation

Part of plan: pre-google-stt-cleanup-unification.md (PR 1 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25109" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
