### PR TITLE
feat(home): expose /v1/home/state route and relationship_state_updated SSE event [JARVIS-470]

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -4081,6 +4081,124 @@ paths:
           schema:
             type: integer
           description: Max runs to return (default 20)
+  /v1/home/state:
+    get:
+      operationId: home_state_get
+      summary: Get relationship state
+      description:
+        Return the current `RelationshipState` snapshot. Reads the persisted `relationship-state.json` when
+        present; falls back to an on-demand compute so fresh installs never see a 404.
+      tags:
+        - home
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  version:
+                    type: number
+                    const: 1
+                  assistantId:
+                    type: string
+                  tier:
+                    anyOf:
+                      - type: number
+                        const: 1
+                      - type: number
+                        const: 2
+                      - type: number
+                        const: 3
+                      - type: number
+                        const: 4
+                  progressPercent:
+                    type: number
+                  facts:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        category:
+                          type: string
+                          enum:
+                            - voice
+                            - world
+                            - priorities
+                        text:
+                          type: string
+                        confidence:
+                          type: string
+                          enum:
+                            - strong
+                            - uncertain
+                        source:
+                          type: string
+                          enum:
+                            - onboarding
+                            - inferred
+                      required:
+                        - id
+                        - category
+                        - text
+                        - confidence
+                        - source
+                      additionalProperties: false
+                  capabilities:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        name:
+                          type: string
+                        description:
+                          type: string
+                        tier:
+                          type: string
+                          enum:
+                            - unlocked
+                            - next-up
+                            - earned
+                        gate:
+                          type: string
+                        unlockHint:
+                          type: string
+                        ctaLabel:
+                          type: string
+                      required:
+                        - id
+                        - name
+                        - description
+                        - tier
+                        - gate
+                      additionalProperties: false
+                  conversationCount:
+                    type: number
+                  hatchedDate:
+                    type: string
+                  assistantName:
+                    type: string
+                  userName:
+                    type: string
+                  updatedAt:
+                    type: string
+                required:
+                  - version
+                  - assistantId
+                  - tier
+                  - progressPercent
+                  - facts
+                  - capabilities
+                  - conversationCount
+                  - hatchedDate
+                  - assistantName
+                  - updatedAt
+                additionalProperties: false
   /v1/host-bash-result:
     post:
       operationId: hostbashresult_post

