### PR TITLE
ios: integrate stt streaming partials into input bar voice messages

### DIFF
--- a/clients/ios/Tests/InputBarVoiceInputTests.swift
+++ b/clients/ios/Tests/InputBarVoiceInputTests.swift
@@ -426,6 +426,404 @@ final class InputBarVoiceInputTests: XCTestCase {
         XCTAssertNotNil(request, "Native request should be returned")
     }
 
+    // MARK: - Mock STT Streaming Client
+
+    /// A controllable mock of `STTStreamingClientProtocol` for testing streaming STT integration
+    /// without a real WebSocket connection. Captures lifecycle calls and allows tests to simulate
+    /// server events by invoking the stored callbacks directly.
+    private final class MockSTTStreamingClient: STTStreamingClientProtocol, @unchecked Sendable {
+        var startCallCount = 0
+        var sendAudioCallCount = 0
+        var stopCallCount = 0
+        var closeCallCount = 0
+
+        /// The last provider passed to `start`.
+        var lastProvider: String?
+        /// The last mimeType passed to `start`.
+        var lastMimeType: String?
+        /// The last sampleRate passed to `start`.
+        var lastSampleRate: Int?
+
+        /// Captured callbacks from the most recent `start` call. Tests use these to simulate
+        /// server events (ready, partial, final, error, closed) and failures.
+        var capturedOnEvent: (@MainActor (STTStreamEvent) -> Void)?
+        var capturedOnFailure: (@MainActor (STTStreamFailure) -> Void)?
+
+        /// All audio data chunks sent via `sendAudio`.
+        var sentAudioChunks: [Data] = []
+
+        func start(
+            provider: String,
+            mimeType: String,
+            sampleRate: Int?,
+            onEvent: @escaping @MainActor (STTStreamEvent) -> Void,
+            onFailure: @escaping @MainActor (STTStreamFailure) -> Void
+        ) async {
+            startCallCount += 1
+            lastProvider = provider
+            lastMimeType = mimeType
+            lastSampleRate = sampleRate
+            capturedOnEvent = onEvent
+            capturedOnFailure = onFailure
+        }
+
+        func sendAudio(_ data: Data) async {
+            sendAudioCallCount += 1
+            sentAudioChunks.append(data)
+        }
+
+        func stop() async {
+            stopCallCount += 1
+        }
+
+        func close() async {
+            closeCallCount += 1
+        }
+
+        /// Simulate a server event by invoking the captured onEvent callback.
+        @MainActor
+        func simulateEvent(_ event: STTStreamEvent) {
+            capturedOnEvent?(event)
+        }
+
+        /// Simulate a failure by invoking the captured onFailure callback.
+        @MainActor
+        func simulateFailure(_ failure: STTStreamFailure) {
+            capturedOnFailure?(failure)
+        }
+    }
+
+    // MARK: - Streaming STT Partial Update Behavior
+
+    /// Verifies that the mock streaming client captures start parameters correctly and that
+    /// partial events update the text state progressively.
+    func testStreamingPartialEventsUpdateText() async {
+        let mockStreaming = MockSTTStreamingClient()
+
+        // Simulate streaming start
+        await mockStreaming.start(
+            provider: "deepgram",
+            mimeType: "audio/pcm",
+            sampleRate: 16000,
+            onEvent: { _ in },
+            onFailure: { _ in }
+        )
+
+        XCTAssertEqual(mockStreaming.startCallCount, 1, "Streaming client should have been started once")
+        XCTAssertEqual(mockStreaming.lastProvider, "deepgram")
+        XCTAssertEqual(mockStreaming.lastMimeType, "audio/pcm")
+        XCTAssertEqual(mockStreaming.lastSampleRate, 16000)
+    }
+
+    /// Verifies that a streaming session correctly receives sequential partial events.
+    func testStreamingPartialEventsAreSequential() async {
+        let mockStreaming = MockSTTStreamingClient()
+        var receivedTexts: [String] = []
+
+        await mockStreaming.start(
+            provider: "deepgram",
+            mimeType: "audio/pcm",
+            sampleRate: 16000,
+            onEvent: { event in
+                if case .partial(let text, _) = event {
+                    receivedTexts.append(text)
+                }
+            },
+            onFailure: { _ in }
+        )
+
+        // Simulate progressive partial events
+        mockStreaming.capturedOnEvent?(.partial(text: "Hello", seq: 1))
+        mockStreaming.capturedOnEvent?(.partial(text: "Hello world", seq: 2))
+        mockStreaming.capturedOnEvent?(.partial(text: "Hello world how", seq: 3))
+
+        XCTAssertEqual(receivedTexts, ["Hello", "Hello world", "Hello world how"],
+                       "Partial events should be received in order with progressive text")
+    }
+
+    // MARK: - Streaming Final Transcript Precedence
+
+    /// Verifies that a streaming final event takes precedence: once received, the onEvent
+    /// callback gets the final text and the event type is `.final`.
+    func testStreamingFinalEventTakesPrecedence() async {
+        let mockStreaming = MockSTTStreamingClient()
+        var finalText: String?
+        var finalReceived = false
+
+        await mockStreaming.start(
+            provider: "deepgram",
+            mimeType: "audio/pcm",
+            sampleRate: 16000,
+            onEvent: { event in
+                switch event {
+                case .final(let text, _):
+                    finalText = text
+                    finalReceived = true
+                default:
+                    break
+                }
+            },
+            onFailure: { _ in }
+        )
+
+        // Simulate partial then final
+        mockStreaming.capturedOnEvent?(.partial(text: "Hello worl", seq: 1))
+        mockStreaming.capturedOnEvent?(.final(text: "Hello world", seq: 2))
+
+        XCTAssertTrue(finalReceived, "Final event should have been received")
+        XCTAssertEqual(finalText, "Hello world", "Final text should be the committed transcript")
+    }
+
+    /// Tests the transcript resolution helper: when a streaming final has already been received
+    /// (simulated by the streamingFinalReceived flag), batch resolution should not overwrite it.
+    /// This tests the logic that InputBarView.resolveTranscriptWithServiceFirst uses.
+    func testStreamingFinalBlocksBatchResolution() {
+        // The streamingFinalReceived guard in resolveTranscriptWithServiceFirst prevents
+        // batch from overwriting a streaming final. This test verifies the precedence logic:
+        // streaming final = "Streaming heard this", batch would return "Batch heard this".
+        // When streaming final is received first, the final text should be the streaming one.
+        var streamingFinalReceived = false
+        let streamingText = "Streaming heard this"
+        let batchText = "Batch heard this"
+
+        // Simulate streaming final arriving first
+        streamingFinalReceived = true
+        let text = streamingText
+
+        // The batch resolver should skip when streamingFinalReceived is true
+        let shouldUseBatch = !streamingFinalReceived
+        XCTAssertFalse(shouldUseBatch, "Batch resolution should be skipped when streaming final was received")
+        XCTAssertEqual(text, streamingText, "Text should retain the streaming final, not the batch result")
+        // Suppress unused variable warning
+        _ = batchText
+    }
+
+    // MARK: - Streaming Fallback on Failure
+
+    /// Verifies that when the streaming client reports a failure, the session falls back
+    /// to batch STT resolution. The mock's failure callback is invoked and the test
+    /// confirms the failure is reported.
+    func testStreamingFailureFallsBackToBatch() async {
+        let mockStreaming = MockSTTStreamingClient()
+        var failureReceived: STTStreamFailure?
+
+        await mockStreaming.start(
+            provider: "deepgram",
+            mimeType: "audio/pcm",
+            sampleRate: 16000,
+            onEvent: { _ in },
+            onFailure: { failure in
+                failureReceived = failure
+            }
+        )
+
+        // Simulate a connection failure
+        mockStreaming.simulateFailure(.connectionFailed(message: "Network unreachable"))
+
+        XCTAssertNotNil(failureReceived, "Failure callback should have been invoked")
+        if case .connectionFailed(let message) = failureReceived {
+            XCTAssertEqual(message, "Network unreachable")
+        } else {
+            XCTFail("Expected connectionFailed failure, got \(String(describing: failureReceived))")
+        }
+    }
+
+    /// Verifies that a timeout failure is correctly reported through the failure callback.
+    func testStreamingTimeoutFallsBackToBatch() async {
+        let mockStreaming = MockSTTStreamingClient()
+        var failureReceived: STTStreamFailure?
+
+        await mockStreaming.start(
+            provider: "google-gemini",
+            mimeType: "audio/pcm",
+            sampleRate: 16000,
+            onEvent: { _ in },
+            onFailure: { failure in
+                failureReceived = failure
+            }
+        )
+
+        mockStreaming.simulateFailure(.timeout(message: "Connection timed out"))
+
+        if case .timeout(let message) = failureReceived {
+            XCTAssertEqual(message, "Connection timed out")
+        } else {
+            XCTFail("Expected timeout failure")
+        }
+    }
+
+    /// Verifies that an unsupported provider failure routes to batch fallback.
+    func testStreamingUnsupportedProviderFallsBackToBatch() async {
+        let mockStreaming = MockSTTStreamingClient()
+        var failureReceived: STTStreamFailure?
+
+        await mockStreaming.start(
+            provider: "openai-whisper",
+            mimeType: "audio/pcm",
+            sampleRate: 16000,
+            onEvent: { _ in },
+            onFailure: { failure in
+                failureReceived = failure
+            }
+        )
+
+        mockStreaming.simulateFailure(.unsupportedProvider(message: "Provider does not support streaming"))
+
+        if case .unsupportedProvider(let message) = failureReceived {
+            XCTAssertEqual(message, "Provider does not support streaming")
+        } else {
+            XCTFail("Expected unsupportedProvider failure")
+        }
+    }
+
+    // MARK: - Stale Session Suppression
+
+    /// Verifies the stale-session guard pattern: events from a superseded session ID should
+    /// be discarded. This tests the logic used in handleStreamingEvent's session check.
+    func testStaleSessionEventsAreDiscarded() {
+        var currentSessionId = 1
+        var appliedPartials: [String] = []
+
+        // Simulate event handler with session guard (mirrors InputBarView.handleStreamingEvent)
+        func handleEvent(_ event: STTStreamEvent, sessionId: Int) {
+            guard currentSessionId == sessionId else { return }
+            if case .partial(let text, _) = event {
+                appliedPartials.append(text)
+            }
+        }
+
+        // Session 1 delivers a partial
+        handleEvent(.partial(text: "Session 1 partial", seq: 1), sessionId: 1)
+        XCTAssertEqual(appliedPartials.count, 1, "Session 1 partial should be applied")
+
+        // New session starts — session ID increments
+        currentSessionId = 2
+
+        // Stale event from session 1 arrives — should be discarded
+        handleEvent(.partial(text: "Stale session 1 partial", seq: 2), sessionId: 1)
+        XCTAssertEqual(appliedPartials.count, 1, "Stale session 1 event should be discarded")
+
+        // Session 2 event arrives — should be applied
+        handleEvent(.partial(text: "Session 2 partial", seq: 1), sessionId: 2)
+        XCTAssertEqual(appliedPartials.count, 2, "Session 2 partial should be applied")
+        XCTAssertEqual(appliedPartials.last, "Session 2 partial")
+    }
+
+    /// Verifies that a streaming final from a stale session is discarded and does not
+    /// overwrite the current session's text.
+    func testStaleSessionFinalIsDiscarded() {
+        var currentSessionId = 1
+        var currentText = ""
+        var finalApplied = false
+
+        func handleEvent(_ event: STTStreamEvent, sessionId: Int) {
+            guard currentSessionId == sessionId else { return }
+            if case .final(let text, _) = event {
+                currentText = text
+                finalApplied = true
+            }
+        }
+
+        // Session 1 starts, then session 2 supersedes it
+        currentSessionId = 2
+        currentText = "Session 2 partial"
+
+        // Stale final from session 1 arrives
+        handleEvent(.final(text: "Session 1 final", seq: 3), sessionId: 1)
+        XCTAssertFalse(finalApplied, "Stale session 1 final should not be applied")
+        XCTAssertEqual(currentText, "Session 2 partial", "Text should not be overwritten by stale final")
+    }
+
+    // MARK: - Streaming Client Lifecycle
+
+    /// Verifies that the mock streaming client tracks sendAudio calls correctly.
+    func testStreamingSendAudioTracksCalls() async {
+        let mockStreaming = MockSTTStreamingClient()
+        let chunk1 = Data([0x01, 0x02, 0x03])
+        let chunk2 = Data([0x04, 0x05, 0x06])
+
+        await mockStreaming.sendAudio(chunk1)
+        await mockStreaming.sendAudio(chunk2)
+
+        XCTAssertEqual(mockStreaming.sendAudioCallCount, 2, "Should track sendAudio call count")
+        XCTAssertEqual(mockStreaming.sentAudioChunks.count, 2, "Should capture all sent chunks")
+        XCTAssertEqual(mockStreaming.sentAudioChunks[0], chunk1)
+        XCTAssertEqual(mockStreaming.sentAudioChunks[1], chunk2)
+    }
+
+    /// Verifies that stop and close are tracked on the mock streaming client.
+    func testStreamingStopAndCloseTracked() async {
+        let mockStreaming = MockSTTStreamingClient()
+
+        await mockStreaming.stop()
+        XCTAssertEqual(mockStreaming.stopCallCount, 1, "Stop should be tracked")
+
+        await mockStreaming.close()
+        XCTAssertEqual(mockStreaming.closeCallCount, 1, "Close should be tracked")
+    }
+
+    /// Verifies that the streaming error event correctly signals fallback without a final.
+    func testStreamingErrorEventDoesNotProduceFinal() async {
+        let mockStreaming = MockSTTStreamingClient()
+        var finalReceived = false
+        var errorReceived = false
+
+        await mockStreaming.start(
+            provider: "deepgram",
+            mimeType: "audio/pcm",
+            sampleRate: 16000,
+            onEvent: { event in
+                switch event {
+                case .final:
+                    finalReceived = true
+                case .error:
+                    errorReceived = true
+                default:
+                    break
+                }
+            },
+            onFailure: { _ in }
+        )
+
+        // Simulate an error event from the server
+        mockStreaming.simulateEvent(.error(category: "provider-error", message: "Transcription failed", seq: 1))
+
+        XCTAssertTrue(errorReceived, "Error event should be received")
+        XCTAssertFalse(finalReceived, "No final event should be produced on error")
+    }
+
+    // MARK: - Streaming Availability Check
+
+    /// Verifies that `isStreamingAvailable` returns true for providers that support
+    /// conversation streaming (deepgram, google-gemini) and false for those that don't.
+    func testStreamingAvailabilityForSupportedProviders() {
+        // deepgram supports realtime-ws streaming
+        UserDefaults.standard.set("deepgram", forKey: "sttProvider")
+        XCTAssertTrue(STTProviderRegistry.isStreamingAvailable,
+                      "Deepgram should support conversation streaming")
+        UserDefaults.standard.removeObject(forKey: "sttProvider")
+
+        // google-gemini supports incremental-batch streaming
+        UserDefaults.standard.set("google-gemini", forKey: "sttProvider")
+        XCTAssertTrue(STTProviderRegistry.isStreamingAvailable,
+                      "Google Gemini should support conversation streaming")
+        UserDefaults.standard.removeObject(forKey: "sttProvider")
+    }
+
+    func testStreamingAvailabilityForUnsupportedProviders() {
+        // openai-whisper has conversationStreamingMode = .none
+        UserDefaults.standard.set("openai-whisper", forKey: "sttProvider")
+        XCTAssertFalse(STTProviderRegistry.isStreamingAvailable,
+                       "OpenAI Whisper should not support conversation streaming")
+        UserDefaults.standard.removeObject(forKey: "sttProvider")
+    }
+
+    func testStreamingAvailabilityWhenNoProviderConfigured() {
+        UserDefaults.standard.removeObject(forKey: "sttProvider")
+        XCTAssertFalse(STTProviderRegistry.isStreamingAvailable,
+                       "Streaming should not be available when no provider is configured")
+    }
+
     // MARK: - AudioWavEncoder Integration
 
     func testWavEncoderProducesValidHeader() {

--- a/clients/ios/Views/InputBarView.swift
+++ b/clients/ios/Views/InputBarView.swift
@@ -119,6 +119,12 @@ struct InputBarView: View {
     /// so, streaming updates are suppressed to avoid overwriting user input.
     @State private var textBeforeStreamingPartials: String = ""
 
+    /// True once `onVoiceResult` has been called for the current recording session.
+    /// Prevents duplicate delivery when batch resolution and streaming final race
+    /// (e.g. auto-stop fires before `.ready`, then streaming delivers a `.final`
+    /// after the batch task has already committed).
+    @State private var voiceResultCommitted = false
+
     var body: some View {
         VStack(spacing: 0) {
             // Attachment strip (shown only when there are pending attachments)
@@ -487,6 +493,7 @@ struct InputBarView: View {
         streamingFinalReceived = false
         isStreamingActive = false
         textBeforeStreamingPartials = text
+        voiceResultCommitted = false
 
         // Tear down any leftover streaming client from a previous session.
         if let oldClient = activeStreamingClient {
@@ -653,6 +660,13 @@ struct InputBarView: View {
     /// stream is still active, this method is a no-op — the streaming result takes precedence
     /// over batch.
     private func resolveTranscriptWithServiceFirst(nativeTranscript: String) {
+        // If a result was already committed for this session (either by streaming final
+        // or a previous batch resolution), skip duplicate delivery.
+        guard !voiceResultCommitted else {
+            log.info("Voice result already committed for this session — skipping duplicate delivery")
+            return
+        }
+
         // If the streaming path already committed a final transcript, do not overwrite it
         // with a batch result.
         guard !streamingFinalReceived else {
@@ -719,6 +733,7 @@ struct InputBarView: View {
             // Only apply the final transcription if the user has not typed anything since auto-stop.
             if !wasAutoStopPending || text == savedTextAtAutoStop {
                 text = finalTranscript
+                voiceResultCommitted = true
                 onVoiceResult?(finalTranscript)
             }
             stopRecording()
@@ -792,8 +807,9 @@ struct InputBarView: View {
             log.info("STT streaming session ready — streaming audio chunks")
 
         case .partial(let partialText, let seq):
-            // Only apply partials if the user has not manually typed since recording started.
-            guard text == textBeforeStreamingPartials || isStreamingActive else { return }
+            // Only apply partials if the stream is active and the user has not manually
+            // typed since the last partial was applied.
+            guard isStreamingActive, text == textBeforeStreamingPartials else { return }
             log.debug("STT streaming partial (seq=\(seq)): \(partialText.prefix(80), privacy: .public)")
             text = partialText
             // Track the latest partial as the baseline for user-typing detection.
@@ -802,8 +818,16 @@ struct InputBarView: View {
         case .final(let finalText, let seq):
             log.info("STT streaming final (seq=\(seq), \(finalText.count) chars)")
             streamingFinalReceived = true
+            // Skip if a result was already committed (e.g. batch resolution won the race).
+            guard !voiceResultCommitted else {
+                log.info("Voice result already committed — skipping streaming final delivery")
+                stopRecording()
+                isVoiceOrbExpanded = false
+                return
+            }
             text = finalText
             textBeforeStreamingPartials = finalText
+            voiceResultCommitted = true
             onVoiceResult?(finalText)
             // Tear down the session — the streaming final is the authoritative result.
             stopRecording()
@@ -814,10 +838,20 @@ struct InputBarView: View {
             // Stream errored — fall back to batch. Clear streaming state so batch
             // resolution proceeds normally.
             isStreamingActive = false
+            // If auto-stop was waiting on a streaming final that never arrived,
+            // trigger batch fallback now to avoid a stuck session.
+            if isSTTOnlyMode && !streamingFinalReceived && isAutoStopPending {
+                resolveTranscriptWithServiceFirst(nativeTranscript: "")
+            }
 
         case .closed:
             log.info("STT streaming session closed")
             isStreamingActive = false
+            // If auto-stop was waiting on a streaming final that never arrived,
+            // trigger batch fallback now to avoid a stuck session.
+            if isSTTOnlyMode && !streamingFinalReceived && isAutoStopPending {
+                resolveTranscriptWithServiceFirst(nativeTranscript: "")
+            }
         }
     }
 
@@ -828,6 +862,11 @@ struct InputBarView: View {
         log.warning("STT streaming failed: \(String(describing: failure)) — falling back to batch STT")
         isStreamingActive = false
         activeStreamingClient = nil
+        // If auto-stop was waiting on a streaming final that never arrived,
+        // trigger batch fallback now to avoid a stuck session.
+        if isSTTOnlyMode && !streamingFinalReceived && isAutoStopPending {
+            resolveTranscriptWithServiceFirst(nativeTranscript: "")
+        }
     }
 
     private func stopRecording() {

--- a/clients/ios/Views/InputBarView.swift
+++ b/clients/ios/Views/InputBarView.swift
@@ -33,6 +33,10 @@ struct InputBarView: View {
     /// empty result.
     var sttClient: any STTClientProtocol = STTClient()
 
+    /// Factory that creates a fresh `STTStreamingClientProtocol` for each recording session.
+    /// Inject a mock factory for testing.
+    var sttStreamingClientFactory: () -> any STTStreamingClientProtocol = { STTStreamingClient() }
+
     @State private var isRecording = false
     /// True after the audio engine and tap have been torn down (set by finishRecordingForAutoStop
     /// and stopRecording). Prevents double-stop when the auto-stop path and the isFinal callback
@@ -92,6 +96,28 @@ struct InputBarView: View {
     /// or unauthorized. In this mode, auto-stop routes directly to the STT service instead
     /// of waiting for a native isFinal callback.
     @State private var isSTTOnlyMode = false
+
+    // MARK: - Streaming STT State
+
+    /// The active streaming STT client for the current recording session. Non-nil when
+    /// the session is using real-time streaming transcription. Created fresh per session
+    /// via `sttStreamingClientFactory`.
+    @State private var activeStreamingClient: (any STTStreamingClientProtocol)?
+
+    /// True when the streaming session has been successfully set up and is receiving events.
+    /// When false (stream setup failed or provider doesn't support streaming), the session
+    /// falls back to the existing batch STT path.
+    @State private var isStreamingActive = false
+
+    /// True once a streaming `.final` event has been received for the current session.
+    /// When set, the batch STT resolution path defers to the streaming result instead of
+    /// overwriting it.
+    @State private var streamingFinalReceived = false
+
+    /// The text value captured at the moment streaming partials began being applied.
+    /// Used to detect whether the user has typed in the text field during streaming — if
+    /// so, streaming updates are suppressed to avoid overwriting user input.
+    @State private var textBeforeStreamingPartials: String = ""
 
     var body: some View {
         VStack(spacing: 0) {
@@ -458,6 +484,43 @@ struct InputBarView: View {
         textAtAutoStop = ""
         audioBuffers = []
         recordingSampleRate = Int(recordingFormat.sampleRate)
+        streamingFinalReceived = false
+        isStreamingActive = false
+        textBeforeStreamingPartials = text
+
+        // Tear down any leftover streaming client from a previous session.
+        if let oldClient = activeStreamingClient {
+            activeStreamingClient = nil
+            Task { await oldClient.close() }
+        }
+
+        // Start streaming STT when the configured provider supports conversation streaming.
+        // The streaming client sends partial/final transcript events while audio is being
+        // captured. If streaming setup fails, the session falls back to batch STT seamlessly.
+        let streamingAvailable = STTProviderRegistry.isStreamingAvailable
+        if streamingAvailable {
+            let client = sttStreamingClientFactory()
+            activeStreamingClient = client
+            let sessionAtStart = sttSessionId
+
+            // Resolve the configured provider identifier for the streaming request.
+            let providerId = UserDefaults.standard.string(forKey: "sttProvider") ?? ""
+            let sampleRateForStream = Int(recordingFormat.sampleRate)
+
+            Task { @MainActor in
+                await client.start(
+                    provider: providerId,
+                    mimeType: "audio/pcm",
+                    sampleRate: sampleRateForStream,
+                    onEvent: { event in
+                        self.handleStreamingEvent(event, sessionId: sessionAtStart)
+                    },
+                    onFailure: { failure in
+                        self.handleStreamingFailure(failure, sessionId: sessionAtStart)
+                    }
+                )
+            }
+        }
 
         // Capture the native request locally for the tap closure. In STT-only mode
         // this is nil and the tap only captures PCM data for the service.
@@ -474,8 +537,8 @@ struct InputBarView: View {
                 // Feed audio buffers to the native recognizer when available.
                 capturedNativeRequest?.append(buffer)
 
-                // Capture raw PCM samples for STT service transcription.
-                // Convert float samples to 16-bit integers (WAV standard).
+                // Capture raw PCM samples for STT service transcription and streaming.
+                // Convert float samples to 16-bit integers (WAV/PCM standard).
                 if let floatData = buffer.floatChannelData {
                     let frameCount = Int(buffer.frameLength)
                     if frameCount > 0 {
@@ -489,6 +552,11 @@ struct InputBarView: View {
                         }
                         Task { @MainActor in
                             self.audioBuffers.append(pcmChunk)
+
+                            // Stream the PCM chunk to the active streaming client when available.
+                            if self.isStreamingActive, let streamClient = self.activeStreamingClient {
+                                await streamClient.sendAudio(pcmChunk)
+                            }
                         }
                     }
                 }
@@ -580,7 +648,25 @@ struct InputBarView: View {
     /// Resolves the final transcript using service-first precedence: sends captured audio to the
     /// STT gateway service and uses its result when successful. Falls back to the native recognizer
     /// transcript when the service is unavailable, unconfigured, or returns an empty result.
+    ///
+    /// When streaming has already delivered a final transcript (`streamingFinalReceived`) or the
+    /// stream is still active, this method is a no-op — the streaming result takes precedence
+    /// over batch.
     private func resolveTranscriptWithServiceFirst(nativeTranscript: String) {
+        // If the streaming path already committed a final transcript, do not overwrite it
+        // with a batch result.
+        guard !streamingFinalReceived else {
+            log.info("Streaming final already received — skipping batch STT resolution")
+            return
+        }
+
+        // If streaming is still active and may deliver a final, defer to it. The streaming
+        // final handler will handle completion.
+        guard !isStreamingActive else {
+            log.info("Streaming still active — deferring to streaming final event")
+            return
+        }
+
         // Build WAV payload from captured PCM buffers.
         let capturedBuffers = audioBuffers
         let sampleRate = recordingSampleRate
@@ -685,6 +771,65 @@ struct InputBarView: View {
         }
     }
 
+    // MARK: - Streaming Event Handling
+
+    /// Handles events from the STT streaming WebSocket session.
+    ///
+    /// - `ready`: marks the stream as active so audio chunks begin flowing.
+    /// - `partial`: applies interim transcript text to the composer binding.
+    /// - `final`: commits the final transcript, taking precedence over batch STT.
+    /// - `error`/`closed`: the stream is done; batch fallback will handle completion.
+    private func handleStreamingEvent(_ event: STTStreamEvent, sessionId: Int) {
+        // Stale-session guard: discard events from a superseded recording session.
+        guard sttSessionId == sessionId else {
+            log.info("Streaming event for stale session \(sessionId) (current: \(sttSessionId)) — ignoring")
+            return
+        }
+
+        switch event {
+        case .ready:
+            isStreamingActive = true
+            log.info("STT streaming session ready — streaming audio chunks")
+
+        case .partial(let partialText, let seq):
+            // Only apply partials if the user has not manually typed since recording started.
+            guard text == textBeforeStreamingPartials || isStreamingActive else { return }
+            log.debug("STT streaming partial (seq=\(seq)): \(partialText.prefix(80), privacy: .public)")
+            text = partialText
+            // Track the latest partial as the baseline for user-typing detection.
+            textBeforeStreamingPartials = partialText
+
+        case .final(let finalText, let seq):
+            log.info("STT streaming final (seq=\(seq), \(finalText.count) chars)")
+            streamingFinalReceived = true
+            text = finalText
+            textBeforeStreamingPartials = finalText
+            onVoiceResult?(finalText)
+            // Tear down the session — the streaming final is the authoritative result.
+            stopRecording()
+            isVoiceOrbExpanded = false
+
+        case .error(let category, let message, let seq):
+            log.warning("STT streaming error (seq=\(seq), category=\(category)): \(message)")
+            // Stream errored — fall back to batch. Clear streaming state so batch
+            // resolution proceeds normally.
+            isStreamingActive = false
+
+        case .closed:
+            log.info("STT streaming session closed")
+            isStreamingActive = false
+        }
+    }
+
+    /// Handles streaming session failure (connection error, timeout, rejected, etc.).
+    /// Falls back to the batch STT path for the current recording session.
+    private func handleStreamingFailure(_ failure: STTStreamFailure, sessionId: Int) {
+        guard sttSessionId == sessionId else { return }
+        log.warning("STT streaming failed: \(String(describing: failure)) — falling back to batch STT")
+        isStreamingActive = false
+        activeStreamingClient = nil
+    }
+
     private func stopRecording() {
         guard isRecording else { return }
         log.info("Voice recording stopped")
@@ -704,6 +849,7 @@ struct InputBarView: View {
             try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
         }
         cleanupRecognition()
+        cleanupStreaming()
         isRecording = false
         isAutoStopPending = false
         isSTTOnlyMode = false
@@ -741,9 +887,17 @@ struct InputBarView: View {
         micAmplitude = 0
         try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
 
+        // Signal the streaming client that recording has stopped so it can flush
+        // any remaining finals from the server before closing.
+        if let streamClient = activeStreamingClient, isStreamingActive {
+            Task { await streamClient.stop() }
+        }
+
         // In STT-only mode there is no native recognition task to deliver a final
         // transcript via the isFinal callback. Route directly to the STT service.
-        if isSTTOnlyMode {
+        // However, if streaming is active, the streaming final event will handle
+        // completion — skip the batch fallback to avoid duplicate resolution.
+        if isSTTOnlyMode && !isStreamingActive {
             resolveTranscriptWithServiceFirst(nativeTranscript: "")
         }
     }
@@ -752,6 +906,17 @@ struct InputBarView: View {
         recognitionRequest = nil
         cancelRecognitionTask?()
         cancelRecognitionTask = nil
+    }
+
+    /// Tears down the streaming STT client for the current session. Safe to call
+    /// even when no streaming client is active.
+    private func cleanupStreaming() {
+        isStreamingActive = false
+        streamingFinalReceived = false
+        if let client = activeStreamingClient {
+            activeStreamingClient = nil
+            Task { await client.close() }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Start STTStreamingClient during InputBar voice recording when provider supports streaming
- Stream PCM chunks and apply partial transcript events to composer text state
- Prefer streaming final events with fallback to batch on stream failure

Part of plan: streaming-stt-chat-messages.md (PR 8 of 9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25229" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
