### PR TITLE
fix: stable placeholder UUID for thinking indicator row

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/TranscriptProjector.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/TranscriptProjector.swift
@@ -13,6 +13,10 @@ import VellumAssistantShared
 /// model that downstream views can consume without re-deriving layout.
 enum TranscriptProjector {
 
+    /// Stable UUID for the thinking placeholder row so ForEach maintains
+    /// view identity across re-projections. Must not collide with real message IDs.
+    private static let thinkingPlaceholderId = UUID(uuidString: "00000000-0000-0000-0000-FFFFFFFFFFFF")!
+
     // MARK: - Projection
 
     /// Project the current chat state into a fully resolved render model.
@@ -168,6 +172,7 @@ enum TranscriptProjector {
         // hold the real assistant message. Eliminates layout jump on transition.
         if shouldShowThinkingIndicator {
             let placeholderMessage = ChatMessage(
+                id: Self.thinkingPlaceholderId,
                 role: .assistant,
                 text: ""
             )


### PR DESCRIPTION
## Summary
- Use static UUID for thinking placeholder instead of new UUID() each frame
- Prevents ForEach identity thrashing and unnecessary re-layouts

Part of plan: scroll-pr-review-fixes.md (PR 1 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25248" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
