### PR TITLE
refactor(config): make services.stt.providers sparse to avoid per-provider migration churn

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -1166,8 +1166,8 @@ describe("AssistantConfigSchema", () => {
     });
     expect(result.services.stt.mode).toBe("your-own");
     expect(result.services.stt.provider).toBe("openai-whisper");
-    expect(result.services.stt.providers["openai-whisper"]).toEqual({});
-    expect(result.services.stt.providers.deepgram).toEqual({});
+    // providers defaults to empty sparse map
+    expect(result.services.stt.providers).toEqual({});
   });
 
   test("accepts valid services.stt provider override", () => {
@@ -1190,6 +1190,33 @@ describe("AssistantConfigSchema", () => {
       },
     });
     expect(result.services.stt.providers["openai-whisper"]).toEqual({});
+  });
+
+  test("parses when providers map is empty (sparse default)", () => {
+    const result = AssistantConfigSchema.parse({
+      services: { stt: { provider: "deepgram", providers: {} } },
+    });
+    expect(result.services.stt.providers).toEqual({});
+    expect(result.services.stt.provider).toBe("deepgram");
+  });
+
+  test("parses when unknown future provider blobs exist under providers", () => {
+    const result = AssistantConfigSchema.parse({
+      services: {
+        stt: {
+          provider: "openai-whisper",
+          providers: {
+            "openai-whisper": {},
+            "future-provider": { model: "next-gen", lang: "en" },
+          },
+        },
+      },
+    });
+    expect(result.services.stt.providers["openai-whisper"]).toEqual({});
+    expect(result.services.stt.providers["future-provider"]).toEqual({
+      model: "next-gen",
+      lang: "en",
+    });
   });
 
   test("rejects services.stt.mode = managed", () => {
@@ -1235,6 +1262,24 @@ describe("AssistantConfigSchema", () => {
         },
       },
     });
+    expect(result.services.stt.providers.deepgram).toEqual({});
+  });
+
+  test("existing configs with explicit per-provider objects continue to parse", () => {
+    // Simulates a config written by a previous migration that seeded both
+    // provider entries — these must continue to round-trip successfully.
+    const result = AssistantConfigSchema.parse({
+      services: {
+        stt: {
+          provider: "openai-whisper",
+          providers: {
+            "openai-whisper": {},
+            deepgram: {},
+          },
+        },
+      },
+    });
+    expect(result.services.stt.providers["openai-whisper"]).toEqual({});
     expect(result.services.stt.providers.deepgram).toEqual({});
   });
 

