### PR TITLE
docs: add SCROLL_STRATEGY.md — canonical scroll behavior specification

### DIFF
--- a/clients/AGENTS.md
+++ b/clients/AGENTS.md
@@ -297,6 +297,8 @@ References:
 
 ### Architecture: Flat Scroll Coordinator
 
+> **Canonical reference:** See [`clients/macos/SCROLL_STRATEGY.md`](macos/SCROLL_STRATEGY.md) for the full scroll behavior specification, design decisions, and restoration guide. If scroll behavior breaks, use that document as the source of truth.
+
 The scroll system has no mode-based state machine. `MessageListScrollState` (`Features/Chat/MessageListScrollState.swift`) is a lightweight `@Observable @MainActor` class owned by `MessageListView` via `@State`. It tracks CTA visibility and distance-from-bottom — not scroll modes.
 
 **Threads open at top.** `.defaultScrollAnchor(.top, for: .initialOffset)` on the ScrollView positions new and switched conversations at the top. No explicit scroll-to-bottom on conversation switch — SwiftUI handles it via `.id(conversationId)` recreation.

--- a/clients/macos/SCROLL_STRATEGY.md
+++ b/clients/macos/SCROLL_STRATEGY.md
@@ -1,0 +1,247 @@
+# Vellum Chat Scroll Strategy
+
+> **Reference commit:** `2dcb606af` (merged 2026-04-13)
+> **PR:** #25206 — "refactor: remove scroll state machine — replace with flat coordinator"
+>
+> This document captures the exact scroll behavior and architecture that feels right.
+> If scroll behavior breaks due to future changes, use this as the source of truth to restore it.
+
+---
+
+## Design Philosophy
+
+1. **No auto-follow.** The viewport does NOT track streaming content. The user message stays pinned at the top while the assistant response grows below it.
+2. **Scroll to bottom on send.** When the user sends a message, we smoothly scroll to the bottom. The assistant's minHeight container fills the viewport, naturally pinning the user message to the top.
+3. **Simple distance-based CTA.** "Scroll to latest" appears when >400pt from bottom. No modes, no hysteresis, no state machine.
+4. **Threads open at top.** `.defaultScrollAnchor(.top, for: .initialOffset)` — conversations start at the first message, not the last.
+5. **One container for thinking + assistant.** A synthetic placeholder row in the ForEach holds the thinking indicator. When the real assistant message arrives, it replaces the placeholder in the same container — no layout jump.
+
+---
+
+## Architecture Overview
+
+### State: `MessageListScrollState` (flat coordinator)
+
+An `@Observable @MainActor` class with **no modes, no transitions, no recovery**. Just tracks:
+
+- **Geometry:** `scrollContentHeight`, `scrollContainerHeight`, `lastContentOffsetY`, `viewportHeight`
+- **CTA visibility:** `showScrollToLatest` (driven by `distanceFromBottom > 400`)
+- **Send scroll:** `pendingSendScrollMessageId: UUID?` — set when user sends, cleared after scroll fires
+- **Pagination:** `wasPaginationTriggerInRange`, `lastPaginationCompletedAt` (rising-edge + 500ms cooldown)
+- **Deep-link anchor:** `anchorSetTime`, `anchorTimeoutTask`
+- **Scroll indicators:** `scrollIndicatorsHidden` (briefly hidden on conversation switch)
+
+**What does NOT exist:** ScrollMode enum, mode transitions, auto-follow, recovery windows, stabilization, deferred bottom pins, circuit breaker, scroll closures (scrollTo/scrollToEdge/cancelScrollAnimation), configureScrollCallbacks, restoreScrollToBottom, ScrollCoordinator.
+
+### View: `MessageListView`
+
+```
+ScrollView {
+    HStack { Spacer + scrollViewContent + Spacer }
+}
+.defaultScrollAnchor(.top, for: .initialOffset)
+.scrollPosition($scrollPosition)
+.scrollIndicators(scrollState.scrollIndicatorsHidden ? .hidden : .automatic)
+.id(conversationId)
+.overlay(alignment: .bottom) { ScrollToLatestOverlayView }
+```
+
+No `.onScrollPhaseChange`. No `.environment(\.suppressAutoScroll)`. No ScrollCoordinator.
+
+### Content: `MessageListContentView`
+
+ForEach renders both:
+- **Normal message cells** via `MessageCellView`
+- **Thinking placeholder** via `row.isThinkingPlaceholder` (synthetic row from TranscriptProjector)
+
+Both share the same `.if(row.isLatestAssistant ...)` minHeight wrapper — one container, no swap.
+
+---
+
+## The Send-Scroll Flow (Critical Path)
+
+This is the most important interaction. When the user sends a message:
+
+### Step 1: Message appended
+`MessageSendCoordinator` appends the user message to `messages` and calls `flushCoalescedPublish()`. Then sets `isSending = true`.
+
+### Step 2: Detect new message
+`handleMessagesCountChanged()` fires (may fire before or after `handleSendingChanged`).
+
+**Safety net:** If `pendingSendScrollMessageId` is nil and a new user message appeared, set it:
+```swift
+if scrollState.pendingSendScrollMessageId == nil {
+    if let lastUser = paginatedVisibleMessages.last(where: { $0.role == .user }),
+       scrollState.lastMessageId != nil,
+       lastUser.id != scrollState.lastMessageId,
+       paginatedVisibleMessages.last?.id != scrollState.lastMessageId {
+        scrollState.pendingSendScrollMessageId = lastUser.id
+    }
+}
+```
+
+**Also:** `handleSendingChanged()` sets the ID when `isSending` becomes true (unless it's a confirmation resume).
+
+### Step 3: Scroll to bottom (deferred)
+Once the user message is in `paginatedVisibleMessages`:
+```swift
+if scrollState.pendingSendScrollMessageId != nil,
+   paginatedVisibleMessages.contains(where: { $0.id == scrollState.pendingSendScrollMessageId }) {
+    let scrollBinding = $scrollPosition
+    scrollState.pendingSendScrollMessageId = nil
+    Task { @MainActor in
+        withAnimation(VAnimation.standard) {
+            scrollBinding.wrappedValue.scrollTo(edge: .bottom)
+        }
+    }
+}
+```
+
+**Why deferred:** `Task { @MainActor in }` gives SwiftUI one run-loop tick to lay out the new cell in the LazyVStack before the scroll fires. Without this, the scroll targets the old content bottom and the user message appears off-screen.
+
+**Why `.scrollTo(edge: .bottom)`:** The imperative method animates correctly. Value replacement (`ScrollPosition(edge: .bottom)`) doesn't animate.
+
+**Why `VAnimation.standard`:** 0.25s easeInOut. Fast enough to feel responsive, slow enough to be smooth.
+
+### Step 4: MinHeight pins user message to top
+The thinking placeholder (or assistant message) has a minHeight wrapper:
+```swift
+.frame(minHeight: turnMinHeight, alignment: .top)
+```
+This fills the viewport below the user message, so after scroll-to-bottom the user message naturally sits at the top.
+
+---
+
+## MinHeight Calculation (Critical)
+
+```swift
+let estimatedUserHeight = min(NSString.boundingRect(text) + 100, 260)
+let composerHeight: CGFloat = 80        // static — composer is empty after send
+let layoutPadding = VSpacing.md * 3 + 1 // top + bottom + inter-item + anchor
+let turnMinHeight = containerHeight - composerHeight - estimatedUserHeight - layoutPadding
+```
+
+### Key decisions:
+- **Uses `containerHeight`** (full chat pane from GeometryReader), NOT `scrollState.viewportHeight`. The viewport height fluctuates when the composer resizes — the container height is stable.
+- **Composer is static 80pt.** We only care about the composer height when it's empty (after the user hits send). It grows when typing, but by then minHeight doesn't matter.
+- **User message estimated via `NSString.boundingRect`** for word-wrap accuracy. Cell overhead is 100pt (bubble padding 24 + timestamp 24 + spacing 12 + show more button 30 + gradient 10). Capped at 260pt (collapse threshold + overhead).
+- **MinHeight applies when `row.isLatestAssistant && row.message.id == state.rows.last?.message.id`.** No `isActiveTurn` gate — the minHeight persists after streaming ends so the viewport doesn't jump.
+
+---
+
+## Thinking Placeholder (Prevents Layout Jump)
+
+`TranscriptProjector` appends a synthetic row when `shouldShowThinkingIndicator` is true:
+
+```swift
+private static let thinkingPlaceholderId = UUID(uuidString: "00000000-0000-0000-0000-FFFFFFFFFFFF")!
+
+if shouldShowThinkingIndicator {
+    let placeholderMessage = ChatMessage(id: Self.thinkingPlaceholderId, role: .assistant, text: "")
+    let placeholder = TranscriptRowModel(..., isLatestAssistant: true, isThinkingPlaceholder: true)
+    rows.append(placeholder)
+}
+```
+
+**Why stable UUID:** ForEach uses `row.id` (which is `message.id`) for view identity. A new UUID every frame would cause layout thrashing.
+
+**Why a placeholder:** Before this, the thinking indicator was a standalone section outside the ForEach. When the assistant message appeared inside the ForEach, SwiftUI destroyed one container and created another — different spacing, different chrome, different content height. The swap caused a visible layout shift. With the placeholder, the thinking indicator renders inside the same ForEach row that will later hold the assistant message.
+
+---
+
+## Scroll-to-Latest CTA
+
+```swift
+// In MessageListScrollState:
+func updateScrollToLatest() {
+    let shouldShow = distanceFromBottom > 400
+    if showScrollToLatest != shouldShow {
+        showScrollToLatest = shouldShow
+    }
+}
+
+func dismissScrollToLatest() {
+    showScrollToLatest = false
+}
+```
+
+Button tap:
+```swift
+withAnimation(VAnimation.spring) {
+    scrollState.dismissScrollToLatest()
+    onScrollToBottom()  // → scrollPosition = ScrollPosition(edge: .bottom)
+}
+```
+
+**Why `dismissScrollToLatest()` inside the animation block:** So the exit transition (`.move(edge: .bottom).combined(with: .opacity)`) animates in sync with the scroll.
+
+**Why value replacement for CTA but imperative for send-scroll:** The CTA doesn't need animation (spring handles it). Send-scroll needs `VAnimation.standard` which works with the imperative `.scrollTo(edge:)` method.
+
+---
+
+## Conversation Switching
+
+```swift
+.id(conversationId)                                    // Destroys + recreates ScrollView
+.defaultScrollAnchor(.top, for: .initialOffset)        // New view starts at top
+```
+
+`handleAppear()` detects the switch via `scrollState.currentConversationId` comparison, calls `handleConversationSwitched()` which:
+1. Cancels queued geometry callbacks (`ScrollGeometryUpdateDispatcher.shared.cancel`)
+2. Resets all scroll state (`scrollState.reset(for:)`)
+3. Seeds `lastMessageId`
+4. Does NOT write to `scrollPosition` — `.defaultScrollAnchor(.top)` handles positioning
+
+**No explicit scroll on switch.** The `.id()` recreation + `.defaultScrollAnchor` is sufficient.
+
+---
+
+## User Message Collapse (Prevents First-Frame Flash)
+
+Long user messages collapse at 150pt. The collapse decision uses `NSString.boundingRect` on the first frame (before `onGeometryChange` fires) to avoid a full-height flash:
+
+```swift
+let isCollapsible = userMessageIntrinsicHeight > 0
+    ? userMessageIntrinsicHeight > userMessageMaxCollapsedHeight
+    : estimatedTextExceedsCollapseThreshold  // NSString.boundingRect estimate
+```
+
+Collapsed messages have:
+- Gradient fade overlay (transparent → `VColor.surfaceLift`)
+- "Show more" button using `VButton(style: .ghost, size: .compact, tintColor: .contentTertiary)`, left-aligned
+- Button is inside the bubble container (rounded corners, surfaceLift background)
+
+---
+
+## What NOT To Add Back
+
+These were removed for a reason. Do not re-introduce:
+
+| Removed | Why |
+|---------|-----|
+| `ScrollMode` enum / state machine | Caused complex mode transitions, race conditions, and recovery loops |
+| Auto-follow during streaming | Fought with user scroll, caused flickering and snap-backs |
+| `ScrollCoordinator` | Added indirection without value — all decisions are simpler inline |
+| `restoreScrollToBottom()` | Recovery-based scrolling was unreliable and caused jarring jumps |
+| `configureScrollCallbacks()` | Scroll closures on state object; direct `ScrollPosition` access is simpler |
+| `suppressAutoScroll` environment | Was for suppressing auto-follow which no longer exists |
+| Recovery windows / deadlines | Complex timer-based scroll correction; the flat model doesn't need it |
+| Stabilization / circuit breaker | Protected against layout storms from mode transitions; no modes = no storms |
+| `isAtBottom` hysteresis | Asymmetric thresholds to prevent oscillation; distance CTA is simpler |
+| `.defaultScrollAnchor(.bottom)` | Conversations should open at top, not bottom |
+
+---
+
+## Files That Own Scroll Behavior
+
+| File | Responsibility |
+|------|---------------|
+| `MessageListScrollState.swift` | Flat coordinator — geometry, CTA, pagination, anchor state |
+| `MessageListView.swift` | ScrollView setup — position binding, anchor, indicators, overlay |
+| `MessageListView+ScrollHandling.swift` | Geometry handler — updates state, triggers pagination |
+| `MessageListView+Lifecycle.swift` | Send detection, scroll-to-bottom, conversation switch, anchor resolution |
+| `MessageListContentView.swift` | ForEach rendering, minHeight wrapper, thinking placeholder |
+| `MessageListHelperViews.swift` | ScrollToLatestOverlayView — CTA button |
+| `TranscriptProjector.swift` | Thinking placeholder row injection |
+| `TranscriptRenderModel.swift` | `isThinkingPlaceholder` flag on row model |
+| `ChatBubble.swift` | User message collapse (instant estimate + gradient fade) |


### PR DESCRIPTION
## Summary
- Add `clients/macos/SCROLL_STRATEGY.md` — comprehensive scroll behavior specification
- Reference it from `clients/AGENTS.md` scroll architecture section

The strategy doc captures the exact scroll UX and architecture so it can be restored if future changes break it. Covers:
- Design philosophy (no auto-follow, scroll-to-bottom on send, distance CTA)
- The send-scroll critical path (safety net, deferred scroll, minHeight)
- MinHeight calculation formula (containerHeight - composer - userMessage - padding)
- Thinking placeholder (unified container, stable UUID)
- Conversation switching behavior
- User message collapse (instant estimate, gradient fade)
- "What NOT to add back" table

## Test plan
- [ ] Docs only — no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25254" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
