### PR TITLE
Server-side skill filtering with category counts

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -6386,7 +6386,9 @@ paths:
     get:
       operationId: skills_get
       summary: List all skills
-      description: Return all installed skills. Pass ?include=catalog to also include available catalog skills.
+      description:
+        "Return all installed skills. Pass ?include=catalog to also include available catalog skills. Supports
+        optional filter params: origin, kind, q, category."
       tags:
         - skills
       responses:
@@ -6589,6 +6591,16 @@ paths:
                             - origin
                           additionalProperties: false
                     description: Skill objects
+                  categoryCounts:
+                    description: Count of skills per category (before category filter is applied)
+                    type: object
+                    propertyNames:
+                      type: string
+                    additionalProperties:
+                      type: number
+                  totalCount:
+                    description: Total number of skills matching non-category filters
+                    type: number
                 required:
                   - skills
                 additionalProperties: false
@@ -6601,6 +6613,30 @@ paths:
             enum:
               - catalog
           description: Optional inclusion flag. Use 'catalog' to merge available Vellum catalog skills into the response.
+        - name: origin
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Filter by skill origin (e.g. 'vellum', 'clawhub', 'skillssh', 'custom').
+        - name: kind
+          in: query
+          required: false
+          schema:
+            type: string
+          description: "Filter by kind: 'installed' (includes bundled), 'available', or pass through as skill.kind."
+        - name: q
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Text search across skill name, description, id, and origin label.
+        - name: category
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Filter by inferred category (e.g. 'communication', 'productivity').
     post:
       operationId: skills_post
       summary: Create skill

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -50,6 +50,8 @@ import {
   upsertSkillsIndex,
 } from "../../skills/catalog-install.js";
 import { filterByQuery } from "../../skills/catalog-search.js";
