### PR TITLE
feat(stt): finalize macOS settings semantics and docs for google-gemini

### DIFF
--- a/assistant/docs/stt-provider-onboarding.md
+++ b/assistant/docs/stt-provider-onboarding.md
@@ -8,8 +8,8 @@ Step-by-step guide for adding a new speech-to-text provider to the assistant. Fo
 
 Add a new entry to the `CATALOG` map with:
 
-- `id` — a unique `SttProviderId` string (e.g. `"google-cloud"`).
-- `credentialProvider` — the credential-store key name used by `getProviderKeyAsync` to retrieve the API key. If the provider shares an API key with another service (e.g. `openai-whisper` shares the `"openai"` key), reuse that name; otherwise use the provider's own name.
+- `id` — a unique `SttProviderId` string (e.g. `"google-gemini"`).
+- `credentialProvider` — the credential-store key name used by `getProviderKeyAsync` to retrieve the API key. If the provider shares an API key with another service (e.g. `openai-whisper` shares the `"openai"` key, or `google-gemini` shares the `"gemini"` key), reuse that name; otherwise use the provider's own name (e.g. `"deepgram"` maps to `"deepgram"`).
 - `supportedBoundaries` — the set of `SttBoundaryId` values the provider supports (currently only `"daemon-batch"` exists).
 - `telephonyMode` — how the provider participates in real-time telephony STT: `"realtime-ws"`, `"batch-only"`, or `"none"`.
 
@@ -33,11 +33,11 @@ The `services.stt.providers` map uses a sparse `z.record(z.string(), ...)` schem
 
 **File:** `src/stt/daemon-batch-transcriber.ts`
 
-1. Create a new `BatchTranscriber` implementation class (e.g. `GoogleCloudBatchTranscriber`) alongside `WhisperBatchTranscriber` and `DeepgramBatchTranscriber`.
+1. Create a new `BatchTranscriber` implementation class (e.g. `GoogleGeminiBatchTranscriber`) alongside `WhisperBatchTranscriber` and `DeepgramBatchTranscriber`.
 2. Implement the `transcribe(request)` method using a lazy-imported provider module (follow the pattern in the existing adapters).
 3. Add a `case` branch in `createDaemonBatchTranscriber()` for the new `SttProviderId`. The exhaustive `never` check at the bottom of the switch ensures a compile error if this step is skipped.
 
-If the provider needs a new REST client module, add it under `src/providers/speech-to-text/` following the pattern of `openai-whisper.ts` and `deepgram.ts`.
+If the provider needs a new REST client module, add it under `src/providers/speech-to-text/` following the pattern of `openai-whisper.ts`, `deepgram.ts`, and `google-gemini.ts`.
 
 ## 5. Credential plumbing
 
@@ -61,6 +61,16 @@ Add a new entry to the `providers` array with the following fields:
 | `setupMode`          | `"api-key"` (inline key field) or `"cli"` (instructions-only).           |
 | `setupHint`          | Brief guidance shown during setup.                                       |
 | `apiKeyProviderName` | Must match the `credentialProvider` value from the daemon catalog entry. |
+
+**Naming/mapping examples:**
+
+| Provider ID      | `credentialProvider` / `apiKeyProviderName` | Key ownership |
+| ---------------- | ------------------------------------------- | ------------- |
+| `openai-whisper` | `openai`                                    | shared        |
+| `deepgram`       | `deepgram`                                  | exclusive     |
+| `google-gemini`  | `gemini`                                    | shared        |
+
+When the provider ID differs from the credential provider name (e.g. `google-gemini` maps to `gemini`), the key is **shared** with other services that use the same credential. The `sttKeyIsExclusive` / `sttKeyIsShared` helpers in the macOS settings layer derive this automatically from the catalog.
 
 Insertion order in the JSON array must match the daemon catalog insertion order.
 
@@ -101,4 +111,4 @@ Before submitting the PR, grep for any accidental coupling between the two STT c
 - **`services.stt`** — controls daemon batch and client service-first STT provider selection. Configured under the Speech-to-Text section in Settings.
 - **`calls.voice.transcriptionProvider`** — controls telephony-native STT (Twilio ConversationRelay). Configured separately under the Calls/Voice section.
 
-These are independent config paths with different provider sets and runtime boundaries. A new `services.stt` provider should never modify `calls.voice` config or vice versa. The prepared dark path for telephony cutover (see ARCHITECTURE.md) is the designated seam for future unification — do not wire a new provider into both paths simultaneously.
+These are independent config paths with different provider sets and runtime boundaries. A new `services.stt` provider should never modify `calls.voice` config or vice versa. For example, `google-gemini` is registered only under `services.stt` and has no effect on `calls.voice.transcriptionProvider`. The prepared dark path for telephony cutover (see ARCHITECTURE.md) is the designated seam for future unification — do not wire a new provider into both paths simultaneously.

--- a/assistant/src/config/bundled-skills/transcribe/SKILL.md
+++ b/assistant/src/config/bundled-skills/transcribe/SKILL.md
@@ -8,7 +8,7 @@ metadata:
     display-name: "Transcribe"
 ---
 
-Transcribe audio and video files using the configured speech-to-text provider. Supports multiple STT providers including OpenAI Whisper and Deepgram — the active provider is selected in Settings under Speech-to-Text (`services.stt`).
+Transcribe audio and video files using the configured speech-to-text provider. Supports multiple STT providers including OpenAI Whisper, Deepgram, and Google Gemini — the active provider is selected in Settings under Speech-to-Text (`services.stt`).
 
 ## Usage Notes
 

