### PR TITLE
fix(providers): propagate tagged AbortReason through OpenAI and Gemini

### DIFF
--- a/assistant/src/__tests__/gemini-provider.test.ts
+++ b/assistant/src/__tests__/gemini-provider.test.ts
@@ -6,6 +6,8 @@ import type {
   ProviderEvent,
   ToolDefinition,
 } from "../providers/types.js";
+import { createAbortReason } from "../util/abort-reasons.js";
+import { ProviderError } from "../util/errors.js";
 
 // ---------------------------------------------------------------------------
 // Mock @google/genai module — must be before importing the provider
@@ -662,6 +664,68 @@ describe("GeminiProvider", () => {
     } catch (error) {
       expect((error as Error).message).toContain("Gemini request failed");
       expect((error as Error).message).toContain("Network failure");
+    }
+  });
+
+  // -----------------------------------------------------------------------
+  // Tagged AbortReason propagation
+  // -----------------------------------------------------------------------
+  test("attaches tagged abortReason to ProviderError wrapping an ApiError when signal is aborted with a reason", async () => {
+    shouldThrow = new FakeApiError(0, "Request was aborted.");
+    const controller = new AbortController();
+    const reason = createAbortReason("user_cancel", "test:gemini");
+    controller.abort(reason);
+
+    try {
+      await provider.sendMessage(
+        [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+        undefined,
+        undefined,
+        { signal: controller.signal },
+      );
+      expect(true).toBe(false);
+    } catch (error) {
+      expect(error).toBeInstanceOf(ProviderError);
+      expect((error as ProviderError).abortReason).toBe(reason);
+    }
+  });
+
+  test("attaches tagged abortReason to ProviderError wrapping a generic error on abort", async () => {
+    shouldThrow = new Error("socket hang up");
+    const controller = new AbortController();
+    const reason = createAbortReason("preempted_by_new_message", "test:gemini");
+    controller.abort(reason);
+
+    try {
+      await provider.sendMessage(
+        [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+        undefined,
+        undefined,
+        { signal: controller.signal },
+      );
+      expect(true).toBe(false);
+    } catch (error) {
+      expect(error).toBeInstanceOf(ProviderError);
+      expect((error as ProviderError).abortReason).toBe(reason);
+    }
+  });
+
+  test("does not attach abortReason when the signal was aborted with a non-tagged reason", async () => {
+    shouldThrow = new FakeApiError(0, "Request was aborted.");
+    const controller = new AbortController();
+    controller.abort(new Error("plain abort"));
+
+    try {
+      await provider.sendMessage(
+        [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+        undefined,
+        undefined,
+        { signal: controller.signal },
+      );
+      expect(true).toBe(false);
+    } catch (error) {
+      expect(error).toBeInstanceOf(ProviderError);
+      expect((error as ProviderError).abortReason).toBeUndefined();
     }
   });
 

--- a/assistant/src/__tests__/openai-provider.test.ts
+++ b/assistant/src/__tests__/openai-provider.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { RetryProvider } from "../providers/retry.js";
+import { createAbortReason } from "../util/abort-reasons.js";
+import { ProviderError } from "../util/errors.js";
 import type {
   ContentBlock,
   Message,
@@ -757,6 +759,68 @@ describe("OpenAIProvider", () => {
     } catch (error) {
       expect((error as Error).message).toContain("OpenAI request failed");
       expect((error as Error).message).toContain("Network failure");
+    }
+  });
+
+  // -----------------------------------------------------------------------
+  // Tagged AbortReason propagation
+  // -----------------------------------------------------------------------
+  test("attaches tagged abortReason to ProviderError wrapping an APIError when signal is aborted with a reason", async () => {
+    shouldThrow = new FakeAPIError(0, "Request was aborted.");
+    const controller = new AbortController();
+    const reason = createAbortReason("user_cancel", "test:openai");
+    controller.abort(reason);
+
+    try {
+      await provider.sendMessage(
+        [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+        undefined,
+        undefined,
+        { signal: controller.signal },
+      );
+      expect(true).toBe(false); // should not reach
+    } catch (error) {
+      expect(error).toBeInstanceOf(ProviderError);
+      expect((error as ProviderError).abortReason).toBe(reason);
+    }
+  });
+
+  test("attaches tagged abortReason to ProviderError wrapping a generic error on abort", async () => {
+    shouldThrow = new Error("socket hang up");
+    const controller = new AbortController();
+    const reason = createAbortReason("preempted_by_new_message", "test:openai");
+    controller.abort(reason);
+
+    try {
+      await provider.sendMessage(
+        [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+        undefined,
+        undefined,
+        { signal: controller.signal },
+      );
+      expect(true).toBe(false);
+    } catch (error) {
+      expect(error).toBeInstanceOf(ProviderError);
+      expect((error as ProviderError).abortReason).toBe(reason);
+    }
+  });
+
+  test("does not attach abortReason when the signal was aborted with a non-tagged reason", async () => {
+    shouldThrow = new FakeAPIError(0, "Request was aborted.");
+    const controller = new AbortController();
+    controller.abort(new Error("plain abort"));
+
+    try {
+      await provider.sendMessage(
+        [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+        undefined,
+        undefined,
+        { signal: controller.signal },
+      );
+      expect(true).toBe(false);
+    } catch (error) {
+      expect(error).toBeInstanceOf(ProviderError);
+      expect((error as ProviderError).abortReason).toBeUndefined();
     }
   });
 

--- a/assistant/src/providers/gemini/client.ts
+++ b/assistant/src/providers/gemini/client.ts
@@ -2,6 +2,7 @@ import type * as genai from "@google/genai";
 import { ApiError, GoogleGenAI } from "@google/genai";
 
 import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../../prompts/cache-boundary.js";
+import { isAbortReason } from "../../util/abort-reasons.js";
 import { ProviderError } from "../../util/errors.js";
 import { getLogger } from "../../util/logger.js";
 import { createStreamTimeout } from "../stream-timeout.js";
@@ -230,11 +231,18 @@ export class GeminiProvider implements Provider {
         rawResponse,
       };
     } catch (error) {
+      // Propagate a tagged AbortReason (set by the daemon at controller.abort())
+      // so wrapped errors can be classified as user cancellation downstream.
+      const abortReason =
+        signal?.aborted && isAbortReason(signal.reason)
+          ? signal.reason
+          : undefined;
       if (error instanceof ApiError) {
         throw new ProviderError(
           `Gemini API error (${error.status}): ${error.message}`,
           "gemini",
           error.status,
+          abortReason ? { abortReason } : undefined,
         );
       }
       throw new ProviderError(
@@ -243,7 +251,7 @@ export class GeminiProvider implements Provider {
         }`,
         "gemini",
         undefined,
-        { cause: error },
+        abortReason ? { cause: error, abortReason } : { cause: error },
       );
     }
   }

--- a/assistant/src/providers/openai/client.ts
+++ b/assistant/src/providers/openai/client.ts
@@ -1,6 +1,7 @@
 import OpenAI from "openai";
 
 import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../../prompts/cache-boundary.js";
+import { isAbortReason } from "../../util/abort-reasons.js";
 import { ProviderError } from "../../util/errors.js";
 import { getLogger } from "../../util/logger.js";
 import { extractRetryAfterMs } from "../../util/retry.js";
@@ -290,13 +291,25 @@ export class OpenAIProvider implements Provider {
         rawResponse,
       };
     } catch (error) {
+      // Propagate a tagged AbortReason (set by the daemon at controller.abort())
+      // so wrapped errors can be classified as user cancellation downstream.
+      const abortReason =
+        signal?.aborted && isAbortReason(signal.reason)
+          ? signal.reason
+          : undefined;
       if (error instanceof OpenAI.APIError) {
         const retryAfterMs = extractRetryAfterMs(error.headers);
+        const errorOptions: {
+          retryAfterMs?: number;
+          abortReason?: unknown;
+        } = {};
+        if (retryAfterMs !== undefined) errorOptions.retryAfterMs = retryAfterMs;
+        if (abortReason) errorOptions.abortReason = abortReason;
         throw new ProviderError(
           `${this.providerLabel} API error (${error.status}): ${error.message}`,
           this.name,
           error.status,
-          retryAfterMs !== undefined ? { retryAfterMs } : undefined,
+          Object.keys(errorOptions).length > 0 ? errorOptions : undefined,
         );
       }
       throw new ProviderError(
@@ -305,7 +318,7 @@ export class OpenAIProvider implements Provider {
         }`,
         this.name,
         undefined,
-        { cause: error },
+        abortReason ? { cause: error, abortReason } : { cause: error },
       );
     }
   }

--- a/assistant/src/util/errors.ts
+++ b/assistant/src/util/errors.ts
@@ -105,7 +105,7 @@ export class ProviderError extends AssistantError {
   /**
    * Tagged daemon-owned abort reason carried over from the AbortSignal that
    * triggered this error. Untyped here to avoid a daemon→util import cycle;
-   * `AbortReason` from `daemon/abort-reasons.ts` is the only producer and
+   * `AbortReason` from `util/abort-reasons.ts` is the only producer and
    * `isAbortReason` is the canonical type guard for consumers.
    */
   public readonly abortReason?: unknown;


### PR DESCRIPTION
## Summary

Addresses Devin review feedback on #25308.

- **Doc fix (`util/errors.ts`)**: corrected JSDoc path reference on `ProviderError.abortReason` from \`daemon/abort-reasons.ts\` to the actual location \`util/abort-reasons.ts\`.
- **Provider fix (`providers/openai/client.ts`, `providers/gemini/client.ts`)**: mirrored the Anthropic client's abort-reason propagation. On a wrapped error, each provider now reads \`signal.reason\`, verifies it with \`isAbortReason\`, and forwards it to \`ProviderError\` via the \`abortReason\` option. Without this, user-initiated aborts against OpenAI/Gemini produced an untagged \`ProviderError\`, \`isUserCancellation\` returned \`false\`, and \`classifyConversationError\` surfaced a red \`CONVERSATION_ABORTED\` card instead of a silent \`generation_cancelled\` event — the exact bug #25308 fixed for Anthropic.

## Test plan

- [x] \`bun test src/__tests__/openai-provider.test.ts src/__tests__/gemini-provider.test.ts src/__tests__/conversation-error.test.ts\` (182 pass)
- [x] \`bunx tsc --noEmit\` clean

Added three abort-reason tests per provider covering: APIError path with tagged reason, generic error path with tagged reason, and ignored non-tagged reasons.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25327" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
