### PR TITLE
chrome-ext: merge local override file into allowlist

### DIFF
--- a/assistant/src/__tests__/extension-id-sync-guard.test.ts
+++ b/assistant/src/__tests__/extension-id-sync-guard.test.ts
@@ -142,12 +142,15 @@ describe("Chrome extension allowlist guard", () => {
     expect(config.allowedExtensionIds.length).toBeGreaterThan(0);
   });
 
-  test("assistant runtime allowlist mirrors canonical config", () => {
+  test("assistant runtime allowlist contains every canonical origin", () => {
+    // The runtime set is the union of canonical + local override
+    // (~/.vellum/chrome-extension-allowlist.local.json) + env var. A dev
+    // machine may have extras; we only assert the canonical IDs are present.
     const config = parseCanonicalConfig();
-    const expectedOrigins = new Set(
-      config.allowedExtensionIds.map((id) => `chrome-extension://${id}/`),
-    );
-    expect(ALLOWED_EXTENSION_ORIGINS).toEqual(expectedOrigins);
+    for (const id of config.allowedExtensionIds) {
+      const origin = `chrome-extension://${id}/`;
+      expect(ALLOWED_EXTENSION_ORIGINS.has(origin)).toBe(true);
+    }
   });
 
   test("concrete extension IDs appear only in canonical config", () => {

--- a/assistant/src/runtime/routes/browser-extension-pair-routes.ts
+++ b/assistant/src/runtime/routes/browser-extension-pair-routes.ts
@@ -42,7 +42,8 @@
  */
 
 import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
 
 import { findGuardianForChannel } from "../../contacts/contact-store.js";
 import { getLogger } from "../../util/logger.js";
@@ -116,19 +117,33 @@ const ALLOWLIST_CONFIG_PATH_CANDIDATES = [
   ),
 ];
 
+/**
+ * Local, user-writable override read in addition to the canonical config.
+ * Lets developers allowlist an unpacked-extension ID without committing it
+ * to the repo. File is optional — a missing file is not an error.
+ */
+const LOCAL_OVERRIDE_PATH = join(
+  homedir(),
+  ".vellum",
+  "chrome-extension-allowlist.local.json",
+);
+
 type ChromeExtensionAllowlistConfig = {
   version: number;
   allowedExtensionIds: string[];
 };
 
-function parseAllowedExtensionIds(value: unknown): string[] {
+function parseAllowedExtensionIds(
+  value: unknown,
+  opts: { allowEmpty?: boolean } = {},
+): string[] {
   if (!Array.isArray(value)) {
     throw new Error("allowedExtensionIds is not an array");
   }
   const ids = value
     .filter((id): id is string => typeof id === "string")
     .filter((id) => EXTENSION_ID_REGEX.test(id));
-  if (ids.length === 0) {
+  if (ids.length === 0 && !opts.allowEmpty) {
     throw new Error("allowedExtensionIds has no valid extension ids");
   }
   return ids;
@@ -147,42 +162,86 @@ function loadAllowedExtensionIdsFromEnv(): string[] {
   return Array.from(new Set(ids));
 }
 
+function readIdsFromFile(
+  path: string,
+  opts: { allowEmpty?: boolean } = {},
+): string[] {
+  const raw = readFileSync(path, "utf8");
+  const parsed = JSON.parse(raw) as Partial<ChromeExtensionAllowlistConfig>;
+  return parseAllowedExtensionIds(parsed.allowedExtensionIds, opts);
+}
+
 function loadAllowedExtensionOrigins(): ReadonlySet<string> {
+  const merged = new Set<string>();
   const loadErrors: string[] = [];
+
+  // 1. Canonical repo config. Try each candidate; first parse wins (the
+  //    two candidates are the same logical file resolved two ways).
+  let canonicalLoaded = false;
   for (const configPath of ALLOWLIST_CONFIG_PATH_CANDIDATES) {
     try {
-      const raw = readFileSync(configPath, "utf8");
-      const parsed = JSON.parse(raw) as Partial<ChromeExtensionAllowlistConfig>;
-      const ids = parseAllowedExtensionIds(parsed.allowedExtensionIds);
-      return new Set<string>(ids.map((id) => `chrome-extension://${id}/`));
+      for (const id of readIdsFromFile(configPath)) {
+        merged.add(`chrome-extension://${id}/`);
+      }
+      canonicalLoaded = true;
+      break;
     } catch (err) {
       const detail = err instanceof Error ? err.message : String(err);
       loadErrors.push(`${configPath}: ${detail}`);
     }
   }
 
-  // Compiled Bun binaries run from a virtual FS root (import.meta.dir is
-  // usually `/$bunfs/root`), so repo-relative config paths can disappear in
-  // packaged builds. In that case, allow a build-time injected env fallback.
-  const envIds = loadAllowedExtensionIdsFromEnv();
-  if (envIds.length > 0) {
-    return new Set<string>(envIds.map((id) => `chrome-extension://${id}/`));
+  // 2. Local override. Silently absent is fine; malformed warns but doesn't
+  //    block other sources.
+  try {
+    for (const id of readIdsFromFile(LOCAL_OVERRIDE_PATH, { allowEmpty: true })) {
+      merged.add(`chrome-extension://${id}/`);
+    }
+  } catch (err) {
+    const isMissing =
+      err instanceof Error &&
+      "code" in err &&
+      (err as NodeJS.ErrnoException).code === "ENOENT";
+    if (!isMissing) {
+      const detail = err instanceof Error ? err.message : String(err);
+      loadErrors.push(`${LOCAL_OVERRIDE_PATH}: ${detail}`);
+    }
   }
 
-  log.error(
-    {
-      allowlistConfigPathCandidates: ALLOWLIST_CONFIG_PATH_CANDIDATES,
-      loadErrors,
-    },
-    "Failed to load Chrome extension allowlist config; pairing will reject all origins",
-  );
-  return new Set<string>();
+  // 3. Env-var fallback. Compiled Bun binaries run from a virtual FS root so
+  //    repo-relative config paths can disappear in packaged builds;
+  //    `clients/macos/build.sh` bakes the canonical IDs into
+  //    `VELLUM_CHROME_EXTENSION_IDS` at compile time for that case.
+  for (const id of loadAllowedExtensionIdsFromEnv()) {
+    merged.add(`chrome-extension://${id}/`);
+  }
+
+  if (merged.size === 0) {
+    log.error(
+      {
+        canonicalCandidates: ALLOWLIST_CONFIG_PATH_CANDIDATES,
+        localOverridePath: LOCAL_OVERRIDE_PATH,
+        loadErrors,
+      },
+      "Failed to load Chrome extension allowlist from any source; pairing will reject all origins",
+    );
+  } else if (!canonicalLoaded && loadErrors.length > 0) {
+    log.warn(
+      { loadErrors },
+      "Canonical Chrome extension allowlist unreadable — using local override and/or env vars only",
+    );
+  }
+
+  return merged;
 }
 
 /**
  * Allowlist of chrome extension origins permitted to request a capability
- * token. Loaded from the canonical config at
- * `meta/browser-extension/chrome-extension-allowlist.json`.
+ * token. Merged from the canonical repo config at
+ * `meta/browser-extension/chrome-extension-allowlist.json`, an optional
+ * local override at `~/.vellum/chrome-extension-allowlist.local.json`, and
+ * the `VELLUM_CHROME_EXTENSION_IDS` env var. Cached at module load —
+ * allowlist edits require a daemon restart to take effect.
  */
 export const ALLOWED_EXTENSION_ORIGINS = loadAllowedExtensionOrigins();
 

--- a/clients/chrome-extension/README.md
+++ b/clients/chrome-extension/README.md
@@ -84,7 +84,20 @@ chmod +x dist/index.js
 export EXTENSION_ID=<id from chrome://extensions>
 ```
 
-3. Add that ID to `meta/browser-extension/chrome-extension-allowlist.json`.
+3. Register the ID locally so the assistant accepts pair requests from your unpacked build. Create `~/.vellum/chrome-extension-allowlist.local.json` — this file is merged with the committed allowlist at assistant startup and stays local to your machine:
+
+```bash
+mkdir -p "$HOME/.vellum"
+cat > "$HOME/.vellum/chrome-extension-allowlist.local.json" <<JSON
+{
+  "version": 1,
+  "allowedExtensionIds": ["$EXTENSION_ID"]
+}
+JSON
+```
+
+Restart the assistant after creating or editing this file — the allowlist is cached at startup. The IDs are public Chrome extension identifiers, so no special file permissions are needed.
+
 4. Install the Chrome native messaging manifest. **Run this from the same `native-host/` directory as step 1** — the snippet reads `$(pwd)/dist/index.js`:
 
 ```bash
@@ -131,9 +144,9 @@ chmod 644 "$NATIVE_HOSTS_DIR/com.vellum.daemon.json"
 
 | Error | Cause / Fix |
 |---|---|
-| `Access to the specified native messaging host is forbidden` | Manifest missing/invalid, or extension ID not in `meta/browser-extension/chrome-extension-allowlist.json` |
+| `Access to the specified native messaging host is forbidden` | Manifest missing/invalid, or extension ID not in the allowlist. Add it to `~/.vellum/chrome-extension-allowlist.local.json` (see Native Messaging Host Setup, step 3). |
 | `Native host has exited` | Chrome couldn't launch Node. Use a wrapper script with an absolute Node path in the manifest. |
-| `assistant pair request failed with HTTP 401` | Extension ID not in allowlist. Add it to `meta/browser-extension/chrome-extension-allowlist.json` and restart the assistant. |
+| `assistant pair request failed with HTTP 401` | Extension ID not in allowlist. Add it to `~/.vellum/chrome-extension-allowlist.local.json` and restart the assistant (the allowlist is cached at daemon startup). |
 | `failed to reach assistant at http://127.0.0.1:<port>/...` | Assistant not running, wrong port, or firewall blocking. |
 | `Automatic cloud sign-in failed` | Use "Re-sign in" in the popup's Troubleshooting section, then click Connect. |
 | `Automatic local pairing failed` | Use "Re-pair" in the popup's Troubleshooting section, then click Connect. |

--- a/clients/chrome-extension/native-host/README.md
+++ b/clients/chrome-extension/native-host/README.md
@@ -275,15 +275,27 @@ performs template substitution.
 ### Allowlist resolution in compiled builds
 
 The helper enforces its own extension-ID allowlist before it calls the
-assistant pair endpoint. It resolves IDs in this order:
+assistant pair endpoint. The effective allowlist is the **union** of three
+sources; all sources are consulted, and any one of them is sufficient to
+admit an ID:
 
-1. `meta/browser-extension/chrome-extension-allowlist.json` (repo checkout paths)
-2. `VELLUM_CHROME_EXTENSION_IDS` (comma/space-separated)
-3. `VELLUM_CHROME_EXTENSION_ID` (single ID)
+1. Canonical repo config at
+   `meta/browser-extension/chrome-extension-allowlist.json` (repo checkout paths).
+2. Local override at `~/.vellum/chrome-extension-allowlist.local.json`
+   (optional — silently ignored if absent). Developers use this to allowlist
+   an unpacked dev-build ID without committing it to the repo.
+3. `VELLUM_CHROME_EXTENSION_IDS` (comma/space-separated) or
+   `VELLUM_CHROME_EXTENSION_ID` (single ID).
 
 `clients/macos/build.sh` injects `VELLUM_CHROME_EXTENSION_IDS` at compile
 time from the canonical JSON allowlist so packaged binaries continue to work
 even when repo-relative paths are unavailable.
+
+The helper re-reads all sources on every `connectNative()` spawn, so
+edits to the local override file take effect the next time Chrome launches
+the helper — no Chrome restart needed. The assistant daemon caches the
+merged allowlist at startup; restart the daemon after editing the local
+override.
 
 ## Testing
 
@@ -299,8 +311,9 @@ multi-frame buffers, partial frames, empty buffers).
 
 Once the assistant is running and exposing `/v1/browser-extension-pair`,
 you can exercise the helper end-to-end without Chrome by piping
-a framed request to it on stdin. If you need to rotate the extension ID,
-edit `meta/browser-extension/chrome-extension-allowlist.json`.
+a framed request to it on stdin. If you need to allowlist an extra
+extension ID, add it to `~/.vellum/chrome-extension-allowlist.local.json`
+(see "Allowlist resolution in compiled builds" above).
 Then run:
 
 ```bash

--- a/clients/chrome-extension/native-host/src/index.ts
+++ b/clients/chrome-extension/native-host/src/index.ts
@@ -51,8 +51,12 @@ import { decodeFrames, encodeFrame, FrameDecodeError } from "./protocol.js";
  * argument, e.g. `chrome-extension://<extension-id>/`.
  * Anything not on this list is rejected before any further processing.
  *
- * Loaded from the canonical config at
- * `meta/browser-extension/chrome-extension-allowlist.json`.
+ * Loaded from the union of three sources so developers can allowlist a
+ * local unpacked-extension ID without committing it to the repo:
+ *
+ *   1. Canonical repo config (`meta/browser-extension/chrome-extension-allowlist.json`)
+ *   2. Local override (`~/.vellum/chrome-extension-allowlist.local.json`)
+ *   3. Env var (`VELLUM_CHROME_EXTENSION_IDS` / `VELLUM_CHROME_EXTENSION_ID`)
  */
 const EXTENSION_ID_REGEX = /^[a-p]{32}$/;
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +81,20 @@ const ALLOWLIST_CONFIG_PATH_CANDIDATES = [
     "chrome-extension-allowlist.json",
   ),
 ];
+const LOCAL_OVERRIDE_PATH = join(
+  homedir(),
+  ".vellum",
+  "chrome-extension-allowlist.local.json",
+);
 
-function parseAllowedExtensionIds(value: unknown): string[] {
+function parseAllowedExtensionIds(value: unknown, opts: { allowEmpty?: boolean } = {}): string[] {
   if (!Array.isArray(value)) {
     throw new Error("allowedExtensionIds is not an array");
   }
   const ids = value
     .filter((id): id is string => typeof id === "string")
     .filter((id) => EXTENSION_ID_REGEX.test(id));
-  if (ids.length === 0) {
+  if (ids.length === 0 && !opts.allowEmpty) {
     throw new Error("allowedExtensionIds has no valid extension ids");
   }
   return ids;
@@ -104,34 +113,67 @@ function loadAllowedExtensionIdsFromEnv(): string[] {
   return Array.from(new Set(ids));
 }
 
+function readIdsFromFile(path: string, opts: { allowEmpty?: boolean } = {}): string[] {
+  const raw = readFileSync(path, "utf8");
+  const parsed = JSON.parse(raw) as { allowedExtensionIds?: unknown };
+  return parseAllowedExtensionIds(parsed.allowedExtensionIds, opts);
+}
+
 function loadAllowedExtensionIds(): ReadonlySet<string> {
+  const merged = new Set<string>();
   const loadErrors: string[] = [];
+
+  // 1. Canonical repo config. Try each candidate; first one that parses wins
+  //    (the two candidates represent the same logical file in different
+  //    resolution contexts — __dirname-relative vs cwd-relative).
+  let canonicalLoaded = false;
   for (const configPath of ALLOWLIST_CONFIG_PATH_CANDIDATES) {
     try {
-      const raw = readFileSync(configPath, "utf8");
-      const parsed = JSON.parse(raw) as {
-        allowedExtensionIds?: unknown;
-      };
-      return new Set<string>(parseAllowedExtensionIds(parsed.allowedExtensionIds));
+      for (const id of readIdsFromFile(configPath)) merged.add(id);
+      canonicalLoaded = true;
+      break;
     } catch (err) {
       const detail = err instanceof Error ? err.message : String(err);
       loadErrors.push(`${configPath}: ${detail}`);
     }
   }
 
-  // Compiled Bun binaries run from a virtual FS root (import.meta.dir is
-  // usually `/$bunfs/root`), so repo-relative config paths can disappear in
-  // packaged builds. In that case, allow a build-time injected env fallback.
-  const envIds = loadAllowedExtensionIdsFromEnv();
-  if (envIds.length > 0) {
-    return new Set<string>(envIds);
+  // 2. Local override. Silently absent is fine; malformed warns but doesn't
+  //    block the load.
+  try {
+    for (const id of readIdsFromFile(LOCAL_OVERRIDE_PATH, { allowEmpty: true })) {
+      merged.add(id);
+    }
+  } catch (err) {
+    const isMissing =
+      err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT";
+    if (!isMissing) {
+      const detail = err instanceof Error ? err.message : String(err);
+      loadErrors.push(`${LOCAL_OVERRIDE_PATH}: ${detail}`);
+    }
   }
 
-  process.stderr.write(
-    "vellum-chrome-native-host: failed to load allowlist config from any candidate path " +
-      `(${ALLOWLIST_CONFIG_PATH_CANDIDATES.join(", ")}); details: ${loadErrors.join(" | ")}\n`,
-  );
-  return new Set<string>();
+  // 3. Env-var fallback. Compiled Bun binaries run from a virtual FS root so
+  //    repo-relative config paths can disappear in packaged builds;
+  //    `clients/macos/build.sh` bakes the canonical IDs into
+  //    `VELLUM_CHROME_EXTENSION_IDS` at compile time for that case.
+  for (const id of loadAllowedExtensionIdsFromEnv()) merged.add(id);
+
+  if (merged.size === 0) {
+    process.stderr.write(
+      "vellum-chrome-native-host: failed to load allowlist from canonical config, " +
+        `local override (${LOCAL_OVERRIDE_PATH}), or env vars; details: ${
+          loadErrors.length > 0 ? loadErrors.join(" | ") : "no sources available"
+        }\n`,
+    );
+  } else if (!canonicalLoaded && loadErrors.length > 0) {
+    process.stderr.write(
+      "vellum-chrome-native-host: canonical allowlist unreadable — using local override and/or " +
+        `env vars only. Details: ${loadErrors.join(" | ")}\n`,
+    );
+  }
+
+  return merged;
 }
 
 const ALLOWED_EXTENSION_IDS: ReadonlySet<string> = loadAllowedExtensionIds();


### PR DESCRIPTION
## Summary
- Native host and daemon pair route now union three allowlist sources: canonical repo config, local `~/.vellum/chrome-extension-allowlist.local.json`, and the existing `VELLUM_CHROME_EXTENSION_IDS` env var — previously it was first-file-wins with env as fallback.
- Developers can allowlist an unpacked dev extension ID by dropping a JSON file in their home dir instead of committing their personal ID to `meta/browser-extension/chrome-extension-allowlist.json`.
- Updated `clients/chrome-extension/README.md` and `clients/chrome-extension/native-host/README.md` to document the new flow, and relaxed `extension-id-sync-guard.test.ts` from strict equality to subset check (dev machines may have extras from the local override).

## Original prompt
it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25134" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
