### PR TITLE
feat(skills): conversation-launcher uses persistent card + direct action

### DIFF
--- a/assistant/src/__tests__/conversation-launcher-skill-regression.test.ts
+++ b/assistant/src/__tests__/conversation-launcher-skill-regression.test.ts
@@ -7,42 +7,38 @@ const SKILL_PATH = resolve(REPO_ROOT, "skills", "conversation-launcher", "SKILL.
 const skillContent = readFileSync(SKILL_PATH, "utf-8");
 
 describe("conversation-launcher skill regression", () => {
-  test("uses structured UI tool, not a new tool registration", () => {
-    expect(skillContent).toContain("surface_type");
-    expect(skillContent).toContain("await_action");
-    expect(skillContent).not.toContain("ui_show(");
+  test("describes the direct surface-action contract the daemon dispatches on", () => {
+    // The skill must render one `ui_show` card whose actions carry the wire
+    // contract that `handleSurfaceAction`'s `launch_conversation` branch reads.
+    // These five tokens are the minimum the model needs to produce a valid card.
+    const requiredTokens = [
+      "ui_show",
+      "persistent: true",
+      '_action: "launch_conversation"',
+      "title",
+      "seedPrompt",
+    ];
+    for (const token of requiredTokens) {
+      expect(skillContent).toContain(token);
+    }
   });
 
-  test("launches via the launch-conversation signal (single write, no curl)", () => {
-    // One signal file per launch — the daemon creates+titles+seeds+opens.
-    expect(skillContent).toContain("launch-conversation.");
-    // Docker-safe path honors VELLUM_WORKSPACE_DIR.
-    expect(skillContent).toContain("VELLUM_WORKSPACE_DIR");
-  });
-
-  test("uses jq -n --arg to build the JSON payload (no raw interpolation)", () => {
-    expect(skillContent).toContain("jq -n");
-  });
-
-  test("payload includes the wire contract fields the daemon reads", () => {
-    expect(skillContent).toContain("requestId");
-    expect(skillContent).toContain("title");
-    expect(skillContent).toContain("seedPrompt");
-  });
-
-  test("explicitly binds NEW_CONV_TITLE and SEED_PROMPT from the action payload", () => {
-    expect(skillContent).toContain("NEW_CONV_TITLE");
-    expect(skillContent).toContain("SEED_PROMPT");
-  });
-
-  test("does not issue HTTP calls — the signal handler does everything server-side", () => {
-    expect(skillContent).not.toContain("curl");
-    expect(skillContent).not.toContain("/v1/conversations");
-    expect(skillContent).not.toContain("/v1/messages");
-    expect(skillContent).not.toContain("signals/emit-event");
-  });
-
-  test("does not instruct the assistant to reply in chat after launching", () => {
-    expect(skillContent).toMatch(/[Dd]on't say anything|[Nn]o chat response/);
+  test("does not resurrect the deprecated bash + signal-file launch flow", () => {
+    // PRs 5-7 replaced the bash step that wrote
+    // `signals/launch-conversation.<id>` with a direct surface-action
+    // dispatch. None of the old-flow tokens should reappear.
+    const forbiddenTokens = [
+      "bash",
+      "curl",
+      "signals/",
+      "jq ",
+      "launch-conversation.",
+      "VELLUM_WORKSPACE_DIR",
+      "INTERNAL_GATEWAY_BASE_URL",
+      "emit-event",
+    ];
+    for (const token of forbiddenTokens) {
+      expect(skillContent).not.toContain(token);
+    }
   });
 });

--- a/skills/conversation-launcher/SKILL.md
+++ b/skills/conversation-launcher/SKILL.md
@@ -1,81 +1,90 @@
 ---
 name: conversation-launcher
-description: Render an inline card where each button creates a new focused conversation seeded with specific context, then opens it. Use when the user asks "what are my open threads", "what's pending", "loose ends", "what should I work on next", or whenever you want to offer the user multiple branching conversation paths from the current one. Surfaces N options as clickable actions; on click, creates a new conversation, seeds it with the option's context, and navigates to it.
+description: Offer the user several spin-off conversations as clickable buttons on a single persistent card. Each click spawns a fresh seeded conversation in the sidebar; the user keeps their place in the current conversation. Use when you want to branch into N focused threads (research directions, draft choices, pending replies, triage of N items) without losing the current context. Not for single-destination pivots — just reply inline.
 compatibility: Designed for Vellum personal assistants
 metadata:
   vellum:
     display-name: "Conversation Launcher"
 ---
 
-Use this skill whenever you want the user to pick one of several threads or topics to work on, and each pick should become its own focused conversation rather than continuing in the current one.
+Use this skill when you want to offer the user several spin-off conversations from the current one. You render **one** persistent card. Each button on the card spawns its own seeded conversation in the sidebar. The user can click multiple buttons without losing their place — the origin conversation (this one) keeps focus.
 
 ## When this fits
 
-- "What are my open threads?" / "What's pending?" / "Loose ends?" — list the threads, let the user click one.
-- "What should I work on next?" — surface prioritized options, each launching a focused conversation.
-- "Here are three research directions" / "Here are the drafts I could write" — each direction becomes its own conversation with seeded context.
-- "Here are the emails I could respond to" — each one opens a conversation for drafting that reply.
+- Research branches — "here are three angles to pursue"
+- Draft choices — "here are the reply drafts I could write"
+- Triaging N items — "here are the five threads with pending replies"
+- Pending-reply fan-out — each sender gets their own drafting conversation
 
-Good fit: the options are distinct enough that continuing in one thread would bleed context. Poor fit: the user wants a quick inline answer, or the options share context and should stay in one conversation.
+## When this does NOT fit
 
-## Shape
+- Single-destination pivots — if there's one obvious next conversation, just reply inline or navigate there directly. One button is not a menu.
+- Options that share context and should stay in one thread — keep them here.
+- Inline Q&A the user can skim in place — answer; don't fan out.
 
-For each option you plan to surface, prepare:
+## How to render
 
-- `label` — short button text (≤ 4 words, ≤ 30 chars)
-- `title` — the new conversation's title (user-facing, shown in the sidebar)
-- `seed_prompt` — the first user message the new conversation will contain. Written in first-person as if the user typed it. Include enough context that the new conversation can pick up without re-asking. Example: "Let's keep working on the sleep schedule shift. Here's where we left off: we agreed 7 AM wake, Monday start, with a 7:30 AM Tuesday push if the first day slips."
+Emit exactly one `ui_show` call with a card shaped like this, then end your turn:
 
-## Steps
+```json
+{
+  "surface_type": "card",
+  "display": "inline",
+  "persistent": true,
+  "data": {
+    "title": "<framing headline>",
+    "body": "<one short sentence framing the choice>"
+  },
+  "actions": [
+    {
+      "id": "opt-1",
+      "label": "<short button label>",
+      "style": "primary",
+      "data": {
+        "_action": "launch_conversation",
+        "title": "<short conversation title>",
+        "seedPrompt": "<full first-user-message seed>",
+        "anchorMessageId": "<optional anchor message id from this conversation>"
+      }
+    },
+    {
+      "id": "opt-2",
+      "label": "<short button label>",
+      "style": "secondary",
+      "data": {
+        "_action": "launch_conversation",
+        "title": "<short conversation title>",
+        "seedPrompt": "<full first-user-message seed>"
+      }
+    }
+  ]
+}
+```
 
-1. **Render the card.** Call the structured UI tool with a card containing one action per option. The action payload (`data` field) carries `{ title, seed_prompt }`. Block until the user clicks.
+Field notes:
 
-   ```json
-   {
-     "surface_type": "card",
-     "display": "inline",
-     "await_action": true,
-     "data": {
-       "title": "Open threads",
-       "body": "<one-sentence lead-in explaining what the user is picking between>"
-     },
-     "actions": [
-       { "id": "opt-1", "label": "<label>", "style": "primary", "data": { "title": "<title>", "seed_prompt": "<seed>" } },
-       { "id": "opt-2", "label": "<label>", "data": { "title": "<title>", "seed_prompt": "<seed>" } }
-     ]
-   }
-   ```
+- `persistent: true` keeps the card visible after a click so the user can fire more buttons.
+- Each action's `data` must contain `_action: "launch_conversation"`, `title`, and `seedPrompt`. `anchorMessageId` is optional — include it when the spawned conversation should thread off a specific message in this one.
+- `label` is the button text (short, ≤ 4 words, ≤ 30 chars). `title` is the new conversation's sidebar name (3–5 words, specific not generic). `seedPrompt` is the first user message of the new conversation — written in first-person as if the user typed it, with enough context that the new conversation can pick up without re-asking.
+- Use `style: "primary"` for the recommended option (at most one), `style: "secondary"` for the rest.
 
-2. **Bind the clicked action's payload.** When the user clicks a button, you receive the `actionId` and its `data` payload. Bind the values before continuing:
+## Do nothing else
 
-   - `NEW_CONV_TITLE` = the `title` field from the clicked action's `data`.
-   - `SEED_PROMPT` = the `seed_prompt` field from the clicked action's `data`.
+After rendering the card, end your turn. The click pipeline handles everything:
 
-3. **Launch the conversation.** Write a single signal file. The assistant picks it up, creates a fresh conversation, titles it, seeds it with `$SEED_PROMPT` as the first user message, and emits an `open_conversation` event so the UI navigates automatically.
+- Do NOT run a follow-up step, issue any HTTP request, or write any file.
+- Do NOT send a chat message after the card. The card is the response.
+- Do NOT re-render the card on each click — it stays visible.
 
-    ```bash
-    REQUEST_ID=$(uuidgen 2>/dev/null || cat /proc/sys/kernel/random/uuid)
-    SIGNALS_DIR="${VELLUM_WORKSPACE_DIR:-$HOME/.vellum/workspace}/signals"
-    mkdir -p "$SIGNALS_DIR"
+## UX contract the client enforces
 
-    # Safely encode user-provided strings as JSON (handles quotes, newlines, $, etc.)
-    PAYLOAD=$(jq -n \
-      --arg requestId "$REQUEST_ID" \
-      --arg title "$NEW_CONV_TITLE" \
-      --arg seedPrompt "$SEED_PROMPT" \
-      '{requestId: $requestId, title: $title, seedPrompt: $seedPrompt}')
+- The card stays open until dismissed by the user.
+- Each `action.id` fires at most once per card lifetime; sibling actions remain clickable.
+- Each spawned conversation inherits this conversation's guardian / trust context automatically.
+- Sidebar focus stays on this conversation. The user sees new entries appear and can navigate in at their pace.
 
-    printf '%s' "$PAYLOAD" > "$SIGNALS_DIR/launch-conversation.$REQUEST_ID"
-    ```
+## Authoring tips
 
-    `jq` is available in the skill sandbox. Do not interpolate `$NEW_CONV_TITLE` or `$SEED_PROMPT` directly into a JSON string — user prompts commonly contain quotes, backslashes, newlines, or `$`, which break raw interpolation.
-
-4. **Don't say anything else.** The UI switch is the signal. No chat response needed after the launch.
-
-## Notes
-
-- One signal file per launch — the assistant handles create + title + seed + open. Do not issue any HTTP calls from this skill.
-- If the user hasn't named the threads, name them concisely yourself (3–5 words, specific not generic).
-- Don't invent threads. Only surface what the user has actually discussed or what they asked about.
-- If there's only one reasonable option, do not use this skill — just continue in the current conversation.
-- Keep the card body brief (one sentence). The buttons carry the payload; the body just frames the choice.
+- Don't invent options. Only surface branches the user has actually discussed or implied.
+- 2–5 buttons is the sweet spot. One option? Just reply inline. More than five? Trim or group.
+- Keep the card body to one sentence. The buttons carry the payload; the body just frames the choice.


### PR DESCRIPTION
## Summary
- Rewrite the `conversation-launcher` skill as a pure `ui_show` render. No bash, no curl, no signal file.
- Card is `persistent: true`; each action's `data` contains `_action: "launch_conversation"` + `title` + `seedPrompt` so the daemon dispatches directly (PR #25189).
- Regression test rewritten to assert the new pattern and forbid the old one.

Part of plan: convo-launcher-fix.md (PR 8 of 9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25190" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
