### PR TITLE
fix(macos): route Escape-dismiss through handleSurfaceDismiss

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
@@ -406,10 +406,17 @@ final class SurfaceManager {
     /// Dismiss only floating panel surfaces, leaving workspace-routed surfaces untouched.
     /// Used by the global Escape handler to avoid destroying workspace apps when the user
     /// presses Escape in another application.
+    ///
+    /// Routes each dismissal through `handleSurfaceDismiss` so the daemon receives a synthetic
+    /// `"dismiss"` action (matching the close-button path) and can clean up its pending-surface
+    /// state. Without this, Escape would leave the daemon with a stale pending entry.
     func dismissFloatingOnly() {
-        let floatingIds = Array(panels.keys).filter { !workspaceRoutedSurfaces.contains($0) }
+        let floatingIds = activeSurfaces.keys.filter { !workspaceRoutedSurfaces.contains($0) }
         for id in floatingIds {
-            dismissSurfaceById(id)
+            handleSurfaceDismiss(
+                conversationId: activeSurfaces[id]?.conversationId,
+                surfaceId: id
+            )
         }
     }
 

--- a/clients/macos/vellum-assistantTests/SurfaceManagerTests.swift
+++ b/clients/macos/vellum-assistantTests/SurfaceManagerTests.swift
@@ -207,6 +207,70 @@ final class SurfaceManagerTests: XCTestCase {
         XCTAssertEqual(dispatched.first?.actionId, "btn-1")
     }
 
+    // MARK: - Escape-dismiss path
+
+    func testDismissFloatingOnly_persistentSurface_sendsSyntheticDismiss() {
+        // Regression: the global Escape handler routes through dismissFloatingOnly(), which
+        // previously called dismissSurfaceById directly and skipped handleSurfaceDismiss.
+        // That left the daemon with a stale pending-surface entry. Escape must now emit the
+        // same synthetic "dismiss" the close-button path does.
+        let surface = makeCardSurface(id: "surf-esc-persistent")
+        surfaceManager.registerForTesting(surface: surface, persistent: true)
+
+        surfaceManager.dismissFloatingOnly()
+
+        XCTAssertEqual(dispatched.count, 1,
+                       "Escape on a persistent surface with no prior action must emit dismiss")
+        XCTAssertEqual(dispatched.first?.actionId, "dismiss")
+        XCTAssertNil(surfaceManager.activeSurfaces[surface.id],
+                     "Surface should be torn down after Escape")
+    }
+
+    func testDismissFloatingOnly_persistentSurfaceAfterAction_suppressed() {
+        let surface = makeCardSurface(id: "surf-esc-persistent-race")
+        surfaceManager.registerForTesting(surface: surface, persistent: true)
+
+        surfaceManager.handleSurfaceAction(
+            conversationId: surface.conversationId,
+            surfaceId: surface.id,
+            actionId: "btn-1",
+            data: nil
+        )
+        surfaceManager.dismissFloatingOnly()
+
+        XCTAssertEqual(dispatched.count, 1,
+                       "Escape after an action on a persistent surface must not double-emit")
+        XCTAssertEqual(dispatched.first?.actionId, "btn-1")
+    }
+
+    func testDismissFloatingOnly_nonPersistentSurface_sendsSyntheticDismiss() {
+        let surface = makeCardSurface(id: "surf-esc-single-shot")
+        surfaceManager.registerForTesting(surface: surface, persistent: false)
+
+        surfaceManager.dismissFloatingOnly()
+
+        XCTAssertEqual(dispatched.count, 1,
+                       "Escape on a non-persistent surface with no prior action must emit dismiss")
+        XCTAssertEqual(dispatched.first?.actionId, "dismiss")
+    }
+
+    func testDismissFloatingOnly_nonPersistentSurfaceAfterAction_suppressed() {
+        let surface = makeCardSurface(id: "surf-esc-single-shot-race")
+        surfaceManager.registerForTesting(surface: surface, persistent: false)
+
+        surfaceManager.handleSurfaceAction(
+            conversationId: surface.conversationId,
+            surfaceId: surface.id,
+            actionId: "btn-1",
+            data: nil
+        )
+        surfaceManager.dismissFloatingOnly()
+
+        XCTAssertEqual(dispatched.count, 1,
+                       "Escape after an action on a non-persistent surface must not double-emit")
+        XCTAssertEqual(dispatched.first?.actionId, "btn-1")
+    }
+
     // MARK: - Non-persistent regression
 
     func testNonPersistentSurface_unchanged() {


### PR DESCRIPTION
Addresses Devin follow-up feedback on #25298: the global Escape handler at AppDelegate+InputMonitors.swift:765 calls dismissFloatingOnly(), which routed directly to dismissSurfaceById and skipped the new handleSurfaceDismiss. Same stale-pending-surface bug the PR fixed for the close-button path, but via Escape.

Route the Escape dismiss through handleSurfaceDismiss so the daemon gets the synthetic 'dismiss' action in the same scenarios. Preserves the PR's behavior matrix (persistent vs. non-persistent, action-then-dismiss suppression).

Addresses feedback on https://github.com/vellum-ai/vellum-assistant/pull/25298.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25313" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
