### PR TITLE
Use distinct pill colors for Clawhub and skills.sh skill badges

### DIFF
--- a/clients/shared/DesignSystem/Core/Feedback/VSkillTypePill.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VSkillTypePill.swift
@@ -32,7 +32,8 @@ public struct VSkillTypePill: View {
         var foregroundColor: Color {
             switch self {
             case .vellum: return VColor.primaryBase
-            case .clawhub, .skillssh: return VColor.funTeal
+            case .clawhub: return VColor.funTeal
+            case .skillssh: return VColor.funCoral
             case .custom: return VColor.funPurple
             case .other(_, _, let fg, _): return fg
             }
@@ -41,7 +42,8 @@ public struct VSkillTypePill: View {
         var backgroundColor: Color {
             switch self {
             case .vellum: return VColor.primaryBase.opacity(0.12)
-            case .clawhub, .skillssh: return VColor.funTeal.opacity(0.12)
+            case .clawhub: return VColor.funTeal.opacity(0.12)
+            case .skillssh: return VColor.funCoral.opacity(0.12)
             case .custom: return VColor.funPurple.opacity(0.12)
             case .other(_, _, _, let bg): return bg
             }


### PR DESCRIPTION
## Summary
- Give skills.sh pills a distinct coral color (`funCoral`) instead of sharing teal with Clawhub
- Clawhub keeps `funTeal`, skills.sh now uses `funCoral` for both foreground and background
- Visually distinguishes the two community skill sources in the UI
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25155" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
