### PR TITLE
macos: align stt settings defaults with explicit services.stt provider

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -3552,10 +3552,13 @@ public final class SettingsStore: ObservableObject {
 
         // Sync the global STT provider from the daemon config so the client
         // stays aligned after restart or reconnection. The canonical path
-        // is services.stt.provider.
+        // is services.stt.provider. Empty/whitespace-only values are
+        // treated as "not configured" and are not persisted — this avoids
+        // clobbering a previously selected provider with a no-op sentinel.
         if let services = config["services"] as? [String: Any],
            let stt = services["stt"] as? [String: Any],
-           let sttProvider = stt["provider"] as? String {
+           let sttProvider = stt["provider"] as? String,
+           !sttProvider.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             UserDefaults.standard.set(sttProvider, forKey: "sttProvider")
         }
 

--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -629,6 +629,13 @@ struct VoiceSettingsView: View {
         sttSaving = true
         sttSaveError = nil
 
+        // Normalize the empty sentinel to the resolved provider so we never
+        // persist an empty string as the STT provider identifier.
+        if draftSTTProvider.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+           let resolved = selectedSTTProvider?.id {
+            draftSTTProvider = resolved
+        }
+
         // Persist provider change if needed
         if draftSTTProvider != sttProviderRaw {
             store.setSTTProvider(draftSTTProvider)

--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -10,7 +10,7 @@ struct VoiceSettingsView: View {
     @AppStorage("activationKey") private var activationKey: String = "fn"
     @AppStorage("voiceConversationTimeoutSeconds") private var conversationTimeoutSeconds: Int = 30
     @AppStorage("ttsProvider") private var ttsProviderRaw: String = "elevenlabs"
-    @AppStorage("sttProvider") private var sttProviderRaw: String = "openai-whisper"
+    @AppStorage("sttProvider") private var sttProviderRaw: String = ""
 
     // TTS draft-based state (mirrors Inference card pattern)
     /// Uncommitted provider selection — only persisted on Save.
@@ -34,11 +34,14 @@ struct VoiceSettingsView: View {
 
     // STT draft-based state
     /// Uncommitted provider selection — persisted only on Save.
-    @State private var draftSTTProvider: String = "openai-whisper"
+    /// Empty-string sentinel means "no explicit selection" — the UI
+    /// resolves the effective provider from the catalog via
+    /// `selectedSTTProvider` which falls back to the first registry entry.
+    @State private var draftSTTProvider: String = ""
     /// API key input text (replaces the old Connect/Set Up flow).
     @State private var sttApiKeyText: String = ""
     /// Baseline provider for change detection — set on appear and after save.
-    @State private var initialSTTProvider: String = "openai-whisper"
+    @State private var initialSTTProvider: String = ""
     /// Whether the current STT provider already has a stored API key.
     @State private var sttProviderHasKey: Bool = false
     /// Save-in-progress indicator.

--- a/clients/macos/vellum-assistantTests/SettingsStoreVoiceServiceTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsStoreVoiceServiceTests.swift
@@ -544,4 +544,170 @@ final class SettingsStoreVoiceServiceTests: XCTestCase {
             "The STT reset flow should be allowed for exclusive-key providers"
         )
     }
+
+    // MARK: - STT Default Selection (Empty Sentinel)
+
+    /// When no STT provider has been persisted, the UserDefaults key should
+    /// be absent (or empty). The UI resolves the effective provider from the
+    /// catalog's first entry via `selectedSTTProvider`.
+    func testDefaultSTTProviderIsEmpty() {
+        UserDefaults.standard.removeObject(forKey: "sttProvider")
+
+        let raw = UserDefaults.standard.string(forKey: "sttProvider")
+        XCTAssertNil(
+            raw,
+            "With no persisted value the sttProvider key should be nil"
+        )
+    }
+
+    /// The STT service configuration check must return false when the
+    /// provider key is an empty string (the new default sentinel).
+    func testEmptySTTProviderIsNotConsideredConfigured() {
+        UserDefaults.standard.set("", forKey: "sttProvider")
+
+        XCTAssertFalse(
+            STTProviderRegistry.isServiceConfigured,
+            "An empty sttProvider value must not be treated as configured"
+        )
+    }
+
+    /// Streaming availability must be false when the STT provider key is
+    /// the empty-string sentinel.
+    func testEmptySTTProviderReportsNoStreamingAvailable() {
+        UserDefaults.standard.set("", forKey: "sttProvider")
+
+        XCTAssertFalse(
+            STTProviderRegistry.isStreamingAvailable,
+            "An empty sttProvider must not report streaming as available"
+        )
+    }
+
+    // MARK: - STT Persistence After Explicit Selection
+
+    /// After explicitly setting a provider via `setSTTProvider`, the value
+    /// should be persisted so subsequent reads return it.
+    func testExplicitSTTProviderSelectionPersists() {
+        UserDefaults.standard.removeObject(forKey: "sttProvider")
+
+        store.setSTTProvider("deepgram")
+        waitForPatchCount(1)
+
+        // The store persists via config patch; simulate the daemon echoing
+        // the value back through applyDaemonConfig.
+        let config: [String: Any] = [
+            "services": ["stt": ["provider": "deepgram"]]
+        ]
+        mockSettingsClient.fetchConfigResponse = config
+        let expectation = XCTestExpectation(description: "config loaded")
+        Task {
+            await store.loadConfigFromDaemon()
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 2.0)
+
+        XCTAssertEqual(
+            UserDefaults.standard.string(forKey: "sttProvider"),
+            "deepgram",
+            "Explicitly selected provider must be persisted after daemon sync"
+        )
+    }
+
+    // MARK: - Daemon Sync Does Not Clobber With Empty Values
+
+    /// When the daemon sends an empty provider string the existing persisted
+    /// value must not be overwritten.
+    func testApplyDaemonConfigDoesNotClobberWithEmptyProvider() {
+        UserDefaults.standard.set("deepgram", forKey: "sttProvider")
+
+        let config: [String: Any] = [
+            "services": [
+                "stt": [
+                    "provider": ""
+                ]
+            ]
+        ]
+
+        mockSettingsClient.fetchConfigResponse = config
+        let expectation = XCTestExpectation(description: "config loaded")
+        Task {
+            await store.loadConfigFromDaemon()
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 2.0)
+
+        XCTAssertEqual(
+            UserDefaults.standard.string(forKey: "sttProvider"),
+            "deepgram",
+            "Empty daemon provider value must not overwrite the persisted selection"
+        )
+    }
+
+    /// When the daemon sends a whitespace-only provider string the existing
+    /// persisted value must not be overwritten.
+    func testApplyDaemonConfigDoesNotClobberWithWhitespaceProvider() {
+        UserDefaults.standard.set("openai-whisper", forKey: "sttProvider")
+
+        let config: [String: Any] = [
+            "services": [
+                "stt": [
+                    "provider": "  "
+                ]
+            ]
+        ]
+
+        mockSettingsClient.fetchConfigResponse = config
+        let expectation = XCTestExpectation(description: "config loaded")
+        Task {
+            await store.loadConfigFromDaemon()
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 2.0)
+
+        XCTAssertEqual(
+            UserDefaults.standard.string(forKey: "sttProvider"),
+            "openai-whisper",
+            "Whitespace-only daemon provider value must not overwrite the persisted selection"
+        )
+    }
+
+    // MARK: - Existing User-Selected Provider Behavior Preserved
+
+    /// A user who previously selected openai-whisper and has it persisted
+    /// must continue to see that value after daemon sync confirms it.
+    func testPreExistingOpenAIWhisperSelectionSurvivesDaemonSync() {
+        UserDefaults.standard.set("openai-whisper", forKey: "sttProvider")
+
+        let config: [String: Any] = [
+            "services": [
+                "stt": [
+                    "provider": "openai-whisper"
+                ]
+            ]
+        ]
+
+        mockSettingsClient.fetchConfigResponse = config
+        let expectation = XCTestExpectation(description: "config loaded")
+        Task {
+            await store.loadConfigFromDaemon()
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 2.0)
+
+        XCTAssertEqual(
+            UserDefaults.standard.string(forKey: "sttProvider"),
+            "openai-whisper",
+            "Pre-existing user selection must survive daemon sync"
+        )
+    }
+
+    /// STT service configuration check must return true when a valid
+    /// provider is persisted.
+    func testPersistedSTTProviderIsConsideredConfigured() {
+        UserDefaults.standard.set("deepgram", forKey: "sttProvider")
+
+        XCTAssertTrue(
+            STTProviderRegistry.isServiceConfigured,
+            "A non-empty persisted sttProvider must be treated as configured"
+        )
+    }
 }


### PR DESCRIPTION
## Summary
- Replace hardcoded openai-whisper default in VoiceSettingsView with empty-string sentinel
- Ensure SettingsStore STT sync falls back deterministically without clobbering server values
- Add settings tests covering default selection, persistence, and daemon-sync behavior

Part of plan: stt-telephony-cleanups.md (PR 5 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25337" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
