### PR TITLE
Add Google Gemini as first-class STT provider

### DIFF
--- a/assistant/docs/stt-provider-onboarding.md
+++ b/assistant/docs/stt-provider-onboarding.md
@@ -8,8 +8,8 @@ Step-by-step guide for adding a new speech-to-text provider to the assistant. Fo
 
 Add a new entry to the `CATALOG` map with:
 
-- `id` — a unique `SttProviderId` string (e.g. `"google-cloud"`).
-- `credentialProvider` — the credential-store key name used by `getProviderKeyAsync` to retrieve the API key. If the provider shares an API key with another service (e.g. `openai-whisper` shares the `"openai"` key), reuse that name; otherwise use the provider's own name.
+- `id` — a unique `SttProviderId` string (e.g. `"google-gemini"`).
+- `credentialProvider` — the credential-store key name used by `getProviderKeyAsync` to retrieve the API key. If the provider shares an API key with another service (e.g. `openai-whisper` shares the `"openai"` key, or `google-gemini` shares the `"gemini"` key), reuse that name; otherwise use the provider's own name (e.g. `"deepgram"` maps to `"deepgram"`).
 - `supportedBoundaries` — the set of `SttBoundaryId` values the provider supports (currently only `"daemon-batch"` exists).
 - `telephonyMode` — how the provider participates in real-time telephony STT: `"realtime-ws"`, `"batch-only"`, or `"none"`.
 
@@ -33,11 +33,11 @@ The `services.stt.providers` map uses a sparse `z.record(z.string(), ...)` schem
 
 **File:** `src/stt/daemon-batch-transcriber.ts`
 
-1. Create a new `BatchTranscriber` implementation class (e.g. `GoogleCloudBatchTranscriber`) alongside `WhisperBatchTranscriber` and `DeepgramBatchTranscriber`.
+1. Create a new `BatchTranscriber` implementation class (e.g. `GoogleGeminiBatchTranscriber`) alongside `WhisperBatchTranscriber` and `DeepgramBatchTranscriber`.
 2. Implement the `transcribe(request)` method using a lazy-imported provider module (follow the pattern in the existing adapters).
 3. Add a `case` branch in `createDaemonBatchTranscriber()` for the new `SttProviderId`. The exhaustive `never` check at the bottom of the switch ensures a compile error if this step is skipped.
 
-If the provider needs a new REST client module, add it under `src/providers/speech-to-text/` following the pattern of `openai-whisper.ts` and `deepgram.ts`.
+If the provider needs a new REST client module, add it under `src/providers/speech-to-text/` following the pattern of `openai-whisper.ts`, `deepgram.ts`, and `google-gemini.ts`.
 
 ## 5. Credential plumbing
 
@@ -61,6 +61,16 @@ Add a new entry to the `providers` array with the following fields:
 | `setupMode`          | `"api-key"` (inline key field) or `"cli"` (instructions-only).           |
 | `setupHint`          | Brief guidance shown during setup.                                       |
 | `apiKeyProviderName` | Must match the `credentialProvider` value from the daemon catalog entry. |
+
+**Naming/mapping examples:**
+
+| Provider ID      | `credentialProvider` / `apiKeyProviderName` | Key ownership |
+| ---------------- | ------------------------------------------- | ------------- |
+| `openai-whisper` | `openai`                                    | shared        |
+| `deepgram`       | `deepgram`                                  | exclusive     |
+| `google-gemini`  | `gemini`                                    | shared        |
+
+When the provider ID differs from the credential provider name (e.g. `google-gemini` maps to `gemini`), the key is **shared** with other services that use the same credential. The `sttKeyIsExclusive` / `sttKeyIsShared` helpers in the macOS settings layer derive this automatically from the catalog.
 
 Insertion order in the JSON array must match the daemon catalog insertion order.
 
@@ -101,4 +111,4 @@ Before submitting the PR, grep for any accidental coupling between the two STT c
 - **`services.stt`** — controls daemon batch and client service-first STT provider selection. Configured under the Speech-to-Text section in Settings.
 - **`calls.voice.transcriptionProvider`** — controls telephony-native STT (Twilio ConversationRelay). Configured separately under the Calls/Voice section.
 
-These are independent config paths with different provider sets and runtime boundaries. A new `services.stt` provider should never modify `calls.voice` config or vice versa. The prepared dark path for telephony cutover (see ARCHITECTURE.md) is the designated seam for future unification — do not wire a new provider into both paths simultaneously.
+These are independent config paths with different provider sets and runtime boundaries. A new `services.stt` provider should never modify `calls.voice` config or vice versa. For example, `google-gemini` is registered only under `services.stt` and has no effect on `calls.voice.transcriptionProvider`. The prepared dark path for telephony cutover (see ARCHITECTURE.md) is the designated seam for future unification — do not wire a new provider into both paths simultaneously.

--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -1251,6 +1251,23 @@ describe("AssistantConfigSchema", () => {
     expect(result.services.stt.mode).toBe("your-own");
   });
 
