### PR TITLE
feat(macos): add credentials guide hints for TTS providers

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -385,6 +385,9 @@ struct VoiceSettingsView: View {
                 // Unified API key field
                 ttsApiKeyField
 
+                // Credentials guide — contextual help for obtaining an API key
+                ttsCredentialsGuideView
+
                 // Voice ID / Reference ID field (provider-specific)
                 ttsVoiceIdField
 
@@ -434,6 +437,26 @@ struct VoiceSettingsView: View {
                 placeholder: "\(selectedTTSProvider?.displayName ?? "Provider") Voice ID (optional)",
                 text: $ttsVoiceIdText
             )
+        }
+    }
+
+    // MARK: - TTS Credentials Guide
+
+    @ViewBuilder
+    private var ttsCredentialsGuideView: some View {
+        if let guide = selectedTTSProvider?.credentialsGuide,
+           let attributed = try? AttributedString(
+               markdown: "\(guide.description) [\(guide.linkLabel)](\(guide.url))"
+           ) {
+            Text(attributed)
+                .font(VFont.labelDefault)
+                .foregroundStyle(VColor.contentTertiary)
+                .tint(VColor.primaryBase)
+                .lineSpacing(1)
+                .environment(\.openURL, OpenURLAction { url in
+                    NSWorkspace.shared.open(url)
+                    return .handled
+                })
         }
     }
 

--- a/clients/shared/Utilities/TTSProviderRegistry.swift
+++ b/clients/shared/Utilities/TTSProviderRegistry.swift
@@ -16,6 +16,19 @@ public enum TTSProviderSetupMode: String, Decodable {
     case cli
 }
 
+/// Guide for obtaining API credentials from a TTS provider.
+///
+/// Contains a short description of the steps, a URL to the provider's
+/// key-management page, and a human-readable link label for display.
+public struct TTSCredentialsGuide: Decodable {
+    /// Brief instructions for obtaining an API key (1-2 sentences).
+    public let description: String
+    /// URL to the provider's API key or console page.
+    public let url: String
+    /// Human-readable label for the link (e.g. "Open ElevenLabs Dashboard").
+    public let linkLabel: String
+}
+
 /// A single entry in the client-facing TTS provider catalog.
 ///
 /// This struct captures the subset of provider metadata that client apps
@@ -32,6 +45,8 @@ public struct TTSProviderCatalogEntry: Decodable {
     public let setupMode: TTSProviderSetupMode
     /// Brief help text guiding the user through setup.
     public let setupHint: String
+    /// Guide for obtaining API credentials from this provider.
+    public let credentialsGuide: TTSCredentialsGuide?
 }
 
 /// Top-level schema for `tts-provider-catalog.json`.
@@ -62,14 +77,24 @@ private let fallbackRegistry = TTSProviderRegistry(
             displayName: "ElevenLabs",
             subtitle: "High-quality voice synthesis for conversations and read-aloud. Requires an ElevenLabs API key.",
             setupMode: .apiKey,
-            setupHint: "Enter your ElevenLabs API key to get started."
+            setupHint: "Enter your ElevenLabs API key to get started.",
+            credentialsGuide: TTSCredentialsGuide(
+                description: "Sign in to ElevenLabs, go to your Profile, and copy your API key.",
+                url: "https://elevenlabs.io/app/settings/api-keys",
+                linkLabel: "Open ElevenLabs API Keys"
+            )
         ),
         TTSProviderCatalogEntry(
             id: "fish-audio",
             displayName: "Fish Audio",
             subtitle: "Natural-sounding voice synthesis with custom voice cloning. Requires a Fish Audio API key and voice reference ID.",
             setupMode: .cli,
-            setupHint: "Run the setup commands in your terminal to configure Fish Audio."
+            setupHint: "Run the setup commands in your terminal to configure Fish Audio.",
+            credentialsGuide: TTSCredentialsGuide(
+                description: "Sign in to Fish Audio, navigate to API Keys in your dashboard, and create a new key.",
+                url: "https://fish.audio/api-keys/",
+                linkLabel: "Open Fish Audio API Keys"
+            )
         ),
     ]
 )

--- a/meta/tts-provider-catalog.json
+++ b/meta/tts-provider-catalog.json
@@ -1,19 +1,29 @@
 {
-  "version": 1,
+  "version": 2,
   "providers": [
     {
       "id": "elevenlabs",
       "displayName": "ElevenLabs",
       "subtitle": "High-quality voice synthesis for conversations and read-aloud. Requires an ElevenLabs API key.",
       "setupMode": "cli",
-      "setupHint": "Run the setup commands in your terminal to configure ElevenLabs credentials."
+      "setupHint": "Run the setup commands in your terminal to configure ElevenLabs credentials.",
+      "credentialsGuide": {
+        "description": "Sign in to ElevenLabs, go to your Profile, and copy your API key.",
+        "url": "https://elevenlabs.io/app/settings/api-keys",
+        "linkLabel": "Open ElevenLabs API Keys"
+      }
     },
     {
       "id": "fish-audio",
       "displayName": "Fish Audio",
       "subtitle": "Natural-sounding voice synthesis with custom voice cloning. Requires a Fish Audio API key and voice reference ID.",
       "setupMode": "cli",
-      "setupHint": "Run the setup commands in your terminal to configure Fish Audio."
+      "setupHint": "Run the setup commands in your terminal to configure Fish Audio.",
+      "credentialsGuide": {
+        "description": "Sign in to Fish Audio, navigate to API Keys in your dashboard, and create a new key.",
+        "url": "https://fish.audio/api-keys/",
+        "linkLabel": "Open Fish Audio API Keys"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add `TTSCredentialsGuide` struct and `credentialsGuide` field to `TTSProviderCatalogEntry`, mirroring the existing STT pattern
- Add credentials guide data (description, URL, link label) for ElevenLabs and Fish Audio to both the JSON catalog and the Swift fallback registry
- Wire `ttsCredentialsGuideView` into the TTS card on the Voice settings page, rendering a contextual help link below the API key field

## Original prompt
For the macOS Text-to-Speech section on the Voice page, add a hint on where to get an API key for ElevenLabs and Fish Audio, much like we do for Deepgram, Google, and OpenAI in the Speech-to-Text section. It should be driven by the catalog (i.e., the hint text/URL should come from the catalog entry, not be hardcoded in the UI).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25446" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
