### PR TITLE
feat(conversations): add `focus` flag to OpenConversation event

### DIFF
--- a/assistant/src/daemon/message-types/conversations.ts
+++ b/assistant/src/daemon/message-types/conversations.ts
@@ -482,6 +482,8 @@ export interface OpenConversation {
   title?: string;
   /** Optional message ID to scroll to after focus. */
   anchorMessageId?: string;
+  /** When `false`, the client should register the conversation in its sidebar (so it's visible and navigable) but must NOT switch focus to it. Omitting the field defaults to `true` for backward compatibility with existing single-target 'jump to conversation' callers. */
+  focus?: boolean;
 }
 
 // --- Domain-level union aliases (consumed by the barrel file) ---


### PR DESCRIPTION
## Summary
- Add optional `focus?: boolean` field to `OpenConversation` with JSDoc. When false the client should add the conversation to the sidebar without switching focus; nil defaults to true for backward compat.
- Purely additive — no emitters or handlers updated in this PR.

Part of plan: convo-launcher-fix.md (PR 2 of 9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25184" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
