### PR TITLE
feat(macos): replace inline queued user bubbles with a single queue marker

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
@@ -131,6 +131,97 @@ struct MessageListContentView: View, Equatable {
         .transition(.opacity)
     }
 
+    // MARK: - Transcript row rendering
+
+    /// Renders a single transcript row (either a real message cell or the
+    /// synthetic thinking placeholder) with the `active turn` minHeight
+    /// wrapper applied when the row is the latest assistant and also the
+    /// tail of `state.rows` (so the user's last message sits at the top
+    /// of the viewport while the assistant streams).
+    @ViewBuilder
+    private func transcriptRow(
+        row: TranscriptRowModel,
+        isUnanchoredThinking: Bool,
+        thinkingLabel: String,
+        turnMinHeight: CGFloat
+    ) -> some View {
+        Group {
+            if row.isThinkingPlaceholder {
+                VStack(alignment: .leading, spacing: VSpacing.md) {
+                    if isCompacting {
+                        compactingIndicatorRow()
+                    } else {
+                        thinkingIndicatorRow(hasUserMessage: state.hasUserMessage)
+                    }
+                    thinkingAvatarRow
+                }
+            } else {
+                // Only pass activePendingRequestId to cells that could use it:
+                // confirmation bubbles need it for keyboard focus, tool-call messages
+                // need it for inline confirmation rendering in AssistantProgressView.
+                // Text-only cells get nil, so they won't fail == when the ID changes.
+                let cellActivePendingRequestId: String? =
+                    (row.message.confirmation != nil || !row.message.toolCalls.isEmpty)
+                    ? state.activePendingRequestId : nil
+                MessageCellView(
+                    message: row.message,
+                    showTimestamp: row.showTimestamp,
+                    nextDecidedConfirmation: row.decidedConfirmation,
+                    isConfirmationRenderedInline: row.isConfirmationRenderedInline,
+                    hasPrecedingAssistant: row.hasPrecedingAssistant,
+                    activePendingRequestId: cellActivePendingRequestId,
+                    subagentsByParent: state.subagentsByParent,
+                    isLatestAssistantMessage: row.isLatestAssistant,
+                    typographyGeneration: typographyGeneration,
+                    isProcessingAfterTools: state.canInlineProcessing && row.isLatestAssistant,
+                    processingStatusText: state.canInlineProcessing && row.isLatestAssistant ? state.effectiveStatusText : nil,
+                    hideInlineAvatar: row.isLatestAssistant && isUnanchoredThinking,
+                    showAnchoredThinkingIndicator: row.isAnchoredThinkingRow,
+                    anchoredThinkingLabel: row.isAnchoredThinkingRow ? thinkingLabel : "",
+                    dismissedDocumentSurfaceIds: dismissedDocumentSurfaceIds,
+                    activeSurfaceId: activeSurfaceId,
+                    isHighlighted: row.isHighlighted,
+                    mediaEmbedSettings: mediaEmbedSettings,
+                    onConfirmationAllow: onConfirmationAllow,
+                    onConfirmationDeny: onConfirmationDeny,
+                    onAlwaysAllow: onAlwaysAllow,
+                    onTemporaryAllow: onTemporaryAllow,
+                    onGuardianAction: onGuardianAction,
+                    onSurfaceAction: onSurfaceAction,
+                    onDismissDocumentWidget: onDismissDocumentWidget,
+                    onForkFromMessage: onForkFromMessage,
+                    showInspectButton: showInspectButton,
+                    isTTSEnabled: isTTSEnabled,
+                    onInspectMessage: onInspectMessage,
+                    onRehydrateMessage: onRehydrateMessage,
+                    onSurfaceRefetch: onSurfaceRefetch,
+                    onRetryFailedMessage: onRetryFailedMessage,
+                    onRetryConversationError: onRetryConversationError,
+                    onAbortSubagent: onAbortSubagent,
+                    onSubagentTap: onSubagentTap,
+                    subagentDetailStore: subagentDetailStore,
+                    selectedModel: selectedModel,
+                    configuredProviders: configuredProviders,
+                    providerCatalog: providerCatalog,
+                    providerCatalogHash: providerCatalogHash
+                )
+                .equatable()
+            }
+        }
+        // Latest assistant message (or thinking placeholder): wrap in
+        // VStack with minHeight so user message sits at top. The same
+        // wrapper applies to both the placeholder and the real assistant
+        // message, eliminating layout jump on transition.
+        .if(row.isLatestAssistant && row.message.id == state.rows.last?.message.id) { view in
+            VStack(spacing: 0) {
+                view
+                Color.clear.frame(height: 1)
+                    .id("active-turn-content-bottom")
+            }
+            .frame(minHeight: turnMinHeight, alignment: .top)
+        }
+    }
+
     @ViewBuilder
     private var thinkingAvatarRow: some View {
         let appearance = AvatarAppearanceManager.shared
@@ -211,81 +302,31 @@ struct MessageListContentView: View, Equatable {
             let thinkingLabel = !hasEverSentMessage && state.hasUserMessage
                 ? "Waking up..."
                 : (state.effectiveStatusText ?? "Thinking")
-            ForEach(state.rows) { row in
-                Group {
-                    if row.isThinkingPlaceholder {
-                        VStack(alignment: .leading, spacing: VSpacing.md) {
-                            if isCompacting {
-                                compactingIndicatorRow()
-                            } else {
-                                thinkingIndicatorRow(hasUserMessage: state.hasUserMessage)
-                            }
-                            thinkingAvatarRow
-                        }
-                    } else {
-                        // Only pass activePendingRequestId to cells that could use it:
-                        // confirmation bubbles need it for keyboard focus, tool-call messages
-                        // need it for inline confirmation rendering in AssistantProgressView.
-                        // Text-only cells get nil, so they won't fail == when the ID changes.
-                        let cellActivePendingRequestId: String? =
-                            (row.message.confirmation != nil || !row.message.toolCalls.isEmpty)
-                            ? state.activePendingRequestId : nil
-                        MessageCellView(
-                            message: row.message,
-                            showTimestamp: row.showTimestamp,
-                            nextDecidedConfirmation: row.decidedConfirmation,
-                            isConfirmationRenderedInline: row.isConfirmationRenderedInline,
-                            hasPrecedingAssistant: row.hasPrecedingAssistant,
-                            activePendingRequestId: cellActivePendingRequestId,
-                            subagentsByParent: state.subagentsByParent,
-                            isLatestAssistantMessage: row.isLatestAssistant,
-                            typographyGeneration: typographyGeneration,
-                            isProcessingAfterTools: state.canInlineProcessing && row.isLatestAssistant,
-                            processingStatusText: state.canInlineProcessing && row.isLatestAssistant ? state.effectiveStatusText : nil,
-                            hideInlineAvatar: row.isLatestAssistant && isUnanchoredThinking,
-                            showAnchoredThinkingIndicator: row.isAnchoredThinkingRow,
-                            anchoredThinkingLabel: row.isAnchoredThinkingRow ? thinkingLabel : "",
-                            dismissedDocumentSurfaceIds: dismissedDocumentSurfaceIds,
-                            activeSurfaceId: activeSurfaceId,
-                            isHighlighted: row.isHighlighted,
-                            mediaEmbedSettings: mediaEmbedSettings,
-                            onConfirmationAllow: onConfirmationAllow,
-                            onConfirmationDeny: onConfirmationDeny,
-                            onAlwaysAllow: onAlwaysAllow,
-                            onTemporaryAllow: onTemporaryAllow,
-                            onGuardianAction: onGuardianAction,
-                            onSurfaceAction: onSurfaceAction,
-                            onDismissDocumentWidget: onDismissDocumentWidget,
-                            onForkFromMessage: onForkFromMessage,
-                            showInspectButton: showInspectButton,
-                            isTTSEnabled: isTTSEnabled,
-                            onInspectMessage: onInspectMessage,
-                            onRehydrateMessage: onRehydrateMessage,
-                            onSurfaceRefetch: onSurfaceRefetch,
-                            onRetryFailedMessage: onRetryFailedMessage,
-                            onRetryConversationError: onRetryConversationError,
-                            onAbortSubagent: onAbortSubagent,
-                            onSubagentTap: onSubagentTap,
-                            subagentDetailStore: subagentDetailStore,
-                            selectedModel: selectedModel,
-                            configuredProviders: configuredProviders,
-                            providerCatalog: providerCatalog,
-                            providerCatalogHash: providerCatalogHash
+            // Collapse consecutive inline queued user bubbles into a single
+            // marker. The queued messages are still managed in the drawer
+            // (`QueuedMessagesDrawer`) — rendering them inline here duplicates
+            // the information and clutters the transcript when many follow-ups
+            // are queued. The pure helper `TranscriptItems.build(from:)` is
+            // shared in `clients/shared/Features/Chat/TranscriptItems.swift`.
+            let rowsByMessageId: [UUID: TranscriptRowModel] = Dictionary(
+                uniqueKeysWithValues: state.rows.map { ($0.message.id, $0) }
+            )
+            let displayedItems = TranscriptItems.build(from: state.rows.map(\.message))
+            ForEach(displayedItems) { item in
+                switch item {
+                case .queuedMarker(let count, _):
+                    QueuedMessagesMarker(count: count)
+                case .message(let message):
+                    // Safe: every displayed message originates from `state.rows`
+                    // so `rowsByMessageId[message.id]` is always present.
+                    if let row = rowsByMessageId[message.id] {
+                        transcriptRow(
+                            row: row,
+                            isUnanchoredThinking: isUnanchoredThinking,
+                            thinkingLabel: thinkingLabel,
+                            turnMinHeight: turnMinHeight
                         )
-                        .equatable()
                     }
-                }
-                // Latest assistant message (or thinking placeholder): wrap in
-                // VStack with minHeight so user message sits at top. The same
-                // wrapper applies to both the placeholder and the real assistant
-                // message, eliminating layout jump on transition.
-                .if(row.isLatestAssistant && row.message.id == state.rows.last?.message.id) { view in
-                    VStack(spacing: 0) {
-                        view
-                        Color.clear.frame(height: 1)
-                            .id("active-turn-content-bottom")
-                    }
-                    .frame(minHeight: turnMinHeight, alignment: .top)
                 }
             }
 

--- a/clients/macos/vellum-assistant/Features/Chat/QueuedMessagesMarker.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/QueuedMessagesMarker.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+import VellumAssistantShared
+
+// MARK: - Queued Messages Marker
+
+/// Inline transcript marker that stands in for one or more collapsed queued
+/// user messages. Rendered in place of the individual queued bubbles —
+/// the queued messages themselves are still listed in the queue drawer
+/// (see `QueuedMessagesDrawer`), so showing them inline duplicates the
+/// information and clutters the transcript when many follow-ups are queued.
+struct QueuedMessagesMarker: View {
+    let count: Int
+
+    var body: some View {
+        HStack {
+            Spacer()
+            Text(label)
+                .font(VFont.labelDefault)
+                .foregroundStyle(VColor.contentSecondary)
+            Spacer()
+        }
+        .padding(EdgeInsets(
+            top: VSpacing.sm,
+            leading: VSpacing.md,
+            bottom: VSpacing.sm,
+            trailing: VSpacing.md
+        ))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(label)
+    }
+
+    private var label: String {
+        let noun = count == 1 ? "message" : "messages"
+        return "\u{2014} \(count) \(noun) queued \u{2014}"
+    }
+}

--- a/clients/macos/vellum-assistantTests/TranscriptItemsTests.swift
+++ b/clients/macos/vellum-assistantTests/TranscriptItemsTests.swift
@@ -1,0 +1,113 @@
+import XCTest
+@testable import VellumAssistantShared
+
+final class TranscriptItemsTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func userMessage(text: String, status: ChatMessageStatus = .sent) -> ChatMessage {
+        ChatMessage(role: .user, text: text, status: status)
+    }
+
+    private func assistantMessage(text: String) -> ChatMessage {
+        ChatMessage(role: .assistant, text: text)
+    }
+
+    // MARK: - Tests
+
+    func test_transcriptItems_collapsesQueuedUserBubblesIntoSingleMarker() {
+        let assistantSent = assistantMessage(text: "hello")
+        let userSent = userMessage(text: "hi", status: .sent)
+        let userQueued1 = userMessage(text: "follow-up 1", status: .queued(position: 1))
+        let userQueued2 = userMessage(text: "follow-up 2", status: .queued(position: 2))
+        let assistantSent2 = assistantMessage(text: "ack")
+        // The plan specifies ordering [assistant-sent, user-sent, user-queued, user-queued, assistant-sent].
+        // In real traffic, the latter assistant couldn't actually arrive after queued messages,
+        // but the helper is pure data — verify the ordering rules hold for arbitrary input.
+        let messages = [assistantSent, userSent, userQueued1, userQueued2, assistantSent2]
+
+        let result = TranscriptItems.build(from: messages)
+
+        XCTAssertEqual(result.count, 4)
+        XCTAssertEqual(result[0], .message(assistantSent))
+        XCTAssertEqual(result[1], .message(userSent))
+        XCTAssertEqual(result[2], .queuedMarker(count: 2, anchorId: userQueued1.id))
+        XCTAssertEqual(result[3], .message(assistantSent2))
+    }
+
+    func test_transcriptItems_noQueuedMessagesYieldsOriginalList() {
+        let messages = [
+            assistantMessage(text: "a"),
+            userMessage(text: "b"),
+            assistantMessage(text: "c"),
+            userMessage(text: "d"),
+        ]
+
+        let result = TranscriptItems.build(from: messages)
+
+        XCTAssertEqual(result.count, messages.count)
+        for (index, message) in messages.enumerated() {
+            XCTAssertEqual(result[index], .message(message))
+        }
+    }
+
+    func test_transcriptItems_queuedMessagesAtEnd_markerAtEnd() {
+        let assistantSent = assistantMessage(text: "hi")
+        let userSent = userMessage(text: "hello", status: .sent)
+        let queued1 = userMessage(text: "q1", status: .queued(position: 1))
+        let queued2 = userMessage(text: "q2", status: .queued(position: 2))
+        let queued3 = userMessage(text: "q3", status: .queued(position: 3))
+        let messages = [assistantSent, userSent, queued1, queued2, queued3]
+
+        let result = TranscriptItems.build(from: messages)
+
+        XCTAssertEqual(result.count, 3)
+        XCTAssertEqual(result[0], .message(assistantSent))
+        XCTAssertEqual(result[1], .message(userSent))
+        XCTAssertEqual(result.last, .queuedMarker(count: 3, anchorId: queued1.id))
+    }
+
+    // MARK: - Identity
+
+    func test_transcriptItem_id_marker_usesAnchorId() {
+        let anchor = UUID()
+        XCTAssertEqual(TranscriptItem.queuedMarker(count: 2, anchorId: anchor).id, anchor)
+    }
+
+    func test_transcriptItem_id_message_usesMessageId() {
+        let message = userMessage(text: "hi")
+        XCTAssertEqual(TranscriptItem.message(message).id, message.id)
+    }
+
+    // MARK: - Edge cases
+
+    func test_transcriptItems_singleQueuedMessage_yieldsMarkerWithCountOne() {
+        let assistantSent = assistantMessage(text: "hi")
+        let queued = userMessage(text: "queued", status: .queued(position: 1))
+        let messages = [assistantSent, queued]
+
+        let result = TranscriptItems.build(from: messages)
+
+        XCTAssertEqual(result.count, 2)
+        XCTAssertEqual(result[0], .message(assistantSent))
+        XCTAssertEqual(result[1], .queuedMarker(count: 1, anchorId: queued.id))
+    }
+
+    func test_transcriptItems_queuedAssistantMessage_isNotCollapsed() {
+        // Assistant messages never carry .queued in practice, but the helper
+        // should only collapse when role == .user AND status is .queued.
+        // This guards against accidentally hiding non-user queued statuses
+        // if the model ever permits them.
+        let queuedAssistant = ChatMessage(role: .assistant, text: "q", status: .queued(position: 1))
+        let messages = [queuedAssistant]
+
+        let result = TranscriptItems.build(from: messages)
+
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result[0], .message(queuedAssistant))
+    }
+
+    func test_transcriptItems_emptyInput_yieldsEmptyOutput() {
+        XCTAssertEqual(TranscriptItems.build(from: []).count, 0)
+    }
+}

--- a/clients/shared/Features/Chat/TranscriptItems.swift
+++ b/clients/shared/Features/Chat/TranscriptItems.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+// MARK: - Transcript Item
+
+/// A single renderable item in the chat transcript after the queued-user-message
+/// collapse has been applied. Consecutive queued user messages are represented
+/// by a single `queuedMarker` placed at the position of the first collapsed
+/// message in the original order.
+///
+/// - `message`: a regular chat message that should be rendered as a bubble.
+/// - `queuedMarker`: a collapsed placeholder standing in for one or more
+///   queued user messages. The `anchorId` is the id of the first collapsed
+///   queued message so the marker has a stable identity across re-projections
+///   (used by SwiftUI `ForEach` / animation diffing).
+public enum TranscriptItem: Equatable, Identifiable {
+    case message(ChatMessage)
+    case queuedMarker(count: Int, anchorId: UUID)
+
+    public var id: UUID {
+        switch self {
+        case .message(let message):
+            return message.id
+        case .queuedMarker(_, let anchorId):
+            return anchorId
+        }
+    }
+}
+
+// MARK: - Transcript Items Builder
+
+/// Pure helper that collapses inline queued user messages into a single marker
+/// item. Cross-platform — the individual queued messages are still rendered
+/// in the queue drawer (PR 5), so showing them as inline bubbles duplicates
+/// the information and makes the transcript hard to read when many
+/// follow-ups are queued.
+///
+/// The first queued user message (in iteration order) is replaced with a
+/// `queuedMarker` whose `count` equals the total number of collapsed queued
+/// user messages. All other queued user messages are omitted from the output.
+/// Non-queued messages (and assistant messages in general) pass through
+/// unchanged.
+public enum TranscriptItems {
+
+    /// Builds the ordered list of transcript items to display.
+    ///
+    /// - Parameter messages: The source list of chat messages in display order.
+    /// - Returns: A list where consecutive-or-scattered queued user messages
+    ///   have been replaced with a single `queuedMarker` placed at the position
+    ///   of the first collapsed message.
+    public static func build(from messages: [ChatMessage]) -> [TranscriptItem] {
+        let queuedCount = messages.reduce(into: 0) { count, message in
+            if message.role == .user, case .queued = message.status {
+                count += 1
+            }
+        }
+        guard queuedCount > 0 else {
+            return messages.map { .message($0) }
+        }
+
+        var result: [TranscriptItem] = []
+        result.reserveCapacity(messages.count - queuedCount + 1)
+        var markerInserted = false
+        for message in messages {
+            let isQueuedUser: Bool = {
+                guard message.role == .user else { return false }
+                if case .queued = message.status { return true }
+                return false
+            }()
+            if isQueuedUser {
+                if !markerInserted {
+                    result.append(.queuedMarker(count: queuedCount, anchorId: message.id))
+                    markerInserted = true
+                }
+                // Otherwise: collapse into the already-inserted marker.
+            } else {
+                result.append(.message(message))
+            }
+        }
+        return result
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `QueuedMessagesMarker` view and a pure, cross-platform helper (`TranscriptItems.build(from:)`) in `clients/shared/Features/Chat/TranscriptItems.swift`.
- Collapses multiple inline queued user bubbles into a single "— N messages queued —" marker.
- Queued message management happens in the drawer (from PR 5); this PR just deduplicates the transcript.

The helper is placed in `clients/shared` (not macOS-local) so PR 8 (iOS) can reuse the same `TranscriptItem` enum and builder without code duplication — iOS's `ChatContentView` iterates `visibleMessages` directly and can swap in `ForEach(TranscriptItems.build(from: messages))` + a switch on case.

Part of plan: queue-drawer-edit-cancel.md (PR 7 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25316" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
