### PR TITLE
docs(drain): rewrite history-narrating comment in drain helper

### DIFF
--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -256,10 +256,8 @@ function buildSlashContext(
   };
 }
 
-// TODO(batch-drain): PR 5 will extend this helper to walk contiguous
-// same-interface passthrough messages at the head of the queue. For now
-// it pops only the head so behavior matches the pre-refactor single-message
-// drain path.
+// Pops the head of the queue as a single-message batch. The batch shape
+// keeps callers stable when this helper extends to multi-message drains.
 async function buildPassthroughBatch(
   conversation: ProcessConversationContext,
 ): Promise<QueuedMessage[]> {


### PR DESCRIPTION
Rewrites the comment on `buildPassthroughBatch` to describe current behavior without narrating the prior implementation ('pre-refactor single-message drain path'), addressing review feedback on #25285 and complying with `assistant/AGENTS.md`'s rule against history-narrating comments.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25296" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
