### PR TITLE
fix: retry platform proxy requests on 429/5xx

### DIFF
--- a/assistant/src/oauth/platform-connection.test.ts
+++ b/assistant/src/oauth/platform-connection.test.ts
@@ -1,5 +1,15 @@
 import { describe, expect, mock, test } from "bun:test";
 
+// Stub out sleep so retry tests don't wait for real delays.
+mock.module("../util/retry.js", () => {
+  const actual =
+    require("../util/retry.js") as typeof import("../util/retry.js");
+  return {
+    ...actual,
+    sleep: () => Promise.resolve(),
+  };
+});
+
 import type { VellumPlatformClient } from "../platform/client.js";
 import { BackendError, VellumError } from "../util/errors.js";
 import {
@@ -224,6 +234,96 @@ describe("PlatformOAuthConnection", () => {
     await expect(conn.withToken(async (token) => token)).rejects.toThrow(
       "Raw token access is not supported for platform-managed connections. Use connection.request() instead.",
     );
+  });
+
+  test("retries on 429 and succeeds", async () => {
+    let callCount = 0;
+    const client = makeMockClient(
+      mock(async () => {
+        callCount++;
+        if (callCount <= 2) {
+          return new Response("", { status: 429 });
+        }
+        return new Response(
+          JSON.stringify({ status: 200, headers: {}, body: { ok: true } }),
+          { status: 200 },
+        );
+      }) as unknown as typeof globalThis.fetch,
+    );
+
+    const conn = new PlatformOAuthConnection({ ...DEFAULT_OPTIONS, client });
+    const result = await conn.request({ method: "GET", path: "/test" });
+
+    expect(result.status).toBe(200);
+    expect(result.body).toEqual({ ok: true });
+    expect(callCount).toBe(3);
+  });
+
+  test("throws after exhausting retries on 429", async () => {
+    const client = makeMockClient(
+      mock(
+        async () => new Response("", { status: 429 }),
+      ) as unknown as typeof globalThis.fetch,
+    );
+
+    const conn = new PlatformOAuthConnection({ ...DEFAULT_OPTIONS, client });
+    await expect(
+      conn.request({ method: "GET", path: "/test" }),
+    ).rejects.toThrow("Platform proxy returned unexpected status 429");
+  });
+
+  test("retries on 500 and succeeds", async () => {
+    let callCount = 0;
+    const client = makeMockClient(
+      mock(async () => {
+        callCount++;
+        if (callCount === 1) {
+          return new Response("", { status: 500 });
+        }
+        return new Response(
+          JSON.stringify({ status: 200, headers: {}, body: null }),
+          { status: 200 },
+        );
+      }) as unknown as typeof globalThis.fetch,
+    );
+
+    const conn = new PlatformOAuthConnection({ ...DEFAULT_OPTIONS, client });
+    const result = await conn.request({ method: "GET", path: "/test" });
+
+    expect(result.status).toBe(200);
+    expect(callCount).toBe(2);
+  });
+
+  test("does not retry on 424", async () => {
+    let callCount = 0;
+    const client = makeMockClient(
+      mock(async () => {
+        callCount++;
+        return new Response("", { status: 424 });
+      }) as unknown as typeof globalThis.fetch,
+    );
+
+    const conn = new PlatformOAuthConnection({ ...DEFAULT_OPTIONS, client });
+    await expect(
+      conn.request({ method: "GET", path: "/test" }),
+    ).rejects.toThrow(CredentialRequiredError);
+    expect(callCount).toBe(1);
+  });
+
+  test("does not retry on 403", async () => {
+    let callCount = 0;
+    const client = makeMockClient(
+      mock(async () => {
+        callCount++;
+        return new Response("", { status: 403 });
+      }) as unknown as typeof globalThis.fetch,
+    );
+
+    const conn = new PlatformOAuthConnection({ ...DEFAULT_OPTIONS, client });
+    await expect(
+      conn.request({ method: "GET", path: "/test" }),
+    ).rejects.toThrow("Platform proxy returned unexpected status 403");
+    expect(callCount).toBe(1);
   });
 
   test("uses connectionId in proxy URL regardless of provider format", async () => {

--- a/assistant/src/oauth/platform-connection.ts
+++ b/assistant/src/oauth/platform-connection.ts
@@ -1,10 +1,17 @@
 import type { VellumPlatformClient } from "../platform/client.js";
 import { BackendError } from "../util/errors.js";
+import {
+  getHttpRetryDelay,
+  isRetryableStatus,
+  sleep,
+} from "../util/retry.js";
 import type {
   OAuthConnection,
   OAuthConnectionRequest,
   OAuthConnectionResponse,
 } from "./connection.js";
+
+const MAX_RETRIES = 3;
 
 export class CredentialRequiredError extends BackendError {
   constructor(message = "Connection not set up on platform") {
@@ -76,39 +83,52 @@ export class PlatformOAuthConnection implements OAuthConnection {
       },
     };
 
-    const response = await this.client.fetch(proxyPath, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(body),
-    });
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      const response = await this.client.fetch(proxyPath, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(body),
+      });
 
-    if (response.status === 424) {
-      throw new CredentialRequiredError();
+      if (response.status === 424) {
+        throw new CredentialRequiredError();
+      }
+
+      if (response.status === 502) {
+        throw new ProviderUnreachableError();
+      }
+
+      if (
+        !response.ok &&
+        isRetryableStatus(response.status) &&
+        attempt < MAX_RETRIES
+      ) {
+        await sleep(getHttpRetryDelay(response, attempt));
+        continue;
+      }
+
+      if (!response.ok) {
+        throw new BackendError(
+          `Platform proxy returned unexpected status ${response.status}`,
+        );
+      }
+
+      const json = (await response.json()) as {
+        status: number;
+        headers: Record<string, string>;
+        body: unknown;
+      };
+
+      return {
+        status: json.status,
+        headers: json.headers,
+        body: json.body,
+      };
     }
 
-    if (response.status === 502) {
-      throw new ProviderUnreachableError();
-    }
-
-    if (!response.ok) {
-      throw new BackendError(
-        `Platform proxy returned unexpected status ${response.status}`,
-      );
-    }
-
-    const json = (await response.json()) as {
-      status: number;
-      headers: Record<string, string>;
-      body: unknown;
-    };
-
-    return {
-      status: json.status,
-      headers: json.headers,
-      body: json.body,
-    };
+    throw new BackendError("Platform proxy request failed after retries");
   }
 
   async withToken<T>(_fn: (token: string) => Promise<T>): Promise<T> {


### PR DESCRIPTION
## Summary
- `PlatformOAuthConnection` was throwing a non-retryable `BackendError` on 429/5xx from the platform proxy infrastructure, causing all OAuth-proxied API calls (Gmail, Calendar, etc.) to fail immediately on transient rate limits
- Added retry loop (up to 3 attempts) with exponential backoff + jitter, reusing existing `getHttpRetryDelay`/`isRetryableStatus` utilities
- Non-retryable statuses (424 credential errors, 502 provider unreachable, other 4xx) still fail immediately

## Test plan
- [x] Added test: retries on 429 and succeeds after transient failures
- [x] Added test: throws after exhausting all retries on persistent 429
- [x] Added test: retries on 500 and succeeds
- [x] Added test: does not retry on 424 (credential error)
- [x] Added test: does not retry on 403 (non-retryable client error)
- [x] All 15 tests in `platform-connection.test.ts` pass
- [x] Full project type-check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25387" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
