### PR TITLE
feat(ios): add QueuedMessagesDrawer_iOS and QueuedMessageRow_iOS components

### DIFF
--- a/clients/ios/Views/QueuedMessageRow_iOS.swift
+++ b/clients/ios/Views/QueuedMessageRow_iOS.swift
@@ -1,0 +1,102 @@
+#if canImport(UIKit)
+import SwiftUI
+import VellumAssistantShared
+
+/// A single row in the iOS queue drawer. Shows an amber accent bar, a numeric
+/// position pill, and a truncated preview of the queued message. When the row
+/// represents the tail of the queue, a pencil icon is rendered inline so the
+/// user can pop the message back into the composer for editing. A trailing
+/// swipe-to-cancel gesture is attached so swipes to the left destroy the row.
+///
+/// Shape mirrors the macOS `QueuedMessageRow` but sized for touch: minimum
+/// 44pt row height and 44x44pt icon hit areas per Apple HIG.
+struct QueuedMessageRow_iOS: View {
+    let message: ChatMessage
+    let positionLabel: String
+    let isTail: Bool
+    let onEdit: () -> Void
+    let onCancel: () -> Void
+
+    var body: some View {
+        HStack(spacing: VSpacing.md) {
+            // Amber accent bar — signals "held, waiting".
+            RoundedRectangle(cornerRadius: 1, style: .continuous)
+                .fill(VColor.systemPendingSoft)
+                .frame(width: 2)
+                .frame(maxHeight: .infinity)
+
+            // Position pill (#1, #2, ...). Tabular numerals keep digit widths
+            // aligned so the column stays tidy as positions change.
+            Text(positionLabel)
+                .font(VFont.numericMono)
+                .foregroundStyle(VColor.contentSecondary)
+                .padding(.horizontal, VSpacing.sm)
+                .padding(.vertical, VSpacing.xxs)
+                .background(VColor.surfaceLift)
+                .clipShape(Capsule())
+
+            // Truncated preview of the queued message text.
+            Text(message.text)
+                .font(VFont.bodyMediumDefault)
+                .foregroundStyle(VColor.contentDefault)
+                .lineLimit(1)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            // Inline edit icon — only on the tail. Swipe-edit would be
+            // ambiguous with the destructive swipe-to-cancel, so edit is
+            // explicitly tap-only.
+            if isTail {
+                Button(action: onEdit) {
+                    VIconView(.pencil, size: 14)
+                        .foregroundStyle(VColor.contentSecondary)
+                        .frame(width: 44, height: 44)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Edit queued message")
+            }
+        }
+        .frame(minHeight: 44)
+        .padding(.horizontal, VSpacing.md)
+        .padding(.vertical, VSpacing.sm)
+        .contentShape(Rectangle())
+        .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+            Button(role: .destructive, action: onCancel) {
+                Label("Cancel", systemImage: "xmark.circle")
+            }
+        }
+    }
+}
+
+#Preview("Tail row") {
+    QueuedMessageRow_iOS(
+        message: ChatMessage(
+            role: .user,
+            text: "Summarize the last three meetings and pull action items for the design review.",
+            status: .queued(position: 2)
+        ),
+        positionLabel: "#3",
+        isTail: true,
+        onEdit: {},
+        onCancel: {}
+    )
+    .padding()
+    .background(VColor.surfaceBase)
+}
+
+#Preview("Mid row") {
+    QueuedMessageRow_iOS(
+        message: ChatMessage(
+            role: .user,
+            text: "Also check the latest Linear issues.",
+            status: .queued(position: 0)
+        ),
+        positionLabel: "#1",
+        isTail: false,
+        onEdit: {},
+        onCancel: {}
+    )
+    .padding()
+    .background(VColor.surfaceBase)
+}
+#endif

