### PR TITLE
Fix duplicate context menu on sidebar conversation items

### DIFF
--- a/clients/shared/DesignSystem/Components/Navigation/VMenuPanel.swift
+++ b/clients/shared/DesignSystem/Components/Navigation/VMenuPanel.swift
@@ -16,6 +16,11 @@ public class VMenuPanel: NSPanel {
     /// Guard to prevent recursive coordinator notification from `close()`.
     private var isClosingFromCoordinator: Bool = false
 
+    /// The currently active root-level menu panel. Only one root panel should
+    /// be visible at a time, matching native NSMenu behavior. Child panels
+    /// (submenus via showAnchored) are managed by the coordinator, not here.
+    private static weak var activeRootPanel: VMenuPanel?
+
     /// Extra padding added around the VMenu content so its shadow can render
     /// without being clipped by the hosting view's bounds.
     static let shadowInset: CGFloat = 14
@@ -47,6 +52,12 @@ public class VMenuPanel: NSPanel {
         @ViewBuilder content: () -> Content,
         onDismiss: @escaping () -> Void
     ) -> VMenuPanel {
+        // Dismiss any existing root panel before showing a new one.
+        // This matches NSMenu's native behavior: only one menu visible at a time.
+        // Using the coordinator's dismissAll() ensures the entire panel tree
+        // (root + submenus) is closed and the old onDismiss handler fires.
+        activeRootPanel?.coordinator?.dismissAll()
+
         let panel = VMenuPanel(
             contentRect: .zero,
             styleMask: [.borderless, .nonactivatingPanel],
@@ -140,6 +151,8 @@ public class VMenuPanel: NSPanel {
                 NSAccessibility.post(element: hostingView, notification: .focusedUIElementChanged)
             }
         }
+
+        activeRootPanel = panel
 
         return panel
     }
@@ -289,6 +302,10 @@ public class VMenuPanel: NSPanel {
     }
 
     public override func close() {
+        if self === VMenuPanel.activeRootPanel {
+            VMenuPanel.activeRootPanel = nil
+        }
+
         clickMonitor.flatMap(NSEvent.removeMonitor)
         clickMonitor = nil
 


### PR DESCRIPTION
## Summary
When right-clicking a sidebar conversation and then clicking the ellipsis button, two identical context menus appeared simultaneously. The root cause was that `VMenuPanel.show()` created independent panel trees with no global coordination — two separate calls could produce two visible panels.

The fix adds a static weak `activeRootPanel` reference to `VMenuPanel` so that `show()` automatically dismisses any existing root panel (via `coordinator.dismissAll()`) before creating a new one. This matches native macOS `NSMenu` behavior where only one menu is ever visible. The fix is entirely within `VMenuPanel.swift` — no call-site changes needed.

## Changes
- **VMenuPanel.swift** (+17 lines): Added `static weak var activeRootPanel`, dismiss guard in `show()`, set after creation, clear in `close()`

## Milestone PRs (merged into feature branch)
- #25371: M1: Enforce single active root panel in VMenuPanel.show()

## Project issue
Closes #25364

## Test plan
- [ ] Right-click a conversation → context menu appears
- [ ] Click ellipsis button → context menu appears
- [ ] Right-click → then click ellipsis → first menu dismissed, only second visible
- [ ] Ellipsis click → then right-click → first menu dismissed, only second visible
- [ ] Click ellipsis while its menu is open → menu dismissed (click-outside via coordinator)
- [ ] Verify submenus still work (hover "Move to" → submenu appears)
- [ ] Verify groups/subgroups context menus still work (right-click only)
- [ ] Verify dropdowns elsewhere in the app still work correctly
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25373" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
