### PR TITLE
fix(macos): use visible fallback title for titleless open_conversation stub

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
@@ -225,7 +225,7 @@ extension AppDelegate {
                        !conversationManager.conversations.contains(where: { $0.conversationId == msg.conversationId }) {
                         conversationManager.createNotificationConversation(
                             conversationId: msg.conversationId,
-                            title: msg.title ?? "",
+                            title: msg.title ?? "Untitled",
                             sourceEventName: "open_conversation",
                             groupId: nil,
                             source: "open_conversation"


### PR DESCRIPTION
## Summary
- Replace `title: ""` with `title: "Untitled"` in the `open_conversation` sidebar stub so titleless payloads render a visible placeholder row instead of a blank one until server sync backfills the real title.
- `"Untitled"` is the established placeholder convention elsewhere in the sidebar/conversation code (`ConversationManager.swift`, `CommandPaletteView.swift`, `ConversationRestorerTests.swift`).

Addresses Codex (P2) + Devin review feedback on #25276.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25291" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
