### PR TITLE
fix(convo-launcher): log surface-action error bodies; narrow SKILL.md persistence claim

### DIFF
--- a/clients/shared/Network/SurfaceActionClient.swift
+++ b/clients/shared/Network/SurfaceActionClient.swift
@@ -9,6 +9,31 @@ public protocol SurfaceActionClientProtocol {
     func sendSurfaceUndo(conversationId: String, surfaceId: String) async
 }
 
+/// Standard error envelope returned by /v1/* endpoints — see
+/// `assistant/src/runtime/http-errors.ts` (`HttpErrorResponse`). Decoded on
+/// non-2xx responses so misfires (e.g. `launch_conversation` with a missing
+/// title / seedPrompt) are diagnosable from the client logs alone.
+private struct SurfaceActionErrorResponse: Decodable {
+    struct ErrorBody: Decodable {
+        let code: String
+        let message: String
+    }
+    let error: ErrorBody
+}
+
+private func logSurfaceActionFailure(operation: String, statusCode: Int, data: Data) {
+    if let decoded = try? JSONDecoder().decode(SurfaceActionErrorResponse.self, from: data) {
+        log.error("\(operation, privacy: .public) failed (HTTP \(statusCode)): \(decoded.error.code, privacy: .public) — \(decoded.error.message, privacy: .public)")
+        return
+    }
+    if let raw = String(data: data, encoding: .utf8), !raw.isEmpty {
+        let preview = String(raw.prefix(200))
+        log.error("\(operation, privacy: .public) failed (HTTP \(statusCode)): \(preview, privacy: .public)")
+    } else {
+        log.error("\(operation, privacy: .public) failed (HTTP \(statusCode))")
+    }
+}
+
 /// Gateway-backed implementation of ``SurfaceActionClientProtocol``.
 public struct SurfaceActionClient: SurfaceActionClientProtocol {
     nonisolated public init() {}
@@ -33,7 +58,7 @@ public struct SurfaceActionClient: SurfaceActionClientProtocol {
 
             let response = try await GatewayHTTPClient.post(path: "assistants/{assistantId}/surface-actions", json: body, timeout: 10)
             if !response.isSuccess {
-                log.error("sendSurfaceAction failed (HTTP \(response.statusCode))")
+                logSurfaceActionFailure(operation: "sendSurfaceAction", statusCode: response.statusCode, data: response.data)
             }
         } catch {
             log.error("sendSurfaceAction error: \(error.localizedDescription)")
@@ -48,7 +73,7 @@ public struct SurfaceActionClient: SurfaceActionClientProtocol {
             ]
             let response = try await GatewayHTTPClient.post(path: "assistants/{assistantId}/surfaces/\(surfaceId)/undo", json: body, timeout: 10)
             if !response.isSuccess {
-                log.error("sendSurfaceUndo failed (HTTP \(response.statusCode))")
+                logSurfaceActionFailure(operation: "sendSurfaceUndo", statusCode: response.statusCode, data: response.data)
             }
         } catch {
             log.error("sendSurfaceUndo error: \(error.localizedDescription)")

--- a/skills/conversation-launcher/SKILL.md
+++ b/skills/conversation-launcher/SKILL.md
@@ -78,7 +78,7 @@ After rendering the card, end your turn. The click pipeline handles everything:
 
 ## UX contract the client enforces
 
-- The card stays open until dismissed by the user.
+- The card stays open and clickable for the lifetime of the live conversation — multiple buttons can be fired in succession without losing the user's place. If the conversation is closed and reopened later from history, the restored card reverts to single-click behavior (history rehydration drops the `persistent` flag — out of scope for this skill).
 - Each `action.id` fires at most once per card lifetime; sibling actions remain clickable.
 - Each spawned conversation inherits this conversation's guardian / trust context automatically.
 - Sidebar focus stays on this conversation. The user sees new entries appear and can navigate in at their pace.


### PR DESCRIPTION
## Summary
- `SurfaceActionClient.sendSurfaceAction()` now decodes the error response body on non-2xx status codes and logs the `code` / `message` so misfires of `_action: "launch_conversation"` (or future CES-driven callers) are diagnosable without daemon logs.
- SKILL.md narrows the persistence claim: the card stays open within the live conversation, but history rehydration reverts to single-click behavior. This matches the current `HistoryResponseSurface` schema, which is explicitly out of scope for this plan.

Fixes gaps identified during plan review for convo-launcher-fix.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25196" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