--- a/assistant/src/__tests__/home-state-routes.test.ts
+++ b/assistant/src/__tests__/home-state-routes.test.ts
@@ -1,0 +1,126 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Stub the OAuth connection store before importing anything that
+// transitively pulls in the writer — otherwise importing the route
+// module would try to open the real OAuth DB.
+mock.module("../oauth/oauth-store.js", () => ({
+  listConnections: () => [],
+}));
+
+const { handleGetHomeState, homeStateRouteDefinitions } =
+  await import("../runtime/routes/home-state-routes.js");
+const { writeRelationshipState, getRelationshipStatePath } =
+  await import("../home/relationship-state-writer.js");
+
+interface RelationshipStateWire {
+  version: number;
+  assistantId: string;
+  tier: number;
+  progressPercent: number;
+  facts: unknown[];
+  capabilities: Array<{ id: string; tier: string }>;
+  conversationCount: number;
+  hatchedDate: string;
+  assistantName: string;
+  userName?: string;
+  updatedAt: string;
+}
+
+let workspaceDir: string;
+let origWorkspaceDir: string | undefined;
+
+beforeEach(() => {
+  workspaceDir = mkdtempSync(join(tmpdir(), "vellum-hsr-"));
+  origWorkspaceDir = process.env.VELLUM_WORKSPACE_DIR;
+  process.env.VELLUM_WORKSPACE_DIR = workspaceDir;
+});
+
+afterEach(() => {
+  if (origWorkspaceDir === undefined) {
+    delete process.env.VELLUM_WORKSPACE_DIR;
+  } else {
+    process.env.VELLUM_WORKSPACE_DIR = origWorkspaceDir;
+  }
+  try {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  } catch {
+    // best-effort cleanup
+  }
+});
+
+describe("home-state-routes", () => {
+  describe("route registration", () => {
+    test("exposes GET /v1/home/state", () => {
+      const routes = homeStateRouteDefinitions();
+      expect(routes).toHaveLength(1);
+      expect(routes[0].endpoint).toBe("home/state");
+      expect(routes[0].method).toBe("GET");
+    });
+  });
+
+  describe("handleGetHomeState", () => {
+    test("returns persisted state when the JSON file exists", async () => {
+      // Seed a minimal USER.md so the writer produces a non-empty
+      // state, then let the writer persist it.
+      mkdirSync(workspaceDir, { recursive: true });
+      writeFileSync(
+        join(workspaceDir, "USER.md"),
+        "- Preferred name: Casey\n- Work role: Engineer\n",
+        "utf-8",
+      );
+      await writeRelationshipState();
+      expect(existsSync(getRelationshipStatePath())).toBe(true);
+
+      const res = await handleGetHomeState();
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as RelationshipStateWire;
+      expect(body.version).toBe(1);
+      expect(body.assistantId).toBe("default");
+      expect(body.capabilities).toHaveLength(6);
+      expect(body.userName).toBe("Casey");
+      expect(typeof body.updatedAt).toBe("string");
+      expect(Number.isNaN(Date.parse(body.updatedAt))).toBe(false);
+    });
+
+    test("read-through fallback when the file is missing", async () => {
+      // Do NOT call the writer — the file should not exist. The
+      // route must still succeed via computeRelationshipState().
+      expect(existsSync(getRelationshipStatePath())).toBe(false);
+
+      const res = await handleGetHomeState();
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as RelationshipStateWire;
+      expect(body.version).toBe(1);
+      expect(body.tier).toBe(1);
+      expect(body.progressPercent).toBe(0);
+      expect(body.capabilities).toHaveLength(6);
+      expect(body.conversationCount).toBe(0);
+
+      // Fallback must NOT write the file — that's the writer's job.
+      expect(existsSync(getRelationshipStatePath())).toBe(false);
+    });
+
+    test("falls back to compute when the persisted file is malformed", async () => {
+      // Write a deliberately broken file at the state path.
+      const path = getRelationshipStatePath();
+      mkdirSync(join(path, ".."), { recursive: true });
+      writeFileSync(path, "this is not json", "utf-8");
+
+      const res = await handleGetHomeState();
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as RelationshipStateWire;
+      // Parsed body is a fresh compute, not the garbage on disk.
+      expect(body.version).toBe(1);
+      expect(body.capabilities).toHaveLength(6);
+    });
+  });
+});

--- a/assistant/src/daemon/message-protocol.ts
+++ b/assistant/src/daemon/message-protocol.ts
@@ -22,6 +22,7 @@ export * from "./message-types/conversations.js";
 export * from "./message-types/diagnostics.js";
 export * from "./message-types/documents.js";
 export * from "./message-types/guardian-actions.js";
+export * from "./message-types/home.js";
 export * from "./message-types/host-bash.js";
 export * from "./message-types/host-browser.js";
 export * from "./message-types/host-cu.js";
@@ -77,6 +78,7 @@ import type {
   _GuardianActionsClientMessages,
   _GuardianActionsServerMessages,
 } from "./message-types/guardian-actions.js";
