### PR TITLE
feat(ios): mount QueuedMessagesDrawer_iOS above InputBarView

### DIFF
--- a/clients/ios/Views/ChatContentView.swift
+++ b/clients/ios/Views/ChatContentView.swift
@@ -148,6 +148,20 @@ struct ChatContentView: View {
                 genericErrorBanner(errorText)
             }
 
+            // Queue drawer — lists user messages still waiting to be sent.
+            // Collapses when the queue is empty.
+            if !viewModel.queuedMessages.isEmpty {
+                QueuedMessagesDrawer_iOS(
+                    viewModel: viewModel,
+                    composerText: $viewModel.inputText,
+                    composerAttachments: $viewModel.pendingAttachments
+                )
+                .transition(.move(edge: .bottom).combined(with: .opacity))
+                .animation(
+                    .spring(duration: 0.28, bounce: 0.15),
+                    value: viewModel.queuedMessages.count
+                )
+            }
 
             // Input bar
             InputBarView(


### PR DESCRIPTION
## Summary
- Mounts `QueuedMessagesDrawer_iOS` in `ChatContentView` between the generic error banner and `InputBarView`
- Conditional on queue non-empty with `.transition(.move(edge: .bottom).combined(with: .opacity))` and `.animation(.spring(duration: 0.28, bounce: 0.15), value: queuedMessages.count)` — same pattern as the macOS PR in this plan
- Bindings: `composerText: $viewModel.inputText` and `composerAttachments: $viewModel.pendingAttachments`. The plan referenced `viewModel.inputAttachments`, but that field does not exist on iOS — `pendingAttachments` is the source-of-truth binding that `InputBarView` reads, so that's what the drawer writes into
- Bubbles still render inline — transcript collapse deferred to PR 8

## Known issue inherited from PR 4 (NOT fixed here — follow-up needed)
PR 4 (#25300) built the drawer with `LazyVStack` + `.swipeActions(edge: .trailing, allowsFullSwipe: true)`. SwiftUI's `.swipeActions` is a no-op outside of `List`, so **swipe-to-cancel on a row does nothing at runtime**. On iOS this is the only per-message cancel affordance (the drawer header only offers 'Cancel all'), so this is a real gap.

I evaluated the suggested `LazyVStack` → plain `List` + `.scrollDisabled(true)` swap and opted not to fold it into this PR:
- `List` inside a `VStack` without a fixed frame does not size to its rows — it claims available vertical space, which would fight the surrounding layout.
- Making it size-to-content requires a computed `.frame(height:)` or a preference-key measurement, both of which have runtime/layout risks I can't verify here (iOS 26.4 simulator runtime is not installed on this machine, so `xcodebuild build` is not runnable).
- A focused follow-up PR with proper simulator verification is safer than shipping an uncertain fix inside an already-compound wiring PR.

Follow-up should either (a) switch to `List` with a measured or row-count-based frame, or (b) replace `.swipeActions` on the row with a custom `DragGesture` that fires `onCancel` on a trailing-edge drag past threshold (keeps `LazyVStack`, avoids List sizing entirely).

## Verification
- `xcrun -sdk iphonesimulator swiftc -parse` across `ChatContentView.swift`, `QueuedMessagesDrawer_iOS.swift`, `QueuedMessageRow_iOS.swift`, and `InputBarView.swift` — clean, no errors
- Full simulator `xcodebuild build` not runnable locally: iOS 26.4 platform not installed. CI is skipped per workflow instructions (`--skip-ci`); the `pr-ios` workflow is gated on a `preview` label anyway
- Manual simulator test deferred to when a runtime is available

## Bindings used (per tasker request)
- Composer text: `$viewModel.inputText` (matches existing `InputBarView(text: $viewModel.inputText, …)` in the same file)
- Composer attachments: `$viewModel.pendingAttachments` (deviates from the plan's placeholder `$viewModel.inputAttachments` because no such field exists; `pendingAttachments` is the observable forwarder to `attachmentManager.pendingAttachments` and is what `InputBarView` already reads)

Part of plan: queue-drawer-edit-cancel.md (PR 6 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25306" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
