### PR TITLE
fix(macos): add missing tooltips to pending confirmation composer buttons

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -568,6 +568,7 @@ struct ComposerView: View, Equatable {
                         iconSize: composerActionButtonSize,
                         action: { onVoiceModeToggle?() }
                     )
+                    .vTooltip("Live voice conversation")
                 }
 
                 VButton(
@@ -577,6 +578,7 @@ struct ComposerView: View, Equatable {
                     iconSize: composerActionButtonSize,
                     action: { (onDictateToggle ?? onMicrophoneToggle)() }
                 )
+                .vTooltip(isRecording ? "Stop recording" : micTooltipText)
 
                 if !isRecording {
                     VButton(
@@ -589,6 +591,7 @@ struct ComposerView: View, Equatable {
                         composerFocus = true
                         performSendAction()
                     }
+                    .vTooltip(canSend ? "Send" : "Type a message to send")
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Add missing `.vTooltip` to dictate/stop button in pending confirmation branch (introduced in #25224)
- Add missing `.vTooltip("Live voice conversation")` to voice mode button (pre-existing)
- Add missing `.vTooltip` to send button (pre-existing)
- Pending confirmation branch now matches the empty-input branch tooltips as documented
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25244" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
