### PR TITLE
stt-stream: make provider query optional and config-authoritative

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -653,8 +653,8 @@ Two provider adapters are supported, each implementing the `StreamingTranscriber
 
 **Session lifecycle (daemon side):**
 
-1. Client opens a WebSocket to `/v1/stt/stream` with query parameters `provider`, `mimeType`, and optional `sampleRate`.
-2. `SttStreamSession` (in `src/stt/stt-stream-session.ts`) resolves a `StreamingTranscriber` via `resolveStreamingTranscriber()` from `src/providers/speech-to-text/resolve.ts`.
+1. Client opens a WebSocket to `/v1/stt/stream` with required query parameter `mimeType` and optional `provider` and `sampleRate`. The `provider` parameter is optional compatibility metadata — the runtime is config-authoritative and always resolves the streaming transcriber from `services.stt.provider`. When a requested provider disagrees with the configured provider, the runtime logs a mismatch warning.
+2. `SttStreamSession` (in `src/stt/stt-stream-session.ts`) resolves a `StreamingTranscriber` via `resolveStreamingTranscriber()` from `src/providers/speech-to-text/resolve.ts`, using the configured provider (not the requested one).
 3. The transcriber's `start()` method opens the provider session.
 4. A `ready` event (with `provider` field) is sent to the client, signaling that audio frames are accepted.
 5. Client sends `audio` frames (binary WebSocket frames or base64-encoded JSON) and a `stop` event when recording ends.

--- a/assistant/src/__tests__/gateway-only-enforcement.test.ts
+++ b/assistant/src/__tests__/gateway-only-enforcement.test.ts
@@ -844,9 +844,25 @@ describe("gateway-only ingress enforcement", () => {
       expect(res.status).not.toBe(401);
     });
 
-    test("returns 400 when provider is missing", async () => {
+    test("succeeds when provider is omitted (config-authoritative)", async () => {
       const res = await fetch(
         `http://127.0.0.1:${port}/v1/stt/stream?token=${GATEWAY_JWT}&mimeType=audio/webm`,
