### PR TITLE
feat(macos): gate open_conversation focus switch on focus flag

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
@@ -217,6 +217,8 @@ extension AppDelegate {
                     // Tag the stub with source: "open_conversation" so it's distinguishable
                     // from true notification-flow stubs (which use source: "notification"
                     // and may drive urgency/alerting behaviors that don't apply here).
+                    // This registration runs regardless of the focus flag so fan-out
+                    // callers (focus: false) still get the conversation in the sidebar.
                     if let title = msg.title,
                        let conversationManager = self.mainWindow?.conversationManager,
                        !conversationManager.conversations.contains(where: { $0.conversationId == msg.conversationId }) {
@@ -228,7 +230,12 @@ extension AppDelegate {
                             source: "open_conversation"
                         )
                     }
-                    self.openConversation(conversationId: msg.conversationId, anchorMessageId: msg.anchorMessageId)
+                    // Switch focus only when the emitter did not explicitly opt out
+                    // (msg.focus != false). Absent (nil) defaults to switching, which
+                    // preserves existing single-target behavior.
+                    if shouldFocusForOpenConversation(msg) {
+                        self.openConversation(conversationId: msg.conversationId, anchorMessageId: msg.anchorMessageId)
+                    }
                 case .navigateSettings(let msg):
                     self.showSettingsTab(msg.tab)
                 case .showPlatformLogin:

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -3106,3 +3106,24 @@ extension WorkItemsListResponseItem {
         Self(id: id, taskId: taskId, title: title, notes: notes, status: status, priorityTier: newTier, sortIndex: sortIndex, lastRunId: lastRunId, lastRunConversationId: lastRunConversationId, lastRunStatus: lastRunStatus, sourceType: sourceType, sourceId: sourceId, createdAt: createdAt, updatedAt: updatedAt)
     }
 }
+
+// MARK: - Open Conversation Helpers
+
+extension OpenConversation {
+    /// Whether the client should switch focus to this conversation.
+    ///
+    /// The daemon emits `focus: false` for fan-out flows (e.g. surface-action
+    /// launches that spawn a background conversation) so the new conversation
+    /// appears in the sidebar without stealing focus from the origin surface.
+    /// Any other value — `true` or absent — defaults to switching focus to
+    /// preserve existing single-target behavior.
+    public var shouldSwitchFocus: Bool {
+        focus != false
+    }
+}
+
+/// Pure helper for the `.openConversation` handler's focus decision.
+/// Extracted so it can be unit-tested without spinning up AppDelegate.
+public func shouldFocusForOpenConversation(_ msg: OpenConversation) -> Bool {
+    msg.shouldSwitchFocus
+}

--- a/clients/shared/Tests/MessageTypesTests.swift
+++ b/clients/shared/Tests/MessageTypesTests.swift
@@ -178,4 +178,55 @@ final class MessageTypesTests: XCTestCase {
         XCTAssertNil(request.title)
         XCTAssertNil(request.anchorMessageId)
     }
+
+    // MARK: - open_conversation focus gating
+    //
+    // The macOS `.openConversation` handler always registers the conversation
+    // in the sidebar but only switches focus when `msg.focus != false`. These
+    // tests cover the `shouldFocusForOpenConversation` helper used by that
+    // handler, which encodes the focus-gating decision so it can be unit
+    // tested without spinning up AppDelegate.
+
+    /// `focus: true` → focus switches.
+    func testShouldFocus_trueWhenFocusIsTrue() {
+        let msg = OpenConversation(
+            type: "open_conversation",
+            conversationId: "conv-focus-true",
+            title: "Focus on this",
+            anchorMessageId: nil,
+            focus: true
+        )
+        XCTAssertTrue(shouldFocusForOpenConversation(msg))
+        XCTAssertTrue(msg.shouldSwitchFocus)
+    }
+
+    /// `focus: false` → focus does NOT switch (but sidebar-registration logic
+    /// in the handler still runs; see `testDecodes_openConversation_*` plus
+    /// the handler code itself for that half of the contract).
+    func testShouldFocus_falseWhenFocusIsFalse() {
+        let msg = OpenConversation(
+            type: "open_conversation",
+            conversationId: "conv-focus-false",
+            title: "Background fan-out",
+            anchorMessageId: nil,
+            focus: false
+        )
+        XCTAssertFalse(shouldFocusForOpenConversation(msg))
+        XCTAssertFalse(msg.shouldSwitchFocus)
+    }
+
+    /// `focus` absent (nil) → focus switches. Preserves backward-compat
+    /// behavior for any existing single-target caller that doesn't set the
+    /// new field.
+    func testShouldFocus_trueWhenFocusIsNil() {
+        let msg = OpenConversation(
+            type: "open_conversation",
+            conversationId: "conv-focus-nil",
+            title: "Legacy caller",
+            anchorMessageId: nil,
+            focus: nil
+        )
+        XCTAssertTrue(shouldFocusForOpenConversation(msg))
+        XCTAssertTrue(msg.shouldSwitchFocus)
+    }
 }


### PR DESCRIPTION
## Summary
- `.openConversation` handler now always registers the new conversation in the sidebar but only switches focus when `msg.focus != false` (nil defaults to true, preserving existing single-target behavior).
- Three new tests cover focus: true, focus: false (registers but doesn't switch), and focus: nil (defaults to switching).

Part of plan: convo-launcher-fix.md (PR 7 of 9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25187" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
