### PR TITLE
Fix Twilio media-stream handshake by moving session metadata off query params

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -604,7 +604,7 @@ Telephony STT uses a provider-conditional hybrid model driven by `services.stt.p
 
 - **`conversation-relay-native`** (Deepgram, Google) — TwiML emits `<Connect><ConversationRelay>` with `transcriptionProvider` and `speechModel` attributes. Twilio handles audio ingestion and transcription natively; the daemon receives transcribed text via the relay WebSocket. The Twilio-native provider name and default speech model are read from the provider catalog entry's `telephonyRouting.twilioNativeMapping` (e.g. Deepgram maps to `provider: "Deepgram"` with `defaultSpeechModel: "nova-3"`; Google maps to `provider: "Google"` with `defaultSpeechModel: undefined`).
 
-- **`media-stream-custom`** (OpenAI Whisper) — TwiML emits `<Connect><Stream>` pointing to the daemon's media-stream server. Raw audio flows from Twilio through the gateway's WebSocket proxy (`twilio-media-websocket.ts`) to the daemon, which transcribes server-side via the provider's batch API.
+- **`media-stream-custom`** (OpenAI Whisper) — TwiML emits `<Connect><Stream>` pointing to the gateway's media-stream proxy. The `<Stream url="...">` encodes `callSessionId` and auth `token` as **URL path segments** (e.g. `.../media-stream/<callSessionId>/<token>`) because Twilio Media Streams does not reliably preserve query parameters across the WebSocket upgrade. The gateway extracts metadata from path segments (with query-parameter fallback for backward compatibility) and proxies raw audio frames to the daemon, which transcribes server-side via the provider's batch API.
 
 Key modules:
 

--- a/assistant/src/__tests__/twilio-routes-twiml.test.ts
+++ b/assistant/src/__tests__/twilio-routes-twiml.test.ts
@@ -478,14 +478,17 @@ describe("generateStreamTwiML", () => {
   const callSessionId = "stream-session-1";
   const streamUrl = "wss://test.example.com/webhooks/twilio/media-stream";
 
-  test("emits <Stream> element with callSessionId in URL query params", () => {
+  test("emits <Stream> element with callSessionId as path segment", () => {
     const twiml = generateStreamTwiML(callSessionId, streamUrl);
 
     expect(twiml).toContain("<Stream");
+    // callSessionId is encoded as a path segment, not a query param
     expect(twiml).toContain(
-      `url="wss://test.example.com/webhooks/twilio/media-stream?callSessionId=${callSessionId}"`,
+      `url="wss://test.example.com/webhooks/twilio/media-stream/${callSessionId}"`,
     );
     expect(twiml).not.toContain("<ConversationRelay");
+    // No query params should be present
+    expect(twiml).not.toContain("?callSessionId=");
   });
 
   test("includes callSessionId as <Parameter>", () => {
@@ -496,27 +499,31 @@ describe("generateStreamTwiML", () => {
     );
   });
 
-  test("includes auth token in URL query params and as <Parameter> when provided", () => {
+  test("includes auth token as path segment and as <Parameter> when provided", () => {
     const twiml = generateStreamTwiML(
       callSessionId,
       streamUrl,
       "test-relay-token-123",
     );
 
-    // Token in URL query params for gateway auth during WS upgrade
-    expect(twiml).toContain("token=test-relay-token-123");
+    // Token as path segment for gateway auth during WS upgrade
+    expect(twiml).toContain(
+      `url="wss://test.example.com/webhooks/twilio/media-stream/${callSessionId}/test-relay-token-123"`,
+    );
     // Token also in <Parameter> for Twilio start event payload
     expect(twiml).toContain(
       '<Parameter name="token" value="test-relay-token-123" />',
     );
   });
 
-  test("omits token from URL and Parameter when not provided", () => {
+  test("omits token from URL path and Parameter when not provided", () => {
     const twiml = generateStreamTwiML(callSessionId, streamUrl);
 
     expect(twiml).not.toContain('name="token"');
-    // URL should not contain a token query param
-    expect(twiml).not.toContain("token=");
+    // URL should only have callSessionId as path segment, no token
+    expect(twiml).toContain(
+      `url="wss://test.example.com/webhooks/twilio/media-stream/${callSessionId}"`,
+    );
   });
 
   test("includes custom parameters as <Parameter> elements", () => {
@@ -543,9 +550,9 @@ describe("generateStreamTwiML", () => {
       `<Parameter name="callSessionId" value="${callSessionId}" />`,
     );
     expect(twiml).not.toContain('value="attacker-session"');
-    // URL must also have the correct callSessionId
-    expect(twiml).toContain(`callSessionId=${callSessionId}`);
-    expect(twiml).not.toContain("callSessionId=attacker-session");
+    // URL path must also have the correct callSessionId
+    expect(twiml).toContain(`/media-stream/${callSessionId}`);
+    expect(twiml).not.toContain("attacker-session");
   });
 
   test("does not include ConversationRelay STT attributes", () => {
@@ -568,6 +575,18 @@ describe("generateStreamTwiML", () => {
     expect(twiml).toContain("</Stream>");
     expect(twiml).toContain("</Connect>");
     expect(twiml).toContain("</Response>");
+  });
+
+  test("URL-encodes special characters in callSessionId path segment", () => {
+    const specialId = "sess&id=1/2";
+    const twiml = generateStreamTwiML(specialId, streamUrl);
+
+    // Special characters must be percent-encoded in the path segment
+    expect(twiml).toContain("/media-stream/sess%26id%3D1%2F2");
+    // But the <Parameter> value should have the raw value (XML-escaped)
+    expect(twiml).toContain(
+      '<Parameter name="callSessionId" value="sess&amp;id=1/2" />',
+    );
   });
 });
 
@@ -612,7 +631,7 @@ describe("Provider-conditional TwiML generation", () => {
     expect(twiml).not.toContain("speechModel=");
   });
 
-  test("OpenAI Whisper: Stream path with no ConversationRelay STT attributes", () => {
+  test("OpenAI Whisper: Stream path with callSessionId/token in path segments", () => {
     const twiml = generateStreamTwiML(callSessionId, streamUrl, "tok");
 
     expect(twiml).toContain("<Stream");
@@ -622,6 +641,9 @@ describe("Provider-conditional TwiML generation", () => {
     expect(twiml).toContain(
       `<Parameter name="callSessionId" value="${callSessionId}" />`,
     );
+    // Metadata is path-based, not query-based
+    expect(twiml).toContain(`/media-stream/${callSessionId}/tok`);
+    expect(twiml).not.toContain("?callSessionId=");
   });
 
   test("ConversationRelay element contains all required STT-related attributes", () => {

--- a/assistant/src/__tests__/twilio-routes.test.ts
+++ b/assistant/src/__tests__/twilio-routes.test.ts
@@ -1126,7 +1126,7 @@ describe("twilio webhook routes", () => {
       expect(twiml).toContain('transcriptionProvider="Google"');
     });
 
-    test("outbound: openai-whisper -> Stream TwiML (no ConversationRelay)", async () => {
+    test("outbound: openai-whisper -> Stream TwiML with path-based metadata (no ConversationRelay)", async () => {
       mockConfigObj.services.stt.provider = "openai-whisper" as any;
       const session = createTestSession("conv-stt-ow-1", "CA_stt_ow_1");
       const req = makeVoiceRequest(session.id, { CallSid: "CA_stt_ow_1" });
@@ -1138,10 +1138,11 @@ describe("twilio webhook routes", () => {
       expect(twiml).toContain("<Stream");
       expect(twiml).not.toContain("<ConversationRelay");
       expect(twiml).not.toContain("transcriptionProvider=");
-      expect(twiml).toContain("callSessionId");
+      // callSessionId is in the URL path, not as a query param
       expect(twiml).toContain(
-        "wss://ingress.example.com/webhooks/twilio/media-stream",
+        `wss://ingress.example.com/webhooks/twilio/media-stream/${session.id}`,
       );
