### PR TITLE
feat(home): add HomeStore observable that fetches state and subscribes to SSE updates

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/HomeStore+SSE.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeStore+SSE.swift
@@ -1,0 +1,26 @@
+import Foundation
+import VellumAssistantShared
+
+/// SSE subscription loop for ``HomeStore``.
+///
+/// Split out of the main file so the store body stays focused on state +
+/// lifecycle, while this extension holds the async-iteration boilerplate.
+/// The task handle lives on the store (`sseTask`) so `deinit` can cancel it.
+extension HomeStore {
+    /// Starts consuming the shared `ServerMessage` stream and triggers a
+    /// reload whenever the daemon broadcasts `relationshipStateUpdated`.
+    ///
+    /// Invoked from `HomeStore.init` — safe to call exactly once per store.
+    func startListening() {
+        sseTask = Task { [weak self] in
+            guard let self else { return }
+            let stream = self.messageStream
+            for await message in stream {
+                if Task.isCancelled { break }
+                if case .relationshipStateUpdated = message {
+                    await self.load()
+                }
+            }
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Home/HomeStore.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeStore.swift
@@ -1,0 +1,154 @@
+import AppKit
+import Foundation
+import Observation
+import VellumAssistantShared
+import os
+
+private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "HomeStore")
+
+/// Observable store that owns the Home page's cached `RelationshipState`.
+///
+/// Responsibilities:
+/// - Fetches the current state from the daemon via ``HomeStateClient``.
+/// - Subscribes to the shared `ServerMessage` stream and re-fetches when the
+///   daemon broadcasts `relationshipStateUpdated`.
+/// - Re-fetches when the app returns to the foreground so the UI stays fresh
+///   if the user switched away while capabilities were being unlocked.
+///
+/// The store deliberately leaves `state` untouched on failure — a transient
+/// network blip should not blank the Home page. `isLoading` reflects the
+/// in-flight state of `load()` so views can show a spinner on first fetch.
+///
+/// `hasUnseenChanges` and `isHomeTabVisible` are stubs declared here so the
+/// public surface is in place; PR 16 drives the unseen-changes logic.
+@MainActor
+@Observable
+public final class HomeStore {
+
+    // MARK: - Reactive State
+
+    public private(set) var state: RelationshipState?
+    public private(set) var isLoading: Bool = false
+
+    /// Set when the daemon emits a `relationshipStateUpdated` SSE event while
+    /// the Home tab is not currently visible. Drives a badge on the tab.
+    /// PR 16 wires the producer side; this PR only declares the property.
+    public private(set) var hasUnseenChanges: Bool = false
+
+    /// Toggled by the Home tab host to track visibility for the unseen-changes
+    /// badge logic in PR 16. This PR only declares the property.
+    public var isHomeTabVisible: Bool = false
+
+    // MARK: - Non-reactive Bookkeeping
+
+    @ObservationIgnored private let client: HomeStateClient
+    @ObservationIgnored let messageStream: AsyncStream<ServerMessage>
+    @ObservationIgnored var sseTask: Task<Void, Never>?
+    @ObservationIgnored private var foregroundObserver: NSObjectProtocol?
+
+    // MARK: - Lifecycle
+
+    public init(client: HomeStateClient, messageStream: AsyncStream<ServerMessage>) {
+        self.client = client
+        self.messageStream = messageStream
+        startListening()
+        observeForeground()
+    }
+
+    deinit {
+        sseTask?.cancel()
+        if let observer = foregroundObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
+    }
+
+    // MARK: - Public API
+
+    /// Fetches the latest `RelationshipState` from the daemon.
+    ///
+    /// Leaves `state` unchanged on failure so the UI keeps showing whatever
+    /// we last successfully fetched. Errors are logged, never thrown out.
+    public func load() async {
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            let next = try await client.fetchRelationshipState()
+            self.state = next
+        } catch {
+            log.error("HomeStore.load failed: \(error.localizedDescription)")
+        }
+    }
+
+    /// Clears the unseen-changes badge. Called by the Home tab host when the
+    /// user navigates to the Home tab. PR 16 will drive the producer side;
+    /// the clearer is exposed here so the acceptance-criteria surface is
+    /// complete.
+    public func markSeen() {
+        hasUnseenChanges = false
+    }
+
+    // MARK: - Foreground Refresh
+
+    private func observeForeground() {
+        foregroundObserver = NotificationCenter.default.addObserver(
+            forName: NSApplication.didBecomeActiveNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                await self?.load()
+            }
+        }
+    }
+}
+
+// MARK: - Mock Client
+
+/// In-memory mock used by unit tests and, in the future, gallery fixtures.
+///
+/// Lives alongside `HomeStore` rather than in a test-only file so it can be
+/// shared between `vellum-assistantTests` and any future preview surfaces
+/// without changing its import path.
+public final class MockHomeStateClient: HomeStateClient, @unchecked Sendable {
+    private let lock = NSLock()
+    private var _state: RelationshipState?
+    private var _error: Error?
+    private var _callCount: Int = 0
+
+    public init(state: RelationshipState? = nil, error: Error? = nil) {
+        self._state = state
+        self._error = error
+    }
+
+    public var callCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return _callCount
+    }
+
+    public func setState(_ state: RelationshipState?) {
+        lock.lock()
+        defer { lock.unlock() }
+        _state = state
+    }
+
+    public func setError(_ error: Error?) {
+        lock.lock()
+        defer { lock.unlock() }
+        _error = error
+    }
+
+    public func fetchRelationshipState() async throws -> RelationshipState {
+        lock.lock()
+        _callCount += 1
+        let error = _error
+        let state = _state
+        lock.unlock()
+
+        if let error { throw error }
+        guard let state else {
+            throw HomeStateClientError.httpError(statusCode: 404)
+        }
+        return state
+    }
+}

