### PR TITLE
fix(updates): make manual deletion and emptying of UPDATES.md stick across restarts

### DIFF
--- a/assistant/src/__tests__/update-bulletin.test.ts
+++ b/assistant/src/__tests__/update-bulletin.test.ts
@@ -193,6 +193,55 @@ describe("syncUpdateBulletinOnStartup", () => {
     expect(existsSync(workspacePath)).toBe(false);
   });
 
+  it("treats an empty UPDATES.md as dismissal of the current release", () => {
+    // Pre-populate active so we're past the fresh-install guard.
+    store.set("updates:active_releases", JSON.stringify(["1.0.0"]));
+    writeFileSync(workspacePath, "", "utf-8");
+
+    syncUpdateBulletinOnStartup();
+
+    // File should be left alone (still empty, not refilled).
+    expect(existsSync(workspacePath)).toBe(true);
+    expect(readFileSync(workspacePath, "utf-8")).toBe("");
+
+    const completed: string[] = JSON.parse(
+      store.get("updates:completed_releases")!,
+    );
+    expect(completed).toContain("1.0.0");
+  });
+
+  it("treats a whitespace-only UPDATES.md as dismissal of the current release", () => {
+    // Pre-populate completed so hasEverMaterialized is true via the completed path.
+    store.set("updates:completed_releases", JSON.stringify(["0.9.0"]));
+    writeFileSync(workspacePath, "   \n\n\t\n", "utf-8");
+
+    syncUpdateBulletinOnStartup();
+
+    // File should be left alone — content must not be re-appended.
+    const content = readFileSync(workspacePath, "utf-8");
+    expect(content).not.toContain("<!-- vellum-update-release:1.0.0 -->");
+
+    const completed: string[] = JSON.parse(
+      store.get("updates:completed_releases")!,
+    );
+    expect(completed).toContain("1.0.0");
+  });
+
+  it("creates file on fresh install even though it is missing", () => {
+    // Both active and completed are empty — brand-new DB.
+    expect(store.get("updates:active_releases")).toBeUndefined();
+    expect(store.get("updates:completed_releases")).toBeUndefined();
+    expect(existsSync(workspacePath)).toBe(false);
+
+    syncUpdateBulletinOnStartup();
+
+    // Fresh install should materialize, not dismiss.
+    expect(existsSync(workspacePath)).toBe(true);
+    expect(readFileSync(workspacePath, "utf-8")).toContain(
+      "<!-- vellum-update-release:1.0.0 -->",
+    );
+  });
+
   it("merges pending old block with new release block", () => {
     // Pre-create workspace file with an old release block
     const oldContent =

--- a/assistant/src/prompts/update-bulletin.ts
+++ b/assistant/src/prompts/update-bulletin.ts
@@ -20,6 +20,7 @@ import {
 import {
   addActiveRelease,
   getActiveReleases,
+  getCompletedReleases,
   isReleaseCompleted,
   markReleasesCompleted,
   setActiveReleases,
@@ -67,13 +68,15 @@ function atomicWriteFileSync(filePath: string, content: string): void {
 /**
  * Materializes the current release's update bulletin on startup.
  *
- * First checks for deletion-completion: if the workspace UPDATES.md was
- * deleted while releases were active, those releases are marked completed
- * (the assistant signals "done" by deleting the file).
+ * First checks for dismissal: if the workspace UPDATES.md was deleted or
+ * emptied after we'd previously materialized it, that's an explicit signal
+ * (from the user or the assistant) that the current release has been handled.
+ * Mark any active releases plus the current release as completed and return
+ * without recreating the file.
  *
- * Then reads the bundled UPDATES.md template, strips comment lines, and
- * appends a release block to the workspace UPDATES.md if one doesn't
- * already exist for this version. Skips completed releases entirely.
+ * Otherwise reads the bundled UPDATES.md template, strips comment lines, and
+ * appends a release block to the workspace UPDATES.md if one doesn't already
+ * exist for this version. Skips completed releases entirely.
  */
 export function syncUpdateBulletinOnStartup(): void {
   if (!getConfig().updates.enabled) return;
@@ -81,13 +84,25 @@ export function syncUpdateBulletinOnStartup(): void {
   const currentReleaseId = APP_VERSION;
   const workspacePath = getWorkspacePromptPath("UPDATES.md");
 
-  // --- Deletion completion ---
-  // If UPDATES.md was deleted and there are active releases, the assistant
-  // has signaled it is done with those updates. Mark them completed.
+  // --- Dismissal detection ---
+  // If UPDATES.md is missing or empty AND we've materialized it at least
+  // once before (i.e. there's prior release state), treat it as a dismissal:
+  // mark the active set plus the current release completed and stop. The
+  // "has ever materialized" guard preserves fresh-install semantics — on a
+  // brand-new DB we want to create the file, not treat its absence as
+  // dismissal of the current release.
   const activeReleases = getActiveReleases();
-  if (!existsSync(workspacePath) && activeReleases.length > 0) {
-    markReleasesCompleted(activeReleases);
+  const fileMissing = !existsSync(workspacePath);
+  const fileEmpty =
+    !fileMissing &&
+    readFileSync(workspacePath, "utf-8").trim().length === 0;
+  const hasEverMaterialized =
+    activeReleases.length > 0 || getCompletedReleases().length > 0;
+
+  if ((fileMissing || fileEmpty) && hasEverMaterialized) {
+    markReleasesCompleted([...activeReleases, currentReleaseId]);
     setActiveReleases([]);
+    return;
   }
 
   // --- Template materialization ---


### PR DESCRIPTION
## Summary
- Collapses the deletion-completion branch so it fires for both missing *and* empty/whitespace-only workspace files — previously emptying the file was ignored and content was re-appended on next startup.
- Always marks `currentReleaseId` (plus any lingering active releases) completed on dismissal, not just the active set. This makes dismissal idempotent even when `updates:active_releases` checkpoint state is out of sync (fresh DB, partial init, etc.).
- Preserves fresh-install semantics via a `hasEverMaterialized` guard: if both active and completed release sets are empty, a missing file is treated as "never created" and the bulletin is materialized normally.
- Adds three regression tests: empty-file dismissal, whitespace-only dismissal, and the fresh-install-still-materializes path.

## Original prompt
this in parallel PRs (if possible)

Companion to the `updates.enabled` config flag PR — that one lets users opt out permanently; this one makes the existing delete/empty-the-file workflow actually work.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25159" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
