### PR TITLE
fix: update stale streaming provider references

### DIFF
--- a/assistant/src/__tests__/stt-stream-session.test.ts
+++ b/assistant/src/__tests__/stt-stream-session.test.ts
@@ -6,7 +6,7 @@
  *   streaming adapters.
  * - Normalized event flow: ready -> partial -> final -> closed.
  * - Per-session ordering guarantees (monotonic `seq` field).
- * - Graceful handling of unsupported providers (e.g. openai-whisper).
+ * - Graceful handling of unsupported providers.
  * - Session teardown on client disconnect.
  * - Idle timeout behavior.
  * - Binary audio frame handling.

--- a/assistant/src/stt/stt-stream-session.ts
+++ b/assistant/src/stt/stt-stream-session.ts
@@ -175,7 +175,7 @@ export class SttStreamSession {
         this.sendEvent({
           type: "error",
           category: "provider-error",
-          message: `Streaming transcription is not supported for provider "${this.provider}". Supported providers: deepgram, google-gemini.`,
+          message: `Streaming transcription is not supported for provider "${this.provider}". Supported providers: deepgram, google-gemini, openai-whisper.`,
         });
         this.sendEvent({ type: "closed" });
         this.state = "closed";


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for openai-whisper-conversation-streaming.md.

**Gap 1:** Stale error message in stt-stream-session.ts listing only deepgram and google-gemini
**Gap 2:** Stale comment in stt-stream-session.test.ts mentioning openai-whisper as unsupported
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25419" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
