### PR TITLE
docs(updates): rewrite history-narrating comment in update-bulletin test

### DIFF
--- a/assistant/src/__tests__/update-bulletin.test.ts
+++ b/assistant/src/__tests__/update-bulletin.test.ts
@@ -235,10 +235,10 @@ describe("syncUpdateBulletinOnStartup", () => {
   });
 
   it("materializes new version bulletin after a prior release was dismissed", () => {
-    // Regression: hasEverMaterialized previously tripped on ANY completed
-    // release, so once 0.9.0 had been dismissed, every future version saw
-    // "file missing" and was auto-marked completed — suppressing its bulletin
-    // forever. The fix scopes the check to the current release.
+    // Verifies that a new version's bulletin is materialized even when a
+    // prior release exists in the completed set. Dismissal detection is
+    // scoped to the current release — only suppress if this version was
+    // already active or completed, not because an unrelated version was.
     store.set("updates:completed_releases", JSON.stringify(["0.9.0"]));
     expect(existsSync(workspacePath)).toBe(false);
 


### PR DESCRIPTION
Addresses review feedback on #25287.

The comment in the 'materializes new version bulletin after a prior release was dismissed' test narrated history and referenced a removed variable (`hasEverMaterialized`). Rewritten to describe the current behavior the test validates: dismissal detection is scoped to the current release, so a prior completed release does not suppress a new version's bulletin.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25295" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
