### PR TITLE
feat(daemon): tag conversation aborts with structured reasons

### DIFF
--- a/assistant/src/__tests__/conversation-error.test.ts
+++ b/assistant/src/__tests__/conversation-error.test.ts
@@ -6,6 +6,10 @@ import {
   classifyConversationError,
   isUserCancellation,
 } from "../daemon/conversation-error.js";
+import {
+  type AbortReasonKind,
+  createAbortReason,
+} from "../util/abort-reasons.js";
 import { ProviderError, ProviderNotConfiguredError } from "../util/errors.js";
 
 describe("isUserCancellation", () => {
@@ -561,6 +565,72 @@ describe("classifyConversationError", () => {
 
       const aborted: ErrorContext = { phase: "agent_loop", aborted: true };
       expect(isUserCancellation(err, aborted)).toBe(true);
+    });
+  });
+
+  describe("wrapped ProviderError carrying tagged abort reason", () => {
+    const abortedCtx: ErrorContext = { phase: "agent_loop", aborted: true };
+    const taggedKinds: AbortReasonKind[] = [
+      "user_cancel",
+      "preempted_by_new_message",
+      "conversation_disposed",
+      "subagent_aborted",
+      "signal_cancel",
+      "voice_session_aborted",
+      "work_item_aborted",
+    ];
+
+    for (const kind of taggedKinds) {
+      it(`treats ProviderError with abortReason kind="${kind}" as user cancellation`, () => {
+        const wrapped = new ProviderError(
+          "Anthropic API error (undefined): Request was aborted.",
+          "anthropic",
+          undefined,
+          { abortReason: createAbortReason(kind, `test:${kind}`) },
+        );
+        expect(isUserCancellation(wrapped, abortedCtx)).toBe(true);
+      });
+    }
+
+    it("does NOT treat tagged ProviderError as cancellation when ctx.aborted is false", () => {
+      const wrapped = new ProviderError(
+        "Anthropic API error (undefined): Request was aborted.",
+        "anthropic",
+        undefined,
+        { abortReason: createAbortReason("user_cancel", "test") },
+      );
+      const notAborted: ErrorContext = { phase: "agent_loop", aborted: false };
+      expect(isUserCancellation(wrapped, notAborted)).toBe(false);
+    });
+
+    it("does NOT treat ProviderError without abortReason as cancellation", () => {
+      const wrapped = new ProviderError(
+        "Anthropic API error (undefined): Request was aborted.",
+        "anthropic",
+        undefined,
+      );
+      expect(isUserCancellation(wrapped, abortedCtx)).toBe(false);
+    });
+
+    it("does NOT treat ProviderError with foreign reason as cancellation", () => {
+      const wrapped = new ProviderError(
+        "Anthropic API error (undefined): Request was aborted.",
+        "anthropic",
+        undefined,
+        { abortReason: { kind: "user_cancel", source: "spoofed" } },
+      );
+      expect(isUserCancellation(wrapped, abortedCtx)).toBe(false);
+    });
+
+    it("falls through to CONVERSATION_ABORTED when wrapped ProviderError has no tagged reason", () => {
+      const wrapped = new ProviderError(
+        "Anthropic API error (undefined): Request was aborted.",
+        "anthropic",
+        undefined,
+      );
+      const result = classifyConversationError(wrapped, abortedCtx);
+      expect(result.code).toBe("CONVERSATION_ABORTED");
+      expect(result.errorCategory).toBe("session_aborted");
     });
   });
 });

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -21,6 +21,7 @@ import { buildAssistantEvent } from "../runtime/assistant-event.js";
 import { assistantEventHub } from "../runtime/assistant-event-hub.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { computeToolApprovalDigest } from "../security/tool-approval-digest.js";
