### PR TITLE
feat(vellum-sounds): add pool flags and legacy-config migration to update-config

### DIFF
--- a/skills/vellum-sounds/SKILL.md
+++ b/skills/vellum-sounds/SKILL.md
@@ -17,7 +17,7 @@ You are helping the user customize the sound effects their macOS app plays. Soun
 Two stores, both under `$VELLUM_WORKSPACE_DIR/data/sounds/`:
 
 - **Sound files** — `.aiff`, `.wav`, `.mp3`, `.m4a`, or `.caf`. No other extensions are accepted. The macOS app scans this directory to populate the dropdown for each event.
-- **`config.json`** — a single JSON file that stores the global on/off switch, the master volume, and a per-event map of `{ enabled, sound }`.
+- **`config.json`** — a single JSON file that stores the global on/off switch, the master volume, and a per-event map of `{ enabled, sounds }`. Each event's `sounds` is a **pool** of filenames; the app picks one at random on playback. An empty pool falls back to the default macOS blip.
 
 ## The 9 events
 
@@ -62,15 +62,37 @@ Rules:
 
 ## Mode 3: Configure via the helper script
 
-Use `scripts/update-config.ts` to edit `config.json`. It validates inputs, creates the file with defaults if missing, and writes atomically so a crash can't corrupt it.
+Use `scripts/update-config.ts` to edit `config.json`. It validates inputs, creates the file with defaults if missing, and writes atomically so a crash can't corrupt it. If the existing file uses the legacy single-sound shape (`"sound": "foo.wav"`), the script normalizes it to the new pool shape (`"sounds": ["foo.wav"]`) on the next write.
 
 ```bash
 bun run scripts/update-config.ts --global-enabled true
 bun run scripts/update-config.ts --volume 0.5
 bun run scripts/update-config.ts --event message_sent --enabled true --sound "gentle-ding.aiff"
 bun run scripts/update-config.ts --event random --enabled false
-bun run scripts/update-config.ts --event task_complete --sound null   # revert to default blip
+bun run scripts/update-config.ts --event task_complete --sound null   # clear the pool, revert to default blip
 ```
+
+### Mode 3a: Sound pools
+
+Each event can hold **one or more** sounds. When the event fires, the macOS app picks one entry at random from the pool. This is how you build variety (e.g. three different "poke" sounds that rotate when the user clicks the avatar). An empty pool falls back to the default macOS blip.
+
+```bash
+# Replace the pool with three sounds
+bun run scripts/update-config.ts --event character_poke --sounds "poke1.wav,poke2.wav,poke3.wav"
+
+# Append one more sound to the existing pool
+bun run scripts/update-config.ts --event character_poke --add-sound "poke4.wav"
+
+# Drop a specific entry
+bun run scripts/update-config.ts --event character_poke --remove-sound "poke2.wav"
+
+# Empty the pool (back to the default blip)
+bun run scripts/update-config.ts --event character_poke --clear-sounds
+```
+
+`--sound` is retained as a convenience for the common single-sound case: it **replaces the whole pool** with one entry (or clears it, when given `null`). Use `--sounds` / `--add-sound` / `--remove-sound` / `--clear-sounds` for pool edits.
+
+Only one pool-mutation flag is allowed per invocation — mixing `--sound` and `--add-sound` (or any other pair) is rejected with a clear error. The one exception is `--add-sound`, which may be passed multiple times to append several filenames in a single run.
 
 Flag reference:
 
@@ -80,7 +102,11 @@ Flag reference:
 | `--volume` | `0.0`–`1.0` (clamped) | Master volume. `0.7` is the default. |
 | `--event` | one of the 9 keys above | Scopes the next flags to a single event. |
 | `--enabled` | `true` or `false` | Per-event on/off (requires `--event`). |
