### PR TITLE
refactor(messaging): honor persistQueuedMessageBody contract by hoisting processing-state cleanup

### DIFF
--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -287,14 +287,21 @@ export async function persistUserMessage(
   ctx.processing = true;
   ctx.abortController = new AbortController();
 
-  return persistQueuedMessageBody(
-    ctx,
-    content,
-    attachments,
-    reqId,
-    metadata,
-    displayContent,
-  );
+  try {
+    return await persistQueuedMessageBody(
+      ctx,
+      content,
+      attachments,
+      reqId,
+      metadata,
+      displayContent,
+    );
+  } catch (err) {
+    ctx.processing = false;
+    ctx.abortController = null;
+    ctx.currentRequestId = undefined;
+    throw err;
+  }
 }
 
 // ── persistQueuedMessageBody ─────────────────────────────────────────
@@ -473,9 +480,6 @@ export async function persistQueuedMessageBody(
     return persistedUserMessage.id;
   } catch (err) {
     ctx.messages.pop();
-    ctx.processing = false;
-    ctx.abortController = null;
-    ctx.currentRequestId = undefined;
     throw err;
   }
 }


### PR DESCRIPTION
## Summary

Addresses Devin review feedback on #25282.

The JSDoc for `persistQueuedMessageBody` states it operates "without touching the \`ctx.processing\` flag or request-id bookkeeping." The catch block violated that contract by resetting \`ctx.processing\`, \`ctx.abortController\`, and \`ctx.currentRequestId\`. Harmless for the single current caller (\`persistUserMessage\`), but it would break the intended batched-drain caller in #25285, where one failed persist would tear down the entire turn's state mid-batch.

## Changes

- \`persistQueuedMessageBody\` catch now only undoes what it itself did: \`ctx.messages.pop()\`, then re-throws.
- \`persistUserMessage\` wraps the call in try/catch that clears \`ctx.processing\`, \`ctx.abortController\`, and \`ctx.currentRequestId\` on failure and re-throws.

## Test plan

- [x] \`bunx tsc --noEmit\` clean
- [x] \`conversation-queue.test.ts\`, \`conversation-messaging-secret-redirect.test.ts\`, \`http-user-message-parity.test.ts\`, \`send-endpoint-busy.test.ts\` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25297" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
