### PR TITLE
feat(home): daemon computes and writes relationship-state.json [JARVIS-470]

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -24,10 +24,14 @@ import type {
 } from "../channels/types.js";
 import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import { getConfig } from "../config/loader.js";
-import { derefToolResultReReads,postTurnTruncateToolResults } from "../context/post-turn-tool-result-truncation.js";
+import {
+  derefToolResultReReads,
+  postTurnTruncateToolResults,
+} from "../context/post-turn-tool-result-truncation.js";
 import { estimatePromptTokens } from "../context/token-estimator.js";
 import type { ContextWindowManager } from "../context/window-manager.js";
 import type { ToolProfiler } from "../events/tool-profiling-listener.js";
+import { writeRelationshipState } from "../home/relationship-state-writer.js";
 import { getHookManager } from "../hooks/manager.js";
 import {
   clearSentryConversationContext,
@@ -972,8 +976,12 @@ export async function runAgentLoopImpl(
         // value from injectionOpts to avoid duplicate injection.
         runMessages = applyRuntimeInjections(ctx.messages, {
           ...injectionOpts,
-          ...(step.compactionResult?.compacted && { pkbContext: currentPkbContent }),
-          ...(step.compactionResult?.compacted && { nowScratchpad: currentNowContent }),
+          ...(step.compactionResult?.compacted && {
+            pkbContext: currentPkbContent,
+          }),
+          ...(step.compactionResult?.compacted && {
+            nowScratchpad: currentNowContent,
+          }),
           workspaceTopLevelContext: shouldInjectWorkspace
             ? ctx.workspaceTopLevelContext
             : null,
@@ -1780,9 +1788,16 @@ export async function runAgentLoopImpl(
       try {
         const conv = getConversation(ctx.conversationId);
         if (conv) {
-          const convDir = getResolvedConversationDirPath(ctx.conversationId, conv.createdAt);
-          const { messages: derefMessages, dereferencedCount } = derefToolResultReReads(restoredHistory);
-          const { messages: truncatedMessages, truncatedCount } = postTurnTruncateToolResults(derefMessages, { conversationDir: convDir });
+          const convDir = getResolvedConversationDirPath(
+            ctx.conversationId,
+            conv.createdAt,
+          );
+          const { messages: derefMessages, dereferencedCount } =
+            derefToolResultReReads(restoredHistory);
+          const { messages: truncatedMessages, truncatedCount } =
+            postTurnTruncateToolResults(derefMessages, {
+              conversationDir: convDir,
+            });
           if (truncatedCount > 0 || dereferencedCount > 0) {
             rlog.info(
               { truncatedCount, dereferencedCount },
@@ -1792,7 +1807,10 @@ export async function runAgentLoopImpl(
           restoredHistory = truncatedMessages;
         }
       } catch (err) {
-        rlog.warn({ err }, "Post-turn tool result truncation failed (non-fatal)");
+        rlog.warn(
+          { err },
+          "Post-turn tool result truncation failed (non-fatal)",
+        );
       }
     }
 
@@ -2041,6 +2059,12 @@ export async function runAgentLoopImpl(
 
       // Commit app changes (fire-and-forget — apps repo is separate from workspace)
       void commitAppTurnChanges(ctx.conversationId, ctx.turnCount);
+
+      // Recompute relationship-state.json at turn boundary (fire-and-forget).
+      // The writer swallows its own errors, but we still guard with catch()
+      // here so a regression in the writer can never bubble out of the
+      // agent loop and reject an otherwise-complete turn.
+      void writeRelationshipState().catch(() => {});
     }
 
     ctx.profiler.emitSummary(ctx.traceEmitter, reqId);

--- a/assistant/src/home/__tests__/progress-formula.test.ts
+++ b/assistant/src/home/__tests__/progress-formula.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  computeProgressPercent,
+  computeTier,
+  PROGRESS_TARGETS,
+  PROGRESS_WEIGHTS,
+} from "../progress-formula.js";
+import type { Capability, Fact } from "../relationship-state.js";
+
+function fact(id: string): Fact {
+  return {
+    id,
+    category: "world",
+    text: "placeholder",
+    confidence: "strong",
+    source: "inferred",
+  };
+}
+
+function cap(id: string, tier: Capability["tier"]): Capability {
+  return {
+    id,
+    name: id,
+    description: "",
+    tier,
+    gate: "",
+  };
+}
+
+function facts(n: number): Fact[] {
+  return Array.from({ length: n }, (_, i) => fact(`f-${i}`));
+}
+
+function unlockedCaps(n: number): Capability[] {
+  return Array.from({ length: n }, (_, i) => cap(`c-${i}`, "unlocked"));
+}
+
+describe("progress-formula", () => {
+  describe("PROGRESS_WEIGHTS", () => {
+    test("sum to exactly 1 so a fully saturated input yields 100", () => {
+      const sum =
+        PROGRESS_WEIGHTS.facts +
+        PROGRESS_WEIGHTS.capabilities +
+        PROGRESS_WEIGHTS.conversations;
+      // Use toBeCloseTo for float safety.
+      expect(sum).toBeCloseTo(1, 10);
+    });
+  });
+
+  describe("computeProgressPercent", () => {
+    test("zero state -> 0", () => {
+      expect(
+        computeProgressPercent({
+          facts: [],
+          capabilities: [],
+          conversationCount: 0,
+        }),
+      ).toBe(0);
+    });
+
+    test("all saturated -> 100", () => {
+      expect(
+        computeProgressPercent({
+          facts: facts(PROGRESS_TARGETS.facts),
+          capabilities: unlockedCaps(PROGRESS_TARGETS.capabilities),
+          conversationCount: PROGRESS_TARGETS.conversations,
+        }),
+      ).toBe(100);
+    });
+
+    test("saturation clamps: inputs beyond target do not exceed 100", () => {
+      expect(
+        computeProgressPercent({
+          facts: facts(PROGRESS_TARGETS.facts * 3),
+          capabilities: unlockedCaps(PROGRESS_TARGETS.capabilities * 3),
+          conversationCount: PROGRESS_TARGETS.conversations * 3,
+        }),
+      ).toBe(100);
+    });
+
+    test("facts-only at target contributes exactly its weight", () => {
+      expect(
+        computeProgressPercent({
+          facts: facts(PROGRESS_TARGETS.facts),
+          capabilities: [],
+          conversationCount: 0,
+        }),
+      ).toBe(Math.round(PROGRESS_WEIGHTS.facts * 100));
+    });
+
+    test("capabilities-only at target contributes exactly its weight", () => {
+      expect(
+        computeProgressPercent({
+          facts: [],
+          capabilities: unlockedCaps(PROGRESS_TARGETS.capabilities),
+          conversationCount: 0,
+        }),
+      ).toBe(Math.round(PROGRESS_WEIGHTS.capabilities * 100));
+    });
+
+    test("conversations-only at target contributes exactly its weight", () => {
+      expect(
+        computeProgressPercent({
+          facts: [],
+          capabilities: [],
+          conversationCount: PROGRESS_TARGETS.conversations,
+        }),
+      ).toBe(Math.round(PROGRESS_WEIGHTS.conversations * 100));
+    });
+
+    test("non-unlocked capabilities do not contribute", () => {
+      const mixed: Capability[] = [
+        cap("a", "next-up"),
+        cap("b", "earned"),
+        cap("c", "unlocked"),
+      ];
+      // Only 1 of PROGRESS_TARGETS.capabilities counts toward the caps weight.
+      const expected = Math.round(
+        ((PROGRESS_WEIGHTS.capabilities * 1) / PROGRESS_TARGETS.capabilities) *
+          100,
+      );
+      expect(
+        computeProgressPercent({
+          facts: [],
+          capabilities: mixed,
+          conversationCount: 0,
+        }),
+      ).toBe(expected);
+    });
+
+    test("specific mix: half facts, half caps, half conversations -> 50", () => {
+      // Each signal at half its target contributes half its weight; total
+      // is half of the combined weight (1) * 100 = 50.
+      expect(
+        computeProgressPercent({
+          facts: facts(PROGRESS_TARGETS.facts / 2),
+          capabilities: unlockedCaps(PROGRESS_TARGETS.capabilities / 2),
+          conversationCount: PROGRESS_TARGETS.conversations / 2,
+        }),
+      ).toBe(50);
+    });
+  });
+
+  describe("computeTier", () => {
+    test("zero state -> tier 1 (Getting to know you)", () => {
+      expect(
+        computeTier({ facts: [], capabilities: [], conversationCount: 0 }),
+      ).toBe(1);
+    });
+
+    test("5 conversations + 3 facts -> tier 2 (Finding my footing)", () => {
+      expect(
+        computeTier({
+          facts: facts(3),
+          capabilities: [],
+          conversationCount: 5,
+        }),
+      ).toBe(2);
+    });
+
+    test("just below tier 2 threshold on facts -> still tier 1", () => {
+      expect(
+        computeTier({
+          facts: facts(2),
+          capabilities: [],
+          conversationCount: 5,
+        }),
+      ).toBe(1);
+    });
+
+    test("just below tier 2 threshold on conversations -> still tier 1", () => {
+      expect(
+        computeTier({
+          facts: facts(3),
+          capabilities: [],
+          conversationCount: 4,
+        }),
+      ).toBe(1);
+    });
+
+    test("20 conversations + 3 unlocked caps -> tier 3 (Hitting our stride)", () => {
+      expect(
+        computeTier({
+          facts: facts(5),
+          capabilities: unlockedCaps(3),
+          conversationCount: 20,
+        }),
+      ).toBe(3);
+    });
+
+    test("20 conversations + 2 unlocked caps -> tier 2 (fallthrough)", () => {
+      expect(
+        computeTier({
+          facts: facts(3),
+          capabilities: unlockedCaps(2),
+          conversationCount: 20,
+        }),
+      ).toBe(2);
+    });
+
+    test("tier 4 is reserved and unreachable from the default heuristic", () => {
+      // Even a fully-saturated input should not produce tier 4 today.
+      const result = computeTier({
+        facts: facts(50),
+        capabilities: unlockedCaps(6),
+        conversationCount: 1_000,
+      });
+      expect(result).not.toBe(4);
+      expect(result).toBe(3);
+    });
+  });
+});

--- a/assistant/src/home/__tests__/relationship-state-writer.test.ts
+++ b/assistant/src/home/__tests__/relationship-state-writer.test.ts
@@ -279,4 +279,38 @@ describe("relationship-state-writer", () => {
       await expect(writeRelationshipState()).resolves.toBeUndefined();
     });
   });
+
+  describe("hatchedDate stability", () => {
+    test("is stable across multiple writes when IDENTITY.md has no explicit hatched bullet", async () => {
+      // Regression guard: `parseIdentity` used to default `hatchedDate`
+      // to `new Date().toISOString()` on every call, so because the
+      // writer runs on every turn boundary the persisted "relationship
+      // start" timestamp drifted forward on every write. It must now
+      // come from IDENTITY.md file birthtime, which is stable.
+      writeFile(
+        "IDENTITY.md",
+        "- **Name:** Sage\n- **Role:** Assistant\n- **Personality:** Curious\n",
+      );
+
+      const first = (await computeRelationshipState()) as RelationshipStateLike;
+      // Wait long enough that any `Date.now()`-based regression would
+      // produce a visibly different value on the second call.
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      const second = (await computeRelationshipState()) as RelationshipStateLike;
+
+      expect(second.hatchedDate).toBe(first.hatchedDate);
+      // Also sanity: it must be a real, recent date (not the epoch
+      // sentinel we emit when stat fails).
+      expect(Date.parse(first.hatchedDate)).toBeGreaterThan(0);
+    });
+
+    test("honors an explicit Hatched bullet in IDENTITY.md over file birthtime", async () => {
+      writeFile(
+        "IDENTITY.md",
+        "- **Name:** Sage\n- **Hatched:** 2025-01-15T00:00:00.000Z\n",
+      );
+      const state = (await computeRelationshipState()) as RelationshipStateLike;
+      expect(state.hatchedDate).toBe("2025-01-15T00:00:00.000Z");
+    });
+  });
 });

--- a/assistant/src/home/__tests__/relationship-state-writer.test.ts
+++ b/assistant/src/home/__tests__/relationship-state-writer.test.ts
@@ -177,9 +177,12 @@ describe("relationship-state-writer", () => {
       }
     });
 
-    test("falls back to users/default.md when USER.md is absent", async () => {
+    test("falls back to legacy workspace USER.md when persona resolver yields nothing", async () => {
+      // In the test environment there is no guardian contact in the DB, so
+      // `resolveGuardianPersonaPath()` either returns null or throws — the
+      // writer must degrade to legacy workspace-root `USER.md`.
       writeFile(
-        "users/default.md",
+        "USER.md",
         ["- Preferred name: Jamie", "- Work role: PM"].join("\n"),
       );
 
@@ -205,6 +208,19 @@ describe("relationship-state-writer", () => {
 
     test("google connection unlocks both email and calendar", async () => {
       fakeConnections.push({ provider: "google", status: "active" });
+      const state = (await computeRelationshipState()) as RelationshipStateLike;
+      const email = state.capabilities.find((c) => c.id === "email");
+      const calendar = state.capabilities.find((c) => c.id === "calendar");
+      expect(email?.tier).toBe("unlocked");
+      expect(calendar?.tier).toBe("unlocked");
+    });
+
+    test("outlook connection unlocks both email and calendar", async () => {
+      // `outlook` is the real provider key used by seed-providers.ts for
+      // the Microsoft integration (carries Calendars.* scopes). Regression
+      // guard: an active Outlook connection must flip calendar to unlocked
+      // the same way it flips email.
+      fakeConnections.push({ provider: "outlook", status: "active" });
       const state = (await computeRelationshipState()) as RelationshipStateLike;
       const email = state.capabilities.find((c) => c.id === "email");
       const calendar = state.capabilities.find((c) => c.id === "calendar");

--- a/assistant/src/home/__tests__/relationship-state-writer.test.ts
+++ b/assistant/src/home/__tests__/relationship-state-writer.test.ts
@@ -215,17 +215,17 @@ describe("relationship-state-writer", () => {
       expect(calendar?.tier).toBe("unlocked");
     });
 
-    test("outlook connection unlocks both email and calendar", async () => {
-      // `outlook` is the real provider key used by seed-providers.ts for
-      // the Microsoft integration (carries Calendars.* scopes). Regression
-      // guard: an active Outlook connection must flip calendar to unlocked
-      // the same way it flips email.
+    test("outlook connection does not unlock any capability", async () => {
+      // `outlook` exists as scaffolding in seed-providers.ts but there is no
+      // real Microsoft integration the assistant can use. The Home page must
+      // not advertise email or calendar as unlocked just because an outlook
+      // OAuth row exists.
       fakeConnections.push({ provider: "outlook", status: "active" });
       const state = (await computeRelationshipState()) as RelationshipStateLike;
       const email = state.capabilities.find((c) => c.id === "email");
       const calendar = state.capabilities.find((c) => c.id === "calendar");
-      expect(email?.tier).toBe("unlocked");
-      expect(calendar?.tier).toBe("unlocked");
+      expect(email?.tier).toBe("next-up");
+      expect(calendar?.tier).toBe("next-up");
     });
 
     test("revoked connections do not count as unlocked", async () => {

--- a/assistant/src/home/__tests__/relationship-state-writer.test.ts
+++ b/assistant/src/home/__tests__/relationship-state-writer.test.ts
@@ -1,0 +1,266 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Stub the OAuth connection store so the writer runs without a
+// database. Tests push provider rows into `fakeConnections` before
+// invoking the writer.
+type FakeConnection = {
+  provider: string;
+  status: "active" | "revoked" | "failed";
+};
+const fakeConnections: FakeConnection[] = [];
+
+mock.module("../../oauth/oauth-store.js", () => ({
+  listConnections: () => [...fakeConnections],
+}));
+
+// Dynamic import so the module resolves after the mock above is in
+// place. Bun's mock.module needs to run before the real import is
+// evaluated for the mock to take effect.
+const {
+  computeRelationshipState,
+  getRelationshipStatePath,
+  RELATIONSHIP_STATE_FILENAME,
+  writeRelationshipState,
+} = await import("../relationship-state-writer.js");
+
+type RelationshipStateLike = {
+  version: number;
+  assistantId: string;
+  tier: number;
+  progressPercent: number;
+  facts: Array<{
+    id: string;
+    category: string;
+    text: string;
+    confidence: string;
+    source: string;
+  }>;
+  capabilities: Array<{
+    id: string;
+    name: string;
+    description: string;
+    tier: string;
+    gate: string;
+  }>;
+  conversationCount: number;
+  hatchedDate: string;
+  assistantName: string;
+  userName?: string;
+  updatedAt: string;
+};
+
+// Per CI gotchas: each test gets its own temp workspace dir to avoid
+// `.git/index.lock` style races on shared tmp paths.
+let workspaceDir: string;
+let origWorkspaceDir: string | undefined;
+
+function writeFile(relPath: string, content: string): void {
+  const full = join(workspaceDir, relPath);
+  mkdirSync(join(full, ".."), { recursive: true });
+  writeFileSync(full, content, "utf-8");
+}
+
+function seedConversations(count: number): void {
+  const dir = join(workspaceDir, "conversations");
+  mkdirSync(dir, { recursive: true });
+  for (let i = 0; i < count; i++) {
+    mkdirSync(join(dir, `conv-${i}`), { recursive: true });
+  }
+}
+
+beforeEach(() => {
+  workspaceDir = mkdtempSync(join(tmpdir(), "vellum-rsw-"));
+  origWorkspaceDir = process.env.VELLUM_WORKSPACE_DIR;
+  process.env.VELLUM_WORKSPACE_DIR = workspaceDir;
+  fakeConnections.length = 0;
+});
+
+afterEach(() => {
+  if (origWorkspaceDir === undefined) {
+    delete process.env.VELLUM_WORKSPACE_DIR;
+  } else {
+    process.env.VELLUM_WORKSPACE_DIR = origWorkspaceDir;
+  }
+  try {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  } catch {
+    // best-effort
+  }
+});
+
+describe("relationship-state-writer", () => {
+  describe("getRelationshipStatePath", () => {
+    test("returns <workspace>/data/relationship-state.json", () => {
+      expect(getRelationshipStatePath()).toBe(
+        join(workspaceDir, "data", RELATIONSHIP_STATE_FILENAME),
+      );
+    });
+  });
+
+  describe("computeRelationshipState", () => {
+    test("fresh empty workspace -> tier 1, 0%, empty facts, 0 conversations", async () => {
+      const state = (await computeRelationshipState()) as RelationshipStateLike;
+      expect(state.version).toBe(1);
+      expect(state.assistantId).toBe("default");
+      expect(state.tier).toBe(1);
+      expect(state.progressPercent).toBe(0);
+      expect(state.conversationCount).toBe(0);
+      expect(state.facts).toEqual([]);
+      expect(state.capabilities).toHaveLength(6);
+      // No integrations connected -> gated caps are next-up.
+      const byId = Object.fromEntries(state.capabilities.map((c) => [c.id, c]));
+      expect(byId.email.tier).toBe("next-up");
+      expect(byId.calendar.tier).toBe("next-up");
+      expect(byId.slack.tier).toBe("next-up");
+      expect(byId["voice-writing"].tier).toBe("earned");
+      expect(byId.proactive.tier).toBe("earned");
+      expect(byId.autonomous.tier).toBe("earned");
+    });
+
+    test("extracts world + priorities facts from USER.md", async () => {
+      writeFile(
+        "USER.md",
+        [
+          "# USER.md",
+          "",
+          "- Preferred name: Alex",
+          "- Pronouns: they/them",
+          "- Work role: Staff engineer",
+          "- Goals: Ship Phase 3 by Friday",
+          "- Daily tools: VSCode, git, bun",
+          "",
+        ].join("\n"),
+      );
+
+      const state = (await computeRelationshipState()) as RelationshipStateLike;
+      // At least one priorities fact (Goals / Work role / Daily tools)
+      // and at least one world fact (Preferred name / Pronouns).
+      expect(state.facts.length).toBeGreaterThanOrEqual(5);
+      const categories = new Set(state.facts.map((f) => f.category));
+      expect(categories.has("priorities")).toBe(true);
+      expect(categories.has("world")).toBe(true);
+      // All extracted facts are "inferred" (not "onboarding").
+      for (const f of state.facts) {
+        expect(f.source).toBe("inferred");
+      }
+      // userName parsed from "Preferred name: Alex".
+      expect(state.userName).toBe("Alex");
+    });
+
+    test("extracts voice facts from SOUL.md", async () => {
+      writeFile(
+        "SOUL.md",
+        [
+          "# SOUL.md",
+          "",
+          "- Tone: dry, precise, never performative",
+          "- Defaults: lowercase, minimal punctuation",
+          "",
+        ].join("\n"),
+      );
+
+      const state = (await computeRelationshipState()) as RelationshipStateLike;
+      const voiceFacts = state.facts.filter((f) => f.category === "voice");
+      expect(voiceFacts.length).toBeGreaterThanOrEqual(2);
+      for (const f of voiceFacts) {
+        expect(f.source).toBe("inferred");
+      }
+    });
+
+    test("falls back to users/default.md when USER.md is absent", async () => {
+      writeFile(
+        "users/default.md",
+        ["- Preferred name: Jamie", "- Work role: PM"].join("\n"),
+      );
+
+      const state = (await computeRelationshipState()) as RelationshipStateLike;
+      expect(state.userName).toBe("Jamie");
+      expect(state.facts.length).toBeGreaterThan(0);
+    });
+
+    test("counts files in conversations dir as conversationCount", async () => {
+      seedConversations(7);
+      const state = (await computeRelationshipState()) as RelationshipStateLike;
+      expect(state.conversationCount).toBe(7);
+    });
+
+    test("slack connection flips slack capability to unlocked", async () => {
+      fakeConnections.push({ provider: "slack", status: "active" });
+      const state = (await computeRelationshipState()) as RelationshipStateLike;
+      const slack = state.capabilities.find((c) => c.id === "slack");
+      expect(slack?.tier).toBe("unlocked");
+      const email = state.capabilities.find((c) => c.id === "email");
+      expect(email?.tier).toBe("next-up");
+    });
+
+    test("google connection unlocks both email and calendar", async () => {
+      fakeConnections.push({ provider: "google", status: "active" });
+      const state = (await computeRelationshipState()) as RelationshipStateLike;
+      const email = state.capabilities.find((c) => c.id === "email");
+      const calendar = state.capabilities.find((c) => c.id === "calendar");
+      expect(email?.tier).toBe("unlocked");
+      expect(calendar?.tier).toBe("unlocked");
+    });
+
+    test("revoked connections do not count as unlocked", async () => {
+      fakeConnections.push({ provider: "slack", status: "revoked" });
+      const state = (await computeRelationshipState()) as RelationshipStateLike;
+      const slack = state.capabilities.find((c) => c.id === "slack");
+      expect(slack?.tier).toBe("next-up");
+    });
+
+    test("voice-writing unlocks once conversationCount >= 10", async () => {
+      seedConversations(10);
+      const state = (await computeRelationshipState()) as RelationshipStateLike;
+      const voice = state.capabilities.find((c) => c.id === "voice-writing");
+      expect(voice?.tier).toBe("unlocked");
+    });
+
+    test("updatedAt is a valid ISO-8601 string", async () => {
+      const state = (await computeRelationshipState()) as RelationshipStateLike;
+      expect(Number.isNaN(Date.parse(state.updatedAt))).toBe(false);
+    });
+  });
+
+  describe("writeRelationshipState", () => {
+    test("writes to <workspace>/data/relationship-state.json", async () => {
+      writeFile("USER.md", "- Preferred name: Sam");
+      seedConversations(3);
+
+      await writeRelationshipState();
+
+      const path = getRelationshipStatePath();
+      expect(existsSync(path)).toBe(true);
+
+      const decoded = JSON.parse(
+        readFileSync(path, "utf-8"),
+      ) as RelationshipStateLike;
+      expect(decoded.version).toBe(1);
+      expect(decoded.assistantId).toBe("default");
+      expect(decoded.conversationCount).toBe(3);
+      expect(decoded.userName).toBe("Sam");
+      expect(decoded.capabilities).toHaveLength(6);
+      expect(decoded.tier).toBe(1);
+    });
+
+    test("never throws when the workspace is unwritable-ish", async () => {
+      // Point the workspace override at a nested path under a file to
+      // force mkdirSync to fail. The public API must swallow this.
+      const sentinelFile = join(workspaceDir, "blocker");
+      writeFileSync(sentinelFile, "blocking", "utf-8");
+      process.env.VELLUM_WORKSPACE_DIR = join(sentinelFile, "nested");
+
+      await expect(writeRelationshipState()).resolves.toBeUndefined();
+    });
+  });
+});

--- a/assistant/src/home/progress-formula.ts
+++ b/assistant/src/home/progress-formula.ts
@@ -1,0 +1,86 @@
+/**
+ * Progress ring formula — pure functions that derive
+ * `progressPercent` (0-100) and `tier` (1-4) from the inputs the
+ * relationship-state writer has assembled.
+ *
+ * The weights and targets ship as named constants so the "start simple"
+ * tuning from the Phase 3 TDD can be retuned without touching the writer
+ * (Open Question #5 in the TDD). Any change here should deliberately
+ * break the unit tests in `progress-formula.test.ts` — those tests are
+ * the contract that pins the current tuning.
+ */
+
+import type { Capability, Fact } from "./relationship-state.js";
+
+/**
+ * Weighted contributions of each signal to the raw progress score.
+ * Must sum to 1 — enforced by the test suite.
+ */
+export const PROGRESS_WEIGHTS = {
+  facts: 0.4,
+  capabilities: 0.4,
+  conversations: 0.2,
+} as const;
+
+/**
+ * Saturation targets for each signal. Once a signal reaches its target
+ * it contributes its full weight to the progress score.
+ */
+export const PROGRESS_TARGETS = {
+  /** Saturates at 20 known facts. */
+  facts: 20,
+  /** Total in DEFAULT_CAPABILITIES. */
+  capabilities: 6,
+  /** Saturates at 20 conversations. */
+  conversations: 20,
+} as const;
+
+/** Inputs to the pure progress functions. */
+export interface ProgressInput {
+  facts: Fact[];
+  capabilities: Capability[];
+  conversationCount: number;
+}
+
+/**
+ * Compute the progress ring percentage (0-100).
+ *
+ * Pure function: no IO, no randomness. The output depends only on the
+ * inputs and the named constants above.
+ */
+export function computeProgressPercent(input: ProgressInput): number {
+  const facts = Math.min(input.facts.length / PROGRESS_TARGETS.facts, 1);
+  const unlocked = input.capabilities.filter(
+    (c) => c.tier === "unlocked",
+  ).length;
+  const caps = Math.min(unlocked / PROGRESS_TARGETS.capabilities, 1);
+  const convs = Math.min(
+    input.conversationCount / PROGRESS_TARGETS.conversations,
+    1,
+  );
+  const raw =
+    PROGRESS_WEIGHTS.facts * facts +
+    PROGRESS_WEIGHTS.capabilities * caps +
+    PROGRESS_WEIGHTS.conversations * convs;
+  return Math.round(raw * 100);
+}
+
+/**
+ * Compute the relationship tier (1-4).
+ *
+ * Tier 4 ("In sync") is reserved for a deeper heuristic later, tied to
+ * autonomous actions — it is intentionally unreachable from this
+ * function today so the upgrade path is observable in the test suite.
+ */
+export function computeTier(input: ProgressInput): 1 | 2 | 3 | 4 {
+  const unlocked = input.capabilities.filter(
+    (c) => c.tier === "unlocked",
+  ).length;
+  const convs = input.conversationCount;
+  // "Hitting our stride" — real working relationship.
+  if (convs >= 20 && unlocked >= 3) return 3;
+  // "Finding my footing" — starting to understand how they work.
+  if (convs >= 5 && input.facts.length >= 3) return 2;
+  // "Getting to know you" — default for fresh relationships.
+  return 1;
+}

--- a/assistant/src/home/relationship-state-writer.ts
+++ b/assistant/src/home/relationship-state-writer.ts
@@ -2,9 +2,11 @@
  * Relationship-state writer.
  *
  * Derives a `RelationshipState` snapshot from the filesystem state of
- * the workspace (USER.md / users/default.md for world+priorities facts,
- * SOUL.md for voice facts, IDENTITY.md for assistant/hatched metadata,
- * the conversations directory for conversationCount) plus the OAuth
+ * the workspace (the guardian's `users/<slug>.md` persona file — resolved
+ * via `persona-resolver` / `contact-store` — for world + priorities facts,
+ * with legacy workspace-root `USER.md` as a last-ditch fallback; SOUL.md
+ * for voice facts; IDENTITY.md for assistant / hatched metadata; the
+ * conversations directory for conversationCount) plus the OAuth
  * connection store (for capability tiers), and writes it to
  * `<workspace>/data/relationship-state.json`.
  *
@@ -24,11 +26,11 @@ import {
 import { join } from "node:path";
 
 import { listConnections } from "../oauth/oauth-store.js";
+import { resolveGuardianPersonaPath } from "../prompts/persona-resolver.js";
 import { getLogger } from "../util/logger.js";
 import {
   getConversationsDir,
   getDataDir,
-  getWorkspaceDir,
   getWorkspacePromptPath,
 } from "../util/platform.js";
 import { computeProgressPercent, computeTier } from "./progress-formula.js";
@@ -79,23 +81,28 @@ export function getRelationshipStatePath(): string {
  * persist the result should use `writeRelationshipState()` instead.
  */
 export async function computeRelationshipState(): Promise<RelationshipState> {
-  const userMd = safeRead(getWorkspacePromptPath("USER.md"));
-  // USER.md was migrated away in workspace migration 031 — fall back to
-  // the guardian persona file so writers built from upgraded workspaces
-  // still produce non-empty world/priorities facts.
-  const legacyUserPath = join(getWorkspaceDir(), "users", "default.md");
-  const legacyUserMd = safeRead(legacyUserPath);
+  // Persona source-of-truth:
+  //   1. The guardian contact's per-user file (`users/<slug>.md`), resolved
+  //      via `resolveGuardianPersonaPath()` — this is the canonical location
+  //      after workspace migration 031 and handles slugged userFiles like
+  //      `users/sidd.md` that were invisible to a hardcoded `default.md`
+  //      lookup.
+  //   2. Legacy workspace-root `USER.md` as a last-ditch fallback for very
+  //      old workspaces that never ran migration 031.
+  //   3. Empty string → extraction yields [] and `userName` is undefined.
+  // Every step is guarded because the writer must never throw.
+  const userMd = resolveGuardianUserContent();
   const soulMd = safeRead(getWorkspacePromptPath("SOUL.md"));
   const identityMd = safeRead(getWorkspacePromptPath("IDENTITY.md"));
 
   const facts = extractFacts({
-    userContent: userMd || legacyUserMd,
+    userContent: userMd,
     soulContent: soulMd,
   });
   const conversationCount = countConversations();
   const capabilities = resolveCapabilityTiers({ conversationCount });
   const { assistantName, hatchedDate } = parseIdentity(identityMd);
-  const userName = parseUserName(userMd || legacyUserMd);
+  const userName = parseUserName(userMd);
 
   const tier = computeTier({ facts, capabilities, conversationCount });
   const progressPercent = computeProgressPercent({
@@ -149,6 +156,45 @@ export async function writeRelationshipState(): Promise<void> {
 // ─── Internal helpers ───────────────────────────────────────────────────
 
 /**
+ * Resolve the raw markdown content of the guardian's user persona file
+ * (`users/<slug>.md`), falling back to legacy workspace-root `USER.md`
+ * when no guardian is resolvable or the persona file is missing.
+ *
+ * Uses `resolveGuardianPersonaPath()` rather than a hardcoded
+ * `users/default.md` so slugged user files populated by
+ * `generateUserFileSlug` (e.g. `users/sidd.md`) are read correctly —
+ * otherwise the writer would systematically under-extract facts and
+ * `userName` for any contact-aware workspace.
+ *
+ * Every step is guarded: any exception from the persona resolver or
+ * the underlying contact store DB lookup collapses to the empty string
+ * via the normal fallback chain, so `computeRelationshipState()` never
+ * throws from this path.
+ */
+function resolveGuardianUserContent(): string {
+  try {
+    const guardianPath = resolveGuardianPersonaPath();
+    if (guardianPath) {
+      const content = safeRead(guardianPath);
+      if (content) return content;
+    }
+  } catch (err) {
+    log.warn(
+      { err },
+      "Failed to resolve guardian persona path; falling back to legacy USER.md",
+    );
+  }
+
+  // Legacy fallback: workspace-root USER.md for very old workspaces
+  // that predate migration 031.
+  const legacyPath = getWorkspacePromptPath("USER.md");
+  const legacy = safeRead(legacyPath);
+  if (legacy) return legacy;
+
+  return "";
+}
+
+/**
  * Read a file as UTF-8, returning "" on any error.
  *
  * Used for every disk read in this module so a missing or unreadable
@@ -171,7 +217,9 @@ function safeRead(path: string): string {
  * produce something non-empty for the UI so progress looks alive.
  *
  * Voice facts come from SOUL.md. World and priorities facts come from
- * USER.md (or its `users/<slug>.md` successor post migration 031).
+ * the guardian's `users/<slug>.md` persona file (resolved via
+ * `persona-resolver`), with legacy workspace-root `USER.md` as a
+ * fallback for workspaces that predate migration 031.
  */
 function extractFacts(input: {
   userContent: string;
@@ -316,10 +364,15 @@ function resolveCapabilityTiers(opts: {
         return { ...cap, tier: unlocked ? "unlocked" : "next-up" };
       }
       case "calendar": {
+        // `outlook` is the real provider key used by seed-providers.ts for
+        // the Microsoft integration (which carries `Calendars.Read` /
+        // `Calendars.ReadWrite` scopes), so an active Outlook connection
+        // must flip `calendar` to `unlocked` the same way it flips `email`.
         const unlocked =
           connectedProviders.has("google") ||
           connectedProviders.has("google-calendar") ||
-          connectedProviders.has("microsoft");
+          connectedProviders.has("microsoft") ||
+          connectedProviders.has("outlook");
         return { ...cap, tier: unlocked ? "unlocked" : "next-up" };
       }
       case "slack": {

--- a/assistant/src/home/relationship-state-writer.ts
+++ b/assistant/src/home/relationship-state-writer.ts
@@ -356,23 +356,18 @@ function resolveCapabilityTiers(opts: {
   return DEFAULT_CAPABILITIES.map((cap) => {
     switch (cap.id) {
       case "email": {
+        // Only Gmail is a real email integration today. Outlook appears in
+        // seed-providers.ts as scaffolding but we don't actually ship a
+        // Microsoft integration, so we do not advertise email unlock for it.
         const unlocked =
-          connectedProviders.has("google") ||
-          connectedProviders.has("gmail") ||
-          connectedProviders.has("microsoft") ||
-          connectedProviders.has("outlook");
+          connectedProviders.has("google") || connectedProviders.has("gmail");
         return { ...cap, tier: unlocked ? "unlocked" : "next-up" };
       }
       case "calendar": {
-        // `outlook` is the real provider key used by seed-providers.ts for
-        // the Microsoft integration (which carries `Calendars.Read` /
-        // `Calendars.ReadWrite` scopes), so an active Outlook connection
-        // must flip `calendar` to `unlocked` the same way it flips `email`.
+        // Only Google Calendar is a real calendar integration today.
         const unlocked =
           connectedProviders.has("google") ||
-          connectedProviders.has("google-calendar") ||
-          connectedProviders.has("microsoft") ||
-          connectedProviders.has("outlook");
+          connectedProviders.has("google-calendar");
         return { ...cap, tier: unlocked ? "unlocked" : "next-up" };
       }
       case "slack": {

--- a/assistant/src/home/relationship-state-writer.ts
+++ b/assistant/src/home/relationship-state-writer.ts
@@ -21,6 +21,7 @@ import {
   mkdirSync,
   readdirSync,
   readFileSync,
+  statSync,
   writeFileSync,
 } from "node:fs";
 import { join } from "node:path";
@@ -93,7 +94,7 @@ export async function computeRelationshipState(): Promise<RelationshipState> {
   // Every step is guarded because the writer must never throw.
   const userMd = resolveGuardianUserContent();
   const soulMd = safeRead(getWorkspacePromptPath("SOUL.md"));
-  const identityMd = safeRead(getWorkspacePromptPath("IDENTITY.md"));
+  const identityPath = getWorkspacePromptPath("IDENTITY.md");
 
   const facts = extractFacts({
     userContent: userMd,
@@ -101,7 +102,7 @@ export async function computeRelationshipState(): Promise<RelationshipState> {
   });
   const conversationCount = countConversations();
   const capabilities = resolveCapabilityTiers({ conversationCount });
-  const { assistantName, hatchedDate } = parseIdentity(identityMd);
+  const { assistantName, hatchedDate } = parseIdentity(identityPath);
   const userName = parseUserName(userMd);
 
   const tier = computeTier({ facts, capabilities, conversationCount });
@@ -425,40 +426,69 @@ function countConversations(): number {
 }
 
 /**
- * Pull `assistantName` and `hatchedDate` out of IDENTITY.md. IDENTITY.md
- * is a freeform markdown file, so we scan bullet lines for the first
- * recognizable `name` / `hatched` label. Returns safe defaults when
- * neither is found.
+ * Pull `assistantName` and `hatchedDate` from IDENTITY.md.
+ *
+ * IDENTITY.md is a freeform markdown file, so for the name we scan
+ * bullet lines for the first recognizable `name` label. For the
+ * hatched date we prefer any explicit `hatched:` / `birth:` bullet,
+ * then fall back to the file's `stat.birthtime` (matching the
+ * pattern already established by `identity-routes.ts`), and finally
+ * to `stat.mtime` if birthtime is unavailable. We never fall back to
+ * `new Date()` — `writeRelationshipState()` is called on every turn
+ * boundary, so a `Date.now()` fallback would cause `hatchedDate` to
+ * drift forward on every write, turning a stable "relationship
+ * start" timestamp into a constantly-updating "last touched"
+ * timestamp. When nothing is readable we emit the Unix epoch as an
+ * unmistakable sentinel instead of silently drifting.
  */
-function parseIdentity(content: string): {
+function parseIdentity(identityPath: string): {
   assistantName: string;
   hatchedDate: string;
 } {
-  let assistantName = DEFAULT_ASSISTANT_NAME;
-  let hatchedDate = new Date().toISOString();
+  const content = safeRead(identityPath);
 
-  if (!content) return { assistantName, hatchedDate };
+  let assistantName = DEFAULT_ASSISTANT_NAME;
+  let explicitHatched: string | undefined;
 
   for (const line of iterateBulletLines(content)) {
     const parsed = parseBulletLabelValue(line);
-    if (!parsed) continue;
+    if (!parsed || !parsed.value) continue;
     const lower = parsed.label.toLowerCase();
-    if (!parsed.value) continue;
     if (lower.startsWith("name") && assistantName === DEFAULT_ASSISTANT_NAME) {
       assistantName = parsed.value;
     }
     if (
-      (lower.startsWith("hatched") || lower.startsWith("birth")) &&
-      parsed.value
+      !explicitHatched &&
+      (lower.startsWith("hatched") || lower.startsWith("birth"))
     ) {
       const parsedDate = new Date(parsed.value);
       if (!isNaN(parsedDate.getTime())) {
-        hatchedDate = parsedDate.toISOString();
+        explicitHatched = parsedDate.toISOString();
       }
     }
   }
 
-  return { assistantName, hatchedDate };
+  if (explicitHatched) {
+    return { assistantName, hatchedDate: explicitHatched };
+  }
+
+  // Stable fallback: use the IDENTITY.md file birth time so the
+  // relationship start date is monotonic across turns. Matches the
+  // approach used by `identity-routes.ts` for the Settings UI.
+  try {
+    const stats = statSync(identityPath);
+    const candidate =
+      stats.birthtime.getTime() > 0 ? stats.birthtime : stats.mtime;
+    if (candidate.getTime() > 0) {
+      return { assistantName, hatchedDate: candidate.toISOString() };
+    }
+  } catch {
+    // File missing or unreadable — fall through to the sentinel.
+  }
+
+  // Last-ditch sentinel: unmistakably ancient so any UI showing it
+  // makes the "we couldn't resolve your hatched date" state obvious.
+  return { assistantName, hatchedDate: new Date(0).toISOString() };
 }
 
 /**

--- a/assistant/src/home/relationship-state-writer.ts
+++ b/assistant/src/home/relationship-state-writer.ts
@@ -1,0 +1,438 @@
+/**
+ * Relationship-state writer.
+ *
+ * Derives a `RelationshipState` snapshot from the filesystem state of
+ * the workspace (USER.md / users/default.md for world+priorities facts,
+ * SOUL.md for voice facts, IDENTITY.md for assistant/hatched metadata,
+ * the conversations directory for conversationCount) plus the OAuth
+ * connection store (for capability tiers), and writes it to
+ * `<workspace>/data/relationship-state.json`.
+ *
+ * Per assistant/CLAUDE.md the daemon must never block or throw at
+ * startup — the public entry points here catch every error and log a
+ * warning instead. Internal helpers use a narrow `safeRead` wrapper so
+ * a missing or unreadable file degrades gracefully to an empty string.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+
+import { listConnections } from "../oauth/oauth-store.js";
+import { getLogger } from "../util/logger.js";
+import {
+  getConversationsDir,
+  getDataDir,
+  getWorkspaceDir,
+  getWorkspacePromptPath,
+} from "../util/platform.js";
+import { computeProgressPercent, computeTier } from "./progress-formula.js";
+import {
+  type Capability,
+  DEFAULT_CAPABILITIES,
+  type Fact,
+  RELATIONSHIP_STATE_VERSION,
+  type RelationshipState,
+} from "./relationship-state.js";
+
+const log = getLogger("relationship-state-writer");
+
+/**
+ * Filename for the on-disk snapshot. Lives under the workspace data dir.
+ */
+export const RELATIONSHIP_STATE_FILENAME = "relationship-state.json";
+
+/**
+ * Conversation-count threshold at which the "voice-writing" capability
+ * flips from `earned` (gated, shown with an `unlockHint`) to `unlocked`.
+ *
+ * This is a placeholder for Open Question #6 in the TDD. Wrap as a
+ * named constant so it's obvious which knob to tune when a deeper
+ * heuristic replaces it.
+ */
+const VOICE_WRITING_UNLOCK_CONVERSATIONS = 10;
+
+/** Default assistant name when IDENTITY.md cannot be parsed. */
+const DEFAULT_ASSISTANT_NAME = "Vellum";
+
+/** Default assistant identifier (multi-assistant reserved for future). */
+const DEFAULT_ASSISTANT_ID = "default";
+
+/**
+ * Canonical path to the relationship-state snapshot
+ * (`<workspace>/data/relationship-state.json`).
+ */
+export function getRelationshipStatePath(): string {
+  return join(getDataDir(), RELATIONSHIP_STATE_FILENAME);
+}
+
+/**
+ * Build a fresh `RelationshipState` from the current on-disk + DB state.
+ *
+ * This is the pure-ish computation half of the writer — it reads files
+ * and the oauth store but performs no writes. Callers that want to
+ * persist the result should use `writeRelationshipState()` instead.
+ */
+export async function computeRelationshipState(): Promise<RelationshipState> {
+  const userMd = safeRead(getWorkspacePromptPath("USER.md"));
+  // USER.md was migrated away in workspace migration 031 — fall back to
+  // the guardian persona file so writers built from upgraded workspaces
+  // still produce non-empty world/priorities facts.
+  const legacyUserPath = join(getWorkspaceDir(), "users", "default.md");
+  const legacyUserMd = safeRead(legacyUserPath);
+  const soulMd = safeRead(getWorkspacePromptPath("SOUL.md"));
+  const identityMd = safeRead(getWorkspacePromptPath("IDENTITY.md"));
+
+  const facts = extractFacts({
+    userContent: userMd || legacyUserMd,
+    soulContent: soulMd,
+  });
+  const conversationCount = countConversations();
+  const capabilities = resolveCapabilityTiers({ conversationCount });
+  const { assistantName, hatchedDate } = parseIdentity(identityMd);
+  const userName = parseUserName(userMd || legacyUserMd);
+
+  const tier = computeTier({ facts, capabilities, conversationCount });
+  const progressPercent = computeProgressPercent({
+    facts,
+    capabilities,
+    conversationCount,
+  });
+
+  return {
+    version: RELATIONSHIP_STATE_VERSION,
+    assistantId: DEFAULT_ASSISTANT_ID,
+    tier,
+    progressPercent,
+    facts,
+    capabilities,
+    conversationCount,
+    hatchedDate,
+    assistantName,
+    userName,
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+/**
+ * Compute a fresh snapshot and persist it to `getRelationshipStatePath()`.
+ *
+ * Never throws — all errors are caught and logged as warnings. Fire-and-
+ * forget callers (e.g. the conversation-complete hook) can safely call
+ * this without additional try/catch wrapping.
+ */
+export async function writeRelationshipState(): Promise<void> {
+  try {
+    const state = await computeRelationshipState();
+    const path = getRelationshipStatePath();
+    mkdirSync(getDataDir(), { recursive: true });
+    writeFileSync(path, JSON.stringify(state, null, 2), "utf8");
+    log.info(
+      {
+        path,
+        tier: state.tier,
+        progress: state.progressPercent,
+        facts: state.facts.length,
+      },
+      "Wrote relationship-state.json",
+    );
+  } catch (err) {
+    log.warn({ err }, "Failed to write relationship-state.json");
+  }
+}
+
+// ─── Internal helpers ───────────────────────────────────────────────────
+
+/**
+ * Read a file as UTF-8, returning "" on any error.
+ *
+ * Used for every disk read in this module so a missing or unreadable
+ * workspace file degrades gracefully to an empty content string rather
+ * than propagating an exception out of a startup path.
+ */
+function safeRead(path: string): string {
+  try {
+    if (!existsSync(path)) return "";
+    return readFileSync(path, "utf-8");
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Walk the workspace prompt files and emit a flat list of inferred
+ * facts. This is deliberately a simple bullet/heading parser — the TDD
+ * explicitly calls out "don't try to be clever" here; the goal is to
+ * produce something non-empty for the UI so progress looks alive.
+ *
+ * Voice facts come from SOUL.md. World and priorities facts come from
+ * USER.md (or its `users/<slug>.md` successor post migration 031).
+ */
+function extractFacts(input: {
+  userContent: string;
+  soulContent: string;
+}): Fact[] {
+  const facts: Fact[] = [];
+  let counter = 0;
+  const nextId = (prefix: string): string => {
+    counter += 1;
+    return `${prefix}-${counter}`;
+  };
+
+  // Heuristic keyword map for USER.md sections -> fact category. Keys
+  // are matched case-insensitively as a prefix of the heading/bullet
+  // label. Everything that doesn't match stays a "world" fact.
+  const priorityKeywords = [
+    "goals",
+    "priority",
+    "priorities",
+    "focus",
+    "work role",
+    "role",
+    "projects",
+    "daily tools",
+    "tools",
+  ];
+  const worldKeywords = [
+    "name",
+    "pronouns",
+    "locale",
+    "location",
+    "hobbies",
+    "fun",
+    "timezone",
+    "background",
+  ];
+
+  for (const line of iterateBulletLines(input.userContent)) {
+    const parsed = parseBulletLabelValue(line);
+    if (!parsed) continue;
+    const { label, value } = parsed;
+    if (!value) continue;
+    const lower = label.toLowerCase();
+    const isPriority = priorityKeywords.some((k) => lower.startsWith(k));
+    const isWorld = worldKeywords.some((k) => lower.startsWith(k));
+    const category: Fact["category"] = isPriority
+      ? "priorities"
+      : isWorld
+        ? "world"
+        : "world";
+    facts.push({
+      id: nextId("user"),
+      category,
+      text: `${capitalizeLabel(label)}: ${value}`,
+      confidence: "strong",
+      source: "inferred",
+    });
+  }
+
+  for (const line of iterateBulletLines(input.soulContent)) {
+    const parsed = parseBulletLabelValue(line);
+    if (!parsed) continue;
+    const { label, value } = parsed;
+    if (!value) continue;
+    facts.push({
+      id: nextId("soul"),
+      category: "voice",
+      text: `${capitalizeLabel(label)}: ${value}`,
+      confidence: "strong",
+      source: "inferred",
+    });
+  }
+
+  return facts;
+}
+
+/**
+ * Yield non-empty bullet lines from a markdown string, skipping comment
+ * lines (leading `_`) and indented continuation. Lines returned are the
+ * trimmed bullet body, without the leading `-` or `*`.
+ */
+function* iterateBulletLines(content: string): Generator<string> {
+  if (!content) return;
+  for (const raw of content.split("\n")) {
+    const line = raw.trim();
+    if (!line) continue;
+    if (line.startsWith("_")) continue;
+    if (!line.startsWith("- ") && !line.startsWith("* ")) continue;
+    const body = line.slice(2).trim();
+    if (body.length === 0) continue;
+    yield body;
+  }
+}
+
+/**
+ * Parse a bullet body of the form `**Label:** value` or `Label: value`
+ * into its label and value halves. Returns null when no colon is found.
+ */
+function parseBulletLabelValue(
+  body: string,
+): { label: string; value: string } | null {
+  const stripped = body.replace(/\*\*/g, "").replace(/__/g, "");
+  const idx = stripped.indexOf(":");
+  if (idx <= 0) return null;
+  const label = stripped.slice(0, idx).trim();
+  const value = stripped.slice(idx + 1).trim();
+  if (!label) return null;
+  return { label, value };
+}
+
+/**
+ * Lowercase-ify a label but keep the first character uppercased for
+ * display: "PREFERRED Name" -> "Preferred name".
+ */
+function capitalizeLabel(label: string): string {
+  const trimmed = label.trim();
+  if (!trimmed) return trimmed;
+  return trimmed.charAt(0).toUpperCase() + trimmed.slice(1).toLowerCase();
+}
+
+/**
+ * Project `DEFAULT_CAPABILITIES` into a concrete capability list by
+ * consulting the OAuth connection store for integration-gated tiers
+ * and the conversation count for usage-gated tiers.
+ *
+ * Failures in the oauth lookup fall back to the "empty set" — every
+ * integration appears as `next-up` — so startup paths never throw.
+ */
+function resolveCapabilityTiers(opts: {
+  conversationCount: number;
+}): Capability[] {
+  const connectedProviders = resolveConnectedProviders();
+
+  return DEFAULT_CAPABILITIES.map((cap) => {
+    switch (cap.id) {
+      case "email": {
+        const unlocked =
+          connectedProviders.has("google") ||
+          connectedProviders.has("gmail") ||
+          connectedProviders.has("microsoft") ||
+          connectedProviders.has("outlook");
+        return { ...cap, tier: unlocked ? "unlocked" : "next-up" };
+      }
+      case "calendar": {
+        const unlocked =
+          connectedProviders.has("google") ||
+          connectedProviders.has("google-calendar") ||
+          connectedProviders.has("microsoft");
+        return { ...cap, tier: unlocked ? "unlocked" : "next-up" };
+      }
+      case "slack": {
+        const unlocked = connectedProviders.has("slack");
+        return { ...cap, tier: unlocked ? "unlocked" : "next-up" };
+      }
+      case "voice-writing": {
+        const unlocked =
+          opts.conversationCount >= VOICE_WRITING_UNLOCK_CONVERSATIONS;
+        return { ...cap, tier: unlocked ? "unlocked" : "earned" };
+      }
+      case "proactive":
+      case "autonomous":
+      default:
+        return { ...cap, tier: "earned" };
+    }
+  });
+}
+
+/**
+ * Return the set of provider keys with at least one `active` OAuth
+ * connection. Any failure (DB not initialized, schema drift, etc.)
+ * returns an empty set so the writer keeps advancing with sane
+ * defaults.
+ */
+function resolveConnectedProviders(): Set<string> {
+  try {
+    const rows = listConnections();
+    const set = new Set<string>();
+    for (const row of rows) {
+      if (row.status === "active") set.add(row.provider);
+    }
+    return set;
+  } catch (err) {
+    log.warn(
+      { err },
+      "Failed to list OAuth connections; assuming no integrations connected",
+    );
+    return new Set<string>();
+  }
+}
+
+/**
+ * Count conversations by listing the conversations directory. Returns
+ * 0 when the directory is missing or unreadable.
+ */
+function countConversations(): number {
+  try {
+    const dir = getConversationsDir();
+    if (!existsSync(dir)) return 0;
+    return readdirSync(dir).length;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Pull `assistantName` and `hatchedDate` out of IDENTITY.md. IDENTITY.md
+ * is a freeform markdown file, so we scan bullet lines for the first
+ * recognizable `name` / `hatched` label. Returns safe defaults when
+ * neither is found.
+ */
+function parseIdentity(content: string): {
+  assistantName: string;
+  hatchedDate: string;
+} {
+  let assistantName = DEFAULT_ASSISTANT_NAME;
+  let hatchedDate = new Date().toISOString();
+
+  if (!content) return { assistantName, hatchedDate };
+
+  for (const line of iterateBulletLines(content)) {
+    const parsed = parseBulletLabelValue(line);
+    if (!parsed) continue;
+    const lower = parsed.label.toLowerCase();
+    if (!parsed.value) continue;
+    if (lower.startsWith("name") && assistantName === DEFAULT_ASSISTANT_NAME) {
+      assistantName = parsed.value;
+    }
+    if (
+      (lower.startsWith("hatched") || lower.startsWith("birth")) &&
+      parsed.value
+    ) {
+      const parsedDate = new Date(parsed.value);
+      if (!isNaN(parsedDate.getTime())) {
+        hatchedDate = parsedDate.toISOString();
+      }
+    }
+  }
+
+  return { assistantName, hatchedDate };
+}
+
+/**
+ * Best-effort user-name extraction from USER.md (or its successor
+ * `users/<slug>.md`). Returns undefined when no `name`/`preferred` line
+ * is present so the caller can leave `userName` off the wire.
+ */
+function parseUserName(content: string): string | undefined {
+  if (!content) return undefined;
+  for (const line of iterateBulletLines(content)) {
+    const parsed = parseBulletLabelValue(line);
+    if (!parsed) continue;
+    const lower = parsed.label.toLowerCase();
+    if (
+      (lower.startsWith("name") ||
+        lower.startsWith("preferred") ||
+        lower === "user" ||
+        lower === "user name") &&
+      parsed.value
+    ) {
+      return parsed.value;
+    }
+  }
+  return undefined;
+}

--- a/assistant/src/home/relationship-state.ts
+++ b/assistant/src/home/relationship-state.ts
@@ -102,7 +102,7 @@ export const DEFAULT_CAPABILITIES: Omit<Capability, "tier">[] = [
     id: "email",
     name: "Email access",
     description: "Read, draft, and manage your email",
-    gate: "Connect Google or Outlook",
+    gate: "Connect Google",
     ctaLabel: "Connect Google →",
   },
   {


### PR DESCRIPTION
## Summary

- **Progress formula** (`assistant/src/home/progress-formula.ts`) — pure `computeProgressPercent()` / `computeTier()` with named `PROGRESS_WEIGHTS` / `PROGRESS_TARGETS` constants so the TDD's "start simple" weights can be retuned without touching the writer. Table-driven tests pin zero-state, saturated-state, and per-signal contributions so any tuning change breaks the suite deliberately.
- **Relationship-state writer** (`assistant/src/home/relationship-state-writer.ts`) — exports `computeRelationshipState()`, `writeRelationshipState()`, `getRelationshipStatePath()`, and `RELATIONSHIP_STATE_FILENAME`. Reads USER.md / `users/default.md` (fallback post migration 031) for world+priorities facts, SOUL.md for voice facts, and IDENTITY.md for assistant/hatched metadata. Capability tiers resolve against `listConnections()` from `oauth-store.js` (discovered as the real exported API; the plan's assumption held); voice-writing flips to `unlocked` once `conversationCount >= 10` via a named threshold. All errors are caught and logged as warnings per the daemon-never-blocks-on-startup directive.
- **Turn-complete hook** — `void writeRelationshipState().catch(() => {})` added to the turn-boundary `finally` block in `assistant/src/daemon/conversation-agent-loop.ts`, right after the existing `commitAppTurnChanges` fire-and-forget. The plan named `daemon/conversation.ts` but that file is a thin delegator; the actual turn completion path lives in `conversation-agent-loop.ts`. Fully fire-and-forget — a failure in the writer can never bubble out of the agent loop.

Ticket: [JARVIS-470](https://linear.app/vellum/issue/JARVIS-470)
Part of plan: phase-3-backend.md (PR 2 of 4)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25250" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
