### PR TITLE
fix(macos): defer app_open sound until config fetch lands

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -660,7 +660,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         RandomSoundTimer.shared.start()
         if !hasPlayedAppOpenSound {
             hasPlayedAppOpenSound = true
-            SoundManager.shared.play(.appOpen)
+            SoundManager.shared.playAppOpen()
         }
 
         // On cold-start reauth (non-first-launch), check for a pending managed

--- a/clients/macos/vellum-assistant/Features/Sounds/SoundManager.swift
+++ b/clients/macos/vellum-assistant/Features/Sounds/SoundManager.swift
@@ -60,6 +60,20 @@ final class SoundManager {
     /// raced a concurrent write).
     @ObservationIgnored private var hasLoadedConfig = false
 
+    /// True once `fetchConfig()` has settled with any deterministic result — a
+    /// decoded config or an empty-data first-run fallback. Distinct from
+    /// `hasLoadedConfig`, which requires a successful decode. This flag exists
+    /// solely to gate the deferred `app_open` play so it fires as soon as the
+    /// first fetch settles, not only after a config file has been written.
+    /// Stays false while every attempt has failed with a network error.
+    @ObservationIgnored private var initialConfigLoaded = false
+
+    /// Set by `playAppOpen()` when called before the initial config fetch has
+    /// landed. Flushed on the next settling of `fetchConfig()` so `app_open`
+    /// fires against the user's real config instead of racing the
+    /// default-silent one.
+    @ObservationIgnored private var pendingAppOpenPlay = false
+
     // MARK: - Lifecycle
 
     func start(featureFlagStore: AssistantFeatureFlagStore? = nil) {
@@ -107,11 +121,15 @@ final class SoundManager {
                 if !hasLoadedConfig {
                     config = .defaultConfig
                 }
+                initialConfigLoaded = true
+                flushPendingAppOpen()
                 return
             }
             let decoded = try JSONDecoder().decode(SoundsConfig.self, from: data)
             config = decoded
             hasLoadedConfig = true
+            initialConfigLoaded = true
+            flushPendingAppOpen()
         } catch {
             if hasLoadedConfig {
                 log.warning("Failed to fetch sounds config via gateway, keeping existing: \(error.localizedDescription)")
@@ -119,6 +137,8 @@ final class SoundManager {
                 log.warning("Failed to fetch sounds config via gateway, using defaults: \(error.localizedDescription)")
                 config = .defaultConfig
             }
+            // Leave `initialConfigLoaded` false — the `.daemonDidReconnect`
+            // reload will retry, and any pending `app_open` play waits for it.
         }
     }
 
@@ -216,6 +236,25 @@ final class SoundManager {
     }
 
     // MARK: - Playback
+
+    /// Plays `app_open` as soon as the initial config fetch completes. Callers
+    /// fire this during `applicationDidFinishLaunching`, before `start()`'s async
+    /// fetch has landed — calling `play(.appOpen)` directly in that window races
+    /// against the fetch and silently returns because `config` is still the
+    /// default-silent fallback.
+    func playAppOpen() {
+        if initialConfigLoaded {
+            play(.appOpen)
+        } else {
+            pendingAppOpenPlay = true
+        }
+    }
+
+    private func flushPendingAppOpen() {
+        guard pendingAppOpenPlay else { return }
+        pendingAppOpenPlay = false
+        play(.appOpen)
+    }
 
     /// Plays the sound associated with the given event, respecting global and per-event toggles.
     func play(_ event: SoundEvent) {


### PR DESCRIPTION
## Summary
- `AppDelegate.applicationDidFinishLaunching` called `SoundManager.play(.appOpen)` directly after `SoundManager.start()`, but `start()` only *kicks off* an async `Task` to fetch `data/sounds/config.json` from the gateway — so `play()` ran against the default-silent config and silently returned at `guard config.globalEnabled else { return }`. `hasPlayedAppOpenSound` then got set to `true`, locking out the real config once it finally loaded.
- New `SoundManager.playAppOpen()` queues a pending play when the initial fetch hasn't landed, and flushes it the first time `fetchConfig()` returns a deterministic result (decoded config or empty-data fallback). Network failures leave the pending flag set so a later `.daemonDidReconnect` reload gets another chance.
- Tracked via `initialConfigLoaded`; no behavior change for callers of the general `play(_:)` API or for later events like `task_complete` that fire well after the fetch has landed.

## Original prompt
option 1
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25405" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
