### PR TITLE
fix(skills): add await_action:false to conversation-launcher card and scrub test comments

### DIFF
--- a/assistant/src/__tests__/conversation-launcher-skill-regression.test.ts
+++ b/assistant/src/__tests__/conversation-launcher-skill-regression.test.ts
@@ -24,16 +24,15 @@ describe("conversation-launcher skill regression", () => {
   });
 
   test("does not resurrect the deprecated bash + signal-file launch flow", () => {
-    // PRs 5-7 replaced the bash step that wrote a per-request signal file
-    // under `<workspace>/signals/` with a direct surface-action dispatch.
-    // None of the old-flow tokens should reappear.
+    // The skill must not reference signal files, HOME-based workspace paths,
+    // or shell-based plumbing — it dispatches surface actions directly.
     const forbiddenTokens = [
       "bash",
       "curl",
       "signals/",
       "jq ",
-      // Deleted signal-file prefix; built from parts so the literal doesn't
-      // appear in repo code (prod code should no longer reference it).
+      // Signal-file prefix assembled from parts so the literal does not appear
+      // in repo code grep results.
       ["launch", "conversation."].join("-"),
       "VELLUM_WORKSPACE_DIR",
       "INTERNAL_GATEWAY_BASE_URL",

--- a/skills/conversation-launcher/SKILL.md
+++ b/skills/conversation-launcher/SKILL.md
@@ -31,6 +31,7 @@ Emit exactly one `ui_show` call with a card shaped like this, then end your turn
   "surface_type": "card",
   "display": "inline",
   "persistent": true,
+  "await_action": false,
   "data": {
     "title": "<framing headline>",
     "body": "<one short sentence framing the choice>"
@@ -64,6 +65,7 @@ Emit exactly one `ui_show` call with a card shaped like this, then end your turn
 Field notes:
 
 - `persistent: true` keeps the card visible after a click so the user can fire more buttons.
+- `await_action: false` lets the turn end without reserving the interactive-surface slot — the launcher dispatches its action directly, so blocking other surfaces is unnecessary.
 - Each action's `data` must contain `_action: "launch_conversation"`, `title`, and `seedPrompt`. `anchorMessageId` is optional — include it when the spawned conversation should thread off a specific message in this one.
 - `label` is the button text (short, ≤ 4 words, ≤ 30 chars). `title` is the new conversation's sidebar name (3–5 words, specific not generic). `seedPrompt` is the first user message of the new conversation — written in first-person as if the user typed it, with enough context that the new conversation can pick up without re-asking.
 - Use `style: "primary"` for the recommended option (at most one), `style: "secondary"` for the rest.


### PR DESCRIPTION
Addresses review feedback from #25190: add await_action:false to the SKILL.md ui_show example so the card doesn't leak a pendingSurfaceActions entry; rewrite test comments that narrate PR history to describe invariants only.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25280" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
