### PR TITLE
fix(shared): pick newest queued message for tail when positions tie

### DIFF
--- a/clients/ios/Tests/ChatViewModelIOSTests.swift
+++ b/clients/ios/Tests/ChatViewModelIOSTests.swift
@@ -556,6 +556,66 @@ final class ChatViewModelIOSTests: XCTestCase {
                      "Tail should be nil when no queued user messages exist")
     }
 
+    func test_tailQueuedMessageId_prefersNewestOnPositionTie() {
+        let first = ChatMessage(role: .user, text: "first", status: .queued(position: 0))
+        let second = ChatMessage(role: .user, text: "second", status: .queued(position: 0))
+        let third = ChatMessage(role: .user, text: "third", status: .queued(position: 0))
+        viewModel.messages = [first, second, third]
+
+        XCTAssertEqual(viewModel.tailQueuedMessageId, third.id,
+                       "On a position-0 tie, tail should be the most recently added message")
+    }
+
+    func test_editQueuedTail_operatesOnNewestWhenPositionsTie() async {
+        let mockQueueClient = MockConversationQueueClient()
+        mockQueueClient.deleteResult = true
+
+        let connection = GatewayConnectionManager()
+        connection.isConnected = true
+        let vm = ChatViewModel(
+            connectionManager: connection,
+            eventStreamClient: connection.eventStreamClient,
+            conversationQueueClient: mockQueueClient
+        )
+        vm.conversationId = "sess-tie-ios"
+
+        let oldest = ChatMessage(role: .user, text: "oldest", status: .queued(position: 0))
+        let middle = ChatMessage(role: .user, text: "middle", status: .queued(position: 0))
+        let newest = ChatMessage(role: .user, text: "newest", status: .queued(position: 0))
+        vm.messages = [oldest, middle, newest]
+        vm.requestIdToMessageId = [
+            "req-oldest": oldest.id,
+            "req-middle": middle.id,
+            "req-newest": newest.id
+        ]
+        vm.pendingQueuedCount = 3
+
+        var composerText = ""
+        var composerAttachments: [ChatAttachment] = []
+        let textBinding = Binding<String>(
+            get: { composerText },
+            set: { composerText = $0 }
+        )
+        let attachmentsBinding = Binding<[ChatAttachment]>(
+            get: { composerAttachments },
+            set: { composerAttachments = $0 }
+        )
+
+        vm.editQueuedTail(into: textBinding, attachments: attachmentsBinding)
+
+        XCTAssertEqual(composerText, "newest",
+                       "Composer should receive the newest queued message's text, not the oldest")
+
+        let deadline = ContinuousClock.now + .seconds(2)
+        while mockQueueClient.calls.isEmpty && ContinuousClock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+
+        XCTAssertEqual(mockQueueClient.calls.count, 1)
+        XCTAssertEqual(mockQueueClient.calls.first?.requestId, "req-newest",
+                       "delete_queued_message should target the newest queued message on ties")
+    }
+
     func test_editQueuedTail_copiesContentAndDeletesOriginal() async {
         let mockQueueClient = MockConversationQueueClient()
         mockQueueClient.deleteResult = true

--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -2995,6 +2995,72 @@ final class ChatViewModelTests: XCTestCase {
                      "Tail should be nil when no queued user messages exist")
     }
 
+    func test_tailQueuedMessageId_prefersNewestOnPositionTie() {
+        // Repro for Codex P1 feedback on #25289: before `message_queued` acks
+        // arrive, multiple queued messages all live at position 0. The tail
+        // should be the most recently added (last in chronological order), not
+        // the first.
+        let first = ChatMessage(role: .user, text: "first", status: .queued(position: 0))
+        let second = ChatMessage(role: .user, text: "second", status: .queued(position: 0))
+        let third = ChatMessage(role: .user, text: "third", status: .queued(position: 0))
+        viewModel.messages = [first, second, third]
+
+        XCTAssertEqual(viewModel.tailQueuedMessageId, third.id,
+                       "On a position-0 tie, tail should be the most recently added message")
+    }
+
+    func test_editQueuedTail_operatesOnNewestWhenPositionsTie() async {
+        // When multiple messages are queued pre-ack (all at position 0),
+        // editQueuedTail must pop the NEWEST, not the oldest.
+        let mockQueueClient = MockConversationQueueClient()
+        mockQueueClient.deleteResult = true
+
+        let connection = GatewayConnectionManager()
+        connection.isConnected = true
+        let vm = ChatViewModel(
+            connectionManager: connection,
+            eventStreamClient: connection.eventStreamClient,
+            conversationQueueClient: mockQueueClient
+        )
+        vm.conversationId = "sess-tie"
+
+        let oldest = ChatMessage(role: .user, text: "oldest", status: .queued(position: 0))
+        let middle = ChatMessage(role: .user, text: "middle", status: .queued(position: 0))
+        let newest = ChatMessage(role: .user, text: "newest", status: .queued(position: 0))
+        vm.messages = [oldest, middle, newest]
+        vm.requestIdToMessageId = [
+            "req-oldest": oldest.id,
+            "req-middle": middle.id,
+            "req-newest": newest.id
+        ]
+        vm.pendingQueuedCount = 3
+
+        var composerText = ""
+        var composerAttachments: [ChatAttachment] = []
+        let textBinding = Binding<String>(
+            get: { composerText },
+            set: { composerText = $0 }
+        )
+        let attachmentsBinding = Binding<[ChatAttachment]>(
+            get: { composerAttachments },
+            set: { composerAttachments = $0 }
+        )
+
+        vm.editQueuedTail(into: textBinding, attachments: attachmentsBinding)
+
+        XCTAssertEqual(composerText, "newest",
+                       "Composer should receive the newest queued message's text, not the oldest")
+
+        let deadline = ContinuousClock.now + .seconds(2)
+        while mockQueueClient.calls.isEmpty && ContinuousClock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+
+        XCTAssertEqual(mockQueueClient.calls.count, 1)
+        XCTAssertEqual(mockQueueClient.calls.first?.requestId, "req-newest",
+                       "delete_queued_message should target the newest queued message on ties")
+    }
+
     func test_editQueuedTail_copiesContentAndDeletesOriginal() async {
         let mockQueueClient = MockConversationQueueClient()
         mockQueueClient.deleteResult = true

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -377,12 +377,17 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
     /// ID of the queued user message with the highest position (i.e. the tail of
     /// the queue that will be processed last). `nil` when no user messages are
     /// currently queued. Used to drive "edit last queued message" affordances.
+    ///
+    /// On position ties (e.g. multiple messages queued before any `message_queued`
+    /// acks arrive — all start at position 0), prefer the most recently added
+    /// message. `messages` is maintained in chronological (append) order, so
+    /// `>=` with iteration ensures the last-at-max wins.
     public var tailQueuedMessageId: UUID? {
         var tailId: UUID?
         var tailPosition = Int.min
         for message in messages where message.role == .user {
             guard case let .queued(position) = message.status else { continue }
-            if position > tailPosition {
+            if position >= tailPosition {
                 tailPosition = position
                 tailId = message.id
             }


### PR DESCRIPTION
Addresses Codex P1 feedback on #25289: when multiple messages are queued before ack, all start at position 0; the existing strict > comparator kept the OLDEST instead of the newest, so editQueuedTail popped the wrong message. Select newest on ties.

Addresses feedback on https://github.com/vellum-ai/vellum-assistant/pull/25289.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25310" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
