### PR TITLE
fix: correct gateway ARCHITECTURE.md STT stream WebSocket path

### DIFF
--- a/gateway/ARCHITECTURE.md
+++ b/gateway/ARCHITECTURE.md
@@ -55,7 +55,7 @@ The request carries base64-encoded WAV audio and a MIME type. The daemon resolve
 
 Native clients (macOS, iOS) open WebSocket connections through the gateway to the daemon's real-time STT streaming endpoint for conversation chat message capture. The gateway authenticates the downstream client using an edge JWT (actor principal required), then opens an upstream WebSocket connection to the daemon's `/v1/stt/stream` endpoint with a short-lived gateway service token. This keeps the daemon's WebSocket endpoint unreachable from the public internet while allowing authenticated clients to stream audio for real-time transcription.
 
-**Client path:** `wss://<gateway>/v1/assistants/:assistantId/stt/stream?provider=<id>&mimeType=<mime>[&sampleRate=<hz>]`
+**Client path:** `wss://<gateway>/v1/stt/stream?provider=<id>&mimeType=<mime>[&sampleRate=<hz>]`
 
 **Query parameters:**
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for streaming-stt-chat-messages.md.

**Gap:** Gateway ARCHITECTURE.md documents wrong WebSocket path
**What was expected:** Docs match actual route
**What was found:** Docs say assistant-scoped path, actual is /v1/stt/stream
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25243" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
