### PR TITLE
chore: exclude feature-flagged features from release notes prompt

### DIFF
--- a/scripts/generate-release-notes.ts
+++ b/scripts/generate-release-notes.ts
@@ -131,6 +131,7 @@ Rules:
 - The output should ONLY be the Highlights section — no other sections
 - Do not add any text outside of the Highlights section
 - Do not wrap the output in a code fence
+- Exclude all feature-flagged features from the release notes
 
 Here are the commits:
 


### PR DESCRIPTION
Adds a rule to the Claude prompt in `scripts/generate-release-notes.ts` to exclude all feature-flagged features from the generated release notes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25265" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
