### PR TITLE
fix(convo-launcher): reachable launch dispatch, validation hoist, openapi sync

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -7700,6 +7700,11 @@ paths:
                 properties:
                   ok:
                     type: boolean
+                  conversationId:
+                    type: string
+                    description:
+                      Id of a newly launched conversation when the action dispatched one (e.g. launch_conversation). Omitted
+                      otherwise.
                 required:
                   - ok
                 additionalProperties: false

--- a/assistant/src/daemon/__tests__/conversation-surfaces-launch.test.ts
+++ b/assistant/src/daemon/__tests__/conversation-surfaces-launch.test.ts
@@ -80,9 +80,8 @@ mock.module("../../memory/conversation-crud.js", () => ({
 const { createSurfaceMutex, handleSurfaceAction } = await import(
   "../conversation-surfaces.js"
 );
-const { registerLaunchConversationDeps } = await import(
-  "../conversation-launch.js"
-);
+const { registerLaunchConversationDeps, resetLaunchConversationDeps } =
+  await import("../conversation-launch.js");
 type SurfaceConversationContext =
   import("../conversation-surfaces.js").SurfaceConversationContext;
 type TrustContext = import("../conversation-runtime-assembly.js").TrustContext;
@@ -255,6 +254,11 @@ describe("handleSurfaceAction — launch_conversation dispatch", () => {
     publishCalls.length = 0;
     updateTitleCalls.length = 0;
     nextKeyStoreResult = { conversationId: "conv-new" };
+    // Reset module-level `_deps` so a test that forgets to call
+    // `setupLaunchDeps()` cannot accidentally piggy-back on deps left
+    // registered by a previous test. Each test that exercises the launch
+    // helper must call `setupLaunchDeps()` explicitly.
+    resetLaunchConversationDeps();
   });
 
   test("launches new conversation with inherited trust context and no chat message", async () => {
@@ -441,5 +445,59 @@ describe("handleSurfaceAction — launch_conversation dispatch", () => {
     // the test completes.
     await Promise.resolve();
     await Promise.resolve();
+  });
+
+  test("dispatches launch even when pendingSurfaceActions has an entry for the surface (first-click case)", async () => {
+    // Regression for the gap that left the launch branch unreachable on the
+    // FIRST click of a freshly-rendered persistent launcher card. `ui_show`
+    // unconditionally sets `pendingSurfaceActions` for any interactive card
+    // (regardless of `persistent`), so without this fix `handleSurfaceAction`
+    // saw `pending` truthy, skipped the launch dispatch, and fell through to
+    // the pending path — emitting the `[User action on card surface: ...]`
+    // message and triggering a full LLM round-trip on every click. The plan
+    // claimed to eliminate that round-trip; this test enforces it.
+    nextKeyStoreResult = { conversationId: "conv-pending-set" };
+    const harness = setupLaunchDeps();
+    const ctx = makeContext();
+    registerCardSurface(ctx, "surface-pending");
+    // Simulate `ui_show` having stamped a pending entry for this surface
+    // (which it does for any interactive card, including persistent ones).
+    ctx.pendingSurfaceActions.set("surface-pending", { surfaceType: "card" });
+
+    const result = await handleSurfaceAction(
+      ctx,
+      "surface-pending",
+      "launch",
+      {
+        _action: "launch_conversation",
+        title: "T",
+        seedPrompt: "S",
+      },
+    );
+
+    expect(result).toEqual({
+      accepted: true,
+      conversationId: "conv-pending-set",
+    });
+
+    // Exactly one open_conversation event with focus: false — the launch
+    // branch ran, not the pending fallthrough.
+    const openEvents = openConversationEvents();
+    expect(openEvents).toHaveLength(1);
+    expect(openEvents[0].message.conversationId).toBe("conv-pending-set");
+    expect(openEvents[0].message.focus).toBe(false);
+
+    // Critical: NO message was enqueued onto the origin conversation. If the
+    // launch dispatch had fallen through to the pending path, the
+    // `[User action on card surface: ...]` text would have been enqueued and
+    // an LLM turn would have started.
+    expect(ctx.enqueueCalls).toHaveLength(0);
+
+    // Pending entry was deleted so subsequent sibling clicks on the same
+    // persistent card aren't blocked behind a stale "owes-an-answer" flag.
+    expect(ctx.pendingSurfaceActions.has("surface-pending")).toBe(false);
+
+    await harness.processStarted;
+    harness.resolveProcess();
   });
 });

--- a/assistant/src/daemon/conversation-launch.ts
+++ b/assistant/src/daemon/conversation-launch.ts
@@ -75,6 +75,17 @@ export function registerLaunchConversationDeps(
   _deps = deps;
 }
 
+/**
+ * Test-only helper: reset the module-level `_deps` between test cases so
+ * accidental coupling between tests can't hide bugs (e.g. a test that does
+ * not register deps but happens to pass because an earlier test in the same
+ * file left deps registered and the validation short-circuit hides the
+ * "deps not registered" throw).
+ */
+export function resetLaunchConversationDeps(): void {
+  _deps = null;
+}
+
 // ── Helper ──────────────────────────────────────────────────────────
 
 export interface LaunchConversationParams {
@@ -115,6 +126,15 @@ export interface LaunchConversationParams {
 export async function launchConversation(
   params: LaunchConversationParams,
 ): Promise<{ conversationId: string }> {
+  // Belt-and-suspenders validation: callers (handleSurfaceAction) also check
+  // for these, but enforcing here keeps the helper self-contained so future
+  // direct callers can't accidentally emit `open_conversation` events with a
+  // blank title (which would create a blank-titled sidebar entry on macOS).
+  if (!params.title || !params.seedPrompt) {
+    throw new Error(
+      "launchConversation: title and seedPrompt are required",
+    );
+  }
   if (!_deps) {
     throw new Error(
       "launchConversation dependencies not registered — daemon may not be ready",
@@ -157,7 +177,12 @@ export async function launchConversation(
       {
         type: "open_conversation",
         conversationId,
-        title: params.title,
+        // Conditional spread so an empty / falsy title is omitted entirely
+        // instead of leaking into the Swift handler (`if let title = msg.title`
+        // accepts empty strings and would create a blank-titled sidebar entry).
+        // The validation guard above already rejects empty titles for our
+        // current callers, but this is defense-in-depth for future ones.
+        ...(params.title ? { title: params.title } : {}),
         ...(params.anchorMessageId
           ? { anchorMessageId: params.anchorMessageId }
           : {}),

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -663,6 +663,64 @@ export async function handleSurfaceAction(
   actionId: string,
   data?: Record<string, unknown>,
 ): Promise<SurfaceActionResult> {
+  // `launch_conversation` actions spawn a fresh conversation inline instead
+  // of round-tripping through the LLM with a `[User action on card surface:
+  // ...]` chat message. This dispatch must run BEFORE the pending-vs-not
+  // branching below: `ui_show` unconditionally calls
+  // `pendingSurfaceActions.set(...)` for any interactive card (regardless of
+  // the `persistent` flag), so on the very first click of a freshly-rendered
+  // launcher card `pending` is already set. Without this hoist the launch
+  // branch would fall through into the pending path and the LLM round-trip
+  // would happen on every click.
+  if (
+    data &&
+    typeof data === "object" &&
+    (data as Record<string, unknown>)._action === "launch_conversation"
+  ) {
+    const payload = data as Record<string, unknown>;
+    const title = typeof payload.title === "string" ? payload.title : "";
+    const seedPrompt =
+      typeof payload.seedPrompt === "string" ? payload.seedPrompt : "";
+    const anchorMessageId =
+      typeof payload.anchorMessageId === "string"
+        ? payload.anchorMessageId
+        : undefined;
+    if (!title || !seedPrompt) {
+      return { accepted: false, error: "missing_title_or_seedPrompt" };
+    }
+    // Launch actions don't consume the surface — persistent launcher cards
+    // keep accepting clicks afterward. Drop the pending entry (if any) so
+    // sibling button presses on the same card aren't blocked behind a stale
+    // expectation that this surface still owes an answer to the LLM.
+    ctx.pendingSurfaceActions.delete(surfaceId);
+    // `ctx` is the origin Conversation — inherit its trust context so the
+    // spawned conversation keeps guardian / trust-class state.
+    //
+    // `launchConversation` is the sole emitter of `open_conversation` for
+    // this path. We pass `focus: false` so the client registers a sidebar
+    // entry for the spawned conversation without switching focus away from
+    // the origin — critical for fan-out UX where one click launches
+    // multiple conversations.
+    //
+    // The helper also kicks off the seed turn fire-and-forget, so this
+    // `await` resolves as soon as the conversation is created + titled +
+    // published to the event hub. The HTTP POST /v1/surface-actions
+    // response no longer blocks on the full LLM turn.
+    const originTrustContext = ctx.trustContext;
+    const { conversationId } = await launchConversation({
+      title,
+      seedPrompt,
+      focus: false,
+      ...(anchorMessageId ? { anchorMessageId } : {}),
+      ...(originTrustContext ? { originTrustContext } : {}),
+    });
+    log.info(
+      { originConversationId: ctx.conversationId, conversationId, surfaceId },
+      "launch_conversation dispatched inline from surface action",
+    );
+    return { accepted: true, conversationId };
+  }
+
   const pending = ctx.pendingSurfaceActions.get(surfaceId);
 
   // When surfaces are restored from history (e.g. onboarding cards), there is
@@ -694,54 +752,6 @@ export async function handleSurfaceAction(
         "Silent state accumulated (history-restored)",
       );
       return;
-    }
-
-    // `launch_conversation` actions spawn a fresh conversation inline instead
-    // of round-tripping through the LLM with a `[User action on app: ...]`
-    // chat message. The origin conversation's trust context is inherited so
-    // guardian-gated tools stay available in the spawned conversation.
-    if (
-      data &&
-      typeof data === "object" &&
-      (data as Record<string, unknown>)._action === "launch_conversation"
-    ) {
-      const payload = data as Record<string, unknown>;
-      const title = typeof payload.title === "string" ? payload.title : "";
-      const seedPrompt =
-        typeof payload.seedPrompt === "string" ? payload.seedPrompt : "";
-      const anchorMessageId =
-        typeof payload.anchorMessageId === "string"
-          ? payload.anchorMessageId
-          : undefined;
-      if (!title || !seedPrompt) {
-        return { accepted: false, error: "missing_title_or_seedPrompt" };
-      }
-      // `ctx` is the origin Conversation — inherit its trust context so the
-      // spawned conversation keeps guardian / trust-class state.
-      //
-      // `launchConversation` is the sole emitter of `open_conversation` for
-      // this path. We pass `focus: false` so the client registers a sidebar
-      // entry for the spawned conversation without switching focus away from
-      // the origin — critical for fan-out UX where one click launches
-      // multiple conversations.
-      //
-      // The helper also kicks off the seed turn fire-and-forget, so this
-      // `await` resolves as soon as the conversation is created + titled +
-      // published to the event hub. The HTTP POST /v1/surface-actions
-      // response no longer blocks on the full LLM turn.
-      const originTrustContext = ctx.trustContext;
-      const { conversationId } = await launchConversation({
-        title,
-        seedPrompt,
-        focus: false,
-        ...(anchorMessageId ? { anchorMessageId } : {}),
-        ...(originTrustContext ? { originTrustContext } : {}),
-      });
-      log.info(
-        { originConversationId: ctx.conversationId, conversationId, surfaceId },
-        "launch_conversation dispatched inline from surface action",
-      );
-      return { accepted: true, conversationId };
     }
 
     // Determine message content from the action.


### PR DESCRIPTION
## Summary
Round-2 remediation of gaps found during self-review.
- **Critical**: `_action: "launch_conversation"` dispatch in `handleSurfaceAction` was nested inside `if (!pending)`. Since `ui_show` sets `pendingSurfaceActions` for interactive cards, the first click always hit the pending path and emitted `[User action on card surface: ...]` — the chat round-trip the plan claimed to eliminate. Promoted the dispatch above the pending check and added `pendingSurfaceActions.delete(surfaceId)` so the card can keep accepting sibling clicks.
- **New regression test** covers the pending-is-set case directly: asserts single publish, zero enqueue, and pending entry cleared.
- Hoisted title/seedPrompt validation into `launchConversation` so all callers share the guard; conditional-spread `title` in the event emit so blank titles can't leak to the sidebar.
- Added `resetLaunchConversationDeps()` test helper; test suite now resets module-level `_deps` in `beforeEach`.
- Regenerated `openapi.yaml` to match the `/v1/surface-actions` response schema (`conversationId` was missing after #25194).

Fixes gaps found during plan review for convo-launcher-fix.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25195" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
