### PR TITLE
fix: remove dead speechModel parameter from resolveTelephonySttRouting

### DIFF
--- a/assistant/src/__tests__/telephony-stt-routing.test.ts
+++ b/assistant/src/__tests__/telephony-stt-routing.test.ts
@@ -79,7 +79,7 @@ describe("resolveTelephonySttRouting", () => {
       expect(strategy.transcriptionProvider).toBe("Deepgram");
     });
 
-    test("defaults speechModel to nova-3 when not provided", () => {
+    test("defaults speechModel to nova-3", () => {
       mockConfig = buildConfig({ provider: "deepgram" });
 
       const result = resolveTelephonySttRouting();
@@ -89,30 +89,6 @@ describe("resolveTelephonySttRouting", () => {
 
       const strategy = result.strategy as ConversationRelayNativeStrategy;
       expect(strategy.speechModel).toBe("nova-3");
-    });
-
-    test("defaults speechModel to nova-3 when explicitly undefined", () => {
-      mockConfig = buildConfig({ provider: "deepgram" });
-
-      const result = resolveTelephonySttRouting(undefined);
-
-      expect(result.status).toBe("resolved");
-      if (result.status !== "resolved") return;
-
-      const strategy = result.strategy as ConversationRelayNativeStrategy;
-      expect(strategy.speechModel).toBe("nova-3");
-    });
-
-    test("uses explicit speechModel when provided", () => {
-      mockConfig = buildConfig({ provider: "deepgram" });
-
-      const result = resolveTelephonySttRouting("nova-2-phonecall");
-
-      expect(result.status).toBe("resolved");
-      if (result.status !== "resolved") return;
-
-      const strategy = result.strategy as ConversationRelayNativeStrategy;
-      expect(strategy.speechModel).toBe("nova-2-phonecall");
     });
   });
 
@@ -135,7 +111,7 @@ describe("resolveTelephonySttRouting", () => {
       expect(strategy.transcriptionProvider).toBe("Google");
     });
 
-    test("leaves speechModel undefined when not provided", () => {
+    test("leaves speechModel undefined (uses provider default)", () => {
       mockConfig = buildConfig({ provider: "google-gemini" });
 
       const result = resolveTelephonySttRouting();
@@ -145,30 +121,6 @@ describe("resolveTelephonySttRouting", () => {
 
       const strategy = result.strategy as ConversationRelayNativeStrategy;
       expect(strategy.speechModel).toBeUndefined();
-    });
-
-    test("suppresses legacy nova-3 model for Google (Deepgram default migration)", () => {
-      mockConfig = buildConfig({ provider: "google-gemini" });
-
-      const result = resolveTelephonySttRouting("nova-3");
-
-      expect(result.status).toBe("resolved");
-      if (result.status !== "resolved") return;
-
-      const strategy = result.strategy as ConversationRelayNativeStrategy;
-      expect(strategy.speechModel).toBeUndefined();
-    });
-
-    test("uses explicit non-Deepgram speechModel when provided for Google", () => {
-      mockConfig = buildConfig({ provider: "google-gemini" });
-
-      const result = resolveTelephonySttRouting("telephony");
-
-      expect(result.status).toBe("resolved");
-      if (result.status !== "resolved") return;
-
-      const strategy = result.strategy as ConversationRelayNativeStrategy;
-      expect(strategy.speechModel).toBe("telephony");
     });
   });
 
@@ -193,7 +145,7 @@ describe("resolveTelephonySttRouting", () => {
     test("media-stream-custom strategy does not include speechModel", () => {
       mockConfig = buildConfig({ provider: "openai-whisper" });
 
-      const result = resolveTelephonySttRouting("whisper-1");
+      const result = resolveTelephonySttRouting();
 
       expect(result.status).toBe("resolved");
       if (result.status !== "resolved") return;

--- a/assistant/src/calls/telephony-stt-routing.ts
+++ b/assistant/src/calls/telephony-stt-routing.ts
@@ -18,11 +18,8 @@
  *   batch API. Used for `openai-whisper`.
  *
  * Model normalization semantics for Twilio-native providers:
- * - Deepgram defaults `speechModel` to `"nova-3"` when unset.
- * - Google leaves `speechModel` undefined when unset. The legacy
- *   Deepgram default `"nova-3"` is treated as unset for Google so
- *   workspaces that switched providers don't send a Deepgram model
- *   name to Google's API.
+ * - Deepgram defaults `speechModel` to `"nova-3"`.
+ * - Google leaves `speechModel` undefined (uses provider default).
  */
 
 import { getConfig } from "../config/loader.js";
@@ -113,28 +110,15 @@ const TWILIO_NATIVE_PROVIDER_MAP: ReadonlyMap<
 /**
  * Resolve the effective speech model for a Twilio-native provider.
  *
- * - Deepgram: falls back to `"nova-3"` when the model is unset.
- * - Google: leaves the model undefined when unset. Treats the legacy
- *   Deepgram default `"nova-3"` as unset so that workspaces that were
- *   previously configured for Deepgram don't send a Deepgram model name
- *   to Google's Cloud Speech API.
+ * - Deepgram: defaults to `"nova-3"`.
+ * - Google: leaves the model undefined (uses provider default).
  */
 function resolveNativeSpeechModel(
   twilioProvider: TwilioNativeTranscriptionProvider,
-  rawSpeechModel: string | undefined,
 ): string | undefined {
-  const isGoogle = twilioProvider === "Google";
-
-  if (rawSpeechModel == null) {
-    return isGoogle ? undefined : DEEPGRAM_DEFAULT_SPEECH_MODEL;
-  }
-
-  // Legacy migration: suppress the Deepgram default when provider is Google.
-  if (rawSpeechModel === DEEPGRAM_DEFAULT_SPEECH_MODEL && isGoogle) {
-    return undefined;
-  }
-
-  return rawSpeechModel;
+  return twilioProvider === "Google"
+    ? undefined
+    : DEEPGRAM_DEFAULT_SPEECH_MODEL;
 }
 
 // ---------------------------------------------------------------------------
@@ -147,14 +131,8 @@ function resolveNativeSpeechModel(
  * Reads the active provider from config, checks the provider catalog for
  * validity, then maps to either a Twilio-native ConversationRelay strategy
  * or a media-stream custom strategy.
- *
- * @param speechModel - Optional raw speech model from config. When provided,
- *   model normalization is applied for Twilio-native providers. Sourced
- *   from `calls.voice.speechModel`.
  */
-export function resolveTelephonySttRouting(
-  speechModel?: string | undefined,
-): TelephonySttRoutingResult {
+export function resolveTelephonySttRouting(): TelephonySttRoutingResult {
   const config = getConfig();
   const providerId = config.services.stt.provider;
 
@@ -178,7 +156,7 @@ export function resolveTelephonySttRouting(
         strategy: "conversation-relay-native",
         providerId: entry.id,
         transcriptionProvider: twilioProvider,
-        speechModel: resolveNativeSpeechModel(twilioProvider, speechModel),
+        speechModel: resolveNativeSpeechModel(twilioProvider),
       },
     };
   }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for twilio-services-stt-telephony-unify.md.

**Gap:** Dead speechModel parameter
**What was expected:** Unused parameter cleaned up after config schema removal
**What was found:** Optional speechModel param never provided in production
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25234" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
