### PR TITLE
feat(daemon): add `open_conversation` server message type

### DIFF
--- a/assistant/src/__tests__/emit-event-open-conversation.test.ts
+++ b/assistant/src/__tests__/emit-event-open-conversation.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Behavioral test for the open_conversation server message type wired
+ * through the generic emit-event signal.
+ *
+ * The CLI (or any in-process daemon caller) writes a JSON-encoded
+ * ServerMessage to `<signalsDir>/emit-event` and the daemon's signal
+ * handler reads it and republishes it through the assistantEventHub so
+ * SSE subscribers receive it.
+ *
+ * This test verifies that the OpenConversation envelope round-trips
+ * through that bridge unchanged.
+ */
+import {
+  existsSync,
+  mkdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { afterEach, describe, expect, test } from "bun:test";
+
+import type { AssistantEvent } from "../runtime/assistant-event.js";
+import { assistantEventHub } from "../runtime/assistant-event-hub.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
+import { handleEmitEventSignal } from "../signals/emit-event.js";
+import { getSignalsDir } from "../util/platform.js";
+
+function signalPath(): string {
+  return join(getSignalsDir(), "emit-event");
+}
+
+const subscriptions: Array<{ dispose(): void }> = [];
+
+afterEach(() => {
+  for (const sub of subscriptions.splice(0)) {
+    sub.dispose();
+  }
+  const path = signalPath();
+  if (existsSync(path)) {
+    rmSync(path, { force: true });
+  }
+});
+
+describe("handleEmitEventSignal — open_conversation", () => {
+  test("publishes an open_conversation envelope to subscribed listeners", async () => {
+    mkdirSync(getSignalsDir(), { recursive: true });
+
+    const payload = {
+      type: "open_conversation" as const,
+      conversationId: "conv-test-1",
+      title: "Seeded thread",
+      anchorMessageId: "msg-1",
+    };
+
+    writeFileSync(signalPath(), JSON.stringify(payload), "utf-8");
+
+    const received: AssistantEvent[] = [];
+    let resolveDelivered: (() => void) | null = null;
+    const delivered = new Promise<void>((resolve) => {
+      resolveDelivered = resolve;
+    });
+
+    subscriptions.push(
+      assistantEventHub.subscribe(
+        { assistantId: DAEMON_INTERNAL_ASSISTANT_ID },
+        (event) => {
+          received.push(event);
+          resolveDelivered?.();
+        },
+      ),
+    );
+
+    handleEmitEventSignal();
+
+    await delivered;
+
+    expect(received).toHaveLength(1);
+    const event = received[0];
+    expect(event.assistantId).toBe(DAEMON_INTERNAL_ASSISTANT_ID);
+    expect(event.message).toEqual(payload);
+    // Spot-check the envelope fields the SSE route relies on.
+    expect(typeof event.id).toBe("string");
+    expect(typeof event.emittedAt).toBe("string");
+  });
+});

--- a/assistant/src/daemon/message-types/conversations.ts
+++ b/assistant/src/daemon/message-types/conversations.ts
@@ -469,6 +469,21 @@ export interface ScheduleConversationCreated {
   title: string;
 }
 
+/**
+ * Server push — instructs the client to open and focus a conversation. If
+ * the conversation isn't already present in the client's sidebar list (e.g.
+ * it was just created via `POST /v1/conversations`), the client should stub
+ * a sidebar entry using the provided `title` before navigating.
+ */
+export interface OpenConversation {
+  type: "open_conversation";
+  conversationId: string;
+  /** Optional conversation title; supplied when the client may not yet have the conversation in its list. */
+  title?: string;
+  /** Optional message ID to scroll to after focus. */
+  anchorMessageId?: string;
+}
+
 // --- Domain-level union aliases (consumed by the barrel file) ---
 
 export type _ConversationsClientMessages =
@@ -507,4 +522,5 @@ export type _ConversationsServerMessages =
   | ConversationsClearResponse
   | ConversationSearchResponse
   | MessageContentResponse
-  | ScheduleConversationCreated;
+  | ScheduleConversationCreated
+  | OpenConversation;


### PR DESCRIPTION
## Summary
- Adds `OpenConversation` interface to `conversations.ts` message types with optional title and anchorMessageId
- Wires it into `_ConversationsServerMessages` so it flows into the top-level `ServerMessage` union
- Adds an integration test that round-trips the event through `handleEmitEventSignal` → `assistantEventHub`

Part of plan: convo-launcher.md (PR 1 of 5)