### PR TITLE
test(macos): add missing containerHeight to MessageListContentView test

### DIFF
--- a/clients/macos/vellum-assistantTests/MessageListTypographyRefreshTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListTypographyRefreshTests.swift
@@ -49,6 +49,7 @@ final class MessageListTypographyRefreshTests: XCTestCase {
             configuredProviders: [],
             subagentDetailStore: SubagentDetailStore(),
             assistantStatusText: nil,
+            containerHeight: 0,
             scrollState: MessageListScrollState()
         )
     }


### PR DESCRIPTION
## Summary
- Add `containerHeight: 0` to `makeMessageListContentView` in `MessageListTypographyRefreshTests` so it compiles against the new required init parameter.
- Fixes macOS Tests CI job that started failing after #25206 added `containerHeight` to `MessageListContentView` without updating this test.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24360465062/job/71138551906
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25290" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
