### PR TITLE
fix(macos): reload sounds config on daemon (re)connect

### DIFF
--- a/clients/macos/vellum-assistant/Features/Sounds/SoundManager.swift
+++ b/clients/macos/vellum-assistant/Features/Sounds/SoundManager.swift
@@ -43,9 +43,29 @@ final class SoundManager {
 
     func start(featureFlagStore: AssistantFeatureFlagStore? = nil) {
         self.featureFlagStore = featureFlagStore
-        // Config is fetched later via reloadConfig() once the gateway is
-        // confirmed ready. Fetching here would race the assistant startup
-        // and fall back to defaults on connection-refused.
+
+        // Reload sounds config on every daemon (re)connect. The daemon
+        // only broadcasts sounds_config_updated on file mutations, so
+        // without this hook the config would stay at `.defaultConfig`
+        // (silent) across every app restart until the user touched
+        // data/sounds/config.json on disk. GatewayConnectionManager
+        // posts .daemonDidReconnect when `isConnected` transitions to
+        // true, giving us the "gateway is confirmed ready" signal.
+        //
+        // Also kick off one eager reload for the race where the
+        // connection already completed before start() runs; if it
+        // fails, fetchConfig() silently falls back to defaults and
+        // the next .daemonDidReconnect will overwrite them.
+        NotificationCenter.default.addObserver(
+            forName: .daemonDidReconnect,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                self?.reloadConfig()
+            }
+        }
+        reloadConfig()
     }
 
     // MARK: - Config Loading & Saving


### PR DESCRIPTION
## Summary

- `SoundManager.reloadConfig()` was only invoked by the SSE `sounds_config_updated` event, which the daemon only broadcasts on file mutations. On every app restart, `SoundManager.config` stayed at `.defaultConfig` (all pools empty / all events disabled) until the user manually saved `~/.vellum/workspace/data/sounds/config.json`, making all configurable sounds silent.
- Fix by subscribing to `.daemonDidReconnect` in `SoundManager.start()` so the config is reloaded on every fresh gateway connection (startup, daemon restart, network reconnect). Also issue one eager `reloadConfig()` to cover the race where the connection completes before `start()` runs — a failed eager call silently falls back to defaults and the next reconnect overwrites them.
- Mirrors the pattern applied to `SettingsStore` in #25168 for the same class of bug (timezone, media embeds, TTS/STT providers, host-browser cdp-inspect, service modes).

## Original prompt

Whenever I restart the app, the in-app sounds are disabled until I manually go and save /Users/sidd/.vellum/workspace/data/sounds/config.json (probably to get the file watcher to pick it up or something)