### PR TITLE
fix(macos): apply italic via .obliqueness to survive NSTextView bridge

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -585,6 +585,14 @@ struct MarkdownSegmentView: View, Equatable {
 
     private static let mdConvertLog = Logger(subsystem: Bundle.appBundleIdentifier, category: "MarkdownConvert")
 
+    /// Shear applied to italic glyphs via `NSAttributedString.Key.obliqueness`.
+    /// DM Sans has no italic font face, so the slant has to be synthesized.
+    /// Negative because `.obliqueness`'s sign convention is the opposite of
+    /// the font-matrix shear — a negative attribute value produces a rightward
+    /// (forward) slant, which is the correct italic appearance. Value matches
+    /// the historical 12° font-matrix transform (tan(12°) ≈ 0.213).
+    private static let emphasisObliqueness: NSNumber = -0.213 as NSNumber
+
     #if os(macOS)
     /// Converts a SwiftUI `AttributedString` to `NSAttributedString` with a
     /// base font and text color applied as defaults. Runs that already carry
@@ -684,19 +692,13 @@ struct MarkdownSegmentView: View, Equatable {
             )
         }
 
-        func fontHasExpectedTraits(_ font: NSFont, isEmphasized: Bool, isBold: Bool) -> Bool {
-            let matrix = CTFontGetMatrix(font as CTFont)
-            let hasOblique = abs(matrix.b) > 0.0001 || abs(matrix.c) > 0.0001
-            let hasBoldWeight: Bool
-            if isBold,
-               let variations = CTFontCopyVariation(font as CTFont) as? [NSNumber: NSNumber],
-               let weightValue = variations[0x77676874 as NSNumber] {
-                hasBoldWeight = abs(CGFloat(truncating: weightValue) - 700) < 0.5
-            } else {
-                hasBoldWeight = !isBold
+        func fontHasExpectedTraits(_ font: NSFont, isBold: Bool) -> Bool {
+            if !isBold { return true }
+            guard let variations = CTFontCopyVariation(font as CTFont) as? [NSNumber: NSNumber],
+                  let weightValue = variations[0x77676874 as NSNumber] else {
+                return false
             }
-
-            return (!isEmphasized || hasOblique) && hasBoldWeight
+            return abs(CGFloat(truncating: weightValue) - 700) < 0.5
         }
 
         for emphRun in emphasisRuns {
@@ -718,6 +720,7 @@ struct MarkdownSegmentView: View, Equatable {
                     continue
                 }
                 ns.addAttribute(.font, value: fontSet.boldItalic, range: nsRange)
+                ns.addAttribute(.obliqueness, value: emphasisObliqueness, range: nsRange)
             } else if isEmph {
                 guard fontSet.italicIsResolved else {
                     unresolvedEmphasisCount += 1
@@ -725,6 +728,7 @@ struct MarkdownSegmentView: View, Equatable {
                     continue
                 }
                 ns.addAttribute(.font, value: fontSet.italic, range: nsRange)
+                ns.addAttribute(.obliqueness, value: emphasisObliqueness, range: nsRange)
             } else if isBold {
                 guard fontSet.boldIsResolved else {
                     unresolvedEmphasisCount += 1
@@ -745,9 +749,16 @@ struct MarkdownSegmentView: View, Equatable {
             }
             let isEmph = emphRun.intent.contains(.emphasized)
             let isBold = emphRun.intent.contains(.stronglyEmphasized)
-            if !fontHasExpectedTraits(actualFont, isEmphasized: isEmph, isBold: isBold) {
+            if !fontHasExpectedTraits(actualFont, isBold: isBold) {
                 unresolvedEmphasisCount += 1
                 logUnresolvedFontsIfNeeded()
+            }
+            if isEmph {
+                let actualObliqueness = ns.attribute(.obliqueness, at: nsRange.location, effectiveRange: nil) as? NSNumber
+                if actualObliqueness == nil || abs(CGFloat(truncating: actualObliqueness!)) < 0.01 {
+                    unresolvedEmphasisCount += 1
+                    logUnresolvedFontsIfNeeded()
+                }
             }
         }
 

--- a/clients/macos/vellum-assistantTests/MarkdownSegmentViewTests.swift
+++ b/clients/macos/vellum-assistantTests/MarkdownSegmentViewTests.swift
@@ -37,13 +37,104 @@ final class MarkdownSegmentViewTests: XCTestCase {
         super.tearDown()
     }
 
-    func testItalicMarkdownUsesObliqueDMSansFont() throws {
+    func testItalicMarkdownAppliesObliquenessAttribute() throws {
         let (rendered, hasUnresolvedEmphasis) = makeRenderedMarkdown("*settles in*")
         let font = try renderedFont(from: rendered)
+        let obliqueness = renderedObliqueness(from: rendered)
 
         XCTAssertFalse(hasUnresolvedEmphasis)
         XCTAssertEqual(familyName(for: font), "DM Sans")
-        XCTAssertGreaterThan(abs(CTFontGetMatrix(font as CTFont).c), 0.0001)
+        XCTAssertNotNil(obliqueness, "Italic emphasis must set the .obliqueness attribute")
+        XCTAssertGreaterThan(
+            abs(CGFloat(truncating: obliqueness!)), 0.01,
+            "Italic emphasis must apply a non-zero obliqueness"
+        )
+    }
+
+    func testItalicAtStartOfMultiLineRendersWithObliqueness() throws {
+        let input = "*...the room goes completely quiet*\n\na following paragraph with no emphasis"
+
+        let source = try makeAttributedString(from: input)
+        let emphasizedRuns = source.runs.filter {
+            $0.inlinePresentationIntent?.contains(.emphasized) == true
+        }
+        XCTAssertFalse(
+            emphasizedRuns.isEmpty,
+            "Apple parser must emit .emphasized for `*...text*` at start of multi-line input. "
+            + "Got runs: \(source.runs.map { (String(source[$0.range].characters), $0.inlinePresentationIntent) })"
+        )
+
+        let (rendered, hasUnresolvedEmphasis) = makeRenderedMarkdown(input)
+        XCTAssertFalse(hasUnresolvedEmphasis)
+        let font = try renderedFont(from: rendered)
+        XCTAssertEqual(familyName(for: font), "DM Sans")
+        let obliqueness = renderedObliqueness(from: rendered)
+        XCTAssertNotNil(obliqueness, "Emphasis at offset 0 must have a non-nil obliqueness attribute")
+        XCTAssertGreaterThan(
+            abs(CGFloat(truncating: obliqueness!)), 0.01,
+            "Emphasis at offset 0 must apply a non-zero obliqueness"
+        )
+    }
+
+    /// Exercises the FULL chat-message rendering pipeline (parseMarkdownSegments
+    /// → MarkdownSegmentView convert) when emphasis appears at the start of a
+    /// multi-paragraph message, with additional emphasis spans embedded in
+    /// later paragraphs. Verifies that the obliqueness attribute survives all
+    /// the way to NSTextStorage — closing the gap that plain font-matrix slant
+    /// has, where NSTextView can normalize the matrix away during
+    /// setAttributedString.
+    func testItalicFirstLineSurvivesFullMessagePipeline() throws {
+        let input = """
+        *...the room goes completely quiet*
+
+        first paragraph after the opening italics, no emphasis here.
+
+        second paragraph with mid-line *emphasis.*
+
+        third paragraph with trailing *italics*. that's it.
+        """
+
+        let segments = parseMarkdownSegments(input)
+        guard case .text(let combinedText) = segments.first else {
+            return XCTFail("Expected first segment to be .text, got \(segments)")
+        }
+        XCTAssertTrue(
+            combinedText.hasPrefix("*...the room goes completely quiet*"),
+            "Pipeline must preserve the italic markers on the first line; got prefix: "
+            + "\(String(combinedText.prefix(60)))"
+        )
+
+        let source = try makeAttributedString(from: combinedText)
+        let firstRun = source.runs.first!
+        let firstRunText = String(source[firstRun.range].characters)
+        let firstRunIntent = firstRun.inlinePresentationIntent
+        XCTAssertTrue(
+            firstRunIntent?.contains(.emphasized) == true,
+            "First run must be .emphasized. Got text=\(firstRunText), intent=\(String(describing: firstRunIntent))"
+        )
+
+        let view = MarkdownSegmentView(segments: segments)
+        let result = view.resolveSelectableRunMeasurementResult(segments)
+        XCTAssertFalse(result.hasUnresolvedEmphasis)
+        let obliquenessAtZero = result.nsAttributedString.attribute(.obliqueness, at: 0, effectiveRange: nil) as? NSNumber
+        XCTAssertNotNil(obliquenessAtZero, "First-line emphasis must apply obliqueness via the full pipeline")
+        XCTAssertGreaterThan(abs(CGFloat(truncating: obliquenessAtZero!)), 0.01)
+
+        // Feed through the real NSTextView path used by VSelectableTextView —
+        // .obliqueness must survive the bridge that previously dropped font
+        // matrix transforms.
+        let textStorage = NSTextStorage()
+        let layoutManager = NSLayoutManager()
+        textStorage.addLayoutManager(layoutManager)
+        let textContainer = NSTextContainer(size: NSSize(width: 600, height: CGFloat.greatestFiniteMagnitude))
+        textContainer.lineFragmentPadding = 0
+        layoutManager.addTextContainer(textContainer)
+        textStorage.setAttributedString(result.nsAttributedString)
+        layoutManager.ensureLayout(for: textContainer)
+
+        let displayedObliqueness = textStorage.attribute(.obliqueness, at: 0, effectiveRange: nil) as? NSNumber
+        XCTAssertNotNil(displayedObliqueness, "NSTextStorage must keep the .obliqueness attribute at offset 0")
+        XCTAssertGreaterThan(abs(CGFloat(truncating: displayedObliqueness!)), 0.01)
     }
 
     func testBoldMarkdownUsesWeightedDMSansFont() throws {
@@ -54,18 +145,21 @@ final class MarkdownSegmentViewTests: XCTestCase {
         XCTAssertFalse(hasUnresolvedEmphasis)
         XCTAssertEqual(familyName(for: font), "DM Sans")
         XCTAssertEqual(weight, 700, accuracy: 0.5)
-        XCTAssertEqual(CTFontGetMatrix(font as CTFont).c, 0, accuracy: 0.0001)
+        let obliqueness = renderedObliqueness(from: rendered)
+        XCTAssertNil(obliqueness, "Bold-only emphasis must not apply obliqueness")
     }
 
-    func testBoldItalicMarkdownUsesWeightedObliqueDMSansFont() throws {
+    func testBoldItalicMarkdownAppliesWeightAndObliqueness() throws {
         let (rendered, hasUnresolvedEmphasis) = makeRenderedMarkdown("***ideas for something fun***")
         let font = try renderedFont(from: rendered)
         let weight = try XCTUnwrap(weightAxis(for: font))
+        let obliqueness = renderedObliqueness(from: rendered)
 
         XCTAssertFalse(hasUnresolvedEmphasis)
         XCTAssertEqual(familyName(for: font), "DM Sans")
         XCTAssertEqual(weight, 700, accuracy: 0.5)
-        XCTAssertGreaterThan(abs(CTFontGetMatrix(font as CTFont).c), 0.0001)
+        XCTAssertNotNil(obliqueness)
+        XCTAssertGreaterThan(abs(CGFloat(truncating: obliqueness!)), 0.01)
     }
 
     func testInvalidEmphasisFontsSkipMeasurementCaching() throws {
@@ -155,7 +249,7 @@ final class MarkdownSegmentViewTests: XCTestCase {
         }
         #endif
 
-        let segments = parseMarkdownSegments("*collar jingles*")
+        let segments = parseMarkdownSegments("*bell jingles*")
         let view = MarkdownSegmentView(segments: segments)
         let generationBefore = VFont.typographyGeneration
 
@@ -176,11 +270,13 @@ final class MarkdownSegmentViewTests: XCTestCase {
             typographyGeneration: VFont.typographyGeneration
         )
         let font = try? renderedFont(from: secondResult.nsAttributedString)
+        let obliqueness = renderedObliqueness(from: secondResult.nsAttributedString)
 
         XCTAssertFalse(secondResult.hasUnresolvedEmphasis)
         XCTAssertEqual(MarkdownSegmentView._measuredTextCacheInsertCount, 1)
         XCTAssertEqual(font.map(familyName(for:)), "DM Sans")
-        XCTAssertGreaterThan(abs(CTFontGetMatrix((try XCTUnwrap(font)) as CTFont).c), 0.0001)
+        XCTAssertNotNil(obliqueness, "Italic emphasis should set obliqueness once fonts resolve")
+        XCTAssertGreaterThan(abs(CGFloat(truncating: try XCTUnwrap(obliqueness))), 0.01)
     }
 
     func testHeadingFontSurvivesConversionPipeline() throws {
@@ -246,6 +342,10 @@ final class MarkdownSegmentViewTests: XCTestCase {
         return try XCTUnwrap(font)
     }
 
+    private func renderedObliqueness(from rendered: NSAttributedString) -> NSNumber? {
+        rendered.attribute(.obliqueness, at: 0, effectiveRange: nil) as? NSNumber
+    }
+
     private func familyName(for font: NSFont) -> String {
         CTFontCopyFamilyName(font as CTFont) as String
     }
@@ -261,8 +361,8 @@ final class MarkdownSegmentViewTests: XCTestCase {
     private func validFontSet(size: CGFloat) -> VFont.ChatMarkdownFontSet {
         let regular = VFont.resolvedDMSansFont(weight: 400, size: size)
         let bold = VFont.resolvedDMSansFont(weight: 700, size: size)
-        let italic = VFont.resolvedDMSansFont(weight: 400, size: size, obliqueDegrees: 12)
-        let boldItalic = VFont.resolvedDMSansFont(weight: 700, size: size, obliqueDegrees: 12)
+        let italic = VFont.resolvedDMSansFont(weight: 400, size: size)
+        let boldItalic = VFont.resolvedDMSansFont(weight: 700, size: size)
         return VFont.ChatMarkdownFontSet(
             regular: regular,
             bold: bold,

--- a/clients/shared/DesignSystem/Tokens/TypographyTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/TypographyTokens.swift
@@ -209,10 +209,16 @@ public enum VFont {
         }
         #endif
 
+        // Italic and boldItalic carry NO font-matrix slant — the slant is
+        // applied as a separate `.obliqueness` NSAttributedString attribute at
+        // emphasis-application time. NSTextView normalizes matrix-transformed
+        // fonts away during `setAttributedString` in some cases (observed when
+        // SwiftUI-bridged AttributedStrings flow through VSelectableTextView),
+        // so the matrix can't be relied on to reach the glyph renderer.
         let regular = resolvedDMSansFont(weight: 400, size: size)
         let bold = resolvedDMSansFont(weight: 700, size: size)
-        let italic = resolvedDMSansFont(weight: 400, size: size, obliqueDegrees: 12)
-        let boldItalic = resolvedDMSansFont(weight: 700, size: size, obliqueDegrees: 12)
+        let italic = resolvedDMSansFont(weight: 400, size: size)
+        let boldItalic = resolvedDMSansFont(weight: 700, size: size)
 
         let diagnosticPostScriptNames = [
             "regular": postScriptName(for: regular),
@@ -223,11 +229,10 @@ public enum VFont {
 
         let regularIsResolved = isResolvedDMSans(regular)
         let boldIsResolved = isResolvedDMSans(bold) && hasWeightAxis(bold, expected: 700)
-        let italicIsResolved = isResolvedDMSans(italic) && hasObliqueTransform(italic)
+        let italicIsResolved = isResolvedDMSans(italic)
         let boldItalicIsResolved =
             isResolvedDMSans(boldItalic)
             && hasWeightAxis(boldItalic, expected: 700)
-            && hasObliqueTransform(boldItalic)
 
         return ChatMarkdownFontSet(
             regular: regular,
@@ -243,11 +248,7 @@ public enum VFont {
         )
     }
 
-    package static func resolvedDMSansFont(
-        weight: Int,
-        size: CGFloat,
-        obliqueDegrees: CGFloat? = nil
-    ) -> NSFont {
+    package static func resolvedDMSansFont(weight: Int, size: CGFloat) -> NSFont {
         let baseName = "DMSans-Regular" as CFString
         let baseFont = CTFontCreateWithName(baseName, size, nil)
         let variations: [CFNumber: CFNumber] = [
@@ -256,19 +257,6 @@ public enum VFont {
         let descriptor = CTFontDescriptorCreateWithAttributes([
             kCTFontVariationAttribute: variations,
         ] as CFDictionary)
-
-        if let obliqueDegrees {
-            var oblique = CGAffineTransform(
-                a: 1,
-                b: 0,
-                c: CGFloat(tan(obliqueDegrees * .pi / 180.0)),
-                d: 1,
-                tx: 0,
-                ty: 0
-            )
-            return CTFontCreateCopyWithAttributes(baseFont, size, &oblique, descriptor) as NSFont
-        }
-
         return CTFontCreateCopyWithAttributes(baseFont, size, nil, descriptor) as NSFont
     }
 
@@ -282,16 +270,6 @@ public enum VFont {
 
     private static func postScriptName(for font: NSFont) -> String {
         CTFontCopyPostScriptName(font as CTFont) as String
-    }
-
-    private static func hasObliqueTransform(_ font: NSFont) -> Bool {
-        let matrix = CTFontGetMatrix(font as CTFont)
-        return abs(matrix.b) > 0.0001
-            || abs(matrix.c) > 0.0001
-            || abs(matrix.a - 1) > 0.0001
-            || abs(matrix.d - 1) > 0.0001
-            || abs(matrix.tx) > 0.0001
-            || abs(matrix.ty) > 0.0001
     }
 
     private static func hasWeightAxis(_ font: NSFont, expected: Int) -> Bool {


### PR DESCRIPTION
## Summary
- Synthesized italic was applied via a font-matrix shear, which NSTextView silently normalized away in some SwiftUI-bridged AttributedString → textStorage paths — asterisks got parsed away but no slant appeared.
- Switched to `NSAttributedString.Key.obliqueness`, a separate render-time attribute that isn't tied to font identity and survives the bridge. Italic/boldItalic fonts are now plain DM Sans variants; slant is applied as an attribute in `convertToNSAttributedString`.
- Added end-to-end regression tests that push the full pipeline (parser → MarkdownSegmentView → NSTextStorage) for the "emphasis at start of multi-paragraph message" pattern.

## Original prompt
The first line `*...bell goes completely quiet*` shows that markdown rendering isn't working properly. Can you fix it?
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25181" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
