### PR TITLE
fix(macos): drop O(n) hashValue from tool-output cache key

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -956,15 +956,14 @@ private struct StepDetailRow: View {
         result: String,
         isError: Bool
     ) -> NSString {
-        // Cheap content fingerprint: length + prefix + suffix + per-process hash.
-        // Ensures the key changes when `result` is overwritten in place with
-        // different text of the same byte count (replay / correction / rehydration
-        // paths all mutate toolCalls[...].result).
+        // O(1) content fingerprint: length + boundary samples. Catches in-place
+        // mutations (replay / correction / rehydration paths all overwrite
+        // toolCalls[...].result) without hashing the full string on every
+        // SwiftUI re-render.
         let count = result.utf8.count
         let prefix = result.prefix(16)
         let suffix = result.suffix(16)
-        let hash = result.hashValue
-        return "\(toolCallID)|\(count)|\(isError ? "err" : "ok")|\(prefix)|\(suffix)|\(hash)" as NSString
+        return "\(toolCallID)|\(count)|\(isError ? "err" : "ok")|\(prefix)|\(suffix)" as NSString
     }
 
     private func coloredOutput(_ result: String, isError: Bool) -> AttributedString {


### PR DESCRIPTION
Addresses Codex feedback on #25092: result.hashValue is O(n) and runs in the SwiftUI render path on every cache lookup, reintroducing the O(n) per-render cost that #25048 eliminated. Removes hashValue from the fingerprint — the remaining count|prefix(16)|suffix(16) terms are O(1) and still catch the in-place mutation case that #25092 was fixing.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25125" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
