### PR TITLE
feat(stt): reorder providers and add credentials guide

### DIFF
--- a/assistant/src/config/schemas/stt.ts
+++ b/assistant/src/config/schemas/stt.ts
@@ -5,9 +5,9 @@ import { z } from "zod";
  * an adapter.
  */
 export const VALID_STT_PROVIDERS = [
-  "openai-whisper",
   "deepgram",
   "google-gemini",
+  "openai-whisper",
 ] as const;
 
 /**

--- a/assistant/src/providers/speech-to-text/provider-catalog.ts
+++ b/assistant/src/providers/speech-to-text/provider-catalog.ts
@@ -148,22 +148,6 @@ const CATALOG: ReadonlyMap<SttProviderId, SttProviderEntry> = new Map<
   SttProviderEntry
 >([
   [
-    "openai-whisper",
-    {
-      id: "openai-whisper",
-      credentialProvider: "openai",
-      supportedBoundaries: new Set<SttBoundaryId>([
-        "daemon-batch",
-        "daemon-streaming",
-      ]),
-      telephonyMode: "batch-only",
-      conversationStreamingMode: "incremental-batch",
-      telephonyRouting: {
-        strategyKind: "media-stream-custom",
-      },
-    },
-  ],
-  [
     "deepgram",
     {
       id: "deepgram",
@@ -200,6 +184,22 @@ const CATALOG: ReadonlyMap<SttProviderId, SttProviderEntry> = new Map<
           provider: "Google",
           defaultSpeechModel: undefined,
         },
+      },
+    },
+  ],
+  [
+    "openai-whisper",
+    {
+      id: "openai-whisper",
+      credentialProvider: "openai",
+      supportedBoundaries: new Set<SttBoundaryId>([
+        "daemon-batch",
+        "daemon-streaming",
+      ]),
+      telephonyMode: "batch-only",
+      conversationStreamingMode: "incremental-batch",
+      telephonyRouting: {
+        strategyKind: "media-stream-custom",
       },
     },
   ],

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -3025,23 +3025,48 @@ public final class SettingsStore: ObservableObject {
         return task
     }
 
+    /// Saves an API key for the given STT provider to the credential store
+    /// and synchronizes it to the assistant.
+    ///
+    /// Returns the gateway write result so callers can surface explicit
+    /// success/failure feedback in UI flows.
+    func saveSTTKeyResult(_ raw: String, sttProviderId: String) async -> APIKeyManager.SetKeyResult {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            return APIKeyManager.SetKeyResult(
+                success: false,
+                error: "Please enter an API key.",
+                isTransient: false
+            )
+        }
+        let keyProvider = Self.sttApiKeyProviderName(for: sttProviderId)
+        let setLocalKey: (String, String) -> Void = APIKeyManager.setKey(_:for:)
+        setLocalKey(trimmed, keyProvider)
+        removeDeletionTombstone(type: "api_key", name: keyProvider)
+        let result = await APIKeyManager.setKey(trimmed, for: keyProvider)
+        if result.success {
+            scheduleRoutingSourceRefresh()
+            return result
+        }
+        if let error = result.error {
+            log.error("Failed to sync STT key for \(sttProviderId, privacy: .public) to daemon: \(error, privacy: .public)")
+        }
+        if !result.isTransient {
+            let _: Void = APIKeyManager.deleteKey(for: keyProvider)
+        }
+        return result
+    }
+
     /// Saves an API key for the given STT provider to the credential store.
     /// The `sttProviderId` is the catalog identifier (e.g. `"openai-whisper"`,
     /// `"deepgram"`); the method resolves the credential provider name from
     /// the STT provider registry's `apiKeyProviderName` field so callers
     /// don't need to know the mapping.
     func saveSTTKey(_ raw: String, sttProviderId: String, onSuccess: (() -> Void)? = nil) {
-        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return }
-        let keyProvider = Self.sttApiKeyProviderName(for: sttProviderId)
-        APIKeyManager.setKey(trimmed, for: keyProvider)
-        removeDeletionTombstone(type: "api_key", name: keyProvider)
         Task {
-            let result = await APIKeyManager.setKey(trimmed, for: keyProvider)
+            let result = await saveSTTKeyResult(raw, sttProviderId: sttProviderId)
             if result.success {
                 onSuccess?()
-            } else if let error = result.error {
-                log.error("Failed to sync STT key for \(sttProviderId, privacy: .public) to daemon: \(error, privacy: .public)")
             }
         }
     }

--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -566,16 +566,8 @@ struct VoiceSettingsView: View {
                 // API key field — label and placeholder adapt to the selected provider
                 sttApiKeyField
 
-                // Provider-specific setup hint
-                if let hint = selectedSTTProvider?.setupHint, !hint.isEmpty {
-                    HStack(spacing: VSpacing.xs) {
-                        VIconView(.info, size: 10)
-                            .foregroundStyle(VColor.contentTertiary)
-                        Text(hint)
-                            .font(VFont.labelDefault)
-                            .foregroundStyle(VColor.contentTertiary)
-                    }
-                }
+                // Credentials guide — contextual help for obtaining an API key
+                sttCredentialsGuideView
 
                 // Save + Reset actions — reset is only shown for
                 // exclusive-key providers to avoid clearing shared
@@ -589,6 +581,10 @@ struct VoiceSettingsView: View {
                     onReset: { resetSTTKey() },
                     showReset: sttResetAllowed
                 )
+
+                if let sttSaveError {
+                    VInlineMessage(sttSaveError, tone: .error)
+                }
             }
         }
     }
@@ -607,9 +603,29 @@ struct VoiceSettingsView: View {
             placeholder: placeholder,
             text: $sttApiKeyText,
             isSecure: true,
-            errorMessage: sttSaveError
+            errorMessage: nil
         )
         .disabled(sttSaving)
+    }
+
+    // MARK: - STT Credentials Guide
+
+    @ViewBuilder
+    private var sttCredentialsGuideView: some View {
+        if let guide = selectedSTTProvider?.credentialsGuide,
+           let attributed = try? AttributedString(
+               markdown: "\(guide.description) [\(guide.linkLabel)](\(guide.url))"
+           ) {
+            Text(attributed)
+                .font(VFont.labelDefault)
+                .foregroundStyle(VColor.contentTertiary)
+                .tint(VColor.primaryBase)
+                .lineSpacing(1)
+                .environment(\.openURL, OpenURLAction { url in
+                    NSWorkspace.shared.open(url)
+                    return .handled
+                })
+        }
     }
 
     // MARK: - STT Reset
@@ -636,22 +652,49 @@ struct VoiceSettingsView: View {
             draftSTTProvider = resolved
         }
 
-        // Persist provider change if needed
-        if draftSTTProvider != sttProviderRaw {
-            store.setSTTProvider(draftSTTProvider)
-            sttProviderRaw = draftSTTProvider
-        }
-
-        // Persist API key if provided. Clear the field and update hasKey
-        // optimistically so the UI reflects the save immediately.
+        let providerToSave = draftSTTProvider
+        let providerChanged = providerToSave != sttProviderRaw
         let trimmedKey = sttApiKeyText.trimmingCharacters(in: .whitespacesAndNewlines)
-        if !trimmedKey.isEmpty {
-            sttApiKeyText = ""
-            sttProviderHasKey = true
-            store.saveSTTKey(trimmedKey, sttProviderId: draftSTTProvider)
-        }
 
-        initialSTTProvider = draftSTTProvider
-        sttSaving = false
+        Task {
+            var providerSaveSucceeded = true
+            var keySaveSucceeded = true
+
+            if providerChanged {
+                providerSaveSucceeded = await store.setSTTProvider(providerToSave).value
+                if providerSaveSucceeded {
+                    sttProviderRaw = providerToSave
+                } else {
+                    sttSaveError = "Could not save speech-to-text provider selection. Please try again."
+                }
+            }
+
+            if !trimmedKey.isEmpty {
+                let keyResult = await store.saveSTTKeyResult(
+                    trimmedKey,
+                    sttProviderId: providerToSave
+                )
+                keySaveSucceeded = keyResult.success
+                if keyResult.success {
+                    sttApiKeyText = ""
+                    sttProviderHasKey = true
+                } else {
+                    sttSaveError = keyResult.error
+                        ?? "Could not save speech-to-text API key. Please try again."
+                }
+            }
+
+            if providerSaveSucceeded {
+                initialSTTProvider = providerToSave
+            }
+
+            if providerSaveSucceeded && keySaveSucceeded {
+                sttSaveError = nil
+            } else if !providerSaveSucceeded && !keySaveSucceeded {
+                sttSaveError = "Could not save speech-to-text settings. Please try again."
+            }
+
+            sttSaving = false
+        }
     }
 }

--- a/clients/shared/Utilities/STTProviderRegistry.swift
+++ b/clients/shared/Utilities/STTProviderRegistry.swift
@@ -42,6 +42,19 @@ public enum STTConversationStreamingMode: String, Decodable, Sendable {
     }
 }
 
+/// Guide for obtaining API credentials from a provider.
+///
+/// Contains a short description of the steps, a URL to the provider's
+/// key-management page, and a human-readable link label for display.
+public struct STTCredentialsGuide: Decodable {
+    /// Brief instructions for obtaining an API key (1-2 sentences).
+    public let description: String
+    /// URL to the provider's API key or console page.
+    public let url: String
+    /// Human-readable label for the link (e.g. "Open Deepgram Console").
+    public let linkLabel: String
+}
+
 /// A single entry in the client-facing STT provider catalog.
 ///
 /// This struct captures the subset of provider metadata that client apps
@@ -68,6 +81,8 @@ public struct STTProviderCatalogEntry: Decodable {
     /// this to decide whether to attempt WebSocket streaming for real-time
     /// transcription or fall back to batch STT.
     public let conversationStreamingMode: STTConversationStreamingMode
+    /// Guide for obtaining API credentials from this provider.
+    public let credentialsGuide: STTCredentialsGuide?
 }
 
 /// Top-level schema for `stt-provider-catalog.json`.
@@ -157,22 +172,18 @@ private let fallbackRegistry = STTProviderRegistry(
     version: 0,
     providers: [
         STTProviderCatalogEntry(
-            id: "openai-whisper",
-            displayName: "OpenAI Whisper",
-            subtitle: "High-accuracy speech-to-text powered by OpenAI Whisper. Requires an OpenAI API key.",
-            setupMode: .apiKey,
-            setupHint: "Enter your OpenAI API key to enable Whisper transcription.",
-            apiKeyProviderName: "openai",
-            conversationStreamingMode: .incrementalBatch
-        ),
-        STTProviderCatalogEntry(
             id: "deepgram",
             displayName: "Deepgram",
             subtitle: "Fast, real-time speech-to-text with streaming support. Requires a Deepgram API key.",
             setupMode: .apiKey,
             setupHint: "Enter your Deepgram API key to enable speech-to-text.",
             apiKeyProviderName: "deepgram",
-            conversationStreamingMode: .realtimeWs
+            conversationStreamingMode: .realtimeWs,
+            credentialsGuide: STTCredentialsGuide(
+                description: "Sign in to the Deepgram console, navigate to API Keys, and create a new key.",
+                url: "https://console.deepgram.com/",
+                linkLabel: "Open Deepgram Console"
+            )
         ),
         STTProviderCatalogEntry(
             id: "google-gemini",
@@ -181,7 +192,26 @@ private let fallbackRegistry = STTProviderRegistry(
             setupMode: .apiKey,
             setupHint: "Enter your Gemini API key to enable Google Gemini transcription.",
             apiKeyProviderName: "gemini",
-            conversationStreamingMode: .incrementalBatch
+            conversationStreamingMode: .incrementalBatch,
+            credentialsGuide: STTCredentialsGuide(
+                description: "Visit Google AI Studio, sign in with your Google account, and create an API key.",
+                url: "https://aistudio.google.com/apikey",
+                linkLabel: "Open Google AI Studio"
+            )
+        ),
+        STTProviderCatalogEntry(
+            id: "openai-whisper",
+            displayName: "OpenAI Whisper",
+            subtitle: "High-accuracy speech-to-text powered by OpenAI Whisper. Requires an OpenAI API key.",
+            setupMode: .apiKey,
+            setupHint: "Enter your OpenAI API key to enable Whisper transcription.",
+            apiKeyProviderName: "openai",
+            conversationStreamingMode: .incrementalBatch,
+            credentialsGuide: STTCredentialsGuide(
+                description: "Log in to the OpenAI platform, go to API Keys, and generate a new secret key.",
+                url: "https://platform.openai.com/api-keys",
+                linkLabel: "Open OpenAI Platform"
+            )
         ),
     ]
 )

--- a/meta/stt-provider-catalog.json
+++ b/meta/stt-provider-catalog.json
@@ -2,22 +2,18 @@
   "version": 2,
   "providers": [
     {
-      "id": "openai-whisper",
-      "displayName": "OpenAI Whisper",
-      "subtitle": "High-accuracy speech-to-text powered by OpenAI Whisper. Requires an OpenAI API key.",
-      "setupMode": "api-key",
-      "setupHint": "Enter your OpenAI API key to enable Whisper transcription.",
-      "apiKeyProviderName": "openai",
-      "conversationStreamingMode": "incremental-batch"
-    },
-    {
       "id": "deepgram",
       "displayName": "Deepgram",
       "subtitle": "Fast, real-time speech-to-text with streaming support. Requires a Deepgram API key.",
       "setupMode": "api-key",
       "setupHint": "Enter your Deepgram API key to enable speech-to-text.",
       "apiKeyProviderName": "deepgram",
-      "conversationStreamingMode": "realtime-ws"
+      "conversationStreamingMode": "realtime-ws",
+      "credentialsGuide": {
+        "description": "Sign in to the Deepgram console, navigate to API Keys, and create a new key.",
+        "url": "https://console.deepgram.com/",
+        "linkLabel": "Open Deepgram Console"
+      }
     },
     {
       "id": "google-gemini",
@@ -26,7 +22,26 @@
       "setupMode": "api-key",
       "setupHint": "Enter your Gemini API key to enable Google Gemini transcription.",
       "apiKeyProviderName": "gemini",
-      "conversationStreamingMode": "incremental-batch"
+      "conversationStreamingMode": "incremental-batch",
+      "credentialsGuide": {
+        "description": "Visit Google AI Studio, sign in with your Google account, and create an API key.",
+        "url": "https://aistudio.google.com/apikey",
+        "linkLabel": "Open Google AI Studio"
+      }
+    },
+    {
+      "id": "openai-whisper",
+      "displayName": "OpenAI Whisper",
+      "subtitle": "High-accuracy speech-to-text powered by OpenAI Whisper. Requires an OpenAI API key.",
+      "setupMode": "api-key",
+      "setupHint": "Enter your OpenAI API key to enable Whisper transcription.",
+      "apiKeyProviderName": "openai",
+      "conversationStreamingMode": "incremental-batch",
+      "credentialsGuide": {
+        "description": "Log in to the OpenAI platform, go to API Keys, and generate a new secret key.",
+        "url": "https://platform.openai.com/api-keys",
+        "linkLabel": "Open OpenAI Platform"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Reorder STT providers across all catalogs (daemon, client JSON, Swift fallback) to put Deepgram first, matching the default `services.stt.provider` value, followed by Google Gemini, then OpenAI Whisper
- Add `credentialsGuide` metadata (description + console URL + link label) to each provider in the catalog JSON, Swift model, and fallback registry
- Replace the static `setupHint` info row in the macOS STT settings card with an inline attributed text paragraph that includes a clickable link to the provider's API key page
- Make STT save flow async with proper error handling — `saveSTTKeyResult` returns a result object, and `saveSTT` now surfaces errors via `VInlineMessage`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25438" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
