### PR TITLE
feat(home): capability CTAs open new conversations pre-seeded with setup context

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/CapabilityCTAContext.swift
+++ b/clients/macos/vellum-assistant/Features/Home/CapabilityCTAContext.swift
@@ -1,0 +1,36 @@
+import Foundation
+import VellumAssistantShared
+
+/// Which CTA the user tapped on the Home page. Determines the shape of the
+/// seed message we pre-fill into a new conversation so the assistant knows
+/// how to frame the setup flow.
+public enum CapabilityCTAKind {
+    /// Next-up tier — integration-gated. The user tapped the primary CTA
+    /// label (e.g. "Connect Google →") because they want to unlock this
+    /// capability right now.
+    case primary
+
+    /// Earned tier — the capability is already within reach, but the user
+    /// wants to accelerate the path to flip it to unlocked.
+    case shortcut
+}
+
+/// Pure helper that builds the seed message sent as the first user turn
+/// when a Home-page capability CTA opens a new conversation. No SwiftUI,
+/// no state, no side effects — just string assembly — so it can be unit
+/// tested directly.
+public enum CapabilityCTAContext {
+    /// Build the seed message to pre-fill into a new conversation when the
+    /// user taps a capability CTA on the Home page. The message is written
+    /// from the user's voice (third-person "the user") so the assistant
+    /// understands the context without treating it as a direct request.
+    public static func setupSeedMessage(for capability: Capability, kind: CapabilityCTAKind) -> String {
+        switch kind {
+        case .primary:
+            let label = capability.ctaLabel ?? capability.name
+            return "The user tapped '\(label)' from the Home page to set up \(capability.name). Skip preamble and guide them through the setup. Be efficient — they came from a CTA, they want this."
+        case .shortcut:
+            return "The user wants to accelerate unlocking \(capability.name) — the capability is currently earned-tier. Guide them through a conversation designed to gather enough signal to flip it to unlocked. Be honest about the effort involved (not a 1-minute thing)."
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -132,8 +132,24 @@ extension MainWindowView {
                     }
                 },
                 onStartConversation: { startNewConversation() },
-                onCapabilityCTA: nil,
-                onCapabilityShortcutCTA: nil,
+                onCapabilityCTA: { capability in
+                    let seed = CapabilityCTAContext.setupSeedMessage(for: capability, kind: .primary)
+                    conversationManager.openConversation(message: seed, forceNew: true)
+                    if let id = conversationManager.activeConversationId {
+                        windowState.selection = .conversation(id)
+                    } else {
+                        windowState.selection = nil
+                    }
+                },
+                onCapabilityShortcutCTA: { capability in
+                    let seed = CapabilityCTAContext.setupSeedMessage(for: capability, kind: .shortcut)
+                    conversationManager.openConversation(message: seed, forceNew: true)
+                    if let id = conversationManager.activeConversationId {
+                        windowState.selection = .conversation(id)
+                    } else {
+                        windowState.selection = nil
+                    }
+                },
                 connectionManager: connectionManager,
                 eventStreamClient: eventStreamClient,
                 store: settingsStore,
@@ -600,8 +616,22 @@ extension MainWindowView {
                     startNewConversation()
                     windowState.dismissOverlay()
                 },
-                onCapabilityCTA: nil,
-                onCapabilityShortcutCTA: nil,
+                onCapabilityCTA: { capability in
+                    let seed = CapabilityCTAContext.setupSeedMessage(for: capability, kind: .primary)
+                    conversationManager.openConversation(message: seed, forceNew: true)
+                    windowState.dismissOverlay()
+                    if let id = conversationManager.activeConversationId {
+                        windowState.selection = .conversation(id)
+                    }
+                },
+                onCapabilityShortcutCTA: { capability in
+                    let seed = CapabilityCTAContext.setupSeedMessage(for: capability, kind: .shortcut)
+                    conversationManager.openConversation(message: seed, forceNew: true)
+                    windowState.dismissOverlay()
+                    if let id = conversationManager.activeConversationId {
+                        windowState.selection = .conversation(id)
+                    }
+                },
                 connectionManager: connectionManager,
                 eventStreamClient: eventStreamClient,
                 store: settingsStore,

--- a/clients/macos/vellum-assistantTests/CapabilityCTAContextTests.swift
+++ b/clients/macos/vellum-assistantTests/CapabilityCTAContextTests.swift
@@ -1,0 +1,66 @@
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+final class CapabilityCTAContextTests: XCTestCase {
+    private func makeCapability(
+        id: String,
+        name: String,
+        tier: Capability.Tier,
+        ctaLabel: String? = nil,
+        unlockHint: String? = nil
+    ) -> Capability {
+        Capability(
+            id: id,
+            name: name,
+            description: "test description",
+            tier: tier,
+            gate: "test gate",
+            unlockHint: unlockHint,
+            ctaLabel: ctaLabel
+        )
+    }
+
+    func testPrimaryUsesCtaLabelWhenPresent() {
+        let cap = makeCapability(id: "email", name: "Email access", tier: .nextUp, ctaLabel: "Connect Google →")
+        let msg = CapabilityCTAContext.setupSeedMessage(for: cap, kind: .primary)
+        XCTAssertTrue(msg.contains("Connect Google →"))
+        XCTAssertTrue(msg.contains("Email access"))
+        XCTAssertTrue(msg.contains("Skip preamble"))
+    }
+
+    func testPrimaryFallsBackToCapabilityNameWhenNoCtaLabel() {
+        let cap = makeCapability(id: "calendar", name: "Calendar awareness", tier: .nextUp, ctaLabel: nil)
+        let msg = CapabilityCTAContext.setupSeedMessage(for: cap, kind: .primary)
+        XCTAssertTrue(msg.contains("Calendar awareness"))
+        XCTAssertFalse(msg.contains("nil"))
+    }
+
+    func testShortcutMentionsHonestEffort() {
+        let cap = makeCapability(id: "voice-writing", name: "Write in your voice", tier: .earned)
+        let msg = CapabilityCTAContext.setupSeedMessage(for: cap, kind: .shortcut)
+        XCTAssertTrue(msg.contains("Write in your voice"))
+        XCTAssertTrue(msg.contains("not a 1-minute thing") || msg.contains("honest"))
+    }
+
+    func testSeedMessageCoversAllSixCapabilities() {
+        let next: [Capability] = [
+            makeCapability(id: "email",    name: "Email access",       tier: .nextUp, ctaLabel: "Connect Google →"),
+            makeCapability(id: "calendar", name: "Calendar awareness", tier: .nextUp, ctaLabel: "Connect Calendar →"),
+            makeCapability(id: "slack",    name: "Slack monitoring",   tier: .nextUp, ctaLabel: "Set up Slack →"),
+        ]
+        for cap in next {
+            let msg = CapabilityCTAContext.setupSeedMessage(for: cap, kind: .primary)
+            XCTAssertFalse(msg.isEmpty)
+        }
+        let earned: [Capability] = [
+            makeCapability(id: "voice-writing", name: "Write in your voice", tier: .earned),
+            makeCapability(id: "proactive",     name: "Proactive suggestions", tier: .earned),
+            makeCapability(id: "autonomous",    name: "Act on your behalf", tier: .earned),
+        ]
+        for cap in earned {
+            let msg = CapabilityCTAContext.setupSeedMessage(for: cap, kind: .shortcut)
+            XCTAssertFalse(msg.isEmpty)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- New `CapabilityCTAContext.setupSeedMessage(for:kind:)` pure helper producing the two seed messages from the TDD (primary CTA / shortcut CTA), with the capability name and `ctaLabel` interpolated.
- Both `IntelligencePanel(...)` call sites in `PanelCoordinator.swift` now pass real handlers replacing the PR 14 stubs: build the seed message, call `conversationManager.openConversation(message: seed, forceNew: true)`, navigate to the new conversation via `windowState.selection = .conversation(id)`. Second call site mirrors the dismiss-overlay pattern used by `onCreateSkill`.
- `CapabilityCTAContextTests.swift` (4 tests): primary uses ctaLabel, primary falls back to capability name, shortcut mentions honest effort, all 6 default capabilities produce non-empty seed messages.
- No `#Preview` blocks.

Part of plan: home-page-phase-3.md (PR 15 of 16)
Refs LUM-859
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25374" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
