### PR TITLE
refactor(daemon): extract launchConversation helper from server.ts callback

### DIFF
--- a/assistant/src/__tests__/signal-launch-conversation.test.ts
+++ b/assistant/src/__tests__/signal-launch-conversation.test.ts
@@ -1,10 +1,12 @@
 /**
- * Unit tests for the launch-conversation signal handler.
+ * Unit tests for the launch-conversation signal handler and the
+ * launchConversation daemon helper.
  *
  * Covers the parse/validate/dispatch/write-result contract of
- * {@link handleLaunchConversationSignal} in isolation. The daemon-side
- * callback (which creates + seeds + focuses the conversation) is exercised
- * through a mock registered via {@link registerLaunchConversationCallback}.
+ * {@link handleLaunchConversationSignal} in isolation (the daemon-side
+ * callback is exercised through a mock registered via
+ * {@link registerLaunchConversationCallback}) plus a direct unit test of
+ * {@link launchConversation}'s `originTrustContext` inheritance behavior.
  */
 import {
   existsSync,
@@ -14,13 +16,30 @@ import {
   writeFileSync,
 } from "node:fs";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
-import {
-  handleLaunchConversationSignal,
-  registerLaunchConversationCallback,
-} from "../signals/launch-conversation.js";
-import { getSignalsDir } from "../util/platform.js";
+// Stub out DB-hitting helpers used by the launchConversation implementation
+// so the direct unit test below does not need a real database. These mocks
+// apply only within this test file.
+mock.module("../memory/conversation-key-store.js", () => ({
+  getOrCreateConversation: (_key: string) => ({
+    conversationId: "conv-mocked-id",
+  }),
+}));
+mock.module("../memory/conversation-crud.js", () => ({
+  updateConversationTitle: () => {},
+}));
+
+// Dynamic imports after mock.module calls so the stubs above take effect
+// before the modules under test are loaded.
+const { launchConversation, registerLaunchConversationDeps } = await import(
+  "../daemon/conversation-launch.js"
+);
+const { handleLaunchConversationSignal, registerLaunchConversationCallback } =
+  await import("../signals/launch-conversation.js");
+const { getSignalsDir } = await import("../util/platform.js");
+type TrustContext =
+  import("../daemon/conversation-runtime-assembly.js").TrustContext;
 
 function signalPath(filename: string): string {
   return join(getSignalsDir(), filename);
@@ -287,5 +306,61 @@ describe("handleLaunchConversationSignal", () => {
     });
 
     cleanupSignalFiles(filename);
+  });
+});
+
+describe("launchConversation", () => {
+  test("launchConversation applies originTrustContext when provided", async () => {
+    const setTrustContextSpy = mock((_ctx: TrustContext | null) => {});
+    // Minimal Conversation-like stub — launchConversation only calls
+    // setTrustContext on the returned object, so we only implement that.
+    const fakeConversation = {
+      setTrustContext: setTrustContextSpy,
+    };
+
+    const persistAndProcessMessageSpy = mock(async () => ({
+      messageId: "msg-mocked",
+    }));
+
+    registerLaunchConversationDeps({
+      // Cast through unknown because we only exercise the methods
+      // launchConversation actually invokes on the Conversation instance.
+      getOrCreateConversation: async () =>
+        fakeConversation as unknown as Awaited<
+          ReturnType<
+            Parameters<typeof registerLaunchConversationDeps>[0]["getOrCreateConversation"]
+          >
+        >,
+      persistAndProcessMessage: persistAndProcessMessageSpy,
+      publishAssistantEvent: () => {},
+      getAssistantId: () => "test-assistant-id",
+    });
+
+    const originTrustContext: TrustContext = {
+      sourceChannel: "telegram",
+      trustClass: "guardian",
+      guardianChatId: "chat-guardian",
+      guardianExternalUserId: "ext-user-guardian",
+      guardianPrincipalId: "principal-guardian",
+      requesterIdentifier: "@guardian",
+      requesterDisplayName: "Guardian",
+    };
+
+    const result = await launchConversation({
+      title: "Inherited",
+      seedPrompt: "Continue the task",
+      anchorMessageId: "msg-anchor-99",
+      originTrustContext,
+    });
+
+    expect(result).toEqual({ conversationId: "conv-mocked-id" });
+    expect(setTrustContextSpy).toHaveBeenCalledTimes(1);
+    expect(setTrustContextSpy).toHaveBeenCalledWith(originTrustContext);
+    // The trust context must be applied before the seed message is persisted
+    // so the first agent turn runs under the inherited guardian scope.
+    expect(persistAndProcessMessageSpy).toHaveBeenCalledTimes(1);
+    expect(
+      setTrustContextSpy.mock.invocationCallOrder[0],
+    ).toBeLessThan(persistAndProcessMessageSpy.mock.invocationCallOrder[0]);
   });
 });

