### PR TITLE
fix: remove incorrect APIKeyManager credential check from isServiceConfigured

### DIFF
--- a/clients/ios/Tests/InputBarVoiceInputTests.swift
+++ b/clients/ios/Tests/InputBarVoiceInputTests.swift
@@ -341,13 +341,9 @@ final class InputBarVoiceInputTests: XCTestCase {
         adapter.authorizationStatus = .denied
         adapter.available = false
 
-        // Simulate STT provider configured via UserDefaults (provider + credential)
+        // Simulate STT provider configured via UserDefaults
         UserDefaults.standard.set("deepgram", forKey: "sttProvider")
-        APIKeyManager.shared.setAPIKey("test-key", provider: "deepgram")
-        defer {
-            UserDefaults.standard.removeObject(forKey: "sttProvider")
-            APIKeyManager.shared.deleteAPIKey(provider: "deepgram")
-        }
+        defer { UserDefaults.standard.removeObject(forKey: "sttProvider") }
 
         XCTAssertTrue(
             STTProviderRegistry.isServiceConfigured,
@@ -377,8 +373,6 @@ final class InputBarVoiceInputTests: XCTestCase {
 
         // Ensure no STT provider is configured
         UserDefaults.standard.removeObject(forKey: "sttProvider")
-        APIKeyManager.shared.deleteAPIKey(provider: "deepgram")
-        APIKeyManager.shared.deleteAPIKey(provider: "openai")
 
         XCTAssertFalse(
             STTProviderRegistry.isServiceConfigured,
@@ -417,13 +411,9 @@ final class InputBarVoiceInputTests: XCTestCase {
         adapter.authorizationStatus = .authorized
         adapter.available = true
 
-        // Simulate STT provider configured (provider + credential)
+        // Simulate STT provider configured
         UserDefaults.standard.set("openai-whisper", forKey: "sttProvider")
-        APIKeyManager.shared.setAPIKey("test-key", provider: "openai")
-        defer {
-            UserDefaults.standard.removeObject(forKey: "sttProvider")
-            APIKeyManager.shared.deleteAPIKey(provider: "openai")
-        }
+        defer { UserDefaults.standard.removeObject(forKey: "sttProvider") }
 
         XCTAssertTrue(STTProviderRegistry.isServiceConfigured)
 

--- a/clients/macos/vellum-assistantTests/VoiceInputManagerTests.swift
+++ b/clients/macos/vellum-assistantTests/VoiceInputManagerTests.swift
@@ -79,8 +79,6 @@ final class VoiceInputManagerTests: XCTestCase {
     override func tearDown() {
         // Clean up any STT provider configuration set during tests.
         UserDefaults.standard.removeObject(forKey: "sttProvider")
-        APIKeyManager.shared.deleteAPIKey(provider: "deepgram")
-        APIKeyManager.shared.deleteAPIKey(provider: "openai")
         manager = nil
         dictationClient = nil
         speechAdapter = nil
@@ -701,7 +699,6 @@ final class VoiceInputManagerTests: XCTestCase {
         }
 
         UserDefaults.standard.set("deepgram", forKey: "sttProvider")
-        APIKeyManager.shared.setAPIKey("test-key", provider: "deepgram")
         speechAdapter.stubbedAuthorizationStatus = .denied
         // Recognizer unavailable because speech is denied
         speechAdapter.stubbedIsRecognizerAvailable = false
@@ -729,7 +726,6 @@ final class VoiceInputManagerTests: XCTestCase {
         // handles transcription. This test does not depend on mic status
         // because it only checks that speech auth was not triggered.
         UserDefaults.standard.set("deepgram", forKey: "sttProvider")
-        APIKeyManager.shared.setAPIKey("test-key", provider: "deepgram")
         speechAdapter.stubbedAuthorizationStatus = .notDetermined
         speechAdapter.stubbedIsRecognizerAvailable = false
 
@@ -760,7 +756,6 @@ final class VoiceInputManagerTests: XCTestCase {
         guard micStatus == .authorized else { return }
 
         UserDefaults.standard.set("deepgram", forKey: "sttProvider")
-        APIKeyManager.shared.setAPIKey("test-key", provider: "deepgram")
         speechAdapter.stubbedAuthorizationStatus = .authorized
         speechAdapter.stubbedIsRecognizerAvailable = false
 
@@ -780,8 +775,6 @@ final class VoiceInputManagerTests: XCTestCase {
         // Existing behavior preserved: when no STT provider is configured
         // and speech recognition is denied, recording should be blocked.
         UserDefaults.standard.removeObject(forKey: "sttProvider")
-        APIKeyManager.shared.deleteAPIKey(provider: "deepgram")
-        APIKeyManager.shared.deleteAPIKey(provider: "openai")
         speechAdapter.stubbedAuthorizationStatus = .denied
 
         manager.toggleRecording()

--- a/clients/macos/vellum-assistantTests/VoiceModeManagerTests.swift
+++ b/clients/macos/vellum-assistantTests/VoiceModeManagerTests.swift
@@ -626,13 +626,9 @@ final class VoiceModeManagerTests: XCTestCase {
     /// When STT is configured and speech recognition is denied, voice mode
     /// should still activate successfully.
     func testActivation_sttConfigured_speechDenied_activates() {
-        // Simulate STT configured via UserDefaults (provider + credential)
+        // Simulate STT configured via UserDefaults
         UserDefaults.standard.set("deepgram", forKey: "sttProvider")
-        APIKeyManager.shared.setAPIKey("test-key", provider: "deepgram")
-        defer {
-            UserDefaults.standard.removeObject(forKey: "sttProvider")
-            APIKeyManager.shared.deleteAPIKey(provider: "deepgram")
-        }
+        defer { UserDefaults.standard.removeObject(forKey: "sttProvider") }
 
         let speechAdapter = MockSpeechRecognizerAdapter()
         speechAdapter.stubbedAuthorizationStatus = .denied
@@ -657,11 +653,7 @@ final class VoiceModeManagerTests: XCTestCase {
     /// and PCM data accumulates for the STT service.
     func testStartRecording_sttConfigured_noRecognizer_succeeds() {
         UserDefaults.standard.set("openai-whisper", forKey: "sttProvider")
-        APIKeyManager.shared.setAPIKey("test-key", provider: "openai")
-        defer {
-            UserDefaults.standard.removeObject(forKey: "sttProvider")
-            APIKeyManager.shared.deleteAPIKey(provider: "openai")
-        }
+        defer { UserDefaults.standard.removeObject(forKey: "sttProvider") }
 
         forceActivate()
         manager.startListening()
@@ -678,11 +670,7 @@ final class VoiceModeManagerTests: XCTestCase {
     /// service returns a configurable transcription result.
     func testTranscription_sttOnly_usesServiceSTT() {
         UserDefaults.standard.set("deepgram", forKey: "sttProvider")
-        APIKeyManager.shared.setAPIKey("test-key", provider: "deepgram")
-        defer {
-            UserDefaults.standard.removeObject(forKey: "sttProvider")
-            APIKeyManager.shared.deleteAPIKey(provider: "deepgram")
-        }
+        defer { UserDefaults.standard.removeObject(forKey: "sttProvider") }
 
         forceActivate()
         mockVoiceService.transcriptionToReturn = "service transcription result"

--- a/clients/shared/Utilities/STTProviderRegistry.swift
+++ b/clients/shared/Utilities/STTProviderRegistry.swift
@@ -60,29 +60,23 @@ public struct STTProviderRegistry: Decodable {
     }
 
     /// Whether the assistant has an LLM-based STT provider configured
-    /// **and credentialed** (e.g. Deepgram, OpenAI Whisper).
+    /// (e.g. Deepgram, OpenAI Whisper).
     ///
     /// When `true`, the app can use the assistant's STT service for
     /// transcription and native `SFSpeechRecognizer` permission is not
     /// required. The value is derived from the `sttProvider` key in
-    /// `UserDefaults` (synced via `client_settings_update`) combined
-    /// with a credential check — a provider without an API key cannot
-    /// perform transcription.
+    /// `UserDefaults`, which is only set when the assistant syncs its
+    /// configuration via `client_settings_update` (see `SettingsStore`).
+    ///
+    /// Note: credentials are managed by the assistant (daemon-side), not
+    /// stored in the client's `APIKeyManager`. The `sttProvider` key is
+    /// only populated when the assistant broadcasts a valid config, so
+    /// its presence reliably indicates the service is operational.
     public static var isServiceConfigured: Bool {
-        guard let providerId = UserDefaults.standard.string(forKey: "sttProvider"),
-              !providerId.isEmpty else {
+        guard let value = UserDefaults.standard.string(forKey: "sttProvider") else {
             return false
         }
-        // Resolve the keychain/UserDefaults key name for this provider's API key.
-        let keyProvider = loadSTTProviderRegistry()
-            .provider(withId: providerId)?
-            .apiKeyProviderName ?? providerId
-        // Check that a credential actually exists — provider without a key can't transcribe.
-        guard let key = APIKeyManager.shared.getAPIKey(provider: keyProvider),
-              !key.isEmpty else {
-            return false
-        }
-        return true
+        return !value.isEmpty
     }
 }
 


### PR DESCRIPTION
## Summary
- Remove APIKeyManager credential check from `STTProviderRegistry.isServiceConfigured` — STT credentials are managed daemon-side, not in the client's APIKeyManager, so the check always returned false even when STT was properly configured
- Revert to checking only the `sttProvider` UserDefaults key, which is only populated when the assistant broadcasts a valid config via `client_settings_update`
- Remove corresponding APIKeyManager test provisioning from VoiceInputManagerTests, VoiceModeManagerTests, and InputBarVoiceInputTests

## Original prompt
Remove the incorrect APIKeyManager credential check from STTProviderRegistry.isServiceConfigured. The STT credentials are managed daemon-side, not in the client's APIKeyManager, so the check always returns false even when STT is properly configured. Revert to just checking the sttProvider UserDefaults key. Also revert the corresponding APIKeyManager test provisioning that was added to all 3 test files (VoiceInputManagerTests, VoiceModeManagerTests, InputBarVoiceInputTests).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25156" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
