### PR TITLE
fix(updates): scope hasEverMaterialized to current release

### DIFF
--- a/assistant/src/__tests__/update-bulletin.test.ts
+++ b/assistant/src/__tests__/update-bulletin.test.ts
@@ -153,28 +153,34 @@ describe("syncUpdateBulletinOnStartup", () => {
   });
 
   it("marks active releases as completed when UPDATES.md is deleted", () => {
-    // Pre-populate active releases in the store
-    store.set("updates:active_releases", JSON.stringify(["0.8.0", "0.9.0"]));
+    // Pre-populate active releases including the current one — simulates
+    // a normal session where 1.0.0 was materialized alongside leftover
+    // entries from prior versions.
+    store.set(
+      "updates:active_releases",
+      JSON.stringify(["0.8.0", "0.9.0", "1.0.0"]),
+    );
 
     // Workspace file does not exist — simulates the assistant having deleted it
     expect(existsSync(workspacePath)).toBe(false);
 
     syncUpdateBulletinOnStartup();
 
-    // Active set should be cleared (except for the newly-added current release)
+    // Active set should be cleared
     const activeRaw = store.get("updates:active_releases");
     expect(activeRaw).toBeDefined();
     const active: string[] = JSON.parse(activeRaw!);
-    // The old releases should not be in the active set
     expect(active).not.toContain("0.8.0");
     expect(active).not.toContain("0.9.0");
+    expect(active).not.toContain("1.0.0");
 
-    // The old releases should now be completed
+    // All releases should now be completed
     const completedRaw = store.get("updates:completed_releases");
     expect(completedRaw).toBeDefined();
     const completed: string[] = JSON.parse(completedRaw!);
     expect(completed).toContain("0.8.0");
     expect(completed).toContain("0.9.0");
+    expect(completed).toContain("1.0.0");
   });
 
   it("does not recreate completed release after deletion", () => {
@@ -211,8 +217,9 @@ describe("syncUpdateBulletinOnStartup", () => {
   });
 
   it("treats a whitespace-only UPDATES.md as dismissal of the current release", () => {
-    // Pre-populate completed so hasEverMaterialized is true via the completed path.
-    store.set("updates:completed_releases", JSON.stringify(["0.9.0"]));
+    // Pre-populate active with the current release so the dismissal branch
+    // is scoped correctly to this version.
+    store.set("updates:active_releases", JSON.stringify(["1.0.0"]));
     writeFileSync(workspacePath, "   \n\n\t\n", "utf-8");
 
     syncUpdateBulletinOnStartup();
@@ -225,6 +232,34 @@ describe("syncUpdateBulletinOnStartup", () => {
       store.get("updates:completed_releases")!,
     );
     expect(completed).toContain("1.0.0");
+  });
+
+  it("materializes new version bulletin after a prior release was dismissed", () => {
+    // Regression: hasEverMaterialized previously tripped on ANY completed
+    // release, so once 0.9.0 had been dismissed, every future version saw
+    // "file missing" and was auto-marked completed — suppressing its bulletin
+    // forever. The fix scopes the check to the current release.
+    store.set("updates:completed_releases", JSON.stringify(["0.9.0"]));
+    expect(existsSync(workspacePath)).toBe(false);
+
+    syncUpdateBulletinOnStartup();
+
+    expect(existsSync(workspacePath)).toBe(true);
+    const content = readFileSync(workspacePath, "utf-8");
+    expect(content).toContain("<!-- vellum-update-release:1.0.0 -->");
+    expect(content).toContain("What's New");
+
+    // 1.0.0 must NOT have been auto-completed.
+    const completed: string[] = JSON.parse(
+      store.get("updates:completed_releases")!,
+    );
+    expect(completed).not.toContain("1.0.0");
+
+    // 1.0.0 should be in the active set.
+    const active: string[] = JSON.parse(
+      store.get("updates:active_releases")!,
+    );
+    expect(active).toContain("1.0.0");
   });
 
   it("creates file on fresh install even though it is missing", () => {

--- a/assistant/src/prompts/update-bulletin.ts
+++ b/assistant/src/prompts/update-bulletin.ts
@@ -20,7 +20,6 @@ import {
 import {
   addActiveRelease,
   getActiveReleases,
-  getCompletedReleases,
   isReleaseCompleted,
   markReleasesCompleted,
   setActiveReleases,
@@ -85,21 +84,24 @@ export function syncUpdateBulletinOnStartup(): void {
   const workspacePath = getWorkspacePromptPath("UPDATES.md");
 
   // --- Dismissal detection ---
-  // If UPDATES.md is missing or empty AND we've materialized it at least
-  // once before (i.e. there's prior release state), treat it as a dismissal:
-  // mark the active set plus the current release completed and stop. The
-  // "has ever materialized" guard preserves fresh-install semantics — on a
-  // brand-new DB we want to create the file, not treat its absence as
-  // dismissal of the current release.
+  // If UPDATES.md is missing or empty AND the CURRENT release has been
+  // materialized before (i.e. it's in the active set, or already marked
+  // completed), treat it as a dismissal: mark the active set plus the
+  // current release completed and stop. Scoping to the current release is
+  // critical — a prior release having been completed must NOT cause a new
+  // version's bulletin to be suppressed as "already dismissed". It also
+  // preserves fresh-install semantics: on a brand-new DB we want to create
+  // the file, not treat its absence as dismissal.
   const activeReleases = getActiveReleases();
   const fileMissing = !existsSync(workspacePath);
   const fileEmpty =
     !fileMissing &&
     readFileSync(workspacePath, "utf-8").trim().length === 0;
-  const hasEverMaterialized =
-    activeReleases.length > 0 || getCompletedReleases().length > 0;
+  const currentReleaseMaterialized =
+    activeReleases.includes(currentReleaseId) ||
+    isReleaseCompleted(currentReleaseId);
 
-  if ((fileMissing || fileEmpty) && hasEverMaterialized) {
+  if ((fileMissing || fileEmpty) && currentReleaseMaterialized) {
     markReleasesCompleted([...activeReleases, currentReleaseId]);
     setActiveReleases([]);
     return;


### PR DESCRIPTION
Addresses review feedback from #25159: hasEverMaterialized was checking whether ANY prior release had been dismissed, which meant a missing UPDATES.md would be interpreted as 'dismissed' for every future version too. Scope the check to the current release so new bulletins materialize after version bumps.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25287" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
