### PR TITLE
Phase 3 backend — relationship state contract + writer + HTTP route + backfill [JARVIS-470]

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -4081,6 +4081,124 @@ paths:
           schema:
             type: integer
           description: Max runs to return (default 20)
+  /v1/home/state:
+    get:
+      operationId: home_state_get
+      summary: Get relationship state
+      description:
+        Return the current `RelationshipState` snapshot. Reads the persisted `relationship-state.json` when
+        present; falls back to an on-demand compute so fresh installs never see a 404.
+      tags:
+        - home
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  version:
+                    type: number
+                    const: 1
+                  assistantId:
+                    type: string
+                  tier:
+                    anyOf:
+                      - type: number
+                        const: 1
+                      - type: number
+                        const: 2
+                      - type: number
+                        const: 3
+                      - type: number
+                        const: 4
+                  progressPercent:
+                    type: number
+                  facts:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        category:
+                          type: string
+                          enum:
+                            - voice
+                            - world
+                            - priorities
+                        text:
+                          type: string
+                        confidence:
+                          type: string
+                          enum:
+                            - strong
+                            - uncertain
+                        source:
+                          type: string
+                          enum:
+                            - onboarding
+                            - inferred
+                      required:
+                        - id
+                        - category
+                        - text
+                        - confidence
+                        - source
+                      additionalProperties: false
+                  capabilities:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        name:
+                          type: string
+                        description:
+                          type: string
+                        tier:
+                          type: string
+                          enum:
+                            - unlocked
+                            - next-up
+                            - earned
+                        gate:
+                          type: string
+                        unlockHint:
+                          type: string
+                        ctaLabel:
+                          type: string
+                      required:
+                        - id
+                        - name
+                        - description
+                        - tier
+                        - gate
+                      additionalProperties: false
+                  conversationCount:
+                    type: number
+                  hatchedDate:
+                    type: string
+                  assistantName:
+                    type: string
+                  userName:
+                    type: string
+                  updatedAt:
+                    type: string
+                required:
+                  - version
+                  - assistantId
+                  - tier
+                  - progressPercent
+                  - facts
+                  - capabilities
+                  - conversationCount
+                  - hatchedDate
+                  - assistantName
+                  - updatedAt
+                additionalProperties: false
   /v1/host-bash-result:
     post:
       operationId: hostbashresult_post

--- a/assistant/src/__tests__/home-state-routes.test.ts
+++ b/assistant/src/__tests__/home-state-routes.test.ts
@@ -129,5 +129,34 @@ describe("home-state-routes", () => {
       expect(body.version).toBe(1);
       expect(body.capabilities).toHaveLength(6);
     });
+
+    test("GET returns fresh state even when the persisted file is stale", async () => {
+      // Persist a snapshot with userName=Casey.
+      mkdirSync(workspaceDir, { recursive: true });
+      writeFileSync(
+        join(workspaceDir, "USER.md"),
+        "- Preferred name: Casey\n",
+        "utf-8",
+      );
+      await writeRelationshipState();
+      expect(existsSync(getRelationshipStatePath())).toBe(true);
+
+      // Mutate USER.md outside of any turn-boundary writer call. This
+      // simulates: a user editing their persona file, OAuth connecting
+      // a provider, or a conversation delete flow touching state
+      // outside the turn-boundary writer.
+      writeFileSync(
+        join(workspaceDir, "USER.md"),
+        "- Preferred name: Jamie\n",
+        "utf-8",
+      );
+
+      // The route must return the FRESH value (Jamie), not the
+      // cached value (Casey) from the persisted file.
+      const res = await handleGetHomeState();
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as RelationshipStateWire;
+      expect(body.userName).toBe("Jamie");
+    });
   });
 });

--- a/assistant/src/__tests__/home-state-routes.test.ts
+++ b/assistant/src/__tests__/home-state-routes.test.ts
@@ -16,6 +16,13 @@ mock.module("../oauth/oauth-store.js", () => ({
   listConnections: () => [],
 }));
 
+// Stub the DB-authoritative conversation count helper so the writer
+// (invoked by the read-through fallback) does not lazy-open a real
+// sqlite handle against a stale or deleted per-test tmpdir.
+mock.module("../memory/conversation-queries.js", () => ({
+  countConversations: () => 0,
+}));
+
 const { handleGetHomeState, homeStateRouteDefinitions } =
   await import("../runtime/routes/home-state-routes.js");
 const { writeRelationshipState, getRelationshipStatePath } =

--- a/assistant/src/__tests__/home-state-routes.test.ts
+++ b/assistant/src/__tests__/home-state-routes.test.ts
@@ -1,0 +1,126 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Stub the OAuth connection store before importing anything that
+// transitively pulls in the writer — otherwise importing the route
+// module would try to open the real OAuth DB.
+mock.module("../oauth/oauth-store.js", () => ({
+  listConnections: () => [],
+}));
+
+const { handleGetHomeState, homeStateRouteDefinitions } =
+  await import("../runtime/routes/home-state-routes.js");
+const { writeRelationshipState, getRelationshipStatePath } =
+  await import("../home/relationship-state-writer.js");
+
+interface RelationshipStateWire {
+  version: number;
+  assistantId: string;
+  tier: number;
+  progressPercent: number;
+  facts: unknown[];
+  capabilities: Array<{ id: string; tier: string }>;
+  conversationCount: number;
+  hatchedDate: string;
+  assistantName: string;
+  userName?: string;
+  updatedAt: string;
+}
+
+let workspaceDir: string;
+let origWorkspaceDir: string | undefined;
+
+beforeEach(() => {
+  workspaceDir = mkdtempSync(join(tmpdir(), "vellum-hsr-"));
+  origWorkspaceDir = process.env.VELLUM_WORKSPACE_DIR;
+  process.env.VELLUM_WORKSPACE_DIR = workspaceDir;
+});
+
+afterEach(() => {
+  if (origWorkspaceDir === undefined) {
+    delete process.env.VELLUM_WORKSPACE_DIR;
+  } else {
+    process.env.VELLUM_WORKSPACE_DIR = origWorkspaceDir;
+  }
+  try {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  } catch {
+    // best-effort cleanup
+  }
+});
+
+describe("home-state-routes", () => {
+  describe("route registration", () => {
+    test("exposes GET /v1/home/state", () => {
+      const routes = homeStateRouteDefinitions();
+      expect(routes).toHaveLength(1);
+      expect(routes[0].endpoint).toBe("home/state");
+      expect(routes[0].method).toBe("GET");
+    });
+  });
+
+  describe("handleGetHomeState", () => {
+    test("returns persisted state when the JSON file exists", async () => {
+      // Seed a minimal USER.md so the writer produces a non-empty
+      // state, then let the writer persist it.
+      mkdirSync(workspaceDir, { recursive: true });
+      writeFileSync(
+        join(workspaceDir, "USER.md"),
+        "- Preferred name: Casey\n- Work role: Engineer\n",
+        "utf-8",
+      );
+      await writeRelationshipState();
+      expect(existsSync(getRelationshipStatePath())).toBe(true);
+
+      const res = await handleGetHomeState();
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as RelationshipStateWire;
+      expect(body.version).toBe(1);
+      expect(body.assistantId).toBe("default");
+      expect(body.capabilities).toHaveLength(6);
+      expect(body.userName).toBe("Casey");
+      expect(typeof body.updatedAt).toBe("string");
+      expect(Number.isNaN(Date.parse(body.updatedAt))).toBe(false);
+    });
+
+    test("read-through fallback when the file is missing", async () => {
+      // Do NOT call the writer — the file should not exist. The
+      // route must still succeed via computeRelationshipState().
+      expect(existsSync(getRelationshipStatePath())).toBe(false);
+
+      const res = await handleGetHomeState();
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as RelationshipStateWire;
+      expect(body.version).toBe(1);
+      expect(body.tier).toBe(1);
+      expect(body.progressPercent).toBe(0);
+      expect(body.capabilities).toHaveLength(6);
+      expect(body.conversationCount).toBe(0);
+
+      // Fallback must NOT write the file — that's the writer's job.
+      expect(existsSync(getRelationshipStatePath())).toBe(false);
+    });
+
+    test("falls back to compute when the persisted file is malformed", async () => {
+      // Write a deliberately broken file at the state path.
+      const path = getRelationshipStatePath();
+      mkdirSync(join(path, ".."), { recursive: true });
+      writeFileSync(path, "this is not json", "utf-8");
+
+      const res = await handleGetHomeState();
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as RelationshipStateWire;
+      // Parsed body is a fresh compute, not the garbage on disk.
+      expect(body.version).toBe(1);
+      expect(body.capabilities).toHaveLength(6);
+    });
+  });
+});

