### PR TITLE
feat(shared): add queuedMessages, tailQueuedMessageId, editQueuedTail to ChatViewModel

### DIFF
--- a/clients/ios/Tests/ChatViewModelIOSTests.swift
+++ b/clients/ios/Tests/ChatViewModelIOSTests.swift
@@ -1,3 +1,4 @@
+import SwiftUI
 import XCTest
 @testable import VellumAssistantShared
 
@@ -518,6 +519,136 @@ final class ChatViewModelIOSTests: XCTestCase {
             try? await Task.sleep(for: .milliseconds(10))
         }
     }
+
+    // MARK: - Queue Helpers: queuedMessages, tailQueuedMessageId, editQueuedTail
+
+    func test_queuedMessages_filtersUserRoleAndSortsByPosition() {
+        let assistantQueued = ChatMessage(role: .assistant, text: "Assistant reply", status: .queued(position: 0))
+        let sentUser = ChatMessage(role: .user, text: "Already sent", status: .sent)
+        let queuedLater = ChatMessage(role: .user, text: "Third in queue", status: .queued(position: 2))
+        let queuedFirst = ChatMessage(role: .user, text: "First in queue", status: .queued(position: 0))
+        let queuedMiddle = ChatMessage(role: .user, text: "Second in queue", status: .queued(position: 1))
+
+        viewModel.messages = [assistantQueued, sentUser, queuedLater, queuedFirst, queuedMiddle]
+
+        let result = viewModel.queuedMessages
+        XCTAssertEqual(result.count, 3, "Only user-role queued messages should be returned")
+        XCTAssertEqual(result.map(\.text), ["First in queue", "Second in queue", "Third in queue"],
+                       "Queued messages should be sorted by position ascending")
+        XCTAssertTrue(result.allSatisfy { $0.role == .user }, "All returned messages should be user-role")
+    }
+
+    func test_tailQueuedMessageId_returnsHighestPositionId() {
+        let p0 = ChatMessage(role: .user, text: "m0", status: .queued(position: 0))
+        let p1 = ChatMessage(role: .user, text: "m1", status: .queued(position: 1))
+        let p2 = ChatMessage(role: .user, text: "m2", status: .queued(position: 2))
+        viewModel.messages = [p0, p1, p2]
+
+        XCTAssertEqual(viewModel.tailQueuedMessageId, p2.id,
+                       "Tail should be the queued user message with the highest position")
+
+        // And nil when no messages are queued.
+        viewModel.messages = [
+            ChatMessage(role: .user, text: "Sent", status: .sent),
+            ChatMessage(role: .assistant, text: "Reply", status: .sent)
+        ]
+        XCTAssertNil(viewModel.tailQueuedMessageId,
+                     "Tail should be nil when no queued user messages exist")
+    }
+
+    func test_editQueuedTail_copiesContentAndDeletesOriginal() async {
+        let mockQueueClient = MockConversationQueueClient()
+        mockQueueClient.deleteResult = true
+
+        let connection = GatewayConnectionManager()
+        connection.isConnected = true
+        let vm = ChatViewModel(
+            connectionManager: connection,
+            eventStreamClient: connection.eventStreamClient,
+            conversationQueueClient: mockQueueClient
+        )
+        vm.conversationId = "sess-edit-tail"
+
+        let attachment = ChatAttachment(
+            id: "att-1",
+            filename: "note.txt",
+            mimeType: "text/plain",
+            data: "ZGF0YQ==",
+            thumbnailData: nil,
+            dataLength: 8,
+            thumbnailImage: nil
+        )
+        let head = ChatMessage(role: .user, text: "First queued", status: .queued(position: 0))
+        var tail = ChatMessage(role: .user, text: "Tail content", status: .queued(position: 1))
+        tail.attachments = [attachment]
+        vm.messages = [head, tail]
+        vm.requestIdToMessageId = ["req-tail": tail.id]
+        vm.pendingQueuedCount = 2
+
+        var composerText = ""
+        var composerAttachments: [ChatAttachment] = []
+        let textBinding = Binding<String>(
+            get: { composerText },
+            set: { composerText = $0 }
+        )
+        let attachmentsBinding = Binding<[ChatAttachment]>(
+            get: { composerAttachments },
+            set: { composerAttachments = $0 }
+        )
+
+        vm.editQueuedTail(into: textBinding, attachments: attachmentsBinding)
+
+        XCTAssertEqual(composerText, "Tail content",
+                       "Composer text binding should receive the tail message text")
+        XCTAssertEqual(composerAttachments.count, 1)
+        XCTAssertEqual(composerAttachments.first?.id, attachment.id,
+                       "Composer attachments binding should receive the tail message attachments")
+
+        let deadline = ContinuousClock.now + .seconds(2)
+        while mockQueueClient.calls.isEmpty && ContinuousClock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+
+        XCTAssertEqual(mockQueueClient.calls.count, 1,
+                       "editQueuedTail should dispatch exactly one delete_queued_message call")
+        XCTAssertEqual(mockQueueClient.calls.first?.conversationId, "sess-edit-tail")
+        XCTAssertEqual(mockQueueClient.calls.first?.requestId, "req-tail")
+    }
+
+    func test_editQueuedTail_isNoOpWhenNoQueue() async {
+        let mockQueueClient = MockConversationQueueClient()
+        let connection = GatewayConnectionManager()
+        connection.isConnected = true
+        let vm = ChatViewModel(
+            connectionManager: connection,
+            eventStreamClient: connection.eventStreamClient,
+            conversationQueueClient: mockQueueClient
+        )
+        vm.conversationId = "sess-empty"
+        vm.messages = [
+            ChatMessage(role: .user, text: "Hello", status: .sent),
+            ChatMessage(role: .assistant, text: "Hi", status: .sent)
+        ]
+
+        var composerText = "unchanged"
+        var composerAttachments: [ChatAttachment] = []
+        let textBinding = Binding<String>(
+            get: { composerText },
+            set: { composerText = $0 }
+        )
+        let attachmentsBinding = Binding<[ChatAttachment]>(
+            get: { composerAttachments },
+            set: { composerAttachments = $0 }
+        )
+
+        vm.editQueuedTail(into: textBinding, attachments: attachmentsBinding)
+
+        try? await Task.sleep(for: .milliseconds(50))
+
+        XCTAssertEqual(composerText, "unchanged", "Text binding should not be modified when queue is empty")
+        XCTAssertTrue(composerAttachments.isEmpty, "Attachments binding should not be modified when queue is empty")
+        XCTAssertTrue(mockQueueClient.calls.isEmpty, "No delete_queued_message call should be dispatched")
+    }
 }
 
 // MARK: - Test Doubles
