### PR TITLE
fix(assistant): forward CES child stderr to the daemon logger

### DIFF
--- a/assistant/src/credential-execution/process-manager.ts
+++ b/assistant/src/credential-execution/process-manager.ts
@@ -240,7 +240,7 @@ export function createCesProcessManager(
       cmd: [discovery.executablePath],
       stdin: "pipe",
       stdout: "pipe",
-      stderr: "ignore",
+      stderr: "pipe",
       env: {
         ...process.env,
         // Signal to CES that it was launched by the assistant
@@ -251,6 +251,7 @@ export function createCesProcessManager(
     childProcess = proc;
 
     log.info({ pid: proc.pid }, "CES child process started");
+    forwardStderrToLogger(proc);
 
     return createStdioTransport(proc);
   }
@@ -272,7 +273,7 @@ export function createCesProcessManager(
       cmd: [bunPath, "run", discovery.sourcePath],
       stdin: "pipe",
       stdout: "pipe",
-      stderr: "ignore",
+      stderr: "pipe",
       env: {
         ...process.env,
         // Signal to CES that it was launched by the assistant
@@ -283,6 +284,7 @@ export function createCesProcessManager(
     childProcess = proc;
 
     log.info({ pid: proc.pid }, "CES child process started (from source)");
+    forwardStderrToLogger(proc);
 
     return createStdioTransport(proc);
   }
@@ -441,6 +443,35 @@ function createSocketTransport(socket: Socket): CesTransport {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+function forwardStderrToLogger(proc: Subprocess): void {
+  if (!proc.stderr || typeof proc.stderr === "number") return;
+
+  const reader = proc.stderr.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  void (async () => {
+    try {
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        let newlineIdx: number;
+        while ((newlineIdx = buffer.indexOf("\n")) !== -1) {
+          const line = buffer.slice(0, newlineIdx).trimEnd();
+          buffer = buffer.slice(newlineIdx + 1);
+          if (line) log.error({ pid: proc.pid }, `[ces-stderr] ${line}`);
+        }
+      }
+      const trailing = buffer.trimEnd();
+      if (trailing) log.error({ pid: proc.pid }, `[ces-stderr] ${trailing}`);
+    } catch {
+      // Process ended or stream closed; nothing to forward.
+    }
+  })();
+}
 
 async function stopLocalProcess(proc: Subprocess): Promise<void> {
   log.info({ pid: proc.pid }, "Stopping CES child process");


### PR DESCRIPTION
## Summary
- CES child processes spawned from the assistant had `stderr: "ignore"`, so a fatal error on CES startup (e.g. a missing `pino` dep after a `package.json` change without a re-run of `bun install`) surfaced only as an opaque retry loop logging "CES child process stopped". The daemon kept retrying CES forever while the HTTP server stayed stuck at 502 with nothing in the logs.
- Changes both `startLocalProcess` and `startLocalSourceProcess` in `assistant/src/credential-execution/process-manager.ts` to `stderr: "pipe"` and adds a `forwardStderrToLogger` helper that reads stderr line-by-line (mirroring the stdout reader in `createStdioTransport`) and forwards each line to the module logger at error level, prefixed with `[ces-stderr]` and tagged with the child PID.
- Scope-limited: no behavioural changes to stdout handling, transport lifecycle, or managed-socket mode.

## Original prompt
Pipe CES child process stderr to the daemon logger instead of dropping it.

Context: When CES crashes on startup (e.g. missing npm dep like pino), the daemon silently loops retrying because CES stderr is discarded. This turned a trivial "missing module" error into a long debugging session where the daemon just logged "CES child process stopped" over and over with no actual error visible.

Locations: `assistant/src/credential-execution/process-manager.ts` lines 243 and 275 — both set `stderr: "ignore"` on `Bun.spawn`. Change to `"pipe"` and forward each stderr line to the daemon logger (via `log.error` or `log.warn` with a `[ces-stderr]` prefix or tagged logger). Handle both `startLocalProcess` and `startLocalSourceProcess`.

The stderr stream on a Bun subprocess is a ReadableStream when piped. Read it similarly to how stdout is read in `createStdioTransport` (line-buffered), but route lines to the logger instead of message handlers.

Keep scope minimal — just the stderr plumbing, no other refactors.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25424" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
