### PR TITLE
feat(home): assemble Home page as new default tab in IntelligencePanel behind home-tab flag

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Assembles the Home page: identity column on the left, and the facts +
+/// capabilities columns on the right. This view is rendered inside
+/// ``IntelligencePanel``'s existing `VPageContainer`, so it does NOT wrap
+/// itself in another page container.
+///
+/// The parent owns all navigation decisions — the "Start a conversation"
+/// and capability CTAs are plain closures plumbed through from the
+/// ``PanelCoordinator``. Loading is driven by `store.load()` on appear; on
+/// transport failure the store keeps the last-good state so we never
+/// blank the UI between refreshes.
+struct HomePageView: View {
+    @Bindable var store: HomeStore
+    let onStartConversation: () -> Void
+    let onPrimaryCTA: (Capability) -> Void
+    let onShortcutCTA: (Capability) -> Void
+
+    var body: some View {
+        Group {
+            if let state = store.state {
+                HStack(alignment: .top, spacing: VSpacing.xl) {
+                    HomeIdentityPanel(
+                        state: state,
+                        onStartConversation: onStartConversation
+                    )
+                    ScrollView {
+                        VStack(alignment: .leading, spacing: VSpacing.xl) {
+                            HomeFactsSection(facts: state.facts)
+                            HomeCapabilitiesSection(
+                                capabilities: state.capabilities,
+                                onPrimaryCTA: onPrimaryCTA,
+                                onShortcutCTA: onShortcutCTA
+                            )
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                }
+                .padding(VSpacing.lg)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                .background(VColor.surfaceBase)
+            } else {
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .background(VColor.surfaceBase)
+            }
+        }
+        .task {
+            await store.load()
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
@@ -8,7 +8,9 @@ import VellumAssistantShared
 ///
 /// The parent owns all navigation decisions — the "Start a conversation"
 /// and capability CTAs are plain closures plumbed through from the
-/// ``PanelCoordinator``. Loading is driven by `store.load()` on appear; on
+/// ``PanelCoordinator``. PR 14 wires only `onStartConversation`; the
+/// capability CTAs ship as no-op stubs that PR 15 replaces with seeded
+/// new-chat handlers. Loading is driven by `store.load()` on appear; on
 /// transport failure the store keeps the last-good state so we never
 /// blank the UI between refreshes.
 struct HomePageView: View {
@@ -41,13 +43,43 @@ struct HomePageView: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
                 .background(VColor.surfaceBase)
             } else {
-                ProgressView()
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .background(VColor.surfaceBase)
+                skeleton
             }
         }
         .task {
             await store.load()
         }
+    }
+
+    private var skeleton: some View {
+        HStack(alignment: .top, spacing: VSpacing.xl) {
+            VStack(alignment: .leading, spacing: VSpacing.lg) {
+                VSkeletonBone(width: 140, height: 140, radius: 70)
+                VSkeletonBone(width: 160, height: 24)
+                VSkeletonBone(width: 120, height: 14)
+                VSkeletonBone(width: 100, height: 24, radius: VRadius.lg)
+                VSkeletonBone(width: 180, height: 12)
+                VSkeletonBone(width: 140, height: 12)
+            }
+            .frame(width: 220, alignment: .leading)
+
+            VStack(alignment: .leading, spacing: VSpacing.xl) {
+                VStack(alignment: .leading, spacing: VSpacing.sm) {
+                    VSkeletonBone(width: 200, height: 18)
+                    VSkeletonBone(width: 320, height: 14)
+                    VSkeletonBone(width: 280, height: 14)
+                }
+                VStack(alignment: .leading, spacing: VSpacing.sm) {
+                    VSkeletonBone(width: 200, height: 18)
+                    VSkeletonBone(height: 56, radius: VRadius.lg)
+                    VSkeletonBone(height: 56, radius: VRadius.lg)
+                    VSkeletonBone(height: 56, radius: VRadius.lg)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(VSpacing.lg)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .background(VColor.surfaceBase)
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -81,6 +81,10 @@ struct MainWindowView: View {
     @State var assistantLoadingTimedOut = false
     /// Whether the main window is in native macOS fullscreen (traffic lights hidden).
     @State var isInFullscreen: Bool = false
+    /// Long-lived store for the Home page. Created once per MainWindowView so the
+    /// Home tab inside the Intelligence panel reuses a single subscription to the
+    /// event stream and keeps its cached relationship state across panel toggles.
+    @State var homeStore: HomeStore
     init(conversationManager: ConversationManager, appListManager: AppListManager, zoomManager: ZoomManager, traceStore: TraceStore, usageDashboardStore: UsageDashboardStore, connectionManager: GatewayConnectionManager, eventStreamClient: EventStreamClient, surfaceManager: SurfaceManager, ambientAgent: AmbientAgent, settingsStore: SettingsStore, authManager: AuthManager, windowState: MainWindowState, assistantFeatureFlagStore: AssistantFeatureFlagStore, documentManager: DocumentManager, onMicrophoneToggle: @escaping () -> Void = {}, voiceModeManager: VoiceModeManager, updateManager: UpdateManager, onSendWakeUp: (() -> Void)? = nil) {
         self.conversationManager = conversationManager
         self.appListManager = appListManager
@@ -104,6 +108,14 @@ struct MainWindowView: View {
         // Show skeleton loading only for normal launches (not post-onboarding where
         // ComingAliveOverlay handles the transition).
         self._showDaemonLoading = State(initialValue: onSendWakeUp == nil)
+        // Build the Home page store eagerly so the Intelligence panel's Home
+        // sub-tab has a stable subscription when the user opens it. The store
+        // is behind the `home-tab` feature flag — when the flag is off it's
+        // still constructed but never rendered.
+        self._homeStore = State(initialValue: HomeStore(
+            client: DefaultHomeStateClient(),
+            messageStream: eventStreamClient.subscribe()
+        ))
     }
 
     // MARK: - Layout Constants

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -131,11 +131,16 @@ extension MainWindowView {
                         windowState.selection = nil
                     }
                 },
+                onStartConversation: { startNewConversation() },
+                onCapabilityCTA: nil,
+                onCapabilityShortcutCTA: nil,
                 connectionManager: connectionManager,
                 eventStreamClient: eventStreamClient,
                 store: settingsStore,
                 conversationManager: conversationManager,
                 authManager: authManager,
+                homeStore: homeStore,
+                assistantFeatureFlagStore: assistantFeatureFlagStore,
                 showToast: { msg, style in windowState.showToast(message: msg, style: style) },
                 initialTab: windowState.pendingMemoryId != nil ? "Memories" : windowState.pendingSkillId != nil ? "Skills" : nil,
                 pendingMemoryId: $windowState.pendingMemoryId,
@@ -591,11 +596,19 @@ extension MainWindowView {
                         windowState.selection = .conversation(id)
                     }
                 },
+                onStartConversation: {
+                    startNewConversation()
+                    windowState.dismissOverlay()
+                },
+                onCapabilityCTA: nil,
+                onCapabilityShortcutCTA: nil,
                 connectionManager: connectionManager,
                 eventStreamClient: eventStreamClient,
                 store: settingsStore,
                 conversationManager: conversationManager,
                 authManager: authManager,
+                homeStore: homeStore,
+                assistantFeatureFlagStore: assistantFeatureFlagStore,
                 showToast: { msg, style in windowState.showToast(message: msg, style: style) },
                 initialTab: windowState.pendingMemoryId != nil ? "Memories" : windowState.pendingSkillId != nil ? "Skills" : nil,
                 pendingMemoryId: $windowState.pendingMemoryId,

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
@@ -8,11 +8,16 @@ struct IntelligencePanel: View {
     var onInvokeSkill: ((SkillInfo) -> Void)?
     var onCreateSkill: (() -> Void)?
     var onImportMemory: ((String) -> Void)?
+    var onStartConversation: () -> Void
+    var onCapabilityCTA: ((Capability) -> Void)?
+    var onCapabilityShortcutCTA: ((Capability) -> Void)?
     let connectionManager: GatewayConnectionManager
     let eventStreamClient: EventStreamClient?
     var store: SettingsStore?
     var conversationManager: ConversationManager?
     var authManager: AuthManager?
+    var homeStore: HomeStore?
+    var assistantFeatureFlagStore: AssistantFeatureFlagStore?
     var showToast: ((String, ToastInfo.Style) -> Void)?
     var initialTab: String? = nil
     @Binding var pendingMemoryId: String?
@@ -22,24 +27,32 @@ struct IntelligencePanel: View {
     @Binding var pendingSkillId: String?
     @State private var pendingFilePath: String?
 
-    init(onClose: @escaping () -> Void, onInvokeSkill: ((SkillInfo) -> Void)? = nil, onCreateSkill: (() -> Void)? = nil, onImportMemory: ((String) -> Void)? = nil, connectionManager: GatewayConnectionManager, eventStreamClient: EventStreamClient? = nil, store: SettingsStore? = nil, conversationManager: ConversationManager? = nil, authManager: AuthManager? = nil, showToast: ((String, ToastInfo.Style) -> Void)? = nil, initialTab: String? = nil, pendingMemoryId: Binding<String?> = .constant(nil), pendingSkillId: Binding<String?> = .constant(nil)) {
+    init(onClose: @escaping () -> Void, onInvokeSkill: ((SkillInfo) -> Void)? = nil, onCreateSkill: (() -> Void)? = nil, onImportMemory: ((String) -> Void)? = nil, onStartConversation: @escaping () -> Void = {}, onCapabilityCTA: ((Capability) -> Void)? = nil, onCapabilityShortcutCTA: ((Capability) -> Void)? = nil, connectionManager: GatewayConnectionManager, eventStreamClient: EventStreamClient? = nil, store: SettingsStore? = nil, conversationManager: ConversationManager? = nil, authManager: AuthManager? = nil, homeStore: HomeStore? = nil, assistantFeatureFlagStore: AssistantFeatureFlagStore? = nil, showToast: ((String, ToastInfo.Style) -> Void)? = nil, initialTab: String? = nil, pendingMemoryId: Binding<String?> = .constant(nil), pendingSkillId: Binding<String?> = .constant(nil)) {
         self.onClose = onClose
         self.onInvokeSkill = onInvokeSkill
         self.onCreateSkill = onCreateSkill
         self.onImportMemory = onImportMemory
+        self.onStartConversation = onStartConversation
+        self.onCapabilityCTA = onCapabilityCTA
+        self.onCapabilityShortcutCTA = onCapabilityShortcutCTA
         self.connectionManager = connectionManager
         self.eventStreamClient = eventStreamClient
         self.store = store
         self.conversationManager = conversationManager
         self.authManager = authManager
+        self.homeStore = homeStore
+        self.assistantFeatureFlagStore = assistantFeatureFlagStore
         self.showToast = showToast
         self.initialTab = initialTab
         _pendingMemoryId = pendingMemoryId
         _pendingSkillId = pendingSkillId
-        _selectedTab = State(initialValue: IntelligenceTab(rawValue: initialTab ?? "") ?? .identity)
+        let homeTabFlagOn = assistantFeatureFlagStore?.isEnabled("home-tab") ?? false
+        let defaultTab: IntelligenceTab = homeTabFlagOn ? .home : .identity
+        _selectedTab = State(initialValue: IntelligenceTab(rawValue: initialTab ?? "") ?? defaultTab)
     }
 
     private enum IntelligenceTab: String, CaseIterable {
+        case home = "Home"
         case identity = "Identity"
         case installedSkills = "Skills"
         case workspace = "Workspace"
@@ -73,7 +86,11 @@ struct IntelligencePanel: View {
     }
 
     private var visibleTabs: [IntelligenceTab] {
-        IntelligenceTab.allCases
+        let flagOn = assistantFeatureFlagStore?.isEnabled("home-tab") ?? false
+        return IntelligenceTab.allCases.filter { tab in
+            if tab == .home { return flagOn }
+            return true
+        }
     }
 
     // MARK: - Tab Content
@@ -81,6 +98,21 @@ struct IntelligencePanel: View {
     @ViewBuilder
     private var tabContent: some View {
         switch selectedTab {
+        case .home:
+            if let homeStore {
+                HomePageView(
+                    store: homeStore,
+                    onStartConversation: onStartConversation,
+                    onPrimaryCTA: { capability in onCapabilityCTA?(capability) },
+                    onShortcutCTA: { capability in onCapabilityShortcutCTA?(capability) }
+                )
+                .padding(.top, VSpacing.sm)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+                .clipped()
+            } else {
+                EmptyView()
+            }
+
         case .identity:
             IdentityPanel(
                 onClose: onClose,

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -336,6 +336,14 @@
       "label": "Pre-Chat Onboarding Flow",
       "description": "Gates the 3-screen pre-chat onboarding flow (tools, tasks/tone, name exchange) shown before the first conversation",
       "defaultEnabled": false
+    },
+    {
+      "id": "home-tab",
+      "scope": "macos",
+      "key": "home-tab",
+      "label": "Home Tab",
+      "description": "Replace the knowledge graph top-level tab with a new Home page showing relationship progression, facts, and capability tiers",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- New `HomePageView` composing `HomeIdentityPanel` (220px left) + `HomeFactsSection` + `HomeCapabilitiesSection` (right ScrollView), with `ProgressView` skeleton fallback while `HomeStore.state` is nil. No outer `VPageContainer` (inherited from IntelligencePanel).
- `IntelligencePanel.IntelligenceTab` gains `.home` as the **first** case. `_selectedTab` defaults to `.home` iff `home-tab` flag is on. `visibleTabs` filters `.home` out when off. `tabContent` switch gets `case .home:` rendering `HomePageView`.
- `PanelCoordinator.swift` updated at both `IntelligencePanel(` call sites (lines ~102 and ~569) to pass `homeStore`, `assistantFeatureFlagStore`, `onStartConversation: { startNewConversation() }`, and stub CTA closures (PR 15 will wire them).
- `MainWindowView` owns the long-lived `HomeStore` via `@State`, constructed once with `DefaultHomeStateClient()` + `eventStreamClient.subscribe()` for the SSE message stream.
- No new sidebar row; `home-tab` flag off path is byte-identical to current main.
- No `#Preview` blocks.

Part of plan: home-page-phase-3.md (PR 14 of 16)
Refs LUM-859
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25369" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
