### PR TITLE
fix(macos): include resultRevision in toolCallsFingerprint

### DIFF
--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -1803,6 +1803,7 @@ public struct ChatMessage: Identifiable, Equatable {
             hasher.combine(tc.inputFullLength)
             hasher.combine(tc.inputRawValueLength)
             hasher.combine(tc.partialOutputRevision)
+            hasher.combine(tc.resultRevision)
             hasher.combine(tc.buildingStatus)
             hasher.combine(tc.reasonDescription)
             hasher.combine(tc.startedAt)


### PR DESCRIPTION
Addresses review feedback from #25140: toolCallsFingerprint's documented invariant requires it to hash every field ToolCallData.== compares. Adding resultRevision (which == now compares) restores that invariant.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25272" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
