### PR TITLE
chore(sounds): drop the sound→sounds compatibility shim

### DIFF
--- a/clients/macos/vellum-assistant/Features/Sounds/SoundsConfig.swift
+++ b/clients/macos/vellum-assistant/Features/Sounds/SoundsConfig.swift
@@ -11,30 +11,14 @@ struct SoundEventConfig: Equatable {
         self.enabled = enabled
         self.sounds = sounds
     }
-
-    /// Compatibility shim — new code should read/write `sounds` directly.
-    /// Scheduled for removal once all consumers migrate.
-    ///
-    /// Getter returns the first entry in the pool (or `nil` when empty).
-    /// Setter replaces the pool: a non-empty string becomes a single-entry pool,
-    /// `nil` or empty string clears the pool.
-    var sound: String? {
-        get { sounds.first }
-        set {
-            if let newValue, !newValue.isEmpty {
-                sounds = [newValue]
-            } else {
-                sounds = []
-            }
-        }
-    }
 }
 
 extension SoundEventConfig: Codable {
     enum CodingKeys: String, CodingKey {
         case enabled
         case sounds
-        case sound
+        // "sound" is the pre-pool legacy JSON key; we still decode it for old config files.
+        case legacySound = "sound"
     }
 
     init(from decoder: Decoder) throws {
@@ -46,7 +30,7 @@ extension SoundEventConfig: Codable {
         let decodedSounds: [String]
         if let pool = try container.decodeIfPresent([String].self, forKey: .sounds) {
             decodedSounds = pool
-        } else if let legacy = try container.decodeIfPresent(String.self, forKey: .sound) {
+        } else if let legacy = try container.decodeIfPresent(String.self, forKey: .legacySound) {
             decodedSounds = [legacy]
         } else {
             decodedSounds = []

--- a/clients/macos/vellum-assistantTests/SoundsConfigTests.swift
+++ b/clients/macos/vellum-assistantTests/SoundsConfigTests.swift
@@ -31,14 +31,12 @@ final class SoundsConfigTests: XCTestCase {
         let config = try decode(#"{"enabled": true, "sound": "gentle.aiff"}"#)
         XCTAssertTrue(config.enabled)
         XCTAssertEqual(config.sounds, ["gentle.aiff"])
-        XCTAssertEqual(config.sound, "gentle.aiff")
     }
 
     func test_legacyDecode_explicitNull_emptyPool() throws {
         let config = try decode(#"{"enabled": true, "sound": null}"#)
         XCTAssertTrue(config.enabled)
         XCTAssertEqual(config.sounds, [])
-        XCTAssertNil(config.sound)
     }
 
     func test_legacyDecode_missingField_emptyPool() throws {
@@ -73,20 +71,6 @@ final class SoundsConfigTests: XCTestCase {
         let data = try JSONEncoder().encode(original)
         let decoded = try JSONDecoder().decode(SoundEventConfig.self, from: data)
         XCTAssertEqual(decoded, original)
-    }
-
-    // MARK: - Shim setter
-
-    func test_shimSetter_nonNil_replacesPool() {
-        var config = SoundEventConfig(enabled: true, sounds: [])
-        config.sound = "x.wav"
-        XCTAssertEqual(config.sounds, ["x.wav"])
-    }
-
-    func test_shimSetter_nil_clearsPool() {
-        var config = SoundEventConfig(enabled: true, sounds: ["a.wav", "b.wav"])
-        config.sound = nil
-        XCTAssertEqual(config.sounds, [])
     }
 
     // MARK: - Top-level decode


### PR DESCRIPTION
## Summary
- Remove the computed sound: String? shim on SoundEventConfig now that all consumers read/write sounds directly
- Preserve the legacy-config decoder path so pre-pool on-disk configs still load
- Drop the shim-only tests while keeping the legacy JSON decode coverage

Part of plan: sound-pools.md (PR 5 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25176" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