--- a/assistant/src/daemon/conversation-launch.ts
+++ b/assistant/src/daemon/conversation-launch.ts
@@ -1,0 +1,176 @@
+/**
+ * Helper that creates, titles, and seeds a fresh conversation for the
+ * conversation-launcher flow.
+ *
+ * Extracted from the `registerLaunchConversationCallback` body in
+ * {@link file:./server.ts}. Callers include:
+ *
+ *   - The launch-conversation signal handler (no origin trust context).
+ *   - `handleSurfaceAction` (future caller — will pass the origin
+ *     conversation's `TrustContext` so spawned conversations inherit
+ *     guardian / trust class).
+ *
+ * The helper depends on DaemonServer state (conversation map,
+ * `persistAndProcessMessage`, assistant ID, hub publisher) and is wired via
+ * {@link registerLaunchConversationDeps} at daemon startup — mirroring the
+ * callback-registration pattern used by `signals/launch-conversation.ts` and
+ * friends. Tests can stub deps directly via the same registration.
+ */
+
+import { randomUUID } from "node:crypto";
+
+import { updateConversationTitle } from "../memory/conversation-crud.js";
+import { getOrCreateConversation as getOrCreateConversationKey } from "../memory/conversation-key-store.js";
+import { buildAssistantEvent } from "../runtime/assistant-event.js";
+import { assistantEventHub } from "../runtime/assistant-event-hub.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
+import type { Conversation } from "./conversation.js";
+import type { TrustContext } from "./conversation-runtime-assembly.js";
+import type { ConversationCreateOptions } from "./handlers/shared.js";
+import type { ServerMessage } from "./message-protocol.js";
+
+// ── Dependency registry ─────────────────────────────────────────────
+
+export interface LaunchConversationDeps {
+  /**
+   * Return the live {@link Conversation} instance for the given id,
+   * creating + hydrating it if necessary. Wraps `DaemonServer.getOrCreateConversation`.
+   */
+  getOrCreateConversation: (
+    conversationId: string,
+    options?: ConversationCreateOptions,
+  ) => Promise<Conversation>;
+  /**
+   * Persist the seed message and run the agent loop. Wraps
+   * `DaemonServer.persistAndProcessMessage`.
+   */
+  persistAndProcessMessage: (
+    conversationId: string,
+    content: string,
+    attachmentIds?: string[],
+    options?: ConversationCreateOptions,
+    sourceChannel?: string,
+    sourceInterface?: string,
+  ) => Promise<{ messageId: string }>;
+  /**
+   * Forward a `ServerMessage` to the process-level assistant event hub.
+   * Wraps `DaemonServer.publishAssistantEvent`.
+   */
+  publishAssistantEvent: (
+    msg: ServerMessage,
+    conversationId?: string,
+  ) => void;
+  /** Assistant id to stamp onto the `open_conversation` event. */
+  getAssistantId: () => string | undefined;
+}
+
+let _deps: LaunchConversationDeps | null = null;
+
+/**
+ * Register the daemon-side dependencies the helper needs. Called once by
+ * `DaemonServer.start()` and (in tests) by unit tests that exercise
+ * {@link launchConversation} directly.
+ */
+export function registerLaunchConversationDeps(
+  deps: LaunchConversationDeps,
+): void {
+  _deps = deps;
+}
+
+// ── Helper ──────────────────────────────────────────────────────────
+
+export interface LaunchConversationParams {
+  title: string;
+  seedPrompt: string;
+  anchorMessageId?: string;
+  originTrustContext?: TrustContext;
+}
+
+/**
+ * Create, title, and seed a fresh conversation and notify connected clients
+ * via an `open_conversation` event.
+ *
+ * If `originTrustContext` is provided, it is applied to the new conversation
+ * before seeding so guardian / trust-class state is inherited from the
+ * spawning context. When absent, the conversation runs without an inherited
+ * trust context — the same behavior as the legacy signal-driven path.
+ *
+ * Throws if the helper's daemon-side dependencies have not been registered
+ * or if any step of the pipeline fails.
+ */
+export async function launchConversation(
+  params: LaunchConversationParams,
+): Promise<{ conversationId: string }> {
+  if (!_deps) {
+    throw new Error(
+      "launchConversation dependencies not registered — daemon may not be ready",
+    );
+  }
+  const deps = _deps;
+
+  // Each launch gets a globally unique conversation key so the skill always
+  // creates a fresh conversation rather than reusing any prior mapping.
+  // `getOrCreateConversation` will insert a new row.
+  const conversationKey = `launcher-${randomUUID()}`;
+  const { conversationId } = getOrCreateConversationKey(conversationKey);
+
+  // Hydrate the live Conversation instance so we can apply trust context
+  // before the seed turn begins. persistAndProcessMessage will reuse this
+  // instance from the conversations map.
+  const conversation = await deps.getOrCreateConversation(conversationId);
+
+  // Inherit guardian / trust-class state from the caller when available.
+  // The signal-driven callsite passes undefined; the handleSurfaceAction
+  // callsite (PR 5) passes the origin conversation's trustContext.
+  if (params.originTrustContext) {
+    conversation.setTrustContext(params.originTrustContext);
+  }
+
+  // Set the user-facing title immediately so clients that stub a sidebar
+  // entry from the open_conversation event see the right label even before
+  // the turn completes.
+  if (params.title) {
+    updateConversationTitle(conversationId, params.title, 0);
+  }
+
+  // Seed the conversation by running the seed prompt through the same
+  // pipeline POST /v1/messages uses. Publishing to the hub lets any
+  // connected client stream the turn live.
+  const hubSender = (msg: ServerMessage) => {
+    const msgConversationId =
+      "conversationId" in msg &&
+      typeof (msg as { conversationId?: unknown }).conversationId === "string"
+        ? (msg as { conversationId: string }).conversationId
+        : undefined;
+    deps.publishAssistantEvent(msg, msgConversationId ?? conversationId);
+  };
+
+  await deps.persistAndProcessMessage(
+    conversationId,
+    params.seedPrompt,
+    undefined,
+    { onEvent: hubSender },
+    "vellum",
+    "cli",
+  );
+
+  // Tell connected clients to focus the new conversation. The client stubs
+  // a sidebar entry from the optional title if the conversation isn't
+  // already in its list.
+  await assistantEventHub.publish(
+    buildAssistantEvent(
+      deps.getAssistantId() ?? DAEMON_INTERNAL_ASSISTANT_ID,
+      {
+        type: "open_conversation",
+        conversationId,
+        title: params.title,
+        ...(params.anchorMessageId
+          ? { anchorMessageId: params.anchorMessageId }
+          : {}),
+      },
+      conversationId,
+    ),
+  );
+
+  return { conversationId };
+}

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from "node:crypto";
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 
@@ -39,7 +38,6 @@ import {
   provenanceFromTrustContext,
   setConversationOriginChannelIfUnset,
   setConversationOriginInterfaceIfUnset,
-  updateConversationTitle,
 } from "../memory/conversation-crud.js";
 import { updateMetaFile } from "../memory/conversation-disk-view.js";
 import { getOrCreateConversation } from "../memory/conversation-key-store.js";
