### PR TITLE
fix(macos): size QueuedMessageRow to padded content, use VIcon for icons

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/QueuedMessageRow.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/QueuedMessageRow.swift
@@ -51,9 +51,9 @@ struct QueuedMessageRow: View {
             // (d) Trailing icon cluster: pencil only when tail, xmark always.
             HStack(spacing: VSpacing.xs) {
                 if isTail {
-                    QueuedRowIconButton(systemName: "pencil", accessibilityLabel: "Edit queued message", action: onEdit)
+                    QueuedRowIconButton(icon: .pencil, accessibilityLabel: "Edit queued message", action: onEdit)
                 }
-                QueuedRowIconButton(systemName: "xmark", accessibilityLabel: "Cancel queued message", action: onCancel)
+                QueuedRowIconButton(icon: .x, accessibilityLabel: "Cancel queued message", action: onCancel)
             }
         }
         .padding(EdgeInsets(
@@ -62,7 +62,6 @@ struct QueuedMessageRow: View {
             bottom: VSpacing.sm,
             trailing: VSpacing.md
         ))
-        .frame(height: VSpacing.xl + VSpacing.sm)
         .contentShape(Rectangle())
     }
 }
@@ -73,7 +72,7 @@ struct QueuedMessageRow: View {
 /// hit target minimum called out in the plan, and swaps the foreground between
 /// `contentSecondary` (resting) and `contentDefault` (hovered).
 private struct QueuedRowIconButton: View {
-    let systemName: String
+    let icon: VIcon
     let accessibilityLabel: String
     let action: () -> Void
 
@@ -81,8 +80,7 @@ private struct QueuedRowIconButton: View {
 
     var body: some View {
         Button(action: action) {
-            Image(systemName: systemName)
-                .font(.system(size: 11, weight: .medium))
+            VIconView(icon, size: 11)
                 .foregroundStyle(isHovered ? VColor.contentDefault : VColor.contentSecondary)
                 .frame(width: 24, height: 24)
                 .contentShape(Rectangle())


### PR DESCRIPTION
Addresses Codex P2 + Devin review feedback on #25294:

- Remove hard 32pt height cap on QueuedMessageRow — content (24pt icons + 8pt top/bottom padding = 40pt min) was overflowing the allocated row bounds, causing overlap between adjacent rows and partially untappable icons.
- Replace Image(systemName:) in QueuedRowIconButton with VIconView/VIcon per clients/AGENTS.md mandatory icon rule.

Addresses feedback on https://github.com/vellum-ai/vellum-assistant/pull/25294.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25311" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
