### PR TITLE
fix: reliable scroll-to-top on send — capture user message ID at source

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -104,7 +104,7 @@ final class MessageListScrollState {
     @ObservationIgnored var currentConversationId: UUID?
     @ObservationIgnored var lastMessageId: UUID?
     @ObservationIgnored var lastActivityPhaseWhenIdle: String = ""
-    @ObservationIgnored var pendingSendScrollToTop: Bool = false
+    @ObservationIgnored var pendingSendScrollMessageId: UUID?
     @ObservationIgnored var isActiveTurnMinHeightApplied: Bool = false
     @ObservationIgnored var hasCompletedInitialPushToTop: Bool = false
 
@@ -219,7 +219,7 @@ final class MessageListScrollState {
         ScrollGeometryUpdateDispatcher.shared.cancel(for: self)
         currentConversationId = conversationId
         lastMessageId = nil
-        pendingSendScrollToTop = false
+        pendingSendScrollMessageId = nil
         isActiveTurnMinHeightApplied = false
         hasCompletedInitialPushToTop = false
         scrollContentHeight = 0

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
@@ -74,7 +74,9 @@ extension MessageListView {
             // jump the viewport to an older user message.
             let isConfirmationResume = scrollState.lastActivityPhaseWhenIdle == "awaiting_confirmation"
             if !isConfirmationResume {
-                scrollState.pendingSendScrollToTop = true
+                if let userMessage = messages.last(where: { $0.role == .user }) {
+                    scrollState.pendingSendScrollMessageId = userMessage.id
+                }
             }
         } else {
             // Capture the activity phase at the moment sending stops.
@@ -119,16 +121,27 @@ extension MessageListView {
                 return
             }
         }
+        // --- Safety net: detect new user message added before isSending onChange fired ---
+        // MessageSendCoordinator appends the user message and calls flushCoalescedPublish()
+        // before setting isSending = true, so messages.count can change first.
+        // Must run before lastMessageId is updated so we can detect the change.
+        if scrollState.pendingSendScrollMessageId == nil {
+            if let lastUser = paginatedVisibleMessages.last(where: { $0.role == .user }),
+               scrollState.lastMessageId != nil,
+               lastUser.id != scrollState.lastMessageId,
+               paginatedVisibleMessages.last?.id != scrollState.lastMessageId {
+                scrollState.pendingSendScrollMessageId = lastUser.id
+            }
+        }
         // --- Update lastMessageId ---
         if let lastId = paginatedVisibleMessages.last?.id {
             scrollState.lastMessageId = lastId
         }
         // --- Scroll user message to top on send ---
-        if scrollState.pendingSendScrollToTop {
-            if let userMessage = messages.last(where: { $0.role == .user }) {
-                scrollPosition = ScrollPosition(id: userMessage.id, anchor: .top)
-            }
-            scrollState.pendingSendScrollToTop = false
+        if let targetId = scrollState.pendingSendScrollMessageId,
+           paginatedVisibleMessages.contains(where: { $0.id == targetId }) {
+            scrollPosition = ScrollPosition(id: targetId, anchor: .top)
+            scrollState.pendingSendScrollMessageId = nil
         }
         // --- Confirmation focus handoff ---
         #if os(macOS)

--- a/clients/macos/vellum-assistantTests/MessageListScrollStateTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListScrollStateTests.swift
@@ -114,7 +114,7 @@ final class MessageListScrollStateTests: XCTestCase {
         state.lastContentOffsetY = 2000
         state.lastMessageId = UUID()
         state.currentConversationId = UUID()
-        state.pendingSendScrollToTop = true
+        state.pendingSendScrollMessageId = UUID()
         state.wasPaginationTriggerInRange = true
         state.lastPaginationCompletedAt = Date()
         state.updateScrollToLatest()
@@ -125,7 +125,7 @@ final class MessageListScrollStateTests: XCTestCase {
 
         XCTAssertEqual(state.currentConversationId, newId)
         XCTAssertNil(state.lastMessageId)
-        XCTAssertFalse(state.pendingSendScrollToTop)
+        XCTAssertNil(state.pendingSendScrollMessageId)
         XCTAssertEqual(state.scrollContentHeight, 0)
         XCTAssertEqual(state.scrollContainerHeight, 0)
         XCTAssertEqual(state.lastContentOffsetY, 0)


### PR DESCRIPTION
## Summary
- Replace pendingSendScrollToTop boolean with UUID-based pendingSendScrollMessageId
- Add safety net: detect new user messages when messages.count fires before isSending
- Scroll only clears after successful execution (not on first count change)
- Confirmation resumes excluded via lastActivityPhaseWhenIdle check

Part of plan: scroll-send-to-top-fix.md (PR 1 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25208" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
