### PR TITLE
fix(design-system): scroll to focused item in capped VMenu

### DIFF
--- a/clients/shared/DesignSystem/Components/Navigation/VMenu.swift
+++ b/clients/shared/DesignSystem/Components/Navigation/VMenu.swift
@@ -167,7 +167,17 @@ public struct VMenu<Content: View>: View {
         .padding(VSpacing.sm)
 
         if maxHeight != nil {
-            ScrollView(.vertical) { stack }
+            ScrollViewReader { proxy in
+                ScrollView(.vertical) { stack }
+                    #if os(macOS)
+                    .onChange(of: focusedItemID) { _, newValue in
+                        guard let newValue else { return }
+                        withAnimation {
+                            proxy.scrollTo(newValue, anchor: .center)
+                        }
+                    }
+                    #endif
+            }
         } else {
             stack
         }
@@ -432,6 +442,7 @@ public struct VMenuItem<Trailing: View>: View {
             #if os(macOS)
             .preference(key: VMenuItemRegistrationKey.self, value: [VMenuItemRegistration(id: itemID, isSubmenu: false)])
             .background(VMenuItemNSViewCapture(itemID: itemID, level: panelLevel, coordinator: coordinator))
+            .id(itemID)
             .onAppear {
                 coordinator?.registerItemAction(level: panelLevel, id: itemID) {
                     dismissMenu?(); action()
@@ -480,6 +491,7 @@ public struct VMenuItem<Trailing: View>: View {
             #if os(macOS)
             .preference(key: VMenuItemRegistrationKey.self, value: [VMenuItemRegistration(id: itemID, isSubmenu: false)])
             .background(VMenuItemNSViewCapture(itemID: itemID, level: panelLevel, coordinator: coordinator))
+            .id(itemID)
             .onAppear {
                 coordinator?.registerItemAction(level: panelLevel, id: itemID) {
                     dismissMenu?(); action()
@@ -649,6 +661,7 @@ public struct VSubMenuItem<Content: View>: View {
         }
         .preference(key: VMenuItemRegistrationKey.self, value: [VMenuItemRegistration(id: itemID, isSubmenu: true)])
         .background(VMenuItemNSViewCapture(itemID: itemID, level: panelLevel, coordinator: coordinator))
+        .id(itemID)
         .onAppear {
             // Register both item action (Enter/Space) and submenu action (right arrow).
             // For submenus, both trigger the same behavior: open the child panel.


### PR DESCRIPTION
Addresses review feedback from #25180: when VMenu has a maxHeight, keyboard arrow navigation could move the focused option off-screen. Wrap the capped ScrollView in a ScrollViewReader and scrollTo the focused item on focus change.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25278" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
