### PR TITLE
fix(sounds): per-row play buttons audition specific pool entries

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsSoundsTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsSoundsTab.swift
@@ -108,20 +108,8 @@ struct SettingsSoundsTab: View {
                 )
             }
 
-            HStack(alignment: .top, spacing: VSpacing.sm) {
-                soundPoolEditor(for: event, eventConfig: eventConfig, sounds: sounds)
-
-                VButton(
-                    label: "Preview sound",
-                    iconOnly: VIcon.play.rawValue,
-                    style: .ghost,
-                    tooltip: "Preview sound"
-                ) {
-                    previewSound(for: event, eventConfig: eventConfig)
-                }
+            soundPoolEditor(for: event, eventConfig: eventConfig, sounds: sounds)
                 .disabled(!eventConfig.enabled)
-            }
-            .disabled(!eventConfig.enabled)
         }
         .padding(.vertical, VSpacing.xs)
     }
@@ -158,6 +146,15 @@ struct SettingsSoundsTab: View {
                             .truncationMode(.tail)
 
                         Spacer()
+
+                        VButton(
+                            label: "Preview sound",
+                            iconOnly: VIcon.play.rawValue,
+                            style: .ghost,
+                            tooltip: "Preview sound"
+                        ) {
+                            soundManager.previewSound(filename: filename)
+                        }
 
                         VButton(
                             label: "Remove sound",
@@ -246,11 +243,5 @@ struct SettingsSoundsTab: View {
     /// Preview the default blip at the current volume, bypassing enabled checks.
     private func previewDefaultBlip() {
         soundManager.previewDefaultBlip()
-    }
-
-    /// Preview the sound configured for a specific event, delegating to
-    /// SoundManager which uses the instance-aware sounds directory.
-    private func previewSound(for event: SoundEvent, eventConfig: SoundEventConfig) {
-        soundManager.previewSound(for: event)
     }
 }

--- a/clients/macos/vellum-assistant/Features/Sounds/SoundManager.swift
+++ b/clients/macos/vellum-assistant/Features/Sounds/SoundManager.swift
@@ -146,8 +146,8 @@ final class SoundManager {
 
     /// Picks a random filename from the pool after filtering out entries that
     /// fail `validateSoundFilename`. Returns `nil` when the pool is empty or
-    /// every entry is invalid. Single source of truth for pool selection so
-    /// `play(_:)` and `previewSound(for:)` stay in lockstep.
+    /// every entry is invalid. Single source of truth for pool selection in
+    /// `play(_:)`.
     internal func pickSoundFilename(from sounds: [String]) -> String? {
         let validated = sounds.filter { validateSoundFilename($0) }
         return validated.randomElement()
@@ -216,13 +216,12 @@ final class SoundManager {
         sound.play()
     }
 
-    /// Preview the sound configured for a specific event at the current volume,
-    /// bypassing enabled checks. Fetches the sound from the gateway if not cached.
-    /// Each invocation picks a random entry from the pool, which doubles as the
-    /// way to audition a multi-sound pool from the Settings UI.
-    func previewSound(for event: SoundEvent) {
-        let eventConfig = config.config(for: event)
-        guard let filename = pickSoundFilename(from: eventConfig.sounds) else {
+    /// Preview a specific sound by filename at the current volume, bypassing
+    /// enabled checks. Fetches from the gateway if not cached. Falls back to
+    /// the default blip if the filename is invalid or cannot be fetched. Used
+    /// by the Settings sound pool UI so each pool entry can be auditioned.
+    func previewSound(filename: String) {
+        guard validateSoundFilename(filename) else {
             previewDefaultBlip()
             return
         }


### PR DESCRIPTION
## Summary
- Each sound pool row in Settings → Sounds now shows its own play button that previews *that specific* sound, instead of one shared button that picked a random entry.
- Added \`SoundManager.previewSound(filename:)\` for deterministic per-file playback and removed the now-unused \`previewSound(for:)\` (random-pick preview) and the \`previewSound(for:eventConfig:)\` settings-tab helper.
- Pool \`.disabled(!eventConfig.enabled)\` behavior preserved — per-row play/trash buttons inherit the disabled state when the event toggle is off.

## Original prompt
it