### PR TITLE
fix: resolve 400 API error when switching to Haiku model

### DIFF
--- a/assistant/src/__tests__/anthropic-provider.test.ts
+++ b/assistant/src/__tests__/anthropic-provider.test.ts
@@ -307,7 +307,10 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
     // Turn-starting user message (first) keeps 1h
     const turnStart = sent[0];
     const turnStartLast = turnStart.content[turnStart.content.length - 1];
-    expect(turnStartLast.cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
+    expect(turnStartLast.cache_control).toEqual({
+      type: "ephemeral",
+      ttl: "1h",
+    });
 
     // Last message (tool_result) gets 5m advancing tail
     const lastMessage = sent[sent.length - 1];
@@ -398,7 +401,10 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
     }>;
     const user = sent[0];
     expect(user.content[0].cache_control).toBeUndefined();
-    expect(user.content[1].cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
+    expect(user.content[1].cache_control).toEqual({
+      type: "ephemeral",
+      ttl: "1h",
+    });
   });
 
   // -----------------------------------------------------------------------
@@ -442,7 +448,10 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
     // Workspace block (first): no cache_control
     expect(user.content[0].cache_control).toBeUndefined();
     // User text (last): cache_control with 1h TTL
-    expect(user.content[1].cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
+    expect(user.content[1].cache_control).toEqual({
+      type: "ephemeral",
+      ttl: "1h",
+    });
   });
 
   test("workspace + multi-block single user message: cache on last block only", async () => {
@@ -476,7 +485,10 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
     // Only last block gets cache_control
     expect(user.content[0].cache_control).toBeUndefined();
     expect(user.content[1].cache_control).toBeUndefined();
-    expect(user.content[2].cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
+    expect(user.content[2].cache_control).toEqual({
+      type: "ephemeral",
+      ttl: "1h",
+    });
   });
 
   // -----------------------------------------------------------------------
@@ -1408,7 +1420,10 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
     // Last user message (turn 3): 1h cache on last block only
     const lastUser = userMsgs[userMsgs.length - 1];
     expect(lastUser.content[0].cache_control).toBeUndefined();
-    expect(lastUser.content[1].cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
+    expect(lastUser.content[1].cache_control).toEqual({
+      type: "ephemeral",
+      ttl: "1h",
+    });
 
     // No top-level cache_control — breakpoints are set directly on blocks
     expect(
@@ -1437,14 +1452,19 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
 
     // First message is the turn-starting user text — gets 1h cache
     expect(sent[0].role).toBe("user");
-    expect(sent[0].content[0].cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
+    expect(sent[0].content[0].cache_control).toEqual({
+      type: "ephemeral",
+      ttl: "1h",
+    });
 
     // Non-last tool result messages do NOT get cache_control
     const toolResultMsgs = sent.filter(
       (m) =>
         m.role === "user" &&
         Array.isArray(m.content) &&
-        m.content.every((b) => typeof b !== "string" && b.type === "tool_result"),
+        m.content.every(
+          (b) => typeof b !== "string" && b.type === "tool_result",
+        ),
     );
     expect(toolResultMsgs.length).toBeGreaterThan(0);
     for (const tr of toolResultMsgs.slice(0, -1)) {
@@ -1754,5 +1774,86 @@ describe("AnthropicProvider — surrogate sanitization", () => {
       content: Array<{ text?: string }>;
     }>;
     expect(sent[0].content[0].text).toContain(EMOJI);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Haiku model gating
+// ---------------------------------------------------------------------------
+
+describe("AnthropicProvider — Haiku Model Gating", () => {
+  let provider: AnthropicProvider;
+
+  beforeEach(() => {
+    lastStreamParams = null;
+    _lastStreamOptions = null;
+    lastConstructorArgs = null;
+    provider = new AnthropicProvider(
+      "sk-ant-test",
+      "claude-haiku-4-5-20251001",
+    );
+  });
+
+  test("max_tokens defaults to 8192 for Haiku", async () => {
+    await provider.sendMessage([userMsg("Hi")], undefined, "You are helpful.");
+
+    expect(lastStreamParams!.max_tokens).toBe(8192);
+  });
+
+  test("caller max_tokens is clamped to 8192 for Haiku", async () => {
+    await provider.sendMessage([userMsg("Hi")], undefined, "You are helpful.", {
+      config: { max_tokens: 64000 },
+    });
+
+    expect(lastStreamParams!.max_tokens).toBe(8192);
+  });
+
+  test("caller max_tokens below 8192 is preserved for Haiku", async () => {
+    await provider.sendMessage([userMsg("Hi")], undefined, "You are helpful.", {
+      config: { max_tokens: 128 },
+    });
+
+    expect(lastStreamParams!.max_tokens).toBe(128);
+  });
+
+  test("non-Haiku provider respects caller max_tokens without clamping", async () => {
+    const sonnetProvider = new AnthropicProvider(
+      "sk-ant-test",
+      "claude-sonnet-4-6",
+    );
+    await sonnetProvider.sendMessage(
+      [userMsg("Hi")],
+      undefined,
+      "You are helpful.",
+      { config: { max_tokens: 200 } },
+    );
+
+    expect(lastStreamParams!.max_tokens).toBe(200);
+  });
+
+  test("cache_control omits ttl for Haiku", async () => {
+    await provider.sendMessage([userMsg("Hi")], undefined, "You are helpful.");
+
+    const system = lastStreamParams!.system as Array<{
+      cache_control?: { type: string; ttl?: string };
+    }>;
+    expect(system[0].cache_control).toEqual({ type: "ephemeral" });
+    expect(system[0].cache_control).not.toHaveProperty("ttl");
+  });
+
+  test("betas array is empty for Haiku (no extended cache TTL or 1M context)", async () => {
+    await provider.sendMessage([userMsg("Hi")], undefined, "You are helpful.");
+
+    // When betas is empty, the non-beta stream path is used, so no betas
+    // field should appear in lastStreamParams.
+    expect(lastStreamParams!.betas).toBeUndefined();
+  });
+
+  test("effort is stripped for Haiku even when provided in config", async () => {
+    await provider.sendMessage([userMsg("Hi")], undefined, "You are helpful.", {
+      config: { effort: "high" },
+    });
+
+    expect(lastStreamParams!.output_config).toBeUndefined();
   });
 });

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -727,6 +727,7 @@ export class AnthropicProvider implements Provider {
         speed,
         output_config,
         cacheTtl: _cacheTtl,
+        max_tokens: _callerMaxTokens,
         ...restConfig
       } = (config ?? {}) as Record<string, unknown> & {
         effort?: Anthropic.OutputConfig["effort"];

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -609,7 +609,10 @@ export class AnthropicProvider implements Provider {
     options?: SendMessageOptions,
   ): Promise<ProviderResponse> {
     const { config, onEvent, signal } = options ?? {};
-    const cacheTtl: "5m" | "1h" = ((config as Record<string, unknown> | undefined)?.cacheTtl as "5m" | "1h") ?? "1h";
+    const cacheTtl: "5m" | "1h" =
+      ((config as Record<string, unknown> | undefined)?.cacheTtl as
+        | "5m"
+        | "1h") ?? "1h";
     let sentMessages: Anthropic.MessageParam[] | undefined;
     try {
       const formatted = messages
@@ -719,25 +722,41 @@ export class AnthropicProvider implements Provider {
       // — the API accepts them. No provider-side stripping needed.
 
       sentMessages = ensureToolPairing(repairOrphanedServerToolUse(formatted));
-      const { effort, speed, output_config, cacheTtl: _cacheTtl, ...restConfig } = (config ??
-        {}) as Record<string, unknown> & {
+      const {
+        effort,
+        speed,
+        output_config,
+        cacheTtl: _cacheTtl,
+        ...restConfig
+      } = (config ?? {}) as Record<string, unknown> & {
         effort?: Anthropic.OutputConfig["effort"];
         speed?: "standard" | "fast";
         output_config?: Record<string, unknown>;
       };
-      // Haiku does not support the effort / output_config parameter.
+      // Haiku does not support the effort / output_config parameter,
+      // extended cache TTL betas, 1M context, or 64K output tokens.
       // Determine the effective model (per-call override or provider default)
-      // and strip effort when the model doesn't support it.
+      // and gate features accordingly.
       const effectiveModel =
         (restConfig as Record<string, unknown>).model?.toString() ?? this.model;
-      const supportsEffort = !effectiveModel.includes("haiku");
+      const isHaiku = effectiveModel.includes("haiku");
+      const supportsEffort = !isHaiku;
       const mergedOutputConfig = {
         ...(output_config ?? {}),
         ...(effort && supportsEffort ? { effort } : {}),
       };
+      // Build cache_control objects: Haiku doesn't support the extended
+      // cache TTL beta, so omit the ttl field for Haiku models.
+      const cacheControl = isHaiku
+        ? { type: "ephemeral" as const }
+        : { type: "ephemeral" as const, ttl: cacheTtl };
+      const tailCacheControl = isHaiku
+        ? { type: "ephemeral" as const }
+        : { type: "ephemeral" as const, ttl: "5m" as const };
+
       let params: Anthropic.MessageStreamParams = {
         model: this.model,
-        max_tokens: 64000,
+        max_tokens: isHaiku ? 8192 : 64000,
         messages: sentMessages,
         ...restConfig,
         ...(Object.keys(mergedOutputConfig).length > 0
@@ -763,12 +782,12 @@ export class AnthropicProvider implements Provider {
             {
               type: "text" as const,
               text: staticBlock,
-              cache_control: { type: "ephemeral" as const, ttl: cacheTtl },
+              cache_control: cacheControl,
             },
             {
               type: "text" as const,
               text: dynamicBlock,
-              cache_control: { type: "ephemeral" as const, ttl: cacheTtl },
+              cache_control: cacheControl,
             },
           ];
         } else {
@@ -776,7 +795,7 @@ export class AnthropicProvider implements Provider {
             {
               type: "text" as const,
               text: systemPrompt,
-              cache_control: { type: "ephemeral" as const, ttl: cacheTtl },
+              cache_control: cacheControl,
             },
           ];
         }
@@ -793,12 +812,7 @@ export class AnthropicProvider implements Provider {
             description: t.description,
             input_schema: t.input_schema as Anthropic.Tool["input_schema"],
             ...(i === otherTools.length - 1
-              ? {
-                  cache_control: {
-                    type: "ephemeral" as const,
-                    ttl: cacheTtl,
-                  },
-                }
+              ? { cache_control: cacheControl }
               : {}),
           }));
           const webSearchTool: Anthropic.WebSearchTool20250305 = {
@@ -812,14 +826,7 @@ export class AnthropicProvider implements Provider {
             name: t.name,
             description: t.description,
             input_schema: t.input_schema as Anthropic.Tool["input_schema"],
-            ...(i === tools.length - 1
-              ? {
-                  cache_control: {
-                    type: "ephemeral" as const,
-                    ttl: cacheTtl,
-                  },
-                }
-              : {}),
+            ...(i === tools.length - 1 ? { cache_control: cacheControl } : {}),
           }));
         }
       }
@@ -843,10 +850,8 @@ export class AnthropicProvider implements Provider {
         if (!hasText) continue;
         const lastBlock = msg.content[msg.content.length - 1];
         if (typeof lastBlock !== "string") {
-          (lastBlock as unknown as Record<string, unknown>).cache_control = {
-            type: "ephemeral",
-            ttl: cacheTtl,
-          };
+          (lastBlock as unknown as Record<string, unknown>).cache_control =
+            cacheControl;
         }
         turnStartIdx = i;
         break;
@@ -862,7 +867,10 @@ export class AnthropicProvider implements Provider {
       if (turnStartIdx >= 0 && turnStartIdx < sentMessages.length - 1) {
         const lastMsg = sentMessages[sentMessages.length - 1];
         if (Array.isArray(lastMsg.content) && lastMsg.content.length > 0) {
-          const NON_CACHEABLE_TYPES = new Set(["thinking", "redacted_thinking"]);
+          const NON_CACHEABLE_TYPES = new Set([
+            "thinking",
+            "redacted_thinking",
+          ]);
           let tailBlock: (typeof lastMsg.content)[number] | undefined;
           for (let j = lastMsg.content.length - 1; j >= 0; j--) {
             const block = lastMsg.content[j];
@@ -875,10 +883,8 @@ export class AnthropicProvider implements Provider {
             }
           }
           if (tailBlock && typeof tailBlock !== "string") {
-            (tailBlock as unknown as Record<string, unknown>).cache_control = {
-              type: "ephemeral",
-              ttl: "5m",
-            };
+            (tailBlock as unknown as Record<string, unknown>).cache_control =
+              tailCacheControl;
             tailBreakpointApplied = true;
           }
         }
@@ -902,7 +908,8 @@ export class AnthropicProvider implements Provider {
         params.system.length === 2 &&
         hasToolCacheBreakpoint
       ) {
-        delete (params.system[0] as unknown as Record<string, unknown>).cache_control;
+        delete (params.system[0] as unknown as Record<string, unknown>)
+          .cache_control;
       }
 
       // Strip orphaned UTF-16 surrogates so the Anthropic JSON parser never
@@ -934,10 +941,10 @@ export class AnthropicProvider implements Provider {
 
       // Collect required betas: extended cache TTL for 1h system prompt caching,
       // 1M context window, and fast-mode when applicable.
-      const betas: string[] = [
-        "extended-cache-ttl-2025-04-11",
-        "context-1m-2025-08-07",
-      ];
+      // Haiku doesn't support the extended cache TTL or 1M context betas.
+      const betas: string[] = isHaiku
+        ? []
+        : ["extended-cache-ttl-2025-04-11", "context-1m-2025-08-07"];
       if (useFastMode) {
         betas.push("fast-mode-2026-02-01");
       }
@@ -954,14 +961,18 @@ export class AnthropicProvider implements Provider {
                 Anthropic.Beta.Messages.MessageCreateParamsStreaming,
               { signal: timeoutSignal },
             ) as unknown as UnifiedStream)
-          : (this.client.beta.messages.stream(
-              {
-                ...(params as Record<string, unknown>),
-                betas,
-              } as Anthropic.Beta.Messages.MessageCreateParamsNonStreaming &
-                Anthropic.Beta.Messages.MessageCreateParamsStreaming,
-              { signal: timeoutSignal },
-            ) as unknown as UnifiedStream);
+          : betas.length > 0
+            ? (this.client.beta.messages.stream(
+                {
+                  ...(params as Record<string, unknown>),
+                  betas,
+                } as Anthropic.Beta.Messages.MessageCreateParamsNonStreaming &
+                  Anthropic.Beta.Messages.MessageCreateParamsStreaming,
+                { signal: timeoutSignal },
+              ) as unknown as UnifiedStream)
+            : (this.client.messages.stream(params, {
+                signal: timeoutSignal,
+              }) as unknown as UnifiedStream);
 
         stream.on("text", (text) => {
           onEvent?.({ type: "text_delta", text });
@@ -1021,7 +1032,9 @@ export class AnthropicProvider implements Provider {
               type: "server_tool_complete",
               toolUseId: block.tool_use_id,
               isError: !!isError,
-              ...(Array.isArray(block.content) ? { content: block.content } : {}),
+              ...(Array.isArray(block.content)
+                ? { content: block.content }
+                : {}),
             });
           }
           if (event.type === "content_block_stop") {

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -727,7 +727,7 @@ export class AnthropicProvider implements Provider {
         speed,
         output_config,
         cacheTtl: _cacheTtl,
-        max_tokens: _callerMaxTokens,
+        max_tokens: callerMaxTokens,
         ...restConfig
       } = (config ?? {}) as Record<string, unknown> & {
         effort?: Anthropic.OutputConfig["effort"];
@@ -757,7 +757,14 @@ export class AnthropicProvider implements Provider {
 
       let params: Anthropic.MessageStreamParams = {
         model: this.model,
-        max_tokens: isHaiku ? 8192 : 64000,
+        max_tokens: isHaiku
+          ? Math.min(
+              typeof callerMaxTokens === "number" ? callerMaxTokens : 8192,
+              8192,
+            )
+          : typeof callerMaxTokens === "number"
+            ? callerMaxTokens
+            : 64000,
         messages: sentMessages,
         ...restConfig,
         ...(Object.keys(mergedOutputConfig).length > 0


### PR DESCRIPTION
## Summary
- Haiku 4.5 doesn't support the `extended-cache-ttl-2025-04-11` and `context-1m-2025-08-07` beta flags, custom TTL on `cache_control`, or 64K max output tokens — sending these caused a 400 Bad Request error
- Added `isHaiku` model detection (alongside existing `supportsEffort`) to conditionally gate: beta flags, cache TTL, max_tokens (8192 for Haiku vs 64000), and use the regular `messages.stream` endpoint when no betas are needed

## Original prompt
--safe when switching to Haiku not able to communicate with assistant receiving 400 API Error
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25302" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