+import { createAbortReason } from "../util/abort-reasons.js";
 import { getLogger } from "../util/logger.js";
 import {
   CALL_OPENING_MARKER,
@@ -539,7 +540,13 @@ export async function startVoiceTurn(
 
   const abortFn = () => {
     if (conversation.currentRequestId === requestId) {
-      conversation.abort();
+      conversation.abort(
+        createAbortReason(
+          "voice_session_aborted",
+          "voice-session-bridge.abortFn",
+          conversation.conversationId,
+        ),
+      );
     }
   };
 

--- a/assistant/src/daemon/conversation-error.ts
+++ b/assistant/src/daemon/conversation-error.ts
@@ -1,4 +1,5 @@
 import { getProviderRoutingSource } from "../providers/registry.js";
+import { isAbortReason } from "../util/abort-reasons.js";
 import { ProviderError, ProviderNotConfiguredError } from "../util/errors.js";
 import type {
   ConversationErrorCode,
@@ -110,11 +111,21 @@ export interface ErrorContext {
  * Returns true if the error looks like a user-initiated cancellation
  * (AbortError or explicit cancel). These should use `generation_cancelled`
  * instead of `conversation_error`.
+ *
+ * Provider SDKs wrap the underlying AbortError in their own error class
+ * (e.g. `ProviderError("Anthropic API error (undefined): Request was aborted.")`),
+ * which erases the `AbortError` name. To compensate, the daemon tags every
+ * `controller.abort(reason)` call with an `AbortReason` object — when the
+ * wrapped `ProviderError` carries that tagged reason, we treat it as a user
+ * cancellation regardless of error class.
  */
 export function isUserCancellation(error: unknown, ctx: ErrorContext): boolean {
   if (!ctx.aborted) return false;
   if (error instanceof DOMException && error.name === "AbortError") return true;
   if (error instanceof Error && error.name === "AbortError") return true;
+  if (error instanceof ProviderError && isAbortReason(error.abortReason)) {
+    return true;
+  }
   return false;
 }
 

--- a/assistant/src/daemon/conversation-lifecycle.ts
+++ b/assistant/src/daemon/conversation-lifecycle.ts
@@ -23,6 +23,10 @@ import {
   type TrustClass,
 } from "../runtime/actor-trust-resolver.js";
 import { unregisterConversationSender } from "../tools/browser/browser-screencast.js";
+import {
+  type AbortReason,
+  createAbortReason,
+} from "../util/abort-reasons.js";
 import { getLogger } from "../util/logger.js";
 import {
   unregisterCallNotifiers,
@@ -261,13 +265,23 @@ export async function loadFromDb(ctx: LoadFromDbContext): Promise<void> {
 
 // ── abort ─────────────────────────────────────────────────────────────
 
-export function abortConversation(ctx: AbortContext): void {
+export function abortConversation(
+  ctx: AbortContext,
+  reason?: AbortReason,
+): void {
   if (ctx.processing) {
+    const effectiveReason =
+      reason ??
+      createAbortReason(
+        "preempted_by_new_message",
+        "abortConversation:default",
+        ctx.conversationId,
+      );
     log.info(
-      { conversationId: ctx.conversationId },
+      { conversationId: ctx.conversationId, abortReason: effectiveReason },
       "Aborting in-flight processing",
     );
-    ctx.abortController?.abort();
+    ctx.abortController?.abort(effectiveReason);
     ctx.prompter.dispose();
     ctx.secretPrompter.dispose();
     ctx.pendingSurfaceActions.clear();
@@ -309,7 +323,14 @@ export function disposeConversation(ctx: DisposeContext): void {
     }
   }
 
-  ctx.abort();
+  abortConversation(
+    ctx,
+    createAbortReason(
+      "conversation_disposed",
+      "disposeConversation",
+      ctx.conversationId,
+    ),
+  );
   unregisterCallNotifiers(ctx.conversationId);
   unregisterConversationSender(ctx.conversationId);
   resetSkillToolProjection(ctx.skillProjectionState);

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -69,6 +69,7 @@ import * as approvalOverrides from "../runtime/conversation-approval-overrides.j
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 import { ToolExecutor } from "../tools/executor.js";
 import type { OnboardingContext } from "../types/onboarding-context.js";
+import type { AbortReason } from "../util/abort-reasons.js";
 import { getLogger } from "../util/logger.js";
 import type { AssistantAttachmentDraft } from "./assistant-attachments.js";
 import { runAgentLoopImpl } from "./conversation-agent-loop.js";
@@ -702,8 +703,8 @@ export class Conversation {
     return this.stale;
   }
 
-  abort(): void {
-    abortConversation(this);
+  abort(reason?: AbortReason): void {
+    abortConversation(this, reason);
   }
 
   dispose(): void {

--- a/assistant/src/daemon/handlers/conversations.ts
+++ b/assistant/src/daemon/handlers/conversations.ts
@@ -16,6 +16,7 @@ import * as pendingInteractions from "../../runtime/pending-interactions.js";
 import { redactSecrets } from "../../security/secret-scanner.js";
 import { getSubagentManager } from "../../subagent/index.js";
 import { summarizeToolInput } from "../../tools/tool-input-summary.js";
+import { createAbortReason } from "../../util/abort-reasons.js";
 import { truncate } from "../../util/truncate.js";
 import type { Conversation } from "../conversation.js";
 import type {
@@ -323,7 +324,9 @@ export function cancelGeneration(
     return false;
   }
   ctx.touchConversation(conversationId);
-  conversation.abort();
+  conversation.abort(
+    createAbortReason("user_cancel", "cancelGeneration", conversationId),
+  );
   // Also abort any child subagents spawned by this conversation.
   // Omit sendToClient to suppress parent notifications — the parent is
   // being cancelled, so enqueuing synthetic messages would trigger

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -59,6 +59,7 @@ import { appendEventToStream } from "../signals/event-stream.js";
 import { registerUserMessageCallback } from "../signals/user-message.js";
 import { getSubagentManager } from "../subagent/index.js";
 import { summarizeToolInput } from "../tools/tool-input-summary.js";
+import { createAbortReason } from "../util/abort-reasons.js";
 import { getLogger } from "../util/logger.js";
 import {
   getAvatarImagePath,
@@ -627,7 +628,13 @@ export class DaemonServer {
       const conversation = this.conversations.get(conversationId);
       if (!conversation) return false;
       this.evictor.touch(conversationId);
-      conversation.abort();
+      conversation.abort(
+        createAbortReason(
+          "signal_cancel",
+          "registerCancelCallback",
+          conversationId,
+        ),
+      );
       getSubagentManager().abortAllForParent(conversationId);
       return true;
     });

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -1,6 +1,7 @@
 import Anthropic from "@anthropic-ai/sdk";
 
 import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../../prompts/system-prompt.js";
+import { isAbortReason } from "../../util/abort-reasons.js";
 import { ProviderError } from "../../util/errors.js";
 import { getLogger } from "../../util/logger.js";
 import { extractRetryAfterMs } from "../../util/retry.js";
@@ -1103,6 +1104,12 @@ export class AnthropicProvider implements Provider {
         rawResponse: response,
       };
     } catch (error) {
+      // Propagate a tagged AbortReason (set by the daemon at controller.abort())
+      // so wrapped errors can be classified as user cancellation downstream.
+      const abortReason =
+        signal?.aborted && isAbortReason(signal.reason)
+          ? signal.reason
+          : undefined;
       if (error instanceof Anthropic.APIError) {
         // Log detailed message structure for tool_use/tool_result ordering errors
         if (
@@ -1118,20 +1125,33 @@ export class AnthropicProvider implements Provider {
             "Anthropic 400: tool_use/tool_result pairing error — dumping message structure",
           );
         }
-        log.error(
-          {
-            status: error.status,
-            message: error.message,
-            headers: Object.fromEntries(error.headers?.entries() ?? []),
-          },
-          `Anthropic API error (${error.status})`,
-        );
+        if (abortReason) {
+          log.info(
+            { abortReason, message: error.message },
+            "Anthropic request aborted by daemon",
+          );
+        } else {
+          log.error(
+            {
+              status: error.status,
+              message: error.message,
+              headers: Object.fromEntries(error.headers?.entries() ?? []),
+            },
+            `Anthropic API error (${error.status})`,
+          );
+        }
         const retryAfterMs = extractRetryAfterMs(error.headers);
+        const errorOptions: {
+          retryAfterMs?: number;
+          abortReason?: unknown;
+        } = {};
+        if (retryAfterMs !== undefined) errorOptions.retryAfterMs = retryAfterMs;
+        if (abortReason) errorOptions.abortReason = abortReason;
         throw new ProviderError(
           `Anthropic API error (${error.status}): ${error.message}`,
           "anthropic",
           error.status,
-          retryAfterMs !== undefined ? { retryAfterMs } : undefined,
+          Object.keys(errorOptions).length > 0 ? errorOptions : undefined,
         );
       }
       throw new ProviderError(
@@ -1140,7 +1160,7 @@ export class AnthropicProvider implements Provider {
         }`,
         "anthropic",
         undefined,
-        { cause: error },
+        abortReason ? { cause: error, abortReason } : { cause: error },
       );
     }
   }

--- a/assistant/src/runtime/routes/work-items-routes.ts
+++ b/assistant/src/runtime/routes/work-items-routes.ts
@@ -19,6 +19,7 @@ import {
   getToolDescription,
   sanitizeToolList,
 } from "../../tasks/tool-sanitizer.js";
+import { createAbortReason } from "../../util/abort-reasons.js";
 import { getLogger } from "../../util/logger.js";
 import { truncate } from "../../util/truncate.js";
 import { resolveRequiredTools } from "../../work-items/resolve-required-tools.js";
@@ -587,7 +588,13 @@ export function workItemRouteDefinitions(
           const conversation = deps.findConversation(conversationId);
           if (conversation) {
             conversation.headlessLock = false;
-            conversation.abort();
+            conversation.abort(
+              createAbortReason(
+                "work_item_aborted",
+                "work-items-routes.cancel",
+                conversationId,
+              ),
+            );
             getSubagentManager().abortAllForParent(conversationId);
           }
         }

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -19,6 +19,7 @@ import type { ServerMessage } from "../daemon/message-protocol.js";
 import { bootstrapConversation } from "../memory/conversation-bootstrap.js";
 import { RateLimitProvider } from "../providers/ratelimit.js";
 import { getProvider } from "../providers/registry.js";
+import { createAbortReason } from "../util/abort-reasons.js";
 import { getLogger } from "../util/logger.js";
 import { getSandboxWorkingDir } from "../util/platform.js";
 import {
@@ -509,7 +510,13 @@ export class SubagentManager {
       return false;
     }
 
-    managed.conversation?.abort();
+    managed.conversation?.abort(
+      createAbortReason(
+        "subagent_aborted",
+        "SubagentManager.abort",
+        managed.conversation.conversationId,
+      ),
+    );
     managed.state.completedAt = Date.now();
     if (parentSendToClient) {
       // Route the status update through the stored parent sender so the
@@ -704,7 +711,13 @@ export class SubagentManager {
 
     if (managed.conversation) {
       if (!TERMINAL_STATUSES.has(managed.state.status)) {
-        managed.conversation.abort();
+        managed.conversation.abort(
+          createAbortReason(
+            "subagent_aborted",
+            "SubagentManager.dispose",
+            managed.conversation.conversationId,
+          ),
+        );
       }
       managed.conversation.dispose();
       managed.conversation = null;

--- a/assistant/src/util/abort-reasons.ts
+++ b/assistant/src/util/abort-reasons.ts
@@ -1,0 +1,58 @@
+/**
+ * Tagged AbortReason objects passed as the `reason` argument to
+ * `AbortController.abort()` for daemon-owned conversation aborts.
+ *
+ * The reason flows through the AbortSignal into provider SDKs (Anthropic,
+ * OpenAI, etc.). When a provider wraps the abort error, the wrapped
+ * `ProviderError` carries the original reason via `ProviderError.abortReason`,
+ * letting `isUserCancellation` distinguish a user-initiated abort from a
+ * genuine provider failure even after wrapping erases the `AbortError` name.
+ */
+
+export type AbortReasonKind =
+  /** User explicitly hit Stop / Esc on the active conversation. */
+  | "user_cancel"
+  /** A new user message arrived for the same conversation, preempting the in-flight turn. */
+  | "preempted_by_new_message"
+  /** The conversation was disposed (eviction, shutdown) while still processing. */
+  | "conversation_disposed"
+  /** A subagent's owning conversation was aborted (parent abort, dispose, or explicit subagent abort). */
+  | "subagent_aborted"
+  /** A signal-file cancel was written by an out-of-process caller (CLI, hook). */
+  | "signal_cancel"
+  /** Voice session bridge aborted the conversation (turn supersession, call end). */
+  | "voice_session_aborted"
+  /** A scheduled work item run was cancelled or its conversation reset. */
+  | "work_item_aborted";
+
+const ABORT_REASON_TAG = "__vellumAbortReason" as const;
+
+export interface AbortReason {
+  readonly [ABORT_REASON_TAG]: true;
+  readonly kind: AbortReasonKind;
+  /** Short identifier of the call site for logging (e.g. "cancelGeneration"). */
+  readonly source: string;
+  readonly conversationId?: string;
+}
+
+export function createAbortReason(
+  kind: AbortReasonKind,
+  source: string,
+  conversationId?: string,
+): AbortReason {
+  return {
+    [ABORT_REASON_TAG]: true,
+    kind,
+    source,
+    ...(conversationId ? { conversationId } : {}),
+  };
+}
+
+export function isAbortReason(value: unknown): value is AbortReason {
+  if (typeof value !== "object" || value === null) return false;
+  return (
+    (value as Record<string, unknown>)[ABORT_REASON_TAG] === true &&
+    typeof (value as Record<string, unknown>).kind === "string" &&
+    typeof (value as Record<string, unknown>).source === "string"
+  );
+}

--- a/assistant/src/util/errors.ts
+++ b/assistant/src/util/errors.ts
@@ -102,16 +102,24 @@ export class AssistantError extends VellumError {
 export class ProviderError extends AssistantError {
   /** Delay (in ms) suggested by the server's Retry-After header, if present. */
   public readonly retryAfterMs?: number;
+  /**
+   * Tagged daemon-owned abort reason carried over from the AbortSignal that
+   * triggered this error. Untyped here to avoid a daemon→util import cycle;
+   * `AbortReason` from `daemon/abort-reasons.ts` is the only producer and
+   * `isAbortReason` is the canonical type guard for consumers.
+   */
+  public readonly abortReason?: unknown;
 
   constructor(
     message: string,
     public readonly provider: string,
     public readonly statusCode?: number,
-    options?: { cause?: unknown; retryAfterMs?: number },
+    options?: { cause?: unknown; retryAfterMs?: number; abortReason?: unknown },
   ) {
     super(message, ErrorCode.PROVIDER_ERROR, options);
     this.name = "ProviderError";
     this.retryAfterMs = options?.retryAfterMs;
+    this.abortReason = options?.abortReason;
   }
 }
 


### PR DESCRIPTION
## Summary
- Daemon-owned `controller.abort()` calls on conversation AbortControllers now carry a tagged `AbortReason` (`user_cancel`, `preempted_by_new_message`, `signal_cancel`, `subagent_aborted`, `voice_session_aborted`, `work_item_aborted`, `conversation_disposed`) so the originating call site survives propagation through the provider SDK.
- The Anthropic client extracts `signal.reason` on abort and threads it onto `ProviderError.abortReason`; `isUserCancellation` recognizes the wrapped case so user/preempt/dispose cancels render as silent `generation_cancelled` instead of a red `CONVERSATION_ABORTED` error card.
- Future "Request was aborted." incidents become diagnosable from the error itself (which call site fired the abort) instead of requiring a daemon log dive.

## Original prompt
> Make daemon abort() calls on conversation AbortControllers pass a tagged reason so that when the Anthropic SDK surfaces "Request was aborted." (status undefined) we can identify which call site triggered it. Today the SDK message loses all provenance and a user cancel is indistinguishable from a preempting message, an SSE-driven cancel, a subagent abort, or a programmatic dispose.
>
> Background context: I just diagnosed a real "Request was aborted." error from the user that surfaced as a visible CONVERSATION_ABORTED card. The user confirmed they did not hit Stop, so the abort came from one of the daemon-internal call sites — but we have no way to tell which. This change makes future incidents diagnosable from the error itself, and also fixes the existing classification bug where user/preempt cancels render as visible errors instead of being silent.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25308" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
