### PR TITLE
assistant: add streaming stt contracts and provider capability resolution

### DIFF
--- a/assistant/src/providers/speech-to-text/__tests__/provider-catalog.test.ts
+++ b/assistant/src/providers/speech-to-text/__tests__/provider-catalog.test.ts
@@ -94,11 +94,48 @@ describe("STT provider catalog", () => {
     expect(supportsBoundary("google-gemini", "daemon-batch")).toBe(true);
   });
 
+  test("supportsBoundary returns true for daemon-streaming on streaming-capable providers", () => {
+    expect(supportsBoundary("deepgram", "daemon-streaming")).toBe(true);
+    expect(supportsBoundary("google-gemini", "daemon-streaming")).toBe(true);
+  });
+
+  test("supportsBoundary returns false for daemon-streaming on non-streaming providers", () => {
+    expect(supportsBoundary("openai-whisper", "daemon-streaming")).toBe(false);
+  });
+
   test("supportsBoundary returns false for unknown provider IDs", () => {
     // Cast to bypass type checking for the test
     expect(supportsBoundary("nonexistent" as never, "daemon-batch")).toBe(
       false,
     );
+  });
+
+  // -----------------------------------------------------------------------
+  // Conversation streaming mode
+  // -----------------------------------------------------------------------
+
+  test("conversationStreamingMode is set for all providers", () => {
+    for (const entry of listProviderEntries()) {
+      expect(entry.conversationStreamingMode).toBeDefined();
+      expect(["realtime-ws", "incremental-batch", "none"]).toContain(
+        entry.conversationStreamingMode,
+      );
+    }
+  });
+
+  test("deepgram has realtime-ws conversation streaming mode", () => {
+    const entry = getProviderEntry("deepgram");
+    expect(entry?.conversationStreamingMode).toBe("realtime-ws");
+  });
+
+  test("google-gemini has incremental-batch conversation streaming mode", () => {
+    const entry = getProviderEntry("google-gemini");
+    expect(entry?.conversationStreamingMode).toBe("incremental-batch");
+  });
+
+  test("openai-whisper has no conversation streaming support", () => {
+    const entry = getProviderEntry("openai-whisper");
+    expect(entry?.conversationStreamingMode).toBe("none");
   });
 
   // -----------------------------------------------------------------------