--- a/clients/ios/Views/QueuedMessagesDrawer_iOS.swift
+++ b/clients/ios/Views/QueuedMessagesDrawer_iOS.swift
@@ -1,0 +1,172 @@
+#if canImport(UIKit)
+import SwiftUI
+import VellumAssistantShared
+
+/// The iOS queue drawer sits directly above `InputBarView` and lists every
+/// user message currently in the conversation queue. Each row is a
+/// `QueuedMessageRow_iOS`. When the queue is empty the drawer collapses to
+/// `EmptyView` so it takes up no vertical space.
+///
+/// The drawer does not own keyboard/safe-area treatment — `ChatContentView`
+/// already anchors `InputBarView` to the keyboard via its own layout, and this
+/// drawer just sits as a sibling above it in the parent `VStack`.
+struct QueuedMessagesDrawer_iOS: View {
+    @Bindable var viewModel: ChatViewModel
+    @Binding var composerText: String
+    @Binding var composerAttachments: [ChatAttachment]
+
+    var body: some View {
+        if viewModel.queuedMessages.isEmpty {
+            EmptyView()
+        } else {
+            container
+        }
+    }
+
+    private var container: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            header
+
+            LazyVStack(spacing: 0) {
+                ForEach(
+                    Array(viewModel.queuedMessages.enumerated()),
+                    id: \.element.id
+                ) { index, message in
+                    QueuedMessageRow_iOS(
+                        message: message,
+                        positionLabel: "#\(index + 1)",
+                        isTail: message.id == viewModel.tailQueuedMessageId,
+                        onEdit: {
+                            viewModel.editQueuedTail(
+                                into: $composerText,
+                                attachments: $composerAttachments
+                            )
+                        },
+                        onCancel: {
+                            viewModel.deleteQueuedMessage(messageId: message.id)
+                        }
+                    )
+                    .transition(.asymmetric(
+                        insertion: .push(from: .bottom).combined(with: .opacity),
+                        removal: .scale(scale: 0.92).combined(with: .opacity)
+                    ))
+                }
+            }
+            .animation(
+                .spring(duration: 0.28, bounce: 0.15),
+                value: viewModel.queuedMessages.map(\.id)
+            )
+        }
+        .padding(VSpacing.md)
+        .background(
+            RoundedRectangle(cornerRadius: VSpacing.md, style: .continuous)
+                .fill(VColor.surfaceOverlay)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: VSpacing.md, style: .continuous)
+                .strokeBorder(VColor.borderBase, lineWidth: 1)
+        )
+        .padding(.horizontal, VSpacing.md)
+    }
+
+    private var header: some View {
+        HStack {
+            Text("Queue · \(viewModel.queuedMessages.count)")
+                .font(VFont.labelDefault)
+                .foregroundStyle(VColor.contentSecondary)
+
+            Spacer()
+
+            Button("Cancel all") {
+                for message in viewModel.queuedMessages {
+                    viewModel.deleteQueuedMessage(messageId: message.id)
+                }
+            }
+            .font(VFont.labelDefault)
+            .foregroundStyle(VColor.contentSecondary)
+            .buttonStyle(.plain)
+            .accessibilityLabel("Cancel all queued messages")
+        }
+    }
+}
+
+#if DEBUG
+@MainActor
+private func previewViewModel(withQueue: Bool) -> ChatViewModel {
+    let connectionManager = GatewayConnectionManager()
+    let viewModel = ChatViewModel(
+        connectionManager: connectionManager,
+        eventStreamClient: connectionManager.eventStreamClient
+    )
+    if withQueue {
+        viewModel.messages = [
+            ChatMessage(
+                role: .user,
+                text: "Pull the latest analytics for the onboarding flow.",
+                status: .queued(position: 0)
+            ),
+            ChatMessage(
+                role: .user,
+                text: "Also compare week-over-week activation.",
+                status: .queued(position: 1)
+            ),
+            ChatMessage(
+                role: .user,
+                text: "And draft a summary email once we've confirmed the numbers.",
+                status: .queued(position: 2)
+            ),
+        ]
+    }
+    return viewModel
+}
+
+#Preview("Three queued") {
+    StatefulPreviewWrapper(("", [ChatAttachment]())) { text, attachments in
+        VStack {
+            Spacer()
+            QueuedMessagesDrawer_iOS(
+                viewModel: previewViewModel(withQueue: true),
+                composerText: text,
+                composerAttachments: attachments
+            )
+            Color.clear.frame(height: 80)
+        }
+        .background(VColor.surfaceBase)
+    }
+}
+
+#Preview("Empty queue collapses") {
+    StatefulPreviewWrapper(("", [ChatAttachment]())) { text, attachments in
+        QueuedMessagesDrawer_iOS(
+            viewModel: previewViewModel(withQueue: false),
+            composerText: text,
+            composerAttachments: attachments
+        )
+        .padding()
+        .background(VColor.surfaceBase)
+    }
+}
+
+/// Test helper that lets previews own two `@State` values and pass them as
+/// bindings to a child view. Without this, previews can't construct a
+/// `Binding` for the drawer's composer parameters.
+private struct StatefulPreviewWrapper<Value1, Value2, Content: View>: View {
+    @State private var value1: Value1
+    @State private var value2: Value2
+    private let content: (Binding<Value1>, Binding<Value2>) -> Content
+
+    init(
+        _ initial: (Value1, Value2),
+        @ViewBuilder content: @escaping (Binding<Value1>, Binding<Value2>) -> Content
+    ) {
+        _value1 = State(initialValue: initial.0)
+        _value2 = State(initialValue: initial.1)
+        self.content = content
+    }
+
+    var body: some View {
+        content($value1, $value2)
+    }
+}
+#endif
+#endif


