### PR TITLE
feat(sounds): store sound pool as an array with legacy-config decoder

### DIFF
--- a/clients/macos/vellum-assistant/Features/Sounds/SoundsConfig.swift
+++ b/clients/macos/vellum-assistant/Features/Sounds/SoundsConfig.swift
@@ -1,11 +1,69 @@
 import Foundation
 
-/// Per-event sound configuration. `sound` is a filename in the sounds directory
-/// (e.g., "Gentle Ding.aiff"); nil means use the default blip.
+/// Per-event sound configuration. `sounds` is a pool of filenames in the sounds
+/// directory (e.g., "Gentle Ding.aiff"); an empty pool means use the default blip.
 /// Display label is the filename minus its extension.
-struct SoundEventConfig: Codable, Equatable {
+struct SoundEventConfig: Equatable {
     var enabled: Bool
-    var sound: String?
+    var sounds: [String]
+
+    init(enabled: Bool, sounds: [String] = []) {
+        self.enabled = enabled
+        self.sounds = sounds
+    }
+
+    /// Compatibility shim — new code should read/write `sounds` directly.
+    /// Scheduled for removal once all consumers migrate.
+    ///
+    /// Getter returns the first entry in the pool (or `nil` when empty).
+    /// Setter replaces the pool: a non-empty string becomes a single-entry pool,
+    /// `nil` or empty string clears the pool.
+    var sound: String? {
+        get { sounds.first }
+        set {
+            if let newValue, !newValue.isEmpty {
+                sounds = [newValue]
+            } else {
+                sounds = []
+            }
+        }
+    }
+}
+
+extension SoundEventConfig: Codable {
+    enum CodingKeys: String, CodingKey {
+        case enabled
+        case sounds
+        case sound
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        // Match the forgiving JSON loader in `SoundManager.fetchConfig()` — missing
+        // `enabled` keys default to `false` rather than failing the decode.
+        let enabled = try container.decodeIfPresent(Bool.self, forKey: .enabled) ?? false
+
+        let decodedSounds: [String]
+        if let pool = try container.decodeIfPresent([String].self, forKey: .sounds) {
+            decodedSounds = pool
+        } else if let legacy = try container.decodeIfPresent(String.self, forKey: .sound) {
+            decodedSounds = [legacy]
+        } else {
+            decodedSounds = []
+        }
+
+        // Defensively drop empty entries so a malformed pool never hits playback.
+        self.enabled = enabled
+        self.sounds = decodedSounds.filter { !$0.isEmpty }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(enabled, forKey: .enabled)
+        try container.encode(sounds, forKey: .sounds)
+        // New writes are always in the new shape — the app and config ship
+        // together, so there are no pre-PR-1 readers in the wild to cater to.
+    }
 }
 
 /// Top-level sound configuration persisted as JSON.
@@ -19,7 +77,7 @@ struct SoundsConfig: Codable, Equatable {
     static var defaultConfig: SoundsConfig {
         var events: [String: SoundEventConfig] = [:]
         for event in SoundEvent.allCases {
-            events[event.rawValue] = SoundEventConfig(enabled: false, sound: nil)
+            events[event.rawValue] = SoundEventConfig(enabled: false, sounds: [])
         }
         return SoundsConfig(
             globalEnabled: false,
@@ -28,9 +86,9 @@ struct SoundsConfig: Codable, Equatable {
         )
     }
 
-    /// Returns the configuration for a specific event, falling back to disabled with default sound
+    /// Returns the configuration for a specific event, falling back to disabled with an empty pool
     /// if the event is not present in the dictionary.
     func config(for event: SoundEvent) -> SoundEventConfig {
-        events[event.rawValue] ?? SoundEventConfig(enabled: false, sound: nil)
+        events[event.rawValue] ?? SoundEventConfig(enabled: false, sounds: [])
     }
 }

--- a/clients/macos/vellum-assistantTests/SoundsConfigTests.swift
+++ b/clients/macos/vellum-assistantTests/SoundsConfigTests.swift
@@ -1,0 +1,142 @@
+import XCTest
+@testable import VellumAssistantLib
+
+final class SoundsConfigTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func decode(_ json: String) throws -> SoundEventConfig {
+        let data = Data(json.utf8)
+        return try JSONDecoder().decode(SoundEventConfig.self, from: data)
+    }
+
+    private func decodeTopLevel(_ json: String) throws -> SoundsConfig {
+        let data = Data(json.utf8)
+        return try JSONDecoder().decode(SoundsConfig.self, from: data)
+    }
+
+    private func encode(_ config: SoundEventConfig) throws -> [String: Any] {
+        let data = try JSONEncoder().encode(config)
+        let obj = try JSONSerialization.jsonObject(with: data)
+        guard let dict = obj as? [String: Any] else {
+            XCTFail("Encoded SoundEventConfig is not a JSON object")
+            return [:]
+        }
+        return dict
+    }
+
+    // MARK: - Legacy decode
+
+    func test_legacyDecode_singleSound_populatesPool() throws {
+        let config = try decode(#"{"enabled": true, "sound": "gentle.aiff"}"#)
+        XCTAssertTrue(config.enabled)
+        XCTAssertEqual(config.sounds, ["gentle.aiff"])
+        XCTAssertEqual(config.sound, "gentle.aiff")
+    }
+
+    func test_legacyDecode_explicitNull_emptyPool() throws {
+        let config = try decode(#"{"enabled": true, "sound": null}"#)
+        XCTAssertTrue(config.enabled)
+        XCTAssertEqual(config.sounds, [])
+        XCTAssertNil(config.sound)
+    }
+
+    func test_legacyDecode_missingField_emptyPool() throws {
+        let config = try decode(#"{"enabled": false}"#)
+        XCTAssertFalse(config.enabled)
+        XCTAssertEqual(config.sounds, [])
+    }
+
+    // MARK: - New decode
+
+    func test_newDecode_multiSoundPool_preservesOrder() throws {
+        let config = try decode(#"{"enabled": true, "sounds": ["a.wav", "b.wav", "c.wav"]}"#)
+        XCTAssertTrue(config.enabled)
+        XCTAssertEqual(config.sounds, ["a.wav", "b.wav", "c.wav"])
+    }
+
+    // MARK: - Encode shape
+
+    func test_encode_writesSoundsKey_omitsLegacySoundKey() throws {
+        let config = SoundEventConfig(enabled: true, sounds: ["a.wav"])
+        let dict = try encode(config)
+
+        XCTAssertEqual(dict["enabled"] as? Bool, true)
+        XCTAssertEqual(dict["sounds"] as? [String], ["a.wav"])
+        XCTAssertNil(dict["sound"], "Legacy 'sound' key should not be written by the encoder")
+    }
+
+    // MARK: - Roundtrip
+
+    func test_roundtrip_multiSound_preservesEquality() throws {
+        let original = SoundEventConfig(enabled: true, sounds: ["a.wav", "b.wav", "c.wav"])
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(SoundEventConfig.self, from: data)
+        XCTAssertEqual(decoded, original)
+    }
+
+    // MARK: - Shim setter
+
+    func test_shimSetter_nonNil_replacesPool() {
+        var config = SoundEventConfig(enabled: true, sounds: [])
+        config.sound = "x.wav"
+        XCTAssertEqual(config.sounds, ["x.wav"])
+    }
+
+    func test_shimSetter_nil_clearsPool() {
+        var config = SoundEventConfig(enabled: true, sounds: ["a.wav", "b.wav"])
+        config.sound = nil
+        XCTAssertEqual(config.sounds, [])
+    }
+
+    // MARK: - Top-level decode
+
+    func test_topLevelDecode_legacyPayload_eachEventResolvesToSoundsArray() throws {
+        // Matches the "Config shape reference" section in skills/vellum-sounds/SKILL.md.
+        let json = #"""
+        {
+          "globalEnabled": false,
+          "volume": 0.7,
+          "events": {
+            "app_open":         { "enabled": false, "sound": null },
+            "task_complete":    { "enabled": true,  "sound": "ding.aiff" },
+            "needs_input":      { "enabled": false, "sound": null },
+            "task_failed":      { "enabled": false, "sound": null },
+            "notification":     { "enabled": false, "sound": null },
+            "new_conversation": { "enabled": false, "sound": null },
+            "message_sent":     { "enabled": true,  "sound": "whoosh.wav" },
+            "character_poke":   { "enabled": false, "sound": null },
+            "random":           { "enabled": false, "sound": null }
+          }
+        }
+        """#
+        let config = try decodeTopLevel(json)
+
+        XCTAssertFalse(config.globalEnabled)
+        XCTAssertEqual(config.volume, Float(0.7))
+
+        for event in SoundEvent.allCases {
+            let eventConfig = config.config(for: event)
+            // Every event must resolve to the new `sounds` array shape.
+            switch event {
+            case .taskComplete:
+                XCTAssertEqual(eventConfig.sounds, ["ding.aiff"])
+                XCTAssertTrue(eventConfig.enabled)
+            case .messageSent:
+                XCTAssertEqual(eventConfig.sounds, ["whoosh.wav"])
+                XCTAssertTrue(eventConfig.enabled)
+            default:
+                XCTAssertEqual(eventConfig.sounds, [], "\(event.rawValue) should have empty pool")
+                XCTAssertFalse(eventConfig.enabled)
+            }
+        }
+    }
+
+    // MARK: - Empty-string defense
+
+    func test_decode_dropsEmptyStringEntries() throws {
+        let config = try decode(#"{"enabled": true, "sounds": ["", "x.wav"]}"#)
+        XCTAssertTrue(config.enabled)
+        XCTAssertEqual(config.sounds, ["x.wav"])
+    }
+}


### PR DESCRIPTION
## Summary
- Replace SoundEventConfig.sound: String? with sounds: [String] backed by a source-compat shim
- Add explicit Codable handling that decodes both the new sounds array and legacy sound string shapes
- Add SoundsConfigTests covering legacy/new decode, encode shape, roundtrip, and the shim

Part of plan: sound-pools.md (PR 1 of 5)