### PR TITLE
feat(feature-flags): enable tool-result-truncation by default

### DIFF
--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -295,7 +295,7 @@
       "key": "tool-result-truncation",
       "label": "Post-Turn Tool Result Truncation",
       "description": "Truncate large tool results after each assistant turn, persisting full content to disk for on-demand re-reads",
-      "defaultEnabled": false
+      "defaultEnabled": true
     },
     {
       "id": "managed-gemini-embeddings-enabled",


### PR DESCRIPTION
## Summary

- Flip the `tool-result-truncation` assistant feature flag default from `false` to `true` in `meta/feature-flags/feature-flag-registry.json` so all installs get post-turn tool result truncation (persist full content to disk, replace in-context with a prefix/suffix stub + file pointer) without opt-in.
- Users with `"tool-result-truncation": false` in their feature flag overrides are unaffected — only the default changes.
- No platform-side change required: the flag is already provisioned in `vellum-assistant-platform/terraform/`; Terraform only declares metadata, `defaultEnabled` is registry-controlled.

## Original prompt

Enable \`tool-result-truncation\` by default. Two changes only: (1) flip \`defaultEnabled\` from \`false\` to \`true\` at line 298 of \`meta/feature-flags/feature-flag-registry.json\`, (2) run \`bun run meta/feature-flags/sync-bundled-copies.ts\` to propagate to \`assistant/src/config/feature-flag-registry.json\` and \`gateway/src/feature-flag-registry.json\`. Skip the UPDATES.md release note. Full plan at /Users/sidd/.claude/plans/mighty-brewing-moler.md — follow it exactly minus the release-note section.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25150" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
