### PR TITLE
macos: cold-launch into new-conversation state

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -118,10 +118,6 @@ final class ConversationManager: ConversationRestorerDelegate {
         selectionStore.restoreRecentConversations
     }
 
-    var lastActiveConversationIdString: String? {
-        selectionStore.lastActiveConversationIdString
-    }
-
     var activeConversationId: UUID? {
         selectionStore.activeConversationId
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
@@ -14,8 +14,6 @@ protocol ConversationRestorerDelegate: AnyObject {
     var groups: [ConversationGroup] { get set }
     var daemonSupportsGroups: Bool { get set }
     var restoreRecentConversations: Bool { get }
-    /// The persisted last-active conversation UUID string (UserDefaults-backed).
-    var lastActiveConversationIdString: String? { get }
     var isLoadingMoreConversations: Bool { get set }
     var hasMoreConversations: Bool { get set }
     var serverOffset: Int { get set }
@@ -347,28 +345,12 @@ final class ConversationRestorer {
             delegate.hasMoreConversations = hasMore
         }
 
-        // Determine the activation target once up front.
-        // Priority: saved last-active > first visible restored > new conversation.
-        let activationTarget: UUID? = {
-            // Try the user's last active conversation first.
-            if delegate.restoreRecentConversations,
-               let savedString = delegate.lastActiveConversationIdString,
-               let savedUUID = UUID(uuidString: savedString),
-               delegate.conversations.contains(where: { $0.id == savedUUID && !$0.isArchived }) {
-                return savedUUID
-            }
-            // Fall back to the first visible restored conversation.
-            if let firstVisible = restoredConversations.first(where: { !$0.isArchived }) {
-                return firstVisible.id
-            }
-            return nil
-        }()
-
-        if let target = activationTarget {
-            delegate.activateConversation(target)
-        } else if defaultConversationIsEmpty {
-            // All restored conversations are archived and the default conversation was removed,
-            // so create a new empty conversation to avoid a blank window.
+        // Cold launch lands on the draft VM created by ConversationManager.init —
+        // do not auto-activate a restored conversation. The sidebar above is still
+        // populated so the user can click into a recent conversation if desired.
+        if defaultConversationIsEmpty && restoredConversations.first(where: { !$0.isArchived }) == nil {
+            // All restored conversations are archived and the default was removed:
+            // fall back to an explicit draft so the window isn't blank.
             delegate.createConversation()
         }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationSelectionStore.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationSelectionStore.swift
@@ -358,37 +358,12 @@ final class ConversationSelectionStore {
 
     // MARK: - Restoration
 
-    /// Restore the last active conversation from UserDefaults after conversation restoration completes.
-    ///
-    /// If `handleConversationListResponse` already activated the correct conversation,
-    /// this is a no-op — `activeConversationId` already matches the saved UUID.
+    /// Final restoration tail — the app always cold-launches into the draft VM
+    /// created by ConversationManager, so no activation happens here. This call
+    /// just clears the restoration flag and fires the completion callback (used
+    /// to drive seen-state bookkeeping).
     func restoreLastActiveConversation() {
         defer { onRestorationComplete?() }
-
-        guard restoreRecentConversations else {
-            isRestoringConversations = false
-            return
-        }
-        guard let savedUUIDString = lastActiveConversationIdString,
-              let savedUUID = UUID(uuidString: savedUUIDString) else {
-            isRestoringConversations = false
-            return
-        }
-
-        // Only restore if conversation exists and is visible (not archived).
-        // Skip when already active to avoid redundant activation side effects.
-        if listStore.conversations.contains(where: { $0.id == savedUUID && !$0.isArchived }) {
-            if activeConversationId != savedUUID {
-                performActivation(for: savedUUID)
-                log.info("Restored last active conversation: \(savedUUID)")
-            } else {
-                log.info("Last active conversation \(savedUUID) already active, skipping")
-            }
-        } else {
-            lastActiveConversationIdString = nil
-            log.info("Saved conversation not found, falling back to default")
-        }
-
         isRestoringConversations = false
     }
 

--- a/clients/macos/vellum-assistantTests/ConversationRestorerTests.swift
+++ b/clients/macos/vellum-assistantTests/ConversationRestorerTests.swift
@@ -11,7 +11,6 @@ final class MockConversationRestorerDelegate: ConversationRestorerDelegate {
     var groups: [ConversationGroup] = []
     var daemonSupportsGroups: Bool = false
     var restoreRecentConversations: Bool = true
-    var lastActiveConversationIdString: String?
     var isLoadingMoreConversations: Bool = false
     var hasMoreConversations: Bool = false
     var serverOffset: Int = 0
@@ -365,8 +364,8 @@ struct ConversationRestorerTests {
         #expect(delegate.viewModels[delegate.conversations[0].id] == nil)
         #expect(delegate.viewModels[delegate.conversations[1].id] == nil)
 
-        // Most recent conversation should be activated
-        #expect(delegate.activatedConversationId == delegate.conversations[0].id)
+        // Cold launch stays on the draft VM — no auto-activation from the restored list.
+        #expect(delegate.activatedConversationId == nil)
     }
 
     @Test @MainActor


### PR DESCRIPTION
## Summary
- Remove auto-activation of the last-active conversation on cold launch — the app now lands on the `ChatEmptyStateView` draft (greeting + suggestion pills) created by `ConversationManager.init`.
- Sidebar still populates with recent conversations; clicking a recent activates it exactly as before.
- Collapse `restoreLastActiveConversation` to a bookkeeping tail and drop the now-dead `lastActiveConversationIdString` protocol member.

## Original prompt
it