+        {
+          headers: {
+            Upgrade: "websocket",
+            Connection: "Upgrade",
+            "Sec-WebSocket-Key": "dGhlIHNhbXBsZSBub25jZQ==",
+            "Sec-WebSocket-Version": "13",
+          },
+        },
+      );
+      // Should NOT be 400 — provider is optional.
+      expect(res.status).not.toBe(400);
+    });
+
+    test("returns 400 when mimeType is missing", async () => {
+      const res = await fetch(
+        `http://127.0.0.1:${port}/v1/stt/stream?token=${GATEWAY_JWT}&provider=deepgram`,
         {
           headers: {
             Upgrade: "websocket",
@@ -859,9 +875,9 @@ describe("gateway-only ingress enforcement", () => {
       expect(res.status).toBe(400);
     });
 
-    test("returns 400 when mimeType is missing", async () => {
+    test("returns 400 when both provider and mimeType are missing", async () => {
       const res = await fetch(
-        `http://127.0.0.1:${port}/v1/stt/stream?token=${GATEWAY_JWT}&provider=deepgram`,
+        `http://127.0.0.1:${port}/v1/stt/stream?token=${GATEWAY_JWT}`,
         {
           headers: {
             Upgrade: "websocket",

--- a/assistant/src/__tests__/openai-provider.test.ts
+++ b/assistant/src/__tests__/openai-provider.test.ts
@@ -1,8 +1,6 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { RetryProvider } from "../providers/retry.js";
-import { createAbortReason } from "../util/abort-reasons.js";
-import { ProviderError } from "../util/errors.js";
 import type {
   ContentBlock,
   Message,
@@ -12,6 +10,8 @@ import type {
   SendMessageOptions,
   ToolDefinition,
 } from "../providers/types.js";
+import { createAbortReason } from "../util/abort-reasons.js";
+import { ProviderError } from "../util/errors.js";
 
 // ---------------------------------------------------------------------------
 // Mock openai module — must be before importing the provider

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -472,26 +472,48 @@ export class RuntimeHttpServer {
             // The runtime is config-authoritative: always resolve the
             // provider from `services.stt.provider` regardless of what
             // the client/gateway requested.
-            const configuredProvider = getConfig().services.stt.provider;
+            //
+            // getConfig() can throw (e.g. after invalidateConfigCache()
+            // when config.json is temporarily invalid). Wrap in try/catch
+            // so the session still starts normally — resolveStreamingTranscriber
+            // reads config inside SttStreamSession.start()'s own guarded path.
+            let configuredProvider: string | undefined;
+            try {
+              configuredProvider = getConfig().services.stt.provider;
 
-            // Mismatch telemetry: when the optional requested provider
-            // disagrees with the configured provider, log a warning so
-            // operators can detect stale client builds.
-            if (sttData.provider && sttData.provider !== configuredProvider) {
+              // Mismatch telemetry: when the optional requested provider
+              // disagrees with the configured provider, log a warning so
+              // operators can detect stale client builds.
+              if (sttData.provider && sttData.provider !== configuredProvider) {
+                log.warn(
+                  {
+                    requestedProvider: sttData.provider,
+                    configuredProvider,
+                    sessionId: sttData.sessionId,
+                  },
+                  "STT stream provider mismatch — requested provider differs from configured provider; using configured provider",
+                );
+              }
+            } catch (err) {
               log.warn(
                 {
-                  requestedProvider: sttData.provider,
-                  configuredProvider,
+                  error: err instanceof Error ? err.message : String(err),
                   sessionId: sttData.sessionId,
                 },
-                "STT stream provider mismatch — requested provider differs from configured provider; using configured provider",
+                "Failed to read config for STT provider mismatch telemetry — proceeding without mismatch check",
               );
             }
+
+            // Fall back to the requested provider (or "unknown") when
+            // config reading failed, so the session constructor still
+            // gets a usable label for logging/error messages.
+            const effectiveProvider =
+              configuredProvider ?? sttData.provider ?? "unknown";
 
             log.info(
               {
                 requestedProvider: sttData.provider ?? "(none)",
-                configuredProvider,
+                configuredProvider: effectiveProvider,
                 mimeType: sttData.mimeType,
                 sessionId: sttData.sessionId,
               },
@@ -499,7 +521,7 @@ export class RuntimeHttpServer {
             );
             const session = new SttStreamSession(
               ws,
-              configuredProvider,
+              effectiveProvider,
               sttData.mimeType,
               { sampleRate: sttData.sampleRate },
             );

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -41,6 +41,7 @@ import {
   hasUngatedHttpAuthDisabled,
   isHttpAuthDisabled,
 } from "../config/env.js";
+import { getConfig } from "../config/loader.js";
 import type { ServerMessage } from "../daemon/message-protocol.js";
 import { PairingStore } from "../daemon/pairing-store.js";
 import {
@@ -310,10 +311,15 @@ interface MediaStreamWebSocketData {
  * WebSocket data attached to `/v1/stt/stream` connections.
  * The `wsType` discriminator routes frames to the STT streaming
  * session orchestrator instead of the other WebSocket handlers.
+ *
+ * `provider` is optional compatibility metadata from the client/gateway.
+ * The runtime is config-authoritative — it always resolves the streaming
+ * transcriber from `services.stt.provider` in the assistant config.
  */
 interface SttStreamWebSocketData {
   wsType: "stt-stream";
-  provider: string;
+  /** Optional requested provider — metadata only; runtime uses config. */
+  provider?: string;
   mimeType: string;
   sampleRate?: number;
   /** The session ID for tracking in the active sessions registry. */
@@ -462,9 +468,30 @@ export class RuntimeHttpServer {
           }
           if ("wsType" in data && data.wsType === "stt-stream") {
             const sttData = data as SttStreamWebSocketData;
+
+            // The runtime is config-authoritative: always resolve the
+            // provider from `services.stt.provider` regardless of what
+            // the client/gateway requested.
+            const configuredProvider = getConfig().services.stt.provider;
+
+            // Mismatch telemetry: when the optional requested provider
+            // disagrees with the configured provider, log a warning so
+            // operators can detect stale client builds.
+            if (sttData.provider && sttData.provider !== configuredProvider) {
+              log.warn(
+                {
+                  requestedProvider: sttData.provider,
+                  configuredProvider,
+                  sessionId: sttData.sessionId,
+                },
+                "STT stream provider mismatch — requested provider differs from configured provider; using configured provider",
+              );
+            }
+
             log.info(
               {
-                provider: sttData.provider,
+                requestedProvider: sttData.provider ?? "(none)",
+                configuredProvider,
                 mimeType: sttData.mimeType,
                 sessionId: sttData.sessionId,
               },
@@ -472,7 +499,7 @@ export class RuntimeHttpServer {
             );
             const session = new SttStreamSession(
               ws,
-              sttData.provider,
+              configuredProvider,
               sttData.mimeType,
               { sampleRate: sttData.sampleRate },
             );
@@ -1328,13 +1355,14 @@ export class RuntimeHttpServer {
     }
 
     const wsUrl = new URL(req.url);
-    const provider = wsUrl.searchParams.get("provider");
+    // provider is optional compatibility metadata — the runtime resolves
+    // the streaming transcriber from config (`services.stt.provider`).
+    const provider = wsUrl.searchParams.get("provider") ?? undefined;
     const mimeType = wsUrl.searchParams.get("mimeType");
-    if (!provider || !mimeType) {
-      return new Response(
-        "Missing required query parameters: provider, mimeType",
-        { status: 400 },
-      );
+    if (!mimeType) {
+      return new Response("Missing required query parameter: mimeType", {
+        status: 400,
+      });
     }
 
     const sampleRateRaw = wsUrl.searchParams.get("sampleRate");

--- a/assistant/src/stt/stt-stream-session.ts
+++ b/assistant/src/stt/stt-stream-session.ts
@@ -9,8 +9,10 @@
  * WebSocket connection with per-session ordering guarantees.
  *
  * Session lifecycle:
- * 1. Client opens a WebSocket to `/v1/stt/stream` with `provider` and
- *    `mimeType` query parameters.
+ * 1. Client opens a WebSocket to `/v1/stt/stream` with required `mimeType`
+ *    query parameter and optional `provider` metadata. The runtime is
+ *    config-authoritative — it resolves the transcriber from
+ *    `services.stt.provider` regardless of the requested provider.
  * 2. The orchestrator resolves a {@link StreamingTranscriber} via
  *    `resolveStreamingTranscriber()` and starts the provider session.
  * 3. The client sends `audio` frames (binary or base64-encoded JSON) and

--- a/gateway/ARCHITECTURE.md
+++ b/gateway/ARCHITECTURE.md
@@ -55,16 +55,18 @@ The request carries base64-encoded WAV audio and a MIME type. The daemon resolve
 
 Native clients (macOS, iOS) open WebSocket connections through the gateway to the daemon's real-time STT streaming endpoint for conversation chat message capture. The gateway authenticates the downstream client using an edge JWT (actor principal required), then opens an upstream WebSocket connection to the daemon's `/v1/stt/stream` endpoint with a short-lived gateway service token. This keeps the daemon's WebSocket endpoint unreachable from the public internet while allowing authenticated clients to stream audio for real-time transcription.
 
-**Client path:** `wss://<gateway>/v1/stt/stream?provider=<id>&mimeType=<mime>[&sampleRate=<hz>]`
+**Config-authoritative model:** The runtime always resolves the streaming transcriber from `services.stt.provider` in the assistant config, regardless of any `provider` query parameter. The `provider` parameter is optional compatibility metadata — when supplied and it disagrees with the configured provider, the runtime logs a mismatch warning for operator visibility.
+
+**Client path:** `wss://<gateway>/v1/stt/stream?mimeType=<mime>[&provider=<id>][&sampleRate=<hz>]`
 
 **Query parameters:**
 
-| Parameter    | Required | Description                                                              |
-| ------------ | -------- | ------------------------------------------------------------------------ |
-| `provider`   | Yes      | STT provider identifier (`deepgram`, `google-gemini`)                    |
-| `mimeType`   | Yes      | MIME type of the audio being streamed (e.g. `audio/webm;codecs=opus`)    |
-| `sampleRate` | No       | Sample rate in Hz (e.g. `16000`). Passed through to the daemon.          |
-| `token`      | No       | Edge JWT (alternative to `Authorization: Bearer` header for WS upgrades) |
+| Parameter    | Required | Description                                                                                                                                                                      |
+| ------------ | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `mimeType`   | Yes      | MIME type of the audio being streamed (e.g. `audio/webm;codecs=opus`)                                                                                                            |
+| `provider`   | No       | Optional STT provider identifier (`deepgram`, `google-gemini`). Forwarded as compatibility metadata — the runtime resolves the transcriber from config, not from this parameter. |
+| `sampleRate` | No       | Sample rate in Hz (e.g. `16000`). Passed through to the daemon.                                                                                                                  |
+| `token`      | No       | Edge JWT (alternative to `Authorization: Bearer` header for WS upgrades)                                                                                                         |
 
 **Auth model:** STT streaming is an authenticated, assistant-scoped path. The client must present a valid edge JWT with an actor principal. Service tokens are rejected. When `runtimeProxyRequireAuth` is globally disabled (dev bypass), the upgrade proceeds without token validation.
 

--- a/gateway/src/__tests__/stt-stream-websocket.test.ts
+++ b/gateway/src/__tests__/stt-stream-websocket.test.ts
@@ -158,7 +158,7 @@ describe("createSttStreamWebsocketHandler", () => {
     expect(server.upgrade).not.toHaveBeenCalled();
   });
 
-  test("returns 400 when provider is missing", () => {
+  test("upgrades successfully when provider is omitted (config-authoritative)", () => {
     const config = makeConfig();
     const handler = createSttStreamWebsocketHandler(config);
     const req = new Request(
@@ -168,8 +168,15 @@ describe("createSttStreamWebsocketHandler", () => {
     const server = makeFakeServer();
     const res = handler(req, server);
 
-    expect(res).toBeInstanceOf(Response);
-    expect(res!.status).toBe(400);
+    expect(res).toBeUndefined();
+    expect(server.upgrade).toHaveBeenCalledTimes(1);
+
+    // Verify provider is undefined in socket data
+    const upgradeCall = (server.upgrade as ReturnType<typeof mock>).mock
+      .calls[0] as unknown[];
+    const opts = upgradeCall[1] as { data: SttStreamSocketData };
+    expect(opts.data.provider).toBeUndefined();
+    expect(opts.data.mimeType).toBe("audio/webm");
   });
 
   test("returns 400 when mimeType is missing", () => {
@@ -177,6 +184,20 @@ describe("createSttStreamWebsocketHandler", () => {
     const handler = createSttStreamWebsocketHandler(config);
     const req = new Request(
       `http://localhost:7830/v1/stt/stream?token=${TEST_TOKEN}&provider=deepgram`,
+      { headers: { upgrade: "websocket" } },
+    );
+    const server = makeFakeServer();
+    const res = handler(req, server);
+
+    expect(res).toBeInstanceOf(Response);
+    expect(res!.status).toBe(400);
+  });
+
+  test("returns 400 when mimeType is missing and provider is also missing", () => {
+    const config = makeConfig();
+    const handler = createSttStreamWebsocketHandler(config);
+    const req = new Request(
+      `http://localhost:7830/v1/stt/stream?token=${TEST_TOKEN}`,
       { headers: { upgrade: "websocket" } },
     );
     const server = makeFakeServer();
@@ -227,11 +248,25 @@ describe("createSttStreamWebsocketHandler", () => {
     expect(server.upgrade).toHaveBeenCalledTimes(1);
   });
 
-  test("returns 400 when auth is disabled but provider is missing", () => {
+  test("upgrades when auth is disabled and provider is omitted", () => {
     const config = makeConfig({ runtimeProxyRequireAuth: false });
     const handler = createSttStreamWebsocketHandler(config);
     const req = new Request(
       "http://localhost:7830/v1/stt/stream?mimeType=audio/webm",
+      { headers: { upgrade: "websocket" } },
+    );
+    const server = makeFakeServer();
+    const res = handler(req, server);
+
+    expect(res).toBeUndefined();
+    expect(server.upgrade).toHaveBeenCalledTimes(1);
+  });
+
+  test("returns 400 when auth is disabled but mimeType is missing", () => {
+    const config = makeConfig({ runtimeProxyRequireAuth: false });
+    const handler = createSttStreamWebsocketHandler(config);
+    const req = new Request(
+      "http://localhost:7830/v1/stt/stream?provider=deepgram",
       { headers: { upgrade: "websocket" } },
     );
     const server = makeFakeServer();

--- a/gateway/src/http/routes/stt-stream-websocket.ts
+++ b/gateway/src/http/routes/stt-stream-websocket.ts
@@ -14,8 +14,15 @@ const MAX_PENDING_MESSAGES = 100;
 export type SttStreamSocketData = {
   wsType: "stt-stream";
   config: GatewayConfig;
-  /** Provider identifier for the STT streaming session (e.g. "deepgram", "google-gemini"). */
-  provider: string;
+  /**
+   * Optional provider identifier for the STT streaming session (e.g.
+   * "deepgram", "google-gemini"). The runtime is config-authoritative —
+   * it always resolves the streaming transcriber from `services.stt.provider`
+   * regardless of this value. When supplied, it is forwarded as compatibility
+   * metadata and the runtime logs a mismatch warning if it disagrees with
+   * the configured provider.
+   */
+  provider?: string;
   /** MIME type of the audio being streamed (e.g. "audio/webm;codecs=opus"). */
   mimeType: string;
   /** Sample rate in Hz, when applicable. */
@@ -53,16 +60,13 @@ export function createSttStreamWebsocketHandler(config: GatewayConfig) {
     if (!config.runtimeProxyRequireAuth) {
       // When runtime proxy auth is globally disabled (dev bypass), we
       // still allow the upgrade but skip token validation.
-      const provider = url.searchParams.get("provider");
+      const provider = url.searchParams.get("provider") ?? undefined;
       const mimeType = url.searchParams.get("mimeType");
 
-      if (!provider || !mimeType) {
-        return new Response(
-          "Missing required query parameters: provider, mimeType",
-          {
-            status: 400,
-          },
-        );
+      if (!mimeType) {
+        return new Response("Missing required query parameter: mimeType", {
+          status: 400,
+        });
       }
 
       const sampleRateRaw = url.searchParams.get("sampleRate");
@@ -126,17 +130,16 @@ export function createSttStreamWebsocketHandler(config: GatewayConfig) {
       return new Response("Unauthorized", { status: 401 });
     }
 
-    // ── Required query parameters ──
-    const provider = url.searchParams.get("provider");
+    // ── Query parameters ──
+    // mimeType is required; provider is optional compatibility metadata
+    // (the runtime resolves the transcriber from config, not from the query).
+    const provider = url.searchParams.get("provider") ?? undefined;
     const mimeType = url.searchParams.get("mimeType");
 
-    if (!provider || !mimeType) {
-      return new Response(
-        "Missing required query parameters: provider, mimeType",
-        {
-          status: 400,
-        },
-      );
+    if (!mimeType) {
+      return new Response("Missing required query parameter: mimeType", {
+        status: 400,
+      });
     }
 
     const sampleRateRaw = url.searchParams.get("sampleRate");
@@ -177,15 +180,19 @@ export function getSttStreamWebsocketHandlers() {
       const upstreamToken = mintServiceToken();
       const query = new URLSearchParams({
         token: upstreamToken,
-        provider,
         mimeType,
       });
+      if (provider) {
+        query.set("provider", provider);
+      }
       if (sampleRate !== undefined) {
         query.set("sampleRate", String(sampleRate));
       }
       const upstreamUrl = `${runtimeBase}/v1/stt/stream?${query.toString()}`;
       const logSafeUpstreamUrl =
-        `${runtimeBase}/v1/stt/stream?token=<redacted>&provider=${provider}&mimeType=${encodeURIComponent(mimeType)}` +
+        `${runtimeBase}/v1/stt/stream?token=<redacted>` +
+        (provider ? `&provider=${provider}` : "") +
+        `&mimeType=${encodeURIComponent(mimeType)}` +
         (sampleRate !== undefined ? `&sampleRate=${sampleRate}` : "");
 
       log.info(

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -874,17 +874,17 @@ export function buildSchema(): Record<string, unknown> {
         get: {
           summary: "STT stream WebSocket",
           description:
-            "Accepts a WebSocket upgrade for real-time speech-to-text streaming. Authenticates the client using an edge JWT (actor principal) and proxies audio frames bidirectionally to the assistant runtime's /v1/stt/stream endpoint using a gateway service token. Requires provider and mimeType query parameters.",
+            "Accepts a WebSocket upgrade for real-time speech-to-text streaming. Authenticates the client using an edge JWT (actor principal) and proxies audio frames bidirectionally to the assistant runtime's /v1/stt/stream endpoint using a gateway service token. Requires mimeType query parameter. The runtime is config-authoritative: the streaming transcriber is always resolved from `services.stt.provider` in the assistant config, not from the optional `provider` query parameter.",
           operationId: "sttStreamWebsocket",
           security: [{ BearerAuth: [] }],
           parameters: [
             {
               name: "provider",
               in: "query",
-              required: true,
+              required: false,
               schema: { type: "string" },
               description:
-                "STT provider identifier (e.g. 'deepgram', 'google-gemini').",
+                "Optional STT provider identifier (e.g. 'deepgram', 'google-gemini'). Forwarded as compatibility metadata — the runtime resolves the transcriber from config (`services.stt.provider`), not from this parameter. When supplied and it disagrees with the configured provider, the runtime logs a mismatch warning.",
             },
             {
               name: "mimeType",
@@ -916,8 +916,7 @@ export function buildSchema(): Record<string, unknown> {
                 "WebSocket upgrade successful — bidirectional STT audio/transcription frame proxying begins.",
             },
             "400": {
-              description:
-                "Missing required query parameters (provider, mimeType)",
+              description: "Missing required query parameter (mimeType)",
               content: {
                 "text/plain": {
                   schema: { type: "string" },


### PR DESCRIPTION
## Summary
- Make provider query parameter optional for /v1/stt/stream websocket upgrades
- Keep runtime transcriber resolution strictly config-driven (services.stt.provider)
- Add mismatch telemetry when optional requested provider disagrees with configured provider
- Update schema, architecture docs, and tests to reflect config-authoritative model

Part of plan: stt-telephony-cleanups.md (PR 3 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25340" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
