### PR TITLE
feat(macos): update permission overlay to only mention microphone when STT is configured

### DIFF
--- a/clients/macos/vellum-assistant/Features/Voice/PermissionPromptOverlay.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/PermissionPromptOverlay.swift
@@ -38,6 +38,7 @@ final class PermissionPromptOverlay {
         switch kind {
         case .firstUse:
             contentView = AnyView(FirstUsePromptView(
+                sttConfigured: STTProviderRegistry.isServiceConfigured,
                 onDismiss: { [weak self] in
                     self?.dismiss()
                     onDismiss()
@@ -121,8 +122,19 @@ final class PermissionPromptOverlay {
 // MARK: - First-Use Primer
 
 private struct FirstUsePromptView: View {
+    let sttConfigured: Bool
     let onDismiss: () -> Void
     let onContinue: () -> Void
+
+    private var title: String {
+        sttConfigured ? "Enable Microphone Access" : "Enable Speech Recognition"
+    }
+
+    private var subtitle: String {
+        sttConfigured
+            ? "Required for voice dictation and conversation."
+            : "So your words come out the way you meant them."
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -130,11 +142,11 @@ private struct FirstUsePromptView: View {
                 VIconView(.mic, size: 20)
                     .foregroundStyle(VColor.primaryBase)
 
-                Text("Enable Speech Recognition")
+                Text(title)
                     .font(VFont.titleSmall)
                     .foregroundStyle(VColor.contentDefault)
 
-                Text("So your words come out the way you meant them.")
+                Text(subtitle)
                     .font(VFont.bodyMediumLighter)
                     .foregroundStyle(VColor.contentSecondary)
                     .multilineTextAlignment(.center)
@@ -182,7 +194,7 @@ private struct DeniedPromptView: View {
 
     private var subtitle: String {
         switch deniedPermission {
-        case .microphone: "Dictation requires microphone access. Grant access in System Settings."
+        case .microphone: "Voice features require microphone access. Grant access in System Settings."
         case .speechRecognition: "Dictation requires speech recognition access. Grant access in System Settings."
         case .both: "Dictation requires microphone and speech recognition access. Grant access in System Settings."
         }


### PR DESCRIPTION
## Summary
- Update first-use primer to say 'Enable Microphone Access' when STT is configured
- Update denied overlay to say 'Voice features require microphone access' instead of 'Dictation requires'
- Existing copy unchanged when no STT provider is configured

Part of plan: optional-speech-rec-with-stt.md (PR 3 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25116" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
