### PR TITLE
stt: encode telephony routing metadata in provider catalog

### DIFF
--- a/assistant/src/__tests__/openai-provider.test.ts
+++ b/assistant/src/__tests__/openai-provider.test.ts
@@ -1,8 +1,6 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { RetryProvider } from "../providers/retry.js";
-import { createAbortReason } from "../util/abort-reasons.js";
-import { ProviderError } from "../util/errors.js";
 import type {
   ContentBlock,
   Message,
@@ -12,6 +10,8 @@ import type {
   SendMessageOptions,
   ToolDefinition,
 } from "../providers/types.js";
+import { createAbortReason } from "../util/abort-reasons.js";
+import { ProviderError } from "../util/errors.js";
 
 // ---------------------------------------------------------------------------
 // Mock openai module — must be before importing the provider

--- a/assistant/src/providers/speech-to-text/__tests__/provider-catalog.test.ts
+++ b/assistant/src/providers/speech-to-text/__tests__/provider-catalog.test.ts
@@ -139,6 +139,70 @@ describe("STT provider catalog", () => {
   });
 
   // -----------------------------------------------------------------------
+  // Telephony routing metadata
+  // -----------------------------------------------------------------------
+
+  test("every entry has telephonyRouting metadata", () => {
+    for (const entry of listProviderEntries()) {
+      expect(entry.telephonyRouting).toBeDefined();
+      expect(["conversation-relay-native", "media-stream-custom"]).toContain(
+        entry.telephonyRouting.strategyKind,
+      );
+    }
+  });
+
+  test("conversation-relay-native entries have twilioNativeMapping", () => {
+    for (const entry of listProviderEntries()) {
+      if (entry.telephonyRouting.strategyKind === "conversation-relay-native") {
+        expect(entry.telephonyRouting.twilioNativeMapping).toBeDefined();
+        expect(
+          entry.telephonyRouting.twilioNativeMapping!.provider.length,
+        ).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  test("media-stream-custom entries do not have twilioNativeMapping", () => {
+    for (const entry of listProviderEntries()) {
+      if (entry.telephonyRouting.strategyKind === "media-stream-custom") {
+        expect(entry.telephonyRouting.twilioNativeMapping).toBeUndefined();
+      }
+    }
+  });
+
+  test("deepgram has conversation-relay-native strategy with Deepgram Twilio mapping", () => {
+    const entry = getProviderEntry("deepgram");
+    expect(entry?.telephonyRouting.strategyKind).toBe(
+      "conversation-relay-native",
+    );
+    expect(entry?.telephonyRouting.twilioNativeMapping?.provider).toBe(
+      "Deepgram",
+    );
+    expect(
+      entry?.telephonyRouting.twilioNativeMapping?.defaultSpeechModel,
+    ).toBe("nova-3");
+  });
+
+  test("google-gemini has conversation-relay-native strategy with Google Twilio mapping", () => {
+    const entry = getProviderEntry("google-gemini");
+    expect(entry?.telephonyRouting.strategyKind).toBe(
+      "conversation-relay-native",
+    );
+    expect(entry?.telephonyRouting.twilioNativeMapping?.provider).toBe(
+      "Google",
+    );
+    expect(
+      entry?.telephonyRouting.twilioNativeMapping?.defaultSpeechModel,
+    ).toBeUndefined();
+  });
+
+  test("openai-whisper has media-stream-custom strategy without Twilio mapping", () => {
+    const entry = getProviderEntry("openai-whisper");
+    expect(entry?.telephonyRouting.strategyKind).toBe("media-stream-custom");
+    expect(entry?.telephonyRouting.twilioNativeMapping).toBeUndefined();
+  });
+
+  // -----------------------------------------------------------------------
   // Credential lookup
   // -----------------------------------------------------------------------
 

--- a/assistant/src/providers/speech-to-text/__tests__/resolve.test.ts
+++ b/assistant/src/providers/speech-to-text/__tests__/resolve.test.ts
@@ -335,8 +335,8 @@ describe("telephony routing catalog alignment", () => {
    * These tests verify that the assumptions made by the telephony STT
    * routing resolver (telephony-stt-routing.ts) remain consistent with
    * the provider catalog entries. If a catalog entry changes its
-   * telephonyMode or a new provider is added, these tests will catch
-   * misalignment early.
+   * telephonyMode, routing metadata, or a new provider is added, these
+   * tests will catch misalignment early.
    */
 
   test("deepgram catalog entry has realtime-ws telephonyMode (Twilio-native eligible)", () => {
@@ -381,6 +381,85 @@ describe("telephony routing catalog alignment", () => {
       const entry = getProviderEntry(id);
       expect(entry).toBeDefined();
       expect(entry!.telephonyMode).not.toBe("none");
+    }
+  });
+
+  // -----------------------------------------------------------------------
+  // Telephony routing metadata invariants
+  // -----------------------------------------------------------------------
+
+  test("every catalog provider has telephonyRouting metadata", () => {
+    for (const id of listProviderIds()) {
+      const entry = getProviderEntry(id);
+      expect(entry).toBeDefined();
+      expect(entry!.telephonyRouting).toBeDefined();
+      expect(["conversation-relay-native", "media-stream-custom"]).toContain(
+        entry!.telephonyRouting.strategyKind,
+      );
+    }
+  });
+
+  test("conversation-relay-native providers have twilioNativeMapping with non-empty provider name", () => {
+    for (const id of listProviderIds()) {
+      const entry = getProviderEntry(id)!;
+      if (entry.telephonyRouting.strategyKind === "conversation-relay-native") {
+        expect(entry.telephonyRouting.twilioNativeMapping).toBeDefined();
+        expect(
+          entry.telephonyRouting.twilioNativeMapping!.provider.length,
+        ).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  test("media-stream-custom providers do not have twilioNativeMapping", () => {
+    for (const id of listProviderIds()) {
+      const entry = getProviderEntry(id)!;
+      if (entry.telephonyRouting.strategyKind === "media-stream-custom") {
+        expect(entry.telephonyRouting.twilioNativeMapping).toBeUndefined();
+      }
+    }
+  });
+
+  test("deepgram routing metadata maps to Twilio-native Deepgram with nova-3 speech model", () => {
+    const entry = getProviderEntry("deepgram")!;
+    expect(entry.telephonyRouting.strategyKind).toBe(
+      "conversation-relay-native",
+    );
+    expect(entry.telephonyRouting.twilioNativeMapping?.provider).toBe(
+      "Deepgram",
+    );
+    expect(entry.telephonyRouting.twilioNativeMapping?.defaultSpeechModel).toBe(
+      "nova-3",
+    );
+  });
+
+  test("google-gemini routing metadata maps to Twilio-native Google with no default speech model", () => {
+    const entry = getProviderEntry("google-gemini")!;
+    expect(entry.telephonyRouting.strategyKind).toBe(
+      "conversation-relay-native",
+    );
+    expect(entry.telephonyRouting.twilioNativeMapping?.provider).toBe("Google");
+    expect(
+      entry.telephonyRouting.twilioNativeMapping?.defaultSpeechModel,
+    ).toBeUndefined();
+  });
+
+  test("openai-whisper routing metadata uses media-stream-custom without Twilio mapping", () => {
+    const entry = getProviderEntry("openai-whisper")!;
+    expect(entry.telephonyRouting.strategyKind).toBe("media-stream-custom");
+    expect(entry.telephonyRouting.twilioNativeMapping).toBeUndefined();
+  });
+
+  // -----------------------------------------------------------------------
+  // Stable provider identity
+  // -----------------------------------------------------------------------
+
+  test("provider IDs remain stable across catalog lookups", () => {
+    // Guard against accidental ID mutation or aliasing bugs.
+    for (const id of listProviderIds()) {
+      const entry = getProviderEntry(id);
+      expect(entry).toBeDefined();
+      expect(entry!.id).toBe(id);
     }
   });
 

--- a/assistant/src/providers/speech-to-text/provider-catalog.ts
+++ b/assistant/src/providers/speech-to-text/provider-catalog.ts
@@ -18,6 +18,68 @@ import type {
 } from "../../stt/types.js";
 
 // ---------------------------------------------------------------------------
+// Telephony routing metadata
+// ---------------------------------------------------------------------------
+
+/**
+ * Strategy kind for telephony call setup.
+ *
+ * Determines how the telephony routing resolver (`telephony-stt-routing.ts`)
+ * wires the STT provider into a Twilio call:
+ *
+ * - `"conversation-relay-native"` — the provider is natively supported by
+ *   Twilio ConversationRelay. TwiML includes `transcriptionProvider` /
+ *   `speechModel` attributes and Twilio handles audio ingestion.
+ * - `"media-stream-custom"` — the provider is not natively supported by
+ *   Twilio. A `<Stream>` media-stream is opened and the daemon transcribes
+ *   audio server-side via the provider's batch API.
+ */
+export type TelephonyStrategyKind =
+  | "conversation-relay-native"
+  | "media-stream-custom";
+
+/**
+ * Twilio-native ConversationRelay provider name.
+ *
+ * These are the values Twilio accepts in the `transcriptionProvider` TwiML
+ * attribute on `<ConversationRelay>`.
+ */
+export type TwilioNativeProvider = "Deepgram" | "Google";
+
+/**
+ * Twilio-native mapping details for providers routed through
+ * ConversationRelay. Only present when `strategyKind` is
+ * `"conversation-relay-native"`.
+ */
+export interface TwilioNativeMapping {
+  /** Twilio-native provider name for the TwiML `transcriptionProvider` attribute. */
+  readonly provider: TwilioNativeProvider;
+  /**
+   * Default ASR speech model identifier, or `undefined` to use the
+   * provider's default model. Individual providers override as needed
+   * (e.g. Deepgram defaults to `"nova-3"`).
+   */
+  readonly defaultSpeechModel: string | undefined;
+}
+
+/**
+ * Telephony routing metadata — the single source of truth for how a
+ * provider is wired into Twilio call setup.
+ *
+ * The telephony routing resolver reads these fields from the catalog
+ * instead of maintaining its own hardcoded maps.
+ */
+export interface TelephonyRouting {
+  /** Which Twilio call-setup strategy this provider uses. */
+  readonly strategyKind: TelephonyStrategyKind;
+  /**
+   * Twilio-native mapping details. Present when `strategyKind` is
+   * `"conversation-relay-native"`, absent for `"media-stream-custom"`.
+   */
+  readonly twilioNativeMapping?: TwilioNativeMapping;
+}
+
+// ---------------------------------------------------------------------------
 // Catalog entry
 // ---------------------------------------------------------------------------
 
@@ -44,8 +106,8 @@ export interface SttProviderEntry {
   readonly supportedBoundaries: ReadonlySet<SttBoundaryId>;
 
   /**
-   * Telephony support mode — describes whether and how the provider can
-   * participate in real-time call ingestion via `services.stt`.
+   * Telephony capability class — describes the provider's native
+   * audio-ingestion capability for telephony contexts.
    */
   readonly telephonyMode: TelephonySttMode;
 
@@ -59,6 +121,13 @@ export interface SttProviderEntry {
    * - `"none"` — no streaming support; fall back to batch transcription.
    */
   readonly conversationStreamingMode: ConversationStreamingMode;
+
+  /**
+   * Telephony routing metadata — describes how this provider is wired
+   * into Twilio call setup. This is the single source of truth for
+   * strategy selection and Twilio-native mapping details.
+   */
+  readonly telephonyRouting: TelephonyRouting;
 }
 
 // ---------------------------------------------------------------------------
@@ -86,6 +155,9 @@ const CATALOG: ReadonlyMap<SttProviderId, SttProviderEntry> = new Map<
       supportedBoundaries: new Set<SttBoundaryId>(["daemon-batch"]),
       telephonyMode: "batch-only",
       conversationStreamingMode: "none",
+      telephonyRouting: {
+        strategyKind: "media-stream-custom",
+      },
     },
   ],
   [
@@ -99,6 +171,13 @@ const CATALOG: ReadonlyMap<SttProviderId, SttProviderEntry> = new Map<
       ]),
       telephonyMode: "realtime-ws",
       conversationStreamingMode: "realtime-ws",
+      telephonyRouting: {
+        strategyKind: "conversation-relay-native",
+        twilioNativeMapping: {
+          provider: "Deepgram",
+          defaultSpeechModel: "nova-3",
+        },
+      },
     },
   ],
   [
@@ -112,6 +191,13 @@ const CATALOG: ReadonlyMap<SttProviderId, SttProviderEntry> = new Map<
       ]),
       telephonyMode: "batch-only",
       conversationStreamingMode: "incremental-batch",
+      telephonyRouting: {
+        strategyKind: "conversation-relay-native",
+        twilioNativeMapping: {
+          provider: "Google",
+          defaultSpeechModel: undefined,
+        },
+      },
     },
   ],
 ]);

--- a/assistant/src/stt/types.ts
+++ b/assistant/src/stt/types.ts
@@ -23,16 +23,22 @@
 export type SttProviderId = "openai-whisper" | "deepgram" | "google-gemini";
 
 /**
- * Telephony-specific STT support mode.
+ * Telephony-specific STT capability class.
  *
- * Describes how a provider can participate in real-time telephony call
- * ingestion when wired through `services.stt`.
+ * Describes the provider's native audio-ingestion capability when used in
+ * a telephony context. This is a **capability classification**, not a direct
+ * Twilio strategy selector — the telephony routing resolver
+ * (`telephony-stt-routing.ts`) maps capability classes plus catalog routing
+ * metadata to concrete Twilio setup strategies (conversation-relay-native
+ * vs media-stream-custom).
  *
  * - `"realtime-ws"` — provider offers a WebSocket streaming endpoint suitable
- *   for low-latency telephony audio. Future PRs will wire this into the
- *   media-stream call adapter.
- * - `"batch-only"` — provider supports only REST batch transcription; not
- *   suitable for real-time telephony.
+ *   for low-latency telephony audio (e.g. Deepgram live transcription).
+ * - `"batch-only"` — provider supports only REST batch transcription as its
+ *   native capability. A `batch-only` provider may still participate in
+ *   telephony via Twilio-native ConversationRelay (e.g. Google Gemini) or
+ *   via the media-stream custom path — the routing strategy is determined
+ *   by the catalog's telephony routing metadata, not this field alone.
  * - `"none"` — provider has no telephony support.
  */
 export type TelephonySttMode = "realtime-ws" | "batch-only" | "none";


### PR DESCRIPTION
## Summary
- Add explicit telephony routing metadata (strategy kind + Twilio-native mapping) to SttProviderEntry in provider catalog
- Populate routing metadata for all current providers (openai-whisper, deepgram, google-gemini)
- Update TelephonySttMode docs to clarify capability class semantics
- Update catalog/resolver tests to assert routing metadata invariants

Part of plan: stt-telephony-cleanups.md (PR 1 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25335" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
