### PR TITLE
fix(chrome-ext): tighten allowlist test and fix daemon terminology in READMEs

### DIFF
--- a/assistant/src/__tests__/extension-id-sync-guard.test.ts
+++ b/assistant/src/__tests__/extension-id-sync-guard.test.ts
@@ -11,7 +11,8 @@
  *      (not duplicated across runtime/tests/docs).
  */
 
-import { readdirSync, readFileSync, statSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 import { describe, expect, test } from "bun:test";
 
@@ -21,6 +22,11 @@ const repoRoot = resolve(__dirname, "..", "..", "..");
 const CANONICAL_CONFIG_REL_PATH =
   "meta/browser-extension/chrome-extension-allowlist.json";
 const CANONICAL_CONFIG_ABS_PATH = join(repoRoot, CANONICAL_CONFIG_REL_PATH);
+const LOCAL_OVERRIDE_PATH = join(
+  homedir(),
+  ".vellum",
+  "chrome-extension-allowlist.local.json",
+);
 
 const EXTENSION_ID_REGEX = /^[a-p]{32}$/;
 const PLACEHOLDER_ID_REGEX = /^TODO_[A-Z0-9_]+$/;
@@ -167,6 +173,27 @@ describe("Chrome extension allowlist guard", () => {
       const origin = `chrome-extension://${id}/`;
       expect(ALLOWED_EXTENSION_ORIGINS.has(origin)).toBe(true);
     }
+  });
+
+  test("assistant runtime allowlist exactly mirrors canonical when no override sources are active", () => {
+    // Exact-equality invariant: when neither the local override file nor
+    // the env-var override is active, the runtime set must equal the
+    // canonical set — nothing extra, nothing missing. A dev machine with
+    // an unpacked-extension override will skip this deterministic check
+    // and rely on the subset assertion above.
+    if (existsSync(LOCAL_OVERRIDE_PATH)) return;
+    if (
+      process.env.VELLUM_CHROME_EXTENSION_IDS ||
+      process.env.VELLUM_CHROME_EXTENSION_ID
+    ) {
+      return;
+    }
+
+    const config = parseCanonicalConfig();
+    const expectedOrigins = new Set(
+      config.allowedExtensionIds.map((id) => `chrome-extension://${id}/`),
+    );
+    expect(new Set(ALLOWED_EXTENSION_ORIGINS)).toEqual(expectedOrigins);
   });
 
   test("concrete extension IDs appear only in canonical config", () => {

--- a/clients/chrome-extension/README.md
+++ b/clients/chrome-extension/README.md
@@ -146,7 +146,7 @@ chmod 644 "$NATIVE_HOSTS_DIR/com.vellum.daemon.json"
 |---|---|
 | `Access to the specified native messaging host is forbidden` | Manifest missing/invalid, or extension ID not in the allowlist. Add it to `~/.vellum/chrome-extension-allowlist.local.json` (see Native Messaging Host Setup, step 3). |
 | `Native host has exited` | Chrome couldn't launch Node. Use a wrapper script with an absolute Node path in the manifest. |
-| `assistant pair request failed with HTTP 401` | Extension ID not in allowlist. Add it to `~/.vellum/chrome-extension-allowlist.local.json` and restart the assistant (the allowlist is cached at daemon startup). |
+| `assistant pair request failed with HTTP 401` | Extension ID not in allowlist. Add it to `~/.vellum/chrome-extension-allowlist.local.json` and restart the assistant (the allowlist is cached at assistant startup). |
 | `failed to reach assistant at http://127.0.0.1:<port>/...` | Assistant not running, wrong port, or firewall blocking. |
 | `Automatic cloud sign-in failed` | Use "Re-sign in" in the popup's Troubleshooting section, then click Connect. |
 | `Automatic local pairing failed` | Use "Re-pair" in the popup's Troubleshooting section, then click Connect. |

--- a/clients/chrome-extension/native-host/README.md
+++ b/clients/chrome-extension/native-host/README.md
@@ -293,8 +293,8 @@ even when repo-relative paths are unavailable.
 
 The helper re-reads all sources on every `connectNative()` spawn, so
 edits to the local override file take effect the next time Chrome launches
-the helper — no Chrome restart needed. The assistant daemon caches the
-merged allowlist at startup; restart the daemon after editing the local
+the helper — no Chrome restart needed. The assistant caches the
+merged allowlist at startup; restart the assistant after editing the local
 override.
 
 ## Testing


### PR DESCRIPTION
Addresses review feedback from #25134: restore exact allowlist equality check under deterministic test inputs; replace user-facing 'daemon' with 'assistant' in chrome-extension READMEs.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25275" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
