### PR TITLE
feat(design-system): add systemPendingSoft color and numericMono font tokens

### DIFF
--- a/clients/shared/DesignSystem/Tokens/ColorTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/ColorTokens.swift
@@ -246,6 +246,14 @@ public enum VColor {
     public static let systemMidStrong = adaptiveColor(light: FigmaRawColor.systemLightMidStrong, dark: FigmaRawColor.systemDarkMidStrong)
     public static let systemMidWeak = adaptiveColor(light: FigmaRawColor.systemLightMidWeak, dark: FigmaRawColor.systemDarkMidWeak)
 
+    // Pending / queued — warm amber for "held, waiting" affordances (queue drawer accent bar,
+    // pending badge backgrounds). Opacity is baked in so the token sits softly over surface
+    // colors without an additional modifier.
+    public static let systemPendingSoft = adaptiveColor(
+        light: Color(.sRGB, red: 0.85, green: 0.58, blue: 0.18, opacity: 0.6),
+        dark: Color(.sRGB, red: 0.98, green: 0.72, blue: 0.35, opacity: 0.55)
+    )
+
     // Diff view — adaptive background tints for unified-diff line highlighting.
     public static let diffAddedBg  = adaptiveColor(light: Color(hex: 0xEDF2EB), dark: Color(hex: 0x073D2E))
     public static let diffRemovedBg = adaptiveColor(light: Color(hex: 0xFFF3EE), dark: Color(hex: 0x4E281D))

--- a/clients/shared/DesignSystem/Tokens/TypographyTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/TypographyTokens.swift
@@ -62,6 +62,41 @@ public enum VFont {
         #endif
     }
 
+    /// Creates a DM Sans font at the given weight and size with the `tnum` OpenType
+    /// feature enabled (tabular numerals — every digit occupies the same advance width).
+    ///
+    /// Used for elements where digit columns must align (position pills like "#1"/"#12",
+    /// counters, timers). Equivalent to `dmSans(weight:size:)` plus a
+    /// `.featureSettings(.init(tag: "tnum", value: 1))` treatment applied at the
+    /// CoreText layer so the feature survives the SwiftUI→CT→NS/UIFont bridge.
+    private static func dmSansTabular(weight: Int, size: CGFloat) -> Font {
+        let baseName = "DMSans-Regular" as CFString
+        let baseFont = CTFontCreateWithName(baseName, size, nil)
+        let variations: [CFNumber: CFNumber] = [
+            wghtTag as CFNumber: weight as CFNumber,
+        ]
+        // OpenType feature "tnum" = tabular numerals. CoreText's OpenType feature keys
+        // expect the tag as a 4-character CFString and the value as a CFNumber (1 = on).
+        let openTypeFeatures: [[CFString: Any]] = [[
+            kCTFontOpenTypeFeatureTag: "tnum" as CFString,
+            kCTFontOpenTypeFeatureValue: 1 as CFNumber,
+        ]]
+        let descriptor = CTFontDescriptorCreateWithAttributes([
+            kCTFontVariationAttribute: variations,
+            kCTFontFeatureSettingsAttribute: openTypeFeatures,
+        ] as CFDictionary)
+        let variantFont = CTFontCreateCopyWithAttributes(baseFont, size, nil, descriptor)
+        #if os(macOS)
+        let nsFont = variantFont as NSFont
+        return Font(nsFont)
+        #elseif os(iOS)
+        let uiFont = variantFont as! UIFont
+        return Font(uiFont)
+        #else
+        return Font.custom("DMSans-Regular", fixedSize: size)
+        #endif
+    }
+
     /// Creates an Instrument Serif font at the given CSS weight and size.
     private static func instrumentSerif(weight: Int, size: CGFloat) -> Font {
         let baseName = "InstrumentSerif-Regular" as CFString
@@ -117,6 +152,10 @@ public enum VFont {
 
     public static let labelDefault = dmSans(weight: 400, size: 11)
     public static let labelSmall   = dmSans(weight: 400, size: 10)
+
+    /// DM Sans at label size with tabular numerals (`tnum`) enabled — for position pills,
+    /// counters, and other short numeric labels where digits must align in a column.
+    public static let numericMono = dmSansTabular(weight: 400, size: 11)
 
     // MARK: - Menu
 
@@ -310,6 +349,7 @@ public enum VFont {
         _ = bodySmallEmphasised
         _ = labelDefault
         _ = labelSmall
+        _ = numericMono
         _ = menuCompact
         _ = chat
 


### PR DESCRIPTION
## Summary
- Adds `VColor.systemPendingSoft` — warm amber for "held, waiting" affordances
- Adds `VFont.numericMono` — DM Sans with tabular numerals enabled for position pills
- Additive only; no existing views consume these tokens yet (wired in PR 3 / PR 4)

Part of plan: queue-drawer-edit-cancel.md (PR 2 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25286" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
