### PR TITLE
fix(macos): enroll app in Screen Recording TCC list via SCShareableContent

### DIFF
--- a/clients/macos/vellum-assistant/App/PermissionManager.swift
+++ b/clients/macos/vellum-assistant/App/PermissionManager.swift
@@ -1,6 +1,7 @@
 import ApplicationServices
 import AppKit
 import AVFoundation
+import ScreenCaptureKit
 import Speech
 import UserNotifications
 
@@ -102,6 +103,16 @@ enum PermissionManager {
         // to the prompt. On the first call we therefore trust the native prompt
         // and skip the System Settings fallback to avoid showing both at once.
         CGRequestScreenCaptureAccess()
+
+        // Also invoke a real ScreenCaptureKit API. On recent macOS,
+        // CGRequestScreenCaptureAccess alone does not reliably enroll the
+        // app in TCC's Screen Recording list — without an actual
+        // SCShareableContent/SCStream call, the app never shows up in
+        // System Settings > Privacy & Security > Screen & System Audio
+        // Recording, leaving the user no row to toggle on.
+        Task.detached {
+            _ = try? await SCShareableContent.current
+        }
 
         if !hasRequestedBefore {
             UserDefaults.standard.set(true, forKey: hasRequestedScreenRecordingFlag)


### PR DESCRIPTION
## Summary
- `PermissionManager.requestScreenRecordingAccess()` called `CGRequestScreenCaptureAccess()` only, which does not reliably enroll the app in TCC's Screen Recording list on recent macOS. Result: users toggled Screen Recording in Velissa, System Settings opened, but Vellum/Velissa did not appear in the list of apps to grant access to.
- Fire a throwaway `SCShareableContent.current` request alongside the existing `CGRequestScreenCaptureAccess()` call. ScreenCaptureKit is the API that reliably engages TCC's full enrollment machinery.
- `NSScreenRecordingUsageDescription` was already correctly set in `Info.plist`; only the permission-request code path needed fixing.

## Original prompt
it