### PR TITLE
fix(macos): reverse typing indicator dot wave to left-to-right

### DIFF
--- a/clients/shared/Features/Chat/TypingIndicatorView.swift
+++ b/clients/shared/Features/Chat/TypingIndicatorView.swift
@@ -49,7 +49,7 @@ public struct TypingIndicatorView: View {
 
         return HStack(spacing: dotSpacing) {
             ForEach(0..<3, id: \.self) { index in
-                let offset = Double(index) * (2.0 * .pi / 3.0)
+                let offset = -Double(index) * (2.0 * .pi / 3.0)
                 let wave = (sin(phase + offset) + 1.0) / 2.0
 
                 Circle()


### PR DESCRIPTION
## Summary
- Negate the sine-wave phase offset in `TypingIndicatorView` so dot 0 (leftmost) peaks first, producing a left-to-right wave direction
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25259" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
