### PR TITLE
feat(home): add tappable TierBadgeView with expand/collapse

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/TierBadgeView.swift
+++ b/clients/macos/vellum-assistant/Features/Home/TierBadgeView.swift
@@ -27,7 +27,7 @@ struct TierBadgeView: View {
             pill
             if isExpanded, let hint = tier.nextTierHint {
                 Text(hint)
-                    .font(.system(size: 12, weight: .regular))
+                    .font(VFont.bodySmallDefault)
                     .foregroundStyle(VColor.contentSecondary)
                     .fixedSize(horizontal: false, vertical: true)
                     .padding(.horizontal, 4)
@@ -36,15 +36,13 @@ struct TierBadgeView: View {
                     )
             }
         }
-        .animation(.spring(response: 0.35, dampingFraction: 0.8), value: isExpanded)
+        .animation(VAnimation.panel, value: isExpanded)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(Text("Relationship tier"))
         .accessibilityValue(Text(accessibilityValue))
         .accessibilityHint(hasHint ? Text("Reveals the hint for the next tier") : Text(""))
         .accessibilityAddTraits(hasHint ? .isButton : [])
-        .accessibilityAction(named: Text(isExpanded ? "Collapse" : "Expand")) {
-            toggle()
-        }
+        .modifier(ExpandActionModifier(isExpanded: isExpanded, enabled: hasHint, action: toggle))
     }
 
     private var accessibilityValue: String {
@@ -58,7 +56,7 @@ struct TierBadgeView: View {
         Button(action: toggle) {
             HStack(spacing: 6) {
                 Text(tier.label)
-                    .font(.system(size: 12, weight: .semibold))
+                    .font(VFont.bodySmallEmphasised)
                     .foregroundStyle(VColor.contentDefault)
                 if hasHint {
                     VIconView(.chevronDown, size: 9)
@@ -83,8 +81,25 @@ struct TierBadgeView: View {
 
     private func toggle() {
         guard hasHint else { return }
-        withAnimation(.spring(response: 0.35, dampingFraction: 0.8)) {
+        withAnimation(VAnimation.panel) {
             isExpanded.toggle()
+        }
+    }
+}
+
+/// Conditionally attaches an expand/collapse accessibility action only when the
+/// badge actually has a hint to disclose. Tier 4 (`.inSync`) gets no action,
+/// matching disabled-control semantics for VoiceOver users.
+private struct ExpandActionModifier: ViewModifier {
+    let isExpanded: Bool
+    let enabled: Bool
+    let action: () -> Void
+
+    func body(content: Content) -> some View {
+        if enabled {
+            content.accessibilityAction(named: Text(isExpanded ? "Collapse" : "Expand"), action)
+        } else {
+            content
         }
     }
 }

--- a/clients/macos/vellum-assistant/Features/Home/TierBadgeView.swift
+++ b/clients/macos/vellum-assistant/Features/Home/TierBadgeView.swift
@@ -1,0 +1,114 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Tappable pill badge that shows the current `RelationshipTier` label and,
+/// when expanded, reveals the next-tier hint underneath.
+///
+/// Tier 4 (`.inSync`) has no `nextTierHint`; in that case the expansion area
+/// is hidden entirely and tapping is disabled (the pill renders as a static
+/// label since there's nothing left to disclose).
+///
+/// All colors come from `VColor` design tokens, which are adaptive and
+/// resolve to the right value automatically in light vs dark mode.
+struct TierBadgeView: View {
+    let tier: RelationshipTier
+
+    @State private var isExpanded: Bool
+
+    init(tier: RelationshipTier, initiallyExpanded: Bool = false) {
+        self.tier = tier
+        self._isExpanded = State(initialValue: initiallyExpanded)
+    }
+
+    private var hasHint: Bool { tier.nextTierHint != nil }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            pill
+            if isExpanded, let hint = tier.nextTierHint {
+                Text(hint)
+                    .font(.system(size: 12, weight: .regular))
+                    .foregroundColor(VColor.contentSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(.horizontal, 4)
+                    .transition(
+                        .move(edge: .top).combined(with: .opacity)
+                    )
+            }
+        }
+        .animation(.spring(response: 0.35, dampingFraction: 0.8), value: isExpanded)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(Text("Relationship tier"))
+        .accessibilityValue(Text(tier.label))
+        .accessibilityHint(hasHint ? Text("Reveals the hint for the next tier") : Text(""))
+        .accessibilityAddTraits(hasHint ? .isButton : [])
+        .accessibilityAction(named: Text(isExpanded ? "Collapse" : "Expand")) {
+            toggle()
+        }
+    }
+
+    private var pill: some View {
+        Button(action: toggle) {
+            HStack(spacing: 6) {
+                Text(tier.label)
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundColor(VColor.contentDefault)
+                if hasHint {
+                    Image(systemName: "chevron.down")
+                        .font(.system(size: 9, weight: .bold))
+                        .foregroundColor(VColor.contentTertiary)
+                        .rotationEffect(.degrees(isExpanded ? 180 : 0))
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 6)
+            .background(
+                Capsule(style: .continuous)
+                    .fill(VColor.surfaceActive)
+            )
+            .overlay(
+                Capsule(style: .continuous)
+                    .strokeBorder(VColor.borderElement, lineWidth: 0.5)
+            )
+            .contentShape(Capsule(style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .disabled(!hasHint)
+    }
+
+    private func toggle() {
+        guard hasHint else { return }
+        withAnimation(.spring(response: 0.35, dampingFraction: 0.8)) {
+            isExpanded.toggle()
+        }
+    }
+}
+
+#Preview("All tiers — light/dark, collapsed/expanded") {
+    HStack(alignment: .top, spacing: 0) {
+        tierColumn(title: "Light", scheme: .light)
+        tierColumn(title: "Dark", scheme: .dark)
+    }
+}
+
+@ViewBuilder
+private func tierColumn(title: String, scheme: ColorScheme) -> some View {
+    VStack(alignment: .leading, spacing: 24) {
+        Text(title)
+            .font(.caption)
+            .foregroundColor(VColor.contentSecondary)
+        ForEach(RelationshipTier.allCases, id: \.rawValue) { tier in
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Tier \(tier.rawValue)")
+                    .font(.caption2)
+                    .foregroundColor(VColor.contentTertiary)
+                TierBadgeView(tier: tier, initiallyExpanded: false)
+                TierBadgeView(tier: tier, initiallyExpanded: true)
+            }
+        }
+    }
+    .padding(20)
+    .frame(width: 320, alignment: .leading)
+    .background(VColor.surfaceBase)
+    .environment(\.colorScheme, scheme)
+}

--- a/clients/macos/vellum-assistant/Features/Home/TierBadgeView.swift
+++ b/clients/macos/vellum-assistant/Features/Home/TierBadgeView.swift
@@ -28,7 +28,7 @@ struct TierBadgeView: View {
             if isExpanded, let hint = tier.nextTierHint {
                 Text(hint)
                     .font(.system(size: 12, weight: .regular))
-                    .foregroundColor(VColor.contentSecondary)
+                    .foregroundStyle(VColor.contentSecondary)
                     .fixedSize(horizontal: false, vertical: true)
                     .padding(.horizontal, 4)
                     .transition(
@@ -39,7 +39,7 @@ struct TierBadgeView: View {
         .animation(.spring(response: 0.35, dampingFraction: 0.8), value: isExpanded)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(Text("Relationship tier"))
-        .accessibilityValue(Text(tier.label))
+        .accessibilityValue(Text(accessibilityValue))
         .accessibilityHint(hasHint ? Text("Reveals the hint for the next tier") : Text(""))
         .accessibilityAddTraits(hasHint ? .isButton : [])
         .accessibilityAction(named: Text(isExpanded ? "Collapse" : "Expand")) {
@@ -47,21 +47,26 @@ struct TierBadgeView: View {
         }
     }
 
+    private var accessibilityValue: String {
+        if isExpanded, let hint = tier.nextTierHint {
+            return "\(tier.label). \(hint)"
+        }
+        return tier.label
+    }
+
     private var pill: some View {
         Button(action: toggle) {
             HStack(spacing: 6) {
                 Text(tier.label)
                     .font(.system(size: 12, weight: .semibold))
-                    .foregroundColor(VColor.contentDefault)
+                    .foregroundStyle(VColor.contentDefault)
                 if hasHint {
-                    Image(systemName: "chevron.down")
-                        .font(.system(size: 9, weight: .bold))
-                        .foregroundColor(VColor.contentTertiary)
+                    VIconView(.chevronDown, size: 9)
+                        .foregroundStyle(VColor.contentTertiary)
                         .rotationEffect(.degrees(isExpanded ? 180 : 0))
                 }
             }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 6)
+            .padding(EdgeInsets(top: 6, leading: 12, bottom: 6, trailing: 12))
             .background(
                 Capsule(style: .continuous)
                     .fill(VColor.surfaceActive)
@@ -82,33 +87,4 @@ struct TierBadgeView: View {
             isExpanded.toggle()
         }
     }
-}
-
-#Preview("All tiers — light/dark, collapsed/expanded") {
-    HStack(alignment: .top, spacing: 0) {
-        tierColumn(title: "Light", scheme: .light)
-        tierColumn(title: "Dark", scheme: .dark)
-    }
-}
-
-@ViewBuilder
-private func tierColumn(title: String, scheme: ColorScheme) -> some View {
-    VStack(alignment: .leading, spacing: 24) {
-        Text(title)
-            .font(.caption)
-            .foregroundColor(VColor.contentSecondary)
-        ForEach(RelationshipTier.allCases, id: \.rawValue) { tier in
-            VStack(alignment: .leading, spacing: 12) {
-                Text("Tier \(tier.rawValue)")
-                    .font(.caption2)
-                    .foregroundColor(VColor.contentTertiary)
-                TierBadgeView(tier: tier, initiallyExpanded: false)
-                TierBadgeView(tier: tier, initiallyExpanded: true)
-            }
-        }
-    }
-    .padding(20)
-    .frame(width: 320, alignment: .leading)
-    .background(VColor.surfaceBase)
-    .environment(\.colorScheme, scheme)
 }


### PR DESCRIPTION
## Summary
- Tappable pill badge bound to `RelationshipTier` from the shared model; expands to reveal next-tier hint
- Smooth spring animation, dark-mode aware, accessibility action exposed for the expansion
- Tier 4 (In sync) gracefully hides the expansion area since it has no next tier

Part of plan: home-page-phase-3.md (PR 5 of 16)
Refs LUM-859
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25334" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
