### PR TITLE
fix(ios): gate ConversationChatView export menu with hasExportableContent

### DIFF
--- a/clients/ios/Views/ConversationListView.swift
+++ b/clients/ios/Views/ConversationListView.swift
@@ -897,9 +897,7 @@ struct ConversationChatView: View {
 
     @ViewBuilder
     private var exportMenu: some View {
-        let hasTextMessages = viewModel.messages.contains {
-            !$0.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-        }
+        let hasTextMessages = ChatTranscriptFormatter.hasExportableContent(messages: viewModel.messages)
 
         Menu {
             Button {


### PR DESCRIPTION
Follow-up to #25348. Applies ChatTranscriptFormatter.hasExportableContent to the duplicate exportMenu in ConversationListView so it stays in lockstep with the actual export filter. Addresses Devin review on #25348.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25390" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
