### PR TITLE
docs(daemon): rewrite regenerate fire-and-forget comments to describe current state

### DIFF
--- a/assistant/src/__tests__/regenerate-fire-and-forget-trace.test.ts
+++ b/assistant/src/__tests__/regenerate-fire-and-forget-trace.test.ts
@@ -1,10 +1,10 @@
 /**
  * Guards the observability contract for the fire-and-forget regenerate path.
  *
- * /regenerate no longer awaits runAgentLoop — any error that escapes the
+ * /regenerate does not await runAgentLoop — any error that escapes the
  * agent loop (e.g. a throw from its `finally` block) would otherwise be
  * swallowed by the `.catch()` without the structured `request_error` trace
- * event that the prior handler-level try/catch used to emit.
+ * event needed for observability.
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 

--- a/assistant/src/daemon/conversation-history.ts
+++ b/assistant/src/daemon/conversation-history.ts
@@ -576,8 +576,8 @@ export async function regenerate(
   //
   // runAgentLoop catches most errors internally and emits `request_error`
   // itself, but anything thrown from its `finally` block (commit, drain,
-  // profiler) would otherwise escape silently now that the caller is no
-  // longer awaiting. Mirror the prior handler-level trace emission so the
+  // profiler) would otherwise escape silently because the caller does
+  // not await the agent loop. Emit a structured trace event so the
   // observability contract is preserved on those paths too.
   void conversation
     .runAgentLoop(content, existingUserMessageId, onEvent, {


### PR DESCRIPTION
Addresses Devin's review feedback on #25326. Rewrites two comments that narrated removed/prior code to describe the current state instead, per assistant/AGENTS.md:21.

- assistant/src/daemon/conversation-history.ts: describes why the `.catch()` emits a structured trace without referencing the prior handler-level emission.
- assistant/src/__tests__/regenerate-fire-and-forget-trace.test.ts: file doc-comment describes the current contract without referencing the prior try/catch.

Addresses https://github.com/vellum-ai/vellum-assistant/pull/25326
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25347" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
