### PR TITLE
fix(macos): anchor navigation + turnMinHeight for collapsed queued bubbles

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
@@ -267,13 +267,30 @@ struct MessageListContentView: View, Equatable {
 
             let _ = os_signpost(.event, log: stallLog, name: "MessageList.bodyEval")
             // Estimate user message cell height for precise minHeight offset.
+            // Queued user messages are collapsed into QueuedMessagesMarker and
+            // don't render as full bubbles, so they must be excluded — using a
+            // queued follow-up's height would over-estimate and under-size the
+            // turn minHeight, breaking the "sent message pinned at top"
+            // invariant during an active turn.
             let estimatedUserHeight: CGFloat = {
-                guard let lastUser = state.rows.last(where: { $0.message.role == .user }) else {
-                    return 80
+                let hasQueuedMessages = state.rows.contains(where: { row in
+                    guard row.message.role == .user else { return false }
+                    if case .queued = row.message.status { return true }
+                    return false
+                })
+                // ~40pt: QueuedMessagesMarker = single-line labelDefault text
+                // with VSpacing.sm top+bottom padding.
+                let markerHeight: CGFloat = hasQueuedMessages ? 40 : 0
+                guard let lastUser = state.rows.last(where: { row in
+                    guard row.message.role == .user else { return false }
+                    if case .queued = row.message.status { return false }
+                    return true
+                }) else {
+                    return 80 + markerHeight
                 }
                 // Messages with attachments are always collapsed — use max height
                 if !lastUser.message.attachments.isEmpty {
-                    return 260
+                    return 260 + markerHeight
                 }
                 let text = lastUser.message.text as NSString
                 let contentWidth = max(layoutMetrics.bubbleMaxWidth - 2 * VSpacing.lg, 0)
@@ -287,7 +304,7 @@ struct MessageListContentView: View, Equatable {
                 // Bubble padding (24) + timestamp (24) + spacing (12) + show more button (30) + gradient (10)
                 let cellOverhead: CGFloat = 100
                 // Cap at collapsed bubble height (150pt content + overhead)
-                return min(textHeight + cellOverhead, 260)
+                return min(textHeight + cellOverhead, 260) + markerHeight
             }()
             // Precise minHeight: fill the space between user message and composer.
             // containerHeight = full chat pane (stable, from GeometryReader)

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
@@ -33,11 +33,12 @@ extension MessageListView {
             scrollState.lastActivityPhaseWhenIdle = assistantActivityPhase
         }
         // Handle pending anchor if already set.
-        if let id = anchorMessageId, messages.contains(where: { $0.id == id }) {
+        if let id = anchorMessageId,
+           let displayId = TranscriptItems.displayId(for: id, in: messages) {
             os_signpost(.event, log: PerfSignposts.log, name: "scrollToRequested", "target=anchorMessage reason=onAppear")
             os_signpost(.event, log: PerfSignposts.log, name: "anchorCleared", "reason=foundOnAppear")
-            $scrollPosition.wrappedValue.scrollTo(id: id, anchor: .center)
-            flashHighlight(messageId: id)
+            $scrollPosition.wrappedValue.scrollTo(id: displayId, anchor: .center)
+            flashHighlight(messageId: displayId)
             anchorMessageId = nil
             scrollState.anchorSetTime = nil
         } else if anchorMessageId != nil {
@@ -93,13 +94,14 @@ extension MessageListView {
         // Guard against stale fires during a conversation switch.
         guard conversationId == scrollState.currentConversationId else { return }
         // --- Anchor message resolution ---
-        if let id = anchorMessageId, messages.contains(where: { $0.id == id }) {
+        if let id = anchorMessageId,
+           let displayId = TranscriptItems.displayId(for: id, in: messages) {
             os_signpost(.event, log: PerfSignposts.log, name: "scrollToRequested", "target=anchorMessage reason=messagesChanged")
             os_signpost(.event, log: PerfSignposts.log, name: "anchorCleared", "reason=foundInMessages")
             withAnimation {
-                $scrollPosition.wrappedValue = ScrollPosition(id: id, anchor: .center)
+                $scrollPosition.wrappedValue = ScrollPosition(id: displayId, anchor: .center)
             }
-            flashHighlight(messageId: id)
+            flashHighlight(messageId: displayId)
             anchorMessageId = nil
             scrollState.anchorSetTime = nil
             scrollState.anchorTimeoutTask?.cancel()
@@ -206,13 +208,13 @@ extension MessageListView {
         scrollState.anchorTimeoutTask?.cancel()
         scrollState.anchorTimeoutTask = nil
         os_signpost(.event, log: PerfSignposts.log, name: "anchorSet", "reason=anchorMessageIdChanged")
-        if messages.contains(where: { $0.id == id }) {
+        if let displayId = TranscriptItems.displayId(for: id, in: messages) {
             os_signpost(.event, log: PerfSignposts.log, name: "scrollToRequested", "target=anchorMessage reason=anchorChanged")
             os_signpost(.event, log: PerfSignposts.log, name: "anchorCleared", "reason=foundOnAnchorChange")
             withAnimation {
-                $scrollPosition.wrappedValue = ScrollPosition(id: id, anchor: .center)
+                $scrollPosition.wrappedValue = ScrollPosition(id: displayId, anchor: .center)
             }
-            flashHighlight(messageId: id)
+            flashHighlight(messageId: displayId)
             anchorMessageId = nil
             scrollState.anchorSetTime = nil
         } else {

--- a/clients/macos/vellum-assistantTests/TranscriptItemsTests.swift
+++ b/clients/macos/vellum-assistantTests/TranscriptItemsTests.swift
@@ -110,4 +110,32 @@ final class TranscriptItemsTests: XCTestCase {
     func test_transcriptItems_emptyInput_yieldsEmptyOutput() {
         XCTAssertEqual(TranscriptItems.build(from: []).count, 0)
     }
+
+    // MARK: - displayId(for:in:)
+
+    func test_displayId_nonQueuedMessage_returnsSameId() {
+        let assistantSent = assistantMessage(text: "hi")
+        let userSent = userMessage(text: "hello", status: .sent)
+        let messages = [assistantSent, userSent]
+
+        XCTAssertEqual(TranscriptItems.displayId(for: userSent.id, in: messages), userSent.id)
+        XCTAssertEqual(TranscriptItems.displayId(for: assistantSent.id, in: messages), assistantSent.id)
+    }
+
+    func test_displayId_queuedMessage_returnsMarkerAnchorId() {
+        let userSent = userMessage(text: "hello", status: .sent)
+        let queued1 = userMessage(text: "q1", status: .queued(position: 1))
+        let queued2 = userMessage(text: "q2", status: .queued(position: 2))
+        let messages = [userSent, queued1, queued2]
+
+        // Both queued messages resolve to the first queued message's id,
+        // which is the marker's anchor id.
+        XCTAssertEqual(TranscriptItems.displayId(for: queued1.id, in: messages), queued1.id)
+        XCTAssertEqual(TranscriptItems.displayId(for: queued2.id, in: messages), queued1.id)
+    }
+
+    func test_displayId_missingMessageId_returnsNil() {
+        let messages = [userMessage(text: "hi")]
+        XCTAssertNil(TranscriptItems.displayId(for: UUID(), in: messages))
+    }
 }

--- a/clients/shared/Features/Chat/TranscriptItems.swift
+++ b/clients/shared/Features/Chat/TranscriptItems.swift
@@ -78,4 +78,33 @@ public enum TranscriptItems {
         }
         return result
     }
+
+    /// Resolves a raw message ID to the ID of the transcript item that
+    /// actually renders it. Queued user messages are collapsed into the
+    /// `queuedMarker`, so scrolling or flashing their original IDs is a
+    /// no-op — callers that target IDs from the full `messages` array
+    /// must route through this helper before handing the ID to
+    /// `scrollTo(id:)` or the highlight binding.
+    ///
+    /// - Returns: The `queuedMarker` anchor ID when `messageId` belongs to
+    ///   a collapsed queued user message; `messageId` otherwise. Returns
+    ///   `nil` if the ID isn't present in `messages`.
+    public static func displayId(for messageId: UUID, in messages: [ChatMessage]) -> UUID? {
+        guard let target = messages.first(where: { $0.id == messageId }) else {
+            return nil
+        }
+        let isQueuedUser: Bool = {
+            guard target.role == .user else { return false }
+            if case .queued = target.status { return true }
+            return false
+        }()
+        guard isQueuedUser else { return messageId }
+        // The marker's anchor ID is the first queued user message's ID.
+        for message in messages {
+            if message.role == .user, case .queued = message.status {
+                return message.id
+            }
+        }
+        return messageId
+    }
 }


### PR DESCRIPTION
## Summary

Address review feedback on #25316.

**Fix 1 (Codex P2) — anchor/navigation for collapsed queued messages.** In-chat search sets `anchorMessageId` from the full `messages` array, but queued user messages are collapsed into a single `queuedMarker` and not rendered in `displayedItems`. When the anchor target is a queued message, `scrollTo(id:)` silently no-ops while the anchor is cleared as if it succeeded.

Fix approach (option a, the most user-friendly): added `TranscriptItems.displayId(for:in:)` — a helper that resolves a message ID to the ID of whatever transcript item actually renders it. If the message is a queued user bubble, returns the `queuedMarker`'s anchor ID; otherwise returns the ID unchanged. Callers in `MessageListView+Lifecycle` (handleAppear, handleMessagesCountChanged, handleAnchorMessageTask) now route through this helper before calling `scrollTo(id:)`. The viewport now lands on the queue marker when the search hit is inside a queued message, instead of silently failing.

**Fix 2 (Devin) — `estimatedUserHeight` uses collapsed queued message.** `state.rows.last(where: { \$0.message.role == .user })` was picking up queued user messages whose bubbles are never rendered, over-estimating the user content height and making `turnMinHeight` too small (sent message fails to pin at top during an active turn).

Fixed by skipping queued user rows in the `last(where:)` predicate, and adding a ~40pt marker offset when any queued messages exist (the `QueuedMessagesMarker` sits between the sent user bubble and the assistant block).

## Files modified
- `clients/shared/Features/Chat/TranscriptItems.swift` — new `displayId(for:in:)` helper
- `clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift` — route anchor resolution through the helper at all three callsites
- `clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift` — skip queued user messages in `estimatedUserHeight`; add marker offset
- `clients/macos/vellum-assistantTests/TranscriptItemsTests.swift` — tests for the new helper

## Test plan
- [x] `xcrun swiftc -parse` on touched files clean
- [ ] Manual: in-chat search for text inside a queued message → viewport lands on the queue marker
- [ ] Manual: send "hi" then queue a long follow-up → sent "hi" stays pinned at top during the active turn
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25328" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