--- a/clients/macos/vellum-assistantTests/HomeStoreTests.swift
+++ b/clients/macos/vellum-assistantTests/HomeStoreTests.swift
@@ -1,0 +1,129 @@
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+/// Unit tests for `HomeStore` — exercised with `MockHomeStateClient` and a
+/// scripted `AsyncStream<ServerMessage>` so the tests stay hermetic (no
+/// network, no gateway, no daemon).
+@MainActor
+final class HomeStoreTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    private func makeRelationshipState(
+        tier: Int = 2,
+        progressPercent: Int = 42,
+        updatedAt: String = "2026-04-13T12:00:00Z"
+    ) -> RelationshipState {
+        RelationshipState(
+            version: 1,
+            assistantId: "self",
+            tier: tier,
+            progressPercent: progressPercent,
+            facts: [],
+            capabilities: [],
+            conversationCount: 3,
+            hatchedDate: "2026-04-01T09:00:00Z",
+            assistantName: "Vellum",
+            userName: nil,
+            updatedAt: updatedAt
+        )
+    }
+
+    /// Creates a `HomeStore` plus its companion stream continuation so the
+    /// test can drive SSE events into the store deterministically.
+    private func makeStore(
+        client: HomeStateClient
+    ) -> (HomeStore, AsyncStream<ServerMessage>.Continuation) {
+        let (stream, continuation) = AsyncStream<ServerMessage>.makeStream()
+        let store = HomeStore(client: client, messageStream: stream)
+        return (store, continuation)
+    }
+
+    // MARK: - Tests
+
+    func testLoadPopulatesStateOnSuccess() async {
+        let expected = makeRelationshipState(tier: 3, progressPercent: 75)
+        let client = MockHomeStateClient(state: expected)
+        let (store, _) = makeStore(client: client)
+
+        XCTAssertNil(store.state, "state should start empty before load()")
+
+        await store.load()
+
+        XCTAssertEqual(store.state, expected)
+        XCTAssertFalse(store.isLoading, "isLoading should flip back to false after load()")
+        XCTAssertEqual(client.callCount, 1)
+    }
+
+    func testLoadLeavesStateUnchangedOnFailure() async {
+        let seeded = makeRelationshipState(tier: 1, progressPercent: 10)
+        let client = MockHomeStateClient(state: seeded)
+        let (store, _) = makeStore(client: client)
+
+        // Prime the cache with a successful load.
+        await store.load()
+        XCTAssertEqual(store.state, seeded)
+
+        // Next fetch fails — store should keep the previous snapshot.
+        client.setError(HomeStateClientError.httpError(statusCode: 500))
+        await store.load()
+
+        XCTAssertEqual(store.state, seeded, "state must not be blanked on transport failure")
+        XCTAssertFalse(store.isLoading)
+    }
+
+    func testSSEEventTriggersReload() async throws {
+        let initial = makeRelationshipState(tier: 2, progressPercent: 30, updatedAt: "2026-04-13T10:00:00Z")
+        let client = MockHomeStateClient(state: initial)
+        let (store, continuation) = makeStore(client: client)
+
+        // Prime with one real fetch so we know the starting call count.
+        await store.load()
+        XCTAssertEqual(store.state, initial)
+        let baselineCallCount = client.callCount
+
+        // Flip the mock to the new payload and emit an SSE event.
+        let updated = makeRelationshipState(tier: 3, progressPercent: 80, updatedAt: "2026-04-13T11:00:00Z")
+        client.setState(updated)
+        continuation.yield(.relationshipStateUpdated(updatedAt: updated.updatedAt))
+
+        // The subscription reload is async — poll briefly on the MainActor
+        // until the store observes the new state (bounded to avoid hangs).
+        try await waitUntil(timeout: 2.0) {
+            client.callCount > baselineCallCount && store.state == updated
+        }
+
+        XCTAssertEqual(store.state, updated)
+        XCTAssertGreaterThan(client.callCount, baselineCallCount)
+    }
+
+    func testMarkSeenClearsUnseenChangesFlag() {
+        let client = MockHomeStateClient(state: makeRelationshipState())
+        let (store, _) = makeStore(client: client)
+
+        // `hasUnseenChanges` starts false; `markSeen()` should keep it false
+        // (idempotent) and callers in PR 16 will flip it via the producer
+        // path. This test locks in the public surface for this PR.
+        XCTAssertFalse(store.hasUnseenChanges)
+        store.markSeen()
+        XCTAssertFalse(store.hasUnseenChanges)
+    }
+
+    // MARK: - Helpers
+
+    /// Polls `condition` on the MainActor until it returns true or the
+    /// timeout elapses. Used instead of a fixed `Task.sleep` so the async
+    /// subscription test finishes as soon as the reload completes.
+    private func waitUntil(
+        timeout: TimeInterval,
+        condition: @MainActor () -> Bool
+    ) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if condition() { return }
+            try await Task.sleep(nanoseconds: 20_000_000) // 20 ms
+        }
+        XCTFail("waitUntil timed out after \(timeout)s")
+    }
+}