-| `--sound` | filename or `null` | Which file to play for this event (requires `--event`). `null` = macOS "Tink" default blip. The file must already exist in `data/sounds/`. |
+| `--sound` | filename or `null` | Single-sound convenience (requires `--event`). **Replaces** the entire pool with one entry, or clears it when given `null`. The file must already exist in `data/sounds/`. |
+| `--sounds` | comma-separated filenames | Replaces the pool with the given list (requires `--event`). Every filename must already exist in `data/sounds/`. Use `--clear-sounds` to empty. |
+| `--add-sound` | filename | Appends one filename to the pool (requires `--event`). No-op with a warning if already present. May be repeated in a single invocation. |
+| `--remove-sound` | filename | Removes one filename from the pool (requires `--event`). No-op with a warning if not present. |
+| `--clear-sounds` | — | Empties the pool (requires `--event`). |
 
 The script prints the resulting config slice so you can confirm what changed.
 
@@ -90,19 +116,24 @@ The script prints the resulting config slice so you can confirm what changed.
 rm "$VELLUM_WORKSPACE_DIR/data/sounds/<filename>"
 ```
 
-Then clear any event that referenced it, so the config doesn't dangle:
+Then remove it from any event pool that referenced it, so the config doesn't dangle:
 
 ```bash
-bun run scripts/update-config.ts --event <key> --sound null
+# If the file was one entry in a larger pool:
+bun run scripts/update-config.ts --event <key> --remove-sound "<filename>"
+
+# If the event only had that one sound (or you want to reset entirely):
+bun run scripts/update-config.ts --event <key> --clear-sounds
 ```
 
-(The macOS app already falls back to the default blip if a referenced file is missing, but cleaning up the config is tidier.)
+(The macOS app already falls back to the default blip if every referenced file is missing, but cleaning up the config is tidier.)
 
 ## UX Guidelines
 
 - **Always check current state first.** Don't ask "what do you want to do" if they already have sounds configured — summarize what's set up, then ask what to change.
 - **The master switch is the #1 gotcha.** `globalEnabled` defaults to `false`. If the user assigns a sound to an event and doesn't hear anything, check that flag first. When assigning the user's first sound, offer to flip the master switch on for them.
-- **Per-event enabled is the #2 gotcha.** Each event has its own `enabled` bool. Setting `sound` alone doesn't enable the event.
+- **Per-event enabled is the #2 gotcha.** Each event has its own `enabled` bool. Setting a sound alone doesn't enable the event.
+- **Pool editing in the UI.** The macOS Settings → Sounds tab also supports pool editing — users can add, remove, and reorder entries there without running this script. Power users can weight a sound more heavily by hand-editing `config.json` to include duplicates (e.g. `["a.wav","a.wav","b.wav"]` makes `a.wav` twice as likely). The script de-dupes on `--add-sound` but does not re-sort or de-dupe on read, so hand-edited duplicates survive round-trips.
 - **Filename sanity.** When the user sends a file named something like `Screen Recording 2026-04-13 at 11.47.23.m4a`, rename it to something memorable before copying — they'll have to pick it from a dropdown later.
 - **Confirm after changes.** Tell the user the Settings → Sounds tab will reflect changes live. Offer to open it: "You can preview it in Settings → Sounds, or I can play it for you next time that event fires."
 - **Don't invent events.** The 9 event keys above are the complete list. There is currently no event for voice-mode activation or typing indicators — if the user asks for those, tell them it'd need a code change to the macOS app.
@@ -116,15 +147,17 @@ If the user inspects `config.json` directly, this is what they'll see. Defaults 
   "globalEnabled": false,
   "volume": 0.7,
   "events": {
-    "app_open":         { "enabled": false, "sound": null },
-    "task_complete":    { "enabled": false, "sound": null },
-    "needs_input":      { "enabled": false, "sound": null },
-    "task_failed":      { "enabled": false, "sound": null },
-    "notification":     { "enabled": false, "sound": null },
-    "new_conversation": { "enabled": false, "sound": null },
-    "message_sent":     { "enabled": false, "sound": null },
-    "character_poke":   { "enabled": false, "sound": null },
-    "random":           { "enabled": false, "sound": null }
+    "app_open":         { "enabled": false, "sounds": [] },
+    "task_complete":    { "enabled": false, "sounds": [] },
+    "needs_input":      { "enabled": false, "sounds": [] },
+    "task_failed":      { "enabled": false, "sounds": [] },
+    "notification":     { "enabled": false, "sounds": [] },
+    "new_conversation": { "enabled": false, "sounds": [] },
+    "message_sent":     { "enabled": false, "sounds": [] },
+    "character_poke":   { "enabled": false, "sounds": [] },
+    "random":           { "enabled": false, "sounds": [] }
   }
 }
 ```
