### PR TITLE
fix(stt): move Deepgram auth to header, fix streaming transcript composition

### DIFF
--- a/assistant/src/providers/speech-to-text/deepgram-realtime.test.ts
+++ b/assistant/src/providers/speech-to-text/deepgram-realtime.test.ts
@@ -141,7 +141,10 @@ describe("DeepgramRealtimeTranscriber", () => {
 
     // Replace global WebSocket with a factory that returns our mock.
     (globalThis as Record<string, unknown>).WebSocket = class {
-      constructor(_url: string) {
+      constructor(
+        _url: string,
+        _options?: { headers?: Record<string, string> },
+      ) {
         // Immediately schedule the mock's open event for the next microtask
         // so start() can attach its handlers first.
         return mockWs;
@@ -584,10 +587,12 @@ describe("DeepgramRealtimeTranscriber", () => {
 
   test("builds correct WebSocket URL with default params", async () => {
     let capturedUrl: string | undefined;
+    let capturedOptions: { headers?: Record<string, string> } | undefined;
     const origWs = (globalThis as Record<string, unknown>).WebSocket;
     (globalThis as Record<string, unknown>).WebSocket = class {
-      constructor(url: string) {
+      constructor(url: string, options?: { headers?: Record<string, string> }) {
         capturedUrl = url;
+        capturedOptions = options;
         return mockWs;
       }
     };
@@ -604,13 +609,16 @@ describe("DeepgramRealtimeTranscriber", () => {
     expect(url.hostname).toBe("api.deepgram.com");
     expect(url.pathname).toBe("/v1/listen");
     expect(url.searchParams.get("model")).toBe("nova-2");
-    expect(url.searchParams.get("token")).toBe(TEST_API_KEY);
+    expect(url.searchParams.get("token")).toBeNull();
     expect(url.searchParams.get("smart_format")).toBe("true");
     expect(url.searchParams.get("interim_results")).toBe("true");
     expect(url.searchParams.get("punctuate")).toBe("true");
     expect(url.searchParams.get("encoding")).toBe("linear16");
     expect(url.searchParams.get("sample_rate")).toBe("16000");
     expect(url.searchParams.get("channels")).toBe("1");
+    expect(capturedOptions?.headers?.Authorization).toBe(
+      `Token ${TEST_API_KEY}`,
+    );
 
     (globalThis as Record<string, unknown>).WebSocket = origWs;
   });

--- a/assistant/src/providers/speech-to-text/deepgram-realtime.ts
+++ b/assistant/src/providers/speech-to-text/deepgram-realtime.ts
@@ -225,10 +225,7 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
     this.onEvent = onEvent;
 
     const url = this.buildWebSocketUrl();
-    log.info(
-      { url: url.replace(/token=[^&]*/, "token=***") },
-      "Opening Deepgram realtime session",
-    );
+    log.info({ url }, "Opening Deepgram realtime session");
 
     const ws = this.createWebSocket(url);
     this.ws = ws;
@@ -342,15 +339,28 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
 
   /**
    * Create a WebSocket instance. Factored out for test mockability.
+   *
+   * Passes the Deepgram API key via the `Authorization: Token <key>` header.
+   * Bun's WebSocket constructor supports a second `options` argument with
+   * custom headers, unlike the browser WebSocket API.
    */
   private createWebSocket(url: string): WsLike {
-    const WebSocketCtor: new (url: string) => WsLike = (
-      globalThis as unknown as { WebSocket: new (url: string) => WsLike }
+    const WebSocketCtor = (
+      globalThis as unknown as {
+        WebSocket: new (
+          url: string,
+          options?: { headers?: Record<string, string> },
+        ) => WsLike;
+      }
     ).WebSocket;
     if (typeof WebSocketCtor !== "function") {
       throw new Error("global WebSocket is not available in this runtime");
     }
-    return new WebSocketCtor(url);
+    return new WebSocketCtor(url, {
+      headers: {
+        Authorization: `Token ${this.apiKey}`,
+      },
+    });
   }
 
   /**
@@ -592,13 +602,13 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
   /**
    * Build the Deepgram live transcription WebSocket URL with query params.
    *
-   * Authentication is done via the `token` query parameter per Deepgram's
-   * WebSocket auth scheme.
+   * Audio format and feature flags are passed as query parameters.
+   * Authentication is handled separately via the `Authorization` header
+   * in {@link createWebSocket}.
    */
   private buildWebSocketUrl(): string {
     const params = new URLSearchParams();
     params.set("model", this.model);
-    params.set("token", this.apiKey);
 
     if (this.language) {
       params.set("language", this.language);

--- a/clients/macos/vellum-assistant/App/VoiceInputManager.swift
+++ b/clients/macos/vellum-assistant/App/VoiceInputManager.swift
@@ -73,6 +73,11 @@ final class VoiceInputManager {
     /// Internal access for testability via `@testable import`.
     var streamingFailed = false
 
+    /// Latest interim transcript text for the active streaming segment.
+    /// Used to compose a stable display transcript in conversation mode as:
+    /// `streamingFinalText + streamingInterimText`.
+    private var streamingInterimText = ""
+
     /// Called when dictation processing returns a response (cleaned-up text + action plan).
     var onDictationResponse: ((DictationResponse) -> Void)?
 
@@ -312,7 +317,11 @@ final class VoiceInputManager {
             stopRecordingByMode()
         } else {
             activeOrigin = origin
-            log.debug("Dictation started (origin: \(String(describing: origin)))")
+            // Chat composer recordings are conversations — enables streaming STT
+            // when the configured provider supports it. Other origins default to
+            // dictation mode (text insertion at cursor via DictationTextInserter).
+            currentMode = origin == .chatComposer ? .conversation : .dictation
+            log.debug("Recording started (origin: \(String(describing: origin)), mode: \(String(describing: self.currentMode)))")
             beginRecording()
         }
     }
@@ -352,6 +361,7 @@ final class VoiceInputManager {
         streamingClient = nil
         streamingSessionActive = false
         streamingFinalText = ""
+        streamingInterimText = ""
         streamingReceivedFinal = false
         streamingFailed = false
     }
@@ -676,6 +686,11 @@ final class VoiceInputManager {
     /// transcription falls through to the conversation path (auto-submit to chat)
     /// instead of going through DictationTextInserter which would double-insert.
     private func captureContextAndBeginRecording() {
+        // Hold-to-talk / hotkey activation is always dictation mode.
+        // Explicitly reset both origin and mode so a prior chat-composer
+        // recording cannot leak conversation-mode behavior into hotkey flow.
+        activeOrigin = .hotkey
+        currentMode = .dictation
         beginRecording()
         guard isRecording else { return }
         if currentMode == .dictation {
@@ -849,13 +864,29 @@ final class VoiceInputManager {
         let useConversationStreaming = currentMode == .conversation && STTProviderRegistry.isStreamingAvailable
 
         let accumulator = audioAccumulator
+        var streamingStartScheduled = false
         let tapBlock: AVAudioNodeTapBlock = { [weak self] buffer, _ in
             // Capture the audio format from the first buffer for WAV encoding.
+            // Conversation streaming also starts from this first buffer so we can
+            // pass the true hardware sample rate to the STT service.
+            let bufferFormat = buffer.format
             if self?.capturedAudioFormat == nil {
                 DispatchQueue.main.async { [weak self] in
                     if self?.capturedAudioFormat == nil {
-                        self?.capturedAudioFormat = buffer.format
+                        self?.capturedAudioFormat = bufferFormat
                     }
+                }
+            }
+            if useConversationStreaming, !streamingStartScheduled {
+                streamingStartScheduled = true
+                let sampleRate = Int(bufferFormat.sampleRate)
+                let capturedGeneration = generation
+                DispatchQueue.main.async { [weak self] in
+                    guard let self, self.isRecording, self.recordingGeneration == capturedGeneration else { return }
+                    self.startStreamingSession(
+                        generation: capturedGeneration,
+                        sampleRate: sampleRate > 0 ? sampleRate : nil
+                    )
                 }
             }
             // Feed the native recognizer only when a recognition request exists.
@@ -964,14 +995,6 @@ final class VoiceInputManager {
             }
             self.hasInstalledTap = true
 
-            // Start the streaming STT session if conversation streaming is enabled.
-            // This runs concurrently with the native recognizer (if available) —
-            // streaming provides live partials and finals while the native recognizer
-            // serves as a fallback source.
-            if useConversationStreaming {
-                self.startStreamingSession(generation: generation)
-            }
-
             // When native recognizer is not available/authorized, recording
             // still proceeds — STT service handles transcription on stop.
             guard useNativeRecognizer, let recognizer = self.speechRecognizer, let req = request else {
@@ -1038,14 +1061,9 @@ final class VoiceInputManager {
     ///
     /// The `generation` parameter is captured at recording start and checked in
     /// all callbacks to suppress stale-session deliveries.
-    private func startStreamingSession(generation: UInt64) {
+    private func startStreamingSession(generation: UInt64, sampleRate: Int?) {
         let client = streamingClientFactory()
         self.streamingClient = client
-
-        // Determine audio format parameters. `capturedAudioFormat` is set from
-        // the first audio buffer; if not yet available, the server will use its
-        // default sample rate.
-        let sampleRate: Int? = capturedAudioFormat.map { Int($0.sampleRate) }
 
         Task { [weak self] in
             await client.start(
@@ -1073,16 +1091,21 @@ final class VoiceInputManager {
     }
 
     /// Handle an incoming event from the streaming STT session.
-    private func handleStreamingEvent(_ event: STTStreamEvent) {
+    func handleStreamingEvent(_ event: STTStreamEvent) {
         switch event {
         case .ready(let provider):
             log.info("Streaming STT ready: provider=\(provider)")
             streamingSessionActive = true
 
         case .partial(let text, _):
-            // Forward streaming partials to the UI. In conversation mode,
-            // these update the chat composer / quick input in real time.
-            onPartialTranscription?(text)
+            // Partial events represent the current in-progress segment.
+            // Compose them with accumulated finals so pauses append instead
+            // of replacing previously dictated text in the composer.
+            streamingInterimText = text
+            let displayText = composedStreamingDisplayText()
+            if !displayText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                onPartialTranscription?(displayText)
+            }
 
         case .final(let text, _):
             let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -1094,6 +1117,12 @@ final class VoiceInputManager {
                 }
                 streamingReceivedFinal = true
                 log.info("Streaming final segment: \"\(text, privacy: .public)\"")
+
+                // Segment is now committed. Clear interim and push the
+                // accumulated transcript so the composer reflects append-only
+                // progress while recording continues.
+                streamingInterimText = ""
+                onPartialTranscription?(composedStreamingDisplayText())
             }
 
         case .error(let category, let message, _):
@@ -1113,6 +1142,16 @@ final class VoiceInputManager {
         log.warning("Streaming STT failure: \(String(describing: failure)) — will fall back to batch STT")
         streamingFailed = true
         streamingSessionActive = false
+    }
+
+    /// Compose the live display transcript from committed and in-progress
+    /// streaming text segments.
+    private func composedStreamingDisplayText() -> String {
+        let final = streamingFinalText.trimmingCharacters(in: .whitespacesAndNewlines)
+        let interim = streamingInterimText.trimmingCharacters(in: .whitespacesAndNewlines)
+        if final.isEmpty { return interim }
+        if interim.isEmpty { return final }
+        return "\(final) \(interim)"
     }
 
     // MARK: - Permission Prompt

--- a/clients/macos/vellum-assistantTests/VoiceInputManagerTests.swift
+++ b/clients/macos/vellum-assistantTests/VoiceInputManagerTests.swift
@@ -410,6 +410,31 @@ final class VoiceInputManagerTests: XCTestCase {
         XCTAssertEqual(manager.currentMode, .conversation)
     }
 
+    func testToggleRecordingFromChatComposerSetsConversationModeAndOrigin() {
+        manager.currentMode = .dictation
+        manager.activeOrigin = .hotkey
+
+        manager.toggleRecording(origin: .chatComposer)
+
+        XCTAssertEqual(manager.currentMode, .conversation,
+                       "Chat composer recordings should use conversation mode")
+        XCTAssertEqual(manager.activeOrigin, .chatComposer,
+                       "Active origin should track chat composer initiator")
+    }
+
+    func testToggleRecordingFromHotkeyResetsModeToDictation() {
+        // Simulate a previous chat-composer recording that left mode at conversation.
+        manager.currentMode = .conversation
+        manager.activeOrigin = .chatComposer
+
+        manager.toggleRecording(origin: .hotkey)
+
+        XCTAssertEqual(manager.currentMode, .dictation,
+                       "Hotkey recordings should always use dictation mode")
+        XCTAssertEqual(manager.activeOrigin, .hotkey,
+                       "Active origin should switch back to hotkey")
+    }
+
     // MARK: - Speech Recognizer Adapter Integration
 
     func testInitUsesAdapterToCreateRecognizer() {
@@ -1129,5 +1154,45 @@ final class VoiceInputManagerTests: XCTestCase {
 
         XCTAssertEqual(receivedText, "hello world how are you",
                        "Multiple streaming final segments should be concatenated")
+    }
+
+    func testStreamingPartialDisplayComposesCommittedAndInterimSegments() {
+        let streamClient = MockSTTStreamingClient()
+        let mgr = makeStreamingManager(streamingClient: streamClient)
+        mgr.currentMode = .conversation
+
+        var partials: [String] = []
+        mgr.onPartialTranscription = { partials.append($0) }
+
+        mgr.handleStreamingEvent(.ready(provider: "deepgram"))
+        mgr.handleStreamingEvent(.final(text: "hello world", seq: 1))
+        mgr.handleStreamingEvent(.partial(text: "how are", seq: 2))
+        mgr.handleStreamingEvent(.partial(text: "how are you", seq: 3))
+
+        XCTAssertEqual(partials, [
+            "hello world",
+            "hello world how are",
+            "hello world how are you",
+        ], "Streaming partial updates should preserve committed text and only revise the current segment")
+    }
+
+    func testStreamingFinalClearsInterimAndContinuesAppending() {
+        let streamClient = MockSTTStreamingClient()
+        let mgr = makeStreamingManager(streamingClient: streamClient)
+        mgr.currentMode = .conversation
+
+        var partials: [String] = []
+        mgr.onPartialTranscription = { partials.append($0) }
+
+        mgr.handleStreamingEvent(.ready(provider: "deepgram"))
+        mgr.handleStreamingEvent(.partial(text: "hello", seq: 1))
+        mgr.handleStreamingEvent(.final(text: "hello", seq: 2))
+        mgr.handleStreamingEvent(.partial(text: "again", seq: 3))
+
+        XCTAssertEqual(partials, [
+            "hello",
+            "hello",
+            "hello again",
+        ], "After a final segment, new interim text should append to the committed transcript")
     }
 }


### PR DESCRIPTION
## Summary
- Move Deepgram API key from URL `token` query param to `Authorization: Token <key>` header, preventing key exposure in logs and server-side URL captures
- Fix streaming STT partial/final text composition in VoiceInputManager — compose display transcript from committed finals + current interim segment so pauses append rather than replace previously dictated text
- Set recording mode per origin (conversation for chat composer, dictation for hotkey) with proper reset on switch; defer streaming session start to first audio buffer for accurate sample rate
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25401" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
