### PR TITLE
fix(macos): populate TTS voice ID field from daemon config on page load

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -206,6 +206,14 @@ public final class SettingsStore: ObservableObject {
     /// Current web search mode. Values: "managed" or "your-own".
     @Published var webSearchMode: String = "your-own"
 
+    // MARK: - TTS Voice ID State
+
+    /// The configured ElevenLabs voice ID from daemon config.
+    @Published var elevenLabsVoiceId: String = ""
+
+    /// The configured Fish Audio reference ID from daemon config.
+    @Published var fishAudioReferenceId: String = ""
+
     /// Managed OAuth mode per provider (keyed by managedServiceConfigKey). Values: "managed" or "your-own".
     @Published var managedOAuthMode: [String: String] = [:]
     /// Managed OAuth connections per provider (keyed by managedServiceConfigKey).
@@ -2986,6 +2994,7 @@ public final class SettingsStore: ObservableObject {
 
     func setElevenLabsVoiceId(_ voiceId: String) {
         let trimmed = voiceId.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.elevenLabsVoiceId = trimmed
         Task {
             let success = await settingsClient.patchConfig([
                 "services": ["tts": ["providers": ["elevenlabs": ["voiceId": trimmed]]]]
@@ -2998,6 +3007,7 @@ public final class SettingsStore: ObservableObject {
 
     func setFishAudioReferenceId(_ referenceId: String) {
         let trimmed = referenceId.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.fishAudioReferenceId = trimmed
         Task {
             let success = await settingsClient.patchConfig([
                 "services": ["tts": ["providers": ["fish-audio": ["referenceId": trimmed]]]]
@@ -3573,6 +3583,21 @@ public final class SettingsStore: ObservableObject {
            let tts = services["tts"] as? [String: Any],
            let ttsProvider = tts["provider"] as? String {
             UserDefaults.standard.set(ttsProvider, forKey: "ttsProvider")
+        }
+
+        // Sync provider-specific voice IDs so the Voice Settings view
+        // can display the configured value on load.
+        if let services = config["services"] as? [String: Any],
+           let tts = services["tts"] as? [String: Any],
+           let providers = tts["providers"] as? [String: Any] {
+            if let elevenlabs = providers["elevenlabs"] as? [String: Any],
+               let voiceId = elevenlabs["voiceId"] as? String {
+                self.elevenLabsVoiceId = voiceId
+            }
+            if let fishAudio = providers["fish-audio"] as? [String: Any],
+               let referenceId = fishAudio["referenceId"] as? String {
+                self.fishAudioReferenceId = referenceId
+            }
         }
 
         // Sync the global STT provider from the daemon config so the client

--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -19,6 +19,8 @@ struct VoiceSettingsView: View {
     @State private var ttsApiKeyText: String = ""
     /// Voice ID / reference ID input text.
     @State private var ttsVoiceIdText: String = ""
+    /// Baseline voice ID for change detection — set on appear and after save.
+    @State private var initialVoiceId: String = ""
     /// Baseline provider for change detection.
     @State private var initialTTSProvider: String = "elevenlabs"
     /// Whether the current TTS provider has a stored API key.
@@ -106,17 +108,26 @@ struct VoiceSettingsView: View {
             initialTTSProvider = ttsProviderRaw
             ttsProviderHasKey = ttsCredentialExists(for: ttsProviderRaw)
 
+            // Load the stored voice ID for the current TTS provider so
+            // the field reflects the daemon-configured value on page load.
+            let voiceId = storedVoiceId(for: ttsProviderRaw)
+            ttsVoiceIdText = voiceId
+            initialVoiceId = voiceId
+
             // Initialize STT draft state from persisted values
             draftSTTProvider = sttProviderRaw
             initialSTTProvider = sttProviderRaw
             sttProviderHasKey = sttKeyExists(for: draftSTTProvider)
         }
         .onChange(of: draftTTSProvider) { _, _ in
-            // Clear API key and voice ID fields when provider changes
+            // Reset API key field and load the stored voice ID for the
+            // newly selected provider so the field shows its current value.
             ttsApiKeyText = ""
-            ttsVoiceIdText = ""
             ttsSaveError = nil
             ttsProviderHasKey = ttsCredentialExists(for: draftTTSProvider)
+            let voiceId = storedVoiceId(for: draftTTSProvider)
+            ttsVoiceIdText = voiceId
+            initialVoiceId = voiceId
         }
         .onChange(of: draftSTTProvider) { _, _ in
             // Clear stale fields when STT provider changes
@@ -361,8 +372,8 @@ struct VoiceSettingsView: View {
     private var ttsHasChanges: Bool {
         let providerChanged = draftTTSProvider != initialTTSProvider
         let hasNewKey = !ttsApiKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-        let hasVoiceId = !ttsVoiceIdText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-        return providerChanged || hasNewKey || hasVoiceId
+        let voiceIdChanged = ttsVoiceIdText.trimmingCharacters(in: .whitespacesAndNewlines) != initialVoiceId
+        return providerChanged || hasNewKey || voiceIdChanged
     }
 
     private var ttsProviderCard: some View {
@@ -484,7 +495,20 @@ struct VoiceSettingsView: View {
 
         // Update baseline for change detection
         initialTTSProvider = draftTTSProvider
-        ttsVoiceIdText = ""
+        initialVoiceId = trimmedVoiceId
+    }
+
+    /// Returns the stored voice ID / reference ID for the given TTS provider
+    /// from the daemon-synced values on `SettingsStore`.
+    private func storedVoiceId(for provider: String) -> String {
+        switch provider {
+        case "elevenlabs":
+            return store.elevenLabsVoiceId
+        case "fish-audio":
+            return store.fishAudioReferenceId
+        default:
+            return ""
+        }
     }
 
     /// Checks whether a TTS credential exists for the given provider.


### PR DESCRIPTION
## Summary
- The Voice Settings view never loaded the configured ElevenLabs voice ID or Fish Audio reference ID from the daemon config, leaving the field empty on page load and clearing it after save
- Added `@Published` properties on `SettingsStore` for both voice IDs, synced from `applyDaemonConfig()` and the setter methods, so `VoiceSettingsView` can read them on appear and on provider change
- Fixed change detection to compare against the initial voice ID baseline instead of checking non-empty, and retained the saved value in the field after save

## Original prompt
Fix ElevenLabs and Fish Audio voice ID not showing on page load in macOS client. Both providers share the same `ttsVoiceIdText` field and neither was loaded from daemon config. Additionally, the field was cleared after saving.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25447" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
