### PR TITLE
Add vellum-sounds skill

### DIFF
--- a/skills/vellum-sounds/SKILL.md
+++ b/skills/vellum-sounds/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: vellum-sounds
+description: Customize the macOS app's sound effects — add sound files to the workspace, enable sounds globally, set volume, and assign sounds to 9 app events (message sent, task complete, notifications, etc.)
+compatibility: "Designed for Vellum personal assistants"
+metadata:
+  emoji: "🔊"
+  vellum:
+    display-name: "Sounds"
+---
+
+You are helping the user customize the sound effects their macOS app plays. Sounds are configured in two places — a `data/sounds/` directory of audio files, and a `data/sounds/config.json` that controls what plays when, at what volume, and whether it's enabled at all. The macOS app's Settings → Sounds tab reads the same files, so whatever you change here appears there live (no restart needed).
+
+**All commands in this skill use the `bash` tool.** `$VELLUM_WORKSPACE_DIR` is available in the sandbox environment — do not use `host_bash`.
+
+## What you're configuring
+
+Two stores, both under `$VELLUM_WORKSPACE_DIR/data/sounds/`:
+
+- **Sound files** — `.aiff`, `.wav`, `.mp3`, `.m4a`, or `.caf`. No other extensions are accepted. The macOS app scans this directory to populate the dropdown for each event.
+- **`config.json`** — a single JSON file that stores the global on/off switch, the master volume, and a per-event map of `{ enabled, sound }`.
+
+## The 9 events
+
+These are the only valid event keys. Other keys are ignored by the app.
+
+| Event key | Fires when |
+|---|---|
+| `app_open` | App launches (first time per session) |
+| `task_complete` | Conversation transitions processing → idle |
+| `needs_input` | Conversation enters waiting-for-input |
+| `task_failed` | Conversation enters error state |
+| `notification` | A tool-triggered notification is sent |
+| `new_conversation` | User creates a new conversation |
+| `message_sent` | User sends a message in the composer |
+| `character_poke` | User clicks the avatar |
+| `random` | Ambient timer (fires every 5–30 minutes) |
+
+## Mode 1: Inspect current state
+
+Always check current state before making changes — the user may already have things configured.
+
+```bash
+ls "$VELLUM_WORKSPACE_DIR/data/sounds/" 2>/dev/null || echo "No sounds directory yet"
+cat "$VELLUM_WORKSPACE_DIR/data/sounds/config.json" 2>/dev/null || echo "No config yet"
+```
+
+Report back what's there: whether sounds are globally enabled, current volume, which events have custom sounds assigned.
+
+## Mode 2: Add a sound file
+
+The user either sends you an audio file or asks you to fetch/generate one. Copy it into `data/sounds/` with a clean filename:
+
+```bash
+mkdir -p "$VELLUM_WORKSPACE_DIR/data/sounds"
+cp "<source-path>" "$VELLUM_WORKSPACE_DIR/data/sounds/<descriptive-name>.<ext>"
+```
+
+Rules:
+- Extension must be one of: `aiff`, `wav`, `mp3`, `m4a`, `caf`. If the user's file is something else (e.g. `.ogg`, `.flac`), tell them — don't try to rename.
+- Keep the filename simple (no path separators, no leading dots). Spaces are fine.
+- After adding a file, it's available in the dropdown — but nothing plays until you assign it to an event (Mode 3).
+
+## Mode 3: Configure via the helper script
+
+Use `scripts/update-config.ts` to edit `config.json`. It validates inputs, creates the file with defaults if missing, and writes atomically so a crash can't corrupt it.
+
+```bash
+bun run scripts/update-config.ts --global-enabled true
+bun run scripts/update-config.ts --volume 0.5
+bun run scripts/update-config.ts --event message_sent --enabled true --sound "gentle-ding.aiff"
+bun run scripts/update-config.ts --event random --enabled false
+bun run scripts/update-config.ts --event task_complete --sound null   # revert to default blip
+```
+
+Flag reference:
+
+| Flag | Value | Effect |
+|---|---|---|
+| `--global-enabled` | `true` or `false` | Master switch. If `false`, NOTHING plays regardless of per-event settings. |
+| `--volume` | `0.0`–`1.0` (clamped) | Master volume. `0.7` is the default. |
+| `--event` | one of the 9 keys above | Scopes the next flags to a single event. |
+| `--enabled` | `true` or `false` | Per-event on/off (requires `--event`). |
+| `--sound` | filename or `null` | Which file to play for this event (requires `--event`). `null` = macOS "Tink" default blip. The file must already exist in `data/sounds/`. |
+
+The script prints the resulting config slice so you can confirm what changed.
+
+## Mode 4: Remove a sound file
+
+```bash
+rm "$VELLUM_WORKSPACE_DIR/data/sounds/<filename>"
+```
+
+Then clear any event that referenced it, so the config doesn't dangle:
+
+```bash
+bun run scripts/update-config.ts --event <key> --sound null
+```
+
+(The macOS app already falls back to the default blip if a referenced file is missing, but cleaning up the config is tidier.)
+
+## UX Guidelines
+
+- **Always check current state first.** Don't ask "what do you want to do" if they already have sounds configured — summarize what's set up, then ask what to change.
+- **The master switch is the #1 gotcha.** `globalEnabled` defaults to `false`. If the user assigns a sound to an event and doesn't hear anything, check that flag first. When assigning the user's first sound, offer to flip the master switch on for them.
+- **Per-event enabled is the #2 gotcha.** Each event has its own `enabled` bool. Setting `sound` alone doesn't enable the event.
+- **Filename sanity.** When the user sends a file named something like `Screen Recording 2026-04-13 at 11.47.23.m4a`, rename it to something memorable before copying — they'll have to pick it from a dropdown later.
+- **Confirm after changes.** Tell the user the Settings → Sounds tab will reflect changes live. Offer to open it: "You can preview it in Settings → Sounds, or I can play it for you next time that event fires."
+- **Don't invent events.** The 9 event keys above are the complete list. There is currently no event for voice-mode activation or typing indicators — if the user asks for those, tell them it'd need a code change to the macOS app.
+
+## Config shape reference
+
+If the user inspects `config.json` directly, this is what they'll see. Defaults match the macOS app's `SoundsConfig.defaultConfig`.
+
+```json
+{
+  "globalEnabled": false,
+  "volume": 0.7,
+  "events": {
+    "app_open":         { "enabled": false, "sound": null },
+    "task_complete":    { "enabled": false, "sound": null },
+    "needs_input":      { "enabled": false, "sound": null },
+    "task_failed":      { "enabled": false, "sound": null },
+    "notification":     { "enabled": false, "sound": null },
+    "new_conversation": { "enabled": false, "sound": null },
+    "message_sent":     { "enabled": false, "sound": null },
+    "character_poke":   { "enabled": false, "sound": null },
+    "random":           { "enabled": false, "sound": null }
+  }
+}
+```

