### PR TITLE
fix(unicode): species-independent clone in sanitizeSurrogates

### DIFF
--- a/assistant/src/__tests__/unicode.test.ts
+++ b/assistant/src/__tests__/unicode.test.ts
@@ -244,6 +244,29 @@ describe("stripOrphanedSurrogatesDeep", () => {
     expect(result.value[1]).toBe(`bad${REPLACEMENT}`);
   });
 
+  test("array subclass with hostile Symbol.species still clones safely", () => {
+    // Regression: Array.prototype.slice consults ArraySpeciesCreate, so an
+    // Array subclass with a custom Symbol.species could produce a non-Array
+    // clone whose push() doesn't exist — crashing the sanitizer. The fix
+    // must build a plain Array literal instead.
+    class HostileContainer {
+      items: unknown[] = [];
+      // Intentionally no `push` method — mimics the shape ArraySpeciesCreate
+      // would produce for a subclass that returns a non-Array constructor.
+    }
+    class WeirdArray extends Array {
+      static get [Symbol.species](): ArrayConstructor {
+        return HostileContainer as unknown as ArrayConstructor;
+      }
+    }
+    const input = new WeirdArray();
+    input.push("clean", `bad${HIGH}`);
+    const result = stripOrphanedSurrogatesDeep(input);
+    expect(result.changed).toBe(true);
+    expect(Array.isArray(result.value)).toBe(true);
+    expect(result.value).toEqual(["clean", `bad${REPLACEMENT}`]);
+  });
+
   test("rewritten output can be JSON-stringified end-to-end", () => {
     // This is the exact shape of the bug: a payload with an orphaned high
     // surrogate buried in a tool_result content string. After sanitization,

--- a/assistant/src/util/unicode.ts
+++ b/assistant/src/util/unicode.ts
@@ -148,7 +148,10 @@ export function stripOrphanedSurrogatesDeep<T>(input: T): DeepSanitizeResult<T> 
       for (let i = 0; i < value.length; i++) {
         const result = walk(value[i]);
         if (result.changed && next === null) {
-          next = Array.prototype.slice.call(value, 0, i) as unknown[];
+          next = [];
+          for (let j = 0; j < i; j++) {
+            next.push(value[j]);
+          }
         }
         if (next !== null) {
           next.push(result.value);


### PR DESCRIPTION
Addresses Codex feedback on #25091: Array.prototype.slice.call still consults ArraySpeciesCreate, so Array subclasses with custom Symbol.species could still produce a non-Array clone and crash on the next push. Replaces the slice.call with a manual loop that builds a plain Array.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25126" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
