### PR TITLE
feat(updates): add updates.enabled flag to opt out of UPDATES.md materialization

### DIFF
--- a/assistant/src/__tests__/update-bulletin.test.ts
+++ b/assistant/src/__tests__/update-bulletin.test.ts
@@ -31,6 +31,13 @@ mock.module("../memory/checkpoints.js", () => ({
   ),
 }));
 
+// --- Mutable config stub for updates.enabled tests ---
+const updatesConfig = { enabled: true };
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({ updates: updatesConfig }),
+}));
+
 // --- Temp directory for template files ---
 // Avoids mutating the real source-controlled UPDATES.md template, preventing
 // race conditions with parallel test execution and working tree corruption
@@ -60,6 +67,7 @@ const COMMENT_ONLY_TEMPLATE =
 describe("syncUpdateBulletinOnStartup", () => {
   beforeEach(() => {
     store.clear();
+    updatesConfig.enabled = true;
     // Remove any leftover workspace UPDATES.md from a previous test
     if (existsSync(workspacePath)) {
       rmSync(workspacePath);
@@ -90,6 +98,18 @@ describe("syncUpdateBulletinOnStartup", () => {
     const content = readFileSync(workspacePath, "utf-8");
     expect(content).toContain("<!-- vellum-update-release:1.0.0 -->");
     expect(content).toContain("What's New");
+  });
+
+  it("skips materialization entirely when updates.enabled is false", () => {
+    updatesConfig.enabled = false;
+    expect(existsSync(workspacePath)).toBe(false);
+
+    syncUpdateBulletinOnStartup();
+
+    expect(existsSync(workspacePath)).toBe(false);
+    // No checkpoint writes should have happened either.
+    expect(store.get("updates:active_releases")).toBeUndefined();
+    expect(store.get("updates:completed_releases")).toBeUndefined();
   });
 
   it("appends release block when workspace file exists without current marker", () => {

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -216,6 +216,8 @@ export {
   TtsServiceSchema,
   VALID_TTS_PROVIDERS as VALID_TTS_SERVICE_PROVIDERS,
 } from "./schemas/tts.js";
+export type { UpdatesConfig } from "./schemas/updates.js";
+export { UpdatesConfigSchema } from "./schemas/updates.js";
 export type { WorkspaceGitConfig } from "./schemas/workspace-git.js";
 export { WorkspaceGitConfigSchema } from "./schemas/workspace-git.js";
 
@@ -263,6 +265,7 @@ import {
   RateLimitConfigSchema,
   TimeoutConfigSchema,
 } from "./schemas/timeouts.js";
+import { UpdatesConfigSchema } from "./schemas/updates.js";
 import { WorkspaceGitConfigSchema } from "./schemas/workspace-git.js";
 
 export const AssistantConfigSchema = z
@@ -305,6 +308,7 @@ export const AssistantConfigSchema = z
       ),
     filing: FilingConfigSchema.default(FilingConfigSchema.parse({})),
     heartbeat: HeartbeatConfigSchema.default(HeartbeatConfigSchema.parse({})),
+    updates: UpdatesConfigSchema.default(UpdatesConfigSchema.parse({})),
     hostBrowser: HostBrowserConfigSchema.default(
       HostBrowserConfigSchema.parse({}),
     ),

--- a/assistant/src/config/schemas/updates.ts
+++ b/assistant/src/config/schemas/updates.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+
+export const UpdatesConfigSchema = z
+  .object({
+    enabled: z
+      .boolean({ error: "updates.enabled must be a boolean" })
+      .default(true)
+      .describe(
+        "Whether the release update bulletin (UPDATES.md) is materialized into the workspace on daemon startup",
+      ),
+  })
+  .describe("Release update bulletin configuration");
+
+export type UpdatesConfig = z.infer<typeof UpdatesConfigSchema>;

--- a/assistant/src/prompts/update-bulletin.ts
+++ b/assistant/src/prompts/update-bulletin.ts
@@ -8,6 +8,7 @@ import {
   writeFileSync,
 } from "node:fs";
 
+import { getConfig } from "../config/loader.js";
 import { getWorkspacePromptPath } from "../util/platform.js";
 import { stripCommentLines } from "../util/strip-comment-lines.js";
 import { APP_VERSION } from "../version.js";
@@ -75,6 +76,8 @@ function atomicWriteFileSync(filePath: string, content: string): void {
  * already exist for this version. Skips completed releases entirely.
  */
 export function syncUpdateBulletinOnStartup(): void {
+  if (!getConfig().updates.enabled) return;
+
   const currentReleaseId = APP_VERSION;
   const workspacePath = getWorkspacePromptPath("UPDATES.md");
 


### PR DESCRIPTION
## Summary
- Adds a new `updates` config section with a single `enabled` boolean (default `true`).
- When `updates.enabled` is `false`, `syncUpdateBulletinOnStartup()` returns immediately — no workspace file is created, no checkpoint state is mutated.
- Users can now opt out permanently by setting `"updates": { "enabled": false }` in `config.json` instead of fighting the daemon to keep the file deleted.

## Original prompt
this in parallel PRs (if possible)

Companion to the dismissal-fix PR which makes manual deletion/emptying stick when the flag is left at the default.