### PR TITLE
fix(macos): suppress self-echo broadcasts on sounds config reload

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
@@ -337,7 +337,7 @@ extension AppDelegate {
                 case .avatarUpdated(let msg):
                     AvatarAppearanceManager.shared.reloadAvatar(avatarPath: msg.avatarPath)
                 case .soundsConfigUpdated:
-                    SoundManager.shared.reloadConfig()
+                    SoundManager.shared.handleSoundsConfigBroadcast()
                 case .configChanged:
                     NotificationCenter.default.post(name: .configChanged, object: nil)
                 case .featureFlagsChanged:

--- a/clients/macos/vellum-assistant/Features/Sounds/SoundManager.swift
+++ b/clients/macos/vellum-assistant/Features/Sounds/SoundManager.swift
@@ -39,6 +39,19 @@ final class SoundManager {
     /// that hammers the workspace/tree API with 429s.
     @ObservationIgnored private var isRefreshingAvailableSounds = false
 
+    /// Timestamp of the most recent `saveConfig(_:)` call. The daemon watches
+    /// `data/sounds/` and broadcasts `soundsConfigUpdated` after any write,
+    /// including our own — refetching while writes are still in flight can
+    /// read a truncated payload and clobber local state with `.defaultConfig`.
+    /// `handleSoundsConfigBroadcast()` uses this to drop self-echo broadcasts.
+    @ObservationIgnored private var lastLocalSaveAt: Date?
+
+    /// Window during which an inbound `soundsConfigUpdated` broadcast is
+    /// treated as an echo of a recent local save and skipped. Covers the
+    /// daemon's 200 ms watcher debounce plus broadcast delivery, with
+    /// headroom.
+    private static let echoSuppressionWindow: TimeInterval = 2.0
+
     // MARK: - Lifecycle
 
     func start(featureFlagStore: AssistantFeatureFlagStore? = nil) {
@@ -101,10 +114,24 @@ final class SoundManager {
         }
     }
 
+    /// Handles a `soundsConfigUpdated` broadcast from the daemon. Drops
+    /// broadcasts that fall within the echo-suppression window of a recent
+    /// local save — those are the daemon echoing our own write, and
+    /// refetching would race against in-flight writes and briefly overwrite
+    /// the UI with `.defaultConfig` (globalEnabled=false, empty pools).
+    func handleSoundsConfigBroadcast() {
+        if let last = lastLocalSaveAt,
+           Date().timeIntervalSince(last) < Self.echoSuppressionWindow {
+            return
+        }
+        reloadConfig()
+    }
+
     /// Encodes and writes the config to the assistant's workspace via the gateway.
     /// Called by the Settings UI when the user changes settings.
     func saveConfig(_ newConfig: SoundsConfig) {
         config = newConfig
+        lastLocalSaveAt = Date()
 
         Task {
             let encoder = JSONEncoder()


### PR DESCRIPTION
## Summary
- Dragging the volume slider rapidly was clobbering the Sounds settings with the default config (everything disabled, sound pools empty) until the app was restarted.
- Root cause: each slider tick triggers a gateway write of `data/sounds/config.json`; the daemon file-watcher broadcasts `soundsConfigUpdated` 200 ms later; the client re-fetches the file, races an in-flight write, reads empty/partial JSON, and falls back to `SoundsConfig.defaultConfig`.
- Fix: route the broadcast through a new `handleSoundsConfigBroadcast()` that drops echoes within 2 s of a local `saveConfig`. Local state already matches disk in that window, so the refetch was pure overhead (plus the UI flicker from `clearCache` wiping the available-sounds list).

## Original prompt
it and /do the defensive fix in a second PR