### PR TITLE
assistant: route twilio voice webhook twiml from services.stt provider strategy

### DIFF
--- a/assistant/src/__tests__/twilio-routes-twiml.test.ts
+++ b/assistant/src/__tests__/twilio-routes-twiml.test.ts
@@ -18,7 +18,7 @@ mock.module("../util/logger.js", () => ({
 
 import { resolveTelephonySttProfile } from "../calls/stt-profile.js";
 import { buildTwilioRelaySpeechConfig } from "../calls/twilio-relay-speech-config.js";
-import { generateTwiML } from "../calls/twilio-routes.js";
+import { generateStreamTwiML, generateTwiML } from "../calls/twilio-routes.js";
 
 // ── Helper to build speech config from raw provider settings ─────────
 
@@ -432,38 +432,108 @@ describe("generateTwiML with voice quality profile", () => {
   });
 });
 
-// ── ConversationRelay STT guardrail tests ─────────────────────────────
-// These tests assert that production TwiML continues to emit
-// ConversationRelay-native STT attributes sourced from
-// calls.voice.transcriptionProvider (not from services.stt). They serve
-// as regression guardrails for the future cutover — if a change
-// inadvertently switches the STT source, these tests will fail.
+// ── generateStreamTwiML unit tests ────────────────────────────────────
+// Tests for the <Connect><Stream> TwiML generator used by the
+// media-stream-custom strategy (e.g. OpenAI Whisper).
 
-describe("ConversationRelay STT attribute guardrails", () => {
-  const callSessionId = "guardrail-session-1";
-  const relayUrl = "wss://test.example.com/v1/calls/relay";
+describe("generateStreamTwiML", () => {
+  const callSessionId = "stream-session-1";
+  const streamUrl = "wss://test.example.com/ws/twilio/media-stream";
 
-  test("TwiML contains <ConversationRelay> element with transcriptionProvider attribute", () => {
-    const twiml = generateTwiML(
-      callSessionId,
-      relayUrl,
-      null,
-      {
-        language: "en-US",
-        ttsProvider: "Google",
-        voice: "Google.en-US-Journey-O",
-      },
-      speechConfigFor("Deepgram", undefined, "low"),
-    );
+  test("emits <Stream> element with correct URL", () => {
+    const twiml = generateStreamTwiML(callSessionId, streamUrl);
 
-    // Must use ConversationRelay (not <Stream> or media-stream)
-    expect(twiml).toContain("<ConversationRelay");
-    expect(twiml).not.toContain("<Stream");
-    // transcriptionProvider is a ConversationRelay-native attribute
-    expect(twiml).toContain('transcriptionProvider="Deepgram"');
+    expect(twiml).toContain("<Stream");
+    expect(twiml).toContain(`url="${streamUrl}"`);
+    expect(twiml).not.toContain("<ConversationRelay");
   });
 
-  test("Deepgram default: TwiML emits transcriptionProvider=Deepgram and speechModel=nova-3", () => {
+  test("includes callSessionId as <Parameter>", () => {
+    const twiml = generateStreamTwiML(callSessionId, streamUrl);
+
+    expect(twiml).toContain(
+      `<Parameter name="callSessionId" value="${callSessionId}" />`,
+    );
+  });
+
+  test("includes auth token as <Parameter> when provided", () => {
+    const twiml = generateStreamTwiML(
+      callSessionId,
+      streamUrl,
+      "test-relay-token-123",
+    );
+
+    expect(twiml).toContain(
+      '<Parameter name="token" value="test-relay-token-123" />',
+    );
+  });
+
+  test("omits token Parameter when not provided", () => {
+    const twiml = generateStreamTwiML(callSessionId, streamUrl);
+
+    expect(twiml).not.toContain('name="token"');
+  });
+
+  test("includes custom parameters as <Parameter> elements", () => {
+    const twiml = generateStreamTwiML(callSessionId, streamUrl, "tok", {
+      verificationSessionId: "vs-123",
+    });
+
+    expect(twiml).toContain(
+      '<Parameter name="verificationSessionId" value="vs-123" />',
+    );
+    expect(twiml).toContain(
+      `<Parameter name="callSessionId" value="${callSessionId}" />`,
+    );
+    expect(twiml).toContain('<Parameter name="token" value="tok" />');
+  });
+
+  test("does not include ConversationRelay STT attributes", () => {
+    const twiml = generateStreamTwiML(callSessionId, streamUrl);
+
+    expect(twiml).not.toContain("transcriptionProvider=");
+    expect(twiml).not.toContain("speechModel=");
+    expect(twiml).not.toContain("interruptSensitivity=");
+    expect(twiml).not.toContain("ttsProvider=");
+    expect(twiml).not.toContain("voice=");
+    expect(twiml).not.toContain("language=");
+  });
+
+  test("XML special characters in stream URL are escaped", () => {
+    const twiml = generateStreamTwiML(
+      callSessionId,
+      'wss://test.example.com/ws?a=1&b="2"',
+    );
+
+    expect(twiml).toContain(
+      'url="wss://test.example.com/ws?a=1&amp;b=&quot;2&quot;"',
+    );
+  });
+
+  test("wraps in valid TwiML structure", () => {
+    const twiml = generateStreamTwiML(callSessionId, streamUrl);
+
+    expect(twiml).toContain('<?xml version="1.0" encoding="UTF-8"?>');
+    expect(twiml).toContain("<Response>");
+    expect(twiml).toContain("<Connect>");
+    expect(twiml).toContain("</Stream>");
+    expect(twiml).toContain("</Connect>");
+    expect(twiml).toContain("</Response>");
+  });
+});
+
+// ── Provider-conditional TwiML generation ─────────────────────────────
+// These tests verify that the two TwiML generators produce the correct
+// structure for each provider strategy:
+// - Deepgram/Google -> ConversationRelay with STT attributes
+// - OpenAI Whisper -> Stream with no STT attributes
+
+describe("Provider-conditional TwiML generation", () => {
+  const callSessionId = "provider-test-1";
+  const relayUrl = "wss://test.example.com/v1/calls/relay";
+  const streamUrl = "wss://test.example.com/ws/twilio/media-stream";
+
+  test("Deepgram: ConversationRelay with transcriptionProvider=Deepgram and speechModel=nova-3", () => {
     const twiml = generateTwiML(
       callSessionId,
       relayUrl,
@@ -472,11 +542,13 @@ describe("ConversationRelay STT attribute guardrails", () => {
       speechConfigFor("Deepgram", undefined, "low"),
     );
 
+    expect(twiml).toContain("<ConversationRelay");
+    expect(twiml).not.toContain("<Stream");
     expect(twiml).toContain('transcriptionProvider="Deepgram"');
     expect(twiml).toContain('speechModel="nova-3"');
   });
 
-  test("Google default: TwiML emits transcriptionProvider=Google with no speechModel", () => {
+  test("Google Gemini: ConversationRelay with transcriptionProvider=Google (no speechModel when unset)", () => {
     const twiml = generateTwiML(
       callSessionId,
       relayUrl,
@@ -485,36 +557,22 @@ describe("ConversationRelay STT attribute guardrails", () => {
       speechConfigFor("Google", undefined, "low"),
     );
 
+    expect(twiml).toContain("<ConversationRelay");
+    expect(twiml).not.toContain("<Stream");
     expect(twiml).toContain('transcriptionProvider="Google"');
     expect(twiml).not.toContain("speechModel=");
   });
 
-  test("STT attributes are sourced from resolveTelephonySttProfile (calls.voice config), not services.stt", () => {
-    // This test verifies the data flow: calls.voice.transcriptionProvider
-    // -> resolveTelephonySttProfile -> buildTwilioRelaySpeechConfig -> TwiML.
-    // The services.stt provider (openai-whisper) must NOT appear in TwiML.
-    const sttProfile = resolveTelephonySttProfile({
-      transcriptionProvider: "Deepgram",
-      speechModel: undefined,
-    });
-    const speechConfig = buildTwilioRelaySpeechConfig(
-      sttProfile,
-      "low",
-      undefined,
-    );
+  test("OpenAI Whisper: Stream path with no ConversationRelay STT attributes", () => {
+    const twiml = generateStreamTwiML(callSessionId, streamUrl, "tok");
 
-    const twiml = generateTwiML(
-      callSessionId,
-      relayUrl,
-      null,
-      { language: "en-US", ttsProvider: "ElevenLabs", voice: "voice1" },
-      speechConfig,
+    expect(twiml).toContain("<Stream");
+    expect(twiml).not.toContain("<ConversationRelay");
+    expect(twiml).not.toContain("transcriptionProvider=");
+    expect(twiml).not.toContain("speechModel=");
+    expect(twiml).toContain(
+      `<Parameter name="callSessionId" value="${callSessionId}" />`,
     );
-
-    // The TwiML must contain the calls.voice provider, not services.stt
-    expect(twiml).toContain('transcriptionProvider="Deepgram"');
-    expect(twiml).not.toContain("openai-whisper");
-    expect(twiml).not.toContain("openai");
   });
 
   test("ConversationRelay element contains all required STT-related attributes", () => {
@@ -530,7 +588,6 @@ describe("ConversationRelay STT attribute guardrails", () => {
       speechConfigFor("Deepgram", "nova-3", "medium", "Alice,Bob"),
     );
 
-    // All STT-related attributes that ConversationRelay supports
     expect(twiml).toContain('transcriptionProvider="Deepgram"');
     expect(twiml).toContain('speechModel="nova-3"');
     expect(twiml).toContain('interruptSensitivity="medium"');

--- a/assistant/src/__tests__/twilio-routes-twiml.test.ts
+++ b/assistant/src/__tests__/twilio-routes-twiml.test.ts
@@ -438,13 +438,15 @@ describe("generateTwiML with voice quality profile", () => {
 
 describe("generateStreamTwiML", () => {
   const callSessionId = "stream-session-1";
-  const streamUrl = "wss://test.example.com/ws/twilio/media-stream";
+  const streamUrl = "wss://test.example.com/webhooks/twilio/media-stream";
 
-  test("emits <Stream> element with correct URL", () => {
+  test("emits <Stream> element with callSessionId in URL query params", () => {
     const twiml = generateStreamTwiML(callSessionId, streamUrl);
 
     expect(twiml).toContain("<Stream");
-    expect(twiml).toContain(`url="${streamUrl}"`);
+    expect(twiml).toContain(
+      `url="wss://test.example.com/webhooks/twilio/media-stream?callSessionId=${callSessionId}"`,
+    );
     expect(twiml).not.toContain("<ConversationRelay");
   });
 
@@ -456,22 +458,27 @@ describe("generateStreamTwiML", () => {
     );
   });
 
-  test("includes auth token as <Parameter> when provided", () => {
+  test("includes auth token in URL query params and as <Parameter> when provided", () => {
     const twiml = generateStreamTwiML(
       callSessionId,
       streamUrl,
       "test-relay-token-123",
     );
 
+    // Token in URL query params for gateway auth during WS upgrade
+    expect(twiml).toContain("token=test-relay-token-123");
+    // Token also in <Parameter> for Twilio start event payload
     expect(twiml).toContain(
       '<Parameter name="token" value="test-relay-token-123" />',
     );
   });
 
-  test("omits token Parameter when not provided", () => {
+  test("omits token from URL and Parameter when not provided", () => {
     const twiml = generateStreamTwiML(callSessionId, streamUrl);
 
     expect(twiml).not.toContain('name="token"');
+    // URL should not contain a token query param
+    expect(twiml).not.toContain("token=");
   });
 
   test("includes custom parameters as <Parameter> elements", () => {
@@ -488,6 +495,21 @@ describe("generateStreamTwiML", () => {
     expect(twiml).toContain('<Parameter name="token" value="tok" />');
   });
 
+  test("callSessionId cannot be overridden by customParameters", () => {
+    const twiml = generateStreamTwiML(callSessionId, streamUrl, undefined, {
+      callSessionId: "attacker-session",
+    });
+
+    // The real callSessionId must win over the custom parameter
+    expect(twiml).toContain(
+      `<Parameter name="callSessionId" value="${callSessionId}" />`,
+    );
+    expect(twiml).not.toContain('value="attacker-session"');
+    // URL must also have the correct callSessionId
+    expect(twiml).toContain(`callSessionId=${callSessionId}`);
+    expect(twiml).not.toContain("callSessionId=attacker-session");
+  });
+
   test("does not include ConversationRelay STT attributes", () => {
     const twiml = generateStreamTwiML(callSessionId, streamUrl);
 
@@ -497,17 +519,6 @@ describe("generateStreamTwiML", () => {
     expect(twiml).not.toContain("ttsProvider=");
     expect(twiml).not.toContain("voice=");
     expect(twiml).not.toContain("language=");
-  });
-
-  test("XML special characters in stream URL are escaped", () => {
-    const twiml = generateStreamTwiML(
-      callSessionId,
-      'wss://test.example.com/ws?a=1&b="2"',
-    );
-
-    expect(twiml).toContain(
-      'url="wss://test.example.com/ws?a=1&amp;b=&quot;2&quot;"',
-    );
   });
 
   test("wraps in valid TwiML structure", () => {
@@ -531,7 +542,7 @@ describe("generateStreamTwiML", () => {
 describe("Provider-conditional TwiML generation", () => {
   const callSessionId = "provider-test-1";
   const relayUrl = "wss://test.example.com/v1/calls/relay";
-  const streamUrl = "wss://test.example.com/ws/twilio/media-stream";
+  const streamUrl = "wss://test.example.com/webhooks/twilio/media-stream";
 
   test("Deepgram: ConversationRelay with transcriptionProvider=Deepgram and speechModel=nova-3", () => {
     const twiml = generateTwiML(

--- a/assistant/src/__tests__/twilio-routes.test.ts
+++ b/assistant/src/__tests__/twilio-routes.test.ts
@@ -113,6 +113,11 @@ const mockConfigObj = {
     },
   },
   services: {
+    stt: {
+      mode: "your-own" as const,
+      provider: "deepgram" as const,
+      providers: {},
+    },
     tts: {
       mode: "your-own" as const,
       provider: "elevenlabs" as const,
@@ -265,6 +270,11 @@ mock.module("../inbound/public-ingress-urls.js", () => ({
     const base = resolveIngressBaseUrlFromConfig(ingressConfig);
     const wsBase = base.replace(/^http(s?)/, "ws$1");
     return `${wsBase}/webhooks/twilio/relay`;
+  },
+  getTwilioMediaStreamUrl: (ingressConfig: unknown) => {
+    const base = resolveIngressBaseUrlFromConfig(ingressConfig);
+    const wsBase = base.replace(/^http(s?)/, "ws$1");
+    return `${wsBase}/ws/twilio/media-stream`;
   },
   getTwilioVoiceWebhookUrl: (ingressConfig: unknown) =>
     `${resolveIngressBaseUrlFromConfig(ingressConfig)}/webhooks/twilio/voice`,
@@ -421,6 +431,9 @@ describe("twilio webhook routes", () => {
     updatePhoneNumberWebhookCalls = [];
     mockTwilioApiValidationStatus = 200;
     mockTwilioApiValidationBody = JSON.stringify({ sid: "AC_validated" });
+    // Reset STT config to defaults between tests
+    mockConfigObj.services.stt.provider = "deepgram" as any;
+    mockConfigObj.calls.voice.transcriptionProvider = "Deepgram" as any;
 
     globalThis.fetch = (async (
       url: string | URL | Request,
@@ -1029,32 +1042,30 @@ describe("twilio webhook routes", () => {
     });
   });
 
-  // ── ConversationRelay STT integration guardrails ────────────────────
-  // These tests assert at the handler level that the voice webhook TwiML
-  // always uses ConversationRelay with STT attributes from
-  // calls.voice.transcriptionProvider — the current production path.
+  // ── services.stt-driven TwiML routing ───────────────────────────────
+  // These tests assert that the voice webhook TwiML path is determined
+  // by services.stt.provider via resolveTelephonySttRouting — the
+  // canonical telephony STT routing resolver.
 
-  describe("ConversationRelay STT integration guardrails", () => {
-    test("outbound voice webhook TwiML uses ConversationRelay with transcriptionProvider from config", async () => {
-      const session = createTestSession("conv-stt-guard-1", "CA_stt_guard_1");
-      const req = makeVoiceRequest(session.id, { CallSid: "CA_stt_guard_1" });
+  describe("services.stt-driven TwiML routing", () => {
+    test("outbound: deepgram -> ConversationRelay with transcriptionProvider=Deepgram", async () => {
+      mockConfigObj.services.stt.provider = "deepgram" as any;
+      const session = createTestSession("conv-stt-dg-1", "CA_stt_dg_1");
+      const req = makeVoiceRequest(session.id, { CallSid: "CA_stt_dg_1" });
 
       const res = await handleVoiceWebhook(req);
       expect(res.status).toBe(200);
 
       const twiml = await res.text();
-      // Must use ConversationRelay (not <Stream> / media-stream)
       expect(twiml).toContain("<ConversationRelay");
       expect(twiml).not.toContain("<Stream");
-      // STT attributes must come from calls.voice config (Deepgram default)
       expect(twiml).toContain('transcriptionProvider="Deepgram"');
-      // services.stt provider must NOT appear in TwiML
-      expect(twiml).not.toContain("openai-whisper");
     });
 
-    test("inbound voice webhook TwiML uses ConversationRelay with transcriptionProvider from config", async () => {
+    test("inbound: deepgram -> ConversationRelay with transcriptionProvider=Deepgram", async () => {
+      mockConfigObj.services.stt.provider = "deepgram" as any;
       const req = makeInboundVoiceRequest({
-        CallSid: "CA_stt_guard_inbound_1",
+        CallSid: "CA_stt_dg_inbound_1",
         From: "+14155551234",
         To: "+15550001111",
       });
@@ -1066,6 +1077,93 @@ describe("twilio webhook routes", () => {
       expect(twiml).toContain("<ConversationRelay");
       expect(twiml).toContain('transcriptionProvider="Deepgram"');
       expect(twiml).not.toContain("<Stream");
+    });
+
+    test("outbound: google-gemini -> ConversationRelay with transcriptionProvider=Google", async () => {
+      mockConfigObj.services.stt.provider = "google-gemini" as any;
+      const session = createTestSession("conv-stt-gg-1", "CA_stt_gg_1");
+      const req = makeVoiceRequest(session.id, { CallSid: "CA_stt_gg_1" });
+
+      const res = await handleVoiceWebhook(req);
+      expect(res.status).toBe(200);
+
+      const twiml = await res.text();
+      expect(twiml).toContain("<ConversationRelay");
+      expect(twiml).not.toContain("<Stream");
+      expect(twiml).toContain('transcriptionProvider="Google"');
+    });
+
+    test("outbound: openai-whisper -> Stream TwiML (no ConversationRelay)", async () => {
+      mockConfigObj.services.stt.provider = "openai-whisper" as any;
+      const session = createTestSession("conv-stt-ow-1", "CA_stt_ow_1");
+      const req = makeVoiceRequest(session.id, { CallSid: "CA_stt_ow_1" });
+
+      const res = await handleVoiceWebhook(req);
+      expect(res.status).toBe(200);
+
+      const twiml = await res.text();
+      expect(twiml).toContain("<Stream");
+      expect(twiml).not.toContain("<ConversationRelay");
+      expect(twiml).not.toContain("transcriptionProvider=");
+      expect(twiml).toContain("callSessionId");
+      expect(twiml).toContain(
+        "wss://ingress.example.com/ws/twilio/media-stream",
+      );
+    });
+
+    test("inbound: openai-whisper -> Stream TwiML (no ConversationRelay)", async () => {
+      mockConfigObj.services.stt.provider = "openai-whisper" as any;
+      const req = makeInboundVoiceRequest({
+        CallSid: "CA_stt_ow_inbound_1",
+        From: "+14155551234",
+        To: "+15550001111",
+      });
+
+      const res = await handleVoiceWebhook(req);
+      expect(res.status).toBe(200);
+
+      const twiml = await res.text();
+      expect(twiml).toContain("<Stream");
+      expect(twiml).not.toContain("<ConversationRelay");
+      expect(twiml).not.toContain("transcriptionProvider=");
+    });
+
+    test("Stream TwiML includes auth token as Parameter", async () => {
+      mockConfigObj.services.stt.provider = "openai-whisper" as any;
+      const session = createTestSession(
+        "conv-stt-ow-token-1",
+        "CA_stt_ow_token_1",
+      );
+      const req = makeVoiceRequest(session.id, {
+        CallSid: "CA_stt_ow_token_1",
+      });
+
+      const res = await handleVoiceWebhook(req);
+      expect(res.status).toBe(200);
+
+      const twiml = await res.text();
+      expect(twiml).toContain('<Parameter name="token"');
+      expect(twiml).toContain('<Parameter name="callSessionId"');
+    });
+
+    test("routing is driven by services.stt.provider, not calls.voice.transcriptionProvider", async () => {
+      // Set calls.voice.transcriptionProvider to Deepgram but services.stt
+      // to openai-whisper. The TwiML path must follow services.stt.
+      mockConfigObj.calls.voice.transcriptionProvider = "Deepgram" as any;
+      mockConfigObj.services.stt.provider = "openai-whisper" as any;
+      const session = createTestSession(
+        "conv-stt-routing-1",
+        "CA_stt_routing_1",
+      );
+      const req = makeVoiceRequest(session.id, { CallSid: "CA_stt_routing_1" });
+
+      const res = await handleVoiceWebhook(req);
+      expect(res.status).toBe(200);
+
+      const twiml = await res.text();
+      // Must be Stream (from services.stt), NOT ConversationRelay
+      expect(twiml).toContain("<Stream");
+      expect(twiml).not.toContain("<ConversationRelay");
     });
   });
 

--- a/assistant/src/__tests__/twilio-routes.test.ts
+++ b/assistant/src/__tests__/twilio-routes.test.ts
@@ -274,7 +274,7 @@ mock.module("../inbound/public-ingress-urls.js", () => ({
   getTwilioMediaStreamUrl: (ingressConfig: unknown) => {
     const base = resolveIngressBaseUrlFromConfig(ingressConfig);
     const wsBase = base.replace(/^http(s?)/, "ws$1");
-    return `${wsBase}/ws/twilio/media-stream`;
+    return `${wsBase}/webhooks/twilio/media-stream`;
   },
   getTwilioVoiceWebhookUrl: (ingressConfig: unknown) =>
     `${resolveIngressBaseUrlFromConfig(ingressConfig)}/webhooks/twilio/voice`,
@@ -1107,7 +1107,7 @@ describe("twilio webhook routes", () => {
       expect(twiml).not.toContain("transcriptionProvider=");
       expect(twiml).toContain("callSessionId");
       expect(twiml).toContain(
-        "wss://ingress.example.com/ws/twilio/media-stream",
+        "wss://ingress.example.com/webhooks/twilio/media-stream",
       );
     });
 

--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -132,9 +132,11 @@ ${greetingAttr}
  * (e.g. OpenAI Whisper). Twilio opens a WebSocket to `streamUrl` and sends
  * raw audio frames; the daemon transcribes server-side.
  *
- * Custom parameters (callSessionId, auth token, verificationSessionId) are
- * propagated as `<Parameter>` children so Twilio includes them in the
- * `start` event's `customParameters` object.
+ * `callSessionId` and `token` are encoded as query parameters on the
+ * WebSocket URL so the gateway can validate and route the upgrade request
+ * before any Twilio `start` frame arrives. They are also propagated as
+ * `<Parameter>` children so Twilio includes them in the `start` event's
+ * `customParameters` object for downstream observability.
  */
 export function generateStreamTwiML(
   callSessionId: string,
@@ -142,10 +144,22 @@ export function generateStreamTwiML(
   relayToken?: string,
   customParameters?: Record<string, string>,
 ): string {
-  // Always include callSessionId so the gateway can correlate the stream.
+  // Build the WebSocket URL with callSessionId and token as query params.
+  // The gateway validates these during the upgrade handshake before any
+  // Twilio frames are available.
+  const urlObj = new URL(streamUrl);
+  urlObj.searchParams.set("callSessionId", callSessionId);
+  if (relayToken) {
+    urlObj.searchParams.set("token", relayToken);
+  }
+  const fullStreamUrl = urlObj.toString();
+
+  // Build <Parameter> elements for the Twilio start event payload.
+  // Spread customParameters first so callSessionId and token cannot be
+  // overridden by caller-supplied values.
   const allParams: Record<string, string> = {
-    callSessionId,
     ...customParameters,
+    callSessionId,
   };
 
   if (relayToken) {
@@ -160,7 +174,7 @@ export function generateStreamTwiML(
   return `<?xml version="1.0" encoding="UTF-8"?>
 <Response>
   <Connect>
-    <Stream url="${escapeXml(streamUrl)}">${parameterElements}
+    <Stream url="${escapeXml(fullStreamUrl)}">${parameterElements}
     </Stream>
   </Connect>
 </Response>`;

--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -1,13 +1,31 @@
 /**
  * HTTP route handlers for Twilio voice webhooks.
  *
- * - handleVoiceWebhook: initial voice webhook; returns TwiML to connect ConversationRelay
+ * - handleVoiceWebhook: initial voice webhook; returns TwiML to connect
+ *   ConversationRelay (Twilio-native STT) or Stream (custom media-stream STT)
  * - handleStatusCallback: call status updates (ringing, in-progress, completed, etc.)
  * - handleConnectAction: called when the ConversationRelay connection ends
+ *
+ * ## STT routing
+ *
+ * TwiML generation is driven by `services.stt.provider` via
+ * {@link resolveTelephonySttRouting}. The resolver returns a discriminated
+ * strategy that determines which TwiML path to use:
+ *
+ * - **`conversation-relay-native`** (deepgram, google-gemini) — emits
+ *   `<Connect><ConversationRelay>` with Twilio-native `transcriptionProvider`
+ *   and `speechModel` attributes.
+ *
+ * - **`media-stream-custom`** (openai-whisper) — emits
+ *   `<Connect><Stream>` so the daemon receives raw audio and transcribes
+ *   server-side.
  */
 
 import { loadConfig } from "../config/loader.js";
-import { getTwilioRelayUrl } from "../inbound/public-ingress-urls.js";
+import {
+  getTwilioMediaStreamUrl,
+  getTwilioRelayUrl,
+} from "../inbound/public-ingress-urls.js";
 import { mintEdgeRelayToken } from "../runtime/auth/token-service.js";
 import { getLogger } from "../util/logger.js";
 import { persistCallCompletionMessage } from "./call-conversation-messages.js";
@@ -27,7 +45,7 @@ import {
   updateCallSession,
 } from "./call-store.js";
 import { resolveCallHints } from "./stt-hints.js";
-import { resolveTelephonySttProfile } from "./stt-profile.js";
+import { resolveTelephonySttRouting } from "./telephony-stt-routing.js";
 import {
   buildTwilioRelaySpeechConfig,
   type TwilioRelaySpeechConfig,
@@ -103,6 +121,47 @@ ${greetingAttr}
       dtmfDetection="true"
       interruptSensitivity="${escapeXml(speechConfig.interruptSensitivity)}"${speechConfig.hints ? `\n      hints="${escapeXml(speechConfig.hints)}"` : ""}
     ${relayClose}
+  </Connect>
+</Response>`;
+}
+
+/**
+ * Generate `<Connect><Stream>` TwiML for the media-stream STT path.
+ *
+ * Used when the telephony STT routing resolver selects `media-stream-custom`
+ * (e.g. OpenAI Whisper). Twilio opens a WebSocket to `streamUrl` and sends
+ * raw audio frames; the daemon transcribes server-side.
+ *
+ * Custom parameters (callSessionId, auth token, verificationSessionId) are
+ * propagated as `<Parameter>` children so Twilio includes them in the
+ * `start` event's `customParameters` object.
+ */
+export function generateStreamTwiML(
+  callSessionId: string,
+  streamUrl: string,
+  relayToken?: string,
+  customParameters?: Record<string, string>,
+): string {
+  // Always include callSessionId so the gateway can correlate the stream.
+  const allParams: Record<string, string> = {
+    callSessionId,
+    ...customParameters,
+  };
+
+  if (relayToken) {
+    allParams.token = relayToken;
+  }
+
+  let parameterElements = "";
+  for (const [key, value] of Object.entries(allParams)) {
+    parameterElements += `\n      <Parameter name="${escapeXml(key)}" value="${escapeXml(value)}" />`;
+  }
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+  <Connect>
+    <Stream url="${escapeXml(streamUrl)}">${parameterElements}
+    </Stream>
   </Connect>
 </Response>`;
 }
@@ -235,8 +294,17 @@ export async function handleVoiceWebhook(req: Request): Promise<Response> {
 
 /**
  * Shared TwiML generation for both inbound and outbound voice webhooks.
- * Resolves voice quality profile, relay URL, and welcome greeting,
- * then returns a Response with the generated TwiML.
+ *
+ * Resolves the telephony STT routing strategy from `services.stt.provider`
+ * and branches:
+ *
+ * - **`conversation-relay-native`** — emits `<Connect><ConversationRelay>`
+ *   TwiML with Twilio-native STT attributes (`transcriptionProvider`,
+ *   `speechModel`). Used for deepgram and google-gemini.
+ *
+ * - **`media-stream-custom`** — emits `<Connect><Stream>` TwiML so the
+ *   daemon receives raw audio for server-side transcription. Used for
+ *   openai-whisper.
  *
  * When `verificationSessionId` is provided, it is included as a
  * `<Parameter>` in the TwiML for observability and compatibility with
@@ -258,25 +326,89 @@ function buildVoiceWebhookTwiml(
   const cfg = loadConfig();
   const profile = resolveVoiceQualityProfile(cfg);
 
-  const hints = resolveCallHints(sessionContext, profile.hints);
-
-  // Build STT attributes via the serialization helper so that route code
-  // never mixes STT config resolution with XML attribute composition.
-  const sttProfile = resolveTelephonySttProfile(cfg.calls.voice);
-  const speechConfig = buildTwilioRelaySpeechConfig(
-    sttProfile,
-    profile.interruptSensitivity,
-    hints || undefined,
-  );
-
   log.info(
     { callSessionId, ttsProvider: profile.ttsProvider, voice: profile.voice },
     "Voice quality profile resolved",
   );
 
+  // Resolve telephony STT strategy from services.stt.provider.
+  // Pass calls.voice.speechModel for model normalization during the
+  // transition period (Twilio-native providers need it for the TwiML
+  // speechModel attribute).
+  const routingResult = resolveTelephonySttRouting(cfg.calls.voice.speechModel);
+
+  if (routingResult.status === "unknown-provider") {
+    log.error(
+      {
+        callSessionId,
+        providerId: routingResult.providerId,
+        reason: routingResult.reason,
+      },
+      "Telephony STT routing failed — unknown provider; falling back to ConversationRelay with Deepgram",
+    );
+    // Graceful degradation: fall back to Deepgram ConversationRelay so
+    // calls don't fail entirely on a misconfigured provider.
+    return buildConversationRelayResponse(
+      callSessionId,
+      cfg,
+      profile,
+      sessionContext,
+      verificationSessionId,
+      { transcriptionProvider: "Deepgram", speechModel: "nova-3" },
+    );
+  }
+
+  const { strategy } = routingResult;
+
+  if (strategy.strategy === "conversation-relay-native") {
+    return buildConversationRelayResponse(
+      callSessionId,
+      cfg,
+      profile,
+      sessionContext,
+      verificationSessionId,
+      {
+        transcriptionProvider: strategy.transcriptionProvider,
+        speechModel: strategy.speechModel,
+      },
+    );
+  }
+
+  // media-stream-custom path
+  return buildMediaStreamResponse(callSessionId, cfg, verificationSessionId);
+}
+
+/**
+ * Build a ConversationRelay TwiML response for Twilio-native STT providers.
+ */
+function buildConversationRelayResponse(
+  callSessionId: string,
+  cfg: ReturnType<typeof loadConfig>,
+  profile: ReturnType<typeof resolveVoiceQualityProfile>,
+  sessionContext: {
+    task: string | null;
+    toNumber: string;
+    fromNumber: string;
+    direction: "inbound" | "outbound";
+    inviteFriendName: string | null;
+    inviteGuardianName: string | null;
+  } | null,
+  verificationSessionId: string | null | undefined,
+  sttAttrs: { transcriptionProvider: string; speechModel: string | undefined },
+): Response {
+  const hints = resolveCallHints(sessionContext, profile.hints);
+
+  const speechConfig = buildTwilioRelaySpeechConfig(
+    {
+      provider: sttAttrs.transcriptionProvider,
+      speechModel: sttAttrs.speechModel,
+    },
+    profile.interruptSensitivity,
+    hints || undefined,
+  );
+
   const relayUrl = getTwilioRelayUrl(cfg);
   const welcomeGreeting = buildWelcomeGreeting(sessionContext?.task ?? null);
-
   const relayToken = mintEdgeRelayToken();
 
   // Propagate verificationSessionId as a TwiML <Parameter> for
@@ -295,7 +427,46 @@ function buildVoiceWebhookTwiml(
     customParameters,
   );
 
-  log.info({ callSessionId }, "Returning ConversationRelay TwiML");
+  log.info(
+    {
+      callSessionId,
+      strategy: "conversation-relay-native",
+      transcriptionProvider: sttAttrs.transcriptionProvider,
+    },
+    "Returning ConversationRelay TwiML",
+  );
+
+  return new Response(twiml, {
+    status: 200,
+    headers: { "Content-Type": "text/xml" },
+  });
+}
+
+/**
+ * Build a Stream TwiML response for custom media-stream STT providers.
+ */
+function buildMediaStreamResponse(
+  callSessionId: string,
+  cfg: ReturnType<typeof loadConfig>,
+  verificationSessionId: string | null | undefined,
+): Response {
+  const streamUrl = getTwilioMediaStreamUrl(cfg);
+  const relayToken = mintEdgeRelayToken();
+
+  const customParameters: Record<string, string> | undefined =
+    verificationSessionId ? { verificationSessionId } : undefined;
+
+  const twiml = generateStreamTwiML(
+    callSessionId,
+    streamUrl,
+    relayToken,
+    customParameters,
+  );
+
+  log.info(
+    { callSessionId, strategy: "media-stream-custom" },
+    "Returning Stream TwiML",
+  );
 
   return new Response(twiml, {
     status: 200,

--- a/assistant/src/inbound/public-ingress-urls.ts
+++ b/assistant/src/inbound/public-ingress-urls.ts
@@ -129,7 +129,7 @@ export function getTwilioRelayUrl(config: IngressConfig): string {
 export function getTwilioMediaStreamUrl(config: IngressConfig): string {
   const base = getPublicBaseUrl(config);
   const wsBase = base.replace(/^http(s?)/, "ws$1");
-  return `${wsBase}/ws/twilio/media-stream`;
+  return `${wsBase}/webhooks/twilio/media-stream`;
 }
 
 /**

--- a/assistant/src/inbound/public-ingress-urls.ts
+++ b/assistant/src/inbound/public-ingress-urls.ts
@@ -121,6 +121,18 @@ export function getTwilioRelayUrl(config: IngressConfig): string {
 }
 
 /**
+ * Build the Twilio media-stream WebSocket URL.
+ * Used for the `<Stream>` TwiML path when the STT provider requires
+ * custom server-side transcription (e.g. OpenAI Whisper).
+ * Converts http:// → ws:// and https:// → wss://.
+ */
+export function getTwilioMediaStreamUrl(config: IngressConfig): string {
+  const base = getPublicBaseUrl(config);
+  const wsBase = base.replace(/^http(s?)/, "ws$1");
+  return `${wsBase}/ws/twilio/media-stream`;
+}
+
+/**
  * Build the OAuth callback URL.
  */
 export function getOAuthCallbackUrl(config: IngressConfig): string {


### PR DESCRIPTION
## Summary
- Wires telephony STT routing resolver into twilio-routes.ts replacing calls.voice.transcriptionProvider
- ConversationRelay TwiML for deepgram/google-gemini native providers, Stream TwiML for openai-whisper
- Adds getTwilioMediaStreamUrl() to public-ingress-urls.ts for media-stream path

Part of plan: twilio-services-stt-telephony-unify.md (PR 3 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25214" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
