### PR TITLE
M2: Add 3-dot hover menu to subgroup disclosure headers

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionView.swift
@@ -52,6 +52,7 @@ struct SidebarSectionView: View {
     /// (mirrors showAll at the section level but per sub-group key).
     @State private var showAllInSubGroup: Set<String> = []
     @State private var hoveredSubGroupKey: String?
+    @State private var menuOpenSubGroupKey: String?
 
     enum CountMode {
         case items
@@ -238,6 +239,9 @@ struct SidebarSectionView: View {
     private func scheduleSubGroupDisclosure(_ subGroup: ScheduleSubGroup) -> some View {
         let isSubGroupExpanded = expandedScheduleGroups?.wrappedValue.contains(subGroup.key) ?? false
         let hasUnread = subGroup.conversations.contains(where: \.hasUnseenLatestAssistantMessage)
+        let isSubGroupHovered = hoveredSubGroupKey == subGroup.key
+        let isSubGroupMenuOpen = menuOpenSubGroupKey == subGroup.key
+        let showEllipsis = isSubGroupHovered || isSubGroupMenuOpen
 
         // Disclosure header — layout matches SidebarConversationItem's skeleton
         // so the chevron aligns with the pin icon and the badge aligns with the ellipsis.
@@ -263,10 +267,10 @@ struct SidebarSectionView: View {
                     font: VFont.bodySmallDefault,
                     measuringFont: VFont.nsBodySmallDefault,
                     foregroundStyle: VColor.contentTertiary,
-                    isHovered: hoveredSubGroupKey == subGroup.key
+                    isHovered: isSubGroupHovered
                 )
                 Spacer()
-                if hasUnread {
+                if hasUnread && !showEllipsis {
                     VBadge(style: .dot, color: VColor.systemMidStrong)
                         .transition(.opacity)
                 }
@@ -277,22 +281,63 @@ struct SidebarSectionView: View {
             .padding(.vertical, SidebarLayoutMetrics.rowVerticalPadding)
             .frame(minHeight: SidebarLayoutMetrics.rowMinHeight)
             .contentShape(Rectangle())
-            // Count badge — trailing overlay matching ellipsis button position
+            // Count badge — hidden on hover when the ellipsis button takes over
             .overlay(alignment: .trailing) {
-                Text("\(subGroup.conversations.count)")
-                    .font(.system(size: 10, weight: .medium))
-                    .foregroundStyle(VColor.contentTertiary)
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 2)
-                    .background(
-                        Capsule()
-                            .fill(VColor.contentTertiary.opacity(0.12))
-                    )
-                    .padding(.trailing, VSpacing.xs)
+                if !showEllipsis {
+                    Text("\(subGroup.conversations.count)")
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundStyle(VColor.contentTertiary)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(
+                            Capsule()
+                                .fill(VColor.contentTertiary.opacity(0.12))
+                        )
+                        .padding(.trailing, VSpacing.xs)
+                }
             }
         }
         .buttonStyle(.plain)
         .pointerCursor()
+        .animation(VAnimation.fast, value: showEllipsis)
+        // Ellipsis button overlay — rendered outside the Button label so it
+        // participates in the hit-test chain above the parent tap gesture.
+        .overlay(alignment: .trailing) {
+            if showEllipsis {
+                VButton(
+                    label: "More options for \(subGroup.label)",
+                    iconOnly: VIcon.ellipsis.rawValue,
+                    style: .ghost,
+                    iconSize: 20,
+                    tooltip: "More options",
+                    iconColor: VColor.contentSecondary
+                ) {
+                    guard menuOpenSubGroupKey != subGroup.id else { return }
+                    menuOpenSubGroupKey = subGroup.id
+                    let appearance = NSApp.keyWindow?.effectiveAppearance
+                    VMenuPanel.show(
+                        at: NSEvent.mouseLocation,
+                        sourceAppearance: appearance
+                    ) {
+                        VMenu(width: 200) {
+                            let unread = subGroup.conversations.filter(\.hasUnseenLatestAssistantMessage)
+                            VMenuItem(icon: VIcon.circleCheck.rawValue, label: "Mark All as Read") {
+                                onMarkAllReadInSubGroup?(subGroup.label, subGroup.conversations.map(\.id))
+                            }
+                            .disabled(unread.isEmpty)
+                            let archivable = subGroup.conversations.filter { !$0.isChannelConversation }
+                            VMenuItem(icon: VIcon.archive.rawValue, label: "Archive All\u{2026}") {
+                                onArchiveAllInSubGroup?(subGroup.label, archivable.map(\.id))
+                            }
+                            .disabled(archivable.isEmpty)
+                        }
+                    } onDismiss: {
+                        menuOpenSubGroupKey = nil
+                    }
+                }
+                .padding(.trailing, VSpacing.xs)
+            }
+        }
         .onHover { hovering in
             if hovering {
                 hoveredSubGroupKey = subGroup.key

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionView.swift
@@ -245,7 +245,52 @@ struct SidebarSectionView: View {
 
         // Disclosure header — layout matches SidebarConversationItem's skeleton
         // so the chevron aligns with the pin icon and the badge aligns with the ellipsis.
-        Button {
+        // Uses .onTapGesture instead of Button so overlay VButtons sit above the
+        // tap gesture in the hit-test chain and absorb taps without triggering the
+        // toggle (same pattern as SidebarSectionHeader and SidebarConversationItem).
+        HStack(spacing: VSpacing.xs) {
+            // Leading 20x20 slot — chevron centered, matching pin icon position
+            VIconView(.chevronRight, size: 10)
+                .foregroundStyle(VColor.contentTertiary)
+                .rotationEffect(.degrees(isSubGroupExpanded ? 90 : 0))
+                .animation(VAnimation.fast, value: isSubGroupExpanded)
+                .frame(width: 20, height: 20)
+
+            VMarqueeText(
+                text: subGroup.label,
+                font: VFont.bodySmallDefault,
+                measuringFont: VFont.nsBodySmallDefault,
+                foregroundStyle: VColor.contentTertiary,
+                isHovered: isSubGroupHovered
+            )
+            Spacer()
+            if hasUnread && !showEllipsis {
+                VBadge(style: .dot, color: VColor.systemMidStrong)
+                    .transition(.opacity)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.leading, VSpacing.xs)
+        .padding(.trailing, SidebarLayoutMetrics.trailingIconPadding)
+        .padding(.vertical, SidebarLayoutMetrics.rowVerticalPadding)
+        .frame(minHeight: SidebarLayoutMetrics.rowMinHeight)
+        .contentShape(Rectangle())
+        // Count badge — hidden on hover when the ellipsis button takes over
+        .overlay(alignment: .trailing) {
+            if !showEllipsis {
+                Text("\(subGroup.conversations.count)")
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundStyle(VColor.contentTertiary)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(
+                        Capsule()
+                            .fill(VColor.contentTertiary.opacity(0.12))
+                    )
+                    .padding(.trailing, VSpacing.xs)
+            }
+        }
+        .onTapGesture {
             withAnimation(VAnimation.fast) {
                 if isSubGroupExpanded {
                     expandedScheduleGroups?.wrappedValue.remove(subGroup.key)
@@ -253,55 +298,12 @@ struct SidebarSectionView: View {
                     expandedScheduleGroups?.wrappedValue.insert(subGroup.key)
                 }
             }
-        } label: {
-            HStack(spacing: VSpacing.xs) {
-                // Leading 20x20 slot — chevron centered, matching pin icon position
-                VIconView(.chevronRight, size: 10)
-                    .foregroundStyle(VColor.contentTertiary)
-                    .rotationEffect(.degrees(isSubGroupExpanded ? 90 : 0))
-                    .animation(VAnimation.fast, value: isSubGroupExpanded)
-                    .frame(width: 20, height: 20)
-
-                VMarqueeText(
-                    text: subGroup.label,
-                    font: VFont.bodySmallDefault,
-                    measuringFont: VFont.nsBodySmallDefault,
-                    foregroundStyle: VColor.contentTertiary,
-                    isHovered: isSubGroupHovered
-                )
-                Spacer()
-                if hasUnread && !showEllipsis {
-                    VBadge(style: .dot, color: VColor.systemMidStrong)
-                        .transition(.opacity)
-                }
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.leading, VSpacing.xs)
-            .padding(.trailing, SidebarLayoutMetrics.trailingIconPadding)
-            .padding(.vertical, SidebarLayoutMetrics.rowVerticalPadding)
-            .frame(minHeight: SidebarLayoutMetrics.rowMinHeight)
-            .contentShape(Rectangle())
-            // Count badge — hidden on hover when the ellipsis button takes over
-            .overlay(alignment: .trailing) {
-                if !showEllipsis {
-                    Text("\(subGroup.conversations.count)")
-                        .font(.system(size: 10, weight: .medium))
-                        .foregroundStyle(VColor.contentTertiary)
-                        .padding(.horizontal, 6)
-                        .padding(.vertical, 2)
-                        .background(
-                            Capsule()
-                                .fill(VColor.contentTertiary.opacity(0.12))
-                        )
-                        .padding(.trailing, VSpacing.xs)
-                }
-            }
         }
-        .buttonStyle(.plain)
         .pointerCursor()
         .animation(VAnimation.fast, value: showEllipsis)
-        // Ellipsis button overlay — rendered outside the Button label so it
-        // participates in the hit-test chain above the parent tap gesture.
+        // Ellipsis button overlay — rendered after .onTapGesture so it sits
+        // above it in the hit-test chain and absorbs taps without triggering
+        // the disclosure toggle (same pattern as SidebarConversationItem).
         .overlay(alignment: .trailing) {
             if showEllipsis {
                 VButton(


### PR DESCRIPTION
## Summary
- Add hover-triggered ellipsis button to subgroup disclosure headers that replaces count badge and unread dot on hover
- Clicking the ellipsis opens a VMenuPanel with the same menu items as the right-click context menu (Mark All as Read, Archive All)
- Follows the exact same VButton/VMenuPanel pattern used in SidebarConversationItem

## Test plan
- [ ] Hover over a subgroup disclosure header in the Scheduled section — the count badge should fade out and be replaced by a 3-dot ellipsis button
- [ ] Click the ellipsis button — a VMenuPanel should appear with "Mark All as Read" and "Archive All..." items
- [ ] Verify "Mark All as Read" is disabled when no conversations are unread
- [ ] Verify "Archive All..." is disabled when all conversations are channel conversations
- [ ] Mouse away from the subgroup header — ellipsis should disappear and count badge should reappear
- [ ] Right-click context menu should continue to work as before
- [ ] Unread dot badge should be hidden when hovered (replaced by ellipsis area)

Closes #25353.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25355" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
