### PR TITLE
feat(stt): upgrade default Gemini model to 2.5-flash

### DIFF
--- a/assistant/src/providers/speech-to-text/google-gemini-stream.ts
+++ b/assistant/src/providers/speech-to-text/google-gemini-stream.ts
@@ -37,7 +37,7 @@ const log = getLogger("google-gemini-stream");
 // Constants
 // ---------------------------------------------------------------------------
 
-const DEFAULT_MODEL = "gemini-2.0-flash";
+const DEFAULT_MODEL = "gemini-2.5-flash";
 
 /**
  * Minimum interval between incremental batch requests (ms).
@@ -59,7 +59,7 @@ const TRANSCRIPTION_PROMPT =
 // ---------------------------------------------------------------------------
 
 export interface GoogleGeminiStreamOptions {
-  /** Gemini model to use (default: "gemini-2.0-flash"). */
+  /** Gemini model to use (default: "gemini-2.5-flash"). */
   model?: string;
   /** Override the Google AI API base URL (useful for proxies or on-prem). */
   baseUrl?: string;

--- a/assistant/src/providers/speech-to-text/google-gemini.test.ts
+++ b/assistant/src/providers/speech-to-text/google-gemini.test.ts
@@ -94,7 +94,7 @@ describe("GoogleGeminiProvider", () => {
     expect(inlineData?.data).toBe(audioData.toString("base64"));
   });
 
-  test("uses default model gemini-2.0-flash", async () => {
+  test("uses default model gemini-2.5-flash", async () => {
     const provider = createProviderWithMock({
       response: { text: "text" },
     });
@@ -103,7 +103,7 @@ describe("GoogleGeminiProvider", () => {
 
     const call = (mockGenerateContent as ReturnType<typeof mock>).mock
       .calls[0][0] as { model: string };
-    expect(call.model).toBe("gemini-2.0-flash");
+    expect(call.model).toBe("gemini-2.5-flash");
   });
 
   test("uses custom model when specified", async () => {

--- a/assistant/src/providers/speech-to-text/google-gemini.ts
+++ b/assistant/src/providers/speech-to-text/google-gemini.ts
@@ -2,7 +2,7 @@ import { GoogleGenAI } from "@google/genai";
 
 import type { SttTranscribeResult } from "../../stt/types.js";
 
-const DEFAULT_MODEL = "gemini-2.0-flash";
+const DEFAULT_MODEL = "gemini-2.5-flash";
 const DEFAULT_TIMEOUT_MS = 60_000;
 
 const TRANSCRIPTION_PROMPT =
@@ -13,7 +13,7 @@ const TRANSCRIPTION_PROMPT =
 // ---------------------------------------------------------------------------
 
 export interface GoogleGeminiProviderOptions {
-  /** Gemini model to use (default: "gemini-2.0-flash"). */
+  /** Gemini model to use (default: "gemini-2.5-flash"). */
   model?: string;
   /** Override the Google AI API base URL (useful for proxies or on-prem). */
   baseUrl?: string;


### PR DESCRIPTION
## Summary
- Upgrade the default Google Gemini STT model from `gemini-2.0-flash` to `gemini-2.5-flash` in both the streaming and non-streaming providers
- Update JSDoc comments and tests to reflect the new default
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25443" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
