### PR TITLE
fix(macos): prevent double-dismiss on persistent surfaces

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
@@ -163,8 +163,12 @@ final class SurfaceManager {
                 )
             },
             onDismiss: { [weak self] in
-                guard let self, !self.respondedSurfaces.contains(surface.id) else {
-                    self?.dismissSurfaceById(surface.id)
+                guard let self else { return }
+                // Persistent surfaces never emit the synthetic "dismiss" — a co-fired
+                // onAction+onDismiss (e.g. cancel-style buttons) would otherwise race.
+                guard !self.persistentSurfaces.contains(surface.id),
+                      !self.respondedSurfaces.contains(surface.id) else {
+                    self.dismissSurfaceById(surface.id)
                     return
                 }
                 self.respondedSurfaces.insert(surface.id)


### PR DESCRIPTION
Addresses review feedback from #25188: persistent surfaces with a UI pattern that calls both onAction and onDismiss (e.g. cancel buttons) could emit a spurious synthetic 'dismiss' action alongside the user's chosen action. Suppress the synthetic dismiss for persistent surfaces.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25279" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
