### PR TITLE
fix(home): self-review remediation (HIGH + MEDIUM gaps)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/HomeIdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeIdentityPanel.swift
@@ -91,7 +91,7 @@ struct HomeIdentityPanel: View {
             .frame(width: 140, height: 140)
             .accessibilityElement(children: .ignore)
             .accessibilityLabel(Text("Relationship progress"))
-            .accessibilityValue(Text("\(state.progressPercent) percent"))
+            .accessibilityValue(Text("\(min(max(state.progressPercent, 0), 100)) percent"))
             Spacer(minLength: 0)
         }
     }

--- a/clients/macos/vellum-assistant/Features/Home/HomeStore+SSE.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeStore+SSE.swift
@@ -12,11 +12,16 @@ extension HomeStore {
     ///
     /// Invoked from `HomeStore.init` — safe to call exactly once per store.
     func startListening() {
+        // Capture `messageStream` by value so the Task does NOT need to hold
+        // a reference to `self` for the lifetime of the loop. Each iteration
+        // re-acquires `self` weakly — if the store has been deallocated, the
+        // loop exits. This is what lets `deinit` actually fire and run its
+        // `sseTask?.cancel()` cleanup.
+        let stream = self.messageStream
         sseTask = Task { [weak self] in
-            guard let self else { return }
-            let stream = self.messageStream
             for await message in stream {
                 if Task.isCancelled { break }
+                guard let self else { break }
                 if case .relationshipStateUpdated = message {
                     // Refresh the cached state, then raise the unseen-changes
                     // dot if the user is currently somewhere other than the

--- a/clients/macos/vellum-assistant/Features/Home/HomeStore.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeStore.swift
@@ -46,6 +46,12 @@ public final class HomeStore {
     @ObservationIgnored var sseTask: Task<Void, Never>?
     @ObservationIgnored private var foregroundObserver: NSObjectProtocol?
 
+    /// Monotonically-increasing generation token bumped on every `load()`
+    /// entry. Used to discard out-of-order responses when concurrent
+    /// `load()` calls overlap (SSE handler + foreground observer +
+    /// HomePageView.task can all fire in the same tick).
+    @ObservationIgnored private var loadGeneration: UInt64 = 0
+
     // MARK: - Lifecycle
 
     public init(client: HomeStateClient, messageStream: AsyncStream<ServerMessage>) {
@@ -68,11 +74,27 @@ public final class HomeStore {
     ///
     /// Leaves `state` unchanged on failure so the UI keeps showing whatever
     /// we last successfully fetched. Errors are logged, never thrown out.
+    ///
+    /// Concurrent calls are guarded by `loadGeneration`: each call captures
+    /// its own generation token at entry, and only applies its result if it
+    /// is still the latest call when the network response lands. This makes
+    /// the SSE handler / foreground observer / HomePageView.task triple-fire
+    /// race safe — older responses are silently discarded instead of
+    /// overwriting newer state.
     public func load() async {
+        loadGeneration &+= 1
+        let myGeneration = loadGeneration
         isLoading = true
-        defer { isLoading = false }
+        defer {
+            // Only the latest in-flight call should clear `isLoading`.
+            if loadGeneration == myGeneration {
+                isLoading = false
+            }
+        }
         do {
             let next = try await client.fetchRelationshipState()
+            // Drop the result if a newer `load()` started while we awaited.
+            guard loadGeneration == myGeneration else { return }
             self.state = next
         } catch {
             log.error("HomeStore.load failed: \(error.localizedDescription)")

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -71,7 +71,7 @@ extension MainWindowView {
     @ViewBuilder
     var intelligenceUnseenChangesDot: some View {
         if assistantFeatureFlagStore.isEnabled("home-tab")
-            && homeStore.hasUnseenChanges
+            && (homeStore?.hasUnseenChanges ?? false)
             && windowState.selection != .panel(.intelligence) {
             Circle()
                 .fill(VColor.systemNegativeStrong)

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -81,10 +81,13 @@ struct MainWindowView: View {
     @State var assistantLoadingTimedOut = false
     /// Whether the main window is in native macOS fullscreen (traffic lights hidden).
     @State var isInFullscreen: Bool = false
-    /// Long-lived store for the Home page. Created once per MainWindowView so the
-    /// Home tab inside the Intelligence panel reuses a single subscription to the
-    /// event stream and keeps its cached relationship state across panel toggles.
-    @State var homeStore: HomeStore
+    /// Long-lived store for the Home page. Lazily constructed on first appear
+    /// when the `home-tab` feature flag is on, so flag-off users do NOT pay
+    /// for an SSE subscription, a foreground observer, or `/v1/home/state`
+    /// fetches. Stays `nil` for the lifetime of the window when the flag is
+    /// off; downstream consumers (IntelligencePanel, sidebar dot) gracefully
+    /// handle the nil case.
+    @State var homeStore: HomeStore?
     init(conversationManager: ConversationManager, appListManager: AppListManager, zoomManager: ZoomManager, traceStore: TraceStore, usageDashboardStore: UsageDashboardStore, connectionManager: GatewayConnectionManager, eventStreamClient: EventStreamClient, surfaceManager: SurfaceManager, ambientAgent: AmbientAgent, settingsStore: SettingsStore, authManager: AuthManager, windowState: MainWindowState, assistantFeatureFlagStore: AssistantFeatureFlagStore, documentManager: DocumentManager, onMicrophoneToggle: @escaping () -> Void = {}, voiceModeManager: VoiceModeManager, updateManager: UpdateManager, onSendWakeUp: (() -> Void)? = nil) {
         self.conversationManager = conversationManager
         self.appListManager = appListManager
@@ -108,14 +111,10 @@ struct MainWindowView: View {
         // Show skeleton loading only for normal launches (not post-onboarding where
         // ComingAliveOverlay handles the transition).
         self._showDaemonLoading = State(initialValue: onSendWakeUp == nil)
-        // Build the Home page store eagerly so the Intelligence panel's Home
-        // sub-tab has a stable subscription when the user opens it. The store
-        // is behind the `home-tab` feature flag — when the flag is off it's
-        // still constructed but never rendered.
-        self._homeStore = State(initialValue: HomeStore(
-            client: DefaultHomeStateClient(),
-            messageStream: eventStreamClient.subscribe()
-        ))
+        // Home store is built lazily on first appear (see `.task` below)
+        // and only when the `home-tab` flag is on, so flag-off users incur
+        // zero cost (no SSE subscription, no foreground observer, no fetch).
+        self._homeStore = State(initialValue: nil)
     }
 
     // MARK: - Layout Constants
@@ -271,6 +270,19 @@ struct MainWindowView: View {
                         }
                     })
                     .transition(.opacity)
+                }
+            }
+            .task {
+                // Lazily construct the Home store on first appear, gated on
+                // the `home-tab` flag. Flag-off users never pay for the SSE
+                // subscription, foreground observer, or fetch. Fires once
+                // because `MainWindowView` is the window's root view and is
+                // not torn down across re-renders.
+                if homeStore == nil && assistantFeatureFlagStore.isEnabled("home-tab") {
+                    homeStore = HomeStore(
+                        client: DefaultHomeStateClient(),
+                        messageStream: eventStreamClient.subscribe()
+                    )
                 }
             }
             .onChange(of: conversationManager.activeConversationId) { oldId, newId in

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -615,6 +615,9 @@ extension MainWindowView {
                 onStartConversation: {
                     startNewConversation()
                     windowState.dismissOverlay()
+                    if let id = conversationManager.activeConversationId {
+                        windowState.selection = .conversation(id)
+                    }
                 },
                 onCapabilityCTA: { capability in
                     let seed = CapabilityCTAContext.setupSeedMessage(for: capability, kind: .primary)


### PR DESCRIPTION
## Summary
Single fix commit addressing 6 gaps surfaced by the post-implementation self-review pass on the Phase 3 Home page feature branch.

## Fixes

1. **HomeStore retain cycle** (`HomeStore+SSE.swift`) — hoisted `messageStream` capture out of the Task and moved `guard let self else { break }` inside the `for await` loop. `sseTask` no longer pins the store, so `deinit` actually fires.
2. **`dismissOverlay()` clobbering selection** (`PanelCoordinator.swift`) — fullWindowPanel `onStartConversation` now re-sets `windowState.selection` after the dismiss, mirroring the sibling `onCreateSkill` / `onCapabilityCTA` pattern.
3. **HomeStore eager allocation + SSE active when flag is off** (`MainWindowView.swift`) — `homeStore` is now `@State HomeStore?` initialized to `nil`, lazily constructed in `.task` only when the `home-tab` flag is on. Flag-off users pay zero cost.
4. **HomeStore.load() race** (`HomeStore.swift`) — added a monotonic `loadGeneration` token. Concurrent calls (SSE + foreground observer + HomePageView.task) can no longer apply stale state out of order; older responses are silently dropped.
5. **progressPercent a11y clamp** (`HomeIdentityPanel.swift`) — VoiceOver value clamps to `0...100` so a server bug can't announce "105 percent" while the ring shows 100.
6. **Sidebar dot optional unwrap** (`MainWindowView+Sidebar.swift`) — `homeStore?.hasUnseenChanges ?? false` to handle the now-optional store.

## Out of scope (deferred LOW gaps)
- `.stroke` → `.strokeBorder` polish in `CapabilityRowView`
- `FactChipView` raw-literal `spacing` → `VSpacing.sm`
- `HomeIdentityPanel` docstring "Component Gallery" cleanup
- `IntelligencePanel.assistantFeatureFlagStore` `@ObservedObject` migration
- Default-tab logic only fires on first `IntelligencePanel` construction
- `HomeStore.deinit` Swift 6 future-proofing

These are tracked as follow-ups; none affect correctness or the user-visible flow.

Refs LUM-859
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25414" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
