### PR TITLE
clients: stop sending provider query for streaming stt

### DIFF
--- a/clients/ios/Tests/InputBarVoiceInputTests.swift
+++ b/clients/ios/Tests/InputBarVoiceInputTests.swift
@@ -437,8 +437,6 @@ final class InputBarVoiceInputTests: XCTestCase {
         var stopCallCount = 0
         var closeCallCount = 0
 
-        /// The last provider passed to `start`.
-        var lastProvider: String?
         /// The last mimeType passed to `start`.
         var lastMimeType: String?
         /// The last sampleRate passed to `start`.
@@ -453,14 +451,12 @@ final class InputBarVoiceInputTests: XCTestCase {
         var sentAudioChunks: [Data] = []
 
         func start(
-            provider: String,
             mimeType: String,
             sampleRate: Int?,
             onEvent: @escaping @MainActor (STTStreamEvent) -> Void,
             onFailure: @escaping @MainActor (STTStreamFailure) -> Void
         ) async {
             startCallCount += 1
-            lastProvider = provider
             lastMimeType = mimeType
             lastSampleRate = sampleRate
             capturedOnEvent = onEvent
@@ -502,7 +498,6 @@ final class InputBarVoiceInputTests: XCTestCase {
 
         // Simulate streaming start
         await mockStreaming.start(
-            provider: "deepgram",
             mimeType: "audio/pcm",
             sampleRate: 16000,
             onEvent: { _ in },
@@ -510,7 +505,6 @@ final class InputBarVoiceInputTests: XCTestCase {
         )
 
         XCTAssertEqual(mockStreaming.startCallCount, 1, "Streaming client should have been started once")
-        XCTAssertEqual(mockStreaming.lastProvider, "deepgram")
         XCTAssertEqual(mockStreaming.lastMimeType, "audio/pcm")
         XCTAssertEqual(mockStreaming.lastSampleRate, 16000)
     }
@@ -521,7 +515,6 @@ final class InputBarVoiceInputTests: XCTestCase {
         var receivedTexts: [String] = []
 
         await mockStreaming.start(
-            provider: "deepgram",
             mimeType: "audio/pcm",
             sampleRate: 16000,
             onEvent: { event in
@@ -551,7 +544,6 @@ final class InputBarVoiceInputTests: XCTestCase {
         var finalReceived = false
 
         await mockStreaming.start(
-            provider: "deepgram",
             mimeType: "audio/pcm",
             sampleRate: 16000,
             onEvent: { event in
@@ -608,7 +600,6 @@ final class InputBarVoiceInputTests: XCTestCase {
         var failureReceived: STTStreamFailure?
 
         await mockStreaming.start(
-            provider: "deepgram",
             mimeType: "audio/pcm",
             sampleRate: 16000,
             onEvent: { _ in },
@@ -634,7 +625,6 @@ final class InputBarVoiceInputTests: XCTestCase {
         var failureReceived: STTStreamFailure?
 
         await mockStreaming.start(
-            provider: "google-gemini",
             mimeType: "audio/pcm",
             sampleRate: 16000,
             onEvent: { _ in },
@@ -658,7 +648,6 @@ final class InputBarVoiceInputTests: XCTestCase {
         var failureReceived: STTStreamFailure?
 
         await mockStreaming.start(
-            provider: "openai-whisper",
             mimeType: "audio/pcm",
             sampleRate: 16000,
             onEvent: { _ in },
@@ -769,7 +758,6 @@ final class InputBarVoiceInputTests: XCTestCase {
         var errorReceived = false
 
         await mockStreaming.start(
-            provider: "deepgram",
             mimeType: "audio/pcm",
             sampleRate: 16000,
             onEvent: { event in

--- a/clients/ios/Views/InputBarView.swift
+++ b/clients/ios/Views/InputBarView.swift
@@ -510,13 +510,10 @@ struct InputBarView: View {
             activeStreamingClient = client
             let sessionAtStart = sttSessionId
 
-            // Resolve the configured provider identifier for the streaming request.
-            let providerId = UserDefaults.standard.string(forKey: "sttProvider") ?? ""
             let sampleRateForStream = Int(recordingFormat.sampleRate)
 
             Task { @MainActor in
                 await client.start(
-                    provider: providerId,
                     mimeType: "audio/pcm",
                     sampleRate: sampleRateForStream,
                     onEvent: { event in

--- a/clients/macos/vellum-assistant/App/VoiceInputManager.swift
+++ b/clients/macos/vellum-assistant/App/VoiceInputManager.swift
@@ -1039,13 +1039,6 @@ final class VoiceInputManager {
     /// The `generation` parameter is captured at recording start and checked in
     /// all callbacks to suppress stale-session deliveries.
     private func startStreamingSession(generation: UInt64) {
-        guard let providerId = UserDefaults.standard.string(forKey: "sttProvider"),
-              !providerId.isEmpty else {
-            log.warning("Streaming session requested but no STT provider configured")
-            streamingFailed = true
-            return
-        }
-
         let client = streamingClientFactory()
         self.streamingClient = client
 
@@ -1056,7 +1049,6 @@ final class VoiceInputManager {
 
         Task { [weak self] in
             await client.start(
-                provider: providerId,
                 mimeType: "audio/pcm",
                 sampleRate: sampleRate,
                 onEvent: { [weak self] event in

--- a/clients/macos/vellum-assistantTests/VoiceInputManagerTests.swift
+++ b/clients/macos/vellum-assistantTests/VoiceInputManagerTests.swift
@@ -18,7 +18,6 @@ private final class MockSTTStreamingClient: STTStreamingClientProtocol {
     var stopCallCount = 0
     var closeCallCount = 0
 
-    var startedProvider: String?
     var startedMimeType: String?
     var startedSampleRate: Int?
 
@@ -28,14 +27,12 @@ private final class MockSTTStreamingClient: STTStreamingClientProtocol {
     var onFailure: (@MainActor (STTStreamFailure) -> Void)?
 
     func start(
-        provider: String,
         mimeType: String,
         sampleRate: Int?,
         onEvent: @escaping @MainActor (STTStreamEvent) -> Void,
         onFailure: @escaping @MainActor (STTStreamFailure) -> Void
     ) async {
         startCallCount += 1
-        startedProvider = provider
         startedMimeType = mimeType
         startedSampleRate = sampleRate
         self.onEvent = onEvent

--- a/clients/shared/Network/STTStreamingClient.swift
+++ b/clients/shared/Network/STTStreamingClient.swift
@@ -70,10 +70,12 @@ public enum STTStreamFailure: Sendable, Equatable {
 /// connect, send audio chunks, receive partial/final transcripts, and
 /// handle close/error events.
 public protocol STTStreamingClientProtocol: Sendable {
-    /// Start a streaming STT session with the given provider and audio format.
+    /// Start a streaming STT session with the given audio format.
+    ///
+    /// The server resolves the STT provider from its own configuration —
+    /// clients do not need to specify a provider identifier.
     ///
     /// - Parameters:
-    ///   - provider: STT provider identifier (e.g. `"deepgram"`, `"google-gemini"`).
     ///   - mimeType: MIME type of the audio being streamed (e.g. `"audio/pcm"`).
     ///   - sampleRate: Sample rate in Hz (e.g. `16000`). Optional.
     ///   - onEvent: Callback invoked on the main actor for each server event.
@@ -81,7 +83,6 @@ public protocol STTStreamingClientProtocol: Sendable {
     ///     or terminates abnormally. After this fires, the session is closed and
     ///     callers should fall back to batch STT.
     func start(
-        provider: String,
         mimeType: String,
         sampleRate: Int?,
         onEvent: @escaping @MainActor (STTStreamEvent) -> Void,
@@ -131,7 +132,6 @@ public final class STTStreamingClient: STTStreamingClientProtocol {
     // MARK: - Lifecycle
 
     public func start(
-        provider: String,
         mimeType: String,
         sampleRate: Int?,
         onEvent: @escaping @MainActor (STTStreamEvent) -> Void,
@@ -147,8 +147,9 @@ public final class STTStreamingClient: STTStreamingClientProtocol {
         self.state = .connecting
 
         // Build query parameters for the WebSocket URL.
+        // The server resolves the STT provider from its own configuration —
+        // clients only send audio format metadata.
         var params: [String: String] = [
-            "provider": provider,
             "mimeType": mimeType,
         ]
         if let sampleRate {
@@ -160,7 +161,7 @@ public final class STTStreamingClient: STTStreamingClientProtocol {
                 path: "stt/stream",
                 params: params
             )
-            log.info("Opening STT stream WebSocket: provider=\(provider), mimeType=\(mimeType), sampleRate=\(sampleRate.map(String.init) ?? "nil")")
+            log.info("Opening STT stream WebSocket: mimeType=\(mimeType), sampleRate=\(sampleRate.map(String.init) ?? "nil")")
 
             let task = URLSession.shared.webSocketTask(with: request)
             self.webSocketTask = task


### PR DESCRIPTION
## Summary
- Remove provider argument from STTStreamingClient.start() protocol and implementation
- Update macOS/iOS callsites to use new method signature (mimeType + sampleRate only)
- Update shared, macOS, and iOS streaming tests to assert request construction without provider query
- Keep event handling and fallback behavior unchanged

Part of plan: stt-telephony-cleanups.md (PR 4 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25346" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
