### PR TITLE
test(cli): regression guard for empty-sshUser abort

### DIFF
--- a/cli/src/__tests__/ssh-user-guard.test.ts
+++ b/cli/src/__tests__/ssh-user-guard.test.ts
@@ -1,0 +1,28 @@
+import { describe, test, expect } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+// Regression guard for PR #25292: hatchAws/hatchGcp must abort before
+// launching a cloud instance when sshUser is empty. Otherwise `useradd ""`
+// in the generated startup script fails after billable resources are live.
+describe("sshUser empty-string guard", () => {
+  const files = [
+    join(import.meta.dir, "..", "lib", "aws.ts"),
+    join(import.meta.dir, "..", "lib", "gcp.ts"),
+  ];
+
+  for (const file of files) {
+    test(`${file.split("/").slice(-2).join("/")} aborts on empty sshUser`, () => {
+      const source = readFileSync(file, "utf8");
+      const fallbackIdx = source.indexOf('sshUser = process.env.USER ?? ""');
+      expect(fallbackIdx).toBeGreaterThan(-1);
+
+      const afterFallback = source.slice(fallbackIdx);
+      const guardIdx = afterFallback.search(/if\s*\(\s*!sshUser\s*\)/);
+      expect(guardIdx).toBeGreaterThan(-1);
+
+      const guardBlock = afterFallback.slice(guardIdx, guardIdx + 400);
+      expect(guardBlock).toContain("process.exit(1)");
+    });
+  }
+});


### PR DESCRIPTION
Addresses Devin feedback on https://github.com/vellum-ai/vellum-assistant/pull/25292.

Audited the two other `userInfo().username` call sites Devin flagged:
- `cli/src/components/DefaultMainScreen.tsx:1944` — fed into `sha256(hostname() + username)` to build a pairing `hostId`. Empty string still produces a valid hex digest; no crash, no billing side-effect.
- `cli/src/commands/pair.ts:41` (via `safeUserInfoUsername` → `getDeviceId`) — same pattern: empty string hashed into a stable `deviceId` sent to the pairing endpoint. Not display-only as Devin suggested, but still non-fatal.

Neither site has a downstream failure analogous to `useradd ""` in the cloud startup script, so no guard needed.

Shipping a source-level regression test instead so the `aws.ts`/`gcp.ts` empty-sshUser guard can't silently regress.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25312" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
