### PR TITLE
fix(macos): center the read-only conversation indicator

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -453,6 +453,7 @@ struct ChatView: View {
             if isReadonly {
                 centeredChatColumn(width: layoutMetrics.chatColumnWidth) {
                     HStack(spacing: VSpacing.xs) {
+                        Spacer(minLength: 0)
                         VIconView(.eye, size: 14)
                         Text("Read-only conversation")
                             .font(VFont.bodySmallDefault)


### PR DESCRIPTION
## Summary
- The \"Read-only conversation\" footer (eye icon + label) in \`ChatView\` was left-aligned inside the centered chat column because its \`HStack\` only had a trailing \`Spacer(minLength: 0)\`.
- Added a matching leading \`Spacer(minLength: 0)\` so the icon + label are horizontally centered within the chat column, matching where the composer sits in editable conversations.

## Original prompt
it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25428" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
