### PR TITLE
refactor(macos): simplify dictation composer — single mic toggle replaces X/check buttons

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerController.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerController.swift
@@ -9,9 +9,9 @@ import VellumAssistantShared
 /// currently spread across ComposerView body logic and SwiftUI bindings.
 ///
 /// Accepts explicit events (`textChanged`, `cursorMoved`, `focusChanged`,
-/// `interactionEnabledChanged`, `dictationStarted`, `dictationStopped`)
-/// instead of reading SwiftUI bindings directly. All popup/focus decisions
-/// live here so they can be unit-tested without importing SwiftUI view types.
+/// `interactionEnabledChanged`) instead of reading SwiftUI bindings
+/// directly. All popup/focus decisions live here so they can be
+/// unit-tested without importing SwiftUI view types.
 @Observable
 @MainActor
 final class ComposerController {
@@ -45,9 +45,6 @@ final class ComposerController {
     @ObservationIgnored private(set) var suppressEmojiReopen = false
 
     // MARK: - Internal bookkeeping
-
-    /// Snapshot of input text captured when dictation starts, used to restore on cancel.
-    @ObservationIgnored private(set) var preDictationText: String = ""
 
     /// Current cursor position (UTF-16 offset).
     @ObservationIgnored private var cursorPosition: Int = 0
@@ -114,16 +111,6 @@ final class ComposerController {
             suppressSlashReopen = false
             suppressEmojiReopen = false
         }
-    }
-
-    /// Called when dictation starts.
-    func dictationStarted() {
-        preDictationText = inputText
-    }
-
-    /// Called when dictation stops (accepted or cancelled).
-    func dictationStopped() {
-        preDictationText = ""
     }
 
     // MARK: - Menu refresh scheduling

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -56,22 +56,18 @@ struct ComposerView: View, Equatable {
 
     // MARK: - ComposerMode
 
-    /// Three-mode state machine for the composer.
+    /// Two-mode state machine for the composer.
     private enum ComposerMode: Equatable {
         /// Normal text entry with attach/send buttons.
         case textEntry
-        /// Inline dictation: text field visible with a recording strip below.
-        case dictationInline
         /// Full voice conversation with inverse/high-contrast container.
         case voiceConversation
     }
 
-    /// The current mode derived from recording and voice-mode state.
+    /// The current mode derived from voice-mode state.
     private var currentMode: ComposerMode {
         if voiceModeManager.map({ $0.state != .off }) ?? false {
             return .voiceConversation
-        } else if isRecording {
-            return .dictationInline
         } else {
             return .textEntry
         }
@@ -157,13 +153,10 @@ struct ComposerView: View, Equatable {
                 .transition(.opacity.combined(with: .move(edge: .bottom)))
             }
 
-            // Composer box — switches on the three-mode state machine
+            // Composer box — switches on the two-mode state machine
             switch currentMode {
             case .voiceConversation:
                 voiceConversationComposer
-
-            case .dictationInline:
-                dictationInlineComposer
 
             case .textEntry:
                 textEntryComposer
@@ -199,9 +192,6 @@ struct ComposerView: View, Equatable {
         }
         .onChange(of: currentMode) {
             composerLog.debug("Composer mode: \(String(describing: currentMode))")
-            if currentMode == .dictationInline {
-                composerController.dictationStarted()
-            }
         }
         .onChange(of: isInteractionEnabled) { _, enabled in
             composerController.interactionEnabledChanged(enabled, hasPendingConfirmation: hasPendingConfirmation)
@@ -407,7 +397,7 @@ struct ComposerView: View, Equatable {
 
     // MARK: - Text Entry Mode
 
-    /// Standard composer shell with border, used for textEntry and dictationInline modes.
+    /// Standard composer shell with border, used for textEntry mode.
     @ViewBuilder
     private func standardComposerShell<Content: View>(@ViewBuilder content: () -> Content) -> some View {
         VStack(spacing: 0) {
@@ -433,8 +423,24 @@ struct ComposerView: View, Equatable {
                 composerTextField
                     .padding(.leading, VSpacing.xs)
                     .frame(minHeight: composerActionButtonSize)
+
+                if isRecording {
+                    VStreamingWaveform(
+                        amplitude: liveAmplitude,
+                        isActive: true,
+                        style: .scrolling,
+                        foregroundColor: VColor.contentTertiary,
+                        lineWidth: 2
+                    )
+                    .frame(height: 32)
+                    .frame(maxWidth: .infinity)
+                }
+
                 composerActionBar
             }
+        }
+        .onReceive(VoiceInputManager.amplitudeSubject.receive(on: RunLoop.main)) { amp in
+            liveAmplitude = amp
         }
     }
 
@@ -582,64 +588,6 @@ struct ComposerView: View, Equatable {
                     performSendAction()
                 }
             }
-        }
-    }
-
-    // MARK: - Dictation Inline Mode
-
-
-    @ViewBuilder
-    private var dictationInlineComposer: some View {
-        standardComposerShell {
-            VStack(spacing: VSpacing.sm) {
-                // Text field remains visible for live transcription
-                composerTextField
-                    .frame(minHeight: composerActionButtonSize)
-
-                // Inline recording strip
-                HStack(alignment: .center, spacing: VSpacing.sm) {
-VStreamingWaveform(
-                        amplitude: liveAmplitude,
-                        isActive: true,
-                        style: .scrolling,
-                        foregroundColor: VColor.contentTertiary,
-                        lineWidth: 2
-                    )
-                    .padding(.trailing, VSpacing.lg)
-                    .frame(height: 44)
-                    .frame(maxWidth: .infinity)
-
-                    // Cancel: stop dictation and discard transcribed text
-                    VButton(
-                        label: "Cancel dictation",
-                        iconOnly: VIcon.x.rawValue,
-                        style: .danger,
-                        iconSize: composerActionButtonSize,
-                        action: {
-                            inputText = composerController.preDictationText
-                            composerController.dictationStopped()
-                            (onDictateToggle ?? onMicrophoneToggle)()
-                        }
-                    )
-                    .vTooltip("Cancel")
-
-                    // Accept: stop dictation and keep transcribed text
-                    VButton(
-                        label: "Accept dictation",
-                        iconOnly: VIcon.check.rawValue,
-                        style: .primary,
-                        iconSize: composerActionButtonSize,
-                        action: {
-                            composerController.dictationStopped()
-                            (onDictateToggle ?? onMicrophoneToggle)()
-                        }
-                    )
-                    .vTooltip("Done")
-                }
-            }
-        }
-        .onReceive(VoiceInputManager.amplitudeSubject.receive(on: RunLoop.main)) { amp in
-            liveAmplitude = amp
         }
     }
 

--- a/clients/macos/vellum-assistantTests/ComposerControllerTests.swift
+++ b/clients/macos/vellum-assistantTests/ComposerControllerTests.swift
@@ -496,28 +496,6 @@ final class ComposerControllerTests: XCTestCase {
         XCTAssertFalse(controller.suppressEmojiReopen)
     }
 
-    // MARK: - Dictation
-
-    @MainActor
-    func testDictationStartedCapturesPreDictationText() {
-        let controller = makeController()
-        controller.textChanged("hello world")
-        controller.dictationStarted()
-
-        XCTAssertEqual(controller.preDictationText, "hello world")
-    }
-
-    @MainActor
-    func testDictationStoppedClearsPreDictationText() {
-        let controller = makeController()
-        controller.textChanged("hello world")
-        controller.dictationStarted()
-        XCTAssertEqual(controller.preDictationText, "hello world")
-
-        controller.dictationStopped()
-        XCTAssertEqual(controller.preDictationText, "")
-    }
-
     // MARK: - Query helpers
 
     @MainActor

--- a/clients/shared/DesignSystem/Gallery/Sections/ChatGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/ChatGallerySection.swift
@@ -12,7 +12,7 @@ struct ChatGallerySection: View {
                 // MARK: - VStreamingWaveform
                 GallerySectionHeader(
                     title: "VStreamingWaveform",
-                    description: "Streaming waveform in composer context. The composer has three modes: textEntry, dictationInline (with dictation-style waveform), and voiceConversation (with conversation-style waveform)."
+                    description: "Streaming waveform in composer context. The composer has two modes: textEntry (with inline waveform during recording) and voiceConversation (with conversation-style waveform)."
                 )
 
                 VCard {


### PR DESCRIPTION
## Summary
- Remove dictationInline composer mode with its cancel (X) and accept (check) buttons
- Dictation now uses the standard textEntry composer with the mic button toggling to stop
- Add waveform visualization to textEntry mode during recording for amplitude feedback
- Remove dead preDictationText tracking code from ComposerController and its tests
- Matches the simpler UX pattern used by Claude, Codex, and other voice input UIs
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25220" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
