### PR TITLE
STT Telephony Post-Unification Cleanups

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -653,8 +653,8 @@ Two provider adapters are supported, each implementing the `StreamingTranscriber
 
 **Session lifecycle (daemon side):**
 
-1. Client opens a WebSocket to `/v1/stt/stream` with query parameters `provider`, `mimeType`, and optional `sampleRate`.
-2. `SttStreamSession` (in `src/stt/stt-stream-session.ts`) resolves a `StreamingTranscriber` via `resolveStreamingTranscriber()` from `src/providers/speech-to-text/resolve.ts`.
+1. Client opens a WebSocket to `/v1/stt/stream` with required query parameter `mimeType` and optional `provider` and `sampleRate`. The `provider` parameter is optional compatibility metadata — the runtime is config-authoritative and always resolves the streaming transcriber from `services.stt.provider`. When a requested provider disagrees with the configured provider, the runtime logs a mismatch warning.
+2. `SttStreamSession` (in `src/stt/stt-stream-session.ts`) resolves a `StreamingTranscriber` via `resolveStreamingTranscriber()` from `src/providers/speech-to-text/resolve.ts`, using the configured provider (not the requested one).
 3. The transcriber's `start()` method opens the provider session.
 4. A `ready` event (with `provider` field) is sent to the client, signaling that audio frames are accepted.
 5. Client sends `audio` frames (binary WebSocket frames or base64-encoded JSON) and a `stop` event when recording ends.

--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -602,7 +602,7 @@ Audio-to-text conversion occurs in five distinct runtime boundaries, each with i
 
 Telephony STT uses a provider-conditional hybrid model driven by `services.stt.provider`. The routing resolver (`src/calls/telephony-stt-routing.ts`) maps the configured provider to a discriminated strategy at call setup time:
 
-- **`conversation-relay-native`** (Deepgram, Google) — TwiML emits `<Connect><ConversationRelay>` with `transcriptionProvider` and `speechModel` attributes. Twilio handles audio ingestion and transcription natively; the daemon receives transcribed text via the relay WebSocket. Model normalization: Deepgram defaults `speechModel` to `"nova-3"` when unset; Google leaves `speechModel` undefined (suppresses the Deepgram default to avoid sending a Deepgram model name to Google's API).
+- **`conversation-relay-native`** (Deepgram, Google) — TwiML emits `<Connect><ConversationRelay>` with `transcriptionProvider` and `speechModel` attributes. Twilio handles audio ingestion and transcription natively; the daemon receives transcribed text via the relay WebSocket. The Twilio-native provider name and default speech model are read from the provider catalog entry's `telephonyRouting.twilioNativeMapping` (e.g. Deepgram maps to `provider: "Deepgram"` with `defaultSpeechModel: "nova-3"`; Google maps to `provider: "Google"` with `defaultSpeechModel: undefined`).
 
 - **`media-stream-custom`** (OpenAI Whisper) — TwiML emits `<Connect><Stream>` pointing to the daemon's media-stream server. Raw audio flows from Twilio through the gateway's WebSocket proxy (`twilio-media-websocket.ts`) to the daemon, which transcribes server-side via the provider's batch API.
 
@@ -622,7 +622,7 @@ Key modules:
 
 Guard tests in `__tests__/twilio-routes-twiml.test.ts` and `__tests__/twilio-routes.test.ts` assert that TwiML generation matches the provider-conditional strategy for each supported provider.
 
-To add a new telephony STT provider: add the provider to `TWILIO_NATIVE_PROVIDER_MAP` in `telephony-stt-routing.ts` if it is Twilio-native, or leave it absent to use the media-stream custom path. Add model normalization logic in `resolveNativeSpeechModel()` for Twilio-native providers.
+To add a new telephony STT provider: add a `telephonyRouting` entry to the provider's catalog entry in `provider-catalog.ts`. Set `strategyKind` to `"conversation-relay-native"` for Twilio-native providers (and include a `twilioNativeMapping` with the Twilio `provider` name and `defaultSpeechModel`), or `"media-stream-custom"` for providers that require daemon-side transcription. The routing resolver reads these fields from the catalog — no hardcoded maps to update.
 
 **Daemon batch boundary:**
 

--- a/assistant/docs/stt-provider-onboarding.md
+++ b/assistant/docs/stt-provider-onboarding.md
@@ -114,6 +114,6 @@ Before submitting the PR, verify that:
 
 1. **No stale config references** — grep for any references to a separate telephony transcription config. The telephony routing module (`src/calls/telephony-stt-routing.ts`) reads `services.stt.provider` and maps it to the appropriate Twilio strategy (either `conversation-relay-native` for providers Twilio supports natively, or `media-stream-custom` for server-side transcription).
 
-2. **Provider catalog `telephonyMode`** — the new provider's catalog entry (step 1) declares how it participates in telephony: `"realtime-ws"`, `"batch-only"`, or `"none"`. This value drives the strategy selection in `telephony-stt-routing.ts`.
+2. **Provider catalog `telephonyRouting` metadata** — the new provider's catalog entry (step 1) includes a `telephonyRouting` object that is the single source of truth for strategy selection in `telephony-stt-routing.ts`. This object declares the `strategyKind` (`"conversation-relay-native"` or `"media-stream-custom"`) and, for native providers, provides a `twilioNativeMapping` with the Twilio `provider` name and `defaultSpeechModel`. The routing module contains no hardcoded provider-to-Twilio maps — it reads these values directly from the catalog.
 
 3. **No duplicate wiring** — a provider should appear only once in `services.stt`. The telephony routing layer consumes the same provider ID; there is no second registration step for telephony.

--- a/assistant/docs/stt-provider-onboarding.md
+++ b/assistant/docs/stt-provider-onboarding.md
@@ -13,6 +13,7 @@ Add a new entry to the `CATALOG` map with:
 - `supportedBoundaries` — the set of `SttBoundaryId` values the provider supports. Valid values are `"daemon-batch"` (post-recording transcription) and `"daemon-streaming"` (real-time streaming transcription during conversation).
 - `conversationStreamingMode` — how the provider handles streaming transcription in conversation mode: `"realtime-ws"` (provider supports real-time streaming natively via WebSocket), `"incremental-batch"` (streaming emulated via throttled polling), or `"none"` (no streaming support). Required for all providers.
 - `telephonyMode` — how the provider participates in real-time telephony STT: `"realtime-ws"`, `"batch-only"`, or `"none"`.
+- `telephonyRouting` — telephony routing metadata that drives Twilio call setup strategy selection. Declare `strategyKind` as `"conversation-relay-native"` or `"media-stream-custom"`. For native providers, include `twilioNativeMapping` with the Twilio `provider` name and `defaultSpeechModel`.
 
 ## 2. Type-system registration
 

--- a/assistant/src/__tests__/gateway-only-enforcement.test.ts
+++ b/assistant/src/__tests__/gateway-only-enforcement.test.ts
@@ -844,9 +844,25 @@ describe("gateway-only ingress enforcement", () => {
       expect(res.status).not.toBe(401);
     });
 
-    test("returns 400 when provider is missing", async () => {
+    test("succeeds when provider is omitted (config-authoritative)", async () => {
       const res = await fetch(
         `http://127.0.0.1:${port}/v1/stt/stream?token=${GATEWAY_JWT}&mimeType=audio/webm`,
