### PR TITLE
fix: unified thinking/assistant container — eliminate layout jump on send

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
@@ -179,59 +179,73 @@ struct MessageListContentView: View, Equatable {
                 ? "Waking up..."
                 : (state.effectiveStatusText ?? "Thinking")
             ForEach(state.rows) { row in
-                // Only pass activePendingRequestId to cells that could use it:
-                // confirmation bubbles need it for keyboard focus, tool-call messages
-                // need it for inline confirmation rendering in AssistantProgressView.
-                // Text-only cells get nil, so they won't fail == when the ID changes.
-                let cellActivePendingRequestId: String? =
-                    (row.message.confirmation != nil || !row.message.toolCalls.isEmpty)
-                    ? state.activePendingRequestId : nil
-                MessageCellView(
-                    message: row.message,
-                    showTimestamp: row.showTimestamp,
-                    nextDecidedConfirmation: row.decidedConfirmation,
-                    isConfirmationRenderedInline: row.isConfirmationRenderedInline,
-                    hasPrecedingAssistant: row.hasPrecedingAssistant,
-                    activePendingRequestId: cellActivePendingRequestId,
-                    subagentsByParent: state.subagentsByParent,
-                    isLatestAssistantMessage: row.isLatestAssistant,
-                    typographyGeneration: typographyGeneration,
-                    isProcessingAfterTools: state.canInlineProcessing && row.isLatestAssistant,
-                    processingStatusText: state.canInlineProcessing && row.isLatestAssistant ? state.effectiveStatusText : nil,
-                    hideInlineAvatar: row.isLatestAssistant && isUnanchoredThinking,
-                    showAnchoredThinkingIndicator: row.isAnchoredThinkingRow,
-                    anchoredThinkingLabel: row.isAnchoredThinkingRow ? thinkingLabel : "",
-                    dismissedDocumentSurfaceIds: dismissedDocumentSurfaceIds,
-                    activeSurfaceId: activeSurfaceId,
-                    isHighlighted: row.isHighlighted,
-                    mediaEmbedSettings: mediaEmbedSettings,
-                    onConfirmationAllow: onConfirmationAllow,
-                    onConfirmationDeny: onConfirmationDeny,
-                    onAlwaysAllow: onAlwaysAllow,
-                    onTemporaryAllow: onTemporaryAllow,
-                    onGuardianAction: onGuardianAction,
-                    onSurfaceAction: onSurfaceAction,
-                    onDismissDocumentWidget: onDismissDocumentWidget,
-                    onForkFromMessage: onForkFromMessage,
-                    showInspectButton: showInspectButton,
-                    isTTSEnabled: isTTSEnabled,
-                    onInspectMessage: onInspectMessage,
-                    onRehydrateMessage: onRehydrateMessage,
-                    onSurfaceRefetch: onSurfaceRefetch,
-                    onRetryFailedMessage: onRetryFailedMessage,
-                    onRetryConversationError: onRetryConversationError,
-                    onAbortSubagent: onAbortSubagent,
-                    onSubagentTap: onSubagentTap,
-                    subagentDetailStore: subagentDetailStore,
-                    selectedModel: selectedModel,
-                    configuredProviders: configuredProviders,
-                    providerCatalog: providerCatalog,
-                    providerCatalogHash: providerCatalogHash
-                )
-                .equatable()
-                // Latest assistant message: wrap in VStack with minHeight so user
-                // message sits at top. Persists until the user sends a new message
-                // (at which point the assistant message is no longer the last row).
+                Group {
+                    if row.isThinkingPlaceholder {
+                        VStack(alignment: .leading, spacing: VSpacing.md) {
+                            if isCompacting {
+                                compactingIndicatorRow()
+                            } else {
+                                thinkingIndicatorRow(hasUserMessage: state.hasUserMessage)
+                            }
+                            thinkingAvatarRow
+                        }
+                    } else {
+                        // Only pass activePendingRequestId to cells that could use it:
+                        // confirmation bubbles need it for keyboard focus, tool-call messages
+                        // need it for inline confirmation rendering in AssistantProgressView.
+                        // Text-only cells get nil, so they won't fail == when the ID changes.
+                        let cellActivePendingRequestId: String? =
+                            (row.message.confirmation != nil || !row.message.toolCalls.isEmpty)
+                            ? state.activePendingRequestId : nil
+                        MessageCellView(
+                            message: row.message,
+                            showTimestamp: row.showTimestamp,
+                            nextDecidedConfirmation: row.decidedConfirmation,
+                            isConfirmationRenderedInline: row.isConfirmationRenderedInline,
+                            hasPrecedingAssistant: row.hasPrecedingAssistant,
+                            activePendingRequestId: cellActivePendingRequestId,
+                            subagentsByParent: state.subagentsByParent,
+                            isLatestAssistantMessage: row.isLatestAssistant,
+                            typographyGeneration: typographyGeneration,
+                            isProcessingAfterTools: state.canInlineProcessing && row.isLatestAssistant,
+                            processingStatusText: state.canInlineProcessing && row.isLatestAssistant ? state.effectiveStatusText : nil,
+                            hideInlineAvatar: row.isLatestAssistant && isUnanchoredThinking,
+                            showAnchoredThinkingIndicator: row.isAnchoredThinkingRow,
+                            anchoredThinkingLabel: row.isAnchoredThinkingRow ? thinkingLabel : "",
+                            dismissedDocumentSurfaceIds: dismissedDocumentSurfaceIds,
+                            activeSurfaceId: activeSurfaceId,
+                            isHighlighted: row.isHighlighted,
+                            mediaEmbedSettings: mediaEmbedSettings,
+                            onConfirmationAllow: onConfirmationAllow,
+                            onConfirmationDeny: onConfirmationDeny,
+                            onAlwaysAllow: onAlwaysAllow,
+                            onTemporaryAllow: onTemporaryAllow,
+                            onGuardianAction: onGuardianAction,
+                            onSurfaceAction: onSurfaceAction,
+                            onDismissDocumentWidget: onDismissDocumentWidget,
+                            onForkFromMessage: onForkFromMessage,
+                            showInspectButton: showInspectButton,
+                            isTTSEnabled: isTTSEnabled,
+                            onInspectMessage: onInspectMessage,
+                            onRehydrateMessage: onRehydrateMessage,
+                            onSurfaceRefetch: onSurfaceRefetch,
+                            onRetryFailedMessage: onRetryFailedMessage,
+                            onRetryConversationError: onRetryConversationError,
+                            onAbortSubagent: onAbortSubagent,
+                            onSubagentTap: onSubagentTap,
+                            subagentDetailStore: subagentDetailStore,
+                            selectedModel: selectedModel,
+                            configuredProviders: configuredProviders,
+                            providerCatalog: providerCatalog,
+                            providerCatalogHash: providerCatalogHash
+                        )
+                        .equatable()
+                    }
+                }
+                // Latest assistant message (or thinking placeholder): wrap in
+                // VStack with minHeight so user message sits at top. The same
+                // wrapper applies to both the placeholder and the real assistant
+                // message, eliminating layout jump on transition.
                 .if(row.isLatestAssistant && row.message.id == state.rows.last?.message.id) { view in
                     VStack(spacing: 0) {
                         view
@@ -257,17 +271,7 @@ struct MessageListContentView: View, Equatable {
                     .transition(.opacity)
             }
 
-            if isUnanchoredThinking {
-                VStack(alignment: .leading, spacing: VSpacing.md) {
-                    if isCompacting {
-                        compactingIndicatorRow()
-                    } else {
-                        thinkingIndicatorRow(hasUserMessage: state.hasUserMessage)
-                    }
-                    thinkingAvatarRow
-                }
-                .frame(minHeight: turnMinHeight, alignment: .top)
-            } else if state.isStreamingWithoutText && !state.canInlineProcessing {
+            if state.isStreamingWithoutText && !state.canInlineProcessing {
                 VStack(spacing: 0) {
                     HStack {
                         TypingIndicatorView()

--- a/clients/macos/vellum-assistant/Features/Chat/TranscriptProjector.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/TranscriptProjector.swift
@@ -148,7 +148,7 @@ enum TranscriptProjector {
 
         // --- Build row models ---
 
-        let rows: [TranscriptRowModel] = visibleMessages.enumerated().map { index, message in
+        var rows: [TranscriptRowModel] = visibleMessages.enumerated().map { index, message in
             TranscriptRowModel(
                 message: message,
                 showTimestamp: timestampSet.contains(message.id),
@@ -160,6 +160,30 @@ enum TranscriptProjector {
                 isConfirmationRenderedInline: isConfirmationRenderedInlineByIndex.contains(index),
                 isAnchoredThinkingRow: index == anchoredThinkingIndex
             )
+        }
+
+        // When thinking indicator should show but no assistant message exists yet,
+        // append a synthetic placeholder row so the thinking indicator renders
+        // inside the ForEach's minHeight wrapper — same container that will later
+        // hold the real assistant message. Eliminates layout jump on transition.
+        if shouldShowThinkingIndicator {
+            let placeholderMessage = ChatMessage(
+                role: .assistant,
+                text: ""
+            )
+            let placeholder = TranscriptRowModel(
+                message: placeholderMessage,
+                showTimestamp: false,
+                hasPrecedingAssistant: false,
+                isLatestAssistant: true,
+                isHighlighted: false,
+                index: rows.count,
+                decidedConfirmation: nil,
+                isConfirmationRenderedInline: false,
+                isAnchoredThinkingRow: false,
+                isThinkingPlaceholder: true
+            )
+            rows.append(placeholder)
         }
 
         return TranscriptRenderModel(

--- a/clients/macos/vellum-assistant/Features/Chat/TranscriptRenderModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/TranscriptRenderModel.swift
@@ -102,4 +102,10 @@ struct TranscriptRowModel: Equatable, Identifiable {
     /// When true, the anchored thinking indicator should attach to
     /// this row (post-confirmation thinking state).
     let isAnchoredThinkingRow: Bool
+
+    /// When true, this row is a synthetic placeholder for the thinking
+    /// indicator — no real message content. The thinking indicator renders
+    /// inside the ForEach so it shares the same minHeight wrapper that
+    /// will later hold the real assistant message.
+    var isThinkingPlaceholder: Bool = false
 }


### PR DESCRIPTION
## Summary
- Add isThinkingPlaceholder flag to TranscriptRowModel
- Append synthetic placeholder row in TranscriptProjector when thinking
- Render thinking indicator inside ForEach via placeholder row
- Remove standalone isUnanchoredThinking section
- Same minHeight wrapper for both thinking and assistant content

Part of plan: unified-thinking-container.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25239" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
