### PR TITLE
fix: thread activationHints and avoidWhen through extra-dir and workspace skills

### DIFF
--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -784,6 +784,8 @@ export function loadSkillCatalog(
             toolManifest: detectToolManifest(directory),
             includes: parsed.includes,
             featureFlag: parsed.featureFlag,
+            activationHints: parsed.activationHints,
+            avoidWhen: parsed.avoidWhen,
             inlineCommandExpansions: parsed.inlineCommandExpansions,
           });
         } catch (err) {
@@ -879,6 +881,8 @@ export function loadSkillCatalog(
           toolManifest: detectToolManifest(directory),
           includes: parsed.includes,
           featureFlag: parsed.featureFlag,
+          activationHints: parsed.activationHints,
+          avoidWhen: parsed.avoidWhen,
           inlineCommandExpansions: parsed.inlineCommandExpansions,
         };
 


### PR DESCRIPTION
The extraDirs and workspace skills code paths in loadSkillCatalog were silently dropping activationHints and avoidWhen from parsed frontmatter when constructing SkillSummary objects. This meant skills loaded from extra directories or the workspace that declared activation-hints or avoid-when would have those routing cues lost. Now both paths include these fields, matching the bundled skills pattern.

Addresses feedback from #24119.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25395" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
