### PR TITLE
fix(daemon): make /regenerate fire-and-forget

### DIFF
--- a/assistant/src/daemon/conversation-history.ts
+++ b/assistant/src/daemon/conversation-history.ts
@@ -566,8 +566,20 @@ export async function regenerate(
   conversation.abortController = new AbortController();
   conversation.currentRequestId = requestId ?? uuid();
 
-  await conversation.runAgentLoop(content, existingUserMessageId, onEvent, {
-    skipPreMessageRollback: true,
-    isUserMessage: true,
-  });
+  // Fire-and-forget: matches the /v1/messages pattern so the HTTP handler
+  // returns 202 immediately rather than blocking on the full agent turn.
+  // Otherwise the client's 15s POST timeout fires on any non-trivial
+  // regenerate and surfaces a misleading "Failed to regenerate message"
+  // banner even though the response streams in normally via SSE.
+  void conversation
+    .runAgentLoop(content, existingUserMessageId, onEvent, {
+      skipPreMessageRollback: true,
+      isUserMessage: true,
+    })
+    .catch((err) => {
+      log.error(
+        { err, conversationId: conversation.conversationId },
+        "runAgentLoop after regenerate failed",
+      );
+    });
 }


### PR DESCRIPTION
## Summary
- `/regenerate` awaited the full agent loop, so the client's 15s HTTP timeout fired on any non-trivial turn and showed "Failed to regenerate message." even when the response streamed in correctly via SSE.
- Drop the `await` on `runAgentLoop` so the HTTP handler returns 202 immediately, matching the `/v1/messages` fire-and-forget pattern documented in `runtime/CLAUDE.md`.
- Synchronous preconditions still emit SSE errors before kickoff; agent-loop errors are now structured-logged via `.catch`.

## Original prompt
it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25305" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
