### PR TITLE
fix(drain): address batched-drain review feedback from #25303

### DIFF
--- a/assistant/src/__tests__/conversation-queue.test.ts
+++ b/assistant/src/__tests__/conversation-queue.test.ts
@@ -1460,6 +1460,64 @@ describe("Batched drain correctness fixes", () => {
     await new Promise((r) => setTimeout(r, 20));
   });
 
+  test("failed tail persist is excluded from fanOutOnEvent agent events", async () => {
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
+
+    const events1: ServerMessage[] = [];
+    const events2: ServerMessage[] = [];
+    const events3: ServerMessage[] = [];
+    const events4: ServerMessage[] = [];
+
+    const p1 = conversation.processMessage(
+      "msg-1",
+      [],
+      (e) => events1.push(e),
+      "req-1",
+    );
+    await waitForPendingRun(1);
+
+    // Mid tail will fail to persist. After the batched run resolves,
+    // message_complete (broadcast via fanOutOnEvent) must NOT land on the
+    // failed mid tail — it already received an error event and persisting
+    // the assistant reply for a user message that has no DB row would
+    // desync the client.
+    addMessageShouldThrowForContent.add("fanout-mid-marker");
+
+    conversation.enqueueMessage(
+      "fanout-head",
+      [],
+      (e) => events2.push(e),
+      "req-fanout-head",
+    );
+    conversation.enqueueMessage(
+      "fanout-mid-marker",
+      [],
+      (e) => events3.push(e),
+      "req-fanout-mid",
+    );
+    conversation.enqueueMessage(
+      "fanout-tail",
+      [],
+      (e) => events4.push(e),
+      "req-fanout-tail",
+    );
+
+    resolveRun(0);
+    await p1;
+    await waitForPendingRun(2);
+
+    // Drive the batched run to emit message_complete via fanOutOnEvent.
+    resolveRun(1);
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(events3.find((e) => e.type === "error")).toBeDefined();
+    expect(events3.find((e) => e.type === "message_complete")).toBeUndefined();
+
+    expect(events2.find((e) => e.type === "message_complete")).toBeDefined();
+    expect(events4.find((e) => e.type === "message_complete")).toBeDefined();
+  });
+
   test("drainBatch emits exactly one activity-state event for the whole batch", async () => {
     const activityStates: ServerMessage[] = [];
     const conversation = makeConversation((msg) => {

--- a/assistant/src/__tests__/conversation-slash-commands.test.ts
+++ b/assistant/src/__tests__/conversation-slash-commands.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  classifySlash,
   resolveSlash,
   type SlashContext,
 } from "../daemon/conversation-slash.js";
@@ -147,4 +148,36 @@ describe("resolveSlash command contract", () => {
     }
     expect(result.message).toContain("Pairing is not available");
   });
+});
+
+describe("classifySlash is a pure classifier matching resolveSlash kinds", () => {
+  // Lookahead in `buildPassthroughBatch` must not run `resolveSlash`'s side
+  // effects (/pair registers a pairing request and writes a QR PNG). The
+  // pure classifier is synchronous, takes no side-effecting dependencies,
+  // and must agree with resolveSlash's `kind`.
+  const cases: Array<{ input: string; kind: "passthrough" | "compact" | "unknown" }> = [
+    { input: "/pair", kind: "unknown" },
+    { input: "/models", kind: "unknown" },
+    { input: "/status", kind: "unknown" },
+    { input: "/commands", kind: "unknown" },
+    { input: "/compact", kind: "compact" },
+    { input: "/model", kind: "unknown" },
+    { input: "/model foo", kind: "unknown" },
+    { input: "/opus", kind: "unknown" },
+    { input: "hello", kind: "passthrough" },
+    { input: "  /compact  ", kind: "compact" },
+    { input: "/pair foo", kind: "passthrough" },
+    { input: "/models foo", kind: "passthrough" },
+  ];
+
+  for (const { input, kind } of cases) {
+    test(`classifies ${JSON.stringify(input)} as ${kind}`, async () => {
+      expect(classifySlash(input)).toBe(kind);
+      const resolved = await resolveSlash(
+        input,
+        makeSlashContext({ userMessageInterface: "macos" }),
+      );
+      expect(resolved.kind).toBe(kind);
+    });
+  }
 });

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -43,7 +43,11 @@ import type {
   ChannelCapabilities,
   TrustContext,
 } from "./conversation-runtime-assembly.js";
