### PR TITLE
test(stt): enforce parity between daemon provider catalog and client STT catalog json

### DIFF
--- a/assistant/src/__tests__/stt-catalog-parity.test.ts
+++ b/assistant/src/__tests__/stt-catalog-parity.test.ts
@@ -2,12 +2,12 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
 
-import type { SttProviderId } from "../../../stt/types.js";
+import type { SttProviderId } from "../stt/types.js";
 import {
   getProviderEntry,
   listCredentialProviderNames,
   listProviderIds,
-} from "../provider-catalog.js";
+} from "../providers/speech-to-text/provider-catalog.js";
 
 /**
  * Parity guard: daemon STT provider catalog vs client STT catalog JSON.

--- a/assistant/src/__tests__/stt-catalog-parity.test.ts
+++ b/assistant/src/__tests__/stt-catalog-parity.test.ts
@@ -2,12 +2,12 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
 
-import type { SttProviderId } from "../stt/types.js";
 import {
   getProviderEntry,
   listCredentialProviderNames,
   listProviderIds,
 } from "../providers/speech-to-text/provider-catalog.js";
+import type { SttProviderId } from "../stt/types.js";
 
 /**
  * Parity guard: daemon STT provider catalog vs client STT catalog JSON.

--- a/assistant/src/providers/speech-to-text/__tests__/stt-catalog-parity.test.ts
+++ b/assistant/src/providers/speech-to-text/__tests__/stt-catalog-parity.test.ts
@@ -1,0 +1,210 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+
+import type { SttProviderId } from "../../../stt/types.js";
+import {
+  getProviderEntry,
+  listCredentialProviderNames,
+  listProviderIds,
+} from "../provider-catalog.js";
+
+/**
+ * Parity guard: daemon STT provider catalog vs client STT catalog JSON.
+ *
+ * The daemon maintains its canonical provider catalog in
+ * `assistant/src/providers/speech-to-text/provider-catalog.ts`.
+ * The client-facing metadata lives in `meta/stt-provider-catalog.json` and is
+ * bundled into native clients at build time.
+ *
+ * These tests enforce that both catalogs stay in sync on the fields they
+ * share: provider IDs and credential-provider (apiKeyProviderName) mappings.
+ * CI will fail when they drift, forcing the developer to update whichever
+ * side fell behind.
+ */
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Resolve repo root (tests run from assistant/) */
+function getRepoRoot(): string {
+  return join(process.cwd(), "..");
+}
+
+interface ClientCatalogEntry {
+  id: string;
+  displayName: string;
+  subtitle: string;
+  setupMode: string;
+  setupHint: string;
+  apiKeyProviderName: string;
+}
+
+interface ClientCatalog {
+  version: number;
+  providers: ClientCatalogEntry[];
+}
+
+function loadClientCatalog(): ClientCatalog {
+  const catalogPath = join(getRepoRoot(), "meta", "stt-provider-catalog.json");
+  const raw = readFileSync(catalogPath, "utf-8");
+  return JSON.parse(raw);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("STT catalog parity: daemon vs client", () => {
+  // -----------------------------------------------------------------------
+  // Provider ID parity
+  // -----------------------------------------------------------------------
+
+  test("client catalog provider IDs match daemon catalog provider IDs", () => {
+    const daemonIds = listProviderIds();
+    const clientCatalog = loadClientCatalog();
+    const clientIds = clientCatalog.providers.map((p) => p.id);
+
+    // Every daemon provider ID must appear in the client catalog
+    const missingInClient = daemonIds.filter((id) => !clientIds.includes(id));
+    if (missingInClient.length > 0) {
+      const message = [
+        "Daemon catalog has provider IDs not present in meta/stt-provider-catalog.json.",
+        "",
+        "Missing in client catalog:",
+        ...missingInClient.map((id) => `  - ${id}`),
+        "",
+        "Add entries for these providers to meta/stt-provider-catalog.json.",
+      ].join("\n");
+      expect(missingInClient, message).toEqual([]);
+    }
+
+    // Every client catalog provider ID must appear in the daemon catalog
+    const missingInDaemon = clientIds.filter(
+      (id) => !daemonIds.includes(id as never),
+    );
+    if (missingInDaemon.length > 0) {
+      const message = [
+        "Client catalog (meta/stt-provider-catalog.json) has provider IDs not present in daemon catalog.",
+        "",
+        "Missing in daemon catalog:",
+        ...missingInDaemon.map((id) => `  - ${id}`),
+        "",
+        "Add entries for these providers to assistant/src/providers/speech-to-text/provider-catalog.ts.",
+      ].join("\n");
+      expect(missingInDaemon, message).toEqual([]);
+    }
+  });
+
+  test("daemon and client catalog list providers in the same order", () => {
+    const daemonIds = listProviderIds();
+    const clientCatalog = loadClientCatalog();
+    const clientIds = clientCatalog.providers.map((p) => p.id);
+
+    expect(clientIds).toEqual([...daemonIds]);
+  });
+
+  // -----------------------------------------------------------------------
+  // Credential provider name parity
+  // -----------------------------------------------------------------------
+
+  test("client catalog apiKeyProviderName values match daemon credential provider mappings", () => {
+    const daemonCredentialNames = listCredentialProviderNames();
+    const clientCatalog = loadClientCatalog();
+    const clientCredentialNames = clientCatalog.providers.map(
+      (p) => p.apiKeyProviderName,
+    );
+
+    // Deduplicate client names the same way the daemon does (first-seen order)
+    const seen = new Set<string>();
+    const deduplicatedClientNames: string[] = [];
+    for (const name of clientCredentialNames) {
+      if (!seen.has(name)) {
+        seen.add(name);
+        deduplicatedClientNames.push(name);
+      }
+    }
+
+    expect(deduplicatedClientNames).toEqual([...daemonCredentialNames]);
+  });
+
+  test("each client catalog entry apiKeyProviderName matches its daemon counterpart", () => {
+    const clientCatalog = loadClientCatalog();
+    const violations: string[] = [];
+
+    for (const clientEntry of clientCatalog.providers) {
+      const daemonEntry = getProviderEntry(clientEntry.id as SttProviderId);
+      if (!daemonEntry) {
+        // Covered by the provider ID parity test above
+        continue;
+      }
+      if (clientEntry.apiKeyProviderName !== daemonEntry.credentialProvider) {
+        violations.push(
+          `Provider "${clientEntry.id}": client apiKeyProviderName="${clientEntry.apiKeyProviderName}" ` +
+            `!= daemon credentialProvider="${daemonEntry.credentialProvider}"`,
+        );
+      }
+    }
+
+    if (violations.length > 0) {
+      const message = [
+        "Credential provider name mismatch between daemon and client catalogs.",
+        "",
+        "Violations:",
+        ...violations.map((v) => `  - ${v}`),
+        "",
+        "Update meta/stt-provider-catalog.json or assistant/src/providers/speech-to-text/provider-catalog.ts to match.",
+      ].join("\n");
+      expect(violations, message).toEqual([]);
+    }
+  });
+
+  // -----------------------------------------------------------------------
+  // Structural sanity
+  // -----------------------------------------------------------------------
+
+  test("client catalog JSON has a version field", () => {
+    const clientCatalog = loadClientCatalog();
+    expect(typeof clientCatalog.version).toBe("number");
+    expect(clientCatalog.version).toBeGreaterThanOrEqual(1);
+  });
+
+  test("client catalog has at least one provider", () => {
+    const clientCatalog = loadClientCatalog();
+    expect(clientCatalog.providers.length).toBeGreaterThan(0);
+  });
+
+  test("every client catalog entry has required fields", () => {
+    const clientCatalog = loadClientCatalog();
+    const violations: string[] = [];
+
+    for (const entry of clientCatalog.providers) {
+      if (!entry.id || typeof entry.id !== "string") {
+        violations.push(`Entry missing or invalid 'id'`);
+      }
+      if (!entry.displayName || typeof entry.displayName !== "string") {
+        violations.push(`${entry.id}: missing or invalid 'displayName'`);
+      }
+      if (
+        !entry.apiKeyProviderName ||
+        typeof entry.apiKeyProviderName !== "string"
+      ) {
+        violations.push(`${entry.id}: missing or invalid 'apiKeyProviderName'`);
+      }
+      if (!entry.setupMode || typeof entry.setupMode !== "string") {
+        violations.push(`${entry.id}: missing or invalid 'setupMode'`);
+      }
+    }
+
+    if (violations.length > 0) {
+      const message = [
+        "Client catalog entries have missing or invalid required fields.",
+        "",
+        "Violations:",
+        ...violations.map((v) => `  - ${v}`),
+      ].join("\n");
+      expect(violations, message).toEqual([]);
+    }
+  });
+});

--- a/clients/ios/Tests/STTProviderRegistryIOSTests.swift
+++ b/clients/ios/Tests/STTProviderRegistryIOSTests.swift
@@ -1,0 +1,90 @@
+#if canImport(UIKit)
+import XCTest
+
+@testable import VellumAssistantShared
+
+/// Tests verifying that the iOS STT provider selector works correctly
+/// with the shared ``STTProviderRegistry``.
+final class STTProviderRegistryIOSTests: XCTestCase {
+
+    // MARK: - Registry Loading
+
+    func testRegistryLoadsNonEmptyProviderList() {
+        let registry = loadSTTProviderRegistry()
+        XCTAssertFalse(registry.providers.isEmpty, "Registry should contain at least one provider")
+    }
+
+    func testRegistryContainsOpenAIWhisper() {
+        let registry = loadSTTProviderRegistry()
+        let entry = registry.provider(withId: "openai-whisper")
+        XCTAssertNotNil(entry, "Registry should contain an 'openai-whisper' provider")
+        XCTAssertEqual(entry?.displayName, "OpenAI Whisper")
+    }
+
+    // MARK: - Provider Lookup and Fallback
+
+    func testProviderLookupReturnsMatchingEntry() {
+        let registry = loadSTTProviderRegistry()
+        for provider in registry.providers {
+            let found = registry.provider(withId: provider.id)
+            XCTAssertNotNil(found, "Lookup should find provider with id '\(provider.id)'")
+            XCTAssertEqual(found?.id, provider.id)
+        }
+    }
+
+    func testProviderLookupReturnsNilForUnknownId() {
+        let registry = loadSTTProviderRegistry()
+        let result = registry.provider(withId: "nonexistent-provider-id")
+        XCTAssertNil(result, "Lookup should return nil for unknown provider IDs")
+    }
+
+    func testFallbackToFirstProviderForUnknownPersistedValue() {
+        let registry = loadSTTProviderRegistry()
+        // Simulate the fallback logic used in settings:
+        // registry.provider(withId: raw) ?? registry.providers.first
+        let unknownRaw = "deleted-provider"
+        let resolved = registry.provider(withId: unknownRaw) ?? registry.providers.first
+        XCTAssertNotNil(resolved, "Fallback should resolve to the first registry provider")
+        XCTAssertEqual(resolved?.id, registry.providers.first?.id)
+    }
+
+    // MARK: - API Key Provider Name
+
+    func testEveryEntryHasNonEmptyApiKeyProviderName() {
+        let registry = loadSTTProviderRegistry()
+        for provider in registry.providers {
+            XCTAssertFalse(
+                provider.apiKeyProviderName.isEmpty,
+                "Provider '\(provider.id)' should have a non-empty apiKeyProviderName"
+            )
+        }
+    }
+
+    func testOpenAIWhisperMapsToOpenAICredentialProvider() {
+        let registry = loadSTTProviderRegistry()
+        let entry = registry.provider(withId: "openai-whisper")
+        XCTAssertEqual(
+            entry?.apiKeyProviderName, "openai",
+            "openai-whisper should map to 'openai' credential provider"
+        )
+    }
+
+    func testDeepgramMapsToDeepgramCredentialProvider() {
+        let registry = loadSTTProviderRegistry()
+        let entry = registry.provider(withId: "deepgram")
+        XCTAssertEqual(
+            entry?.apiKeyProviderName, "deepgram",
+            "deepgram should map to 'deepgram' credential provider"
+        )
+    }
+
+    // MARK: - Default Provider Selection
+
+    func testDefaultProviderIdMatchesRegistryEntry() {
+        let registry = loadSTTProviderRegistry()
+        let defaultId = "openai-whisper" // matches the default STT provider in settings
+        let entry = registry.provider(withId: defaultId)
+        XCTAssertNotNil(entry, "Default provider ID '\(defaultId)' should exist in the registry")
+    }
+}
+#endif

--- a/clients/shared/Utilities/STTProviderRegistry.swift
+++ b/clients/shared/Utilities/STTProviderRegistry.swift
@@ -44,6 +44,12 @@ public struct STTProviderCatalogEntry: Decodable {
 /// The JSON file lives at `meta/stt-provider-catalog.json` and is copied
 /// into `Contents/Resources` by `build.sh`. It is the single source of
 /// truth for client-facing STT provider metadata.
+///
+/// The daemon maintains its own canonical catalog in
+/// `assistant/src/providers/speech-to-text/provider-catalog.ts`.
+/// A CI parity test (`stt-catalog-parity.test.ts`) enforces that provider
+/// IDs and credential-provider name mappings (`apiKeyProviderName`) remain
+/// aligned between the JSON file and the daemon catalog.
 public struct STTProviderRegistry: Decodable {
     public let version: Int
     public let providers: [STTProviderCatalogEntry]
@@ -59,6 +65,16 @@ public struct STTProviderRegistry: Decodable {
 /// Hard-coded fallback registry used when the bundled JSON is missing or
 /// corrupt. Keeps client startup resilient — the app can always show at
 /// least the current set of providers.
+///
+/// **Parity requirement**: The provider IDs and `apiKeyProviderName`
+/// mappings below MUST remain in sync with `meta/stt-provider-catalog.json`
+/// (the single source of truth for client-facing metadata) and with the
+/// daemon-side catalog in
+/// `assistant/src/providers/speech-to-text/provider-catalog.ts`.
+/// A CI parity test (`stt-catalog-parity.test.ts`) enforces alignment
+/// between the daemon catalog and the JSON file. If you add or rename a
+/// provider here, update both the JSON catalog and the daemon catalog to
+/// keep all three in lockstep.
 private let fallbackRegistry = STTProviderRegistry(
     version: 0,
     providers: [


### PR DESCRIPTION
## Summary
- Add daemon/client STT catalog parity test that reads meta/stt-provider-catalog.json
- Add iOS STT provider registry tests following existing TTS pattern
- Document parity relationship in STTProviderRegistry.swift comments

Part of plan: pre-google-stt-cleanup-unification.md (PR 3 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25115" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
