### PR TITLE
feat(macos): add mute/unmute sound effects to menu bar dropdown

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -467,6 +467,13 @@ extension AppDelegate {
             restartItem.image = VIcon.refreshCw.nsImage(size: 16)
             menu.addItem(restartItem)
 
+            let soundsEnabled = SoundManager.shared.config.globalEnabled
+            let muteTitle = soundsEnabled ? "Mute Sound Effects" : "Unmute Sound Effects"
+            let muteItem = NSMenuItem(title: muteTitle, action: #selector(toggleSoundEffectsMute), keyEquivalent: "")
+            muteItem.target = self
+            muteItem.image = VIcon.volume2.nsImage(size: 16)
+            menu.addItem(muteItem)
+
             menu.addItem(NSMenuItem.separator())
 
             let feedbackItem = NSMenuItem(title: "Share Feedback", action: #selector(sendFeedback), keyEquivalent: "")
@@ -606,6 +613,12 @@ extension AppDelegate {
         }
         // Local topology: use Sparkle
         updateManager.checkForUpdates()
+    }
+
+    @objc func toggleSoundEffectsMute() {
+        var updated = SoundManager.shared.config
+        updated.globalEnabled.toggle()
+        SoundManager.shared.saveConfig(updated)
     }
 
     @objc func openAppById(_ sender: NSMenuItem) {


### PR DESCRIPTION
## Summary
- Add a 'Mute Sound Effects' / 'Unmute Sound Effects' item to the status bar menu, placed in the settings cluster next to Restart.
- Toggles `SoundManager.shared.config.globalEnabled` via the existing `saveConfig()` path, so the Settings > Sounds toggle stays in sync automatically (SoundManager is `@MainActor @Observable`).
- Menu is rebuilt on every open, so the title always reflects current mute state without needing any delegate callbacks.

## Original prompt
it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25421" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
