### PR TITLE
fix(macos): prevent InlineChatErrorAlert from filling viewport

### DIFF
--- a/clients/shared/Features/Chat/InlineChatErrorAlert.swift
+++ b/clients/shared/Features/Chat/InlineChatErrorAlert.swift
@@ -181,5 +181,6 @@ public struct InlineChatErrorAlert: View {
                 .strokeBorder(accentColor.opacity(0.15), lineWidth: 1)
         )
         .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+        .fixedSize(horizontal: false, vertical: true)
     }
 }


### PR DESCRIPTION
## Summary
- Add `.fixedSize(horizontal: false, vertical: true)` to `InlineChatErrorAlert` so the error card takes its intrinsic height instead of stretching to fill the latest-assistant-row `minHeight` wrapper in `MessageListContentView`.
- Root cause: the card's left accent `RoundedRectangle` is a flexible `Shape` and accepted the full proposed height under `ChatBubble`'s `.layoutPriority(1)` + the `turnMinHeight` wrapper — so a one-line "Conversation Stopped" card was inflating to the full viewport.
- No behavior change for non-latest error rows or for horizontal layout; the "user message anchored at top" scroll behavior is preserved (empty space just sits below the card instead of inside it).

## Original prompt
Apply the fix from /Users/sidd/.claude/plans/eager-hopping-sunset.md — add `.fixedSize(horizontal: false, vertical: true)` to InlineChatErrorAlert in clients/shared/Features/Chat/InlineChatErrorAlert.swift so the error card no longer stretches to fill the viewport.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25304" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
