### PR TITLE
fix: update ARCHITECTURE.md to reflect catalog-driven telephony routing

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -602,7 +602,7 @@ Audio-to-text conversion occurs in five distinct runtime boundaries, each with i
 
 Telephony STT uses a provider-conditional hybrid model driven by `services.stt.provider`. The routing resolver (`src/calls/telephony-stt-routing.ts`) maps the configured provider to a discriminated strategy at call setup time:
 
-- **`conversation-relay-native`** (Deepgram, Google) — TwiML emits `<Connect><ConversationRelay>` with `transcriptionProvider` and `speechModel` attributes. Twilio handles audio ingestion and transcription natively; the daemon receives transcribed text via the relay WebSocket. Model normalization: Deepgram defaults `speechModel` to `"nova-3"` when unset; Google leaves `speechModel` undefined (suppresses the Deepgram default to avoid sending a Deepgram model name to Google's API).
+- **`conversation-relay-native`** (Deepgram, Google) — TwiML emits `<Connect><ConversationRelay>` with `transcriptionProvider` and `speechModel` attributes. Twilio handles audio ingestion and transcription natively; the daemon receives transcribed text via the relay WebSocket. The Twilio-native provider name and default speech model are read from the provider catalog entry's `telephonyRouting.twilioNativeMapping` (e.g. Deepgram maps to `provider: "Deepgram"` with `defaultSpeechModel: "nova-3"`; Google maps to `provider: "Google"` with `defaultSpeechModel: undefined`).
 
 - **`media-stream-custom`** (OpenAI Whisper) — TwiML emits `<Connect><Stream>` pointing to the daemon's media-stream server. Raw audio flows from Twilio through the gateway's WebSocket proxy (`twilio-media-websocket.ts`) to the daemon, which transcribes server-side via the provider's batch API.
 
@@ -622,7 +622,7 @@ Key modules:
 
 Guard tests in `__tests__/twilio-routes-twiml.test.ts` and `__tests__/twilio-routes.test.ts` assert that TwiML generation matches the provider-conditional strategy for each supported provider.
 
-To add a new telephony STT provider: add the provider to `TWILIO_NATIVE_PROVIDER_MAP` in `telephony-stt-routing.ts` if it is Twilio-native, or leave it absent to use the media-stream custom path. Add model normalization logic in `resolveNativeSpeechModel()` for Twilio-native providers.
+To add a new telephony STT provider: add a `telephonyRouting` entry to the provider's catalog entry in `provider-catalog.ts`. Set `strategyKind` to `"conversation-relay-native"` for Twilio-native providers (and include a `twilioNativeMapping` with the Twilio `provider` name and `defaultSpeechModel`), or `"media-stream-custom"` for providers that require daemon-side transcription. The routing resolver reads these fields from the catalog — no hardcoded maps to update.
 
 **Daemon batch boundary:**
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for stt-telephony-cleanups.md.

**Gap:** ARCHITECTURE.md references deleted TWILIO_NATIVE_PROVIDER_MAP and resolveNativeSpeechModel()
**What was expected:** Documentation should describe the current catalog-driven routing approach
**What was found:** Stale references to removed symbols
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25358" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
