### PR TITLE
fix(macos): restore smooth easing transitions to typing indicator dots

### DIFF
--- a/clients/shared/Features/Chat/TypingIndicatorView.swift
+++ b/clients/shared/Features/Chat/TypingIndicatorView.swift
@@ -7,7 +7,7 @@ public struct TypingIndicatorView: View {
 
     private let dotSize: CGFloat = 8
     private let dotSpacing: CGFloat = 5
-    private let tickInterval: TimeInterval = 0.18
+    private let animationSpeed: Double = 2.0 * .pi / 1.0
 
     public init() {}
 
@@ -16,8 +16,8 @@ public struct TypingIndicatorView: View {
             if reduceMotion {
                 staticDots
             } else {
-                TimelineView(.periodic(from: .now, by: tickInterval)) { context in
-                    animatedDots(activeIndex: animationPhase(at: context.date))
+                TimelineView(.animation) { context in
+                    animatedDots(at: context.date)
                 }
             }
         }
@@ -44,14 +44,19 @@ public struct TypingIndicatorView: View {
         .frame(width: intrinsicDotsWidth, height: dotSize, alignment: .center)
     }
 
-    private func animatedDots(activeIndex: Int) -> some View {
-        HStack(spacing: dotSpacing) {
+    private func animatedDots(at date: Date) -> some View {
+        let phase = date.timeIntervalSinceReferenceDate * animationSpeed
+
+        return HStack(spacing: dotSpacing) {
             ForEach(0..<3, id: \.self) { index in
+                let offset = Double(index) * (2.0 * .pi / 3.0)
+                let wave = (sin(phase + offset) + 1.0) / 2.0
+
                 Circle()
                     .fill(VColor.contentTertiary)
                     .frame(width: dotSize, height: dotSize)
-                    .scaleEffect(activeIndex == index ? 1.0 : 0.6)
-                    .opacity(activeIndex == index ? 1.0 : 0.45)
+                    .scaleEffect(0.6 + 0.4 * wave)
+                    .opacity(0.45 + 0.55 * wave)
             }
         }
         .frame(width: intrinsicDotsWidth, height: dotSize, alignment: .center)
@@ -59,9 +64,5 @@ public struct TypingIndicatorView: View {
 
     private var intrinsicDotsWidth: CGFloat {
         dotSize * 3 + dotSpacing * 2
-    }
-
-    private func animationPhase(at date: Date) -> Int {
-        Int(date.timeIntervalSinceReferenceDate / tickInterval) % 3
     }
 }


### PR DESCRIPTION
## Summary
- Replace `TimelineView(.periodic)` with `TimelineView(.animation)` and sine-wave-driven interpolation to restore the smooth pulsing feel that was lost in PR #24627
- Each dot now smoothly oscillates scale (0.6–1.0) and opacity (0.45–1.0) with 120-degree phase offsets, matching the original visual rhythm
- No changes to the reduce-motion accessibility path, layout modifiers, or public API

## Original prompt
Restore smooth easing animation to the TypingIndicatorView three-dot loading indicator while keeping the TimelineView-based approach that fixed animation lifecycle bugs. The goal is to get the original visual look and feel (smooth easeInOut transitions between dot states) without reverting to the old repeatForever/onAppear/onDisappear pattern that had state management issues.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25223" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
