### PR TITLE
fix(macos): handle all speech auth states in STT fallback prompt

### DIFF
--- a/clients/macos/vellum-assistant/App/VoiceInputManager.swift
+++ b/clients/macos/vellum-assistant/App/VoiceInputManager.swift
@@ -1160,21 +1160,31 @@ final class VoiceInputManager {
         return AudioWavEncoder.encode(pcmData: pcmData, format: wavFormat)
     }
 
-    /// Show the speech recognition permission prompt after an STT transcription failure.
-    /// When speech recognition is `.notDetermined`, this primes the user with a first-use
-    /// overlay before requesting authorization. When denied, it directs them to System Settings.
+    /// Show appropriate feedback after an STT transcription failure with no native fallback.
+    ///
+    /// - `.authorized`: Speech recognition is already granted — the failure is a transient
+    ///   STT service error (missing API key, network issue, silence). Show a generic error.
+    /// - `.notDetermined`: Show a speech-recognition-specific primer, then request
+    ///   authorization. If granted, the next recording will have native fallback.
+    /// - `.denied` / `.restricted`: Direct the user to System Settings.
     private func showSpeechRecognitionFallbackPrompt() {
         let speechStatus = speechRecognizerAdapter.authorizationStatus()
-        if speechStatus == .notDetermined {
-            // Show the first-use primer so the user understands why we're asking,
-            // then request authorization. If granted, the next recording attempt
-            // will have native partials + fallback.
-            permissionOverlay.show(kind: .firstUse, onDismiss: {}, onContinue: { [weak self] in
+        switch speechStatus {
+        case .authorized:
+            // Speech recognition is already authorized — the failure is not a permission
+            // issue. Show a generic transcription error in the dictation overlay.
+            overlayWindow.show(state: .error("Transcription failed. Please try again."))
+        case .notDetermined:
+            // Show a speech-recognition-specific fallback prompt, then request authorization.
+            // If granted, the next recording will have native partials + fallback.
+            permissionOverlay.show(kind: .speechFallback, onDismiss: {}, onContinue: { [weak self] in
                 self?.speechRecognizerAdapter.requestAuthorization { _ in }
             })
-        } else {
+        case .denied, .restricted:
             // Speech recognition was previously denied — direct to System Settings.
             permissionOverlay.show(kind: .denied(.speechRecognition), onDismiss: {}, onContinue: {})
+        @unknown default:
+            overlayWindow.show(state: .error("Transcription failed. Please try again."))
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Voice/PermissionPromptOverlay.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/PermissionPromptOverlay.swift
@@ -20,6 +20,9 @@ final class PermissionPromptOverlay {
         case firstUse
         /// Post-denial prompt directing to System Settings.
         case denied(DeniedPermission)
+        /// Speech recognition fallback prompt shown after an STT service failure.
+        /// Explains that enabling speech recognition improves reliability.
+        case speechFallback
     }
 
     enum DeniedPermission {
@@ -39,6 +42,17 @@ final class PermissionPromptOverlay {
         case .firstUse:
             contentView = AnyView(FirstUsePromptView(
                 sttConfigured: STTProviderRegistry.isServiceConfigured,
+                onDismiss: { [weak self] in
+                    self?.dismiss()
+                    onDismiss()
+                },
+                onContinue: { [weak self] in
+                    self?.dismiss()
+                    onContinue()
+                }
+            ))
+        case .speechFallback:
+            contentView = AnyView(SpeechFallbackPromptView(
                 onDismiss: { [weak self] in
                     self?.dismiss()
                     onDismiss()
@@ -161,6 +175,56 @@ private struct FirstUsePromptView: View {
                     onDismiss()
                 }
                 VButton(label: "Continue", style: .primary, size: .compact) {
+                    onContinue()
+                }
+            }
+            .padding(.horizontal, VSpacing.xl)
+            .padding(.bottom, VSpacing.lg)
+        }
+        .frame(width: 320)
+        .background(VColor.surfaceOverlay)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.md)
+                .stroke(VColor.borderBase, lineWidth: 1)
+        )
+    }
+}
+
+// MARK: - Speech Fallback Prompt
+
+/// Shown after an STT service failure to suggest enabling native speech recognition
+/// as a reliable fallback. Uses informational styling (not error) since the user
+/// hasn't done anything wrong — their cloud STT provider just didn't work.
+private struct SpeechFallbackPromptView: View {
+    let onDismiss: () -> Void
+    let onContinue: () -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            VStack(spacing: VSpacing.sm) {
+                VIconView(.audioWaveform, size: 20)
+                    .foregroundStyle(VColor.primaryBase)
+
+                Text("Enable Speech Recognition")
+                    .font(VFont.titleSmall)
+                    .foregroundStyle(VColor.contentDefault)
+
+                Text("Improves transcription accuracy and provides a reliable fallback when the cloud service is unavailable.")
+                    .font(VFont.bodyMediumLighter)
+                    .foregroundStyle(VColor.contentSecondary)
+                    .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .padding(.horizontal, VSpacing.xl)
+            .padding(.top, VSpacing.xl)
+            .padding(.bottom, VSpacing.lg)
+
+            HStack(spacing: VSpacing.sm) {
+                VButton(label: "Not Now", style: .outlined, size: .compact) {
+                    onDismiss()
+                }
+                VButton(label: "Enable", style: .primary, size: .compact) {
                     onContinue()
                 }
             }


### PR DESCRIPTION
## Summary
- Add `.speechFallback` overlay kind with speech-recognition-specific copy ("Enable Speech Recognition" / "Improves transcription accuracy...") so the user sees the right context instead of the mic-focused first-use primer
- Handle `.authorized` state: show generic "Transcription failed" error instead of misleading "Speech Recognition Required" prompt (speech is already granted — the issue is a transient STT failure)
- Handle `.denied`/`.restricted`: direct to System Settings (unchanged)
- Handle `@unknown default`: fall back to generic error

## Original prompt
fix-stt-fallback-prompt-states.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25211" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
