### PR TITLE
M1: Add 3-dot hover menu to group section headers

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionHeader.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionHeader.swift
@@ -35,6 +35,15 @@ struct SidebarSectionHeader: View {
     var sidebar: SidebarInteractionState?
 
     @State private var isHeaderHovered: Bool = false
+    @State private var isMenuOpen: Bool = false
+
+    /// Whether the trailing ellipsis button should be visible (hovered or menu open).
+    private var hasTrailingIcon: Bool { isHeaderHovered || isMenuOpen }
+
+    /// Whether any context menu action is available (mirrors ConditionalGroupContextMenu logic).
+    private var hasAnyAction: Bool {
+        onRename != nil || onDelete != nil || onMarkAllRead != nil || onArchiveAll != nil
+    }
 
     private var isGroupPinned: Bool {
         group.id == ConversationGroup.pinned.id
@@ -70,7 +79,7 @@ struct SidebarSectionHeader: View {
                 .foregroundStyle(VColor.contentSecondary)
 
             Spacer()
-            if !isExpanded {
+            if !isExpanded && !hasTrailingIcon {
                 switch aggregateState {
                 case .error:
                     VIconView(.circleAlert, size: 10)
@@ -97,7 +106,51 @@ struct SidebarSectionHeader: View {
         .frame(minHeight: SidebarLayoutMetrics.rowMinHeight)
         .contentShape(Rectangle())
         .overlay(alignment: .trailing) {
-            if conversationCount > 0 {
+            if hasTrailingIcon && hasAnyAction {
+                VButton(
+                    label: "More options for \(group.name)",
+                    iconOnly: VIcon.ellipsis.rawValue,
+                    style: .ghost,
+                    iconSize: 20,
+                    tooltip: "More options",
+                    iconColor: VColor.contentSecondary
+                ) {
+                    guard !isMenuOpen else { return }
+                    isMenuOpen = true
+                    let appearance = NSApp.keyWindow?.effectiveAppearance
+                    VMenuPanel.show(
+                        at: NSEvent.mouseLocation,
+                        sourceAppearance: appearance
+                    ) {
+                        VMenu(width: 200) {
+                            if let onMarkAllRead {
+                                VMenuItem(icon: VIcon.circleCheck.rawValue, label: "Mark All as Read") {
+                                    onMarkAllRead()
+                                }
+                                .disabled(!hasUnreadConversations)
+                            }
+                            if let onArchiveAll {
+                                VMenuItem(icon: VIcon.archive.rawValue, label: "Archive All\u{2026}") {
+                                    onArchiveAll()
+                                }
+                                .disabled(conversationCount == 0)
+                            }
+                            if (onMarkAllRead != nil || onArchiveAll != nil) && (onRename != nil || onDelete != nil) {
+                                VMenuDivider()
+                            }
+                            if let onRename {
+                                VMenuItem(icon: VIcon.pencil.rawValue, label: "Rename") { onRename(group.name) }
+                            }
+                            if let onDelete {
+                                VMenuItem(icon: VIcon.trash.rawValue, label: conversationCount > 0 ? "Delete group\u{2026}" : "Delete group") { onDelete() }
+                            }
+                        }
+                    } onDismiss: {
+                        isMenuOpen = false
+                    }
+                }
+                .padding(.trailing, VSpacing.xs)
+            } else if conversationCount > 0 {
                 Text("\(conversationCount)")
                     .font(VFont.labelSmall)
                     .foregroundStyle(VColor.contentTertiary)
@@ -110,6 +163,8 @@ struct SidebarSectionHeader: View {
                     .padding(.trailing, VSpacing.xs)
             }
         }
+        .animation(VAnimation.fast, value: isHeaderHovered)
+        .animation(VAnimation.fast, value: isMenuOpen)
         .onTapGesture { withAnimation(VAnimation.fast) { onToggleExpand() } }
         .pointerCursor(onHover: { hovering in
             isHeaderHovered = hovering

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionHeader.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionHeader.swift
@@ -105,6 +105,9 @@ struct SidebarSectionHeader: View {
         .padding(.vertical, SidebarLayoutMetrics.rowVerticalPadding)
         .frame(minHeight: SidebarLayoutMetrics.rowMinHeight)
         .contentShape(Rectangle())
+        .animation(VAnimation.fast, value: isHeaderHovered)
+        .animation(VAnimation.fast, value: isMenuOpen)
+        .onTapGesture { withAnimation(VAnimation.fast) { onToggleExpand() } }
         .overlay(alignment: .trailing) {
             if hasTrailingIcon && hasAnyAction {
                 VButton(
@@ -163,9 +166,6 @@ struct SidebarSectionHeader: View {
                     .padding(.trailing, VSpacing.xs)
             }
         }
-        .animation(VAnimation.fast, value: isHeaderHovered)
-        .animation(VAnimation.fast, value: isMenuOpen)
-        .onTapGesture { withAnimation(VAnimation.fast) { onToggleExpand() } }
         .pointerCursor(onHover: { hovering in
             isHeaderHovered = hovering
         })


### PR DESCRIPTION
## Summary
- Add hover-triggered ellipsis button to `SidebarSectionHeader` that replaces count badge and aggregate state indicators on hover
- Clicking the button opens the same `VMenuPanel` context menu as right-click (Mark All as Read, Archive All, Rename, Delete group)
- Follows the exact same pattern as `SidebarConversationItem` (ghost VButton, VMenuPanel.show API, trailing overlay)

## Test plan
- [ ] Hover over a group section header — the 3-dot ellipsis button should appear, replacing the count badge and aggregate state indicator
- [ ] Click the ellipsis button — a VMenuPanel should open with the same items as the right-click context menu
- [ ] While the menu is open, mouse can leave the header without the button disappearing
- [ ] Dismiss the menu — the count badge and aggregate state indicator should reappear
- [ ] Verify system groups show the menu (with Mark All as Read, Archive All)
- [ ] Verify custom groups show additional Rename and Delete group items
- [ ] Right-click context menu continues to work as before

Closes #25352.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25354" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