--- a/clients/macos/vellum-assistantTests/SettingsStoreVoiceServiceTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsStoreVoiceServiceTests.swift
@@ -311,6 +311,103 @@ final class SettingsStoreVoiceServiceTests: XCTestCase {
         )
     }
 
+    // MARK: - setSTTProvider with Google Gemini
+
+    func testSetSTTProviderGoogleGeminiEmitsExpectedPatch() {
+        store.setSTTProvider("google-gemini")
+
+        waitForPatchCount(1)
+
+        let patch = lastSTTPatch()
+        XCTAssertNotNil(patch, "expected a services.stt patch payload for google-gemini")
+        XCTAssertEqual(patch?["provider"] as? String, "google-gemini")
+    }
+
+    func testSetSTTProviderGoogleGeminiDoesNotEmitTTSPatch() {
+        store.setSTTProvider("google-gemini")
+
+        waitForPatchCount(1)
+
+        let ttsPatch = lastTTSPatch()
+        XCTAssertNil(ttsPatch, "setSTTProvider(google-gemini) must not emit a TTS patch")
+    }
+
+    func testApplyDaemonConfigSyncsGoogleGeminiSTTProvider() {
+        UserDefaults.standard.removeObject(forKey: "sttProvider")
+
+        let config: [String: Any] = [
+            "services": [
+                "stt": [
+                    "provider": "google-gemini"
+                ]
+            ]
+        ]
+
+        mockSettingsClient.fetchConfigResponse = config
+        let expectation = XCTestExpectation(description: "config loaded")
+        Task {
+            await store.loadConfigFromDaemon()
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 2.0)
+
+        XCTAssertEqual(
+            UserDefaults.standard.string(forKey: "sttProvider"),
+            "google-gemini"
+        )
+    }
+
+    func testApplyDaemonConfigSyncsGoogleGeminiWithExistingDeepgramSTT() {
+        // Start with deepgram persisted, then receive google-gemini from the daemon
+        UserDefaults.standard.set("deepgram", forKey: "sttProvider")
+
+        let config: [String: Any] = [
+            "services": [
+                "stt": [
+                    "provider": "google-gemini"
+                ]
+            ]
+        ]
+
+        mockSettingsClient.fetchConfigResponse = config
+        let expectation = XCTestExpectation(description: "config loaded")
+        Task {
+            await store.loadConfigFromDaemon()
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 2.0)
+
+        XCTAssertEqual(
+            UserDefaults.standard.string(forKey: "sttProvider"),
+            "google-gemini",
+            "Daemon config should overwrite the persisted STT provider"
+        )
+    }
+
+    func testSequentialSTTProviderPatchesIncludingGoogleGemini() {
+        // Patch deepgram then google-gemini — both should produce distinct payloads
+        store.setSTTProvider("deepgram")
+        waitForPatchCount(1)
+
+        store.setSTTProvider("google-gemini")
+        waitForPatchCount(2)
+
+        let patch = lastSTTPatch()
+        XCTAssertEqual(
+            patch?["provider"] as? String,
+            "google-gemini",
+            "Most recent STT patch should reflect the google-gemini provider"
+        )
+    }
+
+    // MARK: - sttApiKeyProviderName mapping (Google Gemini)
+
+    func testSTTApiKeyProviderNameResolvesGoogleGeminiToGemini() {
+        // google-gemini shares the "gemini" API key
+        let keyName = SettingsStore.sttApiKeyProviderName(for: "google-gemini")
+        XCTAssertEqual(keyName, "gemini")
+    }
+
     // MARK: - STT Key Ownership Semantics
 
     func testSharedKeyProviderIsNotExclusive() {
@@ -341,6 +438,35 @@ final class SettingsStoreVoiceServiceTests: XCTestCase {
         XCTAssertFalse(
             SettingsStore.sttKeyIsShared(for: "deepgram"),
             "deepgram owns its own key and must not be classified as shared"
+        )
+    }
+
+    func testGoogleGeminiKeyIsShared() {
+        // google-gemini maps to "gemini" — the credential is shared with
+        // other Gemini services, so sttKeyIsShared must be true.
+        XCTAssertTrue(
+            SettingsStore.sttKeyIsShared(for: "google-gemini"),
+            "google-gemini shares the 'gemini' key and must be classified as shared"
+        )
+    }
+
+    func testGoogleGeminiKeyIsNotExclusive() {
+        // google-gemini maps to "gemini" (not "google-gemini"), so the key
+        // is shared — sttKeyIsExclusive must be false.
+        XCTAssertFalse(
+            SettingsStore.sttKeyIsExclusive(for: "google-gemini"),
+            "google-gemini shares the 'gemini' key and must not be exclusive"
+        )
+    }
+
+    func testGoogleGeminiSharedKeyCannotBeResetThroughSTTFlow() {
+        // The UI checks sttKeyIsExclusive before allowing the reset action.
+        // For google-gemini the guard must prevent the reset because
+        // clearing the "gemini" key would break other Gemini services.
+        let allowReset = SettingsStore.sttKeyIsExclusive(for: "google-gemini")
+        XCTAssertFalse(
+            allowReset,
+            "The STT reset flow must not be allowed for google-gemini (shared key)"
         )
     }
 


### PR DESCRIPTION
## Summary
- Extend macOS SettingsStoreVoiceServiceTests for google-gemini key-ownership semantics
- Update transcribe SKILL.md to include Google Gemini in supported providers
- Update STT provider onboarding docs with google-gemini naming pattern

Part of plan: google-first-class-stt-provider.md (PR 4 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25152" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
