### PR TITLE
fix(convo-launcher): wire persistent, dedupe launch events, non-blocking seed, error response

### DIFF
--- a/assistant/src/daemon/__tests__/conversation-surfaces-launch.test.ts
+++ b/assistant/src/daemon/__tests__/conversation-surfaces-launch.test.ts
@@ -1,59 +1,38 @@
 /**
  * Unit tests for the `_action: "launch_conversation"` dispatch branch in
- * `handleSurfaceAction`.
+ * `handleSurfaceAction` AND the `launchConversation` helper it calls into.
  *
- * `launchConversation` is mocked at the module level so we can assert what
- * parameters the dispatch branch passes in (including `originTrustContext`
- * inherited from the origin conversation) without standing up a real DB.
- * Mocks use dynamic imports after `mock.module` calls so the modules under
- * test see the stubs.
+ * The real `launchConversation` is exercised end-to-end: its DB-hitting
+ * dependencies (`conversation-key-store`, `conversation-crud`) and its
+ * registered daemon deps are stubbed so the helper runs without a DB.
+ * This lets the tests assert the full invariant set in one place:
+ *
+ *   - `handleSurfaceAction` does NOT publish `open_conversation` itself —
+ *     `launchConversation` is the sole emitter of that event.
+ *   - Exactly one `open_conversation` is published per launch, carrying
+ *     the caller-supplied `focus` value (false for fan-out launchers).
+ *   - The handler returns promptly — the seed turn
+ *     (`persistAndProcessMessage`) is fire-and-forget.
+ *   - `originTrustContext` is forwarded to the spawned conversation.
+ *
+ * The historical double-emit bug — both sites publishing, with the
+ * helper's default-true `focus` arriving first and stealing focus away
+ * from the origin — is the regression covered here.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 // ── Module-level mocks ─────────────────────────────────────────────
-//
-// `launchConversation` is the only DB-hitting call path inside the new
-// dispatch branch. Stub it so the test exercises dispatch logic in
-// isolation: it records every call and returns a predictable id.
 
-const launchCalls: Array<{
-  title: string;
-  seedPrompt: string;
-  anchorMessageId?: string;
-  originTrustContext?: unknown;
-}> = [];
-let nextLaunchResult: { conversationId: string } = {
-  conversationId: "conv-new",
-};
-
-mock.module("../conversation-launch.js", () => ({
-  launchConversation: async (params: {
-    title: string;
-    seedPrompt: string;
-    anchorMessageId?: string;
-    originTrustContext?: unknown;
-  }) => {
-    launchCalls.push({
-      title: params.title,
-      seedPrompt: params.seedPrompt,
-      ...(params.anchorMessageId !== undefined
-        ? { anchorMessageId: params.anchorMessageId }
-        : {}),
-      ...(params.originTrustContext !== undefined
-        ? { originTrustContext: params.originTrustContext }
-        : {}),
-    });
-    return nextLaunchResult;
-  },
-  // Preserve the shape of the real module so unrelated imports still resolve.
-  registerLaunchConversationDeps: () => {},
-}));
-
-// Capture hub publish calls so the test can assert that
-// `open_conversation` with `focus: false` is emitted for the new id.
+// Hub publish capture — used by the single-emit assertions. We spread
+// the real module into each override so unrelated exports (e.g.
+// `formatSseFrame` on assistant-event) stay accessible to other
+// importers loaded indirectly through `conversation-surfaces.ts`.
 const publishCalls: Array<unknown> = [];
+const realHub = await import("../../runtime/assistant-event-hub.js");
+const realEvent = await import("../../runtime/assistant-event.js");
 mock.module("../../runtime/assistant-event-hub.js", () => ({
+  ...realHub,
   assistantEventHub: {
     publish: async (event: unknown) => {
       publishCalls.push(event);
@@ -61,8 +40,9 @@ mock.module("../../runtime/assistant-event-hub.js", () => ({
   },
 }));
 mock.module("../../runtime/assistant-event.js", () => ({
-  // Pass-through so `focus` / `conversationId` can be asserted directly on
-  // the captured event's `message` payload.
+  ...realEvent,
+  // Pass-through so `focus` / `conversationId` can be asserted directly
+  // on the captured event's `message` payload.
   buildAssistantEvent: (
     assistantId: string,
     message: unknown,
@@ -70,10 +50,38 @@ mock.module("../../runtime/assistant-event.js", () => ({
   ) => ({ assistantId, message, conversationId }),
 }));
 
+// Stub DB helpers so the real `launchConversation` can run without a DB.
+// We spread the real module and override only the specific functions the
+// helper uses — other importers (e.g. conversation-surfaces itself)
+// continue to see `getMessages`, `updateMessageContent`, etc.
+let nextKeyStoreResult: { conversationId: string } = {
+  conversationId: "conv-new",
+};
+const updateTitleCalls: Array<{ conversationId: string; title: string }> = [];
+const realKeyStore = await import("../../memory/conversation-key-store.js");
+const realCrud = await import("../../memory/conversation-crud.js");
+mock.module("../../memory/conversation-key-store.js", () => ({
+  ...realKeyStore,
+  getOrCreateConversation: (_key: string) => nextKeyStoreResult,
+}));
+mock.module("../../memory/conversation-crud.js", () => ({
+  ...realCrud,
+  updateConversationTitle: (
+    conversationId: string,
+    title: string,
+    _priority: number,
+  ) => {
+    updateTitleCalls.push({ conversationId, title });
+  },
+}));
+
 // Dynamic imports after mock.module calls so the stubs take effect
 // before the modules under test are loaded.
 const { createSurfaceMutex, handleSurfaceAction } = await import(
   "../conversation-surfaces.js"
+);
+const { registerLaunchConversationDeps } = await import(
+  "../conversation-launch.js"
 );
 type SurfaceConversationContext =
   import("../conversation-surfaces.js").SurfaceConversationContext;
@@ -82,7 +90,63 @@ type ServerMessage = import("../message-protocol.js").ServerMessage;
 type SurfaceData = import("../message-protocol.js").SurfaceData;
 type SurfaceType = import("../message-protocol.js").SurfaceType;
 
-// ── Test harness ───────────────────────────────────────────────────
+// ── launchConversation deps harness ────────────────────────────────
+
+interface DepsHarness {
+  getOrCreateCalls: Array<string>;
+  processCalls: Array<{ conversationId: string; content: string }>;
+  lastTrustContext(): unknown | null;
+  resolveProcess: () => void;
+  rejectProcess: (err: Error) => void;
+  /** Resolves once `persistAndProcessMessage` has actually been invoked. */
+  processStarted: Promise<void>;
+}
+
+function setupLaunchDeps(): DepsHarness {
+  const getOrCreateCalls: Array<string> = [];
+  const processCalls: Array<{ conversationId: string; content: string }> = [];
+  let trustContextOnConversation: unknown | null = null;
+  let resolveProcess = () => {};
+  let rejectProcess: (err: Error) => void = () => {};
+  let markProcessStarted = () => {};
+  const processStarted = new Promise<void>((resolve) => {
+    markProcessStarted = resolve;
+  });
+
+  const fakeConversation = {
+    setTrustContext: (c: unknown) => {
+      trustContextOnConversation = c;
+    },
+  };
+
+  registerLaunchConversationDeps({
+    getOrCreateConversation: async (id: string) => {
+      getOrCreateCalls.push(id);
+      return fakeConversation as never;
+    },
+    persistAndProcessMessage: (conversationId: string, content: string) => {
+      processCalls.push({ conversationId, content });
+      markProcessStarted();
+      return new Promise((resolve, reject) => {
+        resolveProcess = () => resolve({ messageId: "msg-1" });
+        rejectProcess = (err) => reject(err);
+      });
+    },
+    publishAssistantEvent: () => {},
+    getAssistantId: () => "assistant-test-id",
+  });
+
+  return {
+    getOrCreateCalls,
+    processCalls,
+    lastTrustContext: () => trustContextOnConversation,
+    resolveProcess: () => resolveProcess(),
+    rejectProcess: (err: Error) => rejectProcess(err),
+    processStarted,
+  };
+}
+
+// ── Surface-context harness ────────────────────────────────────────
 
 interface HarnessContext extends SurfaceConversationContext {
   sent: ServerMessage[];
@@ -150,15 +214,52 @@ function registerCardSurface(
   });
 }
 