@@ -544,5 +675,30 @@ private final class MockInteractionClient: InteractionClientProtocol {
 
     func sendSecretResponse(requestId: String, value: String?, delivery: String?) async -> Bool {
         true
+    }
+}
+
+/// Mock `ConversationQueueClientProtocol` used by queue-drawer tests to record
+/// delete_queued_message dispatches without hitting the network.
+private final class MockConversationQueueClient: ConversationQueueClientProtocol, @unchecked Sendable {
+    struct Call: Equatable {
+        let conversationId: String
+        let requestId: String
+    }
+
+    private let queue = DispatchQueue(label: "MockConversationQueueClient.calls")
+    private var _calls: [Call] = []
+    var calls: [Call] {
+        queue.sync { _calls }
+    }
+    var deleteResult: Bool = true
+
+    init() {}
+
+    func deleteQueuedMessage(conversationId: String, requestId: String) async -> Bool {
+        queue.sync {
+            _calls.append(Call(conversationId: conversationId, requestId: requestId))
+        }
+        return deleteResult
     }
 }

--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -1,3 +1,4 @@
+import SwiftUI
 import XCTest
 @testable import VellumAssistantLib
 @testable import VellumAssistantShared
@@ -2954,5 +2955,168 @@ final class ChatViewModelTests: XCTestCase {
                        "The single text segment should contain all buffered text")
         XCTAssertTrue(viewModel.streamingDeltaBuffer.isEmpty,
                       "Buffer should be empty after flush")
