### PR TITLE
chore: change default services.stt provider to deepgram

### DIFF
--- a/assistant/src/__tests__/workspace-migration-033-stt-service-explicit-config.test.ts
+++ b/assistant/src/__tests__/workspace-migration-033-stt-service-explicit-config.test.ts
@@ -73,7 +73,7 @@ describe("033-stt-service-explicit-config migration", () => {
     const stt = services.stt as Record<string, unknown>;
 
     expect(stt.mode).toBe("your-own");
-    expect(stt.provider).toBe("openai-whisper");
+    expect(stt.provider).toBe("deepgram");
     // providers is sparse — no per-provider entries seeded
     expect(stt.providers).toEqual({});
 
@@ -95,7 +95,7 @@ describe("033-stt-service-explicit-config migration", () => {
     const stt = services.stt as Record<string, unknown>;
 
     expect(stt.mode).toBe("your-own");
-    expect(stt.provider).toBe("openai-whisper");
+    expect(stt.provider).toBe("deepgram");
     // providers is sparse — no per-provider entries seeded
     expect(stt.providers).toEqual({});
 
@@ -114,7 +114,7 @@ describe("033-stt-service-explicit-config migration", () => {
     const stt = services.stt as Record<string, unknown>;
 
     expect(stt.mode).toBe("your-own");
-    expect(stt.provider).toBe("openai-whisper");
+    expect(stt.provider).toBe("deepgram");
     // providers is sparse — no per-provider entries seeded
     expect(stt.providers).toEqual({});
   });
@@ -161,7 +161,7 @@ describe("033-stt-service-explicit-config migration", () => {
       unknown
     >;
 
-    expect(stt.provider).toBe("openai-whisper");
+    expect(stt.provider).toBe("deepgram");
     expect(stt.mode).toBe("your-own");
   });
 
@@ -361,7 +361,7 @@ describe("033-stt-service-explicit-config migration", () => {
 
     // ensureObj replaces the non-object with a fresh object and backfills
     expect(stt.mode).toBe("your-own");
-    expect(stt.provider).toBe("openai-whisper");
+    expect(stt.provider).toBe("deepgram");
   });
 
   test("recovers when services is a non-object value", () => {
@@ -376,7 +376,7 @@ describe("033-stt-service-explicit-config migration", () => {
     const stt = services.stt as Record<string, unknown>;
 
     expect(stt.mode).toBe("your-own");
-    expect(stt.provider).toBe("openai-whisper");
+    expect(stt.provider).toBe("deepgram");
   });
 
   // ─── Second-run idempotency ───────────────────────────────────────────

--- a/assistant/src/config/schemas/services.ts
+++ b/assistant/src/config/schemas/services.ts
@@ -89,7 +89,7 @@ export const ServicesSchema = z.object({
   ),
   stt: SttServiceSchema.default({
     mode: "your-own" as const,
-    provider: "openai-whisper" as const,
+    provider: "deepgram" as const,
     providers: {},
   }),
   tts: TtsServiceSchema.default(TtsServiceSchema.parse({})),

--- a/assistant/src/workspace/migrations/033-stt-service-explicit-config.ts
+++ b/assistant/src/workspace/migrations/033-stt-service-explicit-config.ts
@@ -15,7 +15,7 @@ import type { WorkspaceMigration } from "./types.js";
  * partial, backfilling only structural fields:
  *
  *   - `services.stt.mode`      -> `"your-own"`
- *   - `services.stt.provider`  -> `"openai-whisper"`
+ *   - `services.stt.provider`  -> `"deepgram"`
  *   - `services.stt.providers` -> `{}` (empty object — sparse map)
  *
  * It does NOT seed per-provider entries (`openai-whisper`, `deepgram`, etc.)
@@ -58,7 +58,7 @@ export const sttServiceExplicitConfigMigration: WorkspaceMigration = {
 
     // Backfill provider
     if (!("provider" in stt)) {
-      stt.provider = "openai-whisper";
+      stt.provider = "deepgram";
       changed = true;
     }
 


### PR DESCRIPTION
## Summary
- Change the default `services.stt` provider from `openai-whisper` to `deepgram` to align with the telephony call path which already defaults to Deepgram
- Update migration 033 to backfill `deepgram` instead of `openai-whisper` for new workspaces that haven't run the migration yet
- Update migration test assertions to match the new default

## Original prompt
change the default provider in services.stt to be deepgram as well instead of openai.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25162" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