+  test("accepts google-gemini as services.stt.provider", () => {
+    const result = AssistantConfigSchema.parse({
+      services: { stt: { provider: "google-gemini" } },
+    });
+    expect(result.services.stt.provider).toBe("google-gemini");
+    expect(result.services.stt.mode).toBe("your-own");
+  });
+
+  test("applies services.stt structural defaults when google-gemini provider is explicit", () => {
+    const result = AssistantConfigSchema.parse({
+      services: { stt: { provider: "google-gemini" } },
+    });
+    expect(result.services.stt.mode).toBe("your-own");
+    expect(result.services.stt.provider).toBe("google-gemini");
+    expect(result.services.stt.providers).toEqual({});
+  });
+
   test("accepts valid services.stt.providers.deepgram overrides", () => {
     const result = AssistantConfigSchema.parse({
       services: {

--- a/assistant/src/config/bundled-skills/transcribe/SKILL.md
+++ b/assistant/src/config/bundled-skills/transcribe/SKILL.md
@@ -8,7 +8,7 @@ metadata:
     display-name: "Transcribe"
 ---
 
-Transcribe audio and video files using the configured speech-to-text provider. Supports multiple STT providers including OpenAI Whisper and Deepgram — the active provider is selected in Settings under Speech-to-Text (`services.stt`).
+Transcribe audio and video files using the configured speech-to-text provider. Supports multiple STT providers including OpenAI Whisper, Deepgram, and Google Gemini — the active provider is selected in Settings under Speech-to-Text (`services.stt`).
 
 ## Usage Notes
 

--- a/assistant/src/config/schemas/stt.ts
+++ b/assistant/src/config/schemas/stt.ts
@@ -4,14 +4,18 @@ import { z } from "zod";
  * Valid STT provider identifiers. New providers append here and register
  * an adapter.
  */
-export const VALID_STT_PROVIDERS = ["openai-whisper", "deepgram"] as const;
+export const VALID_STT_PROVIDERS = [
+  "openai-whisper",
+  "deepgram",
+  "google-gemini",
+] as const;
 
 /**
  * Sparse provider config map under `services.stt.providers`.
  *
  * This is a forward-compatible record that accepts any provider ID as key
  * with an object value. All provider entries — known (`openai-whisper`,
- * `deepgram`) and unknown — are accepted with generic object validation.
+ * `deepgram`, `google-gemini`) and unknown — are accepted with generic object validation.
  * Adding a new provider ID does not require a migration to seed
  * `services.stt.providers.<id>`.
  *

--- a/assistant/src/providers/speech-to-text/__tests__/provider-catalog.test.ts
+++ b/assistant/src/providers/speech-to-text/__tests__/provider-catalog.test.ts
@@ -22,6 +22,7 @@ describe("STT provider catalog", () => {
     const ids = listProviderIds();
     expect(ids).toContain("openai-whisper");
     expect(ids).toContain("deepgram");
+    expect(ids).toContain("google-gemini");
   });
 
   test("listProviderIds returns IDs in deterministic insertion order", () => {
@@ -48,9 +49,10 @@ describe("STT provider catalog", () => {
 
   test("listCredentialProviderNames includes expected providers", () => {
     const names = listCredentialProviderNames();
-    // openai-whisper maps to "openai", deepgram maps to "deepgram"
+    // openai-whisper maps to "openai", deepgram maps to "deepgram", google-gemini maps to "gemini"
     expect(names).toContain("openai");
     expect(names).toContain("deepgram");
+    expect(names).toContain("gemini");
   });
 
   test("listCredentialProviderNames returns names in deterministic order", () => {
@@ -89,6 +91,7 @@ describe("STT provider catalog", () => {
   test("supportsBoundary returns true for supported boundaries", () => {
     expect(supportsBoundary("openai-whisper", "daemon-batch")).toBe(true);
     expect(supportsBoundary("deepgram", "daemon-batch")).toBe(true);
+    expect(supportsBoundary("google-gemini", "daemon-batch")).toBe(true);
   });
 
   test("supportsBoundary returns false for unknown provider IDs", () => {
@@ -105,6 +108,7 @@ describe("STT provider catalog", () => {
   test("getCredentialProvider returns correct mapping", () => {
     expect(getCredentialProvider("openai-whisper")).toBe("openai");
     expect(getCredentialProvider("deepgram")).toBe("deepgram");
+    expect(getCredentialProvider("google-gemini")).toBe("gemini");
   });
 
   test("getCredentialProvider returns undefined for unknown ID", () => {

--- a/assistant/src/providers/speech-to-text/__tests__/resolve.test.ts
+++ b/assistant/src/providers/speech-to-text/__tests__/resolve.test.ts
@@ -174,6 +174,50 @@ describe("resolveBatchTranscriber", () => {
     expect(transcriber!.providerId).toBe("deepgram");
     expect(transcriber!.boundaryId).toBe("daemon-batch");
   });
+
+  // -------------------------------------------------------------------------
+  // Google Gemini provider resolution
+  // -------------------------------------------------------------------------
+
+  test("returns a BatchTranscriber when google-gemini is configured and credentials are available", async () => {
+    mockProviderKeys["gemini"] = "gemini-test-key";
+    mockConfig = buildConfig({ provider: "google-gemini" });
+
+    const transcriber = await resolveBatchTranscriber();
+
+    expect(transcriber).not.toBeNull();
+    expect(transcriber!.providerId).toBe("google-gemini");
+    expect(transcriber!.boundaryId).toBe("daemon-batch");
+  });
+
+  test("returns null when google-gemini is configured but no credentials exist", async () => {
+    mockProviderKeys = {}; // no keys
+    mockConfig = buildConfig({ provider: "google-gemini" });
+
+    const transcriber = await resolveBatchTranscriber();
+
+    expect(transcriber).toBeNull();
+  });
+
+  test("google-gemini uses 'gemini' credential key, not 'openai' or 'deepgram'", async () => {
+    // Only openai key is set — google-gemini should NOT resolve
+    mockProviderKeys["openai"] = "sk-test-key";
+    mockConfig = buildConfig({ provider: "google-gemini" });
+
+    const transcriber = await resolveBatchTranscriber();
+
+    expect(transcriber).toBeNull();
+  });
+
+  test("resolved google-gemini transcriber has stable provider identity", async () => {
+    mockProviderKeys["gemini"] = "gemini-identity-test";
+    mockConfig = buildConfig({ provider: "google-gemini" });
+
+    const transcriber = await resolveBatchTranscriber();
+
+    expect(transcriber!.providerId).toBe("google-gemini");
+    expect(transcriber!.boundaryId).toBe("daemon-batch");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -246,5 +290,35 @@ describe("resolveTelephonySttCapability", () => {
     const result = await resolveTelephonySttCapability();
 
     expect(result.status).toBe("unconfigured");
+  });
+
+  // -------------------------------------------------------------------------
+  // Google Gemini telephony capability
+  // -------------------------------------------------------------------------
+
+  test("returns 'supported' for google-gemini with batch-only telephonyMode", async () => {
+    mockProviderKeys["gemini"] = "gemini-telephony-test";
+    mockConfig = buildConfig({ provider: "google-gemini" });
+
+    const result = await resolveTelephonySttCapability();
+
+    expect(result.status).toBe("supported");
+    if (result.status === "supported") {
+      expect(result.providerId).toBe("google-gemini");
+      expect(result.telephonyMode).toBe("batch-only");
+    }
+  });
+
+  test("returns 'missing-credentials' for google-gemini without a gemini key", async () => {
+    mockProviderKeys = {};
+    mockConfig = buildConfig({ provider: "google-gemini" });
+
+    const result = await resolveTelephonySttCapability();
+
+    expect(result.status).toBe("missing-credentials");
+    if (result.status === "missing-credentials") {
+      expect(result.providerId).toBe("google-gemini");
+      expect(result.credentialProvider).toBe("gemini");
+    }
   });
 });

--- a/assistant/src/providers/speech-to-text/google-gemini.test.ts
+++ b/assistant/src/providers/speech-to-text/google-gemini.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import { GoogleGeminiProvider } from "./google-gemini.js";
+
+const TEST_API_KEY = "google-test-key-for-unit-tests";
+
+// ---------------------------------------------------------------------------
+// Mock setup — replace @google/genai's GoogleGenAI before each test
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a mock GoogleGenAI constructor whose `models.generateContent`
+ * resolves to the given value or rejects with the given error.
+ */
+function mockGenAI(
+  behaviour: { response: { text?: string } } | { error: Error },
+) {
+  const generateContent = mock(() => {
+    if ("error" in behaviour) {
+      return Promise.reject(behaviour.error);
+    }
+    return Promise.resolve(behaviour.response);
+  });
+
+  const Constructor = mock((_opts: unknown) => ({
+    models: { generateContent },
+  }));
+
+  return { Constructor, generateContent };
+}
+
+// We need to intercept the GoogleGenAI constructor at the module level.
+// Since the provider uses `new GoogleGenAI(...)`, we mock the module.
+let mockGenerateContent: ReturnType<typeof mock>;
+
+/**
+ * Helper: create a provider that uses a stubbed GoogleGenAI client.
+ * We replace the private `client` field after construction.
+ */
+function createProviderWithMock(
+  behaviour: { response: { text?: string } } | { error: Error },
+  options?: { model?: string; baseUrl?: string },
+): GoogleGeminiProvider {
+  const provider = new GoogleGeminiProvider(TEST_API_KEY, options);
+
+  const mocked = mockGenAI(behaviour);
+  mockGenerateContent = mocked.generateContent;
+
+  // Replace the internal client with our mock
+  (provider as unknown as { client: unknown }).client = {
+    models: { generateContent: mocked.generateContent },
+  };
+
+  return provider;
+}
+
+describe("GoogleGeminiProvider", () => {
+  // -----------------------------------------------------------------------
+  // Success path
+  // -----------------------------------------------------------------------
+
+  test("successful transcription returns trimmed text", async () => {
+    const provider = createProviderWithMock({
+      response: { text: "  Hello from Gemini!  " },
+    });
+
+    const result = await provider.transcribe(
+      Buffer.from("fake-audio"),
+      "audio/wav",
+    );
+
+    expect(result).toEqual({ text: "Hello from Gemini!" });
+  });
+
+  test("passes audio as base64 inlineData with correct mimeType", async () => {
+    const provider = createProviderWithMock({
+      response: { text: "transcribed" },
+    });
+
+    const audioData = Buffer.from("test-audio-bytes");
+    await provider.transcribe(audioData, "audio/ogg");
+
+    expect(mockGenerateContent).toHaveBeenCalledTimes(1);
+
+    const call = (mockGenerateContent as ReturnType<typeof mock>).mock
+      .calls[0][0] as {
+      contents: Array<{
+        parts: Array<{ inlineData?: { mimeType: string; data: string } }>;
+      }>;
+    };
+
+    const inlineData = call.contents[0].parts[0].inlineData;
+    expect(inlineData?.mimeType).toBe("audio/ogg");
+    expect(inlineData?.data).toBe(audioData.toString("base64"));
+  });
+
+  test("uses default model gemini-2.0-flash", async () => {
+    const provider = createProviderWithMock({
+      response: { text: "text" },
+    });
+
+    await provider.transcribe(Buffer.from("audio"), "audio/wav");
+
+    const call = (mockGenerateContent as ReturnType<typeof mock>).mock
+      .calls[0][0] as { model: string };
+    expect(call.model).toBe("gemini-2.0-flash");
+  });
+
+  test("uses custom model when specified", async () => {
+    const provider = createProviderWithMock(
+      { response: { text: "text" } },
+      { model: "gemini-2.0-pro" },
+    );
+
+    await provider.transcribe(Buffer.from("audio"), "audio/wav");
+
+    const call = (mockGenerateContent as ReturnType<typeof mock>).mock
+      .calls[0][0] as { model: string };
+    expect(call.model).toBe("gemini-2.0-pro");
+  });
+
+  // -----------------------------------------------------------------------
+  // Empty transcript fallback
+  // -----------------------------------------------------------------------
+
+  test("returns empty text when response text is empty string", async () => {
+    const provider = createProviderWithMock({
+      response: { text: "" },
+    });
+
+    const result = await provider.transcribe(
+      Buffer.from("silence"),
+      "audio/wav",
+    );
+
+    expect(result).toEqual({ text: "" });
+  });
+
+  test("returns empty text when response text is undefined", async () => {
+    const provider = createProviderWithMock({
+      response: { text: undefined },
+    });
+
+    const result = await provider.transcribe(
+      Buffer.from("silence"),
+      "audio/wav",
+    );
+
+    expect(result).toEqual({ text: "" });
+  });
+
+  // -----------------------------------------------------------------------
+  // Error propagation
+  // -----------------------------------------------------------------------
+
+  test("API error with status code includes status in message", async () => {
+    const apiError = Object.assign(new Error("Invalid API key"), {
+      status: 401,
+    });
+
+    const provider = createProviderWithMock({ error: apiError });
+
+    await expect(
+      provider.transcribe(Buffer.from("fake-audio"), "audio/wav"),
+    ).rejects.toThrow("Google Gemini API error (401)");
+  });
+
+  test("API error with 429 status propagates for rate-limit detection", async () => {
+    const apiError = Object.assign(new Error("Resource exhausted"), {
+      status: 429,
+    });
+
+    const provider = createProviderWithMock({ error: apiError });
+
+    await expect(
+      provider.transcribe(Buffer.from("fake-audio"), "audio/wav"),
+    ).rejects.toThrow("Google Gemini API error (429)");
+  });
+
+  test("API error without status code still throws descriptive error", async () => {
+    const networkError = new Error("Network connection failed");
+
+    const provider = createProviderWithMock({ error: networkError });
+
+    await expect(
+      provider.transcribe(Buffer.from("fake-audio"), "audio/wav"),
+    ).rejects.toThrow("Google Gemini API error: Network connection failed");
+  });
+
+  test("AbortError is re-thrown as-is (not wrapped)", async () => {
+    const abortError = new DOMException(
+      "The operation was aborted",
+      "AbortError",
+    );
+
+    const provider = createProviderWithMock({ error: abortError });
+
+    try {
+      await provider.transcribe(Buffer.from("audio"), "audio/wav");
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect((err as Error).name).toBe("AbortError");
+      expect(err).toBe(abortError);
+    }
+  });
+
+  test("error message body is truncated to 300 characters", async () => {
+    const longMessage = "x".repeat(500);
+    const apiError = Object.assign(new Error(longMessage), {
+      status: 500,
+    });
+
+    const provider = createProviderWithMock({ error: apiError });
+
+    try {
+      await provider.transcribe(Buffer.from("audio"), "audio/wav");
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      const msg = (err as Error).message;
+      expect(msg).toContain("Google Gemini API error (500)");
+      // The body portion should be at most 300 chars
+      const bodyPart = msg.replace("Google Gemini API error (500): ", "");
+      expect(bodyPart.length).toBeLessThanOrEqual(300);
+    }
+  });
+});

--- a/assistant/src/providers/speech-to-text/google-gemini.ts
+++ b/assistant/src/providers/speech-to-text/google-gemini.ts
@@ -1,0 +1,101 @@
+import { GoogleGenAI } from "@google/genai";
+
+import type { SttTranscribeResult } from "../../stt/types.js";
+
+const DEFAULT_MODEL = "gemini-2.0-flash";
+const DEFAULT_TIMEOUT_MS = 60_000;
+
+const TRANSCRIPTION_PROMPT =
+  "Transcribe the audio exactly as spoken. Return only the transcribed text with no additional commentary, labels, or formatting.";
+
+// ---------------------------------------------------------------------------
+// Options
+// ---------------------------------------------------------------------------
+
+export interface GoogleGeminiProviderOptions {
+  /** Gemini model to use (default: "gemini-2.0-flash"). */
+  model?: string;
+  /** Override the Google AI API base URL (useful for proxies or on-prem). */
+  baseUrl?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
+/**
+ * Google Gemini batch STT provider.
+ *
+ * Encodes audio as base64 inline data, sends it to the Gemini
+ * `models.generateContent` endpoint with a transcription-focused prompt,
+ * and returns a normalised `{ text }` result compatible with the daemon
+ * batch transcription boundary.
+ */
+export class GoogleGeminiProvider {
+  private readonly client: GoogleGenAI;
+  private readonly model: string;
+
+  constructor(apiKey: string, options: GoogleGeminiProviderOptions = {}) {
+    this.model = options.model ?? DEFAULT_MODEL;
+
+    this.client = options.baseUrl
+      ? new GoogleGenAI({
+          apiKey,
+          httpOptions: { baseUrl: options.baseUrl },
+        })
+      : new GoogleGenAI({ apiKey });
+  }
+
+  async transcribe(
+    audio: Buffer,
+    mimeType: string,
+    signal?: AbortSignal,
+  ): Promise<SttTranscribeResult> {
+    const base64Audio = audio.toString("base64");
+    const effectiveSignal = signal ?? AbortSignal.timeout(DEFAULT_TIMEOUT_MS);
+
+    try {
+      const response = await this.client.models.generateContent({
+        model: this.model,
+        contents: [
+          {
+            role: "user",
+            parts: [
+              {
+                inlineData: {
+                  mimeType,
+                  data: base64Audio,
+                },
+              },
+              { text: TRANSCRIPTION_PROMPT },
+            ],
+          },
+        ],
+        config: {
+          abortSignal: effectiveSignal,
+        },
+      });
+
+      const text = response.text?.trim() ?? "";
+      return { text };
+    } catch (error: unknown) {
+      // Re-throw AbortError as-is so normalizeSttError() maps it to "timeout"
+      if (error instanceof Error && error.name === "AbortError") {
+        throw error;
+      }
+
+      // Preserve status code context for normalizeSttError() category mapping.
+      // The @google/genai SDK throws ApiError with a `status` property.
+      const status = (error as { status?: number }).status;
+      const message = error instanceof Error ? error.message : String(error);
+
+      if (status != null) {
+        throw new Error(
+          `Google Gemini API error (${status}): ${message.slice(0, 300)}`,
+        );
+      }
+
+      throw new Error(`Google Gemini API error: ${message.slice(0, 300)}`);
+    }
+  }
+}

--- a/assistant/src/providers/speech-to-text/provider-catalog.ts
+++ b/assistant/src/providers/speech-to-text/provider-catalog.ts
@@ -84,6 +84,15 @@ const CATALOG: ReadonlyMap<SttProviderId, SttProviderEntry> = new Map<
       telephonyMode: "realtime-ws",
     },
   ],
+  [
+    "google-gemini",
+    {
+      id: "google-gemini",
+      credentialProvider: "gemini",
+      supportedBoundaries: new Set<SttBoundaryId>(["daemon-batch"]),
+      telephonyMode: "batch-only",
+    },
+  ],
 ]);
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/stt/__tests__/daemon-batch-transcriber.test.ts
+++ b/assistant/src/stt/__tests__/daemon-batch-transcriber.test.ts
@@ -32,6 +32,19 @@ mock.module("../../providers/speech-to-text/deepgram.js", () => ({
   },
 }));
 
+let mockGeminiTranscribeResult: { text: string } = { text: "" };
+let mockGeminiTranscribeError: Error | null = null;
+
+mock.module("../../providers/speech-to-text/google-gemini.js", () => ({
+  GoogleGeminiProvider: class MockGoogleGeminiProvider {
+    constructor(_apiKey: string) {}
+    async transcribe(_audio: Buffer, _mimeType: string, _signal?: AbortSignal) {
+      if (mockGeminiTranscribeError) throw mockGeminiTranscribeError;
+      return mockGeminiTranscribeResult;
+    }
+  },
+}));
+
 // Dynamic import so mocks are active when the module loads.
 const { createDaemonBatchTranscriber, normalizeSttError } =
   await import("../daemon-batch-transcriber.js");
@@ -46,6 +59,8 @@ describe("createDaemonBatchTranscriber", () => {
     mockWhisperTranscribeError = null;
     mockDeepgramTranscribeResult = { text: "" };
     mockDeepgramTranscribeError = null;
+    mockGeminiTranscribeResult = { text: "" };
+    mockGeminiTranscribeError = null;
   });
 
   // -------------------------------------------------------------------------
@@ -214,6 +229,81 @@ describe("createDaemonBatchTranscriber", () => {
   test("returns null for deepgram when no API key is provided", () => {
     expect(createDaemonBatchTranscriber(null, "deepgram")).toBeNull();
     expect(createDaemonBatchTranscriber(undefined, "deepgram")).toBeNull();
+  });
+
+  // -------------------------------------------------------------------------
+  // Provider identity — Google Gemini
+  // -------------------------------------------------------------------------
+
+  test("reports providerId as google-gemini when created with google-gemini", () => {
+    const transcriber = createDaemonBatchTranscriber(
+      "gemini-test-key",
+      "google-gemini",
+    );
+    expect(transcriber).not.toBeNull();
+    expect(transcriber!.providerId).toBe("google-gemini");
+  });
+
+  test("reports boundaryId as daemon-batch for google-gemini", () => {
+    const transcriber = createDaemonBatchTranscriber(
+      "gemini-test-key",
+      "google-gemini",
+    );
+    expect(transcriber!.boundaryId).toBe("daemon-batch");
+  });
+
+  // -------------------------------------------------------------------------
+  // Successful transcription — Google Gemini
+  // -------------------------------------------------------------------------
+
+  test("delegates transcription to the Google Gemini provider", async () => {
+    mockGeminiTranscribeResult = { text: "Hello from Gemini" };
+
+    const transcriber = createDaemonBatchTranscriber(
+      "gemini-test-key",
+      "google-gemini",
+    );
+    const result = await transcriber!.transcribe({
+      audio: Buffer.from("fake-audio"),
+      mimeType: "audio/ogg",
+    });
+
+    expect(result).toEqual({ text: "Hello from Gemini" });
+  });
+
+  // -------------------------------------------------------------------------
+  // Error propagation — Google Gemini
+  // -------------------------------------------------------------------------
+
+  test("propagates Google Gemini errors unchanged", async () => {
+    const original = new Error(
+      "Google Gemini API error (401): Invalid credentials",
+    );
+    mockGeminiTranscribeError = original;
+
+    const transcriber = createDaemonBatchTranscriber(
+      "gemini-test-key",
+      "google-gemini",
+    );
+
+    try {
+      await transcriber!.transcribe({
+        audio: Buffer.from("audio"),
+        mimeType: "audio/wav",
+      });
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBe(original);
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Null on missing key — Google Gemini
+  // -------------------------------------------------------------------------
+
+  test("returns null for google-gemini when no API key is provided", () => {
+    expect(createDaemonBatchTranscriber(null, "google-gemini")).toBeNull();
+    expect(createDaemonBatchTranscriber(undefined, "google-gemini")).toBeNull();
   });
 });
 

--- a/assistant/src/stt/daemon-batch-transcriber.ts
+++ b/assistant/src/stt/daemon-batch-transcriber.ts
@@ -9,6 +9,7 @@
  * Supported daemon-batch providers:
  * - OpenAI Whisper (`openai-whisper`)
  * - Deepgram (`deepgram`)
+ * - Google Gemini (`google-gemini`)
  */
 
 import type {
@@ -88,6 +89,38 @@ class DeepgramBatchTranscriber implements BatchTranscriber {
 }
 
 // ---------------------------------------------------------------------------
+// Google Gemini adapter — implements BatchTranscriber on top of the Google
+// Gemini multimodal provider.
+// ---------------------------------------------------------------------------
+
+/**
+ * Wraps `GoogleGeminiProvider` behind the `BatchTranscriber` contract.
+ *
+ * Same error-propagation semantics as WhisperBatchTranscriber: raw provider
+ * errors pass through unchanged.
+ */
+class GoogleGeminiBatchTranscriber implements BatchTranscriber {
+  readonly providerId = "google-gemini" as const;
+  readonly boundaryId = "daemon-batch" as const;
+
+  private readonly apiKey: string;
+
+  constructor(apiKey: string) {
+    this.apiKey = apiKey;
+  }
+
+  async transcribe(
+    request: SttTranscribeRequest,
+  ): Promise<SttTranscribeResult> {
+    const { GoogleGeminiProvider } =
+      await import("../providers/speech-to-text/google-gemini.js");
+    const provider = new GoogleGeminiProvider(this.apiKey);
+
+    return provider.transcribe(request.audio, request.mimeType, request.signal);
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Error normalization
 // ---------------------------------------------------------------------------
 
@@ -150,6 +183,8 @@ export function createDaemonBatchTranscriber(
       return new WhisperBatchTranscriber(apiKey);
     case "deepgram":
       return new DeepgramBatchTranscriber(apiKey);
+    case "google-gemini":
+      return new GoogleGeminiBatchTranscriber(apiKey);
     default: {
       // Exhaustive check — compile error if a new SttProviderId is added
       // without a corresponding case here.

--- a/assistant/src/stt/types.ts
+++ b/assistant/src/stt/types.ts
@@ -15,7 +15,7 @@
  * Canonical provider identifiers for daemon-hosted batch STT backends.
  * Extend this union as new providers are integrated.
  */
-export type SttProviderId = "openai-whisper" | "deepgram";
+export type SttProviderId = "openai-whisper" | "deepgram" | "google-gemini";
 
 /**
  * Telephony-specific STT support mode.

--- a/clients/ios/Tests/STTProviderRegistryIOSTests.swift
+++ b/clients/ios/Tests/STTProviderRegistryIOSTests.swift
@@ -78,6 +78,52 @@ final class STTProviderRegistryIOSTests: XCTestCase {
         )
     }
 
+    func testGoogleGeminiMapsToGeminiCredentialProvider() {
+        let registry = loadSTTProviderRegistry()
+        let entry = registry.provider(withId: "google-gemini")
+        XCTAssertEqual(
+            entry?.apiKeyProviderName, "gemini",
+            "google-gemini should map to 'gemini' credential provider"
+        )
+    }
+
+    /// Iterate over all registry entries to verify each provider has a
+    /// consistent credential-provider mapping. This provider-agnostic
+    /// approach reduces churn when new STT providers are added.
+    func testAllProvidersHaveExpectedCredentialMapping() {
+        let registry = loadSTTProviderRegistry()
+        let expectedMappings: [String: String] = [
+            "openai-whisper": "openai",
+            "deepgram": "deepgram",
+            "google-gemini": "gemini",
+        ]
+        for provider in registry.providers {
+            guard let expected = expectedMappings[provider.id] else {
+                XCTFail("Provider '\(provider.id)' has no expected mapping — add it to expectedMappings")
+                continue
+            }
+            XCTAssertEqual(
+                provider.apiKeyProviderName, expected,
+                "Provider '\(provider.id)' should map to '\(expected)' credential provider"
+            )
+        }
+    }
+
+    // MARK: - Google Provider
+
+    func testRegistryContainsGoogleGemini() {
+        let registry = loadSTTProviderRegistry()
+        let entry = registry.provider(withId: "google-gemini")
+        XCTAssertNotNil(entry, "Registry should contain a 'google-gemini' provider")
+        XCTAssertEqual(entry?.displayName, "Google Gemini")
+    }
+
+    func testGoogleGeminiUsesApiKeySetupMode() {
+        let registry = loadSTTProviderRegistry()
+        let entry = registry.provider(withId: "google-gemini")
+        XCTAssertEqual(entry?.setupMode, .apiKey, "google-gemini should use api-key setup mode")
+    }
+
     // MARK: - Default Provider Selection
 
     func testDefaultProviderIdMatchesRegistryEntry() {

--- a/clients/macos/vellum-assistantTests/SettingsStoreVoiceServiceTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsStoreVoiceServiceTests.swift
@@ -311,6 +311,103 @@ final class SettingsStoreVoiceServiceTests: XCTestCase {
         )
     }
 
+    // MARK: - setSTTProvider with Google Gemini
+
+    func testSetSTTProviderGoogleGeminiEmitsExpectedPatch() {
+        store.setSTTProvider("google-gemini")
+
+        waitForPatchCount(1)
+
+        let patch = lastSTTPatch()
+        XCTAssertNotNil(patch, "expected a services.stt patch payload for google-gemini")
+        XCTAssertEqual(patch?["provider"] as? String, "google-gemini")
+    }
+
+    func testSetSTTProviderGoogleGeminiDoesNotEmitTTSPatch() {
+        store.setSTTProvider("google-gemini")
+
+        waitForPatchCount(1)
+
+        let ttsPatch = lastTTSPatch()
+        XCTAssertNil(ttsPatch, "setSTTProvider(google-gemini) must not emit a TTS patch")
+    }
+
+    func testApplyDaemonConfigSyncsGoogleGeminiSTTProvider() {
+        UserDefaults.standard.removeObject(forKey: "sttProvider")
+
+        let config: [String: Any] = [
+            "services": [
+                "stt": [
+                    "provider": "google-gemini"
+                ]
+            ]
+        ]
+
+        mockSettingsClient.fetchConfigResponse = config
+        let expectation = XCTestExpectation(description: "config loaded")
+        Task {
+            await store.loadConfigFromDaemon()
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 2.0)
+
+        XCTAssertEqual(
+            UserDefaults.standard.string(forKey: "sttProvider"),
+            "google-gemini"
+        )
+    }
+
+    func testApplyDaemonConfigSyncsGoogleGeminiWithExistingDeepgramSTT() {
+        // Start with deepgram persisted, then receive google-gemini from the daemon
+        UserDefaults.standard.set("deepgram", forKey: "sttProvider")
+
+        let config: [String: Any] = [
+            "services": [
+                "stt": [
+                    "provider": "google-gemini"
+                ]
+            ]
+        ]
+
+        mockSettingsClient.fetchConfigResponse = config
+        let expectation = XCTestExpectation(description: "config loaded")
+        Task {
+            await store.loadConfigFromDaemon()
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 2.0)
+
+        XCTAssertEqual(
+            UserDefaults.standard.string(forKey: "sttProvider"),
+            "google-gemini",
+            "Daemon config should overwrite the persisted STT provider"
+        )
+    }
+
+    func testSequentialSTTProviderPatchesIncludingGoogleGemini() {
+        // Patch deepgram then google-gemini — both should produce distinct payloads
+        store.setSTTProvider("deepgram")
+        waitForPatchCount(1)
+
+        store.setSTTProvider("google-gemini")
+        waitForPatchCount(2)
+
+        let patch = lastSTTPatch()
+        XCTAssertEqual(
+            patch?["provider"] as? String,
+            "google-gemini",
+            "Most recent STT patch should reflect the google-gemini provider"
+        )
+    }
+
+    // MARK: - sttApiKeyProviderName mapping (Google Gemini)
+
+    func testSTTApiKeyProviderNameResolvesGoogleGeminiToGemini() {
+        // google-gemini shares the "gemini" API key
+        let keyName = SettingsStore.sttApiKeyProviderName(for: "google-gemini")
+        XCTAssertEqual(keyName, "gemini")
+    }
+
     // MARK: - STT Key Ownership Semantics
 
     func testSharedKeyProviderIsNotExclusive() {
@@ -341,6 +438,35 @@ final class SettingsStoreVoiceServiceTests: XCTestCase {
         XCTAssertFalse(
             SettingsStore.sttKeyIsShared(for: "deepgram"),
             "deepgram owns its own key and must not be classified as shared"
+        )
+    }
+
+    func testGoogleGeminiKeyIsShared() {
+        // google-gemini maps to "gemini" — the credential is shared with
+        // other Gemini services, so sttKeyIsShared must be true.
+        XCTAssertTrue(
+            SettingsStore.sttKeyIsShared(for: "google-gemini"),
+            "google-gemini shares the 'gemini' key and must be classified as shared"
+        )
+    }
+
+    func testGoogleGeminiKeyIsNotExclusive() {
+        // google-gemini maps to "gemini" (not "google-gemini"), so the key
+        // is shared — sttKeyIsExclusive must be false.
+        XCTAssertFalse(
+            SettingsStore.sttKeyIsExclusive(for: "google-gemini"),
+            "google-gemini shares the 'gemini' key and must not be exclusive"
+        )
+    }
+
+    func testGoogleGeminiSharedKeyCannotBeResetThroughSTTFlow() {
+        // The UI checks sttKeyIsExclusive before allowing the reset action.
+        // For google-gemini the guard must prevent the reset because
+        // clearing the "gemini" key would break other Gemini services.
+        let allowReset = SettingsStore.sttKeyIsExclusive(for: "google-gemini")
+        XCTAssertFalse(
+            allowReset,
+            "The STT reset flow must not be allowed for google-gemini (shared key)"
         )
     }
 

--- a/clients/shared/Utilities/STTProviderRegistry.swift
+++ b/clients/shared/Utilities/STTProviderRegistry.swift
@@ -94,6 +94,14 @@ private let fallbackRegistry = STTProviderRegistry(
             setupHint: "Enter your Deepgram API key to enable speech-to-text.",
             apiKeyProviderName: "deepgram"
         ),
+        STTProviderCatalogEntry(
+            id: "google-gemini",
+            displayName: "Google Gemini",
+            subtitle: "Multimodal speech-to-text powered by Google Gemini. Requires a Gemini API key.",
+            setupMode: .apiKey,
+            setupHint: "Enter your Gemini API key to enable Google Gemini transcription.",
+            apiKeyProviderName: "gemini"
+        ),
     ]
 )
 

--- a/meta/stt-provider-catalog.json
+++ b/meta/stt-provider-catalog.json
@@ -16,6 +16,14 @@
       "setupMode": "api-key",
       "setupHint": "Enter your Deepgram API key to enable speech-to-text.",
       "apiKeyProviderName": "deepgram"
+    },
+    {
+      "id": "google-gemini",
+      "displayName": "Google Gemini",
+      "subtitle": "Multimodal speech-to-text powered by Google Gemini. Requires a Gemini API key.",
+      "setupMode": "api-key",
+      "setupHint": "Enter your Gemini API key to enable Google Gemini transcription.",
+      "apiKeyProviderName": "gemini"
     }
   ]
 }


### PR DESCRIPTION
## Summary
Adds Google Gemini as a third `services.stt` provider alongside `openai-whisper` and `deepgram`, wired through the existing provider-catalog architecture. Runtime selection remains config-driven and explicit. Telephony STT (`calls.voice.transcriptionProvider`) stays fully decoupled.

## Self-review result
PASS — all 3 review passes (external feedback, plan faithfulness, integration) returned PASS with no gaps.

## PRs merged into feature branch
- #25144: feat(stt): add Google Gemini batch transcription provider implementation
- #25149: feat(stt): register google-gemini in daemon catalog, config schema, and transcriber resolver
- #25153: feat(clients): add google-gemini to STT fallback registry and registry tests
- #25152: feat(stt): finalize macOS settings semantics and docs for google-gemini

Part of plan: google-first-class-stt-provider.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25154" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
