### PR TITLE
fix(macos): toggle mic icon to stop during recording and hide send button

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -509,53 +509,55 @@ struct ComposerView: View, Equatable {
                     .vTooltip("Live voice conversation")
                 }
 
-                // Dictate button
-                VButton(
-                    label: "Dictate",
-                    iconOnly: VIcon.mic.rawValue,
-                    style: .ghost,
-                    iconSize: composerActionButtonSize,
-                    action: { (onDictateToggle ?? onMicrophoneToggle)() }
-                )
-
-                .vTooltip(micTooltipText)
-
-                // Send button (always visible, disabled when empty)
-                VButton(
-                    label: "Send message",
-                    iconOnly: VIcon.arrowUp.rawValue,
-                    style: .primary,
-                    isDisabled: !canSend,
-                    iconSize: composerActionButtonSize
-                ) {
-                    composerFocus = true
-                    performSendAction()
-                }
-                .vTooltip("Type a message to send")
-            } else if !hasPendingConfirmation {
-                // Mic button (visible with or without text)
+                // Dictate / stop button
                 VButton(
                     label: isRecording ? "Stop recording" : "Dictate",
-                    iconOnly: VIcon.mic.rawValue,
+                    iconOnly: isRecording ? VIcon.circleStop.rawValue : VIcon.mic.rawValue,
                     style: .ghost,
                     iconSize: composerActionButtonSize,
                     action: { (onDictateToggle ?? onMicrophoneToggle)() }
                 )
+                .vTooltip(isRecording ? "Stop recording" : micTooltipText)
 
-                .vTooltip(micTooltipText)
-
-                // Send button
-                VButton(
-                    label: "Send message",
-                    iconOnly: VIcon.arrowUp.rawValue,
-                    style: .primary,
-                    isDisabled: !canSend,
-                    iconSize: composerActionButtonSize
-                ) {
-                    composerFocus = true
-                    performSendAction()
+                if !isRecording {
+                    // Send button (hidden during recording)
+                    VButton(
+                        label: "Send message",
+                        iconOnly: VIcon.arrowUp.rawValue,
+                        style: .primary,
+                        isDisabled: !canSend,
+                        iconSize: composerActionButtonSize
+                    ) {
+                        composerFocus = true
+                        performSendAction()
+                    }
+                    .vTooltip("Type a message to send")
                 }
-                .vTooltip(canSend ? "Send" : "Type a message to send")
+            } else if !hasPendingConfirmation {
+                // Mic / stop button
+                VButton(
+                    label: isRecording ? "Stop recording" : "Dictate",
+                    iconOnly: isRecording ? VIcon.circleStop.rawValue : VIcon.mic.rawValue,
+                    style: .ghost,
+                    iconSize: composerActionButtonSize,
+                    action: { (onDictateToggle ?? onMicrophoneToggle)() }
+                )
+                .vTooltip(isRecording ? "Stop recording" : micTooltipText)
+
+                if !isRecording {
+                    // Send button (hidden during recording)
+                    VButton(
+                        label: "Send message",
+                        iconOnly: VIcon.arrowUp.rawValue,
+                        style: .primary,
+                        isDisabled: !canSend,
+                        iconSize: composerActionButtonSize
+                    ) {
+                        composerFocus = true
+                        performSendAction()
+                    }
+                    .vTooltip(canSend ? "Send" : "Type a message to send")
+                }
             } else {
                 // Pending confirmation — show same buttons as empty-input state
                 if onVoiceModeToggle != nil {
@@ -570,22 +572,23 @@ struct ComposerView: View, Equatable {
 
                 VButton(
                     label: isRecording ? "Stop recording" : "Dictate",
-                    iconOnly: VIcon.mic.rawValue,
+                    iconOnly: isRecording ? VIcon.circleStop.rawValue : VIcon.mic.rawValue,
                     style: .ghost,
                     iconSize: composerActionButtonSize,
                     action: { (onDictateToggle ?? onMicrophoneToggle)() }
                 )
 
-
-                VButton(
-                    label: "Send message",
-                    iconOnly: VIcon.arrowUp.rawValue,
-                    style: .primary,
-                    isDisabled: !canSend,
-                    iconSize: composerActionButtonSize
-                ) {
-                    composerFocus = true
-                    performSendAction()
+                if !isRecording {
+                    VButton(
+                        label: "Send message",
+                        iconOnly: VIcon.arrowUp.rawValue,
+                        style: .primary,
+                        isDisabled: !canSend,
+                        iconSize: composerActionButtonSize
+                    ) {
+                        composerFocus = true
+                        performSendAction()
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Mic button icon toggles to `circleStop` during recording (was always showing mic icon)
- Tooltip updates to "Stop recording" during recording
- Send/stop button hidden during recording to reduce visual noise — the stop circle is the only action
- Applied across all three button row branches (has text, no text, pending confirmation)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25224" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
