### PR TITLE
feat(home): add relationship state data contract (TS + Swift) [JARVIS-470]

### DIFF
--- a/assistant/src/__tests__/host-bash-proxy.test.ts
+++ b/assistant/src/__tests__/host-bash-proxy.test.ts
@@ -405,26 +405,21 @@ describe("HostBashProxy", () => {
     function spySignal(source: AbortSignal): Spied {
       const addCalls: string[] = [];
       const removeCalls: string[] = [];
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const s = source as any;
       const origAdd = source.addEventListener.bind(source);
       const origRemove = source.removeEventListener.bind(source);
       s.addEventListener = (
         type: string,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         ...rest: any[]
       ) => {
         addCalls.push(type);
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         return (origAdd as any)(type, ...rest);
       };
       s.removeEventListener = (
         type: string,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         ...rest: any[]
       ) => {
         removeCalls.push(type);
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         return (origRemove as any)(type, ...rest);
       };
       return { signal: source, addCalls, removeCalls };

--- a/assistant/src/__tests__/host-cu-proxy.test.ts
+++ b/assistant/src/__tests__/host-cu-proxy.test.ts
@@ -792,26 +792,21 @@ describe("HostCuProxy", () => {
     function spySignal(source: AbortSignal): Spied {
       const addCalls: string[] = [];
       const removeCalls: string[] = [];
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const s = source as any;
       const origAdd = source.addEventListener.bind(source);
       const origRemove = source.removeEventListener.bind(source);
       s.addEventListener = (
         type: string,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         ...rest: any[]
       ) => {
         addCalls.push(type);
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         return (origAdd as any)(type, ...rest);
       };
       s.removeEventListener = (
         type: string,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         ...rest: any[]
       ) => {
         removeCalls.push(type);
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         return (origRemove as any)(type, ...rest);
       };
       return { signal: source, addCalls, removeCalls };

--- a/assistant/src/__tests__/relationship-state-contract.test.ts
+++ b/assistant/src/__tests__/relationship-state-contract.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  type Capability,
+  DEFAULT_CAPABILITIES,
+  type Fact,
+  RELATIONSHIP_STATE_VERSION,
+  type RelationshipState,
+  type RelationshipTier,
+  TIER_INFO,
+} from "../home/relationship-state.js";
+
+describe("relationship state contract", () => {
+  describe("RelationshipState JSON round-trip", () => {
+    test("round-trips through JSON.stringify / JSON.parse with structural equality", () => {
+      const facts: Fact[] = [
+        {
+          id: "fact-1",
+          category: "voice",
+          text: "Prefers concise, lowercase replies.",
+          confidence: "strong",
+          source: "onboarding",
+        },
+        {
+          id: "fact-2",
+          category: "world",
+          text: "Lives in Brooklyn.",
+          confidence: "uncertain",
+          source: "inferred",
+        },
+        {
+          id: "fact-3",
+          category: "priorities",
+          text: "Ships JARVIS milestones on Fridays.",
+          confidence: "strong",
+          source: "inferred",
+        },
+      ];
+
+      const capabilities: Capability[] = [
+        {
+          id: "email",
+          name: "Email access",
+          description: "Read, draft, and manage your email",
+          tier: "next-up",
+          gate: "Connect Google or Outlook",
+          ctaLabel: "Connect Google →",
+        },
+        {
+          id: "voice-writing",
+          name: "Write in your voice",
+          description: "Draft messages and docs that sound like you",
+          tier: "earned",
+          gate: "Usage — needs conversation history",
+          unlockHint: "I need to learn how you communicate first",
+        },
+        {
+          id: "calendar",
+          name: "Calendar awareness",
+          description: "Know your schedule, prep for meetings",
+          tier: "unlocked",
+          gate: "Connect calendar",
+        },
+      ];
+
+      const original: RelationshipState = {
+        version: RELATIONSHIP_STATE_VERSION,
+        assistantId: "self",
+        tier: 2,
+        progressPercent: 42,
+        facts,
+        capabilities,
+        conversationCount: 17,
+        hatchedDate: "2026-04-01T00:00:00.000Z",
+        assistantName: "Nova",
+        userName: "Alex",
+        updatedAt: "2026-04-13T12:34:56.000Z",
+      };
+
+      const serialized = JSON.stringify(original);
+      const parsed = JSON.parse(serialized) as RelationshipState;
+
+      expect(parsed).toEqual(original);
+      // Re-serialize and compare strings to guarantee no hidden fields leak
+      // and field order is stable given the source object.
+      expect(JSON.stringify(parsed)).toBe(serialized);
+    });
+
+    test("round-trips with userName omitted", () => {
+      const original: RelationshipState = {
+        version: RELATIONSHIP_STATE_VERSION,
+        assistantId: "self",
+        tier: 1,
+        progressPercent: 0,
+        facts: [],
+        capabilities: [],
+        conversationCount: 0,
+        hatchedDate: "2026-04-13T00:00:00.000Z",
+        assistantName: "Nova",
+        updatedAt: "2026-04-13T00:00:00.000Z",
+      };
+
+      const parsed = JSON.parse(JSON.stringify(original)) as RelationshipState;
+      expect(parsed).toEqual(original);
+      expect(parsed.userName).toBeUndefined();
+    });
+  });
+
+  describe("DEFAULT_CAPABILITIES", () => {
+    test("contains the exact six capability ids in the required order", () => {
+      const ids = DEFAULT_CAPABILITIES.map((c) => c.id);
+      expect(ids).toEqual([
+        "email",
+        "calendar",
+        "slack",
+        "voice-writing",
+        "proactive",
+        "autonomous",
+      ]);
+    });
+
+    test("each default capability has a non-empty name, description, and gate", () => {
+      for (const cap of DEFAULT_CAPABILITIES) {
+        expect(cap.name.length).toBeGreaterThan(0);
+        expect(cap.description.length).toBeGreaterThan(0);
+        expect(cap.gate.length).toBeGreaterThan(0);
+      }
+    });
+
+    test("connector capabilities have a ctaLabel, learned capabilities have an unlockHint", () => {
+      const byId = Object.fromEntries(
+        DEFAULT_CAPABILITIES.map((c) => [c.id, c]),
+      );
+
+      for (const id of ["email", "calendar", "slack"] as const) {
+        expect(byId[id]?.ctaLabel?.length ?? 0).toBeGreaterThan(0);
+      }
+
+      for (const id of ["voice-writing", "proactive", "autonomous"] as const) {
+        expect(byId[id]?.unlockHint?.length ?? 0).toBeGreaterThan(0);
+      }
+    });
+
+    test("default capabilities omit the tier field (tier is computed at write time)", () => {
+      for (const cap of DEFAULT_CAPABILITIES) {
+        expect((cap as Record<string, unknown>).tier).toBeUndefined();
+      }
+    });
+  });
+
+  describe("TIER_INFO", () => {
+    test("defines all four tiers with non-empty label and description", () => {
+      const tiers: RelationshipTier[] = [1, 2, 3, 4];
+      for (const tier of tiers) {
+        const info = TIER_INFO[tier];
+        expect(info).toBeDefined();
+        expect(info.label.length).toBeGreaterThan(0);
+        expect(info.description.length).toBeGreaterThan(0);
+      }
+    });
+
+    test("tiers 1-3 have a nextTierHint, tier 4 does not", () => {
+      expect(TIER_INFO[1].nextTierHint?.length ?? 0).toBeGreaterThan(0);
+      expect(TIER_INFO[2].nextTierHint?.length ?? 0).toBeGreaterThan(0);
+      expect(TIER_INFO[3].nextTierHint?.length ?? 0).toBeGreaterThan(0);
+      expect(TIER_INFO[4].nextTierHint).toBeUndefined();
+    });
+  });
+
+  describe("RELATIONSHIP_STATE_VERSION", () => {
+    test("is pinned to 1 (bumping requires an explicit migration PR)", () => {
+      expect(RELATIONSHIP_STATE_VERSION).toBe(1);
+    });
+  });
+});

--- a/assistant/src/home/index.ts
+++ b/assistant/src/home/index.ts
@@ -1,0 +1,1 @@
+export * from "./relationship-state.js";

--- a/assistant/src/home/index.ts
+++ b/assistant/src/home/index.ts
@@ -1,1 +1,0 @@
-export * from "./relationship-state.js";

--- a/assistant/src/home/relationship-state.ts
+++ b/assistant/src/home/relationship-state.ts
@@ -1,0 +1,143 @@
+/**
+ * Relationship state data contract.
+ *
+ * This is the shared wire format that describes the assistant's current
+ * relationship with the user: which tier they're at, what facts the
+ * assistant has learned about them, and which capabilities are unlocked.
+ *
+ * The TypeScript types here are the source of truth. A structurally
+ * identical Swift definition lives at
+ * `clients/shared/Models/RelationshipState.swift` — any change here must
+ * be mirrored there (and the contract test guards the default list).
+ */
+
+export const RELATIONSHIP_STATE_VERSION = 1 as const;
+
+export type RelationshipTier = 1 | 2 | 3 | 4;
+
+export interface TierInfo {
+  label: string;
+  description: string;
+  nextTierHint?: string;
+}
+
+export const TIER_INFO: Record<RelationshipTier, TierInfo> = {
+  1: {
+    label: "Getting to know you",
+    description: "We just met — learning the basics",
+    nextTierHint: "A few more conversations and I'll start to find my footing",
+  },
+  2: {
+    label: "Finding my footing",
+    description: "Starting to understand how you work",
+    nextTierHint: "Keep working with me and we'll hit our stride",
+  },
+  3: {
+    label: "Hitting our stride",
+    description: "We have a real working relationship",
+    nextTierHint:
+      "Give me more context and autonomy and we'll be fully in sync",
+  },
+  4: {
+    label: "In sync",
+    description: "Full partnership",
+  },
+};
+
+export type FactCategory = "voice" | "world" | "priorities";
+export type FactConfidence = "strong" | "uncertain";
+export type FactSource = "onboarding" | "inferred";
+
+export interface Fact {
+  id: string;
+  category: FactCategory;
+  text: string;
+  confidence: FactConfidence;
+  source: FactSource;
+}
+
+export type CapabilityTier = "unlocked" | "next-up" | "earned";
+
+export interface Capability {
+  id: string;
+  name: string;
+  description: string;
+  tier: CapabilityTier;
+  /** Human-readable unlock requirement. */
+  gate: string;
+  /** Shown on "earned" tier: why, not when. */
+  unlockHint?: string;
+  /** Shown on "next-up" tier: e.g. "Connect Google →". */
+  ctaLabel?: string;
+}
+
+export interface RelationshipState {
+  version: typeof RELATIONSHIP_STATE_VERSION;
+  /** Forward-compat for multi-assistant. Only one assistant is supported in v1. */
+  assistantId: string;
+  tier: RelationshipTier;
+  /** 0-100 */
+  progressPercent: number;
+  facts: Fact[];
+  capabilities: Capability[];
+  conversationCount: number;
+  /** ISO 8601 */
+  hatchedDate: string;
+  assistantName: string;
+  userName?: string;
+  /** ISO 8601 */
+  updatedAt: string;
+}
+
+/**
+ * Seed list of capabilities the relationship-state writer should project,
+ * minus the `tier` field (which is computed at write time based on what
+ * the assistant has learned and which integrations are connected).
+ *
+ * Order and ids are part of the public contract — the contract test
+ * asserts this list matches the TDD so drift causes a failure.
+ */
+export const DEFAULT_CAPABILITIES: Omit<Capability, "tier">[] = [
+  {
+    id: "email",
+    name: "Email access",
+    description: "Read, draft, and manage your email",
+    gate: "Connect Google or Outlook",
+    ctaLabel: "Connect Google →",
+  },
+  {
+    id: "calendar",
+    name: "Calendar awareness",
+    description: "Know your schedule, prep for meetings",
+    gate: "Connect calendar",
+    ctaLabel: "Connect Calendar →",
+  },
+  {
+    id: "slack",
+    name: "Slack monitoring",
+    description: "Watch channels, surface what matters",
+    gate: "Set up Slack app",
+    ctaLabel: "Set up Slack →",
+  },
+  {
+    id: "voice-writing",
+    name: "Write in your voice",
+    description: "Draft messages and docs that sound like you",
+    gate: "Usage — needs conversation history",
+    unlockHint: "I need to learn how you communicate first",
+  },
+  {
+    id: "proactive",
+    name: "Proactive suggestions",
+    description: "Flag things before you ask",
+    gate: "Trust — needs priority understanding",
+    unlockHint: "I need to understand your priorities first",
+  },
+  {
+    id: "autonomous",
+    name: "Act on your behalf",
+    description: "Send messages, file things, take action",
+    gate: "Trust — deepest level",
+    unlockHint: "We need a deeper working relationship first",
+  },
+];

--- a/clients/shared/Models/RelationshipState.swift
+++ b/clients/shared/Models/RelationshipState.swift
@@ -1,0 +1,165 @@
+import Foundation
+
+/// Relationship state data contract.
+///
+/// Wire-compatible mirror of
+/// `assistant/src/home/relationship-state.ts`. The TypeScript types are
+/// the source of truth — any change there must be mirrored here so a
+/// JSON blob produced by one side decodes byte-for-byte on the other.
+public struct RelationshipState: Codable, Sendable, Equatable {
+    public let version: Int
+    /// Forward-compat for multi-assistant. Only one assistant is supported in v1.
+    public let assistantId: String
+    /// 1-4
+    public let tier: Int
+    /// 0-100
+    public let progressPercent: Int
+    public let facts: [Fact]
+    public let capabilities: [Capability]
+    public let conversationCount: Int
+    /// ISO 8601
+    public let hatchedDate: String
+    public let assistantName: String
+    public let userName: String?
+    /// ISO 8601
+    public let updatedAt: String
+
+    public init(
+        version: Int,
+        assistantId: String,
+        tier: Int,
+        progressPercent: Int,
+        facts: [Fact],
+        capabilities: [Capability],
+        conversationCount: Int,
+        hatchedDate: String,
+        assistantName: String,
+        userName: String?,
+        updatedAt: String
+    ) {
+        self.version = version
+        self.assistantId = assistantId
+        self.tier = tier
+        self.progressPercent = progressPercent
+        self.facts = facts
+        self.capabilities = capabilities
+        self.conversationCount = conversationCount
+        self.hatchedDate = hatchedDate
+        self.assistantName = assistantName
+        self.userName = userName
+        self.updatedAt = updatedAt
+    }
+}
+
+public struct Fact: Codable, Sendable, Equatable, Identifiable {
+    public let id: String
+    public let category: Category
+    public let text: String
+    public let confidence: Confidence
+    public let source: Source
+
+    public enum Category: String, Codable, Sendable {
+        case voice
+        case world
+        case priorities
+    }
+
+    public enum Confidence: String, Codable, Sendable {
+        case strong
+        case uncertain
+    }
+
+    public enum Source: String, Codable, Sendable {
+        case onboarding
+        case inferred
+    }
+
+    public init(
+        id: String,
+        category: Category,
+        text: String,
+        confidence: Confidence,
+        source: Source
+    ) {
+        self.id = id
+        self.category = category
+        self.text = text
+        self.confidence = confidence
+        self.source = source
+    }
+}
+
+public struct Capability: Codable, Sendable, Equatable, Identifiable {
+    public let id: String
+    public let name: String
+    public let description: String
+    public let tier: Tier
+    /// Human-readable unlock requirement.
+    public let gate: String
+    /// Shown on `.earned` tier: why, not when.
+    public let unlockHint: String?
+    /// Shown on `.nextUp` tier: e.g. "Connect Google →".
+    public let ctaLabel: String?
+
+    public enum Tier: String, Codable, Sendable {
+        case unlocked
+        case nextUp = "next-up"
+        case earned
+    }
+
+    public init(
+        id: String,
+        name: String,
+        description: String,
+        tier: Tier,
+        gate: String,
+        unlockHint: String?,
+        ctaLabel: String?
+    ) {
+        self.id = id
+        self.name = name
+        self.description = description
+        self.tier = tier
+        self.gate = gate
+        self.unlockHint = unlockHint
+        self.ctaLabel = ctaLabel
+    }
+}
+
+public enum RelationshipTier: Int, CaseIterable, Sendable {
+    case gettingToKnowYou = 1
+    case findingFooting = 2
+    case hittingStride = 3
+    case inSync = 4
+
+    public var label: String {
+        switch self {
+        case .gettingToKnowYou: return "Getting to know you"
+        case .findingFooting: return "Finding my footing"
+        case .hittingStride: return "Hitting our stride"
+        case .inSync: return "In sync"
+        }
+    }
+
+    public var descriptionText: String {
+        switch self {
+        case .gettingToKnowYou: return "We just met — learning the basics"
+        case .findingFooting: return "Starting to understand how you work"
+        case .hittingStride: return "We have a real working relationship"
+        case .inSync: return "Full partnership"
+        }
+    }
+
+    public var nextTierHint: String? {
+        switch self {
+        case .gettingToKnowYou:
+            return "A few more conversations and I'll start to find my footing"
+        case .findingFooting:
+            return "Keep working with me and we'll hit our stride"
+        case .hittingStride:
+            return "Give me more context and autonomy and we'll be fully in sync"
+        case .inSync:
+            return nil
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `assistant/src/home/relationship-state.ts` with the `RelationshipState` TS contract, `TIER_INFO`, `DEFAULT_CAPABILITIES`, and fact/capability enums
- Adds matching Swift `RelationshipState.swift` (Codable, Sendable) to `clients/shared/Models/` with byte-identical string rawValues so JSON round-trips cleanly
- Adds a contract test that round-trips JSON and guards the default capability list + tier metadata against drift

Ticket: [JARVIS-470](https://linear.app/vellum/issue/JARVIS-470)

Part of plan: phase-3-backend.md (PR 1 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25247" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
