### PR TITLE
fix: attachment messages use collapsed height + consistent heuristic collapse

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -668,6 +668,10 @@ struct ChatBubble: View, Equatable {
     private func heuristicUserMessageCollapseWrapper<Content: View>(@ViewBuilder _ content: () -> Content) -> some View {
         VStack(alignment: .leading, spacing: 0) {
             content()
+                // Clip to same height as the measurement-based collapse path
+                // so both produce a consistent collapsed height.
+                .frame(height: isUserMessageExpanded ? nil : userMessageMaxCollapsedHeight, alignment: .top)
+                .clipped()
                 .overlay(alignment: .bottom) {
                     if !isUserMessageExpanded {
                         LinearGradient(

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
@@ -180,6 +180,10 @@ struct MessageListContentView: View, Equatable {
                 guard let lastUser = state.rows.last(where: { $0.message.role == .user }) else {
                     return 80
                 }
+                // Messages with attachments are always collapsed — use max height
+                if !lastUser.message.attachments.isEmpty {
+                    return 260
+                }
                 let text = lastUser.message.text as NSString
                 let contentWidth = max(layoutMetrics.bubbleMaxWidth - 2 * VSpacing.lg, 0)
                 let font = NSFont.systemFont(ofSize: 14, weight: .regular)


### PR DESCRIPTION
## Summary
- Messages with attachments use 260pt collapsed height immediately for minHeight calculation (attachments always trigger collapse, so text estimation is wrong)
- Heuristic collapse path (>3000 chars or >40 lines) now clips to 150pt matching the height-based collapse path — pasted and typed long messages produce identical collapsed height

## Test plan
- [ ] Send a message with an image attachment — user message should pin correctly at top
- [ ] Paste a very long block of text — collapsed height should match a typed long message
- [ ] Short messages — no change in behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25309" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
