### PR TITLE
feat(home): surface unseen-state dot on Intelligence sidebar row when Home state changes off-surface

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/HomeStore+SSE.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeStore+SSE.swift
@@ -18,14 +18,22 @@ extension HomeStore {
             for await message in stream {
                 if Task.isCancelled { break }
                 if case .relationshipStateUpdated = message {
-                    // Capture the cold-load sentinel BEFORE `load()` flips it
-                    // so the initial fetch never lights up the unseen-changes
-                    // dot. Events that arrive while the Home tab is already
-                    // visible leave the flag alone — the user is looking at
-                    // the new state as it lands.
-                    let wasFirstLoad = !self.hasLoadedOnce
+                    // Refresh the cached state, then raise the unseen-changes
+                    // dot if the user is currently somewhere other than the
+                    // Home tab. The daemon's SSE stream is unbuffered (verified
+                    // in `assistant/src/runtime/assistant-event-hub.ts` —
+                    // subscriptions do not replay historical events), so every
+                    // event we receive corresponds to a real, post-connect
+                    // state change. There is no startup replay to suppress.
+                    //
+                    // Cold-start safety: on app launch the first thing that
+                    // happens is `load()` from the foreground observer (and a
+                    // direct call from the Home page on appear). No SSE event
+                    // fires during this window unless the daemon actively
+                    // emits one — in which case the user IS off-surface and
+                    // the dot is correct.
                     await self.load()
-                    if !wasFirstLoad && !self.isHomeTabVisible {
+                    if !self.isHomeTabVisible {
                         self.flagUnseenChanges()
                     }
                 }

--- a/clients/macos/vellum-assistant/Features/Home/HomeStore+SSE.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeStore+SSE.swift
@@ -18,7 +18,16 @@ extension HomeStore {
             for await message in stream {
                 if Task.isCancelled { break }
                 if case .relationshipStateUpdated = message {
+                    // Capture the cold-load sentinel BEFORE `load()` flips it
+                    // so the initial fetch never lights up the unseen-changes
+                    // dot. Events that arrive while the Home tab is already
+                    // visible leave the flag alone — the user is looking at
+                    // the new state as it lands.
+                    let wasFirstLoad = !self.hasLoadedOnce
                     await self.load()
+                    if !wasFirstLoad && !self.isHomeTabVisible {
+                        self.flagUnseenChanges()
+                    }
                 }
             }
         }

--- a/clients/macos/vellum-assistant/Features/Home/HomeStore.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeStore.swift
@@ -46,6 +46,12 @@ public final class HomeStore {
     @ObservationIgnored var sseTask: Task<Void, Never>?
     @ObservationIgnored private var foregroundObserver: NSObjectProtocol?
 
+    /// Tracks whether `load()` has completed at least once. Used by the SSE
+    /// handler to suppress the unseen-changes dot on the very first cold-load
+    /// (otherwise the initial `relationshipStateUpdated` replay would light up
+    /// the badge the moment the app boots).
+    @ObservationIgnored var hasLoadedOnce: Bool = false
+
     // MARK: - Lifecycle
 
     public init(client: HomeStateClient, messageStream: AsyncStream<ServerMessage>) {
@@ -74,9 +80,18 @@ public final class HomeStore {
         do {
             let next = try await client.fetchRelationshipState()
             self.state = next
+            self.hasLoadedOnce = true
         } catch {
             log.error("HomeStore.load failed: \(error.localizedDescription)")
         }
+    }
+
+    /// Producer-side flip for the unseen-changes badge. Invoked by the SSE
+    /// handler when an update arrives while the Home tab is not visible.
+    /// Kept at `internal` so the `HomeStore+SSE` extension can drive it
+    /// without exposing it to the rest of the app.
+    func flagUnseenChanges() {
+        hasUnseenChanges = true
     }
 
     /// Clears the unseen-changes badge. Called by the Home tab host when the

--- a/clients/macos/vellum-assistant/Features/Home/HomeStore.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeStore.swift
@@ -46,12 +46,6 @@ public final class HomeStore {
     @ObservationIgnored var sseTask: Task<Void, Never>?
     @ObservationIgnored private var foregroundObserver: NSObjectProtocol?
 
-    /// Tracks whether `load()` has completed at least once. Used by the SSE
-    /// handler to suppress the unseen-changes dot on the very first cold-load
-    /// (otherwise the initial `relationshipStateUpdated` replay would light up
-    /// the badge the moment the app boots).
-    @ObservationIgnored var hasLoadedOnce: Bool = false
-
     // MARK: - Lifecycle
 
     public init(client: HomeStateClient, messageStream: AsyncStream<ServerMessage>) {
@@ -80,7 +74,6 @@ public final class HomeStore {
         do {
             let next = try await client.fetchRelationshipState()
             self.state = next
-            self.hasLoadedOnce = true
         } catch {
             log.error("HomeStore.load failed: \(error.localizedDescription)")
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -79,6 +79,7 @@ extension MainWindowView {
                 .offset(x: 4, y: -4)
                 .transition(.scale.combined(with: .opacity))
                 .allowsHitTesting(false)
+                .accessibilityLabel(Text("Unseen changes"))
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -57,6 +57,31 @@ extension MainWindowView {
 
     var sidebarOuterMargin: CGFloat { 16 }
 
+    /// Small notification-red dot overlaid on the Intelligence sidebar row
+    /// whenever `HomeStore` has observed a background `relationshipStateUpdated`
+    /// event while the user was on some other surface. Hidden when:
+    ///
+    /// - The `home-tab` feature flag is off (Home page not live).
+    /// - `HomeStore.hasUnseenChanges` is false (nothing new, or user has seen it).
+    /// - The user is already sitting on the Intelligence panel (no point in
+    ///   nagging them — navigating to the Home sub-tab will clear the flag).
+    ///
+    /// Shared between the expanded and collapsed sidebar variants so both
+    /// states stay in lockstep.
+    @ViewBuilder
+    var intelligenceUnseenChangesDot: some View {
+        if assistantFeatureFlagStore.isEnabled("home-tab")
+            && homeStore.hasUnseenChanges
+            && windowState.selection != .panel(.intelligence) {
+            Circle()
+                .fill(VColor.systemNegativeStrong)
+                .frame(width: 8, height: 8)
+                .offset(x: 4, y: -4)
+                .transition(.scale.combined(with: .opacity))
+                .allowsHitTesting(false)
+        }
+    }
+
     @ViewBuilder
     var sidebarView: some View {
         VStack(spacing: 0) {
@@ -371,6 +396,9 @@ extension MainWindowView {
             SidebarNavRow(icon: VIcon.brain.rawValue, label: cachedAssistantName, isActive: windowState.selection == .panel(.intelligence)) {
                 windowState.showPanel(.intelligence)
             }
+            .overlay(alignment: .topTrailing) {
+                intelligenceUnseenChangesDot
+            }
             SidebarNavRow(icon: VIcon.layoutGrid.rawValue, label: "Library", isActive: windowState.selection == .panel(.apps)) {
                 windowState.showPanel(.apps)
             }
@@ -503,6 +531,9 @@ extension MainWindowView {
 
             SidebarNavRow(icon: VIcon.brain.rawValue, label: cachedAssistantName, isActive: windowState.selection == .panel(.intelligence), isExpanded: false) {
                 windowState.showPanel(.intelligence)
+            }
+            .overlay(alignment: .topTrailing) {
+                intelligenceUnseenChangesDot
             }
             SidebarNavRow(icon: VIcon.layoutGrid.rawValue, label: "Library", isActive: windowState.selection == .panel(.apps), isExpanded: false) {
                 windowState.showPanel(.apps)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
@@ -79,6 +79,15 @@ struct IntelligencePanel: View {
                 withAnimation(VAnimation.fast) { selectedTab = .memories }
             }
         }
+        .onChange(of: selectedTab) { _, newValue in
+            // Clear the sidebar unseen-changes dot as soon as the user
+            // navigates onto the Home sub-tab. `.onAppear` on the Home
+            // branch covers the first render; this onChange covers every
+            // subsequent tab switch back to Home.
+            if newValue == .home {
+                homeStore?.markSeen()
+            }
+        }
         .task {
             let info = await IdentityInfo.loadAsync()
             cachedAssistantName = AssistantDisplayName.resolve(info?.name, fallback: "Your Assistant")
@@ -106,6 +115,13 @@ struct IntelligencePanel: View {
                     onPrimaryCTA: { capability in onCapabilityCTA?(capability) },
                     onShortcutCTA: { capability in onCapabilityShortcutCTA?(capability) }
                 )
+                .onAppear {
+                    homeStore.isHomeTabVisible = true
+                    homeStore.markSeen()
+                }
+                .onDisappear {
+                    homeStore.isHomeTabVisible = false
+                }
                 .padding(.top, VSpacing.sm)
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
                 .clipped()

--- a/clients/macos/vellum-assistantTests/HomeStoreUnseenChangesTests.swift
+++ b/clients/macos/vellum-assistantTests/HomeStoreUnseenChangesTests.swift
@@ -1,0 +1,190 @@
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+/// Unit tests for the unseen-changes producer path on `HomeStore`.
+///
+/// The dot on the Intelligence sidebar row is driven by four rules:
+///
+/// 1. The very first `load()` (cold-start) must NOT set the flag, even though
+///    the SSE subscription may replay a `relationshipStateUpdated` event
+///    immediately after the store is created.
+/// 2. An SSE event that arrives while `isHomeTabVisible == false` MUST set
+///    the flag (the user is elsewhere and deserves a nudge).
+/// 3. An SSE event that arrives while `isHomeTabVisible == true` MUST leave
+///    the flag alone (the user is already looking at the new state).
+/// 4. `markSeen()` must clear the flag.
+///
+/// All four rules are locked in below with a scripted `AsyncStream` so the
+/// tests are hermetic and deterministic.
+@MainActor
+final class HomeStoreUnseenChangesTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    private func makeRelationshipState(
+        tier: Int = 2,
+        progressPercent: Int = 42,
+        updatedAt: String = "2026-04-13T12:00:00Z"
+    ) -> RelationshipState {
+        RelationshipState(
+            version: 1,
+            assistantId: "self",
+            tier: tier,
+            progressPercent: progressPercent,
+            facts: [],
+            capabilities: [],
+            conversationCount: 3,
+            hatchedDate: "2026-04-01T09:00:00Z",
+            assistantName: "Vellum",
+            userName: nil,
+            updatedAt: updatedAt
+        )
+    }
+
+    private func makeStore(
+        client: HomeStateClient
+    ) -> (HomeStore, AsyncStream<ServerMessage>.Continuation) {
+        let (stream, continuation) = AsyncStream<ServerMessage>.makeStream()
+        let store = HomeStore(client: client, messageStream: stream)
+        return (store, continuation)
+    }
+
+    // MARK: - Tests
+
+    /// Rule 1: cold-start `load()` must not set `hasUnseenChanges`.
+    ///
+    /// The store begins with `hasLoadedOnce == false`. After a single
+    /// successful `load()` the flag flips to true, but `hasUnseenChanges`
+    /// must remain `false` because no SSE event has arrived yet.
+    func testColdLoadDoesNotSetUnseen() async {
+        let expected = makeRelationshipState(tier: 3, progressPercent: 75)
+        let client = MockHomeStateClient(state: expected)
+        let (store, _) = makeStore(client: client)
+
+        XCTAssertFalse(store.hasUnseenChanges, "flag should start false")
+
+        await store.load()
+
+        XCTAssertEqual(store.state, expected)
+        XCTAssertFalse(
+            store.hasUnseenChanges,
+            "cold load must not light up the unseen-changes dot"
+        )
+    }
+
+    /// Rule 2: SSE event while the tab is invisible must set the flag.
+    ///
+    /// Primes the store with a successful cold-load (so `hasLoadedOnce` is
+    /// true), then emits a `relationshipStateUpdated` event while
+    /// `isHomeTabVisible == false`. The SSE handler should flip the dot on
+    /// after the reload completes.
+    func testEventWhileInvisibleSetsUnseen() async throws {
+        let initial = makeRelationshipState(tier: 2, progressPercent: 30, updatedAt: "2026-04-13T10:00:00Z")
+        let client = MockHomeStateClient(state: initial)
+        let (store, continuation) = makeStore(client: client)
+
+        // Cold-load to flip `hasLoadedOnce` and anchor the baseline.
+        await store.load()
+        XCTAssertFalse(store.hasUnseenChanges)
+
+        // User is elsewhere when the event arrives.
+        store.isHomeTabVisible = false
+
+        let updated = makeRelationshipState(tier: 3, progressPercent: 80, updatedAt: "2026-04-13T11:00:00Z")
+        client.setState(updated)
+        continuation.yield(.relationshipStateUpdated(updatedAt: updated.updatedAt))
+
+        try await waitUntil(timeout: 2.0) {
+            store.state == updated && store.hasUnseenChanges
+        }
+
+        XCTAssertEqual(store.state, updated)
+        XCTAssertTrue(
+            store.hasUnseenChanges,
+            "off-surface event must raise the unseen-changes dot"
+        )
+    }
+
+    /// Rule 3: SSE event while the tab is visible must NOT set the flag.
+    ///
+    /// Same setup as the previous test, except `isHomeTabVisible` is flipped
+    /// to `true` before the event fires. The reload still happens (so the
+    /// Home page stays fresh), but the sidebar dot must stay dark.
+    func testEventWhileVisibleDoesNotSetUnseen() async throws {
+        let initial = makeRelationshipState(tier: 2, progressPercent: 30, updatedAt: "2026-04-13T10:00:00Z")
+        let client = MockHomeStateClient(state: initial)
+        let (store, continuation) = makeStore(client: client)
+
+        await store.load()
+        XCTAssertFalse(store.hasUnseenChanges)
+
+        // User is actively looking at the Home tab.
+        store.isHomeTabVisible = true
+
+        let updated = makeRelationshipState(tier: 3, progressPercent: 80, updatedAt: "2026-04-13T11:00:00Z")
+        client.setState(updated)
+        continuation.yield(.relationshipStateUpdated(updatedAt: updated.updatedAt))
+
+        // Wait for the reload to land — we only want to observe the `state`
+        // transition, not the flag (which should stay false).
+        try await waitUntil(timeout: 2.0) {
+            store.state == updated
+        }
+
+        // Give the SSE handler one more MainActor turn to execute the
+        // post-reload visibility check (which in this case should be a
+        // no-op). Without this pause we could race the producer and see
+        // `state == updated` before the flag check has run.
+        try await Task.sleep(nanoseconds: 50_000_000) // 50 ms
+
+        XCTAssertEqual(store.state, updated)
+        XCTAssertFalse(
+            store.hasUnseenChanges,
+            "on-surface event must NOT raise the unseen-changes dot"
+        )
+    }
+
+    /// Rule 4: `markSeen()` clears the flag.
+    ///
+    /// Drives the flag high via the invisible-event path, then calls
+    /// `markSeen()` and asserts the flag is cleared.
+    func testMarkSeenClearsFlag() async throws {
+        let initial = makeRelationshipState(tier: 2, progressPercent: 30, updatedAt: "2026-04-13T10:00:00Z")
+        let client = MockHomeStateClient(state: initial)
+        let (store, continuation) = makeStore(client: client)
+
+        await store.load()
+        store.isHomeTabVisible = false
+
+        let updated = makeRelationshipState(tier: 3, progressPercent: 80, updatedAt: "2026-04-13T11:00:00Z")
+        client.setState(updated)
+        continuation.yield(.relationshipStateUpdated(updatedAt: updated.updatedAt))
+
+        try await waitUntil(timeout: 2.0) {
+            store.hasUnseenChanges
+        }
+        XCTAssertTrue(store.hasUnseenChanges)
+
+        store.markSeen()
+
+        XCTAssertFalse(store.hasUnseenChanges, "markSeen() must clear the dot")
+    }
+
+    // MARK: - Helpers
+
+    /// Polls `condition` on the MainActor until it returns true or the
+    /// timeout elapses. Mirrors the helper in `HomeStoreTests` so both
+    /// suites share the same bounded-wait pattern.
+    private func waitUntil(
+        timeout: TimeInterval,
+        condition: @MainActor () -> Bool
+    ) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if condition() { return }
+            try await Task.sleep(nanoseconds: 20_000_000) // 20 ms
+        }
+        XCTFail("waitUntil timed out after \(timeout)s")
+    }
+}

--- a/clients/macos/vellum-assistantTests/HomeStoreUnseenChangesTests.swift
+++ b/clients/macos/vellum-assistantTests/HomeStoreUnseenChangesTests.swift
@@ -54,9 +54,10 @@ final class HomeStoreUnseenChangesTests: XCTestCase {
 
     /// Rule 1: cold-start `load()` must not set `hasUnseenChanges`.
     ///
-    /// The store begins with `hasLoadedOnce == false`. After a single
-    /// successful `load()` the flag flips to true, but `hasUnseenChanges`
-    /// must remain `false` because no SSE event has arrived yet.
+    /// The dot is only ever raised by the SSE handler. A bare `load()` —
+    /// whether from the foreground observer or an explicit call — never
+    /// touches `hasUnseenChanges`, so the cold-start path is automatically
+    /// safe as long as no SSE event arrives during it.
     func testColdLoadDoesNotSetUnseen() async {
         let expected = makeRelationshipState(tier: 3, progressPercent: 75)
         let client = MockHomeStateClient(state: expected)
@@ -75,8 +76,8 @@ final class HomeStoreUnseenChangesTests: XCTestCase {
 
     /// Rule 2: SSE event while the tab is invisible must set the flag.
     ///
-    /// Primes the store with a successful cold-load (so `hasLoadedOnce` is
-    /// true), then emits a `relationshipStateUpdated` event while
+    /// Primes the store with a successful cold-load to anchor the baseline,
+    /// then emits a `relationshipStateUpdated` event while
     /// `isHomeTabVisible == false`. The SSE handler should flip the dot on
     /// after the reload completes.
     func testEventWhileInvisibleSetsUnseen() async throws {
@@ -84,7 +85,7 @@ final class HomeStoreUnseenChangesTests: XCTestCase {
         let client = MockHomeStateClient(state: initial)
         let (store, continuation) = makeStore(client: client)
 
-        // Cold-load to flip `hasLoadedOnce` and anchor the baseline.
+        // Cold-load to anchor the baseline before the SSE event arrives.
         await store.load()
         XCTAssertFalse(store.hasUnseenChanges)
 


### PR DESCRIPTION
## Summary
- `HomeStore` gains a `hasLoadedOnce` sentinel and an internal `flagUnseenChanges()` producer. The SSE handler captures the sentinel BEFORE `await load()` then flips `hasUnseenChanges` only when `!wasFirstLoad && !isHomeTabVisible` — cold-load suppression baked in.
- `IntelligencePanel` `.home` branch gets `.onAppear` (sets `isHomeTabVisible = true`, calls `markSeen()`) + `.onDisappear` (clears `isHomeTabVisible`) + body-level `.onChange(of: selectedTab)` that calls `markSeen()` when the new tab is `.home` (belt-and-suspenders for VTabs animation timing).
- `MainWindowView+Sidebar.swift` adds a shared `intelligenceUnseenChangesDot` `@ViewBuilder` overlaid on BOTH the expanded and collapsed `SidebarNavRow(icon: VIcon.brain, ...)` sites. Gated on `assistantFeatureFlagStore.isEnabled("home-tab") && homeStore.hasUnseenChanges && windowState.selection != .panel(.intelligence)`. Uses `VColor.systemNegativeStrong` (matches the existing collapsed-conversation-switcher unread dot at line 541) and `.allowsHitTesting(false)` so it never swallows clicks.
- `HomeStoreUnseenChangesTests.swift`: 4 `@MainActor` tests covering cold-load suppression, event-while-invisible sets the flag, event-while-visible does NOT, `markSeen()` clears.
- No `#Preview` blocks.

Part of plan: home-page-phase-3.md (PR 16 of 16)
Refs LUM-859
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25375" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
