### PR TITLE
fix(home): address round-2 polish findings [JARVIS-470]

### DIFF
--- a/assistant/src/__tests__/home-state-routes.test.ts
+++ b/assistant/src/__tests__/home-state-routes.test.ts
@@ -16,6 +16,13 @@ mock.module("../oauth/oauth-store.js", () => ({
   listConnections: () => [],
 }));
 
+// Stub the DB-authoritative conversation count helper so the writer
+// (invoked by the read-through fallback) does not lazy-open a real
+// sqlite handle against a stale or deleted per-test tmpdir.
+mock.module("../memory/conversation-queries.js", () => ({
+  countConversations: () => 0,
+}));
+
 const { handleGetHomeState, homeStateRouteDefinitions } =
   await import("../runtime/routes/home-state-routes.js");
 const { writeRelationshipState, getRelationshipStatePath } =

--- a/assistant/src/home/__tests__/relationship-state-writer.test.ts
+++ b/assistant/src/home/__tests__/relationship-state-writer.test.ts
@@ -88,9 +88,10 @@ function writeFile(relPath: string, content: string): void {
 }
 
 function seedConversations(count: number): void {
-  // Drives the mocked DB-authoritative `countConversations` helper
-  // rather than writing files — after the Gap A fix the writer no
-  // longer touches the filesystem for conversation counts.
+  // Drives the mocked DB-authoritative `countConversations` helper.
+  // The writer reads conversation counts from the DB rather than the
+  // filesystem, so tests push counts in here rather than seeding a
+  // conversations directory.
   fakeConversationCount = count;
 }
 
@@ -195,6 +196,24 @@ describe("relationship-state-writer", () => {
       }
     });
 
