### PR TITLE
refactor: simplify scroll geometry handler — just track distance and pagination

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+ScrollHandling.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+ScrollHandling.swift
@@ -87,229 +87,33 @@ extension MessageListView {
     }
 
     func handleScrollGeometryUpdate(_ newState: ScrollGeometrySnapshot) {
-        // --- Scroll direction detection ---
-        let effectiveContentHeight = newState.contentHeight
-        let isScrollable = effectiveContentHeight > newState.containerHeight
-        let isScrollingUp = newState.contentOffsetY < scrollState.lastContentOffsetY
-        let previousContentHeight = scrollState.scrollContentHeight
+        // --- Update geometry on scroll state ---
         scrollState.scrollContentHeight = newState.contentHeight
         scrollState.scrollContainerHeight = newState.containerHeight
         scrollState.lastContentOffsetY = newState.contentOffsetY
 
-        // Detach on user gesture (interacting) AND user-initiated momentum
-        // (decelerating). A fast trackpad flick has a very brief .interacting
-        // phase — sometimes only 1-2 geometry updates fire before the phase
-        // transitions to .decelerating. If the first update hasn't registered
-        // a position change yet, handleUserScrollUp() never fires and the CTA
-        // never appears. .decelerating is exclusively user-initiated momentum
-        // (programmatic scrolls use .animating), so it's safe to detect here.
-        // Only detach when content is scrollable (prevents false detaches
-        // on short conversations).
-        let isUserScrollPhase = scrollState.scrollPhase == .interacting
-            || scrollState.scrollPhase == .decelerating
-        if isUserScrollPhase && isScrollingUp && isScrollable {
-            // During .decelerating, check if the momentum is stale (pre-CTA).
-            // When the user scrolls up and taps "Scroll to latest" while
-            // momentum is active, the CTA fires requestPinToBottom and sets
-            // mode to .followingBottom. But the residual upward momentum
-            // generates geometry updates with isScrollingUp=true in
-            // .decelerating phase — the very next update would fire
-            // handleUserScrollUp(), undoing the CTA's mode transition and
-            // creating a "scroll lock" effect.
-            //
-            // Only suppress during .decelerating (residual momentum from
-            // before the CTA tap). .interacting (new deliberate trackpad
-            // touch) is always respected — the user is explicitly starting
-            // a new scroll gesture, overriding the CTA.
-            if scrollState.scrollPhase == .decelerating,
-               let pinTime = scrollState.lastUserInitiatedPinTime,
-               Date().timeIntervalSince(pinTime) < 0.5 {
-                // Stale momentum from before CTA tap — ignore.
-            } else {
-                // Route through coordinator for policy decision.
-                let browseIntents = scrollCoordinator.handle(.manualBrowseIntent)
-                executeCoordinatorIntents(browseIntents)
-                // Keep scrollState in sync as runtime executor.
-                scrollState.scrollRestoreTask?.cancel()
-                scrollState.scrollRestoreTask = nil
-                scrollState.handleUserScrollUp()
-            }
-        }
-
-        // --- Phase guard (shared by bottom detection, auto-follow, recovery) ---
-        // Only allow automatic scroll actions when scroll is fully at rest
-        // (.idle). Block during ALL non-idle phases including .animating.
-        //
-        // Why no .animating exception: recovery calls non-animated
-        // scrollToEdge(.bottom) which interrupts any in-flight spring
-        // animation (e.g. the CTA's smooth scroll). The user sees the
-        // spring start, then a jarring jump to bottom. By restricting
-        // to .idle only, recovery waits until the animation completes,
-        // then fires cleanly.
-        //
-        // This is safe for streaming auto-follow because the auto-follow
-        // path uses non-animated scrollToEdge(.bottom) which doesn't
-        // trigger .animating — the scroll position changes instantly and
-        // scrollPhase stays .idle.
-        //
-        // Animated pins (handleSendingChanged, handleMessagesCountChanged)
-        // briefly trigger .animating (~150ms with VAnimation.fast), during
-        // which auto-follow is paused. After the animation completes and
-        // phase returns to .idle, auto-follow resumes immediately.
-        let phaseAllowsAutoFollow = !scrollState.scrollPhase.isScrolling
-
         // --- Viewport height update ---
         // Filter non-finite viewport heights and sub-pixel jitter.
-        // A 0.5pt dead-zone prevents floating-point rounding differences
-        // from triggering continuous updates that feed back into layout.
         let decision = PreferenceGeometryFilter.evaluate(
             newValue: newState.visibleRectHeight,
             previous: scrollState.viewportHeight,
             deadZone: 0.5
         )
         if case .accept(let accepted) = decision {
-            os_signpost(.begin, log: PerfSignposts.log, name: "viewportHeightChanged")
             scrollState.viewportHeight = accepted
-            os_signpost(.end, log: PerfSignposts.log, name: "viewportHeightChanged")
         }
 
-        // --- Bottom detection (with hysteresis) ---
-        // Asymmetric thresholds prevent oscillation during streaming:
-        // content-height growth can briefly push distanceFromBottom past
-        // the "at bottom" threshold before the scroll position catches
-        // up, causing rapid true→false→true flips. A wider leave
-        // threshold absorbs those transient spikes without overly
-        // widening the idle-reattach zone (onScrollPhaseChange reattaches
-        // when isAtBottom is true on idle).
-        let distanceFromBottom = effectiveContentHeight - newState.contentOffsetY - newState.visibleRectHeight
-        // Update coordinator's bottom state (hysteresis lives in coordinator).
-        scrollCoordinator.updateBottomState(distanceFromBottom: distanceFromBottom)
-        let nowAtBottom: Bool
-        if scrollState.isAtBottom {
-            // Stay "at bottom" until clearly scrolled away.
-            nowAtBottom = distanceFromBottom.isFinite && distanceFromBottom <= 30
-        } else {
-            // Only re-enter "at bottom" when truly close.
-            nowAtBottom = distanceFromBottom.isFinite && distanceFromBottom <= 10
-        }
-        if scrollState.isAtBottom != nowAtBottom {
-            scrollState.isAtBottom = nowAtBottom
-            // Only reattach during non-user-initiated phases. During
-            // .interacting the user is actively scrolling — reattaching
-            // would cause mode to oscillate between freeBrowsing and
-            // followingBottom within the 16ms UI-sync debounce window,
-            // preventing the CTA from ever appearing. The idle handler
-            // in onScrollPhaseChange provides deferred reattach when
-            // the scroll settles.
-            if nowAtBottom, phaseAllowsAutoFollow {
-                scrollState.handleReachedBottom()
-            }
-        }
+        // --- Distance-based scroll-to-latest CTA ---
+        scrollState.updateScrollToLatest()
 
-        // --- Content-height-change auto-follow ---
-        // Pin to bottom when content height changes in either direction:
-        //   Growth  → streaming, new messages
-        //   Shrinkage → LazyVStack height-estimate convergence after a
-        //               conversation switch (estimated height overshoots,
-        //               then shrinks as views materialize with actual heights)
-        // The 0.5pt threshold filters sub-pixel layout noise. Safe from
-        // feedback loops because pinning changes contentOffsetY, not
-        // contentHeight.
-        if abs(effectiveContentHeight - previousContentHeight) > 0.5,
-           scrollState.mode.allowsAutoScroll,
-           phaseAllowsAutoFollow {
-            scrollState.requestPinToBottom()
-        }
-        // --- Persistent bottom-recovery ---
-        // Independent of the content-height auto-follow. Catches cases
-        // the height-change check misses:
-        //   • LazyVStack estimate converging in <0.5pt increments
-        //   • ID-based scroll landing short due to height estimation
-        //     errors (long conversations with variable content like images)
-        //   • Race conditions during rapid conversation switching
-        //   • "False at-bottom" — viewport at the estimated bottom but
-        //     actual content is above (LazyVStack blank space)
-        //
-        // Uses edge-based scroll instead of ID-based (requestPinToBottom).
-        // ID-based ScrollPosition(id: lastMessageId, .bottom) depends on
-        // accurate height estimates for all preceding views — in long
-        // conversations with images, estimates are unreliable and the
-        // scroll lands short. Edge-based scrollToEdge(.bottom) targets
-        // the absolute content bottom, converging as LazyVStack
-        // materializes more views with each attempt.
-        //
-        // Recovery fires unconditionally until the bottom anchor view
-        // has appeared (meaning LazyVStack materialized to the actual
-        // bottom and isAtBottom is reliable) OR the 2-second deadline
-        // expires (whichever comes first). The deadline is critical
-        // because multiple paths reset bottomAnchorAppeared = false
-        // while the anchor may already be visible in the hierarchy
-        // (CTA taps, sends, resizes) — since onAppear only fires on
-        // hierarchy transitions, the flag won't be re-set and recovery
-        // would fire indefinitely without the time cutoff.
-        // Only fires in initialLoad/followingBottom.
-        let isInRecoveryWindow: Bool
-        if scrollState.bottomAnchorAppeared {
-            // Anchor materialized — isAtBottom is reliable now.
-            isInRecoveryWindow = false
-        } else if let deadline = scrollState.recoveryDeadline,
-                  Date() < deadline {
-            // Bottom anchor hasn't materialized yet and we're within
-            // the 2-second hard time limit. Each recovery attempt
-            // scrolls closer to the actual bottom, materializing more
-            // views. Eventually the bottom anchor materializes and
-            // recovery ends. The 100ms throttle limits this to at most
-            // 10 attempts/second. Recovery naturally stops via:
-            //   • bottomAnchorAppeared (anchor materializes)
-            //   • User scroll-up (mode → freeBrowsing)
-            //   • Conversation switch (reset())
-            //   • 2-second deadline expiry (hard limit)
-            // The deadline is critical because multiple paths reset
-            // bottomAnchorAppeared = false while the anchor may already
-            // be visible (CTA taps, sends, resizes). Since onAppear
-            // only fires on hierarchy transitions, the anchor won't
-            // re-fire if already materialized — without the deadline,
-            // recovery would fire at 10Hz indefinitely.
-            isInRecoveryWindow = true
-        } else {
-            isInRecoveryWindow = false
-        }
-        if scrollState.mode.allowsAutoScroll,
-           phaseAllowsAutoFollow,
-           effectiveContentHeight > newState.visibleRectHeight,
-           (!nowAtBottom || isInRecoveryWindow) {
-            // Throttle recovery to at most once per 100ms. Without this,
-            // geometry updates at ~60fps fire scrollToEdge every ~16ms.
-            // LazyVStack needs time between scroll attempts to materialize
-            // views at the new position — rapid-fire scrolls keep yanking
-            // the viewport before materialization completes, causing the
-            // chat to appear blank (especially in long conversations).
-            // 100ms ≈ 6 frames at 60fps — enough for LazyVStack to
-            // materialize a batch of views while still feeling responsive.
-            let now = Date()
-            if now.timeIntervalSince(scrollState.lastRecoveryAttempt) >= 0.1 {
-                scrollState.lastRecoveryAttempt = now
-                scrollState.scrollToEdge?(.bottom)
-            }
-        }
-
-        // --- Pagination trigger ---
-        // Derive pagination from scroll offset instead of a
-        // GeometryReader+PreferenceKey sentinel inside the
-        // LazyVStack. The old sentinel reported minY in the
-        // ScrollView coordinate space (0 at viewport top,
-        // negative when scrolled past). contentOffsetY has
-        // inverted sign (0 at top, positive when scrolled
-        // down), so we negate to preserve the same semantics.
-        handlePaginationSentinel(
-            sentinelMinY: -newState.contentOffsetY
-        )
+        // --- Pagination ---
+        handlePaginationSentinel(sentinelMinY: -newState.contentOffsetY)
     }
 
     // MARK: - Pagination sentinel
 
