### PR TITLE
refactor: revert minHeight to viewportHeight - 150 and remove dead code

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
@@ -4,7 +4,6 @@ import SwiftUI
 import VellumAssistantShared
 
 private let stallLog = OSLog(subsystem: "com.vellum.assistant", category: "LayoutStall")
-private let scrollDiag = Logger(subsystem: Bundle.appBundleIdentifier, category: "ScrollDiag")
 
 // MARK: - MessageListContentView
 
@@ -172,49 +171,9 @@ struct MessageListContentView: View, Equatable {
             }
 
             let _ = os_signpost(.event, log: stallLog, name: "MessageList.bodyEval")
-            // Min height for the assistant message — ensures the user message
-            // stays visible at the top of the viewport after scroll-to-bottom.
-            // Estimate user message cell height: text height (via boundingRect
-            // for word-wrap accuracy) + 80pt cell overhead (bubble padding,
-            // timestamp, VStack spacing, outer margins).
-            // Capped at 200pt (user messages collapse at 150pt content).
-            let estimatedUserHeight: CGFloat = {
-                guard let lastUser = state.rows.last(where: { $0.message.role == .user }) else {
-                    return 150
-                }
-                let text = lastUser.message.text as NSString
-                let contentWidth = max(layoutMetrics.bubbleMaxWidth - 2 * VSpacing.lg, 0)
-                let font = NSFont.systemFont(ofSize: 14, weight: .regular)
-                let textRect = text.boundingRect(
-                    with: NSSize(width: contentWidth, height: .greatestFiniteMagnitude),
-                    options: [.usesLineFragmentOrigin, .usesFontLeading],
-                    attributes: [.font: font]
-                )
-                let textHeight = ceil(textRect.height)
-                // 80pt covers: bubble padding (24pt), timestamp row (~24pt),
-                // outer VStack spacing (8pt), and cell margins/gaps (~24pt).
-                return min(textHeight + 80, 200)
-            }()
-            let layoutOverhead: CGFloat = VSpacing.md * 3 + 1
             let turnMinHeight: CGFloat = scrollState.viewportHeight.isFinite
-                ? max(0, scrollState.viewportHeight - estimatedUserHeight - layoutOverhead)
+                ? max(0, scrollState.viewportHeight - 150)
                 : 0
-            // Track whether the minHeight wrapper is applied so
-            // executeScrollToBottom can target the content-bottom marker.
-            let minHeightApplied: Bool = {
-                guard let lastRow = state.rows.last else { return false }
-                return lastRow.isLatestAssistant
-            }()
-            let _ = {
-                let wasApplied = scrollState.isActiveTurnMinHeightApplied
-                scrollState.isActiveTurnMinHeightApplied = minHeightApplied
-                // Reset the push-to-top flag when the active turn ends so
-                // the next turn gets a fresh initial pin with lastMessageId.
-                if !minHeightApplied { scrollState.hasCompletedInitialPushToTop = false }
-                if wasApplied != minHeightApplied {
-                    scrollDiag.debug("minHeightApplied changed: \(wasApplied, privacy: .public) → \(minHeightApplied, privacy: .public) isActiveTurn=\(state.isActiveTurn, privacy: .public) rowCount=\(state.rows.count, privacy: .public)")
-                }
-            }()
             let isUnanchoredThinking = state.shouldShowThinkingIndicator && !state.rows.contains(where: \.isAnchoredThinkingRow)
             let thinkingLabel = !hasEverSentMessage && state.hasUserMessage
                 ? "Waking up..."

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -105,10 +105,6 @@ final class MessageListScrollState {
     @ObservationIgnored var lastMessageId: UUID?
     @ObservationIgnored var lastActivityPhaseWhenIdle: String = ""
     @ObservationIgnored var pendingSendScrollMessageId: UUID?
-    @ObservationIgnored var lastUserMessageHeight: CGFloat = 0
-    @ObservationIgnored var isActiveTurnMinHeightApplied: Bool = false
-    @ObservationIgnored var hasCompletedInitialPushToTop: Bool = false
-
     // MARK: - Deep-link anchor
 
     @ObservationIgnored var anchorSetTime: Date?
@@ -221,9 +217,6 @@ final class MessageListScrollState {
         currentConversationId = conversationId
         lastMessageId = nil
         pendingSendScrollMessageId = nil
-        lastUserMessageHeight = 0
-        isActiveTurnMinHeightApplied = false
-        hasCompletedInitialPushToTop = false
         scrollContentHeight = 0
         scrollContainerHeight = 0
         lastContentOffsetY = 0

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListTypes.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListTypes.swift
@@ -17,18 +17,6 @@ extension EnvironmentValues {
     }
 }
 
-// MARK: - Last User Message Height Preference
-
-/// Reports the rendered height of the last user message cell so the
-/// assistant message's minHeight can be computed dynamically.
-struct LastUserMessageHeightKey: PreferenceKey {
-    static let defaultValue: CGFloat = 0
-    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-        let next = nextValue()
-        if next > 0 { value = next }
-    }
-}
-
 // MARK: - Precomputed Cache Key
 
 /// Lightweight key that captures all inputs to `precomputedState`.


### PR DESCRIPTION
## Summary
- Revert minHeight to simple viewportHeight - 150
- Remove dead LastUserMessageHeightKey PreferenceKey
- Remove dead lastUserMessageHeight, isActiveTurnMinHeightApplied, hasCompletedInitialPushToTop
- Remove minHeightApplied tracking side-effect block

Part of plan: scroll-cleanup-revert-minheight.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25236" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
