### PR TITLE
feat(stt): register google-gemini in daemon catalog, config schema, and transcriber resolver

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -1251,6 +1251,23 @@ describe("AssistantConfigSchema", () => {
     expect(result.services.stt.mode).toBe("your-own");
   });
 
+  test("accepts google-gemini as services.stt.provider", () => {
+    const result = AssistantConfigSchema.parse({
+      services: { stt: { provider: "google-gemini" } },
+    });
+    expect(result.services.stt.provider).toBe("google-gemini");
+    expect(result.services.stt.mode).toBe("your-own");
+  });
+
+  test("applies services.stt structural defaults when google-gemini provider is explicit", () => {
+    const result = AssistantConfigSchema.parse({
+      services: { stt: { provider: "google-gemini" } },
+    });
+    expect(result.services.stt.mode).toBe("your-own");
+    expect(result.services.stt.provider).toBe("google-gemini");
+    expect(result.services.stt.providers).toEqual({});
+  });
+
   test("accepts valid services.stt.providers.deepgram overrides", () => {
     const result = AssistantConfigSchema.parse({
       services: {

--- a/assistant/src/config/schemas/stt.ts
+++ b/assistant/src/config/schemas/stt.ts
@@ -4,7 +4,11 @@ import { z } from "zod";
  * Valid STT provider identifiers. New providers append here and register
  * an adapter.
  */
-export const VALID_STT_PROVIDERS = ["openai-whisper", "deepgram"] as const;
+export const VALID_STT_PROVIDERS = [
+  "openai-whisper",
+  "deepgram",
+  "google-gemini",
+] as const;
 
 /**
  * Sparse provider config map under `services.stt.providers`.

--- a/assistant/src/config/schemas/stt.ts
+++ b/assistant/src/config/schemas/stt.ts
@@ -15,7 +15,7 @@ export const VALID_STT_PROVIDERS = [
  *
  * This is a forward-compatible record that accepts any provider ID as key
  * with an object value. All provider entries — known (`openai-whisper`,
- * `deepgram`) and unknown — are accepted with generic object validation.
+ * `deepgram`, `google-gemini`) and unknown — are accepted with generic object validation.
  * Adding a new provider ID does not require a migration to seed
  * `services.stt.providers.<id>`.
  *

--- a/assistant/src/providers/speech-to-text/__tests__/provider-catalog.test.ts
+++ b/assistant/src/providers/speech-to-text/__tests__/provider-catalog.test.ts
@@ -22,6 +22,7 @@ describe("STT provider catalog", () => {
     const ids = listProviderIds();
     expect(ids).toContain("openai-whisper");
     expect(ids).toContain("deepgram");
+    expect(ids).toContain("google-gemini");
   });
 
   test("listProviderIds returns IDs in deterministic insertion order", () => {
@@ -48,9 +49,10 @@ describe("STT provider catalog", () => {
 
   test("listCredentialProviderNames includes expected providers", () => {
     const names = listCredentialProviderNames();
-    // openai-whisper maps to "openai", deepgram maps to "deepgram"
+    // openai-whisper maps to "openai", deepgram maps to "deepgram", google-gemini maps to "gemini"
     expect(names).toContain("openai");
     expect(names).toContain("deepgram");
+    expect(names).toContain("gemini");
   });
 
   test("listCredentialProviderNames returns names in deterministic order", () => {
@@ -89,6 +91,7 @@ describe("STT provider catalog", () => {
   test("supportsBoundary returns true for supported boundaries", () => {
     expect(supportsBoundary("openai-whisper", "daemon-batch")).toBe(true);
     expect(supportsBoundary("deepgram", "daemon-batch")).toBe(true);
+    expect(supportsBoundary("google-gemini", "daemon-batch")).toBe(true);
   });
 
   test("supportsBoundary returns false for unknown provider IDs", () => {
@@ -105,6 +108,7 @@ describe("STT provider catalog", () => {
   test("getCredentialProvider returns correct mapping", () => {
     expect(getCredentialProvider("openai-whisper")).toBe("openai");
     expect(getCredentialProvider("deepgram")).toBe("deepgram");
+    expect(getCredentialProvider("google-gemini")).toBe("gemini");
   });
 
   test("getCredentialProvider returns undefined for unknown ID", () => {

--- a/assistant/src/providers/speech-to-text/__tests__/resolve.test.ts
+++ b/assistant/src/providers/speech-to-text/__tests__/resolve.test.ts
@@ -174,6 +174,50 @@ describe("resolveBatchTranscriber", () => {
     expect(transcriber!.providerId).toBe("deepgram");
     expect(transcriber!.boundaryId).toBe("daemon-batch");
   });
+
+  // -------------------------------------------------------------------------
+  // Google Gemini provider resolution
+  // -------------------------------------------------------------------------
+
+  test("returns a BatchTranscriber when google-gemini is configured and credentials are available", async () => {
+    mockProviderKeys["gemini"] = "gemini-test-key";
+    mockConfig = buildConfig({ provider: "google-gemini" });
+
+    const transcriber = await resolveBatchTranscriber();
+
+    expect(transcriber).not.toBeNull();
+    expect(transcriber!.providerId).toBe("google-gemini");
+    expect(transcriber!.boundaryId).toBe("daemon-batch");
+  });
+
+  test("returns null when google-gemini is configured but no credentials exist", async () => {
+    mockProviderKeys = {}; // no keys
+    mockConfig = buildConfig({ provider: "google-gemini" });
+
+    const transcriber = await resolveBatchTranscriber();
+
+    expect(transcriber).toBeNull();
+  });
+
+  test("google-gemini uses 'gemini' credential key, not 'openai' or 'deepgram'", async () => {
+    // Only openai key is set — google-gemini should NOT resolve
+    mockProviderKeys["openai"] = "sk-test-key";
+    mockConfig = buildConfig({ provider: "google-gemini" });
+
+    const transcriber = await resolveBatchTranscriber();
+
+    expect(transcriber).toBeNull();
+  });
+
+  test("resolved google-gemini transcriber has stable provider identity", async () => {
+    mockProviderKeys["gemini"] = "gemini-identity-test";
+    mockConfig = buildConfig({ provider: "google-gemini" });
+
+    const transcriber = await resolveBatchTranscriber();
+
+    expect(transcriber!.providerId).toBe("google-gemini");
+    expect(transcriber!.boundaryId).toBe("daemon-batch");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -246,5 +290,35 @@ describe("resolveTelephonySttCapability", () => {
     const result = await resolveTelephonySttCapability();
 
     expect(result.status).toBe("unconfigured");
+  });
+
+  // -------------------------------------------------------------------------
+  // Google Gemini telephony capability
+  // -------------------------------------------------------------------------
+
+  test("returns 'supported' for google-gemini with batch-only telephonyMode", async () => {
+    mockProviderKeys["gemini"] = "gemini-telephony-test";
+    mockConfig = buildConfig({ provider: "google-gemini" });
+
+    const result = await resolveTelephonySttCapability();
+
+    expect(result.status).toBe("supported");
+    if (result.status === "supported") {
+      expect(result.providerId).toBe("google-gemini");
+      expect(result.telephonyMode).toBe("batch-only");
+    }
+  });
+
+  test("returns 'missing-credentials' for google-gemini without a gemini key", async () => {
+    mockProviderKeys = {};
+    mockConfig = buildConfig({ provider: "google-gemini" });
+
+    const result = await resolveTelephonySttCapability();
+
+    expect(result.status).toBe("missing-credentials");
+    if (result.status === "missing-credentials") {
+      expect(result.providerId).toBe("google-gemini");
+      expect(result.credentialProvider).toBe("gemini");
+    }
   });
 });

--- a/assistant/src/providers/speech-to-text/provider-catalog.ts
+++ b/assistant/src/providers/speech-to-text/provider-catalog.ts
@@ -84,6 +84,15 @@ const CATALOG: ReadonlyMap<SttProviderId, SttProviderEntry> = new Map<
       telephonyMode: "realtime-ws",
     },
   ],
+  [
+    "google-gemini",
+    {
+      id: "google-gemini",
+      credentialProvider: "gemini",
+      supportedBoundaries: new Set<SttBoundaryId>(["daemon-batch"]),
+      telephonyMode: "batch-only",
+    },
+  ],
 ]);
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/stt/__tests__/daemon-batch-transcriber.test.ts
+++ b/assistant/src/stt/__tests__/daemon-batch-transcriber.test.ts
@@ -32,6 +32,19 @@ mock.module("../../providers/speech-to-text/deepgram.js", () => ({
   },
 }));
 
+let mockGeminiTranscribeResult: { text: string } = { text: "" };
+let mockGeminiTranscribeError: Error | null = null;
+
+mock.module("../../providers/speech-to-text/google-gemini.js", () => ({
+  GoogleGeminiProvider: class MockGoogleGeminiProvider {
+    constructor(_apiKey: string) {}
+    async transcribe(_audio: Buffer, _mimeType: string, _signal?: AbortSignal) {
+      if (mockGeminiTranscribeError) throw mockGeminiTranscribeError;
+      return mockGeminiTranscribeResult;
+    }
+  },
+}));
+
 // Dynamic import so mocks are active when the module loads.
 const { createDaemonBatchTranscriber, normalizeSttError } =
   await import("../daemon-batch-transcriber.js");
@@ -46,6 +59,8 @@ describe("createDaemonBatchTranscriber", () => {
     mockWhisperTranscribeError = null;
     mockDeepgramTranscribeResult = { text: "" };
     mockDeepgramTranscribeError = null;
+    mockGeminiTranscribeResult = { text: "" };
+    mockGeminiTranscribeError = null;
   });
 
   // -------------------------------------------------------------------------
@@ -214,6 +229,81 @@ describe("createDaemonBatchTranscriber", () => {
   test("returns null for deepgram when no API key is provided", () => {
     expect(createDaemonBatchTranscriber(null, "deepgram")).toBeNull();
     expect(createDaemonBatchTranscriber(undefined, "deepgram")).toBeNull();
+  });
+
+  // -------------------------------------------------------------------------
+  // Provider identity — Google Gemini
+  // -------------------------------------------------------------------------
+
+  test("reports providerId as google-gemini when created with google-gemini", () => {
+    const transcriber = createDaemonBatchTranscriber(
+      "gemini-test-key",
+      "google-gemini",
+    );
+    expect(transcriber).not.toBeNull();
+    expect(transcriber!.providerId).toBe("google-gemini");
+  });
+
+  test("reports boundaryId as daemon-batch for google-gemini", () => {
+    const transcriber = createDaemonBatchTranscriber(
+      "gemini-test-key",
+      "google-gemini",
+    );
+    expect(transcriber!.boundaryId).toBe("daemon-batch");
+  });
+
+  // -------------------------------------------------------------------------
+  // Successful transcription — Google Gemini
+  // -------------------------------------------------------------------------
+
+  test("delegates transcription to the Google Gemini provider", async () => {
+    mockGeminiTranscribeResult = { text: "Hello from Gemini" };
+
+    const transcriber = createDaemonBatchTranscriber(
+      "gemini-test-key",
+      "google-gemini",
+    );
+    const result = await transcriber!.transcribe({
+      audio: Buffer.from("fake-audio"),
+      mimeType: "audio/ogg",
+    });
+
+    expect(result).toEqual({ text: "Hello from Gemini" });
+  });
+
+  // -------------------------------------------------------------------------
+  // Error propagation — Google Gemini
+  // -------------------------------------------------------------------------
+
+  test("propagates Google Gemini errors unchanged", async () => {
+    const original = new Error(
+      "Google Gemini API error (401): Invalid credentials",
+    );
+    mockGeminiTranscribeError = original;
+
+    const transcriber = createDaemonBatchTranscriber(
+      "gemini-test-key",
+      "google-gemini",
+    );
+
+    try {
+      await transcriber!.transcribe({
+        audio: Buffer.from("audio"),
+        mimeType: "audio/wav",
+      });
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBe(original);
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Null on missing key — Google Gemini
+  // -------------------------------------------------------------------------
+
+  test("returns null for google-gemini when no API key is provided", () => {
+    expect(createDaemonBatchTranscriber(null, "google-gemini")).toBeNull();
+    expect(createDaemonBatchTranscriber(undefined, "google-gemini")).toBeNull();
   });
 });
 

--- a/assistant/src/stt/daemon-batch-transcriber.ts
+++ b/assistant/src/stt/daemon-batch-transcriber.ts
@@ -9,6 +9,7 @@
  * Supported daemon-batch providers:
  * - OpenAI Whisper (`openai-whisper`)
  * - Deepgram (`deepgram`)
+ * - Google Gemini (`google-gemini`)
  */
 
 import type {
@@ -88,6 +89,38 @@ class DeepgramBatchTranscriber implements BatchTranscriber {
 }
 
 // ---------------------------------------------------------------------------
+// Google Gemini adapter — implements BatchTranscriber on top of the Google
+// Gemini multimodal provider.
+// ---------------------------------------------------------------------------
+
+/**
+ * Wraps `GoogleGeminiProvider` behind the `BatchTranscriber` contract.
+ *
+ * Same error-propagation semantics as WhisperBatchTranscriber: raw provider
+ * errors pass through unchanged.
+ */
+class GoogleGeminiBatchTranscriber implements BatchTranscriber {
+  readonly providerId = "google-gemini" as const;
+  readonly boundaryId = "daemon-batch" as const;
+
+  private readonly apiKey: string;
+
+  constructor(apiKey: string) {
+    this.apiKey = apiKey;
+  }
+
+  async transcribe(
+    request: SttTranscribeRequest,
+  ): Promise<SttTranscribeResult> {
+    const { GoogleGeminiProvider } =
+      await import("../providers/speech-to-text/google-gemini.js");
+    const provider = new GoogleGeminiProvider(this.apiKey);
+
+    return provider.transcribe(request.audio, request.mimeType, request.signal);
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Error normalization
 // ---------------------------------------------------------------------------
 
@@ -150,6 +183,8 @@ export function createDaemonBatchTranscriber(
       return new WhisperBatchTranscriber(apiKey);
     case "deepgram":
       return new DeepgramBatchTranscriber(apiKey);
+    case "google-gemini":
+      return new GoogleGeminiBatchTranscriber(apiKey);
     default: {
       // Exhaustive check — compile error if a new SttProviderId is added
       // without a corresponding case here.

--- a/assistant/src/stt/types.ts
+++ b/assistant/src/stt/types.ts
@@ -15,7 +15,7 @@
  * Canonical provider identifiers for daemon-hosted batch STT backends.
  * Extend this union as new providers are integrated.
  */
-export type SttProviderId = "openai-whisper" | "deepgram";
+export type SttProviderId = "openai-whisper" | "deepgram" | "google-gemini";
 
 /**
  * Telephony-specific STT support mode.

--- a/meta/stt-provider-catalog.json
+++ b/meta/stt-provider-catalog.json
@@ -16,6 +16,14 @@
       "setupMode": "api-key",
       "setupHint": "Enter your Deepgram API key to enable speech-to-text.",
       "apiKeyProviderName": "deepgram"
+    },
+    {
+      "id": "google-gemini",
+      "displayName": "Google Gemini",
+      "subtitle": "Multimodal speech-to-text powered by Google Gemini. Requires a Gemini API key.",
+      "setupMode": "api-key",
+      "setupHint": "Enter your Gemini API key to enable Google Gemini transcription.",
+      "apiKeyProviderName": "gemini"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Register google-gemini in SttProviderId, VALID_STT_PROVIDERS, provider catalog, and daemon batch transcriber
- Add GoogleGeminiBatchTranscriber with lazy import of google-gemini.ts
- Update meta/stt-provider-catalog.json for daemon/client parity
- Extend all relevant test suites for the new provider

Part of plan: google-first-class-stt-provider.md (PR 2 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25149" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
