### PR TITLE
fix(drawer): cache queuedMessages and tailQueuedMessageId in both drawers

### DIFF
--- a/clients/ios/Views/QueuedMessagesDrawer_iOS.swift
+++ b/clients/ios/Views/QueuedMessagesDrawer_iOS.swift
@@ -16,26 +16,31 @@ struct QueuedMessagesDrawer_iOS: View {
     @Binding var composerAttachments: [ChatAttachment]
 
     var body: some View {
-        if viewModel.queuedMessages.isEmpty {
+        // Cache `queuedMessages` and `tailQueuedMessageId` once per render —
+        // both run filter+sorted on access (and `tailQueuedMessageId` is O(N)
+        // and called per row via `isTail`).
+        let queuedMessages = viewModel.queuedMessages
+        let tailId = viewModel.tailQueuedMessageId
+        if queuedMessages.isEmpty {
             EmptyView()
         } else {
-            container
+            container(queuedMessages: queuedMessages, tailId: tailId)
         }
     }
 
-    private var container: some View {
+    private func container(queuedMessages: [ChatMessage], tailId: UUID?) -> some View {
         VStack(alignment: .leading, spacing: VSpacing.sm) {
-            header
+            header(queuedMessages: queuedMessages)
 
             LazyVStack(spacing: 0) {
                 ForEach(
-                    Array(viewModel.queuedMessages.enumerated()),
+                    Array(queuedMessages.enumerated()),
                     id: \.element.id
                 ) { index, message in
                     QueuedMessageRow_iOS(
                         message: message,
                         positionLabel: "#\(index + 1)",
-                        isTail: message.id == viewModel.tailQueuedMessageId,
+                        isTail: message.id == tailId,
                         onEdit: {
                             viewModel.editQueuedTail(
                                 into: $composerText,
@@ -54,7 +59,7 @@ struct QueuedMessagesDrawer_iOS: View {
             }
             .animation(
                 .spring(duration: 0.28, bounce: 0.15),
-                value: viewModel.queuedMessages.map(\.id)
+                value: queuedMessages.map(\.id)
             )
         }
         .padding(VSpacing.md)
@@ -69,16 +74,16 @@ struct QueuedMessagesDrawer_iOS: View {
         .padding(.horizontal, VSpacing.md)
     }
 
-    private var header: some View {
+    private func header(queuedMessages: [ChatMessage]) -> some View {
         HStack {
-            Text("Queue · \(viewModel.queuedMessages.count)")
+            Text("Queue · \(queuedMessages.count)")
                 .font(VFont.labelDefault)
                 .foregroundStyle(VColor.contentSecondary)
 
             Spacer()
 
             Button("Cancel all") {
-                for message in viewModel.queuedMessages {
+                for message in queuedMessages {
                     viewModel.deleteQueuedMessage(messageId: message.id)
                 }
             }

--- a/clients/macos/vellum-assistant/Features/Chat/QueuedMessagesDrawer.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/QueuedMessagesDrawer.swift
@@ -16,17 +16,22 @@ struct QueuedMessagesDrawer: View {
     @Binding var composerAttachments: [ChatAttachment]
 
     var body: some View {
-        if viewModel.queuedMessages.isEmpty {
+        // Cache `queuedMessages` and `tailQueuedMessageId` once per render —
+        // both run filter+sorted on access (and `tailQueuedMessageId` is O(N)
+        // and called per row via `isTail`).
+        let queuedMessages = viewModel.queuedMessages
+        let tailId = viewModel.tailQueuedMessageId
+        if queuedMessages.isEmpty {
             EmptyView()
         } else {
-            drawerBody
+            drawerBody(queuedMessages: queuedMessages, tailId: tailId)
         }
     }
 
-    private var drawerBody: some View {
+    private func drawerBody(queuedMessages: [ChatMessage], tailId: UUID?) -> some View {
         VStack(alignment: .leading, spacing: VSpacing.sm) {
-            header
-            rows
+            header(queuedMessages: queuedMessages)
+            rows(queuedMessages: queuedMessages, tailId: tailId)
         }
         .padding(VSpacing.md)
         .background(
@@ -41,15 +46,15 @@ struct QueuedMessagesDrawer: View {
         .frame(maxWidth: .infinity, alignment: .center)
     }
 
-    private var header: some View {
+    private func header(queuedMessages: [ChatMessage]) -> some View {
         HStack {
-            Text("Queue · \(viewModel.queuedMessages.count)")
+            Text("Queue · \(queuedMessages.count)")
                 .font(VFont.labelDefault)
                 .foregroundStyle(VColor.contentSecondary)
 
             Spacer(minLength: VSpacing.sm)
 
-            Button(action: cancelAll) {
+            Button(action: { cancelAll(queuedMessages: queuedMessages) }) {
                 Text("Cancel all")
                     .font(VFont.labelDefault)
                     .foregroundStyle(VColor.contentSecondary)
@@ -59,13 +64,13 @@ struct QueuedMessagesDrawer: View {
         }
     }
 
-    private var rows: some View {
+    private func rows(queuedMessages: [ChatMessage], tailId: UUID?) -> some View {
         VStack(alignment: .leading, spacing: VSpacing.xs) {
-            ForEach(Array(viewModel.queuedMessages.enumerated()), id: \.element.id) { index, message in
+            ForEach(Array(queuedMessages.enumerated()), id: \.element.id) { index, message in
                 QueuedMessageRow(
                     message: message,
                     positionLabel: "#\(index + 1)",
-                    isTail: message.id == viewModel.tailQueuedMessageId,
+                    isTail: message.id == tailId,
                     onEdit: {
                         viewModel.editQueuedTail(
                             into: $composerText,
@@ -84,12 +89,12 @@ struct QueuedMessagesDrawer: View {
         }
         .animation(
             .spring(duration: 0.28, bounce: 0.15),
-            value: viewModel.queuedMessages.map(\.id)
+            value: queuedMessages.map(\.id)
         )
     }
 
-    private func cancelAll() {
-        for message in viewModel.queuedMessages {
+    private func cancelAll(queuedMessages: [ChatMessage]) {
+        for message in queuedMessages {
             viewModel.deleteQueuedMessage(messageId: message.id)
         }
     }


### PR DESCRIPTION
## Summary
Addresses gap identified during plan review for queue-drawer-edit-cancel.md.

The iOS `ChatContentView` portion of the original gap was resolved independently on main (#25323 landed a strictly-better version with cascade-suppressing `.animation(nil, ...)` on siblings), so this PR scopes to the remaining drawer caching work.

- Both `QueuedMessagesDrawer` (macOS) and `QueuedMessagesDrawer_iOS` now cache `queuedMessages` and `tailQueuedMessageId` once per render instead of re-running `filter+sorted` on every access — `tailQueuedMessageId` is O(N) and was being called per row via `isTail`.