### PR TITLE
refactor(messaging): extract persistQueuedMessageBody from persistUserMessage

### DIFF
--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -287,6 +287,35 @@ export async function persistUserMessage(
   ctx.processing = true;
   ctx.abortController = new AbortController();
 
+  return persistQueuedMessageBody(
+    ctx,
+    content,
+    attachments,
+    reqId,
+    metadata,
+    displayContent,
+  );
+}
+
+// ── persistQueuedMessageBody ─────────────────────────────────────────
+
+/**
+ * Persists a user message body (DB row, attachment indexing, origin
+ * channel/interface updates, meta file write) without touching the
+ * `ctx.processing` flag or request-id bookkeeping.
+ *
+ * Used by `persistUserMessage` (which sets the processing flag first) and
+ * by the batched drain path, which persists multiple sibling messages
+ * under a single in-flight turn.
+ */
+export async function persistQueuedMessageBody(
+  ctx: MessagingConversationContext,
+  content: string,
+  attachments: UserMessageAttachment[],
+  requestId: string,
+  metadata: Record<string, unknown> | undefined,
+  displayContent: string | undefined,
+): Promise<string> {
   const attachmentInputs = attachments.map((attachment) => ({
     id: attachment.id,
     filename: attachment.filename,
@@ -302,6 +331,7 @@ export async function persistUserMessage(
   );
   log.info(
     {
+      requestId,
       contentBlockTypes: Array.isArray(llmMessage.content)
         ? llmMessage.content.map((b) => b.type)
         : typeof llmMessage.content,


### PR DESCRIPTION
## Summary
- Split persistUserMessage into a processing-flag prologue and a reusable body helper.
- New persistQueuedMessageBody can be called during in-flight turns (sibling queued messages) without tripping the processing guard.
- Pure refactor — no behavior change.

Part of plan: batch-queued-drain.md (PR 2 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25282" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
