### PR TITLE
feat(shared): add helper to check if LLM-based STT provider is configured

### DIFF
--- a/clients/shared/Utilities/STTProviderRegistry.swift
+++ b/clients/shared/Utilities/STTProviderRegistry.swift
@@ -53,13 +53,13 @@ public struct STTProviderRegistry: Decodable {
         providers.first { $0.id == id }
     }
 
-    /// Whether the daemon has an LLM-based STT provider configured
+    /// Whether the assistant has an LLM-based STT provider configured
     /// (e.g. Deepgram, OpenAI Whisper).
     ///
-    /// When `true`, the app can use the daemon's STT service for
+    /// When `true`, the app can use the assistant's STT service for
     /// transcription and native `SFSpeechRecognizer` permission is not
     /// required. The value is derived from the `sttProvider` key in
-    /// `UserDefaults`, which the daemon syncs via the
+    /// `UserDefaults`, which the assistant syncs via the
     /// `client_settings_update` message (see `SettingsStore`).
     public static var isServiceConfigured: Bool {
         guard let value = UserDefaults.standard.string(forKey: "sttProvider") else {

--- a/clients/shared/Utilities/STTProviderRegistry.swift
+++ b/clients/shared/Utilities/STTProviderRegistry.swift
@@ -52,6 +52,21 @@ public struct STTProviderRegistry: Decodable {
     public func provider(withId id: String) -> STTProviderCatalogEntry? {
         providers.first { $0.id == id }
     }
+
+    /// Whether the daemon has an LLM-based STT provider configured
+    /// (e.g. Deepgram, OpenAI Whisper).
+    ///
+    /// When `true`, the app can use the daemon's STT service for
+    /// transcription and native `SFSpeechRecognizer` permission is not
+    /// required. The value is derived from the `sttProvider` key in
+    /// `UserDefaults`, which the daemon syncs via the
+    /// `client_settings_update` message (see `SettingsStore`).
+    public static var isServiceConfigured: Bool {
+        guard let value = UserDefaults.standard.string(forKey: "sttProvider") else {
+            return false
+        }
+        return !value.isEmpty
+    }
 }
 
 // MARK: - Fallback


### PR DESCRIPTION
## Summary
- Add static `isServiceConfigured` computed property to `STTProviderRegistry`
- Reads `sttProvider` from UserDefaults (synced from daemon via client_settings_update)
- Returns true when an LLM-based STT provider (Deepgram, OpenAI Whisper) is configured

Part of plan: optional-speech-rec-with-stt.md (PR 1 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25112" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