+import type { SkillCategory } from "../../skills/category-inference.js";
+import { inferCategory } from "../../skills/category-inference.js";
 import {
   clawhubCheckUpdates,
   clawhubInspect,
@@ -84,6 +86,10 @@ import type {
   SkillFileContentResponse,
   SlimSkillResponse,
 } from "../message-types/skills.js";
+
+// Re-export for use by route layer and future consumers.
+export type { SkillCategory };
+export { inferCategory };
 import {
   CONFIG_RELOAD_DEBOUNCE_MS,
   ensureSkillEntry,

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -467,6 +467,138 @@ export async function listSkillsWithCatalog(
   return merged;
 }
 
+// ─── Filtered skill listing ──────────────────────────────────────────────────
+
+export interface SkillListFilter {
+  origin?: string;
+  kind?: string;
+  q?: string;
+  category?: string;
+  includeCatalog?: boolean;
+}
+
+/** Human-readable labels matching Swift's `sourceLabel`. */
+export function originDisplayLabel(origin: string): string {
+  switch (origin) {
+    case "vellum":
+      return "Vellum";
+    case "clawhub":
+      return "Clawhub";
+    case "skillssh":
+      return "skills.sh";
+    case "custom":
+      return "Custom";
+    default:
+      return origin;
+  }
+}
+
+/** Check if a skill's origin matches a text query (matching Swift logic). */
+export function originMatchesQuery(origin: string, query: string): boolean {
+  const label = originDisplayLabel(origin).toLowerCase();
+  if (label.includes(query)) return true;
+  // "community" umbrella matches clawhub and skillssh
+  if (
+    (origin === "clawhub" || origin === "skillssh") &&
+    "community".includes(query)
+  ) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * List skills with filtering, category counts, and sorting.
+ * Calls listSkillsWithCatalog for the full merged list, then applies filters.
+ */
+export async function listSkillsFiltered(
+  filter: SkillListFilter,
+  ctx: SkillOperationContext,
+): Promise<{
+  skills: SlimSkillResponse[];
+  categoryCounts: Record<string, number>;
+  totalCount: number;
+}> {
+  let skills =
+    filter.includeCatalog !== false
+      ? await listSkillsWithCatalog(ctx)
+      : listSkills(ctx);
+
+  // Apply origin filter
+  if (filter.origin) {
+    skills = skills.filter((s) => s.origin === filter.origin);
+  }
+
+  // Apply kind/status filter
+  if (filter.kind) {
+    switch (filter.kind) {
+      case "installed":
+        skills = skills.filter(
+          (s) => s.kind === "installed" || s.kind === "bundled",
+        );
+        break;
+      case "available":
+        skills = skills.filter((s) => s.status === "available");
+        break;
+      default:
+        skills = skills.filter((s) => s.kind === filter.kind);
+        break;
+    }
+  }
+
+  // Apply text search
+  if (filter.q) {
+    const query = filter.q.trim().toLowerCase();
+    if (query) {
+      skills = skills.filter((s) => {
+        if (s.name.toLowerCase().includes(query)) return true;
+        if (s.description.toLowerCase().includes(query)) return true;
+        if (s.id.toLowerCase().includes(query)) return true;
+        if (originMatchesQuery(s.origin, query)) return true;
+        return false;
+      });
+    }
+  }
+
+  // Compute category counts BEFORE applying the category filter
+  const categoryCounts: Record<string, number> = {};
+  for (const s of skills) {
+    const cat = inferCategory(s.name, s.description);
+    categoryCounts[cat] = (categoryCounts[cat] ?? 0) + 1;
+  }
+  const totalCount = skills.length;
+
+  // Apply category filter
+  if (filter.category) {
+    skills = skills.filter(
+      (s) => inferCategory(s.name, s.description) === filter.category,
+    );
+  }
+
+  // Sort: installed first, community origins before core within installed,
+  // then alphabetical by name (matching Swift sorting logic)
+  skills.sort((a, b) => {
+    // Installed (bundled + installed) before catalog (available)
+    const aInstalled = a.kind === "installed" || a.kind === "bundled" ? 0 : 1;
+    const bInstalled = b.kind === "installed" || b.kind === "bundled" ? 0 : 1;
+    if (aInstalled !== bInstalled) return aInstalled - bInstalled;
+
+    // Within installed, community origins (clawhub, skillssh) before core (vellum)
+    if (aInstalled === 0 && bInstalled === 0) {
+      const aCommunity =
+        a.origin === "clawhub" || a.origin === "skillssh" ? 0 : 1;
+      const bCommunity =
+        b.origin === "clawhub" || b.origin === "skillssh" ? 0 : 1;
+      if (aCommunity !== bCommunity) return aCommunity - bCommunity;
+    }
+
+    // Alphabetical by name
+    return a.name.localeCompare(b.name);
+  });
+
+  return { skills, categoryCounts, totalCount };
+}
+
 /** Look up a single skill by ID from the resolved catalog, returning its SlimSkillResponse. */
 function findSkillById(
   skillId: string,

--- a/assistant/src/daemon/message-types/skills.ts
+++ b/assistant/src/daemon/message-types/skills.ts
@@ -129,6 +129,13 @@ export interface SkillsListResponse {
   skills: SlimSkillResponse[];
 }
 
+export interface SkillsListFilteredResponse {
+  type: "skills_list_response";
+  skills: SlimSkillResponse[];
+  categoryCounts: Record<string, number>;
+  totalCount: number;
+}
+
 export interface SkillStateChanged {
   type: "skills_state_changed";
   name: string;

--- a/assistant/src/runtime/routes/skills-routes.ts
+++ b/assistant/src/runtime/routes/skills-routes.ts
@@ -24,7 +24,7 @@ import {
   inspectSkill,
   installSkill,
   listSkills,
-  listSkillsWithCatalog,
+  listSkillsFiltered,
   searchSkills,
   uninstallSkill,
   updateSkill,
@@ -140,7 +140,7 @@ export function skillRouteDefinitions(deps: SkillRouteDeps): RouteDefinition[] {
       policyKey: "skills",
       summary: "List all skills",
       description:
-        "Return all installed skills. Pass ?include=catalog to also include available catalog skills.",
+        "Return all installed skills. Pass ?include=catalog to also include available catalog skills. Supports optional filter params: origin, kind, q, category.",
       tags: ["skills"],
       queryParams: [
         {
@@ -149,16 +149,73 @@ export function skillRouteDefinitions(deps: SkillRouteDeps): RouteDefinition[] {
           description:
             "Optional inclusion flag. Use 'catalog' to merge available Vellum catalog skills into the response.",
         },
+        {
+          name: "origin",
+          schema: { type: "string" },
+          description:
+            "Filter by skill origin (e.g. 'vellum', 'clawhub', 'skillssh', 'custom').",
+        },
+        {
+          name: "kind",
+          schema: { type: "string" },
+          description:
+            "Filter by kind: 'installed' (includes bundled), 'available', or pass through as skill.kind.",
+        },
+        {
+          name: "q",
+          schema: { type: "string" },
+          description:
+            "Text search across skill name, description, id, and origin label.",
+        },
+        {
+          name: "category",
+          schema: { type: "string" },
+          description:
+            "Filter by inferred category (e.g. 'communication', 'productivity').",
+        },
       ],
       responseBody: z.object({
         skills: z.array(slimSkillSchema).describe("Skill objects"),
+        categoryCounts: z
+          .record(z.string(), z.number())
+          .optional()
+          .describe(
+            "Count of skills per category (before category filter is applied)",
+          ),
+        totalCount: z
+          .number()
+          .optional()
+          .describe("Total number of skills matching non-category filters"),
       }),
       handler: async ({ url }) => {
         const include = url.searchParams.get("include");
-        const skills =
-          include === "catalog"
-            ? await listSkillsWithCatalog(ctx())
-            : listSkills(ctx());
+        const origin = url.searchParams.get("origin");
+        const kind = url.searchParams.get("kind");
+        const q = url.searchParams.get("q");
+        const category = url.searchParams.get("category");
+
+        const hasFilter = !!(origin || kind || q || category);
+
+        if (hasFilter || include === "catalog") {
+          const result = await listSkillsFiltered(
+            {
+              ...(origin ? { origin } : {}),
+              ...(kind ? { kind } : {}),
+              ...(q ? { q } : {}),
+              ...(category ? { category } : {}),
+              includeCatalog: include === "catalog",
+            },
+            ctx(),
+          );
+          return Response.json({
+            skills: result.skills,
+            categoryCounts: result.categoryCounts,
+            totalCount: result.totalCount,
+          });
+        }
+
+        // No filter params and include !== catalog: preserve existing behavior
+        const skills = listSkills(ctx());
         return Response.json({ skills });
       },
     },

--- a/assistant/src/skills/category-inference.ts
+++ b/assistant/src/skills/category-inference.ts
@@ -1,0 +1,122 @@
+/**
+ * Skill category inference — ports the Swift `inferCategory` logic from
+ * `ConstellationView.swift` to TypeScript for server-side use.
+ *
+ * Pure function with no side effects or external dependencies.
+ */
+
+export type SkillCategory =
+  | "communication"
+  | "productivity"
+  | "development"
+  | "media"
+  | "automation"
+  | "webSocial"
+  | "knowledge"
+  | "integration";
+
+export const SKILL_CATEGORIES: SkillCategory[] = [
+  "communication",
+  "productivity",
+  "development",
+  "automation",
+  "media",
+  "webSocial",
+  "knowledge",
+  "integration",
+];
+
+const CATEGORY_KEYWORDS: [SkillCategory, string[]][] = [
+  [
+    "communication",
+    [
+      "email",
+      "message",
+      "messaging",
+      "chat",
+      "phone",
+      "phone call",
+      "voice call",
+      "video call",
+      "contact",
+      "notification",
+      "followup",
+      "slack",
+      "telegram",
+    ],
+  ],
+  [
+    "productivity",
+    [
+      "task",
+      "calendar",
+      "reminder",
+      "schedule",
+      "document",
+      "playbook",
+      "notion",
+    ],
+  ],
+  [
+    "development",
+    [
+      "code",
+      "app builder",
+      "github",
+      "developer",
+      "programming",
+      "debug",
+      "typescript",
+      "frontend",
+      "subagent",
+      "api mapping",
+      "cli discovery",
+    ],
+  ],
+  ["automation", ["browser", "computer use", "macos", "watcher", "automat"]],
+  [
+    "media",
+    ["image", "screen", "media", "transcri", "video", "audio", "recording"],
+  ],
+  [
+    "webSocial",
+    [
+      "x.com",
+      "twitter",
+      "public ingress",
+      "influencer",
+      "doordash",
+      "amazon",
+      "restaurant",
+    ],
+  ],
+  [
+    "knowledge",
+    [
+      "knowledge",
+      "weather",
+      "start the day",
+      "skills catalog",
+      "self upgrade",
+      "briefing",
+    ],
+  ],
+  ["integration", ["oauth", "setup", "configure", "connect", "webhook"]],
+];
+
+export function inferCategory(
+  name: string,
+  description: string,
+): SkillCategory {
+  const combined = `${name} ${description}`.toLowerCase();
+
+  for (const [category, keywords] of CATEGORY_KEYWORDS) {
+    for (const keyword of keywords) {
+      if (combined.includes(keyword)) {
+        return category;
+      }
+    }
+  }
+
+  return "knowledge";
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
@@ -223,37 +223,24 @@ final class SkillsManager {
 
     /// Recompute derived display data from server-filtered skills.
     /// Origin, kind, text search, and category filtering are now server-side.
-    /// This method merges external search results, updates category counts
-    /// from the server response, and applies display sorting.
-    ///
-    /// After merging external search results into the skills list, a local
-    /// filter pass removes any items that don't match the active origin/kind
-    /// filter. This is a safety net: external search results bypass the
-    /// server-side filter and could otherwise surface unfiltered catalog
-    /// hits when e.g. the Installed filter is active.
+    /// This method merges external search results, applies a local safety-net
+    /// filter (origin/kind + category) to remove any items that bypass the
+    /// server filter, recomputes category counts from the merged list, and
+    /// applies display sorting.
     private func recomputeFilteredData() {
-        // Convert server-provided category counts (String keys) to SkillCategory keys.
-        var counts: [SkillCategory: Int] = [:]
-        for (key, value) in skillsStore.categoryCounts {
-            if let cat = SkillCategory(rawValue: key) {
-                counts[cat] = value
-            }
-        }
-        categoryCounts = counts
-        searchFilteredCount = skillsStore.totalCount
         baseSkillsEmpty = skills.isEmpty
 
         // Re-apply the current origin/kind filter locally as a safety net
         // for merged external search results that weren't in the original
         // server response.
-        let localFiltered = skills.filter { skill in
+        let kindFiltered = skills.filter { skill in
             switch skillFilter {
             case .all:
                 return true
             case .installed:
                 return skill.isInstalled
             case .available:
-                return !skill.isInstalled
+                return skill.isAvailable
             case .vellum:
                 return skill.origin == "vellum"
             case .clawhub:
@@ -265,8 +252,29 @@ final class SkillsManager {
             }
         }
 
+        // Compute category counts from the merged+filtered list so they
+        // include external search results and always match the displayed
+        // skills. Use server counts as a base, then layer on any external
+        // results the server didn't see.
+        var counts: [SkillCategory: Int] = [:]
+        for skill in kindFiltered {
+            let cat = inferCategory(skill)
+            counts[cat, default: 0] += 1
+        }
+        categoryCounts = counts
+        searchFilteredCount = kindFiltered.count
+
+        // Apply category filter after computing counts (so sidebar shows
+        // accurate counts for all categories, not just the selected one).
+        let categoryFiltered: [SkillInfo]
+        if let category = selectedCategory {
+            categoryFiltered = kindFiltered.filter { inferCategory($0) == category }
+        } else {
+            categoryFiltered = kindFiltered
+        }
+
         // Sort for display: installed first, community origins before core, alphabetical.
-        filteredSkills = localFiltered.sorted { a, b in
+        filteredSkills = categoryFiltered.sorted { a, b in
             if a.isInstalled != b.isInstalled { return a.isInstalled }
             let aCommunity = (a.origin == "clawhub" || a.origin == "skillssh")
             let bCommunity = (b.origin == "clawhub" || b.origin == "skillssh")
@@ -325,7 +333,11 @@ final class SkillsManager {
     // MARK: - Delegated Operations
 
     func fetchSkills(force: Bool = false) {
-        skillsStore.fetchSkills(force: force)
+        if force {
+            fetchFilteredSkills()
+        } else {
+            skillsStore.fetchSkills(force: false)
+        }
     }
 
     func fetchSkillBody(skillId: String) {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
@@ -36,10 +36,6 @@ final class SkillsManager {
     // Forward all published properties from SkillsStore so existing views
     // continue to work via observation on SkillsManager unchanged.
     var skills: [SkillInfo] = []
-    /// Cached skill-id -> category map, rebuilt whenever `skills` changes.
-    /// Use `category(for:)` for O(1) lookups instead of calling `inferCategory` in view bodies.
-    private(set) var categoryMap: [String: SkillCategory] = [:]
-    @ObservationIgnored private var categoryFingerprints: [String: String] = [:]
     var loadedBodies: [String: String] = [:]
     var isLoading = false
     var uninstallResult: SkillsStore.UninstallResult?
@@ -65,16 +61,15 @@ final class SkillsManager {
     var searchQuery: String = "" {
         didSet {
             dispatchSearch(query: searchQuery)
-            recomputeFilteredData()
         }
     }
 
     var selectedCategory: SkillCategory? {
-        didSet { recomputeFilteredData() }
+        didSet { fetchFilteredSkills() }
     }
 
     var skillFilter: SkillFilter = .all {
-        didSet { recomputeFilteredData() }
+        didSet { fetchFilteredSkills() }
     }
 
     // MARK: - Cached Derived Data (O(1) reads from views)
@@ -82,13 +77,13 @@ final class SkillsManager {
     /// Skills filtered by search + category + skill filter, sorted for display.
     private(set) var filteredSkills: [SkillInfo] = []
 
-    /// Per-category counts based on the current search + skill filter (excludes category filter).
+    /// Per-category counts from the server response, keyed by category raw value.
     private(set) var categoryCounts: [SkillCategory: Int] = [:]
 
-    /// Total count of skills matching search + skill filter (the "All" count).
+    /// Total count of skills matching the current filters (from server response).
     private(set) var searchFilteredCount: Int = 0
 
-    /// Whether the base skills (after skill filter, before search/category) are empty.
+    /// Whether the current filtered skills list is empty.
     private(set) var baseSkillsEmpty: Bool = true
 
     @ObservationIgnored private var cancellables = Set<AnyCancellable>()
@@ -139,7 +134,6 @@ final class SkillsManager {
                     mergedSkills = localSkills
                 }
                 self.skills = mergedSkills
-                self.rebuildCategoryMap(from: mergedSkills)
                 self.loadedBodies = self.skillsStore.loadedBodies
                 self.isLoading = self.skillsStore.isLoading
                 self.uninstallResult = self.skillsStore.uninstallResult
@@ -198,104 +192,81 @@ final class SkillsManager {
             .store(in: &cancellables)
     }
 
-    // MARK: - Category Lookup
+    // MARK: - Server-Side Filtered Fetch
 
-    /// O(1) category lookup for a skill. Falls back to `.knowledge` for unknown IDs.
-    func category(for skill: SkillInfo) -> SkillCategory {
-        categoryMap[skill.id] ?? .knowledge
-    }
-
-    private func rebuildCategoryMap(from skills: [SkillInfo]) {
-        var map: [String: SkillCategory] = [:]
-        var fingerprints: [String: String] = [:]
-        map.reserveCapacity(skills.count)
-        fingerprints.reserveCapacity(skills.count)
-        for skill in skills {
-            let fp = skill.name + "\0" + skill.description
-            if let cached = categoryMap[skill.id], categoryFingerprints[skill.id] == fp {
-                map[skill.id] = cached
-            } else {
-                map[skill.id] = inferCategory(skill)
+    /// Translates the current filter state into API params and triggers a server-side
+    /// filtered fetch. Called when the filter dropdown, category, or search query changes.
+    private func fetchFilteredSkills() {
+        let originParam: String? = {
+            switch skillFilter {
+            case .vellum: return "vellum"
+            case .clawhub: return "clawhub"
+            case .skillssh: return "skillssh"
+            case .custom: return "custom"
+            default: return nil
             }
-            fingerprints[skill.id] = fp
-        }
-        categoryMap = map
-        categoryFingerprints = fingerprints
+        }()
+        let kindParam: String? = {
+            switch skillFilter {
+            case .installed: return "installed"
+            case .available: return "available"
+            default: return nil
+            }
+        }()
+        let queryParam = searchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
+        let categoryParam = selectedCategory?.rawValue
+
+        skillsStore.fetchSkills(force: true, origin: originParam, kind: kindParam, query: queryParam.isEmpty ? nil : queryParam, category: categoryParam)
     }
 
     // MARK: - Recomputation
 
-    /// Single-pass O(N) recomputation of all derived data.
-    /// Called whenever any filter input or the underlying skills list changes.
+    /// Recompute derived display data from server-filtered skills.
+    /// Origin, kind, text search, and category filtering are now server-side.
+    /// This method merges external search results, updates category counts
+    /// from the server response, and applies display sorting.
+    ///
+    /// After merging external search results into the skills list, a local
+    /// filter pass removes any items that don't match the active origin/kind
+    /// filter. This is a safety net: external search results bypass the
+    /// server-side filter and could otherwise surface unfiltered catalog
+    /// hits when e.g. the Installed filter is active.
     private func recomputeFilteredData() {
-        let query = searchQuery.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        let hasSearch = !query.isEmpty
-
-        let baseSkills: [SkillInfo]
-        switch skillFilter {
-        case .all:
-            baseSkills = skills
-        case .installed:
-            baseSkills = skills.filter { $0.isInstalled }
-        case .available:
-            baseSkills = skills.filter { $0.isAvailable }
-        case .vellum:
-            baseSkills = skills.filter { $0.origin == "vellum" }
-        case .clawhub:
-            baseSkills = skills.filter { $0.origin == "clawhub" }
-        case .skillssh:
-            baseSkills = skills.filter { $0.origin == "skillssh" }
-        case .custom:
-            baseSkills = skills.filter { $0.origin == "custom" }
-        }
-
-        let searchFiltered: [SkillInfo]
-        if hasSearch {
-            // When external search results have been merged in, the backend
-            // already performed fuzzy/semantic matching — backend-matched
-            // skills pass through unfiltered (they may not contain the query
-            // as a literal substring, e.g. skills.sh results with empty
-            // descriptions). Local-only skills still get the substring
-            // filter so they don't bypass search.
-            let backendIds = Set(skillsStore.searchResults.map(\.id))
-            let backendResultsPresent = !skillsStore.isSearching && baseSkills.contains(where: { backendIds.contains($0.id) })
-            if backendResultsPresent {
-                searchFiltered = baseSkills.filter {
-                    backendIds.contains($0.id) ||
-                    $0.name.lowercased().contains(query) ||
-                    $0.description.lowercased().contains(query) ||
-                    $0.id.lowercased().contains(query) ||
-                    Self.originMatchesQuery($0.origin, query: query)
-                }
-            } else {
-                searchFiltered = baseSkills.filter {
-                    $0.name.lowercased().contains(query) ||
-                    $0.description.lowercased().contains(query) ||
-                    $0.id.lowercased().contains(query) ||
-                    Self.originMatchesQuery($0.origin, query: query)
-                }
-            }
-        } else {
-            searchFiltered = baseSkills
-        }
-
+        // Convert server-provided category counts (String keys) to SkillCategory keys.
         var counts: [SkillCategory: Int] = [:]
-        for skill in searchFiltered {
-            let cat = category(for: skill)
-            counts[cat, default: 0] += 1
+        for (key, value) in skillsStore.categoryCounts {
+            if let cat = SkillCategory(rawValue: key) {
+                counts[cat] = value
+            }
         }
         categoryCounts = counts
-        searchFilteredCount = searchFiltered.count
-        baseSkillsEmpty = baseSkills.isEmpty
+        searchFilteredCount = skillsStore.totalCount
+        baseSkillsEmpty = skills.isEmpty
 
-        let categoryFiltered: [SkillInfo]
-        if let category = selectedCategory {
-            categoryFiltered = searchFiltered.filter { self.category(for: $0) == category }
-        } else {
-            categoryFiltered = searchFiltered
+        // Re-apply the current origin/kind filter locally as a safety net
+        // for merged external search results that weren't in the original
+        // server response.
+        let localFiltered = skills.filter { skill in
+            switch skillFilter {
+            case .all:
+                return true
+            case .installed:
+                return skill.isInstalled
+            case .available:
+                return !skill.isInstalled
+            case .vellum:
+                return skill.origin == "vellum"
+            case .clawhub:
+                return skill.origin == "clawhub"
+            case .skillssh:
+                return skill.origin == "skillssh"
+            case .custom:
+                return skill.origin == "custom"
+            }
         }
 
-        filteredSkills = categoryFiltered.sorted { a, b in
+        // Sort for display: installed first, community origins before core, alphabetical.
+        filteredSkills = localFiltered.sorted { a, b in
             if a.isInstalled != b.isInstalled { return a.isInstalled }
             let aCommunity = (a.origin == "clawhub" || a.origin == "skillssh")
             let bCommunity = (b.origin == "clawhub" || b.origin == "skillssh")
@@ -322,15 +293,6 @@ final class SkillsManager {
         }
     }
 
-    /// Whether a search query matches any searchable term for a skill origin.
-    /// Includes both the display label (e.g. "Clawhub") and the umbrella
-    /// term "community" so users can still discover community skills by searching.
-    static func originMatchesQuery(_ origin: String, query: String) -> Bool {
-        if sourceLabel(origin).lowercased().contains(query) { return true }
-        if (origin == "clawhub" || origin == "skillssh") && "community".contains(query) { return true }
-        return false
-    }
-
     // MARK: - Debounced Search
 
     private func dispatchSearch(query: String) {
@@ -342,6 +304,8 @@ final class SkillsManager {
         let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else {
             isSearching = false
+            // Re-fetch with current filters but no query to reset the list.
+            fetchFilteredSkills()
             return
         }
         // Show spinner immediately during the debounce window so the user
@@ -350,7 +314,10 @@ final class SkillsManager {
         searchDebounceTask = Task { [weak self] in
             try? await Task.sleep(nanoseconds: 300_000_000)
             guard !Task.isCancelled else { return }
+            // Trigger both the external registry search and the server-side
+            // filtered fetch with the query param in parallel.
             self?.skillsStore.searchSkills(query: trimmed, force: true)
+            self?.fetchFilteredSkills()
             self?.searchDebounceTask = nil
         }
     }

--- a/clients/shared/Features/Skills/SkillsStore.swift
+++ b/clients/shared/Features/Skills/SkillsStore.swift
@@ -15,6 +15,9 @@ public final class SkillsStore: ObservableObject {
     @Published public var loadedBodies: [String: String] = [:]
     @Published public var isLoading = false
 
+    @Published public var categoryCounts: [String: Int] = [:]
+    @Published public var totalCount: Int = 0
+
     @Published public var searchResults: [SkillInfo] = []
     @Published public var isSearching = false
 
@@ -92,6 +95,7 @@ public final class SkillsStore: ObservableObject {
 
     private let skillsClient: SkillsClientProtocol
     private var lastSearchQuery: String?
+    private var fetchTask: Task<Void, Never>?
     private var searchTask: Task<Void, Never>?
     private var draftTask: Task<Void, Never>?
     private var createTask: Task<Void, Never>?
@@ -102,6 +106,13 @@ public final class SkillsStore: ObservableObject {
     private var createGeneration: Int = 0
     private var currentDetailSkillId: String?
     private var currentFilesSkillId: String?
+
+    /// Last-used filter params, replayed by post-operation refreshes so
+    /// the user's active filter view is preserved after install/uninstall/etc.
+    private var lastOrigin: String?
+    private var lastKind: String?
+    private var lastQuery: String?
+    private var lastCategory: String?
 
     // MARK: - Init
 
@@ -115,15 +126,30 @@ public final class SkillsStore: ObservableObject {
 
     // MARK: - Fetch Skills
 
-    public func fetchSkills(force: Bool = false) {
-        guard !isLoading else { return }
-        if !force && !skills.isEmpty { return }
+    public func fetchSkills(force: Bool = false, origin: String? = nil, kind: String? = nil, query: String? = nil, category: String? = nil) {
+        if force {
+            // Cancel the in-flight fetch so the latest filter params always win.
+            fetchTask?.cancel()
+        } else {
+            guard !isLoading else { return }
+            if !skills.isEmpty { return }
+        }
+
+        // Remember the filter params so post-operation refreshes replay them.
+        lastOrigin = origin
+        lastKind = kind
+        lastQuery = query
+        lastCategory = category
+
         isLoading = true
 
-        Task {
-            let response = await skillsClient.fetchSkillsList(includeCatalog: true)
+        fetchTask = Task {
+            let response = await skillsClient.fetchSkillsList(includeCatalog: true, origin: origin, kind: kind, query: query, category: category)
+            guard !Task.isCancelled else { return }
             if let response {
                 skills = response.skills
+                categoryCounts = response.categoryCounts ?? [:]
+                totalCount = response.totalCount ?? response.skills.count
             }
             isLoading = false
         }
@@ -191,7 +217,7 @@ public final class SkillsStore: ObservableObject {
             }
             installResult = result
             if result.success {
-                fetchSkills(force: true)
+                fetchSkills(force: true, origin: lastOrigin, kind: lastKind, query: lastQuery, category: lastCategory)
             }
             Task { @MainActor in
                 try? await Task.sleep(nanoseconds: 3_000_000_000)
@@ -219,7 +245,7 @@ public final class SkillsStore: ObservableObject {
             }
             uninstallResult = result
             if result.success {
-                fetchSkills(force: true)
+                fetchSkills(force: true, origin: lastOrigin, kind: lastKind, query: lastQuery, category: lastCategory)
             }
             Task { @MainActor in
                 try? await Task.sleep(nanoseconds: 3_000_000_000)
@@ -236,14 +262,14 @@ public final class SkillsStore: ObservableObject {
     public func enableSkill(name: String) {
         Task {
             _ = await skillsClient.enableSkill(name: name)
-            fetchSkills(force: true)
+            fetchSkills(force: true, origin: lastOrigin, kind: lastKind, query: lastQuery, category: lastCategory)
         }
     }
 
     public func disableSkill(name: String) {
         Task {
             _ = await skillsClient.disableSkill(name: name)
-            fetchSkills(force: true)
+            fetchSkills(force: true, origin: lastOrigin, kind: lastKind, query: lastQuery, category: lastCategory)
         }
     }
 
@@ -306,7 +332,7 @@ public final class SkillsStore: ObservableObject {
             )
             guard generation == self.createGeneration else { return }
             if response?.success == true {
-                fetchSkills(force: true)
+                fetchSkills(force: true, origin: lastOrigin, kind: lastKind, query: lastQuery, category: lastCategory)
             } else {
                 createError = response?.error ?? "Failed to create skill"
             }

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -987,8 +987,20 @@ extension SkillsListResponseSkill {
 }
 
 /// Response containing the list of available skills.
-/// Backed by generated `SkillsListResponse`.
-public typealias SkillsListResponseMessage = SkillsListResponse
+/// Wraps the generated `SkillsListResponse` with additional server-side filter metadata.
+public struct SkillsListResponseMessage: Codable, Sendable {
+    public let type: String
+    public let skills: [SkillsListResponseSkill]
+    public let categoryCounts: [String: Int]?
+    public let totalCount: Int?
+
+    public init(type: String, skills: [SkillsListResponseSkill], categoryCounts: [String: Int]? = nil, totalCount: Int? = nil) {
+        self.type = type
+        self.skills = skills
+        self.categoryCounts = categoryCounts
+        self.totalCount = totalCount
+    }
+}
 
 /// Response containing the full body of a specific skill.
 /// Backed by generated `SkillDetailResponse`.

--- a/clients/shared/Network/SkillsClient.swift
+++ b/clients/shared/Network/SkillsClient.swift
@@ -8,7 +8,7 @@ private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "Skill
 /// Covers listing, enabling, disabling, configuring, installing, uninstalling,
 /// updating, searching, drafting, and creating skills.
 public protocol SkillsClientProtocol {
-    func fetchSkillsList(includeCatalog: Bool) async -> SkillsListResponseMessage?
+    func fetchSkillsList(includeCatalog: Bool, origin: String?, kind: String?, query: String?, category: String?) async -> SkillsListResponseMessage?
     func enableSkill(name: String) async -> SkillOperationResult?
     func disableSkill(name: String) async -> SkillOperationResult?
     func configureSkill(name: String, env: [String: String]?, apiKey: String?, config: [String: AnyCodable]?) async -> SkillOperationResult?
@@ -39,11 +39,16 @@ public struct SkillsClient: SkillsClientProtocol {
         value.addingPercentEncoding(withAllowedCharacters: pathComponentAllowed) ?? value
     }
 
-    public func fetchSkillsList(includeCatalog: Bool) async -> SkillsListResponseMessage? {
+    public func fetchSkillsList(includeCatalog: Bool, origin: String? = nil, kind: String? = nil, query: String? = nil, category: String? = nil) async -> SkillsListResponseMessage? {
         do {
-            let params: [String: String]? = includeCatalog ? ["include": "catalog"] : nil
+            var params: [String: String] = [:]
+            if includeCatalog { params["include"] = "catalog" }
+            if let origin { params["origin"] = origin }
+            if let kind { params["kind"] = kind }
+            if let query, !query.isEmpty { params["q"] = query }
+            if let category { params["category"] = category }
             let response = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/skills", params: params, timeout: 10
+                path: "assistants/{assistantId}/skills", params: params.isEmpty ? nil : params, timeout: 10
             )
             guard response.isSuccess else {
                 log.error("fetchSkillsList failed (HTTP \(response.statusCode))")

--- a/clients/shared/Tests/SkillsFileContentTests.swift
+++ b/clients/shared/Tests/SkillsFileContentTests.swift
@@ -106,7 +106,7 @@ private actor MockSkillsFileContentStore {
 private struct MockSkillsClient: SkillsClientProtocol {
     let backing: MockSkillsFileContentStore
 
-    func fetchSkillsList(includeCatalog: Bool) async -> SkillsListResponseMessage? { nil }
+    func fetchSkillsList(includeCatalog: Bool, origin: String?, kind: String?, query: String?, category: String?) async -> SkillsListResponseMessage? { nil }
     func enableSkill(name: String) async -> SkillOperationResult? { nil }
     func disableSkill(name: String) async -> SkillOperationResult? { nil }
     func configureSkill(name: String, env: [String: String]?, apiKey: String?, config: [String: AnyCodable]?) async -> SkillOperationResult? { nil }


### PR DESCRIPTION
## Summary
Move all skill filtering (origin, status, text search, and category) from client-side to server-side. The daemon's `GET /v1/skills` endpoint now accepts filter query parameters and returns pre-filtered skill lists along with per-category counts.

## Self-review result
PASS — no gaps found

## PRs merged into feature branch
- #25106: Add skill category inference utility to the daemon
- #25108: Add filter query params and category counts to skills list endpoint
- #25114: Update Swift client and SkillsManager to use server-side filtering

## Changes
- New `category-inference.ts` utility ported from Swift's `inferCategory` logic
- `GET /v1/skills` accepts `origin`, `kind`, `q`, `category` query params + `includeCatalog` flag
- Response includes `categoryCounts` and `totalCount` for sidebar display
- Swift `SkillsClient`/`SkillsStore` pass filter params to daemon
- `SkillsManager.recomputeFilteredData()` simplified — uses server results
- In-flight fetch cancellation, filter param replay on post-op refresh, local safety-net filter for merged search results

Part of plan: server-side-skill-filtering.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25119" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
