### PR TITLE
feat(macos): allow VoiceInputManager to record audio without SFSpeechRecognizer when STT is configured

### DIFF
--- a/clients/macos/vellum-assistant/App/VoiceInputManager.swift
+++ b/clients/macos/vellum-assistant/App/VoiceInputManager.swift
@@ -668,6 +668,8 @@ final class VoiceInputManager {
     private func beginRecording() {
         log.info("beginRecording() called — origin=\(String(describing: self.activeOrigin)) mode=\(String(describing: self.currentMode)) isRecording=\(self.isRecording)")
 
+        let sttConfigured = STTProviderRegistry.isServiceConfigured
+
         // Check recognizer availability through the adapter so tests can
         // control the result without depending on a real SFSpeechRecognizer.
         // When unavailable, attempt recreation before giving up.
@@ -682,11 +684,23 @@ final class VoiceInputManager {
             log.warning("Speech recognizer unavailable (nil=\(self.speechRecognizer == nil), adapterAvailable=\(self.speechRecognizerAdapter.isRecognizerAvailable), cachedAvailable=\(String(describing: self.speechRecognizer?.isAvailable))) — recreating")
             speechRecognizer = speechRecognizerAdapter.makeRecognizer(locale: Locale(identifier: "en-US"))
         }
-        guard speechRecognizerAdapter.isRecognizerAvailable else {
-            log.error("Speech recognizer not available after recreation attempt")
-            currentDictationContext = nil
-            return
+
+        // When STT is configured, the native recognizer is optional — if it's
+        // available we get partials, but recording proceeds without it. When STT
+        // is NOT configured, the native recognizer is required.
+        if !sttConfigured {
+            guard speechRecognizerAdapter.isRecognizerAvailable else {
+                log.error("Speech recognizer not available after recreation attempt")
+                currentDictationContext = nil
+                return
+            }
         }
+
+        // Determine whether we can use the native recognizer for partials.
+        let speechStatus = speechRecognizerAdapter.authorizationStatus()
+        let useNativeRecognizer: Bool = speechRecognizerAdapter.isRecognizerAvailable
+            && speechRecognizer != nil
+            && speechStatus == .authorized
 
         // Don't start if a previous recognition task is still processing
         if recognitionTask != nil {
@@ -699,25 +713,63 @@ final class VoiceInputManager {
         // Show an informative overlay for first-use or denied states instead of
         // silently opening System Settings.
         let micStatus = AVCaptureDevice.authorizationStatus(for: .audio)
-        let speechStatus = speechRecognizerAdapter.authorizationStatus()
-        log.info("Permissions — mic=\(String(describing: micStatus)) speech=\(String(describing: speechStatus))")
+        log.info("Permissions — mic=\(String(describing: micStatus)) speech=\(String(describing: speechStatus)) sttConfigured=\(sttConfigured)")
 
-        if micStatus == .notDetermined || speechStatus == .notDetermined {
+        // Determine which permissions still need first-use prompts.
+        let micNotDetermined = micStatus == .notDetermined
+        let speechNotDetermined = speechStatus == .notDetermined
+
+        // Show the first-use primer when:
+        // - mic is not yet determined (always need mic), OR
+        // - speech is not yet determined AND STT is NOT configured (speech required), OR
+        // - speech is not yet determined AND STT IS configured (nice-to-have primer)
+        if micNotDetermined || speechNotDetermined {
             // Show a primer explaining why we need mic access, then request.
             log.info("Showing permission primer (mic=\(String(describing: micStatus)) speech=\(String(describing: speechStatus)))")
             currentDictationContext = nil
-            permissionOverlay.show(kind: .firstUse, onDismiss: {}, onContinue: { [weak self] in
-                Task { @MainActor in
-                    await self?.requestPermissionsAndRecord()
-                }
-            })
+            if sttConfigured && !micNotDetermined && speechNotDetermined {
+                // STT configured + mic already authorized + speech notDetermined:
+                // show the primer as a nice-to-have for partial transcription, but
+                // if the user dismisses it, proceed with recording anyway.
+                permissionOverlay.show(kind: .firstUse, onDismiss: { [weak self] in
+                    Task { @MainActor in
+                        // User dismissed — proceed with mic-only recording.
+                        self?.beginRecording()
+                    }
+                }, onContinue: { [weak self] in
+                    Task { @MainActor in
+                        await self?.requestPermissionsAndRecord()
+                    }
+                })
+            } else if sttConfigured && micNotDetermined && speechNotDetermined {
+                // STT configured + both not determined: need mic auth, but if user
+                // dismisses the primer, still proceed with mic-only.
+                permissionOverlay.show(kind: .firstUse, onDismiss: { [weak self] in
+                    Task { @MainActor in
+                        await self?.requestPermissionsAndRecord()
+                    }
+                }, onContinue: { [weak self] in
+                    Task { @MainActor in
+                        await self?.requestPermissionsAndRecord()
+                    }
+                })
+            } else {
+                // STT not configured or mic-only not determined: standard primer.
+                permissionOverlay.show(kind: .firstUse, onDismiss: {}, onContinue: { [weak self] in
+                    Task { @MainActor in
+                        await self?.requestPermissionsAndRecord()
+                    }
+                })
+            }
             return
         }
         let micDenied = micStatus == .denied || micStatus == .restricted
         let speechDenied = speechStatus == .denied || speechStatus == .restricted
-        if micDenied || speechDenied {
+        // Microphone is always required. Speech recognition is only required
+        // when no STT service is configured.
+        if micDenied || (!sttConfigured && speechDenied) {
             let deniedPermission: PermissionPromptOverlay.DeniedPermission
-            if micDenied && speechDenied {
+            if micDenied && speechDenied && !sttConfigured {
                 deniedPermission = .both
             } else if micDenied {
                 deniedPermission = .microphone
@@ -745,12 +797,19 @@ final class VoiceInputManager {
                 overlayWindow.show(state: .recording)
             }
         }
-        log.info("Voice recording started")
+        log.info("Voice recording started (useNativeRecognizer=\(useNativeRecognizer))")
         VoiceFeedback.playActivationChime()
 
-        let request = SFSpeechAudioBufferRecognitionRequest()
-        request.shouldReportPartialResults = true
-        recognitionRequest = request
+        // Only create the recognition request when we have a working native recognizer.
+        let request: SFSpeechAudioBufferRecognitionRequest?
+        if useNativeRecognizer {
+            let req = SFSpeechAudioBufferRecognitionRequest()
+            req.shouldReportPartialResults = true
+            recognitionRequest = req
+            request = req
+        } else {
+            request = nil
+        }
 
         let ampState = amplitudeState
         ampState.reset()
@@ -767,7 +826,8 @@ final class VoiceInputManager {
                     }
                 }
             }
-            request.append(buffer)
+            // Feed the native recognizer only when a recognition request exists.
+            request?.append(buffer)
             // Capture a copy of the PCM buffer for STT service transcription.
             // AVAudioPCMBuffer is reused by the audio engine across callbacks,
             // so we must copy the data before the engine overwrites it.
@@ -845,23 +905,14 @@ final class VoiceInputManager {
             }
             self.hasInstalledTap = true
 
-            // Ensure the concrete recognizer is still available. It may have
-            // been set to nil if the adapter recreated it between start and
-            // engine ready. In production the adapter ensures makeRecognizer
-            // returns a valid instance when isRecognizerAvailable is true.
-            guard let recognizer = self.speechRecognizer else {
-                log.error("Speech recognizer became nil after engine started — aborting")
-                self.isRecording = false
-                self.onRecordingStateChanged?(false)
-                self.currentDictationContext = nil
-                self.recognitionRequest = nil
-                self.overlayWindow.dismiss()
-                self.engineController.stopAndRemoveTap()
-                self.hasInstalledTap = false
+            // When native recognizer is not available/authorized, recording
+            // still proceeds — STT service handles transcription on stop.
+            guard useNativeRecognizer, let recognizer = self.speechRecognizer, let req = request else {
+                log.info("Recording without native recognizer — STT service will handle transcription on stop")
                 return
             }
 
-            self.recognitionTask = recognizer.recognitionTask(with: request) { [weak self] result, error in
+            self.recognitionTask = recognizer.recognitionTask(with: req) { [weak self] result, error in
                 Task { @MainActor in
                     guard let self = self else { return }
                     // Ignore late callbacks delivered after recording was stopped
@@ -905,8 +956,12 @@ final class VoiceInputManager {
 
 
 
-    /// Request both microphone and speech recognition permissions sequentially,
-    /// then start recording if both are granted.
+    /// Request microphone (and optionally speech recognition) permissions,
+    /// then start recording if granted.
+    ///
+    /// When an STT service is configured, only microphone permission is
+    /// required. Speech recognition permission is skipped because the STT
+    /// service handles transcription.
     private func requestPermissionsAndRecord() async {
         let micGranted = await AVCaptureDevice.requestAccess(for: .audio)
         guard micGranted else {
@@ -915,15 +970,20 @@ final class VoiceInputManager {
             return
         }
 
-        let speechGranted = await withCheckedContinuation { continuation in
-            speechRecognizerAdapter.requestAuthorization { status in
-                continuation.resume(returning: status == .authorized)
+        // When STT is configured, skip speech recognition permission request —
+        // the STT service provides transcription. The native recognizer is a
+        // nice-to-have for partials but not required.
+        if !STTProviderRegistry.isServiceConfigured {
+            let speechGranted = await withCheckedContinuation { continuation in
+                speechRecognizerAdapter.requestAuthorization { status in
+                    continuation.resume(returning: status == .authorized)
+                }
             }
-        }
-        guard speechGranted else {
-            log.warning("Speech recognition access denied by user")
-            permissionOverlay.show(kind: .denied(.speechRecognition), onDismiss: {}, onContinue: {})
-            return
+            guard speechGranted else {
+                log.warning("Speech recognition access denied by user")
+                permissionOverlay.show(kind: .denied(.speechRecognition), onDismiss: {}, onContinue: {})
+                return
+            }
         }
 
         log.info("Permissions granted — starting recording")
@@ -1108,6 +1168,10 @@ final class VoiceInputManager {
     /// so the recognizer delivers a final transcription via the callback.
     /// Does NOT cancel the recognition task or set isRecording=false — the callback
     /// handles cleanup after receiving the isFinal result.
+    ///
+    /// When recording without a native recognizer (STT-only mode), there is no
+    /// `isFinal` callback to wait for. Instead, the accumulated audio is drained,
+    /// encoded to WAV, and sent directly to the STT service.
     private func stopRecordingForDictation() {
         guard isRecording else { return }
         log.info("Stopping dictation recording — waiting for final transcription")
@@ -1119,10 +1183,28 @@ final class VoiceInputManager {
         }
         hasInstalledTap = false
 
-        // If the recognition task hasn't been started yet (async engine start
-        // still in progress), there's no callback to deliver isFinal.
-        // Clean up directly instead of waiting for a callback that won't come.
+        // When there's no recognition task, either:
+        // (a) the async engine start is still in progress, or
+        // (b) we're recording in STT-only mode (no native recognizer).
+        // In both cases, no isFinal callback will come — handle directly.
         guard recognitionTask != nil else {
+            // Check if we have accumulated audio and an STT service to handle it.
+            // Don't drain yet — handleFinalTranscription drains the accumulator
+            // itself so the audio buffers flow through to resolveTranscription.
+            let hasAudio = capturedAudioFormat != nil
+            let sttConfigured = STTProviderRegistry.isServiceConfigured
+
+            if hasAudio && sttConfigured {
+                log.info("STT-only mode — routing through handleFinalTranscription for STT service resolution")
+                // Route through handleFinalTranscription with empty native text.
+                // resolveTranscription (called inside) will drain the accumulator,
+                // encode to WAV, and send to the STT service.
+                recognitionRequest = nil
+
+                handleFinalTranscription("")
+                return
+            }
+
             log.info("Recognition task not yet started — cleaning up directly")
             recognitionRequest = nil
             isRecording = false
@@ -1156,6 +1238,45 @@ final class VoiceInputManager {
         let elapsed = CFAbsoluteTimeGetCurrent() - recordingStartTime
         if elapsed < 1.0 {
             log.warning("Micro-recording detected: recording stopped after only \(String(format: "%.2f", elapsed))s — likely a failure, not user action")
+        }
+
+        // In conversation mode with STT-only recording (no recognition task),
+        // drain audio and send to the STT service for transcription.
+        if currentMode == .conversation && recognitionTask == nil && STTProviderRegistry.isServiceConfigured {
+            let accumulatedBuffers = audioAccumulator.drain()
+            let audioFormat = capturedAudioFormat
+            if !accumulatedBuffers.isEmpty, let format = audioFormat {
+                log.info("STT-only conversation mode — resolving transcription via STT service (\(accumulatedBuffers.count) buffers)")
+                let sttClient = self.sttClient
+                isRecording = false
+                onRecordingStateChanged?(false)
+                activeOrigin = .hotkey
+                amplitudeState.reset()
+                Self.amplitudeSubject.send(0)
+                onAmplitudeChanged?(0)
+                capturedAudioFormat = nil
+                overlayWindow.dismiss()
+                tearDownAudioState()
+
+                Task { [weak self] in
+                    let resolvedText = await Self.resolveTranscription(
+                        nativeText: "",
+                        accumulatedBuffers: accumulatedBuffers,
+                        audioFormat: format,
+                        sttClient: sttClient
+                    )
+                    guard let self else { return }
+                    let trimmed = resolvedText.trimmingCharacters(in: .whitespacesAndNewlines)
+                    if !trimmed.isEmpty {
+                        VoiceFeedback.playDeactivationChime()
+                        self.onTranscription?(resolvedText)
+                    } else {
+                        log.warning("STT-only conversation transcription empty — discarding")
+                        VoiceFeedback.playDeactivationChime()
+                    }
+                }
+                return
+            }
         }
 
         isRecording = false

--- a/clients/macos/vellum-assistantTests/VoiceInputManagerTests.swift
+++ b/clients/macos/vellum-assistantTests/VoiceInputManagerTests.swift
@@ -77,6 +77,8 @@ final class VoiceInputManagerTests: XCTestCase {
     }
 
     override func tearDown() {
+        // Clean up any STT provider configuration set during tests.
+        UserDefaults.standard.removeObject(forKey: "sttProvider")
         manager = nil
         dictationClient = nil
         speechAdapter = nil
@@ -677,5 +679,160 @@ final class VoiceInputManagerTests: XCTestCase {
         let waveMarker = Array(wavData[8..<12])
         XCTAssertEqual(waveMarker, [0x57, 0x41, 0x56, 0x45],
                        "WAV data should contain WAVE marker at offset 8")
+    }
+
+    // MARK: - STT-Only Recording (speech recognition optional)
+
+    func testSTTConfiguredWithSpeechDeniedAllowsRecordingStart() {
+        // When STT is configured and speech recognition is denied,
+        // recording should still start (only mic permission required).
+        // NOTE: This test can only verify the full path when microphone
+        // permission is already authorized. If mic is notDetermined (common
+        // in CI/sandboxed environments), the first-use primer is shown first.
+        // In that case we skip the test to avoid a false failure.
+        let micStatus = AVCaptureDevice.authorizationStatus(for: .audio)
+        guard micStatus == .authorized else {
+            // Can't test full recording start without mic permission.
+            // The recognizer/permission gate logic is still exercised by the
+            // other tests in this section.
+            return
+        }
+
+        UserDefaults.standard.set("deepgram", forKey: "sttProvider")
+        speechAdapter.stubbedAuthorizationStatus = .denied
+        // Recognizer unavailable because speech is denied
+        speechAdapter.stubbedIsRecognizerAvailable = false
+
+        let freshManager = VoiceInputManager(
+            dictationClient: dictationClient,
+            speechRecognizerAdapter: speechAdapter,
+            sttClient: sttClient
+        )
+
+        freshManager.toggleRecording()
+
+        // The manager should have set isRecording=true, meaning it passed
+        // the permission and recognizer checks. The async engine start may
+        // subsequently fail (no hardware in CI), but the permission gate
+        // was cleared.
+        XCTAssertTrue(freshManager.isRecording,
+                      "Recording should start when STT is configured even if speech recognition is denied")
+    }
+
+    func testSTTConfiguredWithSpeechNotDeterminedDoesNotRequestSpeechAuth() {
+        // When STT is configured and speech is notDetermined, beginRecording
+        // shows the first-use primer. The key behavior verified here: speech
+        // authorization is NOT requested immediately, because the STT service
+        // handles transcription. This test does not depend on mic status
+        // because it only checks that speech auth was not triggered.
+        UserDefaults.standard.set("deepgram", forKey: "sttProvider")
+        speechAdapter.stubbedAuthorizationStatus = .notDetermined
+        speechAdapter.stubbedIsRecognizerAvailable = false
+
+        let freshManager = VoiceInputManager(
+            dictationClient: dictationClient,
+            speechRecognizerAdapter: speechAdapter,
+            sttClient: sttClient
+        )
+
+        // Reset the count — init calls makeRecognizer once.
+        speechAdapter.requestAuthorizationCallCount = 0
+
+        freshManager.toggleRecording()
+
+        // Recording should not start immediately (primer is shown first),
+        // but speech authorization should not have been requested yet.
+        XCTAssertFalse(freshManager.isRecording,
+                       "Recording should not start immediately when speech is notDetermined (primer shown)")
+        XCTAssertEqual(speechAdapter.requestAuthorizationCallCount, 0,
+                       "Speech authorization should not be requested when STT is configured")
+    }
+
+    func testSTTConfiguredRecognizerUnavailableStillStartsRecording() {
+        // When STT is configured and the recognizer is unavailable,
+        // recording should still proceed (STT service handles transcription).
+        // Requires mic authorization; skip if not available.
+        let micStatus = AVCaptureDevice.authorizationStatus(for: .audio)
+        guard micStatus == .authorized else { return }
+
+        UserDefaults.standard.set("deepgram", forKey: "sttProvider")
+        speechAdapter.stubbedAuthorizationStatus = .authorized
+        speechAdapter.stubbedIsRecognizerAvailable = false
+
+        let freshManager = VoiceInputManager(
+            dictationClient: dictationClient,
+            speechRecognizerAdapter: speechAdapter,
+            sttClient: sttClient
+        )
+
+        freshManager.toggleRecording()
+
+        XCTAssertTrue(freshManager.isRecording,
+                      "Recording should start when STT is configured even if recognizer is unavailable")
+    }
+
+    func testSTTNotConfiguredSpeechDeniedBlocksRecording() {
+        // Existing behavior preserved: when no STT provider is configured
+        // and speech recognition is denied, recording should be blocked.
+        UserDefaults.standard.removeObject(forKey: "sttProvider")
+        speechAdapter.stubbedAuthorizationStatus = .denied
+
+        manager.toggleRecording()
+
+        XCTAssertFalse(manager.isRecording,
+                       "Recording should be blocked when STT is not configured and speech is denied")
+    }
+
+    func testSTTOnlyRecordingProducesTranscriptionViaResolve() async {
+        // When native recognizer is not available, resolveTranscription
+        // should use the STT service result with empty native text.
+        let format = AVAudioFormat(standardFormatWithSampleRate: 16000, channels: 1)!
+        let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: 160)!
+        buffer.frameLength = 160
+        if let channelData = buffer.floatChannelData {
+            for i in 0..<Int(buffer.frameLength) {
+                channelData[0][i] = Float(i) / Float(buffer.frameLength)
+            }
+        }
+
+        sttClient.stubbedResult = .success(text: "STT service transcription")
+
+        // Simulate STT-only path: empty native text, audio buffers present.
+        let result = await VoiceInputManager.resolveTranscription(
+            nativeText: "",
+            accumulatedBuffers: [buffer],
+            audioFormat: format,
+            sttClient: sttClient
+        )
+
+        XCTAssertEqual(result, "STT service transcription",
+                       "STT service text should be used when native text is empty")
+        XCTAssertEqual(sttClient.transcribeCallCount, 1,
+                       "STT service should be called for transcription")
+    }
+
+    func testSTTOnlyRecordingFallsBackToEmptyWhenServiceFails() async {
+        // When native recognizer is not available and STT service fails,
+        // the empty native text is returned (no transcription available).
+        let format = AVAudioFormat(standardFormatWithSampleRate: 16000, channels: 1)!
+        let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: 160)!
+        buffer.frameLength = 160
+        if let channelData = buffer.floatChannelData {
+            for i in 0..<Int(buffer.frameLength) {
+                channelData[0][i] = Float(i) / Float(buffer.frameLength)
+            }
+        }
+
+        sttClient.stubbedResult = .serviceUnavailable
+
+        let result = await VoiceInputManager.resolveTranscription(
+            nativeText: "",
+            accumulatedBuffers: [buffer],
+            audioFormat: format,
+            sttClient: sttClient
+        )
+
+        XCTAssertEqual(result, "",
+                       "Empty native text should be returned when STT service is unavailable")
     }
 }


### PR DESCRIPTION
## Summary
- Make speech recognition permission optional when LLM-based STT is configured
- VoiceInputManager now records audio and uses STT service directly when native recognizer is unavailable
- Native SFSpeechRecognizer used for partial transcription when available (best of both worlds)
- Add tests for STT-only recording path

Part of plan: optional-speech-rec-with-stt.md (PR 2 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25120" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
