### PR TITLE
fix(backup,gateway): use userInfo().homedir for empty-HOME fallback

### DIFF
--- a/assistant/src/backup/paths.ts
+++ b/assistant/src/backup/paths.ts
@@ -1,4 +1,4 @@
-import { homedir } from "node:os";
+import { homedir, userInfo } from "node:os";
 import { dirname, isAbsolute, join } from "node:path";
 
 import {
@@ -43,17 +43,20 @@ export function getLocalBackupsDir(override?: string | null): string {
  * Drive is enabled and we can safely `mkdir -p` the `VellumAssistant/backups`
  * subtree below it.
  *
- * Reads `process.env.HOME` at call time before falling back to `homedir()`.
- * `homedir()` is snapshot at process start on some platforms, so consulting
- * `$HOME` on each call keeps this function honest under tests that redirect
- * the home directory mid-process. Uses `||` (not `??`) so an empty-string
- * `HOME` — legal in some sandboxed envs — also falls back to `homedir()`
- * rather than producing a relative `Library/...` path. Asserts the result is
+ * Fallback chain: `process.env.HOME` → `userInfo().homedir` → `homedir()`.
+ * Reading `$HOME` at call time keeps the function honest under tests that
+ * redirect the home directory mid-process. Uses `||` (not `??`) so an
+ * empty-string `HOME` — legal in some sandboxed envs — advances to the next
+ * fallback. `homedir()` alone is insufficient because libuv's
+ * `uv_os_homedir` returns `$HOME` as-is when it's set (even to `""`) and
+ * only consults `getpwuid_r` when `HOME` is unset entirely. `userInfo()`
+ * calls `getpwuid_r` directly via `uv_os_get_passwd`, so it returns the
+ * passwd-table home regardless of `HOME`. Asserts the final result is
  * absolute so callers downstream (`deriveSafeAncestor`, the offsite writer)
  * never see a relative path regardless of how the home lookup resolved.
  */
 export function getICloudDriveRoot(): string {
-  const home = process.env.HOME || homedir();
+  const home = process.env.HOME || userInfo().homedir || homedir();
   const root = join(
     home,
     "Library",
@@ -63,7 +66,7 @@ export function getICloudDriveRoot(): string {
   if (!isAbsolute(root)) {
     throw new Error(
       `getICloudDriveRoot resolved to a relative path: ${root}. ` +
-        `HOME and homedir() both returned empty or relative values.`,
+        `HOME, userInfo().homedir, and homedir() all returned empty or relative values.`,
     );
   }
   return root;

--- a/gateway/src/db/connection.ts
+++ b/gateway/src/db/connection.ts
@@ -1,7 +1,7 @@
 import { Database } from "bun:sqlite";
 import { existsSync, mkdirSync, renameSync } from "node:fs";
 import { join } from "node:path";
-import { homedir } from "node:os";
+import { homedir, userInfo } from "node:os";
 import { getGatewaySecurityDir } from "../config.js";
 import { runDataMigrations } from "./data-migrations/index.js";
 
@@ -13,10 +13,19 @@ let db: Database | null = null;
  * credential-reader.ts (getRootDir is being removed). Respects
  * BASE_DATA_DIR for multi-instance local setups where the CLI sets it
  * to the instance directory.
+ *
+ * Home fallback chain: `$HOME` → `userInfo().homedir` → `homedir()`.
+ * `homedir()` alone is insufficient because libuv's `uv_os_homedir` returns
+ * `$HOME` as-is when set (even to `""`) and only consults `getpwuid_r` when
+ * `HOME` is unset entirely. `userInfo()` calls `getpwuid_r` directly, so it
+ * returns the passwd-table home regardless of `HOME`.
  */
 function getLegacyRootDir(): string {
   return join(
-    process.env.BASE_DATA_DIR?.trim() || process.env.HOME || homedir(),
+    process.env.BASE_DATA_DIR?.trim() ||
+      process.env.HOME ||
+      userInfo().homedir ||
+      homedir(),
     ".vellum",
   );
 }


### PR DESCRIPTION
Addresses Codex feedback on #25099: libuv's uv_os_homedir returns `""` as-is when HOME is set to empty string (it doesn't fall back to getpwuid_r unless HOME is unset entirely). So `process.env.HOME || homedir()` is still empty in sandboxed envs with blank HOME, and the isAbsolute assertion throws. Switches to os.userInfo().homedir, which calls getpwuid_r directly and returns the passwd-table entry regardless of HOME. Applies the same fix in both backup/paths.ts and gateway/db/connection.ts.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25132" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