+        {
+          headers: {
+            Upgrade: "websocket",
+            Connection: "Upgrade",
+            "Sec-WebSocket-Key": "dGhlIHNhbXBsZSBub25jZQ==",
+            "Sec-WebSocket-Version": "13",
+          },
+        },
+      );
+      // Should NOT be 400 — provider is optional.
+      expect(res.status).not.toBe(400);
+    });
+
+    test("returns 400 when mimeType is missing", async () => {
+      const res = await fetch(
+        `http://127.0.0.1:${port}/v1/stt/stream?token=${GATEWAY_JWT}&provider=deepgram`,
         {
           headers: {
             Upgrade: "websocket",
@@ -859,9 +875,9 @@ describe("gateway-only ingress enforcement", () => {
       expect(res.status).toBe(400);
     });
 
-    test("returns 400 when mimeType is missing", async () => {
+    test("returns 400 when both provider and mimeType are missing", async () => {
       const res = await fetch(
-        `http://127.0.0.1:${port}/v1/stt/stream?token=${GATEWAY_JWT}&provider=deepgram`,
+        `http://127.0.0.1:${port}/v1/stt/stream?token=${GATEWAY_JWT}`,
         {
           headers: {
             Upgrade: "websocket",

--- a/assistant/src/__tests__/media-stream-server-integration.test.ts
+++ b/assistant/src/__tests__/media-stream-server-integration.test.ts
@@ -128,20 +128,31 @@ mock.module("../runtime/assistant-scope.js", () => ({
 }));
 
 // Mock the relay setup router so handleStart() doesn't query the database.
-// Returns a normal_call outcome with minimal resolved context.
-mock.module("../calls/relay-setup-router.js", () => ({
-  routeSetup: jest.fn(() => ({
-    outcome: { action: "normal_call" as const, isInbound: true },
-    resolved: {
-      assistantId: "self",
-      isInbound: true,
-      otherPartyNumber: "+15551234567",
-      actorTrust: {
-        trustClass: "guardian" as const,
-        memberRecord: null,
-      },
+// Default returns normal_call; individual tests can override via
+// `mockRouteSetupResult` to exercise deny and unsupported-flow branches.
+let mockRouteSetupResult: {
+  outcome: { action: string; [key: string]: unknown };
+  resolved: {
+    assistantId: string;
+    isInbound: boolean;
+    otherPartyNumber: string;
+    actorTrust: { trustClass: string; memberRecord: null };
+  };
+} = {
+  outcome: { action: "normal_call" as const, isInbound: true },
+  resolved: {
+    assistantId: "self",
+    isInbound: true,
+    otherPartyNumber: "+15551234567",
+    actorTrust: {
+      trustClass: "guardian" as const,
+      memberRecord: null,
     },
-  })),
+  },
+};
+
+mock.module("../calls/relay-setup-router.js", () => ({
+  routeSetup: jest.fn(() => mockRouteSetupResult),
 }));
 
 // Mock the actor trust resolver (used by handleStart to derive trust context)
@@ -181,6 +192,7 @@ mock.module("../calls/resolve-call-tts-provider.js", () => ({
 // Now import the module under test.
 // ---------------------------------------------------------------------------
 
+import { speakSystemPrompt } from "../calls/call-speech-output.js";
 import { registerCallController } from "../calls/call-state.js";
 import { recordCallEvent, updateCallSession } from "../calls/call-store.js";
 import { finalizeCall } from "../calls/finalize-call.js";
@@ -306,6 +318,20 @@ beforeEach(() => {
   (recordCallEvent as jest.Mock).mockClear();
   (updateCallSession as jest.Mock).mockClear();
   (finalizeCall as jest.Mock).mockClear();
+  (speakSystemPrompt as jest.Mock).mockClear();
+  // Reset routeSetup to default normal_call
+  mockRouteSetupResult = {
+    outcome: { action: "normal_call" as const, isInbound: true },
+    resolved: {
+      assistantId: "self",
+      isInbound: true,
+      otherPartyNumber: "+15551234567",
+      actorTrust: {
+        trustClass: "guardian" as const,
+        memberRecord: null,
+      },
+    },
+  };
 });
 
 afterEach(() => {
@@ -726,5 +752,330 @@ describe("activeMediaStreamSessions registry", () => {
     expect(activeMediaStreamSessions.get("call-1")).toBe(session);
     activeMediaStreamSessions.delete("call-1");
     expect(activeMediaStreamSessions.get("call-1")).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario-driven setup outcome coverage
+// ---------------------------------------------------------------------------
+// These tests exercise the deny and unsupported-action branches in
+// MediaStreamCallSession.handleStart by overriding mockRouteSetupResult
+// before sending a start message.
+
+describe("media-stream setup outcome scenarios", () => {
+  describe("deny outcome", () => {
+    test("deny outcome records inbound_acl_denied event and sets status to failed", () => {
+      mockRouteSetupResult = {
+        outcome: {
+          action: "deny",
+          message: "This number is not authorized.",
+          logReason: "Inbound voice ACL: blocked caller",
+        },
+        resolved: {
+          assistantId: "self",
+          isInbound: true,
+          otherPartyNumber: "+15559998888",
+          actorTrust: { trustClass: "unknown", memberRecord: null },
+        },
+      };
+
+      const mockWs = createMockWs();
+      mockSessions.set("call-deny-1", {
+        id: "call-deny-1",
+        conversationId: "conv-deny-1",
+        status: "initiated",
+        task: null,
+        startedAt: null,
+        fromNumber: "+15559998888",
+        toNumber: "+15550001111",
+      });
+
+      const session = new MediaStreamCallSession(mockWs.ws, "call-deny-1");
+      session.handleMessage(makeStartMessage());
+
+      // Should record an inbound_acl_denied event
+      expect(recordCallEvent).toHaveBeenCalledWith(
+        "call-deny-1",
+        "inbound_acl_denied",
+        expect.objectContaining({
+          from: "+15559998888",
+        }),
+      );
+
+      // Should update session to failed
+      expect(updateCallSession).toHaveBeenCalledWith(
+        "call-deny-1",
+        expect.objectContaining({
+          status: "failed",
+          lastError: "Inbound voice ACL: blocked caller",
+        }),
+      );
+
+      // Should NOT register a controller (deny path skips it)
+      expect(registerCallController).not.toHaveBeenCalled();
+    });
+
+    test("deny outcome speaks the denial message", () => {
+      mockRouteSetupResult = {
+        outcome: {
+          action: "deny",
+          message: "This number is not authorized to use this assistant.",
+          logReason: "Inbound voice ACL: member policy deny",
+        },
+        resolved: {
+          assistantId: "self",
+          isInbound: true,
+          otherPartyNumber: "+15559998888",
+          actorTrust: { trustClass: "unknown", memberRecord: null },
+        },
+      };
+
+      const mockWs = createMockWs();
+      mockSessions.set("call-deny-speak-1", {
+        id: "call-deny-speak-1",
+        conversationId: "conv-deny-speak-1",
+        status: "initiated",
+        task: null,
+        startedAt: null,
+        fromNumber: "+15559998888",
+        toNumber: "+15550001111",
+      });
+
+      const session = new MediaStreamCallSession(
+        mockWs.ws,
+        "call-deny-speak-1",
+      );
+      session.handleMessage(makeStartMessage());
+
+      // speakSystemPrompt should be called with the denial message
+      expect(speakSystemPrompt).toHaveBeenCalledWith(
+        expect.anything(),
+        "This number is not authorized to use this assistant.",
+      );
+    });
+
+    test("deny outcome runs finalization", () => {
+      mockRouteSetupResult = {
+        outcome: {
+          action: "deny",
+          message: "Not authorized.",
+          logReason: "ACL deny",
+        },
+        resolved: {
+          assistantId: "self",
+          isInbound: true,
+          otherPartyNumber: "+15559998888",
+          actorTrust: { trustClass: "unknown", memberRecord: null },
+        },
+      };
+
+      const mockWs = createMockWs();
+      mockSessions.set("call-deny-finalize-1", {
+        id: "call-deny-finalize-1",
+        conversationId: "conv-deny-finalize-1",
+        status: "initiated",
+        task: null,
+        startedAt: null,
+        fromNumber: "+15559998888",
+        toNumber: "+15550001111",
+      });
+
+      const session = new MediaStreamCallSession(
+        mockWs.ws,
+        "call-deny-finalize-1",
+      );
+      session.handleMessage(makeStartMessage());
+
+      // finalizeCall should be called because early teardown runs it inline
+      expect(finalizeCall).toHaveBeenCalledWith(
+        "call-deny-finalize-1",
+        "conv-deny-finalize-1",
+      );
+    });
+  });
+
+  describe("unsupported interactive setup flow", () => {
+    test("verification outcome records call_failed with preflight-bypass reason", () => {
+      mockRouteSetupResult = {
+        outcome: {
+          action: "verification",
+          assistantId: "self",
+          fromNumber: "+14155551234",
+        },
+        resolved: {
+          assistantId: "self",
+          isInbound: true,
+          otherPartyNumber: "+14155551234",
+          actorTrust: { trustClass: "unknown", memberRecord: null },
+        },
+      };
+
+      const mockWs = createMockWs();
+      mockSessions.set("call-unsup-verify-1", {
+        id: "call-unsup-verify-1",
+        conversationId: "conv-unsup-verify-1",
+        status: "initiated",
+        task: null,
+        startedAt: null,
+        fromNumber: "+14155551234",
+        toNumber: "+15550001111",
+      });
+
+      const session = new MediaStreamCallSession(
+        mockWs.ws,
+        "call-unsup-verify-1",
+      );
+      session.handleMessage(makeStartMessage());
+
+      // Should record call_failed event with preflight-bypass note
+      expect(recordCallEvent).toHaveBeenCalledWith(
+        "call-unsup-verify-1",
+        "call_failed",
+        expect.objectContaining({
+          reason: expect.stringContaining("verification"),
+          transport: "media-stream",
+        }),
+      );
+
+      // Should set session status to failed
+      expect(updateCallSession).toHaveBeenCalledWith(
+        "call-unsup-verify-1",
+        expect.objectContaining({
+          status: "failed",
+          lastError: expect.stringContaining("preflight guard"),
+        }),
+      );
+
+      // Should NOT register a controller
+      expect(registerCallController).not.toHaveBeenCalled();
+    });
+
+    test("name_capture outcome speaks generic apology and tears down", () => {
+      mockRouteSetupResult = {
+        outcome: {
+          action: "name_capture",
+          assistantId: "self",
+          fromNumber: "+14155551234",
+        },
+        resolved: {
+          assistantId: "self",
+          isInbound: true,
+          otherPartyNumber: "+14155551234",
+          actorTrust: { trustClass: "unknown", memberRecord: null },
+        },
+      };
+
+      const mockWs = createMockWs();
+      mockSessions.set("call-unsup-name-1", {
+        id: "call-unsup-name-1",
+        conversationId: "conv-unsup-name-1",
+        status: "initiated",
+        task: null,
+        startedAt: null,
+        fromNumber: "+14155551234",
+        toNumber: "+15550001111",
+      });
+
+      const session = new MediaStreamCallSession(
+        mockWs.ws,
+        "call-unsup-name-1",
+      );
+      session.handleMessage(makeStartMessage());
+
+      // speakSystemPrompt should be called with the generic apology
+      expect(speakSystemPrompt).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.stringContaining("additional verification"),
+      );
+
+      // Should run finalization inline
+      expect(finalizeCall).toHaveBeenCalledWith(
+        "call-unsup-name-1",
+        "conv-unsup-name-1",
+      );
+    });
+
+    test("callee_verification outcome fails with explicit reason", () => {
+      mockRouteSetupResult = {
+        outcome: {
+          action: "callee_verification",
+          verificationConfig: { maxAttempts: 3, codeLength: 6 },
+        },
+        resolved: {
+          assistantId: "self",
+          isInbound: false,
+          otherPartyNumber: "+14155551234",
+          actorTrust: { trustClass: "guardian", memberRecord: null },
+        },
+      };
+
+      const mockWs = createMockWs();
+      mockSessions.set("call-unsup-callee-1", {
+        id: "call-unsup-callee-1",
+        conversationId: "conv-unsup-callee-1",
+        status: "initiated",
+        task: null,
+        startedAt: null,
+        fromNumber: "+15550001111",
+        toNumber: "+14155551234",
+      });
+
+      const session = new MediaStreamCallSession(
+        mockWs.ws,
+        "call-unsup-callee-1",
+      );
+      session.handleMessage(makeStartMessage());
+
+      // Should record the failure with the specific action
+      expect(recordCallEvent).toHaveBeenCalledWith(
+        "call-unsup-callee-1",
+        "call_failed",
+        expect.objectContaining({
+          reason: expect.stringContaining("callee_verification"),
+        }),
+      );
+
+      // Session should be failed
+      expect(updateCallSession).toHaveBeenCalledWith(
+        "call-unsup-callee-1",
+        expect.objectContaining({ status: "failed" }),
+      );
+    });
+
+    test("normal_call after deny scenario still creates controller", () => {
+      // Verify that after a deny-scenario test, resetting to normal_call
+      // properly creates a controller (no cross-test pollution).
+      mockRouteSetupResult = {
+        outcome: { action: "normal_call", isInbound: true },
+        resolved: {
+          assistantId: "self",
+          isInbound: true,
+          otherPartyNumber: "+15551234567",
+          actorTrust: { trustClass: "guardian", memberRecord: null },
+        },
+      };
+
+      const mockWs = createMockWs();
+      mockSessions.set("call-reset-1", {
+        id: "call-reset-1",
+        conversationId: "conv-reset-1",
+        status: "initiated",
+        task: "Test task",
+        startedAt: null,
+        toNumber: "+15551234567",
+      });
+
+      const session = new MediaStreamCallSession(mockWs.ws, "call-reset-1");
+      session.handleMessage(makeStartMessage());
+
+      // Controller should be registered for normal calls
+      expect(registerCallController).toHaveBeenCalledWith(
+        "call-reset-1",
+        expect.anything(),
+      );
+
+      // Initial greeting should fire
+      expect(mockStartInitialGreeting).toHaveBeenCalled();
+    });
   });
 });

--- a/assistant/src/__tests__/openai-provider.test.ts
+++ b/assistant/src/__tests__/openai-provider.test.ts
@@ -1,8 +1,6 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { RetryProvider } from "../providers/retry.js";
-import { createAbortReason } from "../util/abort-reasons.js";
-import { ProviderError } from "../util/errors.js";
 import type {
   ContentBlock,
   Message,
@@ -12,6 +10,8 @@ import type {
   SendMessageOptions,
   ToolDefinition,
 } from "../providers/types.js";
+import { createAbortReason } from "../util/abort-reasons.js";
+import { ProviderError } from "../util/errors.js";
 
 // ---------------------------------------------------------------------------
 // Mock openai module — must be before importing the provider

--- a/assistant/src/__tests__/telephony-stt-routing.test.ts
+++ b/assistant/src/__tests__/telephony-stt-routing.test.ts
@@ -31,6 +31,10 @@ import {
   type MediaStreamCustomStrategy,
   resolveTelephonySttRouting,
 } from "../calls/telephony-stt-routing.js";
+import {
+  getProviderEntry,
+  listProviderEntries,
+} from "../providers/speech-to-text/provider-catalog.js";
 import type { SttProviderId } from "../stt/types.js";
 
 // ---------------------------------------------------------------------------
@@ -52,7 +56,7 @@ function buildConfig(overrides: {
 }
 
 // ---------------------------------------------------------------------------
-// Tests — Provider-to-strategy mapping
+// Tests — Provider-to-strategy mapping (catalog-driven)
 // ---------------------------------------------------------------------------
 
 describe("resolveTelephonySttRouting", () => {
@@ -61,7 +65,7 @@ describe("resolveTelephonySttRouting", () => {
   });
 
   // -----------------------------------------------------------------------
-  // Deepgram → conversation-relay-native
+  // Deepgram → conversation-relay-native (from catalog)
   // -----------------------------------------------------------------------
 
   describe("deepgram", () => {
@@ -90,10 +94,25 @@ describe("resolveTelephonySttRouting", () => {
       const strategy = result.strategy as ConversationRelayNativeStrategy;
       expect(strategy.speechModel).toBe("nova-3");
     });
+
+    test("speechModel matches catalog telephonyRouting.twilioNativeMapping.defaultSpeechModel", () => {
+      mockConfig = buildConfig({ provider: "deepgram" });
+      const entry = getProviderEntry("deepgram");
+
+      const result = resolveTelephonySttRouting();
+
+      expect(result.status).toBe("resolved");
+      if (result.status !== "resolved") return;
+
+      const strategy = result.strategy as ConversationRelayNativeStrategy;
+      expect(strategy.speechModel).toBe(
+        entry?.telephonyRouting.twilioNativeMapping?.defaultSpeechModel,
+      );
+    });
   });
 
   // -----------------------------------------------------------------------
-  // Google Gemini → conversation-relay-native
+  // Google Gemini → conversation-relay-native (from catalog)
   // -----------------------------------------------------------------------
 
   describe("google-gemini", () => {
@@ -122,10 +141,25 @@ describe("resolveTelephonySttRouting", () => {
       const strategy = result.strategy as ConversationRelayNativeStrategy;
       expect(strategy.speechModel).toBeUndefined();
     });
+
+    test("speechModel matches catalog telephonyRouting.twilioNativeMapping.defaultSpeechModel", () => {
+      mockConfig = buildConfig({ provider: "google-gemini" });
+      const entry = getProviderEntry("google-gemini");
+
+      const result = resolveTelephonySttRouting();
+
+      expect(result.status).toBe("resolved");
+      if (result.status !== "resolved") return;
+
+      const strategy = result.strategy as ConversationRelayNativeStrategy;
+      expect(strategy.speechModel).toBe(
+        entry?.telephonyRouting.twilioNativeMapping?.defaultSpeechModel,
+      );
+    });
   });
 
   // -----------------------------------------------------------------------
-  // OpenAI Whisper → media-stream-custom
+  // OpenAI Whisper → media-stream-custom (from catalog)
   // -----------------------------------------------------------------------
 
   describe("openai-whisper", () => {
@@ -229,6 +263,67 @@ describe("resolveTelephonySttRouting", () => {
 
         expect(result.strategy.providerId).toBe(provider);
       }
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Catalog-driven mapping verification
+  // -----------------------------------------------------------------------
+
+  describe("catalog-driven mapping", () => {
+    test("every catalog entry with conversation-relay-native routing resolves to that strategy", () => {
+      const nativeEntries = listProviderEntries().filter(
+        (e) => e.telephonyRouting.strategyKind === "conversation-relay-native",
+      );
+      expect(nativeEntries.length).toBeGreaterThan(0);
+
+      for (const entry of nativeEntries) {
+        mockConfig = buildConfig({ provider: entry.id });
+
+        const result = resolveTelephonySttRouting();
+        expect(result.status).toBe("resolved");
+        if (result.status !== "resolved") return;
+
+        expect(result.strategy.strategy).toBe("conversation-relay-native");
+        const strategy = result.strategy as ConversationRelayNativeStrategy;
+        expect(strategy.transcriptionProvider).toBe(
+          entry.telephonyRouting.twilioNativeMapping!.provider,
+        );
+        expect(strategy.speechModel).toBe(
+          entry.telephonyRouting.twilioNativeMapping!.defaultSpeechModel,
+        );
+      }
+    });
+
+    test("every catalog entry with media-stream-custom routing resolves to that strategy", () => {
+      const customEntries = listProviderEntries().filter(
+        (e) => e.telephonyRouting.strategyKind === "media-stream-custom",
+      );
+      expect(customEntries.length).toBeGreaterThan(0);
+
+      for (const entry of customEntries) {
+        mockConfig = buildConfig({ provider: entry.id });
+
+        const result = resolveTelephonySttRouting();
+        expect(result.status).toBe("resolved");
+        if (result.status !== "resolved") return;
+
+        expect(result.strategy.strategy).toBe("media-stream-custom");
+        expect(result.strategy.providerId).toBe(entry.id);
+      }
+    });
+
+    test("routing module contains no hardcoded provider-to-Twilio map", async () => {
+      // Read the source file and verify the hardcoded map was removed.
+      // This is a structural assertion: the catalog is the sole source of truth.
+      const sourceFile = Bun.file(
+        new URL("../calls/telephony-stt-routing.ts", import.meta.url).pathname,
+      );
+      const source = await sourceFile.text();
+
+      expect(source).not.toContain("TWILIO_NATIVE_PROVIDER_MAP");
+      expect(source).not.toContain("new Map<SttProviderId");
+      expect(source).not.toContain("DEEPGRAM_DEFAULT_SPEECH_MODEL");
     });
   });
 });

--- a/assistant/src/__tests__/twilio-routes.test.ts
+++ b/assistant/src/__tests__/twilio-routes.test.ts
@@ -72,6 +72,30 @@ function resolveIngressBaseUrlFromConfig(ingressConfig: unknown): string {
   );
 }
 
+// Default routeSetup mock — returns normal_call. Tests that need different
+// outcomes override `mockRouteSetupResult` before calling the handler.
+let mockRouteSetupResult: {
+  outcome: { action: string; [key: string]: unknown };
+  resolved: {
+    assistantId: string;
+    isInbound: boolean;
+    otherPartyNumber: string;
+    actorTrust: { trustClass: string; memberRecord: null };
+  };
+} = {
+  outcome: { action: "normal_call", isInbound: true },
+  resolved: {
+    assistantId: "self",
+    isInbound: true,
+    otherPartyNumber: "+15559998888",
+    actorTrust: { trustClass: "guardian", memberRecord: null },
+  },
+};
+
+mock.module("../calls/relay-setup-router.js", () => ({
+  routeSetup: () => mockRouteSetupResult,
+}));
+
 mock.module("../config/env.js", () => ({
   isHttpAuthDisabled: () => true,
   getGatewayInternalBaseUrl: () => "http://gateway.internal:7830",
@@ -433,6 +457,16 @@ describe("twilio webhook routes", () => {
     mockTwilioApiValidationBody = JSON.stringify({ sid: "AC_validated" });
     // Reset STT config to defaults between tests
     mockConfigObj.services.stt.provider = "deepgram" as any;
+    // Reset routeSetup mock to default normal_call
+    mockRouteSetupResult = {
+      outcome: { action: "normal_call", isInbound: true },
+      resolved: {
+        assistantId: "self",
+        isInbound: true,
+        otherPartyNumber: "+15559998888",
+        actorTrust: { trustClass: "guardian", memberRecord: null },
+      },
+    };
 
     globalThis.fetch = (async (
       url: string | URL | Request,
@@ -1163,6 +1197,187 @@ describe("twilio webhook routes", () => {
       // Must be Stream (from services.stt), NOT ConversationRelay
       expect(twiml).toContain("<Stream");
       expect(twiml).not.toContain("<ConversationRelay");
+    });
+  });
+
+  // ── Media-stream preflight setup guardrails ──────────────────────────
+  // These tests assert that the TwiML preflight guard in
+  // buildVoiceWebhookTwiml rejects unsupported interactive setup actions
+  // for media-stream-custom calls before stream bootstrap, falling back
+  // to ConversationRelay for interactive flows.
+
+  describe("media-stream preflight setup guardrails", () => {
+    test("media-stream: normal_call setup proceeds with Stream TwiML", async () => {
+      mockConfigObj.services.stt.provider = "openai-whisper" as any;
+      mockRouteSetupResult = {
+        outcome: { action: "normal_call", isInbound: true },
+        resolved: {
+          assistantId: "self",
+          isInbound: true,
+          otherPartyNumber: "+15559998888",
+          actorTrust: { trustClass: "guardian", memberRecord: null },
+        },
+      };
+
+      const session = createTestSession("conv-ms-normal-1", "CA_ms_normal_1");
+      const req = makeVoiceRequest(session.id, { CallSid: "CA_ms_normal_1" });
+
+      const res = await handleVoiceWebhook(req);
+      expect(res.status).toBe(200);
+
+      const twiml = await res.text();
+      expect(twiml).toContain("<Stream");
+      expect(twiml).not.toContain("<ConversationRelay");
+    });
+
+    test("media-stream: deny setup proceeds with Stream TwiML (deny is handled at stream level)", async () => {
+      mockConfigObj.services.stt.provider = "openai-whisper" as any;
+      mockRouteSetupResult = {
+        outcome: {
+          action: "deny",
+          message: "This number is not authorized.",
+          logReason: "Inbound voice ACL: blocked caller",
+        },
+        resolved: {
+          assistantId: "self",
+          isInbound: true,
+          otherPartyNumber: "+15559998888",
+          actorTrust: { trustClass: "unknown", memberRecord: null },
+        },
+      };
+
+      const session = createTestSession("conv-ms-deny-1", "CA_ms_deny_1");
+      const req = makeVoiceRequest(session.id, { CallSid: "CA_ms_deny_1" });
+
+      const res = await handleVoiceWebhook(req);
+      expect(res.status).toBe(200);
+
+      const twiml = await res.text();
+      // Deny is supported on media-stream — should still produce Stream TwiML
+      expect(twiml).toContain("<Stream");
+      expect(twiml).not.toContain("<ConversationRelay");
+    });
+
+    test("media-stream: verification setup falls back to ConversationRelay", async () => {
+      mockConfigObj.services.stt.provider = "openai-whisper" as any;
+      mockRouteSetupResult = {
+        outcome: {
+          action: "verification",
+          assistantId: "self",
+          fromNumber: "+14155551234",
+        },
+        resolved: {
+          assistantId: "self",
+          isInbound: true,
+          otherPartyNumber: "+14155551234",
+          actorTrust: { trustClass: "unknown", memberRecord: null },
+        },
+      };
+
+      const session = createTestSession("conv-ms-verify-1", "CA_ms_verify_1");
+      const req = makeVoiceRequest(session.id, { CallSid: "CA_ms_verify_1" });
+
+      const res = await handleVoiceWebhook(req);
+      expect(res.status).toBe(200);
+
+      const twiml = await res.text();
+      // Interactive verification cannot work on media-stream — must fall back
+      expect(twiml).toContain("<ConversationRelay");
+      expect(twiml).not.toContain("<Stream");
+      expect(twiml).toContain('transcriptionProvider="Deepgram"');
+    });
+
+    test("media-stream: name_capture setup falls back to ConversationRelay", async () => {
+      mockConfigObj.services.stt.provider = "openai-whisper" as any;
+      mockRouteSetupResult = {
+        outcome: {
+          action: "name_capture",
+          assistantId: "self",
+          fromNumber: "+14155551234",
+        },
+        resolved: {
+          assistantId: "self",
+          isInbound: true,
+          otherPartyNumber: "+14155551234",
+          actorTrust: { trustClass: "unknown", memberRecord: null },
+        },
+      };
+
+      const session = createTestSession("conv-ms-namecap-1", "CA_ms_namecap_1");
+      const req = makeVoiceRequest(session.id, {
+        CallSid: "CA_ms_namecap_1",
+      });
+
+      const res = await handleVoiceWebhook(req);
+      expect(res.status).toBe(200);
+
+      const twiml = await res.text();
+      expect(twiml).toContain("<ConversationRelay");
+      expect(twiml).not.toContain("<Stream");
+    });
+
+    test("media-stream: invite_redemption setup falls back to ConversationRelay", async () => {
+      mockConfigObj.services.stt.provider = "openai-whisper" as any;
+      mockRouteSetupResult = {
+        outcome: {
+          action: "invite_redemption",
+          assistantId: "self",
+          fromNumber: "+14155551234",
+          friendName: "Alice",
+          guardianName: "Bob",
+        },
+        resolved: {
+          assistantId: "self",
+          isInbound: true,
+          otherPartyNumber: "+14155551234",
+          actorTrust: { trustClass: "unknown", memberRecord: null },
+        },
+      };
+
+      const session = createTestSession("conv-ms-invite-1", "CA_ms_invite_1");
+      const req = makeVoiceRequest(session.id, {
+        CallSid: "CA_ms_invite_1",
+      });
+
+      const res = await handleVoiceWebhook(req);
+      expect(res.status).toBe(200);
+
+      const twiml = await res.text();
+      expect(twiml).toContain("<ConversationRelay");
+      expect(twiml).not.toContain("<Stream");
+    });
+
+    test("conversation-relay-native: unsupported setup does not trigger preflight (not media-stream)", async () => {
+      // When the STT provider is deepgram (conversation-relay-native),
+      // the preflight guard is not invoked — setup flows are handled
+      // natively by the relay server.
+      mockConfigObj.services.stt.provider = "deepgram" as any;
+      mockRouteSetupResult = {
+        outcome: {
+          action: "verification",
+          assistantId: "self",
+          fromNumber: "+14155551234",
+        },
+        resolved: {
+          assistantId: "self",
+          isInbound: true,
+          otherPartyNumber: "+14155551234",
+          actorTrust: { trustClass: "unknown", memberRecord: null },
+        },
+      };
+
+      const session = createTestSession("conv-cr-verify-1", "CA_cr_verify_1");
+      const req = makeVoiceRequest(session.id, {
+        CallSid: "CA_cr_verify_1",
+      });
+
+      const res = await handleVoiceWebhook(req);
+      expect(res.status).toBe(200);
+
+      const twiml = await res.text();
+      // ConversationRelay should be emitted regardless of setup outcome
+      expect(twiml).toContain("<ConversationRelay");
+      expect(twiml).not.toContain("<Stream");
     });
   });
 

--- a/assistant/src/calls/media-stream-server.ts
+++ b/assistant/src/calls/media-stream-server.ts
@@ -387,24 +387,27 @@ export class MediaStreamCallSession {
       default:
         // All interactive sub-flows (verification, invite_redemption,
         // name_capture, callee_verification, outbound_verification) are
-        // not supported on the media-stream transport. Speak a generic
-        // apology and end the session rather than silently bypassing
-        // policy enforcement.
-        log.warn(
+        // not supported on the media-stream transport. The TwiML preflight
+        // in twilio-routes.ts should have caught this and fallen back to
+        // ConversationRelay — reaching here indicates the preflight was
+        // bypassed or a new setup action was added without updating the
+        // preflight guard. Speak a generic apology and end the session
+        // rather than silently bypassing policy enforcement.
+        log.error(
           {
             callSessionId: this.callSessionId,
             action: outcome.action,
           },
-          "Media-stream transport does not support interactive setup flow — ending session",
+          "Media-stream transport received unsupported setup flow — preflight guard should have prevented this",
         );
         recordCallEvent(this.callSessionId, "call_failed", {
-          reason: `Setup flow '${outcome.action}' not supported on media-stream transport`,
+          reason: `Setup flow '${outcome.action}' not supported on media-stream transport (preflight guard bypass)`,
           transport: "media-stream",
         });
         updateCallSession(this.callSessionId, {
           status: "failed",
           endedAt: Date.now(),
-          lastError: `Setup flow '${outcome.action}' not supported on media-stream transport`,
+          lastError: `Setup flow '${outcome.action}' not supported on media-stream transport — preflight guard should have prevented this`,
         });
         // Run finalization now because handleTransportClosed will see
         // terminal status and exit early when the WebSocket closes.
@@ -416,7 +419,7 @@ export class MediaStreamCallSession {
           setTimeout(
             () =>
               this.output.endSession(
-                `Unsupported setup flow: ${outcome.action}`,
+                `Unsupported setup flow: ${outcome.action} (preflight guard bypass)`,
               ),
             3000,
           );

--- a/assistant/src/calls/telephony-stt-routing.ts
+++ b/assistant/src/calls/telephony-stt-routing.ts
@@ -17,13 +17,16 @@
  *   and the daemon transcribes audio server-side via the provider's
  *   batch API. Used for `openai-whisper`.
  *
- * Model normalization semantics for Twilio-native providers:
- * - Deepgram defaults `speechModel` to `"nova-3"`.
- * - Google leaves `speechModel` undefined (uses provider default).
+ * Strategy selection and model normalization are driven entirely by
+ * the provider catalog's `telephonyRouting` metadata — this module
+ * contains no hardcoded provider-to-Twilio maps.
  */
 
 import { getConfig } from "../config/loader.js";
-import { getProviderEntry } from "../providers/speech-to-text/provider-catalog.js";
+import {
+  getProviderEntry,
+  type TwilioNativeProvider,
+} from "../providers/speech-to-text/provider-catalog.js";
 import type { SttProviderId } from "../stt/types.js";
 
 // ---------------------------------------------------------------------------
@@ -33,10 +36,10 @@ import type { SttProviderId } from "../stt/types.js";
 /**
  * Twilio-native ConversationRelay transcription provider name.
  *
- * These are the values Twilio accepts in the `transcriptionProvider`
- * TwiML attribute on `<ConversationRelay>`.
+ * Re-exported from the provider catalog for downstream consumers that
+ * reference the strategy types without importing the catalog directly.
  */
-export type TwilioNativeTranscriptionProvider = "Deepgram" | "Google";
+export type TwilioNativeTranscriptionProvider = TwilioNativeProvider;
 
 /**
  * The configured STT provider maps to a Twilio-native
@@ -81,47 +84,6 @@ export type TelephonySttRoutingResult =
   | { status: "unknown-provider"; providerId: string; reason: string };
 
 // ---------------------------------------------------------------------------
-// Model normalization constants
-// ---------------------------------------------------------------------------
-
-const DEEPGRAM_DEFAULT_SPEECH_MODEL = "nova-3";
-
-// ---------------------------------------------------------------------------
-// Provider-to-strategy mapping
-// ---------------------------------------------------------------------------
-
-/**
- * Map from `services.stt.provider` ID to the corresponding Twilio-native
- * transcription provider name. Providers absent from this map use the
- * media-stream custom path.
- */
-const TWILIO_NATIVE_PROVIDER_MAP: ReadonlyMap<
-  SttProviderId,
-  TwilioNativeTranscriptionProvider
-> = new Map<SttProviderId, TwilioNativeTranscriptionProvider>([
-  ["deepgram", "Deepgram"],
-  ["google-gemini", "Google"],
-]);
-
-// ---------------------------------------------------------------------------
-// Model normalization
-// ---------------------------------------------------------------------------
-
-/**
- * Resolve the effective speech model for a Twilio-native provider.
- *
- * - Deepgram: defaults to `"nova-3"`.
- * - Google: leaves the model undefined (uses provider default).
- */
-function resolveNativeSpeechModel(
-  twilioProvider: TwilioNativeTranscriptionProvider,
-): string | undefined {
-  return twilioProvider === "Google"
-    ? undefined
-    : DEEPGRAM_DEFAULT_SPEECH_MODEL;
-}
-
-// ---------------------------------------------------------------------------
 // Public resolver
 // ---------------------------------------------------------------------------
 
@@ -129,8 +91,8 @@ function resolveNativeSpeechModel(
  * Resolve the telephony STT routing strategy from `services.stt.provider`.
  *
  * Reads the active provider from config, checks the provider catalog for
- * validity, then maps to either a Twilio-native ConversationRelay strategy
- * or a media-stream custom strategy.
+ * validity, then derives the telephony strategy from the catalog entry's
+ * `telephonyRouting` metadata.
  */
 export function resolveTelephonySttRouting(): TelephonySttRoutingResult {
   const config = getConfig();
@@ -146,22 +108,33 @@ export function resolveTelephonySttRouting(): TelephonySttRoutingResult {
     };
   }
 
-  // Check if this provider maps to a Twilio-native transcription path.
-  const twilioProvider = TWILIO_NATIVE_PROVIDER_MAP.get(entry.id);
+  const { telephonyRouting } = entry;
 
-  if (twilioProvider) {
+  // Derive strategy from catalog routing metadata.
+  if (telephonyRouting.strategyKind === "conversation-relay-native") {
+    const mapping = telephonyRouting.twilioNativeMapping;
+
+    // Defensive: conversation-relay-native entries must have a mapping.
+    if (!mapping) {
+      return {
+        status: "unknown-provider",
+        providerId: entry.id,
+        reason: `Provider "${entry.id}" declares conversation-relay-native strategy but has no twilioNativeMapping`,
+      };
+    }
+
     return {
       status: "resolved",
       strategy: {
         strategy: "conversation-relay-native",
         providerId: entry.id,
-        transcriptionProvider: twilioProvider,
-        speechModel: resolveNativeSpeechModel(twilioProvider),
+        transcriptionProvider: mapping.provider,
+        speechModel: mapping.defaultSpeechModel,
       },
     };
   }
 
-  // Provider is recognized but not Twilio-native — use media-stream path.
+  // media-stream-custom path.
   return {
     status: "resolved",
     strategy: {

--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -44,6 +44,7 @@ import {
   releaseCallbackClaim,
   updateCallSession,
 } from "./call-store.js";
+import { routeSetup } from "./relay-setup-router.js";
 import { resolveCallHints } from "./stt-hints.js";
 import { resolveTelephonySttRouting } from "./telephony-stt-routing.js";
 import type { CallStatus } from "./types.js";
@@ -401,7 +402,46 @@ function buildVoiceWebhookTwiml(
     );
   }
 
-  // media-stream-custom path
+  // media-stream-custom path — preflight check to reject interactive setup
+  // flows that the media-stream transport cannot support. The media-stream
+  // server has a defensive fallback for these cases, but catching them here
+  // avoids bootstrapping a WebSocket session that will immediately fail.
+  const session = getCallSession(callSessionId);
+  const from = sessionContext?.fromNumber ?? "";
+  const to = sessionContext?.toNumber ?? "";
+
+  const { outcome } = routeSetup({
+    callSessionId,
+    session: session ?? null,
+    from,
+    to,
+  });
+
+  // The media-stream transport supports normal_call and deny (which speaks
+  // a message and tears down). All other outcomes require interactive
+  // sub-flows (DTMF entry, name capture, guardian wait) that media-stream
+  // cannot perform. Reject these deterministically before stream bootstrap.
+  if (outcome.action !== "normal_call" && outcome.action !== "deny") {
+    log.warn(
+      {
+        callSessionId,
+        setupAction: outcome.action,
+        strategy: "media-stream-custom",
+      },
+      "Media-stream preflight rejected unsupported interactive setup flow — falling back to ConversationRelay with Deepgram",
+    );
+    // Fall back to ConversationRelay so the interactive flow can proceed
+    // through the relay server which supports it natively.
+    return buildConversationRelayResponse(
+      callSessionId,
+      cfg,
+      profile,
+      sessionContext,
+      verificationSessionId,
+      { transcriptionProvider: "Deepgram", speechModel: "nova-3" },
+    );
+  }
+
   return buildMediaStreamResponse(callSessionId, cfg, verificationSessionId);
 }
 

--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -26,6 +26,7 @@ import {
   getTwilioMediaStreamUrl,
   getTwilioRelayUrl,
 } from "../inbound/public-ingress-urls.js";
+import { getProviderEntry } from "../providers/speech-to-text/provider-catalog.js";
 import { mintEdgeRelayToken } from "../runtime/auth/token-service.js";
 import { getLogger } from "../util/logger.js";
 import { persistCallCompletionMessage } from "./call-conversation-messages.js";
@@ -365,6 +366,16 @@ function buildVoiceWebhookTwiml(
   // The routing resolver handles speech-model defaults internally per provider.
   const routingResult = resolveTelephonySttRouting();
 
+  // Derive Deepgram fallback values from the provider catalog so they stay
+  // in sync with the single source of truth. Hardcoded strings are kept only
+  // as a final safety net in case the catalog entry is missing.
+  const dgEntry = getProviderEntry("deepgram");
+  const fallbackProvider =
+    dgEntry?.telephonyRouting.twilioNativeMapping?.provider ?? "Deepgram";
+  const fallbackModel =
+    dgEntry?.telephonyRouting.twilioNativeMapping?.defaultSpeechModel ??
+    "nova-3";
+
   if (routingResult.status === "unknown-provider") {
     log.error(
       {
@@ -382,7 +393,7 @@ function buildVoiceWebhookTwiml(
       profile,
       sessionContext,
       verificationSessionId,
-      { transcriptionProvider: "Deepgram", speechModel: "nova-3" },
+      { transcriptionProvider: fallbackProvider, speechModel: fallbackModel },
     );
   }
 
@@ -438,7 +449,7 @@ function buildVoiceWebhookTwiml(
       profile,
       sessionContext,
       verificationSessionId,
-      { transcriptionProvider: "Deepgram", speechModel: "nova-3" },
+      { transcriptionProvider: fallbackProvider, speechModel: fallbackModel },
     );
   }
 

--- a/assistant/src/providers/speech-to-text/__tests__/provider-catalog.test.ts
+++ b/assistant/src/providers/speech-to-text/__tests__/provider-catalog.test.ts
@@ -139,6 +139,70 @@ describe("STT provider catalog", () => {
   });
 
   // -----------------------------------------------------------------------
+  // Telephony routing metadata
+  // -----------------------------------------------------------------------
+
+  test("every entry has telephonyRouting metadata", () => {
+    for (const entry of listProviderEntries()) {
+      expect(entry.telephonyRouting).toBeDefined();
+      expect(["conversation-relay-native", "media-stream-custom"]).toContain(
+        entry.telephonyRouting.strategyKind,
+      );
+    }
+  });
+
+  test("conversation-relay-native entries have twilioNativeMapping", () => {
+    for (const entry of listProviderEntries()) {
+      if (entry.telephonyRouting.strategyKind === "conversation-relay-native") {
+        expect(entry.telephonyRouting.twilioNativeMapping).toBeDefined();
+        expect(
+          entry.telephonyRouting.twilioNativeMapping!.provider.length,
+        ).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  test("media-stream-custom entries do not have twilioNativeMapping", () => {
+    for (const entry of listProviderEntries()) {
+      if (entry.telephonyRouting.strategyKind === "media-stream-custom") {
+        expect(entry.telephonyRouting.twilioNativeMapping).toBeUndefined();
+      }
+    }
+  });
+
+  test("deepgram has conversation-relay-native strategy with Deepgram Twilio mapping", () => {
+    const entry = getProviderEntry("deepgram");
+    expect(entry?.telephonyRouting.strategyKind).toBe(
+      "conversation-relay-native",
+    );
+    expect(entry?.telephonyRouting.twilioNativeMapping?.provider).toBe(
+      "Deepgram",
+    );
+    expect(
+      entry?.telephonyRouting.twilioNativeMapping?.defaultSpeechModel,
+    ).toBe("nova-3");
+  });
+
+  test("google-gemini has conversation-relay-native strategy with Google Twilio mapping", () => {
+    const entry = getProviderEntry("google-gemini");
+    expect(entry?.telephonyRouting.strategyKind).toBe(
+      "conversation-relay-native",
+    );
+    expect(entry?.telephonyRouting.twilioNativeMapping?.provider).toBe(
+      "Google",
+    );
+    expect(
+      entry?.telephonyRouting.twilioNativeMapping?.defaultSpeechModel,
+    ).toBeUndefined();
+  });
+
+  test("openai-whisper has media-stream-custom strategy without Twilio mapping", () => {
+    const entry = getProviderEntry("openai-whisper");
+    expect(entry?.telephonyRouting.strategyKind).toBe("media-stream-custom");
+    expect(entry?.telephonyRouting.twilioNativeMapping).toBeUndefined();
+  });
+
+  // -----------------------------------------------------------------------
   // Credential lookup
   // -----------------------------------------------------------------------
 

--- a/assistant/src/providers/speech-to-text/__tests__/resolve.test.ts
+++ b/assistant/src/providers/speech-to-text/__tests__/resolve.test.ts
@@ -335,8 +335,8 @@ describe("telephony routing catalog alignment", () => {
    * These tests verify that the assumptions made by the telephony STT
    * routing resolver (telephony-stt-routing.ts) remain consistent with
    * the provider catalog entries. If a catalog entry changes its
-   * telephonyMode or a new provider is added, these tests will catch
-   * misalignment early.
+   * telephonyMode, routing metadata, or a new provider is added, these
+   * tests will catch misalignment early.
    */
 
   test("deepgram catalog entry has realtime-ws telephonyMode (Twilio-native eligible)", () => {
@@ -381,6 +381,85 @@ describe("telephony routing catalog alignment", () => {
       const entry = getProviderEntry(id);
       expect(entry).toBeDefined();
       expect(entry!.telephonyMode).not.toBe("none");
+    }
+  });
+
+  // -----------------------------------------------------------------------
+  // Telephony routing metadata invariants
+  // -----------------------------------------------------------------------
+
+  test("every catalog provider has telephonyRouting metadata", () => {
+    for (const id of listProviderIds()) {
+      const entry = getProviderEntry(id);
+      expect(entry).toBeDefined();
+      expect(entry!.telephonyRouting).toBeDefined();
+      expect(["conversation-relay-native", "media-stream-custom"]).toContain(
+        entry!.telephonyRouting.strategyKind,
+      );
+    }
+  });
+
+  test("conversation-relay-native providers have twilioNativeMapping with non-empty provider name", () => {
+    for (const id of listProviderIds()) {
+      const entry = getProviderEntry(id)!;
+      if (entry.telephonyRouting.strategyKind === "conversation-relay-native") {
+        expect(entry.telephonyRouting.twilioNativeMapping).toBeDefined();
+        expect(
+          entry.telephonyRouting.twilioNativeMapping!.provider.length,
+        ).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  test("media-stream-custom providers do not have twilioNativeMapping", () => {
+    for (const id of listProviderIds()) {
+      const entry = getProviderEntry(id)!;
+      if (entry.telephonyRouting.strategyKind === "media-stream-custom") {
+        expect(entry.telephonyRouting.twilioNativeMapping).toBeUndefined();
+      }
+    }
+  });
+
+  test("deepgram routing metadata maps to Twilio-native Deepgram with nova-3 speech model", () => {
+    const entry = getProviderEntry("deepgram")!;
+    expect(entry.telephonyRouting.strategyKind).toBe(
+      "conversation-relay-native",
+    );
+    expect(entry.telephonyRouting.twilioNativeMapping?.provider).toBe(
+      "Deepgram",
+    );
+    expect(entry.telephonyRouting.twilioNativeMapping?.defaultSpeechModel).toBe(
+      "nova-3",
+    );
+  });
+
+  test("google-gemini routing metadata maps to Twilio-native Google with no default speech model", () => {
+    const entry = getProviderEntry("google-gemini")!;
+    expect(entry.telephonyRouting.strategyKind).toBe(
+      "conversation-relay-native",
+    );
+    expect(entry.telephonyRouting.twilioNativeMapping?.provider).toBe("Google");
+    expect(
+      entry.telephonyRouting.twilioNativeMapping?.defaultSpeechModel,
+    ).toBeUndefined();
+  });
+
+  test("openai-whisper routing metadata uses media-stream-custom without Twilio mapping", () => {
+    const entry = getProviderEntry("openai-whisper")!;
+    expect(entry.telephonyRouting.strategyKind).toBe("media-stream-custom");
+    expect(entry.telephonyRouting.twilioNativeMapping).toBeUndefined();
+  });
+
+  // -----------------------------------------------------------------------
+  // Stable provider identity
+  // -----------------------------------------------------------------------
+
+  test("provider IDs remain stable across catalog lookups", () => {
+    // Guard against accidental ID mutation or aliasing bugs.
+    for (const id of listProviderIds()) {
+      const entry = getProviderEntry(id);
+      expect(entry).toBeDefined();
+      expect(entry!.id).toBe(id);
     }
   });
 

--- a/assistant/src/providers/speech-to-text/provider-catalog.ts
+++ b/assistant/src/providers/speech-to-text/provider-catalog.ts
@@ -18,6 +18,68 @@ import type {
 } from "../../stt/types.js";
 
 // ---------------------------------------------------------------------------
+// Telephony routing metadata
+// ---------------------------------------------------------------------------
+
+/**
+ * Strategy kind for telephony call setup.
+ *
+ * Determines how the telephony routing resolver (`telephony-stt-routing.ts`)
+ * wires the STT provider into a Twilio call:
+ *
+ * - `"conversation-relay-native"` — the provider is natively supported by
+ *   Twilio ConversationRelay. TwiML includes `transcriptionProvider` /
+ *   `speechModel` attributes and Twilio handles audio ingestion.
+ * - `"media-stream-custom"` — the provider is not natively supported by
+ *   Twilio. A `<Stream>` media-stream is opened and the daemon transcribes
+ *   audio server-side via the provider's batch API.
+ */
+export type TelephonyStrategyKind =
+  | "conversation-relay-native"
+  | "media-stream-custom";
+
+/**
+ * Twilio-native ConversationRelay provider name.
+ *
+ * These are the values Twilio accepts in the `transcriptionProvider` TwiML
+ * attribute on `<ConversationRelay>`.
+ */
+export type TwilioNativeProvider = "Deepgram" | "Google";
+
+/**
+ * Twilio-native mapping details for providers routed through
+ * ConversationRelay. Only present when `strategyKind` is
+ * `"conversation-relay-native"`.
+ */
+export interface TwilioNativeMapping {
+  /** Twilio-native provider name for the TwiML `transcriptionProvider` attribute. */
+  readonly provider: TwilioNativeProvider;
+  /**
+   * Default ASR speech model identifier, or `undefined` to use the
+   * provider's default model. Individual providers override as needed
+   * (e.g. Deepgram defaults to `"nova-3"`).
+   */
+  readonly defaultSpeechModel: string | undefined;
+}
+
+/**
+ * Telephony routing metadata — the single source of truth for how a
+ * provider is wired into Twilio call setup.
+ *
+ * The telephony routing resolver reads these fields from the catalog
+ * instead of maintaining its own hardcoded maps.
+ */
+export interface TelephonyRouting {
+  /** Which Twilio call-setup strategy this provider uses. */
+  readonly strategyKind: TelephonyStrategyKind;
+  /**
+   * Twilio-native mapping details. Present when `strategyKind` is
+   * `"conversation-relay-native"`, absent for `"media-stream-custom"`.
+   */
+  readonly twilioNativeMapping?: TwilioNativeMapping;
+}
+
+// ---------------------------------------------------------------------------
 // Catalog entry
 // ---------------------------------------------------------------------------
 
@@ -44,8 +106,8 @@ export interface SttProviderEntry {
   readonly supportedBoundaries: ReadonlySet<SttBoundaryId>;
 
   /**
-   * Telephony support mode — describes whether and how the provider can
-   * participate in real-time call ingestion via `services.stt`.
+   * Telephony capability class — describes the provider's native
+   * audio-ingestion capability for telephony contexts.
    */
   readonly telephonyMode: TelephonySttMode;
 
@@ -59,6 +121,13 @@ export interface SttProviderEntry {
    * - `"none"` — no streaming support; fall back to batch transcription.
    */
   readonly conversationStreamingMode: ConversationStreamingMode;
+
+  /**
+   * Telephony routing metadata — describes how this provider is wired
+   * into Twilio call setup. This is the single source of truth for
+   * strategy selection and Twilio-native mapping details.
+   */
+  readonly telephonyRouting: TelephonyRouting;
 }
 
 // ---------------------------------------------------------------------------
@@ -86,6 +155,9 @@ const CATALOG: ReadonlyMap<SttProviderId, SttProviderEntry> = new Map<
       supportedBoundaries: new Set<SttBoundaryId>(["daemon-batch"]),
       telephonyMode: "batch-only",
       conversationStreamingMode: "none",
+      telephonyRouting: {
+        strategyKind: "media-stream-custom",
+      },
     },
   ],
   [
@@ -99,6 +171,13 @@ const CATALOG: ReadonlyMap<SttProviderId, SttProviderEntry> = new Map<
       ]),
       telephonyMode: "realtime-ws",
       conversationStreamingMode: "realtime-ws",
+      telephonyRouting: {
+        strategyKind: "conversation-relay-native",
+        twilioNativeMapping: {
+          provider: "Deepgram",
+          defaultSpeechModel: "nova-3",
+        },
+      },
     },
   ],
   [
@@ -112,6 +191,13 @@ const CATALOG: ReadonlyMap<SttProviderId, SttProviderEntry> = new Map<
       ]),
       telephonyMode: "batch-only",
       conversationStreamingMode: "incremental-batch",
+      telephonyRouting: {
+        strategyKind: "conversation-relay-native",
+        twilioNativeMapping: {
+          provider: "Google",
+          defaultSpeechModel: undefined,
+        },
+      },
     },
   ],
 ]);

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -41,6 +41,7 @@ import {
   hasUngatedHttpAuthDisabled,
   isHttpAuthDisabled,
 } from "../config/env.js";
+import { getConfig } from "../config/loader.js";
 import type { ServerMessage } from "../daemon/message-protocol.js";
 import { PairingStore } from "../daemon/pairing-store.js";
 import {
@@ -310,10 +311,15 @@ interface MediaStreamWebSocketData {
  * WebSocket data attached to `/v1/stt/stream` connections.
  * The `wsType` discriminator routes frames to the STT streaming
  * session orchestrator instead of the other WebSocket handlers.
+ *
+ * `provider` is optional compatibility metadata from the client/gateway.
+ * The runtime is config-authoritative — it always resolves the streaming
+ * transcriber from `services.stt.provider` in the assistant config.
  */
 interface SttStreamWebSocketData {
   wsType: "stt-stream";
-  provider: string;
+  /** Optional requested provider — metadata only; runtime uses config. */
+  provider?: string;
   mimeType: string;
   sampleRate?: number;
   /** The session ID for tracking in the active sessions registry. */
@@ -462,9 +468,52 @@ export class RuntimeHttpServer {
           }
           if ("wsType" in data && data.wsType === "stt-stream") {
             const sttData = data as SttStreamWebSocketData;
+
+            // The runtime is config-authoritative: always resolve the
+            // provider from `services.stt.provider` regardless of what
+            // the client/gateway requested.
+            //
+            // getConfig() can throw (e.g. after invalidateConfigCache()
+            // when config.json is temporarily invalid). Wrap in try/catch
+            // so the session still starts normally — resolveStreamingTranscriber
+            // reads config inside SttStreamSession.start()'s own guarded path.
+            let configuredProvider: string | undefined;
+            try {
+              configuredProvider = getConfig().services.stt.provider;
+
+              // Mismatch telemetry: when the optional requested provider
+              // disagrees with the configured provider, log a warning so
+              // operators can detect stale client builds.
+              if (sttData.provider && sttData.provider !== configuredProvider) {
+                log.warn(
+                  {
+                    requestedProvider: sttData.provider,
+                    configuredProvider,
+                    sessionId: sttData.sessionId,
+                  },
+                  "STT stream provider mismatch — requested provider differs from configured provider; using configured provider",
+                );
+              }
+            } catch (err) {
+              log.warn(
+                {
+                  error: err instanceof Error ? err.message : String(err),
+                  sessionId: sttData.sessionId,
+                },
+                "Failed to read config for STT provider mismatch telemetry — proceeding without mismatch check",
+              );
+            }
+
+            // Fall back to the requested provider (or "unknown") when
+            // config reading failed, so the session constructor still
+            // gets a usable label for logging/error messages.
+            const effectiveProvider =
+              configuredProvider ?? sttData.provider ?? "unknown";
+
             log.info(
               {
-                provider: sttData.provider,
+                requestedProvider: sttData.provider ?? "(none)",
+                configuredProvider: effectiveProvider,
                 mimeType: sttData.mimeType,
                 sessionId: sttData.sessionId,
               },
@@ -472,7 +521,7 @@ export class RuntimeHttpServer {
             );
             const session = new SttStreamSession(
               ws,
-              sttData.provider,
+              effectiveProvider,
               sttData.mimeType,
               { sampleRate: sttData.sampleRate },
             );
@@ -1328,13 +1377,14 @@ export class RuntimeHttpServer {
     }
 
     const wsUrl = new URL(req.url);
-    const provider = wsUrl.searchParams.get("provider");
+    // provider is optional compatibility metadata — the runtime resolves
+    // the streaming transcriber from config (`services.stt.provider`).
+    const provider = wsUrl.searchParams.get("provider") ?? undefined;
     const mimeType = wsUrl.searchParams.get("mimeType");
-    if (!provider || !mimeType) {
-      return new Response(
-        "Missing required query parameters: provider, mimeType",
-        { status: 400 },
-      );
+    if (!mimeType) {
+      return new Response("Missing required query parameter: mimeType", {
+        status: 400,
+      });
     }
 
     const sampleRateRaw = wsUrl.searchParams.get("sampleRate");

--- a/assistant/src/stt/stt-stream-session.ts
+++ b/assistant/src/stt/stt-stream-session.ts
@@ -9,8 +9,10 @@
  * WebSocket connection with per-session ordering guarantees.
  *
  * Session lifecycle:
- * 1. Client opens a WebSocket to `/v1/stt/stream` with `provider` and
- *    `mimeType` query parameters.
+ * 1. Client opens a WebSocket to `/v1/stt/stream` with required `mimeType`
+ *    query parameter and optional `provider` metadata. The runtime is
+ *    config-authoritative — it resolves the transcriber from
+ *    `services.stt.provider` regardless of the requested provider.
  * 2. The orchestrator resolves a {@link StreamingTranscriber} via
  *    `resolveStreamingTranscriber()` and starts the provider session.
  * 3. The client sends `audio` frames (binary or base64-encoded JSON) and

--- a/assistant/src/stt/types.ts
+++ b/assistant/src/stt/types.ts
@@ -23,16 +23,22 @@
 export type SttProviderId = "openai-whisper" | "deepgram" | "google-gemini";
 
 /**
- * Telephony-specific STT support mode.
+ * Telephony-specific STT capability class.
  *
- * Describes how a provider can participate in real-time telephony call
- * ingestion when wired through `services.stt`.
+ * Describes the provider's native audio-ingestion capability when used in
+ * a telephony context. This is a **capability classification**, not a direct
+ * Twilio strategy selector — the telephony routing resolver
+ * (`telephony-stt-routing.ts`) maps capability classes plus catalog routing
+ * metadata to concrete Twilio setup strategies (conversation-relay-native
+ * vs media-stream-custom).
  *
  * - `"realtime-ws"` — provider offers a WebSocket streaming endpoint suitable
- *   for low-latency telephony audio. Future PRs will wire this into the
- *   media-stream call adapter.
- * - `"batch-only"` — provider supports only REST batch transcription; not
- *   suitable for real-time telephony.
+ *   for low-latency telephony audio (e.g. Deepgram live transcription).
+ * - `"batch-only"` — provider supports only REST batch transcription as its
+ *   native capability. A `batch-only` provider may still participate in
+ *   telephony via Twilio-native ConversationRelay (e.g. Google Gemini) or
+ *   via the media-stream custom path — the routing strategy is determined
+ *   by the catalog's telephony routing metadata, not this field alone.
  * - `"none"` — provider has no telephony support.
  */
 export type TelephonySttMode = "realtime-ws" | "batch-only" | "none";

--- a/clients/ios/Tests/InputBarVoiceInputTests.swift
+++ b/clients/ios/Tests/InputBarVoiceInputTests.swift
@@ -437,8 +437,6 @@ final class InputBarVoiceInputTests: XCTestCase {
         var stopCallCount = 0
         var closeCallCount = 0
 
-        /// The last provider passed to `start`.
-        var lastProvider: String?
         /// The last mimeType passed to `start`.
         var lastMimeType: String?
         /// The last sampleRate passed to `start`.
@@ -453,14 +451,12 @@ final class InputBarVoiceInputTests: XCTestCase {
         var sentAudioChunks: [Data] = []
 
         func start(
-            provider: String,
             mimeType: String,
             sampleRate: Int?,
             onEvent: @escaping @MainActor (STTStreamEvent) -> Void,
             onFailure: @escaping @MainActor (STTStreamFailure) -> Void
         ) async {
             startCallCount += 1
-            lastProvider = provider
             lastMimeType = mimeType
             lastSampleRate = sampleRate
             capturedOnEvent = onEvent
@@ -502,7 +498,6 @@ final class InputBarVoiceInputTests: XCTestCase {
 
         // Simulate streaming start
         await mockStreaming.start(
-            provider: "deepgram",
             mimeType: "audio/pcm",
             sampleRate: 16000,
             onEvent: { _ in },
@@ -510,7 +505,6 @@ final class InputBarVoiceInputTests: XCTestCase {
         )
 
         XCTAssertEqual(mockStreaming.startCallCount, 1, "Streaming client should have been started once")
-        XCTAssertEqual(mockStreaming.lastProvider, "deepgram")
         XCTAssertEqual(mockStreaming.lastMimeType, "audio/pcm")
         XCTAssertEqual(mockStreaming.lastSampleRate, 16000)
     }
@@ -521,7 +515,6 @@ final class InputBarVoiceInputTests: XCTestCase {
         var receivedTexts: [String] = []
 
         await mockStreaming.start(
-            provider: "deepgram",
             mimeType: "audio/pcm",
             sampleRate: 16000,
             onEvent: { event in
@@ -551,7 +544,6 @@ final class InputBarVoiceInputTests: XCTestCase {
         var finalReceived = false
 
         await mockStreaming.start(
-            provider: "deepgram",
             mimeType: "audio/pcm",
             sampleRate: 16000,
             onEvent: { event in
@@ -608,7 +600,6 @@ final class InputBarVoiceInputTests: XCTestCase {
         var failureReceived: STTStreamFailure?
 
         await mockStreaming.start(
-            provider: "deepgram",
             mimeType: "audio/pcm",
             sampleRate: 16000,
             onEvent: { _ in },
@@ -634,7 +625,6 @@ final class InputBarVoiceInputTests: XCTestCase {
         var failureReceived: STTStreamFailure?
 
         await mockStreaming.start(
-            provider: "google-gemini",
             mimeType: "audio/pcm",
             sampleRate: 16000,
             onEvent: { _ in },
@@ -658,7 +648,6 @@ final class InputBarVoiceInputTests: XCTestCase {
         var failureReceived: STTStreamFailure?
 
         await mockStreaming.start(
-            provider: "openai-whisper",
             mimeType: "audio/pcm",
             sampleRate: 16000,
             onEvent: { _ in },
@@ -769,7 +758,6 @@ final class InputBarVoiceInputTests: XCTestCase {
         var errorReceived = false
 
         await mockStreaming.start(
-            provider: "deepgram",
             mimeType: "audio/pcm",
             sampleRate: 16000,
             onEvent: { event in

--- a/clients/ios/Views/InputBarView.swift
+++ b/clients/ios/Views/InputBarView.swift
@@ -510,13 +510,10 @@ struct InputBarView: View {
             activeStreamingClient = client
             let sessionAtStart = sttSessionId
 
-            // Resolve the configured provider identifier for the streaming request.
-            let providerId = UserDefaults.standard.string(forKey: "sttProvider") ?? ""
             let sampleRateForStream = Int(recordingFormat.sampleRate)
 
             Task { @MainActor in
                 await client.start(
-                    provider: providerId,
                     mimeType: "audio/pcm",
                     sampleRate: sampleRateForStream,
                     onEvent: { event in

--- a/clients/macos/vellum-assistant/App/VoiceInputManager.swift
+++ b/clients/macos/vellum-assistant/App/VoiceInputManager.swift
@@ -1039,13 +1039,6 @@ final class VoiceInputManager {
     /// The `generation` parameter is captured at recording start and checked in
     /// all callbacks to suppress stale-session deliveries.
     private func startStreamingSession(generation: UInt64) {
-        guard let providerId = UserDefaults.standard.string(forKey: "sttProvider"),
-              !providerId.isEmpty else {
-            log.warning("Streaming session requested but no STT provider configured")
-            streamingFailed = true
-            return
-        }
-
         let client = streamingClientFactory()
         self.streamingClient = client
 
@@ -1056,7 +1049,6 @@ final class VoiceInputManager {
 
         Task { [weak self] in
             await client.start(
-                provider: providerId,
                 mimeType: "audio/pcm",
                 sampleRate: sampleRate,
                 onEvent: { [weak self] event in

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -3552,10 +3552,13 @@ public final class SettingsStore: ObservableObject {
 
         // Sync the global STT provider from the daemon config so the client
         // stays aligned after restart or reconnection. The canonical path
-        // is services.stt.provider.
+        // is services.stt.provider. Empty/whitespace-only values are
+        // treated as "not configured" and are not persisted — this avoids
+        // clobbering a previously selected provider with a no-op sentinel.
         if let services = config["services"] as? [String: Any],
            let stt = services["stt"] as? [String: Any],
-           let sttProvider = stt["provider"] as? String {
+           let sttProvider = stt["provider"] as? String,
+           !sttProvider.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             UserDefaults.standard.set(sttProvider, forKey: "sttProvider")
         }
 

--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -10,7 +10,7 @@ struct VoiceSettingsView: View {
     @AppStorage("activationKey") private var activationKey: String = "fn"
     @AppStorage("voiceConversationTimeoutSeconds") private var conversationTimeoutSeconds: Int = 30
     @AppStorage("ttsProvider") private var ttsProviderRaw: String = "elevenlabs"
-    @AppStorage("sttProvider") private var sttProviderRaw: String = "openai-whisper"
+    @AppStorage("sttProvider") private var sttProviderRaw: String = ""
 
     // TTS draft-based state (mirrors Inference card pattern)
     /// Uncommitted provider selection — only persisted on Save.
@@ -34,11 +34,14 @@ struct VoiceSettingsView: View {
 
     // STT draft-based state
     /// Uncommitted provider selection — persisted only on Save.
-    @State private var draftSTTProvider: String = "openai-whisper"
+    /// Empty-string sentinel means "no explicit selection" — the UI
+    /// resolves the effective provider from the catalog via
+    /// `selectedSTTProvider` which falls back to the first registry entry.
+    @State private var draftSTTProvider: String = ""
     /// API key input text (replaces the old Connect/Set Up flow).
     @State private var sttApiKeyText: String = ""
     /// Baseline provider for change detection — set on appear and after save.
-    @State private var initialSTTProvider: String = "openai-whisper"
+    @State private var initialSTTProvider: String = ""
     /// Whether the current STT provider already has a stored API key.
     @State private var sttProviderHasKey: Bool = false
     /// Save-in-progress indicator.
@@ -625,6 +628,13 @@ struct VoiceSettingsView: View {
     private func saveSTT() {
         sttSaving = true
         sttSaveError = nil
+
+        // Normalize the empty sentinel to the resolved provider so we never
+        // persist an empty string as the STT provider identifier.
+        if draftSTTProvider.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+           let resolved = selectedSTTProvider?.id {
+            draftSTTProvider = resolved
+        }
 
         // Persist provider change if needed
         if draftSTTProvider != sttProviderRaw {

--- a/clients/macos/vellum-assistantTests/SettingsStoreVoiceServiceTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsStoreVoiceServiceTests.swift
@@ -544,4 +544,170 @@ final class SettingsStoreVoiceServiceTests: XCTestCase {
             "The STT reset flow should be allowed for exclusive-key providers"
         )
     }
+
+    // MARK: - STT Default Selection (Empty Sentinel)
+
+    /// When no STT provider has been persisted, the UserDefaults key should
+    /// be absent (or empty). The UI resolves the effective provider from the
+    /// catalog's first entry via `selectedSTTProvider`.
+    func testDefaultSTTProviderIsEmpty() {
+        UserDefaults.standard.removeObject(forKey: "sttProvider")
+
+        let raw = UserDefaults.standard.string(forKey: "sttProvider")
+        XCTAssertNil(
+            raw,
+            "With no persisted value the sttProvider key should be nil"
+        )
+    }
+
+    /// The STT service configuration check must return false when the
+    /// provider key is an empty string (the new default sentinel).
+    func testEmptySTTProviderIsNotConsideredConfigured() {
+        UserDefaults.standard.set("", forKey: "sttProvider")
+
+        XCTAssertFalse(
+            STTProviderRegistry.isServiceConfigured,
+            "An empty sttProvider value must not be treated as configured"
+        )
+    }
+
+    /// Streaming availability must be false when the STT provider key is
+    /// the empty-string sentinel.
+    func testEmptySTTProviderReportsNoStreamingAvailable() {
+        UserDefaults.standard.set("", forKey: "sttProvider")
+
+        XCTAssertFalse(
+            STTProviderRegistry.isStreamingAvailable,
+            "An empty sttProvider must not report streaming as available"
+        )
+    }
+
+    // MARK: - STT Persistence After Explicit Selection
+
+    /// After explicitly setting a provider via `setSTTProvider`, the value
+    /// should be persisted so subsequent reads return it.
+    func testExplicitSTTProviderSelectionPersists() {
+        UserDefaults.standard.removeObject(forKey: "sttProvider")
+
+        store.setSTTProvider("deepgram")
+        waitForPatchCount(1)
+
+        // The store persists via config patch; simulate the daemon echoing
+        // the value back through applyDaemonConfig.
+        let config: [String: Any] = [
+            "services": ["stt": ["provider": "deepgram"]]
+        ]
+        mockSettingsClient.fetchConfigResponse = config
+        let expectation = XCTestExpectation(description: "config loaded")
+        Task {
+            await store.loadConfigFromDaemon()
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 2.0)
+
+        XCTAssertEqual(
+            UserDefaults.standard.string(forKey: "sttProvider"),
+            "deepgram",
+            "Explicitly selected provider must be persisted after daemon sync"
+        )
+    }
+
+    // MARK: - Daemon Sync Does Not Clobber With Empty Values
+
+    /// When the daemon sends an empty provider string the existing persisted
+    /// value must not be overwritten.
+    func testApplyDaemonConfigDoesNotClobberWithEmptyProvider() {
+        UserDefaults.standard.set("deepgram", forKey: "sttProvider")
+
+        let config: [String: Any] = [
+            "services": [
+                "stt": [
+                    "provider": ""
+                ]
+            ]
+        ]
+
+        mockSettingsClient.fetchConfigResponse = config
+        let expectation = XCTestExpectation(description: "config loaded")
+        Task {
+            await store.loadConfigFromDaemon()
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 2.0)
+
+        XCTAssertEqual(
+            UserDefaults.standard.string(forKey: "sttProvider"),
+            "deepgram",
+            "Empty daemon provider value must not overwrite the persisted selection"
+        )
+    }
+
+    /// When the daemon sends a whitespace-only provider string the existing
+    /// persisted value must not be overwritten.
+    func testApplyDaemonConfigDoesNotClobberWithWhitespaceProvider() {
+        UserDefaults.standard.set("openai-whisper", forKey: "sttProvider")
+
+        let config: [String: Any] = [
+            "services": [
+                "stt": [
+                    "provider": "  "
+                ]
+            ]
+        ]
+
+        mockSettingsClient.fetchConfigResponse = config
+        let expectation = XCTestExpectation(description: "config loaded")
+        Task {
+            await store.loadConfigFromDaemon()
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 2.0)
+
+        XCTAssertEqual(
+            UserDefaults.standard.string(forKey: "sttProvider"),
+            "openai-whisper",
+            "Whitespace-only daemon provider value must not overwrite the persisted selection"
+        )
+    }
+
+    // MARK: - Existing User-Selected Provider Behavior Preserved
+
+    /// A user who previously selected openai-whisper and has it persisted
+    /// must continue to see that value after daemon sync confirms it.
+    func testPreExistingOpenAIWhisperSelectionSurvivesDaemonSync() {
+        UserDefaults.standard.set("openai-whisper", forKey: "sttProvider")
+
+        let config: [String: Any] = [
+            "services": [
+                "stt": [
+                    "provider": "openai-whisper"
+                ]
+            ]
+        ]
+
+        mockSettingsClient.fetchConfigResponse = config
+        let expectation = XCTestExpectation(description: "config loaded")
+        Task {
+            await store.loadConfigFromDaemon()
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 2.0)
+
+        XCTAssertEqual(
+            UserDefaults.standard.string(forKey: "sttProvider"),
+            "openai-whisper",
+            "Pre-existing user selection must survive daemon sync"
+        )
+    }
+
+    /// STT service configuration check must return true when a valid
+    /// provider is persisted.
+    func testPersistedSTTProviderIsConsideredConfigured() {
+        UserDefaults.standard.set("deepgram", forKey: "sttProvider")
+
+        XCTAssertTrue(
+            STTProviderRegistry.isServiceConfigured,
+            "A non-empty persisted sttProvider must be treated as configured"
+        )
+    }
 }

--- a/clients/macos/vellum-assistantTests/VoiceInputManagerTests.swift
+++ b/clients/macos/vellum-assistantTests/VoiceInputManagerTests.swift
@@ -18,7 +18,6 @@ private final class MockSTTStreamingClient: STTStreamingClientProtocol {
     var stopCallCount = 0
     var closeCallCount = 0
 
-    var startedProvider: String?
     var startedMimeType: String?
     var startedSampleRate: Int?
 
@@ -28,14 +27,12 @@ private final class MockSTTStreamingClient: STTStreamingClientProtocol {
     var onFailure: (@MainActor (STTStreamFailure) -> Void)?
 
     func start(
-        provider: String,
         mimeType: String,
         sampleRate: Int?,
         onEvent: @escaping @MainActor (STTStreamEvent) -> Void,
         onFailure: @escaping @MainActor (STTStreamFailure) -> Void
     ) async {
         startCallCount += 1
-        startedProvider = provider
         startedMimeType = mimeType
         startedSampleRate = sampleRate
         self.onEvent = onEvent

--- a/clients/shared/Network/STTStreamingClient.swift
+++ b/clients/shared/Network/STTStreamingClient.swift
@@ -70,10 +70,12 @@ public enum STTStreamFailure: Sendable, Equatable {
 /// connect, send audio chunks, receive partial/final transcripts, and
 /// handle close/error events.
 public protocol STTStreamingClientProtocol: Sendable {
-    /// Start a streaming STT session with the given provider and audio format.
+    /// Start a streaming STT session with the given audio format.
+    ///
+    /// The server resolves the STT provider from its own configuration —
+    /// clients do not need to specify a provider identifier.
     ///
     /// - Parameters:
-    ///   - provider: STT provider identifier (e.g. `"deepgram"`, `"google-gemini"`).
     ///   - mimeType: MIME type of the audio being streamed (e.g. `"audio/pcm"`).
     ///   - sampleRate: Sample rate in Hz (e.g. `16000`). Optional.
     ///   - onEvent: Callback invoked on the main actor for each server event.
@@ -81,7 +83,6 @@ public protocol STTStreamingClientProtocol: Sendable {
     ///     or terminates abnormally. After this fires, the session is closed and
     ///     callers should fall back to batch STT.
     func start(
-        provider: String,
         mimeType: String,
         sampleRate: Int?,
         onEvent: @escaping @MainActor (STTStreamEvent) -> Void,
@@ -131,7 +132,6 @@ public final class STTStreamingClient: STTStreamingClientProtocol {
     // MARK: - Lifecycle
 
     public func start(
-        provider: String,
         mimeType: String,
         sampleRate: Int?,
         onEvent: @escaping @MainActor (STTStreamEvent) -> Void,
@@ -147,8 +147,9 @@ public final class STTStreamingClient: STTStreamingClientProtocol {
         self.state = .connecting
 
         // Build query parameters for the WebSocket URL.
+        // The server resolves the STT provider from its own configuration —
+        // clients only send audio format metadata.
         var params: [String: String] = [
-            "provider": provider,
             "mimeType": mimeType,
         ]
         if let sampleRate {
@@ -160,7 +161,7 @@ public final class STTStreamingClient: STTStreamingClientProtocol {
                 path: "stt/stream",
                 params: params
             )
-            log.info("Opening STT stream WebSocket: provider=\(provider), mimeType=\(mimeType), sampleRate=\(sampleRate.map(String.init) ?? "nil")")
+            log.info("Opening STT stream WebSocket: mimeType=\(mimeType), sampleRate=\(sampleRate.map(String.init) ?? "nil")")
 
             let task = URLSession.shared.webSocketTask(with: request)
             self.webSocketTask = task

--- a/gateway/ARCHITECTURE.md
+++ b/gateway/ARCHITECTURE.md
@@ -55,16 +55,18 @@ The request carries base64-encoded WAV audio and a MIME type. The daemon resolve
 
 Native clients (macOS, iOS) open WebSocket connections through the gateway to the daemon's real-time STT streaming endpoint for conversation chat message capture. The gateway authenticates the downstream client using an edge JWT (actor principal required), then opens an upstream WebSocket connection to the daemon's `/v1/stt/stream` endpoint with a short-lived gateway service token. This keeps the daemon's WebSocket endpoint unreachable from the public internet while allowing authenticated clients to stream audio for real-time transcription.
 
-**Client path:** `wss://<gateway>/v1/stt/stream?provider=<id>&mimeType=<mime>[&sampleRate=<hz>]`
+**Config-authoritative model:** The runtime always resolves the streaming transcriber from `services.stt.provider` in the assistant config, regardless of any `provider` query parameter. The `provider` parameter is optional compatibility metadata — when supplied and it disagrees with the configured provider, the runtime logs a mismatch warning for operator visibility.
+
+**Client path:** `wss://<gateway>/v1/stt/stream?mimeType=<mime>[&provider=<id>][&sampleRate=<hz>]`
 
 **Query parameters:**
 
-| Parameter    | Required | Description                                                              |
-| ------------ | -------- | ------------------------------------------------------------------------ |
-| `provider`   | Yes      | STT provider identifier (`deepgram`, `google-gemini`)                    |
-| `mimeType`   | Yes      | MIME type of the audio being streamed (e.g. `audio/webm;codecs=opus`)    |
-| `sampleRate` | No       | Sample rate in Hz (e.g. `16000`). Passed through to the daemon.          |
-| `token`      | No       | Edge JWT (alternative to `Authorization: Bearer` header for WS upgrades) |
+| Parameter    | Required | Description                                                                                                                                                                      |
+| ------------ | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `mimeType`   | Yes      | MIME type of the audio being streamed (e.g. `audio/webm;codecs=opus`)                                                                                                            |
+| `provider`   | No       | Optional STT provider identifier (`deepgram`, `google-gemini`). Forwarded as compatibility metadata — the runtime resolves the transcriber from config, not from this parameter. |
+| `sampleRate` | No       | Sample rate in Hz (e.g. `16000`). Passed through to the daemon.                                                                                                                  |
+| `token`      | No       | Edge JWT (alternative to `Authorization: Bearer` header for WS upgrades)                                                                                                         |
 
 **Auth model:** STT streaming is an authenticated, assistant-scoped path. The client must present a valid edge JWT with an actor principal. Service tokens are rejected. When `runtimeProxyRequireAuth` is globally disabled (dev bypass), the upgrade proceeds without token validation.
 

--- a/gateway/src/__tests__/stt-stream-websocket.test.ts
+++ b/gateway/src/__tests__/stt-stream-websocket.test.ts
@@ -158,7 +158,7 @@ describe("createSttStreamWebsocketHandler", () => {
     expect(server.upgrade).not.toHaveBeenCalled();
   });
 
-  test("returns 400 when provider is missing", () => {
+  test("upgrades successfully when provider is omitted (config-authoritative)", () => {
     const config = makeConfig();
     const handler = createSttStreamWebsocketHandler(config);
     const req = new Request(
@@ -168,8 +168,15 @@ describe("createSttStreamWebsocketHandler", () => {
     const server = makeFakeServer();
     const res = handler(req, server);
 
-    expect(res).toBeInstanceOf(Response);
-    expect(res!.status).toBe(400);
+    expect(res).toBeUndefined();
+    expect(server.upgrade).toHaveBeenCalledTimes(1);
+
+    // Verify provider is undefined in socket data
+    const upgradeCall = (server.upgrade as ReturnType<typeof mock>).mock
+      .calls[0] as unknown[];
+    const opts = upgradeCall[1] as { data: SttStreamSocketData };
+    expect(opts.data.provider).toBeUndefined();
+    expect(opts.data.mimeType).toBe("audio/webm");
   });
 
   test("returns 400 when mimeType is missing", () => {
@@ -177,6 +184,20 @@ describe("createSttStreamWebsocketHandler", () => {
     const handler = createSttStreamWebsocketHandler(config);
     const req = new Request(
       `http://localhost:7830/v1/stt/stream?token=${TEST_TOKEN}&provider=deepgram`,
+      { headers: { upgrade: "websocket" } },
+    );
+    const server = makeFakeServer();
+    const res = handler(req, server);
+
+    expect(res).toBeInstanceOf(Response);
+    expect(res!.status).toBe(400);
+  });
+
+  test("returns 400 when mimeType is missing and provider is also missing", () => {
+    const config = makeConfig();
+    const handler = createSttStreamWebsocketHandler(config);
+    const req = new Request(
+      `http://localhost:7830/v1/stt/stream?token=${TEST_TOKEN}`,
       { headers: { upgrade: "websocket" } },
     );
     const server = makeFakeServer();
@@ -227,11 +248,25 @@ describe("createSttStreamWebsocketHandler", () => {
     expect(server.upgrade).toHaveBeenCalledTimes(1);
   });
 
-  test("returns 400 when auth is disabled but provider is missing", () => {
+  test("upgrades when auth is disabled and provider is omitted", () => {
     const config = makeConfig({ runtimeProxyRequireAuth: false });
     const handler = createSttStreamWebsocketHandler(config);
     const req = new Request(
       "http://localhost:7830/v1/stt/stream?mimeType=audio/webm",
+      { headers: { upgrade: "websocket" } },
+    );
+    const server = makeFakeServer();
+    const res = handler(req, server);
+
+    expect(res).toBeUndefined();
+    expect(server.upgrade).toHaveBeenCalledTimes(1);
+  });
+
+  test("returns 400 when auth is disabled but mimeType is missing", () => {
+    const config = makeConfig({ runtimeProxyRequireAuth: false });
+    const handler = createSttStreamWebsocketHandler(config);
+    const req = new Request(
+      "http://localhost:7830/v1/stt/stream?provider=deepgram",
       { headers: { upgrade: "websocket" } },
     );
     const server = makeFakeServer();

--- a/gateway/src/http/routes/stt-stream-websocket.ts
+++ b/gateway/src/http/routes/stt-stream-websocket.ts
@@ -14,8 +14,15 @@ const MAX_PENDING_MESSAGES = 100;
 export type SttStreamSocketData = {
   wsType: "stt-stream";
   config: GatewayConfig;
-  /** Provider identifier for the STT streaming session (e.g. "deepgram", "google-gemini"). */
-  provider: string;
+  /**
+   * Optional provider identifier for the STT streaming session (e.g.
+   * "deepgram", "google-gemini"). The runtime is config-authoritative —
+   * it always resolves the streaming transcriber from `services.stt.provider`
+   * regardless of this value. When supplied, it is forwarded as compatibility
+   * metadata and the runtime logs a mismatch warning if it disagrees with
+   * the configured provider.
+   */
+  provider?: string;
   /** MIME type of the audio being streamed (e.g. "audio/webm;codecs=opus"). */
   mimeType: string;
   /** Sample rate in Hz, when applicable. */
@@ -53,16 +60,13 @@ export function createSttStreamWebsocketHandler(config: GatewayConfig) {
     if (!config.runtimeProxyRequireAuth) {
       // When runtime proxy auth is globally disabled (dev bypass), we
       // still allow the upgrade but skip token validation.
-      const provider = url.searchParams.get("provider");
+      const provider = url.searchParams.get("provider") ?? undefined;
       const mimeType = url.searchParams.get("mimeType");
 
-      if (!provider || !mimeType) {
-        return new Response(
-          "Missing required query parameters: provider, mimeType",
-          {
-            status: 400,
-          },
-        );
+      if (!mimeType) {
+        return new Response("Missing required query parameter: mimeType", {
+          status: 400,
+        });
       }
 
       const sampleRateRaw = url.searchParams.get("sampleRate");
@@ -126,17 +130,16 @@ export function createSttStreamWebsocketHandler(config: GatewayConfig) {
       return new Response("Unauthorized", { status: 401 });
     }
 
-    // ── Required query parameters ──
-    const provider = url.searchParams.get("provider");
+    // ── Query parameters ──
+    // mimeType is required; provider is optional compatibility metadata
+    // (the runtime resolves the transcriber from config, not from the query).
+    const provider = url.searchParams.get("provider") ?? undefined;
     const mimeType = url.searchParams.get("mimeType");
 
-    if (!provider || !mimeType) {
-      return new Response(
-        "Missing required query parameters: provider, mimeType",
-        {
-          status: 400,
-        },
-      );
+    if (!mimeType) {
+      return new Response("Missing required query parameter: mimeType", {
+        status: 400,
+      });
     }
 
     const sampleRateRaw = url.searchParams.get("sampleRate");
@@ -177,15 +180,19 @@ export function getSttStreamWebsocketHandlers() {
       const upstreamToken = mintServiceToken();
       const query = new URLSearchParams({
         token: upstreamToken,
-        provider,
         mimeType,
       });
+      if (provider) {
+        query.set("provider", provider);
+      }
       if (sampleRate !== undefined) {
         query.set("sampleRate", String(sampleRate));
       }
       const upstreamUrl = `${runtimeBase}/v1/stt/stream?${query.toString()}`;
       const logSafeUpstreamUrl =
-        `${runtimeBase}/v1/stt/stream?token=<redacted>&provider=${provider}&mimeType=${encodeURIComponent(mimeType)}` +
+        `${runtimeBase}/v1/stt/stream?token=<redacted>` +
+        (provider ? `&provider=${provider}` : "") +
+        `&mimeType=${encodeURIComponent(mimeType)}` +
         (sampleRate !== undefined ? `&sampleRate=${sampleRate}` : "");
 
       log.info(

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -874,17 +874,17 @@ export function buildSchema(): Record<string, unknown> {
         get: {
           summary: "STT stream WebSocket",
           description:
-            "Accepts a WebSocket upgrade for real-time speech-to-text streaming. Authenticates the client using an edge JWT (actor principal) and proxies audio frames bidirectionally to the assistant runtime's /v1/stt/stream endpoint using a gateway service token. Requires provider and mimeType query parameters.",
+            "Accepts a WebSocket upgrade for real-time speech-to-text streaming. Authenticates the client using an edge JWT (actor principal) and proxies audio frames bidirectionally to the assistant runtime's /v1/stt/stream endpoint using a gateway service token. Requires mimeType query parameter. The runtime is config-authoritative: the streaming transcriber is always resolved from `services.stt.provider` in the assistant config, not from the optional `provider` query parameter.",
           operationId: "sttStreamWebsocket",
           security: [{ BearerAuth: [] }],
           parameters: [
             {
               name: "provider",
               in: "query",
-              required: true,
+              required: false,
               schema: { type: "string" },
               description:
-                "STT provider identifier (e.g. 'deepgram', 'google-gemini').",
+                "Optional STT provider identifier (e.g. 'deepgram', 'google-gemini'). Forwarded as compatibility metadata — the runtime resolves the transcriber from config (`services.stt.provider`), not from this parameter. When supplied and it disagrees with the configured provider, the runtime logs a mismatch warning.",
             },
             {
               name: "mimeType",
@@ -916,8 +916,7 @@ export function buildSchema(): Record<string, unknown> {
                 "WebSocket upgrade successful — bidirectional STT audio/transcription frame proxying begins.",
             },
             "400": {
-              description:
-                "Missing required query parameters (provider, mimeType)",
+              description: "Missing required query parameter (mimeType)",
               content: {
                 "text/plain": {
                   schema: { type: "string" },


### PR DESCRIPTION
## Summary
Closes the remaining gaps from the telephony/STT unification work: catalog-driven telephony routing, a consistent streaming STT contract, macOS default alignment, and media-stream setup-flow safety.

## Self-review result
GAPS FOUND — 3 gaps fixed across 3 fix PRs (all verified in re-review)

## PRs merged into feature branch
- #25335: stt: encode telephony routing metadata in provider catalog
- #25340: stt-stream: make provider query optional and config-authoritative
- #25337: macos: align stt settings defaults with explicit services.stt provider
- #25345: stt: derive twilio routing from provider catalog metadata
- #25346: clients: stop sending provider query for streaming stt
- #25349: calls: guard media-stream unsupported setup flows and add regression tests

### Fix PRs
- #25356: fix: derive Deepgram fallback from catalog instead of hardcoded values
- #25357: fix: add telephonyRouting field to stt-provider-onboarding step 1
- #25358: fix: update ARCHITECTURE.md to reflect catalog-driven telephony routing

Part of plan: stt-telephony-cleanups.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25361" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
