### PR TITLE
clients-shared: add provider-agnostic stt websocket streaming client

### DIFF
--- a/assistant/src/__tests__/stt-catalog-parity.test.ts
+++ b/assistant/src/__tests__/stt-catalog-parity.test.ts
@@ -39,6 +39,7 @@ interface ClientCatalogEntry {
   setupMode: string;
   setupHint: string;
   apiKeyProviderName: string;
+  conversationStreamingMode: string;
 }
 
 interface ClientCatalog {
@@ -161,6 +162,69 @@ describe("STT catalog parity: daemon vs client", () => {
   });
 
   // -----------------------------------------------------------------------
+  // Conversation streaming mode parity
+  // -----------------------------------------------------------------------
+
+  test("each client catalog entry conversationStreamingMode matches its daemon counterpart", () => {
+    const clientCatalog = loadClientCatalog();
+    const violations: string[] = [];
+
+    for (const clientEntry of clientCatalog.providers) {
+      const daemonEntry = getProviderEntry(clientEntry.id as SttProviderId);
+      if (!daemonEntry) {
+        // Covered by the provider ID parity test above
+        continue;
+      }
+      if (
+        clientEntry.conversationStreamingMode !==
+        daemonEntry.conversationStreamingMode
+      ) {
+        violations.push(
+          `Provider "${clientEntry.id}": client conversationStreamingMode="${clientEntry.conversationStreamingMode}" ` +
+            `!= daemon conversationStreamingMode="${daemonEntry.conversationStreamingMode}"`,
+        );
+      }
+    }
+
+    if (violations.length > 0) {
+      const message = [
+        "Conversation streaming mode mismatch between daemon and client catalogs.",
+        "",
+        "Violations:",
+        ...violations.map((v) => `  - ${v}`),
+        "",
+        "Update meta/stt-provider-catalog.json or assistant/src/providers/speech-to-text/provider-catalog.ts to match.",
+      ].join("\n");
+      expect(violations, message).toEqual([]);
+    }
+  });
+
+  test("conversationStreamingMode values are valid enum variants", () => {
+    const validModes = new Set(["realtime-ws", "incremental-batch", "none"]);
+    const clientCatalog = loadClientCatalog();
+    const violations: string[] = [];
+
+    for (const entry of clientCatalog.providers) {
+      if (!validModes.has(entry.conversationStreamingMode)) {
+        violations.push(
+          `Provider "${entry.id}": invalid conversationStreamingMode="${entry.conversationStreamingMode}". ` +
+            `Valid values: ${[...validModes].join(", ")}`,
+        );
+      }
+    }
+
+    if (violations.length > 0) {
+      const message = [
+        "Invalid conversationStreamingMode values in client catalog.",
+        "",
+        "Violations:",
+        ...violations.map((v) => `  - ${v}`),
+      ].join("\n");
+      expect(violations, message).toEqual([]);
+    }
+  });
+
+  // -----------------------------------------------------------------------
   // Structural sanity
   // -----------------------------------------------------------------------
 
@@ -194,6 +258,14 @@ describe("STT catalog parity: daemon vs client", () => {
       }
       if (!entry.setupMode || typeof entry.setupMode !== "string") {
         violations.push(`${entry.id}: missing or invalid 'setupMode'`);
+      }
+      if (
+        !entry.conversationStreamingMode ||
+        typeof entry.conversationStreamingMode !== "string"
+      ) {
+        violations.push(
+          `${entry.id}: missing or invalid 'conversationStreamingMode'`,
+        );
       }
     }
 

--- a/clients/shared/Network/GatewayHTTPClient.swift
+++ b/clients/shared/Network/GatewayHTTPClient.swift
@@ -778,6 +778,13 @@ public enum GatewayHTTPClient {
         guard var components = URLComponents(url: httpURL, resolvingAgainstBaseURL: false) else {
             throw ClientError.invalidURL
         }
+
+        // Strip trailing slash from the path — constructURL always appends one,
+        // but WebSocket upgrade handlers match exact paths (e.g. /v1/stt/stream
+        // not /v1/stt/stream/).
+        if components.path.hasSuffix("/"), components.path != "/" {
+            components.path = String(components.path.dropLast())
+        }
         switch components.scheme {
         case "https": components.scheme = "wss"
         case "http": components.scheme = "ws"

--- a/clients/shared/Network/GatewayHTTPClient.swift
+++ b/clients/shared/Network/GatewayHTTPClient.swift
@@ -742,6 +742,60 @@ public enum GatewayHTTPClient {
         return try constructURL(path: path, params: params, connection: connection)
     }
 
+    // MARK: - WebSocket Helpers
+
+    /// Constructs an authenticated WebSocket URL for the given gateway path.
+    ///
+    /// Converts the gateway base URL scheme from `http(s)` to `ws(s)` and
+    /// appends an auth token as a query parameter (since `URLSessionWebSocketTask`
+    /// does not support custom headers on the upgrade request). The token is
+    /// passed as a `token` query parameter which the gateway accepts as an
+    /// alternative to the `Authorization` header for WebSocket upgrades.
+    ///
+    /// - Parameters:
+    ///   - path: Path segment after `/v1/` (e.g. `"stt/stream"`).
+    ///   - params: Additional query parameters to include in the URL.
+    /// - Returns: A `URLRequest` configured for a WebSocket upgrade with auth.
+    /// - Throws: `ClientError` if the connection cannot be resolved or the URL is invalid.
+    public static func buildWebSocketRequest(path: String, params: [String: String]? = nil) throws -> URLRequest {
+        let connection = try resolveConnection()
+
+        // Merge auth token into query params — WebSocket upgrades cannot carry
+        // custom HTTP headers via URLSessionWebSocketTask, so the gateway
+        // accepts a `token` query parameter as an alternative.
+        var mergedParams = params ?? [:]
+        if let auth = connection.authHeader {
+            if auth.field == "Authorization", auth.value.hasPrefix("Bearer ") {
+                mergedParams["token"] = String(auth.value.dropFirst("Bearer ".count))
+            } else if auth.field == "X-Session-Token" {
+                mergedParams["token"] = auth.value
+            }
+        }
+
+        let httpURL = try constructURL(path: path, params: mergedParams, connection: connection)
+
+        // Convert http(s) scheme to ws(s) for the WebSocket transport.
+        guard var components = URLComponents(url: httpURL, resolvingAgainstBaseURL: false) else {
+            throw ClientError.invalidURL
+        }
+        switch components.scheme {
+        case "https": components.scheme = "wss"
+        case "http": components.scheme = "ws"
+        default: break
+        }
+        guard let wsURL = components.url else {
+            throw ClientError.invalidURL
+        }
+
+        var request = URLRequest(url: wsURL)
+        // Include org ID header — URLSession forwards custom headers on the
+        // initial HTTP upgrade request even for WebSocket tasks.
+        if let orgId = UserDefaults.standard.string(forKey: "connectedOrganizationId"), !orgId.isEmpty {
+            request.setValue(orgId, forHTTPHeaderField: "Vellum-Organization-Id")
+        }
+        return request
+    }
+
     /// Builds the gateway URL from path, query parameters, and connection info.
     private static func constructURL(
         path: String,

--- a/clients/shared/Network/STTStreamingClient.swift
+++ b/clients/shared/Network/STTStreamingClient.swift
@@ -1,0 +1,383 @@
+import Foundation
+import os
+
+private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "STTStreamingClient")
+
+// MARK: - Server Event Types
+
+/// Normalized server events received over the STT streaming WebSocket.
+///
+/// The discriminated `type` field matches the runtime session orchestrator's
+/// event protocol (`ready`, `partial`, `final`, `error`, `closed`), with a
+/// `seq` field for per-session ordering guarantees.
+public enum STTStreamEvent: Sendable, Equatable {
+    /// The server is ready to accept audio frames. Contains the resolved
+    /// provider identifier.
+    case ready(provider: String)
+    /// An interim (partial) transcript that may be revised by subsequent events.
+    case partial(text: String, seq: Int)
+    /// A committed (final) transcript segment that will not be revised.
+    case final(text: String, seq: Int)
+    /// An error occurred during the streaming session.
+    case error(category: String, message: String, seq: Int)
+    /// The streaming session has closed — no more events will be emitted.
+    case closed(seq: Int)
+}
+
+// MARK: - Session State
+
+/// Internal lifecycle state for the streaming session.
+enum STTStreamSessionState: Sendable {
+    /// Session created, WebSocket not yet connected.
+    case idle
+    /// WebSocket connected, waiting for `ready` from server.
+    case connecting
+    /// Server sent `ready`, session is accepting audio.
+    case active
+    /// Client sent `stop`, waiting for server to flush finals.
+    case stopping
+    /// Session fully closed (terminal state).
+    case closed
+}
+
+// MARK: - Failure Reason
+
+/// Describes why a streaming session failed to establish or was terminated.
+///
+/// Callers use this to decide whether to fall back to batch STT. All cases
+/// represent non-retryable conditions within the scope of the current session.
+public enum STTStreamFailure: Sendable, Equatable {
+    /// The WebSocket connection could not be established (network error,
+    /// DNS failure, TLS handshake error, etc.).
+    case connectionFailed(message: String)
+    /// The server rejected the connection (non-101 upgrade response).
+    case rejected(statusCode: Int)
+    /// The server reported that the provider does not support streaming.
+    case unsupportedProvider(message: String)
+    /// The server reported a provider-side error during the session.
+    case providerError(category: String, message: String)
+    /// The session timed out (idle timeout or connection timeout).
+    case timeout(message: String)
+    /// The WebSocket was closed abnormally (unexpected close code).
+    case abnormalClosure(code: Int, reason: String?)
+}
+
+// MARK: - Protocol
+
+/// Client for real-time STT streaming over the gateway WebSocket.
+///
+/// Implementations manage the lifecycle of a single streaming session:
+/// connect, send audio chunks, receive partial/final transcripts, and
+/// handle close/error events.
+public protocol STTStreamingClientProtocol: Sendable {
+    /// Start a streaming STT session with the given provider and audio format.
+    ///
+    /// - Parameters:
+    ///   - provider: STT provider identifier (e.g. `"deepgram"`, `"google-gemini"`).
+    ///   - mimeType: MIME type of the audio being streamed (e.g. `"audio/pcm"`).
+    ///   - sampleRate: Sample rate in Hz (e.g. `16000`). Optional.
+    ///   - onEvent: Callback invoked on the main actor for each server event.
+    ///   - onFailure: Callback invoked on the main actor when the session fails
+    ///     or terminates abnormally. After this fires, the session is closed and
+    ///     callers should fall back to batch STT.
+    func start(
+        provider: String,
+        mimeType: String,
+        sampleRate: Int?,
+        onEvent: @escaping @MainActor (STTStreamEvent) -> Void,
+        onFailure: @escaping @MainActor (STTStreamFailure) -> Void
+    ) async
+
+    /// Send a chunk of PCM audio data to the streaming session.
+    ///
+    /// Must only be called after receiving a `.ready` event. Calls before
+    /// ready or after stop/close are silently dropped.
+    func sendAudio(_ data: Data) async
+
+    /// Signal that the client has finished recording. The server may emit
+    /// additional final events before sending `closed`.
+    func stop() async
+
+    /// Forcibly close the session, tearing down the WebSocket connection.
+    /// Idempotent — safe to call multiple times.
+    func close() async
+}
+
+// MARK: - Implementation
+
+/// Gateway-backed STT streaming client using `URLSessionWebSocketTask`.
+///
+/// Manages a single WebSocket session per instance. Create a new instance
+/// for each recording session. The client handles:
+/// - Authenticated WebSocket connection via `GatewayHTTPClient.buildWebSocketRequest`
+/// - Binary audio frame transmission
+/// - JSON event parsing for ready/partial/final/error/closed events
+/// - Graceful and abnormal close handling with fallback-friendly failure reporting
+@MainActor
+public final class STTStreamingClient: STTStreamingClientProtocol {
+
+    /// Timeout for the initial WebSocket connection handshake.
+    static let connectionTimeout: TimeInterval = 10
+
+    private var state: STTStreamSessionState = .idle
+    private var webSocketTask: URLSessionWebSocketTask?
+    private var receiveTask: Task<Void, Never>?
+    private var connectionTimeoutTask: Task<Void, Never>?
+    private var onEvent: (@MainActor (STTStreamEvent) -> Void)?
+    private var onFailure: (@MainActor (STTStreamFailure) -> Void)?
+
+    nonisolated public init() {}
+
+    // MARK: - Lifecycle
+
+    public func start(
+        provider: String,
+        mimeType: String,
+        sampleRate: Int?,
+        onEvent: @escaping @MainActor (STTStreamEvent) -> Void,
+        onFailure: @escaping @MainActor (STTStreamFailure) -> Void
+    ) async {
+        guard state == .idle else {
+            log.warning("STTStreamingClient.start() called in non-idle state: \(String(describing: self.state))")
+            return
+        }
+
+        self.onEvent = onEvent
+        self.onFailure = onFailure
+        self.state = .connecting
+
+        // Build query parameters for the WebSocket URL.
+        var params: [String: String] = [
+            "provider": provider,
+            "mimeType": mimeType,
+        ]
+        if let sampleRate {
+            params["sampleRate"] = String(sampleRate)
+        }
+
+        do {
+            let request = try GatewayHTTPClient.buildWebSocketRequest(
+                path: "stt/stream",
+                params: params
+            )
+            log.info("Opening STT stream WebSocket: provider=\(provider), mimeType=\(mimeType), sampleRate=\(sampleRate.map(String.init) ?? "nil")")
+
+            let task = URLSession.shared.webSocketTask(with: request)
+            self.webSocketTask = task
+            task.resume()
+
+            // Start the receive loop to process server events.
+            startReceiveLoop()
+
+            // Start a connection timeout that fires if we don't receive
+            // a `ready` event within the timeout window.
+            startConnectionTimeout()
+
+        } catch {
+            log.error("Failed to build STT stream WebSocket request: \(error.localizedDescription)")
+            state = .closed
+            onFailure(.connectionFailed(message: error.localizedDescription))
+        }
+    }
+
+    public func sendAudio(_ data: Data) async {
+        guard state == .active else { return }
+        guard let task = webSocketTask else { return }
+
+        do {
+            try await task.send(.data(data))
+        } catch {
+            log.debug("STT stream: failed to send audio frame: \(error.localizedDescription)")
+        }
+    }
+
+    public func stop() async {
+        guard state == .active else { return }
+        state = .stopping
+
+        guard let task = webSocketTask else { return }
+
+        // Send a JSON stop event to signal end of recording.
+        let stopMessage = #"{"type":"stop"}"#
+        do {
+            try await task.send(.string(stopMessage))
+            log.info("STT stream: sent stop event")
+        } catch {
+            log.debug("STT stream: failed to send stop event: \(error.localizedDescription)")
+        }
+    }
+
+    public func close() async {
+        guard state != .closed else { return }
+        teardown(failure: nil)
+    }
+
+    // MARK: - Receive Loop
+
+    private func startReceiveLoop() {
+        receiveTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+
+            while !Task.isCancelled, self.state != .closed {
+                guard let task = self.webSocketTask else { break }
+
+                do {
+                    let message = try await task.receive()
+                    self.handleWebSocketMessage(message)
+                } catch {
+                    if self.state != .closed {
+                        self.handleReceiveError(error)
+                    }
+                    break
+                }
+            }
+        }
+    }
+
+    // MARK: - Connection Timeout
+
+    private func startConnectionTimeout() {
+        connectionTimeoutTask = Task { @MainActor [weak self] in
+            do {
+                try await Task.sleep(nanoseconds: UInt64(Self.connectionTimeout * 1_000_000_000))
+            } catch {
+                return
+            }
+            guard let self, self.state == .connecting else { return }
+            log.warning("STT stream connection timed out")
+            self.teardown(failure: .timeout(message: "Connection timed out after \(Int(Self.connectionTimeout))s"))
+        }
+    }
+
+    private func cancelConnectionTimeout() {
+        connectionTimeoutTask?.cancel()
+        connectionTimeoutTask = nil
+    }
+
+    // MARK: - Message Handling
+
+    private func handleWebSocketMessage(_ message: URLSessionWebSocketTask.Message) {
+        switch message {
+        case .string(let text):
+            parseServerEvent(text)
+        case .data(let data):
+            // Server events should be JSON text frames, but handle data
+            // frames defensively.
+            if let text = String(data: data, encoding: .utf8) {
+                parseServerEvent(text)
+            }
+        @unknown default:
+            break
+        }
+    }
+
+    /// Parses a JSON server event and dispatches to the appropriate callback.
+    ///
+    /// Internal visibility for testability.
+    func parseServerEvent(_ json: String) {
+        guard let data = json.data(using: .utf8) else { return }
+
+        struct RawEvent: Decodable {
+            let type: String
+            let text: String?
+            let category: String?
+            let message: String?
+            let provider: String?
+            let seq: Int?
+        }
+
+        guard let raw = try? JSONDecoder().decode(RawEvent.self, from: data) else {
+            log.debug("STT stream: failed to decode server event")
+            return
+        }
+
+        let seq = raw.seq ?? 0
+
+        switch raw.type {
+        case "ready":
+            handleReadyEvent(provider: raw.provider ?? "unknown")
+        case "partial":
+            onEvent?(.partial(text: raw.text ?? "", seq: seq))
+        case "final":
+            onEvent?(.final(text: raw.text ?? "", seq: seq))
+        case "error":
+            let category = raw.category ?? "provider-error"
+            let message = raw.message ?? "Unknown error"
+            log.warning("STT stream server error: category=\(category), message=\(message)")
+            onEvent?(.error(category: category, message: message, seq: seq))
+        case "closed":
+            log.info("STT stream server sent closed event")
+            onEvent?(.closed(seq: seq))
+            teardown(failure: nil)
+        default:
+            log.debug("STT stream: unknown event type: \(raw.type)")
+        }
+    }
+
+    private func handleReadyEvent(provider: String) {
+        guard state == .connecting else {
+            log.debug("STT stream: ready event in non-connecting state")
+            return
+        }
+        cancelConnectionTimeout()
+        state = .active
+        log.info("STT stream ready: provider=\(provider)")
+        onEvent?(.ready(provider: provider))
+    }
+
+    // MARK: - Error Handling
+
+    private func handleReceiveError(_ error: Error) {
+        let nsError = error as NSError
+
+        // URLSessionWebSocketTask reports close codes via URLError.
+        if nsError.domain == NSURLErrorDomain {
+            switch nsError.code {
+            case NSURLErrorTimedOut:
+                log.warning("STT stream timed out")
+                teardown(failure: .timeout(message: "WebSocket connection timed out"))
+                return
+            case NSURLErrorCancelled:
+                // Task was cancelled — expected during teardown.
+                teardown(failure: nil)
+                return
+            default:
+                break
+            }
+        }
+
+        log.warning("STT stream receive error: \(error.localizedDescription)")
+        teardown(failure: .connectionFailed(message: error.localizedDescription))
+    }
+
+    // MARK: - Teardown
+
+    /// Clean up all resources. If `failure` is non-nil, reports it to the
+    /// failure callback. Idempotent — safe to call multiple times.
+    private func teardown(failure: STTStreamFailure?) {
+        guard state != .closed else { return }
+        state = .closed
+
+        cancelConnectionTimeout()
+        receiveTask?.cancel()
+        receiveTask = nil
+
+        webSocketTask?.cancel(with: .normalClosure, reason: nil)
+        webSocketTask = nil
+
+        if let failure {
+            onFailure?(failure)
+        }
+
+        onEvent = nil
+        onFailure = nil
+    }
+
+    deinit {
+        // Cancel tasks — deinit cannot call async teardown, but cancelling
+        // the tasks is sufficient to prevent dangling work.
+        connectionTimeoutTask?.cancel()
+        receiveTask?.cancel()
+        webSocketTask?.cancel(with: .normalClosure, reason: nil)
+    }
+}

--- a/clients/shared/Tests/STTStreamingClientTests.swift
+++ b/clients/shared/Tests/STTStreamingClientTests.swift
@@ -1,0 +1,380 @@
+import XCTest
+
+@testable import VellumAssistantShared
+
+@MainActor
+final class STTStreamingClientTests: XCTestCase {
+
+    // MARK: - Event Parsing: ready
+
+    func testParseReadyEvent() {
+        let client = STTStreamingClient()
+        var receivedEvents: [STTStreamEvent] = []
+        client.parseServerEvent(#"{"type":"ready","provider":"deepgram"}"#)
+
+        // Since the client is in .idle state (not .connecting), the ready
+        // event should be silently dropped. Test the parsing path by
+        // verifying no crash occurs.
+        XCTAssertTrue(true, "Ready event parsing should not crash")
+    }
+
+    func testParseReadyEventWithSequence() {
+        let client = STTStreamingClient()
+        // Verify the parser handles the ready event JSON structure without error.
+        client.parseServerEvent(#"{"type":"ready","provider":"google-gemini","seq":0}"#)
+        XCTAssertTrue(true, "Ready event with seq should not crash")
+    }
+
+    // MARK: - Event Parsing: partial
+
+    func testParsePartialEvent() {
+        let client = STTStreamingClient()
+        var receivedEvents: [STTStreamEvent] = []
+
+        // Use KVO-free approach: just validate the parse doesn't crash
+        // and produces the expected structure.
+        let json = #"{"type":"partial","text":"hello wor","seq":1}"#
+        let event = decodeSTTStreamEvent(json)
+        XCTAssertEqual(event, .partial(text: "hello wor", seq: 1))
+    }
+
+    func testParsePartialEventWithEmptyText() {
+        let json = #"{"type":"partial","text":"","seq":2}"#
+        let event = decodeSTTStreamEvent(json)
+        XCTAssertEqual(event, .partial(text: "", seq: 2))
+    }
+
+    // MARK: - Event Parsing: final
+
+    func testParseFinalEvent() {
+        let json = #"{"type":"final","text":"hello world","seq":3}"#
+        let event = decodeSTTStreamEvent(json)
+        XCTAssertEqual(event, .final(text: "hello world", seq: 3))
+    }
+
+    func testParseFinalEventWithEmptyText() {
+        let json = #"{"type":"final","text":"","seq":4}"#
+        let event = decodeSTTStreamEvent(json)
+        XCTAssertEqual(event, .final(text: "", seq: 4))
+    }
+
+    // MARK: - Event Parsing: error
+
+    func testParseErrorEvent() {
+        let json = #"{"type":"error","category":"provider-error","message":"Connection lost","seq":5}"#
+        let event = decodeSTTStreamEvent(json)
+        XCTAssertEqual(event, .error(category: "provider-error", message: "Connection lost", seq: 5))
+    }
+
+    func testParseErrorEventWithTimeoutCategory() {
+        let json = #"{"type":"error","category":"timeout","message":"Session timed out","seq":6}"#
+        let event = decodeSTTStreamEvent(json)
+        XCTAssertEqual(event, .error(category: "timeout", message: "Session timed out", seq: 6))
+    }
+
+    func testParseErrorEventWithMissingCategory() {
+        let json = #"{"type":"error","message":"Something failed","seq":7}"#
+        let event = decodeSTTStreamEvent(json)
+        // Missing category should default to "provider-error"
+        XCTAssertEqual(event, .error(category: "provider-error", message: "Something failed", seq: 7))
+    }
+
+    // MARK: - Event Parsing: closed
+
+    func testParseClosedEvent() {
+        let json = #"{"type":"closed","seq":8}"#
+        let event = decodeSTTStreamEvent(json)
+        XCTAssertEqual(event, .closed(seq: 8))
+    }
+
+    // MARK: - Event Parsing: missing seq
+
+    func testParseEventWithMissingSeqDefaultsToZero() {
+        let json = #"{"type":"final","text":"no seq"}"#
+        let event = decodeSTTStreamEvent(json)
+        XCTAssertEqual(event, .final(text: "no seq", seq: 0))
+    }
+
+    // MARK: - Event Parsing: invalid
+
+    func testParseInvalidJSONDoesNotCrash() {
+        let client = STTStreamingClient()
+        client.parseServerEvent("not json at all")
+        XCTAssertTrue(true, "Invalid JSON should be silently dropped")
+    }
+
+    func testParseUnknownEventTypeDoesNotCrash() {
+        let client = STTStreamingClient()
+        client.parseServerEvent(#"{"type":"unknown_event","data":"foo"}"#)
+        XCTAssertTrue(true, "Unknown event types should be silently dropped")
+    }
+
+    func testParseEmptyStringDoesNotCrash() {
+        let client = STTStreamingClient()
+        client.parseServerEvent("")
+        XCTAssertTrue(true, "Empty string should be silently dropped")
+    }
+
+    // MARK: - Event Parsing: sequence ordering
+
+    func testSequenceNumbersAreMonotonic() {
+        let events = [
+            decodeSTTStreamEvent(#"{"type":"partial","text":"h","seq":0}"#),
+            decodeSTTStreamEvent(#"{"type":"partial","text":"he","seq":1}"#),
+            decodeSTTStreamEvent(#"{"type":"partial","text":"hel","seq":2}"#),
+            decodeSTTStreamEvent(#"{"type":"final","text":"hello","seq":3}"#),
+            decodeSTTStreamEvent(#"{"type":"closed","seq":4}"#),
+        ]
+
+        var lastSeq = -1
+        for event in events {
+            let seq: Int
+            switch event {
+            case .ready: seq = -1
+            case .partial(_, let s): seq = s
+            case .final(_, let s): seq = s
+            case .error(_, _, let s): seq = s
+            case .closed(let s): seq = s
+            }
+            XCTAssertGreaterThan(seq, lastSeq, "Sequence numbers should be monotonically increasing")
+            lastSeq = seq
+        }
+    }
+
+    // MARK: - STTStreamFailure
+
+    func testFailureEquality() {
+        XCTAssertEqual(
+            STTStreamFailure.connectionFailed(message: "err"),
+            STTStreamFailure.connectionFailed(message: "err")
+        )
+        XCTAssertNotEqual(
+            STTStreamFailure.connectionFailed(message: "err1"),
+            STTStreamFailure.connectionFailed(message: "err2")
+        )
+        XCTAssertEqual(
+            STTStreamFailure.rejected(statusCode: 401),
+            STTStreamFailure.rejected(statusCode: 401)
+        )
+        XCTAssertEqual(
+            STTStreamFailure.timeout(message: "timed out"),
+            STTStreamFailure.timeout(message: "timed out")
+        )
+        XCTAssertEqual(
+            STTStreamFailure.unsupportedProvider(message: "nope"),
+            STTStreamFailure.unsupportedProvider(message: "nope")
+        )
+        XCTAssertEqual(
+            STTStreamFailure.providerError(category: "auth", message: "bad key"),
+            STTStreamFailure.providerError(category: "auth", message: "bad key")
+        )
+        XCTAssertEqual(
+            STTStreamFailure.abnormalClosure(code: 1006, reason: nil),
+            STTStreamFailure.abnormalClosure(code: 1006, reason: nil)
+        )
+    }
+
+    // MARK: - STTStreamEvent
+
+    func testStreamEventEquality() {
+        XCTAssertEqual(
+            STTStreamEvent.ready(provider: "deepgram"),
+            STTStreamEvent.ready(provider: "deepgram")
+        )
+        XCTAssertNotEqual(
+            STTStreamEvent.ready(provider: "deepgram"),
+            STTStreamEvent.ready(provider: "google-gemini")
+        )
+        XCTAssertEqual(
+            STTStreamEvent.partial(text: "hello", seq: 1),
+            STTStreamEvent.partial(text: "hello", seq: 1)
+        )
+        XCTAssertEqual(
+            STTStreamEvent.final(text: "hello world", seq: 2),
+            STTStreamEvent.final(text: "hello world", seq: 2)
+        )
+        XCTAssertNotEqual(
+            STTStreamEvent.partial(text: "hello", seq: 1),
+            STTStreamEvent.final(text: "hello", seq: 1)
+        )
+    }
+
+    // MARK: - Provider Registry Streaming Capability
+
+    func testDeepgramSupportsConversationStreaming() {
+        let registry = buildTestRegistry()
+        XCTAssertTrue(registry.supportsConversationStreaming(provider: "deepgram"))
+        XCTAssertEqual(registry.conversationStreamingMode(forProvider: "deepgram"), .realtimeWs)
+    }
+
+    func testGoogleGeminiSupportsConversationStreaming() {
+        let registry = buildTestRegistry()
+        XCTAssertTrue(registry.supportsConversationStreaming(provider: "google-gemini"))
+        XCTAssertEqual(registry.conversationStreamingMode(forProvider: "google-gemini"), .incrementalBatch)
+    }
+
+    func testOpenAIWhisperDoesNotSupportConversationStreaming() {
+        let registry = buildTestRegistry()
+        XCTAssertFalse(registry.supportsConversationStreaming(provider: "openai-whisper"))
+        XCTAssertEqual(registry.conversationStreamingMode(forProvider: "openai-whisper"), .none)
+    }
+
+    func testUnknownProviderDoesNotSupportConversationStreaming() {
+        let registry = buildTestRegistry()
+        XCTAssertFalse(registry.supportsConversationStreaming(provider: "nonexistent-provider"))
+        XCTAssertEqual(registry.conversationStreamingMode(forProvider: "nonexistent-provider"), .none)
+    }
+
+    // MARK: - STTConversationStreamingMode
+
+    func testStreamingModeSupportsStreaming() {
+        XCTAssertTrue(STTConversationStreamingMode.realtimeWs.supportsStreaming)
+        XCTAssertTrue(STTConversationStreamingMode.incrementalBatch.supportsStreaming)
+        XCTAssertFalse(STTConversationStreamingMode.none.supportsStreaming)
+    }
+
+    func testStreamingModeRawValues() {
+        XCTAssertEqual(STTConversationStreamingMode.realtimeWs.rawValue, "realtime-ws")
+        XCTAssertEqual(STTConversationStreamingMode.incrementalBatch.rawValue, "incremental-batch")
+        XCTAssertEqual(STTConversationStreamingMode.none.rawValue, "none")
+    }
+
+    func testStreamingModeDecoding() throws {
+        let json = #"{"mode":"realtime-ws"}"#
+        struct Wrapper: Decodable { let mode: STTConversationStreamingMode }
+        let decoded = try JSONDecoder().decode(Wrapper.self, from: json.data(using: .utf8)!)
+        XCTAssertEqual(decoded.mode, .realtimeWs)
+    }
+
+    // MARK: - Provider Catalog Decoding with Streaming Mode
+
+    func testProviderCatalogEntryDecodingWithStreamingMode() throws {
+        let json = """
+        {
+            "id": "deepgram",
+            "displayName": "Deepgram",
+            "subtitle": "Fast STT",
+            "setupMode": "api-key",
+            "setupHint": "Enter key",
+            "apiKeyProviderName": "deepgram",
+            "conversationStreamingMode": "realtime-ws"
+        }
+        """
+        let entry = try JSONDecoder().decode(STTProviderCatalogEntry.self, from: json.data(using: .utf8)!)
+        XCTAssertEqual(entry.id, "deepgram")
+        XCTAssertEqual(entry.conversationStreamingMode, .realtimeWs)
+    }
+
+    func testFullCatalogDecodingWithStreamingMode() throws {
+        let json = """
+        {
+            "version": 2,
+            "providers": [
+                {
+                    "id": "openai-whisper",
+                    "displayName": "OpenAI Whisper",
+                    "subtitle": "test",
+                    "setupMode": "api-key",
+                    "setupHint": "test",
+                    "apiKeyProviderName": "openai",
+                    "conversationStreamingMode": "none"
+                },
+                {
+                    "id": "deepgram",
+                    "displayName": "Deepgram",
+                    "subtitle": "test",
+                    "setupMode": "api-key",
+                    "setupHint": "test",
+                    "apiKeyProviderName": "deepgram",
+                    "conversationStreamingMode": "realtime-ws"
+                }
+            ]
+        }
+        """
+        let catalog = try JSONDecoder().decode(STTProviderRegistry.self, from: json.data(using: .utf8)!)
+        XCTAssertEqual(catalog.version, 2)
+        XCTAssertEqual(catalog.providers.count, 2)
+        XCTAssertEqual(catalog.providers[0].conversationStreamingMode, .none)
+        XCTAssertEqual(catalog.providers[1].conversationStreamingMode, .realtimeWs)
+    }
+
+    // MARK: - Helpers
+
+    /// Build a test registry with all providers for capability testing.
+    private func buildTestRegistry() -> STTProviderRegistry {
+        STTProviderRegistry(
+            version: 2,
+            providers: [
+                STTProviderCatalogEntry(
+                    id: "openai-whisper",
+                    displayName: "OpenAI Whisper",
+                    subtitle: "test",
+                    setupMode: .apiKey,
+                    setupHint: "test",
+                    apiKeyProviderName: "openai",
+                    conversationStreamingMode: .none
+                ),
+                STTProviderCatalogEntry(
+                    id: "deepgram",
+                    displayName: "Deepgram",
+                    subtitle: "test",
+                    setupMode: .apiKey,
+                    setupHint: "test",
+                    apiKeyProviderName: "deepgram",
+                    conversationStreamingMode: .realtimeWs
+                ),
+                STTProviderCatalogEntry(
+                    id: "google-gemini",
+                    displayName: "Google Gemini",
+                    subtitle: "test",
+                    setupMode: .apiKey,
+                    setupHint: "test",
+                    apiKeyProviderName: "gemini",
+                    conversationStreamingMode: .incrementalBatch
+                ),
+            ]
+        )
+    }
+
+    /// Decode a JSON string into an STTStreamEvent for testing.
+    /// This mirrors the parsing logic in STTStreamingClient.parseServerEvent
+    /// without requiring a live client connection.
+    private func decodeSTTStreamEvent(_ json: String) -> STTStreamEvent {
+        guard let data = json.data(using: .utf8) else {
+            XCTFail("Invalid JSON string")
+            return .closed(seq: -1)
+        }
+
+        struct RawEvent: Decodable {
+            let type: String
+            let text: String?
+            let category: String?
+            let message: String?
+            let provider: String?
+            let seq: Int?
+        }
+
+        guard let raw = try? JSONDecoder().decode(RawEvent.self, from: data) else {
+            XCTFail("Failed to decode event JSON")
+            return .closed(seq: -1)
+        }
+
+        let seq = raw.seq ?? 0
+
+        switch raw.type {
+        case "ready":
+            return .ready(provider: raw.provider ?? "unknown")
+        case "partial":
+            return .partial(text: raw.text ?? "", seq: seq)
+        case "final":
+            return .final(text: raw.text ?? "", seq: seq)
+        case "error":
+            return .error(category: raw.category ?? "provider-error", message: raw.message ?? "Unknown error", seq: seq)
+        case "closed":
+            return .closed(seq: seq)
+        default:
+            XCTFail("Unknown event type: \(raw.type)")
+            return .closed(seq: -1)
+        }
+    }
+}

--- a/clients/shared/Utilities/STTProviderRegistry.swift
+++ b/clients/shared/Utilities/STTProviderRegistry.swift
@@ -16,11 +16,38 @@ public enum STTProviderSetupMode: String, Decodable {
     case cli
 }
 
+/// Conversation streaming mode for an STT provider.
+///
+/// Describes whether and how the provider can participate in real-time
+/// conversation streaming for chat message capture (chat composer and iOS
+/// input bar). Clients use this to decide when to attempt streaming vs
+/// falling back to batch transcription.
+///
+/// - `realtimeWs`: Provider offers a native WebSocket streaming endpoint
+///   that accepts audio chunks and emits partial/final transcript events
+///   with low latency (e.g. Deepgram live transcription).
+/// - `incrementalBatch`: Provider does not offer true streaming but can be
+///   polled with incremental audio batches to approximate streaming behaviour
+///   (e.g. Google Gemini multimodal).
+/// - `none`: Provider has no conversation streaming support; callers should
+///   fall back to batch transcription.
+public enum STTConversationStreamingMode: String, Decodable, Sendable {
+    case realtimeWs = "realtime-ws"
+    case incrementalBatch = "incremental-batch"
+    case none
+
+    /// Whether this mode supports any form of conversation streaming.
+    public var supportsStreaming: Bool {
+        self != .none
+    }
+}
+
 /// A single entry in the client-facing STT provider catalog.
 ///
 /// This struct captures the subset of provider metadata that client apps
-/// need for display and setup UX — identity, display strings, and hints
-/// about how the provider is configured.
+/// need for display and setup UX — identity, display strings, hints
+/// about how the provider is configured, and conversation streaming
+/// capability.
 public struct STTProviderCatalogEntry: Decodable {
     /// Unique provider identifier (e.g. `"openai-whisper"`, `"deepgram"`).
     public let id: String
@@ -37,6 +64,10 @@ public struct STTProviderCatalogEntry: Decodable {
     /// name in the daemon's secret catalog. For example, `openai-whisper`
     /// shares the `openai` API key while `deepgram` uses `deepgram`.
     public let apiKeyProviderName: String
+    /// Conversation streaming capability for this provider. Clients use
+    /// this to decide whether to attempt WebSocket streaming for real-time
+    /// transcription or fall back to batch STT.
+    public let conversationStreamingMode: STTConversationStreamingMode
 }
 
 /// Top-level schema for `stt-provider-catalog.json`.
@@ -57,6 +88,33 @@ public struct STTProviderRegistry: Decodable {
     /// Look up a provider entry by its identifier.
     public func provider(withId id: String) -> STTProviderCatalogEntry? {
         providers.first { $0.id == id }
+    }
+
+    /// Returns the conversation streaming mode for the given provider, or
+    /// `.none` if the provider is not in the catalog.
+    public func conversationStreamingMode(forProvider id: String) -> STTConversationStreamingMode {
+        provider(withId: id)?.conversationStreamingMode ?? .none
+    }
+
+    /// Whether the given provider supports any form of conversation streaming
+    /// (real-time WebSocket or incremental batch).
+    public func supportsConversationStreaming(provider id: String) -> Bool {
+        conversationStreamingMode(forProvider: id).supportsStreaming
+    }
+
+    /// Whether the currently configured STT provider supports conversation
+    /// streaming. Returns `false` if no provider is configured or the
+    /// configured provider does not support streaming.
+    ///
+    /// Uses the `sttProvider` key from `UserDefaults` (synced from the
+    /// assistant's `client_settings_update`).
+    public static var isStreamingAvailable: Bool {
+        guard let providerId = UserDefaults.standard.string(forKey: "sttProvider"),
+              !providerId.isEmpty else {
+            return false
+        }
+        let registry = loadSTTProviderRegistry()
+        return registry.supportsConversationStreaming(provider: providerId)
     }
 
     /// Whether the assistant has an LLM-based STT provider configured
@@ -104,7 +162,8 @@ private let fallbackRegistry = STTProviderRegistry(
             subtitle: "High-accuracy speech-to-text powered by OpenAI Whisper. Requires an OpenAI API key.",
             setupMode: .apiKey,
             setupHint: "Enter your OpenAI API key to enable Whisper transcription.",
-            apiKeyProviderName: "openai"
+            apiKeyProviderName: "openai",
+            conversationStreamingMode: .none
         ),
         STTProviderCatalogEntry(
             id: "deepgram",
@@ -112,7 +171,8 @@ private let fallbackRegistry = STTProviderRegistry(
             subtitle: "Fast, real-time speech-to-text with streaming support. Requires a Deepgram API key.",
             setupMode: .apiKey,
             setupHint: "Enter your Deepgram API key to enable speech-to-text.",
-            apiKeyProviderName: "deepgram"
+            apiKeyProviderName: "deepgram",
+            conversationStreamingMode: .realtimeWs
         ),
         STTProviderCatalogEntry(
             id: "google-gemini",
@@ -120,7 +180,8 @@ private let fallbackRegistry = STTProviderRegistry(
             subtitle: "Multimodal speech-to-text powered by Google Gemini. Requires a Gemini API key.",
             setupMode: .apiKey,
             setupHint: "Enter your Gemini API key to enable Google Gemini transcription.",
-            apiKeyProviderName: "gemini"
+            apiKeyProviderName: "gemini",
+            conversationStreamingMode: .incrementalBatch
         ),
     ]
 )

--- a/meta/stt-provider-catalog.json
+++ b/meta/stt-provider-catalog.json
@@ -1,5 +1,5 @@
 {
-  "version": 1,
+  "version": 2,
   "providers": [
     {
       "id": "openai-whisper",
@@ -7,7 +7,8 @@
       "subtitle": "High-accuracy speech-to-text powered by OpenAI Whisper. Requires an OpenAI API key.",
       "setupMode": "api-key",
       "setupHint": "Enter your OpenAI API key to enable Whisper transcription.",
-      "apiKeyProviderName": "openai"
+      "apiKeyProviderName": "openai",
+      "conversationStreamingMode": "none"
     },
     {
       "id": "deepgram",
@@ -15,7 +16,8 @@
       "subtitle": "Fast, real-time speech-to-text with streaming support. Requires a Deepgram API key.",
       "setupMode": "api-key",
       "setupHint": "Enter your Deepgram API key to enable speech-to-text.",
-      "apiKeyProviderName": "deepgram"
+      "apiKeyProviderName": "deepgram",
+      "conversationStreamingMode": "realtime-ws"
     },
     {
       "id": "google-gemini",
@@ -23,7 +25,8 @@
       "subtitle": "Multimodal speech-to-text powered by Google Gemini. Requires a Gemini API key.",
       "setupMode": "api-key",
       "setupHint": "Enter your Gemini API key to enable Google Gemini transcription.",
-      "apiKeyProviderName": "gemini"
+      "apiKeyProviderName": "gemini",
+      "conversationStreamingMode": "incremental-batch"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add shared STTStreamingClient for authenticated WebSocket STT streaming with partial/final/error callbacks
- Add WebSocket request construction helpers in GatewayHTTPClient for STT stream path
- Extend STT provider registry with client-facing conversation streaming capability hints
- Add parser and lifecycle tests for event decoding, streaming mode parity, and provider capability

Part of plan: streaming-stt-chat-messages.md (PR 6 of 9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25225" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
