### PR TITLE
fix(macos): codify STT shared-vs-exclusive key behavior in settings

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -3060,6 +3060,37 @@ public final class SettingsStore: ObservableObject {
             .apiKeyProviderName ?? sttProviderId
     }
 
+    /// Whether the given STT provider owns its API key exclusively — i.e. the
+    /// key is not shared with any other service. Exclusive-key providers can
+    /// safely have their key cleared through the STT reset flow without
+    /// affecting other features.
+    ///
+    /// A provider's key is exclusive when its `apiKeyProviderName` matches its
+    /// own `id` (e.g. `deepgram` → `deepgram`). Shared-key providers map to a
+    /// different credential name (e.g. `openai-whisper` → `openai`).
+    ///
+    /// This helper is provider-agnostic: adding a new provider only requires a
+    /// catalog entry — no new conditionals here or in the UI layer.
+    static func sttKeyIsExclusive(for sttProviderId: String) -> Bool {
+        let entry = loadSTTProviderRegistry().provider(withId: sttProviderId)
+        guard let entry else {
+            // Unknown providers are assumed exclusive — clearing an unknown
+            // key cannot collide with a known service.
+            return true
+        }
+        return entry.apiKeyProviderName == entry.id
+    }
+
+    /// Whether the given STT provider's API key is shared with another
+    /// service. The inverse of `sttKeyIsExclusive(for:)`.
+    ///
+    /// Shared-key providers should not expose a "Reset" action in the STT
+    /// settings card because clearing the key would break the sibling service
+    /// that depends on it.
+    static func sttKeyIsShared(for sttProviderId: String) -> Bool {
+        !sttKeyIsExclusive(for: sttProviderId)
+    }
+
     /// Schedules a delayed refresh of provider routing sources, giving the
     /// daemon time to re-initialize providers after a key change.
     private func scheduleRoutingSourceRefresh() {

--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -503,6 +503,25 @@ struct VoiceSettingsView: View {
         return APIKeyManager.getKey(for: keyProvider) != nil
     }
 
+    // MARK: - STT Key Ownership Helpers
+
+    /// Whether the STT reset button should be shown for the current provider.
+    ///
+    /// The reset button is only shown when:
+    /// 1. A key already exists for the provider, AND
+    /// 2. The provider owns its key exclusively (not shared with another
+    ///    service like Inference).
+    ///
+    /// This prevents accidental clearing of shared credentials — e.g.
+    /// resetting `openai-whisper` must not delete the `openai` key that
+    /// Inference also depends on.
+    ///
+    /// Provider-agnostic: adding a third STT provider only requires a
+    /// catalog entry, not a new conditional here.
+    private var sttResetAllowed: Bool {
+        sttProviderHasKey && SettingsStore.sttKeyIsExclusive(for: draftSTTProvider)
+    }
+
     /// Clears the stored TTS credential for the given provider.
     private func clearTTSCredential(for provider: String) {
         switch provider {
@@ -555,21 +574,17 @@ struct VoiceSettingsView: View {
                     }
                 }
 
-                // Save + Reset actions
+                // Save + Reset actions — reset is only shown for
+                // exclusive-key providers to avoid clearing shared
+                // credentials (e.g. `openai` used by both Inference and
+                // Whisper STT).
                 ServiceCardActions(
                     hasChanges: sttHasChanges,
                     isSaving: sttSaving,
                     onSave: { saveSTT() },
                     savingLabel: "Saving...",
-                    onReset: {
-                        store.clearSTTKey(sttProviderId: draftSTTProvider)
-                        sttProviderHasKey = false
-                        sttApiKeyText = ""
-                    },
-                    showReset: sttProviderHasKey && {
-                        let entry = sttRegistry.provider(withId: draftSTTProvider)
-                        return entry.map { $0.apiKeyProviderName == $0.id } ?? true
-                    }()
+                    onReset: { resetSTTKey() },
+                    showReset: sttResetAllowed
                 )
             }
         }
@@ -592,6 +607,17 @@ struct VoiceSettingsView: View {
             errorMessage: sttSaveError
         )
         .disabled(sttSaving)
+    }
+
+    // MARK: - STT Reset
+
+    /// Clears the STT API key for the current draft provider and resets the
+    /// associated UI state. Only called for exclusive-key providers — shared
+    /// credentials are never cleared through the STT settings card.
+    private func resetSTTKey() {
+        store.clearSTTKey(sttProviderId: draftSTTProvider)
+        sttProviderHasKey = false
+        sttApiKeyText = ""
     }
 
     // MARK: - STT Save

--- a/clients/macos/vellum-assistantTests/SettingsStoreVoiceServiceTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsStoreVoiceServiceTests.swift
@@ -310,4 +310,112 @@ final class SettingsStoreVoiceServiceTests: XCTestCase {
             "Most recent STT patch should reflect the deepgram provider"
         )
     }
