### PR TITLE
fix(skills,macos): rewrite conversation-launcher to use `launch-conversation` signal

### DIFF
--- a/assistant/src/__tests__/conversation-launcher-skill-regression.test.ts
+++ b/assistant/src/__tests__/conversation-launcher-skill-regression.test.ts
@@ -13,18 +13,33 @@ describe("conversation-launcher skill regression", () => {
     expect(skillContent).not.toContain("ui_show(");
   });
 
-  test("creates conversations via POST /v1/conversations", () => {
-    expect(skillContent).toContain("/v1/conversations");
-    expect(skillContent).toContain("conversationKey");
+  test("launches via the launch-conversation signal (single write, no curl)", () => {
+    // One signal file per launch — the daemon creates+titles+seeds+opens.
+    expect(skillContent).toContain("launch-conversation.");
+    // Docker-safe path honors VELLUM_WORKSPACE_DIR.
+    expect(skillContent).toContain("VELLUM_WORKSPACE_DIR");
   });
 
-  test("seeds the new conversation via POST /v1/messages", () => {
-    expect(skillContent).toContain("/v1/messages");
+  test("uses jq -n --arg to build the JSON payload (no raw interpolation)", () => {
+    expect(skillContent).toContain("jq -n");
   });
 
-  test("opens the new conversation via the emit-event signal", () => {
-    expect(skillContent).toContain("open_conversation");
-    expect(skillContent).toContain("signals/emit-event");
+  test("payload includes the wire contract fields the daemon reads", () => {
+    expect(skillContent).toContain("requestId");
+    expect(skillContent).toContain("title");
+    expect(skillContent).toContain("seedPrompt");
+  });
+
+  test("explicitly binds NEW_CONV_TITLE and SEED_PROMPT from the action payload", () => {
+    expect(skillContent).toContain("NEW_CONV_TITLE");
+    expect(skillContent).toContain("SEED_PROMPT");
+  });
+
+  test("does not issue HTTP calls — the signal handler does everything server-side", () => {
+    expect(skillContent).not.toContain("curl");
+    expect(skillContent).not.toContain("/v1/conversations");
+    expect(skillContent).not.toContain("/v1/messages");
+    expect(skillContent).not.toContain("signals/emit-event");
   });
 
   test("does not instruct the assistant to reply in chat after launching", () => {

--- a/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
@@ -212,8 +212,11 @@ extension AppDelegate {
                     guard !self.isBootstrapping else { break }
                     self.ensureMainWindowExists()
                     // If the conversation isn't in the sidebar yet (e.g. just created by a
-                    // skill via POST /v1/conversations), stub a sidebar entry using the
-                    // optional title so openConversation's trySelect retries find it.
+                    // skill via the launch-conversation signal), stub a sidebar entry using
+                    // the optional title so openConversation's trySelect retries find it.
+                    // Tag the stub with source: "open_conversation" so it's distinguishable
+                    // from true notification-flow stubs (which use source: "notification"
+                    // and may drive urgency/alerting behaviors that don't apply here).
                     if let title = msg.title,
                        let conversationManager = self.mainWindow?.conversationManager,
                        !conversationManager.conversations.contains(where: { $0.conversationId == msg.conversationId }) {
@@ -222,7 +225,7 @@ extension AppDelegate {
                             title: title,
                             sourceEventName: "open_conversation",
                             groupId: nil,
-                            source: nil
+                            source: "open_conversation"
                         )
                     }
                     self.openConversation(conversationId: msg.conversationId, anchorMessageId: msg.anchorMessageId)

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -59,6 +59,7 @@
       "name": "conversation-launcher",
       "description": "Render an inline card where each button creates a new focused conversation seeded with specific context, then opens it",
       "metadata": {
+        "emoji": "🧭",
         "vellum": {
           "display-name": "Conversation Launcher"
         }

--- a/skills/conversation-launcher/SKILL.md
+++ b/skills/conversation-launcher/SKILL.md
@@ -46,42 +46,35 @@ For each option you plan to surface, prepare:
    }
    ```
 
-2. **Parse the action result.** When the user clicks a button, you receive the `actionId` and its `data` payload. Extract `title` and `seed_prompt`.
+2. **Bind the clicked action's payload.** When the user clicks a button, you receive the `actionId` and its `data` payload. Bind the values before continuing:
 
-3. **Create the new conversation.** Generate a fresh idempotency key (any unique string, e.g. a UUID or timestamp-based slug) and call:
+   - `NEW_CONV_TITLE` = the `title` field from the clicked action's `data`.
+   - `SEED_PROMPT` = the `seed_prompt` field from the clicked action's `data`.
 
-    ```bash
-    curl -sf -X POST "$INTERNAL_GATEWAY_BASE_URL/v1/conversations" \
-      -H "Content-Type: application/json" \
-      -d "{\"conversationKey\":\"launcher-$(date +%s)-$RANDOM\"}"
-    ```
-
-    Capture the returned `id` as `NEW_CONV_ID`.
-
-4. **Seed the new conversation.** Post the seed prompt to it:
+3. **Launch the conversation.** Write a single signal file. The assistant picks it up, creates a fresh conversation, titles it, seeds it with `$SEED_PROMPT` as the first user message, and emits an `open_conversation` event so the UI navigates automatically.
 
     ```bash
-    curl -sf -X POST "$INTERNAL_GATEWAY_BASE_URL/v1/messages" \
-      -H "Content-Type: application/json" \
-      -d "{\"conversationKey\":\"${NEW_CONV_ID}\",\"content\":\"${SEED_PROMPT}\"}"
+    REQUEST_ID=$(uuidgen 2>/dev/null || cat /proc/sys/kernel/random/uuid)
+    SIGNALS_DIR="${VELLUM_WORKSPACE_DIR:-$HOME/.vellum/workspace}/signals"
+    mkdir -p "$SIGNALS_DIR"
+
+    # Safely encode user-provided strings as JSON (handles quotes, newlines, $, etc.)
+    PAYLOAD=$(jq -n \
+      --arg requestId "$REQUEST_ID" \
+      --arg title "$NEW_CONV_TITLE" \
+      --arg seedPrompt "$SEED_PROMPT" \
+      '{requestId: $requestId, title: $title, seedPrompt: $seedPrompt}')
+
+    printf '%s' "$PAYLOAD" > "$SIGNALS_DIR/launch-conversation.$REQUEST_ID"
     ```
 
-    (`conversationKey` here accepts either the idempotency key or the conversation ID — the resolver handles both.)
+    `jq` is available in the skill sandbox. Do not interpolate `$NEW_CONV_TITLE` or `$SEED_PROMPT` directly into a JSON string — user prompts commonly contain quotes, backslashes, newlines, or `$`, which break raw interpolation.
 
-5. **Open the new conversation in the UI.** Write a JSON event to the signals directory; the assistant's config watcher publishes it to connected clients:
-
-    ```bash
-    cat > "${HOME}/.vellum/workspace/signals/emit-event" <<EOF
-    {"type":"open_conversation","conversationId":"${NEW_CONV_ID}","title":"${NEW_CONV_TITLE}"}
-    EOF
-    ```
-
-    Use the conversation's `title` so the client can stub a sidebar entry if the conversation isn't in its list yet.
-
-6. **Don't say anything else.** The UI switch is the signal. No chat response needed after the launch.
+4. **Don't say anything else.** The UI switch is the signal. No chat response needed after the launch.
 
 ## Notes
 
+- One signal file per launch — the assistant handles create + title + seed + open. Do not issue any HTTP calls from this skill.
 - If the user hasn't named the threads, name them concisely yourself (3–5 words, specific not generic).
 - Don't invent threads. Only surface what the user has actually discussed or what they asked about.
 - If there's only one reasonable option, do not use this skill — just continue in the current conversation.


### PR DESCRIPTION
## Summary
- Skill now writes a single `launch-conversation.<requestId>` signal instead of two curl calls + manual emit-event
- Uses `VELLUM_WORKSPACE_DIR`-aware path (Docker-safe) and `jq -n --arg` for JSON escaping
- Explicit binding of `SEED_PROMPT` / `NEW_CONV_TITLE` from action payload
- macOS handler: `source: "open_conversation"` instead of defaulting to `"notification"`
- Catalog entry: adds emoji for sidebar consistency
- Regression test rewritten to match new wire contract

Completes the follow-up to #25157 (signal handler). The end-to-end flow now works without gateway auth: skill → signal file → daemon handler → open_conversation event → macOS navigation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25160" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
