### PR TITLE
fix: show loading feedback for community skill installs

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -7352,6 +7352,8 @@ paths:
                 properties:
                   ok:
                     type: boolean
+                  skillId:
+                    type: string
                 required:
                   - ok
                 additionalProperties: false

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -1068,7 +1068,9 @@ export async function installSkill(
     contactId?: string;
   },
   ctx: SkillOperationContext,
-): Promise<{ success: true } | { success: false; error: string }> {
+): Promise<
+  { success: true; skillId: string } | { success: false; error: string }
+> {
   try {
     // Bundled skills are already available — no install needed
     const catalog = loadSkillCatalog();
@@ -1113,7 +1115,7 @@ export async function installSkill(
       }
       seedSkillGraphNodes();
       void seedUninstalledCatalogSkillMemories().catch(() => {});
-      return { success: true };
+      return { success: true, skillId: spec.slug };
     }
 
     // Check the Vellum catalog (first-party skills hosted on the platform).
@@ -1134,7 +1136,7 @@ export async function installSkill(
 
           const skillDir = join(getWorkspaceSkillsDir(), spec.slug);
           postInstallSkill(spec.slug, skillDir, ctx);
-          return { success: true };
+          return { success: true, skillId: spec.slug };
         }
       } catch (err) {
         // If catalog lookup/install fails, fall through to community registries
@@ -1162,7 +1164,7 @@ export async function installSkill(
 
       const skillDir = join(getWorkspaceSkillsDir(), resolved.skillSlug);
       postInstallSkill(resolved.skillSlug, skillDir, ctx);
-      return { success: true };
+      return { success: true, skillId: resolved.skillSlug };
     }
 
     // Install from clawhub (community)
@@ -1190,7 +1192,7 @@ export async function installSkill(
     upsertSkillsIndex(skillId);
 
     postInstallSkill(skillId, skillDir, ctx);
-    return { success: true };
+    return { success: true, skillId };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     log.error({ err }, "Failed to install skill");

--- a/assistant/src/runtime/routes/skills-routes.ts
+++ b/assistant/src/runtime/routes/skills-routes.ts
@@ -380,6 +380,7 @@ export function skillRouteDefinitions(deps: SkillRouteDeps): RouteDefinition[] {
       }),
       responseBody: z.object({
         ok: z.boolean(),
+        skillId: z.string().optional(),
       }),
       handler: async ({ req, authContext }) => {
         const body = (await req.json()) as {
@@ -405,7 +406,7 @@ export function skillRouteDefinitions(deps: SkillRouteDeps): RouteDefinition[] {
         if (!result.success) {
           return httpError("INTERNAL_ERROR", result.error, 500);
         }
-        return Response.json({ ok: true });
+        return Response.json({ ok: true, skillId: result.skillId });
       },
     },
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
@@ -152,15 +152,25 @@ final class SkillsManager {
                         self.installingSkillId = nil
                         self.installWatchdogTask?.cancel()
                         self.installWatchdogTask = nil
-                    } else if self.skillsStore.skills
-                        .first(where: { $0.id == result.slug })?.kind != "catalog" {
-                        // Success confirmed: the refreshed skills list has
-                        // flipped the kind away from "catalog", so the
-                        // detail view will render the installed UI on the
-                        // next body pass without flicker.
-                        self.installingSkillId = nil
-                        self.installWatchdogTask?.cancel()
-                        self.installWatchdogTask = nil
+                    } else {
+                        // The daemon may return a different skill ID than the
+                        // slug we sent (e.g. skills.sh resolves
+                        // "owner/repo/skill" to just "skill"). Update the
+                        // tracking ID so the list-refresh check below can
+                        // match the installed entry.
+                        if let actualId = result.skillId {
+                            self.installingSkillId = actualId
+                        }
+                        if self.skillsStore.skills
+                            .first(where: { $0.id == (result.skillId ?? result.slug) })?.kind != "catalog" {
+                            // Success confirmed: the refreshed skills list has
+                            // flipped the kind away from "catalog", so the
+                            // detail view will render the installed UI on the
+                            // next body pass without flicker.
+                            self.installingSkillId = nil
+                            self.installWatchdogTask?.cancel()
+                            self.installWatchdogTask = nil
+                        }
                     }
                     // Otherwise: keep the spinner up until fetchSkills(force:)
                     // lands — see `installSkill(slug:)` for the watchdog that

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
@@ -161,8 +161,9 @@ final class SkillsManager {
                         if let actualId = result.skillId {
                             self.installingSkillId = actualId
                         }
-                        if self.skillsStore.skills
-                            .first(where: { $0.id == (result.skillId ?? result.slug) })?.kind != "catalog" {
+                        let lookupId = result.skillId ?? result.slug
+                        if let skill = self.skillsStore.skills.first(where: { $0.id == lookupId }),
+                           skill.kind != "catalog" {
                             // Success confirmed: the refreshed skills list has
                             // flipped the kind away from "catalog", so the
                             // detail view will render the installed UI on the
@@ -364,14 +365,16 @@ final class SkillsManager {
 
         // Defensive watchdog: a wedged `fetchSkills(force:)` response
         // after install would otherwise leave the spinner stuck forever.
-        // Clear `installingSkillId` after 15 seconds if the confirmation
-        // path has not already cleared it.
+        // Clear `installingSkillId` after 120 seconds (matching the HTTP
+        // timeout) if the confirmation path has not already cleared it.
+        // Uses `!= nil` instead of `== slug` because the install result
+        // may update the tracking ID to a resolved value.
         installWatchdogTask?.cancel()
         installWatchdogTask = Task { [weak self] in
-            try? await Task.sleep(nanoseconds: 15_000_000_000)
+            try? await Task.sleep(nanoseconds: 120_000_000_000)
             guard !Task.isCancelled else { return }
             guard let self else { return }
-            if self.installingSkillId == slug {
+            if self.installingSkillId != nil {
                 self.installingSkillId = nil
             }
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
@@ -49,6 +49,12 @@ final class SkillsManager {
     var installingSkillId: String?
     var isSearching = false
 
+    /// The actual installed skill ID returned by the daemon, which may
+    /// differ from `installingSkillId` (e.g. skills.sh resolves
+    /// "owner/repo/skill" to just "skill"). Used only for list-confirmation
+    /// checks — `installingSkillId` stays as the original slug for UI binding.
+    @ObservationIgnored private var resolvedInstallSkillId: String?
+
     /// Safety timeout that defensively clears `installingSkillId` if a
     /// wedged `fetchSkills(force:)` response never lands. Without it, the
     /// install spinner can be stuck indefinitely when the confirmation
@@ -155,12 +161,11 @@ final class SkillsManager {
                     } else {
                         // The daemon may return a different skill ID than the
                         // slug we sent (e.g. skills.sh resolves
-                        // "owner/repo/skill" to just "skill"). Update the
-                        // tracking ID so the list-refresh check below can
-                        // match the installed entry.
-                        if let actualId = result.skillId {
-                            self.installingSkillId = actualId
-                        }
+                        // "owner/repo/skill" to just "skill"). Store it
+                        // separately so the list-confirmation check can match
+                        // the installed entry without breaking UI spinner
+                        // bindings that compare against the original slug.
+                        self.resolvedInstallSkillId = result.skillId
                         let lookupId = result.skillId ?? result.slug
                         if let skill = self.skillsStore.skills.first(where: { $0.id == lookupId }),
                            skill.kind != "catalog" {
@@ -169,6 +174,7 @@ final class SkillsManager {
                             // detail view will render the installed UI on the
                             // next body pass without flicker.
                             self.installingSkillId = nil
+                            self.resolvedInstallSkillId = nil
                             self.installWatchdogTask?.cancel()
                             self.installWatchdogTask = nil
                         }
@@ -178,25 +184,20 @@ final class SkillsManager {
                     // clears the spinner defensively if the refresh wedges.
                 }
 
-                // Independent skills-list-driven clear: `SkillsStore.installSkill`
-                // expires `installResult` after 3 seconds, so on a slow-network
-                // install where `fetchSkills(force:)` lands after the expiry
-                // the branch above will not fire — `installResult` is already
-                // nil by the time the refreshed list arrives. Clear the
-                // spinner here based solely on the skills list: if the
-                // currently-installing id is now a non-catalog entry, the
-                // install has confirmed and the spinner must come down.
-                // `installingSkillId` is only set by `installSkill(slug:)`
-                // for a catalog skill, so any transition away from "catalog"
-                // for that id is a legitimate success signal. Idempotent
-                // with the branch above: the `if let` guard short-circuits
-                // when the first branch has already cleared the id.
-                if let installingId = self.installingSkillId,
-                   self.skillsStore.skills
-                    .first(where: { $0.id == installingId })?.kind != "catalog" {
-                    self.installingSkillId = nil
-                    self.installWatchdogTask?.cancel()
-                    self.installWatchdogTask = nil
+                // Independent skills-list-driven clear: check both the
+                // original slug and the resolved ID (which may differ for
+                // community skills). Requires the skill to actually exist
+                // in the list with a non-catalog kind to avoid premature
+                // clearing when the refresh hasn't landed yet.
+                if let installingId = self.installingSkillId {
+                    let lookupId = self.resolvedInstallSkillId ?? installingId
+                    if let skill = self.skillsStore.skills.first(where: { $0.id == lookupId }),
+                       skill.kind != "catalog" {
+                        self.installingSkillId = nil
+                        self.resolvedInstallSkillId = nil
+                        self.installWatchdogTask?.cancel()
+                        self.installWatchdogTask = nil
+                    }
                 }
                 self.recomputeFilteredData()
             }
@@ -361,14 +362,13 @@ final class SkillsManager {
 
     func installSkill(slug: String) {
         installingSkillId = slug
+        resolvedInstallSkillId = nil
         skillsStore.installSkill(slug: slug)
 
         // Defensive watchdog: a wedged `fetchSkills(force:)` response
         // after install would otherwise leave the spinner stuck forever.
         // Clear `installingSkillId` after 120 seconds (matching the HTTP
         // timeout) if the confirmation path has not already cleared it.
-        // Uses `!= nil` instead of `== slug` because the install result
-        // may update the tracking ID to a resolved value.
         installWatchdogTask?.cancel()
         installWatchdogTask = Task { [weak self] in
             try? await Task.sleep(nanoseconds: 120_000_000_000)
@@ -376,6 +376,7 @@ final class SkillsManager {
             guard let self else { return }
             if self.installingSkillId != nil {
                 self.installingSkillId = nil
+                self.resolvedInstallSkillId = nil
             }
         }
     }

--- a/clients/shared/Features/Skills/SkillsStore.swift
+++ b/clients/shared/Features/Skills/SkillsStore.swift
@@ -51,11 +51,15 @@ public final class SkillsStore: ObservableObject {
 
     public struct InstallResult: Sendable {
         public let slug: String
+        /// The actual installed skill ID returned by the daemon, which may
+        /// differ from `slug` (e.g. skills.sh resolves "owner/repo/skill" to "skill").
+        public let skillId: String?
         public let success: Bool
         public let error: String?
 
-        public init(slug: String, success: Bool, error: String?) {
+        public init(slug: String, skillId: String? = nil, success: Bool, error: String?) {
             self.slug = slug
+            self.skillId = skillId
             self.success = success
             self.error = error
         }
@@ -211,7 +215,7 @@ public final class SkillsStore: ObservableObject {
             let response = await skillsClient.installSkill(slug: slug, version: nil)
             let result: InstallResult
             if let response, response.success {
-                result = InstallResult(slug: slug, success: true, error: nil)
+                result = InstallResult(slug: slug, skillId: response.skillId, success: true, error: nil)
             } else {
                 result = InstallResult(slug: slug, success: false, error: response?.error ?? "Failed to connect")
             }

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -1081,9 +1081,13 @@ public typealias SkillStateChangedMessage = SkillStateChanged
 public struct SkillOperationResult: Sendable {
     public let success: Bool
     public let error: String?
-    public init(success: Bool, error: String? = nil) {
+    /// The actual installed skill ID, which may differ from the slug sent in
+    /// the request (e.g. skills.sh resolves "owner/repo/skill" to just "skill").
+    public let skillId: String?
+    public init(success: Bool, error: String? = nil, skillId: String? = nil) {
         self.success = success
         self.error = error
+        self.skillId = skillId
     }
 }
 

--- a/clients/shared/Network/SkillsClient.swift
+++ b/clients/shared/Network/SkillsClient.swift
@@ -136,7 +136,7 @@ public struct SkillsClient: SkillsClientProtocol {
             if let version { body["version"] = version }
 
             let response = try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/skills/install", json: body, timeout: 10
+                path: "assistants/{assistantId}/skills/install", json: body, timeout: 120
             )
             guard response.isSuccess else {
                 log.error("installSkill failed (HTTP \(response.statusCode))")
@@ -145,7 +145,9 @@ public struct SkillsClient: SkillsClientProtocol {
                     error: extractErrorMessage(from: response.data)
                 )
             }
-            return SkillOperationResult(success: true)
+            let json = try? JSONSerialization.jsonObject(with: response.data) as? [String: Any]
+            let skillId = json?["skillId"] as? String
+            return SkillOperationResult(success: true, skillId: skillId)
         } catch {
             log.error("installSkill error: \(error.localizedDescription)")
             return SkillOperationResult(success: false, error: error.localizedDescription)


### PR DESCRIPTION
## Summary
- Increased client HTTP timeout for skill install from 10s to 120s — community installs (clawhub CLI, Git clones, bun install) easily exceed 10s, causing the client to treat the in-progress install as a failure
- Daemon now returns the actual installed `skillId` in the response, which may differ from the slug sent by the client (e.g. skills.sh resolves `owner/repo/skill` to just `skill`)
- Client updates its spinner tracking ID to the actual installed skill ID so the list-refresh confirmation check matches correctly

## Original prompt
Fix skill install loading feedback for community skills — the Install button flashes and reappears immediately while the skill installs silently in the background.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25338" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
