### PR TITLE
fix(workspace,cli): guard remaining userInfo() call sites

### DIFF
--- a/assistant/src/workspace/top-level-renderer.ts
+++ b/assistant/src/workspace/top-level-renderer.ts
@@ -2,6 +2,18 @@ import { homedir, userInfo } from "node:os";
 
 import type { TopLevelSnapshot } from "./top-level-scanner.js";
 
+// `os.userInfo()` throws `SystemError` when the current UID has no passwd
+// entry (possible in sandboxed/containerized envs, including the daemon's
+// own container). Guarding here keeps the renderer safe since this runs
+// inside the daemon and crashing would break workspace context injection.
+function safeUserInfoUsername(): string {
+  try {
+    return userInfo().username;
+  } catch {
+    return "unknown";
+  }
+}
+
 export interface WorkspaceTopLevelRenderOptions {
   conversationAttachmentsPath?: string | null;
   /**
@@ -41,7 +53,7 @@ export function renderWorkspaceTopLevelContext(
     lines.push("(list truncated — more entries exist)");
   }
   lines.push(`Host home directory: ${options.hostHomeDir ?? homedir()}`);
-  lines.push(`Host username: ${options.hostUsername ?? userInfo().username}`);
+  lines.push(`Host username: ${options.hostUsername ?? safeUserInfoUsername()}`);
   lines.push("</workspace>");
   return lines.join("\n");
 }

--- a/cli/src/commands/pair.ts
+++ b/cli/src/commands/pair.ts
@@ -36,8 +36,16 @@ function decodeQRCodeFromPng(pngPath: string): string {
   return code.data;
 }
 
+function safeUserInfoUsername(): string {
+  try {
+    return userInfo().username;
+  } catch {
+    return "";
+  }
+}
+
 function getDeviceId(): string {
-  const raw = hostname() + userInfo().username;
+  const raw = hostname() + safeUserInfoUsername();
   return createHash("sha256").update(raw).digest("hex");
 }
 

--- a/cli/src/components/DefaultMainScreen.tsx
+++ b/cli/src/components/DefaultMainScreen.tsx
@@ -1939,8 +1939,14 @@ function ChatApp({
             );
           }
 
+          let username: string;
+          try {
+            username = userInfo().username;
+          } catch {
+            username = "";
+          }
           const hostId = createHash("sha256")
-            .update(hostname() + userInfo().username)
+            .update(hostname() + username)
             .digest("hex");
           const payload = JSON.stringify({
             type: "vellum-assistant",

--- a/cli/src/lib/aws.ts
+++ b/cli/src/lib/aws.ts
@@ -411,7 +411,12 @@ export async function hatchAws(
       }
     }
 
-    const sshUser = userInfo().username;
+    let sshUser: string;
+    try {
+      sshUser = userInfo().username;
+    } catch {
+      sshUser = process.env.USER ?? "";
+    }
     const hatchedBy = process.env.VELLUM_HATCHED_BY;
     const providerApiKeys: Record<string, string> = {};
     for (const [, envVar] of Object.entries(PROVIDER_ENV_VAR_NAMES)) {

--- a/cli/src/lib/gcp.ts
+++ b/cli/src/lib/gcp.ts
@@ -503,7 +503,12 @@ export async function hatchGcp(
       }
     }
 
-    const sshUser = userInfo().username;
+    let sshUser: string;
+    try {
+      sshUser = userInfo().username;
+    } catch {
+      sshUser = process.env.USER ?? "";
+    }
     const hatchedBy = process.env.VELLUM_HATCHED_BY;
     const providerApiKeys: Record<string, string> = {};
     for (const [, envVar] of Object.entries(PROVIDER_ENV_VAR_NAMES)) {


### PR DESCRIPTION
Addresses review feedback from #25137: apply the same try/catch guard used in that PR to the remaining unguarded userInfo() call sites, most importantly top-level-renderer.ts which runs inside the daemon.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25277" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
