### PR TITLE
fix(macos): allow editing sound pool when event toggle is off

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsSoundsTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsSoundsTab.swift
@@ -109,7 +109,6 @@ struct SettingsSoundsTab: View {
             }
 
             soundPoolEditor(for: event, eventConfig: eventConfig, sounds: sounds)
-                .disabled(!eventConfig.enabled)
         }
         .padding(.vertical, VSpacing.xs)
     }


### PR DESCRIPTION
## Summary
- Remove `.disabled(!eventConfig.enabled)` from the per-event sound pool editor in `SettingsSoundsTab` so users can add/remove/preview sounds while the event itself is toggled off
- Playback already gates on `eventConfig.enabled` in `SoundManager.play()` (line 183), so a disabled event still stays silent regardless of pool contents
- The global "Enable sound effects" gate and the inner "All sounds added" disabled dropdown are unchanged

## Original prompt
it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25385" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
