### PR TITLE
Enable openai-whisper in daemon streaming resolver and provider catalog

### DIFF
--- a/assistant/src/__tests__/stt-stream-session.test.ts
+++ b/assistant/src/__tests__/stt-stream-session.test.ts
@@ -271,13 +271,13 @@ describe("SttStreamSession", () => {
     });
   });
 
-  // ── Unsupported provider (openai-whisper) ─────────────────────────
+  // ── Unsupported provider fallback ─────────────────────────────────
 
   describe("unsupported provider fallback", () => {
-    test("openai-whisper emits error + closed without crashing", async () => {
-      const { ws, session } = createSession("openai-whisper");
+    test("truly unknown provider emits error + closed without crashing", async () => {
+      const { ws, session } = createSession("nonexistent-provider");
 
-      // Resolve returns null for openai-whisper (no streaming support).
+      // Resolve returns null for unknown providers (no streaming support).
       await session.start(async () => null);
 
       const frames = ws.frames;
@@ -297,8 +297,8 @@ describe("SttStreamSession", () => {
       expect(ws.closeCode).toBe(1000);
     });
 
-    test("unknown provider emits error + closed without crashing", async () => {
-      const { ws, session } = createSession("nonexistent-provider");
+    test("another unknown provider emits error + closed without crashing", async () => {
+      const { ws, session } = createSession("fictional-stt-engine");
 
       await session.start(async () => null);
 

--- a/assistant/src/providers/speech-to-text/__tests__/provider-catalog.test.ts
+++ b/assistant/src/providers/speech-to-text/__tests__/provider-catalog.test.ts
@@ -97,10 +97,7 @@ describe("STT provider catalog", () => {
   test("supportsBoundary returns true for daemon-streaming on streaming-capable providers", () => {
     expect(supportsBoundary("deepgram", "daemon-streaming")).toBe(true);
     expect(supportsBoundary("google-gemini", "daemon-streaming")).toBe(true);
-  });
-
-  test("supportsBoundary returns false for daemon-streaming on non-streaming providers", () => {
-    expect(supportsBoundary("openai-whisper", "daemon-streaming")).toBe(false);
+    expect(supportsBoundary("openai-whisper", "daemon-streaming")).toBe(true);
   });
 
   test("supportsBoundary returns false for unknown provider IDs", () => {
@@ -133,9 +130,9 @@ describe("STT provider catalog", () => {
     expect(entry?.conversationStreamingMode).toBe("incremental-batch");
   });
 
-  test("openai-whisper has no conversation streaming support", () => {
+  test("openai-whisper has incremental-batch conversation streaming mode", () => {
     const entry = getProviderEntry("openai-whisper");
-    expect(entry?.conversationStreamingMode).toBe("none");
+    expect(entry?.conversationStreamingMode).toBe("incremental-batch");
   });
 
   // -----------------------------------------------------------------------

--- a/assistant/src/providers/speech-to-text/__tests__/resolve.test.ts
+++ b/assistant/src/providers/speech-to-text/__tests__/resolve.test.ts
@@ -561,22 +561,33 @@ describe("resolveConversationStreamingSttCapability", () => {
   });
 
   // -------------------------------------------------------------------------
-  // OpenAI Whisper — no streaming support
+  // OpenAI Whisper — incremental-batch streaming
   // -------------------------------------------------------------------------
 
-  test("returns 'unsupported' for openai-whisper (no conversation streaming)", async () => {
+  test("returns 'supported' with incremental-batch mode for openai-whisper", async () => {
     mockProviderKeys["openai"] = "sk-stream-test";
     mockConfig = buildConfig({ provider: "openai-whisper" });
 
     const result = await resolveConversationStreamingSttCapability();
 
-    expect(result.status).toBe("unsupported");
-    if (result.status === "unsupported") {
+    expect(result.status).toBe("supported");
+    if (result.status === "supported") {
       expect(result.providerId).toBe("openai-whisper");
-      expect(result.reason).toContain("openai-whisper");
-      expect(result.reason).toContain(
-        "does not support conversation streaming",
-      );
+      expect(result.streamingMode).toBe("incremental-batch");
+    }
+  });
+
+  test("returns 'missing-credentials' for openai-whisper without an API key", async () => {
+    mockProviderKeys = {};
+    mockConfig = buildConfig({ provider: "openai-whisper" });
+
+    const result = await resolveConversationStreamingSttCapability();
+
+    expect(result.status).toBe("missing-credentials");
+    if (result.status === "missing-credentials") {
+      expect(result.providerId).toBe("openai-whisper");
+      expect(result.credentialProvider).toBe("openai");
+      expect(result.reason).toContain("openai");
     }
   });
 

--- a/assistant/src/providers/speech-to-text/provider-catalog.ts
+++ b/assistant/src/providers/speech-to-text/provider-catalog.ts
@@ -152,9 +152,12 @@ const CATALOG: ReadonlyMap<SttProviderId, SttProviderEntry> = new Map<
     {
       id: "openai-whisper",
       credentialProvider: "openai",
-      supportedBoundaries: new Set<SttBoundaryId>(["daemon-batch"]),
+      supportedBoundaries: new Set<SttBoundaryId>([
+        "daemon-batch",
+        "daemon-streaming",
+      ]),
       telephonyMode: "batch-only",
-      conversationStreamingMode: "none",
+      conversationStreamingMode: "incremental-batch",
       telephonyRouting: {
         strategyKind: "media-stream-custom",
       },

--- a/assistant/src/providers/speech-to-text/resolve.ts
+++ b/assistant/src/providers/speech-to-text/resolve.ts
@@ -317,9 +317,13 @@ async function createStreamingTranscriber(
         await import("./google-gemini-stream.js");
       return new GoogleGeminiStreamingTranscriber(apiKey);
     }
-    case "openai-whisper":
-      // Whisper does not support streaming.
-      return null;
+    case "openai-whisper": {
+      const { OpenAIWhisperStreamingTranscriber } =
+        await import("./openai-whisper-stream.js");
+      return new OpenAIWhisperStreamingTranscriber(apiKey, {
+        pcmSampleRate: options.sampleRate,
+      });
+    }
     default: {
       const _exhaustive: never = providerId;
       return null;

--- a/meta/stt-provider-catalog.json
+++ b/meta/stt-provider-catalog.json
@@ -8,7 +8,7 @@
       "setupMode": "api-key",
       "setupHint": "Enter your OpenAI API key to enable Whisper transcription.",
       "apiKeyProviderName": "openai",
-      "conversationStreamingMode": "none"
+      "conversationStreamingMode": "incremental-batch"
     },
     {
       "id": "deepgram",


### PR DESCRIPTION
## Summary
- Updates openai-whisper catalog entry to support daemon-streaming boundary with incremental-batch mode
- Wires OpenAIWhisperStreamingTranscriber into the streaming resolver
- Updates provider-catalog, resolver, and session tests for streaming capability

Part of plan: openai-whisper-conversation-streaming.md (PR 3 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25417" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
