### PR TITLE
Implement OpenAI Whisper incremental-batch streaming transcriber

### DIFF
--- a/assistant/src/providers/speech-to-text/openai-whisper-stream.test.ts
+++ b/assistant/src/providers/speech-to-text/openai-whisper-stream.test.ts
@@ -521,7 +521,7 @@ describe("OpenAIWhisperStreamingTranscriber", () => {
       }
     });
 
-    test("audio/l16 MIME type is also WAV-wrapped", async () => {
+    test("audio/l16 is NOT WAV-wrapped (big-endian per RFC 3551, needs byte-swap)", async () => {
       const { transcriber, calls } = createTranscriberWithMock([
         { text: "l16 transcription" },
         { text: "l16 transcription complete" },
@@ -534,9 +534,11 @@ describe("OpenAIWhisperStreamingTranscriber", () => {
       transcriber.stop();
       await waitFor(() => events.some((e) => e.type === "closed"));
 
+      // audio/l16 is big-endian per RFC 3551 and should NOT be treated
+      // as PCM16LE for WAV wrapping — it passes through unchanged.
       expect(calls.length).toBeGreaterThanOrEqual(1);
       for (const call of calls) {
-        expect(call.mimeType).toBe("audio/wav");
+        expect(call.mimeType).toBe("audio/l16");
       }
     });
 

--- a/assistant/src/providers/speech-to-text/openai-whisper-stream.test.ts
+++ b/assistant/src/providers/speech-to-text/openai-whisper-stream.test.ts
@@ -1,0 +1,562 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import type { SttStreamServerEvent } from "../../stt/types.js";
+import { OpenAIWhisperStreamingTranscriber } from "./openai-whisper-stream.js";
+
+const TEST_API_KEY = "openai-test-key-for-streaming-tests";
+
+// ---------------------------------------------------------------------------
+// Mock helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a mock `whisperTranscribe` function that returns sequential responses
+ * on each call, or rejects with an error.
+ *
+ * We intercept at the `transcribeAccumulated` level by replacing the
+ * private method so we don't need to mock `fetch` or the shared
+ * `whisperTranscribe` function directly.
+ */
+function mockWhisperResponses(
+  responses: Array<{ text?: string } | { error: Error }>,
+) {
+  let callIndex = 0;
+  const calls: Array<{ audio: Buffer; mimeType: string }> = [];
+
+  const transcribeFn = mock(
+    (audio: Buffer, mimeType: string): Promise<string> => {
+      calls.push({ audio, mimeType });
+      const entry = responses[callIndex] ?? responses[responses.length - 1];
+      callIndex++;
+
+      if ("error" in entry) {
+        return Promise.reject(entry.error);
+      }
+      return Promise.resolve(entry.text ?? "");
+    },
+  );
+
+  return { transcribeFn, calls };
+}
+
+/**
+ * Create a transcriber with an injected mock transcribe method and a very
+ * short poll interval for fast test execution.
+ */
+function createTranscriberWithMock(
+  responses: Array<{ text?: string } | { error: Error }>,
+  options?: { pollIntervalMs?: number },
+): {
+  transcriber: OpenAIWhisperStreamingTranscriber;
+  transcribeFn: ReturnType<typeof mock>;
+  calls: Array<{ audio: Buffer; mimeType: string }>;
+} {
+  const { transcribeFn, calls } = mockWhisperResponses(responses);
+  const transcriber = new OpenAIWhisperStreamingTranscriber(TEST_API_KEY, {
+    pollIntervalMs: options?.pollIntervalMs ?? 10,
+  });
+
+  // Replace the internal transcribeAccumulated method with our mock.
+  // The mock intercepts after PCM-to-WAV conversion has happened (if
+  // applicable), so we can inspect the mimeType that was passed.
+  (
+    transcriber as unknown as {
+      transcribeAccumulated: () => Promise<string>;
+    }
+  ).transcribeAccumulated = async () => {
+    // Access accumulated state through the private fields
+    const chunks = (transcriber as unknown as { audioChunks: Buffer[] })
+      .audioChunks;
+    const mime = (transcriber as unknown as { audioMimeType: string })
+      .audioMimeType;
+    const combined = Buffer.concat(chunks);
+
+    // Check for PCM-to-WAV conversion (mirrors the real implementation)
+    const isPcm = (
+      transcriber as unknown as { isPcmMimeType: (m: string) => boolean }
+    ).isPcmMimeType(mime);
+    const effectiveMime = isPcm ? "audio/wav" : mime;
+
+    return transcribeFn(combined, effectiveMime);
+  };
+
+  return { transcriber, transcribeFn, calls };
+}
+
+/**
+ * Collect all events emitted by a transcriber into an array.
+ */
+function collectEvents(
+  transcriber: OpenAIWhisperStreamingTranscriber,
+): SttStreamServerEvent[] {
+  const events: SttStreamServerEvent[] = [];
+  void transcriber.start((event) => events.push(event));
+  return events;
+}
+
+/**
+ * Wait for a condition to become true, polling at a short interval.
+ */
+async function waitFor(
+  condition: () => boolean,
+  timeoutMs = 2_000,
+): Promise<void> {
+  const start = Date.now();
+  while (!condition()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error("waitFor timed out");
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("OpenAIWhisperStreamingTranscriber", () => {
+  // -----------------------------------------------------------------------
+  // Lifecycle
+  // -----------------------------------------------------------------------
+
+  describe("lifecycle", () => {
+    test("start() registers event callback without error", async () => {
+      const { transcriber } = createTranscriberWithMock([{ text: "" }]);
+      await transcriber.start(() => {});
+      // No error = success
+    });
+
+    test("start() throws if called twice", async () => {
+      const { transcriber } = createTranscriberWithMock([{ text: "" }]);
+      await transcriber.start(() => {});
+
+      await expect(transcriber.start(() => {})).rejects.toThrow(
+        "already started",
+      );
+    });
+
+    test("sendAudio() throws if called before start()", () => {
+      const { transcriber } = createTranscriberWithMock([{ text: "" }]);
+
+      expect(() =>
+        transcriber.sendAudio(Buffer.from("audio"), "audio/webm"),
+      ).toThrow("before start()");
+    });
+
+    test("sendAudio() is silently ignored after stop()", async () => {
+      const { transcriber, transcribeFn } = createTranscriberWithMock([
+        { text: "final" },
+      ]);
+      const events = collectEvents(transcriber);
+
+      transcriber.stop();
+
+      await waitFor(() => events.some((e) => e.type === "closed"));
+
+      // Sending audio after stop should not throw or trigger new requests.
+      transcriber.sendAudio(Buffer.from("late-audio"), "audio/webm");
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      // No audio was sent before stop, so the final emits from
+      // lastEmittedText (empty) without a batch call.
+      expect(transcribeFn).not.toHaveBeenCalled();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Progressive partial updates
+  // -----------------------------------------------------------------------
+
+  describe("partial updates", () => {
+    test("emits partial events as audio accumulates", async () => {
+      const { transcriber } = createTranscriberWithMock([
+        { text: "Hello" },
+        { text: "Hello world" },
+        { text: "Hello world test" },
+      ]);
+      const events = collectEvents(transcriber);
+
+      transcriber.sendAudio(Buffer.from("chunk-1"), "audio/webm");
+      await waitFor(() => events.some((e) => e.type === "partial"));
+
+      transcriber.sendAudio(Buffer.from("chunk-2"), "audio/webm");
+      await waitFor(
+        () => events.filter((e) => e.type === "partial").length >= 2,
+      );
+
+      transcriber.stop();
+      await waitFor(() => events.some((e) => e.type === "closed"));
+
+      const partials = events.filter((e) => e.type === "partial");
+      expect(partials.length).toBeGreaterThanOrEqual(1);
+      expect(partials[0]).toEqual({ type: "partial", text: "Hello" });
+    });
+
+    test("does not emit partial when transcript has not changed", async () => {
+      const { transcriber } = createTranscriberWithMock([
+        { text: "Hello" },
+        { text: "Hello" }, // same as before
+        { text: "Hello world" },
+      ]);
+      const events = collectEvents(transcriber);
+
+      transcriber.sendAudio(Buffer.from("chunk-1"), "audio/webm");
+      await waitFor(() => events.some((e) => e.type === "partial"));
+
+      transcriber.sendAudio(Buffer.from("chunk-2"), "audio/webm");
+      // Wait a bit for the second poll
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      transcriber.sendAudio(Buffer.from("chunk-3"), "audio/webm");
+      await waitFor(
+        () => events.filter((e) => e.type === "partial").length >= 2,
+      );
+
+      transcriber.stop();
+      await waitFor(() => events.some((e) => e.type === "closed"));
+
+      const partials = events.filter((e) => e.type === "partial");
+      // Should have "Hello" and "Hello world", but NOT a duplicate "Hello"
+      const texts = partials.map((e) => (e.type === "partial" ? e.text : ""));
+      expect(texts).toContain("Hello");
+      expect(texts).toContain("Hello world");
+      // No duplicates
+      const uniqueTexts = [...new Set(texts)];
+      expect(uniqueTexts.length).toBe(texts.length);
+    });
+
+    test("does not emit partial when transcript regresses (shorter text)", async () => {
+      const { transcriber } = createTranscriberWithMock([
+        { text: "Hello world" },
+        { text: "Hello" }, // regression — shorter
+        { text: "Hello world again" },
+      ]);
+      const events = collectEvents(transcriber);
+
+      transcriber.sendAudio(Buffer.from("chunk-1"), "audio/webm");
+      await waitFor(() => events.some((e) => e.type === "partial"));
+
+      transcriber.sendAudio(Buffer.from("chunk-2"), "audio/webm");
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      transcriber.sendAudio(Buffer.from("chunk-3"), "audio/webm");
+      await waitFor(
+        () => events.filter((e) => e.type === "partial").length >= 2,
+      );
+
+      transcriber.stop();
+      await waitFor(() => events.some((e) => e.type === "closed"));
+
+      const partials = events.filter((e) => e.type === "partial");
+      const texts = partials.map((e) => (e.type === "partial" ? e.text : ""));
+
+      // "Hello" (regression) should NOT appear as a partial
+      expect(texts).toContain("Hello world");
+      expect(texts).not.toContain("Hello");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Final event
+  // -----------------------------------------------------------------------
+
+  describe("final event", () => {
+    test("emits final event with complete transcript on stop", async () => {
+      const { transcriber } = createTranscriberWithMock([
+        { text: "partial one" },
+        { text: "full transcript" },
+      ]);
+      const events = collectEvents(transcriber);
+
+      transcriber.sendAudio(Buffer.from("chunk-1"), "audio/webm");
+      await waitFor(() => events.some((e) => e.type === "partial"));
+
+      transcriber.stop();
+      await waitFor(() => events.some((e) => e.type === "closed"));
+
+      const finals = events.filter((e) => e.type === "final");
+      expect(finals.length).toBe(1);
+      expect(finals[0]).toEqual({ type: "final", text: "full transcript" });
+    });
+
+    test("emits final with last known partial when no audio was sent", async () => {
+      const { transcriber } = createTranscriberWithMock([{ text: "" }]);
+      const events = collectEvents(transcriber);
+
+      transcriber.stop();
+      await waitFor(() => events.some((e) => e.type === "closed"));
+
+      const finals = events.filter((e) => e.type === "final");
+      expect(finals.length).toBe(1);
+      expect(finals[0]).toEqual({ type: "final", text: "" });
+    });
+
+    test("emits closed event after final", async () => {
+      const { transcriber } = createTranscriberWithMock([{ text: "done" }]);
+      const events = collectEvents(transcriber);
+
+      transcriber.sendAudio(Buffer.from("audio"), "audio/webm");
+      await waitFor(() => events.some((e) => e.type === "partial"));
+
+      transcriber.stop();
+      await waitFor(() => events.some((e) => e.type === "closed"));
+
+      const finalIdx = events.findIndex((e) => e.type === "final");
+      const closedIdx = events.findIndex((e) => e.type === "closed");
+      expect(finalIdx).toBeGreaterThanOrEqual(0);
+      expect(closedIdx).toBeGreaterThan(finalIdx);
+    });
+
+    test("stop() is idempotent", async () => {
+      const { transcriber } = createTranscriberWithMock([{ text: "done" }]);
+      const events = collectEvents(transcriber);
+
+      transcriber.sendAudio(Buffer.from("audio"), "audio/webm");
+      await waitFor(() => events.some((e) => e.type === "partial"));
+
+      transcriber.stop();
+      transcriber.stop(); // second stop should be a no-op
+
+      await waitFor(() => events.some((e) => e.type === "closed"));
+
+      // Only one closed event
+      const closedEvents = events.filter((e) => e.type === "closed");
+      expect(closedEvents.length).toBe(1);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Error handling
+  // -----------------------------------------------------------------------
+
+  describe("error handling", () => {
+    test("transient poll error emits error event but does not close session", async () => {
+      const { transcriber } = createTranscriberWithMock([
+        { error: new Error("transient network failure") },
+        { text: "recovered" },
+        { text: "recovered" },
+      ]);
+      const events = collectEvents(transcriber);
+
+      transcriber.sendAudio(Buffer.from("chunk-1"), "audio/webm");
+      await waitFor(() => events.some((e) => e.type === "error"));
+
+      const errors = events.filter((e) => e.type === "error");
+      expect(errors.length).toBe(1);
+      expect(errors[0]).toEqual({
+        type: "error",
+        category: "provider-error",
+        message: "transient network failure",
+      });
+
+      // Session is still alive — send more audio
+      transcriber.sendAudio(Buffer.from("chunk-2"), "audio/webm");
+      await waitFor(() => events.some((e) => e.type === "partial"));
+
+      transcriber.stop();
+      await waitFor(() => events.some((e) => e.type === "closed"));
+
+      expect(events.some((e) => e.type === "final")).toBe(true);
+    });
+
+    test("final batch error emits error then falls back to last partial", async () => {
+      const { transcriber } = createTranscriberWithMock([
+        { text: "partial before error" },
+        { error: new Error("final request failed") },
+      ]);
+      const events = collectEvents(transcriber);
+
+      transcriber.sendAudio(Buffer.from("audio"), "audio/webm");
+      await waitFor(() => events.some((e) => e.type === "partial"));
+
+      transcriber.stop();
+      await waitFor(() => events.some((e) => e.type === "closed"));
+
+      const finals = events.filter((e) => e.type === "final");
+      expect(finals.length).toBe(1);
+      // Should fall back to last emitted partial text
+      expect(finals[0]).toEqual({
+        type: "final",
+        text: "partial before error",
+      });
+
+      // An error event should have been emitted before the final fallback
+      const errors = events.filter((e) => e.type === "error");
+      expect(errors.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Rate limiting / throttling
+  // -----------------------------------------------------------------------
+
+  describe("rate limiting", () => {
+    test("does not send more than one batch request per poll interval", async () => {
+      const { transcriber, transcribeFn } = createTranscriberWithMock(
+        [
+          { text: "a" },
+          { text: "ab" },
+          { text: "abc" },
+          { text: "abcd" },
+          { text: "abcde" },
+        ],
+        { pollIntervalMs: 100 },
+      );
+      const events = collectEvents(transcriber);
+
+      // Send multiple chunks rapidly
+      transcriber.sendAudio(Buffer.from("c1"), "audio/webm");
+      transcriber.sendAudio(Buffer.from("c2"), "audio/webm");
+      transcriber.sendAudio(Buffer.from("c3"), "audio/webm");
+
+      // Wait for just one poll cycle
+      await waitFor(() => events.some((e) => e.type === "partial"));
+      const callsAfterFirstPoll = (transcribeFn as ReturnType<typeof mock>).mock
+        .calls.length;
+
+      // Only 1 batch request should have fired despite 3 audio chunks.
+      expect(callsAfterFirstPoll).toBe(1);
+
+      transcriber.stop();
+      await waitFor(() => events.some((e) => e.type === "closed"));
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Cancellation
+  // -----------------------------------------------------------------------
+
+  describe("cancellation", () => {
+    test("stop() cancels pending poll timer", async () => {
+      const { transcriber } = createTranscriberWithMock(
+        [{ text: "final text" }],
+        { pollIntervalMs: 500 }, // long interval to ensure timer is pending
+      );
+      const events = collectEvents(transcriber);
+
+      transcriber.sendAudio(Buffer.from("audio"), "audio/webm");
+
+      // Stop immediately before the poll fires
+      transcriber.stop();
+      await waitFor(() => events.some((e) => e.type === "closed"));
+
+      // The final batch should fire (from emitFinal), but no poll should
+      // have fired since we stopped before the interval elapsed.
+      const finals = events.filter((e) => e.type === "final");
+      expect(finals.length).toBe(1);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Provider identity
+  // -----------------------------------------------------------------------
+
+  describe("provider identity", () => {
+    test("providerId is openai-whisper", () => {
+      const { transcriber } = createTranscriberWithMock([{ text: "" }]);
+      expect(transcriber.providerId).toBe("openai-whisper");
+    });
+
+    test("boundaryId is daemon-streaming", () => {
+      const { transcriber } = createTranscriberWithMock([{ text: "" }]);
+      expect(transcriber.boundaryId).toBe("daemon-streaming");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Timeout path
+  // -----------------------------------------------------------------------
+
+  describe("timeout", () => {
+    test("AbortError during poll emits error event with provider-error category", async () => {
+      const abortError = new DOMException(
+        "The operation was aborted",
+        "AbortError",
+      );
+      const { transcriber } = createTranscriberWithMock([
+        { error: abortError },
+        { text: "recovered after timeout" },
+        { text: "recovered after timeout" },
+      ]);
+      const events = collectEvents(transcriber);
+
+      transcriber.sendAudio(Buffer.from("audio"), "audio/webm");
+      await waitFor(() => events.some((e) => e.type === "error"));
+
+      const errors = events.filter((e) => e.type === "error");
+      expect(errors[0]).toEqual({
+        type: "error",
+        category: "provider-error",
+        message: "The operation was aborted",
+      });
+
+      transcriber.stop();
+      await waitFor(() => events.some((e) => e.type === "closed"));
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // PCM-to-WAV format path
+  // -----------------------------------------------------------------------
+
+  describe("PCM-to-WAV transcoding", () => {
+    test("PCM audio input is WAV-wrapped before Whisper transcription calls", async () => {
+      const { transcriber, calls } = createTranscriberWithMock([
+        { text: "pcm transcription" },
+        { text: "pcm transcription complete" },
+      ]);
+      const events = collectEvents(transcriber);
+
+      // Send audio with PCM MIME type
+      transcriber.sendAudio(Buffer.from("pcm-audio-chunk"), "audio/pcm");
+      await waitFor(() => events.some((e) => e.type === "partial"));
+
+      transcriber.stop();
+      await waitFor(() => events.some((e) => e.type === "closed"));
+
+      // Verify that the mock was called with audio/wav (not audio/pcm)
+      expect(calls.length).toBeGreaterThanOrEqual(1);
+      for (const call of calls) {
+        expect(call.mimeType).toBe("audio/wav");
+      }
+    });
+
+    test("audio/l16 MIME type is also WAV-wrapped", async () => {
+      const { transcriber, calls } = createTranscriberWithMock([
+        { text: "l16 transcription" },
+        { text: "l16 transcription complete" },
+      ]);
+      const events = collectEvents(transcriber);
+
+      transcriber.sendAudio(Buffer.from("l16-audio-chunk"), "audio/l16");
+      await waitFor(() => events.some((e) => e.type === "partial"));
+
+      transcriber.stop();
+      await waitFor(() => events.some((e) => e.type === "closed"));
+
+      expect(calls.length).toBeGreaterThanOrEqual(1);
+      for (const call of calls) {
+        expect(call.mimeType).toBe("audio/wav");
+      }
+    });
+
+    test("non-PCM audio is passed through without WAV wrapping", async () => {
+      const { transcriber, calls } = createTranscriberWithMock([
+        { text: "webm transcription" },
+        { text: "webm transcription complete" },
+      ]);
+      const events = collectEvents(transcriber);
+
+      transcriber.sendAudio(Buffer.from("webm-audio-chunk"), "audio/webm");
+      await waitFor(() => events.some((e) => e.type === "partial"));
+
+      transcriber.stop();
+      await waitFor(() => events.some((e) => e.type === "closed"));
+
+      expect(calls.length).toBeGreaterThanOrEqual(1);
+      for (const call of calls) {
+        expect(call.mimeType).toBe("audio/webm");
+      }
+    });
+  });
+});

--- a/assistant/src/providers/speech-to-text/openai-whisper-stream.ts
+++ b/assistant/src/providers/speech-to-text/openai-whisper-stream.ts
@@ -1,0 +1,354 @@
+/**
+ * OpenAI Whisper incremental-batch streaming STT adapter.
+ *
+ * OpenAI Whisper does not expose a native WebSocket streaming transcription
+ * endpoint. This adapter approximates streaming by accumulating audio chunks
+ * and periodically submitting the accumulated buffer to the Whisper
+ * `/v1/audio/transcriptions` endpoint, then diffing the response against the
+ * previous transcript to emit stable partial updates.
+ *
+ * Key design decisions:
+ * - **Throttled polling**: A minimum interval (`POLL_INTERVAL_MS`) between
+ *   batch requests prevents excessive API calls while the user is speaking.
+ * - **Overlap/diff logic**: Each batch includes the full accumulated audio,
+ *   so the model sees complete context. The adapter compares each new
+ *   transcript against the last emitted partial to avoid sending duplicate
+ *   or regressive (flickering) text to the UI.
+ * - **Deterministic final**: On `stop()` the adapter sends one final batch
+ *   request with the complete audio and emits a `final` event followed by
+ *   `closed`, regardless of what partials were sent earlier.
+ * - **PCM-to-WAV transcoding**: When the incoming audio MIME type is
+ *   `audio/pcm`, accumulated PCM chunks are wrapped in a WAV container
+ *   via `encodePcm16LeToWav` before each Whisper request, since the
+ *   `/v1/audio/transcriptions` endpoint requires a supported container
+ *   format.
+ *
+ * Implements the {@link StreamingTranscriber} contract from `stt/types.ts`
+ * so the runtime session orchestrator can use it interchangeably with the
+ * Deepgram realtime-ws adapter and the Google Gemini incremental-batch adapter.
+ */
+
+import type {
+  StreamingTranscriber,
+  SttStreamServerEvent,
+} from "../../stt/types.js";
+import { encodePcm16LeToWav } from "../../stt/wav-encoder.js";
+import { getLogger } from "../../util/logger.js";
+import { whisperTranscribe } from "./openai-whisper.js";
+
+const log = getLogger("openai-whisper-stream");
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimum interval between incremental batch requests (ms).
+ * Prevents excessive API calls while the user is actively speaking.
+ */
+export const POLL_INTERVAL_MS = 1_000;
+
+/**
+ * Timeout per individual batch request (ms).
+ * Prevents a single slow request from blocking the streaming pipeline.
+ */
+const REQUEST_TIMEOUT_MS = 15_000;
+
+/**
+ * Default PCM sample rate when the streaming session does not explicitly
+ * provide format metadata. 16 kHz mono is the most common capture rate
+ * for browser-based microphone input sent as raw PCM.
+ */
+const DEFAULT_PCM_SAMPLE_RATE = 16_000;
+
+/**
+ * Default PCM channel count for WAV wrapping.
+ */
+const DEFAULT_PCM_CHANNELS = 1;
+
+// ---------------------------------------------------------------------------
+// Options
+// ---------------------------------------------------------------------------
+
+export interface OpenAIWhisperStreamOptions {
+  /** Override the poll interval for testing (default: POLL_INTERVAL_MS). */
+  pollIntervalMs?: number;
+  /** PCM sample rate in Hz when receiving `audio/pcm` input (default: 16000). */
+  pcmSampleRate?: number;
+  /** PCM channel count when receiving `audio/pcm` input (default: 1). */
+  pcmChannels?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Adapter
+// ---------------------------------------------------------------------------
+
+export class OpenAIWhisperStreamingTranscriber implements StreamingTranscriber {
+  readonly providerId = "openai-whisper" as const;
+  readonly boundaryId = "daemon-streaming" as const;
+
+  private readonly apiKey: string;
+  private readonly pollIntervalMs: number;
+  private readonly pcmSampleRate: number;
+  private readonly pcmChannels: number;
+
+  /** Accumulated audio chunks across the entire session. */
+  private audioChunks: Buffer[] = [];
+  /** MIME type of the accumulated audio (set on first audio chunk). */
+  private audioMimeType = "audio/webm";
+
+  /** The last partial transcript emitted to the client. */
+  private lastEmittedText = "";
+  /** Whether `start()` has been called and the session is active. */
+  private started = false;
+  /** Whether `stop()` has been called. */
+  private stopped = false;
+
+  /** Timer handle for the throttled polling loop. */
+  private pollTimer: ReturnType<typeof setTimeout> | null = null;
+  /** Timestamp of the last batch request completion. */
+  private lastPollTime = 0;
+  /** Whether a batch request is currently in flight. */
+  private polling = false;
+  /** Whether new audio has arrived since the last poll. */
+  private audioDirty = false;
+
+  /** Event callback registered via start(). */
+  private onEvent: ((event: SttStreamServerEvent) => void) | null = null;
+
+  constructor(apiKey: string, options: OpenAIWhisperStreamOptions = {}) {
+    this.apiKey = apiKey;
+    this.pollIntervalMs = options.pollIntervalMs ?? POLL_INTERVAL_MS;
+    this.pcmSampleRate = options.pcmSampleRate ?? DEFAULT_PCM_SAMPLE_RATE;
+    this.pcmChannels = options.pcmChannels ?? DEFAULT_PCM_CHANNELS;
+  }
+
+  // -----------------------------------------------------------------------
+  // StreamingTranscriber interface
+  // -----------------------------------------------------------------------
+
+  async start(onEvent: (event: SttStreamServerEvent) => void): Promise<void> {
+    if (this.started) {
+      throw new Error("OpenAIWhisperStreamingTranscriber: already started");
+    }
+    this.onEvent = onEvent;
+    this.started = true;
+
+    log.info(
+      { pollIntervalMs: this.pollIntervalMs },
+      "OpenAI Whisper streaming session started",
+    );
+  }
+
+  sendAudio(audio: Buffer, mimeType: string): void {
+    if (!this.started) {
+      throw new Error(
+        "OpenAIWhisperStreamingTranscriber: sendAudio called before start()",
+      );
+    }
+    if (this.stopped) return;
+
+    this.audioChunks.push(audio);
+    this.audioMimeType = mimeType;
+    this.audioDirty = true;
+
+    this.schedulePoll();
+  }
+
+  stop(): void {
+    if (this.stopped) return;
+    this.stopped = true;
+
+    log.info("Stopping OpenAI Whisper streaming session");
+
+    if (this.pollTimer) {
+      clearTimeout(this.pollTimer);
+      this.pollTimer = null;
+    }
+
+    // Fire the final batch asynchronously; the session stays open until
+    // the final event and closed event are emitted.
+    void this.emitFinal();
+  }
+
+  // -----------------------------------------------------------------------
+  // Internal polling
+  // -----------------------------------------------------------------------
+
+  /**
+   * Schedule the next poll if one is not already pending.
+   *
+   * Respects the minimum poll interval to avoid flooding the API.
+   */
+  private schedulePoll(): void {
+    if (this.pollTimer || this.stopped) return;
+
+    const elapsed = Date.now() - this.lastPollTime;
+    const delay = Math.max(0, this.pollIntervalMs - elapsed);
+
+    this.pollTimer = setTimeout(() => {
+      this.pollTimer = null;
+      void this.doPoll();
+    }, delay);
+  }
+
+  /**
+   * Execute a single incremental batch request and emit a partial event
+   * if the transcript has advanced.
+   */
+  private async doPoll(): Promise<void> {
+    if (this.stopped || this.polling || !this.audioDirty) return;
+
+    this.polling = true;
+    this.audioDirty = false;
+
+    log.debug(
+      { chunks: this.audioChunks.length },
+      "Executing incremental poll",
+    );
+
+    try {
+      const text = await this.transcribeAccumulated();
+
+      // Guard: if stop() was called while we were awaiting the API
+      // response, emitFinal() may have already sent final/closed.
+      // Emitting a partial after closed violates the streaming contract.
+      // However, preserve the transcribed text so the fallback final in
+      // emitFinal() uses the most up-to-date transcript if the final
+      // batch request fails.
+      if (this.stopped) {
+        if (text && text.length >= this.lastEmittedText.length) {
+          this.lastEmittedText = text;
+        }
+        return;
+      }
+
+      // Only emit a partial if the text has actually changed AND is
+      // a forward progression (longer or substantially different).
+      // This prevents flickering when the model returns a shorter
+      // intermediate result.
+      if (
+        text &&
+        text !== this.lastEmittedText &&
+        text.length >= this.lastEmittedText.length
+      ) {
+        this.lastEmittedText = text;
+        this.emit({ type: "partial", text });
+      }
+    } catch (err) {
+      // Transient errors during polling are non-fatal — the final
+      // request on stop() will capture the complete audio.
+      log.warn({ error: err }, "Incremental poll request failed");
+      if (!this.stopped) {
+        const message = err instanceof Error ? err.message : String(err);
+        this.emit({ type: "error", category: "provider-error", message });
+      }
+    } finally {
+      // Record poll completion time in both success and error paths so
+      // that throttling still applies when requests fail quickly —
+      // otherwise stale lastPollTime causes immediate retries on each
+      // sendAudio() call, producing request bursts.
+      this.lastPollTime = Date.now();
+      this.polling = false;
+    }
+
+    // If more audio arrived while we were polling, schedule again.
+    if (this.audioDirty && !this.stopped) {
+      this.schedulePoll();
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Final transcript
+  // -----------------------------------------------------------------------
+
+  /**
+   * Send the complete accumulated audio for a deterministic final
+   * transcript, then close the session.
+   */
+  private async emitFinal(): Promise<void> {
+    log.info(
+      { chunks: this.audioChunks.length },
+      "Sending final transcription request",
+    );
+
+    try {
+      if (this.audioChunks.length > 0) {
+        const text = await this.transcribeAccumulated();
+        log.info("Final transcription request complete");
+        this.emit({ type: "final", text: text || this.lastEmittedText });
+      } else {
+        // No audio was ever sent — emit empty final.
+        this.emit({ type: "final", text: this.lastEmittedText });
+      }
+    } catch (err) {
+      log.error({ error: err }, "Final transcription request failed");
+      const message = err instanceof Error ? err.message : String(err);
+      this.emit({ type: "error", category: "provider-error", message });
+      // Still emit a best-effort final from the last known partial.
+      this.emit({ type: "final", text: this.lastEmittedText });
+    } finally {
+      log.info("OpenAI Whisper streaming session closed");
+      this.emit({ type: "closed" });
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Batch transcription helper
+  // -----------------------------------------------------------------------
+
+  /**
+   * Concatenate all accumulated audio chunks and send a single batch
+   * request to the Whisper API.
+   *
+   * When the MIME type is `audio/pcm`, the raw PCM data is wrapped in a
+   * WAV container before submission since Whisper requires a supported
+   * container format.
+   */
+  private async transcribeAccumulated(): Promise<string> {
+    const rawAudio = Buffer.concat(this.audioChunks);
+    const rawMimeType = this.audioMimeType;
+
+    // PCM streaming input must be WAV-wrapped for Whisper compatibility.
+    const isPcm = this.isPcmMimeType(rawMimeType);
+    const audio = isPcm
+      ? encodePcm16LeToWav(rawAudio, {
+          sampleRate: this.pcmSampleRate,
+          channels: this.pcmChannels,
+        })
+      : rawAudio;
+    const mimeType = isPcm ? "audio/wav" : rawMimeType;
+
+    return whisperTranscribe(
+      this.apiKey,
+      audio,
+      mimeType,
+      AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    );
+  }
+
+  /**
+   * Check whether a MIME type represents raw PCM audio that needs
+   * container wrapping before Whisper can accept it.
+   */
+  private isPcmMimeType(mimeType: string): boolean {
+    const base = mimeType.split(";")[0].trim().toLowerCase();
+    return base === "audio/pcm" || base === "audio/l16";
+  }
+
+  // -----------------------------------------------------------------------
+  // Event emission
+  // -----------------------------------------------------------------------
+
+  private emit(event: SttStreamServerEvent): void {
+    if (!this.onEvent) return;
+    try {
+      this.onEvent(event);
+    } catch (err) {
+      log.warn(
+        { error: err },
+        "Listener error in OpenAI Whisper streaming adapter",
+      );
+    }
+  }
+}

--- a/assistant/src/providers/speech-to-text/openai-whisper-stream.ts
+++ b/assistant/src/providers/speech-to-text/openai-whisper-stream.ts
@@ -328,12 +328,17 @@ export class OpenAIWhisperStreamingTranscriber implements StreamingTranscriber {
   }
 
   /**
-   * Check whether a MIME type represents raw PCM audio that needs
+   * Check whether a MIME type represents raw PCM16LE audio that needs
    * container wrapping before Whisper can accept it.
+   *
+   * Only `audio/pcm` (little-endian by convention in this codebase) is
+   * accepted. `audio/l16` is intentionally excluded because it is
+   * big-endian per RFC 3551 and would require byte-swapping before
+   * WAV encoding.
    */
   private isPcmMimeType(mimeType: string): boolean {
     const base = mimeType.split(";")[0].trim().toLowerCase();
-    return base === "audio/pcm" || base === "audio/l16";
+    return base === "audio/pcm";
   }
 
   // -----------------------------------------------------------------------

--- a/assistant/src/providers/speech-to-text/openai-whisper.ts
+++ b/assistant/src/providers/speech-to-text/openai-whisper.ts
@@ -1,13 +1,13 @@
 import type { SttTranscribeResult } from "../../stt/types.js";
 
-const WHISPER_API_URL = "https://api.openai.com/v1/audio/transcriptions";
+export const WHISPER_API_URL = "https://api.openai.com/v1/audio/transcriptions";
 const DEFAULT_TIMEOUT_MS = 60_000;
 
 /**
  * Derive a filename extension from a MIME type so the Whisper API can detect
  * the audio format. Falls back to "audio" when the MIME type is unrecognised.
  */
-function extensionFromMime(mimeType: string): string {
+export function extensionFromMime(mimeType: string): string {
   const map: Record<string, string> = {
     "audio/wav": "wav",
     "audio/x-wav": "wav",
@@ -24,6 +24,62 @@ function extensionFromMime(mimeType: string): string {
   return map[base] ?? "audio";
 }
 
+/**
+ * Build a FormData payload for the Whisper `/v1/audio/transcriptions` endpoint.
+ *
+ * Shared between the batch provider and the streaming adapter to avoid
+ * duplicating request construction logic.
+ */
+export function buildWhisperFormData(
+  audio: Buffer,
+  mimeType: string,
+): FormData {
+  const ext = extensionFromMime(mimeType);
+
+  const formData = new FormData();
+  formData.append(
+    "file",
+    new Blob([new Uint8Array(audio)], { type: mimeType }),
+    `audio.${ext}`,
+  );
+  formData.append("model", "whisper-1");
+
+  return formData;
+}
+
+/**
+ * Send audio to the Whisper API and return the transcribed text.
+ *
+ * Shared helper used by both the batch provider and the streaming adapter.
+ */
+export async function whisperTranscribe(
+  apiKey: string,
+  audio: Buffer,
+  mimeType: string,
+  signal?: AbortSignal,
+): Promise<string> {
+  const formData = buildWhisperFormData(audio, mimeType);
+
+  const effectiveSignal = signal ?? AbortSignal.timeout(DEFAULT_TIMEOUT_MS);
+
+  const response = await fetch(WHISPER_API_URL, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${apiKey}` },
+    body: formData,
+    signal: effectiveSignal,
+  });
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => "");
+    throw new Error(
+      `Whisper API error (${response.status}): ${body.slice(0, 300)}`,
+    );
+  }
+
+  const result = (await response.json()) as { text?: string };
+  return result.text?.trim() ?? "";
+}
+
 export class OpenAIWhisperProvider {
   private readonly apiKey: string;
 
@@ -36,33 +92,7 @@ export class OpenAIWhisperProvider {
     mimeType: string,
     signal?: AbortSignal,
   ): Promise<SttTranscribeResult> {
-    const ext = extensionFromMime(mimeType);
-
-    const formData = new FormData();
-    formData.append(
-      "file",
-      new Blob([new Uint8Array(audio)], { type: mimeType }),
-      `audio.${ext}`,
-    );
-    formData.append("model", "whisper-1");
-
-    const effectiveSignal = signal ?? AbortSignal.timeout(DEFAULT_TIMEOUT_MS);
-
-    const response = await fetch(WHISPER_API_URL, {
-      method: "POST",
-      headers: { Authorization: `Bearer ${this.apiKey}` },
-      body: formData,
-      signal: effectiveSignal,
-    });
-
-    if (!response.ok) {
-      const body = await response.text().catch(() => "");
-      throw new Error(
-        `Whisper API error (${response.status}): ${body.slice(0, 300)}`,
-      );
-    }
-
-    const result = (await response.json()) as { text?: string };
-    return { text: result.text?.trim() ?? "" };
+    const text = await whisperTranscribe(this.apiKey, audio, mimeType, signal);
+    return { text };
   }
 }


### PR DESCRIPTION
## Summary
- Adds OpenAIWhisperStreamingTranscriber with incremental-batch semantics matching google-gemini pattern
- Converts PCM streaming input to WAV format using shared encoder before Whisper API calls
- Extracts shared Whisper request-building logic (extensionFromMime, buildWhisperFormData, whisperTranscribe) from openai-whisper.ts for reuse
- Comprehensive test coverage for lifecycle, partial progression, final flush, error handling, and PCM-to-WAV format path

Part of plan: openai-whisper-conversation-streaming.md (PR 2 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25412" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
