### PR TITLE
Pre-Google STT Cleanup and Unification

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -586,6 +586,8 @@ All guardian decisions for voice access requests flow through:
 
 Audio-to-text conversion occurs in four distinct runtime boundaries, each with its own provider model and adapter layer. The `services.stt` config block controls provider selection for the daemon's STT service; other boundaries resolve providers independently based on their runtime context.
 
+**Provider catalog model:** The daemon's canonical provider catalog (`src/providers/speech-to-text/provider-catalog.ts`) is the single source of truth for STT provider metadata — credential mappings, supported boundaries, and telephony mode. The client-facing catalog (`meta/stt-provider-catalog.json`) carries display metadata (names, hints, setup mode) and is bundled into native apps at build time. A CI parity test (`src/__tests__/stt-catalog-parity.test.ts`) enforces that provider IDs, ordering, and credential-provider name mappings stay aligned between the two catalogs. To add a new provider, follow the checklist in `docs/stt-provider-onboarding.md`.
+
 **Boundary overview:**
 
 | Boundary                     | Runtime                               | Provider (current)                           | Adapter module                                                                                     | Caller                                                                                               |
@@ -634,7 +636,7 @@ The daemon transcribes audio attachments (e.g. voice messages from channel inbou
 - `resolveBatchTranscriber()` in `src/providers/speech-to-text/resolve.ts` is the credential-aware entry point — it reads the configured provider from `services.stt`, resolves the corresponding API key from the secure key store, and delegates to the factory.
 - `tryTranscribeAudioAttachments()` in `src/runtime/routes/inbound-stages/transcribe-audio.ts` is the callsite that uses the facade for channel audio attachment transcription.
 
-To add a new daemon batch STT provider: add a new `SttProviderId` variant in `types.ts`, implement `BatchTranscriber` in a new adapter class alongside `WhisperBatchTranscriber` and `DeepgramBatchTranscriber`, update the factory in `daemon-batch-transcriber.ts` to select the adapter based on configuration, and add the provider to `meta/stt-provider-catalog.json` so clients can display it in settings.
+To add a new daemon batch STT provider, follow the full checklist in `docs/stt-provider-onboarding.md` — it covers the daemon catalog, type registration, config schema, adapter wiring, credential plumbing, client catalog, and parity tests.
 
 **Client service-first boundary:**
 
@@ -669,9 +671,12 @@ These differences are intentional — the adapters were designed for their respe
 
 **Cross-boundary notes:**
 
-- The `services.stt` config block controls provider selection for both the daemon batch boundary and the client service-first boundary (they share `resolveBatchTranscriber()`). Supported providers include OpenAI Whisper (`openai-whisper`) and Deepgram (`deepgram`). Telephony STT is configured separately via `calls.voice.transcriptionProvider`. A prepared (but inactive) dark path exists to unify telephony STT under `services.stt` — see "Prepared dark path" above and the cutover runbook in `docs/internal-reference.md`.
+- The `services.stt` config block controls provider selection for both the daemon batch boundary and the client service-first boundary (they share `resolveBatchTranscriber()`). The daemon provider catalog (`src/providers/speech-to-text/provider-catalog.ts`) is the authoritative registry of supported providers; the client catalog (`meta/stt-provider-catalog.json`) mirrors it for display purposes. The parity guard test (`src/__tests__/stt-catalog-parity.test.ts`) fails CI when the two catalogs diverge on provider IDs, ordering, or credential-provider name mappings.
+- Telephony STT is configured separately via `calls.voice.transcriptionProvider` and operates in a different runtime boundary (Twilio ConversationRelay). A prepared (but inactive) dark path exists to unify telephony STT under `services.stt` — see "Prepared dark path" above and the cutover runbook in `docs/internal-reference.md`.
 - `evaluateServicesSttReadiness()` in `src/calls/stt-profile.ts` can validate cutover prerequisites without affecting active calls.
+- Credential mapping is catalog-driven: `provider-secret-catalog.ts` derives STT API-key provider names from the daemon catalog via `listCredentialProviderNames()`, deduplicating against the LLM/search provider list. Adding a provider to the catalog automatically includes its credential name in `API_KEY_PROVIDERS`.
 - Terminology: "STT" and "transcription" refer to the same operation (converting audio to text). "Speech recognition" is used in client-native contexts where Apple's Speech framework terminology is canonical. All three terms map to the same conceptual operation.
+- **Onboarding**: For a step-by-step guide to adding a new STT provider, see `docs/stt-provider-onboarding.md`.
 
 ### Update Bulletin System
 

--- a/assistant/docs/stt-provider-onboarding.md
+++ b/assistant/docs/stt-provider-onboarding.md
@@ -1,0 +1,104 @@
+# STT Provider Onboarding Checklist
+
+Step-by-step guide for adding a new speech-to-text provider to the assistant. Follow each section in order; the parity tests (step 7) will fail CI if any side is out of sync.
+
+## 1. Daemon provider catalog entry
+
+**File:** `src/providers/speech-to-text/provider-catalog.ts`
+
+Add a new entry to the `CATALOG` map with:
+
+- `id` — a unique `SttProviderId` string (e.g. `"google-cloud"`).
+- `credentialProvider` — the credential-store key name used by `getProviderKeyAsync` to retrieve the API key. If the provider shares an API key with another service (e.g. `openai-whisper` shares the `"openai"` key), reuse that name; otherwise use the provider's own name.
+- `supportedBoundaries` — the set of `SttBoundaryId` values the provider supports (currently only `"daemon-batch"` exists).
+- `telephonyMode` — how the provider participates in real-time telephony STT: `"realtime-ws"`, `"batch-only"`, or `"none"`.
+
+## 2. Type-system registration
+
+**File:** `src/stt/types.ts`
+
+- Append the new provider ID to the `SttProviderId` union type.
+
+This ensures the exhaustive switch in `daemon-batch-transcriber.ts` produces a compile error until the adapter is wired.
+
+## 3. Config schema touchpoints
+
+**File:** `src/config/schemas/stt.ts`
+
+- Append the new provider ID string to the `VALID_STT_PROVIDERS` tuple.
+
+The `services.stt.providers` map uses a sparse `z.record(z.string(), ...)` schema, so adding a new provider does **not** require a workspace migration to seed a `services.stt.providers.<id>` entry. Users only need to set `services.stt.provider` to the new ID and supply credentials.
+
+## 4. Adapter wiring
+
+**File:** `src/stt/daemon-batch-transcriber.ts`
+
+1. Create a new `BatchTranscriber` implementation class (e.g. `GoogleCloudBatchTranscriber`) alongside `WhisperBatchTranscriber` and `DeepgramBatchTranscriber`.
+2. Implement the `transcribe(request)` method using a lazy-imported provider module (follow the pattern in the existing adapters).
+3. Add a `case` branch in `createDaemonBatchTranscriber()` for the new `SttProviderId`. The exhaustive `never` check at the bottom of the switch ensures a compile error if this step is skipped.
+
+If the provider needs a new REST client module, add it under `src/providers/speech-to-text/` following the pattern of `openai-whisper.ts` and `deepgram.ts`.
+
+## 5. Credential plumbing
+
+**File:** `src/providers/provider-secret-catalog.ts`
+
+If the new provider introduces a credential-store key that is not already present in `LLM_AND_SEARCH_API_KEY_PROVIDERS`, it is automatically included via `sttApiKeyProviderNames()` which reads from the STT provider catalog. Verify this by checking that `API_KEY_PROVIDERS` includes the new credential name at runtime.
+
+If the new provider **shares** an existing credential name (e.g. reuses `"openai"`), the deduplication logic in `sttApiKeyProviderNames()` handles it — no changes needed.
+
+## 6. Client catalog entry
+
+**File:** `meta/stt-provider-catalog.json`
+
+Add a new entry to the `providers` array with the following fields:
+
+| Field                | Description                                                              |
+| -------------------- | ------------------------------------------------------------------------ |
+| `id`                 | Must match the `SttProviderId` used in step 1.                           |
+| `displayName`        | Human-readable name shown in client settings UI.                         |
+| `subtitle`           | Short description displayed below the provider selector.                 |
+| `setupMode`          | `"api-key"` (inline key field) or `"cli"` (instructions-only).           |
+| `setupHint`          | Brief guidance shown during setup.                                       |
+| `apiKeyProviderName` | Must match the `credentialProvider` value from the daemon catalog entry. |
+
+Insertion order in the JSON array must match the daemon catalog insertion order.
+
+### Client-side code
+
+**File:** `clients/shared/Utilities/STTProviderRegistry.swift`
+
+Add a matching fallback entry in `fallbackRegistry` with the same `id`, `displayName`, `subtitle`, `setupMode`, `setupHint`, and `apiKeyProviderName` as the JSON catalog entry. The fallback keeps client startup resilient when the bundled JSON is missing.
+
+### macOS settings key behavior
+
+**File:** `clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift`
+
+The `sttKeyIsExclusive(for:)` / `sttKeyIsShared(for:)` helpers derive shared-vs-exclusive key behavior from the catalog automatically: if `apiKeyProviderName == id`, the key is exclusive; otherwise it is shared. No new conditionals are needed unless the provider has a non-standard key-ownership model.
+
+## 7. Parity tests
+
+**File:** `src/__tests__/stt-catalog-parity.test.ts`
+
+The existing parity test suite enforces that:
+
+- Daemon and client catalog provider IDs are identical and in the same order.
+- Each entry's `apiKeyProviderName` matches the daemon's `credentialProvider`.
+- The client catalog has all required fields populated.
+
+Run the test after completing steps 1-6:
+
+```bash
+cd assistant && bun test src/__tests__/stt-catalog-parity.test.ts
+```
+
+If any assertion fails, the error message identifies which side is out of sync and what to fix.
+
+## 8. Verify terminology separation
+
+Before submitting the PR, grep for any accidental coupling between the two STT configuration surfaces:
+
+- **`services.stt`** — controls daemon batch and client service-first STT provider selection. Configured under the Speech-to-Text section in Settings.
+- **`calls.voice.transcriptionProvider`** — controls telephony-native STT (Twilio ConversationRelay). Configured separately under the Calls/Voice section.
+
+These are independent config paths with different provider sets and runtime boundaries. A new `services.stt` provider should never modify `calls.voice` config or vice versa. The prepared dark path for telephony cutover (see ARCHITECTURE.md) is the designated seam for future unification — do not wire a new provider into both paths simultaneously.

--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -1166,8 +1166,8 @@ describe("AssistantConfigSchema", () => {
     });
     expect(result.services.stt.mode).toBe("your-own");
     expect(result.services.stt.provider).toBe("openai-whisper");
-    expect(result.services.stt.providers["openai-whisper"]).toEqual({});
-    expect(result.services.stt.providers.deepgram).toEqual({});
+    // providers defaults to empty sparse map
+    expect(result.services.stt.providers).toEqual({});
   });
 
   test("accepts valid services.stt provider override", () => {
@@ -1190,6 +1190,33 @@ describe("AssistantConfigSchema", () => {
       },
     });
     expect(result.services.stt.providers["openai-whisper"]).toEqual({});
+  });
+
+  test("parses when providers map is empty (sparse default)", () => {
+    const result = AssistantConfigSchema.parse({
+      services: { stt: { provider: "deepgram", providers: {} } },
+    });
+    expect(result.services.stt.providers).toEqual({});
+    expect(result.services.stt.provider).toBe("deepgram");
+  });
+
+  test("parses when unknown future provider blobs exist under providers", () => {
+    const result = AssistantConfigSchema.parse({
+      services: {
+        stt: {
+          provider: "openai-whisper",
+          providers: {
+            "openai-whisper": {},
+            "future-provider": { model: "next-gen", lang: "en" },
+          },
+        },
+      },
+    });
+    expect(result.services.stt.providers["openai-whisper"]).toEqual({});
+    expect(result.services.stt.providers["future-provider"]).toEqual({
+      model: "next-gen",
+      lang: "en",
+    });
   });
 
   test("rejects services.stt.mode = managed", () => {
@@ -1235,6 +1262,24 @@ describe("AssistantConfigSchema", () => {
         },
       },
     });
