### PR TITLE
fix(contacts): disambiguate year-prefixed counter slugs via display name

### DIFF
--- a/assistant/src/__tests__/contact-store-user-file.test.ts
+++ b/assistant/src/__tests__/contact-store-user-file.test.ts
@@ -451,6 +451,39 @@ describe("migrateNormalizeUserFileByPrincipal", () => {
     for (const row of rows) expect(row.user_file).toBe("alex-2025.md");
   });
 
+  test("treats year-prefixed single-digit tail as base slug when display name generates it", () => {
+    // Ambiguous filename: `alex-2025-4.md` could be either a collision counter
+    // on base `alex-2025.md` OR the direct base slug from display name
+    // "Alex 2025 4". The classifier must cross-reference the row's display
+    // name — if `generateUserFileSlug`'s pure slug transform maps the name to
+    // the filename, treat it as a base slug, not an auto-incremented counter.
+    const now = Date.now();
+    insertContact({
+      id: "c1",
+      displayName: "Alex 2025 4",
+      role: "guardian",
+      principalId: "principal-yb",
+      userFile: "alex-2025-4.md",
+      createdAt: now,
+    });
+    insertContact({
+      id: "c2",
+      displayName: "Alex",
+      role: "guardian",
+      principalId: "principal-yb",
+      userFile: "alex-2.md",
+      createdAt: now - 1000,
+    });
+
+    migrateNormalizeUserFileByPrincipal(getDb());
+
+    const rows = fetchUserFilesByPrincipal("principal-yb");
+    // `alex-2025-4.md` is a legitimate base slug (disambiguated by display
+    // name), while `alex-2.md` is auto-incremented. The base slug must win
+    // as canonical, otherwise canonical would point at a collision counter.
+    for (const row of rows) expect(row.user_file).toBe("alex-2025-4.md");
+  });
+
   test("is idempotent", () => {
     const now = Date.now();
     insertContact({

--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -29,16 +29,27 @@ function escapeLike(value: string): string {
 }
 
 /**
- * Generate a collision-free slugified filename for a contact's per-user persona file.
- * Produces filenames like "alice.md", "alice-2.md", "alice-3.md", etc.
+ * Pure slug transform applied to a display name. No DB lookup, no collision
+ * handling — callers that need a collision-free filename should use
+ * `generateUserFileSlug` instead. Exported so the migration classifier can
+ * recompute the expected base slug for a given display name.
  */
-export function generateUserFileSlug(displayName: string): string {
-  const slug =
+export function computeUserFileBaseSlug(displayName: string): string {
+  return (
     displayName
       .toLowerCase()
       .replace(/[^a-z0-9]+/g, "-")
       .replace(/^-+|-+$/g, "")
-      .slice(0, 100) || "user";
+      .slice(0, 100) || "user"
+  );
+}
+
+/**
+ * Generate a collision-free slugified filename for a contact's per-user persona file.
+ * Produces filenames like "alice.md", "alice-2.md", "alice-3.md", etc.
+ */
+export function generateUserFileSlug(displayName: string): string {
+  const slug = computeUserFileBaseSlug(displayName);
 
   const db = getDb();
   const rows = db

--- a/assistant/src/memory/migrations/220-normalize-user-file-by-principal.ts
+++ b/assistant/src/memory/migrations/220-normalize-user-file-by-principal.ts
@@ -1,3 +1,4 @@
+import { computeUserFileBaseSlug } from "../../contacts/contact-store.js";
 import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
 import { withCrashRecovery } from "./validate-migration-state.js";
 
@@ -31,13 +32,28 @@ export function downNormalizeUserFileByPrincipal(_database: DrizzleDb): void {
  * single-digit collision counters: `generateUserFileSlug` emits `-2.md`,
  * `-3.md`, etc. without leading zeros, so `alex-2025-2.md` is a counter on
  * base `alex-2025.md` — not a date — and must remain classified as auto.
+ *
+ * Filename-only classification is still ambiguous at the margins: a display
+ * name like "Alex 2025 4" legitimately produces `alex-2025-4.md` as a base
+ * slug, which looks identical to a year-prefixed counter. When the caller can
+ * supply the row's display name, we disambiguate by recomputing the expected
+ * base slug: if it matches the filename, the name is a base slug and we
+ * classify as non-auto. This closes the only remaining false-positive hole.
  */
 const DATE_LIKE_SUFFIX = /-(19|20|21)\d{2}((-\d{2}){1,2})?\.md$/;
 const INTEGER_SUFFIX = /-\d+\.md$/;
 
-export function isAutoIncrementedUserFile(userFile: string): boolean {
+export function isAutoIncrementedUserFile(
+  userFile: string,
+  displayName?: string,
+): boolean {
   if (DATE_LIKE_SUFFIX.test(userFile)) return false;
-  return INTEGER_SUFFIX.test(userFile);
+  if (!INTEGER_SUFFIX.test(userFile)) return false;
+  if (displayName !== undefined) {
+    const expectedBase = `${computeUserFileBaseSlug(displayName)}.md`;
+    if (expectedBase === userFile) return false;
+  }
+  return true;
 }
 
 /**
@@ -115,7 +131,7 @@ export function migrateNormalizeUserFileByPrincipal(
         // logic in one place avoids SQL/JS drift.
         const selectCandidates = raw.prepare(
           /*sql*/ `
-          SELECT user_file, created_at, id FROM contacts
+          SELECT user_file, display_name, created_at, id FROM contacts
           WHERE principal_id = ? AND user_file IS NOT NULL
           `,
         );
@@ -132,14 +148,19 @@ export function migrateNormalizeUserFileByPrincipal(
         for (const { principal_id } of principals) {
           const candidates = selectCandidates.all(principal_id) as Array<{
             user_file: string;
+            display_name: string;
             created_at: number;
             id: string;
           }>;
           if (candidates.length === 0) continue;
 
           candidates.sort((a, b) => {
-            const aAuto = isAutoIncrementedUserFile(a.user_file) ? 1 : 0;
-            const bAuto = isAutoIncrementedUserFile(b.user_file) ? 1 : 0;
+            const aAuto = isAutoIncrementedUserFile(a.user_file, a.display_name)
+              ? 1
+              : 0;
+            const bAuto = isAutoIncrementedUserFile(b.user_file, b.display_name)
+              ? 1
+              : 0;
             if (aAuto !== bAuto) return aAuto - bAuto;
             if (a.created_at !== b.created_at)
               return a.created_at - b.created_at;


### PR DESCRIPTION
## Summary
Follow-up to #25130 addressing Codex P2 feedback.

Tightening DATE_LIKE_SUFFIX to require 2-digit month/day segments correctly classified collision counters like `alex-2025-2.md`, but created a symmetric false positive: legitimate base slugs from display names like "Alex 2025 4" (→ `alex-2025-4.md`) also match that shape. In the migration, an older counter sibling (`alex-2.md`) would then win canonical selection — reintroducing the very failure this migration exists to prevent.

## Fix
- Extract `computeUserFileBaseSlug()` from `generateUserFileSlug()` as a pure, DB-free transform.
- `isAutoIncrementedUserFile(userFile, displayName?)` now accepts the row's display name. If the expected base slug for that name equals the filename, classify as non-auto regardless of regex shape.
- Migration query selects `display_name` alongside `user_file` and passes it through.

## Test plan
- [x] New test: display name "Alex 2025 4" produces `alex-2025-4.md` as base slug; sibling has `alex-2.md` counter → `alex-2025-4.md` wins canonical.
- [x] All existing classification tests still pass (17 total).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25139" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
