### PR TITLE
test(browser): stub preferred-backend-kind methods in mocks

### DIFF
--- a/assistant/src/__tests__/headless-browser-interactions.test.ts
+++ b/assistant/src/__tests__/headless-browser-interactions.test.ts
@@ -71,8 +71,11 @@ let mockPage: {
 
 let snapshotBackendNodeMaps: Map<string, Map<string, number>>;
 
+const preferredBackendKinds = new Map<string, string>();
+
 mock.module("../tools/browser/browser-manager.js", () => {
   snapshotBackendNodeMaps = new Map();
+  preferredBackendKinds.clear();
   return {
     browserManager: {
       getOrCreateSessionPage: async () => mockPage,
@@ -94,6 +97,14 @@ mock.module("../tools/browser/browser-manager.js", () => {
       },
       clearSnapshotBackendNodeMap: (conversationId: string) => {
         snapshotBackendNodeMaps.delete(conversationId);
+      },
+      getPreferredBackendKind: (conversationId: string) =>
+        preferredBackendKinds.get(conversationId) ?? null,
+      setPreferredBackendKind: (conversationId: string, kind: string) => {
+        preferredBackendKinds.set(conversationId, kind);
+      },
+      clearPreferredBackendKind: (conversationId: string) => {
+        preferredBackendKinds.delete(conversationId);
       },
     },
   };

--- a/assistant/src/__tests__/headless-browser-navigate.test.ts
+++ b/assistant/src/__tests__/headless-browser-navigate.test.ts
@@ -77,10 +77,13 @@ let getOrCreateSessionPageMock: ReturnType<typeof mock>;
 let clearSnapshotBackendNodeMapMock: ReturnType<typeof mock>;
 let positionWindowSidebarMock: ReturnType<typeof mock>;
 
+const preferredBackendKinds = new Map<string, string>();
+
 mock.module("../tools/browser/browser-manager.js", () => {
   getOrCreateSessionPageMock = mock(async () => mockPage);
   clearSnapshotBackendNodeMapMock = mock(() => {});
   positionWindowSidebarMock = mock(async () => {});
+  preferredBackendKinds.clear();
   return {
     browserManager: {
       getOrCreateSessionPage: getOrCreateSessionPageMock,
@@ -88,6 +91,14 @@ mock.module("../tools/browser/browser-manager.js", () => {
       supportsRouteInterception: true,
       isInteractive: () => false,
       positionWindowSidebar: positionWindowSidebarMock,
+      getPreferredBackendKind: (conversationId: string) =>
+        preferredBackendKinds.get(conversationId) ?? null,
+      setPreferredBackendKind: (conversationId: string, kind: string) => {
+        preferredBackendKinds.set(conversationId, kind);
+      },
+      clearPreferredBackendKind: (conversationId: string) => {
+        preferredBackendKinds.delete(conversationId);
+      },
     },
   };
 });

--- a/assistant/src/__tests__/headless-browser-read-tools.test.ts
+++ b/assistant/src/__tests__/headless-browser-read-tools.test.ts
@@ -76,12 +76,23 @@ let mockPage: {
   };
 };
 
+const preferredBackendKinds = new Map<string, string>();
+
 mock.module("../tools/browser/browser-manager.js", () => {
+  preferredBackendKinds.clear();
   return {
     browserManager: {
       getOrCreateSessionPage: async () => mockPage,
       closeSessionPage: async () => {},
       closeAllPages: async () => {},
+      getPreferredBackendKind: (conversationId: string) =>
+        preferredBackendKinds.get(conversationId) ?? null,
+      setPreferredBackendKind: (conversationId: string, kind: string) => {
+        preferredBackendKinds.set(conversationId, kind);
+      },
+      clearPreferredBackendKind: (conversationId: string) => {
+        preferredBackendKinds.delete(conversationId);
+      },
     },
   };
 });

--- a/assistant/src/__tests__/headless-browser-snapshot.test.ts
+++ b/assistant/src/__tests__/headless-browser-snapshot.test.ts
@@ -35,9 +35,11 @@ let closeAllPagesMock: ReturnType<typeof mock>;
 let clearSnapshotBackendNodeMapMock: ReturnType<typeof mock>;
 let storeSnapshotBackendNodeMapMock: ReturnType<typeof mock>;
 let storedBackendNodeMaps: Map<string, Map<string, number>>;
+const preferredBackendKinds = new Map<string, string>();
 
 mock.module("../tools/browser/browser-manager.js", () => {
   storedBackendNodeMaps = new Map();
+  preferredBackendKinds.clear();
   closeSessionPageMock = mock(async () => {});
   closeAllPagesMock = mock(async () => {});
   clearSnapshotBackendNodeMapMock = mock((conversationId: string) => {
@@ -79,6 +81,14 @@ mock.module("../tools/browser/browser-manager.js", () => {
         const map = storedBackendNodeMaps.get(conversationId);
         if (!map) return null;
         return map.get(elementId) ?? null;
+      },
+      getPreferredBackendKind: (conversationId: string) =>
+        preferredBackendKinds.get(conversationId) ?? null,
+      setPreferredBackendKind: (conversationId: string, kind: string) => {
+        preferredBackendKinds.set(conversationId, kind);
+      },
+      clearPreferredBackendKind: (conversationId: string) => {
+        preferredBackendKinds.delete(conversationId);
       },
     },
   };


### PR DESCRIPTION
## Summary
- Add `getPreferredBackendKind`/`setPreferredBackendKind`/`clearPreferredBackendKind` stubs to the `browserManager` mock in `headless-browser-interactions`, `headless-browser-navigate`, `headless-browser-read-tools`, and `headless-browser-snapshot` tests.
- Fixes CI failures introduced when #25122 added the sticky-backend memo to `acquireCdpClientWithMode` without updating these mocks.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24322780736/job/71011997582