### PR TITLE
fix: replace require() with await import() in platform-connection test

### DIFF
--- a/assistant/src/oauth/platform-connection.test.ts
+++ b/assistant/src/oauth/platform-connection.test.ts
@@ -1,9 +1,8 @@
 import { describe, expect, mock, test } from "bun:test";
 
 // Stub out sleep so retry tests don't wait for real delays.
-mock.module("../util/retry.js", () => {
-  const actual =
-    require("../util/retry.js") as typeof import("../util/retry.js");
+mock.module("../util/retry.js", async () => {
+  const actual = await import("../util/retry.js");
   return {
     ...actual,
     sleep: () => Promise.resolve(),


### PR DESCRIPTION
## Summary
- Replace `require("../util/retry.js")` with `await import("../util/retry.js")` in `platform-connection.test.ts` to fix ESLint `@typescript-eslint/no-require-imports` error
- Makes the `mock.module` callback async to support the dynamic import

## Original prompt
fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/24372943142

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25402" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
