### PR TITLE
fix(macos): use scoped NSLock.withLock in MockHomeStateClient for Swift 6 async safety

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/HomeStore.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeStore.swift
@@ -151,29 +151,22 @@ public final class MockHomeStateClient: HomeStateClient, @unchecked Sendable {
     }
 
     public var callCount: Int {
-        lock.lock()
-        defer { lock.unlock() }
-        return _callCount
+        lock.withLock { _callCount }
     }
 
     public func setState(_ state: RelationshipState?) {
-        lock.lock()
-        defer { lock.unlock() }
-        _state = state
+        lock.withLock { _state = state }
     }
 
     public func setError(_ error: Error?) {
-        lock.lock()
-        defer { lock.unlock() }
-        _error = error
+        lock.withLock { _error = error }
     }
 
     public func fetchRelationshipState() async throws -> RelationshipState {
-        lock.lock()
-        _callCount += 1
-        let error = _error
-        let state = _state
-        lock.unlock()
+        let (error, state) = lock.withLock { () -> (Error?, RelationshipState?) in
+            _callCount += 1
+            return (_error, _state)
+        }
 
         if let error { throw error }
         guard let state else {


### PR DESCRIPTION
## Summary

- `MockHomeStateClient.fetchRelationshipState()` is `async`, and Swift 6 flags direct `NSLock.lock()` calls from async contexts as unsafe.
- Replaced all `lock.lock()` / `lock.unlock()` pairs with the scoped `lock.withLock { ... }` pattern already used elsewhere in the codebase (e.g. `HostToolExecutor.swift`, `PodRuntime.swift`).
- Silences the Swift 6 warning that would otherwise become an error in the Swift 6 language mode.

## Original prompt

Fix this:
\`\`\`
/Users/sidd/vocify/vellum-assistant/clients/macos/vellum-assistant/Features/Home/HomeStore.swift:172:14: warning: instance method 'lock' is unavailable from asynchronous contexts; Use async-safe scoped locking instead; this is an error in the Swift 6 language mode
170 |
171 |     public func fetchRelationshipState() async throws -> RelationshipState {
172 |         lock.lock()
    |              \`- warning: instance method 'lock' is unavailable from asynchronous contexts; Use async-safe scoped locking instead; this is an error in the Swift 6 language mode
\`\`\`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25440" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
