### PR TITLE
refactor: simplify lifecycle handlers — declarative scroll only

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
@@ -14,12 +14,6 @@ extension MessageListView {
         // .id(conversationId) on the ScrollView destroys and recreates it on
         // conversation switch, firing onAppear for the new view. Detect the
         // switch by comparing against the last-known conversation ID.
-        // Must check BEFORE configureScrollCallbacks() which updates
-        // currentConversationId.
-        //
-        // Skip when currentConversationId is nil (true first mount) — reset()
-        // on freshly-initialized state is redundant and its 300ms scroll-
-        // indicator-hide task would cause a visual flicker on app launch.
         let previousConversationId = scrollState.currentConversationId
         let isConversationSwitch = previousConversationId != nil
             && previousConversationId != conversationId
@@ -27,15 +21,8 @@ extension MessageListView {
         if isConversationSwitch {
             handleConversationSwitched()
         } else {
-            // Start the recovery window for the initial load — LazyVStack
-            // height estimates are unreliable until views materialize.
-            // (For conversation switches, reset() inside handleConversationSwitched
-            // already sets recoveryDeadline.)
-            scrollState.recoveryDeadline = Date().addingTimeInterval(2.0)
-            // Seed lastMessageId so the CTA and executeScrollToBottom always
-            // have a valid ForEach target. Without this, the initial load
-            // leaves lastMessageId nil — a CTA tap would fall back to the
-            // standalone "scroll-bottom-anchor" which may not be materialized.
+            // Seed lastMessageId so the CTA and scroll-to-bottom always
+            // have a valid ForEach target.
             if let lastId = paginatedVisibleMessages.last?.id {
                 scrollState.lastMessageId = lastId
             }
@@ -45,113 +32,45 @@ extension MessageListView {
         if !isSending {
             scrollState.lastActivityPhaseWhenIdle = assistantActivityPhase
         }
+        // Handle pending anchor if already set.
         if let id = anchorMessageId, messages.contains(where: { $0.id == id }) {
-            // Anchor is already set and the target message is loaded —
-            // scroll to it immediately instead of falling through to bottom.
             os_signpost(.event, log: PerfSignposts.log, name: "scrollToRequested", "target=anchorMessage reason=onAppear")
             os_signpost(.event, log: PerfSignposts.log, name: "anchorCleared", "reason=foundOnAppear")
-            // Notify coordinator of anchor request + immediate resolution.
-            let anchorId = ScrollCoordinator.AnchorID(id)
-            let requestIntents = scrollCoordinator.handle(.anchorRequested(id: anchorId))
-            executeCoordinatorIntents(requestIntents)
-            let resolveIntents = scrollCoordinator.handle(.anchorResolved(id: anchorId))
-            executeCoordinatorIntents(resolveIntents)
             $scrollPosition.wrappedValue.scrollTo(id: id, anchor: .center)
             flashHighlight(messageId: id)
             anchorMessageId = nil
             scrollState.anchorSetTime = nil
         } else if anchorMessageId != nil {
-            // Anchor is set but the target message isn't loaded yet.
             os_signpost(.event, log: PerfSignposts.log, name: "anchorSet", "reason=onAppearPending")
             if scrollState.anchorSetTime == nil { scrollState.anchorSetTime = Date() }
-            // Notify coordinator of the pending anchor request.
-            let anchorId = ScrollCoordinator.AnchorID(anchorMessageId!)
-            let pendingIntents = scrollCoordinator.handle(.anchorRequested(id: anchorId))
-            executeCoordinatorIntents(pendingIntents)
             // Start the independent timeout if not already running.
             if scrollState.anchorTimeoutTask == nil {
-                    scrollState.anchorTimeoutTask = Task { @MainActor [scrollState] in
-                        do {
-                            try await Task.sleep(nanoseconds: 10_000_000_000)
-                        } catch { return }
-                        guard !Task.isCancelled, anchorMessageId != nil else { return }
-                        os_signpost(.event, log: PerfSignposts.log, name: "anchorTimedOut")
-                        log.debug("Anchor message not found (timed out) — clearing stale anchor")
-                        anchorMessageId = nil
-                        scrollState.anchorSetTime = nil
-                        scrollState.anchorTimeoutTask = nil
-                        scrollState.transition(to: .followingBottom)
-                        _ = withAnimation(VAnimation.fast) {
-                            scrollState.requestPinToBottom(animated: true, userInitiated: true)
-                        }
-                    }
+                scrollState.anchorTimeoutTask = Task { @MainActor [scrollState] in
+                    do {
+                        try await Task.sleep(nanoseconds: 10_000_000_000)
+                    } catch { return }
+                    guard !Task.isCancelled, anchorMessageId != nil else { return }
+                    os_signpost(.event, log: PerfSignposts.log, name: "anchorTimedOut")
+                    log.debug("Anchor message not found (timed out) — clearing stale anchor")
+                    anchorMessageId = nil
+                    scrollState.anchorSetTime = nil
+                    scrollState.anchorTimeoutTask = nil
+                }
             }
-        } else {
-            // Initial load (first mount). Let `.defaultScrollAnchor(.bottom,
-            // for: .initialOffset)` handle positioning declaratively —
-            // it places the viewport at the bottom in the same layout pass
-            // as content rendering. An imperative `scrollToEdge(.bottom)`
-            // here would compete with the declarative anchor, causing visible
-            // flicker: the viewport jumps down (declarative), then gets
-            // yanked again by the imperative call, potentially overshooting
-            // into blank LazyVStack estimated space.
-            //
-            // The delayed `restoreScrollToBottom()` (100ms) acts as a safety
-            // net: if `.defaultScrollAnchor` didn't fully resolve (e.g. very
-            // long conversation with unreliable height estimates), the
-            // recovery window + restore fallback will catch it.
-            restoreScrollToBottom()
         }
+        // For initial load (no anchor, no conversation switch),
+        // `.defaultScrollAnchor(.top)` handles positioning declaratively.
     }
 
     // MARK: - onChange handlers
 
     func handleSendingChanged() {
         // Guard against stale fires during a conversation switch.
-        // onChange handlers fire in declaration order; isSending fires
-        // before conversationId, so during a switch this handler sees
-        // the NEW isSending value but the OLD scroll state (reset()
-        // hasn't run yet). Animated pins targeting stale content
-        // accumulate and corrupt SwiftUI's scroll position.
         guard conversationId == scrollState.currentConversationId else { return }
         if isSending {
-            // Clear stale confirmation marker: if the phase left "awaiting_confirmation"
-            // while not sending, the marker is stale.
-            let effectivePhase: String
-            if scrollState.lastActivityPhaseWhenIdle == "awaiting_confirmation"
-                && assistantActivityPhase != "awaiting_confirmation"
-            {
-                effectivePhase = assistantActivityPhase
-            } else {
-                effectivePhase = scrollState.lastActivityPhaseWhenIdle
-            }
-            // Reattach and pin to bottom for user-initiated actions (send,
-            // regenerate, retry). Skip reattach only when the daemon resumes
-            // from a tool confirmation (not a user action during confirmation).
-            let isDaemonConfirmationResume =
-                effectivePhase == "awaiting_confirmation"
-                && assistantActivityPhase != "awaiting_confirmation"
-            if isDaemonConfirmationResume && !scrollState.isFollowingBottom {
-                // Daemon resumed from confirmation while user was scrolled up.
-            } else {
-                // Defer the actual bottom-pin to the next main-queue turn.
-                // Both `isSending` and `messages.count` can change in the
-                // same SwiftUI update cycle after the user sends a message;
-                // issuing immediate `ScrollPosition` writes here can trip
-                // SwiftUI's "Modifying state during view update" guard.
-                scrollState.scheduleDeferredBottomPin(
-                    animated: true,
-                    forceFollowingBottom: true,
-                    refreshRecoveryWindow: true
-                )
-                os_signpost(.event, log: PerfSignposts.log, name: "scrollToRequested",
-                            "target=bottom reason=sendFollowingBottom")
-
-                // Also scroll the user message to top for Claude-style behavior
-                if let userMessage = messages.last(where: { $0.role == .user }) {
-                    scrollPosition.scrollTo(id: userMessage.id, anchor: .top)
-                }
-            }
+            // Mark that we need to scroll the user message to top once it
+            // appears in the messages array.
+            scrollState.pendingSendScrollToTop = true
         } else {
             // Capture the activity phase at the moment sending stops.
             scrollState.lastActivityPhaseWhenIdle = assistantActivityPhase
@@ -165,22 +84,11 @@ extension MessageListView {
 
     func handleMessagesCountChanged() {
         // Guard against stale fires during a conversation switch.
-        // onChange(of: messages.count) fires before onChange(of: conversationId),
-        // so during a switch this handler sees the NEW message count but
-        // the OLD scroll state (reset() hasn't run yet). An animated
-        // requestPinToBottom targeting stale content interferes with the
-        // subsequent conversation switch flow.
         guard conversationId == scrollState.currentConversationId else { return }
         // --- Anchor message resolution ---
         if let id = anchorMessageId, messages.contains(where: { $0.id == id }) {
             os_signpost(.event, log: PerfSignposts.log, name: "scrollToRequested", "target=anchorMessage reason=messagesChanged")
             os_signpost(.event, log: PerfSignposts.log, name: "anchorCleared", "reason=foundInMessages")
-            // Notify coordinator that the anchor resolved.
-            let anchorId = ScrollCoordinator.AnchorID(id)
-            let resolveIntents = scrollCoordinator.handle(.anchorResolved(id: anchorId))
-            executeCoordinatorIntents(resolveIntents)
-            // Keep scrollState in sync as runtime executor.
-            scrollState.transition(to: .programmaticScroll(reason: .deepLinkAnchor(id: id)))
             withAnimation {
                 scrollState.scrollTo?(id, .center)
             }
@@ -203,18 +111,19 @@ extension MessageListView {
                 scrollState.anchorSetTime = nil
                 scrollState.anchorTimeoutTask?.cancel()
                 scrollState.anchorTimeoutTask = nil
-                scrollState.transition(to: .followingBottom)
-                scrollState.requestPinToBottom(animated: true)
                 return
             }
         }
-        // --- Bottom-pin on new messages ---
-        // Keep lastMessageId current so executeScrollToBottom targets ForEach items.
+        // --- Update lastMessageId ---
         if let lastId = paginatedVisibleMessages.last?.id {
             scrollState.lastMessageId = lastId
         }
-        if anchorMessageId == nil {
-            scrollState.scheduleDeferredBottomPin(animated: true)
+        // --- Scroll user message to top on send ---
+        if scrollState.pendingSendScrollToTop {
+            if let userMessage = messages.last(where: { $0.role == .user }) {
+                scrollPosition = ScrollPosition(id: userMessage.id, anchor: .top)
+            }
+            scrollState.pendingSendScrollToTop = false
         }
         // --- Confirmation focus handoff ---
         #if os(macOS)
@@ -227,56 +136,12 @@ extension MessageListView {
         guard containerWidth > 0,
               abs(trackedWidth - scrollState.lastHandledChatColumnWidth) > 2 else { return }
         // First real pane measurement (0 → actual width) is not a resize — just
-        // record the transcript column width so subsequent reflows are treated
-        // as real resizes. Once the pane exceeds chatColumnMaxWidth, widening
-        // only the outer gutters leaves trackedWidth unchanged and skips the
-        // resize recovery path entirely.
+        // record the transcript column width.
         guard scrollState.lastHandledChatColumnWidth > 0 else {
             scrollState.lastHandledChatColumnWidth = trackedWidth
             return
         }
         scrollState.lastHandledChatColumnWidth = trackedWidth
-        // Route through coordinator for policy decision.
-        let intents = scrollCoordinator.handle(.containerWidthChanged)
-        executeCoordinatorIntents(intents)
-        resizeScrollTask?.cancel()
-        resizeScrollTask = Task { @MainActor [scrollState] in
-            scrollState.beginStabilization(.resize)
-            defer {
-                if !Task.isCancelled { resizeScrollTask = nil }
-            }
-            try? await Task.sleep(nanoseconds: 100_000_000)
-            guard !Task.isCancelled else {
-                scrollState.endStabilization()
-                return
-            }
-                scrollState.endStabilization()
-                if scrollState.mode.allowsAutoScroll && anchorMessageId == nil {
-                    // Use mode.allowsAutoScroll (covers both .initialLoad and
-                    // .followingBottom) instead of isFollowingBottom (which
-                    // returns false for .initialLoad). A resize during initial
-                    // load — e.g. app opens with side panel — must still re-pin.
-                    // Always re-pin after resize — don't check isAtBottom.
-                    // After a width change, LazyVStack re-estimates content heights.
-                    // The viewport can be at the *estimated* bottom (blank space)
-                    // where distanceFromBottom ≈ 0 → isAtBottom = true, even though
-                    // actual content is above. Start a fresh recovery window so
-                    // persistent recovery fires unconditionally for 2 seconds.
-                    scrollState.bottomAnchorAppeared = false
-                    scrollState.recoveryDeadline = Date().addingTimeInterval(2.0)
-                    scrollState.requestPinToBottom()
-                } else if case .freeBrowsing = scrollState.mode,
-                          anchorMessageId == nil,
-                          let visibleId = scrollState.cachedFirstVisibleMessageId {
-                    // User was scrolled up when resize happened. LazyVStack
-                    // re-estimates heights for the new container width, which
-                    // can shift content — the viewport may now show blank
-                    // estimated space instead of the message the user was
-                    // reading. Re-anchor at the first visible message to
-                    // maintain the user's reading position.
-                    scrollState.performScrollTo(visibleId, anchor: .top)
-                }
-        }
     }
 
     func handleConversationSwitched() {
@@ -286,8 +151,6 @@ extension MessageListView {
         highlightedMessageId = nil
         scrollState.highlightDismissTask?.cancel()
         scrollState.highlightDismissTask = nil
-        // Reset coordinator for the new conversation.
-        scrollCoordinator.reset()
         // Reset scroll state for the new conversation.
         scrollState.reset(for: conversationId)
         // Capture the new conversation's activity phase so a conversation
@@ -299,31 +162,10 @@ extension MessageListView {
         scrollState.anchorTimeoutTask?.cancel()
         scrollState.anchorTimeoutTask = nil
         scrollState.lastAutoFocusedRequestId = nil
-        // reset() already set mode to .initialLoad, which allows auto-scroll.
-        // Don't override with .programmaticScroll — that would block
-        // handleMessagesCountChanged and content-growth auto-follow during
-        // the critical window while LazyVStack materializes new content.
-        //
-        // Seed lastMessageId so executeScrollToBottom can target it.
+        // Seed lastMessageId so scroll-to-bottom can target it.
         scrollState.lastMessageId = paginatedVisibleMessages.last?.id
-        // Declarative position reset — processed in the same layout pass as new content.
-        // Prefer the last ForEach message ID over the standalone anchor because
-        // ForEach items are always indexable by ScrollPosition even when not
-        // materialized — SwiftUI locates them in the data source. The standalone
-        // "scroll-bottom-anchor" (outside ForEach) is only locatable when materialized.
-        // https://developer.apple.com/documentation/swiftui/scrollposition
-        scrollState.scrollRestoreTask?.cancel()
-        if anchorMessageId == nil {
-            if let lastId = paginatedVisibleMessages.last?.id {
-                scrollPosition = ScrollPosition(id: lastId, anchor: .bottom)
-            } else {
-                // Empty conversation — no ForEach items to target.
-                // Use edge-based position; the standalone "scroll-bottom-anchor"
-                // is outside ForEach and only locatable when materialized.
-                scrollPosition = ScrollPosition(edge: .bottom)
-            }
-        }
-        restoreScrollToBottom()
+        // Don't write to scrollPosition — `.defaultScrollAnchor(.top)` handles
+        // positioning via the `.id(conversationId)` recreation.
     }
 
     func handleAnchorMessageTask() async {
@@ -331,14 +173,9 @@ extension MessageListView {
         // non-nil anchor assignments; nil transitions are cleanup handled
         // by messagesChanged and conversationSwitched.
         guard let id = anchorMessageId else { return }
-        // Route through coordinator for policy decision.
-        let anchorId = ScrollCoordinator.AnchorID(id)
-        let intents = scrollCoordinator.handle(.anchorRequested(id: anchorId))
-        executeCoordinatorIntents(intents)
         // Cancel scroll restore when a new anchor is set.
         scrollState.scrollRestoreTask?.cancel()
         scrollState.scrollRestoreTask = nil
-        scrollState.transition(to: .programmaticScroll(reason: .deepLinkAnchor(id: id)))
         scrollState.anchorSetTime = Date()
         scrollState.anchorTimeoutTask?.cancel()
         scrollState.anchorTimeoutTask = nil
@@ -346,9 +183,6 @@ extension MessageListView {
         if messages.contains(where: { $0.id == id }) {
             os_signpost(.event, log: PerfSignposts.log, name: "scrollToRequested", "target=anchorMessage reason=anchorChanged")
             os_signpost(.event, log: PerfSignposts.log, name: "anchorCleared", "reason=foundOnAnchorChange")
-            // Notify coordinator that the anchor resolved.
-            let resolveIntents = scrollCoordinator.handle(.anchorResolved(id: anchorId))
-            executeCoordinatorIntents(resolveIntents)
             withAnimation {
                 scrollState.scrollTo?(id, .center)
             }
@@ -368,9 +202,6 @@ extension MessageListView {
                 anchorMessageId = nil
                 scrollState.anchorSetTime = nil
                 scrollState.anchorTimeoutTask = nil
-                _ = withAnimation(VAnimation.fast) {
-                    scrollState.requestPinToBottom(animated: true, userInitiated: true)
-                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- Simplified handleAppear, handleSendingChanged, handleMessagesCountChanged, handleConversationSwitched, handleContainerWidthChanged
- Removed all mode transitions, recovery windows, deferred bottom pins
- Send scroll now uses ScrollPosition value replacement to pin user message to top
- Thread switch is just scrollState.reset() + seed lastMessageId

Part of plan: scroll-state-machine-removal.md (PR 4 of 6)