### PR TITLE
feat(clients): add google-gemini to STT fallback registry and registry tests

### DIFF
--- a/clients/ios/Tests/STTProviderRegistryIOSTests.swift
+++ b/clients/ios/Tests/STTProviderRegistryIOSTests.swift
@@ -78,6 +78,50 @@ final class STTProviderRegistryIOSTests: XCTestCase {
         )
     }
 
+    func testGoogleGeminiMapsToGeminiCredentialProvider() {
+        let registry = loadSTTProviderRegistry()
+        let entry = registry.provider(withId: "google-gemini")
+        XCTAssertEqual(
+            entry?.apiKeyProviderName, "gemini",
+            "google-gemini should map to 'gemini' credential provider"
+        )
+    }
+
+    /// Iterate over all registry entries to verify each provider has a
+    /// consistent credential-provider mapping. This provider-agnostic
+    /// approach reduces churn when new STT providers are added.
+    func testAllProvidersHaveExpectedCredentialMapping() {
+        let registry = loadSTTProviderRegistry()
+        let expectedMappings: [String: String] = [
+            "openai-whisper": "openai",
+            "deepgram": "deepgram",
+            "google-gemini": "gemini",
+        ]
+        for provider in registry.providers {
+            if let expected = expectedMappings[provider.id] {
+                XCTAssertEqual(
+                    provider.apiKeyProviderName, expected,
+                    "Provider '\(provider.id)' should map to '\(expected)' credential provider"
+                )
+            }
+        }
+    }
+
+    // MARK: - Google Provider
+
+    func testRegistryContainsGoogleGemini() {
+        let registry = loadSTTProviderRegistry()
+        let entry = registry.provider(withId: "google-gemini")
+        XCTAssertNotNil(entry, "Registry should contain a 'google-gemini' provider")
+        XCTAssertEqual(entry?.displayName, "Google Gemini")
+    }
+
+    func testGoogleGeminiUsesApiKeySetupMode() {
+        let registry = loadSTTProviderRegistry()
+        let entry = registry.provider(withId: "google-gemini")
+        XCTAssertEqual(entry?.setupMode, .apiKey, "google-gemini should use api-key setup mode")
+    }
+
     // MARK: - Default Provider Selection
 
     func testDefaultProviderIdMatchesRegistryEntry() {

--- a/clients/ios/Tests/STTProviderRegistryIOSTests.swift
+++ b/clients/ios/Tests/STTProviderRegistryIOSTests.swift
@@ -98,12 +98,14 @@ final class STTProviderRegistryIOSTests: XCTestCase {
             "google-gemini": "gemini",
         ]
         for provider in registry.providers {
-            if let expected = expectedMappings[provider.id] {
-                XCTAssertEqual(
-                    provider.apiKeyProviderName, expected,
-                    "Provider '\(provider.id)' should map to '\(expected)' credential provider"
-                )
+            guard let expected = expectedMappings[provider.id] else {
+                XCTFail("Provider '\(provider.id)' has no expected mapping — add it to expectedMappings")
+                continue
             }
+            XCTAssertEqual(
+                provider.apiKeyProviderName, expected,
+                "Provider '\(provider.id)' should map to '\(expected)' credential provider"
+            )
         }
     }
 

--- a/clients/shared/Utilities/STTProviderRegistry.swift
+++ b/clients/shared/Utilities/STTProviderRegistry.swift
@@ -94,6 +94,14 @@ private let fallbackRegistry = STTProviderRegistry(
             setupHint: "Enter your Deepgram API key to enable speech-to-text.",
             apiKeyProviderName: "deepgram"
         ),
+        STTProviderCatalogEntry(
+            id: "google-gemini",
+            displayName: "Google Gemini",
+            subtitle: "Multimodal speech-to-text powered by Google Gemini. Requires a Gemini API key.",
+            setupMode: .apiKey,
+            setupHint: "Enter your Gemini API key to enable Google Gemini transcription.",
+            apiKeyProviderName: "gemini"
+        ),
     ]
 )
 


### PR DESCRIPTION
## Summary
- Add google-gemini entry to STT fallback registry with gemini credential provider mapping
- Extend iOS STT registry tests with Google provider assertions and credential mapping coverage

Part of plan: google-first-class-stt-provider.md (PR 3 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25153" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
