### PR TITLE
feat(ios): replace inline queued user bubbles with a single queue marker

### DIFF
--- a/clients/ios/Tests/TranscriptItemsIOSTests.swift
+++ b/clients/ios/Tests/TranscriptItemsIOSTests.swift
@@ -1,0 +1,73 @@
+import XCTest
+@testable import VellumAssistantShared
+
+/// iOS-side verification of the shared `TranscriptItems.build(from:)` helper
+/// used by `ChatContentView` to collapse inline queued user bubbles into a
+/// single marker. The shared helper is already tested on macOS
+/// (`clients/macos/vellum-assistantTests/TranscriptItemsTests.swift`) — these
+/// cases ensure the import resolves and guard against platform-specific
+/// regressions (e.g. a future refactor that accidentally diverges the iOS
+/// transcript projection).
+final class TranscriptItemsIOSTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func userMessage(text: String, status: ChatMessageStatus = .sent) -> ChatMessage {
+        ChatMessage(role: .user, text: text, status: status)
+    }
+
+    private func assistantMessage(text: String) -> ChatMessage {
+        ChatMessage(role: .assistant, text: text)
+    }
+
+    // MARK: - Tests
+
+    func test_transcriptItems_collapsesQueuedUserBubblesIntoSingleMarker() {
+        let assistantSent = assistantMessage(text: "hello")
+        let userSent = userMessage(text: "hi", status: .sent)
+        let userQueued1 = userMessage(text: "follow-up 1", status: .queued(position: 1))
+        let userQueued2 = userMessage(text: "follow-up 2", status: .queued(position: 2))
+        let assistantSent2 = assistantMessage(text: "ack")
+        let messages = [assistantSent, userSent, userQueued1, userQueued2, assistantSent2]
+
+        let result = TranscriptItems.build(from: messages)
+
+        XCTAssertEqual(result.count, 4)
+        XCTAssertEqual(result[0], .message(assistantSent))
+        XCTAssertEqual(result[1], .message(userSent))
+        XCTAssertEqual(result[2], .queuedMarker(count: 2, anchorId: userQueued1.id))
+        XCTAssertEqual(result[3], .message(assistantSent2))
+    }
+
+    func test_transcriptItems_noQueuedMessagesYieldsOriginalList() {
+        let messages = [
+            assistantMessage(text: "a"),
+            userMessage(text: "b"),
+            assistantMessage(text: "c"),
+            userMessage(text: "d"),
+        ]
+
+        let result = TranscriptItems.build(from: messages)
+
+        XCTAssertEqual(result.count, messages.count)
+        for (index, message) in messages.enumerated() {
+            XCTAssertEqual(result[index], .message(message))
+        }
+    }
+
+    func test_transcriptItems_queuedMessagesAtEnd_markerAtEnd() {
+        let assistantSent = assistantMessage(text: "hi")
+        let userSent = userMessage(text: "hello", status: .sent)
+        let queued1 = userMessage(text: "q1", status: .queued(position: 1))
+        let queued2 = userMessage(text: "q2", status: .queued(position: 2))
+        let queued3 = userMessage(text: "q3", status: .queued(position: 3))
+        let messages = [assistantSent, userSent, queued1, queued2, queued3]
+
+        let result = TranscriptItems.build(from: messages)
+
+        XCTAssertEqual(result.count, 3)
+        XCTAssertEqual(result[0], .message(assistantSent))
+        XCTAssertEqual(result[1], .message(userSent))
+        XCTAssertEqual(result.last, .queuedMarker(count: 3, anchorId: queued1.id))
+    }
+}

