### PR TITLE
assistant: wire stt websocket sessions to provider streaming adapters

### DIFF
--- a/assistant/src/__tests__/gateway-only-enforcement.test.ts
+++ b/assistant/src/__tests__/gateway-only-enforcement.test.ts
@@ -68,6 +68,9 @@ mock.module("../config/loader.js", () => ({
     twilio: {
       phoneNumber: "+15550001111",
     },
+    services: {
+      stt: { provider: "deepgram" },
+    },
   }),
   invalidateConfigCache: () => {},
 }));
@@ -90,7 +93,9 @@ mock.module("../calls/twilio-provider.js", () => ({
   },
 }));
 
-mock.module("../security/secure-keys.js", () => ({}));
+mock.module("../security/secure-keys.js", () => ({
+  getProviderKeyAsync: () => Promise.resolve(null),
+}));
 
 // NOTE: Do NOT mock '../inbound/public-ingress-urls.js' here.
 // Those are pure functions that derive URLs from the config object returned by

--- a/assistant/src/__tests__/stt-stream-session.test.ts
+++ b/assistant/src/__tests__/stt-stream-session.test.ts
@@ -1,0 +1,535 @@
+/**
+ * Integration tests for the STT stream session orchestrator.
+ *
+ * Validates:
+ * - End-to-end session lifecycle with mock deepgram and google-gemini
+ *   streaming adapters.
+ * - Normalized event flow: ready -> partial -> final -> closed.
+ * - Per-session ordering guarantees (monotonic `seq` field).
+ * - Graceful handling of unsupported providers (e.g. openai-whisper).
+ * - Session teardown on client disconnect.
+ * - Idle timeout behavior.
+ * - Binary audio frame handling.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  SttStreamSession,
+  type SttStreamSocket,
+} from "../stt/stt-stream-session.js";
+import type {
+  StreamingTranscriber,
+  SttStreamServerEvent,
+} from "../stt/types.js";
+
+// ---------------------------------------------------------------------------
+// Mock WebSocket
+// ---------------------------------------------------------------------------
+
+class MockSocket implements SttStreamSocket {
+  sent: string[] = [];
+  closed = false;
+  closeCode?: number;
+  closeReason?: string;
+
+  send(data: string): void {
+    this.sent.push(data);
+  }
+
+  close(code?: number, reason?: string): void {
+    this.closed = true;
+    this.closeCode = code;
+    this.closeReason = reason;
+  }
+
+  /** Parse all sent frames as JSON. */
+  get frames(): Record<string, unknown>[] {
+    return this.sent.map((s) => JSON.parse(s) as Record<string, unknown>);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Mock streaming transcribers
+// ---------------------------------------------------------------------------
+
+/**
+ * Mock Deepgram-like transcriber that emits partial + final events
+ * when audio is sent and stop is called.
+ */
+class MockDeepgramTranscriber implements StreamingTranscriber {
+  readonly providerId = "deepgram" as const;
+  readonly boundaryId = "daemon-streaming" as const;
+
+  private onEvent: ((event: SttStreamServerEvent) => void) | null = null;
+  audioChunks: Buffer[] = [];
+  stopped = false;
+
+  async start(onEvent: (event: SttStreamServerEvent) => void): Promise<void> {
+    this.onEvent = onEvent;
+  }
+
+  sendAudio(audio: Buffer, _mimeType: string): void {
+    this.audioChunks.push(audio);
+    // Simulate partial transcript on each audio chunk.
+    this.onEvent?.({
+      type: "partial",
+      text: `partial-${this.audioChunks.length}`,
+    });
+  }
+
+  stop(): void {
+    this.stopped = true;
+    // Simulate final transcript and close.
+    this.onEvent?.({ type: "final", text: "final transcript" });
+    this.onEvent?.({ type: "closed" });
+  }
+}
+
+/**
+ * Mock Google Gemini-like transcriber that polls on audio arrival
+ * and emits a final on stop.
+ */
+class MockGoogleTranscriber implements StreamingTranscriber {
+  readonly providerId = "google-gemini" as const;
+  readonly boundaryId = "daemon-streaming" as const;
+
+  private onEvent: ((event: SttStreamServerEvent) => void) | null = null;
+  audioChunks: Buffer[] = [];
+  stopped = false;
+
+  async start(onEvent: (event: SttStreamServerEvent) => void): Promise<void> {
+    this.onEvent = onEvent;
+  }
+
+  sendAudio(audio: Buffer, _mimeType: string): void {
+    this.audioChunks.push(audio);
+    // Simulate incremental-batch partial.
+    this.onEvent?.({
+      type: "partial",
+      text: `transcribing-${this.audioChunks.length}`,
+    });
+  }
+
+  stop(): void {
+    this.stopped = true;
+    this.onEvent?.({ type: "final", text: "complete transcription" });
+    this.onEvent?.({ type: "closed" });
+  }
+}
+
+/**
+ * Mock transcriber that throws on start() to test error handling.
+ */
+class FailingTranscriber implements StreamingTranscriber {
+  readonly providerId = "deepgram" as const;
+  readonly boundaryId = "daemon-streaming" as const;
+
+  async start(_onEvent: (event: SttStreamServerEvent) => void): Promise<void> {
+    throw new Error("Mock provider connection refused");
+  }
+
+  sendAudio(_audio: Buffer, _mimeType: string): void {
+    throw new Error("Should not be called");
+  }
+
+  stop(): void {
+    throw new Error("Should not be called");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function createSession(
+  provider: string,
+  options?: { idleTimeoutMs?: number },
+): { ws: MockSocket; session: SttStreamSession } {
+  const ws = new MockSocket();
+  const session = new SttStreamSession(ws, provider, "audio/webm", options);
+  return { ws, session };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("SttStreamSession", () => {
+  // ── Deepgram end-to-end flow ──────────────────────────────────────
+
+  describe("deepgram provider flow", () => {
+    test("emits ready, partial, final, closed events with ordering", async () => {
+      const { ws, session } = createSession("deepgram");
+      const transcriber = new MockDeepgramTranscriber();
+
+      await session.start(async () => transcriber);
+
+      // Should have sent a ready event.
+      expect(ws.frames.length).toBeGreaterThanOrEqual(1);
+      const readyFrame = ws.frames[0];
+      expect(readyFrame.type).toBe("ready");
+      expect(readyFrame.provider).toBe("deepgram");
+
+      // Send audio via JSON text frame.
+      const audioB64 = Buffer.from("test-audio-1").toString("base64");
+      session.handleMessage(JSON.stringify({ type: "audio", audio: audioB64 }));
+
+      // Should have emitted a partial.
+      const afterAudio1 = ws.frames;
+      expect(afterAudio1.some((f) => f.type === "partial")).toBe(true);
+
+      // Send more audio.
+      session.handleMessage(
+        JSON.stringify({
+          type: "audio",
+          audio: Buffer.from("test-audio-2").toString("base64"),
+        }),
+      );
+
+      // Send stop.
+      session.handleMessage(JSON.stringify({ type: "stop" }));
+
+      // Should have emitted final and closed.
+      const allFrames = ws.frames;
+      expect(allFrames.some((f) => f.type === "final")).toBe(true);
+      expect(allFrames.some((f) => f.type === "closed")).toBe(true);
+
+      // Verify monotonic sequence numbers.
+      const seqs = allFrames
+        .filter((f) => typeof f.seq === "number")
+        .map((f) => f.seq as number);
+      for (let i = 1; i < seqs.length; i++) {
+        expect(seqs[i]).toBeGreaterThan(seqs[i - 1]);
+      }
+
+      // Verify transcriber received audio.
+      expect(transcriber.audioChunks.length).toBe(2);
+      expect(transcriber.stopped).toBe(true);
+
+      // Session should be closed.
+      expect(session.isClosed).toBe(true);
+    });
+
+    test("handles binary audio frames", async () => {
+      const { ws, session } = createSession("deepgram");
+      const transcriber = new MockDeepgramTranscriber();
+
+      await session.start(async () => transcriber);
+
+      // Send binary audio.
+      const audioData = Buffer.from("raw-pcm-audio");
+      session.handleBinaryAudio(audioData);
+
+      expect(transcriber.audioChunks.length).toBe(1);
+      expect(transcriber.audioChunks[0]).toEqual(audioData);
+
+      // Partial should have been emitted.
+      const partialFrames = ws.frames.filter((f) => f.type === "partial");
+      expect(partialFrames.length).toBe(1);
+    });
+  });
+
+  // ── Google Gemini end-to-end flow ─────────────────────────────────
+
+  describe("google-gemini provider flow", () => {
+    test("emits ready, partial, final, closed events", async () => {
+      const { ws, session } = createSession("google-gemini");
+      const transcriber = new MockGoogleTranscriber();
+
+      await session.start(async () => transcriber);
+
+      // Should have sent a ready event.
+      const readyFrame = ws.frames[0];
+      expect(readyFrame.type).toBe("ready");
+      expect(readyFrame.provider).toBe("google-gemini");
+
+      // Send audio.
+      session.handleMessage(
+        JSON.stringify({
+          type: "audio",
+          audio: Buffer.from("audio-chunk-1").toString("base64"),
+        }),
+      );
+
+      // Stop.
+      session.handleMessage(JSON.stringify({ type: "stop" }));
+
+      // Verify event flow.
+      const allFrames = ws.frames;
+      const types = allFrames.map((f) => f.type);
+      expect(types).toContain("ready");
+      expect(types).toContain("partial");
+      expect(types).toContain("final");
+      expect(types).toContain("closed");
+
+      // Final text should match mock.
+      const finalFrame = allFrames.find((f) => f.type === "final");
+      expect(finalFrame?.text).toBe("complete transcription");
+
+      expect(session.isClosed).toBe(true);
+    });
+  });
+
+  // ── Unsupported provider (openai-whisper) ─────────────────────────
+
+  describe("unsupported provider fallback", () => {
+    test("openai-whisper emits error + closed without crashing", async () => {
+      const { ws, session } = createSession("openai-whisper");
+
+      // Resolve returns null for openai-whisper (no streaming support).
+      await session.start(async () => null);
+
+      const frames = ws.frames;
+      expect(frames.length).toBe(2);
+      expect(frames[0].type).toBe("error");
+      expect(frames[0].category).toBe("provider-error");
+      expect((frames[0].message as string).includes("not supported")).toBe(
+        true,
+      );
+      expect(frames[1].type).toBe("closed");
+
+      // Session should be fully closed.
+      expect(session.isClosed).toBe(true);
+
+      // Socket should be closed cleanly.
+      expect(ws.closed).toBe(true);
+      expect(ws.closeCode).toBe(1000);
+    });
+
+    test("unknown provider emits error + closed without crashing", async () => {
+      const { ws, session } = createSession("nonexistent-provider");
+
+      await session.start(async () => null);
+
+      const frames = ws.frames;
+      expect(frames[0].type).toBe("error");
+      expect(frames[0].category).toBe("provider-error");
+      expect(frames[1].type).toBe("closed");
+      expect(session.isClosed).toBe(true);
+    });
+  });
+
+  // ── Provider start failure ────────────────────────────────────────
+
+  describe("provider start failure", () => {
+    test("emits error + closed when transcriber.start() throws", async () => {
+      const { ws, session } = createSession("deepgram");
+
+      await session.start(async () => new FailingTranscriber());
+
+      const frames = ws.frames;
+      expect(frames[0].type).toBe("error");
+      expect(frames[0].category).toBe("provider-error");
+      expect(
+        (frames[0].message as string).includes(
+          "Mock provider connection refused",
+        ),
+      ).toBe(true);
+      expect(frames[1].type).toBe("closed");
+      expect(session.isClosed).toBe(true);
+      expect(ws.closed).toBe(true);
+    });
+  });
+
+  // ── Client disconnect ─────────────────────────────────────────────
+
+  describe("client disconnect", () => {
+    test("tears down session on WebSocket close", async () => {
+      const { session } = createSession("deepgram");
+      const transcriber = new MockDeepgramTranscriber();
+
+      await session.start(async () => transcriber);
+      expect(session.isClosed).toBe(false);
+
+      // Simulate WebSocket close.
+      session.handleClose(1001, "going away");
+
+      expect(session.isClosed).toBe(true);
+      // Transcriber should have been stopped.
+      expect(transcriber.stopped).toBe(true);
+    });
+
+    test("destroy() is idempotent", async () => {
+      const { session } = createSession("deepgram");
+      const transcriber = new MockDeepgramTranscriber();
+
+      await session.start(async () => transcriber);
+
+      session.destroy();
+      expect(session.isClosed).toBe(true);
+
+      // Calling again should not throw.
+      session.destroy();
+      expect(session.isClosed).toBe(true);
+    });
+  });
+
+  // ── Idle timeout ──────────────────────────────────────────────────
+
+  describe("idle timeout", () => {
+    test("fires timeout error after inactivity", async () => {
+      const { ws, session } = createSession("deepgram", {
+        idleTimeoutMs: 50,
+      });
+      const transcriber = new MockDeepgramTranscriber();
+
+      await session.start(async () => transcriber);
+
+      // Wait for idle timeout to fire.
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      const frames = ws.frames;
+      const errorFrame = frames.find(
+        (f) => f.type === "error" && f.category === "timeout",
+      );
+      expect(errorFrame).toBeDefined();
+      expect(session.isClosed).toBe(true);
+    });
+
+    test("activity resets idle timer", async () => {
+      const { session } = createSession("deepgram", {
+        idleTimeoutMs: 100,
+      });
+      const transcriber = new MockDeepgramTranscriber();
+
+      await session.start(async () => transcriber);
+
+      // Send audio at 50ms, resetting the idle timer.
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      session.handleMessage(
+        JSON.stringify({
+          type: "audio",
+          audio: Buffer.from("keep-alive").toString("base64"),
+        }),
+      );
+
+      // At 100ms from start, original timer would have fired but was reset.
+      await new Promise((resolve) => setTimeout(resolve, 60));
+      expect(session.isClosed).toBe(false);
+
+      // Now wait for the reset timer to fire.
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      expect(session.isClosed).toBe(true);
+    });
+  });
+
+  // ── Event ordering guarantees ─────────────────────────────────────
+
+  describe("event ordering", () => {
+    test("all emitted events have monotonically increasing seq numbers", async () => {
+      const { ws, session } = createSession("deepgram");
+      const transcriber = new MockDeepgramTranscriber();
+
+      await session.start(async () => transcriber);
+
+      // Send several audio frames.
+      for (let i = 0; i < 5; i++) {
+        session.handleMessage(
+          JSON.stringify({
+            type: "audio",
+            audio: Buffer.from(`chunk-${i}`).toString("base64"),
+          }),
+        );
+      }
+
+      // Stop.
+      session.handleMessage(JSON.stringify({ type: "stop" }));
+
+      const allFrames = ws.frames;
+      const seqs = allFrames
+        .filter((f) => typeof f.seq === "number")
+        .map((f) => f.seq as number);
+
+      // Verify strict monotonic ordering.
+      for (let i = 1; i < seqs.length; i++) {
+        expect(seqs[i]).toBe(seqs[i - 1] + 1);
+      }
+
+      // First seq should be 0.
+      expect(seqs[0]).toBe(0);
+    });
+  });
+
+  // ── Edge cases ────────────────────────────────────────────────────
+
+  describe("edge cases", () => {
+    test("audio events in non-active state are dropped", async () => {
+      const { ws, session } = createSession("deepgram");
+
+      // Session is in "initializing" state — audio should be dropped.
+      session.handleMessage(
+        JSON.stringify({
+          type: "audio",
+          audio: Buffer.from("too-early").toString("base64"),
+        }),
+      );
+
+      // No events should be sent (session hasn't started).
+      expect(ws.frames.length).toBe(0);
+    });
+
+    test("stop in non-active state is dropped", async () => {
+      const { ws, session } = createSession("deepgram");
+
+      // Session is in "initializing" state — stop should be dropped.
+      session.handleMessage(JSON.stringify({ type: "stop" }));
+      expect(ws.frames.length).toBe(0);
+    });
+
+    test("non-JSON text frames are silently dropped", async () => {
+      const { ws, session } = createSession("deepgram");
+      const transcriber = new MockDeepgramTranscriber();
+
+      await session.start(async () => transcriber);
+
+      const frameCountBefore = ws.frames.length;
+      session.handleMessage("this is not json");
+      // No new events should be emitted.
+      expect(ws.frames.length).toBe(frameCountBefore);
+    });
+
+    test("unknown event types are silently dropped", async () => {
+      const { ws, session } = createSession("deepgram");
+      const transcriber = new MockDeepgramTranscriber();
+
+      await session.start(async () => transcriber);
+
+      const frameCountBefore = ws.frames.length;
+      session.handleMessage(JSON.stringify({ type: "unknown-event" }));
+      expect(ws.frames.length).toBe(frameCountBefore);
+    });
+
+    test("messages after close are dropped", async () => {
+      const { ws, session } = createSession("deepgram");
+      const transcriber = new MockDeepgramTranscriber();
+
+      await session.start(async () => transcriber);
+      session.handleClose(1000, "normal");
+      expect(session.isClosed).toBe(true);
+
+      const frameCountAfterClose = ws.frames.length;
+      session.handleMessage(
+        JSON.stringify({
+          type: "audio",
+          audio: Buffer.from("after-close").toString("base64"),
+        }),
+      );
+      expect(ws.frames.length).toBe(frameCountAfterClose);
+    });
+
+    test("handleClose is idempotent", async () => {
+      const { ws, session } = createSession("deepgram");
+      const transcriber = new MockDeepgramTranscriber();
+
+      await session.start(async () => transcriber);
+      session.handleClose(1001, "first close");
+      expect(session.isClosed).toBe(true);
+
+      // Calling again should not throw or emit additional events.
+      const frameCountAfter = ws.frames.length;
+      session.handleClose(1001, "second close");
+      expect(ws.frames.length).toBe(frameCountAfter);
+    });
+  });
+});

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -66,10 +66,15 @@ import {
 import type { ExternalConversationBinding } from "../memory/external-conversation-store.js";
 import * as externalConversationStore from "../memory/external-conversation-store.js";
 import { listGroups } from "../memory/group-crud.js";
+import { resolveStreamingTranscriber } from "../providers/speech-to-text/resolve.js";
 import {
   consumeCallback,
   consumeCallbackError,
 } from "../security/oauth-callback-registry.js";
+import {
+  activeSttStreamSessions,
+  SttStreamSession,
+} from "../stt/stt-stream-session.js";
 import { UserError } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
 import { getRuntimePortFilePath } from "../util/platform.js";
@@ -303,16 +308,17 @@ interface MediaStreamWebSocketData {
 /**
  * WebSocket data attached to `/v1/stt/stream` connections.
  * The `wsType` discriminator routes frames to the STT streaming
- * session stub instead of the other WebSocket handlers.
- *
- * This is a minimal deploy-safe stub — provider adapters will be
- * wired in by a later PR.
+ * session orchestrator instead of the other WebSocket handlers.
  */
 interface SttStreamWebSocketData {
   wsType: "stt-stream";
   provider: string;
   mimeType: string;
   sampleRate?: number;
+  /** The session ID for tracking in the active sessions registry. */
+  sessionId: string;
+  /** Bound at open time so the close handler tears down the exact session. */
+  session?: SttStreamSession;
 }
 
 export class RuntimeHttpServer {
@@ -456,11 +462,24 @@ export class RuntimeHttpServer {
           if ("wsType" in data && data.wsType === "stt-stream") {
             const sttData = data as SttStreamWebSocketData;
             log.info(
-              { provider: sttData.provider, mimeType: sttData.mimeType },
-              "STT stream WebSocket opened (stub)",
+              {
+                provider: sttData.provider,
+                mimeType: sttData.mimeType,
+                sessionId: sttData.sessionId,
+              },
+              "STT stream WebSocket opened",
             );
-            // Minimal stub — accept connect cleanly. Provider adapters
-            // will be wired in by a later PR.
+            const session = new SttStreamSession(
+              ws,
+              sttData.provider,
+              sttData.mimeType,
+            );
+            sttData.session = session;
+            activeSttStreamSessions.set(sttData.sessionId, session);
+
+            // Start the session asynchronously — resolves the streaming
+            // transcriber and sends a `ready` event on success.
+            void session.start(() => resolveStreamingTranscriber());
             return;
           }
           const callSessionId = (data as RelayWebSocketData).callSessionId;
@@ -608,7 +627,20 @@ export class RuntimeHttpServer {
             return;
           }
           if ("wsType" in data && data.wsType === "stt-stream") {
-            // Stub: drop inbound audio frames until provider adapters land.
+            const sttData = data as SttStreamWebSocketData;
+            const session = sttData.session;
+            if (!session) return;
+
+            if (typeof message === "string") {
+              session.handleMessage(message);
+            } else {
+              // Binary frame — raw audio bytes.
+              const buffer =
+                message instanceof ArrayBuffer
+                  ? Buffer.from(new Uint8Array(message))
+                  : Buffer.from(message);
+              session.handleBinaryAudio(buffer);
+            }
             return;
           }
           const callSessionId = (data as RelayWebSocketData).callSessionId;
@@ -659,9 +691,23 @@ export class RuntimeHttpServer {
           if ("wsType" in data && data.wsType === "stt-stream") {
             const sttData = data as SttStreamWebSocketData;
             log.info(
-              { provider: sttData.provider, code, reason: reason?.toString() },
-              "STT stream WebSocket closed (stub)",
+              {
+                provider: sttData.provider,
+                sessionId: sttData.sessionId,
+                code,
+                reason: reason?.toString(),
+              },
+              "STT stream WebSocket closed",
             );
+            const session = sttData.session;
+            if (session) {
+              session.handleClose(code, reason?.toString());
+              // Only delete from the map if our session is still the
+              // registered one — avoids races with reconnects.
+              if (activeSttStreamSessions.get(sttData.sessionId) === session) {
+                activeSttStreamSessions.delete(sttData.sessionId);
+              }
+            }
             return;
           }
           const callSessionId = (data as RelayWebSocketData).callSessionId;
@@ -832,6 +878,15 @@ export class RuntimeHttpServer {
       clearInterval(this.retrySweepTimer);
       this.retrySweepTimer = null;
     }
+
+    // Deterministic teardown of active STT streaming sessions before
+    // stopping the HTTP server so provider sessions are cleaned up
+    // and clients receive proper close frames.
+    for (const [sessionId, session] of activeSttStreamSessions) {
+      session.destroy();
+      activeSttStreamSessions.delete(sessionId);
+    }
+
     if (this.server) {
       this.server.stop(true);
       this.server = null;
@@ -1279,12 +1334,14 @@ export class RuntimeHttpServer {
     const sampleRateRaw = wsUrl.searchParams.get("sampleRate");
     const sampleRate = sampleRateRaw ? parseInt(sampleRateRaw, 10) : undefined;
 
+    const sessionId = crypto.randomUUID();
     const upgraded = server.upgrade(req, {
       data: {
         wsType: "stt-stream",
         provider,
         mimeType,
         sampleRate,
+        sessionId,
       } satisfies SttStreamWebSocketData,
     });
     if (!upgraded) {

--- a/assistant/src/stt/stt-stream-session.ts
+++ b/assistant/src/stt/stt-stream-session.ts
@@ -142,6 +142,25 @@ export class SttStreamSession {
 
     try {
       const transcriber = await resolveTranscriber();
+
+      // Guard: session may have been closed while resolveTranscriber() was
+      // in flight (e.g. client disconnect). Abort startup to avoid leaking
+      // a provider stream with no live socket.
+      // Note: Use isClosed to defeat TypeScript control-flow narrowing —
+      // the compiler narrows `this.state` to "initializing" after the
+      // guard at the top of start(), but handleClose() can mutate it
+      // concurrently during the await.
+      if (this.isClosed) {
+        if (transcriber) {
+          try {
+            transcriber.stop();
+          } catch {
+            // Best effort cleanup of the just-resolved transcriber.
+          }
+        }
+        return;
+      }
+
       if (!transcriber) {
         log.info(
           { provider: this.provider },
@@ -163,6 +182,18 @@ export class SttStreamSession {
       await transcriber.start((event: SttStreamServerEvent) => {
         this.handleTranscriberEvent(event);
       });
+
+      // Guard: session may have been closed while transcriber.start() was
+      // in flight. If so, stop the transcriber and bail out.
+      if (this.isClosed) {
+        try {
+          transcriber.stop();
+        } catch {
+          // Best effort cleanup.
+        }
+        this.transcriber = null;
+        return;
+      }
 
       this.state = "active";
       this.resetIdleTimer();
@@ -394,6 +425,9 @@ export class SttStreamSession {
       });
       this.sendEvent({ type: "closed" });
       this.teardown();
+      // Close the WebSocket transport so the connection does not linger
+      // indefinitely (runtime sockets use idleTimeout: 0).
+      this.closeSocket(1000, "idle timeout");
     }, this.idleTimeoutMs);
   }
 

--- a/assistant/src/stt/stt-stream-session.ts
+++ b/assistant/src/stt/stt-stream-session.ts
@@ -1,0 +1,454 @@
+/**
+ * Runtime STT stream session orchestrator.
+ *
+ * Manages the lifecycle of a single streaming transcription session between
+ * a client WebSocket connection and a provider-specific streaming adapter.
+ * The orchestrator accepts client events (`audio`, `stop`), routes audio
+ * frames to the resolved {@link StreamingTranscriber}, and emits normalized
+ * server events (`partial`, `final`, `error`, `closed`) back over the same
+ * WebSocket connection with per-session ordering guarantees.
+ *
+ * Session lifecycle:
+ * 1. Client opens a WebSocket to `/v1/stt/stream` with `provider` and
+ *    `mimeType` query parameters.
+ * 2. The orchestrator resolves a {@link StreamingTranscriber} via
+ *    `resolveStreamingTranscriber()` and starts the provider session.
+ * 3. The client sends `audio` frames (binary or base64-encoded JSON) and
+ *    a `stop` event when recording is complete.
+ * 4. The provider emits `partial` and `final` transcript events which the
+ *    orchestrator forwards to the client as JSON frames.
+ * 5. The session closes deterministically on client disconnect, `stop`
+ *    event, idle timeout, or runtime shutdown.
+ *
+ * Error handling:
+ * - Unsupported providers fail gracefully with a structured `error` event
+ *   followed by `closed`, without crashing the socket.
+ * - Provider errors are caught and forwarded as `error` events.
+ * - An idle timeout fires if no client messages arrive within a
+ *   configurable window.
+ */
+
+import { getLogger } from "../util/logger.js";
+import type { StreamingTranscriber, SttStreamServerEvent } from "./types.js";
+
+const log = getLogger("stt-stream-session");
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Default idle timeout (ms). If no client message (audio or stop) arrives
+ * within this window after the session starts, the session is torn down.
+ * This prevents leaked sessions when a client silently disconnects without
+ * sending a WebSocket close frame.
+ */
+const DEFAULT_IDLE_TIMEOUT_MS = 60_000;
+
+// ---------------------------------------------------------------------------
+// Session state
+// ---------------------------------------------------------------------------
+
+type SessionState =
+  /** Session created, waiting for provider start to complete. */
+  | "initializing"
+  /** Provider started, accepting audio frames. */
+  | "active"
+  /** Client sent stop, waiting for provider to flush finals. */
+  | "stopping"
+  /** Session fully closed (terminal state). */
+  | "closed";
+
+// ---------------------------------------------------------------------------
+// WebSocket interface
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal WebSocket send interface so the orchestrator can be tested
+ * without depending on Bun's full ServerWebSocket type.
+ */
+export interface SttStreamSocket {
+  send(data: string): void;
+  close(code?: number, reason?: string): void;
+}
+
+// ---------------------------------------------------------------------------
+// Options
+// ---------------------------------------------------------------------------
+
+export interface SttStreamSessionOptions {
+  /** Override idle timeout for testing. */
+  idleTimeoutMs?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Session class
+// ---------------------------------------------------------------------------
+
+/**
+ * Manages a single streaming STT session.
+ *
+ * Created by the WebSocket `open` handler in `http-server.ts` and destroyed
+ * on close or timeout. Each session owns exactly one
+ * {@link StreamingTranscriber} instance.
+ */
+export class SttStreamSession {
+  private state: SessionState = "initializing";
+  private transcriber: StreamingTranscriber | null = null;
+  private readonly ws: SttStreamSocket;
+  private readonly provider: string;
+  private readonly mimeType: string;
+  private readonly idleTimeoutMs: number;
+
+  /** Sequence counter for per-session ordering guarantees. */
+  private seq = 0;
+
+  /** Idle timer handle — reset on every inbound client message. */
+  private idleTimer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(
+    ws: SttStreamSocket,
+    provider: string,
+    mimeType: string,
+    options: SttStreamSessionOptions = {},
+  ) {
+    this.ws = ws;
+    this.provider = provider;
+    this.mimeType = mimeType;
+    this.idleTimeoutMs = options.idleTimeoutMs ?? DEFAULT_IDLE_TIMEOUT_MS;
+  }
+
+  // ── Public API ──────────────────────────────────────────────────────
+
+  /**
+   * Initialize the session by resolving and starting the streaming
+   * transcriber. Sends a `ready` event on success or an `error` + `closed`
+   * pair on failure.
+   *
+   * The `resolveTranscriber` parameter is injected so tests can provide
+   * mock transcribers without importing the full resolve.ts module (which
+   * pulls in config, secure-keys, etc.).
+   */
+  async start(
+    resolveTranscriber: () => Promise<StreamingTranscriber | null>,
+  ): Promise<void> {
+    if (this.state !== "initializing") {
+      log.warn(
+        { state: this.state },
+        "SttStreamSession.start() called in non-initializing state",
+      );
+      return;
+    }
+
+    try {
+      const transcriber = await resolveTranscriber();
+      if (!transcriber) {
+        log.info(
+          { provider: this.provider },
+          "Streaming transcriber unavailable for provider",
+        );
+        this.sendEvent({
+          type: "error",
+          category: "provider-error",
+          message: `Streaming transcription is not supported for provider "${this.provider}". Supported providers: deepgram, google-gemini.`,
+        });
+        this.sendEvent({ type: "closed" });
+        this.state = "closed";
+        this.closeSocket(1000, "unsupported provider");
+        return;
+      }
+
+      this.transcriber = transcriber;
+
+      await transcriber.start((event: SttStreamServerEvent) => {
+        this.handleTranscriberEvent(event);
+      });
+
+      this.state = "active";
+      this.resetIdleTimer();
+
+      // Send a ready event so the client knows it can start sending audio.
+      this.sendJson({ type: "ready", provider: transcriber.providerId });
+
+      log.info(
+        { provider: transcriber.providerId },
+        "STT stream session started",
+      );
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      log.error(
+        { provider: this.provider, error: message },
+        "Failed to start STT stream session",
+      );
+      this.sendEvent({
+        type: "error",
+        category: "provider-error",
+        message: `Failed to start streaming session: ${message}`,
+      });
+      this.sendEvent({ type: "closed" });
+      this.state = "closed";
+      this.closeSocket(1011, "provider start failed");
+    }
+  }
+
+  /**
+   * Handle an inbound WebSocket message (text frame).
+   *
+   * Parses the message as a client event and routes to the appropriate
+   * handler. Binary frames containing raw audio are handled by
+   * {@link handleBinaryAudio}.
+   */
+  handleMessage(raw: string): void {
+    if (this.state === "closed") return;
+
+    this.resetIdleTimer();
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      // Not JSON — ignore silently. Could be a malformed frame.
+      log.debug("STT stream: dropped non-JSON text frame");
+      return;
+    }
+
+    if (!parsed || typeof parsed !== "object") return;
+
+    const event = parsed as {
+      type?: string;
+      audio?: string;
+      mimeType?: string;
+    };
+    switch (event.type) {
+      case "audio": {
+        if (this.state !== "active") {
+          log.debug(
+            { state: this.state },
+            "STT stream: dropped audio event in non-active state",
+          );
+          return;
+        }
+        // Audio data may be base64-encoded in a JSON text frame.
+        if (typeof event.audio === "string") {
+          const buffer = Buffer.from(event.audio, "base64");
+          const mime = event.mimeType ?? this.mimeType;
+          this.transcriber?.sendAudio(buffer, mime);
+        }
+        return;
+      }
+      case "stop": {
+        this.handleStop();
+        return;
+      }
+      default: {
+        log.debug(
+          { type: event.type },
+          "STT stream: dropped unknown event type",
+        );
+        return;
+      }
+    }
+  }
+
+  /**
+   * Handle a binary WebSocket message (raw audio bytes).
+   *
+   * This path is used when the client sends audio as binary WebSocket
+   * frames rather than base64-encoded JSON.
+   */
+  handleBinaryAudio(data: Buffer | ArrayBuffer | Uint8Array): void {
+    if (this.state !== "active") return;
+
+    this.resetIdleTimer();
+
+    const buffer = Buffer.isBuffer(data)
+      ? data
+      : Buffer.from(data instanceof ArrayBuffer ? new Uint8Array(data) : data);
+
+    this.transcriber?.sendAudio(buffer, this.mimeType);
+  }
+
+  /**
+   * Handle WebSocket close (client disconnected or transport error).
+   * Tears down the provider session and cleans up resources.
+   */
+  handleClose(code: number, reason?: string): void {
+    if (this.state === "closed") return;
+
+    log.info(
+      { provider: this.provider, code, reason },
+      "STT stream WebSocket closed",
+    );
+
+    this.teardown();
+  }
+
+  /**
+   * Forcibly destroy the session. Called during runtime shutdown to
+   * ensure deterministic cleanup of all active sessions.
+   */
+  destroy(): void {
+    if (this.state === "closed") return;
+
+    log.info({ provider: this.provider }, "STT stream session destroyed");
+    this.teardown();
+  }
+
+  /**
+   * Whether the session is in a terminal state.
+   */
+  get isClosed(): boolean {
+    return this.state === "closed";
+  }
+
+  // ── Internal handlers ──────────────────────────────────────────────
+
+  /**
+   * Handle the client `stop` event. Signals the transcriber to stop
+   * and waits for it to flush remaining finals.
+   */
+  private handleStop(): void {
+    if (this.state !== "active") {
+      log.debug(
+        { state: this.state },
+        "STT stream: stop event in non-active state",
+      );
+      return;
+    }
+
+    this.state = "stopping";
+    this.clearIdleTimer();
+
+    try {
+      this.transcriber?.stop();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      log.error({ error: message }, "Error calling transcriber.stop()");
+      // Force teardown if stop() throws.
+      this.sendEvent({
+        type: "error",
+        category: "provider-error",
+        message: `Error stopping transcriber: ${message}`,
+      });
+      this.sendEvent({ type: "closed" });
+      this.state = "closed";
+      this.closeSocket(1011, "stop failed");
+    }
+  }
+
+  /**
+   * Handle events emitted by the streaming transcriber.
+   */
+  private handleTranscriberEvent(event: SttStreamServerEvent): void {
+    if (this.state === "closed") return;
+
+    this.sendEvent(event);
+
+    // When the transcriber emits `closed`, the session is done.
+    if (event.type === "closed") {
+      this.state = "closed";
+      this.clearIdleTimer();
+      this.closeSocket(1000, "session complete");
+    }
+  }
+
+  // ── Event emission ─────────────────────────────────────────────────
+
+  /**
+   * Send a normalized server event with a monotonic sequence number.
+   */
+  private sendEvent(event: SttStreamServerEvent): void {
+    this.sendJson({ ...event, seq: this.seq++ });
+  }
+
+  /**
+   * Send a JSON object over the WebSocket. Swallows send errors to
+   * prevent cascading failures.
+   */
+  private sendJson(data: Record<string, unknown>): void {
+    try {
+      this.ws.send(JSON.stringify(data));
+    } catch (err) {
+      log.debug(
+        { error: err instanceof Error ? err.message : String(err) },
+        "STT stream: failed to send WebSocket frame",
+      );
+    }
+  }
+
+  // ── Idle timer ─────────────────────────────────────────────────────
+
+  private resetIdleTimer(): void {
+    this.clearIdleTimer();
+
+    if (this.state === "closed" || this.state === "stopping") return;
+
+    this.idleTimer = setTimeout(() => {
+      if (this.state === "closed") return;
+
+      log.warn({ provider: this.provider }, "STT stream session idle timeout");
+      this.sendEvent({
+        type: "error",
+        category: "timeout",
+        message: "STT stream session timed out due to inactivity",
+      });
+      this.sendEvent({ type: "closed" });
+      this.teardown();
+    }, this.idleTimeoutMs);
+  }
+
+  private clearIdleTimer(): void {
+    if (this.idleTimer !== null) {
+      clearTimeout(this.idleTimer);
+      this.idleTimer = null;
+    }
+  }
+
+  // ── Teardown ───────────────────────────────────────────────────────
+
+  /**
+   * Clean up all resources (timers, transcriber, socket).
+   * Idempotent — safe to call multiple times.
+   */
+  private teardown(): void {
+    if (this.state === "closed") return;
+    this.state = "closed";
+
+    this.clearIdleTimer();
+
+    // Stop the transcriber if it is still running. The stop() call may
+    // trigger additional events, but since state is already "closed"
+    // they will be dropped by handleTranscriberEvent().
+    if (this.transcriber) {
+      try {
+        this.transcriber.stop();
+      } catch {
+        // Best effort — the transcriber may already be closed.
+      }
+      this.transcriber = null;
+    }
+  }
+
+  /**
+   * Close the WebSocket connection. Best-effort — already-closed sockets
+   * may throw.
+   */
+  private closeSocket(code: number, reason: string): void {
+    try {
+      this.ws.close(code, reason);
+    } catch {
+      // Already closed — swallow.
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Active session registry
+// ---------------------------------------------------------------------------
+
+/**
+ * Map of active STT stream sessions, keyed by a session identifier derived
+ * from the WebSocket connection. Used by the runtime HTTP server to track
+ * sessions for graceful shutdown.
+ */
+export const activeSttStreamSessions = new Map<string, SttStreamSession>();


### PR DESCRIPTION
## Summary
- Implement runtime STT stream session manager routing client events to provider-specific streaming adapters
- Emit normalized server events (partial, final, error, ready) with per-session ordering guarantees
- Add session lifecycle controls and replace PR2 stub with full orchestrator

Part of plan: streaming-stt-chat-messages.md (PR 5 of 9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25219" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
