### PR TITLE
feat: add source links and install counts to skill detail page

### DIFF
--- a/clients/ios/Views/Intelligence/SkillDetailView.swift
+++ b/clients/ios/Views/Intelligence/SkillDetailView.swift
@@ -183,10 +183,7 @@ struct SkillDetailView: View {
                 .font(VFont.labelDefault)
                 .foregroundStyle(VColor.contentTertiary)
             Spacer()
-            Link(destination: destination) {
-                Text(text)
-                    .font(VFont.bodyMediumLighter)
-            }
+            VLink(text, destination: destination, font: VFont.bodyMediumLighter)
         }
         .accessibilityElement(children: .combine)
         .accessibilityLabel("\(label): \(text)")

--- a/clients/ios/Views/Intelligence/SkillDetailView.swift
+++ b/clients/ios/Views/Intelligence/SkillDetailView.swift
@@ -177,6 +177,21 @@ struct SkillDetailView: View {
         .accessibilityLabel("\(label): \(value)")
     }
 
+    private func detailLinkRow(label: String, text: String, destination: URL) -> some View {
+        HStack {
+            Text(label)
+                .font(VFont.labelDefault)
+                .foregroundStyle(VColor.contentTertiary)
+            Spacer()
+            Link(destination: destination) {
+                Text(text)
+                    .font(VFont.bodyMediumLighter)
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(label): \(text)")
+    }
+
     // MARK: - File Row
 
     @ViewBuilder
@@ -241,15 +256,24 @@ struct SkillDetailView: View {
     private var detailsSection: some View {
         switch skill.originMeta {
         case .clawhub(let meta):
-            if !meta.author.isEmpty {
-                detailRow(label: "Author", value: meta.author)
+            if let url = meta.hubURL {
+                detailLinkRow(label: "Source", text: meta.sourceLabel, destination: url)
+            } else {
+                detailRow(label: "Source", value: meta.sourceLabel)
             }
-            if meta.stars > 0 {
-                detailRow(label: "Stars", value: "\(meta.stars)")
+            if meta.installs > 0 {
+                detailRow(label: "Installs", value: "\(meta.installs)")
             }
         case .skillssh(let meta):
             if !meta.sourceRepo.isEmpty {
-                detailRow(label: "Source Repo", value: meta.sourceRepo)
+                if let url = meta.hubURL {
+                    detailLinkRow(label: "Source", text: meta.sourceRepo, destination: url)
+                } else {
+                    detailRow(label: "Source", value: meta.sourceRepo)
+                }
+            }
+            if meta.installs > 0 {
+                detailRow(label: "Installs", value: "\(meta.installs)")
             }
         case .vellum, .custom:
             EmptyView()

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillDetailView.swift
@@ -181,14 +181,15 @@ struct SkillDetailView: View {
             HStack(spacing: VSpacing.lg) {
                 HStack(spacing: VSpacing.xs) {
                     VIconView(.gitBranch, size: 12)
+                        .foregroundStyle(VColor.contentTertiary)
                     if let url = meta.hubURL {
                         VLink(meta.sourceLabel, destination: url)
                     } else {
                         Text(meta.sourceLabel)
                             .font(VFont.labelDefault)
+                            .foregroundStyle(VColor.contentTertiary)
                     }
                 }
-                .foregroundStyle(VColor.contentTertiary)
                 if meta.installs > 0 {
                     HStack(spacing: VSpacing.xs) {
                         VIconView(.arrowDownToLine, size: 12)
@@ -203,14 +204,15 @@ struct SkillDetailView: View {
                 if !meta.sourceRepo.isEmpty {
                     HStack(spacing: VSpacing.xs) {
                         VIconView(.gitBranch, size: 12)
+                            .foregroundStyle(VColor.contentTertiary)
                         if let url = meta.hubURL {
                             VLink(meta.sourceRepo, destination: url)
                         } else {
                             Text(meta.sourceRepo)
                                 .font(VFont.labelDefault)
+                                .foregroundStyle(VColor.contentTertiary)
                         }
                     }
-                    .foregroundStyle(VColor.contentTertiary)
                 }
                 if meta.installs > 0 {
                     HStack(spacing: VSpacing.xs) {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillDetailView.swift
@@ -179,22 +179,16 @@ struct SkillDetailView: View {
         switch skill.originMeta {
         case .clawhub(let meta):
             HStack(spacing: VSpacing.lg) {
-                if !meta.author.isEmpty {
-                    HStack(spacing: VSpacing.xs) {
-                        VIconView(.user, size: 12)
-                        Text(meta.author)
+                HStack(spacing: VSpacing.xs) {
+                    VIconView(.gitBranch, size: 12)
+                    if let url = meta.hubURL {
+                        VLink(meta.sourceLabel, destination: url)
+                    } else {
+                        Text(meta.sourceLabel)
                             .font(VFont.labelDefault)
                     }
-                    .foregroundStyle(VColor.contentTertiary)
                 }
-                if meta.stars > 0 {
-                    HStack(spacing: VSpacing.xs) {
-                        VIconView(.star, size: 12)
-                        Text("\(meta.stars)")
-                            .font(VFont.labelDefault)
-                    }
-                    .foregroundStyle(VColor.contentTertiary)
-                }
+                .foregroundStyle(VColor.contentTertiary)
                 if meta.installs > 0 {
                     HStack(spacing: VSpacing.xs) {
                         VIconView(.arrowDownToLine, size: 12)
@@ -209,8 +203,12 @@ struct SkillDetailView: View {
                 if !meta.sourceRepo.isEmpty {
                     HStack(spacing: VSpacing.xs) {
                         VIconView(.gitBranch, size: 12)
-                        Text(meta.sourceRepo)
-                            .font(VFont.labelDefault)
+                        if let url = meta.hubURL {
+                            VLink(meta.sourceRepo, destination: url)
+                        } else {
+                            Text(meta.sourceRepo)
+                                .font(VFont.labelDefault)
+                        }
                     }
                     .foregroundStyle(VColor.contentTertiary)
                 }

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -1098,6 +1098,17 @@ public struct ClawhubOriginMeta: Codable, Sendable, Equatable {
     public let reports: Int
     public let publishedAt: String?
     public let version: String?
+
+    /// Display label for the source row (e.g. "pskoett/self-improving-agent").
+    public var sourceLabel: String {
+        author.isEmpty ? slug : "\(author)/\(slug)"
+    }
+
+    /// URL to this skill's page on clawhub.ai, or nil when author is missing.
+    public var hubURL: URL? {
+        guard !author.isEmpty else { return nil }
+        return URL(string: "https://clawhub.ai/\(author)/\(slug)")
+    }
 }
 
 /// Origin-specific metadata for a skill sourced from Skills.sh.
@@ -1106,6 +1117,13 @@ public struct SkillsshOriginMeta: Codable, Sendable, Equatable {
     public let sourceRepo: String
     public let installs: Int
     public let audit: [String: PartnerAudit]?
+
+    /// URL to this skill's page on skills.sh.
+    public var hubURL: URL? {
+        guard !sourceRepo.isEmpty else { return nil }
+        let skillName = slug.split(separator: "/").last.map(String.init) ?? slug
+        return URL(string: "https://skills.sh/\(sourceRepo)/\(skillName)")
+    }
 }
 
 /// Discriminated union over the `origin` field of a skill.

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -1104,12 +1104,23 @@ public struct ClawhubOriginMeta: Codable, Sendable, Equatable {
         author.isEmpty ? slug : "\(author)/\(slug)"
     }
 
-    /// URL to this skill's page on clawhub.ai, or nil when author is missing.
+    /// URL to this skill's page on clawhub.ai.
+    /// Uses `author/slug` when author is known; falls back to the raw slug
+    /// when it already contains a "/" (installed skills may store `author/slug`
+    /// as the slug itself). Returns nil only when no valid path can be built.
     public var hubURL: URL? {
-        guard !author.isEmpty else { return nil }
-        let encodedAuthor = author.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? author
-        let encodedSlug = slug.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? slug
-        return URL(string: "https://clawhub.ai/\(encodedAuthor)/\(encodedSlug)")
+        let path: String
+        if !author.isEmpty {
+            path = "\(author)/\(slug)"
+        } else if slug.contains("/") {
+            path = slug
+        } else {
+            return nil
+        }
+        let encoded = path.split(separator: "/").map {
+            String($0).addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? String($0)
+        }.joined(separator: "/")
+        return URL(string: "https://clawhub.ai/\(encoded)")
     }
 }
 

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -1107,7 +1107,9 @@ public struct ClawhubOriginMeta: Codable, Sendable, Equatable {
     /// URL to this skill's page on clawhub.ai, or nil when author is missing.
     public var hubURL: URL? {
         guard !author.isEmpty else { return nil }
-        return URL(string: "https://clawhub.ai/\(author)/\(slug)")
+        let encodedAuthor = author.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? author
+        let encodedSlug = slug.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? slug
+        return URL(string: "https://clawhub.ai/\(encodedAuthor)/\(encodedSlug)")
     }
 }
 
@@ -1122,7 +1124,12 @@ public struct SkillsshOriginMeta: Codable, Sendable, Equatable {
     public var hubURL: URL? {
         guard !sourceRepo.isEmpty else { return nil }
         let skillName = slug.split(separator: "/").last.map(String.init) ?? slug
-        return URL(string: "https://skills.sh/\(sourceRepo)/\(skillName)")
+        // Encode each path segment separately to preserve the separator slash in sourceRepo.
+        let encodedPath = sourceRepo.split(separator: "/").map {
+            String($0).addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? String($0)
+        }.joined(separator: "/")
+        let encodedSkillName = skillName.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? skillName
+        return URL(string: "https://skills.sh/\(encodedPath)/\(encodedSkillName)")
     }
 }
 


### PR DESCRIPTION
## Summary
- Added `hubURL` and `sourceLabel` computed properties to `ClawhubOriginMeta` and `SkillsshOriginMeta` for constructing links to clawhub.ai and skills.sh hub pages
- Updated macOS skill detail `originMetaRow` to show clawhub source as `author/slug` (matching skills.sh layout) with clickable link via `VLink`, and made skills.sh `sourceRepo` clickable too
- Updated iOS skill detail `detailsSection` with linked source rows and install counts for both origins

## Original prompt
Add source links and install counts to the Skill detail page for both clawhub and skills.sh origins. Clawhub should show a source identifier (author/slug) like skills.sh does, and both should be clickable links to their respective hub pages (clawhub.ai, skills.sh). Install counts should be shown for both.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25221" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
