### PR TITLE
fix(browser): make backend kind sticky per conversation

### DIFF
--- a/assistant/src/__tests__/headless-browser-mode.test.ts
+++ b/assistant/src/__tests__/headless-browser-mode.test.ts
@@ -29,6 +29,9 @@ let _cdpDisposed = false;
 /** Configure the factory to throw on getCdpClient for pinned modes. */
 let factoryThrowError: CdpError | null = null;
 
+/** Modes passed to getCdpClient, in order. Reset by resetCdp(). */
+const factoryModeCalls: Array<string | undefined> = [];
+
 function makeFakeCdp(
   kind: "local" | "extension" | "cdp-inspect",
   conversationId: string,
@@ -55,6 +58,7 @@ mock.module("../tools/browser/cdp-client/factory.js", () => ({
     context: { hostBrowserProxy?: unknown; conversationId: string },
     options?: { mode?: string },
   ) => {
+    factoryModeCalls.push(options?.mode);
     if (factoryThrowError) {
       throw factoryThrowError;
     }
@@ -75,6 +79,9 @@ mock.module("../tools/browser/cdp-client/factory.js", () => ({
 
 // ── Minimal browserManager stub ──────────────────────────────────────
 
+/** Mutable memo shared between mock methods and tests. */
+const fakePreferredBackend = new Map<string, string>();
+
 mock.module("../tools/browser/browser-manager.js", () => {
   return {
     browserManager: {
@@ -88,6 +95,14 @@ mock.module("../tools/browser/browser-manager.js", () => {
       clearSnapshotBackendNodeMap: mock(() => {}),
       storeSnapshotBackendNodeMap: mock(() => {}),
       resolveSnapshotBackendNodeId: () => null,
+      getPreferredBackendKind: (conversationId: string) =>
+        fakePreferredBackend.get(conversationId) ?? null,
+      setPreferredBackendKind: (conversationId: string, kind: string) => {
+        fakePreferredBackend.set(conversationId, kind);
+      },
+      clearPreferredBackendKind: (conversationId: string) => {
+        fakePreferredBackend.delete(conversationId);
+      },
       supportsRouteInterception: false,
       isInteractive: () => false,
       positionWindowSidebar: mock(async () => {}),
@@ -194,6 +209,8 @@ function resetCdp() {
   _cdpDisposed = false;
   cdpSendHandler = defaultCdpHandler;
   factoryThrowError = null;
+  factoryModeCalls.length = 0;
+  fakePreferredBackend.clear();
 }
 
 // ── Tests ────────────────────────────────────────────────────────────
@@ -531,5 +548,67 @@ describe("browser_mode wiring through tool execution", () => {
       "extension: FAILED at candidate_selection",
     );
     expect(result.content).toContain("Remediation:");
+  });
+
+  // ── Per-conversation sticky backend kind ─────────────────────────
+
+  test("auto-mode call after an explicit pin sticks to the pinned kind", async () => {
+    const first = await executeBrowserNavigate(
+      { url: "https://example.com", browser_mode: "local" },
+      ctx,
+    );
+    expect(first.isError).toBe(false);
+
+    factoryModeCalls.length = 0;
+    const second = await executeBrowserScreenshot({}, ctx);
+    expect(second.isError).toBe(false);
+    expect(factoryModeCalls).toEqual(["local"]);
+  });
+
+  test("explicit browser_mode on a later call overrides the sticky kind", async () => {
+    await executeBrowserNavigate(
+      { url: "https://example.com", browser_mode: "local" },
+      ctx,
+    );
+    expect(fakePreferredBackend.get(ctx.conversationId)).toBe("local");
+
+    factoryModeCalls.length = 0;
+    const overridden = await executeBrowserScreenshot(
+      { browser_mode: "extension" },
+      { ...ctx, hostBrowserProxy: {} as never },
+    );
+    expect(overridden.isError).toBe(false);
+    expect(factoryModeCalls).toEqual(["extension"]);
+
+    factoryModeCalls.length = 0;
+    const afterOverride = await executeBrowserScreenshot(
+      {},
+      { ...ctx, hostBrowserProxy: {} as never },
+    );
+    expect(afterOverride.isError).toBe(false);
+    expect(factoryModeCalls).toEqual(["extension"]);
+  });
+
+  test("auto-mode with no prior call falls through to the factory's auto logic", async () => {
+    factoryModeCalls.length = 0;
+    const result = await executeBrowserScreenshot({}, ctx);
+    expect(result.isError).toBe(false);
+    expect(factoryModeCalls).toEqual(["auto"]);
+  });
+
+  test("clearPreferredBackendKind resets the sticky choice", async () => {
+    await executeBrowserNavigate(
+      { url: "https://example.com", browser_mode: "local" },
+      ctx,
+    );
+    expect(fakePreferredBackend.get(ctx.conversationId)).toBe("local");
+
+    // Simulate teardown (browser_detach / browser_close with close_all_pages).
+    fakePreferredBackend.delete(ctx.conversationId);
+
+    factoryModeCalls.length = 0;
+    const result = await executeBrowserScreenshot({}, ctx);
+    expect(result.isError).toBe(false);
+    expect(factoryModeCalls).toEqual(["auto"]);
   });
 });

--- a/assistant/src/tools/browser/browser-execution.ts
+++ b/assistant/src/tools/browser/browser-execution.ts
@@ -283,6 +283,18 @@ function collectRemediationHints(
  *   - normalizes aliases (`cdp-debugger` -> `cdp-inspect`, etc.)
  *   - passes the mode preference to the factory
  *   - surfaces a remediation-rich error on pinned-mode failures
+ *
+ * Per-conversation stickiness: when the incoming `browser_mode` is
+ * `"auto"` and the conversation has already resolved to a backend
+ * kind on a prior call, the factory is pinned to that kind instead
+ * of re-running the auto priority list. This prevents
+ * `browser_navigate` (e.g. pinned to `local`) and `browser_screenshot`
+ * (default auto) in the same conversation from landing on different
+ * Chrome instances. Explicit non-auto modes override and update the
+ * memo; teardown via browser_close / browser_detach clears it.
+ *
+ * The returned client is wrapped so its first successful `send()`
+ * writes the resolved kind back to the conversation memo.
  */
 export function acquireCdpClientWithMode(
   input: Record<string, unknown>,
@@ -302,8 +314,17 @@ export function acquireCdpClientWithMode(
   }
   const browserMode = modeResult.mode;
 
+  const rememberedKind = browserManager.getPreferredBackendKind(
+    context.conversationId,
+  );
+  const effectiveMode: BrowserMode =
+    browserMode === "auto" && rememberedKind !== null
+      ? rememberedKind
+      : browserMode;
+
   try {
-    const cdp = getCdpClient(context, { mode: browserMode });
+    const raw = getCdpClient(context, { mode: effectiveMode });
+    const cdp = wrapWithKindMemo(raw, context.conversationId);
     return { cdp, browserMode };
   } catch (err) {
     if (err instanceof CdpError && browserMode !== "auto") {
@@ -316,6 +337,40 @@ export function acquireCdpClientWithMode(
     }
     throw err;
   }
+}
+
+/**
+ * Wrap a {@link ScopedCdpClient} so the first successful `send()`
+ * records the resolved backend kind in the conversation's
+ * `preferredBackendKinds` memo. Subsequent sends are no-ops for the
+ * memo; dispose() delegates to the underlying client.
+ */
+function wrapWithKindMemo(
+  inner: ReturnType<typeof getCdpClient>,
+  conversationId: string,
+): ReturnType<typeof getCdpClient> {
+  let recorded = false;
+  return {
+    get kind() {
+      return inner.kind;
+    },
+    conversationId: inner.conversationId,
+    async send<T = unknown>(
+      method: string,
+      params?: Record<string, unknown>,
+      signal?: AbortSignal,
+    ): Promise<T> {
+      const result = await inner.send<T>(method, params, signal);
+      if (!recorded) {
+        browserManager.setPreferredBackendKind(conversationId, inner.kind);
+        recorded = true;
+      }
+      return result;
+    },
+    dispose(): void {
+      inner.dispose();
+    },
+  };
 }
 
 // ── CDP error diagnostics helper ─────────────────────────────────────
@@ -1009,6 +1064,9 @@ export async function executeBrowserDetach(
 
     // Clear stale snapshot element-id mappings regardless of backend.
     browserManager.clearSnapshotBackendNodeMap(context.conversationId);
+    // Drop the sticky backend kind so the next browser_* call re-runs
+    // the auto priority list from a clean slate.
+    browserManager.clearPreferredBackendKind(context.conversationId);
 
     return {
       content: "Browser debugger detached and snapshot state cleared.",
@@ -1073,6 +1131,7 @@ export async function executeBrowserClose(
       // Tolerate detach failures (already detached, tab closed, etc.)
     }
     browserManager.clearSnapshotBackendNodeMap(context.conversationId);
+    browserManager.clearPreferredBackendKind(context.conversationId);
     return {
       content:
         "Browser session cleared. (Your Chrome tab was not closed — close it yourself if desired.)",

--- a/assistant/src/tools/browser/browser-manager.ts
+++ b/assistant/src/tools/browser/browser-manager.ts
@@ -4,6 +4,7 @@ import { isAbsolute, join, relative, resolve } from "node:path";
 import { getLogger } from "../../util/logger.js";
 import { getDataDir } from "../../util/platform.js";
 import { authSessionCache } from "./auth-cache.js";
+import type { CdpClientKind } from "./cdp-client/types.js";
 import type { ExtractedCredential } from "./network-recording-types.js";
 import { importPlaywright } from "./runtime-check.js";
 
@@ -210,6 +211,16 @@ class BrowserManager {
    * resulting backendNodeId.
    */
   private snapshotBackendNodeMaps = new Map<string, Map<string, number>>();
+  /**
+   * The CDP backend kind that a conversation resolved to on an earlier
+   * tool call. When a subsequent browser_* call arrives with
+   * `browser_mode: "auto"`, the factory is pinned to this kind so
+   * navigate and screenshot cannot land on different Chromes within
+   * the same conversation. Explicit non-auto modes overwrite the entry.
+   * Cleared when the conversation's page is closed or all pages are
+   * closed.
+   */
+  private preferredBackendKinds = new Map<string, CdpClientKind>();
   private browserCdpSession: CDPSession | null = null;
   private browserWindowId: number | null = null;
   private interactiveModeSessions = new Set<string>();
@@ -444,6 +455,7 @@ class BrowserManager {
     this.pages.delete(conversationId);
     this.rawPages.delete(conversationId);
     this.snapshotBackendNodeMaps.delete(conversationId);
+    this.preferredBackendKinds.delete(conversationId);
     this.downloads.delete(conversationId);
     // Reject any pending download waiters
     const pending = this.pendingDownloads.get(conversationId);
@@ -477,6 +489,7 @@ class BrowserManager {
     this.pages.clear();
     this.rawPages.clear();
     this.snapshotBackendNodeMaps.clear();
+    this.preferredBackendKinds.clear();
     this.downloads.clear();
     for (const pending of this.pendingDownloads.values()) {
       for (const waiter of pending) waiter.reject(new Error("Browser closed"));
@@ -530,6 +543,38 @@ class BrowserManager {
       }
       this.cdpSessions.delete(conversationId);
     }
+  }
+
+  /**
+   * Look up the backend kind this conversation has been using. Returns
+   * `null` before the first successful CDP send or after an explicit
+   * teardown. Callers should pass the result to the factory as a
+   * pinned mode so `auto`-mode calls stay consistent across tool
+   * invocations.
+   */
+  getPreferredBackendKind(conversationId: string): CdpClientKind | null {
+    return this.preferredBackendKinds.get(conversationId) ?? null;
+  }
+
+  /**
+   * Record the backend kind that a tool call resolved to. Overwrites
+   * any prior value so an explicit `browser_mode` override on one call
+   * becomes the default for subsequent `auto`-mode calls.
+   */
+  setPreferredBackendKind(
+    conversationId: string,
+    kind: CdpClientKind,
+  ): void {
+    this.preferredBackendKinds.set(conversationId, kind);
+  }
+
+  /**
+   * Drop the remembered backend kind for a conversation. Called on
+   * explicit teardown (browser_close, closeAllPages) so the next call
+   * re-runs the auto priority list.
+   */
+  clearPreferredBackendKind(conversationId: string): void {
+    this.preferredBackendKinds.delete(conversationId);
   }
 
   /**


### PR DESCRIPTION
## Summary
- `browser_navigate` pinned to `browser_mode: "local"` followed by a default `browser_screenshot` could land on a different Chrome (auto re-ran priority and chose `extension`) — screenshots showed the user's real tab, not the page just navigated.
- `BrowserManager` now remembers the resolved backend kind per conversation; `auto`-mode calls reuse it. Explicit `browser_mode` overrides and updates the memo. Detach/close clears it.
- Adds `get/set/clearPreferredBackendKind` accessors, clears on `closeSessionPage`/`closeAllPages`/`browser_detach`/`browser_close` (extension path), and wraps the scoped client so the first successful `send()` writes through.

## Original prompt
it (standing yolo defaults; task: fix the browser skill bug where Velissa's `browser_navigate` opens a separate Chrome but `browser_screenshot` captures the user's original Chrome — root cause: per-invocation backend selection with no per-conversation stickiness)