### PR TITLE
feat(ios): show speech recognition as optional in onboarding when STT is configured

### DIFF
--- a/clients/ios/Views/OnboardingView.swift
+++ b/clients/ios/Views/OnboardingView.swift
@@ -359,7 +359,10 @@ struct PermissionsStep: View {
 
             VStack(spacing: VSpacing.lg) {
                 PermissionRowView(permission: .microphone)
-                PermissionRowView(permission: .speechRecognition)
+                PermissionRowView(
+                    permission: .speechRecognition,
+                    subtitle: STTProviderRegistry.isServiceConfigured ? "(Optional)" : nil
+                )
             }
             .padding(VSpacing.xl)
             .background(VColor.surfaceBase)

--- a/clients/ios/Views/Settings/PermissionRowView.swift
+++ b/clients/ios/Views/Settings/PermissionRowView.swift
@@ -4,12 +4,21 @@ import VellumAssistantShared
 
 struct PermissionRowView: View {
     let permission: PermissionManager.Permission
+    /// Optional subtitle shown below the permission name (e.g. "(Optional)").
+    var subtitle: String? = nil
     @State private var status: PermissionStatus = .notDetermined
     @Environment(\.scenePhase) private var scenePhase
 
     var body: some View {
         HStack {
-            Text(permissionName)
+            VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                Text(permissionName)
+                if let subtitle {
+                    Text(subtitle)
+                        .font(VFont.labelDefault)
+                        .foregroundStyle(VColor.contentTertiary)
+                }
+            }
             Spacer()
             statusIcon
             if status == .notDetermined {

--- a/clients/ios/Views/Settings/PrivacySection.swift
+++ b/clients/ios/Views/Settings/PrivacySection.swift
@@ -17,7 +17,7 @@ struct PrivacySection: View {
         Form {
             Section {
                 permissionRow(name: "Microphone", status: micStatus)
-                permissionRow(name: "Speech Recognition", status: speechStatus)
+                speechRecognitionRow
                 permissionRow(name: "Camera", status: cameraStatus)
                 permissionRow(name: "Notifications", status: notificationStatus)
             } header: {
@@ -31,6 +31,62 @@ struct PrivacySection: View {
         .onAppear { refreshAll() }
         .onChange(of: scenePhase) { _, newPhase in
             if newPhase == .active { refreshAll() }
+        }
+    }
+
+    // MARK: - Speech Recognition Row
+
+    /// Speech recognition row with conditional optional state when an LLM-based
+    /// STT provider is configured. When STT is available, a denied permission is
+    /// shown as a neutral "Not enabled (optional)" badge instead of the red
+    /// "Denied" badge.
+    @ViewBuilder
+    private var speechRecognitionRow: some View {
+        let sttConfigured = STTProviderRegistry.isServiceConfigured
+        if sttConfigured && speechStatus == .denied {
+            // Show neutral state — speech recognition is optional when STT is available
+            Button {
+                openSettings()
+            } label: {
+                HStack {
+                    Text("Speech Recognition")
+                        .foregroundStyle(VColor.contentDefault)
+                    Spacer()
+                    Text("Not enabled (optional)")
+                        .font(.caption2)
+                        .fontWeight(.medium)
+                        .foregroundStyle(VColor.contentTertiary)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(VColor.contentTertiary.opacity(0.15))
+                        .clipShape(Capsule())
+                }
+            }
+            .accessibilityLabel("Speech Recognition, not enabled, optional")
+            .accessibilityHint("Opens iOS Settings to grant access")
+        } else if sttConfigured && speechStatus == .notDetermined {
+            // Show neutral "not set" state with optional hint
+            Button {
+                openSettings()
+            } label: {
+                HStack {
+                    Text("Speech Recognition")
+                        .foregroundStyle(VColor.contentDefault)
+                    Spacer()
+                    Text("Not Set (optional)")
+                        .font(.caption2)
+                        .fontWeight(.medium)
+                        .foregroundStyle(VColor.systemMidStrong)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(VColor.systemMidStrong.opacity(0.15))
+                        .clipShape(Capsule())
+                }
+            }
+            .accessibilityLabel("Speech Recognition, not set, optional")
+            .accessibilityHint("Opens iOS Settings to grant access")
+        } else {
+            permissionRow(name: "Speech Recognition", status: speechStatus)
         }
     }
 


### PR DESCRIPTION
## Summary
- Onboarding shows speech recognition as '(Optional)' when STT is configured
- Privacy section shows 'Not enabled (optional)' instead of error state when STT is configured
- No change to UI when STT is not configured

Part of plan: optional-speech-rec-with-stt.md (PR 6 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25117" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
