### PR TITLE
stt: derive twilio routing from provider catalog metadata

### DIFF
--- a/assistant/docs/stt-provider-onboarding.md
+++ b/assistant/docs/stt-provider-onboarding.md
@@ -114,6 +114,6 @@ Before submitting the PR, verify that:
 
 1. **No stale config references** — grep for any references to a separate telephony transcription config. The telephony routing module (`src/calls/telephony-stt-routing.ts`) reads `services.stt.provider` and maps it to the appropriate Twilio strategy (either `conversation-relay-native` for providers Twilio supports natively, or `media-stream-custom` for server-side transcription).
 
-2. **Provider catalog `telephonyMode`** — the new provider's catalog entry (step 1) declares how it participates in telephony: `"realtime-ws"`, `"batch-only"`, or `"none"`. This value drives the strategy selection in `telephony-stt-routing.ts`.
+2. **Provider catalog `telephonyRouting` metadata** — the new provider's catalog entry (step 1) includes a `telephonyRouting` object that is the single source of truth for strategy selection in `telephony-stt-routing.ts`. This object declares the `strategyKind` (`"conversation-relay-native"` or `"media-stream-custom"`) and, for native providers, provides a `twilioNativeMapping` with the Twilio `provider` name and `defaultSpeechModel`. The routing module contains no hardcoded provider-to-Twilio maps — it reads these values directly from the catalog.
 
 3. **No duplicate wiring** — a provider should appear only once in `services.stt`. The telephony routing layer consumes the same provider ID; there is no second registration step for telephony.

--- a/assistant/src/__tests__/telephony-stt-routing.test.ts
+++ b/assistant/src/__tests__/telephony-stt-routing.test.ts
@@ -31,6 +31,10 @@ import {
   type MediaStreamCustomStrategy,
   resolveTelephonySttRouting,
 } from "../calls/telephony-stt-routing.js";
+import {
+  getProviderEntry,
+  listProviderEntries,
+} from "../providers/speech-to-text/provider-catalog.js";
 import type { SttProviderId } from "../stt/types.js";
 
 // ---------------------------------------------------------------------------
