### PR TITLE
fix(chat): exclude queued messages from transcript markdown export

### DIFF
--- a/clients/ios/Tests/ChatTranscriptFormatterIOSTests.swift
+++ b/clients/ios/Tests/ChatTranscriptFormatterIOSTests.swift
@@ -133,6 +133,41 @@ final class ChatTranscriptFormatterIOSTests: XCTestCase {
         XCTAssertFalse(result.contains("### User\n"), "Should not contain default 'User' participant name")
     }
 
+    // MARK: - Queued message filtering
+
+    func testConversationMarkdownExcludesQueuedUserMessages() {
+        let messages = [
+            ChatMessage(role: .user, text: "Sent question", status: .sent),
+            ChatMessage(role: .assistant, text: "Answer"),
+            ChatMessage(role: .user, text: "Queued follow-up", status: .queued(position: 0)),
+        ]
+
+        let result = ChatTranscriptFormatter.conversationMarkdown(
+            messages: messages,
+            conversationTitle: nil,
+            participantNames: names
+        )
+
+        XCTAssertTrue(result.contains("Sent question"))
+        XCTAssertTrue(result.contains("Answer"))
+        XCTAssertFalse(result.contains("Queued follow-up"))
+    }
+
+    func testConversationMarkdownReturnsEmptyWhenAllUserMessagesQueued() {
+        let messages = [
+            ChatMessage(role: .user, text: "Pending one", status: .queued(position: 0)),
+            ChatMessage(role: .user, text: "Pending two", status: .queued(position: 1)),
+        ]
+
+        let result = ChatTranscriptFormatter.conversationMarkdown(
+            messages: messages,
+            conversationTitle: "Drafts",
+            participantNames: names
+        )
+
+        XCTAssertEqual(result, "")
+    }
+
     // MARK: - messagePlainText
 
     func testMessagePlainTextReturnsTrimmedText() {

--- a/clients/shared/Features/Chat/ChatTranscriptFormatter.swift
+++ b/clients/shared/Features/Chat/ChatTranscriptFormatter.swift
@@ -19,12 +19,16 @@ public enum ChatTranscriptFormatter {
     ///   - conversationTitle: Optional conversation title (rendered as `# title`).
     ///   - participantNames: Display names for assistant and user.
     /// - Returns: Markdown string, or empty string if no text messages exist.
+    /// Queued user messages (`role == .user && status is .queued`) are excluded so
+    /// copy/share output stays consistent with the on-screen transcript, which
+    /// collapses queued user messages into a single marker (see `TranscriptItems.build`).
     public static func conversationMarkdown(
         messages: [ChatMessage],
         conversationTitle: String?,
         participantNames: ParticipantNames
     ) -> String {
-        let textMessages = messages.filter {
+        let deliverableMessages = messages.filter { !isQueuedUser($0) }
+        let textMessages = deliverableMessages.filter {
             !$0.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         }
         guard !textMessages.isEmpty else { return "" }
@@ -51,5 +55,14 @@ public enum ChatTranscriptFormatter {
     /// Returns the trimmed text, or empty string if the message has no text content.
     public static func messagePlainText(_ message: ChatMessage) -> String {
         message.text.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// True when the message is a queued user message (not yet sent to the assistant).
+    /// Mirrors the same `role == .user && case .queued = status` check used in
+    /// `ChatViewModel`, `TranscriptItems`, and the queue-drawer code paths.
+    private static func isQueuedUser(_ message: ChatMessage) -> Bool {
+        guard message.role == .user else { return false }
+        if case .queued = message.status { return true }
+        return false
     }
 }

--- a/clients/shared/Tests/ChatTranscriptFormatterTests.swift
+++ b/clients/shared/Tests/ChatTranscriptFormatterTests.swift
@@ -130,6 +130,79 @@ final class ChatTranscriptFormatterTests: XCTestCase {
         XCTAssertFalse(result.contains("Noa"))
     }
 
+    // MARK: - Queued message filtering
+
+    func testConversationMarkdownExcludesQueuedUserMessages() {
+        let messages = [
+            ChatMessage(role: .user, text: "Sent question", status: .sent),
+            ChatMessage(role: .assistant, text: "Answer"),
+            ChatMessage(role: .user, text: "Queued follow-up", status: .queued(position: 0)),
+            ChatMessage(role: .user, text: "Another queued", status: .queued(position: 1)),
+        ]
+
+        let result = ChatTranscriptFormatter.conversationMarkdown(
+            messages: messages,
+            conversationTitle: nil,
+            participantNames: names
+        )
+
+        XCTAssertTrue(result.contains("Sent question"))
+        XCTAssertTrue(result.contains("Answer"))
+        XCTAssertFalse(result.contains("Queued follow-up"))
+        XCTAssertFalse(result.contains("Another queued"))
+        // Two surviving messages → exactly one separator.
+        let separatorCount = result.components(separatedBy: "\n\n---\n\n").count - 1
+        XCTAssertEqual(separatorCount, 1)
+    }
+
+    func testConversationMarkdownPreservesSentAndAssistantMessagesWhenNoneQueued() {
+        let messages = [
+            ChatMessage(role: .user, text: "Hello", status: .sent),
+            ChatMessage(role: .assistant, text: "Hi"),
+        ]
+
+        let result = ChatTranscriptFormatter.conversationMarkdown(
+            messages: messages,
+            conversationTitle: nil,
+            participantNames: names
+        )
+
+        XCTAssertTrue(result.contains("Hello"))
+        XCTAssertTrue(result.contains("Hi"))
+    }
+
+    func testConversationMarkdownReturnsEmptyWhenAllUserMessagesQueued() {
+        let messages = [
+            ChatMessage(role: .user, text: "Pending one", status: .queued(position: 0)),
+            ChatMessage(role: .user, text: "Pending two", status: .queued(position: 1)),
+        ]
+
+        let result = ChatTranscriptFormatter.conversationMarkdown(
+            messages: messages,
+            conversationTitle: "Drafts",
+            participantNames: names
+        )
+
+        XCTAssertEqual(result, "")
+    }
+
+    func testConversationMarkdownKeepsAssistantMessageWithQueuedStatus() {
+        // Defensive: filter is scoped to user role, so an assistant message with
+        // an unusual status should still come through unchanged.
+        let messages = [
+            ChatMessage(role: .assistant, text: "Streaming reply", status: .queued(position: 0)),
+        ]
+
+        let result = ChatTranscriptFormatter.conversationMarkdown(
+            messages: messages,
+            conversationTitle: nil,
+            participantNames: names
+        )
+
+        XCTAssertTrue(result.contains("Streaming reply"))
+        XCTAssertTrue(result.contains("### Aria"))
+    }
+
     // MARK: - messagePlainText
 
     func testMessagePlainTextReturnsTrimmedText() {


### PR DESCRIPTION
## Summary
Addresses gap identified during plan review for queue-drawer-edit-cancel.md.

**Gap**: Transcript copy/share as markdown included queued messages, disagreeing with the on-screen collapse introduced by PR #25316 / #25319.

Filters queued user messages (`role == .user && status is .queued`) out of `ChatTranscriptFormatter.conversationMarkdown` so copy-to-clipboard and share-as-markdown stay consistent with the transcript marker.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25325" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
