### PR TITLE
fix(chat): use stable sentinel id for queue marker to avoid re-mount on dequeue

### DIFF
--- a/clients/ios/Tests/TranscriptItemsIOSTests.swift
+++ b/clients/ios/Tests/TranscriptItemsIOSTests.swift
@@ -35,8 +35,12 @@ final class TranscriptItemsIOSTests: XCTestCase {
         XCTAssertEqual(result.count, 4)
         XCTAssertEqual(result[0], .message(assistantSent))
         XCTAssertEqual(result[1], .message(userSent))
-        XCTAssertEqual(result[2], .queuedMarker(count: 2, anchorId: userQueued1.id))
+        XCTAssertEqual(result[2], .queuedMarker(count: 2))
         XCTAssertEqual(result[3], .message(assistantSent2))
+        // The marker's id is the stable sentinel — not the first queued
+        // message's id — so SwiftUI keeps the same row across queue mutations.
+        XCTAssertEqual(result[2].id, TranscriptItems.queueMarkerId)
+        XCTAssertNotEqual(result[2].id, userQueued1.id)
     }
 
     func test_transcriptItems_noQueuedMessagesYieldsOriginalList() {
@@ -68,6 +72,7 @@ final class TranscriptItemsIOSTests: XCTestCase {
         XCTAssertEqual(result.count, 3)
         XCTAssertEqual(result[0], .message(assistantSent))
         XCTAssertEqual(result[1], .message(userSent))
-        XCTAssertEqual(result.last, .queuedMarker(count: 3, anchorId: queued1.id))
+        XCTAssertEqual(result.last, .queuedMarker(count: 3))
+        XCTAssertEqual(result.last?.id, TranscriptItems.queueMarkerId)
     }
 }