+      expect(twiml).not.toContain("?callSessionId=");
     });
 
     test("inbound: openai-whisper -> Stream TwiML (no ConversationRelay)", async () => {

--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -149,11 +149,15 @@ ${greetingAttr}
  * (e.g. OpenAI Whisper). Twilio opens a WebSocket to `streamUrl` and sends
  * raw audio frames; the daemon transcribes server-side.
  *
- * `callSessionId` and `token` are encoded as query parameters on the
+ * `callSessionId` and `token` are encoded as **path segments** on the
  * WebSocket URL so the gateway can validate and route the upgrade request
- * before any Twilio `start` frame arrives. They are also propagated as
- * `<Parameter>` children so Twilio includes them in the `start` event's
- * `customParameters` object for downstream observability.
+ * before any Twilio `start` frame arrives. Twilio Media Streams does not
+ * reliably preserve URL query parameters across the WebSocket upgrade, so
+ * path-based encoding is the primary transport for handshake metadata.
+ *
+ * Both values are also propagated as `<Parameter>` children so Twilio
+ * includes them in the `start` event's `customParameters` object for
+ * downstream observability.
  */
 export function generateStreamTwiML(
   callSessionId: string,
@@ -161,15 +165,16 @@ export function generateStreamTwiML(
   relayToken?: string,
   customParameters?: Record<string, string>,
 ): string {
-  // Build the WebSocket URL with callSessionId and token as query params.
-  // The gateway validates these during the upgrade handshake before any
-  // Twilio frames are available.
-  const urlObj = new URL(streamUrl);
-  urlObj.searchParams.set("callSessionId", callSessionId);
+  // Build the WebSocket URL with callSessionId and token as path segments.
+  // Twilio Media Streams does not reliably preserve query parameters
+  // across the WebSocket upgrade, so path-based encoding is the primary
+  // transport. The gateway extracts metadata from path segments first,
+  // falling back to query parameters for legacy compatibility.
+  let fullStreamUrl = streamUrl.replace(/\/+$/, "");
+  fullStreamUrl += `/${encodeURIComponent(callSessionId)}`;
   if (relayToken) {
-    urlObj.searchParams.set("token", relayToken);
+    fullStreamUrl += `/${encodeURIComponent(relayToken)}`;
   }
-  const fullStreamUrl = urlObj.toString();
 
   // Build <Parameter> elements for the Twilio start event payload.
   // Spread customParameters first so callSessionId and token cannot be

--- a/gateway/ARCHITECTURE.md
+++ b/gateway/ARCHITECTURE.md
@@ -1011,15 +1011,17 @@ All five tables live in `~/.vellum/workspace/data/db/assistant.db` alongside exi
 
 Internet-facing Twilio callbacks terminate at the gateway, which validates signatures before forwarding to the runtime. This keeps the runtime behind the gateway's bearer-auth boundary.
 
-| Gateway Route                          | Validates                         | Forwards To (Runtime)                                                                    |
-| -------------------------------------- | --------------------------------- | ---------------------------------------------------------------------------------------- |
-| `POST /webhooks/twilio/voice`          | HMAC-SHA1 signature, payload size | `POST /v1/internal/twilio/voice-webhook` (JSON: `{ params, originalUrl, assistantId? }`) |
-| `POST /webhooks/twilio/status`         | HMAC-SHA1 signature, payload size | `POST /v1/internal/twilio/status` (JSON: `{ params }`)                                   |
-| `POST /webhooks/twilio/connect-action` | HMAC-SHA1 signature, payload size | `POST /v1/internal/twilio/connect-action` (JSON: `{ params }`)                           |
-| `WS /webhooks/twilio/relay`            | WebSocket upgrade                 | `WS /v1/calls/relay` (bidirectional proxy) — ConversationRelay path                      |
-| `WS /webhooks/twilio/media-stream`     | WebSocket upgrade                 | `WS /v1/calls/media-stream` (bidirectional proxy) — Media Streams path                   |
+| Gateway Route                                              | Validates                         | Forwards To (Runtime)                                                                    |
+| ---------------------------------------------------------- | --------------------------------- | ---------------------------------------------------------------------------------------- |
+| `POST /webhooks/twilio/voice`                              | HMAC-SHA1 signature, payload size | `POST /v1/internal/twilio/voice-webhook` (JSON: `{ params, originalUrl, assistantId? }`) |
+| `POST /webhooks/twilio/status`                             | HMAC-SHA1 signature, payload size | `POST /v1/internal/twilio/status` (JSON: `{ params }`)                                   |
+| `POST /webhooks/twilio/connect-action`                     | HMAC-SHA1 signature, payload size | `POST /v1/internal/twilio/connect-action` (JSON: `{ params }`)                           |
+| `WS /webhooks/twilio/relay`                                | WebSocket upgrade                 | `WS /v1/calls/relay` (bidirectional proxy) — ConversationRelay path                      |
+| `WS /webhooks/twilio/media-stream/<callSessionId>/<token>` | WebSocket upgrade                 | `WS /v1/calls/media-stream` (bidirectional proxy) — Media Streams path                   |
 
-In gateway-fronted deployments, the TwiML WebSocket URL (returned by the voice webhook) should point to the gateway's `/webhooks/twilio/relay` (ConversationRelay) or `/webhooks/twilio/media-stream` (Media Streams) endpoint rather than directly to the runtime. The gateway proxies frames bidirectionally between Twilio and the runtime, preserving close and error semantics for proper cleanup.
+In gateway-fronted deployments, the TwiML WebSocket URL (returned by the voice webhook) should point to the gateway's `/webhooks/twilio/relay` (ConversationRelay) or `/webhooks/twilio/media-stream/<callSessionId>/<token>` (Media Streams) endpoint rather than directly to the runtime. The gateway proxies frames bidirectionally between Twilio and the runtime, preserving close and error semantics for proper cleanup.
+
+**Media Streams handshake metadata:** Twilio Media Streams does not reliably preserve URL query parameters across the WebSocket upgrade, so handshake metadata (`callSessionId` and auth `token`) is encoded as **URL path segments** (primary transport). The gateway also supports legacy query-parameter-based handshake as a fallback for backward compatibility. The metadata extractor in `twilio-media-websocket.ts` resolves values from path segments first, falling back to query parameters.
 
 Signature validation is **fail-closed**: if the Twilio auth token is not configured, all webhook requests are rejected with `403`. Missing or invalid `X-Twilio-Signature` headers are also rejected with `403`. Payload size is capped by `maxWebhookPayloadBytes` (checked via both `Content-Length` header and actual body size).
 

--- a/gateway/src/__tests__/twilio-media-websocket.test.ts
+++ b/gateway/src/__tests__/twilio-media-websocket.test.ts
@@ -4,6 +4,7 @@ import { initSigningKey, mintToken } from "../auth/token-service.js";
 import { CURRENT_POLICY_EPOCH } from "../auth/policy.js";
 import {
   createTwilioMediaWebsocketHandler,
+  extractMediaStreamMetadata,
   getMediaStreamWebsocketHandlers,
 } from "../http/routes/twilio-media-websocket.js";
 
@@ -120,15 +121,75 @@ function createFakeUpstreamWs() {
 }
 
 // ---------------------------------------------------------------------------
+// Metadata extraction tests
+// ---------------------------------------------------------------------------
+
+describe("extractMediaStreamMetadata", () => {
+  test("extracts callSessionId and token from path segments", () => {
+    const url = new URL(
+      "http://localhost:7830/webhooks/twilio/media-stream/sess-42/my-token",
+    );
+    const result = extractMediaStreamMetadata(url);
+    expect(result.callSessionId).toBe("sess-42");
+    expect(result.token).toBe("my-token");
+  });
+
+  test("extracts callSessionId from path when token is absent", () => {
+    const url = new URL(
+      "http://localhost:7830/webhooks/twilio/media-stream/sess-42",
+    );
+    const result = extractMediaStreamMetadata(url);
+    expect(result.callSessionId).toBe("sess-42");
+    expect(result.token).toBeNull();
+  });
+
+  test("decodes percent-encoded path segments", () => {
+    const url = new URL(
+      "http://localhost:7830/webhooks/twilio/media-stream/s%26id%3D1/tok%2Fen",
+    );
+    const result = extractMediaStreamMetadata(url);
+    expect(result.callSessionId).toBe("s&id=1");
+    expect(result.token).toBe("tok/en");
+  });
+
+  test("falls back to query parameters when path has no segments", () => {
+    const url = new URL(
+      "http://localhost:7830/webhooks/twilio/media-stream?callSessionId=qs-1&token=qs-tok",
+    );
+    const result = extractMediaStreamMetadata(url);
+    expect(result.callSessionId).toBe("qs-1");
+    expect(result.token).toBe("qs-tok");
+  });
+
+  test("returns nulls when neither path nor query provides metadata", () => {
+    const url = new URL("http://localhost:7830/webhooks/twilio/media-stream");
+    const result = extractMediaStreamMetadata(url);
+    expect(result.callSessionId).toBeNull();
+    expect(result.token).toBeNull();
+  });
+
+  test("path segments take priority over query parameters", () => {
+    const url = new URL(
+      "http://localhost:7830/webhooks/twilio/media-stream/path-sess/path-tok?callSessionId=query-sess&token=query-tok",
+    );
+    const result = extractMediaStreamMetadata(url);
+    expect(result.callSessionId).toBe("path-sess");
+    expect(result.token).toBe("path-tok");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Upgrade handler tests
 // ---------------------------------------------------------------------------
 
 describe("createTwilioMediaWebsocketHandler", () => {
   const TEST_TOKEN = mintEdgeToken();
 
-  test("returns 400 when callSessionId is missing", () => {
+  test("returns 400 when callSessionId is missing from both path and query", () => {
     const handler = createTwilioMediaWebsocketHandler(makeConfig());
-    const req = new Request("http://localhost:7830/ws/twilio/media-stream");
+    const req = new Request(
+      "http://localhost:7830/webhooks/twilio/media-stream",
+    );
     const fakeServer = {
       upgrade: mock(() => true),
     } as unknown as import("bun").Server<any>;
@@ -139,11 +200,11 @@ describe("createTwilioMediaWebsocketHandler", () => {
     expect(fakeServer.upgrade).not.toHaveBeenCalled();
   });
 
-  test("calls server.upgrade with callSessionId and config on valid request with query token", () => {
+  test("succeeds with path-based callSessionId and token", () => {
     const config = makeConfig({});
     const handler = createTwilioMediaWebsocketHandler(config);
     const req = new Request(
-      `http://localhost:7830/ws/twilio/media-stream?callSessionId=sess-42&token=${TEST_TOKEN}`,
+      `http://localhost:7830/webhooks/twilio/media-stream/sess-42/${TEST_TOKEN}`,
     );
     const fakeServer = {
       upgrade: mock(() => true),
@@ -155,7 +216,6 @@ describe("createTwilioMediaWebsocketHandler", () => {
 
     const call = (fakeServer.upgrade as ReturnType<typeof mock>).mock
       .calls[0] as unknown[];
-    // First arg is the request, second is { data: ... }
     expect(call[0]).toBe(req);
     const upgradeData = (
       call[1] as {
@@ -173,11 +233,35 @@ describe("createTwilioMediaWebsocketHandler", () => {
     );
   });
 
+  test("legacy: succeeds with query-based callSessionId and token", () => {
+    const config = makeConfig({});
+    const handler = createTwilioMediaWebsocketHandler(config);
+    const req = new Request(
+      `http://localhost:7830/webhooks/twilio/media-stream?callSessionId=sess-42&token=${TEST_TOKEN}`,
+    );
+    const fakeServer = {
+      upgrade: mock(() => true),
+    } as unknown as import("bun").Server<any>;
+    const res = handler(req, fakeServer);
+
+    expect(res).toBeUndefined();
+    expect(fakeServer.upgrade).toHaveBeenCalledTimes(1);
+
+    const call = (fakeServer.upgrade as ReturnType<typeof mock>).mock
+      .calls[0] as unknown[];
+    const upgradeData = (
+      call[1] as {
+        data: { callSessionId: string };
+      }
+    ).data;
+    expect(upgradeData.callSessionId).toBe("sess-42");
+  });
+
   test("calls server.upgrade when Authorization header provides valid token", () => {
     const config = makeConfig({});
     const handler = createTwilioMediaWebsocketHandler(config);
     const req = new Request(
-      "http://localhost:7830/ws/twilio/media-stream?callSessionId=sess-42",
+      "http://localhost:7830/webhooks/twilio/media-stream/sess-42",
       { headers: { authorization: `Bearer ${TEST_TOKEN}` } },
     );
     const fakeServer = {
@@ -193,7 +277,7 @@ describe("createTwilioMediaWebsocketHandler", () => {
     const config = makeConfig({});
     const handler = createTwilioMediaWebsocketHandler(config);
     const req = new Request(
-      `http://localhost:7830/ws/twilio/media-stream?callSessionId=sess-1&token=${TEST_TOKEN}`,
+      `http://localhost:7830/webhooks/twilio/media-stream/sess-1/${TEST_TOKEN}`,
     );
     const fakeServer = {
       upgrade: mock(() => false),
@@ -206,10 +290,10 @@ describe("createTwilioMediaWebsocketHandler", () => {
 
   // --- Auth tests ---
 
-  test("returns 401 when no token provided and bypass is off", () => {
+  test("returns 401 when no token provided via path, query, or header", () => {
     const handler = createTwilioMediaWebsocketHandler(makeConfig());
     const req = new Request(
-      "http://localhost:7830/ws/twilio/media-stream?callSessionId=sess-1",
+      "http://localhost:7830/webhooks/twilio/media-stream/sess-1",
     );
     const fakeServer = {
       upgrade: mock(() => true),
@@ -221,11 +305,11 @@ describe("createTwilioMediaWebsocketHandler", () => {
     expect(fakeServer.upgrade).not.toHaveBeenCalled();
   });
 
-  test("returns 401 when token is missing from request", () => {
+  test("returns 401 when token is missing from legacy query request", () => {
     const config = makeConfig({});
     const handler = createTwilioMediaWebsocketHandler(config);
     const req = new Request(
-      "http://localhost:7830/ws/twilio/media-stream?callSessionId=sess-1",
+      "http://localhost:7830/webhooks/twilio/media-stream?callSessionId=sess-1",
     );
     const fakeServer = {
       upgrade: mock(() => true),
@@ -237,11 +321,11 @@ describe("createTwilioMediaWebsocketHandler", () => {
     expect(fakeServer.upgrade).not.toHaveBeenCalled();
   });
 
-  test("returns 401 when token is wrong", () => {
+  test("returns 401 when path-based token is invalid", () => {
     const config = makeConfig({});
     const handler = createTwilioMediaWebsocketHandler(config);
     const req = new Request(
-      "http://localhost:7830/ws/twilio/media-stream?callSessionId=sess-1&token=wrong-token",
+      "http://localhost:7830/webhooks/twilio/media-stream/sess-1/wrong-token",
     );
     const fakeServer = {
       upgrade: mock(() => true),

--- a/gateway/src/__tests__/twilio-media-websocket.test.ts
+++ b/gateway/src/__tests__/twilio-media-websocket.test.ts
@@ -168,6 +168,15 @@ describe("extractMediaStreamMetadata", () => {
     expect(result.token).toBeNull();
   });
 
+  test("falls back to query params on malformed percent-encoding in path", () => {
+    const url = new URL(
+      "http://localhost:7830/webhooks/twilio/media-stream/%E0%A4%A/tok?callSessionId=qs-fallback&token=qs-tok",
+    );
+    const result = extractMediaStreamMetadata(url);
+    expect(result.callSessionId).toBe("qs-fallback");
+    expect(result.token).toBe("qs-tok");
+  });
+
   test("path segments take priority over query parameters", () => {
     const url = new URL(
       "http://localhost:7830/webhooks/twilio/media-stream/path-sess/path-tok?callSessionId=query-sess&token=query-tok",

--- a/gateway/src/http/routes/twilio-media-websocket.ts
+++ b/gateway/src/http/routes/twilio-media-websocket.ts
@@ -11,6 +11,9 @@ const log = getLogger("twilio-media-ws");
 // Cap buffered messages to prevent unbounded memory growth if upstream stalls
 const MAX_PENDING_MESSAGES = 100;
 
+/** Path prefix for media-stream WS upgrades. */
+const MEDIA_STREAM_PATH_PREFIX = "/webhooks/twilio/media-stream";
+
 type MediaStreamSocketData = {
   wsType: "twilio-media-stream";
   callSessionId: string;
@@ -20,6 +23,42 @@ type MediaStreamSocketData = {
 };
 
 export type { MediaStreamSocketData };
+
+/**
+ * Extract `callSessionId` and auth `token` from the request.
+ *
+ * **Primary path (new):** path segments after `/webhooks/twilio/media-stream/`.
+ *   Format: `.../media-stream/<callSessionId>/<token>`
+ *   Twilio Media Streams does not reliably preserve URL query parameters
+ *   across the WebSocket upgrade, so path-segment encoding is the primary
+ *   transport for handshake metadata.
+ *
+ * **Legacy fallback:** query parameters `callSessionId` and `token`.
+ *   Supported for backward compatibility during rollout.
+ */
+export function extractMediaStreamMetadata(url: URL): {
+  callSessionId: string | null;
+  token: string | null;
+} {
+  // Try path-based extraction first.
+  // Expected pathname: /webhooks/twilio/media-stream/<callSessionId>[/<token>]
+  if (url.pathname.startsWith(MEDIA_STREAM_PATH_PREFIX + "/")) {
+    const suffix = url.pathname.slice(MEDIA_STREAM_PATH_PREFIX.length + 1);
+    const segments = suffix.split("/").filter(Boolean);
+    if (segments.length >= 1) {
+      const callSessionId = decodeURIComponent(segments[0]);
+      const token =
+        segments.length >= 2 ? decodeURIComponent(segments[1]) : null;
+      return { callSessionId, token };
+    }
+  }
+
+  // Fallback: query parameters (legacy)
+  return {
+    callSessionId: url.searchParams.get("callSessionId"),
+    token: url.searchParams.get("token"),
+  };
+}
 
 /**
  * Create a WebSocket upgrade handler that proxies Twilio Media Stream
@@ -36,20 +75,21 @@ export function createTwilioMediaWebsocketHandler(
     server: import("bun").Server<unknown>,
   ): Response | undefined {
     const url = new URL(req.url);
-    const callSessionId = url.searchParams.get("callSessionId");
+    const { callSessionId, token: pathToken } = extractMediaStreamMetadata(url);
 
     if (!callSessionId) {
       log.warn("Media stream WS upgrade without callSessionId");
       return new Response("Missing callSessionId", { status: 400 });
     }
 
-    // Authenticate before upgrading. Twilio passes the token as a query
-    // parameter since WebSocket upgrades don't support arbitrary headers.
+    // Authenticate before upgrading. Twilio passes the token via path
+    // segments (primary) or query parameters (legacy fallback) since
+    // WebSocket upgrades don't support arbitrary headers.
     const isBypassed =
       process.env.APP_VERSION === "0.0.0-dev" &&
       (caches?.configFile?.getBoolean("telegram", "deliverAuthBypass") ??
         false);
-    const authResponse = checkMediaStreamAuth(req, url, isBypassed);
+    const authResponse = checkMediaStreamAuth(req, url, pathToken, isBypassed);
     if (authResponse) return authResponse;
 
     const upgraded = server.upgrade(req, {
@@ -72,9 +112,10 @@ export function createTwilioMediaWebsocketHandler(
 /**
  * Validate the media-stream WebSocket upgrade request using JWT edge tokens.
  *
- * Accepts a JWT via:
+ * Accepts a JWT via (in priority order):
  *   1. `Authorization: Bearer <token>` header (standard clients)
- *   2. `token` query parameter (Twilio media streams -- no custom headers)
+ *   2. Path-segment token extracted by {@link extractMediaStreamMetadata}
+ *   3. `token` query parameter (legacy Twilio media streams fallback)
  *
  * Fail-closed: rejects all unauthenticated requests unless the deliver auth
  * bypass flag is set (local-dev only escape hatch).
@@ -82,6 +123,7 @@ export function createTwilioMediaWebsocketHandler(
 function checkMediaStreamAuth(
   req: Request,
   url: URL,
+  pathToken: string | null,
   isBypassed: boolean,
 ): Response | null {
   // Local-dev bypass: allow unauthenticated access when deliverAuthBypass is set
@@ -89,14 +131,14 @@ function checkMediaStreamAuth(
     return null;
   }
 
-  // Try Authorization header first, then fall back to query param
+  // Priority: Authorization header > path segment > query param
   const authHeader = req.headers.get("authorization");
   const queryToken = url.searchParams.get("token");
   const rawToken = authHeader
     ? authHeader.toLowerCase().startsWith("bearer ")
       ? authHeader.slice(7)
       : null
-    : queryToken;
+    : (pathToken ?? queryToken);
 
   if (!rawToken) {
     log.warn("Media stream WS: no token provided");

--- a/gateway/src/http/routes/twilio-media-websocket.ts
+++ b/gateway/src/http/routes/twilio-media-websocket.ts
@@ -46,10 +46,14 @@ export function extractMediaStreamMetadata(url: URL): {
     const suffix = url.pathname.slice(MEDIA_STREAM_PATH_PREFIX.length + 1);
     const segments = suffix.split("/").filter(Boolean);
     if (segments.length >= 1) {
-      const callSessionId = decodeURIComponent(segments[0]);
-      const token =
-        segments.length >= 2 ? decodeURIComponent(segments[1]) : null;
-      return { callSessionId, token };
+      try {
+        const callSessionId = decodeURIComponent(segments[0]);
+        const token =
+          segments.length >= 2 ? decodeURIComponent(segments[1]) : null;
+        return { callSessionId, token };
+      } catch {
+        // Malformed percent-encoding — fall through to query param fallback
+      }
     }
   }
 

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -1238,7 +1238,10 @@ async function main() {
         return undefined as unknown as Response;
       }
 
-      if (url.pathname === "/webhooks/twilio/media-stream") {
+      if (
+        url.pathname === "/webhooks/twilio/media-stream" ||
+        url.pathname.startsWith("/webhooks/twilio/media-stream/")
+      ) {
         const upgradeResult = handleTwilioMediaWs(req, server);
         if (upgradeResult !== undefined) return upgradeResult;
         return undefined as unknown as Response;

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -822,28 +822,20 @@ export function buildSchema(): Record<string, unknown> {
           },
         },
       },
-      "/webhooks/twilio/media-stream/{callSessionId}/{token}": {
+      "/webhooks/twilio/media-stream": {
         get: {
           summary: "Twilio Media Stream WebSocket",
           description:
-            "Accepts a WebSocket upgrade from Twilio Media Streams and bidirectionally proxies frames to the assistant runtime's /v1/calls/media-stream endpoint. Handshake metadata (callSessionId and auth token) is carried in URL path segments because Twilio Media Streams does not reliably preserve query parameters across the WebSocket upgrade. Legacy query-parameter-based handshake is still supported as a fallback. Also accepts /webhooks/twilio/media-stream (bare path) with query params for backward compatibility.",
+            "Accepts a WebSocket upgrade from Twilio Media Streams and bidirectionally proxies frames to the assistant runtime's /v1/calls/media-stream endpoint. Handshake metadata (callSessionId and auth token) is carried in URL path segments (e.g. /webhooks/twilio/media-stream/<callSessionId>/<token>) because Twilio Media Streams does not reliably preserve query parameters across the WebSocket upgrade. Legacy query-parameter-based handshake is still supported as a fallback.",
           operationId: "twilioMediaStreamWebsocket",
           parameters: [
             {
               name: "callSessionId",
-              in: "path",
-              required: true,
-              schema: { type: "string" },
-              description:
-                "Call session identifier used to correlate the WebSocket connection with the runtime media-stream session. Encoded as a URL path segment (primary) or query parameter (legacy fallback).",
-            },
-            {
-              name: "token",
-              in: "path",
+              in: "query",
               required: false,
               schema: { type: "string" },
               description:
-                "JWT edge token for authentication. Encoded as a URL path segment (primary), query parameter (legacy fallback), or Authorization header.",
+                "Call session identifier (legacy fallback). The primary transport encodes callSessionId as a URL path segment: /webhooks/twilio/media-stream/<callSessionId>/<token>.",
             },
           ],
           responses: {

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -822,20 +822,28 @@ export function buildSchema(): Record<string, unknown> {
           },
         },
       },
-      "/webhooks/twilio/media-stream": {
+      "/webhooks/twilio/media-stream/{callSessionId}/{token}": {
         get: {
           summary: "Twilio Media Stream WebSocket",
           description:
-            "Accepts a WebSocket upgrade from Twilio Media Streams and bidirectionally proxies frames to the assistant runtime's /v1/calls/media-stream endpoint. Requires a callSessionId query parameter.",
+            "Accepts a WebSocket upgrade from Twilio Media Streams and bidirectionally proxies frames to the assistant runtime's /v1/calls/media-stream endpoint. Handshake metadata (callSessionId and auth token) is carried in URL path segments because Twilio Media Streams does not reliably preserve query parameters across the WebSocket upgrade. Legacy query-parameter-based handshake is still supported as a fallback. Also accepts /webhooks/twilio/media-stream (bare path) with query params for backward compatibility.",
           operationId: "twilioMediaStreamWebsocket",
           parameters: [
             {
               name: "callSessionId",
-              in: "query",
+              in: "path",
               required: true,
               schema: { type: "string" },
               description:
-                "Call session identifier used to correlate the WebSocket connection with the runtime media-stream session.",
+                "Call session identifier used to correlate the WebSocket connection with the runtime media-stream session. Encoded as a URL path segment (primary) or query parameter (legacy fallback).",
+            },
+            {
+              name: "token",
+              in: "path",
+              required: false,
+              schema: { type: "string" },
+              description:
+                "JWT edge token for authentication. Encoded as a URL path segment (primary), query parameter (legacy fallback), or Authorization header.",
             },
           ],
           responses: {


### PR DESCRIPTION
## Summary
- Move `callSessionId` and auth `token` from URL query parameters to path segments in the `<Stream url="...">` TwiML generated for media-stream calls. Twilio Media Streams does not reliably preserve query params across WebSocket upgrades, causing the gateway to reject connections with missing metadata.
- Gateway now extracts handshake metadata from path segments (primary) with query-parameter fallback for backward compatibility. Auth validation unchanged.
- Updated all tests and ARCHITECTURE docs to reflect the new path-based handshake format.

## Original prompt
/Users/noaflaherty/Repos/vellum-ai/vellum-assistant/.private/plans/media-stream-handshake-bugfix.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25409" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
