### PR TITLE
docs(macos): use 'assistant' instead of 'daemon' in client-facing comment

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
@@ -212,7 +212,7 @@ extension AppDelegate {
                     guard !self.isBootstrapping else { break }
                     self.ensureMainWindowExists()
                     // If the conversation isn't in the sidebar yet (e.g. just created by a
-                    // surface action with `_action: "launch_conversation"` that the daemon
+                    // surface action with `_action: "launch_conversation"` that the assistant
                     // dispatched inline, spawning a fresh conversation and emitting
                     // open_conversation), stub a sidebar entry using the optional title so
                     // openConversation's trySelect retries find it.


### PR DESCRIPTION
Addresses review feedback from #25192: client-side comment accidentally reintroduced the word 'daemon', violating the clients/AGENTS.md terminology rule. Rewrites to use 'assistant'.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25284" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
