### PR TITLE
fix(macos): restore timezone and other daemon settings on app restart

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -692,6 +692,26 @@ public final class SettingsStore: ObservableObject {
             await self?.refreshManagedAssistantRecoveryMode()
         }
 
+        // Eagerly fetch daemon config so config-dependent state (e.g.
+        // userTimezone, mediaEmbeds, service providers) is hydrated on
+        // app startup. The daemon only broadcasts config_changed on file
+        // mutations, so without this the store would stay at init
+        // defaults until the user edits config.json.
+        Task { @MainActor [weak self] in
+            await self?.loadConfigFromDaemon()
+        }
+
+        // Refresh config on daemon (re)connect so config-dependent state
+        // recovers after the daemon restarts or after a network blip.
+        NotificationCenter.default.publisher(for: .daemonDidReconnect)
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                Task { @MainActor [weak self] in
+                    await self?.loadConfigFromDaemon()
+                }
+            }
+            .store(in: &cancellables)
+
         // Refresh config when the daemon notifies us that config.json changed.
         NotificationCenter.default.publisher(for: .configChanged)
             .receive(on: RunLoop.main)

--- a/clients/macos/vellum-assistantTests/SettingsStoreUserTimezoneTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsStoreUserTimezoneTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import VellumAssistantLib
+@testable import VellumAssistantShared
 
 @MainActor
 final class SettingsStoreUserTimezoneTests: XCTestCase {
@@ -84,5 +85,64 @@ final class SettingsStoreUserTimezoneTests: XCTestCase {
         let ui = persisted["ui"] as? [String: Any]
         XCTAssertNil(ui?["userTimezone"])
         XCTAssertNotNil(ui?["mediaEmbeds"])
+    }
+
+    // MARK: - Startup/reconnect rehydration
+
+    /// Regression: `userTimezone` must be hydrated from the daemon on
+    /// app startup. Previously `loadConfigFromDaemon()` only ran when
+    /// the daemon broadcast `config_changed` (a file-mutation signal
+    /// that never fires on startup), so the timezone stayed "Not Set"
+    /// across every restart even when `ui.userTimezone` was persisted.
+    func testUserTimezoneHydratesFromDaemonOnInit() {
+        let mock = MockSettingsClient()
+        mock.fetchConfigResponse = [
+            "ui": ["userTimezone": "America/New_York"]
+        ]
+
+        let store = SettingsStore(settingsClient: mock)
+
+        let predicate = NSPredicate { _, _ in
+            store.userTimezone == "America/New_York"
+        }
+        wait(
+            for: [XCTNSPredicateExpectation(predicate: predicate, object: nil)],
+            timeout: 2.0
+        )
+        XCTAssertGreaterThanOrEqual(mock.fetchConfigCallCount, 1)
+    }
+
+    /// Regression: `.daemonDidReconnect` must trigger a config reload
+    /// so the timezone (and other daemon-config-dependent state) is
+    /// restored after the daemon restarts or after a network blip.
+    func testUserTimezoneRehydratesOnDaemonReconnect() {
+        let mock = MockSettingsClient()
+        mock.fetchConfigResponse = [:]
+
+        let store = SettingsStore(settingsClient: mock)
+
+        // Wait for the eager init-time fetch to land.
+        let initFetched = NSPredicate { _, _ in
+            mock.fetchConfigCallCount >= 1
+        }
+        wait(
+            for: [XCTNSPredicateExpectation(predicate: initFetched, object: nil)],
+            timeout: 2.0
+        )
+        XCTAssertNil(store.userTimezone)
+
+        // Daemon comes online with a persisted timezone.
+        mock.fetchConfigResponse = [
+            "ui": ["userTimezone": "Europe/Berlin"]
+        ]
+        NotificationCenter.default.post(name: .daemonDidReconnect, object: nil)
+
+        let rehydrated = NSPredicate { _, _ in
+            store.userTimezone == "Europe/Berlin"
+        }
+        wait(
+            for: [XCTNSPredicateExpectation(predicate: rehydrated, object: nil)],
+            timeout: 2.0
+        )
     }
 }


### PR DESCRIPTION
## Summary

- `SettingsStore.loadConfigFromDaemon()` was only invoked when the daemon broadcast `config_changed`, a file-mutation signal that never fires on startup. On every app restart, `userTimezone` (and `mediaEmbedsEnabled`, `webSearchProvider`, TTS/STT providers, `hostBrowser.cdpInspect`, service modes, etc.) reset to init-time defaults even though the values were persisted in `~/.vellum/workspace/config.json`.
- Fix by performing an eager `loadConfigFromDaemon()` in `SettingsStore.init` and subscribing to `.daemonDidReconnect` so config rehydrates on every fresh daemon connection (startup, daemon restart, network reconnect).
- Added regression tests covering both the init-time hydration and the reconnect path via `MockSettingsClient` and `NotificationCenter.post(.daemonDidReconnect)`.

## Original prompt

fix timezone (and other daemon-config-dependent settings) not being restored on app restart — SettingsStore only loaded config on configChanged broadcasts, which never fire on startup; added eager load in init plus .daemonDidReconnect subscription. Add a regression test if feasible. Skip CI, yolo mode per standing defaults.