### PR TITLE
fix: add missing finalizeCallbackClaim to benchmark mock

### DIFF
--- a/assistant/src/__tests__/conversation-init.benchmark.test.ts
+++ b/assistant/src/__tests__/conversation-init.benchmark.test.ts
@@ -255,6 +255,7 @@ mock.module("../calls/call-store.js", () => ({
   recordProcessedCallback: () => {},
   claimCallback: () => true,
   releaseCallbackClaim: () => {},
+  finalizeCallbackClaim: () => true,
 }));
 
 mock.module("../daemon/watch-handler.js", () => ({


### PR DESCRIPTION
## Summary
- Add missing `finalizeCallbackClaim` export to the `call-store.js` mock in `conversation-init.benchmark.test.ts`
- Fixes CI failure: `SyntaxError: Export named 'finalizeCallbackClaim' not found in module`

## Original prompt
fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/24373030088

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25406" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
