### PR TITLE
fix: use platform-aware UTF-8 locale in sandbox env

### DIFF
--- a/assistant/src/tools/terminal/safe-env.ts
+++ b/assistant/src/tools/terminal/safe-env.ts
@@ -78,7 +78,10 @@ export function buildSanitizedEnv(): Record<string, string> {
   env.VELLUM_WORKSPACE_DIR = getWorkspaceDir();
   // Ensure UTF-8 locale so multi-byte characters (em dashes, curly quotes,
   // arrows, etc.) survive piping through tools like pbcopy without corruption.
-  if (!env.LANG) env.LANG = "C.UTF-8";
-  if (!env.LC_ALL) env.LC_ALL = "C.UTF-8";
+  // macOS (Darwin) does not provide C.UTF-8, so use en_US.UTF-8 there.
+  const utf8Locale =
+    process.platform === "darwin" ? "en_US.UTF-8" : "C.UTF-8";
+  if (!env.LANG) env.LANG = utf8Locale;
+  if (!env.LC_ALL) env.LC_ALL = utf8Locale;
   return env;
 }


### PR DESCRIPTION
## Summary
- Restores macOS compatibility by detecting the platform and using `en_US.UTF-8` on Darwin (which does not provide `C.UTF-8`) while keeping `C.UTF-8` on Linux.
- Prevents locale warnings and non-UTF-8 fallback in child shells on macOS.

Addresses feedback from #24078.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25394" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
