### PR TITLE
fix(skills): route conversation-launcher through gateway internal URL

### DIFF
--- a/skills/conversation-launcher/SKILL.md
+++ b/skills/conversation-launcher/SKILL.md
@@ -51,8 +51,7 @@ For each option you plan to surface, prepare:
 3. **Create the new conversation.** Generate a fresh idempotency key (any unique string, e.g. a UUID or timestamp-based slug) and call:
 
     ```bash
-    curl -sf -X POST "http://127.0.0.1:${ASSISTANT_HTTP_PORT}/v1/conversations" \
-      -H "Authorization: Bearer ${ASSISTANT_JWT}" \
+    curl -sf -X POST "$INTERNAL_GATEWAY_BASE_URL/v1/conversations" \
       -H "Content-Type: application/json" \
       -d "{\"conversationKey\":\"launcher-$(date +%s)-$RANDOM\"}"
     ```
@@ -62,8 +61,7 @@ For each option you plan to surface, prepare:
 4. **Seed the new conversation.** Post the seed prompt to it:
 
     ```bash
-    curl -sf -X POST "http://127.0.0.1:${ASSISTANT_HTTP_PORT}/v1/messages" \
-      -H "Authorization: Bearer ${ASSISTANT_JWT}" \
+    curl -sf -X POST "$INTERNAL_GATEWAY_BASE_URL/v1/messages" \
       -H "Content-Type: application/json" \
       -d "{\"conversationKey\":\"${NEW_CONV_ID}\",\"content\":\"${SEED_PROMPT}\"}"
     ```


### PR DESCRIPTION
## Summary

- `skills/conversation-launcher/SKILL.md` referenced `http://127.0.0.1:${ASSISTANT_HTTP_PORT}/v1/...` with `Authorization: Bearer ${ASSISTANT_JWT}` — neither env var exists in the skill sandbox, so the curl calls would fail at runtime AND tripped `gateway-only-guard.test.ts` (interpolated localhost /v1 URL outside the allowlist).
- Switch both POSTs to `$INTERNAL_GATEWAY_BASE_URL/v1/...` (injected by `assistant/src/tools/terminal/safe-env.ts`), matching the convention used by `public-ingress`, `guardian-verify-setup`, `telegram-setup`, and other first-party skills.
- Drop the bogus `Authorization: Bearer ${ASSISTANT_JWT}` header — the internal gateway URL is trusted and skills don't carry a JWT.

Fixes the `Test` job on https://github.com/vellum-ai/vellum-assistant/actions/runs/24323544996/job/71014153574. The other failure in the same job (`workspace-lifecycle.test.ts`) is a pre-existing flake (see #23012, #22820) and is out of scope.

## Original prompt

--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24323544996/job/71014153574
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25146" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
