### PR TITLE
feat(macos): add 3-dot hover menu to group and subgroup headers

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionHeader.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionHeader.swift
@@ -35,6 +35,15 @@ struct SidebarSectionHeader: View {
     var sidebar: SidebarInteractionState?
 
     @State private var isHeaderHovered: Bool = false
+    @State private var isMenuOpen: Bool = false
+
+    /// Whether the trailing ellipsis button should be visible (hovered or menu open).
+    private var hasTrailingIcon: Bool { isHeaderHovered || isMenuOpen }
+
+    /// Whether any context menu action is available (mirrors ConditionalGroupContextMenu logic).
+    private var hasAnyAction: Bool {
+        onRename != nil || onDelete != nil || onMarkAllRead != nil || onArchiveAll != nil
+    }
 
     private var isGroupPinned: Bool {
         group.id == ConversationGroup.pinned.id
@@ -70,7 +79,7 @@ struct SidebarSectionHeader: View {
                 .foregroundStyle(VColor.contentSecondary)
 
             Spacer()
-            if !isExpanded {
+            if !isExpanded && !hasTrailingIcon {
                 switch aggregateState {
                 case .error:
                     VIconView(.circleAlert, size: 10)
@@ -96,8 +105,55 @@ struct SidebarSectionHeader: View {
         .padding(.vertical, SidebarLayoutMetrics.rowVerticalPadding)
         .frame(minHeight: SidebarLayoutMetrics.rowMinHeight)
         .contentShape(Rectangle())
+        .animation(VAnimation.fast, value: isHeaderHovered)
+        .animation(VAnimation.fast, value: isMenuOpen)
+        .onTapGesture { withAnimation(VAnimation.fast) { onToggleExpand() } }
         .overlay(alignment: .trailing) {
-            if conversationCount > 0 {
+            if hasTrailingIcon && hasAnyAction {
+                VButton(
+                    label: "More options for \(group.name)",
+                    iconOnly: VIcon.ellipsis.rawValue,
+                    style: .ghost,
+                    iconSize: 20,
+                    tooltip: "More options",
+                    iconColor: VColor.contentSecondary
+                ) {
+                    guard !isMenuOpen else { return }
+                    isMenuOpen = true
+                    let appearance = NSApp.keyWindow?.effectiveAppearance
+                    VMenuPanel.show(
+                        at: NSEvent.mouseLocation,
+                        sourceAppearance: appearance
+                    ) {
+                        VMenu(width: 200) {
+                            if let onMarkAllRead {
+                                VMenuItem(icon: VIcon.circleCheck.rawValue, label: "Mark All as Read") {
+                                    onMarkAllRead()
+                                }
+                                .disabled(!hasUnreadConversations)
+                            }
+                            if let onArchiveAll {
+                                VMenuItem(icon: VIcon.archive.rawValue, label: "Archive All\u{2026}") {
+                                    onArchiveAll()
+                                }
+                                .disabled(conversationCount == 0)
+                            }
+                            if (onMarkAllRead != nil || onArchiveAll != nil) && (onRename != nil || onDelete != nil) {
+                                VMenuDivider()
+                            }
+                            if let onRename {
+                                VMenuItem(icon: VIcon.pencil.rawValue, label: "Rename") { onRename(group.name) }
+                            }
+                            if let onDelete {
+                                VMenuItem(icon: VIcon.trash.rawValue, label: conversationCount > 0 ? "Delete group\u{2026}" : "Delete group") { onDelete() }
+                            }
+                        }
+                    } onDismiss: {
+                        isMenuOpen = false
+                    }
+                }
+                .padding(.trailing, VSpacing.xs)
+            } else if conversationCount > 0 {
                 Text("\(conversationCount)")
                     .font(VFont.labelSmall)
                     .foregroundStyle(VColor.contentTertiary)
@@ -110,7 +166,6 @@ struct SidebarSectionHeader: View {
                     .padding(.trailing, VSpacing.xs)
             }
         }
-        .onTapGesture { withAnimation(VAnimation.fast) { onToggleExpand() } }
         .pointerCursor(onHover: { hovering in
             isHeaderHovered = hovering
         })

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionView.swift
@@ -299,6 +299,17 @@ struct SidebarSectionView: View {
                 }
             }
         }
+        .accessibilityAddTraits(.isButton)
+        .accessibilityLabel("Toggle \(subGroup.label)")
+        .accessibilityAction(.default) {
+            withAnimation(VAnimation.fast) {
+                if isSubGroupExpanded {
+                    expandedScheduleGroups?.wrappedValue.remove(subGroup.key)
+                } else {
+                    expandedScheduleGroups?.wrappedValue.insert(subGroup.key)
+                }
+            }
+        }
         .pointerCursor()
         .animation(VAnimation.fast, value: showEllipsis)
         // Ellipsis button overlay — rendered after .onTapGesture so it sits

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionView.swift
@@ -52,6 +52,7 @@ struct SidebarSectionView: View {
     /// (mirrors showAll at the section level but per sub-group key).
     @State private var showAllInSubGroup: Set<String> = []
     @State private var hoveredSubGroupKey: String?
+    @State private var menuOpenSubGroupKey: String?
 
     enum CountMode {
         case items
@@ -238,47 +239,45 @@ struct SidebarSectionView: View {
     private func scheduleSubGroupDisclosure(_ subGroup: ScheduleSubGroup) -> some View {
         let isSubGroupExpanded = expandedScheduleGroups?.wrappedValue.contains(subGroup.key) ?? false
         let hasUnread = subGroup.conversations.contains(where: \.hasUnseenLatestAssistantMessage)
+        let isSubGroupHovered = hoveredSubGroupKey == subGroup.key
+        let isSubGroupMenuOpen = menuOpenSubGroupKey == subGroup.key
+        let showEllipsis = isSubGroupHovered || isSubGroupMenuOpen
 
         // Disclosure header — layout matches SidebarConversationItem's skeleton
         // so the chevron aligns with the pin icon and the badge aligns with the ellipsis.
-        Button {
-            withAnimation(VAnimation.fast) {
-                if isSubGroupExpanded {
-                    expandedScheduleGroups?.wrappedValue.remove(subGroup.key)
-                } else {
-                    expandedScheduleGroups?.wrappedValue.insert(subGroup.key)
-                }
-            }
-        } label: {
-            HStack(spacing: VSpacing.xs) {
-                // Leading 20x20 slot — chevron centered, matching pin icon position
-                VIconView(.chevronRight, size: 10)
-                    .foregroundStyle(VColor.contentTertiary)
-                    .rotationEffect(.degrees(isSubGroupExpanded ? 90 : 0))
-                    .animation(VAnimation.fast, value: isSubGroupExpanded)
-                    .frame(width: 20, height: 20)
+        // Uses .onTapGesture instead of Button so overlay VButtons sit above the
+        // tap gesture in the hit-test chain and absorb taps without triggering the
+        // toggle (same pattern as SidebarSectionHeader and SidebarConversationItem).
+        HStack(spacing: VSpacing.xs) {
+            // Leading 20x20 slot — chevron centered, matching pin icon position
+            VIconView(.chevronRight, size: 10)
+                .foregroundStyle(VColor.contentTertiary)
+                .rotationEffect(.degrees(isSubGroupExpanded ? 90 : 0))
+                .animation(VAnimation.fast, value: isSubGroupExpanded)
+                .frame(width: 20, height: 20)
 
-                VMarqueeText(
-                    text: subGroup.label,
-                    font: VFont.bodySmallDefault,
-                    measuringFont: VFont.nsBodySmallDefault,
-                    foregroundStyle: VColor.contentTertiary,
-                    isHovered: hoveredSubGroupKey == subGroup.key
-                )
-                Spacer()
-                if hasUnread {
-                    VBadge(style: .dot, color: VColor.systemMidStrong)
-                        .transition(.opacity)
-                }
+            VMarqueeText(
+                text: subGroup.label,
+                font: VFont.bodySmallDefault,
+                measuringFont: VFont.nsBodySmallDefault,
+                foregroundStyle: VColor.contentTertiary,
+                isHovered: isSubGroupHovered
+            )
+            Spacer()
+            if hasUnread && !showEllipsis {
+                VBadge(style: .dot, color: VColor.systemMidStrong)
+                    .transition(.opacity)
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.leading, VSpacing.xs)
-            .padding(.trailing, SidebarLayoutMetrics.trailingIconPadding)
-            .padding(.vertical, SidebarLayoutMetrics.rowVerticalPadding)
-            .frame(minHeight: SidebarLayoutMetrics.rowMinHeight)
-            .contentShape(Rectangle())
-            // Count badge — trailing overlay matching ellipsis button position
-            .overlay(alignment: .trailing) {
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.leading, VSpacing.xs)
+        .padding(.trailing, SidebarLayoutMetrics.trailingIconPadding)
+        .padding(.vertical, SidebarLayoutMetrics.rowVerticalPadding)
+        .frame(minHeight: SidebarLayoutMetrics.rowMinHeight)
+        .contentShape(Rectangle())
+        // Count badge — hidden on hover when the ellipsis button takes over
+        .overlay(alignment: .trailing) {
+            if !showEllipsis {
                 Text("\(subGroup.conversations.count)")
                     .font(.system(size: 10, weight: .medium))
                     .foregroundStyle(VColor.contentTertiary)
@@ -291,8 +290,56 @@ struct SidebarSectionView: View {
                     .padding(.trailing, VSpacing.xs)
             }
         }
-        .buttonStyle(.plain)
+        .onTapGesture {
+            withAnimation(VAnimation.fast) {
+                if isSubGroupExpanded {
+                    expandedScheduleGroups?.wrappedValue.remove(subGroup.key)
+                } else {
+                    expandedScheduleGroups?.wrappedValue.insert(subGroup.key)
+                }
+            }
+        }
         .pointerCursor()
+        .animation(VAnimation.fast, value: showEllipsis)
+        // Ellipsis button overlay — rendered after .onTapGesture so it sits
+        // above it in the hit-test chain and absorbs taps without triggering
+        // the disclosure toggle (same pattern as SidebarConversationItem).
+        .overlay(alignment: .trailing) {
+            if showEllipsis {
+                VButton(
+                    label: "More options for \(subGroup.label)",
+                    iconOnly: VIcon.ellipsis.rawValue,
+                    style: .ghost,
+                    iconSize: 20,
+                    tooltip: "More options",
+                    iconColor: VColor.contentSecondary
+                ) {
+                    guard menuOpenSubGroupKey != subGroup.id else { return }
+                    menuOpenSubGroupKey = subGroup.id
+                    let appearance = NSApp.keyWindow?.effectiveAppearance
+                    VMenuPanel.show(
+                        at: NSEvent.mouseLocation,
+                        sourceAppearance: appearance
+                    ) {
+                        VMenu(width: 200) {
+                            let unread = subGroup.conversations.filter(\.hasUnseenLatestAssistantMessage)
+                            VMenuItem(icon: VIcon.circleCheck.rawValue, label: "Mark All as Read") {
+                                onMarkAllReadInSubGroup?(subGroup.label, subGroup.conversations.map(\.id))
+                            }
+                            .disabled(unread.isEmpty)
+                            let archivable = subGroup.conversations.filter { !$0.isChannelConversation }
+                            VMenuItem(icon: VIcon.archive.rawValue, label: "Archive All\u{2026}") {
+                                onArchiveAllInSubGroup?(subGroup.label, archivable.map(\.id))
+                            }
+                            .disabled(archivable.isEmpty)
+                        }
+                    } onDismiss: {
+                        menuOpenSubGroupKey = nil
+                    }
+                }
+                .padding(.trailing, VSpacing.xs)
+            }
+        }
         .onHover { hovering in
             if hovering {
                 hoveredSubGroupKey = subGroup.key


### PR DESCRIPTION
## Summary
Add a hover-triggered 3-dot ellipsis button to sidebar group section headers and subgroup disclosure headers, matching the existing conversation row pattern. On hover, the button replaces count badges and unread/state indicators. Clicking it opens the same context menu as right-click.

## Changes
- **SidebarSectionHeader.swift**: Added `isMenuOpen` state, `hasTrailingIcon` computed property, trailing ellipsis VButton overlay that replaces count badge + aggregate state indicators on hover. Click opens VMenuPanel with same items as right-click context menu. Overlay placed after `.onTapGesture` for correct hit-testing.
- **SidebarSectionView.swift**: Added `menuOpenSubGroupKey` state, `showEllipsis` computed property, trailing ellipsis VButton overlay on subgroup disclosure headers replacing count badge + unread dot on hover. Converted parent `Button` to `.onTapGesture` for correct hit-testing. Click opens VMenuPanel with same items as right-click.

## Milestone PRs (merged into feature branch)
- #25354: M1: Add 3-dot hover menu to group section headers
- #25355: M2: Add 3-dot hover menu to subgroup disclosure headers

## Project issue
Closes #25351

## Test plan
- [ ] Hover over a group section header (Pinned, Recents, custom groups) — 3-dot button should appear, replacing count badge and aggregate state indicator
- [ ] Click the 3-dot button — context menu should open with same items as right-click (Mark All as Read, Archive All, Rename/Delete for custom groups)
- [ ] Hover over a subgroup disclosure header (Scheduled subgroups) — 3-dot button should appear, replacing count badge and unread dot
- [ ] Click the subgroup 3-dot button — context menu should open with Mark All as Read and Archive All
- [ ] Verify clicking the 3-dot does NOT toggle section expand/collapse
- [ ] Verify right-click context menu still works unchanged on both group and subgroup headers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25366" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