--- a/clients/ios/Views/ChatContentView.swift
+++ b/clients/ios/Views/ChatContentView.swift
@@ -417,9 +417,11 @@ struct ChatContentView: View {
         indexByMessageId: [UUID: Int]
     ) -> some View {
         switch item {
-        case .queuedMarker(let count, let anchorId):
+        case .queuedMarker(let count):
+            // No `.id(...)` needed — the enclosing `ForEach` keys rows by
+            // `TranscriptItem.id`, and `.queuedMarker` returns the stable
+            // sentinel `TranscriptItems.queueMarkerId`.
             QueuedMessagesMarker_iOS(count: count)
-                .id(anchorId)
         case .message(let message):
             // Safe: every `.message` in the collapsed transcript originates
             // from `messages`, so the index lookup is always present.

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
@@ -314,7 +314,7 @@ struct MessageListContentView: View, Equatable {
             let displayedItems = TranscriptItems.build(from: state.rows.map(\.message))
             ForEach(displayedItems) { item in
                 switch item {
-                case .queuedMarker(let count, _):
+                case .queuedMarker(let count):
                     QueuedMessagesMarker(count: count)
                 case .message(let message):
                     // Safe: every displayed message originates from `state.rows`

--- a/clients/macos/vellum-assistantTests/TranscriptItemsTests.swift
+++ b/clients/macos/vellum-assistantTests/TranscriptItemsTests.swift
@@ -31,8 +31,13 @@ final class TranscriptItemsTests: XCTestCase {
         XCTAssertEqual(result.count, 4)
         XCTAssertEqual(result[0], .message(assistantSent))
         XCTAssertEqual(result[1], .message(userSent))
-        XCTAssertEqual(result[2], .queuedMarker(count: 2, anchorId: userQueued1.id))
+        XCTAssertEqual(result[2], .queuedMarker(count: 2))
         XCTAssertEqual(result[3], .message(assistantSent2))
+        // The marker uses the stable sentinel id, not any message id, so
+        // SwiftUI keeps the same view across queue mutations (e.g. when the
+        // head dequeues and the "first queued message" changes).
+        XCTAssertEqual(result[2].id, TranscriptItems.queueMarkerId)
+        XCTAssertNotEqual(result[2].id, userQueued1.id)
     }
 
     func test_transcriptItems_noQueuedMessagesYieldsOriginalList() {
@@ -64,14 +69,19 @@ final class TranscriptItemsTests: XCTestCase {
         XCTAssertEqual(result.count, 3)
         XCTAssertEqual(result[0], .message(assistantSent))
         XCTAssertEqual(result[1], .message(userSent))
-        XCTAssertEqual(result.last, .queuedMarker(count: 3, anchorId: queued1.id))
+        XCTAssertEqual(result.last, .queuedMarker(count: 3))
+        XCTAssertEqual(result.last?.id, TranscriptItems.queueMarkerId)
     }
 
     // MARK: - Identity
 
-    func test_transcriptItem_id_marker_usesAnchorId() {
-        let anchor = UUID()
-        XCTAssertEqual(TranscriptItem.queuedMarker(count: 2, anchorId: anchor).id, anchor)
+    func test_transcriptItem_id_marker_usesStableSentinel() {
+        // The marker's identity must be a constant sentinel — not a message
+        // id — so SwiftUI `ForEach` / animation diffing treats it as the same
+        // view across queue mutations (e.g. when the head of the queue
+        // dequeues, the "first queued message" id would otherwise change).
+        XCTAssertEqual(TranscriptItem.queuedMarker(count: 2).id, TranscriptItems.queueMarkerId)
+        XCTAssertEqual(TranscriptItem.queuedMarker(count: 7).id, TranscriptItems.queueMarkerId)
     }
 
     func test_transcriptItem_id_message_usesMessageId() {
@@ -90,7 +100,8 @@ final class TranscriptItemsTests: XCTestCase {
 
         XCTAssertEqual(result.count, 2)
         XCTAssertEqual(result[0], .message(assistantSent))
-        XCTAssertEqual(result[1], .queuedMarker(count: 1, anchorId: queued.id))
+        XCTAssertEqual(result[1], .queuedMarker(count: 1))
+        XCTAssertEqual(result[1].id, TranscriptItems.queueMarkerId)
     }
 
     func test_transcriptItems_queuedAssistantMessage_isNotCollapsed() {

--- a/clients/shared/Features/Chat/TranscriptItems.swift
+++ b/clients/shared/Features/Chat/TranscriptItems.swift
@@ -9,19 +9,22 @@ import Foundation
 ///
 /// - `message`: a regular chat message that should be rendered as a bubble.
 /// - `queuedMarker`: a collapsed placeholder standing in for one or more
-///   queued user messages. The `anchorId` is the id of the first collapsed
-///   queued message so the marker has a stable identity across re-projections
-///   (used by SwiftUI `ForEach` / animation diffing).
+///   queued user messages. Its identity is `TranscriptItems.queueMarkerId`,
+///   a constant sentinel UUID, so SwiftUI `ForEach` / animation diffing
+///   treats the marker as the same view across queue mutations (e.g. when
+///   the head of the queue dequeues and the "first queued message" id
+///   would otherwise change). Mirrors the
+///   `TranscriptProjector.thinkingPlaceholderId` pattern.
 public enum TranscriptItem: Equatable, Identifiable {
     case message(ChatMessage)
-    case queuedMarker(count: Int, anchorId: UUID)
+    case queuedMarker(count: Int)
 
     public var id: UUID {
         switch self {
         case .message(let message):
             return message.id
-        case .queuedMarker(_, let anchorId):
-            return anchorId
+        case .queuedMarker:
+            return TranscriptItems.queueMarkerId
         }
     }
 }
@@ -40,6 +43,13 @@ public enum TranscriptItem: Equatable, Identifiable {
 /// Non-queued messages (and assistant messages in general) pass through
 /// unchanged.
 public enum TranscriptItems {
+
+    /// Stable sentinel UUID for the queued-messages marker so SwiftUI `ForEach`
+    /// maintains view identity across queue mutations (in particular when the
+    /// head of the queue dequeues and the "first queued message" id would
+    /// otherwise change). Mirrors `TranscriptProjector.thinkingPlaceholderId`.
+    /// Must not collide with real message IDs.
+    public static let queueMarkerId = UUID(uuidString: "00000000-0000-0000-0000-0000000055EE")!
 
     /// Builds the ordered list of transcript items to display.
     ///
@@ -68,7 +78,7 @@ public enum TranscriptItems {
             }()
             if isQueuedUser {
                 if !markerInserted {
-                    result.append(.queuedMarker(count: queuedCount, anchorId: message.id))
+                    result.append(.queuedMarker(count: queuedCount))
                     markerInserted = true
                 }
                 // Otherwise: collapse into the already-inserted marker.


### PR DESCRIPTION
## Summary
Addresses gap identified during plan review for queue-drawer-edit-cancel.md.

**Gap**: The queue marker's `anchorId` was derived from the first queued message's id. When the head of the queue dequeued, the id changed, causing SwiftUI to re-mount the marker row (animation thrash, potential scroll-anchor confusion).

- Drops `anchorId` from `.queuedMarker` associated values.
- Adds a constant sentinel UUID `TranscriptItems.queueMarkerId`, mirroring the existing `thinkingPlaceholderId` pattern.
- Updates macOS + iOS renderers (`.id(anchorId)` removed — `ForEach` identity already uses `item.id`).
- Updates unit tests to assert the sentinel.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25330" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
