### PR TITLE
feat(search): add inline citation instructions to web search results

### DIFF
--- a/assistant/src/tools/network/web-search.ts
+++ b/assistant/src/tools/network/web-search.ts
@@ -61,6 +61,9 @@ async function getApiKey(
   return (await getProviderKeyAsync("perplexity")) ?? undefined;
 }
 
+const CITATION_INSTRUCTION =
+  "\n\nWhen presenting these results, cite sources as inline markdown hyperlinks next to the claims they support (e.g., 'according to [Source Title](url)'). Do not list references separately at the end.";
+
 function formatBraveResults(
   results: BraveSearchResult[],
   query: string,
@@ -89,7 +92,7 @@ function formatBraveResults(
     lines.push("");
   }
 
-  return lines.join("\n");
+  return lines.join("\n") + CITATION_INSTRUCTION;
 }
 
 function formatPerplexityResults(
@@ -111,7 +114,7 @@ function formatPerplexityResults(
     }
   }
 
-  return lines.join("\n");
+  return lines.join("\n") + CITATION_INSTRUCTION;
 }
 
 async function executeBraveSearch(


### PR DESCRIPTION
## Summary
- Appends a short instruction suffix to Perplexity and Brave web search tool results, guiding the model to cite sources as inline markdown hyperlinks next to claims (e.g., "according to [CNBC](url)")
- Prevents the model from dumping a disconnected references list at the end of responses
- Native Anthropic web search (`inference-provider-native`) is unaffected since it bypasses these formatters

## Test plan
- [ ] Verify type-check passes (`cd assistant && bunx tsc --noEmit`)
- [ ] Ask the assistant a current-events question that triggers web search and confirm inline citations appear in the response
- [ ] Verify the citation instruction only appears after actual search results (not on "no results found" responses)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25398" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
