### PR TITLE
fix(updates): order update-bulletin sync after config merge at startup

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -479,12 +479,6 @@ export async function runDaemon(): Promise<void> {
         );
       }
 
-      try {
-        syncUpdateBulletinOnStartup();
-      } catch (err) {
-        log.warn({ err }, "Bulletin sync failed — continuing startup");
-      }
-
       // Recover orphaned work items that were left in 'running' state when the
       // daemon previously crashed or was killed mid-task.
       const orphanedRunning = listWorkItems({ status: "running" });
@@ -520,6 +514,18 @@ export async function runDaemon(): Promise<void> {
 
     log.info("Daemon startup: loading config");
     const config = loadConfig();
+
+    // Run bulletin sync AFTER the config merge + load so that getConfig()
+    // inside syncUpdateBulletinOnStartup() observes the fully merged config.
+    // Running it earlier would populate the config cache with pre-merge
+    // values, poisoning every downstream getConfig() consumer.
+    if (dbReady) {
+      try {
+        syncUpdateBulletinOnStartup();
+      } catch (err) {
+        log.warn({ err }, "Bulletin sync failed — continuing startup");
+      }
+    }
 
     // Seed module-level ingress state from the workspace config so that
     // getIngressPublicBaseUrl() returns the correct value immediately after


### PR DESCRIPTION
Addresses review feedback from #25158: syncUpdateBulletinOnStartup previously ran before mergeDefaultWorkspaceConfig, caching pre-merge config values and poisoning later reads. Reorder so the merge happens first.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25281" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