+    }
+
+    // MARK: - Queue Helpers: queuedMessages, tailQueuedMessageId, editQueuedTail
+
+    func test_queuedMessages_filtersUserRoleAndSortsByPosition() {
+        // Mix of user / assistant / sent / queued messages — ensure queuedMessages
+        // returns only user messages with .queued status, sorted by position.
+        let assistantQueued = ChatMessage(role: .assistant, text: "Assistant reply", status: .queued(position: 0))
+        let sentUser = ChatMessage(role: .user, text: "Already sent", status: .sent)
+        let queuedLater = ChatMessage(role: .user, text: "Third in queue", status: .queued(position: 2))
+        let queuedFirst = ChatMessage(role: .user, text: "First in queue", status: .queued(position: 0))
+        let queuedMiddle = ChatMessage(role: .user, text: "Second in queue", status: .queued(position: 1))
+
+        viewModel.messages = [assistantQueued, sentUser, queuedLater, queuedFirst, queuedMiddle]
+
+        let result = viewModel.queuedMessages
+        XCTAssertEqual(result.count, 3, "Only user-role queued messages should be returned")
+        XCTAssertEqual(result.map(\.text), ["First in queue", "Second in queue", "Third in queue"],
+                       "Queued messages should be sorted by position ascending")
+        XCTAssertTrue(result.allSatisfy { $0.role == .user }, "All returned messages should be user-role")
+    }
+
+    func test_tailQueuedMessageId_returnsHighestPositionId() {
+        let p0 = ChatMessage(role: .user, text: "m0", status: .queued(position: 0))
+        let p1 = ChatMessage(role: .user, text: "m1", status: .queued(position: 1))
+        let p2 = ChatMessage(role: .user, text: "m2", status: .queued(position: 2))
+        viewModel.messages = [p0, p1, p2]
+
+        XCTAssertEqual(viewModel.tailQueuedMessageId, p2.id,
+                       "Tail should be the queued user message with the highest position")
+
+        // And nil when no messages are queued.
+        viewModel.messages = [
+            ChatMessage(role: .user, text: "Sent", status: .sent),
+            ChatMessage(role: .assistant, text: "Reply", status: .sent)
+        ]
+        XCTAssertNil(viewModel.tailQueuedMessageId,
+                     "Tail should be nil when no queued user messages exist")
+    }
+
+    func test_editQueuedTail_copiesContentAndDeletesOriginal() async {
+        let mockQueueClient = MockConversationQueueClient()
+        mockQueueClient.deleteResult = true
+
+        let connection = GatewayConnectionManager()
+        connection.isConnected = true
+        let vm = ChatViewModel(
+            connectionManager: connection,
+            eventStreamClient: connection.eventStreamClient,
+            conversationQueueClient: mockQueueClient
+        )
+        vm.conversationId = "sess-edit-tail"
+
+        // Seed tail queued message with text + one attachment, mapped to a requestId.
+        let attachment = ChatAttachment(
+            id: "att-1",
+            filename: "note.txt",
+            mimeType: "text/plain",
+            data: "ZGF0YQ==",
+            thumbnailData: nil,
+            dataLength: 8,
+            thumbnailImage: nil
+        )
+        let head = ChatMessage(role: .user, text: "First queued", status: .queued(position: 0))
+        var tail = ChatMessage(role: .user, text: "Tail content", status: .queued(position: 1))
+        tail.attachments = [attachment]
+        vm.messages = [head, tail]
+        vm.requestIdToMessageId = ["req-tail": tail.id]
+        vm.pendingQueuedCount = 2
+
+        // Bindings the composer would pass.
+        var composerText = ""
+        var composerAttachments: [ChatAttachment] = []
+        let textBinding = Binding<String>(
+            get: { composerText },
+            set: { composerText = $0 }
+        )
+        let attachmentsBinding = Binding<[ChatAttachment]>(
+            get: { composerAttachments },
+            set: { composerAttachments = $0 }
+        )
+
+        vm.editQueuedTail(into: textBinding, attachments: attachmentsBinding)
+
+        XCTAssertEqual(composerText, "Tail content",
+                       "Composer text binding should receive the tail message text")
+        XCTAssertEqual(composerAttachments.count, 1)
+        XCTAssertEqual(composerAttachments.first?.id, attachment.id,
+                       "Composer attachments binding should receive the tail message attachments")
+
+        // Wait for the async deleteQueuedMessage Task to dispatch the delete call.
+        let deadline = ContinuousClock.now + .seconds(2)
+        while mockQueueClient.calls.isEmpty && ContinuousClock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+
+        XCTAssertEqual(mockQueueClient.calls.count, 1,
+                       "editQueuedTail should dispatch exactly one delete_queued_message call")
+        XCTAssertEqual(mockQueueClient.calls.first?.conversationId, "sess-edit-tail")
+        XCTAssertEqual(mockQueueClient.calls.first?.requestId, "req-tail")
+    }
+
+    func test_editQueuedTail_isNoOpWhenNoQueue() async {
+        let mockQueueClient = MockConversationQueueClient()
+        let connection = GatewayConnectionManager()
+        connection.isConnected = true
+        let vm = ChatViewModel(
+            connectionManager: connection,
+            eventStreamClient: connection.eventStreamClient,
+            conversationQueueClient: mockQueueClient
+        )
+        vm.conversationId = "sess-empty"
+        vm.messages = [
+            ChatMessage(role: .user, text: "Hello", status: .sent),
+            ChatMessage(role: .assistant, text: "Hi", status: .sent)
+        ]
+
+        var composerText = "unchanged"
+        var composerAttachments: [ChatAttachment] = []
+        let textBinding = Binding<String>(
+            get: { composerText },
+            set: { composerText = $0 }
+        )
+        let attachmentsBinding = Binding<[ChatAttachment]>(
+            get: { composerAttachments },
+            set: { composerAttachments = $0 }
+        )
+
+        vm.editQueuedTail(into: textBinding, attachments: attachmentsBinding)
+
+        // Give any spurious Task a chance to run before asserting no call was made.
+        try? await Task.sleep(for: .milliseconds(50))
+
+        XCTAssertEqual(composerText, "unchanged", "Text binding should not be modified when queue is empty")
+        XCTAssertTrue(composerAttachments.isEmpty, "Attachments binding should not be modified when queue is empty")
+        XCTAssertTrue(mockQueueClient.calls.isEmpty, "No delete_queued_message call should be dispatched")
+    }
+}
+
+// MARK: - Mock Queue Client
+
+/// Mock `ConversationQueueClientProtocol` used by queue-drawer tests to record
+/// delete_queued_message dispatches without hitting the network.
+final class MockConversationQueueClient: ConversationQueueClientProtocol, @unchecked Sendable {
+    struct Call: Equatable {
+        let conversationId: String
+        let requestId: String
+    }
+
+    private let queue = DispatchQueue(label: "MockConversationQueueClient.calls")
+    private var _calls: [Call] = []
+    var calls: [Call] {
+        queue.sync { _calls }
+    }
+    var deleteResult: Bool = true
+
+    init() {}
+
+    func deleteQueuedMessage(conversationId: String, requestId: String) async -> Bool {
+        queue.sync {
+            _calls.append(Call(conversationId: conversationId, requestId: requestId))
+        }
+        return deleteResult
     }
 }

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -3,6 +3,7 @@ import Foundation
 import Network
 import Observation
 import os
