### PR TITLE
Add browser_status diagnostics and stabilize browser mode constants

### DIFF
--- a/assistant/src/__tests__/browser-skill-baseline-tool-payload.test.ts
+++ b/assistant/src/__tests__/browser-skill-baseline-tool-payload.test.ts
@@ -41,12 +41,12 @@ describe("browser skill cutover — startup tool payload", () => {
     }
   });
 
-  test("total tool definition count reflects removal of 16 browser tools", () => {
+  test("total tool definition count reflects removal of browser tools", () => {
     const definitions = getAllToolDefinitions();
     // Startup has ~20 definitions after moving scaffold/settings/skill-management
     // tools to bundled skills (no browser tools).
     // Allow wider drift for unrelated tool additions while still failing if
-    // browser tools are reintroduced at startup (+16 definitions).
+    // browser tools are reintroduced at startup (+many definitions).
     expect(definitions.length).toBeGreaterThanOrEqual(15);
     expect(definitions.length).toBeLessThanOrEqual(50);
   });

--- a/assistant/src/__tests__/browser-skill-endstate.test.ts
+++ b/assistant/src/__tests__/browser-skill-endstate.test.ts
@@ -61,6 +61,7 @@ describe("browser skill migration end-state", () => {
     "browser_extract",
     "browser_wait_for_download",
     "browser_fill_credential",
+    "browser_status",
   ] as const;
 
   // ── 1. Startup payload excludes browser tools ──────────────────────
@@ -83,7 +84,7 @@ describe("browser skill migration end-state", () => {
     // Startup has ~20 definitions after moving scaffold/settings/skill-management
     // tools to bundled skills (no browser tools).
     // Allow wider drift for unrelated tool additions while still failing if
-    // browser tools are reintroduced at startup (+16 definitions).
+    // browser tools are reintroduced at startup (+many definitions).
     expect(definitions.length).toBeGreaterThanOrEqual(15);
     expect(definitions.length).toBeLessThanOrEqual(50);
 
@@ -112,7 +113,7 @@ describe("browser skill migration end-state", () => {
     expect(fs.existsSync(path.join(skillDir, "TOOLS.json"))).toBe(true);
   });
 
-  test("browser TOOLS.json contains all 16 tools", async () => {
+  test("browser TOOLS.json contains all browser tools", async () => {
     const path = await import("node:path");
     const fs = await import("node:fs");
     const toolsPath = path.resolve(
@@ -121,7 +122,7 @@ describe("browser skill migration end-state", () => {
     );
     const manifest = JSON.parse(fs.readFileSync(toolsPath, "utf-8"));
     expect(manifest.version).toBe(1);
-    expect(manifest.tools).toHaveLength(16);
+    expect(manifest.tools).toHaveLength(BROWSER_TOOLS.length);
     const toolNames = manifest.tools.map((t: { name: string }) => t.name);
     for (const name of BROWSER_TOOLS) {
       expect(toolNames).toContain(name);
@@ -174,7 +175,7 @@ describe("browser skill migration end-state", () => {
 
   // ── 4. Tool wrapper scripts exist ──────────────────────────────────
 
-  test("all 16 browser tool wrapper scripts exist", async () => {
+  test("all browser tool wrapper scripts exist", async () => {
     const path = await import("node:path");
     const fs = await import("node:fs");
     const toolsDir = path.resolve(
@@ -198,6 +199,7 @@ describe("browser skill migration end-state", () => {
       "browser-extract.ts",
       "browser-wait-for-download.ts",
       "browser-fill-credential.ts",
+      "browser-status.ts",
     ];
     for (const file of wrapperFiles) {
       expect(fs.existsSync(path.join(toolsDir, file))).toBe(true);
@@ -234,9 +236,9 @@ describe("browser skill migration end-state", () => {
     }
   });
 
-  // ── 6. Runtime projection adds exactly 16 browser tools ──────────
+  // ── 6. Runtime projection adds all browser tools ──────────
 
-  test("skill_load projection adds all 16 browser tools", () => {
+  test("skill_load projection adds all browser tools", () => {
     const history = buildSkillLoadHistory(BROWSER_SKILL_ID);
     const tracking = new Map<string, string>();
 
@@ -249,7 +251,7 @@ describe("browser skill migration end-state", () => {
       // skill_execute), so toolDefinitions is expected to be empty.
       expect(projection.toolDefinitions).toHaveLength(0);
 
-      // All 16 browser tools should be registered and tracked in allowedToolNames
+      // All browser tools should be registered and tracked in allowedToolNames
       expect(projection.allowedToolNames.size).toBe(BROWSER_TOOL_COUNT);
       for (const name of BROWSER_TOOL_NAMES) {
         expect(projection.allowedToolNames.has(name)).toBe(true);

--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -1637,11 +1637,7 @@ describe("Permission Checker", () => {
       }
 
       // Literal guardian path is auto-allowed.
-      const literal = await check(
-        "file_edit",
-        { path: guardianPath },
-        "/tmp",
-      );
+      const literal = await check("file_edit", { path: guardianPath }, "/tmp");
       expect(literal.decision).toBe("allow");
       expect(literal.matchedRule?.id).toBe(
         "default:allow-file_edit-guardian-persona",
@@ -1649,11 +1645,7 @@ describe("Permission Checker", () => {
 
       // A sibling file that would match if `*` / `[...]` were treated as
       // wildcards must NOT match the dynamic guardian-persona rule.
-      const sibling = await check(
-        "file_edit",
-        { path: siblingPath },
-        "/tmp",
-      );
+      const sibling = await check("file_edit", { path: siblingPath }, "/tmp");
       expect(sibling.matchedRule?.id).not.toBe(
         "default:allow-file_edit-guardian-persona",
       );
@@ -4382,8 +4374,8 @@ describe("Permission Checker", () => {
   });
 
   // ── browser tool permission baselines ─────────────────────────────
-  // All 10 browser tools are core-registered and RiskLevel.Low by default.
-  // These tests lock that baseline so the migration can verify it's preserved.
+  // Representative browser tools are RiskLevel.Low and auto-allowed by
+  // default rules in strict mode.
 
   describe("browser tool permission baselines", () => {
     const browserToolNames = [
@@ -4399,6 +4391,7 @@ describe("Permission Checker", () => {
       "browser_wait_for",
       "browser_extract",
       "browser_fill_credential",
+      "browser_status",
     ] as const;
 
     // Register mock browser tools with the correct metadata so classifyRisk
@@ -4497,6 +4490,7 @@ describe("Permission Checker", () => {
         "browser_wait_for",
         "browser_extract",
         "browser_fill_credential",
+        "browser_status",
       ];
 
       for (const tool of browserTools) {

--- a/assistant/src/__tests__/conversation-skill-tools.test.ts
+++ b/assistant/src/__tests__/conversation-skill-tools.test.ts
@@ -1829,7 +1829,7 @@ describe("bundled skill: browser", () => {
     sessionState = new Map<string, string>();
   });
 
-  test("browser skill activation via loaded_skill marker registers all 16 tools in allowedToolNames", () => {
+  test("browser skill activation via loaded_skill marker registers all browser tools in allowedToolNames", () => {
     mockCatalog = [makeSkill("browser", "/path/to/bundled-skills/browser")];
     mockManifests = { browser: makeManifest([...BROWSER_TOOL_NAMES]) };
 
@@ -1876,7 +1876,7 @@ describe("bundled skill: browser", () => {
 
     const tools = mockRegisteredTools.get("browser");
     expect(tools).toBeDefined();
-    expect(tools!.length).toBe(16);
+    expect(tools!.length).toBe(BROWSER_TOOL_NAMES.length);
 
     for (const tool of tools!) {
       expect(tool.origin).toBe("skill");
@@ -2610,12 +2610,13 @@ describe("browser skill migration harness", () => {
     expect(id1).not.toBe(id2);
   });
 
-  test("BROWSER_TOOL_NAMES contains all 16 browser tools", () => {
-    expect(BROWSER_TOOL_NAMES).toHaveLength(16);
+  test("BROWSER_TOOL_NAMES contains all browser tools", () => {
+    expect(BROWSER_TOOL_NAMES).toHaveLength(17);
     expect(BROWSER_TOOL_NAMES).toContain("browser_navigate");
     expect(BROWSER_TOOL_NAMES).toContain("browser_attach");
     expect(BROWSER_TOOL_NAMES).toContain("browser_detach");
     expect(BROWSER_TOOL_NAMES).toContain("browser_fill_credential");
+    expect(BROWSER_TOOL_NAMES).toContain("browser_status");
   });
 
   test("assertBrowserToolsPresent passes when all tools present", () => {

--- a/assistant/src/__tests__/skills.test.ts
+++ b/assistant/src/__tests__/skills.test.ts
@@ -549,14 +549,14 @@ describe("bundled browser skill", () => {
     );
   });
 
-  test("browser skill has a valid tool manifest with 16 tools", () => {
+  test("browser skill has a valid tool manifest with all browser tools", () => {
     const catalog = loadSkillCatalog();
     const browserSkill = catalog.find((s) => s.id === "browser");
     expect(browserSkill).toBeDefined();
     expect(browserSkill!.toolManifest).toBeDefined();
     expect(browserSkill!.toolManifest!.present).toBe(true);
     expect(browserSkill!.toolManifest!.valid).toBe(true);
-    expect(browserSkill!.toolManifest!.toolCount).toBe(16);
+    expect(browserSkill!.toolManifest!.toolCount).toBe(17);
     expect(browserSkill!.toolManifest!.toolNames).toEqual([
       "browser_navigate",
       "browser_snapshot",
@@ -574,6 +574,7 @@ describe("bundled browser skill", () => {
       "browser_extract",
       "browser_wait_for_download",
       "browser_fill_credential",
+      "browser_status",
     ]);
   });
 });

--- a/assistant/src/__tests__/test-support/browser-skill-harness.ts
+++ b/assistant/src/__tests__/test-support/browser-skill-harness.ts
@@ -1,6 +1,6 @@
 import type { Message } from "../../providers/types.js";
 
-/** The 16 browser tool names provided by the browser skill. */
+/** The browser tool names provided by the browser skill. */
 export const BROWSER_TOOL_NAMES = [
   "browser_navigate",
   "browser_snapshot",
@@ -18,6 +18,7 @@ export const BROWSER_TOOL_NAMES = [
   "browser_extract",
   "browser_wait_for_download",
   "browser_fill_credential",
+  "browser_status",
 ] as const;
 
 /** Number of browser tools provided by the skill. */

--- a/assistant/src/__tests__/trust-store.test.ts
+++ b/assistant/src/__tests__/trust-store.test.ts
@@ -753,6 +753,7 @@ describe("Trust Store", () => {
         "browser_scroll",
         "browser_select_option",
         "browser_snapshot",
+        "browser_status",
         "browser_type",
         "browser_wait_for",
         "browser_wait_for_download",

--- a/assistant/src/__tests__/trust-store.test.ts
+++ b/assistant/src/__tests__/trust-store.test.ts
@@ -1080,7 +1080,7 @@ describe("Trust Store", () => {
 
     // ── default allow: browser tools ────────────────────────────
 
-    test("all 16 browser tools have default allow rules", () => {
+    test("all browser tools have default allow rules", () => {
       const templates = getDefaultRuleTemplates();
       const browserTools = [
         "browser_navigate",
@@ -1099,6 +1099,7 @@ describe("Trust Store", () => {
         "browser_extract",
         "browser_wait_for_download",
         "browser_fill_credential",
+        "browser_status",
       ];
 
       for (const tool of browserTools) {

--- a/assistant/src/config/bundled-skills/browser/SKILL.md
+++ b/assistant/src/config/bundled-skills/browser/SKILL.md
@@ -29,6 +29,7 @@ Use this skill to browse the web. After loading this skill, the following browse
 - `browser_extract` - Extract page text content
 - `browser_wait_for_download` - Wait for a file download to complete
 - `browser_fill_credential` - Fill a stored credential into a form field
+- `browser_status` - Diagnose browser backend readiness and setup steps
 
 ## Capabilities
 
@@ -56,12 +57,13 @@ Every browser tool accepts an optional `browser_mode` parameter that controls wh
 
 ## Typical Workflow
 
-1. `browser_attach` to establish the debugger session (extension path; optional on other backends)
-2. `browser_navigate` to load a page
-3. `browser_snapshot` to discover interactive elements
-4. Use `browser_click`, `browser_type`, `browser_press_key`, `browser_scroll`, `browser_select_option`, or `browser_hover` to interact
-5. `browser_extract` or `browser_screenshot` to capture results
-6. `browser_detach` to end the debugger session, or `browser_close` to close the page entirely
+1. (Optional) `browser_status` to diagnose backend availability and remediation when setup is unclear
+2. `browser_attach` to establish the debugger session (extension path; optional on other backends)
+3. `browser_navigate` to load a page
+4. `browser_snapshot` to discover interactive elements
+5. Use `browser_click`, `browser_type`, `browser_press_key`, `browser_scroll`, `browser_select_option`, or `browser_hover` to interact
+6. `browser_extract` or `browser_screenshot` to capture results
+7. `browser_detach` to end the debugger session, or `browser_close` to close the page entirely
 
 ## Interaction Strategies
 

--- a/assistant/src/config/bundled-skills/browser/TOOLS.json
+++ b/assistant/src/config/bundled-skills/browser/TOOLS.json
@@ -486,6 +486,31 @@
       },
       "executor": "tools/browser-fill-credential.ts",
       "execution_target": "host"
+    },
+    {
+      "name": "browser_status",
+      "description": "Check browser backend readiness and remediation guidance. Reports per-mode availability, verification method, setup steps, and trade-offs for extension, cdp-inspect, and local Playwright modes.",
+      "category": "browser",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "browser_mode": {
+            "type": "string",
+            "description": "Optional scope override for this status check. Use auto (default) to check all modes, or set extension/cdp-inspect/local to check only one mode. Aliases: cdp-debugger -> cdp-inspect, playwright -> local."
+          },
+          "check_local_launch": {
+            "type": "boolean",
+            "description": "If true, run an active local Playwright launch probe. Default false (preflight-only) to avoid creating a new local browser page during diagnostics."
+          },
+          "activity": {
+            "type": "string",
+            "description": "Brief non-technical explanation of why this tool is being called"
+          }
+        }
+      },
+      "executor": "tools/browser-status.ts",
+      "execution_target": "host"
     }
   ]
 }

--- a/assistant/src/config/bundled-skills/browser/tools/browser-status.ts
+++ b/assistant/src/config/bundled-skills/browser/tools/browser-status.ts
@@ -1,0 +1,12 @@
+import { executeBrowserStatus } from "../../../../tools/browser/browser-execution.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executeBrowserStatus(input, context);
+}

--- a/assistant/src/config/bundled-tool-registry.ts
+++ b/assistant/src/config/bundled-tool-registry.ts
@@ -36,6 +36,7 @@ import * as browserScreenshot from "./bundled-skills/browser/tools/browser-scree
 import * as browserScroll from "./bundled-skills/browser/tools/browser-scroll.js";
 import * as browserSelectOption from "./bundled-skills/browser/tools/browser-select-option.js";
 import * as browserSnapshot from "./bundled-skills/browser/tools/browser-snapshot.js";
+import * as browserStatus from "./bundled-skills/browser/tools/browser-status.js";
 import * as browserType from "./bundled-skills/browser/tools/browser-type.js";
 import * as browserWaitFor from "./bundled-skills/browser/tools/browser-wait-for.js";
 import * as browserWaitForDownload from "./bundled-skills/browser/tools/browser-wait-for-download.js";
@@ -221,6 +222,7 @@ export const bundledToolRegistry = new Map<string, SkillToolScript>([
   ["browser:tools/browser-extract.ts", browserExtract],
   ["browser:tools/browser-wait-for-download.ts", browserWaitForDownload],
   ["browser:tools/browser-fill-credential.ts", browserFillCredential],
+  ["browser:tools/browser-status.ts", browserStatus],
 
   // chatgpt-import
   ["chatgpt-import:tools/chatgpt-import.ts", chatgptImport],

--- a/assistant/src/permissions/defaults.ts
+++ b/assistant/src/permissions/defaults.ts
@@ -304,6 +304,7 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
     "browser_extract",
     "browser_wait_for_download",
     "browser_fill_credential",
+    "browser_status",
   ] as const;
 
   const browserToolRules: DefaultRuleTemplate[] = BROWSER_TOOLS_NO_SLASH.map(

--- a/assistant/src/permissions/workspace-policy.ts
+++ b/assistant/src/permissions/workspace-policy.ts
@@ -67,6 +67,7 @@ const NETWORK_TOOLS = new Set([
   "browser_close",
   "browser_attach",
   "browser_detach",
+  "browser_status",
   "network_request",
 ]);
 

--- a/assistant/src/runtime/AGENTS.md
+++ b/assistant/src/runtime/AGENTS.md
@@ -96,7 +96,7 @@ On macOS-originated turns, the CDP factory (`tools/browser/cdp-client/factory.ts
 
 ### Per-tool `browser_mode` override
 
-All CDP-backed browser tools (`browser_navigate`, `browser_snapshot`, `browser_screenshot`, `browser_click`, `browser_type`, `browser_hover`, `browser_scroll`, `browser_press_key`, `browser_select_option`, `browser_wait_for`, `browser_extract`, `browser_fill_credential`, `browser_attach`, `browser_detach`, `browser_close`) accept an optional `browser_mode` input parameter that overrides the automatic backend selection for that invocation.
+All CDP-backed browser tools (`browser_navigate`, `browser_snapshot`, `browser_screenshot`, `browser_click`, `browser_type`, `browser_hover`, `browser_scroll`, `browser_press_key`, `browser_select_option`, `browser_wait_for`, `browser_extract`, `browser_fill_credential`, `browser_attach`, `browser_detach`, `browser_close`, `browser_status`) accept an optional `browser_mode` input parameter that overrides the automatic backend selection for that invocation.
 
 | Value            | Behavior                                                                 |
 | ---------------- | ------------------------------------------------------------------------ |

--- a/assistant/src/tools/browser/__tests__/browser-status.test.ts
+++ b/assistant/src/tools/browser/__tests__/browser-status.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import type { ToolContext } from "../../types.js";
+import {
+  BROWSER_STATUS_INPUT_FIELD,
+  BROWSER_STATUS_MODE,
+} from "../browser-status-constants.js";
+import { CdpError } from "../cdp-client/errors.js";
+
+type ProbeOutcome = "ok" | "fail";
+
+const probeOutcomes: Record<string, ProbeOutcome> = {
+  [BROWSER_STATUS_MODE.EXTENSION]: "ok",
+  [BROWSER_STATUS_MODE.CDP_INSPECT]: "ok",
+  [BROWSER_STATUS_MODE.LOCAL]: "ok",
+};
+
+const buildCandidateListMock = mock((_context: ToolContext) => [
+  { kind: BROWSER_STATUS_MODE.EXTENSION, reason: "mock" },
+  { kind: BROWSER_STATUS_MODE.CDP_INSPECT, reason: "mock" },
+  { kind: BROWSER_STATUS_MODE.LOCAL, reason: "mock" },
+]);
+
+const getCdpClientMock = mock(
+  (_context: ToolContext, options?: { mode?: string }) => {
+    const mode = (options?.mode ?? "auto") as string;
+    const outcome = probeOutcomes[mode];
+    return {
+      kind: mode,
+      conversationId: "test-conversation",
+      send: mock(async () => {
+        if (outcome === "fail") {
+          throw new CdpError("transport_error", `${mode} probe failed`);
+        }
+        return { result: { value: "complete" } };
+      }),
+      dispose: mock(() => {}),
+    };
+  },
+);
+
+mock.module("../cdp-client/factory.js", () => ({
+  buildCandidateList: buildCandidateListMock,
+  getCdpClient: getCdpClientMock,
+  isDesktopAutoCooldownActive: () => false,
+}));
+
+mock.module("../../../config/loader.js", () => ({
+  getConfig: () => ({
+    hostBrowser: {
+      cdpInspect: {
+        enabled: true,
+        host: "localhost",
+        port: 9222,
+        probeTimeoutMs: 500,
+        desktopAuto: { enabled: true, cooldownMs: 30_000 },
+      },
+    },
+  }),
+}));
+
+mock.module("../runtime-check.js", () => ({
+  checkBrowserRuntime: async () => ({
+    playwrightAvailable: true,
+    chromiumInstalled: true,
+    chromiumPath: "/tmp/chromium",
+    error: null,
+  }),
+}));
+
+mock.module("../browser-manager.js", () => ({
+  browserManager: {
+    getPreferredBackendKind: () => null,
+  },
+}));
+
+const { executeBrowserStatus } = await import("../browser-execution.js");
+
+function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
+  return {
+    workingDir: "/tmp",
+    conversationId: "test-conversation",
+    trustClass: "guardian",
+    ...overrides,
+  } as ToolContext;
+}
+
+describe("executeBrowserStatus", () => {
+  test("reports extension preflight-unavailable when no host browser proxy is bound", async () => {
+    const result = await executeBrowserStatus({}, makeContext());
+    expect(result.isError).toBe(false);
+    const payload = JSON.parse(result.content);
+    const extension = payload.modes.find(
+      (m: { mode: string }) => m.mode === BROWSER_STATUS_MODE.EXTENSION,
+    );
+    expect(extension).toBeDefined();
+    expect(extension.available).toBe(false);
+    expect(extension.verified).toBe("preflight");
+  });
+
+  test("supports mode filtering via browser_mode", async () => {
+    const result = await executeBrowserStatus(
+      { browser_mode: BROWSER_STATUS_MODE.LOCAL },
+      makeContext(),
+    );
+    expect(result.isError).toBe(false);
+    const payload = JSON.parse(result.content);
+    expect(payload.checkedModes).toEqual([BROWSER_STATUS_MODE.LOCAL]);
+    expect(payload.modes).toHaveLength(1);
+    expect(payload.modes[0].mode).toBe(BROWSER_STATUS_MODE.LOCAL);
+  });
+
+  test("validates check_local_launch type", async () => {
+    const result = await executeBrowserStatus(
+      { [BROWSER_STATUS_INPUT_FIELD.CHECK_LOCAL_LAUNCH]: "yes" },
+      makeContext(),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain(
+      `${BROWSER_STATUS_INPUT_FIELD.CHECK_LOCAL_LAUNCH} must be a boolean`,
+    );
+  });
+});

--- a/assistant/src/tools/browser/browser-execution.ts
+++ b/assistant/src/tools/browser/browser-execution.ts
@@ -1,3 +1,4 @@
+import { getConfig } from "../../config/loader.js";
 import type { ImageContent } from "../../providers/types.js";
 import { getLogger } from "../../util/logger.js";
 import { truncate } from "../../util/truncate.js";
@@ -19,12 +20,21 @@ import {
 import type { RouteHandler } from "./browser-manager.js";
 import { browserManager } from "./browser-manager.js";
 import { type BrowserMode, normalizeBrowserMode } from "./browser-mode.js";
+import { BROWSER_MODE } from "./browser-mode-constants.js";
 import {
   ensureScreencast,
   getSender,
   stopAllScreencasts,
   stopBrowserScreencast,
 } from "./browser-screencast.js";
+import {
+  BROWSER_STATUS_INPUT_FIELD,
+  BROWSER_STATUS_MODE,
+  BROWSER_STATUS_MODES,
+  type BrowserStatusMode,
+  CDP_INSPECT_STATUS_DISCOVERY_CODE,
+  EXTENSION_STATUS_ERROR_MARKER,
+} from "./browser-status-constants.js";
 import {
   formatAxSnapshot,
   transformAxTree,
@@ -48,8 +58,17 @@ import {
   waitForText as cdpWaitForText,
 } from "./cdp-client/cdp-dom-helpers.js";
 import { CdpError } from "./cdp-client/errors.js";
-import { getCdpClient } from "./cdp-client/factory.js";
-import type { AttemptDiagnostic, CdpClient } from "./cdp-client/types.js";
+import {
+  buildCandidateList,
+  getCdpClient,
+  isDesktopAutoCooldownActive,
+} from "./cdp-client/factory.js";
+import type {
+  AttemptDiagnostic,
+  CdpClient,
+  CdpClientKind,
+} from "./cdp-client/types.js";
+import { checkBrowserRuntime } from "./runtime-check.js";
 
 const log = getLogger("headless-browser");
 
@@ -62,6 +81,37 @@ export const ACTION_TIMEOUT_MS = 10_000;
 export const MAX_WAIT_MS = 30_000;
 
 export const MAX_EXTRACT_LENGTH = 50_000;
+
+type StatusCheckMode = BrowserStatusMode;
+
+const MODE_TRADEOFFS: Record<StatusCheckMode, string[]> = {
+  [BROWSER_STATUS_MODE.EXTENSION]: [
+    "Controls the user's existing Chrome profile and tabs.",
+    "Requires the Vellum extension to be paired and actively connected.",
+    "Best when the user wants the assistant to operate in their real browser session.",
+  ],
+  [BROWSER_STATUS_MODE.CDP_INSPECT]: [
+    "Controls an existing Chrome instance launched with --remote-debugging-port.",
+    "Does not require the extension to be connected.",
+    "Requires remote debugging to stay enabled on localhost, which is more manual to maintain.",
+  ],
+  [BROWSER_STATUS_MODE.LOCAL]: [
+    "Runs a dedicated Playwright-managed Chromium profile.",
+    "Most isolated and reliable fallback when extension/CDP inspect are unavailable.",
+    "Does not use the user's existing browser profile, so sessions/cookies may differ.",
+  ],
+};
+
+interface BrowserStatusModeResult {
+  mode: StatusCheckMode;
+  available: boolean;
+  verified: "active_probe" | "preflight";
+  autoCandidate: boolean;
+  summary: string;
+  userActions: string[];
+  tradeoffs: string[];
+  details: Record<string, unknown>;
+}
 
 /**
  * IIFE evaluated inside the page via `Runtime.evaluate` to auto-dismiss
@@ -262,7 +312,7 @@ function collectRemediationHints(
   // the error code with a generic candidate kind derived from the mode.
   if (diagnostics.length === 0 && error.code) {
     // Try to infer the candidate kind from the error message
-    for (const kind of ["extension", "cdp-inspect", "local"] as const) {
+    for (const kind of BROWSER_STATUS_MODES) {
       if (error.message.toLowerCase().includes(kind)) {
         addHints(`${kind}:${error.code}`);
       }
@@ -1945,5 +1995,489 @@ export async function executeBrowserFillCredential(
     return { content: `Error: Fill credential failed: ${msg}`, isError: true };
   } finally {
     cdp.dispose();
+  }
+}
+
+function dedupeStrings(values: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const value of values) {
+    if (!value) continue;
+    if (seen.has(value)) continue;
+    seen.add(value);
+    out.push(value);
+  }
+  return out;
+}
+
+function modeTradeoffs(mode: StatusCheckMode): string[] {
+  return MODE_TRADEOFFS[mode];
+}
+
+function extensionSetupActions(): string[] {
+  return [
+    "Install and enable the Vellum Relay Chrome extension.",
+    "Open the extension popup and click Pair with local assistant.",
+    "Keep the extension connected to the assistant relay.",
+  ];
+}
+
+function cdpInspectSetupActions(): string[] {
+  return [
+    "Launch Chrome with --remote-debugging-port=9222 (or your configured port).",
+    "Keep Chrome running while browser tools are in use.",
+    "Ensure the configured host is loopback (localhost / 127.0.0.1 / ::1).",
+  ];
+}
+
+function localSetupActions(): string[] {
+  return [
+    "Install assistant dependencies with bun install in assistant/.",
+    "Install Chromium for Playwright: bunx playwright install chromium.",
+  ];
+}
+
+function extractDiscoveryCodes(error: CdpError): string[] {
+  const diagnostics = error.attemptDiagnostics ?? [];
+  const codes: string[] = [];
+  for (const diag of diagnostics) {
+    if (diag.discoveryCode) codes.push(diag.discoveryCode);
+  }
+  return dedupeStrings(codes);
+}
+
+function containsTokenCaseInsensitive(text: string, token: string): boolean {
+  return text.toLowerCase().includes(token.toLowerCase());
+}
+
+function probeFailureActions(mode: StatusCheckMode, error: CdpError): string[] {
+  const actions: string[] = [];
+  const message = error.message.toLowerCase();
+  const discoveryCodes = extractDiscoveryCodes(error).map((c) =>
+    c.toLowerCase(),
+  );
+
+  if (mode === BROWSER_STATUS_MODE.EXTENSION) {
+    actions.push(...extensionSetupActions());
+    if (
+      containsTokenCaseInsensitive(
+        message,
+        EXTENSION_STATUS_ERROR_MARKER.UNAUTHORIZED_ORIGIN,
+      )
+    ) {
+      actions.push(
+        "Ensure this extension ID is present in meta/browser-extension/chrome-extension-allowlist.json and restart the assistant.",
+      );
+    }
+    if (
+      containsTokenCaseInsensitive(
+        message,
+        EXTENSION_STATUS_ERROR_MARKER.NATIVE_MESSAGING_HOST,
+      )
+    ) {
+      actions.push(
+        "Reinstall the native messaging host manifest and confirm it allows this extension ID.",
+      );
+    }
+    if (
+      containsTokenCaseInsensitive(
+        message,
+        EXTENSION_STATUS_ERROR_MARKER.HTTP_401,
+      )
+    ) {
+      actions.push(
+        "Re-pair the extension so it refreshes its local relay credential.",
+      );
+    }
+  }
+
+  if (mode === BROWSER_STATUS_MODE.CDP_INSPECT) {
+    actions.push(...cdpInspectSetupActions());
+    if (discoveryCodes.includes(CDP_INSPECT_STATUS_DISCOVERY_CODE.NO_TARGETS)) {
+      actions.push("Open at least one normal web page tab and retry.");
+    }
+    if (
+      discoveryCodes.includes(
+        CDP_INSPECT_STATUS_DISCOVERY_CODE.INVALID_RESPONSE,
+      ) ||
+      discoveryCodes.includes(
+        CDP_INSPECT_STATUS_DISCOVERY_CODE.WS_FALLBACK_FAILED,
+      )
+    ) {
+      actions.push(
+        "Verify nothing else is bound to the configured CDP port and exposing non-DevTools responses.",
+      );
+    }
+  }
+
+  if (mode === BROWSER_STATUS_MODE.LOCAL) {
+    actions.push(...localSetupActions());
+  }
+
+  return dedupeStrings(actions);
+}
+
+async function probePinnedBrowserMode(
+  mode: StatusCheckMode,
+  context: ToolContext,
+): Promise<
+  | {
+      ok: true;
+      backendKind: CdpClientKind;
+    }
+  | {
+      ok: false;
+      error: CdpError;
+      diagnostic: string;
+    }
+> {
+  let cdp: ReturnType<typeof getCdpClient> | null = null;
+  try {
+    cdp = getCdpClient(context, { mode });
+    await cdp.send(
+      "Runtime.evaluate",
+      {
+        expression: "document.readyState",
+        returnByValue: true,
+      },
+      context.signal,
+    );
+    return { ok: true, backendKind: cdp.kind };
+  } catch (err) {
+    if (err instanceof CdpError) {
+      return {
+        ok: false,
+        error: err,
+        diagnostic: formatModeSelectionFailure(mode, err),
+      };
+    }
+    const wrapped = new CdpError(
+      "transport_error",
+      err instanceof Error ? err.message : String(err),
+      { underlying: err },
+    );
+    return {
+      ok: false,
+      error: wrapped,
+      diagnostic: formatModeSelectionFailure(mode, wrapped),
+    };
+  } finally {
+    cdp?.dispose();
+  }
+}
+
+async function checkExtensionModeStatus(
+  context: ToolContext,
+  autoCandidate: boolean,
+): Promise<BrowserStatusModeResult> {
+  const proxyBound = Boolean(context.hostBrowserProxy);
+  const proxyConnected = context.hostBrowserProxy?.isAvailable() ?? false;
+
+  if (!proxyBound) {
+    return {
+      mode: BROWSER_STATUS_MODE.EXTENSION,
+      available: false,
+      verified: "preflight",
+      autoCandidate,
+      summary:
+        "Extension mode is unavailable: no host browser proxy is bound to this conversation.",
+      userActions: extensionSetupActions(),
+      tradeoffs: modeTradeoffs(BROWSER_STATUS_MODE.EXTENSION),
+      details: {
+        proxyBound,
+        proxyConnected,
+      },
+    };
+  }
+
+  if (!proxyConnected) {
+    return {
+      mode: BROWSER_STATUS_MODE.EXTENSION,
+      available: false,
+      verified: "preflight",
+      autoCandidate,
+      summary:
+        "Extension mode is unavailable: the extension transport is currently disconnected.",
+      userActions: extensionSetupActions(),
+      tradeoffs: modeTradeoffs(BROWSER_STATUS_MODE.EXTENSION),
+      details: {
+        proxyBound,
+        proxyConnected,
+      },
+    };
+  }
+
+  const probe = await probePinnedBrowserMode(
+    BROWSER_STATUS_MODE.EXTENSION,
+    context,
+  );
+  if (probe.ok) {
+    return {
+      mode: BROWSER_STATUS_MODE.EXTENSION,
+      available: true,
+      verified: "active_probe",
+      autoCandidate,
+      summary: "Extension mode is ready and responded to an active CDP probe.",
+      userActions: [],
+      tradeoffs: modeTradeoffs(BROWSER_STATUS_MODE.EXTENSION),
+      details: {
+        proxyBound,
+        proxyConnected,
+        backendKind: probe.backendKind,
+      },
+    };
+  }
+
+  return {
+    mode: BROWSER_STATUS_MODE.EXTENSION,
+    available: false,
+    verified: "active_probe",
+    autoCandidate,
+    summary: `Extension mode probe failed: ${probe.error.message}`,
+    userActions: probeFailureActions(
+      BROWSER_STATUS_MODE.EXTENSION,
+      probe.error,
+    ),
+    tradeoffs: modeTradeoffs(BROWSER_STATUS_MODE.EXTENSION),
+    details: {
+      proxyBound,
+      proxyConnected,
+      errorCode: probe.error.code,
+      diagnostic: probe.diagnostic,
+      attemptDiagnostics: probe.error.attemptDiagnostics ?? [],
+    },
+  };
+}
+
+async function checkCdpInspectModeStatus(
+  context: ToolContext,
+  autoCandidate: boolean,
+): Promise<BrowserStatusModeResult> {
+  const cdpInspectConfig = getConfig().hostBrowser.cdpInspect;
+  const desktopAutoEnabled =
+    context.transportInterface === "macos" &&
+    cdpInspectConfig.desktopAuto.enabled;
+  const cooldownActive =
+    desktopAutoEnabled &&
+    isDesktopAutoCooldownActive(cdpInspectConfig.desktopAuto.cooldownMs);
+
+  const probe = await probePinnedBrowserMode(
+    BROWSER_STATUS_MODE.CDP_INSPECT,
+    context,
+  );
+  if (probe.ok) {
+    return {
+      mode: BROWSER_STATUS_MODE.CDP_INSPECT,
+      available: true,
+      verified: "active_probe",
+      autoCandidate,
+      summary:
+        "CDP inspect mode is ready and responded to an active CDP probe.",
+      userActions: [],
+      tradeoffs: modeTradeoffs(BROWSER_STATUS_MODE.CDP_INSPECT),
+      details: {
+        backendKind: probe.backendKind,
+        configEnabled: cdpInspectConfig.enabled,
+        configHost: cdpInspectConfig.host,
+        configPort: cdpInspectConfig.port,
+        desktopAutoEnabled,
+        desktopAutoCooldownActive: cooldownActive,
+      },
+    };
+  }
+
+  return {
+    mode: BROWSER_STATUS_MODE.CDP_INSPECT,
+    available: false,
+    verified: "active_probe",
+    autoCandidate,
+    summary: `CDP inspect probe failed: ${probe.error.message}`,
+    userActions: probeFailureActions(
+      BROWSER_STATUS_MODE.CDP_INSPECT,
+      probe.error,
+    ),
+    tradeoffs: modeTradeoffs(BROWSER_STATUS_MODE.CDP_INSPECT),
+    details: {
+      errorCode: probe.error.code,
+      discoveryCodes: extractDiscoveryCodes(probe.error),
+      diagnostic: probe.diagnostic,
+      attemptDiagnostics: probe.error.attemptDiagnostics ?? [],
+      configEnabled: cdpInspectConfig.enabled,
+      configHost: cdpInspectConfig.host,
+      configPort: cdpInspectConfig.port,
+      desktopAutoEnabled,
+      desktopAutoCooldownActive: cooldownActive,
+    },
+  };
+}
+
+async function checkLocalModeStatus(
+  context: ToolContext,
+  autoCandidate: boolean,
+  checkLocalLaunch: boolean,
+): Promise<BrowserStatusModeResult> {
+  const runtime = await checkBrowserRuntime();
+  if (!runtime.playwrightAvailable || !runtime.chromiumInstalled) {
+    return {
+      mode: BROWSER_STATUS_MODE.LOCAL,
+      available: false,
+      verified: "preflight",
+      autoCandidate,
+      summary:
+        runtime.error ??
+        "Local mode preflight failed: Playwright Chromium runtime is not ready.",
+      userActions: localSetupActions(),
+      tradeoffs: modeTradeoffs(BROWSER_STATUS_MODE.LOCAL),
+      details: {
+        runtime,
+        launchProbeRequested: checkLocalLaunch,
+      },
+    };
+  }
+
+  if (!checkLocalLaunch) {
+    return {
+      mode: BROWSER_STATUS_MODE.LOCAL,
+      available: true,
+      verified: "preflight",
+      autoCandidate,
+      summary:
+        "Local mode preflight passed (Playwright + Chromium are present). Launch probe was skipped.",
+      userActions: [],
+      tradeoffs: modeTradeoffs(BROWSER_STATUS_MODE.LOCAL),
+      details: {
+        runtime,
+        launchProbeRequested: checkLocalLaunch,
+      },
+    };
+  }
+
+  const probe = await probePinnedBrowserMode(
+    BROWSER_STATUS_MODE.LOCAL,
+    context,
+  );
+  if (probe.ok) {
+    return {
+      mode: BROWSER_STATUS_MODE.LOCAL,
+      available: true,
+      verified: "active_probe",
+      autoCandidate,
+      summary: "Local mode is ready and responded to an active CDP probe.",
+      userActions: [],
+      tradeoffs: modeTradeoffs(BROWSER_STATUS_MODE.LOCAL),
+      details: {
+        runtime,
+        launchProbeRequested: checkLocalLaunch,
+        backendKind: probe.backendKind,
+      },
+    };
+  }
+
+  return {
+    mode: BROWSER_STATUS_MODE.LOCAL,
+    available: false,
+    verified: "active_probe",
+    autoCandidate,
+    summary: `Local mode probe failed: ${probe.error.message}`,
+    userActions: probeFailureActions(BROWSER_STATUS_MODE.LOCAL, probe.error),
+    tradeoffs: modeTradeoffs(BROWSER_STATUS_MODE.LOCAL),
+    details: {
+      runtime,
+      launchProbeRequested: checkLocalLaunch,
+      errorCode: probe.error.code,
+      diagnostic: probe.diagnostic,
+      attemptDiagnostics: probe.error.attemptDiagnostics ?? [],
+    },
+  };
+}
+
+// ── browser_status ────────────────────────────────────────────────────
+
+export async function executeBrowserStatus(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const parsedMode = parseBrowserMode(input);
+  if (!parsedMode.ok) {
+    return { content: parsedMode.error, isError: true };
+  }
+
+  if (
+    input[BROWSER_STATUS_INPUT_FIELD.CHECK_LOCAL_LAUNCH] !== undefined &&
+    typeof input[BROWSER_STATUS_INPUT_FIELD.CHECK_LOCAL_LAUNCH] !== "boolean"
+  ) {
+    return {
+      content: `Error: ${BROWSER_STATUS_INPUT_FIELD.CHECK_LOCAL_LAUNCH} must be a boolean when provided.`,
+      isError: true,
+    };
+  }
+
+  const checkLocalLaunch =
+    input[BROWSER_STATUS_INPUT_FIELD.CHECK_LOCAL_LAUNCH] === true;
+  const requestedMode = parsedMode.mode;
+  const modesToCheck: readonly StatusCheckMode[] =
+    requestedMode === BROWSER_MODE.AUTO
+      ? BROWSER_STATUS_MODES
+      : [requestedMode];
+
+  const autoCandidateKinds = buildCandidateList(context).map((c) => c.kind);
+  const autoCandidateSet = new Set<CdpClientKind>(autoCandidateKinds);
+
+  try {
+    const modeResults: BrowserStatusModeResult[] = [];
+    for (const mode of modesToCheck) {
+      const autoCandidate = autoCandidateSet.has(mode);
+      if (mode === BROWSER_STATUS_MODE.EXTENSION) {
+        modeResults.push(
+          await checkExtensionModeStatus(context, autoCandidate),
+        );
+      } else if (mode === BROWSER_STATUS_MODE.CDP_INSPECT) {
+        modeResults.push(
+          await checkCdpInspectModeStatus(context, autoCandidate),
+        );
+      } else {
+        modeResults.push(
+          await checkLocalModeStatus(context, autoCandidate, checkLocalLaunch),
+        );
+      }
+    }
+
+    const stickyMode = browserManager.getPreferredBackendKind(
+      context.conversationId,
+    );
+    const availableModes = modeResults
+      .filter((r) => r.available)
+      .map((r) => r.mode);
+    const recommendedMode =
+      autoCandidateKinds.find((candidate) =>
+        modeResults.some(
+          (result) => result.mode === candidate && result.available,
+        ),
+      ) ??
+      availableModes[0] ??
+      null;
+
+    return {
+      content: JSON.stringify(
+        {
+          requestedMode,
+          checkedModes: modesToCheck,
+          autoCandidateOrder: autoCandidateKinds,
+          stickyConversationMode: stickyMode,
+          recommendedMode,
+          checkLocalLaunch,
+          modes: modeResults,
+        },
+        null,
+        2,
+      ),
+      isError: false,
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return {
+      content: `Error: browser_status failed: ${msg}`,
+      isError: true,
+    };
   }
 }

--- a/assistant/src/tools/browser/browser-mode-constants.ts
+++ b/assistant/src/tools/browser/browser-mode-constants.ts
@@ -1,0 +1,12 @@
+import type { BrowserMode } from "./cdp-client/types.js";
+
+/**
+ * Canonical browser-mode identifiers shared across parsing and status
+ * reporting paths.
+ */
+export const BROWSER_MODE = {
+  AUTO: "auto",
+  EXTENSION: "extension",
+  CDP_INSPECT: "cdp-inspect",
+  LOCAL: "local",
+} as const satisfies Record<string, BrowserMode>;

--- a/assistant/src/tools/browser/browser-mode.ts
+++ b/assistant/src/tools/browser/browser-mode.ts
@@ -12,6 +12,7 @@
  *   - `playwright`   -> `local`
  */
 
+import { BROWSER_MODE } from "./browser-mode-constants.js";
 import type { BrowserMode } from "./cdp-client/types.js";
 
 /** Canonical browser mode values. Re-exported from cdp-client/types. */
@@ -19,12 +20,12 @@ export type { BrowserMode } from "./cdp-client/types.js";
 
 /** All accepted values (canonical + aliases). */
 const ALIAS_MAP: Record<string, BrowserMode> = {
-  auto: "auto",
-  extension: "extension",
-  "cdp-inspect": "cdp-inspect",
-  "cdp-debugger": "cdp-inspect",
-  local: "local",
-  playwright: "local",
+  [BROWSER_MODE.AUTO]: BROWSER_MODE.AUTO,
+  [BROWSER_MODE.EXTENSION]: BROWSER_MODE.EXTENSION,
+  [BROWSER_MODE.CDP_INSPECT]: BROWSER_MODE.CDP_INSPECT,
+  "cdp-debugger": BROWSER_MODE.CDP_INSPECT,
+  [BROWSER_MODE.LOCAL]: BROWSER_MODE.LOCAL,
+  playwright: BROWSER_MODE.LOCAL,
 };
 
 /** Ordered list of accepted values for error messages. */
@@ -60,7 +61,7 @@ export function normalizeBrowserMode(
   raw: unknown,
 ): NormalizeBrowserModeResult | NormalizeBrowserModeError {
   if (raw === undefined || raw === null || raw === "") {
-    return { mode: "auto" };
+    return { mode: BROWSER_MODE.AUTO };
   }
 
   if (typeof raw !== "string") {

--- a/assistant/src/tools/browser/browser-status-constants.ts
+++ b/assistant/src/tools/browser/browser-status-constants.ts
@@ -1,0 +1,33 @@
+import { BROWSER_MODE } from "./browser-mode-constants.js";
+import { DEVTOOLS_DISCOVERY_CODE } from "./cdp-client/cdp-inspect/discovery.js";
+
+export const BROWSER_STATUS_MODE = {
+  EXTENSION: BROWSER_MODE.EXTENSION,
+  CDP_INSPECT: BROWSER_MODE.CDP_INSPECT,
+  LOCAL: BROWSER_MODE.LOCAL,
+} as const;
+
+export type BrowserStatusMode =
+  (typeof BROWSER_STATUS_MODE)[keyof typeof BROWSER_STATUS_MODE];
+
+export const BROWSER_STATUS_MODES: readonly BrowserStatusMode[] = [
+  BROWSER_STATUS_MODE.EXTENSION,
+  BROWSER_STATUS_MODE.CDP_INSPECT,
+  BROWSER_STATUS_MODE.LOCAL,
+] as const;
+
+export const BROWSER_STATUS_INPUT_FIELD = {
+  CHECK_LOCAL_LAUNCH: "check_local_launch",
+} as const;
+
+export const EXTENSION_STATUS_ERROR_MARKER = {
+  UNAUTHORIZED_ORIGIN: "unauthorized_origin",
+  NATIVE_MESSAGING_HOST: "native messaging host",
+  HTTP_401: "401",
+} as const;
+
+export const CDP_INSPECT_STATUS_DISCOVERY_CODE = {
+  NO_TARGETS: DEVTOOLS_DISCOVERY_CODE.NO_TARGETS,
+  INVALID_RESPONSE: DEVTOOLS_DISCOVERY_CODE.INVALID_RESPONSE,
+  WS_FALLBACK_FAILED: DEVTOOLS_DISCOVERY_CODE.WS_FALLBACK_FAILED,
+} as const;

--- a/assistant/src/tools/browser/cdp-client/cdp-inspect/discovery.ts
+++ b/assistant/src/tools/browser/cdp-client/cdp-inspect/discovery.ts
@@ -42,6 +42,20 @@ export type DevToolsDiscoveryErrorCode =
   | "ws_fallback_failed";
 
 /**
+ * Canonical discovery-code constants for callers that need stable,
+ * typo-safe comparisons without repeating raw string literals.
+ */
+export const DEVTOOLS_DISCOVERY_CODE = {
+  UNREACHABLE: "unreachable",
+  NON_LOOPBACK: "non_loopback",
+  NON_CHROME: "non_chrome",
+  INVALID_RESPONSE: "invalid_response",
+  NO_TARGETS: "no_targets",
+  TIMEOUT: "timeout",
+  WS_FALLBACK_FAILED: "ws_fallback_failed",
+} as const satisfies Record<string, DevToolsDiscoveryErrorCode>;
+
+/**
  * Single error type thrown by all discovery helpers. Mirrors the
  * shape of {@link import("../errors.js").CdpError} so catch sites can
  * rely on an explicit `code` field and an optional underlying cause.


### PR DESCRIPTION
## Summary
- Add a new browser_status tool to the bundled browser skill to report per-mode readiness, active-probe results, remediation steps, and trade-offs.
- Wire browser_status through tool manifests, permission defaults/policy classification, and browser skill/runtime docs so it is first-class and allowed by default.
- Expand and update browser skill tests, and centralize machine-significant browser mode/discovery/error marker constants to reduce string drift across status logic.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25222" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
