### PR TITLE
fix: restore compilation error fallback in resolveEffectiveAppHtml

### DIFF
--- a/assistant/src/memory/app-store.ts
+++ b/assistant/src/memory/app-store.ts
@@ -78,7 +78,7 @@ export function resolveEffectiveAppHtml(app: AppDefinition): string {
   if (existsSync(distIndex)) {
     return inlineDistAssets(appDir, readFileSync(distIndex, "utf-8"));
   }
-  return app.htmlDefinition;
+  return `<p>App compilation failed. Edit a source file to trigger a rebuild.</p>`;
 }
 
 /**

--- a/assistant/src/runtime/routes/app-management-routes.ts
+++ b/assistant/src/runtime/routes/app-management-routes.ts
@@ -40,11 +40,11 @@ import {
   getApp,
   getAppDirPath,
   getAppPreview,
-  inlineDistAssets,
   isMultifileApp,
   listApps,
   queryAppRecords,
   resolveAppDir,
+  resolveEffectiveAppHtml,
   updateApp,
   updateAppRecord,
 } from "../../memory/app-store.js";
@@ -738,8 +738,6 @@ export function appManagementRouteDefinitions(): RouteDefinition[] {
             return httpError("NOT_FOUND", `App not found: ${appId}`, 404);
           }
 
-          let html = app.htmlDefinition;
-
           if (isMultifileApp(app)) {
             const appDir = getAppDirPath(appId);
             const distIndex = join(appDir, "dist", "index.html");
@@ -752,12 +750,8 @@ export function appManagementRouteDefinitions(): RouteDefinition[] {
                 );
               }
             }
-            if (existsSync(distIndex)) {
-              html = inlineDistAssets(appDir, readFileSync(distIndex, "utf-8"));
-            } else {
-              html = `<p>App compilation failed. Edit a source file to trigger a rebuild.</p>`;
-            }
           }
+          const html = resolveEffectiveAppHtml(app);
 
           const { dirName } = resolveAppDir(app.id);
           return Response.json({


### PR DESCRIPTION
Returns a user-visible error message when multifile app compilation fails and dist/index.html is missing, instead of returning an empty string that shows a blank page.

Addresses feedback from #24262.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25392" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
