### PR TITLE
fix(chat): route queued displayId to stable queueMarkerId sentinel

### DIFF
--- a/clients/macos/vellum-assistantTests/TranscriptItemsTests.swift
+++ b/clients/macos/vellum-assistantTests/TranscriptItemsTests.swift
@@ -133,16 +133,15 @@ final class TranscriptItemsTests: XCTestCase {
         XCTAssertEqual(TranscriptItems.displayId(for: assistantSent.id, in: messages), assistantSent.id)
     }
 
-    func test_displayId_queuedMessage_returnsMarkerAnchorId() {
+    func test_displayId_queuedMessage_returnsQueueMarkerId() {
         let userSent = userMessage(text: "hello", status: .sent)
         let queued1 = userMessage(text: "q1", status: .queued(position: 1))
         let queued2 = userMessage(text: "q2", status: .queued(position: 2))
         let messages = [userSent, queued1, queued2]
 
-        // Both queued messages resolve to the first queued message's id,
-        // which is the marker's anchor id.
-        XCTAssertEqual(TranscriptItems.displayId(for: queued1.id, in: messages), queued1.id)
-        XCTAssertEqual(TranscriptItems.displayId(for: queued2.id, in: messages), queued1.id)
+        XCTAssertEqual(TranscriptItems.displayId(for: queued1.id, in: messages), TranscriptItems.queueMarkerId)
+        XCTAssertEqual(TranscriptItems.displayId(for: queued2.id, in: messages), TranscriptItems.queueMarkerId)
+        XCTAssertNotEqual(TranscriptItems.displayId(for: queued1.id, in: messages), queued1.id)
     }
 
     func test_displayId_missingMessageId_returnsNil() {

--- a/clients/shared/Features/Chat/TranscriptItems.swift
+++ b/clients/shared/Features/Chat/TranscriptItems.swift
@@ -109,12 +109,6 @@ public enum TranscriptItems {
             return false
         }()
         guard isQueuedUser else { return messageId }
-        // The marker's anchor ID is the first queued user message's ID.
-        for message in messages {
-            if message.role == .user, case .queued = message.status {
-                return message.id
-            }
-        }
-        return messageId
+        return queueMarkerId
     }
 }


### PR DESCRIPTION
## Summary
Addresses regression found during re-review of queue-drawer-edit-cancel.md remediation.

**Gap**: #25330 switched the queue marker to the stable `queueMarkerId` sentinel for SwiftUI identity, but `TranscriptItems.displayId(for:in:)` (introduced by #25328) still returned the first queued user message's id. Any `scrollTo(id:)` or flash-highlight targeting a queued message would silently no-op because no rendered view owns that id anymore.

- `displayId` now returns `queueMarkerId` for queued users — the id actually keyed into the ForEach.
- Updated and renamed the macOS test (`test_displayId_queuedMessage_returnsQueueMarkerId`) to assert the sentinel and document that the old behavior is intentionally gone.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25344" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
