### PR TITLE
docs(macos): remove stale reference to deleted launch-conversation signal

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
@@ -212,8 +212,10 @@ extension AppDelegate {
                     guard !self.isBootstrapping else { break }
                     self.ensureMainWindowExists()
                     // If the conversation isn't in the sidebar yet (e.g. just created by a
-                    // skill via the launch-conversation signal), stub a sidebar entry using
-                    // the optional title so openConversation's trySelect retries find it.
+                    // surface action with `_action: "launch_conversation"` that the daemon
+                    // dispatched inline, spawning a fresh conversation and emitting
+                    // open_conversation), stub a sidebar entry using the optional title so
+                    // openConversation's trySelect retries find it.
                     // Tag the stub with source: "open_conversation" so it's distinguishable
                     // from true notification-flow stubs (which use source: "notification"
                     // and may drive urgency/alerting behaviors that don't apply here).


### PR DESCRIPTION
## Summary
Updates a comment in AppDelegate+ConnectionSetup.swift that still referenced the `launch-conversation` signal path, which was deleted in PR #25191 as part of convo-launcher-fix. Per repo convention, comments describe the current state rather than narrating removed code.

Fixes gap identified during plan review for convo-launcher-fix.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25192" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
