### PR TITLE
fix(tests): pass credentialsGuide: nil in STT test registry

### DIFF
--- a/clients/shared/Tests/STTStreamingClientTests.swift
+++ b/clients/shared/Tests/STTStreamingClientTests.swift
@@ -312,7 +312,8 @@ final class STTStreamingClientTests: XCTestCase {
                     setupMode: .apiKey,
                     setupHint: "test",
                     apiKeyProviderName: "openai",
-                    conversationStreamingMode: .incrementalBatch
+                    conversationStreamingMode: .incrementalBatch,
+                    credentialsGuide: nil
                 ),
                 STTProviderCatalogEntry(
                     id: "deepgram",
@@ -321,7 +322,8 @@ final class STTStreamingClientTests: XCTestCase {
                     setupMode: .apiKey,
                     setupHint: "test",
                     apiKeyProviderName: "deepgram",
-                    conversationStreamingMode: .realtimeWs
+                    conversationStreamingMode: .realtimeWs,
+                    credentialsGuide: nil
                 ),
                 STTProviderCatalogEntry(
                     id: "google-gemini",
@@ -330,7 +332,8 @@ final class STTStreamingClientTests: XCTestCase {
                     setupMode: .apiKey,
                     setupHint: "test",
                     apiKeyProviderName: "gemini",
-                    conversationStreamingMode: .incrementalBatch
+                    conversationStreamingMode: .incrementalBatch,
+                    credentialsGuide: nil
                 ),
             ]
         )


### PR DESCRIPTION
## Summary
- Fixes the macOS Tests CI failure caused by missing `credentialsGuide` argument in `STTProviderCatalogEntry(...)` calls inside `buildTestRegistry()`.
- The parameter was introduced in #25438 (Deepgram reorder + credentials guide) but the test helper was not updated.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24379371144/job/71199460138
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25442" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
