### PR TITLE
refactor(drain): extract drainSingleMessage from drainQueue

### DIFF
--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -33,8 +33,11 @@ import { createPreference } from "../notifications/preferences-store.js";
 import type { Message } from "../providers/types.js";
 import { routeGuardianReply } from "../runtime/guardian-reply-router.js";
 import { getLogger } from "../util/logger.js";
-import type { MessageQueue } from "./conversation-queue-manager.js";
-import type { QueueDrainReason } from "./conversation-queue-manager.js";
+import type {
+  MessageQueue,
+  QueuedMessage,
+  QueueDrainReason,
+} from "./conversation-queue-manager.js";
 import type {
   ChannelCapabilities,
   TrustContext,
@@ -271,7 +274,14 @@ export async function drainQueue(
 ): Promise<void> {
   const next = conversation.queue.shift();
   if (!next) return;
+  return drainSingleMessage(conversation, next, reason);
+}
 
+async function drainSingleMessage(
+  conversation: ProcessConversationContext,
+  next: QueuedMessage,
+  reason: QueueDrainReason,
+): Promise<void> {
   // Reset per-turn preactivation so a prior iteration (e.g. an unknown-slash
   // from a desktop source that skips runAgentLoop) can't leak CU preactivation
   // into the next queued message.


### PR DESCRIPTION
## Summary
- Move the body of drainQueue into a new private drainSingleMessage helper.
- drainQueue becomes a thin shift + delegate wrapper in preparation for batched drain.
- Pure refactor — no behavior change.

Part of plan: batch-queued-drain.md (PR 3 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25271" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
