### PR TITLE
feat(surfaces): add `persistent` flag to UiSurfaceShow type

### DIFF
--- a/assistant/src/daemon/message-types/surfaces.ts
+++ b/assistant/src/daemon/message-types/surfaces.ts
@@ -184,6 +184,8 @@ interface UiSurfaceShowBase {
   display?: "inline" | "panel";
   /** The message ID that this surface belongs to (for history loading). */
   messageId?: string;
+  /** When `true`, clicking an action does not dismiss the surface — the client keeps the card visible and only marks the clicked `actionId` as spent so siblings remain clickable. */
+  persistent?: boolean;
 }
 
 export interface UiSurfaceShowCard extends UiSurfaceShowBase {


### PR DESCRIPTION
## Summary
- Add optional `persistent?: boolean` field to `UiSurfaceShow` with JSDoc describing the client behavior (card stays visible after an action; clicked actionId is marked spent so siblings still fire).
- Purely additive — no consumers updated in this PR.

Part of plan: convo-launcher-fix.md (PR 1 of 9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25183" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