+    test("userName prefers 'Preferred name/reference' over 'Preferred pronouns'", async () => {
+      // A user who reorders the default guardian template bullets
+      // must never see their pronouns surface as their display name
+      // on the Home page. `parseUserName` only accepts labels whose
+      // lowercased form starts with `preferred name` (plus the
+      // stricter `name` / `user` / `user name` forms).
+      writeFile(
+        "USER.md",
+        [
+          "- Preferred pronouns: she/her",
+          "- Preferred name/reference: Casey",
+        ].join("\n"),
+      );
+
+      const state = (await computeRelationshipState()) as RelationshipStateLike;
+      expect(state.userName).toBe("Casey");
+    });
+
     test("falls back to legacy workspace USER.md when persona resolver yields nothing", async () => {
       // In the test environment there is no guardian contact in the DB, so
       // `resolveGuardianPersonaPath()` either returns null or throws — the
@@ -216,11 +235,9 @@ describe("relationship-state-writer", () => {
     });
 
     test("ignores stray filesystem files (e.g. .DS_Store) in conversations dir", async () => {
-      // Regression guard for Gap A: pre-fix, `countConversations` did
-      // `readdirSync(dir).length`, which included `.DS_Store` and
-      // double-counted legacy/canonical directory pairs during
-      // workspace migration 009. After the fix, the count comes from
-      // the DB, so filesystem noise is invisible by construction.
+      // The DB-authoritative `countConversations` is immune to stray
+      // filesystem entries (.DS_Store, migration artifacts, duplicate
+      // legacy/canonical directory forms) — only DB rows count.
       const dir = join(workspaceDir, "conversations");
       mkdirSync(dir, { recursive: true });
       writeFileSync(join(dir, ".DS_Store"), "junk", "utf-8");
@@ -375,11 +392,10 @@ describe("relationship-state-writer", () => {
 
   describe("hatchedDate stability", () => {
     test("is stable across multiple writes when IDENTITY.md has no explicit hatched bullet", async () => {
-      // Regression guard: `parseIdentity` used to default `hatchedDate`
-      // to `new Date().toISOString()` on every call, so because the
-      // writer runs on every turn boundary the persisted "relationship
-      // start" timestamp drifted forward on every write. It must now
-      // come from IDENTITY.md file birthtime, which is stable.
+      // `hatchedDate` must be stable across writes: when there is no
+      // explicit `Hatched:` bullet, `parseIdentity` derives it from
+      // IDENTITY.md file birthtime, which is monotonic across the
+      // per-turn writer invocations.
       writeFile(
         "IDENTITY.md",
         "- **Name:** Sage\n- **Role:** Assistant\n- **Personality:** Curious\n",
@@ -408,10 +424,9 @@ describe("relationship-state-writer", () => {
     });
 
     test("sidecar fallback: first call with no IDENTITY.md writes and returns a real timestamp", async () => {
-      // Regression guard for Gap E: pre-fix, this path returned the
-      // Unix epoch (`new Date(0)`), which surfaces in the UI as
-      // "1/1/1970". Post-fix, we persist a real `now` timestamp to
-      // `data/hatched.json` and return it.
+      // When no IDENTITY.md exists, the writer persists a real `now`
+      // timestamp to `data/hatched.json` on first use and returns it.
+      // The wire contract never carries a zero/epoch sentinel.
       const state = (await computeRelationshipState()) as RelationshipStateLike;
       const parsed = Date.parse(state.hatchedDate);
       expect(parsed).toBeGreaterThan(0);
@@ -502,11 +517,10 @@ describe("relationship-state-writer", () => {
 
   describe("writeRelationshipState concurrency coalescing (Gap C)", () => {
     test("5 concurrent writes produce a valid on-disk snapshot and are coalesced", async () => {
-      // Regression guard for Gap C: pre-fix, overlapping writes
-      // raced on `writeFileSync` so the persisted file could reflect
-      // an older compute than the latest caller. Post-fix, the
-      // writer serializes and coalesces so at most two writes run
-      // for N overlapping callers (the in-flight + one tail).
+      // The writer serializes and coalesces overlapping calls: at most
+      // two compute+write cycles run for N concurrent callers (the
+      // in-flight write plus one coalesced tail), and the final
+      // on-disk snapshot reflects the latest completed compute.
       writeFile("USER.md", "- Preferred name: Concurrent");
       seedConversations(1);
 

--- a/assistant/src/home/relationship-state-writer.ts
+++ b/assistant/src/home/relationship-state-writer.ts
@@ -76,11 +76,15 @@ export function getRelationshipStatePath(): string {
 }
 
 /**
- * Build a fresh `RelationshipState` from the current on-disk + DB state.
+ * Build a fresh `RelationshipState` snapshot from the current workspace.
+ * Reads USER.md / SOUL.md / IDENTITY.md, queries the oauth connection
+ * store, and counts conversations via the DB-authoritative helper.
  *
- * This is the pure-ish computation half of the writer — it reads files
- * and the oauth store but performs no writes. Callers that want to
- * persist the result should use `writeRelationshipState()` instead.
+ * Side effect: on the very first call when IDENTITY.md cannot provide
+ * a hatched date, `resolveFallbackHatchedDate` persists a one-time
+ * `data/hatched.json` sidecar so subsequent calls return a monotonic
+ * timestamp. All other paths are read-only. Callers that want to
+ * persist the full snapshot should use `writeRelationshipState()`.
  */
 export async function computeRelationshipState(): Promise<RelationshipState> {
   // Persona source-of-truth:
@@ -650,10 +654,9 @@ function parseIdentity(identityPath: string): {
     // File missing or unreadable — fall through to the sidecar.
   }
 
-  // Last-ditch sidecar-backed fallback: `resolveFallbackHatchedDate`
-  // returns a stable, real timestamp (persisted to `data/hatched.json`
-  // on first call) instead of the old epoch sentinel, so the UI never
-  // shows "1/1/1970".
+  // Last-ditch fallback: `resolveFallbackHatchedDate` returns a stable,
+  // real timestamp (persisted to `data/hatched.json` on first call) so
+  // the wire contract always carries a valid ISO date.
   return { assistantName, hatchedDate: resolveFallbackHatchedDate() };
 }
 
@@ -669,10 +672,10 @@ function parseUserName(content: string): string | undefined {
     if (!parsed) continue;
     const lower = parsed.label.toLowerCase();
     if (
-      (lower.startsWith("name") ||
-        lower.startsWith("preferred") ||
-        lower === "user" ||
-        lower === "user name") &&
+      (lower === "user" ||
+        lower === "user name" ||
+        lower.startsWith("preferred name") ||
+        lower.startsWith("name")) &&
       parsed.value
     ) {
       return parsed.value;


### PR DESCRIPTION
## Gap A — Comment hygiene violations

Six comments introduced by the round-1 fix PR (#25258) narrated removed or obsolete behavior in violation of `assistant/AGENTS.md:21`. Rewrote each to describe only the current contract:

- `computeRelationshipState` docstring now accurately notes the one-time `data/hatched.json` sidecar write on first hatched-date fallback instead of claiming the function performs no writes.
- Last-ditch hatched-fallback comment drops the "old epoch sentinel" framing and states the current contract directly.
- Test setup `seedConversations` comment describes the DB-driven flow as the current design rather than narrating a migration.
- `.DS_Store` / stray-file regression test reads as a current-behavior statement: the DB helper is immune to filesystem noise by construction.
- Sidecar-first-call test comment describes the current `hatched.json` write rather than the rejected epoch sentinel.
- Concurrency coalescing test comment states the current coalescing guarantee (at most two cycles for N callers) without a "pre-fix" narrative.

Grep for the forbidden phrases across both touched files returns zero hits.

## Gap B — `parseUserName` over-matches `startsWith("preferred")`

The matcher accepted any label whose lowercased form started with `"preferred"`, so `Preferred pronouns:`, `Preferred contact:`, etc. would surface as the user's display name whenever they appeared before `Preferred name/reference:` in `users/<slug>.md`. Tightened the prefix to `"preferred name"` and added a test that proves `Preferred pronouns: she/her` followed by `Preferred name/reference: Casey` returns `"Casey"`.

## Gap C — `home-state-routes.test.ts` missing `conversation-queries` mock

`handleGetHomeState`'s read-through fallback and the direct `computeRelationshipState` paths invoke `countConversations()` from `conversation-queries`, which lazy-opens a real sqlite handle against `<tmpdir>/data/db/assistant.db`. The drizzle handle is module-cached, so per-test tmpdirs would share a handle bound to a previously-deleted directory. Added a `mock.module("../memory/conversation-queries.js", ...)` stub next to the existing oauth-store stub so the route tests run against an in-memory fake.

Ticket: [JARVIS-470](https://linear.app/vellum/issue/JARVIS-470)

Part of plan: phase-3-backend.md (self-review round 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25260" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
