### PR TITLE
fix(macos): use stopRecordingByMode in toggleRecording so STT-only dictation works

### DIFF
--- a/clients/macos/vellum-assistant/App/VoiceInputManager.swift
+++ b/clients/macos/vellum-assistant/App/VoiceInputManager.swift
@@ -276,7 +276,7 @@ final class VoiceInputManager {
     /// The `origin` parameter tracks which UI surface initiated the recording.
     func toggleRecording(origin: VoiceInputOrigin = .hotkey) {
         if isRecording {
-            stopRecording()
+            stopRecordingByMode()
         } else {
             activeOrigin = origin
             log.debug("Dictation started (origin: \(String(describing: origin)))")


### PR DESCRIPTION
## Summary
- `toggleRecording()` (mic button click) was calling `stopRecording()` directly, which only has an STT-only path for conversation mode — not dictation mode
- Changed to call `stopRecordingByMode()` instead, which routes to `stopRecordingForDictation()` when in dictation mode, enabling the STT service transcription path
- This is why clicking the mic button with STT configured but no speech recognition permission produced no transcription — the accumulated audio was never sent to the STT service
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25163" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
