### PR TITLE
fix(chat): guard editQueuedTail against clobbering composer draft, disable edit button when composer non-empty

### DIFF
--- a/clients/ios/Tests/ChatViewModelIOSTests.swift
+++ b/clients/ios/Tests/ChatViewModelIOSTests.swift
@@ -709,6 +709,122 @@ final class ChatViewModelIOSTests: XCTestCase {
         XCTAssertTrue(composerAttachments.isEmpty, "Attachments binding should not be modified when queue is empty")
         XCTAssertTrue(mockQueueClient.calls.isEmpty, "No delete_queued_message call should be dispatched")
     }
+
+    func test_editQueuedTail_whenComposerNonEmpty_isNoOp() async {
+        // Regression guard for the one-tap composer-clobber bug: tapping the
+        // pencil with an in-progress draft must not overwrite text or
+        // attachments, and must not dispatch a delete_queued_message.
+        let mockQueueClient = MockConversationQueueClient()
+        mockQueueClient.deleteResult = true
+
+        let connection = GatewayConnectionManager()
+        connection.isConnected = true
+        let vm = ChatViewModel(
+            connectionManager: connection,
+            eventStreamClient: connection.eventStreamClient,
+            conversationQueueClient: mockQueueClient
+        )
+        vm.conversationId = "sess-guard-ios"
+
+        let queuedAttachment = ChatAttachment(
+            id: "queued-att",
+            filename: "queued.txt",
+            mimeType: "text/plain",
+            data: "cXVldWVk",
+            thumbnailData: nil,
+            dataLength: 6,
+            thumbnailImage: nil
+        )
+        var tail = ChatMessage(role: .user, text: "Tail content", status: .queued(position: 0))
+        tail.attachments = [queuedAttachment]
+        vm.messages = [tail]
+        vm.requestIdToMessageId = ["req-tail": tail.id]
+        vm.pendingQueuedCount = 1
+
+        let draftAttachment = ChatAttachment(
+            id: "draft-att",
+            filename: "draft.txt",
+            mimeType: "text/plain",
+            data: "ZHJhZnQ=",
+            thumbnailData: nil,
+            dataLength: 5,
+            thumbnailImage: nil
+        )
+
+        // Case A: composer has text only.
+        var composerText = "in-progress draft"
+        var composerAttachments: [ChatAttachment] = []
+        var textBinding = Binding<String>(
+            get: { composerText },
+            set: { composerText = $0 }
+        )
+        var attachmentsBinding = Binding<[ChatAttachment]>(
+            get: { composerAttachments },
+            set: { composerAttachments = $0 }
+        )
+
+        vm.editQueuedTail(into: textBinding, attachments: attachmentsBinding)
+
+        try? await Task.sleep(for: .milliseconds(50))
+
+        XCTAssertEqual(composerText, "in-progress draft",
+                       "Composer text must not be overwritten when a draft is present")
+        XCTAssertTrue(composerAttachments.isEmpty,
+                      "Attachments binding must not be populated when composer has draft text")
+        XCTAssertTrue(mockQueueClient.calls.isEmpty,
+                      "No delete_queued_message must be dispatched while composer has content")
+
+        // Case B: composer has attachments only (no text).
+        composerText = ""
+        composerAttachments = [draftAttachment]
+        textBinding = Binding<String>(
+            get: { composerText },
+            set: { composerText = $0 }
+        )
+        attachmentsBinding = Binding<[ChatAttachment]>(
+            get: { composerAttachments },
+            set: { composerAttachments = $0 }
+        )
+
+        vm.editQueuedTail(into: textBinding, attachments: attachmentsBinding)
+
+        try? await Task.sleep(for: .milliseconds(50))
+
+        XCTAssertEqual(composerText, "",
+                       "Composer text must remain empty when only attachments are staged")
+        XCTAssertEqual(composerAttachments.count, 1)
+        XCTAssertEqual(composerAttachments.first?.id, "draft-att",
+                       "Staged attachment must not be overwritten by the queued attachment")
+        XCTAssertTrue(mockQueueClient.calls.isEmpty,
+                      "No delete_queued_message must be dispatched while composer has attachments")
+
+        // Case C: composer has whitespace-only text — still treated as empty,
+        // so the guard should permit the overwrite.
+        composerText = "   \n  "
+        composerAttachments = []
+        textBinding = Binding<String>(
+            get: { composerText },
+            set: { composerText = $0 }
+        )
+        attachmentsBinding = Binding<[ChatAttachment]>(
+            get: { composerAttachments },
+            set: { composerAttachments = $0 }
+        )
+
+        vm.editQueuedTail(into: textBinding, attachments: attachmentsBinding)
+
+        let deadline = ContinuousClock.now + .seconds(2)
+        while mockQueueClient.calls.isEmpty && ContinuousClock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+
+        XCTAssertEqual(composerText, "Tail content",
+                       "Whitespace-only composer should be treated as empty and accept the overwrite")
+        XCTAssertEqual(composerAttachments.count, 1)
+        XCTAssertEqual(composerAttachments.first?.id, "queued-att")
+        XCTAssertEqual(mockQueueClient.calls.count, 1,
+                       "Whitespace-only composer should permit the delete_queued_message dispatch")
+    }
 }
 
 // MARK: - Test Doubles

