### PR TITLE
fix(chat): disable export button when only queued messages exist

### DIFF
--- a/clients/ios/Views/ChatTabView.swift
+++ b/clients/ios/Views/ChatTabView.swift
@@ -52,9 +52,7 @@ struct ChatTabView: View {
 
     @ViewBuilder
     private func exportMenu(messages: [ChatMessage], conversationTitle: String?) -> some View {
-        let hasTextMessages = messages.contains {
-            !$0.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-        }
+        let hasTextMessages = ChatTranscriptFormatter.hasExportableContent(messages: messages)
 
         Menu {
             Button {

--- a/clients/shared/Features/Chat/ChatTranscriptFormatter.swift
+++ b/clients/shared/Features/Chat/ChatTranscriptFormatter.swift
@@ -57,6 +57,16 @@ public enum ChatTranscriptFormatter {
         message.text.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
+    /// True when `conversationMarkdown` would produce non-empty output for `messages`.
+    /// UI should call this to gate export buttons so the predicate stays in lockstep
+    /// with the actual export filter.
+    public static func hasExportableContent(messages: [ChatMessage]) -> Bool {
+        messages.contains { message in
+            guard !isQueuedUser(message) else { return false }
+            return !message.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+    }
+
     /// True when the message is a queued user message (not yet sent to the assistant).
     /// Mirrors the same `role == .user && case .queued = status` check used in
     /// `ChatViewModel`, `TranscriptItems`, and the queue-drawer code paths.

--- a/clients/shared/Tests/ChatTranscriptFormatterTests.swift
+++ b/clients/shared/Tests/ChatTranscriptFormatterTests.swift
@@ -186,6 +186,29 @@ final class ChatTranscriptFormatterTests: XCTestCase {
         XCTAssertEqual(result, "")
     }
 
+    func testHasExportableContentFalseWhenOnlyQueuedUserMessages() {
+        let messages = [
+            ChatMessage(role: .user, text: "Pending one", status: .queued(position: 0)),
+            ChatMessage(role: .user, text: "Pending two", status: .queued(position: 1)),
+        ]
+
+        XCTAssertFalse(ChatTranscriptFormatter.hasExportableContent(messages: messages))
+    }
+
+    func testHasExportableContentTrueWhenSentMessagesPresent() {
+        let messages = [
+            ChatMessage(role: .user, text: "Pending", status: .queued(position: 0)),
+            ChatMessage(role: .user, text: "Hello", status: .sent),
+            ChatMessage(role: .assistant, text: "Hi"),
+        ]
+
+        XCTAssertTrue(ChatTranscriptFormatter.hasExportableContent(messages: messages))
+    }
+
+    func testHasExportableContentFalseWhenEmpty() {
+        XCTAssertFalse(ChatTranscriptFormatter.hasExportableContent(messages: []))
+    }
+
     func testConversationMarkdownKeepsAssistantMessageWithQueuedStatus() {
         // Defensive: filter is scoped to user role, so an assistant message with
         // an unusual status should still come through unchanged.


### PR DESCRIPTION
## Summary

Addresses Codex review feedback on #25325. After that PR filtered queued user messages out of `ChatTranscriptFormatter.conversationMarkdown`, the iOS export menu's \`hasTextMessages\` predicate still counted queued messages — so when a conversation contained only queued drafts, the Copy/Share buttons looked enabled but silently no-op'd (markdown was empty).

## Changes

- **clients/shared/Features/Chat/ChatTranscriptFormatter.swift** — Added \`hasExportableContent(messages:)\` that mirrors the exact filter used in \`conversationMarkdown\` (skips queued user messages, requires non-whitespace text). Exposing this via the formatter keeps UI gating in lockstep with the actual export filter, so future changes can't drift.
- **clients/ios/Views/ChatTabView.swift** — Replaced the inline \`hasTextMessages\` check with \`ChatTranscriptFormatter.hasExportableContent(...)\`. The export menu is now properly disabled when every user message is queued.
- **clients/shared/Tests/ChatTranscriptFormatterTests.swift** — Added three tests covering the new predicate: only-queued (false), mixed queued+sent (true), empty (false).

## macOS note

macOS uses a different pattern — the \"Copy full conversation\" menu item in \`ConversationTitleActionsControl\` has no enabling gate and \`copyActiveConversationToClipboard\` silently returns when markdown is empty. Because there is no visible enabled/disabled state to desync, the iOS-style bug doesn't manifest the same way. A menu-item version of the gate could be added later, but it's out of scope for this targeted fix.

## Test plan

- [ ] Build and run iOS with only queued messages in the composer — export button appears disabled.
- [ ] Send a message, verify export button becomes enabled once a non-queued message lands.
- [ ] New formatter unit tests pass.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25348" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
