### PR TITLE
refactor: scroll-to-latest visibility based on distance, not mode

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListHelperViews.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListHelperViews.swift
@@ -9,18 +9,19 @@ import VellumAssistantShared
 /// this view — not the parent `MessageListView.body` or `ForEach`.
 struct ScrollToLatestOverlayView: View {
     let scrollState: MessageListScrollState
+    var onScrollToBottom: () -> Void = {}
 
     var body: some View {
         if scrollState.showScrollToLatest {
             Button(action: {
                 os_signpost(.event, log: PerfSignposts.log, name: "scrollToLatestPressed")
                 // Spring animation drives both the CTA exit transition
-                // and the scroll-to-bottom. syncUIImmediately() inside
-                // requestPinToBottom captures showScrollToLatest = false
-                // within this animation transaction, so the .move/.opacity
+                // and the scroll-to-bottom. The parent provides the scroll
+                // action via onScrollToBottom, which repositions ScrollPosition.
+                // Wrapping in an animation transaction ensures the .move/.opacity
                 // transition runs in sync with the scroll.
-                _ = withAnimation(VAnimation.spring) {
-                    scrollState.requestPinToBottom(animated: true, userInitiated: true)
+                withAnimation(VAnimation.spring) {
+                    onScrollToBottom()
                 }
             }) {
                 HStack(spacing: VSpacing.xs) {


### PR DESCRIPTION
## Summary
- Added onScrollToBottom closure parameter to ScrollToLatestOverlayView
- Replaced requestPinToBottom call with onScrollToBottom closure invocation
- Visibility remains driven by scrollState.showScrollToLatest (distance-based after PR 1)

Part of plan: scroll-state-machine-removal.md (PR 5 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25198" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
