### PR TITLE
Update Swift client and SkillsManager to use server-side filtering

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
@@ -36,10 +36,6 @@ final class SkillsManager {
     // Forward all published properties from SkillsStore so existing views
     // continue to work via observation on SkillsManager unchanged.
     var skills: [SkillInfo] = []
-    /// Cached skill-id -> category map, rebuilt whenever `skills` changes.
-    /// Use `category(for:)` for O(1) lookups instead of calling `inferCategory` in view bodies.
-    private(set) var categoryMap: [String: SkillCategory] = [:]
-    @ObservationIgnored private var categoryFingerprints: [String: String] = [:]
     var loadedBodies: [String: String] = [:]
     var isLoading = false
     var uninstallResult: SkillsStore.UninstallResult?
@@ -65,16 +61,15 @@ final class SkillsManager {
     var searchQuery: String = "" {
         didSet {
             dispatchSearch(query: searchQuery)
-            recomputeFilteredData()
         }
     }
 
     var selectedCategory: SkillCategory? {
-        didSet { recomputeFilteredData() }
+        didSet { fetchFilteredSkills() }
     }
 
     var skillFilter: SkillFilter = .all {
-        didSet { recomputeFilteredData() }
+        didSet { fetchFilteredSkills() }
     }
 
     // MARK: - Cached Derived Data (O(1) reads from views)
@@ -82,13 +77,13 @@ final class SkillsManager {
     /// Skills filtered by search + category + skill filter, sorted for display.
     private(set) var filteredSkills: [SkillInfo] = []
 
-    /// Per-category counts based on the current search + skill filter (excludes category filter).
+    /// Per-category counts from the server response, keyed by category raw value.
     private(set) var categoryCounts: [SkillCategory: Int] = [:]
 
-    /// Total count of skills matching search + skill filter (the "All" count).
+    /// Total count of skills matching the current filters (from server response).
     private(set) var searchFilteredCount: Int = 0
 
-    /// Whether the base skills (after skill filter, before search/category) are empty.
+    /// Whether the current filtered skills list is empty.
     private(set) var baseSkillsEmpty: Bool = true
 
     @ObservationIgnored private var cancellables = Set<AnyCancellable>()
@@ -139,7 +134,6 @@ final class SkillsManager {
                     mergedSkills = localSkills
                 }
                 self.skills = mergedSkills
-                self.rebuildCategoryMap(from: mergedSkills)
                 self.loadedBodies = self.skillsStore.loadedBodies
                 self.isLoading = self.skillsStore.isLoading
                 self.uninstallResult = self.skillsStore.uninstallResult
@@ -198,104 +192,53 @@ final class SkillsManager {
             .store(in: &cancellables)
     }
 
-    // MARK: - Category Lookup
+    // MARK: - Server-Side Filtered Fetch
 
-    /// O(1) category lookup for a skill. Falls back to `.knowledge` for unknown IDs.
-    func category(for skill: SkillInfo) -> SkillCategory {
-        categoryMap[skill.id] ?? .knowledge
-    }
-
-    private func rebuildCategoryMap(from skills: [SkillInfo]) {
-        var map: [String: SkillCategory] = [:]
-        var fingerprints: [String: String] = [:]
-        map.reserveCapacity(skills.count)
-        fingerprints.reserveCapacity(skills.count)
-        for skill in skills {
-            let fp = skill.name + "\0" + skill.description
-            if let cached = categoryMap[skill.id], categoryFingerprints[skill.id] == fp {
-                map[skill.id] = cached
-            } else {
-                map[skill.id] = inferCategory(skill)
+    /// Translates the current filter state into API params and triggers a server-side
+    /// filtered fetch. Called when the filter dropdown, category, or search query changes.
+    private func fetchFilteredSkills() {
+        let originParam: String? = {
+            switch skillFilter {
+            case .vellum: return "vellum"
+            case .clawhub: return "clawhub"
+            case .skillssh: return "skillssh"
+            case .custom: return "custom"
+            default: return nil
             }
-            fingerprints[skill.id] = fp
-        }
-        categoryMap = map
-        categoryFingerprints = fingerprints
+        }()
+        let kindParam: String? = {
+            switch skillFilter {
+            case .installed: return "installed"
+            case .available: return "available"
+            default: return nil
+            }
+        }()
+        let queryParam = searchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
+        let categoryParam = selectedCategory?.rawValue
+
+        skillsStore.fetchSkills(force: true, origin: originParam, kind: kindParam, query: queryParam.isEmpty ? nil : queryParam, category: categoryParam)
     }
 
     // MARK: - Recomputation
 
-    /// Single-pass O(N) recomputation of all derived data.
-    /// Called whenever any filter input or the underlying skills list changes.
+    /// Recompute derived display data from server-filtered skills.
+    /// Origin, kind, text search, and category filtering are now server-side.
+    /// This method merges external search results, updates category counts
+    /// from the server response, and applies display sorting.
     private func recomputeFilteredData() {
-        let query = searchQuery.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        let hasSearch = !query.isEmpty
-
-        let baseSkills: [SkillInfo]
-        switch skillFilter {
-        case .all:
-            baseSkills = skills
-        case .installed:
-            baseSkills = skills.filter { $0.isInstalled }
-        case .available:
-            baseSkills = skills.filter { $0.isAvailable }
-        case .vellum:
-            baseSkills = skills.filter { $0.origin == "vellum" }
-        case .clawhub:
-            baseSkills = skills.filter { $0.origin == "clawhub" }
-        case .skillssh:
-            baseSkills = skills.filter { $0.origin == "skillssh" }
-        case .custom:
-            baseSkills = skills.filter { $0.origin == "custom" }
-        }
-
-        let searchFiltered: [SkillInfo]
-        if hasSearch {
-            // When external search results have been merged in, the backend
-            // already performed fuzzy/semantic matching — backend-matched
-            // skills pass through unfiltered (they may not contain the query
-            // as a literal substring, e.g. skills.sh results with empty
-            // descriptions). Local-only skills still get the substring
-            // filter so they don't bypass search.
-            let backendIds = Set(skillsStore.searchResults.map(\.id))
-            let backendResultsPresent = !skillsStore.isSearching && baseSkills.contains(where: { backendIds.contains($0.id) })
-            if backendResultsPresent {
-                searchFiltered = baseSkills.filter {
-                    backendIds.contains($0.id) ||
-                    $0.name.lowercased().contains(query) ||
-                    $0.description.lowercased().contains(query) ||
-                    $0.id.lowercased().contains(query) ||
-                    Self.originMatchesQuery($0.origin, query: query)
-                }
-            } else {
-                searchFiltered = baseSkills.filter {
-                    $0.name.lowercased().contains(query) ||
-                    $0.description.lowercased().contains(query) ||
-                    $0.id.lowercased().contains(query) ||
-                    Self.originMatchesQuery($0.origin, query: query)
-                }
-            }
-        } else {
-            searchFiltered = baseSkills
-        }
-
+        // Convert server-provided category counts (String keys) to SkillCategory keys.
         var counts: [SkillCategory: Int] = [:]
-        for skill in searchFiltered {
-            let cat = category(for: skill)
-            counts[cat, default: 0] += 1
+        for (key, value) in skillsStore.categoryCounts {
+            if let cat = SkillCategory(rawValue: key) {
+                counts[cat] = value
+            }
         }
         categoryCounts = counts
-        searchFilteredCount = searchFiltered.count
-        baseSkillsEmpty = baseSkills.isEmpty
+        searchFilteredCount = skillsStore.totalCount
+        baseSkillsEmpty = skills.isEmpty
 
-        let categoryFiltered: [SkillInfo]
-        if let category = selectedCategory {
-            categoryFiltered = searchFiltered.filter { self.category(for: $0) == category }
-        } else {
-            categoryFiltered = searchFiltered
-        }
-
-        filteredSkills = categoryFiltered.sorted { a, b in
+        // Sort for display: installed first, community origins before core, alphabetical.
+        filteredSkills = skills.sorted { a, b in
             if a.isInstalled != b.isInstalled { return a.isInstalled }
             let aCommunity = (a.origin == "clawhub" || a.origin == "skillssh")
             let bCommunity = (b.origin == "clawhub" || b.origin == "skillssh")
@@ -322,15 +265,6 @@ final class SkillsManager {
         }
     }
 
-    /// Whether a search query matches any searchable term for a skill origin.
-    /// Includes both the display label (e.g. "Clawhub") and the umbrella
-    /// term "community" so users can still discover community skills by searching.
-    static func originMatchesQuery(_ origin: String, query: String) -> Bool {
-        if sourceLabel(origin).lowercased().contains(query) { return true }
-        if (origin == "clawhub" || origin == "skillssh") && "community".contains(query) { return true }
-        return false
-    }
-
     // MARK: - Debounced Search
 
     private func dispatchSearch(query: String) {
@@ -342,6 +276,8 @@ final class SkillsManager {
         let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else {
             isSearching = false
+            // Re-fetch with current filters but no query to reset the list.
+            fetchFilteredSkills()
             return
         }
         // Show spinner immediately during the debounce window so the user
@@ -350,7 +286,10 @@ final class SkillsManager {
         searchDebounceTask = Task { [weak self] in
             try? await Task.sleep(nanoseconds: 300_000_000)
             guard !Task.isCancelled else { return }
+            // Trigger both the external registry search and the server-side
+            // filtered fetch with the query param in parallel.
             self?.skillsStore.searchSkills(query: trimmed, force: true)
+            self?.fetchFilteredSkills()
             self?.searchDebounceTask = nil
         }
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
@@ -225,6 +225,12 @@ final class SkillsManager {
     /// Origin, kind, text search, and category filtering are now server-side.
     /// This method merges external search results, updates category counts
     /// from the server response, and applies display sorting.
+    ///
+    /// After merging external search results into the skills list, a local
+    /// filter pass removes any items that don't match the active origin/kind
+    /// filter. This is a safety net: external search results bypass the
+    /// server-side filter and could otherwise surface unfiltered catalog
+    /// hits when e.g. the Installed filter is active.
     private func recomputeFilteredData() {
         // Convert server-provided category counts (String keys) to SkillCategory keys.
         var counts: [SkillCategory: Int] = [:]
@@ -237,8 +243,30 @@ final class SkillsManager {
         searchFilteredCount = skillsStore.totalCount
         baseSkillsEmpty = skills.isEmpty
 
+        // Re-apply the current origin/kind filter locally as a safety net
+        // for merged external search results that weren't in the original
+        // server response.
+        let localFiltered = skills.filter { skill in
+            switch skillFilter {
+            case .all:
+                return true
+            case .installed:
+                return skill.isInstalled
+            case .available:
+                return !skill.isInstalled
+            case .vellum:
+                return skill.origin == "vellum"
+            case .clawhub:
+                return skill.origin == "clawhub"
+            case .skillssh:
+                return skill.origin == "skillssh"
+            case .custom:
+                return skill.origin == "custom"
+            }
+        }
+
         // Sort for display: installed first, community origins before core, alphabetical.
-        filteredSkills = skills.sorted { a, b in
+        filteredSkills = localFiltered.sorted { a, b in
             if a.isInstalled != b.isInstalled { return a.isInstalled }
             let aCommunity = (a.origin == "clawhub" || a.origin == "skillssh")
             let bCommunity = (b.origin == "clawhub" || b.origin == "skillssh")

--- a/clients/shared/Features/Skills/SkillsStore.swift
+++ b/clients/shared/Features/Skills/SkillsStore.swift
@@ -15,6 +15,9 @@ public final class SkillsStore: ObservableObject {
     @Published public var loadedBodies: [String: String] = [:]
     @Published public var isLoading = false
 
+    @Published public var categoryCounts: [String: Int] = [:]
+    @Published public var totalCount: Int = 0
+
     @Published public var searchResults: [SkillInfo] = []
     @Published public var isSearching = false
 
@@ -115,15 +118,17 @@ public final class SkillsStore: ObservableObject {
 
     // MARK: - Fetch Skills
 
-    public func fetchSkills(force: Bool = false) {
+    public func fetchSkills(force: Bool = false, origin: String? = nil, kind: String? = nil, query: String? = nil, category: String? = nil) {
         guard !isLoading else { return }
         if !force && !skills.isEmpty { return }
         isLoading = true
 
         Task {
-            let response = await skillsClient.fetchSkillsList(includeCatalog: true)
+            let response = await skillsClient.fetchSkillsList(includeCatalog: true, origin: origin, kind: kind, query: query, category: category)
             if let response {
                 skills = response.skills
+                categoryCounts = response.categoryCounts ?? [:]
+                totalCount = response.totalCount ?? response.skills.count
             }
             isLoading = false
         }

--- a/clients/shared/Features/Skills/SkillsStore.swift
+++ b/clients/shared/Features/Skills/SkillsStore.swift
@@ -95,6 +95,7 @@ public final class SkillsStore: ObservableObject {
 
     private let skillsClient: SkillsClientProtocol
     private var lastSearchQuery: String?
+    private var fetchTask: Task<Void, Never>?
     private var searchTask: Task<Void, Never>?
     private var draftTask: Task<Void, Never>?
     private var createTask: Task<Void, Never>?
@@ -105,6 +106,13 @@ public final class SkillsStore: ObservableObject {
     private var createGeneration: Int = 0
     private var currentDetailSkillId: String?
     private var currentFilesSkillId: String?
+
+    /// Last-used filter params, replayed by post-operation refreshes so
+    /// the user's active filter view is preserved after install/uninstall/etc.
+    private var lastOrigin: String?
+    private var lastKind: String?
+    private var lastQuery: String?
+    private var lastCategory: String?
 
     // MARK: - Init
 
@@ -119,12 +127,25 @@ public final class SkillsStore: ObservableObject {
     // MARK: - Fetch Skills
 
     public func fetchSkills(force: Bool = false, origin: String? = nil, kind: String? = nil, query: String? = nil, category: String? = nil) {
-        guard !isLoading else { return }
-        if !force && !skills.isEmpty { return }
+        if force {
+            // Cancel the in-flight fetch so the latest filter params always win.
+            fetchTask?.cancel()
+        } else {
+            guard !isLoading else { return }
+            if !skills.isEmpty { return }
+        }
+
+        // Remember the filter params so post-operation refreshes replay them.
+        lastOrigin = origin
+        lastKind = kind
+        lastQuery = query
+        lastCategory = category
+
         isLoading = true
 
-        Task {
+        fetchTask = Task {
             let response = await skillsClient.fetchSkillsList(includeCatalog: true, origin: origin, kind: kind, query: query, category: category)
+            guard !Task.isCancelled else { return }
             if let response {
                 skills = response.skills
                 categoryCounts = response.categoryCounts ?? [:]
@@ -196,7 +217,7 @@ public final class SkillsStore: ObservableObject {
             }
             installResult = result
             if result.success {
-                fetchSkills(force: true)
+                fetchSkills(force: true, origin: lastOrigin, kind: lastKind, query: lastQuery, category: lastCategory)
             }
             Task { @MainActor in
                 try? await Task.sleep(nanoseconds: 3_000_000_000)
@@ -224,7 +245,7 @@ public final class SkillsStore: ObservableObject {
             }
             uninstallResult = result
             if result.success {
-                fetchSkills(force: true)
+                fetchSkills(force: true, origin: lastOrigin, kind: lastKind, query: lastQuery, category: lastCategory)
             }
             Task { @MainActor in
                 try? await Task.sleep(nanoseconds: 3_000_000_000)
@@ -241,14 +262,14 @@ public final class SkillsStore: ObservableObject {
     public func enableSkill(name: String) {
         Task {
             _ = await skillsClient.enableSkill(name: name)
-            fetchSkills(force: true)
+            fetchSkills(force: true, origin: lastOrigin, kind: lastKind, query: lastQuery, category: lastCategory)
         }
     }
 
     public func disableSkill(name: String) {
         Task {
             _ = await skillsClient.disableSkill(name: name)
-            fetchSkills(force: true)
+            fetchSkills(force: true, origin: lastOrigin, kind: lastKind, query: lastQuery, category: lastCategory)
         }
     }
 
@@ -311,7 +332,7 @@ public final class SkillsStore: ObservableObject {
             )
             guard generation == self.createGeneration else { return }
             if response?.success == true {
-                fetchSkills(force: true)
+                fetchSkills(force: true, origin: lastOrigin, kind: lastKind, query: lastQuery, category: lastCategory)
             } else {
                 createError = response?.error ?? "Failed to create skill"
             }

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -987,8 +987,20 @@ extension SkillsListResponseSkill {
 }
 
 /// Response containing the list of available skills.
-/// Backed by generated `SkillsListResponse`.
-public typealias SkillsListResponseMessage = SkillsListResponse
+/// Wraps the generated `SkillsListResponse` with additional server-side filter metadata.
+public struct SkillsListResponseMessage: Codable, Sendable {
+    public let type: String
+    public let skills: [SkillsListResponseSkill]
+    public let categoryCounts: [String: Int]?
+    public let totalCount: Int?
+
+    public init(type: String, skills: [SkillsListResponseSkill], categoryCounts: [String: Int]? = nil, totalCount: Int? = nil) {
+        self.type = type
+        self.skills = skills
+        self.categoryCounts = categoryCounts
+        self.totalCount = totalCount
+    }
+}
 
 /// Response containing the full body of a specific skill.
 /// Backed by generated `SkillDetailResponse`.

--- a/clients/shared/Network/SkillsClient.swift
+++ b/clients/shared/Network/SkillsClient.swift
@@ -8,7 +8,7 @@ private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "Skill
 /// Covers listing, enabling, disabling, configuring, installing, uninstalling,
 /// updating, searching, drafting, and creating skills.
 public protocol SkillsClientProtocol {
-    func fetchSkillsList(includeCatalog: Bool) async -> SkillsListResponseMessage?
+    func fetchSkillsList(includeCatalog: Bool, origin: String?, kind: String?, query: String?, category: String?) async -> SkillsListResponseMessage?
     func enableSkill(name: String) async -> SkillOperationResult?
     func disableSkill(name: String) async -> SkillOperationResult?
     func configureSkill(name: String, env: [String: String]?, apiKey: String?, config: [String: AnyCodable]?) async -> SkillOperationResult?
@@ -39,11 +39,16 @@ public struct SkillsClient: SkillsClientProtocol {
         value.addingPercentEncoding(withAllowedCharacters: pathComponentAllowed) ?? value
     }
 
-    public func fetchSkillsList(includeCatalog: Bool) async -> SkillsListResponseMessage? {
+    public func fetchSkillsList(includeCatalog: Bool, origin: String? = nil, kind: String? = nil, query: String? = nil, category: String? = nil) async -> SkillsListResponseMessage? {
         do {
-            let params: [String: String]? = includeCatalog ? ["include": "catalog"] : nil
+            var params: [String: String] = [:]
+            if includeCatalog { params["include"] = "catalog" }
+            if let origin { params["origin"] = origin }
+            if let kind { params["kind"] = kind }
+            if let query, !query.isEmpty { params["q"] = query }
+            if let category { params["category"] = category }
             let response = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/skills", params: params, timeout: 10
+                path: "assistants/{assistantId}/skills", params: params.isEmpty ? nil : params, timeout: 10
             )
             guard response.isSuccess else {
                 log.error("fetchSkillsList failed (HTTP \(response.statusCode))")

--- a/clients/shared/Tests/SkillsFileContentTests.swift
+++ b/clients/shared/Tests/SkillsFileContentTests.swift
@@ -106,7 +106,7 @@ private actor MockSkillsFileContentStore {
 private struct MockSkillsClient: SkillsClientProtocol {
     let backing: MockSkillsFileContentStore
 
-    func fetchSkillsList(includeCatalog: Bool) async -> SkillsListResponseMessage? { nil }
+    func fetchSkillsList(includeCatalog: Bool, origin: String?, kind: String?, query: String?, category: String?) async -> SkillsListResponseMessage? { nil }
     func enableSkill(name: String) async -> SkillOperationResult? { nil }
     func disableSkill(name: String) async -> SkillOperationResult? { nil }
     func configureSkill(name: String, env: [String: String]?, apiKey: String?, config: [String: AnyCodable]?) async -> SkillOperationResult? { nil }


### PR DESCRIPTION
## Summary
- Update SkillsClient to pass origin, kind, q, and category filter params to GET /v1/skills
- Update SkillsStore to accept filter params and expose categoryCounts/totalCount
- Simplify SkillsManager to use server-provided filtered results instead of local filtering
- Remove client-side category inference, origin matching, and manual filter logic

Part of plan: server-side-skill-filtering.md (PR 3 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25114" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
