### PR TITLE
docs(chrome-ext): add CWS publishing steps to README

### DIFF
--- a/clients/chrome-extension/README.md
+++ b/clients/chrome-extension/README.md
@@ -38,6 +38,20 @@ bash build.sh
 
 Then in `chrome://extensions`, click **Reload** on the unpacked extension.
 
+## Publishing to Chrome Web Store
+
+To create a zip for manual upload to the [Chrome Web Store developer dashboard](https://chrome.google.com/webstore/devconsole):
+
+```bash
+cd clients/chrome-extension
+bash build.sh
+cd dist && zip -r ../vellum-browser-relay.zip .
+```
+
+Upload `vellum-browser-relay.zip` through the dashboard.
+
+For automated publishing, the `release.yml` GitHub Actions workflow builds, packages, and uploads to CWS when a release tag is created.
+
 ## Usage
 
 1. Open the extension popup.


### PR DESCRIPTION
## Summary
- Added a "Publishing to Chrome Web Store" section to the chrome extension README with manual zip build steps and a note about the automated CI release path
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25111" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
