### PR TITLE
fix(sounds): treat sounds config 404 as loaded so pending app_open flushes

### DIFF
--- a/clients/macos/vellum-assistant/Features/Sounds/SoundManager.swift
+++ b/clients/macos/vellum-assistant/Features/Sounds/SoundManager.swift
@@ -141,6 +141,16 @@ final class SoundManager {
             hasLoadedConfig = true
             initialConfigLoaded = true
             flushPendingAppOpen()
+        } catch WorkspaceFileError.notFound {
+            // First-run state: config.json doesn't exist yet. Treat as a
+            // successful empty-data load so the initial fetch settles and any
+            // pending `app_open` fires now instead of queuing indefinitely
+            // until an unrelated later reload.
+            if !hasLoadedConfig {
+                config = .defaultConfig
+            }
+            initialConfigLoaded = true
+            flushPendingAppOpen()
         } catch {
             if hasLoadedConfig {
                 log.warning("Failed to fetch sounds config via gateway, keeping existing: \(error.localizedDescription)")

--- a/clients/shared/Network/WorkspaceClient.swift
+++ b/clients/shared/Network/WorkspaceClient.swift
@@ -3,6 +3,13 @@ import os
 
 private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "WorkspaceClient")
 
+/// Typed errors emitted by workspace file operations so callers can
+/// distinguish "file absent" (legitimate first-run state) from generic
+/// transport failures.
+public enum WorkspaceFileError: Error {
+    case notFound
+}
+
 /// Focused client for workspace file-system operations routed through the gateway.
 public protocol WorkspaceClientProtocol {
     func fetchWorkspaceTree(path: String, showHidden: Bool) async -> WorkspaceTreeResponse?
@@ -131,6 +138,9 @@ public struct WorkspaceClient: WorkspaceClientProtocol {
         let response = try await GatewayHTTPClient.get(
             path: "assistants/{assistantId}/workspace/file/content", params: params, timeout: 120
         )
+        if response.statusCode == 404 {
+            throw WorkspaceFileError.notFound
+        }
         guard response.isSuccess else {
             log.error("Workspace file content fetch failed (HTTP \(response.statusCode)) for \(path)")
             throw URLError(.badServerResponse)


### PR DESCRIPTION
PR #25405 deferred app_open until the initial config fetch settled, but the workspace file content API throws on any non-2xx including 404. First-run users have no data/sounds/config.json, so the fetch threw, initialConfigLoaded stayed false, and pendingAppOpenPlay lingered until an unrelated later reload (e.g. the user first saving sound settings) fired app_open at the wrong time. Introduce WorkspaceFileError.notFound so WorkspaceClient distinguishes absent files from network failures, and treat .notFound in SoundManager.fetchConfig() as a successful empty-data load that flushes the pending app_open. Follow-up to #25405.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25431" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
