### PR TITLE
feat(clients): add Swift `OpenConversation` wire type

### DIFF
--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -2959,6 +2959,20 @@ public struct OpenUrl: Codable, Sendable {
     }
 }
 
+public struct OpenConversation: Codable, Sendable {
+    public let type: String
+    public let conversationId: String
+    public let title: String?
+    public let anchorMessageId: String?
+
+    public init(type: String, conversationId: String, title: String? = nil, anchorMessageId: String? = nil) {
+        self.type = type
+        self.conversationId = conversationId
+        self.title = title
+        self.anchorMessageId = anchorMessageId
+    }
+}
+
 public struct PairingApprovalRequest: Codable, Sendable {
     public let type: String
     public let pairingRequestId: String


### PR DESCRIPTION
## Summary
- Adds `OpenConversation` Codable struct to `GeneratedAPITypes.swift` following the `OpenUrl` pattern
- Intentionally orphaned: the `ServerMessage` enum case + decoder lands in PR 3 to keep this change small

Part of plan: convo-launcher.md (PR 2 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25141" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
