### PR TITLE
docs(backup): use 'assistant log' per user-facing terminology rule

### DIFF
--- a/assistant/docs/backup-troubleshooting.md
+++ b/assistant/docs/backup-troubleshooting.md
@@ -22,7 +22,7 @@ In rare cases a writer can crash after creating the lock file but before writing
 
 ### Recovery
 
-1. Confirm no backup is actually in progress — check the daemon log for recent `snapshot-worker` activity and look for a running process holding the lock.
+1. Confirm no backup is actually in progress — check the assistant log for recent `snapshot-worker` activity and look for a running process holding the lock.
 
 2. Inspect the lock file:
 


### PR DESCRIPTION
Addresses Codex feedback on #25101: AGENTS.md mandates 'assistant' (not 'daemon') in user-facing text. Updates backup-troubleshooting.md to say 'assistant log' instead of 'daemon log'.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25129" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
