### PR TITLE
fix(avatar): play poke sound on custom avatar taps

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -482,10 +482,14 @@ struct ChatBubble: View, Equatable {
             if appearance.customAvatarImage != nil {
                 VAvatarImage(image: appearance.chatAvatarImage, size: avatarSize)
                     .scaleEffect(avatarBounceScale)
-                    .onTapGesture { triggerBounce() }
+                    .onTapGesture {
+                        SoundManager.shared.play(.characterPoke)
+                        triggerBounce()
+                    }
             } else if let bodyShape = appearance.characterBodyShape,
                       let eyeStyle = appearance.characterEyeStyle,
                       let color = appearance.characterColor {
+                // Sound is played by AnimatedAvatarView.mouseDown; don't double up here.
                 AnimatedAvatarView(bodyShape: bodyShape, eyeStyle: eyeStyle, color: color,
                                    size: avatarSize, blinkEnabled: true, pokeEnabled: true,
                                    isStreaming: message.isStreaming)
@@ -495,7 +499,10 @@ struct ChatBubble: View, Equatable {
             } else {
                 VAvatarImage(image: appearance.chatAvatarImage, size: avatarSize)
                     .scaleEffect(avatarBounceScale)
-                    .onTapGesture { triggerBounce() }
+                    .onTapGesture {
+                        SoundManager.shared.play(.characterPoke)
+                        triggerBounce()
+                    }
             }
         }
         // Ensure the tap-triggered bounce animation is preserved despite the


### PR DESCRIPTION
## Summary
- The \`character_poke\` sound only fired from \`AnimatedAvatarView.mouseDown\`, so clicking a user-uploaded custom avatar (or the fallback \`VAvatarImage\` path) in a chat bubble was silent.
- Added \`SoundManager.shared.play(.characterPoke)\` to the custom-avatar and fallback tap handlers in \`ChatBubble.inlineAvatar\`, alongside the existing \`triggerBounce()\` call.
- Left the character path alone to avoid double-play — sound still fires from \`AnimatedAvatarView\`'s \`mouseDown\` override for drawn-character avatars.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25165" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
