### PR TITLE
refactor(macos): flatten chained .padding() in PermissionPromptOverlay views

### DIFF
--- a/clients/macos/vellum-assistant/Features/Voice/PermissionPromptOverlay.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/PermissionPromptOverlay.swift
@@ -166,9 +166,7 @@ private struct FirstUsePromptView: View {
                     .multilineTextAlignment(.center)
                     .fixedSize(horizontal: false, vertical: true)
             }
-            .padding(.horizontal, VSpacing.xl)
-            .padding(.top, VSpacing.xl)
-            .padding(.bottom, VSpacing.lg)
+            .padding(EdgeInsets(top: VSpacing.xl, leading: VSpacing.xl, bottom: VSpacing.lg, trailing: VSpacing.xl))
 
             HStack(spacing: VSpacing.sm) {
                 VButton(label: "Not Now", style: .outlined, size: .compact) {
@@ -178,8 +176,7 @@ private struct FirstUsePromptView: View {
                     onContinue()
                 }
             }
-            .padding(.horizontal, VSpacing.xl)
-            .padding(.bottom, VSpacing.lg)
+            .padding(EdgeInsets(top: 0, leading: VSpacing.xl, bottom: VSpacing.lg, trailing: VSpacing.xl))
         }
         .frame(width: 320)
         .background(VColor.surfaceOverlay)
@@ -216,9 +213,7 @@ private struct SpeechFallbackPromptView: View {
                     .multilineTextAlignment(.center)
                     .fixedSize(horizontal: false, vertical: true)
             }
-            .padding(.horizontal, VSpacing.xl)
-            .padding(.top, VSpacing.xl)
-            .padding(.bottom, VSpacing.lg)
+            .padding(EdgeInsets(top: VSpacing.xl, leading: VSpacing.xl, bottom: VSpacing.lg, trailing: VSpacing.xl))
 
             HStack(spacing: VSpacing.sm) {
                 VButton(label: "Not Now", style: .outlined, size: .compact) {
@@ -228,8 +223,7 @@ private struct SpeechFallbackPromptView: View {
                     onContinue()
                 }
             }
-            .padding(.horizontal, VSpacing.xl)
-            .padding(.bottom, VSpacing.lg)
+            .padding(EdgeInsets(top: 0, leading: VSpacing.xl, bottom: VSpacing.lg, trailing: VSpacing.xl))
         }
         .frame(width: 320)
         .background(VColor.surfaceOverlay)
@@ -287,9 +281,7 @@ private struct DeniedPromptView: View {
                     .multilineTextAlignment(.center)
                     .fixedSize(horizontal: false, vertical: true)
             }
-            .padding(.horizontal, VSpacing.xl)
-            .padding(.top, VSpacing.xl)
-            .padding(.bottom, VSpacing.lg)
+            .padding(EdgeInsets(top: VSpacing.xl, leading: VSpacing.xl, bottom: VSpacing.lg, trailing: VSpacing.xl))
 
             HStack(spacing: VSpacing.sm) {
                 VButton(label: "Dismiss", style: .outlined, size: .compact) {
@@ -299,8 +291,7 @@ private struct DeniedPromptView: View {
                     onOpenSettings()
                 }
             }
-            .padding(.horizontal, VSpacing.xl)
-            .padding(.bottom, VSpacing.lg)
+            .padding(EdgeInsets(top: 0, leading: VSpacing.xl, bottom: VSpacing.lg, trailing: VSpacing.xl))
         }
         .frame(width: 320)
         .background(VColor.surfaceOverlay)


### PR DESCRIPTION
## Summary
- Flatten chained `.padding(.horizontal, ...).padding(.top, ...).padding(.bottom, ...)` into single `.padding(EdgeInsets(...))` calls per clients/macos/AGENTS.md
- Applied to all three view structs: FirstUsePromptView, SpeechFallbackPromptView, DeniedPromptView (6 modifier chains → 6 single EdgeInsets calls)
- Reduces UnaryLayoutEngine wrapper depth without any visual change
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25215" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
