### PR TITLE
chore(githooks): auto-run bun install on pull/checkout when manifests change

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -66,3 +66,20 @@ Runs before pushing to catch issues that would fail CI.
 ```bash
 git push --no-verify
 ```
+
+### post-merge & post-checkout
+
+Re-runs `bun install` at the repo root when any `package.json` or `bun.lock`
+changed in the commits pulled in by `git pull` / `git checkout` / `git switch`.
+Prevents stale `node_modules` after a branch switch or pull that adds a new
+dependency — the failure mode looks like a silent `Cannot find package 'X'`
+at runtime.
+
+**Behavior:**
+
+- Diffs the pre- and post-HEAD using git (no filesystem scan); silent no-op when no manifest file changed.
+- Runs `bun install` from the repo root when any match is found.
+- Warns and exits 0 if `bun` is not on PATH — never fails `git pull` / `git checkout`.
+- Shared helper: `.githooks/bun-install-if-deps-changed.sh`.
+
+**Bypass:** these hooks are best-effort and cannot fail the pull/checkout. If you need to suppress the install, unset `core.hooksPath` or delete the hook file locally.

--- a/.githooks/bun-install-if-deps-changed.sh
+++ b/.githooks/bun-install-if-deps-changed.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# Re-run `bun install` at the repo root when any `package.json` or `bun.lock`
+# changed between two git revisions. Meant to be invoked by `post-merge` and
+# `post-checkout` hooks so a `git pull` / branch switch that adds a new
+# dependency does not leave `node_modules` stale.
+#
+# Usage: bun-install-if-deps-changed.sh <OLD_SHA> <NEW_SHA>
+#
+# Silent no-op when OLD == NEW or when no dep-tracking file changed.
+# Emits a warning (and exits 0) when `bun` is not on PATH so `git pull`
+# never fails because of this hook.
+
+set -u
+
+OLD="${1:-}"
+NEW="${2:-}"
+
+if [ -z "$OLD" ] || [ -z "$NEW" ] || [ "$OLD" = "$NEW" ]; then
+    exit 0
+fi
+
+# Handle the null SHA git passes for post-checkout when a branch is created
+# from an unborn HEAD. Nothing to compare against.
+NULL_SHA="0000000000000000000000000000000000000000"
+if [ "$OLD" = "$NULL_SHA" ] || [ "$NEW" = "$NULL_SHA" ]; then
+    exit 0
+fi
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
+if [ -z "$REPO_ROOT" ]; then
+    exit 0
+fi
+
+# List changed paths; bail quietly if git can't produce a diff for this range
+# (e.g. one side is unknown to this worktree).
+changed="$(git diff --name-only "$OLD" "$NEW" -- 2>/dev/null || true)"
+if [ -z "$changed" ]; then
+    exit 0
+fi
+
+if ! printf '%s\n' "$changed" | grep -Eq '(^|/)(package\.json|bun\.lock)$'; then
+    exit 0
+fi
+
+if ! command -v bun >/dev/null 2>&1; then
+    echo "[git-hook] package.json/bun.lock changed but 'bun' is not on PATH — skipping bun install." >&2
+    echo "[git-hook] Run 'bun install' manually once bun is available." >&2
+    exit 0
+fi
+
+echo "[git-hook] Dependency manifest changed — running 'bun install' at $REPO_ROOT..." >&2
+( cd "$REPO_ROOT" && bun install ) || {
+    status=$?
+    echo "[git-hook] 'bun install' exited with status $status. Run it manually to investigate." >&2
+    exit 0
+}

--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#
+# post-checkout — fires after `git checkout` and `git switch`. Re-runs
+# `bun install` when a `package.json` or `bun.lock` changed between the
+# previous HEAD and the new HEAD.
+#
+# Arguments from git:
+#   $1 = ref of the previous HEAD
+#   $2 = ref of the new HEAD
+#   $3 = flag: 1 for branch/worktree checkout, 0 for file-only checkout
+#
+# We only run on branch/worktree checkouts — file-only checkouts do not
+# change committed manifests.
+
+set -u
+
+PREV_HEAD="${1:-}"
+NEW_HEAD="${2:-}"
+FLAG="${3:-0}"
+
+if [ "$FLAG" != "1" ]; then
+    exit 0
+fi
+
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+"$HOOK_DIR/bun-install-if-deps-changed.sh" "$PREV_HEAD" "$NEW_HEAD"

--- a/.githooks/post-merge
+++ b/.githooks/post-merge
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+#
+# post-merge — fires after `git merge` (including the merge that `git pull`
+# runs). Re-runs `bun install` when a `package.json` or `bun.lock` changed
+# between `ORIG_HEAD` (pre-merge tip) and `HEAD` (post-merge tip).
+#
+# Argument from git: $1 = squash-flag (1 if `--squash`, 0 otherwise).
+# We don't care about it — we always diff ORIG_HEAD..HEAD.
+
+set -u
+
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+"$HOOK_DIR/bun-install-if-deps-changed.sh" "${ORIG_HEAD:-$(git rev-parse ORIG_HEAD 2>/dev/null || echo)}" "$(git rev-parse HEAD 2>/dev/null || echo)"


### PR DESCRIPTION
## Summary
- Adds `.githooks/post-merge` and `.githooks/post-checkout` hooks plus a shared `.githooks/bun-install-if-deps-changed.sh` helper. The helper diffs the pre- and post-HEAD SHAs and runs `bun install` at the repo root if any `package.json` or `bun.lock` changed. Prevents the stale-`node_modules` failure mode where a `git pull` that adds a new dep (e.g. `pino` in `credential-executor/`) produces silent runtime errors — we just got bitten by this on the CES child process.
- Fast and idempotent: no-op when no manifest file changed (pure git diff, no filesystem scan), and silently no-op on `ORIG_HEAD == HEAD` or null SHAs. Post-checkout only runs for branch/worktree checkouts (`$3 == 1`), not file-only checkouts.
- Safe failure mode: if `bun` is not on PATH, the hook prints a warning and exits 0, so `git pull` / `git checkout` never fails because of it. Hooks are wired via `core.hooksPath=.githooks`, which is already set by the `postinstall` script in `assistant/` and `gateway/` `package.json`, so every contributor picks this up the next time they run `bun install`.

## Original prompt
Add a post-merge and post-checkout git hook that re-runs `bun install` whenever a `package.json` or any `bun.lock` file changes between the old and new revisions.

Context: This repo is a Bun monorepo with multiple packages under `assistant/`, `cli/`, `gateway/`, `packages/*`, `credential-executor/`. Each may have its own `package.json` and `bun.lock`. When someone pulls a change that adds a new dependency (e.g. `pino` in `credential-executor/`), a stale `node_modules/` produces silent-looking runtime failures (e.g. `Cannot find package 'pino'`). We just got bitten by exactly this.

Goal: on `git pull` / `git checkout`, if any `package.json` or `bun.lock` under the repo has changed between the previous and new HEAD, automatically run `bun install` from the repo root so `node_modules` stays in sync. Should be idempotent and fast (no-op when nothing changed).

Keep scope minimal: post-merge hook, post-checkout hook, shared helper. No other automation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25427" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
