### PR TITLE
fix: persist minHeight on latest assistant message until next user message

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
@@ -183,7 +183,7 @@ struct MessageListContentView: View, Equatable {
             // Track whether the minHeight wrapper is applied so
             // executeScrollToBottom can target the content-bottom marker.
             let minHeightApplied: Bool = {
-                guard state.isActiveTurn, let lastRow = state.rows.last else { return false }
+                guard let lastRow = state.rows.last else { return false }
                 return lastRow.isLatestAssistant
             }()
             let _ = {
@@ -251,10 +251,10 @@ struct MessageListContentView: View, Equatable {
                     providerCatalogHash: providerCatalogHash
                 )
                 .equatable()
-                // Active assistant turn: wrap in VStack with minHeight so user
-                // message sits at top. Only applies while the assistant has an
-                // active turn (sending, thinking, streaming, tool running).
-                .if(state.isActiveTurn && row.isLatestAssistant && row.message.id == state.rows.last?.message.id) { view in
+                // Latest assistant message: wrap in VStack with minHeight so user
+                // message sits at top. Persists until the user sends a new message
+                // (at which point the assistant message is no longer the last row).
+                .if(row.isLatestAssistant && row.message.id == state.rows.last?.message.id) { view in
                     VStack(spacing: 0) {
                         view
                         Color.clear.frame(height: 1)


### PR DESCRIPTION
## Summary
- Remove isActiveTurn gate from minHeight wrapper on latest assistant message
- MinHeight persists until user sends next message (assistant no longer last row)
- Prevents viewport jump when streaming completes and isActiveTurn becomes false

Part of plan: scroll-send-to-top-fix.md (PR 2 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25207" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