+
+Legacy `{"sound": "foo.wav"}` entries are still accepted on read (the macOS decoder and this script both normalize them into `{"sounds": ["foo.wav"]}`), but new writes always use the pool shape.

--- a/skills/vellum-sounds/scripts/update-config.ts
+++ b/skills/vellum-sounds/scripts/update-config.ts
@@ -5,6 +5,11 @@
  * Safely reads and writes $VELLUM_WORKSPACE_DIR/data/sounds/config.json,
  * the configuration file consumed by the macOS app's SoundManager. Validates
  * inputs, creates the file with defaults if missing, and writes atomically.
+ *
+ * Each event holds a **pool** of sound filenames (`sounds: string[]`). The
+ * macOS app picks one at random on playback. An empty pool means "use the
+ * default macOS blip." This script also reads legacy single-sound entries
+ * (`{"sound": "foo.wav"}`) and normalizes them to the new pool shape on write.
  */
 
 import {
@@ -37,7 +42,7 @@ type EventKey = (typeof EVENT_KEYS)[number];
 
 interface SoundEventConfig {
   enabled: boolean;
-  sound: string | null;
+  sounds: string[];
 }
 
 interface SoundsConfig {
@@ -49,7 +54,7 @@ interface SoundsConfig {
 function defaultConfig(): SoundsConfig {
   const events: Record<string, SoundEventConfig> = {};
   for (const key of EVENT_KEYS) {
-    events[key] = { enabled: false, sound: null };
+    events[key] = { enabled: false, sounds: [] };
   }
   return { globalEnabled: false, volume: 0.7, events };
 }
@@ -60,20 +65,39 @@ function printUsage(): void {
 Edit data/sounds/config.json in the current workspace. Creates the file with
 defaults if it doesn't exist. Writes atomically.
 
+Each event holds a pool of sound filenames; the macOS app picks one at random
+on playback. An empty pool falls back to the default macOS blip.
+
 Options:
   --global-enabled <true|false>   Master on/off for all sounds.
   --volume <float>                 Master volume, 0.0–1.0 (clamped).
   --event <key>                    One of: ${EVENT_KEYS.join(", ")}
   --enabled <true|false>           Per-event on/off (requires --event).
-  --sound <filename|null>          Sound file in data/sounds/ to play for this
-                                   event, or "null" for the default blip
-                                   (requires --event).
+
+  Pool mutation flags (all require --event; at most one per invocation,
+  except --add-sound which may be repeated):
+  --sound <filename|null>          Single-sound convenience: replaces the
+                                   whole pool with one entry, or clears it
+                                   when given "null".
+  --sounds <csv>                   Replaces the pool with the comma-separated
+                                   list (e.g. "a.wav,b.wav,c.wav"). Use
+                                   --clear-sounds to empty.
+  --add-sound <filename>           Appends to the pool. No-op (warning) if
+                                   already present. May be repeated.
+  --remove-sound <filename>        Removes an entry. No-op (warning) if not
+                                   present.
+  --clear-sounds                   Sets the pool to [].
+
   --help, -h                       Show this help.
 
 Examples:
   bun run scripts/update-config.ts --global-enabled true
   bun run scripts/update-config.ts --volume 0.5
   bun run scripts/update-config.ts --event message_sent --enabled true --sound "gentle-ding.aiff"
+  bun run scripts/update-config.ts --event character_poke --sounds "poke1.wav,poke2.wav,poke3.wav"
+  bun run scripts/update-config.ts --event character_poke --add-sound "poke4.wav"
+  bun run scripts/update-config.ts --event character_poke --remove-sound "poke2.wav"
+  bun run scripts/update-config.ts --event character_poke --clear-sounds
   bun run scripts/update-config.ts --event task_complete --sound null
 `);
 }
@@ -83,12 +107,24 @@ function fail(message: string): never {
   process.exit(1);
 }
 
+/**
+ * Tagged union describing which pool-mutation operation the user requested.
+ * Exactly one variant is allowed per invocation (except `add`, which accepts
+ * multiple filenames via repeated `--add-sound` flags).
+ */
+type PoolOp =
+  | { kind: "sound"; value: string | null }
+  | { kind: "sounds"; values: string[] }
+  | { kind: "add"; values: string[] }
+  | { kind: "remove"; value: string }
+  | { kind: "clear" };
+
 interface ParsedArgs {
   globalEnabled?: boolean;
   volume?: number;
   event?: EventKey;
   enabled?: boolean;
-  sound?: string | null;
+  poolOp?: PoolOp;
   help: boolean;
 }
 
@@ -97,6 +133,35 @@ function parseBool(raw: string, flag: string): boolean {
   if (lower === "true") return true;
   if (lower === "false") return false;
   fail(`${flag} must be "true" or "false" (got "${raw}")`);
+}
+
+function parseCsv(raw: string, flag: string): string[] {
+  if (raw === "") {
+    fail(`${flag} must not be empty (use --clear-sounds to empty the pool)`);
+  }
+  const parts = raw
+    .split(",")
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0);
+  if (parts.length === 0) {
+    fail(`${flag} must contain at least one non-empty filename`);
+  }
+  return parts;
+}
+
+function setPoolOp(out: ParsedArgs, op: PoolOp, flag: string): void {
+  // Multiple --add-sound flags merge; any other combination is an error.
+  if (out.poolOp) {
+    if (out.poolOp.kind === "add" && op.kind === "add") {
+      out.poolOp.values.push(...op.values);
+      return;
+    }
+    fail(
+      `${flag} is mutually exclusive with --sound, --sounds, --remove-sound, ` +
+        `and --clear-sounds. Only --add-sound may be repeated.`,
+    );
+  }
+  out.poolOp = op;
 }
 
 function parseArgs(argv: string[]): ParsedArgs {
@@ -139,9 +204,29 @@ function parseArgs(argv: string[]): ParsedArgs {
         break;
       case "--sound": {
         const raw = next();
-        out.sound = raw === "null" ? null : raw;
+        setPoolOp(out, { kind: "sound", value: raw === "null" ? null : raw }, arg);
         break;
       }
+      case "--sounds": {
+        const raw = next();
+        setPoolOp(out, { kind: "sounds", values: parseCsv(raw, arg) }, arg);
+        break;
+      }
+      case "--add-sound": {
+        const raw = next();
+        if (raw === "") fail(`${arg} must not be empty`);
+        setPoolOp(out, { kind: "add", values: [raw] }, arg);
+        break;
+      }
+      case "--remove-sound": {
+        const raw = next();
+        if (raw === "") fail(`${arg} must not be empty`);
+        setPoolOp(out, { kind: "remove", value: raw }, arg);
+        break;
+      }
+      case "--clear-sounds":
+        setPoolOp(out, { kind: "clear" }, arg);
+        break;
       default:
         fail(`Unknown flag: ${arg}`);
     }
@@ -186,10 +271,24 @@ function readConfig(path: string): SoundsConfig {
       for (const key of EVENT_KEYS) {
         const entry = (p.events as Record<string, unknown>)[key];
         if (entry && typeof entry === "object") {
-          const e = entry as Partial<SoundEventConfig>;
+          const e = entry as {
+            enabled?: unknown;
+            sounds?: unknown;
+            sound?: unknown;
+          };
           if (typeof e.enabled === "boolean") base.events[key].enabled = e.enabled;
-          if (e.sound === null || typeof e.sound === "string") {
-            base.events[key].sound = e.sound;
+          // Match the Swift decoder (SoundsConfig.swift): prefer the new
+          // `sounds` array; fall back to the legacy single `sound` string;
+          // otherwise leave the pool empty. Filter out non-string / empty
+          // entries defensively so a malformed pool never hits playback.
+          if (Array.isArray(e.sounds)) {
+            base.events[key].sounds = e.sounds.filter(
+              (s): s is string => typeof s === "string" && s.length > 0,
+            );
+          } else if (typeof e.sound === "string" && e.sound.length > 0) {
+            base.events[key].sounds = [e.sound];
+          } else {
+            base.events[key].sounds = [];
           }
         }
       }
@@ -223,16 +322,16 @@ function writeConfigAtomic(path: string, config: SoundsConfig): void {
 
 function validateSoundFilename(soundsDir: string, filename: string): void {
   if (filename.includes("/") || filename.includes("\\")) {
-    fail(`--sound filename must not contain path separators (got "${filename}")`);
+    fail(`sound filename must not contain path separators (got "${filename}")`);
   }
   if (filename.startsWith(".")) {
-    fail(`--sound filename must not start with "." (got "${filename}")`);
+    fail(`sound filename must not start with "." (got "${filename}")`);
   }
   const dotIdx = filename.lastIndexOf(".");
   const ext = dotIdx >= 0 ? filename.slice(dotIdx + 1).toLowerCase() : "";
   if (!(SUPPORTED_EXTENSIONS as readonly string[]).includes(ext)) {
     fail(
-      `--sound must have a supported extension (${SUPPORTED_EXTENSIONS.join(", ")}); got ".${ext}"`,
+      `sound filename must have a supported extension (${SUPPORTED_EXTENSIONS.join(", ")}); got ".${ext}"`,
     );
   }
   const full = join(soundsDir, filename);
@@ -243,6 +342,60 @@ function validateSoundFilename(soundsDir: string, filename: string): void {
   }
 }
 
+function applyPoolOp(
+  soundsDir: string,
+  eventConfig: SoundEventConfig,
+  op: PoolOp,
+): void {
+  switch (op.kind) {
+    case "sound": {
+      // Single-sound convenience: replace the whole pool.
+      if (op.value === null) {
+        eventConfig.sounds = [];
+      } else {
+        validateSoundFilename(soundsDir, op.value);
+        eventConfig.sounds = [op.value];
+      }
+      return;
+    }
+    case "sounds": {
+      for (const name of op.values) {
+        validateSoundFilename(soundsDir, name);
+      }
+      eventConfig.sounds = [...op.values];
+      return;
+    }
+    case "add": {
+      for (const name of op.values) {
+        validateSoundFilename(soundsDir, name);
+        if (eventConfig.sounds.includes(name)) {
+          process.stderr.write(
+            `Warning: "${name}" is already in the pool; skipping.\n`,
+          );
+          continue;
+        }
+        eventConfig.sounds.push(name);
+      }
+      return;
+    }
+    case "remove": {
+      const idx = eventConfig.sounds.indexOf(op.value);
+      if (idx < 0) {
+        process.stderr.write(
+          `Warning: "${op.value}" is not in the pool; nothing to remove.\n`,
+        );
+        return;
+      }
+      eventConfig.sounds.splice(idx, 1);
+      return;
+    }
+    case "clear": {
+      eventConfig.sounds = [];
+      return;
+    }
+  }
+}
+
 function main(): void {
   const args = parseArgs(process.argv.slice(2));
   if (args.help) {
@@ -250,9 +403,11 @@ function main(): void {
     return;
   }
 
-  const hasEventFlag = args.enabled !== undefined || args.sound !== undefined;
+  const hasEventFlag = args.enabled !== undefined || args.poolOp !== undefined;
   if (hasEventFlag && !args.event) {
-    fail("--enabled and --sound require --event");
+    fail(
+      "--enabled, --sound, --sounds, --add-sound, --remove-sound, and --clear-sounds require --event",
+    );
   }
   if (
     args.globalEnabled === undefined &&
@@ -280,14 +435,7 @@ function main(): void {
   if (args.event) {
     const eventConfig = config.events[args.event];
     if (args.enabled !== undefined) eventConfig.enabled = args.enabled;
-    if (args.sound !== undefined) {
-      if (args.sound === null) {
-        eventConfig.sound = null;
-      } else {
-        validateSoundFilename(soundsDir, args.sound);
-        eventConfig.sound = args.sound;
-      }
-    }
+    if (args.poolOp) applyPoolOp(soundsDir, eventConfig, args.poolOp);
     changed[`events.${args.event}`] = eventConfig;
   }
 


### PR DESCRIPTION
## Summary
- update-config.ts now accepts --sounds, --add-sound, --remove-sound, --clear-sounds; writes the new { sounds: [] } shape
- readConfig() normalizes legacy single-sound entries into pools on read
- SKILL.md documents the new pool syntax and retains --sound as a single-sound convenience

Part of plan: sound-pools.md (PR 4 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25175" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
