### PR TITLE
fix(sounds): skip turnCompletionTick bump on auxiliary message_complete

### DIFF
--- a/clients/shared/Features/Chat/ChatActionHandler.swift
+++ b/clients/shared/Features/Chat/ChatActionHandler.swift
@@ -571,8 +571,10 @@ final class ChatActionHandler {
         }
         // Signal turn completion to observers (e.g. the `task_complete` sound).
         // Cancel-acknowledgements are user-initiated aborts, not real turn ends,
-        // so they stay silent.
-        if !wasCancelAck {
+        // so they stay silent. Auxiliary `message_complete` events (call
+        // transcript updates, summaries, watch notifiers) lack a `messageId`
+        // and must not be counted as turn ends.
+        if !wasCancelAck && complete.messageId != nil {
             vm.messageManager.turnCompletionTick &+= 1
         }
     }


### PR DESCRIPTION
Auxiliary message_complete events (call transcript, summary, watch notifiers from conversation-notifiers.ts) have no messageId and don't represent main-turn completions. The existing early-return filter in handleMessageComplete only skipped these while a main turn was streaming; when the main agent was idle, they passed through and incremented turnCompletionTick, firing task_complete on every aux event. Gate the tick bump on messageId != nil so only real main-turn completions count. Follow-up to #25389.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25429" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
