### PR TITLE
fix(macos): mute inherited .animation() on sibling subtrees in ChatView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -405,6 +405,7 @@ struct ChatView: View {
                 containerWidth: containerWidth,
                 containerHeight: containerHeight
             )
+            .animation(nil, value: queuedMessages.isEmpty)
 
             if let error = viewModel.errorManager.conversationError, error.isCreditsExhausted {
                 centeredChatColumn(width: max(layoutMetrics.chatColumnWidth - 2 * VSpacing.xl, 0)) {
@@ -413,6 +414,7 @@ struct ChatView: View {
                     )
                 }
                 .padding(.bottom, -VSpacing.sm)
+                .animation(nil, value: queuedMessages.isEmpty)
             }
 
             if let error = viewModel.errorManager.conversationError, error.isProviderNotConfigured {
@@ -423,6 +425,7 @@ struct ChatView: View {
                     )
                 }
                 .padding(.bottom, -VSpacing.sm)
+                .animation(nil, value: queuedMessages.isEmpty)
             }
 
             if let mode = recoveryMode, mode.enabled {
@@ -435,6 +438,7 @@ struct ChatView: View {
                     )
                 }
                 .padding(.bottom, -VSpacing.sm)
+                .animation(nil, value: queuedMessages.isEmpty)
             }
 
             if !queuedMessages.isEmpty {
@@ -457,6 +461,7 @@ struct ChatView: View {
                     .foregroundStyle(VColor.contentTertiary)
                     .padding(.vertical, VSpacing.md)
                 }
+                .animation(nil, value: queuedMessages.isEmpty)
             } else {
                 centeredChatColumn(width: layoutMetrics.chatColumnWidth) {
                     ComposerSection(
@@ -498,6 +503,7 @@ struct ChatView: View {
                     )
                     .equatable()
                 }
+                .animation(nil, value: queuedMessages.isEmpty)
             }
         }
         .animation(.spring(duration: 0.28, bounce: 0.15), value: queuedMessages.isEmpty)


### PR DESCRIPTION
## Summary

Follow-up to #25315. Addresses Devin's review feedback: the hoisted `.animation(.spring(...), value: queuedMessages.isEmpty)` on the parent VStack applies to ALL descendants via SwiftUI's inherited-animation semantics. Siblings (`MessageListView`, banners, `ComposerSection`) would pick up the spring on any simultaneous state change whenever `queuedMessages.isEmpty` flipped, causing layout interpolation artifacts (thinking indicator, new messages, composer state, etc.).

This is the exact pitfall documented in `clients/AGENTS.md`: *"Inherited `.animation()` causing layout interpolation during view switches — A parent's `.animation()` modifier applies to all descendants, including subtrees that should switch instantly."* Documented fix: `.animation(nil, value: switchValue)` on the subtrees that should not animate.

## Changes

Kept the parent `.animation(.spring(...), value: queuedMessages.isEmpty)` on the VStack (needed for the `QueuedMessagesDrawer` insertion/removal transition). Added `.animation(nil, value: queuedMessages.isEmpty)` on every sibling subtree that should opt out of the inherited spring:

- `MessageListView` (main transcript)
- `CreditsExhaustedBanner` conditional branch
- `MissingApiKeyBanner` conditional branch
- `RecoveryModeBanner` conditional branch
- Readonly conversation banner
- `ComposerSection` branch

`QueuedMessagesDrawer` is deliberately left unmodified — it is the intended animation target.

## Test plan

- [x] `xcrun swiftc -parse clients/macos/vellum-assistant/Features/Chat/ChatView.swift` clean
- [ ] Manual: drain a queue while assistant is streaming; transcript/thinking indicator should not spring
- [ ] Manual: drawer insertion/removal still springs as before
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25324" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