+// Helper: filter captured publish calls down to `open_conversation`
+// events. Typed so assertions can reach the inner `message` payload.
+function openConversationEvents(): Array<{
+  assistantId: string;
+  conversationId?: string;
+  message: {
+    type: "open_conversation";
+    conversationId: string;
+    title?: string;
+    anchorMessageId?: string;
+    focus?: boolean;
+  };
+}> {
+  return publishCalls
+    .filter((e): e is { message: { type: "open_conversation" } } => {
+      const ev = e as { message?: { type?: string } };
+      return ev.message?.type === "open_conversation";
+    })
+    .map(
+      (e) =>
+        e as unknown as {
+          assistantId: string;
+          conversationId?: string;
+          message: {
+            type: "open_conversation";
+            conversationId: string;
+            title?: string;
+            anchorMessageId?: string;
+            focus?: boolean;
+          };
+        },
+    );
+}
+
+// ── Tests ──────────────────────────────────────────────────────────
+
 describe("handleSurfaceAction — launch_conversation dispatch", () => {
   beforeEach(() => {
     publishCalls.length = 0;
-    launchCalls.length = 0;
-    nextLaunchResult = { conversationId: "conv-new" };
+    updateTitleCalls.length = 0;
+    nextKeyStoreResult = { conversationId: "conv-new" };
   });
 
   test("launches new conversation with inherited trust context and no chat message", async () => {
-    nextLaunchResult = { conversationId: "conv-launched-1" };
+    nextKeyStoreResult = { conversationId: "conv-launched-1" };
+    const harness = setupLaunchDeps();
     const originTrustContext: TrustContext = {
       sourceChannel: "vellum",
       trustClass: "guardian",
@@ -180,31 +281,27 @@ describe("handleSurfaceAction — launch_conversation dispatch", () => {
       conversationId: "conv-launched-1",
     });
 
-    // 2. `launchConversation` was invoked exactly once with the origin's
-    //    trust context so the spawned conversation inherits the
-    //    guardian scope.
-    expect(launchCalls).toHaveLength(1);
-    expect(launchCalls[0].title).toBe("New Thread");
-    expect(launchCalls[0].seedPrompt).toBe("S");
-    expect(launchCalls[0].originTrustContext).toEqual(originTrustContext);
+    // 2. Exactly ONE `open_conversation` event was published for the new
+    //    id, with focus: false. This is the regression barrier for the
+    //    historical double-emit bug — `handleSurfaceAction` no longer
+    //    publishes its own event on top of the helper's.
+    const openEvents = openConversationEvents();
+    expect(openEvents).toHaveLength(1);
+    expect(openEvents[0].message.conversationId).toBe("conv-launched-1");
+    expect(openEvents[0].message.focus).toBe(false);
+    expect(openEvents[0].message.title).toBe("New Thread");
 
-    // 3. `open_conversation` with focus: false was published for the new id.
-    const openEvents = publishCalls.filter((e) => {
-      const ev = e as { message?: { type?: string } };
-      return ev.message?.type === "open_conversation";
-    });
-    const focusFalseEvent = openEvents.find((e) => {
-      const ev = e as {
-        message: { focus?: boolean; conversationId?: string };
-      };
-      return (
-        ev.message.focus === false &&
-        ev.message.conversationId === "conv-launched-1"
-      );
-    });
-    expect(focusFalseEvent).toBeDefined();
+    // 3. The spawned conversation inherited the origin's trust context.
+    expect(harness.lastTrustContext()).toEqual(originTrustContext);
 
-    // 4. No chat message side effect on the origin conversation — neither
+    // 4. Seed turn was kicked off fire-and-forget — resolve it to clean
+    //    up the pending promise the harness stubbed.
+    await harness.processStarted;
+    expect(harness.processCalls).toHaveLength(1);
+    expect(harness.processCalls[0].content).toBe("S");
+    harness.resolveProcess();
+
+    // 5. No chat message side effect on the origin conversation — neither
     //    the LLM pipeline nor the `[User action on app: ...]` text echo.
     expect(ctx.enqueueCalls).toHaveLength(0);
     expect(ctx.processCalls).toHaveLength(0);
@@ -250,14 +347,15 @@ describe("handleSurfaceAction — launch_conversation dispatch", () => {
       error: "missing_title_or_seedPrompt",
     });
 
-    // No launch-side effects in any of the failed validations.
-    expect(launchCalls).toHaveLength(0);
+    // No launch-side effects in any of the failed validations — no events,
+    // no queued origin-conversation messages.
     expect(publishCalls).toHaveLength(0);
     expect(ctx.enqueueCalls).toHaveLength(0);
   });
 
   test("omits originTrustContext when origin conversation has none", async () => {
-    nextLaunchResult = { conversationId: "conv-launched-3" };
+    nextKeyStoreResult = { conversationId: "conv-launched-3" };
+    const harness = setupLaunchDeps();
     // No `trustContext` on the origin context — simulating the
     // no-inherited-guardian path.
     const ctx = makeContext();
@@ -274,9 +372,74 @@ describe("handleSurfaceAction — launch_conversation dispatch", () => {
       conversationId: "conv-launched-3",
     });
 
-    // With no origin trust context, the dispatch branch must NOT pass
-    // one to `launchConversation`.
-    expect(launchCalls).toHaveLength(1);
-    expect("originTrustContext" in launchCalls[0]).toBe(false);
+    // Trust context was never applied to the spawned conversation.
+    expect(harness.lastTrustContext()).toBeNull();
+
+    // Still exactly one open_conversation event with focus: false.
+    const openEvents = openConversationEvents();
+    expect(openEvents).toHaveLength(1);
+    expect(openEvents[0].message.focus).toBe(false);
+
+    await harness.processStarted;
+    harness.resolveProcess();
+  });
+
+  test("handler returns before the seed turn resolves (fire-and-forget)", async () => {
+    nextKeyStoreResult = { conversationId: "conv-nonblocking" };
+    const harness = setupLaunchDeps();
+    const ctx = makeContext();
+    registerCardSurface(ctx, "surface-4");
+
+    // The harness's `persistAndProcessMessage` returns a pending Promise
+    // that only resolves when we call `resolveProcess()`. If the helper
+    // (or handler) awaited it, `await handleSurfaceAction(...)` below
+    // would hang. The fact that it resolves while the seed turn is still
+    // pending proves the fire-and-forget behavior that the HTTP route
+    // relies on for the fan-out multi-launch UX.
+    const result = await handleSurfaceAction(ctx, "surface-4", "launch", {
+      _action: "launch_conversation",
+      title: "T",
+      seedPrompt: "S",
+    });
+
+    expect(result).toEqual({
+      accepted: true,
+      conversationId: "conv-nonblocking",
+    });
+
+    // Seed turn is in-flight but not yet resolved. Prove the helper
+    // actually invoked it (so we know fire-and-forget is wired), then
+    // resolve it to clean up.
+    await harness.processStarted;
+    expect(harness.processCalls).toHaveLength(1);
+    harness.resolveProcess();
+  });
+
+  test("seed turn rejection is swallowed by the helper's .catch()", async () => {
+    nextKeyStoreResult = { conversationId: "conv-seed-fails" };
+    const harness = setupLaunchDeps();
+    const ctx = makeContext();
+    registerCardSurface(ctx, "surface-5");
+
+    const result = await handleSurfaceAction(ctx, "surface-5", "launch", {
+      _action: "launch_conversation",
+      title: "T",
+      seedPrompt: "boom",
+    });
+
+    expect(result).toEqual({
+      accepted: true,
+      conversationId: "conv-seed-fails",
+    });
+
+    // Reject the pending seed turn — the helper's `.catch()` handler
+    // must swallow it. If it didn't, Bun would surface the unhandled
+    // rejection at test-end and this test would fail.
+    await harness.processStarted;
+    harness.rejectProcess(new Error("seed-turn-failed"));
+    // Give the microtask queue a tick so the `.catch()` runs before
+    // the test completes.
+    await Promise.resolve();
+    await Promise.resolve();
   });
 });

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -237,6 +237,7 @@ export interface AgentLoopConversationContext {
     data: SurfaceData;
     actions?: Array<{ id: string; label: string; style?: string }>;
     display?: string;
+    persistent?: boolean;
   }>;
 
   workingDir: string;

--- a/assistant/src/daemon/conversation-launch.ts
+++ b/assistant/src/daemon/conversation-launch.ts
@@ -19,10 +19,13 @@ import { getOrCreateConversation as getOrCreateConversationKey } from "../memory
 import { buildAssistantEvent } from "../runtime/assistant-event.js";
 import { assistantEventHub } from "../runtime/assistant-event-hub.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
+import { getLogger } from "../util/logger.js";
 import type { Conversation } from "./conversation.js";
 import type { TrustContext } from "./conversation-runtime-assembly.js";
 import type { ConversationCreateOptions } from "./handlers/shared.js";
 import type { ServerMessage } from "./message-protocol.js";
+
+const log = getLogger("conversation-launch");
 
 // ── Dependency registry ─────────────────────────────────────────────
 
@@ -79,6 +82,14 @@ export interface LaunchConversationParams {
   seedPrompt: string;
   anchorMessageId?: string;
   originTrustContext?: TrustContext;
+  /**
+   * Passed through to the `open_conversation` event. Defaults to omitted
+   * (i.e. client-side default of `true`) so direct callers keep their
+   * existing "jump to the new conversation" behavior. Set to `false` for
+   * fan-out launchers that register the conversation in the sidebar but
+   * must not steal focus from the origin.
+   */
+  focus?: boolean;
 }
 
 /**
@@ -90,8 +101,16 @@ export interface LaunchConversationParams {
  * spawning context. When absent, the conversation runs without an inherited
  * trust context.
  *
+ * The seed turn (`persistAndProcessMessage`) runs **fire-and-forget** so this
+ * helper returns as soon as the conversation is created, titled, and the
+ * `open_conversation` event has been published. Callers driving a fan-out
+ * UX (multiple launches from a single click) rely on this: blocking on the
+ * full LLM turn would hold the HTTP request open for tens of seconds.
+ * Errors from the seed turn are logged but not surfaced — the new
+ * conversation still exists in the sidebar so the user can retry from there.
+ *
  * Throws if the helper's daemon-side dependencies have not been registered
- * or if any step of the pipeline fails.
+ * or if conversation creation / titling itself fails.
  */
 export async function launchConversation(
   params: LaunchConversationParams,
@@ -127,30 +146,11 @@ export async function launchConversation(
     updateConversationTitle(conversationId, params.title, 0);
   }
 
-  // Seed the conversation by running the seed prompt through the same
-  // pipeline POST /v1/messages uses. Publishing to the hub lets any
-  // connected client stream the turn live.
-  const hubSender = (msg: ServerMessage) => {
-    const msgConversationId =
-      "conversationId" in msg &&
-      typeof (msg as { conversationId?: unknown }).conversationId === "string"
-        ? (msg as { conversationId: string }).conversationId
-        : undefined;
-    deps.publishAssistantEvent(msg, msgConversationId ?? conversationId);
-  };
-
-  await deps.persistAndProcessMessage(
-    conversationId,
-    params.seedPrompt,
-    undefined,
-    { onEvent: hubSender },
-    "vellum",
-    "cli",
-  );
-
-  // Tell connected clients to focus the new conversation. The client stubs
-  // a sidebar entry from the optional title if the conversation isn't
-  // already in its list.
+  // Tell connected clients about the new conversation BEFORE kicking off the
+  // seed turn so the sidebar entry appears instantly. We are the sole
+  // emitter of `open_conversation` for this launch path — `handleSurfaceAction`
+  // no longer publishes a second event. Pass through the caller-specified
+  // `focus` so fan-out launchers can avoid stealing focus from the origin.
   await assistantEventHub.publish(
     buildAssistantEvent(
       deps.getAssistantId() ?? DAEMON_INTERNAL_ASSISTANT_ID,
@@ -161,10 +161,40 @@ export async function launchConversation(
         ...(params.anchorMessageId
           ? { anchorMessageId: params.anchorMessageId }
           : {}),
+        ...(params.focus !== undefined ? { focus: params.focus } : {}),
       },
       conversationId,
     ),
   );
+
+  // Seed the conversation by running the seed prompt through the same
+  // pipeline POST /v1/messages uses. Publishing to the hub lets any
+  // connected client stream the turn live. Fire-and-forget so callers
+  // aren't blocked on the full LLM turn — errors are logged but swallowed.
+  const hubSender = (msg: ServerMessage) => {
+    const msgConversationId =
+      "conversationId" in msg &&
+      typeof (msg as { conversationId?: unknown }).conversationId === "string"
+        ? (msg as { conversationId: string }).conversationId
+        : undefined;
+    deps.publishAssistantEvent(msg, msgConversationId ?? conversationId);
+  };
+
+  deps
+    .persistAndProcessMessage(
+      conversationId,
+      params.seedPrompt,
+      undefined,
+      { onEvent: hubSender },
+      "vellum",
+      "cli",
+    )
+    .catch((err) => {
+      log.error(
+        { err, conversationId },
+        "Seed turn failed for launched conversation (non-fatal)",
+      );
+    });
 
   return { conversationId };
 }

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -13,9 +13,6 @@ import {
   getMessages,
   updateMessageContent,
 } from "../memory/conversation-crud.js";
-import { buildAssistantEvent } from "../runtime/assistant-event.js";
-import { assistantEventHub } from "../runtime/assistant-event-hub.js";
-import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import type { ToolExecutionResult } from "../tools/types.js";
 import { getLogger } from "../util/logger.js";
 import { isPlainObject } from "../util/object.js";
@@ -287,6 +284,7 @@ export interface SurfaceConversationContext {
       data?: Record<string, unknown>;
     }>;
     display?: string;
+    persistent?: boolean;
   }>;
   /** Optional proxy for delegating computer-use actions to a connected desktop client. */
   hostCuProxy?: import("./host-cu-proxy.js").HostCuProxy;
