### PR TITLE
fix: correct misleading audioBufferToFrames JSDoc in media-stream-output

### DIFF
--- a/assistant/src/calls/media-stream-output.ts
+++ b/assistant/src/calls/media-stream-output.ts
@@ -496,12 +496,15 @@ export class MediaStreamOutput implements CallTransport {
    * base64-encoded mu-law frames.
    *
    * For WAV files, we extract the raw PCM data and convert to mu-law.
-   * For other formats (mp3, opus), we generate a silence placeholder
-   * and log a warning — full codec support would require a native decoder
-   * dependency. The primary production path uses the synthesized-play
-   * mechanism in call-controller which streams audio through the audio
-   * store; this direct conversion is a fallback for the media-stream
-   * transport's simpler egress model.
+   * For other formats (mp3, opus), we send the raw bytes through
+   * {@link chunkMulawToBase64Frames} as a best-effort path. This works
+   * correctly when the TTS provider outputs mu-law or PCM directly
+   * (regardless of the nominal format label), but will produce garbled
+   * audio for genuinely compressed formats (mp3, opus) since we lack a
+   * native decoder. The primary production egress path routes TTS
+   * through the call-controller's audio store mechanism, which handles
+   * transcoding properly; this direct conversion is a fallback for the
+   * media-stream transport's simpler egress model.
    */
   private audioBufferToFrames(
     audio: Buffer,


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for twilio-services-stt-telephony-unify.md.

**Gap:** audioBufferToFrames comment contradicts implementation
**What was expected:** Comments accurately describe behavior
**What was found:** JSDoc says silence placeholder but code sends raw bytes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25232" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