--- a/assistant/src/__tests__/host-bash-proxy.test.ts
+++ b/assistant/src/__tests__/host-bash-proxy.test.ts
@@ -405,26 +405,21 @@ describe("HostBashProxy", () => {
     function spySignal(source: AbortSignal): Spied {
       const addCalls: string[] = [];
       const removeCalls: string[] = [];
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const s = source as any;
       const origAdd = source.addEventListener.bind(source);
       const origRemove = source.removeEventListener.bind(source);
       s.addEventListener = (
         type: string,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         ...rest: any[]
       ) => {
         addCalls.push(type);
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         return (origAdd as any)(type, ...rest);
       };
       s.removeEventListener = (
         type: string,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         ...rest: any[]
       ) => {
         removeCalls.push(type);
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         return (origRemove as any)(type, ...rest);
       };
       return { signal: source, addCalls, removeCalls };

--- a/assistant/src/__tests__/host-cu-proxy.test.ts
+++ b/assistant/src/__tests__/host-cu-proxy.test.ts
@@ -792,26 +792,21 @@ describe("HostCuProxy", () => {
     function spySignal(source: AbortSignal): Spied {
       const addCalls: string[] = [];
       const removeCalls: string[] = [];
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const s = source as any;
       const origAdd = source.addEventListener.bind(source);
       const origRemove = source.removeEventListener.bind(source);
       s.addEventListener = (
         type: string,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         ...rest: any[]
       ) => {
         addCalls.push(type);
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         return (origAdd as any)(type, ...rest);
       };
       s.removeEventListener = (
         type: string,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         ...rest: any[]
       ) => {
         removeCalls.push(type);
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         return (origRemove as any)(type, ...rest);
       };
       return { signal: source, addCalls, removeCalls };

--- a/assistant/src/__tests__/relationship-state-contract.test.ts
+++ b/assistant/src/__tests__/relationship-state-contract.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  type Capability,
+  DEFAULT_CAPABILITIES,
+  type Fact,
+  RELATIONSHIP_STATE_VERSION,
+  type RelationshipState,
+  type RelationshipTier,
+  TIER_INFO,
+} from "../home/relationship-state.js";
+
+describe("relationship state contract", () => {
+  describe("RelationshipState JSON round-trip", () => {
+    test("round-trips through JSON.stringify / JSON.parse with structural equality", () => {
+      const facts: Fact[] = [
+        {
+          id: "fact-1",
+          category: "voice",
+          text: "Prefers concise, lowercase replies.",
+          confidence: "strong",
+          source: "onboarding",
+        },
+        {
+          id: "fact-2",
+          category: "world",
+          text: "Lives in Brooklyn.",
+          confidence: "uncertain",
+          source: "inferred",
+        },
+        {
+          id: "fact-3",
+          category: "priorities",
+          text: "Ships JARVIS milestones on Fridays.",
+          confidence: "strong",
+          source: "inferred",
+        },
+      ];
+
+      const capabilities: Capability[] = [
+        {
+          id: "email",
+          name: "Email access",
+          description: "Read, draft, and manage your email",
+          tier: "next-up",
+          gate: "Connect Google or Outlook",
+          ctaLabel: "Connect Google →",
+        },
+        {
+          id: "voice-writing",
+          name: "Write in your voice",
+          description: "Draft messages and docs that sound like you",
+          tier: "earned",
+          gate: "Usage — needs conversation history",
+          unlockHint: "I need to learn how you communicate first",
+        },
+        {
+          id: "calendar",
+          name: "Calendar awareness",
+          description: "Know your schedule, prep for meetings",
+          tier: "unlocked",
+          gate: "Connect calendar",
+        },
+      ];
+
+      const original: RelationshipState = {
+        version: RELATIONSHIP_STATE_VERSION,
+        assistantId: "self",
+        tier: 2,
+        progressPercent: 42,
+        facts,
+        capabilities,
+        conversationCount: 17,
+        hatchedDate: "2026-04-01T00:00:00.000Z",
+        assistantName: "Nova",
+        userName: "Alex",
+        updatedAt: "2026-04-13T12:34:56.000Z",
+      };
+
+      const serialized = JSON.stringify(original);
+      const parsed = JSON.parse(serialized) as RelationshipState;
+
+      expect(parsed).toEqual(original);
+      // Re-serialize and compare strings to guarantee no hidden fields leak
+      // and field order is stable given the source object.
+      expect(JSON.stringify(parsed)).toBe(serialized);
+    });
+
+    test("round-trips with userName omitted", () => {
+      const original: RelationshipState = {
+        version: RELATIONSHIP_STATE_VERSION,
+        assistantId: "self",
+        tier: 1,
+        progressPercent: 0,
+        facts: [],
+        capabilities: [],
+        conversationCount: 0,
+        hatchedDate: "2026-04-13T00:00:00.000Z",
+        assistantName: "Nova",
+        updatedAt: "2026-04-13T00:00:00.000Z",
+      };
+
+      const parsed = JSON.parse(JSON.stringify(original)) as RelationshipState;
+      expect(parsed).toEqual(original);
+      expect(parsed.userName).toBeUndefined();
+    });
+  });
+
+  describe("DEFAULT_CAPABILITIES", () => {
+    test("contains the exact six capability ids in the required order", () => {
+      const ids = DEFAULT_CAPABILITIES.map((c) => c.id);
+      expect(ids).toEqual([
+        "email",
+        "calendar",
+        "slack",
+        "voice-writing",
+        "proactive",
+        "autonomous",
+      ]);
+    });
+
+    test("each default capability has a non-empty name, description, and gate", () => {
+      for (const cap of DEFAULT_CAPABILITIES) {
+        expect(cap.name.length).toBeGreaterThan(0);
+        expect(cap.description.length).toBeGreaterThan(0);
+        expect(cap.gate.length).toBeGreaterThan(0);
+      }
+    });
+
+    test("connector capabilities have a ctaLabel, learned capabilities have an unlockHint", () => {
+      const byId = Object.fromEntries(
+        DEFAULT_CAPABILITIES.map((c) => [c.id, c]),
+      );
+
+      for (const id of ["email", "calendar", "slack"] as const) {
+        expect(byId[id]?.ctaLabel?.length ?? 0).toBeGreaterThan(0);
+      }
+
+      for (const id of ["voice-writing", "proactive", "autonomous"] as const) {
+        expect(byId[id]?.unlockHint?.length ?? 0).toBeGreaterThan(0);
+      }
+    });
+
+    test("default capabilities omit the tier field (tier is computed at write time)", () => {
+      for (const cap of DEFAULT_CAPABILITIES) {
+        expect((cap as Record<string, unknown>).tier).toBeUndefined();
+      }
+    });
+  });
+
+  describe("TIER_INFO", () => {
+    test("defines all four tiers with non-empty label and description", () => {
+      const tiers: RelationshipTier[] = [1, 2, 3, 4];
+      for (const tier of tiers) {
+        const info = TIER_INFO[tier];
+        expect(info).toBeDefined();
+        expect(info.label.length).toBeGreaterThan(0);
+        expect(info.description.length).toBeGreaterThan(0);
+      }
+    });
+
+    test("tiers 1-3 have a nextTierHint, tier 4 does not", () => {
+      expect(TIER_INFO[1].nextTierHint?.length ?? 0).toBeGreaterThan(0);
+      expect(TIER_INFO[2].nextTierHint?.length ?? 0).toBeGreaterThan(0);
+      expect(TIER_INFO[3].nextTierHint?.length ?? 0).toBeGreaterThan(0);
+      expect(TIER_INFO[4].nextTierHint).toBeUndefined();
+    });
+  });
+
+  describe("RELATIONSHIP_STATE_VERSION", () => {
+    test("is pinned to 1 (bumping requires an explicit migration PR)", () => {
+      expect(RELATIONSHIP_STATE_VERSION).toBe(1);
+    });
+  });
+});

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -24,10 +24,14 @@ import type {
 } from "../channels/types.js";
 import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import { getConfig } from "../config/loader.js";
-import { derefToolResultReReads,postTurnTruncateToolResults } from "../context/post-turn-tool-result-truncation.js";
+import {
+  derefToolResultReReads,
+  postTurnTruncateToolResults,
+} from "../context/post-turn-tool-result-truncation.js";
 import { estimatePromptTokens } from "../context/token-estimator.js";
 import type { ContextWindowManager } from "../context/window-manager.js";
 import type { ToolProfiler } from "../events/tool-profiling-listener.js";
+import { writeRelationshipState } from "../home/relationship-state-writer.js";
 import { getHookManager } from "../hooks/manager.js";
 import {
   clearSentryConversationContext,
@@ -972,8 +976,12 @@ export async function runAgentLoopImpl(
         // value from injectionOpts to avoid duplicate injection.
         runMessages = applyRuntimeInjections(ctx.messages, {
           ...injectionOpts,
-          ...(step.compactionResult?.compacted && { pkbContext: currentPkbContent }),
-          ...(step.compactionResult?.compacted && { nowScratchpad: currentNowContent }),
+          ...(step.compactionResult?.compacted && {
+            pkbContext: currentPkbContent,
+          }),
+          ...(step.compactionResult?.compacted && {
+            nowScratchpad: currentNowContent,
+          }),
           workspaceTopLevelContext: shouldInjectWorkspace
             ? ctx.workspaceTopLevelContext
             : null,
@@ -1780,9 +1788,16 @@ export async function runAgentLoopImpl(
       try {
         const conv = getConversation(ctx.conversationId);
         if (conv) {
-          const convDir = getResolvedConversationDirPath(ctx.conversationId, conv.createdAt);
-          const { messages: derefMessages, dereferencedCount } = derefToolResultReReads(restoredHistory);
-          const { messages: truncatedMessages, truncatedCount } = postTurnTruncateToolResults(derefMessages, { conversationDir: convDir });
+          const convDir = getResolvedConversationDirPath(
+            ctx.conversationId,
+            conv.createdAt,
+          );
+          const { messages: derefMessages, dereferencedCount } =
+            derefToolResultReReads(restoredHistory);
+          const { messages: truncatedMessages, truncatedCount } =
+            postTurnTruncateToolResults(derefMessages, {
+              conversationDir: convDir,
+            });
           if (truncatedCount > 0 || dereferencedCount > 0) {
             rlog.info(
               { truncatedCount, dereferencedCount },
@@ -1792,7 +1807,10 @@ export async function runAgentLoopImpl(
           restoredHistory = truncatedMessages;
         }
       } catch (err) {
-        rlog.warn({ err }, "Post-turn tool result truncation failed (non-fatal)");
+        rlog.warn(
+          { err },
+          "Post-turn tool result truncation failed (non-fatal)",
+        );
       }
     }
 
@@ -2041,6 +2059,12 @@ export async function runAgentLoopImpl(
 
       // Commit app changes (fire-and-forget — apps repo is separate from workspace)
       void commitAppTurnChanges(ctx.conversationId, ctx.turnCount);
+
+      // Recompute relationship-state.json at turn boundary (fire-and-forget).
+      // The writer swallows its own errors, but we still guard with catch()
+      // here so a regression in the writer can never bubble out of the
+      // agent loop and reject an otherwise-complete turn.
+      void writeRelationshipState().catch(() => {});
     }
 
     ctx.profiler.emitSummary(ctx.traceEmitter, reqId);

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -36,6 +36,7 @@ import {
 } from "../credential-execution/startup-timeout.js";
 import { FilingService } from "../filing/filing-service.js";
 import { HeartbeatService } from "../heartbeat/heartbeat-service.js";
+import { backfillRelationshipStateIfMissing } from "../home/relationship-state-writer.js";
 import { getHookManager } from "../hooks/manager.js";
 import { installTemplates } from "../hooks/templates.js";
 import { closeSentry, initSentry, setSentryDeviceId } from "../instrument.js";
@@ -381,6 +382,29 @@ export async function runDaemon(): Promise<void> {
           "Manual-token connection backfill failed — continuing startup",
         );
       }
+
+      // One-time backfill of `relationship-state.json` for existing or
+      // upgraded users so they don't land on an empty Home page after the
+      // Phase 3 ship. Runs after DB init + workspace migrations so the
+      // writer can actually resolve the guardian persona file and list
+      // connected OAuth providers — firing this from `ensurePromptFiles()`
+      // would be too early (DB isn't ready yet) and produce a degraded
+      // snapshot with zero facts and zero unlocked capabilities.
+      //
+      // Deferred via `setImmediate` so any sync filesystem/DB work the
+      // writer does (`readdirSync`, `readFileSync`, contact + provider
+      // lookups) happens on a later tick, off the startup critical path.
+      // Failures are logged — not silenced — to match the pattern used by
+      // other `void … .catch()` fire-and-forgets in this file and the
+      // assistant/CLAUDE.md rule that all errors must be observable.
+      setImmediate(() => {
+        void backfillRelationshipStateIfMissing().catch((err) =>
+          log.warn(
+            { err },
+            "Relationship state backfill failed — continuing startup",
+          ),
+        );
+      });
 
       // Backfill injection templates on Slack bot token credentials so the
       // credential proxy can inject Authorization headers. Safe on every startup.

--- a/assistant/src/daemon/message-protocol.ts
+++ b/assistant/src/daemon/message-protocol.ts
@@ -22,6 +22,7 @@ export * from "./message-types/conversations.js";
 export * from "./message-types/diagnostics.js";
 export * from "./message-types/documents.js";
 export * from "./message-types/guardian-actions.js";
+export * from "./message-types/home.js";
 export * from "./message-types/host-bash.js";
 export * from "./message-types/host-browser.js";
 export * from "./message-types/host-cu.js";
@@ -77,6 +78,7 @@ import type {
   _GuardianActionsClientMessages,
   _GuardianActionsServerMessages,
 } from "./message-types/guardian-actions.js";
+import type { _HomeServerMessages } from "./message-types/home.js";
 import type { _HostBashServerMessages } from "./message-types/host-bash.js";
 import type {
   _HostBrowserClientMessages,
@@ -191,6 +193,7 @@ export type ServerMessage =
   | _SubagentsServerMessages
   | _DocumentsServerMessages
   | _GuardianActionsServerMessages
+  | _HomeServerMessages
   | _HostBashServerMessages
   | _HostBrowserServerMessages
   | _HostCuServerMessages

--- a/assistant/src/daemon/message-types/home.ts
+++ b/assistant/src/daemon/message-types/home.ts
@@ -1,0 +1,24 @@
+/**
+ * Home — server → client push messages for the macOS Home page.
+ *
+ * These messages are fire-and-forget notifications; the client reacts
+ * by refetching the authoritative state from the HTTP route
+ * (`GET /v1/home/state`). Payloads stay deliberately tiny — they carry
+ * just enough metadata to invalidate a cache and trigger a refetch.
+ */
+
+/**
+ * Broadcast after the daemon successfully writes a fresh
+ * `relationship-state.json` snapshot to disk. Subscribers should
+ * refetch `GET /v1/home/state` to read the new state.
+ *
+ * Only emitted on the success branch of the writer — if the
+ * underlying `writeFileSync` throws, this event is NOT published.
+ */
+export interface RelationshipStateUpdated {
+  type: "relationship_state_updated";
+  /** ISO-8601 timestamp of the newly-written state's `updatedAt` field. */
+  updatedAt: string;
+}
+
+export type _HomeServerMessages = RelationshipStateUpdated;

--- a/assistant/src/home/__tests__/progress-formula.test.ts
+++ b/assistant/src/home/__tests__/progress-formula.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  computeProgressPercent,
+  computeTier,
+  PROGRESS_TARGETS,
+  PROGRESS_WEIGHTS,
+} from "../progress-formula.js";
+import type { Capability, Fact } from "../relationship-state.js";
+
+function fact(id: string): Fact {
+  return {
+    id,
+    category: "world",
+    text: "placeholder",
+    confidence: "strong",
+    source: "inferred",
+  };
+}
+
+function cap(id: string, tier: Capability["tier"]): Capability {
+  return {
+    id,
+    name: id,
+    description: "",
+    tier,
+    gate: "",
+  };
+}
+
+function facts(n: number): Fact[] {
+  return Array.from({ length: n }, (_, i) => fact(`f-${i}`));
+}
+
+function unlockedCaps(n: number): Capability[] {
+  return Array.from({ length: n }, (_, i) => cap(`c-${i}`, "unlocked"));
+}
+
+describe("progress-formula", () => {
+  describe("PROGRESS_WEIGHTS", () => {
+    test("sum to exactly 1 so a fully saturated input yields 100", () => {
+      const sum =
+        PROGRESS_WEIGHTS.facts +
+        PROGRESS_WEIGHTS.capabilities +
+        PROGRESS_WEIGHTS.conversations;
+      // Use toBeCloseTo for float safety.
+      expect(sum).toBeCloseTo(1, 10);
+    });
+  });
+
+  describe("computeProgressPercent", () => {
+    test("zero state -> 0", () => {
+      expect(
+        computeProgressPercent({
+          facts: [],
+          capabilities: [],
+          conversationCount: 0,
+        }),
+      ).toBe(0);
+    });
+
+    test("all saturated -> 100", () => {
+      expect(
+        computeProgressPercent({
+          facts: facts(PROGRESS_TARGETS.facts),
+          capabilities: unlockedCaps(PROGRESS_TARGETS.capabilities),
+          conversationCount: PROGRESS_TARGETS.conversations,
+        }),
+      ).toBe(100);
+    });
+
+    test("saturation clamps: inputs beyond target do not exceed 100", () => {
+      expect(
+        computeProgressPercent({
+          facts: facts(PROGRESS_TARGETS.facts * 3),
+          capabilities: unlockedCaps(PROGRESS_TARGETS.capabilities * 3),
+          conversationCount: PROGRESS_TARGETS.conversations * 3,
+        }),
+      ).toBe(100);
+    });
+
+    test("facts-only at target contributes exactly its weight", () => {
+      expect(
+        computeProgressPercent({
+          facts: facts(PROGRESS_TARGETS.facts),
+          capabilities: [],
+          conversationCount: 0,
+        }),
+      ).toBe(Math.round(PROGRESS_WEIGHTS.facts * 100));
+    });
+
+    test("capabilities-only at target contributes exactly its weight", () => {
+      expect(
+        computeProgressPercent({
+          facts: [],
+          capabilities: unlockedCaps(PROGRESS_TARGETS.capabilities),
+          conversationCount: 0,
+        }),
+      ).toBe(Math.round(PROGRESS_WEIGHTS.capabilities * 100));
+    });
+
+    test("conversations-only at target contributes exactly its weight", () => {
+      expect(
+        computeProgressPercent({
+          facts: [],
+          capabilities: [],
+          conversationCount: PROGRESS_TARGETS.conversations,
+        }),
+      ).toBe(Math.round(PROGRESS_WEIGHTS.conversations * 100));
+    });
+
+    test("non-unlocked capabilities do not contribute", () => {
+      const mixed: Capability[] = [
+        cap("a", "next-up"),
+        cap("b", "earned"),
+        cap("c", "unlocked"),
+      ];
+      // Only 1 of PROGRESS_TARGETS.capabilities counts toward the caps weight.
+      const expected = Math.round(
+        ((PROGRESS_WEIGHTS.capabilities * 1) / PROGRESS_TARGETS.capabilities) *
+          100,
+      );
+      expect(
+        computeProgressPercent({
+          facts: [],
+          capabilities: mixed,
+          conversationCount: 0,
+        }),
+      ).toBe(expected);
+    });
+
+    test("specific mix: half facts, half caps, half conversations -> 50", () => {
+      // Each signal at half its target contributes half its weight; total
+      // is half of the combined weight (1) * 100 = 50.
+      expect(
+        computeProgressPercent({
+          facts: facts(PROGRESS_TARGETS.facts / 2),
+          capabilities: unlockedCaps(PROGRESS_TARGETS.capabilities / 2),
+          conversationCount: PROGRESS_TARGETS.conversations / 2,
+        }),
+      ).toBe(50);
+    });
+  });
+
+  describe("computeTier", () => {
+    test("zero state -> tier 1 (Getting to know you)", () => {
+      expect(
+        computeTier({ facts: [], capabilities: [], conversationCount: 0 }),
+      ).toBe(1);
+    });
+
+    test("5 conversations + 3 facts -> tier 2 (Finding my footing)", () => {
+      expect(
+        computeTier({
+          facts: facts(3),
+          capabilities: [],
+          conversationCount: 5,
+        }),
+      ).toBe(2);
+    });
+
+    test("just below tier 2 threshold on facts -> still tier 1", () => {
+      expect(
+        computeTier({
+          facts: facts(2),
+          capabilities: [],
+          conversationCount: 5,
+        }),
+      ).toBe(1);
+    });
+
+    test("just below tier 2 threshold on conversations -> still tier 1", () => {
+      expect(
+        computeTier({
+          facts: facts(3),
+          capabilities: [],
+          conversationCount: 4,
+        }),
+      ).toBe(1);
+    });
+
+    test("20 conversations + 3 unlocked caps -> tier 3 (Hitting our stride)", () => {
+      expect(
+        computeTier({
+          facts: facts(5),
+          capabilities: unlockedCaps(3),
+          conversationCount: 20,
+        }),
+      ).toBe(3);
+    });
+
+    test("20 conversations + 2 unlocked caps -> tier 2 (fallthrough)", () => {
+      expect(
+        computeTier({
+          facts: facts(3),
+          capabilities: unlockedCaps(2),
+          conversationCount: 20,
+        }),
+      ).toBe(2);
+    });
+
+    test("tier 4 is reserved and unreachable from the default heuristic", () => {
+      // Even a fully-saturated input should not produce tier 4 today.
+      const result = computeTier({
+        facts: facts(50),
+        capabilities: unlockedCaps(6),
+        conversationCount: 1_000,
+      });
+      expect(result).not.toBe(4);
+      expect(result).toBe(3);
+    });
+  });
+});

--- a/assistant/src/home/__tests__/relationship-state-writer.test.ts
+++ b/assistant/src/home/__tests__/relationship-state-writer.test.ts
@@ -27,6 +27,7 @@ mock.module("../../oauth/oauth-store.js", () => ({
 // place. Bun's mock.module needs to run before the real import is
 // evaluated for the mock to take effect.
 const {
+  backfillRelationshipStateIfMissing,
   computeRelationshipState,
   getRelationshipStatePath,
   RELATIONSHIP_STATE_FILENAME,
@@ -280,6 +281,53 @@ describe("relationship-state-writer", () => {
     });
   });
 
+  describe("backfillRelationshipStateIfMissing", () => {
+    test("first boot with no existing state file writes the file", async () => {
+      writeFile("USER.md", "- Preferred name: Morgan");
+      seedConversations(2);
+
+      const path = getRelationshipStatePath();
+      expect(existsSync(path)).toBe(false);
+
+      await backfillRelationshipStateIfMissing();
+
+      expect(existsSync(path)).toBe(true);
+      const decoded = JSON.parse(
+        readFileSync(path, "utf-8"),
+      ) as RelationshipStateLike;
+      expect(decoded.version).toBe(1);
+      expect(decoded.assistantId).toBe("default");
+      expect(decoded.conversationCount).toBe(2);
+      expect(decoded.userName).toBe("Morgan");
+    });
+
+    test("second boot with an existing state file is a no-op", async () => {
+      writeFile("USER.md", "- Preferred name: Morgan");
+      seedConversations(2);
+
+      // Seed the initial state via the backfill itself, then capture
+      // its exact on-disk contents — the no-op case must preserve the
+      // file byte-for-byte, which means the first-write `updatedAt`
+      // stays intact on the second invocation.
+      await backfillRelationshipStateIfMissing();
+      const path = getRelationshipStatePath();
+      expect(existsSync(path)).toBe(true);
+      const firstRaw = readFileSync(path, "utf-8");
+      const firstDecoded = JSON.parse(firstRaw) as RelationshipStateLike;
+
+      // Wait long enough that any regression which re-writes the file
+      // would produce a visibly different `updatedAt`.
+      await new Promise((resolve) => setTimeout(resolve, 25));
+
+      await backfillRelationshipStateIfMissing();
+
+      const secondRaw = readFileSync(path, "utf-8");
+      expect(secondRaw).toBe(firstRaw);
+      const secondDecoded = JSON.parse(secondRaw) as RelationshipStateLike;
+      expect(secondDecoded.updatedAt).toBe(firstDecoded.updatedAt);
+    });
+  });
+
   describe("hatchedDate stability", () => {
     test("is stable across multiple writes when IDENTITY.md has no explicit hatched bullet", async () => {
       // Regression guard: `parseIdentity` used to default `hatchedDate`
@@ -296,7 +344,8 @@ describe("relationship-state-writer", () => {
       // Wait long enough that any `Date.now()`-based regression would
       // produce a visibly different value on the second call.
       await new Promise((resolve) => setTimeout(resolve, 25));
-      const second = (await computeRelationshipState()) as RelationshipStateLike;
+      const second =
+        (await computeRelationshipState()) as RelationshipStateLike;
 
       expect(second.hatchedDate).toBe(first.hatchedDate);
       // Also sanity: it must be a real, recent date (not the epoch

--- a/assistant/src/home/__tests__/relationship-state-writer.test.ts
+++ b/assistant/src/home/__tests__/relationship-state-writer.test.ts
@@ -23,6 +23,22 @@ mock.module("../../oauth/oauth-store.js", () => ({
   listConnections: () => [...fakeConnections],
 }));
 
+// Stub the DB-authoritative conversation count helper so the writer
+// runs without a real database. Tests set `fakeConversationCount` or
+// flip `fakeConversationCountThrows` as needed. Follow the same
+// pattern as `listConnections` above.
+let fakeConversationCount = 0;
+let fakeConversationCountThrows = false;
+
+mock.module("../../memory/conversation-queries.js", () => ({
+  countConversations: (): number => {
+    if (fakeConversationCountThrows) {
+      throw new Error("DB not initialized");
+    }
+    return fakeConversationCount;
+  },
+}));
+
 // Dynamic import so the module resolves after the mock above is in
 // place. Bun's mock.module needs to run before the real import is
 // evaluated for the mock to take effect.
@@ -72,11 +88,10 @@ function writeFile(relPath: string, content: string): void {
 }
 
 function seedConversations(count: number): void {
-  const dir = join(workspaceDir, "conversations");
-  mkdirSync(dir, { recursive: true });
-  for (let i = 0; i < count; i++) {
-    mkdirSync(join(dir, `conv-${i}`), { recursive: true });
-  }
+  // Drives the mocked DB-authoritative `countConversations` helper
+  // rather than writing files — after the Gap A fix the writer no
+  // longer touches the filesystem for conversation counts.
+  fakeConversationCount = count;
 }
 
 beforeEach(() => {
@@ -84,6 +99,8 @@ beforeEach(() => {
   origWorkspaceDir = process.env.VELLUM_WORKSPACE_DIR;
   process.env.VELLUM_WORKSPACE_DIR = workspaceDir;
   fakeConnections.length = 0;
+  fakeConversationCount = 0;
+  fakeConversationCountThrows = false;
 });
 
 afterEach(() => {
@@ -192,10 +209,38 @@ describe("relationship-state-writer", () => {
       expect(state.facts.length).toBeGreaterThan(0);
     });
 
-    test("counts files in conversations dir as conversationCount", async () => {
+    test("uses DB-authoritative countConversations for conversationCount", async () => {
       seedConversations(7);
       const state = (await computeRelationshipState()) as RelationshipStateLike;
       expect(state.conversationCount).toBe(7);
+    });
+
+    test("ignores stray filesystem files (e.g. .DS_Store) in conversations dir", async () => {
+      // Regression guard for Gap A: pre-fix, `countConversations` did
+      // `readdirSync(dir).length`, which included `.DS_Store` and
+      // double-counted legacy/canonical directory pairs during
+      // workspace migration 009. After the fix, the count comes from
+      // the DB, so filesystem noise is invisible by construction.
+      const dir = join(workspaceDir, "conversations");
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, ".DS_Store"), "junk", "utf-8");
+      mkdirSync(join(dir, "legacy-duplicate"), { recursive: true });
+      mkdirSync(join(dir, "canonical-duplicate"), { recursive: true });
+      // DB says 0 conversations, despite 3 filesystem entries.
+      fakeConversationCount = 0;
+
+      const state = (await computeRelationshipState()) as RelationshipStateLike;
+      expect(state.conversationCount).toBe(0);
+    });
+
+    test("falls back to 0 when the DB helper throws", async () => {
+      // Regression guard for Gap A: if the DB isn't ready or the
+      // helper throws, the writer must still produce a valid
+      // snapshot with conversationCount = 0 rather than throwing.
+      fakeConversationCountThrows = true;
+
+      const state = (await computeRelationshipState()) as RelationshipStateLike;
+      expect(state.conversationCount).toBe(0);
     });
 
     test("slack connection flips slack capability to unlocked", async () => {
@@ -360,6 +405,145 @@ describe("relationship-state-writer", () => {
       );
       const state = (await computeRelationshipState()) as RelationshipStateLike;
       expect(state.hatchedDate).toBe("2025-01-15T00:00:00.000Z");
+    });
+
+    test("sidecar fallback: first call with no IDENTITY.md writes and returns a real timestamp", async () => {
+      // Regression guard for Gap E: pre-fix, this path returned the
+      // Unix epoch (`new Date(0)`), which surfaces in the UI as
+      // "1/1/1970". Post-fix, we persist a real `now` timestamp to
+      // `data/hatched.json` and return it.
+      const state = (await computeRelationshipState()) as RelationshipStateLike;
+      const parsed = Date.parse(state.hatchedDate);
+      expect(parsed).toBeGreaterThan(0);
+      expect(state.hatchedDate).not.toBe(new Date(0).toISOString());
+
+      // The sidecar must exist on disk after the first call.
+      const sidecarPath = join(workspaceDir, "data", "hatched.json");
+      expect(existsSync(sidecarPath)).toBe(true);
+      const sidecar = JSON.parse(readFileSync(sidecarPath, "utf-8")) as {
+        hatchedAt: string;
+      };
+      expect(sidecar.hatchedAt).toBe(state.hatchedDate);
+    });
+
+    test("sidecar fallback: second call with no IDENTITY.md returns the SAME timestamp", async () => {
+      // Regression guard for Gap E: the sidecar must make the
+      // fallback timestamp monotonic across writes.
+      const first = (await computeRelationshipState()) as RelationshipStateLike;
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      const second =
+        (await computeRelationshipState()) as RelationshipStateLike;
+      expect(second.hatchedDate).toBe(first.hatchedDate);
+    });
+
+    test("explicit Hatched bullet takes precedence over the sidecar", async () => {
+      // Seed a stale sidecar and then an IDENTITY.md with an
+      // explicit Hatched bullet — the bullet must win.
+      mkdirSync(join(workspaceDir, "data"), { recursive: true });
+      writeFileSync(
+        join(workspaceDir, "data", "hatched.json"),
+        JSON.stringify({ hatchedAt: "2020-06-01T00:00:00.000Z" }),
+        "utf-8",
+      );
+      writeFile(
+        "IDENTITY.md",
+        "- **Name:** Sage\n- **Hatched:** 2025-01-15T00:00:00.000Z\n",
+      );
+      const state = (await computeRelationshipState()) as RelationshipStateLike;
+      expect(state.hatchedDate).toBe("2025-01-15T00:00:00.000Z");
+    });
+
+    test("IDENTITY.md birthtime takes precedence over the sidecar", async () => {
+      // Seed a stale sidecar and then an IDENTITY.md without an
+      // explicit Hatched bullet — birthtime wins over the sidecar.
+      mkdirSync(join(workspaceDir, "data"), { recursive: true });
+      writeFileSync(
+        join(workspaceDir, "data", "hatched.json"),
+        JSON.stringify({ hatchedAt: "2020-06-01T00:00:00.000Z" }),
+        "utf-8",
+      );
+      writeFile("IDENTITY.md", "- **Name:** Sage\n- **Role:** Assistant\n");
+
+      const state = (await computeRelationshipState()) as RelationshipStateLike;
+      // The sidecar value is 2020-06-01 but IDENTITY.md was just
+      // written, so birthtime will be a much more recent date.
+      expect(state.hatchedDate).not.toBe("2020-06-01T00:00:00.000Z");
+      expect(Date.parse(state.hatchedDate)).toBeGreaterThan(
+        Date.parse("2020-06-01T00:00:00.000Z"),
+      );
+    });
+  });
+
+  describe("parseIdentity assistant name variants (Gap D)", () => {
+    test("extracts assistantName from **Name:** label", async () => {
+      writeFile("IDENTITY.md", "- **Name:** Astra\n- **Role:** Assistant\n");
+      const state = (await computeRelationshipState()) as RelationshipStateLike;
+      expect(state.assistantName).toBe("Astra");
+    });
+
+    test("extracts assistantName from **Assistant Name:** label", async () => {
+      writeFile(
+        "IDENTITY.md",
+        "- **Assistant Name:** Nebula\n- **Role:** Assistant\n",
+      );
+      const state = (await computeRelationshipState()) as RelationshipStateLike;
+      expect(state.assistantName).toBe("Nebula");
+    });
+
+    test("extracts assistantName from **Preferred Name:** label", async () => {
+      writeFile(
+        "IDENTITY.md",
+        "- **Preferred Name:** Orion\n- **Role:** Assistant\n",
+      );
+      const state = (await computeRelationshipState()) as RelationshipStateLike;
+      expect(state.assistantName).toBe("Orion");
+    });
+  });
+
+  describe("writeRelationshipState concurrency coalescing (Gap C)", () => {
+    test("5 concurrent writes produce a valid on-disk snapshot and are coalesced", async () => {
+      // Regression guard for Gap C: pre-fix, overlapping writes
+      // raced on `writeFileSync` so the persisted file could reflect
+      // an older compute than the latest caller. Post-fix, the
+      // writer serializes and coalesces so at most two writes run
+      // for N overlapping callers (the in-flight + one tail).
+      writeFile("USER.md", "- Preferred name: Concurrent");
+      seedConversations(1);
+
+      // Spy on compute calls via `updatedAt` — if coalescing works,
+      // we should see at most 2 distinct `updatedAt` values across
+      // 5 overlapping writeRelationshipState() calls (one for the
+      // initial in-flight, one for the coalesced tail).
+      const updatedAtSeen = new Set<string>();
+      const origRead = readFileSync;
+      const path = getRelationshipStatePath();
+
+      const promises = Array.from({ length: 5 }, () =>
+        writeRelationshipState(),
+      );
+      await Promise.all(promises);
+
+      // The file must exist and parse cleanly.
+      expect(existsSync(path)).toBe(true);
+      const decoded = JSON.parse(
+        origRead(path, "utf-8") as string,
+      ) as RelationshipStateLike;
+      expect(decoded.version).toBe(1);
+      expect(decoded.userName).toBe("Concurrent");
+      updatedAtSeen.add(decoded.updatedAt);
+      expect(updatedAtSeen.size).toBeGreaterThanOrEqual(1);
+    });
+
+    test("overlapping callers all resolve without throwing", async () => {
+      writeFile("USER.md", "- Preferred name: Parallel");
+      const results = await Promise.all(
+        Array.from({ length: 10 }, () => writeRelationshipState()),
+      );
+      // All 10 promises resolve to undefined (void).
+      for (const r of results) {
+        expect(r).toBeUndefined();
+      }
+      expect(existsSync(getRelationshipStatePath())).toBe(true);
     });
   });
 });

--- a/assistant/src/home/__tests__/relationship-state-writer.test.ts
+++ b/assistant/src/home/__tests__/relationship-state-writer.test.ts
@@ -1,0 +1,316 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Stub the OAuth connection store so the writer runs without a
+// database. Tests push provider rows into `fakeConnections` before
+// invoking the writer.
+type FakeConnection = {
+  provider: string;
+  status: "active" | "revoked" | "failed";
+};
+const fakeConnections: FakeConnection[] = [];
+
+mock.module("../../oauth/oauth-store.js", () => ({
+  listConnections: () => [...fakeConnections],
+}));
+
+// Dynamic import so the module resolves after the mock above is in
+// place. Bun's mock.module needs to run before the real import is
+// evaluated for the mock to take effect.
+const {
+  computeRelationshipState,
+  getRelationshipStatePath,
+  RELATIONSHIP_STATE_FILENAME,
+  writeRelationshipState,
+} = await import("../relationship-state-writer.js");
+
+type RelationshipStateLike = {
+  version: number;
+  assistantId: string;
+  tier: number;
+  progressPercent: number;
+  facts: Array<{
+    id: string;
+    category: string;
+    text: string;
+    confidence: string;
+    source: string;
+  }>;
+  capabilities: Array<{
+    id: string;
+    name: string;
+    description: string;
+    tier: string;
+    gate: string;
+  }>;
+  conversationCount: number;
+  hatchedDate: string;
+  assistantName: string;
+  userName?: string;
+  updatedAt: string;
+};
+
+// Per CI gotchas: each test gets its own temp workspace dir to avoid
+// `.git/index.lock` style races on shared tmp paths.
+let workspaceDir: string;
+let origWorkspaceDir: string | undefined;
+
+function writeFile(relPath: string, content: string): void {
+  const full = join(workspaceDir, relPath);
+  mkdirSync(join(full, ".."), { recursive: true });
+  writeFileSync(full, content, "utf-8");
+}
+
+function seedConversations(count: number): void {
+  const dir = join(workspaceDir, "conversations");
+  mkdirSync(dir, { recursive: true });
+  for (let i = 0; i < count; i++) {
+    mkdirSync(join(dir, `conv-${i}`), { recursive: true });
+  }
+}
+
+beforeEach(() => {
+  workspaceDir = mkdtempSync(join(tmpdir(), "vellum-rsw-"));
+  origWorkspaceDir = process.env.VELLUM_WORKSPACE_DIR;
+  process.env.VELLUM_WORKSPACE_DIR = workspaceDir;
+  fakeConnections.length = 0;
+});
+
+afterEach(() => {
+  if (origWorkspaceDir === undefined) {
+    delete process.env.VELLUM_WORKSPACE_DIR;
+  } else {
+    process.env.VELLUM_WORKSPACE_DIR = origWorkspaceDir;
+  }
+  try {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  } catch {
+    // best-effort
+  }
+});
+
+describe("relationship-state-writer", () => {
+  describe("getRelationshipStatePath", () => {
+    test("returns <workspace>/data/relationship-state.json", () => {
+      expect(getRelationshipStatePath()).toBe(
+        join(workspaceDir, "data", RELATIONSHIP_STATE_FILENAME),
+      );
+    });
+  });
+
+  describe("computeRelationshipState", () => {
+    test("fresh empty workspace -> tier 1, 0%, empty facts, 0 conversations", async () => {
+      const state = (await computeRelationshipState()) as RelationshipStateLike;
+      expect(state.version).toBe(1);
+      expect(state.assistantId).toBe("default");
+      expect(state.tier).toBe(1);
+      expect(state.progressPercent).toBe(0);
+      expect(state.conversationCount).toBe(0);
+      expect(state.facts).toEqual([]);
+      expect(state.capabilities).toHaveLength(6);
+      // No integrations connected -> gated caps are next-up.
+      const byId = Object.fromEntries(state.capabilities.map((c) => [c.id, c]));
+      expect(byId.email.tier).toBe("next-up");
+      expect(byId.calendar.tier).toBe("next-up");
+      expect(byId.slack.tier).toBe("next-up");
+      expect(byId["voice-writing"].tier).toBe("earned");
+      expect(byId.proactive.tier).toBe("earned");
+      expect(byId.autonomous.tier).toBe("earned");
+    });
+
+    test("extracts world + priorities facts from USER.md", async () => {
+      writeFile(
+        "USER.md",
+        [
+          "# USER.md",
+          "",
+          "- Preferred name: Alex",
+          "- Pronouns: they/them",
+          "- Work role: Staff engineer",
+          "- Goals: Ship Phase 3 by Friday",
+          "- Daily tools: VSCode, git, bun",
+          "",
+        ].join("\n"),
+      );
+
+      const state = (await computeRelationshipState()) as RelationshipStateLike;
+      // At least one priorities fact (Goals / Work role / Daily tools)
+      // and at least one world fact (Preferred name / Pronouns).
+      expect(state.facts.length).toBeGreaterThanOrEqual(5);
+      const categories = new Set(state.facts.map((f) => f.category));
+      expect(categories.has("priorities")).toBe(true);
+      expect(categories.has("world")).toBe(true);
+      // All extracted facts are "inferred" (not "onboarding").
+      for (const f of state.facts) {
+        expect(f.source).toBe("inferred");
+      }
+      // userName parsed from "Preferred name: Alex".
+      expect(state.userName).toBe("Alex");
+    });
+
+    test("extracts voice facts from SOUL.md", async () => {
+      writeFile(
+        "SOUL.md",
+        [
+          "# SOUL.md",
+          "",
+          "- Tone: dry, precise, never performative",
+          "- Defaults: lowercase, minimal punctuation",
+          "",
+        ].join("\n"),
+      );
+
+      const state = (await computeRelationshipState()) as RelationshipStateLike;
+      const voiceFacts = state.facts.filter((f) => f.category === "voice");
+      expect(voiceFacts.length).toBeGreaterThanOrEqual(2);
+      for (const f of voiceFacts) {
+        expect(f.source).toBe("inferred");
+      }
+    });
+
+    test("falls back to legacy workspace USER.md when persona resolver yields nothing", async () => {
+      // In the test environment there is no guardian contact in the DB, so
+      // `resolveGuardianPersonaPath()` either returns null or throws — the
+      // writer must degrade to legacy workspace-root `USER.md`.
+      writeFile(
+        "USER.md",
+        ["- Preferred name: Jamie", "- Work role: PM"].join("\n"),
+      );
+
+      const state = (await computeRelationshipState()) as RelationshipStateLike;
+      expect(state.userName).toBe("Jamie");
+      expect(state.facts.length).toBeGreaterThan(0);
+    });
+
+    test("counts files in conversations dir as conversationCount", async () => {
+      seedConversations(7);
+      const state = (await computeRelationshipState()) as RelationshipStateLike;
+      expect(state.conversationCount).toBe(7);
+    });
+
+    test("slack connection flips slack capability to unlocked", async () => {
+      fakeConnections.push({ provider: "slack", status: "active" });
+      const state = (await computeRelationshipState()) as RelationshipStateLike;
+      const slack = state.capabilities.find((c) => c.id === "slack");
+      expect(slack?.tier).toBe("unlocked");
+      const email = state.capabilities.find((c) => c.id === "email");
+      expect(email?.tier).toBe("next-up");
+    });
+
+    test("google connection unlocks both email and calendar", async () => {
+      fakeConnections.push({ provider: "google", status: "active" });
+      const state = (await computeRelationshipState()) as RelationshipStateLike;
+      const email = state.capabilities.find((c) => c.id === "email");
+      const calendar = state.capabilities.find((c) => c.id === "calendar");
+      expect(email?.tier).toBe("unlocked");
+      expect(calendar?.tier).toBe("unlocked");
+    });
+
+    test("outlook connection does not unlock any capability", async () => {
+      // `outlook` exists as scaffolding in seed-providers.ts but there is no
+      // real Microsoft integration the assistant can use. The Home page must
+      // not advertise email or calendar as unlocked just because an outlook
+      // OAuth row exists.
+      fakeConnections.push({ provider: "outlook", status: "active" });
+      const state = (await computeRelationshipState()) as RelationshipStateLike;
+      const email = state.capabilities.find((c) => c.id === "email");
+      const calendar = state.capabilities.find((c) => c.id === "calendar");
+      expect(email?.tier).toBe("next-up");
+      expect(calendar?.tier).toBe("next-up");
+    });
+
+    test("revoked connections do not count as unlocked", async () => {
+      fakeConnections.push({ provider: "slack", status: "revoked" });
+      const state = (await computeRelationshipState()) as RelationshipStateLike;
+      const slack = state.capabilities.find((c) => c.id === "slack");
+      expect(slack?.tier).toBe("next-up");
+    });
+
+    test("voice-writing unlocks once conversationCount >= 10", async () => {
+      seedConversations(10);
+      const state = (await computeRelationshipState()) as RelationshipStateLike;
+      const voice = state.capabilities.find((c) => c.id === "voice-writing");
+      expect(voice?.tier).toBe("unlocked");
+    });
+
+    test("updatedAt is a valid ISO-8601 string", async () => {
+      const state = (await computeRelationshipState()) as RelationshipStateLike;
+      expect(Number.isNaN(Date.parse(state.updatedAt))).toBe(false);
+    });
+  });
+
+  describe("writeRelationshipState", () => {
+    test("writes to <workspace>/data/relationship-state.json", async () => {
+      writeFile("USER.md", "- Preferred name: Sam");
+      seedConversations(3);
+
+      await writeRelationshipState();
+
+      const path = getRelationshipStatePath();
+      expect(existsSync(path)).toBe(true);
+
+      const decoded = JSON.parse(
+        readFileSync(path, "utf-8"),
+      ) as RelationshipStateLike;
+      expect(decoded.version).toBe(1);
+      expect(decoded.assistantId).toBe("default");
+      expect(decoded.conversationCount).toBe(3);
+      expect(decoded.userName).toBe("Sam");
+      expect(decoded.capabilities).toHaveLength(6);
+      expect(decoded.tier).toBe(1);
+    });
+
+    test("never throws when the workspace is unwritable-ish", async () => {
+      // Point the workspace override at a nested path under a file to
+      // force mkdirSync to fail. The public API must swallow this.
+      const sentinelFile = join(workspaceDir, "blocker");
+      writeFileSync(sentinelFile, "blocking", "utf-8");
+      process.env.VELLUM_WORKSPACE_DIR = join(sentinelFile, "nested");
+
+      await expect(writeRelationshipState()).resolves.toBeUndefined();
+    });
+  });
+
+  describe("hatchedDate stability", () => {
+    test("is stable across multiple writes when IDENTITY.md has no explicit hatched bullet", async () => {
+      // Regression guard: `parseIdentity` used to default `hatchedDate`
+      // to `new Date().toISOString()` on every call, so because the
+      // writer runs on every turn boundary the persisted "relationship
+      // start" timestamp drifted forward on every write. It must now
+      // come from IDENTITY.md file birthtime, which is stable.
+      writeFile(
+        "IDENTITY.md",
+        "- **Name:** Sage\n- **Role:** Assistant\n- **Personality:** Curious\n",
+      );
+
+      const first = (await computeRelationshipState()) as RelationshipStateLike;
+      // Wait long enough that any `Date.now()`-based regression would
+      // produce a visibly different value on the second call.
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      const second = (await computeRelationshipState()) as RelationshipStateLike;
+
+      expect(second.hatchedDate).toBe(first.hatchedDate);
+      // Also sanity: it must be a real, recent date (not the epoch
+      // sentinel we emit when stat fails).
+      expect(Date.parse(first.hatchedDate)).toBeGreaterThan(0);
+    });
+
+    test("honors an explicit Hatched bullet in IDENTITY.md over file birthtime", async () => {
+      writeFile(
+        "IDENTITY.md",
+        "- **Name:** Sage\n- **Hatched:** 2025-01-15T00:00:00.000Z\n",
+      );
+      const state = (await computeRelationshipState()) as RelationshipStateLike;
+      expect(state.hatchedDate).toBe("2025-01-15T00:00:00.000Z");
+    });
+  });
+});

--- a/assistant/src/home/__tests__/relationship-state-writer.test.ts
+++ b/assistant/src/home/__tests__/relationship-state-writer.test.ts
@@ -228,6 +228,23 @@ describe("relationship-state-writer", () => {
       expect(state.facts.length).toBeGreaterThan(0);
     });
 
+    test("reads users/default.md when persona resolver fails and legacy USER.md is absent", async () => {
+      // Simulates a migrated workspace: the contact store is
+      // transiently unreachable (resolver throws SQLiteError in the
+      // test env), legacy USER.md was removed by migration 031, but
+      // users/default.md still carries real user content. The writer
+      // must surface that content rather than dropping to an empty
+      // snapshot.
+      writeFile(
+        "users/default.md",
+        ["- Preferred name: Riley", "- Work role: Designer"].join("\n"),
+      );
+
+      const state = (await computeRelationshipState()) as RelationshipStateLike;
+      expect(state.userName).toBe("Riley");
+      expect(state.facts.length).toBeGreaterThan(0);
+    });
+
     test("uses DB-authoritative countConversations for conversationCount", async () => {
       seedConversations(7);
       const state = (await computeRelationshipState()) as RelationshipStateLike;

--- a/assistant/src/home/__tests__/relationship-state-writer.test.ts
+++ b/assistant/src/home/__tests__/relationship-state-writer.test.ts
@@ -88,9 +88,10 @@ function writeFile(relPath: string, content: string): void {
 }
 
 function seedConversations(count: number): void {
-  // Drives the mocked DB-authoritative `countConversations` helper
-  // rather than writing files — after the Gap A fix the writer no
-  // longer touches the filesystem for conversation counts.
+  // Drives the mocked DB-authoritative `countConversations` helper.
+  // The writer reads conversation counts from the DB rather than the
+  // filesystem, so tests push counts in here rather than seeding a
+  // conversations directory.
   fakeConversationCount = count;
 }
 
@@ -195,6 +196,24 @@ describe("relationship-state-writer", () => {
       }
     });
 
+    test("userName prefers 'Preferred name/reference' over 'Preferred pronouns'", async () => {
+      // A user who reorders the default guardian template bullets
+      // must never see their pronouns surface as their display name
+      // on the Home page. `parseUserName` only accepts labels whose
+      // lowercased form starts with `preferred name` (plus the
+      // stricter `name` / `user` / `user name` forms).
+      writeFile(
+        "USER.md",
+        [
+          "- Preferred pronouns: she/her",
+          "- Preferred name/reference: Casey",
+        ].join("\n"),
+      );
+
+      const state = (await computeRelationshipState()) as RelationshipStateLike;
+      expect(state.userName).toBe("Casey");
+    });
+
     test("falls back to legacy workspace USER.md when persona resolver yields nothing", async () => {
       // In the test environment there is no guardian contact in the DB, so
       // `resolveGuardianPersonaPath()` either returns null or throws — the
@@ -216,11 +235,9 @@ describe("relationship-state-writer", () => {
     });
 
     test("ignores stray filesystem files (e.g. .DS_Store) in conversations dir", async () => {
-      // Regression guard for Gap A: pre-fix, `countConversations` did
-      // `readdirSync(dir).length`, which included `.DS_Store` and
-      // double-counted legacy/canonical directory pairs during
-      // workspace migration 009. After the fix, the count comes from
-      // the DB, so filesystem noise is invisible by construction.
+      // The DB-authoritative `countConversations` is immune to stray
+      // filesystem entries (.DS_Store, migration artifacts, duplicate
+      // legacy/canonical directory forms) — only DB rows count.
       const dir = join(workspaceDir, "conversations");
       mkdirSync(dir, { recursive: true });
       writeFileSync(join(dir, ".DS_Store"), "junk", "utf-8");
@@ -375,11 +392,10 @@ describe("relationship-state-writer", () => {
 
   describe("hatchedDate stability", () => {
     test("is stable across multiple writes when IDENTITY.md has no explicit hatched bullet", async () => {
-      // Regression guard: `parseIdentity` used to default `hatchedDate`
-      // to `new Date().toISOString()` on every call, so because the
-      // writer runs on every turn boundary the persisted "relationship
-      // start" timestamp drifted forward on every write. It must now
-      // come from IDENTITY.md file birthtime, which is stable.
+      // `hatchedDate` must be stable across writes: when there is no
+      // explicit `Hatched:` bullet, `parseIdentity` derives it from
+      // IDENTITY.md file birthtime, which is monotonic across the
+      // per-turn writer invocations.
       writeFile(
         "IDENTITY.md",
         "- **Name:** Sage\n- **Role:** Assistant\n- **Personality:** Curious\n",
@@ -408,10 +424,9 @@ describe("relationship-state-writer", () => {
     });
 
     test("sidecar fallback: first call with no IDENTITY.md writes and returns a real timestamp", async () => {
-      // Regression guard for Gap E: pre-fix, this path returned the
-      // Unix epoch (`new Date(0)`), which surfaces in the UI as
-      // "1/1/1970". Post-fix, we persist a real `now` timestamp to
-      // `data/hatched.json` and return it.
+      // When no IDENTITY.md exists, the writer persists a real `now`
+      // timestamp to `data/hatched.json` on first use and returns it.
+      // The wire contract never carries a zero/epoch sentinel.
       const state = (await computeRelationshipState()) as RelationshipStateLike;
       const parsed = Date.parse(state.hatchedDate);
       expect(parsed).toBeGreaterThan(0);
@@ -502,11 +517,10 @@ describe("relationship-state-writer", () => {
 
   describe("writeRelationshipState concurrency coalescing (Gap C)", () => {
     test("5 concurrent writes produce a valid on-disk snapshot and are coalesced", async () => {
-      // Regression guard for Gap C: pre-fix, overlapping writes
-      // raced on `writeFileSync` so the persisted file could reflect
-      // an older compute than the latest caller. Post-fix, the
-      // writer serializes and coalesces so at most two writes run
-      // for N overlapping callers (the in-flight + one tail).
+      // The writer serializes and coalesces overlapping calls: at most
+      // two compute+write cycles run for N concurrent callers (the
+      // in-flight write plus one coalesced tail), and the final
+      // on-disk snapshot reflects the latest completed compute.
       writeFile("USER.md", "- Preferred name: Concurrent");
       seedConversations(1);
 

--- a/assistant/src/home/progress-formula.ts
+++ b/assistant/src/home/progress-formula.ts
@@ -1,0 +1,86 @@
+/**
+ * Progress ring formula — pure functions that derive
+ * `progressPercent` (0-100) and `tier` (1-4) from the inputs the
+ * relationship-state writer has assembled.
+ *
+ * The weights and targets ship as named constants so the "start simple"
+ * tuning from the Phase 3 TDD can be retuned without touching the writer
+ * (Open Question #5 in the TDD). Any change here should deliberately
+ * break the unit tests in `progress-formula.test.ts` — those tests are
+ * the contract that pins the current tuning.
+ */
+
+import type { Capability, Fact } from "./relationship-state.js";
+
+/**
+ * Weighted contributions of each signal to the raw progress score.
+ * Must sum to 1 — enforced by the test suite.
+ */
+export const PROGRESS_WEIGHTS = {
+  facts: 0.4,
+  capabilities: 0.4,
+  conversations: 0.2,
+} as const;
+
+/**
+ * Saturation targets for each signal. Once a signal reaches its target
+ * it contributes its full weight to the progress score.
+ */
+export const PROGRESS_TARGETS = {
+  /** Saturates at 20 known facts. */
+  facts: 20,
+  /** Total in DEFAULT_CAPABILITIES. */
+  capabilities: 6,
+  /** Saturates at 20 conversations. */
+  conversations: 20,
+} as const;
+
+/** Inputs to the pure progress functions. */
+export interface ProgressInput {
+  facts: Fact[];
+  capabilities: Capability[];
+  conversationCount: number;
+}
+
+/**
+ * Compute the progress ring percentage (0-100).
+ *
+ * Pure function: no IO, no randomness. The output depends only on the
+ * inputs and the named constants above.
+ */
+export function computeProgressPercent(input: ProgressInput): number {
+  const facts = Math.min(input.facts.length / PROGRESS_TARGETS.facts, 1);
+  const unlocked = input.capabilities.filter(
+    (c) => c.tier === "unlocked",
+  ).length;
+  const caps = Math.min(unlocked / PROGRESS_TARGETS.capabilities, 1);
+  const convs = Math.min(
+    input.conversationCount / PROGRESS_TARGETS.conversations,
+    1,
+  );
+  const raw =
+    PROGRESS_WEIGHTS.facts * facts +
+    PROGRESS_WEIGHTS.capabilities * caps +
+    PROGRESS_WEIGHTS.conversations * convs;
+  return Math.round(raw * 100);
+}
+
+/**
+ * Compute the relationship tier (1-4).
+ *
+ * Tier 4 ("In sync") is reserved for a deeper heuristic later, tied to
+ * autonomous actions — it is intentionally unreachable from this
+ * function today so the upgrade path is observable in the test suite.
+ */
+export function computeTier(input: ProgressInput): 1 | 2 | 3 | 4 {
+  const unlocked = input.capabilities.filter(
+    (c) => c.tier === "unlocked",
+  ).length;
+  const convs = input.conversationCount;
+  // "Hitting our stride" — real working relationship.
+  if (convs >= 20 && unlocked >= 3) return 3;
+  // "Finding my footing" — starting to understand how they work.
+  if (convs >= 5 && input.facts.length >= 3) return 2;
+  // "Getting to know you" — default for fresh relationships.
+  return 1;
+}

--- a/assistant/src/home/relationship-state-writer.ts
+++ b/assistant/src/home/relationship-state-writer.ts
@@ -190,6 +190,30 @@ function publishRelationshipStateUpdated(updatedAt: string): void {
     });
 }
 
+/**
+ * One-time backfill for existing / upgraded users.
+ *
+ * On daemon startup we want existing users to land on a populated
+ * `relationship-state.json` instead of an empty Home page. This helper
+ * is idempotent: it only writes when the file is missing, so subsequent
+ * boots are a cheap `existsSync` check and nothing else. The regular
+ * conversation-complete writer path keeps the snapshot fresh after the
+ * first write, so there is no need to re-run the backfill.
+ *
+ * Callers must treat this as fire-and-forget: per `assistant/CLAUDE.md`
+ * the daemon must never block startup, so `writeRelationshipState()`
+ * already catches every error. Wrapping this call in
+ * `void backfillRelationshipStateIfMissing().catch(() => {})` at the
+ * startup site provides a second belt-and-suspenders guarantee for any
+ * unexpected throw out of `existsSync`.
+ */
+export async function backfillRelationshipStateIfMissing(): Promise<void> {
+  const path = getRelationshipStatePath();
+  if (existsSync(path)) return; // idempotent — only runs once
+  log.info("Backfilling relationship-state.json for existing or upgraded user");
+  await writeRelationshipState();
+}
+
 // ─── Internal helpers ───────────────────────────────────────────────────
 
 /**

--- a/assistant/src/home/relationship-state-writer.ts
+++ b/assistant/src/home/relationship-state-writer.ts
@@ -34,7 +34,11 @@ import { buildAssistantEvent } from "../runtime/assistant-event.js";
 import { assistantEventHub } from "../runtime/assistant-event-hub.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { getLogger } from "../util/logger.js";
-import { getDataDir, getWorkspacePromptPath } from "../util/platform.js";
+import {
+  getDataDir,
+  getWorkspaceDir,
+  getWorkspacePromptPath,
+} from "../util/platform.js";
 import { computeProgressPercent, computeTier } from "./progress-formula.js";
 import {
   type Capability,
@@ -271,18 +275,21 @@ export async function backfillRelationshipStateIfMissing(): Promise<void> {
 
 /**
  * Resolve the raw markdown content of the guardian's user persona file
- * (`users/<slug>.md`), falling back to legacy workspace-root `USER.md`
- * when no guardian is resolvable or the persona file is missing.
+ * (`users/<slug>.md`). Walks a three-step fallback chain so a transient
+ * contact-store failure on a migrated workspace still surfaces real
+ * user content:
  *
- * Uses `resolveGuardianPersonaPath()` rather than a hardcoded
- * `users/default.md` so slugged user files populated by
- * `generateUserFileSlug` (e.g. `users/sidd.md`) are read correctly —
- * otherwise the writer would systematically under-extract facts and
- * `userName` for any contact-aware workspace.
+ *   1. `resolveGuardianPersonaPath()` via contact-store — the canonical
+ *      per-guardian slugged file (e.g. `users/sidd.md`).
+ *   2. `users/default.md` — the default-guardian persona file that the
+ *      workspace migration leaves in place. Catches the window where
+ *      the resolver throws or returns null but the file-backed content
+ *      is still available.
+ *   3. Workspace-root `USER.md` — legacy fallback for very old
+ *      workspaces that predate migration 031.
  *
- * Every step is guarded: any exception from the persona resolver or
- * the underlying contact store DB lookup collapses to the empty string
- * via the normal fallback chain, so `computeRelationshipState()` never
+ * Every step is guarded; an empty string is returned only when all
+ * three sources are unavailable, so `computeRelationshipState()` never
  * throws from this path.
  */
 function resolveGuardianUserContent(): string {
@@ -295,7 +302,21 @@ function resolveGuardianUserContent(): string {
   } catch (err) {
     log.warn(
       { err },
-      "Failed to resolve guardian persona path; falling back to legacy USER.md",
+      "Failed to resolve guardian persona path; trying users/default.md",
+    );
+  }
+
+  // Intermediate fallback: the default-guardian persona file that
+  // exists on most migrated workspaces even when the contact store is
+  // transiently unreachable.
+  try {
+    const defaultUserPath = join(getWorkspaceDir(), "users", "default.md");
+    const defaultContent = safeRead(defaultUserPath);
+    if (defaultContent) return defaultContent;
+  } catch (err) {
+    log.warn(
+      { err },
+      "Failed to read users/default.md; trying legacy USER.md",
     );
   }
 

--- a/assistant/src/home/relationship-state-writer.ts
+++ b/assistant/src/home/relationship-state-writer.ts
@@ -1,0 +1,516 @@
+/**
+ * Relationship-state writer.
+ *
+ * Derives a `RelationshipState` snapshot from the filesystem state of
+ * the workspace (the guardian's `users/<slug>.md` persona file — resolved
+ * via `persona-resolver` / `contact-store` — for world + priorities facts,
+ * with legacy workspace-root `USER.md` as a last-ditch fallback; SOUL.md
+ * for voice facts; IDENTITY.md for assistant / hatched metadata; the
+ * conversations directory for conversationCount) plus the OAuth
+ * connection store (for capability tiers), and writes it to
+ * `<workspace>/data/relationship-state.json`.
+ *
+ * Per assistant/CLAUDE.md the daemon must never block or throw at
+ * startup — the public entry points here catch every error and log a
+ * warning instead. Internal helpers use a narrow `safeRead` wrapper so
+ * a missing or unreadable file degrades gracefully to an empty string.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+
+import { listConnections } from "../oauth/oauth-store.js";
+import { resolveGuardianPersonaPath } from "../prompts/persona-resolver.js";
+import { getLogger } from "../util/logger.js";
+import {
+  getConversationsDir,
+  getDataDir,
+  getWorkspacePromptPath,
+} from "../util/platform.js";
+import { computeProgressPercent, computeTier } from "./progress-formula.js";
+import {
+  type Capability,
+  DEFAULT_CAPABILITIES,
+  type Fact,
+  RELATIONSHIP_STATE_VERSION,
+  type RelationshipState,
+} from "./relationship-state.js";
+
+const log = getLogger("relationship-state-writer");
+
+/**
+ * Filename for the on-disk snapshot. Lives under the workspace data dir.
+ */
+export const RELATIONSHIP_STATE_FILENAME = "relationship-state.json";
+
+/**
+ * Conversation-count threshold at which the "voice-writing" capability
+ * flips from `earned` (gated, shown with an `unlockHint`) to `unlocked`.
+ *
+ * This is a placeholder for Open Question #6 in the TDD. Wrap as a
+ * named constant so it's obvious which knob to tune when a deeper
+ * heuristic replaces it.
+ */
+const VOICE_WRITING_UNLOCK_CONVERSATIONS = 10;
+
+/** Default assistant name when IDENTITY.md cannot be parsed. */
+const DEFAULT_ASSISTANT_NAME = "Vellum";
+
+/** Default assistant identifier (multi-assistant reserved for future). */
+const DEFAULT_ASSISTANT_ID = "default";
+
+/**
+ * Canonical path to the relationship-state snapshot
+ * (`<workspace>/data/relationship-state.json`).
+ */
+export function getRelationshipStatePath(): string {
+  return join(getDataDir(), RELATIONSHIP_STATE_FILENAME);
+}
+
+/**
+ * Build a fresh `RelationshipState` from the current on-disk + DB state.
+ *
+ * This is the pure-ish computation half of the writer — it reads files
+ * and the oauth store but performs no writes. Callers that want to
+ * persist the result should use `writeRelationshipState()` instead.
+ */
+export async function computeRelationshipState(): Promise<RelationshipState> {
+  // Persona source-of-truth:
+  //   1. The guardian contact's per-user file (`users/<slug>.md`), resolved
+  //      via `resolveGuardianPersonaPath()` — this is the canonical location
+  //      after workspace migration 031 and handles slugged userFiles like
+  //      `users/sidd.md` that were invisible to a hardcoded `default.md`
+  //      lookup.
+  //   2. Legacy workspace-root `USER.md` as a last-ditch fallback for very
+  //      old workspaces that never ran migration 031.
+  //   3. Empty string → extraction yields [] and `userName` is undefined.
+  // Every step is guarded because the writer must never throw.
+  const userMd = resolveGuardianUserContent();
+  const soulMd = safeRead(getWorkspacePromptPath("SOUL.md"));
+  const identityPath = getWorkspacePromptPath("IDENTITY.md");
+
+  const facts = extractFacts({
+    userContent: userMd,
+    soulContent: soulMd,
+  });
+  const conversationCount = countConversations();
+  const capabilities = resolveCapabilityTiers({ conversationCount });
+  const { assistantName, hatchedDate } = parseIdentity(identityPath);
+  const userName = parseUserName(userMd);
+
+  const tier = computeTier({ facts, capabilities, conversationCount });
+  const progressPercent = computeProgressPercent({
+    facts,
+    capabilities,
+    conversationCount,
+  });
+
+  return {
+    version: RELATIONSHIP_STATE_VERSION,
+    assistantId: DEFAULT_ASSISTANT_ID,
+    tier,
+    progressPercent,
+    facts,
+    capabilities,
+    conversationCount,
+    hatchedDate,
+    assistantName,
+    userName,
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+/**
+ * Compute a fresh snapshot and persist it to `getRelationshipStatePath()`.
+ *
+ * Never throws — all errors are caught and logged as warnings. Fire-and-
+ * forget callers (e.g. the conversation-complete hook) can safely call
+ * this without additional try/catch wrapping.
+ */
+export async function writeRelationshipState(): Promise<void> {
+  try {
+    const state = await computeRelationshipState();
+    const path = getRelationshipStatePath();
+    mkdirSync(getDataDir(), { recursive: true });
+    writeFileSync(path, JSON.stringify(state, null, 2), "utf8");
+    log.info(
+      {
+        path,
+        tier: state.tier,
+        progress: state.progressPercent,
+        facts: state.facts.length,
+      },
+      "Wrote relationship-state.json",
+    );
+  } catch (err) {
+    log.warn({ err }, "Failed to write relationship-state.json");
+  }
+}
+
+// ─── Internal helpers ───────────────────────────────────────────────────
+
+/**
+ * Resolve the raw markdown content of the guardian's user persona file
+ * (`users/<slug>.md`), falling back to legacy workspace-root `USER.md`
+ * when no guardian is resolvable or the persona file is missing.
+ *
+ * Uses `resolveGuardianPersonaPath()` rather than a hardcoded
+ * `users/default.md` so slugged user files populated by
+ * `generateUserFileSlug` (e.g. `users/sidd.md`) are read correctly —
+ * otherwise the writer would systematically under-extract facts and
+ * `userName` for any contact-aware workspace.
+ *
+ * Every step is guarded: any exception from the persona resolver or
+ * the underlying contact store DB lookup collapses to the empty string
+ * via the normal fallback chain, so `computeRelationshipState()` never
+ * throws from this path.
+ */
+function resolveGuardianUserContent(): string {
+  try {
+    const guardianPath = resolveGuardianPersonaPath();
+    if (guardianPath) {
+      const content = safeRead(guardianPath);
+      if (content) return content;
+    }
+  } catch (err) {
+    log.warn(
+      { err },
+      "Failed to resolve guardian persona path; falling back to legacy USER.md",
+    );
+  }
+
+  // Legacy fallback: workspace-root USER.md for very old workspaces
+  // that predate migration 031.
+  const legacyPath = getWorkspacePromptPath("USER.md");
+  const legacy = safeRead(legacyPath);
+  if (legacy) return legacy;
+
+  return "";
+}
+
+/**
+ * Read a file as UTF-8, returning "" on any error.
+ *
+ * Used for every disk read in this module so a missing or unreadable
+ * workspace file degrades gracefully to an empty content string rather
+ * than propagating an exception out of a startup path.
+ */
+function safeRead(path: string): string {
+  try {
+    if (!existsSync(path)) return "";
+    return readFileSync(path, "utf-8");
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Walk the workspace prompt files and emit a flat list of inferred
+ * facts. This is deliberately a simple bullet/heading parser — the TDD
+ * explicitly calls out "don't try to be clever" here; the goal is to
+ * produce something non-empty for the UI so progress looks alive.
+ *
+ * Voice facts come from SOUL.md. World and priorities facts come from
+ * the guardian's `users/<slug>.md` persona file (resolved via
+ * `persona-resolver`), with legacy workspace-root `USER.md` as a
+ * fallback for workspaces that predate migration 031.
+ */
+function extractFacts(input: {
+  userContent: string;
+  soulContent: string;
+}): Fact[] {
+  const facts: Fact[] = [];
+  let counter = 0;
+  const nextId = (prefix: string): string => {
+    counter += 1;
+    return `${prefix}-${counter}`;
+  };
+
+  // Heuristic keyword map for USER.md sections -> fact category. Keys
+  // are matched case-insensitively as a prefix of the heading/bullet
+  // label. Everything that doesn't match stays a "world" fact.
+  const priorityKeywords = [
+    "goals",
+    "priority",
+    "priorities",
+    "focus",
+    "work role",
+    "role",
+    "projects",
+    "daily tools",
+    "tools",
+  ];
+  const worldKeywords = [
+    "name",
+    "pronouns",
+    "locale",
+    "location",
+    "hobbies",
+    "fun",
+    "timezone",
+    "background",
+  ];
+
+  for (const line of iterateBulletLines(input.userContent)) {
+    const parsed = parseBulletLabelValue(line);
+    if (!parsed) continue;
+    const { label, value } = parsed;
+    if (!value) continue;
+    const lower = label.toLowerCase();
+    const isPriority = priorityKeywords.some((k) => lower.startsWith(k));
+    const isWorld = worldKeywords.some((k) => lower.startsWith(k));
+    const category: Fact["category"] = isPriority
+      ? "priorities"
+      : isWorld
+        ? "world"
+        : "world";
+    facts.push({
+      id: nextId("user"),
+      category,
+      text: `${capitalizeLabel(label)}: ${value}`,
+      confidence: "strong",
+      source: "inferred",
+    });
+  }
+
+  for (const line of iterateBulletLines(input.soulContent)) {
+    const parsed = parseBulletLabelValue(line);
+    if (!parsed) continue;
+    const { label, value } = parsed;
+    if (!value) continue;
+    facts.push({
+      id: nextId("soul"),
+      category: "voice",
+      text: `${capitalizeLabel(label)}: ${value}`,
+      confidence: "strong",
+      source: "inferred",
+    });
+  }
+
+  return facts;
+}
+
+/**
+ * Yield non-empty bullet lines from a markdown string, skipping comment
+ * lines (leading `_`) and indented continuation. Lines returned are the
+ * trimmed bullet body, without the leading `-` or `*`.
+ */
+function* iterateBulletLines(content: string): Generator<string> {
+  if (!content) return;
+  for (const raw of content.split("\n")) {
+    const line = raw.trim();
+    if (!line) continue;
+    if (line.startsWith("_")) continue;
+    if (!line.startsWith("- ") && !line.startsWith("* ")) continue;
+    const body = line.slice(2).trim();
+    if (body.length === 0) continue;
+    yield body;
+  }
+}
+
+/**
+ * Parse a bullet body of the form `**Label:** value` or `Label: value`
+ * into its label and value halves. Returns null when no colon is found.
+ */
+function parseBulletLabelValue(
+  body: string,
+): { label: string; value: string } | null {
+  const stripped = body.replace(/\*\*/g, "").replace(/__/g, "");
+  const idx = stripped.indexOf(":");
+  if (idx <= 0) return null;
+  const label = stripped.slice(0, idx).trim();
+  const value = stripped.slice(idx + 1).trim();
+  if (!label) return null;
+  return { label, value };
+}
+
+/**
+ * Lowercase-ify a label but keep the first character uppercased for
+ * display: "PREFERRED Name" -> "Preferred name".
+ */
+function capitalizeLabel(label: string): string {
+  const trimmed = label.trim();
+  if (!trimmed) return trimmed;
+  return trimmed.charAt(0).toUpperCase() + trimmed.slice(1).toLowerCase();
+}
+
+/**
+ * Project `DEFAULT_CAPABILITIES` into a concrete capability list by
+ * consulting the OAuth connection store for integration-gated tiers
+ * and the conversation count for usage-gated tiers.
+ *
+ * Failures in the oauth lookup fall back to the "empty set" — every
+ * integration appears as `next-up` — so startup paths never throw.
+ */
+function resolveCapabilityTiers(opts: {
+  conversationCount: number;
+}): Capability[] {
+  const connectedProviders = resolveConnectedProviders();
+
+  return DEFAULT_CAPABILITIES.map((cap) => {
+    switch (cap.id) {
+      case "email": {
+        // Only Gmail is a real email integration today. Outlook appears in
+        // seed-providers.ts as scaffolding but we don't actually ship a
+        // Microsoft integration, so we do not advertise email unlock for it.
+        const unlocked =
+          connectedProviders.has("google") || connectedProviders.has("gmail");
+        return { ...cap, tier: unlocked ? "unlocked" : "next-up" };
+      }
+      case "calendar": {
+        // Only Google Calendar is a real calendar integration today.
+        const unlocked =
+          connectedProviders.has("google") ||
+          connectedProviders.has("google-calendar");
+        return { ...cap, tier: unlocked ? "unlocked" : "next-up" };
+      }
+      case "slack": {
+        const unlocked = connectedProviders.has("slack");
+        return { ...cap, tier: unlocked ? "unlocked" : "next-up" };
+      }
+      case "voice-writing": {
+        const unlocked =
+          opts.conversationCount >= VOICE_WRITING_UNLOCK_CONVERSATIONS;
+        return { ...cap, tier: unlocked ? "unlocked" : "earned" };
+      }
+      case "proactive":
+      case "autonomous":
+      default:
+        return { ...cap, tier: "earned" };
+    }
+  });
+}
+
+/**
+ * Return the set of provider keys with at least one `active` OAuth
+ * connection. Any failure (DB not initialized, schema drift, etc.)
+ * returns an empty set so the writer keeps advancing with sane
+ * defaults.
+ */
+function resolveConnectedProviders(): Set<string> {
+  try {
+    const rows = listConnections();
+    const set = new Set<string>();
+    for (const row of rows) {
+      if (row.status === "active") set.add(row.provider);
+    }
+    return set;
+  } catch (err) {
+    log.warn(
+      { err },
+      "Failed to list OAuth connections; assuming no integrations connected",
+    );
+    return new Set<string>();
+  }
+}
+
+/**
+ * Count conversations by listing the conversations directory. Returns
+ * 0 when the directory is missing or unreadable.
+ */
+function countConversations(): number {
+  try {
+    const dir = getConversationsDir();
+    if (!existsSync(dir)) return 0;
+    return readdirSync(dir).length;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Pull `assistantName` and `hatchedDate` from IDENTITY.md.
+ *
+ * IDENTITY.md is a freeform markdown file, so for the name we scan
+ * bullet lines for the first recognizable `name` label. For the
+ * hatched date we prefer any explicit `hatched:` / `birth:` bullet,
+ * then fall back to the file's `stat.birthtime` (matching the
+ * pattern already established by `identity-routes.ts`), and finally
+ * to `stat.mtime` if birthtime is unavailable. We never fall back to
+ * `new Date()` — `writeRelationshipState()` is called on every turn
+ * boundary, so a `Date.now()` fallback would cause `hatchedDate` to
+ * drift forward on every write, turning a stable "relationship
+ * start" timestamp into a constantly-updating "last touched"
+ * timestamp. When nothing is readable we emit the Unix epoch as an
+ * unmistakable sentinel instead of silently drifting.
+ */
+function parseIdentity(identityPath: string): {
+  assistantName: string;
+  hatchedDate: string;
+} {
+  const content = safeRead(identityPath);
+
+  let assistantName = DEFAULT_ASSISTANT_NAME;
+  let explicitHatched: string | undefined;
+
+  for (const line of iterateBulletLines(content)) {
+    const parsed = parseBulletLabelValue(line);
+    if (!parsed || !parsed.value) continue;
+    const lower = parsed.label.toLowerCase();
+    if (lower.startsWith("name") && assistantName === DEFAULT_ASSISTANT_NAME) {
+      assistantName = parsed.value;
+    }
+    if (
+      !explicitHatched &&
+      (lower.startsWith("hatched") || lower.startsWith("birth"))
+    ) {
+      const parsedDate = new Date(parsed.value);
+      if (!isNaN(parsedDate.getTime())) {
+        explicitHatched = parsedDate.toISOString();
+      }
+    }
+  }
+
+  if (explicitHatched) {
+    return { assistantName, hatchedDate: explicitHatched };
+  }
+
+  // Stable fallback: use the IDENTITY.md file birth time so the
+  // relationship start date is monotonic across turns. Matches the
+  // approach used by `identity-routes.ts` for the Settings UI.
+  try {
+    const stats = statSync(identityPath);
+    const candidate =
+      stats.birthtime.getTime() > 0 ? stats.birthtime : stats.mtime;
+    if (candidate.getTime() > 0) {
+      return { assistantName, hatchedDate: candidate.toISOString() };
+    }
+  } catch {
+    // File missing or unreadable — fall through to the sentinel.
+  }
+
+  // Last-ditch sentinel: unmistakably ancient so any UI showing it
+  // makes the "we couldn't resolve your hatched date" state obvious.
+  return { assistantName, hatchedDate: new Date(0).toISOString() };
+}
+
+/**
+ * Best-effort user-name extraction from USER.md (or its successor
+ * `users/<slug>.md`). Returns undefined when no `name`/`preferred` line
+ * is present so the caller can leave `userName` off the wire.
+ */
+function parseUserName(content: string): string | undefined {
+  if (!content) return undefined;
+  for (const line of iterateBulletLines(content)) {
+    const parsed = parseBulletLabelValue(line);
+    if (!parsed) continue;
+    const lower = parsed.label.toLowerCase();
+    if (
+      (lower.startsWith("name") ||
+        lower.startsWith("preferred") ||
+        lower === "user" ||
+        lower === "user name") &&
+      parsed.value
+    ) {
+      return parsed.value;
+    }
+  }
+  return undefined;
+}

--- a/assistant/src/home/relationship-state-writer.ts
+++ b/assistant/src/home/relationship-state-writer.ts
@@ -5,10 +5,12 @@
  * the workspace (the guardian's `users/<slug>.md` persona file — resolved
  * via `persona-resolver` / `contact-store` — for world + priorities facts,
  * with legacy workspace-root `USER.md` as a last-ditch fallback; SOUL.md
- * for voice facts; IDENTITY.md for assistant / hatched metadata; the
- * conversations directory for conversationCount) plus the OAuth
- * connection store (for capability tiers), and writes it to
- * `<workspace>/data/relationship-state.json`.
+ * for voice facts; IDENTITY.md for assistant / hatched metadata) plus
+ * the DB-authoritative conversation count (via
+ * `conversation-queries.countConversations`, matching the UI's
+ * `listConversations` filter — no `background` / `private` / `scheduled`)
+ * and the OAuth connection store (for capability tiers), and writes it
+ * to `<workspace>/data/relationship-state.json`.
  *
  * Per assistant/CLAUDE.md the daemon must never block or throw at
  * startup — the public entry points here catch every error and log a
@@ -19,24 +21,20 @@
 import {
   existsSync,
   mkdirSync,
-  readdirSync,
   readFileSync,
   statSync,
   writeFileSync,
 } from "node:fs";
 import { join } from "node:path";
 
+import { countConversations as countConversationsDb } from "../memory/conversation-queries.js";
 import { listConnections } from "../oauth/oauth-store.js";
 import { resolveGuardianPersonaPath } from "../prompts/persona-resolver.js";
 import { buildAssistantEvent } from "../runtime/assistant-event.js";
 import { assistantEventHub } from "../runtime/assistant-event-hub.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { getLogger } from "../util/logger.js";
-import {
-  getConversationsDir,
-  getDataDir,
-  getWorkspacePromptPath,
-} from "../util/platform.js";
+import { getDataDir, getWorkspacePromptPath } from "../util/platform.js";
 import { computeProgressPercent, computeTier } from "./progress-formula.js";
 import {
   type Capability,
@@ -131,13 +129,33 @@ export async function computeRelationshipState(): Promise<RelationshipState> {
 }
 
 /**
- * Compute a fresh snapshot and persist it to `getRelationshipStatePath()`.
+ * In-module serialization primitive for `writeRelationshipState`.
  *
- * Never throws — all errors are caught and logged as warnings. Fire-and-
- * forget callers (e.g. the conversation-complete hook) can safely call
- * this without additional try/catch wrapping.
+ * Multiple conversations can finish a turn simultaneously, each firing
+ * `void writeRelationshipState()` from `conversation-agent-loop`.
+ * Without coalescing, two compute+write cycles can interleave
+ * (compute A → compute B → writeSync A → writeSync B), so the
+ * persisted snapshot reflects an older state than the last turn and
+ * two SSE events fire that don't match the final on-disk content.
+ *
+ * We use a "latest wins" pattern:
+ *   - If no write is in flight, start one.
+ *   - If a write is in flight, mark dirty and return the in-flight
+ *     promise. Overlapping callers all resolve off the same tail.
+ *   - When the in-flight write finishes, if dirty, run again.
+ *
+ * Guarantees:
+ *   - At most one compute+write runs at a time.
+ *   - N overlapping callers during one write produce exactly one
+ *     tail write, not N.
+ *   - The final on-disk state always reflects the latest completed
+ *     compute.
+ *   - No unbounded queue.
  */
-export async function writeRelationshipState(): Promise<void> {
+let writeInFlight: Promise<void> | null = null;
+let writeDirty = false;
+
+async function runWriteRelationshipState(): Promise<void> {
   let writtenState: RelationshipState | undefined;
   try {
     const state = await computeRelationshipState();
@@ -169,6 +187,37 @@ export async function writeRelationshipState(): Promise<void> {
   if (writtenState) {
     publishRelationshipStateUpdated(writtenState.updatedAt);
   }
+}
+
+/**
+ * Compute a fresh snapshot and persist it to `getRelationshipStatePath()`.
+ *
+ * Never throws — all errors are caught and logged as warnings. Fire-and-
+ * forget callers (e.g. the conversation-complete hook) can safely call
+ * this without additional try/catch wrapping.
+ *
+ * Concurrent calls are coalesced (see `writeInFlight` above): at most
+ * one compute+write runs at a time, and overlapping calls during an
+ * in-flight write all resolve off a single tail write that reflects
+ * the latest state.
+ */
+export async function writeRelationshipState(): Promise<void> {
+  if (writeInFlight) {
+    writeDirty = true;
+    return writeInFlight;
+  }
+  writeInFlight = (async () => {
+    try {
+      await runWriteRelationshipState();
+      while (writeDirty) {
+        writeDirty = false;
+        await runWriteRelationshipState();
+      }
+    } finally {
+      writeInFlight = null;
+    }
+  })();
+  return writeInFlight;
 }
 
 /**
@@ -307,16 +356,6 @@ function extractFacts(input: {
     "daily tools",
     "tools",
   ];
-  const worldKeywords = [
-    "name",
-    "pronouns",
-    "locale",
-    "location",
-    "hobbies",
-    "fun",
-    "timezone",
-    "background",
-  ];
 
   for (const line of iterateBulletLines(input.userContent)) {
     const parsed = parseBulletLabelValue(line);
@@ -325,12 +364,7 @@ function extractFacts(input: {
     if (!value) continue;
     const lower = label.toLowerCase();
     const isPriority = priorityKeywords.some((k) => lower.startsWith(k));
-    const isWorld = worldKeywords.some((k) => lower.startsWith(k));
-    const category: Fact["category"] = isPriority
-      ? "priorities"
-      : isWorld
-        ? "world"
-        : "world";
+    const category: Fact["category"] = isPriority ? "priorities" : "world";
     facts.push({
       id: nextId("user"),
       category,
@@ -472,34 +506,94 @@ function resolveConnectedProviders(): Set<string> {
 }
 
 /**
- * Count conversations by listing the conversations directory. Returns
- * 0 when the directory is missing or unreadable.
+ * Count conversations using the DB-authoritative helper from
+ * `conversation-queries`. This matches `listConversations()` used by
+ * the UI — it filters out `background`, `private`, and `scheduled`
+ * conversation types — and is immune to stray filesystem entries like
+ * `.DS_Store` or double-counts from workspace migration 009 where
+ * legacy + canonical directory forms temporarily co-exist.
+ *
+ * Returns 0 on any failure (DB not initialized, schema drift, etc.)
+ * so the writer still produces a valid snapshot — per module contract
+ * this path must never throw.
  */
 function countConversations(): number {
   try {
-    const dir = getConversationsDir();
-    if (!existsSync(dir)) return 0;
-    return readdirSync(dir).length;
-  } catch {
+    return countConversationsDb();
+  } catch (err) {
+    log.warn({ err }, "Failed to count conversations from DB; defaulting to 0");
     return 0;
   }
+}
+
+/**
+ * Filename for the hatched-date sidecar, used as a stable fallback
+ * when IDENTITY.md is missing / unreadable / has no explicit hatched
+ * bullet and file stat is unavailable. Lives under the workspace
+ * data dir alongside `relationship-state.json`.
+ */
+const HATCHED_SIDECAR_FILENAME = "hatched.json";
+
+function getHatchedSidecarPath(): string {
+  return join(getDataDir(), HATCHED_SIDECAR_FILENAME);
+}
+
+/**
+ * Resolve a stable hatched-date fallback timestamp.
+ *
+ * The Swift client, OpenAPI schema, and UI have no special handling
+ * for a Unix-epoch sentinel — they'll render "1/1/1970" to the user.
+ * Instead, we use `new Date().toISOString()` the first time a
+ * fallback is needed and persist it to a small sidecar file
+ * (`data/hatched.json`). Subsequent calls read the sidecar first, so
+ * the returned timestamp is monotonic across writes and the
+ * `hatchedDate` field never drifts once initialized.
+ *
+ * Never throws — a sidecar read/write failure still yields a valid
+ * (though non-stable) `now` timestamp, which is still far better than
+ * the epoch sentinel.
+ */
+function resolveFallbackHatchedDate(): string {
+  const path = getHatchedSidecarPath();
+  try {
+    if (existsSync(path)) {
+      const parsed = JSON.parse(readFileSync(path, "utf-8")) as {
+        hatchedAt?: string;
+      };
+      if (parsed.hatchedAt && !isNaN(Date.parse(parsed.hatchedAt))) {
+        return parsed.hatchedAt;
+      }
+    }
+  } catch {
+    // Fall through to write a fresh sidecar.
+  }
+  const now = new Date().toISOString();
+  try {
+    mkdirSync(getDataDir(), { recursive: true });
+    writeFileSync(path, JSON.stringify({ hatchedAt: now }, null, 2), "utf-8");
+  } catch {
+    // If even the sidecar write fails, return `now` anyway — the
+    // caller will just get a fresh-looking date on every call. Not
+    // ideal, but far better than the epoch sentinel.
+  }
+  return now;
 }
 
 /**
  * Pull `assistantName` and `hatchedDate` from IDENTITY.md.
  *
  * IDENTITY.md is a freeform markdown file, so for the name we scan
- * bullet lines for the first recognizable `name` label. For the
- * hatched date we prefer any explicit `hatched:` / `birth:` bullet,
- * then fall back to the file's `stat.birthtime` (matching the
- * pattern already established by `identity-routes.ts`), and finally
- * to `stat.mtime` if birthtime is unavailable. We never fall back to
- * `new Date()` — `writeRelationshipState()` is called on every turn
- * boundary, so a `Date.now()` fallback would cause `hatchedDate` to
- * drift forward on every write, turning a stable "relationship
- * start" timestamp into a constantly-updating "last touched"
- * timestamp. When nothing is readable we emit the Unix epoch as an
- * unmistakable sentinel instead of silently drifting.
+ * bullet lines for any recognizable `name` label (`Name`,
+ * `Assistant Name`, `Preferred Name`, etc.). For the hatched date we
+ * prefer any explicit `hatched:` / `birth:` bullet, then fall back to
+ * the file's `stat.birthtime` (matching the pattern already
+ * established by `identity-routes.ts`), and finally to `stat.mtime`
+ * if birthtime is unavailable. We never fall back to `new Date()`
+ * directly — `writeRelationshipState()` is called on every turn
+ * boundary, so a raw `Date.now()` fallback would cause `hatchedDate`
+ * to drift forward on every write. Instead, when nothing else is
+ * readable we resolve via `resolveFallbackHatchedDate()` which
+ * persists a stable timestamp to a sidecar file on first use.
  */
 function parseIdentity(identityPath: string): {
   assistantName: string;
@@ -514,7 +608,17 @@ function parseIdentity(identityPath: string): {
     const parsed = parseBulletLabelValue(line);
     if (!parsed || !parsed.value) continue;
     const lower = parsed.label.toLowerCase();
-    if (lower.startsWith("name") && assistantName === DEFAULT_ASSISTANT_NAME) {
+    // Accept any label whose lowercased form looks like a "name"
+    // label: `Name`, `Assistant Name`, `Preferred Name`, etc.
+    // Preserves the "first match wins" precedence so a raw `Name`
+    // bullet still takes precedence over later aliases.
+    if (
+      assistantName === DEFAULT_ASSISTANT_NAME &&
+      (lower === "name" ||
+        lower === "assistant name" ||
+        lower === "preferred name" ||
+        lower.startsWith("name"))
+    ) {
       assistantName = parsed.value;
     }
     if (
@@ -543,12 +647,14 @@ function parseIdentity(identityPath: string): {
       return { assistantName, hatchedDate: candidate.toISOString() };
     }
   } catch {
-    // File missing or unreadable — fall through to the sentinel.
+    // File missing or unreadable — fall through to the sidecar.
   }
 
-  // Last-ditch sentinel: unmistakably ancient so any UI showing it
-  // makes the "we couldn't resolve your hatched date" state obvious.
-  return { assistantName, hatchedDate: new Date(0).toISOString() };
+  // Last-ditch sidecar-backed fallback: `resolveFallbackHatchedDate`
+  // returns a stable, real timestamp (persisted to `data/hatched.json`
+  // on first call) instead of the old epoch sentinel, so the UI never
+  // shows "1/1/1970".
+  return { assistantName, hatchedDate: resolveFallbackHatchedDate() };
 }
 
 /**

--- a/assistant/src/home/relationship-state-writer.ts
+++ b/assistant/src/home/relationship-state-writer.ts
@@ -28,6 +28,9 @@ import { join } from "node:path";
 
 import { listConnections } from "../oauth/oauth-store.js";
 import { resolveGuardianPersonaPath } from "../prompts/persona-resolver.js";
+import { buildAssistantEvent } from "../runtime/assistant-event.js";
+import { assistantEventHub } from "../runtime/assistant-event-hub.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { getLogger } from "../util/logger.js";
 import {
   getConversationsDir,
@@ -135,11 +138,17 @@ export async function computeRelationshipState(): Promise<RelationshipState> {
  * this without additional try/catch wrapping.
  */
 export async function writeRelationshipState(): Promise<void> {
+  let writtenState: RelationshipState | undefined;
   try {
     const state = await computeRelationshipState();
     const path = getRelationshipStatePath();
     mkdirSync(getDataDir(), { recursive: true });
     writeFileSync(path, JSON.stringify(state, null, 2), "utf8");
+    // Only mark the state as "written" AFTER the sync write has
+    // succeeded — any throw from `writeFileSync` short-circuits the
+    // SSE emit below so subscribers never see a stale update event
+    // that contradicts on-disk state.
+    writtenState = state;
     log.info(
       {
         path,
@@ -152,6 +161,33 @@ export async function writeRelationshipState(): Promise<void> {
   } catch (err) {
     log.warn({ err }, "Failed to write relationship-state.json");
   }
+
+  // SSE fanout lives outside the try/catch so a publish failure does
+  // not get mis-logged as a write failure. Still guarded against the
+  // publish throwing (e.g. a subscriber rejects) — the writer promise
+  // must never reject from this path.
+  if (writtenState) {
+    publishRelationshipStateUpdated(writtenState.updatedAt);
+  }
+}
+
+/**
+ * Publish the `relationship_state_updated` event to the in-process
+ * assistant event hub. Called only on the success branch of
+ * `writeRelationshipState()` so the event accurately reflects what
+ * just landed on disk.
+ */
+function publishRelationshipStateUpdated(updatedAt: string): void {
+  assistantEventHub
+    .publish(
+      buildAssistantEvent(DAEMON_INTERNAL_ASSISTANT_ID, {
+        type: "relationship_state_updated",
+        updatedAt,
+      }),
+    )
+    .catch((err) => {
+      log.warn({ err }, "Failed to publish relationship_state_updated event");
+    });
 }
 
 // ─── Internal helpers ───────────────────────────────────────────────────

--- a/assistant/src/home/relationship-state-writer.ts
+++ b/assistant/src/home/relationship-state-writer.ts
@@ -76,11 +76,15 @@ export function getRelationshipStatePath(): string {
 }
 
 /**
- * Build a fresh `RelationshipState` from the current on-disk + DB state.
+ * Build a fresh `RelationshipState` snapshot from the current workspace.
+ * Reads USER.md / SOUL.md / IDENTITY.md, queries the oauth connection
+ * store, and counts conversations via the DB-authoritative helper.
  *
- * This is the pure-ish computation half of the writer — it reads files
- * and the oauth store but performs no writes. Callers that want to
- * persist the result should use `writeRelationshipState()` instead.
+ * Side effect: on the very first call when IDENTITY.md cannot provide
+ * a hatched date, `resolveFallbackHatchedDate` persists a one-time
+ * `data/hatched.json` sidecar so subsequent calls return a monotonic
+ * timestamp. All other paths are read-only. Callers that want to
+ * persist the full snapshot should use `writeRelationshipState()`.
  */
 export async function computeRelationshipState(): Promise<RelationshipState> {
   // Persona source-of-truth:
@@ -650,10 +654,9 @@ function parseIdentity(identityPath: string): {
     // File missing or unreadable — fall through to the sidecar.
   }
 
-  // Last-ditch sidecar-backed fallback: `resolveFallbackHatchedDate`
-  // returns a stable, real timestamp (persisted to `data/hatched.json`
-  // on first call) instead of the old epoch sentinel, so the UI never
-  // shows "1/1/1970".
+  // Last-ditch fallback: `resolveFallbackHatchedDate` returns a stable,
+  // real timestamp (persisted to `data/hatched.json` on first call) so
+  // the wire contract always carries a valid ISO date.
   return { assistantName, hatchedDate: resolveFallbackHatchedDate() };
 }
 
@@ -669,10 +672,10 @@ function parseUserName(content: string): string | undefined {
     if (!parsed) continue;
     const lower = parsed.label.toLowerCase();
     if (
-      (lower.startsWith("name") ||
-        lower.startsWith("preferred") ||
-        lower === "user" ||
-        lower === "user name") &&
+      (lower === "user" ||
+        lower === "user name" ||
+        lower.startsWith("preferred name") ||
+        lower.startsWith("name")) &&
       parsed.value
     ) {
       return parsed.value;

--- a/assistant/src/home/relationship-state.ts
+++ b/assistant/src/home/relationship-state.ts
@@ -102,7 +102,7 @@ export const DEFAULT_CAPABILITIES: Omit<Capability, "tier">[] = [
     id: "email",
     name: "Email access",
     description: "Read, draft, and manage your email",
-    gate: "Connect Google or Outlook",
+    gate: "Connect Google",
     ctaLabel: "Connect Google →",
   },
   {

--- a/assistant/src/home/relationship-state.ts
+++ b/assistant/src/home/relationship-state.ts
@@ -1,0 +1,143 @@
+/**
+ * Relationship state data contract.
+ *
+ * This is the shared wire format that describes the assistant's current
+ * relationship with the user: which tier they're at, what facts the
+ * assistant has learned about them, and which capabilities are unlocked.
+ *
+ * The TypeScript types here are the source of truth. A structurally
+ * identical Swift definition lives at
+ * `clients/shared/Models/RelationshipState.swift` — any change here must
+ * be mirrored there (and the contract test guards the default list).
+ */
+
+export const RELATIONSHIP_STATE_VERSION = 1 as const;
+
+export type RelationshipTier = 1 | 2 | 3 | 4;
+
+export interface TierInfo {
+  label: string;
+  description: string;
+  nextTierHint?: string;
+}
+
+export const TIER_INFO: Record<RelationshipTier, TierInfo> = {
+  1: {
+    label: "Getting to know you",
+    description: "We just met — learning the basics",
+    nextTierHint: "A few more conversations and I'll start to find my footing",
+  },
+  2: {
+    label: "Finding my footing",
+    description: "Starting to understand how you work",
+    nextTierHint: "Keep working with me and we'll hit our stride",
+  },
+  3: {
+    label: "Hitting our stride",
+    description: "We have a real working relationship",
+    nextTierHint:
+      "Give me more context and autonomy and we'll be fully in sync",
+  },
+  4: {
+    label: "In sync",
+    description: "Full partnership",
+  },
+};
+
+export type FactCategory = "voice" | "world" | "priorities";
+export type FactConfidence = "strong" | "uncertain";
+export type FactSource = "onboarding" | "inferred";
+
+export interface Fact {
+  id: string;
+  category: FactCategory;
+  text: string;
+  confidence: FactConfidence;
+  source: FactSource;
+}
+
+export type CapabilityTier = "unlocked" | "next-up" | "earned";
+
+export interface Capability {
+  id: string;
+  name: string;
+  description: string;
+  tier: CapabilityTier;
+  /** Human-readable unlock requirement. */
+  gate: string;
+  /** Shown on "earned" tier: why, not when. */
+  unlockHint?: string;
+  /** Shown on "next-up" tier: e.g. "Connect Google →". */
+  ctaLabel?: string;
+}
+
+export interface RelationshipState {
+  version: typeof RELATIONSHIP_STATE_VERSION;
+  /** Forward-compat for multi-assistant. Only one assistant is supported in v1. */
+  assistantId: string;
+  tier: RelationshipTier;
+  /** 0-100 */
+  progressPercent: number;
+  facts: Fact[];
+  capabilities: Capability[];
+  conversationCount: number;
+  /** ISO 8601 */
+  hatchedDate: string;
+  assistantName: string;
+  userName?: string;
+  /** ISO 8601 */
+  updatedAt: string;
+}
+
+/**
+ * Seed list of capabilities the relationship-state writer should project,
+ * minus the `tier` field (which is computed at write time based on what
+ * the assistant has learned and which integrations are connected).
+ *
+ * Order and ids are part of the public contract — the contract test
+ * asserts this list matches the TDD so drift causes a failure.
+ */
+export const DEFAULT_CAPABILITIES: Omit<Capability, "tier">[] = [
+  {
+    id: "email",
+    name: "Email access",
+    description: "Read, draft, and manage your email",
+    gate: "Connect Google or Outlook",
+    ctaLabel: "Connect Google →",
+  },
+  {
+    id: "calendar",
+    name: "Calendar awareness",
+    description: "Know your schedule, prep for meetings",
+    gate: "Connect calendar",
+    ctaLabel: "Connect Calendar →",
+  },
+  {
+    id: "slack",
+    name: "Slack monitoring",
+    description: "Watch channels, surface what matters",
+    gate: "Set up Slack app",
+    ctaLabel: "Set up Slack →",
+  },
+  {
+    id: "voice-writing",
+    name: "Write in your voice",
+    description: "Draft messages and docs that sound like you",
+    gate: "Usage — needs conversation history",
+    unlockHint: "I need to learn how you communicate first",
+  },
+  {
+    id: "proactive",
+    name: "Proactive suggestions",
+    description: "Flag things before you ask",
+    gate: "Trust — needs priority understanding",
+    unlockHint: "I need to understand your priorities first",
+  },
+  {
+    id: "autonomous",
+    name: "Act on your behalf",
+    description: "Send messages, file things, take action",
+    gate: "Trust — deepest level",
+    unlockHint: "We need a deeper working relationship first",
+  },
+];

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -181,6 +181,7 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   // Settings / integrations / identity
   { endpoint: "identity", scopes: ["settings.read"] },
   { endpoint: "identity/intro", scopes: ["settings.read"] },
+  { endpoint: "home/state", scopes: ["settings.read"] },
   { endpoint: "brain-graph", scopes: ["settings.read"] },
   { endpoint: "brain-graph-ui", scopes: ["settings.read"] },
   { endpoint: "contacts", scopes: ["settings.read"] },

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -164,6 +164,7 @@ import { guardianActionRouteDefinitions } from "./routes/guardian-action-routes.
 import { handleGuardianBootstrap } from "./routes/guardian-bootstrap-routes.js";
 import { handleGuardianRefresh } from "./routes/guardian-refresh-routes.js";
 import { heartbeatRouteDefinitions } from "./routes/heartbeat-routes.js";
+import { homeStateRouteDefinitions } from "./routes/home-state-routes.js";
 import { hostBashRouteDefinitions } from "./routes/host-bash-routes.js";
 import {
   hostBrowserRouteDefinitions,
@@ -1459,6 +1460,7 @@ export class RuntimeHttpServer {
       ...heartbeatRouteDefinitions({
         getHeartbeatService: this.getHeartbeatService,
       }),
+      ...homeStateRouteDefinitions(),
       ...notificationRouteDefinitions(),
       ...diagnosticsRouteDefinitions(),
       ...logExportRouteDefinitions(),

--- a/assistant/src/runtime/routes/home-state-routes.ts
+++ b/assistant/src/runtime/routes/home-state-routes.ts
@@ -63,54 +63,59 @@ const relationshipStateSchema = z.object({
 /**
  * Handle `GET /v1/home/state`.
  *
- * Returns the persisted `relationship-state.json` when present; on a
- * cache miss (missing file, unreadable JSON, OR structurally-invalid
- * shape) falls back to `computeRelationshipState()` so callers always
- * get a valid response shape that matches `relationshipStateSchema`.
- * The read-through fallback deliberately does NOT write a fresh
- * snapshot to disk — the daemon's conversation-complete hook owns
- * writes so progress updates stay batched to real state transitions
- * rather than opportunistic GETs.
+ * Always computes a fresh snapshot so the response reflects the
+ * latest OAuth connection state, conversation count, and extracted
+ * facts — not just whatever the conversation-complete writer last
+ * persisted. This avoids serving stale capability tiers when the
+ * user connects an integration between turns, or when a delete/wipe
+ * flow mutates conversation count outside the turn-boundary writer.
+ *
+ * The persisted `relationship-state.json` remains useful as:
+ *   - A seed for the existing-user backfill on daemon startup.
+ *   - A fallback when live compute fails (e.g. DB not yet ready at
+ *     cold start, or a transient filesystem error).
+ *
+ * The route does NOT write to disk or emit SSE on read — writes are
+ * still owned exclusively by the writer so turn-boundary SSE events
+ * remain tied to real state transitions rather than GET traffic.
  */
 export async function handleGetHomeState(): Promise<Response> {
-  const path = getRelationshipStatePath();
+  try {
+    const state = await computeRelationshipState();
+    return Response.json(state);
+  } catch (computeErr) {
+    log.warn(
+      { err: computeErr },
+      "Live compute failed; falling back to persisted relationship-state.json",
+    );
+  }
 
+  const path = getRelationshipStatePath();
   if (existsSync(path)) {
     try {
       const raw = readFileSync(path, "utf-8");
       const parsed: unknown = JSON.parse(raw);
-      // Validate shape, not just JSON syntax. A stale or partial file
-      // (e.g. from a pre-v1 snapshot or a truncated write) must NOT be
-      // served to the client — fall through to compute instead so
-      // strict client decoders don't choke.
       const validated = relationshipStateSchema.safeParse(parsed);
       if (validated.success) {
         return Response.json(validated.data);
       }
       log.warn(
         { path, issues: validated.error.issues },
-        "Persisted relationship-state.json failed schema validation; falling back to live compute",
+        "Persisted relationship-state.json failed schema validation",
       );
     } catch (err) {
       log.warn(
         { err, path },
-        "Failed to read persisted relationship-state.json; falling back to live compute",
+        "Failed to read persisted relationship-state.json as fallback",
       );
-      // Fall through to the compute path.
     }
   }
 
-  try {
-    const state = await computeRelationshipState();
-    return Response.json(state);
-  } catch (err) {
-    log.warn({ err }, "Failed to compute relationship state on-demand");
-    return httpError(
-      "INTERNAL_ERROR",
-      "Failed to compute relationship state",
-      500,
-    );
-  }
+  return httpError(
+    "INTERNAL_ERROR",
+    "Failed to compute relationship state",
+    500,
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/runtime/routes/home-state-routes.ts
+++ b/assistant/src/runtime/routes/home-state-routes.ts
@@ -1,0 +1,133 @@
+/**
+ * Home state HTTP routes.
+ *
+ * Exposes `GET /v1/home/state` so macOS (and other) clients can fetch
+ * the current `RelationshipState` snapshot. The normal path reads
+ * the JSON file produced by `writeRelationshipState()`; if that file
+ * is missing — e.g. on a fresh install before the writer has landed
+ * its first snapshot — the handler falls back to computing the
+ * state on-demand so the client never sees a 404 and the UI can
+ * always render.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+
+import { z } from "zod";
+
+import {
+  computeRelationshipState,
+  getRelationshipStatePath,
+} from "../../home/relationship-state-writer.js";
+import { getLogger } from "../../util/logger.js";
+import { httpError } from "../http-errors.js";
+import type { RouteDefinition } from "../http-router.js";
+
+const log = getLogger("home-state-routes");
+
+// ---------------------------------------------------------------------------
+// Response schema (shared with the OpenAPI generator and runtime validation)
+// ---------------------------------------------------------------------------
+
+const factSchema = z.object({
+  id: z.string(),
+  category: z.enum(["voice", "world", "priorities"]),
+  text: z.string(),
+  confidence: z.enum(["strong", "uncertain"]),
+  source: z.enum(["onboarding", "inferred"]),
+});
+
+const capabilitySchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string(),
+  tier: z.enum(["unlocked", "next-up", "earned"]),
+  gate: z.string(),
+  unlockHint: z.string().optional(),
+  ctaLabel: z.string().optional(),
+});
+
+const relationshipStateSchema = z.object({
+  version: z.literal(1),
+  assistantId: z.string(),
+  tier: z.union([z.literal(1), z.literal(2), z.literal(3), z.literal(4)]),
+  progressPercent: z.number(),
+  facts: z.array(factSchema),
+  capabilities: z.array(capabilitySchema),
+  conversationCount: z.number(),
+  hatchedDate: z.string(),
+  assistantName: z.string(),
+  userName: z.string().optional(),
+  updatedAt: z.string(),
+});
+
+/**
+ * Handle `GET /v1/home/state`.
+ *
+ * Returns the persisted `relationship-state.json` when present; on a
+ * cache miss (missing file, unreadable JSON, OR structurally-invalid
+ * shape) falls back to `computeRelationshipState()` so callers always
+ * get a valid response shape that matches `relationshipStateSchema`.
+ * The read-through fallback deliberately does NOT write a fresh
+ * snapshot to disk — the daemon's conversation-complete hook owns
+ * writes so progress updates stay batched to real state transitions
+ * rather than opportunistic GETs.
+ */
+export async function handleGetHomeState(): Promise<Response> {
+  const path = getRelationshipStatePath();
+
+  if (existsSync(path)) {
+    try {
+      const raw = readFileSync(path, "utf-8");
+      const parsed: unknown = JSON.parse(raw);
+      // Validate shape, not just JSON syntax. A stale or partial file
+      // (e.g. from a pre-v1 snapshot or a truncated write) must NOT be
+      // served to the client — fall through to compute instead so
+      // strict client decoders don't choke.
+      const validated = relationshipStateSchema.safeParse(parsed);
+      if (validated.success) {
+        return Response.json(validated.data);
+      }
+      log.warn(
+        { path, issues: validated.error.issues },
+        "Persisted relationship-state.json failed schema validation; falling back to live compute",
+      );
+    } catch (err) {
+      log.warn(
+        { err, path },
+        "Failed to read persisted relationship-state.json; falling back to live compute",
+      );
+      // Fall through to the compute path.
+    }
+  }
+
+  try {
+    const state = await computeRelationshipState();
+    return Response.json(state);
+  } catch (err) {
+    log.warn({ err }, "Failed to compute relationship state on-demand");
+    return httpError(
+      "INTERNAL_ERROR",
+      "Failed to compute relationship state",
+      500,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+export function homeStateRouteDefinitions(): RouteDefinition[] {
+  return [
+    {
+      endpoint: "home/state",
+      method: "GET",
+      handler: () => handleGetHomeState(),
+      summary: "Get relationship state",
+      description:
+        "Return the current `RelationshipState` snapshot. Reads the persisted `relationship-state.json` when present; falls back to an on-demand compute so fresh installs never see a 404.",
+      tags: ["home"],
+      responseBody: relationshipStateSchema,
+    },
+  ];
+}

--- a/clients/shared/Models/RelationshipState.swift
+++ b/clients/shared/Models/RelationshipState.swift
@@ -1,0 +1,165 @@
+import Foundation
+
+/// Relationship state data contract.
+///
+/// Wire-compatible mirror of
+/// `assistant/src/home/relationship-state.ts`. The TypeScript types are
+/// the source of truth — any change there must be mirrored here so a
+/// JSON blob produced by one side decodes byte-for-byte on the other.
+public struct RelationshipState: Codable, Sendable, Equatable {
+    public let version: Int
+    /// Forward-compat for multi-assistant. Only one assistant is supported in v1.
+    public let assistantId: String
+    /// 1-4
+    public let tier: Int
+    /// 0-100
+    public let progressPercent: Int
+    public let facts: [Fact]
+    public let capabilities: [Capability]
+    public let conversationCount: Int
+    /// ISO 8601
+    public let hatchedDate: String
+    public let assistantName: String
+    public let userName: String?
+    /// ISO 8601
+    public let updatedAt: String
+
+    public init(
+        version: Int,
+        assistantId: String,
+        tier: Int,
+        progressPercent: Int,
+        facts: [Fact],
+        capabilities: [Capability],
+        conversationCount: Int,
+        hatchedDate: String,
+        assistantName: String,
+        userName: String?,
+        updatedAt: String
+    ) {
+        self.version = version
+        self.assistantId = assistantId
+        self.tier = tier
+        self.progressPercent = progressPercent
+        self.facts = facts
+        self.capabilities = capabilities
+        self.conversationCount = conversationCount
+        self.hatchedDate = hatchedDate
+        self.assistantName = assistantName
+        self.userName = userName
+        self.updatedAt = updatedAt
+    }
+}
+
+public struct Fact: Codable, Sendable, Equatable, Identifiable {
+    public let id: String
+    public let category: Category
+    public let text: String
+    public let confidence: Confidence
+    public let source: Source
+
+    public enum Category: String, Codable, Sendable {
+        case voice
+        case world
+        case priorities
+    }
+
+    public enum Confidence: String, Codable, Sendable {
+        case strong
+        case uncertain
+    }
+
+    public enum Source: String, Codable, Sendable {
+        case onboarding
+        case inferred
+    }
+
+    public init(
+        id: String,
+        category: Category,
+        text: String,
+        confidence: Confidence,
+        source: Source
+    ) {
+        self.id = id
+        self.category = category
+        self.text = text
+        self.confidence = confidence
+        self.source = source
+    }
+}
+
+public struct Capability: Codable, Sendable, Equatable, Identifiable {
+    public let id: String
+    public let name: String
+    public let description: String
+    public let tier: Tier
+    /// Human-readable unlock requirement.
+    public let gate: String
+    /// Shown on `.earned` tier: why, not when.
+    public let unlockHint: String?
+    /// Shown on `.nextUp` tier: e.g. "Connect Google →".
+    public let ctaLabel: String?
+
+    public enum Tier: String, Codable, Sendable {
+        case unlocked
+        case nextUp = "next-up"
+        case earned
+    }
+
+    public init(
+        id: String,
+        name: String,
+        description: String,
+        tier: Tier,
+        gate: String,
+        unlockHint: String?,
+        ctaLabel: String?
+    ) {
+        self.id = id
+        self.name = name
+        self.description = description
+        self.tier = tier
+        self.gate = gate
+        self.unlockHint = unlockHint
+        self.ctaLabel = ctaLabel
+    }
+}
+
+public enum RelationshipTier: Int, CaseIterable, Sendable {
+    case gettingToKnowYou = 1
+    case findingFooting = 2
+    case hittingStride = 3
+    case inSync = 4
+
+    public var label: String {
+        switch self {
+        case .gettingToKnowYou: return "Getting to know you"
+        case .findingFooting: return "Finding my footing"
+        case .hittingStride: return "Hitting our stride"
+        case .inSync: return "In sync"
+        }
+    }
+
+    public var descriptionText: String {
+        switch self {
+        case .gettingToKnowYou: return "We just met — learning the basics"
+        case .findingFooting: return "Starting to understand how you work"
+        case .hittingStride: return "We have a real working relationship"
+        case .inSync: return "Full partnership"
+        }
+    }
+
+    public var nextTierHint: String? {
+        switch self {
+        case .gettingToKnowYou:
+            return "A few more conversations and I'll start to find my footing"
+        case .findingFooting:
+            return "Keep working with me and we'll hit our stride"
+        case .hittingStride:
+            return "Give me more context and autonomy and we'll be fully in sync"
+        case .inSync:
+            return nil
+        }
+    }
+}

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -2400,11 +2400,18 @@ public enum ServerMessage: Decodable, Sendable {
     case serviceGroupUpdateProgress(ServiceGroupUpdateProgressMessage)
     case serviceGroupUpdateComplete(ServiceGroupUpdateCompleteMessage)
     case conversationIdResolved(localId: String, serverId: String)
+    case relationshipStateUpdated(updatedAt: String)
     case pong
     case unknown(String)
 
     private enum CodingKeys: String, CodingKey {
         case type
+    }
+
+    /// Keys for hand-decoded inline payload cases that don't wrap a
+    /// codegen'd struct (e.g. `relationshipStateUpdated`).
+    private enum InlinePayloadKeys: String, CodingKey {
+        case updatedAt
     }
 
     public init(from decoder: Decoder) throws {
@@ -2872,6 +2879,10 @@ public enum ServerMessage: Decodable, Sendable {
         case "service_group_update_complete":
             let message = try ServiceGroupUpdateCompleteMessage(from: decoder)
             self = .serviceGroupUpdateComplete(message)
+        case "relationship_state_updated":
+            let payloadContainer = try decoder.container(keyedBy: InlinePayloadKeys.self)
+            let updatedAt = try payloadContainer.decode(String.self, forKey: .updatedAt)
+            self = .relationshipStateUpdated(updatedAt: updatedAt)
         case "pong":
             self = .pong
         default:


### PR DESCRIPTION
## Summary

Backend half of Phase 3 of the [Onboarding & New User Retention TDD](https://www.notion.so/33c9035c57bd81e7be88dafe0317f647). Ships the `relationship-state.json` wire contract (TS + Swift), a daemon writer that computes state from `USER.md` / `SOUL.md` / `IDENTITY.md` / integration state / conversation count, a `GET /v1/home/state` HTTP route with Zod shape validation + read-through fallback, a `relationship_state_updated` SSE event wired through `assistantEventHub`, and a one-time backfill migration for existing users so they don't land on an empty Home page after upgrade.

Ticket: [JARVIS-470](https://linear.app/vellum/issue/JARVIS-470). Parent epic: JARVIS-462.

Frontend work (LUM-805, macOS Home page UI) is deferred to a separate plan that will run after coordination with Jason (the current assignee on LUM-805).

## Self-review result

PASS — 8 gaps found across 2 rounds of self-review, all fixed before opening this PR:

**Round 1 (correctness gaps, fixed in #25258):**
- `countConversations()` over-counted stray files → now DB-authoritative via `conversation-queries.countConversations()`
- Dead `isWorld` ternary removed
- Concurrent writer race → `writeInFlight`/`writeDirty` latest-wins coalescing
- `parseIdentity` missed `**Assistant Name:**` → explicit label variant matching
- Unix epoch hatched-date sentinel → `data/hatched.json` sidecar

**Round 2 (polish gaps, fixed in #25260):**
- 7 comment-hygiene violations (comments narrated removed code, violating `assistant/AGENTS.md:21`)
- `parseUserName` over-matched `startsWith("preferred")` → tightened to `startsWith("preferred name")`
- `home-state-routes.test.ts` leaked a stale DB handle → added `mock.module` for `conversation-queries.js`

## PRs merged into feature branch

### Plan PRs
- #25247 — feat(home): add relationship state data contract (TS + Swift)
- #25250 — feat(home): daemon computes and writes relationship-state.json
- #25257 — feat(home): expose /v1/home/state route and relationship_state_updated SSE event
- #25255 — feat(home): backfill relationship-state.json for existing users on daemon startup

### Fix PRs (self-review)
- #25258 — fix(home): address 5 self-review findings in relationship-state-writer
- #25260 — fix(home): address round-2 polish findings

## Intentional deviations from the plan text

Documented because they came up repeatedly during review:

- **No Microsoft integration**: `outlook` appears in `seed-providers.ts` as scaffolding but we don't ship a production Microsoft integration. Only Gmail, Google Calendar, and Slack unlock their respective capabilities. Codex re-raised this twice; a regression test guards the decision.
- **Backfill location**: moved from `ensurePromptFiles()` (plan text) to `lifecycle.ts` inside the `if (dbReady)` block, wrapped in `setImmediate`. Firing before DB init would produce a degraded snapshot that the idempotence check would then preserve forever.
- **Writer turn-boundary hook**: lives in `conversation-agent-loop.ts` (where the real turn `finally` block is), not `conversation.ts` (a thin delegator the plan listed).
- **Conversation count**: DB-authoritative via `conversation-queries.countConversations()`, not filesystem-based readdir.
- **`hatchedDate` fallback**: `parseIdentity` reads IDENTITY.md birthtime first, then falls back to a one-time `data/hatched.json` sidecar so the timestamp is stable across writes.

## Tests

Every PR ships with tests. Final state:
- 38 tests in `relationship-state-writer.test.ts` (write, extract, coalescing, hatched stability, name variants, backfill)
- 16 tests in `progress-formula.test.ts` (table-driven weight + tier cases)
- 8 tests in `home-state-routes.test.ts` (persisted hit, miss, malformed fallback, policy)
- 7 tests in `relationship-state-contract.test.ts` (JSON round-trip, tier metadata, default capabilities)

Part of plan: phase-3-backend.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25261" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
