### PR TITLE
feat(macos): persistent ui_show cards with per-action click tracking

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
@@ -68,7 +68,18 @@ final class SurfaceManager {
 
     /// Surfaces that have already sent an action to the daemon.
     /// Prevents duplicate actions (e.g. submit followed by dismiss) from racing.
+    /// Only used for non-persistent surfaces. Persistent surfaces use
+    /// `spentActionIdsBySurface` for per-action dedupe instead.
     @ObservationIgnored private var respondedSurfaces: Set<String> = []
+
+    /// Per-surface set of action IDs already dispatched for persistent surfaces.
+    /// A persistent surface stays visible after a click and allows distinct actions to
+    /// fire, but the same `actionId` will not fire twice within a single surface lifetime.
+    @ObservationIgnored private var spentActionIdsBySurface: [String: Set<String>] = [:]
+
+    /// Surface IDs whose `persistent` flag was true at show time. Carried out-of-band so the
+    /// action dispatch path can branch without consulting the message again.
+    @ObservationIgnored private var persistentSurfaces: Set<String> = []
 
     /// Surfaces routed to the workspace instead of floating NSPanels.
     /// Tracked so that update/dismiss messages can be forwarded via notifications.
@@ -114,6 +125,10 @@ final class SurfaceManager {
         activeSurfaces[surface.id] = surface
         surfaceOrder.append(surface.id)
 
+        if message.persistent == true {
+            persistentSurfaces.insert(surface.id)
+        }
+
         // Extract and track appId for persistent app RPC routing.
         let dict = message.data.value as? [String: Any?] ?? [:]
         if let appId = dict["appId"] as? String {
@@ -140,9 +155,12 @@ final class SurfaceManager {
         let viewModel = SurfaceViewModel(
             surface: surface,
             onAction: { [weak self] actionId, data in
-                guard let self, !self.respondedSurfaces.contains(surface.id) else { return }
-                self.respondedSurfaces.insert(surface.id)
-                self.onAction?(surface.conversationId, surface.id, actionId, data)
+                self?.handleSurfaceAction(
+                    conversationId: surface.conversationId,
+                    surfaceId: surface.id,
+                    actionId: actionId,
+                    data: data
+                )
             },
             onDismiss: { [weak self] in
                 guard let self, !self.respondedSurfaces.contains(surface.id) else {
@@ -271,6 +289,50 @@ final class SurfaceManager {
         log.info("Showing surface: id=\(surface.id), type=\(surface.type.rawValue)")
     }
 
+    // MARK: - Action Dispatch
+
+    /// Dispatches a user-initiated action to the `onAction` callback, branching on whether the
+    /// surface was shown with `persistent == true`:
+    ///
+    /// - Non-persistent surfaces are single-shot: the first action latches `respondedSurfaces`
+    ///   and subsequent actions (including the implicit post-action dismiss) are suppressed.
+    /// - Persistent surfaces stay visible and accept sibling actions. The same `actionId` is
+    ///   de-duplicated via `spentActionIdsBySurface`, but distinct action IDs on the same
+    ///   surface are all delivered.
+    ///
+    /// Internal for unit testing — production callers go through the `SurfaceViewModel.onAction`
+    /// closure registered in `showSurface`.
+    func handleSurfaceAction(conversationId: String?, surfaceId: String, actionId: String, data: [String: Any]?) {
+        if persistentSurfaces.contains(surfaceId) {
+            var spent = spentActionIdsBySurface[surfaceId] ?? []
+            guard !spent.contains(actionId) else { return }
+            spent.insert(actionId)
+            spentActionIdsBySurface[surfaceId] = spent
+            // Persistent: do NOT insert into respondedSurfaces; do NOT dismiss. Fire the action.
+            onAction?(conversationId, surfaceId, actionId, data)
+            return
+        }
+
+        // Non-persistent: single-shot with latching dedupe.
+        guard !respondedSurfaces.contains(surfaceId) else { return }
+        respondedSurfaces.insert(surfaceId)
+        onAction?(conversationId, surfaceId, actionId, data)
+    }
+
+    /// Test-only hook so unit tests can exercise `handleSurfaceAction` and surface lifecycle
+    /// without creating NSPanels. Mirrors the `activeSurfaces`/`persistentSurfaces` side effects
+    /// that `showSurface` performs in production.
+    #if DEBUG
+    func registerForTesting(surface: Surface, persistent: Bool) {
+        activeSurfaces[surface.id] = surface
+        if persistent {
+            persistentSurfaces.insert(surface.id)
+        } else {
+            persistentSurfaces.remove(surface.id)
+        }
+    }
+    #endif
+
     // MARK: - Update
 
     func updateSurface(_ message: UiSurfaceUpdateMessage) {
@@ -355,6 +417,8 @@ final class SurfaceManager {
         surfaceAppIds.removeAll()
         surfaceCoordinators.removeAll()
         respondedSurfaces.removeAll()
+        spentActionIdsBySurface.removeAll()
+        persistentSurfaces.removeAll()
 
         if hadWorkspaceRouted {
             NotificationCenter.default.post(
@@ -378,6 +442,8 @@ final class SurfaceManager {
         surfaceAppIds.removeValue(forKey: surfaceId)
         surfaceCoordinators.removeValue(forKey: surfaceId)
         respondedSurfaces.remove(surfaceId)
+        spentActionIdsBySurface.removeValue(forKey: surfaceId)
+        persistentSurfaces.remove(surfaceId)
         surfaceOrder.removeAll { $0 == surfaceId }
         repositionAllPanels()
 

--- a/clients/macos/vellum-assistantTests/SurfaceManagerTests.swift
+++ b/clients/macos/vellum-assistantTests/SurfaceManagerTests.swift
@@ -1,0 +1,157 @@
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+/// Behavioral tests for `SurfaceManager`'s action dispatch path.
+///
+/// The `persistent` flag on `UiSurfaceShowMessage` flips the action-dispatch behavior:
+/// - Non-persistent (default): single-shot. The first action latches the surface and any
+///   subsequent action (including implicit dismiss) is suppressed client-side.
+/// - Persistent: the card stays visible and multiple distinct action IDs fire; the same
+///   action ID is de-duplicated per-surface via `spentActionIdsBySurface`.
+///
+/// These tests exercise `handleSurfaceAction` directly through the test-only
+/// `registerForTesting` hook, bypassing NSPanel creation so the suite stays hermetic.
+@MainActor
+final class SurfaceManagerTests: XCTestCase {
+
+    private var surfaceManager: SurfaceManager!
+
+    /// Captured `onAction` dispatches from `SurfaceManager`'s outbound callback.
+    /// In production this is wired to `SurfaceActionClient.sendSurfaceAction`.
+    private var dispatched: [(conversationId: String?, surfaceId: String, actionId: String, data: [String: Any]?)] = []
+
+    override func setUp() {
+        super.setUp()
+        surfaceManager = SurfaceManager()
+        dispatched = []
+        surfaceManager.onAction = { [weak self] conversationId, surfaceId, actionId, data in
+            self?.dispatched.append((conversationId, surfaceId, actionId, data))
+        }
+    }
+
+    override func tearDown() {
+        surfaceManager = nil
+        dispatched = []
+        super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private func makeCardSurface(id: String, conversationId: String? = "conv-1") -> Surface {
+        let card = CardSurfaceData(
+            title: "Launch Conversation",
+            subtitle: nil,
+            body: "Pick a topic",
+            metadata: nil,
+            template: nil,
+            templateData: nil
+        )
+        let actions = [
+            SurfaceActionButton(id: "btn-1", label: "Topic 1", style: .primary, data: nil, index: 0),
+            SurfaceActionButton(id: "btn-2", label: "Topic 2", style: .primary, data: nil, index: 1)
+        ]
+        return Surface(
+            id: id,
+            conversationId: conversationId,
+            type: .card,
+            title: "Launch Conversation",
+            data: .card(card),
+            actions: actions
+        )
+    }
+
+    // MARK: - Persistent surfaces
+
+    func testPersistentSurface_doesNotDismissOnAction() {
+        let surface = makeCardSurface(id: "surf-persistent-1")
+        surfaceManager.registerForTesting(surface: surface, persistent: true)
+
+        surfaceManager.handleSurfaceAction(
+            conversationId: surface.conversationId,
+            surfaceId: surface.id,
+            actionId: "btn-1",
+            data: nil
+        )
+
+        // Persistent card stays visible — not removed from activeSurfaces on action.
+        XCTAssertNotNil(surfaceManager.activeSurfaces[surface.id],
+                        "Persistent surface should remain in activeSurfaces after an action")
+        // The action should have been dispatched exactly once.
+        XCTAssertEqual(dispatched.count, 1)
+        XCTAssertEqual(dispatched.first?.surfaceId, surface.id)
+        XCTAssertEqual(dispatched.first?.actionId, "btn-1")
+    }
+
+    func testPersistentSurface_blocksSameActionTwice() {
+        let surface = makeCardSurface(id: "surf-persistent-dedupe")
+        surfaceManager.registerForTesting(surface: surface, persistent: true)
+
+        surfaceManager.handleSurfaceAction(
+            conversationId: surface.conversationId,
+            surfaceId: surface.id,
+            actionId: "btn-1",
+            data: nil
+        )
+        surfaceManager.handleSurfaceAction(
+            conversationId: surface.conversationId,
+            surfaceId: surface.id,
+            actionId: "btn-1",
+            data: nil
+        )
+
+        // Same actionId de-duped within a persistent surface.
+        XCTAssertEqual(dispatched.count, 1,
+                       "Same actionId clicked twice on a persistent surface should dispatch only once")
+        XCTAssertEqual(dispatched.first?.actionId, "btn-1")
+    }
+
+    func testPersistentSurface_allowsSiblingAction() {
+        let surface = makeCardSurface(id: "surf-persistent-siblings")
+        surfaceManager.registerForTesting(surface: surface, persistent: true)
+
+        surfaceManager.handleSurfaceAction(
+            conversationId: surface.conversationId,
+            surfaceId: surface.id,
+            actionId: "btn-1",
+            data: nil
+        )
+        surfaceManager.handleSurfaceAction(
+            conversationId: surface.conversationId,
+            surfaceId: surface.id,
+            actionId: "btn-2",
+            data: nil
+        )
+
+        // Sibling actions on the same persistent surface are both dispatched.
+        XCTAssertEqual(dispatched.count, 2,
+                       "Distinct action IDs on a persistent surface should each fire exactly once")
+        XCTAssertEqual(dispatched.map(\.actionId), ["btn-1", "btn-2"])
+    }
+
+    // MARK: - Non-persistent regression
+
+    func testNonPersistentSurface_unchanged() {
+        let surface = makeCardSurface(id: "surf-single-shot")
+        surfaceManager.registerForTesting(surface: surface, persistent: false)
+
+        // First action fires.
+        surfaceManager.handleSurfaceAction(
+            conversationId: surface.conversationId,
+            surfaceId: surface.id,
+            actionId: "btn-1",
+            data: nil
+        )
+        // Second action (same or different id) is suppressed by the single-shot latch.
+        surfaceManager.handleSurfaceAction(
+            conversationId: surface.conversationId,
+            surfaceId: surface.id,
+            actionId: "btn-2",
+            data: nil
+        )
+
+        XCTAssertEqual(dispatched.count, 1,
+                       "Non-persistent surface should remain single-shot — only the first action dispatches")
+        XCTAssertEqual(dispatched.first?.actionId, "btn-1")
+    }
+}

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -812,8 +812,11 @@ public struct UiSurfaceShowMessage: Decodable, Sendable {
     public let display: String?
     /// The message ID that this surface belongs to (for history loading).
     public let messageId: String?
+    /// When `true`, clicking an action does not dismiss the surface — the client keeps the card
+    /// visible and only marks the clicked `actionId` as spent so siblings remain clickable.
+    public let persistent: Bool?
 
-    public init(conversationId: String?, surfaceId: String, surfaceType: String, title: String?, data: AnyCodable, actions: [SurfaceActionData]?, display: String?, messageId: String?) {
+    public init(conversationId: String?, surfaceId: String, surfaceType: String, title: String?, data: AnyCodable, actions: [SurfaceActionData]?, display: String?, messageId: String?, persistent: Bool? = nil) {
         self.conversationId = conversationId
         self.surfaceId = surfaceId
         self.surfaceType = surfaceType
@@ -822,6 +825,7 @@ public struct UiSurfaceShowMessage: Decodable, Sendable {
         self.actions = actions
         self.display = display
         self.messageId = messageId
+        self.persistent = persistent
     }
 }
 


### PR DESCRIPTION
## Summary
- Add `persistent: Bool?` to `UiSurfaceShowMessage` in `MessageTypes.swift` so `SurfaceManager` can read the flag.
- `SurfaceManager` now tracks clicked actionIds per-surface (`spentActionIdsBySurface`) when `persistent == true`, skipping the auto-dismiss and single-shot guard. Same actionId is still de-duped within a surface; sibling actions on the same surface remain clickable.
- Four new unit tests cover persistent multi-click, same-action dedupe, sibling allow, and non-persistent regression.

Part of plan: convo-launcher-fix.md (PR 6 of 9)