--- a/clients/ios/Views/QueuedMessageRow_iOS.swift
+++ b/clients/ios/Views/QueuedMessageRow_iOS.swift
@@ -9,10 +9,17 @@ import VellumAssistantShared
 ///
 /// Shape mirrors the macOS `QueuedMessageRow` but sized for touch: minimum
 /// 44pt row height and 44x44pt icon hit areas per Apple HIG.
+///
+/// `isComposerEmpty` is provided by the drawer so the pencil button can be
+/// disabled while the composer has user-typed content or staged attachments.
+/// This prevents a one-click data-loss hazard: the underlying view-model guard
+/// already no-ops the call, and disabling the button gives the user clear
+/// visual feedback (and an accessibility hint) before tapping.
 struct QueuedMessageRow_iOS: View {
     let message: ChatMessage
     let positionLabel: String
     let isTail: Bool
+    let isComposerEmpty: Bool
     let onEdit: () -> Void
     let onCancel: () -> Void
 
@@ -45,6 +52,8 @@ struct QueuedMessageRow_iOS: View {
                         accessibilityLabel: "Edit queued message",
                         action: onEdit
                     )
+                    .disabled(!isComposerEmpty)
+                    .accessibilityHint(isComposerEmpty ? "" : "Clear the composer to edit")
                 }
                 QueuedRowIconButton(
                     icon: .x,

--- a/clients/ios/Views/QueuedMessagesDrawer_iOS.swift
+++ b/clients/ios/Views/QueuedMessagesDrawer_iOS.swift
@@ -29,7 +29,12 @@ struct QueuedMessagesDrawer_iOS: View {
     }
 
     private func container(queuedMessages: [ChatMessage], tailId: UUID?) -> some View {
-        VStack(alignment: .leading, spacing: VSpacing.sm) {
+        // Computed once per render so the pencil button can be disabled when
+        // the user has an in-progress composer draft. The view-model guard is
+        // the source of truth, but the disabled state gives visual feedback.
+        let isComposerEmpty = composerText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && composerAttachments.isEmpty
+        return VStack(alignment: .leading, spacing: VSpacing.sm) {
             header(queuedMessages: queuedMessages)
 
             LazyVStack(spacing: 0) {
@@ -41,6 +46,7 @@ struct QueuedMessagesDrawer_iOS: View {
                         message: message,
                         positionLabel: "#\(index + 1)",
                         isTail: message.id == tailId,
+                        isComposerEmpty: isComposerEmpty,
                         onEdit: {
                             viewModel.editQueuedTail(
                                 into: $composerText,

--- a/clients/macos/vellum-assistant/Features/Chat/QueuedMessageRow.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/QueuedMessageRow.swift
@@ -9,10 +9,17 @@ import VellumAssistantShared
 ///
 /// The drawer owns interaction callbacks: `onEdit` is only invoked when the
 /// pencil is visible (`isTail == true`); `onCancel` is always available.
+///
+/// `isComposerEmpty` is provided by the drawer so the pencil button can be
+/// disabled while the composer has user-typed content or staged attachments.
+/// This prevents a one-click data-loss hazard: the underlying view-model guard
+/// already no-ops the call, and disabling the button gives the user clear
+/// visual feedback before clicking.
 struct QueuedMessageRow: View {
     let message: ChatMessage
     let positionLabel: String
     let isTail: Bool
+    let isComposerEmpty: Bool
     let onEdit: () -> Void
     let onCancel: () -> Void
 
@@ -49,9 +56,13 @@ struct QueuedMessageRow: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
 
             // (d) Trailing icon cluster: pencil only when tail, xmark always.
+            // Pencil is disabled when the composer has content so we don't
+            // clobber the user's in-progress draft.
             HStack(spacing: VSpacing.xs) {
                 if isTail {
                     QueuedRowIconButton(icon: .pencil, accessibilityLabel: "Edit queued message", action: onEdit)
+                        .disabled(!isComposerEmpty)
+                        .help(isComposerEmpty ? "Edit queued message" : "Clear the composer to edit")
                 }
                 QueuedRowIconButton(icon: .x, accessibilityLabel: "Cancel queued message", action: onCancel)
             }

--- a/clients/macos/vellum-assistant/Features/Chat/QueuedMessagesDrawer.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/QueuedMessagesDrawer.swift
@@ -65,12 +65,18 @@ struct QueuedMessagesDrawer: View {
     }
 
     private func rows(queuedMessages: [ChatMessage], tailId: UUID?) -> some View {
-        VStack(alignment: .leading, spacing: VSpacing.xs) {
+        // Computed once per render so the pencil button can be disabled when
+        // the user has an in-progress composer draft. The view-model guard is
+        // the source of truth, but the disabled state gives visual feedback.
+        let isComposerEmpty = composerText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && composerAttachments.isEmpty
+        return VStack(alignment: .leading, spacing: VSpacing.xs) {
             ForEach(Array(queuedMessages.enumerated()), id: \.element.id) { index, message in
                 QueuedMessageRow(
                     message: message,
                     positionLabel: "#\(index + 1)",
                     isTail: message.id == tailId,
+                    isComposerEmpty: isComposerEmpty,
                     onEdit: {
                         viewModel.editQueuedTail(
                             into: $composerText,

--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -3158,6 +3158,122 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertTrue(composerAttachments.isEmpty, "Attachments binding should not be modified when queue is empty")
         XCTAssertTrue(mockQueueClient.calls.isEmpty, "No delete_queued_message call should be dispatched")
     }
+
+    func test_editQueuedTail_whenComposerNonEmpty_isNoOp() async {
+        // Regression guard for the one-click composer-clobber bug: clicking the
+        // pencil with an in-progress draft must not overwrite text or
+        // attachments, and must not dispatch a delete_queued_message.
+        let mockQueueClient = MockConversationQueueClient()
+        mockQueueClient.deleteResult = true
+
+        let connection = GatewayConnectionManager()
+        connection.isConnected = true
+        let vm = ChatViewModel(
+            connectionManager: connection,
+            eventStreamClient: connection.eventStreamClient,
+            conversationQueueClient: mockQueueClient
+        )
+        vm.conversationId = "sess-guard"
+
+        let queuedAttachment = ChatAttachment(
+            id: "queued-att",
+            filename: "queued.txt",
+            mimeType: "text/plain",
+            data: "cXVldWVk",
+            thumbnailData: nil,
+            dataLength: 6,
+            thumbnailImage: nil
+        )
+        var tail = ChatMessage(role: .user, text: "Tail content", status: .queued(position: 0))
+        tail.attachments = [queuedAttachment]
+        vm.messages = [tail]
+        vm.requestIdToMessageId = ["req-tail": tail.id]
+        vm.pendingQueuedCount = 1
+
+        let draftAttachment = ChatAttachment(
+            id: "draft-att",
+            filename: "draft.txt",
+            mimeType: "text/plain",
+            data: "ZHJhZnQ=",
+            thumbnailData: nil,
+            dataLength: 5,
+            thumbnailImage: nil
+        )
+
+        // Case A: composer has text only.
+        var composerText = "in-progress draft"
+        var composerAttachments: [ChatAttachment] = []
+        var textBinding = Binding<String>(
+            get: { composerText },
+            set: { composerText = $0 }
+        )
+        var attachmentsBinding = Binding<[ChatAttachment]>(
+            get: { composerAttachments },
+            set: { composerAttachments = $0 }
+        )
+
+        vm.editQueuedTail(into: textBinding, attachments: attachmentsBinding)
+
+        try? await Task.sleep(for: .milliseconds(50))
+
+        XCTAssertEqual(composerText, "in-progress draft",
+                       "Composer text must not be overwritten when a draft is present")
+        XCTAssertTrue(composerAttachments.isEmpty,
+                      "Attachments binding must not be populated when composer has draft text")
+        XCTAssertTrue(mockQueueClient.calls.isEmpty,
+                      "No delete_queued_message must be dispatched while composer has content")
+
+        // Case B: composer has attachments only (no text).
+        composerText = ""
+        composerAttachments = [draftAttachment]
+        textBinding = Binding<String>(
+            get: { composerText },
+            set: { composerText = $0 }
+        )
+        attachmentsBinding = Binding<[ChatAttachment]>(
+            get: { composerAttachments },
+            set: { composerAttachments = $0 }
+        )
+
+        vm.editQueuedTail(into: textBinding, attachments: attachmentsBinding)
+
+        try? await Task.sleep(for: .milliseconds(50))
+
+        XCTAssertEqual(composerText, "",
+                       "Composer text must remain empty when only attachments are staged")
+        XCTAssertEqual(composerAttachments.count, 1)
+        XCTAssertEqual(composerAttachments.first?.id, "draft-att",
+                       "Staged attachment must not be overwritten by the queued attachment")
+        XCTAssertTrue(mockQueueClient.calls.isEmpty,
+                      "No delete_queued_message must be dispatched while composer has attachments")
+
+        // Case C: composer has whitespace-only text — still treated as empty,
+        // so the guard should permit the overwrite.
+        composerText = "   \n  "
+        composerAttachments = []
+        textBinding = Binding<String>(
+            get: { composerText },
+            set: { composerText = $0 }
+        )
+        attachmentsBinding = Binding<[ChatAttachment]>(
+            get: { composerAttachments },
+            set: { composerAttachments = $0 }
+        )
+
+        vm.editQueuedTail(into: textBinding, attachments: attachmentsBinding)
+
+        let deadline = ContinuousClock.now + .seconds(2)
+        while mockQueueClient.calls.isEmpty && ContinuousClock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+
+        XCTAssertEqual(composerText, "Tail content",
+                       "Whitespace-only composer should be treated as empty and accept the overwrite")
+        XCTAssertEqual(composerAttachments.count, 1)
+        XCTAssertEqual(composerAttachments.first?.id, "queued-att")
+        XCTAssertEqual(mockQueueClient.calls.count, 1,
+                       "Whitespace-only composer should permit the delete_queued_message dispatch")
+    }
 }
 
 // MARK: - Mock Queue Client

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1552,10 +1552,18 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
     /// Pop the tail (highest-position) queued message back into the composer
     /// bindings and delete it from the queue. No-op when the queue is empty.
     /// Used by the queue drawer's "edit last queued" affordance.
+    ///
+    /// Guards against clobbering an in-progress composer draft: if the composer
+    /// already has text (post-trim) or attachments, the call is a no-op — no
+    /// overwrite, no delete. Callers should also disable the edit affordance
+    /// when the composer is non-empty so the user gets visual feedback before
+    /// clicking.
     public func editQueuedTail(
         into text: Binding<String>,
         attachments: Binding<[ChatAttachment]>
     ) {
+        guard text.wrappedValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              attachments.wrappedValue.isEmpty else { return }
         guard let tailId = tailQueuedMessageId,
               let message = messages.first(where: { $0.id == tailId }) else { return }
         text.wrappedValue = message.text


### PR DESCRIPTION
## Summary
Addresses gap identified during plan review for queue-drawer-edit-cancel.md.

**Gap**: `editQueuedTail` unconditionally overwrote the composer, destroying any in-progress user input on a single pencil click.

- Guards the VM method: returns early if composer text or attachments are non-empty (no overwrite, no delete).
- Disables the edit button in `QueuedMessageRow` / `QueuedMessageRow_iOS` when the composer has content, with a tooltip/hint explaining why.
- Adds a regression test asserting the guard.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25332" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