+    expect(result.services.stt.providers.deepgram).toEqual({});
+  });
+
+  test("existing configs with explicit per-provider objects continue to parse", () => {
+    // Configs with explicit per-provider objects must continue to
+    // parse and round-trip successfully.
+    const result = AssistantConfigSchema.parse({
+      services: {
+        stt: {
+          provider: "openai-whisper",
+          providers: {
+            "openai-whisper": {},
+            deepgram: {},
+          },
+        },
+      },
+    });
+    expect(result.services.stt.providers["openai-whisper"]).toEqual({});
     expect(result.services.stt.providers.deepgram).toEqual({});
   });
 

--- a/assistant/src/__tests__/stt-catalog-parity.test.ts
+++ b/assistant/src/__tests__/stt-catalog-parity.test.ts
@@ -1,0 +1,210 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+
+import {
+  getProviderEntry,
+  listCredentialProviderNames,
+  listProviderIds,
+} from "../providers/speech-to-text/provider-catalog.js";
+import type { SttProviderId } from "../stt/types.js";
+
+/**
+ * Parity guard: daemon STT provider catalog vs client STT catalog JSON.
+ *
+ * The daemon maintains its canonical provider catalog in
+ * `assistant/src/providers/speech-to-text/provider-catalog.ts`.
+ * The client-facing metadata lives in `meta/stt-provider-catalog.json` and is
+ * bundled into native clients at build time.
+ *
+ * These tests enforce that both catalogs stay in sync on the fields they
+ * share: provider IDs and credential-provider (apiKeyProviderName) mappings.
+ * CI will fail when they drift, forcing the developer to update whichever
+ * side fell behind.
+ */
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Resolve repo root (tests run from assistant/) */
+function getRepoRoot(): string {
+  return join(process.cwd(), "..");
+}
+
+interface ClientCatalogEntry {
+  id: string;
+  displayName: string;
+  subtitle: string;
+  setupMode: string;
+  setupHint: string;
+  apiKeyProviderName: string;
+}
+
+interface ClientCatalog {
+  version: number;
+  providers: ClientCatalogEntry[];
+}
+
+function loadClientCatalog(): ClientCatalog {
+  const catalogPath = join(getRepoRoot(), "meta", "stt-provider-catalog.json");
+  const raw = readFileSync(catalogPath, "utf-8");
+  return JSON.parse(raw);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("STT catalog parity: daemon vs client", () => {
+  // -----------------------------------------------------------------------
+  // Provider ID parity
+  // -----------------------------------------------------------------------
+
+  test("client catalog provider IDs match daemon catalog provider IDs", () => {
+    const daemonIds = listProviderIds();
+    const clientCatalog = loadClientCatalog();
+    const clientIds = clientCatalog.providers.map((p) => p.id);
+
+    // Every daemon provider ID must appear in the client catalog
+    const missingInClient = daemonIds.filter((id) => !clientIds.includes(id));
+    if (missingInClient.length > 0) {
+      const message = [
+        "Daemon catalog has provider IDs not present in meta/stt-provider-catalog.json.",
+        "",
+        "Missing in client catalog:",
+        ...missingInClient.map((id) => `  - ${id}`),
+        "",
+        "Add entries for these providers to meta/stt-provider-catalog.json.",
+      ].join("\n");
+      expect(missingInClient, message).toEqual([]);
+    }
+
+    // Every client catalog provider ID must appear in the daemon catalog
+    const missingInDaemon = clientIds.filter(
+      (id) => !daemonIds.includes(id as never),
+    );
+    if (missingInDaemon.length > 0) {
+      const message = [
+        "Client catalog (meta/stt-provider-catalog.json) has provider IDs not present in daemon catalog.",
+        "",
+        "Missing in daemon catalog:",
+        ...missingInDaemon.map((id) => `  - ${id}`),
+        "",
+        "Add entries for these providers to assistant/src/providers/speech-to-text/provider-catalog.ts.",
+      ].join("\n");
+      expect(missingInDaemon, message).toEqual([]);
+    }
+  });
+
+  test("daemon and client catalog list providers in the same order", () => {
+    const daemonIds = listProviderIds();
+    const clientCatalog = loadClientCatalog();
+    const clientIds = clientCatalog.providers.map((p) => p.id);
+
+    expect(clientIds).toEqual([...daemonIds]);
+  });
+
+  // -----------------------------------------------------------------------
+  // Credential provider name parity
+  // -----------------------------------------------------------------------
+
+  test("client catalog apiKeyProviderName values match daemon credential provider mappings", () => {
+    const daemonCredentialNames = listCredentialProviderNames();
+    const clientCatalog = loadClientCatalog();
+    const clientCredentialNames = clientCatalog.providers.map(
+      (p) => p.apiKeyProviderName,
+    );
+
+    // Deduplicate client names the same way the daemon does (first-seen order)
+    const seen = new Set<string>();
+    const deduplicatedClientNames: string[] = [];
+    for (const name of clientCredentialNames) {
+      if (!seen.has(name)) {
+        seen.add(name);
+        deduplicatedClientNames.push(name);
+      }
+    }
+
+    expect(deduplicatedClientNames).toEqual([...daemonCredentialNames]);
+  });
+
+  test("each client catalog entry apiKeyProviderName matches its daemon counterpart", () => {
+    const clientCatalog = loadClientCatalog();
+    const violations: string[] = [];
+
+    for (const clientEntry of clientCatalog.providers) {
+      const daemonEntry = getProviderEntry(clientEntry.id as SttProviderId);
+      if (!daemonEntry) {
+        // Covered by the provider ID parity test above
+        continue;
+      }
+      if (clientEntry.apiKeyProviderName !== daemonEntry.credentialProvider) {
+        violations.push(
+          `Provider "${clientEntry.id}": client apiKeyProviderName="${clientEntry.apiKeyProviderName}" ` +
+            `!= daemon credentialProvider="${daemonEntry.credentialProvider}"`,
+        );
+      }
+    }
+
+    if (violations.length > 0) {
+      const message = [
+        "Credential provider name mismatch between daemon and client catalogs.",
+        "",
+        "Violations:",
+        ...violations.map((v) => `  - ${v}`),
+        "",
+        "Update meta/stt-provider-catalog.json or assistant/src/providers/speech-to-text/provider-catalog.ts to match.",
+      ].join("\n");
+      expect(violations, message).toEqual([]);
+    }
+  });
+
+  // -----------------------------------------------------------------------
+  // Structural sanity
+  // -----------------------------------------------------------------------
+
+  test("client catalog JSON has a version field", () => {
+    const clientCatalog = loadClientCatalog();
+    expect(typeof clientCatalog.version).toBe("number");
+    expect(clientCatalog.version).toBeGreaterThanOrEqual(1);
+  });
+
+  test("client catalog has at least one provider", () => {
+    const clientCatalog = loadClientCatalog();
+    expect(clientCatalog.providers.length).toBeGreaterThan(0);
+  });
+
+  test("every client catalog entry has required fields", () => {
+    const clientCatalog = loadClientCatalog();
+    const violations: string[] = [];
+
+    for (const entry of clientCatalog.providers) {
+      if (!entry.id || typeof entry.id !== "string") {
+        violations.push(`Entry missing or invalid 'id'`);
+      }
+      if (!entry.displayName || typeof entry.displayName !== "string") {
+        violations.push(`${entry.id}: missing or invalid 'displayName'`);
+      }
+      if (
+        !entry.apiKeyProviderName ||
+        typeof entry.apiKeyProviderName !== "string"
+      ) {
+        violations.push(`${entry.id}: missing or invalid 'apiKeyProviderName'`);
+      }
+      if (!entry.setupMode || typeof entry.setupMode !== "string") {
+        violations.push(`${entry.id}: missing or invalid 'setupMode'`);
+      }
+    }
+
+    if (violations.length > 0) {
+      const message = [
+        "Client catalog entries have missing or invalid required fields.",
+        "",
+        "Violations:",
+        ...violations.map((v) => `  - ${v}`),
+      ].join("\n");
+      expect(violations, message).toEqual([]);
+    }
+  });
+});

--- a/assistant/src/__tests__/workspace-migration-033-stt-service-explicit-config.test.ts
+++ b/assistant/src/__tests__/workspace-migration-033-stt-service-explicit-config.test.ts
@@ -74,10 +74,8 @@ describe("033-stt-service-explicit-config migration", () => {
 
     expect(stt.mode).toBe("your-own");
     expect(stt.provider).toBe("openai-whisper");
-    expect(stt.providers).toEqual({
-      "openai-whisper": {},
-      deepgram: {},
-    });
+    // providers is sparse — no per-provider entries seeded
+    expect(stt.providers).toEqual({});
 
     // Other config keys preserved
     expect(config.maxTokens).toBe(64000);
@@ -98,10 +96,8 @@ describe("033-stt-service-explicit-config migration", () => {
 
     expect(stt.mode).toBe("your-own");
     expect(stt.provider).toBe("openai-whisper");
-    expect(stt.providers).toEqual({
-      "openai-whisper": {},
-      deepgram: {},
-    });
+    // providers is sparse — no per-provider entries seeded
+    expect(stt.providers).toEqual({});
 
     // Existing services preserved
     const inference = services.inference as Record<string, unknown>;
@@ -119,10 +115,8 @@ describe("033-stt-service-explicit-config migration", () => {
 
     expect(stt.mode).toBe("your-own");
     expect(stt.provider).toBe("openai-whisper");
-    expect(stt.providers).toEqual({
-      "openai-whisper": {},
-      deepgram: {},
-    });
+    // providers is sparse — no per-provider entries seeded
+    expect(stt.providers).toEqual({});
   });
 
   // ─── Partial STT object completion ────────────────────────────────────
@@ -171,7 +165,7 @@ describe("033-stt-service-explicit-config migration", () => {
     expect(stt.mode).toBe("your-own");
   });
 
-  test("fills in missing providers entries when stt has mode and provider", () => {
+  test("fills in missing providers as empty object when stt has mode and provider", () => {
     writeConfig({
       services: {
         stt: {
@@ -188,13 +182,12 @@ describe("033-stt-service-explicit-config migration", () => {
       string,
       unknown
     >;
-    const providers = stt.providers as Record<string, unknown>;
 
-    expect(providers["openai-whisper"]).toEqual({});
-    expect(providers.deepgram).toEqual({});
+    // providers is sparse — no per-provider entries seeded
+    expect(stt.providers).toEqual({});
   });
 
-  test("fills in missing deepgram entry when only openai-whisper exists in providers", () => {
+  test("does not inject per-provider entries when only openai-whisper exists in providers", () => {
     writeConfig({
       services: {
         stt: {
@@ -214,8 +207,9 @@ describe("033-stt-service-explicit-config migration", () => {
     >;
     const providers = stt.providers as Record<string, unknown>;
 
+    // Existing entry preserved, no new entries injected
     expect(providers["openai-whisper"]).toEqual({});
-    expect(providers.deepgram).toEqual({});
+    expect(providers.deepgram).toBeUndefined();
   });
 
   // ─── Preservation of explicit user provider overrides ─────────────────
@@ -428,6 +422,30 @@ describe("033-stt-service-explicit-config migration", () => {
         stt: {
           mode: "your-own",
           provider: "openai-whisper",
+          providers: {},
+        },
+      },
+    };
+    writeConfig(original);
+
+    // Capture the file's content before migration
+    const before = readFileSync(join(workspaceDir, "config.json"), "utf-8");
+
+    sttServiceExplicitConfigMigration.run(workspaceDir);
+
+    const after = readFileSync(join(workspaceDir, "config.json"), "utf-8");
+    // Content should be byte-identical since nothing changed
+    expect(after).toBe(before);
+  });
+
+  test("does not write file when nothing changed (config with per-provider entries from prior migration)", () => {
+    // Configs that include per-provider keys are already complete — the
+    // migration treats them as a no-op and must not rewrite the file.
+    const original = {
+      services: {
+        stt: {
+          mode: "your-own",
+          provider: "openai-whisper",
           providers: {
             "openai-whisper": {},
             deepgram: {},
@@ -437,13 +455,11 @@ describe("033-stt-service-explicit-config migration", () => {
     };
     writeConfig(original);
 
-    // Capture the file's mtime before migration
     const before = readFileSync(join(workspaceDir, "config.json"), "utf-8");
 
     sttServiceExplicitConfigMigration.run(workspaceDir);
 
     const after = readFileSync(join(workspaceDir, "config.json"), "utf-8");
-    // Content should be byte-identical since nothing changed
     expect(after).toBe(before);
   });
 

--- a/assistant/src/config/bundled-skills/transcribe/SKILL.md
+++ b/assistant/src/config/bundled-skills/transcribe/SKILL.md
@@ -18,3 +18,7 @@ Transcribe audio and video files using the configured speech-to-text provider. S
 - Large files are automatically split into chunks for processing.
 - If no STT provider credentials are configured, the tool will return an error with setup instructions.
 - The STT provider used here (`services.stt`) is independent of the telephony transcription provider (`calls.voice.transcriptionProvider`), which is configured separately for phone call STT.
+
+## Maintenance
+
+When adding or modifying an STT provider, follow the onboarding checklist at `assistant/docs/stt-provider-onboarding.md`. That document covers the daemon catalog, config schema, adapter wiring, client catalog parity, and required tests.

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -192,15 +192,8 @@ export {
   SkillsInstallConfigSchema,
   SkillsLoadConfigSchema,
 } from "./schemas/skills.js";
-export type {
-  SttDeepgramProviderConfig,
-  SttOpenAiWhisperProviderConfig,
-  SttProviders,
-  SttService,
-} from "./schemas/stt.js";
+export type { SttProviders, SttService } from "./schemas/stt.js";
 export {
-  SttDeepgramProviderConfigSchema,
-  SttOpenAiWhisperProviderConfigSchema,
   SttProvidersSchema,
   SttServiceSchema,
   VALID_STT_PROVIDERS,

--- a/assistant/src/config/schemas/services.ts
+++ b/assistant/src/config/schemas/services.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-import { SttProvidersSchema, SttServiceSchema } from "./stt.js";
+import { SttServiceSchema } from "./stt.js";
 import { TtsServiceSchema } from "./tts.js";
 
 export const ServiceModeSchema = z.enum(["managed", "your-own"]);
@@ -90,7 +90,7 @@ export const ServicesSchema = z.object({
   stt: SttServiceSchema.default({
     mode: "your-own" as const,
     provider: "openai-whisper" as const,
-    providers: SttProvidersSchema.parse({}),
+    providers: {},
   }),
   tts: TtsServiceSchema.default(TtsServiceSchema.parse({})),
   "google-oauth": GoogleOAuthServiceSchema.default(

--- a/assistant/src/config/schemas/stt.ts
+++ b/assistant/src/config/schemas/stt.ts
@@ -7,46 +7,21 @@ import { z } from "zod";
 export const VALID_STT_PROVIDERS = ["openai-whisper", "deepgram"] as const;
 
 /**
- * Per-provider config schemas nested under `services.stt.providers.<id>`.
+ * Sparse provider config map under `services.stt.providers`.
  *
- * Each provider's schema is the full provider-specific config (tuning
- * params, etc.). New providers add sibling schemas without restructuring.
+ * This is a forward-compatible record that accepts any provider ID as key
+ * with an object value. All provider entries — known (`openai-whisper`,
+ * `deepgram`) and unknown — are accepted with generic object validation.
+ * Adding a new provider ID does not require a migration to seed
+ * `services.stt.providers.<id>`.
  *
- * The provider config is an empty object. Per-provider tuning params
- * (e.g., model, language) can be added here once the provider adapter
- * consumes them at runtime.
+ * The map only holds entries the user has explicitly configured — it is
+ * NOT required to enumerate every known provider.
  */
-export const SttOpenAiWhisperProviderConfigSchema = z
-  .object({})
-  .describe("OpenAI Whisper provider configuration under services.stt");
-
-export type SttOpenAiWhisperProviderConfig = z.infer<
-  typeof SttOpenAiWhisperProviderConfigSchema
->;
-
-/**
- * Deepgram provider configuration under `services.stt.providers.deepgram`.
- *
- * Provider-specific tuning params (model, language, smart formatting)
- * can be added here as the adapter evolves. For now the schema is empty
- * so that adding the provider to config.json is friction-free.
- */
-export const SttDeepgramProviderConfigSchema = z
-  .object({})
-  .describe("Deepgram provider configuration under services.stt");
-
-export type SttDeepgramProviderConfig = z.infer<
-  typeof SttDeepgramProviderConfigSchema
->;
-
-export const SttProvidersSchema = z.object({
-  "openai-whisper": SttOpenAiWhisperProviderConfigSchema.default(
-    SttOpenAiWhisperProviderConfigSchema.parse({}),
-  ),
-  deepgram: SttDeepgramProviderConfigSchema.default(
-    SttDeepgramProviderConfigSchema.parse({}),
-  ),
-});
+export const SttProvidersSchema = z.record(
+  z.string(),
+  z.record(z.string(), z.unknown()).default({}),
+);
 export type SttProviders = z.infer<typeof SttProvidersSchema>;
 
 /**
@@ -71,7 +46,7 @@ export const SttServiceSchema = z
         error: `services.stt.provider must be one of: ${VALID_STT_PROVIDERS.join(", ")}`,
       })
       .describe("Active STT provider used for speech-to-text transcription"),
-    providers: SttProvidersSchema.default(SttProvidersSchema.parse({})),
+    providers: SttProvidersSchema.default({}),
   })
   .describe(
     "Speech-to-text service configuration -- provider selection and per-provider settings",

--- a/assistant/src/providers/__tests__/provider-secret-catalog.test.ts
+++ b/assistant/src/providers/__tests__/provider-secret-catalog.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+
+import { API_KEY_PROVIDERS } from "../provider-secret-catalog.js";
+
+// ---------------------------------------------------------------------------
+// API_KEY_PROVIDERS derivation invariants
+// ---------------------------------------------------------------------------
+
+describe("API_KEY_PROVIDERS", () => {
+  test("includes deepgram (STT catalog-derived)", () => {
+    expect(API_KEY_PROVIDERS).toContain("deepgram");
+  });
+
+  test("includes openai exactly once (shared by LLM and STT)", () => {
+    const occurrences = API_KEY_PROVIDERS.filter((p) => p === "openai");
+    expect(occurrences.length).toBe(1);
+  });
+
+  test("contains no duplicate entries", () => {
+    const unique = new Set(API_KEY_PROVIDERS);
+    expect(API_KEY_PROVIDERS.length).toBe(unique.size);
+  });
+
+  test("is deterministic across calls", () => {
+    // Re-import would return the same module-level constant, but this
+    // validates that the composition does not introduce non-determinism.
+    const first = [...API_KEY_PROVIDERS];
+    const second = [...API_KEY_PROVIDERS];
+    expect(first).toEqual(second);
+  });
+
+  test("includes core LLM providers", () => {
+    expect(API_KEY_PROVIDERS).toContain("anthropic");
+    expect(API_KEY_PROVIDERS).toContain("openai");
+    expect(API_KEY_PROVIDERS).toContain("gemini");
+  });
+});

--- a/assistant/src/providers/provider-secret-catalog.ts
+++ b/assistant/src/providers/provider-secret-catalog.ts
@@ -6,8 +6,8 @@
  *
  * 1. **LLM / search providers** -- statically declared here because they
  *    have no separate catalog module yet.
- * 2. **STT providers** -- statically declared here because no STT
- *    provider-catalog module exists yet.
+ * 2. **STT providers** -- dynamically derived from the canonical STT
+ *    provider catalog by reading credential-provider names.
  * 3. **TTS catalog providers** -- dynamically derived from the canonical
  *    TTS provider catalog by selecting entries whose secret requirements
  *    use the bare-name (non-credential) storage convention.
@@ -18,6 +18,7 @@
  */
 
 import { listCatalogProviders } from "../tts/provider-catalog.js";
+import { listCredentialProviderNames as listSttCredentialProviderNames } from "./speech-to-text/provider-catalog.js";
 
 // ---------------------------------------------------------------------------
 // Static LLM / search providers
@@ -43,19 +44,20 @@ const LLM_AND_SEARCH_API_KEY_PROVIDERS = [
 ] as const;
 
 // ---------------------------------------------------------------------------
-// Static STT providers
+// STT catalog-derived providers
 // ---------------------------------------------------------------------------
 
 /**
- * STT providers that store API keys under their bare provider name in the
- * secure credential store (e.g. `deepgram`).
- *
- * Declared statically because no STT provider-catalog module exists yet.
- * Providers whose credential key collides with an LLM provider (e.g.
- * `openai-whisper` uses the `openai` key which is already in the LLM
- * list) are intentionally omitted to avoid duplicates.
+ * Derive the deduplicated set of STT credential-provider names from the
+ * canonical STT provider catalog, filtering out names that already appear
+ * in the LLM/search list to avoid duplicates (e.g. `openai-whisper` maps
+ * to `"openai"` which is already present in
+ * {@link LLM_AND_SEARCH_API_KEY_PROVIDERS}).
  */
-const STT_API_KEY_PROVIDERS = ["deepgram"] as const;
+function sttApiKeyProviderNames(): string[] {
+  const llmSet = new Set<string>(LLM_AND_SEARCH_API_KEY_PROVIDERS);
+  return listSttCredentialProviderNames().filter((name) => !llmSet.has(name));
+}
 
 // ---------------------------------------------------------------------------
 // TTS catalog-derived providers
@@ -103,13 +105,15 @@ function catalogApiKeyProviderIds(): string[] {
  * - Provider availability checks
  *
  * Adding a new TTS provider to the catalog with a bare-name secret
- * requirement automatically includes it here. Adding a new LLM or
- * search provider requires appending to
+ * requirement automatically includes it here. Adding a new STT
+ * provider to the STT catalog automatically includes it here (shared
+ * credential names like `openai` are deduplicated against the LLM
+ * list). Adding a new LLM or search provider requires appending to
  * {@link LLM_AND_SEARCH_API_KEY_PROVIDERS} until those domains get
  * their own catalog modules.
  */
 export const API_KEY_PROVIDERS: readonly string[] = [
   ...LLM_AND_SEARCH_API_KEY_PROVIDERS,
-  ...STT_API_KEY_PROVIDERS,
+  ...sttApiKeyProviderNames(),
   ...catalogApiKeyProviderIds(),
 ] as const;

--- a/assistant/src/providers/speech-to-text/__tests__/provider-catalog.test.ts
+++ b/assistant/src/providers/speech-to-text/__tests__/provider-catalog.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  getCredentialProvider,
+  getProviderEntry,
+  listCredentialProviderNames,
+  listProviderEntries,
+  listProviderIds,
+  supportsBoundary,
+} from "../provider-catalog.js";
+
+// ---------------------------------------------------------------------------
+// Catalog invariants
+// ---------------------------------------------------------------------------
+
+describe("STT provider catalog", () => {
+  // -----------------------------------------------------------------------
+  // Stable IDs
+  // -----------------------------------------------------------------------
+
+  test("listProviderIds returns all known provider IDs", () => {
+    const ids = listProviderIds();
+    expect(ids).toContain("openai-whisper");
+    expect(ids).toContain("deepgram");
+  });
+
+  test("listProviderIds returns IDs in deterministic insertion order", () => {
+    const first = listProviderIds();
+    const second = listProviderIds();
+    expect(first).toEqual(second);
+  });
+
+  test("every ID returned by listProviderIds has a catalog entry", () => {
+    for (const id of listProviderIds()) {
+      expect(getProviderEntry(id)).toBeDefined();
+    }
+  });
+
+  // -----------------------------------------------------------------------
+  // Credential provider names
+  // -----------------------------------------------------------------------
+
+  test("listCredentialProviderNames returns deduplicated names", () => {
+    const names = listCredentialProviderNames();
+    const unique = new Set(names);
+    expect(names.length).toBe(unique.size);
+  });
+
+  test("listCredentialProviderNames includes expected providers", () => {
+    const names = listCredentialProviderNames();
+    // openai-whisper maps to "openai", deepgram maps to "deepgram"
+    expect(names).toContain("openai");
+    expect(names).toContain("deepgram");
+  });
+
+  test("listCredentialProviderNames returns names in deterministic order", () => {
+    const first = listCredentialProviderNames();
+    const second = listCredentialProviderNames();
+    expect(first).toEqual(second);
+  });
+
+  // -----------------------------------------------------------------------
+  // Entry-level invariants
+  // -----------------------------------------------------------------------
+
+  test("every entry has a non-empty credentialProvider", () => {
+    for (const entry of listProviderEntries()) {
+      expect(entry.credentialProvider.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("every entry has at least one supported boundary", () => {
+    for (const entry of listProviderEntries()) {
+      expect(entry.supportedBoundaries.size).toBeGreaterThan(0);
+    }
+  });
+
+  test("every entry ID matches its catalog key", () => {
+    for (const id of listProviderIds()) {
+      const entry = getProviderEntry(id);
+      expect(entry?.id).toBe(id);
+    }
+  });
+
+  // -----------------------------------------------------------------------
+  // Boundary support
+  // -----------------------------------------------------------------------
+
+  test("supportsBoundary returns true for supported boundaries", () => {
+    expect(supportsBoundary("openai-whisper", "daemon-batch")).toBe(true);
+    expect(supportsBoundary("deepgram", "daemon-batch")).toBe(true);
+  });
+
+  test("supportsBoundary returns false for unknown provider IDs", () => {
+    // Cast to bypass type checking for the test
+    expect(supportsBoundary("nonexistent" as never, "daemon-batch")).toBe(
+      false,
+    );
+  });
+
+  // -----------------------------------------------------------------------
+  // Credential lookup
+  // -----------------------------------------------------------------------
+
+  test("getCredentialProvider returns correct mapping", () => {
+    expect(getCredentialProvider("openai-whisper")).toBe("openai");
+    expect(getCredentialProvider("deepgram")).toBe("deepgram");
+  });
+
+  test("getCredentialProvider returns undefined for unknown ID", () => {
+    expect(getCredentialProvider("nonexistent" as never)).toBeUndefined();
+  });
+});

--- a/assistant/src/providers/speech-to-text/provider-catalog.ts
+++ b/assistant/src/providers/speech-to-text/provider-catalog.ts
@@ -130,3 +130,31 @@ export function supportsBoundary(
 ): boolean {
   return CATALOG.get(id)?.supportedBoundaries.has(boundary) ?? false;
 }
+
+/**
+ * Return all canonical provider IDs in deterministic (insertion) order.
+ */
+export function listProviderIds(): readonly SttProviderId[] {
+  return [...CATALOG.keys()];
+}
+
+/**
+ * Return the deduplicated set of credential-provider names used by STT
+ * providers, in deterministic (first-seen) order.
+ *
+ * Multiple STT providers may share a single credential provider (e.g.
+ * `openai-whisper` and a future `openai-realtime` both map to `"openai"`).
+ * This helper deduplicates so that callers composing API-key provider
+ * lists do not produce duplicate entries.
+ */
+export function listCredentialProviderNames(): readonly string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const entry of CATALOG.values()) {
+    if (!seen.has(entry.credentialProvider)) {
+      seen.add(entry.credentialProvider);
+      result.push(entry.credentialProvider);
+    }
+  }
+  return result;
+}

--- a/assistant/src/workspace/migrations/033-stt-service-explicit-config.ts
+++ b/assistant/src/workspace/migrations/033-stt-service-explicit-config.ts
@@ -12,11 +12,15 @@ import type { WorkspaceMigration } from "./types.js";
  * to users and tooling that inspects config on disk.
  *
  * This migration writes a canonical `services.stt` block when missing or
- * partial, backfilling:
+ * partial, backfilling only structural fields:
  *
  *   - `services.stt.mode`      -> `"your-own"`
  *   - `services.stt.provider`  -> `"openai-whisper"`
- *   - `services.stt.providers` -> `{ "openai-whisper": {}, "deepgram": {} }`
+ *   - `services.stt.providers` -> `{}` (empty object — sparse map)
+ *
+ * It does NOT seed per-provider entries (`openai-whisper`, `deepgram`, etc.)
+ * — the providers map is sparse and only holds entries the user explicitly
+ * configures. Adding a new provider ID does not require a migration.
  *
  * It never clobbers user-defined STT values — only fills in what is missing.
  *
@@ -58,14 +62,14 @@ export const sttServiceExplicitConfigMigration: WorkspaceMigration = {
       changed = true;
     }
 
-    // Backfill providers map and its entries
-    const providers = ensureObj(stt, "providers");
-    if (!("openai-whisper" in providers)) {
-      providers["openai-whisper"] = {};
-      changed = true;
-    }
-    if (!("deepgram" in providers)) {
-      providers.deepgram = {};
+    // Ensure providers map exists as an object (sparse — no per-provider seeding)
+    if (
+      !("providers" in stt) ||
+      stt.providers == null ||
+      typeof stt.providers !== "object" ||
+      Array.isArray(stt.providers)
+    ) {
+      stt.providers = {};
       changed = true;
     }
 

--- a/clients/ios/Tests/STTProviderRegistryIOSTests.swift
+++ b/clients/ios/Tests/STTProviderRegistryIOSTests.swift
@@ -1,0 +1,90 @@
+#if canImport(UIKit)
+import XCTest
+
+@testable import VellumAssistantShared
+
+/// Tests verifying that the iOS STT provider selector works correctly
+/// with the shared ``STTProviderRegistry``.
+final class STTProviderRegistryIOSTests: XCTestCase {
+
+    // MARK: - Registry Loading
+
+    func testRegistryLoadsNonEmptyProviderList() {
+        let registry = loadSTTProviderRegistry()
+        XCTAssertFalse(registry.providers.isEmpty, "Registry should contain at least one provider")
+    }
+
+    func testRegistryContainsOpenAIWhisper() {
+        let registry = loadSTTProviderRegistry()
+        let entry = registry.provider(withId: "openai-whisper")
+        XCTAssertNotNil(entry, "Registry should contain an 'openai-whisper' provider")
+        XCTAssertEqual(entry?.displayName, "OpenAI Whisper")
+    }
+
+    // MARK: - Provider Lookup and Fallback
+
+    func testProviderLookupReturnsMatchingEntry() {
+        let registry = loadSTTProviderRegistry()
+        for provider in registry.providers {
+            let found = registry.provider(withId: provider.id)
+            XCTAssertNotNil(found, "Lookup should find provider with id '\(provider.id)'")
+            XCTAssertEqual(found?.id, provider.id)
+        }
+    }
+
+    func testProviderLookupReturnsNilForUnknownId() {
+        let registry = loadSTTProviderRegistry()
+        let result = registry.provider(withId: "nonexistent-provider-id")
+        XCTAssertNil(result, "Lookup should return nil for unknown provider IDs")
+    }
+
+    func testFallbackToFirstProviderForUnknownPersistedValue() {
+        let registry = loadSTTProviderRegistry()
+        // Simulate the fallback logic used in settings:
+        // registry.provider(withId: raw) ?? registry.providers.first
+        let unknownRaw = "deleted-provider"
+        let resolved = registry.provider(withId: unknownRaw) ?? registry.providers.first
+        XCTAssertNotNil(resolved, "Fallback should resolve to the first registry provider")
+        XCTAssertEqual(resolved?.id, registry.providers.first?.id)
+    }
+
+    // MARK: - API Key Provider Name
+
+    func testEveryEntryHasNonEmptyApiKeyProviderName() {
+        let registry = loadSTTProviderRegistry()
+        for provider in registry.providers {
+            XCTAssertFalse(
+                provider.apiKeyProviderName.isEmpty,
+                "Provider '\(provider.id)' should have a non-empty apiKeyProviderName"
+            )
+        }
+    }
+
+    func testOpenAIWhisperMapsToOpenAICredentialProvider() {
+        let registry = loadSTTProviderRegistry()
+        let entry = registry.provider(withId: "openai-whisper")
+        XCTAssertEqual(
+            entry?.apiKeyProviderName, "openai",
+            "openai-whisper should map to 'openai' credential provider"
+        )
+    }
+
+    func testDeepgramMapsToDeepgramCredentialProvider() {
+        let registry = loadSTTProviderRegistry()
+        let entry = registry.provider(withId: "deepgram")
+        XCTAssertEqual(
+            entry?.apiKeyProviderName, "deepgram",
+            "deepgram should map to 'deepgram' credential provider"
+        )
+    }
+
+    // MARK: - Default Provider Selection
+
+    func testDefaultProviderIdMatchesRegistryEntry() {
+        let registry = loadSTTProviderRegistry()
+        let defaultId = "openai-whisper" // matches the default STT provider in settings
+        let entry = registry.provider(withId: defaultId)
+        XCTAssertNotNil(entry, "Default provider ID '\(defaultId)' should exist in the registry")
+    }
+}
+#endif

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -3060,6 +3060,37 @@ public final class SettingsStore: ObservableObject {
             .apiKeyProviderName ?? sttProviderId
     }
 
+    /// Whether the given STT provider owns its API key exclusively — i.e. the
+    /// key is not shared with any other service. Exclusive-key providers can
+    /// safely have their key cleared through the STT reset flow without
+    /// affecting other features.
+    ///
+    /// A provider's key is exclusive when its `apiKeyProviderName` matches its
+    /// own `id` (e.g. `deepgram` → `deepgram`). Shared-key providers map to a
+    /// different credential name (e.g. `openai-whisper` → `openai`).
+    ///
+    /// This helper is provider-agnostic: adding a new provider only requires a
+    /// catalog entry — no new conditionals here or in the UI layer.
+    static func sttKeyIsExclusive(for sttProviderId: String) -> Bool {
+        let entry = loadSTTProviderRegistry().provider(withId: sttProviderId)
+        guard let entry else {
+            // Unknown providers are assumed exclusive — clearing an unknown
+            // key cannot collide with a known service.
+            return true
+        }
+        return entry.apiKeyProviderName == entry.id
+    }
+
+    /// Whether the given STT provider's API key is shared with another
+    /// service. The inverse of `sttKeyIsExclusive(for:)`.
+    ///
+    /// Shared-key providers should not expose a "Reset" action in the STT
+    /// settings card because clearing the key would break the sibling service
+    /// that depends on it.
+    static func sttKeyIsShared(for sttProviderId: String) -> Bool {
+        !sttKeyIsExclusive(for: sttProviderId)
+    }
+
     /// Schedules a delayed refresh of provider routing sources, giving the
     /// daemon time to re-initialize providers after a key change.
     private func scheduleRoutingSourceRefresh() {

--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -503,6 +503,25 @@ struct VoiceSettingsView: View {
         return APIKeyManager.getKey(for: keyProvider) != nil
     }
 
+    // MARK: - STT Key Ownership Helpers
+
+    /// Whether the STT reset button should be shown for the current provider.
+    ///
+    /// The reset button is only shown when:
+    /// 1. A key already exists for the provider, AND
+    /// 2. The provider owns its key exclusively (not shared with another
+    ///    service like Inference).
+    ///
+    /// This prevents accidental clearing of shared credentials — e.g.
+    /// resetting `openai-whisper` must not delete the `openai` key that
+    /// Inference also depends on.
+    ///
+    /// Provider-agnostic: adding a third STT provider only requires a
+    /// catalog entry, not a new conditional here.
+    private var sttResetAllowed: Bool {
+        sttProviderHasKey && SettingsStore.sttKeyIsExclusive(for: draftSTTProvider)
+    }
+
     /// Clears the stored TTS credential for the given provider.
     private func clearTTSCredential(for provider: String) {
         switch provider {
@@ -555,21 +574,17 @@ struct VoiceSettingsView: View {
                     }
                 }
 
-                // Save + Reset actions
+                // Save + Reset actions — reset is only shown for
+                // exclusive-key providers to avoid clearing shared
+                // credentials (e.g. `openai` used by both Inference and
+                // Whisper STT).
                 ServiceCardActions(
                     hasChanges: sttHasChanges,
                     isSaving: sttSaving,
                     onSave: { saveSTT() },
                     savingLabel: "Saving...",
-                    onReset: {
-                        store.clearSTTKey(sttProviderId: draftSTTProvider)
-                        sttProviderHasKey = false
-                        sttApiKeyText = ""
-                    },
-                    showReset: sttProviderHasKey && {
-                        let entry = sttRegistry.provider(withId: draftSTTProvider)
-                        return entry.map { $0.apiKeyProviderName == $0.id } ?? true
-                    }()
+                    onReset: { resetSTTKey() },
+                    showReset: sttResetAllowed
                 )
             }
         }
@@ -592,6 +607,17 @@ struct VoiceSettingsView: View {
             errorMessage: sttSaveError
         )
         .disabled(sttSaving)
+    }
+
+    // MARK: - STT Reset
+
+    /// Clears the STT API key for the current draft provider and resets the
+    /// associated UI state. Only called for exclusive-key providers — shared
+    /// credentials are never cleared through the STT settings card.
+    private func resetSTTKey() {
+        store.clearSTTKey(sttProviderId: draftSTTProvider)
+        sttProviderHasKey = false
+        sttApiKeyText = ""
     }
 
     // MARK: - STT Save

--- a/clients/macos/vellum-assistantTests/SettingsStoreVoiceServiceTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsStoreVoiceServiceTests.swift
@@ -310,4 +310,112 @@ final class SettingsStoreVoiceServiceTests: XCTestCase {
             "Most recent STT patch should reflect the deepgram provider"
         )
     }
+
+    // MARK: - STT Key Ownership Semantics
+
+    func testSharedKeyProviderIsNotExclusive() {
+        // openai-whisper maps to the "openai" credential — shared with
+        // Inference, so it must NOT be classified as exclusive.
+        XCTAssertFalse(
+            SettingsStore.sttKeyIsExclusive(for: "openai-whisper"),
+            "openai-whisper shares the 'openai' key and must not be exclusive"
+        )
+    }
+
+    func testSharedKeyProviderIsShared() {
+        XCTAssertTrue(
+            SettingsStore.sttKeyIsShared(for: "openai-whisper"),
+            "openai-whisper shares the 'openai' key and must be classified as shared"
+        )
+    }
+
+    func testExclusiveKeyProviderIsExclusive() {
+        // deepgram maps to "deepgram" — its own credential, not shared.
+        XCTAssertTrue(
+            SettingsStore.sttKeyIsExclusive(for: "deepgram"),
+            "deepgram owns its own key and must be classified as exclusive"
+        )
+    }
+
+    func testExclusiveKeyProviderIsNotShared() {
+        XCTAssertFalse(
+            SettingsStore.sttKeyIsShared(for: "deepgram"),
+            "deepgram owns its own key and must not be classified as shared"
+        )
+    }
+
+    func testUnknownProviderDefaultsToExclusive() {
+        // Unknown providers fall back to exclusive — clearing an unknown
+        // key cannot collide with a known service.
+        XCTAssertTrue(
+            SettingsStore.sttKeyIsExclusive(for: "future-provider"),
+            "Unknown providers should default to exclusive"
+        )
+    }
+
+    func testUnknownProviderIsNotShared() {
+        XCTAssertFalse(
+            SettingsStore.sttKeyIsShared(for: "future-provider"),
+            "Unknown providers should not be classified as shared"
+        )
+    }
+
+    // MARK: - Provider Mapping Stability
+
+    /// Ensures that every provider in the STT registry has a consistent
+    /// `apiKeyProviderName` mapping. This test fails fast when a new
+    /// provider is added with an inconsistent catalog entry.
+    func testAllRegistryProvidersHaveStableKeyMapping() {
+        let registry = loadSTTProviderRegistry()
+        for provider in registry.providers {
+            let resolved = SettingsStore.sttApiKeyProviderName(for: provider.id)
+            XCTAssertEqual(
+                resolved,
+                provider.apiKeyProviderName,
+                "sttApiKeyProviderName(for: \"\(provider.id)\") returned \"\(resolved)\" "
+                + "but the catalog entry specifies \"\(provider.apiKeyProviderName)\""
+            )
+        }
+    }
+
+    /// Ensures the ownership classification for every registered provider
+    /// is consistent with the catalog's `apiKeyProviderName` field.
+    func testAllRegistryProvidersHaveConsistentOwnership() {
+        let registry = loadSTTProviderRegistry()
+        for provider in registry.providers {
+            let isExclusive = SettingsStore.sttKeyIsExclusive(for: provider.id)
+            let expectedExclusive = (provider.apiKeyProviderName == provider.id)
+            XCTAssertEqual(
+                isExclusive,
+                expectedExclusive,
+                "Ownership mismatch for \"\(provider.id)\": sttKeyIsExclusive returned "
+                + "\(isExclusive) but apiKeyProviderName=\"\(provider.apiKeyProviderName)\" "
+                + "implies exclusive=\(expectedExclusive)"
+            )
+        }
+    }
+
+    /// Verifies that shared-key providers cannot be reset through the STT
+    /// card — the `sttKeyIsExclusive` guard prevents `clearSTTKey` from
+    /// being called for providers whose key is shared with another service.
+    func testSharedKeyProviderCannotBeResetThroughSTTFlow() {
+        // Simulate what the UI does: check sttKeyIsExclusive before
+        // allowing the reset action. For openai-whisper, the guard
+        // must prevent the reset.
+        let allowReset = SettingsStore.sttKeyIsExclusive(for: "openai-whisper")
+        XCTAssertFalse(
+            allowReset,
+            "The STT reset flow must not be allowed for shared-key providers"
+        )
+    }
+
+    /// Verifies that exclusive-key providers can be reset through the STT
+    /// card without affecting other services.
+    func testExclusiveKeyProviderCanBeResetSafely() {
+        let allowReset = SettingsStore.sttKeyIsExclusive(for: "deepgram")
+        XCTAssertTrue(
+            allowReset,
+            "The STT reset flow should be allowed for exclusive-key providers"
+        )
+    }
 }

--- a/clients/shared/Utilities/STTProviderRegistry.swift
+++ b/clients/shared/Utilities/STTProviderRegistry.swift
@@ -44,6 +44,12 @@ public struct STTProviderCatalogEntry: Decodable {
 /// The JSON file lives at `meta/stt-provider-catalog.json` and is copied
 /// into `Contents/Resources` by `build.sh`. It is the single source of
 /// truth for client-facing STT provider metadata.
+///
+/// The daemon maintains its own canonical catalog in
+/// `assistant/src/providers/speech-to-text/provider-catalog.ts`.
+/// A CI parity test (`stt-catalog-parity.test.ts`) enforces that provider
+/// IDs and credential-provider name mappings (`apiKeyProviderName`) remain
+/// aligned between the JSON file and the daemon catalog.
 public struct STTProviderRegistry: Decodable {
     public let version: Int
     public let providers: [STTProviderCatalogEntry]
@@ -59,6 +65,16 @@ public struct STTProviderRegistry: Decodable {
 /// Hard-coded fallback registry used when the bundled JSON is missing or
 /// corrupt. Keeps client startup resilient — the app can always show at
 /// least the current set of providers.
+///
+/// **Parity requirement**: The provider IDs and `apiKeyProviderName`
+/// mappings below MUST remain in sync with `meta/stt-provider-catalog.json`
+/// (the single source of truth for client-facing metadata) and with the
+/// daemon-side catalog in
+/// `assistant/src/providers/speech-to-text/provider-catalog.ts`.
+/// A CI parity test (`stt-catalog-parity.test.ts`) enforces alignment
+/// between the daemon catalog and the JSON file. If you add or rename a
+/// provider here, update both the JSON catalog and the daemon catalog to
+/// keep all three in lockstep.
 private let fallbackRegistry = STTProviderRegistry(
     version: 0,
     providers: [


### PR DESCRIPTION
## Summary
Hardens and unifies STT provider plumbing so adding Google/Gemini as a third provider is mostly additive instead of another round of cross-cutting cleanup. Removes remaining metadata drift points, makes `services.stt.providers` future-proof for new providers, and adds parity tests that fail fast when daemon/client catalogs diverge.

## PRs merged into feature branch
- #25109: refactor(stt): derive API-key provider names from STT provider catalog
- #25110: fix(macos): codify STT shared-vs-exclusive key behavior in settings
- #25113: refactor(config): make services.stt.providers sparse to avoid per-provider migration churn
- #25115: test(stt): enforce parity between daemon provider catalog and client STT catalog json
- #25123: docs(stt): add provider-onboarding checklist and architecture updates

## Self-review result
Skipped per user request — proceeding directly to feature branch review.

Part of plan: pre-google-stt-cleanup-unification.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25124" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
