### PR TITLE
perf(macos): cache queuedMessages per render, hoist animation to parent

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -347,6 +347,7 @@ struct ChatView: View {
     @ViewBuilder
     private func activeConversationContent(containerWidth: CGFloat, containerHeight: CGFloat = 0) -> some View {
         let layoutMetrics = MessageListLayoutMetrics(containerWidth: containerWidth)
+        let queuedMessages = viewModel.queuedMessages
         VStack(spacing: 0) {
             MessageListView(
                 // -- TranscriptProjector inputs --
@@ -436,14 +437,13 @@ struct ChatView: View {
                 .padding(.bottom, -VSpacing.sm)
             }
 
-            if !viewModel.queuedMessages.isEmpty {
+            if !queuedMessages.isEmpty {
                 QueuedMessagesDrawer(
                     viewModel: viewModel,
                     composerText: $viewModel.inputText,
                     composerAttachments: $viewModel.pendingAttachments
                 )
                 .transition(.move(edge: .bottom).combined(with: .opacity))
-                .animation(.spring(duration: 0.28, bounce: 0.15), value: viewModel.queuedMessages.count)
             }
 
             if isReadonly {
@@ -500,6 +500,7 @@ struct ChatView: View {
                 }
             }
         }
+        .animation(.spring(duration: 0.28, bounce: 0.15), value: queuedMessages.isEmpty)
     }
 
     private func toggleConversationHostAccess() {


### PR DESCRIPTION
Addresses Codex P2 + Devin review feedback on #25301:

- Cache viewModel.queuedMessages (or use the cached pendingQueuedCount) in ChatView.body so each body evaluation doesn't re-run the O(n log n) filter+sort on the full messages array during streaming.
- Hoist the .animation() modifier from the conditional QueuedMessagesDrawer view to the enclosing VStack so the .transition() actually fires on insert/remove. Matches the existing in-file patterns for the search bar (ChatView.swift:212-215) and btwOverlay (ChatView.swift:174/618).

Addresses feedback on https://github.com/vellum-ai/vellum-assistant/pull/25301.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25315" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