--- a/skills/vellum-sounds/scripts/update-config.ts
+++ b/skills/vellum-sounds/scripts/update-config.ts
@@ -1,0 +1,301 @@
+#!/usr/bin/env bun
+/**
+ * CLI for vellum-sounds skill: `bun run scripts/update-config.ts`
+ *
+ * Safely reads and writes $VELLUM_WORKSPACE_DIR/data/sounds/config.json,
+ * the configuration file consumed by the macOS app's SoundManager. Validates
+ * inputs, creates the file with defaults if missing, and writes atomically.
+ */
+
+import {
+  closeSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+
+const SUPPORTED_EXTENSIONS = ["aiff", "wav", "mp3", "m4a", "caf"] as const;
+
+const EVENT_KEYS = [
+  "app_open",
+  "task_complete",
+  "needs_input",
+  "task_failed",
+  "notification",
+  "new_conversation",
+  "message_sent",
+  "character_poke",
+  "random",
+] as const;
+
+type EventKey = (typeof EVENT_KEYS)[number];
+
+interface SoundEventConfig {
+  enabled: boolean;
+  sound: string | null;
+}
+
+interface SoundsConfig {
+  globalEnabled: boolean;
+  volume: number;
+  events: Record<string, SoundEventConfig>;
+}
+
+function defaultConfig(): SoundsConfig {
+  const events: Record<string, SoundEventConfig> = {};
+  for (const key of EVENT_KEYS) {
+    events[key] = { enabled: false, sound: null };
+  }
+  return { globalEnabled: false, volume: 0.7, events };
+}
+
+function printUsage(): void {
+  process.stderr.write(`Usage: bun run scripts/update-config.ts [options]
+
+Edit data/sounds/config.json in the current workspace. Creates the file with
+defaults if it doesn't exist. Writes atomically.
+
+Options:
+  --global-enabled <true|false>   Master on/off for all sounds.
+  --volume <float>                 Master volume, 0.0–1.0 (clamped).
+  --event <key>                    One of: ${EVENT_KEYS.join(", ")}
+  --enabled <true|false>           Per-event on/off (requires --event).
+  --sound <filename|null>          Sound file in data/sounds/ to play for this
+                                   event, or "null" for the default blip
+                                   (requires --event).
+  --help, -h                       Show this help.
+
+Examples:
+  bun run scripts/update-config.ts --global-enabled true
+  bun run scripts/update-config.ts --volume 0.5
+  bun run scripts/update-config.ts --event message_sent --enabled true --sound "gentle-ding.aiff"
+  bun run scripts/update-config.ts --event task_complete --sound null
+`);
+}
+
+function fail(message: string): never {
+  process.stderr.write(`Error: ${message}\n`);
+  process.exit(1);
+}
+
+interface ParsedArgs {
+  globalEnabled?: boolean;
+  volume?: number;
+  event?: EventKey;
+  enabled?: boolean;
+  sound?: string | null;
+  help: boolean;
+}
+
+function parseBool(raw: string, flag: string): boolean {
+  const lower = raw.toLowerCase();
+  if (lower === "true") return true;
+  if (lower === "false") return false;
+  fail(`${flag} must be "true" or "false" (got "${raw}")`);
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+  const out: ParsedArgs = { help: false };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    const next = (): string => {
+      const v = argv[i + 1];
+      if (v === undefined) fail(`${arg} requires a value`);
+      i++;
+      return v;
+    };
+    switch (arg) {
+      case "--help":
+      case "-h":
+        out.help = true;
+        break;
+      case "--global-enabled":
+        out.globalEnabled = parseBool(next(), arg);
+        break;
+      case "--volume": {
+        const raw = next();
+        const n = Number(raw);
+        if (!Number.isFinite(n)) fail(`--volume must be a number (got "${raw}")`);
+        out.volume = Math.max(0, Math.min(1, n));
+        break;
+      }
+      case "--event": {
+        const raw = next();
+        if (!(EVENT_KEYS as readonly string[]).includes(raw)) {
+          fail(
+            `--event must be one of: ${EVENT_KEYS.join(", ")} (got "${raw}")`,
+          );
+        }
+        out.event = raw as EventKey;
+        break;
+      }
+      case "--enabled":
+        out.enabled = parseBool(next(), arg);
+        break;
+      case "--sound": {
+        const raw = next();
+        out.sound = raw === "null" ? null : raw;
+        break;
+      }
+      default:
+        fail(`Unknown flag: ${arg}`);
+    }
+  }
+  return out;
+}
+
+function resolveSoundsDir(): string {
+  const workspace = process.env.VELLUM_WORKSPACE_DIR;
+  if (!workspace) {
+    fail(
+      "VELLUM_WORKSPACE_DIR is not set. This script must run inside the Vellum skill sandbox.",
+    );
+  }
+  return join(workspace, "data", "sounds");
+}
+
+function readConfig(path: string): SoundsConfig {
+  if (!existsSync(path)) return defaultConfig();
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf8");
+  } catch (err) {
+    fail(`Failed to read ${path}: ${(err as Error).message}`);
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    fail(`${path} is not valid JSON: ${(err as Error).message}`);
+  }
+  const base = defaultConfig();
+  const p = parsed as Partial<SoundsConfig> | null;
+  if (p && typeof p === "object") {
+    if (typeof p.globalEnabled === "boolean") {
+      base.globalEnabled = p.globalEnabled;
+    }
+    if (typeof p.volume === "number" && Number.isFinite(p.volume)) {
+      base.volume = Math.max(0, Math.min(1, p.volume));
+    }
+    if (p.events && typeof p.events === "object") {
+      for (const key of EVENT_KEYS) {
+        const entry = (p.events as Record<string, unknown>)[key];
+        if (entry && typeof entry === "object") {
+          const e = entry as Partial<SoundEventConfig>;
+          if (typeof e.enabled === "boolean") base.events[key].enabled = e.enabled;
+          if (e.sound === null || typeof e.sound === "string") {
+            base.events[key].sound = e.sound;
+          }
+        }
+      }
+    }
+  }
+  return base;
+}
+
+function writeConfigAtomic(path: string, config: SoundsConfig): void {
+  const dir = dirname(path);
+  mkdirSync(dir, { recursive: true });
+  const tmp = `${path}.tmp.${process.pid}`;
+  const body = JSON.stringify(config, null, 2) + "\n";
+  const fd = openSync(tmp, "w", 0o644);
+  try {
+    writeSync(fd, body);
+  } finally {
+    closeSync(fd);
+  }
+  try {
+    renameSync(tmp, path);
+  } catch (err) {
+    try {
+      unlinkSync(tmp);
+    } catch {
+      // ignore cleanup failure
+    }
+    fail(`Failed to write ${path}: ${(err as Error).message}`);
+  }
+}
+
+function validateSoundFilename(soundsDir: string, filename: string): void {
+  if (filename.includes("/") || filename.includes("\\")) {
+    fail(`--sound filename must not contain path separators (got "${filename}")`);
+  }
+  if (filename.startsWith(".")) {
+    fail(`--sound filename must not start with "." (got "${filename}")`);
+  }
+  const dotIdx = filename.lastIndexOf(".");
+  const ext = dotIdx >= 0 ? filename.slice(dotIdx + 1).toLowerCase() : "";
+  if (!(SUPPORTED_EXTENSIONS as readonly string[]).includes(ext)) {
+    fail(
+      `--sound must have a supported extension (${SUPPORTED_EXTENSIONS.join(", ")}); got ".${ext}"`,
+    );
+  }
+  const full = join(soundsDir, filename);
+  if (!existsSync(full)) {
+    fail(
+      `Sound file not found at ${full}. Copy it into data/sounds/ first, then rerun.`,
+    );
+  }
+}
+
+function main(): void {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printUsage();
+    return;
+  }
+
+  const hasEventFlag = args.enabled !== undefined || args.sound !== undefined;
+  if (hasEventFlag && !args.event) {
+    fail("--enabled and --sound require --event");
+  }
+  if (
+    args.globalEnabled === undefined &&
+    args.volume === undefined &&
+    args.event === undefined
+  ) {
+    printUsage();
+    fail("No changes requested");
+  }
+
+  const soundsDir = resolveSoundsDir();
+  const configPath = join(soundsDir, "config.json");
+  const config = readConfig(configPath);
+
+  const changed: Record<string, unknown> = {};
+
+  if (args.globalEnabled !== undefined) {
+    config.globalEnabled = args.globalEnabled;
+    changed.globalEnabled = config.globalEnabled;
+  }
+  if (args.volume !== undefined) {
+    config.volume = args.volume;
+    changed.volume = config.volume;
+  }
+  if (args.event) {
+    const eventConfig = config.events[args.event];
+    if (args.enabled !== undefined) eventConfig.enabled = args.enabled;
+    if (args.sound !== undefined) {
+      if (args.sound === null) {
+        eventConfig.sound = null;
+      } else {
+        validateSoundFilename(soundsDir, args.sound);
+        eventConfig.sound = args.sound;
+      }
+    }
+    changed[`events.${args.event}`] = eventConfig;
+  }
+
+  writeConfigAtomic(configPath, config);
+
+  process.stdout.write(
+    JSON.stringify({ ok: true, path: configPath, changed }, null, 2) + "\n",
+  );
+}
+
+main();


### PR DESCRIPTION
## Summary
- Adds `skills/vellum-sounds/` with `SKILL.md` and `scripts/update-config.ts`, teaching the assistant how to drop sound files into the workspace and edit `data/sounds/config.json` on the user's behalf.
- Documents the 9 event keys from `SoundEvent.swift`, the 5 supported extensions from `SoundManager.swift`, and the two gotchas (global `globalEnabled: false` default + per-event `enabled` flag) that made Velissa guess incorrectly in chat.
- Helper script validates event keys, clamps volume to `[0, 1]`, rejects path traversal and unsupported extensions, verifies the referenced sound file exists, and writes atomically (temp file + rename).
- No macOS or backend changes — the existing Swift `SoundManager` already hot-reloads the workspace config via the gateway API, so the skill is purely additive.

## Original prompt
it