### PR TITLE
M1: Enforce single active root panel in VMenuPanel.show()

### DIFF
--- a/clients/shared/DesignSystem/Components/Navigation/VMenuPanel.swift
+++ b/clients/shared/DesignSystem/Components/Navigation/VMenuPanel.swift
@@ -16,6 +16,11 @@ public class VMenuPanel: NSPanel {
     /// Guard to prevent recursive coordinator notification from `close()`.
     private var isClosingFromCoordinator: Bool = false
 
+    /// The currently active root-level menu panel. Only one root panel should
+    /// be visible at a time, matching native NSMenu behavior. Child panels
+    /// (submenus via showAnchored) are managed by the coordinator, not here.
+    private static weak var activeRootPanel: VMenuPanel?
+
     /// Extra padding added around the VMenu content so its shadow can render
     /// without being clipped by the hosting view's bounds.
     static let shadowInset: CGFloat = 14
@@ -47,6 +52,12 @@ public class VMenuPanel: NSPanel {
         @ViewBuilder content: () -> Content,
         onDismiss: @escaping () -> Void
     ) -> VMenuPanel {
+        // Dismiss any existing root panel before showing a new one.
+        // This matches NSMenu's native behavior: only one menu visible at a time.
+        // Using the coordinator's dismissAll() ensures the entire panel tree
+        // (root + submenus) is closed and the old onDismiss handler fires.
+        activeRootPanel?.coordinator?.dismissAll()
+
         let panel = VMenuPanel(
             contentRect: .zero,
             styleMask: [.borderless, .nonactivatingPanel],
@@ -140,6 +151,8 @@ public class VMenuPanel: NSPanel {
                 NSAccessibility.post(element: hostingView, notification: .focusedUIElementChanged)
             }
         }
+
+        activeRootPanel = panel
 
         return panel
     }
@@ -289,6 +302,10 @@ public class VMenuPanel: NSPanel {
     }
 
     public override func close() {
+        if self === VMenuPanel.activeRootPanel {
+            VMenuPanel.activeRootPanel = nil
+        }
+
         clickMonitor.flatMap(NSEvent.removeMonitor)
         clickMonitor = nil
 


### PR DESCRIPTION
## Summary
- Added static weak `activeRootPanel` to `VMenuPanel` for global root panel tracking
- `show()` now dismisses the active root panel via `coordinator.dismissAll()` before creating a new one
- `close()` clears the static reference when the active root panel is closed
- No changes to call sites — mutual exclusion is enforced at the panel level

This matches native macOS NSMenu behavior where only one menu is visible at a time. The fix is entirely within VMenuPanel.swift — no other files modified.

Closes #25370
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25371" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
