### PR TITLE
assistant: implement google conversation streaming adapter for partial transcript updates

### DIFF
--- a/assistant/src/providers/speech-to-text/google-gemini-stream.test.ts
+++ b/assistant/src/providers/speech-to-text/google-gemini-stream.test.ts
@@ -1,0 +1,469 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import type { SttStreamServerEvent } from "../../stt/types.js";
+import { GoogleGeminiStreamingTranscriber } from "./google-gemini-stream.js";
+
+const TEST_API_KEY = "google-test-key-for-streaming-tests";
+
+// ---------------------------------------------------------------------------
+// Mock helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a mock GoogleGenAI client whose `models.generateContent` returns
+ * sequential responses on each call, or rejects with an error.
+ */
+function mockGenAIClient(
+  responses: Array<{ text?: string } | { error: Error }>,
+) {
+  let callIndex = 0;
+
+  const generateContent = mock(() => {
+    const entry = responses[callIndex] ?? responses[responses.length - 1];
+    callIndex++;
+
+    if ("error" in entry) {
+      return Promise.reject(entry.error);
+    }
+    return Promise.resolve(entry);
+  });
+
+  return { generateContent, client: { models: { generateContent } } };
+}
+
+/**
+ * Create a transcriber with an injected mock client and a very short
+ * poll interval for fast test execution.
+ */
+function createTranscriberWithMock(
+  responses: Array<{ text?: string } | { error: Error }>,
+  options?: { pollIntervalMs?: number },
+): {
+  transcriber: GoogleGeminiStreamingTranscriber;
+  generateContent: ReturnType<typeof mock>;
+} {
+  const { client, generateContent } = mockGenAIClient(responses);
+  const transcriber = new GoogleGeminiStreamingTranscriber(TEST_API_KEY, {
+    pollIntervalMs: options?.pollIntervalMs ?? 10,
+  });
+
+  // Replace the internal client with our mock
+  (transcriber as unknown as { client: unknown }).client = client;
+
+  return { transcriber, generateContent };
+}
+
+/**
+ * Collect all events emitted by a transcriber into an array.
+ */
+function collectEvents(
+  transcriber: GoogleGeminiStreamingTranscriber,
+): SttStreamServerEvent[] {
+  const events: SttStreamServerEvent[] = [];
+  void transcriber.start((event) => events.push(event));
+  return events;
+}
+
+/**
+ * Wait for a condition to become true, polling at a short interval.
+ */
+async function waitFor(
+  condition: () => boolean,
+  timeoutMs = 2_000,
+): Promise<void> {
+  const start = Date.now();
+  while (!condition()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error("waitFor timed out");
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("GoogleGeminiStreamingTranscriber", () => {
+  // -----------------------------------------------------------------------
+  // Lifecycle
+  // -----------------------------------------------------------------------
+
+  describe("lifecycle", () => {
+    test("start() registers event callback without error", async () => {
+      const { transcriber } = createTranscriberWithMock([{ text: "" }]);
+      await transcriber.start(() => {});
+      // No error = success
+    });
+
+    test("start() throws if called twice", async () => {
+      const { transcriber } = createTranscriberWithMock([{ text: "" }]);
+      await transcriber.start(() => {});
+
+      await expect(transcriber.start(() => {})).rejects.toThrow(
+        "already started",
+      );
+    });
+
+    test("sendAudio() throws if called before start()", () => {
+      const { transcriber } = createTranscriberWithMock([{ text: "" }]);
+
+      expect(() =>
+        transcriber.sendAudio(Buffer.from("audio"), "audio/webm"),
+      ).toThrow("before start()");
+    });
+
+    test("sendAudio() is silently ignored after stop()", async () => {
+      const { transcriber, generateContent } = createTranscriberWithMock([
+        { text: "final" },
+      ]);
+      const events = collectEvents(transcriber);
+
+      transcriber.stop();
+
+      await waitFor(() => events.some((e) => e.type === "closed"));
+
+      // Sending audio after stop should not throw or trigger new requests.
+      transcriber.sendAudio(Buffer.from("late-audio"), "audio/webm");
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      // Only one generateContent call for the final (from stop's emitFinal).
+      // The late audio should not have triggered an additional call.
+      // Actually no audio was sent before stop, so the final emits from
+      // lastEmittedText (empty) without a batch call.
+      expect(generateContent).not.toHaveBeenCalled();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Progressive partial updates
+  // -----------------------------------------------------------------------
+
+  describe("partial updates", () => {
+    test("emits partial events as audio accumulates", async () => {
+      const { transcriber } = createTranscriberWithMock([
+        { text: "Hello" },
+        { text: "Hello world" },
+        { text: "Hello world test" },
+      ]);
+      const events = collectEvents(transcriber);
+
+      transcriber.sendAudio(Buffer.from("chunk-1"), "audio/webm");
+      await waitFor(() => events.some((e) => e.type === "partial"));
+
+      transcriber.sendAudio(Buffer.from("chunk-2"), "audio/webm");
+      await waitFor(
+        () => events.filter((e) => e.type === "partial").length >= 2,
+      );
+
+      transcriber.stop();
+      await waitFor(() => events.some((e) => e.type === "closed"));
+
+      const partials = events.filter((e) => e.type === "partial");
+      expect(partials.length).toBeGreaterThanOrEqual(1);
+      expect(partials[0]).toEqual({ type: "partial", text: "Hello" });
+    });
+
+    test("does not emit partial when transcript has not changed", async () => {
+      const { transcriber } = createTranscriberWithMock([
+        { text: "Hello" },
+        { text: "Hello" }, // same as before
+        { text: "Hello world" },
+      ]);
+      const events = collectEvents(transcriber);
+
+      transcriber.sendAudio(Buffer.from("chunk-1"), "audio/webm");
+      await waitFor(() => events.some((e) => e.type === "partial"));
+
+      transcriber.sendAudio(Buffer.from("chunk-2"), "audio/webm");
+      // Wait a bit for the second poll
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      transcriber.sendAudio(Buffer.from("chunk-3"), "audio/webm");
+      await waitFor(
+        () => events.filter((e) => e.type === "partial").length >= 2,
+      );
+
+      transcriber.stop();
+      await waitFor(() => events.some((e) => e.type === "closed"));
+
+      const partials = events.filter((e) => e.type === "partial");
+      // Should have "Hello" and "Hello world", but NOT a duplicate "Hello"
+      const texts = partials.map((e) => (e.type === "partial" ? e.text : ""));
+      expect(texts).toContain("Hello");
+      expect(texts).toContain("Hello world");
+      // No duplicates
+      const uniqueTexts = [...new Set(texts)];
+      expect(uniqueTexts.length).toBe(texts.length);
+    });
+
+    test("does not emit partial when transcript regresses (shorter text)", async () => {
+      const { transcriber } = createTranscriberWithMock([
+        { text: "Hello world" },
+        { text: "Hello" }, // regression — shorter
+        { text: "Hello world again" },
+      ]);
+      const events = collectEvents(transcriber);
+
+      transcriber.sendAudio(Buffer.from("chunk-1"), "audio/webm");
+      await waitFor(() => events.some((e) => e.type === "partial"));
+
+      transcriber.sendAudio(Buffer.from("chunk-2"), "audio/webm");
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      transcriber.sendAudio(Buffer.from("chunk-3"), "audio/webm");
+      await waitFor(
+        () => events.filter((e) => e.type === "partial").length >= 2,
+      );
+
+      transcriber.stop();
+      await waitFor(() => events.some((e) => e.type === "closed"));
+
+      const partials = events.filter((e) => e.type === "partial");
+      const texts = partials.map((e) => (e.type === "partial" ? e.text : ""));
+
+      // "Hello" (regression) should NOT appear as a partial
+      expect(texts).toContain("Hello world");
+      expect(texts).not.toContain("Hello");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Final event
+  // -----------------------------------------------------------------------
+
+  describe("final event", () => {
+    test("emits final event with complete transcript on stop", async () => {
+      const { transcriber } = createTranscriberWithMock([
+        { text: "partial one" },
+        { text: "full transcript" },
+      ]);
+      const events = collectEvents(transcriber);
+
+      transcriber.sendAudio(Buffer.from("chunk-1"), "audio/webm");
+      await waitFor(() => events.some((e) => e.type === "partial"));
+
+      transcriber.stop();
+      await waitFor(() => events.some((e) => e.type === "closed"));
+
+      const finals = events.filter((e) => e.type === "final");
+      expect(finals.length).toBe(1);
+      expect(finals[0]).toEqual({ type: "final", text: "full transcript" });
+    });
+
+    test("emits final with last known partial when no audio was sent", async () => {
+      const { transcriber } = createTranscriberWithMock([{ text: "" }]);
+      const events = collectEvents(transcriber);
+
+      transcriber.stop();
+      await waitFor(() => events.some((e) => e.type === "closed"));
+
+      const finals = events.filter((e) => e.type === "final");
+      expect(finals.length).toBe(1);
+      expect(finals[0]).toEqual({ type: "final", text: "" });
+    });
+
+    test("emits closed event after final", async () => {
+      const { transcriber } = createTranscriberWithMock([{ text: "done" }]);
+      const events = collectEvents(transcriber);
+
+      transcriber.sendAudio(Buffer.from("audio"), "audio/webm");
+      await waitFor(() => events.some((e) => e.type === "partial"));
+
+      transcriber.stop();
+      await waitFor(() => events.some((e) => e.type === "closed"));
+
+      const finalIdx = events.findIndex((e) => e.type === "final");
+      const closedIdx = events.findIndex((e) => e.type === "closed");
+      expect(finalIdx).toBeGreaterThanOrEqual(0);
+      expect(closedIdx).toBeGreaterThan(finalIdx);
+    });
+
+    test("stop() is idempotent", async () => {
+      const { transcriber } = createTranscriberWithMock([{ text: "done" }]);
+      const events = collectEvents(transcriber);
+
+      transcriber.sendAudio(Buffer.from("audio"), "audio/webm");
+      await waitFor(() => events.some((e) => e.type === "partial"));
+
+      transcriber.stop();
+      transcriber.stop(); // second stop should be a no-op
+
+      await waitFor(() => events.some((e) => e.type === "closed"));
+
+      // Only one closed event
+      const closedEvents = events.filter((e) => e.type === "closed");
+      expect(closedEvents.length).toBe(1);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Error handling
+  // -----------------------------------------------------------------------
+
+  describe("error handling", () => {
+    test("transient poll error emits error event but does not close session", async () => {
+      const { transcriber } = createTranscriberWithMock([
+        { error: new Error("transient network failure") },
+        { text: "recovered" },
+        { text: "recovered" },
+      ]);
+      const events = collectEvents(transcriber);
+
+      transcriber.sendAudio(Buffer.from("chunk-1"), "audio/webm");
+      await waitFor(() => events.some((e) => e.type === "error"));
+
+      const errors = events.filter((e) => e.type === "error");
+      expect(errors.length).toBe(1);
+      expect(errors[0]).toEqual({
+        type: "error",
+        category: "provider-error",
+        message: "transient network failure",
+      });
+
+      // Session is still alive — send more audio
+      transcriber.sendAudio(Buffer.from("chunk-2"), "audio/webm");
+      await waitFor(() => events.some((e) => e.type === "partial"));
+
+      transcriber.stop();
+      await waitFor(() => events.some((e) => e.type === "closed"));
+
+      expect(events.some((e) => e.type === "final")).toBe(true);
+    });
+
+    test("final batch error emits error then falls back to last partial", async () => {
+      const { transcriber } = createTranscriberWithMock([
+        { text: "partial before error" },
+        { error: new Error("final request failed") },
+      ]);
+      const events = collectEvents(transcriber);
+
+      transcriber.sendAudio(Buffer.from("audio"), "audio/webm");
+      await waitFor(() => events.some((e) => e.type === "partial"));
+
+      transcriber.stop();
+      await waitFor(() => events.some((e) => e.type === "closed"));
+
+      const finals = events.filter((e) => e.type === "final");
+      expect(finals.length).toBe(1);
+      // Should fall back to last emitted partial text
+      expect(finals[0]).toEqual({
+        type: "final",
+        text: "partial before error",
+      });
+
+      // An error event should have been emitted before the final fallback
+      const errors = events.filter((e) => e.type === "error");
+      expect(errors.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Rate limiting / throttling
+  // -----------------------------------------------------------------------
+
+  describe("rate limiting", () => {
+    test("does not send more than one batch request per poll interval", async () => {
+      const { transcriber, generateContent } = createTranscriberWithMock(
+        [
+          { text: "a" },
+          { text: "ab" },
+          { text: "abc" },
+          { text: "abcd" },
+          { text: "abcde" },
+        ],
+        { pollIntervalMs: 100 },
+      );
+      const events = collectEvents(transcriber);
+
+      // Send multiple chunks rapidly
+      transcriber.sendAudio(Buffer.from("c1"), "audio/webm");
+      transcriber.sendAudio(Buffer.from("c2"), "audio/webm");
+      transcriber.sendAudio(Buffer.from("c3"), "audio/webm");
+
+      // Wait for just one poll cycle
+      await waitFor(() => events.some((e) => e.type === "partial"));
+      const callsAfterFirstPoll = (generateContent as ReturnType<typeof mock>)
+        .mock.calls.length;
+
+      // Only 1 batch request should have fired despite 3 audio chunks.
+      expect(callsAfterFirstPoll).toBe(1);
+
+      transcriber.stop();
+      await waitFor(() => events.some((e) => e.type === "closed"));
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Cancellation
+  // -----------------------------------------------------------------------
+
+  describe("cancellation", () => {
+    test("stop() cancels pending poll timer", async () => {
+      const { transcriber } = createTranscriberWithMock(
+        [{ text: "final text" }],
+        { pollIntervalMs: 500 }, // long interval to ensure timer is pending
+      );
+      const events = collectEvents(transcriber);
+
+      transcriber.sendAudio(Buffer.from("audio"), "audio/webm");
+
+      // Stop immediately before the poll fires
+      transcriber.stop();
+      await waitFor(() => events.some((e) => e.type === "closed"));
+
+      // The final batch should fire (from emitFinal), but no poll should
+      // have fired since we stopped before the interval elapsed.
+      const finals = events.filter((e) => e.type === "final");
+      expect(finals.length).toBe(1);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Provider identity
+  // -----------------------------------------------------------------------
+
+  describe("provider identity", () => {
+    test("providerId is google-gemini", () => {
+      const { transcriber } = createTranscriberWithMock([{ text: "" }]);
+      expect(transcriber.providerId).toBe("google-gemini");
+    });
+
+    test("boundaryId is daemon-streaming", () => {
+      const { transcriber } = createTranscriberWithMock([{ text: "" }]);
+      expect(transcriber.boundaryId).toBe("daemon-streaming");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Timeout path
+  // -----------------------------------------------------------------------
+
+  describe("timeout", () => {
+    test("AbortError during poll emits error event with provider-error category", async () => {
+      const abortError = new DOMException(
+        "The operation was aborted",
+        "AbortError",
+      );
+      const { transcriber } = createTranscriberWithMock([
+        { error: abortError },
+        { text: "recovered after timeout" },
+        { text: "recovered after timeout" },
+      ]);
+      const events = collectEvents(transcriber);
+
+      transcriber.sendAudio(Buffer.from("audio"), "audio/webm");
+      await waitFor(() => events.some((e) => e.type === "error"));
+
+      const errors = events.filter((e) => e.type === "error");
+      expect(errors[0]).toEqual({
+        type: "error",
+        category: "provider-error",
+        message: "The operation was aborted",
+      });
+
+      transcriber.stop();
+      await waitFor(() => events.some((e) => e.type === "closed"));
+    });
+  });
+});

--- a/assistant/src/providers/speech-to-text/google-gemini-stream.ts
+++ b/assistant/src/providers/speech-to-text/google-gemini-stream.ts
@@ -186,7 +186,11 @@ export class GoogleGeminiStreamingTranscriber implements StreamingTranscriber {
 
     try {
       const text = await this.transcribeAccumulated();
-      this.lastPollTime = Date.now();
+
+      // Guard: if stop() was called while we were awaiting the API
+      // response, emitFinal() may have already sent final/closed.
+      // Emitting a partial after closed violates the streaming contract.
+      if (this.stopped) return;
 
       // Only emit a partial if the text has actually changed AND is
       // a forward progression (longer or substantially different).
@@ -208,6 +212,11 @@ export class GoogleGeminiStreamingTranscriber implements StreamingTranscriber {
         this.emit({ type: "error", category: "provider-error", message });
       }
     } finally {
+      // Record poll completion time in both success and error paths so
+      // that throttling still applies when requests fail quickly —
+      // otherwise stale lastPollTime causes immediate retries on each
+      // sendAudio() call, producing request bursts.
+      this.lastPollTime = Date.now();
       this.polling = false;
     }
 

--- a/assistant/src/providers/speech-to-text/google-gemini-stream.ts
+++ b/assistant/src/providers/speech-to-text/google-gemini-stream.ts
@@ -190,7 +190,15 @@ export class GoogleGeminiStreamingTranscriber implements StreamingTranscriber {
       // Guard: if stop() was called while we were awaiting the API
       // response, emitFinal() may have already sent final/closed.
       // Emitting a partial after closed violates the streaming contract.
-      if (this.stopped) return;
+      // However, preserve the transcribed text so the fallback final in
+      // emitFinal() uses the most up-to-date transcript if the final
+      // batch request fails.
+      if (this.stopped) {
+        if (text && text.length >= this.lastEmittedText.length) {
+          this.lastEmittedText = text;
+        }
+        return;
+      }
 
       // Only emit a partial if the text has actually changed AND is
       // a forward progression (longer or substantially different).

--- a/assistant/src/providers/speech-to-text/google-gemini-stream.ts
+++ b/assistant/src/providers/speech-to-text/google-gemini-stream.ts
@@ -1,0 +1,290 @@
+/**
+ * Google Gemini incremental-batch streaming STT adapter.
+ *
+ * Google Gemini does not expose a native WebSocket streaming transcription
+ * endpoint. This adapter approximates streaming by accumulating audio chunks
+ * and periodically submitting the accumulated buffer to the Gemini
+ * `models.generateContent` endpoint, then diffing the response against the
+ * previous transcript to emit stable partial updates.
+ *
+ * Key design decisions:
+ * - **Throttled polling**: A minimum interval (`POLL_INTERVAL_MS`) between
+ *   batch requests prevents excessive API calls while the user is speaking.
+ * - **Overlap/diff logic**: Each batch includes the full accumulated audio,
+ *   so the model sees complete context. The adapter compares each new
+ *   transcript against the last emitted partial to avoid sending duplicate
+ *   or regressive (flickering) text to the UI.
+ * - **Deterministic final**: On `stop()` the adapter sends one final batch
+ *   request with the complete audio and emits a `final` event followed by
+ *   `closed`, regardless of what partials were sent earlier.
+ *
+ * Implements the {@link StreamingTranscriber} contract from `stt/types.ts`
+ * so the runtime session orchestrator (PR 5) can use it interchangeably
+ * with the Deepgram realtime-ws adapter.
+ */
+
+import { GoogleGenAI } from "@google/genai";
+
+import type {
+  StreamingTranscriber,
+  SttStreamServerEvent,
+} from "../../stt/types.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const DEFAULT_MODEL = "gemini-2.0-flash";
+
+/**
+ * Minimum interval between incremental batch requests (ms).
+ * Prevents excessive API calls while the user is actively speaking.
+ */
+export const POLL_INTERVAL_MS = 1_000;
+
+/**
+ * Timeout per individual batch request (ms).
+ * Prevents a single slow request from blocking the streaming pipeline.
+ */
+const REQUEST_TIMEOUT_MS = 15_000;
+
+const TRANSCRIPTION_PROMPT =
+  "Transcribe the audio exactly as spoken. Return only the transcribed text with no additional commentary, labels, or formatting.";
+
+// ---------------------------------------------------------------------------
+// Options
+// ---------------------------------------------------------------------------
+
+export interface GoogleGeminiStreamOptions {
+  /** Gemini model to use (default: "gemini-2.0-flash"). */
+  model?: string;
+  /** Override the Google AI API base URL (useful for proxies or on-prem). */
+  baseUrl?: string;
+  /** Override the poll interval for testing (default: POLL_INTERVAL_MS). */
+  pollIntervalMs?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Adapter
+// ---------------------------------------------------------------------------
+
+export class GoogleGeminiStreamingTranscriber implements StreamingTranscriber {
+  readonly providerId = "google-gemini" as const;
+  readonly boundaryId = "daemon-streaming" as const;
+
+  private readonly client: GoogleGenAI;
+  private readonly model: string;
+  private readonly pollIntervalMs: number;
+
+  /** Accumulated audio chunks across the entire session. */
+  private audioChunks: Buffer[] = [];
+  /** MIME type of the accumulated audio (set on first audio chunk). */
+  private audioMimeType = "audio/webm";
+
+  /** The last partial transcript emitted to the client. */
+  private lastEmittedText = "";
+  /** Whether `start()` has been called and the session is active. */
+  private started = false;
+  /** Whether `stop()` has been called. */
+  private stopped = false;
+
+  /** Timer handle for the throttled polling loop. */
+  private pollTimer: ReturnType<typeof setTimeout> | null = null;
+  /** Timestamp of the last batch request completion. */
+  private lastPollTime = 0;
+  /** Whether a batch request is currently in flight. */
+  private polling = false;
+  /** Whether new audio has arrived since the last poll. */
+  private audioDirty = false;
+
+  /** Event callback registered via start(). */
+  private onEvent: ((event: SttStreamServerEvent) => void) | null = null;
+
+  constructor(apiKey: string, options: GoogleGeminiStreamOptions = {}) {
+    this.model = options.model ?? DEFAULT_MODEL;
+    this.pollIntervalMs = options.pollIntervalMs ?? POLL_INTERVAL_MS;
+
+    this.client = options.baseUrl
+      ? new GoogleGenAI({
+          apiKey,
+          httpOptions: { baseUrl: options.baseUrl },
+        })
+      : new GoogleGenAI({ apiKey });
+  }
+
+  // -----------------------------------------------------------------------
+  // StreamingTranscriber interface
+  // -----------------------------------------------------------------------
+
+  async start(onEvent: (event: SttStreamServerEvent) => void): Promise<void> {
+    if (this.started) {
+      throw new Error("GoogleGeminiStreamingTranscriber: already started");
+    }
+    this.onEvent = onEvent;
+    this.started = true;
+  }
+
+  sendAudio(audio: Buffer, mimeType: string): void {
+    if (!this.started) {
+      throw new Error(
+        "GoogleGeminiStreamingTranscriber: sendAudio called before start()",
+      );
+    }
+    if (this.stopped) return;
+
+    this.audioChunks.push(audio);
+    this.audioMimeType = mimeType;
+    this.audioDirty = true;
+
+    this.schedulePoll();
+  }
+
+  stop(): void {
+    if (this.stopped) return;
+    this.stopped = true;
+
+    if (this.pollTimer) {
+      clearTimeout(this.pollTimer);
+      this.pollTimer = null;
+    }
+
+    // Fire the final batch asynchronously; the session stays open until
+    // the final event and closed event are emitted.
+    void this.emitFinal();
+  }
+
+  // -----------------------------------------------------------------------
+  // Internal polling
+  // -----------------------------------------------------------------------
+
+  /**
+   * Schedule the next poll if one is not already pending.
+   *
+   * Respects the minimum poll interval to avoid flooding the API.
+   */
+  private schedulePoll(): void {
+    if (this.pollTimer || this.stopped) return;
+
+    const elapsed = Date.now() - this.lastPollTime;
+    const delay = Math.max(0, this.pollIntervalMs - elapsed);
+
+    this.pollTimer = setTimeout(() => {
+      this.pollTimer = null;
+      void this.doPoll();
+    }, delay);
+  }
+
+  /**
+   * Execute a single incremental batch request and emit a partial event
+   * if the transcript has advanced.
+   */
+  private async doPoll(): Promise<void> {
+    if (this.stopped || this.polling || !this.audioDirty) return;
+
+    this.polling = true;
+    this.audioDirty = false;
+
+    try {
+      const text = await this.transcribeAccumulated();
+      this.lastPollTime = Date.now();
+
+      // Only emit a partial if the text has actually changed AND is
+      // a forward progression (longer or substantially different).
+      // This prevents flickering when the model returns a shorter
+      // intermediate result.
+      if (
+        text &&
+        text !== this.lastEmittedText &&
+        text.length >= this.lastEmittedText.length
+      ) {
+        this.lastEmittedText = text;
+        this.emit({ type: "partial", text });
+      }
+    } catch (err) {
+      // Transient errors during polling are non-fatal — the final
+      // request on stop() will capture the complete audio.
+      if (!this.stopped) {
+        const message = err instanceof Error ? err.message : String(err);
+        this.emit({ type: "error", category: "provider-error", message });
+      }
+    } finally {
+      this.polling = false;
+    }
+
+    // If more audio arrived while we were polling, schedule again.
+    if (this.audioDirty && !this.stopped) {
+      this.schedulePoll();
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Final transcript
+  // -----------------------------------------------------------------------
+
+  /**
+   * Send the complete accumulated audio for a deterministic final
+   * transcript, then close the session.
+   */
+  private async emitFinal(): Promise<void> {
+    try {
+      if (this.audioChunks.length > 0) {
+        const text = await this.transcribeAccumulated();
+        this.emit({ type: "final", text: text || this.lastEmittedText });
+      } else {
+        // No audio was ever sent — emit empty final.
+        this.emit({ type: "final", text: this.lastEmittedText });
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.emit({ type: "error", category: "provider-error", message });
+      // Still emit a best-effort final from the last known partial.
+      this.emit({ type: "final", text: this.lastEmittedText });
+    } finally {
+      this.emit({ type: "closed" });
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Batch transcription helper
+  // -----------------------------------------------------------------------
+
+  /**
+   * Concatenate all accumulated audio chunks and send a single batch
+   * request to the Gemini API.
+   */
+  private async transcribeAccumulated(): Promise<string> {
+    const combined = Buffer.concat(this.audioChunks);
+    const base64Audio = combined.toString("base64");
+
+    const response = await this.client.models.generateContent({
+      model: this.model,
+      contents: [
+        {
+          role: "user",
+          parts: [
+            {
+              inlineData: {
+                mimeType: this.audioMimeType,
+                data: base64Audio,
+              },
+            },
+            { text: TRANSCRIPTION_PROMPT },
+          ],
+        },
+      ],
+      config: {
+        abortSignal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      },
+    });
+
+    return response.text?.trim() ?? "";
+  }
+
+  // -----------------------------------------------------------------------
+  // Event emission
+  // -----------------------------------------------------------------------
+
+  private emit(event: SttStreamServerEvent): void {
+    this.onEvent?.(event);
+  }
+}

--- a/assistant/src/providers/speech-to-text/resolve.ts
+++ b/assistant/src/providers/speech-to-text/resolve.ts
@@ -1,7 +1,11 @@
 import { getConfig } from "../../config/loader.js";
 import { getProviderKeyAsync } from "../../security/secure-keys.js";
 import { createDaemonBatchTranscriber } from "../../stt/daemon-batch-transcriber.js";
-import type { BatchTranscriber, SttProviderId } from "../../stt/types.js";
+import type {
+  BatchTranscriber,
+  StreamingTranscriber,
+  SttProviderId,
+} from "../../stt/types.js";
 import {
   getCredentialProvider,
   getProviderEntry,
@@ -221,4 +225,73 @@ export async function resolveConversationStreamingSttCapability(): Promise<Conve
     providerId: entry.id,
     streamingMode: entry.conversationStreamingMode,
   };
+}
+
+// ---------------------------------------------------------------------------
+// Streaming transcriber resolver
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve a `StreamingTranscriber` for daemon-hosted streaming transcription.
+ *
+ * Reads `services.stt.provider` from the assistant config to determine which
+ * STT provider to use, verifies it supports the `daemon-streaming` boundary,
+ * and constructs the appropriate streaming adapter. Credential lookup is
+ * centralized here (an authorized secure-keys importer) so callers don't
+ * need to import secure-keys directly.
+ *
+ * Returns `null` when:
+ * - The configured provider is not in the catalog.
+ * - The configured provider doesn't support the `daemon-streaming` boundary.
+ * - No credentials are configured for the resolved provider.
+ * - No streaming adapter exists for the configured provider.
+ */
+export async function resolveStreamingTranscriber(): Promise<StreamingTranscriber | null> {
+  const config = getConfig();
+  const provider = config.services.stt.provider;
+
+  // Look up credential provider via the catalog.
+  const credentialProviderName = getCredentialProvider(
+    provider as SttProviderId,
+  );
+  if (!credentialProviderName) {
+    return null;
+  }
+
+  // Verify the provider supports the daemon-streaming boundary.
+  if (!supportsBoundary(provider as SttProviderId, "daemon-streaming")) {
+    return null;
+  }
+
+  const apiKey = await getProviderKeyAsync(credentialProviderName);
+  if (!apiKey) {
+    return null;
+  }
+
+  return createStreamingTranscriber(apiKey, provider as SttProviderId);
+}
+
+/**
+ * Create a `StreamingTranscriber` for the given provider.
+ *
+ * Uses lazy imports so the adapter modules are only loaded when needed,
+ * keeping the module graph lightweight for callers that only need batch
+ * transcription.
+ *
+ * Returns `null` for providers that do not have a streaming adapter.
+ */
+async function createStreamingTranscriber(
+  apiKey: string,
+  providerId: SttProviderId,
+): Promise<StreamingTranscriber | null> {
+  switch (providerId) {
+    case "google-gemini": {
+      const { GoogleGeminiStreamingTranscriber } =
+        await import("./google-gemini-stream.js");
+      return new GoogleGeminiStreamingTranscriber(apiKey);
+    }
+    // Future: case "deepgram" will be wired here by PR 3.
+    default:
+      return null;
+  }
 }


### PR DESCRIPTION
## Summary
- Implement Google streaming adapter with progressive partial transcript updates for chat capture
- Normalize output to same daemon stream event contract as Deepgram for provider-agnostic clients
- Add throttling and overlap/diff logic for stable partial updates without UI flickering

Part of plan: streaming-stt-chat-messages.md (PR 4 of 9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25212" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
