### PR TITLE
feat(macos): mount QueuedMessagesDrawer between MessageListView and composer

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -436,6 +436,16 @@ struct ChatView: View {
                 .padding(.bottom, -VSpacing.sm)
             }
 
+            if !viewModel.queuedMessages.isEmpty {
+                QueuedMessagesDrawer(
+                    viewModel: viewModel,
+                    composerText: $viewModel.inputText,
+                    composerAttachments: $viewModel.pendingAttachments
+                )
+                .transition(.move(edge: .bottom).combined(with: .opacity))
+                .animation(.spring(duration: 0.28, bounce: 0.15), value: viewModel.queuedMessages.count)
+            }
+
             if isReadonly {
                 centeredChatColumn(width: layoutMetrics.chatColumnWidth) {
                     HStack(spacing: VSpacing.xs) {


### PR DESCRIPTION
## Summary
- Mounts `QueuedMessagesDrawer` in `ChatView` between the transcript and the composer
- Conditional on `viewModel.queuedMessages.isEmpty`; animated slide/opacity transition
- Bubbles still render inline in the transcript — transcript collapse deferred to PR 7

Part of plan: queue-drawer-edit-cancel.md (PR 5 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25301" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