--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -1266,8 +1266,8 @@ describe("AssistantConfigSchema", () => {
   });
 
   test("existing configs with explicit per-provider objects continue to parse", () => {
-    // Simulates a config written by a previous migration that seeded both
-    // provider entries — these must continue to round-trip successfully.
+    // Configs with explicit per-provider objects must continue to
+    // parse and round-trip successfully.
     const result = AssistantConfigSchema.parse({
       services: {
         stt: {

--- a/assistant/src/__tests__/workspace-migration-033-stt-service-explicit-config.test.ts
+++ b/assistant/src/__tests__/workspace-migration-033-stt-service-explicit-config.test.ts
@@ -74,10 +74,8 @@ describe("033-stt-service-explicit-config migration", () => {
 
     expect(stt.mode).toBe("your-own");
     expect(stt.provider).toBe("openai-whisper");
-    expect(stt.providers).toEqual({
-      "openai-whisper": {},
-      deepgram: {},
-    });
+    // providers is sparse — no per-provider entries seeded
+    expect(stt.providers).toEqual({});
 
     // Other config keys preserved
     expect(config.maxTokens).toBe(64000);
@@ -98,10 +96,8 @@ describe("033-stt-service-explicit-config migration", () => {
 
     expect(stt.mode).toBe("your-own");
     expect(stt.provider).toBe("openai-whisper");
-    expect(stt.providers).toEqual({
-      "openai-whisper": {},
-      deepgram: {},
-    });
+    // providers is sparse — no per-provider entries seeded
+    expect(stt.providers).toEqual({});
 
     // Existing services preserved
     const inference = services.inference as Record<string, unknown>;
@@ -119,10 +115,8 @@ describe("033-stt-service-explicit-config migration", () => {
 
     expect(stt.mode).toBe("your-own");
     expect(stt.provider).toBe("openai-whisper");
-    expect(stt.providers).toEqual({
-      "openai-whisper": {},
-      deepgram: {},
-    });
+    // providers is sparse — no per-provider entries seeded
+    expect(stt.providers).toEqual({});
   });
 
   // ─── Partial STT object completion ────────────────────────────────────
@@ -171,7 +165,7 @@ describe("033-stt-service-explicit-config migration", () => {
     expect(stt.mode).toBe("your-own");
   });
 
-  test("fills in missing providers entries when stt has mode and provider", () => {
+  test("fills in missing providers as empty object when stt has mode and provider", () => {
     writeConfig({
       services: {
         stt: {
@@ -188,13 +182,12 @@ describe("033-stt-service-explicit-config migration", () => {
       string,
       unknown
     >;
-    const providers = stt.providers as Record<string, unknown>;
 
-    expect(providers["openai-whisper"]).toEqual({});
-    expect(providers.deepgram).toEqual({});
+    // providers is sparse — no per-provider entries seeded
+    expect(stt.providers).toEqual({});
   });
 
-  test("fills in missing deepgram entry when only openai-whisper exists in providers", () => {
+  test("does not inject per-provider entries when only openai-whisper exists in providers", () => {
     writeConfig({
       services: {
         stt: {
@@ -214,8 +207,9 @@ describe("033-stt-service-explicit-config migration", () => {
     >;
     const providers = stt.providers as Record<string, unknown>;
 
+    // Existing entry preserved, no new entries injected
     expect(providers["openai-whisper"]).toEqual({});
-    expect(providers.deepgram).toEqual({});
+    expect(providers.deepgram).toBeUndefined();
   });
 
   // ─── Preservation of explicit user provider overrides ─────────────────
@@ -428,6 +422,30 @@ describe("033-stt-service-explicit-config migration", () => {
         stt: {
           mode: "your-own",
           provider: "openai-whisper",
+          providers: {},
+        },
+      },
+    };
+    writeConfig(original);
+
+    // Capture the file's content before migration
+    const before = readFileSync(join(workspaceDir, "config.json"), "utf-8");
+
+    sttServiceExplicitConfigMigration.run(workspaceDir);
+
+    const after = readFileSync(join(workspaceDir, "config.json"), "utf-8");
+    // Content should be byte-identical since nothing changed
+    expect(after).toBe(before);
+  });
+
+  test("does not write file when nothing changed (config with per-provider entries from prior migration)", () => {
+    // Configs written by the old migration version had per-provider keys.
+    // The new migration must not re-write them — it should remain a no-op.
+    const original = {
+      services: {
+        stt: {
+          mode: "your-own",
+          provider: "openai-whisper",
           providers: {
             "openai-whisper": {},
             deepgram: {},
@@ -437,13 +455,11 @@ describe("033-stt-service-explicit-config migration", () => {
     };
     writeConfig(original);
 
-    // Capture the file's mtime before migration
     const before = readFileSync(join(workspaceDir, "config.json"), "utf-8");
 
     sttServiceExplicitConfigMigration.run(workspaceDir);
 
     const after = readFileSync(join(workspaceDir, "config.json"), "utf-8");
-    // Content should be byte-identical since nothing changed
     expect(after).toBe(before);
   });
 

--- a/assistant/src/__tests__/workspace-migration-033-stt-service-explicit-config.test.ts
+++ b/assistant/src/__tests__/workspace-migration-033-stt-service-explicit-config.test.ts
@@ -439,8 +439,8 @@ describe("033-stt-service-explicit-config migration", () => {
   });
 
   test("does not write file when nothing changed (config with per-provider entries from prior migration)", () => {
-    // Configs written by the old migration version had per-provider keys.
-    // The new migration must not re-write them — it should remain a no-op.
+    // Configs that include per-provider keys are already complete — the
+    // migration treats them as a no-op and must not rewrite the file.
     const original = {
       services: {
         stt: {

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -192,15 +192,8 @@ export {
   SkillsInstallConfigSchema,
   SkillsLoadConfigSchema,
 } from "./schemas/skills.js";
-export type {
-  SttDeepgramProviderConfig,
-  SttOpenAiWhisperProviderConfig,
-  SttProviders,
-  SttService,
-} from "./schemas/stt.js";
+export type { SttProviders, SttService } from "./schemas/stt.js";
 export {
-  SttDeepgramProviderConfigSchema,
-  SttOpenAiWhisperProviderConfigSchema,
   SttProvidersSchema,
   SttServiceSchema,
   VALID_STT_PROVIDERS,

--- a/assistant/src/config/schemas/services.ts
+++ b/assistant/src/config/schemas/services.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-import { SttProvidersSchema, SttServiceSchema } from "./stt.js";
+import { SttServiceSchema } from "./stt.js";
 import { TtsServiceSchema } from "./tts.js";
 
 export const ServiceModeSchema = z.enum(["managed", "your-own"]);
@@ -90,7 +90,7 @@ export const ServicesSchema = z.object({
   stt: SttServiceSchema.default({
     mode: "your-own" as const,
     provider: "openai-whisper" as const,
-    providers: SttProvidersSchema.parse({}),
+    providers: {},
   }),
   tts: TtsServiceSchema.default(TtsServiceSchema.parse({})),
   "google-oauth": GoogleOAuthServiceSchema.default(

--- a/assistant/src/config/schemas/stt.ts
+++ b/assistant/src/config/schemas/stt.ts
@@ -39,14 +39,22 @@ export type SttDeepgramProviderConfig = z.infer<
   typeof SttDeepgramProviderConfigSchema
 >;
 
-export const SttProvidersSchema = z.object({
-  "openai-whisper": SttOpenAiWhisperProviderConfigSchema.default(
-    SttOpenAiWhisperProviderConfigSchema.parse({}),
-  ),
-  deepgram: SttDeepgramProviderConfigSchema.default(
-    SttDeepgramProviderConfigSchema.parse({}),
-  ),
-});
+/**
+ * Sparse provider config map under `services.stt.providers`.
+ *
+ * This is a forward-compatible record that accepts any provider ID as key
+ * with an object value. Existing known providers (`openai-whisper`,
+ * `deepgram`) are validated at schema level; unknown future provider
+ * entries are accepted and passed through so adding a new provider ID
+ * no longer requires a migration to seed `services.stt.providers.<id>`.
+ *
+ * The map only holds entries the user has explicitly configured — it is
+ * NOT required to enumerate every known provider.
+ */
+export const SttProvidersSchema = z.record(
+  z.string(),
+  z.record(z.string(), z.unknown()).default({}),
+);
 export type SttProviders = z.infer<typeof SttProvidersSchema>;
 
 /**
@@ -71,7 +79,7 @@ export const SttServiceSchema = z
         error: `services.stt.provider must be one of: ${VALID_STT_PROVIDERS.join(", ")}`,
       })
       .describe("Active STT provider used for speech-to-text transcription"),
-    providers: SttProvidersSchema.default(SttProvidersSchema.parse({})),
+    providers: SttProvidersSchema.default({}),
   })
   .describe(
     "Speech-to-text service configuration -- provider selection and per-provider settings",

--- a/assistant/src/config/schemas/stt.ts
+++ b/assistant/src/config/schemas/stt.ts
@@ -7,46 +7,13 @@ import { z } from "zod";
 export const VALID_STT_PROVIDERS = ["openai-whisper", "deepgram"] as const;
 
 /**
- * Per-provider config schemas nested under `services.stt.providers.<id>`.
- *
- * Each provider's schema is the full provider-specific config (tuning
- * params, etc.). New providers add sibling schemas without restructuring.
- *
- * The provider config is an empty object. Per-provider tuning params
- * (e.g., model, language) can be added here once the provider adapter
- * consumes them at runtime.
- */
-export const SttOpenAiWhisperProviderConfigSchema = z
-  .object({})
-  .describe("OpenAI Whisper provider configuration under services.stt");
-
-export type SttOpenAiWhisperProviderConfig = z.infer<
-  typeof SttOpenAiWhisperProviderConfigSchema
->;
-
-/**
- * Deepgram provider configuration under `services.stt.providers.deepgram`.
- *
- * Provider-specific tuning params (model, language, smart formatting)
- * can be added here as the adapter evolves. For now the schema is empty
- * so that adding the provider to config.json is friction-free.
- */
-export const SttDeepgramProviderConfigSchema = z
-  .object({})
-  .describe("Deepgram provider configuration under services.stt");
-
-export type SttDeepgramProviderConfig = z.infer<
-  typeof SttDeepgramProviderConfigSchema
->;
-
-/**
  * Sparse provider config map under `services.stt.providers`.
  *
  * This is a forward-compatible record that accepts any provider ID as key
- * with an object value. Existing known providers (`openai-whisper`,
- * `deepgram`) are validated at schema level; unknown future provider
- * entries are accepted and passed through so adding a new provider ID
- * no longer requires a migration to seed `services.stt.providers.<id>`.
+ * with an object value. All provider entries — known (`openai-whisper`,
+ * `deepgram`) and unknown — are accepted with generic object validation.
+ * Adding a new provider ID does not require a migration to seed
+ * `services.stt.providers.<id>`.
  *
  * The map only holds entries the user has explicitly configured — it is
  * NOT required to enumerate every known provider.

--- a/assistant/src/workspace/migrations/033-stt-service-explicit-config.ts
+++ b/assistant/src/workspace/migrations/033-stt-service-explicit-config.ts
@@ -20,7 +20,7 @@ import type { WorkspaceMigration } from "./types.js";
  *
  * It does NOT seed per-provider entries (`openai-whisper`, `deepgram`, etc.)
  * — the providers map is sparse and only holds entries the user explicitly
- * configures. Adding a new provider ID no longer requires a migration.
+ * configures. Adding a new provider ID does not require a migration.
  *
  * It never clobbers user-defined STT values — only fills in what is missing.
  *

--- a/assistant/src/workspace/migrations/033-stt-service-explicit-config.ts
+++ b/assistant/src/workspace/migrations/033-stt-service-explicit-config.ts
@@ -12,11 +12,15 @@ import type { WorkspaceMigration } from "./types.js";
  * to users and tooling that inspects config on disk.
  *
  * This migration writes a canonical `services.stt` block when missing or
- * partial, backfilling:
+ * partial, backfilling only structural fields:
  *
  *   - `services.stt.mode`      -> `"your-own"`
  *   - `services.stt.provider`  -> `"openai-whisper"`
- *   - `services.stt.providers` -> `{ "openai-whisper": {}, "deepgram": {} }`
+ *   - `services.stt.providers` -> `{}` (empty object — sparse map)
+ *
+ * It does NOT seed per-provider entries (`openai-whisper`, `deepgram`, etc.)
+ * — the providers map is sparse and only holds entries the user explicitly
+ * configures. Adding a new provider ID no longer requires a migration.
  *
  * It never clobbers user-defined STT values — only fills in what is missing.
  *
@@ -58,14 +62,14 @@ export const sttServiceExplicitConfigMigration: WorkspaceMigration = {
       changed = true;
     }
 
-    // Backfill providers map and its entries
-    const providers = ensureObj(stt, "providers");
-    if (!("openai-whisper" in providers)) {
-      providers["openai-whisper"] = {};
-      changed = true;
-    }
-    if (!("deepgram" in providers)) {
-      providers.deepgram = {};
+    // Ensure providers map exists as an object (sparse — no per-provider seeding)
+    if (
+      !("providers" in stt) ||
+      stt.providers == null ||
+      typeof stt.providers !== "object" ||
+      Array.isArray(stt.providers)
+    ) {
+      stt.providers = {};
       changed = true;
     }
 


### PR DESCRIPTION
## Summary
- Convert services.stt.providers from fully enumerated shape to sparse forward-compatible map
- Simplify migration 033 to only backfill structural fields, not per-provider keys
- Add tests for sparse-provider parsing and migration idempotency

Part of plan: pre-google-stt-cleanup-unification.md (PR 2 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25113" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
