### PR TITLE
fix(sounds): handle pool duplicates and empty-library state in settings UI

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsSoundsTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsSoundsTab.swift
@@ -147,7 +147,7 @@ struct SettingsSoundsTab: View {
                 }
                 .frame(maxWidth: 220, alignment: .leading)
             } else {
-                ForEach(eventConfig.sounds, id: \.self) { filename in
+                ForEach(Array(eventConfig.sounds.enumerated()), id: \.offset) { index, filename in
                     HStack(spacing: VSpacing.xs) {
                         let displayLabel = labelsByFilename[filename]
                             ?? (filename as NSString).deletingPathExtension
@@ -165,7 +165,7 @@ struct SettingsSoundsTab: View {
                             style: .ghost,
                             tooltip: "Remove sound"
                         ) {
-                            removeSound(filename, for: event)
+                            removeSound(at: index, for: event)
                         }
                     }
                     .frame(maxWidth: 220, alignment: .leading)
@@ -177,9 +177,15 @@ struct SettingsSoundsTab: View {
                 .filter { !inPool.contains($0.filename) }
                 .map { (label: $0.label, value: $0.filename) }
 
-            if remainingOptions.isEmpty {
-                // Every available sound is already in the pool — show a disabled
-                // dropdown so the UI stays stable rather than visually jumping.
+            if sounds.isEmpty {
+                // Library is empty — render a subtle hint instead of a misleading "All sounds added" dropdown.
+                Text("No sound files yet")
+                    .font(VFont.bodyMediumLighter)
+                    .foregroundStyle(VColor.contentDisabled)
+                    .frame(maxWidth: 220, alignment: .leading)
+            } else if remainingOptions.isEmpty {
+                // Every available sound is already in the pool — show a disabled dropdown
+                // so the UI stays stable rather than visually jumping.
                 VDropdown(
                     placeholder: "All sounds added",
                     selection: .constant(""),
@@ -214,10 +220,11 @@ struct SettingsSoundsTab: View {
         soundManager.saveConfig(updated)
     }
 
-    private func removeSound(_ filename: String, for event: SoundEvent) {
+    private func removeSound(at index: Int, for event: SoundEvent) {
         var updated = soundManager.config
         var ec = updated.config(for: event)
-        ec.sounds = ec.sounds.filter { $0 != filename }
+        guard ec.sounds.indices.contains(index) else { return }
+        ec.sounds.remove(at: index)
         updated.events[event.rawValue] = ec
         soundManager.saveConfig(updated)
     }


### PR DESCRIPTION
## Summary
- Pool editor iterates by index so duplicates render and remove correctly (one click removes one occurrence, not all)
- Distinguish empty-library from all-added in the Add-sound row so a fresh install no longer shows a misleading 'All sounds added' label

Fixes gaps identified during plan review for sound-pools.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25178" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