@@ -80,6 +78,10 @@ import {
   DEFAULT_MEMORY_POLICY,
 } from "./conversation.js";
 import { ConversationEvictor } from "./conversation-evictor.js";
+import {
+  launchConversation,
+  registerLaunchConversationDeps,
+} from "./conversation-launch.js";
 import { formatCompactResult } from "./conversation-process.js";
 import { resolveChannelCapabilities } from "./conversation-runtime-assembly.js";
 import { resolveSlash, type SlashContext } from "./conversation-slash.js";
@@ -756,59 +758,45 @@ export class DaemonServer {
       return { accepted: true };
     });
 
+    // Wire the launchConversation helper to daemon-side state so both the
+    // signal-driven path (below) and the handleSurfaceAction path can use it.
+    registerLaunchConversationDeps({
+      getOrCreateConversation: (id, options) =>
+        this.getOrCreateConversation(id, options),
+      persistAndProcessMessage: (
+        conversationId,
+        content,
+        attachmentIds,
+        options,
+        sourceChannel,
+        sourceInterface,
+      ) =>
+        this.persistAndProcessMessage(
+          conversationId,
+          content,
+          attachmentIds,
+          options,
+          sourceChannel,
+          sourceInterface,
+        ),
+      publishAssistantEvent: (msg, conversationId) =>
+        this.publishAssistantEvent(msg, conversationId),
+      getAssistantId: () => this.assistantId,
+    });
+
     registerLaunchConversationCallback(async (params) => {
       try {
-        // Each launch gets a globally unique conversation key so the skill
-        // always creates a fresh conversation rather than reusing any prior
-        // mapping. `getOrCreateConversation` will insert a new row.
-        const conversationKey = `launcher-${randomUUID()}`;
-        const { conversationId } = getOrCreateConversation(conversationKey);
-
-        // Set the user-facing title immediately so clients that stub a
-        // sidebar entry from the open_conversation event see the right
-        // label even before the turn completes.
-        updateConversationTitle(conversationId, params.title, 0);
-
-        // Seed the conversation by running the seed prompt through the same
-        // pipeline POST /v1/messages uses. Publishing to the hub lets any
-        // connected client stream the turn live.
-        const hubSender = (msg: ServerMessage) => {
-          const msgConversationId =
-            "conversationId" in msg &&
-            typeof (msg as { conversationId?: unknown }).conversationId ===
-              "string"
-              ? (msg as { conversationId: string }).conversationId
-              : undefined;
-          this.publishAssistantEvent(msg, msgConversationId ?? conversationId);
-        };
-
-        await this.persistAndProcessMessage(
-          conversationId,
-          params.seedPrompt,
-          undefined,
-          { onEvent: hubSender },
-          "vellum",
-          "cli",
-        );
-
-        // Tell connected clients to focus the new conversation. The client
-        // stubs a sidebar entry from the optional title if the conversation
-        // isn't already in its list.
-        await assistantEventHub.publish(
-          buildAssistantEvent(
-            this.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID,
-            {
-              type: "open_conversation",
-              conversationId,
-              title: params.title,
-              ...(params.anchorMessageId
-                ? { anchorMessageId: params.anchorMessageId }
-                : {}),
-            },
-            conversationId,
-          ),
-        );
-
+        // Signal payload carries no origin context — preserves the existing
+        // behavior where signal-launched conversations run without an
+        // inherited trust context.
+        const { conversationId } = await launchConversation({
+          title: params.title,
+          seedPrompt: params.seedPrompt,
+          ...(params.anchorMessageId
+            ? { anchorMessageId: params.anchorMessageId }
+            : {}),
+          originTrustContext: undefined,
+        });
         return { accepted: true, conversationId };
       } catch (err) {
         log.warn({ err }, "Failed to launch conversation via signal");


### PR DESCRIPTION
## Summary
- New `assistant/src/daemon/conversation-launch.ts` exports `launchConversation({title, seedPrompt, anchorMessageId?, originTrustContext?})` — the body of the current `registerLaunchConversationCallback` extracted into a reusable helper.
- `server.ts` callback now delegates to the helper with `originTrustContext: undefined` (unchanged behavior for the signal path).
- Helper applies `originTrustContext` via `setTrustContext` when provided — new optional behavior that PR 5 (`handleSurfaceAction`) will use to inherit the origin conversation's trust context.
- Added one test case for the new `originTrustContext` behavior.

Part of plan: convo-launcher-fix.md (PR 4 of 9)