### PR TITLE
feat(daemon): add `launch-conversation` signal handler

### DIFF
--- a/assistant/src/__tests__/signal-launch-conversation.test.ts
+++ b/assistant/src/__tests__/signal-launch-conversation.test.ts
@@ -1,0 +1,291 @@
+/**
+ * Unit tests for the launch-conversation signal handler.
+ *
+ * Covers the parse/validate/dispatch/write-result contract of
+ * {@link handleLaunchConversationSignal} in isolation. The daemon-side
+ * callback (which creates + seeds + focuses the conversation) is exercised
+ * through a mock registered via {@link registerLaunchConversationCallback}.
+ */
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  handleLaunchConversationSignal,
+  registerLaunchConversationCallback,
+} from "../signals/launch-conversation.js";
+import { getSignalsDir } from "../util/platform.js";
+
+function signalPath(filename: string): string {
+  return join(getSignalsDir(), filename);
+}
+
+type RecordedCall = {
+  title: string;
+  seedPrompt: string;
+  anchorMessageId?: string;
+};
+
+function cleanupSignalFiles(filename: string): void {
+  const base = signalPath(filename);
+  for (const path of [base, `${base}.result`]) {
+    if (existsSync(path)) rmSync(path, { force: true });
+  }
+}
+
+describe("handleLaunchConversationSignal", () => {
+  beforeEach(() => {
+    mkdirSync(getSignalsDir(), { recursive: true });
+  });
+
+  afterEach(() => {
+    // Leave a benign no-op registered so the process isn't left holding
+    // a reference to the previous test's callback.
+    registerLaunchConversationCallback(async () => ({ accepted: false }));
+  });
+
+  test("callback not registered → writes 'Assistant not ready' error", async () => {
+    // Intentionally FIRST: the callback registry is a module singleton that
+    // starts out null. Once any prior test registers a callback, this case
+    // can't be reproduced without a module re-import. Running first keeps
+    // the assertion simple.
+    const requestId = "req-not-ready";
+    const filename = `launch-conversation.${requestId}`;
+    cleanupSignalFiles(filename);
+
+    writeFileSync(
+      signalPath(filename),
+      JSON.stringify({
+        requestId,
+        title: "Fresh",
+        seedPrompt: "Still cold",
+      }),
+      "utf-8",
+    );
+
+    await handleLaunchConversationSignal(filename);
+
+    const resultPath = signalPath(`${filename}.result`);
+    expect(existsSync(resultPath)).toBe(true);
+    const result = JSON.parse(readFileSync(resultPath, "utf-8")) as {
+      ok: boolean;
+      error: string;
+      requestId: string;
+    };
+    expect(result).toEqual({
+      ok: false,
+      error: "Assistant not ready",
+      requestId,
+    });
+
+    cleanupSignalFiles(filename);
+  });
+
+  test("happy path dispatches to registered callback and writes result", async () => {
+    const requestId = "req-happy-1";
+    const filename = `launch-conversation.${requestId}`;
+    cleanupSignalFiles(filename);
+
+    const calls: RecordedCall[] = [];
+    registerLaunchConversationCallback(async (params) => {
+      calls.push(params);
+      return { accepted: true, conversationId: "conv-new-1" };
+    });
+
+    writeFileSync(
+      signalPath(filename),
+      JSON.stringify({
+        requestId,
+        title: "New thread",
+        seedPrompt: "Let's talk about X",
+        anchorMessageId: "msg-99",
+      }),
+      "utf-8",
+    );
+
+    await handleLaunchConversationSignal(filename);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual({
+      title: "New thread",
+      seedPrompt: "Let's talk about X",
+      anchorMessageId: "msg-99",
+    });
+
+    // Signal file was consumed.
+    expect(existsSync(signalPath(filename))).toBe(false);
+
+    // Result file was written with the callback outcome.
+    const resultPath = signalPath(`${filename}.result`);
+    expect(existsSync(resultPath)).toBe(true);
+    const result = JSON.parse(readFileSync(resultPath, "utf-8")) as {
+      ok: boolean;
+      accepted: boolean;
+      requestId: string;
+      conversationId?: string;
+    };
+    expect(result).toEqual({
+      ok: true,
+      accepted: true,
+      requestId,
+      conversationId: "conv-new-1",
+    });
+
+    cleanupSignalFiles(filename);
+  });
+
+  test("happy path omits anchorMessageId when not supplied", async () => {
+    const requestId = "req-happy-no-anchor";
+    const filename = `launch-conversation.${requestId}`;
+    cleanupSignalFiles(filename);
+
+    const calls: RecordedCall[] = [];
+    registerLaunchConversationCallback(async (params) => {
+      calls.push(params);
+      return { accepted: true, conversationId: "conv-new-2" };
+    });
+
+    writeFileSync(
+      signalPath(filename),
+      JSON.stringify({
+        requestId,
+        title: "Minimal thread",
+        seedPrompt: "Hello",
+      }),
+      "utf-8",
+    );
+
+    await handleLaunchConversationSignal(filename);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual({
+      title: "Minimal thread",
+      seedPrompt: "Hello",
+    });
+
+    cleanupSignalFiles(filename);
+  });
+
+  test("missing requestId → writes error result with requestId=null", async () => {
+    const filename = "launch-conversation.no-id";
+    cleanupSignalFiles(filename);
+
+    let callbackFired = false;
+    registerLaunchConversationCallback(async () => {
+      callbackFired = true;
+      return { accepted: true, conversationId: "should-not-fire" };
+    });
+
+    writeFileSync(
+      signalPath(filename),
+      JSON.stringify({
+        title: "No id",
+        seedPrompt: "Seed",
+      }),
+      "utf-8",
+    );
+
+    await handleLaunchConversationSignal(filename);
+
+    expect(callbackFired).toBe(false);
+
+    const resultPath = signalPath(`${filename}.result`);
+    expect(existsSync(resultPath)).toBe(true);
+    const result = JSON.parse(readFileSync(resultPath, "utf-8")) as {
+      ok: boolean;
+      error: string;
+      requestId: string | null;
+    };
+    expect(result).toEqual({
+      ok: false,
+      error: "Missing requestId",
+      requestId: null,
+    });
+
+    cleanupSignalFiles(filename);
+  });
+
+  test("missing title → writes error result", async () => {
+    const requestId = "req-no-title";
+    const filename = `launch-conversation.${requestId}`;
+    cleanupSignalFiles(filename);
+
+    let callbackFired = false;
+    registerLaunchConversationCallback(async () => {
+      callbackFired = true;
+      return { accepted: true };
+    });
+
+    writeFileSync(
+      signalPath(filename),
+      JSON.stringify({
+        requestId,
+        seedPrompt: "Seed only",
+      }),
+      "utf-8",
+    );
+
+    await handleLaunchConversationSignal(filename);
+
+    expect(callbackFired).toBe(false);
+
+    const resultPath = signalPath(`${filename}.result`);
+    const result = JSON.parse(readFileSync(resultPath, "utf-8")) as {
+      ok: boolean;
+      error: string;
+      requestId: string;
+    };
+    expect(result).toEqual({
+      ok: false,
+      error: "Missing title",
+      requestId,
+    });
+
+    cleanupSignalFiles(filename);
+  });
+
+  test("missing seedPrompt → writes error result", async () => {
+    const requestId = "req-no-seed";
+    const filename = `launch-conversation.${requestId}`;
+    cleanupSignalFiles(filename);
+
+    let callbackFired = false;
+    registerLaunchConversationCallback(async () => {
+      callbackFired = true;
+      return { accepted: true };
+    });
+
+    writeFileSync(
+      signalPath(filename),
+      JSON.stringify({
+        requestId,
+        title: "Title only",
+      }),
+      "utf-8",
+    );
+
+    await handleLaunchConversationSignal(filename);
+
+    expect(callbackFired).toBe(false);
+
+    const resultPath = signalPath(`${filename}.result`);
+    const result = JSON.parse(readFileSync(resultPath, "utf-8")) as {
+      ok: boolean;
+      error: string;
+      requestId: string;
+    };
+    expect(result).toEqual({
+      ok: false,
+      error: "Missing seedPrompt",
+      requestId,
+    });
+
+    cleanupSignalFiles(filename);
+  });
+});

