### PR TITLE
fix(daemon): reapply trustContext for idle reused conversations

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -997,12 +997,16 @@ export class DaemonServer {
       // overwrite the in-flight conversation's transportHints.
       if (!conversation.isProcessing()) {
         this.applyTransportMetadata(conversation, options);
+        // trustContext is reapplied here only when the conversation is idle,
+        // so concurrent requests cannot overwrite an in-flight turn's guardian
+        // scope. Direct callers (e.g. schedule-routes run-now) that invoke
+        // processMessage without going through prepareConversationForMessage
+        // rely on this to pick up the trustContext passed in options.
+        // prepareConversationForMessage also reapplies after its own idle check.
+        if (options?.trustContext !== undefined) {
+          conversation.setTrustContext(options.trustContext);
+        }
       }
-      // Note: trustContext reapplication for reused conversations is handled
-      // in prepareConversationForMessage AFTER the isProcessing() idle check.
-      // Applying it here would race concurrent requests — a busy-rejected
-      // caller could still overwrite the in-flight turn's guardian scope,
-      // changing authorization mid-turn.
       this.evictor.touch(conversationId);
     }
     return conversation;


### PR DESCRIPTION
Addresses Codex feedback on #25095: direct callers in schedule-routes.ts (run-now paths) call getOrCreateConversation then processMessage without going through prepareConversationForMessage, so the trustContext passed in options was being ignored for reused conversations. Restores the setTrustContext call in the reuse branch, but gates it on !conversation.isProcessing() so concurrent-request races still cannot overwrite mid-turn trust context (which was the bug #25095 was fixing).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25127" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
