### PR TITLE
fix(contacts): migration 220 treats year-prefixed counters as auto

### DIFF
--- a/assistant/src/__tests__/contact-store-user-file.test.ts
+++ b/assistant/src/__tests__/contact-store-user-file.test.ts
@@ -419,6 +419,38 @@ describe("migrateNormalizeUserFileByPrincipal", () => {
       expect(row.user_file).toBe("alex-2025-04-13.md");
   });
 
+  test("treats year-prefixed single-digit counter slug as auto-incremented", () => {
+    // `alex-2025-2.md` is `generateUserFileSlug` output when the base
+    // `alex-2025.md` was already taken — it is a collision counter, NOT a
+    // date. Counters are emitted without leading zeros (`-2`, `-3`, ...)
+    // while ISO date components are always 2 digits (`-02`, `-04`), so
+    // single-digit trailing segments mark the tail as a counter.
+    const now = Date.now();
+    insertContact({
+      id: "c1",
+      displayName: "Alex 2025",
+      role: "guardian",
+      principalId: "principal-yc",
+      userFile: "alex-2025-2.md",
+      createdAt: now - 2000,
+    });
+    insertContact({
+      id: "c2",
+      displayName: "Alex 2025",
+      role: "guardian",
+      principalId: "principal-yc",
+      userFile: "alex-2025.md",
+      createdAt: now,
+    });
+
+    migrateNormalizeUserFileByPrincipal(getDb());
+
+    const rows = fetchUserFilesByPrincipal("principal-yc");
+    // Despite being older, `alex-2025-2.md` is auto-incremented, so
+    // `alex-2025.md` (the clean base) wins as canonical.
+    for (const row of rows) expect(row.user_file).toBe("alex-2025.md");
+  });
+
   test("is idempotent", () => {
     const now = Date.now();
     insertContact({

--- a/assistant/src/memory/migrations/220-normalize-user-file-by-principal.ts
+++ b/assistant/src/memory/migrations/220-normalize-user-file-by-principal.ts
@@ -26,8 +26,13 @@ export function downNormalizeUserFileByPrincipal(_database: DrizzleDb): void {
  * where YYYY is a 4-digit year starting with 19, 20, or 21. A counter that
  * happens to fall in that range (e.g. `-1999.md`) is indistinguishable from
  * a year by filename alone, so we conservatively treat it as non-auto.
+ *
+ * Month/day segments must be 2 digits (ISO style) to discriminate them from
+ * single-digit collision counters: `generateUserFileSlug` emits `-2.md`,
+ * `-3.md`, etc. without leading zeros, so `alex-2025-2.md` is a counter on
+ * base `alex-2025.md` — not a date — and must remain classified as auto.
  */
-const DATE_LIKE_SUFFIX = /-(19|20|21)\d{2}(-\d{1,2}){0,2}\.md$/;
+const DATE_LIKE_SUFFIX = /-(19|20|21)\d{2}((-\d{2}){1,2})?\.md$/;
 const INTEGER_SUFFIX = /-\d+\.md$/;
 
 export function isAutoIncrementedUserFile(userFile: string): boolean {


### PR DESCRIPTION
Addresses Codex feedback on #25097: DATE_LIKE_SUFFIX was matching year + single-digit segments (e.g. `alex-2025-2.md`) which are valid collision-counter outputs of generateUserFileSlug when the base slug has a year. Tightens the regex to require 2-digit month/day segments (matching ISO date formatting) so single-digit counters are not misclassified as dates.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25130" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
