### PR TITLE
fix(ios): hoist drawer animation to parent VStack (addresses #25306 feedback)

### DIFF
--- a/clients/ios/Views/ChatContentView.swift
+++ b/clients/ios/Views/ChatContentView.swift
@@ -135,32 +135,36 @@ struct ChatContentView: View {
     }
 
     var body: some View {
+        let queuedMessages = viewModel.queuedMessages
         VStack(spacing: 0) {
             // Messages area — empty state when no messages, otherwise scrollable list
-            if viewModel.messages.isEmpty && !viewModel.isSending && !viewModel.isThinking {
-                emptyStateView
-            } else {
-                messagesScrollView
+            Group {
+                if viewModel.messages.isEmpty && !viewModel.isSending && !viewModel.isThinking {
+                    emptyStateView
+                } else {
+                    messagesScrollView
+                }
             }
+            .animation(nil, value: queuedMessages.isEmpty)
 
             // Generic error banner (conversation errors are shown inline in messages)
             if viewModel.conversationError == nil, let errorText = viewModel.errorText {
                 genericErrorBanner(errorText)
+                    .animation(nil, value: queuedMessages.isEmpty)
             }
 
             // Queue drawer — lists user messages still waiting to be sent.
-            // Collapses when the queue is empty.
-            if !viewModel.queuedMessages.isEmpty {
+            // Collapses when the queue is empty. The drawer's show/hide
+            // animation is driven by a parent-level `.animation(...)` keyed
+            // on `queuedMessages.isEmpty` so the removal transition fires
+            // even as this subtree is torn down.
+            if !queuedMessages.isEmpty {
                 QueuedMessagesDrawer_iOS(
                     viewModel: viewModel,
                     composerText: $viewModel.inputText,
                     composerAttachments: $viewModel.pendingAttachments
                 )
                 .transition(.move(edge: .bottom).combined(with: .opacity))
-                .animation(
-                    .spring(duration: 0.28, bounce: 0.15),
-                    value: viewModel.queuedMessages.count
-                )
             }
 
             // Input bar
@@ -177,11 +181,13 @@ struct ChatContentView: View {
                 },
                 viewModel: viewModel
             )
+            .animation(nil, value: queuedMessages.isEmpty)
         }
         .background(alignment: .bottom) { chatBackground }
         .background(VColor.surfaceOverlay)
         .animation(VAnimation.standard, value: viewModel.conversationError != nil)
         .animation(VAnimation.standard, value: viewModel.errorText)
+        .animation(.spring(duration: 0.28, bounce: 0.15), value: queuedMessages.isEmpty)
     }
 
     // MARK: - Messages Scroll View


### PR DESCRIPTION
## Summary

Mirrors the macOS fix from #25315 on the iOS side.

- Hoists `.animation(.spring(duration: 0.28, bounce: 0.15), value: queuedMessages.isEmpty)` from the child view (inside the `if !queuedMessages.isEmpty` block) onto the parent `VStack`. When applied inside the `if`, the animation modifier is torn down with the view as the queue empties, so the removal transition does not reliably animate. Hoisting it keeps the animation context alive across the boolean transition.
- Switches the observed value from `queuedMessages.count` to `queuedMessages.isEmpty` so the animation fires on the boolean drawer show/hide transition, not every count tick.
- Caches `viewModel.queuedMessages` into a local so the `if` check and the parent animation both read the same slice per render (parity with #25315).
- Mutes the hoisted animation on sibling subtrees (messages area, generic error banner, input bar) with `.animation(nil, value: queuedMessages.isEmpty)` per the pitfall table in `clients/AGENTS.md` — without this, a parent `.animation()` would bleed into every descendant and cause layout interpolation on unrelated view switches.

## Not addressed here

- Codex raised a P2 about per-row cancel via `.swipeActions` not firing inside a `LazyVStack`. This is a known limitation acknowledged in the original PR #25306 description with a tracked follow-up; intentionally out of scope for this PR.

## Test plan

- [x] `xcrun -sdk iphonesimulator swiftc -parse clients/ios/Views/ChatContentView.swift` — clean
- [ ] Manual: open chat with queued messages, confirm drawer slides in/out on queue transitions (insertion AND removal)
- [ ] Manual: switch conversations / toggle error banner, confirm no spurious spring interpolation of siblings

Addresses review feedback on #25306.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25323" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
