### PR TITLE
fix(daemon): emit request_error trace on regenerate fire-and-forget failure

### DIFF
--- a/assistant/src/__tests__/regenerate-fire-and-forget-trace.test.ts
+++ b/assistant/src/__tests__/regenerate-fire-and-forget-trace.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Guards the observability contract for the fire-and-forget regenerate path.
+ *
+ * /regenerate no longer awaits runAgentLoop — any error that escapes the
+ * agent loop (e.g. a throw from its `finally` block) would otherwise be
+ * swallowed by the `.catch()` without the structured `request_error` trace
+ * event that the prior handler-level try/catch used to emit.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+}));
+
+let dbMessages: Array<{
+  id: string;
+  conversationId: string;
+  role: string;
+  content: string;
+  createdAt: number;
+  metadata: string | null;
+}> = [];
+
+mock.module("../memory/conversation-crud.js", () => ({
+  getMessages: (conversationId: string) =>
+    dbMessages.filter((m) => m.conversationId === conversationId),
+  deleteMessageById: (messageId: string) => {
+    dbMessages = dbMessages.filter((m) => m.id !== messageId);
+    return { segmentIds: [], deletedSummaryIds: [] };
+  },
+  updateMessageContent: () => {},
+  relinkAttachments: () => 0,
+  deleteLastExchange: () => 0,
+}));
+
+mock.module("../memory/conversation-queries.js", () => ({
+  isLastUserMessageToolResult: () => false,
+}));
+
+mock.module("../memory/jobs-store.js", () => ({
+  enqueueMemoryJob: () => {},
+}));
+
+mock.module("../memory/llm-request-log-store.js", () => ({
+  relinkLlmRequestLogs: () => {},
+}));
+
+mock.module("../memory/qdrant-circuit-breaker.js", () => ({
+  withQdrantBreaker: async (fn: () => Promise<unknown>) => fn(),
+}));
+
+mock.module("../memory/qdrant-client.js", () => ({
+  getQdrantClient: () => {
+    throw new Error("Qdrant not initialized");
+  },
+}));
+
+import {
+  type HistoryConversationContext,
+  regenerate,
+} from "../daemon/conversation-history.js";
+import type { Message } from "../providers/types.js";
+
+type TraceEvent = {
+  event: string;
+  body: string;
+  options: { requestId?: string; attributes?: Record<string, unknown> };
+};
+
+function buildContext(
+  overrides: Partial<{
+    runAgentLoop: HistoryConversationContext["runAgentLoop"];
+    messages: Message[];
+    traceEvents: TraceEvent[];
+  }> = {},
+): HistoryConversationContext {
+  const conversationId = "conv-regen-trace";
+
+  const messages: Message[] = overrides.messages ?? [
+    { role: "user", content: [{ type: "text", text: "hello" }] },
+    { role: "assistant", content: [{ type: "text", text: "hi" }] },
+  ];
+
+  dbMessages = [
+    {
+      id: "msg-u1",
+      conversationId,
+      role: "user",
+      content: JSON.stringify([{ type: "text", text: "hello" }]),
+      createdAt: 1000,
+      metadata: null,
+    },
+    {
+      id: "msg-a1",
+      conversationId,
+      role: "assistant",
+      content: JSON.stringify([{ type: "text", text: "hi" }]),
+      createdAt: 2000,
+      metadata: null,
+    },
+  ];
+
+  const traceEvents = overrides.traceEvents ?? [];
+
+  const runAgentLoop: HistoryConversationContext["runAgentLoop"] =
+    overrides.runAgentLoop ??
+    (async () => {
+      throw new Error("boom");
+    });
+
+  return {
+    conversationId,
+    traceEmitter: {
+      emit: (event: string, body: string, options: TraceEvent["options"]) => {
+        traceEvents.push({ event, body, options });
+      },
+    } as unknown as HistoryConversationContext["traceEmitter"],
+    messages,
+    processing: false,
+    abortController: null,
+    runAgentLoop,
+  };
+}
+
+describe("regenerate fire-and-forget error path", () => {
+  beforeEach(() => {
+    dbMessages = [];
+  });
+
+  test("emits request_error trace when runAgentLoop rejects asynchronously", async () => {
+    const traceEvents: TraceEvent[] = [];
+
+    const session = buildContext({
+      traceEvents,
+      runAgentLoop: async () => {
+        throw new Error("agent loop blew up in finally");
+      },
+    });
+
+    await regenerate(session, () => {}, "req-123");
+
+    // Give the fire-and-forget .catch() a tick to run.
+    await new Promise((resolve) => setImmediate(resolve));
+
+    const errorEvents = traceEvents.filter((e) => e.event === "request_error");
+    expect(errorEvents).toHaveLength(1);
+    expect(errorEvents[0].body).toBe("agent loop blew up in finally");
+    expect(errorEvents[0].options.requestId).toBe("req-123");
+    expect(errorEvents[0].options.attributes?.errorClass).toBe("Error");
+    expect(errorEvents[0].options.attributes?.source).toBe(
+      "regenerate_fire_and_forget",
+    );
+    expect(errorEvents[0].options.attributes?.message).toBe(
+      "agent loop blew up in finally",
+    );
+  });
+
+  test("uses generated requestId when caller did not pass one", async () => {
+    const traceEvents: TraceEvent[] = [];
+
+    const session = buildContext({
+      traceEvents,
+      runAgentLoop: async () => {
+        throw new Error("boom");
+      },
+    });
+
+    await regenerate(session, () => {});
+
+    await new Promise((resolve) => setImmediate(resolve));
+
+    const errorEvents = traceEvents.filter((e) => e.event === "request_error");
+    expect(errorEvents).toHaveLength(1);
+    expect(typeof errorEvents[0].options.requestId).toBe("string");
+    expect((errorEvents[0].options.requestId ?? "").length).toBeGreaterThan(0);
+  });
+
+  test("does not emit request_error when runAgentLoop succeeds", async () => {
+    const traceEvents: TraceEvent[] = [];
+
+    const session = buildContext({
+      traceEvents,
+      runAgentLoop: async () => {},
+    });
+
+    await regenerate(session, () => {}, "req-ok");
+
+    await new Promise((resolve) => setImmediate(resolve));
+
+    const errorEvents = traceEvents.filter((e) => e.event === "request_error");
+    expect(errorEvents).toHaveLength(0);
+  });
+});

