### PR TITLE
fix(convo-launcher): persist ui_surface persistent flag and scrub history-narrating comments

### DIFF
--- a/assistant/src/daemon/__tests__/conversation-surfaces-launch.test.ts
+++ b/assistant/src/daemon/__tests__/conversation-surfaces-launch.test.ts
@@ -15,9 +15,10 @@
  *     (`persistAndProcessMessage`) is fire-and-forget.
  *   - `originTrustContext` is forwarded to the spawned conversation.
  *
- * The historical double-emit bug — both sites publishing, with the
- * helper's default-true `focus` arriving first and stealing focus away
- * from the origin — is the regression covered here.
+ * These tests guard the single-emitter invariant: exactly one
+ * `open_conversation` event is published per launch, with the
+ * caller-supplied `focus` value preserved so fan-out launchers do not
+ * steal focus from the origin.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -286,9 +287,8 @@ describe("handleSurfaceAction — launch_conversation dispatch", () => {
     });
 
     // 2. Exactly ONE `open_conversation` event was published for the new
-    //    id, with focus: false. This is the regression barrier for the
-    //    historical double-emit bug — `handleSurfaceAction` no longer
-    //    publishes its own event on top of the helper's.
+    //    id, with focus: false. `launchConversation` is the sole emitter;
+    //    `handleSurfaceAction` delegates entirely to it.
     const openEvents = openConversationEvents();
     expect(openEvents).toHaveLength(1);
     expect(openEvents[0].message.conversationId).toBe("conv-launched-1");

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -590,6 +590,7 @@ function annotatePersistedAssistantMessage(
         data: surface.data,
         actions: surface.actions,
         display: surface.display,
+        ...(surface.persistent ? { persistent: true } : {}),
       } as unknown as ContentBlock);
     }
     modified = true;
@@ -759,6 +760,7 @@ export async function handleMessageComplete(
       data: surface.data,
       actions: surface.actions,
       display: surface.display,
+      ...(surface.persistent ? { persistent: true } : {}),
     } as unknown as ContentBlock);
   }
 

--- a/assistant/src/daemon/conversation-launch.ts
+++ b/assistant/src/daemon/conversation-launch.ts
@@ -167,10 +167,10 @@ export async function launchConversation(
   }
 
   // Tell connected clients about the new conversation BEFORE kicking off the
-  // seed turn so the sidebar entry appears instantly. We are the sole
-  // emitter of `open_conversation` for this launch path — `handleSurfaceAction`
-  // no longer publishes a second event. Pass through the caller-specified
-  // `focus` so fan-out launchers can avoid stealing focus from the origin.
+  // seed turn so the sidebar entry appears instantly. This helper is the sole
+  // emitter of `open_conversation` for this launch path. Pass through the
+  // caller-specified `focus` so fan-out launchers can avoid stealing focus
+  // from the origin.
   await assistantEventHub.publish(
     buildAssistantEvent(
       deps.getAssistantId() ?? DAEMON_INTERNAL_ASSISTANT_ID,

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -705,7 +705,7 @@ export async function handleSurfaceAction(
     // The helper also kicks off the seed turn fire-and-forget, so this
     // `await` resolves as soon as the conversation is created + titled +
     // published to the event hub. The HTTP POST /v1/surface-actions
-    // response no longer blocks on the full LLM turn.
+    // response returns promptly — the seed turn runs in the background.
     const originTrustContext = ctx.trustContext;
     const { conversationId } = await launchConversation({
       title,

--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -81,6 +81,7 @@ export interface HistorySurface {
   data: Record<string, unknown>;
   actions?: Array<{ id: string; label: string; style?: string }>;
   display?: string;
+  persistent?: boolean;
   completed?: boolean;
   completionSummary?: string;
 }
@@ -288,6 +289,7 @@ export function renderHistoryContent(content: unknown): RenderedHistoryContent {
           : {},
         actions: Array.isArray(block.actions) ? block.actions : undefined,
         display: typeof block.display === "string" ? block.display : undefined,
+        persistent: block.persistent === true ? true : undefined,
         completed: block.completed === true ? true : undefined,
         completionSummary:
           typeof block.completionSummary === "string"


### PR DESCRIPTION
## Summary

Addresses review feedback on #25194.

**Codex (P2) — Persist `persistent` flag in stored `ui_surface` blocks**

`currentTurnSurfaces` captures `persistent: true` but the two message-serialization sites in \`conversation-agent-loop-handlers.ts\` emitted \`ui_surface\` blocks without it, so persistent launcher cards lost their persistence after history reload / daemon restart. Both serialization paths (\`handleToolResult\` late-surfaces append and \`handleMessageComplete\` inline append) now include \`persistent\` via conditional spread. Also extended \`HistorySurface\` in \`handlers/shared.ts\` so the field round-trips through the rendered-history payload consumed by clients.

**Devin (× 4) — Scrub comments that narrate removed behavior**

Per \`assistant/AGENTS.md\`: comments should describe current state, not narrate history. Rewrote four spots that used \"no longer\" / \"historical\" phrasing:

- \`conversation-launch.ts\` — now: \"this helper is the sole emitter of \`open_conversation\` for this launch path\".
- \`conversation-surfaces.ts\` — now: \"response returns promptly — the seed turn runs in the background\".
- \`__tests__/conversation-surfaces-launch.test.ts\` module docstring and inline comment — rewritten to describe the single-emit invariant the test protects.

## Test plan
- [ ] No runtime behavior change for non-persistent cards
- [ ] Persistent launcher cards keep \`persistent: true\` after daemon restart (message reload)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25299" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