@@ -720,27 +718,25 @@ export async function handleSurfaceAction(
       }
       // `ctx` is the origin Conversation — inherit its trust context so the
       // spawned conversation keeps guardian / trust-class state.
+      //
+      // `launchConversation` is the sole emitter of `open_conversation` for
+      // this path. We pass `focus: false` so the client registers a sidebar
+      // entry for the spawned conversation without switching focus away from
+      // the origin — critical for fan-out UX where one click launches
+      // multiple conversations.
+      //
+      // The helper also kicks off the seed turn fire-and-forget, so this
+      // `await` resolves as soon as the conversation is created + titled +
+      // published to the event hub. The HTTP POST /v1/surface-actions
+      // response no longer blocks on the full LLM turn.
       const originTrustContext = ctx.trustContext;
       const { conversationId } = await launchConversation({
         title,
         seedPrompt,
+        focus: false,
         ...(anchorMessageId ? { anchorMessageId } : {}),
         ...(originTrustContext ? { originTrustContext } : {}),
       });
-      const assistantId = ctx.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID;
-      await assistantEventHub.publish(
-        buildAssistantEvent(
-          assistantId,
-          {
-            type: "open_conversation",
-            conversationId,
-            title,
-            ...(anchorMessageId ? { anchorMessageId } : {}),
-            focus: false,
-          },
-          conversationId,
-        ),
-      );
       log.info(
         { originConversationId: ctx.conversationId, conversationId, surfaceId },
         "launch_conversation dispatched inline from surface action",
@@ -1442,6 +1438,11 @@ export async function surfaceProxyResolver(
     }
 
     const display = (input.display as string) === "panel" ? "panel" : "inline";
+    // `persistent: true` keeps the card visible through action clicks (only
+    // marks the clicked action as spent). Forward the flag so
+    // `SurfaceManager.showSurface` on the client sees it — without this the
+    // field is dropped and every card dismisses on first click.
+    const persistent = input.persistent === true ? true : undefined;
 
     const mappedActions = actions?.map((a) => ({
       id: a.id,
@@ -1470,6 +1471,7 @@ export async function surfaceProxyResolver(
         dataKeys: Object.keys(data),
         actionCount: mappedActions?.length ?? 0,
         display,
+        persistent: persistent ?? false,
         conversationId: ctx.conversationId,
       },
       "Sending ui_surface_show to client",
@@ -1484,6 +1486,7 @@ export async function surfaceProxyResolver(
       data,
       actions: mappedActions,
       display,
+      ...(persistent ? { persistent: true } : {}),
     } as unknown as UiSurfaceShow);
 
     // Track surface for persistence with the message
@@ -1494,6 +1497,7 @@ export async function surfaceProxyResolver(
       data,
       actions: mappedActions,
       display,
+      ...(persistent ? { persistent: true } : {}),
     });
 
     if (awaitAction) {

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -219,6 +219,7 @@ export function createToolExecutor(
             data: s.data,
             actions: s.actions,
             display: s.display,
+            ...(s.persistent ? { persistent: true } : {}),
           });
         }
       },

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -270,6 +270,7 @@ export class Conversation {
     data: SurfaceData;
     actions?: Array<{ id: string; label: string; style?: string }>;
     display?: string;
+    persistent?: boolean;
   }> = [];
   /** @internal */ workspaceTopLevelContext: string | null = null;
   /** @internal */ workspaceTopLevelDirty = true;

