### PR TITLE
fix(macos): preserve loaded sounds config on transient fetch failure

### DIFF
--- a/clients/macos/vellum-assistant/Features/Sounds/SoundManager.swift
+++ b/clients/macos/vellum-assistant/Features/Sounds/SoundManager.swift
@@ -52,6 +52,14 @@ final class SoundManager {
     /// headroom.
     private static let echoSuppressionWindow: TimeInterval = 2.0
 
+    /// Whether a valid config has ever been decoded from disk. While `false`,
+    /// fetch failures fall back to `.defaultConfig` so first-run (no file
+    /// yet) still renders sensible state. Once `true`, fetch failures
+    /// preserve the in-memory config rather than clobbering a known-good
+    /// state with defaults on a transient read error (e.g. a read that
+    /// raced a concurrent write).
+    @ObservationIgnored private var hasLoadedConfig = false
+
     // MARK: - Lifecycle
 
     func start(featureFlagStore: AssistantFeatureFlagStore? = nil) {
@@ -84,22 +92,33 @@ final class SoundManager {
     // MARK: - Config Loading & Saving
 
     /// Fetches and decodes config.json from the assistant's workspace via the
-    /// gateway. Falls back to `SoundsConfig.defaultConfig` if the file doesn't
-    /// exist or is malformed.
+    /// gateway. Before a successful decode has been observed, falls back to
+    /// `SoundsConfig.defaultConfig` so first-run (no file yet) still renders
+    /// sensible state. After a successful decode, transient failures (empty
+    /// body from a read that raced a concurrent write, decode errors,
+    /// network errors) preserve the in-memory config instead of clobbering
+    /// a known-good state with defaults.
     private func fetchConfig() async {
         do {
             let data = try await WorkspaceClient().fetchWorkspaceFileContent(
                 path: "data/sounds/config.json", showHidden: false
             )
             guard !data.isEmpty else {
-                config = .defaultConfig
+                if !hasLoadedConfig {
+                    config = .defaultConfig
+                }
                 return
             }
             let decoded = try JSONDecoder().decode(SoundsConfig.self, from: data)
             config = decoded
+            hasLoadedConfig = true
         } catch {
-            log.warning("Failed to fetch sounds config via gateway, using defaults: \(error.localizedDescription)")
-            config = .defaultConfig
+            if hasLoadedConfig {
+                log.warning("Failed to fetch sounds config via gateway, keeping existing: \(error.localizedDescription)")
+            } else {
+                log.warning("Failed to fetch sounds config via gateway, using defaults: \(error.localizedDescription)")
+                config = .defaultConfig
+            }
         }
     }
 
@@ -132,6 +151,7 @@ final class SoundManager {
     func saveConfig(_ newConfig: SoundsConfig) {
         config = newConfig
         lastLocalSaveAt = Date()
+        hasLoadedConfig = true
 
         Task {
             let encoder = JSONEncoder()


### PR DESCRIPTION
## Summary
- `SoundManager.fetchConfig` reset to `SoundsConfig.defaultConfig` on any empty/decoded-invalid/network-failed read, which conflates "no file yet" (legitimate defaults) with "read raced a write" (clobbering good state).
- Track `hasLoadedConfig` and only fall back to defaults when no successful decode has happened yet. After that, transient failures keep the in-memory config.
- Defensive complement to the echo-suppression fix in #25403 — stops any remaining race windows from flashing the Sounds settings page into the disabled-default state.

## Original prompt
it and /do the defensive fix in a second PR