@@ -52,7 +56,7 @@ function buildConfig(overrides: {
 }
 
 // ---------------------------------------------------------------------------
-// Tests — Provider-to-strategy mapping
+// Tests — Provider-to-strategy mapping (catalog-driven)
 // ---------------------------------------------------------------------------
 
 describe("resolveTelephonySttRouting", () => {
@@ -61,7 +65,7 @@ describe("resolveTelephonySttRouting", () => {
   });
 
   // -----------------------------------------------------------------------
-  // Deepgram → conversation-relay-native
+  // Deepgram → conversation-relay-native (from catalog)
   // -----------------------------------------------------------------------
 
   describe("deepgram", () => {
@@ -90,10 +94,25 @@ describe("resolveTelephonySttRouting", () => {
       const strategy = result.strategy as ConversationRelayNativeStrategy;
       expect(strategy.speechModel).toBe("nova-3");
     });
+
+    test("speechModel matches catalog telephonyRouting.twilioNativeMapping.defaultSpeechModel", () => {
+      mockConfig = buildConfig({ provider: "deepgram" });
+      const entry = getProviderEntry("deepgram");
+
+      const result = resolveTelephonySttRouting();
+
+      expect(result.status).toBe("resolved");
+      if (result.status !== "resolved") return;
+
+      const strategy = result.strategy as ConversationRelayNativeStrategy;
+      expect(strategy.speechModel).toBe(
+        entry?.telephonyRouting.twilioNativeMapping?.defaultSpeechModel,
+      );
+    });
   });
 
   // -----------------------------------------------------------------------
-  // Google Gemini → conversation-relay-native
+  // Google Gemini → conversation-relay-native (from catalog)
   // -----------------------------------------------------------------------
 
   describe("google-gemini", () => {
@@ -122,10 +141,25 @@ describe("resolveTelephonySttRouting", () => {
       const strategy = result.strategy as ConversationRelayNativeStrategy;
       expect(strategy.speechModel).toBeUndefined();
     });
+
+    test("speechModel matches catalog telephonyRouting.twilioNativeMapping.defaultSpeechModel", () => {
+      mockConfig = buildConfig({ provider: "google-gemini" });
+      const entry = getProviderEntry("google-gemini");
+
+      const result = resolveTelephonySttRouting();
+
+      expect(result.status).toBe("resolved");
+      if (result.status !== "resolved") return;
+
+      const strategy = result.strategy as ConversationRelayNativeStrategy;
+      expect(strategy.speechModel).toBe(
+        entry?.telephonyRouting.twilioNativeMapping?.defaultSpeechModel,
+      );
+    });
   });
 
   // -----------------------------------------------------------------------
-  // OpenAI Whisper → media-stream-custom
+  // OpenAI Whisper → media-stream-custom (from catalog)
   // -----------------------------------------------------------------------
 
   describe("openai-whisper", () => {
@@ -229,6 +263,67 @@ describe("resolveTelephonySttRouting", () => {
 
         expect(result.strategy.providerId).toBe(provider);
       }
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Catalog-driven mapping verification
+  // -----------------------------------------------------------------------
+
+  describe("catalog-driven mapping", () => {
+    test("every catalog entry with conversation-relay-native routing resolves to that strategy", () => {
+      const nativeEntries = listProviderEntries().filter(
+        (e) => e.telephonyRouting.strategyKind === "conversation-relay-native",
+      );
+      expect(nativeEntries.length).toBeGreaterThan(0);
+
+      for (const entry of nativeEntries) {
+        mockConfig = buildConfig({ provider: entry.id });
+
+        const result = resolveTelephonySttRouting();
+        expect(result.status).toBe("resolved");
+        if (result.status !== "resolved") return;
+
+        expect(result.strategy.strategy).toBe("conversation-relay-native");
+        const strategy = result.strategy as ConversationRelayNativeStrategy;
+        expect(strategy.transcriptionProvider).toBe(
+          entry.telephonyRouting.twilioNativeMapping!.provider,
+        );
+        expect(strategy.speechModel).toBe(
+          entry.telephonyRouting.twilioNativeMapping!.defaultSpeechModel,
+        );
+      }
+    });
+
+    test("every catalog entry with media-stream-custom routing resolves to that strategy", () => {
+      const customEntries = listProviderEntries().filter(
+        (e) => e.telephonyRouting.strategyKind === "media-stream-custom",
+      );
+      expect(customEntries.length).toBeGreaterThan(0);
+
+      for (const entry of customEntries) {
+        mockConfig = buildConfig({ provider: entry.id });
+
+        const result = resolveTelephonySttRouting();
+        expect(result.status).toBe("resolved");
+        if (result.status !== "resolved") return;
+
+        expect(result.strategy.strategy).toBe("media-stream-custom");
+        expect(result.strategy.providerId).toBe(entry.id);
+      }
+    });
+
+    test("routing module contains no hardcoded provider-to-Twilio map", async () => {
+      // Read the source file and verify the hardcoded map was removed.
+      // This is a structural assertion: the catalog is the sole source of truth.
+      const sourceFile = Bun.file(
+        new URL("../calls/telephony-stt-routing.ts", import.meta.url).pathname,
+      );
+      const source = await sourceFile.text();
+
+      expect(source).not.toContain("TWILIO_NATIVE_PROVIDER_MAP");
+      expect(source).not.toContain("new Map<SttProviderId");
+      expect(source).not.toContain("DEEPGRAM_DEFAULT_SPEECH_MODEL");
     });
   });
 });

--- a/assistant/src/calls/telephony-stt-routing.ts
+++ b/assistant/src/calls/telephony-stt-routing.ts
@@ -17,13 +17,16 @@
  *   and the daemon transcribes audio server-side via the provider's
  *   batch API. Used for `openai-whisper`.
  *
- * Model normalization semantics for Twilio-native providers:
- * - Deepgram defaults `speechModel` to `"nova-3"`.
- * - Google leaves `speechModel` undefined (uses provider default).
+ * Strategy selection and model normalization are driven entirely by
+ * the provider catalog's `telephonyRouting` metadata — this module
+ * contains no hardcoded provider-to-Twilio maps.
  */
 
 import { getConfig } from "../config/loader.js";
-import { getProviderEntry } from "../providers/speech-to-text/provider-catalog.js";
+import {
+  getProviderEntry,
+  type TwilioNativeProvider,
+} from "../providers/speech-to-text/provider-catalog.js";
 import type { SttProviderId } from "../stt/types.js";
 
 // ---------------------------------------------------------------------------
@@ -33,10 +36,10 @@ import type { SttProviderId } from "../stt/types.js";
 /**
  * Twilio-native ConversationRelay transcription provider name.
  *
- * These are the values Twilio accepts in the `transcriptionProvider`
- * TwiML attribute on `<ConversationRelay>`.
+ * Re-exported from the provider catalog for downstream consumers that
+ * reference the strategy types without importing the catalog directly.
  */
-export type TwilioNativeTranscriptionProvider = "Deepgram" | "Google";
+export type TwilioNativeTranscriptionProvider = TwilioNativeProvider;
 
 /**
  * The configured STT provider maps to a Twilio-native
@@ -81,47 +84,6 @@ export type TelephonySttRoutingResult =
   | { status: "unknown-provider"; providerId: string; reason: string };
 
 // ---------------------------------------------------------------------------
-// Model normalization constants
-// ---------------------------------------------------------------------------
-
-const DEEPGRAM_DEFAULT_SPEECH_MODEL = "nova-3";
-
-// ---------------------------------------------------------------------------
-// Provider-to-strategy mapping
-// ---------------------------------------------------------------------------
-
-/**
- * Map from `services.stt.provider` ID to the corresponding Twilio-native
- * transcription provider name. Providers absent from this map use the
- * media-stream custom path.
- */
-const TWILIO_NATIVE_PROVIDER_MAP: ReadonlyMap<
-  SttProviderId,
-  TwilioNativeTranscriptionProvider
-> = new Map<SttProviderId, TwilioNativeTranscriptionProvider>([
-  ["deepgram", "Deepgram"],
-  ["google-gemini", "Google"],
-]);
-
-// ---------------------------------------------------------------------------
-// Model normalization
-// ---------------------------------------------------------------------------
-
-/**
- * Resolve the effective speech model for a Twilio-native provider.
- *
- * - Deepgram: defaults to `"nova-3"`.
- * - Google: leaves the model undefined (uses provider default).
- */
-function resolveNativeSpeechModel(
-  twilioProvider: TwilioNativeTranscriptionProvider,
-): string | undefined {
-  return twilioProvider === "Google"
-    ? undefined
-    : DEEPGRAM_DEFAULT_SPEECH_MODEL;
-}
-
-// ---------------------------------------------------------------------------
 // Public resolver
 // ---------------------------------------------------------------------------
 
@@ -129,8 +91,8 @@ function resolveNativeSpeechModel(
  * Resolve the telephony STT routing strategy from `services.stt.provider`.
  *
  * Reads the active provider from config, checks the provider catalog for
- * validity, then maps to either a Twilio-native ConversationRelay strategy
- * or a media-stream custom strategy.
+ * validity, then derives the telephony strategy from the catalog entry's
+ * `telephonyRouting` metadata.
  */
 export function resolveTelephonySttRouting(): TelephonySttRoutingResult {
   const config = getConfig();
@@ -146,22 +108,33 @@ export function resolveTelephonySttRouting(): TelephonySttRoutingResult {
     };
   }
 
-  // Check if this provider maps to a Twilio-native transcription path.
-  const twilioProvider = TWILIO_NATIVE_PROVIDER_MAP.get(entry.id);
+  const { telephonyRouting } = entry;
 
-  if (twilioProvider) {
+  // Derive strategy from catalog routing metadata.
+  if (telephonyRouting.strategyKind === "conversation-relay-native") {
+    const mapping = telephonyRouting.twilioNativeMapping;
+
+    // Defensive: conversation-relay-native entries must have a mapping.
+    if (!mapping) {
+      return {
+        status: "unknown-provider",
+        providerId: entry.id,
+        reason: `Provider "${entry.id}" declares conversation-relay-native strategy but has no twilioNativeMapping`,
+      };
+    }
+
     return {
       status: "resolved",
       strategy: {
         strategy: "conversation-relay-native",
         providerId: entry.id,
-        transcriptionProvider: twilioProvider,
-        speechModel: resolveNativeSpeechModel(twilioProvider),
+        transcriptionProvider: mapping.provider,
+        speechModel: mapping.defaultSpeechModel,
       },
     };
   }
 
-  // Provider is recognized but not Twilio-native — use media-stream path.
+  // media-stream-custom path.
   return {
     status: "resolved",
     strategy: {


### PR DESCRIPTION
## Summary
- Remove hardcoded TWILIO_NATIVE_PROVIDER_MAP from telephony-stt-routing.ts
- Resolve telephony strategy purely from provider catalog routing metadata
- Update routing tests to verify catalog-driven mapping behavior
- Update onboarding docs to reflect catalog as source of truth

Part of plan: stt-telephony-cleanups.md (PR 2 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25345" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
