### PR TITLE
fix(sounds): widen sound pool dropdown and enable scrolling

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsSoundsTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsSoundsTab.swift
@@ -190,7 +190,9 @@ struct SettingsSoundsTab: View {
                     placeholder: "All sounds added",
                     selection: .constant(""),
                     options: [(label: "All sounds added", value: "")],
-                    maxWidth: 220
+                    maxWidth: 220,
+                    menuWidth: 260,
+                    menuMaxHeight: 360
                 )
                 .disabled(true)
             } else {
@@ -204,7 +206,9 @@ struct SettingsSoundsTab: View {
                         }
                     ),
                     options: remainingOptions,
-                    maxWidth: 220
+                    maxWidth: 220,
+                    menuWidth: 260,
+                    menuMaxHeight: 360
                 )
             }
         }

--- a/clients/shared/DesignSystem/Components/Navigation/VMenu.swift
+++ b/clients/shared/DesignSystem/Components/Navigation/VMenu.swift
@@ -133,6 +133,7 @@ public extension EnvironmentValues {
 /// ```
 public struct VMenu<Content: View>: View {
     public let width: CGFloat?
+    public let maxHeight: CGFloat?
     public let content: Content
 
     #if os(macOS)
@@ -147,18 +148,35 @@ public struct VMenu<Content: View>: View {
 
     public init(
         width: CGFloat? = nil,
+        maxHeight: CGFloat? = nil,
         @ViewBuilder content: () -> Content
     ) {
         self.width = width
+        self.maxHeight = maxHeight
         self.content = content()
     }
 
-    public var body: some View {
-        VStack(alignment: .leading, spacing: VSpacing.xs) {
+    /// The menu's inner content, optionally wrapped in a vertical `ScrollView` when
+    /// `maxHeight` is set. Keeping the scroll wrapper conditional preserves the
+    /// intrinsic-size path for existing callers that don't opt into a height cap.
+    @ViewBuilder
+    private var innerContent: some View {
+        let stack = VStack(alignment: .leading, spacing: VSpacing.xs) {
             content
         }
         .padding(VSpacing.sm)
+
+        if maxHeight != nil {
+            ScrollView(.vertical) { stack }
+        } else {
+            stack
+        }
+    }
+
+    public var body: some View {
+        innerContent
         .frame(width: width)
+        .frame(maxHeight: maxHeight)
         .environment(\.vMenuParentWidth, width)
         #if os(macOS)
         .environment(\.vMenuFocusedItemID, focusedItemID)

--- a/clients/shared/DesignSystem/Core/Inputs/VDropdown.swift
+++ b/clients/shared/DesignSystem/Core/Inputs/VDropdown.swift
@@ -47,6 +47,7 @@ public struct VDropdown<T: Hashable>: View {
     public var emptyValue: T?
     public var maxWidth: CGFloat = .infinity
     public var menuWidth: CGFloat = 180
+    public var menuMaxHeight: CGFloat?
     public var icon: VIcon?
     public var optionIcon: ((T) -> VIcon?)?
     public var onChange: ((T) -> Void)?
@@ -62,6 +63,7 @@ public struct VDropdown<T: Hashable>: View {
         emptyValue: T? = nil,
         maxWidth: CGFloat = .infinity,
         menuWidth: CGFloat = 180,
+        menuMaxHeight: CGFloat? = nil,
         icon: VIcon? = nil,
         optionIcon: ((T) -> VIcon?)? = nil,
         onChange: ((T) -> Void)? = nil
@@ -73,6 +75,7 @@ public struct VDropdown<T: Hashable>: View {
         self.emptyValue = emptyValue
         self.maxWidth = maxWidth
         self.menuWidth = menuWidth
+        self.menuMaxHeight = menuMaxHeight
         self.icon = icon
         self.optionIcon = optionIcon
         self.onChange = onChange
@@ -87,6 +90,7 @@ public struct VDropdown<T: Hashable>: View {
         emptyValue: T? = nil,
         maxWidth: CGFloat = .infinity,
         menuWidth: CGFloat = 180,
+        menuMaxHeight: CGFloat? = nil,
         icon: VIcon? = nil,
         optionIcon: ((T) -> VIcon?)? = nil,
         onChange: ((T) -> Void)? = nil
@@ -98,6 +102,7 @@ public struct VDropdown<T: Hashable>: View {
         self.emptyValue = emptyValue
         self.maxWidth = maxWidth
         self.menuWidth = menuWidth
+        self.menuMaxHeight = menuMaxHeight
         self.icon = icon
         self.optionIcon = optionIcon
         self.onChange = onChange
@@ -218,7 +223,7 @@ public struct VDropdown<T: Hashable>: View {
         // window) — attaching to the wrong parent shoves the modal behind via
         // `addChildWindow`.
         activePanel = VMenuPanel.show(at: screenPoint, sourceWindow: window, sourceAppearance: appearance, excludeRect: triggerScreenRect) {
-            VMenu(width: menuWidth) {
+            VMenu(width: menuWidth, maxHeight: menuMaxHeight) {
                 ForEach(optionList) { option in
                     VMenuItem(
                         icon: option.icon?.rawValue ?? optionIcon?(option.value)?.rawValue,


### PR DESCRIPTION
## Summary
- Add `maxHeight` to `VMenu` (conditional `ScrollView` wrap) and `menuMaxHeight` to `VDropdown` so any dropdown can cap its menu height and scroll
- Pass `menuWidth: 260, menuMaxHeight: 360` on the Settings → Sounds "Add sound…" dropdown so long filenames (e.g. `velissa-hey-over-here`) render in full and long lists scroll within the menu instead of overflowing the screen

## Original prompt
it