### PR TITLE
fix(backup,gateway): guard userInfo() in empty-HOME fallback

### DIFF
--- a/assistant/src/backup/paths.ts
+++ b/assistant/src/backup/paths.ts
@@ -37,6 +37,14 @@ export function getLocalBackupsDir(override?: string | null): string {
   return override ?? join(getBackupRootDir(), "local");
 }
 
+function safeUserInfoHomedir(): string {
+  try {
+    return userInfo().homedir;
+  } catch {
+    return "";
+  }
+}
+
 /**
  * Returns the iCloud Drive root on macOS. This is the "safe ancestor" we use
  * for bootstrapping the default offsite path: if this directory exists iCloud
@@ -51,12 +59,16 @@ export function getLocalBackupsDir(override?: string | null): string {
  * `uv_os_homedir` returns `$HOME` as-is when it's set (even to `""`) and
  * only consults `getpwuid_r` when `HOME` is unset entirely. `userInfo()`
  * calls `getpwuid_r` directly via `uv_os_get_passwd`, so it returns the
- * passwd-table home regardless of `HOME`. Asserts the final result is
- * absolute so callers downstream (`deriveSafeAncestor`, the offsite writer)
- * never see a relative path regardless of how the home lookup resolved.
+ * passwd-table home regardless of `HOME`. The `userInfo()` call is guarded
+ * via `safeUserInfoHomedir()` because it throws `SystemError` when the
+ * current UID has no passwd entry (rare on macOS but possible in
+ * sandboxed/containerized envs); catching keeps the `homedir()` fallback
+ * reachable. Asserts the final result is absolute so callers downstream
+ * (`deriveSafeAncestor`, the offsite writer) never see a relative path
+ * regardless of how the home lookup resolved.
  */
 export function getICloudDriveRoot(): string {
-  const home = process.env.HOME || userInfo().homedir || homedir();
+  const home = process.env.HOME || safeUserInfoHomedir() || homedir();
   const root = join(
     home,
     "Library",

--- a/gateway/src/db/connection.ts
+++ b/gateway/src/db/connection.ts
@@ -7,6 +7,14 @@ import { runDataMigrations } from "./data-migrations/index.js";
 
 let db: Database | null = null;
 
+function safeUserInfoHomedir(): string {
+  try {
+    return userInfo().homedir;
+  } catch {
+    return "";
+  }
+}
+
 /**
  * @deprecated Only used for one-time migration from the legacy DB path.
  * Replicates the old getRootDir() logic inline so we don't depend on
@@ -18,13 +26,17 @@ let db: Database | null = null;
  * `homedir()` alone is insufficient because libuv's `uv_os_homedir` returns
  * `$HOME` as-is when set (even to `""`) and only consults `getpwuid_r` when
  * `HOME` is unset entirely. `userInfo()` calls `getpwuid_r` directly, so it
- * returns the passwd-table home regardless of `HOME`.
+ * returns the passwd-table home regardless of `HOME`. The `userInfo()` call
+ * is guarded via `safeUserInfoHomedir()` because it throws `SystemError`
+ * when the current UID has no passwd entry (common in containers run with
+ * `--user <uid>` without a matching `/etc/passwd` line); catching keeps the
+ * `homedir()` fallback reachable.
  */
 function getLegacyRootDir(): string {
   return join(
     process.env.BASE_DATA_DIR?.trim() ||
       process.env.HOME ||
-      userInfo().homedir ||
+      safeUserInfoHomedir() ||
       homedir(),
     ".vellum",
   );


### PR DESCRIPTION
## Summary
- Wrap `userInfo().homedir` in a `safeUserInfoHomedir()` helper in `gateway/src/db/connection.ts` and `assistant/src/backup/paths.ts` so a `SystemError` thrown by `os.userInfo()` no longer breaks the `|| homedir()` fallback chain.
- `os.userInfo()` throws when the current UID has no passwd entry (containers run with `--user <uid>` without matching `/etc/passwd`). Before this fix, that throw propagated from `getLegacyRootDir()` → `migrateLegacyDb()` → `getGatewayDb()`, crashing the gateway at startup, and from `getICloudDriveRoot()` before its `isAbsolute` validation.
- Matches the existing guarded pattern in `gateway/src/credential-reader.ts` and `assistant/src/security/encrypted-store.ts`.
- Block comments updated to mention the guard; libuv `uv_os_homedir` rationale preserved.

Addresses Codex P1 + Devin 🔴 Bug on #25132.

## Test plan
- [ ] Type-check passes (`bunx tsc --noEmit`)
- [ ] Existing backup / gateway DB tests still pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25137" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