--- a/clients/shared/Network/HomeStateClient.swift
+++ b/clients/shared/Network/HomeStateClient.swift
@@ -1,0 +1,64 @@
+import Foundation
+import os
+
+private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "HomeStateClient")
+
+/// Focused client for fetching the current `RelationshipState` from the
+/// assistant runtime via the gateway.
+///
+/// The protocol is expressed in a `throws` style (unlike most sibling
+/// clients that return optionals) so that `HomeStore` can distinguish a
+/// successful empty state from a transport or decode failure, and leave
+/// its cached `state` untouched on error instead of blanking it.
+public protocol HomeStateClient: Sendable {
+    func fetchRelationshipState() async throws -> RelationshipState
+}
+
+/// Errors produced by ``DefaultHomeStateClient``.
+public enum HomeStateClientError: LocalizedError {
+    case httpError(statusCode: Int)
+    case decodingFailed(underlying: Error)
+
+    public var errorDescription: String? {
+        switch self {
+        case .httpError(let statusCode):
+            return "Home state request failed (HTTP \(statusCode))"
+        case .decodingFailed(let underlying):
+            return "Failed to decode home state: \(underlying.localizedDescription)"
+        }
+    }
+}
+
+/// Gateway-backed implementation of ``HomeStateClient``.
+///
+/// Hits `GET /v1/home/state` via ``GatewayHTTPClient`` — the assistant-scoped
+/// path prefix (`assistants/{assistantId}/`) is rewritten to the flat daemon
+/// path by the gateway's runtime proxy, matching the pattern used by
+/// `IdentityClient`, `AppsClient`, etc.
+public struct DefaultHomeStateClient: HomeStateClient {
+    nonisolated public init() {}
+
+    public func fetchRelationshipState() async throws -> RelationshipState {
+        let response: GatewayHTTPClient.Response
+        do {
+            response = try await GatewayHTTPClient.get(
+                path: "assistants/{assistantId}/home/state", timeout: 10
+            )
+        } catch {
+            log.error("fetchRelationshipState transport error: \(error.localizedDescription)")
+            throw error
+        }
+
+        guard response.isSuccess else {
+            log.error("fetchRelationshipState failed (HTTP \(response.statusCode))")
+            throw HomeStateClientError.httpError(statusCode: response.statusCode)
+        }
+
+        do {
+            return try JSONDecoder().decode(RelationshipState.self, from: response.data)
+        } catch {
+            log.error("fetchRelationshipState decode error: \(error.localizedDescription)")
+            throw HomeStateClientError.decodingFailed(underlying: error)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- `HomeStateClient` protocol + `DefaultHomeStateClient` matching the existing `AppsClient`/`IdentityClient` pattern (same `Bundle.appBundleIdentifier` logger, same `GatewayHTTPClient.get` shape, same `assistants/{assistantId}/...` path template). Throws on failure (intentional divergence from sibling clients) so the store can preserve cached state on transient errors.
- `HomeStore`: `@Observable @MainActor public final class` with `state`, `isLoading`, `hasUnseenChanges` (PR 16 stub), `isHomeTabVisible` (PR 16 stub), `load()`, `markSeen()`. Uses `@ObservationIgnored` for `sseTask`/`foregroundObserver` per the documented `swift#79551` deinit workaround in `clients/AGENTS.md`.
- `HomeStore+SSE.swift`: SSE subscription loop that triggers `load()` on each `.relationshipStateUpdated` event. Foreground refetch via `NSApplication.didBecomeActiveNotification`.
- `HomeStoreTests.swift`: 4 `@MainActor` tests via `MockHomeStateClient` + scripted `AsyncStream<ServerMessage>.Continuation` covering load success, failure-preserves-cache, SSE-triggers-reload, and `markSeen()` idempotency.
- No `#Preview` blocks anywhere.

Part of plan: home-page-phase-3.md (PR 13 of 16)
Refs LUM-859
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25363" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
