### PR TITLE
gateway+assistant: add authenticated websocket path for stt streaming

### DIFF
--- a/assistant/src/__tests__/gateway-only-enforcement.test.ts
+++ b/assistant/src/__tests__/gateway-only-enforcement.test.ts
@@ -766,6 +766,110 @@ describe("gateway-only ingress enforcement", () => {
     });
   });
 
+  // ── STT stream WebSocket upgrade ────────────────────────────────────
+
+  describe("STT stream WebSocket upgrade", () => {
+    test("blocks non-private-network origin", async () => {
+      const res = await fetch(
+        `http://127.0.0.1:${port}/v1/stt/stream?provider=deepgram&mimeType=audio/webm`,
+        {
+          headers: {
+            Upgrade: "websocket",
+            Connection: "Upgrade",
+            Origin: "https://external.example.com",
+            "Sec-WebSocket-Key": "dGhlIHNhbXBsZSBub25jZQ==",
+            "Sec-WebSocket-Version": "13",
+          },
+        },
+      );
+      expect(res.status).toBe(403);
+      const body = (await res.json()) as {
+        error: { code: string; message: string };
+      };
+      expect(body.error.code).toBe("FORBIDDEN");
+      expect(body.error.message).toContain("Direct STT stream access disabled");
+    });
+
+    test("rejects upgrade without a token", async () => {
+      const res = await fetch(
+        `http://127.0.0.1:${port}/v1/stt/stream?provider=deepgram&mimeType=audio/webm`,
+        {
+          headers: {
+            Upgrade: "websocket",
+            Connection: "Upgrade",
+            "Sec-WebSocket-Key": "dGhlIHNhbXBsZSBub25jZQ==",
+            "Sec-WebSocket-Version": "13",
+          },
+        },
+      );
+      expect(res.status).toBe(401);
+    });
+
+    test("rejects upgrade with actor JWT (requires gateway service token)", async () => {
+      const res = await fetch(
+        `http://127.0.0.1:${port}/v1/stt/stream?token=${TEST_JWT}&provider=deepgram&mimeType=audio/webm`,
+        {
+          headers: {
+            Upgrade: "websocket",
+            Connection: "Upgrade",
+            "Sec-WebSocket-Key": "dGhlIHNhbXBsZSBub25jZQ==",
+            "Sec-WebSocket-Version": "13",
+          },
+        },
+      );
+      // Actor JWTs should be rejected — only gateway service tokens are allowed.
+      expect(res.status).toBe(401);
+    });
+
+    test("accepts upgrade with gateway service token from private network", async () => {
+      const res = await fetch(
+        `http://127.0.0.1:${port}/v1/stt/stream?token=${GATEWAY_JWT}&provider=deepgram&mimeType=audio/webm`,
+        {
+          headers: {
+            Upgrade: "websocket",
+            Connection: "Upgrade",
+            "Sec-WebSocket-Key": "dGhlIHNhbXBsZSBub25jZQ==",
+            "Sec-WebSocket-Version": "13",
+          },
+        },
+      );
+      // Should NOT be 403 or 401 — WebSocket upgrade may or may not succeed
+      // depending on test environment, but the auth and network guards should pass.
+      expect(res.status).not.toBe(403);
+      expect(res.status).not.toBe(401);
+    });
+
+    test("returns 400 when provider is missing", async () => {
+      const res = await fetch(
+        `http://127.0.0.1:${port}/v1/stt/stream?token=${GATEWAY_JWT}&mimeType=audio/webm`,
+        {
+          headers: {
+            Upgrade: "websocket",
+            Connection: "Upgrade",
+            "Sec-WebSocket-Key": "dGhlIHNhbXBsZSBub25jZQ==",
+            "Sec-WebSocket-Version": "13",
+          },
+        },
+      );
+      expect(res.status).toBe(400);
+    });
+
+    test("returns 400 when mimeType is missing", async () => {
+      const res = await fetch(
+        `http://127.0.0.1:${port}/v1/stt/stream?token=${GATEWAY_JWT}&provider=deepgram`,
+        {
+          headers: {
+            Upgrade: "websocket",
+            Connection: "Upgrade",
+            "Sec-WebSocket-Key": "dGhlIHNhbXBsZSBub25jZQ==",
+            "Sec-WebSocket-Version": "13",
+          },
+        },
+      );
+      expect(res.status).toBe(400);
+    });
+  });
+
   // ── Startup warning for non-loopback host ──────────────────────────
 
   describe("startup guard — non-loopback host", () => {

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -300,6 +300,21 @@ interface MediaStreamWebSocketData {
   session?: MediaStreamCallSession;
 }
 
+/**
+ * WebSocket data attached to `/v1/stt/stream` connections.
+ * The `wsType` discriminator routes frames to the STT streaming
+ * session stub instead of the other WebSocket handlers.
+ *
+ * This is a minimal deploy-safe stub — provider adapters will be
+ * wired in by a later PR.
+ */
+interface SttStreamWebSocketData {
+  wsType: "stt-stream";
+  provider: string;
+  mimeType: string;
+  sampleRate?: number;
+}
+
 export class RuntimeHttpServer {
   private server: ReturnType<typeof Bun.serve> | null = null;
   private port: number;
@@ -393,7 +408,8 @@ export class RuntimeHttpServer {
     type AllWebSocketData =
       | RelayWebSocketData
       | BrowserRelayWebSocketData
-      | MediaStreamWebSocketData;
+      | MediaStreamWebSocketData
+      | SttStreamWebSocketData;
     this.server = Bun.serve<AllWebSocketData>({
       port: this.port,
       hostname: this.hostname,
@@ -435,6 +451,16 @@ export class RuntimeHttpServer {
             // handler tears down *this* session, not a replacement that
             // a reconnect may have inserted under the same callSessionId.
             msData.session = session;
+            return;
+          }
+          if ("wsType" in data && data.wsType === "stt-stream") {
+            const sttData = data as SttStreamWebSocketData;
+            log.info(
+              { provider: sttData.provider, mimeType: sttData.mimeType },
+              "STT stream WebSocket opened (stub)",
+            );
+            // Minimal stub — accept connect cleanly. Provider adapters
+            // will be wired in by a later PR.
             return;
           }
           const callSessionId = (data as RelayWebSocketData).callSessionId;
@@ -581,6 +607,10 @@ export class RuntimeHttpServer {
             msData.session?.handleMessage(raw);
             return;
           }
+          if ("wsType" in data && data.wsType === "stt-stream") {
+            // Stub: drop inbound audio frames until provider adapters land.
+            return;
+          }
           const callSessionId = (data as RelayWebSocketData).callSessionId;
           if (callSessionId) {
             const connection = activeRelayConnections.get(callSessionId);
@@ -624,6 +654,14 @@ export class RuntimeHttpServer {
                 activeMediaStreamSessions.delete(msData.callSessionId);
               }
             }
+            return;
+          }
+          if ("wsType" in data && data.wsType === "stt-stream") {
+            const sttData = data as SttStreamWebSocketData;
+            log.info(
+              { provider: sttData.provider, code, reason: reason?.toString() },
+              "STT stream WebSocket closed (stub)",
+            );
             return;
           }
           const callSessionId = (data as RelayWebSocketData).callSessionId;
@@ -857,6 +895,15 @@ export class RuntimeHttpServer {
       req.headers.get("upgrade")?.toLowerCase() === "websocket"
     ) {
       return this.handleMediaStreamUpgrade(req, server);
+    }
+
+    // WebSocket upgrade for STT streaming — private-network restrictions
+    // and explicit gateway-service token verification before upgrade.
+    if (
+      path === "/v1/stt/stream" &&
+      req.headers.get("upgrade")?.toLowerCase() === "websocket"
+    ) {
+      return this.handleSttStreamUpgrade(req, server);
     }
 
     // Twilio webhook endpoints — before auth check because Twilio
@@ -1172,6 +1219,73 @@ export class RuntimeHttpServer {
         wsType: "media-stream",
         callSessionId,
       } satisfies MediaStreamWebSocketData,
+    });
+    if (!upgraded) {
+      return new Response("WebSocket upgrade failed", { status: 500 });
+    }
+    // Bun's WebSocket upgrade consumes the request — no Response is sent.
+    return undefined!;
+  }
+
+  /**
+   * Handle WebSocket upgrade for `/v1/stt/stream`.
+   *
+   * Private-network restrictions apply (same as relay/media-stream) so the
+   * runtime remains unreachable from the public internet. The gateway
+   * authenticates the downstream client and proxies the upgrade with a
+   * short-lived gateway service token.
+   */
+  private handleSttStreamUpgrade(
+    req: Request,
+    server: ReturnType<typeof Bun.serve>,
+  ): Response {
+    if (!isPrivateNetworkPeer(server, req) || !isPrivateNetworkOrigin(req)) {
+      return httpError(
+        "FORBIDDEN",
+        "Direct STT stream access disabled — only private network peers allowed",
+        403,
+      );
+    }
+
+    // Verify the gateway service token before accepting the upgrade.
+    if (!isHttpAuthDisabled()) {
+      const wsUrl = new URL(req.url);
+      const token = wsUrl.searchParams.get("token");
+      if (!token) {
+        return httpError("UNAUTHORIZED", "Unauthorized", 401);
+      }
+      const jwtResult = verifyToken(token, "vellum-daemon");
+      if (!jwtResult.ok) {
+        return httpError("UNAUTHORIZED", "Unauthorized", 401);
+      }
+      // Accept gateway service tokens (svc:gateway:*) — these are the
+      // only tokens the gateway mints for upstream connections.
+      const subResult = parseSub(jwtResult.claims.sub);
+      if (!subResult.ok || subResult.principalType !== "svc_gateway") {
+        return httpError("UNAUTHORIZED", "Unauthorized", 401);
+      }
+    }
+
+    const wsUrl = new URL(req.url);
+    const provider = wsUrl.searchParams.get("provider");
+    const mimeType = wsUrl.searchParams.get("mimeType");
+    if (!provider || !mimeType) {
+      return new Response(
+        "Missing required query parameters: provider, mimeType",
+        { status: 400 },
+      );
+    }
+
+    const sampleRateRaw = wsUrl.searchParams.get("sampleRate");
+    const sampleRate = sampleRateRaw ? parseInt(sampleRateRaw, 10) : undefined;
+
+    const upgraded = server.upgrade(req, {
+      data: {
+        wsType: "stt-stream",
+        provider,
+        mimeType,
+        sampleRate,
+      } satisfies SttStreamWebSocketData,
     });
     if (!upgraded) {
       return new Response("WebSocket upgrade failed", { status: 500 });

--- a/gateway/src/__tests__/schema.test.ts
+++ b/gateway/src/__tests__/schema.test.ts
@@ -62,6 +62,7 @@ describe("/schema route", () => {
     expect(body.paths["/webhooks/twilio/connect-action"]).toBeDefined();
     expect(body.paths["/webhooks/twilio/relay"]).toBeDefined();
     expect(body.paths["/webhooks/twilio/media-stream"]).toBeDefined();
+    expect(body.paths["/v1/stt/stream"]).toBeDefined();
     expect(body.paths["/webhooks/oauth/callback"]).toBeDefined();
     expect(body.paths["/v1/integrations/telegram/config"]).toBeDefined();
     expect(body.paths["/v1/integrations/telegram/commands"]).toBeDefined();

--- a/gateway/src/__tests__/stt-stream-websocket.test.ts
+++ b/gateway/src/__tests__/stt-stream-websocket.test.ts
@@ -1,0 +1,357 @@
+import { describe, test, expect, mock } from "bun:test";
+import type { GatewayConfig } from "../config.js";
+import { initSigningKey, mintToken } from "../auth/token-service.js";
+import { CURRENT_POLICY_EPOCH } from "../auth/policy.js";
+import {
+  createSttStreamWebsocketHandler,
+  getSttStreamWebsocketHandlers,
+  type SttStreamSocketData,
+} from "../http/routes/stt-stream-websocket.js";
+
+const TEST_SIGNING_KEY = Buffer.from("test-signing-key-at-least-32-bytes-long");
+initSigningKey(TEST_SIGNING_KEY);
+
+/** Mint a valid actor edge JWT for STT stream auth. */
+function mintEdgeToken(actorPrincipalId: string = "test-user"): string {
+  return mintToken({
+    aud: "vellum-gateway",
+    sub: `actor:test-assistant:${actorPrincipalId}`,
+    scope_profile: "actor_client_v1",
+    policy_epoch: CURRENT_POLICY_EPOCH,
+    ttlSeconds: 300,
+  });
+}
+
+/** Mint a service-style token (no actor principal). */
+function mintServiceEdgeToken(): string {
+  return mintToken({
+    aud: "vellum-gateway",
+    sub: "svc:gateway:self",
+    scope_profile: "gateway_service_v1",
+    policy_epoch: CURRENT_POLICY_EPOCH,
+    ttlSeconds: 300,
+  });
+}
+
+function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
+  return {
+    assistantRuntimeBaseUrl: "http://localhost:7821",
+    routingEntries: [],
+    defaultAssistantId: undefined,
+    unmappedPolicy: "reject",
+    port: 7830,
+    runtimeProxyEnabled: false,
+    runtimeProxyRequireAuth: true,
+    shutdownDrainMs: 5000,
+    runtimeTimeoutMs: 30000,
+    runtimeMaxRetries: 2,
+    runtimeInitialBackoffMs: 500,
+    maxWebhookPayloadBytes: 1048576,
+    logFile: { dir: undefined, retentionDays: 30 },
+    maxAttachmentBytes: {
+      telegram: 50 * 1024 * 1024,
+      slack: 100 * 1024 * 1024,
+      whatsapp: 16 * 1024 * 1024,
+      default: 50 * 1024 * 1024,
+    },
+    maxAttachmentConcurrency: 3,
+    gatewayInternalBaseUrl: "http://127.0.0.1:7830",
+    trustProxy: false,
+    ...overrides,
+  } as GatewayConfig;
+}
+
+function makeFakeServer(upgradeResult: boolean = true) {
+  return {
+    requestIP: mock(() => ({
+      address: "127.0.0.1",
+      family: "IPv4",
+      port: 54000,
+    })),
+    upgrade: mock(() => upgradeResult),
+  } as unknown as import("bun").Server<unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// createSttStreamWebsocketHandler — upgrade handler tests
+// ---------------------------------------------------------------------------
+
+describe("createSttStreamWebsocketHandler", () => {
+  const TEST_TOKEN = mintEdgeToken();
+
+  test("upgrades when token query parameter is valid and required params present", () => {
+    const config = makeConfig();
+    const handler = createSttStreamWebsocketHandler(config);
+    const req = new Request(
+      `http://localhost:7830/v1/stt/stream?token=${TEST_TOKEN}&provider=deepgram&mimeType=audio/webm`,
+      { headers: { upgrade: "websocket" } },
+    );
+    const server = makeFakeServer();
+    const res = handler(req, server);
+
+    expect(res).toBeUndefined();
+    expect(server.upgrade).toHaveBeenCalledTimes(1);
+  });
+
+  test("upgrades when Authorization header is valid", () => {
+    const config = makeConfig();
+    const handler = createSttStreamWebsocketHandler(config);
+    const req = new Request(
+      "http://localhost:7830/v1/stt/stream?provider=deepgram&mimeType=audio/webm",
+      {
+        headers: {
+          upgrade: "websocket",
+          authorization: `Bearer ${TEST_TOKEN}`,
+        },
+      },
+    );
+    const server = makeFakeServer();
+    const res = handler(req, server);
+
+    expect(res).toBeUndefined();
+    expect(server.upgrade).toHaveBeenCalledTimes(1);
+  });
+
+  test("returns 401 when no token is provided", () => {
+    const config = makeConfig();
+    const handler = createSttStreamWebsocketHandler(config);
+    const req = new Request(
+      "http://localhost:7830/v1/stt/stream?provider=deepgram&mimeType=audio/webm",
+      { headers: { upgrade: "websocket" } },
+    );
+    const server = makeFakeServer();
+    const res = handler(req, server);
+
+    expect(res).toBeInstanceOf(Response);
+    expect(res!.status).toBe(401);
+    expect(server.upgrade).not.toHaveBeenCalled();
+  });
+
+  test("returns 401 when token is invalid", () => {
+    const config = makeConfig();
+    const handler = createSttStreamWebsocketHandler(config);
+    const req = new Request(
+      "http://localhost:7830/v1/stt/stream?token=bad-token&provider=deepgram&mimeType=audio/webm",
+      { headers: { upgrade: "websocket" } },
+    );
+    const server = makeFakeServer();
+    const res = handler(req, server);
+
+    expect(res).toBeInstanceOf(Response);
+    expect(res!.status).toBe(401);
+    expect(server.upgrade).not.toHaveBeenCalled();
+  });
+
+  test("returns 401 for service tokens (requires actor principal)", () => {
+    const serviceToken = mintServiceEdgeToken();
+    const config = makeConfig();
+    const handler = createSttStreamWebsocketHandler(config);
+    const req = new Request(
+      `http://localhost:7830/v1/stt/stream?token=${serviceToken}&provider=deepgram&mimeType=audio/webm`,
+      { headers: { upgrade: "websocket" } },
+    );
+    const server = makeFakeServer();
+    const res = handler(req, server);
+
+    expect(res).toBeInstanceOf(Response);
+    expect(res!.status).toBe(401);
+    expect(server.upgrade).not.toHaveBeenCalled();
+  });
+
+  test("returns 400 when provider is missing", () => {
+    const config = makeConfig();
+    const handler = createSttStreamWebsocketHandler(config);
+    const req = new Request(
+      `http://localhost:7830/v1/stt/stream?token=${TEST_TOKEN}&mimeType=audio/webm`,
+      { headers: { upgrade: "websocket" } },
+    );
+    const server = makeFakeServer();
+    const res = handler(req, server);
+
+    expect(res).toBeInstanceOf(Response);
+    expect(res!.status).toBe(400);
+  });
+
+  test("returns 400 when mimeType is missing", () => {
+    const config = makeConfig();
+    const handler = createSttStreamWebsocketHandler(config);
+    const req = new Request(
+      `http://localhost:7830/v1/stt/stream?token=${TEST_TOKEN}&provider=deepgram`,
+      { headers: { upgrade: "websocket" } },
+    );
+    const server = makeFakeServer();
+    const res = handler(req, server);
+
+    expect(res).toBeInstanceOf(Response);
+    expect(res!.status).toBe(400);
+  });
+
+  test("returns 426 when upgrade header is not websocket", () => {
+    const config = makeConfig();
+    const handler = createSttStreamWebsocketHandler(config);
+    const req = new Request(
+      `http://localhost:7830/v1/stt/stream?token=${TEST_TOKEN}&provider=deepgram&mimeType=audio/webm`,
+    );
+    const server = makeFakeServer();
+    const res = handler(req, server);
+
+    expect(res).toBeInstanceOf(Response);
+    expect(res!.status).toBe(426);
+  });
+
+  test("returns 500 when Bun.serve upgrade fails", () => {
+    const config = makeConfig();
+    const handler = createSttStreamWebsocketHandler(config);
+    const req = new Request(
+      `http://localhost:7830/v1/stt/stream?token=${TEST_TOKEN}&provider=deepgram&mimeType=audio/webm`,
+      { headers: { upgrade: "websocket" } },
+    );
+    const server = makeFakeServer(false); // upgrade returns false
+    const res = handler(req, server);
+
+    expect(res).toBeInstanceOf(Response);
+    expect(res!.status).toBe(500);
+  });
+
+  test("allows unauthenticated upgrade when auth is disabled (dev bypass)", () => {
+    const config = makeConfig({ runtimeProxyRequireAuth: false });
+    const handler = createSttStreamWebsocketHandler(config);
+    const req = new Request(
+      "http://localhost:7830/v1/stt/stream?provider=deepgram&mimeType=audio/webm",
+      { headers: { upgrade: "websocket" } },
+    );
+    const server = makeFakeServer();
+    const res = handler(req, server);
+
+    expect(res).toBeUndefined();
+    expect(server.upgrade).toHaveBeenCalledTimes(1);
+  });
+
+  test("returns 400 when auth is disabled but provider is missing", () => {
+    const config = makeConfig({ runtimeProxyRequireAuth: false });
+    const handler = createSttStreamWebsocketHandler(config);
+    const req = new Request(
+      "http://localhost:7830/v1/stt/stream?mimeType=audio/webm",
+      { headers: { upgrade: "websocket" } },
+    );
+    const server = makeFakeServer();
+    const res = handler(req, server);
+
+    expect(res).toBeInstanceOf(Response);
+    expect(res!.status).toBe(400);
+  });
+
+  test("passes sampleRate to socket data when provided", () => {
+    const config = makeConfig();
+    const handler = createSttStreamWebsocketHandler(config);
+    const req = new Request(
+      `http://localhost:7830/v1/stt/stream?token=${TEST_TOKEN}&provider=deepgram&mimeType=audio/webm&sampleRate=16000`,
+      { headers: { upgrade: "websocket" } },
+    );
+    const server = makeFakeServer();
+    handler(req, server);
+
+    const upgradeCall = (server.upgrade as ReturnType<typeof mock>).mock
+      .calls[0] as unknown[];
+    const opts = upgradeCall[1] as { data: SttStreamSocketData };
+    expect(opts.data.provider).toBe("deepgram");
+    expect(opts.data.mimeType).toBe("audio/webm");
+    expect(opts.data.sampleRate).toBe(16000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getSttStreamWebsocketHandlers — WS lifecycle tests
+// ---------------------------------------------------------------------------
+
+describe("getSttStreamWebsocketHandlers", () => {
+  function createFakeDownstreamWs(data: Partial<SttStreamSocketData> = {}) {
+    const sent: (string | Uint8Array)[] = [];
+    const closes: { code: number; reason: string }[] = [];
+    const fullData: SttStreamSocketData = {
+      wsType: "stt-stream",
+      config: makeConfig(),
+      provider: "deepgram",
+      mimeType: "audio/webm",
+      ...data,
+    };
+    return {
+      data: fullData,
+      sent,
+      closes,
+      send: mock((msg: string | Uint8Array) => {
+        sent.push(msg);
+      }),
+      close: mock((code?: number, reason?: string) => {
+        closes.push({ code: code ?? 1000, reason: reason ?? "" });
+      }),
+    };
+  }
+
+  test("open handler initializes pending messages buffer", () => {
+    const handlers = getSttStreamWebsocketHandlers();
+    const ws = createFakeDownstreamWs();
+
+    // The open handler creates a WebSocket to upstream which will fail in test,
+    // but pendingMessages should be initialized before that happens.
+    try {
+      handlers.open(ws as never);
+    } catch {
+      // WebSocket constructor may throw in test environment
+    }
+
+    expect(ws.data.pendingMessages).toBeDefined();
+  });
+
+  test("message handler buffers messages when upstream is not connected", () => {
+    const handlers = getSttStreamWebsocketHandlers();
+    const ws = createFakeDownstreamWs();
+    ws.data.pendingMessages = [];
+
+    handlers.message(ws as never, "test-audio-frame");
+
+    expect(ws.data.pendingMessages).toContain("test-audio-frame");
+  });
+
+  test("message handler closes connection on buffer overflow", () => {
+    const handlers = getSttStreamWebsocketHandlers();
+    const ws = createFakeDownstreamWs();
+    ws.data.pendingMessages = new Array(100).fill("x"); // At MAX_PENDING_MESSAGES
+
+    handlers.message(ws as never, "overflow-frame");
+
+    expect(ws.close).toHaveBeenCalledWith(1008, "Buffer overflow");
+  });
+
+  test("close handler cleans up pending messages and closes upstream", () => {
+    const handlers = getSttStreamWebsocketHandlers();
+    const ws = createFakeDownstreamWs();
+    ws.data.pendingMessages = ["some-data"];
+
+    const fakeUpstream = {
+      readyState: WebSocket.OPEN,
+      close: mock(() => {}),
+    };
+    ws.data.upstream = fakeUpstream as unknown as WebSocket;
+
+    handlers.close(ws as never, 1000, "normal");
+
+    expect(ws.data.pendingMessages).toBeUndefined();
+    expect(fakeUpstream.close).toHaveBeenCalledWith(1000, "normal");
+  });
+
+  test("close handler is safe when upstream is already closed", () => {
+    const handlers = getSttStreamWebsocketHandlers();
+    const ws = createFakeDownstreamWs();
+
+    const fakeUpstream = {
+      readyState: WebSocket.CLOSED,
+      close: mock(() => {}),
+    };
+    ws.data.upstream = fakeUpstream as unknown as WebSocket;
+
+    handlers.close(ws as never, 1000, "normal");
+
+    expect(fakeUpstream.close).not.toHaveBeenCalled();
+  });
+});

--- a/gateway/src/http/routes/stt-stream-websocket.ts
+++ b/gateway/src/http/routes/stt-stream-websocket.ts
@@ -1,0 +1,270 @@
+import {
+  validateEdgeToken,
+  mintServiceToken,
+} from "../../auth/token-exchange.js";
+import { parseSub } from "../../auth/subject.js";
+import type { GatewayConfig } from "../../config.js";
+import { getLogger } from "../../logger.js";
+
+const log = getLogger("stt-stream-ws");
+
+// Cap buffered messages to prevent unbounded memory growth if upstream stalls
+const MAX_PENDING_MESSAGES = 100;
+
+export type SttStreamSocketData = {
+  wsType: "stt-stream";
+  config: GatewayConfig;
+  /** Provider identifier for the STT streaming session (e.g. "deepgram", "google-gemini"). */
+  provider: string;
+  /** MIME type of the audio being streamed (e.g. "audio/webm;codecs=opus"). */
+  mimeType: string;
+  /** Sample rate in Hz, when applicable. */
+  sampleRate?: number;
+  upstream?: WebSocket;
+  pendingMessages?: (string | ArrayBuffer | Uint8Array)[];
+};
+
+/**
+ * Create a WebSocket upgrade handler that proxies client STT audio frames
+ * to the runtime's /v1/stt/stream endpoint.
+ *
+ * The gateway authenticates the downstream client using an edge JWT and
+ * then opens an upstream connection to the runtime with a short-lived
+ * gateway service token. This keeps the runtime unreachable from the
+ * public internet while allowing authenticated clients to stream audio
+ * for real-time transcription.
+ */
+export function createSttStreamWebsocketHandler(config: GatewayConfig) {
+  return function handleUpgrade(
+    req: Request,
+    server: import("bun").Server<unknown>,
+  ): Response | undefined {
+    if (req.headers.get("upgrade")?.toLowerCase() !== "websocket") {
+      return new Response("Upgrade Required", { status: 426 });
+    }
+
+    const url = new URL(req.url);
+
+    // ── Auth ──
+    // STT streaming is an authenticated, assistant-scoped path. The
+    // client must present a valid edge JWT (actor principal). Unlike
+    // browser-relay, STT streaming does not have an auth-bypass mode —
+    // fail closed.
+    if (!config.runtimeProxyRequireAuth) {
+      // When runtime proxy auth is globally disabled (dev bypass), we
+      // still allow the upgrade but skip token validation.
+      const provider = url.searchParams.get("provider");
+      const mimeType = url.searchParams.get("mimeType");
+
+      if (!provider || !mimeType) {
+        return new Response(
+          "Missing required query parameters: provider, mimeType",
+          {
+            status: 400,
+          },
+        );
+      }
+
+      const sampleRateRaw = url.searchParams.get("sampleRate");
+      const sampleRate = sampleRateRaw
+        ? parseInt(sampleRateRaw, 10)
+        : undefined;
+
+      const upgraded = server.upgrade(req, {
+        data: {
+          wsType: "stt-stream",
+          config,
+          provider,
+          mimeType,
+          sampleRate,
+        } satisfies SttStreamSocketData,
+      });
+
+      if (!upgraded) {
+        return new Response("WebSocket upgrade failed", { status: 500 });
+      }
+      return undefined;
+    }
+
+    const authHeader = req.headers.get("authorization");
+    const queryToken = url.searchParams.get("token");
+    const rawToken = authHeader
+      ? authHeader.toLowerCase().startsWith("bearer ")
+        ? authHeader.slice(7)
+        : null
+      : queryToken;
+
+    if (!rawToken) {
+      log.warn("STT stream WS: no token provided");
+      return new Response("Unauthorized", { status: 401 });
+    }
+
+    const result = validateEdgeToken(rawToken);
+    if (!result.ok) {
+      log.warn(
+        { reason: result.reason },
+        "STT stream WS: authentication failed",
+      );
+      return new Response("Unauthorized", { status: 401 });
+    }
+
+    // Require an actor principal — service tokens are not allowed on
+    // this client-facing path.
+    const parsed = parseSub(result.claims.sub);
+    if (
+      !parsed.ok ||
+      parsed.principalType !== "actor" ||
+      !parsed.actorPrincipalId
+    ) {
+      log.warn(
+        {
+          reason: parsed.ok ? "missing_actor_principal" : parsed.reason,
+          sub: result.claims.sub,
+        },
+        "STT stream WS: denied token without actor principal",
+      );
+      return new Response("Unauthorized", { status: 401 });
+    }
+
+    // ── Required query parameters ──
+    const provider = url.searchParams.get("provider");
+    const mimeType = url.searchParams.get("mimeType");
+
+    if (!provider || !mimeType) {
+      return new Response(
+        "Missing required query parameters: provider, mimeType",
+        {
+          status: 400,
+        },
+      );
+    }
+
+    const sampleRateRaw = url.searchParams.get("sampleRate");
+    const sampleRate = sampleRateRaw ? parseInt(sampleRateRaw, 10) : undefined;
+
+    const upgraded = server.upgrade(req, {
+      data: {
+        wsType: "stt-stream",
+        config,
+        provider,
+        mimeType,
+        sampleRate,
+      } satisfies SttStreamSocketData,
+    });
+
+    if (!upgraded) {
+      return new Response("WebSocket upgrade failed", { status: 500 });
+    }
+
+    // Return undefined to indicate upgrade was handled
+    return undefined;
+  };
+}
+
+/**
+ * WebSocket handler config for Bun.serve() that proxies STT audio
+ * frames to the runtime's /v1/stt/stream endpoint.
+ */
+export function getSttStreamWebsocketHandlers() {
+  return {
+    open(ws: import("bun").ServerWebSocket<SttStreamSocketData>) {
+      const { config, provider, mimeType, sampleRate } = ws.data;
+
+      // Initialize message buffer for frames arriving before upstream connects
+      ws.data.pendingMessages = [];
+
+      const runtimeBase = config.assistantRuntimeBaseUrl.replace(/^http/, "ws");
+      const upstreamToken = mintServiceToken();
+      const query = new URLSearchParams({
+        token: upstreamToken,
+        provider,
+        mimeType,
+      });
+      if (sampleRate !== undefined) {
+        query.set("sampleRate", String(sampleRate));
+      }
+      const upstreamUrl = `${runtimeBase}/v1/stt/stream?${query.toString()}`;
+      const logSafeUpstreamUrl =
+        `${runtimeBase}/v1/stt/stream?token=<redacted>&provider=${provider}&mimeType=${encodeURIComponent(mimeType)}` +
+        (sampleRate !== undefined ? `&sampleRate=${sampleRate}` : "");
+
+      log.info(
+        { upstreamUrl: logSafeUpstreamUrl, provider, mimeType, sampleRate },
+        "Opening upstream STT stream WS to runtime",
+      );
+
+      const upstream = new WebSocket(upstreamUrl);
+      ws.data.upstream = upstream;
+
+      upstream.addEventListener("open", () => {
+        log.info({ provider }, "Upstream STT stream WS connected");
+        const pending = ws.data.pendingMessages;
+        if (pending) {
+          for (const msg of pending) {
+            upstream.send(msg);
+          }
+          ws.data.pendingMessages = undefined;
+        }
+      });
+
+      upstream.addEventListener("message", (event) => {
+        // Forward runtime transcription events -> client
+        const data =
+          typeof event.data === "string"
+            ? event.data
+            : new Uint8Array(event.data as ArrayBuffer);
+        ws.send(data);
+      });
+
+      upstream.addEventListener("close", (event) => {
+        log.info(
+          { code: event.code, provider },
+          "Upstream STT stream WS closed",
+        );
+        ws.close(event.code, event.reason);
+      });
+
+      upstream.addEventListener("error", (event) => {
+        log.error({ error: event, provider }, "Upstream STT stream WS error");
+        ws.close(1011, "Upstream error");
+      });
+    },
+
+    message(
+      ws: import("bun").ServerWebSocket<SttStreamSocketData>,
+      message: string | ArrayBuffer | Uint8Array,
+    ) {
+      // Forward client audio frames -> runtime
+      const upstream = ws.data.upstream;
+      if (upstream && upstream.readyState === WebSocket.OPEN) {
+        upstream.send(message);
+      } else if (ws.data.pendingMessages) {
+        if (ws.data.pendingMessages.length >= MAX_PENDING_MESSAGES) {
+          log.warn(
+            "STT stream pending message buffer overflow — closing connection",
+          );
+          ws.close(1008, "Buffer overflow");
+          return;
+        }
+        ws.data.pendingMessages.push(message);
+      }
+    },
+
+    close(
+      ws: import("bun").ServerWebSocket<SttStreamSocketData>,
+      code: number,
+      reason: string,
+    ) {
+      const { upstream, provider } = ws.data;
+      log.info({ code, reason, provider }, "STT stream downstream WS closed");
+      ws.data.pendingMessages = undefined;
+      if (
+        upstream &&
+        (upstream.readyState === WebSocket.OPEN ||
+          upstream.readyState === WebSocket.CONNECTING)
+      ) {
+        upstream.close(code, reason);
+      }
+    },
+  };
+}

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -39,6 +39,11 @@ import {
   getMediaStreamWebsocketHandlers,
   type MediaStreamSocketData,
 } from "./http/routes/twilio-media-websocket.js";
+import {
+  createSttStreamWebsocketHandler,
+  getSttStreamWebsocketHandlers,
+  type SttStreamSocketData,
+} from "./http/routes/stt-stream-websocket.js";
 import { createWhatsAppWebhookHandler } from "./http/routes/whatsapp-webhook.js";
 import { createWhatsAppDeliverHandler } from "./http/routes/whatsapp-deliver.js";
 import { createEmailWebhookHandler } from "./http/routes/email-webhook.js";
@@ -176,6 +181,14 @@ function isMediaStreamSocketData(data: unknown): data is MediaStreamSocketData {
   );
 }
 
+function isSttStreamSocketData(data: unknown): data is SttStreamSocketData {
+  return (
+    !!data &&
+    typeof data === "object" &&
+    (data as { wsType?: unknown }).wsType === "stt-stream"
+  );
+}
+
 function getClientIp(
   req: Request,
   server: ReturnType<typeof Bun.serve>,
@@ -254,9 +267,11 @@ async function main() {
     configFile: configFileCache,
   });
   const handleBrowserRelayWs = createBrowserRelayWebsocketHandler(config);
+  const handleSttStreamWs = createSttStreamWebsocketHandler(config);
   const twilioRelayWebsocketHandlers = getRelayWebsocketHandlers();
   const twilioMediaStreamWebsocketHandlers = getMediaStreamWebsocketHandlers();
   const browserRelayWebsocketHandlers = getBrowserRelayWebsocketHandlers();
+  const sttStreamWebsocketHandlers = getSttStreamWebsocketHandlers();
   const { handler: handleWhatsAppWebhook, dedupCache: whatsappDedupCache } =
     createWhatsAppWebhookHandler(config, {
       credentials: credentialCache,
@@ -1067,6 +1082,10 @@ async function main() {
           twilioMediaStreamWebsocketHandlers.open(ws as never);
           return;
         }
+        if (isSttStreamSocketData(ws.data)) {
+          sttStreamWebsocketHandlers.open(ws as never);
+          return;
+        }
         twilioRelayWebsocketHandlers.open(ws as never);
       },
       message(ws, message) {
@@ -1078,6 +1097,10 @@ async function main() {
           twilioMediaStreamWebsocketHandlers.message(ws as never, message);
           return;
         }
+        if (isSttStreamSocketData(ws.data)) {
+          sttStreamWebsocketHandlers.message(ws as never, message);
+          return;
+        }
         twilioRelayWebsocketHandlers.message(ws as never, message);
       },
       close(ws, code, reason) {
@@ -1087,6 +1110,10 @@ async function main() {
         }
         if (isMediaStreamSocketData(ws.data)) {
           twilioMediaStreamWebsocketHandlers.close(ws as never, code, reason);
+          return;
+        }
+        if (isSttStreamSocketData(ws.data)) {
+          sttStreamWebsocketHandlers.close(ws as never, code, reason);
           return;
         }
         twilioRelayWebsocketHandlers.close(ws as never, code, reason);
@@ -1219,6 +1246,12 @@ async function main() {
 
       if (config.runtimeProxyEnabled && url.pathname === "/v1/browser-relay") {
         const upgradeResult = handleBrowserRelayWs(req, server);
+        if (upgradeResult !== undefined) return upgradeResult;
+        return undefined as unknown as Response;
+      }
+
+      if (url.pathname === "/v1/stt/stream") {
+        const upgradeResult = handleSttStreamWs(req, server);
         if (upgradeResult !== undefined) return upgradeResult;
         return undefined as unknown as Response;
       }

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -870,6 +870,88 @@ export function buildSchema(): Record<string, unknown> {
           },
         },
       },
+      "/v1/stt/stream": {
+        get: {
+          summary: "STT stream WebSocket",
+          description:
+            "Accepts a WebSocket upgrade for real-time speech-to-text streaming. Authenticates the client using an edge JWT (actor principal) and proxies audio frames bidirectionally to the assistant runtime's /v1/stt/stream endpoint using a gateway service token. Requires provider and mimeType query parameters.",
+          operationId: "sttStreamWebsocket",
+          security: [{ BearerAuth: [] }],
+          parameters: [
+            {
+              name: "provider",
+              in: "query",
+              required: true,
+              schema: { type: "string" },
+              description:
+                "STT provider identifier (e.g. 'deepgram', 'google-gemini').",
+            },
+            {
+              name: "mimeType",
+              in: "query",
+              required: true,
+              schema: { type: "string" },
+              description:
+                "MIME type of the audio being streamed (e.g. 'audio/webm;codecs=opus').",
+            },
+            {
+              name: "sampleRate",
+              in: "query",
+              required: false,
+              schema: { type: "integer" },
+              description: "Audio sample rate in Hz, when applicable.",
+            },
+            {
+              name: "token",
+              in: "query",
+              required: false,
+              schema: { type: "string" },
+              description:
+                "Edge JWT for authentication (alternative to Authorization header, since browser WebSocket upgrades cannot set custom headers).",
+            },
+          ],
+          responses: {
+            "101": {
+              description:
+                "WebSocket upgrade successful — bidirectional STT audio/transcription frame proxying begins.",
+            },
+            "400": {
+              description:
+                "Missing required query parameters (provider, mimeType)",
+              content: {
+                "text/plain": {
+                  schema: { type: "string" },
+                },
+              },
+            },
+            "401": {
+              description: "Unauthorized — missing or invalid token",
+              content: {
+                "text/plain": {
+                  schema: { type: "string" },
+                },
+              },
+            },
+            "426": {
+              description:
+                "Upgrade Required — request is not a WebSocket upgrade",
+              content: {
+                "text/plain": {
+                  schema: { type: "string" },
+                },
+              },
+            },
+            "500": {
+              description: "WebSocket upgrade failed",
+              content: {
+                "text/plain": {
+                  schema: { type: "string" },
+                },
+              },
+            },
+          },
+        },
+      },
       "/webhooks/oauth/callback": {
         get: {
           summary: "OAuth2 callback",


### PR DESCRIPTION
## Summary
- Add gateway WebSocket upgrade route for STT streaming with JWT auth and runtime proxy
- Register runtime WebSocket upgrade handling for /v1/stt/stream with gateway-service token verification
- Add minimal session stub for deploy-safe endpoint before provider adapters land

Part of plan: streaming-stt-chat-messages.md (PR 2 of 9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25210" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
