### PR TITLE
feat(stt): reduce Whisper poll interval to 400ms for snappier dictation

### DIFF
--- a/assistant/src/providers/speech-to-text/openai-whisper-stream.ts
+++ b/assistant/src/providers/speech-to-text/openai-whisper-stream.ts
@@ -45,8 +45,12 @@ const log = getLogger("openai-whisper-stream");
 /**
  * Minimum interval between incremental batch requests (ms).
  * Prevents excessive API calls while the user is actively speaking.
+ *
+ * Tuned lower than 1s so chat-composer dictation feels more responsive:
+ * OpenAI Whisper remains incremental-batch (not true token streaming), but
+ * a tighter poll cadence reduces perceived latency for partial updates.
  */
-export const POLL_INTERVAL_MS = 1_000;
+export const POLL_INTERVAL_MS = 400;
 
 /**
  * Timeout per incremental poll request (ms).


### PR DESCRIPTION
## Summary
- Lowers `POLL_INTERVAL_MS` from 1000ms to 400ms in the OpenAI Whisper incremental-batch STT adapter
- Reduces perceived latency for partial transcript updates during chat-composer dictation
- Adds inline comment explaining the tuning rationale
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25436" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