+import type { _HomeServerMessages } from "./message-types/home.js";
 import type { _HostBashServerMessages } from "./message-types/host-bash.js";
 import type {
   _HostBrowserClientMessages,
@@ -191,6 +193,7 @@ export type ServerMessage =
   | _SubagentsServerMessages
   | _DocumentsServerMessages
   | _GuardianActionsServerMessages
+  | _HomeServerMessages
   | _HostBashServerMessages
   | _HostBrowserServerMessages
   | _HostCuServerMessages

--- a/assistant/src/daemon/message-types/home.ts
+++ b/assistant/src/daemon/message-types/home.ts
@@ -1,0 +1,24 @@
+/**
+ * Home — server → client push messages for the macOS Home page.
+ *
+ * These messages are fire-and-forget notifications; the client reacts
+ * by refetching the authoritative state from the HTTP route
+ * (`GET /v1/home/state`). Payloads stay deliberately tiny — they carry
+ * just enough metadata to invalidate a cache and trigger a refetch.
+ */
+
+/**
+ * Broadcast after the daemon successfully writes a fresh
+ * `relationship-state.json` snapshot to disk. Subscribers should
+ * refetch `GET /v1/home/state` to read the new state.
+ *
+ * Only emitted on the success branch of the writer — if the
+ * underlying `writeFileSync` throws, this event is NOT published.
+ */
+export interface RelationshipStateUpdated {
+  type: "relationship_state_updated";
+  /** ISO-8601 timestamp of the newly-written state's `updatedAt` field. */
+  updatedAt: string;
+}
+
+export type _HomeServerMessages = RelationshipStateUpdated;

--- a/assistant/src/home/relationship-state-writer.ts
+++ b/assistant/src/home/relationship-state-writer.ts
@@ -28,6 +28,9 @@ import { join } from "node:path";
 
 import { listConnections } from "../oauth/oauth-store.js";
 import { resolveGuardianPersonaPath } from "../prompts/persona-resolver.js";
+import { buildAssistantEvent } from "../runtime/assistant-event.js";
+import { assistantEventHub } from "../runtime/assistant-event-hub.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { getLogger } from "../util/logger.js";
 import {
   getConversationsDir,
@@ -135,11 +138,17 @@ export async function computeRelationshipState(): Promise<RelationshipState> {
  * this without additional try/catch wrapping.
  */
 export async function writeRelationshipState(): Promise<void> {
+  let writtenState: RelationshipState | undefined;
   try {
     const state = await computeRelationshipState();
     const path = getRelationshipStatePath();
     mkdirSync(getDataDir(), { recursive: true });
     writeFileSync(path, JSON.stringify(state, null, 2), "utf8");
+    // Only mark the state as "written" AFTER the sync write has
+    // succeeded — any throw from `writeFileSync` short-circuits the
+    // SSE emit below so subscribers never see a stale update event
+    // that contradicts on-disk state.
+    writtenState = state;
     log.info(
       {
         path,
@@ -152,6 +161,33 @@ export async function writeRelationshipState(): Promise<void> {
   } catch (err) {
     log.warn({ err }, "Failed to write relationship-state.json");
   }
+
+  // SSE fanout lives outside the try/catch so a publish failure does
+  // not get mis-logged as a write failure. Still guarded against the
+  // publish throwing (e.g. a subscriber rejects) — the writer promise
+  // must never reject from this path.
+  if (writtenState) {
+    publishRelationshipStateUpdated(writtenState.updatedAt);
+  }
+}
+
+/**
+ * Publish the `relationship_state_updated` event to the in-process
+ * assistant event hub. Called only on the success branch of
+ * `writeRelationshipState()` so the event accurately reflects what
+ * just landed on disk.
+ */
+function publishRelationshipStateUpdated(updatedAt: string): void {
+  assistantEventHub
+    .publish(
+      buildAssistantEvent(DAEMON_INTERNAL_ASSISTANT_ID, {
+        type: "relationship_state_updated",
+        updatedAt,
+      }),
+    )
+    .catch((err) => {
+      log.warn({ err }, "Failed to publish relationship_state_updated event");
+    });
 }
 
 // ─── Internal helpers ───────────────────────────────────────────────────

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -181,6 +181,7 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   // Settings / integrations / identity
   { endpoint: "identity", scopes: ["settings.read"] },
   { endpoint: "identity/intro", scopes: ["settings.read"] },
+  { endpoint: "home/state", scopes: ["settings.read"] },
   { endpoint: "brain-graph", scopes: ["settings.read"] },
   { endpoint: "brain-graph-ui", scopes: ["settings.read"] },
   { endpoint: "contacts", scopes: ["settings.read"] },

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -164,6 +164,7 @@ import { guardianActionRouteDefinitions } from "./routes/guardian-action-routes.
 import { handleGuardianBootstrap } from "./routes/guardian-bootstrap-routes.js";
 import { handleGuardianRefresh } from "./routes/guardian-refresh-routes.js";
 import { heartbeatRouteDefinitions } from "./routes/heartbeat-routes.js";
+import { homeStateRouteDefinitions } from "./routes/home-state-routes.js";
 import { hostBashRouteDefinitions } from "./routes/host-bash-routes.js";
 import {
   hostBrowserRouteDefinitions,
@@ -1459,6 +1460,7 @@ export class RuntimeHttpServer {
       ...heartbeatRouteDefinitions({
         getHeartbeatService: this.getHeartbeatService,
       }),
+      ...homeStateRouteDefinitions(),
       ...notificationRouteDefinitions(),
       ...diagnosticsRouteDefinitions(),
       ...logExportRouteDefinitions(),

--- a/assistant/src/runtime/routes/home-state-routes.ts
+++ b/assistant/src/runtime/routes/home-state-routes.ts
@@ -1,0 +1,124 @@
+/**
+ * Home state HTTP routes.
+ *
+ * Exposes `GET /v1/home/state` so macOS (and other) clients can fetch
+ * the current `RelationshipState` snapshot. The normal path reads
+ * the JSON file produced by `writeRelationshipState()`; if that file
+ * is missing — e.g. on a fresh install before the writer has landed
+ * its first snapshot — the handler falls back to computing the
+ * state on-demand so the client never sees a 404 and the UI can
+ * always render.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+
+import { z } from "zod";
+
+import type { RelationshipState } from "../../home/relationship-state.js";
+import {
+  computeRelationshipState,
+  getRelationshipStatePath,
+} from "../../home/relationship-state-writer.js";
+import { getLogger } from "../../util/logger.js";
+import { httpError } from "../http-errors.js";
+import type { RouteDefinition } from "../http-router.js";
+
+const log = getLogger("home-state-routes");
+
+/**
+ * Handle `GET /v1/home/state`.
+ *
+ * Returns the persisted `relationship-state.json` when present; on a
+ * cache miss (missing file OR unreadable / malformed JSON) falls back
+ * to `computeRelationshipState()` so callers always get a valid
+ * response shape. The read-through fallback deliberately does NOT
+ * write a fresh snapshot to disk — the daemon's conversation-complete
+ * hook owns writes so progress updates stay batched to real state
+ * transitions rather than opportunistic GETs.
+ */
+export async function handleGetHomeState(): Promise<Response> {
+  const path = getRelationshipStatePath();
+
+  if (existsSync(path)) {
+    try {
+      const raw = readFileSync(path, "utf-8");
+      // Validate JSON by parsing; we re-emit the same bytes so the
+      // client sees byte-identical content to what is on disk.
+      const parsed = JSON.parse(raw) as RelationshipState;
+      return Response.json(parsed);
+    } catch (err) {
+      log.warn(
+        { err, path },
+        "Failed to read persisted relationship-state.json; falling back to live compute",
+      );
+      // Fall through to the compute path.
+    }
+  }
+
+  try {
+    const state = await computeRelationshipState();
+    return Response.json(state);
+  } catch (err) {
+    log.warn({ err }, "Failed to compute relationship state on-demand");
+    return httpError(
+      "INTERNAL_ERROR",
+      "Failed to compute relationship state",
+      500,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Response schema (shared with the OpenAPI generator)
+// ---------------------------------------------------------------------------
+
+const factSchema = z.object({
+  id: z.string(),
+  category: z.enum(["voice", "world", "priorities"]),
+  text: z.string(),
+  confidence: z.enum(["strong", "uncertain"]),
+  source: z.enum(["onboarding", "inferred"]),
+});
+
+const capabilitySchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string(),
+  tier: z.enum(["unlocked", "next-up", "earned"]),
+  gate: z.string(),
+  unlockHint: z.string().optional(),
+  ctaLabel: z.string().optional(),
+});
+
+const relationshipStateSchema = z.object({
+  version: z.literal(1),
+  assistantId: z.string(),
+  tier: z.union([z.literal(1), z.literal(2), z.literal(3), z.literal(4)]),
+  progressPercent: z.number(),
+  facts: z.array(factSchema),
+  capabilities: z.array(capabilitySchema),
+  conversationCount: z.number(),
+  hatchedDate: z.string(),
+  assistantName: z.string(),
+  userName: z.string().optional(),
+  updatedAt: z.string(),
+});
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+export function homeStateRouteDefinitions(): RouteDefinition[] {
+  return [
+    {
+      endpoint: "home/state",
+      method: "GET",
+      handler: () => handleGetHomeState(),
+      summary: "Get relationship state",
+      description:
+        "Return the current `RelationshipState` snapshot. Reads the persisted `relationship-state.json` when present; falls back to an on-demand compute so fresh installs never see a 404.",
+      tags: ["home"],
+      responseBody: relationshipStateSchema,
+    },
+  ];
+}

--- a/assistant/src/runtime/routes/home-state-routes.ts
+++ b/assistant/src/runtime/routes/home-state-routes.ts
@@ -14,7 +14,6 @@ import { existsSync, readFileSync } from "node:fs";
 
 import { z } from "zod";
 
-import type { RelationshipState } from "../../home/relationship-state.js";
 import {
   computeRelationshipState,
   getRelationshipStatePath,
@@ -25,51 +24,8 @@ import type { RouteDefinition } from "../http-router.js";
 
 const log = getLogger("home-state-routes");
 
-/**
- * Handle `GET /v1/home/state`.
- *
- * Returns the persisted `relationship-state.json` when present; on a
- * cache miss (missing file OR unreadable / malformed JSON) falls back
- * to `computeRelationshipState()` so callers always get a valid
- * response shape. The read-through fallback deliberately does NOT
- * write a fresh snapshot to disk — the daemon's conversation-complete
- * hook owns writes so progress updates stay batched to real state
- * transitions rather than opportunistic GETs.
- */
-export async function handleGetHomeState(): Promise<Response> {
-  const path = getRelationshipStatePath();
-
-  if (existsSync(path)) {
-    try {
-      const raw = readFileSync(path, "utf-8");
-      // Validate JSON by parsing; we re-emit the same bytes so the
-      // client sees byte-identical content to what is on disk.
-      const parsed = JSON.parse(raw) as RelationshipState;
-      return Response.json(parsed);
-    } catch (err) {
-      log.warn(
-        { err, path },
-        "Failed to read persisted relationship-state.json; falling back to live compute",
-      );
-      // Fall through to the compute path.
-    }
-  }
-
-  try {
-    const state = await computeRelationshipState();
-    return Response.json(state);
-  } catch (err) {
-    log.warn({ err }, "Failed to compute relationship state on-demand");
-    return httpError(
-      "INTERNAL_ERROR",
-      "Failed to compute relationship state",
-      500,
-    );
-  }
-}
-
 // ---------------------------------------------------------------------------
-// Response schema (shared with the OpenAPI generator)
+// Response schema (shared with the OpenAPI generator and runtime validation)
 // ---------------------------------------------------------------------------
 
 const factSchema = z.object({
@@ -103,6 +59,59 @@ const relationshipStateSchema = z.object({
   userName: z.string().optional(),
   updatedAt: z.string(),
 });
+
+/**
+ * Handle `GET /v1/home/state`.
+ *
+ * Returns the persisted `relationship-state.json` when present; on a
+ * cache miss (missing file, unreadable JSON, OR structurally-invalid
+ * shape) falls back to `computeRelationshipState()` so callers always
+ * get a valid response shape that matches `relationshipStateSchema`.
+ * The read-through fallback deliberately does NOT write a fresh
+ * snapshot to disk — the daemon's conversation-complete hook owns
+ * writes so progress updates stay batched to real state transitions
+ * rather than opportunistic GETs.
+ */
+export async function handleGetHomeState(): Promise<Response> {
+  const path = getRelationshipStatePath();
+
+  if (existsSync(path)) {
+    try {
+      const raw = readFileSync(path, "utf-8");
+      const parsed: unknown = JSON.parse(raw);
+      // Validate shape, not just JSON syntax. A stale or partial file
+      // (e.g. from a pre-v1 snapshot or a truncated write) must NOT be
+      // served to the client — fall through to compute instead so
+      // strict client decoders don't choke.
+      const validated = relationshipStateSchema.safeParse(parsed);
+      if (validated.success) {
+        return Response.json(validated.data);
+      }
+      log.warn(
+        { path, issues: validated.error.issues },
+        "Persisted relationship-state.json failed schema validation; falling back to live compute",
+      );
+    } catch (err) {
+      log.warn(
+        { err, path },
+        "Failed to read persisted relationship-state.json; falling back to live compute",
+      );
+      // Fall through to the compute path.
+    }
+  }
+
+  try {
+    const state = await computeRelationshipState();
+    return Response.json(state);
+  } catch (err) {
+    log.warn({ err }, "Failed to compute relationship state on-demand");
+    return httpError(
+      "INTERNAL_ERROR",
+      "Failed to compute relationship state",
+      500,
+    );
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Route definitions

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -2400,11 +2400,18 @@ public enum ServerMessage: Decodable, Sendable {
     case serviceGroupUpdateProgress(ServiceGroupUpdateProgressMessage)
     case serviceGroupUpdateComplete(ServiceGroupUpdateCompleteMessage)
     case conversationIdResolved(localId: String, serverId: String)
+    case relationshipStateUpdated(updatedAt: String)
     case pong
     case unknown(String)
 
     private enum CodingKeys: String, CodingKey {
         case type
+    }
+
+    /// Keys for hand-decoded inline payload cases that don't wrap a
+    /// codegen'd struct (e.g. `relationshipStateUpdated`).
+    private enum InlinePayloadKeys: String, CodingKey {
+        case updatedAt
     }
 
     public init(from decoder: Decoder) throws {
@@ -2872,6 +2879,10 @@ public enum ServerMessage: Decodable, Sendable {
         case "service_group_update_complete":
             let message = try ServiceGroupUpdateCompleteMessage(from: decoder)
             self = .serviceGroupUpdateComplete(message)
+        case "relationship_state_updated":
+            let payloadContainer = try decoder.container(keyedBy: InlinePayloadKeys.self)
+            let updatedAt = try payloadContainer.decode(String.self, forKey: .updatedAt)
+            self = .relationshipStateUpdated(updatedAt: updatedAt)
         case "pong":
             self = .pong
         default:


### PR DESCRIPTION
## Summary

- Add `GET /v1/home/state` route that reads the persisted `relationship-state.json` when present and falls back to a read-through `computeRelationshipState()` on miss (and on malformed-JSON) so fresh installs never see a 404.
- `writeRelationshipState()` now emits a `relationship_state_updated` assistant-event-hub event on the success branch only — if `writeFileSync` throws, no event is published.
- Swift `ServerMessage` enum gains a `relationshipStateUpdated(updatedAt: String)` case with an inline decoder branch keyed on the `"relationship_state_updated"` wire type.

## Test plan

- [x] `bun test assistant/src/__tests__/home-state-routes.test.ts` (4 pass)
- [x] `bun test assistant/src/home/__tests__/relationship-state-writer.test.ts` (16 pass, writer still swallows all errors)
- [x] `bunx tsc --noEmit` clean
- [x] `bunx eslint` clean on touched files
- [x] `swift build` clean (after clearing `.build/ModuleCache` once per the documented cross-worktree collision)

Ticket: [JARVIS-470](https://linear.app/vellum/issue/JARVIS-470)
Part of plan: phase-3-backend.md (PR 3 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25257" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
