### PR TITLE
fix(anthropic): signal orphaned web_search as error, not empty results

### DIFF
--- a/assistant/src/__tests__/anthropic-provider.test.ts
+++ b/assistant/src/__tests__/anthropic-provider.test.ts
@@ -724,7 +724,8 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
   test("orphaned server_tool_use gets synthetic web_search_tool_result injected", async () => {
     // When stream is interrupted, server_tool_use may be stored without its
     // paired web_search_tool_result. repairOrphanedServerToolUse should inject
-    // a synthetic empty-content web_search_tool_result after the orphan.
+    // a synthetic error web_search_tool_result after the orphan so the model
+    // knows the search failed (rather than silently returning zero results).
     const messages: Message[] = [
       userMsg("Search for something"),
       {
@@ -757,7 +758,10 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
     expect(sent[1].content[0].type).toBe("server_tool_use");
     expect(sent[1].content[1].type).toBe("web_search_tool_result");
     expect(sent[1].content[1].tool_use_id).toBe("srvtoolu_abc123");
-    expect(sent[1].content[1].content).toEqual([]);
+    expect(sent[1].content[1].content).toEqual({
+      type: "web_search_tool_result_error",
+      error_code: "unavailable",
+    });
     expect(sent[2].role).toBe("user");
     expect(sent[2].content[0].type).toBe("text");
   });
@@ -1037,7 +1041,10 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
         b.tool_use_id === "srvtoolu_interrupted",
     );
     expect(syntheticResults).toHaveLength(1);
-    expect(syntheticResults[0].content).toEqual([]);
+    expect(syntheticResults[0].content).toEqual({
+      type: "web_search_tool_result_error",
+      error_code: "unavailable",
+    });
   });
 
   test("paired server_tool_use is not modified by repair", async () => {

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -392,7 +392,10 @@ function repairOrphanedServerToolUse(
         repairedContent.push({
           type: "web_search_tool_result",
           tool_use_id: block.id,
-          content: [],
+          content: {
+            type: "web_search_tool_result_error",
+            error_code: "unavailable",
+          },
         } as unknown as Anthropic.ContentBlockParam);
       }
     }


### PR DESCRIPTION
## Summary
- When Anthropic returns unresolved `server_tool_use` (web_search) blocks — typically when the model batches a client-side `tool_use` in the same response — `repairOrphanedServerToolUse` injected `content: []`, which the model reads as *"search returned zero results"* and silently falls back to memory.
- Changed the synthetic repair block to a `web_search_tool_result_error` with `error_code: "unavailable"`, an already-supported Anthropic content type. The model now gets an explicit failure signal and can retry or tell the user the search flaked.
- Updated two existing repair tests to assert the new error shape.

## Original prompt
it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25386" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
