### PR TITLE
fix: address self-review gaps in media-stream whisper changes

### DIFF
--- a/assistant/src/calls/media-stream-server.ts
+++ b/assistant/src/calls/media-stream-server.ts
@@ -95,8 +95,8 @@ export class MediaStreamCallSession {
   private bargeInAccepted = 0;
   /** Number of barge-in attempts that were ignored (assistant not speaking). */
   private bargeInIgnored = 0;
-  /** Number of turns segmented by the STT session. */
-  private turnsSegmented = 0;
+  /** Number of turn-start transitions detected by the STT session. */
+  private turnStarts = 0;
   /** Number of transcript finals produced (non-empty). */
   private transcriptFinalsProduced = 0;
 
@@ -179,7 +179,7 @@ export class MediaStreamCallSession {
         terminationReason,
         closeCode: code,
         closeReason: reason,
-        turnsSegmented: this.turnsSegmented,
+        turnStarts: this.turnStarts,
         transcriptFinalsProduced: this.transcriptFinalsProduced,
         bargeInAccepted: this.bargeInAccepted,
         bargeInIgnored: this.bargeInIgnored,
@@ -284,7 +284,7 @@ export class MediaStreamCallSession {
     log.info(
       {
         callSessionId: this.callSessionId,
-        turnsSegmented: this.turnsSegmented,
+        turnStarts: this.turnStarts,
         transcriptFinalsProduced: this.transcriptFinalsProduced,
         bargeInAccepted: this.bargeInAccepted,
         bargeInIgnored: this.bargeInIgnored,
@@ -495,17 +495,21 @@ export class MediaStreamCallSession {
   // ── STT callbacks ─────────────────────────────────────────────────
 
   private handleSpeechStart(): void {
-    this.turnsSegmented++;
+    this.turnStarts++;
 
     // Barge-in: clear queued outbound audio and abort the in-flight LLM
     // turn only when the assistant is actively speaking. Uses the gated
     // handleBargeIn path so initial inbound audio frames do not cancel a
     // still-starting initial turn.
+    //
+    // clearAudio runs BEFORE handleBargeIn so that the end-of-turn mark
+    // enqueued by handleInterrupt (called within handleBargeIn) is not
+    // wiped by the queue flush.
     if (this.output && this.controller) {
+      this.output.clearAudio();
       const accepted = this.controller.handleBargeIn();
       if (accepted) {
         this.bargeInAccepted++;
-        this.output.clearAudio();
         log.info(
           { callSessionId: this.callSessionId },
           "Media-stream barge-in accepted — cleared outbound audio",

--- a/assistant/src/calls/media-stream-stt-session.ts
+++ b/assistant/src/calls/media-stream-stt-session.ts
@@ -208,13 +208,17 @@ export class MediaStreamSttSession {
     // Only process inbound (caller) audio
     if (event.media.track !== "inbound") return;
 
-    this.currentTurnChunks.push(event.media.payload);
-
     // Compute speech activity from the audio payload using a lightweight
     // energy heuristic. mu-law encoded audio has a companded dynamic
     // range — silence sits near 0xFF/0x7F while speech has higher energy.
+    //
+    // The detector call runs BEFORE the push so that the onTurnStart
+    // callback can clear stale inter-turn silence from the buffer
+    // without also wiping the first speech chunk of the new turn.
     const hasSpeech = detectSpeechActivity(event.media.payload);
     this.turnDetector.onMediaChunk(hasSpeech);
+
+    this.currentTurnChunks.push(event.media.payload);
   }
 
   private handleStop(): void {

--- a/assistant/src/calls/media-stream-stt-session.ts
+++ b/assistant/src/calls/media-stream-stt-session.ts
@@ -59,7 +59,7 @@ const DEFAULT_TRANSCRIPTION_TIMEOUT_MS = 10_000;
 // ---------------------------------------------------------------------------
 
 export interface MediaStreamSttSessionCallbacks {
-  /** Called when the turn detector transitions to active (first audio chunk). */
+  /** Called when the turn detector transitions to active (first speech-bearing chunk). */
   onSpeechStart?: () => void;
 
   /**
@@ -127,6 +127,9 @@ export class MediaStreamSttSession {
 
     this.turnDetector = new MediaTurnDetector(config.turnDetector, {
       onTurnStart: () => {
+        // Clear inter-turn silence that accumulated while idle so each
+        // transcription request contains only speech-relevant chunks.
+        this.currentTurnChunks = [];
         this.callbacks.onSpeechStart?.();
       },
       onTurnEnd: (reason, durationMs) => {

--- a/assistant/src/calls/media-turn-detector.ts
+++ b/assistant/src/calls/media-turn-detector.ts
@@ -15,10 +15,11 @@
  * 2. **Max turn duration** — to prevent unbounded accumulation, a turn
  *    is forcibly ended when its total duration exceeds `maxTurnDurationMs`.
  *
- * Unlike the previous chunk-gap-only approach, continuous inbound media
- * frames (which Twilio sends at a steady cadence regardless of speech)
- * do not prevent turn boundaries. Only frames classified as containing
- * speech reset the silence timer.
+ * Continuous inbound media frames (which Twilio sends at a steady
+ * cadence regardless of speech) do not prevent turn boundaries. Only
+ * frames classified as containing speech reset the silence timer. Turns
+ * that never contain a speech-bearing chunk are silently discarded
+ * without firing the `onTurnEnd` callback.
  *
  * Design:
  * - Stateful but single-threaded (no locking; runs on the main event loop).
@@ -193,7 +194,14 @@ export class MediaTurnDetector {
       clearTimeout(this.silenceTimer);
     }
     this.silenceTimer = setTimeout(() => {
-      this.endTurn("silence");
+      if (this.hasSpeechInTurn) {
+        this.endTurn("silence");
+      } else {
+        // No speech was detected during the turn — reset state without
+        // emitting a turn-end callback to avoid bogus empty turns.
+        this.clearTimers();
+        this.active = false;
+      }
     }, this.silenceThresholdMs);
   }
 

--- a/docs/internal-reference.md
+++ b/docs/internal-reference.md
@@ -688,7 +688,7 @@ Search daemon logs for the `media-stream-server` and `media-stt-session` logger 
 | `Media-stream barge-in accepted — cleared outbound audio` | `media-stream-server` | Caller spoke while assistant was speaking; turn interrupted |
 | `Media-stream barge-in ignored — assistant not speaking` | `media-stream-server` | Inbound audio arrived but assistant was idle/processing; no interrupt |
 | `Media stream stop event received` | `media-stream-server` | Twilio sent `stop`; call is ending |
-| `Media stream transport closed — session diagnostics` | `media-stream-server` | WebSocket closed; includes `turnsSegmented`, `transcriptFinalsProduced`, `bargeInAccepted`, `bargeInIgnored`, `terminationReason` |
+| `Media stream transport closed — session diagnostics` | `media-stream-server` | WebSocket closed; includes `turnStarts`, `transcriptFinalsProduced`, `bargeInAccepted`, `bargeInIgnored`, `terminationReason` |
 | `Media stream call session destroyed` | `media-stream-server` | Full teardown; includes session-lifetime diagnostic counters |
 | `Media stream STT session started` | `media-stt-session` | STT session initialized with stream metadata |
 | `Barge-in ignored — assistant not speaking` | `call-controller` | Controller received barge-in but was idle or processing |
@@ -700,16 +700,16 @@ Search daemon logs for the `media-stream-server` and `media-stt-session` logger 
 | --- | --- | --- |
 | **Connected but no reply** | False barge-in abort: initial inbound audio interrupted the first turn before the assistant could respond | Check logs for `barge-in accepted` immediately after `session started`. If present, the gating fix is not active. Verify `handleBargeIn` (not `handleInterrupt`) is called from `handleSpeechStart`. |
 | **Connected but no reply (no barge-in)** | Handshake/setup failure: `start` event never arrived or setup policy denied the call | Check for `Media stream session started` log. If absent, verify gateway WebSocket proxy is forwarding to the daemon. Check for `setup denied` events. |
-| **Call active but no transcript** | Turn segmentation blocked by continuous chunk cadence (pre-fix behavior) | Check `turnsSegmented` and `transcriptFinalsProduced` in the session diagnostics log. If `turnsSegmented=0`, the speech-aware detector is not receiving speech-bearing chunks. Verify audio encoding and energy levels. |
+| **Call active but no transcript** | Turn segmentation not detecting speech-bearing chunks | Check `turnStarts` and `transcriptFinalsProduced` in the session diagnostics log. If `turnStarts=0`, the speech-aware detector is not receiving speech-bearing chunks. Verify audio encoding and energy levels. |
 | **Transcript only at hangup** | Turn boundaries not detected mid-call; only `forceEnd` at stream stop produced a transcript | Check `transcriptFinalsProduced` — if it equals 1 and the call was long, speech-to-silence transitions are not being detected. Verify `detectSpeechActivity` thresholds match the audio characteristics. |
 | **Immediate abort after connect** | Controller destroyed before first turn completes | Check for `Media stream call session destroyed` appearing within 1-2 seconds of `session started`. Cross-reference with `terminationReason` in transport-close diagnostics. |
-| **Repeated bogus transcriptions** | Silent/noise frames classified as speech | Check `turnsSegmented` — if much higher than expected, the speech energy threshold is too low. Tune `SPEECH_ENERGY_THRESHOLD` in `media-stream-stt-session.ts`. |
+| **Repeated bogus transcriptions** | Silent/noise frames classified as speech | Check `turnStarts` — if much higher than expected, the speech energy threshold is too low. Tune `SPEECH_ENERGY_THRESHOLD` in `media-stream-stt-session.ts`. |
 
 #### Session Diagnostic Fields
 
 The `Media stream transport closed — session diagnostics` and `Media stream call session destroyed` log entries include:
 
-- **`turnsSegmented`** — Number of speech turns detected by the turn detector.
+- **`turnStarts`** — Number of turn-start transitions detected by the turn detector.
 - **`transcriptFinalsProduced`** — Number of non-empty transcripts delivered to the controller.
 - **`bargeInAccepted`** — Interrupts that fired (assistant was speaking).
 - **`bargeInIgnored`** — Interrupts that were suppressed (assistant idle/processing).


### PR DESCRIPTION
## Summary
Fixes 6 gaps identified during self-review of the media-stream whisper changes:

1. Fix order-of-operations inversion in handleSpeechStart (clearAudio before handleBargeIn)
2. Clear transcription buffer on turn start to prevent silence accumulation
3. Rename turnsSegmented to turnStarts for accuracy
4. Use hasSpeechInTurn to prevent empty turns from triggering transcription
5. Remove backward-looking comments per CLAUDE.md conventions
6. Update stale onSpeechStart JSDoc

Part of plan: twilio-whisper-answers-no-response.md (review fix round 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25439" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
