### PR TITLE
fix: derive Deepgram fallback from catalog instead of hardcoded values

### DIFF
--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -26,6 +26,7 @@ import {
   getTwilioMediaStreamUrl,
   getTwilioRelayUrl,
 } from "../inbound/public-ingress-urls.js";
+import { getProviderEntry } from "../providers/speech-to-text/provider-catalog.js";
 import { mintEdgeRelayToken } from "../runtime/auth/token-service.js";
 import { getLogger } from "../util/logger.js";
 import { persistCallCompletionMessage } from "./call-conversation-messages.js";
@@ -365,6 +366,16 @@ function buildVoiceWebhookTwiml(
   // The routing resolver handles speech-model defaults internally per provider.
   const routingResult = resolveTelephonySttRouting();
 
+  // Derive Deepgram fallback values from the provider catalog so they stay
+  // in sync with the single source of truth. Hardcoded strings are kept only
+  // as a final safety net in case the catalog entry is missing.
+  const dgEntry = getProviderEntry("deepgram");
+  const fallbackProvider =
+    dgEntry?.telephonyRouting.twilioNativeMapping?.provider ?? "Deepgram";
+  const fallbackModel =
+    dgEntry?.telephonyRouting.twilioNativeMapping?.defaultSpeechModel ??
+    "nova-3";
+
   if (routingResult.status === "unknown-provider") {
     log.error(
       {
@@ -382,7 +393,7 @@ function buildVoiceWebhookTwiml(
       profile,
       sessionContext,
       verificationSessionId,
-      { transcriptionProvider: "Deepgram", speechModel: "nova-3" },
+      { transcriptionProvider: fallbackProvider, speechModel: fallbackModel },
     );
   }
 
@@ -438,7 +449,7 @@ function buildVoiceWebhookTwiml(
       profile,
       sessionContext,
       verificationSessionId,
-      { transcriptionProvider: "Deepgram", speechModel: "nova-3" },
+      { transcriptionProvider: fallbackProvider, speechModel: fallbackModel },
     );
   }
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for stt-telephony-cleanups.md.

**Gap:** Media-stream preflight hardcodes Deepgram/nova-3 instead of reading from catalog
**What was expected:** Fallback values should come from the provider catalog
**What was found:** Hardcoded transcriptionProvider and speechModel in twilio-routes.ts
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25356" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
