### PR TITLE
feat(home): seed onboarding-sourced facts into relationship-state [JARVIS-471]

### DIFF
--- a/assistant/src/home/__tests__/relationship-state-writer.test.ts
+++ b/assistant/src/home/__tests__/relationship-state-writer.test.ts
@@ -45,8 +45,11 @@ mock.module("../../memory/conversation-queries.js", () => ({
 const {
   backfillRelationshipStateIfMissing,
   computeRelationshipState,
+  getOnboardingSidecarPath,
   getRelationshipStatePath,
+  ONBOARDING_SIDECAR_FILENAME,
   RELATIONSHIP_STATE_FILENAME,
+  writeOnboardingSidecar,
   writeRelationshipState,
 } = await import("../relationship-state-writer.js");
 
@@ -575,6 +578,163 @@ describe("relationship-state-writer", () => {
         expect(r).toBeUndefined();
       }
       expect(existsSync(getRelationshipStatePath())).toBe(true);
+    });
+  });
+
+  describe("onboarding sidecar (JARVIS-471)", () => {
+    test("getOnboardingSidecarPath returns <workspace>/data/onboarding-context.json", () => {
+      expect(getOnboardingSidecarPath()).toBe(
+        join(workspaceDir, "data", ONBOARDING_SIDECAR_FILENAME),
+      );
+    });
+
+    test("writeOnboardingSidecar persists the payload to disk", () => {
+      writeOnboardingSidecar({
+        tools: ["Slack", "Gmail"],
+        tasks: ["Inbox triage"],
+        tone: "Dry and precise",
+        userName: "Alex",
+        assistantName: "Nova",
+      });
+
+      const path = getOnboardingSidecarPath();
+      expect(existsSync(path)).toBe(true);
+      const decoded = JSON.parse(readFileSync(path, "utf-8")) as {
+        tools: string[];
+        tasks: string[];
+        tone: string;
+        userName?: string;
+        assistantName?: string;
+      };
+      expect(decoded.tools).toEqual(["Slack", "Gmail"]);
+      expect(decoded.tasks).toEqual(["Inbox triage"]);
+      expect(decoded.tone).toBe("Dry and precise");
+      expect(decoded.userName).toBe("Alex");
+      expect(decoded.assistantName).toBe("Nova");
+    });
+
+    test("computeRelationshipState emits onboarding-sourced facts when the sidecar is present", async () => {
+      writeOnboardingSidecar({
+        tools: ["Slack", "Gmail", "Notion"],
+        tasks: ["Email triage", "Meeting prep"],
+        tone: "Friendly and warm",
+        userName: "Alex",
+        assistantName: "Nova",
+      });
+
+      const state = (await computeRelationshipState()) as RelationshipStateLike;
+
+      const onboardingFacts = state.facts.filter(
+        (f) => f.source === "onboarding",
+      );
+      expect(onboardingFacts).toHaveLength(6); // 3 tools + 2 tasks + 1 tone
+
+      const worldTexts = onboardingFacts
+        .filter((f) => f.category === "world")
+        .map((f) => f.text);
+      expect(worldTexts).toEqual(["Slack", "Gmail", "Notion"]);
+
+      const prioritiesTexts = onboardingFacts
+        .filter((f) => f.category === "priorities")
+        .map((f) => f.text);
+      expect(prioritiesTexts).toEqual(["Email triage", "Meeting prep"]);
+
+      const voiceTexts = onboardingFacts
+        .filter((f) => f.category === "voice")
+        .map((f) => f.text);
+      expect(voiceTexts).toEqual(["Friendly and warm"]);
+
+      for (const f of onboardingFacts) {
+        expect(f.confidence).toBe("strong");
+        expect(f.id.startsWith("onboarding-")).toBe(true);
+      }
+    });
+
+    test("sidecar userName / assistantName fill in when IDENTITY.md and USER.md are absent", async () => {
+      writeOnboardingSidecar({
+        tools: [],
+        tasks: [],
+        tone: "",
+        userName: "Alex",
+        assistantName: "Nova",
+      });
+
+      const state = (await computeRelationshipState()) as RelationshipStateLike;
+      expect(state.userName).toBe("Alex");
+      expect(state.assistantName).toBe("Nova");
+    });
+
+    test("IDENTITY.md / USER.md take precedence over sidecar names", async () => {
+      writeFile("IDENTITY.md", "- Name: RealAssistant\n");
+      writeFile("USER.md", "- Preferred name: RealUser\n");
+      writeOnboardingSidecar({
+        tools: [],
+        tasks: [],
+        tone: "",
+        userName: "StaleOnboardingUser",
+        assistantName: "StaleOnboardingAssistant",
+      });
+
+      const state = (await computeRelationshipState()) as RelationshipStateLike;
+      expect(state.userName).toBe("RealUser");
+      expect(state.assistantName).toBe("RealAssistant");
+    });
+
+    test("onboarding and inferred facts coexist with correct sources", async () => {
+      writeFile(
+        "USER.md",
+        ["- Preferred name: Alex", "- Work role: Staff engineer"].join("\n"),
+      );
+      writeFile("SOUL.md", "- Tone: dry, precise\n");
+      writeOnboardingSidecar({
+        tools: ["Slack"],
+        tasks: ["Email triage"],
+        tone: "Friendly",
+        userName: "Alex",
+      });
+
+      const state = (await computeRelationshipState()) as RelationshipStateLike;
+      const bySource = new Map<string, number>();
+      for (const f of state.facts) {
+        bySource.set(f.source, (bySource.get(f.source) ?? 0) + 1);
+      }
+      expect(bySource.get("onboarding")).toBe(3); // 1 tool + 1 task + 1 tone
+      expect(bySource.get("inferred") ?? 0).toBeGreaterThanOrEqual(2);
+      // Onboarding facts render first so they lead the Home chip list.
+      expect(state.facts[0]?.source).toBe("onboarding");
+    });
+
+    test("missing sidecar produces no onboarding-sourced facts", async () => {
+      writeFile("USER.md", "- Preferred name: Alex");
+      const state = (await computeRelationshipState()) as RelationshipStateLike;
+      for (const f of state.facts) {
+        expect(f.source).toBe("inferred");
+      }
+    });
+
+    test("empty / whitespace-only onboarding entries are skipped", async () => {
+      writeOnboardingSidecar({
+        tools: ["Slack", "", "  "],
+        tasks: ["  ", "Email"],
+        tone: "   ",
+      });
+      const state = (await computeRelationshipState()) as RelationshipStateLike;
+      const onboardingFacts = state.facts.filter(
+        (f) => f.source === "onboarding",
+      );
+      expect(onboardingFacts.map((f) => f.text).sort()).toEqual([
+        "Email",
+        "Slack",
+      ]);
+    });
+
+    test("corrupt sidecar JSON degrades to zero onboarding facts", async () => {
+      mkdirSync(join(workspaceDir, "data"), { recursive: true });
+      writeFileSync(getOnboardingSidecarPath(), "{not valid json", "utf-8");
+      const state = (await computeRelationshipState()) as RelationshipStateLike;
+      for (const f of state.facts) {
+        expect(f.source).not.toBe("onboarding");
+      }
     });
   });
 });