--- a/clients/ios/Views/ChatContentView.swift
+++ b/clients/ios/Views/ChatContentView.swift
@@ -192,16 +192,24 @@ struct ChatContentView: View {
                 LazyVStack(spacing: VSpacing.md) {
                     paginationHeader(proxy: proxy)
 
+                    // Collapse consecutive inline queued user bubbles into a
+                    // single marker. The queued messages are still managed in
+                    // the drawer (`QueuedMessagesDrawer_iOS`) — rendering them
+                    // inline here duplicates the information and clutters the
+                    // transcript when many follow-ups are queued. The pure
+                    // helper `TranscriptItems.build(from:)` is shared in
+                    // `clients/shared/Features/Chat/TranscriptItems.swift`.
                     let messages = visibleMessages
-                    ForEach(Array(messages.enumerated()), id: \.element.id) { index, message in
-                        messageBubble(message: message, index: index, messages: messages)
-
-                        // Subagent chips anchored to the message that spawned them
-                        ForEach(viewModel.activeSubagents.filter { $0.parentMessageId == message.id }) { subagent in
-                            SubagentStatusChip(subagent: subagent)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                                .id("subagent-\(subagent.id)")
-                        }
+                    let indexByMessageId: [UUID: Int] = Dictionary(
+                        uniqueKeysWithValues: messages.enumerated().map { ($0.element.id, $0.offset) }
+                    )
+                    let transcriptItems = TranscriptItems.build(from: messages)
+                    ForEach(transcriptItems) { item in
+                        transcriptRowContent(
+                            item: item,
+                            messages: messages,
+                            indexByMessageId: indexByMessageId
+                        )
                     }
 
                     // Subagents with no parent message (e.g. from history load)
@@ -394,6 +402,36 @@ struct ChatContentView: View {
                         }
                     }
                 }
+        }
+    }
+
+    // MARK: - Transcript Row
+
+    /// Renders a single item from the collapsed transcript. Either the queue
+    /// marker (in place of one or more inline queued user bubbles) or a normal
+    /// message bubble plus any subagent chips anchored to it.
+    @ViewBuilder
+    private func transcriptRowContent(
+        item: TranscriptItem,
+        messages: [ChatMessage],
+        indexByMessageId: [UUID: Int]
+    ) -> some View {
+        switch item {
+        case .queuedMarker(let count, let anchorId):
+            QueuedMessagesMarker_iOS(count: count)
+                .id(anchorId)
+        case .message(let message):
+            // Safe: every `.message` in the collapsed transcript originates
+            // from `messages`, so the index lookup is always present.
+            let index = indexByMessageId[message.id] ?? 0
+            messageBubble(message: message, index: index, messages: messages)
+
+            // Subagent chips anchored to the message that spawned them
+            ForEach(viewModel.activeSubagents.filter { $0.parentMessageId == message.id }) { subagent in
+                SubagentStatusChip(subagent: subagent)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .id("subagent-\(subagent.id)")
+            }
         }
     }
 

--- a/clients/ios/Views/QueuedMessagesMarker_iOS.swift
+++ b/clients/ios/Views/QueuedMessagesMarker_iOS.swift
@@ -1,0 +1,42 @@
+#if canImport(UIKit)
+import SwiftUI
+import VellumAssistantShared
+
+// MARK: - Queued Messages Marker (iOS)
+
+/// Inline transcript marker that stands in for one or more collapsed queued
+/// user messages. Rendered in place of the individual queued bubbles —
+/// the queued messages themselves are still listed in the queue drawer
+/// (see `QueuedMessagesDrawer_iOS`), so showing them inline duplicates the
+/// information and clutters the transcript when many follow-ups are queued.
+///
+/// Mirrors the macOS `QueuedMessagesMarker` visually (centered caption, same
+/// tokens). Touch behavior is not applicable — the drawer owns cancel/edit
+/// affordances for individual queued messages.
+struct QueuedMessagesMarker_iOS: View {
+    let count: Int
+
+    var body: some View {
+        HStack {
+            Spacer()
+            Text(label)
+                .font(VFont.labelDefault)
+                .foregroundStyle(VColor.contentSecondary)
+            Spacer()
+        }
+        .padding(EdgeInsets(
+            top: VSpacing.sm,
+            leading: VSpacing.md,
+            bottom: VSpacing.sm,
+            trailing: VSpacing.md
+        ))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(label)
+    }
+
+    private var label: String {
+        let noun = count == 1 ? "message" : "messages"
+        return "\u{2014} \(count) \(noun) queued \u{2014}"
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- Adds `QueuedMessagesMarker_iOS` view
- Uses shared `TranscriptItems.build(from:)` helper (from PR 7) to collapse queued user bubbles into a single marker in the iOS transcript
- Queue management continues to happen via the drawer (PR 6)
- Scroll/pagination behavior unchanged

Part of plan: queue-drawer-edit-cancel.md (PR 8 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25319" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
