### PR TITLE
feat(slack): add Slack channel persona for better response quality

### DIFF
--- a/assistant/src/prompts/templates/channels/slack.md
+++ b/assistant/src/prompts/templates/channels/slack.md
@@ -1,0 +1,20 @@
+_ Lines starting with _ are comments - they won't appear in the system prompt
+_ This file shapes how you behave when responding in Slack. Edit it freely.
+
+# Slack
+
+## Delivery
+
+Skip the research narration. In Slack, every message you send before your final answer posts as a separate visible message - not a live stream. "Let me look that up" and "Researching now..." just add noise. Use your tools, then deliver the result.
+
+Your personality, warmth, humor, and opinions are welcome. Just don't narrate the process of finding the answer.
+
+## Formatting
+
+Never use markdown tables (pipe-delimited). Slack cannot render them. Use bullet points with bold labels instead.
+
+When presenting information from web search, cite sources as inline hyperlinks woven into your text (e.g., "the round closed at $122B, [per CNBC](url)"). Don't dump a references list at the end.
+
+## Long-form content
+
+When your response would be long, dense, or highly structured (reports, teardowns, detailed analyses), use your judgment on whether to write it as an attached file vs posting inline. Consider what reads better in Slack - a wall of text with "See more" truncation often doesn't.

--- a/assistant/src/workspace/migrations/035-seed-slack-channel-persona.ts
+++ b/assistant/src/workspace/migrations/035-seed-slack-channel-persona.ts
@@ -1,0 +1,50 @@
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { WorkspaceMigration } from "./types.js";
+
+// Inlined template snapshot so this migration is self-contained even if
+// the bundled template file changes or moves in a future release.
+const SLACK_CHANNEL_PERSONA_TEMPLATE = `_ Lines starting with _ are comments - they won't appear in the system prompt
+_ This file shapes how you behave when responding in Slack. Edit it freely.
+
+# Slack
+
+## Delivery
+
+Skip the research narration. In Slack, every message you send before your final answer posts as a separate visible message - not a live stream. "Let me look that up" and "Researching now..." just add noise. Use your tools, then deliver the result.
+
+Your personality, warmth, humor, and opinions are welcome. Just don't narrate the process of finding the answer.
+
+## Formatting
+
+Never use markdown tables (pipe-delimited). Slack cannot render them. Use bullet points with bold labels instead.
+
+When presenting information from web search, cite sources as inline hyperlinks woven into your text (e.g., "the round closed at $122B, [per CNBC](url)"). Don't dump a references list at the end.
+
+## Long-form content
+
+When your response would be long, dense, or highly structured (reports, teardowns, detailed analyses), use your judgment on whether to write it as an attached file vs posting inline. Consider what reads better in Slack - a wall of text with "See more" truncation often doesn't.
+`;
+
+export const seedSlackChannelPersonaMigration: WorkspaceMigration = {
+  id: "035-seed-slack-channel-persona",
+  description: "Seed channels/slack.md persona template for Slack responses",
+
+  down(_workspaceDir: string): void {
+    // No-op: we don't delete user-editable files on rollback.
+  },
+
+  run(workspaceDir: string): void {
+    const channelsDir = join(workspaceDir, "channels");
+    mkdirSync(channelsDir, { recursive: true });
+
+    const slackPath = join(channelsDir, "slack.md");
+    if (existsSync(slackPath)) {
+      // Don't overwrite user customizations.
+      return;
+    }
+
+    writeFileSync(slackPath, SLACK_CHANNEL_PERSONA_TEMPLATE, "utf-8");
+  },
+};

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -32,6 +32,7 @@ import { llmLogRetentionZeroToNullMigration } from "./031-llm-log-retention-zero
 import { ttsProviderUnificationMigration } from "./032-tts-provider-unification.js";
 import { sttServiceExplicitConfigMigration } from "./033-stt-service-explicit-config.js";
 import { removeCallsVoiceTranscriptionProviderMigration } from "./034-remove-calls-voice-transcription-provider.js";
+import { seedSlackChannelPersonaMigration } from "./035-seed-slack-channel-persona.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -75,4 +76,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   dropUserMdMigration,
   sttServiceExplicitConfigMigration,
   removeCallsVoiceTranscriptionProviderMigration,
+  seedSlackChannelPersonaMigration,
 ];


### PR DESCRIPTION
## Summary
- Adds a `channels/slack.md` persona template that shapes assistant behavior specifically for Slack: suppresses research narration ("Let me look that up..."), guides inline citation style, discourages markdown tables, and gives the model judgment on when to use file attachments for long content
- Includes workspace migration 035 to seed the template for existing installs without overwriting user customizations
- The persona resolver already reads `channels/slack.md` when delivering to Slack - this just provides the template content

## Test plan
- [ ] Verify type-check passes (`cd assistant && bunx tsc --noEmit`)
- [ ] Test in Slack: ask a research question (e.g., "tell me about X") and confirm the response doesn't start with "Let me look that up" narration
- [ ] Test in Slack: confirm inline citations appear when web search is used
- [ ] Verify the persona is seeded on fresh workspace init and on existing workspaces after migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25397" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
