### PR TITLE
fix(macos): use resultRevision counter for tool-output cache key

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -665,7 +665,7 @@ private struct StepDetailRow: View {
         guard let result = toolCall.result, !result.isEmpty else { return nil }
         let key = Self.coloredOutputCacheKey(
             toolCallID: toolCall.id.uuidString,
-            result: result,
+            resultRevision: toolCall.resultRevision,
             isError: toolCall.isError
         )
         if let cached = Self.coloredOutputCache.object(forKey: key) {
@@ -953,17 +953,14 @@ private struct StepDetailRow: View {
 
     private static func coloredOutputCacheKey(
         toolCallID: String,
-        result: String,
+        resultRevision: Int,
         isError: Bool
     ) -> NSString {
-        // O(1) content fingerprint: length + boundary samples. Catches in-place
-        // mutations (replay / correction / rehydration paths all overwrite
-        // toolCalls[...].result) without hashing the full string on every
-        // SwiftUI re-render.
-        let count = result.utf8.count
-        let prefix = result.prefix(16)
-        let suffix = result.suffix(16)
-        return "\(toolCallID)|\(count)|\(isError ? "err" : "ok")|\(prefix)|\(suffix)" as NSString
+        // O(1) cache key. `resultRevision` is a monotonic counter bumped on every
+        // write to `toolCall.result` (see ToolCallData), so it detects in-place
+        // mutations (replay / correction / rehydration) without touching the
+        // string contents on every SwiftUI re-render.
+        return "\(toolCallID)|\(resultRevision)|\(isError ? "err" : "ok")" as NSString
     }
 
     private func coloredOutput(_ result: String, isError: Bool) -> AttributedString {

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -806,6 +806,11 @@ public struct ToolCallData: Identifiable, Equatable {
     /// Lightweight sentinel tracking `result?.count` so that `==` can detect
     /// rehydration without expensive full-string comparison on multi-MB results.
     public var resultLength: Int = 0
+    /// Monotonically increasing revision counter bumped on every write to `result`.
+    /// Included in `==` so same-length in-place mutations (replay / correction /
+    /// rehydration) still trigger view re-evaluation, and used as an O(1) cache-key
+    /// component in render-time memoization of colored output.
+    public var resultRevision: Int = 0
     public var isError: Bool
     public var isComplete: Bool
     /// Raw decoded tool input dictionary, stored for lazy formatting of `inputFull`.
@@ -863,6 +868,7 @@ public struct ToolCallData: Identifiable, Equatable {
             && lhs.inputFullLength == rhs.inputFullLength
             && lhs.inputRawValueLength == rhs.inputRawValueLength
             && lhs.partialOutputRevision == rhs.partialOutputRevision
+            && lhs.resultRevision == rhs.resultRevision
             && lhs.buildingStatus == rhs.buildingStatus
             && lhs.reasonDescription == rhs.reasonDescription
             && lhs.startedAt == rhs.startedAt
@@ -1847,6 +1853,7 @@ public struct ChatMessage: Identifiable, Equatable {
             toolCalls[i].imageDataList = nil
             toolCalls[i].result = nil
             toolCalls[i].resultLength = 0
+            toolCalls[i].resultRevision &+= 1
             toolCalls[i].inputFull = ""
             toolCalls[i].inputFullLength = 0
             toolCalls[i].inputRawDict = nil

--- a/clients/shared/Features/Chat/ChatViewModel+StreamingHelpers.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+StreamingHelpers.swift
@@ -431,6 +431,7 @@ extension ChatViewModel {
         if let msgIndex = targetMsgIndex, let tcIndex = targetTcIndex {
             messages[msgIndex].toolCalls[tcIndex].result = msg.result
             messages[msgIndex].toolCalls[tcIndex].resultLength = msg.result.count
+            messages[msgIndex].toolCalls[tcIndex].resultRevision &+= 1
             messages[msgIndex].toolCalls[tcIndex].isError = msg.isError ?? false
             messages[msgIndex].toolCalls[tcIndex].isComplete = true
             messages[msgIndex].toolCalls[tcIndex].completedAt = Date()

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -917,6 +917,7 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
                     if let result = fullTC.result {
                         msgs[idx].toolCalls[tcIdx].result = result
                         msgs[idx].toolCalls[tcIdx].resultLength = result.count
+                        msgs[idx].toolCalls[tcIdx].resultRevision &+= 1
                     }
                     if let input = fullTC.input {
                         let formatted = ToolCallData.formatAllToolInput(input)


### PR DESCRIPTION
## Summary

Follow-up to #25125. Codex (P1) and Devin (🔴) flagged that the boundary-only cache key (`count | prefix(16) | suffix(16)`) can collide when the same \`toolCallID\` has its \`result\` mutated in place during replay / correction / rehydration — any two strings sharing UTF-8 length, first 16 chars, and last 16 chars reuse the stale \`AttributedString\`, which is especially likely for JSON/diff output where boundaries are stable.

## Fix

Promote \`ToolCallData.result\` to carry a monotonic \`resultRevision\` counter (mirroring the existing \`partialOutputRevision\` pattern). The counter is bumped at every write site:

- \`ChatViewModel.swift\` (rehydration/correction)
- \`ChatViewModel+StreamingHelpers.swift\` (streaming completion)
- \`stripHeavyContent()\` (reset path)

Included in \`==\` so same-length in-place mutations still invalidate SwiftUI body caching, and used as the sole content-varying component of \`coloredOutputCacheKey\`. The cache key is now \`toolCallID | resultRevision | err/ok\` — truly O(1), no string sampling, no collisions.

## Files

- \`clients/shared/Features/Chat/ChatMessage.swift\`
- \`clients/shared/Features/Chat/ChatViewModel.swift\`
- \`clients/shared/Features/Chat/ChatViewModel+StreamingHelpers.swift\`
- \`clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift\`

## Test plan

- [ ] Rehydrate a conversation with a tool whose result changes mid-body (e.g. status JSON) and confirm the displayed colored text updates.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25140" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
