### PR TITLE
assistant: add services.stt telephony routing resolver for twilio call setup

### DIFF
--- a/assistant/src/__tests__/telephony-stt-routing.test.ts
+++ b/assistant/src/__tests__/telephony-stt-routing.test.ts
@@ -31,6 +31,7 @@ import {
   type MediaStreamCustomStrategy,
   resolveTelephonySttRouting,
 } from "../calls/telephony-stt-routing.js";
+import type { SttProviderId } from "../stt/types.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -262,7 +263,12 @@ describe("resolveTelephonySttRouting", () => {
     });
 
     test("all resolved strategies include the original providerId", () => {
-      for (const provider of ["deepgram", "google-gemini", "openai-whisper"]) {
+      const providers: SttProviderId[] = [
+        "deepgram",
+        "google-gemini",
+        "openai-whisper",
+      ];
+      for (const provider of providers) {
         mockConfig = buildConfig({ provider });
 
         const result = resolveTelephonySttRouting();

--- a/assistant/src/__tests__/telephony-stt-routing.test.ts
+++ b/assistant/src/__tests__/telephony-stt-routing.test.ts
@@ -1,0 +1,276 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before any subject imports
+// ---------------------------------------------------------------------------
+
+// -- Logger mock ----------------------------------------------------------
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// -- Config mock ----------------------------------------------------------
+
+let mockConfig: Record<string, unknown> = {};
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => mockConfig,
+  loadConfig: () => mockConfig,
+}));
+
+// ---------------------------------------------------------------------------
+// Subject import (after mocks)
+// ---------------------------------------------------------------------------
+
+import {
+  type ConversationRelayNativeStrategy,
+  type MediaStreamCustomStrategy,
+  resolveTelephonySttRouting,
+} from "../calls/telephony-stt-routing.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildConfig(overrides: {
+  provider?: string;
+}): Record<string, unknown> {
+  return {
+    services: {
+      stt: {
+        mode: "your-own",
+        provider: overrides.provider ?? "deepgram",
+        providers: {},
+      },
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests — Provider-to-strategy mapping
+// ---------------------------------------------------------------------------
+
+describe("resolveTelephonySttRouting", () => {
+  beforeEach(() => {
+    mockConfig = buildConfig({});
+  });
+
+  // -----------------------------------------------------------------------
+  // Deepgram → conversation-relay-native
+  // -----------------------------------------------------------------------
+
+  describe("deepgram", () => {
+    test("resolves to conversation-relay-native with Deepgram transcriptionProvider", () => {
+      mockConfig = buildConfig({ provider: "deepgram" });
+
+      const result = resolveTelephonySttRouting();
+
+      expect(result.status).toBe("resolved");
+      if (result.status !== "resolved") return;
+
+      expect(result.strategy.strategy).toBe("conversation-relay-native");
+      const strategy = result.strategy as ConversationRelayNativeStrategy;
+      expect(strategy.providerId).toBe("deepgram");
+      expect(strategy.transcriptionProvider).toBe("Deepgram");
+    });
+
+    test("defaults speechModel to nova-3 when not provided", () => {
+      mockConfig = buildConfig({ provider: "deepgram" });
+
+      const result = resolveTelephonySttRouting();
+
+      expect(result.status).toBe("resolved");
+      if (result.status !== "resolved") return;
+
+      const strategy = result.strategy as ConversationRelayNativeStrategy;
+      expect(strategy.speechModel).toBe("nova-3");
+    });
+
+    test("defaults speechModel to nova-3 when explicitly undefined", () => {
+      mockConfig = buildConfig({ provider: "deepgram" });
+
+      const result = resolveTelephonySttRouting(undefined);
+
+      expect(result.status).toBe("resolved");
+      if (result.status !== "resolved") return;
+
+      const strategy = result.strategy as ConversationRelayNativeStrategy;
+      expect(strategy.speechModel).toBe("nova-3");
+    });
+
+    test("uses explicit speechModel when provided", () => {
+      mockConfig = buildConfig({ provider: "deepgram" });
+
+      const result = resolveTelephonySttRouting("nova-2-phonecall");
+
+      expect(result.status).toBe("resolved");
+      if (result.status !== "resolved") return;
+
+      const strategy = result.strategy as ConversationRelayNativeStrategy;
+      expect(strategy.speechModel).toBe("nova-2-phonecall");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Google Gemini → conversation-relay-native
+  // -----------------------------------------------------------------------
+
+  describe("google-gemini", () => {
+    test("resolves to conversation-relay-native with Google transcriptionProvider", () => {
+      mockConfig = buildConfig({ provider: "google-gemini" });
+
+      const result = resolveTelephonySttRouting();
+
+      expect(result.status).toBe("resolved");
+      if (result.status !== "resolved") return;
+
+      expect(result.strategy.strategy).toBe("conversation-relay-native");
+      const strategy = result.strategy as ConversationRelayNativeStrategy;
+      expect(strategy.providerId).toBe("google-gemini");
+      expect(strategy.transcriptionProvider).toBe("Google");
+    });
+
+    test("leaves speechModel undefined when not provided", () => {
+      mockConfig = buildConfig({ provider: "google-gemini" });
+
+      const result = resolveTelephonySttRouting();
+
+      expect(result.status).toBe("resolved");
+      if (result.status !== "resolved") return;
+
+      const strategy = result.strategy as ConversationRelayNativeStrategy;
+      expect(strategy.speechModel).toBeUndefined();
+    });
+
+    test("suppresses legacy nova-3 model for Google (Deepgram default migration)", () => {
+      mockConfig = buildConfig({ provider: "google-gemini" });
+
+      const result = resolveTelephonySttRouting("nova-3");
+
+      expect(result.status).toBe("resolved");
+      if (result.status !== "resolved") return;
+
+      const strategy = result.strategy as ConversationRelayNativeStrategy;
+      expect(strategy.speechModel).toBeUndefined();
+    });
+
+    test("uses explicit non-Deepgram speechModel when provided for Google", () => {
+      mockConfig = buildConfig({ provider: "google-gemini" });
+
+      const result = resolveTelephonySttRouting("telephony");
+
+      expect(result.status).toBe("resolved");
+      if (result.status !== "resolved") return;
+
+      const strategy = result.strategy as ConversationRelayNativeStrategy;
+      expect(strategy.speechModel).toBe("telephony");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // OpenAI Whisper → media-stream-custom
+  // -----------------------------------------------------------------------
+
+  describe("openai-whisper", () => {
+    test("resolves to media-stream-custom strategy", () => {
+      mockConfig = buildConfig({ provider: "openai-whisper" });
+
+      const result = resolveTelephonySttRouting();
+
+      expect(result.status).toBe("resolved");
+      if (result.status !== "resolved") return;
+
+      expect(result.strategy.strategy).toBe("media-stream-custom");
+      const strategy = result.strategy as MediaStreamCustomStrategy;
+      expect(strategy.providerId).toBe("openai-whisper");
+    });
+
+    test("media-stream-custom strategy does not include speechModel", () => {
+      mockConfig = buildConfig({ provider: "openai-whisper" });
+
+      const result = resolveTelephonySttRouting("whisper-1");
+
+      expect(result.status).toBe("resolved");
+      if (result.status !== "resolved") return;
+
+      // media-stream-custom has no speechModel property
+      expect(result.strategy.strategy).toBe("media-stream-custom");
+      expect("speechModel" in result.strategy).toBe(false);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Unknown / malformed provider handling
+  // -----------------------------------------------------------------------
+
+  describe("unknown provider handling", () => {
+    test("returns unknown-provider for a provider not in the catalog", () => {
+      mockConfig = buildConfig({ provider: "nonexistent-provider" as string });
+
+      const result = resolveTelephonySttRouting();
+
+      expect(result.status).toBe("unknown-provider");
+      if (result.status !== "unknown-provider") return;
+
+      expect(result.providerId).toBe("nonexistent-provider");
+      expect(result.reason).toContain("nonexistent-provider");
+      expect(result.reason).toContain("not in the provider catalog");
+    });
+
+    test("returns unknown-provider for empty-string provider", () => {
+      mockConfig = buildConfig({ provider: "" as string });
+
+      const result = resolveTelephonySttRouting();
+
+      expect(result.status).toBe("unknown-provider");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Strategy discrimination correctness
+  // -----------------------------------------------------------------------
+
+  describe("strategy discrimination", () => {
+    test("conversation-relay-native strategies always have transcriptionProvider", () => {
+      for (const provider of ["deepgram", "google-gemini"]) {
+        mockConfig = buildConfig({ provider });
+
+        const result = resolveTelephonySttRouting();
+        expect(result.status).toBe("resolved");
+        if (result.status !== "resolved") return;
+
+        expect(result.strategy.strategy).toBe("conversation-relay-native");
+        const strategy = result.strategy as ConversationRelayNativeStrategy;
+        expect(strategy.transcriptionProvider).toBeDefined();
+        expect(strategy.transcriptionProvider.length).toBeGreaterThan(0);
+      }
+    });
+
+    test("media-stream-custom strategies never have transcriptionProvider", () => {
+      mockConfig = buildConfig({ provider: "openai-whisper" });
+
+      const result = resolveTelephonySttRouting();
+      expect(result.status).toBe("resolved");
+      if (result.status !== "resolved") return;
+
+      expect(result.strategy.strategy).toBe("media-stream-custom");
+      expect("transcriptionProvider" in result.strategy).toBe(false);
+    });
+
+    test("all resolved strategies include the original providerId", () => {
+      for (const provider of ["deepgram", "google-gemini", "openai-whisper"]) {
+        mockConfig = buildConfig({ provider });
+
+        const result = resolveTelephonySttRouting();
+        expect(result.status).toBe("resolved");
+        if (result.status !== "resolved") return;
+
+        expect(result.strategy.providerId).toBe(provider);
+      }
+    });
+  });
+});

--- a/assistant/src/calls/telephony-stt-routing.ts
+++ b/assistant/src/calls/telephony-stt-routing.ts
@@ -1,0 +1,196 @@
+/**
+ * Telephony STT routing resolver.
+ *
+ * Maps the `services.stt.provider` value to a discriminated telephony
+ * setup strategy that downstream TwiML generation and media-stream
+ * adapters can consume without re-deriving provider semantics.
+ *
+ * Two strategy variants exist:
+ *
+ * - **`conversation-relay-native`** — the STT provider is natively
+ *   supported by Twilio ConversationRelay. TwiML includes
+ *   `transcriptionProvider` / `speechModel` attributes and Twilio
+ *   handles audio ingestion. Used for `deepgram` and `google-gemini`.
+ *
+ * - **`media-stream-custom`** — the STT provider is not natively
+ *   supported by Twilio. A `<Stream>` media-stream is opened instead
+ *   and the daemon transcribes audio server-side via the provider's
+ *   batch API. Used for `openai-whisper`.
+ *
+ * Model normalization semantics from {@link stt-profile.ts} are
+ * preserved here for Twilio-native providers:
+ * - Deepgram defaults `speechModel` to `"nova-3"` when unset.
+ * - Google leaves `speechModel` undefined when unset. The legacy
+ *   Deepgram default `"nova-3"` is treated as unset for Google so
+ *   workspaces that switched providers don't send a Deepgram model
+ *   name to Google's API.
+ */
+
+import { getConfig } from "../config/loader.js";
+import { getProviderEntry } from "../providers/speech-to-text/provider-catalog.js";
+import type { SttProviderId } from "../stt/types.js";
+
+// ---------------------------------------------------------------------------
+// Strategy types
+// ---------------------------------------------------------------------------
+
+/**
+ * Twilio-native ConversationRelay transcription provider name.
+ *
+ * These are the values Twilio accepts in the `transcriptionProvider`
+ * TwiML attribute on `<ConversationRelay>`.
+ */
+export type TwilioNativeTranscriptionProvider = "Deepgram" | "Google";
+
+/**
+ * The configured STT provider maps to a Twilio-native
+ * ConversationRelay transcription path.
+ */
+export interface ConversationRelayNativeStrategy {
+  readonly strategy: "conversation-relay-native";
+  /** Provider ID from `services.stt.provider`. */
+  readonly providerId: SttProviderId;
+  /** Twilio-native provider name for the TwiML attribute. */
+  readonly transcriptionProvider: TwilioNativeTranscriptionProvider;
+  /** ASR model identifier, or undefined to use the provider default. */
+  readonly speechModel: string | undefined;
+}
+
+/**
+ * The configured STT provider requires a media-stream for custom
+ * server-side transcription.
+ */
+export interface MediaStreamCustomStrategy {
+  readonly strategy: "media-stream-custom";
+  /** Provider ID from `services.stt.provider`. */
+  readonly providerId: SttProviderId;
+}
+
+/**
+ * Discriminated union of telephony setup strategies.
+ */
+export type TelephonySttStrategy =
+  | ConversationRelayNativeStrategy
+  | MediaStreamCustomStrategy;
+
+/**
+ * Result of resolving a telephony STT routing decision.
+ *
+ * - `resolved` — the provider was recognized and a strategy was determined.
+ * - `unknown-provider` — the provider ID is not in the catalog or has no
+ *   telephony routing mapping.
+ */
+export type TelephonySttRoutingResult =
+  | { status: "resolved"; strategy: TelephonySttStrategy }
+  | { status: "unknown-provider"; providerId: string; reason: string };
+
+// ---------------------------------------------------------------------------
+// Model normalization constants
+// ---------------------------------------------------------------------------
+
+const DEEPGRAM_DEFAULT_SPEECH_MODEL = "nova-3";
+
+// ---------------------------------------------------------------------------
+// Provider-to-strategy mapping
+// ---------------------------------------------------------------------------
+
+/**
+ * Map from `services.stt.provider` ID to the corresponding Twilio-native
+ * transcription provider name. Providers absent from this map use the
+ * media-stream custom path.
+ */
+const TWILIO_NATIVE_PROVIDER_MAP: ReadonlyMap<
+  SttProviderId,
+  TwilioNativeTranscriptionProvider
+> = new Map<SttProviderId, TwilioNativeTranscriptionProvider>([
+  ["deepgram", "Deepgram"],
+  ["google-gemini", "Google"],
+]);
+
+// ---------------------------------------------------------------------------
+// Model normalization
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the effective speech model for a Twilio-native provider.
+ *
+ * Preserves the normalization semantics from `stt-profile.ts`:
+ * - Deepgram: falls back to `"nova-3"` when the model is unset.
+ * - Google: leaves the model undefined when unset. Treats the legacy
+ *   Deepgram default `"nova-3"` as unset so that workspaces that were
+ *   previously configured for Deepgram don't send a Deepgram model name
+ *   to Google's Cloud Speech API.
+ */
+function resolveNativeSpeechModel(
+  twilioProvider: TwilioNativeTranscriptionProvider,
+  rawSpeechModel: string | undefined,
+): string | undefined {
+  const isGoogle = twilioProvider === "Google";
+
+  if (rawSpeechModel == null) {
+    return isGoogle ? undefined : DEEPGRAM_DEFAULT_SPEECH_MODEL;
+  }
+
+  // Legacy migration: suppress the Deepgram default when provider is Google.
+  if (rawSpeechModel === DEEPGRAM_DEFAULT_SPEECH_MODEL && isGoogle) {
+    return undefined;
+  }
+
+  return rawSpeechModel;
+}
+
+// ---------------------------------------------------------------------------
+// Public resolver
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the telephony STT routing strategy from `services.stt.provider`.
+ *
+ * Reads the active provider from config, checks the provider catalog for
+ * validity, then maps to either a Twilio-native ConversationRelay strategy
+ * or a media-stream custom strategy.
+ *
+ * @param speechModel - Optional raw speech model from config. When provided,
+ *   model normalization is applied for Twilio-native providers. Typically
+ *   sourced from `calls.voice.speechModel` during the transition period.
+ */
+export function resolveTelephonySttRouting(
+  speechModel?: string | undefined,
+): TelephonySttRoutingResult {
+  const config = getConfig();
+  const providerId = config.services.stt.provider;
+
+  // Validate the provider exists in the catalog.
+  const entry = getProviderEntry(providerId as SttProviderId);
+  if (!entry) {
+    return {
+      status: "unknown-provider",
+      providerId,
+      reason: `STT provider "${providerId}" is not in the provider catalog`,
+    };
+  }
+
+  // Check if this provider maps to a Twilio-native transcription path.
+  const twilioProvider = TWILIO_NATIVE_PROVIDER_MAP.get(entry.id);
+
+  if (twilioProvider) {
+    return {
+      status: "resolved",
+      strategy: {
+        strategy: "conversation-relay-native",
+        providerId: entry.id,
+        transcriptionProvider: twilioProvider,
+        speechModel: resolveNativeSpeechModel(twilioProvider, speechModel),
+      },
+    };
+  }
+
+  // Provider is recognized but not Twilio-native — use media-stream path.
+  return {
+    status: "resolved",
+    strategy: {
+      strategy: "media-stream-custom",
+      providerId: entry.id,
+    },
+  };
+}

--- a/assistant/src/providers/speech-to-text/__tests__/resolve.test.ts
+++ b/assistant/src/providers/speech-to-text/__tests__/resolve.test.ts
@@ -322,3 +322,89 @@ describe("resolveTelephonySttCapability", () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// Tests — telephony routing alignment with provider catalog
+// ---------------------------------------------------------------------------
+
+import { getProviderEntry, listProviderIds } from "../provider-catalog.js";
+
+describe("telephony routing catalog alignment", () => {
+  /**
+   * These tests verify that the assumptions made by the telephony STT
+   * routing resolver (telephony-stt-routing.ts) remain consistent with
+   * the provider catalog entries. If a catalog entry changes its
+   * telephonyMode or a new provider is added, these tests will catch
+   * misalignment early.
+   */
+
+  test("deepgram catalog entry has realtime-ws telephonyMode (Twilio-native eligible)", () => {
+    const entry = getProviderEntry("deepgram");
+    expect(entry).toBeDefined();
+    expect(entry!.telephonyMode).toBe("realtime-ws");
+  });
+
+  test("google-gemini catalog entry has batch-only telephonyMode (Twilio-native eligible)", () => {
+    const entry = getProviderEntry("google-gemini");
+    expect(entry).toBeDefined();
+    expect(entry!.telephonyMode).toBe("batch-only");
+  });
+
+  test("openai-whisper catalog entry has batch-only telephonyMode (media-stream path)", () => {
+    const entry = getProviderEntry("openai-whisper");
+    expect(entry).toBeDefined();
+    expect(entry!.telephonyMode).toBe("batch-only");
+  });
+
+  test("deepgram uses 'deepgram' credential provider", () => {
+    const entry = getProviderEntry("deepgram");
+    expect(entry!.credentialProvider).toBe("deepgram");
+  });
+
+  test("google-gemini uses 'gemini' credential provider", () => {
+    const entry = getProviderEntry("google-gemini");
+    expect(entry!.credentialProvider).toBe("gemini");
+  });
+
+  test("openai-whisper uses 'openai' credential provider", () => {
+    const entry = getProviderEntry("openai-whisper");
+    expect(entry!.credentialProvider).toBe("openai");
+  });
+
+  test("every catalog provider has a non-none telephonyMode", () => {
+    // The telephony routing resolver assumes all known providers
+    // participate in some telephony path (native or media-stream).
+    // If a provider with telephonyMode: "none" is added, the routing
+    // resolver would need to handle it explicitly.
+    for (const id of listProviderIds()) {
+      const entry = getProviderEntry(id);
+      expect(entry).toBeDefined();
+      expect(entry!.telephonyMode).not.toBe("none");
+    }
+  });
+
+  test("capability resolver returns supported for all catalog providers with credentials", async () => {
+    // Verify that every provider in the catalog can resolve to "supported"
+    // when the correct credentials are present. This catches regressions
+    // where a catalog entry is added but the credential mapping is wrong.
+    const credentialMap: Record<string, string> = {
+      "openai-whisper": "openai",
+      deepgram: "deepgram",
+      "google-gemini": "gemini",
+    };
+
+    for (const id of listProviderIds()) {
+      const credKey = credentialMap[id];
+      expect(credKey).toBeDefined();
+
+      mockProviderKeys = { [credKey]: `test-key-${id}` };
+      mockConfig = buildConfig({ provider: id });
+
+      const result = await resolveTelephonySttCapability();
+      expect(result.status).toBe("supported");
+      if (result.status === "supported") {
+        expect(result.providerId).toBe(id);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a typed telephony STT routing resolver that maps services.stt.provider to Twilio setup strategies
- deepgram/google-gemini → ConversationRelay native STT; openai-whisper → media-stream custom path
- Preserves model-normalization semantics from stt-profile.ts for Twilio-native providers

Part of plan: twilio-services-stt-telephony-unify.md (PR 1 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25169" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
