### PR TITLE
fix(drain): correctness fixes for batched queued-message drain

### DIFF
--- a/assistant/src/__tests__/conversation-queue.test.ts
+++ b/assistant/src/__tests__/conversation-queue.test.ts
@@ -112,6 +112,13 @@ const capturedAddMessages: Array<{
   metadata?: Record<string, unknown>;
 }> = [];
 
+/**
+ * Content substrings that should cause `addMessage` to throw — used to
+ * simulate a mid-batch persist failure (e.g. a DB error on a specific
+ * tail message while its siblings succeed).
+ */
+const addMessageShouldThrowForContent = new Set<string>();
+
 mock.module("../prompts/system-prompt.js", () => ({
   buildSystemPrompt: () => "system prompt",
 }));
@@ -173,6 +180,14 @@ mock.module("../memory/conversation-crud.js", () => ({
     content: string,
     metadata?: Record<string, unknown>,
   ) => {
+    // Simulate a persist failure for tests that need to exercise the
+    // tail-persist-failed path in drainBatch. Triggered by matching any
+    // registered substring against the serialized content payload.
+    for (const needle of addMessageShouldThrowForContent) {
+      if (content.includes(needle)) {
+        throw new Error(`Simulated addMessage failure for content: ${needle}`);
+      }
+    }
     const id = `msg-${Date.now()}-${capturedAddMessages.length}`;
     capturedAddMessages.push({ id, role, content, metadata });
     return { id };
@@ -473,6 +488,7 @@ beforeEach(() => {
   turnCommitCalls.length = 0;
   turnCommitHangForever = false;
   linkAttachmentShouldThrow = false;
+  addMessageShouldThrowForContent.clear();
 });
 
 afterAll(() => {
@@ -1140,6 +1156,273 @@ describe("Batched drain", () => {
     resolveRun(3);
     await new Promise((r) => setTimeout(r, 10));
   });
+});
+
+// ---------------------------------------------------------------------------
+// Batched drain — correctness fixes (surface exclusion, abort, last-successful
+// tracking, single activity-state emission)
+// ---------------------------------------------------------------------------
+
+describe("Batched drain correctness fixes", () => {
+  beforeEach(() => {
+    pendingRuns = [];
+    capturedAddMessages.length = 0;
+  });
+
+  test("surface-action messages are not batched with regular passthroughs", async () => {
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
+
+    const eventsSurface: ServerMessage[] = [];
+    const eventsRegular: ServerMessage[] = [];
+
+    // Start in-flight message
+    const p1 = conversation.processMessage("msg-1", [], () => {}, "req-1");
+    await waitForPendingRun(1);
+
+    // Enqueue a surface-action message (activeSurfaceId set + tracked in
+    // surfaceActionRequestIds) followed by a regular passthrough from the
+    // same interface. The batch builder must reject the surface-action head
+    // so each drains as its own run.
+    conversation.surfaceActionRequestIds.add("req-surface");
+    conversation.enqueueMessage(
+      "surface action response",
+      [],
+      (e) => eventsSurface.push(e),
+      "req-surface",
+      "surface-1", // activeSurfaceId
+    );
+    conversation.enqueueMessage(
+      "regular follow-up",
+      [],
+      (e) => eventsRegular.push(e),
+      "req-regular",
+    );
+    expect(conversation.getQueueDepth()).toBe(2);
+
+    // Complete run 0 → drain must NOT batch the surface-action with the
+    // regular passthrough. Expect the surface-action to drain as a single
+    // run first.
+    resolveRun(0);
+    await p1;
+    await waitForPendingRun(2);
+
+    // The second run is the surface-action single-message run.
+    const surfaceUserRowsAfterRun2 = capturedAddMessages.filter(
+      (m) => m.role === "user" && m.content.includes("surface action response"),
+    );
+    expect(surfaceUserRowsAfterRun2).toHaveLength(1);
+    expect(eventsSurface.filter((e) => e.type === "message_dequeued")).toHaveLength(
+      1,
+    );
+
+    // Complete the surface-action run; drain pulls the regular passthrough
+    // as its own separate run.
+    resolveRun(1);
+    await waitForPendingRun(3);
+    expect(pendingRuns.length).toBe(3);
+    expect(eventsRegular.filter((e) => e.type === "message_dequeued")).toHaveLength(
+      1,
+    );
+
+    // Total runs = 3: msg-1, surface-action, regular — NOT 2 (would mean
+    // they were batched).
+    resolveRun(2);
+    await new Promise((r) => setTimeout(r, 10));
+  });
+
+  test("abort mid-batch stops tail persists", async () => {
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
+
+    const events1: ServerMessage[] = [];
+    const events2: ServerMessage[] = [];
+    const events3: ServerMessage[] = [];
+    const events4: ServerMessage[] = [];
+
+    // Start in-flight message
+    const p1 = conversation.processMessage(
+      "msg-1",
+      [],
+      (e) => events1.push(e),
+      "req-1",
+    );
+    await waitForPendingRun(1);
+
+    // Enqueue three sibling passthroughs (msg-2 = head, msg-3 = mid,
+    // msg-4 = tail). We trigger abort from msg-3's dequeue callback —
+    // by the time that fires, msg-2 has already been persisted (which
+    // REPLACED the abortController, since persistUserMessage creates a
+    // fresh one). Calling abort() now aborts that fresh controller, and
+    // the drainBatch loop's abort check after msg-3's persist will break,
+    // so msg-4 never persists.
+    conversation.enqueueMessage("msg-2", [], (e) => events2.push(e), "req-2");
+
+    // Install a one-shot abort trigger on msg-3's dequeue event. We do
+    // this before enqueueing so the wrapped callback is what drainBatch
+    // invokes.
+    let aborted = false;
+    const onMsg3Event = (e: ServerMessage) => {
+      events3.push(e);
+      if (!aborted && e.type === "message_dequeued") {
+        aborted = true;
+        conversation.abort();
+      }
+    };
+    conversation.enqueueMessage("msg-3", [], onMsg3Event, "req-3");
+    conversation.enqueueMessage("msg-4", [], (e) => events4.push(e), "req-4");
+    expect(conversation.getQueueDepth()).toBe(3);
+
+    const persistedUserRowCountBefore = capturedAddMessages.filter(
+      (m) => m.role === "user",
+    ).length;
+
+    // Complete run 0 → drain pulls the sibling batch.
+    resolveRun(0);
+    await p1;
+
+    // Give the drain loop a chance to iterate. Abort happens on msg-3's
+    // dequeue (between msg-2's persist and msg-3's persist), so msg-3 may
+    // still persist before the abort check at the end of its iteration.
+    // Either way, msg-4 must NOT persist.
+    await new Promise((r) => setTimeout(r, 30));
+
+    const userRowsAfter = capturedAddMessages
+      .slice(persistedUserRowCountBefore)
+      .filter((m) => m.role === "user");
+    const contents = userRowsAfter.map((r) => r.content).join("||");
+    expect(contents).toContain("msg-2");
+    expect(contents).not.toContain("msg-4");
+    expect(
+      events4.filter((e) => e.type === "message_dequeued"),
+    ).toHaveLength(0);
+  });
+
+  test("failed tail persist uses last-successful requestId", async () => {
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
+
+    const events1: ServerMessage[] = [];
+    const events2: ServerMessage[] = [];
+    const events3: ServerMessage[] = [];
+    const events4: ServerMessage[] = [];
+
+    // Start in-flight message
+    const p1 = conversation.processMessage(
+      "msg-1",
+      [],
+      (e) => events1.push(e),
+      "req-1",
+    );
+    await waitForPendingRun(1);
+
+    // Enqueue three siblings. Configure addMessage to throw for the second
+    // tail (msg-mid) but succeed for msg-head and msg-tail. This simulates
+    // a middle tail persist failure — currentRequestId should end up as
+    // msg-tail's requestId (the LAST successful persist), not msg-mid's.
+    addMessageShouldThrowForContent.add("msg-mid-unique-marker");
+
+    conversation.enqueueMessage(
+      "msg-head",
+      [],
+      (e) => events2.push(e),
+      "req-head",
+    );
+    conversation.enqueueMessage(
+      "msg-mid-unique-marker",
+      [],
+      (e) => events3.push(e),
+      "req-mid",
+    );
+    conversation.enqueueMessage(
+      "msg-tail",
+      [],
+      (e) => events4.push(e),
+      "req-tail",
+    );
+    expect(conversation.getQueueDepth()).toBe(3);
+
+    // Complete run 0 → batched drain.
+    resolveRun(0);
+    await p1;
+    await waitForPendingRun(2);
+
+    // mid should have emitted an error event via persist failure.
+    const errMid = events3.find((e) => e.type === "error");
+    expect(errMid).toBeDefined();
+
+    // The agent loop should have been invoked with the tail's userMessageId
+    // (last SUCCESSFUL persist), not the mid's. We check via currentRequestId
+    // on the conversation which drainBatch assigns after the loop.
+    expect(
+      (conversation as unknown as { currentRequestId?: string }).currentRequestId,
+    ).toBe("req-tail");
+
+    // Cleanup: resolve the batched run.
+    resolveRun(1);
+    await new Promise((r) => setTimeout(r, 20));
+  });
+
+  test("drainBatch emits exactly one activity-state event for the whole batch", async () => {
+    const activityStates: ServerMessage[] = [];
+    const conversation = makeConversation((msg) => {
+      if ("type" in msg && msg.type === "assistant_activity_state") {
+        activityStates.push(msg);
+      }
+    });
+    await conversation.loadFromDb();
+
+    // Start in-flight message
+    const p1 = conversation.processMessage("msg-1", [], () => {}, "req-1");
+    await waitForPendingRun(1);
+
+    // Snapshot the count before drain so we only compare batch-emitted
+    // transitions (msg-1's processMessage already fired one).
+    const baseline = activityStates.length;
+
+    // Enqueue three sibling passthroughs.
+    conversation.enqueueMessage("msg-2", [], () => {}, "req-2");
+    conversation.enqueueMessage("msg-3", [], () => {}, "req-3");
+    conversation.enqueueMessage("msg-4", [], () => {}, "req-4");
+
+    // Complete run 0 → drain pulls the batched siblings as ONE run.
+    resolveRun(0);
+    await p1;
+    await waitForPendingRun(2);
+
+    // Filter for "message_dequeued" reasons emitted by the batched drain.
+    const batchEmissions = activityStates
+      .slice(baseline)
+      .filter(
+        (m) =>
+          "type" in m &&
+          m.type === "assistant_activity_state" &&
+          (m as { reason?: string }).reason === "message_dequeued",
+      );
+    expect(batchEmissions).toHaveLength(1);
+    expect(batchEmissions[0]).toMatchObject({
+      type: "assistant_activity_state",
+      reason: "message_dequeued",
+      requestId: "req-2", // head's requestId, per the fix
+    });
+
+    resolveRun(1);
+    await new Promise((r) => setTimeout(r, 10));
+  });
+
+  // Defensive recovery path: buildPassthroughBatch is designed to make
+  // the invariant throw unreachable in practice. Left as a todo so the
+  // harness contract is documented without wedging mainline CI. Covering
+  // this would require either (a) reflecting into drainBatch to short-
+  // circuit resolveSlash for a specific batch entry, or (b) exposing a
+  // seam on SlashContext — both are more invasive than the safety-net
+  // value justifies.
+  test.todo(
+    "invariant violation in persist loop triggers error event + recovery, not stranded state",
+    async () => {
+      // no-op: see comment above.
+    },
+  );
 });
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -97,6 +97,12 @@ export interface ProcessConversationContext {
   currentRequestId?: string;
   readonly queue: MessageQueue;
   readonly traceEmitter: TraceEmitter;
+  /**
+   * Set of requestIds created by surface-action responses. Used to
+   * distinguish surface-action turns from regular user turns (e.g. for
+   * stale-surface auto-dismiss guards and batched-drain exclusion).
+   */
+  readonly surfaceActionRequestIds: Set<string>;
   currentActiveSurfaceId?: string;
   currentPage?: string;
   /** Cumulative token usage stats for the conversation. */
@@ -290,6 +296,16 @@ async function buildPassthroughBatch(
     // skill preactivation isn't leaked into batched tail messages.
     return [];
   }
+  // Surface-action messages rely on per-message `activeSurfaceId` and
+  // `surfaceActionRequestIds` semantics that last-wins batching would
+  // corrupt (e.g. erasing the head's surface context when the last tail is
+  // a regular text message). Keep them on the single-message path.
+  if (
+    head.activeSurfaceId !== undefined ||
+    conversation.surfaceActionRequestIds.has(head.requestId)
+  ) {
+    return [];
+  }
 
   let i = 1;
   for (;;) {
@@ -314,6 +330,14 @@ async function buildPassthroughBatch(
       "direct_setup"
     )
       break;
+    // Stop at the first surface-action tail; it will drain via the single-
+    // message path so its per-message surface context is preserved.
+    if (
+      candidate.activeSurfaceId !== undefined ||
+      conversation.surfaceActionRequestIds.has(candidate.requestId)
+    ) {
+      break;
+    }
     i++;
   }
 
@@ -942,9 +966,27 @@ async function drainBatch(
   conversation.currentTurnChannelCapabilities =
     conversation.channelCapabilities;
 
-  // Per-message dequeue events and persistence loop.
-  let lastUserMessageId = "";
-  let lastResolvedContent = "";
+  // Single activity-state transition for the batched turn. Per-message
+  // emissions would publish N "thinking" phase transitions to every
+  // connected SSE client (via activityVersion increments), whipsawing the
+  // client-side thinking indicator. The single-message path emits exactly
+  // one such event per turn; match it here.
+  conversation.emitActivityState(
+    "thinking",
+    "message_dequeued",
+    "assistant_turn",
+    head.requestId,
+  );
+
+  // Per-message dequeue events and persistence loop. Track the last
+  // SUCCESSFUL persist separately from the batch tail — a failed tail
+  // must not corrupt the requestId/surface context that `runAgentLoop`
+  // will tag `message_complete` / `generation_cancelled` with.
+  let lastSuccessfulRequestId: string | undefined;
+  let lastSuccessfulActiveSurfaceId: string | undefined;
+  let lastSuccessfulCurrentPage: string | undefined;
+  let lastSuccessfulContent: string | undefined;
+  let lastUserMessageId: string | undefined;
   for (let i = 0; i < batch.length; i++) {
     const qm = batch[i];
     qm.onEvent({
@@ -961,21 +1003,54 @@ async function drainBatch(
         attributes: { reason, batchIndex: i, batchSize: batch.length },
       },
     );
-    conversation.emitActivityState(
-      "thinking",
-      "message_dequeued",
-      "assistant_turn",
-      qm.requestId,
-    );
 
     const qmSlash = await resolveSlash(
       qm.content,
       buildSlashContext(conversation),
     );
     if (qmSlash.kind !== "passthrough") {
-      throw new Error(
-        "batch contained non-passthrough message — buildPassthroughBatch invariant violated",
+      // Defensive recovery. `buildPassthroughBatch` should make this
+      // unreachable, but a synchronous throw here would strand
+      // `conversation.processing = true` (head already persisted) with no
+      // `runAgentLoop` ever called to clear it. Log, emit an error to
+      // the affected client, and either recover-and-drain (head case) or
+      // skip the tail (tail case) so the rest of the batch still runs.
+      const invariantMessage =
+        "Internal error: batch drain invariant violated (non-passthrough message in batch)";
+      log.error(
+        {
+          conversationId: conversation.conversationId,
+          requestId: qm.requestId,
+          batchIndex: i,
+          batchSize: batch.length,
+          slashKind: qmSlash.kind,
+        },
+        "drainBatch invariant violated — non-passthrough message found in batch",
       );
+      conversation.traceEmitter.emit(
+        "request_error",
+        invariantMessage,
+        {
+          requestId: qm.requestId,
+          status: "error",
+          attributes: { reason: "batch_invariant_violation" },
+        },
+      );
+      qm.onEvent({ type: "error", message: invariantMessage });
+      if (i === 0) {
+        // Head case — no in-flight turn yet. Clear processing state that
+        // the head's `persistUserMessage` would have set (but didn't,
+        // because we threw before calling it) and recover via drainQueue.
+        conversation.processing = false;
+        conversation.abortController = null;
+        conversation.currentRequestId = undefined;
+        conversation.preactivatedSkillIds = undefined;
+        await drainQueue(conversation);
+        return;
+      }
+      // Tail case — processing is live, just skip this message. Loop
+      // continues to drain any remaining tails.
+      continue;
     }
     const qmContent = qmSlash.content;
 
@@ -1040,11 +1115,18 @@ async function drainBatch(
       // Tail persist failed — we cannot abandon the batch without stranding
       // the head's in-flight turn. Processing state is already set; skip
       // this message and continue accumulating siblings. The emitted error
-      // event lets the tail client see the failure.
+      // event lets the tail client see the failure. Crucially we do NOT
+      // update lastSuccessful* here, so runAgentLoop tags completion with
+      // the most recent successfully-persisted message's requestId.
       continue;
     }
 
-    lastResolvedContent = qmContent;
+    // Persist succeeded. Update last-successful markers so a later tail
+    // failure won't overwrite them.
+    lastSuccessfulRequestId = qm.requestId;
+    lastSuccessfulActiveSurfaceId = qm.activeSurfaceId;
+    lastSuccessfulCurrentPage = qm.currentPage;
+    lastSuccessfulContent = qmContent;
 
     // Fire-and-forget: detect notification preferences in each batched user
     // message and persist any that are found, mirroring drainSingleMessage.
@@ -1075,15 +1157,46 @@ async function drainBatch(
           );
         });
     }
+
+    // If the user hit abort mid-batch, stop persisting remaining tails.
+    // runAgentLoop's existing abort handling will emit generation_cancelled
+    // and clear processing state for whatever did persist.
+    if (conversation.abortController?.signal.aborted) {
+      log.info(
+        {
+          conversationId: conversation.conversationId,
+          requestId: qm.requestId,
+          batchIndex: i,
+          batchSize: batch.length,
+        },
+        "drainBatch: abort signaled mid-batch; stopping tail persist",
+      );
+      break;
+    }
   }
 
-  const last = batch[batch.length - 1];
-  // Last-wins: tag `message_complete` / surface-action IDs with the most
-  // recent user's requestId so client-side correlation surfaces the message
-  // the user is actively waiting on.
-  conversation.currentRequestId = last.requestId;
-  conversation.currentActiveSurfaceId = last.activeSurfaceId;
-  conversation.currentPage = last.currentPage;
+  if (lastUserMessageId === undefined || lastSuccessfulContent === undefined) {
+    // Nothing persisted — either the head's invariant-violation recovery
+    // already drained and returned, or every message failed. Head failure
+    // has its own recovery path above; if we get here it's because a
+    // defensive code path left us with nothing to run. Log and bail.
+    log.error(
+      {
+        conversationId: conversation.conversationId,
+        batchSize: batch.length,
+      },
+      "drainBatch: no messages persisted successfully; skipping runAgentLoop",
+    );
+    conversation.preactivatedSkillIds = undefined;
+    return;
+  }
+
+  // Tag turn-completion state with the last SUCCESSFUL persist so client-
+  // side correlation (message_complete / generation_cancelled /
+  // generation_handoff) surfaces a requestId that actually has a DB row.
+  conversation.currentRequestId = lastSuccessfulRequestId;
+  conversation.currentActiveSurfaceId = lastSuccessfulActiveSurfaceId;
+  conversation.currentPage = lastSuccessfulCurrentPage;
 
   const fanOutOnEvent = (msg: ServerMessage) => {
     for (const qm of batch) qm.onEvent(msg);
@@ -1094,14 +1207,19 @@ async function drainBatch(
     isUserMessage?: boolean;
     titleText?: string;
   } = { isUserMessage: true };
-  if (last.isInteractive !== undefined)
-    drainLoopOptions.isInteractive = last.isInteractive;
+  // Source interactive flag from the last successfully-persisted sibling so
+  // a trailing failed tail doesn't flip the agent loop's interactivity.
+  const lastSuccessfulBatchEntry = batch.find(
+    (qm) => qm.requestId === lastSuccessfulRequestId,
+  );
+  if (lastSuccessfulBatchEntry?.isInteractive !== undefined)
+    drainLoopOptions.isInteractive = lastSuccessfulBatchEntry.isInteractive;
 
   // Fire-and-forget: runAgentLoop's finally block recursively calls drainQueue
   // when this run completes. Mirrors drainSingleMessage.
   conversation
     .runAgentLoop(
-      lastResolvedContent,
+      lastSuccessfulContent,
       lastUserMessageId,
       fanOutOnEvent,
       drainLoopOptions,
@@ -1112,7 +1230,7 @@ async function drainBatch(
         {
           err,
           conversationId: conversation.conversationId,
-          requestId: last.requestId,
+          requestId: lastSuccessfulRequestId,
           batchSize: batch.length,
         },
         "Error processing batched queued messages",


### PR DESCRIPTION
## Summary
Follow-up fixes identified during self-review of #25303 (batched queued-message drain):
- Exclude surface-action messages from batching (they rely on per-message activeSurfaceId / surfaceActionRequestIds semantics that last-wins breaks).
- Check abortController.signal.aborted between persists so user-initiated abort stops the batch from writing tail messages to DB.
- Track last-SUCCESSFUL persist for currentRequestId / currentActiveSurfaceId / currentPage so a failed tail doesn't break client-side message_complete correlation.
- Recover from invariant-violation throws in the persist loop (log, emit error, clean up processing state) instead of stranding the conversation.
- Collapse N per-message emitActivityState calls into one at the top of drainBatch so the client-side thinking indicator doesn't whipsaw.

Fixes gaps identified during plan review for batch-queued-drain.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25320" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
