### PR TITLE
Fix linear-ticket-reminder hook path resolution

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/linear-ticket-reminder.sh"
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/linear-ticket-reminder.sh"
           }
         ]
       }


### PR DESCRIPTION
## Summary
- Replace relative path `.claude/hooks/linear-ticket-reminder.sh` with `$CLAUDE_PROJECT_DIR/.claude/hooks/linear-ticket-reminder.sh` in the project-level UserPromptSubmit hook
- Fixes 'UserPromptSubmit hook error: /bin/sh: .claude/hooks/linear-ticket-reminder.sh: No such file or directory' that fired on every message when Claude Code's shell CWD wasn't the project root