--- a/assistant/src/providers/speech-to-text/__tests__/resolve.test.ts
+++ b/assistant/src/providers/speech-to-text/__tests__/resolve.test.ts
@@ -43,6 +43,7 @@ mock.module("../../../security/credential-key.js", () => ({
 
 import {
   resolveBatchTranscriber,
+  resolveConversationStreamingSttCapability,
   resolveTelephonySttCapability,
 } from "../resolve.js";
 
@@ -319,6 +320,139 @@ describe("resolveTelephonySttCapability", () => {
     if (result.status === "missing-credentials") {
       expect(result.providerId).toBe("google-gemini");
       expect(result.credentialProvider).toBe("gemini");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — resolveConversationStreamingSttCapability
+// ---------------------------------------------------------------------------
+
+describe("resolveConversationStreamingSttCapability", () => {
+  beforeEach(() => {
+    mockConfig = buildConfig({});
+    mockProviderKeys = {};
+  });
+
+  // -------------------------------------------------------------------------
+  // Deepgram — realtime-ws streaming
+  // -------------------------------------------------------------------------
+
+  test("returns 'supported' with realtime-ws mode for deepgram", async () => {
+    mockProviderKeys["deepgram"] = "dg-stream-key";
+    mockConfig = buildConfig({ provider: "deepgram" });
+
+    const result = await resolveConversationStreamingSttCapability();
+
+    expect(result.status).toBe("supported");
+    if (result.status === "supported") {
+      expect(result.providerId).toBe("deepgram");
+      expect(result.streamingMode).toBe("realtime-ws");
+    }
+  });
+
+  test("returns 'missing-credentials' for deepgram without an API key", async () => {
+    mockProviderKeys = {};
+    mockConfig = buildConfig({ provider: "deepgram" });
+
+    const result = await resolveConversationStreamingSttCapability();
+
+    expect(result.status).toBe("missing-credentials");
+    if (result.status === "missing-credentials") {
+      expect(result.providerId).toBe("deepgram");
+      expect(result.credentialProvider).toBe("deepgram");
+      expect(result.reason).toContain("deepgram");
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Google Gemini — incremental-batch streaming
+  // -------------------------------------------------------------------------
+
+  test("returns 'supported' with incremental-batch mode for google-gemini", async () => {
+    mockProviderKeys["gemini"] = "gemini-stream-key";
+    mockConfig = buildConfig({ provider: "google-gemini" });
+
+    const result = await resolveConversationStreamingSttCapability();
+
+    expect(result.status).toBe("supported");
+    if (result.status === "supported") {
+      expect(result.providerId).toBe("google-gemini");
+      expect(result.streamingMode).toBe("incremental-batch");
+    }
+  });
+
+  test("returns 'missing-credentials' for google-gemini without a gemini key", async () => {
+    mockProviderKeys = {};
+    mockConfig = buildConfig({ provider: "google-gemini" });
+
+    const result = await resolveConversationStreamingSttCapability();
+
+    expect(result.status).toBe("missing-credentials");
+    if (result.status === "missing-credentials") {
+      expect(result.providerId).toBe("google-gemini");
+      expect(result.credentialProvider).toBe("gemini");
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // OpenAI Whisper — no streaming support
+  // -------------------------------------------------------------------------
+
+  test("returns 'unsupported' for openai-whisper (no conversation streaming)", async () => {
+    mockProviderKeys["openai"] = "sk-stream-test";
+    mockConfig = buildConfig({ provider: "openai-whisper" });
+
+    const result = await resolveConversationStreamingSttCapability();
+
+    expect(result.status).toBe("unsupported");
+    if (result.status === "unsupported") {
+      expect(result.providerId).toBe("openai-whisper");
+      expect(result.reason).toContain("openai-whisper");
+      expect(result.reason).toContain(
+        "does not support conversation streaming",
+      );
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Unknown / unconfigured provider
+  // -------------------------------------------------------------------------
+
+  test("returns 'unconfigured' when provider is not in the catalog", async () => {
+    mockProviderKeys["unknown-provider"] = "key-doesnt-matter";
+    mockConfig = buildConfig({ provider: "unknown-provider" as string });
+
+    const result = await resolveConversationStreamingSttCapability();
+
+    expect(result.status).toBe("unconfigured");
+    if (result.status === "unconfigured") {
+      expect(result.reason).toContain("unknown-provider");
+      expect(result.reason).toContain("not in the provider catalog");
+    }
+  });
+
+  test("returns 'unconfigured' for empty-string provider", async () => {
+    mockConfig = buildConfig({ provider: "" as string });
+
+    const result = await resolveConversationStreamingSttCapability();
+
+    expect(result.status).toBe("unconfigured");
+  });
+
+  // -------------------------------------------------------------------------
+  // Config-driven behaviour
+  // -------------------------------------------------------------------------
+
+  test("uses config-driven provider, not a hardcoded default", async () => {
+    mockProviderKeys["deepgram"] = "dg-config-test";
+    mockConfig = buildConfig({ provider: "deepgram" });
+
+    const result = await resolveConversationStreamingSttCapability();
+
+    expect(result.status).toBe("supported");
+    if (result.status === "supported") {
+      expect(result.providerId).toBe("deepgram");
     }
   });
 });

--- a/assistant/src/providers/speech-to-text/provider-catalog.ts
+++ b/assistant/src/providers/speech-to-text/provider-catalog.ts
@@ -11,6 +11,7 @@
  */
 
 import type {
+  ConversationStreamingMode,
   SttBoundaryId,
   SttProviderId,
   TelephonySttMode,
@@ -47,6 +48,17 @@ export interface SttProviderEntry {
    * participate in real-time call ingestion via `services.stt`.
    */
   readonly telephonyMode: TelephonySttMode;
+
+  /**
+   * Conversation streaming mode — describes whether and how the provider
+   * can participate in real-time conversation chat message capture
+   * (chat composer and iOS input bar).
+   *
+   * - `"realtime-ws"` — native WebSocket streaming with partial/final events.
+   * - `"incremental-batch"` — polling-based incremental batch approximation.
+   * - `"none"` — no streaming support; fall back to batch transcription.
+   */
+  readonly conversationStreamingMode: ConversationStreamingMode;
 }
 
 // ---------------------------------------------------------------------------
@@ -73,6 +85,7 @@ const CATALOG: ReadonlyMap<SttProviderId, SttProviderEntry> = new Map<
       credentialProvider: "openai",
       supportedBoundaries: new Set<SttBoundaryId>(["daemon-batch"]),
       telephonyMode: "batch-only",
+      conversationStreamingMode: "none",
     },
   ],
   [
@@ -80,8 +93,12 @@ const CATALOG: ReadonlyMap<SttProviderId, SttProviderEntry> = new Map<
     {
       id: "deepgram",
       credentialProvider: "deepgram",
-      supportedBoundaries: new Set<SttBoundaryId>(["daemon-batch"]),
+      supportedBoundaries: new Set<SttBoundaryId>([
+        "daemon-batch",
+        "daemon-streaming",
+      ]),
       telephonyMode: "realtime-ws",
+      conversationStreamingMode: "realtime-ws",
     },
   ],
   [
@@ -89,8 +106,12 @@ const CATALOG: ReadonlyMap<SttProviderId, SttProviderEntry> = new Map<
     {
       id: "google-gemini",
       credentialProvider: "gemini",
-      supportedBoundaries: new Set<SttBoundaryId>(["daemon-batch"]),
+      supportedBoundaries: new Set<SttBoundaryId>([
+        "daemon-batch",
+        "daemon-streaming",
+      ]),
       telephonyMode: "batch-only",
+      conversationStreamingMode: "incremental-batch",
     },
   ],
 ]);

--- a/assistant/src/providers/speech-to-text/resolve.ts
+++ b/assistant/src/providers/speech-to-text/resolve.ts
@@ -132,3 +132,93 @@ export async function resolveTelephonySttCapability(): Promise<TelephonySttCapab
     telephonyMode: entry.telephonyMode,
   };
 }
+
+// ---------------------------------------------------------------------------
+// Conversation streaming capability resolver
+// ---------------------------------------------------------------------------
+
+/**
+ * Result of resolving whether the configured `services.stt` provider
+ * supports conversation streaming for chat message capture.
+ */
+export type ConversationStreamingSttCapability =
+  | {
+      /** The configured provider supports conversation streaming. */
+      status: "supported";
+      providerId: SttProviderId;
+      /** How the provider implements conversation streaming. */
+      streamingMode: "realtime-ws" | "incremental-batch";
+    }
+  | {
+      /** The configured provider does not support conversation streaming. */
+      status: "unsupported";
+      providerId: SttProviderId;
+      reason: string;
+    }
+  | {
+      /** The configured provider is unknown or not in the catalog. */
+      status: "unconfigured";
+      reason: string;
+    }
+  | {
+      /** The provider is eligible but missing credentials. */
+      status: "missing-credentials";
+      providerId: SttProviderId;
+      credentialProvider: string;
+      reason: string;
+    };
+
+/**
+ * Validate whether the configured `services.stt` provider supports
+ * conversation streaming for chat message capture (chat composer and
+ * iOS input bar).
+ *
+ * This resolver does **not** create a live streaming session — it only
+ * validates that the configuration, catalog entry, and credentials are
+ * all in order. The actual session creation is handled by the runtime
+ * session orchestrator (PR 5).
+ *
+ * Callers can branch on the discriminated `status` field:
+ * - `"supported"` — the provider supports streaming and credentials exist.
+ * - `"unsupported"` — the provider exists but has
+ *   `conversationStreamingMode: "none"`.
+ * - `"unconfigured"` — the provider is unknown or missing from the catalog.
+ * - `"missing-credentials"` — the provider is eligible but has no API key.
+ */
+export async function resolveConversationStreamingSttCapability(): Promise<ConversationStreamingSttCapability> {
+  const config = getConfig();
+  const provider = config.services.stt.provider;
+
+  const entry = getProviderEntry(provider as SttProviderId);
+  if (!entry) {
+    return {
+      status: "unconfigured",
+      reason: `STT provider "${provider}" is not in the provider catalog`,
+    };
+  }
+
+  if (entry.conversationStreamingMode === "none") {
+    return {
+      status: "unsupported",
+      providerId: entry.id,
+      reason: `STT provider "${entry.id}" does not support conversation streaming`,
+    };
+  }
+
+  // Provider is streaming-eligible — verify credentials exist.
+  const apiKey = await getProviderKeyAsync(entry.credentialProvider);
+  if (!apiKey) {
+    return {
+      status: "missing-credentials",
+      providerId: entry.id,
+      credentialProvider: entry.credentialProvider,
+      reason: `No API key configured for credential provider "${entry.credentialProvider}"`,
+    };
+  }
+
+  return {
+    status: "supported",
+    providerId: entry.id,
+    streamingMode: entry.conversationStreamingMode,
+  };
+}

--- a/assistant/src/stt/types.ts
+++ b/assistant/src/stt/types.ts
@@ -1,10 +1,15 @@
 /**
- * Provider-agnostic speech-to-text domain types for daemon batch transcription.
+ * Provider-agnostic speech-to-text domain types for daemon transcription.
  *
  * These types define the boundary between callers that need audio transcription
  * and the concrete STT provider implementations. The goal is to let daemon
  * callsites program against a single typed interface so that provider swaps are
  * localized to the adapter layer.
+ *
+ * Two execution modes are supported:
+ * - **Batch** — a single audio buffer is sent and a final transcript returned.
+ * - **Streaming** — audio chunks are sent over a persistent session, and the
+ *   provider emits partial/final transcript events in real time.
  */
 
 // ---------------------------------------------------------------------------
@@ -12,7 +17,7 @@
 // ---------------------------------------------------------------------------
 
 /**
- * Canonical provider identifiers for daemon-hosted batch STT backends.
+ * Canonical provider identifiers for daemon-hosted STT backends.
  * Extend this union as new providers are integrated.
  */
 export type SttProviderId = "openai-whisper" | "deepgram" | "google-gemini";
@@ -33,6 +38,27 @@ export type SttProviderId = "openai-whisper" | "deepgram" | "google-gemini";
  */
 export type TelephonySttMode = "realtime-ws" | "batch-only" | "none";
 
+/**
+ * Conversation streaming STT support mode.
+ *
+ * Describes how a provider can participate in real-time conversation
+ * streaming when used for chat message capture (chat composer and iOS
+ * input bar).
+ *
+ * - `"realtime-ws"` — provider offers a native WebSocket streaming endpoint
+ *   that accepts audio chunks and emits partial/final transcript events
+ *   with low latency (e.g. Deepgram live transcription).
+ * - `"incremental-batch"` — provider does not offer true streaming but can
+ *   be polled with incremental audio batches to approximate streaming
+ *   behaviour (e.g. Google Gemini multimodal).
+ * - `"none"` — provider has no conversation streaming support; callers
+ *   should fall back to batch transcription.
+ */
+export type ConversationStreamingMode =
+  | "realtime-ws"
+  | "incremental-batch"
+  | "none";
+
 // ---------------------------------------------------------------------------
 // Boundary identifier
 // ---------------------------------------------------------------------------
@@ -41,8 +67,10 @@ export type TelephonySttMode = "realtime-ws" | "batch-only" | "none";
  * Runtime boundary through which STT is executed.
  * - `daemon-batch` — transcription runs in the daemon process via a REST API
  *   call to the provider (e.g. OpenAI Whisper).
+ * - `daemon-streaming` — transcription runs in the daemon process over a
+ *   persistent streaming session (e.g. WebSocket or incremental-batch loop).
  */
-export type SttBoundaryId = "daemon-batch";
+export type SttBoundaryId = "daemon-batch" | "daemon-streaming";
 
 // ---------------------------------------------------------------------------
 // Call-context hints
@@ -151,4 +179,133 @@ export interface BatchTranscriber {
    * structured {@link SttErrorCategory}.
    */
   transcribe(request: SttTranscribeRequest): Promise<SttTranscribeResult>;
+}
+
+// ---------------------------------------------------------------------------
+// Streaming client events (client -> daemon)
+// ---------------------------------------------------------------------------
+
+/**
+ * Events that a client sends to the daemon streaming session.
+ *
+ * The discriminated `type` field lets the runtime session handler
+ * dispatch to the correct streaming adapter method without coupling
+ * to transport-level framing (WebSocket opcodes, HTTP/2 frames, etc.).
+ */
+export type SttStreamClientEvent =
+  | SttStreamClientAudioEvent
+  | SttStreamClientStopEvent;
+
+/** A chunk of audio data to be transcribed. */
+export interface SttStreamClientAudioEvent {
+  readonly type: "audio";
+  /** Raw audio data for the current chunk. */
+  readonly audio: Buffer;
+  /** MIME type of the audio data (e.g. "audio/webm", "audio/pcm"). */
+  readonly mimeType: string;
+}
+
+/** Signals that the client has finished sending audio. */
+export interface SttStreamClientStopEvent {
+  readonly type: "stop";
+}
+
+// ---------------------------------------------------------------------------
+// Streaming server events (daemon -> client)
+// ---------------------------------------------------------------------------
+
+/**
+ * Events that the daemon streaming session emits to the client.
+ *
+ * The discriminated `type` field allows clients to handle partial
+ * and final transcripts, errors, and session lifecycle signals in a
+ * type-safe manner.
+ */
+export type SttStreamServerEvent =
+  | SttStreamServerPartialEvent
+  | SttStreamServerFinalEvent
+  | SttStreamServerErrorEvent
+  | SttStreamServerClosedEvent;
+
+/**
+ * A partial (interim) transcript — may be revised by subsequent
+ * partial or final events.
+ */
+export interface SttStreamServerPartialEvent {
+  readonly type: "partial";
+  /** Interim transcript text. May change with subsequent events. */
+  readonly text: string;
+}
+
+/**
+ * A final (committed) transcript — this segment will not be revised.
+ */
+export interface SttStreamServerFinalEvent {
+  readonly type: "final";
+  /** Committed transcript text for a completed speech segment. */
+  readonly text: string;
+}
+
+/** An error occurred during streaming transcription. */
+export interface SttStreamServerErrorEvent {
+  readonly type: "error";
+  /** Normalized error category for caller branching. */
+  readonly category: SttErrorCategory;
+  /** Human-readable error description. */
+  readonly message: string;
+}
+
+/** The streaming session has closed (no more events will be emitted). */
+export interface SttStreamServerClosedEvent {
+  readonly type: "closed";
+}
+
+// ---------------------------------------------------------------------------
+// Streaming transcriber interface
+// ---------------------------------------------------------------------------
+
+/**
+ * Daemon-hosted streaming transcriber contract.
+ *
+ * Implementations manage a persistent session that accepts audio chunks
+ * and emits partial/final transcript events. The runtime session
+ * orchestrator (PR 5) drives this interface from the gateway WebSocket
+ * path.
+ *
+ * Lifecycle:
+ * 1. Call {@link start} to open the provider session.
+ * 2. Feed audio chunks via {@link sendAudio}.
+ * 3. Call {@link stop} when the client finishes recording.
+ * 4. The `onEvent` callback receives server events until `closed`.
+ */
+export interface StreamingTranscriber {
+  /** Which provider backs this transcriber. */
+  readonly providerId: SttProviderId;
+  /** Which runtime boundary this transcriber operates in. */
+  readonly boundaryId: "daemon-streaming";
+
+  /**
+   * Open the streaming session with the provider.
+   *
+   * Must be called once before {@link sendAudio}. Rejects if the
+   * provider session cannot be established.
+   */
+  start(onEvent: (event: SttStreamServerEvent) => void): Promise<void>;
+
+  /**
+   * Feed a chunk of audio into the streaming session.
+   *
+   * Callers must not call this before {@link start} resolves or after
+   * {@link stop} has been called.
+   */
+  sendAudio(audio: Buffer, mimeType: string): void;
+
+  /**
+   * Signal that the client has finished sending audio.
+   *
+   * The provider may emit additional final events after stop is called.
+   * The session is fully closed when the `onEvent` callback receives a
+   * `closed` event.
+   */
+  stop(): void;
 }


### PR DESCRIPTION
## Summary
- Extend STT domain types with streaming-specific contracts and boundary identifier
- Add conversation streaming capability metadata to the STT provider catalog
- Add streaming capability resolver with structured result for runtime sessions

Part of plan: streaming-stt-chat-messages.md (PR 1 of 9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25209" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
