### PR TITLE
fix: remove bot-only channels:join from Slack user_scope

### DIFF
--- a/assistant/src/oauth/seed-providers.ts
+++ b/assistant/src/oauth/seed-providers.ts
@@ -163,7 +163,7 @@ export const PROVIDER_SEED_DATA: Record<
     },
     authorizeParams: {
       user_scope:
-        "channels:join,channels:read,channels:history,groups:read,groups:history,im:read,im:history,im:write,mpim:read,mpim:history,users:read,chat:write,search:read,reactions:write",
+        "channels:read,channels:history,groups:read,groups:history,im:read,im:history,im:write,mpim:read,mpim:history,users:read,chat:write,search:read,reactions:write",
     },
     loopbackPort: 17322,
     injectionTemplates: [


### PR DESCRIPTION
Removes `channels:join` from the Slack OAuth `user_scope` parameter since it is a bot-token-only scope. Including it in `user_scope` could cause `invalid_scope` errors during OAuth setup.

Addresses feedback from #25388.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25393" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
