### PR TITLE
feat(macos): add QueuedMessagesDrawer and QueuedMessageRow components

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/QueuedMessageRow.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/QueuedMessageRow.swift
@@ -1,0 +1,96 @@
+import SwiftUI
+import VellumAssistantShared
+
+// MARK: - Queued Message Row
+
+/// Single row rendered inside `QueuedMessagesDrawer`. Shows a position pill,
+/// a truncated preview of the queued message text, and a trailing icon cluster
+/// (pencil for the tail row, xmark for all rows).
+///
+/// The drawer owns interaction callbacks: `onEdit` is only invoked when the
+/// pencil is visible (`isTail == true`); `onCancel` is always available.
+struct QueuedMessageRow: View {
+    let message: ChatMessage
+    let positionLabel: String
+    let isTail: Bool
+    let onEdit: () -> Void
+    let onCancel: () -> Void
+
+    var body: some View {
+        HStack(spacing: VSpacing.md) {
+            // (a) 2pt vertical accent bar signalling "held / pending".
+            RoundedRectangle(cornerRadius: 1)
+                .fill(VColor.systemPendingSoft)
+                .frame(width: 2)
+                .frame(maxHeight: .infinity)
+                .accessibilityHidden(true)
+
+            // (b) Position pill — tabular numerals so "#10" and "#1" align.
+            Text(positionLabel)
+                .font(VFont.numericMono)
+                .foregroundStyle(VColor.contentSecondary)
+                .padding(EdgeInsets(
+                    top: VSpacing.xxs,
+                    leading: VSpacing.sm,
+                    bottom: VSpacing.xxs,
+                    trailing: VSpacing.sm
+                ))
+                .background(
+                    Capsule(style: .continuous)
+                        .fill(VColor.surfaceLift)
+                )
+
+            // (c) Truncated content preview.
+            Text(message.text)
+                .font(VFont.bodyMediumDefault)
+                .foregroundStyle(VColor.contentDefault)
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            // (d) Trailing icon cluster: pencil only when tail, xmark always.
+            HStack(spacing: VSpacing.xs) {
+                if isTail {
+                    QueuedRowIconButton(systemName: "pencil", accessibilityLabel: "Edit queued message", action: onEdit)
+                }
+                QueuedRowIconButton(systemName: "xmark", accessibilityLabel: "Cancel queued message", action: onCancel)
+            }
+        }
+        .padding(EdgeInsets(
+            top: VSpacing.sm,
+            leading: VSpacing.md,
+            bottom: VSpacing.sm,
+            trailing: VSpacing.md
+        ))
+        .frame(height: VSpacing.xl + VSpacing.sm)
+        .contentShape(Rectangle())
+    }
+}
+
+// MARK: - Icon Button
+
+/// Trailing icon button used inside `QueuedMessageRow`. Matches the 24×24pt
+/// hit target minimum called out in the plan, and swaps the foreground between
+/// `contentSecondary` (resting) and `contentDefault` (hovered).
+private struct QueuedRowIconButton: View {
+    let systemName: String
+    let accessibilityLabel: String
+    let action: () -> Void
+
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: systemName)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(isHovered ? VColor.contentDefault : VColor.contentSecondary)
+                .frame(width: 24, height: 24)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering in
+            isHovered = hovering
+        }
+        .accessibilityLabel(accessibilityLabel)
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Chat/QueuedMessagesDrawer.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/QueuedMessagesDrawer.swift
@@ -1,0 +1,96 @@
+import SwiftUI
+import VellumAssistantShared
+
+// MARK: - Queued Messages Drawer
+
+/// Drawer rendered above the composer when one or more user messages are
+/// waiting in the queue. Each queued message renders as a `QueuedMessageRow`
+/// with a position pill, preview, and cancel icon; the tail row additionally
+/// exposes an edit affordance that pops the message back into the composer
+/// bindings and removes it from the queue.
+///
+/// Not yet wired into `ChatView` — call sites will be added in a later PR.
+struct QueuedMessagesDrawer: View {
+    @Bindable var viewModel: ChatViewModel
+    @Binding var composerText: String
+    @Binding var composerAttachments: [ChatAttachment]
+
+    var body: some View {
+        if viewModel.queuedMessages.isEmpty {
+            EmptyView()
+        } else {
+            drawerBody
+        }
+    }
+
+    private var drawerBody: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            header
+            rows
+        }
+        .padding(VSpacing.md)
+        .background(
+            RoundedRectangle(cornerRadius: VSpacing.md, style: .continuous)
+                .fill(VColor.surfaceOverlay)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: VSpacing.md, style: .continuous)
+                .strokeBorder(VColor.borderBase, lineWidth: 1)
+        )
+        .frame(maxWidth: VSpacing.chatColumnMaxWidth)
+        .frame(maxWidth: .infinity, alignment: .center)
+    }
+
+    private var header: some View {
+        HStack {
+            Text("Queue · \(viewModel.queuedMessages.count)")
+                .font(VFont.labelDefault)
+                .foregroundStyle(VColor.contentSecondary)
+
+            Spacer(minLength: VSpacing.sm)
+
+            Button(action: cancelAll) {
+                Text("Cancel all")
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentSecondary)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Cancel all queued messages")
+        }
+    }
+
+    private var rows: some View {
+        VStack(alignment: .leading, spacing: VSpacing.xs) {
+            ForEach(Array(viewModel.queuedMessages.enumerated()), id: \.element.id) { index, message in
+                QueuedMessageRow(
+                    message: message,
+                    positionLabel: "#\(index + 1)",
+                    isTail: message.id == viewModel.tailQueuedMessageId,
+                    onEdit: {
+                        viewModel.editQueuedTail(
+                            into: $composerText,
+                            attachments: $composerAttachments
+                        )
+                    },
+                    onCancel: {
+                        viewModel.deleteQueuedMessage(messageId: message.id)
+                    }
+                )
+                .transition(.asymmetric(
+                    insertion: .push(from: .bottom).combined(with: .opacity),
+                    removal: .scale(scale: 0.92).combined(with: .opacity)
+                ))
+            }
+        }
+        .animation(
+            .spring(duration: 0.28, bounce: 0.15),
+            value: viewModel.queuedMessages.map(\.id)
+        )
+    }
+
+    private func cancelAll() {
+        for message in viewModel.queuedMessages {
+            viewModel.deleteQueuedMessage(messageId: message.id)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `QueuedMessagesDrawer` and `QueuedMessageRow` SwiftUI views for the macOS chat UI
- Not yet wired into `ChatView` (that lands in PR 5)
- Consumes `viewModel.queuedMessages`, `viewModel.tailQueuedMessageId`, `viewModel.editQueuedTail` from PR 1 and `VColor.systemPendingSoft` / `VFont.numericMono` from PR 2

## Deviations from plan
- **No pbxproj edits.** The macOS client is SPM-based (no `xcodeproj` at `clients/macos/vellum-assistant.xcodeproj`); `.swift` files under `macos/vellum-assistant/` are auto-picked up by the `VellumAssistantLib` target per `clients/macos/AGENTS.md`.
- **No `#Preview` blocks.** `clients/AGENTS.md` (Preview Policy section) and `clients/macos/AGENTS.md` line 270 both explicitly prohibit committing `#Preview` / `PreviewProvider` blocks. Visual review happens via the Component Gallery + running app. Deferred to project policy over the plan step.
- **Token substitutions** (plan flagged these as acceptable if verbatim names are missing):
  - `VColor.surfaceElevated` -> `VColor.surfaceLift` (most-lifted surface above overlay; matches the intent of an 'elevated' inner pill).
  - `VColor.borderSubtle` -> `VColor.borderBase` (`borderElement` is visibly stronger; `borderBase` is the subtlest border token).
  - `VFont.bodyDefault` -> `VFont.bodyMediumDefault` (14pt DM Sans regular; the only "body default" without size modifier is split into Large/Medium/Small in this codebase).

Part of plan: queue-drawer-edit-cancel.md (PR 3 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25294" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
