### PR TITLE
calls: guard media-stream unsupported setup flows and add regression tests

### DIFF
--- a/assistant/src/__tests__/media-stream-server-integration.test.ts
+++ b/assistant/src/__tests__/media-stream-server-integration.test.ts
@@ -128,20 +128,31 @@ mock.module("../runtime/assistant-scope.js", () => ({
 }));
 
 // Mock the relay setup router so handleStart() doesn't query the database.
-// Returns a normal_call outcome with minimal resolved context.
-mock.module("../calls/relay-setup-router.js", () => ({
-  routeSetup: jest.fn(() => ({
-    outcome: { action: "normal_call" as const, isInbound: true },
-    resolved: {
-      assistantId: "self",
-      isInbound: true,
-      otherPartyNumber: "+15551234567",
-      actorTrust: {
-        trustClass: "guardian" as const,
-        memberRecord: null,
-      },
+// Default returns normal_call; individual tests can override via
+// `mockRouteSetupResult` to exercise deny and unsupported-flow branches.
+let mockRouteSetupResult: {
+  outcome: { action: string; [key: string]: unknown };
+  resolved: {
+    assistantId: string;
+    isInbound: boolean;
+    otherPartyNumber: string;
+    actorTrust: { trustClass: string; memberRecord: null };
+  };
+} = {
+  outcome: { action: "normal_call" as const, isInbound: true },
+  resolved: {
+    assistantId: "self",
+    isInbound: true,
+    otherPartyNumber: "+15551234567",
+    actorTrust: {
+      trustClass: "guardian" as const,
+      memberRecord: null,
     },
-  })),
+  },
+};
+
+mock.module("../calls/relay-setup-router.js", () => ({
+  routeSetup: jest.fn(() => mockRouteSetupResult),
 }));
 
 // Mock the actor trust resolver (used by handleStart to derive trust context)
@@ -181,6 +192,7 @@ mock.module("../calls/resolve-call-tts-provider.js", () => ({
 // Now import the module under test.
 // ---------------------------------------------------------------------------
 
+import { speakSystemPrompt } from "../calls/call-speech-output.js";
 import { registerCallController } from "../calls/call-state.js";
 import { recordCallEvent, updateCallSession } from "../calls/call-store.js";
 import { finalizeCall } from "../calls/finalize-call.js";
@@ -306,6 +318,20 @@ beforeEach(() => {
   (recordCallEvent as jest.Mock).mockClear();
   (updateCallSession as jest.Mock).mockClear();
   (finalizeCall as jest.Mock).mockClear();
+  (speakSystemPrompt as jest.Mock).mockClear();
+  // Reset routeSetup to default normal_call
+  mockRouteSetupResult = {
+    outcome: { action: "normal_call" as const, isInbound: true },
+    resolved: {
+      assistantId: "self",
+      isInbound: true,
+      otherPartyNumber: "+15551234567",
+      actorTrust: {
+        trustClass: "guardian" as const,
+        memberRecord: null,
+      },
+    },
+  };
 });
 
 afterEach(() => {
@@ -726,5 +752,330 @@ describe("activeMediaStreamSessions registry", () => {
     expect(activeMediaStreamSessions.get("call-1")).toBe(session);
     activeMediaStreamSessions.delete("call-1");
     expect(activeMediaStreamSessions.get("call-1")).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario-driven setup outcome coverage
+// ---------------------------------------------------------------------------
+// These tests exercise the deny and unsupported-action branches in
+// MediaStreamCallSession.handleStart by overriding mockRouteSetupResult
+// before sending a start message.
+
+describe("media-stream setup outcome scenarios", () => {
+  describe("deny outcome", () => {
+    test("deny outcome records inbound_acl_denied event and sets status to failed", () => {
+      mockRouteSetupResult = {
+        outcome: {
+          action: "deny",
+          message: "This number is not authorized.",
+          logReason: "Inbound voice ACL: blocked caller",
+        },
+        resolved: {
+          assistantId: "self",
+          isInbound: true,
+          otherPartyNumber: "+15559998888",
+          actorTrust: { trustClass: "unknown", memberRecord: null },
+        },
+      };
+
+      const mockWs = createMockWs();
+      mockSessions.set("call-deny-1", {
+        id: "call-deny-1",
+        conversationId: "conv-deny-1",
+        status: "initiated",
+        task: null,
+        startedAt: null,
+        fromNumber: "+15559998888",
+        toNumber: "+15550001111",
+      });
+
+      const session = new MediaStreamCallSession(mockWs.ws, "call-deny-1");
+      session.handleMessage(makeStartMessage());
+
+      // Should record an inbound_acl_denied event
+      expect(recordCallEvent).toHaveBeenCalledWith(
+        "call-deny-1",
+        "inbound_acl_denied",
+        expect.objectContaining({
+          from: "+15559998888",
+        }),
+      );
+
+      // Should update session to failed
+      expect(updateCallSession).toHaveBeenCalledWith(
+        "call-deny-1",
+        expect.objectContaining({
+          status: "failed",
+          lastError: "Inbound voice ACL: blocked caller",
+        }),
+      );
+
+      // Should NOT register a controller (deny path skips it)
+      expect(registerCallController).not.toHaveBeenCalled();
+    });
+
+    test("deny outcome speaks the denial message", () => {
+      mockRouteSetupResult = {
+        outcome: {
+          action: "deny",
+          message: "This number is not authorized to use this assistant.",
+          logReason: "Inbound voice ACL: member policy deny",
+        },
+        resolved: {
+          assistantId: "self",
+          isInbound: true,
+          otherPartyNumber: "+15559998888",
+          actorTrust: { trustClass: "unknown", memberRecord: null },
+        },
+      };
+
+      const mockWs = createMockWs();
+      mockSessions.set("call-deny-speak-1", {
+        id: "call-deny-speak-1",
+        conversationId: "conv-deny-speak-1",
+        status: "initiated",
+        task: null,
+        startedAt: null,
+        fromNumber: "+15559998888",
+        toNumber: "+15550001111",
+      });
+
+      const session = new MediaStreamCallSession(
+        mockWs.ws,
+        "call-deny-speak-1",
+      );
+      session.handleMessage(makeStartMessage());
+
+      // speakSystemPrompt should be called with the denial message
+      expect(speakSystemPrompt).toHaveBeenCalledWith(
+        expect.anything(),
+        "This number is not authorized to use this assistant.",
+      );
+    });
+
+    test("deny outcome runs finalization", () => {
+      mockRouteSetupResult = {
+        outcome: {
+          action: "deny",
+          message: "Not authorized.",
+          logReason: "ACL deny",
+        },
+        resolved: {
+          assistantId: "self",
+          isInbound: true,
+          otherPartyNumber: "+15559998888",
+          actorTrust: { trustClass: "unknown", memberRecord: null },
+        },
+      };
+
+      const mockWs = createMockWs();
+      mockSessions.set("call-deny-finalize-1", {
+        id: "call-deny-finalize-1",
+        conversationId: "conv-deny-finalize-1",
+        status: "initiated",
+        task: null,
+        startedAt: null,
+        fromNumber: "+15559998888",
+        toNumber: "+15550001111",
+      });
+
+      const session = new MediaStreamCallSession(
+        mockWs.ws,
+        "call-deny-finalize-1",
+      );
+      session.handleMessage(makeStartMessage());
+
+      // finalizeCall should be called because early teardown runs it inline
+      expect(finalizeCall).toHaveBeenCalledWith(
+        "call-deny-finalize-1",
+        "conv-deny-finalize-1",
+      );
+    });
+  });
+
+  describe("unsupported interactive setup flow", () => {
+    test("verification outcome records call_failed with preflight-bypass reason", () => {
+      mockRouteSetupResult = {
+        outcome: {
+          action: "verification",
+          assistantId: "self",
+          fromNumber: "+14155551234",
+        },
+        resolved: {
+          assistantId: "self",
+          isInbound: true,
+          otherPartyNumber: "+14155551234",
+          actorTrust: { trustClass: "unknown", memberRecord: null },
+        },
+      };
+
+      const mockWs = createMockWs();
+      mockSessions.set("call-unsup-verify-1", {
+        id: "call-unsup-verify-1",
+        conversationId: "conv-unsup-verify-1",
+        status: "initiated",
+        task: null,
+        startedAt: null,
+        fromNumber: "+14155551234",
+        toNumber: "+15550001111",
+      });
+
+      const session = new MediaStreamCallSession(
+        mockWs.ws,
+        "call-unsup-verify-1",
+      );
+      session.handleMessage(makeStartMessage());
+
+      // Should record call_failed event with preflight-bypass note
+      expect(recordCallEvent).toHaveBeenCalledWith(
+        "call-unsup-verify-1",
+        "call_failed",
+        expect.objectContaining({
+          reason: expect.stringContaining("verification"),
+          transport: "media-stream",
+        }),
+      );
+
+      // Should set session status to failed
+      expect(updateCallSession).toHaveBeenCalledWith(
+        "call-unsup-verify-1",
+        expect.objectContaining({
+          status: "failed",
+          lastError: expect.stringContaining("preflight guard"),
+        }),
+      );
+
+      // Should NOT register a controller
+      expect(registerCallController).not.toHaveBeenCalled();
+    });
+
+    test("name_capture outcome speaks generic apology and tears down", () => {
+      mockRouteSetupResult = {
+        outcome: {
+          action: "name_capture",
+          assistantId: "self",
+          fromNumber: "+14155551234",
+        },
+        resolved: {
+          assistantId: "self",
+          isInbound: true,
+          otherPartyNumber: "+14155551234",
+          actorTrust: { trustClass: "unknown", memberRecord: null },
+        },
+      };
+
+      const mockWs = createMockWs();
+      mockSessions.set("call-unsup-name-1", {
+        id: "call-unsup-name-1",
+        conversationId: "conv-unsup-name-1",
+        status: "initiated",
+        task: null,
+        startedAt: null,
+        fromNumber: "+14155551234",
+        toNumber: "+15550001111",
+      });
+
+      const session = new MediaStreamCallSession(
+        mockWs.ws,
+        "call-unsup-name-1",
+      );
+      session.handleMessage(makeStartMessage());
+
+      // speakSystemPrompt should be called with the generic apology
+      expect(speakSystemPrompt).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.stringContaining("additional verification"),
+      );
+
+      // Should run finalization inline
+      expect(finalizeCall).toHaveBeenCalledWith(
+        "call-unsup-name-1",
+        "conv-unsup-name-1",
+      );
+    });
+
+    test("callee_verification outcome fails with explicit reason", () => {
+      mockRouteSetupResult = {
+        outcome: {
+          action: "callee_verification",
+          verificationConfig: { maxAttempts: 3, codeLength: 6 },
+        },
+        resolved: {
+          assistantId: "self",
+          isInbound: false,
+          otherPartyNumber: "+14155551234",
+          actorTrust: { trustClass: "guardian", memberRecord: null },
+        },
+      };
+
+      const mockWs = createMockWs();
+      mockSessions.set("call-unsup-callee-1", {
+        id: "call-unsup-callee-1",
+        conversationId: "conv-unsup-callee-1",
+        status: "initiated",
+        task: null,
+        startedAt: null,
+        fromNumber: "+15550001111",
+        toNumber: "+14155551234",
+      });
+
+      const session = new MediaStreamCallSession(
+        mockWs.ws,
+        "call-unsup-callee-1",
+      );
+      session.handleMessage(makeStartMessage());
+
+      // Should record the failure with the specific action
+      expect(recordCallEvent).toHaveBeenCalledWith(
+        "call-unsup-callee-1",
+        "call_failed",
+        expect.objectContaining({
+          reason: expect.stringContaining("callee_verification"),
+        }),
+      );
+
+      // Session should be failed
+      expect(updateCallSession).toHaveBeenCalledWith(
+        "call-unsup-callee-1",
+        expect.objectContaining({ status: "failed" }),
+      );
+    });
+
+    test("normal_call after deny scenario still creates controller", () => {
+      // Verify that after a deny-scenario test, resetting to normal_call
+      // properly creates a controller (no cross-test pollution).
+      mockRouteSetupResult = {
+        outcome: { action: "normal_call", isInbound: true },
+        resolved: {
+          assistantId: "self",
+          isInbound: true,
+          otherPartyNumber: "+15551234567",
+          actorTrust: { trustClass: "guardian", memberRecord: null },
+        },
+      };
+
+      const mockWs = createMockWs();
+      mockSessions.set("call-reset-1", {
+        id: "call-reset-1",
+        conversationId: "conv-reset-1",
+        status: "initiated",
+        task: "Test task",
+        startedAt: null,
+        toNumber: "+15551234567",
+      });
+
+      const session = new MediaStreamCallSession(mockWs.ws, "call-reset-1");
+      session.handleMessage(makeStartMessage());
+
+      // Controller should be registered for normal calls
+      expect(registerCallController).toHaveBeenCalledWith(
+        "call-reset-1",
+        expect.anything(),
+      );
+
+      // Initial greeting should fire
+      expect(mockStartInitialGreeting).toHaveBeenCalled();
+    });
   });
 });

--- a/assistant/src/__tests__/twilio-routes.test.ts
+++ b/assistant/src/__tests__/twilio-routes.test.ts
@@ -72,6 +72,30 @@ function resolveIngressBaseUrlFromConfig(ingressConfig: unknown): string {
   );
 }
 
+// Default routeSetup mock — returns normal_call. Tests that need different
+// outcomes override `mockRouteSetupResult` before calling the handler.
+let mockRouteSetupResult: {
+  outcome: { action: string; [key: string]: unknown };
+  resolved: {
+    assistantId: string;
+    isInbound: boolean;
+    otherPartyNumber: string;
+    actorTrust: { trustClass: string; memberRecord: null };
+  };
+} = {
+  outcome: { action: "normal_call", isInbound: true },
+  resolved: {
+    assistantId: "self",
+    isInbound: true,
+    otherPartyNumber: "+15559998888",
+    actorTrust: { trustClass: "guardian", memberRecord: null },
+  },
+};
+
+mock.module("../calls/relay-setup-router.js", () => ({
+  routeSetup: () => mockRouteSetupResult,
+}));
+
 mock.module("../config/env.js", () => ({
   isHttpAuthDisabled: () => true,
   getGatewayInternalBaseUrl: () => "http://gateway.internal:7830",
@@ -433,6 +457,16 @@ describe("twilio webhook routes", () => {
     mockTwilioApiValidationBody = JSON.stringify({ sid: "AC_validated" });
     // Reset STT config to defaults between tests
     mockConfigObj.services.stt.provider = "deepgram" as any;
+    // Reset routeSetup mock to default normal_call
+    mockRouteSetupResult = {
+      outcome: { action: "normal_call", isInbound: true },
+      resolved: {
+        assistantId: "self",
+        isInbound: true,
+        otherPartyNumber: "+15559998888",
+        actorTrust: { trustClass: "guardian", memberRecord: null },
+      },
+    };
 
     globalThis.fetch = (async (
       url: string | URL | Request,
@@ -1163,6 +1197,187 @@ describe("twilio webhook routes", () => {
       // Must be Stream (from services.stt), NOT ConversationRelay
       expect(twiml).toContain("<Stream");
       expect(twiml).not.toContain("<ConversationRelay");
+    });
+  });
+
+  // ── Media-stream preflight setup guardrails ──────────────────────────
+  // These tests assert that the TwiML preflight guard in
+  // buildVoiceWebhookTwiml rejects unsupported interactive setup actions
+  // for media-stream-custom calls before stream bootstrap, falling back
+  // to ConversationRelay for interactive flows.
+
+  describe("media-stream preflight setup guardrails", () => {
+    test("media-stream: normal_call setup proceeds with Stream TwiML", async () => {
+      mockConfigObj.services.stt.provider = "openai-whisper" as any;
+      mockRouteSetupResult = {
+        outcome: { action: "normal_call", isInbound: true },
+        resolved: {
+          assistantId: "self",
+          isInbound: true,
+          otherPartyNumber: "+15559998888",
+          actorTrust: { trustClass: "guardian", memberRecord: null },
+        },
+      };
+
+      const session = createTestSession("conv-ms-normal-1", "CA_ms_normal_1");
+      const req = makeVoiceRequest(session.id, { CallSid: "CA_ms_normal_1" });
+
+      const res = await handleVoiceWebhook(req);
+      expect(res.status).toBe(200);
+
+      const twiml = await res.text();
+      expect(twiml).toContain("<Stream");
+      expect(twiml).not.toContain("<ConversationRelay");
+    });
+
+    test("media-stream: deny setup proceeds with Stream TwiML (deny is handled at stream level)", async () => {
+      mockConfigObj.services.stt.provider = "openai-whisper" as any;
+      mockRouteSetupResult = {
+        outcome: {
+          action: "deny",
+          message: "This number is not authorized.",
+          logReason: "Inbound voice ACL: blocked caller",
+        },
+        resolved: {
+          assistantId: "self",
+          isInbound: true,
+          otherPartyNumber: "+15559998888",
+          actorTrust: { trustClass: "unknown", memberRecord: null },
+        },
+      };
+
+      const session = createTestSession("conv-ms-deny-1", "CA_ms_deny_1");
+      const req = makeVoiceRequest(session.id, { CallSid: "CA_ms_deny_1" });
+
+      const res = await handleVoiceWebhook(req);
+      expect(res.status).toBe(200);
+
+      const twiml = await res.text();
+      // Deny is supported on media-stream — should still produce Stream TwiML
+      expect(twiml).toContain("<Stream");
+      expect(twiml).not.toContain("<ConversationRelay");
+    });
+
+    test("media-stream: verification setup falls back to ConversationRelay", async () => {
+      mockConfigObj.services.stt.provider = "openai-whisper" as any;
+      mockRouteSetupResult = {
+        outcome: {
+          action: "verification",
+          assistantId: "self",
+          fromNumber: "+14155551234",
+        },
+        resolved: {
+          assistantId: "self",
+          isInbound: true,
+          otherPartyNumber: "+14155551234",
+          actorTrust: { trustClass: "unknown", memberRecord: null },
+        },
+      };
+
+      const session = createTestSession("conv-ms-verify-1", "CA_ms_verify_1");
+      const req = makeVoiceRequest(session.id, { CallSid: "CA_ms_verify_1" });
+
+      const res = await handleVoiceWebhook(req);
+      expect(res.status).toBe(200);
+
+      const twiml = await res.text();
+      // Interactive verification cannot work on media-stream — must fall back
+      expect(twiml).toContain("<ConversationRelay");
+      expect(twiml).not.toContain("<Stream");
+      expect(twiml).toContain('transcriptionProvider="Deepgram"');
+    });
+
+    test("media-stream: name_capture setup falls back to ConversationRelay", async () => {
+      mockConfigObj.services.stt.provider = "openai-whisper" as any;
+      mockRouteSetupResult = {
+        outcome: {
+          action: "name_capture",
+          assistantId: "self",
+          fromNumber: "+14155551234",
+        },
+        resolved: {
+          assistantId: "self",
+          isInbound: true,
+          otherPartyNumber: "+14155551234",
+          actorTrust: { trustClass: "unknown", memberRecord: null },
+        },
+      };
+
+      const session = createTestSession("conv-ms-namecap-1", "CA_ms_namecap_1");
+      const req = makeVoiceRequest(session.id, {
+        CallSid: "CA_ms_namecap_1",
+      });
+
+      const res = await handleVoiceWebhook(req);
+      expect(res.status).toBe(200);
+
+      const twiml = await res.text();
+      expect(twiml).toContain("<ConversationRelay");
+      expect(twiml).not.toContain("<Stream");
+    });
+
+    test("media-stream: invite_redemption setup falls back to ConversationRelay", async () => {
+      mockConfigObj.services.stt.provider = "openai-whisper" as any;
+      mockRouteSetupResult = {
+        outcome: {
+          action: "invite_redemption",
+          assistantId: "self",
+          fromNumber: "+14155551234",
+          friendName: "Alice",
+          guardianName: "Bob",
+        },
+        resolved: {
+          assistantId: "self",
+          isInbound: true,
+          otherPartyNumber: "+14155551234",
+          actorTrust: { trustClass: "unknown", memberRecord: null },
+        },
+      };
+
+      const session = createTestSession("conv-ms-invite-1", "CA_ms_invite_1");
+      const req = makeVoiceRequest(session.id, {
+        CallSid: "CA_ms_invite_1",
+      });
+
+      const res = await handleVoiceWebhook(req);
+      expect(res.status).toBe(200);
+
+      const twiml = await res.text();
+      expect(twiml).toContain("<ConversationRelay");
+      expect(twiml).not.toContain("<Stream");
+    });
+
+    test("conversation-relay-native: unsupported setup does not trigger preflight (not media-stream)", async () => {
+      // When the STT provider is deepgram (conversation-relay-native),
+      // the preflight guard is not invoked — setup flows are handled
+      // natively by the relay server.
+      mockConfigObj.services.stt.provider = "deepgram" as any;
+      mockRouteSetupResult = {
+        outcome: {
+          action: "verification",
+          assistantId: "self",
+          fromNumber: "+14155551234",
+        },
+        resolved: {
+          assistantId: "self",
+          isInbound: true,
+          otherPartyNumber: "+14155551234",
+          actorTrust: { trustClass: "unknown", memberRecord: null },
+        },
+      };
+
+      const session = createTestSession("conv-cr-verify-1", "CA_cr_verify_1");
+      const req = makeVoiceRequest(session.id, {
+        CallSid: "CA_cr_verify_1",
+      });
+
+      const res = await handleVoiceWebhook(req);
+      expect(res.status).toBe(200);
+
+      const twiml = await res.text();
+      // ConversationRelay should be emitted regardless of setup outcome
+      expect(twiml).toContain("<ConversationRelay");
+      expect(twiml).not.toContain("<Stream");
     });
   });
 

--- a/assistant/src/calls/media-stream-server.ts
+++ b/assistant/src/calls/media-stream-server.ts
@@ -387,24 +387,27 @@ export class MediaStreamCallSession {
       default:
         // All interactive sub-flows (verification, invite_redemption,
         // name_capture, callee_verification, outbound_verification) are
-        // not supported on the media-stream transport. Speak a generic
-        // apology and end the session rather than silently bypassing
-        // policy enforcement.
-        log.warn(
+        // not supported on the media-stream transport. The TwiML preflight
+        // in twilio-routes.ts should have caught this and fallen back to
+        // ConversationRelay — reaching here indicates the preflight was
+        // bypassed or a new setup action was added without updating the
+        // preflight guard. Speak a generic apology and end the session
+        // rather than silently bypassing policy enforcement.
+        log.error(
           {
             callSessionId: this.callSessionId,
             action: outcome.action,
           },
-          "Media-stream transport does not support interactive setup flow — ending session",
+          "Media-stream transport received unsupported setup flow — preflight guard should have prevented this",
         );
         recordCallEvent(this.callSessionId, "call_failed", {
-          reason: `Setup flow '${outcome.action}' not supported on media-stream transport`,
+          reason: `Setup flow '${outcome.action}' not supported on media-stream transport (preflight guard bypass)`,
           transport: "media-stream",
         });
         updateCallSession(this.callSessionId, {
           status: "failed",
           endedAt: Date.now(),
-          lastError: `Setup flow '${outcome.action}' not supported on media-stream transport`,
+          lastError: `Setup flow '${outcome.action}' not supported on media-stream transport — preflight guard should have prevented this`,
         });
         // Run finalization now because handleTransportClosed will see
         // terminal status and exit early when the WebSocket closes.
@@ -416,7 +419,7 @@ export class MediaStreamCallSession {
           setTimeout(
             () =>
               this.output.endSession(
-                `Unsupported setup flow: ${outcome.action}`,
+                `Unsupported setup flow: ${outcome.action} (preflight guard bypass)`,
               ),
             3000,
           );

--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -44,6 +44,7 @@ import {
   releaseCallbackClaim,
   updateCallSession,
 } from "./call-store.js";
+import { routeSetup } from "./relay-setup-router.js";
 import { resolveCallHints } from "./stt-hints.js";
 import { resolveTelephonySttRouting } from "./telephony-stt-routing.js";
 import type { CallStatus } from "./types.js";
@@ -401,7 +402,46 @@ function buildVoiceWebhookTwiml(
     );
   }
 
-  // media-stream-custom path
+  // media-stream-custom path — preflight check to reject interactive setup
+  // flows that the media-stream transport cannot support. The media-stream
+  // server has a defensive fallback for these cases, but catching them here
+  // avoids bootstrapping a WebSocket session that will immediately fail.
+  const session = getCallSession(callSessionId);
+  const from = sessionContext?.fromNumber ?? "";
+  const to = sessionContext?.toNumber ?? "";
+
+  const { outcome } = routeSetup({
+    callSessionId,
+    session: session ?? null,
+    from,
+    to,
+  });
+
+  // The media-stream transport supports normal_call and deny (which speaks
+  // a message and tears down). All other outcomes require interactive
+  // sub-flows (DTMF entry, name capture, guardian wait) that media-stream
+  // cannot perform. Reject these deterministically before stream bootstrap.
+  if (outcome.action !== "normal_call" && outcome.action !== "deny") {
+    log.warn(
+      {
+        callSessionId,
+        setupAction: outcome.action,
+        strategy: "media-stream-custom",
+      },
+      "Media-stream preflight rejected unsupported interactive setup flow — falling back to ConversationRelay with Deepgram",
+    );
+    // Fall back to ConversationRelay so the interactive flow can proceed
+    // through the relay server which supports it natively.
+    return buildConversationRelayResponse(
+      callSessionId,
+      cfg,
+      profile,
+      sessionContext,
+      verificationSessionId,
+      { transcriptionProvider: "Deepgram", speechModel: "nova-3" },
+    );
+  }
+
   return buildMediaStreamResponse(callSessionId, cfg, verificationSessionId);
 }
 


### PR DESCRIPTION
## Summary
- Add preflight guard in twilio-routes.ts to reject unsupported interactive setup actions before media-stream bootstrap
- Tighten media-stream-server.ts defensive handling with explicit failure cause logging
- Add Twilio route tests for normal_call, deny, and unsupported setup actions
- Replace fixed normal_call mock in integration tests with scenario-driven coverage

Part of plan: stt-telephony-cleanups.md (PR 6 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25349" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
