### PR TITLE
test(browser): stub preferred-backend-kind methods in browser-fill-credential mock

### DIFF
--- a/assistant/src/__tests__/browser-fill-credential.test.ts
+++ b/assistant/src/__tests__/browser-fill-credential.test.ts
@@ -61,8 +61,11 @@ let mockPage: {
 
 let snapshotBackendNodeMaps: Map<string, Map<string, number>>;
 
+const preferredBackendKinds = new Map<string, string>();
+
 mock.module("../tools/browser/browser-manager.js", () => {
   snapshotBackendNodeMaps = new Map();
+  preferredBackendKinds.clear();
   return {
     browserManager: {
       getOrCreateSessionPage: async () => mockPage,
@@ -84,6 +87,14 @@ mock.module("../tools/browser/browser-manager.js", () => {
       },
       clearSnapshotBackendNodeMap: (conversationId: string) => {
         snapshotBackendNodeMaps.delete(conversationId);
+      },
+      getPreferredBackendKind: (conversationId: string) =>
+        preferredBackendKinds.get(conversationId) ?? null,
+      setPreferredBackendKind: (conversationId: string, kind: string) => {
+        preferredBackendKinds.set(conversationId, kind);
+      },
+      clearPreferredBackendKind: (conversationId: string) => {
+        preferredBackendKinds.delete(conversationId);
       },
     },
   };


### PR DESCRIPTION
## Summary
- Add the missing \`getPreferredBackendKind\` / \`setPreferredBackendKind\` / \`clearPreferredBackendKind\` stubs to the \`browser-manager\` \`mock.module\` block in \`browser-fill-credential.test.ts\`.
- #25135 added these stubs to 4 of the 5 browser test files but missed this one, so it's still the lone red file on main (13 failing cases).

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24323054830/job/71012772354