### PR TITLE
feat(macos): handle `open_conversation` SSE event

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
@@ -208,6 +208,24 @@ extension AppDelegate {
                             NSWorkspace.shared.open(url)
                         }
                     }
+                case .openConversation(let msg):
+                    guard !self.isBootstrapping else { break }
+                    self.ensureMainWindowExists()
+                    // If the conversation isn't in the sidebar yet (e.g. just created by a
+                    // skill via POST /v1/conversations), stub a sidebar entry using the
+                    // optional title so openConversation's trySelect retries find it.
+                    if let title = msg.title,
+                       let conversationManager = self.mainWindow?.conversationManager,
+                       !conversationManager.conversations.contains(where: { $0.conversationId == msg.conversationId }) {
+                        conversationManager.createNotificationConversation(
+                            conversationId: msg.conversationId,
+                            title: title,
+                            sourceEventName: "open_conversation",
+                            groupId: nil,
+                            source: nil
+                        )
+                    }
+                    self.openConversation(conversationId: msg.conversationId, anchorMessageId: msg.anchorMessageId)
                 case .navigateSettings(let msg):
                     self.showSettingsTab(msg.tab)
                 case .showPlatformLogin:


### PR DESCRIPTION
## Summary
- Adds `case .openConversation` to the macOS SSE dispatcher in `AppDelegate+ConnectionSetup.swift`
- Routes to existing `openConversation(conversationId:anchorMessageId:)` helper
- When the conversation isn't in the sidebar yet and `title` is provided, stubs a sidebar entry first so navigation can find it
- Respects `isBootstrapping` guard like sibling conversation-created events

Part of plan: convo-launcher.md (final PR of 5 — end-to-end flow now activated)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25147" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
