### PR TITLE
fix(cli): abort on empty sshUser fallback before launching cloud instance

### DIFF
--- a/cli/src/lib/aws.ts
+++ b/cli/src/lib/aws.ts
@@ -417,6 +417,12 @@ export async function hatchAws(
     } catch {
       sshUser = process.env.USER ?? "";
     }
+    if (!sshUser) {
+      console.error(
+        "Error: Could not determine SSH username. Set the USER environment variable and try again.",
+      );
+      process.exit(1);
+    }
     const hatchedBy = process.env.VELLUM_HATCHED_BY;
     const providerApiKeys: Record<string, string> = {};
     for (const [, envVar] of Object.entries(PROVIDER_ENV_VAR_NAMES)) {

--- a/cli/src/lib/gcp.ts
+++ b/cli/src/lib/gcp.ts
@@ -509,6 +509,12 @@ export async function hatchGcp(
     } catch {
       sshUser = process.env.USER ?? "";
     }
+    if (!sshUser) {
+      console.error(
+        "Error: Could not determine SSH username. Set the USER environment variable and try again.",
+      );
+      process.exit(1);
+    }
     const hatchedBy = process.env.VELLUM_HATCHED_BY;
     const providerApiKeys: Record<string, string> = {};
     for (const [, envVar] of Object.entries(PROVIDER_ENV_VAR_NAMES)) {


### PR DESCRIPTION
## Summary

Addresses review feedback on #25277.

When `userInfo()` throws AND `process.env.USER` is unset, `sshUser` silently fell back to `""`. That empty string was passed to `buildStartupScript()` → `buildUserSetup("")` which generated `SSH_USER=""` followed by `useradd ""` under `set -e` — failing AFTER the EC2/GCP instance was already launched (and billed). It also broke recovery SSH commands like `${sshUser}@${instanceName}` in `recoverFromCurlFailure`.

After the try/catch fallback, check if `sshUser` is empty; if so, print a clear error and `process.exit(1)` before provisioning.

## Files
- `cli/src/lib/aws.ts`
- `cli/src/lib/gcp.ts`

## Test plan
- [ ] Unset `USER` and verify CLI aborts with clear error before launching any cloud instance
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25292" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