-    /// Evaluates a pagination sentinel preference change and triggers pagination
-    /// if the sentinel entered the trigger band.
+    /// Triggers pagination when the sentinel enters the trigger band.
+    /// Uses rising-edge detection with a 500ms cooldown (via scrollState).
     func handlePaginationSentinel(sentinelMinY: CGFloat) {
         guard PreferenceGeometryFilter.evaluate(
             newValue: sentinelMinY,
@@ -317,26 +121,12 @@ extension MessageListView {
             deadZone: 0
         ) != .rejectNonFinite else { return }
 
-        let isInRange = MessageListPaginationTriggerPolicy.isInTriggerBand(
-            sentinelMinY: sentinelMinY,
-            viewportHeight: scrollState.viewportHeight
-        )
-        let shouldFire = MessageListPaginationTriggerPolicy.shouldTrigger(
-            sentinelMinY: sentinelMinY,
-            viewportHeight: scrollState.viewportHeight,
-            wasInRange: scrollState.wasPaginationTriggerInRange
-        )
-        guard shouldFire,
+        guard scrollState.handlePaginationSentinel(sentinelMinY: sentinelMinY),
               hasMoreMessages,
               !isLoadingMoreMessages,
               !scrollState.isPaginationInFlight
         else { return }
 
-        guard Date().timeIntervalSince(scrollState.lastPaginationCompletedAt) > 0.5 else { return }
-
-        // Fire pagination — update edge state only now so guard rejections
-        // (including cooldown) don't consume the one-shot rising edge.
-        scrollState.wasPaginationTriggerInRange = isInRange
         scrollState.isPaginationInFlight = true
         let anchorId = scrollState.derivedStateCache.cachedFirstVisibleMessageId
         let taskConversationId = scrollState.currentConversationId


### PR DESCRIPTION
## Summary
- Rewrote handleScrollGeometryUpdate to ~20 lines (from ~300)
- Just tracks geometry, updates scroll-to-latest distance, triggers pagination
- Removed all auto-follow, recovery, mode transitions, scroll closure setup from the geometry handler
- Simplified pagination sentinel to delegate rising-edge detection to scrollState

Part of plan: scroll-state-machine-removal.md (PR 3 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25203" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