+import SwiftUI
 import UniformTypeIdentifiers
 #if os(macOS)
 import AppKit
@@ -364,6 +365,42 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
         get { messageManager.pendingQueuedCount }
         set { messageManager.pendingQueuedCount = newValue }
     }
+    /// User-role messages currently in the queue, ordered by queue position ascending.
+    /// The queue drawer consumes this to render each queued message row.
+    public var queuedMessages: [ChatMessage] {
+        messages
+            .filter { $0.role == .user && isQueued($0.status) }
+            .sorted { lhs, rhs in
+                queuePosition(of: lhs.status) < queuePosition(of: rhs.status)
+            }
+    }
+    /// ID of the queued user message with the highest position (i.e. the tail of
+    /// the queue that will be processed last). `nil` when no user messages are
+    /// currently queued. Used to drive "edit last queued message" affordances.
+    public var tailQueuedMessageId: UUID? {
+        var tailId: UUID?
+        var tailPosition = Int.min
+        for message in messages where message.role == .user {
+            guard case let .queued(position) = message.status else { continue }
+            if position > tailPosition {
+                tailPosition = position
+                tailId = message.id
+            }
+        }
+        return tailId
+    }
+    /// Returns true when the status is `.queued(position:)`, false otherwise.
+    private func isQueued(_ status: ChatMessageStatus) -> Bool {
+        if case .queued = status { return true }
+        return false
+    }
+    /// Extracts the position from a queued status, or `Int.max` for other statuses
+    /// so non-queued messages sort after queued ones (defensive — `queuedMessages`
+    /// already filters to queued-only).
+    private func queuePosition(of status: ChatMessageStatus) -> Int {
+        if case let .queued(position) = status { return position }
+        return .max
+    }
     public var suggestion: String? {
         get { messageManager.suggestion }
         set { messageManager.suggestion = newValue }
@@ -521,7 +558,7 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
     private let trustRuleClient: any TrustRuleClientProtocol = TrustRuleClient()
     private let guardianClient: any GuardianClientProtocol = GuardianClient()
     private let regenerateClient: any RegenerateClientProtocol = RegenerateClient()
-    let conversationQueueClient: any ConversationQueueClientProtocol = ConversationQueueClient()
+    let conversationQueueClient: any ConversationQueueClientProtocol
     /// Tracks the action submitted for each guardian decision requestId so the
     /// response handler can display the correct resolved state (the server does
     /// not echo back the action in its acknowledgement).
@@ -1024,12 +1061,14 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
         eventStreamClient: EventStreamClient,
         settingsClient: any SettingsClientProtocol = SettingsClient(),
         interactionClient: any InteractionClientProtocol = InteractionClient(),
+        conversationQueueClient: any ConversationQueueClientProtocol = ConversationQueueClient(),
         onToolCallsComplete: ((_ toolCalls: [ToolCallData]) -> Void)? = nil
     ) {
         self.connectionManager = connectionManager
         self.eventStreamClient = eventStreamClient
         self.settingsClient = settingsClient
         self.interactionClient = interactionClient
+        self.conversationQueueClient = conversationQueueClient
         self.onToolCallsComplete = onToolCallsComplete
         self.paginationState = ChatPaginationState(
             messageManager: messageManager
@@ -1503,6 +1542,20 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
                 log.error("Failed to delete queued message")
             }
         }
+    }
+
+    /// Pop the tail (highest-position) queued message back into the composer
+    /// bindings and delete it from the queue. No-op when the queue is empty.
+    /// Used by the queue drawer's "edit last queued" affordance.
+    public func editQueuedTail(
+        into text: Binding<String>,
+        attachments: Binding<[ChatAttachment]>
+    ) {
+        guard let tailId = tailQueuedMessageId,
+              let message = messages.first(where: { $0.id == tailId }) else { return }
+        text.wrappedValue = message.text
+        attachments.wrappedValue = message.attachments
+        deleteQueuedMessage(messageId: tailId)
     }
 
     /// Update local state after the server confirms a queued message deletion.


### PR DESCRIPTION
## Summary
- Adds `queuedMessages` and `tailQueuedMessageId` computed properties to `ChatViewModel`
- Adds `editQueuedTail(into:attachments:)` method that pops the tail queued message back into composer bindings and deletes it from the queue
- Covers new helpers with unit tests on both macOS and iOS test targets

Part of plan: queue-drawer-edit-cancel.md (PR 1 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25289" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