+
+    // MARK: - STT Key Ownership Semantics
+
+    func testSharedKeyProviderIsNotExclusive() {
+        // openai-whisper maps to the "openai" credential — shared with
+        // Inference, so it must NOT be classified as exclusive.
+        XCTAssertFalse(
+            SettingsStore.sttKeyIsExclusive(for: "openai-whisper"),
+            "openai-whisper shares the 'openai' key and must not be exclusive"
+        )
+    }
+
+    func testSharedKeyProviderIsShared() {
+        XCTAssertTrue(
+            SettingsStore.sttKeyIsShared(for: "openai-whisper"),
+            "openai-whisper shares the 'openai' key and must be classified as shared"
+        )
+    }
+
+    func testExclusiveKeyProviderIsExclusive() {
+        // deepgram maps to "deepgram" — its own credential, not shared.
+        XCTAssertTrue(
+            SettingsStore.sttKeyIsExclusive(for: "deepgram"),
+            "deepgram owns its own key and must be classified as exclusive"
+        )
+    }
+
+    func testExclusiveKeyProviderIsNotShared() {
+        XCTAssertFalse(
+            SettingsStore.sttKeyIsShared(for: "deepgram"),
+            "deepgram owns its own key and must not be classified as shared"
+        )
+    }
+
+    func testUnknownProviderDefaultsToExclusive() {
+        // Unknown providers fall back to exclusive — clearing an unknown
+        // key cannot collide with a known service.
+        XCTAssertTrue(
+            SettingsStore.sttKeyIsExclusive(for: "future-provider"),
+            "Unknown providers should default to exclusive"
+        )
+    }
+
+    func testUnknownProviderIsNotShared() {
+        XCTAssertFalse(
+            SettingsStore.sttKeyIsShared(for: "future-provider"),
+            "Unknown providers should not be classified as shared"
+        )
+    }
+
+    // MARK: - Provider Mapping Stability
+
+    /// Ensures that every provider in the STT registry has a consistent
+    /// `apiKeyProviderName` mapping. This test fails fast when a new
+    /// provider is added with an inconsistent catalog entry.
+    func testAllRegistryProvidersHaveStableKeyMapping() {
+        let registry = loadSTTProviderRegistry()
+        for provider in registry.providers {
+            let resolved = SettingsStore.sttApiKeyProviderName(for: provider.id)
+            XCTAssertEqual(
+                resolved,
+                provider.apiKeyProviderName,
+                "sttApiKeyProviderName(for: \"\(provider.id)\") returned \"\(resolved)\" "
+                + "but the catalog entry specifies \"\(provider.apiKeyProviderName)\""
+            )
+        }
+    }
+
+    /// Ensures the ownership classification for every registered provider
+    /// is consistent with the catalog's `apiKeyProviderName` field.
+    func testAllRegistryProvidersHaveConsistentOwnership() {
+        let registry = loadSTTProviderRegistry()
+        for provider in registry.providers {
+            let isExclusive = SettingsStore.sttKeyIsExclusive(for: provider.id)
+            let expectedExclusive = (provider.apiKeyProviderName == provider.id)
+            XCTAssertEqual(
+                isExclusive,
+                expectedExclusive,
+                "Ownership mismatch for \"\(provider.id)\": sttKeyIsExclusive returned "
+                + "\(isExclusive) but apiKeyProviderName=\"\(provider.apiKeyProviderName)\" "
+                + "implies exclusive=\(expectedExclusive)"
+            )
+        }
+    }
+
+    /// Verifies that shared-key providers cannot be reset through the STT
+    /// card — the `sttKeyIsExclusive` guard prevents `clearSTTKey` from
+    /// being called for providers whose key is shared with another service.
+    func testSharedKeyProviderCannotBeResetThroughSTTFlow() {
+        // Simulate what the UI does: check sttKeyIsExclusive before
+        // allowing the reset action. For openai-whisper, the guard
+        // must prevent the reset.
+        let allowReset = SettingsStore.sttKeyIsExclusive(for: "openai-whisper")
+        XCTAssertFalse(
+            allowReset,
+            "The STT reset flow must not be allowed for shared-key providers"
+        )
+    }
+
+    /// Verifies that exclusive-key providers can be reset through the STT
+    /// card without affecting other services.
+    func testExclusiveKeyProviderCanBeResetSafely() {
+        let allowReset = SettingsStore.sttKeyIsExclusive(for: "deepgram")
+        XCTAssertTrue(
+            allowReset,
+            "The STT reset flow should be allowed for exclusive-key providers"
+        )
+    }
 }


### PR DESCRIPTION
## Summary
- Extract shared-key/exclusive-key decisions into named helpers in VoiceSettingsView
- Add STT key ownership helper methods to SettingsStore for testable behavior
- Add/expand tests for shared-key and exclusive-key provider reset flows

Part of plan: pre-google-stt-cleanup-unification.md (PR 4 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25110" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