--- a/assistant/src/daemon/config-watcher.ts
+++ b/assistant/src/daemon/config-watcher.ts
@@ -24,6 +24,7 @@ import { handleBashSignal } from "../signals/bash.js";
 import { handleCancelSignal } from "../signals/cancel.js";
 import { handleConversationUndoSignal } from "../signals/conversation-undo.js";
 import { handleEmitEventSignal } from "../signals/emit-event.js";
+import { handleLaunchConversationSignal } from "../signals/launch-conversation.js";
 import { handleMcpReloadSignal } from "../signals/mcp-reload.js";
 import { handleShotgunSignal } from "../signals/shotgun.js";
 import { handleUserMessageSignal } from "../signals/user-message.js";
@@ -398,6 +399,7 @@ export class ConfigWatcher {
       "bash.": handleBashSignal,
       "shotgun.": handleShotgunSignal,
       "user-message.": handleUserMessageSignal,
+      "launch-conversation.": handleLaunchConversationSignal,
     };
 
     try {

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 
@@ -38,6 +39,7 @@ import {
   provenanceFromTrustContext,
   setConversationOriginChannelIfUnset,
   setConversationOriginInterfaceIfUnset,
+  updateConversationTitle,
 } from "../memory/conversation-crud.js";
 import { updateMetaFile } from "../memory/conversation-disk-view.js";
 import { getOrCreateConversation } from "../memory/conversation-key-store.js";
@@ -56,6 +58,7 @@ import { updatePublishedAppDeployment } from "../services/published-app-updater.
 import { registerCancelCallback } from "../signals/cancel.js";
 import { registerConversationUndoCallback } from "../signals/conversation-undo.js";
 import { appendEventToStream } from "../signals/event-stream.js";
+import { registerLaunchConversationCallback } from "../signals/launch-conversation.js";
 import { registerUserMessageCallback } from "../signals/user-message.js";
 import { getSubagentManager } from "../subagent/index.js";
 import { summarizeToolInput } from "../tools/tool-input-summary.js";
@@ -751,6 +754,70 @@ export class DaemonServer {
         params.sourceInterface,
       );
       return { accepted: true };
+    });
+
+    registerLaunchConversationCallback(async (params) => {
+      try {
+        // Each launch gets a globally unique conversation key so the skill
+        // always creates a fresh conversation rather than reusing any prior
+        // mapping. `getOrCreateConversation` will insert a new row.
+        const conversationKey = `launcher-${randomUUID()}`;
+        const { conversationId } = getOrCreateConversation(conversationKey);
+
+        // Set the user-facing title immediately so clients that stub a
+        // sidebar entry from the open_conversation event see the right
+        // label even before the turn completes.
+        updateConversationTitle(conversationId, params.title, 0);
+
+        // Seed the conversation by running the seed prompt through the same
+        // pipeline POST /v1/messages uses. Publishing to the hub lets any
+        // connected client stream the turn live.
+        const hubSender = (msg: ServerMessage) => {
+          const msgConversationId =
+            "conversationId" in msg &&
+            typeof (msg as { conversationId?: unknown }).conversationId ===
+              "string"
+              ? (msg as { conversationId: string }).conversationId
+              : undefined;
+          this.publishAssistantEvent(msg, msgConversationId ?? conversationId);
+        };
+
+        await this.persistAndProcessMessage(
+          conversationId,
+          params.seedPrompt,
+          undefined,
+          { onEvent: hubSender },
+          "vellum",
+          "cli",
+        );
+
+        // Tell connected clients to focus the new conversation. The client
+        // stubs a sidebar entry from the optional title if the conversation
+        // isn't already in its list.
+        await assistantEventHub.publish(
+          buildAssistantEvent(
+            this.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID,
+            {
+              type: "open_conversation",
+              conversationId,
+              title: params.title,
+              ...(params.anchorMessageId
+                ? { anchorMessageId: params.anchorMessageId }
+                : {}),
+            },
+            conversationId,
+          ),
+        );
+
+        return { accepted: true, conversationId };
+      } catch (err) {
+        log.warn({ err }, "Failed to launch conversation via signal");
+        return {
+          accepted: false,
+          error: "launch_failed" as const,
+          message: err instanceof Error ? err.message : String(err),
+        };
+      }
     });
 
     this.configWatcher.start(

--- a/assistant/src/signals/launch-conversation.ts
+++ b/assistant/src/signals/launch-conversation.ts
@@ -1,0 +1,172 @@
+/**
+ * Handle launch-conversation signals delivered via signal files from skills.
+ *
+ * Each invocation writes JSON to a unique
+ * `signals/launch-conversation.<requestId>` file. ConfigWatcher detects the
+ * new file and invokes {@link handleLaunchConversationSignal}, which reads
+ * the payload, creates + seeds + titles a fresh conversation through the
+ * daemon's registered callback, and writes the outcome to
+ * `signals/launch-conversation.<requestId>.result` for the caller.
+ *
+ * Per-request filenames avoid dropped messages when overlapping invocations
+ * race on the same signal file.
+ *
+ * Because the signal handler needs access to the daemon's conversation map,
+ * title store, and event hub, the daemon registers a callback at startup via
+ * {@link registerLaunchConversationCallback}.
+ */
+
+import { readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { getLogger } from "../util/logger.js";
+import { getSignalsDir } from "../util/platform.js";
+
+const log = getLogger("signal:launch-conversation");
+
+// ── Daemon callback registry ─────────────────────────────────────────
+
+type LaunchConversationCallback = (params: {
+  title: string;
+  seedPrompt: string;
+  anchorMessageId?: string;
+}) => Promise<{
+  accepted: boolean;
+  conversationId?: string;
+  error?: string;
+  message?: string;
+}>;
+
+let _launchConversation: LaunchConversationCallback | null = null;
+
+/**
+ * Register the launch-conversation callback. Called once by the daemon
+ * server at startup so the signal handler can reach the conversation map,
+ * title store, and event hub.
+ */
+export function registerLaunchConversationCallback(
+  cb: LaunchConversationCallback,
+): void {
+  _launchConversation = cb;
+}
+
+// ── Signal handler ───────────────────────────────────────────────────
+
+/**
+ * Read a `signals/launch-conversation.<requestId>` file and spawn a new
+ * conversation via the daemon's launch pipeline. Writes
+ * `signals/launch-conversation.<requestId>.result` with the outcome so the
+ * caller can observe success/failure and learn the new conversationId.
+ */
+export async function handleLaunchConversationSignal(
+  filename: string,
+): Promise<void> {
+  const signalsDir = getSignalsDir();
+  const signalPath = join(signalsDir, filename);
+  const resultPath = join(signalsDir, `${filename}.result`);
+
+  const writeResult = (
+    data:
+      | {
+          ok: true;
+          accepted: boolean;
+          requestId: string;
+          conversationId?: string;
+          error?: string;
+          message?: string;
+        }
+      | { ok: false; error: string; requestId: string | null },
+  ): void => {
+    try {
+      writeFileSync(resultPath, JSON.stringify(data));
+    } catch {
+      // Best-effort — filesystem may be broken.
+    }
+  };
+
+  let raw: string;
+  try {
+    raw = readFileSync(signalPath, "utf-8");
+  } catch {
+    // File may already be deleted (e.g. re-trigger from our own unlinkSync).
+    return;
+  }
+
+  try {
+    unlinkSync(signalPath);
+  } catch {
+    // Best-effort cleanup; the file may already be gone.
+  }
+
+  let parsedRequestId: string | undefined;
+
+  try {
+    const parsed = JSON.parse(raw) as {
+      requestId?: string;
+      title?: string;
+      seedPrompt?: string;
+      anchorMessageId?: string;
+    };
+    const { requestId } = parsed;
+    parsedRequestId = requestId;
+
+    if (!requestId || typeof requestId !== "string") {
+      log.warn("Launch-conversation signal missing requestId");
+      writeResult({ ok: false, error: "Missing requestId", requestId: null });
+      return;
+    }
+
+    if (!parsed.title || typeof parsed.title !== "string") {
+      log.warn("Launch-conversation signal missing title");
+      writeResult({ ok: false, error: "Missing title", requestId });
+      return;
+    }
+
+    if (!parsed.seedPrompt || typeof parsed.seedPrompt !== "string") {
+      log.warn("Launch-conversation signal missing seedPrompt");
+      writeResult({ ok: false, error: "Missing seedPrompt", requestId });
+      return;
+    }
+
+    if (!_launchConversation) {
+      log.warn(
+        "Launch-conversation callback not registered; daemon may not be ready",
+      );
+      writeResult({ ok: false, error: "Assistant not ready", requestId });
+      return;
+    }
+
+    const result = await _launchConversation({
+      title: parsed.title,
+      seedPrompt: parsed.seedPrompt,
+      ...(typeof parsed.anchorMessageId === "string"
+        ? { anchorMessageId: parsed.anchorMessageId }
+        : {}),
+    });
+
+    log.info(
+      {
+        accepted: result.accepted,
+        conversationId: result.conversationId,
+      },
+      "Launch-conversation dispatched via signal file",
+    );
+    writeResult({
+      ok: true,
+      accepted: result.accepted,
+      requestId,
+      ...(result.conversationId
+        ? { conversationId: result.conversationId }
+        : {}),
+      ...(result.error ? { error: result.error } : {}),
+      ...(result.message ? { message: result.message } : {}),
+    });
+  } catch (err) {
+    log.error({ err }, "Failed to handle launch-conversation signal");
+    writeResult({
+      ok: false,
+      error: "Internal error",
+      requestId: parsedRequestId ?? null,
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- New `launch-conversation.<requestId>` signal handler that creates + seeds + focuses a new conversation in-process
- Mirrors the `user-message` signal pattern (per-request filenames, callback-based architecture)
- Daemon callback orchestrates: create conversation -> seed via user-message pipeline -> set title -> publish `open_conversation` SSE event
- Unblocks the `conversation-launcher` skill, which previously tried to curl authenticated daemon endpoints from an unauth sandbox

Follow-up PR will rewrite `skills/conversation-launcher/SKILL.md` to use this signal, and clean up the macOS source tag + catalog emoji.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25157" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
