### PR TITLE
fix(macos): register sidebar stub for titleless open_conversation payloads

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
@@ -221,12 +221,11 @@ extension AppDelegate {
                     // and may drive urgency/alerting behaviors that don't apply here).
                     // This registration runs regardless of the focus flag so fan-out
                     // callers (focus: false) still get the conversation in the sidebar.
-                    if let title = msg.title,
-                       let conversationManager = self.mainWindow?.conversationManager,
+                    if let conversationManager = self.mainWindow?.conversationManager,
                        !conversationManager.conversations.contains(where: { $0.conversationId == msg.conversationId }) {
                         conversationManager.createNotificationConversation(
                             conversationId: msg.conversationId,
-                            title: title,
+                            title: msg.title ?? "",
                             sourceEventName: "open_conversation",
                             groupId: nil,
                             source: "open_conversation"


### PR DESCRIPTION
Addresses review feedback from #25187: a valid {conversationId, focus:false} payload without a title previously produced no effect. Register the sidebar stub even when title is nil so the message isn't silently dropped.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25276" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
