### PR TITLE
docs(stt): add provider-onboarding checklist and architecture updates

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -586,6 +586,8 @@ All guardian decisions for voice access requests flow through:
 
 Audio-to-text conversion occurs in four distinct runtime boundaries, each with its own provider model and adapter layer. The `services.stt` config block controls provider selection for the daemon's STT service; other boundaries resolve providers independently based on their runtime context.
 
+**Provider catalog model:** The daemon's canonical provider catalog (`src/providers/speech-to-text/provider-catalog.ts`) is the single source of truth for STT provider metadata — credential mappings, supported boundaries, and telephony mode. The client-facing catalog (`meta/stt-provider-catalog.json`) carries display metadata (names, hints, setup mode) and is bundled into native apps at build time. A CI parity test (`src/__tests__/stt-catalog-parity.test.ts`) enforces that provider IDs, ordering, and credential-provider name mappings stay aligned between the two catalogs. To add a new provider, follow the checklist in `docs/stt-provider-onboarding.md`.
+
 **Boundary overview:**
 
 | Boundary                     | Runtime                               | Provider (current)                           | Adapter module                                                                                     | Caller                                                                                               |
@@ -634,7 +636,7 @@ The daemon transcribes audio attachments (e.g. voice messages from channel inbou
 - `resolveBatchTranscriber()` in `src/providers/speech-to-text/resolve.ts` is the credential-aware entry point — it reads the configured provider from `services.stt`, resolves the corresponding API key from the secure key store, and delegates to the factory.
 - `tryTranscribeAudioAttachments()` in `src/runtime/routes/inbound-stages/transcribe-audio.ts` is the callsite that uses the facade for channel audio attachment transcription.
 
-To add a new daemon batch STT provider: add a new `SttProviderId` variant in `types.ts`, implement `BatchTranscriber` in a new adapter class alongside `WhisperBatchTranscriber` and `DeepgramBatchTranscriber`, update the factory in `daemon-batch-transcriber.ts` to select the adapter based on configuration, and add the provider to `meta/stt-provider-catalog.json` so clients can display it in settings.
+To add a new daemon batch STT provider, follow the full checklist in `docs/stt-provider-onboarding.md` — it covers the daemon catalog, type registration, config schema, adapter wiring, credential plumbing, client catalog, and parity tests.
 
 **Client service-first boundary:**
 
@@ -669,9 +671,12 @@ These differences are intentional — the adapters were designed for their respe
 
 **Cross-boundary notes:**
 
-- The `services.stt` config block controls provider selection for both the daemon batch boundary and the client service-first boundary (they share `resolveBatchTranscriber()`). Supported providers include OpenAI Whisper (`openai-whisper`) and Deepgram (`deepgram`). Telephony STT is configured separately via `calls.voice.transcriptionProvider`. A prepared (but inactive) dark path exists to unify telephony STT under `services.stt` — see "Prepared dark path" above and the cutover runbook in `docs/internal-reference.md`.
+- The `services.stt` config block controls provider selection for both the daemon batch boundary and the client service-first boundary (they share `resolveBatchTranscriber()`). The daemon provider catalog (`src/providers/speech-to-text/provider-catalog.ts`) is the authoritative registry of supported providers; the client catalog (`meta/stt-provider-catalog.json`) mirrors it for display purposes. The parity guard test (`src/__tests__/stt-catalog-parity.test.ts`) fails CI when the two catalogs diverge on provider IDs, ordering, or credential-provider name mappings.
+- Telephony STT is configured separately via `calls.voice.transcriptionProvider` and operates in a different runtime boundary (Twilio ConversationRelay). A prepared (but inactive) dark path exists to unify telephony STT under `services.stt` — see "Prepared dark path" above and the cutover runbook in `docs/internal-reference.md`.
 - `evaluateServicesSttReadiness()` in `src/calls/stt-profile.ts` can validate cutover prerequisites without affecting active calls.
+- Credential mapping is catalog-driven: `provider-secret-catalog.ts` derives STT API-key provider names from the daemon catalog via `listCredentialProviderNames()`, deduplicating against the LLM/search provider list. Adding a provider to the catalog automatically includes its credential name in `API_KEY_PROVIDERS`.
 - Terminology: "STT" and "transcription" refer to the same operation (converting audio to text). "Speech recognition" is used in client-native contexts where Apple's Speech framework terminology is canonical. All three terms map to the same conceptual operation.
+- **Onboarding**: For a step-by-step guide to adding a new STT provider, see `docs/stt-provider-onboarding.md`.
 
 ### Update Bulletin System
 

--- a/assistant/docs/stt-provider-onboarding.md
+++ b/assistant/docs/stt-provider-onboarding.md
@@ -1,0 +1,104 @@
+# STT Provider Onboarding Checklist
+
+Step-by-step guide for adding a new speech-to-text provider to the assistant. Follow each section in order; the parity tests (step 6) will fail CI if any side is out of sync.
+
+## 1. Daemon provider catalog entry
+
+**File:** `src/providers/speech-to-text/provider-catalog.ts`
+
+Add a new entry to the `CATALOG` map with:
+
+- `id` — a unique `SttProviderId` string (e.g. `"google-cloud"`).
+- `credentialProvider` — the credential-store key name used by `getProviderKeyAsync` to retrieve the API key. If the provider shares an API key with another service (e.g. `openai-whisper` shares the `"openai"` key), reuse that name; otherwise use the provider's own name.
+- `supportedBoundaries` — the set of `SttBoundaryId` values the provider supports (currently only `"daemon-batch"` exists).
+- `telephonyMode` — how the provider participates in real-time telephony STT: `"realtime-ws"`, `"batch-only"`, or `"none"`.
+
+## 2. Type-system registration
+
+**File:** `src/stt/types.ts`
+
+- Append the new provider ID to the `SttProviderId` union type.
+
+This ensures the exhaustive switch in `daemon-batch-transcriber.ts` produces a compile error until the adapter is wired.
+
+## 3. Config schema touchpoints
+
+**File:** `src/config/schemas/stt.ts`
+
+- Append the new provider ID string to the `VALID_STT_PROVIDERS` tuple.
+
+The `services.stt.providers` map uses a sparse `z.record(z.string(), ...)` schema, so adding a new provider does **not** require a workspace migration to seed a `services.stt.providers.<id>` entry. Users only need to set `services.stt.provider` to the new ID and supply credentials.
+
+## 4. Adapter wiring
+
+**File:** `src/stt/daemon-batch-transcriber.ts`
+
+1. Create a new `BatchTranscriber` implementation class (e.g. `GoogleCloudBatchTranscriber`) alongside `WhisperBatchTranscriber` and `DeepgramBatchTranscriber`.
+2. Implement the `transcribe(request)` method using a lazy-imported provider module (follow the pattern in the existing adapters).
+3. Add a `case` branch in `createDaemonBatchTranscriber()` for the new `SttProviderId`. The exhaustive `never` check at the bottom of the switch ensures a compile error if this step is skipped.
+
+If the provider needs a new REST client module, add it under `src/providers/speech-to-text/` following the pattern of `openai-whisper.ts` and `deepgram.ts`.
+
+## 5. Credential plumbing
+
+**File:** `src/providers/provider-secret-catalog.ts`
+
+If the new provider introduces a credential-store key that is not already present in `LLM_AND_SEARCH_API_KEY_PROVIDERS`, it is automatically included via `sttApiKeyProviderNames()` which reads from the STT provider catalog. Verify this by checking that `API_KEY_PROVIDERS` includes the new credential name at runtime.
+
+If the new provider **shares** an existing credential name (e.g. reuses `"openai"`), the deduplication logic in `sttApiKeyProviderNames()` handles it — no changes needed.
+
+## 6. Client catalog entry
+
+**File:** `meta/stt-provider-catalog.json`
+
+Add a new entry to the `providers` array with the following fields:
+
+| Field                | Description                                                              |
+| -------------------- | ------------------------------------------------------------------------ |
+| `id`                 | Must match the `SttProviderId` used in step 1.                           |
+| `displayName`        | Human-readable name shown in client settings UI.                         |
+| `subtitle`           | Short description displayed below the provider selector.                 |
+| `setupMode`          | `"api-key"` (inline key field) or `"cli"` (instructions-only).           |
+| `setupHint`          | Brief guidance shown during setup.                                       |
+| `apiKeyProviderName` | Must match the `credentialProvider` value from the daemon catalog entry. |
+
+Insertion order in the JSON array must match the daemon catalog insertion order.
+
+### Client-side code
+
+**File:** `clients/shared/Utilities/STTProviderRegistry.swift`
+
+Add a matching fallback entry in `fallbackRegistry` with the same `id`, `displayName`, `subtitle`, `setupMode`, `setupHint`, and `apiKeyProviderName` as the JSON catalog entry. The fallback keeps client startup resilient when the bundled JSON is missing.
+
+### macOS settings key behavior
+
+**File:** `clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift`
+
+The `sttKeyIsExclusive(for:)` / `sttKeyIsShared(for:)` helpers derive shared-vs-exclusive key behavior from the catalog automatically: if `apiKeyProviderName == id`, the key is exclusive; otherwise it is shared. No new conditionals are needed unless the provider has a non-standard key-ownership model.
+
+## 7. Parity tests
+
+**File:** `src/__tests__/stt-catalog-parity.test.ts`
+
+The existing parity test suite enforces that:
+
+- Daemon and client catalog provider IDs are identical and in the same order.
+- Each entry's `apiKeyProviderName` matches the daemon's `credentialProvider`.
+- The client catalog has all required fields populated.
+
+Run the test after completing steps 1-6:
+
+```bash
+cd assistant && bun test src/__tests__/stt-catalog-parity.test.ts
+```
+
+If any assertion fails, the error message identifies which side is out of sync and what to fix.
+
+## 8. Verify terminology separation
+
+Before submitting the PR, grep for any accidental coupling between the two STT configuration surfaces:
+
+- **`services.stt`** — controls daemon batch and client service-first STT provider selection. Configured under the Speech-to-Text section in Settings.
+- **`calls.voice.transcriptionProvider`** — controls telephony-native STT (Twilio ConversationRelay). Configured separately under the Calls/Voice section.
+
+These are independent config paths with different provider sets and runtime boundaries. A new `services.stt` provider should never modify `calls.voice` config or vice versa. The prepared dark path for telephony cutover (see ARCHITECTURE.md) is the designated seam for future unification — do not wire a new provider into both paths simultaneously.

--- a/assistant/docs/stt-provider-onboarding.md
+++ b/assistant/docs/stt-provider-onboarding.md
@@ -1,6 +1,6 @@
 # STT Provider Onboarding Checklist
 
-Step-by-step guide for adding a new speech-to-text provider to the assistant. Follow each section in order; the parity tests (step 6) will fail CI if any side is out of sync.
+Step-by-step guide for adding a new speech-to-text provider to the assistant. Follow each section in order; the parity tests (step 7) will fail CI if any side is out of sync.
 
 ## 1. Daemon provider catalog entry
 

--- a/assistant/src/config/bundled-skills/transcribe/SKILL.md
+++ b/assistant/src/config/bundled-skills/transcribe/SKILL.md
@@ -18,3 +18,7 @@ Transcribe audio and video files using the configured speech-to-text provider. S
 - Large files are automatically split into chunks for processing.
 - If no STT provider credentials are configured, the tool will return an error with setup instructions.
 - The STT provider used here (`services.stt`) is independent of the telephony transcription provider (`calls.voice.transcriptionProvider`), which is configured separately for phone call STT.
+
+## Maintenance
+
+When adding or modifying an STT provider, follow the onboarding checklist at `assistant/docs/stt-provider-onboarding.md`. That document covers the daemon catalog, config schema, adapter wiring, client catalog parity, and required tests.


### PR DESCRIPTION
## Summary
- Add STT provider onboarding checklist at assistant/docs/stt-provider-onboarding.md
- Update ARCHITECTURE.md STT section to reference daemon catalog and parity tests
- Add maintenance note in transcribe SKILL.md pointing to onboarding doc

Part of plan: pre-google-stt-cleanup-unification.md (PR 5 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25123" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
