### PR TITLE
fix(sounds): play task_complete once per turn, not per tool call

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationActivityStore.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationActivityStore.swift
@@ -51,6 +51,12 @@ final class ConversationActivityStore {
     /// only fire on discrete transitions, not on every streaming delta.
     @ObservationIgnored private var previousInteractionStates: [UUID: ConversationInteractionState] = [:]
 
+    /// Last observed `turnCompletionTick` per conversation. The `task_complete`
+    /// sound fires on increments, which correspond to the daemon's
+    /// `message_complete` event — not to derived idle-state transitions that
+    /// also fire between tool calls within a single turn.
+    @ObservationIgnored private var previousTurnCompletionTicks: [UUID: UInt64] = [:]
+
     /// Whether the initial interaction state has been observed for each
     /// conversation. Prevents sounds from firing on initial subscription
     /// (e.g., a conversation that loads in an error state).
@@ -116,6 +122,7 @@ final class ConversationActivityStore {
         interactionGenerations[conversationId] = generation
         hasInitialInteractionState[conversationId] = false
         previousInteractionStates.removeValue(forKey: conversationId)
+        previousTurnCompletionTicks.removeValue(forKey: conversationId)
         observeInteractionStateLoop(
             conversationId: conversationId,
             messageManager: messageManager,
@@ -198,6 +205,7 @@ final class ConversationActivityStore {
         busyConversationIds.remove(conversationId)
         conversationInteractionStates.removeValue(forKey: conversationId)
         previousInteractionStates.removeValue(forKey: conversationId)
+        previousTurnCompletionTicks.removeValue(forKey: conversationId)
         hasInitialInteractionState.removeValue(forKey: conversationId)
         latestAssistantActivitySnapshots.removeValue(forKey: conversationId)
     }
@@ -247,10 +255,12 @@ final class ConversationActivityStore {
         guard interactionGenerations[conversationId] == generation else { return }
 
         var state = ConversationInteractionState.idle
+        var turnCompletionTick: UInt64 = 0
         withObservationTracking {
             let hasError = errorManager.errorText != nil || errorManager.conversationError != nil
             let hasPendingConfirmation = messageManager.hasPendingConfirmation
             let isBusy = messageManager.isSending || messageManager.isThinking || messageManager.pendingQueuedCount > 0
+            turnCompletionTick = messageManager.turnCompletionTick
 
             if hasError {
                 state = .error
@@ -272,31 +282,41 @@ final class ConversationActivityStore {
         }
 
         let previous = previousInteractionStates[conversationId]
+        let previousTick = previousTurnCompletionTicks[conversationId]
         let isInitial = hasInitialInteractionState[conversationId] != true
         hasInitialInteractionState[conversationId] = true
+        previousTurnCompletionTicks[conversationId] = turnCompletionTick
 
-        // Only update stored state if it actually changed (equivalent to .removeDuplicates()).
-        guard state != previous || isInitial else { return }
-        previousInteractionStates[conversationId] = state
-
-        if state == .idle {
-            conversationInteractionStates.removeValue(forKey: conversationId)
-        } else {
-            conversationInteractionStates[conversationId] = state
+        let stateChanged = state != previous || isInitial
+        if stateChanged {
+            previousInteractionStates[conversationId] = state
+            if state == .idle {
+                conversationInteractionStates.removeValue(forKey: conversationId)
+            } else {
+                conversationInteractionStates[conversationId] = state
+            }
         }
 
-        // Play sounds on discrete state transitions. Skip the initial observation
-        // to avoid sounds firing when a conversation loads in an error state.
+        // Skip the initial observation to avoid sounds firing when a
+        // conversation loads in an error state or carries a stale tick.
         guard !isInitial else { return }
-        switch state {
-        case .idle where previous == .processing:
+
+        // `task_complete` is driven by the daemon's `message_complete` signal
+        // (surfaced as `turnCompletionTick`) rather than by the derived
+        // processing → idle transition — that transition also fires between
+        // tool calls within a single turn, which produced duplicate sounds.
+        if let previousTick, turnCompletionTick > previousTick {
             SoundManager.shared.play(.taskComplete)
-        case .waitingForInput:
-            SoundManager.shared.play(.needsInput)
-        case .error:
-            SoundManager.shared.play(.taskFailed)
-        default:
-            break
+        }
+        if stateChanged {
+            switch state {
+            case .waitingForInput:
+                SoundManager.shared.play(.needsInput)
+            case .error:
+                SoundManager.shared.play(.taskFailed)
+            default:
+                break
+            }
         }
     }
 

--- a/clients/shared/Features/Chat/ChatActionHandler.swift
+++ b/clients/shared/Features/Chat/ChatActionHandler.swift
@@ -382,6 +382,9 @@ final class ChatActionHandler {
         if complete.messageId == nil && (vm.currentAssistantMessageId != nil || vm.isThinking) {
             return
         }
+        // Capture before dispatchPendingSendDirect clears the flag so we can
+        // tell a real turn end from a cancel-acknowledgement completion.
+        let wasCancelAck = vm.pendingSendDirectText != nil
         // Flush any buffered streaming text before finalizing the message.
         vm.flushStreamingBuffer()
         vm.flushPartialOutputBuffer()
@@ -562,6 +565,12 @@ final class ChatActionHandler {
             } else {
                 callback("Response complete")
             }
+        }
+        // Signal turn completion to observers (e.g. the `task_complete` sound).
+        // Cancel-acknowledgements are user-initiated aborts, not real turn ends,
+        // so they stay silent.
+        if !wasCancelAck {
+            vm.messageManager.turnCompletionTick &+= 1
         }
     }
 

--- a/clients/shared/Features/Chat/ChatMessageManager.swift
+++ b/clients/shared/Features/Chat/ChatMessageManager.swift
@@ -209,6 +209,12 @@ public final class ChatMessageManager {
     public var contextWindowTokens: Int? = nil
     public var contextWindowMaxTokens: Int? = nil
     public var pendingQueuedCount: Int = 0
+    /// Monotonic counter incremented once per successful main-turn completion
+    /// (daemon `message_complete` event that isn't an auxiliary or cancel-ack).
+    /// Observers watch this to fire end-of-turn side effects (e.g. the
+    /// `task_complete` sound) without re-deriving state from transient flags
+    /// that also flip between tool calls.
+    public var turnCompletionTick: UInt64 = 0
     public var suggestion: String?
     public var isRecording: Bool = false
     public var recordingAmplitude: Float = 0


### PR DESCRIPTION
## Summary

- Drove the `task_complete` sound off the daemon's `message_complete` signal via a new `turnCompletionTick` counter on `ChatMessageManager`, instead of the derived `.processing → .idle` state transition, which also fires between tool calls.
- Kept `task_failed` on entry to `.error` state (works correctly today) and `needs_input` on entry to `.waitingForInput`.
- Cancel-acknowledgement completions (user hit stop and sent a new message) and user-initiated cancels are silent — no `message_complete` is emitted for the aborted turn.

Net behavior: multi-tool turns get exactly one `task_complete` at the real end; terminal failures get one `task_failed`; queued messages get one `task_complete` per dequeued turn.