--- a/assistant/src/runtime/routes/surface-action-routes.ts
+++ b/assistant/src/runtime/routes/surface-action-routes.ts
@@ -143,11 +143,44 @@ export async function handleSurfaceAction(
   }
 
   try {
-    await conversation.handleSurfaceAction(surfaceId, actionId, data);
+    // Most action paths return `void` (regular button/selection forwards);
+    // the `launch_conversation` dispatch branch returns a structured result
+    // so we can surface validation errors (e.g. missing title / seedPrompt)
+    // as 4xx responses instead of silently reporting success.
+    const raw = await conversation.handleSurfaceAction(
+      surfaceId,
+      actionId,
+      data,
+    );
+    const result =
+      raw && typeof raw === "object" && "accepted" in raw
+        ? (raw as
+            | { accepted: true; conversationId?: string }
+            | { accepted: false; error: string })
+        : undefined;
+    if (result && result.accepted === false) {
+      log.warn(
+        {
+          conversationId: conversationId ?? undefined,
+          surfaceId,
+          actionId,
+          error: result.error,
+        },
+        "Surface action rejected",
+      );
+      return httpError("BAD_REQUEST", result.error, 400);
+    }
     log.info(
       { conversationId: conversationId ?? undefined, surfaceId, actionId },
       "Surface action handled via HTTP",
     );
+    if (
+      result &&
+      result.accepted === true &&
+      typeof result.conversationId === "string"
+    ) {
+      return Response.json({ ok: true, conversationId: result.conversationId });
+    }
     return Response.json({ ok: true });
   } catch (err) {
     log.error(
@@ -239,6 +272,12 @@ export function surfaceActionRouteDefinitions(deps: {
       }),
       responseBody: z.object({
         ok: z.boolean(),
+        conversationId: z
+          .string()
+          .describe(
+            "Id of a newly launched conversation when the action dispatched one (e.g. launch_conversation). Omitted otherwise.",
+          )
+          .optional(),
       }),
       handler: async ({ req, authContext }) => {
         if (!deps.findConversation) {

--- a/assistant/src/tools/ui-surface/definitions.ts
+++ b/assistant/src/tools/ui-surface/definitions.ts
@@ -98,6 +98,11 @@ export const uiShowTool: Tool = {
             description:
               "Whether to block until the user interacts with an action. Defaults to true when actions are provided.",
           },
+          persistent: {
+            type: "boolean",
+            description:
+              "When true, clicking an action does not dismiss the surface — the card stays visible and only the clicked action is marked as spent. Use for launcher or menu-style cards where the user may click multiple buttons. Defaults to false.",
+          },
         },
         required: ["surface_type", "data"],
       },


### PR DESCRIPTION
## Summary
Fixes 5 gaps found during self-review of the `convo-launcher-fix` plan:
- `ui_show` tool handler now forwards `input.persistent` to the client — otherwise `SurfaceManager` never sees the flag and cards still dismiss on action.
- `launchConversation` now accepts a `focus?` parameter and is the sole emitter of `open_conversation`; `handleSurfaceAction` no longer emits a second event. Previously the helper's event (no `focus` → default true) stole focus before the handler's `focus: false` event arrived.
- `launchConversation` kicks off `persistAndProcessMessage` fire-and-forget (with error logging) and returns `{conversationId}` synchronously, so the `POST /v1/surface-actions` HTTP response no longer blocks on the full seed turn — critical for the multi-click fan-out UX.
- `surface-action-routes.ts` maps `{accepted: false, error}` to a 400 response instead of silently returning `{ok: true}`.
- `conversation-surfaces-launch.test.ts` hardened to assert a single `open_conversation` is emitted per launch (was previously mocking the helper entirely, which hid the double-emit).

Fixes gaps identified during plan review for convo-launcher-fix.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25194" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