--- a/assistant/src/home/relationship-state-writer.ts
+++ b/assistant/src/home/relationship-state-writer.ts
@@ -33,6 +33,7 @@ import { resolveGuardianPersonaPath } from "../prompts/persona-resolver.js";
 import { buildAssistantEvent } from "../runtime/assistant-event.js";
 import { assistantEventHub } from "../runtime/assistant-event-hub.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
+import type { OnboardingContext } from "../types/onboarding-context.js";
 import { getLogger } from "../util/logger.js";
 import {
   getDataDir,
@@ -56,6 +57,17 @@ const log = getLogger("relationship-state-writer");
 export const RELATIONSHIP_STATE_FILENAME = "relationship-state.json";
 
 /**
+ * Filename for the pre-chat onboarding sidecar. Lives under the workspace
+ * data dir alongside `relationship-state.json`. Written once by the
+ * `POST /v1/messages` handler on first message and read on every
+ * `computeRelationshipState()` call so onboarding-sourced facts survive
+ * the pure-recomputation write cycle (every turn boundary rebuilds facts
+ * from scratch — without the sidecar, onboarding chips would vanish on
+ * turn 2).
+ */
+export const ONBOARDING_SIDECAR_FILENAME = "onboarding-context.json";
+
+/**
  * Conversation-count threshold at which the "voice-writing" capability
  * flips from `earned` (gated, shown with an `unlockHint`) to `unlocked`.
  *
@@ -77,6 +89,60 @@ const DEFAULT_ASSISTANT_ID = "default";
  */
 export function getRelationshipStatePath(): string {
   return join(getDataDir(), RELATIONSHIP_STATE_FILENAME);
+}
+
+/**
+ * Canonical path to the onboarding sidecar
+ * (`<workspace>/data/onboarding-context.json`).
+ */
+export function getOnboardingSidecarPath(): string {
+  return join(getDataDir(), ONBOARDING_SIDECAR_FILENAME);
+}
+
+/**
+ * Persist the pre-chat onboarding context to the sidecar file. Called
+ * once from the first-message path in `handleSendMessage`. Never throws
+ * — a failed write degrades to "no onboarding facts on the Home page",
+ * which is the same state as a skipped onboarding flow.
+ */
+export function writeOnboardingSidecar(ctx: OnboardingContext): void {
+  try {
+    mkdirSync(getDataDir(), { recursive: true });
+    writeFileSync(
+      getOnboardingSidecarPath(),
+      JSON.stringify(ctx, null, 2),
+      "utf-8",
+    );
+    log.info(
+      {
+        path: getOnboardingSidecarPath(),
+        tools: ctx.tools.length,
+        tasks: ctx.tasks.length,
+      },
+      "Wrote onboarding-context.json sidecar",
+    );
+  } catch (err) {
+    log.warn({ err }, "Failed to write onboarding-context.json sidecar");
+  }
+}
+
+/**
+ * Read and parse the onboarding sidecar, returning null when the file
+ * is missing or unreadable. Used by `computeRelationshipState()` to
+ * inject onboarding-sourced facts alongside the inferred ones.
+ */
+function readOnboardingSidecar(): OnboardingContext | null {
+  try {
+    const path = getOnboardingSidecarPath();
+    if (!existsSync(path)) return null;
+    const parsed = JSON.parse(readFileSync(path, "utf-8")) as OnboardingContext;
+    if (!parsed || !Array.isArray(parsed.tools) || !Array.isArray(parsed.tasks))
+      return null;
+    return parsed;
+  } catch (err) {
+    log.warn({ err }, "Failed to read onboarding-context.json sidecar");
+    return null;
+  }
 }
 
 /**
@@ -104,15 +170,30 @@ export async function computeRelationshipState(): Promise<RelationshipState> {
   const userMd = resolveGuardianUserContent();
   const soulMd = safeRead(getWorkspacePromptPath("SOUL.md"));
   const identityPath = getWorkspacePromptPath("IDENTITY.md");
+  const onboarding = readOnboardingSidecar();
 
   const facts = extractFacts({
     userContent: userMd,
     soulContent: soulMd,
+    onboarding,
   });
   const conversationCount = countConversations();
   const capabilities = resolveCapabilityTiers({ conversationCount });
-  const { assistantName, hatchedDate } = parseIdentity(identityPath);
-  const userName = parseUserName(userMd);
+  const { assistantName: identityName, hatchedDate } =
+    parseIdentity(identityPath);
+  const parsedUserName = parseUserName(userMd);
+
+  // Fall back to onboarding sidecar values when IDENTITY.md / USER.md
+  // haven't yielded anything yet. On a brand-new workspace the sidecar
+  // is often the only source of these names until the daemon parses the
+  // markdown files on a subsequent turn.
+  const sidecarAssistantName = onboarding?.assistantName?.trim();
+  const assistantName =
+    identityName !== DEFAULT_ASSISTANT_NAME || !sidecarAssistantName
+      ? identityName
+      : sidecarAssistantName;
+  const userName =
+    parsedUserName ?? (onboarding?.userName?.trim() || undefined);
 
   const tier = computeTier({ facts, capabilities, conversationCount });
   const progressPercent = computeProgressPercent({
@@ -314,10 +395,7 @@ function resolveGuardianUserContent(): string {
     const defaultContent = safeRead(defaultUserPath);
     if (defaultContent) return defaultContent;
   } catch (err) {
-    log.warn(
-      { err },
-      "Failed to read users/default.md; trying legacy USER.md",
-    );
+    log.warn({ err }, "Failed to read users/default.md; trying legacy USER.md");
   }
 
   // Legacy fallback: workspace-root USER.md for very old workspaces
@@ -359,6 +437,7 @@ function safeRead(path: string): string {
 function extractFacts(input: {
   userContent: string;
   soulContent: string;
+  onboarding?: OnboardingContext | null;
 }): Fact[] {
   const facts: Fact[] = [];
   let counter = 0;
@@ -366,6 +445,45 @@ function extractFacts(input: {
     counter += 1;
     return `${prefix}-${counter}`;
   };
+
+  // Onboarding-sourced facts come first so they render at the top of
+  // the Home page chip list until enough inferred facts accumulate to
+  // displace them. Each tool/task/tone line the user picked becomes a
+  // dashed-border chip tagged `source: "onboarding"`.
+  if (input.onboarding) {
+    for (const tool of input.onboarding.tools) {
+      const text = tool.trim();
+      if (!text) continue;
+      facts.push({
+        id: nextId("onboarding"),
+        category: "world",
+        text,
+        confidence: "strong",
+        source: "onboarding",
+      });
+    }
+    for (const task of input.onboarding.tasks) {
+      const text = task.trim();
+      if (!text) continue;
+      facts.push({
+        id: nextId("onboarding"),
+        category: "priorities",
+        text,
+        confidence: "strong",
+        source: "onboarding",
+      });
+    }
+    const tone = input.onboarding.tone?.trim();
+    if (tone) {
+      facts.push({
+        id: nextId("onboarding"),
+        category: "voice",
+        text: tone,
+        confidence: "strong",
+        source: "onboarding",
+      });
+    }
+  }
 
   // Heuristic keyword map for USER.md sections -> fact category. Keys
   // are matched case-insensitively as a prefix of the heading/bullet

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1,7 +1,7 @@
 /**
  * Route handlers for conversation messages and suggestions.
  */
-import { existsSync, readdirSync, statSync } from "node:fs";
+import { existsSync, readdirSync, statSync, writeFileSync } from "node:fs";
 import { join, relative } from "node:path";
 
 import { z } from "zod";
@@ -48,6 +48,10 @@ import type {
   NonHostProxyTransportMetadata,
 } from "../../daemon/message-types/conversations.js";
 import type { HeartbeatService } from "../../heartbeat/heartbeat-service.js";
+import {
+  writeOnboardingSidecar,
+  writeRelationshipState,
+} from "../../home/relationship-state-writer.js";
 import * as attachmentsStore from "../../memory/attachments-store.js";
 import {
   createCanonicalGuardianRequest,
@@ -77,6 +81,7 @@ import { checkIngressForSecrets } from "../../security/secret-ingress.js";
 import { redactSecrets } from "../../security/secret-scanner.js";
 import { summarizeToolInput } from "../../tools/tool-input-summary.js";
 import { getLogger } from "../../util/logger.js";
+import { getWorkspacePromptPath } from "../../util/platform.js";
 import { silentlyWithLog } from "../../util/silently.js";
 import { buildAssistantEvent } from "../assistant-event.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../assistant-scope.js";
@@ -1205,6 +1210,78 @@ function resolveHostBrowserSender(
   return { sender: registrySender, isRegistryRouted: true };
 }
 
+/**
+ * Persist the pre-chat onboarding payload to disk.
+ *
+ * Runs only on the very first message of a fresh conversation. Three
+ * artifacts are produced:
+ *
+ *   1. `data/onboarding-context.json` — sidecar read by the
+ *      relationship-state writer so onboarding-sourced facts survive
+ *      the pure-recomputation write cycle (every turn boundary rebuilds
+ *      facts from markdown; the sidecar is the durable source for the
+ *      tool/task/tone chips).
+ *   2. `IDENTITY.md` / `USER.md` — persona seed files, only written
+ *      when missing so we never clobber existing content. These feed
+ *      the system prompt and the relationship-state writer's
+ *      `parseIdentity` / `parseUserName` helpers after a daemon
+ *      restart when the in-memory onboarding context is gone.
+ *   3. `data/relationship-state.json` — kicked off fire-and-forget so
+ *      the Home page can populate immediately on first visit instead
+ *      of waiting for the first agent-turn boundary.
+ *
+ * Never throws: every write is guarded and logged as a warning on
+ * failure. The route handler path must never reject because of a
+ * best-effort persistence step.
+ */
+function persistOnboardingArtifacts(onboarding: {
+  tools: string[];
+  tasks: string[];
+  tone: string;
+  userName?: string;
+  assistantName?: string;
+}): void {
+  writeOnboardingSidecar(onboarding);
+
+  const assistantName = onboarding.assistantName?.trim();
+  if (assistantName) {
+    const identityPath = getWorkspacePromptPath("IDENTITY.md");
+    if (!existsSync(identityPath)) {
+      try {
+        writeFileSync(
+          identityPath,
+          `# Identity\n\n- Name: ${assistantName}\n`,
+          "utf-8",
+        );
+      } catch (err) {
+        log.warn(
+          { err, identityPath },
+          "Failed to seed IDENTITY.md from onboarding",
+        );
+      }
+    }
+  }
+
+  const userName = onboarding.userName?.trim();
+  if (userName) {
+    const userPath = getWorkspacePromptPath("USER.md");
+    if (!existsSync(userPath)) {
+      try {
+        writeFileSync(userPath, `# User\n\n- Name: ${userName}\n`, "utf-8");
+      } catch (err) {
+        log.warn({ err, userPath }, "Failed to seed USER.md from onboarding");
+      }
+    }
+  }
+
+  void writeRelationshipState().catch((err) => {
+    log.warn(
+      { err },
+      "Failed to kick off relationship-state write after onboarding",
+    );
+  });
+}
+
 export async function handleSendMessage(
   req: Request,
   deps: {
@@ -1360,10 +1437,14 @@ export async function handleSendMessage(
   );
 
   // Store pre-chat onboarding context on the conversation when this is the
-  // very first message (no prior messages loaded). The context is in-memory
-  // only and used to personalize the system prompt for the first turn.
+  // very first message (no prior messages loaded). Also persist the
+  // onboarding selections so the Home page shows onboarding-sourced
+  // chips immediately, and seed IDENTITY.md / USER.md so subsequent
+  // turn-boundary recomputes of relationship-state have a stable
+  // persona source beyond the in-memory conversation object.
   if (body.onboarding && conversation.messages.length === 0) {
     conversation.setOnboardingContext(body.onboarding);
+    persistOnboardingArtifacts(body.onboarding);
   }
 
   // Resolve guardian context from the AuthContext's actorPrincipalId.


### PR DESCRIPTION
## Summary

Phase 4 backend of the Onboarding & New User Retention TDD. On the very first message of a fresh conversation, persist the pre-chat onboarding payload so the Home page renders dashed-border onboarding chips immediately.

## What changed

- **`assistant/src/home/relationship-state-writer.ts`** — new `writeOnboardingSidecar()` / `getOnboardingSidecarPath()` exports + a private `readOnboardingSidecar()`. `extractFacts()` now accepts an `onboarding?` arg and emits tools → world / tasks → priorities / tone → voice facts tagged `source: "onboarding"` (rendered first so they lead the Home chip list). `computeRelationshipState()` reads the sidecar and falls back to its `userName` / `assistantName` when IDENTITY.md / USER.md haven't yielded names yet.
- **`assistant/src/runtime/routes/conversation-routes.ts`** — new `persistOnboardingArtifacts()` helper called from the existing `body.onboarding && conversation.messages.length === 0` gate in `handleSendMessage`. Writes the sidecar, seeds `IDENTITY.md` / `USER.md` only when missing (never clobbers existing persona content), and kicks `writeRelationshipState()` fire-and-forget so the Home page populates on first visit.
- **`assistant/src/home/__tests__/relationship-state-writer.test.ts`** — new `onboarding sidecar (JARVIS-471)` block with 9 tests.

## Critical design note

The relationship-state writer is a **pure recomputation on every turn boundary** — it reads USER.md / SOUL.md / IDENTITY.md from disk and rebuilds `facts[]` from scratch, never merging with the on-disk JSON. Without a durable source for onboarding selections, chips written on the first message would vanish on the second turn. The sidecar (`data/onboarding-context.json`) is exactly that durable source — read on every recomputation so onboarding facts survive restarts and subsequent writes.

IDENTITY.md / USER.md are seeded from onboarding too, but only when missing, so we never clobber existing persona content. They're the durable source for the system prompt and the writer's `parseIdentity` / `parseUserName` helpers after a daemon restart drops the in-memory `conversation.onboardingContext`.

## No frontend changes

Phase 3 already baked in the dashed-border `source: "onboarding"` fact chips + the empty-state "Start chatting and I'll pick up a lot more" nudge as forward-compat for Phase 4. The macOS client renders this PR's new facts correctly with no additional work. LUM-806 (Jason's frontend ticket) is effectively superseded by Phase 3's forward-compat.

## Test plan
- [x] `bun test src/home/__tests__/relationship-state-writer.test.ts` — 40 tests pass (9 new + 31 existing)
- [x] `bun run typecheck` — clean
- [x] Pre-push type-check + lint + Swift build — passes
- [x] Hand-test: Pax launches cleanly on macOS Tahoe (after #25426 merged the SSE guard fix that unblocked testing)
- [ ] Hand-test: toggle `home-tab` on, run pre-chat onboarding, confirm Home tab shows 4–8 dashed-border chips immediately on first visit
- [ ] Hand-test: second turn of the same conversation does not vanish the onboarding chips
- [ ] Hand-test: daemon + app restart after first turn preserves both onboarding chips (sidecar durability) and assistantName/userName (IDENTITY.md / USER.md seed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)