--- a/assistant/src/daemon/conversation-history.ts
+++ b/assistant/src/daemon/conversation-history.ts
@@ -15,6 +15,7 @@ import { withQdrantBreaker } from "../memory/qdrant-circuit-breaker.js";
 import { getQdrantClient } from "../memory/qdrant-client.js";
 import type { ContentBlock, Message } from "../providers/types.js";
 import { getLogger } from "../util/logger.js";
+import { truncate } from "../util/truncate.js";
 import type { ServerMessage } from "./message-protocol.js";
 import type { TraceEmitter } from "./trace-emitter.js";
 
@@ -564,22 +565,43 @@ export async function regenerate(
   // in both this.messages and the DB.
   conversation.processing = true;
   conversation.abortController = new AbortController();
-  conversation.currentRequestId = requestId ?? uuid();
+  const resolvedRequestId = requestId ?? uuid();
+  conversation.currentRequestId = resolvedRequestId;
 
   // Fire-and-forget: matches the /v1/messages pattern so the HTTP handler
   // returns 202 immediately rather than blocking on the full agent turn.
   // Otherwise the client's 15s POST timeout fires on any non-trivial
   // regenerate and surfaces a misleading "Failed to regenerate message"
   // banner even though the response streams in normally via SSE.
+  //
+  // runAgentLoop catches most errors internally and emits `request_error`
+  // itself, but anything thrown from its `finally` block (commit, drain,
+  // profiler) would otherwise escape silently now that the caller is no
+  // longer awaiting. Mirror the prior handler-level trace emission so the
+  // observability contract is preserved on those paths too.
   void conversation
     .runAgentLoop(content, existingUserMessageId, onEvent, {
       skipPreMessageRollback: true,
       isUserMessage: true,
     })
     .catch((err) => {
+      const message = err instanceof Error ? err.message : String(err);
       log.error(
         { err, conversationId: conversation.conversationId },
         "runAgentLoop after regenerate failed",
+      );
+      conversation.traceEmitter.emit(
+        "request_error",
+        truncate(message, 200, ""),
+        {
+          requestId: resolvedRequestId,
+          status: "error",
+          attributes: {
+            errorClass: err instanceof Error ? err.constructor.name : "Error",
+            message: truncate(message, 500, ""),
+            source: "regenerate_fire_and_forget",
+          },
+        },
       );
     });
 }


### PR DESCRIPTION
## Summary

Addresses review feedback on #25305.

After that PR made \`regenerate()\` kick off \`runAgentLoop\` fire-and-forget, the handler-level try/catch in \`handleRegenerateRequest\` no longer catches agent-loop failures — the new \`.catch()\` inside \`regenerate()\` only called \`log.error\`, losing the structured \`request_error\` trace event that used to fire on failure.

\`runAgentLoopImpl\` already emits \`request_error\` itself for errors caught inside its main try block, but errors escaping its \`finally\` (commit, drainQueue, profiler, etc.) bypass that emission. Mirror the prior handler-level trace in the fire-and-forget \`.catch()\` so observability is preserved on those paths.

## Changes
- \`assistant/src/daemon/conversation-history.ts\`: in the fire-and-forget \`.catch\`, emit \`request_error\` with the same shape the caller used before, tagged with \`source: "regenerate_fire_and_forget"\` so these are distinguishable from inner-loop emissions.
- Added \`assistant/src/__tests__/regenerate-fire-and-forget-trace.test.ts\` covering the happy path, failure path, and generated-requestId fallback.

## Test plan
- [x] \`bun test src/__tests__/regenerate-fire-and-forget-trace.test.ts\` — 3 pass
- [x] \`bunx tsc --noEmit\` clean
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25326" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
