### PR TITLE
fix(macos): clear isCompacting on messageComplete

### DIFF
--- a/clients/shared/Features/Chat/ChatActionHandler.swift
+++ b/clients/shared/Features/Chat/ChatActionHandler.swift
@@ -421,6 +421,7 @@ final class ChatActionHandler {
         vm.cancelTimeoutTask = nil
         vm.isCancelling = false
         vm.isThinking = false
+        vm.isCompacting = false
         // When a send-direct is pending, this messageComplete is the
         // cancel acknowledgment. Reset all queue state so the follow-up
         // sendMessage() starts a fresh send instead of re-queuing.


### PR DESCRIPTION
## Summary

- `/compact` left the UI stuck: the "Compacting context..." indicator stayed pinned and a huge empty region appeared above the composer until the 60s `isSending` watchdog fired.
- Root cause: `vm.isCompacting` is set to `true` by `assistantActivityState` with `reason: "context_compacting"` but was never cleared on `message_complete`. The `/compact` slash path emits `message_complete` without a trailing activity-state transition, so the flag leaked. The empty space was the `isCompacting` branch in `MessageListContentView.swift:376-379` rendering a `VStack` with `minHeight: turnMinHeight`.
- Fix: clear `vm.isCompacting = false` in `handleMessageComplete` next to the other per-turn transient resets (`isThinking`, `isSending`, `isCancelling`). Matches the "turn is over" contract and covers every path that sets the flag.

## Original prompt

> Whenever I run `/compact` the UI of the Vellum desktop app gets super weird. There's tons of empty space and the "Compacting context..." thing stays there even though it's not true.