### PR TITLE
fix(macos): guard SSE task against superseded session on MainActor race

### DIFF
--- a/clients/shared/Network/EventStreamClient.swift
+++ b/clients/shared/Network/EventStreamClient.swift
@@ -277,6 +277,15 @@ public final class EventStreamClient {
         sseTask = Task { @MainActor [weak self] in
             guard let self else { return }
 
+            // A back-to-back call to `startSSEStream()` on the MainActor can
+            // cancel this task and invalidate `session` before it runs its
+            // first instruction. Calling `session.bytes(for:)` on an already
+            // invalidated session throws an ObjC NSGenericException from
+            // `-[__NSURLSessionLocal taskForClassInfo:]`, which is
+            // uncatchable in Swift and crashes the process with SIGABRT.
+            // Bail out before touching the session if we've been superseded.
+            guard !Task.isCancelled, self.sseSession === session else { return }
+
             do {
                 let (bytes, response) = try await GatewayHTTPClient.stream(
                     path: "assistants/{assistantId}/events",


### PR DESCRIPTION
## Summary
- #25396 made each SSE connection own a dedicated `URLSession` and invalidates the previous session at the top of `startSSEStream()`. That fixed an iterator-vs-invalidation EXC_BAD_ACCESS, but introduced a new crash: when `startSSEStream()` is called twice in rapid succession on MainActor (which happens on boot — `MainWindowView+Lifecycle` and `GatewayConnectionManager` both call `startSSE`), the second call invalidates the session and cancels the prior task before that task has run its first instruction. When the cancelled task finally runs and calls `session.bytes(for:)`, NSURLSession throws an uncatchable ObjC `NSGenericException` from `-[__NSURLSessionLocal taskForClassInfo:]`, aborting the process (SIGABRT).
- Adds a `guard !Task.isCancelled, self.sseSession === session else { return }` at the top of the SSE task body in `EventStreamClient.startSSEStream`, so a superseded task exits cleanly instead of invoking `bytes(for:)` on an invalidated session.
- Scope-limited: no change to the session creation, invalidation order, reconnect logic, or call sites.

## Original prompt
it