### PR DESCRIPTION
## Summary
- Adds `QueuedMessagesDrawer_iOS` and `QueuedMessageRow_iOS` SwiftUI views for iOS chat UI
- Swipe-to-cancel on each row; edit icon only on the tail message
- Not yet wired into `ChatContentView` (that lands in PR 6)

Part of plan: queue-drawer-edit-cancel.md (PR 4 of 8)

## Deviations from plan
- **pbxproj edit not needed**: The iOS project generates its Xcode project from `project.yml` via xcodegen (`clients/ios/vellum-assistant-ios.xcodeproj/` is gitignored). Any file added to `clients/ios/Views/` is picked up automatically at generation time, so no manual pbxproj edit is required. Verified by running `xcodegen generate` and grepping for both new filenames in the generated pbxproj (8 occurrences confirming BuildFile + FileRef entries for each file).
- **Token substitutions** (matching PR 3's choices on macOS):
  - `VColor.surfaceElevated` → `VColor.surfaceLift` (nearest elevated-surface token).
  - `VColor.borderSubtle` → `VColor.borderBase` (nearest subtle border token).
  - `VFont.bodyDefault` → `VFont.bodyMediumDefault` (DM Sans 400 at 14pt; matches macOS row).
- **Xcode build not run**: iOS 26.4 simulator runtime is not installed on this build host (only the macOS 26 Xcode toolchain is available), so `xcodebuild build -scheme VellumAssistantIOS` cannot be executed here. The two files were authored to closely mirror the already-merged macOS `QueuedMessagesDrawer` / `QueuedMessageRow` pair so token and API usage matches a known-good reference. CI should exercise the iOS build.

## Known risk
- `.swipeActions(edge:allowsFullSwipe:content:)` is documented as 'Adds custom swipe actions to a row in a list.' Since the plan explicitly requires the row list wrapped in `LazyVStack` (not `List`), the modifier is attached to each row as specified but will be a no-op when the drawer is mounted as-is. If PR 6's manual swipe-to-cancel acceptance criterion fails at runtime, the fix would be to swap the `LazyVStack` for a `List` with `.listStyle(.plain)` + `.listRowBackground(Color.clear)` + `.listRowSeparator(.hidden)` + `.listRowInsets(EdgeInsets())` (preserves 'no insetGrouped styling mismatch' while activating swipe actions). Flagged here rather than silently changing the plan.

## Test plan
- [ ] CI runs `xcodebuild build -scheme VellumAssistantIOS` against an iOS simulator destination.
- [ ] Open both files in Xcode Previews on a local dev machine: verify the three-queued preview shows the header, three rows with `#1`/`#2`/`#3` pills, and the pencil icon only on the tail (`#3`) row. Verify the empty-queue preview collapses to zero height.
- [ ] Smoke-test in PR 6 once the drawer is wired: confirm swipe gesture behaviour matches expectations; if it does not, apply the `List`-with-plain-style remediation documented above.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25300" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
