### PR TITLE
refactor: remove dead scroll code — restoreScrollToBottom, suppressAutoScroll, unused stubs

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -29,7 +29,6 @@ struct AssistantProgressView: View {
     /// expansion, override, and rehydration tracking survive view recycling.
     @Binding var progressUIState: ProgressCardUIState
 
-    @Environment(\.suppressAutoScroll) private var suppressAutoScroll
     @State private var isExpanded: Bool
     @State private var startDate: Date
     @State private var processingStartDate: Date?
@@ -381,7 +380,6 @@ struct AssistantProgressView: View {
                 reason: "manual_toggle:\(isExpanded ? "collapse" : "expand")",
                 toolCallCount: model.totalToolCount
             ))
-            suppressAutoScroll?()
             withAnimation(VAnimation.fast) {
                 isExpanded.toggle()
             }
@@ -645,7 +643,6 @@ private struct StepDetailRow: View {
     /// Human-friendly label for skill_execute rows (e.g. "Using my frontend design skill").
     var skillLabel: String?
     var onRehydrate: (() -> Void)?
-    @Environment(\.suppressAutoScroll) private var suppressAutoScroll
 
     private static let coloredOutputCache: NSCache<NSString, StepDetailAttributedStringCacheEntry> = {
         let cache = NSCache<NSString, StepDetailAttributedStringCacheEntry>()
@@ -720,7 +717,6 @@ private struct StepDetailRow: View {
             // Row header
             Button {
                 guard hasDetails else { return }
-                suppressAutoScroll?()
                 withAnimation(VAnimation.fast) { isDetailExpanded.toggle() }
             } label: {
                 HStack(spacing: VSpacing.sm) {

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
@@ -318,15 +318,6 @@ struct MessageListContentView: View, Equatable {
 
             Color.clear.frame(height: 1)
                 .id("scroll-bottom-anchor")
-                .onAppear {
-                    // Signal that the bottom anchor has materialized —
-                    // isAtBottom is now reliable (based on actual content
-                    // height, not LazyVStack estimates).
-                    scrollState.bottomAnchorAppeared = true
-                    if !scrollState.hasBeenInteracted {
-                        scrollState.handleReachedBottom()
-                    }
-                }
         }
         .disabled(!isInteractionEnabled)
         .transaction { $0.animation = nil }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -1,85 +1,12 @@
 import Foundation
-import os
 import SwiftUI
 import VellumAssistantShared
-
-// MARK: - Legacy enums (still referenced by view layer callers)
-
-/// Legacy enum retained because MessageListView+ScrollHandling pattern-matches
-/// on `.freeBrowsing`, `.programmaticScroll`, `.stabilizing` in restoreScrollToBottom().
-/// Remove once those callers are migrated.
-enum ScrollMode: Equatable, CustomStringConvertible {
-    case initialLoad
-    case followingBottom
-    case freeBrowsing
-    case programmaticScroll(reason: ProgrammaticScrollReason)
-    case stabilizing(previousMode: StabilizedMode, reason: StabilizationReason)
-
-    var description: String {
-        switch self {
-        case .initialLoad: "initialLoad"
-        case .followingBottom: "followingBottom"
-        case .freeBrowsing: "freeBrowsing"
-        case .programmaticScroll(let reason): "programmaticScroll(\(reason))"
-        case .stabilizing(let prev, let reason): "stabilizing(\(prev), \(reason))"
-        }
-    }
-
-    /// Stub — always returns true. Remove with enum.
-    var allowsAutoScroll: Bool { true }
-
-    /// Stub — always returns false. Remove with enum.
-    var showsScrollToLatest: Bool { false }
-}
-
-enum ProgrammaticScrollReason: Equatable, CustomStringConvertible {
-    case deepLinkAnchor(id: UUID)
-
-    var description: String {
-        switch self {
-        case .deepLinkAnchor(let id): "deepLinkAnchor(\(id))"
-        }
-    }
-}
-
-enum StabilizationReason: Equatable, CustomStringConvertible {
-    case resize
-    case expansion
-    case pagination
-
-    var description: String {
-        switch self {
-        case .resize: "resize"
-        case .expansion: "expansion"
-        case .pagination: "pagination"
-        }
-    }
-}
-
-enum StabilizedMode: Equatable, CustomStringConvertible {
-    case followingBottom
-    case freeBrowsing
-
-    var description: String {
-        switch self {
-        case .followingBottom: "followingBottom"
-        case .freeBrowsing: "freeBrowsing"
-        }
-    }
-}
-
-private let scrollLog = Logger(subsystem: Bundle.appBundleIdentifier, category: "ScrollState")
 
 // MARK: - MessageListScrollState
 
 /// Flat scroll coordinator — tracks geometry, distance-based scroll-to-latest
 /// visibility, pagination sentinel, and deep-link anchor state. No mode
 /// transitions, stabilization, or recovery logic.
-///
-/// Legacy `ScrollMode` enum, mode-transition methods, and scroll closures are
-/// retained as stubs because the view layer (MessageListView+ScrollHandling,
-/// MessageListView+Lifecycle, MessageListContentView) still references them.
-/// Remove once those callers are migrated to the flat coordinator API.
 @Observable @MainActor
 final class MessageListScrollState {
 
@@ -230,15 +157,8 @@ final class MessageListScrollState {
         scrollIndicatorRestoreTask?.cancel()
         derivedStateCache.reset()
 
-        // Reset stub state
-        mode = .initialLoad
-        scrollPhase = .idle
-        isAtBottom = false
-        bottomAnchorAppeared = false
         isPaginationInFlight = false
         lastHandledChatColumnWidth = 0
-        scrollRestoreTask?.cancel()
-        scrollRestoreTask = nil
         paginationTask?.cancel()
         paginationTask = nil
         highlightDismissTask?.cancel()
@@ -255,20 +175,10 @@ final class MessageListScrollState {
         scrollIndicatorRestoreTask?.cancel()
         scrollIndicatorRestoreTask = nil
         derivedStateCache.reset()
-
-        // Cancel stub tasks
-        scrollRestoreTask?.cancel()
-        scrollRestoreTask = nil
         paginationTask?.cancel()
         paginationTask = nil
         highlightDismissTask?.cancel()
         highlightDismissTask = nil
-
-        // Reset stub state
-        mode = .initialLoad
-        scrollPhase = .idle
-        isAtBottom = false
-        bottomAnchorAppeared = false
         isPaginationInFlight = false
         lastMessageId = nil
         scrollContentHeight = 0
@@ -279,110 +189,11 @@ final class MessageListScrollState {
         lastPaginationCompletedAt = .distantPast
     }
 
-    // MARK: - Legacy stubs (still referenced by view layer)
-    //
-    // These properties and methods are referenced by MessageListView,
-    // MessageListContentView, MessageListView+ScrollHandling,
-    // MessageListView+Lifecycle, and MessageListView+DerivedState.
-    // Remove once those callers are migrated to the flat coordinator API.
+    // MARK: - Live properties (used by view layer)
 
-    // --- Mode (stub, no real transitions) ---
-
-    @ObservationIgnored var mode: ScrollMode = .initialLoad
-
-    /// No-op stub. Remove once view layer callers are migrated.
-    func transition(to newMode: ScrollMode) {
-        mode = newMode
-    }
-
-    // --- Scroll closures (set by MessageListView+ScrollHandling) ---
-
-    @ObservationIgnored var scrollTo: ((_ id: any Hashable, _ anchor: UnitPoint?) -> Void)?
-    @ObservationIgnored var scrollToEdge: ((_ edge: Edge) -> Void)?
-    @ObservationIgnored var cancelScrollAnimation: (() -> Void)?
-
-    // --- Geometry stubs ---
-
-    @ObservationIgnored var scrollPhase: ScrollPhase = .idle
-    @ObservationIgnored var isAtBottom: Bool = false
-    @ObservationIgnored var bottomAnchorAppeared: Bool = false
     @ObservationIgnored var lastHandledChatColumnWidth: CGFloat = 0
-
-    // --- Pagination stubs ---
-
     @ObservationIgnored var isPaginationInFlight: Bool = false
-
-    var hideScrollIndicators: Bool {
-        get { scrollIndicatorsHidden }
-        set { scrollIndicatorsHidden = newValue }
-    }
-
-    // --- Task stubs ---
-
     @ObservationIgnored var paginationTask: Task<Void, Never>?
-    @ObservationIgnored var scrollRestoreTask: Task<Void, Never>?
     @ObservationIgnored var highlightDismissTask: Task<Void, Never>?
-
-    // --- Convenience stubs ---
-
-    /// No-op stub. Remove once view layer callers are migrated.
-    var hasBeenInteracted: Bool { true }
-
-    /// No-op stub. Remove once view layer callers are migrated.
-    var isFollowingBottom: Bool { false }
-
-    /// No-op stub. Remove once view layer callers are migrated.
-    var isSuppressed: Bool { false }
-
-    // --- Method stubs ---
-
-    /// No-op stub. Remove once view layer callers are migrated.
-    func handleReachedBottom() {}
-
-    /// Stub that preserves scroll-to-bottom behavior for external callers.
-    /// Remove once view layer callers are migrated.
-    @discardableResult
-    func requestPinToBottom(animated: Bool = false, userInitiated: Bool = false) -> Bool {
-        if userInitiated {
-            showScrollToLatest = false
-            let target: any Hashable = lastMessageId ?? ("scroll-bottom-anchor" as any Hashable)
-            scrollTo?(target, .bottom)
-            return true
-        }
-        if let target = lastMessageId {
-            if animated {
-                withAnimation(VAnimation.fast) {
-                    scrollTo?(target, .bottom)
-                }
-            } else {
-                scrollTo?(target, .bottom)
-            }
-        } else {
-            if animated {
-                withAnimation(VAnimation.fast) {
-                    scrollToEdge?(.bottom)
-                }
-            } else {
-                scrollToEdge?(.bottom)
-            }
-        }
-        return true
-    }
-
-
-    /// Stub that preserves scroll-to-id for external callers.
-    /// Remove once view layer callers are migrated.
-    func performScrollTo(_ id: any Hashable, anchor: UnitPoint? = nil) {
-        scrollTo?(id, anchor)
-    }
-
-    /// No-op stub. Remove once view layer callers are migrated.
-    func beginStabilization(_ reason: StabilizationReason) {}
-
-    /// No-op stub. Remove once view layer callers are migrated.
-    func endStabilization() {}
-
-    /// No-op stub. Remove once view layer callers are migrated.
-    func recordBodyEvaluation() {}
 
 }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListTypes.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListTypes.swift
@@ -2,21 +2,6 @@ import Foundation
 import SwiftUI
 import VellumAssistantShared
 
-// MARK: - Scroll Suppression Environment
-
-/// Environment key that child views (e.g. AssistantProgressView) call to
-/// temporarily suppress auto-scroll-to-bottom during content expansion.
-struct SuppressAutoScrollKey: EnvironmentKey {
-    static let defaultValue: (() -> Void)? = nil
-}
-
-extension EnvironmentValues {
-    var suppressAutoScroll: (() -> Void)? {
-        get { self[SuppressAutoScrollKey.self] }
-        set { self[SuppressAutoScrollKey.self] = newValue }
-    }
-}
-
 // MARK: - Precomputed Cache Key
 
 /// Lightweight key that captures all inputs to `precomputedState`.

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+DerivedState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+DerivedState.swift
@@ -60,7 +60,6 @@ extension MessageListView {
     /// state changes.
     var derivedState: TranscriptRenderModel {
         os_signpost(.begin, log: stallLog, name: "DerivedState.resolve")
-        scrollState.recordBodyEvaluation()
         let cache = scrollState.derivedStateCache
 
         if cache.isThrottled, let cached = cache.cachedProjection {

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
@@ -17,7 +17,7 @@ extension MessageListView {
         let previousConversationId = scrollState.currentConversationId
         let isConversationSwitch = previousConversationId != nil
             && previousConversationId != conversationId
-        configureScrollCallbacks()
+        scrollState.currentConversationId = conversationId
         if isConversationSwitch {
             handleConversationSwitched()
         } else {
@@ -97,7 +97,7 @@ extension MessageListView {
             os_signpost(.event, log: PerfSignposts.log, name: "scrollToRequested", "target=anchorMessage reason=messagesChanged")
             os_signpost(.event, log: PerfSignposts.log, name: "anchorCleared", "reason=foundInMessages")
             withAnimation {
-                scrollState.scrollTo?(id, .center)
+                $scrollPosition.wrappedValue = ScrollPosition(id: id, anchor: .center)
             }
             flashHighlight(messageId: id)
             anchorMessageId = nil
@@ -202,9 +202,6 @@ extension MessageListView {
         // non-nil anchor assignments; nil transitions are cleanup handled
         // by messagesChanged and conversationSwitched.
         guard let id = anchorMessageId else { return }
-        // Cancel scroll restore when a new anchor is set.
-        scrollState.scrollRestoreTask?.cancel()
-        scrollState.scrollRestoreTask = nil
         scrollState.anchorSetTime = Date()
         scrollState.anchorTimeoutTask?.cancel()
         scrollState.anchorTimeoutTask = nil
@@ -213,7 +210,7 @@ extension MessageListView {
             os_signpost(.event, log: PerfSignposts.log, name: "scrollToRequested", "target=anchorMessage reason=anchorChanged")
             os_signpost(.event, log: PerfSignposts.log, name: "anchorCleared", "reason=foundOnAnchorChange")
             withAnimation {
-                scrollState.scrollTo?(id, .center)
+                $scrollPosition.wrappedValue = ScrollPosition(id: id, anchor: .center)
             }
             flashHighlight(messageId: id)
             anchorMessageId = nil

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+ScrollHandling.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+ScrollHandling.swift
@@ -63,6 +63,7 @@ extension MessageListView {
         scrollState.isPaginationInFlight = true
         let anchorId = scrollState.derivedStateCache.cachedFirstVisibleMessageId
         let taskConversationId = scrollState.currentConversationId
+        let scrollBinding = $scrollPosition
         os_signpost(.event, log: PerfSignposts.log, name: "paginationSentinelFired")
         scrollState.paginationTask = Task { [scrollState] in
             defer {
@@ -78,53 +79,15 @@ extension MessageListView {
             }
             let hadMore = await loadPreviousMessagePage?() ?? false
             if hadMore, let id = anchorId {
-                    scrollState.beginStabilization(.pagination)
                     try? await Task.sleep(nanoseconds: 100_000_000)
-                    guard !Task.isCancelled else {
-                        scrollState.endStabilization()
-                        return
-                    }
+                    guard !Task.isCancelled else { return }
                     os_signpost(.event, log: PerfSignposts.log, name: "scrollToRequested", "target=paginationAnchor")
-                    scrollState.performScrollTo(id, anchor: .top)
-                    scrollState.endStabilization()
+                    scrollBinding.wrappedValue = ScrollPosition(id: id, anchor: .top)
             }
         }
     }
 
     // MARK: - Scroll helpers
-
-    /// Restores scroll-to-bottom after a conversation load or app restart.
-    /// Issues a delayed fallback pin that catches cases where the declarative
-    /// `ScrollPosition(edge: .bottom)` hasn't fully resolved for the new content.
-    /// The `isAtBottom` guard is intentionally omitted: during a conversation
-    /// switch, `isAtBottom` is unreliable because scroll geometry hasn't updated
-    /// yet for the new content. An extra pin when already at bottom is a no-op.
-    func restoreScrollToBottom() {
-        scrollState.scrollRestoreTask?.cancel()
-        scrollState.scrollRestoreTask = Task { @MainActor [scrollState] in
-            try? await Task.sleep(nanoseconds: 100_000_000)
-            guard !Task.isCancelled else { return }
-            if anchorMessageId == nil,
-               case .freeBrowsing = scrollState.mode {
-                // User scrolled away during the restore window — respect that.
-            } else if anchorMessageId == nil,
-                      case .programmaticScroll = scrollState.mode {
-                // A deep-link anchor scroll resolved and cleared anchorMessageId
-                // before this task fired. Don't yank the viewport back to bottom.
-            } else if anchorMessageId == nil,
-                      case .stabilizing = scrollState.mode {
-                // A resize or expansion stabilization started during the
-                // restore window. Overriding with .followingBottom would
-                // leak activeStabilizationCount — endStabilization() checks
-                // `guard case .stabilizing = mode` and bails if mode changed.
-            } else if anchorMessageId == nil {
-                os_signpost(.event, log: PerfSignposts.log, name: "scrollRestoreStage", "stage=fallback")
-                scrollState.transition(to: .followingBottom)
-                scrollState.requestPinToBottom()
-            }
-            scrollState.scrollRestoreTask = nil
-        }
-    }
 
     /// Flash-highlights a message and schedules auto-dismiss after 1.5 seconds.
     func flashHighlight(messageId: UUID) {
@@ -142,56 +105,4 @@ extension MessageListView {
         }
     }
 
-    /// Configures scroll action closures on the scroll state so it can
-    /// perform programmatic scrolls via the view-owned ScrollPosition.
-    func configureScrollCallbacks() {
-        let binding = $scrollPosition
-        // Replace the entire ScrollPosition value instead of calling the
-        // mutating `.scrollTo(id:anchor:)` method. Value replacement
-        // forces SwiftUI to process a fresh scroll command every time.
-        // The `.scrollTo()` method can be silently deduped when the
-        // position was previously set to the same ID (e.g. from a
-        // conversation switch `ScrollPosition(id: lastId, .bottom)`) —
-        // even after the user has scrolled away, the internal state may
-        // still consider itself "at" that ID.
-        scrollState.scrollTo = { id, anchor in
-            if let uuidId = id as? UUID {
-                binding.wrappedValue = ScrollPosition(id: uuidId, anchor: anchor)
-            } else if let stringId = id as? String {
-                binding.wrappedValue = ScrollPosition(id: stringId, anchor: anchor)
-            }
-        }
-        // Replace the entire ScrollPosition value (same as the ID-based
-        // closure above) instead of calling the mutating `.scrollTo(edge:)`
-        // method. Value replacement forces SwiftUI to process a fresh
-        // scroll command every time. The mutating method can be silently
-        // deduped when SwiftUI considers the position "already at that
-        // edge" — the same class of bug that affected `.scrollTo(id:)`.
-        // After SwiftUI processes the edge scroll, it updates the binding
-        // to the actual content offset, so the next value replacement
-        // with ScrollPosition(edge:) is always a new value.
-        scrollState.scrollToEdge = { edge in
-            binding.wrappedValue = ScrollPosition(edge: edge)
-        }
-        // Cancel in-flight spring animations on the scroll position.
-        //
-        // SwiftUI's `withAnimation { scrollPosition = ScrollPosition(...) }`
-        // creates a SwiftUI-managed spring animation that does NOT cancel
-        // when the user starts a new scroll gesture — unlike UIKit's
-        // `UIScrollView.setContentOffset(animated:)` which cancels on touch.
-        //
-        // Writing an empty `ScrollPosition()` (no target) with animations
-        // disabled overwrites the animated value, cancelling the spring.
-        // During `.interacting` phase the user's gesture has priority, so
-        // the empty position doesn't move the viewport — it just stops the
-        // animation from fighting the user's drag.
-        scrollState.cancelScrollAnimation = {
-            var transaction = Transaction()
-            transaction.disablesAnimations = true
-            withTransaction(transaction) {
-                binding.wrappedValue = ScrollPosition()
-            }
-        }
-        scrollState.currentConversationId = conversationId
-    }
 }

--- a/clients/macos/vellum-assistantTests/MessageListAnchorPerformanceTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListAnchorPerformanceTests.swift
@@ -78,21 +78,22 @@ final class MessageListAnchorPerformanceTests: XCTestCase {
     ```
     """
 
-    // MARK: - 1. Scroll State Bottom-Detection Rapid-Update Stress Test
+    // MARK: - 1. Scroll State Geometry Rapid-Update Stress Test
 
-    /// Benchmarks setting `isAtBottom` 10,000 times in a tight loop. While
+    /// Benchmarks updating scroll geometry 10,000 times in a tight loop. While
     /// individually trivial (O(1)), this mirrors the per-scroll-frame hot path.
     /// This test detects if any future refactoring adds overhead.
-    func testBottomDetectionRapidUpdateStress() {
+    func testGeometryRapidUpdateStress() {
         let scrollState = MessageListScrollState()
 
         measure(metrics: [XCTClockMetric(), XCTCPUMetric()]) {
             for i in 0..<10_000 {
-                // Simulate scroll position changes: alternate between bottom
-                // anchor and other views to stress isAtBottom updates.
-                // Simulate scroll geometry bottom detection: every 10th
-                // iteration is "at bottom", the rest are not.
-                scrollState.isAtBottom = (i % 10 == 0)
+                // Simulate scroll position changes: alternate between near-bottom
+                // and far-from-bottom to stress geometry updates.
+                scrollState.scrollContentHeight = 5000
+                scrollState.scrollContainerHeight = 800
+                scrollState.lastContentOffsetY = (i % 10 == 0) ? 4200 : CGFloat(i % 3000)
+                scrollState.updateScrollToLatest()
             }
         }
     }


### PR DESCRIPTION
## Summary
- Delete restoreScrollToBottom() (never called)
- Delete configureScrollCallbacks() (migrate anchor callers to direct ScrollPosition)
- Remove SuppressAutoScrollKey environment key (never set)
- Remove dead stub properties/methods from MessageListScrollState
- Clean up reset()/cancelAll() for removed properties

Part of plan: scroll-pr-review-fixes.md (PR 2 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25251" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