-import { resolveSlash, type SlashContext } from "./conversation-slash.js";
+import {
+  classifySlash,
+  resolveSlash,
+  type SlashContext,
+} from "./conversation-slash.js";
 import { getModelInfo } from "./handlers/config-model.js";
 import type {
   ServerMessage,
@@ -284,13 +288,13 @@ async function buildPassthroughBatch(
     head,
     conversation.getTurnInterfaceContext(),
   );
-  const headSlash = await resolveSlash(
-    head.content,
-    buildSlashContext(conversation),
-  );
-  if (headSlash.kind !== "passthrough") return [];
+  // Pure classifier — no side effects. `resolveSlash` runs /pair's side
+  // effects (pairing registration, QR PNG write); if we called it here the
+  // real drain would invoke those again and the second call would fail with
+  // "active pairing already in progress".
+  if (classifySlash(head.content) !== "passthrough") return [];
   if (
-    resolveVerificationSessionIntent(headSlash.content).kind === "direct_setup"
+    resolveVerificationSessionIntent(head.content).kind === "direct_setup"
   ) {
     // Verification intents stay on the single-message path so their per-turn
     // skill preactivation isn't leaked into batched tail messages.
@@ -320,13 +324,9 @@ async function buildPassthroughBatch(
     // otherwise diverge.
     if (candIf?.userMessageInterface !== headInterface?.userMessageInterface)
       break;
-    const candSlash = await resolveSlash(
-      candidate.content,
-      buildSlashContext(conversation),
-    );
-    if (candSlash.kind !== "passthrough") break;
+    if (classifySlash(candidate.content) !== "passthrough") break;
     if (
-      resolveVerificationSessionIntent(candSlash.content).kind ===
+      resolveVerificationSessionIntent(candidate.content).kind ===
       "direct_setup"
     )
       break;
@@ -987,6 +987,11 @@ async function drainBatch(
   let lastSuccessfulCurrentPage: string | undefined;
   let lastSuccessfulContent: string | undefined;
   let lastUserMessageId: string | undefined;
+  // Members whose persist succeeded. `fanOutOnEvent` below must only
+  // broadcast agent-loop events to these — clients whose persist failed
+  // already received an error event and must not also receive the
+  // assistant's streaming response for a turn that isn't theirs.
+  const successfulBatch: QueuedMessage[] = [];
   for (let i = 0; i < batch.length; i++) {
     const qm = batch[i];
     qm.onEvent({
@@ -1127,6 +1132,7 @@ async function drainBatch(
     lastSuccessfulActiveSurfaceId = qm.activeSurfaceId;
     lastSuccessfulCurrentPage = qm.currentPage;
     lastSuccessfulContent = qmContent;
+    successfulBatch.push(qm);
 
     // Fire-and-forget: detect notification preferences in each batched user
     // message and persist any that are found, mirroring drainSingleMessage.
@@ -1198,8 +1204,12 @@ async function drainBatch(
   conversation.currentActiveSurfaceId = lastSuccessfulActiveSurfaceId;
   conversation.currentPage = lastSuccessfulCurrentPage;
 
+  // Broadcast agent-loop events only to members whose persist succeeded.
+  // Members whose persist failed already received an error event in the
+  // catch block above; sending them the assistant's streaming response
+  // would surface a reply for a user message that isn't in their DB.
   const fanOutOnEvent = (msg: ServerMessage) => {
-    for (const qm of batch) qm.onEvent(msg);
+    for (const qm of successfulBatch) qm.onEvent(msg);
   };
 
   const drainLoopOptions: {
@@ -1209,9 +1219,10 @@ async function drainBatch(
   } = { isUserMessage: true };
   // Source interactive flag from the last successfully-persisted sibling so
   // a trailing failed tail doesn't flip the agent loop's interactivity.
-  const lastSuccessfulBatchEntry = batch.find(
-    (qm) => qm.requestId === lastSuccessfulRequestId,
-  );
+  const lastSuccessfulBatchEntry =
+    successfulBatch.length > 0
+      ? successfulBatch[successfulBatch.length - 1]
+      : undefined;
   if (lastSuccessfulBatchEntry?.isInteractive !== undefined)
     drainLoopOptions.isInteractive = lastSuccessfulBatchEntry.isInteractive;
 

--- a/assistant/src/daemon/conversation-slash.ts
+++ b/assistant/src/daemon/conversation-slash.ts
@@ -173,6 +173,42 @@ function resolveCommandsList(context?: SlashContext): string[] {
 }
 
 /**
+ * Pure classifier: returns the kind of slash resolution `resolveSlash` would
+ * produce for `content`, without triggering any side effects.
+ *
+ * Queue-drain lookahead (`buildPassthroughBatch`) uses this to decide whether
+ * to include a queued message in a contiguous passthrough batch. `resolveSlash`
+ * itself runs side effects (e.g. `/pair` registers a pairing request and
+ * writes a QR PNG), so calling it during lookahead and then again in the real
+ * drain would execute those side effects twice — the second call sees the
+ * first registration and fails with "active pairing already in progress".
+ */
+export function classifySlash(
+  content: string,
+): "passthrough" | "compact" | "unknown" {
+  const trimmed = content.trim();
+  if (
+    trimmed === "/model" ||
+    (trimmed.startsWith("/model ") && trimmed !== "/models")
+  ) {
+    return "unknown";
+  }
+  const shortcutMatch = trimmed.match(/^\/([a-z0-9-]+)(\s|$)/i);
+  if (
+    shortcutMatch &&
+    DEPRECATED_MODEL_SHORTCUTS.has(shortcutMatch[1].toLowerCase())
+  ) {
+    return "unknown";
+  }
+  if (trimmed === "/models") return "unknown";
+  if (trimmed === "/pair") return "unknown";
+  if (trimmed === "/compact") return "compact";
+  if (trimmed === "/status") return "unknown";
+  if (trimmed === "/commands") return "unknown";
+  return "passthrough";
+}
+
+/**
  * Resolve built-in slash commands (/models, /status, /commands, /compact, /pair).
  * Returns `unknown` with a deterministic message, `compact` for forced compaction,
  * or the (possibly rewritten) content as `passthrough`.


### PR DESCRIPTION
## Summary

Addresses the remaining reviewer feedback on #25303. Two of the three items were already covered by follow-up PRs; this PR handles what's left.

### Feedback 1 (Codex P1) — resolveSlash side effects in batch lookahead
\`buildPassthroughBatch\` previously called \`resolveSlash\` on the head and each candidate during lookahead. \`resolveSlash\` has side effects — \`/pair\` registers a pairing request and writes a QR PNG — so the real drain re-running resolveSlash saw the first pairing still active and surfaced \"active pairing already in progress\" to the user.

Fix: split a pure \`classifySlash(content)\` classifier out of \`resolveSlash\`. Lookahead uses the classifier (no side effects); the real drain continues to use \`resolveSlash\`, so /pair's registration runs exactly once.

### Feedback 2 (Codex P1) — persistQueuedMessageBody rollback in batched tail
**Already addressed by #25297** (\`refactor(messaging): honor persistQueuedMessageBody contract by hoisting processing-state cleanup\`). \`persistQueuedMessageBody\` no longer clears \`ctx.processing\` / \`ctx.abortController\` on error — that cleanup lives in \`persistUserMessage\` which is only used for the head.

### Feedback 3 (Devin) — fanOutOnEvent sends agent events to failed batch members
**Partially addressed by #25320**: last-successful tracking for \`currentRequestId\` / \`currentActiveSurfaceId\` / \`currentPage\` / \`isInteractive\` was already in place. But \`fanOutOnEvent\` still iterated the full \`batch\` array, so clients whose tail persist failed also received the assistant's streaming response for a turn that wasn't theirs.

Fix: track successful persists in a parallel \`successfulBatch\` and fan out agent-loop events to that array instead. Also source \`lastSuccessfulBatchEntry\` directly from its tail rather than searching \`batch\` by requestId.

## Test plan
- [x] \`bun test src/__tests__/conversation-queue.test.ts\` (49 pass, 1 pre-existing todo)
- [x] \`bun test src/__tests__/conversation-slash-commands.test.ts\` (21 pass — adds classifier/resolver parity cases)
- [x] \`bunx tsc --noEmit\` clean
- [x] \`bun run lint\` clean
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25329" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
