### PR TITLE
fix(macos): only suppress persistent dismiss when action already sent

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
@@ -163,17 +163,10 @@ final class SurfaceManager {
                 )
             },
             onDismiss: { [weak self] in
-                guard let self else { return }
-                // Persistent surfaces never emit the synthetic "dismiss" — a co-fired
-                // onAction+onDismiss (e.g. cancel-style buttons) would otherwise race.
-                guard !self.persistentSurfaces.contains(surface.id),
-                      !self.respondedSurfaces.contains(surface.id) else {
-                    self.dismissSurfaceById(surface.id)
-                    return
-                }
-                self.respondedSurfaces.insert(surface.id)
-                self.onAction?(surface.conversationId, surface.id, "dismiss", nil)
-                self.dismissSurfaceById(surface.id)
+                self?.handleSurfaceDismiss(
+                    conversationId: surface.conversationId,
+                    surfaceId: surface.id
+                )
             },
             appId: appId,
             onDataRequest: appId != nil ? { [weak self] callId, method, recordId, data in
@@ -321,6 +314,33 @@ final class SurfaceManager {
         guard !respondedSurfaces.contains(surfaceId) else { return }
         respondedSurfaces.insert(surfaceId)
         onAction?(conversationId, surfaceId, actionId, data)
+    }
+
+    /// Handles a user-initiated dismissal (panel close button, Escape, or an explicit
+    /// cancel flow that invokes `onDismiss`).
+    ///
+    /// Emits a synthetic `"dismiss"` action so the daemon can clean up its pending-surface
+    /// state, unless the surface already dispatched an action this turn — in which case
+    /// the dismiss would race with the action (e.g. a cancel-style button that fires both
+    /// `onAction` and `onDismiss` for a single click).
+    ///
+    /// "Already dispatched" is tracked differently for the two modes:
+    /// - Non-persistent surfaces latch via `respondedSurfaces` in `handleSurfaceAction`.
+    /// - Persistent surfaces never enter `respondedSurfaces`; instead, any prior action
+    ///   leaves an entry in `spentActionIdsBySurface`, which we use as the signal.
+    func handleSurfaceDismiss(conversationId: String?, surfaceId: String) {
+        let alreadyDispatched: Bool
+        if persistentSurfaces.contains(surfaceId) {
+            alreadyDispatched = !(spentActionIdsBySurface[surfaceId]?.isEmpty ?? true)
+        } else {
+            alreadyDispatched = respondedSurfaces.contains(surfaceId)
+        }
+
+        if !alreadyDispatched {
+            respondedSurfaces.insert(surfaceId)
+            onAction?(conversationId, surfaceId, "dismiss", nil)
+        }
+        dismissSurfaceById(surfaceId)
     }
 
     /// Test-only hook so unit tests can exercise `handleSurfaceAction` and surface lifecycle

--- a/clients/macos/vellum-assistantTests/SurfaceManagerTests.swift
+++ b/clients/macos/vellum-assistantTests/SurfaceManagerTests.swift
@@ -129,6 +129,84 @@ final class SurfaceManagerTests: XCTestCase {
         XCTAssertEqual(dispatched.map(\.actionId), ["btn-1", "btn-2"])
     }
 
+    // MARK: - Dismiss behavior
+
+    func testPersistentSurface_userInitiatedClose_sendsDismiss() {
+        // Regression: before the fix, the onDismiss guard suppressed "dismiss" for ALL
+        // persistent surfaces, leaving the daemon's pending-surface entry stale and causing
+        // subsequent interactive ui_show calls to be rejected. User-initiated close without
+        // any prior action must still notify the daemon so it can clean up.
+        let surface = makeCardSurface(id: "surf-persistent-close")
+        surfaceManager.registerForTesting(surface: surface, persistent: true)
+
+        surfaceManager.handleSurfaceDismiss(
+            conversationId: surface.conversationId,
+            surfaceId: surface.id
+        )
+
+        XCTAssertEqual(dispatched.count, 1,
+                       "User-initiated close on a persistent surface with no prior action must emit dismiss")
+        XCTAssertEqual(dispatched.first?.actionId, "dismiss")
+        XCTAssertNil(surfaceManager.activeSurfaces[surface.id],
+                     "Surface should be torn down after dismiss")
+    }
+
+    func testPersistentSurface_dismissAfterAction_suppressed() {
+        // Preserves the original PR's fix: a co-fired onAction+onDismiss (e.g. cancel-style
+        // buttons) must not double-emit — the synthetic "dismiss" is suppressed once any
+        // action has fired for a persistent surface.
+        let surface = makeCardSurface(id: "surf-persistent-race")
+        surfaceManager.registerForTesting(surface: surface, persistent: true)
+
+        surfaceManager.handleSurfaceAction(
+            conversationId: surface.conversationId,
+            surfaceId: surface.id,
+            actionId: "btn-1",
+            data: nil
+        )
+        surfaceManager.handleSurfaceDismiss(
+            conversationId: surface.conversationId,
+            surfaceId: surface.id
+        )
+
+        XCTAssertEqual(dispatched.count, 1,
+                       "Dismiss must be suppressed when an action already fired this turn")
+        XCTAssertEqual(dispatched.first?.actionId, "btn-1")
+    }
+
+    func testNonPersistentSurface_userInitiatedClose_sendsDismiss() {
+        let surface = makeCardSurface(id: "surf-single-shot-close")
+        surfaceManager.registerForTesting(surface: surface, persistent: false)
+
+        surfaceManager.handleSurfaceDismiss(
+            conversationId: surface.conversationId,
+            surfaceId: surface.id
+        )
+
+        XCTAssertEqual(dispatched.count, 1)
+        XCTAssertEqual(dispatched.first?.actionId, "dismiss")
+    }
+
+    func testNonPersistentSurface_dismissAfterAction_suppressed() {
+        let surface = makeCardSurface(id: "surf-single-shot-race")
+        surfaceManager.registerForTesting(surface: surface, persistent: false)
+
+        surfaceManager.handleSurfaceAction(
+            conversationId: surface.conversationId,
+            surfaceId: surface.id,
+            actionId: "btn-1",
+            data: nil
+        )
+        surfaceManager.handleSurfaceDismiss(
+            conversationId: surface.conversationId,
+            surfaceId: surface.id
+        )
+
+        XCTAssertEqual(dispatched.count, 1,
+                       "Non-persistent surface's post-action dismiss must be suppressed")
+        XCTAssertEqual(dispatched.first?.actionId, "btn-1")
+    }
+
     // MARK: - Non-persistent regression
 
     func testNonPersistentSurface_unchanged() {


### PR DESCRIPTION
## Summary

Addresses Codex (P1) and Devin review feedback on #25279. The original fix's `onDismiss` guard suppressed the synthetic `"dismiss"` action for *all* persistent surfaces — not just the co-fired action+dismiss race case. When a user closed a persistent card via the panel close/X button with no prior action, the daemon never heard about it, leaving the pending-surface entry stale and causing later interactive \`ui_show\` calls to be rejected with *"another interactive surface is already awaiting user input"*.

## Fix

Distinguish "an action already fired this turn" from "user-initiated close":

- **Persistent surfaces** don't enter \`respondedSurfaces\` (by design in \`handleSurfaceAction\`), so we now use \`spentActionIdsBySurface[surfaceId]\` as the "already dispatched" signal — it's non-empty iff some action has fired.
- **Non-persistent surfaces** continue using \`respondedSurfaces\` as before.

The dismiss logic is extracted into \`handleSurfaceDismiss\` so it's testable without NSPanels.

### Behavior matrix

| Scenario | Before | After |
|---|---|---|
| Persistent + user closes (no prior action) | suppressed (bug) | emits \`dismiss\` |
| Persistent + co-fired action + dismiss | suppressed | suppressed (preserved) |
| Non-persistent + user closes | emits \`dismiss\` | emits \`dismiss\` |
| Non-persistent + post-action dismiss | suppressed | suppressed |

## Test plan

- [x] New unit tests in \`SurfaceManagerTests.swift\` cover all four rows of the matrix
- [x] Existing \`handleSurfaceAction\` tests untouched and still pass
- [ ] Manual: open persistent card, click X → daemon should receive \`dismiss\` and accept the next \`ui_show\`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25298" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
