### PR TITLE
fix(drain): head-invariant recovery re-dispatches batch tails

### DIFF
--- a/assistant/src/__tests__/conversation-queue.test.ts
+++ b/assistant/src/__tests__/conversation-queue.test.ts
@@ -1508,12 +1508,14 @@ describe("Batched drain correctness fixes", () => {
   });
 
   // Defensive recovery path: buildPassthroughBatch is designed to make
-  // the invariant throw unreachable in practice. Left as a todo so the
-  // harness contract is documented without wedging mainline CI. Covering
-  // this would require either (a) reflecting into drainBatch to short-
-  // circuit resolveSlash for a specific batch entry, or (b) exposing a
-  // seam on SlashContext — both are more invasive than the safety-net
-  // value justifies.
+  // the invariant throw unreachable in practice, so neither the head
+  // branch (re-dispatch batch.slice(1) to drainBatch/drainSingleMessage/
+  // drainQueue) nor the tail branch (skip + continue) can fire in normal
+  // operation. Left as a todo so the harness contract is documented
+  // without wedging mainline CI. Covering this would require either
+  // (a) reflecting into drainBatch to short-circuit resolveSlash for a
+  // specific batch entry, or (b) exposing a seam on SlashContext — both
+  // are more invasive than the safety-net value justifies.
   test.todo(
     "invariant violation in persist loop triggers error event + recovery, not stranded state",
     async () => {

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -1010,10 +1010,10 @@ async function drainBatch(
     );
     if (qmSlash.kind !== "passthrough") {
       // Defensive recovery. `buildPassthroughBatch` should make this
-      // unreachable, but a synchronous throw here would strand
-      // `conversation.processing = true` (head already persisted) with no
-      // `runAgentLoop` ever called to clear it. Log, emit an error to
-      // the affected client, and either recover-and-drain (head case) or
+      // unreachable, but if it ever fires we must avoid stranding
+      // per-turn state and dropping the batch tails that have already
+      // been shifted out of the queue. Log, emit an error to the
+      // affected client, and either recover-and-drain (head case) or
       // skip the tail (tail case) so the rest of the batch still runs.
       const invariantMessage =
         "Internal error: batch drain invariant violated (non-passthrough message in batch)";
@@ -1038,14 +1038,24 @@ async function drainBatch(
       );
       qm.onEvent({ type: "error", message: invariantMessage });
       if (i === 0) {
-        // Head case — no in-flight turn yet. Clear processing state that
-        // the head's `persistUserMessage` would have set (but didn't,
-        // because we threw before calling it) and recover via drainQueue.
+        // Head invariant fired — no in-flight turn yet (the check runs
+        // before persistUserMessage, so the head was never persisted).
+        // Clear per-turn state and recursively drain the remaining tails,
+        // which were already shifted out of the queue by
+        // buildPassthroughBatch and would otherwise be stranded. Mirrors
+        // the head persist-failure recovery below.
         conversation.processing = false;
         conversation.abortController = null;
         conversation.currentRequestId = undefined;
         conversation.preactivatedSkillIds = undefined;
-        await drainQueue(conversation);
+        const remaining = batch.slice(1);
+        if (remaining.length >= 2) {
+          await drainBatch(conversation, remaining, reason);
+        } else if (remaining.length === 1) {
+          await drainSingleMessage(conversation, remaining[0], reason);
+        } else {
+          await drainQueue(conversation);
+        }
         return;
       }
       // Tail case — processing is live, just skip this message. Loop


### PR DESCRIPTION
## Summary
Close out the last round-2 review gap on the batched queued-message drain.

drainBatch's head-invariant-violation recovery called drainQueue after resetting per-turn state, but the tails have already been shifted out of the queue by buildPassthroughBatch. If this (defensive-unreachable) path ever fired, the tails would be silently dropped. Mirror the sibling head-persist-failure recovery: dispatch batch.slice(1) to drainBatch / drainSingleMessage / drainQueue depending on remainder size.

Also corrects a comment that claimed the head was already persisted at the invariant branch — it isn't; the invariant check runs before persistUserMessage.

Fixes the final gap from the batch-queued-drain.md plan review.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25322" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
