### PR TITLE
fix(macos): sync dark mode class on document editor to fix text contrast

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/DocumentEditorView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/DocumentEditorView.swift
@@ -407,6 +407,22 @@ private func generateEditorHTML(title: String, initialContent: String) -> String
       // Initial word count
       updateWordCount();
 
+      // Sync dark mode class when system appearance changes (fixes race
+      // condition where WKWebView appearance may not be resolved at init)
+      const darkMQ = window.matchMedia('(prefers-color-scheme: dark)');
+      function syncDarkClass(e) {
+        const editorEl = document.querySelector('.toastui-editor-defaultUI');
+        if (!editorEl) return;
+        if (e.matches) {
+          editorEl.classList.add('toastui-editor-dark');
+        } else {
+          editorEl.classList.remove('toastui-editor-dark');
+        }
+      }
+      // Apply immediately in case JS ran before appearance was resolved
+      syncDarkClass(darkMQ);
+      darkMQ.addEventListener('change', syncDarkClass);
+
       // Focus editor
       setTimeout(() => window.editor.focus(), 100);
     } catch (e) {


### PR DESCRIPTION
## Summary
- Fix document editor text being nearly invisible in dark mode
- Root cause: Toast UI Editor's `.toastui-editor-dark` class was only set at JS init via `matchMedia`, but WKWebView appearance may not be resolved yet during `loadHTMLString` — so the dark theme CSS never kicked in for paragraph text
- Sync the dark class immediately after editor init and on every subsequent appearance change

## Test plan
- [ ] Open a document in dark mode — all paragraph, list, and heading text should be readable
- [ ] Toggle between light/dark mode — text contrast should update correctly
- [ ] Launch app in dark mode and open a document — no flash of invisible text

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25339" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
