### PR TITLE
feat(clients): decode `open_conversation` into `ServerMessage` enum

### DIFF
--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -2292,6 +2292,7 @@ public enum ServerMessage: Decodable, Sendable {
     case documentListResponse(DocumentListResponseMessage)
     case assistantStatus(AssistantStatusMessage)
     case openUrl(OpenUrlMessage)
+    case openConversation(OpenConversation)
     case navigateSettings(NavigateSettings)
     case showPlatformLogin(ShowPlatformLogin)
     case platformDisconnected(PlatformDisconnected)
@@ -2617,6 +2618,9 @@ public enum ServerMessage: Decodable, Sendable {
         case "open_url":
             let message = try OpenUrlMessage(from: decoder)
             self = .openUrl(message)
+        case "open_conversation":
+            let message = try OpenConversation(from: decoder)
+            self = .openConversation(message)
         case "navigate_settings":
             let message = try NavigateSettings(from: decoder)
             self = .navigateSettings(message)

--- a/clients/shared/Tests/MessageTypesTests.swift
+++ b/clients/shared/Tests/MessageTypesTests.swift
@@ -132,4 +132,50 @@ final class MessageTypesTests: XCTestCase {
         XCTAssertEqual(cancel.type, "host_browser_cancel")
         XCTAssertEqual(cancel.requestId, "req-abc-123")
     }
+
+    // MARK: - open_conversation
+
+    func testDecodes_openConversation_withAllFields() throws {
+        let json = Data(
+            """
+            {
+              "type": "open_conversation",
+              "conversationId": "conv-abc-123",
+              "title": "New research thread",
+              "anchorMessageId": "msg-999"
+            }
+            """.utf8
+        )
+
+        let message = try decoder.decode(ServerMessage.self, from: json)
+
+        guard case .openConversation(let request) = message else {
+            XCTFail("Expected .openConversation, got \(message)")
+            return
+        }
+
+        XCTAssertEqual(request.type, "open_conversation")
+        XCTAssertEqual(request.conversationId, "conv-abc-123")
+        XCTAssertEqual(request.title, "New research thread")
+        XCTAssertEqual(request.anchorMessageId, "msg-999")
+    }
+
+    func testDecodes_openConversation_withOnlyConversationId() throws {
+        let json = Data(
+            """
+            { "type": "open_conversation", "conversationId": "conv-min" }
+            """.utf8
+        )
+
+        let message = try decoder.decode(ServerMessage.self, from: json)
+
+        guard case .openConversation(let request) = message else {
+            XCTFail("Expected .openConversation, got \(message)")
+            return
+        }
+
+        XCTAssertEqual(request.conversationId, "conv-min")
+        XCTAssertNil(request.title)
+        XCTAssertNil(request.anchorMessageId)
+    }
 }


### PR DESCRIPTION
## Summary
- Adds `openConversation(OpenConversation)` case to the `ServerMessage` enum
- Wires the `"open_conversation"` type tag through the decoder's switch
- Adds two round-trip tests in `MessageTypesTests.swift` (all-fields + minimal payload)

Part of plan: convo-launcher.md (PR 3 of 5)