### PR TITLE
refactor: simplify MessageListView scroll setup — remove closure callbacks

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
@@ -50,12 +50,6 @@ extension MessageListView {
             // scroll to it immediately instead of falling through to bottom.
             os_signpost(.event, log: PerfSignposts.log, name: "scrollToRequested", "target=anchorMessage reason=onAppear")
             os_signpost(.event, log: PerfSignposts.log, name: "anchorCleared", "reason=foundOnAppear")
-            // Notify coordinator of anchor request + immediate resolution.
-            let anchorId = ScrollCoordinator.AnchorID(id)
-            let requestIntents = scrollCoordinator.handle(.anchorRequested(id: anchorId))
-            executeCoordinatorIntents(requestIntents)
-            let resolveIntents = scrollCoordinator.handle(.anchorResolved(id: anchorId))
-            executeCoordinatorIntents(resolveIntents)
             $scrollPosition.wrappedValue.scrollTo(id: id, anchor: .center)
             flashHighlight(messageId: id)
             anchorMessageId = nil
@@ -64,10 +58,6 @@ extension MessageListView {
             // Anchor is set but the target message isn't loaded yet.
             os_signpost(.event, log: PerfSignposts.log, name: "anchorSet", "reason=onAppearPending")
             if scrollState.anchorSetTime == nil { scrollState.anchorSetTime = Date() }
-            // Notify coordinator of the pending anchor request.
-            let anchorId = ScrollCoordinator.AnchorID(anchorMessageId!)
-            let pendingIntents = scrollCoordinator.handle(.anchorRequested(id: anchorId))
-            executeCoordinatorIntents(pendingIntents)
             // Start the independent timeout if not already running.
             if scrollState.anchorTimeoutTask == nil {
                     scrollState.anchorTimeoutTask = Task { @MainActor [scrollState] in
@@ -175,11 +165,6 @@ extension MessageListView {
         if let id = anchorMessageId, messages.contains(where: { $0.id == id }) {
             os_signpost(.event, log: PerfSignposts.log, name: "scrollToRequested", "target=anchorMessage reason=messagesChanged")
             os_signpost(.event, log: PerfSignposts.log, name: "anchorCleared", "reason=foundInMessages")
-            // Notify coordinator that the anchor resolved.
-            let anchorId = ScrollCoordinator.AnchorID(id)
-            let resolveIntents = scrollCoordinator.handle(.anchorResolved(id: anchorId))
-            executeCoordinatorIntents(resolveIntents)
-            // Keep scrollState in sync as runtime executor.
             scrollState.transition(to: .programmaticScroll(reason: .deepLinkAnchor(id: id)))
             withAnimation {
                 scrollState.scrollTo?(id, .center)
@@ -236,9 +221,6 @@ extension MessageListView {
             return
         }
         scrollState.lastHandledChatColumnWidth = trackedWidth
-        // Route through coordinator for policy decision.
-        let intents = scrollCoordinator.handle(.containerWidthChanged)
-        executeCoordinatorIntents(intents)
         resizeScrollTask?.cancel()
         resizeScrollTask = Task { @MainActor [scrollState] in
             scrollState.beginStabilization(.resize)
@@ -286,8 +268,6 @@ extension MessageListView {
         highlightedMessageId = nil
         scrollState.highlightDismissTask?.cancel()
         scrollState.highlightDismissTask = nil
-        // Reset coordinator for the new conversation.
-        scrollCoordinator.reset()
         // Reset scroll state for the new conversation.
         scrollState.reset(for: conversationId)
         // Capture the new conversation's activity phase so a conversation
@@ -331,10 +311,6 @@ extension MessageListView {
         // non-nil anchor assignments; nil transitions are cleanup handled
         // by messagesChanged and conversationSwitched.
         guard let id = anchorMessageId else { return }
-        // Route through coordinator for policy decision.
-        let anchorId = ScrollCoordinator.AnchorID(id)
-        let intents = scrollCoordinator.handle(.anchorRequested(id: anchorId))
-        executeCoordinatorIntents(intents)
         // Cancel scroll restore when a new anchor is set.
         scrollState.scrollRestoreTask?.cancel()
         scrollState.scrollRestoreTask = nil
@@ -346,9 +322,6 @@ extension MessageListView {
         if messages.contains(where: { $0.id == id }) {
             os_signpost(.event, log: PerfSignposts.log, name: "scrollToRequested", "target=anchorMessage reason=anchorChanged")
             os_signpost(.event, log: PerfSignposts.log, name: "anchorCleared", "reason=foundOnAnchorChange")
-            // Notify coordinator that the anchor resolved.
-            let resolveIntents = scrollCoordinator.handle(.anchorResolved(id: anchorId))
-            executeCoordinatorIntents(resolveIntents)
             withAnimation {
                 scrollState.scrollTo?(id, .center)
             }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+ScrollHandling.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+ScrollHandling.swift
@@ -3,73 +3,6 @@ import os.signpost
 import SwiftUI
 import VellumAssistantShared
 
-// MARK: - ScrollCoordinator.Phase Bridge
-
-extension ScrollCoordinator.Phase {
-    /// Maps SwiftUI's `ScrollPhase` to the coordinator's phase abstraction.
-    /// Lives in the view layer (not in ScrollCoordinator) to keep the
-    /// coordinator free of SwiftUI imports.
-    static func from(_ phase: ScrollPhase) -> ScrollCoordinator.Phase {
-        switch phase {
-        case .idle: .idle
-        case .interacting: .interacting
-        case .tracking: .interacting
-        case .decelerating: .decelerating
-        case .animating: .animating
-        @unknown default: .idle
-        }
-    }
-}
-
-extension MessageListView {
-
-    // MARK: - Coordinator Intent Execution
-
-    /// Translates `ScrollCoordinator.OutputIntent`s into concrete scroll
-    /// mutations on `scrollState` / `ScrollPosition`. The coordinator is
-    /// the policy layer; this method is the execution layer.
-    func executeCoordinatorIntents(_ intents: [ScrollCoordinator.OutputIntent]) {
-        for intent in intents {
-            switch intent {
-            case .scrollToBottom(let animated):
-                if animated {
-                    scrollState.scheduleDeferredBottomPin(animated: true)
-                } else {
-                    scrollState.requestPinToBottom(animated: false)
-                }
-
-            case .scrollToMessage(let anchorId, let anchor):
-                let unitPoint: UnitPoint
-                switch anchor {
-                case .top: unitPoint = .top
-                case .center: unitPoint = .center
-                case .bottom: unitPoint = .bottom
-                }
-                scrollState.performScrollTo(anchorId.rawValue, anchor: unitPoint)
-
-            case .showScrollToLatest:
-                // The coordinator signals that the CTA should appear.
-                // scrollState's mode-based UI sync handles visibility;
-                // this is a forward-looking hook for when the coordinator
-                // fully owns the CTA lifecycle.
-                break
-
-            case .hideIndicators:
-                // Forward-looking hook — scrollState's syncUIImmediately
-                // handles indicator visibility for now.
-                break
-
-            case .startRecoveryWindow:
-                scrollState.bottomAnchorAppeared = false
-                scrollState.recoveryDeadline = Date().addingTimeInterval(2.0)
-
-            case .cancelRecoveryWindow:
-                scrollState.recoveryDeadline = nil
-            }
-        }
-    }
-}
-
 extension MessageListView {
 
     // MARK: - Scroll geometry handler
@@ -126,10 +59,6 @@ extension MessageListView {
                Date().timeIntervalSince(pinTime) < 0.5 {
                 // Stale momentum from before CTA tap — ignore.
             } else {
-                // Route through coordinator for policy decision.
-                let browseIntents = scrollCoordinator.handle(.manualBrowseIntent)
-                executeCoordinatorIntents(browseIntents)
-                // Keep scrollState in sync as runtime executor.
                 scrollState.scrollRestoreTask?.cancel()
                 scrollState.scrollRestoreTask = nil
                 scrollState.handleUserScrollUp()
@@ -182,8 +111,6 @@ extension MessageListView {
         // widening the idle-reattach zone (onScrollPhaseChange reattaches
         // when isAtBottom is true on idle).
         let distanceFromBottom = effectiveContentHeight - newState.contentOffsetY - newState.visibleRectHeight
-        // Update coordinator's bottom state (hysteresis lives in coordinator).
-        scrollCoordinator.updateBottomState(distanceFromBottom: distanceFromBottom)
         let nowAtBottom: Bool
         if scrollState.isAtBottom {
             // Stay "at bottom" until clearly scrolled away.

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -97,11 +97,6 @@ struct MessageListView: View {
     /// re-evaluates views that read the specific property that changed.
     /// See `MessageListScrollState.swift` for details.
     @State var scrollState = MessageListScrollState()
-    /// Pure policy coordinator that models scroll decisions. All scroll
-    /// policy flows through this coordinator's `handle(_:)` method; the
-    /// resulting output intents are translated into concrete `scrollState`
-    /// / `ScrollPosition` mutations by the view layer.
-    @State var scrollCoordinator = ScrollCoordinator()
     /// In-flight resize scroll stabilization task; cancelled on each new resize.
     @State var resizeScrollTask: Task<Void, Never>?
     /// Native SwiftUI scroll position struct (macOS 15+). Replaces
@@ -148,49 +143,25 @@ struct MessageListView: View {
             // https://developer.apple.com/documentation/swiftui/view/defaultscrollanchor(_:for:)
             .defaultScrollAnchor(.bottom, for: .initialOffset)
             .scrollPosition($scrollPosition)
-            .environment(\.suppressAutoScroll, { [self] in
-                os_signpost(.event, log: PerfSignposts.log, name: "scrollSuppressionChanged", "on reason=manualExpansionDetach")
-                let intents = scrollCoordinator.handle(.manualExpansion)
-                executeCoordinatorIntents(intents)
-                // Keep scrollState in sync as runtime executor.
-                scrollState.handleManualExpansionInteraction()
-            })
-            .onScrollPhaseChange { oldPhase, newPhase in
-                let coordinatorPhase = ScrollCoordinator.Phase.from(newPhase)
-                let intents = scrollCoordinator.handle(.scrollPhaseChanged(phase: coordinatorPhase))
-                executeCoordinatorIntents(intents)
-                // Keep scrollState in sync as runtime executor.
-                scrollState.scrollPhase = newPhase
-                if newPhase == .idle && oldPhase != .idle && scrollState.isAtBottom {
-                    scrollState.handleReachedBottom()
-                }
-            }
             .scrollIndicators(scrollState.scrollIndicatorsHidden ? .hidden : .automatic)
             .id(conversationId)
             .frame(width: widths.scrollSurfaceWidth)
             .overlay(alignment: .bottom) {
-                ScrollToLatestOverlayView(scrollState: scrollState)
+                ScrollToLatestOverlayView(scrollState: scrollState, onScrollToBottom: { scrollPosition.scrollTo(edge: .bottom) })
             }
             .onAppear {
-                let intents = scrollCoordinator.handle(.appeared)
-                executeCoordinatorIntents(intents)
                 handleAppear()
             }
             .onDisappear {
-                scrollCoordinator.reset()
                 scrollState.cancelAll()
                 resizeScrollTask?.cancel()
                 resizeScrollTask = nil
                 highlightedMessageId = nil
             }
             .onChange(of: isSending) {
-                let intents = scrollCoordinator.handle(.sendingChanged(isSending: isSending))
-                executeCoordinatorIntents(intents)
                 handleSendingChanged()
             }
             .onChange(of: messages.count) {
-                let intents = scrollCoordinator.handle(.messageCountChanged)
-                executeCoordinatorIntents(intents)
                 handleMessagesCountChanged()
             }
             .onChange(of: containerWidth) { handleContainerWidthChanged() }


### PR DESCRIPTION
## Summary
- Removed `ScrollCoordinator` `@State` and all `executeCoordinatorIntents` calls from MessageListView, its scroll handling extension, and its lifecycle extension
- Removed `.environment(\.suppressAutoScroll, ...)` modifier
- Removed `.onScrollPhaseChange` handler (was driving no-op mode transitions after PR 1)
- Removed `ScrollCoordinator.Phase` bridge extension from ScrollHandling
- Removed `scrollCoordinator.updateBottomState` call from geometry handler
- Wired up `onScrollToBottom` closure on `ScrollToLatestOverlayView` to connect PR 5's closure to `scrollPosition.scrollTo(edge: .bottom)`
- Kept `configureScrollCallbacks()` — still needed to bridge `ScrollPosition` to `scrollState` closures (`scrollTo`, `scrollToEdge`, `cancelScrollAnimation`)
- ScrollView setup is now minimal: position binding, anchor, indicators, overlay

Part of plan: scroll-state-machine-removal.md (PR 2 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25202" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
