### PR TITLE
Update client STT catalog and registry to allow openai-whisper streaming

### DIFF
--- a/clients/ios/Tests/InputBarVoiceInputTests.swift
+++ b/clients/ios/Tests/InputBarVoiceInputTests.swift
@@ -796,13 +796,19 @@ final class InputBarVoiceInputTests: XCTestCase {
         XCTAssertTrue(STTProviderRegistry.isStreamingAvailable,
                       "Google Gemini should support conversation streaming")
         UserDefaults.standard.removeObject(forKey: "sttProvider")
+
+        // openai-whisper supports incremental-batch streaming
+        UserDefaults.standard.set("openai-whisper", forKey: "sttProvider")
+        XCTAssertTrue(STTProviderRegistry.isStreamingAvailable,
+                      "OpenAI Whisper should support conversation streaming")
+        UserDefaults.standard.removeObject(forKey: "sttProvider")
     }
 
     func testStreamingAvailabilityForUnsupportedProviders() {
-        // openai-whisper has conversationStreamingMode = .none
-        UserDefaults.standard.set("openai-whisper", forKey: "sttProvider")
+        // Unknown/nonexistent providers should not support streaming
+        UserDefaults.standard.set("nonexistent-provider", forKey: "sttProvider")
         XCTAssertFalse(STTProviderRegistry.isStreamingAvailable,
-                       "OpenAI Whisper should not support conversation streaming")
+                       "Unknown providers should not support conversation streaming")
         UserDefaults.standard.removeObject(forKey: "sttProvider")
     }
 

--- a/clients/shared/Tests/STTStreamingClientTests.swift
+++ b/clients/shared/Tests/STTStreamingClientTests.swift
@@ -213,10 +213,10 @@ final class STTStreamingClientTests: XCTestCase {
         XCTAssertEqual(registry.conversationStreamingMode(forProvider: "google-gemini"), .incrementalBatch)
     }
 
-    func testOpenAIWhisperDoesNotSupportConversationStreaming() {
+    func testOpenAIWhisperSupportsConversationStreaming() {
         let registry = buildTestRegistry()
-        XCTAssertFalse(registry.supportsConversationStreaming(provider: "openai-whisper"))
-        XCTAssertEqual(registry.conversationStreamingMode(forProvider: "openai-whisper"), .none)
+        XCTAssertTrue(registry.supportsConversationStreaming(provider: "openai-whisper"))
+        XCTAssertEqual(registry.conversationStreamingMode(forProvider: "openai-whisper"), .incrementalBatch)
     }
 
     func testUnknownProviderDoesNotSupportConversationStreaming() {
@@ -277,7 +277,7 @@ final class STTStreamingClientTests: XCTestCase {
                     "setupMode": "api-key",
                     "setupHint": "test",
                     "apiKeyProviderName": "openai",
-                    "conversationStreamingMode": "none"
+                    "conversationStreamingMode": "incremental-batch"
                 },
                 {
                     "id": "deepgram",
@@ -294,7 +294,7 @@ final class STTStreamingClientTests: XCTestCase {
         let catalog = try JSONDecoder().decode(STTProviderRegistry.self, from: json.data(using: .utf8)!)
         XCTAssertEqual(catalog.version, 2)
         XCTAssertEqual(catalog.providers.count, 2)
-        XCTAssertEqual(catalog.providers[0].conversationStreamingMode, .none)
+        XCTAssertEqual(catalog.providers[0].conversationStreamingMode, .incrementalBatch)
         XCTAssertEqual(catalog.providers[1].conversationStreamingMode, .realtimeWs)
     }
 
@@ -312,7 +312,7 @@ final class STTStreamingClientTests: XCTestCase {
                     setupMode: .apiKey,
                     setupHint: "test",
                     apiKeyProviderName: "openai",
-                    conversationStreamingMode: .none
+                    conversationStreamingMode: .incrementalBatch
                 ),
                 STTProviderCatalogEntry(
                     id: "deepgram",

--- a/clients/shared/Utilities/STTProviderRegistry.swift
+++ b/clients/shared/Utilities/STTProviderRegistry.swift
@@ -163,7 +163,7 @@ private let fallbackRegistry = STTProviderRegistry(
             setupMode: .apiKey,
             setupHint: "Enter your OpenAI API key to enable Whisper transcription.",
             apiKeyProviderName: "openai",
-            conversationStreamingMode: .none
+            conversationStreamingMode: .incrementalBatch
         ),
         STTProviderCatalogEntry(
             id: "deepgram",


### PR DESCRIPTION
## Summary
- Updates STTProviderRegistry fallback to use incrementalBatch mode for openai-whisper
- Updates Swift test expectations for openai-whisper streaming support
- Verifies daemon/client catalog parity

Part of plan: openai-whisper-conversation-streaming.md (PR 4 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25418" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
