### PR TITLE
fix: use /skills/<slug> URL pattern for clawhub hub links

### DIFF
--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -1105,22 +1105,9 @@ public struct ClawhubOriginMeta: Codable, Sendable, Equatable {
     }
 
     /// URL to this skill's page on clawhub.ai.
-    /// Uses `author/slug` when author is known; falls back to the raw slug
-    /// when it already contains a "/" (installed skills may store `author/slug`
-    /// as the slug itself). Returns nil only when no valid path can be built.
     public var hubURL: URL? {
-        let path: String
-        if !author.isEmpty {
-            path = "\(author)/\(slug)"
-        } else if slug.contains("/") {
-            path = slug
-        } else {
-            return nil
-        }
-        let encoded = path.split(separator: "/").map {
-            String($0).addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? String($0)
-        }.joined(separator: "/")
-        return URL(string: "https://clawhub.ai/\(encoded)")
+        let encodedSlug = slug.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? slug
+        return URL(string: "https://clawhub.ai/skills/\(encodedSlug)")
     }
 }
 

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -1105,7 +1105,15 @@ public struct ClawhubOriginMeta: Codable, Sendable, Equatable {
     }
 
     /// URL to this skill's page on clawhub.ai.
+    /// Namespaced slugs (e.g. "author/skill") use the root path directly;
+    /// simple slugs use the `/skills/` prefix.
     public var hubURL: URL? {
+        if slug.contains("/") {
+            let encoded = slug.split(separator: "/").map {
+                String($0).addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? String($0)
+            }.joined(separator: "/")
+            return URL(string: "https://clawhub.ai/\(encoded)")
+        }
         let encodedSlug = slug.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? slug
         return URL(string: "https://clawhub.ai/skills/\(encodedSlug)")
     }


### PR DESCRIPTION
## Summary
- Changed clawhub `hubURL` from `https://clawhub.ai/<author>/<slug>` to `https://clawhub.ai/skills/<slug>`
- This removes the dependency on `author` data which is empty for installed skills, fixing non-clickable source links
- Simplifies the URL construction significantly (no author guard, no slash-in-slug fallback)

## Original prompt
Fix clawhub source links on Skill detail page — installed clawhub skills had `author: ""` so the link was never clickable. Clawhub supports `/skills/<slug>` URLs that don't need author data.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25263" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
