### PR TITLE
test(skills): assert await_action:false in conversation-launcher regression test

### DIFF
--- a/assistant/src/__tests__/conversation-launcher-skill-regression.test.ts
+++ b/assistant/src/__tests__/conversation-launcher-skill-regression.test.ts
@@ -10,13 +10,14 @@ describe("conversation-launcher skill regression", () => {
   test("describes the direct surface-action contract the daemon dispatches on", () => {
     // The skill must render one `ui_show` card whose actions carry the wire
     // contract that `handleSurfaceAction`'s `launch_conversation` branch reads.
-    // These five tokens are the minimum the model needs to produce a valid card.
+    // These tokens are the minimum the model needs to produce a valid card.
     const requiredTokens = [
       "ui_show",
       "persistent: true",
       '_action: "launch_conversation"',
       "title",
       "seedPrompt",
+      '"await_action": false',
     ];
     for (const token of requiredTokens) {
       expect(skillContent).toContain(token);


### PR DESCRIPTION
## Summary
Adds `'"await_action": false'` to the `requiredTokens` array in `conversation-launcher-skill-regression.test.ts` so that if someone later removes `await_action: false` from `skills/conversation-launcher/SKILL.md`, the regression test will catch it. Without this, the model would silently produce cards that block other interactive surfaces.

Addresses Devin review feedback on #25280.

## Test plan
- [x] `bun test src/__tests__/conversation-launcher-skill-regression.test.ts` passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25293" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
