### PR TITLE
fix(sounds): tie broadcast suppression to in-flight saves instead of a 2s window

### DIFF
--- a/clients/macos/vellum-assistant/Features/Sounds/SoundManager.swift
+++ b/clients/macos/vellum-assistant/Features/Sounds/SoundManager.swift
@@ -39,18 +39,29 @@ final class SoundManager {
     /// that hammers the workspace/tree API with 429s.
     @ObservationIgnored private var isRefreshingAvailableSounds = false
 
-    /// Timestamp of the most recent `saveConfig(_:)` call. The daemon watches
-    /// `data/sounds/` and broadcasts `soundsConfigUpdated` after any write,
-    /// including our own — refetching while writes are still in flight can
-    /// read a truncated payload and clobber local state with `.defaultConfig`.
-    /// `handleSoundsConfigBroadcast()` uses this to drop self-echo broadcasts.
-    @ObservationIgnored private var lastLocalSaveAt: Date?
+    /// Number of `saveConfig(_:)` writes currently in flight. The daemon
+    /// watches `data/sounds/` and broadcasts `soundsConfigUpdated` after any
+    /// write, including our own — refetching while writes are still in flight
+    /// can read a truncated payload and clobber local state with
+    /// `.defaultConfig`. `handleSoundsConfigBroadcast()` drops broadcasts
+    /// while this is non-zero. A counter (not a bool) correctly handles
+    /// overlapping saves from e.g. rapid slider drags.
+    @ObservationIgnored private var inFlightSaveCount: Int = 0
 
-    /// Window during which an inbound `soundsConfigUpdated` broadcast is
-    /// treated as an echo of a recent local save and skipped. Covers the
-    /// daemon's 200 ms watcher debounce plus broadcast delivery, with
-    /// headroom.
-    private static let echoSuppressionWindow: TimeInterval = 2.0
+    /// Timestamp of the most recent `saveConfig(_:)` completion (success or
+    /// failure). `handleSoundsConfigBroadcast()` also suppresses broadcasts
+    /// within a short grace window after this stamp to cover the daemon's
+    /// 200 ms watcher debounce plus broadcast delivery latency after the
+    /// final save settles. Outside this window, legitimate non-echo
+    /// broadcasts (e.g. sound file additions or edits from another client)
+    /// are processed normally.
+    @ObservationIgnored private var lastSaveCompletedAt: Date?
+
+    /// Grace window after the last save completes during which broadcasts
+    /// are still treated as potential self-echoes. Sized to cover the
+    /// daemon's 200 ms watcher debounce plus broadcast delivery slack,
+    /// without significantly delaying legitimate cross-client updates.
+    private static let postSaveGraceWindow: TimeInterval = 0.5
 
     /// Whether a valid config has ever been decoded from disk. While `false`,
     /// fetch failures fall back to `.defaultConfig` so first-run (no file
@@ -154,13 +165,19 @@ final class SoundManager {
     }
 
     /// Handles a `soundsConfigUpdated` broadcast from the daemon. Drops
-    /// broadcasts that fall within the echo-suppression window of a recent
-    /// local save — those are the daemon echoing our own write, and
-    /// refetching would race against in-flight writes and briefly overwrite
-    /// the UI with `.defaultConfig` (globalEnabled=false, empty pools).
+    /// broadcasts while a local save is in flight, or within a short grace
+    /// window after the last save completes — those are the daemon echoing
+    /// our own write, and refetching would race against in-flight writes and
+    /// briefly overwrite the UI with `.defaultConfig` (globalEnabled=false,
+    /// empty pools). Outside those conditions the broadcast is treated as a
+    /// legitimate non-echo update (e.g. sound file additions or edits from
+    /// another client) and triggers a reload.
     func handleSoundsConfigBroadcast() {
-        if let last = lastLocalSaveAt,
-           Date().timeIntervalSince(last) < Self.echoSuppressionWindow {
+        if inFlightSaveCount > 0 {
+            return
+        }
+        if let completed = lastSaveCompletedAt,
+           Date().timeIntervalSince(completed) < Self.postSaveGraceWindow {
             return
         }
         reloadConfig()
@@ -170,10 +187,14 @@ final class SoundManager {
     /// Called by the Settings UI when the user changes settings.
     func saveConfig(_ newConfig: SoundsConfig) {
         config = newConfig
-        lastLocalSaveAt = Date()
         hasLoadedConfig = true
+        inFlightSaveCount += 1
 
-        Task {
+        Task { @MainActor in
+            defer {
+                inFlightSaveCount -= 1
+                lastSaveCompletedAt = Date()
+            }
             let encoder = JSONEncoder()
             encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
             guard let data = try? encoder.encode(newConfig) else {


### PR DESCRIPTION
The 2s time-based guard in #25403 fixed the slider-drag echo race but also dropped legitimate cross-client broadcasts during that window. Replace it with an in-flight-save counter plus a short post-completion grace window: broadcasts are suppressed while any saveConfig is outstanding or within ~500 ms of the last save completing. Non-echo broadcasts (sound file additions/edits from other clients) are no longer silently dropped. Follow-up to #25403.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25430" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
